### PR TITLE
[runsofa] Drag and drop from scene graph or data field into an external text editor

### DIFF
--- a/applications/sofa/gui/qt/GUI.ui
+++ b/applications/sofa/gui/qt/GUI.ui
@@ -339,8 +339,11 @@
             <height>0</height>
            </size>
           </property>
+          <property name="acceptDrops">
+           <bool>false</bool>
+          </property>
           <property name="currentIndex">
-           <number>0</number>
+           <number>1</number>
           </property>
           <widget class="QWidget" name="TabGraph">
            <attribute name="title">

--- a/applications/sofa/gui/qt/QDisplayDataWidget.cpp
+++ b/applications/sofa/gui/qt/QDisplayDataWidget.cpp
@@ -27,8 +27,11 @@
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QGroupBox>
-#include <QLabel>
 #include <QValidator>
+#include <QMimeData>
+#include <QLabel>
+#include <QDrag>
+#include <QCoreApplication>
 
 #define TEXTSIZE_THRESHOLD 45
 
@@ -53,7 +56,9 @@ QDisplayDataWidget::QDisplayDataWidget(QWidget* parent,
     numWidgets_(0)
 
 {
+    setCursor(Qt::OpenHandCursor);
     gridLayout_ = new QGridLayout();
+
     this->setLayout(gridLayout_);
 
     parent->layout()->addWidget(this);
@@ -151,19 +156,11 @@ QDisplayDataWidget::QDisplayDataWidget(QWidget* parent,
 
         setStyleSheet("QGroupBox{border:0;}");
         setContentsMargins(0, 0, 0, 0);
-        //setInsideMargin(0);
-        //setInsideSpacing(0);
-
-        //setColumns(numWidgets_);
     }
     else
     {
         setTitle(data_->getName().c_str());
         setContentsMargins(0,0,0,0);
-        //setInsideMargin(4);
-        //setInsideSpacing(2);
-
-        //setColumns(numWidgets_); //datawidget_->numColumnWidget());
     }
     gridLayout_->setContentsMargins(10,10,10,10);
     gridLayout_->addWidget(datawidget_, 0, 1);
@@ -179,6 +176,24 @@ void QDisplayDataWidget::UpdateWidgets()
 {
     emit WidgetUpdate();
 }
+
+void QDisplayDataWidget::mousePressEvent(QMouseEvent * event){
+    if (event->button() == Qt::LeftButton) {
+            QDrag *drag = new QDrag(this);
+            QMimeData *mimeData = new QMimeData;
+
+            QString text;
+            text  = QString(data_->getName().c_str());
+            text += "=\'" ;
+            text += QString(data_->getValueString().c_str());
+            text += "\'\n" ;
+
+            mimeData->setText(text);
+            drag->setMimeData(mimeData);
+            Qt::DropAction dropAction = drag->exec();
+        }
+}
+
 
 QDataSimpleEdit::QDataSimpleEdit(QWidget* parent, const char* name, BaseData* data):
     DataWidget(parent,name,data)
@@ -203,9 +218,6 @@ bool QDataSimpleEdit::createWidgets()
         connect( innerWidget_.widget.lineEdit, SIGNAL(textChanged(const QString&)), this, SLOT( setWidgetDirty() ) );
         layout->addWidget(innerWidget_.widget.lineEdit);
     }
-
-
-
 
     return true;
 }
@@ -252,12 +264,10 @@ void QDataSimpleEdit::writeToData()
     }
 }
 
-/* QPoissonRatioWidget */
 
 QPoissonRatioWidget::QPoissonRatioWidget(QWidget * parent, const char * name, sofa::core::objectmodel::Data<double> *data)
     :TDataWidget<double>(parent,name,data)
 {
-
 }
 
 

--- a/applications/sofa/gui/qt/QDisplayDataWidget.h
+++ b/applications/sofa/gui/qt/QDisplayDataWidget.h
@@ -60,6 +60,11 @@ public:
 
     ModifyObjectFlags flag() {return flags_;}
 
+
+    // Inherited from QGroupBox. These are reimplemented to implement
+    // drag&drop.
+    virtual void 	mousePressEvent(QMouseEvent * event) ;
+
 public slots:
     void UpdateData();              //QWidgets ---> BaseData
     void UpdateWidgets();           //BaseData ---> QWidget
@@ -71,17 +76,17 @@ signals:
     void dataValueChanged(QString);
 
 protected:
-	static QIcon& RefreshIcon()
-	{
-		static QIcon icon;
-		if(icon.isNull())
-		{
-			std::string filename = "textures/refresh.png";
-			sofa::helper::system::DataRepository.findFile(filename);
-			icon = QIcon(filename.c_str());
-		}
-		return icon;
-	}
+    static QIcon& RefreshIcon()
+    {
+        static QIcon icon;
+        if(icon.isNull())
+        {
+            std::string filename = "textures/refresh.png";
+            sofa::helper::system::DataRepository.findFile(filename);
+            icon = QIcon(filename.c_str());
+        }
+        return icon;
+    }
 
 protected:
     core::objectmodel::BaseData* data_;

--- a/applications/sofa/gui/qt/QSofaListView.cpp
+++ b/applications/sofa/gui/qt/QSofaListView.cpp
@@ -220,6 +220,16 @@ void QSofaListView::expandNode(QTreeWidgetItem* item)
     emit Lock(false);
 }
 
+Base* QSofaListView::findBaseFromItem(QTreeWidgetItem* item)
+{
+    Base* base=NULL ;
+    if(item == NULL)
+        return NULL ;
+
+    base = graphListener_->findObject(item) ;
+    return base ;
+}
+
 void QSofaListView::updateMatchingObjectmodel(QTreeWidgetItem* item, int)
 {
     updateMatchingObjectmodel(item);
@@ -777,6 +787,8 @@ void QSofaListView::mouseMoveEvent(QMouseEvent *event)
     }
 
 }
+
+
 
 void QSofaListView::mousePressEvent(QMouseEvent * event){
     if (event->button() == Qt::LeftButton) {

--- a/applications/sofa/gui/qt/QSofaListView.h
+++ b/applications/sofa/gui/qt/QSofaListView.h
@@ -29,6 +29,7 @@
 #include <QTreeWidgetItem>
 #include <QHeaderView>
 #include <QPushButton>
+#include <QPoint>
 
 
 #include <sofa/gui/qt/SofaGUIQt.h>
@@ -96,7 +97,17 @@ public:
     SofaListViewAttribute getAttribute() const { return attribute_; }
 
     void contextMenuEvent(QContextMenuEvent *event);
+
+    Node* getNode(QTreeWidgetItem *item) const ;
+    Base* getComponent(QTreeWidgetItem *item) const ;
+    BaseObject* getObject(QTreeWidgetItem *item) const ;
+
+    // From QTreeWidget
+    virtual void mousePressEvent(QMouseEvent* event) ;
+    virtual void mouseMoveEvent(QMouseEvent* event) ;
+
 public Q_SLOTS:
+
     void Export();
     void CloseAllDialogs();
     void UpdateOpenedDialogs();
@@ -159,6 +170,7 @@ protected:
     SofaListViewAttribute attribute_;
     QDisplayPropertyWidget* propertyWidget;
 
+    QPoint m_dragStartPosition ;
 };
 
 } //sofa

--- a/applications/sofa/gui/qt/QSofaListView.h
+++ b/applications/sofa/gui/qt/QSofaListView.h
@@ -155,6 +155,7 @@ protected Q_SLOTS:
     void focusObject();
     void focusNode();
 protected:
+    core::objectmodel::Base* findBaseFromItem(QTreeWidgetItem* item) ;
     void collapseNode(QTreeWidgetItem* item);
     void expandNode(QTreeWidgetItem* item);
     void transformObject ( sofa::simulation::Node *node, double dx, double dy, double dz,  double rx, double ry, double rz, double scale );

--- a/applications/sofa/gui/qt/QSofaListView.h
+++ b/applications/sofa/gui/qt/QSofaListView.h
@@ -98,9 +98,9 @@ public:
 
     void contextMenuEvent(QContextMenuEvent *event);
 
-    Node* getNode(QTreeWidgetItem *item) const ;
-    Base* getComponent(QTreeWidgetItem *item) const ;
-    BaseObject* getObject(QTreeWidgetItem *item) const ;
+    sofa::simulation::Node* getNode(QTreeWidgetItem *item) const ;
+    sofa::core::objectmodel::Base* getComponent(QTreeWidgetItem *item) const ;
+    sofa::core::objectmodel::BaseObject* getObject(QTreeWidgetItem *item) const ;
 
     // From QTreeWidget
     virtual void mousePressEvent(QMouseEvent* event) ;


### PR DESCRIPTION
Hi all,

as earlier, I'm making PR on several 'simple' behavior that I implemented a long time ago but could make user of runSofa happier. Here is one that allows to drag & drop data or scene from the  gui into and external text editor to have the data serialized. This feature is  very useful if you like editing your scene in runSofa and need to transfer the results into sofa.  

As GUI stuff are nicer with image... I will make a small video to show it in use. 
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
