### PR TITLE
[runSofa] Remove the scenechecker when reloading a file in interactive mode.

### DIFF
--- a/applications/sofa/gui/qt/RealGUI.cpp
+++ b/applications/sofa/gui/qt/RealGUI.cpp
@@ -756,11 +756,15 @@ void RealGUI::fileOpen ( std::string filename, bool temporaryFile, bool reload )
 
     /// We want to warn user that there is component that are implemented in specific plugin
     /// and that there is no RequiredPlugin in their scene.
-    SceneCheckerVisitor checker(ExecParams::defaultInstance()) ;
-    checker.addCheck(simulation::SceneCheckAPIChange::newSPtr());
-    checker.addCheck(simulation::SceneCheckDuplicatedName::newSPtr());
-    checker.addCheck(simulation::SceneCheckMissingRequiredPlugin::newSPtr());
-    checker.validate(mSimulation.get()) ;
+    /// But we don't want that to happen each reload in interactive mode.
+    if(reload)
+    {
+        SceneCheckerVisitor checker(ExecParams::defaultInstance()) ;
+        checker.addCheck(simulation::SceneCheckAPIChange::newSPtr());
+        checker.addCheck(simulation::SceneCheckDuplicatedName::newSPtr());
+        checker.addCheck(simulation::SceneCheckMissingRequiredPlugin::newSPtr());
+        checker.validate(mSimulation.get()) ;
+    }
 }
 
 


### PR DESCRIPTION
While working in interactive mode the scenechecker is executed each time the file is reloaded. This is 
not really convenient.. Thus this fix.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
