### PR TITLE
[SofaKernel] FIX don't inline exported functions

### DIFF
--- a/SofaKernel/framework/sofa/core/objectmodel/Data.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/Data.cpp
@@ -34,7 +34,6 @@ namespace objectmodel
 
 /// Specialization for reading strings
 template<>
-inline
 bool SOFA_CORE_API TData<std::string>::read( const std::string& str )
 {
     virtualSetValue(str);
@@ -43,7 +42,6 @@ bool SOFA_CORE_API TData<std::string>::read( const std::string& str )
 
 /// Specialization for reading booleans
 template<>
-inline
 bool SOFA_CORE_API TData<bool>::read( const std::string& str )
 {
     if (str.empty())


### PR DESCRIPTION
We had some errors while compiling sofa 17.06 on macos with Apple LLVM 9.0.
This was caused by two oddly inlined functions.

So here's a PR removing the inline declaration.
We hope it'll be useful.

Cheers.
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
