### PR TITLE
[CI] Add VS-2013 support

### DIFF
--- a/scripts/ci/compile.sh
+++ b/scripts/ci/compile.sh
@@ -6,7 +6,7 @@
 ## Significant environnement variables:
 # - CI_MAKE_OPTIONS       # additional arguments to pass to make
 # - CI_ARCH               # x86|amd64  (32-bit or 64-bit build - Windows-specific)
-# - CI_COMPILER           # important for Visual Studio (VS-2012 or VS-2015)
+# - CI_COMPILER           # important for Visual Studio (VS-2012, VS-2013 or VS-2015)
 
 # Exit on error
 set -o errexit
@@ -45,9 +45,15 @@ call-make() {
             echo "Calling $COMSPEC /c \"$vcvarsall & nmake $CI_MAKE_OPTIONS\""
             $COMSPEC /c "$vcvarsall & nmake $CI_MAKE_OPTIONS"
         else
-            local vcvarsall="call \"%VS110COMNTOOLS%..\\..\\VC\vcvarsall.bat\" $CI_ARCH"
-            echo "Calling $COMSPEC /c \"$vcvarsall & nmake $CI_MAKE_OPTIONS\""
-            $COMSPEC /c "$vcvarsall & nmake $CI_MAKE_OPTIONS"
+            if [ "$CI_COMPILER" = "VS-2013" ]; then
+                local vcvarsall="call \"%VS120COMNTOOLS%..\\..\\VC\vcvarsall.bat\" $CI_ARCH"
+                echo "Calling $COMSPEC /c \"$vcvarsall & nmake $CI_MAKE_OPTIONS\""
+                $COMSPEC /c "$vcvarsall & nmake $CI_MAKE_OPTIONS"
+            else
+                local vcvarsall="call \"%VS110COMNTOOLS%..\\..\\VC\vcvarsall.bat\" $CI_ARCH"
+                echo "Calling $COMSPEC /c \"$vcvarsall & nmake $CI_MAKE_OPTIONS\""
+                $COMSPEC /c "$vcvarsall & nmake $CI_MAKE_OPTIONS"
+            fi
         fi
     else
         make $CI_MAKE_OPTIONS

--- a/scripts/ci/compile.sh
+++ b/scripts/ci/compile.sh
@@ -39,22 +39,16 @@ if [ -z "$CI_ARCH" ]; then CI_ARCH="x86"; fi
 
 call-make() {
     if [[ "$(uname)" != "Darwin" && "$(uname)" != "Linux" ]]; then
-        # We need to call vcvarsall.bat before nmake to setup compiler stuff
+        # Call vcvarsall.bat first to setup environment
         if [ "$CI_COMPILER" = "VS-2015" ]; then
-            local vcvarsall="call \"%VS140COMNTOOLS%..\\..\\VC\vcvarsall.bat\" $CI_ARCH"
-            echo "Calling $COMSPEC /c \"$vcvarsall & nmake $CI_MAKE_OPTIONS\""
-            $COMSPEC /c "$vcvarsall & nmake $CI_MAKE_OPTIONS"
+            vcvarsall="call \"%VS140COMNTOOLS%..\\..\\VC\vcvarsall.bat\" $CI_ARCH"
+        elif [ "$CI_COMPILER" = "VS-2013" ]; then
+            vcvarsall="call \"%VS120COMNTOOLS%..\\..\\VC\vcvarsall.bat\" $CI_ARCH"
         else
-            if [ "$CI_COMPILER" = "VS-2013" ]; then
-                local vcvarsall="call \"%VS120COMNTOOLS%..\\..\\VC\vcvarsall.bat\" $CI_ARCH"
-                echo "Calling $COMSPEC /c \"$vcvarsall & nmake $CI_MAKE_OPTIONS\""
-                $COMSPEC /c "$vcvarsall & nmake $CI_MAKE_OPTIONS"
-            else
-                local vcvarsall="call \"%VS110COMNTOOLS%..\\..\\VC\vcvarsall.bat\" $CI_ARCH"
-                echo "Calling $COMSPEC /c \"$vcvarsall & nmake $CI_MAKE_OPTIONS\""
-                $COMSPEC /c "$vcvarsall & nmake $CI_MAKE_OPTIONS"
-            fi
+            vcvarsall="call \"%VS110COMNTOOLS%..\\..\\VC\vcvarsall.bat\" $CI_ARCH"
         fi
+        echo "Calling $COMSPEC /c \"$vcvarsall & nmake $CI_MAKE_OPTIONS\""
+        $COMSPEC /c "$vcvarsall & nmake $CI_MAKE_OPTIONS"
     else
         make $CI_MAKE_OPTIONS
     fi

--- a/scripts/ci/configure.sh
+++ b/scripts/ci/configure.sh
@@ -86,8 +86,8 @@ call-cmake() {
         else
             vcvarsall="call \"%VS110COMNTOOLS%..\\..\\VC\vcvarsall.bat\" $CI_ARCH"
         fi
-        echo "Calling $COMSPEC /c \"$vcvarsall & cmake $CI_MAKE_OPTIONS\""
-        $COMSPEC /c "$vcvarsall & cmake $CI_MAKE_OPTIONS"
+        echo "Calling $COMSPEC /c \"$vcvarsall & cmake $*\""
+        $COMSPEC /c "$vcvarsall & cmake $*"
     else
         cmake "$@"
     fi

--- a/scripts/ci/configure.sh
+++ b/scripts/ci/configure.sh
@@ -11,7 +11,7 @@
 # - CI_ARCH = x86 | amd64     (for Windows builds)
 # - CI_BUILD_TYPE             Debug|Release
 # - CC and CXX
-# - CI_COMPILER               # important for Visual Studio paths (VS-2012 or VS-2015)
+# - CI_COMPILER               # important for Visual Studio paths (VS-2012, VS-2013 or VS-2015)
 # About available libraries:
 # - CI_HAVE_BOOST
 # - CI_BOOST_PATH             (empty string if installed in standard location)
@@ -84,9 +84,15 @@ call-cmake() {
             echo "Calling $COMSPEC /c \"$vcvarsall & cmake $*\""
             $COMSPEC /c "$vcvarsall & cmake $*"
         else
-            local vcvarsall="call \"%VS110COMNTOOLS%..\\..\\VC\vcvarsall.bat\" $CI_ARCH"
-            echo "Calling $COMSPEC /c \"$vcvarsall & cmake $*\""
-            $COMSPEC /c "$vcvarsall & cmake $*"
+            if [ "$CI_COMPILER" = "VS-2013" ]; then
+                local vcvarsall="call \"%VS120COMNTOOLS%..\\..\\VC\vcvarsall.bat\" $CI_ARCH"
+                echo "Calling $COMSPEC /c \"$vcvarsall & cmake $*\""
+                $COMSPEC /c "$vcvarsall & cmake $*"
+            else
+                local vcvarsall="call \"%VS110COMNTOOLS%..\\..\\VC\vcvarsall.bat\" $CI_ARCH"
+                echo "Calling $COMSPEC /c \"$vcvarsall & cmake $*\""
+                $COMSPEC /c "$vcvarsall & cmake $*"
+            fi
         fi
     else
         cmake "$@"

--- a/scripts/ci/configure.sh
+++ b/scripts/ci/configure.sh
@@ -77,23 +77,17 @@ generator() {
 }
 
 call-cmake() {
-    if [ $(uname) != Darwin -a $(uname) != Linux ]; then
-        # Run cmake after calling vcvarsall.bat to setup compiler stuff
+    if [[ "$(uname)" != "Darwin" && "$(uname)" != "Linux" ]]; then
+        # Call vcvarsall.bat first to setup environment
         if [ "$CI_COMPILER" = "VS-2015" ]; then
-            local vcvarsall="call \"%VS140COMNTOOLS%..\\..\\VC\vcvarsall.bat\" $CI_ARCH"
-            echo "Calling $COMSPEC /c \"$vcvarsall & cmake $*\""
-            $COMSPEC /c "$vcvarsall & cmake $*"
+            vcvarsall="call \"%VS140COMNTOOLS%..\\..\\VC\vcvarsall.bat\" $CI_ARCH"
+        elif [ "$CI_COMPILER" = "VS-2013" ]; then
+            vcvarsall="call \"%VS120COMNTOOLS%..\\..\\VC\vcvarsall.bat\" $CI_ARCH"
         else
-            if [ "$CI_COMPILER" = "VS-2013" ]; then
-                local vcvarsall="call \"%VS120COMNTOOLS%..\\..\\VC\vcvarsall.bat\" $CI_ARCH"
-                echo "Calling $COMSPEC /c \"$vcvarsall & cmake $*\""
-                $COMSPEC /c "$vcvarsall & cmake $*"
-            else
-                local vcvarsall="call \"%VS110COMNTOOLS%..\\..\\VC\vcvarsall.bat\" $CI_ARCH"
-                echo "Calling $COMSPEC /c \"$vcvarsall & cmake $*\""
-                $COMSPEC /c "$vcvarsall & cmake $*"
-            fi
+            vcvarsall="call \"%VS110COMNTOOLS%..\\..\\VC\vcvarsall.bat\" $CI_ARCH"
         fi
+        echo "Calling $COMSPEC /c \"$vcvarsall & cmake $CI_MAKE_OPTIONS\""
+        $COMSPEC /c "$vcvarsall & cmake $CI_MAKE_OPTIONS"
     else
         cmake "$@"
     fi


### PR DESCRIPTION
This PR adds support for Visual Studio 13 in the ci scripts. VS2013 builds (on ci) won't work without this.
As soon as the builds of every non-VS2013 configurations are ok on this branch (see https://www.sofa-framework.org/dash/index.php?branch=origin%2Fci-vs2013 ) , I believe it is save to merge.