### PR TITLE
[SofaKernel] Fix a minor regression introduced during the post-sprint

### DIFF
--- a/SofaKernel/modules/SofaSimulationCommon/xml/ObjectElement.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/xml/ObjectElement.cpp
@@ -83,14 +83,18 @@ bool ObjectElement::initNode()
         BaseObjectDescription desc("InfoComponent", "InfoComponent") ;
         desc.setAttribute("name", ("Not created ("+getType()+")").c_str());
         obj = core::ObjectFactory::CreateObject(ctx, &desc) ;
+        std::stringstream tmp ;
+        for(auto& s : this->getErrors())
+            tmp << s << msgendl ;
+
         if(obj)
         {
            obj->init() ;
-           msg_error(obj.get()) << "Object type \"" << getType() << "\" creation Failed." ;
+           msg_error(obj.get()) << tmp.str() ;
            return false;
         }
 
-        msg_error(ctx) << "Object type \"" << getType() << "\" creation Failed." ;
+        msg_error(ctx) << tmp.str() ;
         return false;
     }
     setObject(obj);


### PR DESCRIPTION
Because of the InfoComponent (that report in the GUI the fact that a component
was not created the complete error log from the factory where not reported.

This commit fix that.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
