### PR TITLE
Ui colorunifying

### DIFF
--- a/SofaKernel/framework/sofa/core/CollisionModel.cpp
+++ b/SofaKernel/framework/sofa/core/CollisionModel.cpp
@@ -37,6 +37,7 @@ std::vector<int> BaseCollisionElementIterator::emptyVector; ///< empty vector to
 const float* CollisionModel::getColor4f()
 {
 
+    //TODO FIXME because of: https://github.com/sofa-framework/sofa/issues/64
     static const float defaultColorSimulatedMovingActive[4] = {1, 0.5f, 0, 1};
 
     static const float defaultColorSimulatedMoving[4] = {0.5f, 0.25f, 0, 1};

--- a/SofaKernel/modules/SofaBaseVisual/VisualModelImpl.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/VisualModelImpl.cpp
@@ -465,7 +465,7 @@ void VisualModelImpl::setMesh(helper::io::Mesh &objLoader, bool tex)
             }
         }
     }
-    
+
     m_edges.endEdit();
     m_triangles.endEdit();
     m_quads.endEdit();
@@ -478,7 +478,7 @@ void VisualModelImpl::setMesh(helper::io::Mesh &objLoader, bool tex)
 bool VisualModelImpl::load(const std::string& filename, const std::string& loader, const std::string& textureName)
 {
     using sofa::helper::io::Mesh;
-    
+
     //      bool tex = !textureName.empty() || putOnlyTexCoords.getValue();
     if (!textureName.empty())
     {
@@ -491,7 +491,7 @@ bool VisualModelImpl::load(const std::string& filename, const std::string& loade
         else
             serr << "Texture \"" << textureName << "\" not found" << sendl;
     }
-    
+
     // Make sure all Data are up-to-date
     m_vertices2.updateIfDirty();
     m_vnormals.updateIfDirty();
@@ -501,7 +501,7 @@ bool VisualModelImpl::load(const std::string& filename, const std::string& loade
     m_edges.updateIfDirty();
     m_triangles.updateIfDirty();
     m_quads.updateIfDirty();
-    
+
     if (!filename.empty() && (m_positions.getValue()).size() == 0 && (m_vertices2.getValue()).size() == 0)
     {
         std::string meshFilename(filename);
@@ -517,7 +517,7 @@ bool VisualModelImpl::load(const std::string& filename, const std::string& loade
             {
                 objLoader.reset(Mesh::Create(loader, filename));
             }
-            
+
             if (objLoader.get() == 0)
             {
                 return false;
@@ -536,7 +536,7 @@ bool VisualModelImpl::load(const std::string& filename, const std::string& loade
                     setMesh(*objLoader, true);
                 }
             }
-            
+
             if(textureName.empty())
             {
                 //we check how many textures are linked with a material (only if a texture name is not defined in the scn file)
@@ -568,10 +568,10 @@ bool VisualModelImpl::load(const std::string& filename, const std::string& loade
             sout << "VisualModel: will use Topology." << sendl;
             useTopology = true;
         }
-        
+
         modified = true;
     }
-    
+
     if (!xformsModified)
     {
         // add one identity matrix
@@ -1057,7 +1057,7 @@ void VisualModelImpl::flipFaces()
     ResizableExtVector<Edge>& edges = *(m_edges.beginEdit());
     ResizableExtVector<Triangle>& triangles = *(m_triangles.beginEdit());
     ResizableExtVector<Quad>& quads = *(m_quads.beginEdit());
-    
+
     for (unsigned int i = 0; i < edges.size() ; i++)
     {
         int temp = edges[i][1];
@@ -1108,6 +1108,8 @@ static int hexval(char c)
     else return 0;
 }
 
+//TODO FIXME because of: https://github.com/sofa-framework/sofa/issues/64
+// This code should be factored out.
 void VisualModelImpl::setColor(std::string color)
 {
     if (color.empty()) return;
@@ -1303,20 +1305,20 @@ void VisualModelImpl::computeMesh()
                 setMesh(m, !texturename.getValue().empty());
                 sout << m.getVertices().size() << " points, " << m.getFacets().size()  << " triangles." << sendl;
                 useTopology = false; //visual model needs to be created only once at initial time
-				return;
-			}
+                return;
+            }
 
-			if (this->f_printLog.getValue())
-				sout << "VisualModel: copying " << m_topology->getNbPoints() << " points from topology." << sendl;
+            if (this->f_printLog.getValue())
+                sout << "VisualModel: copying " << m_topology->getNbPoints() << " points from topology." << sendl;
 
-			vertices.resize(m_topology->getNbPoints());
+            vertices.resize(m_topology->getNbPoints());
 
-			for (unsigned int i=0; i<vertices.size(); i++)
-			{
-				vertices[i][0] = (Real)m_topology->getPX(i);
-				vertices[i][1] = (Real)m_topology->getPY(i);
-				vertices[i][2] = (Real)m_topology->getPZ(i);
-			}
+            for (unsigned int i=0; i<vertices.size(); i++)
+            {
+                vertices[i][0] = (Real)m_topology->getPX(i);
+                vertices[i][1] = (Real)m_topology->getPY(i);
+                vertices[i][2] = (Real)m_topology->getPZ(i);
+            }
 
         }
         else
@@ -1324,20 +1326,20 @@ void VisualModelImpl::computeMesh()
             BaseMechanicalState* mstate = m_topology->getContext()->getMechanicalState();
 
             if (mstate)
-			{
-				if (this->f_printLog.getValue())
-					sout << "VisualModel: copying " << mstate->getSize() << " points from mechanical state." << sendl;
+            {
+                if (this->f_printLog.getValue())
+                    sout << "VisualModel: copying " << mstate->getSize() << " points from mechanical state." << sendl;
 
-				vertices.resize(mstate->getSize());
+                vertices.resize(mstate->getSize());
 
-				for (unsigned int i=0; i<vertices.size(); i++)
-				{
-					vertices[i][0] = (Real)mstate->getPX(i);
-					vertices[i][1] = (Real)mstate->getPY(i);
-					vertices[i][2] = (Real)mstate->getPZ(i);
-				}
-				
-			}
+                for (unsigned int i=0; i<vertices.size(); i++)
+                {
+                    vertices[i][0] = (Real)mstate->getPX(i);
+                    vertices[i][1] = (Real)mstate->getPY(i);
+                    vertices[i][2] = (Real)mstate->getPZ(i);
+                }
+
+            }
         }
         m_positions.endEdit();
     }
@@ -1347,17 +1349,17 @@ void VisualModelImpl::computeMesh()
     const vector< Triangle >& inputTriangles = m_topology->getTriangles();
 
 
-	if (this->f_printLog.getValue())
-		sout << "VisualModel: copying " << inputTriangles.size() << " triangles from topology." << sendl;
+    if (this->f_printLog.getValue())
+        sout << "VisualModel: copying " << inputTriangles.size() << " triangles from topology." << sendl;
 
-	ResizableExtVector< Triangle >& triangles = *(m_triangles.beginEdit());
-	triangles.resize(inputTriangles.size());
+    ResizableExtVector< Triangle >& triangles = *(m_triangles.beginEdit());
+    triangles.resize(inputTriangles.size());
 
-	for (unsigned int i=0; i<triangles.size(); ++i)
-	{
-		triangles[i] = inputTriangles[i];
-	}
-	m_triangles.endEdit();
+    for (unsigned int i=0; i<triangles.size(); ++i)
+    {
+        triangles[i] = inputTriangles[i];
+    }
+    m_triangles.endEdit();
 
 
     const vector< BaseMeshTopology::Quad >& inputQuads = m_topology->getQuads();
@@ -1898,7 +1900,7 @@ void VisualModelImpl::exportOBJ(std::string name, std::ostream* out, std::ostrea
             *out << "vt "<< std::fixed << vtexcoords[i][0]<<' '<< std::fixed <<vtexcoords[i][1]<<'\n';
         }
     }
-    
+
     for (unsigned int i = 0; i < edges.size() ; i++)
     {
         *out << "f";

--- a/modules/SofaBoundaryCondition/ConicalForceField.h
+++ b/modules/SofaBoundaryCondition/ConicalForceField.h
@@ -122,6 +122,8 @@ protected:
 
         , stiffness(initData(&stiffness, (Real)500, "stiffness", "force stiffness"))
         , damping(initData(&damping, (Real)5, "damping", "force damping"))
+        //TODO FIXME because of: https://github.com/sofa-framework/sofa/issues/64
+        //This field should support the color="red" api.
         , color(initData(&color, defaulttype::Vec3f(0.0f,0.0f,1.0f), "color", "cone color"))
         , bDraw(initData(&bDraw, true, "draw", "enable/disable drawing of the cone"))
     {

--- a/modules/SofaBoundaryCondition/EllipsoidForceField.h
+++ b/modules/SofaBoundaryCondition/EllipsoidForceField.h
@@ -110,6 +110,8 @@ protected:
         , vradius(initData(&vradius, "vradius", "ellipsoid radius"))
         , stiffness(initData(&stiffness, (Real)500, "stiffness", "force stiffness (positive to repulse outward, negative inward)"))
         , damping(initData(&damping, (Real)5, "damping", "force damping"))
+        //TODO FIXME because of: https://github.com/sofa-framework/sofa/issues/64
+        //This field should support the color="red" api.
         , color(initData(&color, defaulttype::Vec3f(0.0f,0.5f,1.0f), "color", "ellipsoid color"))
         , bDraw(initData(&bDraw, true, "draw", "enable/disable drawing of the ellipsoid"))
     {

--- a/modules/SofaBoundaryCondition/PlaneForceField.inl
+++ b/modules/SofaBoundaryCondition/PlaneForceField.inl
@@ -66,6 +66,8 @@ PlaneForceField<DataTypes>::PlaneForceField() :
     // TODO(dmarchal): draw is a bad name. doDraw, doDebugDraw or drawEnabled to be consistent with the drawSize ?
     , d_drawIsEnabled(initData(&d_drawIsEnabled, false, "draw", "enable/disable drawing of plane. (default=false)"))
     // TODO(dmarchal): color is a bad name.
+    //TODO FIXME because of: https://github.com/sofa-framework/sofa/issues/64
+    //This field should support the color="red" api.
     , d_drawColor(initData(&d_drawColor, defaulttype::Vec3f(0.0f,.5f,.2f), "color", "plane color. (default=[0.0,0.5,0.2])"))
     , d_drawSize(initData(&d_drawSize, (Real)10.0f, "drawSize", "plane display size if draw is enabled. (default=10)"))
 {

--- a/modules/SofaBoundaryCondition/SphereForceField.h
+++ b/modules/SofaBoundaryCondition/SphereForceField.h
@@ -113,6 +113,8 @@ protected:
         , sphereRadius(initData(&sphereRadius, (Real)1, "radius", "sphere radius"))
         , stiffness(initData(&stiffness, (Real)500, "stiffness", "force stiffness"))
         , damping(initData(&damping, (Real)5, "damping", "force damping"))
+        //TODO FIXME because of: https://github.com/sofa-framework/sofa/issues/64
+        //This field should support the color="red" api.
         , color(initData(&color, defaulttype::Vec3f(0.0f,0.0f,1.0f), "color", "sphere color"))
         , bDraw(initData(&bDraw, true, "draw", "enable/disable drawing of the sphere"))
         , localRange( initData(&localRange, defaulttype::Vec<2,int>(-1,-1), "localRange", "optional range of local DOF indices. Any computation involving only indices outside of this range are discarded (useful for parallelization using mesh partitionning)" ) )

--- a/modules/SofaBoundaryCondition/VaccumSphereForceField.h
+++ b/modules/SofaBoundaryCondition/VaccumSphereForceField.h
@@ -115,6 +115,8 @@ protected:
         , sphereRadius(initData(&sphereRadius, (Real)1, "radius", "sphere radius"))
         , stiffness(initData(&stiffness, (Real)500, "stiffness", "force stiffness"))
         , damping(initData(&damping, (Real)5, "damping", "force damping"))
+        //TODO FIXME because of: https://github.com/sofa-framework/sofa/issues/64
+        //This field should support the color="red" api.
         , color(initData(&color, defaulttype::Vec3f(0.0f,0.0f,1.0f), "color", "sphere color"))
         , bDraw(initData(&bDraw, true, "draw", "enable/disable drawing of the sphere"))
         , centerState(initData(&centerState, "centerState", "path to the MechanicalState controlling the center point"))

--- a/modules/SofaGeneralObjectInteraction/InteractionEllipsoidForceField.h
+++ b/modules/SofaGeneralObjectInteraction/InteractionEllipsoidForceField.h
@@ -132,6 +132,8 @@ protected:
         , vradius(initData(&vradius, "vradius", "ellipsoid radius"))
         , stiffness(initData(&stiffness, (Real1)500, "stiffness", "force stiffness (positive to repulse outward, negative inward)"))
         , damping(initData(&damping, (Real1)5, "damping", "force damping"))
+        //TODO FIXME because of: https://github.com/sofa-framework/sofa/issues/64
+        //This field should support the color="red" api.
         , color(initData(&color, defaulttype::Vec3f(0.0f,0.5f,1.0f), "color", "ellipsoid color"))
         , bDraw(initData(&bDraw, true, "draw", "enable/disable drawing of the ellipsoid"))
         , object2_dof_index(initData(&object2_dof_index, (int)0, "object2_dof_index", "Dof index of object 2 where the forcefield is attached"))

--- a/modules/SofaGraphComponent/BackgroundSetting.cpp
+++ b/modules/SofaGraphComponent/BackgroundSetting.cpp
@@ -43,6 +43,8 @@ int BackgroundSettingClass = core::RegisterObject("Background colour setting")
         ;
 
 BackgroundSetting::BackgroundSetting():
+    //TODO FIXME because of: https://github.com/sofa-framework/sofa/issues/64
+    //This field should support the color="red" api.
     color(initData(&color, "color", "Color of the Background of the Viewer"))
     , image(initData(&image, "image", "Image to be used as background of the viewer"))
 {

--- a/modules/SofaOpenglVisual/Light.cpp
+++ b/modules/SofaOpenglVisual/Light.cpp
@@ -90,6 +90,8 @@ Light::Light()
     , m_depthShader(sofa::core::objectmodel::New<OglShader>())
     , m_blurShader(sofa::core::objectmodel::New<OglShader>())
 #endif
+    //TODO FIXME because of: https://github.com/sofa-framework/sofa/issues/64
+    //This field should support the color="red" api.
     , d_color(initData(&d_color, (Vector3) Vector3(1,1,1), "color", "Set the color of the light"))
     , d_shadowTextureSize (initData(&d_shadowTextureSize, (GLuint) 0, "shadowTextureSize", "Set size for shadow texture "))
     , d_drawSource(initData(&d_drawSource, (bool) false, "drawSource", "Draw Light Source"))

--- a/modules/SofaOpenglVisual/OglCylinderModel.cpp
+++ b/modules/SofaOpenglVisual/OglCylinderModel.cpp
@@ -57,11 +57,13 @@ int OglCylinderModelClass = core::RegisterObject("A simple visualization for set
 using namespace sofa::defaulttype;
 using namespace sofa::core::topology;
 
-OglCylinderModel::OglCylinderModel() 
+OglCylinderModel::OglCylinderModel()
     : radius(initData(&radius, 1.0f, "radius", "Radius of the cylinder.")),
+      //TODO FIXME because of: https://github.com/sofa-framework/sofa/issues/64
+      //This field should support the color="red" api.
       color(initData(&color, std::string("white"), "color", "Color of the cylinders."))
     , d_edges(initData(&d_edges,"edges","List of edge indices"))
-	  // , pointData(initData(&pointData, "pointData", "scalar field modulating point colors"))
+      // , pointData(initData(&pointData, "pointData", "scalar field modulating point colors"))
 {
 }
 
@@ -92,9 +94,9 @@ void OglCylinderModel::drawVisual(const core::visual::VisualParams* vparams)
     // glPushAttrib(GL_ENABLE_BIT);
 
     vparams->drawTool()->setLightingEnabled(true);
-	Real _radius = radius.getValue();
+    Real _radius = radius.getValue();
 
-	Vec<4,float> col( r, g, b, a );
+    Vec<4,float> col( r, g, b, a );
 
     const SeqEdges& edges = d_edges.getValue();
 

--- a/modules/SofaOpenglVisual/OglGrid.h
+++ b/modules/SofaOpenglVisual/OglGrid.h
@@ -60,6 +60,8 @@ public:
         plane(initData(&plane, std::string("z"),  "plane", "Plane of the grid")),
         size(initData(&size, 10.0f,  "size", "Size of the squared grid")),
         nbSubdiv(initData(&nbSubdiv, 16,  "nbSubdiv", "Number of subdivisions")),
+        //TODO FIXME because of: https://github.com/sofa-framework/sofa/issues/64
+        //This field should support the color="red" api.
         color(initData(&color, sofa::defaulttype::Vec<4, float>(0.34117647058f,0.34117647058f,0.34117647058f,1.0f),  "color", "Color of the lines in the grid")),
         thickness(initData(&thickness, 1.0f,  "thickness", "Thickness of the lines in the grid")),
         draw(initData(&draw, true,  "draw", "Display the grid or not"))

--- a/modules/SofaOpenglVisual/OglLabel.cpp
+++ b/modules/SofaOpenglVisual/OglLabel.cpp
@@ -57,6 +57,8 @@ OglLabel::OglLabel(): stepCounter(0)
   ,x(initData(&x, (unsigned int)10, "x", "The x position of the text on the screen"))
   ,y(initData(&y, (unsigned int)10, "y", "The y position of the text on the screen"))
   ,fontsize(initData(&fontsize, (unsigned int)14, "fontsize", "The size of the font used to display the text on the screen"))
+  //TODO FIXME because of: https://github.com/sofa-framework/sofa/issues/64
+  //This field should support the color="red" api.
   ,color(initData(&color, std::string("contrast"), "color", "The color of the text to display"))
   ,updateLabelEveryNbSteps(initData(&updateLabelEveryNbSteps, (unsigned int)0, "updateLabelEveryNbSteps", "Update the display of the label every nb of time steps"))
   ,f_visible(initData(&f_visible,true,"visible","Is label displayed"))
@@ -117,19 +119,19 @@ void OglLabel::drawVisual(const core::visual::VisualParams* vparams)
 
     // Save state and disable clipping plane
     glPushAttrib(GL_ENABLE_BIT);
-	for(int i = 0; i < GL_MAX_CLIP_PLANES; ++i)
-		glDisable(GL_CLIP_PLANE0+i);
+    for(int i = 0; i < GL_MAX_CLIP_PLANES; ++i)
+        glDisable(GL_CLIP_PLANE0+i);
     glDisable(GL_DEPTH_TEST);
     glDisable(GL_TEXTURE_1D);
     glDisable(GL_BLEND);
     glDepthMask(1);
 
     vparams->drawTool()->setLightingEnabled(false);
-	// vparams->drawTool()->setPolygonMode(1,true);
+    // vparams->drawTool()->setPolygonMode(1,true);
 
-	// color of the text
+    // color of the text
     Color color( r, g, b, a);
-	glColor4f( r, g, b, a );
+    glColor4f( r, g, b, a );
 
     glMaterialfv (GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, &color[0]);
     static const float emissive[4] = { 0.0f, 0.0f, 0.0f, 0.0f};

--- a/modules/SofaOpenglVisual/PointSplatModel.cpp
+++ b/modules/SofaOpenglVisual/PointSplatModel.cpp
@@ -62,6 +62,8 @@ PointSplatModel::PointSplatModel() //const std::string &name, std::string filena
     : radius(initData(&radius, 1.0f, "radius", "Radius of the spheres.")),
       textureSize(initData(&textureSize, 32, "textureSize", "Size of the billboard texture.")),
       alpha(initData(&alpha, 1.0f, "alpha", "Opacity of the billboards. 1.0 is 100% opaque.")),
+      //TODO FIXME because of: https://github.com/sofa-framework/sofa/issues/64
+      //This field should support the color="red" api.
       color(initData(&color, std::string("white"), "color", "Billboard color.")),
       _topology(NULL),
       _mstate(NULL),

--- a/modules/SofaOpenglVisual/SlicedVolumetricModel.cpp
+++ b/modules/SofaOpenglVisual/SlicedVolumetricModel.cpp
@@ -70,6 +70,8 @@ const int SlicedVolumetricModel::__edges__[12][2] = {{ 0,1 }, { 3,2 }, { 4,5 }, 
 SlicedVolumetricModel::SlicedVolumetricModel() //const std::string &name, std::string filename, std::string loader, std::string textureName)
     :
     alpha(initData(&alpha, 0.2f, "alpha", "Opacity of the billboards. 1.0 is 100% opaque.")),
+    //TODO FIXME because of: https://github.com/sofa-framework/sofa/issues/64
+    //This field should support the color="red" api.
     color(initData(&color, std::string("white"), "color", "Billboard color.")),
     _nbPlanes(initData(&_nbPlanes, 100, "nbSlices", "Number of billboards.")),
     _topology(NULL),

--- a/modules/SofaSphFluid/ParticleSink.h
+++ b/modules/SofaSphFluid/ParticleSink.h
@@ -99,6 +99,8 @@ protected:
         : planeNormal(initData(&planeNormal, "normal", "plane normal"))
         , planeD0(initData(&planeD0, (Real)0, "d0", "plane d coef at which particles acceleration is constrained to 0"))
         , planeD1(initData(&planeD1, (Real)0, "d1", "plane d coef at which particles are removed"))
+        //TODO FIXME because of: https://github.com/sofa-framework/sofa/issues/64
+        //This field should support the color="red" api.
         , color(initData(&color, defaulttype::Vec3f(0.0f,.5f,.2f), "color", "plane color"))
         , showPlane(initData(&showPlane, false, "showPlane", "enable/disable drawing of plane"))
         , fixed(initData(&fixed, "fixed", "indices of fixed particles"))

--- a/modules/SofaVolumetricData/DistanceGridForceField.h
+++ b/modules/SofaVolumetricData/DistanceGridForceField.h
@@ -187,6 +187,8 @@ protected:
         , stiffnessArea(initData(&stiffnessArea, (Real)100, "stiffnessArea", "force stiffness if a triangle have an area less than minArea"))
         , minVolume(initData(&minVolume, (Real)0, "minVolume", "minimal volume for each tetrahedron (a flipped triangle will have a negative volume)"))
         , stiffnessVolume(initData(&stiffnessVolume, (Real)0, "stiffnessVolume", "force stiffness if a tetrahedron have an volume less than minVolume"))
+        //TODO FIXME because of: https://github.com/sofa-framework/sofa/issues/64
+        //This field should support the color="red" api.
         , color(initData(&color, defaulttype::Vec3f(0.0f,.5f,.2f), "color", "display color"))
         , bDraw(initData(&bDraw, false, "draw", "enable/disable drawing of distancegrid"))
         , drawPoints(initData(&drawPoints, false, "drawPoints", "enable/disable drawing of distancegrid"))


### PR DESCRIPTION
This pull-request is related to the issue 
https://github.com/sofa-framework/sofa/issues/64 

 It appears that in 2/3 of the cases only 1,0,0 syntax is allowed while the others also
 allows "red" "blue" etc..for color definition.
    
This is an UI consistency issue. Because of UI consistencies our users think that sofa is:
    - hard to understand & master
    - not well done
    
So we should unify that (if we want to smooth our user&own experience with sofa).
So I add a TODO where this should be done and maybe in the future I will fix some of them :)

This Pull-request depends on the following pull-request:
  -  https://github.com/sofa-framework/sofa/pull/58