### PR TITLE
[SofaGraphComponent] Refactor the SceneChecker and add a new SceneChecker to test dumplicated names.

### DIFF
--- a/SofaKernel/modules/SofaSimulationGraph/DAGNode.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/DAGNode.cpp
@@ -63,7 +63,6 @@ Node::SPtr DAGNode::createChild(const std::string& nodeName)
 /// Add a child node
 void DAGNode::doAddChild(DAGNode::SPtr node)
 {
-//    printf("DAGNode::doAddChild this=%X(%s) child=%X(%s)\n",this,getName().c_str(),node.get(),node->getName().c_str());
     child.add(node);
     node->l_parents.add(this);
     node->l_parents.updateLinks(); // to fix load-time unresolved links

--- a/applications/sofa/gui/qt/RealGUI.cpp
+++ b/applications/sofa/gui/qt/RealGUI.cpp
@@ -904,6 +904,9 @@ void RealGUI::setSceneWithoutMonitor (Node::SPtr root, const char* filename, boo
         /// We want to warn user that there is component that are implemented in specific plugin
         /// and that there is no RequiredPlugin in their scene.
         SceneCheckerVisitor checker(ExecParams::defaultInstance()) ;
+        checker.addCheck(simulation::SceneCheckAPIChange::newSPtr());
+        checker.addCheck(simulation::SceneCheckDuplicatedName::newSPtr());
+        checker.addCheck(simulation::SceneCheckMissingRequiredPlugin::newSPtr());
         checker.validate(root.get()) ;
 
         mSimulation = root;

--- a/applications/sofa/gui/qt/RealGUI.cpp
+++ b/applications/sofa/gui/qt/RealGUI.cpp
@@ -763,6 +763,9 @@ void RealGUI::fileOpen ( std::string filename, bool temporaryFile, bool reload )
     /// We want to warn user that there is component that are implemented in specific plugin
     /// and that there is no RequiredPlugin in their scene.
     SceneCheckerVisitor checker(ExecParams::defaultInstance()) ;
+    checker.addCheck(simulation::SceneCheckAPIChange::newSPtr());
+    checker.addCheck(simulation::SceneCheckDuplicatedName::newSPtr());
+    checker.addCheck(simulation::SceneCheckMissingRequiredPlugin::newSPtr());
     checker.validate(mSimulation.get()) ;
 }
 

--- a/modules/SofaGraphComponent/CMakeLists.txt
+++ b/modules/SofaGraphComponent/CMakeLists.txt
@@ -16,6 +16,7 @@ set(HEADER_FILES
     SofaDefaultPathSetting.h
     StatsSetting.h
     ViewerSetting.h
+    SceneChecks.h
     SceneCheckerVisitor.h
     APIVersion.h
     config.h
@@ -36,6 +37,7 @@ set(SOURCE_FILES
     SofaDefaultPathSetting.cpp
     StatsSetting.cpp
     ViewerSetting.cpp
+    SceneChecks.cpp
     SceneCheckerVisitor.cpp
     APIVersion.cpp
     initGraphComponent.cpp

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
@@ -47,11 +47,7 @@ using sofa::helper::system::PluginManager ;
 
 SceneCheckerVisitor::SceneCheckerVisitor(const ExecParams* params) : Visitor(params)
 {
-    std::stringstream version;
-    version << SOFA_VERSION / 10000 << "." << SOFA_VERSION / 100 % 100;
-    m_currentApiLevel = version.str();
 
-    installChangeSets() ;
 }
 
 SceneCheckerVisitor::~SceneCheckerVisitor()
@@ -66,38 +62,11 @@ void SceneCheckerVisitor::addCheck(SceneCheck* check)
 
 void SceneCheckerVisitor::removeCheck(SceneCheck* check)
 {
-     m_checkset.erase( std::remove( m_checkset.begin(), m_checkset.end(), check ), m_checkset.end() );
-}
-
-
-void SceneCheckerVisitor::addHookInChangeSet(const std::string& version, ChangeSetHookFunction fct)
-{
-    m_changesets[version].push_back(fct) ;
-}
-
-void SceneCheckerVisitor::installChangeSets()
-{
-    addHookInChangeSet("17.06", [](Base* o){
-        if(o->getClassName() == "RestShapeSpringsForceField" && o->findLink("external_rest_shape")->getSize() != 0)
-            msg_warning(o) << "RestShapeSpringsForceField have changed since 17.06. The parameter 'external_rest_shape' is now a Link. To fix your scene you need to add and '@' in front of the provided path. See PR#315" ;
-    }) ;
-
-    addHookInChangeSet("17.06", [](Base* o){
-        if(o->getClassName() == "BoxStiffSpringForceField" )
-            msg_warning(o) << "BoxStiffSpringForceField have changed since 17.06. To use the old behavior you need to set parameter 'forceOldBehavior=true'" ;
-    }) ;
-
-    addHookInChangeSet("17.06", [](Base* o){
-        if(o->getClassName() == "TheComponentWeWantToRemove" )
-            msg_warning(o) << "TheComponentWewantToRemove is deprecated since sofa 17.06. It have been replaced by TheSuperComponent. #See PR318" ;
-    }) ;
+    m_checkset.erase( std::remove( m_checkset.begin(), m_checkset.end(), check ), m_checkset.end() );
 }
 
 void SceneCheckerVisitor::validate(Node* node)
 {
-    enableValidationAPIVersion(node) ;
-    enableValidationRequiredPlugins(node) ;
-
     std::stringstream tmp;
     for(SceneCheck* check : m_checkset)
     {
@@ -110,79 +79,13 @@ void SceneCheckerVisitor::validate(Node* node)
     execute(node) ;
 }
 
-void SceneCheckerVisitor::enableValidationAPIVersion(Node* node)
-{
-    APIVersion* apiversion {nullptr} ;
-
-    /// 1. Find if there is an APIVersion component in the scene. If there is none, warn the user and set
-    /// the version to 17.06 (the last version before it was introduced). If there is one...use
-    /// this component to request the API version requested by the scene.
-    node->getTreeObject(apiversion) ;
-    if(!apiversion)
-    {
-        msg_info("SceneChecker") << "The 'APIVersion' directive is missing in the current scene. Switching to the default APIVersion level '"<< m_selectedApiLevel <<"' " ;
-    }
-    else
-    {
-        m_selectedApiLevel = apiversion->getApiLevel() ;
-    }
-
-    /// 2. We activate if the API level mis-match. In the future we may want to be able to handle
-    /// more precise way to track difference between version but for the moment let's take the
-    /// easy path for the developpers.
-    m_isAPIVersionValidationEnabled = m_selectedApiLevel != m_currentApiLevel ;
-}
-
-void SceneCheckerVisitor::enableValidationRequiredPlugins(Node* node)
-{
-    helper::vector< RequiredPlugin* > plugins ;
-    node->getTreeObjects< RequiredPlugin >(&plugins) ;
-
-    for(auto& plugin : plugins)
-        m_requiredPlugins[plugin->getName()] = true ;
-}
-
 Visitor::Result SceneCheckerVisitor::processNodeTopDown(Node* node)
 {
-    for (auto& object : node->object )
+    for(SceneCheck* check : m_checkset)
     {
-        for(SceneCheck* check : m_checkset)
-        {
-            check->doCheckOn(node) ;
-        }
-
-        if(m_isRequiredPluginValidationEnabled)
-        {
-            ObjectFactory::ClassEntry entry = ObjectFactory::getInstance()->getEntry(object->getClassName());
-            if(!entry.creatorMap.empty())
-            {
-                ObjectFactory::CreatorMap::iterator it = entry.creatorMap.find(object->getTemplateName());
-                if(entry.creatorMap.end() != it && *it->second->getTarget()){
-                    std::string pluginName = it->second->getTarget() ;
-                    std::string path = PluginManager::getInstance().findPlugin(pluginName) ;
-                    if( PluginManager::getInstance().pluginIsLoaded(path)
-                            && m_requiredPlugins.find(pluginName) == m_requiredPlugins.end() )
-                    {
-                        msg_warning("SceneChecker")
-                            << "This scene is using component '" << object->getClassName() << "'. " << msgendl
-                            << "This component is part of the '" << pluginName << "' plugin but there is no <RequiredPlugin name='" << pluginName << "'> directive in your scene." << msgendl
-                            << "Your scene may not work on a sofa environment that does not have pre-loaded the plugin." << msgendl
-                            << "To fix your scene and remove this warning you need to add the RequiredPlugin directive at the beginning of your scene. ";
-                    }
-                }
-            }
-        }
-        if(m_isAPIVersionValidationEnabled)
-        {
-            if(m_selectedApiLevel != m_currentApiLevel && m_changesets.find(m_selectedApiLevel) != m_changesets.end())
-            {
-                for(auto& hook : m_changesets[m_selectedApiLevel])
-                {
-                    hook(object.get());
-                }
-            }
-        }
+        check->doCheckOn(node) ;
     }
+
     return RESULT_CONTINUE;
 }
 

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
@@ -45,22 +45,26 @@ using sofa::core::ExecParams ;
 using sofa::helper::system::PluginRepository ;
 using sofa::helper::system::PluginManager ;
 
+
 SceneCheckerVisitor::SceneCheckerVisitor(const ExecParams* params) : Visitor(params)
 {
 
 }
 
+
 SceneCheckerVisitor::~SceneCheckerVisitor()
 {
 }
 
-void SceneCheckerVisitor::addCheck(SceneCheck* check)
+
+void SceneCheckerVisitor::addCheck(SceneCheck::SPtr check)
 {
     if( std::find(m_checkset.begin(), m_checkset.end(), check) == m_checkset.end() )
         m_checkset.push_back(check) ;
 }
 
-void SceneCheckerVisitor::removeCheck(SceneCheck* check)
+
+void SceneCheckerVisitor::removeCheck(SceneCheck::SPtr check)
 {
     m_checkset.erase( std::remove( m_checkset.begin(), m_checkset.end(), check ), m_checkset.end() );
 }
@@ -68,7 +72,7 @@ void SceneCheckerVisitor::removeCheck(SceneCheck* check)
 void SceneCheckerVisitor::validate(Node* node)
 {
     std::stringstream tmp;
-    for(SceneCheck* check : m_checkset)
+    for(SceneCheck::SPtr& check : m_checkset)
     {
         tmp << "- " << check->getName() << msgendl ;
     }
@@ -79,9 +83,10 @@ void SceneCheckerVisitor::validate(Node* node)
     execute(node) ;
 }
 
+
 Visitor::Result SceneCheckerVisitor::processNodeTopDown(Node* node)
 {
-    for(SceneCheck* check : m_checkset)
+    for(SceneCheck::SPtr& check : m_checkset)
     {
         check->doCheckOn(node) ;
     }

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
@@ -75,9 +75,11 @@ void SceneCheckerVisitor::validate(Node* node)
     for(SceneCheck::SPtr& check : m_checkset)
     {
         tmp << "- " << check->getName() << msgendl ;
+        check->doInit(node) ;
     }
 
-    msg_info("SceneChecker") << "Validating '"<< node->getName() << "' with: " << msgendl
+    msg_info("SceneChecker") << "Validating node '"<< node->getPathName() << "'. " << msgendl
+                             << "Activate checkers: " << msgendl
                              << tmp.str() ;
 
     execute(node) ;

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
@@ -19,9 +19,12 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <algorithm>
+#include <sofa/version.h>
+
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/helper/system/PluginManager.h>
-#include <sofa/version.h>
+#include <sofa/helper/system/FileRepository.h>
 
 #include "SceneChecks.h"
 #include "SceneCheckerVisitor.h"
@@ -55,7 +58,6 @@ SceneCheckerVisitor::~SceneCheckerVisitor()
 {
 }
 
-#include <algorithm>
 void SceneCheckerVisitor::addCheck(SceneCheck* check)
 {
     if( std::find(m_checkset.begin(), m_checkset.end(), check) == m_checkset.end() )

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.h
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.h
@@ -43,7 +43,6 @@ namespace sofa
 namespace simulation
 {
 
-typedef std::function<void(sofa::core::objectmodel::Base*)> ChangeSetHookFunction ;
 
 class SOFA_GRAPH_COMPONENT_API SceneCheckerVisitor : public Visitor
 {
@@ -52,26 +51,11 @@ public:
     virtual ~SceneCheckerVisitor() ;
 
     void validate(Node* node) ;
-
-    void enableValidationAPIVersion(Node *node) ;
-    void enableValidationRequiredPlugins(Node* node) ;
-
     virtual Result processNodeTopDown(Node* node) override ;
-
-    void installChangeSets() ;
-    void addHookInChangeSet(const std::string& version, ChangeSetHookFunction fct) ;
 
     void addCheck(SceneCheck* check) ;
     void removeCheck(SceneCheck* check) ;
 private:
-    std::map<std::string,bool> m_requiredPlugins ;
-    bool m_isRequiredPluginValidationEnabled {true} ;
-    bool m_isAPIVersionValidationEnabled {true} ;
-    std::string m_currentApiLevel;
-    std::string m_selectedApiLevel {"17.06"} ;
-
-    std::map<std::string, std::vector<ChangeSetHookFunction>> m_changesets ;
-
     std::vector<SceneCheck*> m_checkset ;
 };
 

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.h
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.h
@@ -28,21 +28,13 @@
 #include <map>
 
 #include <sofa/simulation/Visitor.h>
-
-/////////////////////////////// FORWARD DECLARATION ////////////////////////////////////////////////
-namespace sofa {
-    namespace simulation {
-        class SceneCheck ;
-    }
-}
-
+#include "SceneChecks.h"
 
 /////////////////////////////////////// DECLARATION ////////////////////////////////////////////////
 namespace sofa
 {
 namespace simulation
 {
-
 
 class SOFA_GRAPH_COMPONENT_API SceneCheckerVisitor : public Visitor
 {
@@ -53,10 +45,11 @@ public:
     void validate(Node* node) ;
     virtual Result processNodeTopDown(Node* node) override ;
 
-    void addCheck(SceneCheck* check) ;
-    void removeCheck(SceneCheck* check) ;
+    void addCheck(SceneCheck::SPtr check) ;
+    void removeCheck(SceneCheck::SPtr check) ;
+
 private:
-    std::vector<SceneCheck*> m_checkset ;
+    std::vector<SceneCheck::SPtr> m_checkset ;
 };
 
 } // namespace simulation

--- a/modules/SofaGraphComponent/SceneChecks.cpp
+++ b/modules/SofaGraphComponent/SceneChecks.cpp
@@ -19,13 +19,14 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <sofa/core/ObjectFactory.h>
-#include <sofa/helper/system/PluginManager.h>
 #include <sofa/version.h>
+#include <sofa/core/ObjectFactory.h>
+#include <sofa/simulation/Visitor.h>
+#include <sofa/helper/system/PluginManager.h>
+#include <sofa/helper/system/FileRepository.h>
 
 #include "SceneChecks.h"
 #include "RequiredPlugin.h"
-#include <sofa/simulation/Visitor.h>
 
 #include "APIVersion.h"
 using sofa::component::APIVersion ;

--- a/modules/SofaGraphComponent/SceneChecks.cpp
+++ b/modules/SofaGraphComponent/SceneChecks.cpp
@@ -132,6 +132,7 @@ void SceneCheckMissingRequiredPlugin::doInit(Node* node)
         m_requiredPlugins[plugin->getName()] = true ;
 }
 
+
 const std::string SceneCheckAPIChange::getName()
 {
     return "SceneCheckAPIChange";
@@ -147,9 +148,6 @@ void SceneCheckAPIChange::doInit(Node* node)
     std::stringstream version;
     version << SOFA_VERSION / 10000 << "." << SOFA_VERSION / 100 % 100;
     m_currentApiLevel = version.str();
-
-    m_changesets.clear() ;
-    installChangeSets() ;
 
     APIVersion* apiversion {nullptr} ;
     /// 1. Find if there is an APIVersion component in the scene. If there is none, warn the user and set
@@ -181,7 +179,7 @@ void SceneCheckAPIChange::doCheckOn(Node* node)
     }
 }
 
-void SceneCheckAPIChange::installChangeSets()
+void SceneCheckAPIChange::installDefaultChangeSets()
 {
     addHookInChangeSet("17.06", [](Base* o){
         if(o->getClassName() == "RestShapeSpringsForceField" && o->findData("external_rest_shape")->isSet())

--- a/modules/SofaGraphComponent/SceneChecks.cpp
+++ b/modules/SofaGraphComponent/SceneChecks.cpp
@@ -57,9 +57,36 @@ const std::string SceneCheckDuplicatedName::getDesc()
 
 void SceneCheckDuplicatedName::doCheckOn(Node* node)
 {
-    std::cout << "Do: " << getName() << std::endl ;
-}
+    std::map<std::string, int> duplicated ;
+    for (auto& object : node->object )
+    {
+        if( duplicated.find(object->getName()) == duplicated.end() )
+            duplicated[object->getName()] = 0 ;
+        duplicated[object->getName()]++ ;
+    }
 
+    for (auto& child : node->child )
+    {
+        if( duplicated.find(child->getName()) == duplicated.end() )
+            duplicated[child->getName()] = 0 ;
+        duplicated[child->getName()]++ ;
+    }
+
+    std::stringstream tmp ;
+    for(auto& p : duplicated)
+    {
+        if(p.second!=1)
+        {
+            tmp << "- duplicated '" << p.first << "'" << msgendl ;
+        }
+    }
+    if(!tmp.str().empty())
+    {
+       msg_warning("SceneCheckDuplicatedName") << "In '"<<  node->getPathName() <<"'" << msgendl
+                                               << tmp.str() ;
+    }
+
+}
 
 const std::string SceneCheckMissingRequiredPlugin::getName()
 {

--- a/modules/SofaGraphComponent/SceneChecks.cpp
+++ b/modules/SofaGraphComponent/SceneChecks.cpp
@@ -19,64 +19,81 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_SIMULATION_SCENECHECKERVISTOR_H
-#define SOFA_SIMULATION_SCENECHECKERVISTOR_H
+#include <sofa/core/ObjectFactory.h>
+#include <sofa/helper/system/PluginManager.h>
+#include <sofa/version.h>
 
-#include "config.h"
-
-#include <functional>
-#include <map>
-
+#include "SceneChecks.h"
+#include "RequiredPlugin.h"
 #include <sofa/simulation/Visitor.h>
 
-/////////////////////////////// FORWARD DECLARATION ////////////////////////////////////////////////
-namespace sofa {
-    namespace simulation {
-        class SceneCheck ;
-    }
-}
+#include "APIVersion.h"
+using sofa::component::APIVersion ;
 
-
-/////////////////////////////////////// DECLARATION ////////////////////////////////////////////////
 namespace sofa
 {
 namespace simulation
 {
-
-typedef std::function<void(sofa::core::objectmodel::Base*)> ChangeSetHookFunction ;
-
-class SOFA_GRAPH_COMPONENT_API SceneCheckerVisitor : public Visitor
+namespace _scenechecks_
 {
-public:
-    SceneCheckerVisitor(const sofa::core::ExecParams* params) ;
-    virtual ~SceneCheckerVisitor() ;
 
-    void validate(Node* node) ;
+using sofa::core::objectmodel::Base ;
+using sofa::component::misc::RequiredPlugin ;
+using sofa::core::ObjectFactory ;
+using sofa::core::ExecParams ;
+using sofa::helper::system::PluginRepository ;
+using sofa::helper::system::PluginManager ;
 
-    void enableValidationAPIVersion(Node *node) ;
-    void enableValidationRequiredPlugins(Node* node) ;
+const std::string SceneCheckDuplicatedName::getName()
+{
+    return "SceneCheckDuplicatedName";
+}
 
-    virtual Result processNodeTopDown(Node* node) override ;
+const std::string SceneCheckDuplicatedName::getDesc()
+{
+    return "Check there is not duplicated name in the scenegraph";
+}
 
-    void installChangeSets() ;
-    void addHookInChangeSet(const std::string& version, ChangeSetHookFunction fct) ;
+void SceneCheckDuplicatedName::doCheckOn(Node* node)
+{
+    std::cout << "Do: " << getName() << std::endl ;
+}
 
-    void addCheck(SceneCheck* check) ;
-    void removeCheck(SceneCheck* check) ;
-private:
-    std::map<std::string,bool> m_requiredPlugins ;
-    bool m_isRequiredPluginValidationEnabled {true} ;
-    bool m_isAPIVersionValidationEnabled {true} ;
-    std::string m_currentApiLevel;
-    std::string m_selectedApiLevel {"17.06"} ;
 
-    std::map<std::string, std::vector<ChangeSetHookFunction>> m_changesets ;
+const std::string SceneCheckMissingRequiredPlugin::getName()
+{
+    return "SceneCheckMissingRequiredPlugin";
+}
 
-    std::vector<SceneCheck*> m_checkset ;
-};
+const std::string SceneCheckMissingRequiredPlugin::getDesc()
+{
+    return "Check for each component provided by a plugin that the corresponding <RequiredPlugin> directive is present in the scene";
+}
+
+void SceneCheckMissingRequiredPlugin::doCheckOn(Node* node)
+{
+    std::cout << "Do: " << getName() << std::endl ;
+}
+
+
+const std::string SceneCheckAPIChange::getName()
+{
+    return "SceneCheckAPIChange";
+}
+
+const std::string SceneCheckAPIChange::getDesc()
+{
+    return "Check for each component that the behavior have not changed since reference version of sofa.";
+}
+
+void SceneCheckAPIChange::doCheckOn(Node* node)
+{
+    std::cout << "Do: " << getName() << std::endl ;
+}
+
+} // _scenechecks_
 
 } // namespace simulation
 
 } // namespace sofa
 
-#endif

--- a/modules/SofaGraphComponent/SceneChecks.cpp
+++ b/modules/SofaGraphComponent/SceneChecks.cpp
@@ -73,9 +73,37 @@ const std::string SceneCheckMissingRequiredPlugin::getDesc()
 
 void SceneCheckMissingRequiredPlugin::doCheckOn(Node* node)
 {
-    std::cout << "Do: " << getName() << std::endl ;
+    for (auto& object : node->object )
+    {
+        ObjectFactory::ClassEntry entry = ObjectFactory::getInstance()->getEntry(object->getClassName());
+        if(!entry.creatorMap.empty())
+        {
+            ObjectFactory::CreatorMap::iterator it = entry.creatorMap.find(object->getTemplateName());
+            if(entry.creatorMap.end() != it && *it->second->getTarget()){
+                std::string pluginName = it->second->getTarget() ;
+                std::string path = PluginManager::getInstance().findPlugin(pluginName) ;
+                if( PluginManager::getInstance().pluginIsLoaded(path)
+                        && m_requiredPlugins.find(pluginName) == m_requiredPlugins.end() )
+                {
+                    msg_warning("SceneChecker")
+                            << "This scene is using component '" << object->getClassName() << "'. " << msgendl
+                            << "This component is part of the '" << pluginName << "' plugin but there is no <RequiredPlugin name='" << pluginName << "'> directive in your scene." << msgendl
+                            << "Your scene may not work on a sofa environment that does not have pre-loaded the plugin." << msgendl
+                            << "To fix your scene and remove this warning you need to add the RequiredPlugin directive at the beginning of your scene. ";
+                }
+            }
+        }
+    }
 }
 
+void SceneCheckMissingRequiredPlugin::doInit(Node* node)
+{
+    helper::vector< RequiredPlugin* > plugins ;
+    node->getTreeObjects< RequiredPlugin >(&plugins) ;
+
+    for(auto& plugin : plugins)
+        m_requiredPlugins[plugin->getName()] = true ;
+}
 
 const std::string SceneCheckAPIChange::getName()
 {
@@ -87,10 +115,68 @@ const std::string SceneCheckAPIChange::getDesc()
     return "Check for each component that the behavior have not changed since reference version of sofa.";
 }
 
+void SceneCheckAPIChange::doInit(Node* node)
+{
+    std::stringstream version;
+    version << SOFA_VERSION / 10000 << "." << SOFA_VERSION / 100 % 100;
+    m_currentApiLevel = version.str();
+
+    m_changesets.clear() ;
+    installChangeSets() ;
+
+    APIVersion* apiversion {nullptr} ;
+    /// 1. Find if there is an APIVersion component in the scene. If there is none, warn the user and set
+    /// the version to 17.06 (the last version before it was introduced). If there is one...use
+    /// this component to request the API version requested by the scene.
+    node->getTreeObject(apiversion) ;
+    if(!apiversion)
+    {
+        msg_info("SceneChecker") << "The 'APIVersion' directive is missing in the current scene. Switching to the default APIVersion level '"<< m_selectedApiLevel <<"' " ;
+    }
+    else
+    {
+        m_selectedApiLevel = apiversion->getApiLevel() ;
+    }
+}
+
 void SceneCheckAPIChange::doCheckOn(Node* node)
 {
-    std::cout << "Do: " << getName() << std::endl ;
+    for (auto& object : node->object )
+    {
+        if(m_selectedApiLevel != m_currentApiLevel && m_changesets.find(m_selectedApiLevel) != m_changesets.end())
+        {
+            for(auto& hook : m_changesets[m_selectedApiLevel])
+            {
+                hook(object.get());
+            }
+        }
+
+    }
 }
+
+void SceneCheckAPIChange::installChangeSets()
+{
+    addHookInChangeSet("17.06", [](Base* o){
+        if(o->getClassName() == "RestShapeSpringsForceField" && o->findData("external_rest_shape")->isSet())
+            msg_warning(o) << "RestShapeSpringsForceField have changed since 17.06. The parameter 'external_rest_shape' is now a Link. To fix your scene you need to add and '@' in front of the provided path. See PR#315" ;
+    }) ;
+
+    addHookInChangeSet("17.06", [](Base* o){
+        if(o->getClassName() == "BoxStiffSpringForceField" )
+            msg_warning(o) << "BoxStiffSpringForceField have changed since 17.06. To use the old behavior you need to set parameter 'forceOldBehavior=true'" ;
+    }) ;
+
+    addHookInChangeSet("17.06", [](Base* o){
+        if(o->getClassName() == "TheComponentWeWantToRemove" )
+            msg_warning(o) << "TheComponentWewantToRemove is deprecated since sofa 17.06. It have been replaced by TheSuperComponent. #See PR318" ;
+    }) ;
+}
+
+void SceneCheckAPIChange::addHookInChangeSet(const std::string& version, ChangeSetHookFunction fct)
+{
+    m_changesets[version].push_back(fct) ;
+}
+
 
 } // _scenechecks_
 

--- a/modules/SofaGraphComponent/SceneChecks.h
+++ b/modules/SofaGraphComponent/SceneChecks.h
@@ -40,7 +40,7 @@ namespace simulation
 namespace _scenechecks_
 {
 
-class SceneCheck
+class SOFA_GRAPH_COMPONENT_API SceneCheck
 {
 public:
     typedef std::shared_ptr<SceneCheck> SPtr ;
@@ -50,7 +50,7 @@ public:
     virtual void doCheckOn(Node* node) = 0 ;
 };
 
-class SceneCheckDuplicatedName : public SceneCheck
+class SOFA_GRAPH_COMPONENT_API SceneCheckDuplicatedName : public SceneCheck
 {
 public:
     typedef std::shared_ptr<SceneCheckDuplicatedName> SPtr ;
@@ -60,7 +60,7 @@ public:
     virtual void doCheckOn(Node* node) override ;
 };
 
-class SceneCheckMissingRequiredPlugin : public SceneCheck
+class SOFA_GRAPH_COMPONENT_API SceneCheckMissingRequiredPlugin : public SceneCheck
 {
 public:
     typedef std::shared_ptr<SceneCheckMissingRequiredPlugin > SPtr ;
@@ -75,7 +75,7 @@ private:
 };
 
 typedef std::function<void(sofa::core::objectmodel::Base*)> ChangeSetHookFunction ;
-class SceneCheckAPIChange : public SceneCheck
+class SOFA_GRAPH_COMPONENT_API SceneCheckAPIChange : public SceneCheck
 {
 public:
     typedef std::shared_ptr<SceneCheckAPIChange> SPtr ;

--- a/modules/SofaGraphComponent/SceneChecks.h
+++ b/modules/SofaGraphComponent/SceneChecks.h
@@ -85,7 +85,7 @@ public:
     virtual void doInit(Node* node) override ;
     virtual void doCheckOn(Node* node) override ;
 
-    void installChangeSets() ;
+    void installDefaultChangeSets() ;
     void addHookInChangeSet(const std::string& version, ChangeSetHookFunction fct) ;
 private:
     std::string m_currentApiLevel;
@@ -100,6 +100,14 @@ using _scenechecks_::SceneCheck ;
 using _scenechecks_::SceneCheckDuplicatedName ;
 using _scenechecks_::SceneCheckMissingRequiredPlugin ;
 using _scenechecks_::SceneCheckAPIChange ;
+
+namespace scenecheckers
+{
+    using _scenechecks_::SceneCheck ;
+    using _scenechecks_::SceneCheckDuplicatedName ;
+    using _scenechecks_::SceneCheckMissingRequiredPlugin ;
+    using _scenechecks_::SceneCheckAPIChange ;
+} /// checkers
 
 } /// namespace simulation
 

--- a/modules/SofaGraphComponent/SceneChecks.h
+++ b/modules/SofaGraphComponent/SceneChecks.h
@@ -23,7 +23,7 @@
 #define SOFA_SIMULATION_SCENECHECKS_H
 
 #include "config.h"
-
+#include <map>
 /////////////////////////////// FORWARD DECLARATION ////////////////////////////////////////////////
 namespace sofa {
     namespace simulation {
@@ -45,6 +45,7 @@ class SceneCheck
 public:
     virtual const std::string getName() = 0 ;
     virtual const std::string getDesc() = 0 ;
+    virtual void doInit(Node* node) {}
     virtual void doCheckOn(Node* node) = 0 ;
 };
 
@@ -61,15 +62,29 @@ class SceneCheckMissingRequiredPlugin : public SceneCheck
 public:
     virtual const std::string getName() override ;
     virtual const std::string getDesc() override ;
+    virtual void doInit(Node* node) override ;
     virtual void doCheckOn(Node* node) override ;
+
+private:
+    std::map<std::string,bool> m_requiredPlugins ;
 };
 
+typedef std::function<void(sofa::core::objectmodel::Base*)> ChangeSetHookFunction ;
 class SceneCheckAPIChange : public SceneCheck
 {
 public:
     virtual const std::string getName() override ;
     virtual const std::string getDesc() override ;
+    virtual void doInit(Node* node) override ;
     virtual void doCheckOn(Node* node) override ;
+
+    void installChangeSets() ;
+    void addHookInChangeSet(const std::string& version, ChangeSetHookFunction fct) ;
+private:
+    std::string m_currentApiLevel;
+    std::string m_selectedApiLevel {"17.06"} ;
+
+    std::map<std::string, std::vector<ChangeSetHookFunction>> m_changesets ;
 };
 
 } /// _scenechecks_

--- a/modules/SofaGraphComponent/SceneChecks.h
+++ b/modules/SofaGraphComponent/SceneChecks.h
@@ -19,20 +19,15 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_SIMULATION_SCENECHECKERVISTOR_H
-#define SOFA_SIMULATION_SCENECHECKERVISTOR_H
+#ifndef SOFA_SIMULATION_SCENECHECKS_H
+#define SOFA_SIMULATION_SCENECHECKS_H
 
 #include "config.h"
-
-#include <functional>
-#include <map>
-
-#include <sofa/simulation/Visitor.h>
 
 /////////////////////////////// FORWARD DECLARATION ////////////////////////////////////////////////
 namespace sofa {
     namespace simulation {
-        class SceneCheck ;
+        class Node ;
     }
 }
 
@@ -42,41 +37,50 @@ namespace sofa
 {
 namespace simulation
 {
+namespace _scenechecks_
+{
 
-typedef std::function<void(sofa::core::objectmodel::Base*)> ChangeSetHookFunction ;
-
-class SOFA_GRAPH_COMPONENT_API SceneCheckerVisitor : public Visitor
+class SceneCheck
 {
 public:
-    SceneCheckerVisitor(const sofa::core::ExecParams* params) ;
-    virtual ~SceneCheckerVisitor() ;
-
-    void validate(Node* node) ;
-
-    void enableValidationAPIVersion(Node *node) ;
-    void enableValidationRequiredPlugins(Node* node) ;
-
-    virtual Result processNodeTopDown(Node* node) override ;
-
-    void installChangeSets() ;
-    void addHookInChangeSet(const std::string& version, ChangeSetHookFunction fct) ;
-
-    void addCheck(SceneCheck* check) ;
-    void removeCheck(SceneCheck* check) ;
-private:
-    std::map<std::string,bool> m_requiredPlugins ;
-    bool m_isRequiredPluginValidationEnabled {true} ;
-    bool m_isAPIVersionValidationEnabled {true} ;
-    std::string m_currentApiLevel;
-    std::string m_selectedApiLevel {"17.06"} ;
-
-    std::map<std::string, std::vector<ChangeSetHookFunction>> m_changesets ;
-
-    std::vector<SceneCheck*> m_checkset ;
+    virtual const std::string getName() = 0 ;
+    virtual const std::string getDesc() = 0 ;
+    virtual void doCheckOn(Node* node) = 0 ;
 };
 
-} // namespace simulation
+class SceneCheckDuplicatedName : public SceneCheck
+{
+public:
+    virtual const std::string getName() override ;
+    virtual const std::string getDesc() override ;
+    virtual void doCheckOn(Node* node) override ;
+};
 
-} // namespace sofa
+class SceneCheckMissingRequiredPlugin : public SceneCheck
+{
+public:
+    virtual const std::string getName() override ;
+    virtual const std::string getDesc() override ;
+    virtual void doCheckOn(Node* node) override ;
+};
 
-#endif
+class SceneCheckAPIChange : public SceneCheck
+{
+public:
+    virtual const std::string getName() override ;
+    virtual const std::string getDesc() override ;
+    virtual void doCheckOn(Node* node) override ;
+};
+
+} /// _scenechecks_
+
+using _scenechecks_::SceneCheck ;
+using _scenechecks_::SceneCheckDuplicatedName ;
+using _scenechecks_::SceneCheckMissingRequiredPlugin ;
+using _scenechecks_::SceneCheckAPIChange ;
+
+} /// namespace simulation
+
+} /// namespace sofa
+
+#endif /// SOFA_SIMULATION_SCENECHECKS_H

--- a/modules/SofaGraphComponent/SceneChecks.h
+++ b/modules/SofaGraphComponent/SceneChecks.h
@@ -43,15 +43,18 @@ namespace _scenechecks_
 class SceneCheck
 {
 public:
+    typedef std::shared_ptr<SceneCheck> SPtr ;
     virtual const std::string getName() = 0 ;
     virtual const std::string getDesc() = 0 ;
-    virtual void doInit(Node* node) {}
+    virtual void doInit(Node* node) { SOFA_UNUSED(node); }
     virtual void doCheckOn(Node* node) = 0 ;
 };
 
 class SceneCheckDuplicatedName : public SceneCheck
 {
 public:
+    typedef std::shared_ptr<SceneCheckDuplicatedName> SPtr ;
+    static SPtr newSPtr() { return SPtr(new SceneCheckDuplicatedName()); }
     virtual const std::string getName() override ;
     virtual const std::string getDesc() override ;
     virtual void doCheckOn(Node* node) override ;
@@ -60,6 +63,8 @@ public:
 class SceneCheckMissingRequiredPlugin : public SceneCheck
 {
 public:
+    typedef std::shared_ptr<SceneCheckMissingRequiredPlugin > SPtr ;
+    static SPtr newSPtr() { return SPtr(new SceneCheckMissingRequiredPlugin()); }
     virtual const std::string getName() override ;
     virtual const std::string getDesc() override ;
     virtual void doInit(Node* node) override ;
@@ -73,6 +78,8 @@ typedef std::function<void(sofa::core::objectmodel::Base*)> ChangeSetHookFunctio
 class SceneCheckAPIChange : public SceneCheck
 {
 public:
+    typedef std::shared_ptr<SceneCheckAPIChange> SPtr ;
+    static SPtr newSPtr() { return SPtr(new SceneCheckAPIChange()); }
     virtual const std::string getName() override ;
     virtual const std::string getDesc() override ;
     virtual void doInit(Node* node) override ;

--- a/modules/SofaGraphComponent/SofaGraphComponent_test/SceneChecker_test.cpp
+++ b/modules/SofaGraphComponent/SofaGraphComponent_test/SceneChecker_test.cpp
@@ -5,7 +5,7 @@ using sofa::Sofa_test;
 using sofa::simulation::SceneCheckerVisitor ;
 
 #include <SofaGraphComponent/SceneChecks.h>
-using sofa::simulation::SceneCheckAPIChange ;
+using namespace sofa::simulation::scenecheckers ;
 
 #include <sofa/helper/system/PluginManager.h>
 using sofa::helper::system::PluginManager ;
@@ -63,16 +63,69 @@ struct SceneChecker_test : public Sofa_test<>
         ASSERT_NE(root.get(), nullptr) ;
         root->init(ExecParams::defaultInstance()) ;
 
+        SceneCheckerVisitor checker(ExecParams::defaultInstance());
+        checker.addCheck( SceneCheckMissingRequiredPlugin::newSPtr() );
+
         if(missing)
         {
             EXPECT_MSG_EMIT(Warning);
-            SceneCheckerVisitor checker(ExecParams::defaultInstance());
             checker.validate(root.get()) ;
         }else{
             EXPECT_MSG_NOEMIT(Warning);
-            SceneCheckerVisitor checker(ExecParams::defaultInstance());
             checker.validate(root.get()) ;
         }
+    }
+
+    void checkDuplicatedNames()
+    {
+        EXPECT_MSG_EMIT(Error) ;
+        EXPECT_MSG_NOEMIT(Warning);
+
+        std::stringstream scene ;
+        scene << "<?xml version='1.0'?>"
+              << "<Node name='Root' gravity='0 -9.81 0' time='0' animate='0' >                   \n"
+              << "    <Node name='nodeCheck'>                                                    \n"
+              << "      <Node name='nodeA' />                                                    \n"
+              << "      <Node name='nodeA' />                                                    \n"
+              << "    </Node>                                                                    \n"
+              << "    <Node name='objectCheck'>                                                  \n"
+              << "      <OglModel name='objectA' />                                              \n"
+              << "      <OglModel name='objectA' />                                              \n"
+              << "    </Node>                                                                    \n"
+              << "    <Node name='mixCheck'>                                                     \n"
+              << "      <Node name='mixA' />                                                     \n"
+              << "      <OglModel name='mixA' />                                                 \n"
+              << "    </Node>                                                                    \n"
+              << "    <Node name='nothingCheck'>                                                 \n"
+              << "      <Node name='nodeA' />                                                    \n"
+              << "      <OglModel name='objectA' />                                              \n"
+              << "    </Node>                                                                    \n"
+              << "</Node>                                                                        \n" ;
+
+        Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
+                                                          scene.str().c_str(),
+                                                          scene.str().size()) ;
+
+        ASSERT_NE(root.get(), nullptr) ;
+        root->init(ExecParams::defaultInstance()) ;
+
+        SceneCheckerVisitor checker(ExecParams::defaultInstance());
+        checker.addCheck( SceneCheckDuplicatedName::newSPtr() );
+
+        std::vector<std::string> nodenames = {"nodeCheck", "objectCheck", "mixCheck"} ;
+        for( auto& nodename : nodenames )
+        {
+            EXPECT_MSG_EMIT(Warning);
+            ASSERT_NE(root->getChild(nodename), nullptr) ;
+            checker.validate(root->getChild(nodename)) ;
+        }
+
+        {
+            EXPECT_MSG_NOEMIT(Warning);
+            ASSERT_NE(root->getChild("nothingCheck"), nullptr) ;
+            checker.validate(root->getChild("nothingCheck")) ;
+        }
+
     }
 
     void checkAPIVersion(bool shouldWarn)
@@ -85,7 +138,7 @@ struct SceneChecker_test : public Sofa_test<>
         std::stringstream scene ;
         scene << "<?xml version='1.0'?>"
               << "<Node name='Root' gravity='0 -9.81 0' time='0' animate='0' >                   \n"
-              << "      <APIVersion level='"<< lvl <<"'/>                                              \n"
+              << "      <APIVersion level='"<< lvl <<"'/>                                        \n"
               << "      <ComponentDeprecated />                                                  \n"
               << "</Node>                                                                        \n" ;
 
@@ -97,29 +150,20 @@ struct SceneChecker_test : public Sofa_test<>
         root->init(ExecParams::defaultInstance()) ;
 
         SceneCheckerVisitor checker(ExecParams::defaultInstance());
+        SceneCheckAPIChange::SPtr apichange = SceneCheckAPIChange::newSPtr() ;
+        apichange->installDefaultChangeSets() ;
+        apichange->addHookInChangeSet("17.06", [](Base* o){
+            if(o->getClassName() == "ComponentDeprecated")
+                msg_warning(o) << "ComponentDeprecated have changed since 17.06." ;
+        }) ;
+        checker.addCheck(apichange) ;
 
         if(shouldWarn){
             /// We check that running a scene set to 17.12 generate a warning on a 17.06 component
             EXPECT_MSG_EMIT(Warning) ;
-            SceneCheckAPIChange::SPtr apichange = SceneCheckAPIChange::newSPtr() ;
-
-            apichange->addHookInChangeSet("17.06", [](Base* o){
-                if(o->getClassName() == "ComponentDeprecated")
-                    msg_warning(o) << "ComponentDeprecated have changed since 17.06." ;
-            }) ;
-            checker.addCheck(apichange) ;
             checker.validate(root.get()) ;
         }
         else {
-            SceneCheckAPIChange::SPtr apichange = SceneCheckAPIChange::newSPtr() ;
-
-            /// We check that running a scene set to 17.12 generate a warning on a 17.06 component
-            apichange->addHookInChangeSet("17.06", [](Base* o){
-                if(o->getClassName() == "ComponentDeprecated")
-                    msg_warning(o) << "RestShapeSpringsForceField have changed since 17.06." ;
-            }) ;
-
-            checker.addCheck(apichange) ;
             checker.validate(root.get()) ;
         }
     }
@@ -148,4 +192,9 @@ TEST_F(SceneChecker_test, checkAPIVersionCurrent )
 TEST_F(SceneChecker_test, checkAPIVersionDeprecated )
 {
     checkAPIVersion(true) ;
+}
+
+TEST_F(SceneChecker_test, checkDuplicatedNames )
+{
+    checkDuplicatedNames() ;
 }

--- a/modules/SofaGraphComponent/SofaGraphComponent_test/SceneChecker_test.cpp
+++ b/modules/SofaGraphComponent/SofaGraphComponent_test/SceneChecker_test.cpp
@@ -4,6 +4,9 @@ using sofa::Sofa_test;
 #include <SofaGraphComponent/SceneCheckerVisitor.h>
 using sofa::simulation::SceneCheckerVisitor ;
 
+#include <SofaGraphComponent/SceneChecks.h>
+using sofa::simulation::SceneCheckAPIChange ;
+
 #include <sofa/helper/system/PluginManager.h>
 using sofa::helper::system::PluginManager ;
 
@@ -94,21 +97,29 @@ struct SceneChecker_test : public Sofa_test<>
         root->init(ExecParams::defaultInstance()) ;
 
         SceneCheckerVisitor checker(ExecParams::defaultInstance());
+
         if(shouldWarn){
             /// We check that running a scene set to 17.12 generate a warning on a 17.06 component
             EXPECT_MSG_EMIT(Warning) ;
-            checker.addHookInChangeSet("17.06", [](Base* o){
+            SceneCheckAPIChange::SPtr apichange = SceneCheckAPIChange::newSPtr() ;
+
+            apichange->addHookInChangeSet("17.06", [](Base* o){
                 if(o->getClassName() == "ComponentDeprecated")
                     msg_warning(o) << "ComponentDeprecated have changed since 17.06." ;
             }) ;
+            checker.addCheck(apichange) ;
             checker.validate(root.get()) ;
         }
         else {
+            SceneCheckAPIChange::SPtr apichange = SceneCheckAPIChange::newSPtr() ;
+
             /// We check that running a scene set to 17.12 generate a warning on a 17.06 component
-            checker.addHookInChangeSet("17.06", [](Base* o){
+            apichange->addHookInChangeSet("17.06", [](Base* o){
                 if(o->getClassName() == "ComponentDeprecated")
                     msg_warning(o) << "RestShapeSpringsForceField have changed since 17.06." ;
             }) ;
+
+            checker.addCheck(apichange) ;
             checker.validate(root.get()) ;
         }
     }


### PR DESCRIPTION
Hi all,

This PR is implementing what was discussed in in #362 

CHANGELOG:
- refactor the SceneChecker object for more modularity. Adding new checks should be easier. 
- add a SceneCheckDuplicateName that warns user if the scene contains duplicated names. 
- add the corresponding tests. 
- use the new version in runSofa. 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
