### PR TITLE
[Plugins] Disable pluginized modules by default

### DIFF
--- a/SofaKernel/SofaFramework/SofaMacros.cmake
+++ b/SofaKernel/SofaFramework/SofaMacros.cmake
@@ -229,6 +229,11 @@ macro(sofa_add_plugin directory plugin_name)
     sofa_add_generic( ${directory} ${plugin_name} "Plugin" ${ARGV2} )
 endmacro()
 
+macro(sofa_add_plugin_experimental directory plugin_name)
+    sofa_add_generic( ${directory} ${plugin_name} "Plugin" ${ARGV2} )
+    message("-- ${plugin_name} is an experimental feature, use it at your own risk.")
+endmacro()
+
 
 macro(sofa_add_application directory app_name)
     sofa_add_generic( ${directory} ${app_name} "Application" ${ARGV2} )

--- a/applications/plugins/CMakeLists.txt
+++ b/applications/plugins/CMakeLists.txt
@@ -4,8 +4,8 @@ find_package(SofaFramework)
 
 sofa_add_plugin(CImgPlugin CImgPlugin ON) # ON by default and first as it is used by other plugins.
 sofa_add_plugin(SofaEulerianFluid SofaEulerianFluid)
-sofa_add_plugin(SofaSphFluid SofaSphFluid ON)
-sofa_add_plugin(SofaMiscCollision SofaMiscCollision ON)
+sofa_add_plugin(SofaSphFluid SofaSphFluid)
+sofa_add_plugin(SofaMiscCollision SofaMiscCollision ON) # Contains DefaultCollisionGroupManager
 sofa_add_plugin(SofaDistanceGrid SofaDistanceGrid)
 sofa_add_plugin(SofaImplicitField SofaImplicitField)
 sofa_add_plugin(SofaVolumetricData SofaVolumetricData)  ##TRANSITIONAL DEPEND ON DISTANCEGRID & IMPLICIT

--- a/applications/plugins/CMakeLists.txt
+++ b/applications/plugins/CMakeLists.txt
@@ -43,7 +43,7 @@ sofa_add_plugin(LeapMotion LeapMotion)
 sofa_add_plugin(Geomagic Geomagic)
 
 # SOFA_WITH_EXPERIMENTAL_FEATURES_17_12
-sofa_add_plugin(PSL PSL ON)
+sofa_add_plugin_experimental(PSL PSL)
 
 if((${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") AND (${CMAKE_SYSTEM_NAME} MATCHES "Linux"))
     sofa_add_plugin(SofaPardisoSolver SofaPardisoSolver) # SofaPardisoSolver is only available under linux with gcc

--- a/applications/plugins/PSL/CMakeLists.txt
+++ b/applications/plugins/PSL/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 project(PSL)
 
-message("-- PSL is a 17.12 experimental feature, use it at your own risk.")
-
 ### Plugin dependencies
 find_package(SofaFramework REQUIRED)
 find_package(SofaPython QUIET)

--- a/scripts/ci/configure.sh
+++ b/scripts/ci/configure.sh
@@ -113,6 +113,13 @@ if [[ -n "$CI_HAVE_BOOST" ]]; then
     append "-DBOOST_ROOT=$CI_BOOST_PATH"
 fi
 
+# Also enable pluginized modules
+append "-DPLUGIN_SOFAEULERIANFLUID=ON"
+append "-DPLUGIN_SOFASPHFLUID=ON"
+append "-DPLUGIN_SOFAMISCCOLLISION=ON"
+append "-DPLUGIN_SOFADISTANCEGRID=ON"
+append "-DPLUGIN_SOFAIMPLICITFIELD=ON"
+
 case $CI_OPTIONS in
     # Build with as many options enabled as possible
     *options*)
@@ -149,8 +156,7 @@ case $CI_OPTIONS in
         append "-DPLUGIN_COMPLIANT=ON"
         append "-DPLUGIN_EXTERNALBEHAVIORMODEL=ON"
         append "-DPLUGIN_FLEXIBLE=ON"
-        # Requires specific libraries.
-        append "-DPLUGIN_HAPTION=OFF"
+        append "-DPLUGIN_HAPTION=OFF" # Requires specific libraries.
         append "-DPLUGIN_IMAGE=ON"
         append "-DPLUGIN_INVERTIBLEFVM=ON"
         append "-DPLUGIN_MANIFOLDTOPOLOGIES=ON"
@@ -162,19 +168,17 @@ case $CI_OPTIONS in
         fi
         append "-DPLUGIN_MULTITHREADING=ON"
         append "-DPLUGIN_OPTITRACKNATNET=ON"
-        # Does not compile, but it just needs to be updated.
-        append "-DPLUGIN_PERSISTENTCONTACT=OFF"
+        append "-DPLUGIN_PERSISTENTCONTACT=OFF" # Does not compile, but it just needs to be updated.
         append "-DPLUGIN_PLUGINEXAMPLE=ON"
         append "-DPLUGIN_REGISTRATION=ON"
-        # Requires OpenHaptics libraries.
-        append "-DPLUGIN_SENSABLE=OFF"
+        append "-DPLUGIN_RIGIDSCALE=ON"
+        append "-DPLUGIN_SENSABLE=OFF" # Requires OpenHaptics libraries.
         if [[ -n "$CI_HAVE_BOOST" ]]; then
             append "-DPLUGIN_SENSABLEEMULATION=ON"
         else
             append "-DPLUGIN_SENSABLEEMULATION=OFF"
         fi
-        # Requires Sixense libraries.
-        append "-DPLUGIN_SIXENSEHYDRA=OFF"
+        append "-DPLUGIN_SIXENSEHYDRA=OFF" # Requires Sixense libraries.
         append "-DPLUGIN_SOFACARVING=ON"
         if [[ -n "$CI_HAVE_CUDA" ]]; then
             append "-DPLUGIN_SOFACUDA=ON"
@@ -182,16 +186,10 @@ case $CI_OPTIONS in
             append "-DPLUGIN_SOFACUDA=OFF"
         fi
         append "-DPLUGIN_SOFADISTANCEGRID=ON"
-        # Requires HAPI libraries.
-        append "-DPLUGIN_SOFAHAPI=OFF"
-        append "-DPLUGIN_SOFAIMPLICITFIELD=ON"
-        # Not sure if worth maintaining
-        append "-DPLUGIN_SOFASIMPLEGUI=ON"
+        append "-DPLUGIN_SOFAHAPI=OFF" # Requires HAPI libraries.
+        append "-DPLUGIN_SOFASIMPLEGUI=ON" # Not sure if worth maintaining
         append "-DPLUGIN_THMPGSPATIALHASHING=ON"
-        # Requires XiRobot library.
-        append "-DPLUGIN_XITACT=OFF"
-        append "-DPLUGIN_RIGIDSCALE=ON"
-        append "-DPLUGIN_SOFAEULERIANFLUID=ON"
+        append "-DPLUGIN_XITACT=OFF" # Requires XiRobot library.
         ;;
 esac
 


### PR DESCRIPTION
This PR disables all freshly pluginized modules by default except for SofaMiscCollision because it contains DefaultCollisionGroupManager. It also disables PSL by default.
Tell me if these default plugins should actually be kept.

To continue testing as before (and to keep our scene tests working) I manually enable all these plugins in CI at configuration step. This will fix some failing scene tests due to missing dependency (RequiredPlugin).
Actually, the scenes with missing dependencies due to disabled plugin (plugin library not found in `bin`) should not even be tested. Some scenes like `Fluid2D.scn` and `Fluid3D.scn` could even be moved to an examples folder in `plugins/SofaEulerianFluid`.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [x] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
