### PR TITLE
[SofaTest] replace TestMessageHandler by ExpectMessage

### DIFF
--- a/SofaKernel/framework/framework_test/helper/Utils_test.cpp
+++ b/SofaKernel/framework/framework_test/helper/Utils_test.cpp
@@ -62,7 +62,6 @@ TEST(UtilsTest, getSofaPathPrefix)
 TEST(UtilsTest, readBasicIniFile_nonexistentFile)
 {
     // this test will raise an error on purpose
-    sofa::helper::logging::ScopedDeactivatedTestMessageHandler scopedDeactivatedTestMessageHandler;
     std::map<std::string, std::string> values = Utils::readBasicIniFile("this-file-does-not-exist");
     EXPECT_TRUE(values.empty());
 }

--- a/SofaKernel/framework/framework_test/helper/system/FileSystem_test.cpp
+++ b/SofaKernel/framework/framework_test/helper/system/FileSystem_test.cpp
@@ -4,6 +4,10 @@
 #include <exception>
 #include <algorithm>
 #include <SofaTest/TestMessageHandler.h>
+using sofa::helper::logging::MessageAsTestFailure;
+using sofa::helper::logging::ExpectMessage;
+using sofa::helper::logging::Message;
+
 
 using sofa::helper::system::FileSystem;
 
@@ -21,6 +25,8 @@ static std::string getPath(std::string s) {
 
 TEST(FileSystemTest, listDirectory_nonEmpty)
 {
+    MessageAsTestFailure error(Message::Error) ;
+
     std::vector<std::string> fileList;
     FileSystem::listDirectory(getPath("non-empty-directory"), fileList);
     // Workaround: svn adds a '.svn' directory in each subdirectory
@@ -35,6 +41,8 @@ TEST(FileSystemTest, listDirectory_nonEmpty)
 
 TEST(FileSystemTest, listDirectory_nonEmpty_trailingSlash)
 {
+    MessageAsTestFailure error(Message::Error) ;
+
     std::vector<std::string> fileList;
     FileSystem::listDirectory(getPath("non-empty-directory/"), fileList);
     // Workaround: svn adds a '.svn' directory in each subdirectory
@@ -49,6 +57,8 @@ TEST(FileSystemTest, listDirectory_nonEmpty_trailingSlash)
 
 TEST(FileSystemTest, listDirectory_withExtension_multipleMatches)
 {
+    MessageAsTestFailure error(Message::Error) ;
+
     std::vector<std::string> fileList;
     FileSystem::listDirectory(getPath("non-empty-directory/"), fileList, "txt");
     EXPECT_EQ(fileList.size(), 2u);
@@ -58,6 +68,8 @@ TEST(FileSystemTest, listDirectory_withExtension_multipleMatches)
 
 TEST(FileSystemTest, listDirectory_withExtension_oneMatch)
 {
+    MessageAsTestFailure error(Message::Error) ;
+
     std::vector<std::string> fileList;
     FileSystem::listDirectory(getPath("non-empty-directory/"), fileList, "so");
     EXPECT_EQ(fileList.size(), 1u);
@@ -66,6 +78,8 @@ TEST(FileSystemTest, listDirectory_withExtension_oneMatch)
 
 TEST(FileSystemTest, listDirectory_withExtension_noMatch)
 {
+    MessageAsTestFailure error(Message::Error) ;
+
     std::vector<std::string> fileList;
     FileSystem::listDirectory(getPath("non-empty-directory/"), fileList, "h");
     EXPECT_TRUE(fileList.empty());
@@ -73,6 +87,8 @@ TEST(FileSystemTest, listDirectory_withExtension_noMatch)
 
 TEST(FileSystemTest, createDirectory)
 {
+    MessageAsTestFailure error(Message::Error) ;
+
     EXPECT_FALSE(FileSystem::createDirectory("createDirectoryTestDir"));
     EXPECT_TRUE(FileSystem::exists("createDirectoryTestDir"));
     EXPECT_TRUE(FileSystem::isDirectory("createDirectoryTestDir"));
@@ -82,18 +98,24 @@ TEST(FileSystemTest, createDirectory)
 
 TEST(FileSystemTest, createDirectory_alreadyExists)
 {
-    FileSystem::createDirectory("createDirectoryTestDir");
     {
-        // this test will raise an error on purpose
-        sofa::helper::logging::ScopedDeactivatedTestMessageHandler scopedDeactivatedTestMessageHandler;
+        MessageAsTestFailure error(Message::Error) ;
+        FileSystem::createDirectory("createDirectoryTestDir");
+    }
+    {
+        ExpectMessage error(Message::Error) ;
         EXPECT_TRUE(FileSystem::createDirectory("createDirectoryTestDir"));
     }
-    // Cleanup
-    FileSystem::removeDirectory("createDirectoryTestDir");
+    {
+        MessageAsTestFailure error(Message::Error) ;
+        FileSystem::removeDirectory("createDirectoryTestDir");
+    }
 }
 
 TEST(FileSystemTest, removeDirectory)
 {
+    MessageAsTestFailure error(Message::Error);
+
     FileSystem::createDirectory("removeDirectoryTestDir");
     EXPECT_FALSE(FileSystem::removeDirectory("removeDirectoryTestDir"));
     EXPECT_FALSE(FileSystem::exists("removeDirectoryTestDir"));
@@ -103,10 +125,14 @@ TEST(FileSystemTest, removeDirectory_doesNotExists)
 {
     {
         // this test will raise an error on purpose
-        sofa::helper::logging::ScopedDeactivatedTestMessageHandler scopedDeactivatedTestMessageHandler;
+        ExpectMessage error(Message::Error) ;
+
         EXPECT_TRUE(FileSystem::removeDirectory("removeDirectoryTestDir"));
     }
-    EXPECT_FALSE(FileSystem::exists("removeDirectoryTestDir"));
+    {
+        MessageAsTestFailure error(Message::Error);
+        EXPECT_FALSE(FileSystem::exists("removeDirectoryTestDir"));
+    }
 }
 
 TEST(FileSystemTest, exists_yes)

--- a/SofaKernel/framework/sofa/helper/logging/LoggingMessageHandler.h
+++ b/SofaKernel/framework/sofa/helper/logging/LoggingMessageHandler.h
@@ -136,7 +136,7 @@ public:
     {
         const std::vector<Message>& messages = MainLoggingMessageHandler::getMessages() ;
 
-        return messages.size() ;
+        return messages.end()-(messages.begin()+m_firstMessage);
     }
 
 private:

--- a/applications/plugins/SofaTest/Sofa_test.cpp
+++ b/applications/plugins/SofaTest/Sofa_test.cpp
@@ -30,6 +30,7 @@
 #include <sofa/helper/system/FileSystem.h>
 #include <sofa/helper/Utils.h>
 #include <sofa/helper/logging/MessageDispatcher.h>
+#include <sofa/helper/logging/CountingMessageHandler.h>
 #include "TestMessageHandler.h"
 
 using sofa::helper::system::PluginRepository;
@@ -41,14 +42,13 @@ namespace sofa {
 
 
 // some basic RAII stuff to automatically add a TestMessageHandler to every tests
-namespace {
 
+namespace {
     static struct raii {
       raii() {
-            helper::logging::MessageDispatcher::addHandler( &helper::logging::TestMessageHandler::getInstance() ) ;
             helper::logging::MessageDispatcher::addHandler( &helper::logging::MainCountingMessageHandler::getInstance() ) ;
+            helper::logging::MessageDispatcher::addHandler( &helper::logging::MainLoggingMessageHandler::getInstance() ) ;
       }
-
     } singleton;
 }
 
@@ -63,6 +63,12 @@ BaseSofa_test::BaseSofa_test(){
     //use the same seed (the seed value is indicated at the 2nd line of test results)
     //and pass the seed in command argument line ex: SofaTest_test.exe seed 32
     helper::srand(seed);
+
+
+    // Repeating this for each class is harmless because addHandler test if the handler is already installed and
+    // if so it don't install it again.
+    helper::logging::MessageDispatcher::addHandler( &helper::logging::MainCountingMessageHandler::getInstance() ) ;
+    helper::logging::MessageDispatcher::addHandler( &helper::logging::MainLoggingMessageHandler::getInstance() ) ;
 }
 
 BaseSofa_test::~BaseSofa_test(){ clearSceneGraph(); }

--- a/applications/plugins/SofaTest/Sofa_test.h
+++ b/applications/plugins/SofaTest/Sofa_test.h
@@ -38,6 +38,9 @@
 #include <time.h>
 #include <iostream>
 
+#include <sofa/helper/logging/LoggingMessageHandler.h>
+#include <sofa/helper/logging/CountingMessageHandler.h>
+
 // Maybe not the right place to put this (private header?)
 #ifndef SOFA_FLOAT
 typedef sofa::defaulttype::Rigid3dTypes Rigid3;
@@ -61,7 +64,7 @@ const SReal g_minDeltaErrorRatio = .1; // TODO is it already too small?
 struct SOFA_TestPlugin_API BaseSofa_test : public ::testing::Test
 {
     /// Initialize Sofa and the random number generator
-    BaseSofa_test();
+    BaseSofa_test() ;
 
     /// Clear the scene graph
     virtual ~BaseSofa_test();
@@ -313,10 +316,10 @@ void setRot(typename DataTypes::Coord& coord, const sofa::helper::Quater<SReal>&
 template<class DataTypes>
 typename DataTypes::Coord createCoord(const sofa::defaulttype::Vector3& pos, const sofa::helper::Quater<SReal>& rot)
 {
-	typename DataTypes::Coord temp;
-	DataTypes::set(temp, pos[0], pos[1], pos[2]);
-	setRot<DataTypes>(temp, rot);
-	return temp;
+    typename DataTypes::Coord temp;
+    DataTypes::set(temp, pos[0], pos[1], pos[2]);
+    setRot<DataTypes>(temp, rot);
+    return temp;
 }
 
 template <int N, class real>

--- a/applications/plugins/SofaTest/TestMessageHandler.h
+++ b/applications/plugins/SofaTest/TestMessageHandler.h
@@ -48,70 +48,10 @@ namespace helper
 namespace logging
 {
 
-/// each ERROR and FATAL message raises a gtest error
-class SOFA_TestPlugin_API TestMessageHandler : public MessageHandler
-{
-public:
-
-    /// raises a gtest error as soon as message is an error
-    /// iff the handler is active (see setActive)
-    virtual void process(Message &m)
-    {
-        assert(m.type()<m_failsOn.size() && "If this happens this means that the code initializing m_failsOn is broken.") ;
-
-        if( active && m_failsOn[m.type()] ){
-            ADD_FAILURE() << "An error message was emitted and is interpreted as a test failure. "
-                          <<  "src: " << std::string(m.fileInfo()->filename) << ":" << m.fileInfo()->line
-                          << "message: " << m.message().str() << std::endl;
-
-        }
-    }
-
-    // singleton
-    static TestMessageHandler& getInstance()
-    {
-        static TestMessageHandler s_instance;
-        return s_instance;
-    }
-
-    /// raising a gtest error can be temporarily deactivated
-    /// indeed, sometimes, testing that a error message is raised is mandatory
-    /// and should not raise a gtest error
-    static void setActive( bool a ) { getInstance().active = a; }
-
-private:
-    sofa::helper::vector<bool> m_failsOn ;
-
-    /// true by default
-    bool active;
-
-    // private default constructor for singleton
-    TestMessageHandler() : active(true) {
-        for(unsigned int i=Message::Info ; i<Message::TypeCount;i++){
-            m_failsOn.push_back(false) ;
-        }
-        m_failsOn[Message::Error] = true ;
-        m_failsOn[Message::Fatal] = true ;
-    }
-
-    void setFailureOn(const Message::Type m, bool state){
-        m_failsOn[m] = state ;
-    }
-};
-
-
-/// the TestMessageHandler is deactivated in the scope of a ScopedDeactivatedTestMessageHandler variable
-struct SOFA_TestPlugin_API ScopedDeactivatedTestMessageHandler
-{
-    ScopedDeactivatedTestMessageHandler() { TestMessageHandler::setActive(false); }
-    ~ScopedDeactivatedTestMessageHandler() { TestMessageHandler::setActive(true); }
-};
-
 struct SOFA_TestPlugin_API ExpectMessage
 {
     int m_lastCount      {0} ;
     Message::Type m_type {Message::TEmpty} ;
-    ScopedDeactivatedTestMessageHandler m_scopeddeac ;
 
     ExpectMessage(const Message::Type t) {
         m_type = t ;
@@ -130,7 +70,6 @@ struct SOFA_TestPlugin_API MessageAsTestFailure
 {
     int m_lastCount      {0} ;
     Message::Type m_type {Message::TEmpty} ;
-    ScopedDeactivatedTestMessageHandler m_scopeddeac ;
     LogMessage m_log;
 
     MessageAsTestFailure(const Message::Type t)


### PR DESCRIPTION
This PR is a proposal to remove the TestMessageHandler as it was discussed during the today's meeting (connected to Issue https://github.com/sofa-framework/sofa/issues/94).

The reason is that the TestMessageHandler class is more or less included in the behavior of the ExpectMessage & MessageAsTestFailure. In case I'm wrong please tell me if some scenario of yours cannot be handled nicely with the ExpectMessage & MessageAsTestFailure so that I can update their API.

Concretely by this PR:
- The class TestMessageHandler is removed
- Handler needed by ExpectMessage & MessageAsTestFailure are now installed by default for tests ( Issue https://github.com/sofa-framework/sofa/issues/94)
- The tests using the TestMessageHandler class have been fixed to use the ExpectMessage&MessageAsTestFailure.
- A bug in LoggingMessageHandler.h has also been corrected.

Examples of use of the ExpectMessage & MessageAsTestFailure classes...

To generate a test failure when an expected message have not been emitted you have to do
```cpp
{
    ExpectMessage raii(Message::Error);
    ... do something that must emit a message ...
}
```
To generate a test failure when a un-expected message have been emitted you have to do
```cpp
{
	MessageAsTestFailure raii(Message::Error);
    ... do something that must not emit an error message ...
}
```

The raii can be combined in the following way:
```cpp
{
	ExpectMessage warning(Message::Info);
	MessageAsTestFailure raii(Message::Error);
	MessageAsTestFailure raii(Message::Warning);
	...
}
```

Any suggestion on this API is more than welcome. 

TODO:
	It would be nice to be able to write
        ExpectMessage warning(Message::Info & Message::Warning);