### PR TITLE
[Multithreading, THMPGSpatialHashing] Fix build with Boost 1.64.0

### DIFF
--- a/applications/plugins/MultiThreading/src/TaskSchedulerBoost.cpp
+++ b/applications/plugins/MultiThreading/src/TaskSchedulerBoost.cpp
@@ -189,7 +189,6 @@ namespace sofa
 			mTaskCount		= 0;
 			mFinished		= false;
 			mCurrentStatus = NULL;
-			mTaskMutex.v_ = 0L;
 		}
 
 

--- a/applications/plugins/THMPGSpatialHashing/THMPGHashTable.h
+++ b/applications/plugins/THMPGSpatialHashing/THMPGHashTable.h
@@ -2,7 +2,12 @@
 
 #include <vector>
 #include <sofa/core/CollisionElement.h>
+#include <boost/version.hpp>
+#if BOOST_VERSION < 106400
 #include <boost/unordered/detail/util.hpp>
+#else
+#include <boost/unordered/detail/implementation.hpp>
+#endif
 #include <sofa/core/collision/Intersection.h>
 #include <sofa/core/collision/NarrowPhaseDetection.h>
 #include <sofa/helper/AdvancedTimer.h>


### PR DESCRIPTION
This PR kind of fixes #316 
Concerning Multithreading plugin, it still would be better to get rid of Boost dependency as stated by @fjourdes in #316.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
