### PR TITLE
[CMake] remove useless if block in qt CMakelists.txt

### DIFF
--- a/applications/sofa/gui/qt/CMakeLists.txt
+++ b/applications/sofa/gui/qt/CMakeLists.txt
@@ -204,10 +204,6 @@ endif()
 # target_compile_definitions(${PROJECT_NAME} PUBLIC "QT3_SUPPORT")
 
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-DSOFA_BUILD_SOFAGUIQT")
-if(SOFA_ENABLE_QWT)
-    set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-DSOFA_BUILD_SOFAGUIQT")
-endif()
-
 
 sofa_install_targets(SofaGui SofaGuiQt "")
 


### PR DESCRIPTION
Simply remove a useless if block. Related to : https://github.com/sofa-framework/sofa/issues/535
Fixes #535 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
