### PR TITLE
[SofaBaseLinearSolver] FIX breaking condition in CG at first step regarding threshold

### DIFF
--- a/SofaKernel/modules/SofaBaseLinearSolver/CGLinearSolver.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/CGLinearSolver.h
@@ -75,6 +75,7 @@ protected:
 
 public:
     virtual void init() override;
+    virtual void reinit() override;
 
     void resetSystem() override;
 

--- a/SofaKernel/modules/SofaBaseLinearSolver/CGLinearSolver.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/CGLinearSolver.h
@@ -74,6 +74,8 @@ protected:
     inline void cgstep_alpha(const core::ExecParams* params, Vector& x, Vector& r, Vector& p, Vector& q, SReal alpha);
 
 public:
+    virtual void init() override;
+
     void resetSystem() override;
 
     void setSystemMBKMatrix(const sofa::core::MechanicalParams* mparams) override;

--- a/SofaKernel/modules/SofaBaseLinearSolver/CGLinearSolver.inl
+++ b/SofaKernel/modules/SofaBaseLinearSolver/CGLinearSolver.inl
@@ -223,11 +223,11 @@ void CGLinearSolver<TMatrix,TVector>::solve(Matrix& M, Vector& x, Vector& b)
             {
                 if(f_warmStart.getValue())
                 {
-                    msg_info() << "Equilibrium found at first step (x=A^{-1}b)";
+                    msg_info() << "Equilibrium found at first step";
                 }
                 else
                 {
-                    msg_warning() << "b or A is zero (in Ax=b system), i.e. no external force or no mass is defined.";
+                    msg_info() << "b or A is zero (in Ax=b system), i.e. no external force or no mass is defined";
                 }
 
                 endcond = "threshold";
@@ -245,7 +245,7 @@ void CGLinearSolver<TMatrix,TVector>::solve(Matrix& M, Vector& x, Vector& b)
             else if(nb_iter == 1)
             {
                 msg_warning() << "denominator threshold reached at first iteration of CG" << msgendl
-                                 "Check the 'threshold' data field, you might decrease it";
+                              << "Check the 'threshold' data field, you might decrease it";
             }
             else
             {

--- a/SofaKernel/modules/SofaBaseLinearSolver/CGLinearSolver.inl
+++ b/SofaKernel/modules/SofaBaseLinearSolver/CGLinearSolver.inl
@@ -92,6 +92,15 @@ void CGLinearSolver<TMatrix,TVector>::init()
 }
 
 template<class TMatrix, class TVector>
+void CGLinearSolver<TMatrix,TVector>::reinit()
+{
+    if(f_verbose.getValue())
+    {
+        this->f_printLog.setValue(true);
+    }
+}
+
+template<class TMatrix, class TVector>
 void CGLinearSolver<TMatrix,TVector>::resetSystem()
 {
     f_graph.beginEdit()->clear();

--- a/SofaKernel/modules/SofaBaseLinearSolver/CGLinearSolver.inl
+++ b/SofaKernel/modules/SofaBaseLinearSolver/CGLinearSolver.inl
@@ -182,7 +182,6 @@ void CGLinearSolver<TMatrix,TVector>::solve(Matrix& M, Vector& x, Vector& b)
         }
 #endif
 
-
         /// Compute p = r^2
         rho = r.dot(r);
 
@@ -224,7 +223,6 @@ void CGLinearSolver<TMatrix,TVector>::solve(Matrix& M, Vector& x, Vector& b)
             /// Update p = p*beta + r;
             cgstep_beta(params, p,r,beta);
         }
-
 
         if( verbose )
         {
@@ -276,7 +274,6 @@ void CGLinearSolver<TMatrix,TVector>::solve(Matrix& M, Vector& x, Vector& b)
 
         /// End of the CG step : update x and r
         cgstep_alpha(params, x,r,p,q,alpha);
-
 
         if( verbose )
         {

--- a/SofaKernel/modules/SofaBaseLinearSolver/CGLinearSolver.inl
+++ b/SofaKernel/modules/SofaBaseLinearSolver/CGLinearSolver.inl
@@ -66,6 +66,11 @@ CGLinearSolver<TMatrix,TVector>::CGLinearSolver()
 template<class TMatrix, class TVector>
 void CGLinearSolver<TMatrix,TVector>::init()
 {
+    if(f_verbose.getValue())
+    {
+        this->f_printLog.setValue(true);
+    }
+
     if(f_maxIter.getValue() < 0)
     {
         msg_warning() << "'iterations' must be a positive value" << msgendl
@@ -132,7 +137,7 @@ void CGLinearSolver<TMatrix,TVector>::solve(Matrix& M, Vector& x, Vector& b)
     double rho, rho_1=0, alpha, beta;
 
 
-    msg_info_when(verbose) << " CGLinearSolver, b = " << b ;
+    msg_info_when(verbose) << "b = " << b ;
 
 
     /// Compute the initial residual r
@@ -205,7 +210,7 @@ void CGLinearSolver<TMatrix,TVector>::solve(Matrix& M, Vector& x, Vector& b)
             endcond = "tolerance";
             if( verbose )
             {
-                msg_info() << "CGLinearSolver, error = " << err <<", tolerance = " << f_tolerance.getValue();
+                msg_info() << "error = " << err <<", tolerance = " << f_tolerance.getValue();
             }
 
 #ifdef SOFA_DUMP_VISITOR_INFO
@@ -259,7 +264,7 @@ void CGLinearSolver<TMatrix,TVector>::solve(Matrix& M, Vector& x, Vector& b)
             endcond = "threshold";
             if( verbose )
             {
-                msg_info() << "CGLinearSolver, den = " << den <<", smallDenominatorThreshold = " << f_smallDenominatorThreshold.getValue();
+                msg_info() << "den = " << den <<", smallDenominatorThreshold = " << f_smallDenominatorThreshold.getValue();
             }
 
 #ifdef SOFA_DUMP_VISITOR_INFO
@@ -278,9 +283,7 @@ void CGLinearSolver<TMatrix,TVector>::solve(Matrix& M, Vector& x, Vector& b)
 
         if( verbose )
         {
-            msg_info() << "den = " << den << ", alpha = " << alpha;
-            msg_info() << "x : " << x;
-            msg_info() << "r : " << r;
+            msg_info() << "den = " << den << ", alpha = " << alpha << ", x = " << x << ", r = " << r;
         }
 
         rho_1 = rho;

--- a/SofaKernel/modules/SofaBaseLinearSolver/CGLinearSolver.inl
+++ b/SofaKernel/modules/SofaBaseLinearSolver/CGLinearSolver.inl
@@ -46,9 +46,9 @@ namespace linearsolver
 /// Linear system solver using the conjugate gradient iterative algorithm
 template<class TMatrix, class TVector>
 CGLinearSolver<TMatrix,TVector>::CGLinearSolver()
-    : f_maxIter( initData(&f_maxIter,(unsigned)25,"iterations","maximum number of iterations of the Conjugate Gradient solution") )
-    , f_tolerance( initData(&f_tolerance,(SReal)1e-5,"tolerance","desired precision of the Conjugate Gradient Solution (ratio of current residual norm over initial residual norm)") )
-    , f_smallDenominatorThreshold( initData(&f_smallDenominatorThreshold,(SReal)1e-5,"threshold","minimum value of the denominator in the conjugate Gradient solution") )
+    : f_maxIter( initData(&f_maxIter,(unsigned)25,"iterations","Maximum number of iterations of the Conjugate Gradient solution") )
+    , f_tolerance( initData(&f_tolerance,(SReal)1e-5,"tolerance","Desired accuracy of the Conjugate Gradient solution (ratio of current residual norm over initial residual norm)") )
+    , f_smallDenominatorThreshold( initData(&f_smallDenominatorThreshold,(SReal)1e-5,"threshold","Minimum value of the denominator in the conjugate Gradient solution") )
     , f_warmStart( initData(&f_warmStart,false,"warmStart","Use previous solution as initial solution") )
     , f_verbose( initData(&f_verbose,false,"verbose","Dump system state at each iteration") )
     , f_graph( initData(&f_graph,"graph","Graph of residuals at each iteration") )
@@ -201,15 +201,18 @@ void CGLinearSolver<TMatrix,TVector>::solve(Matrix& M, Vector& x, Vector& b)
                 msg_warning() << "tolerance reached at first iteration of CG" << msgendl
                               << "Check the 'tolerance' data field, you might decrease it";
             }
-            else
+
+            endcond = "tolerance";
+            if( verbose )
             {
-                endcond = "tolerance";
-    #ifdef SOFA_DUMP_VISITOR_INFO
-                if (simulation::Visitor::isPrintActivated())
-                    simulation::Visitor::printCloseNode(comment.str());
-    #endif
-                break;
+                msg_info() << "CGLinearSolver, error = " << err <<", tolerance = " << f_tolerance.getValue();
             }
+
+#ifdef SOFA_DUMP_VISITOR_INFO
+            if (simulation::Visitor::isPrintActivated())
+                simulation::Visitor::printCloseNode(comment.str());
+#endif
+            break;
         }
 
 
@@ -252,20 +255,18 @@ void CGLinearSolver<TMatrix,TVector>::solve(Matrix& M, Vector& x, Vector& b)
                 msg_warning() << "denominator threshold reached at first iteration of CG" << msgendl
                               << "Check the 'threshold' data field, you might decrease it";
             }
-            else
-            {
-                endcond = "threshold";
-                if( verbose )
-                {
-                    msg_info() << "CGLinearSolver, den = " << den <<", smallDenominatorThreshold = " << f_smallDenominatorThreshold.getValue();
-                }
 
-    #ifdef SOFA_DUMP_VISITOR_INFO
-                if (simulation::Visitor::isPrintActivated())
-                    simulation::Visitor::printCloseNode(comment.str());
-    #endif
-                break;
+            endcond = "threshold";
+            if( verbose )
+            {
+                msg_info() << "CGLinearSolver, den = " << den <<", smallDenominatorThreshold = " << f_smallDenominatorThreshold.getValue();
             }
+
+#ifdef SOFA_DUMP_VISITOR_INFO
+            if (simulation::Visitor::isPrintActivated())
+                simulation::Visitor::printCloseNode(comment.str());
+#endif
+            break;
         }
 
 


### PR DESCRIPTION
Fix bug introduced in #521 

If threshold is met at first step with den=0, break but info msg
about the status of the linear system.

If threshold is met at first with den!=0, then continue one more iteration
and warning about threshold value too large.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
