### PR TITLE
FIX no step if condition on denominator is met at first step

### DIFF
--- a/SofaKernel/modules/SofaBaseLinearSolver/CGLinearSolver.inl
+++ b/SofaKernel/modules/SofaBaseLinearSolver/CGLinearSolver.inl
@@ -216,8 +216,8 @@ void CGLinearSolver<TMatrix,TVector>::solve(Matrix& M, Vector& x, Vector& b)
         graph_den.push_back(den);
 
 
-        /// Break condition = THRESHOLD criterion regarding the denominator is reached
-        if( fabs(den)<f_smallDenominatorThreshold.getValue() )
+        /// Break condition = THRESHOLD criterion regarding the denominator is reached (but do at least one iteration)
+        if( fabs(den)<f_smallDenominatorThreshold.getValue() && nb_iter>1)
         {
             endcond = "threshold";
             if( verbose )


### PR DESCRIPTION
Some scenes where presenting strange behavior : no object moving
with specific numerical settings, and with some others it was
working fine. This was due to a threshold of CG met at first step
on denominator value. Now force at least one step.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
