### PR TITLE
[SofaBoundaryCondition] FIX Removed incorrect warning from LinearForceField

### DIFF
--- a/modules/SofaBoundaryCondition/LinearForceField.h
+++ b/modules/SofaBoundaryCondition/LinearForceField.h
@@ -115,6 +115,8 @@ public:
         mparams->setKFactorUsed(true);
     };
 
+    virtual void addKToMatrix(sofa::defaulttype::BaseMatrix * matrix, SReal kFact, unsigned int &offset);
+
     virtual SReal getPotentialEnergy(const core::MechanicalParams* mparams, const DataVecCoord& x) const;
 
 private :

--- a/modules/SofaBoundaryCondition/LinearForceField.inl
+++ b/modules/SofaBoundaryCondition/LinearForceField.inl
@@ -161,6 +161,14 @@ void LinearForceField<DataTypes>::addForce(const core::MechanicalParams* /*mpara
 }// LinearForceField::addForce
 
 template<class DataTypes>
+void LinearForceField<DataTypes>::addKToMatrix(defaulttype::BaseMatrix* matrix, SReal kFact, unsigned int& offset)
+{
+    SOFA_UNUSED(matrix);
+    SOFA_UNUSED(kFact);
+    SOFA_UNUSED(offset);
+}
+
+template<class DataTypes>
 SReal LinearForceField<DataTypes>::getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord& x) const
 {
     Real cT = (Real) this->getContext()->getTime();


### PR DESCRIPTION

The LinearForceField component does not contribute anything to the matrix when solving a system. Accordingly, the addKToMatrix function does nothing. However, since it is not implemented, it displays a warning when running a simulation. This PR simply adds an empty implementation of that function, which removes the warning displayed by the definition in the base class.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
