### PR TITLE
WARNING: fix missing r in SofaSparseSolver

### DIFF
--- a/modules/SofaSparseSolver/SparseLDLSolver.h
+++ b/modules/SofaSparseSolver/SparseLDLSolver.h
@@ -58,7 +58,7 @@ public :
     typedef sofa::component::linearsolver::SparseLDLSolverImpl<TMatrix,TVector,TThreadManager> Inherit;
     typedef typename Inherit::ResMatrixType ResMatrixType;
     typedef typename Inherit::JMatrixType JMatrixType;
-    typedef SpaseLDLImplInvertData<helper::vector<int>, helper::vector<Real> > InvertData;
+    typedef SparseLDLImplInvertData<helper::vector<int>, helper::vector<Real> > InvertData;
 
     void solve (Matrix& M, Vector& x, Vector& b);
     void invert(Matrix& M);

--- a/modules/SofaSparseSolver/SparseLDLSolverImpl.h
+++ b/modules/SofaSparseSolver/SparseLDLSolverImpl.h
@@ -44,7 +44,7 @@ namespace linearsolver
 
 //defaut structure for a LDL factorization
 template<class VecInt,class VecReal>
-class SpaseLDLImplInvertData : public MatrixInvertData {
+class SparseLDLImplInvertData : public MatrixInvertData {
 public :
     int n, P_nnz, L_nnz;
     VecInt P_rowind,P_colptr,L_rowind,L_colptr,LT_rowind,LT_colptr;
@@ -170,7 +170,7 @@ protected :
     SparseLDLSolverImpl() : Inherit() {}
 
     template<class VecInt,class VecReal>
-    void solve_cpu(Real * x,const Real * b,SpaseLDLImplInvertData<VecInt,VecReal> * data) {
+    void solve_cpu(Real * x,const Real * b,SparseLDLImplInvertData<VecInt,VecReal> * data) {
         int n = data->n;
         const Real * invD = &data->invD[0];
         const int * perm = &data->perm[0];
@@ -282,7 +282,7 @@ protected :
     }
 
     template<class VecInt,class VecReal>
-    void factorize(int n,int * M_colptr, int * M_rowind, Real * M_values, SpaseLDLImplInvertData<VecInt,VecReal> * data) {
+    void factorize(int n,int * M_colptr, int * M_rowind, Real * M_values, SparseLDLImplInvertData<VecInt,VecReal> * data) {
         data->new_factorization_needed = data->P_colptr.size() == 0 || data->P_rowind.size() == 0 || CSPARSE_need_symbolic_factorization(n, M_colptr, M_rowind, data->n, (int *) &data->P_colptr[0],(int *) &data->P_rowind[0]);
 
         data->n = n;

--- a/modules/SofaSparseSolver/SparseLUSolver.h
+++ b/modules/SofaSparseSolver/SparseLUSolver.h
@@ -46,7 +46,7 @@ namespace linearsolver
 
 //defaut structure for a LDL factorization
 template<class Real>
-class SpaseLUInvertData : public MatrixInvertData {
+class SparseLUInvertData : public MatrixInvertData {
 public :
 
     css *S;
@@ -55,12 +55,12 @@ public :
     helper::vector<int> A_i, A_p;
     helper::vector<Real> A_x;
     Real * tmp;
-    SpaseLUInvertData()
+    SparseLUInvertData()
     {
         S=NULL; N=NULL; tmp=NULL;
     }
 
-    ~SpaseLUInvertData()
+    ~SparseLUInvertData()
     {
         if (S) cs_sfree (S);
         if (N) cs_nfree (N);
@@ -91,7 +91,7 @@ public:
 protected :
 
     MatrixInvertData * createInvertData() {
-        return new SpaseLUInvertData<Real>();
+        return new SparseLUInvertData<Real>();
     }
 
 };

--- a/modules/SofaSparseSolver/SparseLUSolver.inl
+++ b/modules/SofaSparseSolver/SparseLUSolver.inl
@@ -67,7 +67,7 @@ SparseLUSolver<TMatrix,TVector,TThreadManager>::SparseLUSolver()
 template<class TMatrix, class TVector,class TThreadManager>
 void SparseLUSolver<TMatrix,TVector,TThreadManager>::solve (Matrix& M, Vector& z, Vector& r)
 {
-    SpaseLUInvertData<Real> * invertData = (SpaseLUInvertData<Real>*) this->getMatrixInvertData(&M);
+    SparseLUInvertData<Real> * invertData = (SparseLUInvertData<Real>*) this->getMatrixInvertData(&M);
     int n = invertData->A.n;
 
     cs_ipvec (n, invertData->N->Pinv, r.ptr(), invertData->tmp) ;	/* x = P*b */
@@ -79,7 +79,7 @@ void SparseLUSolver<TMatrix,TVector,TThreadManager>::solve (Matrix& M, Vector& z
 template<class TMatrix, class TVector,class TThreadManager>
 void SparseLUSolver<TMatrix,TVector,TThreadManager>::invert(Matrix& M)
 {
-    SpaseLUInvertData<Real> * invertData = (SpaseLUInvertData<Real>*) this->getMatrixInvertData(&M);
+    SparseLUInvertData<Real> * invertData = (SparseLUInvertData<Real>*) this->getMatrixInvertData(&M);
     int order = -1; //?????
 
     if (invertData->S) cs_sfree(invertData->S);


### PR DESCRIPTION
Just a little fix in SparseLDLImplInvertData, r of sparse is missing. 
Fix needed for Cuda plugins update in sofa-dev.