### PR TITLE
[CMakeLists.txt] Add macro to handle out-of-tree plugins in way similar to plugins/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,12 @@
 cmake_minimum_required(VERSION 3.1)
+# Force cmake to use the NEW policy regaring the find_package() policy management.
+# The OLD policy was generating a warning because we are shipping our own findThreads.cmake
+# which is overriding the one install on the host system. This warning is supress by
+# using the NEW policy. You can have more info by calling: "cmake --help-policy CMP0017"
+cmake_policy(SET CMP0017 NEW)
+
 project(Sofa)
+
 
 set(SOFA_KERNEL_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/SofaKernel" CACHE STRING "Path to SofaKernel")
 
@@ -373,6 +380,16 @@ if(NOT "${SOFA_EXTERNAL_DIRECTORIES}" STREQUAL "")
         get_filename_component(name ${dir} NAME) # Get the name of the actual directory
         message("Adding external directory: ${name} (${dir})")
         add_subdirectory(${dir} "${CMAKE_CURRENT_BINARY_DIR}/external_directories/${name}")
+    endforeach()
+endif()
+
+## Build external plugins at the same time
+set(SOFA_EXTERNAL_PLUGINS "" CACHE STRING "list of paths separated by ';'")
+if(NOT "${SOFA_EXTERNAL_PLUGINS}" STREQUAL "")
+    foreach(dir ${SOFA_EXTERNAL_PLUGINS})
+        get_filename_component(name ${dir} NAME) # Get the name of the actual directory
+        message("Adding external plugin: ${name} (${dir})")
+        sofa_add_plugin(${dir} ${name})
     endforeach()
 endif()
 

--- a/SofaKernel/SofaFramework/SofaMacros.cmake
+++ b/SofaKernel/SofaFramework/SofaMacros.cmake
@@ -162,7 +162,14 @@ endmacro()
 macro(sofa_add_generic directory name type)
 
     if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/${directory}" AND IS_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/${directory}")
+        set(absdirectory "${CMAKE_CURRENT_LIST_DIR}/${directory}")
+        set(type-ext "")
+    else()
+        set(absdirectory "${directory}")
+        set(type-ext "(out-of-tree location)")
+    endif()
 
+    if(EXISTS "${absdirectory}" AND IS_DIRECTORY "${absdirectory}")
         string(TOUPPER ${type}_${name} option)
 
         # optional parameter to activate/desactivate the option
@@ -176,7 +183,7 @@ macro(sofa_add_generic directory name type)
 
         option(${option} "Build the ${name} ${type}." ${active})
         if(${option})
-            message("Adding ${type} ${name}")
+            message("Adding ${type} ${name} ${type-ext}")
             add_subdirectory(${directory} ${name})
             #Check if the target has been successfully added
             if(TARGET ${name})
@@ -188,7 +195,7 @@ macro(sofa_add_generic directory name type)
         set_property(GLOBAL APPEND PROPERTY __GlobalTargetList__ ${name})
         set_property(GLOBAL APPEND PROPERTY __GlobalTargetNameList__ ${option})
     else()
-        message("${type} ${name} (${CMAKE_CURRENT_LIST_DIR}/${directory}) does not exist and will be ignored.")
+        message("${type} ${name} (${absdirectory}) does not exist and will be ignored.")
     endif()
 endmacro()
 


### PR DESCRIPTION
Currently there is the SOFA_EXTERNAL_DIRECTORY to add out-of-tree
directory in the compilation process. But when this directory contains
plugins those one are not handled the same way as are the one in
application/plugin.

To unify that I added a SOFA_EXTERNAL_PLUGIN option and
did minimal change to the 'sofa_add_generic' macro to detect and
handle out of tree directory.

So if you want to add external plugin you can use SOFA_EXTERNAL_PLUGIN
instead of SOFA_EXTERNAL_DIRECTORY.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
