### PR TITLE
[Headless Recorder] ADD frameskip option to headless recorder

### DIFF
--- a/applications/sofa/gui/headlessRecorder/HeadlessRecorder.cpp
+++ b/applications/sofa/gui/headlessRecorder/HeadlessRecorder.cpp
@@ -113,7 +113,7 @@ int HeadlessRecorder::RegisterGUIParameters(ArgumentParser* argumentParser)
     argumentParser->addArgument(po::value<int>(&height)->default_value(1080), "height", "(only HeadLessRecorder) video or picture height");
     argumentParser->addArgument(po::value<int>(&fps)->default_value(60), "fps", "(only HeadLessRecorder) define how many frame per second HeadlessRecorder will generate");
     argumentParser->addArgument(po::value<bool>(&recordUntilStopAnimate)->default_value(false)->implicit_value(true),         "recordUntilEndAnimate", "(only HeadLessRecorder) recording until the end of animation does not care how many seconds have been set");
-    argumentParser->addArgument(po::value<std::string>(&recordTypeRaw)->default_value("wallclocktime"), "recordingmode", "(only HeadLessRecorder) define how the recording should be made; either \"simulationtime\", \"wallclocktime\" or an arbitrary interval time between each frame as a float.");
+    argumentParser->addArgument(po::value<std::string>(&recordTypeRaw)->default_value("wallclocktime"), "recordingmode", "(only HeadLessRecorder) define how the recording should be made; either \"simulationtime\" (records as if it was simulating in real time and skips frames accordingly), \"wallclocktime\" (records a frame for each time step) or an arbitrary interval time between each frame as a float.");
     return 0;
 }
 
@@ -349,7 +349,7 @@ bool HeadlessRecorder::keepFrame()
             return true;
         case RecordMode::simulationtime :
         case RecordMode::timeinterval :
-            return groot->getTime() > m_nFrames * skipTime;
+            return groot->getTime() >= m_nFrames * skipTime;
     }
     return false;
 }

--- a/applications/sofa/gui/headlessRecorder/HeadlessRecorder.cpp
+++ b/applications/sofa/gui/headlessRecorder/HeadlessRecorder.cpp
@@ -113,7 +113,7 @@ int HeadlessRecorder::RegisterGUIParameters(ArgumentParser* argumentParser)
     argumentParser->addArgument(po::value<int>(&height)->default_value(1080), "height", "(only HeadLessRecorder) video or picture height");
     argumentParser->addArgument(po::value<int>(&fps)->default_value(60), "fps", "(only HeadLessRecorder) define how many frame per second HeadlessRecorder will generate");
     argumentParser->addArgument(po::value<bool>(&recordUntilStopAnimate)->default_value(false)->implicit_value(true),         "recordUntilEndAnimate", "(only HeadLessRecorder) recording until the end of animation does not care how many seconds have been set");
-    argumentParser->addArgument(po::value<std::string>(&recordTypeRaw)->default_value("wallclocktime"), "recordingmode", "(only HeadLessRecorder) define how the recording should be made; either \"realtime\", \"wallclocktime\" or an arbitrary interval time between each frame as a float.");
+    argumentParser->addArgument(po::value<std::string>(&recordTypeRaw)->default_value("wallclocktime"), "recordingmode", "(only HeadLessRecorder) define how the recording should be made; either \"simulationtime\", \"wallclocktime\" or an arbitrary interval time between each frame as a float.");
     return 0;
 }
 

--- a/applications/sofa/gui/headlessRecorder/HeadlessRecorder.h
+++ b/applications/sofa/gui/headlessRecorder/HeadlessRecorder.h
@@ -64,6 +64,8 @@ namespace gui
 namespace hRecorder
 {
 
+enum FRAMESKIP_TYPE { NOSKIP, REALTIME, FIXEDTIME };
+
 class HeadlessRecorder : public sofa::gui::BaseGUI
 {
 
@@ -93,6 +95,7 @@ public:
     // Needed for the registration
     static BaseGUI* CreateGUI(const char* name, sofa::simulation::Node::SPtr groot = NULL, const char* filename = NULL);
     static int RegisterGUIParameters(ArgumentParser* argumentParser);
+    static void parseSkipOption(const std::string& skipRaw);
 
     static int recordTimeInSeconds; // public for SIGTERM
     static bool recordUntilStopAnimate; // public for SIGTERM
@@ -100,6 +103,7 @@ public:
 private:
     void record();
     bool canRecord();
+    bool keepFrame();
     void screenshotPNG(std::string fileName);
     void videoYUVToRGB();
     void videoEncoderStart(const char *filename, int codec_id);
@@ -138,7 +142,8 @@ private:
     static std::string fileName;
     static bool saveAsScreenShot, saveAsVideo;
     static HeadlessRecorder instance;
-
+    static FRAMESKIP_TYPE skipType;
+    static float skipTime;
 };
 
 } // namespace glut

--- a/applications/sofa/gui/headlessRecorder/HeadlessRecorder.h
+++ b/applications/sofa/gui/headlessRecorder/HeadlessRecorder.h
@@ -64,7 +64,7 @@ namespace gui
 namespace hRecorder
 {
 
-enum FRAMESKIP_TYPE { NOSKIP, REALTIME, FIXEDTIME };
+enum class RecordMode { wallclocktime, simulationtime, timeinterval };
 
 class HeadlessRecorder : public sofa::gui::BaseGUI
 {
@@ -95,7 +95,7 @@ public:
     // Needed for the registration
     static BaseGUI* CreateGUI(const char* name, sofa::simulation::Node::SPtr groot = NULL, const char* filename = NULL);
     static int RegisterGUIParameters(ArgumentParser* argumentParser);
-    static void parseSkipOption(const std::string& skipRaw);
+    static void parseRecordingModeOption();
 
     static int recordTimeInSeconds; // public for SIGTERM
     static bool recordUntilStopAnimate; // public for SIGTERM
@@ -142,7 +142,8 @@ private:
     static std::string fileName;
     static bool saveAsScreenShot, saveAsVideo;
     static HeadlessRecorder instance;
-    static FRAMESKIP_TYPE skipType;
+    static std::string recordTypeRaw;
+    static RecordMode recordType;
     static float skipTime;
 };
 


### PR DESCRIPTION
This PR add a frameskip option to the headless recorder.
Previous behavior is kept for compatibility.
Frameskip option can have 4 different values : 
- noskip and simulationtime : previous behavior, now default. One frame is taken at each time step.
- realtime : Output images at rate of 1/fps
- an arbitrary float : tries to skip this much time between each frame.

The order between simulation and frame saving has also been inverted : now the first frame taken is at time 0, instead of time dt.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
