### PR TITLE
[CGALPlugin] ADD compatible CGAL versions in Readme

### DIFF
--- a/applications/plugins/CGALPlugin/CGALPlugin.txt
+++ b/applications/plugins/CGALPlugin/CGALPlugin.txt
@@ -17,3 +17,4 @@ LICENCE :
 
 OTHER COMMENTS :
 Use CGAL components in SOFA.
+Compatible with CGAL <= 4.9.1 (TODO: make it compatible with CGAL > 4.9.1)


### PR DESCRIPTION
Very basic PR just to let you know that the CGAL plugin is not compatible with latest CGAL.
As is, it compiles with CGAL <= 4.9.1

CI build is unnecessary for this PR.
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
