### PR TITLE
[SofaPython] FIX: PyString_FromString -> PyString_FromStringAndSize

### DIFF
--- a/applications/plugins/SofaPython/Binding_Data.cpp
+++ b/applications/plugins/SofaPython/Binding_Data.cpp
@@ -82,7 +82,7 @@ PyObject *GetDataValuePython(BaseData* data)
         /// This type is not yet supported, the fallback scenario is to convert it using the python str() function and emit
         /// a warning message.
         msg_warning(data->getOwner()) << "BaseData_getAttr_value unsupported native type="<<data->getValueTypeString()<<" for data "<<data->getName()<<" ; returning string value" ;
-        return PyString_FromString(data->getValueString().c_str());
+        return PyString_FromStringAndSize(data->getValueString().c_str(), data->getValueString().size());
     }
     else
     {
@@ -93,7 +93,7 @@ PyObject *GetDataValuePython(BaseData* data)
         if( !typeinfo->Text() && !typeinfo->Scalar() && !typeinfo->Integer() )
         {
             SP_MESSAGE_WARNING( "BaseData_getAttr_value unsupported native type="<<data->getValueTypeString()<<" for data "<<data->getName()<<" ; returning string value" )
-            return PyString_FromString(data->getValueString().c_str());
+            return PyString_FromStringAndSize(data->getValueString().c_str(), data->getValueString().size());
         }
 
         PyObject *rows = PyList_New(nbRows);
@@ -131,7 +131,8 @@ PyObject *GetDataValuePython(BaseData* data)
     //TODO(PR:304) If this should not happen (see comment later) then we should rise an exception instead of providing a fallback scenario.
     /// default (should not happen)...
     SP_MESSAGE_WARNING( "BaseData_getAttr_value unsupported native type="<<data->getValueTypeString()<<" for data "<<data->getName()<<" ; returning string value (should not come here!)" )
-    return PyString_FromString(data->getValueString().c_str());
+    return PyString_FromStringAndSize(data->getValueString().c_str(), data->getValueString().size());
+
 }
 
 


### PR DESCRIPTION
When trying to serialize / desserialize custom  binary data structures (non-native / non-scalar Sofa types) as byte arrays from C++ to Python, PyString_FromStirng is called, which stops the input stream at the first \0 it encounters.
PyString_FromStringAndSize retrieves the full stream instead, which is more likely to be what we want here.
@damienmarchal could you tell me what you think of this?

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
