### PR TITLE
[SofaHelper] Replacing afficheResult with resultToString

### DIFF
--- a/SofaKernel/framework/sofa/helper/LCPcalc.h
+++ b/SofaKernel/framework/sofa/helper/LCPcalc.h
@@ -27,6 +27,7 @@
 #include <cmath>
 #include <sofa/helper/system/thread/CTime.h>
 #include <vector>
+#include <ostream>
 
 
 namespace sofa

--- a/SofaKernel/framework/sofa/helper/LCPcalc.h
+++ b/SofaKernel/framework/sofa/helper/LCPcalc.h
@@ -111,7 +111,7 @@ SOFA_HELPER_API int resoudreLCP(int, double *, double **, double *);
 SOFA_HELPER_API void afficheSyst(double *q,double **M, int *base, double **mat, int dim);
 SOFA_HELPER_API void afficheLCP(double *q, double **M, int dim);
 SOFA_HELPER_API void afficheLCP(double *q, double **M, double *f, int dim);
-SOFA_HELPER_API void afficheResult(double *f, int dim);
+SOFA_HELPER_API void resultToString(std::ostream& s, double *f, int dim);
 
 typedef SOFA_HELPER_API double FemClipsReal;
 SOFA_HELPER_API void gaussSeidelLCP1(int dim, FemClipsReal * q, FemClipsReal ** M, FemClipsReal * res, double tol, int numItMax, double minW=0.0, double maxF=0.0, std::vector<double>* residuals = NULL);

--- a/modules/SofaConstraint/ConstraintAnimationLoop.cpp
+++ b/modules/SofaConstraint/ConstraintAnimationLoop.cpp
@@ -598,7 +598,7 @@ void ConstraintAnimationLoop::step ( const core::ExecParams* params, SReal dt )
         {
             computePredictiveForce(CP.getSize(), CP.getF()->ptr(), CP.getConstraintResolutions());
             msg_info() << "getF() after computePredictiveForce:" ;
-            helper::afficheResult(CP.getF()->ptr(),CP.getSize());
+            helper::resultToString(std::cout,CP.getF()->ptr(),CP.getSize());
         }
     }
 
@@ -607,7 +607,7 @@ void ConstraintAnimationLoop::step ( const core::ExecParams* params, SReal dt )
         (*CP.getF())*=0.0;
         computePredictiveForce(CP.getSize(), CP.getF()->ptr(), CP.getConstraintResolutions());
         msg_info() << "getF() after re-computePredictiveForce:" ;
-        helper::afficheResult(CP.getF()->ptr(),CP.getSize());
+        helper::resultToString(std::cout,CP.getF()->ptr(),CP.getSize());
     }
 
 
@@ -636,7 +636,7 @@ void ConstraintAnimationLoop::step ( const core::ExecParams* params, SReal dt )
     if (EMIT_EXTRA_DEBUG_MESSAGE)
     {
         msg_info() << "getF() after setConstraintEquations:" ;
-        helper::afficheResult(CP.getF()->ptr(),CP.getSize());
+        helper::resultToString(std::cout, CP.getF()->ptr(),CP.getSize());
     }
 
     sofa::helper::AdvancedTimer::stepBegin("GaussSeidel");


### PR DESCRIPTION
sofa::helper::afficheResult definition no longer exists, resulting in unresolved external link error with msvc during debug compilation

I stumbled upon an unresolved external which apparently was introduced by a42dcec 
I guess the initial intent was to replace this method by a new method called `resultToString`, but its declaration did not make it through the header file.

I suspect the unresolved external should have been caught by other compilers, but am I the only one
to compile in debug mode sometimes ?
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
