### PR TITLE
[runSofa] autoload plugins (2nd version)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Adds a new orientedBox dataField in BoxROI so that we can use it to either defined AABoxes or OrientedBox
 - Minor improvement on the way warning/error message are presented to the users in runSofa. A single panel is now used instead of of two, it is always displayed, the Panel name also contains the number of message eg: "Messages(5)" 
 - The Graph view is now displaying the type of message they contains. 
+- [runSofa]
+    - Autoload plugins, described in the user-custom file 'plugin_list.conf' if present; else 'plugin_list.conf.default' containing all compiled plugins and generated automatically by CMake.
 
 **For developpers**
 - Add a Logger component that stores the history of messages into each sofa component. 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,9 +229,7 @@ option(SOFA_NINJA_BUILD_POOLS "Activate the Ninja build pools feature, to limit 
 ### Extlibs
 add_subdirectory(extlibs)
 
-
 ### Main Sofa subdirectories
-
 add_subdirectory(${SOFA_KERNEL_SOURCE_DIR}/SofaFramework)
 add_subdirectory(${SOFA_KERNEL_SOURCE_DIR}/SofaSimulation)
 if(SOFA_BUILD_TESTS)
@@ -310,6 +308,41 @@ if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/custom.cmake")
     include( "custom.cmake" )
 endif()
 
+# Generate default list of plugins (according to the options)
+get_property(_allTargets GLOBAL PROPERTY __GlobalTargetList__)
+get_property(_allTargetNames GLOBAL PROPERTY __GlobalTargetNameList__)
+
+list(LENGTH _allTargets nbTargets) 
+math(EXPR len "${nbTargets} - 1")
+
+set(_pluginPrefix "PLUGIN")
+foreach(counter RANGE ${len})
+    list(GET _allTargets ${counter} _target)
+    list(GET _allTargetNames ${counter} _targetName)
+    
+    string(SUBSTRING "${_targetName}" 0 6 _testPlugin)
+    if(${_testPlugin} MATCHES "${_pluginPrefix}.*")
+        if(${${_targetName}})
+            get_target_property(_version ${_target} VERSION )
+            if(${_version} MATCHES ".*NOTFOUND")
+                set(_version "NO_VERSION")
+            endif()
+            string(CONCAT _pluginConfig "${_pluginConfig}\n${_target} ${_version}")
+        endif()
+    endif()
+endforeach()
+message("Write Plugin list")
+set(_defaultConfigPluginFilePath ${CMAKE_CURRENT_BINARY_DIR}/bin/plugin_list.conf.default)
+FILE(WRITE ${_defaultConfigPluginFilePath} ${_pluginConfig})
+
+if (MSVC)
+    add_custom_target(do_always ALL 
+    COMMAND "${CMAKE_COMMAND}" -E copy "${_defaultConfigPluginFilePath}" "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/"
+)
+endif(MSVC)
+
+
+############
 
 # Install configuration:
 ## when installing, keep an eye on options/params/sources used for compilation
@@ -320,6 +353,7 @@ install(FILES "${CMAKE_SOURCE_DIR}/README.md" DESTINATION .)
 install(FILES "${CMAKE_SOURCE_DIR}/CHANGELOG.md" DESTINATION .)
 install(FILES "${CMAKE_SOURCE_DIR}/LICENSE.LGPL.txt" DESTINATION .)
 install(FILES "${CMAKE_SOURCE_DIR}/Authors.txt" DESTINATION .)
+install(FILES "${CMAKE_BINARY_DIR}/bin/plugin_list.conf.default" DESTINATION bin/)
 
 ## Create etc/installedSofa.ini: it contains the paths to share/ and examples/. Compare to the Sofa.ini in the
 ## build directory, this one contains relative paths to the installed resource directory.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,40 +308,6 @@ if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/custom.cmake")
     include( "custom.cmake" )
 endif()
 
-# Generate default list of plugins (according to the options)
-get_property(_allTargets GLOBAL PROPERTY __GlobalTargetList__)
-get_property(_allTargetNames GLOBAL PROPERTY __GlobalTargetNameList__)
-
-list(LENGTH _allTargets nbTargets) 
-math(EXPR len "${nbTargets} - 1")
-
-set(_pluginPrefix "PLUGIN")
-foreach(counter RANGE ${len})
-    list(GET _allTargets ${counter} _target)
-    list(GET _allTargetNames ${counter} _targetName)
-    
-    string(SUBSTRING "${_targetName}" 0 6 _testPlugin)
-    if(${_testPlugin} MATCHES "${_pluginPrefix}.*")
-        if(${${_targetName}})
-            get_target_property(_version ${_target} VERSION )
-            if(${_version} MATCHES ".*NOTFOUND")
-                set(_version "NO_VERSION")
-            endif()
-            string(CONCAT _pluginConfig "${_pluginConfig}\n${_target} ${_version}")
-        endif()
-    endif()
-endforeach()
-message("Write Plugin list")
-set(_defaultConfigPluginFilePath ${CMAKE_CURRENT_BINARY_DIR}/bin/plugin_list.conf.default)
-FILE(WRITE ${_defaultConfigPluginFilePath} ${_pluginConfig})
-
-if (MSVC)
-    add_custom_target(do_always ALL 
-    COMMAND "${CMAKE_COMMAND}" -E copy "${_defaultConfigPluginFilePath}" "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/"
-)
-endif(MSVC)
-
-
 ############
 
 # Install configuration:
@@ -353,7 +319,6 @@ install(FILES "${CMAKE_SOURCE_DIR}/README.md" DESTINATION .)
 install(FILES "${CMAKE_SOURCE_DIR}/CHANGELOG.md" DESTINATION .)
 install(FILES "${CMAKE_SOURCE_DIR}/LICENSE.LGPL.txt" DESTINATION .)
 install(FILES "${CMAKE_SOURCE_DIR}/Authors.txt" DESTINATION .)
-install(FILES "${CMAKE_BINARY_DIR}/bin/plugin_list.conf.default" DESTINATION bin/)
 
 ## Create etc/installedSofa.ini: it contains the paths to share/ and examples/. Compare to the Sofa.ini in the
 ## build directory, this one contains relative paths to the installed resource directory.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,7 +229,9 @@ option(SOFA_NINJA_BUILD_POOLS "Activate the Ninja build pools feature, to limit 
 ### Extlibs
 add_subdirectory(extlibs)
 
+
 ### Main Sofa subdirectories
+
 add_subdirectory(${SOFA_KERNEL_SOURCE_DIR}/SofaFramework)
 add_subdirectory(${SOFA_KERNEL_SOURCE_DIR}/SofaSimulation)
 if(SOFA_BUILD_TESTS)
@@ -308,7 +310,6 @@ if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/custom.cmake")
     include( "custom.cmake" )
 endif()
 
-############
 
 # Install configuration:
 ## when installing, keep an eye on options/params/sources used for compilation

--- a/SofaKernel/SofaFramework/SofaMacros.cmake
+++ b/SofaKernel/SofaFramework/SofaMacros.cmake
@@ -181,10 +181,11 @@ macro(sofa_add_generic directory name type)
             set_target_properties(${name} PROPERTIES FOLDER ${type}s) # IDE folder
             set_target_properties(${name} PROPERTIES DEBUG_POSTFIX "_d")
         endif()
+
+        set_property(GLOBAL APPEND PROPERTY __GlobalTargetList__ ${name})
+        set_property(GLOBAL APPEND PROPERTY __GlobalTargetNameList__ ${option})
     else()
-
         message("${type} ${name} (${CMAKE_CURRENT_LIST_DIR}/${directory}) does not exist and will be ignored.")
-
     endif()
 endmacro()
 

--- a/SofaKernel/framework/framework_test/helper/system/PluginManager_test.cpp
+++ b/SofaKernel/framework/framework_test/helper/system/PluginManager_test.cpp
@@ -69,10 +69,18 @@ struct PluginManager_test: public ::testing::Test
     void TearDown()
     {
         PluginManager&pm = PluginManager::getInstance();
-
         //empty loaded plugin(s)
-        for (PluginManager::PluginMap::iterator it = pm.getPluginMap().begin(); it != pm.getPluginMap().end(); it++)
-            ASSERT_TRUE(pm.unloadPlugin((*it).first));
+        std::vector<std::string> toDelete;
+        for (PluginManager::PluginMap::const_iterator it = pm.getPluginMap().begin(); it != pm.getPluginMap().end(); it++)
+        {
+            toDelete.push_back((*it).first);
+            //std::cout << pm.getPluginMap().size() << std::endl;
+            //std::cout << "Try to unload Plugin :" << (*it).first << std::endl;
+            //ASSERT_TRUE(pm.unloadPlugin((*it).first));
+        }
+
+        for(std::string p : toDelete)
+            ASSERT_TRUE(pm.unloadPlugin(p));
 
         ASSERT_EQ(pm.getPluginMap().size(), 0u);
     }
@@ -86,8 +94,11 @@ TEST_F(PluginManager_test, loadTestPluginByPath)
     std::string pluginPath = pluginDir + separator + prefix + pluginFileName + dotExt;
     std::string nonpluginPath = pluginDir + separator + prefix + nonpluginName + dotExt;
 
+    std::cout << pm.getPluginMap().size() << std::endl;
     ASSERT_TRUE(pm.loadPluginByPath(pluginPath));
+    std::cout << pm.getPluginMap().size() << std::endl;
     ASSERT_FALSE(pm.loadPluginByPath(nonpluginPath));
+    std::cout << pm.getPluginMap().size() << std::endl;
 
     ASSERT_GT(pm.findPlugin(pluginName).size(), 0u);
     ASSERT_EQ(pm.findPlugin(nonpluginName).size(), 0u);

--- a/SofaKernel/framework/sofa/helper/Utils.cpp
+++ b/SofaKernel/framework/sofa/helper/Utils.cpp
@@ -230,6 +230,20 @@ const std::string& Utils::getExecutableDirectory()
     return path;
 }
 
+
+const std::string& Utils::getPluginDirectory()
+{
+    static std::string pluginDir;
+
+#ifdef WIN32
+    pluginDir = helper::Utils::getExecutableDirectory();
+#else
+    pluginDir = helper::Utils::getSofaPathPrefix() + "/lib";
+#endif
+
+    return pluginDir;
+}
+
 static std::string computeSofaPathPrefix()
 {
     char* pathVar = getenv("SOFA_ROOT");

--- a/SofaKernel/framework/sofa/helper/Utils.h
+++ b/SofaKernel/framework/sofa/helper/Utils.h
@@ -72,6 +72,9 @@ static const std::string& getExecutablePath();
 /// @brief Get the path to the directory of the executable that is currently running.
 static const std::string& getExecutableDirectory();
 
+/// @brief Get the path where plugins are located
+static const std::string& getPluginDirectory();
+
 /// @brief Get the path to the "root" path of Sofa (i.e. the build directory or
 /// the installation prefix).
 ///

--- a/SofaKernel/framework/sofa/helper/fixed_array.h
+++ b/SofaKernel/framework/sofa/helper/fixed_array.h
@@ -499,7 +499,7 @@ inline fixed_array<T, 10> make_array(const T& v0, const T& v1, const T& v2, cons
 }
 
 #ifndef FIXED_ARRAY_CPP
-extern template class fixed_array<float, 4> ;
+extern template class SOFA_HELPER_API fixed_array<float, 4> ;
 #endif //
 
 } // namespace helper

--- a/SofaKernel/framework/sofa/helper/system/PluginManager.cpp
+++ b/SofaKernel/framework/sofa/helper/system/PluginManager.cpp
@@ -87,12 +87,18 @@ PluginManager::~PluginManager()
 void PluginManager::readFromIniFile(const std::string& path)
 {
     std::ifstream instream(path.c_str());
-    std::string pluginPath;
-
-    while(std::getline(instream,pluginPath))
+    std::string pluginPath, line, version;
+    while(std::getline(instream, line))
     {
+        if (line.empty()) continue;
+
+        std::istringstream is(line);
+        is >> pluginPath;
+        is >> version; // information not used for now
         if(loadPlugin(pluginPath))
+        {
             m_pluginMap[pluginPath].initExternalModule();
+        }
     }
     instream.close();
 }
@@ -104,7 +110,8 @@ void PluginManager::writeToIniFile(const std::string& path)
     for( iter = m_pluginMap.begin(); iter!=m_pluginMap.end(); ++iter)
     {
         const std::string& pluginPath = (iter->first);
-        outstream << pluginPath << "\n";
+        outstream << pluginPath << " ";
+        outstream << m_pluginMap[pluginPath].getModuleVersion() << "\n";
     }
     outstream.close();
 }

--- a/SofaKernel/framework/sofa/helper/system/PluginManager.cpp
+++ b/SofaKernel/framework/sofa/helper/system/PluginManager.cpp
@@ -94,7 +94,10 @@ void PluginManager::readFromIniFile(const std::string& path)
 
         std::istringstream is(line);
         is >> pluginPath;
-        is >> version; // information not used for now
+        if (is.eof())
+            msg_deprecated("PluginManager") << path << " file is using a deprecated syntax (version information missing). Please update it in the near future.";
+        else
+            is >> version; // information not used for now
         if(loadPlugin(pluginPath))
         {
             m_pluginMap[pluginPath].initExternalModule();

--- a/SofaKernel/framework/sofa/helper/types/fixed_array.cpp
+++ b/SofaKernel/framework/sofa/helper/types/fixed_array.cpp
@@ -31,7 +31,7 @@ namespace sofa
 namespace helper
 {
 
-template class fixed_array<float, 4>;
+template class SOFA_HELPER_API fixed_array<float, 4>;
 
 } // namespace helper
 } // namespace sofa

--- a/applications/projects/runSofa/CMakeLists.txt
+++ b/applications/projects/runSofa/CMakeLists.txt
@@ -48,6 +48,13 @@ if(SOFA_HAVE_GLUT)
 	target_compile_definitions(${PROJECT_NAME} PUBLIC "SOFA_HAVE_GLUT_GUI")
 endif()
 
+if(SOFA_BUILD_TESTS)
+    find_package(SofaTest QUIET)
+    if(SofaTest_FOUND)
+        add_subdirectory(runSofa_test)
+    endif()
+endif()
+
 if(APPLE AND RUNSOFA_INSTALL_AS_BUNDLE)
 	# set(CPACK_COMPONENTS_ALL BundlePack)
 	set_property(GLOBAL PROPERTY RUNSOFA_CPACK_COMPONENTS_ALL BundlePack)

--- a/applications/projects/runSofa/CMakeLists.txt
+++ b/applications/projects/runSofa/CMakeLists.txt
@@ -12,9 +12,15 @@ endif()
 find_package(SofaFramework) # to get SOFA_HAVE_GLUT
 
 include(cmake/GeneratePluginConfig.cmake)
+# if MSVC then plugins are located in bin/ instead of lib/ on Mac and Linux
+if(MSVC)
+	set(_pluginLocation "bin")
+else()
+	set(_pluginLocation "lib")
+endif()
 set(_configPluginFileName plugin_list.conf)
 set(_defaultConfigPluginFileName "${_configPluginFileName}.default")
-set(_defaultConfigPluginFilePath "${CMAKE_BINARY_DIR}/bin/${_defaultConfigPluginFileName}")
+set(_defaultConfigPluginFilePath "${CMAKE_BINARY_DIR}/${_pluginLocation}/${_defaultConfigPluginFileName}")
 sofa_generate_plugin_config(${_defaultConfigPluginFilePath})
 message("Write Plugin list at ${_defaultConfigPluginFilePath}")
 
@@ -50,5 +56,7 @@ else()
 	sofa_install_targets(SofaGui runSofa "")
 endif()
 
+# if MSVC then plugins are located in bin/ instead of lib/ on Mac and Linux
 
-install(FILES "${CMAKE_BINARY_DIR}/bin/plugin_list.conf.default" DESTINATION bin/)
+install(FILES "${_defaultConfigPluginFilePath}" DESTINATION ${_pluginLocation}/)
+

--- a/applications/projects/runSofa/CMakeLists.txt
+++ b/applications/projects/runSofa/CMakeLists.txt
@@ -11,6 +11,13 @@ endif()
 
 find_package(SofaFramework) # to get SOFA_HAVE_GLUT
 
+include(cmake/GeneratePluginConfig.cmake)
+set(_configPluginFileName plugin_list.conf)
+set(_defaultConfigPluginFileName "${_configPluginFileName}.default")
+set(_defaultConfigPluginFilePath "${CMAKE_BINARY_DIR}/bin/${_defaultConfigPluginFileName}")
+sofa_generate_plugin_config(${_defaultConfigPluginFilePath})
+message("Write Plugin list at ${_defaultConfigPluginFilePath}")
+
 if(APPLE)
 	set_source_files_properties(${RC_FILES} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
 endif()
@@ -25,6 +32,8 @@ if(APPLE)
 	set_target_properties( ${PROJECT_NAME} PROPERTIES MACOSX_BUNDLE_ICON_FILE "runSOFA.icns" )
 endif()
 
+target_compile_definitions(${PROJECT_NAME} PUBLIC "CONFIG_PLUGIN_FILENAME=${_configPluginFileName}")
+target_compile_definitions(${PROJECT_NAME} PUBLIC "DEFAULT_CONFIG_PLUGIN_FILENAME=${_defaultConfigPluginFileName}")
 target_link_libraries(${PROJECT_NAME} SofaComponentAdvanced SofaComponentMisc)
 target_link_libraries(${PROJECT_NAME} SofaSimulationGraph)
 target_link_libraries(${PROJECT_NAME} SofaGuiMain)
@@ -40,3 +49,6 @@ if(APPLE AND RUNSOFA_INSTALL_AS_BUNDLE)
 else()
 	sofa_install_targets(SofaGui runSofa "")
 endif()
+
+
+install(FILES "${CMAKE_BINARY_DIR}/bin/plugin_list.conf.default" DESTINATION bin/)

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -326,11 +326,7 @@ int main(int argc, char** argv)
 
 
     // Add the plugin directory to PluginRepository
-#ifdef WIN32
-    const string pluginDir = Utils::getExecutableDirectory();
-#else
-    const string pluginDir = Utils::getSofaPathPrefix() + "/lib";
-#endif
+    const std::string& pluginDir = Utils::getPluginDirectory();
     PluginRepository.addFirstPath(pluginDir);
 
     // Initialise paths
@@ -348,15 +344,15 @@ int main(int argc, char** argv)
 
     if (!noAutoloadPlugins)
     {
-        if (sofa::helper::system::DataRepository.findFile(configPluginPath))
+        if (DataRepository.findFile(configPluginPath))
         {
             msg_info("runSofa") << "Loading automatically plugin list in " << configPluginPath;
-            sofa::helper::system::PluginManager::getInstance().readFromIniFile(configPluginPath);
+            PluginManager::getInstance().readFromIniFile(configPluginPath);
         }
-        else if (sofa::helper::system::DataRepository.findFile(defaultConfigPluginPath))
+        else if (DataRepository.findFile(defaultConfigPluginPath))
         {
             msg_info("runSofa") << "Loading automatically plugin list in " << defaultConfigPluginPath;
-            sofa::helper::system::PluginManager::getInstance().readFromIniFile(defaultConfigPluginPath);
+            PluginManager::getInstance().readFromIniFile(defaultConfigPluginPath);
         }
         else
             msg_info("runSofa") << "No plugin list found. No plugin will be automatically loaded.";

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -339,11 +339,24 @@ int main(int argc, char** argv)
     for (unsigned int i=0; i<plugins.size(); i++)
         PluginManager::getInstance().loadPlugin(plugins[i]);
 
-    // to force loading plugin SofaPython if existing
+    std::string configPluginPath = pluginDir + "/plugin_list.conf";
+    std::string defaultConfigPluginPath = pluginDir + "/plugin_list.conf.default";
+
+    if (sofa::helper::system::DataRepository.findFile(configPluginPath))
     {
-        std::ostringstream no_error_message; // no to get an error on the console if SofaPython does not exist
-        sofa::helper::system::PluginManager::getInstance().loadPlugin("SofaPython",&no_error_message);
+        sofa::helper::system::PluginManager::getInstance().readFromIniFile(configPluginPath);
     }
+    else if (sofa::helper::system::DataRepository.findFile(defaultConfigPluginPath))
+    {
+        sofa::helper::system::PluginManager::getInstance().readFromIniFile(defaultConfigPluginPath);
+
+    }
+
+    //// to force loading plugin SofaPython if existing
+    //{
+    //    std::ostringstream no_error_message; // no to get an error on the console if SofaPython does not exist
+    //    sofa::helper::system::PluginManager::getInstance().loadPlugin("SofaPython",&no_error_message);
+    //}
 
     PluginManager::getInstance().init();
 

--- a/applications/projects/runSofa/cmake/GeneratePluginConfig.cmake
+++ b/applications/projects/runSofa/cmake/GeneratePluginConfig.cmake
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.1)
+
+macro(sofa_generate_plugin_config config_filename)
+	# Generate default list of plugins (according to the options)
+	get_property(_allTargets GLOBAL PROPERTY __GlobalTargetList__)
+	get_property(_allTargetNames GLOBAL PROPERTY __GlobalTargetNameList__)
+
+	list(LENGTH _allTargets nbTargets) 
+	math(EXPR len "${nbTargets} - 1")
+
+	set(_pluginPrefix "PLUGIN")
+	foreach(counter RANGE ${len})
+	    list(GET _allTargets ${counter} _target)
+	    list(GET _allTargetNames ${counter} _targetName)
+	    
+	    string(SUBSTRING "${_targetName}" 0 6 _testPlugin)
+	    if(${_testPlugin} MATCHES "${_pluginPrefix}.*")
+	        if(${${_targetName}})
+	            get_target_property(_version ${_target} VERSION )
+	            if(${_version} MATCHES ".*NOTFOUND")
+	                set(_version "NO_VERSION")
+	            endif()
+	            string(CONCAT _pluginConfig "${_pluginConfig}\n${_target} ${_version}")
+	        endif()
+	    endif()
+	endforeach()
+	FILE(WRITE ${config_filename} ${_pluginConfig})
+
+	# only useful for devs working directly with a build version (not installed)
+	# With Win/MVSC, we can only know $CONFIG at build time
+	if (MSVC)
+	    add_custom_target(do_always ALL 
+	    COMMAND "${CMAKE_COMMAND}" -E copy "${config_filename}" "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/"
+	)
+	endif(MSVC)
+
+endmacro()

--- a/applications/projects/runSofa/runSofa_test/CMakeLists.txt
+++ b/applications/projects/runSofa/runSofa_test/CMakeLists.txt
@@ -6,7 +6,6 @@ set(SOURCE_FILES
     runSofa_test.cpp
 )
 
-message("dsds ${PROJECT_NAME}")
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} )
 target_link_libraries(${PROJECT_NAME} SofaTest SofaGTestMain)
 

--- a/applications/projects/runSofa/runSofa_test/CMakeLists.txt
+++ b/applications/projects/runSofa/runSofa_test/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.1)
+project(runSofa_test)
+
+
+set(SOURCE_FILES
+    runSofa_test.cpp
+)
+
+message("dsds ${PROJECT_NAME}")
+add_executable(${PROJECT_NAME} ${SOURCE_FILES} )
+target_link_libraries(${PROJECT_NAME} SofaTest SofaGTestMain)
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/applications/projects/runSofa/runSofa_test/runSofa_test.cpp
+++ b/applications/projects/runSofa/runSofa_test/runSofa_test.cpp
@@ -32,9 +32,6 @@
 namespace sofa
 {
 
-
-
-
 class runSofa_test : public Sofa_test<>
 {
 protected:
@@ -74,16 +71,14 @@ TEST_F(runSofa_test, runSofa_autoload)
 {
     sofa::helper::system::PluginManager& pm = sofa::helper::system::PluginManager::getInstance();
 
-    ASSERT_EQ(pm.getPluginMap().size(), 0);
+    ASSERT_EQ(pm.getPluginMap().size(), 0U);
     pm.readFromIniFile(m_testConfigPluginPath);
     helper::system::PluginManager::getInstance().init();
-    ASSERT_GT(pm.getPluginMap().size(), 0);
+    ASSERT_GT(pm.getPluginMap().size(), 0U);
     const std::string pluginPath = pm.findPlugin(m_testPluginName);
-    ASSERT_GT(pluginPath.size(), 0);
+    ASSERT_GT(pluginPath.size(), 0U);
     sofa::helper::system::Plugin& p = pm.getPluginMap()[pluginPath];
     ASSERT_EQ(0, std::string(p.getModuleName()).compare(m_testPluginName));
-   
-
 }
 
 } // namespace sofa

--- a/applications/projects/runSofa/runSofa_test/runSofa_test.cpp
+++ b/applications/projects/runSofa/runSofa_test/runSofa_test.cpp
@@ -25,12 +25,15 @@
 #include <SofaTest/Sofa_test.h>
 
 #include <sofa/helper/Utils.h>
-#include <sofa/helper/Utils.h>
 #include <sofa/helper/system/PluginManager.h>
 #include <sofa/helper/system/FileRepository.h>
 
 namespace sofa
 {
+
+using sofa::helper::system::DataRepository;
+using sofa::helper::system::PluginRepository;
+using sofa::helper::system::PluginManager;
 
 class runSofa_test : public Sofa_test<>
 {
@@ -45,11 +48,8 @@ protected:
 
     void SetUp()
     {
-#ifdef WIN32
-        const std::string pluginDir = helper::Utils::getExecutableDirectory();
-#else
-        const std::string pluginDir = helper::Utils::getSofaPathPrefix() + "/lib";
-#endif
+        const std::string& pluginDir = helper::Utils::getPluginDirectory();
+
         m_testConfigPluginName = "test_plugin_list.conf";
         m_testConfigPluginPath = pluginDir + "/" + m_testConfigPluginName;
         m_testPluginName = "TestPlugin";
@@ -69,15 +69,15 @@ protected:
 
 TEST_F(runSofa_test, runSofa_autoload)
 {
-    sofa::helper::system::PluginManager& pm = sofa::helper::system::PluginManager::getInstance();
+    PluginManager& pm = PluginManager::getInstance();
 
     ASSERT_EQ(pm.getPluginMap().size(), 0U);
     pm.readFromIniFile(m_testConfigPluginPath);
-    helper::system::PluginManager::getInstance().init();
+    PluginManager::getInstance().init();
     ASSERT_GT(pm.getPluginMap().size(), 0U);
     const std::string pluginPath = pm.findPlugin(m_testPluginName);
     ASSERT_GT(pluginPath.size(), 0U);
-    sofa::helper::system::Plugin& p = pm.getPluginMap()[pluginPath];
+    helper::system::Plugin& p = pm.getPluginMap()[pluginPath];
     ASSERT_EQ(0, std::string(p.getModuleName()).compare(m_testPluginName));
 }
 

--- a/applications/projects/runSofa/runSofa_test/runSofa_test.cpp
+++ b/applications/projects/runSofa/runSofa_test/runSofa_test.cpp
@@ -1,0 +1,89 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU General Public License as published by the Free  *
+* Software Foundation; either version 2 of the License, or (at your option)   *
+* any later version.                                                          *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for    *
+* more details.                                                               *
+*                                                                             *
+* You should have received a copy of the GNU General Public License along     *
+* with this program. If not, see <http://www.gnu.org/licenses/>.              *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <fstream>
+#include <gtest/gtest.h>
+#include <SofaTest/Sofa_test.h>
+
+#include <sofa/helper/Utils.h>
+#include <sofa/helper/Utils.h>
+#include <sofa/helper/system/PluginManager.h>
+#include <sofa/helper/system/FileRepository.h>
+
+namespace sofa
+{
+
+
+
+
+class runSofa_test : public Sofa_test<>
+{
+protected:
+    std::string m_testConfigPluginName;
+    std::string m_testConfigPluginPath;
+    std::string m_testPluginName;
+
+    runSofa_test() {
+
+    }
+
+    void SetUp()
+    {
+#ifdef WIN32
+        const std::string pluginDir = helper::Utils::getExecutableDirectory();
+#else
+        const std::string pluginDir = helper::Utils::getSofaPathPrefix() + "/lib";
+#endif
+        m_testConfigPluginName = "test_plugin_list.conf";
+        m_testConfigPluginPath = pluginDir + "/" + m_testConfigPluginName;
+        m_testPluginName = "TestPlugin";
+        
+        //generate on the fly test list
+        std::ofstream testPluginList;
+        testPluginList.open(m_testConfigPluginPath);
+        testPluginList << m_testPluginName << std::endl;
+        testPluginList.close();
+    }
+    void TearDown()
+    {
+
+    }
+    
+};
+
+TEST_F(runSofa_test, runSofa_autoload)
+{
+    sofa::helper::system::PluginManager& pm = sofa::helper::system::PluginManager::getInstance();
+
+    ASSERT_EQ(pm.getPluginMap().size(), 0);
+    pm.readFromIniFile(m_testConfigPluginPath);
+    helper::system::PluginManager::getInstance().init();
+    ASSERT_GT(pm.getPluginMap().size(), 0);
+    const std::string pluginPath = pm.findPlugin(m_testPluginName);
+    ASSERT_GT(pluginPath.size(), 0);
+    sofa::helper::system::Plugin& p = pm.getPluginMap()[pluginPath];
+    ASSERT_EQ(0, std::string(p.getModuleName()).compare(m_testPluginName));
+   
+
+}
+
+} // namespace sofa


### PR DESCRIPTION
Implementation of the (2nd part of) proposal #281  .

Quick Reminder:
 - CMake generates the list of compiled plugins in a file (`plugin_list.conf.default`) at  the configuration stage.
 - runSofa loads this list at startup
 - if the user creates a custom `plugin_list.conf`, it will load this list instead.
 - add an option to bypass the file (thus disable automatic loading) in runSofa.

Everything is done in the runSofa application (+small patch in the macro sofa_add_generic() in SofaFramework CMake modules ; that allows us to have a list of all added targets which is not possible in CMake 3.1) .

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
