### PR TITLE
Add stop in add_mbktomatrixVisitor

### DIFF
--- a/SofaKernel/framework/sofa/simulation/MechanicalMatrixVisitor.h
+++ b/SofaKernel/framework/sofa/simulation/MechanicalMatrixVisitor.h
@@ -214,9 +214,10 @@ public:
         return RESULT_CONTINUE;
     }
 
-    virtual bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map)
+    virtual bool stopAtMechanicalMapping(simulation::Node* node, core::BaseMapping* map)
     {
-        return !map->f_mapMatrices.getValue();
+        SOFA_UNUSED(node);
+        return !map->areMatricesMapped();
     }
 };
 

--- a/SofaKernel/framework/sofa/simulation/MechanicalMatrixVisitor.h
+++ b/SofaKernel/framework/sofa/simulation/MechanicalMatrixVisitor.h
@@ -213,6 +213,11 @@ public:
 
         return RESULT_CONTINUE;
     }
+
+    virtual bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map)
+    {
+        return !map->f_mapMatrices.getValue();
+    }
 };
 
 /** Accumulate the entries of a mechanical matrix (mass or stiffness) of the whole scene ONLY ON THE subMatrixIndex */

--- a/applications/plugins/CMakeLists.txt
+++ b/applications/plugins/CMakeLists.txt
@@ -42,9 +42,9 @@ sofa_add_plugin(LeapMotion LeapMotion)
 sofa_add_plugin(Geomagic Geomagic)
 sofa_add_plugin(CImgPlugin CImgPlugin ON) # ON by default
 
-#if((${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") AND (${CMAKE_SYSTEM_NAME} MATCHES "Linux"))
-#    sofa_add_plugin(SofaPardisoSolver SofaPardisoSolver) # SofaPardisoSolver is only available under linux with gcc
-#endif()
+if((${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") AND (${CMAKE_SYSTEM_NAME} MATCHES "Linux"))
+    sofa_add_plugin(SofaPardisoSolver SofaPardisoSolver) # SofaPardisoSolver is only available under linux with gcc
+endif()
 
 if(${SOFA_NO_OPENGL})
     message("SOFA_NO_OPENGL flag prevents from using the SofaCUDA, SofaSimpleGUI and VolumetricRendering plugins")

--- a/applications/plugins/SofaPardisoSolver/SparsePARDISOSolver.h
+++ b/applications/plugins/SofaPardisoSolver/SparsePARDISOSolver.h
@@ -33,6 +33,7 @@
 #include <assert.h>
 #include <float.h>
 #include <stdlib.h>
+#include <fstream>
 
 namespace sofa
 {


### PR DESCRIPTION
Adds a stop when the visitor encounters a mapping



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
