### PR TITLE
[SofaPython] proper error handling

### DIFF
--- a/applications/plugins/SofaPython/Binding_Base.cpp
+++ b/applications/plugins/SofaPython/Binding_Base.cpp
@@ -54,8 +54,7 @@ extern "C" PyObject * Base_findData(PyObject *self, PyObject *args )
         }
 
         PyErr_BadArgument();
-
-        Py_RETURN_NONE;
+        return NULL;
     }
 
 
@@ -90,7 +89,7 @@ extern "C" PyObject * Base_findLink(PyObject *self, PyObject *args)
         }
 
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     return SP_BUILD_PYPTR(Link,BaseLink,link,false);
@@ -171,7 +170,7 @@ extern "C" PyObject * Base_getDataFields(PyObject *self, PyObject * /*args*/)
     if(!component)
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     const sofa::helper::vector<BaseData*> dataFields = component->getDataFields();

--- a/applications/plugins/SofaPython/Binding_BaseContext.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseContext.cpp
@@ -82,7 +82,7 @@ extern "C" PyObject * BaseContext_createObject_Impl(PyObject * self, PyObject * 
     if (!PyArg_ParseTuple(args, "s",&type))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     // temporarily, the name is set to the type name.
@@ -124,7 +124,7 @@ extern "C" PyObject * BaseContext_createObject_Impl(PyObject * self, PyObject * 
         for (std::vector< std::string >::const_iterator it = desc.getErrors().begin(); it != desc.getErrors().end(); ++it)
             SP_MESSAGE_ERROR(*it);
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
 
@@ -190,7 +190,7 @@ extern "C" PyObject * BaseContext_getObject(PyObject * self, PyObject * args, Py
     if (!context || !path)
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     BaseObject::SPtr sptr;
     context->get<BaseObject>(sptr,path);
@@ -219,7 +219,7 @@ extern "C" PyObject * BaseContext_getObject_noWarning(PyObject * self, PyObject 
     if (!context || !path)
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     BaseObject::SPtr sptr;
     context->get<BaseObject>(sptr,path);
@@ -246,7 +246,7 @@ extern "C" PyObject * BaseContext_getObjects(PyObject * self, PyObject * args)
     if (!context)
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     sofa::core::objectmodel::BaseContext::SearchDirection search_direction_enum= sofa::core::objectmodel::BaseContext::Local;

--- a/applications/plugins/SofaPython/Binding_BaseLoader.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseLoader.cpp
@@ -50,7 +50,7 @@ extern "C" PyObject * BaseLoader_setFilename(PyObject *self, PyObject * args)
     if (!PyArg_ParseTuple(args, "s",&filename))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     obj->setFilename(filename);
     Py_RETURN_NONE;

--- a/applications/plugins/SofaPython/Binding_BaseMapping.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseMapping.cpp
@@ -76,7 +76,7 @@ extern "C" PyObject * BaseMapping_setFrom(PyObject * self, PyObject * args)
     {
         SP_MESSAGE_ERROR( "BaseMapping_setFrom: is not a BaseState*" );
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     mapping->setFrom( from );
@@ -96,7 +96,7 @@ extern "C" PyObject * BaseMapping_setTo(PyObject * self, PyObject * args)
     if (!to)
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     mapping->setTo( to );

--- a/applications/plugins/SofaPython/Binding_BaseMechanicalState.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseMechanicalState.cpp
@@ -40,7 +40,7 @@ extern "C" PyObject * BaseMechanicalState_applyTranslation(PyObject *self, PyObj
         if (!PyArg_ParseTuple(args, "iii",&ix,&iy,&iz))
         {
             PyErr_BadArgument();
-            Py_RETURN_NONE;
+            return NULL;
         }
         dx = (double)ix;
         dy = (double)iy;
@@ -60,7 +60,7 @@ extern "C" PyObject * BaseMechanicalState_applyScale(PyObject *self, PyObject * 
         if (!PyArg_ParseTuple(args, "iii",&ix,&iy,&iz))
         {
             PyErr_BadArgument();
-            return 0;
+            return NULL;
         }
         dx = (double)ix;
         dy = (double)iy;
@@ -80,7 +80,7 @@ extern "C" PyObject * BaseMechanicalState_applyRotation(PyObject *self, PyObject
         if (!PyArg_ParseTuple(args, "iii",&ix,&iy,&iz))
         {
             PyErr_BadArgument();
-            Py_RETURN_NONE;
+            return NULL;
         }
         dx = (double)ix;
         dy = (double)iy;

--- a/applications/plugins/SofaPython/Binding_BaseObject.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseObject.cpp
@@ -89,7 +89,7 @@ extern "C" PyObject * BaseObject_setSrc(PyObject *self, PyObject * args)
     if (!PyArg_ParseTuple(args, "sO",&valueString,&pyLoader))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     BaseObject* loader=((PySPtr<Base>*)self)->object->toBaseObject();
     obj->setSrc(valueString,loader);

--- a/applications/plugins/SofaPython/Binding_Data.cpp
+++ b/applications/plugins/SofaPython/Binding_Data.cpp
@@ -355,7 +355,7 @@ bool SetDataValuePython(BaseData* data, PyObject* args)
             }
         }
 
-
+        PyErr_BadArgument();
         return false;
     }
 
@@ -633,8 +633,8 @@ bool SetDataValuePython(BaseData* data, PyObject* args)
 
     }
 
+    PyErr_BadArgument();    
     return false;
-
 }
 
 

--- a/applications/plugins/SofaPython/Binding_Data.cpp
+++ b/applications/plugins/SofaPython/Binding_Data.cpp
@@ -185,136 +185,84 @@ PyObject *GetDataValuePython(BaseData* data)
     return PyString_FromString(data->getValueString().c_str());
 }
 
-bool SetDataValuePython(BaseData* data, PyObject* args)
-{
-    // de quel type est args ?
-    bool isInt = PyInt_Check(args);
-    bool isScalar = PyFloat_Check(args);
-    bool isString = PyString_Check(args);
-    bool isList = PyList_Check(args);
+
+static bool SetDataValuePythonVectorLinearSpring(BaseData* data, PyObject* args,
+                                          Data<sofa::helper::vector<LinearSpring<SReal> > >* dataVectorLinearSpring) {
+    const bool isList = PyList_Check(args);
+
     const AbstractTypeInfo *typeinfo = data->getValueTypeInfo(); // info about the data value
-    int rowWidth = (typeinfo && typeinfo->ValidInfo()) ? typeinfo->size() : 1;
-    int nbRows = (typeinfo && typeinfo->ValidInfo()) ? typeinfo->size(data->getValueVoidPtr()) / typeinfo->size() : 1;
+    const bool valid = (typeinfo && typeinfo->ValidInfo());
+        
+    const int rowWidth = valid ? typeinfo->size() : 1;
+    int nbRows = valid ? typeinfo->size(data->getValueVoidPtr()) / typeinfo->size() : 1;
 
-    // horrible special case that needs to be refactored
-    Data<sofa::helper::vector<LinearSpring<SReal> > >* dataVectorLinearSpring = dynamic_cast<Data<sofa::helper::vector<LinearSpring<SReal> > >*>(data);
-    if (dataVectorLinearSpring)
+    // special type, a vector of LinearSpring objects
+
+    if (!isList)
     {
-        // special type, a vector of LinearSpring objects
-
-        if (!isList)
+        // one value
+        // check the python object type
+        if (rowWidth*nbRows<1 || !PyObject_IsInstance(args,reinterpret_cast<PyObject*>(&SP_SOFAPYTYPEOBJECT(LinearSpring))))
         {
-            // one value
-            // check the python object type
-            if (rowWidth*nbRows<1 || !PyObject_IsInstance(args,reinterpret_cast<PyObject*>(&SP_SOFAPYTYPEOBJECT(LinearSpring))))
-            {
-                // type mismatch or too long list
-                PyErr_BadArgument();
-                return false;
-            }
-
-            LinearSpring<SReal>* obj=dynamic_cast<LinearSpring<SReal>*>(((PyPtr<LinearSpring<SReal> >*)args)->object);
-            sofa::helper::vector<LinearSpring<SReal> >* vectorLinearSpring = dataVectorLinearSpring->beginEdit();
-
-            (*vectorLinearSpring)[0].m1 = obj->m1;
-            (*vectorLinearSpring)[0].m2 = obj->m2;
-            (*vectorLinearSpring)[0].ks = obj->ks;
-            (*vectorLinearSpring)[0].kd = obj->kd;
-            (*vectorLinearSpring)[0].initpos = obj->initpos;
-
-            dataVectorLinearSpring->endEdit();
-
-            return true;
+            // type mismatch or too long list
+            PyErr_BadArgument();
+            return false;
         }
-        else
+
+        LinearSpring<SReal>* obj=dynamic_cast<LinearSpring<SReal>*>(((PyPtr<LinearSpring<SReal> >*)args)->object);
+        sofa::helper::vector<LinearSpring<SReal> >* vectorLinearSpring = dataVectorLinearSpring->beginEdit();
+
+        (*vectorLinearSpring)[0].m1 = obj->m1;
+        (*vectorLinearSpring)[0].m2 = obj->m2;
+        (*vectorLinearSpring)[0].ks = obj->ks;
+        (*vectorLinearSpring)[0].kd = obj->kd;
+        (*vectorLinearSpring)[0].initpos = obj->initpos;
+
+        dataVectorLinearSpring->endEdit();
+
+        return true;
+    }
+    else
+    {
+        // values list
+        // is it a double-dimension list ?
+        //PyObject *firstRow = PyList_GetItem(args,0);
+
+        if (PyList_Check(PyList_GetItem(args,0)))
         {
-            // values list
-            // is it a double-dimension list ?
-            //PyObject *firstRow = PyList_GetItem(args,0);
+            // two-dimension array!
 
-            if (PyList_Check(PyList_GetItem(args,0)))
+            // right number if rows ?
+            if (PyList_Size(args)!=nbRows)
             {
-                // two-dimension array!
-
-                // right number if rows ?
-                if (PyList_Size(args)!=nbRows)
-                {
-                    // only a warning; do not raise an exception...
-                    SP_MESSAGE_WARNING( "list size mismatch for data \""<<data->getName()<<"\" (incorrect rows count)" )
+                // only a warning; do not raise an exception...
+                SP_MESSAGE_WARNING( "list size mismatch for data \""<<data->getName()<<"\" (incorrect rows count)" )
                     if (PyList_Size(args)<nbRows)
                         nbRows = PyList_Size(args);
-                }
-
-                sofa::helper::vector<LinearSpring<SReal> >* vectorLinearSpring = dataVectorLinearSpring->beginEdit();
-
-                // let's fill our rows!
-                for (int i=0; i<nbRows; i++)
-                {
-                    PyObject *row = PyList_GetItem(args,i);
-
-                    // right number if list members ?
-                    int size = rowWidth;
-                    if (PyList_Size(row)!=size)
-                    {
-                        // only a warning; do not raise an exception...
-                        SP_MESSAGE_WARNING( "row "<<i<<" size mismatch for data \""<<data->getName()<<"\" (src="<<(int)PyList_Size(row)<<"x"<<nbRows<<" dst="<<size<<"x"<<nbRows<<")" )
-                        if (PyList_Size(row)<size)
-                            size = PyList_Size(row);
-                    }
-
-                    // okay, let's set our list...
-                    for (int j=0; j<size; j++)
-                    {
-
-                        PyObject *listElt = PyList_GetItem(row,j);
-                        if(!PyObject_IsInstance(listElt,reinterpret_cast<PyObject*>(&SP_SOFAPYTYPEOBJECT(LinearSpring))))
-                        {
-                            // type mismatch
-                            dataVectorLinearSpring->endEdit();
-                            PyErr_BadArgument();
-                            return false;
-                        }
-                        LinearSpring<SReal>* spring=dynamic_cast<LinearSpring<SReal>*>(((PyPtr<LinearSpring<SReal> >*)listElt)->object);
-
-
-                        (*vectorLinearSpring)[j+i*rowWidth].m1 = spring->m1;
-                        (*vectorLinearSpring)[j+i*rowWidth].m2 = spring->m2;
-                        (*vectorLinearSpring)[j+i*rowWidth].ks = spring->ks;
-                        (*vectorLinearSpring)[j+i*rowWidth].kd = spring->kd;
-                        (*vectorLinearSpring)[j+i*rowWidth].initpos = spring->initpos;
-
-                    }
-
-
-
-                }
-
-                dataVectorLinearSpring->endEdit();
-
-                return true;
-
             }
-            else
+
+            sofa::helper::vector<LinearSpring<SReal> >* vectorLinearSpring = dataVectorLinearSpring->beginEdit();
+
+            // let's fill our rows!
+            for (int i=0; i<nbRows; i++)
             {
-                // it is a one-dimension only array
+                PyObject *row = PyList_GetItem(args,i);
+
                 // right number if list members ?
-                int size = rowWidth*nbRows;
-                if (PyList_Size(args)!=size)
+                int size = rowWidth;
+                if (PyList_Size(row)!=size)
                 {
                     // only a warning; do not raise an exception...
-                    SP_MESSAGE_WARNING( "list size mismatch for data \""<<data->getName()<<"\" (src="<<(int)PyList_Size(args)<<" dst="<<size<<")" )
-                    if (PyList_Size(args)<size)
-                        size = PyList_Size(args);
+                    SP_MESSAGE_WARNING( "row "<<i<<" size mismatch for data \""<<data->getName()<<"\" (src="<<(int)PyList_Size(row)<<"x"<<nbRows<<" dst="<<size<<"x"<<nbRows<<")" )
+                        if (PyList_Size(row)<size)
+                            size = PyList_Size(row);
                 }
 
-                sofa::helper::vector<LinearSpring<SReal> >* vectorLinearSpring = dataVectorLinearSpring->beginEdit();
-
                 // okay, let's set our list...
-                for (int i=0; i<size; i++)
+                for (int j=0; j<size; j++)
                 {
 
-                    PyObject *listElt = PyList_GetItem(args,i);
-
+                    PyObject *listElt = PyList_GetItem(row,j);
                     if(!PyObject_IsInstance(listElt,reinterpret_cast<PyObject*>(&SP_SOFAPYTYPEOBJECT(LinearSpring))))
                     {
                         // type mismatch
@@ -322,41 +270,342 @@ bool SetDataValuePython(BaseData* data, PyObject* args)
                         PyErr_BadArgument();
                         return false;
                     }
-
                     LinearSpring<SReal>* spring=dynamic_cast<LinearSpring<SReal>*>(((PyPtr<LinearSpring<SReal> >*)listElt)->object);
 
-                    (*vectorLinearSpring)[i].m1 = spring->m1;
-                    (*vectorLinearSpring)[i].m2 = spring->m2;
-                    (*vectorLinearSpring)[i].ks = spring->ks;
-                    (*vectorLinearSpring)[i].kd = spring->kd;
-                    (*vectorLinearSpring)[i].initpos = spring->initpos;
 
+                    (*vectorLinearSpring)[j+i*rowWidth].m1 = spring->m1;
+                    (*vectorLinearSpring)[j+i*rowWidth].m2 = spring->m2;
+                    (*vectorLinearSpring)[j+i*rowWidth].ks = spring->ks;
+                    (*vectorLinearSpring)[j+i*rowWidth].kd = spring->kd;
+                    (*vectorLinearSpring)[j+i*rowWidth].initpos = spring->initpos;
 
-    /*
-                    if (PyFloat_Check(listElt))
-                    {
-                        // it's a scalar
-                        if (!typeinfo->Scalar())
-                        {
-                            // type mismatch
-                            PyErr_BadArgument();
-                            return false;
-                        }
-                        SReal value = PyFloat_AsDouble(listElt);
-                        void* editVoidPtr = data->beginEditVoidPtr();
-                        typeinfo->setScalarValue(editVoidPtr,i,value);
-                        data->endEditVoidPtr();
-                    }
-     */
                 }
-                dataVectorLinearSpring->endEdit();
 
-                return true;
+
+
+            }
+
+            dataVectorLinearSpring->endEdit();
+
+            return true;
+
+        }
+        else
+        {
+            // it is a one-dimension only array
+            // right number if list members ?
+            int size = rowWidth*nbRows;
+            if (PyList_Size(args)!=size)
+            {
+                // only a warning; do not raise an exception...
+                SP_MESSAGE_WARNING( "list size mismatch for data \""<<data->getName()<<"\" (src="<<(int)PyList_Size(args)<<" dst="<<size<<")" )
+                    if (PyList_Size(args)<size)
+                        size = PyList_Size(args);
+            }
+
+            sofa::helper::vector<LinearSpring<SReal> >* vectorLinearSpring = dataVectorLinearSpring->beginEdit();
+
+            // okay, let's set our list...
+            for (int i=0; i<size; i++)
+            {
+
+                PyObject *listElt = PyList_GetItem(args,i);
+
+                if(!PyObject_IsInstance(listElt,reinterpret_cast<PyObject*>(&SP_SOFAPYTYPEOBJECT(LinearSpring))))
+                {
+                    // type mismatch
+                    dataVectorLinearSpring->endEdit();
+                    PyErr_BadArgument();
+                    return false;
+                }
+
+                LinearSpring<SReal>* spring=dynamic_cast<LinearSpring<SReal>*>(((PyPtr<LinearSpring<SReal> >*)listElt)->object);
+
+                (*vectorLinearSpring)[i].m1 = spring->m1;
+                (*vectorLinearSpring)[i].m2 = spring->m2;
+                (*vectorLinearSpring)[i].ks = spring->ks;
+                (*vectorLinearSpring)[i].kd = spring->kd;
+                (*vectorLinearSpring)[i].initpos = spring->initpos;
+
+
+                /*
+                  if (PyFloat_Check(listElt))
+                  {
+                  // it's a scalar
+                  if (!typeinfo->Scalar())
+                  {
+                  // type mismatch
+                  PyErr_BadArgument();
+                  return false;
+                  }
+                  SReal value = PyFloat_AsDouble(listElt);
+                  void* editVoidPtr = data->beginEditVoidPtr();
+                  typeinfo->setScalarValue(editVoidPtr,i,value);
+                  data->endEditVoidPtr();
+                  }
+                */
+            }
+            dataVectorLinearSpring->endEdit();
+
+            return true;
+        }
+    }
+
+    PyErr_BadArgument();
+    return false;
+}
+
+
+
+static bool SetDataValuePythonList(BaseData* data, PyObject* args,
+                            const int rowWidth, int nbRows) {
+    const AbstractTypeInfo *typeinfo = data->getValueTypeInfo(); // info about the data value
+        
+    // check list emptyness
+    if (PyList_Size(args)==0)
+    {
+        data->read("");
+        return true;
+    }
+
+    // is it a double-dimension list ?
+    //PyObject *firstRow = PyList_GetItem(args,0);
+
+    if (PyList_Check(PyList_GetItem(args,0)))
+    {
+        // two-dimension array!
+
+        void* editVoidPtr = data->beginEditVoidPtr();
+
+        // same number of rows?
+        {
+            int newNbRows = PyList_Size(args);
+            if (newNbRows!=nbRows)
+            {
+                // try to resize (of course, it is not possible with every container, the resize policy is defined in DataTypeInfo)
+                typeinfo->setSize( editVoidPtr, newNbRows*rowWidth );
+
+                if( typeinfo->size(editVoidPtr) != (size_t)(newNbRows*rowWidth) )
+                {
+                    // resizing was not possible
+                    // only a warning; do not raise an exception...
+                    SP_MESSAGE_WARNING( "list size mismatch for data \""<<data->getName()<<"\" (incorrect rows count)" )
+                        if (newNbRows<nbRows)
+                            nbRows = newNbRows;
+                }
+                else
+                {
+                    // resized
+                    nbRows = newNbRows;
+                }
             }
         }
 
-        PyErr_BadArgument();
-        return false;
+
+        // let's fill our rows!
+        for (int i=0; i<nbRows; i++)
+        {
+            PyObject *row = PyList_GetItem(args,i);
+
+            // right number of list members ?
+            int size = rowWidth;
+            if (PyList_Size(row)!=size)
+            {
+                // only a warning; do not raise an exception...
+                SP_MESSAGE_WARNING( "row "<<i<<" size mismatch for data \""<<data->getName()<<"\"" )
+                    if (PyList_Size(row)<size)
+                        size = PyList_Size(row);
+            }
+
+            // okay, let's set our list...
+            for (int j=0; j<size; j++)
+            {
+
+                PyObject *listElt = PyList_GetItem(row,j);
+
+                if (PyInt_Check(listElt))
+                {
+                    // it's an int
+                    if (typeinfo->Integer())
+                    {
+                        // integer value
+                        long value = PyInt_AsLong(listElt);
+                        typeinfo->setIntegerValue(editVoidPtr,i*rowWidth+j,value);
+                    }
+                    else if (typeinfo->Scalar())
+                    {
+                        // cast to scalar value
+                        SReal value = (SReal)PyInt_AsLong(listElt);
+                        typeinfo->setScalarValue(editVoidPtr,i*rowWidth+j,value);
+                    }
+                    else
+                    {
+                        // type mismatch
+                        PyErr_BadArgument();
+                        return false;
+                    }
+                }
+                else if (PyFloat_Check(listElt))
+                {
+                    // it's a scalar
+                    if (!typeinfo->Scalar())
+                    {
+                        // type mismatch
+                        PyErr_BadArgument();
+                        return false;
+                    }
+                    SReal value = PyFloat_AsDouble(listElt);
+                    typeinfo->setScalarValue(editVoidPtr,i*rowWidth+j,value);
+                }
+                else if (PyString_Check(listElt))
+                {
+                    // it's a string
+                    if (!typeinfo->Text())
+                    {
+                        // type mismatch
+                        PyErr_BadArgument();
+                        return false;
+                    }
+                    char *str = PyString_AsString(listElt); // pour les setters, un seul objet et pas un tuple....
+                    typeinfo->setTextValue(editVoidPtr,i*rowWidth+j,str);
+                }
+                else
+                {
+                    msg_warning("SetDataValuePython") << "Lists not yet supported...";
+                    PyErr_BadArgument();
+                    return false;
+                }
+            }
+
+
+
+        }
+        data->endEditVoidPtr();
+        return true;
+
+    }
+    else
+    {
+        // it is a one-dimension only array
+
+        void* editVoidPtr = data->beginEditVoidPtr();
+
+        // same number of list members?
+        int size = rowWidth*nbRows; // start with oldsize
+        {
+            int newSize = PyList_Size(args);
+            if (newSize!=size)
+            {
+                // try to resize (of course, it is not possible with every container, the resize policy is defined in DataTypeInfo)
+                typeinfo->setSize( editVoidPtr, newSize );
+
+                if( typeinfo->size(editVoidPtr) != (size_t)newSize )
+                {
+                    // resizing was not possible
+                    // only a warning; do not raise an exception...
+                    SP_MESSAGE_WARNING( "list size mismatch for data \""<<data->getName()<<"\" (incorrect rows count)" )
+                        if (newSize<size)
+                            size = newSize;
+                }
+                else
+                {
+                    // resized
+                    size = newSize;
+                }
+            }
+        }
+
+        // okay, let's set our list...
+        for (int i=0; i<size; i++)
+        {
+
+            PyObject *listElt = PyList_GetItem(args,i);
+
+            if (PyInt_Check(listElt))
+            {
+                // it's an int
+                if (typeinfo->Integer())
+                {
+                    // integer value
+                    long value = PyInt_AsLong(listElt);
+                    typeinfo->setIntegerValue(editVoidPtr,i,value);
+                }
+                else if (typeinfo->Scalar())
+                {
+                    // cast to scalar value
+                    SReal value = (SReal)PyInt_AsLong(listElt);
+                    typeinfo->setScalarValue(editVoidPtr,i,value);
+                }
+                else
+                {
+                    // type mismatch
+                    PyErr_BadArgument();
+                    return false;
+                }
+            }
+            else if (PyFloat_Check(listElt))
+            {
+                // it's a scalar
+                if (!typeinfo->Scalar())
+                {
+                    // type mismatch
+                    PyErr_BadArgument();
+                    return false;
+                }
+                SReal value = PyFloat_AsDouble(listElt);
+                typeinfo->setScalarValue(editVoidPtr,i,value);
+            }
+            else if (PyString_Check(listElt))
+            {
+                // it's a string
+                if (!typeinfo->Text())
+                {
+                    // type mismatch
+                    PyErr_BadArgument();
+                    return false;
+                }
+                char *str = PyString_AsString(listElt); // pour les setters, un seul objet et pas un tuple....
+                typeinfo->setTextValue(editVoidPtr,i,str);
+            }
+            else
+            {
+                msg_warning("SetDataValuePython") << "Lists not yet supported...";
+                PyErr_BadArgument();
+                return false;
+
+            }
+        }
+        data->endEditVoidPtr();
+        return true;
+    }
+
+    // no idea whether this is reachable
+    PyErr_BadArgument();
+    return false;
+}
+
+
+
+bool SetDataValuePython(BaseData* data, PyObject* args)
+{
+    // de quel type est args ?
+    const bool isInt = PyInt_Check(args);
+    const bool isScalar = PyFloat_Check(args);
+    const bool isString = PyString_Check(args);
+    const bool isList = PyList_Check(args);
+    
+    const AbstractTypeInfo *typeinfo = data->getValueTypeInfo(); // info about the data value
+    const bool valid = (typeinfo && typeinfo->ValidInfo());
+    
+    const int rowWidth = valid ? typeinfo->size() : 1;
+    const int nbRows = valid ? typeinfo->size(data->getValueVoidPtr()) / typeinfo->size() : 1;
+
+    
+    if ( Data<sofa::helper::vector<LinearSpring<SReal> > >*ptr =
+         dynamic_cast<Data<sofa::helper::vector<LinearSpring<SReal> > >*>(data) )
+    {
+        // who uses linear springs anyways lol
+        return SetDataValuePythonVectorLinearSpring(data, args, ptr);
     }
 
 
@@ -412,227 +661,10 @@ bool SetDataValuePython(BaseData* data, PyObject* args)
     }
     else if (isList)
     {
-        // it's a list
-        // check list emptyness
-        if (PyList_Size(args)==0)
-        {
-            data->read("");
-            return true;
-        }
-
-        // is it a double-dimension list ?
-        //PyObject *firstRow = PyList_GetItem(args,0);
-
-        if (PyList_Check(PyList_GetItem(args,0)))
-        {
-            // two-dimension array!
-
-            void* editVoidPtr = data->beginEditVoidPtr();
-
-            // same number of rows?
-            {
-            int newNbRows = PyList_Size(args);
-            if (newNbRows!=nbRows)
-            {
-                // try to resize (of course, it is not possible with every container, the resize policy is defined in DataTypeInfo)
-                typeinfo->setSize( editVoidPtr, newNbRows*rowWidth );
-
-                if( typeinfo->size(editVoidPtr) != (size_t)(newNbRows*rowWidth) )
-                {
-                    // resizing was not possible
-                    // only a warning; do not raise an exception...
-                    SP_MESSAGE_WARNING( "list size mismatch for data \""<<data->getName()<<"\" (incorrect rows count)" )
-                    if (newNbRows<nbRows)
-                        nbRows = newNbRows;
-                }
-                else
-                {
-                    // resized
-                    nbRows = newNbRows;
-                }
-            }
-            }
-
-
-            // let's fill our rows!
-            for (int i=0; i<nbRows; i++)
-            {
-                PyObject *row = PyList_GetItem(args,i);
-
-                // right number of list members ?
-                int size = rowWidth;
-                if (PyList_Size(row)!=size)
-                {
-                    // only a warning; do not raise an exception...
-                    SP_MESSAGE_WARNING( "row "<<i<<" size mismatch for data \""<<data->getName()<<"\"" )
-                    if (PyList_Size(row)<size)
-                        size = PyList_Size(row);
-                }
-
-                // okay, let's set our list...
-                for (int j=0; j<size; j++)
-                {
-
-                    PyObject *listElt = PyList_GetItem(row,j);
-
-                    if (PyInt_Check(listElt))
-                    {
-                        // it's an int
-                        if (typeinfo->Integer())
-                        {
-                            // integer value
-                            long value = PyInt_AsLong(listElt);
-                            typeinfo->setIntegerValue(editVoidPtr,i*rowWidth+j,value);
-                        }
-                        else if (typeinfo->Scalar())
-                        {
-                            // cast to scalar value
-                            SReal value = (SReal)PyInt_AsLong(listElt);
-                            typeinfo->setScalarValue(editVoidPtr,i*rowWidth+j,value);
-                        }
-                        else
-                        {
-                            // type mismatch
-                            PyErr_BadArgument();
-                            return false;
-                        }
-                    }
-                    else if (PyFloat_Check(listElt))
-                    {
-                        // it's a scalar
-                        if (!typeinfo->Scalar())
-                        {
-                            // type mismatch
-                            PyErr_BadArgument();
-                            return false;
-                        }
-                        SReal value = PyFloat_AsDouble(listElt);
-                        typeinfo->setScalarValue(editVoidPtr,i*rowWidth+j,value);
-                    }
-                    else if (PyString_Check(listElt))
-                    {
-                        // it's a string
-                        if (!typeinfo->Text())
-                        {
-                            // type mismatch
-                            PyErr_BadArgument();
-                            return false;
-                        }
-                        char *str = PyString_AsString(listElt); // pour les setters, un seul objet et pas un tuple....
-                        typeinfo->setTextValue(editVoidPtr,i*rowWidth+j,str);
-                    }
-                    else
-                    {
-                        msg_warning("SetDataValuePython") << "Lists not yet supported...";
-                        PyErr_BadArgument();
-                        return false;
-                    }
-                }
-
-
-
-            }
-            data->endEditVoidPtr();
-            return true;
-
-        }
-        else
-        {
-            // it is a one-dimension only array
-
-            void* editVoidPtr = data->beginEditVoidPtr();
-
-            // same number of list members?
-            int size = rowWidth*nbRows; // start with oldsize
-            {
-            int newSize = PyList_Size(args);
-            if (newSize!=size)
-            {
-                // try to resize (of course, it is not possible with every container, the resize policy is defined in DataTypeInfo)
-                typeinfo->setSize( editVoidPtr, newSize );
-
-                if( typeinfo->size(editVoidPtr) != (size_t)newSize )
-                {
-                    // resizing was not possible
-                    // only a warning; do not raise an exception...
-                    SP_MESSAGE_WARNING( "list size mismatch for data \""<<data->getName()<<"\" (incorrect rows count)" )
-                    if (newSize<size)
-                        size = newSize;
-                }
-                else
-                {
-                    // resized
-                    size = newSize;
-                }
-            }
-            }
-
-            // okay, let's set our list...
-            for (int i=0; i<size; i++)
-            {
-
-                PyObject *listElt = PyList_GetItem(args,i);
-
-                if (PyInt_Check(listElt))
-                {
-                    // it's an int
-                    if (typeinfo->Integer())
-                    {
-                        // integer value
-                        long value = PyInt_AsLong(listElt);
-                        typeinfo->setIntegerValue(editVoidPtr,i,value);
-                    }
-                    else if (typeinfo->Scalar())
-                    {
-                        // cast to scalar value
-                        SReal value = (SReal)PyInt_AsLong(listElt);
-                        typeinfo->setScalarValue(editVoidPtr,i,value);
-                    }
-                    else
-                    {
-                        // type mismatch
-                        PyErr_BadArgument();
-                        return false;
-                    }
-                }
-                else if (PyFloat_Check(listElt))
-                {
-                    // it's a scalar
-                    if (!typeinfo->Scalar())
-                    {
-                        // type mismatch
-                        PyErr_BadArgument();
-                        return false;
-                    }
-                    SReal value = PyFloat_AsDouble(listElt);
-                    typeinfo->setScalarValue(editVoidPtr,i,value);
-                }
-                else if (PyString_Check(listElt))
-                {
-                    // it's a string
-                    if (!typeinfo->Text())
-                    {
-                        // type mismatch
-                        PyErr_BadArgument();
-                        return false;
-                    }
-                    char *str = PyString_AsString(listElt); // pour les setters, un seul objet et pas un tuple....
-                    typeinfo->setTextValue(editVoidPtr,i,str);
-                }
-                else
-                {
-                    msg_warning("SetDataValuePython") << "Lists not yet supported...";
-                    PyErr_BadArgument();
-                    return false;
-
-                }
-            }
-            data->endEditVoidPtr();
-            return true;
-        }
-
+        return SetDataValuePythonList(data, args, rowWidth, nbRows);
     }
 
+    // bad luck yo
     PyErr_BadArgument();    
     return false;
 }
@@ -687,6 +719,7 @@ extern "C" PyObject * Data_getValue(PyObject *self, PyObject * args)
     PyErr_BadArgument();
     return NULL;
 }
+
 extern "C" PyObject * Data_setValue(PyObject *self, PyObject * args)
 {
     BaseData* data=((PyPtr<BaseData>*)self)->object;

--- a/applications/plugins/SofaPython/Binding_Data.cpp
+++ b/applications/plugins/SofaPython/Binding_Data.cpp
@@ -666,14 +666,14 @@ extern "C" PyObject * Data_getValue(PyObject *self, PyObject * args)
     if (!PyArg_ParseTuple(args, "i",&index))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     if ((unsigned int)index>=typeinfo->size())
     {
         // out of bounds!
         SP_MESSAGE_ERROR( "Data.getValue index overflow" )
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     if (typeinfo->Scalar())
         return PyFloat_FromDouble(typeinfo->getScalarValue(data->getValueVoidPtr(),index));
@@ -685,7 +685,7 @@ extern "C" PyObject * Data_getValue(PyObject *self, PyObject * args)
     // should never happen....
     SP_MESSAGE_ERROR( "Data.getValue unknown data type" )
     PyErr_BadArgument();
-    Py_RETURN_NONE;
+    return NULL;
 }
 extern "C" PyObject * Data_setValue(PyObject *self, PyObject * args)
 {
@@ -696,14 +696,14 @@ extern "C" PyObject * Data_setValue(PyObject *self, PyObject * args)
     if (!PyArg_ParseTuple(args, "iO",&index,&value))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     if ((unsigned int)index>=typeinfo->size())
     {
         // out of bounds!
         SP_MESSAGE_ERROR( "Data.setValue index overflow" )
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     if (typeinfo->Scalar() && PyFloat_Check(value))
     {
@@ -724,7 +724,7 @@ extern "C" PyObject * Data_setValue(PyObject *self, PyObject * args)
     // should never happen....
     SP_MESSAGE_ERROR( "Data.setValue type mismatch" )
     PyErr_BadArgument();
-    Py_RETURN_NONE;
+    return NULL;
 }
 
 
@@ -762,7 +762,7 @@ extern "C" PyObject * Data_setSize(PyObject *self, PyObject * args)
     if (!PyArg_ParseTuple(args, "i",&size))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     const AbstractTypeInfo *typeinfo = data->getValueTypeInfo();
     typeinfo->setSize((void*)data->getValueVoidPtr(),size);
@@ -797,7 +797,7 @@ extern "C" PyObject * Data_read(PyObject *self, PyObject * args)
     if (!PyArg_ParseTuple(args, "O",&value))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     if (PyString_Check(value))
@@ -808,8 +808,9 @@ extern "C" PyObject * Data_read(PyObject *self, PyObject * args)
     {
         SP_MESSAGE_ERROR( "Data.read type mismatch" )
         PyErr_BadArgument();
+        return NULL;
     }
-
+    
     Py_RETURN_NONE;
 }
 
@@ -821,7 +822,7 @@ extern "C" PyObject * Data_setParent(PyObject *self, PyObject * args)
     if (!PyArg_ParseTuple(args, "O",&value))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     typedef PyPtr<BaseData> PyBaseData;
@@ -840,8 +841,9 @@ extern "C" PyObject * Data_setParent(PyObject *self, PyObject * args)
     {
         SP_MESSAGE_ERROR( "Data.setParent type mismatch" )
         PyErr_BadArgument();
+        return NULL;
     }
-
+    
     Py_RETURN_NONE;
 }
 

--- a/applications/plugins/SofaPython/Binding_GridTopology.cpp
+++ b/applications/plugins/SofaPython/Binding_GridTopology.cpp
@@ -33,7 +33,7 @@ extern "C" PyObject * GridTopology_setSize(PyObject *self, PyObject * args)
     if (!PyArg_ParseTuple(args, "iii",&nx,&ny,&nz))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     obj->setSize(nx,ny,nz);
     Py_RETURN_NONE;
@@ -46,7 +46,7 @@ extern "C" PyObject * GridTopology_setNumVertices(PyObject *self, PyObject * arg
     if (!PyArg_ParseTuple(args, "iii",&nx,&ny,&nz))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     obj->setNumVertices(nx,ny,nz);
     Py_RETURN_NONE;
@@ -65,7 +65,7 @@ extern "C" PyObject * GridTopology_setNx(PyObject *self, PyObject * args)
     if (!PyArg_ParseTuple(args, "i",&nb))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     obj->setNx(nb);
     Py_RETURN_NONE;
@@ -84,7 +84,7 @@ extern "C" PyObject * GridTopology_setNy(PyObject *self, PyObject * args)
     if (!PyArg_ParseTuple(args, "i",&nb))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     obj->setNy(nb);
     Py_RETURN_NONE;
@@ -103,7 +103,7 @@ extern "C" PyObject * GridTopology_setNz(PyObject *self, PyObject * args)
     if (!PyArg_ParseTuple(args, "i",&nb))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     obj->setNz(nb);
     Py_RETURN_NONE;

--- a/applications/plugins/SofaPython/Binding_LinearSpring.cpp
+++ b/applications/plugins/SofaPython/Binding_LinearSpring.cpp
@@ -43,7 +43,7 @@ extern "C" int LinearSpring_setAttr_Index1(PyObject *self, PyObject * args, void
     if (!obj)
     {
         PyErr_BadArgument();
-        return NULL;
+        return -1;
     }
 //    printf("***** DBG LinearSpring_setAttr_Index1 %d\n",(int)PyInt_AsLong(args));
     obj->m1=PyInt_AsLong(args);

--- a/applications/plugins/SofaPython/Binding_LinearSpring.cpp
+++ b/applications/plugins/SofaPython/Binding_LinearSpring.cpp
@@ -67,7 +67,7 @@ extern "C" int LinearSpring_setAttr_Index2(PyObject *self, PyObject * args, void
     if (!obj)
     {
         PyErr_BadArgument();
-        return NULL;
+        return -1;
     }
 //    printf("***** DBG LinearSpring_setAttr_Index2 %d\n",(int)PyInt_AsLong(args));
     obj->m2=PyInt_AsLong(args);
@@ -91,7 +91,7 @@ extern "C" int LinearSpring_setAttr_Ks(PyObject *self, PyObject * args, void*)
     if (!obj)
     {
         PyErr_BadArgument();
-        return NULL;
+        return -1;
     }
 //    printf("***** DBG LinearSpring_setAttr_Ks %f\n",(float)PyFloat_AsDouble(args));
     obj->ks=PyFloat_AsDouble(args);

--- a/applications/plugins/SofaPython/Binding_LinearSpring.cpp
+++ b/applications/plugins/SofaPython/Binding_LinearSpring.cpp
@@ -32,7 +32,7 @@ extern "C" PyObject * LinearSpring_getAttr_Index1(PyObject *self, void*)
     if (!obj)
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     return PyInt_FromLong(obj->m1);
 }
@@ -43,7 +43,7 @@ extern "C" int LinearSpring_setAttr_Index1(PyObject *self, PyObject * args, void
     if (!obj)
     {
         PyErr_BadArgument();
-        return 0;
+        return NULL;
     }
 //    printf("***** DBG LinearSpring_setAttr_Index1 %d\n",(int)PyInt_AsLong(args));
     obj->m1=PyInt_AsLong(args);
@@ -56,7 +56,7 @@ extern "C" PyObject * LinearSpring_getAttr_Index2(PyObject *self, void*)
     if (!obj)
     {
         PyErr_BadArgument();
-        return 0;
+        return NULL;
     }
     return PyInt_FromLong(obj->m2);
 }
@@ -67,7 +67,7 @@ extern "C" int LinearSpring_setAttr_Index2(PyObject *self, PyObject * args, void
     if (!obj)
     {
         PyErr_BadArgument();
-        return 0;
+        return NULL;
     }
 //    printf("***** DBG LinearSpring_setAttr_Index2 %d\n",(int)PyInt_AsLong(args));
     obj->m2=PyInt_AsLong(args);
@@ -80,7 +80,7 @@ extern "C" PyObject * LinearSpring_getAttr_Ks(PyObject *self, void*)
     if (!obj)
     {
         PyErr_BadArgument();
-        return 0;
+        return NULL;
     }
     return PyFloat_FromDouble(obj->ks);
 }
@@ -91,7 +91,7 @@ extern "C" int LinearSpring_setAttr_Ks(PyObject *self, PyObject * args, void*)
     if (!obj)
     {
         PyErr_BadArgument();
-        return 0;
+        return NULL;
     }
 //    printf("***** DBG LinearSpring_setAttr_Ks %f\n",(float)PyFloat_AsDouble(args));
     obj->ks=PyFloat_AsDouble(args);
@@ -105,7 +105,7 @@ extern "C" PyObject * LinearSpring_getAttr_Kd(PyObject *self, void*)
     if (!obj)
     {
         PyErr_BadArgument();
-        return 0;
+        return NULL;
     }
     return PyFloat_FromDouble(obj->kd);
 }
@@ -116,7 +116,7 @@ extern "C" int LinearSpring_setAttr_Kd(PyObject *self, PyObject * args, void*)
     if (!obj)
     {
         PyErr_BadArgument();
-        return 0;
+        return -1;
     }
 //    printf("***** DBG LinearSpring_setAttr_Kd %f\n",(float)PyFloat_AsDouble(args));
     obj->kd=PyFloat_AsDouble(args);
@@ -130,7 +130,7 @@ extern "C" PyObject * LinearSpring_getAttr_L(PyObject *self, void*)
     if (!obj)
     {
         PyErr_BadArgument();
-        return 0;
+        return NULL;
     }
     return PyFloat_FromDouble(obj->initpos);
 }
@@ -141,7 +141,7 @@ extern "C" int LinearSpring_setAttr_L(PyObject *self, PyObject * args, void*)
     if (!obj)
     {
         PyErr_BadArgument();
-        return 0;
+        return -1;
     }
 //    printf("***** DBG LinearSpring_setAttr_L %f\n",(float)PyFloat_AsDouble(args));
     obj->initpos=PyFloat_AsDouble(args);

--- a/applications/plugins/SofaPython/Binding_Link.cpp
+++ b/applications/plugins/SofaPython/Binding_Link.cpp
@@ -80,9 +80,9 @@ SP_CLASS_ATTR_GET(Link,value)(PyObject *self, void*)
 SP_CLASS_ATTR_SET(Link,value)(PyObject *self, PyObject * args, void*)
 {
     BaseLink* link=((PyPtr<BaseLink>*)self)->object; // TODO: check dynamic cast
-    if (SetLinkValuePython(link,args))
-        return 0;   // OK
-
+    if (SetLinkValuePython(link,args)) {
+        return 0;
+    }
 
     SP_MESSAGE_ERROR( "argument type not supported" )
     PyErr_BadArgument();
@@ -198,3 +198,4 @@ SP_CLASS_ATTR(Link,value)
 SP_CLASS_ATTRS_END
 
 SP_CLASS_TYPE_BASE_PTR_ATTR(Link,BaseLink)
+

--- a/applications/plugins/SofaPython/Binding_MechanicalObject.cpp
+++ b/applications/plugins/SofaPython/Binding_MechanicalObject.cpp
@@ -41,7 +41,7 @@ extern "C" PyObject * MechanicalObject_setTranslation(PyObject *self, PyObject *
         if (!PyArg_ParseTuple(args, "iii",&ix,&iy,&iz))
         {
             PyErr_BadArgument();
-            Py_RETURN_NONE;
+            return NULL;
         }
         dx = (double)ix;
         dy = (double)iy;
@@ -61,7 +61,7 @@ extern "C" PyObject * MechanicalObject_setScale(PyObject *self, PyObject * args)
         if (!PyArg_ParseTuple(args, "iii",&ix,&iy,&iz))
         {
             PyErr_BadArgument();
-            Py_RETURN_NONE;
+            return NULL;
         }
         dx = (double)ix;
         dy = (double)iy;
@@ -81,7 +81,7 @@ extern "C" PyObject * MechanicalObject_setRotation(PyObject *self, PyObject * ar
         if (!PyArg_ParseTuple(args, "iii",&ix,&iy,&iz))
         {
             PyErr_BadArgument();
-            Py_RETURN_NONE;
+            return NULL;
         }
         dx = (double)ix;
         dy = (double)iy;

--- a/applications/plugins/SofaPython/Binding_Node.cpp
+++ b/applications/plugins/SofaPython/Binding_Node.cpp
@@ -105,7 +105,7 @@ extern "C" PyObject * Node_getChild(PyObject * self, PyObject * args, PyObject *
     if (!node || !path)
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     bool warning = true;
@@ -244,7 +244,7 @@ extern "C" PyObject * Node_addObject_Impl(PyObject *self, PyObject * args, PyObj
     if (!object)
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     node->addObject(object);
 
@@ -274,7 +274,7 @@ extern "C" PyObject * Node_removeObject(PyObject *self, PyObject * args)
     if (!object)
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     node->removeObject(object);
 
@@ -294,7 +294,7 @@ extern "C" PyObject * Node_addChild(PyObject *self, PyObject * args)
     if (!child)
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     obj->addChild(child);
     Py_RETURN_NONE;
@@ -310,7 +310,7 @@ extern "C" PyObject * Node_removeChild(PyObject *self, PyObject * args)
     if (!child)
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     obj->removeChild(child);
     Py_RETURN_NONE;
@@ -326,7 +326,7 @@ extern "C" PyObject * Node_moveChild(PyObject *self, PyObject * args)
     if (!child)
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     obj->moveChild(child);
     Py_RETURN_NONE;
@@ -347,7 +347,7 @@ extern "C" PyObject * Node_sendScriptEvent(PyObject *self, PyObject * args)
     if (!PyArg_ParseTuple(args, "sO",&eventName,&pyUserData))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     PythonScriptEvent event(node,eventName,pyUserData);
     down_cast<Node>(node->getRoot())->propagateEvent(sofa::core::ExecParams::defaultInstance(), &event);
@@ -361,7 +361,7 @@ extern "C" PyObject * Node_sendKeypressedEvent(PyObject *self, PyObject * args)
     if (!PyArg_ParseTuple(args, "s",&eventName))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     sofa::core::objectmodel::KeypressedEvent event(eventName ? eventName[0] : '\0');
     down_cast<Node>(node->getRoot())->propagateEvent(sofa::core::ExecParams::defaultInstance(), &event);
@@ -375,7 +375,7 @@ extern "C" PyObject * Node_sendKeyreleasedEvent(PyObject *self, PyObject * args)
     if (!PyArg_ParseTuple(args, "s",&eventName))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     sofa::core::objectmodel::KeyreleasedEvent event(eventName ? eventName[0] : '\0');
     down_cast<Node>(node->getRoot())->propagateEvent(sofa::core::ExecParams::defaultInstance(), &event);

--- a/applications/plugins/SofaPython/Binding_OptionsGroupData.cpp
+++ b/applications/plugins/SofaPython/Binding_OptionsGroupData.cpp
@@ -77,7 +77,7 @@ extern "C" PyObject * OptionsGroupData_setSelectedId(PyObject *self, PyObject * 
     if (!PyArg_ParseTuple(args, "i",&index))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     OptionsGroupData_setAttr_selectedId_impl(self,index);
     Py_RETURN_NONE;
@@ -92,7 +92,7 @@ extern "C" PyObject * OptionsGroupData_setSelectedItem(PyObject *self, PyObject 
     if (!PyArg_ParseTuple(args, "s",&item))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     OptionsGroupData_setAttr_selectedItem_impl(self,item);
     Py_RETURN_NONE;
@@ -106,7 +106,7 @@ extern "C" PyObject * OptionsGroupData_getItem(PyObject *self, PyObject * args)
     if (!PyArg_ParseTuple(args, "i",&index))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     return PyString_FromString(data->getValue()[index].c_str());
 }

--- a/applications/plugins/SofaPython/Binding_PythonScriptController.cpp
+++ b/applications/plugins/SofaPython/Binding_PythonScriptController.cpp
@@ -56,7 +56,7 @@ extern "C" PyObject * PythonScriptController_onLoaded(PyObject * /*self*/, PyObj
     if (!PyArg_ParseTuple(args, "O",&pyNode))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
@@ -74,7 +74,7 @@ extern "C" PyObject * PythonScriptController_createGraph(PyObject * /*self*/, Py
     if (!PyArg_ParseTuple(args, "O",&pyNode))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
@@ -92,7 +92,7 @@ extern "C" PyObject * PythonScriptController_initGraph(PyObject * /*self*/, PyOb
     if (!PyArg_ParseTuple(args, "O",&pyNode))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
@@ -110,7 +110,7 @@ extern "C" PyObject * PythonScriptController_bwdInitGraph(PyObject * /*self*/, P
     if (!PyArg_ParseTuple(args, "O",&pyNode))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
@@ -128,7 +128,7 @@ extern "C" PyObject * PythonScriptController_onBeginAnimationStep(PyObject * /*s
     if (!PyArg_ParseTuple(args, "d",&dt))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     else
     {
@@ -149,7 +149,7 @@ extern "C" PyObject * PythonScriptController_onEndAnimationStep(PyObject * /*sel
     if (!PyArg_ParseTuple(args, "d",&dt))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
@@ -201,7 +201,7 @@ extern "C" PyObject * PythonScriptController_onGUIEvent(PyObject * /*self*/, PyO
     if (!PyArg_ParseTuple(args, "sss",&controlID,&valueName,&value))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
@@ -218,7 +218,7 @@ extern "C" PyObject * PythonScriptController_onKeyPressed(PyObject * /*self*/, P
     if (!PyArg_ParseTuple(args, "c",&k))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
@@ -235,7 +235,7 @@ extern "C" PyObject * PythonScriptController_onKeyReleased(PyObject * /*self*/, 
     if (!PyArg_ParseTuple(args, "c",&k))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
@@ -253,7 +253,7 @@ extern "C" PyObject * PythonScriptController_onMouseButtonLeft(PyObject * /*self
     if (!PyArg_ParseTuple(args, "iib",&x,&y,&pressed))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
@@ -271,7 +271,7 @@ extern "C" PyObject * PythonScriptController_onMouseButtonMiddle(PyObject * /*se
     if (!PyArg_ParseTuple(args, "iib",&x,&y,&pressed))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
@@ -289,7 +289,7 @@ extern "C" PyObject * PythonScriptController_onMouseButtonRight(PyObject * /*sel
     if (!PyArg_ParseTuple(args, "iib",&x,&y,&pressed))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
@@ -306,7 +306,7 @@ extern "C" PyObject * PythonScriptController_onMouseWheel(PyObject * /*self*/, P
     if (!PyArg_ParseTuple(args, "iii",&x,&y,&delta))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
@@ -325,13 +325,13 @@ extern "C" PyObject * PythonScriptController_onScriptEvent(PyObject * /*self*/, 
     if (!PyArg_ParseTuple(args, "OsO",&pySenderNode,&eventName,&pyData))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     BaseNode* senderBaseNode = ((PySPtr<Base>*)pySenderNode)->object->toBaseNode();
     if (!senderBaseNode)
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     // TODO check pyData

--- a/applications/plugins/SofaPython/Binding_RegularGridTopology.cpp
+++ b/applications/plugins/SofaPython/Binding_RegularGridTopology.cpp
@@ -33,7 +33,7 @@ extern "C" PyObject * RegularGridTopology_setPos(PyObject *self, PyObject * args
     if (!PyArg_ParseTuple(args, "dddddd",&xmin,&xmax,&ymin,&ymax,&zmin,&zmax))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     obj->setPos(xmin,xmax,ymin,ymax,zmin,zmax);
     Py_RETURN_NONE;

--- a/applications/plugins/SofaPython/Binding_SofaModule.cpp
+++ b/applications/plugins/SofaPython/Binding_SofaModule.cpp
@@ -64,7 +64,7 @@ extern "C" PyObject * Sofa_createNode(PyObject * /*self*/, PyObject * args)
     if (!PyArg_ParseTuple(args, "s",&name))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     sofa::simulation::Node::SPtr node = sofa::simulation::Node::create( name );
@@ -80,7 +80,7 @@ extern "C" PyObject * Sofa_createObject(PyObject * /*self*/, PyObject * args, Py
     if (!PyArg_ParseTuple(args, "s",&type))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     SP_MESSAGE_DEPRECATED( "Sofa.createObject is deprecated; use Sofa.Node.createObject instead." )
@@ -106,7 +106,7 @@ extern "C" PyObject * Sofa_createObject(PyObject * /*self*/, PyObject * args, Py
     {
         SP_MESSAGE_ERROR( "createObject "<<desc.getName().c_str()<<" of type "<<desc.getAttribute("type","") )
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     // by default, it will always be at least a BaseObject...
@@ -119,7 +119,7 @@ extern "C" PyObject * Sofa_getObject(PyObject * /*self*/, PyObject * /*args*/)
     // deprecated on date 2012/07/18
     SP_MESSAGE_DEPRECATED( "Sofa.getObject(BaseContext,path) is deprecated. Please use BaseContext.getObject(path) instead." )
     PyErr_BadArgument();
-    Py_RETURN_NONE;
+    return NULL;
 
 }
 
@@ -128,7 +128,7 @@ extern "C" PyObject * Sofa_getChildNode(PyObject * /*self*/, PyObject * /*args*/
     // deprecated on date 2012/07/18
     SP_MESSAGE_DEPRECATED( "Sofa.getChildNode(Node,path) is deprecated. Please use Node.getChild(path) instead." )
     PyErr_BadArgument();
-    Py_RETURN_NONE;
+    return NULL;
 }
 
 using namespace sofa::gui;
@@ -159,7 +159,7 @@ extern "C" PyObject * Sofa_saveScreenshot(PyObject * /*self*/, PyObject * args)
     if (!PyArg_ParseTuple(args, "s",&filename))
     {
         PyErr_BadArgument();
-        return 0;
+        return NULL;
     }
     BaseGUI *gui = GUIManager::getGUI();
     if (!gui)
@@ -181,7 +181,7 @@ extern "C" PyObject * Sofa_setViewerResolution(PyObject * /*self*/, PyObject * a
     if (!PyArg_ParseTuple(args, "ii",&width,&height))
     {
         PyErr_BadArgument();
-        return 0;
+        return NULL;
     }
     BaseGUI *gui = GUIManager::getGUI();
     if (!gui)
@@ -204,13 +204,13 @@ extern "C" PyObject * Sofa_setViewerBackgroundColor(PyObject * /*self*/, PyObjec
     if (!PyArg_ParseTuple(args, "fff", &r, &g, &b))
     {
         PyErr_BadArgument();
-        return 0;
+        return NULL;
     }
 	color[0] = r; color[1] = g; color[2] = b;
 	for (int i = 0; i < 3; ++i){
 		if (color[i] < 00.f || color[i] > 1.0) {
 			PyErr_BadArgument();
-			return 0;
+			return NULL;
 		}
 	}
 
@@ -235,7 +235,7 @@ extern "C" PyObject * Sofa_setViewerCamera(PyObject * /*self*/, PyObject * args)
     if (!PyArg_ParseTuple(args, "fffffff", &px, &py, &pz, &qx, &qy, &qz, &qw))
     {
         PyErr_BadArgument();
-        return 0;
+        return NULL;
     }
 
 
@@ -293,7 +293,7 @@ extern "C" PyObject * Sofa_generateRigid(PyObject * /*self*/, PyObject * args)
     if (!PyArg_ParseTuple(args, "sddddddd",&meshFilename,&density,&sx,&sy,&sz,&rx,&ry,&rz))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     sofa::helper::GenerateRigidInfo rigid;
@@ -316,14 +316,14 @@ extern "C" PyObject * Sofa_exportGraph(PyObject * /*self*/, PyObject * args)
     if (!PyArg_ParseTuple(args, "Os", &pyNode, &filename))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     BaseNode* node=((PySPtr<Base>*)pyNode)->object->toBaseNode();
     if (!node)
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
 
@@ -340,14 +340,14 @@ extern "C" PyObject * Sofa_updateVisual(PyObject * /*self*/, PyObject * args)
     if (!PyArg_ParseTuple(args, "O", &pyNode))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     BaseNode* basenode=((PySPtr<Base>*)pyNode)->object->toBaseNode();
     if (!basenode)
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     Node* node = down_cast<Node>(basenode);
@@ -377,7 +377,7 @@ extern "C" PyObject * Sofa_msg_info(PyObject * /*self*/, PyObject * args)
         if( !PyArg_ParseTuple(args, "ss", &emitter, &message) )
         {
             PyErr_BadArgument();
-            Py_RETURN_NONE;
+            return NULL;
         }
 
         msg_info( emitter ) << message;
@@ -387,7 +387,7 @@ extern "C" PyObject * Sofa_msg_info(PyObject * /*self*/, PyObject * args)
         if( !PyArg_ParseTuple(args, "s", &message) )
         {
             PyErr_BadArgument();
-            Py_RETURN_NONE;
+            return NULL;
         }
 
         msg_info( s_emitter ) << message;
@@ -408,7 +408,7 @@ extern "C" PyObject * Sofa_msg_deprecated(PyObject * /*self*/, PyObject * args)
         if( !PyArg_ParseTuple(args, "ss", &emitter, &message) )
         {
             PyErr_BadArgument();
-            Py_RETURN_NONE;
+            return NULL;
         }
 
         msg_deprecated( emitter ) << message;
@@ -418,7 +418,7 @@ extern "C" PyObject * Sofa_msg_deprecated(PyObject * /*self*/, PyObject * args)
         if( !PyArg_ParseTuple(args, "s", &message) )
         {
             PyErr_BadArgument();
-            Py_RETURN_NONE;
+            return NULL;
         }
 
         msg_deprecated( s_emitter ) << message;
@@ -439,7 +439,7 @@ extern "C" PyObject * Sofa_msg_warning(PyObject * /*self*/, PyObject * args)
         if( !PyArg_ParseTuple(args, "ss", &emitter, &message) )
         {
             PyErr_BadArgument();
-            Py_RETURN_NONE;
+            return NULL;
         }
 
         msg_warning( emitter ) << message;
@@ -449,7 +449,7 @@ extern "C" PyObject * Sofa_msg_warning(PyObject * /*self*/, PyObject * args)
         if( !PyArg_ParseTuple(args, "s", &message) )
         {
             PyErr_BadArgument();
-            Py_RETURN_NONE;
+            return NULL;
         }
 
         msg_warning( s_emitter ) << message;
@@ -470,7 +470,7 @@ extern "C" PyObject * Sofa_msg_error(PyObject * /*self*/, PyObject * args)
         if( !PyArg_ParseTuple(args, "ss", &emitter, &message) )
         {
             PyErr_BadArgument();
-            Py_RETURN_NONE;
+            return NULL;
         }
 
         msg_error( emitter ) << message;
@@ -480,7 +480,7 @@ extern "C" PyObject * Sofa_msg_error(PyObject * /*self*/, PyObject * args)
         if( !PyArg_ParseTuple(args, "s", &message) )
         {
             PyErr_BadArgument();
-            Py_RETURN_NONE;
+            return NULL;
         }
 
         msg_error( s_emitter ) << message;
@@ -501,7 +501,7 @@ extern "C" PyObject * Sofa_msg_fatal(PyObject * /*self*/, PyObject * args)
         if( !PyArg_ParseTuple(args, "ss", &emitter, &message) )
         {
             PyErr_BadArgument();
-            Py_RETURN_NONE;
+            return NULL;
         }
 
         msg_fatal( emitter ) << message;
@@ -511,7 +511,7 @@ extern "C" PyObject * Sofa_msg_fatal(PyObject * /*self*/, PyObject * args)
         if( !PyArg_ParseTuple(args, "s", &message) )
         {
             PyErr_BadArgument();
-            Py_RETURN_NONE;
+            return NULL;
         }
 
         msg_fatal( s_emitter ) << message;
@@ -527,7 +527,7 @@ extern "C" PyObject * Sofa_loadScene(PyObject * /*self*/, PyObject * args)
     if (!PyArg_ParseTuple(args, "s",&filename))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     if( sofa::helper::system::SetDirectory::GetFileName(filename).empty() || // no filename
@@ -583,7 +583,7 @@ extern "C" PyObject * Sofa_loadPlugin(PyObject * /*self*/, PyObject * args)
     if (!PyArg_ParseTuple(args, "s",&pluginName))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     using sofa::helper::system::PluginManager;
@@ -609,6 +609,7 @@ extern "C" PyObject * Sofa_loadPlugin(PyObject * /*self*/, PyObject * args)
     {
         SP_MESSAGE_WARNING( "Sofa_loadPlugin: cannot find plugin: " << pluginName );
         PyErr_BadArgument();
+        return NULL;
     }
 
     Py_RETURN_NONE;

--- a/applications/plugins/SofaPython/Binding_SubsetMultiMapping.cpp
+++ b/applications/plugins/SofaPython/Binding_SubsetMultiMapping.cpp
@@ -35,7 +35,7 @@ extern "C" PyObject * SubsetMultiMapping3_to_3_addPoint(PyObject *self, PyObject
     if (!PyArg_ParseTuple(args, "Oi",&pyState,&index))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     sofa::core::BaseState* state=((PySPtr<sofa::core::objectmodel::Base>*)pyState)->object->toBaseState();
 

--- a/applications/plugins/SofaPython/Binding_Topology.cpp
+++ b/applications/plugins/SofaPython/Binding_Topology.cpp
@@ -47,7 +47,7 @@ extern "C" PyObject * Topology_setNbPoints(PyObject *self, PyObject * args)
     if (!PyArg_ParseTuple(args, "i",&nb))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     obj->setNbPoints(nb);
     Py_RETURN_NONE;
@@ -60,7 +60,7 @@ extern "C" PyObject * Topology_getPX(PyObject *self, PyObject * args)
     if (!PyArg_ParseTuple(args, "i",&i))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     return PyFloat_FromDouble(obj->getPX(i));
 }
@@ -72,7 +72,7 @@ extern "C" PyObject * Topology_getPY(PyObject *self, PyObject * args)
     if (!PyArg_ParseTuple(args, "i",&i))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     return PyFloat_FromDouble(obj->getPY(i));
 }
@@ -84,7 +84,7 @@ extern "C" PyObject * Topology_getPZ(PyObject *self, PyObject * args)
     if (!PyArg_ParseTuple(args, "i",&i))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
     return PyFloat_FromDouble(obj->getPZ(i));
 }

--- a/applications/plugins/SofaPython/Binding_Vector.cpp
+++ b/applications/plugins/SofaPython/Binding_Vector.cpp
@@ -33,7 +33,7 @@ SP_CLASS_ATTR_GET(Vector3,x)(PyObject *self, void*)
     if (!obj)
     {
         PyErr_BadArgument();
-        return 0;
+        return NULL;
     }
     return PyFloat_FromDouble(obj->x());
 }
@@ -43,7 +43,7 @@ SP_CLASS_ATTR_SET(Vector3,x)(PyObject *self, PyObject * args, void*)
     if (!obj)
     {
         PyErr_BadArgument();
-        return 0;
+        return -1;
     }
     obj->x()=PyFloat_AsDouble(args);
     return 0;
@@ -55,7 +55,7 @@ SP_CLASS_ATTR_GET(Vector3,y)(PyObject *self, void*)
     if (!obj)
     {
         PyErr_BadArgument();
-        return 0;
+        return NULL;
     }
     return PyFloat_FromDouble(obj->y());
 }
@@ -65,7 +65,7 @@ SP_CLASS_ATTR_SET(Vector3,y)(PyObject *self, PyObject * args, void*)
     if (!obj)
     {
         PyErr_BadArgument();
-        return 0;
+        return -1;
     }
     obj->y()=PyFloat_AsDouble(args);
     return 0;
@@ -77,7 +77,7 @@ SP_CLASS_ATTR_GET(Vector3,z)(PyObject *self, void*)
     if (!obj)
     {
         PyErr_BadArgument();
-        return 0;
+        return NULL;
     }
     return PyFloat_FromDouble(obj->z());
 }
@@ -87,7 +87,7 @@ SP_CLASS_ATTR_SET(Vector3,z)(PyObject *self, PyObject * args, void*)
     if (!obj)
     {
         PyErr_BadArgument();
-        return 0;
+        return -1;
     }
     obj->z()=PyFloat_AsDouble(args);
     return 0;

--- a/applications/plugins/SofaPython/Binding_VisualModel.cpp
+++ b/applications/plugins/SofaPython/Binding_VisualModel.cpp
@@ -39,7 +39,7 @@ extern "C" PyObject * VisualModelImpl_setColor(PyObject *self, PyObject * args)
         if (!PyArg_ParseTuple(args, "iiii",&ir,&ig,&ib,&ia))
         {
             PyErr_BadArgument();
-            Py_RETURN_NONE;
+            return NULL;
         }
         r = (double)ir;
         g = (double)ig;
@@ -58,7 +58,7 @@ extern "C" PyObject * VisualModel_exportOBJ(PyObject *self, PyObject * args)
     if (!PyArg_ParseTuple(args, "s",&filename))
     {
         PyErr_BadArgument();
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     std::ofstream outfile(filename);


### PR DESCRIPTION
This PR fixes exception handling in Python bindings.

Mostly, the PR replaces the incorrect:
```c++
    PyErr_BadArgument();
    Py_RETURN_NONE;
```
with the correct:
```c++
    PyErr_BadArgument();
    return NULL;
```

As the [Python API](https://docs.python.org/2/c-api/exceptions.html) documentation says: 

> [Python exception handling] works somewhat like the Unix errno variable: there is a global indicator (per thread) of the last error that occurred. Most functions don’t clear this on success, but will set it to indicate the cause of the error on failure.
> 
> **Most functions also return an error indicator, usually NULL if they are supposed to return a pointer, or -1 if they return an integer (exception: the PyArg_*() functions return 1 for success and 0 for failure).**

As it happened, any error triggered within the python bindings would go unnoticed until someone else would check the error flag using `PyErr_Occurred`, possibly during a python code error or by some other C extension (in my case, Numpy). 

Hopefully the behaviour is now correct.


<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings nor unit test failures.
- [x] does not break existing scenes.
- [x] does not break API compatibility.
- [x] the content of the PR is clear and that a future PR from @maxime-tournier may follow the @matthieu-nesme suggestion. 
- [x] is more than 1 week old.
**Reviewers will merge only if all this checks are true.**