### PR TITLE
[runSofa] Fix minor consistency issues related to the readOnly flag

### DIFF
--- a/applications/sofa/gui/qt/MaterialDataWidget.cpp
+++ b/applications/sofa/gui/qt/MaterialDataWidget.cpp
@@ -245,6 +245,7 @@ bool MaterialDataWidget::createWidgets()
 void MaterialDataWidget::setDataReadOnly(bool readOnly)
 {
     _nameEdit->setReadOnly(readOnly);
+    _nameEdit->setEnabled(!readOnly);
     _ambientPicker->setEnabled(!readOnly);
     _ambientCheckBox->setEnabled(!readOnly);
     _emissivePicker->setEnabled(!readOnly);

--- a/applications/sofa/gui/qt/QModelViewTableDataContainer.h
+++ b/applications/sofa/gui/qt/QModelViewTableDataContainer.h
@@ -395,7 +395,7 @@ public:
         wSize->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
 
         wDisplay = new QPushButtonUpdater( QString("Display the values"), parent);
-		wDisplay->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+        wDisplay->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
 
         if (dataRows > 0)
             cols = vhelper::size(*rhelper::get(d,0));
@@ -422,12 +422,9 @@ public:
         if(displayDataWidget)
             propertyWidgetFlagOn = displayDataWidget->flag().PROPERTY_WIDGET_FLAG;
 
-		//if(isDisplayed() || propertyWidgetFlagOn)
-		{
-			processTableModifications(d);
-			fillTable(d);
-			rows = dataRows;
-		}
+        processTableModifications(d);
+        fillTable(d);
+        rows = dataRows;
 
         if(!propertyWidgetFlagOn)
             wDisplay->setChecked(dataRows < MAX_NUM_ELEM && dataRows != 0 );
@@ -440,8 +437,6 @@ public:
         if (readOnly)
         {
             wSize->setEnabled(false);
-
-            //wTableView->setEnabled(false);
             wTableView->setEditTriggers(QAbstractItemView::NoEditTriggers);
         }
         else
@@ -449,8 +444,6 @@ public:
             if (!(FLAGS & TABLE_FIXEDSIZE))
             {
                 parent->connect(wSize, SIGNAL( valueChanged(int) ), parent, SLOT( setWidgetDirty() ));
-                //_widget->connect(wSize, SIGNAL( valueChanged(int) ), _widget, SLOT(updateDataValue()) );
-
 
                 if( FLAGS & TABLE_HORIZONTAL)
                     parent->connect(wSize, SIGNAL( valueChanged(int) ), wTableModel, SLOT(resizeTableH(int) ) );
@@ -483,7 +476,6 @@ public:
     void setReadOnly(bool readOnly)
     {
         wSize->setEnabled(!readOnly);
-        //wTableView->setEnabled(!readOnly);
         if (readOnly)
         {
             wTableView->setEditTriggers(QAbstractItemView::NoEditTriggers);

--- a/applications/sofa/gui/qt/QModelViewTableDataContainer.h
+++ b/applications/sofa/gui/qt/QModelViewTableDataContainer.h
@@ -454,12 +454,8 @@ public:
             {
                 wSize->setEnabled(false);
             }
-            parent->connect(wTableView, SIGNAL( activated(QModelIndex) ) , parent, SLOT(setWidgetDirty()) );
-            parent->connect(wTableView, SIGNAL( pressed(QModelIndex) ) , parent, SLOT(setWidgetDirty()) );
-            parent->connect(wTableView, SIGNAL( clicked(QModelIndex) ) , parent, SLOT(setWidgetDirty()) );
         }
         parent->connect(wDisplay, SIGNAL( toggled(bool) ), wTableView,   SLOT(setDisplayed(bool)));
-        parent->connect(wDisplay, SIGNAL( toggled(bool) ), parent,   SLOT(setWidgetDirty()));
         parent->connect(wDisplay, SIGNAL( toggled(bool) ), wDisplay, SLOT(setDisplayed(bool)));
         parent->connect(wDisplay, SIGNAL( toggled(bool) ), parent, SLOT( updateWidgetValue() ));
 
@@ -478,7 +474,15 @@ public:
         wSize->setEnabled(!readOnly);
         if (readOnly)
         {
+            wTableModel->setReadOnly(true);
             wTableView->setEditTriggers(QAbstractItemView::NoEditTriggers);
+            QObject::disconnect(wTableView, SIGNAL( activated(QModelIndex) ) , widget, SLOT(setWidgetDirty()) );
+            QObject::disconnect(wTableView, SIGNAL( pressed(QModelIndex) ) , widget, SLOT(setWidgetDirty()) );
+            QObject::disconnect(wTableView, SIGNAL( clicked(QModelIndex) ) , widget, SLOT(setWidgetDirty()) );
+        }else{
+            QObject::connect(wTableView, SIGNAL( activated(QModelIndex) ) , widget, SLOT(setWidgetDirty()) );
+            QObject::connect(wTableView, SIGNAL( pressed(QModelIndex) ) , widget, SLOT(setWidgetDirty()) );
+            QObject::connect(wTableView, SIGNAL( clicked(QModelIndex) ) , widget, SLOT(setWidgetDirty()) );
         }
     }
 

--- a/applications/sofa/gui/qt/QModelViewTableUpdater.cpp
+++ b/applications/sofa/gui/qt/QModelViewTableUpdater.cpp
@@ -29,7 +29,7 @@
 #include <QSpinBox>
 #include <QTableView>
 #include <QStandardItemModel>
-
+#include <QApplication>
 
 namespace sofa
 {
@@ -66,9 +66,9 @@ QVariant QTableModelUpdater::data(const QModelIndex &index, int role) const
     if(m_isReadOnly){
         switch(role){
         case Qt::BackgroundRole:
-            return QGuiApplication::palette().color(QPalette::Disabled, QPalette::Background) ;
+            return QApplication::palette().color(QPalette::Disabled, QPalette::Background) ;
         case Qt::ForegroundRole:
-            return QGuiApplication::palette().color(QPalette::Disabled, QPalette::Text);
+            return QApplication::palette().color(QPalette::Disabled, QPalette::Text);
         }
     }
     return QStandardItemModel::data(index,role) ;

--- a/applications/sofa/gui/qt/QModelViewTableUpdater.cpp
+++ b/applications/sofa/gui/qt/QModelViewTableUpdater.cpp
@@ -54,6 +54,31 @@ QTableModelUpdater::QTableModelUpdater ( int numRows, int numCols, QWidget * par
     QStandardItemModel(numRows, numCols, parent)
 {}
 
+Qt::ItemFlags QTableModelUpdater::flags(const QModelIndex&) const
+{
+    if(m_isReadOnly)
+        return (Qt::ItemIsSelectable) ;
+    return Qt::ItemIsSelectable | Qt::ItemIsEditable | Qt::ItemIsEnabled ;
+}
+
+QVariant QTableModelUpdater::data(const QModelIndex &index, int role) const
+{
+    if(m_isReadOnly){
+        switch(role){
+        case Qt::BackgroundRole:
+            return QGuiApplication::palette().color(QPalette::Disabled, QPalette::Background) ;
+        case Qt::ForegroundRole:
+            return QGuiApplication::palette().color(QPalette::Disabled, QPalette::Text);
+        }
+    }
+    return QStandardItemModel::data(index,role) ;
+}
+
+void QTableModelUpdater::setReadOnly(const bool isReadOnly)
+{
+    m_isReadOnly=isReadOnly;
+}
+
 void QTableModelUpdater::resizeTableV( int number )
 {
     QSpinBox *spinBox = (QSpinBox *) sender();

--- a/applications/sofa/gui/qt/QModelViewTableUpdater.h
+++ b/applications/sofa/gui/qt/QModelViewTableUpdater.h
@@ -33,7 +33,7 @@
 #include <QSpinBox>
 #include <QTableView>
 #include <QStandardItemModel>
-
+#include <QGuiApplication>
 
 namespace sofa
 {
@@ -57,9 +57,14 @@ public slots:
 class QTableModelUpdater : public QStandardItemModel
 {
     Q_OBJECT
-
+    bool m_isReadOnly ;
 public:
     QTableModelUpdater ( int numRows, int numCols, QWidget * parent = 0, const char * /*name*/ = 0 );
+
+    virtual Qt::ItemFlags flags(const QModelIndex&) const override ;
+    virtual QVariant data(const QModelIndex &index, int role) const ;
+
+    void setReadOnly(const bool isReadOnly) ;
 
 public slots:
     void resizeTableV( int number );

--- a/applications/sofa/gui/qt/QModelViewTableUpdater.h
+++ b/applications/sofa/gui/qt/QModelViewTableUpdater.h
@@ -33,7 +33,7 @@
 #include <QSpinBox>
 #include <QTableView>
 #include <QStandardItemModel>
-#include <QGuiApplication>
+
 
 namespace sofa
 {

--- a/applications/sofa/gui/qt/SimpleDataWidget.h
+++ b/applications/sofa/gui/qt/SimpleDataWidget.h
@@ -88,6 +88,7 @@ public:
     }
     static void setReadOnly(Widget* w, bool readOnly)
     {
+        w->setEnabled(!readOnly);
         w->setReadOnly(readOnly);
     }
     static void connectChanged(Widget* w, DataWidget* datawidget)
@@ -144,7 +145,10 @@ public:
     }
     void setReadOnly(bool readOnly)
     {
-        if(w) helper::setReadOnly(w, readOnly);
+        if(w){
+            w->setEnabled(!readOnly);
+            helper::setReadOnly(w, readOnly);
+        }
     }
     void readFromData(const data_type& d)
     {
@@ -226,7 +230,7 @@ public:
     static Widget* create(QWidget* parent, const data_type& /*d*/)
     {
         Widget* w = new Widget(parent);
-		w->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+        w->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
         return w;
     }
     static void readFromData(Widget* w, const data_type& d)
@@ -240,6 +244,7 @@ public:
     }
     static void setReadOnly(Widget* w, bool readOnly)
     {
+        w->setEnabled(!readOnly);
         w->setReadOnly(readOnly);
     }
     static void connectChanged(Widget* w, DataWidget* datawidget)
@@ -346,7 +351,7 @@ public:
         w->setMaximum(vmax);
         w->setSingleStep(1);
 
-		w->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+        w->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
         return w;
     }
     static void readFromData(Widget* w, const data_type& d)
@@ -817,6 +822,7 @@ public:
     }
     static void setReadOnly(Widget* w, bool readOnly)
     {
+        w->setEnabled(!readOnly);
         w->setReadOnly(readOnly);
     }
     static void connectChanged(Widget* w, DataWidget* datawidget)


### PR DESCRIPTION
Data field are not handle in a consistent way in the runSofa GUI regarding the readOnly flags. 

This is puzzling and disturbing the users because  some readOnly field are grayed-out while others aren't. 

This PR fix that. 

PS: 
I was working on saving scenes... found that... cannot prevent myself to it.