### PR TITLE
[SofaCore] Add some read/write free method to construct Data Read/WriteAccessor

### DIFF
--- a/SofaKernel/framework/sofa/core/objectmodel/Data.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/Data.h
@@ -687,7 +687,31 @@ public:
 
 /// Easy syntax for getting read/write access to a Data using operator ->. Example: write(someFlagData)->setFlagValue(true);
 template<class T>
-inline WriteAccessor<core::objectmodel::Data<T> > write(core::objectmodel::Data<T>& data) { return WriteAccessor<core::objectmodel::Data<T> >(data); }
+inline WriteAccessor<core::objectmodel::Data<T> > write(core::objectmodel::Data<T>& data, const core::ExecParams* params)
+{
+    return WriteAccessor<core::objectmodel::Data<T> >(params,data);
+}
+
+
+template<class T>
+inline WriteAccessor<core::objectmodel::Data<T> > write(core::objectmodel::Data<T>& data) 
+{ 
+    return write(data,sofa::core::ExecParams::defaultInstance() ); 
+}
+
+
+template<class T>
+inline ReadAccessor<core::objectmodel::Data<T> > read(const core::objectmodel::Data<T>& data, const core::ExecParams* params)
+{
+    return ReadAccessor<core::objectmodel::Data<T> >(params, data);
+}
+
+
+template<class T>
+inline ReadAccessor<core::objectmodel::Data<T> > read(core::objectmodel::Data<T>& data)
+{
+    return read(data, sofa::core::ExecParams::defaultInstance());
+}
 
 /// Easy syntax for getting write only access to a Data using operator ->. Example: writeOnly(someFlagData)->setFlagValue(true);
 template<class T>


### PR DESCRIPTION
This PR adds some read/write access method for Data which can shorten slightly the syntax 
required when you want to construct a Read(Write)Accessor object for a Data. 
It extends the method implemented in commit 77ca6f2a7c2cf18a39cdad6a4a88f02ed6d9a9dd
for WriteOnlyAccessor to other types of Data Accessor.
 
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
