### PR TITLE
Fix VS2013-options compilation: Usage of typename outside of template is not allowed in C++03

### DIFF
--- a/applications/plugins/Flexible/quadrature/GaussPointSmoother.h
+++ b/applications/plugins/Flexible/quadrature/GaussPointSmoother.h
@@ -57,10 +57,10 @@ public:
     //@{
     typedef core::behavior::ShapeFunctionTypes<spatial_dimensions,Real> ShapeFunctionType;
     typedef core::behavior::BaseShapeFunction<ShapeFunctionType> BaseShapeFunction;
-    typedef typename BaseShapeFunction::VReal VReal;
-    typedef typename BaseShapeFunction::VecVReal VecVReal;
-    typedef typename BaseShapeFunction::VRef VRef;
-    typedef typename BaseShapeFunction::VecVRef VecVRef;
+    typedef BaseShapeFunction::VReal VReal;
+    typedef BaseShapeFunction::VecVReal VecVReal;
+    typedef BaseShapeFunction::VRef VRef;
+    typedef BaseShapeFunction::VecVRef VecVRef;
     //@}
 
     Data< VTransform > d_inputTransforms;   ///< parent transforms from another GP sampler


### PR DESCRIPTION
In order to allow the compilation on VS2013-options, this PR removes the typename keyword used outside a template :

This is not allowed in C++03 (I guess VS2013 uses this version of the standard)

However this restriction has been lifted in C++0x/11 (which the other compilers use, if I'm not wrong) and this usage is allowed but **not required**.