### PR TITLE
[SofaKernel] Fix compilation errors when working with transform class

### DIFF
--- a/SofaKernel/framework/sofa/defaulttype/SolidTypes.h
+++ b/SofaKernel/framework/sofa/defaulttype/SolidTypes.h
@@ -337,7 +337,7 @@ public:
         template<class Real2>
         Transform& operator*=(Real2 a)
         {
-            dmsg_info() << "SolidTypes<R>::Transform::operator *=";
+            dmsg_info("Transform") << "SolidTypes<R>::Transform::operator *=";
             origin_ *= a;
             return *this;
         }


### PR DESCRIPTION
A fix for compilation errors when working with operator '*=' from Transform class.


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
