### PR TITLE
Change how rest shape is given in RestShapeSpringsForceField [BREAKING]

### DIFF
--- a/SofaKernel/modules/SofaDeformable/RestShapeSpringsForceField.h
+++ b/SofaKernel/modules/SofaDeformable/RestShapeSpringsForceField.h
@@ -87,7 +87,7 @@ public:
     Data< bool > drawSpring;
     Data< defaulttype::RGBAColor > springColor;
 
-    sofa::core::behavior::MechanicalState< DataTypes > *restMState;
+    SingleLink<RestShapeSpringsForceField<DataTypes>, sofa::core::behavior::MechanicalState< DataTypes >, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> restMState;
     linearsolver::EigenBaseSparseMatrix<typename DataTypes::Real> matS;
 
     //VecDeriv Springs_dir;

--- a/applications/plugins/DEPRECATED/SofaVRPNClient/examples/VRPNImagerRigidPhysics1.scn
+++ b/applications/plugins/DEPRECATED/SofaVRPNClient/examples/VRPNImagerRigidPhysics1.scn
@@ -25,7 +25,7 @@
        <Node name="cage">
                 <MechanicalObject template="Rigid" position="0 0 -1.15 0 0 0 1"/>
                 <UniformMass  mass="0.001" showAxisSizeFactor="0.01"/>
-		<RestShapeSpringsForceField points="0" external_points="0" external_rest_shape="../proxy/center/mechCenter" stiffness="2000" angularStiffness="50000"/>
+		<RestShapeSpringsForceField points="0" external_points="0" external_rest_shape="@../proxy/center/mechCenter" stiffness="2000" angularStiffness="50000"/>
                 <UncoupledConstraintCorrection compliance="0.0005 0.00002 0 0  0.00002  0 0.00002"/>
                 <Node name="Visu">
 			<OglModel name="Visual" fileMesh="mesh/box_outside_duriez.obj" color="1 0 0 0.7"/>

--- a/applications/plugins/LeapMotion/examples/buffoon.scn
+++ b/applications/plugins/LeapMotion/examples/buffoon.scn
@@ -34,7 +34,7 @@
 		<Node name="Palm">
 	        <Gravity name="Gravity" gravity="0 0 0" />
 			<MechanicalObject name="palmState" template="Rigid" rest_position="@../../leapMotionDriver.handPalmCoordinate" showObject="false" showObjectScale="0.02" />
-			<RestShapeSpringsForceField  name="RSFF" stiffness="1e6" angularStiffness="1e3" external_rest_shape="../../TrackedHand/TrackedPalm/movingDOFs" recompute_indices="false" />
+			<RestShapeSpringsForceField  name="RSFF" stiffness="1e6" angularStiffness="1e3" external_rest_shape="@../../TrackedHand/TrackedPalm/movingDOFs" recompute_indices="false" />
 			<UniformMass name="uniformMass" template="Rigid"  totalmass="0.1" />
 			<Node name="Collision_Model" >
 				<MechanicalObject name="collisDOFs" template="Vec3d" position="@../../../leapMotionDriver.handPalmCoordinate" />
@@ -45,7 +45,7 @@
 		<Node name="Fingers" >
 			<Gravity name="Gravity" gravity="0 0 0" />
 			<MechanicalObject name="handDOFs" template="Rigid" rest_position="@../../leapMotionDriver.fingersCoordinates" showObject="false" showObjectScale="0.02" />
-			<RestShapeSpringsForceField  name="RSFF" stiffness="1e3" angularStiffness="1e3" external_rest_shape="../../TrackedHand/TrackedFingers/movingDOFs" recompute_indices="false" />
+			<RestShapeSpringsForceField  name="RSFF" stiffness="1e3" angularStiffness="1e3" external_rest_shape="@../../TrackedHand/TrackedFingers/movingDOFs" recompute_indices="false" />
 			<UniformMass name="uniformMass" template="Rigid"  totalmass="0.5" />
 			<Node name="Collision_Model" >
 				<MechanicalObject name="lineCollisDOFs" template="Vec3d" position="@../../../leapMotionDriver.fingersCoordinates" />	

--- a/applications/plugins/Sensable/examples/SimpleBox-Method2.scn
+++ b/applications/plugins/Sensable/examples/SimpleBox-Method2.scn
@@ -48,7 +48,7 @@
         </Node>
               
 
-        <RestShapeSpringsForceField template="Rigid" stiffness="1000000" angularStiffness="200000000" external_rest_shape="../OmniObject/RigidLayer/Tool1/RealPosition" />
+        <RestShapeSpringsForceField template="Rigid" stiffness="1000000" angularStiffness="200000000" external_rest_shape="@../OmniObject/RigidLayer/Tool1/RealPosition" />
         <UncoupledConstraintCorrection compliance="0.001   0.00003 0 0   0.00003 0   0.00003" />
     </Node>
 

--- a/applications/plugins/SensableEmulation/examples/SimpleBox-Method2.scn
+++ b/applications/plugins/SensableEmulation/examples/SimpleBox-Method2.scn
@@ -49,7 +49,7 @@
         </Node>
               
 
-        <RestShapeSpringsForceField template="Rigid" stiffness="1000000" angularStiffness="200000000" external_rest_shape="../OmniObject/RigidLayer/Tool1/RealPosition" />
+        <RestShapeSpringsForceField template="Rigid" stiffness="1000000" angularStiffness="200000000" external_rest_shape="@../OmniObject/RigidLayer/Tool1/RealPosition" />
         <UncoupledConstraintCorrection compliance="0.001   0.00003 0 0   0.00003 0   0.00003" />
     </Node>
 

--- a/applications/plugins/SofaHAPI/examples/SofaHAPI1.scn
+++ b/applications/plugins/SofaHAPI/examples/SofaHAPI1.scn
@@ -50,7 +50,7 @@
 			<RigidMapping />
 		</Node>	
 
-		<RestShapeSpringsForceField template="Rigid" stiffness="1000000" angularStiffness="200000000" external_rest_shape="../OmniObject/RigidLayer/Tool1/RealPosition" />
+		<RestShapeSpringsForceField template="Rigid" stiffness="1000000" angularStiffness="200000000" external_rest_shape="@../OmniObject/RigidLayer/Tool1/RealPosition" />
 		<UncoupledConstraintCorrection compliance="0.001   0.00003 0 0   0.00003 0   0.00003" />
 	</Node>
 

--- a/applications/plugins/Xitact/examples/XitactGrasping.scn
+++ b/applications/plugins/Xitact/examples/XitactGrasping.scn
@@ -80,7 +80,7 @@
     <UniformMass totalMass="0.01"/>
 
 
-    <RestShapeSpringsForceField points="0" stiffness="10000" angularStiffness="1000000000"/> <!--external_rest_shape="toto"/>-->
+    <RestShapeSpringsForceField points="0" stiffness="10000" angularStiffness="1000000000"/> <!--external_rest_shape="@toto"/>-->
     <UncoupledConstraintCorrection compliance="0.0001  0.000000001 0 0 0.000000001 0 0.000000001"/>
     
 

--- a/applications/plugins/Xitact/examples/XitactGraspingWithForceFeedBack.scn
+++ b/applications/plugins/Xitact/examples/XitactGraspingWithForceFeedBack.scn
@@ -80,7 +80,7 @@
     <UniformMass totalMass="0.01"/>
 
 
-    <RestShapeSpringsForceField points="0" stiffness="10000" angularStiffness="1000000000" external_rest_shape="toto"/>
+    <RestShapeSpringsForceField points="0" stiffness="10000" angularStiffness="1000000000" external_rest_shape="@toto"/>
     <UncoupledConstraintCorrection compliance="0.0001  0.000000001 0 0 0.000000001 0 0.000000001"/>
     
 

--- a/applications/plugins/Xitact/examples/XitactGrasping_coupledModel.scn
+++ b/applications/plugins/Xitact/examples/XitactGrasping_coupledModel.scn
@@ -80,7 +80,7 @@
     <UniformMass totalMass="0.01"/>
 
 
-    <RestShapeSpringsForceField points="0" stiffness="10000" angularStiffness="1000000000" external_rest_shape="toto"/>
+    <RestShapeSpringsForceField points="0" stiffness="10000" angularStiffness="1000000000" external_rest_shape="@toto"/>
     <UncoupledConstraintCorrection compliance="0.0001  0.000000001 0 0 0.000000001 0 0.000000001"/>
     
 
@@ -194,7 +194,7 @@
     <UniformMass totalMass="0.01"/>
 
 
-    <RestShapeSpringsForceField points="0" stiffness="10000" angularStiffness="1000000000" external_rest_shape="toto"/>
+    <RestShapeSpringsForceField points="0" stiffness="10000" angularStiffness="1000000000" external_rest_shape="@toto"/>
     <UncoupledConstraintCorrection compliance="0.0001  0.000000001 0 0 0.000000001 0 0.000000001"/>
     
 

--- a/applications/plugins/Xitact/examples/XitactGrasping_coupledModel_withITP.scn
+++ b/applications/plugins/Xitact/examples/XitactGrasping_coupledModel_withITP.scn
@@ -80,7 +80,7 @@
     <UniformMass totalMass="0.01"/>
 
 
-    <RestShapeSpringsForceField points="0" stiffness="10000" angularStiffness="1000000000" external_rest_shape="toto"/>
+    <RestShapeSpringsForceField points="0" stiffness="10000" angularStiffness="1000000000" external_rest_shape="@toto"/>
     <UncoupledConstraintCorrection compliance="0.0001  0.000000001 0 0 0.000000001 0 0.000000001"/>
     
 
@@ -194,7 +194,7 @@
     <UniformMass totalMass="0.01"/>
 
 
-    <RestShapeSpringsForceField points="0" stiffness="10000" angularStiffness="1000000000" external_rest_shape="toto"/>
+    <RestShapeSpringsForceField points="0" stiffness="10000" angularStiffness="1000000000" external_rest_shape="@toto"/>
     <UncoupledConstraintCorrection compliance="0.0001  0.000000001 0 0 0.000000001 0 0.000000001"/>
     
 
@@ -308,7 +308,7 @@
     <UniformMass totalMass="0.01"/>
 
 
-    <RestShapeSpringsForceField points="0" stiffness="10000" angularStiffness="1000000000" external_rest_shape="toto"/>
+    <RestShapeSpringsForceField points="0" stiffness="10000" angularStiffness="1000000000" external_rest_shape="@toto"/>
     <UncoupledConstraintCorrection compliance="0.0001  0.000000001 0 0 0.000000001 0 0.000000001"/>
     
 

--- a/applications/plugins/Xitact/examples/xitactTest.scn
+++ b/applications/plugins/Xitact/examples/xitactTest.scn
@@ -15,7 +15,7 @@
     <CGLinearSolver iterations="40" name="linear solver" tolerance="1.0e-9" threshold="1.0e-15" printLog="0"/>
     <!-- Modify this position in the scene -->
     <MechanicalObject name="bati" template="Rigid" position="0 0 0 0 0 0 1"/>
-    <RestShapeSpringsForceField points="0" stiffness="100000" angularStiffness="1000000"/> <!--external_rest_shape="toto"/>-->
+    <RestShapeSpringsForceField points="0" stiffness="100000" angularStiffness="1000000"/> <!--external_rest_shape="@toto"/>-->
     <UncoupledConstraintCorrection compliance="0.00001  0.000001 0 0 0.000001 0 0.000001"/>
 
     <Node name="VisuOfXitactBase">

--- a/examples/Components/forcefield/RestShapeSpringsForceField2.scn
+++ b/examples/Components/forcefield/RestShapeSpringsForceField2.scn
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+
+<Node name="root" dt="0.01" gravity="0 0 0" >
+      <VisualStyle displayFlags=" showCollisionModels showForceFields" />
+
+      <FreeMotionAnimationLoop />
+      <GenericConstraintSolver maxIt="1000" tolerance="1e-10" printLog="false" />
+
+	<Node name="Object1">
+		<MechanicalObject name="ms" template="Rigid" position="0 0 0 0 0 0 0 1" showObject="false"/>
+		<Sphere radius="0.01" color="0 1 0 1" />  
+	</Node> 
+	
+	<Node name="Object2">
+		<EulerImplicit rayleighMass="0" rayleighStiffness="0"/>
+		<SparseLUSolver />
+		<MechanicalObject name="mstate" template="Rigid" position="0.1 0 0  0  0 0 0 1" />     
+	        <Sphere color="1 0 0 1" radius="0.01" />
+		<RestShapeSpringsForceField stiffness="11" angularStiffness="11" external_rest_shape="@../Object1/ms" points="0" external_points="0" drawSpring="true" springColor="1 1 1 1"/>
+		<UniformMass totalmass="0.01" />
+		<Sphere radius="0.0005" color="1 0 0  1" />
+		    
+		<LinearSolverConstraintCorrection /> 
+	</Node> 
+	
+</Node>   

--- a/scripts/updateRSSFFscenes.py
+++ b/scripts/updateRSSFFscenes.py
@@ -1,0 +1,23 @@
+from os import system, listdir, path, walk
+system("clear")
+LOGFILE = open("LogRSSFF.txt", "w")
+desktop_dir = r"../"
+#desktop_dir = r"/home/rtrivi/wor/Sofa/src/sofa-stable_v16.08"
+
+for root, dirs, files in walk(desktop_dir):
+	for file in files:
+		with open(path.join(root, file), "r") as auto:
+			for i, line in enumerate(auto, 0):# for line in auto:
+				for word in line.split():
+			  		if word in {"<RestShapeSpringsForceField"}:
+						LOGFILE.write("<RestShapeSpringsForcefield found in " + file + " {" + str(i) + "}\n")
+						for word in line.lower().split():
+							if(word.find("external_rest_shape=\"") > -1 and word.find("@") == -1):
+								with open(path.join(root, file), "r") as filer:
+									s = filer.readlines()
+									LOGFILE.write("\tLINE bef: " + str(s[i]))
+									s[i] = s[i].replace("external_rest_shape=\"", "external_rest_shape=\"@")
+									LOGFILE.write("\tLINE aft: " + str(s[i]))
+								with open(path.join(root, file), "w") as filew:
+									filew.writelines(s)
+LOGFILE.close()


### PR DESCRIPTION
In RestShapeSpringsForceField the rest_shape is currently provided using  a raw pointer which is really Bad. 
In this PR is change that to use SingleLink instead. 

The PR imply a change by which the syntax of the external_rest_shape is provided. Adding an "@" as in the test examples/Components/forcefield/RestShapeSpringsForceField2.scn make it work.

Editting: Damien. 
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
