### PR TITLE
[All] Fixing issue related to parsing attributes with atof/atoi

### DIFF
--- a/SofaKernel/framework/framework_test/CMakeLists.txt
+++ b/SofaKernel/framework/framework_test/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCE_FILES
     core/loader/MeshLoader_test.cpp
     core/objectmodel/AspectPool_test.cpp
     core/objectmodel/Data_test.cpp
+    core/objectmodel/BaseObjectDescription_test.cpp
     core/DataEngine_test.cpp
     core/TrackedData_test.cpp
     defaulttype/MatTypes_test.cpp

--- a/SofaKernel/framework/framework_test/core/objectmodel/BaseObjectDescription_test.cpp
+++ b/SofaKernel/framework/framework_test/core/objectmodel/BaseObjectDescription_test.cpp
@@ -134,6 +134,34 @@ struct BaseObjectDescription_test: public Sofa_test<>
         EXPECT_EQ( objectDescription.getErrors().size(), (size_t)3) ;
     }
 
+    void checkGetAttributeAsInt()
+    {
+        BaseObjectDescription objectDescription("theName", "theType");
+        size_t numattr=objectDescription.getAttributeMap().size() ;
+
+        objectDescription.setAttribute("anAttribute", "true") ;
+        EXPECT_EQ( objectDescription.getAttributeMap().size(), numattr+1) ;
+
+        objectDescription.setAttribute("aFirstIntAttribute", "234") ;
+        EXPECT_EQ( objectDescription.getAttributeMap().size(), numattr+2) ;
+
+        objectDescription.setAttribute("aSecondIntAttribute", "-234") ;
+        EXPECT_EQ( objectDescription.getAttributeMap().size(), numattr+2) ;
+
+        objectDescription.setAttribute("aFirstNonIntAttribute", "1,0") ;
+        EXPECT_EQ( objectDescription.getAttributeMap().size(), numattr+3) ;
+
+        objectDescription.setAttribute("aSecondNonIntAttribute", "1.0") ;
+        EXPECT_EQ( objectDescription.getAttributeMap().size(), numattr+4) ;
+
+        EXPECT_EQ( objectDescription.getAttributeAsInt("aFirstIntAttribute", 1234), 234) ;
+        EXPECT_EQ( objectDescription.getAttributeAsInt("aSecondIntAttribute", 1234), -234) ;
+
+        EXPECT_EQ( objectDescription.getAttributeAsInt("aFirstNonIntAttribute", -1234.0), -1234.0) ;
+        EXPECT_EQ( objectDescription.getAttributeAsInt("aSecondNonIntAttribute", -1234.0), -1234.0) ;
+        EXPECT_EQ( objectDescription.getErrors().size(), (size_t)2) << "If this fails this means that one of the three previous "
+                                                               "conversion succeded while it shouldn't";
+    }
 };
 
 
@@ -148,6 +176,11 @@ TEST_F(BaseObjectDescription_test, checkSetGetAttribute)
 }
 
 TEST_F(BaseObjectDescription_test ,  checkGetAttributeAsFloat)
+{
+    this->checkGetAttributeAsFloat();
+}
+
+TEST_F(BaseObjectDescription_test ,  checkGetAttributeAsInt)
 {
     this->checkGetAttributeAsFloat();
 }

--- a/SofaKernel/framework/framework_test/core/objectmodel/BaseObjectDescription_test.cpp
+++ b/SofaKernel/framework/framework_test/core/objectmodel/BaseObjectDescription_test.cpp
@@ -1,0 +1,159 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU General Public License as published by the Free  *
+* Software Foundation; either version 2 of the License, or (at your option)   *
+* any later version.                                                          *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for    *
+* more details.                                                               *
+*                                                                             *
+* You should have received a copy of the GNU General Public License along     *
+* with this program. If not, see <http://www.gnu.org/licenses/>.              *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <SofaSimulationCommon/init.h>
+using sofa::simulation::common::init ;
+
+#include <SofaSimulationGraph/init.h>
+using sofa::simulation::graph::init ;
+
+#include <SofaComponentBase/initComponentBase.h>
+using sofa::component::initComponentBase ;
+
+#include <SofaTest/Sofa_test.h>
+using sofa::Sofa_test ;
+
+#include <sofa/core/objectmodel/BaseObjectDescription.h>
+using sofa::core::objectmodel::BaseObjectDescription ;
+
+#include <SofaTest/TestMessageHandler.h>
+using sofa::helper::logging::Message ;
+using sofa::helper::logging::ExpectMessage ;
+
+
+
+struct BaseObjectDescription_test: public Sofa_test<>
+{
+    void SetUp()
+    {
+    }
+
+    void TearDown()
+    {
+    }
+
+    void checkConstructorBehavior()
+    {
+        BaseObjectDescription objectDescription("theName", "theType");
+
+        EXPECT_EQ( objectDescription.getName(), "theName");
+        EXPECT_STREQ( objectDescription.getAttribute("name"), "theName");
+        EXPECT_STREQ( objectDescription.getAttribute("type"), "theType");
+
+        EXPECT_EQ( objectDescription.getBaseFile(), "") ;
+
+        EXPECT_EQ( objectDescription.find(""), nullptr );
+        EXPECT_EQ( objectDescription.find("aNonExistantName"), nullptr );
+
+        EXPECT_EQ( objectDescription.getObject(), nullptr );
+
+        /// This function is supposed to return an error message if there is no context.
+        {
+            ExpectMessage error(Message::Error) ;
+            EXPECT_EQ( objectDescription.findObject("aNonExistantName"), nullptr );
+        }
+
+    }
+
+    void checkSetGetAttribute()
+    {
+        BaseObjectDescription objectDescription("theName", "theType");
+
+        size_t numattr=objectDescription.getAttributeMap().size() ;
+
+        objectDescription.setAttribute("anAttribute", "true") ;
+        EXPECT_EQ( (objectDescription.getAttributeMap().size()), numattr+1) ;
+
+        const char* res = objectDescription.getAttribute("anAttribute", "notFound") ;
+        EXPECT_STREQ(res, "true");
+    }
+
+    void checkRemoveAnAttribute()
+    {
+        BaseObjectDescription objectDescription("theName", "theType");
+
+        size_t numattr=objectDescription.getAttributeMap().size() ;
+
+        objectDescription.setAttribute("anAttribute", "true") ;
+        EXPECT_EQ( (objectDescription.getAttributeMap().size()), numattr+1) ;
+
+        ASSERT_FALSE( objectDescription.removeAttribute("anAttributeThatDoesNotExist") );
+        EXPECT_EQ( objectDescription.getAttributeMap().size(), numattr+1) ;
+
+        ASSERT_TRUE( objectDescription.removeAttribute("anAttribute") ) ;
+        EXPECT_EQ( objectDescription.getAttributeMap().size(), numattr) ;
+
+        const char* res = objectDescription.getAttribute("anAttribute", "notFound") ;
+        EXPECT_STREQ(res, "notFound");
+    }
+
+
+    void checkGetAttributeAsFloat()
+    {
+        BaseObjectDescription objectDescription("theName", "theType");
+        size_t numattr=objectDescription.getAttributeMap().size() ;
+
+        objectDescription.setAttribute("anAttribute", "true") ;
+        EXPECT_EQ( objectDescription.getAttributeMap().size(), numattr+1) ;
+
+        objectDescription.setAttribute("aFloatAttribute", "1.0") ;
+        EXPECT_EQ( objectDescription.getAttributeMap().size(), numattr+2) ;
+
+        objectDescription.setAttribute("aFirstNonFloatAttribute", "1,0") ;
+        EXPECT_EQ( objectDescription.getAttributeMap().size(), numattr+3) ;
+
+        objectDescription.setAttribute("aSecondNonFloatAttribute", "1.0 2.0") ;
+        EXPECT_EQ( objectDescription.getAttributeMap().size(), numattr+4) ;
+
+
+        EXPECT_EQ( objectDescription.getAttributeAsFloat("anAttribute", -1234.0), -1234.0) ;
+        EXPECT_EQ( objectDescription.getAttributeAsFloat("aFirstNonFloatAttribute", -1234.0), -1234.0) ;
+        EXPECT_EQ( objectDescription.getAttributeAsFloat("aSecondNonFloatAttribute", -1234.0), -1234.0) ;
+        EXPECT_EQ( objectDescription.getErrors().size(), (size_t)3) << "If this fails this means that one of the three previous "
+                                                               "conversion succeded while it shouldn't";
+
+        EXPECT_EQ( objectDescription.getAttributeAsFloat("aFloatAttribute", -1234.0), 1.0) ;
+        EXPECT_EQ( objectDescription.getErrors().size(), (size_t)3) ;
+    }
+
+};
+
+
+TEST_F(BaseObjectDescription_test, checkConstructorBehavior)
+{
+    this->checkConstructorBehavior();
+}
+
+TEST_F(BaseObjectDescription_test, checkSetGetAttribute)
+{
+    this->checkSetGetAttribute();
+}
+
+TEST_F(BaseObjectDescription_test ,  checkGetAttributeAsFloat)
+{
+    this->checkGetAttributeAsFloat();
+}
+
+TEST_F(BaseObjectDescription_test ,  checkRemoveAnAttribute_OpenIssue)
+{
+    this->checkRemoveAnAttribute();
+}
+

--- a/SofaKernel/framework/sofa/core/loader/MeshLoader.cpp
+++ b/SofaKernel/framework/sofa/core/loader/MeshLoader.cpp
@@ -94,7 +94,7 @@ void MeshLoader::parse(sofa::core::objectmodel::BaseObjectDescription* arg)
 
     if (arg->getAttribute("scale"))
     {
-        SReal s = (SReal) atof(arg->getAttribute("scale"));
+        SReal s = (SReal) arg->getAttributeAsFloat("scale", 1.0);
         d_scale.setValue(d_scale.getValue()*s);
     }
 
@@ -224,7 +224,7 @@ void MeshLoader::updateElements()
         for (size_t i = 0; i < triangles.size(); ++i)
             eSetTri.insert(uniqueOrder(triangles[i]));
         int nbnewTri = 0;
-  
+
         for (size_t i = 0; i < pentahedra.size(); ++i)
         {
             Pentahedron p = pentahedra[i];
@@ -243,7 +243,7 @@ void MeshLoader::updateElements()
                 quads.push_back(quad2);
                 ++nbnewQuad;
             }
-            if (eSetQuad.insert(uniqueOrder(quad3)).second){ // the element was inserted     
+            if (eSetQuad.insert(uniqueOrder(quad3)).second){ // the element was inserted
                 quads.push_back(quad3);
                 ++nbnewQuad;
             }
@@ -255,7 +255,7 @@ void MeshLoader::updateElements()
                 triangles.push_back(tri2);
                 ++nbnewTri;
             }
-           
+
         }
         if (nbnewQuad > 0 || nbnewTri>0 )
             sout << nbnewQuad << " quads, "<<nbnewTri<<" triangles were missing around the pentahedra" << sendl;
@@ -263,7 +263,7 @@ void MeshLoader::updateElements()
     if (d_pyramids.getValue().size() > 0 && d_createSubelements.getValue())
     {
         helper::ReadAccessor<Data<helper::vector< Pyramid > > > pyramids = this->d_pyramids;
-        
+
         helper::WriteAccessor<Data<helper::vector< Quad > > > quads = this->d_quads;
         helper::WriteAccessor<Data<helper::vector< Triangle > > > triangles = this->d_triangles;
 
@@ -276,7 +276,7 @@ void MeshLoader::updateElements()
         for (size_t i = 0; i < triangles.size(); ++i)
             eSetTri.insert(uniqueOrder(triangles[i]));
         int nbnewTri = 0;
-        
+
         for (size_t i = 0; i < pyramids.size(); ++i)
         {
             Pyramid p = pyramids[i];
@@ -324,7 +324,7 @@ void MeshLoader::updateElements()
             Tetrahedron t = tetrahedra[i];
             Triangle e1(t[0],t[2],t[1]);
             Triangle e2(t[0],t[1],t[3]);
-            Triangle e3(t[0],t[3],t[2]); 
+            Triangle e3(t[0],t[3],t[2]);
             Triangle e4(t[1],t[2],t[3]);  //vtk ordering http://www.vtk.org/wp-content/uploads/2015/04/file-formats.pdf
             if (eSet.insert(uniqueOrder(e1)).second){ // the element was inserted
                 triangles.push_back(e1);

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseObjectDescription.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseObjectDescription.cpp
@@ -111,8 +111,7 @@ const char* BaseObjectDescription::getAttribute(const std::string& attr, const c
         return it->second.c_str();
 }
 
-/// Get an attribute given its name (return defaultVal if not present)
-/// send a message if there the attribute cannot be fully parsed.
+/// Docs is in .h
 float BaseObjectDescription::getAttributeAsFloat(const std::string& attr, const float defaultVal)
 {
     AttributeMap::iterator it = attributes.find(attr);
@@ -129,8 +128,35 @@ float BaseObjectDescription::getAttributeAsFloat(const std::string& attr, const 
     /// It is important to check that the attribute was totally parsed to report
     /// message to users because a silent error is the worse thing that can happen in UX.
     if(end !=  attrstr+strlen(attrstr)){
-        errors.push_back("unable to parse the a float from attribute '"+attr+"'='"+it->second.c_str()+"'");
+        std::stringstream msg;
+        msg << "Unable to parse a float value from attribute '" << attr << "'='"<<it->second.c_str()<<"'. "
+               "Use the default value '"<<defaultVal<< "' instead.";
+        errors.push_back(msg.str());
         return defaultVal ;
+    }
+
+    return retval ;
+}
+
+/// Docs is in .h
+int BaseObjectDescription::getAttributeAsInt(const std::string& attr, const int defaultVal)
+{
+    AttributeMap::iterator it = attributes.find(attr);
+    if (it == attributes.end())
+        return defaultVal;
+
+    const char* attrstr=it->second.c_str();
+    char* end=nullptr;
+    int retval = strtol(attrstr, &end, 10);
+
+    /// It is important to check that the attribute was totally parsed to report
+    /// message to users because a silent error is the worse thing that can happen in UX.
+    if(end !=  attrstr+strlen(attrstr)){
+        std::stringstream msg;
+        msg << "Unable to parse an integer value from attribute '" << attr << "'='"<<it->second.c_str()<<"'. "
+               "Use the default value '"<<defaultVal<< "' instead.";
+        errors.push_back(msg.str());
+        return defaultVal;
     }
 
     return retval ;

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseObjectDescription.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseObjectDescription.h
@@ -107,6 +107,9 @@ public:
     /// Get an attribute given its name (return defaultVal if not present)
     virtual const char* getAttribute(const std::string& attr, const char* defaultVal=NULL);
 
+    /// Get an attribute given its name (return defaultVal if not present)
+    virtual float getAttributeAsFloat(const std::string& attr, const float defaultVal=0.0);
+
     /// Set an attribute. Override any existing value
     virtual void setAttribute(const std::string& attr, const char* val);
 

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseObjectDescription.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseObjectDescription.h
@@ -107,8 +107,15 @@ public:
     /// Get an attribute given its name (return defaultVal if not present)
     virtual const char* getAttribute(const std::string& attr, const char* defaultVal=NULL);
 
-    /// Get an attribute given its name (return defaultVal if not present)
+    /// Get an attribute converted to a float given its name.
+    /// returns defaultVal if not present or in case the attribute cannot be parsed totally
+    /// adds a message in the logError if the attribute cannot be totally parsed.
     virtual float getAttributeAsFloat(const std::string& attr, const float defaultVal=0.0);
+
+    /// Get an attribute converted to a int given its name.
+    /// returns defaultVal if not present or in case the attribute cannot be parsed totally
+    /// adds a message in the logError if the attribute cannot be totally parsed.
+    virtual int getAttributeAsInt(const std::string& attr, const int defaultVal=0.0) ;
 
     /// Set an attribute. Override any existing value
     virtual void setAttribute(const std::string& attr, const char* val);

--- a/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.inl
@@ -289,7 +289,17 @@ void MechanicalObject<DataTypes>::parse ( sofa::core::objectmodel::BaseObjectDes
 
     if (arg->getAttribute("size") != NULL)
     {
-        resize(atoi(arg->getAttribute("size", "0")));
+        int newsize = arg->getAttributeAsInt("size", 0) ;
+        if(newsize>=0)
+        {
+            resize(newsize) ;
+        }
+        else
+        {
+            msg_warning(this) << "The attribute 'size' cannot have a negative value.  "
+                                 "The value "<<newsize<<" is ignored."
+                                 "To remove this warning you need to fix your scene.";
+        }
     }
 
     if (arg->getAttribute("scale") != NULL)

--- a/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.inl
@@ -289,7 +289,7 @@ void MechanicalObject<DataTypes>::parse ( sofa::core::objectmodel::BaseObjectDes
 
     if (arg->getAttribute("size") != NULL)
     {
-        int newsize = arg->getAttributeAsInt("size", 0) ;
+        int newsize = arg->getAttributeAsInt("size", 1) ;
         if(newsize>=0)
         {
             resize(newsize) ;
@@ -297,7 +297,7 @@ void MechanicalObject<DataTypes>::parse ( sofa::core::objectmodel::BaseObjectDes
         else
         {
             msg_warning(this) << "The attribute 'size' cannot have a negative value.  "
-                                 "The value "<<newsize<<" is ignored."
+                                 "The value "<<newsize<<" is ignored. Current value is " <<getSize()<< ".  "
                                  "To remove this warning you need to fix your scene.";
         }
     }

--- a/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.inl
@@ -294,33 +294,43 @@ void MechanicalObject<DataTypes>::parse ( sofa::core::objectmodel::BaseObjectDes
 
     if (arg->getAttribute("scale") != NULL)
     {
-        SReal s = (SReal)atof(arg->getAttribute("scale", "1.0"));
+        SReal s = (SReal)arg->getAttributeAsFloat("scale", 1.0);
         scale.setValue(Vector3(s, s, s));
     }
 
     if (arg->getAttribute("sx") != NULL || arg->getAttribute("sy") != NULL || arg->getAttribute("sz") != NULL)
     {
-        scale.setValue(Vector3((SReal)(atof(arg->getAttribute("sx","1.0"))),(SReal)(atof(arg->getAttribute("sy","1.0"))),(SReal)(atof(arg->getAttribute("sz","1.0")))));
+        scale.setValue(Vector3((SReal)arg->getAttributeAsFloat("sx",1.0),
+                               (SReal)arg->getAttributeAsFloat("sy",1.0),
+                               (SReal)arg->getAttributeAsFloat("sz",1.0)));
     }
 
     if (arg->getAttribute("rx") != NULL || arg->getAttribute("ry") != NULL || arg->getAttribute("rz") != NULL)
     {
-        rotation.setValue(Vector3((SReal)(atof(arg->getAttribute("rx","0.0"))),(SReal)(atof(arg->getAttribute("ry","0.0"))),(SReal)(atof(arg->getAttribute("rz","0.0")))));
+        rotation.setValue(Vector3((SReal)arg->getAttributeAsFloat("rx",0.0),
+                                  (SReal)arg->getAttributeAsFloat("ry",0.0),
+                                  (SReal)arg->getAttributeAsFloat("rz",0.0)));
     }
 
     if (arg->getAttribute("dx") != NULL || arg->getAttribute("dy") != NULL || arg->getAttribute("dz") != NULL)
     {
-        translation.setValue(Vector3((Real)atof(arg->getAttribute("dx","0.0")), (Real)atof(arg->getAttribute("dy","0.0")), (Real)atof(arg->getAttribute("dz","0.0"))));
+        translation.setValue(Vector3((Real)arg->getAttributeAsFloat("dx",0.0),
+                                     (Real)arg->getAttributeAsFloat("dy",0.0),
+                                     (Real)arg->getAttributeAsFloat("dz",0.0)));
     }
 
     if (arg->getAttribute("rx2") != NULL || arg->getAttribute("ry2") != NULL || arg->getAttribute("rz2") != NULL)
     {
-        rotation2.setValue(Vector3((SReal)(atof(arg->getAttribute("rx2","0.0"))),(SReal)(atof(arg->getAttribute("ry2","0.0"))),(SReal)(atof(arg->getAttribute("rz2","0.0")))));
+        rotation2.setValue(Vector3((SReal)arg->getAttributeAsFloat("rx2",0.0),
+                                   (SReal)arg->getAttributeAsFloat("ry2",0.0),
+                                   (SReal)arg->getAttributeAsFloat("rz2",0.0)));
     }
 
     if (arg->getAttribute("dx2") != NULL || arg->getAttribute("dy2") != NULL || arg->getAttribute("dz2") != NULL)
     {
-        translation2.setValue(Vector3((Real)atof(arg->getAttribute("dx2","0.0")), (Real)atof(arg->getAttribute("dy2","0.0")), (Real)atof(arg->getAttribute("dz2","0.0"))));
+        translation2.setValue(Vector3((Real)arg->getAttributeAsFloat("dx2",0.0),
+                                      (Real)arg->getAttributeAsFloat("dy2",0.0),
+                                      (Real)arg->getAttributeAsFloat("dz2",0.0)));
     }
 
 

--- a/SofaKernel/modules/SofaBaseTopology/GridTopology.h
+++ b/SofaKernel/modules/SofaBaseTopology/GridTopology.h
@@ -84,10 +84,10 @@ public:
 
         if (arg->getAttribute("nx")!=NULL && arg->getAttribute("ny")!=NULL && arg->getAttribute("nz")!=NULL )
         {
-            const char* nx = arg->getAttribute("nx");
-            const char* ny = arg->getAttribute("ny");
-            const char* nz = arg->getAttribute("nz");
-            n.setValue(Vec3i(atoi(nx),atoi(ny),atoi(nz)));
+            int nx = arg->getAttributeAsInt("nx", n.getValue().x());
+            int ny = arg->getAttributeAsInt("ny", n.getValue().y());
+            int nz = arg->getAttributeAsInt("nz", n.getValue().z());
+            n.setValue(Vec3i(nx,ny,nz));
         }
 
         this->setSize();

--- a/SofaKernel/modules/SofaBaseTopology/RegularGridTopology.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/RegularGridTopology.cpp
@@ -41,7 +41,7 @@ void RegularGridTopology::parse(core::objectmodel::BaseObjectDescription* arg)
     float scale=1.0f;
     if (arg->getAttribute("scale")!=NULL)
     {
-        scale = (float)atof(arg->getAttribute("scale"));
+        scale = arg->getAttributeAsFloat("scale", 1.0);
     }
 
     this->GridTopology::parse(arg);
@@ -52,14 +52,14 @@ void RegularGridTopology::parse(core::objectmodel::BaseObjectDescription* arg)
         arg->getAttribute("ymax") != NULL &&
         arg->getAttribute("zmax") != NULL )
     {
-        const char* xmin = arg->getAttribute("xmin");
-        const char* ymin = arg->getAttribute("ymin");
-        const char* zmin = arg->getAttribute("zmin");
-        const char* xmax = arg->getAttribute("xmax");
-        const char* ymax = arg->getAttribute("ymax");
-        const char* zmax = arg->getAttribute("zmax");
-        min.setValue(Vector3((SReal)atof(xmin)*scale, (SReal)atof(ymin)*scale, (SReal)atof(zmin)*scale));
-        max.setValue(Vector3((SReal)atof(xmax)*scale, (SReal)atof(ymax)*scale, (SReal)atof(zmax)*scale));
+        float xmin = arg->getAttributeAsFloat("xmin",0);
+        float ymin = arg->getAttributeAsFloat("ymin",0);
+        float zmin = arg->getAttributeAsFloat("zmin",0);
+        float xmax = arg->getAttributeAsFloat("xmax",1);
+        float ymax = arg->getAttributeAsFloat("ymax",1);
+        float zmax = arg->getAttributeAsFloat("zmax",1);
+        min.setValue(Vector3((SReal)xmin*scale, (SReal)ymin*scale, (SReal)zmin*scale));
+        max.setValue(Vector3((SReal)xmax*scale, (SReal)ymax*scale, (SReal)zmax*scale));
     }
     this->setPos(min.getValue()[0],max.getValue()[0],min.getValue()[1],max.getValue()[1],min.getValue()[2],max.getValue()[2]);
 

--- a/SofaKernel/modules/SofaBaseVisual/VisualModelImpl.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/VisualModelImpl.cpp
@@ -81,24 +81,34 @@ void VisualModelImpl::parse(core::objectmodel::BaseObjectDescription* arg)
         obj->setColor(arg->getAttribute("color"));
 
     if (arg->getAttribute("su")!=NULL || arg->getAttribute("sv")!=NULL)
-        m_scaleTex = TexCoord((float)atof(arg->getAttribute("su","1.0")),(float)atof(arg->getAttribute("sv","1.0")));
+        m_scaleTex = TexCoord(arg->getAttributeAsFloat("su",1.0),
+                              arg->getAttributeAsFloat("sv",1.0));
 
     if (arg->getAttribute("du")!=NULL || arg->getAttribute("dv")!=NULL)
-        m_translationTex = TexCoord((float)atof(arg->getAttribute("du","0.0")),(float)atof(arg->getAttribute("dv","0.0")));
+        m_translationTex = TexCoord(arg->getAttributeAsFloat("du",0.0),
+                                    arg->getAttributeAsFloat("dv",0.0));
 
     if (arg->getAttribute("rx")!=NULL || arg->getAttribute("ry")!=NULL || arg->getAttribute("rz")!=NULL)
-        m_rotation.setValue(Vec3Real((Real)(atof(arg->getAttribute("rx","0.0"))),(Real)(atof(arg->getAttribute("ry","0.0"))),(Real)(atof(arg->getAttribute("rz","0.0")))));
+        m_rotation.setValue(Vec3Real((Real)arg->getAttributeAsFloat("rx",0.0),
+                                     (Real)arg->getAttributeAsFloat("ry",0.0),
+                                     (Real)arg->getAttributeAsFloat("rz",0.0)));
 
     if (arg->getAttribute("dx")!=NULL || arg->getAttribute("dy")!=NULL || arg->getAttribute("dz")!=NULL)
-        m_translation.setValue(Vec3Real((Real)atof(arg->getAttribute("dx","0.0")), (Real)atof(arg->getAttribute("dy","0.0")), (Real)atof(arg->getAttribute("dz","0.0"))));
+        m_translation.setValue(Vec3Real((Real)arg->getAttributeAsFloat("dx",0.0),
+                                        (Real)arg->getAttributeAsFloat("dy",0.0),
+                                        (Real)arg->getAttributeAsFloat("dz",0.0)));
 
     if (arg->getAttribute("scale")!=NULL)
     {
-        m_scale.setValue(Vec3Real((Real)atof(arg->getAttribute("scale","1.0")), (Real)atof(arg->getAttribute("scale","1.0")), (Real)atof(arg->getAttribute("scale","1.0"))));
+        m_scale.setValue(Vec3Real((Real)arg->getAttributeAsFloat("scale",1.0),
+                                  (Real)arg->getAttributeAsFloat("scale",1.0),
+                                  (Real)arg->getAttributeAsFloat("scale",1.0)));
     }
     else if (arg->getAttribute("sx")!=NULL || arg->getAttribute("sy")!=NULL || arg->getAttribute("sz")!=NULL)
     {
-        m_scale.setValue(Vec3Real((Real)atof(arg->getAttribute("sx","1.0")), (Real)atof(arg->getAttribute("sy","1.0")), (Real)atof(arg->getAttribute("sz","1.0"))));
+        m_scale.setValue(Vec3Real((Real)arg->getAttributeAsFloat("sx",1.0),
+                                  (Real)arg->getAttributeAsFloat("sy",1.0),
+                                  (Real)arg->getAttributeAsFloat("sz",1.0)));
     }
 }
 

--- a/SofaKernel/modules/SofaBaseVisual/VisualModelImpl.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/VisualModelImpl.cpp
@@ -69,10 +69,10 @@ void VisualModelImpl::parse(core::objectmodel::BaseObjectDescription* arg)
     VisualModelImpl* obj = this;
 
     if (arg->getAttribute("normals")!=NULL)
-        obj->setUseNormals(atoi(arg->getAttribute("normals"))!=0);
+        obj->setUseNormals(arg->getAttributeAsInt("normals", 1)!=0);
 
     if (arg->getAttribute("castshadow")!=NULL)
-        obj->setCastShadow(atoi(arg->getAttribute("castshadow"))!=0);
+        obj->setCastShadow(arg->getAttributeAsInt("castshadow", 1)!=0);
 
     if (arg->getAttribute("flip")!=NULL)
         obj->flipFaces();

--- a/modules/SofaGeneralTopology/CubeTopology.cpp
+++ b/modules/SofaGeneralTopology/CubeTopology.cpp
@@ -42,7 +42,7 @@ void CubeTopology::parse(core::objectmodel::BaseObjectDescription* arg)
     float scale=1.0f;
     if (arg->getAttribute("scale")!=NULL)
     {
-        scale = (float)atof(arg->getAttribute("scale"));
+        scale = arg->getAttributeAsFloat("scale",1.0);
     }
     this->setSize();
     if (arg->getAttribute("xmin") != NULL &&
@@ -52,14 +52,14 @@ void CubeTopology::parse(core::objectmodel::BaseObjectDescription* arg)
         arg->getAttribute("ymax") != NULL &&
         arg->getAttribute("zmax") != NULL )
     {
-        const char* xmin = arg->getAttribute("xmin");
-        const char* ymin = arg->getAttribute("ymin");
-        const char* zmin = arg->getAttribute("zmin");
-        const char* xmax = arg->getAttribute("xmax");
-        const char* ymax = arg->getAttribute("ymax");
-        const char* zmax = arg->getAttribute("zmax");
-        min.setValue(Vector3((SReal)(atof(xmin)*scale), (SReal)(atof(ymin)*scale), (SReal)(atof(zmin)*scale)));
-        max.setValue(Vector3((SReal)(atof(xmax)*scale), (SReal)(atof(ymax)*scale), (SReal)(atof(zmax)*scale)));
+        float xmin = arg->getAttributeAsFloat("xmin",0);
+        float ymin = arg->getAttributeAsFloat("ymin",0);
+        float zmin = arg->getAttributeAsFloat("zmin",0);
+        float xmax = arg->getAttributeAsFloat("xmax",1);
+        float ymax = arg->getAttributeAsFloat("ymax",1);
+        float zmax = arg->getAttributeAsFloat("zmax",1);
+        min.setValue(Vector3((SReal)(xmin*scale), (SReal)(ymin*scale), (SReal)(zmin*scale)));
+        max.setValue(Vector3((SReal)(xmax*scale), (SReal)(ymax*scale), (SReal)(zmax*scale)));
     }
     this->setPos(min.getValue()[0],max.getValue()[0],min.getValue()[1],max.getValue()[1],min.getValue()[2],max.getValue()[2]);
 }

--- a/modules/SofaVolumetricData/ImplicitSurfaceMapping.inl
+++ b/modules/SofaVolumetricData/ImplicitSurfaceMapping.inl
@@ -51,13 +51,13 @@ void ImplicitSurfaceMapping<In,Out>::parse(core::objectmodel::BaseObjectDescript
 {
     this->Inherit::parse(arg);
     if ( arg->getAttribute("minx") || arg->getAttribute("miny") || arg->getAttribute("minz"))
-        this->setGridMin(atof(arg->getAttribute("minx","-100.0")),
-                atof(arg->getAttribute("miny","-100.0")),
-                atof(arg->getAttribute("minz","-100.0")));
+        this->setGridMin(arg->getAttributeAsFloat("minx",-100.0),
+                         arg->getAttributeAsFloat("miny",-100.0),
+                         arg->getAttributeAsFloat("minz",-100.0));
     if (arg->getAttribute("maxx") || arg->getAttribute("maxy") || arg->getAttribute("maxz"))
-        this->setGridMax(atof(arg->getAttribute("maxx","100.0")),
-                atof(arg->getAttribute("maxy","100.0")),
-                atof(arg->getAttribute("maxz","100.0")));
+        this->setGridMax(arg->getAttributeAsFloat("maxx",100.0),
+                         arg->getAttributeAsFloat("maxy",100.0),
+                         arg->getAttributeAsFloat("maxz",100.0));
 }
 
 template<class Real>


### PR DESCRIPTION
This PR address the problem of the uses of atoi and atof in the parse methods. 

In short, 
using atof/i is flawned because:
      - it does not check that the attribute is successfully parsed by atoi/atof resulting in undefined behavior when user input is invalid. 
      - the components that use them also forgot to set the Local to "C"  resulting in wrong parsing of 0.1 vs 0,1 (reported in issue https://github.com/sofa-framework/sofa/issues/151)
      - a failure during the parsing of the attribute does not generate a message to the user when something is wrong. 

This PR add getAttributeAsFloat and getAttributeAsInt to be used in place of atof(attr->getAttribute()).
The getAttributeAs* method set the correct Local as well as generates error messages in case they are unable to parse the attribute.

The PR contains new tests for the two added functions as well as a more general test in MechanicalObject.
This PR shouldn't break any API or scene or whatever.

<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings nor unit test failures.
- [ ] does not break existing scenes.
- [ ] does not break API compatibility.
- [ ] has been reviewed and agreed to be transitional.
- [ ] is more than 1 week old.
**Reviewers will merge only if all this checks are true.**