### PR TITLE
[Sensable] Fix compilation error when using a const context node for the creation of the visual node

### DIFF
--- a/applications/plugins/Sensable/NewOmniDriver.cpp
+++ b/applications/plugins/Sensable/NewOmniDriver.cpp
@@ -372,7 +372,10 @@ int NewOmniDriver::initDevice()
 
             if (HD_DEVICE_ERROR(error = hdGetError()))
             {
-                std::cout<<"[NewOmni] Failed to initialize the device "<<autreOmniDriver[i]->deviceName.getValue()<<std::endl;
+              std::string m = "[NewOmni] Failed to initialize the device " + autreOmniDriver[i]->deviceName.getValue();
+              printError(&error, m.c_str());
+              autreOmniDriver[i]->isInitialized = false;
+              return -1;
             }
             else
             {
@@ -666,7 +669,10 @@ void NewOmniDriver::bwdInit()
         }
         else
         {
-            autreOmniDriver[this->deviceIndex.getValue()]->DOFs = DOFs;
+          sofa::helper::WriteAccessor<sofa::core::objectmodel::Data<VecCoord> > xfree = *DOFs->write(this->setRestShape.getValue() ? sofa::core::VecCoordId::restPosition() : sofa::core::VecCoordId::freePosition());
+          if (xfree.size() == 0)
+            xfree.resize(1);
+          autreOmniDriver[this->deviceIndex.getValue()]->DOFs = DOFs;
         }
 }
 

--- a/applications/plugins/Sensable/NewOmniDriver.cpp
+++ b/applications/plugins/Sensable/NewOmniDriver.cpp
@@ -474,10 +474,10 @@ void NewOmniDriver::setForceFeedback(ForceFeedback* ff)
 //executed once at the start of Sofa, initialization of all variables excepts haptics-related ones
 void NewOmniDriver::init()
 {
+    sofa::simulation::Node::SPtr rootContext = static_cast<simulation::Node*>(this->getContext()->getRootContext());
     if(firstDevice)
     {
-        simulation::Node *context = dynamic_cast<simulation::Node*>(this->getContext()->getRootContext());
-        context->getTreeObjects<NewOmniDriver>(&autreOmniDriver);
+        rootContext->getTreeObjects<NewOmniDriver>(&autreOmniDriver);
         sout<<"Detected NewOmniDriver:"<<sendl;
         for(unsigned int i=0; i<autreOmniDriver.size(); i++)
         {
@@ -541,13 +541,7 @@ void NewOmniDriver::init()
         visualNode[i].mapping = NULL;
     }
 
-    parent = dynamic_cast<simulation::Node*>(this->getContext());
-
-    sofa::simulation::tree::GNode *parentRoot = dynamic_cast<sofa::simulation::tree::GNode*>(this->getContext());
-    if (parentRoot->parent())
-        parentRoot = parentRoot->parent();
-
-    nodePrincipal= parentRoot->createChild("omniVisu "+deviceName.getValue());
+    nodePrincipal = rootContext->createChild("omniVisu "+deviceName.getValue());
     nodePrincipal->updateContext();
 
     DOFs=NULL;

--- a/applications/plugins/Sensable/NewOmniDriver.h
+++ b/applications/plugins/Sensable/NewOmniDriver.h
@@ -76,6 +76,7 @@ namespace controller
 class ForceFeedback;
 
 using namespace sofa::defaulttype;
+using namespace sofa::helper;
 using core::objectmodel::Data;
 
 /** Holds data retrieved from HDAPI. */
@@ -198,7 +199,6 @@ public:
     void setDataValue();
 
     //variable pour affichage graphique
-    simulation::Node *parent;
     enum
     {
         VN_stylus = 0,

--- a/applications/plugins/Sensable/OmniDriver.h
+++ b/applications/plugins/Sensable/OmniDriver.h
@@ -54,6 +54,7 @@ class ForceFeedback;
 
 
 using namespace sofa::defaulttype;
+using namespace sofa::helper;
 using core::objectmodel::Data;
 
 /** Holds data retrieved from HDAPI. */


### PR DESCRIPTION
This is a small correction to fix the compilation of the Sensable plugin.

Also, any idea why we keep the OmniDriver when there is a NewOmniDriver available? 
