### PR TITLE
Modularizing config.h

### DIFF
--- a/SofaKernel/SofaFramework/CMakeLists.txt
+++ b/SofaKernel/SofaFramework/CMakeLists.txt
@@ -175,12 +175,23 @@ list(APPEND SOFAFRAMEWORK_DEPENDENCY_INCLUDE_DIRECTORIES ${EIGEN3_INCLUDE_DIR})
 ## JSON
 list(APPEND SOFAFRAMEWORK_DEPENDENCY_INCLUDE_DIRECTORIES ${JSON_INCLUDE_DIR})
 
-## sofa/config.h
-configure_file(config.h.in "${CMAKE_BINARY_DIR}/include/sofa/config.h")
-install(FILES "${CMAKE_BINARY_DIR}/include/sofa/config.h" DESTINATION "include/sofa")
+## Generate & install the different files that contains the defines associated with
+## the state of the build option.
+set(SOFA_BUILD_OPTIONS_SRC
+        sharedlibrary_defines.h
+        build_option_componentset.h
+        build_option_dump_visitor.h
+        build_option_experimental_features.h
+        build_option_opengl.h
+        build_option_threading.h
+    )
+foreach(NAME ${SOFA_BUILD_OPTIONS_SRC})
+    configure_file("${NAME}.in" "${CMAKE_BINARY_DIR}/include/sofa/config/${NAME}")
+    install(FILES "${CMAKE_BINARY_DIR}/include/sofa/config/${NAME}" DESTINATION "include/sofa/config")
+endforeach()
 
-configure_file(build_option_componentset.h.in "${CMAKE_BINARY_DIR}/include/sofa/config/build_option_componentset.h")
-install(FILES "${CMAKE_BINARY_DIR}/include/sofa/config/build_option_componentset.h" DESTINATION "include/sofa/config")
+configure_file("config.h.in" "${CMAKE_BINARY_DIR}/include/sofa/config.h")
+install(FILES "${CMAKE_BINARY_DIR}/include/sofa/config.h" DESTINATION "include/sofa/")
 
 # make sure everyone in the build tree can see <sofa/config.h>
 #list(APPEND SOFAFRAMEWORK_DEPENDENCY_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_BINARY_DIR})

--- a/SofaKernel/SofaFramework/build_option_dump_visitor.h.in
+++ b/SofaKernel/SofaFramework/build_option_dump_visitor.h.in
@@ -1,0 +1,27 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#ifndef SOFA_CONFIG_BUILD_OPTION_DUMP_VISITOR_H
+#define SOFA_CONFIG_BUILD_OPTION_DUMP_VISITOR_H
+
+#cmakedefine SOFA_DUMP_VISITOR_INFO
+
+#endif

--- a/SofaKernel/SofaFramework/build_option_experimental_features.h.in
+++ b/SofaKernel/SofaFramework/build_option_experimental_features.h.in
@@ -1,0 +1,27 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#ifndef SOFA_CONFIG_BUILD_OPTION_EXPERIMENTAL_FEATURES_H
+#define SOFA_CONFIG_BUILD_OPTION_EXPERIMENTAL_FEATURES_H
+
+#define SOFA_WITH_EXPERIMENTAL_FEATURES ${SOFA_WITH_EXPERIMENTAL_FEATURES_}
+
+#endif

--- a/SofaKernel/SofaFramework/build_option_opengl.h.in
+++ b/SofaKernel/SofaFramework/build_option_opengl.h.in
@@ -1,0 +1,28 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#ifndef SOFA_CONFIG_BUILD_OPTION_OPENGL_H
+#define SOFA_CONFIG_BUILD_OPTION_OPENGL_H
+
+#cmakedefine SOFA_NO_OPENGL
+#define SOFA_WITH_OPENGL ${SOFA_WITH_OPENGL_}
+
+#endif

--- a/SofaKernel/SofaFramework/build_option_threading.h.in
+++ b/SofaKernel/SofaFramework/build_option_threading.h.in
@@ -1,0 +1,28 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#ifndef SOFA_CONFIG_BUILD_OPTION_THREADING_H
+#define SOFA_CONFIG_BUILD_OPTION_THREADING_H
+
+/// This can be either true or false
+#define SOFA_WITH_THREADING ${SOFA_WITH_THREADING_}
+
+#endif

--- a/SofaKernel/SofaFramework/config.h.in
+++ b/SofaKernel/SofaFramework/config.h.in
@@ -22,6 +22,12 @@
 #ifndef SOFA_CONFIG_H
 #define SOFA_CONFIG_H
 
+#include <sofa/config/sharedlibrary_defines.h>
+#include <sofa/config/build_option_dump_visitor.h>
+#include <sofa/config/build_option_experimental_features.h>
+#include <sofa/config/build_option_opengl.h>
+#include <sofa/config/build_option_threading.h>
+
 // fixes CGAL plugin build errors (default value: 5)
 #define BOOST_PARAMETER_MAX_ARITY 12
 
@@ -45,10 +51,6 @@
 
 #cmakedefine SOFA_HAVE_TINYXML
 
-#cmakedefine SOFA_DUMP_VISITOR_INFO
-
-#cmakedefine SOFA_NO_OPENGL
-
 #cmakedefine SOFA_NO_UPDATE_BBOX
 
 #cmakedefine DETECTIONOUTPUT_FREEMOTION
@@ -66,11 +68,6 @@
 #cmakedefine SOFA_USE_MASK
 
 #cmakedefine SOFA_WITH_DEVTOOLS
-
-/// This can be either true or false
-#define SOFA_WITH_THREADING ${SOFA_WITH_THREADING_}
-
-#define SOFA_WITH_EXPERIMENTAL_FEATURES ${SOFA_WITH_EXPERIMENTAL_FEATURES_}
 
 #ifdef _MSC_VER
 #define EIGEN_DONT_ALIGN
@@ -100,18 +97,6 @@ typedef double SReal;
 // supported by all majors compilers.)
 #ifndef SOFA_NO_EXTERN_TEMPLATE
 #  define SOFA_EXTERN_TEMPLATE
-#endif
-
-#ifndef WIN32
-#	define SOFA_EXPORT_DYNAMIC_LIBRARY
-#   define SOFA_IMPORT_DYNAMIC_LIBRARY
-#else
-#	define SOFA_EXPORT_DYNAMIC_LIBRARY __declspec( dllexport )
-#   define SOFA_IMPORT_DYNAMIC_LIBRARY __declspec( dllimport )
-#   ifdef _MSC_VER
-#       pragma warning(disable : 4231)
-#       pragma warning(disable : 4910)
-#   endif
 #endif
 
 #ifdef SOFA_BUILD_HELPER

--- a/SofaKernel/SofaFramework/config.h.in
+++ b/SofaKernel/SofaFramework/config.h.in
@@ -24,7 +24,6 @@
 
 #include <sofa/config/sharedlibrary_defines.h>
 #include <sofa/config/build_option_dump_visitor.h>
-#include <sofa/config/build_option_experimental_features.h>
 #include <sofa/config/build_option_opengl.h>
 #include <sofa/config/build_option_threading.h>
 

--- a/SofaKernel/SofaFramework/sharedlibrary_defines.h.in
+++ b/SofaKernel/SofaFramework/sharedlibrary_defines.h.in
@@ -1,0 +1,38 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#ifndef SOFA_CONFIG_SHAREDLIBRARY_DEFINES_H
+#define SOFA_CONFIG_SHAREDLIBRARY_DEFINES_H
+
+#ifndef WIN32
+#	define SOFA_EXPORT_DYNAMIC_LIBRARY
+#   define SOFA_IMPORT_DYNAMIC_LIBRARY
+#else
+#	define SOFA_EXPORT_DYNAMIC_LIBRARY __declspec( dllexport )
+#   define SOFA_IMPORT_DYNAMIC_LIBRARY __declspec( dllimport )
+#   ifdef _MSC_VER
+#       pragma warning(disable : 4231)
+#       pragma warning(disable : 4910)
+#   endif
+#endif
+
+#endif /// SOFA_CONFIG_SHAREDLIBRARY_DEFINES_H
+

--- a/SofaKernel/framework/sofa/core/behavior/BaseMechanicalState.h
+++ b/SofaKernel/framework/sofa/core/behavior/BaseMechanicalState.h
@@ -22,6 +22,8 @@
 #ifndef SOFA_CORE_BEHAVIOR_BASEMECHANICALSTATE_H
 #define SOFA_CORE_BEHAVIOR_BASEMECHANICALSTATE_H
 
+#include <sofa/config/build_option_experimental_features.h>
+
 #include <sofa/core/BaseState.h>
 #include <sofa/core/MultiVecId.h>
 #include <sofa/defaulttype/BaseMatrix.h>

--- a/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.h
+++ b/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.h
@@ -23,6 +23,8 @@
 #define SOFA_COMPONENT_MECHANICALOBJECT_H
 #include "config.h"
 
+#include <sofa/config/build_option_experimental_features.h>
+
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/objectmodel/DataFileName.h>
 #include <sofa/core/topology/BaseMeshTopology.h>

--- a/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.inl
@@ -22,6 +22,8 @@
 #ifndef SOFA_COMPONENT_MECHANICALOBJECT_INL
 #define SOFA_COMPONENT_MECHANICALOBJECT_INL
 
+#include <sofa/config/build_option_experimental_features.h>
+
 #include <SofaBaseMechanics/MechanicalObject.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <SofaBaseLinearSolver/SparseMatrix.h>


### PR DESCRIPTION
Currently config.h is a all-in-one configuration file that is generated by CMakeLists and included nearly everywhere. The problem is that it contains also very specific options that very few files are using. But, each time any of these specific option is changed sofa needs to be recompiled entirely.

This PR is a implementing a more modular approach in which each .cpp that specifically requires a given define include a dedicated file.
Eg:
#include<config/build_option_opengl.h>  // to do #if(SOFA_WITH_OPENGL==1)
or
#include<config/build_option_experimental.h>  // to do #if(SOFA_WITH_EXPERIMENTALFATURE==1)
or
#include<config/sharedlibrary_defines.h>

It is still possible to use the old file but by being more specific we will reduce the amount of file to recompile when we will changed something.


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
