### PR TITLE
[SofaKernel] Fix XML export

### DIFF
--- a/SofaKernel/framework/sofa/simulation/XMLPrintVisitor.cpp
+++ b/SofaKernel/framework/sofa/simulation/XMLPrintVisitor.cpp
@@ -123,17 +123,6 @@ Visitor::Result XMLPrintVisitor::processNodeTopDown(simulation::Node* node)
 
 void XMLPrintVisitor::processNodeBottomUp(simulation::Node* node)
 {
-    for (simulation::Node::ObjectIterator it = node->object.begin(); it != node->object.end(); ++it)
-    {
-        sofa::core::objectmodel::BaseObject* obj = it->get();
-        if (    obj->toBaseInteractionForceField() == NULL
-            &&  obj->toBaseInteractionConstraint() == NULL
-            &&  obj->toBaseInteractionProjectiveConstraintSet() == NULL
-            &&  obj->toBaseLMConstraint() == NULL
-           )
-            this->processObject(obj);
-    }
-
     --level;
 
     for (int i=0; i<level; i++)


### PR DESCRIPTION
As suggested by Alex Bilger in SOFA forum: https://www.sofa-framework.org/community/forum/topic/duplicated-components-in-xml-export/

> Hello guys,
> 
> I noticed a bad behavior when exporting a scene in xml. The components are duplicated within the same node. The node components are written, then the sub-nodes, and then the same node components again.
> You can get the same behavior by opening any sofa scene and exporting it (File -> Save As in runSofa), then open it in a text editor.
> I see that the xml export uses visitors. I found that the objects are processed twice: once in processNodeTopDown and once in processNodeBottomUp. So I removed the processing part in processNodeBottomUp, and kept only the node closure. I get the expected behavior. Could you guys confirm this is the right thing to do?
> I tested on Windows with a very recent commit.
