### PR TITLE
[SofaExporter] FIX message in VTKExporter with new API and activate printLog

### DIFF
--- a/examples/Components/misc/VTKExporter.scn
+++ b/examples/Components/misc/VTKExporter.scn
@@ -1,7 +1,7 @@
 <Node name="root" dt="0.01" gravity="0 -9.81 0">
     <Mesh name="mesh" filename="mesh/dragon.obj" />
     <MeshObjLoader name="loader" filename="mesh/dragon.obj" />
-    <MechanicalObject src="@loader" template="Vec3f" name="mecha" />
+    <MechanicalObject src="@loader" template="Vec3f" name="mecha" showObject="1" />
     <TetrahedronSetTopologyContainer src="@loader" name="topo" />
-    <VTKExporter filename="example.vtk" listening="true" edges="0" triangles="1" quads="0" tetras="0" pointsDataFields="mecha.position" />
+    <VTKExporter filename="example.vtk" listening="true" edges="0" triangles="1" quads="0" tetras="0" pointsDataFields="mecha.position" exportAtBegin="1" />
 </Node>

--- a/modules/SofaExporter/VTKExporter.cpp
+++ b/modules/SofaExporter/VTKExporter.cpp
@@ -37,6 +37,7 @@
 #include <sofa/simulation/AnimateEndEvent.h>
 #include <sofa/core/objectmodel/KeypressedEvent.h>
 #include <sofa/core/objectmodel/KeyreleasedEvent.h>
+#include <sofa/helper/logging/Messaging.h>
 
 namespace sofa
 {
@@ -78,17 +79,24 @@ VTKExporter::~VTKExporter()
 }
 
 void VTKExporter::init()
-{
+{    
     sofa::core::objectmodel::BaseContext* context = this->getContext();
     context->get(topology);
     context->get(mstate);
 
+    // if not set, set the printLog to true to read the msg_info()
+    if(!this->f_printLog.isSet())
+        f_printLog.setValue(true);
+
     if (!topology)
     {
-        serr << "VTKExporter : error, no topology ." << sendl;
+        msg_error() << "VTKExporter : error, no topology ." ;
         return;
     }
-    else sout << "VTKExporter: found topology " << topology->getName() << sendl;
+    else
+    {
+        msg_info() << "VTKExporter: found topology " << topology->getName() ;
+    }
 
     nbFiles = 0;
 
@@ -129,7 +137,7 @@ void VTKExporter::fetchDataFields(const helper::vector<std::string>& strData, he
         }
         else
         {
-            serr << "VTKExporter : error while parsing dataField names" << sendl;
+            msg_error() << "VTKExporter : error while parsing dataField names" ;
             continue;
         }
         if (name.empty()) name = dataFieldName;
@@ -155,13 +163,13 @@ void VTKExporter::writeData(const helper::vector<std::string>& objects, const he
         if (!obj || !field)
         {
             if (!obj)
-                serr << "VTKExporter : error while fetching data field '"
-                     << fields[i] << "' of object '" << objects[i]
-                     << "', check object name" << sendl;
+                msg_error() << "VTKExporter : error while fetching data field '" << msgendl
+                            << fields[i] << "' of object '" << objects[i] << msgendl
+                            << "', check object name"  << msgendl;
             else if (!field)
-                serr << "VTKExporter : error while fetching data field "
-                     << fields[i] << " of object '" << objects[i]
-                     << "', check field name " << sendl;
+                msg_error() << "VTKExporter : error while fetching data field " << msgendl
+                            << fields[i] << " of object '" << objects[i] << msgendl
+                            << "', check field name " << msgendl;
         }
         else
         {
@@ -237,13 +245,13 @@ void VTKExporter::writeDataArray(const helper::vector<std::string>& objects, con
         if (!obj || !field)
         {
             if (!obj)
-                serr << "VTKExporter : error while fetching data field '"
-                     << fields[i] << "' of object '" << objects[i]
-                     << "', check object name" << sendl;
+                msg_error() << "VTKExporter : error while fetching data field '" << msgendl
+                            << fields[i] << "' of object '" << objects[i] << msgendl
+                            << "', check object name" << msgendl;
             else if (!field)
-                serr << "VTKExporter : error while fetching data field "
-                     << fields[i] << " of object '" << objects[i]
-                     << "', check field name " << sendl;
+                msg_error()  << "VTKExporter : error while fetching data field " << msgendl
+                             << fields[i] << " of object '" << objects[i] << msgendl
+                             << "', check field name " << msgendl;
         }
         else
         {
@@ -388,7 +396,7 @@ void VTKExporter::writeVTKSimple()
     outfile = new std::ofstream(filename.c_str());
     if( !outfile->is_open() )
     {
-        serr << "Error creating file "<<filename<<sendl;
+        msg_error() << "Error creating file "<<filename;
         delete outfile;
         outfile = NULL;
         return;
@@ -531,10 +539,12 @@ void VTKExporter::writeVTKSimple()
         *outfile << "CELL_DATA " << numberOfCells << std::endl;
         writeData(cellsDataObject, cellsDataField, cellsDataName);
     }
+
     outfile->close();
-    sout << filename << " written" << sendl;
 
     ++nbFiles;
+
+    msg_info() << "Export VTK in file " << filename << "  done.";
 }
 
 void VTKExporter::writeVTKXML()
@@ -559,7 +569,7 @@ void VTKExporter::writeVTKXML()
     outfile = new std::ofstream(filename.c_str());
     if( !outfile->is_open() )
     {
-        serr << "Error creating file "<<filename<<sendl;
+        msg_error() << "Error creating file "<<filename;
         delete outfile;
         outfile = NULL;
         return;
@@ -749,8 +759,9 @@ void VTKExporter::writeVTKXML()
     *outfile << "  </UnstructuredGrid>" << std::endl;
     *outfile << "</VTKFile>" << std::endl;
     outfile->close();
-    sout << filename << " written" << sendl;
     ++nbFiles;
+
+    msg_info() << "Export VTK XML in file " << filename << "  done.";
 }
 
 void VTKExporter::writeParallelFile()
@@ -762,7 +773,7 @@ void VTKExporter::writeParallelFile()
     outfile = new std::ofstream(filename.c_str());
     if( !outfile->is_open() )
     {
-        serr << "Error creating file "<<filename<<sendl;
+        msg_error() << "Error creating file "<<filename;
         delete outfile;
         outfile = NULL;
         return;
@@ -790,13 +801,13 @@ void VTKExporter::writeParallelFile()
             if (!obj || !field)
             {
                 if (!obj)
-                    serr << "VTKExporter : error while fetching data field '"
-                         << pointsDataField[i] << "' of object '" << pointsDataObject[i]
-                         << "', check object name" << sendl;
+                    msg_error() << "VTKExporter : error while fetching data field '" << msgendl
+                                << pointsDataField[i] << "' of object '" << pointsDataObject[i] << msgendl
+                                << "', check object name" << msgendl;
                 else if (!field)
-                    serr << "VTKExporter : error while fetching data field '"
-                         << pointsDataField[i] << "' of object '" << pointsDataObject[i]
-                         << "', check field name " << sendl;
+                    msg_error() << "VTKExporter : error while fetching data field '" << msgendl
+                                << pointsDataField[i] << "' of object '" << pointsDataObject[i] << msgendl
+                                << "', check field name " << msgendl;
             }
             else
             {
@@ -863,13 +874,13 @@ void VTKExporter::writeParallelFile()
             if (!obj || !field)
             {
                 if (!obj)
-                    serr << "VTKExporter : error while fetching data field '"
+                    msg_error() << "VTKExporter : error while fetching data field '"
                          << cellsDataField[i] << "' of object '" << cellsDataObject[i]
                          << "', check object name" << sendl;
                 else if (!field)
-                    serr << "VTKExporter : error while fetching data field '"
-                         << cellsDataField[i] << "' of object '" << cellsDataObject[i]
-                         << "', check field name " << sendl;
+                    msg_error() << "VTKExporter : error while fetching data field '" << msgendl
+                                << cellsDataField[i] << "' of object '" << cellsDataObject[i] << msgendl
+                                << "', check field name " << msgendl;
             }
             else
             {
@@ -938,7 +949,8 @@ void VTKExporter::writeParallelFile()
     *outfile << "  </PUnstructuredGrid>" << std::endl;
     *outfile << "</VTKFile>" << std::endl;
     outfile->close();
-    sout << "parallel file " << filename << " written" << sendl;
+
+    msg_info() << "Export VTK in file " << filename << "  done.";
 }
 
 


### PR DESCRIPTION
Minor PR just allowing the messages (msg_info) of **VTKExporter** of being indeed outputed
To do this, I just activated the _printLog_ flag for msg_info



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
