### PR TITLE
Fix for SofaImplicitField and SofaVolumetricData plugin

### DIFF
--- a/applications/plugins/CMakeLists.txt
+++ b/applications/plugins/CMakeLists.txt
@@ -6,8 +6,11 @@ add_subdirectory(../../extlibs/CImg extlibs/CImg)
 find_package(SofaFramework)
 
 sofa_add_plugin(SofaEulerianFluid SofaEulerianFluid)
+
 sofa_add_plugin(SofaDistanceGrid SofaDistanceGrid)
 sofa_add_plugin(SofaImplicitField SofaImplicitField)
+sofa_add_plugin(SofaVolumetricData SofaVolumetricData)  ##TRANSITIONAL DEPEND ON DISTANCEGRID & IMPLICIT
+
 sofa_add_plugin(image image)
 sofa_add_plugin(Compliant Compliant)
 sofa_add_plugin(CGALPlugin CGALPlugin) # Depends on image
@@ -54,5 +57,3 @@ else()
     sofa_add_plugin(VolumetricRendering VolumetricRendering) # VolumetricRendering plugin can't work without OPENGL
 endif()
 
-# The following are just transitional packages to help switching module to plugin while refactoring.
-sofa_add_plugin(SofaVolumetricData SofaVolumetricData)

--- a/applications/plugins/SofaImplicitField/deprecated/ImplicitSurfaceContainer.h
+++ b/applications/plugins/SofaImplicitField/deprecated/ImplicitSurfaceContainer.h
@@ -8,7 +8,7 @@ namespace component
 namespace container
 {
 
-class ImplicitSurfaceMapping : public sofa::component::DiscreteGridField
+class ImplicitSurfaceContainer : public sofa::component::geometry::DiscreteGridField
 {
 public:
     bool loadImage( const char *filename )

--- a/applications/plugins/SofaVolumetricData/CMakeLists.txt
+++ b/applications/plugins/SofaVolumetricData/CMakeLists.txt
@@ -46,4 +46,4 @@ target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CUR
 target_include_directories(${PROJECT_NAME} PUBLIC "$<INSTALL_INTERFACE:include>")
 
 ## Install rules for the library and headers; CMake package configurations files
-##sofa_create_package(SofaVolumetricData ${SOFAVOLUMETRICDATA_VERSION} ${PROJECT_NAME} SofaVolumetricData)
+sofa_create_package(SofaVolumetricData ${SOFAVOLUMETRICDATA_VERSION} ${PROJECT_NAME} SofaVolumetricData)

--- a/applications/plugins/SofaVolumetricData/SofaVolumetricDataConfig.cmake.in
+++ b/applications/plugins/SofaVolumetricData/SofaVolumetricDataConfig.cmake.in
@@ -4,6 +4,8 @@
 
 find_package(SofaFramework REQUIRED)
 find_package(SofaMisc REQUIRED)
+find_package(SofaDistanceGrid REQUIRED)
+find_package(SofaImplicitField REQUIRED)
 find_package(SofaPython QUIET)
 
 if(NOT TARGET SofaVolumetricData)


### PR DESCRIPTION
In ImplicitSurfaceContainer:
Class name didn't match and also the namespace of DiscreteGridField

In applications/plugin/CMakeLists.txt:
SofaVolumetricData depends on SofaDistanceGrid and SofaImplicitField, so should be added first


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
