### PR TITLE
[SofaSPHFluid] Fix invalid plugin initialization.

### DIFF
--- a/applications/plugins/SofaSphFluid/initSPHFluid.cpp
+++ b/applications/plugins/SofaSphFluid/initSPHFluid.cpp
@@ -29,8 +29,16 @@ namespace sofa
 namespace component
 {
 
+extern "C" {
+SOFA_SPH_FLUID_API void initExternalModule();
+SOFA_SPH_FLUID_API const char* getModuleName();
+SOFA_SPH_FLUID_API const char* getModuleVersion();
+SOFA_SPH_FLUID_API const char* getModuleLicense();
+SOFA_SPH_FLUID_API const char* getModuleDescription();
+SOFA_SPH_FLUID_API const char* getModuleComponentList();
+}
 
-void initSPHFluid()
+void initExternalModule()
 {
     static bool first = true;
     if (first)
@@ -38,6 +46,33 @@ void initSPHFluid()
         first = false;
     }
 }
+
+const char* getModuleName()
+{
+    return "SofaSphFluid";
+}
+
+const char* getModuleVersion()
+{
+    return "1.0";
+}
+
+const char* getModuleLicense()
+{
+    return "LGPL";
+}
+
+const char* getModuleDescription()
+{
+    return "This plugin contains fluids simulation based on the SPH method.";
+}
+
+const char* getModuleComponentList()
+{
+    return "SpatialGridContainer SPHFluidForceField SPHFluidSurfaceMapping"
+           " ParticleSink ParticuleSource ParticlesRepulsionForceField";
+}
+
 
 SOFA_LINK_CLASS(SpatialGridContainer)
 SOFA_LINK_CLASS(SPHFluidForceField)

--- a/applications/plugins/SofaSphFluid/initSPHFluid.h
+++ b/applications/plugins/SofaSphFluid/initSPHFluid.h
@@ -29,9 +29,6 @@ namespace sofa
 namespace component
 {
 
-
-void SOFA_SPH_FLUID_API initSPHFluid();
-
 } // namespace component
 
 } // namespace sofa


### PR DESCRIPTION
All tests scenes are now failing because we cannot load the SofaSphFluid plugin. 
This fix should helps ;) 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
