### PR TITLE
[CI] Replace 'make' by 'ninja' when available. 

### DIFF
--- a/scripts/ci/compile.sh
+++ b/scripts/ci/compile.sh
@@ -38,7 +38,10 @@ if [ -z "$CI_ARCH" ]; then CI_ARCH="x86"; fi
 ### Actual work
 
 call-make() {
-    if [[ "$(uname)" != "Darwin" && "$(uname)" != "Linux" ]]; then
+    if [ -x "$(command -v ninja)" ]; then
+        echo "Ninja ! (VRAAOUUUUUMmmmm)"
+        ninja $CI_MAKE_OPTIONS
+    elif [[ "$(uname)" != "Darwin" && "$(uname)" != "Linux" ]]; then
         # Call vcvarsall.bat first to setup environment
         if [ "$CI_COMPILER" = "VS-2015" ]; then
             vcvarsall="call \"%VS140COMNTOOLS%..\\..\\VC\vcvarsall.bat\" $CI_ARCH"

--- a/scripts/ci/configure.sh
+++ b/scripts/ci/configure.sh
@@ -69,7 +69,9 @@ if [ -z "$CI_BUILD_TYPE" ]; then CI_BUILD_TYPE="Release"; fi
 ## Utils
 
 generator() {
-    if [[ $(uname) = Darwin || $(uname) = Linux ]]; then
+    if [ -x "$(command -v ninja)" ]; then
+        echo "Ninja"
+    elif [[ $(uname) = Darwin || $(uname) = Linux ]]; then
         echo "Unix Makefiles"
     else
         echo "\"NMake Makefiles\""
@@ -77,6 +79,7 @@ generator() {
 }
 
 call-cmake() {
+    pwd
     if [[ "$(uname)" != "Darwin" && "$(uname)" != "Linux" ]]; then
         # Call vcvarsall.bat first to setup environment
         if [ "$CI_COMPILER" = "VS-2015" ]; then


### PR DESCRIPTION
Add support for the Ninja generator and build system. 

Ninja is faster when doing incremental builds and it reports the number of file compiled like this [45/1384] instead of a percentage [5%]].

Having the numbers is very useful to debug CI/ccach problem.  