### PR TITLE
[ColladaSceneLoader] FIX Assimp copy on Windows

### DIFF
--- a/applications/plugins/ColladaSceneLoader/CMakeLists.txt
+++ b/applications/plugins/ColladaSceneLoader/CMakeLists.txt
@@ -55,6 +55,12 @@ install(DIRECTORY Demos/ DESTINATION share/sofa/plugins/${PROJECT_NAME})
 
 # Copy Assimp DLLs on Windows
 if(WIN32)
-    file(COPY ${ASSIMP_DLLS} DESTINATION bin)
+    if(CMAKE_CONFIGURATION_TYPES) # Multi-config generator (MSVC)
+        foreach(CONFIG ${CMAKE_CONFIGURATION_TYPES})
+            file(COPY ${ASSIMP_DLLS} DESTINATION "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CONFIG}")
+        endforeach()
+    else()                      # Single-config generator (nmake)
+        file(COPY ${ASSIMP_DLLS} DESTINATION "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+    endif()
     install(FILES ${ASSIMP_DLLS} DESTINATION bin)
 endif()


### PR DESCRIPTION
This should fix "a few" failing scene tests due to ColladaSceneLoader on Windows.

See the Details tab of https://ci.inria.fr/sofa-ci/job/windows7_VS-2015_options_amd64_pr1/526/warnings2Result/category.96784904/

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
