### PR TITLE
[GUI] Fixes #30 : Stay with QString for path manipulations and allow to change the screenshot prefix without automatic path prepend

### DIFF
--- a/applications/sofa/gui/BaseViewer.cpp
+++ b/applications/sofa/gui/BaseViewer.cpp
@@ -125,9 +125,10 @@ const std::string BaseViewer::screenshotName()
 #endif
 }
 
-void BaseViewer::setPrefix(const std::string& prefix)
+void BaseViewer::setPrefix(const std::string& prefix, bool prependDirectory)
 {
-    const std::string fullPrefix = sofa::gui::BaseGUI::getScreenshotDirectoryPath() + "/" + prefix;
+    const std::string fullPrefix = (prependDirectory) ? sofa::gui::BaseGUI::getScreenshotDirectoryPath() + "/" + prefix
+                                                      : prefix;
 #ifndef SOFA_NO_OPENGL
     capture.setPrefix(fullPrefix);
 #endif

--- a/applications/sofa/gui/BaseViewer.h
+++ b/applications/sofa/gui/BaseViewer.h
@@ -114,7 +114,7 @@ public:
 
     //Fonctions needed to take a screenshot
     const std::string screenshotName();
-    void setPrefix(const std::string& prefix);
+    void setPrefix(const std::string& prefix, bool prependDirectory = true);
     virtual void screenshot(const std::string& filename, int compression_level =-1);
 
     virtual void getView(sofa::defaulttype::Vector3& pos, sofa::defaulttype::Quat& ori) const;

--- a/applications/sofa/gui/qt/RealGUI.cpp
+++ b/applications/sofa/gui/qt/RealGUI.cpp
@@ -2177,14 +2177,20 @@ void RealGUI::screenshot()
 
     if ( filename != "" )
     {
-        std::ostringstream ofilename;
-        const char* begin = filename.toStdString().c_str();
-        const char* end = strrchr ( begin,'_' );
-        if ( !end )
-            end = begin + filename.length();
-        ofilename << std::string ( begin, end );
-        ofilename << "_";
-        getViewer()->setPrefix ( ofilename.str() );
+        QString prefix;
+        int end = filename.lastIndexOf('_');
+        if (end > -1) {
+            prefix = filename.mid(
+                0,
+                end+1
+            );
+        } else {
+            prefix = QString::fromStdString(
+              sofa::helper::system::SetDirectory::GetFileNameWithoutExtension(filename.toStdString().c_str()) + "_");
+        }
+
+        if (!prefix.isEmpty())
+            getViewer()->setPrefix ( prefix.toStdString(), false );
 
         getViewer()->screenshot ( filename.toStdString() );
     }


### PR DESCRIPTION
See issue #30 
