### PR TITLE
[SofaKernel] Autoload plugin mechanism

### DIFF
--- a/SofaKernel/framework/framework_test/helper/system/PluginManager_test.cpp
+++ b/SofaKernel/framework/framework_test/helper/system/PluginManager_test.cpp
@@ -169,3 +169,22 @@ TEST_F(PluginManager_test, testIniFile)
     ASSERT_TRUE(pm.unloadPlugin(pluginPath));
     ASSERT_EQ(pm.getPluginMap().size(), 0);
 }
+
+TEST_F(PluginManager_test, autoloadTestPlugin)
+{
+    sofa::helper::system::PluginManager&pm = sofa::helper::system::PluginManager::getInstance();
+    ASSERT_TRUE(pm.autoloadPlugins());
+    
+    ASSERT_GT(pm.getPluginMap().size(), 0);
+
+    const std::string pluginPath = pm.findPlugin(pluginName);
+    ASSERT_GT(pluginPath.size(), 0);
+    sofa::helper::system::Plugin& p = pm.getPluginMap()[pluginPath];
+    ASSERT_EQ(0, std::string(p.getModuleName()).compare(pluginName));
+    
+    ASSERT_TRUE(pm.unloadPlugin(pluginPath));
+    //autoload might have loaded other plugins (e.g SofaPython) so lets unload all of them
+    for (sofa::helper::system::PluginManager::PluginMap::iterator it = pm.getPluginMap().begin(); it != pm.getPluginMap().end(); it++)
+        pm.unloadPlugin((*it).first);
+    ASSERT_EQ(pm.getPluginMap().size(), 0);
+}

--- a/SofaKernel/framework/framework_test/plugins/TestPlugin/initTestPlugin.cpp
+++ b/SofaKernel/framework/framework_test/plugins/TestPlugin/initTestPlugin.cpp
@@ -61,6 +61,11 @@ SOFA_TESTPLUGIN_API const char* getModuleComponentList()
     return "ComponentA, ComponentB";
 }
 
+SOFA_TESTPLUGIN_API bool isAutoloadablePlugin()
+{
+    return true;
+}
+
 } // extern "C"
 
 

--- a/SofaKernel/framework/sofa/helper/system/FileSystem.cpp
+++ b/SofaKernel/framework/sofa/helper/system/FileSystem.cpp
@@ -359,6 +359,20 @@ std::string FileSystem::stripDirectory(const std::string& path)
 }
 
 
+bool FileSystem::isSymbolicLink(const std::string& path)
+{
+#if defined(WIN32)
+    return false;
+#endif // WIN32
+
+#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+    struct stat buf;
+    lstat (path.c_str(), &buf);
+    return (S_ISLNK(buf.st_mode));
+#endif // (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+}
+
+
 } // namespace system
 } // namespace helper
 } // namespace sofa

--- a/SofaKernel/framework/sofa/helper/system/FileSystem.h
+++ b/SofaKernel/framework/sofa/helper/system/FileSystem.h
@@ -107,6 +107,9 @@ static std::string getParentDirectory(const std::string& path);
 /// E.g. /a/b/c --> c
 static std::string stripDirectory(const std::string& path);
 
+/// @brief (UNIX) check if path is a symbolic link (on Windows, will always return false)
+static bool isSymbolicLink(const std::string& path);
+
 };
 
 

--- a/SofaKernel/framework/sofa/helper/system/PluginManager.h
+++ b/SofaKernel/framework/sofa/helper/system/PluginManager.h
@@ -161,10 +161,9 @@ public:
     std::string findPlugin(const std::string& pluginName, bool ignoreCase = true);
     bool pluginIsLoaded(const std::string& pluginPath);
 
-    //search all possible plugins into a given path
-    bool browsePluginPath();
-    bool checkIfPlugin(const std::string& filePath);
-
+    //@brief browse all plugins and load ones marked "autoload"
+    bool autoloadPlugins();
+    
     inline friend std::ostream& operator<< ( std::ostream& os, const PluginManager& pluginManager )
     {
         return pluginManager.writeToStream( os );

--- a/SofaKernel/framework/sofa/helper/system/PluginManager.h
+++ b/SofaKernel/framework/sofa/helper/system/PluginManager.h
@@ -118,12 +118,26 @@ public:
         GetModuleVersion():func(0) {}
     } GetModuleVersion;
 
+    typedef struct IsAutoloadablePlugin
+    {
+        static const char* symbol;
+        typedef bool (*FuncPtr) ();
+        FuncPtr func;
+        bool operator() () const
+        {
+            if (func) return func();
+            else return false;
+        }
+        IsAutoloadablePlugin():func(0) {}
+    } IsAutoloadablePlugin;
+
     InitExternalModule     initExternalModule;
     GetModuleName          getModuleName;
     GetModuleDescription   getModuleDescription;
     GetModuleLicense       getModuleLicense;
     GetModuleComponentList getModuleComponentList;
     GetModuleVersion       getModuleVersion;
+    IsAutoloadablePlugin   isAutoloadablePlugin;
 private:
     DynamicLibrary::Handle dynamicLibrary;
 
@@ -146,6 +160,10 @@ public:
 
     std::string findPlugin(const std::string& pluginName, bool ignoreCase = true);
     bool pluginIsLoaded(const std::string& pluginPath);
+
+    //search all possible plugins into a given path
+    bool browsePluginPath();
+    bool checkIfPlugin(const std::string& filePath);
 
     inline friend std::ostream& operator<< ( std::ostream& os, const PluginManager& pluginManager )
     {

--- a/applications/plugins/SofaPython/initSofaPython.cpp
+++ b/applications/plugins/SofaPython/initSofaPython.cpp
@@ -62,6 +62,12 @@ SOFA_SOFAPYTHON_API const char* getModuleComponentList()
     return "PythonScriptController";
 }
 
+SOFA_SOFAPYTHON_API bool isAutoloadablePlugin()
+{
+    return true;
+}
+
+
 }
 
 

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -339,12 +339,9 @@ int main(int argc, char** argv)
     for (unsigned int i=0; i<plugins.size(); i++)
         PluginManager::getInstance().loadPlugin(plugins[i]);
 
-    // to force loading plugin SofaPython if existing
-    {
-        //std::ostringstream no_error_message; // no to get an error on the console if SofaPython does not exist
-        //sofa::helper::system::PluginManager::getInstance().loadPlugin("SofaPython",&no_error_message);
-        sofa::helper::system::PluginManager::getInstance().browsePluginPath();
-    }
+    // autoloading plugins (if compiled as such, e.g SofaPython)
+    sofa::helper::system::PluginManager::getInstance().autoloadPlugins();
+    
 
     PluginManager::getInstance().init();
 

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -180,6 +180,7 @@ int main(int argc, char** argv)
     bool        loadRecent = false;
     bool        temporaryFile = false;
     bool        testMode = false;
+    bool        noAutoloadPlugins = false;
     int         nbIterations = BatchGUI::DEFAULT_NUMBER_OF_ITERATIONS;
     unsigned int nbMSSASamples = 1;
     unsigned    computationTimeSampling=0; ///< Frequency of display of the computation time statistics, in number of animation steps. 0 means never.
@@ -214,6 +215,7 @@ int main(int argc, char** argv)
     .option(&computationTimeSampling,'c',"computationTimeSampling","Frequency of display of the computation time statistics, in number of animation steps. 0 means never.")
     .option(&gui,'g',"gui",gui_help.c_str())
     .option(&plugins,'l',"load","load given plugins")
+    .option(&noAutoloadPlugins, '0', "noautoload", "disable plugins autoloading")
     .option(&nbMSSASamples, 'm', "msaa", "number of samples for MSAA (Multi Sampling Anti Aliasing ; value < 2 means disabled")
     .option(&nbIterations,'n',"nb_iterations","(only batch) Number of iterations of the simulation")
     .option(&printFactory,'p',"factory","print factory logs")
@@ -340,7 +342,8 @@ int main(int argc, char** argv)
         PluginManager::getInstance().loadPlugin(plugins[i]);
 
     // autoloading plugins (if compiled as such, e.g SofaPython)
-    sofa::helper::system::PluginManager::getInstance().autoloadPlugins();
+    if(!noAutoloadPlugins)
+        sofa::helper::system::PluginManager::getInstance().autoloadPlugins();
     
 
     PluginManager::getInstance().init();

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -341,8 +341,9 @@ int main(int argc, char** argv)
 
     // to force loading plugin SofaPython if existing
     {
-        std::ostringstream no_error_message; // no to get an error on the console if SofaPython does not exist
-        sofa::helper::system::PluginManager::getInstance().loadPlugin("SofaPython",&no_error_message);
+        //std::ostringstream no_error_message; // no to get an error on the console if SofaPython does not exist
+        //sofa::helper::system::PluginManager::getInstance().loadPlugin("SofaPython",&no_error_message);
+        sofa::helper::system::PluginManager::getInstance().browsePluginPath();
     }
 
     PluginManager::getInstance().init();


### PR DESCRIPTION
This PR adds the ability to autoload plugins, i.e without the need to add "RequiredPlugin" in each scene file.
This is especially useful for "essential" plugins such as SofaPython.
For now, only SofaPython is marked as "Autoloadable". An other future PR will activate CImgPlugin to add image loading (and remove ImagePNG/ImageBMP from SofaKernel)

"Main" programs just needs to add the line : 
`sofa::helper::system::PluginManager::getInstance().autoloadPlugins();`

Important Changes:
* autoload API in Plugin "interface"
* remove hard loading of SofaPython in runSofa
* add a new commandline in runSofa to disable autoloading of plugins (enable by default)
* add a test
* (not really related to the PR but could be useful) add an helper function to check if a file is a symbolic link

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings nor unit test failures.
- [ ] does not break existing scenes.
- [ ] does not break API compatibility.
- [ ] has been reviewed and agreed to be transitional.
- [ ] is more than 1 week old (or has fast-merge label).
- [ ] reports important changes in Changelog.

**Reviewers will merge only if all these checks are true.**
