### PR TITLE
CHANGE usage of d_totalMass in DiagonalMass and add tests

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.cpp
@@ -46,7 +46,7 @@ SReal DiagonalMass<RigidTypes, RigidMass>::getPotentialEnergyRigidImpl( const Me
 {
     SOFA_UNUSED(mparams) ;
     SReal e = 0;
-    const MassVector &masses= f_mass.getValue();
+    const MassVector &masses= d_mass.getValue();
     const VecCoord& _x = x.getValue();
 
     // gravity
@@ -65,7 +65,7 @@ template <class RigidTypes, class RigidMass>
 template <class T>
 void DiagonalMass<RigidTypes, RigidMass>::drawRigid3dImpl(const VisualParams* vparams)
 {
-    const MassVector &masses= f_mass.getValue();
+    const MassVector &masses= d_mass.getValue();
     if (!vparams->displayFlags().getShowBehaviorModels()) return;
     const VecCoord& x =mstate->read(core::ConstVecCoordId::position())->getValue();
 
@@ -94,18 +94,18 @@ void DiagonalMass<RigidTypes, RigidMass>::drawRigid3dImpl(const VisualParams* vp
         len[1] = sqrt(m00+m22-m11);
         len[2] = sqrt(m00+m11-m22);
 
-        vparams->drawTool()->drawFrame(center, orient, len*showAxisSize.getValue() );
+        vparams->drawTool()->drawFrame(center, orient, len*d_showAxisSize.getValue() );
 
         gravityCenter += (center * masses[i].mass);
         totalMass += masses[i].mass;
     }
 
-    if(showCenterOfGravity.getValue())
+    if(d_showCenterOfGravity.getValue())
     {
         gravityCenter /= totalMass;
         const sofa::defaulttype::Vec4f color(1.0,1.0,0.0,1.0);
 
-        vparams->drawTool()->drawCross(gravityCenter, showAxisSize.getValue(), color);
+        vparams->drawTool()->drawCross(gravityCenter, d_showAxisSize.getValue(), color);
     }
 }
 
@@ -114,7 +114,7 @@ template <class RigidTypes, class RigidMass>
 template <class T>
 void DiagonalMass<RigidTypes, RigidMass>::drawRigid2dImpl(const VisualParams* vparams)
 {
-    const MassVector &masses= f_mass.getValue();
+    const MassVector &masses= d_mass.getValue();
     if (!vparams->displayFlags().getShowBehaviorModels()) return;
     const VecCoord& x =mstate->read(core::ConstVecCoordId::position())->getValue();
     for (unsigned int i=0; i<x.size(); i++)
@@ -126,7 +126,7 @@ void DiagonalMass<RigidTypes, RigidMass>::drawRigid2dImpl(const VisualParams* vp
 
         Quat orient(Vec3d(0,0,1), x[i].getOrientation());
         Vec3d center; center = x[i].getCenter();
-        vparams->drawTool()->drawFrame(center, orient, len*showAxisSize.getValue() );
+        vparams->drawTool()->drawFrame(center, orient, len*d_showAxisSize.getValue() );
     }
 }
 
@@ -160,22 +160,22 @@ void DiagonalMass<RigidTypes, RigidMass>::initRigidImpl()
         //return;
     }
 
-    if (!fileMass.getValue().empty())
-        load(fileMass.getFullPath().c_str());
+    if (!d_fileMass.getValue().empty())
+        load(d_fileMass.getFullPath().c_str());
     Inherited::init();
     initTopologyHandlers();
 
     // Initialize the f_mass vector. The f_mass vector is enlarged to contains
     // as much as value as the 'mstate'. The new entries are initialized with the
     // last value of f_mass.
-    if (!this->mstate && f_mass.getValue().size() > 0 && f_mass.getValue().size() < (unsigned)this->mstate->getSize())
+    if (!this->mstate && d_mass.getValue().size() > 0 && d_mass.getValue().size() < (unsigned)this->mstate->getSize())
     {
-        MassVector &masses= *f_mass.beginEdit();
+        MassVector &masses= *d_mass.beginEdit();
         size_t i = masses.size()-1;
         size_t n = (size_t)this->mstate->getSize();
         while (masses.size() < n)
             masses.push_back(masses[i]);
-        f_mass.endEdit();
+        d_mass.endEdit();
     }
 
     m_componentstate = ComponentState::Valid ;
@@ -190,7 +190,7 @@ Vector6 DiagonalMass<RigidTypes,RigidMass>::getMomentumRigid3Impl ( const Mechan
     ReadAccessor<DataVecDeriv> v = vv;
     ReadAccessor<DataVecCoord> x = vx;
 
-    const MassVector &masses = f_mass.getValue();
+    const MassVector &masses = d_mass.getValue();
 
     defaulttype::Vec6d momentum;
 
@@ -215,7 +215,7 @@ Vector6 DiagonalMass<Vec3Types, Vec3Mass>::getMomentumVec3Impl( const Mechanical
     ReadAccessor<DataVecDeriv> v = vv;
     ReadAccessor<DataVecCoord> x = vx;
 
-    const MassVector &masses = f_mass.getValue();
+    const MassVector &masses = d_mass.getValue();
 
     Vector6 momentum;
 

--- a/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.h
+++ b/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.h
@@ -97,7 +97,7 @@ public:
     typedef typename DiagonalMassInternalData<DataTypes,TMassType>::MassVector MassVector;
     typedef typename DiagonalMassInternalData<DataTypes,TMassType>::GeometricalTypes GeometricalTypes;
 
-    VecMass f_mass;
+    VecMass d_mass;
 
     typedef core::topology::BaseMeshTopology::Point Point;
     typedef core::topology::BaseMeshTopology::Edge Edge;
@@ -175,20 +175,20 @@ public:
     protected:
         DiagonalMass<DataTypes,TMassType>* dm;
     };
-    DMassPointHandler* pointHandler;
+    DMassPointHandler* m_pointHandler;
     /// the mass density used to compute the mass from a mesh topology and geometry
-    Data< Real > m_massDensity;
+    Data< Real > d_massDensity;
 
     /// if true, the mass of every element is computed based on the rest position rather than the position
-    Data< bool > m_computeMassOnRest;
+    Data< bool > d_computeMassOnRest;
 
     /// total mass of the object
-    Data< Real > m_totalMass;
+    Data< Real > d_totalMass;
 
     /// to display the center of gravity of the system
-    Data< bool > showCenterOfGravity;
-    Data< float > showAxisSize;
-    core::objectmodel::DataFileName fileMass;
+    Data< bool > d_showCenterOfGravity;
+    Data< float > d_showAxisSize;
+    core::objectmodel::DataFileName d_fileMass;
 
 protected:
     ////////////////////////// Inherited attributes ////////////////////////////
@@ -204,7 +204,7 @@ protected:
 
     class Loader;
     /// The type of topology to build the mass from the topology
-    TopologyType topologyType;
+    TopologyType m_topologyType;
 
 
 public:
@@ -231,11 +231,12 @@ public:
 
     TopologyType getMassTopologyType() const
     {
-        return topologyType;
+        return m_topologyType;
     }
+
     Real getMassDensity() const
     {
-        return m_massDensity.getValue();
+        return d_massDensity.getValue();
     }
 
 protected:
@@ -245,11 +246,11 @@ public:
 
     void setMassDensity(Real m)
     {
-        m_massDensity.setValue(m);
+        d_massDensity.setValue(m);
     }
 
-    SReal getTotalMass() const { return m_totalMass.getValue(); }
-    int getMassCount() { return f_mass.getValue().size(); }
+    SReal getTotalMass() const { return d_totalMass.getValue(); }
+    int getMassCount() { return d_mass.getValue().size(); }
 
 
     void addMass(const MassType& mass);

--- a/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.inl
@@ -46,26 +46,26 @@ namespace mass
 
 template <class DataTypes, class MassType>
 DiagonalMass<DataTypes, MassType>::DiagonalMass()
-    : f_mass( initData(&f_mass, "mass", "values of the particles masses") )
-    , pointHandler(NULL)
-    , m_massDensity( initData(&m_massDensity, (Real)1.0,"massDensity", "mass density that allows to compute the  particles masses from a mesh topology and geometry.\nOnly used if > 0") )
-    , m_computeMassOnRest(initData(&m_computeMassOnRest, false, "computeMassOnRest", "if true, the mass of every element is computed based on the rest position rather than the position"))
-    , m_totalMass(initData(&m_totalMass, (Real)-1.0, "totalMass", "Total mass of the object (read only)"))
-    , showCenterOfGravity( initData(&showCenterOfGravity, false, "showGravityCenter", "display the center of gravity of the system" ) )
-    , showAxisSize( initData(&showAxisSize, 1.0f, "showAxisSizeFactor", "factor length of the axis displayed (only used for rigids)" ) )
-    , fileMass( initData(&fileMass,  "fileMass", "an Xsp3.0 file to specify the mass parameters" ) )
-    , topologyType(TOPOLOGY_UNKNOWN)
+    : d_mass( initData(&d_mass, "mass", "values of the particles masses") )
+    , m_pointHandler(NULL)
+    , d_massDensity( initData(&d_massDensity, (Real)1.0,"massDensity", "mass density that allows to compute the  particles masses from a mesh topology and geometry.\nOnly used if > 0") )
+    , d_computeMassOnRest(initData(&d_computeMassOnRest, false, "computeMassOnRest", "if true, the mass of every element is computed based on the rest position rather than the position"))
+    , d_totalMass(initData(&d_totalMass, (Real)-1.0, "totalMass", "Total mass of the object (read only)"))
+    , d_showCenterOfGravity( initData(&d_showCenterOfGravity, false, "showGravityCenter", "display the center of gravity of the system" ) )
+    , d_showAxisSize( initData(&d_showAxisSize, 1.0f, "showAxisSizeFactor", "factor length of the axis displayed (only used for rigids)" ) )
+    , d_fileMass( initData(&d_fileMass,  "fileMass", "an Xsp3.0 file to specify the mass parameters" ) )
+    , m_topologyType(TOPOLOGY_UNKNOWN)
 {
-    this->addAlias(&fileMass,"filename");
+    this->addAlias(&d_fileMass,"filename");
 
-    m_totalMass.setReadOnly(true);
+    d_totalMass.setReadOnly(true);
 }
 
 template <class DataTypes, class MassType>
 DiagonalMass<DataTypes, MassType>::~DiagonalMass()
 {
-    if (pointHandler)
-        delete pointHandler;
+    if (m_pointHandler)
+        delete m_pointHandler;
 }
 
 
@@ -398,32 +398,32 @@ void DiagonalMass<DataTypes,MassType>::DMassPointHandler::ApplyTopologyChange(co
 template <class DataTypes, class MassType>
 void DiagonalMass<DataTypes, MassType>::clear()
 {
-    MassVector& masses = *f_mass.beginEdit();
+    MassVector& masses = *d_mass.beginEdit();
     masses.clear();
-    f_mass.endEdit();
+    d_mass.endEdit();
 }
 
 template <class DataTypes, class MassType>
 void DiagonalMass<DataTypes, MassType>::addMass(const MassType& m)
 {
-    MassVector& masses = *f_mass.beginEdit();
+    MassVector& masses = *d_mass.beginEdit();
     masses.push_back(m);
-    f_mass.endEdit();
+    d_mass.endEdit();
 }
 
 template <class DataTypes, class MassType>
 void DiagonalMass<DataTypes, MassType>::resize(int vsize)
 {
-    MassVector& masses = *f_mass.beginEdit();
+    MassVector& masses = *d_mass.beginEdit();
     masses.resize(vsize);
-    f_mass.endEdit();
+    d_mass.endEdit();
 }
 
 // -- Mass interface
 template <class DataTypes, class MassType>
 void DiagonalMass<DataTypes, MassType>::addMDx(const core::MechanicalParams* /*mparams*/, DataVecDeriv& res, const DataVecDeriv& dx, SReal factor)
 {
-    const MassVector &masses= f_mass.getValue();
+    const MassVector &masses= d_mass.getValue();
     //std::cout << "DIAGONALMASS: dx size = " << dx.size() << " res size = " << res.size() << " masses size = " << masses.size() << std::endl;
     helper::WriteAccessor< DataVecDeriv > _res = res;
     helper::ReadAccessor< DataVecDeriv > _dx = dx;
@@ -453,7 +453,7 @@ template <class DataTypes, class MassType>
 void DiagonalMass<DataTypes, MassType>::accFromF(const core::MechanicalParams* /*mparams*/, DataVecDeriv& a, const DataVecDeriv& f)
 {
 
-    const MassVector &masses= f_mass.getValue();
+    const MassVector &masses= d_mass.getValue();
     helper::WriteOnlyAccessor< DataVecDeriv > _a = a;
     const VecDeriv& _f = f.getValue();
 
@@ -467,7 +467,7 @@ template <class DataTypes, class MassType>
 SReal DiagonalMass<DataTypes, MassType>::getKineticEnergy( const core::MechanicalParams* /*mparams*/, const DataVecDeriv& v ) const
 {
 
-    const MassVector &masses= f_mass.getValue();
+    const MassVector &masses= d_mass.getValue();
     helper::ReadAccessor< DataVecDeriv > _v = v;
     SReal e = 0.0;
     for (unsigned int i=0; i<masses.size(); i++)
@@ -481,7 +481,7 @@ template <class DataTypes, class MassType>
 SReal DiagonalMass<DataTypes, MassType>::getPotentialEnergy( const core::MechanicalParams* /*mparams*/, const DataVecCoord& x ) const
 {
 
-    const MassVector &masses= f_mass.getValue();
+    const MassVector &masses= d_mass.getValue();
     helper::ReadAccessor< DataVecCoord > _x = x;
     SReal e = 0;
     // gravity
@@ -506,7 +506,7 @@ DiagonalMass<DataTypes, MassType>::getMomentum ( const core::MechanicalParams*, 
 template <class DataTypes, class MassType>
 void DiagonalMass<DataTypes, MassType>::addMToMatrix(const core::MechanicalParams *mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {
-    const MassVector &masses= f_mass.getValue();
+    const MassVector &masses= d_mass.getValue();
     const int N = defaulttype::DataTypeInfo<Deriv>::size();
     AddMToMatrixFunctor<Deriv,MassType> calc;
     sofa::core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate);
@@ -519,7 +519,7 @@ void DiagonalMass<DataTypes, MassType>::addMToMatrix(const core::MechanicalParam
 template <class DataTypes, class MassType>
 SReal DiagonalMass<DataTypes, MassType>::getElementMass(unsigned int index) const
 {
-    return (SReal)(f_mass.getValue()[index]);
+    return (SReal)(d_mass.getValue()[index]);
 }
 
 
@@ -531,19 +531,19 @@ void DiagonalMass<DataTypes, MassType>::getElementMass(unsigned int index, defau
     if (m->rowSize() != dimension || m->colSize() != dimension) m->resize(dimension,dimension);
 
     m->clear();
-    AddMToMatrixFunctor<Deriv,MassType>()(m, f_mass.getValue()[index], 0, 1);
+    AddMToMatrixFunctor<Deriv,MassType>()(m, d_mass.getValue()[index], 0, 1);
 }
 
 template <class DataTypes, class MassType>
 void DiagonalMass<DataTypes, MassType>::reinit()
 {
-    if (_topology && (m_massDensity.getValue() > 0 || f_mass.getValue().size() == 0))
+    if (_topology && (d_massDensity.getValue() > 0 || d_mass.getValue().size() == 0))
     {
         if (_topology->getNbTetrahedra()>0 && tetraGeo)
         {
 
-            MassVector& masses = *f_mass.beginEdit();
-            topologyType=TOPOLOGY_TETRAHEDRONSET;
+            MassVector& masses = *d_mass.beginEdit();
+            m_topologyType=TOPOLOGY_TETRAHEDRONSET;
 
             // resize array
             clear();
@@ -552,7 +552,7 @@ void DiagonalMass<DataTypes, MassType>::reinit()
             for(unsigned int i=0; i<masses.size(); ++i)
                 masses[i]=(Real)0;
 
-            Real md=m_massDensity.getValue();
+            Real md=d_massDensity.getValue();
             Real mass=(Real)0;
             Real total_mass=(Real)0;
 
@@ -562,7 +562,7 @@ void DiagonalMass<DataTypes, MassType>::reinit()
                 const Tetrahedron &t=_topology->getTetrahedron(i);
                 if(tetraGeo)
                 {
-                    if (m_computeMassOnRest.getValue())
+                    if (d_computeMassOnRest.getValue())
                         mass=(md*tetraGeo->computeRestTetrahedronVolume(i))/(Real)4.0;
                     else
                         mass=(md*tetraGeo->computeTetrahedronVolume(i))/(Real)4.0;
@@ -573,13 +573,13 @@ void DiagonalMass<DataTypes, MassType>::reinit()
                     total_mass += mass;
                 }
             }
-            m_totalMass.setValue(total_mass);
-            f_mass.endEdit();
+            d_totalMass.setValue(total_mass);
+            d_mass.endEdit();
         }
         else if (_topology->getNbTriangles()>0 && triangleGeo)
         {
-            MassVector& masses = *f_mass.beginEdit();
-            topologyType=TOPOLOGY_TRIANGLESET;
+            MassVector& masses = *d_mass.beginEdit();
+            m_topologyType=TOPOLOGY_TRIANGLESET;
 
             // resize array
             clear();
@@ -588,7 +588,7 @@ void DiagonalMass<DataTypes, MassType>::reinit()
             for(unsigned int i=0; i<masses.size(); ++i)
                 masses[i]=(Real)0;
 
-            Real md=m_massDensity.getValue();
+            Real md=d_massDensity.getValue();
             Real mass=(Real)0;
             Real total_mass=(Real)0;
 
@@ -597,7 +597,7 @@ void DiagonalMass<DataTypes, MassType>::reinit()
                 const Triangle &t=_topology->getTriangle(i);
                 if(triangleGeo)
                 {
-                    if (m_computeMassOnRest.getValue())
+                    if (d_computeMassOnRest.getValue())
                         mass=(md*triangleGeo->computeRestTriangleArea(i))/(Real)3.0;
                     else
                         mass=(md*triangleGeo->computeTriangleArea(i))/(Real)3.0;
@@ -608,21 +608,21 @@ void DiagonalMass<DataTypes, MassType>::reinit()
                     total_mass += mass;
                 }
             }
-            m_totalMass.setValue(total_mass);
-            f_mass.endEdit();
+            d_totalMass.setValue(total_mass);
+            d_mass.endEdit();
         }
 
         else if (_topology->getNbHexahedra()>0)
         {
 
-            MassVector& masses = *f_mass.beginEdit();
-            topologyType=TOPOLOGY_HEXAHEDRONSET;
+            MassVector& masses = *d_mass.beginEdit();
+            m_topologyType=TOPOLOGY_HEXAHEDRONSET;
 
             masses.resize(this->mstate->getSize());
             for(unsigned int i=0; i<masses.size(); ++i)
               masses[i]=(Real)0;
 
-            Real md=m_massDensity.getValue();
+            Real md=d_massDensity.getValue();
             Real mass=(Real)0;
             Real total_mass=(Real)0;
 
@@ -631,7 +631,7 @@ void DiagonalMass<DataTypes, MassType>::reinit()
                 const Hexahedron &h=_topology->getHexahedron(i);
                 if (hexaGeo)
                 {
-                    if (m_computeMassOnRest.getValue())
+                    if (d_computeMassOnRest.getValue())
                         mass=(md*hexaGeo->computeRestHexahedronVolume(i))/(Real)8.0;
                     else
                         mass=(md*hexaGeo->computeHexahedronVolume(i))/(Real)8.0;
@@ -644,13 +644,13 @@ void DiagonalMass<DataTypes, MassType>::reinit()
                 }
             }
 
-            m_totalMass.setValue(total_mass);
-            f_mass.endEdit();
+            d_totalMass.setValue(total_mass);
+            d_mass.endEdit();
 
         }
         else if (_topology->getNbQuads()>0 && quadGeo) {
-            MassVector& masses = *f_mass.beginEdit();
-            topologyType=TOPOLOGY_QUADSET;
+            MassVector& masses = *d_mass.beginEdit();
+            m_topologyType=TOPOLOGY_QUADSET;
 
             // resize array
             clear();
@@ -659,7 +659,7 @@ void DiagonalMass<DataTypes, MassType>::reinit()
             for(unsigned int i=0; i<masses.size(); ++i)
                 masses[i]=(Real)0;
 
-            Real md=m_massDensity.getValue();
+            Real md=d_massDensity.getValue();
             Real mass=(Real)0;
             Real total_mass=(Real)0;
 
@@ -668,7 +668,7 @@ void DiagonalMass<DataTypes, MassType>::reinit()
                 const Quad &t=_topology->getQuad(i);
                 if(quadGeo)
                 {
-                    if (m_computeMassOnRest.getValue())
+                    if (d_computeMassOnRest.getValue())
                         mass=(md*quadGeo->computeRestQuadArea(i))/(Real)4.0;
                     else
                         mass=(md*quadGeo->computeQuadArea(i))/(Real)4.0;
@@ -679,14 +679,14 @@ void DiagonalMass<DataTypes, MassType>::reinit()
                     total_mass += mass;
                 }
             }
-            m_totalMass.setValue(total_mass);
-            f_mass.endEdit();
+            d_totalMass.setValue(total_mass);
+            d_mass.endEdit();
         }
         else if (_topology->getNbEdges()>0 && edgeGeo)
         {
 
-            MassVector& masses = *f_mass.beginEdit();
-            topologyType=TOPOLOGY_EDGESET;
+            MassVector& masses = *d_mass.beginEdit();
+            m_topologyType=TOPOLOGY_EDGESET;
 
             // resize array
             clear();
@@ -695,7 +695,7 @@ void DiagonalMass<DataTypes, MassType>::reinit()
             for(unsigned int i=0; i<masses.size(); ++i)
                 masses[i]=(Real)0;
 
-            Real md=m_massDensity.getValue();
+            Real md=d_massDensity.getValue();
             Real mass=(Real)0;
             Real total_mass=(Real)0;
 
@@ -704,7 +704,7 @@ void DiagonalMass<DataTypes, MassType>::reinit()
                 const Edge &e=_topology->getEdge(i);
                 if(edgeGeo)
                 {
-                    if (m_computeMassOnRest.getValue())
+                    if (d_computeMassOnRest.getValue())
                         mass=(md*edgeGeo->computeRestEdgeLength(i))/(Real)2.0;
                     else
                         mass=(md*edgeGeo->computeEdgeLength(i))/(Real)2.0;
@@ -715,8 +715,8 @@ void DiagonalMass<DataTypes, MassType>::reinit()
                     total_mass += mass;
                 }
             }
-            m_totalMass.setValue(total_mass);
-            f_mass.endEdit();
+            d_totalMass.setValue(total_mass);
+            d_mass.endEdit();
         }
     }
 }
@@ -725,26 +725,26 @@ template <class DataTypes, class MassType>
 void DiagonalMass<DataTypes, MassType>::initTopologyHandlers()
 {
     // add the functions to handle topology changes.
-    pointHandler = new DMassPointHandler(this, &f_mass);
-    f_mass.createTopologicalEngine(_topology, pointHandler);
+    m_pointHandler = new DMassPointHandler(this, &d_mass);
+    d_mass.createTopologicalEngine(_topology, m_pointHandler);
     if (edgeGeo)
-        f_mass.linkToEdgeDataArray();
+        d_mass.linkToEdgeDataArray();
     if (triangleGeo)
-        f_mass.linkToTriangleDataArray();
+        d_mass.linkToTriangleDataArray();
     if (quadGeo)
-        f_mass.linkToQuadDataArray();
+        d_mass.linkToQuadDataArray();
     if (tetraGeo)
-        f_mass.linkToTetrahedronDataArray();
+        d_mass.linkToTetrahedronDataArray();
     if (hexaGeo)
-        f_mass.linkToHexahedronDataArray();
-    f_mass.registerTopologicalData();
+        d_mass.linkToHexahedronDataArray();
+    d_mass.registerTopologicalData();
 }
 
 template <class DataTypes, class MassType>
 void DiagonalMass<DataTypes, MassType>::init()
 {
-    if (!fileMass.getValue().empty())
-        load(fileMass.getFullPath().c_str());
+    if (!d_fileMass.getValue().empty())
+        load(d_fileMass.getFullPath().c_str());
 
     _topology = this->getContext()->getMeshTopology();
 
@@ -772,18 +772,18 @@ void DiagonalMass<DataTypes, MassType>::init()
     initTopologyHandlers();
 
     // TODO(dmarchal): this code is duplicated with the one in RigidImpl
-    if (this->mstate && f_mass.getValue().size() > 0 && f_mass.getValue().size() < (unsigned)this->mstate->getSize())
+    if (this->mstate && d_mass.getValue().size() > 0 && d_mass.getValue().size() < (unsigned)this->mstate->getSize())
     {
-        MassVector &masses= *f_mass.beginEdit();
+        MassVector &masses= *d_mass.beginEdit();
         size_t i = masses.size()-1;
         size_t n = (size_t)this->mstate->getSize();
         masses.reserve(n);
         while (masses.size() < n)
             masses.push_back(masses[i]);
-        f_mass.endEdit();
+        d_mass.endEdit();
     }
 
-    if ((f_mass.getValue().size()==0) && (_topology!=0))
+    if ((d_mass.getValue().size()==0) && (_topology!=0))
     {
         reinit();
     }
@@ -815,7 +815,7 @@ template <class DataTypes, class MassType>
 void DiagonalMass<DataTypes, MassType>::addForce(const core::MechanicalParams* /*mparams*/, DataVecDeriv& f, const DataVecCoord& x, const DataVecDeriv& v)
 {
 
-    const MassVector &masses= f_mass.getValue();
+    const MassVector &masses= d_mass.getValue();
     helper::WriteAccessor< DataVecDeriv > _f = f;
     helper::ReadAccessor< DataVecCoord > _x = x;
     helper::ReadAccessor< DataVecDeriv > _v = v;
@@ -851,7 +851,7 @@ void DiagonalMass<DataTypes, MassType>::addForce(const core::MechanicalParams* /
     if(this->m_separateGravity.getValue())
         return;
 
-    const MassVector &masses= f_mass.getValue();
+    const MassVector &masses= d_mass.getValue();
     helper::WriteAccessor< DataVecDeriv > _f = f;
 
     // gravity
@@ -874,7 +874,7 @@ void DiagonalMass<DataTypes, MassType>::draw(const core::visual::VisualParams* v
     if (!vparams->displayFlags().getShowBehaviorModels())
         return;
 
-    const MassVector &masses= f_mass.getValue();
+    const MassVector &masses= d_mass.getValue();
     if (masses.empty())
         return;
 
@@ -895,12 +895,12 @@ void DiagonalMass<DataTypes, MassType>::draw(const core::visual::VisualParams* v
         totalMass += masses[i];
     }
 
-    if ( showCenterOfGravity.getValue() )
+    if ( d_showCenterOfGravity.getValue() )
     {
         gravityCenter /= totalMass;
         const sofa::defaulttype::Vec4f color(1.0,1.0,0.0,1.0);
 
-        Real axisSize = showAxisSize.getValue();
+        Real axisSize = d_showAxisSize.getValue();
         sofa::defaulttype::Vector3 temp;
 
         for ( unsigned int i=0 ; i<3 ; i++ )

--- a/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/DiagonalMass_test.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/DiagonalMass_test.cpp
@@ -114,16 +114,16 @@ public:
     void check(MassType expectedTotalMass, const VecMass& expectedMass)
     {
         // Check that the mass vector has the right size.
-        ASSERT_EQ(mstate->x.getValue().size(), mass->f_mass.getValue().size());
+        ASSERT_EQ(mstate->x.getValue().size(), mass->d_mass.getValue().size());
         // Safety check...
         ASSERT_EQ(mstate->x.getValue().size(), expectedMass.size());
 
         // Check the total mass.
-        EXPECT_FLOAT_EQ(expectedTotalMass, mass->m_totalMass.getValue());
+        EXPECT_FLOAT_EQ(expectedTotalMass, mass->d_totalMass.getValue());
 
         // Check the mass at each index.
         for (size_t i = 0 ; i < mstate->x.getValue().size() ; i++)
-            EXPECT_FLOAT_EQ(expectedMass[i], mass->f_mass.getValue()[i]);
+            EXPECT_FLOAT_EQ(expectedMass[i], mass->d_mass.getValue()[i]);
     }
 
     void runTest(VecCoord positions, BaseObject::SPtr topologyContainer, BaseObject::SPtr geometryAlgorithms,

--- a/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/DiagonalMass_test.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/DiagonalMass_test.cpp
@@ -170,13 +170,15 @@ public:
     }
 
 
-    void checkAttributeSemantics(){
+    void checkTotalMassFromMassDensity_Hexa(){
         string scene =
-                "<?xml version='1.0'?>"
-                "<Node 	name='Root' gravity='0 0 0' time='0' animate='0'   > "
-                "   <MechanicalObject position='0 0 0 4 5 6'/>               "
-                "   <DiagonalMass name='m_mass' totalMass='8.0' />           "
-                "</Node>                                                     " ;
+                "<?xml version='1.0'?>                                                                          "
+                "<Node  name='Root' gravity='0 0 0' time='0' animate='0'   >                                    "
+                "    <MechanicalObject />                                                                       "
+                "    <RegularGrid nx='2' ny='2' nz='2' xmin='0' xmax='2' ymin='0' ymax='2' zmin='0' zmax='2' /> "
+                "    <HexahedronSetGeometryAlgorithms />                                                        "
+                "    <DiagonalMass name='m_mass' massDensity='1.0' />                                           "
+                "</Node>                                                                                        " ;
 
         Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
                                                           scene.c_str(),
@@ -188,21 +190,22 @@ public:
         EXPECT_TRUE( mass != nullptr ) ;
 
         if(mass!=nullptr){
-            // TODO(dmarchal): The totalmass shouldn't be initialized with scene value as it is
-            // a read only value.
-            EXPECT_NE( mass->getTotalMass(), 8 ) ;
+            EXPECT_EQ( mass->getMassCount(), 8 ) ;
+            EXPECT_EQ( (float)mass->getTotalMass(), 8 ) ; //casting in float seems due to HexahedronSetGeometryAlgorithms
         }
 
         return ;
     }
 
-    void checkAttributeTotalMassValidity(){
+    void checkMassDensityFromTotalMass_Hexa(){
         string scene =
-                "<?xml version='1.0'?>"
-                "<Node 	name='Root' gravity='0 0 0' time='0' animate='0'   > "
-                "   <MechanicalObject position='0 0 0 4 5 6'/>               "
-                "   <DiagonalMass name='m_mass'/>           "
-                "</Node>                                                     " ;
+                "<?xml version='1.0'?>                                                                          "
+                "<Node  name='Root' gravity='0 0 0' time='0' animate='0'   >                                    "
+                "    <MechanicalObject />                                                                       "
+                "    <RegularGrid nx='2' ny='2' nz='2' xmin='0' xmax='2' ymin='0' ymax='2' zmin='0' zmax='2' /> "
+                "    <HexahedronSetGeometryAlgorithms/>                                                         "
+                "    <DiagonalMass name='m_mass' totalMass='10'/>                                               "
+                "</Node>                                                                                        " ;
 
         Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
                                                           scene.c_str(),
@@ -214,10 +217,101 @@ public:
         EXPECT_TRUE( mass != nullptr ) ;
 
         if(mass!=nullptr){
-            // TODO(dmarchal): The totalmass shouldn't be at -1 because
-            // it indicate it has not been properly initialized in init or reinit.
-            // the source code should be fixed.
-            EXPECT_NE( mass->getTotalMass(), -1 ) ;
+            EXPECT_EQ( mass->getMassCount(), 8 ) ;
+            EXPECT_EQ( (float)mass->getMassDensity(), 1.25 ) ; //casting in float seems due to HexahedronSetGeometryAlgorithms
+        }
+
+        return ;
+    }
+
+    void checkTotalMassOverwritesMassDensity_Hexa(){
+        string scene =
+                "<?xml version='1.0'?>                                                                          "
+                "<Node  name='Root' gravity='0 0 0' time='0' animate='0'   >                                    "
+                "    <MechanicalObject />                                                                       "
+                "    <RegularGrid nx='2' ny='2' nz='2' xmin='0' xmax='2' ymin='0' ymax='2' zmin='0' zmax='2' /> "
+                "    <HexahedronSetGeometryAlgorithms />                                                        "
+                "    <DiagonalMass name='m_mass' massDensity='1.0' totalMass='10'/>                             "
+                "</Node>                                                                                        " ;
+
+        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
+                                                          scene.c_str(),
+                                                          scene.size()) ;
+
+        root->init(ExecParams::defaultInstance()) ;
+
+        TheDiagonalMass* mass = root->getTreeObject<TheDiagonalMass>() ;
+        EXPECT_TRUE( mass != nullptr ) ;
+
+        if(mass!=nullptr){
+            EXPECT_EQ( mass->getMassCount(), 8 ) ;
+            EXPECT_EQ( (float)mass->getMassDensity(), 1.25 ) ; //casting in float seems due to HexahedronSetGeometryAlgorithms
+        }
+
+        return ;
+    }
+
+    void checkTotalMassFromMassDensity_Tetra(){
+        string scene =
+                "<?xml version='1.0'?>                                                                              "
+                "<Node  name='Root' gravity='0 0 0' time='0' animate='0'   >                                        "
+                "    <MechanicalObject />                                                                           "
+                "    <RegularGridTopology name='grid' n='2 2 2' min='0 0 0' max='2 2 2' p0='0 0 0' />               "
+                "    <Node name='Tetra' >                                                                           "
+                "            <TetrahedronSetTopologyContainer name='Container' />                                   "
+                "            <TetrahedronSetTopologyModifier name='Modifier' />                                     "
+                "            <TetrahedronSetTopologyAlgorithms template='Vec3d' name='TopoAlgo' />                  "
+                "            <TetrahedronSetGeometryAlgorithms template='Vec3d' name='GeomAlgo' />                  "
+                "            <Hexa2TetraTopologicalMapping name='default28' input='@../grid' output='@Container' /> "
+                "            <DiagonalMass name='m_mass' massDensity='1.0'/>                                        "
+                "    </Node>                                                                                        "
+                "</Node>                                                                                            " ;
+
+        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
+                                                          scene.c_str(),
+                                                          scene.size()) ;
+
+        root->init(ExecParams::defaultInstance()) ;
+
+        TheDiagonalMass* mass = root->getTreeObject<TheDiagonalMass>() ;
+        EXPECT_TRUE( mass != nullptr ) ;
+
+        if(mass!=nullptr){
+            EXPECT_EQ( mass->getMassCount(), 8 ) ;
+            EXPECT_EQ( (float)mass->getTotalMass(), 8 ) ; //casting in float seems due to HexahedronSetGeometryAlgorithms
+        }
+
+        return ;
+    }
+
+    void checkMassDensityFromTotalMass_Tetra(){
+        string scene =
+                "<?xml version='1.0'?>                                                                              "
+                "<Node  name='Root' gravity='0 0 0' time='0' animate='0'   >                                        "
+                "    <MechanicalObject />                                                                           "
+                "    <RegularGridTopology name='grid' n='2 2 2' min='0 0 0' max='2 2 2' p0='0 0 0' />               "
+                "    <Node name='Tetra' >                                                                           "
+                "            <TetrahedronSetTopologyContainer name='Container' />                                   "
+                "            <TetrahedronSetTopologyModifier name='Modifier' />                                     "
+                "            <TetrahedronSetTopologyAlgorithms template='Vec3d' name='TopoAlgo' />                  "
+                "            <TetrahedronSetGeometryAlgorithms template='Vec3d' name='GeomAlgo' />                  "
+                "            <Hexa2TetraTopologicalMapping name='default28' input='@../grid' output='@Container' /> "
+                "            <DiagonalMass name='m_mass' totalMass='10.0'/>                                        "
+                "    </Node>                                                                                        "
+                "</Node>                                                                                            " ;
+
+        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
+                                                          scene.c_str(),
+                                                          scene.size()) ;
+
+        root->init(ExecParams::defaultInstance()) ;
+
+        TheDiagonalMass* mass = root->getTreeObject<TheDiagonalMass>() ;
+        EXPECT_TRUE( mass != nullptr ) ;
+
+        if(mass!=nullptr){
+            EXPECT_EQ( mass->getMassCount(), 8 ) ;
+            EXPECT_EQ( (float)mass->getMassDensity(), 1.25 ) ; //casting in float seems due to HexahedronSetGeometryAlgorithms
         }
 
         return ;
@@ -383,13 +477,26 @@ TEST_F(DiagonalMass3_test, checkAttributes){
     checkAttributes() ;
 }
 
-TEST_F(DiagonalMass3_test, checkAttributeSemantics_OpenIssue){
-    checkAttributeSemantics() ;
+TEST_F(DiagonalMass3_test, checkTotalMassFromMassDensity_Hexa){
+    checkTotalMassFromMassDensity_Hexa();
 }
 
-TEST_F(DiagonalMass3_test, checkAttributeTotalMassValidity_OpenIssue){
-    checkAttributeTotalMassValidity(); ;
+TEST_F(DiagonalMass3_test, checkMassDensityFromTotalMass_Hexa){
+    checkMassDensityFromTotalMass_Hexa();
 }
+
+TEST_F(DiagonalMass3_test, checkTotalMassOverwritesMassDensity_Hexa){
+    checkTotalMassOverwritesMassDensity_Hexa();
+}
+
+TEST_F(DiagonalMass3_test, checkTotalMassFromMassDensity_Tetra){
+    checkTotalMassFromMassDensity_Tetra();
+}
+
+TEST_F(DiagonalMass3_test, checkMassDensityFromTotalMass_Tetra){
+    checkMassDensityFromTotalMass_Tetra();
+}
+
 
 TEST_F(DiagonalMass3_test, checkAttributeLoadFromFile_OpenIssue){
     checkAttributeLoadFromFile(); ;

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaDiagonalMass.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaDiagonalMass.inl
@@ -64,8 +64,8 @@ void DiagonalMass<CudaVec3fTypes, float>::addMDx(const core::MechanicalParams* /
     VecDeriv& f = *d_f.beginEdit();
     const VecDeriv& dx = d_dx.getValue();
 
-    DiagonalMassCuda_addMDxf(dx.size(),(float) d_factor, f_mass.getValue().deviceRead() , dx.deviceRead(), f.deviceWrite());
-//     const MassVector &masses= f_mass.getValue();
+    DiagonalMassCuda_addMDxf(dx.size(),(float) d_factor, d_mass.getValue().deviceRead() , dx.deviceRead(), f.deviceWrite());
+//     const MassVector &masses= d_mass.getValue();
 //     for (unsigned int i=0;i<dx.size();i++) {
 // 	res[i] += dx[i] * masses[i] * (Real)factor;
 //     }
@@ -79,8 +79,8 @@ void DiagonalMass<CudaVec3fTypes, float>::accFromF(const core::MechanicalParams*
     VecDeriv& a = *d_a.beginEdit();
     const VecDeriv& f = d_f.getValue();
 
-    DiagonalMassCuda_accFromFf(f.size(),  f_mass.getValue().deviceRead(), f.deviceRead(), a.deviceWrite());
-//     const MassVector &masses= f_mass.getValue();
+    DiagonalMassCuda_accFromFf(f.size(),  d_mass.getValue().deviceRead(), f.deviceRead(), a.deviceWrite());
+//     const MassVector &masses= d_mass.getValue();
 //     for (unsigned int i=0;i<f.size();i++) {
 //         a[i] = f[i] / masses[i];
 //     }
@@ -96,7 +96,7 @@ void DiagonalMass<CudaVec3fTypes, float>::addForce(const core::MechanicalParams*
     //const VecDeriv& v = d_v.getValue();
 
     defaulttype::Vec3d g ( this->getContext()->getGravity() );
-    const MassVector &masses= f_mass.getValue();
+    const MassVector &masses= d_mass.getValue();
     DiagonalMassCuda_addForcef(masses.size(),masses.deviceRead(),g.ptr(), f.deviceWrite());
 
 //     // gravity
@@ -121,7 +121,7 @@ void DiagonalMass<CudaVec3dTypes, double>::addMDx(const core::MechanicalParams* 
     VecDeriv& f = *d_f.beginEdit();
     const VecDeriv& dx = d_dx.getValue();
 
-    DiagonalMassCuda_addMDxd(dx.size(),(double) d_factor, f_mass.getValue().deviceRead() , dx.deviceRead(), f.deviceWrite());
+    DiagonalMassCuda_addMDxd(dx.size(),(double) d_factor, d_mass.getValue().deviceRead() , dx.deviceRead(), f.deviceWrite());
 
     d_f.endEdit();
 }
@@ -132,7 +132,7 @@ void DiagonalMass<CudaVec3dTypes, double>::accFromF(const core::MechanicalParams
     VecDeriv& a = *d_a.beginEdit();
     const VecDeriv& f = d_f.getValue();
 
-    DiagonalMassCuda_accFromFd(f.size(),  f_mass.getValue().deviceRead(), f.deviceRead(), a.deviceWrite());
+    DiagonalMassCuda_accFromFd(f.size(),  d_mass.getValue().deviceRead(), f.deviceRead(), a.deviceWrite());
 
     d_a.endEdit();
 }
@@ -145,7 +145,7 @@ void DiagonalMass<CudaVec3dTypes, double>::addForce(const core::MechanicalParams
     //const VecDeriv& v = d_v.getValue();
 
     Vec3d g ( this->getContext()->getGravity() );
-    const MassVector &masses= f_mass.getValue();
+    const MassVector &masses= d_mass.getValue();
     DiagonalMassCuda_addForced(masses.size(),masses.deviceRead(),g.ptr(), f.deviceWrite());
 
     d_f.endEdit();


### PR DESCRIPTION
This commit sets the d_totalMass as read and write in DiagonalMass.
Before set as read-only, without reason.
The commit also updates the coding rules in the Data.

Tests are added to check for both hexa and tetra topologies,
the coherency between totalMass and massDensity. It also checks that
if both totalMass and massDensity are defined, totalMass predomines.

WARNING: the test showed issue of casting in the EXPECT_EQ()






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings nor unit test failures.
- [x] breaks existing scenes.
- [x] breaks API compatibility.
- [x] has been reviewed.
- [x] is more than 1 week old.

**Reviewers will merge only if all these checks are true.**
