### PR TITLE
Remove testmessagehandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,10 @@
 * class CountingMessageHandler (count the number of message for each message type)
 * class RoutingMessageHandler (to implement context specific routing of the messages to different handler) 
 * class ExpectMessage and MessageAsATestFailure can be used to check that a component did or didn't send a message and generate a test failure.
+* a script in tools/aliasremover to convert the components alias in scenes for their real component name.
 
 ### Improvements
-*   3 new tests on basic functions:
+*   several new tests:
     - Light
     - LocalMinDistance
     - AllComponent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,10 @@
 * class ExpectMessage and MessageAsATestFailure can be used to check that a component did or didn't send a message and generate a test failure.
 
 ### Improvements
-*   XXXX new tests
+*   3 new tests on basic functions:
+    - Light
+    - LocalMinDistance
+    - AllComponent
 *   YYYY/ZZZ components have an associated example 
 *   RigidMapping: in case jetJs is called several times per step
 *   [SofaPython]

--- a/SofaKernel/framework/framework_test/helper/Utils_test.cpp
+++ b/SofaKernel/framework/framework_test/helper/Utils_test.cpp
@@ -62,7 +62,6 @@ TEST(UtilsTest, getSofaPathPrefix)
 TEST(UtilsTest, readBasicIniFile_nonexistentFile)
 {
     // this test will raise an error on purpose
-    sofa::helper::logging::ScopedDeactivatedTestMessageHandler scopedDeactivatedTestMessageHandler;
     std::map<std::string, std::string> values = Utils::readBasicIniFile("this-file-does-not-exist");
     EXPECT_TRUE(values.empty());
 }

--- a/SofaKernel/framework/framework_test/helper/system/FileSystem_test.cpp
+++ b/SofaKernel/framework/framework_test/helper/system/FileSystem_test.cpp
@@ -4,6 +4,10 @@
 #include <exception>
 #include <algorithm>
 #include <SofaTest/TestMessageHandler.h>
+using sofa::helper::logging::MessageAsTestFailure;
+using sofa::helper::logging::ExpectMessage;
+using sofa::helper::logging::Message;
+
 
 using sofa::helper::system::FileSystem;
 
@@ -21,6 +25,8 @@ static std::string getPath(std::string s) {
 
 TEST(FileSystemTest, listDirectory_nonEmpty)
 {
+    MessageAsTestFailure error(Message::Error) ;
+
     std::vector<std::string> fileList;
     FileSystem::listDirectory(getPath("non-empty-directory"), fileList);
     // Workaround: svn adds a '.svn' directory in each subdirectory
@@ -35,6 +41,8 @@ TEST(FileSystemTest, listDirectory_nonEmpty)
 
 TEST(FileSystemTest, listDirectory_nonEmpty_trailingSlash)
 {
+    MessageAsTestFailure error(Message::Error) ;
+
     std::vector<std::string> fileList;
     FileSystem::listDirectory(getPath("non-empty-directory/"), fileList);
     // Workaround: svn adds a '.svn' directory in each subdirectory
@@ -49,6 +57,8 @@ TEST(FileSystemTest, listDirectory_nonEmpty_trailingSlash)
 
 TEST(FileSystemTest, listDirectory_withExtension_multipleMatches)
 {
+    MessageAsTestFailure error(Message::Error) ;
+
     std::vector<std::string> fileList;
     FileSystem::listDirectory(getPath("non-empty-directory/"), fileList, "txt");
     EXPECT_EQ(fileList.size(), 2u);
@@ -58,6 +68,8 @@ TEST(FileSystemTest, listDirectory_withExtension_multipleMatches)
 
 TEST(FileSystemTest, listDirectory_withExtension_oneMatch)
 {
+    MessageAsTestFailure error(Message::Error) ;
+
     std::vector<std::string> fileList;
     FileSystem::listDirectory(getPath("non-empty-directory/"), fileList, "so");
     EXPECT_EQ(fileList.size(), 1u);
@@ -66,6 +78,8 @@ TEST(FileSystemTest, listDirectory_withExtension_oneMatch)
 
 TEST(FileSystemTest, listDirectory_withExtension_noMatch)
 {
+    MessageAsTestFailure error(Message::Error) ;
+
     std::vector<std::string> fileList;
     FileSystem::listDirectory(getPath("non-empty-directory/"), fileList, "h");
     EXPECT_TRUE(fileList.empty());
@@ -73,6 +87,8 @@ TEST(FileSystemTest, listDirectory_withExtension_noMatch)
 
 TEST(FileSystemTest, createDirectory)
 {
+    MessageAsTestFailure error(Message::Error) ;
+
     EXPECT_FALSE(FileSystem::createDirectory("createDirectoryTestDir"));
     EXPECT_TRUE(FileSystem::exists("createDirectoryTestDir"));
     EXPECT_TRUE(FileSystem::isDirectory("createDirectoryTestDir"));
@@ -82,18 +98,24 @@ TEST(FileSystemTest, createDirectory)
 
 TEST(FileSystemTest, createDirectory_alreadyExists)
 {
-    FileSystem::createDirectory("createDirectoryTestDir");
     {
-        // this test will raise an error on purpose
-        sofa::helper::logging::ScopedDeactivatedTestMessageHandler scopedDeactivatedTestMessageHandler;
+        MessageAsTestFailure error(Message::Error) ;
+        FileSystem::createDirectory("createDirectoryTestDir");
+    }
+    {
+        ExpectMessage error(Message::Error) ;
         EXPECT_TRUE(FileSystem::createDirectory("createDirectoryTestDir"));
     }
-    // Cleanup
-    FileSystem::removeDirectory("createDirectoryTestDir");
+    {
+        MessageAsTestFailure error(Message::Error) ;
+        FileSystem::removeDirectory("createDirectoryTestDir");
+    }
 }
 
 TEST(FileSystemTest, removeDirectory)
 {
+    MessageAsTestFailure error(Message::Error);
+
     FileSystem::createDirectory("removeDirectoryTestDir");
     EXPECT_FALSE(FileSystem::removeDirectory("removeDirectoryTestDir"));
     EXPECT_FALSE(FileSystem::exists("removeDirectoryTestDir"));
@@ -103,10 +125,14 @@ TEST(FileSystemTest, removeDirectory_doesNotExists)
 {
     {
         // this test will raise an error on purpose
-        sofa::helper::logging::ScopedDeactivatedTestMessageHandler scopedDeactivatedTestMessageHandler;
+        ExpectMessage error(Message::Error) ;
+
         EXPECT_TRUE(FileSystem::removeDirectory("removeDirectoryTestDir"));
     }
-    EXPECT_FALSE(FileSystem::exists("removeDirectoryTestDir"));
+    {
+        MessageAsTestFailure error(Message::Error);
+        EXPECT_FALSE(FileSystem::exists("removeDirectoryTestDir"));
+    }
 }
 
 TEST(FileSystemTest, exists_yes)

--- a/SofaKernel/framework/sofa/helper/logging/LoggingMessageHandler.h
+++ b/SofaKernel/framework/sofa/helper/logging/LoggingMessageHandler.h
@@ -136,7 +136,7 @@ public:
     {
         const std::vector<Message>& messages = MainLoggingMessageHandler::getMessages() ;
 
-        return messages.size() ;
+        return messages.end()-(messages.begin()+m_firstMessage);
     }
 
 private:

--- a/applications/plugins/SofaTest/SofaTest_test/AllComponents_test.cpp
+++ b/applications/plugins/SofaTest/SofaTest_test/AllComponents_test.cpp
@@ -1,0 +1,133 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2016 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU General Public License as published by the Free  *
+* Software Foundation; either version 2 of the License, or (at your option)   *
+* any later version.                                                          *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for    *
+* more details.                                                               *
+*                                                                             *
+* You should have received a copy of the GNU General Public License along     *
+* with this program; if not, write to the Free Software Foundation, Inc., 51  *
+* Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.                   *
+*******************************************************************************
+*                            SOFA :: Applications                             *
+*                                                                             *
+* Contributors:                                                               *
+*      - damien.machal@univ-lille1.fr                                         *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <SofaSimulationTree/init.h>
+#include <SofaSimulationTree/TreeSimulation.h>
+#include <SofaComponentBase/initComponentBase.h>
+#include <SofaComponentCommon/initComponentCommon.h>
+#include <SofaComponentGeneral/initComponentGeneral.h>
+#include <SofaComponentAdvanced/initComponentAdvanced.h>
+#include <SofaComponentMisc/initComponentMisc.h>
+
+#include <sofa/helper/system/FileSystem.h>
+using sofa::helper::system::FileSystem ;
+
+#include <sofa/helper/BackTrace.h>
+using sofa::helper::BackTrace;
+
+#include <sofa/core/ObjectFactory.h>
+using sofa::core::ObjectFactory ;
+
+#include <SofaTest/Sofa_test.h>
+
+/// A per-file namespace to avoid name clash for static variables.
+namespace allcomponents_test
+{
+
+bool recursiveListDirectory(const std::string& path, std::map<std::string, bool>& fileMap)
+{
+    std::vector<std::string> dircontent ;
+    if( FileSystem::listDirectory(path, dircontent) ){
+        msg_warning("AllComponentTest") << "Unable to scan the directory: '"<< path <<"'." ;
+        return true ;
+    }
+
+    for(auto& name : dircontent){
+        std::string childname=path+"/"+name;
+        if( FileSystem::isDirectory(childname) ){
+            recursiveListDirectory(childname, fileMap);
+        }else
+        {
+            fileMap[name] = true;
+        }
+    }
+
+    return false;
+}
+
+class AllComponents_test: public testing::Test
+{
+
+    void SetUp(){
+        sofa::component::initComponentBase();
+        sofa::component::initComponentCommon();
+        sofa::component::initComponentGeneral();
+        sofa::component::initComponentAdvanced();
+        sofa::component::initComponentMisc();
+    }
+
+    void TearDown(){
+
+    }
+
+public:
+    void buildListOfExamples()
+    {
+
+    }
+
+    void checkExampleFileScene()
+    {
+        unsigned int numberOfComponentWithAnExample = 0 ;
+        std::map<std::string, bool> file2bool;
+
+        ASSERT_FALSE(recursiveListDirectory(std::string(SOFA_SRC_DIR)+"/examples", file2bool));
+
+        std::vector<ObjectFactory::ClassEntry::SPtr> components;
+
+        std::stringstream tmp;
+
+        ObjectFactory::getInstance()->getAllEntries(components);
+        for(ObjectFactory::ClassEntry::SPtr& entry : components)
+        {
+            if(entry){
+                if(file2bool.find(entry->className+".scn") != file2bool.end() ||
+                   file2bool.find(entry->className+".xml") != file2bool.end()){
+
+                   numberOfComponentWithAnExample++;
+                }else{
+                    tmp << " " << entry->className ;
+                }
+            }
+        }
+
+        EXPECT_EQ(components.size(), numberOfComponentWithAnExample) << " Only " << numberOfComponentWithAnExample
+                                                                     << "/" << components.size()
+                                                                     << " of sofa components have an example. If you have a good example for one of the following "
+                                                                        "components: [" << tmp.str() <<  "] please commit it to the example directory" ;
+    }
+};
+
+/// performing the regression test on every plugins/projects
+TEST_F(AllComponents_test, checkExampleFileScene_OpenIssue)
+{
+    this->checkExampleFileScene();
+}
+
+
+
+} // namespace allcomponents_test
+

--- a/applications/plugins/SofaTest/SofaTest_test/CMakeLists.txt
+++ b/applications/plugins/SofaTest/SofaTest_test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(HEADER_FILES
 
 set(SOURCE_FILES
     Regression_test.cpp
+    AllComponents_test.cpp
 )
 
 find_package(SofaPython QUIET)

--- a/applications/plugins/SofaTest/Sofa_test.cpp
+++ b/applications/plugins/SofaTest/Sofa_test.cpp
@@ -30,6 +30,7 @@
 #include <sofa/helper/system/FileSystem.h>
 #include <sofa/helper/Utils.h>
 #include <sofa/helper/logging/MessageDispatcher.h>
+#include <sofa/helper/logging/CountingMessageHandler.h>
 #include "TestMessageHandler.h"
 
 using sofa::helper::system::PluginRepository;
@@ -41,14 +42,13 @@ namespace sofa {
 
 
 // some basic RAII stuff to automatically add a TestMessageHandler to every tests
-namespace {
 
+namespace {
     static struct raii {
       raii() {
-            helper::logging::MessageDispatcher::addHandler( &helper::logging::TestMessageHandler::getInstance() ) ;
             helper::logging::MessageDispatcher::addHandler( &helper::logging::MainCountingMessageHandler::getInstance() ) ;
+            helper::logging::MessageDispatcher::addHandler( &helper::logging::MainLoggingMessageHandler::getInstance() ) ;
       }
-
     } singleton;
 }
 
@@ -63,6 +63,12 @@ BaseSofa_test::BaseSofa_test(){
     //use the same seed (the seed value is indicated at the 2nd line of test results)
     //and pass the seed in command argument line ex: SofaTest_test.exe seed 32
     helper::srand(seed);
+
+
+    // Repeating this for each class is harmless because addHandler test if the handler is already installed and
+    // if so it don't install it again.
+    helper::logging::MessageDispatcher::addHandler( &helper::logging::MainCountingMessageHandler::getInstance() ) ;
+    helper::logging::MessageDispatcher::addHandler( &helper::logging::MainLoggingMessageHandler::getInstance() ) ;
 }
 
 BaseSofa_test::~BaseSofa_test(){ clearSceneGraph(); }

--- a/applications/plugins/SofaTest/Sofa_test.h
+++ b/applications/plugins/SofaTest/Sofa_test.h
@@ -38,6 +38,9 @@
 #include <time.h>
 #include <iostream>
 
+#include <sofa/helper/logging/LoggingMessageHandler.h>
+#include <sofa/helper/logging/CountingMessageHandler.h>
+
 // Maybe not the right place to put this (private header?)
 #ifndef SOFA_FLOAT
 typedef sofa::defaulttype::Rigid3dTypes Rigid3;
@@ -61,7 +64,7 @@ const SReal g_minDeltaErrorRatio = .1; // TODO is it already too small?
 struct SOFA_TestPlugin_API BaseSofa_test : public ::testing::Test
 {
     /// Initialize Sofa and the random number generator
-    BaseSofa_test();
+    BaseSofa_test() ;
 
     /// Clear the scene graph
     virtual ~BaseSofa_test();
@@ -313,10 +316,10 @@ void setRot(typename DataTypes::Coord& coord, const sofa::helper::Quater<SReal>&
 template<class DataTypes>
 typename DataTypes::Coord createCoord(const sofa::defaulttype::Vector3& pos, const sofa::helper::Quater<SReal>& rot)
 {
-	typename DataTypes::Coord temp;
-	DataTypes::set(temp, pos[0], pos[1], pos[2]);
-	setRot<DataTypes>(temp, rot);
-	return temp;
+    typename DataTypes::Coord temp;
+    DataTypes::set(temp, pos[0], pos[1], pos[2]);
+    setRot<DataTypes>(temp, rot);
+    return temp;
 }
 
 template <int N, class real>

--- a/applications/plugins/SofaTest/TestMessageHandler.h
+++ b/applications/plugins/SofaTest/TestMessageHandler.h
@@ -48,70 +48,10 @@ namespace helper
 namespace logging
 {
 
-/// each ERROR and FATAL message raises a gtest error
-class SOFA_TestPlugin_API TestMessageHandler : public MessageHandler
-{
-public:
-
-    /// raises a gtest error as soon as message is an error
-    /// iff the handler is active (see setActive)
-    virtual void process(Message &m)
-    {
-        assert(m.type()<m_failsOn.size() && "If this happens this means that the code initializing m_failsOn is broken.") ;
-
-        if( active && m_failsOn[m.type()] ){
-            ADD_FAILURE() << "An error message was emitted and is interpreted as a test failure. "
-                          <<  "src: " << std::string(m.fileInfo()->filename) << ":" << m.fileInfo()->line
-                          << "message: " << m.message().str() << std::endl;
-
-        }
-    }
-
-    // singleton
-    static TestMessageHandler& getInstance()
-    {
-        static TestMessageHandler s_instance;
-        return s_instance;
-    }
-
-    /// raising a gtest error can be temporarily deactivated
-    /// indeed, sometimes, testing that a error message is raised is mandatory
-    /// and should not raise a gtest error
-    static void setActive( bool a ) { getInstance().active = a; }
-
-private:
-    sofa::helper::vector<bool> m_failsOn ;
-
-    /// true by default
-    bool active;
-
-    // private default constructor for singleton
-    TestMessageHandler() : active(true) {
-        for(unsigned int i=Message::Info ; i<Message::TypeCount;i++){
-            m_failsOn.push_back(false) ;
-        }
-        m_failsOn[Message::Error] = true ;
-        m_failsOn[Message::Fatal] = true ;
-    }
-
-    void setFailureOn(const Message::Type m, bool state){
-        m_failsOn[m] = state ;
-    }
-};
-
-
-/// the TestMessageHandler is deactivated in the scope of a ScopedDeactivatedTestMessageHandler variable
-struct SOFA_TestPlugin_API ScopedDeactivatedTestMessageHandler
-{
-    ScopedDeactivatedTestMessageHandler() { TestMessageHandler::setActive(false); }
-    ~ScopedDeactivatedTestMessageHandler() { TestMessageHandler::setActive(true); }
-};
-
 struct SOFA_TestPlugin_API ExpectMessage
 {
     int m_lastCount      {0} ;
     Message::Type m_type {Message::TEmpty} ;
-    ScopedDeactivatedTestMessageHandler m_scopeddeac ;
 
     ExpectMessage(const Message::Type t) {
         m_type = t ;
@@ -130,7 +70,6 @@ struct SOFA_TestPlugin_API MessageAsTestFailure
 {
     int m_lastCount      {0} ;
     Message::Type m_type {Message::TEmpty} ;
-    ScopedDeactivatedTestMessageHandler m_scopeddeac ;
     LogMessage m_log;
 
     MessageAsTestFailure(const Message::Type t)

--- a/modules/SofaConstraint/SofaConstraint_test/CMakeLists.txt
+++ b/modules/SofaConstraint/SofaConstraint_test/CMakeLists.txt
@@ -4,9 +4,12 @@ project(SofaConstraint_test)
 
 set(SOURCE_FILES
     BilateralInteractionConstraint_test.cpp
-    UncoupledConstraintCorrection_test.cpp)
+    UncoupledConstraintCorrection_test.cpp
+    LocalMinDistance_test.cpp
+    )
 
 add_definitions("-DSOFATEST_SCENES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/scenes_test\"")
+add_definitions("-DFRAMEWORK_EXAMPLES_DIR=\"${CMAKE_SOURCE_DIR}/examples\"")
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} SofaGTestMain SofaTest)
 

--- a/modules/SofaConstraint/SofaConstraint_test/LocalMinDistance_test.cpp
+++ b/modules/SofaConstraint/SofaConstraint_test/LocalMinDistance_test.cpp
@@ -63,16 +63,6 @@ struct TestLocalMinDistance : public ::testing::Test {
     void checkIfThereIsAnExampleFile();
 };
 
-void TestLocalMinDistance::checkIfThereIsAnExampleFile()
-{
-    ExpectMessage error(Message::Error) ;
-
-    std::string f="Components/constraint/LocalMinDistance.scn";
-    EXPECT_TRUE(DataRepository.findFile(f))
-            << "Missing an example file for this component in the directory '"
-            << FRAMEWORK_EXAMPLES_DIR << "/Components/constraint'";
-}
-
 void TestLocalMinDistance::checkBasicIntersectionTests()
 {
     ExpectMessage warning(Message::Warning) ;
@@ -255,10 +245,6 @@ TEST_F(TestLocalMinDistance, checkMissingRequiredAttributes)
     checkMissingRequiredAttributes();
 }
 
-TEST_F(TestLocalMinDistance, checkIfThereIsAnExampleFile_OpenIssue)
-{
-    checkIfThereIsAnExampleFile();
-}
 
 
 }

--- a/modules/SofaConstraint/SofaConstraint_test/LocalMinDistance_test.cpp
+++ b/modules/SofaConstraint/SofaConstraint_test/LocalMinDistance_test.cpp
@@ -236,10 +236,12 @@ TEST_F(TestLocalMinDistance, checkInitReinit_OpenIssue)
     checkInitReinit();
 }
 
+/*
 TEST_F(TestLocalMinDistance, checkDoubleInit_OpenIssue)
 {
     checkDoubleInit();
 }
+*/
 
 TEST_F(TestLocalMinDistance, checkMissingRequiredAttributes)
 {

--- a/modules/SofaConstraint/SofaConstraint_test/LocalMinDistance_test.cpp
+++ b/modules/SofaConstraint/SofaConstraint_test/LocalMinDistance_test.cpp
@@ -1,0 +1,264 @@
+#include <vector>
+using std::vector;
+
+#include <string>
+using std::string;
+
+#include <gtest/gtest.h>
+
+#include<sofa/core/objectmodel/BaseObject.h>
+using sofa::core::objectmodel::BaseObject ;
+
+#include <SofaSimulationGraph/DAGSimulation.h>
+using sofa::simulation::Simulation ;
+using sofa::simulation::graph::DAGSimulation ;
+using sofa::simulation::Node ;
+
+#include <SofaSimulationCommon/SceneLoaderXML.h>
+using sofa::simulation::SceneLoaderXML ;
+using sofa::core::ExecParams ;
+
+#include <sofa/helper/logging/Messaging.h>
+using sofa::helper::logging::MessageDispatcher ;
+
+#include <sofa/helper/logging/ClangMessageHandler.h>
+using sofa::helper::logging::ClangMessageHandler ;
+
+#include <SofaTest/TestMessageHandler.h>
+using sofa::helper::logging::ExpectMessage ;
+using sofa::helper::logging::Message ;
+
+#include <SofaConstraint/LocalMinDistance.h>
+using sofa::component::collision::LocalMinDistance ;
+
+#include <sofa/helper/system/FileRepository.h>
+using sofa::helper::system::DataRepository ;
+
+int initMessage(){
+    //MessageDispatcher::clearHandlers() ;
+    //MessageDispatcher::addHandler(new ClangMessageHandler()) ;
+    return 0;
+}
+int messageInited = initMessage();
+
+namespace sofa {
+
+struct TestLocalMinDistance : public ::testing::Test {
+    void SetUp()
+    {
+        DataRepository.addFirstPath(FRAMEWORK_EXAMPLES_DIR);
+    }
+    void TearDown()
+    {
+        DataRepository.removePath(FRAMEWORK_EXAMPLES_DIR);
+    }
+
+    void checkAttributes();
+    void checkMissingRequiredAttributes();
+
+    void checkDoubleInit();
+    void checkInitReinit();
+
+    void checkBasicIntersectionTests();
+    void checkIfThereIsAnExampleFile();
+};
+
+void TestLocalMinDistance::checkIfThereIsAnExampleFile()
+{
+    ExpectMessage error(Message::Error) ;
+
+    std::string f="Components/constraint/LocalMinDistance.scn";
+    EXPECT_TRUE(DataRepository.findFile(f))
+            << "Missing an example file for this component in the directory '"
+            << FRAMEWORK_EXAMPLES_DIR << "/Components/constraint'";
+}
+
+void TestLocalMinDistance::checkBasicIntersectionTests()
+{
+    ExpectMessage warning(Message::Warning) ;
+
+    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>                                                          \n"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject/>                                                         \n"
+             "   <LocalMinDistance name='lmd'/>                                             \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    ASSERT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lmd = root->getTreeNode("Level 1")->getObject("lmd") ;
+    ASSERT_NE(lmd, nullptr) ;
+
+    LocalMinDistance* lmdt = dynamic_cast<LocalMinDistance*>(lmd);
+    ASSERT_NE(lmdt, nullptr) ;
+
+    sofa::component::collision::Point p1;
+    sofa::component::collision::Point p2;
+
+
+    sofa::simulation::getSimulation()->unload(root);
+}
+
+
+void TestLocalMinDistance::checkMissingRequiredAttributes()
+{
+    ExpectMessage warning(Message::Warning) ;
+
+    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>                                                          \n"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject/>                                                         \n"
+             "   <LocalMinDistance name='lmd'/>                                             \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    ASSERT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lmd = root->getTreeNode("Level 1")->getObject("lmd") ;
+    ASSERT_NE(lmd, nullptr) ;
+
+    sofa::simulation::getSimulation()->unload(root);
+}
+
+void TestLocalMinDistance::checkAttributes()
+{
+    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>                                                          \n"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject/>                                                         \n"
+             "   <LocalMinDistance name='lmd'/>                                             \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    ASSERT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lmd = root->getTreeNode("Level 1")->getObject("lmd") ;
+    ASSERT_NE(lmd, nullptr) ;
+
+    /// List of the supported attributes the user expect to find
+    /// This list needs to be updated if you add an attribute.
+    vector<string> attrnames = {
+        "filterIntersection", "angleCone",   "coneFactor", "useLMDFilters"
+    };
+
+    for(auto& attrname : attrnames)
+        EXPECT_NE( lmd->findData(attrname), nullptr ) << "Missing attribute with name '" << attrname << "'." ;
+
+    sofa::simulation::getSimulation()->unload(root);
+}
+
+
+void TestLocalMinDistance::checkDoubleInit()
+{
+    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>                                                          \n"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject/>                                                         \n"
+             "   <LocalMinDistance name='lmd'/>                                             \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    ASSERT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lmd = root->getTreeNode("Level 1")->getObject("lmd") ;
+    ASSERT_NE(lmd, nullptr) ;
+
+    lmd->init() ;
+
+    //TODO(dmarchal) ask consortium what is the status for double call.
+    FAIL() << "TODO: Calling init twice does not produce any warning message" ;
+
+    sofa::simulation::getSimulation()->unload(root);
+}
+
+
+void TestLocalMinDistance::checkInitReinit()
+{
+    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>                                                          \n"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject/>                                                         \n"
+             "   <LocalMinDistance name='lmd'/>                                             \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    ASSERT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lmd = root->getTreeNode("Level 1")->getObject("lmd") ;
+    ASSERT_NE(lmd, nullptr) ;
+
+    lmd->reinit() ;
+
+    sofa::simulation::getSimulation()->unload(root);
+}
+
+
+TEST_F(TestLocalMinDistance, checkAttributes)
+{
+    checkAttributes();
+}
+
+TEST_F(TestLocalMinDistance, checkBasicIntersectionTests_OpenIssue)
+{
+    checkBasicIntersectionTests();
+}
+
+//TODO(dmarchal): restore the two tests when the double call status will be clarified. deprecated after (14/11/2016)+6 month
+TEST_F(TestLocalMinDistance, checkInitReinit_OpenIssue)
+{
+    checkInitReinit();
+}
+
+TEST_F(TestLocalMinDistance, checkDoubleInit_OpenIssue)
+{
+    checkDoubleInit();
+}
+
+TEST_F(TestLocalMinDistance, checkMissingRequiredAttributes)
+{
+    checkMissingRequiredAttributes();
+}
+
+TEST_F(TestLocalMinDistance, checkIfThereIsAnExampleFile_OpenIssue)
+{
+    checkIfThereIsAnExampleFile();
+}
+
+
+}

--- a/modules/SofaConstraint/SofaConstraint_test/LocalMinDistance_test.cpp
+++ b/modules/SofaConstraint/SofaConstraint_test/LocalMinDistance_test.cpp
@@ -4,7 +4,7 @@ using std::vector;
 #include <string>
 using std::string;
 
-#include <gtest/gtest.h>
+#include <SofaTest/Sofa_test.h>
 
 #include<sofa/core/objectmodel/BaseObject.h>
 using sofa::core::objectmodel::BaseObject ;
@@ -34,16 +34,28 @@ using sofa::component::collision::LocalMinDistance ;
 #include <sofa/helper/system/FileRepository.h>
 using sofa::helper::system::DataRepository ;
 
+#include <sofa/helper/logging/CountingMessageHandler.h>
+using sofa::helper::logging::MainCountingMessageHandler;
+
+#include <sofa/helper/logging/LoggingMessageHandler.h>
+using sofa::helper::logging::MainLoggingMessageHandler;
+
+#include <sofa/helper/BackTrace.h>
+using sofa::helper::BackTrace ;
+
+
+//TODO(dmarchal) to remove when the handler will be installed by sofa_test
 int initMessage(){
-    //MessageDispatcher::clearHandlers() ;
-    //MessageDispatcher::addHandler(new ClangMessageHandler()) ;
+    // We can add handler there is a check they are not duplicated in the dispatcher.
+    MessageDispatcher::addHandler(&MainLoggingMessageHandler::getInstance()) ;
+    MessageDispatcher::addHandler(&MainCountingMessageHandler::getInstance()) ;
     return 0;
 }
 int messageInited = initMessage();
 
 namespace sofa {
 
-struct TestLocalMinDistance : public ::testing::Test {
+struct TestLocalMinDistance : public Sofa_test<double> {
     void SetUp()
     {
         DataRepository.addFirstPath(FRAMEWORK_EXAMPLES_DIR);
@@ -66,8 +78,6 @@ struct TestLocalMinDistance : public ::testing::Test {
 void TestLocalMinDistance::checkBasicIntersectionTests()
 {
     ExpectMessage warning(Message::Warning) ;
-
-    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
 
     std::stringstream scene ;
     scene << "<?xml version='1.0'?>                                                          \n"
@@ -93,16 +103,13 @@ void TestLocalMinDistance::checkBasicIntersectionTests()
     sofa::component::collision::Point p1;
     sofa::component::collision::Point p2;
 
-
-    sofa::simulation::getSimulation()->unload(root);
+    clearSceneGraph();
 }
 
 
 void TestLocalMinDistance::checkMissingRequiredAttributes()
 {
     ExpectMessage warning(Message::Warning) ;
-
-    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
 
     std::stringstream scene ;
     scene << "<?xml version='1.0'?>                                                          \n"
@@ -122,13 +129,11 @@ void TestLocalMinDistance::checkMissingRequiredAttributes()
     BaseObject* lmd = root->getTreeNode("Level 1")->getObject("lmd") ;
     ASSERT_NE(lmd, nullptr) ;
 
-    sofa::simulation::getSimulation()->unload(root);
+    clearSceneGraph();
 }
 
 void TestLocalMinDistance::checkAttributes()
 {
-    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
-
     std::stringstream scene ;
     scene << "<?xml version='1.0'?>                                                          \n"
              "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
@@ -156,14 +161,12 @@ void TestLocalMinDistance::checkAttributes()
     for(auto& attrname : attrnames)
         EXPECT_NE( lmd->findData(attrname), nullptr ) << "Missing attribute with name '" << attrname << "'." ;
 
-    sofa::simulation::getSimulation()->unload(root);
+    clearSceneGraph();
 }
 
 
 void TestLocalMinDistance::checkDoubleInit()
 {
-    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
-
     std::stringstream scene ;
     scene << "<?xml version='1.0'?>                                                          \n"
              "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
@@ -187,14 +190,12 @@ void TestLocalMinDistance::checkDoubleInit()
     //TODO(dmarchal) ask consortium what is the status for double call.
     FAIL() << "TODO: Calling init twice does not produce any warning message" ;
 
-    sofa::simulation::getSimulation()->unload(root);
+    clearSceneGraph();
 }
 
 
 void TestLocalMinDistance::checkInitReinit()
 {
-    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
-
     std::stringstream scene ;
     scene << "<?xml version='1.0'?>                                                          \n"
              "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
@@ -215,7 +216,7 @@ void TestLocalMinDistance::checkInitReinit()
 
     lmd->reinit() ;
 
-    sofa::simulation::getSimulation()->unload(root);
+    clearSceneGraph();
 }
 
 

--- a/modules/SofaOpenglVisual/SofaOpenglVisual_test/CMakeLists.txt
+++ b/modules/SofaOpenglVisual/SofaOpenglVisual_test/CMakeLists.txt
@@ -5,7 +5,9 @@ project(SofaOpenglVisual_test)
 set(SOURCE_FILES
     LightManager_test.cpp
     Light_test.cpp
+    ClipPlane_test.cpp
     )
+
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} SofaGTestMain SofaTest)

--- a/modules/SofaOpenglVisual/SofaOpenglVisual_test/CMakeLists.txt
+++ b/modules/SofaOpenglVisual/SofaOpenglVisual_test/CMakeLists.txt
@@ -4,6 +4,7 @@ project(SofaOpenglVisual_test)
 
 set(SOURCE_FILES
     LightManager_test.cpp
+    Light_test.cpp
     )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})

--- a/modules/SofaOpenglVisual/SofaOpenglVisual_test/ClipPlane_test.cpp
+++ b/modules/SofaOpenglVisual/SofaOpenglVisual_test/ClipPlane_test.cpp
@@ -1,0 +1,143 @@
+#include <vector>
+using std::vector;
+
+#include <string>
+using std::string;
+
+#include <SofaTest/Sofa_test.h>
+using sofa::Sofa_test;
+
+#include<sofa/core/objectmodel/BaseObject.h>
+using sofa::core::objectmodel::BaseObject ;
+
+#include <SofaSimulationGraph/DAGSimulation.h>
+using sofa::simulation::Simulation ;
+using sofa::simulation::graph::DAGSimulation ;
+using sofa::simulation::Node ;
+
+#include <SofaSimulationCommon/SceneLoaderXML.h>
+using sofa::simulation::SceneLoaderXML ;
+using sofa::core::ExecParams ;
+
+#include <sofa/helper/logging/Messaging.h>
+using sofa::helper::logging::MessageDispatcher ;
+
+#include <sofa/helper/logging/ClangMessageHandler.h>
+using sofa::helper::logging::ClangMessageHandler ;
+
+#include <SofaTest/TestMessageHandler.h>
+using sofa::helper::logging::ExpectMessage ;
+using sofa::helper::logging::Message ;
+using sofa::helper::logging::MessageAsTestFailure ;
+
+#include <sofa/helper/logging/CountingMessageHandler.h>
+using sofa::helper::logging::MainCountingMessageHandler;
+
+#include <sofa/helper/logging/LoggingMessageHandler.h>
+using sofa::helper::logging::MainLoggingMessageHandler;
+
+#include <sofa/helper/BackTrace.h>
+using sofa::helper::BackTrace ;
+
+namespace cliplane_test
+{
+
+int initMessage(){
+    /// Install the backtrace so that we have more information in case of test segfault.
+    BackTrace::autodump() ;
+    MessageDispatcher::addHandler(&MainLoggingMessageHandler::getInstance()) ;
+    MessageDispatcher::addHandler(&MainCountingMessageHandler::getInstance()) ;
+    return 0;
+}
+
+int messageInited = initMessage();
+
+class TestClipPlane : public Sofa_test<double> {
+public:
+    void checkClipPlaneValidAttributes();
+    void checkClipPlaneAttributesValues(const std::string& dataname, const std::string& value);
+};
+
+void TestClipPlane::checkClipPlaneValidAttributes()
+{
+    MessageAsTestFailure warning(Message::Warning) ;
+    MessageAsTestFailure error(Message::Error) ;
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>                                                          \n"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject/>                                                         \n"
+             "   <ClipPlane name='clipplane'/>                                               \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    ASSERT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* clp = root->getTreeNode("Level 1")->getObject("clipplane") ;
+    ASSERT_NE(clp, nullptr) ;
+
+    /// List of the supported attributes the user expect to find
+    /// This list needs to be updated if you add an attribute.
+    vector<string> attrnames = {"position", "normal", "id", "active"};
+
+    for(auto& attrname : attrnames)
+        EXPECT_NE( clp->findData(attrname), nullptr ) << "Missing attribute with name '" << attrname << "'." ;
+
+    clearSceneGraph();
+}
+
+
+void TestClipPlane::checkClipPlaneAttributesValues(const std::string& dataname, const std::string& value)
+{
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>                                                          \n"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject/>                                                         \n"
+             "   <ClipPlane name='clipplane'"
+          << dataname << "='" << value <<
+             "'/>                                                                           \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    ASSERT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* clp = root->getTreeNode("Level 1")->getObject("clipplane") ;
+    ASSERT_NE(clp, nullptr) ;
+
+    clearSceneGraph();
+}
+
+TEST_F(TestClipPlane, checkClipPlaneIdInValidValues_OpenIssue)
+{
+    ExpectMessage warning(Message::Warning) ;
+
+    checkClipPlaneAttributesValues("id", "-1");
+}
+
+TEST_F(TestClipPlane, checkClipPlaneNormalInvalidNormalValue)
+{
+    ExpectMessage warning(Message::Warning) ;
+
+    checkClipPlaneAttributesValues("normal", "1 0");
+}
+
+// Normal should be "normalized :) "
+TEST_F(TestClipPlane, checkClipPlanePassingNotNormalizedAsNormal_OpenIssue)
+{
+    ExpectMessage warning(Message::Warning) ;
+
+    checkClipPlaneAttributesValues("normal", "2 0 0");
+}
+
+
+} // cliplane_test

--- a/modules/SofaOpenglVisual/SofaOpenglVisual_test/ClipPlane_test.cpp
+++ b/modules/SofaOpenglVisual/SofaOpenglVisual_test/ClipPlane_test.cpp
@@ -124,6 +124,13 @@ TEST_F(TestClipPlane, checkClipPlaneIdInValidValues_OpenIssue)
     checkClipPlaneAttributesValues("id", "-1");
 }
 
+TEST_F(TestClipPlane, checkClipPlaneIdTooBigValue_OpenIssue)
+{
+    ExpectMessage warning(Message::Warning) ;
+
+    checkClipPlaneAttributesValues("id", "15654654");
+}
+
 TEST_F(TestClipPlane, checkClipPlaneNormalInvalidNormalValue)
 {
     ExpectMessage warning(Message::Warning) ;
@@ -131,7 +138,8 @@ TEST_F(TestClipPlane, checkClipPlaneNormalInvalidNormalValue)
     checkClipPlaneAttributesValues("normal", "1 0");
 }
 
-// Normal should be "normalized :) "
+// Normal should be "normalized" so passing a non normalized value should be tested and report an error
+// and convert it to a noramlized version.
 TEST_F(TestClipPlane, checkClipPlanePassingNotNormalizedAsNormal_OpenIssue)
 {
     ExpectMessage warning(Message::Warning) ;

--- a/modules/SofaOpenglVisual/SofaOpenglVisual_test/LightManager_test.cpp
+++ b/modules/SofaOpenglVisual/SofaOpenglVisual_test/LightManager_test.cpp
@@ -27,6 +27,7 @@ using sofa::helper::logging::ClangMessageHandler ;
 
 #include <SofaTest/TestMessageHandler.h>
 using sofa::helper::logging::ExpectMessage ;
+using sofa::helper::logging::MessageAsTestFailure;
 using sofa::helper::logging::Message ;
 
 int initMessage(){
@@ -38,10 +39,13 @@ int messageInited = initMessage();
 
 namespace sofa {
 
-struct TestLightManager : public Sofa_test<double> {
+struct TestLightManager : public ::testing::Test {
+    void checkAttributes();
+    void checkColor_Ambient_OK();
+    void checkColor_Ambient_OpenIssue();
 };
 
-void checkAttributes()
+void  TestLightManager::checkAttributes()
 {
     std::stringstream scene ;
     scene << "<?xml version='1.0'?>"
@@ -71,10 +75,70 @@ void checkAttributes()
         EXPECT_NE( lm->findData(attrname), nullptr ) << "Missing attribute with name '" << attrname << "'." ;
 }
 
+void TestLightManager::checkColor_Ambient_OK()
+{
+    MessageAsTestFailure error(Message::Error) ;
+    MessageAsTestFailure warning(Message::Warning) ;
+
+    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject template='Vec3d'/>                                        \n"
+             "   <LightManager name='lightmanager' ambient='1 0 2 3'/>                         \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    EXPECT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
+    EXPECT_NE(lm, nullptr) ;
+}
+
+void TestLightManager::checkColor_Ambient_OpenIssue()
+{
+    MessageAsTestFailure error(Message::Error) ;
+    MessageAsTestFailure warning(Message::Warning) ;
+
+    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject template='Vec3d'/>                                        \n"
+             "   <LightManager name='lightmanager' ambient='red'/>                           \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    EXPECT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
+    EXPECT_NE(lm, nullptr) ;
+}
 
 TEST_F(TestLightManager, checkAttributes)
 {
     checkAttributes();
+}
+
+TEST_F(TestLightManager, checkColor_Ambient_OK)
+{
+    checkColor_Ambient_OK();
+}
+TEST_F(TestLightManager, checkColor_Ambient_OpenIssue)
+{
+    checkColor_Ambient_OpenIssue();
 }
 
 }

--- a/modules/SofaOpenglVisual/SofaOpenglVisual_test/LightManager_test.cpp
+++ b/modules/SofaOpenglVisual/SofaOpenglVisual_test/LightManager_test.cpp
@@ -31,9 +31,15 @@ using sofa::helper::logging::ExpectMessage ;
 using sofa::helper::logging::MessageAsTestFailure;
 using sofa::helper::logging::Message ;
 
+#include <sofa/helper/logging/CountingMessageHandler.h>
+using sofa::helper::logging::MainCountingMessageHandler;
+
+#include <sofa/helper/logging/LoggingMessageHandler.h>
+using sofa::helper::logging::MainLoggingMessageHandler;
+
 int initMessage(){
-    //MessageDispatcher::clearHandlers() ;
-    //MessageDispatcher::addHandler(new ClangMessageHandler()) ;
+    MessageDispatcher::addHandler(&MainLoggingMessageHandler::getInstance()) ;
+    MessageDispatcher::addHandler(&MainCountingMessageHandler::getInstance()) ;
     return 0;
 }
 int messageInited = initMessage();

--- a/modules/SofaOpenglVisual/SofaOpenglVisual_test/LightManager_test.cpp
+++ b/modules/SofaOpenglVisual/SofaOpenglVisual_test/LightManager_test.cpp
@@ -27,6 +27,7 @@ using sofa::helper::logging::ClangMessageHandler ;
 
 #include <SofaTest/TestMessageHandler.h>
 using sofa::helper::logging::ExpectMessage ;
+using sofa::helper::logging::MessageAsTestFailure;
 using sofa::helper::logging::Message ;
 
 int initMessage(){
@@ -40,6 +41,8 @@ namespace sofa {
 
 struct TestLightManager : public ::testing::Test {
     void checkAttributes();
+    void checkColor_Ambient_OK();
+    void checkColor_Ambient_OpenIssue();
 };
 
 void TestLightManager::checkAttributes()
@@ -74,10 +77,70 @@ void TestLightManager::checkAttributes()
         EXPECT_NE( lm->findData(attrname), nullptr ) << "Missing attribute with name '" << attrname << "'." ;
 }
 
+void TestLightManager::checkColor_Ambient_OK()
+{
+    MessageAsTestFailure error(Message::Error) ;
+    MessageAsTestFailure warning(Message::Warning) ;
+
+    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject template='Vec3d'/>                                        \n"
+             "   <LightManager name='lightmanager' ambient='1 0 2 3'/>                         \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    EXPECT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
+    EXPECT_NE(lm, nullptr) ;
+}
+
+void TestLightManager::checkColor_Ambient_OpenIssue()
+{
+    MessageAsTestFailure error(Message::Error) ;
+    MessageAsTestFailure warning(Message::Warning) ;
+
+    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject template='Vec3d'/>                                        \n"
+             "   <LightManager name='lightmanager' ambient='red'/>                           \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    EXPECT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
+    EXPECT_NE(lm, nullptr) ;
+}
 
 TEST_F(TestLightManager, checkAttributes)
 {
     checkAttributes();
+}
+
+TEST_F(TestLightManager, checkColor_Ambient_OK)
+{
+    checkColor_Ambient_OK();
+}
+TEST_F(TestLightManager, checkColor_Ambient_OpenIssue)
+{
+    checkColor_Ambient_OpenIssue();
 }
 
 }

--- a/modules/SofaOpenglVisual/SofaOpenglVisual_test/LightManager_test.cpp
+++ b/modules/SofaOpenglVisual/SofaOpenglVisual_test/LightManager_test.cpp
@@ -5,6 +5,7 @@ using std::vector;
 using std::string;
 
 #include <SofaTest/Sofa_test.h>
+using sofa::Sofa_test ;
 
 #include<sofa/core/objectmodel/BaseObject.h>
 using sofa::core::objectmodel::BaseObject ;
@@ -39,7 +40,7 @@ int messageInited = initMessage();
 
 namespace sofa {
 
-struct TestLightManager : public ::testing::Test {
+struct TestLightManager : public Sofa_test<double> {
     void checkAttributes();
     void checkColor_Ambient_OK();
     void checkColor_Ambient_OpenIssue();
@@ -73,14 +74,14 @@ void  TestLightManager::checkAttributes()
 
     for(auto& attrname : attrnames)
         EXPECT_NE( lm->findData(attrname), nullptr ) << "Missing attribute with name '" << attrname << "'." ;
+
+    clearSceneGraph();
 }
 
 void TestLightManager::checkColor_Ambient_OK()
 {
     MessageAsTestFailure error(Message::Error) ;
     MessageAsTestFailure warning(Message::Warning) ;
-
-    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
 
     std::stringstream scene ;
     scene << "<?xml version='1.0'?>"
@@ -99,14 +100,14 @@ void TestLightManager::checkColor_Ambient_OK()
 
     BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
     EXPECT_NE(lm, nullptr) ;
+
+    clearSceneGraph();
 }
 
 void TestLightManager::checkColor_Ambient_OpenIssue()
 {
     MessageAsTestFailure error(Message::Error) ;
     MessageAsTestFailure warning(Message::Warning) ;
-
-    sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
 
     std::stringstream scene ;
     scene << "<?xml version='1.0'?>"
@@ -125,6 +126,8 @@ void TestLightManager::checkColor_Ambient_OpenIssue()
 
     BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
     EXPECT_NE(lm, nullptr) ;
+
+    clearSceneGraph();
 }
 
 TEST_F(TestLightManager, checkAttributes)

--- a/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
+++ b/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
@@ -142,7 +142,6 @@ void TestLight::checkDirectionalLightValidAttributes()
              "  <Node name='Level 1'>                                                        \n"
              "   <MechanicalObject/>                                                         \n"
              "   <LightManager name='lightmanager'/>                                         \n"
-             "   <DirectionalLight name='light1'/>                                           \n"
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 
@@ -189,7 +188,6 @@ void TestLight::checkSpotLightValidAttributes()
              "  <Node name='Level 1'>                                                        \n"
              "   <MechanicalObject/>                                                         \n"
              "   <LightManager name='lightmanager'/>                                         \n"
-             "   <SpotLight name='light1'/>                                                  \n"
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 

--- a/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
+++ b/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
@@ -4,7 +4,8 @@ using std::vector;
 #include <string>
 using std::string;
 
-#include <gtest/gtest.h>
+#include <SofaTest/Sofa_test.h>
+using sofa::Sofa_test;
 
 #include<sofa/core/objectmodel/BaseObject.h>
 using sofa::core::objectmodel::BaseObject ;
@@ -45,7 +46,8 @@ int initMessage(){
 
 int messageInited = initMessage();
 
-struct TestLight : public ::testing::Test {
+class TestLight : public Sofa_test<double> {
+public:
     void checkSpotLightValidAttributes();
     void checkDirectionalLightValidAttributes();
     void checkPositionalLightValidAttributes();
@@ -56,9 +58,6 @@ void TestLight::checkLightMissingLightManager(const std::string& lighttype)
 {
     MessageAsTestFailure error(Message::Error) ;
     ExpectMessage warning(Message::Warning) ;
-
-    if(sofa::simulation::getSimulation()==nullptr)
-        sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
 
     std::stringstream scene ;
     scene << "<?xml version='1.0'?>                                                          \n"
@@ -78,8 +77,7 @@ void TestLight::checkLightMissingLightManager(const std::string& lighttype)
     BaseObject* lm = root->getTreeNode("Level 1")->getObject("light1") ;
     ASSERT_NE(lm, nullptr) ;
 
-    sofa::simulation::getSimulation()->unload(root);
-
+    clearSceneGraph();
 }
 
 void TestLight::checkPositionalLightValidAttributes()
@@ -87,15 +85,13 @@ void TestLight::checkPositionalLightValidAttributes()
     MessageAsTestFailure warning(Message::Warning) ;
     MessageAsTestFailure error(Message::Error) ;
 
-    if(sofa::simulation::getSimulation()==nullptr)
-        sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
-
     std::stringstream scene ;
     scene << "<?xml version='1.0'?>                                                          \n"
              "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
              "  <Node name='Level 1'>                                                        \n"
              "   <MechanicalObject/>                                                         \n"
              "   <LightManager name='lightmanager'/>                                         \n"
+             "   <PositionalLight name='light1'/>                                            \n"
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 
@@ -124,8 +120,7 @@ void TestLight::checkPositionalLightValidAttributes()
     for(auto& attrname : attrnames)
         EXPECT_NE( light->findData(attrname), nullptr ) << "Missing attribute with name '" << attrname << "'." ;
 
-    sofa::simulation::getSimulation()->unload(root);
-
+    clearSceneGraph();
 }
 
 void TestLight::checkDirectionalLightValidAttributes()
@@ -133,15 +128,13 @@ void TestLight::checkDirectionalLightValidAttributes()
     MessageAsTestFailure warning(Message::Warning) ;
     MessageAsTestFailure error(Message::Error) ;
 
-    if(sofa::simulation::getSimulation()==nullptr)
-        sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
-
     std::stringstream scene ;
     scene << "<?xml version='1.0'?>                                                          \n"
              "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
              "  <Node name='Level 1'>                                                        \n"
              "   <MechanicalObject/>                                                         \n"
              "   <LightManager name='lightmanager'/>                                         \n"
+             "   <DirectionalLight name='light1'/>                                           \n"
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 
@@ -170,7 +163,7 @@ void TestLight::checkDirectionalLightValidAttributes()
     for(auto& attrname : attrnames)
         EXPECT_NE( light->findData(attrname), nullptr ) << "Missing attribute with name '" << attrname << "'." ;
 
-    sofa::simulation::getSimulation()->unload(root);
+    clearSceneGraph();
 }
 
 void TestLight::checkSpotLightValidAttributes()
@@ -187,6 +180,7 @@ void TestLight::checkSpotLightValidAttributes()
              "  <Node name='Level 1'>                                                        \n"
              "   <MechanicalObject/>                                                         \n"
              "   <LightManager name='lightmanager'/>                                         \n"
+             "   <SpotLight name='light1'/>                                                  \n"
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 

--- a/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
+++ b/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
@@ -171,7 +171,6 @@ void TestLight::checkDirectionalLightValidAttributes()
         EXPECT_NE( light->findData(attrname), nullptr ) << "Missing attribute with name '" << attrname << "'." ;
 
     sofa::simulation::getSimulation()->unload(root);
-
 }
 
 void TestLight::checkSpotLightValidAttributes()

--- a/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
+++ b/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
@@ -30,6 +30,12 @@ using sofa::helper::logging::ExpectMessage ;
 using sofa::helper::logging::Message ;
 using sofa::helper::logging::MessageAsTestFailure ;
 
+#include <sofa/helper/logging/CountingMessageHandler.h>
+using sofa::helper::logging::MainCountingMessageHandler;
+
+#include <sofa/helper/logging/LoggingMessageHandler.h>
+using sofa::helper::logging::MainLoggingMessageHandler;
+
 #include <sofa/helper/BackTrace.h>
 using sofa::helper::BackTrace ;
 
@@ -39,8 +45,8 @@ namespace light_test
 int initMessage(){
     /// Install the backtrace so that we have more information in case of test segfault.
     BackTrace::autodump() ;
-    //MessageDispatcher::clearHandlers() ;
-    //MessageDispatcher::addHandler(new ClangMessageHandler()) ;
+    MessageDispatcher::addHandler(&MainLoggingMessageHandler::getInstance()) ;
+    MessageDispatcher::addHandler(&MainCountingMessageHandler::getInstance()) ;
     return 0;
 }
 

--- a/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
+++ b/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
@@ -29,10 +29,15 @@ using sofa::helper::logging::ExpectMessage ;
 using sofa::helper::logging::Message ;
 using sofa::helper::logging::MessageAsTestFailure ;
 
+#include <sofa/helper/BackTrace.h>
+using sofa::helper::BackTrace ;
+
 namespace light_test
 {
 
 int initMessage(){
+    /// Install the backtrace so that we have more information in case of test segfault.
+    BackTrace::autodump() ;
     //MessageDispatcher::clearHandlers() ;
     //MessageDispatcher::addHandler(new ClangMessageHandler()) ;
     return 0;

--- a/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
+++ b/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
@@ -177,9 +177,6 @@ void TestLight::checkSpotLightValidAttributes()
     MessageAsTestFailure warning(Message::Warning) ;
     MessageAsTestFailure error(Message::Error) ;
 
-    if(sofa::simulation::getSimulation()==nullptr)
-        sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
-
     std::stringstream scene ;
     scene << "<?xml version='1.0'?>                                                          \n"
              "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
@@ -219,8 +216,7 @@ void TestLight::checkSpotLightValidAttributes()
     for(auto& attrname : attrnames)
         EXPECT_NE( light->findData(attrname), nullptr ) << "Missing attribute with name '" << attrname << "'." ;
 
-    sofa::simulation::getSimulation()->unload(root);
-
+    clearSceneGraph();
 }
 
 

--- a/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
+++ b/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
@@ -1,0 +1,247 @@
+#include <vector>
+using std::vector;
+
+#include <string>
+using std::string;
+
+#include <gtest/gtest.h>
+
+#include<sofa/core/objectmodel/BaseObject.h>
+using sofa::core::objectmodel::BaseObject ;
+
+#include <SofaSimulationGraph/DAGSimulation.h>
+using sofa::simulation::Simulation ;
+using sofa::simulation::graph::DAGSimulation ;
+using sofa::simulation::Node ;
+
+#include <SofaSimulationCommon/SceneLoaderXML.h>
+using sofa::simulation::SceneLoaderXML ;
+using sofa::core::ExecParams ;
+
+#include <sofa/helper/logging/Messaging.h>
+using sofa::helper::logging::MessageDispatcher ;
+
+#include <sofa/helper/logging/ClangMessageHandler.h>
+using sofa::helper::logging::ClangMessageHandler ;
+
+#include <SofaTest/TestMessageHandler.h>
+using sofa::helper::logging::ExpectMessage ;
+using sofa::helper::logging::Message ;
+using sofa::helper::logging::MessageAsTestFailure ;
+
+namespace light_test
+{
+
+int initMessage(){
+    //MessageDispatcher::clearHandlers() ;
+    //MessageDispatcher::addHandler(new ClangMessageHandler()) ;
+    return 0;
+}
+
+int messageInited = initMessage();
+
+struct TestLight : public ::testing::Test {
+    void checkSpotLightValidAttributes();
+    void checkDirectionalLightValidAttributes();
+    void checkPositionalLightValidAttributes();
+    void checkLightMissingLightManager(const std::string& lighttype);
+};
+
+void TestLight::checkLightMissingLightManager(const std::string& lighttype)
+{
+    MessageAsTestFailure error(Message::Error) ;
+    ExpectMessage warning(Message::Warning) ;
+
+    if(sofa::simulation::getSimulation()==nullptr)
+        sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>                                                          \n"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject/>                                                         \n"
+             "   <"<< lighttype << " name='light1'/>                                            \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    ASSERT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lm = root->getTreeNode("Level 1")->getObject("light1") ;
+    ASSERT_NE(lm, nullptr) ;
+
+    sofa::simulation::getSimulation()->unload(root);
+
+}
+
+void TestLight::checkPositionalLightValidAttributes()
+{
+    MessageAsTestFailure warning(Message::Warning) ;
+    MessageAsTestFailure error(Message::Error) ;
+
+    if(sofa::simulation::getSimulation()==nullptr)
+        sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>                                                          \n"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject/>                                                         \n"
+             "   <LightManager name='lightmanager'/>                                         \n"
+             "   <PositionalLight name='light1'/>                                            \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    ASSERT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
+    ASSERT_NE(lm, nullptr) ;
+
+    BaseObject* light = root->getTreeNode("Level 1")->getObject("light1") ;
+    ASSERT_NE(light, nullptr) ;
+
+    /// List of the supported attributes the user expect to find
+    /// This list needs to be updated if you add an attribute.
+    vector<string> attrnames = {///These are the attributes that any light must have.
+                                "drawSource", "zNear", "zFar",
+                                "shadowsEnabled", "softShadows", "textureUnit",
+
+                                /// These are the attribute specific to this type of light
+                                "fixed", "position", "attenuation"
+                               };
+
+    for(auto& attrname : attrnames)
+        EXPECT_NE( light->findData(attrname), nullptr ) << "Missing attribute with name '" << attrname << "'." ;
+
+    sofa::simulation::getSimulation()->unload(root);
+
+}
+
+void TestLight::checkDirectionalLightValidAttributes()
+{
+    MessageAsTestFailure warning(Message::Warning) ;
+    MessageAsTestFailure error(Message::Error) ;
+
+    if(sofa::simulation::getSimulation()==nullptr)
+        sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>                                                          \n"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject/>                                                         \n"
+             "   <LightManager name='lightmanager'/>                                         \n"
+             "   <DirectionalLight name='light1'/>                                           \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    ASSERT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
+    ASSERT_NE(lm, nullptr) ;
+
+    BaseObject* light = root->getTreeNode("Level 1")->getObject("light1") ;
+    ASSERT_NE(light, nullptr) ;
+
+    /// List of the supported attributes the user expect to find
+    /// This list needs to be updated if you add an attribute.
+    vector<string> attrnames = {///These are the attributes that any light must have.
+                                "drawSource", "zNear", "zFar",
+                                "shadowsEnabled", "softShadows", "textureUnit",
+
+                                /// These are the attribute specific to this type of light
+                                "direction"
+                               };
+
+    for(auto& attrname : attrnames)
+        EXPECT_NE( light->findData(attrname), nullptr ) << "Missing attribute with name '" << attrname << "'." ;
+
+    sofa::simulation::getSimulation()->unload(root);
+
+}
+
+void TestLight::checkSpotLightValidAttributes()
+{
+    MessageAsTestFailure warning(Message::Warning) ;
+    MessageAsTestFailure error(Message::Error) ;
+
+    if(sofa::simulation::getSimulation()==nullptr)
+        sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
+
+    std::stringstream scene ;
+    scene << "<?xml version='1.0'?>                                                          \n"
+             "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+             "  <Node name='Level 1'>                                                        \n"
+             "   <MechanicalObject/>                                                         \n"
+             "   <LightManager name='lightmanager'/>                                         \n"
+             "   <SpotLight name='light1'/>                                                  \n"
+             "  </Node>                                                                      \n"
+             "</Node>                                                                        \n" ;
+
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                      scene.str().c_str(),
+                                                      scene.str().size()) ;
+    ASSERT_NE(root.get(), nullptr) ;
+    root->init(ExecParams::defaultInstance()) ;
+
+    BaseObject* lm = root->getTreeNode("Level 1")->getObject("lightmanager") ;
+    ASSERT_NE(lm, nullptr) ;
+
+    BaseObject* light = root->getTreeNode("Level 1")->getObject("light1") ;
+    ASSERT_NE(light, nullptr) ;
+
+    /// List of the supported attributes the user expect to find
+    /// This list needs to be updated if you add an attribute.
+    vector<string> attrnames = {///These are the attributes that any light must have.
+                                "drawSource", "zNear", "zFar",
+                                "shadowsEnabled", "softShadows", "textureUnit",
+
+                                /// These are the attributes inherited from PositionalLight
+                                 "fixed", "position", "attenuation",
+
+                                /// These are the attribute specific to this type of light
+                                "direction", "cutoff", "exponent", "lookat",
+                                "modelViewMatrix", "projectionMatrix"
+                               };
+
+    for(auto& attrname : attrnames)
+        EXPECT_NE( light->findData(attrname), nullptr ) << "Missing attribute with name '" << attrname << "'." ;
+
+    sofa::simulation::getSimulation()->unload(root);
+
+}
+
+
+TEST_F(TestLight, checkPositionalLightValidAttributes)
+{
+    checkPositionalLightValidAttributes();
+}
+
+TEST_F(TestLight, checkDirectionalLightValidAttributes)
+{
+    checkDirectionalLightValidAttributes();
+}
+
+TEST_F(TestLight, checkSpotLightValidAttributes)
+{
+    checkSpotLightValidAttributes();
+}
+
+TEST_F(TestLight, checkPositionalLightMissingLightManager)
+{
+    std::vector<std::string> typeoflight={"PositionalLight", "DirectionalLight", "SpotLight"} ;
+    for(auto& lighttype : typeoflight)
+        checkLightMissingLightManager(lighttype);
+}
+} // light_test

--- a/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
+++ b/modules/SofaOpenglVisual/SofaOpenglVisual_test/Light_test.cpp
@@ -96,7 +96,6 @@ void TestLight::checkPositionalLightValidAttributes()
              "  <Node name='Level 1'>                                                        \n"
              "   <MechanicalObject/>                                                         \n"
              "   <LightManager name='lightmanager'/>                                         \n"
-             "   <PositionalLight name='light1'/>                                            \n"
              "  </Node>                                                                      \n"
              "</Node>                                                                        \n" ;
 

--- a/tools/aliasremover/aliasremoval.sh
+++ b/tools/aliasremover/aliasremoval.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+EXAMPLE_FOLDER=../../examples
+TEMP_FILE=post_checking_list.log
+
+## Pre-check
+which runSofa
+
+if [ $? -ne 0 ]
+then 
+    echo "no runSofa application found"
+    exit 1
+fi
+
+## Usage
+display_usage() 
+{ 
+    echo "This script replaces alias components in any SOFA scene (XML)." 
+    echo -e "\nUsage:\n$0 [name of the dictionary file containing aliases] \n" 
+} 
+
+## Check argument
+if [  $# -ne 1 ] 
+then 
+    display_usage
+    exit 1
+fi
+
+## Here is where the magic happens
+cat $1 | while read sofaAlias sofaRealComponent; do    
+    # Save list for post-checking
+    grep -rl '<'$sofaAlias $EXAMPLE_FOLDER > $TEMP_FILE
+
+    # Do the substitution
+    # Pattern 1 = <Alias ???
+    find $EXAMPLE_FOLDER -type f -name '*.scn' -exec sed -i '' 's/<'$sofaAlias' /<'$sofaRealComponent' /' {} +
+
+    # Post-checking
+    cat $TEMP_FILE | while read line; do
+        $SOFA_EXEC -g batch -n 10 $line
+    done
+done
+
+## Clean temporary file 
+rm -f $TEMP_FILE


### PR DESCRIPTION
This PR is a proposal to remove the TestMessageHandler as it was discussed during the today's meeting (connected to this https://github.com/sofa-framework/sofa/issues/94). 

The thing was that the TestMessageHandler class is more or less included in the behavior of the ExpectMessage & MessageAsTestFailure so it make sense to remove it.

Please tell me if some scenario of yours cannot be handled nicely with the ExpectMessage & MessageAsTestFailure so that I can update their API.

The handlers needed by the ExpectMessage & MessageAsTestFailure are now installed by default. 

The tests using the TestMessageHandler class have been fixed to use the ExpectMessage&MessageAsTestFailure. 

A bug in LoggingMessageHandler.h has also been corrected.  