### PR TITLE
[SofaPython] GIL: fix windows link

### DIFF
--- a/applications/plugins/SofaPython/PythonEnvironment.cpp
+++ b/applications/plugins/SofaPython/PythonEnvironment.cpp
@@ -434,7 +434,7 @@ PythonEnvironment::gil::~gil() {
 }
 
 
-
+// not exactly sure what to do
 PythonEnvironment::no_gil::no_gil(const char* trace)
     : state(PyEval_SaveThread()),
       trace(trace) {


### PR DESCRIPTION
The title says it all. 

I'm confused as the windows build used to terminate correctly when the PR was merged :-/

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
