### PR TITLE
[Viewer] FIX draw scenes on classical and retina screens

### DIFF
--- a/applications/sofa/gui/qt/viewer/qt/QtViewer.cpp
+++ b/applications/sofa/gui/qt/viewer/qt/QtViewer.cpp
@@ -1061,7 +1061,7 @@ void QtViewer::calcProjection(int width, int height)
     GLdouble projectionMatrix[16];
     currentCamera->getOpenGLProjectionMatrix(projectionMatrix);
 
-    glViewport(0, 0, width, height);
+    glViewport(0, 0, width * this->devicePixelRatio(), height * this->devicePixelRatio()); // to handle retina displays
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
     glMultMatrixd(projectionMatrix);


### PR DESCRIPTION
Tested on classical and retina screens on os x system and classical screen on linux system. I do not know how to create a unit test for this fix.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
