### PR TITLE
[ImagePNG] FIX: Library linking in debug configuration under MSVS

### DIFF
--- a/SofaKernel/framework/sofa/helper/io/ImagePNG.cpp
+++ b/SofaKernel/framework/sofa/helper/io/ImagePNG.cpp
@@ -27,8 +27,13 @@
 #ifdef SOFA_HAVE_PNG
 #include <png.h>
 #ifdef _MSC_VER
+#ifdef _DEBUG
+#pragma comment(lib,"libpngd.lib")
+#pragma comment(lib,"zlibd.lib")
+#else
 #pragma comment(lib,"libpng.lib")
 #pragma comment(lib,"zlib.lib")
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
Libraries for debug configuration have suffix "d". For that reason release and
debug configurations must have different pragmas for linking libpng and zlib
under MSVS.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
