### PR TITLE
[SofaKernel] Fix the integration scheme for Quaternion

### DIFF
--- a/SofaKernel/modules/SofaRigid/SofaRigid_test/CMakeLists.txt
+++ b/SofaKernel/modules/SofaRigid/SofaRigid_test/CMakeLists.txt
@@ -4,7 +4,8 @@ project(SofaRigid_test)
 
 set(SOURCE_FILES
     RigidMapping_test.cpp
-    RigidRigidMapping_test.cpp)
+    RigidRigidMapping_test.cpp
+    QuaternionIntegration_test.cpp)
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} SofaGTestMain SofaTest)

--- a/SofaKernel/modules/SofaRigid/SofaRigid_test/QuaternionIntegration_test.cpp
+++ b/SofaKernel/modules/SofaRigid/SofaRigid_test/QuaternionIntegration_test.cpp
@@ -1,0 +1,88 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU General Public License as published by the Free  *
+* Software Foundation; either version 2 of the License, or (at your option)   *
+* any later version.                                                          *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for    *
+* more details.                                                               *
+*                                                                             *
+* You should have received a copy of the GNU General Public License along     *
+* with this program. If not, see <http://www.gnu.org/licenses/>.              *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+/* Francois Faure, 2013 */
+#include <SofaTest/Mapping_test.h>
+#include <SofaSimulationGraph/DAGSimulation.h>
+#include <sofa/defaulttype/VecTypes.h>
+#include <sofa/defaulttype/RigidTypes.h>
+#include <SofaRigid/RigidMapping.h>
+#include <SofaBaseMechanics/MechanicalObject.h>
+
+
+namespace sofa {
+namespace {
+
+// checks that a 1 second rotation at 1 rad.s^{-1} rotates by 1 rad.
+template<class Rigid3Types>
+struct QuaternionIntegrationTest : Sofa_test< typename Rigid3Types::Real > {
+
+    using data_types = Rigid3Types;
+    
+    typename data_types::Coord coord;
+    typename data_types::Deriv deriv;
+    
+    typename data_types::Real dt;
+    
+    QuaternionIntegrationTest()
+        : dt(1) {
+
+        deriv.getVOrientation()[1] = 1;
+
+        // time integration
+        coord += deriv * dt;
+    }
+
+
+    void test_quaternion_angle() const {
+        using real = typename data_types::Real;
+        defaulttype::Vec<3, real> axis; real angle;
+        coord.getOrientation().quatToAxis(axis, angle);
+
+        const real expected_angle = dt * deriv.getVOrientation().norm();
+
+        // std::clog << expected_angle << " " << angle << std::endl;
+        
+        // child coordinates given directly in parent frame
+        ASSERT_TRUE(this->isSmall(expected_angle - angle));
+    }
+
+};
+  
+
+// Define the list of types to instanciate. We do not necessarily need to test all combinations.
+using testing::Types;
+typedef Types<
+    defaulttype::Rigid3dTypes,
+    defaulttype::Rigid3fTypes
+> DataTypes; // the types to instanciate.
+
+// Test suite for all the instanciations
+TYPED_TEST_CASE(QuaternionIntegrationTest, DataTypes);
+
+// first test case
+TYPED_TEST( QuaternionIntegrationTest, quaternion_angle) {
+    this->test_quaternion_angle();
+}
+
+}
+}

--- a/SofaKernel/modules/SofaRigid/SofaRigid_test/QuaternionIntegration_test.cpp
+++ b/SofaKernel/modules/SofaRigid/SofaRigid_test/QuaternionIntegration_test.cpp
@@ -20,7 +20,6 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
-/* Francois Faure, 2013 */
 #include <SofaTest/Mapping_test.h>
 #include <SofaSimulationGraph/DAGSimulation.h>
 #include <sofa/defaulttype/VecTypes.h>
@@ -46,7 +45,7 @@ struct QuaternionIntegrationTest : Sofa_test< typename Rigid3Types::Real > {
     QuaternionIntegrationTest()
         : dt(1) {
 
-        deriv.getVOrientation()[1] = 1;
+        deriv = data_types::randomDeriv(0, M_PI / 2);        
 
         // time integration
         coord += deriv * dt;
@@ -63,7 +62,7 @@ struct QuaternionIntegrationTest : Sofa_test< typename Rigid3Types::Real > {
         // std::clog << expected_angle << " " << angle << std::endl;
         
         // child coordinates given directly in parent frame
-        ASSERT_TRUE(this->isSmall(expected_angle - angle));
+        ASSERT_TRUE(this->isSmall(expected_angle - angle, 10));
     }
 
 };


### PR DESCRIPTION
This PR fixes quaternion integration so that a 1 rad.s^{-1} angular velocity integrated during 1 second results in a 1 rad angle change, as one generally expects.

The original quaternion integration scheme is a [gnomonic projection](https://en.wikipedia.org/wiki/Gnomonic_projection) on the 3-sphere (or equivalently, a variant of  the Cayley transform) that prevents the maximum angular change to exceed *pi* rad during one time-step, which is problematic as angular velocities get larger.

Also, the angular velocity does not integrate to the corresponding rotation angle using this chart, as demonstrated in the failing test.

This PR implements the [exponential map](https://en.wikipedia.org/wiki/Exponential_map_(Riemannian_geometry)) for unit quaternion integration given spatial angular velocity, which fixes both issues.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings nor unit test failures.
- [x] does not break existing scenes.
- [x] does not break API compatibility.
- [x] has been reviewed 
- [x] is more than 1 week old.

**Reviewers will merge only if all these checks are true.**
