### PR TITLE
[SofaKernel] SofaComponentCommon does not always register all its components in the object factory

### DIFF
--- a/SofaKernel/modules/SofaComponentCommon/initComponentCommon.cpp
+++ b/SofaKernel/modules/SofaComponentCommon/initComponentCommon.cpp
@@ -23,7 +23,7 @@
 #include <SofaComponentCommon/initComponentCommon.h>
 #include <SofaLoader/initLoader.h>
 #include <SofaEngine/initEngine.h>
-/*
+
 #include <SofaRigid/initRigid.h>
 #include <SofaDeformable/initDeformable.h>
 #include <SofaSimpleFem/initSimpleFEM.h>
@@ -31,7 +31,8 @@
 #include <SofaMeshCollision/initMeshCollision.h>
 #include <SofaExplicitOdeSolver/initExplicitODESolver.h>
 #include <SofaImplicitOdeSolver/initImplicitODESolver.h>
-*/
+#include <SofaEigen2Solver/initEigen2Solver.h>
+#include <SofaObjectInteraction/initObjectInteraction.h>
 
 namespace sofa
 {
@@ -50,7 +51,6 @@ void initComponentCommon()
 
     initLoader();
     initEngine();
-/*
     initRigid();
     initDeformable();
     initSimpleFEM();
@@ -59,7 +59,7 @@ void initComponentCommon()
     initExplicitODESolver();
     initImplicitODESolver();
     initEigen2Solver();
-*/
+    initObjectInteraction();
 }
 
 } // namespace component


### PR DESCRIPTION
# Purpose
For some reason, I stumbled upon a strange error where `EulerImplicitSolver` is no longer registered in the factory. It turns out that some `init...()` methods call are missing in `SofaComponentCommon`
Maybe this error arised on master because some includes directive have been cleaned, or some 
dependencies have been removed which were hiding this problem before. 

# CHANGELOG
FIX
[SofaComponentCommon]
- Make sure `initComponentCommon()` method calls the init method of all the libraries that compose the package so that we are sure the `ObjectFactory` is well populated. 






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
