### PR TITLE
[SceneChecker] Add mechanisme to report API & SceneChange to users.  (NOW CLEAN IN PR 329)

### DIFF
--- a/SofaKernel/framework/sofa/core/objectmodel/BaseContext.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseContext.h
@@ -89,11 +89,11 @@ public:
 protected:
     BaseContext();
     virtual ~BaseContext();
-	
-private:	
-	BaseContext(const BaseContext&);
+
+private:
+    BaseContext(const BaseContext&);
     BaseContext& operator=(const BaseContext& );
-    
+
 public:
     /// Get the default Context object, that contains the default values for
     /// all parameters and can be used when no local context is defined.
@@ -114,11 +114,11 @@ public:
     /// State of the context
     virtual void setActive(bool) {}
 
-	/// Sleeping state of the context
-	virtual bool isSleeping() const;
+    /// Sleeping state of the context
+    virtual bool isSleeping() const;
 
-	/// Whether the context can change its sleeping state or not
-	virtual bool canChangeSleepingState() const;
+    /// Whether the context can change its sleeping state or not
+    virtual bool canChangeSleepingState() const;
 
     /// Simulation time
     virtual SReal getTime() const;
@@ -240,6 +240,12 @@ public:
     /// Note that the template wrapper method should generally be used to have the correct return type,
     virtual void getObjects(const ClassInfo& class_info, GetObjectsCallBack& container, const TagSet& tags, SearchDirection dir = SearchUp) const;
 
+    /// Returns a list of object of type passed as a parameter.
+    template<class Container=std::vector<sofa::core::objectmodel::BaseObject*>>
+    Container& getNodeObjects(Container& result=Container(), SearchDirection dir = SearchUp){
+        this->get<Container::value_type, Container>(result, dir);
+        return result ;
+    }
 
     /// Generic object access template wrapper, possibly searching up or down from the current context
     template<class T>
@@ -376,13 +382,13 @@ public:
     virtual void setAnimate(bool /*val*/)
     { }
 
-	/// Sleeping state of the context
-	virtual void setSleeping(bool /*val*/) 
-	{ }
+    /// Sleeping state of the context
+    virtual void setSleeping(bool /*val*/)
+    { }
 
-	/// Sleeping state change of the context
-	virtual void setChangeSleepingState(bool /*val*/)
-	{ }
+    /// Sleeping state change of the context
+    virtual void setChangeSleepingState(bool /*val*/)
+    { }
 
 #ifdef SOFA_SUPPORT_MULTIRESOLUTION
     /// Multiresolution support (UNSTABLE) : Set the current level, return false if l >= coarsestLevel

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseLink.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseLink.cpp
@@ -62,7 +62,7 @@ void BaseLink::printValue( std::ostream& o ) const
 {
     std::size_t size = getSize();
     bool first = true;
-	for (std::size_t i = 0; i<size; ++i)
+    for (std::size_t i = 0; i<size; ++i)
     {
         std::string path = getLinkedPath(i);
         if (path.empty()) continue;
@@ -112,13 +112,13 @@ bool BaseLink::ParseString(const std::string& text, std::string* path, std::stri
 {
     if (text.empty())
     {
-        if (owner) owner->serr << "ERROR parsing Link \""<<text<<"\": empty path." << owner->sendl;
+        if (owner) msg_error(owner) << "Parsing Link \""<<text<<"\": empty path.";
         else msg_error("BaseLink") << "ParseString: \""<<text<<"\": empty path.";
         return false;
     }
     if (text[0] != '@')
     {
-        if (owner) owner->serr << "ERROR parsing Link \""<<text<<"\": first character should be '@'." << owner->sendl;
+        if (owner) msg_error(owner) << "ERROR parsing Link \""<<text<<"\": first character should be '@'.";
         else msg_error("BaseLink") << "ParseString: \""<<text<<"\": first character should be '@'.";
         return false;
     }
@@ -130,14 +130,14 @@ bool BaseLink::ParseString(const std::string& text, std::string* path, std::stri
     if (posDot == text.size()-1 && (text[posDot-1] == '/' || posDot == 1)) posDot = std::string::npos; // a single dot is allowed at the end of the path, although it is better to end it with '/' instead in order to remove any ambiguity
     if (!data && posDot != std::string::npos)
     {
-        if (owner) owner->serr << "ERROR parsing Link \""<<text<<"\": a Data field name is specified while an object was expected." << owner->sendl;
+        if (owner) msg_error(owner) << "Parsing Link \""<<text<<"\": a Data field name is specified while an object was expected.";
         else msg_error("BaseLink") << "ParseString: \""<<text<<"\": a Data field name is specified while an object was expected.";
         return false;
     }
 
     if (data && data->empty() && posDot == std::string::npos)
     {
-        if (owner) owner->serr << "ERROR parsing Link \""<<text<<"\": a Data field name is required." << owner->sendl;
+        if (owner) msg_error(owner) << "Parsing Link \""<<text<<"\": a Data field name is required." ;
         else msg_error("BaseLink") << "ParseString: \""<<text<<"\": a Data field name is required.";
         return false;
     }
@@ -157,21 +157,17 @@ bool BaseLink::ParseString(const std::string& text, std::string* path, std::stri
     {
         if ((*path)[0] == '[' && (*path)[path->size()-1] != ']')
         {
-            if (owner) owner->serr << "ERROR parsing Link \""<<text<<"\": missing closing bracket ']'." << owner->sendl;
+            if (owner) msg_error(owner) << "Parsing Link \""<<text<<"\": missing closing bracket ']'." ;
             else msg_error("BaseLink") << "ParseString: \""<<text<<"\": missing closing bracket ']'.";
             return false;
         }
         if ((*path)[0] == '[' && (*path)[1] != '-' && (*path)[1] != ']')
         {
-            if (owner) owner->serr << "ERROR parsing Link \""<<text<<"\": bracket syntax can only be used for self-reference or preceding objects with a negative index." << owner->sendl;
+            if (owner) msg_error(owner) << "Parsing Link \""<<text<<"\": bracket syntax can only be used for self-reference or preceding objects with a negative index." << owner->sendl;
             else msg_error("BaseLink") << "ParseString: \""<<text<<"\": bracket syntax can only be used for self-reference or preceding objects with a negative index.";
             return false;
         }
     }
-    //std::cout << "LINK: Parsed \"" << text << "\":";
-    //if (path) std::cout << " path=\"" << *path << "\"";
-    //if (data) std::cout << " data=\"" << *data << "\"";
-    //std::cout << std::endl;
     return true;
 }
 

--- a/SofaKernel/framework/sofa/helper/logging/Message.cpp
+++ b/SofaKernel/framework/sofa/helper/logging/Message.cpp
@@ -126,6 +126,13 @@ bool Message::empty() const
     return end <= 0;
 }
 
+template<>
+Message& Message::operator<<(const FileInfo &fi)
+{
+    (*m_fileInfo.get()) = fi;
+    return *this;
+}
+
 
 
 } // logging

--- a/SofaKernel/framework/sofa/helper/logging/Message.h
+++ b/SofaKernel/framework/sofa/helper/logging/Message.h
@@ -100,6 +100,9 @@ protected:
 
 };
 
+
+template<> Message& Message::operator<<(const FileInfo &fi) ;
+
 SOFA_HELPER_API std::ostream& operator<< (std::ostream&, const Message&) ;
 SOFA_HELPER_API const std::string toString(const Message::Type type) ;
 

--- a/SofaKernel/framework/sofa/helper/logging/Messaging.h
+++ b/SofaKernel/framework/sofa/helper/logging/Messaging.h
@@ -135,6 +135,8 @@
 #define msg_fatal_withfile(emitter, file,line)      sofa::helper::logging::MessageDispatcher::fatal(sofa::helper::logging::Message::Runtime, sofa::helper::logging::getComponentInfo(emitter), SOFA_FILE_INFO2(file,line))
 #define msg_advice_withfile(emitter, file,line)      sofa::helper::logging::MessageDispatcher::advice(sofa::helper::logging::Message::Runtime, sofa::helper::logging::getComponentInfo(emitter), SOFA_FILE_INFO2(file,line))
 
+#define FILEINFO(filename, line) sofa::helper::logging::FileInfo(filename, line)
+
 /// THESE MACRO BEASTS ARE FOR AUTOMATIC DETECTION OF MACRO NO or ONE ARGUMENTS
 #define TWO_FUNC_CHOOSER(_f1, _f2 ,...) _f2
 #define TWO_FUNC_RECOMPOSER(argsWithParentheses) TWO_FUNC_CHOOSER argsWithParentheses

--- a/SofaKernel/framework/sofa/simulation/Node.h
+++ b/SofaKernel/framework/sofa/simulation/Node.h
@@ -33,6 +33,8 @@
 #ifndef SOFA_SIMULATION_CORE_NODE_H
 #define SOFA_SIMULATION_CORE_NODE_H
 
+#include <type_traits>
+
 #include <sofa/core/ExecParams.h>
 #include <sofa/core/objectmodel/Context.h>
 // moved from GNode (27/04/08)
@@ -351,15 +353,27 @@ public:
         getObjects(class_info, container, sofa::core::objectmodel::TagSet(), dir);
     }
 
-
-
-
     /// List all objects of this node deriving from a given class
     template<class Object, class Container>
     void getNodeObjects(Container* list)
     {
         this->get<Object, Container>(list, Local);
     }
+
+    /// Returns a list of object of type passed as a parameter.
+    template<class Container>
+    Container& getNodeObjects(Container& result){
+        this->get<typename std::remove_pointer<typename Container::value_type>::type, Container>(&result, Local);
+        return result ;
+    }
+
+    /// Returns a list of object of type passed as a parameter.
+    template<class Container>
+    Container& getNodeObjects(Container* result){
+        this->get<typename std::remove_pointer<typename Container::value_type>::type, Container>(result, Local);
+        return result ;
+    }
+
 
     /// Return an object of this node deriving from a given class, or NULL if not found.
     /// Note that only the first object is returned.
@@ -482,8 +496,8 @@ public:
     /// return the smallest common parent between this and node2 (returns NULL if separated sub-graphes)
     virtual Node* findCommonParent( simulation::Node* node2 ) = 0;
 
-	/// override context setSleeping to add notification.
-	virtual void setSleeping(bool /*val*/);
+    /// override context setSleeping to add notification.
+    virtual void setSleeping(bool /*val*/);
 
 protected:
     bool debug_;
@@ -501,7 +515,7 @@ protected:
     virtual void notifyAddObject(sofa::core::objectmodel::BaseObject::SPtr obj);
     virtual void notifyRemoveObject(sofa::core::objectmodel::BaseObject::SPtr obj);
     virtual void notifyMoveObject(sofa::core::objectmodel::BaseObject::SPtr obj, Node* prev);
-	virtual void notifySleepChanged();
+    virtual void notifySleepChanged();
 
 
     BaseContext* _context;

--- a/SofaKernel/modules/SofaSimulationCommon/xml/BaseElement.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/xml/BaseElement.cpp
@@ -44,14 +44,10 @@ BaseElement::BaseElement(const std::string& name, const std::string& type, BaseE
     : BaseObjectDescription(name.c_str(), type.c_str()), parent(NULL), includeNodeType(INCLUDE_NODE_CHILD)
 {
     if (newParent!=NULL) newParent->addChild(this);
-    //attributes["name"]=&this->name;
-    //attributes["type"]=&this->type;
 }
 
 BaseElement::~BaseElement()
 {
-    //attributes.erase("name");
-    //attributes.erase("type");
     for (ChildList::iterator it = children.begin();
             it != children.end(); ++it)
     {
@@ -96,18 +92,6 @@ void BaseElement::setSrcLine(const int l)
     m_srcline = l ;
 }
 
-
-// const std::map<std::string,std::string*>& BaseElement::getAttributeMap() const
-// {
-// 	return attributes;
-// }
-//
-// std::map<std::string,std::string*>& BaseElement::getAttributeMap()
-// {
-// 	return attributes;
-// }
-
-
 bool BaseElement::presenceAttribute(const std::string& s)
 {
     return (attributes.find(s) != attributes.end());
@@ -118,11 +102,6 @@ bool BaseElement::removeAttribute(const std::string& attr)
     AttributeMap::iterator it = attributes.find(attr);
     if (it == attributes.end())
         return false;
-    //if (it->second == &name)
-    //    return false;
-    //if (it->second == &type)
-    //    return false;
-    //delete it->second;
     attributes.erase(it);
     return true;
 }

--- a/SofaKernel/modules/SofaSimulationCommon/xml/BaseElement.h
+++ b/SofaKernel/modules/SofaSimulationCommon/xml/BaseElement.h
@@ -52,9 +52,6 @@ enum IncludeNodeType
 class SOFA_SIMULATION_COMMON_API BaseElement : public core::objectmodel::BaseObjectDescription
 {
 private:
-    //std::string name;
-    //std::string type;
-
     std::string basefile;
     std::string m_srcfile;
     int m_srcline;

--- a/SofaKernel/modules/SofaSimulationCommon/xml/NodeElement.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/xml/NodeElement.cpp
@@ -63,7 +63,6 @@ bool NodeElement::initNode()
         core::objectmodel::BaseNode* baseNode;
         if (getTypedObject()!=NULL && getParentElement()!=NULL && (baseNode = getParentElement()->getObject()->toBaseNode()))
         {
-            // 		std::cout << "Adding Child "<<getName()<<" to "<<getParentElement()->getName()<<std::endl;
             baseNode->addChild(getTypedObject());
         }
         return true;
@@ -77,16 +76,11 @@ bool NodeElement::initNode()
 bool NodeElement::init()
 {
     bool res = Element<core::objectmodel::BaseNode>::init();
-    //Store the warnings created by the objects
+
+    /// send the errors created by the object in this node in the node's log
     for (unsigned int i=0; i<errors.size(); ++i)
     {
-        //TODO(dmarchal): This way of getting the name of a component should be replaced
-        // with the use of the ComponentInfo from message.h.
-
-        const std::string name = getObject()->getClassName() + " \"" + getObject()->getName() + "\"";
-        //MAINLOGGER( Error, errors[i], name );
-        //msg_error(this) << errors[i];
-        msg_error(name) << errors[i];
+        msg_error(getObject()) << errors[i];
     }
 
     return res;

--- a/SofaKernel/modules/SofaSimulationCommon/xml/ObjectElement.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/xml/ObjectElement.cpp
@@ -84,26 +84,19 @@ bool ObjectElement::initNode()
         return false;
     }
     setObject(obj);
-    // display any unused attributes
-    //std::string unused;
+    /// display any unused attributes
     for (AttributeMap::iterator it = attributes.begin(), itend = attributes.end(); it != itend; ++it)
     {
         if (!it->second.isAccessed())
         {
             std::string name = it->first;
-            // ignore some prefix that are used to quickly disable parameters in XML files
-            if (name.substr(0,1) == "_" || name.substr(0,2) == "NO") continue;
-            //unused += ' ';
-            //unused += name;
 
-            obj->serr <<"Unused Attribute: \""<<it->first <<"\" with value: \"" <<it->second.c_str() <<"\"" << obj->sendl;
+            /// ignore some prefix that are used to quickly disable parameters in XML files
+            if (name.substr(0,1) == "_" || name.substr(0,2) == "NO") continue;
+
+            msg_warning(obj.get()) << SOFA_FILE_INFO2(getSrcFile(), getSrcLine()) << "Unused Attribute: \""<<it->first <<"\" with value: \"" <<it->second.c_str() <<"\"" ;
         }
     }
-//     if (!unused.empty())
-//     {
-//         msg_warning("XML") << "Unused attribute(s) in "<<getFullName()<<" :"<<unused";
-//     }
-
     return true;
 }
 

--- a/applications/sofa/gui/qt/RealGUI.cpp
+++ b/applications/sofa/gui/qt/RealGUI.cpp
@@ -147,17 +147,8 @@ protected:
         {
         case QEvent::FileOpen:
         {
-//            std::string filename = static_cast<QFileOpenEvent *>(event)->file().toStdString();
             if(this->topLevelWidgets().count() < 1)
                 return false;
-//            RealGUI* mainGui = static_cast<RealGUI*>(this->topLevelWidgets()[0]);
-            //mainGui->fileOpen(filename);
-
-//            if (filename != std::string(static_cast<RealGUI*>(QApplication::topLevelWidgets()[0])->windowFilePath().toStdString()))
-//            {
-//                static_cast<RealGUI*>(QApplication::topLevelWidgets()[0])->fileOpen(static_cast<QFileOpenEvent *>(event)->file().toStdString());
-//            }
-
             return true;
         }
         default:
@@ -299,7 +290,6 @@ RealGUI::RealGUI ( const char* viewername, const std::vector<std::string>& optio
 {
     setupUi(this);
 
-//    this->setWindowFlags(Qt::CustomizeWindowHint | Qt::FramelessWindowHint);
     parseOptions(options);
 
     createPluginManager();
@@ -331,19 +321,10 @@ RealGUI::RealGUI ( const char* viewername, const std::vector<std::string>& optio
     }
 
     this->setDockOptions(QMainWindow::AnimatedDocks | QMainWindow::AllowTabbedDocks);
-    //dockWidget=new QDockWidget(tr(""), this);
-    //dockWidget->setResizeEnabled(true);
-    //dockWidget->setFixedWidth(300);
     dockWidget->setFeatures(QDockWidget::AllDockWidgetFeatures);
     dockWidget->setAllowedAreas(Qt::RightDockWidgetArea | Qt::LeftDockWidgetArea);
-    //addDockWidget(Qt::LeftDockWidgetArea, dockWidget);
-    //dockWidget->setWidget(optionTabs);
 
     connect(dockWidget, SIGNAL(dockLocationChanged(Qt::DockWidgetArea)), this, SLOT(toolsDockMoved()));
-
-    /*moveDockWindow(dockWidget, Qt::DockLeft);
-    dockWidget->setFixedExtentWidth(400);
-    dockWidget->setFixedExtentHeight(600);*/
 
     // create a Dock Window to receive the Sofa Recorder
 #ifndef SOFA_GUI_QT_NO_RECORDER
@@ -394,26 +375,6 @@ RealGUI::RealGUI ( const char* viewername, const std::vector<std::string>& optio
 
     SofaMouseManager::getInstance()->hide();
     SofaVideoRecorderManager::getInstance()->hide();
-
-    //Center the application
-    /** This code doesn't work for all the multi screen config, so i comment and replace it by the previous code **/
-    /*
-    QSettings settings;
-    settings.beginGroup("viewer");
-    int screenNumber = settings.value("screenNumber", QApplication::desktop()->primaryScreen()).toInt();
-    settings.endGroup();
-
-    if (screenNumber >= QApplication::desktop()->screenCount())
-        screenNumber = QApplication::desktop()->primaryScreen();
-
-    int offset = 0;
-    if (screenNumber > 0)
-        for (int i = 0 ; i < screenNumber; i++)
-            offset = QApplication::desktop()->availableGeometry(i).width();
-
-    const QRect screen = QApplication::desktop()->availableGeometry(screenNumber);
-    this->move( offset + ( screen.width()- this->width()  ) / 2 - 200,  ( screen.height() - this->height()) / 2 - 50  );
-    */
 
     //Center the application
     const QRect screen = QApplication::desktop()->availableGeometry(QApplication::desktop()->primaryScreen());
@@ -719,14 +680,6 @@ int RealGUI::closeGUI()
     settings.setValue("screenNumber", QApplication::desktop()->screenNumber(this));
     settings.endGroup();
 
-//    std::string viewerFileName;
-//    std::string path = sofa::helper::system::DataRepository.getFirstPath();
-//    viewerFileName = path.append("/share/config/sofaviewer.ini");
-
-//    std::ofstream out(viewerFileName.c_str(),std::ios::out);
-//    out << sizeW->value() << std::endl << sizeH->value() << std::endl;
-//    out.close();
-
     delete this;
     return 0;
 }
@@ -777,6 +730,11 @@ void RealGUI::fileOpen ( std::string filename, bool temporaryFile )
     this->setWindowFilePath(filename.c_str());
     setExportGnuplot(exportGnuplotFilesCheckbox->isChecked());
     stopDumpVisitor();
+
+    /// We want to warn user that there is component that are implemented in specific plugin
+    /// and that there is no RequiredPlugin in their scene.
+    SceneCheckerVisitor checker(ExecParams::defaultInstance()) ;
+    checker.validate(mSimulation.get()) ;
 }
 
 
@@ -858,11 +816,6 @@ void RealGUI::fileOpen()
             else
                 fileOpen (s.toStdString());
     }
-
-    /// We want to warn user that there is component that are implemented in specific plugin
-    /// and that there is no RequiredPlugin in their scene.
-    SceneCheckerVisitor checker(ExecParams::defaultInstance()) ;
-    checker.validate(mSimulation.get()) ;
 }
 
 //------------------------------------
@@ -916,11 +869,13 @@ void RealGUI::setScene ( Node::SPtr root, const char* filename, bool temporaryFi
 
     if (root)
     {
+        /// We want to warn user that there is component that are implemented in specific plugin
+        /// and that there is no RequiredPlugin in their scene.
+        SceneCheckerVisitor checker(ExecParams::defaultInstance()) ;
+        checker.validate(root.get()) ;
+
         mSimulation = root;
-
         eventNewTime();
-
-        //simulation::getSimulation()->updateVisualContext ( root );
         startButton->setChecked(root->getContext()->getAnimate() );
         dtEdit->setText ( QString::number ( root->getDt() ) );
         simulationGraph->Clear(root.get());

--- a/modules/SofaGraphComponent/APIVersion.cpp
+++ b/modules/SofaGraphComponent/APIVersion.cpp
@@ -1,0 +1,77 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+/******************************************************************************
+*  Contributors:                                                              *
+*  - damien.marchal@univ-lille1.fr                                            *
+******************************************************************************/
+#include <sofa/core/objectmodel/BaseObject.h>
+using sofa::core::objectmodel::BaseObject ;
+
+#include <sofa/core/objectmodel/BaseContext.h>
+using sofa::core::objectmodel::BaseContext ;
+
+#include <sofa/core/objectmodel/BaseNode.h>
+using sofa::core::objectmodel::BaseNode ;
+
+#include <sofa/core/objectmodel/BaseObjectDescription.h>
+using sofa::core::objectmodel::BaseObjectDescription ;
+
+#include <sofa/simulation/Node.h>
+using sofa::simulation::Node ;
+
+#include <sofa/core/ObjectFactory.h>
+using sofa::core::ObjectFactory ;
+using sofa::core::RegisterObject ;
+
+#include "APIVersion.h"
+
+namespace sofa
+{
+
+namespace component
+{
+
+namespace _apiversion_
+{
+
+APIVersion::APIVersion() :
+     d_level ( initData(&d_level, 0, "level", "The API Level of the scene ('17.06', '17.12', '18.06')"))
+{
+}
+
+APIVersion::~APIVersion()
+{
+}
+
+const std::string& APIVersion::getApiLevel()
+{
+    return d_level.getValue() ;
+}
+
+SOFA_DECL_CLASS(APIVersion)
+int APIVersionClass = core::RegisterObject("Specify the APIVersion of the component used in a scene.")
+        .add< APIVersion >();
+
+} // namespace _apiversion_
+
+} // namespace component
+
+} // namespace sofa

--- a/modules/SofaGraphComponent/APIVersion.h
+++ b/modules/SofaGraphComponent/APIVersion.h
@@ -1,0 +1,61 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+/******************************************************************************
+*  Contributors:                                                              *
+*  - damien.marchal@univ-lille1.fr                                            *
+******************************************************************************/
+#include <sofa/core/objectmodel/BaseObject.h>
+using sofa::core::objectmodel::BaseObject ;
+
+#include "config.h"
+
+namespace sofa
+{
+
+namespace component
+{
+
+namespace _apiversion_
+{
+
+class SOFA_GRAPH_COMPONENT_API APIVersion : public BaseObject
+{
+
+public:
+    SOFA_CLASS(APIVersion, BaseObject);
+
+    const std::string& getApiLevel() ;
+
+protected:
+    APIVersion() ;
+    virtual ~APIVersion() ;
+
+private:
+    Data<std::string>  d_level ;
+};
+
+} // namespace _apiversion_
+
+using _apiversion_::APIVersion ;
+
+} // namespace component
+
+} // namespace sofa

--- a/modules/SofaGraphComponent/CMakeLists.txt
+++ b/modules/SofaGraphComponent/CMakeLists.txt
@@ -17,6 +17,7 @@ set(HEADER_FILES
     StatsSetting.h
     ViewerSetting.h
     SceneCheckerVisitor.h
+    APIVersion.h
     config.h
     initGraphComponent.h
 )
@@ -36,6 +37,7 @@ set(SOURCE_FILES
     StatsSetting.cpp
     ViewerSetting.cpp
     SceneCheckerVisitor.cpp
+    APIVersion.cpp
     initGraphComponent.cpp
 )
 

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
@@ -61,6 +61,11 @@ void SceneCheckerVisitor::installChangeSets()
     }) ;
 
     addHookInChangeSet("17.06", [](Base* o){
+        if(o->getClassName() == "BoxStiffSpringForceField" )
+            msg_warning(o) << "BoxStiffSpringForceField have changed since 17.06. To use the old behavior you need to set parameter 'forceOldBehavior=true'" ;
+    }) ;
+
+    addHookInChangeSet("17.06", [](Base* o){
         if(o->getClassName() == "TheComponentWeWantToRemove" )
             msg_warning(o) << "TheComponentWewantToRemove is deprecated since sofa 17.06. It have been replaced by TheSuperComponent. #See PR318" ;
     }) ;

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
@@ -19,15 +19,20 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "SceneCheckerVisitor.h"
-#include "RequiredPlugin.h"
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/helper/system/PluginManager.h>
+
+#include "SceneCheckerVisitor.h"
+#include "RequiredPlugin.h"
+
+#include "APIVersion.h"
+using sofa::component::APIVersion ;
 
 namespace sofa
 {
 namespace simulation
 {
+using sofa::core::objectmodel::Base ;
 using sofa::component::misc::RequiredPlugin ;
 using sofa::core::ObjectFactory ;
 using sofa::core::ExecParams ;
@@ -36,44 +41,109 @@ using sofa::helper::system::PluginManager ;
 
 SceneCheckerVisitor::SceneCheckerVisitor(const ExecParams* params) : Visitor(params)
 {
+    installChangeSets() ;
 }
 
 SceneCheckerVisitor::~SceneCheckerVisitor()
 {
 }
 
+void SceneCheckerVisitor::addHookInChangeSet(const std::string& version, ChangeSetHookFunction fct)
+{
+    m_changesets[version].push_back(fct) ;
+}
+
+void SceneCheckerVisitor::installChangeSets()
+{
+    addHookInChangeSet("17.06", [](Base* o){
+        if(o->getClassName() == "RestShapeSpringsForceField" && o->findData("external_rest_shape")->isSet())
+            msg_warning(o) << "RestShapeSpringsForceField have changed since 17.06. The parameter 'external_rest_shape' is now a Link. To fix your scene you need to add and '@' in front of the provided path. See PR#315" ;
+    }) ;
+
+    addHookInChangeSet("17.06", [](Base* o){
+        if(o->getClassName() == "TheComponentWeWantToRemove" )
+            msg_warning(o) << "TheComponentWewantToRemove is deprecated since sofa 17.06. It have been replaced by TheSuperComponent. #See PR318" ;
+    }) ;
+}
+
 void SceneCheckerVisitor::validate(Node* node)
+{
+    enableValidationAPIVersion(node, "17.12") ;
+    enableValidationRequiredPlugins(node) ;
+
+    msg_info("SceneChecker") << "Validating a scene: " << msgendl
+                             << "- APIVersion checking: " << m_isAPIVersionValidationEnabled << msgendl
+                             << "- RequiredPlugin checking: " << m_isRequiredPluginValidationEnabled ;
+
+    execute(node) ;
+}
+
+void SceneCheckerVisitor::enableValidationAPIVersion(Node* node, const std::string& currentApiLevel)
+{
+    APIVersion* apiversion {nullptr} ;
+
+    /// 1. Find if there is an APIVersion component in the scene. If there is none, warn the user and set
+    /// the version to 17.06 (the last version before it was introduced). If there is one...use
+    /// this component to request the API version requested by the scene.
+    m_currentApiLevel = currentApiLevel ;
+    node->getTreeObject(apiversion) ;
+    if(!apiversion)
+    {
+        msg_info("SceneChecker") << "The 'APIVersion' directive is missing in the current scene. Switching to the APIVersion level '"<< m_selectedApiLevel <<"' " ;
+    }
+    else
+    {
+        m_selectedApiLevel = apiversion->getApiLevel() ;
+    }
+
+    /// 2. We activate if the API level mis-match. In the future we may want to be able to handle
+    /// more precise way to track difference between version but for the moment let's take the
+    /// easy path for the developpers.
+    m_isAPIVersionValidationEnabled = m_selectedApiLevel != m_currentApiLevel ;
+}
+
+void SceneCheckerVisitor::enableValidationRequiredPlugins(Node* node)
 {
     helper::vector< RequiredPlugin* > plugins ;
     node->getTreeObjects< RequiredPlugin >(&plugins) ;
 
     for(auto& plugin : plugins)
         m_requiredPlugins[plugin->getName()] = true ;
-
-    execute(node) ;
 }
 
 Visitor::Result SceneCheckerVisitor::processNodeTopDown(Node* node)
 {
     for (auto& object : node->object )
     {
-        ObjectFactory::ClassEntry entry = ObjectFactory::getInstance()->getEntry(object->getClassName());
-        if(!entry.creatorMap.empty())
+        if(m_isRequiredPluginValidationEnabled)
         {
-            ObjectFactory::CreatorMap::iterator it = entry.creatorMap.find(object->getTemplateName());
-            if(entry.creatorMap.end() != it && *it->second->getTarget()){
-                std::string pluginName = it->second->getTarget() ;
-                std::string path = PluginManager::getInstance().findPlugin(pluginName) ;
-                if( PluginManager::getInstance().pluginIsLoaded(path)
-                    && m_requiredPlugins.find(pluginName) == m_requiredPlugins.end() )
-                {
-                    msg_warning("SceneChecker") << "This scene is using component '" << object->getClassName() << "'. " << msgendl
-                                                << "This component is part of the '" << pluginName << "' plugin but there is no <RequiredPlugin name='" << pluginName << "'> directive in your scene." << msgendl
-                                                << "Your scene may not work on a sofa environment that does not have pre-loaded the plugin." << msgendl
-                                                << "To fix your scene and remove this warning you need to add the RequiredPlugin directive at the beginning of your scene. ";
+            ObjectFactory::ClassEntry entry = ObjectFactory::getInstance()->getEntry(object->getClassName());
+            if(!entry.creatorMap.empty())
+            {
+                ObjectFactory::CreatorMap::iterator it = entry.creatorMap.find(object->getTemplateName());
+                if(entry.creatorMap.end() != it && *it->second->getTarget()){
+                    std::string pluginName = it->second->getTarget() ;
+                    std::string path = PluginManager::getInstance().findPlugin(pluginName) ;
+                    if( PluginManager::getInstance().pluginIsLoaded(path)
+                            && m_requiredPlugins.find(pluginName) == m_requiredPlugins.end() )
+                    {
+                        msg_warning("SceneChecker") << "This scene is using component '" << object->getClassName() << "'. " << msgendl
+                                                    << "This component is part of the '" << pluginName << "' plugin but there is no <RequiredPlugin name='" << pluginName << "'> directive in your scene." << msgendl
+                                                    << "Your scene may not work on a sofa environment that does not have pre-loaded the plugin." << msgendl
+                                                    << "To fix your scene and remove this warning you need to add the RequiredPlugin directive at the beginning of your scene. ";
+                    }
                 }
             }
-
+        }
+        if(m_isAPIVersionValidationEnabled)
+        {
+            if(m_selectedApiLevel != m_currentApiLevel && m_changesets.find(m_selectedApiLevel) != m_changesets.end())
+            {
+                for(auto& hook : m_changesets[m_selectedApiLevel])
+                {
+                    hook(object.get());
+                }
+            }
         }
     }
     return RESULT_CONTINUE;

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.h
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.h
@@ -24,14 +24,16 @@
 
 #include "config.h"
 
+#include <functional>
 #include <map>
+
 #include <sofa/simulation/Visitor.h>
 
 namespace sofa
 {
-
 namespace simulation
 {
+typedef std::function<void(sofa::core::objectmodel::Base*)> ChangeSetHookFunction ;
 
 class SOFA_GRAPH_COMPONENT_API SceneCheckerVisitor : public Visitor
 {
@@ -40,9 +42,22 @@ public:
     virtual ~SceneCheckerVisitor() ;
 
     void validate(Node* node) ;
+
+    void enableValidationAPIVersion(Node *node, const std::string& currentApiLevel) ;
+    void enableValidationRequiredPlugins(Node* node) ;
+
     virtual Result processNodeTopDown(Node* node) override ;
+
+    void installChangeSets() ;
+    void addHookInChangeSet(const std::string& version, ChangeSetHookFunction fct) ;
 private:
     std::map<std::string,bool> m_requiredPlugins ;
+    bool m_isRequiredPluginValidationEnabled {true} ;
+    bool m_isAPIVersionValidationEnabled {true} ;
+    std::string m_currentApiLevel {"17.12"} ;
+    std::string m_selectedApiLevel {"17.06"} ;
+
+    std::map<std::string, std::vector<ChangeSetHookFunction>> m_changesets ;
 };
 
 } // namespace simulation


### PR DESCRIPTION
(EDIT: THIS PR WAS NOT CLEANED SO I MADE A VERSION 2 in PR #329)

Currently in Sofa there is only rudimentary way to handle component evolution (change of implementation, change of parameters, deprecation) and report the change to our users. 

In this PR I implemented a mecanism to do that.  
The basic idea is to have in scene a component that specify for which version of Sofa the scene have been tested. Here is how it looks in the scene:
```xml
   <APIVersion level='17.06'/>
```
If the scene does not have this component the level is automatically set to 17.06 so existing scene will just work as they should. Now what happens if a scene with a given level is loaded in a sofa that have a different level (eg: '17.12'). In this case dedicated messages are printed to warn user things may go wrong.  

Here is an example of what happen when loading a scene at level '17.06' on runSofa at level '17.12' (our master branch) with a BoxStiffSpringForceField (that could behave differently because of PR #290)
```
[INFO]    [SceneChecker] The 'APIVersion' directive is missing in the current scene. 
                                           Switching to the APIVersion level '17.06' 
[INFO]    [SceneChecker] Validating a scene:   
                                           - APIVersion checking: 1  
                                           - RequiredPlugin checking: 1
[WARNING] [BoxStiffSpringForceField(Spring)] BoxStiffSpringForceField have changed since 17.06. To use the old behavior you need to set parameter 'forceOldBehavior=true'
```


The nice thing with the approach is that we can write custom condition to rise those messages.

Here is a simple example (to handle PR315 & an imaginary deprecation of a component):
```cpp
 addHookInChangeSet("17.06", [](Base* o){
        if(o->getClassName() == "RestShapeSpringsForceField" && o->findData("external_rest_shape")->isSet())
            msg_warning(o) << "RestShapeSpringsForceField have changed since 17.06. The parameter 'external_rest_shape' is now a Link. To fix your scene you need to add and '@' in front of the provided path. See PR#315" ;
    }) ;

    addHookInChangeSet("17.06", [](Base* o){
        if(o->getClassName() == "TheComponentWeWantToRemove" )
            msg_warning(o) << "TheComponentWewantToRemove is deprecated since sofa 17.06. It have been replaced by TheSuperComponent. #See PR318" ;
    }) ;
}
```

Everything is in SceneChecker.cpp/SceneChecker.h and APIVersion.* ...the other files in the changes are 
in fact the content of PR #314
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
