### PR TITLE
[Fix cuda] Fix compilation problem with cuda. 

### DIFF
--- a/SofaKernel/framework/sofa/helper/vector_device.h
+++ b/SofaKernel/framework/sofa/helper/vector_device.h
@@ -650,6 +650,18 @@ public:
         return *hostWriteAt(i);
     }
 
+    const T* data( ) const
+    {
+        checkIndex ( 0 );
+        return hostReadAt(0);
+    }
+
+    T* data( )
+    {
+        checkIndex ( 0 );
+        return hostWriteAt(0);
+    }
+
     const T& getCached ( size_type i ) const
     {
         checkIndex ( i );


### PR DESCRIPTION
The access to the pointer of data &ptr[0] have been replaced by the use of .data() in PR #279 

This generate a problem because helper::vector is specialized for cuda (thanks to the MemoryManager) in vector_device.h. This type of vector mimic a std::vector but it does not implement all the functions of the stl. If new functions are necessary they must be also implemented in this vector_device class, but the consistency of data must be CAREFULLY checked. Indeed a cudavector has data both on the CPU and the GPU and one must guarantee that the accessed data is the correct one.

This PR add the missing function in vector_device to make it match the API of helper::vector.  
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
