### PR TITLE
[CI] FIX Results loss on crashed unit tests

### DIFF
--- a/scripts/ci/main.sh
+++ b/scripts/ci/main.sh
@@ -67,8 +67,7 @@ send-message-to-dashboard \
     "tests_failures=$("$src_dir/scripts/ci/tests.sh" count-failures $build_dir $src_dir)" \
     "tests_disabled=$("$src_dir/scripts/ci/tests.sh" count-disabled $build_dir $src_dir)" \
     "tests_errors=$("$src_dir/scripts/ci/tests.sh" count-errors $build_dir $src_dir)" \
-    "tests_suites=$("$src_dir/scripts/ci/tests.sh" count-test-suites $build_dir $src_dir)" \
-    "tests_crash=$("$src_dir/scripts/ci/tests.sh" count-crashes $build_dir $src_dir)"
+    "tests_suites=$("$src_dir/scripts/ci/tests.sh" count-test-suites $build_dir $src_dir)"
 
 touch "$build_dir/build-finished"
 

--- a/scripts/ci/tests.sh
+++ b/scripts/ci/tests.sh
@@ -102,9 +102,9 @@ run-single-test-subtests() {
             echo "$0: error: $subtest ended with code $pipestatus" >&2
             # Write the XML output by hand
             echo '<?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="1" failures="0" disabled="0" errors="1" time="0.002" name="AllTests">
-    <testsuite name="'"$test_name"'" tests="1" failures="0" disabled="0" errors="1" time="0.002">
-        <testcase name="'"$subtest_name"'" type_param="" status="run" time="0.002" classname="'"$test_name"'">
+<testsuites tests="1" failures="0" disabled="0" errors="1" time="1" name="AllTests">
+    <testsuite name="'"$test_name"'" tests="1" failures="0" disabled="0" errors="1" time="1">
+        <testcase name="'"$subtest_name"'" type_param="" status="run" time="1" classname="'"$test_name"'">
             <error message="[CRASH] '"$subtest"' ended with code '"$pipestatus"'">
 <![CDATA['"$(cat $output_dir/$test/$subtest/output.txt)"']]>
             </error>

--- a/scripts/ci/tests.sh
+++ b/scripts/ci/tests.sh
@@ -226,9 +226,11 @@ print-summary() {
                         ;;
                 esac
                 last_run_line_number="$(grep -n "\[ RUN      \]" "$output_dir/$test/output.txt" | tail -1 | tr ":" "\n" | head -1)"
+                tail --lines=+"$last_run_line_number" "$output_dir/$test/output.txt" > "$output_dir/$test/last_run_output.tmp"
                 while read log_line; do
                     echo "      $log_line"
-                done < <(tail --lines=+"$last_run_line_number" "$output_dir/$test/output.txt")
+                done < "$output_dir/$test/last_run_output.tmp"
+                rm -f "$output_dir/$test/last_run_output.tmp"
             fi
         done < "$output_dir/tests.txt"
     fi

--- a/scripts/ci/tests.sh
+++ b/scripts/ci/tests.sh
@@ -75,9 +75,8 @@ run-single-test-subtests() {
     IFS=''; while read line; do
         if echo "$line" | grep -q "^.*\." ; then
             local current_test="$(echo "$line" | grep -o "^.*\.")"
-        elif echo "$line" | grep -q "^  .*" ; then
-            local current_subtest="$(echo "$line" | grep -o "[^ ]*")"
-            mkdir -p "$output_dir/$test/$current_test$current_subtest"
+        elif echo "$line" | grep -q "^  [^ ]*" ; then
+            local current_subtest="$(echo "$line" | grep -o "[^ ]*" | head -1)"
             echo "$current_test$current_subtest" >> "$output_dir/$test/subtests.txt"
         fi
     done < "$output_dir/$test/subtests.tmp.txt"
@@ -90,6 +89,7 @@ run-single-test-subtests() {
         local output_file="$output_dir/$test/$subtest/report.xml"
         local test_cmd="$build_dir/bin/$test --gtest_output=xml:$output_file --gtest_filter=$subtest 2>&1"
 
+        mkdir -p "$output_dir/$test/$subtest"
         echo "$test_cmd" >> "$output_dir/$test/$subtest/command.txt"
         bash -c "$test_cmd" | tee "$output_dir/$test/$subtest/output.txt"
         pipestatus="${PIPESTATUS[0]}"

--- a/scripts/ci/tests.sh
+++ b/scripts/ci/tests.sh
@@ -166,7 +166,7 @@ count-test-suites() {
     list-tests | wc -w | tr -d ' '
 }
 count-test-reports() {
-    ls "$output_dir/reports/"*.xml 2> /dev/null | wc -l | tr -d ' '
+    ls "$output_dir/reports/" --ignore="*subtest*" 2> /dev/null | wc -l | tr -d ' '
 }
 count-crashes() {
     echo "$(( $(count-test-suites) - $(count-test-reports) ))"
@@ -203,13 +203,12 @@ print-summary() {
     echo "- $(tests-get tests) test(s)"
     echo "- $(tests-get disabled) disabled test(s)"
     echo "- $(tests-get failures) failure(s)"
-    echo "- $(tests-get errors) error(s)"
 
-    local crashes='$(count-crashes)'
-    echo "- $(count-crashes) crash(es)"
-    if [[ "$crashes" != 0 ]]; then
+    local errors='$(tests-get errors)'
+    echo "- $(tests-get errors) error(s)"
+    if [[ "$errors" != 0 ]]; then
         while read test; do
-            if [[ ! -e "$output_dir/$test/report.xml" ]]; then
+            if [[ ! -e "$output_dir/$test/report.xml" ]]; then # this test crashed
                 local status="$(cat "$output_dir/$test/status.txt")"
                 case "$status" in
                     "timeout")


### PR DESCRIPTION
- ADD function run-single-test-subtests executed if a test crashes to run each subtest and avoid results loss.
- EDIT function print-summary to count crashes as errors.
- EDIT XML report on crashed tests. Set duration to 1s to differentiate errors and failures. This should be done by Jenkins JUnit plugin... See https://issues.jenkins-ci.org/browse/JENKINS-4951
- FIX function print-summary on Windows (MinGW bash).

See issue #149 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings nor unit test failures.
- [x] does not break existing scenes.
- [x] does not break API compatibility.
- [ ] has been reviewed and agreed to be transitional.
- [ ] is more than 1 week old.

**Reviewers will merge only if all these checks are true.**
