### PR TITLE
[SofaHelper] remove libpng pragma link directive

### DIFF
--- a/SofaKernel/framework/sofa/helper/io/ImagePNG.cpp
+++ b/SofaKernel/framework/sofa/helper/io/ImagePNG.cpp
@@ -26,15 +26,6 @@
 
 #ifdef SOFA_HAVE_PNG
 #include <png.h>
-#ifdef _MSC_VER
-#ifdef _DEBUG
-#pragma comment(lib,"libpngd.lib")
-#pragma comment(lib,"zlibd.lib")
-#else
-#pragma comment(lib,"libpng.lib")
-#pragma comment(lib,"zlib.lib")
-#endif
-#endif
 #endif
 
 #if PNG_LIBPNG_VER >= 10209


### PR DESCRIPTION
 UPDATE: SofaHelper compilation with msvc. libpng should not be forced
to be linked using pragma directive. The name of the library may vary,
and it the debug version may well not be available, and its
unavailability should not break the debug build.

I fell in the same problem as the one mentionned in issue #443 while compiling
with msvc in debug, without having on my system a version of the libpng 
library called "libpngd.lib"




______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
