### PR TITLE
[examples] FIX scenes with bad RegularGrid position

### DIFF
--- a/examples/Components/collision/RayTraceCollision.scn
+++ b/examples/Components/collision/RayTraceCollision.scn
@@ -12,13 +12,13 @@
         <RegularGrid nx="6" ny="5" nz="2" xmin="-7.5" xmax="7.5" ymin="-6" ymax="6" zmin="-1.75" zmax="1.75" />
         <RegularGridSpringForceField name="Springs" stiffness="270" damping="0" />
         <Node name="Visu">
-            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" dx="0" dy="20" dz="-11" color="blue" />
+            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" color="blue" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader name="loader" filename="mesh/torus2_scale3_for_collision.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="0" dy="20" dz="-11" />
+            <MechanicalObject src="@loader" />
             <TriangleOctree />
             <BarycentricMapping />
         </Node>
@@ -31,13 +31,13 @@
         <RegularGrid nx="6" ny="5" nz="2" xmin="-7.5" xmax="7.5" ymin="-6" ymax="6" zmin="-1.75" zmax="1.75" />
         <RegularGridSpringForceField name="Springs" stiffness="270" damping="0" />
         <Node name="Visu">
-            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" dx="0" dy="20" dz="-13" color="blue" />
+            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" color="blue" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader name="loader" filename="mesh/torus2_scale3_for_collision.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="0" dy="20" dz="-13" />
+            <MechanicalObject src="@loader"/>
             <TriangleOctree />
             <BarycentricMapping />
         </Node>
@@ -50,13 +50,13 @@
         <RegularGrid nx="6" ny="5" nz="2" xmin="-7.5" xmax="7.5" ymin="-6" ymax="6" zmin="-1.75" zmax="1.75" />
         <RegularGridSpringForceField name="Springs" stiffness="270" damping="0" />
         <Node name="Visu">
-            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" dx="0" dy="20" dz="-15" color="blue" />
+            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" color="blue" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader name="loader" filename="mesh/torus2_scale3_for_collision.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="0" dy="20" dz="-15" />
+            <MechanicalObject src="@loader" />
             <TriangleOctree />
             <BarycentricMapping />
         </Node>
@@ -69,13 +69,13 @@
         <RegularGrid nx="6" ny="5" nz="2" xmin="-7.5" xmax="7.5" ymin="-6" ymax="6" zmin="-1.75" zmax="1.75" />
         <RegularGridSpringForceField name="Springs" stiffness="270" damping="0" />
         <Node name="Visu">
-            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" dx="0" dy="20" dz="-17" color="blue" />
+            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" color="blue" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader name="loader" filename="mesh/torus2_scale3_for_collision.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="0" dy="20" dz="-17" />
+            <MechanicalObject src="@loader" />
             <TriangleOctree />
             <BarycentricMapping />
         </Node>
@@ -88,13 +88,13 @@
         <RegularGrid nx="6" ny="5" nz="2" xmin="-7.5" xmax="7.5" ymin="-6" ymax="6" zmin="-1.75" zmax="1.75" />
         <RegularGridSpringForceField name="Springs" stiffness="270" damping="0" />
         <Node name="Visu">
-            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" dx="0" dy="20" dz="-19" color="blue" />
+            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" color="blue" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader name="loader" filename="mesh/torus2_scale3_for_collision.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="0" dy="20" dz="-19" />
+            <MechanicalObject src="@loader" />
             <TriangleOctree />
             <BarycentricMapping />
         </Node>
@@ -107,13 +107,13 @@
         <RegularGrid nx="6" ny="5" nz="2" xmin="-7.5" xmax="7.5" ymin="-6" ymax="6" zmin="-1.75" zmax="1.75" />
         <RegularGridSpringForceField name="Springs" stiffness="270" damping="0" />
         <Node name="Visu">
-            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" dx="0" dy="20" dz="-23" color="blue" />
+            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" color="blue" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader name="loader" filename="mesh/torus2_scale3_for_collision.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="0" dy="20" dz="-23" />
+            <MechanicalObject src="@loader" />
             <TriangleOctree />
             <BarycentricMapping />
         </Node>
@@ -126,13 +126,13 @@
         <RegularGrid nx="6" ny="5" nz="2" xmin="-7.5" xmax="7.5" ymin="-6" ymax="6" zmin="-1.75" zmax="1.75" />
         <RegularGridSpringForceField name="Springs" stiffness="270" damping="0" />
         <Node name="Visu">
-            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" dx="0" dy="20" dz="-21" color="blue" />
+            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" color="blue" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader name="loader" filename="mesh/torus2_scale3_for_collision.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="0" dy="20" dz="-21" />
+            <MechanicalObject src="@loader" />
             <TriangleOctree />
             <BarycentricMapping />
         </Node>
@@ -145,13 +145,13 @@
         <RegularGrid nx="6" ny="5" nz="2" xmin="-7.5" xmax="7.5" ymin="-6" ymax="6" zmin="-1.75" zmax="1.75" />
         <RegularGridSpringForceField name="Springs" stiffness="270" damping="0" />
         <Node name="Visu">
-            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" dx="0" dy="20" dz="-29" color="blue" />
+            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" color="blue" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader name="loader" filename="mesh/torus2_scale3_for_collision.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="0" dy="20" dz="-29" />
+            <MechanicalObject src="@loader" />
             <TriangleOctree />
             <BarycentricMapping />
         </Node>
@@ -164,13 +164,13 @@
         <RegularGrid nx="6" ny="5" nz="2" xmin="-7.5" xmax="7.5" ymin="-6" ymax="6" zmin="-1.75" zmax="1.75" />
         <RegularGridSpringForceField name="Springs" stiffness="270" damping="0" />
         <Node name="Visu">
-            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" dx="0" dy="20" dz="-27" color="blue" />
+            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" color="blue" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader name="loader" filename="mesh/torus2_scale3_for_collision.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="0" dy="20" dz="-27" />
+            <MechanicalObject src="@loader" />
             <TriangleOctree />
             <BarycentricMapping />
         </Node>
@@ -183,13 +183,13 @@
         <RegularGrid nx="6" ny="5" nz="2" xmin="-7.5" xmax="7.5" ymin="-6" ymax="6" zmin="-1.75" zmax="1.75" />
         <RegularGridSpringForceField name="Springs" stiffness="270" damping="0" />
         <Node name="Visu">
-            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" dx="0" dy="20" dz="-25" color="blue" />
+            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" color="blue" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader name="loader" filename="mesh/torus2_scale3_for_collision.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="0" dy="20" dz="-25" />
+            <MechanicalObject src="@loader" />
             <TriangleOctree />
             <BarycentricMapping />
         </Node>

--- a/examples/Components/mapping/BarycentricMapping.scn
+++ b/examples/Components/mapping/BarycentricMapping.scn
@@ -68,13 +68,13 @@
             <RegularGrid nx="6" ny="2" nz="5" xmin="-2.5" xmax="2.5" ymin="-0.5" ymax="0.5" zmin="-2" zmax="2" />
             <RegularGridSpringForceField name="Springs" stiffness="200" damping="2" />
             <Node name="Visu">
-                <OglModel name="Visual" fileMesh="mesh/torus.obj" dx="7.5" color="yellow" />
+                <OglModel name="Visual" fileMesh="mesh/torus.obj" color="yellow" />
                 <BarycentricMapping input="@.." output="@Visual" />
             </Node>
             <Node name="Surf2">
                 <MeshObjLoader name="loader" filename="mesh/torus_for_collision.obj" />
                 <Mesh src="@loader" />
-                <MechanicalObject src="@loader" dx="7.5" />
+                <MechanicalObject src="@loader" />
                 <Triangle />
                 <Line />
                 <Point />
@@ -317,13 +317,13 @@
             <RegularGrid nx="6" ny="2" nz="5" xmin="-2.5" xmax="2.5" ymin="-0.5" ymax="0.5" zmin="-2" zmax="2" />
             <RegularGridSpringForceField name="Springs" stiffness="200" damping="2" />
             <Node name="Visu">
-                <OglModel name="Visual" fileMesh="mesh/torus.obj" dx="2.5" dz="18" color="yellow" />
+                <OglModel name="Visual" fileMesh="mesh/torus.obj" color="yellow" />
                 <BarycentricMapping input="@.." output="@Visual" />
             </Node>
             <Node name="Surf2">
                 <MeshObjLoader name="loader" filename="mesh/torus_for_collision.obj" />
                 <Mesh src="@loader" />
-                <MechanicalObject src="@loader" dx="2.5" dz="18" />
+                <MechanicalObject src="@loader" />
                 <Triangle />
                 <Line />
                 <Point />
@@ -338,13 +338,13 @@
             <RegularGrid nx="6" ny="5" nz="2" xmin="-2.5" xmax="2.5" ymin="-2" ymax="2" zmin="-0.5" zmax="0.5" />
             <RegularGridSpringForceField name="Springs" stiffness="200" damping="2" />
             <Node name="Visu">
-                <OglModel name="Visual" fileMesh="mesh/torus2.obj" dx="5" dz="18" color="yellow" />
+                <OglModel name="Visual" fileMesh="mesh/torus2.obj" color="yellow" />
                 <BarycentricMapping input="@.." output="@Visual" />
             </Node>
             <Node name="Surf2">
                 <MeshObjLoader name="loader" filename="mesh/torus2_for_collision.obj" />
                 <Mesh src="@loader" />
-                <MechanicalObject src="@loader" dx="5" dz="18" />
+                <MechanicalObject src="@loader" />
                 <Triangle />
                 <Line />
                 <Point />
@@ -359,13 +359,13 @@
             <RegularGrid nx="6" ny="2" nz="5" xmin="-2.5" xmax="2.5" ymin="-0.5" ymax="0.5" zmin="-2" zmax="2" />
             <RegularGridSpringForceField name="Springs" stiffness="200" damping="2" />
             <Node name="Visu">
-                <OglModel name="Visual" fileMesh="mesh/torus.obj" dx="7.5" dz="18" color="yellow" />
+                <OglModel name="Visual" fileMesh="mesh/torus.obj" color="yellow" />
                 <BarycentricMapping input="@.." output="@Visual" />
             </Node>
             <Node name="Surf2">
                 <MeshObjLoader name="loader" filename="mesh/torus_for_collision.obj" />
                 <Mesh src="@loader" />
-                <MechanicalObject src="@loader" dx="7.5" dz="18" />
+                <MechanicalObject src="@loader" />
                 <Triangle />
                 <Line />
                 <Point />
@@ -380,13 +380,13 @@
             <RegularGrid nx="6" ny="5" nz="2" xmin="-2.5" xmax="2.5" ymin="-2" ymax="2" zmin="-0.5" zmax="0.5" />
             <RegularGridSpringForceField name="Springs" stiffness="200" damping="2" />
             <Node name="Visu">
-                <OglModel name="Visual" fileMesh="mesh/torus2.obj" dx="10" dz="18" color="yellow" />
+                <OglModel name="Visual" fileMesh="mesh/torus2.obj" color="yellow" />
                 <BarycentricMapping input="@.." output="@Visual" />
             </Node>
             <Node name="Surf2">
                 <MeshObjLoader name="loader" filename="mesh/torus2_for_collision.obj" />
                 <Mesh src="@loader" />
-                <MechanicalObject src="@loader" dx="10" dz="18" />
+                <MechanicalObject src="@loader" />
                 <Triangle />
                 <Line />
                 <Point />

--- a/examples/Components/misc/Gravity.scn
+++ b/examples/Components/misc/Gravity.scn
@@ -13,13 +13,13 @@
         <RegularGrid nx="6" ny="5" nz="2" xmin="-7.5" xmax="7.5" ymin="-6" ymax="6" zmin="-1.75" zmax="1.75" />
         <RegularGridSpringForceField name="Springs" stiffness="350" damping="1" />
         <Node name="Visu">
-            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" dx="0" dy="20" dz="0" color="blue" />
+            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" color="blue" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader name="loader" filename="mesh/torus2_scale3.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="0" dy="20" dz="0" />
+            <MechanicalObject src="@loader"/>
             <Triangle />
             <Line />
             <Point />
@@ -35,13 +35,13 @@
         <RegularGrid nx="6" ny="5" nz="2" xmin="-7.5" xmax="7.5" ymin="-6" ymax="6" zmin="-1.75" zmax="1.75" />
         <RegularGridSpringForceField name="Springs" stiffness="350" damping="1" />
         <Node name="Visu">
-            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" dx="0" dy="-20" dz="0" color="blue" />
+            <OglModel name="Visual" fileMesh="mesh/torus2_scale3.obj" color="blue" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader name="loader" filename="mesh/torus2_scale3.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="0" dy="-20" dz="0" />
+            <MechanicalObject src="@loader" />
             <Triangle />
             <Line />
             <Point />

--- a/examples/Demos/chainAll.scn
+++ b/examples/Demos/chainAll.scn
@@ -65,13 +65,13 @@
         <RegularGrid nx="6" ny="2" nz="5" xmax="2.5" xmin="-2.5" ymax="0.5" ymin="-0.5" zmax="2" zmin="-2" />
         <RegularGridSpringForceField damping="2" name="Springs" stiffness="200" />
         <Node name="Visu">
-            <OglModel color="1.000 1.000 0.000" dx="12.3521" dy="0.0000" dz="3.2783" fileMesh="mesh/torus.obj" name="Visual" />
+            <OglModel color="1.000 1.000 0.000" fileMesh="mesh/torus.obj" name="Visual" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf2">
             <MeshObjLoader name="loader" filename="mesh/torus_for_collision.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject dx="12.3521" dy="0.0000" dz="3.2783" src="@loader" />
+            <MechanicalObject src="@loader" />
             <Triangle />
             <Line />
             <Point />
@@ -281,13 +281,13 @@
         <RegularGrid nx="6" ny="2" nz="5" xmax="2.5" xmin="-2.5" ymax="0.5" ymin="-0.5" zmax="2" zmin="-2" />
         <RegularGridSpringForceField damping="2" name="Springs" stiffness="200" />
         <Node name="Visu">
-            <OglModel color="1.000 1.000 0.000" dx="12.2149" dy="0.0000" dz="21.0581" fileMesh="mesh/torus.obj" name="Visual" />
+            <OglModel color="1.000 1.000 0.000" fileMesh="mesh/torus.obj" name="Visual" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf2">
             <MeshObjLoader name="loader" filename="mesh/torus_for_collision.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject dx="12.2149" dy="0.0000" dz="21.0581" src="@loader" />
+            <MechanicalObject src="@loader" />
             <Triangle />
             <Line />
             <Point />
@@ -302,13 +302,13 @@
         <RegularGrid nx="6" ny="5" nz="2" xmax="2.5" xmin="-2.5" ymax="2" ymin="-2" zmax="0.5" zmin="-0.5" />
         <RegularGridSpringForceField damping="2" name="Springs" stiffness="200" />
         <Node name="Visu">
-            <OglModel color="1.000 1.000 0.000" dx="14.5348" dy="0.0000" dz="19.7939" fileMesh="mesh/torus2.obj" name="Visual" />
+            <OglModel color="1.000 1.000 0.000" fileMesh="mesh/torus2.obj" name="Visual" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf2">
             <MeshObjLoader name="loader" filename="mesh/torus2_for_collision.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject dx="14.5348" dy="0.0000" dz="19.7939" src="@loader" />
+            <MechanicalObject src="@loader" />
             <Triangle />
             <Line />
             <Point />
@@ -323,13 +323,13 @@
         <RegularGrid nx="6" ny="2" nz="5" xmax="2.5" xmin="-2.5" ymax="0.5" ymin="-0.5" zmax="2" zmin="-2" />
         <RegularGridSpringForceField damping="2" name="Springs" stiffness="200" />
         <Node name="Visu">
-            <OglModel color="1.000 1.000 0.000" dx="16.7666" dy="0.0000" dz="18.3835" fileMesh="mesh/torus.obj" name="Visual" />
+            <OglModel color="1.000 1.000 0.000" fileMesh="mesh/torus.obj" name="Visual" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf2">
             <MeshObjLoader name="loader" filename="mesh/torus_for_collision.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject dx="16.7666" dy="0.0000" dz="18.3835" src="@loader" />
+            <MechanicalObject src="@loader" />
             <Triangle />
             <Line />
             <Point />
@@ -344,13 +344,13 @@
         <RegularGrid nx="6" ny="5" nz="2" xmax="2.5" xmin="-2.5" ymax="2" ymin="-2" zmax="0.5" zmin="-0.5" />
         <RegularGridSpringForceField damping="2" name="Springs" stiffness="200" />
         <Node name="Visu">
-            <OglModel color="1.000 1.000 0.000" dx="18.8145" dy="0.0000" dz="16.9496" fileMesh="mesh/torus2.obj" name="Visual" />
+            <OglModel color="1.000 1.000 0.000" fileMesh="mesh/torus2.obj" name="Visual" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf2">
             <MeshObjLoader name="loader" filename="mesh/torus2_for_collision.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject dx="18.8145" dy="0.0000" dz="16.9496" src="@loader" />
+            <MechanicalObject src="@loader" />
             <Triangle />
             <Line />
             <Point />

--- a/examples/Demos/collisionMultiple.scn
+++ b/examples/Demos/collisionMultiple.scn
@@ -12,13 +12,13 @@
         <RegularGrid nx="6" ny="5" nz="2" xmin="-7.5" xmax="7.5" ymin="-6" ymax="6" zmin="-1.75" zmax="1.75" />
         <RegularGridSpringForceField name="Springs" stiffness="350" damping="1" />
         <Node name="VisuTorus" tags="Visual">
-            <OglModel name="Visual" filename="mesh/torus2_scale3.obj" dx="0" dy="20" dz="29" color="blue" />
+            <OglModel name="Visual" filename="mesh/torus2_scale3.obj" color="blue" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader name="loader" filename="mesh/torus2_scale3.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="0" dy="20" dz="29" />
+            <MechanicalObject src="@loader"/>
             <Triangle />
             <Line />
             <Point />
@@ -33,13 +33,13 @@
         <RegularGrid nx="6" ny="5" nz="3" xmin="-11" xmax="11" ymin="-7" ymax="7" zmin="-4" zmax="4" />
         <RegularGridSpringForceField name="Springs" stiffness="350" damping="1" />
         <Node name="VisuDragon" tags="Visual">
-            <OglModel name="Visual" filename="mesh/dragon.obj" dx="20" dy="20" dz="29" color="red" />
+            <OglModel name="Visual" filename="mesh/dragon.obj" color="red" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader name="loader" filename="mesh/dragon.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="20" dy="20" dz="29" />
+            <MechanicalObject src="@loader" />
             <Triangle />
             <Line />
             <Point />
@@ -55,26 +55,26 @@
         <RegularGridSpringForceField name="Springs" stiffness="350" damping="1" />
         <Node name="VisualFrog" tags="Visual">
             <Node name="Visu1">
-                <OglModel name="VisualBody" filename="mesh/frog_body.obj" normals="0" dx="-20" dy="20" dz="29" color="0.17 0.70 0.05" />
+                <OglModel name="VisualBody" filename="mesh/frog_body.obj" normals="0" color="0.17 0.70 0.05" />
                 <BarycentricMapping input="@.." output="@VisualBody" />
             </Node>
             <Node name="Visu2">
-                <OglModel name="VisualEyes" filename="mesh/frog_eyes.obj" normals="0" dx="-20" dy="20" dz="29" color="0.04 0.19 0.52" />
+                <OglModel name="VisualEyes" filename="mesh/frog_eyes.obj" normals="0" color="0.04 0.19 0.52" />
                 <BarycentricMapping input="@.." output="@VisualEyes" />
             </Node>
             <Node name="Visu3">
-                <OglModel name="VisualEyebrows" filename="mesh/frog_eyebrows.obj" normals="0" dx="-20" dy="20" dz="29" color="0.44 0.43 0.00" />
+                <OglModel name="VisualEyebrows" filename="mesh/frog_eyebrows.obj" normals="0" color="0.44 0.43 0.00" />
                 <BarycentricMapping input="@.." output="@VisualEyebrows" />
             </Node>
             <Node name="Visu4">
-                <OglModel name="VisualLips" filename="mesh/frog_lips.obj" normals="0" dx="-20" dy="20" dz="29" color="0.47 0.25 0.03" />
+                <OglModel name="VisualLips" filename="mesh/frog_lips.obj" normals="0" color="0.47 0.25 0.03" />
                 <BarycentricMapping input="@.." output="@VisualLips" />
             </Node>
         </Node>
         <Node name="Surf">
             <MeshObjLoader name="loader" filename="mesh/frog-push25.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="-20" dy="20" dz="29" />
+            <MechanicalObject src="@loader" />
             <Triangle />
             <Line />
             <Point />

--- a/examples/Demos/collisionMultipleMask.scn
+++ b/examples/Demos/collisionMultipleMask.scn
@@ -13,13 +13,13 @@
         <RegularGrid nx="6" ny="5" nz="2" xmin="-7.5" xmax="7.5" ymin="-6" ymax="6" zmin="-1.75" zmax="1.75" />
         <RegularGridSpringForceField name="Springs" stiffness="350" damping="1" />
         <Node name="Visu">
-            <OglModel name="Visual" filename="mesh/torus2_scale3.obj" dx="0" dy="20" dz="29" color="blue" />
+            <OglModel name="Visual" filename="mesh/torus2_scale3.obj" color="blue" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader name="loader" filename="mesh/torus2_scale3.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader"  dx="0" dy="20" dz="29" />
+            <MechanicalObject src="@loader"/>
             <Triangle />
             <Line />
             <Point />
@@ -34,13 +34,13 @@
         <RegularGrid nx="6" ny="5" nz="3" xmin="-11" xmax="11" ymin="-7" ymax="7" zmin="-4" zmax="4" />
         <RegularGridSpringForceField name="Springs" stiffness="350" damping="1" />
         <Node name="Visu">
-            <OglModel name="Visual" filename="mesh/dragon.obj" dx="20" dy="20" dz="29" color="red" />
+            <OglModel name="Visual" filename="mesh/dragon.obj" color="red" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader name="loader" filename="mesh/dragon.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader"  dx="20" dy="20" dz="29" />
+            <MechanicalObject src="@loader"/>
             <Triangle />
             <Line />
             <Point />
@@ -55,25 +55,25 @@
         <RegularGrid nx="6" ny="3" nz="5" xmin="-10" xmax="8" ymin="-3" ymax="2.5" zmin="-7" zmax="7" />
         <RegularGridSpringForceField name="Springs" stiffness="350" damping="1" />
         <Node name="Visu1">
-            <OglModel name="VisualBody" filename="mesh/frog_body.obj" normals="0" dx="-20" dy="20" dz="29" color="0.17 0.70 0.05" />
+            <OglModel name="VisualBody" filename="mesh/frog_body.obj" normals="0" color="0.17 0.70 0.05" />
             <BarycentricMapping input="@.." output="@VisualBody" />
         </Node>
         <Node name="Visu2">
-            <OglModel name="VisualEyes" filename="mesh/frog_eyes.obj" normals="0" dx="-20" dy="20" dz="29" color="0.04 0.19 0.52" />
+            <OglModel name="VisualEyes" filename="mesh/frog_eyes.obj" normals="0" color="0.04 0.19 0.52" />
             <BarycentricMapping input="@.." output="@VisualEyes" />
         </Node>
         <Node name="Visu3">
-            <OglModel name="VisualEyebrows" filename="mesh/frog_eyebrows.obj" normals="0" dx="-20" dy="20" dz="29" color="0.44 0.43 0.00" />
+            <OglModel name="VisualEyebrows" filename="mesh/frog_eyebrows.obj" normals="0" color="0.44 0.43 0.00" />
             <BarycentricMapping input="@.." output="@VisualEyebrows" />
         </Node>
         <Node name="Visu4">
-            <OglModel name="VisualLips" filename="mesh/frog_lips.obj" normals="0" dx="-20" dy="20" dz="29" color="0.47 0.25 0.03" />
+            <OglModel name="VisualLips" filename="mesh/frog_lips.obj" normals="0" color="0.47 0.25 0.03" />
             <BarycentricMapping input="@.." output="@VisualLips" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader name="loader" filename="mesh/frog-push25.obj" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader"  dx="-20" dy="20" dz="29" />
+            <MechanicalObject src="@loader" />
             <Triangle />
             <Line />
             <Point />

--- a/examples/Tutorials/OldTutorials/demo10.scn
+++ b/examples/Tutorials/OldTutorials/demo10.scn
@@ -13,12 +13,12 @@
         <RegularGrid nx="3" ny="3" nz="3" xmin="-3.5" xmax="3.5" ymin="-3.5" ymax="3.5" zmin="-3.5" zmax="3.5" />
         <RegularGridSpringForceField name="Springs" stiffness="800" damping="8" />
         <Node name="Visu">
-            <OglModel name="Visual" filename="mesh/smCube27.obj" color="yellow" dx="0" dy="-10.5" dz="0" />
+            <OglModel name="Visual" filename="mesh/smCube27.obj" color="yellow" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <SphereLoader filename="mesh/smCube27b.sph" />
-            <MechanicalObject translation="0 -10.5 0" position="@[-1].position" />
+            <MechanicalObject position="@[-1].position" />
             <Sphere listRadius="@[-2].listRadius" />
             <BarycentricMapping />
         </Node>
@@ -49,12 +49,12 @@
         <RegularGrid nx="5" ny="5" nz="5" xmin="-3.5" xmax="3.5" ymin="-3.5" ymax="3.5" zmin="-3.5" zmax="3.5" />
         <RegularGridSpringForceField name="Springs" stiffness="400" damping="4" />
         <Node name="Visu">
-            <OglModel name="Visual" filename="mesh/smCube27.obj" color="red" dx="0" dy="10.5" dz="-4" />
+            <OglModel name="Visual" filename="mesh/smCube27.obj" color="red" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <SphereLoader filename="mesh/smCube27b.sph" />
-            <MechanicalObject position="@[-1].position" dx="0" dy="10.5" dz="-4" />
+            <MechanicalObject position="@[-1].position"/>
             <Sphere listRadius="@[-2].listRadius" />
             <BarycentricMapping />
         </Node>
@@ -67,12 +67,12 @@
         <RegularGrid nx="6" ny="6" nz="6" xmin="-3.5" xmax="3.5" ymin="-3.5" ymax="3.5" zmin="-3.5" zmax="3.5" />
         <RegularGridSpringForceField name="Springs" stiffness="280" damping="2.8" />
         <Node name="Visu">
-            <OglModel name="Visual" filename="mesh/smCube27.obj" color="#801080" dx="0" dy="21" dz="0" />
+            <OglModel name="Visual" filename="mesh/smCube27.obj" color="#801080"/>
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <SphereLoader filename="mesh/smCube27b.sph" />
-            <MechanicalObject position="@[-1].position" translation="0 21 0" />
+            <MechanicalObject position="@[-1].position"/>
             <Sphere listRadius="@[-2].listRadius" />
             <BarycentricMapping />
         </Node>

--- a/examples/Tutorials/OldTutorials/demo10Triangle.scn
+++ b/examples/Tutorials/OldTutorials/demo10Triangle.scn
@@ -13,13 +13,13 @@
         <RegularGrid nx="3" ny="3" nz="3" xmin="-3.5" xmax="3.5" ymin="-3.5" ymax="3.5" zmin="-3.5" zmax="3.5" />
         <RegularGridSpringForceField name="Springs" stiffness="800" damping="8" />
         <Node name="Visu">
-            <OglModel name="Visual" filename="mesh/smCube27.obj" color="yellow" dx="0" dy="-10.5" dz="0" />
+            <OglModel name="Visual" filename="mesh/smCube27.obj" color="yellow"/>
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader filename="mesh/smCube27.obj" name="loader" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="0" dy="-10.5" dz="0" />
+            <MechanicalObject src="@loader"/>
             <Triangle />
             <Line />
             <Point />
@@ -34,13 +34,13 @@
         <RegularGrid nx="4" ny="4" nz="4" xmin="-3.5" xmax="3.5" ymin="-3.5" ymax="3.5" zmin="-3.5" zmax="3.5" />
         <RegularGridSpringForceField name="Springs" stiffness="560" damping="5.6" />
         <Node name="Visu">
-            <OglModel name="Visual" filename="mesh/smCube27.obj" color="#ff8000" dx="2" dy="0" dz="0" />
+            <OglModel name="Visual" filename="mesh/smCube27.obj" color="#ff8000"/>
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader filename="mesh/smCube27.obj" name="loader" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="2" dy="0" dz="0" />
+            <MechanicalObject src="@loader"/>
             <Triangle />
             <Line />
             <Point />
@@ -55,13 +55,13 @@
         <RegularGrid nx="5" ny="5" nz="5" xmin="-3.5" xmax="3.5" ymin="-3.5" ymax="3.5" zmin="-3.5" zmax="3.5" />
         <RegularGridSpringForceField name="Springs" stiffness="400" damping="4" />
         <Node name="Visu">
-            <OglModel name="Visual" filename="mesh/smCube27.obj" color="red" dx="0" dy="10.5" dz="-4" />
+            <OglModel name="Visual" filename="mesh/smCube27.obj" color="red"/>
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader filename="mesh/smCube27.obj" name="loader" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="0" dy="10.5" dz="-4" />
+            <MechanicalObject src="@loader"/>
             <Triangle />
             <Line />
             <Point />
@@ -76,13 +76,13 @@
         <RegularGrid nx="6" ny="6" nz="6" xmin="-3.5" xmax="3.5" ymin="-3.5" ymax="3.5" zmin="-3.5" zmax="3.5" />
         <RegularGridSpringForceField name="Springs" stiffness="400" damping="4" />
         <Node name="Visu">
-            <OglModel name="Visual" filename="mesh/smCube27.obj" color="#801080" dx="0" dy="21" dz="0" />
+            <OglModel name="Visual" filename="mesh/smCube27.obj" color="#801080"/>
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader filename="mesh/smCube27.obj" name="loader" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="0" dy="21" dz="0" />
+            <MechanicalObject src="@loader"/>
             <Triangle />
             <Line />
             <Point />

--- a/examples/Tutorials/OldTutorials/tutorial3.scn
+++ b/examples/Tutorials/OldTutorials/tutorial3.scn
@@ -13,13 +13,13 @@
         <RegularGrid nx="5" ny="5" nz="5" xmin="-3.5" xmax="3.5" ymin="-3.5" ymax="3.5" zmin="-3.5" zmax="3.5" />
         <RegularGridSpringForceField name="Springs" stiffness="200" damping="1" />
         <Node name="Visu">
-            <OglModel name="Visual" filename="mesh/smCube125.obj" color="green" dx="18" dy="17" dz="29" />
+            <OglModel name="Visual" filename="mesh/smCube125.obj" color="green"/>
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader filename="mesh/smCube125.obj" name="loader" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="18" dy="17" dz="29" />
+            <MechanicalObject src="@loader"/>
             <Triangle />
             <Line />
             <Point />
@@ -34,13 +34,13 @@
         <RegularGrid nx="5" ny="5" nz="5" xmin="-3.5" xmax="3.5" ymin="-3.5" ymax="3.5" zmin="-3.5" zmax="3.5" />
         <TetrahedronFEMForceField name="FEM" youngModulus="300" poissonRatio="0.3" method="polar" />
         <Node name="Visu">
-            <OglModel name="Visual" filename="mesh/smCube125.obj" color="cyan" dx="0" dy="17" dz="29" />
+            <OglModel name="Visual" filename="mesh/smCube125.obj" color="cyan"/>
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader filename="mesh/smCube125.obj" name="loader" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="0" dy="17" dz="29" />
+            <MechanicalObject src="@loader"/>
             <Triangle />
             <Line />
             <Point />

--- a/examples/Tutorials/OldTutorials/tutorial4.scn
+++ b/examples/Tutorials/OldTutorials/tutorial4.scn
@@ -12,13 +12,13 @@
         <RegularGrid nx="6" ny="5" nz="2" xmin="-7.5" xmax="7.5" ymin="-6" ymax="6" zmin="-1.75" zmax="1.75" />
         <RegularGridSpringForceField name="Springs" stiffness="350" damping="1" />
         <Node name="Visu">
-            <OglModel name="Visual" filename="mesh/torus2_scale3.obj" color="blue" dx="0" dy="20" dz="29" />
+            <OglModel name="Visual" filename="mesh/torus2_scale3.obj" color="blue"/>
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader filename="mesh/torus2_scale3.obj" name="loader" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="0" dy="20" dz="29" />
+            <MechanicalObject src="@loader"/>
             <Triangle />
             <Line />
             <Point />
@@ -33,13 +33,13 @@
         <RegularGrid nx="6" ny="5" nz="3" xmin="-11" xmax="11" ymin="-7" ymax="7" zmin="-4" zmax="4" />
         <RegularGridSpringForceField name="Springs" stiffness="350" damping="1" />
         <Node name="Visu">
-            <OglModel name="Visual" filename="mesh/dragon.obj" color="red" dx="20" dy="20" dz="29" />
+            <OglModel name="Visual" filename="mesh/dragon.obj" color="red"/>
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader filename="mesh/dragon.obj" name="loader" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="20" dy="20" dz="29" />
+            <MechanicalObject src="@loader"/>
             <Triangle />
             <Line />
             <Point />
@@ -54,25 +54,25 @@
         <RegularGrid nx="6" ny="3" nz="5" xmin="-10" xmax="8" ymin="-3" ymax="2.5" zmin="-7" zmax="7" />
         <RegularGridSpringForceField name="Springs" stiffness="350" damping="1" />
         <Node name="Visu1">
-            <OglModel name="VisualBody" filename="mesh/frog_body.obj" normals="0" color="0.17 0.70 0.05" dx="-20" dy="20" dz="29" />
+            <OglModel name="VisualBody" filename="mesh/frog_body.obj" normals="0" color="0.17 0.70 0.05"/>
             <BarycentricMapping input="@.." output="@VisualBody" />
         </Node>
         <Node name="Visu2">
-            <OglModel name="VisualEyes" filename="mesh/frog_eyes.obj" normals="0" color="0.04 0.19 0.52" dx="-20" dy="20" dz="29" />
+            <OglModel name="VisualEyes" filename="mesh/frog_eyes.obj" normals="0" color="0.04 0.19 0.52"/>
             <BarycentricMapping input="@.." output="@VisualEyes" />
         </Node>
         <Node name="Visu3">
-            <OglModel name="VisualEyebrows" filename="mesh/frog_eyebrows.obj" normals="0" color="0.44 0.43 0.00" dx="-20" dy="20" dz="29" />
+            <OglModel name="VisualEyebrows" filename="mesh/frog_eyebrows.obj" normals="0" color="0.44 0.43 0.00"/>
             <BarycentricMapping input="@.." output="@VisualEyebrows" />
         </Node>
         <Node name="Visu4">
-            <OglModel name="VisualLips" filename="mesh/frog_lips.obj" normals="0" color="0.47 0.25 0.03" dx="-20" dy="20" dz="29" />
+            <OglModel name="VisualLips" filename="mesh/frog_lips.obj" normals="0" color="0.47 0.25 0.03"/>
             <BarycentricMapping input="@.." output="@VisualLips" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader filename="mesh/frog-push25.obj" name="loader" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="-20" dy="20" dz="29" />
+            <MechanicalObject src="@loader"/>
             <Triangle />
             <Line />
             <Point />

--- a/examples/Tutorials/OldTutorials/tutorial4FEM.scn
+++ b/examples/Tutorials/OldTutorials/tutorial4FEM.scn
@@ -12,13 +12,13 @@
         <RegularGrid nx="6" ny="5" nz="2" xmin="-7.5" xmax="7.5" ymin="-6" ymax="6" zmin="-1.75" zmax="1.75" />
         <TetrahedronFEMForceField name="FEM" youngModulus="500" poissonRatio="0.3" method="polar" />
         <Node name="Visu">
-            <OglModel name="Visual" filename="mesh/torus2_scale3.obj" color="blue" dx="0" dy="20" dz="29" />
+            <OglModel name="Visual" filename="mesh/torus2_scale3.obj" color="blue"/>
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader filename="mesh/torus2_scale3.obj" name="loader" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="0" dy="20" dz="29" />
+            <MechanicalObject src="@loader"/>
             <Triangle />
             <Line />
             <Point />
@@ -33,13 +33,13 @@
         <RegularGrid nx="6" ny="5" nz="3" xmin="-11" xmax="11" ymin="-7" ymax="7" zmin="-4" zmax="4" />
         <TetrahedronFEMForceField name="FEM" youngModulus="500" poissonRatio="0.3" method="polar" />
         <Node name="Visu">
-            <OglModel name="Visual" filename="mesh/dragon.obj" color="red" dx="20" dy="20" dz="29" />
+            <OglModel name="Visual" filename="mesh/dragon.obj" color="red" />
             <BarycentricMapping input="@.." output="@Visual" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader filename="mesh/dragon.obj" name="loader" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="20" dy="20" dz="29" />
+            <MechanicalObject src="@loader"/>
             <Triangle />
             <Line />
             <Point />
@@ -54,25 +54,25 @@
         <RegularGrid nx="6" ny="3" nz="5" xmin="-10" xmax="8" ymin="-3" ymax="2.5" zmin="-7" zmax="7" />
         <TetrahedronFEMForceField name="FEM" youngModulus="500" poissonRatio="0.3" method="polar" />
         <Node name="Visu1">
-            <OglModel name="VisualBody" filename="mesh/frog_body.obj" normals="0" color="0.17 0.70 0.05" dx="-20" dy="20" dz="29" />
+            <OglModel name="VisualBody" filename="mesh/frog_body.obj" normals="0" color="0.17 0.70 0.05" />
             <BarycentricMapping input="@.." output="@VisualBody" />
         </Node>
         <Node name="Visu2">
-            <OglModel name="VisualEyes" filename="mesh/frog_eyes.obj" normals="0" color="0.04 0.19 0.52" dx="-20" dy="20" dz="29" />
+            <OglModel name="VisualEyes" filename="mesh/frog_eyes.obj" normals="0" color="0.04 0.19 0.52" />
             <BarycentricMapping input="@.." output="@VisualEyes" />
         </Node>
         <Node name="Visu3">
-            <OglModel name="VisualEyebrows" filename="mesh/frog_eyebrows.obj" normals="0" color="0.44 0.43 0.00" dx="-20" dy="20" dz="29" />
+            <OglModel name="VisualEyebrows" filename="mesh/frog_eyebrows.obj" normals="0" color="0.44 0.43 0.00" />
             <BarycentricMapping input="@.." output="@VisualEyebrows" />
         </Node>
         <Node name="Visu4">
-            <OglModel name="VisualLips" filename="mesh/frog_lips.obj" normals="0" color="0.47 0.25 0.03" dx="-20" dy="20" dz="29" />
+            <OglModel name="VisualLips" filename="mesh/frog_lips.obj" normals="0" color="0.47 0.25 0.03" />
             <BarycentricMapping input="@.." output="@VisualLips" />
         </Node>
         <Node name="Surf">
             <MeshObjLoader filename="mesh/frog-push25.obj" name="loader" />
             <Mesh src="@loader" />
-            <MechanicalObject src="@loader" dx="-20" dy="20" dz="29" />
+            <MechanicalObject src="@loader" />
             <Triangle />
             <Line />
             <Point />


### PR DESCRIPTION
This PR is linked to the issue #308 .
Since the modification of MechanicalObject reinit method in PR #270 ([this commit](https://github.com/sofa-framework/sofa/pull/270/commits/b6750f06ea0c5082f8c88d5aaea6bc65d8840429) ). The mechanicalObject doesn't change the value of P0. Thus, it is not necessary anymore to shift the OglModel and the Surf mechanicalObj.

Several scenes were impacted but without ground truth it is hard to say if the scene is totally fixed.


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
