### PR TITLE
[SofaHelper] CLEAN commented code and double parentheses in Messaging.h

### DIFF
--- a/SofaKernel/framework/sofa/helper/logging/Messaging.h
+++ b/SofaKernel/framework/sofa/helper/logging/Messaging.h
@@ -114,13 +114,6 @@
 #define oldmsg_fatal(emitter)      sofa::helper::logging::MessageDispatcher::fatal(sofa::helper::logging::Message::Runtime, sofa::helper::logging::getComponentInfo(emitter), SOFA_FILE_INFO)
 #define oldmsg_advice(emitter)      sofa::helper::logging::MessageDispatcher::advice(sofa::helper::logging::Message::Runtime, sofa::helper::logging::getComponentInfo(emitter), SOFA_FILE_INFO)
 
-///#define msg_info_when(cond)          if(cond) sofa::helper::logging::MessageDispatcher::info(sofa::helper::logging::Message::Runtime, this, SOFA_FILE_INFO)
-///#define msg_deprecated_when(cond)    if(cond) sofa::helper::logging::MessageDispatcher::deprecated(sofa::helper::logging::Message::Runtime, this, SOFA_FILE_INFO)
-///#define msg_warning_when(cond)       if(cond) sofa::helper::logging::MessageDispatcher::warning(sofa::helper::logging::Message::Runtime, this, SOFA_FILE_INFO)
-///#define msg_error_when(cond)         if(cond) sofa::helper::logging::MessageDispatcher::error(sofa::helper::logging::Message::Runtime, this, SOFA_FILE_INFO)
-///#define msg_fatal_when(cond)         if(cond) sofa::helper::logging::MessageDispatcher::fatal(sofa::helper::logging::Message::Runtime, this, SOFA_FILE_INFO)
-///#define msg_advice_when(cond)        if(cond) sofa::helper::logging::MessageDispatcher::advice(sofa::helper::logging::Message::Runtime, this, SOFA_FILE_INFO)
-
 #define logmsg_info(emitter)       sofa::helper::logging::MessageDispatcher::info(sofa::helper::logging::Message::Log, sofa::helper::logging::getComponentInfo(emitter), SOFA_FILE_INFO)
 #define logmsg_deprecated(emitter) sofa::helper::logging::MessageDispatcher::deprecated(sofa::helper::logging::Message::Log, sofa::helper::logging::getComponentInfo(emitter), SOFA_FILE_INFO)
 #define logmsg_warning(emitter)    sofa::helper::logging::MessageDispatcher::warning(sofa::helper::logging::Message::Log, sofa::helper::logging::getComponentInfo(emitter), SOFA_FILE_INFO)
@@ -163,7 +156,7 @@
 #define MSGWARNING_CHOOSER(...) MSGWARNING_CHOOSE_FROM_ARG_COUNT(MSGWARNING_NO_ARG_EXPANDER __VA_ARGS__ ())
 
 #define msg_warning(...) MSGWARNING_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
-#define msg_warning_when(cond, ...) if((cond)) msg_warning(__VA_ARGS__)
+#define msg_warning_when(cond, ...) if(cond) msg_warning(__VA_ARGS__)
 
 
 /// THE ERROR BEAST
@@ -175,7 +168,7 @@
 #define MSGERROR_CHOOSER(...) MSGERROR_CHOOSE_FROM_ARG_COUNT(MSGERROR_NO_ARG_EXPANDER __VA_ARGS__ ())
 
 #define msg_error(...) MSGERROR_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
-#define msg_error_when(cond, ...) if((cond)) msg_error(__VA_ARGS__)
+#define msg_error_when(cond, ...) if(cond) msg_error(__VA_ARGS__)
 
 
 /// THE FATAL BEAST
@@ -187,7 +180,7 @@
 #define MSGFATAL_CHOOSER(...) MSGFATAL_CHOOSE_FROM_ARG_COUNT(MSGFATAL_NO_ARG_EXPANDER __VA_ARGS__ ())
 
 #define msg_fatal(...) MSGFATAL_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
-#define msg_fatal_when(cond, ...) if((cond)) msg_fatal(__VA_ARGS__)
+#define msg_fatal_when(cond, ...) if(cond) msg_fatal(__VA_ARGS__)
 
 
 /// THE DEPRECATED BEAST
@@ -199,7 +192,7 @@
 #define MSGDEPRECATED_CHOOSER(...) MSGDEPRECATED_CHOOSE_FROM_ARG_COUNT(MSGDEPRECATED_NO_ARG_EXPANDER __VA_ARGS__ ())
 
 #define msg_deprecated(...) MSGDEPRECATED_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
-#define msg_deprecated_when(cond, ...) if((cond)) msg_deprecated(__VA_ARGS__)
+#define msg_deprecated_when(cond, ...) if(cond) msg_deprecated(__VA_ARGS__)
 
 
 /// THE ADVICE BEAST
@@ -211,7 +204,7 @@
 #define MSGADVICE_CHOOSER(...) MSGADVICE_CHOOSE_FROM_ARG_COUNT(MSGADVICE_NO_ARG_EXPANDER __VA_ARGS__ ())
 
 #define msg_advice(...) MSGADVICE_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
-#define msg_advice_when(cond, ...) if((cond)) msg_advice(__VA_ARGS__)
+#define msg_advice_when(cond, ...) if(cond) msg_advice(__VA_ARGS__)
 
 
 ////////////////////////////////// DMSG
@@ -237,7 +230,7 @@
 #define DMSGWARNING_CHOOSER(...) DMSGWARNING_CHOOSE_FROM_ARG_COUNT(DMSGWARNING_NO_ARG_EXPANDER __VA_ARGS__ ())
 
 #define dmsg_warning(...) DMSGWARNING_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
-#define dmsg_warning_when(cond, ...) if((cond)) dmsg_warning(__VA_ARGS__)
+#define dmsg_warning_when(cond, ...) if(cond) dmsg_warning(__VA_ARGS__)
 
 
 /// THE ERROR BEAST
@@ -249,7 +242,7 @@
 #define DMSGERROR_CHOOSER(...) DMSGERROR_CHOOSE_FROM_ARG_COUNT(DMSGERROR_NO_ARG_EXPANDER __VA_ARGS__ ())
 
 #define dmsg_error(...) DMSGERROR_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
-#define dmsg_error_when(cond, ...) if((cond)) dmsg_error(__VA_ARGS__)
+#define dmsg_error_when(cond, ...) if(cond) dmsg_error(__VA_ARGS__)
 
 
 /// THE FATAL BEAST
@@ -261,7 +254,7 @@
 #define DMSGFATAL_CHOOSER(...) DMSGFATAL_CHOOSE_FROM_ARG_COUNT(DMSGFATAL_NO_ARG_EXPANDER __VA_ARGS__ ())
 
 #define dmsg_fatal(...) DMSGFATAL_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
-#define dmsg_fatal_when(cond, ...) if((cond)) dmsg_fatal(__VA_ARGS__)
+#define dmsg_fatal_when(cond, ...) if(cond) dmsg_fatal(__VA_ARGS__)
 
 
 /// THE DEPRECATED BEAST
@@ -273,7 +266,7 @@
 #define DMSGDEPRECATED_CHOOSER(...) DMSGDEPRECATED_CHOOSE_FROM_ARG_COUNT(DMSGDEPRECATED_NO_ARG_EXPANDER __VA_ARGS__ ())
 
 #define dmsg_deprecated(...) DMSGDEPRECATED_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
-#define dmsg_deprecated_when(cond, ...) if((cond)) dmsg_deprecated(__VA_ARGS__)
+#define dmsg_deprecated_when(cond, ...) if(cond) dmsg_deprecated(__VA_ARGS__)
 
 
 /// THE ADVICE BEAST
@@ -285,7 +278,7 @@
 #define DMSGADVICE_CHOOSER(...) DMSGADVICE_CHOOSE_FROM_ARG_COUNT(DMSGADVICE_NO_ARG_EXPANDER __VA_ARGS__ ())
 
 #define dmsg_advice(...) DMSGADVICE_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
-#define dmsg_advice_when(cond, ...) if((cond)) dmsg_advice(__VA_ARGS__)
+#define dmsg_advice_when(cond, ...) if(cond) dmsg_advice(__VA_ARGS__)
 
 #define MSG_REGISTER_CLASS(classType, nameName) \
     namespace sofa {         \


### PR DESCRIPTION
Clean the Messaging.h class by:

- removing commented/unused code
- removing the double parentheses used for the conditions of the **msg_*_when(cond)**

Compiles fine. This should also remove some warnings.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
