### PR TITLE
Image api

### DIFF
--- a/applications/plugins/image/ImageTypes.h
+++ b/applications/plugins/image/ImageTypes.h
@@ -846,7 +846,7 @@ public:
 
         for(unsigned int m=0; m<visualModels.size(); m++)
         {
-            sofa::component::visualmodel::VisualStyle::SPtr ptr = visualModels[m]->searchUp<sofa::component::visualmodel::VisualStyle>();
+            sofa::component::visualmodel::VisualStyle::SPtr ptr = visualModels[m]->template searchUp<sofa::component::visualmodel::VisualStyle>();
             if (ptr && !ptr->displayFlags.getValue().getShowVisualModels()) continue;
 
             const ResizableExtVector<VisualModelTypes::Coord>& verts= visualModels[m]->getVertices();

--- a/applications/plugins/image/ImageTypes.h
+++ b/applications/plugins/image/ImageTypes.h
@@ -448,6 +448,10 @@ public:
     virtual Coord toImageInt(const Coord& p) const { Coord p2 = toImage(p); return Coord( helper::round(p2.x()),helper::round(p2.y()),helper::round(p2.z()) );}		// space coord to rounded image transform
     virtual Real toImageInt(const Real& p) const { return helper::round(toImage(p));}		// time to rounded image index transform
 
+    virtual const Coord& getTranslation() const = 0;
+    virtual const Coord& getRotation() const = 0;
+    virtual const Coord& getScale() const = 0;
+
     virtual void update()=0;
 
 };
@@ -880,6 +884,10 @@ public:
         return get_slicedModels(index,axis,roi);
     }
 
+    // returns the transformed parameters (for the widget)
+    Coord get_transformTranslation() const { return transform->getTranslation(); }
+    Coord get_transformRotation() const { return transform->getRotation(); }
+    Coord get_transformScale() const { return transform->getScale(); }
 
     // returns the transformed point (for the widget)
     Coord get_pointCoord(const Coord& ip) const { return transform->fromImage(ip); }

--- a/applications/plugins/image/ImageTypes.h
+++ b/applications/plugins/image/ImageTypes.h
@@ -38,6 +38,7 @@
 #include <sofa/defaulttype/Mat.h>
 #include <sofa/defaulttype/Quat.h>
 #include <SofaBaseVisual/VisualModelImpl.h>
+#include <SofaBaseVisual/VisualStyle.h>
 #include <sofa/helper/rmath.h>
 #include <sofa/helper/accessor.h>
 #include <sofa/helper/fixed_array.h>
@@ -841,6 +842,9 @@ public:
 
         for(unsigned int m=0; m<visualModels.size(); m++)
         {
+            sofa::component::visualmodel::VisualStyle::SPtr ptr = visualModels[m]->searchUp<sofa::component::visualmodel::VisualStyle>();
+            if (ptr && !ptr->displayFlags.getValue().getShowVisualModels()) continue;
+
             const ResizableExtVector<VisualModelTypes::Coord>& verts= visualModels[m]->getVertices();
             //            const ResizableExtVector<VisualModelTypes::Coord>& verts= visualModels[m]->m_positions.getValue();
             //            const ResizableExtVector<int> * extvertPosIdx = &visualModels[m]->m_vertPosIdx.getValue();


### PR DESCRIPTION
Add virtuals functions in image API

Problem : the virtual class ImageTransform doesn't have transformations functions (translation, rotation, scale). These functions are only available for ImageLPTransform type.

(fix needed for an incoming feature in sofaqtquick)

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings nor unit test failures.
- [x] does not break existing scenes.
- [x] does not break API compatibility.
- [x] has been reviewed and agreed to be transitional.
- [ ] is more than 1 week old.

**Reviewers will merge only if all these checks are true.**
