### PR TITLE
[SofaKernel] FIX Mat::transpose() and Mat::invert()

### DIFF
--- a/SofaKernel/framework/framework_test/defaulttype/MatTypes_test.cpp
+++ b/SofaKernel/framework/framework_test/defaulttype/MatTypes_test.cpp
@@ -72,9 +72,6 @@ TEST(MatTypesTest, isTransform)
     EXPECT_TRUE(M.isTransform());
 }
 
-/// Following input and result matrices were generated
-///  using matlab's 'magic' function
-
 TEST(MatTypesTest, transpose)
 {
     Matrix4 M(Matrix4::Line(16, 2, 3, 13), Matrix4::Line(5, 11, 10, 8), Matrix4::Line(9, 7, 6, 12),
@@ -124,17 +121,13 @@ TEST(MatTypesTest, invert)
     Matrix2 Mtest(Matrix2::Line(0.6,-0.7),
                   Matrix2::Line(-0.2,0.4));
 
-    // Test direct call to invertMatrix()
     EXPECT_EQ(Minv, Mtest);
 
-    // Test call to inverted() (Why is inverted()
     EXPECT_EQ(M.inverted(), Mtest);
 
-    // Test call to invert() in standard use case
     Minv.invert(M);
     EXPECT_EQ(Minv, Mtest);
 
-    // Test call to invert() in self-inversion case
     M.invert(M);
     EXPECT_EQ(M, Mtest);
 }

--- a/SofaKernel/framework/framework_test/defaulttype/MatTypes_test.cpp
+++ b/SofaKernel/framework/framework_test/defaulttype/MatTypes_test.cpp
@@ -117,10 +117,10 @@ TEST(MatTypesTest, invert)
 {
     Matrix2 M(Matrix2::Line(4.0, 7.0), Matrix2::Line(2.0, 6.0));
     Matrix2 Minv;
-    invertMatrix(Minv, M);
     Matrix2 Mtest(Matrix2::Line(0.6,-0.7),
                   Matrix2::Line(-0.2,0.4));
 
+    invertMatrix(Minv, M);
     EXPECT_EQ(Minv, Mtest);
 
     EXPECT_EQ(M.inverted(), Mtest);

--- a/SofaKernel/framework/framework_test/defaulttype/MatTypes_test.cpp
+++ b/SofaKernel/framework/framework_test/defaulttype/MatTypes_test.cpp
@@ -71,3 +71,70 @@ TEST(MatTypesTest, isTransform)
     M.identity();
     EXPECT_TRUE(M.isTransform());
 }
+
+/// Following input and result matrices were generated
+///  using matlab's 'magic' function
+
+TEST(MatTypesTest, transpose)
+{
+    Matrix4 M(Matrix4::Line(16, 2, 3, 13), Matrix4::Line(5, 11, 10, 8), Matrix4::Line(9, 7, 6, 12),
+              Matrix4::Line(4, 14, 15, 1));
+
+    Matrix4 Mnew;
+    Mnew.transpose(M);
+
+    Matrix4 Mtest(Matrix4::Line(16, 5, 9, 4), Matrix4::Line(2, 11, 7, 14), Matrix4::Line(3, 10, 6, 15),
+                  Matrix4::Line(13, 8, 12, 1));
+
+    EXPECT_EQ(Mnew, Mtest);
+    EXPECT_EQ(M.transposed(), Mtest);
+
+    M.transpose(M);
+    EXPECT_EQ(M, Mtest);
+
+    M = Matrix4(Matrix4::Line(16, 2, 3, 13), Matrix4::Line(5, 11, 10, 8), Matrix4::Line(9, 7, 6, 12),
+              Matrix4::Line(4, 14, 15, 1));
+
+    M.transpose();
+    EXPECT_EQ(M, Mtest);
+
+    M.identity();
+    EXPECT_EQ(M.transposed(), M);
+}
+
+TEST(MatTypesTest, nonSquareTranspose)
+{
+    Mat<3,4,double> M(Matrix4::Line(16, 2, 3, 13), Matrix4::Line(5, 11, 10, 8), Matrix4::Line(9, 7, 6, 12));
+
+    Mat<4,3,double> Mnew;
+    Mnew.transpose(M);
+
+    Mat<4,3,double> Mtest(Matrix3::Line(16,5,9), Matrix3::Line(2,11,7), Matrix3::Line(3,10,6), Matrix3::Line(13,8,12));
+
+    EXPECT_EQ(Mnew, Mtest);
+    EXPECT_EQ(M.transposed(), Mtest);
+    EXPECT_EQ(M, Mtest.transposed());
+}
+
+TEST(MatTypesTest, invert)
+{
+    Matrix2 M(Matrix2::Line(4.0, 7.0), Matrix2::Line(2.0, 6.0));
+    Matrix2 Minv;
+    invertMatrix(Minv, M);
+    Matrix2 Mtest(Matrix2::Line(0.6,-0.7),
+                  Matrix2::Line(-0.2,0.4));
+
+    // Test direct call to invertMatrix()
+    EXPECT_EQ(Minv, Mtest);
+
+    // Test call to inverted() (Why is inverted()
+    EXPECT_EQ(M.inverted(), Mtest);
+
+    // Test call to invert() in standard use case
+    Minv.invert(M);
+    EXPECT_EQ(Minv, Mtest);
+
+    // Test call to invert() in self-inversion case
+    M.invert(M);
+    EXPECT_EQ(M, Mtest);
+}

--- a/SofaKernel/framework/sofa/defaulttype/Mat.h
+++ b/SofaKernel/framework/sofa/defaulttype/Mat.h
@@ -360,10 +360,10 @@ public:
         return m;
     }
 
-        /// Transpose the square matrix.
-        void transpose()
+    /// Transpose the square matrix.
+    void transpose()
     {
-                assert(L == C && "Cannot self-transpose a non-square matrix. Use transposed() instead");
+        assert(L == C && "Cannot self-transpose a non-square matrix. Use transposed() instead");
         for (int i=0; i<L; i++)
             for (int j=i+1; j<C; j++)
             {

--- a/SofaKernel/framework/sofa/defaulttype/Mat.h
+++ b/SofaKernel/framework/sofa/defaulttype/Mat.h
@@ -327,10 +327,15 @@ public:
     /// Set matrix as the transpose of m.
     void transpose(const Mat<C,L,real> &m)
     {
-        for (int i=0; i<L; i++)
-            for (int j=0; j<C; j++)
-                this->elems[i][j]=m[j][i];
-    }
+				if (L == C && reinterpret_cast<Mat<C,L,real>*>(this) == &m)
+						this->operator =(transposed());
+				else
+				{
+						for (int i=0; i<L; i++)
+								for (int j=0; j<C; j++)
+										this->elems[i][j]=m[j][i];
+				}
+		}
 
     /// Return the transpose of m.
     Mat<C,L,real> transposed() const
@@ -599,10 +604,26 @@ public:
             this->elems[i]-=m[i];
     }
 
+
+		/// invert this
+		Mat<L,C,real>& inverted()
+		{
+			Mat<L,C,real> m = *this;
+			invertMatrix(*this, m);
+			return *this;
+		}
+
     /// Invert matrix m
     bool invert(const Mat<L,C,real>& m)
     {
-        return invertMatrix(*this, m);
+				if (&m == this)
+				{
+						Mat<L,C,real> mat = m;
+						bool res = invertMatrix(mat, m);
+						this->operator =(mat);
+						return res;
+				}
+				return invertMatrix(*this, m);
     }
 
     static Mat<L,C,real> transformTranslation(const Vec<C-1,real>& t)

--- a/SofaKernel/framework/sofa/defaulttype/Mat.h
+++ b/SofaKernel/framework/sofa/defaulttype/Mat.h
@@ -341,7 +341,17 @@ public:
     void transpose(const Mat<C,L,real> &m)
     {
         if (canSelfTranspose(*this, m))
-            *this = transposed();
+        {
+            for (int i=0; i<L; i++)
+            {
+                for (int j=i+1; j<C; j++)
+                {
+                    real t = this->elems[i][j];
+                    this->elems[i][j] = this->elems[j][i];
+                    this->elems[j][i] = t;
+                }
+            }
+        }
         else
         {
             for (int i=0; i<L; i++)
@@ -365,12 +375,14 @@ public:
     {
         static_assert(L == C, "Cannot self-transpose a non-square matrix. Use transposed() instead");
         for (int i=0; i<L; i++)
+        {
             for (int j=i+1; j<C; j++)
             {
                 real t = this->elems[i][j];
                 this->elems[i][j] = this->elems[j][i];
                 this->elems[j][i] = t;
             }
+        }
     }
 
     /// @name Tests operators

--- a/SofaKernel/framework/sofa/defaulttype/Mat.h
+++ b/SofaKernel/framework/sofa/defaulttype/Mat.h
@@ -619,12 +619,12 @@ public:
 
 
     /// invert this
-    Mat<L,C,real>& inverted()
+    Mat<L,C,real>& inverted() const
     {
         static_assert(L == C, "Cannot invert a non-square matrix");
         Mat<L,C,real> m = *this;
-        invertMatrix(*this, m);
-        return *this;
+        invertMatrix(m, *this);
+        return m;
     }
 
     /// Invert square matrix m

--- a/SofaKernel/framework/sofa/defaulttype/Mat.h
+++ b/SofaKernel/framework/sofa/defaulttype/Mat.h
@@ -627,22 +627,14 @@ public:
         return *this;
     }
 
-    /// assert when trying to invert a non-square matrix
-    bool invert(const Mat<L,C,real>& /*m*/)
+    /// Invert square matrix m
+    bool invert(const Mat<L,C,real>& m)
     {
         static_assert(L == C, "Cannot invert a non-square matrix");
-        return false;
-    }
-
-    /// Invert square matrix m
-    template<int S>
-    bool invert(const Mat<S,S,real>& m)
-    {
         if (&m == this)
         {
-            Mat<S,S,real> mat = m;
-            bool res = invertMatrix(mat, m);
-            this->operator =(mat);
+            Mat<L,C,real> mat = m;
+            bool res = invertMatrix(*this, mat);
             return res;
         }
         return invertMatrix(*this, m);

--- a/SofaKernel/framework/sofa/defaulttype/Mat.h
+++ b/SofaKernel/framework/sofa/defaulttype/Mat.h
@@ -619,7 +619,7 @@ public:
 
 
     /// invert this
-    Mat<L,C,real>& inverted() const
+    Mat<L,C,real> inverted() const
     {
         static_assert(L == C, "Cannot invert a non-square matrix");
         Mat<L,C,real> m = *this;

--- a/SofaKernel/framework/sofa/defaulttype/Mat.h
+++ b/SofaKernel/framework/sofa/defaulttype/Mat.h
@@ -341,7 +341,7 @@ public:
     void transpose(const Mat<C,L,real> &m)
     {
         if (canSelfTranspose(*this, m))
-            transpose();
+            *this = transposed();
         else
         {
             for (int i=0; i<L; i++)
@@ -363,7 +363,7 @@ public:
     /// Transpose the square matrix.
     void transpose()
     {
-        assert(L == C && "Cannot self-transpose a non-square matrix. Use transposed() instead");
+        static_assert(L == C, "Cannot self-transpose a non-square matrix. Use transposed() instead");
         for (int i=0; i<L; i++)
             for (int j=i+1; j<C; j++)
             {

--- a/SofaKernel/framework/sofa/defaulttype/Mat.h
+++ b/SofaKernel/framework/sofa/defaulttype/Mat.h
@@ -346,9 +346,7 @@ public:
             {
                 for (int j=i+1; j<C; j++)
                 {
-                    real t = this->elems[i][j];
-                    this->elems[i][j] = this->elems[j][i];
-                    this->elems[j][i] = t;
+                    std::swap(this->elems[i][j], this->elems[j][i]);
                 }
             }
         }
@@ -378,9 +376,7 @@ public:
         {
             for (int j=i+1; j<C; j++)
             {
-                real t = this->elems[i][j];
-                this->elems[i][j] = this->elems[j][i];
-                this->elems[j][i] = t;
+                std::swap(this->elems[i][j], this->elems[j][i]);
             }
         }
     }


### PR DESCRIPTION
when passing "this" as argument, forcing object copy to avoid unexpected results
Fixes #280 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
