### PR TITLE
[all] Replacement of std::cout with msg_* (week 17)

### DIFF
--- a/applications/plugins/SofaPython/Binding_BaseContext.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseContext.cpp
@@ -76,8 +76,6 @@ extern "C" PyObject * BaseContext_createObject_Impl(PyObject * self, PyObject * 
 {
     BaseContext* context=((PySPtr<Base>*)self)->object->toBaseContext();
 
-//    std::cout << "<PYTHON> BaseContext_createObject PyTuple_Size=" << PyTuple_Size(args) << " PyDict_Size=" << PyDict_Size(kw) << std::endl;
-
     char *type;
     if (!PyArg_ParseTuple(args, "s",&type))
     {
@@ -106,7 +104,6 @@ extern "C" PyObject * BaseContext_createObject_Impl(PyObject * self, PyObject * 
             }
             else
             {
-            //    std::cout << PyString_AsString(PyList_GetItem(keys,i)) << "=\"" << PyString_AsString(PyObject_Str(PyList_GetItem(values,i))) << "\"" << std::endl;
                 if (PyString_Check(value))
                     desc.setAttribute(PyString_AsString(key),PyString_AsString(value));
                 else
@@ -250,7 +247,7 @@ extern "C" PyObject * BaseContext_getObjects(PyObject * self, PyObject * args)
     }
 
     sofa::core::objectmodel::BaseContext::SearchDirection search_direction_enum= sofa::core::objectmodel::BaseContext::Local;
-    if ( search_direction ) 
+    if ( search_direction )
     {
         std::string search_direction_str ( search_direction );
         if ( search_direction_str == "SearchUp" )
@@ -273,7 +270,7 @@ extern "C" PyObject * BaseContext_getObjects(PyObject * self, PyObject * args)
         {
             search_direction_enum= sofa::core::objectmodel::BaseContext::SearchParents;
         }
-        else 
+        else
         {
             SP_MESSAGE_WARNING( "BaseContext_getObjects: Invalid search direction, using 'Local'. Expected: 'SearchUp', 'Local', 'SearchDown', 'SearchRoot', or 'SearchParents'." )
         }

--- a/applications/plugins/SofaPython/ScriptController.cpp
+++ b/applications/plugins/SofaPython/ScriptController.cpp
@@ -57,8 +57,6 @@ void ScriptController::parse(sofa::core::objectmodel::BaseObjectDescription *arg
 {
     Controller::parse(arg);
 
-    //std::cout<<getName()<<" ScriptController::parse"<<std::endl;
-
     // load & bind script
     loadScript();
     // call script notifications...

--- a/applications/plugins/SofaPython/SofaPython_test/PyScene.cpp
+++ b/applications/plugins/SofaPython/SofaPython_test/PyScene.cpp
@@ -16,8 +16,6 @@ struct PyScene_test : public ::testing::Test
     bool loadPySceneWithPyCtrlr()
     {
         static const std::string scenePath = std::string(SOFAPYTHON_TEST_PYTHON_DIR)+std::string("/test_PySceneWithPyCtlr.py");
-        //std::cout<<scenePath<<std::endl;
-
         //Init
 
         simulation::Simulation* simulation;
@@ -34,8 +32,6 @@ struct PyScene_test : public ::testing::Test
 
         if (!ctr->scriptControllerInstance())
             return false; // script not loaded correctly
-
-        //std::cout<<ctr->getName()<<std::endl;
 
         return true;
     }
@@ -43,8 +39,6 @@ struct PyScene_test : public ::testing::Test
     bool loadXmlSceneWithPyCtrlr()
     {
         static const std::string scenePath = std::string(SOFAPYTHON_TEST_PYTHON_DIR)+std::string("/test_XmlSceneWithPyCtlr.scn");
-        //std::cout<<scenePath<<std::endl;
-
         //Init
 
         simulation::Simulation* simulation;
@@ -61,8 +55,6 @@ struct PyScene_test : public ::testing::Test
 
         if (!ctr->scriptControllerInstance())
             return false; // script not loaded correctly
-
-        //std::cout<<ctr->getName()<<std::endl;
 
         return true;
     }

--- a/modules/SofaNonUniformFem/NonUniformHexahedralFEMForceFieldAndMass.inl
+++ b/modules/SofaNonUniformFem/NonUniformHexahedralFEMForceFieldAndMass.inl
@@ -28,12 +28,6 @@
 #include <SofaBaseTopology/TopologyData.inl>
 #include <sofa/core/objectmodel/Base.h>
 
-#ifndef NDEBUG
-    #define DO_DEBUG_PRINT true
-#else
-    #define DO_DEBUG_PRINT false
-#endif
-
 namespace sofa
 {
 
@@ -190,14 +184,6 @@ void NonUniformHexahedralFEMForceFieldAndMass<T>::reinit()
 
     HexahedralFEMForceFieldAndMassT::computeParticleMasses();
     HexahedralFEMForceFieldAndMassT::computeLumpedMasses();
-
-//                helper::vector<ElementMass>* ElementMassMatrices = this->_elementMasses.beginEdit();
-//                typename helper::vector<ElementMass>::iterator iter;
-//                for ( iter = ElementMassMatrices->begin(); iter != ElementMassMatrices->end() ; ++iter)
-//                {
-//                    computeCorrection(*iter);
-//                }
-//                this->_elementMasses.endEdit();
 }
 
 template<class T>
@@ -271,8 +257,7 @@ void NonUniformHexahedralFEMForceFieldAndMass<T>::handleHexaAdded(const core::to
 {
     const sofa::helper::vector<unsigned int> &hexaModif = hexaAddedEvent.hexahedronIndexArray;
 
-    msg_info_when(DO_DEBUG_PRINT)
-            << "HEXAHEDRAADDED hexaId: " << hexaModif ;
+    dmsg_info() << "HEXAHEDRAADDED hexaId: " << hexaModif ;
 
     const VecElement& hexahedra = this->_topology->getHexahedra();
 
@@ -335,7 +320,7 @@ void NonUniformHexahedralFEMForceFieldAndMass<T>::handleHexaRemoved(const core::
 {
     const sofa::helper::vector<unsigned int> &hexaModif = hexaRemovedEvent.getArray();
 
-    dmsg_info_when(DO_DEBUG_PRINT) << "HEXAHEDRAREMOVED hexaId: " << hexaModif ;
+    dmsg_info() << "HEXAHEDRAREMOVED hexaId: " << hexaModif ;
 
     const VecElement& hexahedra = this->_topology->getHexahedra();
     helper::vector<Real>&	particleMasses = *this->_particleMasses.beginEdit();
@@ -381,7 +366,7 @@ void NonUniformHexahedralFEMForceFieldAndMass<T>::handleMultilevelModif(const co
 {
     const sofa::helper::vector<unsigned int> &hexaModif = modEvent.getArray();
 
-    dmsg_info_when(DO_DEBUG_PRINT) << "MULTILEVEL_MODIFICATION hexaId: " << hexaModif ;
+    dmsg_info() << "MULTILEVEL_MODIFICATION hexaId: " << hexaModif ;
 
     const VecElement& hexahedra = this->_topology->getHexahedra();
 
@@ -585,47 +570,6 @@ void NonUniformHexahedralFEMForceFieldAndMass<T>::computeMechanicalMatricesByCon
             this->addHtfineHtoCoarse(H, M_fine, M);
             totalMass += mass_fine;
         }
-        /*
-        msg_info() << "M_fine" << std::endl;
-            for( int i = 0; i < 24; i++)
-            {
-                for( int j = 0; j < 24; j++)
-                    msg_info() << M_fine[i][j]*8 << " ";
-                msg_info() << endl;
-            }
-
-            msg_info() << "M" << std::endl;
-            for( int i = 0; i < 24; i++)
-            {
-                for( int j = 0; j < 24; j++)
-                    msg_info() << M[i][j] << " ";
-                msg_info() << endl;
-            }
-
-            msg_info() << "K_fine" << std::endl;
-            for( int i = 0; i < 24; i++)
-            {
-                for( int j = 0; j < 24; j++)
-                    msg_info() << K_fine[i][j]*2 << " ";
-                msg_info() << endl;
-            }
-
-            msg_info() << "K" << std::endl;
-            for( int i = 0; i < 24; i++)
-            {
-                for( int j = 0; j < 24; j++)
-                    msg_info() << K[i][j] << " ";
-                msg_info() << endl;
-            }
-
-            for( int i = 0; i < 24; i++)
-                for( int j = 0; j < 24; j++)
-                    if ((float)(M_fine[i][j]*8) != (float)(M[i][j])) msg_info() << "diff en M["<<i<<"]["<<j<<"]: " << M_fine[i][j]*8 << ", " << M[i][j] << std::endl;
-
-            for( int i = 0; i < 24; i++)
-                for( int j = 0; j < 24; j++)
-                    if ((float)(K_fine[i][j]*2) != (float)(K[i][j])) msg_info() << "diff en K["<<i<<"]["<<j<<"]: " << K_fine[i][j]*2 << ", " << K[i][j] << std::endl;
-            */
     }
     else
     {
@@ -1036,8 +980,6 @@ void NonUniformHexahedralFEMForceFieldAndMass<DataTypes>::addMBKdx(const core::M
     // mFactor > 0 , so we assume this is a product of the equation matrix done by an implicit solver
     if( matrixIsDirty )
     {
-//                    serr<<"NonUniformHexahedralFEMForceFieldAndMass<DataTypes>::addMBKdx, recomputation of the matrix" << sendl;
-
         // Compute the matrix
         this->mbkMatrix.resize(hexahedra.size());
 
@@ -1053,7 +995,6 @@ void NonUniformHexahedralFEMForceFieldAndMass<DataTypes>::addMBKdx(const core::M
             for ( unsigned n1 = 0; n1 < 8; n1++ )
             {
                 for (unsigned n2=0; n2<8; n2++)
-//                            unsigned n2 = n1; /////////// WARNING Changed to compute only diag elements
                 {
                     // add M to matrix
                     Mat33 tmp( Deriv ( Me[3*n1+0][3*n2+0]*mFactor, Me[3*n1+0][3*n2+1]*mFactor, Me[3*n1+0][3*n2+2]*mFactor ),

--- a/modules/SofaNonUniformFem/NonUniformHexahedralFEMForceFieldAndMass.inl
+++ b/modules/SofaNonUniformFem/NonUniformHexahedralFEMForceFieldAndMass.inl
@@ -28,6 +28,11 @@
 #include <SofaBaseTopology/TopologyData.inl>
 #include <sofa/core/objectmodel/Base.h>
 
+#ifndef NDEBUG
+    #define DO_DEBUG_PRINT true
+#else
+    #define DO_DEBUG_PRINT false
+#endif
 
 namespace sofa
 {
@@ -266,9 +271,8 @@ void NonUniformHexahedralFEMForceFieldAndMass<T>::handleHexaAdded(const core::to
 {
     const sofa::helper::vector<unsigned int> &hexaModif = hexaAddedEvent.hexahedronIndexArray;
 
-#ifndef NDEBUG
-    std::cout << "HEXAHEDRAADDED hexaId: " << hexaModif << std::endl;
-#endif
+    msg_info_when(DO_DEBUG_PRINT)
+            << "HEXAHEDRAADDED hexaId: " << hexaModif ;
 
     const VecElement& hexahedra = this->_topology->getHexahedra();
 
@@ -331,9 +335,7 @@ void NonUniformHexahedralFEMForceFieldAndMass<T>::handleHexaRemoved(const core::
 {
     const sofa::helper::vector<unsigned int> &hexaModif = hexaRemovedEvent.getArray();
 
-#ifndef NDEBUG
-    std::cout << "HEXAHEDRAREMOVED hexaId: " << hexaModif << std::endl;
-#endif
+    dmsg_info_when(DO_DEBUG_PRINT) << "HEXAHEDRAREMOVED hexaId: " << hexaModif ;
 
     const VecElement& hexahedra = this->_topology->getHexahedra();
     helper::vector<Real>&	particleMasses = *this->_particleMasses.beginEdit();
@@ -379,9 +381,7 @@ void NonUniformHexahedralFEMForceFieldAndMass<T>::handleMultilevelModif(const co
 {
     const sofa::helper::vector<unsigned int> &hexaModif = modEvent.getArray();
 
-#ifndef NDEBUG
-    std::cout << "MULTILEVEL_MODIFICATION hexaId: " << hexaModif << std::endl;
-#endif
+    dmsg_info_when(DO_DEBUG_PRINT) << "MULTILEVEL_MODIFICATION hexaId: " << hexaModif ;
 
     const VecElement& hexahedra = this->_topology->getHexahedra();
 
@@ -546,27 +546,7 @@ void NonUniformHexahedralFEMForceFieldAndMass<T>::computeMechanicalMatricesByCon
     else
     {
         computeMechanicalMatricesByCondensation_IntervalAnalysis( K, M, totalMass, _material.K, _material.M, _material.mass, level, voxels);
-
-        //ElementStiffness K_tmp;
-        //ElementMass M_tmp;
-        //Real totalMass_tmp = (Real) 0.0;
-
-        //computeMechanicalMatricesByCondensation_Direct( K_tmp, M_tmp, totalMass_tmp, _material.K, _material.M, _material.mass, level, voxels);
-
-        //if(K_tmp != K)
-        //{
-        //	std::cout << "Stiffness matrices don't match." << std::endl;
-        //}
-        //if(M_tmp != M)
-        //{
-        //	std::cout << "Mass matrices don't match." << std::endl;
-        //}
-        //if(fabs(totalMass_tmp - totalMass) > 0.0001)
-        //{
-        //	std::cout << "Total masses don't match." << std::endl;
-        //}
     }
-//                computeCorrection(M);
 }
 
 template<class T>
@@ -606,46 +586,46 @@ void NonUniformHexahedralFEMForceFieldAndMass<T>::computeMechanicalMatricesByCon
             totalMass += mass_fine;
         }
         /*
-        std::cout << "M_fine" << std::endl;
-        	for( int i = 0; i < 24; i++)
-        	{
-        		for( int j = 0; j < 24; j++)
-        			std::cout << M_fine[i][j]*8 << " ";
-        		std::cout << endl;
-        	}
+        msg_info() << "M_fine" << std::endl;
+            for( int i = 0; i < 24; i++)
+            {
+                for( int j = 0; j < 24; j++)
+                    msg_info() << M_fine[i][j]*8 << " ";
+                msg_info() << endl;
+            }
 
-        	std::cout << "M" << std::endl;
-        	for( int i = 0; i < 24; i++)
-        	{
-        		for( int j = 0; j < 24; j++)
-        			std::cout << M[i][j] << " ";
-        		std::cout << endl;
-        	}
+            msg_info() << "M" << std::endl;
+            for( int i = 0; i < 24; i++)
+            {
+                for( int j = 0; j < 24; j++)
+                    msg_info() << M[i][j] << " ";
+                msg_info() << endl;
+            }
 
-        	std::cout << "K_fine" << std::endl;
-        	for( int i = 0; i < 24; i++)
-        	{
-        		for( int j = 0; j < 24; j++)
-        			std::cout << K_fine[i][j]*2 << " ";
-        		std::cout << endl;
-        	}
+            msg_info() << "K_fine" << std::endl;
+            for( int i = 0; i < 24; i++)
+            {
+                for( int j = 0; j < 24; j++)
+                    msg_info() << K_fine[i][j]*2 << " ";
+                msg_info() << endl;
+            }
 
-        	std::cout << "K" << std::endl;
-        	for( int i = 0; i < 24; i++)
-        	{
-        		for( int j = 0; j < 24; j++)
-        			std::cout << K[i][j] << " ";
-        		std::cout << endl;
-        	}
+            msg_info() << "K" << std::endl;
+            for( int i = 0; i < 24; i++)
+            {
+                for( int j = 0; j < 24; j++)
+                    msg_info() << K[i][j] << " ";
+                msg_info() << endl;
+            }
 
-        	for( int i = 0; i < 24; i++)
-        		for( int j = 0; j < 24; j++)
-        			if ((float)(M_fine[i][j]*8) != (float)(M[i][j])) std::cout << "diff en M["<<i<<"]["<<j<<"]: " << M_fine[i][j]*8 << ", " << M[i][j] << std::endl;
+            for( int i = 0; i < 24; i++)
+                for( int j = 0; j < 24; j++)
+                    if ((float)(M_fine[i][j]*8) != (float)(M[i][j])) msg_info() << "diff en M["<<i<<"]["<<j<<"]: " << M_fine[i][j]*8 << ", " << M[i][j] << std::endl;
 
-        	for( int i = 0; i < 24; i++)
-        		for( int j = 0; j < 24; j++)
-        			if ((float)(K_fine[i][j]*2) != (float)(K[i][j])) std::cout << "diff en K["<<i<<"]["<<j<<"]: " << K_fine[i][j]*2 << ", " << K[i][j] << std::endl;
-        	*/
+            for( int i = 0; i < 24; i++)
+                for( int j = 0; j < 24; j++)
+                    if ((float)(K_fine[i][j]*2) != (float)(K[i][j])) msg_info() << "diff en K["<<i<<"]["<<j<<"]: " << K_fine[i][j]*2 << ", " << K[i][j] << std::endl;
+            */
     }
     else
     {
@@ -1102,12 +1082,6 @@ void NonUniformHexahedralFEMForceFieldAndMass<DataTypes>::addMBKdx(const core::M
 
             // store
             this->mbkMatrix[e] = MBKe;
-//                        cerr << "Re = " << Re << endl << endl;
-//                        cerr << "Me = " << Me << endl << endl;
-//                        cerr << "Ke = " << Ke << endl << endl;
-//                        cerr << "mFactor = " << mFactor << endl;
-//                        cerr << "kFactor = " << kFactor << endl;
-//                        cerr << "MBKe = " << MBKe << endl << endl;
         }
 
         this->matrixIsDirty = false;
@@ -1126,20 +1100,7 @@ void NonUniformHexahedralFEMForceFieldAndMass<DataTypes>::addMBKdx(const core::M
             X[w*3+2] = x_2[2];
         }
         Displacement F;
-//                   cerr << "dx = " << X << endl;
         F = this->mbkMatrix[e] * X;
-//                   cerr << "MBKdx = " << F << endl;
-////                   F = this->_elementMasses.getValue()[e] * X * mFactor;
-//                   F = Mfoo * X * mFactor;
-////                   cerr << "M = " << this->_elementMasses.getValue()[e] << endl<< endl;
-//                   cerr << "M = " << Mfoo << endl<< endl;
-//                   cerr << "Mfoo * X  = " << Mfoo * X << endl<< endl;
-//                   cerr << "mFactor  = " << mFactor << endl<< endl;
-//                   cerr << "Mfoo * X * mFactor  = " << Mfoo * X * mFactor << endl<< endl;
-//                   cerr << "Mdx = " << F << endl ;
-//                   F += hexahedronInf[e].stiffness * X * kFactor;
-//                   cerr << "(M+K)dx = " << F << endl;
-
 
         for(int w=0; w<8; ++w)
             df[hexahedra[e][w]] += Deriv( F[w*3],  F[w*3+1],  F[w*3+2]  );

--- a/modules/SofaOpenglVisual/CompositingVisualLoop.cpp
+++ b/modules/SofaOpenglVisual/CompositingVisualLoop.cpp
@@ -26,7 +26,6 @@
  *      Author: Jeremy Ringard
  */
 
-#define DO_DEBUG_DRAW true
 
 #include <SofaOpenglVisual/CompositingVisualLoop.h>
 #include <sofa/core/ObjectFactory.h>
@@ -96,13 +95,13 @@ void CompositingVisualLoop::drawStep(sofa::core::visual::VisualParams* vparams)
 
     if (!(vparams->displayFlags().getShowRendering()))
     {
-        msg_info_when(DO_DEBUG_DRAW) << "Advanced Rendering is OFF" ;
+        dmsg_info() << "Advanced Rendering is OFF" ;
 
         defaultRendering(vparams);
         return;
     }
     else{
-        msg_info_when(DO_DEBUG_DRAW) << "Advanced Rendering is ON" ;
+        dmsg_info() << "Advanced Rendering is ON" ;
     }
     //should not happen: the compositing loop relies on one or more rendered passes done by the VisualManagerPass component
     if (gRoot->visualManager.empty())
@@ -126,7 +125,7 @@ void CompositingVisualLoop::drawStep(sofa::core::visual::VisualParams* vparams)
             VisualManagerPass* currentVMP=dynamic_cast<VisualManagerPass*>(*it);
             if( currentVMP!=NULL && !currentVMP->isPrerendered())
             {
-                msg_info_when(DO_DEBUG_DRAW) << "final pass is "<<currentVMP->getName()<< "end of predraw loop"  ;
+                msg_info() << "final pass is "<<currentVMP->getName()<< "end of predraw loop"  ;
                 break;
             }
         }

--- a/modules/SofaOpenglVisual/CompositingVisualLoop.cpp
+++ b/modules/SofaOpenglVisual/CompositingVisualLoop.cpp
@@ -26,7 +26,7 @@
  *      Author: Jeremy Ringard
  */
 
-//#define DEBUG_DRAW
+#define DO_DEBUG_DRAW true
 
 #include <SofaOpenglVisual/CompositingVisualLoop.h>
 #include <sofa/core/ObjectFactory.h>
@@ -96,17 +96,14 @@ void CompositingVisualLoop::drawStep(sofa::core::visual::VisualParams* vparams)
 
     if (!(vparams->displayFlags().getShowRendering()))
     {
-#ifdef DEBUG_DRAW
-        std::cout << "Advanced Rendering is OFF" << std::endl;
-#endif
+        msg_info_when(DO_DEBUG_DRAW) << "Advanced Rendering is OFF" ;
+
         defaultRendering(vparams);
         return;
     }
-#ifdef DEBUG_DRAW
-    else
-        std::cout << "Advanced Rendering is ON" << std::endl;
-#endif
-
+    else{
+        msg_info_when(DO_DEBUG_DRAW) << "Advanced Rendering is ON" ;
+    }
     //should not happen: the compositing loop relies on one or more rendered passes done by the VisualManagerPass component
     if (gRoot->visualManager.empty())
     {
@@ -129,9 +126,7 @@ void CompositingVisualLoop::drawStep(sofa::core::visual::VisualParams* vparams)
             VisualManagerPass* currentVMP=dynamic_cast<VisualManagerPass*>(*it);
             if( currentVMP!=NULL && !currentVMP->isPrerendered())
             {
-#ifdef DEBUG_DRAW
-                std::cout<<"final pass is "<<currentVMP->getName()<< "end of predraw loop" <<std::endl;
-#endif
+                msg_info_when(DO_DEBUG_DRAW) << "final pass is "<<currentVMP->getName()<< "end of predraw loop"  ;
                 break;
             }
         }

--- a/modules/SofaOpenglVisual/Light.cpp
+++ b/modules/SofaOpenglVisual/Light.cpp
@@ -448,11 +448,6 @@ void DirectionalLight::computeOpenGLModelViewMatrix(GLfloat mat[16], const sofa:
     mat[13] = 0;
     mat[14] = (sceneBBox.maxBBox()[2] - sceneBBox.minBBox()[2])*-0.5;
 
-    //std::cout << "BB " << sceneBBox << std::endl;
-    //std::cout << "LightBB " << lightBBox << std::endl;
-    //std::cout << "Position " << position << std::endl;
-    //std::cout << "Center " << center << std::endl;
-
     //w
     mat[15] = 1;
 

--- a/modules/SofaOpenglVisual/OglModel.cpp
+++ b/modules/SofaOpenglVisual/OglModel.cpp
@@ -792,11 +792,9 @@ bool OglModel::loadTextures()
 //                textureFile = this->fileMesh.getFullPath();
 //                unsigned int position = textureFile.rfind("/");
 //                textureFile.replace (position+1,textureFile.length() - position, this->materials.getValue()[i].bumpTextureFilename);
-////                std::cout << "Loading texture: " << textureFile << std::endl;
 //
 //                if (!sofa::helper::system::DataRepository.findFile(textureFile))
 //                {
-//                    std::cout <<  std::endl;
 //                    serr << "Texture \"" << this->materials.getValue()[i].bumpTextureFilename << "\" not found"
 //                            << " in material " << this->materials.getValue()[i].name << " for OglModel " << this->name
 //                            << "(\""<< this->fileMesh.getFullPath() << "\")" << sendl;
@@ -807,7 +805,6 @@ bool OglModel::loadTextures()
 //            helper::io::Image *img = helper::io::Image::Create(textureFile);
 //            if (!img)
 //            {
-//                std::cout <<  std::endl;
 //               msg_error() << "Error:OglModel:loadTextures: couldn't create an image from file " << this->materials.getValue()[i].bumpTextureFilename << std::endl;
 //               return false;
 //            }
@@ -815,11 +812,10 @@ bool OglModel::loadTextures()
 //            materialTextureIdMap.insert(std::pair<int, int>(i,textures.size()));
 //            textures.push_back( text );
 //
-//            std::cout << "\r\033[K" << i+1 << "/" << this->materials.getValue().size() << " textures loaded for bump mapping for OglModel " << this->getName()
+//            msg_info() << "\r\033[K" << i+1 << "/" << this->materials.getValue().size() << " textures loaded for bump mapping for OglModel " << this->getName()
 //                    << "(loading "<<textureFile << ")"<< std::flush;
 //       }
 //    }
-//    std::cout << "\r\033[K" << std::flush;
     return result;
 }
 

--- a/modules/SofaOpenglVisual/VisualManagerSecondaryPass.cpp
+++ b/modules/SofaOpenglVisual/VisualManagerSecondaryPass.cpp
@@ -125,7 +125,6 @@ void VisualManagerSecondaryPass::initShaderInputTexId()
             if((!currentSecondaryPass->getOutputTags().empty()) && (input_tags.getValue().includes(currentSecondaryPass->getOutputTags())) )
             {
                 m_shaderPostproc->setInt(0, (currentSecondaryPass->getOutputName()).c_str(), nbFbo);
-                //std::cout << "---"<<this->getName()<<"--- add sampler2D \""<< currentSecondaryPass->getName()<<"\" at id="<<nbFbo<<std::endl;
                 nbFbo++;
             }
         }
@@ -136,10 +135,8 @@ void VisualManagerSecondaryPass::initShaderInputTexId()
                 if(input_tags.getValue().includes(currentPass->getTags()))
                 {
                     m_shaderPostproc->setInt(0, (currentPass->getOutputName()).c_str(), nbFbo);
-                    //std::cout << "---"<<this->getName()<<"--- add sampler2D \""<< currentPass->getName()<<"\" at id="<<nbFbo<<std::endl;
                     nbFbo++;
                     m_shaderPostproc->setInt(0, (currentPass->getOutputName()+"_Z").c_str(), nbFbo);
-                    //std::cout << "---"<<this->getName()<<"--- add sampler2D \""<< currentPass->getName()<<"_Z\" at id="<<nbFbo<<std::endl;
                     nbFbo++;
                 }
             }

--- a/modules/SofaPreconditioner/PrecomputedWarpPreconditioner.inl
+++ b/modules/SofaPreconditioner/PrecomputedWarpPreconditioner.inl
@@ -167,7 +167,7 @@ void PrecomputedWarpPreconditioner<TDataTypes>::loadMatrix(TMatrix& M)
 
     if (share_matrix.getValue() && internalData.MinvPtr->rowSize() == (defaulttype::BaseMatrix::Index)systemSize)
     {
-        std::cout << "shared matrix : " << fname << " is already built" << std::endl;
+        msg_info("PrecomputedWarpPreconditioner") << "shared matrix : " << fname << " is already built." ;
     }
     else
     {
@@ -177,14 +177,13 @@ void PrecomputedWarpPreconditioner<TDataTypes>::loadMatrix(TMatrix& M)
 
         if(compFileIn.good() && use_file.getValue())
         {
-            std::cout << "file open : " << fname << " compliance being loaded" << std::endl;
+            msg_info("PrecomputedWarpPreconditioner") << "file open : " << fname << " compliance being loaded" ;
             internalData.readMinvFomFile(compFileIn);
-            //compFileIn.read((char*) (*internalData.MinvPtr)[0], matrixSize * matrixSize * sizeof(Real));
             compFileIn.close();
         }
         else
         {
-            std::cout << "Precompute : " << fname << " compliance" << std::endl;
+            msg_info("PrecomputedWarpPreconditioner") << "Precompute : " << fname << " compliance." ;
             if (solverName.getValue().empty()) loadMatrixWithCSparse(M);
             else loadMatrixWithSolver();
 
@@ -192,7 +191,6 @@ void PrecomputedWarpPreconditioner<TDataTypes>::loadMatrix(TMatrix& M)
             {
                 std::ofstream compFileOut(fname.c_str(), std::fstream::out | std::fstream::binary);
                 internalData.writeMinvFomFile(compFileOut);
-                //compFileOut.write((char*)(*internalData.MinvPtr)[0], matrixSize * matrixSize * sizeof(Real));
                 compFileOut.close();
             }
             compFileIn.close();
@@ -218,7 +216,7 @@ void PrecomputedWarpPreconditioner<TDataTypes>::loadMatrix(TMatrix& M)
 template<class TDataTypes>
 void PrecomputedWarpPreconditioner<TDataTypes>::loadMatrixWithCSparse(TMatrix& M)
 {
-    std::cout << "Compute the initial invert matrix with CS_PARSE" << std::endl;
+    msg_info("PrecomputedWarpPreconditioner") << "Compute the initial invert matrix with CS_PARSE" ;
 
     FullVector<Real> r;
     FullVector<Real> b;
@@ -229,7 +227,7 @@ void PrecomputedWarpPreconditioner<TDataTypes>::loadMatrixWithCSparse(TMatrix& M
 
     SparseCholeskySolver<CompressedRowSparseMatrix<Real>, FullVector<Real> > solver;
 
-    std::cout << "Precomputing constraint correction LU decomposition " << std::endl;
+    msg_info("PrecomputedWarpPreconditioner") << "Precomputing constraint correction LU decomposition " ;
     solver.invert(M);
 
     for (unsigned int j=0; j<nb_dofs; j++)
@@ -268,7 +266,7 @@ void PrecomputedWarpPreconditioner<TDataTypes>::loadMatrixWithCSparse(TMatrix& M
 template<class TDataTypes>
 void PrecomputedWarpPreconditioner<TDataTypes>::loadMatrixWithCSparse(TMatrix& /*M*/)
 {
-    std::cout << "WARNING ; you don't have CS_parse CG will be use, (if also can specify solverName to accelerate the precomputation" << std::endl;
+    msg_warning("PrecomputedWarpPreconditioner") << "you don't have CS_parse CG will be use, (if also can specify solverName to accelerate the precomputation" ;
     loadMatrixWithSolver();
 }
 #endif
@@ -278,7 +276,7 @@ void PrecomputedWarpPreconditioner<TDataTypes>::loadMatrixWithSolver()
 {
     usePrecond = false;//Don'Use precond during precomputing
 
-    std::cout << "Compute the initial invert matrix with solver" << std::endl;
+    msg_info("PrecomputedWarpPreconditioner") << "Compute the initial invert matrix with solver" ;
 
     if (mstate==NULL)
     {
@@ -336,10 +334,10 @@ void PrecomputedWarpPreconditioner<TDataTypes>::loadMatrixWithSolver()
     mstate->vAlloc(core::ExecParams::defaultInstance(), lhId);
     mstate->vAvail(core::ExecParams::defaultInstance(), rhId);
     mstate->vAlloc(core::ExecParams::defaultInstance(), rhId);
-    std::cout << "System: (" << init_mFact << " * M + " << init_bFact << " * B + " << init_kFact << " * K) " << lhId << " = " << rhId << std::endl;
+    msg_info("PrecomputedWarpPreconditioner") << "System: (" << init_mFact << " * M + " << init_bFact << " * B + " << init_kFact << " * K) " << lhId << " = " << rhId ;
     if (linearSolver)
     {
-        std::cout << "System Init Solver: " << linearSolver->getName() << " (" << linearSolver->getClassName() << ")" << std::endl;
+        msg_info("PrecomputedWarpPreconditioner") << "System Init Solver: " << linearSolver->getName() << " (" << linearSolver->getClassName() << ")" ;
         core::MechanicalParams mparams;
         mparams.setMFactor(init_mFact);
         mparams.setBFactor(init_bFact);
@@ -347,10 +345,6 @@ void PrecomputedWarpPreconditioner<TDataTypes>::loadMatrixWithSolver()
         linearSolver->setSystemMBKMatrix(&mparams);
     }
 
-    //<TO REMOVE>
-    //VecDeriv& force = *mstate->getVecDeriv(rhId.index);
-    //Data<VecDeriv>* dataForce = mstate->writeVecDeriv(rhId);
-    //VecDeriv& force = *dataForce->beginEdit();
     helper::WriteAccessor<Data<VecDeriv> > dataForce = *mstate->write(core::VecDerivId::externalForce());
     VecDeriv& force = dataForce.wref();
 
@@ -371,15 +365,10 @@ void PrecomputedWarpPreconditioner<TDataTypes>::loadMatrixWithSolver()
     }
     ///////////////////////////////////////////////////////////////////////////////////////////////
 
-    //<TO REMOVE>
-    //VecDeriv& velocity = *mstate->getVecDeriv(lhId.index);
-    //Data<VecDeriv>* dataVelocity = mstate->writeVecDeriv(lhId);
-    //VecDeriv& velocity = *dataVelocity->beginEdit();
     helper::WriteAccessor<Data<VecDeriv> > dataVelocity = *mstate->write(core::VecDerivId::velocity());
     VecDeriv& velocity = dataVelocity.wref();
 
     VecDeriv velocity0 = velocity;
-    //VecCoord& pos =mstate->read(core::ConstVecCoordId::position())->getValue();
     helper::WriteAccessor<Data<VecCoord> > posData = *mstate->write(core::VecCoordId::position());
     VecCoord& pos = posData.wref();
     VecCoord pos0 = pos;
@@ -393,9 +382,10 @@ void PrecomputedWarpPreconditioner<TDataTypes>::loadMatrixWithSolver()
 
         for (unsigned int d=0; d<dof_on_node; d++)
         {
-            std::cout.precision(2);
-            std::cout << "Precomputing constraint correction : " << std::fixed << (float)(j*dof_on_node+d)*100.0f/(float)(nb_dofs*dof_on_node) << " %   " << '\xd';
-            std::cout.flush();
+            std::stringstream tmp;
+            tmp.precision(2);
+            tmp << "Precomputing constraint correction : " << std::fixed << (float)(j*dof_on_node+d)*100.0f/(float)(nb_dofs*dof_on_node) << " %   " << '\xd';
+            msg_info("PrecomputedWarpPreconditioner") << tmp.str() ;
 
             unitary_force.clear();
             unitary_force[d]=1.0;
@@ -443,9 +433,7 @@ void PrecomputedWarpPreconditioner<TDataTypes>::loadMatrixWithSolver()
         unitary_force.clear();
         force[pid_j] = unitary_force;
     }
-    std::cout << "Precomputing constraint correction : " << std::fixed << 100.0f << " %" << std::endl;
-    std::cout.flush();
-
+    msg_info("PrecomputedWarpPreconditioner") << "Precomputing constraint correction : " << std::fixed << 100.0f << " %" ;
     ///////////////////////////////////////////////////////////////////////////////////////////////
 
     if (linearSolver) linearSolver->freezeSystemMatrix(); // do not recompute the matrix for the rest of the precomputation
@@ -465,9 +453,6 @@ void PrecomputedWarpPreconditioner<TDataTypes>::loadMatrixWithSolver()
     for (unsigned int i=0; i<velocity0.size(); i++) velocity[i]=velocity0[i];
     //Reset the position
     for (unsigned int i=0; i<pos0.size(); i++) pos[i]=pos0[i];
-
-//         dataForce->endEdit();
-//         dataVelocity->endEdit();
 
     mstate->vFree(core::ExecParams::defaultInstance(), lhId);
     mstate->vFree(core::ExecParams::defaultInstance(), rhId);

--- a/modules/SofaSparseSolver/PrecomputedLinearSolver.h
+++ b/modules/SofaSparseSolver/PrecomputedLinearSolver.h
@@ -59,7 +59,7 @@ public :
 
         if(compFileIn.good())
         {
-            std::cout << "file open : " << filename << " compliance being loaded" << std::endl;
+            msg_info("PrecomputedLInearSolverInternalData") << "file '" << filename << "' with compliance being loaded." ;
             compFileIn.read((char*) Minv[0], systemSize * systemSize * sizeof(Real));
             compFileIn.close();
             return true;

--- a/modules/SofaSparseSolver/PrecomputedLinearSolver.inl
+++ b/modules/SofaSparseSolver/PrecomputedLinearSolver.inl
@@ -124,7 +124,7 @@ void PrecomputedLinearSolver<TMatrix,TVector >::loadMatrix(TMatrix& M)
 template<class TMatrix,class TVector>
 void PrecomputedLinearSolver<TMatrix,TVector>::loadMatrixWithCSparse(TMatrix& M)
 {
-    std::cout << "Compute the initial invert matrix with CS_PARSE" << std::endl;
+    msg_info("PrecomputedLinearSolver") << "Compute the initial invert matrix with CS_PARSE" ;
 
     CompressedRowSparseMatrix<double> matSolv;
     FullVector<double> r;
@@ -146,14 +146,15 @@ void PrecomputedLinearSolver<TMatrix,TVector>::loadMatrixWithCSparse(TMatrix& M)
         b.set(j,0.0);
     }
 
-    std::cout << "Precomputing constraint correction LU decomposition " << std::endl;
+    msg_info("PrecomputedLinearSolver") << "Precomputing constraint correction LU decomposition " ;
     solver.invert(matSolv);
 
     for (unsigned int j=0; j<systemSize; j++)
     {
-        std::cout.precision(2);
-        std::cout << "Precomputing constraint correction : " << std::fixed << (float)j/(float)systemSize*100.0f << " %   " << '\xd';
-        std::cout.flush();
+        std::stringstream tmp;
+        tmp.precision(2);
+        tmp << "Precomputing constraint correction : " << std::fixed << (float)j/(float)systemSize*100.0f << " %   " << '\xd';
+        msg_info("PrecomputedLinearSolver") << tmp.str() ;
 
         if (j>0) b.set(j-1,0.0);
         b.set(j,1.0);
@@ -164,8 +165,8 @@ void PrecomputedLinearSolver<TMatrix,TVector>::loadMatrixWithCSparse(TMatrix& M)
             internalData.Minv.set(j,i,r.element(i) * factInt);
         }
     }
-    std::cout << "Precomputing constraint correction : " << std::fixed << 100.0f << " %   " << '\xd';
-    std::cout.flush();
+    msg_info("PrecomputedLinearSolver") << "Precomputing constraint correction : " << std::fixed << 100.0f << " %   " << '\xd';
+
 }
 #endif
 

--- a/modules/SofaSphFluid/ParticleSource.h
+++ b/modules/SofaSphFluid/ParticleSource.h
@@ -135,7 +135,7 @@ public:
 
         void applyDestroyFunction(unsigned int index, value_type& /*T*/)
         {
-            std::cout << "PSRemovalFunction\n";
+            dmsg_info("ParticleSource") << "PSRemovalFunction";
             if(ps)
             {
                 /*topology::PointSubset::const_iterator it = std::find(ps->lastparticles.begin(),ps->lastparticles.end(), (unsigned int)index);

--- a/modules/SofaSphFluid/SPHFluidSurfaceMapping.inl
+++ b/modules/SofaSphFluid/SPHFluidSurfaceMapping.inl
@@ -367,23 +367,22 @@ void SPHFluidSurfaceMapping<In,Out>::apply(const core::MechanicalParams * /*mpar
 
     //sout << out.size() << " points, "<<seqTriangles.size()<<" faces."<<sendl;
     /*
-    	if (firstApply)
-    	{
+        if (firstApply)
+        {
     #ifdef SOFA_HAVE_GLEW
-    		visualmodel::OglShaderVisualModel* oglsvm = dynamic_cast<visualmodel::OglShaderVisualModel*>(this->toModel);
+            visualmodel::OglShaderVisualModel* oglsvm = dynamic_cast<visualmodel::OglShaderVisualModel*>(this->toModel);
 
-    		if(oglsvm)
-    		{
-    			Vec3fTypes::VecCoord tempRest;
-    			for(unsigned int i=0 ; i<out.size() ; i++)
-    				tempRest.push_back(out[i]);
-    			oglsvm->putRestPositions(tempRest);
-    			//std::cout << "void SPHFluidSurfaceMapping<In,Out>::apply" << std::endl;
-    		}
+            if(oglsvm)
+            {
+                Vec3fTypes::VecCoord tempRest;
+                for(unsigned int i=0 ; i<out.size() ; i++)
+                    tempRest.push_back(out[i]);
+                oglsvm->putRestPositions(tempRest);
+            }
 
-    		firstApply = false;
+            firstApply = false;
     #endif
-    	}
+        }
     */
     if(normals_data == NULL)
         delete normals;

--- a/modules/SofaSphFluid/SpatialGridContainer.inl
+++ b/modules/SofaSphFluid/SpatialGridContainer.inl
@@ -292,7 +292,6 @@ void SpatialGrid<DataTypes>::computeField(ParticleField* field, Real dist)
         dmsg_info("SpatalGrid") << "Distance too large in computeField ("<<r<<" > "<<GRIDDIM<<")" ;
         return;
     }
-    //std::cout << "accumulate particles with radius "<<dist<<std::endl;
     for (typename Map::iterator itg = map.begin(); itg != map.end(); itg++)
     {
         Grid* g = itg->second;
@@ -321,7 +320,6 @@ void SpatialGrid<DataTypes>::computeField(ParticleField* field, Real dist)
                             typename std::list<Entry>::const_iterator begin = c->plist.begin();
                             typename std::list<Entry>::const_iterator end = c->plist.end();
                             typename std::list<Entry>::const_iterator it;
-                            //std::cout << "accumulate "<<c->plist.size()<<" particles from <"<<pos<<">+<"<<x<<" "<<y<<" "<<z<<"> to area <"<<x0<<" "<<y0<<" "<<z0<<">-<"<<x1<<" "<<y1<<" "<<z1<<">"<<std::endl;
                             c2 = g->cell+(x0*DX+y0*DY+z0*DZ);
                             const int dy = DY-(x1-x0+1)*DX;
                             const int dz = DZ-(y1-y0+1)*DY;
@@ -375,7 +373,6 @@ void SpatialGrid<DataTypes>::computeField(ParticleField* field, Real dist)
                         if (gz<0)      { g2_z0 = GRIDDIM-r; } // g_z1 = 0;  g_dz1 = 1; }
                         else if (gz>0) { g2_z1 = r-1; } // g_z0 = GRIDDIM-r;  g_dz0 = 1; }
 
-                        //std::cout << "accumulate neighbors particles from <"<<g2_x0<<" "<<g2_y0<<" "<<g2_z0<<">-<"<<g2_x1<<" "<<g2_y1<<" "<<g2_z1<<">"<<std::endl;
                         //int z0 = g_z0;
                         //int z1 = g_z1;
                         const Cell* cz = g2->cell+(g2_x0*DX+g2_y0*DY+g2_z0*DZ);
@@ -402,7 +399,6 @@ void SpatialGrid<DataTypes>::computeField(ParticleField* field, Real dist)
                                         int y1 = y + gy*GRIDDIM + r; if (y1>GRIDDIM-1) y1 = GRIDDIM-1;
                                         int z0 = z + gz*GRIDDIM - r+1; if (z0<0) z0 = 0;
                                         int z1 = z + gz*GRIDDIM + r; if (z1>GRIDDIM-1) z1 = GRIDDIM-1;
-                                        //std::cout << "accumulate neighbors "<<c->plist.size()<<" particles from <"<<pos<<">+<"<<x+gx*GRIDDIM<<" "<<y+gy*GRIDDIM<<" "<<z+gz*GRIDDIM<<"> to area <"<<x0<<" "<<y0<<" "<<z0<<">-<"<<x1<<" "<<y1<<" "<<z1<<">"<<std::endl;
                                         Cell* c2 = g->cell+(x0*DX+y0*DY+z0*DZ);
                                         const int dy = DY-(x1-x0+1)*DX;
                                         const int dz = DZ-(y1-y0+1)*DY;

--- a/modules/SofaTopologyMapping/IdentityTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/IdentityTopologicalMapping.cpp
@@ -102,23 +102,21 @@ void IdentityTopologicalMapping::updateTopologicalMappingTopDown()
     PointSetTopologyModifier *toPointMod = NULL;
     EdgeSetTopologyModifier *toEdgeMod = NULL;
     TriangleSetTopologyModifier *toTriangleMod = NULL;
-    //QuadSetTopologyModifier *toQuadMod = NULL;
-    //TetrahedronSetTopologyModifier *toTetrahedronMod = NULL;
-    //HexahedronSetTopologyModifier *toHexahedronMod = NULL;
 
     TriangleSetTopologyContainer *fromTriangleCon = NULL;
     fromModel->getContext()->get(fromTriangleCon);
 
-    std::cout << "Begin Nb of points of fromModel : " << fromTriangleCon->getNbPoints() << std::endl;
-    std::cout << "Begin Nb of edges of fromModel : " << fromTriangleCon->getNbEdges() << std::endl;
-    std::cout << "Begin Nb of triangles of fromModel : " << fromTriangleCon->getNbTriangles() << std::endl;
-
 
     TriangleSetTopologyContainer *toTriangleCon = NULL;
     toModel->getContext()->get(toTriangleCon);
-    std::cout << "Begin Nb of points of toModel : " << toTriangleCon->getNbPoints() << std::endl;
-    std::cout << "Begin Nb of edges of toModel : " << toTriangleCon->getNbEdges() << std::endl;
-    std::cout << "Begin Nb of triangles of toModel : " << toTriangleCon->getNbTriangles() << std::endl;
+
+    msg_info() << "Begin: " << msgendl
+               << "    Nb of points of fromModel : " << fromTriangleCon->getNbPoints() << msgendl
+               << "    Nb of edges of fromModel : " << fromTriangleCon->getNbEdges() << msgendl
+               << "    Nb of triangles of fromModel : " << fromTriangleCon->getNbTriangles() << msgendl
+               << "    Nb of points of toModel : " << toTriangleCon->getNbPoints() << msgendl
+               << "    Nb of edges of toModel : " << toTriangleCon->getNbEdges() << msgendl
+               << "    Nb of triangles of toModel : " << toTriangleCon->getNbTriangles();
 
     toModel->getContext()->get(toPointMod);
     if (!toPointMod)
@@ -137,7 +135,7 @@ void IdentityTopologicalMapping::updateTopologicalMappingTopDown()
 
         case core::topology::ENDING_EVENT:
         {
-            std::cout << "ENDING_EVENT" << std::endl;
+            dmsg_info() << "ENDING_EVENT" ;
             toPointMod->propagateTopologicalChanges();
             toPointMod->notifyEndingEvent();
             toPointMod->propagateTopologicalChanges();
@@ -147,7 +145,7 @@ void IdentityTopologicalMapping::updateTopologicalMappingTopDown()
         case core::topology::POINTSADDED:
         {
             const PointsAdded * pAdd = static_cast< const PointsAdded * >( topoChange );
-            std::cout << "POINTSADDED : " << pAdd->getNbAddedVertices() << std::endl;
+            dmsg_info() << "POINTSADDED : " << pAdd->getNbAddedVertices() ;
             toPointMod->addPointsProcess(pAdd->getNbAddedVertices());
             toPointMod->addPointsWarning(pAdd->getNbAddedVertices(), pAdd->ancestorsList, pAdd->coefs, true);
             toPointMod->propagateTopologicalChanges();
@@ -157,7 +155,7 @@ void IdentityTopologicalMapping::updateTopologicalMappingTopDown()
         {
             const PointsRemoved *pRem = static_cast< const PointsRemoved * >( topoChange );
             sofa::helper::vector<unsigned int> tab = pRem->getArray();
-            std::cout << "POINTSREMOVED : " << tab.size() << std::endl;
+            dmsg_info() << "POINTSREMOVED : " << tab.size() ;
             toPointMod->removePointsWarning(tab, true);
             toPointMod->propagateTopologicalChanges();
             toPointMod->removePointsProcess(tab, true);
@@ -168,7 +166,7 @@ void IdentityTopologicalMapping::updateTopologicalMappingTopDown()
             const PointsRenumbering *pRenumber = static_cast< const PointsRenumbering * >( topoChange );
             const sofa::helper::vector<unsigned int> &tab = pRenumber->getIndexArray();
             const sofa::helper::vector<unsigned int> &inv_tab = pRenumber->getinv_IndexArray();
-            std::cout << "POINTSRENUMBERING : " << tab.size() <<std::endl;
+            dmsg_info() << "POINTSRENUMBERING : " << tab.size() ;
             toPointMod->renumberPointsWarning(tab, inv_tab, true);
             toPointMod->propagateTopologicalChanges();
             toPointMod->renumberPointsProcess(tab, inv_tab, true);
@@ -180,7 +178,7 @@ void IdentityTopologicalMapping::updateTopologicalMappingTopDown()
             if (!toEdgeMod) toModel->getContext()->get(toEdgeMod);
             if (!toEdgeMod) break;
             const EdgesAdded *eAdd = static_cast< const EdgesAdded * >( topoChange );
-            std::cout << "EDGESADDED : " << eAdd->getNbAddedEdges() << std::endl;
+            dmsg_info() << "EDGESADDED : " << eAdd->getNbAddedEdges() ;
             toEdgeMod->addEdgesProcess(eAdd->edgeArray);
             toEdgeMod->addEdgesWarning(eAdd->getNbAddedEdges(), eAdd->edgeArray, eAdd->edgeIndexArray, eAdd->ancestorsList, eAdd->coefs);
             toEdgeMod->propagateTopologicalChanges();
@@ -193,7 +191,7 @@ void IdentityTopologicalMapping::updateTopologicalMappingTopDown()
             if (!toEdgeMod) break;
             const EdgesRemoved *eRem = static_cast< const EdgesRemoved * >( topoChange );
             sofa::helper::vector<unsigned int> tab = eRem->getArray();
-            std::cout << "EDGESREMOVED : " << std::endl;
+            dmsg_info() << "EDGESREMOVED : " ;
             toEdgeMod->removeEdgesWarning(tab);
             toEdgeMod->propagateTopologicalChanges();
             toEdgeMod->removeEdgesProcess(tab, false);
@@ -205,7 +203,7 @@ void IdentityTopologicalMapping::updateTopologicalMappingTopDown()
             if (!toTriangleMod) toModel->getContext()->get(toTriangleMod);
             if (!toTriangleMod) break;
             const TrianglesAdded *tAdd = static_cast< const TrianglesAdded * >( topoChange );
-            std::cout << "TRIANGLESADDED : " << tAdd->getNbAddedTriangles() << std::endl;
+            dmsg_info() << "TRIANGLESADDED : " << tAdd->getNbAddedTriangles() ;
             toTriangleMod->addTrianglesProcess(tAdd->triangleArray);
             toTriangleMod->addTrianglesWarning(tAdd->getNbAddedTriangles(), tAdd->triangleArray, tAdd->triangleIndexArray, tAdd->ancestorsList, tAdd->coefs);
             toTriangleMod->propagateTopologicalChanges();
@@ -218,7 +216,7 @@ void IdentityTopologicalMapping::updateTopologicalMappingTopDown()
             if (!toTriangleMod) break;
             const TrianglesRemoved *tRem = static_cast< const TrianglesRemoved * >( topoChange );
             sofa::helper::vector<unsigned int> tab = tRem->getArray();
-            std::cout << "TRIANGLESREMOVED : " << tab.size() << std::endl;
+            dmsg_info() << "TRIANGLESREMOVED : " << tab.size() ;
             toTriangleMod->removeTrianglesWarning(tab);
             toTriangleMod->propagateTopologicalChanges();
             toTriangleMod->removeTrianglesProcess(tab, false);
@@ -233,15 +231,15 @@ void IdentityTopologicalMapping::updateTopologicalMappingTopDown()
     }
     toPointMod->propagateTopologicalChanges();
 
-    std::cout << "End Nb of points of fromModel : " << fromTriangleCon->getNbPoints() << std::endl;
-    std::cout << "End Nb of points of fromState : " << fromTriangleCon->getContext()->getState()->getSize() << std::endl;
-    std::cout << "End Nb of edges of fromModel : " << fromTriangleCon->getNbEdges() << std::endl;
-    std::cout << "End Nb of triangles of fromModel : " << fromTriangleCon->getNbTriangles() << std::endl;
-
-    std::cout << "End Nb of points of toModel : " << toTriangleCon->getNbPoints() << std::endl;
-    std::cout << "End Nb of points of toState : " << toTriangleCon->getContext()->getState()->getSize() << std::endl;
-    std::cout << "End Nb of edges of toModel : " << toTriangleCon->getNbEdges() << std::endl;
-    std::cout << "End Nb of triangles of toModel : " << toTriangleCon->getNbTriangles() << std::endl;
+    msg_info() << "End: "
+               << "    Nb of points of fromModel : " << fromTriangleCon->getNbPoints() << msgendl
+               << "    Nb of points of fromState : " << fromTriangleCon->getContext()->getState()->getSize() << msgendl
+               << "    Nb of edges of fromModel : " << fromTriangleCon->getNbEdges() << msgendl
+               << "    Nb of triangles of fromModel : " << fromTriangleCon->getNbTriangles() << msgendl
+               << "    Nb of points of toModel : " << toTriangleCon->getNbPoints() << msgendl
+               << "    Nb of points of toState : " << toTriangleCon->getContext()->getState()->getSize() << msgendl
+               << "    Nb of edges of toModel : " << toTriangleCon->getNbEdges() << msgendl
+               << "    Nb of triangles of toModel : " << toTriangleCon->getNbTriangles() ;
 
 }
 

--- a/modules/SofaTopologyMapping/Quad2TriangleTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/Quad2TriangleTopologicalMapping.cpp
@@ -137,10 +137,6 @@ void Quad2TriangleTopologicalMapping::init()
 
             for (unsigned int i=0; i<quadArray.size(); ++i)
             {
-
-                //std::cout << "INFO_print : Quad2TriangleTopologicalMapping - i = " << i << std::endl;
-                //std::cout << "INFO_print : Quad2TriangleTopologicalMapping - quad = " << quadArray[i] << std::endl;
-
                 unsigned int p0 = quadArray[i][0];
                 unsigned int p1 = quadArray[i][1];
                 unsigned int p2 = quadArray[i][2];

--- a/modules/SofaUserInteraction/ArticulatedHierarchyBVHController.cpp
+++ b/modules/SofaUserInteraction/ArticulatedHierarchyBVHController.cpp
@@ -75,7 +75,7 @@ void ArticulatedHierarchyBVHController::applyController(void)
 
         double residu = (externalTime.getValue() / ahc->dtbvh) - (double) frame;
 
-        std::cout<<"externalTime.getValue() = "<<externalTime.getValue() <<"  frame= "<<frame<<" residu = "<<residu<<std::endl;
+        msg_info() << "externalTime.getValue() = "<<externalTime.getValue() <<"  frame= "<<frame<<" residu = "<<residu ;
 
         if(frame > ahc->numOfFrames-2)
         {
@@ -83,12 +83,6 @@ void ArticulatedHierarchyBVHController::applyController(void)
         }
 
         alpha = residu;
-
-
-        // ndiv=1.0;
-        // n = residu;
-
-
     }
     else
     {

--- a/modules/SofaUserInteraction/ArticulatedHierarchyController.cpp
+++ b/modules/SofaUserInteraction/ArticulatedHierarchyController.cpp
@@ -181,11 +181,11 @@ void ArticulatedHierarchyController::dumpActiveArticulations(void) const
     int i=0;
     while (it != itEnd)
     {
-        if (*it)
-            std::cout << "-------------> Articulation " << articulationsIndices.getValue()[i] << " active"<<std::endl;
-        else
-            std::cout << "-------------> Articulation " << articulationsIndices.getValue()[i] << " inactive"<<std::endl;
-
+        if (*it){
+            msg_info() << "-------------> Articulation " << articulationsIndices.getValue()[i] << " active" ;
+        }else{
+            msg_info() << "-------------> Articulation " << articulationsIndices.getValue()[i] << " inactive" ;
+        }
         ++it;
         i++;
     }
@@ -195,7 +195,7 @@ void ArticulatedHierarchyController::dumpActiveArticulations(void) const
 
 void ArticulatedHierarchyController::dumpArticulationsAndBindingKeys(void) const
 {
-    std::cout << "ARTICULATIONS_KEYBOARD_CONTROLER : Controled Articulations & Binding Keys"<<std::endl;
+    msg_info() << "ARTICULATIONS_KEYBOARD_CONTROLER : Controled Articulations & Binding Keys" ;
 
     vector<int>::const_iterator articulationsIndicesIt = articulationsIndices.getValue().begin();
     vector<int>::const_iterator articulationsIndicesItEnd = articulationsIndices.getValue().end();
@@ -205,7 +205,7 @@ void ArticulatedHierarchyController::dumpArticulationsAndBindingKeys(void) const
 
     while (articulationsIndicesIt != articulationsIndicesItEnd)
     {
-        std::cout << "Articulation " << *articulationsIndicesIt << " controlled with key " << *bindinKeysIt << std::endl;
+        msg_info() << "Articulation " << *articulationsIndicesIt << " controlled with key " << *bindinKeysIt ;
         ++articulationsIndicesIt;
         ++bindinKeysIt;
         if (bindinKeysIt == bindinKeysItEnd)

--- a/modules/SofaUserInteraction/InciseAlongPathPerformer.cpp
+++ b/modules/SofaUserInteraction/InciseAlongPathPerformer.cpp
@@ -133,14 +133,14 @@ void InciseAlongPathPerformer::PerformCompleteIncision()
 {
     if (firstIncisionBody.body == NULL || startBody.body == NULL)
     {
-        std::cout << "Error: One picked body is null." << std::endl;
+        msg_error("InciseAlongPathPerformer") << "One picked body is null." ;
         return;
     }
 
 
     if (firstIncisionBody.indexCollisionElement == startBody.indexCollisionElement)
     {
-        std::cout << "Error: picked body are the same." << std::endl;
+        msg_error("InciseAlongPathPerformer") << "Picked body are the same." ;
         return;
     }
 
@@ -158,7 +158,7 @@ void InciseAlongPathPerformer::PerformCompleteIncision()
 
     if (!findTri)
     {
-        std::cout << "Error: initial point of incision has not been found." << std::endl;
+        dmsg_error("InciseAlongPathPerformer") << " initial point of incision has not been found." ;
         return;
     }
 
@@ -178,7 +178,7 @@ void InciseAlongPathPerformer::PerformCompleteIncision()
 
     if (the_triangle == -1)
     {
-        std::cout << "Error: initial triangle of incision has not been found." << std::endl;
+        msg_error("InciseAlongPathPerformer") << " initial triangle of incision has not been found." ;
         return;
     }
 

--- a/modules/SofaUserInteraction/MechanicalStateController.cpp
+++ b/modules/SofaUserInteraction/MechanicalStateController.cpp
@@ -92,10 +92,6 @@ void MechanicalStateController<Vec1dTypes>::applyController()
     using sofa::defaulttype::Vec;
 
 
-    //std::cout<<" applyController() : device "<< device << "  buttonDevice " <<buttonDevice<<std::endl;
-
-//	if(device)
-//	{
     if(mState)
     {
         helper::WriteAccessor<Data<VecCoord> > x0 = *mState->write(sofa::core::VecCoordId::restPosition());
@@ -106,15 +102,13 @@ void MechanicalStateController<Vec1dTypes>::applyController()
             else
                 x0[0].x() =  -0.1;
             /*
-            				if (x0[1].x() > 0.001)
-            					x0[1].x() -= 0.05;
-            				else
-            					x0[1].x() = 0.001;*/
+                            if (x0[1].x() > 0.001)
+                                x0[1].x() -= 0.05;
+                            else
+                                x0[1].x() = 0.001;*/
         }
         else
         {
-            //sout<<"mouseMode==Release"<<sendl;
-
             if (x0[0].x() > -0.5)	 //angle d'ouverture max
                 x0[0].x() -= 0.05;   //vitesse d'ouverture
             else
@@ -149,14 +143,6 @@ void MechanicalStateController<Vec1dTypes>::applyController()
 
         }
     }
-    //}
-
-
-
-    //	//sofa::simulation::Node *node = static_cast<sofa::simulation::Node*> (this->getContext());
-    //	//sofa::simulation::MechanicalPropagatePositionAndVelocityVisitor mechaVisitor; mechaVisitor.execute(node);
-    //	//sofa::simulation::UpdateMappingVisitor updateVisitor; updateVisitor.execute(node);
-    //}
 };
 #endif
 

--- a/modules/SofaUserInteraction/MechanicalStateControllerOmni.inl
+++ b/modules/SofaUserInteraction/MechanicalStateControllerOmni.inl
@@ -59,7 +59,7 @@ namespace controller
 template <class DataTypes>
 MechanicalStateControllerOmni<DataTypes>::MechanicalStateControllerOmni()
     :/* index( initData(&index, (unsigned int)0, "index", "Index of the controlled DOF") )
-	, onlyTranslation( initData(&onlyTranslation, false, "onlyTranslation", "Controlling the DOF only in translation") )
+    , onlyTranslation( initData(&onlyTranslation, false, "onlyTranslation", "Controlling the DOF only in translation") )
     ,*/ buttonDeviceState(initData(&buttonDeviceState, false, "buttonDeviceState", "state of ths device button"))
     , deviceId(initData(&deviceId, -1, "deviceId", "id of active device for this controller"))
     , angle(initData(&angle, (Real)10, "angle", "max angle"))
@@ -91,98 +91,98 @@ void MechanicalStateControllerOmni<DataTypes>::applyController(double /*dt*/)
     if(device)
     {
            if(mState)device
-    	{
+        {
     //			if(mState->read(sofa::core::ConstVecCoordId::freePosition())->getValue())
-    		{
+            {
                    helper::WriteAccessor<Data<VecCoord> > x = *this->mState->write(core::VecCoordId::position());
                    helper::WriteAccessor<Data<VecCoord> > xfree = *this->mState->write(core::VecCoordId::freePosition());
-    			xfree[0].getCenter() = position;
-    			x[0].getCenter() = position;
+                xfree[0].getCenter() = position;
+                x[0].getCenter() = position;
 
-    			xfree[0].getOrientation() = orientation;
-    			x[0].getOrientation() = orientation;
-    		}
-    	}
-    	device = false;
+                xfree[0].getOrientation() = orientation;
+                x[0].getOrientation() = orientation;
+            }
+        }
+        device = false;
     }
 
     if ( !onlyTranslation.getValue()  && ((mouseMode==BtLeft) || (mouseMode==BtRight)))
     {
-    	int dx = eventX - mouseSavedPosX;
-    	int dy = eventY - mouseSavedPosY;
-    	mouseSavedPosX = eventX;
-    	mouseSavedPosY = eventY;
+        int dx = eventX - mouseSavedPosX;
+        int dy = eventY - mouseSavedPosY;
+        mouseSavedPosX = eventX;
+        mouseSavedPosY = eventY;
 
-    	if (mState)
-    	{
+        if (mState)
+        {
                helper::WriteAccessor<Data<VecCoord> > x = *this->mState->write(core::VecCoordId::position());
                helper::WriteAccessor<Data<VecCoord> > xfree = *this->mState->write(core::VecCoordId::freePosition());
 
-    		unsigned int i = index.getValue();
+            unsigned int i = index.getValue();
 
-    		Vec<3,Real> vx(1,0,0);
-    		Vec<3,Real> vy(0,1,0);
-    		Vec<3,Real> vz(0,0,1);
+            Vec<3,Real> vx(1,0,0);
+            Vec<3,Real> vy(0,1,0);
+            Vec<3,Real> vz(0,0,1);
 
-    		if (mouseMode==BtLeft)
-    		{
-    			xfree[i].getOrientation() = x[i].getOrientation() * Quat(vy, dx * (Real)0.001) * Quat(vz, dy * (Real)0.001);
-    			x[i].getOrientation() = x[i].getOrientation() * Quat(vy, dx * (Real)0.001) * Quat(vz, dy * (Real)0.001);
-    		}
-    		else
-    		{
-    			sofa::helper::Quater<Real>& quatrot = x[i].getOrientation();
-    			sofa::defaulttype::Vec<3,Real> vectrans(dy * mainDirection.getValue()[0] * (Real)0.05, dy * mainDirection.getValue()[1] * (Real)0.05, dy * mainDirection.getValue()[2] * (Real)0.05);
-    			vectrans = quatrot.rotate(vectrans);
+            if (mouseMode==BtLeft)
+            {
+                xfree[i].getOrientation() = x[i].getOrientation() * Quat(vy, dx * (Real)0.001) * Quat(vz, dy * (Real)0.001);
+                x[i].getOrientation() = x[i].getOrientation() * Quat(vy, dx * (Real)0.001) * Quat(vz, dy * (Real)0.001);
+            }
+            else
+            {
+                sofa::helper::Quater<Real>& quatrot = x[i].getOrientation();
+                sofa::defaulttype::Vec<3,Real> vectrans(dy * mainDirection.getValue()[0] * (Real)0.05, dy * mainDirection.getValue()[1] * (Real)0.05, dy * mainDirection.getValue()[2] * (Real)0.05);
+                vectrans = quatrot.rotate(vectrans);
 
-    			x[i].getCenter() += vectrans;
-    			x[i].getOrientation() = x[i].getOrientation() * Quat(vx, dx * (Real)0.001);
+                x[i].getCenter() += vectrans;
+                x[i].getOrientation() = x[i].getOrientation() * Quat(vx, dx * (Real)0.001);
 
-    		//	x0[i].getCenter() += vectrans;
-    		//	x0[i].getOrientation() = x0[i].getOrientation() * Quat(vx, dx * (Real)0.001);
+            //	x0[i].getCenter() += vectrans;
+            //	x0[i].getOrientation() = x0[i].getOrientation() * Quat(vx, dx * (Real)0.001);
 
-    			if(xfree.size() > 0)
-    			{
-    				xfree[i].getCenter() += vectrans;
-    				xfree[i].getOrientation() = x[i].getOrientation() * Quat(vx, dx * (Real)0.001);
-    			}
-    		}
-    	}
+                if(xfree.size() > 0)
+                {
+                    xfree[i].getCenter() += vectrans;
+                    xfree[i].getOrientation() = x[i].getOrientation() * Quat(vx, dx * (Real)0.001);
+                }
+            }
+        }
     }
     else if( onlyTranslation.getValue() )
     {
-    	if( mouseMode )
-    	{
-    		int dx = eventX - mouseSavedPosX;
-    		int dy = eventY - mouseSavedPosY;
-    		mouseSavedPosX = eventX;
-    		mouseSavedPosY = eventY;
+        if( mouseMode )
+        {
+            int dx = eventX - mouseSavedPosX;
+            int dy = eventY - mouseSavedPosY;
+            mouseSavedPosX = eventX;
+            mouseSavedPosY = eventY;
 
     // 			Real d = sqrt(dx*dx+dy*dy);
     // 			if( dx<0 || dy<0 ) d = -d;
 
-    		if (mState)
-    		{
+            if (mState)
+            {
                    helper::WriteAccessor<Data<VecCoord> > x = *this->mState->write(core::VecCoordId::position());
 
-    			unsigned int i = index.getValue();
+                unsigned int i = index.getValue();
 
-    			switch( mouseMode )
-    			{
-    				case BtLeft:
-    					x[i].getCenter() += Vec<3,Real>((Real)dx,(Real)0,(Real)0);
-    					break;
-    				case BtRight :
-    					x[i].getCenter() += Vec<3,Real>((Real)0,(Real)dy,(Real)0);
-    					break;
-    				case BtMiddle :
-    					x[i].getCenter() += Vec<3,Real>((Real)0,(Real)0,(Real)dy);
-    					break;
-    				default :
-    					break;
-    			}
-    		}
-    	}
+                switch( mouseMode )
+                {
+                    case BtLeft:
+                        x[i].getCenter() += Vec<3,Real>((Real)dx,(Real)0,(Real)0);
+                        break;
+                    case BtRight :
+                        x[i].getCenter() += Vec<3,Real>((Real)0,(Real)dy,(Real)0);
+                        break;
+                    case BtMiddle :
+                        x[i].getCenter() += Vec<3,Real>((Real)0,(Real)0,(Real)dy);
+                        break;
+                    default :
+                        break;
+                }
+            }
+        }
     }
 
     sofa::simulation::Node *node = static_cast<sofa::simulation::Node*> (this->getContext());
@@ -197,9 +197,6 @@ template <class DataTypes>
 void MechanicalStateControllerOmni<DataTypes>::onHapticDeviceEvent(core::objectmodel::HapticDeviceEvent *oev)
 {
     if (deviceId.getValue() != -1 && (int)oev->getDeviceId() != deviceId.getValue()) return;
-    //std::cout << "void MechanicalStateControllerOmni<DataTypes>::onHapticDeviceEvent()"<<std::endl;
-    //if (oev->getButton())
-    //  std::cout<<" Button1 pressed"<<std::endl;
 
     device = true;
     buttonDeviceState.setValue(oev->getButton());
@@ -234,7 +231,7 @@ void MechanicalStateControllerOmni<DataTypes>::setMechanicalState(core::behavior
 template <class DataTypes>
 unsigned int MechanicalStateControllerOmni<DataTypes>::getIndex() const
 {
-	return index.getValue();
+    return index.getValue();
 }
 
 
@@ -242,7 +239,7 @@ unsigned int MechanicalStateControllerOmni<DataTypes>::getIndex() const
 template <class DataTypes>
 void MechanicalStateControllerOmni<DataTypes>::setIndex(const unsigned int _index)
 {
-	index.setValue(_index);
+    index.setValue(_index);
 }
 
 
@@ -250,7 +247,7 @@ void MechanicalStateControllerOmni<DataTypes>::setIndex(const unsigned int _inde
 template <class DataTypes>
 const sofa::defaulttype::Vec<3, typename MechanicalStateControllerOmni<DataTypes>::Real > &MechanicalStateControllerOmni<DataTypes>::getMainDirection() const
 {
-	return mainDirection.getValue();
+    return mainDirection.getValue();
 }
 
 
@@ -258,7 +255,7 @@ const sofa::defaulttype::Vec<3, typename MechanicalStateControllerOmni<DataTypes
 template <class DataTypes>
 void MechanicalStateControllerOmni<DataTypes>::setMainDirection(const sofa::defaulttype::Vec<3,Real> _mainDirection)
 {
-	mainDirection.setValue(_mainDirection);
+    mainDirection.setValue(_mainDirection);
 }
 */
 

--- a/modules/SofaUserInteraction/NodeToggleController.cpp
+++ b/modules/SofaUserInteraction/NodeToggleController.cpp
@@ -210,7 +210,7 @@ void NodeToggleController::onHapticDeviceEvent(core::objectmodel::HapticDeviceEv
     // toggle on button 2 pressed
     if (oev->getButton(1))
     {
-        std::cout << "NodeToggleController: switching active node" << std::endl;
+        msg_info() << "switching active node" ;
         toggle();
     }
 }
@@ -224,7 +224,7 @@ void NodeToggleController::onKeyPressedEvent(core::objectmodel::KeypressedEvent 
         case 'A':
         case 'a':
         {
-            msg_info() << "NodeToggleController: switching active node" ;
+            msg_info() << "switching active node" ;
             toggle();
             break;
         }
@@ -236,7 +236,7 @@ void NodeToggleController::onKeyPressedEvent(core::objectmodel::KeypressedEvent 
     {
         if(d_key.getValue()==oev->getKey())
         {
-            msg_info() << "NodeToggleController: switching active node" ;
+            msg_info() << "switching active node" ;
             toggle();
         }
     }

--- a/modules/SofaUserInteraction/RemovePrimitivePerformer.inl
+++ b/modules/SofaUserInteraction/RemovePrimitivePerformer.inl
@@ -151,8 +151,7 @@ void RemovePrimitivePerformer<DataTypes>::execute()
 template <class DataTypes>
 void RemovePrimitivePerformer<DataTypes>::end()
 {
-    std::cout << "RemovePrimitivePerformer::end()" << std::endl;
-    //	firstClick = true;
+    dmsg_info("RemovePrimitivePerfomer") << " end()" ;
 }
 
 

--- a/modules/SofaUserInteraction/SleepController.cpp
+++ b/modules/SofaUserInteraction/SleepController.cpp
@@ -243,8 +243,10 @@ void SleepController::wakeUpNodes()
             const BaseContexts& wakeupPairRef = wakeupPairs[i];
             if (!wakeupPairRef.empty())
             {
+                std::stringstream tmp
                 for (unsigned int j = 0, nbLinks = wakeupPairRef.size(); j < nbLinks; ++j)
-                    std::cout << m_contextsThatCanSleep[i]->getName() << " --> " << wakeupPairRef[j]->getName() << std::endl;
+                    tmp << m_contextsThatCanSleep[i]->getName() << " --> " << wakeupPairRef[j]->getName() << msgendl;
+                msg_info() << tmp ;
             }
         }
     } */

--- a/modules/SofaUserInteraction/TopologicalChangeManager.cpp
+++ b/modules/SofaUserInteraction/TopologicalChangeManager.cpp
@@ -46,6 +46,12 @@
 
 #include <SofaTopologyMapping/Hexa2TetraTopologicalMapping.h>
 
+#ifndef NDEBUG
+    #define DEBUG_MSG true
+#else
+    #define DEBUG_MSG false
+#endif
+
 namespace sofa
 {
 
@@ -100,7 +106,7 @@ int TopologicalChangeManager::removeItemsFromTriangleModel(sofa::component::coll
         model->getContext()->get(badMapping, sofa::core::objectmodel::BaseContext::SearchRoot);
         if(badMapping) //stop process
         {
-            std::cout << "WARNING: TopologicalChangeManager: Removing element is not handle by Hexa2TetraTopologicalMapping. Stopping process." << std::endl;
+            msg_warning("TopologicalChangeManager") << " Removing element is not handle by Hexa2TetraTopologicalMapping. Stopping process." ;
             return 0;
         }
 
@@ -108,7 +114,6 @@ int TopologicalChangeManager::removeItemsFromTriangleModel(sofa::component::coll
         for (unsigned int i=0; i<indices.size(); ++i)
         {
             items.insert(indices[i] < nbt ? indices[i] : (indices[i]+nbt)/2);
-            //std::cout << indices[i] <<std::endl;
         }
     }
 
@@ -135,7 +140,6 @@ int TopologicalChangeManager::removeItemsFromTriangleModel(sofa::component::coll
                     {
                         unsigned int ind_glob = topoMap->getGlobIndex(*it);
                         unsigned int ind = topoMap->getFromIndex(ind_glob);
-                        //std::cout << *it << " -> "<<ind_glob << " -> "<<ind<<std::endl;
                         items.insert(ind);
                     }
                 }
@@ -147,7 +151,6 @@ int TopologicalChangeManager::removeItemsFromTriangleModel(sofa::component::coll
                         topoMap->getFromIndex( indices, *it);
                         for( vector<unsigned int>::const_iterator itIndices = indices.begin(); itIndices != indices.end(); ++itIndices)
                         {
-                            //std::cout << *it << " -> " << *itIndices << std::endl;
                             items.insert( *itIndices );
                         }
                     }
@@ -230,7 +233,6 @@ int TopologicalChangeManager::removeItemsFromTetrahedronModel(sofa::component::c
                         topoMap->getFromIndex( indices, *it);
                         for( vector<unsigned int>::const_iterator itIndices = indices.begin(); itIndices != indices.end(); itIndices++)
                         {
-                            //std::cout << *it << " -> " << *itIndices << std::endl;
                             items.insert( *itIndices );
                         }
                     }
@@ -300,7 +302,6 @@ int TopologicalChangeManager::removeItemsFromSphereModel(sofa::component::collis
                     {
                         unsigned int ind_glob = topoMap->getGlobIndex(*it);
                         unsigned int ind = topoMap->getFromIndex(ind_glob);
-                        //sout << *it << " -> "<<ind_glob << " -> "<<ind<<sendl;
                         items.insert(ind);
                     }
                 }
@@ -312,7 +313,6 @@ int TopologicalChangeManager::removeItemsFromSphereModel(sofa::component::collis
                         topoMap->getFromIndex( indices, *it);
                         for( vector<unsigned int>::const_iterator itIndices = indices.begin(); itIndices != indices.end(); ++itIndices)
                         {
-                            //std::cout << *it << " -> " << *itIndices << std::endl;
                             items.insert( *itIndices );
                         }
                     }
@@ -520,9 +520,8 @@ bool TopologicalChangeManager::incisionTriangleModel(TriangleModel *firstModel ,
 
         if (!path_ok)
         {
-#ifndef NDEBUG
-            std::cout << "ERROR in computeIntersectedObjectsList" << std::endl;
-#endif
+            if(DEBUG_MSG)
+                dmsg_error("TopologicalChangeManager") << " in computeIntersectedObjectsList" ;
             return false;
         }
 
@@ -545,9 +544,8 @@ bool TopologicalChangeManager::incisionTriangleModel(TriangleModel *firstModel ,
 
         if (!incision_ok)
         {
-#ifndef NDEBUG
-            std::cout << "ERROR in InciseAlongEdgeList" << std::endl;
-#endif
+            if(DEBUG_MSG)
+                dmsg_error("TopologicalChangeManager") << " in InciseAlongEdgeList" ;
             return false;
         }
 

--- a/modules/SofaUserInteraction/TopologicalChangeManager.cpp
+++ b/modules/SofaUserInteraction/TopologicalChangeManager.cpp
@@ -46,12 +46,6 @@
 
 #include <SofaTopologyMapping/Hexa2TetraTopologicalMapping.h>
 
-#ifndef NDEBUG
-    #define DEBUG_MSG true
-#else
-    #define DEBUG_MSG false
-#endif
-
 namespace sofa
 {
 
@@ -520,8 +514,7 @@ bool TopologicalChangeManager::incisionTriangleModel(TriangleModel *firstModel ,
 
         if (!path_ok)
         {
-            if(DEBUG_MSG)
-                dmsg_error("TopologicalChangeManager") << " in computeIntersectedObjectsList" ;
+            dmsg_error("TopologicalChangeManager") << " in computeIntersectedObjectsList" ;
             return false;
         }
 
@@ -544,8 +537,7 @@ bool TopologicalChangeManager::incisionTriangleModel(TriangleModel *firstModel ,
 
         if (!incision_ok)
         {
-            if(DEBUG_MSG)
-                dmsg_error("TopologicalChangeManager") << " in InciseAlongEdgeList" ;
+            dmsg_error("TopologicalChangeManager") << " in InciseAlongEdgeList" ;
             return false;
         }
 

--- a/modules/SofaValidation/EvalPointsDistance.inl
+++ b/modules/SofaValidation/EvalPointsDistance.inl
@@ -125,7 +125,7 @@ void EvalPointsDistance<DataTypes>::reinit()
         else
         {
             (*outfile) << "# name\t\t\ttime\t\tmean\t\tmin\t\tmax\t\tdev\t\tmean(%)\t\tmin(%)\t\tmax(%)\t\tdev(%)" << std::endl;
-            std::cout << "OutputFile " << filename << " created" << std::endl;
+            msg_info() << "OutputFile " << filename << " created.";
         }
     }
     else

--- a/modules/SofaVolumetricData/DistanceGrid.cpp
+++ b/modules/SofaVolumetricData/DistanceGrid.cpp
@@ -36,6 +36,8 @@
 
 #include <sofa/helper/logging/Messaging.h>
 
+#define FMM_VERBOSE false
+
 namespace sofa
 {
 
@@ -182,7 +184,6 @@ DistanceGrid* DistanceGrid::load(const std::string& filename,
             msg_error("DistanceGrid")<<"loading FlowVR mesh file "<<filename;
             return NULL;
         }
-        //std::cout << "bbox = "<<mesh.bb<<std::endl;
 
         if (!mesh.getAttrib(flowvr::render::Mesh::MESH_DISTMAP))
         {
@@ -196,7 +197,6 @@ DistanceGrid* DistanceGrid::load(const std::string& filename,
         ftl::Vec3f fpmax = ftl::transform(mesh.distmap->mat,ftl::Vec3f((float)(nx-1),(float)(ny-1),(float)(nz-1)))*(float)absscale;
         pmin = Coord(fpmin.ptr());
         pmax = Coord(fpmax.ptr());
-        //std::cout << "Copying "<<nx<<"x"<<ny<<"x"<<nz<<" distance grid in <"<<pmin<<">-<"<<pmax<<">"<<std::endl;
         DistanceGrid* grid = new DistanceGrid(nx, ny, nz, pmin, pmax);
         for (int i=0; i< grid->nxnynz; i++)
             grid->dists[i] = mesh.distmap->data[i]*scale;
@@ -210,7 +210,6 @@ DistanceGrid* DistanceGrid::load(const std::string& filename,
                 if (mesh.getGP0(i) >= 0)
                     ++nbpos;
             }
-            //std::cout << "Copying "<<nbpos<<" mesh vertices."<<std::endl;
             grid->meshPts.resize(nbpos);
             int p = 0;
             for (int i=0; i<mesh.nbg(); i++)
@@ -223,7 +222,6 @@ DistanceGrid* DistanceGrid::load(const std::string& filename,
         else
         {
             int nbpos = mesh.nbp();
-            //std::cout << "Copying "<<nbpos<<" mesh vertices."<<std::endl;
             grid->meshPts.resize(nbpos);
             for (int i=0; i<nbpos; i++)
                 grid->meshPts[i] = Coord(mesh.getPP(i).ptr())*absscale;
@@ -235,7 +233,6 @@ DistanceGrid* DistanceGrid::load(const std::string& filename,
         }
         else
             grid->computeBBox();
-        //std::cout<< "Distance grid creation DONE."<<std::endl;
         return grid;
 #else
         msg_error("DistanceGrid")<<"Loading a .fmesh file requires the FlowVR library (activatable with the CMake option 'SOFA_BUILD_MINIFLOWVR')";
@@ -309,7 +306,7 @@ bool DistanceGrid::save(const std::string& filename)
     }
     else
     {
-        msg_error("DistanceGrid")<<"save(): Unsupported extension: "<<filename;
+        msg_error("DistanceGrid")<<" save(): Unsupported extension: "<<filename;
         return false;
     }
     return true;
@@ -591,7 +588,7 @@ void DistanceGrid::calcDistance(sofa::helper::io::Mesh* mesh, double scale)
     fmm_status.resize(nxnynz);
     fmm_heap.resize(nxnynz);
     fmm_heap_size = 0;
-    msg_info("DistanceGrid")<< "FMM: Init.";
+    dmsg_info("DistanceGrid")<< "FMM: Init.";
 
     std::fill(fmm_status.begin(), fmm_status.end(), FMM_FAR);
     std::fill(dists.begin(), dists.end(), maxDist());
@@ -600,7 +597,7 @@ void DistanceGrid::calcDistance(sofa::helper::io::Mesh* mesh, double scale)
     const helper::vector<helper::vector<helper::vector<int> > > & facets = mesh->getFacets();
 
     // Initialize distance of edges crossing triangles
-    msg_info("DistanceGrid")<< "FMM: Initialize distance of edges crossing triangles.";
+    dmsg_info("DistanceGrid")<< "FMM: Initialize distance of edges crossing triangles.";
 
     for (unsigned int i=0; i<facets.size(); i++)
     {
@@ -1005,9 +1002,10 @@ inline void DistanceGrid::fmm_swap(int entry1, int entry2)
 int DistanceGrid::fmm_pop()
 {
     int res = fmm_heap[0];
-#ifdef FMM_VERBOSE
-    msg_info("DistanceGrid")<< "fmm_pop -> <"<<(res%nx)<<','<<((res/nx)%ny)<<','<<(res/nxny)<<">="<<dists[res];
-#endif
+
+    if(FMM_VERBOSE)
+        msg_info("DistanceGrid")<< "fmm_pop -> <"<<(res%nx)<<','<<((res/nx)%ny)<<','<<(res/nxny)<<">="<<dists[res];
+
     --fmm_heap_size;
     if (fmm_heap_size>0)
     {
@@ -1048,13 +1046,15 @@ int DistanceGrid::fmm_pop()
             else break;
         }
     }
-#ifdef FMM_VERBOSE
-    std::cout << "fmm_heap = [";
-    for (int i=0; i<fmm_heap_size; i++)
-        std::cout << " <"<<(fmm_heap[i]%nx)<<','<<((fmm_heap[i]/nx)%ny)<<','<<(fmm_heap[i]/nxny)<<">="<<dists[fmm_heap[i]];
-    std::cout << std::endl;
-#endif
-    //fmm_status[res] = FMM_KNOWN;
+
+    if(FMM_VERBOSE){
+        std::stringstream tmp;
+        tmp << "fmm_heap = [";
+        for (int i=0; i<fmm_heap_size; i++)
+            tmp << " <"<<(fmm_heap[i]%nx)<<','<<((fmm_heap[i]/nx)%ny)<<','<<(fmm_heap[i]/nxny)<<">="<<dists[fmm_heap[i]];
+        msg_info("DistanceGrid") << tmp.str() ;
+    }
+
     return res;
 }
 
@@ -1065,9 +1065,10 @@ void DistanceGrid::fmm_push(int index)
     if (fmm_status[index] >= FMM_FRONT0)
     {
         i = fmm_status[index] - FMM_FRONT0;
-#ifdef FMM_VERBOSE
-        std::cout << "fmm update <"<<(index%nx)<<','<<((index/nx)%ny)<<','<<(index/nxny)<<">="<<dists[index]<<" from entry "<<i<<std::endl;
-#endif
+
+        if(FMM_VERBOSE)
+           dmsg_info("DistanceGrid") << "fmm update <"<<(index%nx)<<','<<((index/nx)%ny)<<','<<(index/nxny)<<">="<<dists[index]<<" from entry "<<i ;
+
         while (i>0 && phi < (dists[fmm_heap[(i-1)/2]]))
         {
             fmm_swap(i,(i-1)/2);
@@ -1109,9 +1110,9 @@ void DistanceGrid::fmm_push(int index)
     }
     else
     {
-#ifdef FMM_VERBOSE
-        std::cout << "fmm push <"<<(index%nx)<<','<<((index/nx)%ny)<<','<<(index/nxny)<<">="<<dists[index]<<std::endl;
-#endif
+        if(FMM_VERBOSE)
+           dmsg_info("DistanceGrid") << "fmm push <"<<(index%nx)<<','<<((index/nx)%ny)<<','<<(index/nxny)<<">="<<dists[index] ;
+
         i = fmm_heap_size;
         ++fmm_heap_size;
         fmm_heap[i] = index;
@@ -1122,12 +1123,14 @@ void DistanceGrid::fmm_push(int index)
             i = (i-1)/2;
         }
     }
-#ifdef FMM_VERBOSE
-    std::cout << "fmm_heap = [";
-    for (int i=0; i<fmm_heap_size; i++)
-        std::cout << " <"<<(fmm_heap[i]%nx)<<','<<((fmm_heap[i]/nx)%ny)<<','<<(fmm_heap[i]/nxny)<<">="<<dists[fmm_heap[i]];
-    std::cout << std::endl;
-#endif
+
+    if(FMM_VERBOSE){
+        std::stringstream tmp;
+        tmp << "fmm_heap = [";
+        for (int i=0; i<fmm_heap_size; i++)
+            tmp << " <"<<(fmm_heap[i]%nx)<<','<<((fmm_heap[i]/nx)%ny)<<','<<(fmm_heap[i]/nxny)<<">="<<dists[fmm_heap[i]];
+        msg_info("DistanceGrid") << tmp.str() ;
+    }
 }
 
 /// Sample the surface with points approximately separated by the given sampling distance (expressed in voxels if the value is negative)
@@ -1165,7 +1168,8 @@ void DistanceGrid::sampleSurface(double sampling)
                     }
                     if (it == 10 && rabs(d) > 0.1f*maxD)
                     {
-                        msg_warning("DistanceGrid")<< "Failed to converge at ("<<x<<","<<y<<","<<z<<"):"
+                        msg_warning("DistanceGrid")
+                                << "Failed to converge at ("<<x<<","<<y<<","<<z<<"):"
                                 << " pos0 = " << coord(x,y,z) << " d0 = " << dists[index(x,y,z)] << " grad0 = " << grad(index(x,y,z), Coord())
                                 << " pos = " << pos << " d = " << d << " grad = " << n;
                         continue;
@@ -1182,7 +1186,7 @@ void DistanceGrid::sampleSurface(double sampling)
         int nstepY = (int)ceil((pmax[1] - pmin[1])/sampling);
         int nstepZ = (int)ceil((pmax[2] - pmin[2])/sampling);
         Coord p0 = pmin + ((pmax-pmin) - Coord((nstepX)*sampling, (nstepY)*sampling, (nstepZ)*sampling))*0.5f;
-        msg_info("DistanceGrid")<< "sampling bbox " << pmin << " - " << pmax << " starting at " << p0 << " with number of steps: " << nstepX << " " << nstepY << " " << nstepZ;
+        msg_info("DistanceGrid") << "sampling bbox " << pmin << " - " << pmax << " starting at " << p0 << " with number of steps: " << nstepX << " " << nstepY << " " << nstepZ;
 
         for (int z=0; z<=nstepZ; z++)
             for (int y=0; y<=nstepY; y++)

--- a/modules/SofaVolumetricData/DistanceGridCollisionModel.cpp
+++ b/modules/SofaVolumetricData/DistanceGridCollisionModel.cpp
@@ -224,7 +224,6 @@ void RigidDistanceGridCollisionModel::computeBoundingTree(int maxDepth)
         Vector3 emin, emax;
         if (elems[i].isTransformed)
         {
-            //std::cout << "Grid "<<i<<" transformation: <"<<elems[i].rotation<<"> x + <"<<elems[i].translation<<">"<<std::endl;
             for (int j=0; j<8; j++)
             {
                 Vector3 corner = elems[i].translation + elems[i].rotation * (flipped ? elems[i].grid->getCorner(j) : elems[i].grid->getBBCorner(j));
@@ -247,7 +246,6 @@ void RigidDistanceGridCollisionModel::computeBoundingTree(int maxDepth)
             emax = flipped ? elems[i].grid->getPMax() : elems[i].grid->getBBMax();
         }
         cubeModel->setParentOf(i, emin, emax); // define the bounding box of the current element
-        //std::cout << "Grid "<<i<<" within  <"<<emin<<">-<"<<emax<<">"<<std::endl;
     }
     cubeModel->computeBoundingTree(maxDepth);
     modified = false;
@@ -462,14 +460,11 @@ FFDDistanceGridCollisionModel::FFDDistanceGridCollisionModel()
 
 FFDDistanceGridCollisionModel::~FFDDistanceGridCollisionModel()
 {
-    //for (unsigned int i=0; i<elems.size(); i++)
-    //    if (elems[i].grid!=NULL) elems[i].grid->release();
     if (elems.size()>0 && elems[0].grid!=NULL) elems[0].grid->release();
 }
 
 void FFDDistanceGridCollisionModel::init()
 {
-    //std::cout << "> FFDDistanceGridCollisionModel::init()"<<std::endl;
     this->core::CollisionModel::init();
     ffd = dynamic_cast< core::behavior::MechanicalState<Vec3Types>* > (getContext()->getMechanicalState());
     ffdMesh = /*dynamic_cast< topology::RegularGridTopology* >*/ (getContext()->getMeshTopology());
@@ -605,14 +600,10 @@ bool FFDDistanceGridCollisionModel::canCollideWithElement(int index, CollisionMo
 {
     if (model2 != this) return true;
     if (!this->bSelfCollision.getValue()) return true;
-    //if (this->getContext() != model2->getContext()) return true;
-    //if (model2 == this)
-    {
-        //sout << "ffd self test "<<index<<" - "<<index2<<sendl;
-        if (index >= index2) return false;
-        if (elems[index].neighbors.count(index2)) return false;
-        return true;
-    }
+
+    if (index >= index2) return false;
+    if (elems[index].neighbors.count(index2)) return false;
+    return true;
 }
 
 void FFDDistanceGridCollisionModel::setGrid(DistanceGrid* surf, int index)
@@ -632,7 +623,6 @@ void FFDDistanceGridCollisionModel::computeBoundingTree(int maxDepth)
     cubeModel->resize(size);
     for (int i=0; i<size; i++)
     {
-        //static_cast<DistanceGridCollisionElement*>(elems[i])->recalcBBox();
         Vector3 emin, emax;
         const DeformedCube& cube = getDeformCube(i);
         {

--- a/modules/SofaVolumetricData/DistanceGridCollisionModel.h
+++ b/modules/SofaVolumetricData/DistanceGridCollisionModel.h
@@ -460,8 +460,7 @@ public:
     core::behavior::MechanicalState<DataTypes>* getDeformModel() { return ffd; }
     core::topology::BaseMeshTopology* getDeformGrid() { return ffdMesh; }
 
-    // alias used by ContactMapper
-
+    /// alias used by ContactMapper
     core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return ffd; }
     core::topology::BaseMeshTopology* getMeshTopology() { return ffdMesh; }
 
@@ -479,8 +478,7 @@ public:
 
     void setGrid(DistanceGrid* surf, int index=0);
 
-    // -- CollisionModel interface
-
+    /// CollisionModel interface
     void resize(int size);
 
     /// Create or update the bounding volume hierarchy.
@@ -515,13 +513,8 @@ public:
     int addPoint(const Coord& P, int index, Real&)
     {
         defaulttype::Vector3 bary;
-        int elem = this->model->getDeformCube(index).elem; //getDeformGrid()->findCube(P,bary[0],bary[1],bary[2]);
+        int elem = this->model->getDeformCube(index).elem;
         bary = this->model->getDeformCube(index).baryCoords(P);
-        //if (elem == -1)
-        //{
-        //    msg_info()<<"WARNING: BarycentricContactMapper from FFDDistanceGridCollisionModel on point no within any the FFD grid."<<std::endl;
-        //    elem = model->getDeformGrid()->findNearestCube(P,bary[0],bary[1],bary[2]);
-        //}
         return this->mapper->addPointInCube(elem,bary.ptr());
     }
 };
@@ -548,6 +541,7 @@ public:
         MMechanicalState* outmodel = Inherit::createMapping(name);
         if (this->child!=NULL && this->mapping==NULL)
         {
+            //TODO(dmarchal):2017-05-26 This comment may become a conditional code.
             // add velocity visualization
             /*        sofa::component::visualmodel::DrawV* visu = new sofa::component::visualmodel::DrawV;
                     this->child->addObject(visu);
@@ -603,7 +597,6 @@ public:
                     {
                         DistanceGrid::Coord n = prevGrid->grad(i,coefs);
                         v += n * (d  / ( n.norm() * gdt));
-                        //std::cout << "Estimated v at "<<P<<" = "<<v<<" using distance from previous model "<<d<<std::endl;
                     }
                 }
             }
@@ -614,13 +607,6 @@ public:
 
 
 #if defined(SOFA_EXTERN_TEMPLATE) && !defined(SOFA_COMPONENT_COLLISION_DISTANCEGRIDCOLLISIONMODEL_CPP)
-
-//#ifndef SOFA_DOUBLE
-//extern template class SOFA_VOLUMETRIC_DATA_API RigidContactMapper<RigidDistanceGridCollisionModel,Vec3fTypes>;
-//#endif
-//#ifndef SOFA_FLOAT
-//extern template class SOFA_VOLUMETRIC_DATA_API RigidContactMapper<RigidDistanceGridCollisionModel,Vec3dTypes>;
-//#endif
 
 extern template class SOFA_VOLUMETRIC_DATA_API ContactMapper<FFDDistanceGridCollisionModel, sofa::defaulttype::Vec3Types>;
 extern template class SOFA_VOLUMETRIC_DATA_API ContactMapper<RigidDistanceGridCollisionModel, sofa::defaulttype::Vec3Types>;

--- a/modules/SofaVolumetricData/DistanceGridForceField.inl
+++ b/modules/SofaVolumetricData/DistanceGridForceField.inl
@@ -52,15 +52,21 @@ void DistanceGridForceField<DataTypes>::init()
     if (fileDistanceGrid.getValue().empty())
     {
         if (grid==NULL)
-            serr << "ERROR: DistanceGridForceField requires an input filename." << sendl;
-        // else the grid has already been set
+            msg_error() << "DistanceGridForceField requires an input filename." ;
+        /// the grid has already been set
         return;
     }
-    std::cout << "DistanceGridForceField: creating "<<nx.getValue()<<"x"<<ny.getValue()<<"x"<<nz.getValue()<<" DistanceGrid from file "<<fileDistanceGrid.getValue();
-    if (scale.getValue()!=1.0) std::cout<<" scale="<<scale.getValue();
-    if (box.getValue()[0][0]<box.getValue()[1][0]) std::cout<<" bbox=<"<<box.getValue()[0]<<">-<"<<box.getValue()[0]<<">";
-    std::cout << std::endl;
-    grid = DistanceGrid::loadShared(fileDistanceGrid.getFullPath(), scale.getValue(), 0.0, nx.getValue(),ny.getValue(),nz.getValue(),box.getValue()[0],box.getValue()[1]);
+    msg_info() << " creating "<<nx.getValue()<<"x"<<ny.getValue()<<"x"<<nz.getValue()<< msgendl
+               << " DistanceGrid from file '"<< fileDistanceGrid.getValue() <<"'.";
+
+    msg_info_when(scale.getValue()!=1.0) << " scale="<<scale.getValue();
+
+    msg_info_when(box.getValue()[0][0]<box.getValue()[1][0])
+            <<" bbox=<"<<box.getValue()[0]<<">-<"<<box.getValue()[0]<<">";
+
+    grid = DistanceGrid::loadShared(fileDistanceGrid.getFullPath(), scale.getValue(), 0.0,
+                                    nx.getValue(),ny.getValue(),nz.getValue(),
+                                    box.getValue()[0],box.getValue()[1]);
 
     if (this->stiffnessArea.getValue() != 0 && this->mstate)
     {
@@ -75,7 +81,6 @@ void DistanceGridForceField<DataTypes>::init()
             for (unsigned int ti = 0; ti < triangles.size(); ++ti)
             {
                 helper::fixed_array<unsigned int,3> t = triangles[ti];
-                //if (t[0] < ibegin && t[0] >= iend && t[1] < ibegin && t[1] >= iend && t[2] < ibegin && t[2] >= iend) continue;
                 Coord B = p1[t[1]]-p1[t[0]];
                 Coord C = p1[t[2]]-p1[t[0]];
                 Coord tN = cross(B, C);
@@ -87,7 +92,7 @@ void DistanceGridForceField<DataTypes>::init()
                 pOnBorder[t[1]] = true;
                 pOnBorder[t[2]] = true;
             }
-            sout << "Surface area : " << sumArea << " ( mean " << sumArea / triangles.size() << " per triangle )"<<sendl;
+            msg_info() << "Surface area : " << sumArea << " ( mean " << sumArea / triangles.size() << " per triangle )" ;
             flipNormals = (sumSArea < 0);
         }
         else
@@ -113,7 +118,7 @@ void DistanceGridForceField<DataTypes>::init()
                 Real volume = (A*cross(B, C))/6.0f;
                 sumVolume += volume;
             }
-            sout << "Volume : " << sumVolume << " ( mean " << sumVolume / tetrahedra.size() << " per tetra )"<<sendl;
+            msg_info() << "Volume : " << sumVolume << " ( mean " << sumVolume / tetrahedra.size() << " per tetra )" ;
         }
         else
         {
@@ -205,7 +210,6 @@ void DistanceGridForceField<DataTypes>::addForce(const sofa::core::MechanicalPar
             for (unsigned int ti = 0; ti < triangles.size(); ++ti)
             {
                 helper::fixed_array<unsigned int,3> t = triangles[ti];
-                //if (t[0] < ibegin && t[0] >= iend && t[1] < ibegin && t[1] >= iend && t[2] < ibegin && t[2] >= iend) continue;
                 Coord B = p1[t[1]]-p1[t[0]];
                 Coord C = p1[t[2]]-p1[t[0]];
                 Coord tN = cross(B, C);
@@ -261,7 +265,6 @@ void DistanceGridForceField<DataTypes>::addForce(const sofa::core::MechanicalPar
             for (unsigned int ti = 0; ti < tetrahedra.size(); ++ti)
             {
                 helper::fixed_array<unsigned int,4> t = tetrahedra[ti];
-                //if (t[0] < ibegin && t[0] >= iend && t[1] < ibegin && t[1] >= iend && t[2] < ibegin && t[2] >= iend) continue;
                 Coord A = p1[t[1]]-p1[t[0]];
                 Coord B = p1[t[2]]-p1[t[0]];
                 Coord C = p1[t[3]]-p1[t[0]];
@@ -309,7 +312,6 @@ void DistanceGridForceField<DataTypes>::addDForce(const sofa::core::MechanicalPa
     const VecCoord& dx1=   datadX.getValue()  ;
     Real kFactor = (Real)mparams->kFactorIncludingRayleighDamping(this->rayleighStiffness.getValue());
 
-    //(VecDeriv& df1, const VecDeriv& dx1, double kFactor, double /*bFactor*/)
     if (!grid)
         return;
 
@@ -340,6 +342,7 @@ void DistanceGridForceField<DataTypes>::addDForce(const sofa::core::MechanicalPa
         const helper::fixed_array<unsigned int,3>& t = c.index;
         Coord dB = dx1[t[1]]-dx1[t[0]];
         Coord dC = dx1[t[2]]-dx1[t[0]];
+
         // d(area) = dot(0.5*cross(C,sN), dB) + dot(0.5*cross(sN,B), dC)
         Real darea = 0.5f*(cross(c.C,c.normal)*dB + cross(c.normal,c.B)*dC);
 
@@ -441,7 +444,6 @@ void DistanceGridForceField<DataTypes>::drawDistanceGrid(const core::visual::Vis
 
     const Real stiffIn = stiffnessIn.getValue();
     const Real stiffOut = stiffnessOut.getValue();
-    //const Real damp = damping.getValue();
     const Real maxdist = maxDist.getValue();
 
     defaulttype::Vector3 point1,point2;
@@ -478,6 +480,7 @@ void DistanceGridForceField<DataTypes>::drawDistanceGrid(const core::visual::Vis
         vparams->drawTool()->drawLines(pointsLineIn, 1, defaulttype::Vec<4,float>(1,0,0,1));
     if (!pointsLineOut.empty())
         vparams->drawTool()->drawLines(pointsLineOut, 1, defaulttype::Vec<4,float>(1,0,1,1));
+
     const sofa::helper::vector<TContact>& tcontacts = this->tcontacts.getValue();
     if (!tcontacts.empty())
     {

--- a/modules/SofaVolumetricData/FFDDistanceGridDiscreteIntersection.cpp
+++ b/modules/SofaVolumetricData/FFDDistanceGridDiscreteIntersection.cpp
@@ -77,7 +77,6 @@ int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridColl
     const double d0 = e1.getProximity() + e2.getProximity() + (intersection->getContactDistance() == 0.0 ? 0.001 : intersection->getContactDistance());
     //const SReal margin = 0.001f + (SReal)d0;
     const SReal margin = (SReal)((e1.getProximity() + e2.getProximity() + (intersection->getAlarmDistance() == 0.0 ? 0.001 : intersection->getAlarmDistance()))/2);
-    //std::cout << "margin="<<margin<<std::endl;
     const bool singleContact = e1.getCollisionModel()->singleContact.getValue();
 
     // transform from grid1 to grid2
@@ -127,7 +126,6 @@ int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridColl
                     contacts->resize(contacts->size()+1);
                 DetectionOutput *detection = &*(contacts->end()-1);
                 double value = d + margin - d0;
-                //std::cout << "value = d + margin - d0 = " << d << " + " << margin << " - " << d0 << " = " << value << std::endl;
                 if (!singleContact || first || (value < detection->value))
                 {
                     detection->point[0] = grid1->meshPts[c1.points[i].index];

--- a/modules/SofaVolumetricData/ImplicitSurfaceContainer.cpp
+++ b/modules/SofaVolumetricData/ImplicitSurfaceContainer.cpp
@@ -154,8 +154,8 @@ void ImplicitSurface::projectPointonSurface(defaulttype::Vec3d& point, int i)
 
     if (it==10)
     {
-        std::cout<<"No Convergence in projecting the contact point"<<std::endl;
-        std::cout<<"-  grad :"	<< grad <<std::endl;
+        msg_warning() << "No Convergence in projecting the contact point" << msgendl
+                      << "-  grad :"	<< grad  ;
     }
 }
 
@@ -168,7 +168,7 @@ bool ImplicitSurface::projectPointonSurface2(defaulttype::Vec3d& point, int i, d
     defaulttype::Vec3d posInside, posOutside;
     if (dir.norm()< 0.001)
     {
-        printf("Warning : grad is null \n");
+        msg_warning() << "grad is too small" ;
         return false;
     }
 
@@ -203,7 +203,7 @@ bool ImplicitSurface::projectPointonSurface2(defaulttype::Vec3d& point, int i, d
     }
     if (count == 30)
     {
-        printf("\n WARNING : no projection found in  ImplSurf::projectPointonSurface(Vec3d& point, Vec3d& dir)");
+        dmsg_warning() << "no projection found in ImplSurf::projectPointonSurface(Vec3d& point, Vec3d& dir)";
         return false;
     }
     return computeSegIntersection(posInside, posOutside, point, i);
@@ -223,7 +223,7 @@ bool ImplicitSurface::projectPointOutOfSurface(defaulttype::Vec3d& point, int i,
         point += grad*dist_out;
         return true;
     }
-    printf(" pb in projectPointOutOfSurface \n");
+    dmsg_warning() << " problem while computing 'projectPointOutOfSurface" ;
     return false;
 
 


### PR DESCRIPTION
When I have free time but cannot be concentrated I do trivial 'cleaning' changes resulting in this kind of PR where I replaced the std::cout by msg_info.

CHANGELOG for @hugtalbot :
Trivial replacement of std::cout by msg_info
  - [SofaUserInteraction] 
  - [SofaValidation]
  - [SofaVolumetricData]
  - [SofaOpenGl]
  - [SofaNonUniformFem]
  - [SofaPython]
  - [SofaSparseSolver]
  - [SofaSphFluid]
  - [SofaTopology]
  - [SofaUserInteraction]

I also replaced this code pattern:
```cpp
#ifndef NDEBUG
     std::cout << blahblah
#endif
```

into this pattern:
```cpp
dmsg_info() << 
....
```
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings nor unit test failures.
- [x] does not break existing scenes.
- [x] does not break API compatibility.
- [x] has been reviewed
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
