### PR TITLE
[SofaExporter] FIX allow to extend VTKExporter in a plugin

### DIFF
--- a/modules/SofaExporter/VTKExporter.h
+++ b/modules/SofaExporter/VTKExporter.h
@@ -52,7 +52,7 @@ class SOFA_EXPORTER_API VTKExporter : public core::objectmodel::BaseObject
 public:
     SOFA_CLASS(VTKExporter,core::objectmodel::BaseObject);
 
-private:
+protected:
     sofa::core::topology::BaseMeshTopology* topology;
     sofa::core::behavior::BaseMechanicalState* mstate;
     unsigned int stepCounter;


### PR DESCRIPTION
FIX allows to extend VTKExporter in a plugin (for quadratic meshes for example)






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
