### PR TITLE
[SofaCUDA] FIX: NVCC flags for debug build on Windows

### DIFF
--- a/applications/plugins/SofaCUDA/SofaCUDANvccFlags.cmake
+++ b/applications/plugins/SofaCUDA/SofaCUDANvccFlags.cmake
@@ -5,6 +5,12 @@ if(NOT (${CUDA_NVCC_FLAGS} MATCHES ${TEMP_CUDA_FLAGS}))
 	    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -fPIC")
 	endif()
 endif()
+
 set(CUDA_NVCC_FLAGS_DEBUG "-g")
 set(CUDA_NVCC_FLAGS_RELEASE "-DNDEBUG")
+
+if (WIN32)
+	set(CUDA_NVCC_FLAGS_DEBUG "--compiler-options /MDd")
+endif (WIN32)
+
 unset(TEMP_CUDA_FLAGS)


### PR DESCRIPTION
Targets are built with debug version of runtime library in debug configuration
under MS Visual Studio. This is enabled with /MDd compiler flag. Missing this
flag for NVCC generated object files results in linker fails due to different
versions of runtime libraries.

The problem is resolved by explicitly setting compiler options for debug build
under Windows. The solution is given only for Windows and only for MSVS because
it's the only officially supported by NVidia compiler on this platform.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
 