### PR TITLE
[SofaConstraint] FIX BilateralInteractionConstraint_test on MacOS

### DIFF
--- a/modules/SofaConstraint/SofaConstraint_test/BilateralInteractionConstraint_test.cpp
+++ b/modules/SofaConstraint/SofaConstraint_test/BilateralInteractionConstraint_test.cpp
@@ -101,7 +101,7 @@ struct BilateralInteractionConstraint_test : public Sofa_test<typename _DataType
                  "   <BilateralInteractionConstraint template='"<< DataTypes::Name() << "' object1='@./o1' object2='@./o2'/>     \n"
                  "</Node>                                                     \n" ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory (__FILE__,
+        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
                                                           scene.str().c_str(),
                                                           scene.str().size()) ;
         root->init(ExecParams::defaultInstance()) ;
@@ -133,7 +133,7 @@ struct BilateralInteractionConstraint_test : public Sofa_test<typename _DataType
                  "   <BilateralInteractionConstraint template='"<< DataTypes::Name() << "' />     \n"
                  "</Node>                                                     \n" ;
 
-        Node::SPtr root = SceneLoaderXML::loadFromMemory (__FILE__,
+        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
                                                           scene.str().c_str(),
                                                           scene.str().size()) ;
         root->init(ExecParams::defaultInstance()) ;
@@ -158,7 +158,7 @@ void BilateralInteractionConstraint_test<Rigid3fTypes>::checkRigid3fFixForBackwa
              "   <BilateralInteractionConstraint template='"<< DataTypes::Name() << "' object1='@./o1' object2='@./o2'/>     \n"
              "</Node>                                                     \n" ;
 
-    Node::SPtr root = SceneLoaderXML::loadFromMemory (__FILE__,
+    Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
                                                       scene.str().c_str(),
                                                       scene.str().size()) ;
     root->init(ExecParams::defaultInstance()) ;


### PR DESCRIPTION
Appeared after upgrading MacOS to 10.11:
using a relative filename in SceneLoaderXML::loadFromMemory raises ENOENT (No such file or directory) error during SetDirectory chdir.
Still don't know why though :-/

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
