### PR TITLE
[SofaHelper] More robust method to test end of string

### DIFF
--- a/SofaKernel/framework/sofa/helper/system/PluginManager.cpp
+++ b/SofaKernel/framework/sofa/helper/system/PluginManager.cpp
@@ -204,7 +204,7 @@ bool PluginManager::loadPlugin(const std::string& plugin, const std::string& suf
 {
     // If 'plugin' ends with ".so", ".dll" or ".dylib", this is a path
     const std::string dotExt = "." + DynamicLibrary::extension;
-    if (std::equal(dotExt.rbegin(), dotExt.rend(), plugin.rbegin()))
+    if (plugin.size() > dotExt.size() && std::equal(dotExt.rbegin(), dotExt.rend(), plugin.rbegin()))
     {
         return loadPluginByPath(plugin,  errlog);
     }

--- a/SofaKernel/framework/sofa/helper/system/PluginManager.cpp
+++ b/SofaKernel/framework/sofa/helper/system/PluginManager.cpp
@@ -236,7 +236,7 @@ Plugin* PluginManager::getPlugin(const std::string& plugin, const std::string& s
 
     // If 'plugin' ends with ".so", ".dll" or ".dylib", this is a path
     const std::string dotExt = "." + DynamicLibrary::extension;
-    if (!std::equal(dotExt.rbegin(), dotExt.rend(), plugin.rbegin()))
+    if (!(plugin.size() > dotExt.size() && std::equal(dotExt.rbegin(), dotExt.rend(), plugin.rbegin())))
     {
         pluginPath = findPlugin(plugin, suffix, ignoreCase);
     }
@@ -337,7 +337,7 @@ bool PluginManager::pluginIsLoaded(const std::string& plugin)
 
     // If 'plugin' ends with ".so", ".dll" or ".dylib", this is a path
     const std::string dotExt = "." + DynamicLibrary::extension;
-    if (!std::equal(dotExt.rbegin(), dotExt.rend(), plugin.rbegin()))
+    if (!(plugin.size() > dotExt.size() && std::equal(dotExt.rbegin(), dotExt.rend(), plugin.rbegin())))
     {
         pluginPath = findPlugin(plugin);
     }


### PR DESCRIPTION
The case where plugin is smaller than dotExt is not handled by std::equal. See how it works: http://en.cppreference.com/w/cpp/algorithm/equal. An assert is called.
I had the case when dotExt = ".dll" and plugin = "PSL".






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
