### PR TITLE
[SofaPython] Fix python live coding that is broken

### DIFF
--- a/applications/plugins/SofaPython/PythonScriptController.cpp
+++ b/applications/plugins/SofaPython/PythonScriptController.cpp
@@ -84,6 +84,8 @@ public:
     virtual ~MyFileEventListener(){}
 
     virtual void fileHasChanged(const std::string& filepath){
+        PythonEnvironment::gil lock {__func__} ;
+
         /// This function is called when the file has changed. Two cases have
         /// to be considered if the script was already loaded once or not.
         if(!m_controller->scriptControllerInstance()){
@@ -242,7 +244,6 @@ void PythonScriptController::doLoadScript()
 
 void PythonScriptController::script_onIdleEvent(const IdleEvent* /*event*/)
 {
-    
     FileMonitor::updates(0);
 
     {


### PR DESCRIPTION
Hi,

This PR fix the live coding of python component. I found two problems. 

One is a bug in the FileMonitor which prevent to monitor several files located in the same directory but given in a different manner as in: 
```
"./examples/Afile.txt"
"/this/is/absolute/examples/Afile2.txt"
```

The second problem is a missing PythonEnvironement::gil before calling python code.

This PR fix the two. 
@guparan and @hugtalbot  Could this PR be treated in fast-path please ? 



@maxime-tournier I took me a while to understand that 
```cpp
PythonEnvironment::gil lock(); 
```
Is not doing anything useful. The problem is well known but in general it is quickly catched but here, as lock is a RAII, everything compile but just crash when calling python code. I'm quite sure this will happen to a lot of people so I wonder if we can make something more elegant that removing the default constructor and forcing to provide the *trace pointer (possibly nullptr). Any idea ? 



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
