### PR TITLE
[framework] FIX : StateMask method clean needs to resize m_size to 0

### DIFF
--- a/SofaKernel/framework/sofa/helper/StateMask.h
+++ b/SofaKernel/framework/sofa/helper/StateMask.h
@@ -169,7 +169,7 @@ public:
     //    const InternalStorage& getEntries() const { return mask; }
 
     void resize( size_t size ) { m_size=size; }
-    inline void clear() {}
+    inline void clear() { m_size=0; }
 
     size_t size() const {
         return m_size;


### PR DESCRIPTION
Commit 9b8dcf0 cleaning the code of StateMask forgot to implement clean method, just add a resize to 0
