### PR TITLE
[SofaHelper] FileMonitor_windows compilation

### DIFF
--- a/SofaKernel/framework/sofa/helper/system/FileMonitor_windows.cpp
+++ b/SofaKernel/framework/sofa/helper/system/FileMonitor_windows.cpp
@@ -37,7 +37,6 @@ using namespace std;
 //////////////////// Windows Header ///////////////////////////////////////////////
 #include <windows.h>
 #include <FileAPI.h>
-#include <cstringt.h>
 
 namespace sofa
 {


### PR DESCRIPTION
I do not have cstringt.h on my system, and it does not seem to be a requirement to build
FileMonitor_windows.cpp 
Any thoughts about this ?

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
