### PR TITLE
[SofaPython] sparse matrix aliasing scipy/eigen

### DIFF
--- a/SofaKernel/framework/sofa/defaulttype/DataTypeInfo.h
+++ b/SofaKernel/framework/sofa/defaulttype/DataTypeInfo.h
@@ -84,7 +84,10 @@ namespace defaulttype
     generically in non-template code.
 */
 template<class TDataType>
-struct DataTypeInfo
+struct DataTypeInfo;
+
+template<class TDataType>
+struct DefaultDataTypeInfo
 {
     /// Template parameter.
     typedef TDataType DataType;
@@ -139,6 +142,8 @@ struct DataTypeInfo
     {
     }
 
+    // mtournier: wtf is this supposed to do?
+    // mtournier: wtf is this not returning &type?
     static const void* getValuePtr(const DataType& /*type*/)
     {
         return NULL;
@@ -152,6 +157,11 @@ struct DataTypeInfo
     static const char* name() { return "unknown"; }
 
 };
+
+template<class TDataType>
+struct DataTypeInfo : DefaultDataTypeInfo<TDataType> { };
+
+
 
 /// Type name template: default to using DataTypeInfo::name(), but can be overriden for types with shorter typedefs
 template<class TDataType>

--- a/SofaKernel/modules/SofaEigen2Solver/EigenBaseSparseMatrix.h
+++ b/SofaKernel/modules/SofaEigen2Solver/EigenBaseSparseMatrix.h
@@ -483,6 +483,10 @@ struct DataTypeInfo< component::linearsolver::EigenBaseSparseMatrix<Real> >
     : DefaultDataTypeInfo<component::linearsolver::EigenBaseSparseMatrix<Real> > {
 
     using typename DataTypeInfo::DefaultDataTypeInfo::DataType;
+
+    static const char* name() {
+        return DataType::Name();
+    }
     
     static const void* getValuePtr(const DataType& type) {
         return &type.compressedMatrix;

--- a/SofaKernel/modules/SofaEigen2Solver/EigenBaseSparseMatrix.h
+++ b/SofaKernel/modules/SofaEigen2Solver/EigenBaseSparseMatrix.h
@@ -52,8 +52,6 @@ namespace linearsolver
 
 
 
-
-
 /** Sparse matrix based on the Eigen library.
 
 An Eigen::SparseMatrix<Real, RowMajor> matrix is used to store the data in Compressed Row Storage mode.
@@ -476,6 +474,27 @@ template<> inline const char* EigenBaseSparseMatrix<float>::Name()  { return "Ei
 } // namespace linearsolver
 
 } // namespace component
+
+
+namespace defaulttype {
+
+template<class Real>
+struct DataTypeInfo< component::linearsolver::EigenBaseSparseMatrix<Real> > 
+    : DefaultDataTypeInfo<component::linearsolver::EigenBaseSparseMatrix<Real> > {
+
+    using typename DataTypeInfo::DefaultDataTypeInfo::DataType;
+    
+    static const void* getValuePtr(const DataType& type) {
+        return &type.compressedMatrix;
+    }
+
+    static void* getValuePtr(DataType& type) {
+        return &type.compressedMatrix;
+    }
+    
+};
+
+}
 
 } // namespace sofa
 

--- a/SofaKernel/modules/SofaEigen2Solver/EigenSparseMatrix.h
+++ b/SofaKernel/modules/SofaEigen2Solver/EigenSparseMatrix.h
@@ -656,17 +656,7 @@ namespace defaulttype {
 
 template<class TIn, class TOut>
 struct DataTypeInfo< component::linearsolver::EigenSparseMatrix<TIn, TOut> > 
-    : DefaultDataTypeInfo<component::linearsolver::EigenSparseMatrix<TIn, TOut> > {
-
-    using typename DataTypeInfo::DefaultDataTypeInfo::DataType;
-    
-    static const void* getValuePtr(const DataType& type) {
-        return &type.compressedMatrix;
-    }
-
-    static void* getValuePtr(DataType& type) {
-        return &type.compressedMatrix;
-    }
+    : DataTypeInfo< typename component::linearsolver::EigenSparseMatrix<TIn, TOut>::Inherit > {
     
 };
 

--- a/SofaKernel/modules/SofaEigen2Solver/EigenSparseMatrix.h
+++ b/SofaKernel/modules/SofaEigen2Solver/EigenSparseMatrix.h
@@ -652,6 +652,25 @@ template<> inline const char* EigenSparseMatrix<defaulttype::Vec3fTypes, default
     }
 
 
+namespace defaulttype {
+
+template<class TIn, class TOut>
+struct DataTypeInfo< component::linearsolver::EigenSparseMatrix<TIn, TOut> > 
+    : DefaultDataTypeInfo<component::linearsolver::EigenSparseMatrix<TIn, TOut> > {
+
+    using typename DataTypeInfo::DefaultDataTypeInfo::DataType;
+    
+    static const void* getValuePtr(const DataType& type) {
+        return &type.compressedMatrix;
+    }
+
+    static void* getValuePtr(DataType& type) {
+        return &type.compressedMatrix;
+    }
+    
+};
+
+}
 
 } // namespace sofa
 

--- a/applications/plugins/Compliant/CMakeLists.txt
+++ b/applications/plugins/Compliant/CMakeLists.txt
@@ -251,6 +251,8 @@ if( SofaPython_FOUND )
         mapping/PythonMultiMapping.cpp
         python/_Compliant.cpp
         python/Binding_AssembledSystem.cpp
+
+        # note: need to fix assembled solver in python before removing
         python/python.cpp
         )
 

--- a/applications/plugins/Compliant/python/Compliant/sparse.py
+++ b/applications/plugins/Compliant/python/Compliant/sparse.py
@@ -1,0 +1,113 @@
+import Sofa
+
+import numpy as np
+import scipy as sp
+from scipy import sparse
+from contextlib import contextmanager
+
+from ctypes import *
+
+dll_path = Sofa.loadPlugin('Compliant')
+dll = CDLL(dll_path)
+
+
+# note: we don't alias eigen matrices directly as the memory layout could change
+# between versions (it did once in the past IIRC), so we use a low-level
+# exchange data structure instead
+
+class Matrix(Structure):
+    '''all the data needed to alias a sparse matrix in eigen/scipy'''
+    
+    _fields_ = (('rows', c_size_t),
+                ('cols', c_size_t),
+                ('outer_index', POINTER(c_int)),
+                ('inner_nonzero', POINTER(c_int)),
+                ('values', POINTER(c_double)),
+                ('indices', POINTER(c_int)),
+                ('size', c_size_t))
+
+
+    @staticmethod
+    def from_scipy(s):
+        data = Matrix()
+        values, inner_indices, outer_index = s.data, s.indices, s.indptr
+        
+        data.rows, data.cols = s.shape
+
+        data.outer_index = outer_index.ctypes.data_as(POINTER(c_int))
+        data.inner_nonzero = None
+
+        data.values = values.ctypes.data_as(POINTER(c_double))
+        data.indices = inner_indices.ctypes.data_as(POINTER(c_int))
+        data.size = values.size
+
+        return data
+
+    @staticmethod
+    def from_eigen(ptr):
+        data = Matrix()
+        dll.eigen_to_scipy(byref(data), ptr)
+        return data
+        
+
+    def to_eigen(self, ptr):
+        return dll.eigen_from_scipy(ptr, byref(self))
+
+    
+    def to_scipy(self):
+        '''warning: if the scipy view reallocates, it will no longer alias the sparse
+        matrix.
+        '''
+
+        data = self
+        
+        # needed: outer_index, data.values, data.size, data.indices, outer_size, inner_size
+        outer_index = np.ctypeslib.as_array( as_buffer(data.outer_index, data.rows + 1) )
+        
+        shape = (data.rows, data.cols)
+
+        if not data.values:
+            return sp.sparse.csr_matrix( shape )
+
+        values = np.ctypeslib.as_array( as_buffer(data.values, data.size) )
+        inner_indices = np.ctypeslib.as_array( as_buffer(data.indices, data.size) )
+
+        return sp.sparse.csr_matrix( (values, inner_indices, outer_index), shape)
+
+
+    @staticmethod
+    @contextmanager
+    def view(ptr):
+        view = Matrix.from_eigen(ptr).to_scipy()
+        data = view.data.ctypes.data
+        
+        try:
+            yield view
+        finally:
+            new = view.data.ctypes.data
+            if new != data:
+                # data pointer changed: rebuild view and assign back to eigen
+                Matrix.from_scipy(view).to_eigen(ptr)
+
+            
+# sparse <- eigen        
+dll.eigen_to_scipy.restype = None
+dll.eigen_to_scipy.argtypes = (POINTER(Matrix), c_void_p)
+
+# eigen <- sparse
+dll.eigen_from_scipy.restype = None
+dll.eigen_from_scipy.argtypes = (c_void_p, POINTER(Matrix))
+        
+    
+def as_buffer(ptr, *size):
+    '''cast a ctypes pointer to a multidimensional array of given sizes'''
+    
+    addr = addressof(ptr.contents)
+    
+    buffer_type = type(ptr.contents)
+    
+    for s in reversed(size):
+        buffer_type = buffer_type * s
+        
+    return buffer_type.from_address(addr)
+

--- a/applications/plugins/SofaPython/CMakeLists.txt
+++ b/applications/plugins/SofaPython/CMakeLists.txt
@@ -124,6 +124,7 @@ set(SOURCE_FILES
     ScriptEvent.cpp
     ScriptFunction.cpp
     initSofaPython.cpp
+    ctypes.cpp
 )
 
 set(PYTHON_FILES

--- a/applications/plugins/SofaPython/ctypes.cpp
+++ b/applications/plugins/SofaPython/ctypes.cpp
@@ -2,7 +2,7 @@
 
 #include <Eigen/Sparse>
 #include <cstddef>
-
+#include <type_traits>
 
 template<class U>
 struct scipy_csr_matrix {

--- a/applications/plugins/SofaPython/ctypes.cpp
+++ b/applications/plugins/SofaPython/ctypes.cpp
@@ -1,0 +1,144 @@
+// a bunch of ctypes-bound functions
+
+#include <Eigen/Sparse>
+#include <cstddef>
+
+
+template<class U>
+struct scipy_csr_matrix {
+    
+    // SparseMatrix
+    std::size_t rows, cols;
+    int* outer_index;
+    int* inner_nonzero;
+
+    // CompressedStorage
+    struct storage_type {
+        U* values;
+        int* indices;
+        std::size_t size;
+    } storage;
+
+};
+
+
+template<class U>
+struct eigen_csr_matrix : Eigen::SparseMatrix<U, Eigen::RowMajor> {
+
+    // this is a dummy class that provides glue between scipy matrices and eigen
+    // matrices (mostly adapting pointers/shapes)
+
+    
+private:
+    // that's right: use placement new to make sure the destructor is never
+    // called since memory is owned by scipy.
+    ~eigen_csr_matrix() { }
+    
+public:
+
+    eigen_csr_matrix( const scipy_csr_matrix<U>* source ) {
+        this->m_outerSize = source->rows;
+        this->m_innerSize = source->cols;
+
+        this->m_outerIndex = source->outer_index;
+        this->m_innerNonZeros = source->inner_nonzero;
+
+        // same here
+        new (&this->m_data) eigen_compressed_storage(source->storage);
+    }
+
+
+    using eigen_compressed_storage_base = typename eigen_csr_matrix::Storage;
+    
+    struct eigen_compressed_storage : eigen_compressed_storage_base {
+
+        eigen_compressed_storage(const typename scipy_csr_matrix<U>::storage_type& source) {
+            this->m_values = source.values;
+            this->m_indices = source.indices;
+            this->m_size = source.size;
+        }
+        
+        typename scipy_csr_matrix<U>::storage_type to_scipy() const {
+            typename scipy_csr_matrix<U>::storage_type res;
+
+            res.size = this->m_size;
+
+            if( res.size ) {
+                res.values = this->m_values;
+                res.indices = this->m_indices;
+            } else {
+                // this keeps ctypes for yelling a warning
+                res.values = nullptr;
+                res.indices = nullptr;
+            }
+
+            return res;
+        }
+            
+    };
+
+    scipy_csr_matrix<U> to_scipy() const {
+        scipy_csr_matrix<U> res;
+
+        res.rows = this->m_outerSize;
+        res.cols = this->m_innerSize;
+
+        res.outer_index = this->m_outerIndex;
+        res.inner_nonzero = this->m_innerNonZeros;
+
+        res.storage = static_cast<const eigen_compressed_storage&>(this->m_data).to_scipy();
+
+        return res;
+    }
+};
+
+
+template<class U>
+static void eigen_from_scipy_impl(eigen_csr_matrix<U>* lvalue,
+                                  const scipy_csr_matrix<U>* rvalue) {
+    // note: we use placement new to make sure destructor is never called
+    // since memory is owned by scipy
+    typename std::aligned_union<0, eigen_csr_matrix<U> >::type storage;
+    const eigen_csr_matrix<U>* alias = new (&storage) eigen_csr_matrix<U>(rvalue);
+        
+    *lvalue = *alias;
+    lvalue->makeCompressed();
+}
+
+
+
+extern "C" {
+
+    std::size_t eigen_sizeof_double() {
+        return sizeof(eigen_csr_matrix<double>);
+    }
+
+    void eigen_to_scipy_double(scipy_csr_matrix<double>* dst, const eigen_csr_matrix<double>* src) {
+        *dst = src->to_scipy();
+    }
+
+    void eigen_from_scipy_double(eigen_csr_matrix<double>* lvalue,
+                                 const scipy_csr_matrix<double>* rvalue) {    
+        eigen_from_scipy_impl<double>(lvalue, rvalue);
+    }
+
+
+    std::size_t eigen_sizeof_float() {
+        return sizeof(eigen_csr_matrix<float>);
+    }
+
+
+    void eigen_to_scipy_float(scipy_csr_matrix<float>* dst, const eigen_csr_matrix<float>* src) {
+        *dst = src->to_scipy();
+    }
+
+    void eigen_from_scipy_float(eigen_csr_matrix<float>* lvalue,
+                                const scipy_csr_matrix<float>* rvalue) {    
+        eigen_from_scipy_impl<float>(lvalue, rvalue);
+    }
+    
+}
+
+
+
+

--- a/applications/plugins/SofaPython/ctypes.cpp
+++ b/applications/plugins/SofaPython/ctypes.cpp
@@ -106,6 +106,7 @@ static void eigen_from_scipy_impl(eigen_csr_matrix<U>* lvalue,
         eigen_csr_matrix<U> matrix;
         char bytes[0]; // ye olde c trick ahoy
         storage_type() { }
+        ~storage_type() { }
     } storage;
 
     const eigen_csr_matrix<U>* alias = new (storage.bytes) eigen_csr_matrix<U>(rvalue);

--- a/applications/plugins/SofaPython/examples/sparse.py
+++ b/applications/plugins/SofaPython/examples/sparse.py
@@ -1,0 +1,43 @@
+from __future__ import print_function
+from SofaPython import sparse
+
+import numpy as np
+
+import Sofa
+Sofa.loadPlugin('Flexible')
+
+def createScene(node):
+
+    template = 'Affine'
+    dofs = node.createObject('MechanicalObject', template = template, name="dof", 
+                             showObject="true", showObjectScale="0.7", size = 1)
+    dofs.init()
+    
+    mass = node.createObject('AffineMass', template = template)
+    mass.init()
+    mass.bwdInit()
+
+    ref = np.identity(12)
+    
+    with sparse.data_view(mass, 'massMatrix') as m:
+        assert (m == ref).all()
+
+        m[10, 10] = 14
+        ref[10, 10] = 14
+
+        # assert our in-place modifications are reflected
+        with sparse.data_view(mass, 'massMatrix') as mm:
+            assert (mm == ref).all()
+
+        m[0, 10] = 14
+        ref[0, 10] = 14
+
+        # sparsity change
+        with sparse.data_view(mass, 'massMatrix') as mm:
+            assert not (mm == ref).all()
+
+    # modification commit happens here
+    with sparse.data_view(mass, 'massMatrix') as mm:
+        assert (mm == ref).all()
+
+        

--- a/applications/plugins/SofaPython/examples/sparse.py
+++ b/applications/plugins/SofaPython/examples/sparse.py
@@ -40,4 +40,10 @@ def createScene(node):
     with sparse.data_view(mass, 'massMatrix') as m:
         assert (m == ref).all()
 
+    try:
+        # this must throw ValueError since m is read-only outside context
+        m[1,1] = 10
+        assert False
+    except ValueError:
+        pass
         

--- a/applications/plugins/SofaPython/examples/sparse.py
+++ b/applications/plugins/SofaPython/examples/sparse.py
@@ -37,7 +37,7 @@ def createScene(node):
             assert not (mm == ref).all()
 
     # modification commit happens here
-    with sparse.data_view(mass, 'massMatrix') as mm:
-        assert (mm == ref).all()
+    with sparse.data_view(mass, 'massMatrix') as m:
+        assert (m == ref).all()
 
         

--- a/applications/plugins/SofaPython/python/SofaPython/__init__.py
+++ b/applications/plugins/SofaPython/python/SofaPython/__init__.py
@@ -77,11 +77,14 @@ def sofaExceptHandler(type, value, tb):
           File file1.py line 23 ...
             faulty line
     """
-    s="\nPython Stack: \n"
-    for line in traceback.format_tb(tb):
-        s += line
+    h = type.__name__
 
-    Sofa.msg_error(str(value)+" "+s, "line", 7)
+    if str(value) != '':
+        h += ': ' + str(value)
+    
+    s = ''.join(traceback.format_tb(tb))
+    
+    Sofa.msg_error(h + '\n' + s, "line", 7)
 
 sys.excepthook=sofaExceptHandler
 

--- a/applications/plugins/SofaPython/python/SofaPython/sparse.py
+++ b/applications/plugins/SofaPython/python/SofaPython/sparse.py
@@ -1,0 +1,162 @@
+import Sofa
+
+import numpy as np
+import scipy as sp
+from scipy import sparse
+from contextlib import contextmanager
+
+from ctypes import *
+
+dll_path = Sofa.loadPlugin('SofaPython')
+dll = CDLL(dll_path)
+
+
+
+# note: we don't alias eigen matrices directly as the memory layout could change
+# between versions (it did once in the past IIRC), so we use a low-level
+# exchange data structure instead
+def matrix(dtype):
+
+    from_eigen_table = {
+        c_double: dll.eigen_to_scipy_double,
+        c_float: dll.eigen_to_scipy_float,        
+    }
+
+
+    to_eigen_table = {
+        c_double: dll.eigen_from_scipy_double,
+        c_float: dll.eigen_from_scipy_float,        
+    }
+    
+    
+    class Matrix(Structure):
+        '''all the data needed to alias a sparse matrix in eigen/scipy'''
+
+        _fields_ = (('rows', c_size_t),
+                    ('cols', c_size_t),
+                    ('outer_index', POINTER(c_int)),
+                    ('inner_nonzero', POINTER(c_int)),
+                    ('values', POINTER(dtype)),
+                    ('indices', POINTER(c_int)),
+                    ('size', c_size_t))
+
+
+        @staticmethod
+        def from_scipy(s):
+            data = Matrix()
+            values, inner_indices, outer_index = s.data, s.indices, s.indptr
+
+            data.rows, data.cols = s.shape
+
+            data.outer_index = outer_index.ctypes.data_as(POINTER(c_int))
+            data.inner_nonzero = None
+
+            # TODO mettre le bon type
+            data.values = values.ctypes.data_as(POINTER(dtype))
+            data.indices = inner_indices.ctypes.data_as(POINTER(c_int))
+            data.size = values.size
+
+            return data
+
+
+
+        @staticmethod
+        def from_eigen(ptr):
+            data = Matrix()
+            from_eigen_table[dtype](byref(data), ptr)
+            return data
+
+
+
+        def to_eigen(self, ptr):
+            return to_eigen_table[dtype](ptr, byref(self))
+        
+
+        def to_scipy(self):
+            '''warning: if the scipy view reallocates, it will no longer alias the sparse
+            matrix.
+            '''
+
+            data = self
+
+            # needed: outer_index, data.values, data.size, data.indices, outer_size, inner_size
+            outer_index = np.ctypeslib.as_array( as_buffer(data.outer_index, data.rows + 1) )
+
+            shape = (data.rows, data.cols)
+
+            if not data.values:
+                return sp.sparse.csr_matrix( shape )
+
+            values = np.ctypeslib.as_array( as_buffer(data.values, data.size) )
+            inner_indices = np.ctypeslib.as_array( as_buffer(data.indices, data.size) )
+
+            return sp.sparse.csr_matrix( (values, inner_indices, outer_index), shape)
+
+
+        @staticmethod
+        @contextmanager
+        def view(ptr):
+            view = Matrix.from_eigen(ptr).to_scipy()
+            data = view.data.ctypes.data
+
+            try:
+                yield view
+            finally:
+                new = view.data.ctypes.data
+                if new != data:
+                    # data pointer changed: rebuild view and assign back to eigen
+                    Matrix.from_scipy(view).to_eigen(ptr)
+
+
+    return Matrix
+
+
+Matrixd = matrix(c_double)
+Matrixf = matrix(c_float)
+
+# sparse <- eigen        
+dll.eigen_to_scipy_double.restype = None
+dll.eigen_to_scipy_double.argtypes = (POINTER(Matrixd), c_void_p)
+
+dll.eigen_to_scipy_float.restype = None
+dll.eigen_to_scipy_float.argtypes = (POINTER(Matrixf), c_void_p)
+
+# eigen <- sparse
+dll.eigen_from_scipy_double.restype = None
+dll.eigen_from_scipy_double.argtypes = (c_void_p, POINTER(Matrixd))
+
+dll.eigen_from_scipy_float.restype = None
+dll.eigen_from_scipy_float.argtypes = (c_void_p, POINTER(Matrixf))
+
+
+matrix_type_from_data_type = {
+    'EigenBaseSparseMatrixd': Matrixd,
+    'EigenBaseSparseMatrixf': Matrixf,    
+}
+
+
+@contextmanager
+def data_view(obj, data_name):
+
+    data = obj.findData(data_name)
+    ptr, _, data_type = data.getValueVoidPtr()
+
+    matrix_type = matrix_type_from_data_type[data_type]
+    
+    with matrix_type.view(ptr) as view:
+        yield view
+
+
+    
+def as_buffer(ptr, *size):
+    '''cast a ctypes pointer to a multidimensional array of given sizes'''
+    
+    addr = addressof(ptr.contents)
+    
+    buffer_type = type(ptr.contents)
+    
+    for s in reversed(size):
+        buffer_type = buffer_type * s
+        
+    return buffer_type.from_address(addr)
+


### PR DESCRIPTION
This PR provides support for aliasing Eigen sparse matrices (classes derived from `EigenBaseSparseMatrix`) through scipy sparse matrices.

The scipy matrix *aliases* the eigen matrix, so that any modification will reflect on both sides provided the sparsity pattern does not change (on either side). A python context manager is provided to commit modifications back, should the sparsity pattern change, as shown in the example below.

The binding is somewhat unconventional as it uses `ctypes` for simplicity. Perhaps a cleaner version could be made using regular bindings + passing Eigen matrix pointers through python capsules if someone is motivated.

# Example
```python
from SofaPython import sparse
import numpy as np

import Sofa
Sofa.loadPlugin('Flexible')

def createScene(node):
    template = 'Affine'

    dofs = node.createObject('MechanicalObject', template = template, size = 1)
    dofs.init()
    
    mass = node.createObject('AffineMass', template = template)
    mass.init()
    mass.bwdInit()

    ref = np.identity(12)
    
    with sparse.data_view(mass, 'massMatrix') as m:
        assert (m == ref).all()

        m[10, 10] = 14
        ref[10, 10] = 14

        # assert our in-place modifications are reflected
        with sparse.data_view(mass, 'massMatrix') as mm:
            assert (mm == ref).all()

        m[0, 10] = 14
        ref[0, 10] = 14

        # sparsity change: scipy matrix reallocates, no longer aliases 
        with sparse.data_view(mass, 'massMatrix') as mm:
            assert not (mm == ref).all()
        
        # modification commit happens here

    with sparse.data_view(mass, 'massMatrix') as m:
        assert (m == ref).all()
```

# Changelog

- Added `DataTypeInfo` for `EigenBaseSparseMatrix` derived classes
- Added a bunch of C functions in `SofaPython/ctypes.cpp` for aliasing logic
- Added a ctypes binding for aliasing + contexts in `SofaPython.sparse`
- Added an example in `SofaPython/examples/sparse.py`
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
