### PR TITLE
[CI] FIX wget certificate error

### DIFF
--- a/scripts/ci/main.sh
+++ b/scripts/ci/main.sh
@@ -30,7 +30,7 @@ send-message-to-dashboard() {
         message="$message&sha=$sha&config=$CI_JOB"
         local url="$CI_DASHBOARD_URL"
         echo "Message (sent): " sha="$sha" "config=$CI_JOB" $*
-        wget --no-verbose --output-document=/dev/null --post-data="$message" "$CI_DASHBOARD_URL"
+        wget --no-check-certificate --no-verbose --output-document=/dev/null --post-data="$message" "$CI_DASHBOARD_URL"
     fi
 }
 


### PR DESCRIPTION
Happened after migration to Let's Encrypt SSL certificate on sofa-framework.org

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings nor unit test failures.
- [x] does not break existing scenes.
- [x] does not break API compatibility.
- [x] has been reviewed and agreed to be transitional.
- [x] is more than 1 week old.

**Reviewers will merge only if all these checks are true.**
