### PR TITLE
[all] Clean BaseLoader & Remove un-needed #includes 

### DIFF
--- a/SofaKernel/framework/framework_test/helper/io/MeshOBJ_test.cpp
+++ b/SofaKernel/framework/framework_test/helper/io/MeshOBJ_test.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/helper/io/MeshOBJ.h>
+#include <sofa/helper/system/FileRepository.h>
 
 #include <gtest/gtest.h>
 

--- a/SofaKernel/framework/framework_test/helper/io/MeshSTL_test.cpp
+++ b/SofaKernel/framework/framework_test/helper/io/MeshSTL_test.cpp
@@ -19,6 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/io/MeshSTL.h>
 
 #include <gtest/gtest.h>

--- a/SofaKernel/framework/sofa/core/CMakeLists.txt
+++ b/SofaKernel/framework/sofa/core/CMakeLists.txt
@@ -192,6 +192,7 @@ set(SOURCE_FILES
     collision/Intersection.cpp
     collision/Pipeline.cpp
     init.cpp
+    loader/BaseLoader.cpp
     loader/MeshLoader.cpp
     loader/SceneLoader.cpp
     loader/VoxelLoader.cpp

--- a/SofaKernel/framework/sofa/core/loader/BaseLoader.cpp
+++ b/SofaKernel/framework/sofa/core/loader/BaseLoader.cpp
@@ -1,0 +1,134 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <fstream>
+
+#include "BaseLoader.h"
+#include <sofa/helper/system/FileRepository.h>
+
+namespace sofa
+{
+
+namespace core
+{
+
+namespace loader
+{
+
+bool SOFA_CORE_API canLoad(const char* filename);
+
+BaseLoader::BaseLoader(): m_filename(initData(&m_filename,"filename","Filename of the object"))
+{
+}
+
+BaseLoader::~BaseLoader()
+{
+}
+
+void BaseLoader::parse(sofa::core::objectmodel::BaseObjectDescription *arg)
+{
+    objectmodel::BaseObject::parse(arg);
+    if (canLoad())
+        load();
+    else
+        sout << "Doing nothing" << sendl;
+}
+
+
+bool BaseLoader::canLoad()
+{
+    std::string cmd;
+
+    // -- Check filename field:
+    if(m_filename.getValue() == "")
+    {
+        serr << "Error: MeshLoader: No file name given." << sendl;
+        return false;
+    }
+
+
+    // -- Check if file exist:
+    const char* filename = m_filename.getFullPath().c_str();
+    std::string sfilename (filename);
+
+    if (!sofa::helper::system::DataRepository.findFile(sfilename))
+    {
+        serr << "Error: MeshLoader: File '" << m_filename << "' not found. " << sendl;
+        return false;
+    }
+
+    std::ifstream file(filename);
+
+    // -- Check if file is readable:
+    if (!file.good())
+    {
+        serr << "Error: MeshLoader: Cannot read file '" << m_filename << "'." << sendl;
+        return false;
+    }
+
+    // -- Check first line:
+    file >> cmd;
+    if (cmd.empty())
+    {
+        serr << "Error: MeshLoader: Cannot read first line in file '" << m_filename << "'." << sendl;
+        file.close();
+        return false;
+    }
+
+    file.close();
+    return true;
+}
+
+
+void BaseLoader::setFilename(std::string f)
+{
+    m_filename.setValue(f);
+}
+
+const std::string& BaseLoader::getFilename()
+{
+    return m_filename.getValue();
+}
+
+
+void BaseLoader::skipToEOL(FILE* f)
+{
+    int ch;
+    while ((ch = fgetc(f)) != EOF && ch != '\n') ;
+}
+
+
+bool BaseLoader::readLine(char* buf, int size, FILE* f)
+{
+    buf[0] = '\0';
+    if (fgets(buf, size, f) == NULL)
+        return false;
+    if ((int)strlen(buf)==size-1 && buf[size-1] != '\n')
+        skipToEOL(f);
+    return true;
+}
+
+} /// namespace loader
+
+} /// namespace core
+
+} /// namespace sofa
+

--- a/SofaKernel/framework/sofa/core/loader/BaseLoader.h
+++ b/SofaKernel/framework/sofa/core/loader/BaseLoader.h
@@ -24,11 +24,6 @@
 
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/core/objectmodel/DataFileName.h>
-#include <sofa/core/objectmodel/BaseObjectDescription.h>
-
-#include <string>
-#include <cstring>
-#include <fstream>
 
 namespace sofa
 {
@@ -41,114 +36,34 @@ namespace loader
 
 bool SOFA_CORE_API canLoad(const char* filename);
 
-class BaseLoader : public virtual objectmodel::BaseObject
+class BaseLoader : public objectmodel::BaseObject
 {
 public:
     SOFA_ABSTRACT_CLASS(BaseLoader, objectmodel::BaseObject);
     SOFA_BASE_CAST_IMPLEMENTATION(BaseLoader)
-protected:
-    ///Constructor
-    BaseLoader(): m_filename(initData(&m_filename,"filename","Filename of the object")) {}
-
-    ///Destructor
-    virtual ~BaseLoader() { }
-public:
 
     virtual bool load() = 0;
+    virtual bool canLoad() ;
 
-    virtual void parse(sofa::core::objectmodel::BaseObjectDescription *arg)
-    {
-        objectmodel::BaseObject::parse(arg);
-        if (canLoad())
-            load();
-        else
-            sout << "Doing nothing" << sendl;
-    }
+    virtual void parse(objectmodel::BaseObjectDescription *arg) override ;
 
+    void setFilename(std::string f)  ;
+    const std::string &getFilename() ;
 
-    virtual bool canLoad()
-    {
-        std::string cmd;
+    objectmodel::DataFileName m_filename;
 
-        // -- Check filename field:
-        if(m_filename.getValue() == "")
-        {
-            serr << "Error: MeshLoader: No file name given." << sendl;
-            return false;
-        }
+protected:
+    BaseLoader() ;
+    virtual ~BaseLoader() ;
 
-
-        // -- Check if file exist:
-        const char* filename = m_filename.getFullPath().c_str();
-        std::string sfilename (filename);
-
-        if (!sofa::helper::system::DataRepository.findFile(sfilename))
-        {
-            serr << "Error: MeshLoader: File '" << m_filename << "' not found. " << sendl;
-            return false;
-        }
-
-        std::ifstream file(filename);
-
-        // -- Check if file is readable:
-        if (!file.good())
-        {
-            serr << "Error: MeshLoader: Cannot read file '" << m_filename << "'." << sendl;
-            return false;
-        }
-
-        // -- Check first line:
-        file >> cmd;
-        if (cmd.empty())
-        {
-            serr << "Error: MeshLoader: Cannot read first line in file '" << m_filename << "'." << sendl;
-            file.close();
-            return false;
-        }
-
-        file.close();
-        return true;
-    }
-
-
-    void setFilename(std::string f)
-    {
-        m_filename.setValue(f);
-    }
-
-    const std::string &getFilename()
-    {
-        return m_filename.getValue();
-    }
-
-
-    static void skipToEOL(FILE* f)
-    {
-        int ch;
-        while ((ch = fgetc(f)) != EOF && ch != '\n') ;
-    }
-
-
-    static bool readLine(char* buf, int size, FILE* f)
-    {
-        buf[0] = '\0';
-        if (fgets(buf, size, f) == NULL)
-            return false;
-        if ((int)strlen(buf)==size-1 && buf[size-1] != '\n')
-            skipToEOL(f);
-        return true;
-    }
-
-    sofa::core::objectmodel::DataFileName m_filename;
-
+    static void skipToEOL(FILE* f) ;
+    static bool readLine(char* buf, int size, FILE* f) ;
 };
 
+} /// namespace loader
 
+} /// namespace core
 
-} // namespace loader
+} /// namespace sofa
 
-} // namespace core
-
-} // namespace sofa
-
-#endif
+#endif /// SOFA_CORE_LOADER_BASELOADER_H

--- a/SofaKernel/framework/sofa/core/loader/BaseLoader.h
+++ b/SofaKernel/framework/sofa/core/loader/BaseLoader.h
@@ -36,7 +36,7 @@ namespace loader
 
 bool SOFA_CORE_API canLoad(const char* filename);
 
-class BaseLoader : public objectmodel::BaseObject
+class SOFA_CORE_API BaseLoader : public objectmodel::BaseObject
 {
 public:
     SOFA_ABSTRACT_CLASS(BaseLoader, objectmodel::BaseObject);

--- a/SofaKernel/framework/sofa/core/objectmodel/DataFileName.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/DataFileName.cpp
@@ -19,6 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <sofa/helper/system/FileRepository.h>
 #include <sofa/core/objectmodel/DataFileName.h>
 #include <sofa/core/objectmodel/Base.h>
 

--- a/SofaKernel/framework/sofa/core/objectmodel/DataFileName.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/DataFileName.h
@@ -27,7 +27,6 @@
 #endif
 
 #include <sofa/core/objectmodel/Data.h>
-#include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/SVector.h>
 
 namespace sofa

--- a/SofaKernel/framework/sofa/helper/types/Material.h
+++ b/SofaKernel/framework/sofa/helper/types/Material.h
@@ -26,7 +26,6 @@
 #include <sofa/core/core.h>
 #include <sofa/defaulttype/RGBAColor.h>
 #include <sofa/core/objectmodel/DataFileName.h>
-#include <sofa/helper/system/FileRepository.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetGeometryAlgorithms.inl
@@ -22,6 +22,7 @@
 #ifndef SOFA_COMPONENT_TOPOLOGY_EDGESETGEOMETRYALGORITHMS_INL
 #define SOFA_COMPONENT_TOPOLOGY_EDGESETGEOMETRYALGORITHMS_INL
 
+#include <fstream>
 #include <SofaBaseTopology/EdgeSetGeometryAlgorithms.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/MatEigen.h>

--- a/SofaKernel/modules/SofaDeformable/SpringForceField.inl
+++ b/SofaKernel/modules/SofaDeformable/SpringForceField.inl
@@ -35,6 +35,7 @@
 #include <sofa/helper/system/config.h>
 #include <cassert>
 #include <iostream>
+#include <fstream>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaLoader/SofaLoader_test/MeshObjLoader_test.cpp
+++ b/SofaKernel/modules/SofaLoader/SofaLoader_test/MeshObjLoader_test.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
+#include <sofa/helper/system/FileRepository.h>
 #include <SofaTest/Sofa_test.h>
 
 #include <SofaLoader/MeshObjLoader.h>

--- a/SofaKernel/modules/SofaSimulationCommon/SceneLoaderPHP.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/SceneLoaderPHP.cpp
@@ -24,6 +24,7 @@
 #include <SofaSimulationCommon/SceneLoaderXML.h>
 #include <sofa/helper/system/PipeProcess.h>
 #include <SofaSimulationCommon/xml/NodeElement.h>
+#include <sofa/helper/system/FileRepository.h>
 
 namespace sofa
 {

--- a/applications/plugins/Compliant/numericalsolver/AnalysisSolver.cpp
+++ b/applications/plugins/Compliant/numericalsolver/AnalysisSolver.cpp
@@ -1,5 +1,5 @@
 #include "AnalysisSolver.h"
-
+#include <fstream>
 #include <sofa/core/ObjectFactory.h>
 
 #include <Eigen/SVD>
@@ -16,29 +16,29 @@ AnalysisSolver::AnalysisSolver()
     : condest(initData(&condest, false, "condest", "compute condition number with svd"))
     , eigenvaluesign(initData(&eigenvaluesign, false, "eigenvaluesign", "computing the sign of the eigenvalues (of the implicit matrix H)"))
     , dump_qp(initData(&dump_qp, "dump_qp", "dump qp to file if non-empty"))
-      
+
 {}
 
 void AnalysisSolver::init() {
 
-	solvers.clear();
-	this->getContext()->get<KKTSolver>( &solvers, core::objectmodel::BaseContext::Local );
-	
-	if( solvers.size() < 2 ) {
-		std::cerr << "warning: no other kkt solvers found" << std::endl;
-	} else {
-		std::cout << "AnalysisSolver: dynamics/correction will use " 
-				  << solvers.back()->getName() 
-				  << std::endl;
-	}
+    solvers.clear();
+    this->getContext()->get<KKTSolver>( &solvers, core::objectmodel::BaseContext::Local );
+
+    if( solvers.size() < 2 ) {
+        std::cerr << "warning: no other kkt solvers found" << std::endl;
+    } else {
+        std::cout << "AnalysisSolver: dynamics/correction will use "
+                  << solvers.back()->getName()
+                  << std::endl;
+    }
 }
 
 void AnalysisSolver::factor(const system_type& system) {
 
-	// start at 1 since 0 is current solver
+    // start at 1 since 0 is current solver
     for( unsigned i = 1, n = solvers.size() ; i < n; ++i ) {
-		solvers[i]->factor(system);
-	}
+        solvers[i]->factor(system);
+    }
 
 
 
@@ -105,7 +105,7 @@ void AnalysisSolver::factor(const system_type& system) {
 
     }
 
-    
+
     // TODO add more as needed
 }
 
@@ -115,7 +115,7 @@ static void write_qp(std::ofstream& out,
                      const AssembledSystem::vec& rhs) {
 
     const char endl = '\n';
-    
+
     out << sys.m << ' ' << sys.n << endl;
 
     out << sys.H << endl;
@@ -128,7 +128,7 @@ static void write_qp(std::ofstream& out,
 
         // TODO unilateral mask !
     }
-    
+
 }
 
 // solution is that of the first solver
@@ -136,37 +136,37 @@ void AnalysisSolver::correct(vec& res,
                              const system_type& sys,
                              const vec& rhs,
                              real damping) const {
-	assert( solvers.size() > 1 );
-	solvers.back()->correct(res, sys, rhs, damping);
+    assert( solvers.size() > 1 );
+    solvers.back()->correct(res, sys, rhs, damping);
 
     if(!dump_qp.getValue().empty() ) {
         const std::string filename = dump_qp.getValue() + ".correction";
         std::ofstream out(filename.c_str());
-        
+
         write_qp(out, sys, rhs);
     }
 }
 
 // solution is that of the last solver
 void AnalysisSolver::solve(vec& res,
-							const system_type& sys,
-							const vec& rhs) const {
+                            const system_type& sys,
+                            const vec& rhs) const {
 
     vec backup = res; // backup initial solution
 
-	// start at 1 since 0 is current solver
+    // start at 1 since 0 is current solver
     for( unsigned i = 1, n = solvers.size(); i < n; ++i ) {
-		res = backup;
-		solvers[i]->solve(res, sys, rhs);
-	}
+        res = backup;
+        solvers[i]->solve(res, sys, rhs);
+    }
 
     if(!dump_qp.getValue().empty() ) {
         const std::string filename = dump_qp.getValue() + ".correction";
         std::ofstream out(filename.c_str());
-        
+
         write_qp(out, sys, rhs);
     }
-	
+
 }
 
 

--- a/applications/plugins/OptiTrackNatNet/OptiTrackNatNetDevice.cpp
+++ b/applications/plugins/OptiTrackNatNet/OptiTrackNatNetDevice.cpp
@@ -31,6 +31,7 @@
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/helper/system/glut.h>
 #include <algorithm>
+#include <fstream>
 
 namespace SofaOptiTrackNatNet
 {

--- a/applications/plugins/SceneCreator/SceneCreator.cpp
+++ b/applications/plugins/SceneCreator/SceneCreator.cpp
@@ -84,6 +84,8 @@
 
 #include <SofaBaseLinearSolver/FullVector.h>
 
+#include <sofa/helper/system/FileRepository.h>
+
 namespace sofa
 {
 namespace modeling {

--- a/applications/plugins/SofaPython/PythonEnvironment.cpp
+++ b/applications/plugins/SofaPython/PythonEnvironment.cpp
@@ -19,6 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <fstream>
 #include "PythonMacros.h"
 #include "PythonEnvironment.h"
 #include "PythonScriptController.h"

--- a/applications/plugins/SofaPython/SceneLoaderPY.cpp
+++ b/applications/plugins/SofaPython/SceneLoaderPY.cpp
@@ -30,6 +30,7 @@
 #include <SofaSimulationCommon/FindByTypeVisitor.h>
 
 #include <sstream>
+#include <fstream>
 
 #include "PythonMainScriptController.h"
 #include "PythonEnvironment.h"

--- a/applications/plugins/SofaPython/SofaPython_test/PythonFactory_test.cpp
+++ b/applications/plugins/SofaPython/SofaPython_test/PythonFactory_test.cpp
@@ -1,3 +1,5 @@
+#include <fstream>
+
 #include <SofaTest/Sofa_test.h>
 
 #include <SofaPython/PythonFactory.h>

--- a/applications/plugins/SofaPython/SofaPython_test/PythonScriptController_test.cpp
+++ b/applications/plugins/SofaPython/SofaPython_test/PythonScriptController_test.cpp
@@ -1,5 +1,6 @@
 #include <regex>
 #include <vector>
+#include <fstream>
 
 #include <SofaTest/Sofa_test.h>
 using sofa::Sofa_test;

--- a/applications/plugins/SofaTest/Python_test.cpp
+++ b/applications/plugins/SofaTest/Python_test.cpp
@@ -1,4 +1,5 @@
 #include <SofaPython/PythonScriptEvent.h>
+#include <fstream>
 
 #include "Python_test.h"
 

--- a/applications/plugins/image/ImageContainer.h
+++ b/applications/plugins/image/ImageContainer.h
@@ -36,6 +36,7 @@
 #include <sofa/defaulttype/Mat.h>
 #include <sofa/defaulttype/Quat.h>
 #include <sofa/helper/rmath.h>
+#include <sofa/helper/system/FileRepository.h>
 
 #ifdef SOFA_HAVE_ZLIB
 #include <zlib.h>

--- a/applications/plugins/image/imagetoolbox/labelbox/labelboximagetoolbox.h
+++ b/applications/plugins/image/imagetoolbox/labelbox/labelboximagetoolbox.h
@@ -6,10 +6,10 @@
 #include <sofa/core/DataEngine.h>
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/core/objectmodel/DataFileName.h>
+#include <sofa/helper/system/FileRepository.h>
 
 #include "labelboximagetoolboxaction.h"
 #include "../labelimagetoolbox.h"
-
 
 
 #include <image/image_gui/config.h>

--- a/applications/plugins/image/imagetoolbox/labelpointsbysection/labelpointsbysectionimagetoolbox.h
+++ b/applications/plugins/image/imagetoolbox/labelpointsbysection/labelpointsbysectionimagetoolbox.h
@@ -12,7 +12,7 @@
 #include <sofa/core/objectmodel/DataFileName.h>
 
 #include "labelpointsbysectionimagetoolboxaction.h"
-
+#include <sofa/helper/system/FileRepository.h>
 
 #include <string>
 #include <cstring>

--- a/applications/projects/Modeler/lib/GraphModeler.cpp
+++ b/applications/projects/Modeler/lib/GraphModeler.cpp
@@ -19,6 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <fstream>
 #include "GraphModeler.h"
 #include "AddPreset.h"
 

--- a/applications/projects/Modeler/lib/SofaModeler.cpp
+++ b/applications/projects/Modeler/lib/SofaModeler.cpp
@@ -19,6 +19,8 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <fstream>
+
 #include "SofaModeler.h"
 
 #include <sofa/helper/system/FileRepository.h>

--- a/applications/sofa/gui/GUIManager.cpp
+++ b/applications/sofa/gui/GUIManager.cpp
@@ -19,6 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <fstream>
 
 #include "GUIManager.h"
 #include "BaseGUI.h"
@@ -31,7 +32,7 @@
 #include <sofa/helper/system/FileSystem.h>
 #include <sofa/helper/Utils.h>
 #include <sofa/helper/logging/Messaging.h>
-
+#include <sofa/helper/system/FileRepository.h>
 
 using sofa::helper::system::FileSystem;
 using sofa::helper::Utils;

--- a/applications/sofa/gui/qt/QDisplayLinkWidget.h
+++ b/applications/sofa/gui/qt/QDisplayLinkWidget.h
@@ -30,7 +30,7 @@
 #include <QTextEdit>
 #include <QGroupBox>
 #include <QSlider>
-
+#include <sofa/helper/system/FileRepository.h>
 
 namespace sofa
 {
@@ -64,17 +64,17 @@ signals:
     void LinkOwnerDirty(bool);
 
 protected:
-	static QIcon& RefreshIcon()
-	{
-		static QIcon icon;
-		if(icon.isNull())
-		{
-			std::string filename = "textures/refresh.png";
-			sofa::helper::system::DataRepository.findFile(filename);
-			icon = QIcon(filename.c_str());
-		}
-		return icon;
-	}
+    static QIcon& RefreshIcon()
+    {
+        static QIcon icon;
+        if(icon.isNull())
+        {
+            std::string filename = "textures/refresh.png";
+            sofa::helper::system::DataRepository.findFile(filename);
+            icon = QIcon(filename.c_str());
+        }
+        return icon;
+    }
 
 protected:
     core::objectmodel::BaseLink* link_;

--- a/modules/SofaConstraint/PrecomputedConstraintCorrection.inl
+++ b/modules/SofaConstraint/PrecomputedConstraintCorrection.inl
@@ -38,14 +38,14 @@
 
 #include <sofa/core/behavior/RotationFinder.h>
 
+#include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/gl/Axis.h>
 #include <sofa/helper/Quater.h>
 
 #include <SofaConstraint/LMConstraintSolver.h>
 #include <sofa/simulation/Node.h>
 
-
-//#include <glib.h>
+#include <fstream>
 #include <sstream>
 #include <list>
 #include <iomanip>

--- a/modules/SofaGeneralEngine/ClusteringEngine.inl
+++ b/modules/SofaGeneralEngine/ClusteringEngine.inl
@@ -29,6 +29,7 @@
 #include <fstream>
 
 #include <sofa/helper/logging/Messaging.h>
+#include <sofa/helper/system/FileRepository.h>
 
 namespace sofa
 {

--- a/modules/SofaGeneralLoader/CMakeLists.txt
+++ b/modules/SofaGeneralLoader/CMakeLists.txt
@@ -42,7 +42,7 @@ set(SOURCE_FILES
 
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaSimulationTree SofaHelper)
+target_link_libraries(${PROJECT_NAME} PUBLIC SofaCore SofaSimulationTree SofaHelper)
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-DSOFA_BUILD_GENERAL_LOADER")
 set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${HEADER_FILES}")
 

--- a/modules/SofaGeneralLoader/GIDMeshLoader.cpp
+++ b/modules/SofaGeneralLoader/GIDMeshLoader.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #include <algorithm>
 #include <string>
+#include <fstream>
 
 #include <sofa/core/ObjectFactory.h>
 #include <SofaGeneralLoader/GIDMeshLoader.h>

--- a/modules/SofaGeneralLoader/MeshGmshLoader.cpp
+++ b/modules/SofaGeneralLoader/MeshGmshLoader.cpp
@@ -23,6 +23,7 @@
 #include <SofaGeneralLoader/MeshGmshLoader.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <iostream>
+#include <fstream>
 
 namespace sofa
 {
@@ -236,7 +237,7 @@ bool MeshGmshLoader::readGmsh(std::ifstream &file, const unsigned int gmshFormat
             case 3: // Quad
                 nnodes = 4;
                 break;
-            case 4: // Tetra                
+            case 4: // Tetra
                 nnodes = 4;
                 break;
             case 5: // Hexa
@@ -250,7 +251,7 @@ bool MeshGmshLoader::readGmsh(std::ifstream &file, const unsigned int gmshFormat
                 break;
             case 11: // Quadratic Tetrahedron
                 nnodes = 10;
-                break; 
+                break;
             default:
                 serr << "Error: MeshGmshLoader: Elements of type 1, 2, 3, 4, 5, or 6 expected. Element of type " << etype << " found." << sendl;
                 nnodes = 0;

--- a/modules/SofaGeneralLoader/MeshOffLoader.cpp
+++ b/modules/SofaGeneralLoader/MeshOffLoader.cpp
@@ -23,6 +23,7 @@
 #include <SofaGeneralLoader/MeshOffLoader.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/system/SetDirectory.h>
+#include <fstream>
 
 namespace sofa
 {

--- a/modules/SofaGeneralLoader/MeshSTLLoader.cpp
+++ b/modules/SofaGeneralLoader/MeshSTLLoader.cpp
@@ -24,7 +24,7 @@
 #include <sofa/core/visual/VisualParams.h>
 
 #include <iostream>
-//#include <fstream> // we can't use iostream because the windows implementation gets confused by the mix of text and binary
+#include <fstream>
 #include <cstdio>
 #include <sstream>
 #include <string>

--- a/modules/SofaGeneralLoader/MeshTrianLoader.cpp
+++ b/modules/SofaGeneralLoader/MeshTrianLoader.cpp
@@ -23,12 +23,8 @@
 #include <SofaGeneralLoader/MeshTrianLoader.h>
 #include <sofa/core/visual/VisualParams.h>
 
-//#include <sofa/helper/system/FileRepository.h>
-//#include <stdlib.h>
 #include <iostream>
-//#include <string>
-
-//#include <cstdio>
+#include <fstream>
 
 namespace sofa
 {
@@ -189,7 +185,7 @@ bool MeshTrianLoader::readTrian (const char* filename)
              {
         sout << " ((v1<v2) | (ngh0== -1)) " << sendl;
         e=new E(trian,vertexTable[v1],vertexTable[v2],
-        	t,0);
+            t,0);
         t->setEdge(0,e);
         // if we have a boundary edge store it in the vertex
         if (ngh0== -1)
@@ -203,7 +199,7 @@ bool MeshTrianLoader::readTrian (const char* filename)
              {
         sout << " ((v2<v0)| (ngh1== -1)) " << sendl;
         e=new E(trian,vertexTable[v2],vertexTable[v0],
-        	t,0);
+            t,0);
         t->setEdge(1,e);
         // if we have a boundary edge store it in the vertex
         if (ngh1== -1)

--- a/modules/SofaGeneralLoader/MeshXspLoader.cpp
+++ b/modules/SofaGeneralLoader/MeshXspLoader.cpp
@@ -23,6 +23,7 @@
 #include <SofaGeneralLoader/MeshXspLoader.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <iostream>
+#include <fstream>
 
 namespace sofa
 {

--- a/modules/SofaGeneralLoader/OffSequenceLoader.cpp
+++ b/modules/SofaGeneralLoader/OffSequenceLoader.cpp
@@ -26,7 +26,7 @@
 #include <sofa/simulation/AnimateBeginEvent.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sstream>
-
+#include <fstream>
 
 namespace sofa
 {

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
@@ -19,9 +19,12 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <algorithm>
+#include <sofa/version.h>
+
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/helper/system/PluginManager.h>
-#include <sofa/version.h>
+#include <sofa/helper/system/FileRepository.h>
 
 #include "SceneCheckerVisitor.h"
 #include "RequiredPlugin.h"

--- a/modules/SofaMiscEngine/Distances.inl
+++ b/modules/SofaMiscEngine/Distances.inl
@@ -31,10 +31,12 @@
 #include <SofaNonUniformFem/DynamicSparseGridGeometryAlgorithms.inl>
 #include <SofaBaseTopology/HexahedronSetGeometryAlgorithms.inl>
 #include <sofa/core/loader/VoxelLoader.h>
+#include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/gl/glText.inl>
 #include <algorithm>
 #include <functional>
 #include <queue>
+#include <fstream>
 namespace sofa
 {
 

--- a/modules/SofaOpenglVisual/OglModel.cpp
+++ b/modules/SofaOpenglVisual/OglModel.cpp
@@ -22,6 +22,7 @@
 #include <SofaOpenglVisual/OglModel.h>
 #include <SofaBaseTopology/TopologyData.inl>
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/system/gl.h>
 #include <sofa/helper/gl/RAII.h>
 #include <sofa/helper/vector.h>
@@ -29,6 +30,8 @@
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <string.h>
 #include <sofa/helper/types/RGBAColor.h>
+
+
 //#ifdef SOFA_HAVE_GLEW
 //#include <sofa/helper/gl/GLSLShader.h>
 //#endif // SOFA_HAVE_GLEW

--- a/modules/SofaPreconditioner/PrecomputedWarpPreconditioner.h
+++ b/modules/SofaPreconditioner/PrecomputedWarpPreconditioner.h
@@ -31,6 +31,7 @@
 #include <SofaBaseLinearSolver/FullMatrix.h>
 #include <sofa/helper/map.h>
 #include <math.h>
+#include <fstream>
 
 namespace sofa
 {

--- a/modules/SofaSparseSolver/PrecomputedLinearSolver.h
+++ b/modules/SofaSparseSolver/PrecomputedLinearSolver.h
@@ -31,6 +31,7 @@
 #include <sofa/helper/map.h>
 #include <math.h>
 #include <SofaBaseLinearSolver/CompressedRowSparseMatrix.h>
+#include <fstream>
 
 namespace sofa
 {

--- a/modules/SofaSparseSolver/SparseLDLSolver.inl
+++ b/modules/SofaSparseSolver/SparseLDLSolver.inl
@@ -33,6 +33,7 @@
 #include <math.h>
 #include <sofa/helper/system/thread/CTime.h>
 #include <SofaBaseLinearSolver/CompressedRowSparseMatrix.inl>
+#include <fstream>
 
 namespace sofa {
 

--- a/modules/SofaVolumetricData/InterpolatedImplicitSurface.cpp
+++ b/modules/SofaVolumetricData/InterpolatedImplicitSurface.cpp
@@ -22,6 +22,7 @@
 
 #include <SofaVolumetricData/InterpolatedImplicitSurface.inl>
 #include <sofa/core/ObjectFactory.h>
+#include <fstream>
 
 namespace sofa
 {


### PR DESCRIPTION
Hi all, 

BaseLoader was implemented in .h. 
This is bad so I splitted it into BaseLoader.cpp/h 
Then I removed the un-needed includes
Then I updated all the codebase that were missing specific includes.

In case your code does not compile... after this PR then you need to add the include you are missing 
(probably fstream or sofa::helper::system::FileRepository) 
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
