### PR TITLE
[SofaKernel] CHANGE behavior of FileRepository::getRelativePath

### DIFF
--- a/SofaKernel/framework/sofa/core/objectmodel/DataFileName.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/DataFileName.cpp
@@ -65,7 +65,8 @@ void DataFileName::updatePath()
         {
             if( m_fullpath.find(path) == 0 )
             {
-                m_relativepath=DataRepository.relativeToPath(m_fullpath, path);
+                m_relativepath=DataRepository.relativeToPath(m_fullpath, path,
+                                                             false /*option for backward compatibility*/);
                 break;
             }
         }

--- a/SofaKernel/framework/sofa/helper/system/FileRepository.h
+++ b/SofaKernel/framework/sofa/helper/system/FileRepository.h
@@ -64,8 +64,8 @@ public:
     /// Adds a path to the front of the set of paths.
     void addFirstPath(const std::string& path);
 
-	/// Replaces every occurrences of "//" by "/"
-	std::string cleanPath( const std::string& path );
+    /// Replaces every occurrences of "//" by "/"
+    std::string cleanPath( const std::string& path );
 
     /// Adds a path to the back of the set of paths.
     void addLastPath(const std::string& path);
@@ -78,8 +78,10 @@ public:
 
     /// Returns a string such as refPath + string = path if path contains refPath.
     /// Otherwise returns path.
-    /// Under WIN32 the method returns a lower cased unix formatted path.
-    static std::string relativeToPath(std::string path, std::string refPath);
+    /// On WIN32 the implementation was also returning the path in lower case. This behavior is now
+    /// deprecated and should be remove the 2018-05-01. Until this date new implementation can be
+    /// used by setting doLowerCaseOnWin32=false;
+    static std::string relativeToPath(std::string path, std::string refPath, bool doLowerCaseOnWin32=true);
 
     const std::vector< std::string > &getPaths() const {return vpath;}
 

--- a/applications/sofa/gui/qt/DataFilenameWidget.cpp
+++ b/applications/sofa/gui/qt/DataFilenameWidget.cpp
@@ -95,22 +95,7 @@ void DataFileNameWidget::raiseDialog()
 
     if (s.isNull() ) return;
     fileName=std::string (s.toStdString());
-//
-//#ifdef WIN32
-//
-//  /* WIN32 is a pain here because of mixed case formatting with randomly
-//  picked slash and backslash to separate dirs
-//  */
-//  std::replace(fileName.begin(),fileName.end(),'\\' , '/' );
-//  std::replace(SofaPath.begin(),SofaPath.end(),'\\' , '/' );
-//  std::transform(fileName.begin(), fileName.end(), fileName.begin(), ::tolower );
-//  std::transform(SofaPath.begin(), SofaPath.end(), SofaPath.begin(), ::tolower );
-//
-//#endif
-//	std::string::size_type loc = fileName.find( SofaPath, 0 );
-//	if (loc==0) fileName = fileName.substr(SofaPath.size()+1);
-    fileName = sofa::helper::system::FileRepository::relativeToPath(fileName,SofaPath);
-
+    fileName = sofa::helper::system::FileRepository::relativeToPath(fileName,SofaPath,false);
 
     openFilePath->setText( QString( fileName.c_str() ) );
 }


### PR DESCRIPTION
The WIN32 implementation is lowering the case of the given path. This is
not consistent with other case insensitive OS like macos and is discussed in:
https://github.com/sofa-framework/sofa/pull/250

In this PR I deprecate this 'lowering' behavior, adds a dedicated message & I updated
the calling point all around Sofa. Code updated shouldn't print any message but un-touched one should continue working as usual and prints the deprecated message to indicate to user they must update.

CHANGELOG:
   - [SofaKernel]
           - FileRepository::getRelativePath() lowering the case on WIN32 is now a deprecated behavior. 
                                                               




______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings nor unit test failures.
- [x] does not break existing scenes.
- [x] does not break API compatibility.
- [x] has been reviewed and agreed to be transitional.
- [x] is more than 1 week old (or has fast-merge label).
- [x] reports important changes in Changelog.

**Reviewers will merge only if all these checks are true.**
