### PR TITLE
warning removal

### DIFF
--- a/SofaKernel/framework/sofa/helper/list.h
+++ b/SofaKernel/framework/sofa/helper/list.h
@@ -57,7 +57,7 @@ std::ostream& operator<< ( std::ostream& os, const std::list<T>& l )
 template<class T>
 std::istream& operator>> ( std::istream& in, std::list<T>& l )
 {
-    T t;
+    T t {};
     l.clear();
     while(in>>t)
         l.push_back(t);

--- a/SofaKernel/modules/SofaBaseCollision/DefaultPipeline.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/DefaultPipeline.cpp
@@ -155,7 +155,7 @@ void DefaultPipeline::doCollisionDetection(const helper::vector<core::CollisionM
             else
                 (*it)->computeBoundingTree(used_depth);
 
-                vectBoundingVolume.push_back ((*it)->getFirst());
+            vectBoundingVolume.push_back ((*it)->getFirst());
             ++nActive;
         }
 

--- a/modules/SofaGeneralSimpleFem/BeamFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/BeamFEMForceField.inl
@@ -687,10 +687,10 @@ void BeamFEMForceField<DataTypes>::computeBBox(const core::ExecParams* params, b
     Real minBBox[3] = {max_real,max_real,max_real};
 
 
-    const int npoints = this->mstate->getSize();
+    const size_t npoints = this->mstate->getSize();
     const VecCoord& p = this->mstate->read(core::ConstVecCoordId::position())->getValue();
 
-    for (long int i=0; i<npoints; i++)
+    for (size_t i=0; i<npoints; i++)
     {
         const defaulttype::Vector3 &pt = p[i].getCenter();
 

--- a/modules/SofaGeneralSimpleFem/BeamFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/BeamFEMForceField.inl
@@ -690,7 +690,7 @@ void BeamFEMForceField<DataTypes>::computeBBox(const core::ExecParams* params, b
     const int npoints = this->mstate->getSize();
     const VecCoord& p = this->mstate->read(core::ConstVecCoordId::position())->getValue();
 
-    for (unsigned i=0; i<npoints; i++)
+    for (long int i=0; i<npoints; i++)
     {
         const defaulttype::Vector3 &pt = p[i].getCenter();
 

--- a/modules/SofaMiscForceField/GearSpringForceField.inl
+++ b/modules/SofaMiscForceField/GearSpringForceField.inl
@@ -173,8 +173,10 @@ void GearSpringForceField<DataTypes>::addSpringForce( SReal& /*potentialEnergy*/
          newAngle2 = getAngleAroundAxis(*cp2,*cc2,spring.freeAxis[1]);
 
     Real PI2=(Real)2.*(Real)pi;
-    while(newAngle1 - spring.previousAngle1 > pi) newAngle1 -= PI2;		while(newAngle1 - spring.previousAngle1 < -pi) newAngle1 += PI2;
-    while(newAngle2 - spring.previousAngle2 > pi) newAngle2 -= PI2;		while(newAngle2 - spring.previousAngle2 < -pi) newAngle2 += PI2;
+    while(newAngle1 - spring.previousAngle1 > pi) newAngle1 -= PI2;
+    while(newAngle1 - spring.previousAngle1 < -pi) newAngle1 += PI2;
+    while(newAngle2 - spring.previousAngle2 > pi) newAngle2 -= PI2;
+    while(newAngle2 - spring.previousAngle2 < -pi) newAngle2 += PI2;
 
     spring.angle1 += newAngle1 - spring.previousAngle1; spring.previousAngle1 = newAngle1;
     spring.angle2 += newAngle2 - spring.previousAngle2; spring.previousAngle2 = newAngle2;


### PR DESCRIPTION
This PR will remove various warnings generated when compiling with gcc 6.3.0. Warnings coming from extlibs are not fixed.
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
