### PR TITLE
FIX compilation for LeapMotion plugin due to moved files

### DIFF
--- a/applications/plugins/LeapMotion/src/LeapMotionDriver.cpp
+++ b/applications/plugins/LeapMotion/src/LeapMotionDriver.cpp
@@ -24,7 +24,7 @@
 #ifdef SOFA_HAVE_BOOST
 #include <boost/thread/thread.hpp>
 #endif
-#include <SofaBaseVisual/VisualTransform.h>
+#include <SofaGeneralVisual/VisualTransform.h>
 #include <sofa/core/objectmodel/KeypressedEvent.h>
 #include <sofa/core/objectmodel/MouseEvent.h>
 

--- a/applications/plugins/LeapMotion/src/LeapMotionDriver.h
+++ b/applications/plugins/LeapMotion/src/LeapMotionDriver.h
@@ -21,7 +21,7 @@
 ******************************************************************************/
 
 #include <sofa/core/behavior/BaseController.h>
-#include <SofaOpenglVisual//OglModel.h>
+#include <SofaOpenglVisual/OglModel.h>
 #include <SofaUserInteraction/Controller.h>
 //#include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/visual/VisualParams.h>


### PR DESCRIPTION
VisualTransform moved from SofaBaseVisual to SofaGeneralVisual

ChangeLog:
- FIX: compilation LeapMotion plugin (issue since v16.12)


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
