### PR TITLE
[SofaDeformable] RestShapeSpringsForceField: use current/updated stiffness vector

### DIFF
--- a/SofaKernel/modules/SofaDeformable/RestShapeSpringsForceField.h
+++ b/SofaKernel/modules/SofaDeformable/RestShapeSpringsForceField.h
@@ -82,6 +82,7 @@ public:
     Data< VecReal > angularStiffness;
     Data< helper::vector< CPos > > pivotPoints;
     Data< helper::vector< unsigned int > > external_points;
+    Data< bool > updatedStiffness;
     Data< bool > recompute_indices;
     Data< bool > drawSpring;
     Data< defaulttype::RGBAColor > springColor;


### PR DESCRIPTION
Only an optimal version based on the initial values of the
stiffness vector was implemented. Need to have updated stiffnesses.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
