### PR TITLE
 [SofaPython] Cleaner Script Controllers

### DIFF
--- a/applications/plugins/SofaPython/Binding_BaseObject.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseObject.cpp
@@ -86,9 +86,7 @@ extern "C" PyObject * BaseObject_setSrc(PyObject *self, PyObject * args)
     BaseObject* obj=((PySPtr<Base>*)self)->object->toBaseObject();
     char *valueString;
     PyObject *pyLoader;
-    if (!PyArg_ParseTuple(args, "sO",&valueString,&pyLoader))
-    {
-        PyErr_BadArgument();
+    if (!PyArg_ParseTuple(args, "sO",&valueString,&pyLoader)) {
         return NULL;
     }
     BaseObject* loader=((PySPtr<Base>*)self)->object->toBaseObject();

--- a/applications/plugins/SofaPython/Binding_Data.cpp
+++ b/applications/plugins/SofaPython/Binding_Data.cpp
@@ -463,7 +463,7 @@ SP_CLASS_ATTR_SET(Data,value)(PyObject *self, PyObject * args, void*)
 }
 
 // access ONE element of the vector
-extern "C" PyObject * Data_getValue(PyObject *self, PyObject * args)
+static PyObject * Data_getValue(PyObject *self, PyObject * args)
 {
     BaseData* data=((PyPtr<BaseData>*)self)->object;
     const AbstractTypeInfo *typeinfo = data->getValueTypeInfo(); // info about the data value
@@ -493,24 +493,25 @@ extern "C" PyObject * Data_getValue(PyObject *self, PyObject * args)
     return NULL;
 }
 
-extern "C" PyObject * Data_setValue(PyObject *self, PyObject * args)
+static PyObject * Data_setValue(PyObject *self, PyObject * args)
 {
     BaseData* data=((PyPtr<BaseData>*)self)->object;
     const AbstractTypeInfo *typeinfo = data->getValueTypeInfo(); // info about the data value
     int index;
     PyObject *value;
-    if (!PyArg_ParseTuple(args, "iO",&index,&value))
-    {
-        PyErr_BadArgument();
+    
+    if (!PyArg_ParseTuple(args, "iO", &index, &value)) {
         return NULL;
     }
-    if ((unsigned int)index>=typeinfo->size())
+    
+    if ((unsigned int)index >= typeinfo->size())
     {
         // out of bounds!
         SP_MESSAGE_ERROR( "Data.setValue index overflow" )
         PyErr_BadArgument();
         return NULL;
     }
+    
     if (typeinfo->Scalar() && PyFloat_Check(value))
     {
         typeinfo->setScalarValue((void*)data->getValueVoidPtr(),index,PyFloat_AsDouble(value));
@@ -534,13 +535,13 @@ extern "C" PyObject * Data_setValue(PyObject *self, PyObject * args)
 }
 
 
-extern "C" PyObject * Data_getValueTypeString(PyObject *self, PyObject * /*args*/)
+static PyObject * Data_getValueTypeString(PyObject *self, PyObject * /*args*/)
 {
     BaseData* data=((PyPtr<BaseData>*)self)->object;
     return PyString_FromString(data->getValueTypeString().c_str());
 }
 
-extern "C" PyObject * Data_getValueString(PyObject *self, PyObject * /*args*/)
+static PyObject * Data_getValueString(PyObject *self, PyObject * /*args*/)
 {
     BaseData* data=((PyPtr<BaseData>*)self)->object;
     return PyString_FromString(data->getValueString().c_str());
@@ -548,7 +549,7 @@ extern "C" PyObject * Data_getValueString(PyObject *self, PyObject * /*args*/)
 
 
 // TODO a description of what this function is supposed to do?
-extern "C" PyObject * Data_getSize(PyObject *self, PyObject * /*args*/)
+static PyObject * Data_getSize(PyObject *self, PyObject * /*args*/)
 {
     BaseData* data=((PyPtr<BaseData>*)self)->object;
 
@@ -561,7 +562,7 @@ extern "C" PyObject * Data_getSize(PyObject *self, PyObject * /*args*/)
     return PyInt_FromLong(0); //temp ==> WTF ?????
 }
 
-extern "C" PyObject * Data_setSize(PyObject *self, PyObject * args)
+static PyObject * Data_setSize(PyObject *self, PyObject * args)
 {
     BaseData* data=((PyPtr<BaseData>*)self)->object;
     int size;
@@ -576,7 +577,7 @@ extern "C" PyObject * Data_setSize(PyObject *self, PyObject * args)
 }
 
 
-extern "C" PyObject * Data_unset(PyObject *self, PyObject * /*args*/)
+static PyObject * Data_unset(PyObject *self, PyObject * /*args*/)
 {
     BaseData* data=((PyPtr<BaseData>*)self)->object;
 
@@ -585,7 +586,7 @@ extern "C" PyObject * Data_unset(PyObject *self, PyObject * /*args*/)
     Py_RETURN_NONE;
 }
 
-extern "C" PyObject * Data_updateIfDirty(PyObject *self, PyObject * /*args*/)
+static PyObject * Data_updateIfDirty(PyObject *self, PyObject * /*args*/)
 {
     BaseData* data=((PyPtr<BaseData>*)self)->object;
 
@@ -595,7 +596,7 @@ extern "C" PyObject * Data_updateIfDirty(PyObject *self, PyObject * /*args*/)
 }
 
 
-extern "C" PyObject * Data_read(PyObject *self, PyObject * args)
+static PyObject * Data_read(PyObject *self, PyObject * args)
 {
     BaseData* data=((PyPtr<BaseData>*)self)->object;
 
@@ -620,7 +621,7 @@ extern "C" PyObject * Data_read(PyObject *self, PyObject * args)
     Py_RETURN_NONE;
 }
 
-extern "C" PyObject * Data_setParent(PyObject *self, PyObject * args)
+static PyObject * Data_setParent(PyObject *self, PyObject * args)
 {
     BaseData* data=((PyPtr<BaseData>*)self)->object;
 
@@ -655,7 +656,7 @@ extern "C" PyObject * Data_setParent(PyObject *self, PyObject * args)
 
 
 // returns the complete link path name (i.e. following the shape "@/path/to/my/object.dataname")
-extern "C" PyObject * Data_getLinkPath(PyObject * self, PyObject * /*args*/)
+static PyObject * Data_getLinkPath(PyObject * self, PyObject * /*args*/)
 {
     BaseData* data=((PyPtr<BaseData>*)self)->object;
     Base* owner = data->getOwner();
@@ -677,7 +678,7 @@ extern "C" PyObject * Data_getLinkPath(PyObject * self, PyObject * /*args*/)
 
 
 // returns a pointer to the Data
-extern "C" PyObject * Data_getValueVoidPtr(PyObject * self, PyObject * /*args*/)
+static PyObject * Data_getValueVoidPtr(PyObject * self, PyObject * /*args*/)
 {
     BaseData* data=((PyPtr<BaseData>*)self)->object;
 

--- a/applications/plugins/SofaPython/Binding_PythonScriptController.cpp
+++ b/applications/plugins/SofaPython/Binding_PythonScriptController.cpp
@@ -36,325 +36,327 @@ using namespace sofa::core::objectmodel;
 // they are meant to be overriden by real python controller scripts
 
 
+// TODO FIXME this will not work (see FIXMEs below)
 //#define LOG_UNIMPLEMENTED_METHODS   // prints a message each time a non-implemented (in the script) method is called
 
-extern "C" PyObject * PythonScriptController_onIdle(PyObject * /*self*/, PyObject * args)
-{
-    SOFA_UNUSED(args) ;
+// also, can we PLEASE STOP COPYPASTING EVERYTHING KTHXBY
 
+
+
+template<class T>
+static inline T* get(PyObject* obj) {
+    // functions plz
+    return dynamic_cast<T*>(((PySPtr<Base>*)obj)->object.get());
+}
+
+
+static inline PythonScriptController* get_controller(PyObject* obj) {
+    return get<PythonScriptController>(obj);
+}
+
+static PyObject * PythonScriptController_onIdle(PyObject * /*self*/, PyObject * args) {
+    (void) args;
+    
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    PythonScriptController* obj=dynamic_cast<PythonScriptController*>(((PySPtr<Base>*)self)->object.get());
-     msg_error("PythonScriptController") << obj->m_classname.getValueString() << ".onIdle not implemented in " << obj->name.getValueString() << std::endl;
+    // TODO FIXME self is commented out
+    PythonScriptController* obj = get_controller(self);
+     msg_error("PythonScriptController") << obj->m_classname.getValueString() 
+                                         << ".onIdle not implemented in " 
+                                         << obj->name.getValueString() << std::endl;
 #endif
 
     Py_RETURN_NONE;
 }
 
-extern "C" PyObject * PythonScriptController_onLoaded(PyObject * /*self*/, PyObject * args)
-{
+static PyObject * PythonScriptController_onLoaded(PyObject * /*self*/, PyObject * args) {
     PyObject *pyNode;
-    if (!PyArg_ParseTuple(args, "O",&pyNode))
-    {
-        PyErr_BadArgument();
-        return NULL;
-    }
+    if (!PyArg_ParseTuple(args, "O", &pyNode)) return NULL;
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    PythonScriptController* obj=dynamic_cast<PythonScriptController*>(((PySPtr<Base>*)self)->object.get());
-    Node* node=dynamic_cast<Node*>(((PySPtr<Base>*)pyNode)->object.get());
-    msg_error("PythonScriptController")<< obj->m_classname.getValueString() << ".onLoaded not implemented in " << obj->name.getValueString() << std::endl;
+    // TODO FIXME self is commented
+    PythonScriptController* obj = get_controller(self);
+    Node* node = get<Node>(pyNode);
+    msg_error("PythonScriptController")<< obj->m_classname.getValueString() 
+                                       << ".onLoaded not implemented in " 
+                                       << obj->name.getValueString() << std::endl;
 #endif
 
     Py_RETURN_NONE;
 }
 
-extern "C" PyObject * PythonScriptController_createGraph(PyObject * /*self*/, PyObject * args)
-{
+static PyObject * PythonScriptController_createGraph(PyObject * /*self*/, PyObject * args) {
     PyObject *pyNode;
-    if (!PyArg_ParseTuple(args, "O",&pyNode))
-    {
-        PyErr_BadArgument();
-        return NULL;
-    }
-
+    if (!PyArg_ParseTuple(args, "O", &pyNode)) return NULL;
+    
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    PythonScriptController* obj=dynamic_cast<PythonScriptController*>(((PySPtr<Base>*)self)->object.get());
-    Node* node=dynamic_cast<Node*>(((PySPtr<Base>*)pyNode)->object.get());
-    msg_error("PythonScriptController") << obj->m_classname.getValueString() << ".createGraph not implemented in " << obj->name.getValueString() << std::endl;
+    // TODO FIXME self is commented
+    PythonScriptController* obj = get_controller(self);
+    Node* node = get<Node>(pyNode);
+    msg_error("PythonScriptController") << obj->m_classname.getValueString() 
+                                        << ".createGraph not implemented in " 
+                                        << obj->name.getValueString() << std::endl;
 #endif
 
     Py_RETURN_NONE;
 }
 
-extern "C" PyObject * PythonScriptController_initGraph(PyObject * /*self*/, PyObject * args)
-{
+static PyObject * PythonScriptController_initGraph(PyObject * /*self*/, PyObject * args) {
     PyObject *pyNode;
-    if (!PyArg_ParseTuple(args, "O",&pyNode))
-    {
-        PyErr_BadArgument();
-        return NULL;
-    }
+    if (!PyArg_ParseTuple(args, "O", &pyNode)) return NULL;
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    PythonScriptController* obj=dynamic_cast<PythonScriptController*>(((PySPtr<Base>*)self)->object.get());
-    Node* node=dynamic_cast<Node*>(((PySPtr<Base>*)pyNode)->object.get());
-    msg_error("PythonScriptController") << obj->m_classname.getValueString() << ".initGraph not implemented in " << obj->name.getValueString() << std::endl;
+    // TODO FIXME self is commented
+    PythonScriptController* obj = get_controller(self);
+    Node* node = get<Node>(pyNode);
+    msg_error("PythonScriptController") << obj->m_classname.getValueString() 
+                                        << ".initGraph not implemented in " 
+                                        << obj->name.getValueString() << std::endl;
 #endif
 
     Py_RETURN_NONE;
 }
 
-extern "C" PyObject * PythonScriptController_bwdInitGraph(PyObject * /*self*/, PyObject * args)
-{
+static PyObject * PythonScriptController_bwdInitGraph(PyObject * /*self*/, PyObject * args) {
     PyObject *pyNode;
-    if (!PyArg_ParseTuple(args, "O",&pyNode))
-    {
-        PyErr_BadArgument();
-        return NULL;
-    }
+    if (!PyArg_ParseTuple(args, "O", &pyNode)) return NULL;
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    PythonScriptController* obj=dynamic_cast<PythonScriptController*>(((PySPtr<Base>*)self)->object.get());
-    Node* node=dynamic_cast<Node*>(((PySPtr<Base>*)pyNode)->object.get());
-    msg_error("PythonScriptController") << obj->m_classname.getValueString() << ".bwdInitGraph not implemented in " << obj->name.getValueString() << std::endl;
+    // TODO FIXME self is commented
+    PythonScriptController* obj = get_controller(self);
+    Node* node = get<Node>(pyNode);
+    msg_error("PythonScriptController") << obj->m_classname.getValueString() 
+                                        << ".bwdInitGraph not implemented in " 
+                                        << obj->name.getValueString() << std::endl;
 #endif
 
     Py_RETURN_NONE;
 }
 
-extern "C" PyObject * PythonScriptController_onBeginAnimationStep(PyObject * /*self*/, PyObject * args)
-{
+static PyObject * PythonScriptController_onBeginAnimationStep(PyObject * /*self*/, PyObject * args) {
     double dt;
-    if (!PyArg_ParseTuple(args, "d",&dt))
-    {
-        PyErr_BadArgument();
-        return NULL;
-    }
-    else
-    {
-      dt = 1;
-    }
+    if (!PyArg_ParseTuple(args, "d", &dt)) return NULL;
+
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    PythonScriptController* obj=dynamic_cast<PythonScriptController*>(((PySPtr<Base>*)self)->object.get());
-    msg_error("PythonScriptController") << obj->m_classname.getValueString() << ".onBeginAnimationStep not implemented in " << obj->name.getValueString() << std::endl;
+    // TODO FIXME self is commented
+    PythonScriptController* obj = get_controller(self);
+    msg_error("PythonScriptController") << obj->m_classname.getValueString() 
+                                        << ".onBeginAnimationStep not implemented in " 
+                                        << obj->name.getValueString() << std::endl;
 #endif
 
     Py_RETURN_NONE;
 }
 
-extern "C" PyObject * PythonScriptController_onEndAnimationStep(PyObject * /*self*/, PyObject * args)
-{
+static PyObject * PythonScriptController_onEndAnimationStep(PyObject * /*self*/, PyObject * args) {
     double dt;
-    if (!PyArg_ParseTuple(args, "d",&dt))
-    {
-        PyErr_BadArgument();
-        return NULL;
-    }
+    if (!PyArg_ParseTuple(args, "d", &dt)) return NULL;
 
+    
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    PythonScriptController* obj=dynamic_cast<PythonScriptController*>(((PySPtr<Base>*)self)->object.get());
-    msg_error("PythonScriptController") << obj->m_classname.getValueString() << ".onEndAnimationStep not implemented in " << obj->name.getValueString() << std::endl;
+    // TODO FIXME self is commented
+    PythonScriptController* obj = get_controller(self);
+    msg_error("PythonScriptController") << obj->m_classname.getValueString() 
+                                        << ".onEndAnimationStep not implemented in " 
+                                        << obj->name.getValueString() << std::endl;
 #endif
 
     Py_RETURN_NONE;
 }
 
-extern "C" PyObject * PythonScriptController_storeResetState(PyObject * /*self*/, PyObject * /*args*/)
-{
+static PyObject * PythonScriptController_storeResetState(PyObject * /*self*/, PyObject * /*args*/) {
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    PythonScriptController* obj=dynamic_cast<PythonScriptController*>(((PySPtr<Base>*)self)->object.get());
-    msg_error("PythonScriptController") << obj->m_classname.getValueString() << ".storeresetState not implemented in " << obj->name.getValueString() << std::endl;
+    // TODO FIXME self is commented
+    PythonScriptController* obj = get_controller(self);
+    msg_error("PythonScriptController") << obj->m_classname.getValueString() 
+                                        << ".storeresetState not implemented in " 
+                                        << obj->name.getValueString() << std::endl;
 #endif
 
     Py_RETURN_NONE;
 }
 
-extern "C" PyObject * PythonScriptController_reset(PyObject * /*self*/, PyObject * /*args*/)
-{
+static PyObject * PythonScriptController_reset(PyObject * /*self*/, PyObject * /*args*/)  {
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    PythonScriptController* obj=dynamic_cast<PythonScriptController*>(((PySPtr<Base>*)self)->object.get());
-    msg_error("PythonScriptController") << obj->m_classname.getValueString() << ".reset not implemented in " << obj->name.getValueString() << std::endl;
+    // TODO FIXME self is commented
+    PythonScriptController* obj = get_controller(self);
+    msg_error("PythonScriptController") << obj->m_classname.getValueString() 
+                                        << ".reset not implemented in " 
+                                        << obj->name.getValueString() << std::endl;
 #endif
 
     Py_RETURN_NONE;
 }
 
-extern "C" PyObject * PythonScriptController_cleanup(PyObject * /*self*/, PyObject * /*args*/)
-{
+static PyObject * PythonScriptController_cleanup(PyObject * /*self*/, PyObject * /*args*/) {
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    PythonScriptController* obj=dynamic_cast<PythonScriptController*>(((PySPtr<Base>*)self)->object.get());
-    msg_error("PythonScriptController") << obj->m_classname.getValueString() << ".cleanup not implemented in " << obj->name.getValueString() << std::endl;
+    // TODO FIXME self is commented
+    PythonScriptController* obj = get_controller(self);
+    msg_error("PythonScriptController") << obj->m_classname.getValueString() 
+                                        << ".cleanup not implemented in " 
+                                        << obj->name.getValueString() << std::endl;
 #endif
 
     Py_RETURN_NONE;
 }
 
-extern "C" PyObject * PythonScriptController_onGUIEvent(PyObject * /*self*/, PyObject * args)
-{
+static PyObject * PythonScriptController_onGUIEvent(PyObject * /*self*/, PyObject * args) {
     char* controlID;
     char* valueName;
     char* value;
-    if (!PyArg_ParseTuple(args, "sss",&controlID,&valueName,&value))
-    {
-        PyErr_BadArgument();
-        return NULL;
-    }
+    if (!PyArg_ParseTuple(args, "sss", &controlID, &valueName,&value)) return NULL;
+
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    PythonScriptController* obj=dynamic_cast<PythonScriptController*>(((PySPtr<Base>*)self)->object.get());
-    msg_error("PythonScriptController") << obj->m_classname.getValueString() << ".onGUIEvent not implemented in " << obj->name.getValueString() << std::endl;
+    // TODO FIXME self is commented
+    PythonScriptController* obj = get_controller(self);
+    msg_error("PythonScriptController") << obj->m_classname.getValueString() 
+                                        << ".onGUIEvent not implemented in " 
+                                        << obj->name.getValueString() << std::endl;
 #endif
 
     Py_RETURN_NONE;
 }
 
-extern "C" PyObject * PythonScriptController_onKeyPressed(PyObject * /*self*/, PyObject * args)
-{
+static PyObject * PythonScriptController_onKeyPressed(PyObject * /*self*/, PyObject * args) {
     char k;
-    if (!PyArg_ParseTuple(args, "c",&k))
-    {
-        PyErr_BadArgument();
-        return NULL;
-    }
+    if (!PyArg_ParseTuple(args, "c", &k)) return NULL;
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    PythonScriptController* obj=dynamic_cast<PythonScriptController*>(((PySPtr<Base>*)self)->object.get());
-    msg_error("PythonScriptController") << obj->m_classname.getValueString() << ".onKeyPressed not implemented in " << obj->name.getValueString() << std::endl;
+    // TODO FIXME self is commented
+    PythonScriptController* obj = get_controller(self);
+    msg_error("PythonScriptController") << obj->m_classname.getValueString() 
+                                        << ".onKeyPressed not implemented in " 
+                                        << obj->name.getValueString() << std::endl;
 #endif
 
     Py_RETURN_FALSE;
 }
 
-extern "C" PyObject * PythonScriptController_onKeyReleased(PyObject * /*self*/, PyObject * args)
-{
+static PyObject * PythonScriptController_onKeyReleased(PyObject * /*self*/, PyObject * args) {
     char k;
-    if (!PyArg_ParseTuple(args, "c",&k))
-    {
-        PyErr_BadArgument();
-        return NULL;
-    }
-
+    if (!PyArg_ParseTuple(args, "c", &k)) return NULL;
+    
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    PythonScriptController* obj=dynamic_cast<PythonScriptController*>(((PySPtr<Base>*)self)->object.get());
-    msg_error("PythonScriptController") << obj->m_classname.getValueString() << ".onKeyReleased not implemented in " << obj->name.getValueString() << std::endl;
+    // TODO FIXME self is commented
+    PythonScriptController* obj = get_controller(self);
+    msg_error("PythonScriptController") << obj->m_classname.getValueString() 
+                                        << ".onKeyReleased not implemented in " 
+                                        << obj->name.getValueString() << std::endl;
 #endif
 
     Py_RETURN_FALSE;
 }
 
-extern "C" PyObject * PythonScriptController_onMouseButtonLeft(PyObject * /*self*/, PyObject * args)
-{
-    int x,y;
+static PyObject * PythonScriptController_onMouseButtonLeft(PyObject * /*self*/, PyObject * args) {
+    int x, y;
     bool pressed;
-    if (!PyArg_ParseTuple(args, "iib",&x,&y,&pressed))
-    {
-        PyErr_BadArgument();
-        return NULL;
-    }
+    if (!PyArg_ParseTuple(args, "iib", &x, &y, &pressed)) return NULL;
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    PythonScriptController* obj=dynamic_cast<PythonScriptController*>(((PySPtr<Base>*)self)->object.get());
-    msg_error("PythonScriptController") << obj->m_classname.getValueString() << ".onMouseButtonLeft not implemented in " << obj->name.getValueString() << std::endl;
+    // TODO FIXME self is commented
+    PythonScriptController* obj = get_controller(self);
+    msg_error("PythonScriptController") << obj->m_classname.getValueString() 
+                                        << ".onMouseButtonLeft not implemented in " 
+                                        << obj->name.getValueString() << std::endl;
 #endif
 
     Py_RETURN_NONE;
 }
 
-extern "C" PyObject * PythonScriptController_onMouseButtonMiddle(PyObject * /*self*/, PyObject * args)
-{
-    int x,y;
+static PyObject * PythonScriptController_onMouseButtonMiddle(PyObject * /*self*/, PyObject * args) {
+    int x, y;
     bool pressed;
-    if (!PyArg_ParseTuple(args, "iib",&x,&y,&pressed))
-    {
-        PyErr_BadArgument();
-        return NULL;
-    }
+    if (!PyArg_ParseTuple(args, "iib", &x, &y, &pressed)) return NULL;
+
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    PythonScriptController* obj=dynamic_cast<PythonScriptController*>(((PySPtr<Base>*)self)->object.get());
-    msg_error("PythonScriptController") << obj->m_classname.getValueString() << ".onMouseButtonMiddle not implemented in " << obj->name.getValueString() << std::endl;
+    // TODO FIXME self is commented
+    PythonScriptController* obj = get_controller(self);
+    msg_error("PythonScriptController") << obj->m_classname.getValueString() 
+                                        << ".onMouseButtonMiddle not implemented in " 
+                                        << obj->name.getValueString() << std::endl;
 #endif
 
     Py_RETURN_NONE;
 }
 
-extern "C" PyObject * PythonScriptController_onMouseButtonRight(PyObject * /*self*/, PyObject * args)
-{
-    int x,y;
+static PyObject * PythonScriptController_onMouseButtonRight(PyObject * /*self*/, PyObject * args) {
+    int x, y;
     bool pressed;
-    if (!PyArg_ParseTuple(args, "iib",&x,&y,&pressed))
-    {
-        PyErr_BadArgument();
-        return NULL;
-    }
+    if (!PyArg_ParseTuple(args, "iib", &x, &y, &pressed)) return NULL;
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    PythonScriptController* obj=dynamic_cast<PythonScriptController*>(((PySPtr<Base>*)self)->object.get());
-    msg_error("PythonScriptController") << obj->m_classname.getValueString() << ".onMouseButtonRight not implemented in " << obj->name.getValueString() << std::endl;
+    // TODO FIXME self is commented
+    PythonScriptController* obj = get_controller(self);
+    msg_error("PythonScriptController") << obj->m_classname.getValueString() 
+                                        << ".onMouseButtonRight not implemented in " 
+                                        << obj->name.getValueString() << std::endl;
 #endif
 
     Py_RETURN_NONE;
 }
 
-extern "C" PyObject * PythonScriptController_onMouseWheel(PyObject * /*self*/, PyObject * args)
-{
-    int x,y,delta;
-    if (!PyArg_ParseTuple(args, "iii",&x,&y,&delta))
-    {
-        PyErr_BadArgument();
-        return NULL;
-    }
+static PyObject * PythonScriptController_onMouseWheel(PyObject * /*self*/, PyObject * args) {
+    int x, y, delta;
+    if (!PyArg_ParseTuple(args, "iii",&x, &y, &delta)) return NULL;
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    PythonScriptController* obj=dynamic_cast<PythonScriptController*>(((PySPtr<Base>*)self)->object.get());
-    msg_error("PythonScriptController") << obj->m_classname.getValueString() << ".onMouseWheel not implemented in " << obj->name.getValueString() << std::endl;
+    // TODO FIXME self is commented
+    PythonScriptController* obj = get_controller(self);
+    msg_error("PythonScriptController") << obj->m_classname.getValueString() 
+                                        << ".onMouseWheel not implemented in " 
+                                        << obj->name.getValueString() << std::endl;
 #endif
 
     Py_RETURN_NONE;
 }
 
-extern "C" PyObject * PythonScriptController_onScriptEvent(PyObject * /*self*/, PyObject * args)
-{
+// TOOD here
+
+static PyObject * PythonScriptController_onScriptEvent(PyObject * /*self*/, PyObject * args) {
     PyObject *pySenderNode;
     char* eventName;
     PyObject *pyData;
-    if (!PyArg_ParseTuple(args, "OsO",&pySenderNode,&eventName,&pyData))
-    {
-        PyErr_BadArgument();
+    if (!PyArg_ParseTuple(args, "OsO", &pySenderNode, &eventName, &pyData)) {
         return NULL;
     }
+    
     BaseNode* senderBaseNode = ((PySPtr<Base>*)pySenderNode)->object->toBaseNode();
-    if (!senderBaseNode)
-    {
-        PyErr_BadArgument();
+    if (!senderBaseNode) {
+        // TODO this should not happen
+        PyErr_SetString(PyExc_RuntimeError, "null node wtf");
         return NULL;
     }
 
     // TODO check pyData
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    PythonScriptController* obj=dynamic_cast<PythonScriptController*>(((PySPtr<Base>*)self)->object.get());
-    msg_error("PythonScriptController") << obj->m_classname.getValueString() << ".onScriptEvent not implemented in " << obj->name.getValueString() << std::endl;
+    // TODO FIXME self is commented
+    PythonScriptController* obj = get_controller(self);
+    msg_error("PythonScriptController") << obj->m_classname.getValueString() 
+                                        << ".onScriptEvent not implemented in " 
+                                        << obj->name.getValueString() << std::endl;
 #endif
 
     Py_RETURN_NONE;
 }
 
-extern "C" PyObject * PythonScriptController_draw(PyObject * /*self*/, PyObject * /*args*/)
-{
+static PyObject * PythonScriptController_draw(PyObject * /*self*/, PyObject * /*args*/) {
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    PythonScriptController* obj=dynamic_cast<PythonScriptController*>(((PySPtr<Base>*)self)->object.get());
-    msg_error("PythonScriptController") << obj->m_classname.getValueString() << ".draw not implemented in " << obj->name.getValueString() << std::endl;
+    // TODO FIXME self is commented
+    PythonScriptController* obj = get_controller(self);
+    msg_error("PythonScriptController") << obj->m_classname.getValueString() 
+                                        << ".draw not implemented in " 
+                                        << obj->name.getValueString() << std::endl;
 #endif
 
     Py_RETURN_NONE;
 }
-
 
 
 
@@ -382,4 +384,4 @@ SP_CLASS_METHOD(PythonScriptController,onIdle)
 SP_CLASS_METHODS_END
 
 
-SP_CLASS_TYPE_SPTR(PythonScriptController,PythonScriptController,Base)
+SP_CLASS_TYPE_SPTR(PythonScriptController, PythonScriptController, Base);

--- a/applications/plugins/SofaPython/Binding_PythonScriptController.cpp
+++ b/applications/plugins/SofaPython/Binding_PythonScriptController.cpp
@@ -39,8 +39,6 @@ using namespace sofa::core::objectmodel;
 // #define LOG_UNIMPLEMENTED_METHODS // prints a message each time a
 // non-implemented (in the script) method is called
 
-// TODO FIXME the above will not work (see FIXMEs below) 
-
 // also, can we PLEASE STOP COPYPASTING EVERYTHING KTHXBY
 
 
@@ -56,11 +54,11 @@ static inline PythonScriptController* get_controller(PyObject* obj) {
     return get<PythonScriptController>(obj);
 }
 
-static PyObject * PythonScriptController_onIdle(PyObject * /*self*/, PyObject * args) {
-    (void) args;
+
+static PyObject * PythonScriptController_onIdle(PyObject * self, PyObject * args) {
+    (void) args; (void) self;
     
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    // TODO FIXME self is commented out
     PythonScriptController* obj = get_controller(self);
      msg_error("PythonScriptController") << obj->m_classname.getValueString() 
                                          << ".onIdle not implemented in " 
@@ -70,12 +68,13 @@ static PyObject * PythonScriptController_onIdle(PyObject * /*self*/, PyObject * 
     Py_RETURN_NONE;
 }
 
-static PyObject * PythonScriptController_onLoaded(PyObject * /*self*/, PyObject * args) {
+static PyObject * PythonScriptController_onLoaded(PyObject * self, PyObject * args) {
+    (void) self;
+    
     PyObject *pyNode;
     if (!PyArg_ParseTuple(args, "O", &pyNode)) return NULL;
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    // TODO FIXME self is commented
     PythonScriptController* obj = get_controller(self);
     Node* node = get<Node>(pyNode);
     msg_error("PythonScriptController")<< obj->m_classname.getValueString() 
@@ -91,7 +90,6 @@ static PyObject * PythonScriptController_createGraph(PyObject * /*self*/, PyObje
     if (!PyArg_ParseTuple(args, "O", &pyNode)) return NULL;
     
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    // TODO FIXME self is commented
     PythonScriptController* obj = get_controller(self);
     Node* node = get<Node>(pyNode);
     msg_error("PythonScriptController") << obj->m_classname.getValueString() 
@@ -102,12 +100,13 @@ static PyObject * PythonScriptController_createGraph(PyObject * /*self*/, PyObje
     Py_RETURN_NONE;
 }
 
-static PyObject * PythonScriptController_initGraph(PyObject * /*self*/, PyObject * args) {
+static PyObject * PythonScriptController_initGraph(PyObject * self, PyObject * args) {
+    (void) self;
+
     PyObject *pyNode;
     if (!PyArg_ParseTuple(args, "O", &pyNode)) return NULL;
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    // TODO FIXME self is commented
     PythonScriptController* obj = get_controller(self);
     Node* node = get<Node>(pyNode);
     msg_error("PythonScriptController") << obj->m_classname.getValueString() 
@@ -118,12 +117,13 @@ static PyObject * PythonScriptController_initGraph(PyObject * /*self*/, PyObject
     Py_RETURN_NONE;
 }
 
-static PyObject * PythonScriptController_bwdInitGraph(PyObject * /*self*/, PyObject * args) {
+static PyObject * PythonScriptController_bwdInitGraph(PyObject * self, PyObject * args) {
+    (void) self;
+
     PyObject *pyNode;
     if (!PyArg_ParseTuple(args, "O", &pyNode)) return NULL;
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    // TODO FIXME self is commented
     PythonScriptController* obj = get_controller(self);
     Node* node = get<Node>(pyNode);
     msg_error("PythonScriptController") << obj->m_classname.getValueString() 
@@ -134,13 +134,14 @@ static PyObject * PythonScriptController_bwdInitGraph(PyObject * /*self*/, PyObj
     Py_RETURN_NONE;
 }
 
-static PyObject * PythonScriptController_onBeginAnimationStep(PyObject * /*self*/, PyObject * args) {
+static PyObject * PythonScriptController_onBeginAnimationStep(PyObject * self, PyObject * args) {
+    (void) self;
+
     double dt;
     if (!PyArg_ParseTuple(args, "d", &dt)) return NULL;
 
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    // TODO FIXME self is commented
     PythonScriptController* obj = get_controller(self);
     msg_error("PythonScriptController") << obj->m_classname.getValueString() 
                                         << ".onBeginAnimationStep not implemented in " 
@@ -150,13 +151,14 @@ static PyObject * PythonScriptController_onBeginAnimationStep(PyObject * /*self*
     Py_RETURN_NONE;
 }
 
-static PyObject * PythonScriptController_onEndAnimationStep(PyObject * /*self*/, PyObject * args) {
+static PyObject * PythonScriptController_onEndAnimationStep(PyObject * self, PyObject * args) {
+    (void) self;
+
     double dt;
     if (!PyArg_ParseTuple(args, "d", &dt)) return NULL;
 
     
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    // TODO FIXME self is commented
     PythonScriptController* obj = get_controller(self);
     msg_error("PythonScriptController") << obj->m_classname.getValueString() 
                                         << ".onEndAnimationStep not implemented in " 
@@ -166,10 +168,11 @@ static PyObject * PythonScriptController_onEndAnimationStep(PyObject * /*self*/,
     Py_RETURN_NONE;
 }
 
-static PyObject * PythonScriptController_storeResetState(PyObject * /*self*/, PyObject * /*args*/) {
+static PyObject * PythonScriptController_storeResetState(PyObject * self, PyObject * /*args*/) {
+    (void) self;
+
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    // TODO FIXME self is commented
     PythonScriptController* obj = get_controller(self);
     msg_error("PythonScriptController") << obj->m_classname.getValueString() 
                                         << ".storeresetState not implemented in " 
@@ -179,10 +182,11 @@ static PyObject * PythonScriptController_storeResetState(PyObject * /*self*/, Py
     Py_RETURN_NONE;
 }
 
-static PyObject * PythonScriptController_reset(PyObject * /*self*/, PyObject * /*args*/)  {
+static PyObject * PythonScriptController_reset(PyObject * self, PyObject * /*args*/)  {
+    (void) self;
+
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    // TODO FIXME self is commented
     PythonScriptController* obj = get_controller(self);
     msg_error("PythonScriptController") << obj->m_classname.getValueString() 
                                         << ".reset not implemented in " 
@@ -192,10 +196,11 @@ static PyObject * PythonScriptController_reset(PyObject * /*self*/, PyObject * /
     Py_RETURN_NONE;
 }
 
-static PyObject * PythonScriptController_cleanup(PyObject * /*self*/, PyObject * /*args*/) {
+static PyObject * PythonScriptController_cleanup(PyObject * self, PyObject * /*args*/) {
+    (void) self;
+
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    // TODO FIXME self is commented
     PythonScriptController* obj = get_controller(self);
     msg_error("PythonScriptController") << obj->m_classname.getValueString() 
                                         << ".cleanup not implemented in " 
@@ -205,7 +210,9 @@ static PyObject * PythonScriptController_cleanup(PyObject * /*self*/, PyObject *
     Py_RETURN_NONE;
 }
 
-static PyObject * PythonScriptController_onGUIEvent(PyObject * /*self*/, PyObject * args) {
+static PyObject * PythonScriptController_onGUIEvent(PyObject * self, PyObject * args) {
+    (void) self;
+
     char* controlID;
     char* valueName;
     char* value;
@@ -213,7 +220,6 @@ static PyObject * PythonScriptController_onGUIEvent(PyObject * /*self*/, PyObjec
 
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    // TODO FIXME self is commented
     PythonScriptController* obj = get_controller(self);
     msg_error("PythonScriptController") << obj->m_classname.getValueString() 
                                         << ".onGUIEvent not implemented in " 
@@ -223,12 +229,13 @@ static PyObject * PythonScriptController_onGUIEvent(PyObject * /*self*/, PyObjec
     Py_RETURN_NONE;
 }
 
-static PyObject * PythonScriptController_onKeyPressed(PyObject * /*self*/, PyObject * args) {
+static PyObject * PythonScriptController_onKeyPressed(PyObject * self, PyObject * args) {
+    (void) self;
+
     char k;
     if (!PyArg_ParseTuple(args, "c", &k)) return NULL;
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    // TODO FIXME self is commented
     PythonScriptController* obj = get_controller(self);
     msg_error("PythonScriptController") << obj->m_classname.getValueString() 
                                         << ".onKeyPressed not implemented in " 
@@ -238,12 +245,13 @@ static PyObject * PythonScriptController_onKeyPressed(PyObject * /*self*/, PyObj
     Py_RETURN_FALSE;
 }
 
-static PyObject * PythonScriptController_onKeyReleased(PyObject * /*self*/, PyObject * args) {
+static PyObject * PythonScriptController_onKeyReleased(PyObject * self, PyObject * args) {
+    (void) self;
+
     char k;
     if (!PyArg_ParseTuple(args, "c", &k)) return NULL;
     
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    // TODO FIXME self is commented
     PythonScriptController* obj = get_controller(self);
     msg_error("PythonScriptController") << obj->m_classname.getValueString() 
                                         << ".onKeyReleased not implemented in " 
@@ -253,13 +261,14 @@ static PyObject * PythonScriptController_onKeyReleased(PyObject * /*self*/, PyOb
     Py_RETURN_FALSE;
 }
 
-static PyObject * PythonScriptController_onMouseButtonLeft(PyObject * /*self*/, PyObject * args) {
+static PyObject * PythonScriptController_onMouseButtonLeft(PyObject * self, PyObject * args) {
+    (void) self;
+
     int x, y;
     bool pressed;
     if (!PyArg_ParseTuple(args, "iib", &x, &y, &pressed)) return NULL;
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    // TODO FIXME self is commented
     PythonScriptController* obj = get_controller(self);
     msg_error("PythonScriptController") << obj->m_classname.getValueString() 
                                         << ".onMouseButtonLeft not implemented in " 
@@ -269,14 +278,15 @@ static PyObject * PythonScriptController_onMouseButtonLeft(PyObject * /*self*/, 
     Py_RETURN_NONE;
 }
 
-static PyObject * PythonScriptController_onMouseButtonMiddle(PyObject * /*self*/, PyObject * args) {
+static PyObject * PythonScriptController_onMouseButtonMiddle(PyObject * self, PyObject * args) {
+    (void) self;
+
     int x, y;
     bool pressed;
     if (!PyArg_ParseTuple(args, "iib", &x, &y, &pressed)) return NULL;
 
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    // TODO FIXME self is commented
     PythonScriptController* obj = get_controller(self);
     msg_error("PythonScriptController") << obj->m_classname.getValueString() 
                                         << ".onMouseButtonMiddle not implemented in " 
@@ -286,13 +296,14 @@ static PyObject * PythonScriptController_onMouseButtonMiddle(PyObject * /*self*/
     Py_RETURN_NONE;
 }
 
-static PyObject * PythonScriptController_onMouseButtonRight(PyObject * /*self*/, PyObject * args) {
+static PyObject * PythonScriptController_onMouseButtonRight(PyObject * self, PyObject * args) {
+    (void) self;
+
     int x, y;
     bool pressed;
     if (!PyArg_ParseTuple(args, "iib", &x, &y, &pressed)) return NULL;
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    // TODO FIXME self is commented
     PythonScriptController* obj = get_controller(self);
     msg_error("PythonScriptController") << obj->m_classname.getValueString() 
                                         << ".onMouseButtonRight not implemented in " 
@@ -302,12 +313,13 @@ static PyObject * PythonScriptController_onMouseButtonRight(PyObject * /*self*/,
     Py_RETURN_NONE;
 }
 
-static PyObject * PythonScriptController_onMouseWheel(PyObject * /*self*/, PyObject * args) {
+static PyObject * PythonScriptController_onMouseWheel(PyObject * self, PyObject * args) {
+    (void) self;
+
     int x, y, delta;
     if (!PyArg_ParseTuple(args, "iii",&x, &y, &delta)) return NULL;
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    // TODO FIXME self is commented
     PythonScriptController* obj = get_controller(self);
     msg_error("PythonScriptController") << obj->m_classname.getValueString() 
                                         << ".onMouseWheel not implemented in " 
@@ -317,9 +329,11 @@ static PyObject * PythonScriptController_onMouseWheel(PyObject * /*self*/, PyObj
     Py_RETURN_NONE;
 }
 
-// TOOD here
 
-static PyObject * PythonScriptController_onScriptEvent(PyObject * /*self*/, PyObject * args) {
+
+static PyObject * PythonScriptController_onScriptEvent(PyObject * self, PyObject * args) {
+    (void) self;
+
     PyObject *pySenderNode;
     char* eventName;
     PyObject *pyData;
@@ -337,7 +351,6 @@ static PyObject * PythonScriptController_onScriptEvent(PyObject * /*self*/, PyOb
     // TODO check pyData
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    // TODO FIXME self is commented
     PythonScriptController* obj = get_controller(self);
     msg_error("PythonScriptController") << obj->m_classname.getValueString() 
                                         << ".onScriptEvent not implemented in " 
@@ -347,10 +360,10 @@ static PyObject * PythonScriptController_onScriptEvent(PyObject * /*self*/, PyOb
     Py_RETURN_NONE;
 }
 
-static PyObject * PythonScriptController_draw(PyObject * /*self*/, PyObject * /*args*/) {
+static PyObject * PythonScriptController_draw(PyObject * self, PyObject * /*args*/) {
+    (void) self;
 
 #ifdef LOG_UNIMPLEMENTED_METHODS
-    // TODO FIXME self is commented
     PythonScriptController* obj = get_controller(self);
     msg_error("PythonScriptController") << obj->m_classname.getValueString() 
                                         << ".draw not implemented in " 

--- a/applications/plugins/SofaPython/Binding_SofaModule.cpp
+++ b/applications/plugins/SofaPython/Binding_SofaModule.cpp
@@ -61,9 +61,7 @@ extern "C" PyObject * Sofa_getSofaPythonVersion(PyObject * /*self*/, PyObject *)
 extern "C" PyObject * Sofa_createNode(PyObject * /*self*/, PyObject * args)
 {
     char *name;
-    if (!PyArg_ParseTuple(args, "s",&name))
-    {
-        PyErr_BadArgument();
+    if (!PyArg_ParseTuple(args, "s",&name)) {
         return NULL;
     }
 
@@ -74,12 +72,9 @@ extern "C" PyObject * Sofa_createNode(PyObject * /*self*/, PyObject * args)
 
 
 // object factory
-extern "C" PyObject * Sofa_createObject(PyObject * /*self*/, PyObject * args, PyObject * kw)
-{
+static PyObject * Sofa_createObject(PyObject * /*self*/, PyObject * args, PyObject * kw) {
     char *type;
-    if (!PyArg_ParseTuple(args, "s",&type))
-    {
-        PyErr_BadArgument();
+    if (!PyArg_ParseTuple(args, "s", &type)) {
         return NULL;
     }
 
@@ -134,12 +129,12 @@ extern "C" PyObject * Sofa_getChildNode(PyObject * /*self*/, PyObject * /*args*/
 using namespace sofa::gui;
 
 // send a text message to the GUI
-extern "C" PyObject * Sofa_sendGUIMessage(PyObject * /*self*/, PyObject * args)
-{
+static PyObject * Sofa_sendGUIMessage(PyObject * /*self*/, PyObject * args) {
     char *msgType;
     char *msgValue;
-    if (!PyArg_ParseTuple(args, "ss",&msgType,&msgValue))
-        Py_RETURN_NONE;
+    if (!PyArg_ParseTuple(args, "ss",&msgType,&msgValue)) {
+        return NULL;
+    }
     BaseGUI *gui = GUIManager::getGUI();
     if (!gui)
     {
@@ -153,12 +148,9 @@ extern "C" PyObject * Sofa_sendGUIMessage(PyObject * /*self*/, PyObject * args)
 }
 
 // ask the GUI to save a screenshot
-extern "C" PyObject * Sofa_saveScreenshot(PyObject * /*self*/, PyObject * args)
-{
+static PyObject * Sofa_saveScreenshot(PyObject * /*self*/, PyObject * args) {
     char *filename;
-    if (!PyArg_ParseTuple(args, "s",&filename))
-    {
-        PyErr_BadArgument();
+    if (!PyArg_ParseTuple(args, "s",&filename)) {
         return NULL;
     }
     BaseGUI *gui = GUIManager::getGUI();
@@ -175,12 +167,9 @@ extern "C" PyObject * Sofa_saveScreenshot(PyObject * /*self*/, PyObject * args)
 
 
 // set the viewer resolution
-extern "C" PyObject * Sofa_setViewerResolution(PyObject * /*self*/, PyObject * args)
-{
+static PyObject * Sofa_setViewerResolution(PyObject * /*self*/, PyObject * args) {
     int width, height;
-    if (!PyArg_ParseTuple(args, "ii",&width,&height))
-    {
-        PyErr_BadArgument();
+    if (!PyArg_ParseTuple(args, "ii", &width, &height)) {
         return NULL;
     }
     BaseGUI *gui = GUIManager::getGUI();
@@ -201,9 +190,7 @@ extern "C" PyObject * Sofa_setViewerBackgroundColor(PyObject * /*self*/, PyObjec
 {
     float r = 0.0f, g = 0.0f, b = 0.0f;
     sofa::defaulttype::RGBAColor color;
-    if (!PyArg_ParseTuple(args, "fff", &r, &g, &b))
-    {
-        PyErr_BadArgument();
+    if (!PyArg_ParseTuple(args, "fff", &r, &g, &b)) {
         return NULL;
     }
 
@@ -260,8 +247,7 @@ extern "C" PyObject * Sofa_setViewerCamera(PyObject * /*self*/, PyObject * args)
 }
 
 
-extern "C" PyObject * Sofa_getViewerCamera(PyObject * /*self*/, PyObject *)
-{
+static PyObject * Sofa_getViewerCamera(PyObject * /*self*/, PyObject *) {
     sofa::defaulttype::Vector3 pos;
     sofa::defaulttype::Quat orient;
 
@@ -285,17 +271,17 @@ extern "C" PyObject * Sofa_getViewerCamera(PyObject * /*self*/, PyObject *)
 
 
 
-// from a mesh, a density and a 3d scale
-// computes a mass, a center of mass, a diagonal inertia matrix and an inertia rotation
-extern "C" PyObject * Sofa_generateRigid(PyObject * /*self*/, PyObject * args)
-{
+// from a mesh, a density and a 3d scale, computes a mass, a center of mass, a
+// diagonal inertia matrix and an inertia rotation
+static PyObject * Sofa_generateRigid(PyObject * /*self*/, PyObject * args) {
     char* meshFilename;
     double density;
-    double sx,sy,sz;
-    double rx,ry,rz;
-    if (!PyArg_ParseTuple(args, "sddddddd",&meshFilename,&density,&sx,&sy,&sz,&rx,&ry,&rz))
-    {
-        PyErr_BadArgument();
+    double sx = 1, sy = 1, sz = 1;
+    double rx = 0, ry = 0, rz = 0;
+    
+    if (!PyArg_ParseTuple(args, "sd|dddddd", &meshFilename, &density,
+                          &sx, &sy, &sz,
+                          &rx, &ry, &rz)) {
         return NULL;
     }
 
@@ -312,19 +298,16 @@ extern "C" PyObject * Sofa_generateRigid(PyObject * /*self*/, PyObject * args)
 
 
 /// save a sofa scene from python
-extern "C" PyObject * Sofa_exportGraph(PyObject * /*self*/, PyObject * args)
-{
+static PyObject * Sofa_exportGraph(PyObject * /*self*/, PyObject * args) {
     char* filename;
     PyObject* pyNode;
-    if (!PyArg_ParseTuple(args, "Os", &pyNode, &filename))
-    {
-        PyErr_BadArgument();
+    if (!PyArg_ParseTuple(args, "Os", &pyNode, &filename)) {
         return NULL;
     }
 
     BaseNode* node=((PySPtr<Base>*)pyNode)->object->toBaseNode();
-    if (!node)
-    {
+    if (!node) {
+        // this should not happen
         PyErr_BadArgument();
         return NULL;
     }
@@ -337,18 +320,15 @@ extern "C" PyObject * Sofa_exportGraph(PyObject * /*self*/, PyObject * args)
 
 
 
-extern "C" PyObject * Sofa_updateVisual(PyObject * /*self*/, PyObject * args)
-{
+static PyObject * Sofa_updateVisual(PyObject * /*self*/, PyObject * args) {
     PyObject* pyNode;
-    if (!PyArg_ParseTuple(args, "O", &pyNode))
-    {
-        PyErr_BadArgument();
+    if (!PyArg_ParseTuple(args, "O", &pyNode)) {
         return NULL;
     }
 
     BaseNode* basenode=((PySPtr<Base>*)pyNode)->object->toBaseNode();
-    if (!basenode)
-    {
+    if (!basenode) {
+        // this should not happen
         PyErr_BadArgument();
         return NULL;
     }
@@ -368,168 +348,76 @@ extern "C" PyObject * Sofa_updateVisual(PyObject * /*self*/, PyObject * args)
 
 static const std::string s_emitter = "PythonScript";
 
-extern "C" PyObject * Sofa_msg_info(PyObject * /*self*/, PyObject * args)
-{
-    size_t argSize = PyTuple_Size(args);
+// please use functions instead of copypasting all the time god dammit
+template<class Action>
+static PyObject* parse_emitter_message_then(PyObject* args, const Action& action) {
+    const size_t argSize = PyTuple_Size(args);
 
     char* message;
 
-    if( argSize==2 )
-    {
+    // the logic would be to have the optional arg in last position :-/
+    if( argSize == 2 ) {
         char* emitter;
-        if( !PyArg_ParseTuple(args, "ss", &emitter, &message) )
-        {
-            PyErr_BadArgument();
+        if( !PyArg_ParseTuple(args, "ss", &emitter, &message) ) {
             return NULL;
         }
 
-        msg_info( emitter ) << message;
-    }
-    else // no emitter
-    {
-        if( !PyArg_ParseTuple(args, "s", &message) )
-        {
-            PyErr_BadArgument();
+        action(emitter, message);
+    } else { 
+        // no emitter
+        if( !PyArg_ParseTuple(args, "s", &message) ) {
             return NULL;
         }
 
-        msg_info( s_emitter ) << message;
+        action(s_emitter, message);
     }
-
+    
     Py_RETURN_NONE;
 }
 
-extern "C" PyObject * Sofa_msg_deprecated(PyObject * /*self*/, PyObject * args)
-{
-    size_t argSize = PyTuple_Size(args);
-
-    char* message;
-
-    if( argSize==2 )
-    {
-        char* emitter;
-        if( !PyArg_ParseTuple(args, "ss", &emitter, &message) )
-        {
-            PyErr_BadArgument();
-            return NULL;
-        }
-
-        msg_deprecated( emitter ) << message;
-    }
-    else // no emitter
-    {
-        if( !PyArg_ParseTuple(args, "s", &message) )
-        {
-            PyErr_BadArgument();
-            return NULL;
-        }
-
-        msg_deprecated( s_emitter ) << message;
-    }
-
-    Py_RETURN_NONE;
+// also, we'd probably would be better off having 'error', 'fatal', 'info' as
+// argument
+static PyObject * Sofa_msg_info(PyObject * /*self*/, PyObject * args) {
+    return parse_emitter_message_then(args, [](const std::string& emitter, const char* message) {
+            msg_info(emitter) << message;
+        });
 }
 
-extern "C" PyObject * Sofa_msg_warning(PyObject * /*self*/, PyObject * args)
-{
-    size_t argSize = PyTuple_Size(args);
+static PyObject * Sofa_msg_deprecated(PyObject * /*self*/, PyObject * args) {
 
-    char* message;
+    return parse_emitter_message_then(args, [](const std::string& emitter, const char* message) {
+            msg_deprecated(emitter) << message;
+        });
 
-    if( argSize==2 )
-    {
-        char* emitter;
-        if( !PyArg_ParseTuple(args, "ss", &emitter, &message) )
-        {
-            PyErr_BadArgument();
-            return NULL;
-        }
-
-        msg_warning( emitter ) << message;
-    }
-    else // no emitter
-    {
-        if( !PyArg_ParseTuple(args, "s", &message) )
-        {
-            PyErr_BadArgument();
-            return NULL;
-        }
-
-        msg_warning( s_emitter ) << message;
-    }
-
-    Py_RETURN_NONE;
 }
 
-extern "C" PyObject * Sofa_msg_error(PyObject * /*self*/, PyObject * args)
-{
-    size_t argSize = PyTuple_Size(args);
+static PyObject * Sofa_msg_warning(PyObject * /*self*/, PyObject * args) {
 
-    char* message;
-
-    if( argSize==2 )
-    {
-        char* emitter;
-        if( !PyArg_ParseTuple(args, "ss", &emitter, &message) )
-        {
-            PyErr_BadArgument();
-            return NULL;
-        }
-
-        msg_error( emitter ) << message;
-    }
-    else // no emitter
-    {
-        if( !PyArg_ParseTuple(args, "s", &message) )
-        {
-            PyErr_BadArgument();
-            return NULL;
-        }
-
-        msg_error( s_emitter ) << message;
-    }
-
-    Py_RETURN_NONE;
+    return parse_emitter_message_then(args, [](const std::string& emitter, const char* message) {
+            msg_warning(emitter) << message;
+        });
+    
 }
 
-extern "C" PyObject * Sofa_msg_fatal(PyObject * /*self*/, PyObject * args)
-{
-    size_t argSize = PyTuple_Size(args);
+static PyObject * Sofa_msg_error(PyObject * /*self*/, PyObject * args) {
+    return parse_emitter_message_then(args, [](const std::string& emitter, const char* message) {
+            msg_error(emitter) << message;
+        });
+    
+}
 
-    char* message;
-
-    if( argSize==2 )
-    {
-        char* emitter;
-        if( !PyArg_ParseTuple(args, "ss", &emitter, &message) )
-        {
-            PyErr_BadArgument();
-            return NULL;
-        }
-
-        msg_fatal( emitter ) << message;
-    }
-    else // no emitter
-    {
-        if( !PyArg_ParseTuple(args, "s", &message) )
-        {
-            PyErr_BadArgument();
-            return NULL;
-        }
-
-        msg_fatal( s_emitter ) << message;
-    }
-
-    Py_RETURN_NONE;
+static PyObject * Sofa_msg_fatal(PyObject * /*self*/, PyObject * args) {
+    return parse_emitter_message_then(args, [](const std::string& emitter, const char* message) {
+            msg_fatal(emitter) << message;
+        });
 }
 
 
-extern "C" PyObject * Sofa_loadScene(PyObject * /*self*/, PyObject * args)
+
+static PyObject * Sofa_loadScene(PyObject * /*self*/, PyObject * args)
 {
     char *filename;
-    if (!PyArg_ParseTuple(args, "s",&filename))
-    {
-        PyErr_BadArgument();
+    if (!PyArg_ParseTuple(args, "s",&filename)) {
         return NULL;
     }
 
@@ -546,7 +434,8 @@ extern "C" PyObject * Sofa_loadScene(PyObject * /*self*/, PyObject * args)
     }
 
     // unable to load file
-    SP_MESSAGE_ERROR( "Sofa_loadScene: extension ("<<sofa::helper::system::SetDirectory::GetExtension(filename)<<") not handled" );
+    SP_MESSAGE_ERROR( "Sofa_loadScene: extension ("
+                      << sofa::helper::system::SetDirectory::GetExtension(filename)<<") not handled" );
 
     Py_RETURN_NONE;
 }
@@ -557,8 +446,9 @@ extern "C" PyObject * Sofa_loadPythonSceneWithArguments(PyObject * /*self*/, PyO
 {
     size_t argSize = PyTuple_Size(args);
 
-    if( !argSize )
-    {
+    // TODO FIXME this is an error, raise proper exception
+    // e.g. PyError_SetString(PyExc_RuntimeError, "derp"); then return NULL;
+    if( !argSize ) {
         SP_MESSAGE_ERROR( "Sofa_loadPythonSceneWithArguments: should have at least a filename as arguments" );
         Py_RETURN_NONE;
     }
@@ -566,12 +456,15 @@ extern "C" PyObject * Sofa_loadPythonSceneWithArguments(PyObject * /*self*/, PyO
     // PyString_Check(PyTuple_GetItem(args,0)) // to check the arg type and raise an error
     char *filename = PyString_AsString(PyTuple_GetItem(args,0));
 
-    if( sofa::helper::system::SetDirectory::GetFileName(filename).empty() ) // no filename
+    if( sofa::helper::system::SetDirectory::GetFileName(filename).empty() ) {// no filename
+        // TODO FIXME same here
         Py_RETURN_NONE;
+    }
 
-    std::vector<std::string> arguments;;
-    for( size_t i=1 ; i<argSize ; i++ )
+    std::vector<std::string> arguments;
+    for( size_t i=1 ; i<argSize ; i++ ) {
         arguments.push_back( PyString_AsString(PyTuple_GetItem(args,i)) );
+    }
 
     sofa::simulation::SceneLoaderPY loader;
     sofa::simulation::Node::SPtr node = loader.loadSceneWithArguments(filename,arguments);
@@ -583,9 +476,7 @@ extern "C" PyObject * Sofa_loadPythonSceneWithArguments(PyObject * /*self*/, PyO
 extern "C" PyObject * Sofa_loadPlugin(PyObject * /*self*/, PyObject * args)
 {
     char *pluginName;
-    if (!PyArg_ParseTuple(args, "s",&pluginName))
-    {
-        PyErr_BadArgument();
+    if (!PyArg_ParseTuple(args, "s", &pluginName)) {
         return NULL;
     }
 

--- a/applications/plugins/SofaPython/PythonMacros.h
+++ b/applications/plugins/SofaPython/PythonMacros.h
@@ -92,9 +92,8 @@ struct PySPtr
 };
 
 template <class T>
-PyObject* BuildPySPtr(T* obj,PyTypeObject *pto)
-{
-    PySPtr<T> * pyObj = (PySPtr<T> *)PyType_GenericAlloc(pto, 0);
+static inline PyObject* BuildPySPtr(T* obj, PyTypeObject *pto) {
+    PySPtr<T> * pyObj = (PySPtr<T> *) PyType_GenericAlloc(pto, 0);
     pyObj->object = obj;
     return (PyObject*)pyObj;
 }
@@ -114,8 +113,7 @@ struct PyPtr
 };
 
 template <class T>
-PyObject* BuildPyPtr(T* obj,PyTypeObject *pto,bool del)
-{
+static inline PyObject* BuildPyPtr(T* obj, PyTypeObject *pto, bool del) {
     PyPtr<T> * pyObj = (PyPtr<T> *)PyType_GenericAlloc(pto, 0);
     pyObj->object = obj;
     pyObj->deletable = del;

--- a/applications/plugins/SofaPython/PythonScriptController.cpp
+++ b/applications/plugins/SofaPython/PythonScriptController.cpp
@@ -209,25 +209,7 @@ void PythonScriptController::loadScript()
                 return;
     }
 
-    BIND_OBJECT_METHOD(onLoaded)
-    BIND_OBJECT_METHOD(createGraph)
-    BIND_OBJECT_METHOD(initGraph)
-    BIND_OBJECT_METHOD(bwdInitGraph)
-    BIND_OBJECT_METHOD(onKeyPressed)
-    BIND_OBJECT_METHOD(onKeyReleased)
-    BIND_OBJECT_METHOD(onMouseButtonLeft)
-    BIND_OBJECT_METHOD(onMouseButtonRight)
-    BIND_OBJECT_METHOD(onMouseButtonMiddle)
-    BIND_OBJECT_METHOD(onMouseWheel)
-    BIND_OBJECT_METHOD(onBeginAnimationStep)
-    BIND_OBJECT_METHOD(onEndAnimationStep)
-    BIND_OBJECT_METHOD(storeResetState)
-    BIND_OBJECT_METHOD(reset)
-    BIND_OBJECT_METHOD(cleanup)
-    BIND_OBJECT_METHOD(onGUIEvent)
-    BIND_OBJECT_METHOD(onScriptEvent)
-    BIND_OBJECT_METHOD(draw)
-    BIND_OBJECT_METHOD(onIdle)
+    refreshBinding();
 }
 
 void PythonScriptController::doLoadScript()

--- a/applications/plugins/SofaPython/PythonScriptController.cpp
+++ b/applications/plugins/SofaPython/PythonScriptController.cpp
@@ -137,6 +137,25 @@ PythonScriptController::~PythonScriptController()
     }
 }
 
+
+void PythonScriptController::setInstance(PyObject* instance) {
+    // "trust me i'm an engineer"
+    if( m_ScriptControllerInstance ) {
+        Py_DECREF( m_ScriptControllerInstance );
+    }
+    
+    m_ScriptControllerInstance = instance;
+
+    // note: we don't use PyObject_Type as it returns a new reference which is
+    // not handled correctly in loadScript
+    m_ScriptControllerClass = (PyObject*)instance->ob_type;
+    
+    Py_INCREF( instance );
+    
+    refreshBinding();
+}
+
+
 void PythonScriptController::refreshBinding()
 {
     BIND_OBJECT_METHOD(onLoaded)

--- a/applications/plugins/SofaPython/PythonScriptController.h
+++ b/applications/plugins/SofaPython/PythonScriptController.h
@@ -56,6 +56,10 @@ public:
     bool isDerivedFrom(const std::string& name, const std::string& module = "__main__");
     void doLoadScript();
     void refreshBinding();
+    
+    // setup from existing python instance
+    void setInstance(PyObject* instance);
+    
 protected:
     PythonScriptController();
     virtual ~PythonScriptController();

--- a/applications/plugins/SofaPython/examples/ControllerVariable.py
+++ b/applications/plugins/SofaPython/examples/ControllerVariable.py
@@ -1,6 +1,9 @@
+from __future__ import print_function
+
 import Sofa
 import sys
 from SofaPython import script
+
 
 ############################################################################################
 # this is a PythonScriptController example script
@@ -10,35 +13,73 @@ from SofaPython import script
 
 def createScene( root ):
 
-    myController = MyControllerClass(root,"hello world controller", myArg = 'additionalArgument', myArg2 = 'additionalArgument2')
+    # here, you can notice how we can create a PythonScriptController with a
+    # true python variable note how to give it optional extra arguments (@see
+    # additionalArguments)
+    myController = MyControllerClass(root, "hello world controller",
+                                     myArg = 'additionalArgument',
+                                     myArg2 = 'additionalArgument2')
+
+    # we have now access to its own member functions and variables
     myController.helloWorld()
     myController.myText = "hello world!"
 
 
 
-class MyControllerClass(script.Controller):
+class MyControllerClass(Sofa.PythonScriptController):
 
    ### Overloaded PythonScriptController callbacks
+    def __init__(self, node, name, *args, **kwargs):
+       print("createGraph: myText ==", self.myText)
 
-    def createGraph(self, node):
-       print "createGraph: myText ==",self.myText
-       sys.stdout.flush()
+       # note: this member aliases the sofa component `name` data, so you can't
+       # put anything in here (in this case, strings only)
+       self.name = name
 
+       # this one only exists on the python side (no such data exists in the c++
+       # object)
+       self.myText = kwargs['myArg']
+       
+       # here, you can notice how a controller can create another controller
+       # during its own creation
+       sub = RecursiveFibonacciControllerClass(node, "recursiveFibonacciController 0", f_1 = 0, f_2 = 1)
+       
     def initGraph(self,node):
-        print "initGraph: myText ==", self.myText
-        sys.stdout.flush()
+        print("initGraph: myText ==", self.myText)
 
 
-   ### Local variables / functions
-
+    ### class variables / functions
     myText = "nothing to say"
-
+    
     def helloWorld(self):
-        print "helloWorld() function"
-        sys.stdout.flush()
+        print("helloWorld() function")
 
 
-    ### to handle optional constructor arguments before createGraph
-    def additionalArguments(self,kwarg):
-        print "additionalArguments",kwarg
-        self.myText = kwarg['myArg']
+
+
+class RecursiveFibonacciControllerClass(Sofa.PythonScriptController):
+
+    nbInstances = 0
+
+    def __init__(self, node, name, *args, **kwargs):
+
+        RecursiveFibonacciControllerClass.nbInstances += 1
+
+        self.name = name
+        
+        self.f_1 = kwargs['f_1']
+        self.f_2 = kwargs['f_2']
+        
+        f = self.f_1 + self.f_2
+
+        # lolwat
+        print("Guys, I am crazy, I am creating myself recursively!")
+        
+        if RecursiveFibonacciControllerClass.nbInstances < 20:
+            # here, you can notice how a controller can create another
+            # controller of the same class during its own creation, just
+            # awesome!
+            self.recursive = RecursiveFibonacciControllerClass(node, "recursiveFibonacciController " + str(f),
+                                                               f_2 = self.f_1, f_1 = f)
+            
+

--- a/applications/plugins/SofaPython/python/SofaPython/__init__.py
+++ b/applications/plugins/SofaPython/python/SofaPython/__init__.py
@@ -1,7 +1,7 @@
 import __builtin__
 import sys
 
-## @author Matthieu Nesme
+## @author Matthieu Nesme, Maxime Tournier
 ## @date 2017
 
 
@@ -26,5 +26,29 @@ def unloadModules():
     toremove = [name for name in sys.modules if not name in __SofaPythonEnvironment_importedModules__ and not name in __SofaPythonEnvironment_modulesExcludedFromReload ]
     for name in toremove:
         del(sys.modules[name]) # unload it
+
+
+
+
+import Sofa
+class Controller(Sofa.PythonScriptController):
+
+    def __init__(self, node, *args, **kwargs):
+        Sofa.msg_warning('SofaPython', 'SofaPython.Controller is intended as compatibility class only')
+
+        # setting attributes from kwargs
+        for name, value in kwargs.iteritems():
+            setattr(self, name, value)
+
+        # call createGraph for compatibility purposes
+        self.createGraph(node)
+
+
+        # check whether derived class has 'onLoaded'
+        cls = type(self)
+        if not cls.onLoaded is Sofa.PythonScriptController.onLoaded:
+            Sofa.msg_warning('SofaPython', 
+                             '`onLoaded` is defined in subclass but will not be called in the future' )
+
 
         

--- a/applications/plugins/SofaPython/python/SofaPython/script.py
+++ b/applications/plugins/SofaPython/python/SofaPython/script.py
@@ -1,9 +1,30 @@
-'''simpler python script controllers'''
+'''simpler & deprecated python script controllers'''
 
 import Sofa
 import inspect
 
+def deprecated(cls):
+
+    # TODO maybe we should print a backtrace to locate the origin?
+    # or even better, use: https://docs.python.org/2/library/warnings.html#warnings.warn
+    line = '''class `{0}` from module `{1}` is deprecated. You may now derive from `Sofa.PythonScriptController` and instantiate derived classes directly.'''.format(cls.__name__, cls.__module__)
+    
+    Sofa.msg_deprecated('SofaPython', line)
+    
+    Sofa.msg_deprecated('SofaPython', 
+                        'note: `createGraph` will no longer be called automatically. You need to call manually from __init__ instead.')
+    
+    Sofa.msg_deprecated('SofaPython',
+                        'note: `onLoaded` will no longer be called automatically. You need to call manually from __init__ instead.')
+    
+    return cls
+
+@deprecated
 class Controller(Sofa.PythonScriptController):
+    
+    # to stack data for recursive creations of Controllers
+    instances = []
+    kwargs = []
 
     def __new__(cls, node, name='pythonScriptController', filename='', **kwarg):
         """


### PR DESCRIPTION
Hello all,

This PR somewhat simplifies the creation and handling of `PythonScriptControllers` from python scenes.

Here's the TL;DR version:

```python
import Sofa    
class Script(Sofa.PythonScriptController): pass

def createScene(node):
    # now you can do
    script = Script(node, 'bar', egg = 'spam')

    # the old behavior still works:
    old = node.createObject('PythonScriptController', filename = '', classname = 'Script')
```

Now for the details:

## Existing approach
The current approach is to use 
```python
node.createObject('PythonScriptController', filename = '', classname = 'Script')
```
which has several drawbacks:
- The returned object does not point to the control object, but to the component wrapper. This makes it complicated to pass data around at scene creation (people generally resort to `global` variables for this purpose).
- If `filename` is non-empty, the corresponding file is (re)loaded, causing all sorts of *interesting* side-effects. If you ever had to struggle with these, you know what I mean.
- If `filename` is empty, the control class has to lie in the `__main__` namespace
- It is quite verbose
- It just feels plain wrong *not* to create python objects directly when called from python


It does have a few advantages though:
- It does not require any `PythonScriptController`-specific code for object creation,
- It enables the creation of `PythonScriptController` instances from XML scenes 

## Current workaround
There is a workaround class `SofaPython.script.Controller` that somewhat fixes some of the issues by implementing `__new__` in a derived Python class, intercepting and returning the control instance and optional initialization arguments, but overall it feels more like a hack.

## This PR

This PR simply provides a clean binding for instance creation. You need to provide a node as a first argument, but otherwise Controllers now act as any other python object. The old behavior still works, should you need it.

```python
    
import Sofa    
class Script(Sofa.PythonScriptController):

    def __init__(self, node, *args, **kwargs):
        self.bacon = kwargs.pop('egg', 'spam')

    def onBeginAnimationStep(self, dt):
        print(self.bacon)

        
def createScene(node):
    script = Script(node, egg = 'spam')
    

```

Creating instances directly no longer calls `onLoaded` nor `createGraph`:

- nothing is actually loaded
- code in `createGraph` really belongs to `__init__` anyways

This behavior can be changed of course, maybe a warning can/should be emitted if the instance creation detects a derived implementation. Comments welcome :)

The PR also removes heavy copypasta in some files, removes unneeded `extern "C"` linkage and a few other cosmetic changes.

# Changelog

- `PythonScriptController` and derived classes are now instantiable directly in python. The constructor requires a `Node` as first parameter.
- `onLoaded` and `createGraph` entry points are no longer called when classes are instantiated directly from python. Corresponding code belongs to the derived class constructor.
- creating instances "the old way" through `node.createGraph` has unchanged behavior
- the workaround module `SofaPython.script` now features a deprecation message, together with a derived class easing transition (calls `createGraph` on construction, warns if `onLoaded` is defined)
- updated `ControllerVariable.py` example 
- some minor cleanups
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
