### PR TITLE
[SofaKernel extlibs] Warning fix with eigen when compiling with msvc

### DIFF
--- a/SofaKernel/extlibs/eigen-3.2.7/Eigen/src/Core/Functors.h
+++ b/SofaKernel/extlibs/eigen-3.2.7/Eigen/src/Core/Functors.h
@@ -10,9 +10,10 @@
 #ifndef EIGEN_FUNCTORS_H
 #define EIGEN_FUNCTORS_H
 
+#ifndef WIN32
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations" // deprecated std::binder1st and std::binder2nd
-
+#endif // WIN32
 
 
 namespace Eigen {
@@ -1028,6 +1029,8 @@ struct functor_traits<std::binary_compose<T0,T1,T2> >
 
 } // end namespace Eigen
 
+#ifndef WIN32
 #pragma GCC diagnostic pop
+#endif // WIN32 
 
 #endif // EIGEN_FUNCTORS_H

--- a/SofaKernel/extlibs/eigen-3.2.7/Eigen/src/Core/Functors.h
+++ b/SofaKernel/extlibs/eigen-3.2.7/Eigen/src/Core/Functors.h
@@ -10,10 +10,10 @@
 #ifndef EIGEN_FUNCTORS_H
 #define EIGEN_FUNCTORS_H
 
-#ifndef WIN32
+#ifdef GNUC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations" // deprecated std::binder1st and std::binder2nd
-#endif // WIN32
+#endif // GNUC
 
 
 namespace Eigen {
@@ -1029,8 +1029,8 @@ struct functor_traits<std::binary_compose<T0,T1,T2> >
 
 } // end namespace Eigen
 
-#ifndef WIN32
+#ifdef GNUC
 #pragma GCC diagnostic pop
-#endif // WIN32 
+#endif // GNUC 
 
 #endif // EIGEN_FUNCTORS_H


### PR DESCRIPTION
Some pragma directive were introduced by 4548ab474f89a229f
but they work only with gcc, and generate some warnings with 
other compilers, at least msvc based on my own experience.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
