### PR TITLE
[SofaBoundaryCondition] make LinearMovementConstraint accept absolute movements

### DIFF
--- a/modules/SofaBoundaryCondition/LinearMovementConstraint.h
+++ b/modules/SofaBoundaryCondition/LinearMovementConstraint.h
@@ -86,8 +86,8 @@ public :
     /// the motions corresponding to the key frames
     Data<VecDeriv > m_keyMovements;
 
-    //indicates whether movements are relative to the dof or absolute 
-    Data< bool > relativeMovements;
+    /// indicates whether movements are relative to the dof or absolute
+    Data< bool > d_relativeMovements;
 
     /// attributes to precise display
     /// if showMovement is true we display the expected movement

--- a/modules/SofaBoundaryCondition/LinearMovementConstraint.h
+++ b/modules/SofaBoundaryCondition/LinearMovementConstraint.h
@@ -86,10 +86,14 @@ public :
     /// the motions corresponding to the key frames
     Data<VecDeriv > m_keyMovements;
 
+    //indicates whether movements are relative to the dof or absolute 
+    Data< bool > relativeMovements;
+
     /// attributes to precise display
     /// if showMovement is true we display the expected movement
     /// otherwise we show which are the fixed dofs
     Data< bool > showMovement;
+
 
     /// the key times surrounding the current simulation time (for interpolation)
     Real prevT, nextT;

--- a/modules/SofaBoundaryCondition/LinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/LinearMovementConstraint.inl
@@ -254,9 +254,19 @@ void LinearMovementConstraint<DataTypes>::interpolatePosition(Real cT, typename 
     Deriv m = prevM + (nextM-prevM)*dt;
 
     //set the motion to the Dofs
-    for (SetIndexArray::const_iterator it = indices.begin(); it != indices.end(); ++it)
+    if (d_relativeMovements.getValue())
     {
-        x[*it] = x0[*it] + m ;
+        for (SetIndexArray::const_iterator it = indices.begin(); it != indices.end(); ++it)
+        {
+            x[*it] = x0[*it] + m ;
+        }
+    }
+    else
+    {
+        for (SetIndexArray::const_iterator it = indices.begin(); it != indices.end(); ++it)
+        {
+            x[*it] = m ;
+        }
     }
 }
 

--- a/modules/SofaBoundaryCondition/LinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/LinearMovementConstraint.inl
@@ -66,7 +66,7 @@ LinearMovementConstraint<DataTypes>::LinearMovementConstraint()
     , m_indices( initData(&m_indices,"indices","Indices of the constrained points") )
     , m_keyTimes(  initData(&m_keyTimes,"keyTimes","key times for the movements") )
     , m_keyMovements(  initData(&m_keyMovements,"movements","movements corresponding to the key times") )
-    , relativeMovements( initData(&relativeMovements, (bool)true, "relativeMovements", "If true, movements are relative to first position, absolute otherwise") )
+    , d_relativeMovements( initData(&d_relativeMovements, (bool)true, "relativeMovements", "If true, movements are relative to first position, absolute otherwise") )
     , showMovement( initData(&showMovement, (bool)false, "showMovement", "Visualization of the movement to be applied to constrained dofs."))
 {
     // default to indice 0
@@ -249,24 +249,15 @@ template <class MyCoord>
 void LinearMovementConstraint<DataTypes>::interpolatePosition(Real cT, typename std::enable_if<!std::is_same<MyCoord, defaulttype::RigidCoord<3, Real> >::value, VecCoord>::type& x)
 {
     const SetIndexArray & indices = m_indices.getValue();
-//                cerr<<"LinearMovementConstraint<DataTypes>::interpolatePosition,  current time cT = "<<cT<<endl;
-//                cerr<<"LinearMovementConstraint<DataTypes>::interpolatePosition,  prevT = "<<prevT<<" ,prevM= "<<prevM<<endl;
-//                cerr<<"LinearMovementConstraint<DataTypes>::interpolatePosition,  nextT = "<<nextT<<" ,nextM= "<<nextM<<endl;
-    //cerr<<"LinearMovementConstraint<DataTypes>::interpolatePosition, current x = "<<x<<endl;
 
     Real dt = (cT - prevT) / (nextT - prevT);
-//                cerr<<"LinearMovementConstraint<DataTypes>::interpolatePosition, dt = "<<dt<<endl;
     Deriv m = prevM + (nextM-prevM)*dt;
-
-    //cerr<<"LinearMovementConstraint<DataTypes>::interpolatePosition, movement m = "<<m<<endl;
 
     //set the motion to the Dofs
     for (SetIndexArray::const_iterator it = indices.begin(); it != indices.end(); ++it)
     {
         x[*it] = x0[*it] + m ;
     }
-
-    //cerr<<"LinearMovementConstraint<DataTypes>::interpolatePosition, new x = "<<x<<endl<<endl<<endl;
 }
 
 template <class DataTypes>
@@ -281,7 +272,7 @@ void LinearMovementConstraint<DataTypes>::interpolatePosition(Real cT, typename 
     helper::Quater<Real> nextOrientation = helper::Quater<Real>::createQuaterFromEuler(getVOrientation(nextM));
 
     //set the motion to the Dofs
-    if (relativeMovements.getValue())
+    if (d_relativeMovements.getValue())
     {
         for (SetIndexArray::const_iterator it = indices.begin(); it != indices.end(); ++it)
         {
@@ -368,7 +359,6 @@ void LinearMovementConstraint<DataTypes>::projectMatrix( sofa::defaulttype::Base
 template <class DataTypes>
 void LinearMovementConstraint<DataTypes>::applyConstraint(defaulttype::BaseMatrix *mat, unsigned int offset)
 {
-    //sout << "applyConstraint in Matrix with offset = " << offset << sendl;
     const unsigned int N = Deriv::size();
     const SetIndexArray & indices = m_indices.getValue();
 
@@ -386,7 +376,6 @@ void LinearMovementConstraint<DataTypes>::applyConstraint(defaulttype::BaseMatri
 template <class DataTypes>
 void LinearMovementConstraint<DataTypes>::applyConstraint(defaulttype::BaseVector *vect, unsigned int offset)
 {
-    //sout << "applyConstraint in Vector with offset = " << offset << sendl;
     const unsigned int N = Deriv::size();
 
     const SetIndexArray & indices = m_indices.getValue();
@@ -411,7 +400,7 @@ void LinearMovementConstraint<DataTypes>::draw(const core::visual::VisualParams*
         glColor4f(1, 0.5, 0.5, 1);
         glBegin(GL_LINES);
         const SetIndexArray & indices = m_indices.getValue();
-        if (relativeMovements.getValue()) 
+        if (d_relativeMovements.getValue()) 
         {
             for (unsigned int i = 0; i < m_keyMovements.getValue().size() - 1; i++)
             {


### PR DESCRIPTION
This is small feature addition.

Currently, LinearMovementConstraint only takes trajectories relative to the rest position of the MechanicalState. Sometimes though, the trajectory is specified in world frame coordinates, and especially with Rigid3D (i.e. orientations), conversion is not trivial for the user  

This patch introduces a switch "relativeMovements" (default true).
When disabled, trajectories can be specified in world frame coordinates.


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
