### PR TITLE
remove warning generated by MapMapSparseMatrixEigenUtils

### DIFF
--- a/SofaKernel/framework/sofa/defaulttype/MapMapSparseMatrixEigenUtils.h
+++ b/SofaKernel/framework/sofa/defaulttype/MapMapSparseMatrixEigenUtils.h
@@ -125,7 +125,6 @@ struct EigenSparseToMapMapSparseMatrixVec
 
                 int i = 0;
                 const int*  colPtr = innerIndexPtr + offset;
-                const Real* valPtr = valuePtr + offset;
                 int   blockIndex   = *colPtr / TVec::size();
                 int   blockOffset  = *colPtr - (blockIndex * TVec::size());
 
@@ -134,7 +133,6 @@ struct EigenSparseToMapMapSparseMatrixVec
                 {
                     TVec val;
                     int currentBlockIndex = blockIndex;
-                    int currentCol   = *colPtr;
                     while (currentBlockIndex == blockIndex && i != rowNonZeros)
                     {
                         val[blockOffset] = *valuePtr;


### PR DESCRIPTION
Remove new warning in MapMapSparseMatrixEigenUtils.h


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
