### PR TITLE
Fix linearforcefield that disappears

### DIFF
--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearForceField.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearForceField.inl
@@ -99,19 +99,19 @@ void LinearForceFieldInternalData< gpu::cuda::CudaRigidTypes<N, real> >::addForc
 
     Real cT = (Real) m->getContext()->getTime();
 
-	if (m->keyTimes.getValue().size() != 0 && cT >= *m->keyTimes.getValue().begin() && cT <= *m->keyTimes.getValue().rbegin())
+    if (m->d_keyTimes.getValue().size() != 0 && cT >= *m->d_keyTimes.getValue().begin() && cT <= *m->d_keyTimes.getValue().rbegin())
     {
-        m->nextT = *m->keyTimes.getValue().begin();
+        m->nextT = *m->d_keyTimes.getValue().begin();
         m->prevT = m->nextT;
 
         bool finished = false;
 
-        typename helper::vector< Real >::const_iterator it_t = m->keyTimes.getValue().begin();
-        typename VecDeriv::const_iterator it_f = m->keyForces.getValue().begin();
+        typename helper::vector< Real >::const_iterator it_t = m->d_keyTimes.getValue().begin();
+        typename VecDeriv::const_iterator it_f = m->d_keyForces.getValue().begin();
 
         // WARNING : we consider that the key-events are in chronological order
         // here we search between which keyTimes we are.
-        while( it_t != m->keyTimes.getValue().end() && !finished)
+        while( it_t != m->d_keyTimes.getValue().end() && !finished)
         {
             if ( *it_t <= cT)
             {
@@ -132,7 +132,7 @@ void LinearForceFieldInternalData< gpu::cuda::CudaRigidTypes<N, real> >::addForc
         {
             Deriv slope = (m->nextF - m->prevF)*(1.0/(m->nextT - m->prevT));
             Deriv ff = slope*(cT - m->prevT) + m->prevF;
-            ff = ff*m->force.getValue();
+            ff = ff*m->d_force.getValue();
 
             Kernels::addForce(
                 data.size,

--- a/modules/SofaBoundaryCondition/LinearForceField.h
+++ b/modules/SofaBoundaryCondition/LinearForceField.h
@@ -70,19 +70,19 @@ public:
     SetIndex points;
 
     /// applied force for all the points
-    Data< Real > force;
+    Data< Real > d_force;
 
     /// the key frames when the forces are defined by the user
-    Data< helper::vector< Real > > keyTimes;
+    Data< helper::vector< Real > > d_keyTimes;
 
     /// forces corresponding to the key frames
-    Data< VecDeriv > keyForces;
+    Data< VecDeriv > d_keyForces;
 
     /// for drawing. The sign changes the direction, 0 doesn't draw arrow
-    Data< SReal > arrowSizeCoef;
+    Data< SReal > d_arrowSizeCoef;
 protected:
     LinearForceField();
-    virtual ~LinearForceField() { delete data; };
+    virtual ~LinearForceField() override { delete data; }
 
 public:
     void draw(const core::visual::VisualParams* vparams) override;
@@ -113,7 +113,7 @@ public:
     {
         //TODO: remove this line (avoid warning message) ...
         mparams->setKFactorUsed(true);
-    };
+    }
 
     virtual void addKToMatrix(sofa::defaulttype::BaseMatrix * matrix, SReal kFact, unsigned int &offset) override;
 


### PR DESCRIPTION
To use a LinearForceField, we need to specify a series of key times associated with forces. However, when simulation time goes beyond the last key time, the force becomes zero instantly. This PR changes it so that it stays at the last specified force instead.
There are a few more small changes to remove some warnings and to use SOFA coding conventions.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
