### PR TITLE
[SceneChecker] Add mechanism to report API & SceneChange to users

### DIFF
--- a/SofaKernel/SofaFramework/CMakeLists.txt
+++ b/SofaKernel/SofaFramework/CMakeLists.txt
@@ -170,11 +170,11 @@ list(APPEND SOFAFRAMEWORK_DEPENDENCY_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_BINARY_
 list(REMOVE_DUPLICATES SOFAFRAMEWORK_DEPENDENCY_INCLUDE_DIRECTORIES)
 
 ## Version
-set(SOFAFRAMEWORK_VERSION "17.dev.0")
+set(SOFAFRAMEWORK_VERSION "17.12.dev")
 
 ## sofa/version.h
-set(SOFA_VERSION "999999")
-set(SOFA_VERSION_STR "\"devel\"")
+set(SOFA_VERSION "171299")
+set(SOFA_VERSION_STR "\"17.12.dev\"")
 configure_file(../framework/sofa/version.h.in "${CMAKE_BINARY_DIR}/include/sofa/version.h")
 install(FILES "${CMAKE_BINARY_DIR}/include/sofa/version.h" DESTINATION include/sofa)
 

--- a/applications/sofa/gui/qt/RealGUI.cpp
+++ b/applications/sofa/gui/qt/RealGUI.cpp
@@ -147,17 +147,8 @@ protected:
         {
         case QEvent::FileOpen:
         {
-//            std::string filename = static_cast<QFileOpenEvent *>(event)->file().toStdString();
             if(this->topLevelWidgets().count() < 1)
                 return false;
-//            RealGUI* mainGui = static_cast<RealGUI*>(this->topLevelWidgets()[0]);
-            //mainGui->fileOpen(filename);
-
-//            if (filename != std::string(static_cast<RealGUI*>(QApplication::topLevelWidgets()[0])->windowFilePath().toStdString()))
-//            {
-//                static_cast<RealGUI*>(QApplication::topLevelWidgets()[0])->fileOpen(static_cast<QFileOpenEvent *>(event)->file().toStdString());
-//            }
-
             return true;
         }
         default:
@@ -299,7 +290,6 @@ RealGUI::RealGUI ( const char* viewername, const std::vector<std::string>& optio
 {
     setupUi(this);
 
-//    this->setWindowFlags(Qt::CustomizeWindowHint | Qt::FramelessWindowHint);
     parseOptions(options);
 
     createPluginManager();
@@ -331,19 +321,10 @@ RealGUI::RealGUI ( const char* viewername, const std::vector<std::string>& optio
     }
 
     this->setDockOptions(QMainWindow::AnimatedDocks | QMainWindow::AllowTabbedDocks);
-    //dockWidget=new QDockWidget(tr(""), this);
-    //dockWidget->setResizeEnabled(true);
-    //dockWidget->setFixedWidth(300);
     dockWidget->setFeatures(QDockWidget::AllDockWidgetFeatures);
     dockWidget->setAllowedAreas(Qt::RightDockWidgetArea | Qt::LeftDockWidgetArea);
-    //addDockWidget(Qt::LeftDockWidgetArea, dockWidget);
-    //dockWidget->setWidget(optionTabs);
 
     connect(dockWidget, SIGNAL(dockLocationChanged(Qt::DockWidgetArea)), this, SLOT(toolsDockMoved()));
-
-    /*moveDockWindow(dockWidget, Qt::DockLeft);
-    dockWidget->setFixedExtentWidth(400);
-    dockWidget->setFixedExtentHeight(600);*/
 
     // create a Dock Window to receive the Sofa Recorder
 #ifndef SOFA_GUI_QT_NO_RECORDER
@@ -394,26 +375,6 @@ RealGUI::RealGUI ( const char* viewername, const std::vector<std::string>& optio
 
     SofaMouseManager::getInstance()->hide();
     SofaVideoRecorderManager::getInstance()->hide();
-
-    //Center the application
-    /** This code doesn't work for all the multi screen config, so i comment and replace it by the previous code **/
-    /*
-    QSettings settings;
-    settings.beginGroup("viewer");
-    int screenNumber = settings.value("screenNumber", QApplication::desktop()->primaryScreen()).toInt();
-    settings.endGroup();
-
-    if (screenNumber >= QApplication::desktop()->screenCount())
-        screenNumber = QApplication::desktop()->primaryScreen();
-
-    int offset = 0;
-    if (screenNumber > 0)
-        for (int i = 0 ; i < screenNumber; i++)
-            offset = QApplication::desktop()->availableGeometry(i).width();
-
-    const QRect screen = QApplication::desktop()->availableGeometry(screenNumber);
-    this->move( offset + ( screen.width()- this->width()  ) / 2 - 200,  ( screen.height() - this->height()) / 2 - 50  );
-    */
 
     //Center the application
     const QRect screen = QApplication::desktop()->availableGeometry(QApplication::desktop()->primaryScreen());
@@ -719,14 +680,6 @@ int RealGUI::closeGUI()
     settings.setValue("screenNumber", QApplication::desktop()->screenNumber(this));
     settings.endGroup();
 
-//    std::string viewerFileName;
-//    std::string path = sofa::helper::system::DataRepository.getFirstPath();
-//    viewerFileName = path.append("/share/config/sofaviewer.ini");
-
-//    std::ofstream out(viewerFileName.c_str(),std::ios::out);
-//    out << sizeW->value() << std::endl << sizeH->value() << std::endl;
-//    out.close();
-
     delete this;
     return 0;
 }
@@ -777,6 +730,11 @@ void RealGUI::fileOpen ( std::string filename, bool temporaryFile )
     this->setWindowFilePath(filename.c_str());
     setExportGnuplot(exportGnuplotFilesCheckbox->isChecked());
     stopDumpVisitor();
+
+    /// We want to warn user that there is component that are implemented in specific plugin
+    /// and that there is no RequiredPlugin in their scene.
+    SceneCheckerVisitor checker(ExecParams::defaultInstance()) ;
+    checker.validate(mSimulation.get()) ;
 }
 
 
@@ -858,11 +816,6 @@ void RealGUI::fileOpen()
             else
                 fileOpen (s.toStdString());
     }
-
-    /// We want to warn user that there is component that are implemented in specific plugin
-    /// and that there is no RequiredPlugin in their scene.
-    SceneCheckerVisitor checker(ExecParams::defaultInstance()) ;
-    checker.validate(mSimulation.get()) ;
 }
 
 //------------------------------------
@@ -916,11 +869,13 @@ void RealGUI::setScene ( Node::SPtr root, const char* filename, bool temporaryFi
 
     if (root)
     {
+        /// We want to warn user that there is component that are implemented in specific plugin
+        /// and that there is no RequiredPlugin in their scene.
+        SceneCheckerVisitor checker(ExecParams::defaultInstance()) ;
+        checker.validate(root.get()) ;
+
         mSimulation = root;
-
         eventNewTime();
-
-        //simulation::getSimulation()->updateVisualContext ( root );
         startButton->setChecked(root->getContext()->getAnimate() );
         dtEdit->setText ( QString::number ( root->getDt() ) );
         simulationGraph->Clear(root.get());

--- a/modules/SofaGraphComponent/APIVersion.cpp
+++ b/modules/SofaGraphComponent/APIVersion.cpp
@@ -53,12 +53,34 @@ namespace _apiversion_
 {
 
 APIVersion::APIVersion() :
-     d_level ( initData(&d_level, 0, "level", "The API Level of the scene ('17.06', '17.12', '18.06')"))
+     d_level ( initData(&d_level, std::string("17.06"), "level", "The API Level of the scene ('17.06', '17.12', '18.06', ...)"))
 {
 }
 
 APIVersion::~APIVersion()
 {
+}
+
+void APIVersion::init()
+{
+    Inherit1::init();
+    checkInputData() ;
+}
+
+void APIVersion::checkInputData()
+{
+    if(!d_level.isSet() && !name.isSet() ){
+        msg_warning() << "The level is not set. Using 17.06 as default value. " ;
+        return ;
+    }
+    if( !d_level.isSet() && name.isSet() ){
+        d_level.setValue(getName());
+    }
+    std::vector<std::string> allowedVersion = { "17.06", "17.12", "18.06", "18.12" } ;
+    if( std::find( allowedVersion.begin(), allowedVersion.end(), d_level.getValue()) == allowedVersion.end() )
+    {
+        msg_warning() << "The provided level '"<< d_level.getValue() <<"' is now valid. " ;
+    }
 }
 
 const std::string& APIVersion::getApiLevel()

--- a/modules/SofaGraphComponent/APIVersion.cpp
+++ b/modules/SofaGraphComponent/APIVersion.cpp
@@ -1,0 +1,77 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+/******************************************************************************
+*  Contributors:                                                              *
+*  - damien.marchal@univ-lille1.fr                                            *
+******************************************************************************/
+#include <sofa/core/objectmodel/BaseObject.h>
+using sofa::core::objectmodel::BaseObject ;
+
+#include <sofa/core/objectmodel/BaseContext.h>
+using sofa::core::objectmodel::BaseContext ;
+
+#include <sofa/core/objectmodel/BaseNode.h>
+using sofa::core::objectmodel::BaseNode ;
+
+#include <sofa/core/objectmodel/BaseObjectDescription.h>
+using sofa::core::objectmodel::BaseObjectDescription ;
+
+#include <sofa/simulation/Node.h>
+using sofa::simulation::Node ;
+
+#include <sofa/core/ObjectFactory.h>
+using sofa::core::ObjectFactory ;
+using sofa::core::RegisterObject ;
+
+#include "APIVersion.h"
+
+namespace sofa
+{
+
+namespace component
+{
+
+namespace _apiversion_
+{
+
+APIVersion::APIVersion() :
+     d_level ( initData(&d_level, 0, "level", "The API Level of the scene ('17.06', '17.12', '18.06')"))
+{
+}
+
+APIVersion::~APIVersion()
+{
+}
+
+const std::string& APIVersion::getApiLevel()
+{
+    return d_level.getValue() ;
+}
+
+SOFA_DECL_CLASS(APIVersion)
+int APIVersionClass = core::RegisterObject("Specify the APIVersion of the component used in a scene.")
+        .add< APIVersion >();
+
+} // namespace _apiversion_
+
+} // namespace component
+
+} // namespace sofa

--- a/modules/SofaGraphComponent/APIVersion.h
+++ b/modules/SofaGraphComponent/APIVersion.h
@@ -43,11 +43,12 @@ public:
     SOFA_CLASS(APIVersion, BaseObject);
 
     const std::string& getApiLevel() ;
+    virtual void init() override ;
 
 protected:
     APIVersion() ;
     virtual ~APIVersion() ;
-
+    void checkInputData() ;
 private:
     Data<std::string>  d_level ;
 };

--- a/modules/SofaGraphComponent/APIVersion.h
+++ b/modules/SofaGraphComponent/APIVersion.h
@@ -1,0 +1,61 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+/******************************************************************************
+*  Contributors:                                                              *
+*  - damien.marchal@univ-lille1.fr                                            *
+******************************************************************************/
+#include <sofa/core/objectmodel/BaseObject.h>
+using sofa::core::objectmodel::BaseObject ;
+
+#include "config.h"
+
+namespace sofa
+{
+
+namespace component
+{
+
+namespace _apiversion_
+{
+
+class SOFA_GRAPH_COMPONENT_API APIVersion : public BaseObject
+{
+
+public:
+    SOFA_CLASS(APIVersion, BaseObject);
+
+    const std::string& getApiLevel() ;
+
+protected:
+    APIVersion() ;
+    virtual ~APIVersion() ;
+
+private:
+    Data<std::string>  d_level ;
+};
+
+} // namespace _apiversion_
+
+using _apiversion_::APIVersion ;
+
+} // namespace component
+
+} // namespace sofa

--- a/modules/SofaGraphComponent/CMakeLists.txt
+++ b/modules/SofaGraphComponent/CMakeLists.txt
@@ -17,6 +17,7 @@ set(HEADER_FILES
     StatsSetting.h
     ViewerSetting.h
     SceneCheckerVisitor.h
+    APIVersion.h
     config.h
     initGraphComponent.h
 )
@@ -36,6 +37,7 @@ set(SOURCE_FILES
     StatsSetting.cpp
     ViewerSetting.cpp
     SceneCheckerVisitor.cpp
+    APIVersion.cpp
     initGraphComponent.cpp
 )
 

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
@@ -21,9 +21,11 @@
 ******************************************************************************/
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/helper/system/PluginManager.h>
+#include <sofa/version.h>
 
 #include "SceneCheckerVisitor.h"
 #include "RequiredPlugin.h"
+
 
 #include "APIVersion.h"
 using sofa::component::APIVersion ;
@@ -73,7 +75,9 @@ void SceneCheckerVisitor::installChangeSets()
 
 void SceneCheckerVisitor::validate(Node* node)
 {
-    enableValidationAPIVersion(node, "17.12") ;
+    std::stringstream version;
+    version << SOFA_VERSION / 10000 << "." << SOFA_VERSION / 100;
+    enableValidationAPIVersion(node, version.str().c_str()) ;
     enableValidationRequiredPlugins(node) ;
 
     msg_info("SceneChecker") << "Validating a scene: " << msgendl

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
@@ -61,6 +61,11 @@ void SceneCheckerVisitor::installChangeSets()
     }) ;
 
     addHookInChangeSet("17.06", [](Base* o){
+        if(o->getClassName() == "BoxStiffSpringForceField" )
+            msg_warning(o) << "BoxStiffSpringForceField have changed since 17.06. To use the old behavior you need to set parameter 'forceOldBehavior=true'" ;
+    }) ;
+
+    addHookInChangeSet("17.06", [](Base* o){
         if(o->getClassName() == "TheComponentWeWantToRemove" )
             msg_warning(o) << "TheComponentWewantToRemove is deprecated since sofa 17.06. It have been replaced by TheSuperComponent. #See PR318" ;
     }) ;

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
@@ -19,15 +19,20 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "SceneCheckerVisitor.h"
-#include "RequiredPlugin.h"
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/helper/system/PluginManager.h>
+
+#include "SceneCheckerVisitor.h"
+#include "RequiredPlugin.h"
+
+#include "APIVersion.h"
+using sofa::component::APIVersion ;
 
 namespace sofa
 {
 namespace simulation
 {
+using sofa::core::objectmodel::Base ;
 using sofa::component::misc::RequiredPlugin ;
 using sofa::core::ObjectFactory ;
 using sofa::core::ExecParams ;
@@ -36,44 +41,109 @@ using sofa::helper::system::PluginManager ;
 
 SceneCheckerVisitor::SceneCheckerVisitor(const ExecParams* params) : Visitor(params)
 {
+    installChangeSets() ;
 }
 
 SceneCheckerVisitor::~SceneCheckerVisitor()
 {
 }
 
+void SceneCheckerVisitor::addHookInChangeSet(const std::string& version, ChangeSetHookFunction fct)
+{
+    m_changesets[version].push_back(fct) ;
+}
+
+void SceneCheckerVisitor::installChangeSets()
+{
+    addHookInChangeSet("17.06", [](Base* o){
+        if(o->getClassName() == "RestShapeSpringsForceField" && o->findData("external_rest_shape")->isSet())
+            msg_warning(o) << "RestShapeSpringsForceField have changed since 17.06. The parameter 'external_rest_shape' is now a Link. To fix your scene you need to add and '@' in front of the provided path. See PR#315" ;
+    }) ;
+
+    addHookInChangeSet("17.06", [](Base* o){
+        if(o->getClassName() == "TheComponentWeWantToRemove" )
+            msg_warning(o) << "TheComponentWewantToRemove is deprecated since sofa 17.06. It have been replaced by TheSuperComponent. #See PR318" ;
+    }) ;
+}
+
 void SceneCheckerVisitor::validate(Node* node)
+{
+    enableValidationAPIVersion(node, "17.12") ;
+    enableValidationRequiredPlugins(node) ;
+
+    msg_info("SceneChecker") << "Validating a scene: " << msgendl
+                             << "- APIVersion checking: " << m_isAPIVersionValidationEnabled << msgendl
+                             << "- RequiredPlugin checking: " << m_isRequiredPluginValidationEnabled ;
+
+    execute(node) ;
+}
+
+void SceneCheckerVisitor::enableValidationAPIVersion(Node* node, const std::string& currentApiLevel)
+{
+    APIVersion* apiversion {nullptr} ;
+
+    /// 1. Find if there is an APIVersion component in the scene. If there is none, warn the user and set
+    /// the version to 17.06 (the last version before it was introduced). If there is one...use
+    /// this component to request the API version requested by the scene.
+    m_currentApiLevel = currentApiLevel ;
+    node->getTreeObject(apiversion) ;
+    if(!apiversion)
+    {
+        msg_info("SceneChecker") << "The 'APIVersion' directive is missing in the current scene. Switching to the APIVersion level '"<< m_selectedApiLevel <<"' " ;
+    }
+    else
+    {
+        m_selectedApiLevel = apiversion->getApiLevel() ;
+    }
+
+    /// 2. We activate if the API level mis-match. In the future we may want to be able to handle
+    /// more precise way to track difference between version but for the moment let's take the
+    /// easy path for the developpers.
+    m_isAPIVersionValidationEnabled = m_selectedApiLevel != m_currentApiLevel ;
+}
+
+void SceneCheckerVisitor::enableValidationRequiredPlugins(Node* node)
 {
     helper::vector< RequiredPlugin* > plugins ;
     node->getTreeObjects< RequiredPlugin >(&plugins) ;
 
     for(auto& plugin : plugins)
         m_requiredPlugins[plugin->getName()] = true ;
-
-    execute(node) ;
 }
 
 Visitor::Result SceneCheckerVisitor::processNodeTopDown(Node* node)
 {
     for (auto& object : node->object )
     {
-        ObjectFactory::ClassEntry entry = ObjectFactory::getInstance()->getEntry(object->getClassName());
-        if(!entry.creatorMap.empty())
+        if(m_isRequiredPluginValidationEnabled)
         {
-            ObjectFactory::CreatorMap::iterator it = entry.creatorMap.find(object->getTemplateName());
-            if(entry.creatorMap.end() != it && *it->second->getTarget()){
-                std::string pluginName = it->second->getTarget() ;
-                std::string path = PluginManager::getInstance().findPlugin(pluginName) ;
-                if( PluginManager::getInstance().pluginIsLoaded(path)
-                    && m_requiredPlugins.find(pluginName) == m_requiredPlugins.end() )
-                {
-                    msg_warning("SceneChecker") << "This scene is using component '" << object->getClassName() << "'. " << msgendl
-                                                << "This component is part of the '" << pluginName << "' plugin but there is no <RequiredPlugin name='" << pluginName << "'> directive in your scene." << msgendl
-                                                << "Your scene may not work on a sofa environment that does not have pre-loaded the plugin." << msgendl
-                                                << "To fix your scene and remove this warning you need to add the RequiredPlugin directive at the beginning of your scene. ";
+            ObjectFactory::ClassEntry entry = ObjectFactory::getInstance()->getEntry(object->getClassName());
+            if(!entry.creatorMap.empty())
+            {
+                ObjectFactory::CreatorMap::iterator it = entry.creatorMap.find(object->getTemplateName());
+                if(entry.creatorMap.end() != it && *it->second->getTarget()){
+                    std::string pluginName = it->second->getTarget() ;
+                    std::string path = PluginManager::getInstance().findPlugin(pluginName) ;
+                    if( PluginManager::getInstance().pluginIsLoaded(path)
+                            && m_requiredPlugins.find(pluginName) == m_requiredPlugins.end() )
+                    {
+                        msg_warning("SceneChecker") << "This scene is using component '" << object->getClassName() << "'. " << msgendl
+                                                    << "This component is part of the '" << pluginName << "' plugin but there is no <RequiredPlugin name='" << pluginName << "'> directive in your scene." << msgendl
+                                                    << "Your scene may not work on a sofa environment that does not have pre-loaded the plugin." << msgendl
+                                                    << "To fix your scene and remove this warning you need to add the RequiredPlugin directive at the beginning of your scene. ";
+                    }
                 }
             }
-
+        }
+        if(m_isAPIVersionValidationEnabled)
+        {
+            if(m_selectedApiLevel != m_currentApiLevel && m_changesets.find(m_selectedApiLevel) != m_changesets.end())
+            {
+                for(auto& hook : m_changesets[m_selectedApiLevel])
+                {
+                    hook(object.get());
+                }
+            }
         }
     }
     return RESULT_CONTINUE;

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.h
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.h
@@ -43,7 +43,7 @@ public:
 
     void validate(Node* node) ;
 
-    void enableValidationAPIVersion(Node *node, const std::string& currentApiLevel) ;
+    void enableValidationAPIVersion(Node *node) ;
     void enableValidationRequiredPlugins(Node* node) ;
 
     virtual Result processNodeTopDown(Node* node) override ;
@@ -54,7 +54,7 @@ private:
     std::map<std::string,bool> m_requiredPlugins ;
     bool m_isRequiredPluginValidationEnabled {true} ;
     bool m_isAPIVersionValidationEnabled {true} ;
-    std::string m_currentApiLevel {"xx.xx"} ;
+    std::string m_currentApiLevel;
     std::string m_selectedApiLevel {"17.06"} ;
 
     std::map<std::string, std::vector<ChangeSetHookFunction>> m_changesets ;

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.h
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.h
@@ -54,7 +54,7 @@ private:
     std::map<std::string,bool> m_requiredPlugins ;
     bool m_isRequiredPluginValidationEnabled {true} ;
     bool m_isAPIVersionValidationEnabled {true} ;
-    std::string m_currentApiLevel {"17.12"} ;
+    std::string m_currentApiLevel {"xx.xx"} ;
     std::string m_selectedApiLevel {"17.06"} ;
 
     std::map<std::string, std::vector<ChangeSetHookFunction>> m_changesets ;

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.h
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.h
@@ -24,14 +24,16 @@
 
 #include "config.h"
 
+#include <functional>
 #include <map>
+
 #include <sofa/simulation/Visitor.h>
 
 namespace sofa
 {
-
 namespace simulation
 {
+typedef std::function<void(sofa::core::objectmodel::Base*)> ChangeSetHookFunction ;
 
 class SOFA_GRAPH_COMPONENT_API SceneCheckerVisitor : public Visitor
 {
@@ -40,9 +42,22 @@ public:
     virtual ~SceneCheckerVisitor() ;
 
     void validate(Node* node) ;
+
+    void enableValidationAPIVersion(Node *node, const std::string& currentApiLevel) ;
+    void enableValidationRequiredPlugins(Node* node) ;
+
     virtual Result processNodeTopDown(Node* node) override ;
+
+    void installChangeSets() ;
+    void addHookInChangeSet(const std::string& version, ChangeSetHookFunction fct) ;
 private:
     std::map<std::string,bool> m_requiredPlugins ;
+    bool m_isRequiredPluginValidationEnabled {true} ;
+    bool m_isAPIVersionValidationEnabled {true} ;
+    std::string m_currentApiLevel {"17.12"} ;
+    std::string m_selectedApiLevel {"17.06"} ;
+
+    std::map<std::string, std::vector<ChangeSetHookFunction>> m_changesets ;
 };
 
 } // namespace simulation


### PR DESCRIPTION
(THIS WAS PR 322)

Currently in Sofa there is only rudimentary way to handle component evolution (change of implementation, change of parameters, deprecation) and report the change to our users. 

In this PR I implemented a mecanism to do that.  
The basic idea is to have in scene a component that specify for which version of Sofa the scene have been tested. Here is how it looks in the scene:
```xml
   <APIVersion level='17.06'/>
```
If the scene does not have this component the level is automatically set to 17.06 so existing scene will just work as they should. Now what happens if a scene with a given level is loaded in a sofa that have a different level (eg: '17.12'). In this case dedicated messages are printed to warn user things may go wrong.  

Here is an example of what happen when loading a scene at level '17.06' on runSofa at level '17.12' (our master branch) with a BoxStiffSpringForceField (that could behave differently because of PR #290)
```
[INFO]    [SceneChecker] The 'APIVersion' directive is missing in the current scene. 
                                           Switching to the APIVersion level '17.06' 
[INFO]    [SceneChecker] Validating a scene:   
                                           - APIVersion checking: 1  
                                           - RequiredPlugin checking: 1
[WARNING] [BoxStiffSpringForceField(Spring)] BoxStiffSpringForceField have changed since 17.06. To use the old behavior you need to set parameter 'forceOldBehavior=true'
```


The nice thing with the approach is that we can write custom condition to rise those messages.

Here is a simple example (to handle PR315 & an imaginary deprecation of a component):
```cpp
 addHookInChangeSet("17.06", [](Base* o){
        if(o->getClassName() == "RestShapeSpringsForceField" && o->findData("external_rest_shape")->isSet())
            msg_warning(o) << "RestShapeSpringsForceField have changed since 17.06. The parameter 'external_rest_shape' is now a Link. To fix your scene you need to add and '@' in front of the provided path. See PR#315" ;
    }) ;

    addHookInChangeSet("17.06", [](Base* o){
        if(o->getClassName() == "TheComponentWeWantToRemove" )
            msg_warning(o) << "TheComponentWewantToRemove is deprecated since sofa 17.06. It have been replaced by TheSuperComponent. #See PR318" ;
    }) ;
}
```

Everything is in SceneChecker.cpp/SceneChecker.h and APIVersion.* ...the other files in the changes are 
in fact the content of PR #314
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**

