### PR TITLE
[SofaValidation] move code to set default folder for monitor to init function

### DIFF
--- a/modules/SofaValidation/Monitor.inl
+++ b/modules/SofaValidation/Monitor.inl
@@ -64,7 +64,7 @@ Monitor<DataTypes>::Monitor()
     ,d_trajectoriesPrecision (initData (&d_trajectoriesPrecision, 0.1,"TrajectoriesPrecision", "set the dt between to save of positions"))
     ,d_trajectoriesColor(initData (&d_trajectoriesColor, "TrajectoriesColor", "define the color of the trajectories"))
     ,d_showSizeFactor(initData (&d_showSizeFactor, 1.0, "sizeFactor", "factor to multiply to arrows"))
-    ,d_fileName(initData (&d_fileName, std::string("./") + getName(), "fileName", "name of the plot files to be generated"))
+    ,d_fileName(initData (&d_fileName, "fileName", "name of the plot files to be generated"))
     ,m_saveGnuplotX ( NULL ), m_saveGnuplotV ( NULL ), m_saveGnuplotF ( NULL )
     ,m_X (NULL), m_V(NULL), m_F(NULL)
     ,m_internalDt(0.0)
@@ -97,6 +97,10 @@ Monitor<DataTypes>::~Monitor()
 template<class DataTypes>
 void Monitor<DataTypes>::init()
 {
+    if (!d_fileName.isSet()) {
+        d_fileName.setValue(std::string("./") + getName());
+    }
+
     core::behavior::MechanicalState<DataTypes>* mmodel = dynamic_cast<core::behavior::MechanicalState<DataTypes>*>( this->getContext()->getMechanicalState() );
 
     if(!mmodel)

--- a/modules/SofaValidation/SofaValidation_test/Monitor_test.cpp
+++ b/modules/SofaValidation/SofaValidation_test/Monitor_test.cpp
@@ -30,6 +30,8 @@ struct MonitorTest : public Monitor<Rigid3>
 
         EXPECT_TRUE(i1.size() == i2.size());
         for (size_t i = 0; i < i1.size(); ++i) EXPECT_EQ(i1[i], i2[i]);
+
+        EXPECT_EQ(d_fileName, std::string("./") + getName());
     }
 
     void testModif(MechanicalObject<Rigid3>* mo)


### PR DESCRIPTION
This fix allows to set the default filename for the Monitor class. The default name assignment is removed in 'init()' function since in constructor it doesn't work. 


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
