### PR TITLE
[GL] Fix: Intel graphics on linux now overrides the core profile context

### DIFF
--- a/applications/sofa/gui/qt/viewer/qt/QtViewer.cpp
+++ b/applications/sofa/gui/qt/viewer/qt/QtViewer.cpp
@@ -32,6 +32,7 @@
 #include <fstream>
 #include <string.h>
 #include <math.h>
+#include <stdlib.h>
 
 #include <qevent.h>
 
@@ -153,6 +154,10 @@ QtViewer::QtViewer(QWidget* parent, const char* name, const unsigned int nbMSAAS
     : QOpenGLWidget(setupGLFormat(nbMSAASamples), parent)
 #endif // defined(QT_VERSION) && QT_VERSION >= 0x050400
 {
+#ifdef __linux__
+    ::setenv("MESA_GL_VERSION_OVERRIDE", "3.0", 1);
+#endif // __linux
+
     this->setObjectName(name);
 
 #if defined(QT_VERSION) && QT_VERSION >= 0x050400

--- a/applications/sofa/gui/qt/viewer/qt/QtViewer.cpp
+++ b/applications/sofa/gui/qt/viewer/qt/QtViewer.cpp
@@ -218,7 +218,19 @@ QtViewer::~QtViewer()
 // -----------------------------------------------------------------
 void QtViewer::initializeGL(void)
 {
-    std::cout << "QtViewer: OpenGL " << glGetString(GL_VERSION) << " context created." << std::endl;
+    std::cout << "QtViewer: OpenGL " << glGetString(GL_VERSION)
+              << " context created." << std::endl;
+    if (std::string((const char*)glGetString(GL_VENDOR)).find("Intel") !=
+            std::string::npos)
+    {
+        const char* mesaEnv = ::getenv("MESA_GL_VERSION_OVERRIDE");
+        if ( !mesaEnv || std::string(mesaEnv) != "3.0")
+            msg_error("runSofa") << "QtViewer is not compatible with Intel drivers on "
+                                    "Linux. To use runSofa, either change the gui to "
+                                    "qglviewer (runSofa -g qglviewer) or set the "
+                                    "environment variable \"MESA_GL_VERSION_OVERRIDE\" "
+                                    "to the value \"3.0\"";
+    }
 
     static GLfloat specref[4];
     static GLfloat ambientLight[4];


### PR DESCRIPTION
fixing #238 
This fix solves the segfault at startup that intel-powered linux machines experience.
It should be a linux-specific bugfix to my understanding.
If anyone knows a clean way of probing whether or not a "Core profile" context would be created (something better than parsing lspci to see if we're runing an intel GPU...), I'll update this PR accordingly

Anyone to review?

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
