### PR TITLE
[SofaHelper] VisualToolGL, fix single primitive calls

### DIFF
--- a/SofaKernel/framework/sofa/core/visual/DrawTool.h
+++ b/SofaKernel/framework/sofa/core/visual/DrawTool.h
@@ -67,6 +67,7 @@ public:
     virtual void drawPoints(const std::vector<Vector3> &points, float size,  const  Vec4f& colour) = 0 ;
     virtual void drawPoints(const std::vector<Vector3> &points, float size, const std::vector<Vec4f>& colour) = 0;
 
+    virtual void drawLine(const Vector3 &p1, const Vector3 &p2, const Vec4f& colour) =  0;
     virtual void drawLines(const std::vector<Vector3> &points, float size, const Vec4f& colour) = 0 ;
     virtual void drawLines(const std::vector<Vector3> &points, float size, const std::vector<Vec4f>& colours) = 0 ;
     virtual void drawLines(const std::vector<Vector3> &points, const std::vector< Vec2i > &index , float size, const Vec4f& colour) = 0 ;

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
@@ -112,6 +112,18 @@ void DrawToolGL::drawPoints(const std::vector<Vector3> &points, float size, cons
     glPointSize(1);
 }
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void DrawToolGL::internalDrawLine(const Vector3 &p1, const Vector3 &p2, const Vec4f& colour)
+{
+    internalDrawPoint(p1, colour );
+    internalDrawPoint(p2, colour );
+}
+
+void DrawToolGL::drawLine(const Vector3 &p1, const Vector3 &p2, const Vec4f& colour)
+{
+    glBegin(GL_LINES);
+    internalDrawLine(p1,p2,colour);
+    glEnd();
+}
 
 void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const Vec<4,float>& colour)
 {
@@ -122,8 +134,7 @@ void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const
     {
         for (unsigned int i=0; i<points.size()/2; ++i)
         {
-            internalDrawPoint(points[2*i]  , colour );
-            internalDrawPoint(points[2*i+1], colour );
+            internalDrawLine(points[2*i],points[2*i+1]  , colour );
         }
     } glEnd();
     if (getLightEnabled()) glEnable(GL_LIGHTING);
@@ -140,8 +151,7 @@ void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const
         for (unsigned int i=0; i<points.size()/2; ++i)
         {
             setMaterial(colours[i]);
-            internalDrawPoint(points[2*i]  , colours[i] );
-            internalDrawPoint(points[2*i+1], colours[i] );
+            internalDrawLine(points[2*i],points[2*i+1]  , colours[i] );
             resetMaterial(colours[i]);
         }
     } glEnd();
@@ -160,8 +170,7 @@ void DrawToolGL::drawLines(const std::vector<Vector3> &points, const std::vector
     {
         for (unsigned int i=0; i<index.size(); ++i)
         {
-            internalDrawPoint(points[ index[i][0] ], colour );
-            internalDrawPoint(points[ index[i][1] ], colour );
+            internalDrawLine(points[ index[i][0] ],points[ index[i][1] ], colour );
         }
     } glEnd();
     if (getLightEnabled()) glEnable(GL_LIGHTING);

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
@@ -87,7 +87,7 @@ void DrawToolGL::drawPoints(const std::vector<Vector3> &points, float size, cons
     {
         for (unsigned int i=0; i<points.size(); ++i)
         {
-            drawPoint(points[i], colour);
+            internalDrawPoint(points[i], colour);
         }
     } glEnd();
     if (getLightEnabled()) glEnable(GL_LIGHTING);
@@ -104,7 +104,7 @@ void DrawToolGL::drawPoints(const std::vector<Vector3> &points, float size, cons
         for (unsigned int i=0; i<points.size(); ++i)
         {
             setMaterial(colour[i]);
-            drawPoint(points[i], colour[i]);
+            internalDrawPoint(points[i], colour[i]);
             if (getLightEnabled()) glEnable(GL_LIGHTING);
             resetMaterial(colour[i]);
         }
@@ -122,8 +122,8 @@ void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const
     {
         for (unsigned int i=0; i<points.size()/2; ++i)
         {
-            drawPoint(points[2*i]  , colour );
-            drawPoint(points[2*i+1], colour );
+            internalDrawPoint(points[2*i]  , colour );
+            internalDrawPoint(points[2*i+1], colour );
         }
     } glEnd();
     if (getLightEnabled()) glEnable(GL_LIGHTING);
@@ -140,8 +140,8 @@ void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const
         for (unsigned int i=0; i<points.size()/2; ++i)
         {
             setMaterial(colours[i]);
-            drawPoint(points[2*i]  , colours[i] );
-            drawPoint(points[2*i+1], colours[i] );
+            internalDrawPoint(points[2*i]  , colours[i] );
+            internalDrawPoint(points[2*i+1], colours[i] );
             resetMaterial(colours[i]);
         }
     } glEnd();
@@ -160,8 +160,8 @@ void DrawToolGL::drawLines(const std::vector<Vector3> &points, const std::vector
     {
         for (unsigned int i=0; i<index.size(); ++i)
         {
-            drawPoint(points[ index[i][0] ], colour );
-            drawPoint(points[ index[i][1] ], colour );
+            internalDrawPoint(points[ index[i][0] ], colour );
+            internalDrawPoint(points[ index[i][1] ], colour );
         }
     } glEnd();
     if (getLightEnabled()) glEnable(GL_LIGHTING);
@@ -180,7 +180,7 @@ void DrawToolGL::drawLineStrip(const std::vector<Vector3> &points, float size, c
     {
         for (unsigned int i=0; i<points.size(); ++i)
         {
-            drawPoint(points[i]  , colour );
+            internalDrawPoint(points[i]  , colour );
         }
     } glEnd();
     if (getLightEnabled()) glEnable(GL_LIGHTING);
@@ -266,9 +266,9 @@ void DrawToolGL::drawTriangles(const std::vector<Vector3> &points,
                 Vector3 n = cross((b-a),(c-a));
                 n.normalize();
 
-                drawPoint(a,n,colour[3*i+0]);
-                drawPoint(b,n,colour[3*i+1]);
-                drawPoint(c,n,colour[3*i+2]);
+                internalDrawPoint(a,n,colour[3*i+0]);
+                internalDrawPoint(b,n,colour[3*i+1]);
+                internalDrawPoint(c,n,colour[3*i+2]);
 
             }
         }
@@ -590,7 +590,7 @@ void DrawToolGL::drawPlus ( const float& radius, const Vec<4,float>& colour, con
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void DrawToolGL::drawPoint(const Vector3 &p, const Vec<4,float> &c)
+void DrawToolGL::internalDrawPoint(const Vector3 &p, const Vec<4,float> &c)
 {
 #ifdef PS3
     // bit of a hack we force to enter our emulation of draw immediate
@@ -602,9 +602,7 @@ void DrawToolGL::drawPoint(const Vector3 &p, const Vec<4,float> &c)
     glVertexNv<3>(p.ptr());
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-void DrawToolGL::drawPoint(const Vector3 &p, const Vector3 &n, const Vec<4,float> &c)
+void DrawToolGL::internalDrawPoint(const Vector3 &p, const Vector3 &n, const Vec<4,float> &c)
 {
 #ifdef PS3
     // bit of a hack we force to enter our emulation of draw immediate
@@ -615,6 +613,23 @@ void DrawToolGL::drawPoint(const Vector3 &p, const Vector3 &n, const Vec<4,float
 #endif
     glNormalT(n);
     glVertexNv<3>(p.ptr());
+}
+
+
+void DrawToolGL::drawPoint(const Vector3 &p, const Vec<4,float> &c)
+{
+    glBegin(GL_POINTS);
+    internalDrawPoint(p,c);
+    glEnd();
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void DrawToolGL::drawPoint(const Vector3 &p, const Vector3 &n, const Vec<4,float> &c)
+{
+    glBegin(GL_POINTS);
+    internalDrawPoint(p, n, c);
+    glEnd();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
@@ -618,8 +618,7 @@ void DrawToolGL::drawPoint(const Vector3 &p, const Vector3 &n, const Vec<4,float
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-void DrawToolGL::drawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
+void DrawToolGL::internalDrawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
         const Vector3 &normal,
         const Vec<4,float> &c1, const Vec<4,float> &c2, const Vec<4,float> &c3)
 {
@@ -633,7 +632,7 @@ void DrawToolGL::drawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 
 }
 
 
-void DrawToolGL::drawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
+void DrawToolGL::internalDrawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
         const Vector3 &normal1, const Vector3 &normal2, const Vector3 &normal3,
         const Vec<4,float> &c1, const Vec<4,float> &c2, const Vec<4,float> &c3)
 {
@@ -649,7 +648,7 @@ void DrawToolGL::drawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 
 }
 
 
-void DrawToolGL::drawTriangle( const Vector3 &p1, const Vector3 &p2, const Vector3 &p3,
+void DrawToolGL::internalDrawTriangle( const Vector3 &p1, const Vector3 &p2, const Vector3 &p3,
         const Vector3 &normal, const  Vec<4,float> &c)
 {
     glNormalT(normal);
@@ -660,7 +659,7 @@ void DrawToolGL::drawTriangle( const Vector3 &p1, const Vector3 &p2, const Vecto
 }
 
 
-void DrawToolGL::drawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
+void DrawToolGL::internalDrawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
         const Vector3 &normal)
 {
     glNormalT(normal);
@@ -668,6 +667,44 @@ void DrawToolGL::drawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 
     glVertexNv<3>(p2.ptr());
     glVertexNv<3>(p3.ptr());
 }
+
+void DrawToolGL::drawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
+        const Vector3 &normal,
+        const Vec<4,float> &c1, const Vec<4,float> &c2, const Vec<4,float> &c3)
+{
+    glBegin(GL_TRIANGLES);
+    internalDrawTriangle(p1, p2, p3, normal, c1, c2, c3);
+    glEnd();
+}
+
+
+void DrawToolGL::drawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
+        const Vector3 &normal1, const Vector3 &normal2, const Vector3 &normal3,
+        const Vec<4,float> &c1, const Vec<4,float> &c2, const Vec<4,float> &c3)
+{
+    glBegin(GL_TRIANGLES);
+    internalDrawTriangle(p1, p2, p3, normal1, normal2, normal3, c1, c2, c3);
+    glEnd();
+}
+
+
+void DrawToolGL::drawTriangle( const Vector3 &p1, const Vector3 &p2, const Vector3 &p3,
+        const Vector3 &normal, const  Vec<4,float> &c)
+{
+    glBegin(GL_TRIANGLES);
+    internalDrawTriangle(p1, p2, p3, normal, c);
+    glEnd();
+}
+
+
+void DrawToolGL::drawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
+        const Vector3 &normal)
+{
+    glBegin(GL_TRIANGLES);
+    internalDrawTriangle(p1, p2, p3, normal);
+    glEnd();
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void DrawToolGL::internalDrawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,const Vector3 &p4,
         const Vector3 &normal)

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
@@ -669,10 +669,30 @@ void DrawToolGL::drawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 
     glVertexNv<3>(p3.ptr());
 }
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void DrawToolGL::internalDrawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,const Vector3 &p4,
+        const Vector3 &normal)
+{
+    glNormalT(normal);
+    glVertexNv<3>(p1.ptr());
+    glVertexNv<3>(p2.ptr());
+    glVertexNv<3>(p3.ptr());
+    glVertexNv<3>(p4.ptr());
+}
 
-void DrawToolGL::drawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,const Vector3 &p4,
+void DrawToolGL::internalDrawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,const Vector3 &p4,
+        const Vector3 &normal, const Vec4f &c)
+{
+    glNormalT(normal);
+    glColor4fv(c.ptr());
+    glVertexNv<3>(p1.ptr());
+    glVertexNv<3>(p2.ptr());
+    glVertexNv<3>(p3.ptr());
+    glVertexNv<3>(p4.ptr());
+}
+
+void DrawToolGL::internalDrawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,const Vector3 &p4,
         const Vector3 &normal,
-        const Vec<4,float> &c1, const Vec<4,float> &c2, const Vec<4,float> &c3, const Vec<4,float> &c4)
+        const Vec4f &c1, const Vec4f &c2, const Vec4f &c3, const Vec4f &c4)
 {
     glNormalT(normal);
     glColor4fv(c1.ptr());
@@ -685,10 +705,9 @@ void DrawToolGL::drawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
     glVertexNv<3>(p4.ptr());
 }
 
-
-void DrawToolGL::drawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,const Vector3 &p4,
+void DrawToolGL::internalDrawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,const Vector3 &p4,
         const Vector3 &normal1, const Vector3 &normal2, const Vector3 &normal3, const Vector3 &normal4,
-        const Vec<4,float> &c1, const Vec<4,float> &c2, const Vec<4,float> &c3, const Vec<4,float> &c4)
+        const Vec4f &c1, const Vec4f &c2, const Vec4f &c3, const Vec4f &c4)
 {
     glNormalT(normal1);
     glColor4fv(c1.ptr());
@@ -705,26 +724,41 @@ void DrawToolGL::drawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
 }
 
 
+void DrawToolGL::drawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,const Vector3 &p4,
+        const Vector3 &normal,
+        const Vec<4,float> &c1, const Vec<4,float> &c2, const Vec<4,float> &c3, const Vec<4,float> &c4)
+{
+    glBegin(GL_QUADS);
+    internalDrawQuad(p1, p2, p3, p4, normal, c1, c2, c3, c4);
+    glEnd();
+}
+
+
+void DrawToolGL::drawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,const Vector3 &p4,
+        const Vector3 &normal1, const Vector3 &normal2, const Vector3 &normal3, const Vector3 &normal4,
+        const Vec<4,float> &c1, const Vec<4,float> &c2, const Vec<4,float> &c3, const Vec<4,float> &c4)
+{
+    glBegin(GL_QUADS);
+    internalDrawQuad(p1, p2, p3, p4, normal1, normal2, normal3, normal4, c1, c2, c3, c4);
+    glEnd();
+}
+
+
 void DrawToolGL::drawQuad( const Vector3 &p1, const Vector3 &p2, const Vector3 &p3,const Vector3 &p4,
         const Vector3 &normal, const  Vec<4,float> &c)
 {
-    glNormalT(normal);
-    glColor4fv(c.ptr());
-    glVertexNv<3>(p1.ptr());
-    glVertexNv<3>(p2.ptr());
-    glVertexNv<3>(p3.ptr());
-    glVertexNv<3>(p4.ptr());
+    glBegin(GL_QUADS);
+    internalDrawQuad(p1, p2, p3, p4, normal, c);
+    glEnd();
 }
 
 
 void DrawToolGL::drawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,const Vector3 &p4,
         const Vector3 &normal)
 {
-    glNormalT(normal);
-    glVertexNv<3>(p1.ptr());
-    glVertexNv<3>(p2.ptr());
-    glVertexNv<3>(p3.ptr());
-    glVertexNv<3>(p4.ptr());
+    glBegin(GL_QUADS);
+    internalDrawQuad(p1, p2, p3, p4, normal);
+    glEnd();
 }
 
 void DrawToolGL::drawQuads(const std::vector<Vector3> &points, const Vec4f& colour)
@@ -740,7 +774,7 @@ void DrawToolGL::drawQuads(const std::vector<Vector3> &points, const Vec4f& colo
             const Vector3& d = points[ 4*i+3 ];
             Vector3 n = cross((b-a),(c-a));
             n.normalize();
-            drawQuad(a,b,c,d,n,colour);
+            internalDrawQuad(a,b,c,d,n,colour);
         }
     } glEnd();
     resetMaterial(colour);

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.h
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.h
@@ -61,6 +61,7 @@ public:
     virtual void drawPoints(const std::vector<Vector3> &points, float size,  const Vec4f& colour);
     virtual void drawPoints(const std::vector<Vector3> &points, float size, const std::vector<Vec4f>& colour);
 
+    virtual void drawLine(const Vector3 &p1, const Vector3 &p2, const Vec4f& colour);
     virtual void drawLines(const std::vector<Vector3> &points, float size, const Vec4f& colour);
     virtual void drawLines(const std::vector<Vector3> &points, float size, const std::vector<Vec4f>& colours);
     virtual void drawLines(const std::vector<Vector3> &points, const std::vector< Vec2i > &index, float size, const Vec4f& colour);
@@ -188,6 +189,8 @@ protected:
     // utility functions, defining primitives
     virtual void internalDrawPoint(const Vector3 &p, const Vec4f &c);
     virtual void internalDrawPoint(const Vector3 &p, const Vector3 &n, const Vec4f &c);
+
+    virtual void internalDrawLine(const Vector3 &p1, const Vector3 &p2, const Vec4f& colour);
 
     virtual void internalDrawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
             const Vector3 &normal);

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.h
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.h
@@ -55,6 +55,9 @@ public:
 
     virtual void init();
 
+    virtual void drawPoint(const Vector3 &p, const Vec4f &c);
+    //normal on a point is useless
+    virtual void drawPoint(const Vector3 &p, const Vector3 &n, const Vec4f &c);
     virtual void drawPoints(const std::vector<Vector3> &points, float size,  const Vec4f& colour);
     virtual void drawPoints(const std::vector<Vector3> &points, float size, const std::vector<Vec4f>& colour);
 
@@ -114,9 +117,6 @@ public:
     virtual void drawCross(const Vector3&p, float length, const Vec4f& colour);
 
     virtual void drawPlus    (const float& radius, const Vec4f& colour, const int& subd=16);
-
-    virtual void drawPoint(const Vector3 &p, const Vec4f &c);
-    virtual void drawPoint(const Vector3 &p, const Vector3 &n, const Vec4f &c);
 
     virtual void drawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,const Vector3 &p4,
             const Vector3 &normal);
@@ -186,6 +186,9 @@ protected:
     helper::gl::BasicShapesGL_FakeSphere<Vector3> m_fakeSphereUtil;
 
     // utility functions, defining primitives
+    virtual void internalDrawPoint(const Vector3 &p, const Vec4f &c);
+    virtual void internalDrawPoint(const Vector3 &p, const Vector3 &n, const Vec4f &c);
+
     virtual void internalDrawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
             const Vector3 &normal);
     virtual void internalDrawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.h
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.h
@@ -64,6 +64,16 @@ public:
 
     virtual void drawLineStrip(const std::vector<Vector3> &points, float size, const Vec4f& colour);
 
+    virtual void drawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
+            const Vector3 &normal);
+    virtual void drawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
+            const Vector3 &normal, const Vec4f &c);
+    virtual void drawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
+            const Vector3 &normal,
+            const Vec4f &c1, const Vec4f &c2, const Vec4f &c3);
+    virtual void drawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
+            const Vector3 &normal1, const Vector3 &normal2, const Vector3 &normal3,
+            const Vec4f &c1, const Vec4f &c2, const Vec4f &c3);
     virtual void drawTriangles(const std::vector<Vector3> &points, const Vec4f& colour);
     virtual void drawTriangles(const std::vector<Vector3> &points, const Vector3& normal, const Vec4f& colour);
     virtual void drawTriangles(const std::vector<Vector3> &points,
@@ -107,17 +117,6 @@ public:
 
     virtual void drawPoint(const Vector3 &p, const Vec4f &c);
     virtual void drawPoint(const Vector3 &p, const Vector3 &n, const Vec4f &c);
-
-    virtual void drawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
-            const Vector3 &normal);
-    virtual void drawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
-            const Vector3 &normal, const Vec4f &c);
-    virtual void drawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
-            const Vector3 &normal,
-            const Vec4f &c1, const Vec4f &c2, const Vec4f &c3);
-    virtual void drawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
-            const Vector3 &normal1, const Vector3 &normal2, const Vector3 &normal3,
-            const Vec4f &c1, const Vec4f &c2, const Vec4f &c3);
 
     virtual void drawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,const Vector3 &p4,
             const Vector3 &normal);
@@ -187,6 +186,17 @@ protected:
     helper::gl::BasicShapesGL_FakeSphere<Vector3> m_fakeSphereUtil;
 
     // utility functions, defining primitives
+    virtual void internalDrawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
+            const Vector3 &normal);
+    virtual void internalDrawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
+            const Vector3 &normal, const Vec4f &c);
+    virtual void internalDrawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
+            const Vector3 &normal,
+            const Vec4f &c1, const Vec4f &c2, const Vec4f &c3);
+    virtual void internalDrawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
+            const Vector3 &normal1, const Vector3 &normal2, const Vector3 &normal3,
+            const Vec4f &c1, const Vec4f &c2, const Vec4f &c3);
+
     virtual void internalDrawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,const Vector3 &p4,
             const Vector3 &normal);
     virtual void internalDrawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,const Vector3 &p4,

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.h
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.h
@@ -186,6 +186,18 @@ protected:
     helper::gl::BasicShapesGL_Sphere<Vector3> m_sphereUtil;
     helper::gl::BasicShapesGL_FakeSphere<Vector3> m_fakeSphereUtil;
 
+    // utility functions, defining primitives
+    virtual void internalDrawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,const Vector3 &p4,
+            const Vector3 &normal);
+    virtual void internalDrawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,const Vector3 &p4,
+            const Vector3 &normal, const Vec4f &c);
+    virtual void internalDrawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,const Vector3 &p4,
+            const Vector3 &normal,
+            const Vec4f &c1, const Vec4f &c2, const Vec4f &c3, const Vec4f &c4);
+    virtual void internalDrawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,const Vector3 &p4,
+            const Vector3 &normal1, const Vector3 &normal2, const Vector3 &normal3, const Vector3 &normal4,
+            const Vec4f &c1, const Vec4f &c2, const Vec4f &c3, const Vec4f &c4);
+
 public:
     // getter & setter
     virtual void setLightingEnabled(bool _isAnabled);

--- a/modules/SofaMiscMapping/ProjectionToPlaneMapping.inl
+++ b/modules/SofaMiscMapping/ProjectionToPlaneMapping.inl
@@ -174,12 +174,8 @@ void ProjectionToTargetPlaneMapping<TIn, TOut>::draw(const core::visual::VisualP
     helper::ReadAccessor< Data<OutVecCoord> > origins(f_origins);
     helper::ReadAccessor< Data<OutVecCoord> > normals(f_normals);
 
-#ifndef SOFA_NO_OPENGL
-    glPushAttrib(GL_LIGHTING_BIT);
-    glDisable(GL_LIGHTING);
-
-    glBegin(GL_QUADS);
-
+    vparams->drawTool()->saveLastState();
+    vparams->drawTool()->setLightingEnabled(false);
 
     size_t nb = std::max( normals.size(), origins.size() );
     for(unsigned i=0; i<nb; i++ )
@@ -198,10 +194,8 @@ void ProjectionToTargetPlaneMapping<TIn, TOut>::draw(const core::visual::VisualP
         vparams->drawTool()->drawQuad( o -t0*scale -t1*scale, o +t0*scale -t1*scale, o +t0*scale +t1*scale, o -t0*scale +t1*scale, n, color );
 
     }
-    glEnd();
 
-    glPopAttrib();
-#endif // SOFA_NO_OPENGL
+    vparams->drawTool()->restoreLastState();
 }
 
 
@@ -402,12 +396,8 @@ void ProjectionToPlaneMultiMapping<TIn, TOut>::draw(const core::visual::VisualPa
     const OutCoord& o = plane[0];
     OutCoord n = plane[1].normalized();
 
-#ifndef SOFA_NO_OPENGL
-    glPushAttrib(GL_LIGHTING_BIT);
-    glDisable(GL_LIGHTING);
-
-    glBegin(GL_QUADS);
-
+    vparams->drawTool()->saveLastState();
+    vparams->drawTool()->setLightingEnabled(false);
 
     OutCoord t0, t1;
 
@@ -420,11 +410,7 @@ void ProjectionToPlaneMultiMapping<TIn, TOut>::draw(const core::visual::VisualPa
 
     vparams->drawTool()->drawQuad( o -t0*scale -t1*scale, o +t0*scale -t1*scale, o +t0*scale +t1*scale, o -t0*scale +t1*scale, n, color );
 
-    glEnd();
-
-    glPopAttrib();
-#endif // SOFA_NO_OPENGL
-
+    vparams->drawTool()->restoreLastState();
 
     // normal
     helper::vector< defaulttype::Vector3 > points;

--- a/modules/SofaOpenglVisual/DataDisplay.cpp
+++ b/modules/SofaOpenglVisual/DataDisplay.cpp
@@ -340,7 +340,6 @@ void DataDisplay::drawVisual(const core::visual::VisualParams* vparams)
         helper::ColorMap::evaluator<Real> eval = colorMap->getEvaluator(min, max);
         // Just the points
         glPointSize(10);
-        glBegin(GL_POINTS);
         for (unsigned int i=0; i<x.size(); ++i)
         {
             Vec4f color = isnan(ptData[i])
@@ -348,7 +347,6 @@ void DataDisplay::drawVisual(const core::visual::VisualParams* vparams)
                 : defaulttype::RGBAColor::fromVec4(eval(ptData[i]));
             vparams->drawTool()->drawPoint(x[i], color);
         }
-        glEnd();
 
     } else if (bDrawPointData) {
         helper::ColorMap::evaluator<Real> eval = colorMap->getEvaluator(min, max);

--- a/modules/SofaOpenglVisual/DataDisplay.cpp
+++ b/modules/SofaOpenglVisual/DataDisplay.cpp
@@ -284,7 +284,6 @@ void DataDisplay::drawVisual(const core::visual::VisualParams* vparams)
         {
             glDisable( GL_LIGHTING );
             int nbQuads = topology->getNbQuads();
-            glBegin(GL_QUADS);
             for (int i=0; i<nbQuads; i++)
             {
                 Vec4f color = isnan(quadData[i])
@@ -296,7 +295,6 @@ void DataDisplay::drawVisual(const core::visual::VisualParams* vparams)
                     m_normals[ t[0] ], m_normals[ t[1] ], m_normals[ t[2] ], m_normals[ t[3] ],
                     color, color, color, color);
             }
-            glEnd();
         }
         else if( !pointQuadData.empty() )
         {

--- a/modules/SofaOpenglVisual/DataDisplay.cpp
+++ b/modules/SofaOpenglVisual/DataDisplay.cpp
@@ -231,7 +231,6 @@ void DataDisplay::drawVisual(const core::visual::VisualParams* vparams)
         {
             // Triangles
             int nbTriangles = topology->getNbTriangles();
-            glBegin(GL_TRIANGLES);
             for (int i=0; i<nbTriangles; i++)
             {
                 Vec4f color = isnan(triData[i])
@@ -243,7 +242,6 @@ void DataDisplay::drawVisual(const core::visual::VisualParams* vparams)
                     m_normals[ t[0] ], m_normals[ t[1] ], m_normals[ t[2] ],
                     color, color, color);
             }
-            glEnd();
         }
         else if( !pointTriData.empty() )
         {


### PR DESCRIPTION
Fix issue #7 

Summary: drawQuad needed a call to glBegin(GL_QUADS) to draw a quad, defeating the purpose to avoid to use explicitly OpenGL API. Same problem with drawTriangle and drawPoint,
I suppose  that these functions, at the beginning, was just needed to factorize OpenGL code (but still you needed to use OpenGL with it). 
Now that we remove the explicit calls, those functions should not be accessible outside.
But a few code in Sofa (and maybe plugins?) are using those calls to draw one primitive.

Finally, what have been done:
 - remove public visibility to those functions and rename it to internalDrawXXXX (where XXXX is point, triangle, quad)
 - keep the old calls to keep compatibility
 - add addLine to keep consistency with the other primitives.

I am wondering if in the future (or just right now), the drawXXX (drawing ONE primitive) should be removed and force users to use the drawXXXXs with a vector (and oblige user to build a std::vector with ONE primitive.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**