### PR TITLE
[MultiThreading] FIX Windows dll loading

### DIFF
--- a/applications/plugins/MultiThreading/src/initMultiThreading.cpp
+++ b/applications/plugins/MultiThreading/src/initMultiThreading.cpp
@@ -21,9 +21,19 @@
 ******************************************************************************/
 #include <MultiThreading/config.h>
 
-
-extern "C"
+namespace sofa
 {
+namespace component
+{
+
+extern "C" {
+SOFA_MULTITHREADING_PLUGIN_API void initExternalModule();
+SOFA_MULTITHREADING_PLUGIN_API const char* getModuleName();
+SOFA_MULTITHREADING_PLUGIN_API const char* getModuleVersion();
+SOFA_MULTITHREADING_PLUGIN_API const char* getModuleLicense();
+SOFA_MULTITHREADING_PLUGIN_API const char* getModuleDescription();
+SOFA_MULTITHREADING_PLUGIN_API const char* getModuleComponentList();
+}
 
 void initExternalModule()
 {
@@ -59,12 +69,5 @@ const char* getModuleComponentList()
     return "DataExchange, AnimationLoopParallelScheduler ";
 }
 
-}
-
-
-// Fix this it doesn't compile with these lines !!
-//#ifdef SOFA_HAVE_BOOST
-//SOFA_LINK_CLASS(AnimationLoopParallelScheduler)
-//#endif
-//SOFA_LINK_CLASS(DataExchange)
-
+} // namespace component
+} // namespace sofa


### PR DESCRIPTION
Very simple PR to allow Windows loading MultiThreading plugin.
Will fix these errors: https://ci.inria.fr/sofa-ci/job/windows7_VS-2015_options_amd64/550/warnings2Result/category.96784904/

[ci-build][with-scene-tests]
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
