### PR TITLE
[SofaKernel] msg_* API improvement

### DIFF
--- a/SofaKernel/framework/sofa/helper/CMakeLists.txt
+++ b/SofaKernel/framework/sofa/helper/CMakeLists.txt
@@ -113,6 +113,7 @@ set(HEADER_FILES
     logging/FileMessageHandler.h
     logging/CountingMessageHandler.h
     logging/LoggingMessageHandler.h
+    logging/RoutingMessageHandler.h
     logging/MessageHandler.h
     logging/MessageFormatter.h
     logging/ClangMessageHandler.h
@@ -192,6 +193,7 @@ set(SOURCE_FILES
     logging/FileMessageHandler.cpp
     logging/CountingMessageHandler.cpp
     logging/LoggingMessageHandler.cpp
+    logging/RoutingMessageHandler.cpp
     logging/ExceptionMessageHandler.cpp
     logging/RichConsoleStyleMessageFormatter.cpp
 )

--- a/SofaKernel/framework/sofa/helper/logging/Message.h
+++ b/SofaKernel/framework/sofa/helper/logging/Message.h
@@ -121,7 +121,7 @@ public:
     enum Type {Info=0, Advice, Deprecated, Warning, Error, Fatal, TEmpty, TypeCount};
 
     /// class of messages
-    enum Class {Dev, Runtime, CEmpty, ClassCount};
+    enum Class {Dev, Runtime, Log, CEmpty, ClassCount};
 
     Message() {}
     Message( const Message& msg );

--- a/SofaKernel/framework/sofa/helper/logging/Messaging.h
+++ b/SofaKernel/framework/sofa/helper/logging/Messaging.h
@@ -111,12 +111,18 @@
 #define msg_fatal(emitter)      sofa::helper::logging::MessageDispatcher::fatal(sofa::helper::logging::Message::Runtime, emitter, SOFA_FILE_INFO)
 #define msg_advice(emitter)      sofa::helper::logging::MessageDispatcher::advice(sofa::helper::logging::Message::Runtime, emitter, SOFA_FILE_INFO)
 
+#define logmsg_info(emitter)       sofa::helper::logging::MessageDispatcher::info(sofa::helper::logging::Message::Log, emitter, SOFA_FILE_INFO)
+#define logmsg_deprecated(emitter) sofa::helper::logging::MessageDispatcher::deprecated(sofa::helper::logging::Message::Log, emitter, SOFA_FILE_INFO)
+#define logmsg_warning(emitter)    sofa::helper::logging::MessageDispatcher::warning(sofa::helper::logging::Message::Log, emitter, SOFA_FILE_INFO)
+#define logmsg_error(emitter)      sofa::helper::logging::MessageDispatcher::error(sofa::helper::logging::Message::Log, emitter, SOFA_FILE_INFO)
+#define logmsg_fatal(emitter)      sofa::helper::logging::MessageDispatcher::fatal(sofa::helper::logging::Message::Log, emitter, SOFA_FILE_INFO)
+#define logmsg_advice(emitter)      sofa::helper::logging::MessageDispatcher::advice(sofa::helper::logging::Message::Log, emitter, SOFA_FILE_INFO)
+
 #define msg_info_withfile(emitter, file, line)       sofa::helper::logging::MessageDispatcher::info(sofa::helper::logging::Message::Runtime, emitter, SOFA_FILE_INFO2(file,line))
 #define msg_deprecated_withfile(emitter, file, line) sofa::helper::logging::MessageDispatcher::deprecated(sofa::helper::logging::Message::Runtime, emitter, SOFA_FILE_INFO2(file,line))
 #define msg_warning_withfile(emitter, file,line)    sofa::helper::logging::MessageDispatcher::warning(sofa::helper::logging::Message::Runtime, emitter, SOFA_FILE_INFO2(file,line))
 #define msg_error_withfile(emitter, file,line)      sofa::helper::logging::MessageDispatcher::error(sofa::helper::logging::Message::Runtime, emitter, SOFA_FILE_INFO2(file,line))
 #define msg_fatal_withfile(emitter, file,line)      sofa::helper::logging::MessageDispatcher::fatal(sofa::helper::logging::Message::Runtime, emitter, SOFA_FILE_INFO2(file,line))
 #define msg_advice_withfile(emitter, file,line)      sofa::helper::logging::MessageDispatcher::advice(sofa::helper::logging::Message::Runtime, emitter, SOFA_FILE_INFO2(file,line))
-
 
 #endif // MESSAGING_H

--- a/SofaKernel/framework/sofa/helper/logging/RoutingMessageHandler.cpp
+++ b/SofaKernel/framework/sofa/helper/logging/RoutingMessageHandler.cpp
@@ -1,0 +1,90 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-20ll6 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This library is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This library is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this library; if not, write to the Free Software Foundation,     *
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.          *
+*******************************************************************************
+*                               SOFA :: Modules                               *
+*                                                                             *
+* This component is open-source                                               *
+*                                                                             *
+* Contributors:                                                               *
+*       - damien.marchal@univ-lille1.fr                                       *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+/*****************************************************************************
+* User of this library should read the documentation
+* in the messaging.h file.
+******************************************************************************/
+#include <sofa/helper/logging/RoutingMessageHandler.h>
+
+namespace sofa
+{
+namespace helper
+{
+namespace logging
+{
+namespace routingmessagehandler
+{
+
+void RoutingMessageHandler::process(Message& m)
+{
+    for(auto& f : m_filters)
+    {
+        if(f.first(m))
+        {
+            f.second->process(m) ;
+        }
+    }
+}
+
+RoutingMessageHandler::RoutingMessageHandler()
+{
+}
+
+void RoutingMessageHandler::setAFilter(FilterFunction f, MessageHandler* handler)
+{
+    m_filters.push_back(std::make_pair(f, handler));
+}
+
+void RoutingMessageHandler::removeAllFilters()
+{
+    m_filters.clear();
+}
+
+RoutingMessageHandler& MainRoutingMessageHandler::getInstance()
+{
+    static RoutingMessageHandler s_instance;
+    return s_instance;
+}
+
+void MainRoutingMessageHandler::setAFilter(FilterFunction filter,
+                                           MessageHandler* handler)
+{
+    getInstance().setAFilter(filter, handler);
+}
+
+void MainRoutingMessageHandler::removeAllFilters()
+{
+    getInstance().removeAllFilters() ;
+}
+
+
+} // loggingmessagehandler
+} // logging
+} // helper
+} // sofa
+

--- a/SofaKernel/framework/sofa/helper/logging/RoutingMessageHandler.h
+++ b/SofaKernel/framework/sofa/helper/logging/RoutingMessageHandler.h
@@ -1,0 +1,116 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-20ll6 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This library is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This library is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this library; if not, write to the Free Software Foundation,     *
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.          *
+*******************************************************************************
+*                               SOFA :: Modules                               *
+*                                                                             *
+* This component is open-source                                               *
+*                                                                             *
+* Contributors:                                                               *
+*       - damien.marchal@univ-lille1.fr                                       *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+/*****************************************************************************
+* User of this library should read the documentation
+* in the messaging.h file.
+******************************************************************************/
+#ifndef ROUTINGMESSAGEHANDLER_H
+#define ROUTINGMESSAGEHANDLER_H
+
+#include <sofa/helper/logging/MessageHandler.h>
+#include <sofa/helper/logging/Message.h>
+#include <vector>
+
+namespace sofa
+{
+namespace helper
+{
+namespace logging
+{
+
+/// I use a per-file namespace so that I can employ the 'using' keywords without
+/// fearing it will leack names into the global namespace.
+/// When closing this namespace selected objects from this per-file namespace
+/// are then imported into their parent namespace for ease of use.
+namespace routingmessagehandler
+{
+using std::vector ;
+
+typedef bool (*FilterFunction) (Message&) ;
+
+///
+/// \brief The RoutingMessageHandler class saves a copy of the messages in a buffer.
+///
+/// This class is a MessageHandler that can be added to in a MessageDispatcher.
+/// Once set the class can start copying the messages passing through
+/// the MessageDispatcher in a buffer.
+///
+///
+/// User interested in having a singleton of this class should have a look
+/// at \see MainRoutingMessageHandler.
+///
+///
+class SOFA_HELPER_API RoutingMessageHandler : public MessageHandler
+{
+public:
+    RoutingMessageHandler() ;
+    virtual ~RoutingMessageHandler() {}
+
+    /// All the message of the given class will be routed to this handler
+    void setAFilter(FilterFunction,
+                         MessageHandler* handler) ;
+
+    /// Remove all the filter but don't delete the associated memory.
+    void removeAllFilters() ;
+
+    /// Inherited from MessageHandler
+    virtual void process(Message& m) ;
+
+private:
+    std::vector<std::pair<FilterFunction, MessageHandler*> > m_filters;
+} ;
+
+///
+/// \brief The MainRoutingMessageHandler class contains a singleton to RoutingMessageHandler
+/// and offer static version of RoutingMessageHandler API
+///
+/// \see RoutingMessageHandler
+///
+class SOFA_HELPER_API MainRoutingMessageHandler
+{
+public:
+    static RoutingMessageHandler& getInstance() ;
+
+    /// All the message of the given class will be routed to this handler
+    static void setAFilter(FilterFunction,
+                                MessageHandler* handler) ;
+
+    static void removeAllFilters() ;
+};
+
+} // loggingmessagehandler
+
+using routingmessagehandler::RoutingMessageHandler ;
+using routingmessagehandler::MainRoutingMessageHandler ;
+
+} // logging
+} // helper
+} // sofa
+
+#endif // TESTMESSAGEHANDLER_H
+


### PR DESCRIPTION
Implement the improvement discussed in
https://github.com/sofa-framework/sofa/issues/56

This request contains: 
A new message class have been added for logging (in addition to Dev & Runtime).
A new RoutingMessageHandler.
A new test to validate the basic behavior of RoutingMessageHandler.

Eg of use... to install a filter that will only send the
Runtime message of type Warning to a File you can do something like:
```cpp
RoutingMessageHandler* m = new RoutingMessageHandler();
FileMessageHandler* toAFile = new FileMessageHandler("the file")

/// Yes this is using c++ lambda syntax
m->setAFilter( [](Message& m)
        {
            if(m.context() == Message::Runtime && m.type() == Message::Warning)
                return true ;
            return false ;
        }, toAFile );
```
