### PR TITLE
[DCO] Update the CONTRIBUTING to use DCO instead of CLA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ For more information on forks and pull request, check out [this GitHub guide](ht
 
 ### SOFA Developer Certificate Of Origin (DCO)
 
-If you are contributing code or documentation to the SOFA project, and using the git signed-off-by mechanism, you are agreeing to this certificate.  This DCO essentially means that:
+SOFA is using the [mechanism of the linux project](https://www.kernel.org/doc/html/latest/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin) to track and secure all issues related to copyrights: the Developper Certificate of Origin (DCO). If you are contributing code or documentation to the SOFA project, and using the git signed-off-by mechanism, you are agreeing to this certificate.  This DCO essentially means that:
 
 - you offer the changes under the same license agreement as the project, and
 - you have the right to do that,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,11 +95,53 @@ Remember that:
 
 For more information on forks and pull request, check out [this GitHub guide](https://guides.github.com/activities/forking/).
 
-### SOFA Contributor License Agreement ("Agreement"), v1.0
 
-Note that by submitting a "Contribution" (shall mean the code, documentation or other original works of authorship) to SOFA, through the Pull Request mechanism in github or by other means, "You" (the entity that is making this Contribution) hereby accept and agree to the following terms and conditions for Your present and future Contributions:
+### SOFA Developer Certificate Of Origin (DCO)
 
-- You certify that You have authored 100% of the content, or in the event part or all of the content has been authored by a third party, you have appropriate permissions to include their work in your Contribution,
-- You certify You have the necessary rights to license the Contribution (i.e. if You are employed You have received the necessary permissions from Your employer to make the Contribution),
-- You grant a perpetual, irrevocable, non-exclusive, royalty-free, worldwide license to distribute this Contribution under the license agreement commonly known as the [LGPL License](https://opensource.org/licenses/LGPL-2.1).
-- You will remain the copyright holder of your Contribution.
+If you are contributing code or documentation to the SOFA project, and using the git signed-off-by mechanism, you are agreeing to this certificate.  This DCO essentially means that:
+
+- you offer the changes under the same license agreement as the project, and
+- you have the right to do that,
+- you did not steal somebody else’s work.
+
+The original DCO is available online : [http://developercertificate.org](http://developercertificate.org)
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```


### PR DESCRIPTION
When making a PR, the message for developers would then be:

Thank you for your pull request!
Someone will soon check it and start the builds.

Note that by submitting a contribution to SOFA and signing-off your commits (*git commit -S*), you hereby adhere to the [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)

Discussion with @dmargery