### PR TITLE
[SofaTest] Add Backtrace::autodump to all tests

### DIFF
--- a/applications/plugins/SofaTest/Sofa_test.cpp
+++ b/applications/plugins/SofaTest/Sofa_test.cpp
@@ -23,17 +23,22 @@
 #include "Sofa_test.h"
 #include <SceneCreator/SceneCreator.h>
 
-#include <sofa/helper/system/FileRepository.h>
-#include <sofa/helper/system/FileSystem.h>
-#include <sofa/helper/Utils.h>
 #include <sofa/helper/logging/MessageDispatcher.h>
 #include <sofa/helper/logging/CountingMessageHandler.h>
 #include "TestMessageHandler.h"
 
+#include <sofa/helper/system/FileRepository.h>
+#include <sofa/helper/system/FileSystem.h>
 using sofa::helper::system::PluginRepository;
 using sofa::helper::system::DataRepository;
 using sofa::helper::system::FileSystem;
+
+#include <sofa/helper/Utils.h>
 using sofa::helper::Utils;
+
+#include <sofa/helper/BackTrace.h>
+using sofa::helper::BackTrace;
+
 
 namespace sofa {
 
@@ -45,6 +50,7 @@ namespace {
       raii() {
             helper::logging::MessageDispatcher::addHandler( &helper::logging::MainCountingMessageHandler::getInstance() ) ;
             helper::logging::MessageDispatcher::addHandler( &helper::logging::MainLoggingMessageHandler::getInstance() ) ;
+            BackTrace::autodump() ;
       }
     } singleton;
 }


### PR DESCRIPTION
As requested by @matthieu-nesme in https://github.com/sofa-framework/sofa/issues/149
(but what is the xml ?) 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings nor unit test failures.
- [x] does not break existing scenes.
- [x] does not break API compatibility.
- [x] has been reviewed and agreed to be transitional.
- [x] is more than 1 week old.

**Reviewers will merge only if all these checks are true.**
