### PR TITLE
[all] Fix rgbacolor parsing

### DIFF
--- a/SofaKernel/framework/framework_test/CMakeLists.txt
+++ b/SofaKernel/framework/framework_test/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SOURCE_FILES
     defaulttype/MatTypes_test.cpp
     defaulttype/VecTypes_test.cpp
     helper/types/Color_test.cpp
+    helper/types/Material_test.cpp
     helper/KdTree_test.cpp
     helper/Utils_test.cpp
     helper/Quater_test.cpp

--- a/SofaKernel/framework/framework_test/helper/types/Material_test.cpp
+++ b/SofaKernel/framework/framework_test/helper/types/Material_test.cpp
@@ -19,32 +19,71 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_CORE_LOADER_MATERIAL_H_
-#define SOFA_CORE_LOADER_MATERIAL_H_
+#include <sstream>
+using std::stringstream ;
+
+#include <string>
+using std::string ;
+
+#include <sofa/core/objectmodel/Base.h>
+using sofa::core::objectmodel::Data ;
 
 #include <sofa/helper/types/Material.h>
-
-namespace sofa
-{
-
-namespace core
-{
-
-namespace loader
-{
-
-///The Material object that was previously in this sofa::core::loader is now in sofa::helper:types::Material.
-///The following lines is there to provide backward compatibility with existing code base.
-///This is just there for a transitional period of time and will be removed after 2018-01-07
 using sofa::helper::types::Material ;
 
-//TODO(dmarchal 2017-06-13): Delete that around 2018-01-07
+#include <SofaTest/Sofa_test.h>
+using sofa::Sofa_test ;
+
+namespace sofa {
+
+class Material_test : public Sofa_test<>
+{
+public:
+
+    void checkConstructor()
+    {
+        Material m;
+        EXPECT_FALSE( m.activated );
+        EXPECT_TRUE( m.useAmbient );
+        EXPECT_TRUE( m.useDiffuse );
+        EXPECT_FALSE( m.useSpecular );
+        EXPECT_FALSE( m.useEmissive );
+        EXPECT_FALSE( m.useShininess );
+        EXPECT_FALSE( m.useTexture );
+        EXPECT_FALSE( m.useBumpMapping );
+    }
+
+    void checkDataRead(const std::string& testmat)
+    {
+        Material m1;
+        m1.name = "notdefault" ;
+        EXPECT_EQ( m1.name, "notdefault" ) ;
+
+        Data<Material> m;
+        m.setValue(m1) ;
+        EXPECT_EQ( m.getValue().name, "notdefault" ) ;
+
+        m.read( testmat );
+        EXPECT_EQ( m.getValue().name, "sofa_logo" ) ;
+        EXPECT_TRUE( m.getValue().useAmbient ) ;
+        EXPECT_TRUE( m.getValue().useDiffuse ) ;
+        EXPECT_TRUE( m.getValue().useSpecular ) ;
+        EXPECT_TRUE( m.getValue().useShininess ) ;
+        EXPECT_FALSE( m.getValue().useEmissive ) ;
+        EXPECT_EQ( m.getValueString(), testmat ) ;
+    }
+};
+
+TEST_F(Material_test, checkConstructor)
+{
+        checkConstructor();
+}
+
+TEST_F(Material_test, checkDataRead)
+{
+        checkDataRead("sofa_logo Diffuse 1 0.3 0.18 0.05 1 Ambient 1 0.05 0.02 0 1 Specular 1 1 1 1 1 Emissive 0 0 0 0 0 Shininess 1 1000 ");
+}
 
 
-} // namespace loader
 
-} // namespace core
-
-} // namespace sofa
-
-#endif /* SOFA_CORE_LOADER_MATERIAL_H_ */
+}// namespace sofa

--- a/SofaKernel/framework/sofa/helper/CMakeLists.txt
+++ b/SofaKernel/framework/sofa/helper/CMakeLists.txt
@@ -106,6 +106,7 @@ set(HEADER_FILES
     vector_algebra.h
     vector_device.h
     types/RGBAColor.h
+    types/Material.h
     logging/Messaging.h
     logging/Message.h
     logging/ComponentInfo.h
@@ -187,6 +188,7 @@ set(SOURCE_FILES
     vector.cpp
     types/fixed_array.cpp
     types/RGBAColor.cpp
+    types/Material.cpp
     logging/Message.cpp
     logging/MessageDispatcher.cpp
     logging/ComponentInfo.cpp

--- a/SofaKernel/framework/sofa/helper/types/Material.cpp
+++ b/SofaKernel/framework/sofa/helper/types/Material.cpp
@@ -1,0 +1,119 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *-
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/helper/types/Material.h>
+
+namespace sofa
+{
+
+namespace helper
+{
+
+namespace types
+{
+
+    void Material::setColor(float r, float g, float b, float a)
+    {
+        ambient = defaulttype::RGBAColor(r*0.2f,g*0.2f,b*0.2f,a);
+        diffuse = defaulttype::RGBAColor(r,g,b,a);
+        specular = defaulttype::RGBAColor(r,g,b,a);
+        emissive = defaulttype::RGBAColor(r,g,b,a);
+    }
+
+    std::ostream&  operator << (std::ostream& out, const Material& m )
+    {
+        out   << m.name         << " ";
+        out  << "Diffuse"       << " " <<  m.useDiffuse   << " " <<  m.diffuse      << " ";
+        out  << "Ambient"       << " " <<  m.useAmbient   << " " <<  m.ambient      << " ";
+        out  << "Specular"      << " " <<  m.useSpecular  << " " <<  m.specular     << " ";
+        out  << "Emissive"      << " " <<  m.useEmissive  << " " <<  m.emissive     << " ";
+        out  << "Shininess"     << " " <<  m.useShininess << " " <<  m.shininess   << " ";
+        return out;
+    }
+
+   std::istream& operator >> (std::istream& in, Material &m )
+    {
+        std::string element;
+        in  >>  m.name ;
+        for (unsigned int i=0; i<5; ++i)
+        {
+            in  >>  element;
+            if      (element == std::string("Diffuse")   || element == std::string("diffuse")   ) { in  >>  m.useDiffuse   ; in >> m.diffuse;   }
+            else if (element == std::string("Ambient")   || element == std::string("ambient")   ) { in  >>  m.useAmbient   ; in >> m.ambient;   }
+            else if (element == std::string("Specular")  || element == std::string("specular")  ) { in  >>  m.useSpecular  ; in >> m.specular;  }
+            else if (element == std::string("Emissive")  || element == std::string("emissive")  ) { in  >>  m.useEmissive  ; in >> m.emissive;  }
+            else if (element == std::string("Shininess") || element == std::string("shininess") ) { in  >>  m.useShininess ; in >> m.shininess; }
+        }
+        return in;
+    }
+
+     Material::Material()
+{
+    ambient =  defaulttype::RGBAColor( 0.2f,0.2f,0.2f,1.0f);
+    diffuse =  defaulttype::RGBAColor( 0.75f,0.75f,0.75f,1.0f);
+    specular =  defaulttype::RGBAColor( 1.0f,1.0f,1.0f,1.0f);
+    emissive =  defaulttype::RGBAColor( 0.0f,0.0f,0.0f,0.0f);
+
+    shininess =  45.0f;
+    name = "Default";
+    useAmbient =  true;
+    useDiffuse =  true;
+    useSpecular =  false;
+    useEmissive =  false;
+    useShininess =  false;
+    activated = false;
+
+    useTexture = false;
+    textureFilename ="DEFAULT";
+
+    useBumpMapping = false;
+    bumpTextureFilename ="DEFAULT";
+}
+
+Material::Material(const Material& mat)
+{
+    ambient =  mat.ambient;
+    diffuse =  mat.diffuse;
+    specular =  mat.specular;
+    emissive =  mat.emissive;
+
+    shininess =  mat.shininess;
+    name = mat.name;
+    useAmbient =  mat.useAmbient;
+    useDiffuse =  mat.useDiffuse ;
+    useSpecular =  mat.useSpecular ;
+    useEmissive =  mat.useEmissive;
+    useShininess =  mat.useShininess ;
+    activated = mat.activated;
+
+    useTexture = mat.useTexture;
+    textureFilename = mat.textureFilename;
+
+    useBumpMapping = mat.useBumpMapping;
+    bumpTextureFilename = mat.bumpTextureFilename;
+}
+
+} // namespace loader
+
+} // namespace core
+
+} // namespace sofa
+

--- a/SofaKernel/framework/sofa/helper/types/Material.cpp
+++ b/SofaKernel/framework/sofa/helper/types/Material.cpp
@@ -38,7 +38,7 @@ namespace types
         emissive = defaulttype::RGBAColor(r,g,b,a);
     }
 
-    std::ostream&  operator << (std::ostream& out, const Material& m )
+    std::ostream& SOFA_HELPER_API operator << (std::ostream& out, const Material& m )
     {
         out   << m.name         << " ";
         out  << "Diffuse"       << " " <<  m.useDiffuse   << " " <<  m.diffuse      << " ";
@@ -49,7 +49,7 @@ namespace types
         return out;
     }
 
-   std::istream& operator >> (std::istream& in, Material &m )
+   std::istream& SOFA_HELPER_API operator >> (std::istream& in, Material &m )
     {
         std::string element;
         in  >>  m.name ;

--- a/SofaKernel/framework/sofa/helper/types/Material.cpp
+++ b/SofaKernel/framework/sofa/helper/types/Material.cpp
@@ -38,7 +38,7 @@ namespace types
         emissive = defaulttype::RGBAColor(r,g,b,a);
     }
 
-    std::ostream& SOFA_HELPER_API operator << (std::ostream& out, const Material& m )
+    SOFA_HELPER_API std::ostream&  operator << (std::ostream& out, const Material& m )
     {
         out   << m.name         << " ";
         out  << "Diffuse"       << " " <<  m.useDiffuse   << " " <<  m.diffuse      << " ";
@@ -49,7 +49,7 @@ namespace types
         return out;
     }
 
-   std::istream& SOFA_HELPER_API operator >> (std::istream& in, Material &m )
+    SOFA_HELPER_API std::istream&  operator >> (std::istream& in, Material &m )
     {
         std::string element;
         in  >>  m.name ;

--- a/SofaKernel/framework/sofa/helper/types/Material.h
+++ b/SofaKernel/framework/sofa/helper/types/Material.h
@@ -37,7 +37,7 @@ namespace helper
 namespace types
 {
 
-class Material
+class SOFA_HELPER_API Material
 {
 public:
     std::string 	name;		        /* name of material */
@@ -59,8 +59,8 @@ public:
 
     void setColor(float r, float g, float b, float a) ;
 
-    friend std::ostream& operator << (std::ostream& out, const Material& m ) ;
-    friend std::istream& operator >> (std::istream& in, Material &m ) ;
+    friend SOFA_HELPER_API std::ostream& operator << (std::ostream& out, const Material& m ) ;
+    friend SOFA_HELPER_API std::istream& operator >> (std::istream& in, Material &m ) ;
     Material() ;
     Material(const Material& mat) ;
 };

--- a/SofaKernel/framework/sofa/helper/types/Material.h
+++ b/SofaKernel/framework/sofa/helper/types/Material.h
@@ -19,32 +19,56 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_CORE_LOADER_MATERIAL_H_
-#define SOFA_CORE_LOADER_MATERIAL_H_
 
-#include <sofa/helper/types/Material.h>
+#ifndef SOFA_HELPER_TYPES_MATERIAL_H_
+#define SOFA_HELPER_TYPES_MATERIAL_H_
+
+#include <sofa/core/core.h>
+#include <sofa/defaulttype/RGBAColor.h>
+#include <sofa/core/objectmodel/DataFileName.h>
+#include <sofa/helper/system/FileRepository.h>
 
 namespace sofa
 {
 
-namespace core
+namespace helper
 {
 
-namespace loader
+namespace types
 {
 
-///The Material object that was previously in this sofa::core::loader is now in sofa::helper:types::Material.
-///The following lines is there to provide backward compatibility with existing code base.
-///This is just there for a transitional period of time and will be removed after 2018-01-07
-using sofa::helper::types::Material ;
+class Material
+{
+public:
+    std::string 	name;		        /* name of material */
+    defaulttype::RGBAColor  diffuse ;	/* diffuse component */
+    defaulttype::RGBAColor  ambient ;	/* ambient component */
+    defaulttype::RGBAColor  specular;	/* specular component */
+    defaulttype::RGBAColor  emissive;	/* emmissive component */
+    float  shininess;	                /* specular exponent */
+    bool   useDiffuse;
+    bool   useSpecular;
+    bool   useAmbient;
+    bool   useEmissive;
+    bool   useShininess;
+    bool   useTexture;
+    bool   useBumpMapping;
+    bool   activated;
+    std::string   textureFilename; // path to the texture linked to the material
+    std::string   bumpTextureFilename; // path to the bump texture linked to the material
 
-//TODO(dmarchal 2017-06-13): Delete that around 2018-01-07
+    void setColor(float r, float g, float b, float a) ;
 
+    friend std::ostream& operator << (std::ostream& out, const Material& m ) ;
+    friend std::istream& operator >> (std::istream& in, Material &m ) ;
+    Material() ;
+    Material(const Material& mat) ;
+};
 
-} // namespace loader
+} // namespace types
 
-} // namespace core
+} // namespace helper
 
 } // namespace sofa
 
-#endif /* SOFA_CORE_LOADER_MATERIAL_H_ */
+#endif /* SOFA_HELPER_TYPES_MATERIAL_H_ */

--- a/SofaKernel/framework/sofa/helper/types/RGBAColor.cpp
+++ b/SofaKernel/framework/sofa/helper/types/RGBAColor.cpp
@@ -48,33 +48,43 @@ static int hexval(char c)
     else return 0;
 }
 
-static bool isValidEncoding(const std::string& s)
-{
-    auto c = s.begin();
-    if( *c != '#' )
-        return false;
 
-    for( c++ ; c != s.end() ; ++c ){
-        if (*c>='0' && *c<='9') {}
-        else if (*c>='a' && *c<='f') {}
-        else if (*c>='A' && *c<='F') {}
-        else return false;
+static void extractValidatedHexaString(std::istream& in, std::string& s)
+{
+    s.reserve(9);
+    char c = in.get();
+
+    if(c!='#')
+    {
+        in.setstate(std::ios_base::failbit) ;
+        return;
     }
-    return true;
+
+    s.push_back(c);
+    while(in.get(c)){
+        if( !ishexsymbol(c) )
+            return;
+
+        s.push_back(c) ;
+        if(s.size()>9){
+            in.setstate(std::ios_base::failbit) ;
+            return ;
+        }
+    }
+    /// we need to reset the failbit because it is set by the get function
+    /// on the last character.
+    in.clear(in.rdstate() & ~std::ios_base::failbit) ;
 }
 
 
 RGBAColor::RGBAColor() : fixed_array<float, 4>(1,1,1,1)
 {
-
 }
 
 
 RGBAColor::RGBAColor(const fixed_array<float, 4>& c) : fixed_array<float, 4>(c)
 {
-
 }
-
 
 
 RGBAColor::RGBAColor(const float pr, const float pg, const float pb, const float pa)
@@ -84,6 +94,7 @@ RGBAColor::RGBAColor(const float pr, const float pg, const float pb, const float
     b(pb);
     a(pa);
 }
+
 
 bool RGBAColor::read(const std::string& str, RGBAColor& color)
 {
@@ -131,6 +142,7 @@ RGBAColor RGBAColor::fromVec4(const fixed_array<double, 4>& color)
     return RGBAColor(color[0], color[1], color[2], color[3]) ;
 }
 
+
 RGBAColor RGBAColor::fromHSVA(float h, float s, float v, float a )
 {
     // H [0, 360] S, V and A [0.0, 1.0].
@@ -162,35 +174,8 @@ RGBAColor RGBAColor::fromHSVA(float h, float s, float v, float a )
 }
 
 
-static void extractValidatedHexaString(std::istream& in, std::string& s)
-{
-    s.reserve(9);
-    char c = in.get();
-
-    if(c!='#')
-    {
-        in.setstate(std::ios_base::failbit) ;
-        return;
-    }
-
-    s.push_back(c);
-    while(in.get(c)){
-        if( !ishexsymbol(c) )
-            return;
-
-        s.push_back(c) ;
-        if(s.size()>9){
-            in.setstate(std::ios_base::failbit) ;
-            return ;
-        }
-    }
-    /// we need to reset the failbit because it is set by the get function
-    /// on the last character.
-    in.clear(in.rdstate() & ~std::ios_base::failbit) ;
-}
-
 /// This function remove the leading space in the stream.
-std::istream& trimInitialSpaces(std::istream& in)
+static std::istream& trimInitialSpaces(std::istream& in)
 {
     char first=in.peek();
     while(!in.eof() && !in.fail() && std::isspace(first, std::locale()))
@@ -200,6 +185,7 @@ std::istream& trimInitialSpaces(std::istream& in)
     }
     return in;
 }
+
 
 SOFA_HELPER_API std::istream& operator>>(std::istream& in, RGBAColor& t)
 {
@@ -276,6 +262,7 @@ SOFA_HELPER_API std::istream& operator>>(std::istream& in, RGBAColor& t)
     t.set(r,g,b,a) ;
     return in;
 }
+
 
 /// Write to an output stream
 SOFA_HELPER_API std::ostream& operator << ( std::ostream& out, const RGBAColor& v )

--- a/SofaKernel/framework/sofa/helper/types/RGBAColor.cpp
+++ b/SofaKernel/framework/sofa/helper/types/RGBAColor.cpp
@@ -26,6 +26,8 @@
 #include <sofa/helper/types/RGBAColor.h>
 #include <sofa/helper/logging/Messaging.h>
 #include <sstream>
+#include <locale>         // std::locale, std::isalnum
+
 namespace sofa
 {
 namespace helper
@@ -33,7 +35,12 @@ namespace helper
 namespace types
 {
 
-int hexval(char c)
+static bool ishexsymbol(char c)
+{
+    return (c>='0' && c<='9') || (c>='a' && c<='f') || (c>='A' && c<='F') ;
+}
+
+static int hexval(char c)
 {
     if (c>='0' && c<='9') return c-'0';
     else if (c>='a' && c<='f') return (c-'a')+10;
@@ -41,7 +48,7 @@ int hexval(char c)
     else return 0;
 }
 
-bool isValidEncoding(const std::string& s)
+static bool isValidEncoding(const std::string& s)
 {
     auto c = s.begin();
     if( *c != '#' )
@@ -78,68 +85,12 @@ RGBAColor::RGBAColor(const float pr, const float pg, const float pb, const float
     a(pa);
 }
 
-
 bool RGBAColor::read(const std::string& str, RGBAColor& color)
 {
-    if (str.empty())
-        return true;
-
-    float r,g,b,a=1.0;
-    if (str[0]>='0' && str[0]<='9')
-    {
-        std::istringstream iss(str);
-        iss >> r >> g >> b ;
-        if(iss.fail()){
-            return false;
-        }
-        if(!iss.eof()){
-            iss >> a;
-            if(iss.fail() || !iss.eof()){
-                return false;
-            }
-        }
-    }
-    else if (str[0]=='#' && str.length()>=7)
-    {
-        if(!isValidEncoding(str))
-            return false;
-
-        r = (hexval(str[1])*16+hexval(str[2]))/255.0f;
-        g = (hexval(str[3])*16+hexval(str[4]))/255.0f;
-        b = (hexval(str[5])*16+hexval(str[6]))/255.0f;
-        if (str.length()>=9)
-            a = (hexval(str[7])*16+hexval(str[8]))/255.0f;
-        if (str.length()>9)
-            return false;
-    }
-    else if (str[0]=='#' && str.length()>=4)
-    {
-        if(!isValidEncoding(str))
-            return false;
-
-        r = (hexval(str[1])*17)/255.0f;
-        g = (hexval(str[2])*17)/255.0f;
-        b = (hexval(str[3])*17)/255.0f;
-        if (str.length()>=5)
-            a = (hexval(str[4])*17)/255.0f;
-        if (str.length()>5)
-            return false;
-    }
-    /// If you add more colors... please also add them in the test file.
-    else if (str == "white")    { r = 1.0f; g = 1.0f; b = 1.0f; }
-    else if (str == "black")    { r = 0.0f; g = 0.0f; b = 0.0f; }
-    else if (str == "red")      { r = 1.0f; g = 0.0f; b = 0.0f; }
-    else if (str == "green")    { r = 0.0f; g = 1.0f; b = 0.0f; }
-    else if (str == "blue")     { r = 0.0f; g = 0.0f; b = 1.0f; }
-    else if (str == "cyan")     { r = 0.0f; g = 1.0f; b = 1.0f; }
-    else if (str == "magenta")  { r = 1.0f; g = 0.0f; b = 1.0f; }
-    else if (str == "yellow")   { r = 1.0f; g = 1.0f; b = 0.0f; }
-    else if (str == "gray")     { r = 0.5f; g = 0.5f; b = 0.5f; }
-    else {
-        return false ;
-    }
-
-    color.set(r,g,b,a) ;
+    std::stringstream s(str);
+    s >> color ;
+    if(s.fail() || !s.eof())
+        return false;
     return true ;
 }
 
@@ -210,15 +161,120 @@ RGBAColor RGBAColor::fromHSVA(float h, float s, float v, float a )
     return rgba;
 }
 
-SOFA_HELPER_API std::istream& operator>>(std::istream& i, RGBAColor& t)
+
+static void extractValidatedHexaString(std::istream& in, std::string& s)
 {
-    std::string s;
-    std::getline(i, s);
-    if(!RGBAColor::read(s, t)){
-        i.setstate(std::ios::failbit) ;
+    s.reserve(9);
+    char c = in.get();
+
+    if(c!='#')
+    {
+        in.setstate(std::ios_base::failbit) ;
+        return;
     }
 
-    return i;
+    s.push_back(c);
+    while(in.get(c)){
+        if( !ishexsymbol(c) )
+            return;
+
+        s.push_back(c) ;
+        if(s.size()>9){
+            in.setstate(std::ios_base::failbit) ;
+            return ;
+        }
+    }
+    /// we need to reset the failbit because it is set by the get function
+    /// on the last character.
+    in.clear(in.rdstate() & ~std::ios_base::failbit) ;
+}
+
+/// This function remove the leading space in the stream.
+std::istream& trimInitialSpaces(std::istream& in)
+{
+    char first=in.peek();
+    while(!in.eof() && !in.fail() && std::isspace(first, std::locale()))
+    {
+        in.get();
+        first=in.peek();
+    }
+    return in;
+}
+
+SOFA_HELPER_API std::istream& operator>>(std::istream& in, RGBAColor& t)
+{
+    float r=0.0,g=0.0, b=0.0, a=1.0;
+
+    trimInitialSpaces(in) ;
+
+    /// Let's remove the initial spaces.
+    if( in.eof() || in.fail() )
+        return in;
+
+    char first = in.peek() ;
+    if (std::isdigit(first, std::locale()))
+    {
+        in >> r >> g >> b ;
+        if(!in.eof()){
+            in >> a;
+        }
+    }
+    else if (first=='#')
+    {
+        std::string str;
+        extractValidatedHexaString(in, str) ;
+
+        if(in.fail()){
+            return in;
+        }
+
+        if(str.length()>=7){
+            r = (hexval(str[1])*16+hexval(str[2]))/255.0f;
+            g = (hexval(str[3])*16+hexval(str[4]))/255.0f;
+            b = (hexval(str[5])*16+hexval(str[6]))/255.0f;
+
+            if (str.length()>7)
+                a = (hexval(str[7])*16+hexval(str[8]))/255.0f;
+        }else if (str.length()>=4){
+            r = (hexval(str[1])*17)/255.0f;
+            g = (hexval(str[2])*17)/255.0f;
+            b = (hexval(str[3])*17)/255.0f;
+
+            if (str.length()>4)
+                a = (hexval(str[4])*17)/255.0f;
+        }else{
+            /// If we cannot parse the field we returns that with the fail bit.
+            in.setstate(std::ios_base::failbit) ;
+            return in;
+        }
+    } else {
+        std::string str;
+        /// Search for the first word, it is not needed to read more char than size("magenta"
+        std::getline(in, str, ' ');
+
+        /// if end of line is returned before encountering ' ' or 7... is it fine
+        /// so we can clear the failure bitset.
+
+        /// Compare the resulting string with supported colors.
+        /// If you add more colors... please also add them in the test file.
+        if (str == "white")    { r = 1.0f; g = 1.0f; b = 1.0f; }
+        else if (str == "black")    { r = 0.0f; g = 0.0f; b = 0.0f; }
+        else if (str == "red")      { r = 1.0f; g = 0.0f; b = 0.0f; }
+        else if (str == "green")    { r = 0.0f; g = 1.0f; b = 0.0f; }
+        else if (str == "blue")     { r = 0.0f; g = 0.0f; b = 1.0f; }
+        else if (str == "cyan")     { r = 0.0f; g = 1.0f; b = 1.0f; }
+        else if (str == "magenta")  { r = 1.0f; g = 0.0f; b = 1.0f; }
+        else if (str == "yellow")   { r = 1.0f; g = 1.0f; b = 0.0f; }
+        else if (str == "gray")     { r = 0.5f; g = 0.5f; b = 0.5f; }
+        else {
+            /// If we cannot parse the field we returns that with the fail bit.
+            in.setstate(std::ios_base::failbit) ;
+            return in;
+        }
+    }
+
+    t.set(r,g,b,a) ;
+    return in;
 }
 
 /// Write to an output stream


### PR DESCRIPTION
There was a regression in the way RGBAColor are parsed by the stream operator>>.
This was the cause of Material reading was not working (issue #302). 

This PR fix:
   - fix the problem. 
   - add new tests for RGBAColor & Material 
   - Clean Material without breaking the API. 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
