### PR TITLE
[SofaKernel] Fix the Filemonitor_test random failure on MacOs

### DIFF
--- a/SofaKernel/framework/framework_test/helper/system/FileMonitor_test.cpp
+++ b/SofaKernel/framework/framework_test/helper/system/FileMonitor_test.cpp
@@ -38,10 +38,6 @@ void createAFilledFile(const string filename, unsigned int rep){
 
 void waitForFileEvents()
 {
-    // on osx there is a latency between 0.2 and 0.5s for file events...
-#ifdef __APPLE__
-	sleep(1);
-#endif
 	// on windows we use file date, which resoution is assumed (by us) to be below this value in ms
 #ifdef WIN32
 	Sleep(100);
@@ -103,7 +99,7 @@ TEST(FileMonitor, addFileTwice_test)
     createAFilledFile(getPath("existing.txt"), 10) ;
 
     waitForFileEvents();
-    FileMonitor::updates(0) ;
+    FileMonitor::updates(2) ;
 
     // The listener should be notified 1 times with the same event.
     EXPECT_EQ( listener.m_files.size(), 1u) ;
@@ -128,7 +124,7 @@ TEST(FileMonitor, updateNoChange_test)
 
     FileMonitor::addFile(getPath("existing.txt"), &listener) ;
     waitForFileEvents();
-    FileMonitor::updates(0) ;
+    FileMonitor::updates(2) ;
     EXPECT_EQ( listener.m_files.size(), 0u) ;
 
     FileMonitor::removeListener(&listener) ;
@@ -139,13 +135,13 @@ TEST(FileMonitor, fileChange_test)
     MyFileListener listener ;
 
     FileMonitor::addFile(getPath("existing.txt"), &listener) ;
-	waitForFileEvents();
-	FileMonitor::updates(0) ;
+    //waitForFileEvents();
+    //FileMonitor::updates(2) ;
 
     // change the file content..
     createAFilledFile(getPath("existing.txt"), 10) ;
     waitForFileEvents();
-    FileMonitor::updates(0) ;
+    FileMonitor::updates(2) ;
     EXPECT_EQ( listener.m_files.size(), 1u) ;
 
     FileMonitor::removeListener(&listener) ;
@@ -156,7 +152,7 @@ TEST(FileMonitor, fileChangeTwice_test)
     MyFileListener listener ;
 
     FileMonitor::addFile(getPath("existing.txt"), &listener) ;
-    FileMonitor::updates(0) ;
+    //FileMonitor::updates(2) ;
 
     // change the file content 2x to test if the events are coalesced.
     listener.m_files.clear() ;
@@ -164,7 +160,7 @@ TEST(FileMonitor, fileChangeTwice_test)
     createAFilledFile(getPath("existing.txt"), 200) ;
 
     waitForFileEvents();
-    FileMonitor::updates(0) ;
+    FileMonitor::updates(2) ;
     EXPECT_EQ( listener.m_files.size(), 1u) ;
 
     FileMonitor::removeListener(&listener) ;
@@ -177,7 +173,7 @@ TEST(FileMonitor, fileListenerRemoved_test)
 
     FileMonitor::addFile(getPath("existing.txt"), &listener1) ;
     FileMonitor::addFile(getPath("existing.txt"), &listener2) ;
-    FileMonitor::updates(0) ;
+    //FileMonitor::updates(2) ;
 
     // change the file content 2x to test if the events are coalesced.
     listener1.m_files.clear() ;
@@ -187,7 +183,7 @@ TEST(FileMonitor, fileListenerRemoved_test)
     FileMonitor::removeFileListener(getPath("existing.txt"), &listener1) ;
 
     waitForFileEvents();
-    FileMonitor::updates(0) ;
+    FileMonitor::updates(2) ;
     EXPECT_EQ( listener1.m_files.size(), 0u) ;
     EXPECT_EQ( listener2.m_files.size(), 1u) ;
 
@@ -202,7 +198,7 @@ TEST(FileMonitor, listenerRemoved_test)
 
     FileMonitor::addFile(getPath("existing.txt"), &listener1) ;
     FileMonitor::addFile(getPath("existing.txt"), &listener2) ;
-    FileMonitor::updates(0) ;
+    //FileMonitor::updates(2) ;
 
     // change the file content 2x to test if the events are coalesced.
     listener1.m_files.clear() ;
@@ -212,7 +208,7 @@ TEST(FileMonitor, listenerRemoved_test)
     FileMonitor::removeListener(&listener1) ;
 
     waitForFileEvents();
-    FileMonitor::updates(0) ;
+    FileMonitor::updates(2) ;
     EXPECT_EQ( listener1.m_files.size(), 0u) ;
     EXPECT_EQ( listener2.m_files.size(), 1u) ;
 
@@ -225,14 +221,14 @@ TEST(FileMonitor, fileChange2_test)
     MyFileListener listener ;
 
     FileMonitor::addFile(getPath(""),"existing.txt", &listener) ;
-    waitForFileEvents();
-    FileMonitor::updates(0) ;
+    //waitForFileEvents();
+    //FileMonitor::updates(2) ;
 
     // change the file content..
     createAFilledFile(getPath("existing.txt"), 10) ;
 
     waitForFileEvents();
-    FileMonitor::updates(0) ;
+    FileMonitor::updates(2) ;
     EXPECT_EQ( listener.m_files.size(), 1u) ;
 
     FileMonitor::removeListener(&listener) ;


### PR DESCRIPTION
Update: 

- now with a correct implementation of the timeout parameter. Tests should not fail randomly now...
- also updated the filemonitor tests to use this timeout parameter correctly