### PR TITLE
FIX collision of the fontain example

### DIFF
--- a/applications/plugins/SofaPython/examples/fontain.py
+++ b/applications/plugins/SofaPython/examples/fontain.py
@@ -25,7 +25,8 @@ class Fontain(Sofa.PythonScriptController):
         node.createObject('EulerImplicit')
         node.createObject('CGLinearSolver',iterations=25,tolerance=1.0e-9,threshold=1.0e-9)
         object = node.createObject('MechanicalObject',name='MecaObject',template='Rigid')
-        node.createObject('UniformMass',totalmass=100)
+        node.createObject('UniformMass',totalmass=1)
+        node.createObject('SphereModel',radius='0.5', group='1')
 
         # VisualNode
         VisuNode = node.createChild('Visu')

--- a/applications/plugins/SofaPython/examples/fontain.scn
+++ b/applications/plugins/SofaPython/examples/fontain.scn
@@ -18,9 +18,9 @@
         <MeshObjLoader name="loader" filename="mesh/floor2b.obj" />
         <Mesh src="@loader" />
         <MechanicalObject src="@loader" dy="-10.25" scale="0.5" />
-        <Triangle name="Floor" simulated="0" moving="0" />
-        <Line name="Floor" simulated="0" moving="0" />
-        <Point name="Floor" simulated="0" moving="0" />
+        <Triangle name="Floor" simulated="0" moving="0"  group='2'/>
+        <Line name="Floor" simulated="0" moving="0" group='2'/>
+        <Point name="Floor" simulated="0" moving="0" group='2'/>
         <OglModel name="FloorV" filename="mesh/floor2b.obj" scale="0.5" texturename="textures/floor.bmp" dy="-10" />
     </Node>
 


### PR DESCRIPTION
Add just a collision model (Sphere to have collision in the default fontain.scn example of the SofaPython example.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
