### PR TITLE
[CImgPlugin] Use sofa cmake command to create proper package

### DIFF
--- a/applications/plugins/CImgPlugin/CImgPluginConfig.cmake.in
+++ b/applications/plugins/CImgPlugin/CImgPluginConfig.cmake.in
@@ -1,0 +1,11 @@
+# CMake package configuration file for the CImgPlugin plugin
+
+@PACKAGE_INIT@
+
+find_package(SofaGeneral REQUIRED)
+
+if(NOT TARGET CImgPlugin)
+    include("${CMAKE_CURRENT_LIST_DIR}/CImgPluginTargets.cmake")
+endif()
+
+check_required_components(CImgPlugin)

--- a/applications/plugins/CImgPlugin/CMakeLists.txt
+++ b/applications/plugins/CImgPlugin/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(CImgPlugin)
 
+set(${PROJECT_NAME}_MAJOR_VERSION 0)
+set(${PROJECT_NAME}_MINOR_VERSION 1)
+set(${PROJECT_NAME}_VERSION ${${PROJECT_NAME}_MAJOR_VERSION}.${${PROJECT_NAME}_MINOR_VERSION})
+
 ## RPATH
 if(UNIX)
     set(CMAKE_INSTALL_RPATH "../lib")
@@ -90,10 +94,6 @@ target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CUR
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CImg_INCLUDE_DIRS}>")
 
-install(TARGETS ${PROJECT_NAME}
-        COMPONENT CImgPlugin_libraries
-        EXPORT CImgPluginTargets
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib)
+## Install rules for the library; CMake package configurations files
+sofa_create_package(${PROJECT_NAME} ${${PROJECT_NAME}_VERSION} ${PROJECT_NAME} ${PROJECT_NAME})
 


### PR DESCRIPTION
With this PR you can `find_package(CImgPlugin)` in an other cmake project. Quite useful since this plugin is indeed part of the *core*



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
