### PR TITLE
[Build] FIX Sofa installation failure (tries to install non-existing files)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,9 +405,6 @@ if(SOFA_INSTALL_RESOURCES_FILES)
     install(DIRECTORY examples/ DESTINATION share/sofa/examples)	
 endif()
 
-## Temporary (todo: think about this typedef thing)
-install(DIRECTORY modules/sofa/component/typedef/ DESTINATION include/sofa/component/typedef)
-
 
 #CPack install
 SET(CPACK_PACKAGE_VERSION "17.dev.0")


### PR DESCRIPTION
A directory that was recently removed is still mentioned in the cmake build files, so installation fails (compilation is fine).






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
