### PR TITLE
[SofaPython] ADD Improve data field in SofaPython

### DIFF
--- a/applications/plugins/SofaPython/Binding_BaseContext.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseContext.cpp
@@ -76,11 +76,6 @@ void SofaPythonListToStdStr(PyObject *list, std::stringstream& out)
          for (int i=0; i<PyList_Size(list); i++)
          {
              PyObject* item = PyList_GetItem(list, i) ;
-             /// [0, [1], 3]
-             /// 0
-             /// [1]
-             /// 3
-
              char* ptr = PyString_AsString(PyObject_Str(item)) ;
              out << ptr << " " ;
          }

--- a/applications/plugins/SofaPython/Binding_BaseContext.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseContext.cpp
@@ -113,16 +113,17 @@ static std::ostream& pythonToSofaDataString(const char* type, PyObject* value, s
 
     /// Check if the object has an explicit conversion to a Sofa path. If this is the case
     /// we use it.
-    if( PyObject_HasAttrString(value, "getSofaPath") ){
-       PyObject* retvalue = PyObject_CallMethod(value, "getSofaPath", nullptr) ;
+    if( PyObject_HasAttrString(value, "getAsACreateObjectParameter") ){
+       PyObject* retvalue = PyObject_CallMethod(value, "getAsACreateObjectParameter", nullptr) ;
        return out <<  PyString_AsString(PyObject_Str(retvalue)) ;
     }
 
     /// Default conversion for standard type:
     if( !(PyInt_Check(value) || PyLong_Check(value) || PyFloat_Check(value) || PyBool_Check(value) )){
-        msg_warning("SofaPython") << "You are trying to convert a non primitive type to Sofa using the 'str' operator. "
-                                     "Automatic conversion is provided for: String, Integer, Long, Float and Bool and Sequences"
-                                     "Other objects should implement the method getSofaPath() to return the adequate string.";
+        msg_warning("SofaPython") << "You are trying to convert a non primitive type to Sofa using the 'str' operator. " << msgendl
+                                     "Automatic conversion is provided for: String, Integer, Long, Float and Bool and Sequences." << msgendl
+                                     "Other objects should implement the method getAsACreateObjectParameter() returning a string usable as a parameter in createObject()." << msgendl
+                                     "To remove this message you must add a method getAsCreateObjectParameter(self)" ;
     }
 
     return out << PyString_AsString(PyObject_Str(value)) ;

--- a/applications/plugins/SofaPython/Binding_BaseContext.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseContext.cpp
@@ -113,7 +113,10 @@ static std::ostream& pythonToSofaDataString(const char* type, PyObject* value, s
     /// we use it.
     if( PyObject_HasAttrString(value, "getAsACreateObjectParameter") ){
        PyObject* retvalue = PyObject_CallMethod(value, (char*)"getAsACreateObjectParameter", nullptr) ;
-       return out <<  PyString_AsString(PyObject_Str(retvalue)) ;
+       PyObject* tmpstr=PyObject_Str(retvalue);
+       out <<  PyString_AsString(tmpstr) ;
+       Py_DECREF(tmpstr) ;
+       return out ;
     }
 
     /// Default conversion for standard type:
@@ -124,7 +127,10 @@ static std::ostream& pythonToSofaDataString(const char* type, PyObject* value, s
                                      "To remove this message you must add a method getAsCreateObjectParameter(self)" ;
     }
 
-    return out << PyString_AsString(PyObject_Str(value)) ;
+    PyObject* tmpstr=PyObject_Str(value);
+    out << PyString_AsString(tmpstr) ;
+    Py_DECREF(tmpstr) ;
+    return out ;
 }
 
 

--- a/applications/plugins/SofaPython/Binding_BaseContext.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseContext.cpp
@@ -71,6 +71,21 @@ extern "C" PyObject * BaseContext_getRootContext(PyObject *self, PyObject * /*ar
     return sofa::PythonFactory::toPython(obj->getRootContext());
 }
 
+void SofaPythonListToStdStr(PyObject *list, std::stringstream& out)
+{
+         for (int i=0; i<PyList_Size(list); i++)
+         {
+             PyObject* item = PyList_GetItem(list, i) ;
+             /// [0, [1], 3]
+             /// 0
+             /// [1]
+             /// 3
+
+             char* ptr = PyString_AsString(PyObject_Str(item)) ;
+             out << ptr << " " ;
+         }
+}
+
 // object factory
 extern "C" PyObject * BaseContext_createObject_Impl(PyObject * self, PyObject * args, PyObject * kw, bool printWarnings)
 {
@@ -106,7 +121,12 @@ extern "C" PyObject * BaseContext_createObject_Impl(PyObject * self, PyObject * 
             {
                 if (PyString_Check(value))
                     desc.setAttribute(PyString_AsString(key),PyString_AsString(value));
-                else
+                else if (PyList_Check(value)){
+                    SP_MESSAGE_WARNING( "Sofa.Node.createObject("<<type<<"), automatic conversion from List for attribute "<<PyString_AsString(key)<<")..." )
+                    std::stringstream tmp;
+                    SofaPythonListToStdStr(value, tmp) ;
+                    desc.setAttribute(PyString_AsString(key), tmp.str().c_str());
+                }else
                     desc.setAttribute(PyString_AsString(key),PyString_AsString(PyObject_Str(value)));
             }
         }

--- a/applications/plugins/SofaPython/Binding_BaseContext.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseContext.cpp
@@ -102,7 +102,8 @@ static std::ostream& pythonToSofaDataString(PyObject* value, std::ostream& out)
 
             if (PyErr_Occurred())
             {
-                msg_error("SofaPython") << "error while iterating";
+                msg_error("SofaPython") << "error while iterating." << msgendl
+                                        << PythonEnvironment::getStackAsString() ;
             }
             return out;
         }
@@ -124,8 +125,10 @@ static std::ostream& pythonToSofaDataString(PyObject* value, std::ostream& out)
                                   << "Other objects should implement the method getAsACreateObjectParameter(). " << msgendl
                                   << "This function should return a string usable as a parameter in createObject()." << msgendl
                                   << "So to remove this message you must add a method getAsCreateObjectParameter(self) "
-                                     "to the object you are passing the createObject function." << msgendl ;
+                                     "to the object you are passing the createObject function." << msgendl
+                                  << PythonEnvironment::getStackAsString() ;
     }
+
 
     PyObject* tmpstr=PyObject_Str(value);
     out << PyString_AsString(tmpstr) ;

--- a/applications/plugins/SofaPython/Binding_BaseObject.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseObject.cpp
@@ -134,6 +134,10 @@ extern "C" PyObject * BaseObject_getName(PyObject * self, PyObject * /*args*/)
     return PyString_FromString((node->getName()).c_str());
 }
 
+extern "C" PyObject * BaseObject_getAsACreateObjectParameter(PyObject * self, PyObject *args)
+{
+    return BaseObject_getLinkPath(self, args);
+}
 
 SP_CLASS_METHODS_BEGIN(BaseObject)
 SP_CLASS_METHOD(BaseObject,init)
@@ -149,6 +153,7 @@ SP_CLASS_METHOD(BaseObject,getPathName)
 SP_CLASS_METHOD(BaseObject,getLinkPath)
 SP_CLASS_METHOD(BaseObject,getSlaves)
 SP_CLASS_METHOD(BaseObject,getName)
+SP_CLASS_METHOD(BaseObject,getAsACreateObjectParameter)
 SP_CLASS_METHODS_END
 
 

--- a/applications/plugins/SofaPython/Binding_Data.cpp
+++ b/applications/plugins/SofaPython/Binding_Data.cpp
@@ -131,7 +131,7 @@ PyObject *GetDataValuePython(BaseData* data)
 static int SetDataValuePythonList(BaseData* data, PyObject* args,
                             const int rowWidth, int nbRows) {
     const AbstractTypeInfo *typeinfo = data->getValueTypeInfo(); // info about the data value
-        
+
     // check list emptyness
     if (PyList_Size(args)==0)
     {
@@ -616,7 +616,7 @@ extern "C" PyObject * Data_read(PyObject *self, PyObject * args)
         PyErr_BadArgument();
         return NULL;
     }
-    
+
     Py_RETURN_NONE;
 }
 
@@ -649,7 +649,7 @@ extern "C" PyObject * Data_setParent(PyObject *self, PyObject * args)
         PyErr_BadArgument();
         return NULL;
     }
-    
+
     Py_RETURN_NONE;
 }
 
@@ -722,8 +722,10 @@ extern "C" PyObject * Data_getValueVoidPtr(PyObject * self, PyObject * /*args*/)
     return res;
 }
 
-
-
+extern "C" PyObject * Data_getAsACreateObjectParameter(PyObject * self, PyObject * args)
+{
+    return Data_getLinkPath(self, args);
+}
 
 SP_CLASS_METHODS_BEGIN(Data)
 SP_CLASS_METHOD(Data,getValueTypeString)
@@ -738,6 +740,7 @@ SP_CLASS_METHOD(Data,read)
 SP_CLASS_METHOD(Data,setParent)
 SP_CLASS_METHOD(Data,getLinkPath)
 SP_CLASS_METHOD(Data,getValueVoidPtr)
+SP_CLASS_METHOD(Data,getAsACreateObjectParameter)
 SP_CLASS_METHODS_END
 
 

--- a/applications/plugins/SofaPython/Binding_Node.cpp
+++ b/applications/plugins/SofaPython/Binding_Node.cpp
@@ -428,6 +428,10 @@ extern "C" PyObject * Node_printGraph(PyObject *self, PyObject * /*args*/)
     Py_RETURN_NONE;
 }
 
+extern "C" PyObject * Node_getAsACreateObjectParameter(PyObject * self, PyObject *args)
+{
+    return Node_getLinkPath(self, args);
+}
 
 SP_CLASS_METHODS_BEGIN(Node)
 SP_CLASS_METHOD(Node,executeVisitor)
@@ -457,6 +461,7 @@ SP_CLASS_METHOD(Node,getMechanicalMapping)
 SP_CLASS_METHOD(Node,propagatePositionAndVelocity)
 SP_CLASS_METHOD(Node,isInitialized)
 SP_CLASS_METHOD(Node,printGraph)
+SP_CLASS_METHOD(Node,getAsACreateObjectParameter)
 SP_CLASS_METHODS_END
 
 SP_CLASS_TYPE_SPTR(Node,Node,Context)

--- a/applications/plugins/SofaPython/PythonEnvironment.cpp
+++ b/applications/plugins/SofaPython/PythonEnvironment.cpp
@@ -280,7 +280,7 @@ std::string PythonEnvironment::getStackAsString()
     PyObject* pFunc = PyDict_GetItemString(pDict, "getStackForSofa");
     if (PyCallable_Check(pFunc))
     {
-        PyObject* res = PyObject_CallFunction(pFunc, "b", '0');
+        PyObject* res = PyObject_CallFunction(pFunc, nullptr);
         std::string tmp=PyString_AsString(PyObject_Str(res));
         Py_DECREF(res) ;
         return tmp;

--- a/applications/plugins/SofaPython/PythonEnvironment.cpp
+++ b/applications/plugins/SofaPython/PythonEnvironment.cpp
@@ -274,6 +274,20 @@ bool PythonEnvironment::runString(const std::string& script)
     return true;
 }
 
+std::string PythonEnvironment::getStackAsString()
+{
+    PyObject* pDict = PyModule_GetDict(PyImport_AddModule("SofaPython"));
+    PyObject* pFunc = PyDict_GetItemString(pDict, "getStackForSofa");
+    if (PyCallable_Check(pFunc))
+    {
+        PyObject* res = PyObject_CallFunction(pFunc, "b", '0');
+        std::string tmp=PyString_AsString(PyObject_Str(res));
+        Py_DECREF(res) ;
+        return tmp;
+    }
+    return "Python Stack is empty.";
+}
+
 bool PythonEnvironment::runFile( const char *filename, const std::vector<std::string>& arguments)
 {
 //    SP_MESSAGE_INFO( "Loading python script \""<<filename<<"\"" )

--- a/applications/plugins/SofaPython/PythonEnvironment.h
+++ b/applications/plugins/SofaPython/PythonEnvironment.h
@@ -56,10 +56,13 @@ public:
     /// add module to python context, Init() must have been called before
     static void addModule(const std::string& name, PyMethodDef* methodDef);
 
-    // basic script functions
+    /// basic script functions
     static std::string  getError();
     static bool         runString(const std::string& script);
     static bool         runFile( const char *filename, const std::vector<std::string>& arguments=std::vector<std::string>(0) );
+
+    /// returns the file information associated with the current frame.
+    static std::string getStackAsString() ;
 
     /// should the future scene loadings reload python modules?
     static void setAutomaticModuleReload( bool );

--- a/applications/plugins/SofaPython/SofaPython_test/PythonFactory_test.cpp
+++ b/applications/plugins/SofaPython/SofaPython_test/PythonFactory_test.cpp
@@ -112,7 +112,7 @@ protected:
                  "from SofaTest.Macro import *         \n"
                  "                                     \n"
                  "class TestGetSofaPath(object):       \n"
-                 "   def getSofaPath(self):            \n"
+                 "   def getAsACreateObjectParameter(self):            \n"
                  "        return '@/theFirst.name'     \n"
                  "def createScene(rootNode):           \n"
                  "    first = rootNode.createObject( 'ExternalComponent', name='theFirst') \n"
@@ -152,6 +152,7 @@ std::vector<std::vector<std::string>> dataconversionvalues =
      {"xrange(1,5)", "1 2 3 4"},
      {"'XX_'+first.findData('name').getLinkPath()", "XX_@/theFirst.name"},
      {"first.findData('name').getLinkPath()", "theFirst"},
+     {"first.findData('name')", "theFirst"},
      {"TestGetSofaPath()", "theFirst"}
     } ;
 

--- a/applications/plugins/SofaPython/SofaPython_test/PythonFactory_test.cpp
+++ b/applications/plugins/SofaPython/SofaPython_test/PythonFactory_test.cpp
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <SofaTest/Sofa_test.h>
 
 #include <SofaPython/PythonFactory.h>
 #include <SofaPython/Binding_BaseObject.h>
@@ -6,21 +6,28 @@
 
 #include <SofaSimulationGraph/DAGSimulation.h>
 #include <sofa/simulation/Node.h>
+using sofa::simulation::Node;
+
 #include <sofa/core/ObjectFactory.h>
 
-
+#include "../SceneLoaderPY.h"
+using sofa::simulation::SceneLoaderPY ;
+using sofa::core::objectmodel::BaseObject ;
 
 namespace sofa {
 
-
-
-
-////// A new Component ////////
-
+/////////////////////////////// A new Component ////////////////////////////////////////////////////
 class ExternalComponent : public core::objectmodel::BaseObject
 {
 public:
+    Data<std::string> d_value ;
+
     SOFA_CLASS( ExternalComponent,core::objectmodel::BaseObject);
+
+    ExternalComponent() :
+        d_value(initData(&d_value, "value", "value", "simpletest"))
+    {
+    }
 
     void helloWorld()
     {
@@ -29,28 +36,21 @@ public:
     }
 
     static int nbcalls;
-
 };
 
 int ExternalComponent::nbcalls = 0;
 
 
-//////// Registering the new component in the factory //////////
 
-
+//////////////////// //////// Registering the new component in the factory /////////////////////////
 SOFA_DECL_CLASS (ExternalComponent)
-
 int ExternalComponentClass = core::RegisterObject ( "An dummy External Component" )
         .add<ExternalComponent>(true);
-
-
 }
 
 
 
-//////// Binding the new component in Python //////////
-
-
+////////////////////////////// Binding the new component in Python /////////////////////////////////
 SP_DECLARE_CLASS_TYPE(ExternalComponent)
 
 extern "C" PyObject * ExternalComponent_helloWorld(PyObject *self, PyObject * /*args*/)
@@ -65,48 +65,101 @@ SP_CLASS_METHOD(ExternalComponent,helloWorld)
 SP_CLASS_METHODS_END
 
 SP_CLASS_TYPE_SPTR(ExternalComponent,sofa::ExternalComponent,BaseObject)
+//////////////////////// End of the new component  /////////////////////////////////////////////////
 
 
 
-
-//////// End of the new component  //////////
-
-
-
-
-
-
+///////////////////////////////////// TESTS ////////////////////////////////////////////////////////
 namespace sofa {
-
-
-struct PythonFactory_test : public ::testing::Test
+struct PythonFactory_test : public Sofa_test<>,
+                            public ::testing::WithParamInterface<std::vector<std::string>>
 {
 protected:
 
-    virtual void SetUp()
+    virtual void SetUp() override
     {
-        // ADDING new component in the python Factory
-        // of course its binding must be defined!
+        /// ADDING new component in the python Factory
+        /// of course its binding must be defined!
         SP_ADD_CLASS_IN_FACTORY( ExternalComponent, sofa::ExternalComponent )
+    }
 
+    virtual void TearDown() override
+    {
     }
 
     void test()
     {
         EXPECT_EQ(0, ExternalComponent::nbcalls);
+        sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
 
         static const std::string scenePath = std::string(SOFAPYTHON_TEST_PYTHON_DIR)+std::string("/test_PythonFactory.py");
-        sofa::simulation::setSimulation(new sofa::simulation::graph::DAGSimulation());
         simulation::getSimulation()->load(scenePath.c_str());
 
         EXPECT_EQ(1, ExternalComponent::nbcalls);
     }
 
+
+    void testAttributeConversion(const std::vector<std::string>& params)
+    {
+        std::string value = params[0] ;
+        std::string result = params[1] ;
+
+        const std::string scenePath = std::string(SOFAPYTHON_TEST_PYTHON_DIR)+std::string("/test_PythonFactory2.py");
+        std::ofstream f(scenePath, std::ofstream::out);
+        ASSERT_TRUE(f.is_open());
+        f <<
+                 "import Sofa                          \n"
+                 "from SofaTest.Macro import *         \n"
+                 "                                     \n"
+                 "def createScene(rootNode):           \n"
+                 "    first = rootNode.createObject( 'ExternalComponent', name='theFirst') \n"
+                 "    externalComponent = rootNode.createObject( 'ExternalComponent', name='second', value="<<value<<") \n"
+                 "    externalComponent.helloWorld()   \n" ;
+        f.close();
+
+        Node::SPtr root = simulation::getSimulation()->load(scenePath.c_str());
+        ASSERT_NE(root, nullptr);
+
+        BaseObject* aComponent = root->getObject("second") ;
+
+        ASSERT_NE(aComponent, nullptr);
+        ASSERT_NE(aComponent->findData("value"), nullptr);
+        ASSERT_EQ(aComponent->findData("value")->getValueString(), result);
+        simulation::getSimulation()->unload(root);
+    }
 };
 
 TEST_F(PythonFactory_test, result)
 {
     test();
 }
+
+
+std::vector<std::vector<std::string>> dataconversionvalues =
+    {{"1", "1"},
+     {"1.1", "1.1"},
+     {"True", "True"},
+     {"'aString'", "aString"},
+     {"'aString'.join('[ ]')", "[aString aString]"},
+     {"[1, 2, 3, 4]", "1 2 3 4"},
+     {"[1.0, 2.0, 3.0, 4.0]", "1.0 2.0 3.0 4.0"},
+     {"['ab', 'cd', 'ef', 'gh']", "ab cd ef gh"},
+     {"range(1,5)", "1 2 3 4"},
+     {"xrange(1,5)", "1 2 3 4"},
+     {"first.findData('name')", "theFirst"},
+     //{"first.name", "@/first @/first"},    ///Fetch the actual data...not the BaseData
+     //{"[first, first]", "@/first @/first"},
+     //{"[1, [2, 3], 4]", "1 2 3 4"},
+    } ;
+
+TEST_P(PythonFactory_test, testCreateObjectDataConversion)
+{
+   this->testAttributeConversion(GetParam());
+}
+
+INSTANTIATE_TEST_CASE_P(testCreateObjectDataConversion,
+                        PythonFactory_test,
+                        ::testing::ValuesIn(dataconversionvalues));
+
 
 }

--- a/applications/plugins/SofaPython/SofaPython_test/PythonFactory_test.cpp
+++ b/applications/plugins/SofaPython/SofaPython_test/PythonFactory_test.cpp
@@ -141,6 +141,7 @@ std::vector<std::vector<std::string>> dataconversionvalues =
      {"True", "True"},
      {"'aString'", "aString"},
      {"'aString'.join('[ ]')", "[aString aString]"},
+     {"' '.join(['AA', 'BB', 'CC'])", "AA BB CC"},
      {"[1, 2, 3, 4]", "1 2 3 4"},
      {"[1.0, 2.0, 3.0, 4.0]", "1.0 2.0 3.0 4.0"},
      {"['ab', 'cd', 'ef', 'gh']", "ab cd ef gh"},

--- a/applications/plugins/SofaPython/SofaPython_test/PythonFactory_test.cpp
+++ b/applications/plugins/SofaPython/SofaPython_test/PythonFactory_test.cpp
@@ -148,6 +148,8 @@ std::vector<std::vector<std::string>> dataconversionvalues =
      {"[1, 2, 3, 4]", "1 2 3 4"},
      {"[1.0, 2.0, 3.0, 4.0]", "1.0 2.0 3.0 4.0"},
      {"['ab', 'cd', 'ef', 'gh']", "ab cd ef gh"},
+     {"[[1,2], [3,4], [5,6]]", "1 2 3 4 5 6"},
+     {"[['aa','bb'], ['cc','dd'], ['ee','ff']]", "aa bb cc dd ee ff"},
      {"range(1,5)", "1 2 3 4"},
      {"xrange(1,5)", "1 2 3 4"},
      {"'XX_'+first.findData('name').getLinkPath()", "XX_@/theFirst.name"},

--- a/applications/plugins/SofaPython/SofaPython_test/PythonFactory_test.cpp
+++ b/applications/plugins/SofaPython/SofaPython_test/PythonFactory_test.cpp
@@ -155,7 +155,7 @@ std::vector<std::vector<std::string>> dataconversionvalues =
      {"'XX_'+first.findData('name').getLinkPath()", "XX_@/theFirst.name"},
      {"first.findData('name').getLinkPath()", "theFirst"},
      {"first.findData('name')", "theFirst"},
-     {"TestGetSofaPath()", "theFirst"}
+     {"'XX_'+rootNode.getAsACreateObjectParameter()", "XX_@"}
     } ;
 
 TEST_P(PythonFactory_test, testCreateObjectDataConversion)

--- a/applications/plugins/SofaPython/SofaPython_test/PythonFactory_test.cpp
+++ b/applications/plugins/SofaPython/SofaPython_test/PythonFactory_test.cpp
@@ -111,6 +111,9 @@ protected:
                  "import Sofa                          \n"
                  "from SofaTest.Macro import *         \n"
                  "                                     \n"
+                 "class TestGetSofaPath(object):       \n"
+                 "   def getSofaPath(self):            \n"
+                 "        return '@/theFirst.name'     \n"
                  "def createScene(rootNode):           \n"
                  "    first = rootNode.createObject( 'ExternalComponent', name='theFirst') \n"
                  "    externalComponent = rootNode.createObject( 'ExternalComponent', name='second', value="<<value<<") \n"
@@ -147,10 +150,9 @@ std::vector<std::vector<std::string>> dataconversionvalues =
      {"['ab', 'cd', 'ef', 'gh']", "ab cd ef gh"},
      {"range(1,5)", "1 2 3 4"},
      {"xrange(1,5)", "1 2 3 4"},
-     {"first.findData('name')", "theFirst"},
-     //{"first.name", "@/first @/first"},    ///Fetch the actual data...not the BaseData
-     //{"[first, first]", "@/first @/first"},
-     //{"[1, [2, 3], 4]", "1 2 3 4"},
+     {"'XX_'+first.findData('name').getLinkPath()", "XX_@/theFirst.name"},
+     {"first.findData('name').getLinkPath()", "theFirst"},
+     {"TestGetSofaPath()", "theFirst"}
     } ;
 
 TEST_P(PythonFactory_test, testCreateObjectDataConversion)

--- a/applications/plugins/SofaPython/SofaPython_test/PythonFactory_test.cpp
+++ b/applications/plugins/SofaPython/SofaPython_test/PythonFactory_test.cpp
@@ -111,9 +111,14 @@ protected:
                  "import Sofa                          \n"
                  "from SofaTest.Macro import *         \n"
                  "                                     \n"
-                 "class TestGetSofaPath(object):       \n"
+                 "class NonCustomizedObject(object):   \n"
+                 "   def __init__(self):               \n"
+                 "        return None                  \n"
+                 "   def __str__(self):                \n"
+                 "        return 'default'             \n"
+                 "class CustomObject(object):           \n"
                  "   def getAsACreateObjectParameter(self):            \n"
-                 "        return '@/theFirst.name'     \n"
+                 "        return 'custom value'        \n"
                  "def createScene(rootNode):           \n"
                  "    first = rootNode.createObject( 'ExternalComponent', name='theFirst') \n"
                  "    externalComponent = rootNode.createObject( 'ExternalComponent', name='second', value="<<value<<") \n"
@@ -138,6 +143,12 @@ TEST_F(PythonFactory_test, result)
 }
 
 
+TEST_F(PythonFactory_test, testCreateObjectDataConversionWarning)
+{
+    EXPECT_MSG_EMIT(Warning) ;
+    this->testAttributeConversion({"NonCustomizedObject()", "default"});
+}
+
 std::vector<std::vector<std::string>> dataconversionvalues =
     {{"1", "1"},
      {"1.1", "1.1"},
@@ -155,7 +166,8 @@ std::vector<std::vector<std::string>> dataconversionvalues =
      {"'XX_'+first.findData('name').getLinkPath()", "XX_@/theFirst.name"},
      {"first.findData('name').getLinkPath()", "theFirst"},
      {"first.findData('name')", "theFirst"},
-     {"'XX_'+rootNode.getAsACreateObjectParameter()", "XX_@"}
+     {"'XX_'+rootNode.getAsACreateObjectParameter()", "XX_@"},
+     {"CustomObject()", "custom value"}
     } ;
 
 TEST_P(PythonFactory_test, testCreateObjectDataConversion)
@@ -166,6 +178,6 @@ TEST_P(PythonFactory_test, testCreateObjectDataConversion)
 INSTANTIATE_TEST_CASE_P(testCreateObjectDataConversion,
                         PythonFactory_test,
                         ::testing::ValuesIn(dataconversionvalues));
-
-
 }
+
+

--- a/applications/plugins/SofaPython/python/SofaPython/__init__.py
+++ b/applications/plugins/SofaPython/python/SofaPython/__init__.py
@@ -1,5 +1,6 @@
 import __builtin__
 import sys
+import inspect
 
 ## @author Matthieu Nesme
 ## @date 2017
@@ -27,4 +28,15 @@ def unloadModules():
     for name in toremove:
         del(sys.modules[name]) # unload it
 
-        
+
+def formatStackForSofa(o):
+    ss='Python Stack: \n'
+    for entry in o:
+        ss+= ' in ' + str(entry[1]) + ':' + str(entry[2]) + ':'+ entry[3] + '() \n'
+        ss+= '  -> '+ entry[4][0] + ' \n'
+        return ss
+
+def getStackForSofa(self):
+    ss=inspect.stack()[1:]
+    return formatStackForSofa(ss)
+

--- a/applications/plugins/SofaPython/python/SofaPython/__init__.py
+++ b/applications/plugins/SofaPython/python/SofaPython/__init__.py
@@ -2,7 +2,10 @@ import __builtin__
 import sys
 import inspect
 
-## @author Matthieu Nesme
+## @contributors
+##   - Matthieu Nesme
+##   - damien.marchal@univ-lille1.fr
+##
 ## @date 2017
 
 
@@ -30,13 +33,24 @@ def unloadModules():
 
 
 def formatStackForSofa(o):
+    """ format the stack trace provided as a parameter into a string like that:
+        in filename.py:10:functioname()
+          -> the line of code.
+        in filename2.py:101:functioname1()
+            -> the line of code.
+        in filename3.py:103:functioname2()
+              -> the line of code.
+    """
     ss='Python Stack: \n'
     for entry in o:
-        ss+= ' in ' + str(entry[1]) + ':' + str(entry[2]) + ':'+ entry[3] + '() \n'
-        ss+= '  -> '+ entry[4][0] + ' \n'
+        ss+= ' in ' + str(entry[1]) + ':' + str(entry[2]) + ':'+ entry[3] + '()  \n'
+        ss+= '  -> '+ entry[4][0] + '  \n'
         return ss
 
-def getStackForSofa(self):
+def getStackForSofa():
+    """returns the currunt stack with a "unformal" formatting.
+    """
+    # we exclude the first level in the stack because it is the getStackForSofa() function itself.
     ss=inspect.stack()[1:]
     return formatStackForSofa(ss)
 


### PR DESCRIPTION
In createObject...

When you given an object as argument instead of a string the binding convert it (with str). This is problematic in many cases eg. with a list it is converted with the bracket (ie: '[' ) and comma as separator.

To resolve that I add a method that, if a list is passed as an argument,  convert it as a string following the sofa style (without comma and bracket).

CHANGELOG for @hugtalbot & @guparan :
 [SofaPython]: change the way createObject() handle its arguments to simplify scene writing + batch of tests.
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
