### PR TITLE
[modules] FIX data field name in VariationalSymplecticSolver

### DIFF
--- a/modules/SofaGeneralImplicitOdeSolver/VariationalSymplecticSolver.cpp
+++ b/modules/SofaGeneralImplicitOdeSolver/VariationalSymplecticSolver.cpp
@@ -56,7 +56,7 @@ VariationalSymplecticSolver::VariationalSymplecticSolver()
     , f_fileName(initData(&f_fileName,"file","File name where kinetic and potential energies are saved in a CSV file"))
     , f_computeHamiltonian( initData(&f_computeHamiltonian,true,"computeHamiltonian","Compute hamiltonian") )
     , f_hamiltonianEnergy( initData(&f_hamiltonianEnergy,0.0,"hamiltonianEnergy","hamiltonian energy") )
-    , f_useIncrementalPotentialEnergy( initData(&f_useIncrementalPotentialEnergy,true,"use incremental potential Energy","use real potential energy, if false use approximate potential energy"))
+    , f_useIncrementalPotentialEnergy( initData(&f_useIncrementalPotentialEnergy,true,"useIncrementalPotentialEnergy","use real potential energy, if false use approximate potential energy"))
 {
     cpt=0;
 }


### PR DESCRIPTION
FIX: Name of a parameter (allowing to select incremental potential energy): before, the name contained spaces, was replaced by useIncrementalPotentialEnergy.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
