### PR TITLE
[VolumetricRendering] Explicit incompatibility with SOFA_NO_OPENGL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,16 @@
 
 ## New features for users
 
-* Adding ForceMaskOff, a component to locally (in a branch of the scene graph) cancel the force mask
-* Live-coding for python 
-* Live-coding for GLSL 
+* adding ForceMaskOff, a component to locally (in a branch of the scene graph) cancel the force mask
+* live-coding for python 
+* live-coding for GLSL 
 * new component MakeAlias 
 * new component MakeDataAlias
-* Improved error message & console rendering
+* improved error message & console rendering
 
 ## New features for developpers
 
-* Preliminary Markdown support in the msg_* API. You can now write much better formatting & alignement as well as adding URL to documentations related to  the error.
+* preliminary Markdown support in the msg_* API. You can now write much better formatting & alignement as well as adding URL to documentations related to  the error.
 * class RichStyleConsoleFormatter which interprete the markdowns in the message and format this to a resizable console with nice alignement.
 * class CountingMessageHandler (count the number of message for each message type)
 * class RoutingMessageHandler (to implement context specific routing of the messages to different handler) 
@@ -44,7 +44,7 @@
 
 ### Cleaning
 
-
+* clean the compilation when SOFA_NO_OPENGL flag is activated
 
 ### Moved files
 

--- a/applications/plugins/CMakeLists.txt
+++ b/applications/plugins/CMakeLists.txt
@@ -29,7 +29,6 @@ sofa_add_plugin(PersistentContact PersistentContact)
 # sofa_add_plugin(SofaPML SofaPML)
 sofa_add_plugin(Sensable Sensable)
 sofa_add_plugin(SensableEmulation SensableEmulation)
-sofa_add_plugin(VolumetricRendering VolumetricRendering)
 sofa_add_plugin(SofaCUDA SofaCUDA)
 sofa_add_plugin(SofaHAPI SofaHAPI)
 sofa_add_plugin(THMPGSpatialHashing THMPGSpatialHashing)
@@ -40,4 +39,10 @@ sofa_add_plugin(Geomagic Geomagic)
 
 if((${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") AND (${CMAKE_SYSTEM_NAME} MATCHES "Linux"))
     sofa_add_plugin(SofaPardisoSolver SofaPardisoSolver) # SofaPardisoSolver is only available under linux with gcc
+endif()
+
+if(${SOFA_NO_OPENGL})
+    message("SOFA_NO_OPENGL flag prevents from using the VolumetricRendering plugin")
+else()
+    sofa_add_plugin(VolumetricRendering VolumetricRendering) # VolumetricRendering plugin can't working without OPENGL
 endif()

--- a/applications/plugins/CMakeLists.txt
+++ b/applications/plugins/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.1)
 
 find_package(SofaFramework)
 
-sofa_add_plugin(SofaSimpleGUI SofaSimpleGUI)
 sofa_add_plugin(image image)
 sofa_add_plugin(Compliant Compliant)
 sofa_add_plugin(CGALPlugin CGALPlugin) # Depends on image
@@ -29,7 +28,6 @@ sofa_add_plugin(PersistentContact PersistentContact)
 # sofa_add_plugin(SofaPML SofaPML)
 sofa_add_plugin(Sensable Sensable)
 sofa_add_plugin(SensableEmulation SensableEmulation)
-sofa_add_plugin(SofaCUDA SofaCUDA)
 sofa_add_plugin(SofaHAPI SofaHAPI)
 sofa_add_plugin(THMPGSpatialHashing THMPGSpatialHashing)
 sofa_add_plugin(SofaCarving SofaCarving)
@@ -42,7 +40,9 @@ if((${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") AND (${CMAKE_SYSTEM_NAME} MATCHES "
 endif()
 
 if(${SOFA_NO_OPENGL})
-    message("SOFA_NO_OPENGL flag prevents from using the VolumetricRendering plugin")
+    message("SOFA_NO_OPENGL flag prevents from using the SofaCUDA, SofaSimpleGUI and VolumetricRendering plugins")
 else()
-    sofa_add_plugin(VolumetricRendering VolumetricRendering) # VolumetricRendering plugin can't working without OPENGL
+    sofa_add_plugin(SofaCUDA SofaCUDA)           # SofaCUDA plugin can't work without OPENGL
+    sofa_add_plugin(SofaSimpleGUI SofaSimpleGUI) # SofaSimpleGUI plugin can't work without OPENGL
+    sofa_add_plugin(VolumetricRendering VolumetricRendering) # VolumetricRendering plugin can't work without OPENGL
 endif()

--- a/applications/plugins/Geomagic/CMakeLists.txt
+++ b/applications/plugins/Geomagic/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(Geomagic)
 
+find_package(OpenHaptics)
+
+if( NOT OPENHAPTICS_FOUND )
+    message( SEND_ERROR "OpenHaptics library not found, GeomagicDriver cannot compile")
+endif()
+
+
 set(HEADER_FILES
       src/GeomagicDriver.h
       src/initPlugin.h
@@ -15,15 +22,12 @@ set(SCENES_FILES
       scenes/Geomagic-Demo.scn
 )
 
+include_directories( ${OPENHAPTICS_INCLUDE_DIR})
 
-find_package(OpenHaptics)
+add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${SCENES_FILES} ${README_FILES})
+set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-DPLUGIN_DATA_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/\"")
+target_link_libraries(${PROJECT_NAME} SofaHelper SofaUserInteraction ${OPENHAPTICS_LIBRARIES})
 
-if( NOT OPENHAPTICS_FOUND )
-	message(WARNING "OpenHaptics library not found, GeomagicDriver cannot compile")
-else()
-	include_directories( ${OPENHAPTICS_INCLUDE_DIR})
-
-	add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${SCENES_FILES} ${README_FILES})
-	set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-DPLUGIN_DATA_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/\"")
-	target_link_libraries(${PROJECT_NAME} SofaHelper SofaOpenglVisual SofaUserInteraction ${OPENHAPTICS_LIBRARIES})
-endif( NOT OPENHAPTICS_FOUND )
+if(NOT ${SOFA_NO_OPENGL})
+    target_link_libraries(${PROJECT_NAME} SofaOpenglVisual)
+endif()

--- a/applications/plugins/Geomagic/src/GeomagicDriver.cpp
+++ b/applications/plugins/Geomagic/src/GeomagicDriver.cpp
@@ -331,6 +331,7 @@ void GeomagicDriver::getMatrix(Mat<4,4, GLdouble> & M1, int index, double teta) 
 }
 
 void GeomagicDriver::draw(const sofa::core::visual::VisualParams* vparams) {
+#ifndef SOFA_NO_OPENGL
     if (!d_omniVisu.getValue()) return;
 
     Mat<4,4, GLdouble> M;
@@ -355,6 +356,7 @@ void GeomagicDriver::draw(const sofa::core::visual::VisualParams* vparams) {
     vparams->drawTool()->drawArrow(d_posDevice.getValue().getCenter(), d_posDevice.getValue().getCenter() + d_posDevice.getValue().getOrientation().rotate(Vector3(2,0,0)*d_scale.getValue()), d_scale.getValue()*0.1, Vec4f(1,0,0,1) );
     vparams->drawTool()->drawArrow(d_posDevice.getValue().getCenter(), d_posDevice.getValue().getCenter() + d_posDevice.getValue().getOrientation().rotate(Vector3(0,2,0)*d_scale.getValue()), d_scale.getValue()*0.1, Vec4f(0,1,0,1) );
     vparams->drawTool()->drawArrow(d_posDevice.getValue().getCenter(), d_posDevice.getValue().getCenter() + d_posDevice.getValue().getOrientation().rotate(Vector3(0,0,2)*d_scale.getValue()), d_scale.getValue()*0.1, Vec4f(0,0,1,1) );
+#endif
 }
 
 void GeomagicDriver::computeBBox(const core::ExecParams*  params, bool  ) {

--- a/applications/plugins/Geomagic/src/GeomagicDriver.h
+++ b/applications/plugins/Geomagic/src/GeomagicDriver.h
@@ -28,7 +28,10 @@
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/defaulttype/Vec.h>
 #include <sofa/helper/Quater.h>
+
+#ifndef SOFA_NO_OPENGL
 #include <SofaOpenglVisual/OglModel.h>
+#endif
 
 #include <SofaUserInteraction/Controller.h>
 #include <sofa/core/behavior/BaseController.h>

--- a/applications/plugins/Registration/CMakeLists.txt
+++ b/applications/plugins/Registration/CMakeLists.txt
@@ -57,9 +57,13 @@ install(FILES "${CMAKE_BINARY_DIR}/include/Registration/config.h" DESTINATION "i
 sofa_set_python_directory(Registration "python")
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${README_FILES} ${PYTHON_FILES})
-target_link_libraries(${PROJECT_NAME} SofaMeshCollision SofaBaseCollision SofaGuiCommon SofaBaseVisual SofaExporter SofaLoader SofaOpenglVisual SofaMiscForceField SofaGeneralEngine)
+target_link_libraries(${PROJECT_NAME} SofaMeshCollision SofaBaseCollision SofaGuiCommon SofaBaseVisual SofaExporter SofaLoader SofaMiscForceField SofaGeneralEngine)
+
 if(image_FOUND)
     target_link_libraries(${PROJECT_NAME} image)
+endif()
+if(NOT ${SOFA_NO_OPENGL})
+    target_link_libraries(${PROJECT_NAME} SofaOpenglVisual)
 endif()
 
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>")

--- a/applications/plugins/Registration/ClosestPointRegistrationForceField.inl
+++ b/applications/plugins/Registration/ClosestPointRegistrationForceField.inl
@@ -370,6 +370,7 @@ void ClosestPointRegistrationForceField<DataTypes>::addKToMatrix(const core::Mec
 template<class DataTypes>
 void ClosestPointRegistrationForceField<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
+#ifndef SOFA_NO_OPENGL
     if(ks.getValue()==0) return;
 
     if (!vparams->displayFlags().getShowForceFields() && !drawColorMap.getValue()) return;
@@ -443,7 +444,7 @@ void ClosestPointRegistrationForceField<DataTypes>::draw(const core::visual::Vis
 
         glPopAttrib();
     }
-
+#endif
 }
 
 

--- a/applications/plugins/Registration/RegistrationContactForceField.inl
+++ b/applications/plugins/Registration/RegistrationContactForceField.inl
@@ -161,6 +161,7 @@ template <class DataTypes>
 template<class DataTypes>
 void RegistrationContactForceField<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
+#ifndef SOFA_NO_OPENGL
 	if (!((this->mstate1 == this->mstate2)?vparams->displayFlags().getShowForceFields():vparams->displayFlags().getShowInteractionForceFields())) return;
 	const VecCoord& p1 = this->mstate1->read(core::ConstVecCoordId::position())->getValue();
 	const VecCoord& p2 = this->mstate2->read(core::ConstVecCoordId::position())->getValue();
@@ -220,6 +221,7 @@ void RegistrationContactForceField<DataTypes>::draw(const core::visual::VisualPa
 		}
                 vparams->drawTool()->drawLines(pointsN, 1, defaulttype::Vec<4,float>(1,1,0,1));
 	}
+#endif
 }
 
 

--- a/applications/plugins/SceneCreator/SceneCreator.cpp
+++ b/applications/plugins/SceneCreator/SceneCreator.cpp
@@ -65,6 +65,7 @@
 
 //Including Visual Models
 #include <SofaBaseVisual/VisualStyle.h>
+
 #ifndef SOFA_NO_OPENGL
 #include <SofaOpenglVisual/OglModel.h>
 #else
@@ -94,7 +95,12 @@ using sofa::component::odesolver::EulerSolver ;
 
 using sofa::component::loader::MeshObjLoader ;
 using sofa::component::topology::MeshTopology ;
+
+#ifndef SOFA_NO_OPENGL
 using sofa::component::visualmodel::OglModel ;
+#else
+using sofa::component::visualmodel::VisualModelImpl;
+#endif
 
 using sofa::component::mapping::BarycentricMapping ;
 using sofa::component::mapping::RigidMapping ;

--- a/applications/plugins/SofaCUDA/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/CMakeLists.txt
@@ -10,6 +10,11 @@ if(NOT WIN32)
     set(CUDA_PROPAGATE_HOST_FLAGS OFF)
 endif()
 
+if(${SOFA_NO_OPENGL})
+    message(SEND_ERROR "Warning: CMake flag SOFA_NO_OPENGL is active.")
+    message("Flag SOFA_NO_OPENGL incompatible with the SofaCUDA plugin.")
+endif()
+
 set(HEADER_FILES
     sofa/gpu/cuda/CudaBarycentricMapping.h
     sofa/gpu/cuda/CudaBarycentricMapping.inl

--- a/applications/plugins/SofaSimpleGUI/CMakeLists.txt
+++ b/applications/plugins/SofaSimpleGUI/CMakeLists.txt
@@ -3,6 +3,11 @@ project(SofaSimpleGUI)
 
 set(SOFASIMPLEGUI_VERSION 0.1)
 
+if(${SOFA_NO_OPENGL})
+    message(SEND_ERROR "Warning: CMake flag SOFA_NO_OPENGL is active.")
+    message("Flag SOFA_NO_OPENGL incompatible with the SofaSimpleGUI plugin.")
+endif()
+
 set(HEADER_FILES
     Camera.h
     Interactor.h

--- a/applications/plugins/VolumetricRendering/CMakeLists.txt
+++ b/applications/plugins/VolumetricRendering/CMakeLists.txt
@@ -9,6 +9,11 @@ find_package(SofaFramework REQUIRED)
 find_package(SofaBase REQUIRED)
 find_package(SofaGeneral REQUIRED)
 
+if(${SOFA_NO_OPENGL})
+    message(SEND_ERROR "Warning: CMake flag SOFA_NO_OPENGL is active.")
+    message("Flag SOFA_NO_OPENGL incompatible with the VolumetricRendering plugin.")
+endif()
+
 set(HEADER_FILES
     initVolumetricRendering.h
     OglTetrahedralModel.h

--- a/applications/plugins/image/CMakeLists.txt
+++ b/applications/plugins/image/CMakeLists.txt
@@ -92,7 +92,7 @@ install(FILES "${CMAKE_BINARY_DIR}/include/image/config.h" DESTINATION "include/
 # Config files and install rules for pythons scripts
 sofa_set_python_directory(${PROJECT_NAME} "python")
 
-if(NOT SOFA-NO_OPENGL)
+if(NOT ${SOFA_NO_OPENGL})
     list(APPEND HEADER_FILES ImageViewer.h)
     list(APPEND SOURCE_FILES ImageViewer.cpp)
 endif()

--- a/applications/plugins/image/ImageViewer.h
+++ b/applications/plugins/image/ImageViewer.h
@@ -174,14 +174,18 @@ public:
         plane.setWidget("imageplane");
         
         vectorVisualization.setWidget("vectorvis");
-        
+
+#ifndef SOFA_NO_OPENGL
         for(unsigned int i=0;i<3;i++)	cutplane_tex[i]=NULL;
+#endif //SOFA_NO_OPENGL
     }
     
     
     virtual ~ImageViewer()
     {
+#ifndef SOFA_NO_OPENGL
         for(unsigned int i=0;i<3;i++)	if(cutplane_tex[i]) delete cutplane_tex[i];
+#endif //SOFA_NO_OPENGL
     }
     
     virtual void init()
@@ -323,6 +327,7 @@ public:
     
     virtual void draw(const core::visual::VisualParams* vparams)
     {
+#ifndef SOFA_NO_OPENGL
         if (!vparams->displayFlags().getShowVisualModels() || display.getValue()==false) return;
 
         bool initialized=true;
@@ -398,7 +403,7 @@ public:
         glPushAttrib( GL_LIGHTING_BIT | GL_ENABLE_BIT | GL_LINE_BIT | GL_CURRENT_BIT);
         drawCutplanes();
         glPopAttrib();
-        
+#endif //SOFA_NO_OPENGL
     }
 
 
@@ -441,7 +446,10 @@ public:
 protected:
     
     static const unsigned cutplane_res=1024;
+
+#ifndef SOFA_NO_OPENGL
     helper::gl::Texture* cutplane_tex[3];
+#endif //SOFA_NO_OPENGL
 
     //Draw vectors as arrows
     void drawArrows(const core::visual::VisualParams* vparams)
@@ -478,6 +486,7 @@ protected:
     //Draw tensors as ellipsoids
     void drawEllipsoid()
     {
+#ifndef SOFA_NO_OPENGL
         raImage rimage(this->image);
         raPlane rplane(this->plane);
         raTransform rtransform(this->transform);
@@ -577,7 +586,7 @@ protected:
 
                     }
         }
-
+#endif //SOFA_NO_OPENGL
     }
 
     cimg_library::CImg<T> computeTensorFromLowerTriRowMajorVector(cimg_library::CImg<T> vector)
@@ -621,6 +630,7 @@ protected:
     //Draw the boxes around the slices
     void drawCutplanes()
     {
+#ifndef SOFA_NO_OPENGL
         raPlane rplane(this->plane);
         if (!rplane->getDimensions()[0]) return;
 
@@ -668,14 +678,14 @@ protected:
                             glEnd ();
 
                         }
-
+#endif //SOFA_NO_OPENGL
     }
 
 
     //Update and draw the slices
     void updateTextures()
     {
-
+#ifndef SOFA_NO_OPENGL
         raPlane rplane(this->plane);
         if (!rplane->getDimensions()[0]) return;
 
@@ -721,6 +731,7 @@ protected:
                 cutplane_tex[i]->update();
             }
         }
+#endif //SOFA_NO_OPENGL
     }
 
 };

--- a/applications/plugins/image/image_test/DataImage_test.cpp
+++ b/applications/plugins/image/image_test/DataImage_test.cpp
@@ -27,7 +27,6 @@
 
 #include <SofaTest/Sofa_test.h>
 #include <image/ImageContainer.h>
-#include <image/ImageViewer.h>
 
 namespace sofa {
 

--- a/applications/plugins/image/image_test/ImageEngine_test.cpp
+++ b/applications/plugins/image/image_test/ImageEngine_test.cpp
@@ -40,7 +40,7 @@ namespace sofa {
  * Visualize the output image of the engine with ImageViewer.
  * The input image of ImageViewer is then linked to the ouput image of the engine.
  * Copy on Write option is true.
- * Note: the function draw of ImageViewer is acutally not called in this test (it works with the gui).
+ * Note: the function draw of ImageViewer is actually not called in this test (it works with the gui).
   */
 struct ImageEngine_test : public Sofa_test<>
 {

--- a/modules/SofaGeneralVisual/Visual3DText.cpp
+++ b/modules/SofaGeneralVisual/Visual3DText.cpp
@@ -71,6 +71,7 @@ void Visual3DText::reinit()
 
 void Visual3DText::drawTransparent(const core::visual::VisualParams* vparams)
 {
+#ifndef SOFA_NO_OPENGL
     if(!vparams->displayFlags().getShowVisualModels()) return;
 
     const defaulttype::Vec3f& pos = d_position.getValue();
@@ -91,6 +92,7 @@ void Visual3DText::drawTransparent(const core::visual::VisualParams* vparams)
 
     if( !depthTest )
         glPopAttrib();
+#endif /* SOFA_NO_OPENGL */
 }
 
 

--- a/modules/SofaOpenglVisual/CMakeLists.txt
+++ b/modules/SofaOpenglVisual/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.1)
 project(SofaOpenglVisual)
 
+if(${SOFA_NO_OPENGL})
+    message(SEND_ERROR "Warning: CMake flag SOFA_NO_OPENGL is active.")
+    message("Flag SOFA_NO_OPENGL incompatible with the SofaOpenglVisual module.")    
+endif()
+
 set(HEADER_FILES
     ClipPlane.h
     OglColorMap.h


### PR DESCRIPTION
If the flag SOFA_NO_OPENGL is active, the plugin VolumetricRendering
cannot be compiled. Add the proper CMake warning and error message.