### PR TITLE
[SofaDefaulttype] multTranspose method between MapMapSparseMatrix and BaseVector

### DIFF
--- a/SofaKernel/framework/sofa/defaulttype/MapMapSparseMatrix.h
+++ b/SofaKernel/framework/sofa/defaulttype/MapMapSparseMatrix.h
@@ -23,6 +23,7 @@
 #define SOFA_DEFAULTTYPE_MAPMAPSPARSEMATRIX_H
 
 #include <map>
+#include "BaseVector.h"
 
 namespace sofa
 {
@@ -110,6 +111,23 @@ public:
         }
 
         return in;
+    }
+
+    template< class VecDeriv>
+    void multTransposeBaseVector(VecDeriv& res, const sofa::defaulttype::BaseVector* lambda ) const
+    {
+        typedef typename VecDeriv::value_type Deriv;
+
+        static_assert(std::is_same<Deriv, T>::value, "res must be contain same type as MapMapSparseMatrix type");
+
+        for (auto rowIt = begin(), rowItEnd = end(); rowIt != rowItEnd; ++rowIt)
+        {
+            const SReal f = lambda->element(rowIt.index());
+            for (auto colIt = rowIt.begin(), colItEnd = rowIt.end(); colIt != colItEnd; ++colIt)
+            {
+                res[colIt.index()] += colIt.val() * f;
+            }
+        }
     }
 
 protected:

--- a/SofaKernel/framework/sofa/defaulttype/MapMapSparseMatrix.h
+++ b/SofaKernel/framework/sofa/defaulttype/MapMapSparseMatrix.h
@@ -118,7 +118,7 @@ public:
     {
         typedef typename VecDeriv::value_type Deriv;
 
-        static_assert(std::is_same<Deriv, T>::value, "res must be contain same type as MapMapSparseMatrix type");
+        static_assert(std::is_same<Deriv, T>::value, "res must contain same type as MapMapSparseMatrix type");
 
         for (auto rowIt = begin(), rowItEnd = end(); rowIt != rowItEnd; ++rowIt)
         {


### PR DESCRIPTION
# CHANGELOG 
- [SofaDefaulttype] Add MapMapSparseMatrix multTranspose method with BaseVector. 
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
