### PR TITLE
[SofaGraphComponent] Add SceneCheckerVisitor to detect missing RequiredPlugin

### DIFF
--- a/applications/plugins/SofaPython/PythonScriptController.h
+++ b/applications/plugins/SofaPython/PythonScriptController.h
@@ -116,30 +116,29 @@ public:
 protected:
     sofa::helper::system::FileEventListener* m_filelistener ;
 
-    PyObject *m_ScriptControllerClass;      // class implemented in the script to use to instanciate the python controller
-    //PyObject *m_ScriptControllerInstanceDict;  // functions dictionnary
-    PyObject *m_ScriptControllerInstance;   // instance of m_ScriptControllerClass
+    PyObject *m_ScriptControllerClass {nullptr};      // class implemented in the script to use to instanciate the python controller
+    PyObject *m_ScriptControllerInstance {nullptr};   // instance of m_ScriptControllerClass
 
     // optionnal script entry points:
-    PyObject *m_Func_onKeyPressed;
-    PyObject *m_Func_onKeyReleased;
-    PyObject *m_Func_onMouseButtonLeft;
-    PyObject *m_Func_onMouseButtonRight;
-    PyObject *m_Func_onMouseButtonMiddle;
-    PyObject *m_Func_onMouseWheel;
-    PyObject *m_Func_onGUIEvent;
-    PyObject *m_Func_onScriptEvent;
-    PyObject *m_Func_onBeginAnimationStep;
-    PyObject *m_Func_onEndAnimationStep;
-    PyObject *m_Func_onLoaded;
-    PyObject *m_Func_createGraph;
-    PyObject *m_Func_initGraph;
-    PyObject *m_Func_bwdInitGraph;
-    PyObject *m_Func_storeResetState;
-    PyObject *m_Func_reset;
-    PyObject *m_Func_cleanup;
-    PyObject *m_Func_draw;
-    PyObject *m_Func_onIdle;
+    PyObject *m_Func_onKeyPressed {nullptr} ;
+    PyObject *m_Func_onKeyReleased {nullptr} ;
+    PyObject *m_Func_onMouseButtonLeft {nullptr} ;
+    PyObject *m_Func_onMouseButtonRight{nullptr} ;
+    PyObject *m_Func_onMouseButtonMiddle {nullptr} ;
+    PyObject *m_Func_onMouseWheel {nullptr} ;
+    PyObject *m_Func_onGUIEvent {nullptr} ;
+    PyObject *m_Func_onScriptEvent {nullptr} ;
+    PyObject *m_Func_onBeginAnimationStep {nullptr} ;
+    PyObject *m_Func_onEndAnimationStep {nullptr} ;
+    PyObject *m_Func_onLoaded {nullptr} ;
+    PyObject *m_Func_createGraph {nullptr} ;
+    PyObject *m_Func_initGraph {nullptr} ;
+    PyObject *m_Func_bwdInitGraph {nullptr} ;
+    PyObject *m_Func_storeResetState {nullptr} ;
+    PyObject *m_Func_reset {nullptr} ;
+    PyObject *m_Func_cleanup {nullptr} ;
+    PyObject *m_Func_draw {nullptr} ;
+    PyObject *m_Func_onIdle {nullptr} ;
 };
 
 

--- a/applications/sofa/gui/qt/RealGUI.cpp
+++ b/applications/sofa/gui/qt/RealGUI.cpp
@@ -96,6 +96,11 @@ using sofa::core::objectmodel::IdleEvent ;
 #include <sofa/helper/system/FileMonitor.h>
 using sofa::helper::system::FileMonitor ;
 
+#include <SofaGraphComponent/SceneCheckerVisitor.h>
+using sofa::simulation::SceneCheckerVisitor ;
+
+using sofa::core::ExecParams ;
+
 namespace sofa
 {
 
@@ -771,7 +776,6 @@ void RealGUI::fileOpen ( std::string filename, bool temporaryFile )
 
     this->setWindowFilePath(filename.c_str());
     setExportGnuplot(exportGnuplotFilesCheckbox->isChecked());
-    //  displayComputationTime(m_displayComputationTime);  // (FF) This can be set outside of the GUI and should not be changed implicitly by the GUI
     stopDumpVisitor();
 }
 
@@ -854,6 +858,11 @@ void RealGUI::fileOpen()
             else
                 fileOpen (s.toStdString());
     }
+
+    /// We want to warn user that there is component that are implemented in specific plugin
+    /// and that there is no RequiredPlugin in their scene.
+    SceneCheckerVisitor checker(ExecParams::defaultInstance()) ;
+    checker.validate(mSimulation.get()) ;
 }
 
 //------------------------------------

--- a/modules/SofaGraphComponent/CMakeLists.txt
+++ b/modules/SofaGraphComponent/CMakeLists.txt
@@ -41,7 +41,7 @@ set(SOURCE_FILES
 
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaSimulationTree)
+target_link_libraries(${PROJECT_NAME} PUBLIC SofaSimulationCore SofaSimulationTree)
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-DSOFA_BUILD_GRAPH_COMPONENT")
 set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${HEADER_FILES}")
 

--- a/modules/SofaGraphComponent/CMakeLists.txt
+++ b/modules/SofaGraphComponent/CMakeLists.txt
@@ -16,6 +16,7 @@ set(HEADER_FILES
     SofaDefaultPathSetting.h
     StatsSetting.h
     ViewerSetting.h
+    SceneCheckerVisitor.h
     config.h
     initGraphComponent.h
 )
@@ -34,6 +35,7 @@ set(SOURCE_FILES
     SofaDefaultPathSetting.cpp
     StatsSetting.cpp
     ViewerSetting.cpp
+    SceneCheckerVisitor.cpp
     initGraphComponent.cpp
 )
 

--- a/modules/SofaGraphComponent/RequiredPlugin.cpp
+++ b/modules/SofaGraphComponent/RequiredPlugin.cpp
@@ -38,7 +38,7 @@ namespace misc
 
 SOFA_DECL_CLASS(RequiredPlugin)
 
-int RequiredPluginClass = core::RegisterObject("Load required plugin")
+int RequiredPluginClass = core::RegisterObject("Load the required plugins")
         .add< RequiredPlugin >();
 
 RequiredPlugin::RequiredPlugin()

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
@@ -1,0 +1,85 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include "SceneCheckerVisitor.h"
+#include "RequiredPlugin.h"
+#include <sofa/core/ObjectFactory.h>
+#include <sofa/helper/system/PluginManager.h>
+
+namespace sofa
+{
+namespace simulation
+{
+using sofa::component::misc::RequiredPlugin ;
+using sofa::core::ObjectFactory ;
+using sofa::core::ExecParams ;
+using sofa::helper::system::PluginRepository ;
+using sofa::helper::system::PluginManager ;
+
+SceneCheckerVisitor::SceneCheckerVisitor(const ExecParams* params) : Visitor(params)
+{
+}
+
+SceneCheckerVisitor::~SceneCheckerVisitor()
+{
+}
+
+void SceneCheckerVisitor::validate(Node* node)
+{
+    helper::vector< RequiredPlugin* > plugins ;
+    node->getTreeObjects< RequiredPlugin >(&plugins) ;
+
+    for(auto& plugin : plugins)
+        m_pluginsrequired[plugin->getName()] = true ;
+
+    execute(node) ;
+}
+
+Visitor::Result SceneCheckerVisitor::processNodeTopDown(Node* node)
+{
+    for (auto& object : node->object )
+    {
+        ObjectFactory::ClassEntry entry = ObjectFactory::getInstance()->getEntry(object->getClassName());
+        if(!entry.creatorMap.empty())
+        {
+            ObjectFactory::CreatorMap::iterator it = entry.creatorMap.find(object->getTemplateName());
+            if(entry.creatorMap.end() != it && *it->second->getTarget()){
+                std::string pluginName = it->second->getTarget() ;
+                std::string path = PluginManager::getInstance().findPlugin(pluginName) ;
+                if( PluginManager::getInstance().pluginIsLoaded(path)
+                    && m_pluginsrequired.find(pluginName) == m_pluginsrequired.end() )
+                {
+                    msg_warning("SceneChecker") << "This scene is using component '" << object->getClassName() << "'. " << msgendl
+                                                << "This component is part of the '" << pluginName << "' plugin but there is no RequiredPlugin name='" << pluginName << "' directive in your scene." << msgendl
+                                                << "Your scene may not work on a sofa environment that does not have a pre-loaded the plugin." << msgendl
+                                                << "To fix your scene and remove this warning you need to add the RequiredPlugin directive at the beginning of your scene. ";
+                }
+            }
+
+        }
+    }
+    return RESULT_CONTINUE;
+}
+
+} // namespace simulation
+
+} // namespace sofa
+

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
@@ -48,7 +48,7 @@ void SceneCheckerVisitor::validate(Node* node)
     node->getTreeObjects< RequiredPlugin >(&plugins) ;
 
     for(auto& plugin : plugins)
-        m_pluginsrequired[plugin->getName()] = true ;
+        m_requiredPlugins[plugin->getName()] = true ;
 
     execute(node) ;
 }
@@ -65,7 +65,7 @@ Visitor::Result SceneCheckerVisitor::processNodeTopDown(Node* node)
                 std::string pluginName = it->second->getTarget() ;
                 std::string path = PluginManager::getInstance().findPlugin(pluginName) ;
                 if( PluginManager::getInstance().pluginIsLoaded(path)
-                    && m_pluginsrequired.find(pluginName) == m_pluginsrequired.end() )
+                    && m_requiredPlugins.find(pluginName) == m_requiredPlugins.end() )
                 {
                     msg_warning("SceneChecker") << "This scene is using component '" << object->getClassName() << "'. " << msgendl
                                                 << "This component is part of the '" << pluginName << "' plugin but there is no RequiredPlugin name='" << pluginName << "' directive in your scene." << msgendl

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
@@ -68,8 +68,8 @@ Visitor::Result SceneCheckerVisitor::processNodeTopDown(Node* node)
                     && m_requiredPlugins.find(pluginName) == m_requiredPlugins.end() )
                 {
                     msg_warning("SceneChecker") << "This scene is using component '" << object->getClassName() << "'. " << msgendl
-                                                << "This component is part of the '" << pluginName << "' plugin but there is no RequiredPlugin name='" << pluginName << "' directive in your scene." << msgendl
-                                                << "Your scene may not work on a sofa environment that does not have a pre-loaded the plugin." << msgendl
+                                                << "This component is part of the '" << pluginName << "' plugin but there is no <RequiredPlugin name='" << pluginName << "'> directive in your scene." << msgendl
+                                                << "Your scene may not work on a sofa environment that does not have pre-loaded the plugin." << msgendl
                                                 << "To fix your scene and remove this warning you need to add the RequiredPlugin directive at the beginning of your scene. ";
                 }
             }

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.h
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.h
@@ -22,7 +22,7 @@
 #ifndef SOFA_SIMULATION_SCENECHECKERVISTOR_H
 #define SOFA_SIMULATION_SCENECHECKERVISTOR_H
 
-#include <sofa/helper/map.h>
+#include <map>
 #include <sofa/simulation/Visitor.h>
 
 namespace sofa

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.h
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.h
@@ -1,0 +1,50 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#ifndef SOFA_SIMULATION_SCENECHECKERVISTOR_H
+#define SOFA_SIMULATION_SCENECHECKERVISTOR_H
+
+#include <sofa/helper/map.h>
+#include <sofa/simulation/Visitor.h>
+
+namespace sofa
+{
+
+namespace simulation
+{
+
+class SOFA_SIMULATION_CORE_API SceneCheckerVisitor : public Visitor
+{
+public:
+    SceneCheckerVisitor(const sofa::core::ExecParams* params) ;
+    virtual ~SceneCheckerVisitor() ;
+
+    void validate(Node* node) ;
+    virtual Result processNodeTopDown(Node* node) override ;
+private:
+    std::map<std::string,bool> m_pluginsrequired ;
+};
+
+} // namespace simulation
+
+} // namespace sofa
+
+#endif

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.h
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.h
@@ -22,6 +22,8 @@
 #ifndef SOFA_SIMULATION_SCENECHECKERVISTOR_H
 #define SOFA_SIMULATION_SCENECHECKERVISTOR_H
 
+#include "config.h"
+
 #include <map>
 #include <sofa/simulation/Visitor.h>
 
@@ -31,7 +33,7 @@ namespace sofa
 namespace simulation
 {
 
-class SOFA_SIMULATION_CORE_API SceneCheckerVisitor : public Visitor
+class SOFA_GRAPH_COMPONENT_API SceneCheckerVisitor : public Visitor
 {
 public:
     SceneCheckerVisitor(const sofa::core::ExecParams* params) ;
@@ -40,7 +42,7 @@ public:
     void validate(Node* node) ;
     virtual Result processNodeTopDown(Node* node) override ;
 private:
-    std::map<std::string,bool> m_pluginsrequired ;
+    std::map<std::string,bool> m_requiredPlugins ;
 };
 
 } // namespace simulation

--- a/modules/SofaGraphComponent/SofaGraphComponent_test/CMakeLists.txt
+++ b/modules/SofaGraphComponent/SofaGraphComponent_test/CMakeLists.txt
@@ -4,6 +4,7 @@ project(SofaGraphComponent_test)
 
 set(SOURCE_FILES
     RequiredPlugin_test.cpp
+    SceneChecker_test.cpp
     )
 
 #add_definitions("-DSOFAGENERALTOPOLOGY_TEST_SCENES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/scenes\"")

--- a/modules/SofaGraphComponent/SofaGraphComponent_test/SceneChecker_test.cpp
+++ b/modules/SofaGraphComponent/SofaGraphComponent_test/SceneChecker_test.cpp
@@ -1,0 +1,61 @@
+#include <SofaTest/Sofa_test.h>
+using sofa::Sofa_test;
+
+#include <SofaGraphComponent/SceneCheckerVisitor.h>
+using sofa::simulation::SceneCheckerVisitor ;
+
+#include <sofa/helper/system/PluginManager.h>
+using sofa::helper::system::PluginManager ;
+
+#include <SofaSimulationCommon/SceneLoaderXML.h>
+using sofa::simulation::SceneLoaderXML ;
+using sofa::simulation::Node ;
+
+using sofa::core::ExecParams;
+
+struct SceneChecker_test : public Sofa_test<>
+{
+    void checkRequiredPlugin(bool missing)
+    {
+        EXPECT_MSG_EMIT(Error) ;
+        EXPECT_MSG_NOEMIT(Warning);
+
+        PluginManager::getInstance().loadPluginByName("SofaPython") ;
+
+        std::string missStr = (missing)?"" : "<RequiredPlugin name='SofaPython'/> \n";
+        std::stringstream scene ;
+        scene << "<?xml version='1.0'?>"
+              << "<Node name='Root' gravity='0 -9.81 0' time='0' animate='0' >                   \n"
+              << missStr
+              << "      <PythonScriptController classname='AClass' />                            \n"
+              << "</Node>                                                                        \n" ;
+
+        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                          scene.str().c_str(),
+                                                          scene.str().size()) ;
+
+        ASSERT_NE(root.get(), nullptr) ;
+        root->init(ExecParams::defaultInstance()) ;
+
+        if(missing)
+        {
+            EXPECT_MSG_EMIT(Warning);
+            SceneCheckerVisitor checker(ExecParams::defaultInstance());
+            checker.validate(root.get()) ;
+        }else{
+            EXPECT_MSG_NOEMIT(Warning);
+            SceneCheckerVisitor checker(ExecParams::defaultInstance());
+            checker.validate(root.get()) ;
+        }
+    }
+};
+
+TEST_F(SceneChecker_test, checkMissingRequiredPlugin )
+{
+    checkRequiredPlugin(true) ;
+}
+
+TEST_F(SceneChecker_test, checkPresentRequiredPlugin )
+{
+    checkRequiredPlugin(false) ;
+}


### PR DESCRIPTION
Problem:
It is common that people write scene in which they used components from specific plugins but forgot the corresponding 
```xml 
<RequiredPlugin name=''>
```
because they, in a way or an other, preload the plugin. 

This is problematic because, when the environment change (you compile sofa in a different way, your preload different plugin, it is a different person on a different computer,... ) and the preload is not done anymore it makes the component/plugin tracking very hard if it is not a trivial component in a trivial plugin. 

To solve this problem, I implemented a SceneCheckerVistitor that scans the scene and detects which components are from a plugin and warn the user if there is no RequiredPlugin in there scene with this component and explaine how his scene should be fixed for the good of all. 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
