### PR TITLE
[SofaSimulation] warn users if the BBox is invalid

### DIFF
--- a/SofaKernel/framework/sofa/simulation/InitVisitor.cpp
+++ b/SofaKernel/framework/sofa/simulation/InitVisitor.cpp
@@ -42,7 +42,8 @@ Visitor::Result InitVisitor::processNodeTopDown(simulation::Node* node)
     node->initialize();
 
     sofa::defaulttype::BoundingBox* nodeBBox = node->f_bbox.beginEdit(params);
-    nodeBBox->invalidate();
+    if(!node->f_bbox.isSet())
+        nodeBBox->invalidate();
 
     for(unsigned int i=0; i<node->object.size(); ++i)
     {

--- a/SofaKernel/framework/sofa/simulation/Simulation.cpp
+++ b/SofaKernel/framework/sofa/simulation/Simulation.cpp
@@ -209,15 +209,6 @@ void Simulation::init ( Node* root )
 
     root->execute<UpdateBoundingBoxVisitor>(params);
 
-    //Check the validity of the BBox
-    const sofa::defaulttype::BoundingBox& nodeBBox = root->getContext()->f_bbox.getValue();
-    if(nodeBBox.isNegligeable())
-    {
-        msg_error("Simulation") << "Global Bounding Box seems invalid ; please implement updateBBox in your components "
-                                << "or force a value by adding the parameter bbox=\"minX minY minZ maxX maxY maxZ\" in your root node \n";
-        msg_error("Simulation") << "Your viewer settings (based on the bbox) are likely invalid.";
-    }
-
     // propagate the visualization settings (showVisualModels, etc.) in the whole graph
     updateVisualContext(root);
 }

--- a/SofaKernel/framework/sofa/simulation/Simulation.cpp
+++ b/SofaKernel/framework/sofa/simulation/Simulation.cpp
@@ -209,6 +209,15 @@ void Simulation::init ( Node* root )
 
     root->execute<UpdateBoundingBoxVisitor>(params);
 
+    //Check the validity of the BBox
+    const sofa::defaulttype::BoundingBox& nodeBBox = root->getContext()->f_bbox.getValue();
+    if(nodeBBox.isNegligeable())
+    {
+        msg_error("Simulation") << "Global Bounding Box seems invalid ; please implement updateBBox in your components "
+                                << "or force a value by adding the parameter bbox=\"minX minY minZ maxX maxY maxZ\" in your root node \n";
+        msg_error("Simulation") << "Your viewer settings (based on the bbox) are likely invalid.";
+    }
+
     // propagate the visualization settings (showVisualModels, etc.) in the whole graph
     updateVisualContext(root);
 }

--- a/SofaKernel/framework/sofa/simulation/UpdateBoundingBoxVisitor.cpp
+++ b/SofaKernel/framework/sofa/simulation/UpdateBoundingBoxVisitor.cpp
@@ -42,7 +42,8 @@ Visitor::Result UpdateBoundingBoxVisitor::processNodeTopDown(Node* node)
     helper::vector<BaseObject*>::iterator object;
     node->get<BaseObject>(&objectList,BaseContext::Local);
     sofa::defaulttype::BoundingBox* nodeBBox = node->f_bbox.beginEdit(params);
-    nodeBBox->invalidate();
+    if(!node->f_bbox.isSet())
+        nodeBBox->invalidate();
     for ( object = objectList.begin(); object != objectList.end(); ++object)
     {
         // warning the second parameter should NOT be false

--- a/applications/sofa/gui/qt/RealGUI.cpp
+++ b/applications/sofa/gui/qt/RealGUI.cpp
@@ -909,6 +909,15 @@ void RealGUI::setSceneWithoutMonitor (Node::SPtr root, const char* filename, boo
         checker.addCheck(simulation::SceneCheckMissingRequiredPlugin::newSPtr());
         checker.validate(root.get()) ;
 
+        //Check the validity of the BBox
+        const sofa::defaulttype::BoundingBox& nodeBBox = root->getContext()->f_bbox.getValue();
+        if(nodeBBox.isNegligeable())
+        {
+            msg_error("RealGUI") << "Global Bounding Box seems invalid ; please implement updateBBox in your components "
+                                    << "or force a value by adding the parameter bbox=\"minX minY minZ maxX maxY maxZ\" in your root node \n";
+            msg_error("RealGUI") << "Your viewer settings (based on the bbox) are likely invalid.";
+        }
+
         mSimulation = root;
         eventNewTime();
         startButton->setChecked(root->getContext()->getAnimate() );


### PR DESCRIPTION
The user was never informed that its scene does not compute bbox.
Consequently the viewer settings based on the bbox are messed up.

This PR will at least warn the user that he needs to either:
 - add a component which implements computeBBox
 - implement itself in its own components
 - force set  bbox="minx miny minz maxx maxy maxz" parameter in a node/component. The logic would want to set it in the root node.
This PR fixes also the fact that the bbox parameter was being ignored by the BBox computing visitors. 

This PR is related to issue #29, but it does not compute BBox automatically so #29 should not be closed, in my opinion.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
