### PR TITLE
[SofaKernel] Remove last direct calls of OpenGL in modules

### DIFF
--- a/SofaKernel/framework/sofa/core/visual/DrawTool.h
+++ b/SofaKernel/framework/sofa/core/visual/DrawTool.h
@@ -73,6 +73,7 @@ public:
     virtual void drawLines(const std::vector<Vector3> &points, const std::vector< Vec2i > &index , float size, const Vec4f& colour) = 0 ;
 
     virtual void drawLineStrip(const std::vector<Vector3> &points, float size, const Vec4f& colour) = 0 ;
+    virtual void drawLineLoop(const std::vector<Vector3> &points, float size, const Vec4f& colour) = 0 ;
 
     virtual void drawTriangles(const std::vector<Vector3> &points, const Vec4f& colour) = 0 ;
     virtual void drawTriangles(const std::vector<Vector3> &points, const Vector3& normal, const Vec4f& colour) = 0 ;

--- a/SofaKernel/framework/sofa/core/visual/DrawTool.h
+++ b/SofaKernel/framework/sofa/core/visual/DrawTool.h
@@ -192,6 +192,9 @@ public:
     virtual void enableBlending() = 0;
     virtual void disableBlending() = 0;
 
+    virtual void enableLighting() = 0;
+    virtual void disableLighting() = 0;
+
     /// @name States (save/restore)
     virtual void saveLastState() = 0;
     virtual void restoreLastState() = 0;

--- a/SofaKernel/framework/sofa/core/visual/DrawTool.h
+++ b/SofaKernel/framework/sofa/core/visual/DrawTool.h
@@ -196,6 +196,9 @@ public:
     virtual void enableLighting() = 0;
     virtual void disableLighting() = 0;
 
+    virtual void enableDepthTest() = 0;
+    virtual void disableDepthTest() = 0;
+
     /// @name States (save/restore)
     virtual void saveLastState() = 0;
     virtual void restoreLastState() = 0;

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
@@ -82,7 +82,7 @@ void DrawToolGL::drawPoints(const std::vector<Vector3> &points, float size, cons
 {
     setMaterial(colour);
     glPointSize(size);
-    glDisable(GL_LIGHTING);
+    disableLighting();
     glBegin(GL_POINTS);
     {
         for (unsigned int i=0; i<points.size(); ++i)
@@ -90,7 +90,7 @@ void DrawToolGL::drawPoints(const std::vector<Vector3> &points, float size, cons
             internalDrawPoint(points[i], colour);
         }
     } glEnd();
-    if (getLightEnabled()) glEnable(GL_LIGHTING);
+    if (getLightEnabled()) enableLighting();
     resetMaterial(colour);
     glPointSize(1);
 }
@@ -98,14 +98,14 @@ void DrawToolGL::drawPoints(const std::vector<Vector3> &points, float size, cons
 void DrawToolGL::drawPoints(const std::vector<Vector3> &points, float size, const std::vector<Vec4f>& colour)
 {
     glPointSize(size);
-    glDisable(GL_LIGHTING);
+    disableLighting();
     glBegin(GL_POINTS);
     {
         for (unsigned int i=0; i<points.size(); ++i)
         {
             setMaterial(colour[i]);
             internalDrawPoint(points[i], colour[i]);
-            if (getLightEnabled()) glEnable(GL_LIGHTING);
+            if (getLightEnabled()) enableLighting();
             resetMaterial(colour[i]);
         }
     } glEnd();
@@ -129,7 +129,7 @@ void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const
 {
     setMaterial(colour);
     glLineWidth(size);
-    glDisable(GL_LIGHTING);
+    disableLighting();
     glBegin(GL_LINES);
     {
         for (unsigned int i=0; i<points.size()/2; ++i)
@@ -137,7 +137,7 @@ void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const
             internalDrawLine(points[2*i],points[2*i+1]  , colour );
         }
     } glEnd();
-    if (getLightEnabled()) glEnable(GL_LIGHTING);
+    if (getLightEnabled()) enableLighting();
     resetMaterial(colour);
     glLineWidth(1);
 }
@@ -145,7 +145,7 @@ void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const
 void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const std::vector<Vec<4,float> >& colours)
 {
     glLineWidth(size);
-    glDisable(GL_LIGHTING);
+    disableLighting();
     glBegin(GL_LINES);
     {
         for (unsigned int i=0; i<points.size()/2; ++i)
@@ -155,7 +155,7 @@ void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const
             resetMaterial(colours[i]);
         }
     } glEnd();
-    if (getLightEnabled()) glEnable(GL_LIGHTING);
+    if (getLightEnabled()) enableLighting();
     glLineWidth(1);
 }
 
@@ -165,7 +165,7 @@ void DrawToolGL::drawLines(const std::vector<Vector3> &points, const std::vector
 {
     setMaterial(colour);
     glLineWidth(size);
-    glDisable(GL_LIGHTING);
+    disableLighting();
     glBegin(GL_LINES);
     {
         for (unsigned int i=0; i<index.size(); ++i)
@@ -173,7 +173,7 @@ void DrawToolGL::drawLines(const std::vector<Vector3> &points, const std::vector
             internalDrawLine(points[ index[i][0] ],points[ index[i][1] ], colour );
         }
     } glEnd();
-    if (getLightEnabled()) glEnable(GL_LIGHTING);
+    if (getLightEnabled()) enableLighting();
     resetMaterial(colour);
     glLineWidth(1);
 }
@@ -184,7 +184,7 @@ void DrawToolGL::drawLineStrip(const std::vector<Vector3> &points, float size, c
 {
     setMaterial(colour);
     glLineWidth(size);
-    glDisable(GL_LIGHTING);
+    disableLighting();
     glBegin(GL_LINE_STRIP);
     {
         for (unsigned int i=0; i<points.size(); ++i)
@@ -192,7 +192,7 @@ void DrawToolGL::drawLineStrip(const std::vector<Vector3> &points, float size, c
             internalDrawPoint(points[i]  , colour );
         }
     } glEnd();
-    if (getLightEnabled()) glEnable(GL_LIGHTING);
+    if (getLightEnabled()) enableLighting();
     resetMaterial(colour);
     glLineWidth(1);
 }
@@ -1081,8 +1081,8 @@ void DrawToolGL::setPolygonMode(int _mode, bool _wireframe)
 void DrawToolGL::setLightingEnabled(bool _isAnabled)
 {
     mLightEnabled = _isAnabled;
-    if (this->getLightEnabled()) glEnable(GL_LIGHTING);
-    else glDisable(GL_LIGHTING);
+    if (this->getLightEnabled()) enableLighting();
+    else disableLighting();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1220,6 +1220,17 @@ void DrawToolGL::disableBlending()
 {
     glDisable(GL_BLEND);
 }
+
+void DrawToolGL::enableLighting()
+{
+    glEnable(GL_LIGHTING);
+}
+
+void DrawToolGL::disableLighting()
+{
+    glDisable(GL_LIGHTING);
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void DrawToolGL::draw3DText(const Vector3 &p, float scale, const Vec4f &color, const char* text)
 {

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
@@ -199,6 +199,24 @@ void DrawToolGL::drawLineStrip(const std::vector<Vector3> &points, float size, c
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+void DrawToolGL::drawLineLoop(const std::vector<Vector3> &points, float size, const Vec<4,float>& colour)
+{
+    setMaterial(colour);
+    glLineWidth(size);
+    disableLighting();
+    glBegin(GL_LINE_LOOP);
+    {
+        for (unsigned int i=0; i<points.size(); ++i)
+        {
+            internalDrawPoint(points[i]  , colour );
+        }
+    } glEnd();
+    if (getLightEnabled()) enableLighting();
+    resetMaterial(colour);
+    glLineWidth(1);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void DrawToolGL::drawTriangles(const std::vector<Vector3> &points, const Vec<4,float>& colour)
 {

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
@@ -1249,6 +1249,16 @@ void DrawToolGL::disableLighting()
     glDisable(GL_LIGHTING);
 }
 
+void DrawToolGL::enableDepthTest()
+{
+    glEnable(GL_DEPTH_TEST);
+}
+
+void DrawToolGL::disableDepthTest()
+{
+    glDisable(GL_DEPTH_TEST);
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void DrawToolGL::draw3DText(const Vector3 &p, float scale, const Vec4f &color, const char* text)
 {

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.h
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.h
@@ -67,6 +67,7 @@ public:
     virtual void drawLines(const std::vector<Vector3> &points, const std::vector< Vec2i > &index, float size, const Vec4f& colour);
 
     virtual void drawLineStrip(const std::vector<Vector3> &points, float size, const Vec4f& colour);
+    virtual void drawLineLoop(const std::vector<Vector3> &points, float size, const Vec4f& colour);
 
     virtual void drawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
             const Vector3 &normal);

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.h
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.h
@@ -172,6 +172,9 @@ public:
     virtual void enableLighting();
     virtual void disableLighting();
 
+    virtual void enableDepthTest();
+    virtual void disableDepthTest();
+
     virtual void saveLastState();
     virtual void restoreLastState();
 

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.h
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.h
@@ -166,8 +166,10 @@ public:
     virtual void writeOverlayText( int x, int y, unsigned fontSize, const Vec4f &color, const char* text );
 
     virtual void enableBlending();
-
     virtual void disableBlending();
+
+    virtual void enableLighting();
+    virtual void disableLighting();
 
     virtual void saveLastState();
     virtual void restoreLastState();

--- a/SofaKernel/modules/SofaBaseCollision/MinProximityIntersection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/MinProximityIntersection.cpp
@@ -30,7 +30,6 @@
 #include <sofa/core/collision/Intersection.inl>
 #include <iostream>
 #include <algorithm>
-#include <sofa/helper/gl/template.h>
 #include <SofaBaseCollision/BaseIntTool.h>
 
 #define DYNAMIC_CONE_ANGLE_COMPUTATION

--- a/SofaKernel/modules/SofaBaseMechanics/BarycentricMapping.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/BarycentricMapping.inl
@@ -43,7 +43,6 @@
 #include <SofaBaseTopology/TopologyData.inl>
 
 #include <sofa/helper/vector.h>
-#include <sofa/helper/gl/template.h>
 #include <sofa/helper/system/config.h>
 
 #include <sofa/simulation/Simulation.h>

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.cpp
@@ -23,8 +23,6 @@
 #include <sofa/core/visual/VisualParams.h>
 
 #include <sofa/core/ObjectFactory.h>
-//#include <SofaBaseMechanics/MechanicalObject.inl>
-//#include <sofa/helper/gl/glText.inl>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaBaseVisual/BaseCamera.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/BaseCamera.cpp
@@ -24,7 +24,6 @@
 
 #include <sofa/defaulttype/Mat.h>
 #include <sofa/defaulttype/SolidTypes.h>
-#include <sofa/helper/gl/Axis.h>
 #include <sofa/simulation/AnimateBeginEvent.h>
 
 #include <tinyxml.h>

--- a/SofaKernel/modules/SofaBaseVisual/VisualModelImpl.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/VisualModelImpl.cpp
@@ -35,7 +35,6 @@
 #include <SofaBaseTopology/SparseGridTopology.h>
 #include <SofaBaseTopology/CommonAlgorithms.h>
 #include <sofa/helper/system/FileRepository.h>
-#include <sofa/helper/gl/RAII.h>
 #include <sofa/helper/vector.h>
 #include <sofa/defaulttype/Quat.h>
 #include <sofa/core/ObjectFactory.h>

--- a/SofaKernel/modules/SofaDeformable/AngularSpringForceField.inl
+++ b/SofaKernel/modules/SofaDeformable/AngularSpringForceField.inl
@@ -30,7 +30,6 @@
 #include <sofa/helper/system/config.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/defaulttype/RigidTypes.h>
-#include <sofa/helper/gl/template.h>
 #include <assert.h>
 #include <iostream>
 

--- a/SofaKernel/modules/SofaDeformable/RestShapeSpringsForceField.inl
+++ b/SofaKernel/modules/SofaDeformable/RestShapeSpringsForceField.inl
@@ -27,7 +27,6 @@
 #include <sofa/helper/system/config.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/defaulttype/RigidTypes.h>
-#include <sofa/helper/gl/template.h>
 
 #include <sofa/defaulttype/RGBAColor.h>
 

--- a/SofaKernel/modules/SofaDeformable/SpringForceField.inl
+++ b/SofaKernel/modules/SofaDeformable/SpringForceField.inl
@@ -31,7 +31,6 @@
 #include <sofa/core/topology/TopologyChange.h>
 #include <sofa/simulation/Simulation.h>
 #include <sofa/helper/io/MassSpringLoader.h>
-#include <sofa/helper/gl/template.h>
 #include <sofa/helper/system/config.h>
 #include <cassert>
 #include <iostream>

--- a/SofaKernel/modules/SofaEngine/BoxROI.inl
+++ b/SofaKernel/modules/SofaEngine/BoxROI.inl
@@ -27,8 +27,6 @@
 #endif
 
 #include <SofaEngine/BoxROI.h>
-#include <sofa/helper/gl/template.h>
-#include <sofa/helper/gl/BasicShapes.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/defaulttype/BoundingBox.h>
 #include <limits>

--- a/SofaKernel/modules/SofaMeshCollision/LineModel.inl
+++ b/SofaKernel/modules/SofaMeshCollision/LineModel.inl
@@ -30,7 +30,6 @@
 #include <SofaMeshCollision/Line.h>
 #include <sofa/core/CollisionElement.h>
 #include <vector>
-#include <sofa/helper/gl/template.h>
 #include <sofa/simulation/Node.h>
 #include <sofa/core/topology/TopologyChange.h>
 #include <sofa/simulation/Simulation.h>

--- a/SofaKernel/modules/SofaMeshCollision/PointModel.inl
+++ b/SofaKernel/modules/SofaMeshCollision/PointModel.inl
@@ -30,17 +30,12 @@
 #include <iostream>
 #include <algorithm>
 
-
-
-
 #include <SofaMeshCollision/PointModel.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <SofaMeshCollision/PointLocalMinDistanceFilter.h>
 #include <SofaBaseCollision/CubeModel.h>
 #include <sofa/core/ObjectFactory.h>
 #include <vector>
-#include <sofa/helper/system/gl.h>
-#include <sofa/helper/gl/template.h>
 
 #include <sofa/core/topology/BaseMeshTopology.h>
 

--- a/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
+++ b/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
@@ -32,7 +32,6 @@
 #include <SofaBaseTopology/RegularGridTopology.h>
 #include <sofa/core/CollisionElement.h>
 #include <vector>
-#include <sofa/helper/gl/template.h>
 #include <iostream>
 
 #include <sofa/core/topology/TopologyChange.h>
@@ -543,12 +542,6 @@ template<class DataTypes>
 void TTriangleModel<DataTypes>::draw(const core::visual::VisualParams* vparams ,int index)
 {
     Element t(this,index);
-    //        glBegin(GL_TRIANGLES);
-    //        helper::gl::glNormalT(t.n());
-    //        helper::gl::glVertexT(t.p1());
-    //        helper::gl::glVertexT(t.p2());
-    //        helper::gl::glVertexT(t.p3());
-    //        glEnd();
 
     vparams->drawTool()->setPolygonMode(0,vparams->displayFlags().getShowWireFrame());
     vparams->drawTool()->setLightingEnabled(true);

--- a/SofaKernel/modules/SofaObjectInteraction/PenalityContactForceField.inl
+++ b/SofaKernel/modules/SofaObjectInteraction/PenalityContactForceField.inl
@@ -26,7 +26,6 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/system/config.h>
 #include <cassert>
-#include <sofa/helper/gl/template.h>
 #include <iostream>
 
 #include <sofa/simulation/Simulation.h>
@@ -161,8 +160,6 @@ void PenalityContactForceField<DataTypes>::draw(const core::visual::VisualParams
     const VecCoord& p1 = this->mstate1->read(core::ConstVecCoordId::position())->getValue();
     const VecCoord& p2 = this->mstate2->read(core::ConstVecCoordId::position())->getValue();
     const helper::vector<Contact>& cc = contacts.getValue();
-
-    //glDisable(GL_LIGHTING); // do not use gl under draw component, it cause crash when using other render !
 
     std::vector< defaulttype::Vector3 > points[4];
 

--- a/SofaKernel/modules/SofaRigid/JointSpringForceField.inl
+++ b/SofaKernel/modules/SofaRigid/JointSpringForceField.inl
@@ -26,10 +26,6 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/helper/io/MassSpringLoader.h>
-#include <sofa/helper/gl/template.h>
-#include <sofa/helper/gl/Cylinder.h>
-#include <sofa/helper/gl/BasicShapes.h>
-#include <sofa/helper/gl/Axis.h>
 #include <sofa/helper/system/config.h>
 #include <cassert>
 #include <iostream>

--- a/SofaKernel/modules/SofaRigid/RigidMapping.inl
+++ b/SofaKernel/modules/SofaRigid/RigidMapping.inl
@@ -34,7 +34,6 @@
 #include <sofa/helper/io/MassSpringLoader.h>
 #include <sofa/helper/io/SphereLoader.h>
 #include <sofa/helper/io/Mesh.h>
-#include <sofa/helper/gl/template.h>
 #include <sofa/helper/decompose.h>
 
 #include <sofa/simulation/Simulation.h>

--- a/SofaKernel/modules/SofaRigid/RigidRigidMapping.inl
+++ b/SofaKernel/modules/SofaRigid/RigidRigidMapping.inl
@@ -28,8 +28,6 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/defaulttype/RigidTypes.h>
 
-#include <sofa/helper/gl/Axis.h>
-#include <sofa/helper/gl/template.h>
 #include <sofa/helper/io/MassSpringLoader.h>
 #include <sofa/helper/io/SphereLoader.h>
 #include <sofa/helper/io/Mesh.h>

--- a/SofaKernel/modules/SofaSimpleFem/HexahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/HexahedronFEMForceField.inl
@@ -26,7 +26,6 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/simulation/Simulation.h>
 #include <sofa/helper/decompose.h>
-#include <sofa/helper/gl/template.h>
 #include <assert.h>
 #include <iostream>
 #include <set>

--- a/SofaKernel/modules/SofaSimpleFem/TetrahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/TetrahedronFEMForceField.inl
@@ -27,7 +27,6 @@
 #include <SofaBaseTopology/GridTopology.h>
 #include <sofa/simulation/Simulation.h>
 #include <sofa/helper/decompose.h>
-#include <sofa/helper/gl/template.h>
 #include <assert.h>
 #include <iostream>
 #include <set>

--- a/applications/plugins/Compliant/mapping/AdditionMapping.h
+++ b/applications/plugins/Compliant/mapping/AdditionMapping.h
@@ -127,7 +127,7 @@ class SOFA_Compliant_API AdditionMapping : public ConstantAssembledMapping<TIn, 
 
         if( scale < 0 ) return;
 
-        glEnable(GL_LIGHTING);
+        vparams->drawTool()->enableLighting();
 
         typename core::behavior::MechanicalState<TIn>::ReadVecCoord pos = this->getFromModel()->readPositions();
         const pairs_type& p = pairs.getValue();

--- a/applications/plugins/Compliant/mapping/DifferenceMapping.h
+++ b/applications/plugins/Compliant/mapping/DifferenceMapping.h
@@ -122,7 +122,7 @@ class SOFA_Compliant_API DifferenceMapping : public ConstantAssembledMapping<TIn
 
         if( scale < 0 ) return;
 
-        glEnable(GL_LIGHTING);
+        vparams->drawTool()->enableLighting();
 
         typename core::behavior::MechanicalState<TIn>::ReadVecCoord pos = this->getFromModel()->readPositions();
         const pairs_type& p = pairs.getValue();

--- a/applications/plugins/Compliant/mapping/SafeDistanceMapping.h
+++ b/applications/plugins/Compliant/mapping/SafeDistanceMapping.h
@@ -305,7 +305,7 @@ public:
 
         if( scale < 0 ) return;
 
-        glEnable(GL_LIGHTING);
+        vparams->drawTool()->enableLighting();
 
         typename core::behavior::MechanicalState<TIn>::ReadVecCoord pos = this->getFromModel()->readPositions();
         const pairs_type& p = d_pairs.getValue();
@@ -637,7 +637,7 @@ public:
 
         if( scale < 0 ) return;
 
-        glEnable(GL_LIGHTING);
+        vparams->drawTool()->enableLighting();
 
         typename core::behavior::MechanicalState<TIn>::ReadVecCoord pos = this->getFromModel()->readPositions();
         const helper::vector< unsigned >& indices = d_indices.getValue();

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaFixedTranslationConstraint.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaFixedTranslationConstraint.cpp
@@ -27,6 +27,8 @@
 
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/core/ObjectFactory.h>
+#include <sofa/helper/gl/template.h>
+
 namespace sofa
 {
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPenalityContactForceField.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPenalityContactForceField.inl
@@ -24,7 +24,7 @@
 
 #include "CudaPenalityContactForceField.h"
 #include <SofaObjectInteraction/PenalityContactForceField.inl>
-
+#include <sofa/helper/gl/template.h>
 
 namespace sofa
 {

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSPHFluidForceField.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSPHFluidForceField.inl
@@ -24,6 +24,7 @@
 
 #include "CudaSPHFluidForceField.h"
 #include <SofaSphFluid/SPHFluidForceField.inl>
+#include <sofa/helper/gl/template.h>
 //#include <sofa/gpu/cuda/CudaSpatialGridContainer.inl>
 
 namespace sofa

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaVisualModel.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaVisualModel.inl
@@ -318,7 +318,7 @@ void CudaVisualModel< TDataTypes >::internalDraw(const core::visual::VisualParam
     if (vparams->displayFlags().getShowWireFrame())
         glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
 
-    glEnable(GL_LIGHTING);
+    vparams->drawTool()->enableLighting();
 
     bool transparent = (matDiffuse.getValue()[3] < 1.0);
 

--- a/applications/plugins/image/ImageSampler.h
+++ b/applications/plugins/image/ImageSampler.h
@@ -654,7 +654,7 @@ protected:
             {
             case 1:
                 glPushAttrib(GL_LIGHTING_BIT);
-                glEnable(GL_LIGHTING);
+                vparams->drawTool()->enableLighting();
                 vparams->drawTool()->drawSpheres(this->position.getValue(),showSamplesScale.getValue(),defaulttype::Vec4f(0.1,0.7,0.1,1));
                 vparams->drawTool()->drawSpheres(this->fixedPosition.getValue(),showSamplesScale.getValue(),defaulttype::Vec4f(0.1,0.7,0.1,1));
                 glPopAttrib();

--- a/modules/SofaBoundaryCondition/BuoyantForceField.inl
+++ b/modules/SofaBoundaryCondition/BuoyantForceField.inl
@@ -379,17 +379,11 @@ int BuoyantForceField<DataTypes>::isTriangleInFluid(const Triangle &tri, const V
 template<class DataTypes>
 void BuoyantForceField<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
-#ifndef SOFA_NO_OPENGL
     if (!this->mstate) return;
 
-    glPushAttrib( GL_ALL_ATTRIB_BITS);
-
-
-    if (vparams->displayFlags().getShowWireFrame())
-        glPolygonMode(GL_FRONT, GL_LINE);
-
-    glDisable(GL_LIGHTING);
-
+    vparams->drawTool()->saveLastState();
+    vparams->drawTool()->setPolygonMode(1, vparams->displayFlags().getShowWireFrame());
+    vparams->drawTool()->disableLighting();
 
     if (m_showBoxOrPlane.getValue())
     {
@@ -398,78 +392,69 @@ void BuoyantForceField<DataTypes>::draw(const core::visual::VisualParams* vparam
 
         if ( fluidModel == AABOX)
         {
-            glLineWidth(5.0f);
-            glBegin(GL_LINE_LOOP);
-            glColor4f(0.f, 0.f, 1.0f, 1.f);
-            glVertex3d(min[0],min[1],min[2]);
-            glVertex3d(min[0],min[1],max[2]);
-            glVertex3d(min[0],max[1],max[2]);
-            glVertex3d(min[0],max[1],min[2]);
-            glEnd();
+            vparams->drawTool()->drawLineLoop({
+                {min[0], min[1], min[2]},
+                {min[0], min[1], max[2]},
+                {min[0], max[1], max[2]},
+                {min[0], max[1], min[2]}},
+                5.0f, {0.f, 0.f, 1.0f, 1.f});
 
-            glBegin(GL_LINE_LOOP);
-            glColor4f(0.f, 1.f, 1.0f, 1.f);
-            glVertex3d(min[0],max[1],min[2]);
-            glVertex3d(min[0],max[1],max[2]);
-            glVertex3d(max[0],max[1],max[2]);
-            glVertex3d(max[0],max[1],min[2]);
-            glEnd();
+            vparams->drawTool()->drawLineLoop({
+                {min[0], max[1], min[2]},
+                {min[0], max[1], max[2]},
+                {max[0], max[1], max[2]},
+                {max[0], max[1], min[2]}},
+                5.0f, {0.f, 1.f, 1.0f, 1.f});
 
-            glBegin(GL_LINE_LOOP);
-            glColor4f(1.f, 0.f, 1.0f, 1.f);
-            glVertex3d(min[0],min[1],max[2]);
-            glVertex3d(max[0],min[1],max[2]);
-            glVertex3d(max[0],max[1],max[2]);
-            glVertex3d(min[0],max[1],max[2]);
-            glEnd();
+            vparams->drawTool()->drawLineLoop(
+                {{min[0], min[1], max[2]},
+                {max[0], min[1], max[2]},
+                {max[0], max[1], max[2]},
+                {min[0], max[1], max[2]}},
+                5.f, {1.f, 0.f, 1.0f, 1.f});
 
-            glBegin(GL_LINE_LOOP);
-            glColor4f(1.f, 1.f, 1.0f, 1.f);
-            glVertex3d(max[0],min[1],min[2]);
-            glVertex3d(max[0],min[1],max[2]);
-            glVertex3d(max[0],max[1],max[2]);
-            glVertex3d(max[0],max[1],min[2]);
-            glEnd();
+            vparams->drawTool()->drawLineLoop(
+                {{max[0], min[1], min[2]},
+                {max[0], min[1], max[2]},
+                {max[0], max[1], max[2]},
+                {max[0], max[1], min[2]}},
+                5.0f, {1.f, 1.f, 1.0f, 1.f});
 
-            glBegin(GL_LINE_LOOP);
-            glColor4f(1.f, 0.f, 0.0f, 1.f);
-            glVertex3d(min[0],min[1],min[2]);
-            glVertex3d(min[0],min[1],max[2]);
-            glVertex3d(max[0],min[1],max[2]);
-            glVertex3d(max[0],min[1],min[2]);
-            glEnd();
+            vparams->drawTool()->drawLineLoop(
+                {{min[0],min[1],min[2]},
+                {min[0],min[1],max[2]},
+                {max[0],min[1],max[2]},
+                {max[0],min[1],min[2]}},
+                0.5f, {1.f, 0.f, 0.0f, 1.f});
 
-            glBegin(GL_LINE_LOOP);
-            glColor4f(1.f, 1.f, 0.0f, 1.f);
-            glVertex3d(min[0],min[1],min[2]);
-            glVertex3d(max[0],min[1],min[2]);
-            glVertex3d(max[0],max[1],min[2]);
-            glVertex3d(min[0],max[1],min[2]);
-            glEnd();
+            vparams->drawTool()->drawLineLoop(
+                {{min[0],min[1],min[2]},
+                {max[0],min[1],min[2]},
+                {max[0],max[1],min[2]},
+                {min[0],max[1],min[2]}},
+                5.0f, {1.f, 1.f, 0.0f, 1.f});
 
-            glColor4f(1.f, 0.f, 0.0f, 1.f);
-            glBegin(GL_LINES);
-            glVertex3d(m_fluidSurfaceOrigin[0],m_fluidSurfaceOrigin[1],m_fluidSurfaceOrigin[2]);
-            glVertex3d(m_fluidSurfaceOrigin[0] +m_fluidSurfaceDirection[0],
-                    m_fluidSurfaceOrigin[1] +m_fluidSurfaceDirection[1],
-                    m_fluidSurfaceOrigin[2] +m_fluidSurfaceDirection[2]);
-            glEnd();
+            vparams->drawTool()->drawLines(
+                {{m_fluidSurfaceOrigin[0],m_fluidSurfaceOrigin[1],m_fluidSurfaceOrigin[2]},
+                {m_fluidSurfaceOrigin[0] +m_fluidSurfaceDirection[0],
+                 m_fluidSurfaceOrigin[1] +m_fluidSurfaceDirection[1],
+                 m_fluidSurfaceOrigin[2] +m_fluidSurfaceDirection[2]}},
+                5.f, {1.f, 0.f, 0.0f, 1.f});
 
-            glColor4f(0.f, 1.f, 1.0f, 1.f);
 
-            glPointSize(10.0f);
-            glBegin(GL_POINTS);
-            glVertex3d(min[0],min[1],min[2]);
-            glVertex3d(max[0],min[1],min[2]);
-            glVertex3d(max[0],max[1],min[2]);
-            glVertex3d(min[0],max[1],min[2]);
-            glVertex3d(min[0],min[1],max[2]);
-            glVertex3d(max[0],min[1],max[2]);
-            glVertex3d(min[0],max[1],max[2]);
-            glVertex3d(max[0],max[1],max[2]);
-            glColor4f(1.f, 0.f, 0.0f, 1.f); glPointSize(20.0f);
-            glVertex3d(m_fluidSurfaceOrigin[0],m_fluidSurfaceOrigin[1],m_fluidSurfaceOrigin[2]);
-            glEnd();
+            vparams->drawTool()->drawPoints(
+                {{min[0],min[1],min[2]},
+                {max[0],min[1],min[2]},
+                {max[0],max[1],min[2]},
+                {min[0],max[1],min[2]},
+                {min[0],min[1],max[2]},
+                {max[0],min[1],max[2]},
+                {min[0],max[1],max[2]},
+                {max[0],max[1],max[2]}},
+                10.0f, {0.f, 1.f, 1.0f, 1.f});
+
+            vparams->drawTool()->drawPoints({{m_fluidSurfaceOrigin[0],m_fluidSurfaceOrigin[1],m_fluidSurfaceOrigin[2]}},
+                                            20.0f, {1.f, 0.f, 0.0f, 1.f});
         }
         else if (fluidModel == PLANE)
         {
@@ -525,20 +510,16 @@ void BuoyantForceField<DataTypes>::draw(const core::visual::VisualParams* vparam
                 }
 
                 //disable depth test to draw transparency
-                glDisable(GL_DEPTH_TEST);
+                vparams->drawTool()->disableDepthTest();
+                vparams->drawTool()->enableBlending();
 
-                glEnable (GL_BLEND);
-                glBlendFunc (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+                vparams->drawTool()->drawQuads(
+                {{firstPoint[0],firstPoint[1],firstPoint[2]},
+                 {secondPoint[0],secondPoint[1],secondPoint[2]},
+                 {thirdPoint[0],thirdPoint[1],thirdPoint[2]},
+                 {fourthPoint[0],fourthPoint[1],fourthPoint[2]}}, {1.f, 1.f, 1.0f, 0.2f});
 
-                glBegin(GL_QUADS);
-                glColor4f(1.f, 1.f, 1.0f, 0.2f);
-                glVertex3d(firstPoint[0],firstPoint[1],firstPoint[2]);
-                glVertex3d(secondPoint[0],secondPoint[1],secondPoint[2]);
-                glVertex3d(thirdPoint[0],thirdPoint[1],thirdPoint[2]);
-                glVertex3d(fourthPoint[0],fourthPoint[1],fourthPoint[2]);
-                glEnd();
-
-                glEnable(GL_DEPTH_TEST);
+                vparams->drawTool()->enableDepthTest();
             }
         }
     }
@@ -549,167 +530,31 @@ void BuoyantForceField<DataTypes>::draw(const core::visual::VisualParams* vparam
         {
             if (this->m_showPressureForces.getValue())
             {
-                glColor4f(1.f, 0.f, 0.0f, 1.0f);
+                sofa::helper::vector<sofa::defaulttype::Vector3> lines;
 
-                glBegin(GL_LINES);
                 for ( unsigned int i = 0 ; i < m_showPosition.size() ; i++)
                 {
-                    glVertex3d(m_showPosition[i][0], m_showPosition[i][1], m_showPosition[i][2]);
-                    glVertex3d(m_showPosition[i][0] - m_showForce[i][0]*m_showFactorSize.getValue(), m_showPosition[i][1] -  m_showForce[i][1]*m_showFactorSize.getValue(), m_showPosition[i][2] - m_showForce[i][2]*m_showFactorSize.getValue());
+                    lines.push_back({m_showPosition[i][0], m_showPosition[i][1], m_showPosition[i][2]});
+                    lines.push_back({m_showPosition[i][0] - m_showForce[i][0]*m_showFactorSize.getValue(), m_showPosition[i][1] -  m_showForce[i][1]*m_showFactorSize.getValue(), m_showPosition[i][2] - m_showForce[i][2]*m_showFactorSize.getValue()});
                 }
-                glEnd();
+
+                vparams->drawTool()->drawLines(lines, 1.f, {1.f, 0.f, 0.0f, 1.0f});
             }
             if (this->m_showViscosityForces.getValue())
             {
-                glColor4f(0.f, 1.f, 1.0f, 1.0f);
+                sofa::helper::vector<sofa::defaulttype::Vector3> lines;
 
-                glBegin(GL_LINES);
                 for ( unsigned int i = 0 ; i < m_showPosition.size() ; i++)
                 {
-                    glVertex3d(m_showPosition[i][0], m_showPosition[i][1], m_showPosition[i][2]);
-                    glVertex3d(m_showPosition[i][0] - m_showViscosityForce[i][0]*m_showFactorSize.getValue(), m_showPosition[i][1] -  m_showViscosityForce[i][1]*m_showFactorSize.getValue(), m_showPosition[i][2] - m_showViscosityForce[i][2]*m_showFactorSize.getValue());
+                    lines.push_back({m_showPosition[i][0], m_showPosition[i][1], m_showPosition[i][2]});
+                    lines.push_back({m_showPosition[i][0] - m_showViscosityForce[i][0]*m_showFactorSize.getValue(), m_showPosition[i][1] -  m_showViscosityForce[i][1]*m_showFactorSize.getValue(), m_showPosition[i][2] - m_showViscosityForce[i][2]*m_showFactorSize.getValue()});
                 }
-                glEnd();
+                vparams->drawTool()->drawLines(lines, 1.f, {0.f, 1.f, 1.0f, 1.0f});
             }
         }
 
-    glPopAttrib();
-#endif /* SOFA_NO_OPENGL */
+    vparams->drawTool()->restoreLastState();
 }
-
-
-/*  OLD IMPLEMENTATION
-
- compute the immersed volume but maybe useless
- Real immersedVolume = static_cast<Real>(0.0f);
- for (int i = 0 ; i < m_topology->getNbTetrahedra() ; i++)
- {
-     Tetra tetra = m_tetraContainer->getTetra(i);
-     int nbPointsInside = isTetraInFluid(tetra, x);
-
-     if ( nbPointsInside > 0)
-     {
-       immersedVolume += m_tetraGeo->computeTetrahedronVolume(i);
-     }
- }
- m_immersedVolume.setValue(immersedVolume);
-           std::cout << "Immersed Volume >> " << m_immersedVolume.getValue() << std::endl;
-
-
-
-template <class DataTypes>
-int BuoyantForceField<DataTypes>::isTetraInFluid(const Tetra &tetra, const VecCoord& x)
-{
-    int nbPointsInFluid = 0;
-
-    for (unsigned int i = 0 ; i < 4 ; i++)
-    {
-        if (isPointInFluid(x[ tetra[i] ] )  )
-        {
-            nbPointsInFluid++;
-        }
-    }
-
-    return nbPointsInFluid;
-}
-
-template <class DataTypes>
-bool BuoyantForceField<DataTypes>::isCornerInTetra(const Tetra &tetra, const VecCoord& x) const
-{
-        if ( fluidModel == AABOX)
-        {
-        Deriv a = x[tetra[0]];
-        Deriv b = x[tetra[ (0 + 1)%4 ]];
-        Deriv c = x[tetra[ (0 + 2)%4 ]];
-        Deriv d = x[tetra[ (0 + 3)%4 ]];
-
-        Deriv ab = b - a;
-        Deriv ac = c - a;
-        Deriv ad = d - a;
-
-        for ( int i = 0 ; i < 1 ; i++)
-        {
-            for (int j = 0 ; j < 1 ; j++)
-            {
-                for (int k = 0 ; k < 1 ; k++)
-                {
-                    Deriv corner(
-                            i%2 ? m_minBox.getValue()[0] : m_maxBox.getValue()[0],
-                            j%2 ? m_minBox.getValue()[1] : m_maxBox.getValue()[1],
-                            k%2 ? m_minBox.getValue()[2] : m_maxBox.getValue()[2]
-                            );
-
-                    Real c0 = dot(ab.cross(ac), corner - a);
-                    Real c1 = dot((c-b).cross(b-d), corner - b);
-                    Real c2 = dot((b-a).cross(d-a), corner - a);
-                    Real c3 = dot((c-a).cross(d-a), corner - a);
-
-                    if ( c0 < 0 || c1 < 0 || c2 < 0 || c3 < 0 )
-                    {
-                        return true;
-                    }
-                }
-            }
-        }
-        }
-        return false;
-}
-
-template <class DataTypes>
-typename BuoyantForceField<DataTypes>::Real BuoyantForceField<DataTypes>::getImmersedVolume(const Tetra &tetra, const VecCoord& x)
-{
-    Real immersedVolume = static_cast<Real>(0.f);
-
-    int nbPointsInside = isTetraInFluid(tetra, x);
-
-    if ( nbPointsInside > 0)
-    {
-        //the whole tetra is in the fluid
-        if ( nbPointsInside == 4)
-        {
-
-            int index = m_topology->getTetrahedronIndex(tetra[0], tetra[1], tetra[2], tetra[3]);
-//            Deriv ab = x[tetra[1]] - x[tetra[0]];
-//            Deriv ac = x[tetra[2]] - x[tetra[0]];
-//            Deriv ad = x[tetra[3]] - x[tetra[0]];
-
-            return m_tetraGeo->computeTetrahedronVolume(index);
-        }
-        //the tetra is partially in the fluid
-//        else if ( nbPointsInside < 4)
-//        {
-//            int firstPointInside = 0;
-//
-//            //find the first point which is in the fluid
-//            for ( int i = 0 ; i < 4 ; i++)
-//            {
-//                if (isPointInFluid(x[ tetra[i] ] )  )
-//                {
-//                    firstPointInside = i;
-//                    break;
-//                }
-//            }
-//
-//            Deriv a = x[tetra[ firstPointInside ] ];
-//            Deriv b = x[tetra[ (firstPointInside + 1)%4 ]];
-//            Deriv c = x[tetra[ (firstPointInside + 2)%4 ]];
-//            Deriv d = x[tetra[ (firstPointInside + 3)%4 ]];
-//
-//            //check if a corner of the box (fluid) is inside the tetrahedron
-//            if ( isCornerInTetra(tetra, x))
-//            {
-//                //then a corner of the box (fluid) is in a tetrahedron and it's a annoying
-//                return 0.f;
-//            }
-
-            return immersedVolume;
-
-//        }
-    }
-
-    return immersedVolume;
-}*/
-
 
 
 } // namespace forcefield

--- a/modules/SofaBoundaryCondition/FixedPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/FixedPlaneConstraint.inl
@@ -259,19 +259,17 @@ void FixedPlaneConstraint<DataTypes>::init()
 template <class DataTypes>
 void FixedPlaneConstraint<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
-#ifndef SOFA_NO_OPENGL
     if (!vparams->displayFlags().getShowBehaviorModels()) return;
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
-    glDisable (GL_LIGHTING);
-    glPointSize(10);
-    glColor4f (1,1.0,0.5,1);
-    glBegin (GL_POINTS);
+    vparams->drawTool()->disableLighting();
+
+    sofa::helper::vector<sofa::defaulttype::Vector3> points;
     for (helper::vector< unsigned int >::const_iterator it = this->indices.getValue().begin(); it != this->indices.getValue().end(); ++it)
     {
-        helper::gl::glVertexT(x[*it]);
+        points.push_back({x[*it][0], x[*it][1], x[*it][2]});
     }
-    glEnd();
-#endif /* SOFA_NO_OPENGL */
+
+    vparams->drawTool()->drawPoints(points, 10, {1,1.0,0.5,1});
 }
 
 } // namespace constraint

--- a/modules/SofaMiscMapping/BarycentricMappingRigid.inl
+++ b/modules/SofaMiscMapping/BarycentricMappingRigid.inl
@@ -421,7 +421,6 @@ void BarycentricMapperTetrahedronSetTopologyRigid<In,Out>::applyJT ( typename In
 template <class In, class Out>
 void BarycentricMapperTetrahedronSetTopologyRigid<In,Out>::draw  (const core::visual::VisualParams* vparams,const typename Out::VecCoord& out, const typename In::VecCoord& in )
 {
-#ifndef SOFA_NO_OPENGL
     const sofa::helper::vector<core::topology::BaseMeshTopology::Tetrahedron>& tetrahedra = this->fromTopology->getTetrahedra();
     const sofa::helper::vector<MappingData >& map = this->map.getValue();
     // TODO(dmarchal 2017-05-03) who do it & when it will be done. Otherwise I will delete that one day.
@@ -455,6 +454,10 @@ void BarycentricMapperTetrahedronSetTopologyRigid<In,Out>::draw  (const core::vi
     }
     vparams->drawTool()->drawLines ( points, 1, sofa::defaulttype::Vec<4,float> ( 0,1,0,1 ) );
 
+    points.clear();
+    std::vector< sofa::defaulttype::Vector3 > tetraPoints;
+    std::vector< sofa::defaulttype::Vector3 > tetraLines;
+
     for ( unsigned int i=0; i<map.size(); i++ )
     {
         //get velocity of the DoF
@@ -478,39 +481,25 @@ void BarycentricMapperTetrahedronSetTopologyRigid<In,Out>::draw  (const core::vi
         //for (unsigned int ti = 0; ti<4; ti++)
         //    out[tetra[ti]] -= cross(actualTetraPosition[tetra[ti]],torque);
         //}
-
         for (size_t i = 0; i < actualPos.size(); i++)
-        {
-            glPointSize(10);
-            glColor3d(1.0,0,0.0);
-            glBegin(GL_POINTS);
-            helper::gl::glVertexT(actualPos[i]);
-            glEnd();
-        }
-
+            points.push_back(sofa::defaulttype::Vector3(actualPos[i][0],actualPos[i][1],actualPos[i][2]));
 
         for (unsigned int ti = 0; ti<4; ti++)
         {
-            glPointSize(10);
-            glColor3d(1.0,0,1.0);
-            glBegin(GL_POINTS);
-            helper::gl::glVertexT(actualTetraPosition[tetra[ti]]);
-            glEnd();
+            const typename In::Coord& tp0 = actualTetraPosition[tetra[ti]];
+            typename In::Coord tp1 = actualTetraPosition[tetra[ti]]+actualOut[tetra[ti]];
 
+            tetraPoints.push_back(sofa::defaulttype::Vector3(tp0[0],tp0[1],tp0[2]));
 
-            if (tetra[ti] < actualOut.size())
-            {
-                glLineWidth(3.0);
-                glBegin(GL_LINES);
-                helper::gl::glVertexT(actualTetraPosition[tetra[ti]]);
-                helper::gl::glVertexT(actualTetraPosition[tetra[ti]]+actualOut[tetra[ti]]);
-                glEnd();
-            }
-
+            tetraLines.push_back(sofa::defaulttype::Vector3(tp0[0],tp0[1],tp0[2]));
+            tetraLines.push_back(sofa::defaulttype::Vector3(tp1[0],tp1[1],tp1[2]));
         }
-        glEnd();
+
+        vparams->drawTool()->drawPoints ( points, 10, sofa::defaulttype::Vec<4,float> ( 1,0,0,1 ) );
+        vparams->drawTool()->drawPoints ( tetraPoints, 10, sofa::defaulttype::Vec<4,float> ( 1,0,1,1 ) );
+        vparams->drawTool()->drawLines ( tetraLines, 3.0, sofa::defaulttype::Vec<4,float> ( 1,0,1,1 ) );
+
     }
-#endif /* SOFA_NO_OPENGL */
 }
 
 } // namespace mapping


### PR DESCRIPTION
There should be no more calls of OpenGL API in SofaKernel's modules.
Clean gl's related includes as well.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
