### PR TITLE
[CI] EDIT: make scene-tests output file smaller

### DIFF
--- a/scripts/ci/scene-tests.sh
+++ b/scripts/ci/scene-tests.sh
@@ -321,7 +321,9 @@ extract-warnings() {
             sed -ne "/^\[WARNING\] [^]]*/s:\([^]]*\):$scene\: \1:p \
                 " "$output_dir/$scene/output.txt"
         fi
-    done < "$output_dir/all-tested-scenes.txt" > "$output_dir/warnings.txt"
+    done < "$output_dir/all-tested-scenes.txt" > "$output_dir/warnings.tmp"
+    sort "$output_dir/warnings.tmp" | uniq > "$output_dir/warnings.txt"
+    rm -f "$output_dir/warnings.tmp"
 }
 
 extract-errors() {
@@ -330,7 +332,9 @@ extract-errors() {
             sed -ne "/^\[ERROR\] [^]]*/s:\([^]]*\):$scene\: \1:p \
                 " "$output_dir/$scene/output.txt"
         fi
-    done < "$output_dir/all-tested-scenes.txt" > "$output_dir/errors.txt"
+    done < "$output_dir/all-tested-scenes.txt" > "$output_dir/errors.tmp"
+    sort "$output_dir/errors.tmp" | uniq > "$output_dir/errors.txt"
+    rm -f "$output_dir/errors.tmp"
 }
 
 extract-crashes() {
@@ -341,7 +345,9 @@ extract-crashes() {
                 echo "$scene: error: $status"
             fi
         fi
-    done < "$output_dir/all-tested-scenes.txt" > "$output_dir/crashes.txt"
+    done < "$output_dir/all-tested-scenes.txt" > "$output_dir/crashes.tmp"
+    sort "$output_dir/crashes.tmp" | uniq > "$output_dir/crashes.txt"
+    rm -f "$output_dir/crashes.tmp"
 }
 
 extract-successes() {
@@ -352,7 +358,9 @@ extract-successes() {
                 grep --silent "\[ERROR\]" "$output_dir/$scene/output.txt" || echo "$scene"
             fi
         fi
-    done < "$output_dir/all-tested-scenes.txt" > "$output_dir/successes.txt"
+    done < "$output_dir/all-tested-scenes.txt" > "$output_dir/successes.tmp"
+    sort "$output_dir/successes.tmp" | uniq > "$output_dir/successes.txt"
+    rm -f "$output_dir/successes.tmp"
 }
 
 count-tested-scenes() {
@@ -360,11 +368,11 @@ count-tested-scenes() {
 }
 
 count-successes() {
-    sort "$output_dir/successes.txt" | uniq | wc -l | tr -d ' 	'
+    wc -l < "$output_dir/successes.txt" | tr -d ' 	'
 }
 
 count-warnings() {
-    sort "$output_dir/warnings.txt" | uniq | wc -l | tr -d ' 	'
+    wc -l < "$output_dir/warnings.txt" | tr -d ' 	'
 }
 
 count-errors() {


### PR DESCRIPTION
by filtering duplicates warnings/errors/crashes

This should fix JVM heap problems on small VMs when parsing scene-testing/warnings.txt, scene-testing/errors.txt and scene-testing/crashes.txt

Please don't forget the real problem is that we have 60k+ scene-test warnings...

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
