### PR TITLE
[CI] FIX scene-test segfault on timeout (Windows)

### DIFF
--- a/scripts/ci/scene-tests.sh
+++ b/scripts/ci/scene-tests.sh
@@ -305,6 +305,7 @@ test-all-scenes() {
         if [[ -e runSofa.timeout ]]; then
             echo 'Timeout!'
             echo timeout > "$output_dir/$scene/status.txt"
+            echo -e "\n\nINFO: Abort caused by timeout.\n" >> "$output_dir/$scene/output.txt"
             rm -f runSofa.timeout
         else
             cat runSofa.exit_code > "$output_dir/$scene/status.txt"

--- a/scripts/ci/timeout.sh
+++ b/scripts/ci/timeout.sh
@@ -49,13 +49,9 @@ run-command-with-timeout() {
     rm -f $1.pid
 }
 
-if [[ $(uname) != Linux && $(uname) != Darwin ]]; then
-    run-command-with-timeout "$1" "$2" "$3" 2> /dev/null
-else
-    timeout "$3" bash -c "$2"
-    exit_code=$?
-    if [[ ( $(uname) = Linux && $exit_code = 124 ) || ($(uname) = Darwin && $exit_code = 137 ) ]]; then
-        touch "$1".timeout
-    fi
-    echo $exit_code > "$1".exit_code
+timeout "$3" bash -c "$2"
+exit_code=$?
+if [[ ($(uname) = Darwin && $exit_code = 137 ) || ( $exit_code = 124 ) ]]; then
+    touch "$1".timeout
 fi
+echo $exit_code > "$1".exit_code


### PR DESCRIPTION
Unix timeout command is now accessible in Windows VMs (using "Git for Windows" Bash).

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
