### PR TITLE
[SofaHelper] FIX Windows relative path from runSofa

### DIFF
--- a/SofaKernel/framework/sofa/helper/Utils.cpp
+++ b/SofaKernel/framework/sofa/helper/Utils.cpp
@@ -265,6 +265,11 @@ const std::string& Utils::getSofaPathPrefix()
     return prefix;
 }
 
+const std::string Utils::getSofaPathTo(const std::string& pathFromBuildDir)
+{
+    return getSofaPathPrefix() + "/" + pathFromBuildDir;
+}
+
 std::map<std::string, std::string> Utils::readBasicIniFile(const std::string& path)
 {
     std::map<std::string, std::string> map;

--- a/SofaKernel/framework/sofa/helper/Utils.h
+++ b/SofaKernel/framework/sofa/helper/Utils.h
@@ -85,6 +85,12 @@ static const std::string& getPluginDirectory();
 /// the "bin" directory.)
 static const std::string& getSofaPathPrefix();
 
+/// @brief Construct a path based on the build dir path of Sofa
+///
+/// @warning This function is meant to be used only by the applications that are
+/// distributed with SOFA: it uses getSofaPathPrefix()
+static const std::string getSofaPathTo(const std::string& pathFromBuildDir);
+
 /// @brief Read a file written in a very basic ini-like format.
 ///
 /// For each line that contains a '=' character, (e.g. "key=value"), the returned

--- a/SofaKernel/framework/sofa/helper/system/FileRepository.cpp
+++ b/SofaKernel/framework/sofa/helper/system/FileRepository.cpp
@@ -42,6 +42,7 @@
 #include <algorithm>
 #include <sstream>
 #include <sofa/helper/logging/Messaging.h>
+#include <sofa/helper/Utils.h>
 
 #ifdef WIN32
 #define ON_WIN32 true
@@ -76,9 +77,9 @@ std::string cleanPath( const std::string& path )
 
 /// Initialize PluginRepository with the current working directory
 #ifdef WIN32
-FileRepository PluginRepository("SOFA_PLUGIN_PATH", "../bin" );
+FileRepository PluginRepository( "SOFA_PLUGIN_PATH", Utils::getExecutableDirectory().c_str() );
 #else
-FileRepository PluginRepository("SOFA_PLUGIN_PATH", "../lib");
+FileRepository PluginRepository( "SOFA_PLUGIN_PATH", Utils::getSofaPathTo("lib").c_str() );
 #endif
 
 FileRepository DataRepository("SOFA_DATA_PATH");

--- a/applications/plugins/Registration/Registration_run/Registration_run.cpp
+++ b/applications/plugins/Registration/Registration_run/Registration_run.cpp
@@ -23,13 +23,6 @@ int main(int argc, char** argv)
 {
     glutInit(&argc,argv);
 
-#ifdef WIN32
-    const std::string pluginsDir = "bin";
-#else
-    const std::string pluginsDir = "lib";
-#endif
-    sofa::helper::system::PluginRepository.addFirstPath(Utils::getSofaPathPrefix() + "/" + pluginsDir);
-
     std::string fileName;
     // these can be passed using the command line
 //    fileName = std::string(registration_SRC_DIR) + "/examples/knee/precompute_model.py";

--- a/applications/projects/Modeler/exec/Main.cpp
+++ b/applications/projects/Modeler/exec/Main.cpp
@@ -85,13 +85,6 @@ int main(int argc, char** argv)
         sofa::helper::system::DataRepository.addFirstPath(examplesDir);
     }
 
-#ifdef WIN32
-    const std::string pluginDir = Utils::getExecutableDirectory();
-#else
-    const std::string pluginDir = Utils::getSofaPathPrefix() + "/lib";
-#endif
-    sofa::helper::system::PluginRepository.addFirstPath(pluginDir);
-
 	Q_INIT_RESOURCE(icons);
     sofa::gui::qt::SofaModeler* sofaModeler = new sofa::gui::qt::SofaModeler();
 

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -328,7 +328,6 @@ int main(int argc, char** argv)
     // Initialise paths
     BaseGUI::setConfigDirectoryPath(Utils::getSofaPathPrefix() + "/config", true);
     BaseGUI::setScreenshotDirectoryPath(Utils::getSofaPathPrefix() + "/screenshots", true);
-    PluginRepository.addFirstPath( Utils::getPluginDirectory() );
 
     if (!files.empty())
         fileName = files[0];

--- a/applications/sofa/gui/qt/GuiDataRepository.cpp
+++ b/applications/sofa/gui/qt/GuiDataRepository.cpp
@@ -25,6 +25,10 @@
 *******************************************************************************/
 
 #include "GuiDataRepository.h"
+#include <sofa/helper/Utils.h>
+
+using sofa::helper::system::FileRepository;
+using sofa::helper::Utils;
 
 namespace sofa
 {
@@ -32,7 +36,9 @@ namespace gui
 {
 namespace qt
 {
-    sofa::helper::system::FileRepository GuiDataRepository("GUI_DATA_PATH", "../share/sofa/gui/qt/resources/");
+
+FileRepository GuiDataRepository("GUI_DATA_PATH", Utils::getSofaPathTo("share/sofa/gui/qt/resources").c_str());
+
 }
 }
 }

--- a/tools/SofaGTestMain/SofaGTestMain.cpp
+++ b/tools/SofaGTestMain/SofaGTestMain.cpp
@@ -23,14 +23,6 @@ int main(int argc, char **argv)
     sofa::simulation::graph::init();
 #endif
 
-#ifdef WIN32
-    const std::string pluginDirectory = Utils::getExecutableDirectory();
-#else
-    const std::string pluginDirectory = Utils::getSofaPathPrefix() + "/lib";
-#endif
-    sofa::helper::system::PluginRepository.addFirstPath(pluginDirectory);
-    DataRepository.addFirstPath(std::string(SOFA_SRC_DIR) + "/share");
-
     int ret =  RUN_ALL_TESTS();
 
 #ifdef SOFA_HAVE_DAG


### PR DESCRIPTION
Fixes #561 

This PR does the same work as #564 but using the existing `Utils::getSofaPathPrefix()` function and avoiding heavy macro creation in root CMakelists.
I also removed all the PluginRepository and DataRepository re-inits.

Sorry @ErwanDouaille I did not know this function before :-/

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
