### PR TITLE
[runSofa] remove non-ASCII chars in string

### DIFF
--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -320,7 +320,7 @@ int main(int argc, char** argv)
         MessageDispatcher::addHandler( new ExceptionMessageHandler() ) ;
     }
     else{
-        msg_warning("") << "Invalid argument ‘" << messageHandler << "‘ for ‘--formatting‘";
+        msg_warning("") << "Invalid argument '" << messageHandler << "' for '--formatting'";
     }
     MessageDispatcher::addHandler(&MainPerComponentLoggingMessageHandler::getInstance()) ;
 


### PR DESCRIPTION
non-ASCII chars caused problems in some platform when compiling
Discussed in [Issue323](https://github.com/sofa-framework/sofa/issues/323)





______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
