### PR TITLE
[simulation] adding listener mechanism to SceneLoader

### DIFF
--- a/SofaKernel/framework/sofa/simulation/SceneLoaderFactory.cpp
+++ b/SofaKernel/framework/sofa/simulation/SceneLoaderFactory.cpp
@@ -30,6 +30,8 @@ namespace sofa
 namespace simulation
 {
 
+SceneLoader::Listeners SceneLoader::s_listerners;
+
 SceneLoaderFactory* SceneLoaderFactory::getInstance()
 {
     static SceneLoaderFactory instance;

--- a/SofaKernel/framework/sofa/simulation/SceneLoaderFactory.h
+++ b/SofaKernel/framework/sofa/simulation/SceneLoaderFactory.h
@@ -66,6 +66,7 @@ public:
     virtual bool canWriteFileExtension(const char * /*extension*/) { return false; }
 
     /// load the file
+    /// @warning do not forgot to call notifyLoadingScene()
     virtual sofa::simulation::Node::SPtr load(const char *filename) = 0;
 
     /// write scene graph in the file
@@ -77,6 +78,26 @@ public:
     /// get the list of file extensions
     virtual void getExtensionList(ExtensionList* list) = 0;
 
+
+
+    /// to be able to inform when a scene is loaded
+    struct Listener
+    {
+        virtual void rightBeforeLoadingScene() {} ///< callback called just before loading the scene file
+    };
+
+    /// adding a listener
+    static void addListener( Listener* l ) { s_listerners.insert(l); }
+
+    /// removing a listener
+    static void removeListener( Listener* l ) { s_listerners.erase(l); }
+
+protected:
+
+    /// the list of listerners
+    typedef std::set<Listener*> Listeners;
+    static Listeners s_listerners;
+    static void notifyLoadingScene() { for( auto* l : s_listerners ) l->rightBeforeLoadingScene(); }
 
 };
 

--- a/SofaKernel/modules/SofaSimulationCommon/SceneLoaderXML.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/SceneLoaderXML.cpp
@@ -73,6 +73,8 @@ sofa::simulation::Node::SPtr SceneLoaderXML::load(const char *filename)
     if (!canLoadFileName(filename))
         return 0;
 
+    notifyLoadingScene();
+
     xml::BaseElement* xml = xml::loadFromFile ( filename );
     root = processXML(xml, filename);
 
@@ -140,6 +142,8 @@ Node::SPtr SceneLoaderXML::processXML(xml::BaseElement* xml, const char *filenam
 /// Load from a string in memory
 Node::SPtr SceneLoaderXML::loadFromMemory ( const char *filename, const char *data, unsigned int size )
 {
+    notifyLoadingScene();
+
     xml::BaseElement* xml = xml::loadFromMemory (filename, data, size );
 
     Node::SPtr root = processXML(xml, filename);

--- a/applications/plugins/SofaPython/SceneLoaderPY.cpp
+++ b/applications/plugins/SofaPython/SceneLoaderPY.cpp
@@ -96,6 +96,7 @@ sofa::simulation::Node::SPtr SceneLoaderPY::loadSceneWithArguments(const char *f
     // We go the the current file's directory so that all relative path are correct
     helper::system::SetDirectory chdir ( filename );
 
+    notifyLoadingScene();
     if(!PythonEnvironment::runFile(helper::system::SetDirectory::GetFileName(filename).c_str(), arguments))
     {
         // LOAD ERROR


### PR DESCRIPTION
in order to be informed when a scene is loaded.

WARNING: each SceneLoader's loading function must call "notifyLoadingScene".



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings nor unit test failures.
- [x] does not break existing scenes.
- [x] does not break API compatibility.
- [ ] has been reviewed and agreed to be transitional.
- [x] is more than 1 week old.

**Reviewers will merge only if all these checks are true.**
