### PR TITLE
[SofaPython] FIX crash in python script when visualizing advanced timer output

### DIFF
--- a/applications/plugins/SofaPython/python/AdvancedTimerOutputAnalysis/timerLjsonManyFilesPlot.py
+++ b/applications/plugins/SofaPython/python/AdvancedTimerOutputAnalysis/timerLjsonManyFilesPlot.py
@@ -98,8 +98,13 @@ class TimerLjsonManyFilesPlot() :
                     openedFile.close()
                 return 0
 
+            try:
+                jsonParsedFile = json.load(openedJsonFile, object_pairs_hook=OrderedDict)
+            except:
+                print "[ERROR] Could not parse json file " + jsonFile
+                continue
+
             jsonOpenedFiles.append(openedJsonFile)
-            jsonParsedFile = json.load(openedJsonFile, object_pairs_hook=OrderedDict)
             jsonAnalysedFiles.append(self.parseJsonComponantsId(jsonParsedFile, componantID, value))
 
 

--- a/applications/plugins/SofaPython/python/SofaPython/PythonAdvancedTimer.py
+++ b/applications/plugins/SofaPython/python/SofaPython/PythonAdvancedTimer.py
@@ -21,7 +21,7 @@ def measureAnimationTime(node, timerName, timerInterval, timerOutputType, result
     with open(resultFileName, "w+") as outputFile :
         outputFile.write("{")
         i = 0
-        Sofa.timerSetOutPutType(timerName, timerOutputType)
+        Sofa.timerSetOutputType(timerName, timerOutputType)
         while i < iterations:
             Sofa.timerBegin(timerName)
             rootNode.simulationStep(simulationDeltaTime)


### PR DESCRIPTION
That script is used to parse the output of the AdvancedTimer in a Python scene to plot it. One of the function bindings has changed name, but this change was not reflected in the script.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
