### PR TITLE
[SofaDistanceGrid] ADD .scene-tests to ignore scene

### DIFF
--- a/applications/plugins/SofaDistanceGrid/examples/.scene-tests
+++ b/applications/plugins/SofaDistanceGrid/examples/.scene-tests
@@ -1,0 +1,2 @@
+# is  only working with FlowVR
+ignore "DistanceGridForceField-liver.scn"

--- a/examples/.scene-tests
+++ b/examples/.scene-tests
@@ -38,8 +38,4 @@ ignore "Tutorials/Mappings/TutorialMappingOctopusArticulated.scn"
 # uses the SofaCUDA plugin.
 ignore "Benchmark/Accuracy/cylinder_TLEDTetraSolution.scn"
 
-# is  only working with FlowVR
-ignore "Components/forcefield/DistanceGridForceField-liver.scn"
-
-
 

--- a/scripts/ci/configure.sh
+++ b/scripts/ci/configure.sh
@@ -117,7 +117,7 @@ fi
 append "-DPLUGIN_SOFAEULERIANFLUID=ON"
 append "-DPLUGIN_SOFASPHFLUID=ON"
 append "-DPLUGIN_SOFAMISCCOLLISION=ON"
-append "-DPLUGIN_SOFADISTANCEGRID=ON"
+append "-DPLUGIN_SOFADISTANCEGRID=ON" # Requires MiniFlowVR for DistanceGridForceField-liver.scn
 append "-DPLUGIN_SOFAIMPLICITFIELD=ON"
 
 case $CI_OPTIONS in
@@ -185,7 +185,6 @@ case $CI_OPTIONS in
         else
             append "-DPLUGIN_SOFACUDA=OFF"
         fi
-        append "-DPLUGIN_SOFADISTANCEGRID=ON"
         append "-DPLUGIN_SOFAHAPI=OFF" # Requires HAPI libraries.
         append "-DPLUGIN_SOFASIMPLEGUI=ON" # Not sure if worth maintaining
         append "-DPLUGIN_THMPGSPATIALHASHING=ON"


### PR DESCRIPTION
ignored scene: DistanceGridForceField-liver.scn

This way, the scene has to remain ignored to build the plugin in default mode (we need it for SofaImplicitField, which is needed for a bunch of examples).

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
