### PR TITLE
[libQGLViewer] FIX missing headers

### DIFF
--- a/extlibs/libQGLViewer-2.6.3/QGLViewer/VRender/PrimitivePositioning.cpp
+++ b/extlibs/libQGLViewer-2.6.3/QGLViewer/VRender/PrimitivePositioning.cpp
@@ -91,6 +91,8 @@
 #include "math.h"
 #include "Vector2.h"
 
+#include <algorithm>
+
 using namespace vrender ;
 using namespace std ;
 

--- a/extlibs/libQGLViewer-2.6.3/QGLViewer/VRender/Vector2.cpp
+++ b/extlibs/libQGLViewer-2.6.3/QGLViewer/VRender/Vector2.cpp
@@ -44,6 +44,7 @@
 
 #include "Vector2.h"
 #include "Vector3.h"
+#include <algorithm>
 #include <math.h>
 
 #ifdef WIN32

--- a/extlibs/libQGLViewer-2.6.3/QGLViewer/VRender/Vector3.cpp
+++ b/extlibs/libQGLViewer-2.6.3/QGLViewer/VRender/Vector3.cpp
@@ -45,6 +45,7 @@
 #include <iostream>
 #include "Vector3.h"
 #include "NVector3.h"
+#include <algorithm>
 #include <math.h>
 
 #ifdef WIN32


### PR DESCRIPTION
We ran into some more compile errors on windows using MSVC 2015.

libQGLViewer wouldn't compile without those missing headers.

Here's a quick fix but you might want to update libQGLViewer to the latest version (2.7.0).

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
