### PR TITLE
[All] auto-init/cleanup libraries

### DIFF
--- a/SofaKernel/framework/sofa/core/init.cpp
+++ b/SofaKernel/framework/sofa/core/init.cpp
@@ -64,13 +64,17 @@ SOFA_CORE_API bool isCleanedUp()
 // Detect missing cleanup() call.
 static const struct CleanupCheck
 {
-    CleanupCheck() {}
-    ~CleanupCheck()
-    {
+    CleanupCheck() {
+        init();
+    }
+    
+    ~CleanupCheck() {
+        cleanup();
         if (core::isInitialized() && !core::isCleanedUp())
             helper::printLibraryNotCleanedUpWarning("SofaCore", "sofa::core::cleanup()");
     }
 } check;
+
 
 } // namespace core
 

--- a/SofaKernel/framework/sofa/defaulttype/init.cpp
+++ b/SofaKernel/framework/sofa/defaulttype/init.cpp
@@ -63,13 +63,17 @@ SOFA_DEFAULTTYPE_API bool isCleanedUp()
 // Detect missing cleanup() call.
 static const struct CleanupCheck
 {
-    CleanupCheck() {}
-    ~CleanupCheck()
-    {
+    CleanupCheck() {
+        init();
+    }
+    
+    ~CleanupCheck() {
+        cleanup();
         if (defaulttype::isInitialized() && !defaulttype::isCleanedUp())
             helper::printLibraryNotCleanedUpWarning("SofaDefaultType", "sofa::defaulttype::cleanup()");
     }
 } check;
+
 
 } // namespace defaulttype
 

--- a/SofaKernel/framework/sofa/helper/init.cpp
+++ b/SofaKernel/framework/sofa/helper/init.cpp
@@ -76,22 +76,28 @@ SOFA_HELPER_API void printLibraryNotCleanedUpWarning(const std::string& library,
               << cleanupFunction << " has never been called, see sofa/helper/init.h)";
 }
 
+
+
 // Detect missing cleanup() call.
 static const struct CleanupCheck
 {
     CleanupCheck()
     {
+        init();
         // to make sure the static variable is created before this
         // and so will be deleted after (at least in c++11)
         // such as an eventual message is possible during this' destructor
         logging::MessageDispatcher::getHandlers();
+        // max: wth is this supposed to mean?
     }
     ~CleanupCheck()
     {
+        cleanup();
         if (helper::isInitialized() && !helper::isCleanedUp())
             helper::printLibraryNotCleanedUpWarning("SofaHelper", "sofa::helper::cleanup()");
     }
 } check;
+
 
 } // namespace helper
 

--- a/SofaKernel/framework/sofa/simulation/init.cpp
+++ b/SofaKernel/framework/sofa/simulation/init.cpp
@@ -67,13 +67,17 @@ SOFA_SIMULATION_CORE_API bool isCleanedUp()
 // Detect missing cleanup() call.
 static const struct CleanupCheck
 {
-    CleanupCheck() {}
-    ~CleanupCheck()
-    {
+    CleanupCheck() {
+        init();
+    }
+    
+    ~CleanupCheck() {
+        cleanup();
         if (simulation::core::isInitialized() && !simulation::core::isCleanedUp())
             helper::printLibraryNotCleanedUpWarning("SofaSimulationCore", "sofa::simulation::core::cleanup()");
     }
 } check;
+
 
 } // namespace core
 

--- a/SofaKernel/modules/SofaSimulationCommon/init.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/init.cpp
@@ -74,13 +74,18 @@ SOFA_SIMULATION_COMMON_API bool isCleanedUp()
 // Detect missing cleanup() call.
 static const struct CleanupCheck
 {
-    CleanupCheck() {}
-    ~CleanupCheck()
-    {
+    CleanupCheck() {
+        init();
+    }
+    
+    ~CleanupCheck() {
+        cleanup();
         if (simulation::common::isInitialized() && !simulation::common::isCleanedUp())
             helper::printLibraryNotCleanedUpWarning("SofaSimulationCommon", "sofa::simulation::common::cleanup()");
     }
 } check;
+
+
 
 } // namespace common
 

--- a/SofaKernel/modules/SofaSimulationGraph/init.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/init.cpp
@@ -67,13 +67,18 @@ SOFA_SIMULATION_GRAPH_API bool isCleanedUp()
 // Detect missing cleanup() call.
 static const struct CleanupCheck
 {
-    CleanupCheck() {}
-    ~CleanupCheck()
-    {
+    CleanupCheck() {
+        init();
+    }
+    
+    ~CleanupCheck() {
+        cleanup();
         if (simulation::graph::isInitialized() && !simulation::graph::isCleanedUp())
             helper::printLibraryNotCleanedUpWarning("SofaSimulationGraph", "sofa::simulation::graph::cleanup()");
     }
 } check;
+
+
 
 } // namespace graph
 

--- a/SofaKernel/modules/SofaSimulationTree/init.cpp
+++ b/SofaKernel/modules/SofaSimulationTree/init.cpp
@@ -67,13 +67,19 @@ SOFA_SIMULATION_TREE_API bool isCleanedUp()
 // Detect missing cleanup() call.
 static const struct CleanupCheck
 {
-    CleanupCheck() {}
-    ~CleanupCheck()
-    {
+    CleanupCheck() {
+        init();
+    }
+
+    ~CleanupCheck() {
+        cleanup();
         if (simulation::tree::isInitialized() && !simulation::tree::isCleanedUp())
             helper::printLibraryNotCleanedUpWarning("SofaSimulationTree", "sofa::simulation::tree::cleanup()");
     }
+    
 } check;
+
+
 
 } // namespace tree
 


### PR DESCRIPTION
I am unsure this PR is correct, so it really needs a green light from others before merge.

When trying to call `std::exit` in some plugin, I had a segfault in cleanup code similar to this one:

```c++
// Detect missing cleanup() call.
static const struct CleanupCheck
{
    CleanupCheck() {
    }
    
    ~CleanupCheck() {
        if (core::isInitialized() && !core::isCleanedUp())
            helper::printLibraryNotCleanedUpWarning("SofaCore", "sofa::core::cleanup()"); // segfault
    }
} check;
```

In fact, most `init.cpp` files in SOFA have code similar to this one. In my case, `MessageDispatcher::LoggerStream::~LoggerStream` caused a call to `MessageDispatcher::process` which would then cause a segfault.

What I don't understand is *why* the above code snipped does not simply `cleanup()` the library in the destructor, since the latter is being called while the library unloads and this is the last chance to actually clean things up, instead of (trying to) emit a warning while the whole program is being terminated.

So unless there is a compelling reason to leave it this way (and I would really like to know it), I suggest the above to be changed to:

```c++
static const struct CleanupCheck
{
    CleanupCheck() {
        init();
    }
    
    ~CleanupCheck() {
        cleanup();
        // leaving the warning if for some reason cleanup failed
        if (core::isInitialized() && !core::isCleanedUp())
            helper::printLibraryNotCleanedUpWarning("SofaCore", "sofa::core::cleanup()");
    }
} check;
```

so that the library automatically `init()` and `cleanup()` upon `dlopen`/`exit`.


<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings nor unit test failures.
- [ ] does not break existing scenes.
- [ ] does not break API compatibility.
- [ ] has been reviewed and agreed to be transitional.
- [ ] is more than 1 week old.
**Reviewers will merge only if all this checks are true.**