### PR TITLE
Newtests week47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,10 @@
 * class CountingMessageHandler (count the number of message for each message type)
 * class RoutingMessageHandler (to implement context specific routing of the messages to different handler) 
 * class ExpectMessage and MessageAsATestFailure can be used to check that a component did or didn't send a message and generate a test failure.
+* a script in tools/aliasremover to convert the components alias in scenes for their real component name.
 
 ### Improvements
-*   3 new tests on basic functions:
+*   several new tests:
     - Light
     - LocalMinDistance
     - AllComponent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,10 @@
 * class ExpectMessage and MessageAsATestFailure can be used to check that a component did or didn't send a message and generate a test failure.
 
 ### Improvements
-*   XXXX new tests
+*   3 new tests on basic functions:
+    - Light
+    - LocalMinDistance
+    - AllComponent
 *   YYYY/ZZZ components have an associated example 
 *   RigidMapping: in case jetJs is called several times per step
 *   [SofaPython]

--- a/applications/plugins/SofaTest/SofaTest_test/AllComponents_test.cpp
+++ b/applications/plugins/SofaTest/SofaTest_test/AllComponents_test.cpp
@@ -1,0 +1,133 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2016 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU General Public License as published by the Free  *
+* Software Foundation; either version 2 of the License, or (at your option)   *
+* any later version.                                                          *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for    *
+* more details.                                                               *
+*                                                                             *
+* You should have received a copy of the GNU General Public License along     *
+* with this program; if not, write to the Free Software Foundation, Inc., 51  *
+* Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.                   *
+*******************************************************************************
+*                            SOFA :: Applications                             *
+*                                                                             *
+* Contributors:                                                               *
+*      - damien.machal@univ-lille1.fr                                         *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <SofaSimulationTree/init.h>
+#include <SofaSimulationTree/TreeSimulation.h>
+#include <SofaComponentBase/initComponentBase.h>
+#include <SofaComponentCommon/initComponentCommon.h>
+#include <SofaComponentGeneral/initComponentGeneral.h>
+#include <SofaComponentAdvanced/initComponentAdvanced.h>
+#include <SofaComponentMisc/initComponentMisc.h>
+
+#include <sofa/helper/system/FileSystem.h>
+using sofa::helper::system::FileSystem ;
+
+#include <sofa/helper/BackTrace.h>
+using sofa::helper::BackTrace;
+
+#include <sofa/core/ObjectFactory.h>
+using sofa::core::ObjectFactory ;
+
+#include <SofaTest/Sofa_test.h>
+
+/// A per-file namespace to avoid name clash for static variables.
+namespace allcomponents_test
+{
+
+bool recursiveListDirectory(const std::string& path, std::map<std::string, bool>& fileMap)
+{
+    std::vector<std::string> dircontent ;
+    if( FileSystem::listDirectory(path, dircontent) ){
+        msg_warning("AllComponentTest") << "Unable to scan the directory: '"<< path <<"'." ;
+        return true ;
+    }
+
+    for(auto& name : dircontent){
+        std::string childname=path+"/"+name;
+        if( FileSystem::isDirectory(childname) ){
+            recursiveListDirectory(childname, fileMap);
+        }else
+        {
+            fileMap[name] = true;
+        }
+    }
+
+    return false;
+}
+
+class AllComponents_test: public testing::Test
+{
+
+    void SetUp(){
+        sofa::component::initComponentBase();
+        sofa::component::initComponentCommon();
+        sofa::component::initComponentGeneral();
+        sofa::component::initComponentAdvanced();
+        sofa::component::initComponentMisc();
+    }
+
+    void TearDown(){
+
+    }
+
+public:
+    void buildListOfExamples()
+    {
+
+    }
+
+    void checkExampleFileScene()
+    {
+        unsigned int numberOfComponentWithAnExample = 0 ;
+        std::map<std::string, bool> file2bool;
+
+        ASSERT_FALSE(recursiveListDirectory(std::string(SOFA_SRC_DIR)+"/examples", file2bool));
+
+        std::vector<ObjectFactory::ClassEntry::SPtr> components;
+
+        std::stringstream tmp;
+
+        ObjectFactory::getInstance()->getAllEntries(components);
+        for(ObjectFactory::ClassEntry::SPtr& entry : components)
+        {
+            if(entry){
+                if(file2bool.find(entry->className+".scn") != file2bool.end() ||
+                   file2bool.find(entry->className+".xml") != file2bool.end()){
+
+                   numberOfComponentWithAnExample++;
+                }else{
+                    tmp << " " << entry->className ;
+                }
+            }
+        }
+
+        EXPECT_EQ(components.size(), numberOfComponentWithAnExample) << " Only " << numberOfComponentWithAnExample
+                                                                     << "/" << components.size()
+                                                                     << " of sofa components have an example. If you have a good example for one of the following "
+                                                                        "components: [" << tmp.str() <<  "] please commit it to the example directory" ;
+    }
+};
+
+/// performing the regression test on every plugins/projects
+TEST_F(AllComponents_test, checkExampleFileScene_OpenIssue)
+{
+    this->checkExampleFileScene();
+}
+
+
+
+} // namespace allcomponents_test
+

--- a/applications/plugins/SofaTest/SofaTest_test/CMakeLists.txt
+++ b/applications/plugins/SofaTest/SofaTest_test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(HEADER_FILES
 
 set(SOURCE_FILES
     Regression_test.cpp
+    AllComponents_test.cpp
 )
 
 find_package(SofaPython QUIET)

--- a/modules/SofaConstraint/SofaConstraint_test/CMakeLists.txt
+++ b/modules/SofaConstraint/SofaConstraint_test/CMakeLists.txt
@@ -4,9 +4,12 @@ project(SofaConstraint_test)
 
 set(SOURCE_FILES
     BilateralInteractionConstraint_test.cpp
-    UncoupledConstraintCorrection_test.cpp)
+    UncoupledConstraintCorrection_test.cpp
+    LocalMinDistance_test.cpp
+    )
 
 add_definitions("-DSOFATEST_SCENES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/scenes_test\"")
+add_definitions("-DFRAMEWORK_EXAMPLES_DIR=\"${CMAKE_SOURCE_DIR}/examples\"")
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} SofaGTestMain SofaTest)
 

--- a/modules/SofaConstraint/SofaConstraint_test/LocalMinDistance_test.cpp
+++ b/modules/SofaConstraint/SofaConstraint_test/LocalMinDistance_test.cpp
@@ -63,16 +63,6 @@ struct TestLocalMinDistance : public ::testing::Test {
     void checkIfThereIsAnExampleFile();
 };
 
-void TestLocalMinDistance::checkIfThereIsAnExampleFile()
-{
-    ExpectMessage error(Message::Error) ;
-
-    std::string f="Components/constraint/LocalMinDistance.scn";
-    EXPECT_TRUE(DataRepository.findFile(f))
-            << "Missing an example file for this component in the directory '"
-            << FRAMEWORK_EXAMPLES_DIR << "/Components/constraint'";
-}
-
 void TestLocalMinDistance::checkBasicIntersectionTests()
 {
     ExpectMessage warning(Message::Warning) ;
@@ -255,10 +245,6 @@ TEST_F(TestLocalMinDistance, checkMissingRequiredAttributes)
     checkMissingRequiredAttributes();
 }
 
-TEST_F(TestLocalMinDistance, checkIfThereIsAnExampleFile_OpenIssue)
-{
-    checkIfThereIsAnExampleFile();
-}
 
 
 }

--- a/modules/SofaConstraint/SofaConstraint_test/LocalMinDistance_test.cpp
+++ b/modules/SofaConstraint/SofaConstraint_test/LocalMinDistance_test.cpp
@@ -1,0 +1,264 @@
+#include <vector>
+using std::vector;
+
+#include <string>
+using std::string;
+
+#include <gtest/gtest.h>
+
+#include<sofa/core/objectmodel/BaseObject.h>
+using sofa::core::objectmodel::BaseObject ;
+
+#include <SofaSimulationGraph/DAGSimulation.h>
+using sofa::simulation::Simulation ;
+using sofa::simulation::graph::DAGSimulation ;
+using sofa::simulation::Node ;
+
+#include <SofaSimulationCommon/SceneLoaderXML.h>
+using sofa::simulation::SceneLoaderXML ;
+using sofa::core::ExecParams ;
+
+#include <sofa/helper/logging/Messaging.h>
+using sofa::helper::logging::MessageDispatcher ;
+
+#include <sofa/helper/logging/ClangMessageHandler.h>
+using sofa::helper::logging::ClangMessageHandler ;
+
+#include <SofaTest/TestMessageHandler.h>
+using sofa::helper::logging::ExpectMessage ;
+using sofa::helper::logging::Message ;
+
+#include <SofaConstraint/LocalMinDistance.h>
+using sofa::component::collision::LocalMinDistance ;
+
+#include <sofa/helper/system/FileRepository.h>
+using sofa::helper::system::DataRepository ;
+
+int initMessage(){
+    //MessageDispatcher::clearHandlers() ;
+    //MessageDispatcher::addHandler(new ClangMessageHandler()) ;
+    return 0;
+}
+int messageInited = initMessage();
+
+namespace sofa {
+
+struct TestLocalMinDistance : public ::testing::Test {
+    void SetUp()
+    {
+        DataRepository.addFirstPath(FRAMEWORK_EXAMPLES_DIR);
+    }
+    void TearDown()
+    {
+        DataRepository.removePath(FRAMEWORK_EXAMPLES_DIR);
+    }
+
+    void checkAttributes();
+    void checkMissingRequiredAttributes();
+
+    void checkDoubleInit();
+    void checkInitReinit();
+
+    void checkBasicIntersectionTests();
+    void checkIfThereIsAnExampleFile();
+};
+
+void TestLocalMinDistance::checkIfThereIsAnExampleFile()
+{
+    ExpectMessage error(Message::Error) ;
+
+    std::string f="Components/constraint/LocalMinDistance.scn";
+    EXPECT_TRUE(DataRepository.findFile(f))
+            << "Missing an example file for this component in the directory '"
+            << FRAMEWORK_EXAMPLES_DIR << "/Components/constraint'";
+}
+
+void TestLocalMinDistance::checkBasicIntersectionTests()
+{
+    ExpectMessage warning(Message::Warning) ;
+
+    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>                                                          \n"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject/>                                                         \n"
+             "   <LocalMinDistance name='lmd'/>                                             \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    ASSERT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lmd = root->getTreeNode("Level 1")->getObject("lmd") ;
+    ASSERT_NE(lmd, nullptr) ;
+
+    LocalMinDistance* lmdt = dynamic_cast<LocalMinDistance*>(lmd);
+    ASSERT_NE(lmdt, nullptr) ;
+
+    sofa::component::collision::Point p1;
+    sofa::component::collision::Point p2;
+
+
+    sofa::simulation::getSimulation()->unload(root);
+}
+
+
+void TestLocalMinDistance::checkMissingRequiredAttributes()
+{
+    ExpectMessage warning(Message::Warning) ;
+
+    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>                                                          \n"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject/>                                                         \n"
+             "   <LocalMinDistance name='lmd'/>                                             \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    ASSERT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lmd = root->getTreeNode("Level 1")->getObject("lmd") ;
+    ASSERT_NE(lmd, nullptr) ;
+
+    sofa::simulation::getSimulation()->unload(root);
+}
+
+void TestLocalMinDistance::checkAttributes()
+{
+    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>                                                          \n"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject/>                                                         \n"
+             "   <LocalMinDistance name='lmd'/>                                             \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    ASSERT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lmd = root->getTreeNode("Level 1")->getObject("lmd") ;
+    ASSERT_NE(lmd, nullptr) ;
+
+    /// List of the supported attributes the user expect to find
+    /// This list needs to be updated if you add an attribute.
+    vector<string> attrnames = {
+        "filterIntersection", "angleCone",   "coneFactor", "useLMDFilters"
+    };
+
+    for(auto& attrname : attrnames)
+        EXPECT_NE( lmd->findData(attrname), nullptr ) << "Missing attribute with name '" << attrname << "'." ;
+
+    sofa::simulation::getSimulation()->unload(root);
+}
+
+
+void TestLocalMinDistance::checkDoubleInit()
+{
+    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>                                                          \n"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject/>                                                         \n"
+             "   <LocalMinDistance name='lmd'/>                                             \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    ASSERT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lmd = root->getTreeNode("Level 1")->getObject("lmd") ;
+    ASSERT_NE(lmd, nullptr) ;
+
+    lmd->init() ;
+
+    //TODO(dmarchal) ask consortium what is the status for double call.
+    FAIL() << "TODO: Calling init twice does not produce any warning message" ;
+
+    sofa::simulation::getSimulation()->unload(root);
+}
+
+
+void TestLocalMinDistance::checkInitReinit()
+{
+    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>                                                          \n"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject/>                                                         \n"
+             "   <LocalMinDistance name='lmd'/>                                             \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    ASSERT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lmd = root->getTreeNode("Level 1")->getObject("lmd") ;
+    ASSERT_NE(lmd, nullptr) ;
+
+    lmd->reinit() ;
+
+    sofa::simulation::getSimulation()->unload(root);
+}
+
+
+TEST_F(TestLocalMinDistance, checkAttributes)
+{
+    checkAttributes();
+}
+
+TEST_F(TestLocalMinDistance, checkBasicIntersectionTests_OpenIssue)
+{
+    checkBasicIntersectionTests();
+}
+
+//TODO(dmarchal): restore the two tests when the double call status will be clarified. deprecated after (14/11/2016)+6 month
+TEST_F(TestLocalMinDistance, checkInitReinit_OpenIssue)
+{
+    checkInitReinit();
+}
+
+TEST_F(TestLocalMinDistance, checkDoubleInit_OpenIssue)
+{
+    checkDoubleInit();
+}
+
+TEST_F(TestLocalMinDistance, checkMissingRequiredAttributes)
+{
+    checkMissingRequiredAttributes();
+}
+
+TEST_F(TestLocalMinDistance, checkIfThereIsAnExampleFile_OpenIssue)
+{
+    checkIfThereIsAnExampleFile();
+}
+
+
+}

--- a/modules/SofaOpenglVisual/SofaOpenglVisual_test/CMakeLists.txt
+++ b/modules/SofaOpenglVisual/SofaOpenglVisual_test/CMakeLists.txt
@@ -4,6 +4,7 @@ project(SofaOpenglVisual_test)
 
 set(SOURCE_FILES
     LightManager_test.cpp
+    Light_test.cpp
     )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})

--- a/modules/SofaOpenglVisual/SofaOpenglVisual_test/LightManager_test.cpp
+++ b/modules/SofaOpenglVisual/SofaOpenglVisual_test/LightManager_test.cpp
@@ -27,6 +27,7 @@ using sofa::helper::logging::ClangMessageHandler ;
 
 #include <SofaTest/TestMessageHandler.h>
 using sofa::helper::logging::ExpectMessage ;
+using sofa::helper::logging::MessageAsTestFailure;
 using sofa::helper::logging::Message ;
 
 int initMessage(){
@@ -40,6 +41,8 @@ namespace sofa {
 
 struct TestLightManager : public ::testing::Test {
     void checkAttributes();
+    void checkColor_Ambient_OK();
+    void checkColor_Ambient_OpenIssue();
 };
 
 void TestLightManager::checkAttributes()
@@ -74,10 +77,70 @@ void TestLightManager::checkAttributes()
         EXPECT_NE( lm->findData(attrname), nullptr ) << "Missing attribute with name '" << attrname << "'." ;
 }
 
+void TestLightManager::checkColor_Ambient_OK()
+{
+    MessageAsTestFailure error(Message::Error) ;
+    MessageAsTestFailure warning(Message::Warning) ;
+
+    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject template='Vec3d'/>                                        \n"
+             "   <LightManager name='lightmanager' ambient='1 0 2 3'/>                         \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    EXPECT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
+    EXPECT_NE(lm, nullptr) ;
+}
+
+void TestLightManager::checkColor_Ambient_OpenIssue()
+{
+    MessageAsTestFailure error(Message::Error) ;
+    MessageAsTestFailure warning(Message::Warning) ;
+
+    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject template='Vec3d'/>                                        \n"
+             "   <LightManager name='lightmanager' ambient='red'/>                           \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    EXPECT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
+    EXPECT_NE(lm, nullptr) ;
+}
 
 TEST_F(TestLightManager, checkAttributes)
 {
     checkAttributes();
+}
+
+TEST_F(TestLightManager, checkColor_Ambient_OK)
+{
+    checkColor_Ambient_OK();
+}
+TEST_F(TestLightManager, checkColor_Ambient_OpenIssue)
+{
+    checkColor_Ambient_OpenIssue();
 }
 
 }

--- a/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
+++ b/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
@@ -142,7 +142,6 @@ void TestLight::checkDirectionalLightValidAttributes()
              "  <Node name='Level 1'>                                                        \n"
              "   <MechanicalObject/>                                                         \n"
              "   <LightManager name='lightmanager'/>                                         \n"
-             "   <DirectionalLight name='light1'/>                                           \n"
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 
@@ -189,7 +188,6 @@ void TestLight::checkSpotLightValidAttributes()
              "  <Node name='Level 1'>                                                        \n"
              "   <MechanicalObject/>                                                         \n"
              "   <LightManager name='lightmanager'/>                                         \n"
-             "   <SpotLight name='light1'/>                                                  \n"
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 

--- a/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
+++ b/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
@@ -29,10 +29,15 @@ using sofa::helper::logging::ExpectMessage ;
 using sofa::helper::logging::Message ;
 using sofa::helper::logging::MessageAsTestFailure ;
 
+#include <sofa/helper/BackTrace.h>
+using sofa::helper::BackTrace ;
+
 namespace light_test
 {
 
 int initMessage(){
+    /// Install the backtrace so that we have more information in case of test segfault.
+    BackTrace::autodump() ;
     //MessageDispatcher::clearHandlers() ;
     //MessageDispatcher::addHandler(new ClangMessageHandler()) ;
     return 0;

--- a/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
+++ b/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
@@ -1,0 +1,247 @@
+#include <vector>
+using std::vector;
+
+#include <string>
+using std::string;
+
+#include <gtest/gtest.h>
+
+#include<sofa/core/objectmodel/BaseObject.h>
+using sofa::core::objectmodel::BaseObject ;
+
+#include <SofaSimulationGraph/DAGSimulation.h>
+using sofa::simulation::Simulation ;
+using sofa::simulation::graph::DAGSimulation ;
+using sofa::simulation::Node ;
+
+#include <SofaSimulationCommon/SceneLoaderXML.h>
+using sofa::simulation::SceneLoaderXML ;
+using sofa::core::ExecParams ;
+
+#include <sofa/helper/logging/Messaging.h>
+using sofa::helper::logging::MessageDispatcher ;
+
+#include <sofa/helper/logging/ClangMessageHandler.h>
+using sofa::helper::logging::ClangMessageHandler ;
+
+#include <SofaTest/TestMessageHandler.h>
+using sofa::helper::logging::ExpectMessage ;
+using sofa::helper::logging::Message ;
+using sofa::helper::logging::MessageAsTestFailure ;
+
+namespace light_test
+{
+
+int initMessage(){
+    //MessageDispatcher::clearHandlers() ;
+    //MessageDispatcher::addHandler(new ClangMessageHandler()) ;
+    return 0;
+}
+
+int messageInited = initMessage();
+
+struct TestLight : public ::testing::Test {
+    void checkSpotLightValidAttributes();
+    void checkDirectionalLightValidAttributes();
+    void checkPositionalLightValidAttributes();
+    void checkLightMissingLightManager(const std::string& lighttype);
+};
+
+void TestLight::checkLightMissingLightManager(const std::string& lighttype)
+{
+    MessageAsTestFailure error(Message::Error) ;
+    ExpectMessage warning(Message::Warning) ;
+
+    if(sofa::simulation::getSimulation()==nullptr)
+        sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>                                                          \n"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject/>                                                         \n"
+             "   <"<< lighttype << " name='light1'/>                                            \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    ASSERT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lm = root->getTreeNode("Level 1")->getObject("light1") ;
+    ASSERT_NE(lm, nullptr) ;
+
+    sofa::simulation::getSimulation()->unload(root);
+
+}
+
+void TestLight::checkPositionalLightValidAttributes()
+{
+    MessageAsTestFailure warning(Message::Warning) ;
+    MessageAsTestFailure error(Message::Error) ;
+
+    if(sofa::simulation::getSimulation()==nullptr)
+        sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>                                                          \n"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject/>                                                         \n"
+             "   <LightManager name='lightmanager'/>                                         \n"
+             "   <PositionalLight name='light1'/>                                            \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    ASSERT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
+    ASSERT_NE(lm, nullptr) ;
+
+    BaseObject* light = root->getTreeNode("Level 1")->getObject("light1") ;
+    ASSERT_NE(light, nullptr) ;
+
+    /// List of the supported attributes the user expect to find
+    /// This list needs to be updated if you add an attribute.
+    vector<string> attrnames = {///These are the attributes that any light must have.
+                                "drawSource", "zNear", "zFar",
+                                "shadowsEnabled", "softShadows", "textureUnit",
+
+                                /// These are the attribute specific to this type of light
+                                "fixed", "position", "attenuation"
+                               };
+
+    for(auto& attrname : attrnames)
+        EXPECT_NE( light->findData(attrname), nullptr ) << "Missing attribute with name '" << attrname << "'." ;
+
+    sofa::simulation::getSimulation()->unload(root);
+
+}
+
+void TestLight::checkDirectionalLightValidAttributes()
+{
+    MessageAsTestFailure warning(Message::Warning) ;
+    MessageAsTestFailure error(Message::Error) ;
+
+    if(sofa::simulation::getSimulation()==nullptr)
+        sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>                                                          \n"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject/>                                                         \n"
+             "   <LightManager name='lightmanager'/>                                         \n"
+             "   <DirectionalLight name='light1'/>                                           \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    ASSERT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
+    ASSERT_NE(lm, nullptr) ;
+
+    BaseObject* light = root->getTreeNode("Level 1")->getObject("light1") ;
+    ASSERT_NE(light, nullptr) ;
+
+    /// List of the supported attributes the user expect to find
+    /// This list needs to be updated if you add an attribute.
+    vector<string> attrnames = {///These are the attributes that any light must have.
+                                "drawSource", "zNear", "zFar",
+                                "shadowsEnabled", "softShadows", "textureUnit",
+
+                                /// These are the attribute specific to this type of light
+                                "direction"
+                               };
+
+    for(auto& attrname : attrnames)
+        EXPECT_NE( light->findData(attrname), nullptr ) << "Missing attribute with name '" << attrname << "'." ;
+
+    sofa::simulation::getSimulation()->unload(root);
+
+}
+
+void TestLight::checkSpotLightValidAttributes()
+{
+    MessageAsTestFailure warning(Message::Warning) ;
+    MessageAsTestFailure error(Message::Error) ;
+
+    if(sofa::simulation::getSimulation()==nullptr)
+        sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>                                                          \n"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject/>                                                         \n"
+             "   <LightManager name='lightmanager'/>                                         \n"
+             "   <SpotLight name='light1'/>                                                  \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    ASSERT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
+    ASSERT_NE(lm, nullptr) ;
+
+    BaseObject* light = root->getTreeNode("Level 1")->getObject("light1") ;
+    ASSERT_NE(light, nullptr) ;
+
+    /// List of the supported attributes the user expect to find
+    /// This list needs to be updated if you add an attribute.
+    vector<string> attrnames = {///These are the attributes that any light must have.
+                                "drawSource", "zNear", "zFar",
+                                "shadowsEnabled", "softShadows", "textureUnit",
+
+                                /// These are the attributes inherited from PositionalLight
+                                 "fixed", "position", "attenuation",
+
+                                /// These are the attribute specific to this type of light
+                                "direction", "cutoff", "exponent", "lookat",
+                                "modelViewMatrix", "projectionMatrix"
+                               };
+
+    for(auto& attrname : attrnames)
+        EXPECT_NE( light->findData(attrname), nullptr ) << "Missing attribute with name '" << attrname << "'." ;
+
+    sofa::simulation::getSimulation()->unload(root);
+
+}
+
+
+TEST_F(TestLight, checkPositionalLightValidAttributes)
+{
+    checkPositionalLightValidAttributes();
+}
+
+TEST_F(TestLight, checkDirectionalLightValidAttributes)
+{
+    checkDirectionalLightValidAttributes();
+}
+
+TEST_F(TestLight, checkSpotLightValidAttributes)
+{
+    checkSpotLightValidAttributes();
+}
+
+TEST_F(TestLight, checkPositionalLightMissingLightManager)
+{
+    std::vector<std::string> typeoflight={"PositionalLight", "DirectionalLight", "SpotLight"} ;
+    for(auto& lighttype : typeoflight)
+        checkLightMissingLightManager(lighttype);
+}
+} // light_test

--- a/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
+++ b/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
@@ -96,7 +96,6 @@ void TestLight::checkPositionalLightValidAttributes()
              "  <Node name='Level 1'>                                                        \n"
              "   <MechanicalObject/>                                                         \n"
              "   <LightManager name='lightmanager'/>                                         \n"
-             "   <PositionalLight name='light1'/>                                            \n"
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 

--- a/tools/aliasremover/aliasremoval.sh
+++ b/tools/aliasremover/aliasremoval.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+EXAMPLE_FOLDER=../../examples
+TEMP_FILE=post_checking_list.log
+
+## Pre-check
+which runSofa
+
+if [ $? -ne 0 ]
+then 
+    echo "no runSofa application found"
+    exit 1
+fi
+
+## Usage
+display_usage() 
+{ 
+    echo "This script replaces alias components in any SOFA scene (XML)." 
+    echo -e "\nUsage:\n$0 [name of the dictionary file containing aliases] \n" 
+} 
+
+## Check argument
+if [  $# -ne 1 ] 
+then 
+    display_usage
+    exit 1
+fi
+
+## Here is where the magic happens
+cat $1 | while read sofaAlias sofaRealComponent; do    
+    # Save list for post-checking
+    grep -rl '<'$sofaAlias $EXAMPLE_FOLDER > $TEMP_FILE
+
+    # Do the substitution
+    # Pattern 1 = <Alias ???
+    find $EXAMPLE_FOLDER -type f -name '*.scn' -exec sed -i '' 's/<'$sofaAlias' /<'$sofaRealComponent' /' {} +
+
+    # Post-checking
+    cat $TEMP_FILE | while read line; do
+        $SOFA_EXEC -g batch -n 10 $line
+    done
+done
+
+## Clean temporary file 
+rm -f $TEMP_FILE


### PR DESCRIPTION
Hi,

Here is our 'newtests' contributions for sofa this week. 

It is very simple and consists in several new test for components:
  - Light, LightManager, LocalMinDistance

One of them is tagged with OpenIssue because it shows a User Interface consistency problem; the ambient term of LightManager is a color but it does not accept string based color name as other sofa component do. To fix this we will need to unify the 'color' in all sofa. 
 
There is also a weird test called AllComponent that checks each sofa components if there is a corresponding example. Currently it fails because only 1/3 of them have one. 

Finally Jérémie commited a script to convert the alias in a sofa scene to the real component name. 