### PR TITLE
[CMake][tests] installing gtest headers for separate plugin builds

### DIFF
--- a/extlibs/gtest/CMakeLists.txt
+++ b/extlibs/gtest/CMakeLists.txt
@@ -44,3 +44,7 @@ target_include_directories(gtest_main PUBLIC "$<INSTALL_INTERFACE:include>")
 
 include(${SOFA_KERNEL_SOURCE_DIR}/SofaFramework/SofaMacros.cmake)
 sofa_create_package(GTest 2.6.2 "gtest;gtest_main" "")
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/gtest
+        COMPONENT GTest_headers
+        DESTINATION include/)


### PR DESCRIPTION
Hi,

In order to reduce compile time of sofa plugins, I decided to compile my plugins outside of Sofa (a build folder for each plugin, CMAKE_PREFIX_PATH and CMAKE_INSTALL_PREFIX to tell cmake where to find sofa)
Compiling tests then doesn't work since the gtest headers, that are bundled in sofa, are not deployed on sofa's install dir.

This PR rectifies that

@sofa-framework/consortium, I also believe that there should be clear guidelines in SOFA to determine what the "normal" way of compiling plugins should be.
I believe that outsourced builds should be the way to go, instead of adding plugins through 
`applications/plugins/CMakeLists.txt`
or cmake's
`EXTERNAL_DIRECTORIES`
 since it allows people to isolate SOFA a bit more from their work.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
