### PR TITLE
[SofaPython] FIX build for MacOS >10.13.0

### DIFF
--- a/applications/plugins/SofaPython/PythonCommon.h
+++ b/applications/plugins/SofaPython/PythonCommon.h
@@ -23,11 +23,9 @@
 
 #endif
 
-#if defined(__APPLE__) && defined(__MACH__)
-#    include <Python/Python.h>
-#else
-#    include <Python.h>
-#endif
+
+#include <Python.h>
+
 
 #if defined(_MSC_VER)
 // redefine _DEBUG if it was undefed


### PR DESCRIPTION
Issue detected by @quentinfrancois0

This comes from a change in the Python configuration since the last High Sierra.
The line #include <Python/Python.h> involved a link "Python" to the python include, but this is no longer valid in High Sierra. This was causing a fail in the compilation (include not found)





______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
