### PR TITLE
[SofaHelper] FIX PluginManager readFromIniFile plugin loading

### DIFF
--- a/SofaKernel/framework/sofa/helper/system/PluginManager.cpp
+++ b/SofaKernel/framework/sofa/helper/system/PluginManager.cpp
@@ -87,21 +87,25 @@ PluginManager::~PluginManager()
 void PluginManager::readFromIniFile(const std::string& path)
 {
     std::ifstream instream(path.c_str());
-    std::string pluginPath, line, version;
+    std::string plugin, line, version;
     while(std::getline(instream, line))
     {
         if (line.empty()) continue;
 
         std::istringstream is(line);
-        is >> pluginPath;
+        is >> plugin;
         if (is.eof())
             msg_deprecated("PluginManager") << path << " file is using a deprecated syntax (version information missing). Please update it in the near future.";
         else
             is >> version; // information not used for now
-        if(loadPlugin(pluginPath))
-    {
-            m_pluginMap[pluginPath].initExternalModule();
-    }
+        if(loadPlugin(plugin))
+        {
+            Plugin* p = getPlugin(plugin);
+            if(p) // should always be true as we are protected by if(loadPlugin(...))
+            {
+                p->initExternalModule();
+            }
+        }
     }
     instream.close();
 }
@@ -114,7 +118,7 @@ void PluginManager::writeToIniFile(const std::string& path)
     {
         const std::string& pluginPath = (iter->first);
         outstream << pluginPath << " ";
-        outstream << m_pluginMap[pluginPath].getModuleVersion() << "\n";
+        outstream << getPlugin(pluginPath)->getModuleVersion() << "\n";
     }
     outstream.close();
 }
@@ -226,6 +230,28 @@ bool PluginManager::unloadPlugin(const std::string &pluginPath, std::ostream* er
     }
 }
 
+Plugin* PluginManager::getPlugin(const std::string& plugin, const std::string& suffix, bool ignoreCase)
+{
+    std::string pluginPath = plugin;
+
+    // If 'plugin' ends with ".so", ".dll" or ".dylib", this is a path
+    const std::string dotExt = "." + DynamicLibrary::extension;
+    if (!std::equal(dotExt.rbegin(), dotExt.rend(), plugin.rbegin()))
+    {
+        pluginPath = findPlugin(plugin, suffix, ignoreCase);
+    }
+
+    if (!pluginPath.empty() && m_pluginMap.find(pluginPath) != m_pluginMap.end())
+    {
+        return &m_pluginMap[pluginPath];
+    }
+    else
+    {
+        msg_info("PluginManager") << "Plugin not found in loaded plugins: " << plugin << msgendl;
+        return NULL;
+    }
+}
+
 std::istream& PluginManager::readFromStream(std::istream & in)
 {
     while(!in.eof())
@@ -305,8 +331,17 @@ std::string PluginManager::findPlugin(const std::string& pluginName, const std::
     return std::string();
 }
 
-bool PluginManager::pluginIsLoaded(const std::string& pluginPath)
+bool PluginManager::pluginIsLoaded(const std::string& plugin)
 {
+    std::string pluginPath = plugin;
+
+    // If 'plugin' ends with ".so", ".dll" or ".dylib", this is a path
+    const std::string dotExt = "." + DynamicLibrary::extension;
+    if (!std::equal(dotExt.rbegin(), dotExt.rend(), plugin.rbegin()))
+    {
+        pluginPath = findPlugin(plugin);
+    }
+
     return m_pluginMap.find(pluginPath) != m_pluginMap.end();
 }
 

--- a/SofaKernel/framework/sofa/helper/system/PluginManager.h
+++ b/SofaKernel/framework/sofa/helper/system/PluginManager.h
@@ -169,7 +169,7 @@ public:
     void init(const std::string& pluginPath);
 
     std::string findPlugin(const std::string& pluginName, const std::string& suffix = getDefaultSuffix(), bool ignoreCase = true);
-    bool pluginIsLoaded(const std::string& pluginPath);
+    bool pluginIsLoaded(const std::string& plugin);
 
     inline friend std::ostream& operator<< ( std::ostream& os, const PluginManager& pluginManager )
     {
@@ -181,6 +181,9 @@ public:
     }
 
     PluginMap& getPluginMap()  { return m_pluginMap; }
+
+    Plugin* getPlugin(const std::string& plugin, const std::string& suffix = getDefaultSuffix(), bool ignoreCase = true);
+
     std::vector<std::string>& getSearchPaths() { return m_searchPaths; }
 
     void readFromIniFile(const std::string& path);

--- a/applications/sofa/gui/qt/SofaPluginManager.cpp
+++ b/applications/sofa/gui/qt/SofaPluginManager.cpp
@@ -121,7 +121,6 @@ void SofaPluginManager::addLibrary()
     std::string pluginFile = std::string(sfile.toStdString());
     if(sofa::helper::system::PluginManager::getInstance().loadPluginByPath(pluginFile,&sstream))
     {
-        typedef sofa::helper::system::PluginManager::PluginMap PluginMap;
         typedef sofa::helper::system::Plugin    Plugin;
         if( ! sstream.str().empty())
         {
@@ -131,11 +130,16 @@ void SofaPluginManager::addLibrary()
             mbox->setText(sstream.str().c_str());
             mbox->show();
         }
-        PluginMap& map = sofa::helper::system::PluginManager::getInstance().getPluginMap();
-        Plugin& plugin = map[pluginFile];
-        QString slicense = plugin.getModuleLicense();
-        QString sname    = plugin.getModuleName();
-        QString sversion = plugin.getModuleVersion();
+        Plugin* plugin = sofa::helper::system::PluginManager::getInstance().getPlugin(pluginFile);
+        if(!plugin)
+        {
+            // This should not happen as we are protected by if(loadPluginByPath(...))
+            msg_error("SofaPluginManager") << "plugin should be loaded: " << pluginFile << msgendl;
+            return;
+        }
+        QString slicense = plugin->getModuleLicense();
+        QString sname    = plugin->getModuleName();
+        QString sversion = plugin->getModuleVersion();
 
         //QTreeWidgetItem * item = new QTreeWidgetItem(listPlugins, sname, slicense, sversion, pluginFile.c_str());
         QTreeWidgetItem * item = new QTreeWidgetItem(listPlugins);
@@ -215,12 +219,15 @@ void SofaPluginManager::updateComponentList()
 
     std::string location( curItem->text(LOCATION_COLUMN).toStdString() ); //get the location value
 
-    typedef sofa::helper::system::PluginManager::PluginMap PluginMap;
     typedef sofa::helper::system::Plugin    Plugin;
-    PluginMap& map = sofa::helper::system::PluginManager::getInstance().getPluginMap();
-    Plugin& plugin = map[location];
+    Plugin* plugin = sofa::helper::system::PluginManager::getInstance().getPlugin(location);
+    if(!plugin)
+    {
+        msg_warning("SofaPluginManager") << "plugin is not loaded: " << location << msgendl;
+        return;
+    }
 
-    QString cpts( plugin.getModuleComponentList() );
+    QString cpts( plugin->getModuleComponentList() );
     cpts.replace(", ","\n");
     cpts.replace(",","\n");
     std::istringstream in(cpts.toStdString());
@@ -234,7 +241,6 @@ void SofaPluginManager::updateComponentList()
         QTreeWidgetItem * item = new QTreeWidgetItem(listComponents);
         item->setText(0, componentText.c_str());
     }
-
 }
 
 
@@ -251,11 +257,14 @@ void SofaPluginManager::updateDescription()
 
     std::string location( curItem->text(LOCATION_COLUMN).toStdString() ); //get the location value
 
-    typedef sofa::helper::system::PluginManager::PluginMap PluginMap;
     typedef sofa::helper::system::Plugin    Plugin;
-    PluginMap& map = sofa::helper::system::PluginManager::getInstance().getPluginMap();
-    Plugin plugin = map[location];
-    description->setText(QString(plugin.getModuleDescription()));
+    Plugin* plugin = sofa::helper::system::PluginManager::getInstance().getPlugin(location);
+    if(!plugin)
+    {
+        msg_warning("SofaPluginManager") << "plugin is not loaded: " << location << msgendl;
+        return;
+    }
+    description->setText(QString(plugin->getModuleDescription()));
 }
 
 void SofaPluginManager::savePluginsToIniFile()


### PR DESCRIPTION
This line is the origin of our problem: https://github.com/sofa-framework/sofa/blob/9c85b17b55f4cd1a14927090754004aaba51b802/SofaKernel/framework/sofa/helper/system/PluginManager.cpp#L103
This line was creating entries in m_pluginMap because pluginPath is not always a path.
It is not a path when we are reading "plugin_list.conf.default" file to auto-load plugins at startup.

This PR adds getPlugin method to avoid future operator[] mishandlings. It gets a loaded plugin by paths OR names (even if the map is based on paths).

Conclusion: **`operator[]` on maps should be globally avoided for read access**

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
