### PR TITLE
[config] CHANGE USE_MASK option to off by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,7 @@ if(MSVC)
 endif()
 
 ### Mask
-option(SOFA_USE_MASK "Use mask optimization" ON)
+option(SOFA_USE_MASK "Use mask optimization" OFF)
 
 ### SOFA_DEV_TOOL
 option(SOFA_WITH_DEVTOOLS "Compile with developement extra features." ON)


### PR DESCRIPTION
A few people in the Mimesis team have made comments about errors that occur when the USE_MASK option is enabled. This PR simply sets the option as disabled by default, so that users will not unknowingly use it.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
