### PR TITLE
[CI] ADD log for crashes in testing summary

### DIFF
--- a/scripts/ci/tests.sh
+++ b/scripts/ci/tests.sh
@@ -140,6 +140,11 @@ tests-get()
 print-summary() {
     echo "Testing summary:"
     echo "- $(count-test-suites) test suite(s)"
+    echo "- $(tests-get tests) test(s)"
+    echo "- $(tests-get disabled) disabled test(s)"
+    echo "- $(tests-get failures) failure(s)"
+    echo "- $(tests-get errors) error(s)"
+
     local crashes='$(count-crashes)'
     echo "- $(count-crashes) crash(es)"
     if [[ "$crashes" != 0 ]]; then
@@ -161,13 +166,13 @@ print-summary() {
                         echo "Error: unexpected value in $output_dir/$test/status.txt: $status"
                         ;;
                 esac
+                last_run_line_number="$(grep -n "\[ RUN      \]" "$output_dir/$test/output.txt" | tail -1 | tr ":" "\n" | head -1)"
+                while read log_line; do
+                    echo "      $log_line"
+                done < <(tail --lines=+"$last_run_line_number" "$output_dir/$test/output.txt")
             fi
         done < "$output_dir/tests.txt"
     fi
-    echo "- $(tests-get tests) test(s)"
-    echo "- $(tests-get failures) failure(s)"
-    echo "- $(tests-get disabled) disabled test(s)"
-    echo "- $(tests-get errors) error(s)"
 }
 
 if [[ "$command" = run ]]; then


### PR DESCRIPTION
This should avoid us to scroll through the entire build output searching for a crashed unit test (often due to a segfault).
It is just re-printing the output that was already printed. Some dump is still needed to debug the crash (see PR #191).

This PR fixes issue #149.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings nor unit test failures.
- [x] does not break existing scenes.
- [x] does not break API compatibility.
- [x] has been reviewed
- [x] is more than 1 week old.

**Reviewers will merge only if all these checks are true.**
