### PR TITLE
[TOOLS] FIX sofa-launcher stdout

### DIFF
--- a/tools/sofa-launcher/integration_example.py
+++ b/tools/sofa-launcher/integration_example.py
@@ -29,10 +29,6 @@ results = startSofa([ {"GRAVITYXML": "0 0 0", "GRAVITYPY": [1,2,3], "nbIteration
                     filesandtemplates, launcher=SerialLauncher())
 
 for res in results:
-        matrix = scip.loadmatrix(res["directory")+"/"+"toto.mtx") 
-        plot(matrix) 
-
-for res in results:
        print("Results: ")
        print("    directory: "+res["directory"])
        print("        scene: "+res["scene"])

--- a/tools/sofa-launcher/launcher.py
+++ b/tools/sofa-launcher/launcher.py
@@ -45,7 +45,8 @@ class SerialLauncher(Launcher):
                         logfile.write(astdout)
                         logfile.write("========= STDERR-LOG============\n")
                         logfile.write(astderr) 
-                        
+                        logfile.close()
+
                         results.append({
                                 "directory" : directory,
                                 "scene" : scene,
@@ -75,7 +76,7 @@ class ParallelLauncher(Launcher):
                         
                         begin = time.time()
                         try:
-                                a = Popen(["runSofa", "-g", "-l", "SofaPython", "batch", "-n", str(numiterations), scene], cwd=directory, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+                                a = Popen(["runSofa", "-l", "SofaPython", "-g", "batch", "-n", str(numiterations), scene], cwd=directory, stdout=PIPE, stderr=PIPE, universal_newlines=True)
                         except:
                                 print("Unable to find runSofa, please add the runSofa location to your PATH and restart sofa-launcher.")
                                 sys.exit(-1)
@@ -91,7 +92,8 @@ class ParallelLauncher(Launcher):
                         logfile.write(astdout)
                         logfile.write("========= STDERR-LOG============\n")
                         logfile.write(astderr) 
-                        
+                        logfile.close()
+
                         #logfile.write("========== MATCH-LOG ===========\n")
                         #logfile.write(str(filtering(astdout)))                        
                                                 
@@ -155,8 +157,8 @@ class SSHLauncher(Launcher):
                         logfile.write(astdout)
                         logfile.write("========= STDERR-LOG============\n")
                         logfile.write(astderr) 
-                        
                         logfile.write("========== MATCH-LOG ===========\n")
+                        logfile.close()
                                                 
                         self.pendingtask.task_done()
                         
@@ -203,6 +205,7 @@ def startSofa(parameters, filesandtemplates, launcher):
                         theFile = open(files[i], "w+") 
                         t = Template(template, searchList=param)
                         theFile.write(str(t))
+                        theFile.close()
                         i+=1
                         
                 tasks.append((param["nbIterations"], tempdir, param["FILE0"], tempdir+"/output.log")) 


### PR DESCRIPTION
This PR fix an issue with sofa-launcher.

When we are using sofa-launcher the scene we want to execute is copied in the /tmp directory. 
But because we weren't closing the current file it wasn't saved and so wasn't executed. 

The fix close it.
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
