### PR TITLE
[SofaKernel] Fix two failing tests

### DIFF
--- a/SofaKernel/framework/framework_test/helper/io/ImagePNG_test.cpp
+++ b/SofaKernel/framework/framework_test/helper/io/ImagePNG_test.cpp
@@ -29,8 +29,16 @@
 #include <gtest/gtest.h>
 
 #include <SofaTest/TestMessageHandler.h>
+using sofa::helper::logging::MessageDispatcher ;
 using sofa::helper::logging::ExpectMessage ;
 using sofa::helper::logging::Message ;
+
+#include <sofa/helper/logging/LoggingMessageHandler.h>
+using sofa::helper::logging::MainLoggingMessageHandler ;
+
+#include <sofa/helper/logging/CountingMessageHandler.h>
+using sofa::helper::logging::MainCountingMessageHandler ;
+
 
 namespace sofa {
 
@@ -38,7 +46,11 @@ namespace sofa {
 class ImagePNG_test : public ::testing::Test
 {
 protected:
-    ImagePNG_test() {}
+    ImagePNG_test() {
+        MessageDispatcher::clearHandlers() ;
+        MessageDispatcher::addHandler( &MainCountingMessageHandler::getInstance() ) ;
+        MessageDispatcher::addHandler( &MainLoggingMessageHandler::getInstance() ) ;
+    }
 
     void SetUp()
     {

--- a/SofaKernel/framework/framework_test/helper/io/MeshOBJ_test.cpp
+++ b/SofaKernel/framework/framework_test/helper/io/MeshOBJ_test.cpp
@@ -30,6 +30,15 @@
 using sofa::helper::logging::ExpectMessage;
 using sofa::helper::logging::Message;
 
+#include <sofa/helper/logging/Message.h>
+using sofa::helper::logging::MessageDispatcher ;
+
+#include <sofa/helper/logging/LoggingMessageHandler.h>
+using sofa::helper::logging::MainLoggingMessageHandler ;
+
+#include <sofa/helper/logging/CountingMessageHandler.h>
+using sofa::helper::logging::MainCountingMessageHandler ;
+
 
 namespace sofa {
 
@@ -38,7 +47,11 @@ using namespace core::loader;
 class MeshOBJ_test : public ::testing::Test
 {
 protected:
-    MeshOBJ_test() {}
+    MeshOBJ_test() {
+        MessageDispatcher::clearHandlers() ;
+        MessageDispatcher::addHandler( &MainCountingMessageHandler::getInstance() ) ;
+        MessageDispatcher::addHandler( &MainLoggingMessageHandler::getInstance() ) ;
+    }
 
     void SetUp()
     {


### PR DESCRIPTION
This should fix the failing ImagePng test failure. 

The problem is the consequence of the use of the ExpectMessage RAII without adding a  CountingMessageHandler to the MessageDispatcher.

This is quick fix but more fundamentally we need an API improvement to make
that automatical/hidden. But how to do that in an efficient way is yet unclear. 