### PR TITLE
[SofaHelper] PluginManager now checks for file existence instead of library extension match.

### DIFF
--- a/SofaKernel/framework/framework_test/helper/system/FileSystem_test.cpp
+++ b/SofaKernel/framework/framework_test/helper/system/FileSystem_test.cpp
@@ -24,6 +24,7 @@
 #include <gtest/gtest.h>
 #include <exception>
 #include <algorithm>
+#include <fstream>
 #include <sofa/helper/testing/BaseTest.h>
 using sofa::helper::testing::BaseTest ;
 
@@ -187,6 +188,31 @@ TEST(FileSystemTest, isDirectory_yes_trailingSlash)
 TEST(FileSystemTest, isDirectory_nope)
 {
     EXPECT_FALSE(FileSystem::isDirectory(getPath("non-empty-directory/fileA.txt")));
+}
+
+TEST(FileSystemTest, isFile_yes)
+{
+    // Absolute path
+    EXPECT_TRUE(FileSystem::isFile(getPath("non-empty-directory/fileA.txt")));
+
+    // Relative path
+    std::ofstream ofs ("FileSystemTest_isFile_yes.txt", std::ofstream::out);
+    ofs.close();
+    EXPECT_TRUE(FileSystem::isFile("FileSystemTest_isFile_yes.txt"));
+    std::remove("FileSystemTest_isFile_yes.txt");
+    EXPECT_FALSE(FileSystem::isFile("FileSystemTest_isFile_yes.txt"));
+
+}
+
+TEST(FileSystemTest, isFile_nope)
+{
+    // Absolute path
+    EXPECT_FALSE(FileSystem::isFile(getPath("non-empty-directory")));
+
+    // Relative path
+    FileSystem::createDirectory("FileSystemTest_isFile_no");
+    EXPECT_FALSE(FileSystem::isFile("FileSystemTest_isFile_no"));
+    FileSystem::removeDirectory("FileSystemTest_isFile_no");
 }
 
 TEST(FileSystemTest, isAbsolute)

--- a/SofaKernel/framework/sofa/helper/system/FileSystem.cpp
+++ b/SofaKernel/framework/sofa/helper/system/FileSystem.cpp
@@ -295,6 +295,14 @@ bool FileSystem::isAbsolute(const std::string& path)
                 || path[0] == '/');
 }
 
+bool FileSystem::isFile(const std::string &path)
+{
+    return
+            FileSystem::exists(path) &&
+            !FileSystem::isDirectory(path)
+    ;
+}
+
 std::string FileSystem::convertBackSlashesToSlashes(const std::string& path)
 {
     std::string str = path;

--- a/SofaKernel/framework/sofa/helper/system/FileSystem.h
+++ b/SofaKernel/framework/sofa/helper/system/FileSystem.h
@@ -101,6 +101,9 @@ static bool isDirectory(const std::string& path);
 /// @brief Return true if and only if the given file path is absolute.
 static bool isAbsolute(const std::string& path);
 
+/// @brief Return true if and only if the given file path is an existing file.
+static bool isFile(const std::string& path);
+
 /// @brief Replace backslashes with slashes.
 static std::string convertBackSlashesToSlashes(const std::string& path);
 

--- a/SofaKernel/framework/sofa/helper/system/PluginManager.cpp
+++ b/SofaKernel/framework/sofa/helper/system/PluginManager.cpp
@@ -202,9 +202,7 @@ bool PluginManager::loadPluginByName(const std::string& pluginName, const std::s
 
 bool PluginManager::loadPlugin(const std::string& plugin, const std::string& suffix, bool ignoreCase, std::ostream* errlog)
 {
-    // If 'plugin' ends with ".so", ".dll" or ".dylib", this is a path
-    const std::string dotExt = "." + DynamicLibrary::extension;
-    if (plugin.size() > dotExt.size() && std::equal(dotExt.rbegin(), dotExt.rend(), plugin.rbegin()))
+    if (FileSystem::isFile(plugin))
     {
         return loadPluginByPath(plugin,  errlog);
     }
@@ -234,11 +232,8 @@ Plugin* PluginManager::getPlugin(const std::string& plugin, const std::string& s
 {
     std::string pluginPath = plugin;
 
-    // If 'plugin' ends with ".so", ".dll" or ".dylib", this is a path
-    const std::string dotExt = "." + DynamicLibrary::extension;
-    if (!(plugin.size() > dotExt.size() && std::equal(dotExt.rbegin(), dotExt.rend(), plugin.rbegin())))
-    {
-        pluginPath = findPlugin(plugin, suffix, ignoreCase);
+    if (!FileSystem::isFile(plugin)) {
+        pluginPath = findPlugin(plugin);
     }
 
     if (!pluginPath.empty() && m_pluginMap.find(pluginPath) != m_pluginMap.end())
@@ -305,7 +300,7 @@ std::string PluginManager::findPlugin(const std::string& pluginName, const std::
     for (std::vector<std::string>::iterator i = m_searchPaths.begin(); i!=m_searchPaths.end(); i++)
     {
         const std::string path = *i + "/" + libName;
-        if (FileSystem::exists(path))
+        if (FileSystem::isFile(path))
             return path;
     }
     // Second try: case insensitive
@@ -335,10 +330,7 @@ bool PluginManager::pluginIsLoaded(const std::string& plugin)
 {
     std::string pluginPath = plugin;
 
-    // If 'plugin' ends with ".so", ".dll" or ".dylib", this is a path
-    const std::string dotExt = "." + DynamicLibrary::extension;
-    if (!(plugin.size() > dotExt.size() && std::equal(dotExt.rbegin(), dotExt.rend(), plugin.rbegin())))
-    {
+    if (!FileSystem::isFile(plugin)) {
         pluginPath = findPlugin(plugin);
     }
 


### PR DESCRIPTION
This PR adds a `isFile` function to the FileSystem component. The PluginManager will then use this new function to test whether or not the plugin path is an existent file.

@guparan Concerning your question last week (what happens if the name of the plugin is passed without a path), the previous behavior was to check if the file was a valid library file (.so, etc.), and then gather the full path from the search directories. The new behavior will first check that the file is a valid file (which won't be if only the name is passed), and then try to find it in the search directories. This should not break any old behaviors.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
