### PR TITLE
[runSofa] Fix compilation when SofaGuiQt is not activated

### DIFF
--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -100,8 +100,8 @@ using  sofa::helper::logging::MainPerComponentLoggingMessageHandler ;
 #include <windows.h>
 #endif
 
-#include <sofa/gui/qt/GuiDataRepository.h>
-using sofa::gui::qt::GuiDataRepository ;
+#include <sofa/gui/GuiDataRepository.h>
+using sofa::gui::GuiDataRepository ;
 
 using sofa::helper::system::DataRepository;
 using sofa::helper::system::PluginRepository;

--- a/applications/sofa/gui/GuiDataRepository.cpp
+++ b/applications/sofa/gui/GuiDataRepository.cpp
@@ -34,11 +34,8 @@ namespace sofa
 {
 namespace gui
 {
-namespace qt
-{
 
 FileRepository GuiDataRepository("GUI_DATA_PATH", Utils::getSofaPathTo("share/sofa/gui/qt/resources").c_str());
 
-}
 }
 }

--- a/applications/sofa/gui/GuiDataRepository.cpp
+++ b/applications/sofa/gui/GuiDataRepository.cpp
@@ -35,7 +35,7 @@ namespace sofa
 namespace gui
 {
 
-FileRepository GuiDataRepository("GUI_DATA_PATH", Utils::getSofaPathTo("share/sofa/gui/qt/resources").c_str());
+FileRepository GuiDataRepository("GUI_DATA_PATH", Utils::getSofaPathTo("share/sofa/gui/common/resources").c_str());
 
 }
 }

--- a/applications/sofa/gui/GuiDataRepository.h
+++ b/applications/sofa/gui/GuiDataRepository.h
@@ -30,9 +30,6 @@ namespace sofa
 {
 namespace gui
 {
-namespace qt
-{
     extern SOFA_HELPER_API sofa::helper::system::FileRepository GuiDataRepository;
-}
 }
 }

--- a/applications/sofa/gui/SofaGuiCommon/CMakeLists.txt
+++ b/applications/sofa/gui/SofaGuiCommon/CMakeLists.txt
@@ -13,6 +13,7 @@ set(HEADER_FILES
     ../SofaGUI.h
     ../ViewerFactory.h
     ../GUIManager.h
+    ../GuiDataRepository.h
 )
 
 set(SOURCE_FILES
@@ -25,6 +26,7 @@ set(SOURCE_FILES
     ../PickHandler.cpp
     ../GUIManager.cpp
     ../ViewerFactory.cpp
+    ../GuiDataRepository.cpp
 )
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})

--- a/applications/sofa/gui/qt/CMakeLists.txt
+++ b/applications/sofa/gui/qt/CMakeLists.txt
@@ -34,7 +34,6 @@ set(MOC_HEADER_FILES
 
 # these header files do not need MOCcing
 set(HEADER_FILES
-    GuiDataRepository.h
     FileManagement.h
     GraphListenerQListView.h
     PickHandlerCallBacks.h
@@ -83,7 +82,6 @@ set(SOURCE_FILES
     WDoubleLineEdit.cpp
     viewer/SofaViewer.cpp
     panels/QDocBrowser.cpp
-    GuiDataRepository.cpp
 )
 
 set(UI_FILES

--- a/applications/sofa/gui/qt/RealGUI.cpp
+++ b/applications/sofa/gui/qt/RealGUI.cpp
@@ -61,8 +61,14 @@ using sofa::helper::system::SetDirectory ;
 #include <sofa/helper/system/FileSystem.h>
 using sofa::helper::system::FileSystem ;
 
+#include <sofa/helper/Utils.h>
+using sofa::helper::Utils;
+
 #include <sofa/helper/system/FileRepository.h>
 using sofa::helper::system::DataRepository ;
+
+#include <sofa/gui/GuiDataRepository.h>
+using sofa::gui::GuiDataRepository;
 
 #include <sofa/simulation/SceneLoaderFactory.h>
 using sofa::simulation::SceneLoaderFactory ;
@@ -237,6 +243,9 @@ void RealGUI::CreateApplication(int /*_argc*/, char** /*_argv*/)
     argv[0] = strdup ( BaseGUI::GetProgramName() );
     argv[1]=NULL;
     application = new QSOFAApplication ( *argc,argv );
+
+    //Initialize GUI resources path
+    GuiDataRepository.addFirstPath(Utils::getSofaPathTo("share/sofa/gui/qt/resources").c_str());
 
     //force locale to Standard C
     //(must be done immediatly after the QApplication has been created)

--- a/applications/sofa/gui/qt/panels/QDocBrowser.cpp
+++ b/applications/sofa/gui/qt/panels/QDocBrowser.cpp
@@ -34,7 +34,7 @@ using sofa::helper::system::FileSystem ;
 
 #include "QDocBrowser.h"
 #include "../RealGUI.h"
-#include "../GuiDataRepository.h"
+#include <sofa/gui/GuiDataRepository.h>
 
 namespace sofa
 {


### PR DESCRIPTION
It was not possible to compile runSofa without activating SofaGuiQt, because GuiDataRepository was instantiated in SofaGuiQt library.
As GuiDataRepository seems to be rather generic and not tied to Qt, GuiDataRepository has been moved to SofaGuiCommon ; and allows runSofa to be compiled without enabling SOFA_GUI_QT.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
