### PR TITLE
[SofaKernel] add ability to use NoArgument  for BaseCreator and Factory

### DIFF
--- a/SofaKernel/framework/sofa/helper/Factory.h
+++ b/SofaKernel/framework/sofa/helper/Factory.h
@@ -34,6 +34,9 @@ namespace sofa
 namespace helper
 {
 
+/// Allow us to use BaseCreator and Factory without using any Arguments
+class NoArgument {} ;
+
 /// Decode the type's name to a more readable form if possible
 std::string SOFA_HELPER_API gettypename(const std::type_info& t);
 
@@ -43,7 +46,7 @@ void SOFA_HELPER_API logFactoryRegister(std::string baseclass, std::string class
 /// Print factory log
 void SOFA_HELPER_API printFactoryLog(std::ostream& out = std::cout);
 
-template <class Object, class Argument, class ObjectPtr = Object*>
+template <class Object, class Argument = NoArgument, class ObjectPtr = Object*>
 class BaseCreator
 {
 public:
@@ -52,7 +55,7 @@ public:
     virtual const std::type_info& type() = 0;
 };
 
-template <typename TKey, class TObject, typename TArgument, typename TPtr = TObject* >
+template <typename TKey, class TObject, typename TArgument = NoArgument, typename TPtr = TObject* >
 class Factory
 {
 public:

--- a/SofaKernel/framework/sofa/helper/Factory.h
+++ b/SofaKernel/framework/sofa/helper/Factory.h
@@ -25,6 +25,7 @@
 #include <map>
 #include <iostream>
 #include <typeinfo>
+#include <type_traits>
 
 #include <sofa/helper/helper.h>
 
@@ -79,7 +80,13 @@ public:
         return true;
     }
 
+    template< class U = Argument, typename std::enable_if<std::is_same<U, NoArgument>::value, int>::type = 0>
+    ObjectPtr createObject(Key key, Argument arg = NoArgument()){
+        createObject(key, arg);
+    }
+
     ObjectPtr createObject(Key key, Argument arg);
+
     ObjectPtr createAnyObject(Argument arg);
 
     template< typename OutIterator >


### PR DESCRIPTION
This PR simply add a default class named NoArgument in Factory.h.
NoArgument is usefull when you try to instantiate BaseCreator or Factory without passing arguments

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
