### PR TITLE
fixes compilation with SOFA_NO_OPENGL flag

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetGeometryAlgorithms.inl
@@ -712,6 +712,7 @@ void EdgeSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
 {
     PointSetGeometryAlgorithms<DataTypes>::draw(vparams);
 
+#ifndef SOFA_NO_OPENGL 
     // Draw Edges indices
     if (showEdgeIndices.getValue())
     {
@@ -741,7 +742,6 @@ void EdgeSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
         vparams->drawTool()->draw3DText_Indices(positions, scale, color4);
     }
 
-
     // Draw edges
     if (_draw.getValue())
     {
@@ -764,6 +764,7 @@ void EdgeSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
             vparams->drawTool()->drawPoints(positions, 4.0f, defaulttype::Vec4f(color[0], color[1], color[2], 1.0f));
         }
     }
+#endif //SOFA_NO_OPENGL
 
 }
 

--- a/SofaKernel/modules/SofaBaseTopology/HexahedronSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/HexahedronSetGeometryAlgorithms.inl
@@ -837,7 +837,7 @@ template<class DataTypes>
 void HexahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
     QuadSetGeometryAlgorithms<DataTypes>::draw(vparams);
-
+#ifndef SOFA_NO_OPENGL
     // Draw Hexa indices
     if (d_showHexaIndices.getValue())
     {
@@ -873,6 +873,7 @@ void HexahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visual
 
         vparams->drawTool()->draw3DText_Indices(positions, scale, color4);
     }
+
 
 
     //Draw hexahedra
@@ -913,6 +914,7 @@ void HexahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visual
             vparams->drawTool()->setPolygonMode(0, false);
            
     }
+#endif //SOFA_NO_OPENGL
 }
 
 

--- a/SofaKernel/modules/SofaBaseTopology/PointSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/PointSetGeometryAlgorithms.inl
@@ -236,6 +236,7 @@ void PointSetGeometryAlgorithms<DataTypes>::initPointAdded(unsigned int index, c
 template<class DataTypes>
 void PointSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
+#ifndef SOFA_NO_OPENGL
     if (showPointIndices.getValue())
     {
         sofa::defaulttype::Mat<4,4, GLfloat> modelviewM;
@@ -258,6 +259,7 @@ void PointSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParam
         }
         vparams->drawTool()->draw3DText_Indices(positions, scale, color4);
     }
+#endif //SOFA_NO_OPENGL
 }
 
 

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetGeometryAlgorithms.inl
@@ -352,7 +352,7 @@ template<class DataTypes>
 void QuadSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
     EdgeSetGeometryAlgorithms<DataTypes>::draw(vparams);
-
+#ifndef SOFA_NO_OPENGL
     // Draw Quads indices
     if (showQuadIndices.getValue())
     {
@@ -384,7 +384,7 @@ void QuadSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
         }
         vparams->drawTool()->draw3DText_Indices(positions, scale, color4);
     }
-
+#endif //SOFA_NO_OPENGL
 
     // Draw Quads
     if (_drawQuads.getValue())

--- a/applications/sofa/gui/PickHandler.cpp
+++ b/applications/sofa/gui/PickHandler.cpp
@@ -55,7 +55,9 @@ PickHandler::PickHandler():
     mouseNode(NULL),
     mouseContainer(NULL),
     mouseCollision(NULL),
+#ifndef SOFA_NO_OPENGL
     _fbo(true,true,true,0),
+#endif
     renderCallback(NULL),
     pickingMethod(RAY_CASTING),
     _fboAllocated(false)


### PR DESCRIPTION
This commit fixes compilation of a basic configuration with the additional SOFA_NO_OPENGL flag being set, including compilation of Compliant and SofaPython plugins

Tested for runSofa -gui batch
