### PR TITLE
[CI] Ignore some scenes in scene tests

### DIFF
--- a/applications/projects/CMakeLists.txt
+++ b/applications/projects/CMakeLists.txt
@@ -14,9 +14,7 @@ if(SOFA_HAVE_QT_LIBRARIES)
     sofa_add_application(Modeler Modeler ON)
 endif()
 
-if(SOFA_WITH_DEPRECATED_COMPONENTS)
-    sofa_add_application(getDeprecatedComponents getDeprecatedComponents ON)
-endif()
+sofa_add_application(getDeprecatedComponents getDeprecatedComponents OFF)
 
 sofa_add_application(GenerateRigid GenerateRigid)
 sofa_add_application(meshconv meshconv OFF)

--- a/scripts/ci/configure.sh
+++ b/scripts/ci/configure.sh
@@ -115,13 +115,6 @@ if [[ -n "$CI_HAVE_BOOST" ]]; then
     append "-DBOOST_ROOT=$CI_BOOST_PATH"
 fi
 
-# Also enable pluginized modules
-append "-DPLUGIN_SOFAEULERIANFLUID=ON"
-append "-DPLUGIN_SOFASPHFLUID=ON"
-append "-DPLUGIN_SOFAMISCCOLLISION=ON"
-append "-DPLUGIN_SOFADISTANCEGRID=ON" # Requires MiniFlowVR for DistanceGridForceField-liver.scn
-append "-DPLUGIN_SOFAIMPLICITFIELD=ON"
-
 case $CI_OPTIONS in
     # Build with as many options enabled as possible
     *options*)
@@ -197,8 +190,13 @@ case $CI_OPTIONS in
         else
             append "-DPLUGIN_SOFACUDA=OFF"
         fi
+        append "-DPLUGIN_SOFADISTANCEGRID=ON" # Requires MiniFlowVR for DistanceGridForceField-liver.scn
+        append "-DPLUGIN_SOFAEULERIANFLUID=ON"
         append "-DPLUGIN_SOFAHAPI=OFF" # Requires HAPI libraries.
+        append "-DPLUGIN_SOFAIMPLICITFIELD=ON"
+        append "-DPLUGIN_SOFAMISCCOLLISION=ON"
         append "-DPLUGIN_SOFASIMPLEGUI=ON" # Not sure if worth maintaining
+        append "-DPLUGIN_SOFASPHFLUID=ON"
         append "-DPLUGIN_THMPGSPATIALHASHING=ON"
         append "-DPLUGIN_XITACT=OFF" # Requires XiRobot library.
         ;;

--- a/scripts/ci/configure.sh
+++ b/scripts/ci/configure.sh
@@ -106,6 +106,7 @@ append() {
 }
 
 # Options common to all configurations
+append "-DSOFA_WITH_DEPRECATED_COMPONENTS=ON"
 append "-DAPPLICATION_GETDEPRECATEDCOMPONENTS=ON"
 append "-DSOFA_BUILD_TUTORIALS=ON"
 append "-DSOFA_BUILD_TESTS=ON"

--- a/scripts/ci/configure.sh
+++ b/scripts/ci/configure.sh
@@ -106,7 +106,6 @@ append() {
 }
 
 # Options common to all configurations
-append "-DSOFA_WITH_DEPRECATED_COMPONENTS=ON"
 append "-DSOFA_BUILD_TUTORIALS=ON"
 append "-DSOFA_BUILD_TESTS=ON"
 append "-DSOFAGUI_BUILD_TESTS=OFF"

--- a/scripts/ci/configure.sh
+++ b/scripts/ci/configure.sh
@@ -106,6 +106,7 @@ append() {
 }
 
 # Options common to all configurations
+append "-DAPPLICATION_GETDEPRECATEDCOMPONENTS=ON"
 append "-DSOFA_BUILD_TUTORIALS=ON"
 append "-DSOFA_BUILD_TESTS=ON"
 append "-DSOFAGUI_BUILD_TESTS=OFF"

--- a/scripts/ci/scene-tests.sh
+++ b/scripts/ci/scene-tests.sh
@@ -178,28 +178,28 @@ create-directories() {
 
 
 ignore-missing-plugins() {
-	echo "Searching for missing plugins..."
+    echo "Searching for missing plugins..."
     while read scene; do
-		if grep -q '^[	 ]*<[	 ]*RequiredPlugin' "$src_dir/examples/$scene"; then
-			grep '^[	 ]*<[	 ]*RequiredPlugin' "$src_dir/examples/$scene" > "$output_dir/grep.tmp"
-			while read match; do
-				if echo "$match" | grep -q 'pluginName'; then
-					plugin="$(echo "$match" | grep -o "pluginName[ 	]*=[\'\"][A-Za-z _-]*[\'\"]" | grep -o [\'\"].*[\'\"] | head -c -2 | tail -c +2)"
-				elif echo "$match" | grep -q 'name'; then
-					plugin="$(echo "$match" | grep -o "name[ 	]*=[\'\"][A-Za-z _-]*[\'\"]" | grep -o [\'\"].*[\'\"] | head -c -2 | tail -c +2)"
-				else
-					echo "ERROR: unknown RequiredPlugin found in $scene"
-					break
-				fi
-				local lib="$(get-lib "$plugin")"
-				if [ -z "$lib" ]; then
-					echo "ignore $scene: missing plugin $plugin"
-					echo "$scene" >> "$output_dir/examples/ignore-patterns.txt"
-				fi
-			done < "$output_dir/grep.tmp"
-			rm -f "$output_dir/grep.tmp"
-		fi
-	done < "$output_dir/examples/scenes.txt"
+        if grep -q '^[	 ]*<[	 ]*RequiredPlugin' "$src_dir/examples/$scene"; then
+            grep '^[	 ]*<[	 ]*RequiredPlugin' "$src_dir/examples/$scene" > "$output_dir/grep.tmp"
+            while read match; do
+                if echo "$match" | grep -q 'pluginName'; then
+                    plugin="$(echo "$match" | grep -o "pluginName[	 ]*=[\'\"][A-Za-z _-]*[\'\"]" | grep -o [\'\"].*[\'\"] | head -c -2 | tail -c +2)"
+                elif echo "$match" | grep -q 'name'; then
+                    plugin="$(echo "$match" | grep -o "name[	 ]*=[\'\"][A-Za-z _-]*[\'\"]" | grep -o [\'\"].*[\'\"] | head -c -2 | tail -c +2)"
+                else
+                    echo "ERROR: unknown RequiredPlugin found in $scene"
+                    break
+                fi
+                local lib="$(get-lib "$plugin")"
+                if [ -z "$lib" ]; then
+                    echo "ignore $scene: missing plugin $plugin"
+                    echo "$scene" >> "$output_dir/examples/ignore-patterns.txt"
+                fi
+            done < "$output_dir/grep.tmp"
+            rm -f "$output_dir/grep.tmp"
+        fi
+    done < "$output_dir/examples/scenes.txt"
 }
 
 parse-options-files() {
@@ -218,7 +218,7 @@ parse-options-files() {
                                 echo "$path/.scene-tests: warning: 'ignore' expects one argument: ignore <pattern>" | log
                             fi
                             ;;
-			add)
+                        add)
                             if [[ "$(count-args "$args")" = 1 ]]; then
                                 scene="$(get-arg "$args" 1)"
                                 echo $scene >> "$output_dir/$path/add-patterns.txt"
@@ -336,7 +336,7 @@ initialize-scene-testing() {
     touch "$output_dir/errors.txt"
 
     create-directories
-	ignore-missing-plugins
+    ignore-missing-plugins
     parse-options-files
 }
 
@@ -462,7 +462,7 @@ print-summary() {
     echo "- $(count-errors) error(s)"
     if [[ "$errors" != 0 ]]; then
         while read error; do
-			echo "  - $error"
+            echo "  - $error"
         done < "$output_dir/errors.txt"
     fi
     

--- a/scripts/ci/scene-tests.sh
+++ b/scripts/ci/scene-tests.sh
@@ -274,8 +274,8 @@ parse-options-files() {
 
 ignore-scenes-with-deprecated-components() {
     echo "Searching for deprecated components..."
-    SofaDeprecatedComponents="$(ls "$build_dir/bin/SofaDeprecatedComponents"{,d,_d} 2> /dev/null || true)"
-    $SofaDeprecatedComponents > "$output_dir/deprecatedcomponents.txt"
+    getDeprecatedComponents="$(ls "$build_dir/bin/getDeprecatedComponents"{,d,_d} 2> /dev/null || true)"
+    $getDeprecatedComponents > "$output_dir/deprecatedcomponents.txt"
     base_dir="$(pwd)"
     cd "$src_dir"
     while read component; do

--- a/scripts/ci/scene-tests.sh
+++ b/scripts/ci/scene-tests.sh
@@ -282,14 +282,14 @@ ignore-scenes-with-deprecated-components() {
         component="$(echo "$component" | tr -d '\n' | tr -d '\r')"
         grep -r "$component" --include=\*.{scn,py,pyscn} | cut -f1 -d":" | sort | uniq > "$base_dir/$output_dir/grep.tmp"
         while read scene; do
-            if ! grep -q "$scene" "$base_dir/$output_dir/all-ignored-scenes.txt"; then
-                echo "  ignore $scene: deprecated component $component"
-                echo "$scene" >> "$base_dir/$output_dir/all-ignored-scenes.txt"
-            fi
             if grep -q "$scene" "$base_dir/$output_dir/all-tested-scenes.txt"; then
                 grep -v "$scene" "$base_dir/$output_dir/all-tested-scenes.txt" > "$base_dir/$output_dir/all-tested-scenes.tmp"
                 mv "$base_dir/$output_dir/all-tested-scenes.tmp" "$base_dir/$output_dir/all-tested-scenes.txt"
                 rm -f "$base_dir/$output_dir/all-tested-scenes.tmp"
+                if ! grep -q "$scene" "$base_dir/$output_dir/all-ignored-scenes.txt"; then
+                    echo "  ignore $scene: deprecated component $component"
+                    echo "$scene" >> "$base_dir/$output_dir/all-ignored-scenes.txt"
+                fi
             fi
         done < "$base_dir/$output_dir/grep.tmp"
     done < "$base_dir/$output_dir/deprecatedcomponents.txt"
@@ -315,14 +315,14 @@ ignore-scenes-with-missing-plugins() {
                 fi
                 local lib="$(get-lib "$plugin")"
                 if [ -z "$lib" ]; then
-                    if ! grep -q "$scene" "$output_dir/all-ignored-scenes.txt"; then
-                        echo "  ignore $scene: missing plugin $plugin"
-                        echo "$scene" >> "$output_dir/all-ignored-scenes.txt"
-                    fi
                     if grep -q "$scene" "$output_dir/all-tested-scenes.txt"; then
                         grep -v "$scene" "$output_dir/all-tested-scenes.txt" > "$output_dir/all-tested-scenes.tmp"
                         mv "$output_dir/all-tested-scenes.tmp" "$output_dir/all-tested-scenes.txt"
                         rm -f "$output_dir/all-tested-scenes.tmp"
+                        if ! grep -q "$scene" "$output_dir/all-ignored-scenes.txt"; then
+                            echo "  ignore $scene: missing plugin $plugin"
+                            echo "$scene" >> "$output_dir/all-ignored-scenes.txt"
+                        fi
                     fi
                 fi
             done < "$output_dir/grep.tmp"

--- a/scripts/ci/scene-tests.sh
+++ b/scripts/ci/scene-tests.sh
@@ -506,7 +506,9 @@ print-summary() {
 
 if [[ "$command" = run ]]; then
     initialize-scene-testing
-    ignore-scenes-with-deprecated-components
+    if grep -q "SOFA_WITH_DEPRECATED_COMPONENTS:BOOL=ON" "$build_dir/CMakeCache.txt"
+        ignore-scenes-with-deprecated-components
+    fi
     ignore-scenes-with-missing-plugins
     test-all-scenes
     extract-successes


### PR DESCRIPTION
Now we have a tool to list the deprecated components, we can build with `SOFA_WITH_DEPRECATED_COMPONENTS=OFF` + `APPLICATION_GETDEPRECATEDCOMPONENTS=ON` and ignore scenes using deprecated components during scene tests.

I also added a function to ignore scenes using non-existent (because disabled) plugins.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
