### PR TITLE
[SofaFramework] CMake:Fix and clean boost, when using Sofa as an external lib

### DIFF
--- a/SofaKernel/SofaFramework/CMakeLists.txt
+++ b/SofaKernel/SofaFramework/CMakeLists.txt
@@ -127,35 +127,51 @@ endif()
 set(SOFA_HAVE_PNG ${PNG_FOUND})
 
 ## Boost
-# optional boost libraries
-find_package(Boost REQUIRED system filesystem locale
-                   OPTIONAL_COMPONENTS thread date_time)
-set(SOFA_HAVE_BOOST_THREAD ${Boost_THREAD_FOUND})
+# required boost libraries
+find_package(Boost REQUIRED system filesystem locale 
+                   OPTIONAL_COMPONENTS thread date_time )
+
 set(SOFA_HAVE_BOOST_DATE_TIME ${Boost_DATE_TIME_FOUND})
+set(SOFA_HAVE_BOOST_SYSTEM ${Boost_SYSTEM_FOUND})
+set(SOFA_HAVE_BOOST_LOCALE ${Boost_LOCALE_FOUND})
+set(SOFA_HAVE_BOOST_FILESYSTEM ${Boost_FILESYSTEM_FOUND})
+set(SOFA_HAVE_BOOST_THREAD ${Boost_THREAD_FOUND})
 
 list(APPEND Boost_INCLUDE_DIRS ${Boost_INCLUDE_DIR})
 
-# if(SOFA_HAVE_BOOST_SYSTEM
-#    AND SOFA_HAVE_BOOST_THREAD
-#    AND SOFA_HAVE_BOOST_DATE_TIME)
-#     set(SOFA_HAVE_BOOST 1)
+if(SOFA_HAVE_BOOST_SYSTEM
+   AND SOFA_HAVE_BOOST_FILESYSTEM
+   AND SOFA_HAVE_BOOST_LOCALE)
 
-#     sofa_create_target(BoostSystem SofaFramework "${Boost_SYSTEM_LIBRARY}" "${Boost_INCLUDE_DIRS}")
-#     sofa_create_target(BoostThread SofaFramework "${Boost_THREAD_LIBRARY}" "${Boost_INCLUDE_DIRS}")
-#     sofa_create_target(BoostDateTime SofaFramework "${Boost_DATE_TIME_LIBRARY}" "${Boost_INCLUDE_DIRS}")
+    set(SOFA_HAVE_BOOST 1)
 
-# 	list(APPEND SOFAFRAMEWORK_DEPENDENCY_LINK ${BoostSystem_Target})
-# 	list(APPEND SOFAFRAMEWORK_DEPENDENCY_LINK ${BoostThread_Target})
-#     list(APPEND SOFAFRAMEWORK_DEPENDENCY_LINK ${BoostDateTime_Target})
+    sofa_create_target(BoostSystem SofaFramework "${Boost_SYSTEM_LIBRARY}" "${Boost_INCLUDE_DIRS}")
+    sofa_create_target(BoostLocale SofaFramework "${Boost_LOCALE_LIBRARY}" "${Boost_INCLUDE_DIRS}")
+    sofa_create_target(BoostFileSystem SofaFramework "${Boost_FILESYSTEM_LIBRARY}" "${Boost_INCLUDE_DIRS}")
 
-#     sofa_install_get_libraries(${Boost_SYSTEM_LIBRARY})
-#     sofa_install_get_libraries(${Boost_THREAD_LIBRARY})
-#     sofa_install_get_libraries(${Boost_DATE_TIME_LIBRARY})
-# else()
-#     list(APPEND SOFAFRAMEWORK_DEPENDENCY_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIRS})
-# endif()
+	list(APPEND SOFAFRAMEWORK_DEPENDENCY_LINK ${BoostSystem_Target})
+    list(APPEND SOFAFRAMEWORK_DEPENDENCY_LINK ${BoostLocale_Target})
+    list(APPEND SOFAFRAMEWORK_DEPENDENCY_LINK ${BoostFileSystem_Target})
 
-list(APPEND SOFAFRAMEWORK_DEPENDENCY_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIRS})
+    sofa_install_get_libraries(${Boost_SYSTEM_LIBRARY})
+    sofa_install_get_libraries(${Boost_LOCALE_LIBRARY})
+    sofa_install_get_libraries(${Boost_FILESYSTEM_LIBRARY})
+
+    if(SOFA_HAVE_BOOST_DATE_TIME)
+        sofa_create_target(BoostDateTime SofaFramework "${Boost_DATE_TIME_LIBRARY}" "${Boost_INCLUDE_DIRS}")
+        list(APPEND SOFAFRAMEWORK_DEPENDENCY_LINK ${BoostDateTime_Target})
+        sofa_install_get_libraries(${Boost_DATE_TIME_LIBRARY})
+    endif()
+
+    if(SOFA_HAVE_BOOST_THREAD)
+        sofa_create_target(BoostThread SofaFramework "${Boost_THREAD_LIBRARY}" "${Boost_INCLUDE_DIRS}")
+        list(APPEND SOFAFRAMEWORK_DEPENDENCY_LINK ${BoostThread_Target})
+        sofa_install_get_libraries(${Boost_THREAD_LIBRARY})
+    endif()
+
+else()
+    list(APPEND SOFAFRAMEWORK_DEPENDENCY_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIRS})
+endif()
 
 ## Eigen
 find_package(Eigen3 REQUIRED)

--- a/SofaKernel/SofaFramework/SofaFrameworkConfig.cmake.in
+++ b/SofaKernel/SofaFramework/SofaFrameworkConfig.cmake.in
@@ -45,10 +45,21 @@ if(SOFA_HAVE_GLUT)
 endif()
 
 if(SOFA_HAVE_BOOST)
-    find_package(Boost QUIET REQUIRED COMPONENTS thread system date_time)
-    sofa_create_target(BoostSystem SofaFramework "${Boost_SYSTEM_LIBRARY}" "${Boost_INCLUDE_DIRS}")
-    sofa_create_target(BoostThread SofaFramework "${Boost_THREAD_LIBRARY}" "${Boost_INCLUDE_DIRS}")
-    sofa_create_target(BoostDateTime SofaFramework "${Boost_DATE_TIME_LIBRARY}" "${Boost_INCLUDE_DIRS}")
+    find_package(Boost QUIET REQUIRED COMPONENTS system filesystem locale OPTIONAL_COMPONENTS date_time thread)
+    
+    if(Boost_SYSTEM_FOUND AND Boost_FILESYSTEM_FOUND AND Boost_LOCALE_FOUND)
+        sofa_create_target(BoostSystem SofaFramework "${Boost_SYSTEM_LIBRARY}" "${Boost_INCLUDE_DIRS}")
+        sofa_create_target(BoostLocale SofaFramework "${Boost_LOCALE_LIBRARY}" "${Boost_INCLUDE_DIRS}")
+        sofa_create_target(BoostFileSystem SofaFramework "${Boost_FILESYSTEM_LIBRARY}" "${Boost_INCLUDE_DIRS}")
+    endif()
+
+    if(Boost_DATE_TIME_FOUND)
+        sofa_create_target(BoostDateTime SofaFramework "${Boost_DATE_TIME_LIBRARY}" "${Boost_INCLUDE_DIRS}")
+    endif()
+
+    if(Boost_THREAD_FOUND)
+        sofa_create_target(BoostThread SofaFramework "${Boost_THREAD_LIBRARY}" "${Boost_INCLUDE_DIRS}")
+    endif()
 endif()
 
 if(NOT TARGET SofaCore)

--- a/SofaKernel/SofaFramework/config.h.in
+++ b/SofaKernel/SofaFramework/config.h.in
@@ -41,6 +41,10 @@
 
 #cmakedefine SOFA_HAVE_BOOST_DATE_TIME
 
+#cmakedefine SOFA_HAVE_BOOST_LOCALE
+
+#cmakedefine SOFA_HAVE_BOOST_FILESYSTEM
+
 #cmakedefine SOFA_HAVE_TINYXML
 
 #cmakedefine SOFA_DUMP_VISITOR_INFO


### PR DESCRIPTION
Fix regression (appeared when boost was supposed to be removed from Sofa).
-> Plugins _not able to find Boost automatically_ failed to compile (because it needs boost to compile obviously)
 
The problem was coming on Windows mainly, as boost are often installed in the system directories on Unix system.

And few changes were added to make boost's CMake part more consistent. 



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
