### PR TITLE
[runSofa] FIX PluginRepository initialization

### DIFF
--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -286,6 +286,7 @@ int main(int argc, char** argv)
     // Initialise paths
     BaseGUI::setConfigDirectoryPath(Utils::getSofaPathPrefix() + "/config", true);
     BaseGUI::setScreenshotDirectoryPath(Utils::getSofaPathPrefix() + "/screenshots", true);
+    PluginRepository.addFirstPath( Utils::getPluginDirectory() );
 
     if (!files.empty())
         fileName = files[0];
@@ -300,16 +301,18 @@ int main(int argc, char** argv)
     {
         if (DataRepository.findFile(configPluginPath))
         {
-            msg_info("runSofa") << "Loading automatically plugin list in " << configPluginPath;
+            msg_info("runSofa") << "Loading automatically custom plugin list from " << configPluginPath;
             PluginManager::getInstance().readFromIniFile(configPluginPath);
         }
         else if (DataRepository.findFile(defaultConfigPluginPath))
         {
-            msg_info("runSofa") << "Loading automatically plugin list in " << defaultConfigPluginPath;
+            msg_info("runSofa") << "Loading automatically default plugin list from " << defaultConfigPluginPath;
             PluginManager::getInstance().readFromIniFile(defaultConfigPluginPath);
         }
         else
-            msg_info("runSofa") << "No plugin list found. No plugin will be automatically loaded.";
+            msg_info("runSofa") << "No plugin will be automatically loaded" << msgendl
+                                << "- No custom list found at " << configPluginPath << msgendl
+                                << "- No default list found at " << defaultConfigPluginPath;
     }
     else
         msg_info("runSofa") << "Automatic plugin loading disabled.";


### PR DESCRIPTION
This should fix failing scene tests due to issofa_plugin merge 
Failures were due to wrong `plugin_list.conf` path implying no plugin loading.

Added some output to understand better were this list is loaded from (especially in case of failure).

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
