### PR TITLE
[SofaTest] repair the minor API breaks introduced by PR #213

### DIFF
--- a/applications/plugins/SofaTest/Sofa_test.h
+++ b/applications/plugins/SofaTest/Sofa_test.h
@@ -85,8 +85,8 @@ struct SOFA_TestPlugin_API Sofa_test : public BaseSofa_test
     sofa::helper::logging::MessageAsTestFailure m_error ; //(sofa::helper::logging::Message::Error, __FILE__, __LINE__ );
 
     //todo(dmarchal): reactive progressively the test (remove this todo after 07/04/2018)
-    ///sofa::helper::logging::MesssageAsTestFailure m_warning ; //(sofa::helper::logging::Message::Warning, __FILE__, __LINE__ );
-    ///sofa::helper::logging::MesssageAsTestFailure m_deprecated ; //(sofa::helper::logging::Message::Deprecated, __FILE__, __LINE__ );
+    ///sofa::helper::logging::MessageAsTestFailure m_warning ; //(sofa::helper::logging::Message::Warning, __FILE__, __LINE__ );
+    ///sofa::helper::logging::MessageAsTestFailure m_deprecated ; //(sofa::helper::logging::Message::Deprecated, __FILE__, __LINE__ );
 
 
     Sofa_test() :

--- a/applications/plugins/SofaTest/Sofa_test.h
+++ b/applications/plugins/SofaTest/Sofa_test.h
@@ -81,8 +81,8 @@ struct SOFA_TestPlugin_API Sofa_test : public BaseSofa_test
     /// By default all test based on Sofa_test are failing if there is one of the following.
     /// To prevent that you simply need to add the line
     /// EXPECT_MSG_EMIT(Error); Where you want to allow a message.
-    sofa::helper::logging::MesssageAsTestFailure m_fatal ; //(sofa::helper::logging::Message::Fatal, __FILE__, __LINE__ );
-    sofa::helper::logging::MesssageAsTestFailure m_error ; //(sofa::helper::logging::Message::Error, __FILE__, __LINE__ );
+    sofa::helper::logging::MessageAsTestFailure m_fatal ; //(sofa::helper::logging::Message::Fatal, __FILE__, __LINE__ );
+    sofa::helper::logging::MessageAsTestFailure m_error ; //(sofa::helper::logging::Message::Error, __FILE__, __LINE__ );
 
     //todo(dmarchal): reactive progressively the test (remove this todo after 07/04/2018)
     ///sofa::helper::logging::MesssageAsTestFailure m_warning ; //(sofa::helper::logging::Message::Warning, __FILE__, __LINE__ );

--- a/applications/plugins/SofaTest/TestMessageHandler.cpp
+++ b/applications/plugins/SofaTest/TestMessageHandler.cpp
@@ -222,14 +222,14 @@ void MainGtestMessageHandlerPrivate::popFrame(Message::Type type){
 ///
 ///
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-MesssageAsTestFailure::MesssageAsTestFailure(Message::Type type,
+MessageAsTestFailure::MessageAsTestFailure(Message::Type type,
                                                const char* filename, int lineno)
 {
     m_frame = new GtestMessageFrameFailure(type, filename, lineno) ;
     MainGtestMessageHandlerPrivate::pushFrame(type, m_frame) ;
 }
 
-MesssageAsTestFailure::~MesssageAsTestFailure(){
+MessageAsTestFailure::~MessageAsTestFailure(){
     MainGtestMessageHandlerPrivate::popFrame( m_frame->m_type ) ;
     m_frame->finalize() ;
     delete m_frame ;

--- a/applications/plugins/SofaTest/TestMessageHandler.h
+++ b/applications/plugins/SofaTest/TestMessageHandler.h
@@ -171,10 +171,10 @@ public:
 #define EXPECT_MSG_EMIT(...) EXPECT_MSG_EMIT_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
 
 #define EXPECT_MSG_NOEMIT2(a,b) \
-       sofa::helper::logging::MesssageAsTestFailure EXPECT_MSG_EVALUATOR(__hiddenscopevarA_, __LINE__) ( sofa::helper::logging::Message::a, __FILE__, __LINE__ ); \
-       sofa::helper::logging::MesssageAsTestFailure EXPECT_MSG_EVALUATOR(__hiddenscopevarB_, __LINE__) ( sofa::helper::logging::Message::b, __FILE__, __LINE__ )
+       sofa::helper::logging::MessageAsTestFailure EXPECT_MSG_EVALUATOR(__hiddenscopevarA_, __LINE__) ( sofa::helper::logging::Message::a, __FILE__, __LINE__ ); \
+       sofa::helper::logging::MessageAsTestFailure EXPECT_MSG_EVALUATOR(__hiddenscopevarB_, __LINE__) ( sofa::helper::logging::Message::b, __FILE__, __LINE__ )
 
-#define EXPECT_MSG_NOEMIT1(t)   sofa::helper::logging::MesssageAsTestFailure EXPECT_MSG_EVALUATOR(__hiddenscopevarT_, __LINE__)( sofa::helper::logging::Message::t, __FILE__, __LINE__ )
+#define EXPECT_MSG_NOEMIT1(t)   sofa::helper::logging::MessageAsTestFailure EXPECT_MSG_EVALUATOR(__hiddenscopevarT_, __LINE__)( sofa::helper::logging::Message::t, __FILE__, __LINE__ )
 #define EXPECT_MSG_NOEMIT0
 
 #define EXPECT_MSG_NOEMIT_CHOOSE_FROM_ARG_COUNT(...) FUNC_RECOMPOSER((__VA_ARGS__, EXPECT_MSG_NOEMIT2, EXPECT_MSG_NOEMIT1, ))

--- a/applications/plugins/SofaTest/TestMessageHandler.h
+++ b/applications/plugins/SofaTest/TestMessageHandler.h
@@ -78,13 +78,13 @@ class GtestMessageFrame;
 ///    EXPECT_MSG_NOEMIT(Error) as a more 'good looking' version of
 ///
 /// sofa::helper::logging::MessageAsTestFailure failure(sofa::helper::logging::Message::Error, __FILE__, __LINE__);
-class SOFA_TestPlugin_API MesssageAsTestFailure
+class SOFA_TestPlugin_API MessageAsTestFailure
 {
 public:
-    MesssageAsTestFailure(Message::Type t,
+    MessageAsTestFailure(Message::Type t,
                            const char* filename="unknown", int lineno=0) ;
 
-    virtual ~MesssageAsTestFailure() ;
+    virtual ~MessageAsTestFailure() ;
 
 private:
     GtestMessageFrame* m_frame ;


### PR DESCRIPTION
PR #213 breaks api compatibility because it misspelled MessageAsTestFailure
by MesssageAsTestFailure (with three 's').

This commit fix that.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings nor unit test failures.
- [x] does not break existing scenes.
- [x] does not break API compatibility.
- [ ] has been reviewed and agreed to be transitional.
- [x] is more than 1 week old (or has fast-merge label).
- [x] reports important changes in Changelog.

**Reviewers will merge only if all these checks are true.**
