### PR TITLE
[SofaPython/core] forward sys.argv to python scripts

### DIFF
--- a/SofaKernel/framework/sofa/helper/ArgumentParser.cpp
+++ b/SofaKernel/framework/sofa/helper/ArgumentParser.cpp
@@ -34,6 +34,8 @@ namespace helper
 
 typedef std::istringstream istrstream;
 
+ArgumentParser::extra_type ArgumentParser::extra;
+
 ArgumentBase::ArgumentBase(char s, string l, string h, bool m)
     : shortName(s)
     , longName(l)
@@ -86,9 +88,7 @@ ArgumentParser::~ArgumentParser()
 */
 void ArgumentParser::operator () ( int argc, char** argv )
 {
-    std::list<std::string> str;
-    for (int i=1; i<argc; ++i)
-        str.push_back(std::string(argv[i]));
+    std::list<std::string> str(argv + 1, argv + argc);
     (*this)(str);
 }
 
@@ -108,16 +108,20 @@ void ArgumentParser::operator () ( std::list<std::string> str )
         // display help
         if( name == shHelp || name == lgHelp )
         {
-            if( globalHelp.size()>0 )
-                std::cout<< globalHelp <<std::endl;
-
+            if( globalHelp.size()>0 ) std::cout<< globalHelp <<std::endl;
+            
             std::cout << "(short name, long name, description, default value)\n-h,\t--help: this help" << std::endl;
             std::cout << std::boolalpha;
             for( ArgVec::const_iterator a=commands.begin(), aend=commands.end(); a!=aend; ++a )
                 (*a)->print();
             std::cout << std::noboolalpha;
+
+            std::cout << "--argv [...]\t" << "forward extra args to the python interpreter" << std::endl;
+            
             if( files )
                 std::cout << "others: file names" << std::endl;
+            
+            
             exit(EXIT_FAILURE);
         }
 
@@ -136,9 +140,7 @@ void ArgumentParser::operator () ( std::list<std::string> str )
 
         // extra args
         else if( name == extra_opt ) {
-            if( _extra ) {
-                std::copy(str.begin(), str.end(), std::back_inserter(*_extra));
-            }
+            extra = extra_type(str.begin(), str.end());
             return;
         }
         

--- a/SofaKernel/framework/sofa/helper/ArgumentParser.cpp
+++ b/SofaKernel/framework/sofa/helper/ArgumentParser.cpp
@@ -97,6 +97,9 @@ void ArgumentParser::operator () ( std::list<std::string> str )
     string shHelp("-");  shHelp.push_back( helpShortName );
     string lgHelp("--"); lgHelp.append( helpLongName );
     string name;
+
+    static const std::string extra_opt = "--argv";
+    
     while( !str.empty() )
     {
         name = str.front();
@@ -131,6 +134,14 @@ void ArgumentParser::operator () ( std::list<std::string> str )
             str.pop_front();
         }
 
+        // extra args
+        else if( name == extra_opt ) {
+            if( _extra ) {
+                std::copy(str.begin(), str.end(), std::back_inserter(*_extra));
+            }
+            return;
+        }
+        
         // long name
         else if( name.length() > 1 && name[0]=='-' && name[1]=='-' )
         {

--- a/SofaKernel/framework/sofa/helper/ArgumentParser.h
+++ b/SofaKernel/framework/sofa/helper/ArgumentParser.h
@@ -252,8 +252,8 @@ class SOFA_HELPER_API ArgumentParser
     std::vector<std::string>* files;
 
     /// extra args appearing after --argv
-    using extra_type = std::vector<std::string>*;
-    extra_type _extra = nullptr;
+    using extra_type = std::vector<std::string>;
+    static extra_type extra;
     
     // help stuff
     string globalHelp;    ///< Overall presentation
@@ -261,7 +261,9 @@ class SOFA_HELPER_API ArgumentParser
     string helpLongName;  ///< long name for help
 
 public:
-
+    /** last parsed extra arguments */
+    static const extra_type& extra_args() { return extra; }
+    
     /// Constructor using a global help string
     ArgumentParser( const string& helpstr="", char hlpShrt='h', const string& hlpLng="help" );
 
@@ -354,12 +356,6 @@ public:
     }
 
 
-    /** specify output vector for extra args */
-    ArgumentParser& extra(extra_type e) {
-        _extra = e;
-        return *this;
-    }
-    
     /** Parse a command line
     \param argc number of arguments + 1, as usual in C
     \param argv arguments

--- a/SofaKernel/framework/sofa/helper/ArgumentParser.h
+++ b/SofaKernel/framework/sofa/helper/ArgumentParser.h
@@ -251,6 +251,10 @@ class SOFA_HELPER_API ArgumentParser
     /// Set of remaining file
     std::vector<std::string>* files;
 
+    /// extra args appearing after --argv
+    using extra_type = std::vector<std::string>*;
+    extra_type _extra = nullptr;
+    
     // help stuff
     string globalHelp;    ///< Overall presentation
     char helpShortName;   ///< short name for help
@@ -349,6 +353,13 @@ public:
         return (*this);
     }
 
+
+    /** specify output vector for extra args */
+    ArgumentParser& extra(extra_type e) {
+        _extra = e;
+        return *this;
+    }
+    
     /** Parse a command line
     \param argc number of arguments + 1, as usual in C
     \param argv arguments

--- a/applications/plugins/SofaPython/PythonEnvironment.cpp
+++ b/applications/plugins/SofaPython/PythonEnvironment.cpp
@@ -294,27 +294,19 @@ bool PythonEnvironment::runFile( const char *filename, const std::vector<std::st
     std::string dir = sofa::helper::system::SetDirectory::GetParentDir(filename);
     std::string bareFilename = sofa::helper::system::SetDirectory::GetFileNameWithoutExtension(filename);
 
-    if(!arguments.empty())
     {
-        char**argv = new char*[arguments.size()+1];
-        argv[0] = new char[bareFilename.size()+1];
-        strcpy( argv[0], bareFilename.c_str() );
-        for( size_t i=0 ; i<arguments.size() ; ++i )
-        {
-            argv[i+1] = new char[arguments[i].size()+1];
-            strcpy( argv[i+1], arguments[i].c_str() );
+        // setup sys.argv
+        std::vector<const char*> argv;
+        argv.push_back(bareFilename.c_str());
+        
+        for(const std::string& arg : arguments) {
+            argv.push_back(arg.c_str());
         }
-
-        Py_SetProgramName(argv[0]); // TODO check what it is doing exactly
-        PySys_SetArgv(arguments.size()+1, argv);
-
-        for( size_t i=0 ; i<arguments.size()+1 ; ++i )
-        {
-            delete [] argv[i];
-        }
-        delete [] argv;
+        
+        Py_SetProgramName((char*) argv[0]); // TODO check what it is doing exactly
+        PySys_SetArgv(argv.size(), (char**)argv.data());
     }
-
+    
     // Load the scene script
     char* pythonFilename = strdup(filename);
     PyObject* scriptPyFile = PyFile_FromString(pythonFilename, (char*)("r"));

--- a/applications/plugins/SofaPython/PythonEnvironment.cpp
+++ b/applications/plugins/SofaPython/PythonEnvironment.cpp
@@ -327,14 +327,15 @@ bool PythonEnvironment::runFile( const char *filename, const std::vector<std::st
     PyObject* __tmpfile__ = PyString_FromString(filename);
     PyDict_SetItemString(__main__, "__file__", __tmpfile__);
 
-    // note: we don't closeit here on purpose
-    const int error = PyRun_SimpleFile(PyFile_AsFile(script), filename);
+    const int error = PyRun_SimpleFile(PyFile_AsFile(script), filename, 0);
 
     Py_XDECREF(__tmpfile__);
 
     // don't wait for gc to close the file
-    PyObject_CallMethod(script, "close", NULL);    
-    Py_XDECREF(script);
+    PyObject_CallMethod(script, "close", NULL);
+
+    // segfault :-/
+    // Py_XDECREF(script);
     
     // restore backup
     PyDict_SetItemString(__main__, "__file__", __file__);

--- a/applications/plugins/SofaPython/PythonEnvironment.cpp
+++ b/applications/plugins/SofaPython/PythonEnvironment.cpp
@@ -294,7 +294,7 @@ bool PythonEnvironment::runFile( const char *filename, const std::vector<std::st
     std::string dir = sofa::helper::system::SetDirectory::GetParentDir(filename);
     std::string bareFilename = sofa::helper::system::SetDirectory::GetFileNameWithoutExtension(filename);
 
-    {
+    if(!arguments.empty() ) {
         // setup sys.argv
         std::vector<const char*> argv;
         argv.push_back(bareFilename.c_str());

--- a/applications/plugins/SofaPython/PythonEnvironment.cpp
+++ b/applications/plugins/SofaPython/PythonEnvironment.cpp
@@ -327,7 +327,7 @@ bool PythonEnvironment::runFile( const char *filename, const std::vector<std::st
     PyObject* __tmpfile__ = PyString_FromString(filename);
     PyDict_SetItemString(__main__, "__file__", __tmpfile__);
 
-    const int error = PyRun_SimpleFile(PyFile_AsFile(script), filename, 0);
+    const int error = PyRun_SimpleFileEx(PyFile_AsFile(script), filename, 0);
 
     Py_XDECREF(__tmpfile__);
 

--- a/applications/plugins/SofaPython/SceneLoaderPY.cpp
+++ b/applications/plugins/SofaPython/SceneLoaderPY.cpp
@@ -25,6 +25,7 @@
 
 
 #include <sofa/simulation/Simulation.h>
+#include <sofa/helper/ArgumentParser.h>
 #include <SofaSimulationCommon/xml/NodeElement.h>
 #include <SofaSimulationCommon/FindByTypeVisitor.h>
 
@@ -83,7 +84,7 @@ void SceneLoaderPY::getExtensionList(ExtensionList* list)
 sofa::simulation::Node::SPtr SceneLoaderPY::load(const char *filename)
 {
     sofa::simulation::Node::SPtr root;
-    loadSceneWithArguments(filename, {}, &root);
+    loadSceneWithArguments(filename, helper::ArgumentParser::extra_args(), &root);
     return root;
 }
 


### PR DESCRIPTION
Changelog:
- added a mechanism to obtain extra args from command-line (everything following `--argv`)
- forwarded extra args to python in `SceneLoaderPy`

Example:
```python
# test.py
def createScene(node):
    import sys
    print(sys.argv)
```

```sh
runSofa -a test.py --argv --spam --bacon eggs
# ['test', '--spam', '--bacon', 'eggs']
```
___________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
