### PR TITLE
[SceneCreator] FIX build error with AppleClang 6.0.0.6000051

### DIFF
--- a/applications/plugins/SceneCreator/SimpleApi.h
+++ b/applications/plugins/SceneCreator/SimpleApi.h
@@ -48,14 +48,14 @@ void SOFA_SCENECREATOR_API importPlugin(const std::string& name) ;
 
 Simulation::SPtr SOFA_SCENECREATOR_API createSimulation(const std::string& type="DAG") ;
 
-Node::SPtr SOFA_SCENECREATOR_API createRootNode(Simulation::SPtr, const std::string& name,
-                                                const std::map<std::string, std::string>& params={}) ;
+Node::SPtr SOFA_SCENECREATOR_API createRootNode( Simulation::SPtr, const std::string& name,
+    const std::map<std::string, std::string>& params = std::map<std::string, std::string>{} );
 
-BaseObject::SPtr SOFA_SCENECREATOR_API createObject(Node::SPtr parent, const std::string& type,
-                                                    const std::map<std::string, std::string>& params={}) ;
+BaseObject::SPtr SOFA_SCENECREATOR_API createObject( Node::SPtr parent, const std::string& type,
+    const std::map<std::string, std::string>& params = std::map<std::string, std::string>{} );
 
-Node::SPtr SOFA_SCENECREATOR_API createChild(Node::SPtr& node, const std::string& name,
-                                             const std::map<std::string, std::string>& params={}) ;
+Node::SPtr SOFA_SCENECREATOR_API createChild( Node::SPtr& node, const std::string& name,
+    const std::map<std::string, std::string>& params = std::map<std::string, std::string>{} );
 
 void SOFA_SCENECREATOR_API dumpScene(Node::SPtr root) ;
 


### PR DESCRIPTION
Fixes `error: chosen constructor is explicit in copy-initialization`
see https://ci.inria.fr/sofa-ci/job/mac_clang-3.4_options/6311/console

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
