### PR TITLE
[runsofa] Fix GuiRepository path for Windows and file opening for the doc browser

### DIFF
--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -151,7 +151,7 @@ void addGUIParameters(ArgumentParser* argumentParser)
 // ---------------------------------------------------------------------
 int main(int argc, char** argv)
 {
-    GuiDataRepository.addFirstPath(SetDirectory::GetRelativeFromProcess("../share/sofa/gui/runSofa/resources/")) ;
+    GuiDataRepository.addFirstPath(Utils::getSofaPathTo("share/sofa/gui/runSofa/resources/").c_str()) ;
     sofa::helper::BackTrace::autodump();
 
     ExecParams::defaultInstance()->setAspectID(0);

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -151,7 +151,7 @@ void addGUIParameters(ArgumentParser* argumentParser)
 // ---------------------------------------------------------------------
 int main(int argc, char** argv)
 {
-    GuiDataRepository.addFirstPath(Utils::getSofaPathTo("share/sofa/gui/runSofa/resources/").c_str()) ;
+    GuiDataRepository.addFirstPath(Utils::getSofaPathTo("share/sofa/gui/runSofa/resources").c_str()) ;
     sofa::helper::BackTrace::autodump();
 
     ExecParams::defaultInstance()->setAspectID(0);

--- a/applications/sofa/gui/qt/panels/QDocBrowser.cpp
+++ b/applications/sofa/gui/qt/panels/QDocBrowser.cpp
@@ -206,7 +206,7 @@ void DocBrowser::loadHtml(const std::string& filename)
     if (DataRepository.findFile(htmlfile, "", NULL))
     {
         m_htmlPage->setSearchPaths(QStringList(QString(rootdir.c_str())));
-        m_htmlPage->setSource( QUrl(QString(htmlfile.c_str())) );
+        m_htmlPage->setSource(QUrl::fromLocalFile(QString(htmlfile.c_str())) );
         m_browserhistory->push(htmlfile, filename, rootdir) ;
     }
 


### PR DESCRIPTION
This fixes the GuiRepository path for Windows VS compiling related to issue #577 and then a subsequent issue with QTextBrowser opening the runsofa.html file.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
