### PR TITLE
[SofaKernel] Fix getRelativePath() in DataFileName + add tests

### DIFF
--- a/SofaKernel/framework/framework_test/CMakeLists.txt
+++ b/SofaKernel/framework/framework_test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCE_FILES
     core/objectmodel/AspectPool_test.cpp
     core/objectmodel/Data_test.cpp
     core/objectmodel/BaseObjectDescription_test.cpp
+    core/objectmodel/DataFileName_test.cpp
     core/DataEngine_test.cpp
     core/TrackedData_test.cpp
     defaulttype/MatTypes_test.cpp

--- a/SofaKernel/framework/framework_test/core/objectmodel/DataFileName_test.cpp
+++ b/SofaKernel/framework/framework_test/core/objectmodel/DataFileName_test.cpp
@@ -1,0 +1,93 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU General Public License as published by the Free  *
+* Software Foundation; either version 2 of the License, or (at your option)   *
+* any later version.                                                          *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for    *
+* more details.                                                               *
+*                                                                             *
+* You should have received a copy of the GNU General Public License along     *
+* with this program. If not, see <http://www.gnu.org/licenses/>.              *
+*******************************************************************************
+* Contributors:                                                               *
+*     - damien.marchal@univ-lille1.fr                                         *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <SofaTest/Sofa_test.h>
+using sofa::Sofa_test ;
+
+#include <SofaTest/TestMessageHandler.h>
+using sofa::helper::logging::Message ;
+using sofa::helper::logging::ExpectMessage ;
+
+#include <sofa/core/objectmodel/BaseObjectDescription.h>
+using sofa::core::objectmodel::BaseObjectDescription ;
+
+#include <sofa/core/objectmodel/DataFileName.h>
+using sofa::core::objectmodel::DataFileName ;
+
+#include <sofa/helper/system/FileRepository.h>
+using sofa::helper::system::DataRepository ;
+
+#include <sofa/helper/system/SetDirectory.h>
+using sofa::helper::system::SetDirectory ;
+
+#define filename "UtilsTest.ini"
+
+class DataFileName_test: public Sofa_test<>
+{
+    DataFileName d_filename;
+public:
+    void SetUp()
+    {
+        DataRepository.addFirstPath( FRAMEWORK_TEST_RESOURCES_DIR );
+    }
+
+    /// These two should return the same things
+    void checkSetGetValues(){
+        d_filename.setValue(filename) ;
+        EXPECT_EQ( filename, d_filename.getValue()) ;
+
+        d_filename.setValue( FRAMEWORK_TEST_RESOURCES_DIR "/" filename) ;
+        EXPECT_EQ( FRAMEWORK_TEST_RESOURCES_DIR "/" filename, d_filename.getValue() ) ;
+    }
+
+    /// I see no reason why asking for the full path return a short path.
+    void checkSetGetFullPath(){
+        d_filename.setValue(filename) ;
+        EXPECT_EQ( FRAMEWORK_TEST_RESOURCES_DIR "/" filename, d_filename.getFullPath() )  ;
+
+        d_filename.setValue(FRAMEWORK_TEST_RESOURCES_DIR "/" filename) ;
+        EXPECT_EQ( FRAMEWORK_TEST_RESOURCES_DIR "/" filename, d_filename.getFullPath() ) ;
+    }
+
+    void checkSetGetRelativePath(){
+        d_filename.setValue(filename) ;
+        EXPECT_EQ( filename, d_filename.getRelativePath() ) ;
+
+        d_filename.setValue(FRAMEWORK_TEST_RESOURCES_DIR "/" filename) ;
+        EXPECT_EQ( filename, d_filename.getRelativePath() ) ;
+    }
+};
+
+TEST_F(DataFileName_test, checkSetGetValues)
+{
+    this->checkSetGetValues();
+}
+
+TEST_F(DataFileName_test, checkSetGetFullPath)
+{
+    this->checkSetGetFullPath();
+}
+
+TEST_F(DataFileName_test, checkSetGetRelativePath)
+{
+    this->checkSetGetRelativePath();
+}

--- a/SofaKernel/framework/sofa/core/objectmodel/DataFileName.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/DataFileName.cpp
@@ -22,6 +22,8 @@
 #include <sofa/core/objectmodel/DataFileName.h>
 #include <sofa/core/objectmodel/Base.h>
 
+using sofa::helper::system::DataRepository ;
+
 namespace sofa
 {
 
@@ -33,9 +35,9 @@ namespace objectmodel
 
 bool DataFileName::read(const std::string& s )
 {
-	bool ret = Inherit::read(s);
-	if (ret) updatePath();
-	return ret;
+    bool ret = Inherit::read(s);
+    if (ret) updatePath();
+    return ret;
 }
 
 void DataFileName::updatePath()
@@ -43,17 +45,33 @@ void DataFileName::updatePath()
     DataFileName* parentDataFileName = NULL;
     if (parentData)
         parentDataFileName = dynamic_cast<DataFileName*>(parentData.get());
+
     if (parentDataFileName)
     {
-        fullpath = parentDataFileName->getFullPath();
+        m_fullpath = parentDataFileName->getFullPath();
         if (this->m_owner)
-            this->m_owner->sout << "Updated DataFileName " << this->getName() << " with path " << fullpath << this->m_owner->sendl;
+            this->m_owner->sout << "Updated DataFileName " << this->getName() << " with path " << m_fullpath << this->m_owner->sendl;
+        m_relativepath = parentDataFileName->getRelativePath() ;
     }
     else
     {
-        fullpath = m_values[currentAspect()].getValue();
-        if (!fullpath.empty())
-            helper::system::DataRepository.findFile(fullpath,"",(this->m_owner ? &(this->m_owner->serr.ostringstream()) : &std::cerr));
+        // Update the fullpath.
+        m_fullpath = m_values[currentAspect()].getValue();
+        if (!m_fullpath.empty())
+            DataRepository.findFile(m_fullpath,"",(this->m_owner ? &(this->m_owner->serr.ostringstream()) : &std::cerr));
+
+        // Update the relative path.
+        for(const std::string& path : DataRepository.getPaths() )
+        {
+            if( m_fullpath.find(path) == 0 )
+            {
+                m_relativepath=DataRepository.relativeToPath(m_fullpath, path);
+                break;
+            }
+        }
+        if (m_relativepath.empty())
+            m_relativepath = m_values[currentAspect()].getValue();
+
     }
 }
 

--- a/SofaKernel/framework/sofa/core/objectmodel/DataFileName.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/DataFileName.h
@@ -95,16 +95,21 @@ public:
     virtual void virtualSetValue(const std::string& v) { setValue(v); }
     virtual bool read(const std::string& s );
 
-    virtual const std::string& getRelativePath() const { return getValue(); }
+    virtual const std::string& getRelativePath() const
+    {
+        this->updateIfDirty();
+        return m_relativepath ;
+    }
+
     virtual const std::string& getFullPath() const
     {
         this->updateIfDirty();
-        return fullpath;
+        return m_fullpath;
     }
     virtual const std::string& getAbsolutePath() const
     {
         this->updateIfDirty();
-        return fullpath;
+        return m_fullpath;
     }
 
     virtual void update()
@@ -116,7 +121,8 @@ public:
 protected:
     void updatePath();
 
-    std::string fullpath;
+    std::string m_fullpath;
+    std::string m_relativepath;
 
 private:
     DataFileName(const Inherit& d);

--- a/applications/plugins/SofaPython/Binding_DataFileName.cpp
+++ b/applications/plugins/SofaPython/Binding_DataFileName.cpp
@@ -44,10 +44,26 @@ SP_CLASS_ATTR_SET(DataFileName, fullPath)(PyObject */*self*/, PyObject * /*args*
 }
 
 
+SP_CLASS_ATTR_GET(DataFileName, relativePath)(PyObject *self, void*)
+{
+    DataFileName* dataFilename = down_cast<DataFileName>( ((PyPtr<BaseData>*)self)->object );
+    return PyString_FromString(dataFilename->getRelativePath().c_str());
+}
+
+
+SP_CLASS_ATTR_SET(DataFileName, relativePath)(PyObject */*self*/, PyObject * /*args*/, void*)
+{
+    SP_MESSAGE_ERROR("relativePath attribute is read only")
+        PyErr_BadArgument();
+    return -1;
+}
+
+
 
 
 SP_CLASS_ATTRS_BEGIN(DataFileName)
 SP_CLASS_ATTR(DataFileName,fullPath)
+SP_CLASS_ATTR(DataFileName,relativePath)
 SP_CLASS_ATTRS_END
 
 


### PR DESCRIPTION
Problem:
The implementation of getRelativePath is broken as it returns the current
value which can be either a relative or an absolute path.

Solution:
The new implementation is building a real relative path against the path contained
in the DataRepository.

I also added few test for DataFileName to valide the different behaviors.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings nor unit test failures.
- [x] does not break existing scenes.
- [x] does not break API compatibility.
- [x] has been reviewed.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
