### PR TITLE
FIX: explicitily link rt library when on unix systems

### DIFF
--- a/applications/plugins/Compliant/CMakeLists.txt
+++ b/applications/plugins/Compliant/CMakeLists.txt
@@ -246,6 +246,10 @@ sofa_set_python_directory(${PROJECT_NAME} "python")
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${README_FILES} ${PYTHON_FILES})
 target_link_libraries(${PROJECT_NAME} SofaEigen2Solver SofaUserInteraction SofaComponentMisc SofaSimulationGraph SofaPython)
+if(UNIX)
+	target_link_libraries(${PROJECT_NAME} rt)
+endif()
+
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>")
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>")
 target_include_directories(${PROJECT_NAME} PUBLIC "$<INSTALL_INTERFACE:include>")


### PR DESCRIPTION
Not sure if this is correct, but it seems that sofa uses the rt library  (high resolution clock?) on unix, but does not explicitly specify the library when linking.  Because of that, compilation may fail on some systems.

This patch just makes dependency on the rt library explicit in cmake
