### PR TITLE
[SofaBaseMechanics] MechanicalObject: cleaning (symbols & include)

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.h
+++ b/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.h
@@ -479,40 +479,40 @@ protected :
 };
 
 #ifndef SOFA_FLOAT
-template<>
+template<> SOFA_BASE_MECHANICS_API
 void MechanicalObject<defaulttype::Rigid3dTypes>::applyRotation (const defaulttype::Quat q);
 #endif
 #ifndef SOFA_DOUBLE
-template<>
+template<> SOFA_BASE_MECHANICS_API
 void MechanicalObject<defaulttype::Rigid3fTypes>::applyRotation (const defaulttype::Quat q);
 #endif
 #ifndef SOFA_FLOAT
-template<>
+template<> SOFA_BASE_MECHANICS_API
 void MechanicalObject<defaulttype::Rigid3dTypes>::addFromBaseVectorSameSize(core::VecId dest, const defaulttype::BaseVector* src, unsigned int &offset );
 #endif
 #ifndef SOFA_DOUBLE
-template<>
+template<> SOFA_BASE_MECHANICS_API
 void MechanicalObject<defaulttype::Rigid3fTypes>::addFromBaseVectorSameSize(core::VecId dest, const defaulttype::BaseVector* src, unsigned int &offset );
 #endif
 
 #ifndef SOFA_FLOAT
-template<>
+template<> SOFA_BASE_MECHANICS_API
 void MechanicalObject<defaulttype::Rigid3dTypes>::addFromBaseVectorDifferentSize(core::VecId dest, const defaulttype::BaseVector* src, unsigned int &offset );
 #endif
 #ifndef SOFA_DOUBLE
-template<>
+template<> SOFA_BASE_MECHANICS_API
 void MechanicalObject<defaulttype::Rigid3fTypes>::addFromBaseVectorDifferentSize(core::VecId dest, const defaulttype::BaseVector* src, unsigned int &offset );
 #endif
 
 #ifndef SOFA_FLOAT
-template<>
+template<> SOFA_BASE_MECHANICS_API
 void MechanicalObject<defaulttype::Rigid3dTypes>::draw(const core::visual::VisualParams* vparams);
 #endif
 #ifndef SOFA_DOUBLE
-template<>
+template<> SOFA_BASE_MECHANICS_API
 void MechanicalObject<defaulttype::Rigid3fTypes>::draw(const core::visual::VisualParams* vparams);
 #endif
-template<>
+template<> SOFA_BASE_MECHANICS_API
 void MechanicalObject<defaulttype::LaparoscopicRigid3Types>::draw(const core::visual::VisualParams* vparams);
 
 

--- a/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.h
+++ b/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.h
@@ -37,7 +37,9 @@
 #include <vector>
 #include <fstream>
 
+#ifdef SOFA_HAVE_NEW_TOPOLOGYCHANGES
 #include <SofaBaseTopology/TopologyData.h>
+#endif // SOFA_HAVE_NEW_TOPOLOGYCHANGES
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.inl
@@ -44,8 +44,6 @@
 #include <assert.h>
 #include <iostream>
 
-#include <SofaBaseTopology/TopologyData.inl>
-
 namespace
 {
 

--- a/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.inl
@@ -28,6 +28,7 @@
 #include <SofaBaseMechanics/MechanicalObjectTasks.inl>
 #endif
 #include <SofaBaseLinearSolver/SparseMatrix.h>
+#include <sofa/core/topology/BaseTopology.h>
 #include <sofa/core/topology/TopologyChange.h>
 #include <SofaBaseTopology/RegularGridTopology.h>
 
@@ -43,6 +44,10 @@
 
 #include <assert.h>
 #include <iostream>
+
+#ifdef SOFA_HAVE_NEW_TOPOLOGYCHANGES
+#include <SofaBaseTopology/TopologyData.inl>
+#endif // SOFA_HAVE_NEW_TOPOLOGYCHANGES
 
 namespace
 {

--- a/modules/SofaTopologyMapping/Edge2QuadTopologicalMapping.h
+++ b/modules/SofaTopologyMapping/Edge2QuadTopologicalMapping.h
@@ -67,6 +67,9 @@ public:
     typedef defaulttype::Vec<M,Real> Vec;
     typedef helper::vector<unsigned int> VecIndex;
 
+    typedef sofa::core::topology::BaseMeshTopology::Edge Edge;
+    typedef sofa::core::topology::BaseMeshTopology::Quad Quad;
+
 
 protected:
 


### PR DESCRIPTION
Small PR to : 
 - ~~remove useless header~~ (and then remove one dependency on SofaBaseTopology) (see discussion #242 ) (actually instead of removing, I used an existing #ifdef macro)
 - add forgotten Windows macro to export specialized functions into DLLs

This should not break any API compatibility or compilation (hopefully)



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings nor unit test failures.
- [x] does not break existing scenes.
- [x] does not break API compatibility.
- [x] has been reviewed.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
