### PR TITLE
[SofaKernel] ADD brace initializer to helper::vector class

### DIFF
--- a/SofaKernel/framework/sofa/helper/vector.h
+++ b/SofaKernel/framework/sofa/helper/vector.h
@@ -87,9 +87,10 @@ public:
     explicit vector(size_type n): std::vector<T,Alloc>(n) {}
     /// Constructor
     vector(const std::vector<T, Alloc>& x): std::vector<T,Alloc>(x) {}
+    /// Constructor
+    vector(const std::initializer_list<T>& t) : std::vector<T>(t) {}
     /// Move constructor
     vector(std::vector<T,Alloc>&& v): std::vector<T,Alloc>(std::move(v)) {}
-
     /// Copy operator
     vector<T, Alloc>& operator=(const std::vector<T, Alloc>& x)
     {

--- a/SofaKernel/framework/sofa/helper/vector.h
+++ b/SofaKernel/framework/sofa/helper/vector.h
@@ -87,8 +87,8 @@ public:
     explicit vector(size_type n): std::vector<T,Alloc>(n) {}
     /// Constructor
     vector(const std::vector<T, Alloc>& x): std::vector<T,Alloc>(x) {}
-    /// Constructor
-    vector(const std::initializer_list<T>& t) : std::vector<T>(t) {}
+    /// Brace initalizer constructor
+    vector(const std::initializer_list<T>& t) : std::vector<T,Alloc>(t) {}
     /// Move constructor
     vector(std::vector<T,Alloc>&& v): std::vector<T,Alloc>(std::move(v)) {}
     /// Copy operator


### PR DESCRIPTION
This PR add:
Initialization of helper::vector using {}

Example:
helper::vector< double > vec1 = {5,4,7,1,2};
helper::vector<helper::vector< double >> vec2 = {{5,4},{7,1,2}};
______________________________________________________

This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings nor unit test failures.
- [x] does not break existing scenes.
- [x] does not break API compatibility.
- [x] has been reviewed.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
