### PR TITLE
[CI] Improve tests script

### DIFF
--- a/scripts/ci/tests.sh
+++ b/scripts/ci/tests.sh
@@ -115,7 +115,7 @@ run-single-test-subtests() {
 
         if [ -f "$output_file" ]; then
             fix-test-report "$output_file"
-            cp "$output_file" "$output_dir/reports/"$test"_subtest"$i".xml"
+            cp "$output_file" "$output_dir/reports/"$test"_subtest"$(printf "%03d" $i)".xml"
         else
             echo "$0: error: $test subtest $subtest ended with code $(cat $output_dir/$test/$subtest/status.txt)" >&2
         fi

--- a/scripts/ci/tests.sh
+++ b/scripts/ci/tests.sh
@@ -225,12 +225,6 @@ print-summary() {
                         echo "Error: unexpected value in $output_dir/$test/status.txt: $status"
                         ;;
                 esac
-                last_run_line_number="$(grep -n "\[ RUN      \]" "$output_dir/$test/output.txt" | tail -1 | tr ":" "\n" | head -1)"
-                tail --lines=+"$last_run_line_number" "$output_dir/$test/output.txt" > "$output_dir/$test/last_run_output.tmp"
-                while read log_line; do
-                    echo "      $log_line"
-                done < "$output_dir/$test/last_run_output.tmp"
-                rm -f "$output_dir/$test/last_run_output.tmp"
             fi
         done < "$output_dir/tests.txt"
     fi

--- a/scripts/ci/tests.sh
+++ b/scripts/ci/tests.sh
@@ -73,11 +73,11 @@ run-single-test-subtests() {
     # List all the subtests in this test
     bash -c "$build_dir/bin/$test --gtest_list_tests > $output_dir/$test/subtests.tmp.txt"
     IFS=''; while read line; do
-        if echo "$line" | grep -q "^.*\." ; then
-            local current_test="$(echo "$line" | grep -o "^.*\.")"
-        elif echo "$line" | grep -q "^  [^ ]*" ; then
-            local current_subtest="$(echo "$line" | grep -o "[^ ]*" | head -1)"
-            echo "$current_test$current_subtest" >> "$output_dir/$test/subtests.txt"
+        if echo "$line" | grep -q "^  [^ ][^ ]*" ; then
+            local current_subtest="$(echo "$line" | sed 's/^  \([^ ][^ ]*\).*/\1/g')"
+            echo "$current_test.$current_subtest" >> "$output_dir/$test/subtests.txt"
+        else
+            local current_test="$(echo "$line" | sed 's/\..*//g')"
         fi
     done < "$output_dir/$test/subtests.tmp.txt"
     rm -f "$output_dir/$test/subtests.tmp.txt"

--- a/scripts/ci/tests.sh
+++ b/scripts/ci/tests.sh
@@ -204,8 +204,8 @@ print-summary() {
     echo "- $(tests-get disabled) disabled test(s)"
     echo "- $(tests-get failures) failure(s)"
 
-    local errors='$(tests-get errors)'
-    echo "- $(tests-get errors) error(s)"
+    local errors="$(tests-get errors)"
+    echo "- $errors error(s)"
     if [[ "$errors" != 0 ]]; then
         while read test; do
             if [[ ! -e "$output_dir/$test/report.xml" ]]; then # this test crashed


### PR DESCRIPTION
- FIX error ["cannot create directory: File name too long"](https://ci.inria.fr/sofa-ci/job/windows7_VS-2013_options_amd64/579/console) by improving subtests listing regex.
- FIX error ["tail: illegal option -- -"](https://ci.inria.fr/sofa-ci/job/centos_clang-3.4_options/387/console) by removing crash dump from log summary (dump can be found in test report and build log).
- ADD cosmetic changes

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings nor unit test failures.
- [x] does not break existing scenes.
- [x] does not break API compatibility.
- [x] has been reviewed and agreed to be transitional.
- [x] is more than 1 week old.

**Reviewers will merge only if all these checks are true.**
