### PR TITLE
[SofaHelper] drawFakeSphere: fix ambient component in shaders

### DIFF
--- a/SofaKernel/framework/sofa/helper/gl/shaders/generateSphere.cppglsl
+++ b/SofaKernel/framework/sofa/helper/gl/shaders/generateSphere.cppglsl
@@ -18,6 +18,7 @@ varying vec2 v_mapping;
 varying vec4 v_cameraSpherePos;
 varying vec3 v_lightDir;
 varying float v_radius;
+varying vec4 v_ambientGlobal;
 
 void main(void)
 {
@@ -35,7 +36,9 @@ void main(void)
 
         vec3 vertexToLightSource = gl_LightSource[0].position.xyz - cameraCornerPos.xyz;
     v_lightDir = normalize(vertexToLightSource);  
-    v_radius = a_radius; 	
+    v_radius = a_radius;
+
+    v_ambientGlobal = gl_LightSource[0].ambient * gl_FrontMaterial.ambient; 	
     
     gl_Position = gl_ProjectionMatrix * cameraCornerPos;
     // gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * gl_Vertex;
@@ -53,11 +56,13 @@ varying vec2 v_mapping;
 varying vec4 v_cameraSpherePos;
 varying vec3 v_lightDir;
 varying float v_radius;
+varying vec4 v_ambientGlobal;
 
 void main()
 {
     //const vec3 lightDir = vec3(0,0,1);
     vec3 lightDir = v_lightDir;
+    vec4 ambientColor = v_ambientGlobal;
     vec4 diffuseColor = gl_FrontMaterial.diffuse;
     vec4 specularColor = gl_FrontMaterial.specular;
     float shininess = gl_FrontMaterial.shininess;
@@ -82,7 +87,7 @@ void main()
 
         vec4 specular = vec4(specularColor.xyz * spec, 1.0) * gl_LightSource[0].specular ;
 
-        gl_FragColor = diffuse + specular;
+        gl_FragColor = ambientColor + diffuse + specular;
     //gl_FragColor = vec4(v_mapping,0,1);  
 }
 )SHADER_DELIM";


### PR DESCRIPTION
Small patch to restore ambient component in fake sphere rendering.

Was:
![manyspheres_00000002](https://cloud.githubusercontent.com/assets/11028016/23556748/ef984e7c-002d-11e7-9346-c7208b12f44d.png)

Now:
![manyspheres_00000001](https://cloud.githubusercontent.com/assets/11028016/23556756/f77050b8-002d-11e7-948d-5605c6cd2825.png)


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings nor unit test failures.
- [x] does not break existing scenes.
- [x] does not break API compatibility.
- [x] has been reviewed 
- [x] is more than 1 week old.

**Reviewers will merge only if all these checks are true.**
