### PR TITLE
[SofaGraphComponent] FIX Fix suggested by SceneChecker contains an error

### DIFF
--- a/modules/SofaGraphComponent/SceneChecks.cpp
+++ b/modules/SofaGraphComponent/SceneChecks.cpp
@@ -92,7 +92,7 @@ void SceneCheckDuplicatedName::doCheckOn(Node* node)
     if(!tmp.str().empty())
     {
         m_hasDuplicates = true ;
-        m_duplicatedMsg << "- Found duplicated names "<<"' [" << tmp.str() << "] in node '"<<  node->getPathName() << "'" << msgendl ;
+        m_duplicatedMsg << "- Found duplicated names [" << tmp.str() << "] in node '"<<  node->getPathName() << "'" << msgendl ;
     }
 }
 
@@ -102,8 +102,8 @@ void SceneCheckDuplicatedName::doPrintSummary()
     {
         msg_warning("SceneCheckDuplicatedName") << msgendl
                                                 << m_duplicatedMsg.str()
-                                                << "Nodes with similar names at the same leve of your scene can "
-                                                   "crash certain operations, please them rename" ;
+                                                << "Nodes with similar names at the same level in your scene can "
+                                                   "crash certain operations, please rename them" ;
     }
 }
 
@@ -151,7 +151,7 @@ void SceneCheckMissingRequiredPlugin::doPrintSummary()
         std::stringstream tmp ;
         for(auto& kv : m_requiredPlugins)
         {
-            tmp << "<RequiredPlugin name='"<<kv.first<<"'> <!-- Needed to use components [" ;
+            tmp << "<RequiredPlugin name='"<<kv.first<<"'/> <!-- Needed to use components [" ;
             for(auto& name : kv.second)
             {
                 tmp << name << ", " ;


### PR DESCRIPTION
The scene checker detects when we use a plugin but forgot the "required plugin" tag and tells us how to add it in our scene, but without closing the tag. This PR fixes the bug in the suggestion and corrects some typos in error messages in the same file.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
