### PR TITLE
[SofaPython] unused argument warning

### DIFF
--- a/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
@@ -510,19 +510,17 @@ void  Base::parseFields ( const std::map<std::string,std::string*>& args )
 /// Parse the given description to assign values to this object's fields and potentially other parameters
 void  Base::parse ( BaseObjectDescription* arg )
 {
-    std::vector< std::string > attributeList;
-    arg->getAttributeList(attributeList);
-    for (unsigned int i=0; i<attributeList.size(); ++i)
+    for( auto& it : arg->getAttributeMap() )
     {
-        std::string attrName = attributeList[i];
+        const std::string& attrName = it.first;
+
         // FIX: "type" is already used to define the type of object to instanciate, any Data with
         // the same name cannot be extracted from BaseObjectDescription
         if (attrName == std::string("type")) continue;
+
         if (!hasField(attrName)) continue;
-        const char* val = arg->getAttribute(attrName);
-        if (!val) continue;
-        std::string valueString(val);
-        parseField(attrName, valueString);
+
+        parseField(attrName, it.second);
     }
     updateLinks(false);
 }

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseObject.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseObject.cpp
@@ -92,8 +92,6 @@ void BaseObject::parse( BaseObjectDescription* arg )
 {
     if (arg->getAttribute("src"))
     {
-        std::vector< std::string > attributeList;
-        arg->getAttributeList(attributeList);
         std::string valueString(arg->getAttribute("src"));
 
         if (valueString[0] != '@')
@@ -102,6 +100,8 @@ void BaseObject::parse( BaseObjectDescription* arg )
         }
         else
         {
+            std::vector< std::string > attributeList;
+            arg->getAttributeList(attributeList);
             setSrc(valueString, &attributeList);
         }
         arg->removeAttribute("src");

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseObjectDescription.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseObjectDescription.cpp
@@ -86,10 +86,10 @@ std::string BaseObjectDescription::getBaseFile()
 }
 
 ///// Get all attribute data, read-only
-//const BaseObjectDescription::AttributeMap& BaseObjectDescription::getAttributeMap() const
-//{
-//    return attributes;
-//}
+const BaseObjectDescription::AttributeMap& BaseObjectDescription::getAttributeMap() const
+{
+    return attributes;
+}
 
 /// Find an object description given its name (relative to this object)
 BaseObjectDescription* BaseObjectDescription::find(const char* /*nodeName*/, bool /*absolute*/)

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseObjectDescription.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseObjectDescription.h
@@ -57,15 +57,15 @@ public:
     {
     protected:
         std::string value;
-        bool accessed;
+        mutable bool accessed;
     public:
         Attribute() : accessed(false) {}
         Attribute(const std::string& v) : value(v), accessed(false) {}
         void operator=(const std::string& v) { value = v; }
         void operator=(const char* v) { value = v; }
-        operator std::string() { accessed = true; return value; }
-        const char* c_str() { accessed = true; return value.c_str(); }
-        bool isAccessed() { return accessed; }
+        operator std::string() const { accessed = true; return value; }
+        const char* c_str() const { accessed = true; return value.c_str(); }
+        bool isAccessed() const { return accessed; }
         void setAccessed(bool v) { accessed = v; }
     };
 
@@ -91,12 +91,12 @@ public:
     virtual std::string getBaseFile();
 
     ///// Get all attribute data, read-only
-    //virtual const AttributeMap& getAttributeMap() const;
+    virtual const AttributeMap& getAttributeMap() const;
 
     ///// Get list of all attributes
-    template<class T> void getAttributeList(T& container)
+    template<class T> void getAttributeList(T& container) const
     {
-        for (AttributeMap::iterator it = attributes.begin();
+        for (AttributeMap::const_iterator it = attributes.begin();
                 it != attributes.end(); ++it)
             container.push_back(it->first);
     }

--- a/applications/plugins/SofaPython/Binding_BaseContext.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseContext.cpp
@@ -130,15 +130,20 @@ extern "C" PyObject * BaseContext_createObject_Impl(PyObject * self, PyObject * 
         Py_RETURN_NONE;
     }
 
+
     if( warning )
     {
-        Node *node = static_cast<Node*>(context);
-        if (node)
+        for( auto it : desc.getAttributeMap() )
         {
-            //SP_MESSAGE_INFO( "Sofa.Node.createObject("<<type<<") node="<<node->getName()<<" isInitialized()="<<node->isInitialized() )
-            if (node->isInitialized())
-                SP_MESSAGE_WARNING( "Sofa.Node.createObject("<<type<<") called on a node("<<node->getName()<<") that is already initialized" )
+            if (!it.second.isAccessed())
+            {
+                obj->serr <<"Unused Attribute: \""<<it.first <<"\" with value: \"" <<(std::string)it.second<<"\"" << obj->sendl;
+            }
         }
+
+        Node *node = static_cast<Node*>(context);
+        if (node && node->isInitialized())
+            SP_MESSAGE_WARNING( "Sofa.Node.createObject("<<type<<") called on a node("<<node->getName()<<") that is already initialized" )
     }
 
     return sofa::PythonFactory::toPython(obj.get());


### PR DESCRIPTION
Printing a warning when an argument is not used while creating a component.
This is useful to avoid typos that can make you lose plenty of time!

Cleaning Base::parse a bit on the way.