### PR TITLE
[runSofa] add verification if help is not null from displayed data

### DIFF
--- a/applications/sofa/gui/qt/QDisplayDataWidget.cpp
+++ b/applications/sofa/gui/qt/QDisplayDataWidget.cpp
@@ -63,7 +63,8 @@ QDisplayDataWidget::QDisplayDataWidget(QWidget* parent,
     if(data_ == NULL)
         return;
 
-    const std::string label_text = data_->getHelp();
+    const char* help_text = data_->getHelp();
+    const std::string label_text = help_text == NULL ? "" : help_text;
 
     if (label_text != "TODO")
     {


### PR DESCRIPTION
Ensure data_->getHelp() is not null.
If it's null an empty string will be used, instead of make runSofa crash

EDIT : fixes #381 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
