### PR TITLE
[SofaPython] FIX error in script for plotting advancedTimer output

### DIFF
--- a/applications/plugins/SofaPython/python/AdvancedTimerOutputAnalysis/timerLjsonManyFilesPlot.py
+++ b/applications/plugins/SofaPython/python/AdvancedTimerOutputAnalysis/timerLjsonManyFilesPlot.py
@@ -49,7 +49,7 @@ class TimerLjsonManyFilesPlot() :
 
             # First analys to take Steps informations
             if firstPass == 1 :
-                row = ["Steps", k]
+                row = ["Steps", int(k)]
                 parsedInformations.append(row)
                 # Take informations from the target componant
                 for kbis, vbis in v.items() :


### PR DESCRIPTION
The script would sometimes plot completely wrong info because some numbers were treated as strings.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
