### PR TITLE
[Compliant] Fix windows compilation

### DIFF
--- a/applications/plugins/Compliant/mapping/PythonMultiMapping.inl
+++ b/applications/plugins/Compliant/mapping/PythonMultiMapping.inl
@@ -3,7 +3,9 @@
 
 #ifdef NDEBUG
 #undef NDEBUG
+#ifdef __GNUC__
 #warning NDEBUG
+#endif
 #endif
 
 #include "PythonMultiMapping.h"


### PR DESCRIPTION
The preprocessor directive #warning is not standard. It does not exist on Windows in the Visual C++ compiler, creating an error in compilation.
