### PR TITLE
[SofaKernel] Cherry-pick PR#122 : Fix FileRepository should not be optional

### DIFF
--- a/SofaKernel/SofaFramework/CMakeLists.txt
+++ b/SofaKernel/SofaFramework/CMakeLists.txt
@@ -146,13 +146,14 @@ endif()
 set(SOFA_HAVE_PNG ${PNG_FOUND})
 
 ## Boost
+# optional boost libraries
 find_package(Boost COMPONENTS thread system date_time filesystem locale QUIET)
-
 set(SOFA_HAVE_BOOST_SYSTEM ${Boost_SYSTEM_FOUND})
 set(SOFA_HAVE_BOOST_THREAD ${Boost_THREAD_FOUND})
 set(SOFA_HAVE_BOOST_DATE_TIME ${Boost_DATE_TIME_FOUND})
-set(SOFA_HAVE_BOOST_FILESYSTEM ${Boost_FILESYSTEM_FOUND})
-set(SOFA_HAVE_BOOST_LOCALE ${Boost_LOCALE_FOUND})
+
+# required boost libraries
+find_package(Boost COMPONENTS filesystem locale REQUIRED)
 
 list(APPEND Boost_INCLUDE_DIRS ${Boost_INCLUDE_DIR})
 

--- a/SofaKernel/SofaFramework/CMakeLists.txt
+++ b/SofaKernel/SofaFramework/CMakeLists.txt
@@ -147,13 +147,10 @@ set(SOFA_HAVE_PNG ${PNG_FOUND})
 
 ## Boost
 # optional boost libraries
-find_package(Boost COMPONENTS thread system date_time filesystem locale QUIET)
-set(SOFA_HAVE_BOOST_SYSTEM ${Boost_SYSTEM_FOUND})
+find_package(Boost REQUIRED system filesystem locale
+                   OPTIONAL_COMPONENTS thread date_time)
 set(SOFA_HAVE_BOOST_THREAD ${Boost_THREAD_FOUND})
 set(SOFA_HAVE_BOOST_DATE_TIME ${Boost_DATE_TIME_FOUND})
-
-# required boost libraries
-find_package(Boost COMPONENTS filesystem locale REQUIRED)
 
 list(APPEND Boost_INCLUDE_DIRS ${Boost_INCLUDE_DIR})
 

--- a/SofaKernel/framework/sofa/helper/CMakeLists.txt
+++ b/SofaKernel/framework/sofa/helper/CMakeLists.txt
@@ -98,6 +98,7 @@ set(HEADER_FILES
     system/thread/debug.h
     system/thread/thread_specific_ptr.h
     system/FileMonitor.h
+    system/FileRepository.h
     vector.h
     vectorData.h
     vectorLinks.h
@@ -180,6 +181,7 @@ set(SOURCE_FILES
     system/thread/CTime.cpp
     system/thread/CircularQueue.cpp
     system/thread/debug.cpp
+    system/FileRepository.cpp
     vector.cpp
     logging/Message.cpp
     logging/MessageDispatcher.cpp
@@ -217,11 +219,6 @@ endif()
 if(Boost_thread_FOUND)
     list(APPEND HEADER_FILES system/thread/TimeoutWatchdog.h)
     list(APPEND SOURCE_FILES system/thread/TimeoutWatchdog.cpp)
-endif()
-
-if(Boost_FILESYSTEM_FOUND AND Boost_LOCALE_FOUND)
-    list(APPEND HEADER_FILES system/FileRepository.h)
-    list(APPEND SOURCE_FILES system/FileRepository.cpp)
 endif()
 
 if(NOT SOFA_NO_OPENGL)


### PR DESCRIPTION
Cherry-pick from master to v16.12.
Fix compilation (https://github.com/sofa-framework/sofa/pull/122) due to boost : FileRepository was not compiled if Boost_FILESYSTEM was not found.
Commits 586820f and  6454b77 fixing it.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings nor unit test failures.
- [x] does not break existing scenes.
- [x] does not break API compatibility.
- [x] has been reviewed and agreed to be transitional.

**Reviewers will merge only if all these checks are true.**
