### PR TITLE
[MultiThreading] FIX: add createSubelements param in MeshGmshLoader

### DIFF
--- a/applications/plugins/MultiThreading/examples/TriangularForceFieldComparison.scn
+++ b/applications/plugins/MultiThreading/examples/TriangularForceFieldComparison.scn
@@ -18,7 +18,7 @@
     <Node name="TriangularBendingSprings">
       <EulerImplicit name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
       <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-      <MeshGmshLoader name="loader" filename="mesh/square3.msh" translation="-1 0 0"/>
+      <MeshGmshLoader name="loader" filename="mesh/square3.msh" translation="-1 0 0" createSubelements="true"/>
       <MechanicalObject name="TriangularBendingSprings" src="@loader" scale="10" />
       <include href="Objects/TriangleSetTopology.xml" src="@loader" />
       <DiagonalMass massDensity="0.015" />
@@ -44,7 +44,7 @@
     <Node name="TriangularBiquadratic">
         <EulerImplicit name="cg_odesolver" printLog="false" />
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-        <MeshGmshLoader name="loader" filename="mesh/square3.msh" />
+        <MeshGmshLoader name="loader" filename="mesh/square3.msh" createSubelements="true"/>
         <MechanicalObject name="TriangularBiquadratic" src="@loader" scale="10" />
         <include href="Objects/TriangleSetTopology.xml" src="@loader" />
         <DiagonalMass massDensity="0.015" />
@@ -69,7 +69,7 @@
     <Node name="TriangularQuadratic">
       <EulerImplicit name="cg_odesolver" printLog="false" />
       <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-      <MeshGmshLoader name="loader" filename="mesh/square3.msh" translation="1 0 0"/>
+      <MeshGmshLoader name="loader" filename="mesh/square3.msh" translation="1 0 0" createSubelements="true"/>
       <MechanicalObject name="TriangularQuadratic" src="@loader" scale="10" />
       <include href="Objects/TriangleSetTopology.xml" src="@loader" />
       <DiagonalMass massDensity="0.015" />
@@ -94,7 +94,7 @@
     <Node name="TriangularFEM">
         <EulerImplicit name="cg_odesolver" printLog="false" />
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-        <MeshGmshLoader name="loader" filename="mesh/square3.msh" translation="-1 0 -1"/>
+        <MeshGmshLoader name="loader" filename="mesh/square3.msh" translation="-1 0 -1" createSubelements="true"/>
         <MechanicalObject name="TriangularFEM" src="@loader" scale="10" />
         <include href="Objects/TriangleSetTopology.xml" src="@loader" />
         <DiagonalMass massDensity="0.015" />


### PR DESCRIPTION
This fix was already applied to examples/Components/forcefield/TriangularForceFieldComparison.scn
See 28c8b68f9d6ed4be725baf305a0957097581fb13

Sorry but I can't explain why this fix was needed in the first place.  
If someone could, that would be great :+1: 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
