### PR TITLE
Plugin Manager: Fix segfault when removing a plugin

### DIFF
--- a/applications/sofa/gui/qt/SofaPluginManager.cpp
+++ b/applications/sofa/gui/qt/SofaPluginManager.cpp
@@ -181,7 +181,7 @@ void SofaPluginManager::removeLibrary()
     if( sofa::helper::system::PluginManager::getInstance().unloadPlugin(location,&sstream) )
     {
         //listPlugins->removeItem(curItem);
-        delete curItem->parent()->takeChild(curItem->parent()->indexOfChild(curItem));
+        delete curItem;
 
         savePluginsToIniFile();
         emit( libraryRemoved() );

--- a/applications/sofa/gui/qt/SofaPluginManager.cpp
+++ b/applications/sofa/gui/qt/SofaPluginManager.cpp
@@ -185,6 +185,12 @@ void SofaPluginManager::removeLibrary()
 
         savePluginsToIniFile();
         emit( libraryRemoved() );
+
+        if(this->listPlugins->selectedItems().count() < 1)
+        {
+            description->clear();
+            listComponents->clear();
+        }
     }
     else
     {

--- a/applications/sofa/gui/qt/SofaPluginManager.cpp
+++ b/applications/sofa/gui/qt/SofaPluginManager.cpp
@@ -185,8 +185,6 @@ void SofaPluginManager::removeLibrary()
 
         savePluginsToIniFile();
         emit( libraryRemoved() );
-        //description->clear();
-        //listComponents->clear();
     }
     else
     {
@@ -210,7 +208,7 @@ void SofaPluginManager::updateComponentList()
 
     if(curItem == NULL ) return;
     //update the component list when an item is selected
-    //listComponents->clear();
+    listComponents->clear();
 
     std::string location( curItem->text(LOCATION_COLUMN).toStdString() ); //get the location value
 


### PR DESCRIPTION
To reproduce the bug: start runSofa, open Plugin Manager, add a plugin, remove the plugin, segfault.
