### PR TITLE
[GUI] Fix #131 - Mouse events are now transmitted to the scene (with QtGLViewer)

### DIFF
--- a/applications/sofa/gui/qt/viewer/qgl/QtGLViewer.cpp
+++ b/applications/sofa/gui/qt/viewer/qgl/QtGLViewer.cpp
@@ -993,7 +993,12 @@ void QtGLViewer::keyReleaseEvent ( QKeyEvent * e )
 void QtGLViewer::mousePressEvent ( QMouseEvent * e )
 {
     if( ! mouseEvent(e) )
-        QGLViewer::mousePressEvent(e);
+    {
+        if ( isControlPressed() )
+            SofaViewer::mousePressEvent(e);
+        else
+            QGLViewer::mousePressEvent(e);
+    }
 }
 
 
@@ -1002,7 +1007,12 @@ void QtGLViewer::mousePressEvent ( QMouseEvent * e )
 void QtGLViewer::mouseReleaseEvent ( QMouseEvent * e )
 {
     if( ! mouseEvent(e) )
-        QGLViewer::mouseReleaseEvent(e);
+    {
+        if (isControlPressed())
+            SofaViewer::mouseReleaseEvent(e);
+        else
+            QGLViewer::mouseReleaseEvent(e);
+    }
 }
 
 
@@ -1012,7 +1022,12 @@ void QtGLViewer::mouseReleaseEvent ( QMouseEvent * e )
 void QtGLViewer::mouseMoveEvent ( QMouseEvent * e )
 {
     if( ! mouseEvent(e) )
-        QGLViewer::mouseMoveEvent(e);
+    {
+        if ( isControlPressed() )
+            SofaViewer::mouseMoveEvent(e);
+        else
+            QGLViewer::mouseMoveEvent(e);
+    }
 }
 
 


### PR DESCRIPTION
Mouse events were not sent to the scene as they should (according to https://www.sofa-framework.org/community/doc/programming-with-sofa/components-api/events-in-sofa/)