### PR TITLE
[all] template alias sptr for downsizing the include graph

### DIFF
--- a/SofaKernel/framework/sofa/core/objectmodel/AspectPool.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/AspectPool.h
@@ -27,7 +27,8 @@
 #include <sofa/helper/system/atomic.h>
 #include <sofa/helper/system/thread/CircularQueue.h>
 #include <sofa/helper/vector.h>
-#include <boost/intrusive_ptr.hpp>
+#include <sofa/core/sptr.h>
+
 #include <functional>
 
 namespace sofa
@@ -42,7 +43,9 @@ namespace objectmodel
 class Aspect;
 class AspectPool;
 class AspectBuffer;
-typedef boost::intrusive_ptr<Aspect> AspectRef;
+
+using AspectRef = sptr<Aspect>;
+
 SOFA_CORE_API void intrusive_ptr_add_ref(Aspect* b);
 SOFA_CORE_API void intrusive_ptr_release(Aspect* b);
 

--- a/SofaKernel/framework/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/Base.h
@@ -35,7 +35,7 @@
 #include <sofa/core/objectmodel/BaseObjectDescription.h>
 #include <sofa/core/objectmodel/Tag.h>
 
-#include <boost/intrusive_ptr.hpp>
+#include <sofa/core/sptr.h>
 
 #include <deque>
 #include <string>
@@ -133,8 +133,9 @@ class SOFA_CORE_API Base
 public:
 
     typedef Base* Ptr;
-    typedef boost::intrusive_ptr<Base> SPtr;
 
+    using SPtr = sptr<Base>;
+    
     typedef TClass< Base, void > MyClass;
     static const MyClass* GetClass() { return MyClass::get(); }
     virtual const BaseClass* getClass() const { return GetClass(); }

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseClass.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseClass.h
@@ -269,7 +269,7 @@ public:
 // Do not use this macro directly, use SOFA_ABSTRACT_CLASS instead
 #define SOFA_ABSTRACT_CLASS_DECL                                        \
     typedef MyType* Ptr;                                                \
-    typedef boost::intrusive_ptr<MyType> SPtr;                          \
+    using SPtr = sofa::core::sptr<MyType>;                              \
                                                                         \
     static const MyClass* GetClass() { return MyClass::get(); }         \
     virtual const ::sofa::core::objectmodel::BaseClass* getClass() const \

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseContext.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseContext.h
@@ -258,7 +258,7 @@ public:
 
     /// Generic object access template wrapper, possibly searching up or down from the current context
     template<class T>
-    void get(boost::intrusive_ptr<T>& ptr, SearchDirection dir = SearchUp) const
+    void get(sptr<T>& ptr, SearchDirection dir = SearchUp) const
     {
         ptr = this->get<T>(dir);
     }
@@ -279,7 +279,7 @@ public:
 
     /// Generic object access template wrapper, given a required tag, possibly searching up or down from the current context
     template<class T>
-    void get(boost::intrusive_ptr<T>& ptr, const Tag& tag, SearchDirection dir = SearchUp) const
+    void get(sptr<T>& ptr, const Tag& tag, SearchDirection dir = SearchUp) const
     {
         ptr = this->get<T>(tag, dir);
     }
@@ -300,7 +300,7 @@ public:
 
     /// Generic object access template wrapper, given a set of required tags, possibly searching up or down from the current context
     template<class T>
-    void get(boost::intrusive_ptr<T>& ptr, const TagSet& tags, SearchDirection dir = SearchUp) const
+    void get(sptr<T>& ptr, const TagSet& tags, SearchDirection dir = SearchUp) const
     {
         ptr = this->get<T>(tags, dir);
     }
@@ -321,7 +321,7 @@ public:
 
     /// Generic object access template wrapper, given a path from the current context
     template<class T>
-    void get(boost::intrusive_ptr<T>& ptr, const std::string& path) const
+    void get(sptr<T>& ptr, const std::string& path) const
     {
         ptr = this->get<T>(path);
     }
@@ -428,13 +428,13 @@ public:
     /// @{
 
     /// Add an object, or return false if not supported
-    virtual bool addObject( boost::intrusive_ptr<BaseObject> /*obj*/ )
+    virtual bool addObject( sptr<BaseObject> /*obj*/ )
     {
         return false;
     }
 
     /// Remove an object, or return false if not supported
-    virtual bool removeObject( boost::intrusive_ptr<BaseObject> /*obj*/ )
+    virtual bool removeObject( sptr<BaseObject> /*obj*/ )
     {
         return false;
     }

--- a/SofaKernel/framework/sofa/core/objectmodel/SPtr.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/SPtr.h
@@ -50,31 +50,11 @@ namespace objectmodel
  *
  */
 template<class T>
-class New : public T::SPtr
-{
+class New : public T::SPtr {
     typedef typename T::SPtr SPtr;
 public:
-    New() : SPtr(new T) {}
-    template <class A1>
-    New(A1 a1) : SPtr(new T(a1)) {}
-    template <class A1, class A2>
-    New(A1 a1, A2 a2) : SPtr(new T(a1,a2)) {}
-    template <class A1, class A2, class A3>
-    New(A1 a1, A2 a2, A3 a3) : SPtr(new T(a1,a2,a3)) {}
-    template <class A1, class A2, class A3, class A4>
-    New(A1 a1, A2 a2, A3 a3, A4 a4) : SPtr(new T(a1,a2,a3,a4)) {}
-    template <class A1, class A2, class A3, class A4, class A5>
-    New(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5) : SPtr(new T(a1,a2,a3,a4,a5)) {}
-    template <class A1, class A2, class A3, class A4, class A5, class A6>
-    New(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6) : SPtr(new T(a1,a2,a3,a4,a5,a6)) {}
-    template <class A1, class A2, class A3, class A4, class A5, class A6, class A7>
-    New(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7) : SPtr(new T(a1,a2,a3,a4,a5,a6,a7)) {}
-    template <class A1, class A2, class A3, class A4, class A5, class A6, class A7, class A8>
-    New(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8) : SPtr(new T(a1,a2,a3,a4,a5,a6,a7,a8)) {}
-    template <class A1, class A2, class A3, class A4, class A5, class A6, class A7, class A8, class A9>
-    New(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9) : SPtr(new T(a1,a2,a3,a4,a5,a6,a7,a8,a9)) {}
-    template <class A1, class A2, class A3, class A4, class A5, class A6, class A7, class A8, class A9, class A10>
-    New(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9, A10 a10) : SPtr(new T(a1,a2,a3,a4,a5,a6,a7,a8,a9,a10)) {}
+    template<class ... Args>
+    New(Args&& ... args) : SPtr( new T(std::forward<Args>(args)...) ) { }
 };
 
 /// dynamic_cast operator for SPtr

--- a/SofaKernel/framework/sofa/core/sptr.h
+++ b/SofaKernel/framework/sofa/core/sptr.h
@@ -1,0 +1,17 @@
+#ifndef SOFA_CORE_SPTR_H
+#define SOFA_CORE_SPTR_H
+
+#include <boost/intrusive_ptr.hpp>
+
+namespace sofa {
+
+namespace core {
+
+template<class T>
+using sptr = boost::intrusive_ptr<T>;
+
+}
+}
+ 
+
+#endif

--- a/applications/plugins/Compliant/odesolver/CompliantImplicitSolver.cpp
+++ b/applications/plugins/Compliant/odesolver/CompliantImplicitSolver.cpp
@@ -3,8 +3,9 @@
 #include <SofaEigen2Solver/EigenSparseMatrix.h>
 #include <sofa/core/ObjectFactory.h>
 
-#include "../assembly/AssemblyVisitor.h"
-#include "../utils/scoped.h"
+#include <Compliant/assembly/AssemblyVisitor.h>
+#include <Compliant/utils/scoped.h>
+#include <Compliant/numericalsolver/KKTSolver.h>
 
 namespace sofa {
 namespace component {

--- a/applications/plugins/Compliant/odesolver/CompliantImplicitSolver.h
+++ b/applications/plugins/Compliant/odesolver/CompliantImplicitSolver.h
@@ -11,8 +11,7 @@
 #include <sofa/simulation/MechanicalOperations.h>
 #include <sofa/simulation/VectorOperations.h>
 
-// TODO forward instead ?
-#include "../numericalsolver/KKTSolver.h"
+#include <Compliant/assembly/AssembledSystem.h>
 
 #include <sofa/helper/OptionsGroup.h>
 
@@ -34,6 +33,7 @@ namespace component {
 
 namespace linearsolver {
 class AssembledSystem;
+class KKTSolver;
 }
 
 
@@ -228,7 +228,7 @@ class SOFA_Compliant_API CompliantImplicitSolver : public sofa::core::behavior::
 	
 	// linear solver: TODO hide in pimpl ?
 	typedef linearsolver::KKTSolver kkt_type;
-	kkt_type::SPtr kkt;
+    core::sptr<kkt_type> kkt;
 
 
 

--- a/applications/plugins/Compliant/odesolver/CompliantNLImplicitSolver.cpp
+++ b/applications/plugins/Compliant/odesolver/CompliantNLImplicitSolver.cpp
@@ -2,13 +2,12 @@
 
 #include <sofa/core/ObjectFactory.h>
 
-#include "../assembly/AssemblyVisitor.h"
-#include "../utils/scoped.h"
+#include <Compliant/assembly/AssemblyVisitor.h>
+#include <Compliant/utils/scoped.h>
+#include <Compliant/numericalsolver/KKTSolver.h>
 
 using std::cerr;
 using std::endl;
-
-
 
 namespace sofa {
 namespace component {

--- a/applications/plugins/SofaPython/Binding_BaseContext.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseContext.cpp
@@ -366,7 +366,7 @@ static PyObject * BaseContext_getObjects(PyObject * self, PyObject * args)
         }
     }
 
-    sofa::helper::vector< boost::intrusive_ptr<BaseObject> > list;
+    sofa::helper::vector< BaseObject::SPtr > list;
     context->get<BaseObject>(&list,search_direction_enum);
 
     PyObject *pyList = PyList_New(0);

--- a/applications/plugins/SofaPython/PythonCommon.h
+++ b/applications/plugins/SofaPython/PythonCommon.h
@@ -9,8 +9,9 @@
 // standard headers on some systems, you must include Python.h before any
 // standard headers are included."
 #if defined(_MSC_VER)
-// intrusive_ptr.hpp has to be ahead of python.h on windows to support debug compilation.
-#include <boost/intrusive_ptr.hpp>
+// intrusive_ptr.hpp has to be ahead of python.h on windows to support debug
+// compilation.
+#include <sofa/core/sptr.h>
 
 // undefine _DEBUG since we want to always link to the release version of
 // python and pyconfig.h automatically links debug version if _DEBUG is

--- a/applications/plugins/SofaPython/PythonMacros.h
+++ b/applications/plugins/SofaPython/PythonMacros.h
@@ -27,7 +27,7 @@
 #include <sofa/config.h>
 
 #include "PythonCommon.h"
-#include <boost/intrusive_ptr.hpp>
+#include <sofa/core/sptr.h>
 
 #include <sofa/core/objectmodel/Base.h>
 #include <sofa/core/objectmodel/BaseObject.h>
@@ -83,7 +83,8 @@ template <class T>
 struct PySPtr
 {
     PyObject_HEAD
-    boost::intrusive_ptr<T> object;
+    sofa::core::sptr<T> object;
+    
 //    PySPtr()        { object=0; }
 //    PySPtr(T *obj)  { object=obj; }
 


### PR DESCRIPTION
This PR simply introduces the template alias:

```c++ 
sofa::core::sptr<T> = boost::intrusive_ptr<T>;
```
in `<sofa/core/sptr.h>` and reflects the needed changes in the codebase.

# Motivation

Most (all?) component types in SOFA come with a member typename `T::SPtr` referring to `boost::intrusive_ptr<T>`, which makes it impossible to declare a member shared pointer to another component without including the component header file.

In an effort to decrease compilation times by removing unneeded include files, this PR introduces a template alias to solve this problem. It is now possible to declare member shared pointers using a forward declaration of their types only, as shown in 48f1447.

# Changelog

- added `sofa::core::sptr<T>` template alias
- reflected changes in BaseClass macros, Base and Aspects
- replaced many constructors in `New` with variadic templates
- added an example include fix in `Compliant`

# Note

This PR is *not* intended to be a place for fixing every member SPtr + includes, otherwise it will never get merged. 

If we can agree on the PR's philosophy and get it merged, please make separate PRs for include simplifications.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
