### PR TITLE
[runSofa] Make names of scene object parameters and links selectable

### DIFF
--- a/applications/sofa/gui/qt/QDisplayDataWidget.cpp
+++ b/applications/sofa/gui/qt/QDisplayDataWidget.cpp
@@ -168,7 +168,6 @@ QDisplayDataWidget::QDisplayDataWidget(QWidget* parent,
         QLabel* propertyName = new QLabel(data_->getName().c_str(), this);
         propertyName->setAlignment(Qt::AlignLeft);
         propertyName->setTextInteractionFlags(Qt::TextSelectableByMouse);
-        propertyName->setContentsMargins(10,10,10,10);
         gridLayout_->setVerticalSpacing(0);
         gridLayout_->addWidget(propertyName, 0, 1);
         gridLayout_->setAlignment(propertyName, Qt::AlignVCenter);

--- a/applications/sofa/gui/qt/QDisplayDataWidget.cpp
+++ b/applications/sofa/gui/qt/QDisplayDataWidget.cpp
@@ -173,7 +173,7 @@ QDisplayDataWidget::QDisplayDataWidget(QWidget* parent,
         gridLayout_->setAlignment(propertyName, Qt::AlignVCenter);
         datawidget_->setContentsMargins(0, 0, 0, 0);
         gridLayout_->setContentsMargins(10,10,10,10);
-        gridLayout_->addWidget(datawidget_, 1, 1);
+        gridLayout_->addWidget(datawidget_, 0, 2);
 
         //setColumns(numWidgets_); //datawidget_->numColumnWidget());
     }

--- a/applications/sofa/gui/qt/QDisplayDataWidget.cpp
+++ b/applications/sofa/gui/qt/QDisplayDataWidget.cpp
@@ -154,18 +154,30 @@ QDisplayDataWidget::QDisplayDataWidget(QWidget* parent,
         //setInsideSpacing(0);
 
         //setColumns(numWidgets_);
+
+        gridLayout_->setContentsMargins(10,10,10,10);
+        gridLayout_->addWidget(datawidget_, 0, 1);
+
     }
     else
     {
-        setTitle(data_->getName().c_str());
+        //setTitle(data_->getName().c_str());
         setContentsMargins(0,0,0,0);
         //setInsideMargin(4);
         //setInsideSpacing(2);
+        QLabel* propertyName = new QLabel(data_->getName().c_str(), this);
+        propertyName->setAlignment(Qt::AlignLeft);
+        propertyName->setTextInteractionFlags(Qt::TextSelectableByMouse);
+        propertyName->setContentsMargins(10,10,10,10);
+        gridLayout_->setVerticalSpacing(0);
+        gridLayout_->addWidget(propertyName, 0, 1);
+        gridLayout_->setAlignment(propertyName, Qt::AlignVCenter);
+        datawidget_->setContentsMargins(0, 0, 0, 0);
+        gridLayout_->setContentsMargins(10,10,10,10);
+        gridLayout_->addWidget(datawidget_, 1, 1);
 
         //setColumns(numWidgets_); //datawidget_->numColumnWidget());
     }
-    gridLayout_->setContentsMargins(10,10,10,10);
-    gridLayout_->addWidget(datawidget_, 0, 1);
     gridLayout_->setAlignment(datawidget_, Qt::AlignVCenter);
 }
 

--- a/applications/sofa/gui/qt/QDisplayLinkWidget.cpp
+++ b/applications/sofa/gui/qt/QDisplayLinkWidget.cpp
@@ -56,7 +56,7 @@ QDisplayLinkWidget::QDisplayLinkWidget(QWidget* parent,
         return;
     }
 
-    gridLayout_ = new QHBoxLayout();
+    gridLayout_ = new QGridLayout();
     this->setLayout(gridLayout_);
 
     parent->layout()->addWidget(this);
@@ -137,17 +137,30 @@ QDisplayLinkWidget::QDisplayLinkWidget(QWidget* parent,
         //setInsideSpacing(0);
 
         //setColumns(numWidgets_);
+        gridLayout_->addWidget(linkwidget_, 0, 1);
     }
     else
     {
-        setTitle(link_->getName().c_str());
+        //setTitle(link_->getName().c_str());
         setContentsMargins(2,2,4,4);
         //setInsideMargin(4);
         //setInsideSpacing(2);
 
         //setColumns(numWidgets_); //linkwidget_->numColumnWidget()
+
+        QLabel* linkName = new QLabel(link_->getName().c_str(), this);
+        linkName->setAlignment(Qt::AlignLeft);
+        linkName->setTextInteractionFlags(Qt::TextSelectableByMouse);
+        linkName->setContentsMargins(10,10,10,10);
+        gridLayout_->setVerticalSpacing(0);
+        gridLayout_->addWidget(linkName, 0, 1);
+        gridLayout_->setAlignment(linkName, Qt::AlignVCenter);
+        linkwidget_->setContentsMargins(0, 0, 0, 0);
+        gridLayout_->setContentsMargins(10,10,10,10);
+        gridLayout_->addWidget(linkwidget_, 1, 1);
+
     }
-    gridLayout_->addWidget(linkwidget_);
+    gridLayout_->setAlignment(linkwidget_, Qt::AlignVCenter);
 }
 
 void QDisplayLinkWidget::UpdateLink()

--- a/applications/sofa/gui/qt/QDisplayLinkWidget.cpp
+++ b/applications/sofa/gui/qt/QDisplayLinkWidget.cpp
@@ -156,8 +156,7 @@ QDisplayLinkWidget::QDisplayLinkWidget(QWidget* parent,
         gridLayout_->setAlignment(linkName, Qt::AlignVCenter);
         linkwidget_->setContentsMargins(0, 0, 0, 0);
         gridLayout_->setContentsMargins(10,10,10,10);
-        gridLayout_->addWidget(linkwidget_, 1, 1);
-
+        gridLayout_->addWidget(linkwidget_, 0, 2);
     }
     gridLayout_->setAlignment(linkwidget_, Qt::AlignVCenter);
 }

--- a/applications/sofa/gui/qt/QDisplayLinkWidget.cpp
+++ b/applications/sofa/gui/qt/QDisplayLinkWidget.cpp
@@ -151,7 +151,6 @@ QDisplayLinkWidget::QDisplayLinkWidget(QWidget* parent,
         QLabel* linkName = new QLabel(link_->getName().c_str(), this);
         linkName->setAlignment(Qt::AlignLeft);
         linkName->setTextInteractionFlags(Qt::TextSelectableByMouse);
-        linkName->setContentsMargins(10,10,10,10);
         gridLayout_->setVerticalSpacing(0);
         gridLayout_->addWidget(linkName, 0, 1);
         gridLayout_->setAlignment(linkName, Qt::AlignVCenter);

--- a/applications/sofa/gui/qt/QDisplayLinkWidget.h
+++ b/applications/sofa/gui/qt/QDisplayLinkWidget.h
@@ -81,7 +81,7 @@ protected:
     QDisplayLinkInfoWidget*  linkinfowidget_;
     LinkWidget* linkwidget_;
     unsigned int numWidgets_;
-    QHBoxLayout* gridLayout_;
+    QGridLayout* gridLayout_;
 
 };
 


### PR DESCRIPTION
This fix allows to select and copy parameters names in Sofa GUI interface, which is very useful when setting default values for elements in scene files. Instead of setting parameters names as titles of widgets I created QLabel objects and set them as the first row of the GridLayout manager.

I know that current sofa GUI will be replaced with Qt quick GUI soon, but I guess this modification will still be useful for those who use this version of GUI. I also would to make this change for Qt quick GUI, but all parameters names in QML are covered with "Mouse Area" objects, which don't allow to handle mouse events for text objects under them.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
