### PR TITLE
[SofaPython] Fix python unicode data

### DIFF
--- a/applications/plugins/SofaPython/Binding_BaseContext.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseContext.cpp
@@ -82,9 +82,22 @@ static std::ostream& pythonToSofaDataString(PyObject* value, std::ostream& out)
         return out << PyString_AsString(value) ;
     }
 
+    /// Unicode are converted to string.
+    if(PyUnicode_Check(value))
+    {
+        PyObject* tmpstr = PyUnicode_AsUTF8String(value);
+        out << PyString_AsString(tmpstr) ;
+        Py_DECREF(tmpstr);
+
+        return out;
+    }
 
     if( PySequence_Check(value) )
     {
+        if(!PyList_Check(value))
+        {
+            msg_warning("SofaPython") << "A sequence which is not a list will be convert to a sofa string.";
+        }
         /// It is a sequence...so we can iterate over it.
         PyObject *iterator = PyObject_GetIter(value);
         if(iterator)

--- a/applications/plugins/SofaPython/Binding_Data.cpp
+++ b/applications/plugins/SofaPython/Binding_Data.cpp
@@ -27,6 +27,7 @@
 #include <sofa/core/objectmodel/Data.h>
 #include <sofa/core/objectmodel/BaseNode.h>
 
+#include <sstream>
 
 using namespace sofa::core::objectmodel;
 using namespace sofa::defaulttype;
@@ -380,6 +381,26 @@ int SetDataValuePython(BaseData* data, PyObject* args)
         return 0;
     }
 
+    // Unicode
+    if (PyUnicode_Check(args))
+    {
+        std::stringstream streamstr;
+        PyObject* tmpstr = PyUnicode_AsUTF8String(args);
+        streamstr << PyString_AsString(tmpstr) ;
+        Py_DECREF(tmpstr);
+        std::string str(streamstr.str());
+
+        if( str.size() > 0u && str[0]=='@' ) // DataLink
+        {
+            data->setParent(str);
+            data->setDirtyOutputs(); // forcing children updates (should it be done in BaseData?)
+        }
+        else
+        {
+            data->read(str);
+        }
+        return 0;
+    }
     const AbstractTypeInfo *typeinfo = data->getValueTypeInfo(); // info about the data value
     const bool valid = (typeinfo && typeinfo->ValidInfo());
 

--- a/applications/plugins/SofaPython/SofaPython_test/python/unicodeData.py
+++ b/applications/plugins/SofaPython/SofaPython_test/python/unicodeData.py
@@ -1,0 +1,31 @@
+# coding=utf-8
+
+import Sofa
+import SofaPython.Tools
+import SofaTest
+
+
+def createScene(node):
+    node.createObject('PythonScriptController', filename=__file__, classname='VerifController')
+
+
+class VerifController(SofaTest.Controller):
+
+    def initGraph(self, node):
+
+        name = u"aaéæœ®ßþ"
+        mechanical_object = node.createObject("MechanicalObject", name=name)
+
+        self.ASSERT(unicode(mechanical_object.name, "utf-8") == name, "test1")
+
+        mechanical_object.name = name
+        self.ASSERT(unicode(mechanical_object.name, "utf-8") == name, "test2")
+
+        mechanical_object.name = u"ĳðð…"
+        self.ASSERT(unicode(mechanical_object.name, "utf-8") == u"ĳðð…", "test3")
+
+        self.ASSERT(isinstance(mechanical_object.name, str), "test4")
+
+        Sofa.msg_info(mechanical_object.name)
+        mechanical_object.name = mechanical_object.name
+        self.sendSuccess()

--- a/applications/plugins/SofaPython/SofaPython_test/python/unicodeData.py
+++ b/applications/plugins/SofaPython/SofaPython_test/python/unicodeData.py
@@ -28,4 +28,6 @@ class VerifController(SofaTest.Controller):
 
         Sofa.msg_info(mechanical_object.name)
         mechanical_object.name = mechanical_object.name
+
+    def onEndAnimationStep(self, dt):
         self.sendSuccess()

--- a/applications/plugins/SofaPython/SofaPython_test/python_test_list.cpp
+++ b/applications/plugins/SofaPython/SofaPython_test/python_test_list.cpp
@@ -56,7 +56,8 @@ static struct SceneTests : public Python_test_list
         addTest( "sysPathDuplicate.py", scenePath );
         addTest( "dataVecResize.py", scenePath );
         addTest( "automaticNodeInitialization.py", scenePath );
-
+        addTest( "unicodeData.py", scenePath);
+        
         // call it several times in the same python environment to simulate a reload
         for( int i=0 ; i<5 ; ++i )
             addTest( "moduleReload.py",  scenePath );


### PR DESCRIPTION

### Problem: Sofa crash when an Unicode string is used.
Here an example scene:

``` python
# coding=utf-8
import Sofa

def createScene(node):
    node.createObject('MechanicalObject', name=u"Éœùæ")
```
With the current behavior, an Unicode string used as data is interpreted as a sequence. This causes some problems with path to files for example.

### Changelog

* In `Binding_BaseContext::pythonToSofaDataString:`, add unicode to string convertion and a warning message when  PySequence_Check is true but the given PyObject is not a list.
* In `Binding_BaseData::SetDataValuePython` an unicode to string convertion too.
* And add a test



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
