### PR TITLE
[tools] Improve scn2python

### DIFF
--- a/applications/plugins/SofaPython/scn2python.py
+++ b/applications/plugins/SofaPython/scn2python.py
@@ -55,7 +55,7 @@ def attributesToStringPython(child,printName) :
 def rootAttributesToStringPython(root,tabs) :
     attribute_str = str()
     for item in root.items() :
-        if (not (item[0] == 'name') ):
+        if (not (item[0] == 'name') ) and (not (item[0] == 'showBoundingTree') ) :
             attribute_str += tabs+"rootNode.findData(\'" + item[0] + "\').value = \'" + item[1] + "\'\n"
     return attribute_str;
 
@@ -205,7 +205,13 @@ def writePythonFile(info_str,classNamePythonFile,node,outputFilenamePython,produ
         tabs = "    "
         pythonFile_str += "\n\ndef createScene(rootNode):\n"
         pythonFile_str += rootAttributesToStringPython(node,tabs)
-        pythonFile_str += tabs+"my"+classNamePythonFile+" = "+classNamePythonFile+"(rootNode,sys.argv)"
+        pythonFile_str += tabs+"try : \n"
+        pythonFile_str += tabs+"    sys.argv[0]\n"
+        pythonFile_str += tabs+"except :\n"
+        pythonFile_str += tabs+"    commandLineArguments = []\n"
+        pythonFile_str += tabs+"else :\n"
+        pythonFile_str += tabs+"    commandLineArguments = sys.argv\n"
+        pythonFile_str += tabs+"my"+classNamePythonFile+" = "+classNamePythonFile+"(rootNode,commandLineArguments)"
         pythonFile_str += "\n"+tabs+"return 0;"
 
     # write python file

--- a/applications/plugins/SofaPython/scn2python.py
+++ b/applications/plugins/SofaPython/scn2python.py
@@ -162,11 +162,14 @@ def writePythonFile(info_str,classNamePythonFile,node,outputFilenamePython,produ
     pythonFile_str = "\"\"\"\n"
     pythonFile_str += info_str
     pythonFile_str += "\"\"\"\n\n"
+    pythonFile_str += "import sys\n"
     pythonFile_str += "import Sofa\n\n"
     
     pythonFile_str += "class " + classNamePythonFile + " (Sofa.PythonScriptController):\n\n"
     if not produceSceneAndPythonFile :
-        pythonFile_str += "    def __init__(self, node) : \n"
+        pythonFile_str += "    def __init__(self, node, commandLineArguments) : \n"
+        pythonFile_str += tabs+"self.commandLineArguments = commandLineArguments\n"
+        pythonFile_str += tabs+'print "Command line arguments for python : "+str(commandLineArguments)\n'
         pythonFile_str += tabs+"self.createGraph(node)\n"
         pythonFile_str += tabs+"return None;\n\n"
     pythonFile_str += "    def createGraph(self,rootNode):\n\n"
@@ -183,7 +186,7 @@ def writePythonFile(info_str,classNamePythonFile,node,outputFilenamePython,produ
         tabs = "    "
         pythonFile_str += "\n\ndef createScene(rootNode):\n"
         pythonFile_str += rootAttributesToStringPython(node,tabs)
-        pythonFile_str += tabs+"my"+classNamePythonFile+" = "+classNamePythonFile+"(rootNode)"
+        pythonFile_str += tabs+"my"+classNamePythonFile+" = "+classNamePythonFile+"(rootNode,sys.argv)"
         pythonFile_str += "\n"+tabs+"return 0;"
 
     # write python file
@@ -213,8 +216,9 @@ def transformXMLSceneToPythonScene(pythonFilename,inputScene,produceSceneAndPyth
     if produceSceneAndPythonFile :
         info_str += ".scn"
     else :
-        info_str += ".py"
-        info_str += "\nThe sofa python plugin has to be added in the sofa plugin manager, \ni.e. add the sofa python plugin in runSofa->Edit->PluginManager."
+        info_str += ".py --argv 123"
+        info_str += "\nThe sofa python plugin might have to be added in the sofa plugin manager, \ni.e. add the sofa python plugin in runSofa->Edit->PluginManager."
+        info_str += "\nThe arguments given after --argv can be used by accessing self.commandLineArguments, e.g. combined with ast.literal_eval to convert a string to a number."
     info_str += "\n\n"
     info_str += "The current file has been written by the python script\n"
     info_str += pythonFilename + "\n"

--- a/applications/plugins/SofaPython/scn2python.py
+++ b/applications/plugins/SofaPython/scn2python.py
@@ -155,10 +155,10 @@ def parseInput() :
         description='Script to transform a Sofa scene from xml to python',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,# ArgumentDefaultsHelpFormatter
         epilog='''The output of this script uses the python plugin of sofa. The python plugin allows for a manipulation of a scene at run time. More informations about the plugin itself can be found in sofa/applications/plugins/SofaPython/doc/SofaPython.pdf. If you prefer to only produce one output file O.py (instead of producing two ouputfiles O.scn and O.py), then set the flag --py. To be able to run a scene O.py, the sofa python plugin has to be added in the sofa plugin manager, i.e. add the sofa python plugin in runSofa->Edit->PluginManager. Author of createPythonScene.py: Christoph PAULUS, christoph.paulus@inria.fr''')
-    parser.add_argument('inputScenes', metavar='I', type=str, nargs='+',help='filename(s) of the standard scene(s)')
-    parser.add_argument('-n', nargs='?', help='node to replace by python script, if N the complete scene is replaced by a python script')
-    parser.add_argument('-o', nargs='*', help='filename(s) of the transformed scene(s)')
-    parser.add_argument('-p', dest='onlyOutputPythonScript', action='store_const', default=0, const=1, help='Output .scn and .py file')
+    parser.add_argument('inputScenes', metavar='I', type=str, nargs='+',help='Filename(s) of the standard scene(s)')
+    parser.add_argument('-n', nargs='?', help='Node to replace by python script, if equals None the complete scene is replaced by a python script')
+    parser.add_argument('-o', nargs='*', help='Filename(s) of the transformed scene(s)')
+    parser.add_argument('-s', dest='onlyOutputPythonScript', action='store_const', default=0, const=1, help='Output .scn and .py file')
     args = parser.parse_args()
     return parser,args;
 
@@ -294,11 +294,14 @@ def main() :
     parser,args = parseInput()
     pythonFilename = sys.argv[0]
     produceSceneAndPythonFile = args.onlyOutputPythonScript
+    nodeToPythonScript = args.n
+    if nodeToPythonScript and not produceSceneAndPythonFile :
+        print "ERROR: If you would like to replace a node using -n, please also use -s to produce a scene. If you would like to replace the complete scene by a python script (recommended), then please remove the argument -n."
+        sys.exit()
 
     # transform each standard scene to a python scene
     for i in range(len(args.inputScenes)) :
         inputScene = args.inputScenes[i]
-        nodeToPythonScript = args.n
         outputFilename = chopStringAtChar(inputScene,'\.',useContentBeforeChar=1)+'Python'
         if args.o is not None :
             if i < len(args.o) :

--- a/applications/plugins/SofaPython/scn2python.py
+++ b/applications/plugins/SofaPython/scn2python.py
@@ -12,6 +12,7 @@ from subprocess import check_output
 import argparse
 import sys
 import os
+import commands
 
 def stringToVariableName(s):
     ### converting a string in a valid variable name

--- a/applications/plugins/SofaPython/scn2python.py
+++ b/applications/plugins/SofaPython/scn2python.py
@@ -85,10 +85,9 @@ def getNodeName(node,numberOfUnnamedNodes) :
         numberOfUnnamedNodes += 1
     return nodeName,numberOfUnnamedNodes
 
-def printChildren(parent, tabs, numberOfUnnamedNodes, scenePath='rootNode', nodeIsRootNode=0) :
-    parentName = parent.get('name')
-    if nodeIsRootNode :
-        parentName = 'rootNode'
+def printChildren(parent, tabs, numberOfUnnamedNodes, scenePath='rootNode', nodeIsRootNode=0, parentName='rootNode') :
+    if not nodeIsRootNode :
+        parentName = parent.get('name')
     parentVariableName = stringToVariableName(parentName)
     myChildren = str()
     for child in parent :
@@ -101,7 +100,19 @@ def printChildren(parent, tabs, numberOfUnnamedNodes, scenePath='rootNode', node
             myChildren += childAttributesToStringPython(child,childName,tabs)
             myChildren += printChildren(child,tabs,numberOfUnnamedNodes,scenePath=currentScenePath)
         else :
-            myChildren += tabs+parentVariableName+"."+createObject(child)+"\n"
+            if not child.tag == "include" :
+                myChildren += tabs+parentVariableName+"."+createObject(child)+"\n"
+            else :
+                href = ""
+                for item in child.items() :
+                    if item[0] == "href" :
+                        href = item[1]
+                inputFilename = check_output(["locate",href])[:-1]
+                tree = ET.parse(inputFilename)
+                root = tree.getroot()
+                fromExternalFile = printChildren(root,tabs,numberOfUnnamedNodes,scenePath=scenePath,nodeIsRootNode=1,parentName=parentVariableName)
+                myChildren += fromExternalFile
+                print "WARNING: Included external file, please check the links starting from \n"+fromExternalFile[:100]+"\n... until ...\n"+fromExternalFile[-100:]
     return myChildren;
 
 def getElement (node,name) :

--- a/applications/plugins/SofaPython/scn2python.py
+++ b/applications/plugins/SofaPython/scn2python.py
@@ -11,6 +11,7 @@ import xml.etree.ElementTree as ET
 from subprocess import check_output
 import argparse
 import sys
+import os
 
 def stringToVariableName(s):
     ### converting a string in a valid variable name
@@ -162,12 +163,42 @@ def parseInput() :
     args = parser.parse_args()
     return parser,args;
 
+def getFilename() :
+    filename = __file__
+    if filename[0] == "." :
+        filename = commands.getstatusoutput('pwd')[1]+filename[1:]
+    else :
+        filename = commands.getstatusoutput('pwd')[1]+"/"+filename
+    return filename
+
 def pythonScriptControllerFunctions() :
-    allScriptControllerFunctions = ['onKeyPressed(self, c)','onKeyReleased(self, c)','onLoaded(self, node)','onMouseButtonLeft(self, mouseX,mouseY,isPressed)','onMouseButtonRight(self, mouseX,mouseY,isPressed)','onMouseButtonMiddle(self, mouseX,mouseY,isPressed)','onMouseWheel(self, mouseX,mouseY,wheelDelta)','onGUIEvent(self, strControlID,valueName,strValue)','onBeginAnimationStep(self, deltaTime)','onEndAnimationStep(self, deltaTime)','onScriptEvent(self, senderNode, eventName,data)','initGraph(self, node)','bwdInitGraph(self, node)','storeResetState(self)','reset(self)','cleanup(self)']
+    noExample = '## Please feel free to add an example for a simple usage in '+getFilename()
+    scriptControllerFunctions = {
+        'onKeyPressed(self, c)' : '## usage e.g.\n#if c=="A" :\n#    print "You pressed control+a"',
+        'onKeyReleased(self, c)' : '## usage e.g.\n#if c=="A" :\n#    print "You released a"',
+        'onLoaded(self, node)' : noExample,
+        'onMouseButtonLeft(self, mouseX,mouseY,isPressed)' : '## usage e.g.\n#if isPressed : \n#    print "Control+Left mouse button pressed at position "+str(mouseX)+", "+str(mouseY)',
+        'onMouseButtonRight(self, mouseX,mouseY,isPressed)' : '## usage e.g.\n#if isPressed : \n#    print "Control+Right mouse button pressed at position "+str(mouseX)+", "+str(mouseY)',
+        'onMouseButtonMiddle(self, mouseX,mouseY,isPressed)' : '## usage e.g.\n#if isPressed : \n#    print "Control+Middle mouse button pressed at position "+str(mouseX)+", "+str(mouseY)',
+        'onMouseWheel(self, mouseX,mouseY,wheelDelta)' : '## usage e.g.\n#if isPressed : \n#    print "Control button pressed+mouse wheel turned at position "+str(mouseX)+", "+str(mouseY)+", wheel delta"+str(wheelDelta)',
+        'onGUIEvent(self, strControlID,valueName,strValue)' : noExample,
+        'onBeginAnimationStep(self, deltaTime)' : noExample,
+        'onEndAnimationStep(self, deltaTime)' : noExample,
+        'onScriptEvent(self, senderNode, eventName,data)' : noExample,
+        'initGraph(self, node)' : noExample,
+        'bwdInitGraph(self, node)' : noExample,
+        'storeResetState(self)' : noExample,
+        'reset(self)' : noExample,
+        'cleanup(self)' : noExample}
     result = '\n'
     tabs = "    "
-    for curFct in allScriptControllerFunctions :
-        result += '\n'+tabs+'def ' + curFct + ':\n'+tabs+'    return 0;\n'
+    for curFct in scriptControllerFunctions.keys() :
+        result += '\n'+tabs+'def ' + curFct + ':\n'
+        if len(scriptControllerFunctions[curFct]) :
+            exampleUsage = scriptControllerFunctions[curFct].split("\n")
+            for line in exampleUsage :
+                result += tabs+'    '+line+'\n'
+        result += tabs+'    return 0;\n'
     return result
 
 def writePythonFile(info_str,classNamePythonFile,node,outputFilenamePython,produceSceneAndPythonFile=1,nodeIsRootNode=1) :
@@ -219,7 +250,9 @@ def writePythonFile(info_str,classNamePythonFile,node,outputFilenamePython,produ
     f_py.write(pythonFile_str)
     f_py.close()
 
-def transformXMLSceneToPythonScene(pythonFilename,inputScene,produceSceneAndPythonFile,outputFilename,nodeToPythonScript) :
+def transformXMLSceneToPythonScene(inputScene,produceSceneAndPythonFile,outputFilename,nodeToPythonScript) :
+    # get the correct input filename
+    pythonFilename = getFilename()
     # get the correct names for the output files
     pythonFilenameWithoutPath = chopStringAtChar(pythonFilename,'/')
     outputFilenameWithoutPath = chopStringAtChar(outputFilename,'/')
@@ -292,7 +325,6 @@ def transformXMLSceneToPythonScene(pythonFilename,inputScene,produceSceneAndPyth
 def main() :
     # parse the console input
     parser,args = parseInput()
-    pythonFilename = sys.argv[0]
     produceSceneAndPythonFile = args.onlyOutputPythonScript
     nodeToPythonScript = args.n
     if nodeToPythonScript and not produceSceneAndPythonFile :
@@ -307,7 +339,7 @@ def main() :
             if i < len(args.o) :
                 outputFilename = args.o[i]
         print 'Input Scene: '+inputScene+', replace node: '+str(nodeToPythonScript)+', output: '+outputFilename+', produce .scn and .py: '+str(produceSceneAndPythonFile)
-        transformXMLSceneToPythonScene(pythonFilename,inputScene,produceSceneAndPythonFile,outputFilename,nodeToPythonScript)
+        transformXMLSceneToPythonScene(inputScene,produceSceneAndPythonFile,outputFilename,nodeToPythonScript)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
In this pull request I propose several improvements of the script scn2python.py: 
- Improved the structure of the output file, i.e. for both, the generation of .scn+.py and .py a class python script controller is introduced (before it was only the case for .scn+.py). For .py the function createScene then introduces an instance of the class. Moreover, the script now saves every node in self, s.t. it is not necessary to use getChild.
- In createScene, the command line arguments introduced in #356 are now forwarded to the class (not possible before)
- If an xml scene includes another file, the script now locates this file and then introduces all its objects automatically
- In an insertion like the one mentioned in the last point, it can happen, that there are links like '@', are now dealt with the input of the user.

I am open for any improvements!
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
