### PR TITLE
FIX failing "FileMonitor-fileChangeTwice_test"

### DIFF
--- a/SofaKernel/framework/framework_test/helper/system/FileMonitor_test.cpp
+++ b/SofaKernel/framework/framework_test/helper/system/FileMonitor_test.cpp
@@ -61,7 +61,10 @@ void waitForFileEvents()
 {
 	// on windows we use file date, which resoution is assumed (by us) to be below this value in ms
 #ifdef WIN32
-	Sleep(100);
+    Sleep(100);
+#endif
+#ifdef __APPLE__
+    sleep(1);
 #endif
 }
 
@@ -113,6 +116,9 @@ TEST(FileMonitor, addFileTwice_test)
 {
     MyFileListener listener ;
 
+    // create the file
+    createAFilledFile(getPath("existing.txt"), 1) ;
+
     // Add an existing file.It should work.
     FileMonitor::addFile(getPath("existing.txt"), &listener);
 
@@ -135,6 +141,9 @@ TEST(FileMonitor, noUpdate_test)
 {
     MyFileListener listener ;
 
+    // create the file
+    createAFilledFile(getPath("existing.txt"), 1) ;
+
     // Add an existing file.It should work.
     FileMonitor::addFile(getPath("existing.txt"), &listener) ;
     EXPECT_EQ( listener.m_files.size(), 0u) ;
@@ -145,6 +154,10 @@ TEST(FileMonitor, noUpdate_test)
 TEST(FileMonitor, updateNoChange_test)
 {
     MyFileListener listener ;
+
+    // create the file
+    createAFilledFile(getPath("existing.txt"), 1) ;
+    waitForFileEvents();
 
     FileMonitor::addFile(getPath("existing.txt"), &listener) ;
     waitForFileEvents();
@@ -157,6 +170,9 @@ TEST(FileMonitor, updateNoChange_test)
 TEST(FileMonitor, fileChange_test)
 {
     MyFileListener listener ;
+
+    // create the file
+    createAFilledFile(getPath("existing.txt"), 1) ;
 
     FileMonitor::addFile(getPath("existing.txt"), &listener) ;
     //waitForFileEvents();
@@ -174,6 +190,9 @@ TEST(FileMonitor, fileChange_test)
 TEST(FileMonitor, fileChangeTwice_test)
 {
     MyFileListener listener ;
+
+    // create the file
+    createAFilledFile(getPath("existing.txt"), 1) ;
 
     FileMonitor::addFile(getPath("existing.txt"), &listener) ;
     //FileMonitor::updates(2) ;
@@ -194,6 +213,9 @@ TEST(FileMonitor, fileListenerRemoved_test)
 {
     MyFileListener listener1 ;
     MyFileListener listener2 ;
+
+    // create the file
+    createAFilledFile(getPath("existing.txt"), 1) ;
 
     FileMonitor::addFile(getPath("existing.txt"), &listener1) ;
     FileMonitor::addFile(getPath("existing.txt"), &listener2) ;
@@ -220,6 +242,9 @@ TEST(FileMonitor, listenerRemoved_test)
     MyFileListener listener1 ;
     MyFileListener listener2 ;
 
+    // create the file
+    createAFilledFile(getPath("existing.txt"), 1) ;
+
     FileMonitor::addFile(getPath("existing.txt"), &listener1) ;
     FileMonitor::addFile(getPath("existing.txt"), &listener2) ;
     //FileMonitor::updates(2) ;
@@ -243,6 +268,9 @@ TEST(FileMonitor, listenerRemoved_test)
 TEST(FileMonitor, fileChange2_test)
 {
     MyFileListener listener ;
+
+    // create the file
+    createAFilledFile(getPath("existing.txt"), 1) ;
 
     FileMonitor::addFile(getPath(""),"existing.txt", &listener) ;
     //waitForFileEvents();

--- a/SofaKernel/framework/framework_test/helper/system/FileMonitor_test.cpp
+++ b/SofaKernel/framework/framework_test/helper/system/FileMonitor_test.cpp
@@ -58,7 +58,7 @@ void createAFilledFile(const string filename, unsigned int rep, bool resetFileMo
 
     // dirty fix to avoid interferences between successive tests using the same file
     if (resetFileMonitor)
-        FileMonitor::updates();
+        FileMonitor::updates(1);
 }
 
 void waitForFileEvents()
@@ -125,6 +125,7 @@ TEST(FileMonitor, addFileTwice_test)
 
     // create the file
     createAFilledFile(getPath("existing.txt"), 1) ;
+	waitForFileEvents();
 
     // Add an existing file.It should work.
     FileMonitor::addFile(getPath("existing.txt"), &listener);
@@ -180,6 +181,7 @@ TEST(FileMonitor, fileChange_test)
 
     // create the file
     createAFilledFile(getPath("existing.txt"), 1) ;
+	waitForFileEvents();
 
     FileMonitor::addFile(getPath("existing.txt"), &listener) ;
     //waitForFileEvents();
@@ -200,6 +202,7 @@ TEST(FileMonitor, fileChangeTwice_test)
 
     // create the file
     createAFilledFile(getPath("existing.txt"), 1) ;
+	waitForFileEvents();
 
     FileMonitor::addFile(getPath("existing.txt"), &listener) ;
     //FileMonitor::updates(2) ;
@@ -223,6 +226,7 @@ TEST(FileMonitor, fileListenerRemoved_test)
 
     // create the file
     createAFilledFile(getPath("existing.txt"), 1) ;
+	waitForFileEvents();
 
     FileMonitor::addFile(getPath("existing.txt"), &listener1) ;
     FileMonitor::addFile(getPath("existing.txt"), &listener2) ;
@@ -251,6 +255,7 @@ TEST(FileMonitor, listenerRemoved_test)
 
     // create the file
     createAFilledFile(getPath("existing.txt"), 1) ;
+	waitForFileEvents();
 
     FileMonitor::addFile(getPath("existing.txt"), &listener1) ;
     FileMonitor::addFile(getPath("existing.txt"), &listener2) ;
@@ -278,6 +283,7 @@ TEST(FileMonitor, fileChange2_test)
 
     // create the file
     createAFilledFile(getPath("existing.txt"), 1) ;
+	waitForFileEvents();
 
     FileMonitor::addFile(getPath(""),"existing.txt", &listener) ;
     //waitForFileEvents();

--- a/SofaKernel/framework/framework_test/helper/system/FileMonitor_test.cpp
+++ b/SofaKernel/framework/framework_test/helper/system/FileMonitor_test.cpp
@@ -66,6 +66,9 @@ void waitForFileEvents()
 #ifdef __APPLE__
     sleep(1);
 #endif
+#ifdef __linux__
+    sleep(1);
+#endif
 }
 
 class MyFileListener : public FileEventListener


### PR DESCRIPTION
This is an attempt to fix FileMonitor-fileChangeTwice_test, failing on windows on other PRs since merge of PR #258 

CHANGELOG:
  - Fix FileMonitor_test about file that was not correctly recreated.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not break existing scenes.
- [x] does not break API compatibility.
- [x] has been reviewed and agreed to be transitional.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**