### PR TITLE
[SofaKernel] Add defaulttype::RGBAColor

### DIFF
--- a/SofaKernel/framework/framework_test/CMakeLists.txt
+++ b/SofaKernel/framework/framework_test/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCE_FILES
     core/TrackedData_test.cpp
     defaulttype/MatTypes_test.cpp
     defaulttype/VecTypes_test.cpp
+    defaulttype/Color_test.cpp
     helper/KdTree_test.cpp
     helper/Utils_test.cpp
     helper/Quater_test.cpp

--- a/SofaKernel/framework/framework_test/CMakeLists.txt
+++ b/SofaKernel/framework/framework_test/CMakeLists.txt
@@ -34,7 +34,7 @@ include_directories(${gtest_SOURCE_DIR}/include)
 add_definitions("-DFRAMEWORK_TEST_RESOURCES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/resources\"")
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} gtest_main SofaCore SofaTest)
+target_link_libraries(${PROJECT_NAME} gtest_main SofaCore SofaDefaultType SofaTest)
 #add_dependencies(${PROJECT_NAME} PluginA PluginB PluginC PluginD PluginE PluginF)
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/SofaKernel/framework/framework_test/defaulttype/Color_test.cpp
+++ b/SofaKernel/framework/framework_test/defaulttype/Color_test.cpp
@@ -1,0 +1,156 @@
+#include <SofaComponentBase/initComponentBase.h>
+#include <SofaComponentCommon/initComponentCommon.h>
+#include <SofaComponentGeneral/initComponentGeneral.h>
+#include <SofaComponentAdvanced/initComponentAdvanced.h>
+#include <SofaComponentMisc/initComponentMisc.h>
+#include <SofaSimulationCommon/init.h>
+#include <SofaSimulationGraph/init.h>
+
+#include <SofaTest/Sofa_test.h>
+using sofa::Sofa_test;
+
+#include <sofa/defaulttype/Vec.h>
+using sofa::defaulttype::Vec4d ;
+
+#include <sofa/core/objectmodel/Data.h>
+using sofa::core::objectmodel::Data ;
+
+#include <sofa/defaulttype/Color.h>
+using sofa::defaulttype::RGBAColor ;
+
+class Color_Test : public Sofa_test<>
+{
+public:
+    void SetUp() ;
+    void TearDown() ;;
+    void checkCreateFromString() ;
+    void checkCreateFromDouble() ;
+    void checkEquality() ;
+    void checkGetSet() ;
+    void checkColorDataField() ;
+};
+
+void Color_Test::SetUp()
+{
+    sofa::simulation::common::init();
+    sofa::simulation::graph::init();
+}
+
+void Color_Test::TearDown()
+{
+    sofa::simulation::common::cleanup();
+    sofa::simulation::graph::cleanup();
+}
+
+void Color_Test::checkCreateFromString()
+{
+    EXPECT_EQ( RGBAColor::fromString("white"), RGBAColor(1.0,1.0,1.0,1.0) ) ;
+    EXPECT_EQ( RGBAColor::fromString("black"), RGBAColor(0.0,0.0,0.0,1.0) ) ;
+    EXPECT_EQ( RGBAColor::fromString("red"), RGBAColor(1.0,0.0,0.0,1.0) ) ;
+    EXPECT_EQ( RGBAColor::fromString("green"), RGBAColor(0.0,1.0,0.0,1.0) ) ;
+    EXPECT_EQ( RGBAColor::fromString("blue"), RGBAColor(0.0,0.0,1.0,1.0) ) ;
+    EXPECT_EQ( RGBAColor::fromString("cyan"), RGBAColor(0.0,1.0,1.0,1.0) ) ;
+    EXPECT_EQ( RGBAColor::fromString("magenta"), RGBAColor(1.0,0.0,1.0,1.0) ) ;
+    EXPECT_EQ( RGBAColor::fromString("yellow"), RGBAColor(1.0,1.0,0.0,1.0) ) ;
+    EXPECT_EQ( RGBAColor::fromString("yellow"), RGBAColor(1.0,1.0,0.0,1.0) ) ;
+    EXPECT_EQ( RGBAColor::fromString("gray"), RGBAColor(0.5,0.5,0.5,1.0) ) ;
+
+    RGBAColor color;
+    EXPECT_TRUE( RGBAColor::read("white", color) ) ;
+    EXPECT_FALSE( RGBAColor::read("invalidcolor", color) ) ;
+
+    EXPECT_EQ( RGBAColor::fromString("1 2 3 4"), RGBAColor(1.0,2.0,3.0,4.0) ) ;
+    EXPECT_EQ( RGBAColor::fromString("0 0 3 4"), RGBAColor(0.0,0.0,3.0,4.0) ) ;
+
+    RGBAColor color2;
+    EXPECT_TRUE( RGBAColor::read("1 2 3 4", color2) ) ;
+    EXPECT_EQ( color2, RGBAColor(1,2,3,4));
+
+    EXPECT_TRUE( RGBAColor::read("0 0 3 4", color2) ) ;
+    EXPECT_EQ( color2, RGBAColor(0,0,3,4));
+
+    EXPECT_FALSE( RGBAColor::read("1 2 3", color2) ) ;
+    EXPECT_FALSE( RGBAColor::read("1 2 3 4 5", color2) ) ;
+    EXPECT_FALSE( RGBAColor::read("1 a 3 4", color2) ) ;
+    EXPECT_FALSE( RGBAColor::read("-1 2 3 5", color2) ) ;
+}
+
+void Color_Test::checkCreateFromDouble()
+{
+    EXPECT_EQ( RGBAColor::fromDouble(1.0,1.0,1.0,1.0), RGBAColor(1.0,1.0,1.0,1.0)) ;
+    EXPECT_EQ( RGBAColor::fromDouble(1.0,0.0,1.0,1.0), RGBAColor(1.0,0.0,1.0,1.0)) ;
+    EXPECT_EQ( RGBAColor::fromDouble(1.0,1.0,0.0,1.0), RGBAColor(1.0,1.0,0.0,1.0)) ;
+    EXPECT_EQ( RGBAColor::fromDouble(1.0,1.0,1.0,0.0), RGBAColor(1.0,1.0,1.0,0.0)) ;
+
+    Vec4d tt(2,3,4,5) ;
+    EXPECT_EQ( RGBAColor::fromVec4(tt), RGBAColor(2,3,4,5)) ;
+}
+
+void Color_Test::checkGetSet()
+{
+    RGBAColor a;
+    a.r(1);
+    EXPECT_EQ(a.r(), 1.0) ;
+
+    a.g(2);
+    EXPECT_EQ(a.g(), 2.0) ;
+
+    a.b(3);
+    EXPECT_EQ(a.b(), 3.0) ;
+
+    a.a(4);
+    EXPECT_EQ(a.a(), 4.0) ;
+
+    EXPECT_EQ(a, RGBAColor(1.0,2.0,3.0,4.0)) ;
+}
+
+void Color_Test::checkColorDataField()
+{
+    Data<RGBAColor> color ;
+
+    EXPECT_FALSE(color.read("invalidcolor"));
+
+    EXPECT_TRUE(color.read("white"));
+    EXPECT_EQ(color.getValue(), RGBAColor(1.0,1.0,1.0,1.0));
+
+    EXPECT_TRUE(color.read("blue"));
+    EXPECT_EQ(color.getValue(), RGBAColor(0.0,0.0,1.0,1.0));
+
+    std::stringstream tmp;
+    tmp << color ;
+
+    EXPECT_TRUE(color.read(tmp.str()));
+    EXPECT_EQ(color.getValue(), RGBAColor(0.0,0.0,1.0,1.0));
+}
+
+void Color_Test::checkEquality()
+{
+    EXPECT_EQ(RGBAColor(), RGBAColor());
+    EXPECT_EQ(RGBAColor(0.0,1.0,2.0,3.0), RGBAColor(0.0,1.0,2.0,3.0));
+
+    EXPECT_NE(RGBAColor(0.1,1.0,2.0,3.0), RGBAColor(0.0,1.0,2.0,3.0));
+    EXPECT_NE(RGBAColor(0.1,1.1,2.0,3.0), RGBAColor(0.1,1.0,2.0,3.0));
+    EXPECT_NE(RGBAColor(0.1,1.1,2.1,3.0), RGBAColor(0.1,1.1,2.0,3.0));
+    EXPECT_NE(RGBAColor(0.1,1.1,2.1,3.1), RGBAColor(0.1,1.1,2.1,3.0));
+}
+
+TEST_F(Color_Test, checkColorDataField)
+{
+    this->checkColorDataField() ;
+}
+
+TEST_F(Color_Test, checkCreateFromString)
+{
+    this->checkCreateFromString() ;
+}
+
+TEST_F(Color_Test, checkCreateFromDouble)
+{
+    this->checkCreateFromString() ;
+}
+
+TEST_F(Color_Test, checkEquality)
+{
+    this->checkEquality() ;
+}
+

--- a/SofaKernel/framework/framework_test/defaulttype/Color_test.cpp
+++ b/SofaKernel/framework/framework_test/defaulttype/Color_test.cpp
@@ -73,6 +73,34 @@ void Color_Test::checkCreateFromString()
     EXPECT_FALSE( RGBAColor::read("1 2 3 4 5", color2) ) ;
     EXPECT_FALSE( RGBAColor::read("1 a 3 4", color2) ) ;
     EXPECT_FALSE( RGBAColor::read("-1 2 3 5", color2) ) ;
+
+    ///# short hexadecimal notation
+    EXPECT_EQ( RGBAColor::fromString("#000"), RGBAColor(0.0,0.0,0.0,1.0) ) ;
+    EXPECT_EQ( RGBAColor::fromString("#0000"), RGBAColor(0.0,0.0,0.0,0.0) ) ;
+
+    EXPECT_TRUE( RGBAColor::read("#ABA", color2) ) ;
+    EXPECT_TRUE( RGBAColor::read("#FFAA", color2) ) ;
+
+    EXPECT_TRUE( RGBAColor::read("#aba", color2) ) ;
+    EXPECT_TRUE( RGBAColor::read("#ffaa", color2) ) ;
+
+    EXPECT_FALSE( RGBAColor::read("#ara", color2) ) ;
+    EXPECT_FALSE( RGBAColor::read("#ffap", color2) ) ;
+    EXPECT_FALSE( RGBAColor::read("##fapa", color2) ) ;
+    EXPECT_FALSE( RGBAColor::read("#f#apa", color2) ) ;
+
+    ///# long hexadecimal notation
+    EXPECT_EQ( RGBAColor::fromString("#000000"), RGBAColor(0.0,0.0,0.0,1.0) ) ;
+    EXPECT_EQ( RGBAColor::fromString("#00000000"), RGBAColor(0.0,0.0,0.0,0.0) ) ;
+
+    EXPECT_TRUE( RGBAColor::read("#AABBAA", color2) ) ;
+    EXPECT_TRUE( RGBAColor::read("#FFAA99AA", color2) ) ;
+
+    EXPECT_FALSE( RGBAColor::read("#aabraa", color2) ) ;
+    EXPECT_FALSE( RGBAColor::read("#fffapaba", color2) ) ;
+    EXPECT_FALSE( RGBAColor::read("##fpaapddda", color2) ) ;
+    EXPECT_FALSE( RGBAColor::read("#fasdqdpa", color2) ) ;
+
 }
 
 void Color_Test::checkCreateFromDouble()

--- a/SofaKernel/framework/framework_test/defaulttype/Color_test.cpp
+++ b/SofaKernel/framework/framework_test/defaulttype/Color_test.cpp
@@ -59,8 +59,13 @@ void Color_Test::checkCreateFromString()
     EXPECT_TRUE( RGBAColor::read("white", color) ) ;
     EXPECT_FALSE( RGBAColor::read("invalidcolor", color) ) ;
 
+    /// READ RGBA colors
     EXPECT_EQ( RGBAColor::fromString("1 2 3 4"), RGBAColor(1.0,2.0,3.0,4.0) ) ;
     EXPECT_EQ( RGBAColor::fromString("0 0 3 4"), RGBAColor(0.0,0.0,3.0,4.0) ) ;
+
+    /// READ RGB colors
+    EXPECT_EQ( RGBAColor::fromString("1 2 3"), RGBAColor(1.0,2.0,3.0,1.0) ) ;
+    EXPECT_EQ( RGBAColor::fromString("0 0 3"), RGBAColor(0.0,0.0,3.0,1.0) ) ;
 
     RGBAColor color2;
     EXPECT_TRUE( RGBAColor::read("1 2 3 4", color2) ) ;
@@ -69,7 +74,9 @@ void Color_Test::checkCreateFromString()
     EXPECT_TRUE( RGBAColor::read("0 0 3 4", color2) ) ;
     EXPECT_EQ( color2, RGBAColor(0,0,3,4));
 
-    EXPECT_FALSE( RGBAColor::read("1 2 3", color2) ) ;
+    EXPECT_TRUE( RGBAColor::read("1 2 3", color2) ) ;
+    EXPECT_EQ( color2, RGBAColor(1,2,3,1));
+
     EXPECT_FALSE( RGBAColor::read("1 2 3 4 5", color2) ) ;
     EXPECT_FALSE( RGBAColor::read("1 a 3 4", color2) ) ;
     EXPECT_FALSE( RGBAColor::read("-1 2 3 5", color2) ) ;

--- a/SofaKernel/framework/sofa/defaulttype/CMakeLists.txt
+++ b/SofaKernel/framework/sofa/defaulttype/CMakeLists.txt
@@ -29,6 +29,7 @@ set(HEADER_FILES
     VecTypes.h
     defaulttype.h
     init.h
+    Color.h
 )
 
 set(SOURCE_FILES
@@ -38,6 +39,7 @@ set(SOURCE_FILES
     # RigidInertia.cpp
     SolidTypes.cpp
     TemplatesAliases.cpp
+    Color.cpp
     init.cpp
 )
 

--- a/SofaKernel/framework/sofa/defaulttype/Color.cpp
+++ b/SofaKernel/framework/sofa/defaulttype/Color.cpp
@@ -38,6 +38,8 @@ int hexval(char c)
     else return 0;
 }
 
+RGBAColorEMPTY empty;
+
 RGBAColor::RGBAColor()
 {
 

--- a/SofaKernel/framework/sofa/defaulttype/Color.cpp
+++ b/SofaKernel/framework/sofa/defaulttype/Color.cpp
@@ -1,0 +1,142 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2016 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This library is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This library is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this library; if not, write to the Free Software Foundation,     *
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.          *
+*******************************************************************************
+*                              SOFA :: Framework                              *
+*                                                                             *
+* Contributions:                                                              *
+*     - damien.marchal@univ-lille1.fr                                         *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/defaulttype/Color.h>
+
+namespace sofa
+{
+namespace defaulttype
+{
+
+int hexval(char c)
+{
+    if (c>='0' && c<='9') return c-'0';
+    else if (c>='a' && c<='f') return (c-'a')+10;
+    else if (c>='A' && c<='F') return (c-'A')+10;
+    else return 0;
+}
+
+RGBAColor::RGBAColor()
+{
+
+}
+
+RGBAColor::RGBAColor(const Vec<4,double>& c) : Vec<4,double>(c)
+{
+
+}
+
+RGBAColor::RGBAColor(const double pr, const double pg, const double pb, const double pa)
+{
+    r(pr);
+    g(pg);
+    b(pb);
+    a(pa);
+}
+
+bool RGBAColor::read(const std::string& str, RGBAColor& color)
+{
+    if (str.empty())
+        return true;
+
+    float r,g,b,a=1.0;
+    if (str[0]>='0' && str[0]<='9')
+    {
+        std::istringstream iss(str);
+        iss >> r >> g >> b >> a ;
+        if(iss.fail())
+            return false;
+        if(!iss.eof())
+            return false;
+    }
+    else if (str[0]=='#' && str.length()>=7)
+    {
+        r = (hexval(str[1])*16+hexval(str[2]))/255.0f;
+        g = (hexval(str[3])*16+hexval(str[4]))/255.0f;
+        b = (hexval(str[5])*16+hexval(str[6]))/255.0f;
+        if (str.length()>=9)
+            a = (hexval(str[7])*16+hexval(str[8]))/255.0f;
+    }
+    else if (str[0]=='#' && str.length()>=4)
+    {
+        r = (hexval(str[1])*17)/255.0f;
+        g = (hexval(str[2])*17)/255.0f;
+        b = (hexval(str[3])*17)/255.0f;
+        if (str.length()>=5)
+            a = (hexval(str[4])*17)/255.0f;
+    }
+    /// If you add more colors... please also add them in the test file.
+    else if (str == "white")    { r = 1.0f; g = 1.0f; b = 1.0f; }
+    else if (str == "black")    { r = 0.0f; g = 0.0f; b = 0.0f; }
+    else if (str == "red")      { r = 1.0f; g = 0.0f; b = 0.0f; }
+    else if (str == "green")    { r = 0.0f; g = 1.0f; b = 0.0f; }
+    else if (str == "blue")     { r = 0.0f; g = 0.0f; b = 1.0f; }
+    else if (str == "cyan")     { r = 0.0f; g = 1.0f; b = 1.0f; }
+    else if (str == "magenta")  { r = 1.0f; g = 0.0f; b = 1.0f; }
+    else if (str == "yellow")   { r = 1.0f; g = 1.0f; b = 0.0f; }
+    else if (str == "gray")     { r = 0.5f; g = 0.5f; b = 0.5f; }
+    else
+    {
+        return false ;
+    }
+
+    color.set(r,g,b,a) ;
+    return true ;
+}
+
+RGBAColor RGBAColor::fromString(const std::string& c)
+{
+    RGBAColor color(1.0,1.0,1.0,1.0) ;
+    if( !RGBAColor::read(c, color) ){
+        msg_info("RGBAColor") << "Unable to scan color from string '" << c << "'" ;
+    }
+    return color;
+}
+
+RGBAColor RGBAColor::fromDouble(const double r, const double g, const double b, const double a)
+{
+    return RGBAColor(r,g,b,a);
+}
+
+RGBAColor RGBAColor::fromVec4(const Vec4d color)
+{
+    return RGBAColor(color) ;
+}
+
+std::istream& operator>>(std::istream& i, RGBAColor& t)
+{
+    std::string s;
+    std::getline(i, s);
+    if(!RGBAColor::read(s, t)){
+        i.setstate(std::ios::failbit) ;
+    }
+
+    return i;
+}
+
+
+} // namespace defaulttype
+} // namespace sofa
+

--- a/SofaKernel/framework/sofa/defaulttype/Color.cpp
+++ b/SofaKernel/framework/sofa/defaulttype/Color.cpp
@@ -23,6 +23,8 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#define SOFA_DEFAULTTYPE_COLOR_CPP
+
 #include <sofa/defaulttype/Color.h>
 
 namespace sofa
@@ -53,17 +55,20 @@ bool isValidEncoding(const std::string& s)
     return true;
 }
 
-RGBAColor::RGBAColor()
+template<>
+TRGBAColor<float>::TRGBAColor()
 {
 
 }
 
-RGBAColor::RGBAColor(const Vec4f& c) : Vec4f(c)
+template<>
+TRGBAColor<float>::TRGBAColor(const Vec4f& c) : Vec4f(c)
 {
 
 }
 
-RGBAColor::RGBAColor(const float pr, const float pg, const float pb, const float pa)
+template<>
+TRGBAColor<float>::TRGBAColor(const float pr, const float pg, const float pb, const float pa)
 {
     r(pr);
     g(pg);
@@ -71,7 +76,8 @@ RGBAColor::RGBAColor(const float pr, const float pg, const float pb, const float
     a(pa);
 }
 
-bool RGBAColor::read(const std::string& str, RGBAColor& color)
+template<>
+bool TRGBAColor<float>::read(const std::string& str, TRGBAColor<float>& color)
 {
     if (str.empty())
         return true;
@@ -134,35 +140,39 @@ bool RGBAColor::read(const std::string& str, RGBAColor& color)
     return true ;
 }
 
-RGBAColor RGBAColor::fromString(const std::string& c)
+template<>
+TRGBAColor<float> TRGBAColor<float>::fromString(const std::string& c)
 {
-    RGBAColor color(1.0,1.0,1.0,1.0) ;
-    if( !RGBAColor::read(c, color) ){
-        msg_info("RGBAColor") << "Unable to scan color from string '" << c << "'" ;
+    TRGBAColor<float> color(1.0,1.0,1.0,1.0) ;
+    if( !TRGBAColor<float>::read(c, color) ){
+        msg_info("TRGBAColor") << "Unable to scan color from string '" << c << "'" ;
     }
     return color;
 }
 
-RGBAColor RGBAColor::fromDouble(const float r, const float g, const float b, const float a)
+template<>
+TRGBAColor<float> TRGBAColor<float>::fromDouble(const float r, const float g, const float b, const float a)
 {
-    return RGBAColor(r,g,b,a);
+    return TRGBAColor<float>(r,g,b,a);
 }
 
-RGBAColor RGBAColor::fromVec4(const Vec4d& color)
+template<>
+TRGBAColor<float> TRGBAColor<float>::fromVec4(const Vec4d& color)
 {
-    return RGBAColor(color) ;
+    return TRGBAColor<float>(color) ;
 }
 
-RGBAColor RGBAColor::fromVec4(const Vec4f& color)
+template<>
+TRGBAColor<float> TRGBAColor<float>::fromVec4(const Vec4f& color)
 {
-    return RGBAColor(color.x(), color.y(), color.z(), color.w()) ;
+    return TRGBAColor<float>(color.x(), color.y(), color.z(), color.w()) ;
 }
 
-std::istream& operator>>(std::istream& i, RGBAColor& t)
+std::istream& operator>>(std::istream& i, TRGBAColor<float>& t)
 {
     std::string s;
     std::getline(i, s);
-    if(!RGBAColor::read(s, t)){
+    if(!TRGBAColor<float>::read(s, t)){
         i.setstate(std::ios::failbit) ;
     }
 

--- a/SofaKernel/framework/sofa/defaulttype/Color.cpp
+++ b/SofaKernel/framework/sofa/defaulttype/Color.cpp
@@ -127,6 +127,11 @@ RGBAColor RGBAColor::fromVec4(const Vec4d color)
     return RGBAColor(color) ;
 }
 
+RGBAColor RGBAColor::fromVec4(const Vec4f color)
+{
+    return RGBAColor(color.x(), color.y(), color.z(), color.w()) ;
+}
+
 std::istream& operator>>(std::istream& i, RGBAColor& t)
 {
     std::string s;

--- a/SofaKernel/framework/sofa/defaulttype/Color.cpp
+++ b/SofaKernel/framework/sofa/defaulttype/Color.cpp
@@ -80,11 +80,14 @@ bool RGBAColor::read(const std::string& str, RGBAColor& color)
     if (str[0]>='0' && str[0]<='9')
     {
         std::istringstream iss(str);
-        iss >> r >> g >> b >> a ;
+        iss >> r >> g >> b ;
         if(iss.fail())
             return false;
-        if(!iss.eof())
-            return false;
+        if(!iss.eof()){
+            iss >> a;
+            if(iss.fail() || !iss.eof())
+                return false;
+        }
     }
     else if (str[0]=='#' && str.length()>=7)
     {

--- a/SofaKernel/framework/sofa/defaulttype/Color.cpp
+++ b/SofaKernel/framework/sofa/defaulttype/Color.cpp
@@ -168,7 +168,7 @@ RGBAColor RGBAColor::fromVec4(const Vec4f& color)
     return RGBAColor(color.x(), color.y(), color.z(), color.w()) ;
 }
 
-std::istream& operator>>(std::istream& i, RGBAColor& t)
+SOFA_DEFAULTTYPE_API std::istream& operator>>(std::istream& i, RGBAColor& t)
 {
     std::string s;
     std::getline(i, s);

--- a/SofaKernel/framework/sofa/defaulttype/Color.cpp
+++ b/SofaKernel/framework/sofa/defaulttype/Color.cpp
@@ -58,12 +58,12 @@ RGBAColor::RGBAColor()
 
 }
 
-RGBAColor::RGBAColor(const Vec<4,double>& c) : Vec<4,double>(c)
+RGBAColor::RGBAColor(const Vec4f& c) : Vec4f(c)
 {
 
 }
 
-RGBAColor::RGBAColor(const double pr, const double pg, const double pb, const double pa)
+RGBAColor::RGBAColor(const float pr, const float pg, const float pb, const float pa)
 {
     r(pr);
     g(pg);
@@ -143,17 +143,17 @@ RGBAColor RGBAColor::fromString(const std::string& c)
     return color;
 }
 
-RGBAColor RGBAColor::fromDouble(const double r, const double g, const double b, const double a)
+RGBAColor RGBAColor::fromDouble(const float r, const float g, const float b, const float a)
 {
     return RGBAColor(r,g,b,a);
 }
 
-RGBAColor RGBAColor::fromVec4(const Vec4d color)
+RGBAColor RGBAColor::fromVec4(const Vec4d& color)
 {
     return RGBAColor(color) ;
 }
 
-RGBAColor RGBAColor::fromVec4(const Vec4f color)
+RGBAColor RGBAColor::fromVec4(const Vec4f& color)
 {
     return RGBAColor(color.x(), color.y(), color.z(), color.w()) ;
 }

--- a/SofaKernel/framework/sofa/defaulttype/Color.cpp
+++ b/SofaKernel/framework/sofa/defaulttype/Color.cpp
@@ -38,7 +38,20 @@ int hexval(char c)
     else return 0;
 }
 
-RGBAColorEMPTY empty;
+bool isValidEncoding(const std::string& s)
+{
+    auto c = s.begin();
+    if( *c != '#' )
+        return false;
+
+    for( c++ ; c != s.end() ; ++c ){
+        if (*c>='0' && *c<='9') {}
+        else if (*c>='a' && *c<='f') {}
+        else if (*c>='A' && *c<='F') {}
+        else return false;
+    }
+    return true;
+}
 
 RGBAColor::RGBAColor()
 {
@@ -75,19 +88,29 @@ bool RGBAColor::read(const std::string& str, RGBAColor& color)
     }
     else if (str[0]=='#' && str.length()>=7)
     {
+        if(!isValidEncoding(str))
+            return false;
+
         r = (hexval(str[1])*16+hexval(str[2]))/255.0f;
         g = (hexval(str[3])*16+hexval(str[4]))/255.0f;
         b = (hexval(str[5])*16+hexval(str[6]))/255.0f;
         if (str.length()>=9)
             a = (hexval(str[7])*16+hexval(str[8]))/255.0f;
+        if (str.length()>9)
+            return false;
     }
     else if (str[0]=='#' && str.length()>=4)
     {
+        if(!isValidEncoding(str))
+            return false;
+
         r = (hexval(str[1])*17)/255.0f;
         g = (hexval(str[2])*17)/255.0f;
         b = (hexval(str[3])*17)/255.0f;
         if (str.length()>=5)
             a = (hexval(str[4])*17)/255.0f;
+        if (str.length()>5)
+            return false;
     }
     /// If you add more colors... please also add them in the test file.
     else if (str == "white")    { r = 1.0f; g = 1.0f; b = 1.0f; }

--- a/SofaKernel/framework/sofa/defaulttype/Color.cpp
+++ b/SofaKernel/framework/sofa/defaulttype/Color.cpp
@@ -55,20 +55,20 @@ bool isValidEncoding(const std::string& s)
     return true;
 }
 
-template<>
-TRGBAColor<float>::TRGBAColor()
+
+RGBAColor::RGBAColor()
 {
 
 }
 
-template<>
-TRGBAColor<float>::TRGBAColor(const Vec4f& c) : Vec4f(c)
+
+RGBAColor::RGBAColor(const Vec4f& c) : Vec4f(c)
 {
 
 }
 
-template<>
-TRGBAColor<float>::TRGBAColor(const float pr, const float pg, const float pb, const float pa)
+
+RGBAColor::RGBAColor(const float pr, const float pg, const float pb, const float pa)
 {
     r(pr);
     g(pg);
@@ -76,8 +76,8 @@ TRGBAColor<float>::TRGBAColor(const float pr, const float pg, const float pb, co
     a(pa);
 }
 
-template<>
-bool TRGBAColor<float>::read(const std::string& str, TRGBAColor<float>& color)
+
+bool RGBAColor::read(const std::string& str, RGBAColor& color)
 {
     if (str.empty())
         return true;
@@ -140,45 +140,44 @@ bool TRGBAColor<float>::read(const std::string& str, TRGBAColor<float>& color)
     return true ;
 }
 
-template<>
-TRGBAColor<float> TRGBAColor<float>::fromString(const std::string& c)
+
+RGBAColor RGBAColor::fromString(const std::string& c)
 {
-    TRGBAColor<float> color(1.0,1.0,1.0,1.0) ;
-    if( !TRGBAColor<float>::read(c, color) ){
-        msg_info("TRGBAColor") << "Unable to scan color from string '" << c << "'" ;
+    RGBAColor color(1.0,1.0,1.0,1.0) ;
+    if( !RGBAColor::read(c, color) ){
+        msg_info("RGBAColor") << "Unable to scan color from string '" << c << "'" ;
     }
     return color;
 }
 
-template<>
-TRGBAColor<float> TRGBAColor<float>::fromDouble(const float r, const float g, const float b, const float a)
+
+RGBAColor RGBAColor::fromDouble(const float r, const float g, const float b, const float a)
 {
-    return TRGBAColor<float>(r,g,b,a);
+    return RGBAColor(r,g,b,a);
 }
 
-template<>
-TRGBAColor<float> TRGBAColor<float>::fromVec4(const Vec4d& color)
+
+RGBAColor RGBAColor::fromVec4(const Vec4d& color)
 {
-    return TRGBAColor<float>(color) ;
+    return RGBAColor(color) ;
 }
 
-template<>
-TRGBAColor<float> TRGBAColor<float>::fromVec4(const Vec4f& color)
+
+RGBAColor RGBAColor::fromVec4(const Vec4f& color)
 {
-    return TRGBAColor<float>(color.x(), color.y(), color.z(), color.w()) ;
+    return RGBAColor(color.x(), color.y(), color.z(), color.w()) ;
 }
 
-std::istream& operator>>(std::istream& i, TRGBAColor<float>& t)
+std::istream& operator>>(std::istream& i, RGBAColor& t)
 {
     std::string s;
     std::getline(i, s);
-    if(!TRGBAColor<float>::read(s, t)){
+    if(!RGBAColor::read(s, t)){
         i.setstate(std::ios::failbit) ;
     }
 
     return i;
 }
-
 
 } // namespace defaulttype
 } // namespace sofa

--- a/SofaKernel/framework/sofa/defaulttype/Color.h
+++ b/SofaKernel/framework/sofa/defaulttype/Color.h
@@ -27,7 +27,7 @@
 #define SOFA_DEFAULTTYPE_COLOR_H
 #include <string>
 
-#include <sofa/helper/system/config.h>
+#include <sofa/defaulttype/defaulttype.h>
 #include <sofa/defaulttype/Vec.h>
 
 namespace sofa
@@ -36,7 +36,7 @@ namespace sofa
 namespace defaulttype
 {
 
-class RGBAColorEMPTY : public sofa::defaulttype::Vec<4, double>
+class SOFA_DEFAULTTYPE_API RGBAColorEMPTY : public sofa::defaulttype::Vec<4, double>
 {
 public:
 };
@@ -44,7 +44,7 @@ public:
 /**
  *  \brief encode a 4 RGBA component color as a specialized Vec<4, double> vector.
  */
-class RGBAColor : public sofa::defaulttype::Vec<4, double>
+class SOFA_DEFAULTTYPE_API RGBAColor : public sofa::defaulttype::Vec<4, double>
 {
 public:
     static RGBAColor fromString(const std::string& str) ;

--- a/SofaKernel/framework/sofa/defaulttype/Color.h
+++ b/SofaKernel/framework/sofa/defaulttype/Color.h
@@ -39,24 +39,30 @@ namespace defaulttype
 /**
  *  \brief encode a 4 RGBA component color as a specialized Vec<4, float> vector.
  */
-class SOFA_DEFAULTTYPE_API RGBAColor : public Vec4f
+template<typename T>
+class SOFA_DEFAULTTYPE_API TRGBAColor : public Vec<4, T>
 {
 public:
-    static RGBAColor fromString(const std::string& str) ;
-    static RGBAColor fromDouble(const float r, const float g, const float b, const float a) ;
-    static RGBAColor fromVec4(const Vec4d& color) ;
-    static RGBAColor fromVec4(const Vec4f& color) ;
-    static bool read(const std::string& str, RGBAColor& color) ;
+    static TRGBAColor<T> fromString(const std::string& str) ;
+    static TRGBAColor fromDouble(const float r, const float g, const float b, const float a) ;
+    static TRGBAColor fromVec4(const Vec4d& color) ;
+    static TRGBAColor fromVec4(const Vec4f& color) ;
+    static bool read(const std::string& str, TRGBAColor& color) ;
 
-    static RGBAColor white()  { return RGBAColor(1.0,1.0,1.0,1.0); }
-    static RGBAColor black()  { return RGBAColor(0.0,0.0,0.0,1.0); }
-    static RGBAColor red()    { return RGBAColor(1.0,0.0,0.0,1.0); }
-    static RGBAColor green()  { return RGBAColor(0.0,1.0,0.0,1.0); }
-    static RGBAColor blue()   { return RGBAColor(0.0,0.0,1.0,1.0); }
-    static RGBAColor cyan()   { return RGBAColor(0.0,1.0,1.0,1.0); }
-    static RGBAColor magenta() { return RGBAColor(1.0,0.0,1.0,1.0); }
-    static RGBAColor yellow()  { return RGBAColor(1.0,1.0,0.0,1.0); }
-    static RGBAColor gray()    { return RGBAColor(0.5,0.5,0.5,1.0); }
+    static TRGBAColor white()  { return TRGBAColor(1.0,1.0,1.0,1.0); }
+    static TRGBAColor black()  { return TRGBAColor(0.0,0.0,0.0,1.0); }
+    static TRGBAColor red()    { return TRGBAColor(1.0,0.0,0.0,1.0); }
+    static TRGBAColor green()  { return TRGBAColor(0.0,1.0,0.0,1.0); }
+    static TRGBAColor blue()   { return TRGBAColor(0.0,0.0,1.0,1.0); }
+    static TRGBAColor cyan()   { return TRGBAColor(0.0,1.0,1.0,1.0); }
+    static TRGBAColor magenta() { return TRGBAColor(1.0,0.0,1.0,1.0); }
+    static TRGBAColor yellow()  { return TRGBAColor(1.0,1.0,0.0,1.0); }
+    static TRGBAColor gray()    { return TRGBAColor(0.5,0.5,0.5,1.0); }
+
+    using Vec<4,T>::x ;
+    using Vec<4,T>::y ;
+    using Vec<4,T>::z ;
+    using Vec<4,T>::w ;
 
     float& r(){ return x() ; }
     float& g(){ return y() ; }
@@ -72,20 +78,27 @@ public:
     void b(const float r){ z()=r; }
     void a(const float r){ w()=r; }
 
-    friend std::istream& operator>>(std::istream& i, RGBAColor& t) ;
+    friend std::istream& operator>>(std::istream& i, TRGBAColor<float>& t) ;
 
 public:
-    RGBAColor() ;
-    RGBAColor(const  Vec4f&) ;
-    RGBAColor(const float r, const float g, const float b, const float a) ;
+    TRGBAColor() ;
+    TRGBAColor(const  Vec4f&) ;
+    TRGBAColor(const float r, const float g, const float b, const float a) ;
 
 };
 
+#if defined(SOFA_EXTERN_TEMPLATE) && !defined(SOFA_DEFAULTTYPE_COLOR_CPP)
+extern template class SOFA_DEFAULTTYPE_API TRGBAColor<float> ;
+#endif
+
+typedef TRGBAColor<float> RGBAColor ;
+
+/*
 template<>
-struct DataTypeInfo< RGBAColor > : public FixedArrayTypeInfo<Vec4f>
+struct DataTypeInfo< TRGBAColor > : public FixedArrayTypeInfo<Vec4f>
 {
-    static std::string name() { std::ostringstream o; o << "RGBAColor" << 4 << "f"; return o.str(); }
-};
+    static std::string name() { std::ostringstream o; o << "TRGBAColor" << 4 << "f"; return o.str(); }
+};*/
 
 } // namespace defaulttype
 

--- a/SofaKernel/framework/sofa/defaulttype/Color.h
+++ b/SofaKernel/framework/sofa/defaulttype/Color.h
@@ -77,7 +77,7 @@ public:
     inline void b(const float r){ z()=r; }
     inline void a(const float r){ w()=r; }
 
-    friend std::istream& operator>>(std::istream& i, RGBAColor& t) ;
+    friend SOFA_DEFAULTTYPE_API std::istream& operator>>(std::istream& i, RGBAColor& t) ;
 
 public:
     RGBAColor() ;
@@ -85,13 +85,6 @@ public:
     RGBAColor(const float r, const float g, const float b, const float a) ;
 
 };
-
-/*
-template<>
-struct DataTypeInfo< TRGBAColor > : public FixedArrayTypeInfo<Vec4f>
-{
-    static std::string name() { std::ostringstream o; o << "TRGBAColor" << 4 << "f"; return o.str(); }
-};*/
 
 } // namespace defaulttype
 

--- a/SofaKernel/framework/sofa/defaulttype/Color.h
+++ b/SofaKernel/framework/sofa/defaulttype/Color.h
@@ -62,6 +62,11 @@ public:
     double& g(){ return y() ; }
     double& b(){ return z() ; }
     double& a(){ return w() ; }
+    const double& r() const { return x() ; }
+    const double& g() const { return y() ; }
+    const double& b() const { return z() ; }
+    const double& a() const { return w() ; }
+
     void r(const double r){ x()=r; }
     void g(const double r){ y()=r; }
     void b(const double r){ z()=r; }

--- a/SofaKernel/framework/sofa/defaulttype/Color.h
+++ b/SofaKernel/framework/sofa/defaulttype/Color.h
@@ -39,59 +39,52 @@ namespace defaulttype
 /**
  *  \brief encode a 4 RGBA component color as a specialized Vec<4, float> vector.
  */
-template<typename T>
-class SOFA_DEFAULTTYPE_API TRGBAColor : public Vec<4, T>
+class SOFA_DEFAULTTYPE_API RGBAColor : public Vec<4, float>
 {
 public:
-    static TRGBAColor<T> fromString(const std::string& str) ;
-    static TRGBAColor fromDouble(const float r, const float g, const float b, const float a) ;
-    static TRGBAColor fromVec4(const Vec4d& color) ;
-    static TRGBAColor fromVec4(const Vec4f& color) ;
-    static bool read(const std::string& str, TRGBAColor& color) ;
+    static RGBAColor fromString(const std::string& str) ;
+    static RGBAColor fromDouble(const float r, const float g, const float b, const float a) ;
+    static RGBAColor fromVec4(const Vec4d& color) ;
+    static RGBAColor fromVec4(const Vec4f& color) ;
+    static bool read(const std::string& str, RGBAColor& color) ;
 
-    static TRGBAColor white()  { return TRGBAColor(1.0,1.0,1.0,1.0); }
-    static TRGBAColor black()  { return TRGBAColor(0.0,0.0,0.0,1.0); }
-    static TRGBAColor red()    { return TRGBAColor(1.0,0.0,0.0,1.0); }
-    static TRGBAColor green()  { return TRGBAColor(0.0,1.0,0.0,1.0); }
-    static TRGBAColor blue()   { return TRGBAColor(0.0,0.0,1.0,1.0); }
-    static TRGBAColor cyan()   { return TRGBAColor(0.0,1.0,1.0,1.0); }
-    static TRGBAColor magenta() { return TRGBAColor(1.0,0.0,1.0,1.0); }
-    static TRGBAColor yellow()  { return TRGBAColor(1.0,1.0,0.0,1.0); }
-    static TRGBAColor gray()    { return TRGBAColor(0.5,0.5,0.5,1.0); }
+    static RGBAColor white()  { return RGBAColor(1.0,1.0,1.0,1.0); }
+    static RGBAColor black()  { return RGBAColor(0.0,0.0,0.0,1.0); }
+    static RGBAColor red()    { return RGBAColor(1.0,0.0,0.0,1.0); }
+    static RGBAColor green()  { return RGBAColor(0.0,1.0,0.0,1.0); }
+    static RGBAColor blue()   { return RGBAColor(0.0,0.0,1.0,1.0); }
+    static RGBAColor cyan()   { return RGBAColor(0.0,1.0,1.0,1.0); }
+    static RGBAColor magenta() { return RGBAColor(1.0,0.0,1.0,1.0); }
+    static RGBAColor yellow()  { return RGBAColor(1.0,1.0,0.0,1.0); }
+    static RGBAColor gray()    { return RGBAColor(0.5,0.5,0.5,1.0); }
 
-    using Vec<4,T>::x ;
-    using Vec<4,T>::y ;
-    using Vec<4,T>::z ;
-    using Vec<4,T>::w ;
+    using Vec<4,float>::x ;
+    using Vec<4,float>::y ;
+    using Vec<4,float>::z ;
+    using Vec<4,float>::w ;
 
-    float& r(){ return x() ; }
-    float& g(){ return y() ; }
-    float& b(){ return z() ; }
-    float& a(){ return w() ; }
-    const float& r() const { return x() ; }
-    const float& g() const { return y() ; }
-    const float& b() const { return z() ; }
-    const float& a() const { return w() ; }
+    inline float& r(){ return x() ; }
+    inline float& g(){ return y() ; }
+    inline float& b(){ return z() ; }
+    inline float& a(){ return w() ; }
+    inline const float& r() const { return x() ; }
+    inline const float& g() const { return y() ; }
+    inline const float& b() const { return z() ; }
+    inline const float& a() const { return w() ; }
 
-    void r(const float r){ x()=r; }
-    void g(const float r){ y()=r; }
-    void b(const float r){ z()=r; }
-    void a(const float r){ w()=r; }
+    inline void r(const float r){ x()=r; }
+    inline void g(const float r){ y()=r; }
+    inline void b(const float r){ z()=r; }
+    inline void a(const float r){ w()=r; }
 
-    friend std::istream& operator>>(std::istream& i, TRGBAColor<float>& t) ;
+    friend std::istream& operator>>(std::istream& i, RGBAColor& t) ;
 
 public:
-    TRGBAColor() ;
-    TRGBAColor(const  Vec4f&) ;
-    TRGBAColor(const float r, const float g, const float b, const float a) ;
+    RGBAColor() ;
+    RGBAColor(const  Vec4f&) ;
+    RGBAColor(const float r, const float g, const float b, const float a) ;
 
 };
-
-#if defined(SOFA_EXTERN_TEMPLATE) && !defined(SOFA_DEFAULTTYPE_COLOR_CPP)
-extern template class SOFA_DEFAULTTYPE_API TRGBAColor<float> ;
-#endif
-
-typedef TRGBAColor<float> RGBAColor ;
 
 /*
 template<>

--- a/SofaKernel/framework/sofa/defaulttype/Color.h
+++ b/SofaKernel/framework/sofa/defaulttype/Color.h
@@ -36,11 +36,6 @@ namespace sofa
 namespace defaulttype
 {
 
-class SOFA_DEFAULTTYPE_API RGBAColorEMPTY : public sofa::defaulttype::Vec<4, float>
-{
-public:
-};
-
 /**
  *  \brief encode a 4 RGBA component color as a specialized Vec<4, float> vector.
  */

--- a/SofaKernel/framework/sofa/defaulttype/Color.h
+++ b/SofaKernel/framework/sofa/defaulttype/Color.h
@@ -64,19 +64,19 @@ public:
     using Vec<4,T>::z ;
     using Vec<4,T>::w ;
 
-    float& SOFA_DEFAULTTYPE_API r(){ return x() ; }
-    float& SOFA_DEFAULTTYPE_API g(){ return y() ; }
-    float& SOFA_DEFAULTTYPE_API b(){ return z() ; }
-    float& SOFA_DEFAULTTYPE_API a(){ return w() ; }
-    const float& SOFA_DEFAULTTYPE_API r() const { return x() ; }
-    const float& SOFA_DEFAULTTYPE_API g() const { return y() ; }
-    const float& SOFA_DEFAULTTYPE_API b() const { return z() ; }
-    const float& SOFA_DEFAULTTYPE_API a() const { return w() ; }
+    float& r(){ return x() ; }
+    float& g(){ return y() ; }
+    float& b(){ return z() ; }
+    float& a(){ return w() ; }
+    const float& r() const { return x() ; }
+    const float& g() const { return y() ; }
+    const float& b() const { return z() ; }
+    const float& a() const { return w() ; }
 
-    void SOFA_DEFAULTTYPE_API r(const float rr){ x()=rr; }
-    void SOFA_DEFAULTTYPE_API g(const float rr){ y()=rr; }
-    void SOFA_DEFAULTTYPE_API b(const float rr){ z()=rr; }
-    void SOFA_DEFAULTTYPE_API a(const float rr){ w()=rr; }
+    void r(const float r){ x()=r; }
+    void g(const float r){ y()=r; }
+    void b(const float r){ z()=r; }
+    void a(const float r){ w()=r; }
 
     friend std::istream& operator>>(std::istream& i, TRGBAColor<float>& t) ;
 

--- a/SofaKernel/framework/sofa/defaulttype/Color.h
+++ b/SofaKernel/framework/sofa/defaulttype/Color.h
@@ -36,21 +36,21 @@ namespace sofa
 namespace defaulttype
 {
 
-class SOFA_DEFAULTTYPE_API RGBAColorEMPTY : public sofa::defaulttype::Vec<4, double>
+class SOFA_DEFAULTTYPE_API RGBAColorEMPTY : public sofa::defaulttype::Vec<4, float>
 {
 public:
 };
 
 /**
- *  \brief encode a 4 RGBA component color as a specialized Vec<4, double> vector.
+ *  \brief encode a 4 RGBA component color as a specialized Vec<4, float> vector.
  */
-class SOFA_DEFAULTTYPE_API RGBAColor : public sofa::defaulttype::Vec<4, double>
+class SOFA_DEFAULTTYPE_API RGBAColor : public Vec4f
 {
 public:
     static RGBAColor fromString(const std::string& str) ;
-    static RGBAColor fromDouble(const double r, const double g, const double b, const double a) ;
-    static RGBAColor fromVec4(const Vec4d color) ;
-    static RGBAColor fromVec4(const Vec4f color) ;
+    static RGBAColor fromDouble(const float r, const float g, const float b, const float a) ;
+    static RGBAColor fromVec4(const Vec4d& color) ;
+    static RGBAColor fromVec4(const Vec4f& color) ;
     static bool read(const std::string& str, RGBAColor& color) ;
 
     static RGBAColor white()  { return RGBAColor(1.0,1.0,1.0,1.0); }
@@ -63,33 +63,33 @@ public:
     static RGBAColor yellow()  { return RGBAColor(1.0,1.0,0.0,1.0); }
     static RGBAColor gray()    { return RGBAColor(0.5,0.5,0.5,1.0); }
 
-    double& r(){ return x() ; }
-    double& g(){ return y() ; }
-    double& b(){ return z() ; }
-    double& a(){ return w() ; }
-    const double& r() const { return x() ; }
-    const double& g() const { return y() ; }
-    const double& b() const { return z() ; }
-    const double& a() const { return w() ; }
+    float& r(){ return x() ; }
+    float& g(){ return y() ; }
+    float& b(){ return z() ; }
+    float& a(){ return w() ; }
+    const float& r() const { return x() ; }
+    const float& g() const { return y() ; }
+    const float& b() const { return z() ; }
+    const float& a() const { return w() ; }
 
-    void r(const double r){ x()=r; }
-    void g(const double r){ y()=r; }
-    void b(const double r){ z()=r; }
-    void a(const double r){ w()=r; }
+    void r(const float r){ x()=r; }
+    void g(const float r){ y()=r; }
+    void b(const float r){ z()=r; }
+    void a(const float r){ w()=r; }
 
     friend std::istream& operator>>(std::istream& i, RGBAColor& t) ;
 
 public:
     RGBAColor() ;
-    RGBAColor(const  Vec4d&) ;
-    RGBAColor(const double r, const double g, const double b, const double a) ;
+    RGBAColor(const  Vec4f&) ;
+    RGBAColor(const float r, const float g, const float b, const float a) ;
 
 };
 
 template<>
-struct DataTypeInfo< RGBAColor > : public FixedArrayTypeInfo<sofa::defaulttype::Vec<4, double> >
+struct DataTypeInfo< RGBAColor > : public FixedArrayTypeInfo<Vec4f>
 {
-    static std::string name() { std::ostringstream o; o << "RGBAColor" << 4 << "d"; return o.str(); }
+    static std::string name() { std::ostringstream o; o << "RGBAColor" << 4 << "f"; return o.str(); }
 };
 
 } // namespace defaulttype

--- a/SofaKernel/framework/sofa/defaulttype/Color.h
+++ b/SofaKernel/framework/sofa/defaulttype/Color.h
@@ -50,6 +50,7 @@ public:
     static RGBAColor fromString(const std::string& str) ;
     static RGBAColor fromDouble(const double r, const double g, const double b, const double a) ;
     static RGBAColor fromVec4(const Vec4d color) ;
+    static RGBAColor fromVec4(const Vec4f color) ;
     static bool read(const std::string& str, RGBAColor& color) ;
 
     static RGBAColor white()  { return RGBAColor(1.0,1.0,1.0,1.0); }

--- a/SofaKernel/framework/sofa/defaulttype/Color.h
+++ b/SofaKernel/framework/sofa/defaulttype/Color.h
@@ -36,11 +36,15 @@ namespace sofa
 namespace defaulttype
 {
 
+class RGBAColorEMPTY : public sofa::defaulttype::Vec<4, double>
+{
+public:
+};
 
 /**
  *  \brief encode a 4 RGBA component color as a specialized Vec<4, double> vector.
  */
-class SOFA_DEFAULTTYPE_API RGBAColor : public sofa::defaulttype::Vec<4, double>
+class RGBAColor : public sofa::defaulttype::Vec<4, double>
 {
 public:
     static RGBAColor fromString(const std::string& str) ;

--- a/SofaKernel/framework/sofa/defaulttype/Color.h
+++ b/SofaKernel/framework/sofa/defaulttype/Color.h
@@ -64,19 +64,19 @@ public:
     using Vec<4,T>::z ;
     using Vec<4,T>::w ;
 
-    float& r(){ return x() ; }
-    float& g(){ return y() ; }
-    float& b(){ return z() ; }
-    float& a(){ return w() ; }
-    const float& r() const { return x() ; }
-    const float& g() const { return y() ; }
-    const float& b() const { return z() ; }
-    const float& a() const { return w() ; }
+    float& SOFA_DEFAULTTYPE_API r(){ return x() ; }
+    float& SOFA_DEFAULTTYPE_API g(){ return y() ; }
+    float& SOFA_DEFAULTTYPE_API b(){ return z() ; }
+    float& SOFA_DEFAULTTYPE_API a(){ return w() ; }
+    const float& SOFA_DEFAULTTYPE_API r() const { return x() ; }
+    const float& SOFA_DEFAULTTYPE_API g() const { return y() ; }
+    const float& SOFA_DEFAULTTYPE_API b() const { return z() ; }
+    const float& SOFA_DEFAULTTYPE_API a() const { return w() ; }
 
-    void r(const float r){ x()=r; }
-    void g(const float r){ y()=r; }
-    void b(const float r){ z()=r; }
-    void a(const float r){ w()=r; }
+    void SOFA_DEFAULTTYPE_API r(const float rr){ x()=rr; }
+    void SOFA_DEFAULTTYPE_API g(const float rr){ y()=rr; }
+    void SOFA_DEFAULTTYPE_API b(const float rr){ z()=rr; }
+    void SOFA_DEFAULTTYPE_API a(const float rr){ w()=rr; }
 
     friend std::istream& operator>>(std::istream& i, TRGBAColor<float>& t) ;
 

--- a/SofaKernel/framework/sofa/defaulttype/Color.h
+++ b/SofaKernel/framework/sofa/defaulttype/Color.h
@@ -81,12 +81,12 @@ public:
 
 };
 
-
+/*
 template<>
 struct DataTypeInfo< RGBAColor > : public FixedArrayTypeInfo<sofa::defaulttype::Vec<4, double> >
 {
     static std::string name() { std::ostringstream o; o << "RGBAColor" << 4 << "d"; return o.str(); }
-};
+};*/
 
 } // namespace defaulttype
 

--- a/SofaKernel/framework/sofa/defaulttype/Color.h
+++ b/SofaKernel/framework/sofa/defaulttype/Color.h
@@ -48,6 +48,16 @@ public:
     static RGBAColor fromVec4(const Vec4d color) ;
     static bool read(const std::string& str, RGBAColor& color) ;
 
+    static RGBAColor white()  { return RGBAColor(1.0,1.0,1.0,1.0); }
+    static RGBAColor black()  { return RGBAColor(0.0,0.0,0.0,1.0); }
+    static RGBAColor red()    { return RGBAColor(1.0,0.0,0.0,1.0); }
+    static RGBAColor green()  { return RGBAColor(0.0,1.0,0.0,1.0); }
+    static RGBAColor blue()   { return RGBAColor(0.0,0.0,1.0,1.0); }
+    static RGBAColor cyan()   { return RGBAColor(0.0,1.0,1.0,1.0); }
+    static RGBAColor magenta() { return RGBAColor(1.0,0.0,1.0,1.0); }
+    static RGBAColor yellow()  { return RGBAColor(1.0,1.0,0.0,1.0); }
+    static RGBAColor gray()    { return RGBAColor(0.5,0.5,0.5,1.0); }
+
     double& r(){ return x() ; }
     double& g(){ return y() ; }
     double& b(){ return z() ; }

--- a/SofaKernel/framework/sofa/defaulttype/Color.h
+++ b/SofaKernel/framework/sofa/defaulttype/Color.h
@@ -1,0 +1,82 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2016 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This library is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This library is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this library; if not, write to the Free Software Foundation,     *
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.          *
+*******************************************************************************
+*                              SOFA :: Framework                              *
+*                                                                             *
+* Contributions:                                                              *
+*     - damien.marchal@univ-lille1.fr                                         *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#ifndef SOFA_DEFAULTTYPE_COLOR_H
+#define SOFA_DEFAULTTYPE_COLOR_H
+#include <string>
+
+#include <sofa/helper/system/config.h>
+#include <sofa/defaulttype/Vec.h>
+
+namespace sofa
+{
+
+namespace defaulttype
+{
+
+
+/**
+ *  \brief encode a 4 RGBA component color as a specialized Vec<4, double> vector.
+ */
+class SOFA_DEFAULTTYPE_API RGBAColor : public Vec<4, double>
+{
+public:
+    static RGBAColor fromString(const std::string& str) ;
+    static RGBAColor fromDouble(const double r, const double g, const double b, const double a) ;
+    static RGBAColor fromVec4(const Vec4d color) ;
+    static bool read(const std::string& str, RGBAColor& color) ;
+
+    double& r(){ return x() ; }
+    double& g(){ return y() ; }
+    double& b(){ return z() ; }
+    double& a(){ return w() ; }
+    void r(const double r){ x()=r; }
+    void g(const double r){ y()=r; }
+    void b(const double r){ z()=r; }
+    void a(const double r){ w()=r; }
+
+    friend std::istream& operator>>(std::istream& i, RGBAColor& t) ;
+
+public:
+    RGBAColor() ;
+    RGBAColor(const  Vec4d&) ;
+    RGBAColor(const double r, const double g, const double b, const double a) ;
+
+};
+
+
+template<>
+struct DataTypeInfo< RGBAColor > : public FixedArrayTypeInfo<sofa::defaulttype::Vec<4, double> >
+{
+    static std::string name() { std::ostringstream o; o << "RGBAColor" << 4 << "d"; return o.str(); }
+};
+
+} // namespace defaulttype
+
+} // namespace sofa
+
+
+#endif
+

--- a/SofaKernel/framework/sofa/defaulttype/Color.h
+++ b/SofaKernel/framework/sofa/defaulttype/Color.h
@@ -40,7 +40,7 @@ namespace defaulttype
 /**
  *  \brief encode a 4 RGBA component color as a specialized Vec<4, double> vector.
  */
-class SOFA_DEFAULTTYPE_API RGBAColor : public Vec<4, double>
+class SOFA_DEFAULTTYPE_API RGBAColor : public sofa::defaulttype::Vec<4, double>
 {
 public:
     static RGBAColor fromString(const std::string& str) ;
@@ -81,12 +81,11 @@ public:
 
 };
 
-/*
 template<>
 struct DataTypeInfo< RGBAColor > : public FixedArrayTypeInfo<sofa::defaulttype::Vec<4, double> >
 {
     static std::string name() { std::ostringstream o; o << "RGBAColor" << 4 << "d"; return o.str(); }
-};*/
+};
 
 } // namespace defaulttype
 

--- a/SofaKernel/framework/sofa/defaulttype/Vec.h
+++ b/SofaKernel/framework/sofa/defaulttype/Vec.h
@@ -75,6 +75,7 @@ public:
     }
 
     /// Specific constructor for 1-element vectors.
+    template<int NN = N, typename std::enable_if<NN==1,int>::type = 0>
     void operator=(real r1)
     {
         set( r1 );

--- a/SofaKernel/framework/sofa/defaulttype/Vec.h
+++ b/SofaKernel/framework/sofa/defaulttype/Vec.h
@@ -42,7 +42,7 @@ namespace defaulttype
 enum NoInit { NOINIT }; ///< use when calling Vec or Mat constructor to skip initialization of values to 0
 
 template <int N, typename real=float>
-class SOFA_DEFAULTTYPE_API Vec : public helper::fixed_array<real,N>
+class Vec : public helper::fixed_array<real,N>
 {
 
     static_assert( N > 0, "" );

--- a/SofaKernel/framework/sofa/defaulttype/Vec.h
+++ b/SofaKernel/framework/sofa/defaulttype/Vec.h
@@ -42,7 +42,7 @@ namespace defaulttype
 enum NoInit { NOINIT }; ///< use when calling Vec or Mat constructor to skip initialization of values to 0
 
 template <int N, typename real=float>
-class Vec : public helper::fixed_array<real,N>
+class SOFA_DEFAULTTYPE_API Vec : public helper::fixed_array<real,N>
 {
 
     static_assert( N > 0, "" );

--- a/SofaKernel/framework/sofa/defaulttype/Vec.h
+++ b/SofaKernel/framework/sofa/defaulttype/Vec.h
@@ -141,6 +141,7 @@ public:
     }
 
     /// Specific set for 1-element vectors.
+    template<int NN = N, typename std::enable_if<NN==1,int>::type = 0>
     void set(real r1)
     {
         static_assert(N==1, "");
@@ -148,6 +149,7 @@ public:
     }
 
     /// Specific set for 2-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==2,int>::type = 0>
     void set(real r1, real r2)
     {
         static_assert(N == 2, "");
@@ -156,6 +158,7 @@ public:
     }
 
     /// Specific set for 3-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==3,int>::type = 0>
     void set(real r1, real r2, real r3)
     {
         static_assert(N == 3, "");
@@ -165,6 +168,7 @@ public:
     }
 
     /// Specific set for 4-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==4,int>::type = 0>
     void set(real r1, real r2, real r3, real r4)
     {
         static_assert(N == 4, "");
@@ -175,6 +179,7 @@ public:
     }
 
     /// Specific set for 5-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==5,int>::type = 0>
     void set(real r1, real r2, real r3, real r4, real r5)
     {
         static_assert(N == 5, "");
@@ -186,6 +191,7 @@ public:
     }
 
     /// Specific set for 6-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==6,int>::type = 0>
     void set(real r1, real r2, real r3, real r4, real r5, real r6)
     {
         static_assert(N == 6, "");
@@ -198,6 +204,7 @@ public:
     }
 
     /// Specific constructor for 7-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==7,int>::type = 0>
     void set(real r1, real r2, real r3, real r4, real r5, real r6, real r7)
     {
         static_assert(N == 7, "");
@@ -211,6 +218,7 @@ public:
     }
 
     /// Specific set for 8-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==8,int>::type = 0>
     void set(real r1, real r2, real r3, real r4, real r5, real r6, real r7, real r8)
     {
         static_assert(N == 8, "");
@@ -225,6 +233,7 @@ public:
     }
 
     /// Specific set for 9-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==9,int>::type = 0>
     void set(real r1, real r2, real r3, real r4, real r5, real r6, real r7, real r8, real r9)
     {
         static_assert(N == 9, "");
@@ -240,6 +249,7 @@ public:
     }
 
     /// Specific set for 12-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==12,int>::type = 0>
     void set(real r1, real r2, real r3, real r4, real r5, real r6, real r7, real r8, real r9, real r10, real r11, real r12)
     {
         static_assert(N == 12, "");
@@ -270,6 +280,7 @@ public:
 
 
     /// Constructor from an N-1 elements vector and an additional value (added at the end).
+    //template<int NN = N, typename std::enable_if<(NN>1),int>::type = 0>
     Vec(const Vec<N-1,real>& v, real r1)
     {
         static_assert(N > 1, "");
@@ -301,24 +312,28 @@ public:
     }
 
     /// Special access to first element.
+    template<int NN = N, typename std::enable_if<(NN>=1),int>::type = 0>
     real& x()
     {
         static_assert(N >= 1, "");
         return this->elems[0];
     }
     /// Special access to second element.
+    template<int NN = N, typename std::enable_if<(NN>=2),int>::type = 0>
     real& y()
     {
         static_assert(N >= 2, "");
         return this->elems[1];
     }
     /// Special access to third element.
+    template<int NN = N, typename std::enable_if<(NN>=3),int>::type = 0>
     real& z()
     {
         static_assert(N >= 3, "");
         return this->elems[2];
     }
     /// Special access to fourth element.
+    template<int NN = N, typename std::enable_if<(NN>=4),int>::type = 0>
     real& w()
     {
         static_assert(N >= 4, "");
@@ -326,24 +341,28 @@ public:
     }
 
     /// Special const access to first element.
+    template<int NN = N, typename std::enable_if<(NN>=1),int>::type = 0>
     const real& x() const
     {
         static_assert(N >= 1, "");
         return this->elems[0];
     }
     /// Special const access to second element.
+    template<int NN = N, typename std::enable_if<(NN>=2),int>::type = 0>
     const real& y() const
     {
         static_assert(N >= 2, "");
         return this->elems[1];
     }
     /// Special const access to third element.
+    template<int NN = N, typename std::enable_if<(NN>=3),int>::type = 0>
     const real& z() const
     {
         static_assert(N >= 3, "");
         return this->elems[2];
     }
     /// Special const access to fourth element.
+    template<int NN = N, typename std::enable_if<(NN>=4),int>::type = 0>
     const real& w() const
     {
         static_assert(N >= 4, "");
@@ -689,7 +708,7 @@ public:
     /// return true iff norm()==1
     bool isNormalized( real threshold=std::numeric_limits<real>::epsilon()*(real)10 ) const { return helper::rabs<real>( norm2()-(real)1 ) <= threshold; }
 
-    template<typename R>
+    template<typename R,int NN = N, typename std::enable_if<(NN==3),int>::type = 0>
     Vec cross( const Vec<3,R>& b ) const
     {
         static_assert(N == 3, "");

--- a/SofaKernel/framework/sofa/defaulttype/Vec.h
+++ b/SofaKernel/framework/sofa/defaulttype/Vec.h
@@ -68,6 +68,7 @@ public:
     }
 
     /// Specific constructor for 1-element vectors.
+    template<int NN = N, typename std::enable_if<NN==1,int>::type = 0>
     explicit Vec(real r1)
     {
         set( r1 );
@@ -80,61 +81,70 @@ public:
     }
 
     /// Specific constructor for 2-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==2,int>::type = 0>
     Vec(real r1, real r2)
     {
         set( r1, r2 );
     }
 
     /// Specific constructor for 3-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==3,int>::type = 0>
     Vec(real r1, real r2, real r3)
     {
         set( r1, r2, r3 );
     }
 
     /// Specific constructor for 4-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==4,int>::type = 0>
     Vec(real r1, real r2, real r3, real r4)
     {
         set( r1, r2, r3, r4 );
     }
 
     /// Specific constructor for 5-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==5,int>::type = 0>
     Vec(real r1, real r2, real r3, real r4, real r5)
     {
         set( r1, r2, r3, r4, r5 );
     }
 
     /// Specific constructor for 6-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==6,int>::type = 0>
     Vec(real r1, real r2, real r3, real r4, real r5, real r6)
     {
         set( r1, r2, r3, r4, r5, r6 );
     }
 
     /// Specific constructor for 6-elements vectors.
-    template<typename R, typename T>
+    template<typename R, typename T, int NN=N, typename std::enable_if<NN==6,int>::type = 0 >
     Vec( const Vec<3,R>& a , const Vec<3,T>& b )
     {
         set( a[0], a[1], a[2], b[0], b[1], b[2] );
     }
 
     /// Specific constructor for 7-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==7,int>::type = 0>
     Vec(real r1, real r2, real r3, real r4, real r5, real r6, real r7)
     {
         set( r1, r2, r3, r4, r5, r6, r7 );
     }
 
     /// Specific constructor for 8-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==8,int>::type = 0>
     Vec(real r1, real r2, real r3, real r4, real r5, real r6, real r7, real r8)
     {
         set( r1, r2, r3, r4, r5, r6, r7, r8 );
     }
 
     /// Specific constructor for 9-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==9,int>::type = 0>
     Vec(real r1, real r2, real r3, real r4, real r5, real r6, real r7, real r8, real r9)
     {
         set( r1, r2, r3, r4, r5, r6, r7, r8, r9 );
     }
 
     /// Specific constructor for 12-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==12,int>::type = 0>
     Vec(real r1, real r2, real r3, real r4, real r5, real r6, real r7, real r8, real r9, real r10, real r11, real r12)
     {
         set( r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12 );

--- a/SofaKernel/framework/sofa/helper/fixed_array.h
+++ b/SofaKernel/framework/sofa/helper/fixed_array.h
@@ -71,7 +71,7 @@ namespace helper
 {
 
 template<class T, std::size_t N>
-class fixed_array
+class SOFA_DEFAULTTYPE_API fixed_array
 {
 public:
     T elems[N];    // fixed-size array of elements of type T

--- a/SofaKernel/framework/sofa/helper/fixed_array.h
+++ b/SofaKernel/framework/sofa/helper/fixed_array.h
@@ -1,24 +1,21 @@
 /******************************************************************************
 *       SOFA, Simulation Open-Framework Architecture, development version     *
-*                (c) 2006-2016 INRIA, USTL, UJF, CNRS, MGH                    *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
 *                                                                             *
-* This library is free software; you can redistribute it and/or modify it     *
+* This program is free software; you can redistribute it and/or modify it     *
 * under the terms of the GNU Lesser General Public License as published by    *
 * the Free Software Foundation; either version 2.1 of the License, or (at     *
 * your option) any later version.                                             *
 *                                                                             *
-* This library is distributed in the hope that it will be useful, but WITHOUT *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
 * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
 * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
 * for more details.                                                           *
 *                                                                             *
 * You should have received a copy of the GNU Lesser General Public License    *
-* along with this library; if not, write to the Free Software Foundation,     *
-* Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.          *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
 *******************************************************************************
-*                              SOFA :: Framework                              *
-*                                                                             *
-* Authors: The SOFA Team (see Authors.txt)                                    *
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
@@ -35,6 +32,7 @@
  * This software is provided "as is" without express or implied
  * warranty, and with no claim as to its suitability for any purpose.
  *
+ * 17 Jan 2017 - add std::enable_if to replace static_assert (Damien Marchal)
  * 29 Jun 2005 - remove boost includes and reverse iterators. (Jeremie Allard)
  * 23 Aug 2002 - fix for Non-MSVC compilers combined with MSVC libraries.
  * 05 Aug 2001 - minor update (Nico Josuttis)
@@ -52,9 +50,6 @@
 #if !defined(__GNUC__) || (__GNUC__ > 3 || (_GNUC__ == 3 && __GNUC_MINOR__ > 3))
 #pragma once
 #endif
-
-#include <sofa/helper/system/config.h>
-#include <sofa/helper/helper.h>
 
 #include <cstddef>
 #include <stdexcept>
@@ -94,6 +89,7 @@ public:
 
 
     /// Specific constructor for 1-element vectors.
+    template<int NN = N, typename std::enable_if<NN==1,int>::type = 0>
     explicit fixed_array(value_type r1)
     {
         static_assert(N==1, "");
@@ -101,6 +97,7 @@ public:
     }
 
     /// Specific constructor for 2-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==2,int>::type = 0>
     fixed_array(value_type r1, value_type r2)
     {
         static_assert(N == 2, "");
@@ -109,6 +106,7 @@ public:
     }
 
     /// Specific constructor for 3-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==3,int>::type = 0>
     fixed_array(value_type r1, value_type r2, value_type r3)
     {
         static_assert(N == 3, "");
@@ -118,6 +116,7 @@ public:
     }
 
     /// Specific constructor for 4-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==4,int>::type = 0>
     fixed_array(value_type r1, value_type r2, value_type r3, value_type r4)
     {
         static_assert(N == 4, "");
@@ -128,6 +127,7 @@ public:
     }
 
     /// Specific constructor for 5-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==5,int>::type = 0>
     fixed_array(value_type r1, value_type r2, value_type r3, value_type r4, value_type r5)
     {
         static_assert(N == 5, "");
@@ -139,6 +139,7 @@ public:
     }
 
     /// Specific constructor for 6-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==6,int>::type = 0>
     fixed_array(value_type r1, value_type r2, value_type r3, value_type r4, value_type r5, value_type r6)
     {
         static_assert(N == 6, "");
@@ -151,6 +152,7 @@ public:
     }
 
     /// Specific constructor for 7-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==7,int>::type = 0>
     fixed_array(value_type r1, value_type r2, value_type r3, value_type r4, value_type r5, value_type r6, value_type r7)
     {
         static_assert(N == 7, "");
@@ -164,6 +166,7 @@ public:
     }
 
     /// Specific constructor for 8-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==8,int>::type = 0>
     fixed_array(value_type r1, value_type r2, value_type r3, value_type r4, value_type r5, value_type r6, value_type r7, value_type r8)
     {
         static_assert(N == 8, "");
@@ -178,6 +181,7 @@ public:
     }
 
     /// Specific constructor for 9-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==9,int>::type = 0>
     fixed_array(value_type r1, value_type r2, value_type r3, value_type r4, value_type r5, value_type r6, value_type r7, value_type r8, value_type r9)
     {
         static_assert(N == 9, "");
@@ -193,6 +197,7 @@ public:
     }
 
     /// Specific constructor for 10-elements vectors.
+    template<int NN = N, typename std::enable_if<NN==10,int>::type = 0>
     fixed_array(value_type r1, value_type r2, value_type r3, value_type r4, value_type r5, value_type r6, value_type r7, value_type r8, value_type r9, value_type r10)
     {
         static_assert(N == 10, "");

--- a/SofaKernel/framework/sofa/helper/fixed_array.h
+++ b/SofaKernel/framework/sofa/helper/fixed_array.h
@@ -71,7 +71,7 @@ namespace helper
 {
 
 template<class T, std::size_t N>
-class SOFA_DEFAULTTYPE_API fixed_array
+class fixed_array
 {
 public:
     T elems[N];    // fixed-size array of elements of type T

--- a/SofaKernel/framework/sofa/helper/fixed_array.h
+++ b/SofaKernel/framework/sofa/helper/fixed_array.h
@@ -51,6 +51,9 @@
 #pragma once
 #endif
 
+#include <sofa/helper/system/config.h>
+#include <sofa/helper/helper.h>
+
 #include <cstddef>
 #include <stdexcept>
 #include <iterator>


### PR DESCRIPTION
This PR adds a RGBAColor type in defaulttype as well as dedicated tests. 

There is several advantage of doing so:
      - no ambiguity in the code between a rgba color and vector4.
      - the code needed to build colors from their name, hexadecimal or list of float is factored in  this class (while currently there is at least 8 duplications in the sofa code base)
      - unifying the underlying data also offer the possibility to offer consistent user interface for colors 

This PR will be the ground to solve issue #https://github.com/sofa-framework/sofa/issues/64. 

This PR have no impact on the sofa source code.

Checklist to be merge: 
  - [x] succeed on each compilation setup on the CI.
  - [x] does not generates new test failure. 
  - [x] does not seems to break existing scenes. 
  - [x] does not seems to break API compatibility.  
  - [x] introduces new component with tests & documentation. 
  - [x] is now 1 week old and no one send a 'no go' comment. 
