### PR TITLE
[SofaDefaulttype] MapMapSparseMatrix conversion utils with Eigen Sparse

### DIFF
--- a/SofaKernel/framework/framework_test/CMakeLists.txt
+++ b/SofaKernel/framework/framework_test/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCE_FILES
     core/objectmodel/DataFileName_test.cpp
     core/DataEngine_test.cpp
     core/TrackedData_test.cpp
+    defaulttype/MapMapSparseMatrixEigenUtils_test.cpp
     defaulttype/MatTypes_test.cpp
     defaulttype/VecTypes_test.cpp
     helper/types/Color_test.cpp

--- a/SofaKernel/framework/framework_test/defaulttype/MapMapSparseMatrixEigenUtils_test.cpp
+++ b/SofaKernel/framework/framework_test/defaulttype/MapMapSparseMatrixEigenUtils_test.cpp
@@ -179,7 +179,7 @@ TEST(MapMapSparseMatrixEigenUtilsTest, checkConversionMapMapSparseVec1dEigenSpar
         {
             for (std::size_t i = 0; i < TVec::size(); ++i)
             {
-                EXPECT_EQ(col.val()[0], eigenMat.coeff(row.index(), col.index()));
+                EXPECT_EQ(col.val()[i], eigenMat.coeff(row.index(), col.index()+i));
             }
         }
     }
@@ -228,7 +228,7 @@ TEST(MapMapSparseMatrixEigenUtilsTest, checkConversionMapMapSparseVec3dEigenSpar
         {
             for (std::size_t i = 0; i < TVec::size(); ++i)
             {
-                EXPECT_EQ(col.val()[0], eigenMat.coeff(row.index(), col.index()));
+                EXPECT_EQ(col.val()[i], eigenMat.coeff(row.index(), col.index()+i));
             }
         }
     }

--- a/SofaKernel/framework/framework_test/defaulttype/MapMapSparseMatrixEigenUtils_test.cpp
+++ b/SofaKernel/framework/framework_test/defaulttype/MapMapSparseMatrixEigenUtils_test.cpp
@@ -1,0 +1,240 @@
+#include <gtest/gtest.h>
+#include <sofa/defaulttype/MapMapSparseMatrix.h>
+#include <sofa/defaulttype/MapMapSparseMatrixEigenUtils.h>
+#include <Eigen/Sparse>
+
+namespace
+{
+
+
+TEST(MapMapSparseMatrixEigenUtilsTest, checkEigenSparseMatrixLowLeveAPI)
+{
+    typedef Eigen::SparseMatrix<double, Eigen::RowMajor> EigenSparseMatrix;
+
+    EigenSparseMatrix mat(5,5);
+
+    std::vector< Eigen::Triplet<double> > matEntries =
+    {
+        {0,0,0}, {0,1,3},
+        {1,0,22}, {1,4,17},
+        {2,0,5}, {2,1,5}, {2,4,1},
+        {4,2,14}, {4,4,8}
+    };
+
+    mat.setFromTriplets(matEntries.begin(), matEntries.end());
+
+    mat.makeCompressed();
+
+    int*    outerIndexPtr = mat.outerIndexPtr();
+    int*    innerIndexPtr = mat.innerIndexPtr();
+    double* valuePtr = mat.valuePtr();
+
+
+    int nonZero_0 = *(outerIndexPtr + 0+1) - *(outerIndexPtr+0);
+    EXPECT_EQ(2, nonZero_0);
+    
+    int nonZero_1 = *(outerIndexPtr + 1+1) - *(outerIndexPtr+1);
+    EXPECT_EQ(2, nonZero_1);
+
+    int nonZero_2 = *(outerIndexPtr + 2 + 1) - *(outerIndexPtr + 2);
+    EXPECT_EQ(3, nonZero_2);
+
+    int nonZero_3 = *(outerIndexPtr + 3 + 1) - *(outerIndexPtr + 3);
+    EXPECT_EQ(0, nonZero_3);
+
+    int nonZero_4 = *(outerIndexPtr + 4 + 1) - *(outerIndexPtr + 4);
+    EXPECT_EQ(2, nonZero_4);
+
+    EXPECT_EQ(0,*(innerIndexPtr + 0));
+    EXPECT_EQ(1,*(innerIndexPtr + 1));
+    EXPECT_EQ(0,*(innerIndexPtr + 2));
+    EXPECT_EQ(4,*(innerIndexPtr + 3));
+    EXPECT_EQ(0,*(innerIndexPtr + 4));
+    EXPECT_EQ(1,*(innerIndexPtr + 5));
+    EXPECT_EQ(4,*(innerIndexPtr + 6));
+    EXPECT_EQ(2,*(innerIndexPtr + 7));
+    EXPECT_EQ(4,*(innerIndexPtr + 8));
+
+    EXPECT_EQ(matEntries.size(), mat.nonZeros());
+    
+    for (int i = 0; i < mat.nonZeros(); ++i)
+    {
+        double value = *(valuePtr + i);
+        EXPECT_EQ(matEntries[i].value(), value);
+    }
+}
+
+
+TEST(MapMapSparseMatrixEigenUtilsTest, checkConversionEigenSparseMapMapSparseVec1d)
+{
+    typedef sofa::defaulttype::Vec<1, double > TVec;
+
+    typedef sofa::defaulttype::EigenSparseToMapMapSparseMatrix< TVec > EigenSparseToMapMapSparseVec1d;
+    EigenSparseToMapMapSparseVec1d eigenSparseToMapMapVec1d;
+    typedef typename EigenSparseToMapMapSparseVec1d::EigenSparseMatrix EigenSparseMatrix;
+    typedef typename EigenSparseToMapMapSparseVec1d::TMapMapSparseMatrix TMapMapSparseMatrix;
+
+    std::vector< Eigen::Triplet<double> > matEntries =
+    {
+        { 0,0,0 },{ 0,1,3 },
+        { 1,0,22 },{ 1,4,17 },
+        { 2,0,5 },{ 2,1,5 },{ 2,4,1 },
+        { 4,2,14 },{ 4,4,8 }
+    };
+
+    EigenSparseMatrix eigenMat(5,5);
+    eigenMat.setFromTriplets(matEntries.begin(),matEntries.end() );
+
+
+    TMapMapSparseMatrix mat = eigenSparseToMapMapVec1d(eigenMat);
+
+    int indexEntry = 0;
+    for (auto row = mat.begin(); row != mat.end(); ++row)
+    {
+
+        for (auto col = row.begin(); col != row.end(); ++col)
+        {
+            EXPECT_EQ( matEntries[indexEntry++].value(), col.val()[0]  );
+        }
+    }
+
+    EXPECT_EQ(matEntries.size(), indexEntry);
+}
+
+
+TEST(MapMapSparseMatrixEigenUtilsTest, checkConversionEigenSparseMapMapSparseVec3d)
+{
+    typedef  sofa::defaulttype::Vec<3, double > TVec;
+    typedef sofa::defaulttype::EigenSparseToMapMapSparseMatrix< TVec > EigenSparseToMapMapSparseVec3d;
+    EigenSparseToMapMapSparseVec3d eigenSparseToMapMapVec3d;
+    typedef typename EigenSparseToMapMapSparseVec3d::EigenSparseMatrix EigenSparseMatrix;
+    typedef typename EigenSparseToMapMapSparseVec3d::TMapMapSparseMatrix TMapMapSparseMatrix;
+
+
+    EigenSparseMatrix eigenMat(12, 12);
+    std::vector< Eigen::Triplet<double> > matEntries =
+    {
+        { 3,3,0.1 },{ 3,4,0.2 },{ 3,5,0.3 }
+    };
+
+    eigenMat.setFromTriplets(matEntries.begin(), matEntries.end());
+
+    TMapMapSparseMatrix mat = eigenSparseToMapMapVec3d(eigenMat);
+
+    int indexEntry = 0;
+    for (auto row = mat.begin(); row != mat.end(); ++row)
+    {
+        for (auto col = row.begin(); col != row.end(); ++col)
+        {
+            for (std::size_t i = 0; i < TVec::total_size; ++i)
+            {
+                EXPECT_EQ(matEntries[indexEntry++].value(), col.val()[i]);
+            }
+        }
+    }
+
+    EXPECT_EQ(matEntries.size(), indexEntry);
+}
+
+
+TEST(MapMapSparseMatrixEigenUtilsTest, checkConversionMapMapSparseVec1dEigenSparse)
+{
+    typedef sofa::defaulttype::Vec<1, double > TVec;
+    typedef sofa::defaulttype::MapMapSparseMatrixToEigenSparse< TVec > MapMapSparseMatrixToEigenSparseVec1d;
+    MapMapSparseMatrixToEigenSparseVec1d mapmapSparseToEigenSparse;
+    typedef typename MapMapSparseMatrixToEigenSparseVec1d::EigenSparseMatrix EigenSparseMatrix;
+    typedef typename MapMapSparseMatrixToEigenSparseVec1d::TMapMapSparseMatrix TMapMapSparseMatrix;
+
+    TMapMapSparseMatrix mat;
+
+    std::vector< Eigen::Triplet<double> > matEntries =
+    {
+        { 0,0,0 },{ 0,1,3 },
+        { 1,0,22 },{ 1,4,17 },
+        { 2,0,5 },{ 2,1,5 },{ 2,4,1 },
+        { 4,2,14 },{ 4,4,8 }
+    };
+
+    auto it = matEntries.begin();
+
+    while(it != matEntries.end())
+    {
+        int row = it->row();
+        int col = it->col();
+        TVec vec;
+        for (std::size_t i = 0; i < TVec::size(); ++i)
+        {
+            vec[i] = it->value();
+            ++it;
+        }
+
+        mat.writeLine(row).setCol(col,vec);
+    }
+
+    EigenSparseMatrix eigenMat = mapmapSparseToEigenSparse(mat, 5);
+
+    for (auto row = mat.begin(); row != mat.end(); ++row)
+    {
+        for (auto col = row.begin(); col != row.end(); ++col)
+        {
+            for (std::size_t i = 0; i < TVec::size(); ++i)
+            {
+                EXPECT_EQ(col.val()[0], eigenMat.coeff(row.index(), col.index()));
+            }
+        }
+    }
+
+    EXPECT_EQ(matEntries.size(), eigenMat.nonZeros());
+}
+
+
+TEST(MapMapSparseMatrixEigenUtilsTest, checkConversionMapMapSparseVec3dEigenSparse)
+{
+    typedef sofa::defaulttype::Vec<1, double > TVec;
+    typedef sofa::defaulttype::MapMapSparseMatrixToEigenSparse< TVec > checkConversionMapMapSparseVec3dEigenSparse;
+    checkConversionMapMapSparseVec3dEigenSparse mapmapSparseToEigenSparse;
+    typedef typename checkConversionMapMapSparseVec3dEigenSparse::EigenSparseMatrix EigenSparseMatrix;
+    typedef typename checkConversionMapMapSparseVec3dEigenSparse::TMapMapSparseMatrix TMapMapSparseMatrix;
+
+    TMapMapSparseMatrix mat;
+
+    std::vector< Eigen::Triplet<double> > matEntries =
+    {
+        { 3,3,0.1 },{ 3,4,0.2 },{ 3,5,0.3 }
+    };
+
+
+    auto it = matEntries.begin();
+
+    while (it != matEntries.end())
+    {
+        int row = it->row();
+        int col = it->col();
+        TVec vec;
+        for (std::size_t i = 0; i < TVec::size(); ++i)
+        {
+            vec[i] = it->value();
+            ++it;
+        }
+
+        mat.writeLine(row).setCol(col, vec);
+    }
+
+    EigenSparseMatrix eigenMat = mapmapSparseToEigenSparse(mat, 12);
+
+    for (auto row = mat.begin(); row != mat.end(); ++row)
+    {
+        for (auto col = row.begin(); col != row.end(); ++col)
+        {
+            for (std::size_t i = 0; i < TVec::size(); ++i)
+            {
+                EXPECT_EQ(col.val()[0], eigenMat.coeff(row.index(), col.index()));
+            }
+        }
+    }
+
+    EXPECT_EQ(matEntries.size(), eigenMat.nonZeros());
+}
+
+
+}

--- a/SofaKernel/framework/framework_test/defaulttype/MapMapSparseMatrixEigenUtils_test.cpp
+++ b/SofaKernel/framework/framework_test/defaulttype/MapMapSparseMatrixEigenUtils_test.cpp
@@ -1,3 +1,25 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
 #include <gtest/gtest.h>
 #include <sofa/defaulttype/MapMapSparseMatrix.h>
 #include <sofa/defaulttype/MapMapSparseMatrixEigenUtils.h>

--- a/SofaKernel/framework/sofa/defaulttype/CMakeLists.txt
+++ b/SofaKernel/framework/sofa/defaulttype/CMakeLists.txt
@@ -32,6 +32,12 @@ set(HEADER_FILES
     Color.h
 )
 
+if(EIGEN3_FOUND OR Eigen3_FOUND)
+    list(APPEND HEADER_FILES 
+         MapMapSparseMatrixEigenUtils.h
+        )
+endif()
+
 set(SOURCE_FILES
     BaseMatrix.cpp
     BoundingBox.cpp

--- a/SofaKernel/framework/sofa/defaulttype/MapMapSparseMatrix.h
+++ b/SofaKernel/framework/sofa/defaulttype/MapMapSparseMatrix.h
@@ -588,7 +588,7 @@ public:
             return m_internal > it2.m_internal;
         }
 
-        void addCol(KeyT id, T value)
+        void addCol(KeyT id, const T& value)
         {
             RowType& row = m_internal->second;
             typename RowType::iterator it = row.find(id);
@@ -603,7 +603,7 @@ public:
             }
         }
 
-        void setCol(KeyT id, T value)
+        void setCol(KeyT id, const T& value)
         {
             RowType& row = m_internal->second;
             typename RowType::iterator it = row.find(id);

--- a/SofaKernel/framework/sofa/defaulttype/MapMapSparseMatrixEigenUtils.h
+++ b/SofaKernel/framework/sofa/defaulttype/MapMapSparseMatrixEigenUtils.h
@@ -1,0 +1,109 @@
+#include "MapMapSparseMatrix.h"
+#include <Eigen/Sparse>
+#include <sofa/defaulttype/Vec.h>
+#include <cassert>
+
+namespace sofa
+{
+namespace defaulttype
+{
+
+
+template< class TBloc >
+struct MapMapSparseMatrixToEigenSparse
+{
+
+};
+
+
+template <int N, typename Real>
+struct MapMapSparseMatrixToEigenSparse < sofa::defaulttype::Vec<N, Real> >
+{
+
+    typedef typename sofa::defaulttype::Vec<N, Real>   TVec;
+    typedef MapMapSparseMatrix< TVec >                 TMapMapSparseMatrix;
+    typedef Eigen::SparseMatrix<Real, Eigen::RowMajor> EigenSparseMatrix;
+
+
+    EigenSparseMatrix operator() (const TMapMapSparseMatrix& mat, std::size_t size)
+    {
+        std::size_t eigenMatSize = size * TVec::size();
+        EigenSparseMatrix eigenMat(eigenMatSize, eigenMatSize);
+
+        std::vector<Eigen::Triplet<Real> > triplets;
+
+        for (auto row = mat.begin(); row != mat.end(); ++row)
+        {
+            for (auto col = row.begin(), colend = row.end(); col !=colend; ++col)
+            {
+                const TVec& vec = col.val();
+                int   colIndex  = col.index() * N;
+
+                for (std::size_t i = 0; i < vec.size(); ++i)
+                {
+                    triplets.emplace_back(Eigen::Triplet<Real>( row.index(), colIndex + i, vec[i]) );
+                }
+
+            }
+        }
+
+        eigenMat.setFromTriplets(triplets.begin(), triplets.end());;
+        eigenMat.makeCompressed();
+
+        return eigenMat;
+    }
+
+};
+
+
+template< class TBloc >
+struct EigenSparseToMapMapSparseMatrix
+{
+
+};
+
+template <int N, typename Real >
+struct EigenSparseToMapMapSparseMatrix< sofa::defaulttype::Vec<N, Real> >
+{
+    typedef typename sofa::defaulttype::Vec<N, Real>   TVec;
+    typedef MapMapSparseMatrix< TVec >                 TMapMapSparseMatrix;
+    typedef Eigen::SparseMatrix<Real, Eigen::RowMajor> EigenSparseMatrix;
+
+
+    TMapMapSparseMatrix operator() (const EigenSparseMatrix& eigenMat)
+    {
+        TMapMapSparseMatrix mat;
+
+        const int* outerIndexPtr  = eigenMat.outerIndexPtr();
+        const int* innerIndexPtr  = eigenMat.innerIndexPtr();
+        const Real* valuePtr      = eigenMat.valuePtr();
+
+        for (int rowIndex = 0; rowIndex < eigenMat.outerSize(); ++rowIndex)
+        {
+            int offset      = *(outerIndexPtr + rowIndex);
+            int rowNonZeros = *(outerIndexPtr + rowIndex + 1) - *(outerIndexPtr + rowIndex);
+
+            if (rowNonZeros != 0)
+            {
+                auto rowIterator = mat.writeLine(rowIndex);
+
+                assert(rowNonZeros % TVec::size() == 0); // the filling must be compatible with the bloc size
+
+                for (int i=0;i<rowNonZeros; i+=TVec::size() )
+                {
+                    int colIndex         = *(innerIndexPtr + offset + i);
+                    const double* valPtr = (valuePtr + offset + i);
+                    rowIterator.setCol(colIndex, TVec(valPtr));
+                }
+            }
+        }
+
+        return mat;
+    }
+};
+
+
+
+}
+
+}

--- a/SofaKernel/framework/sofa/defaulttype/MapMapSparseMatrixEigenUtils.h
+++ b/SofaKernel/framework/sofa/defaulttype/MapMapSparseMatrixEigenUtils.h
@@ -1,3 +1,25 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
 #include "MapMapSparseMatrix.h"
 #include <Eigen/Sparse>
 #include <sofa/defaulttype/Vec.h>

--- a/SofaKernel/framework/sofa/defaulttype/RigidTypes.h
+++ b/SofaKernel/framework/sofa/defaulttype/RigidTypes.h
@@ -96,6 +96,12 @@ public:
         : vCenter(Vec<3,real2>(v.data())), vOrientation(Vec<3,real2>(v.data()+3))
     {}
 
+    template<typename real2>
+    RigidDeriv(const real2* ptr)
+        :vCenter(ptr),vOrientation(ptr+3)
+    {
+    }
+
     void clear()
     {
         vCenter.clear();


### PR DESCRIPTION
This PR add some facility method to convert back and forth a `MapMapSparseMatrix` type 
into an `Eigen::SparseMatrix`.

# CHANGELOG 
* Added some utility methods to be able to accumulate MatrixDeriv types to parent dofs when the mapping implements its jacobian using a sparse matrix from the Eigen library.
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
