### PR TITLE
[runSofa] FIX plugin config copy on Windows

### DIFF
--- a/applications/projects/runSofa/cmake/GeneratePluginConfig.cmake
+++ b/applications/projects/runSofa/cmake/GeneratePluginConfig.cmake
@@ -29,10 +29,10 @@ macro(sofa_generate_plugin_config config_filename)
 	# only useful for devs working directly with a build version (not installed)
 	# With Win/MVSC, we can only know $CONFIG at build time
 	if (MSVC)
-	    add_custom_target(do_always ALL 
-	    COMMAND if exist "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/"
-            "${CMAKE_COMMAND}" -E copy "${config_filename}" "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/"
-	)
-	endif(MSVC)
+        add_custom_target(do_always ALL 
+            COMMAND if exist "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/" # does not exist if using MSVC without Visual Studio IDE
+                "${CMAKE_COMMAND}" -E copy "${config_filename}" "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/"
+        )
+    endif(MSVC)
 
 endmacro()

--- a/applications/projects/runSofa/cmake/GeneratePluginConfig.cmake
+++ b/applications/projects/runSofa/cmake/GeneratePluginConfig.cmake
@@ -30,7 +30,8 @@ macro(sofa_generate_plugin_config config_filename)
 	# With Win/MVSC, we can only know $CONFIG at build time
 	if (MSVC)
 	    add_custom_target(do_always ALL 
-	    COMMAND "${CMAKE_COMMAND}" -E copy "${config_filename}" "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/"
+	    COMMAND if exist "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/"
+            "${CMAKE_COMMAND}" -E copy "${config_filename}" "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/"
 	)
 	endif(MSVC)
 


### PR DESCRIPTION
`${CMAKE_BINARY_DIR}/bin/$<CONFIG>/` does not exist if using MSVC without Visual Studio IDE.


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
