### PR TITLE
[examples] FIX missing RequiredPlugin

### DIFF
--- a/examples/Components/collision/SpatialGridPointModel.scn
+++ b/examples/Components/collision/SpatialGridPointModel.scn
@@ -1,4 +1,7 @@
 <Node dt="0.005" gravity="0 -10 0">
+    <RequiredPlugin pluginName="SofaSphFluid"/>
+    <RequiredPlugin pluginName="SofaMiscCollision"/>
+
     <VisualStyle displayFlags="showBehaviorModels showForceFields" />
     <CollisionPipeline verbose="0" />
     <NewProximityIntersection alarmDistance="0.5" contactDistance="0.3" />

--- a/examples/Components/forcefield/ParticlesRepulsionForceField.scn
+++ b/examples/Components/forcefield/ParticlesRepulsionForceField.scn
@@ -1,4 +1,6 @@
 <Node name="root" gravity="0.0 -2.0 0.0" dt="0.04">
+    <RequiredPlugin pluginName="SofaSphFluid"/>
+
     <CollisionPipeline verbose="0" />
     <BruteForceDetection name="N2" />
     <CollisionResponse name="Response" />

--- a/examples/Components/forcefield/SPHFluidForceField.scn
+++ b/examples/Components/forcefield/SPHFluidForceField.scn
@@ -1,4 +1,6 @@
 <Node dt="0.01" gravity="0 -10 0">
+    <RequiredPlugin pluginName="SofaSphFluid"/>
+
     <VisualStyle displayFlags="showBehaviorModels showForceFields showCollisionModels" />
     <Node>
 <!--        <RungeKutta4 /> -->

--- a/examples/Components/mapping/SPHFluidSurfaceMapping.scn
+++ b/examples/Components/mapping/SPHFluidSurfaceMapping.scn
@@ -1,4 +1,6 @@
 <Node dt="0.005" gravity="0 -10 0">
+    <RequiredPlugin pluginName="SofaSphFluid"/>
+
     <VisualStyle displayFlags="showBehaviorModels showForceFields" />
     <Node name="Liver">
         <EulerImplicit name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />

--- a/examples/Components/visualmodel/PointSplatModel.scn
+++ b/examples/Components/visualmodel/PointSplatModel.scn
@@ -1,5 +1,8 @@
 <!-- Mechanical PointSplatModel Example -->
 <Node dt="0.005" gravity="0 -10 0">
+    <RequiredPlugin pluginName="SofaSphFluid"/>
+    <RequiredPlugin pluginName="SofaMiscCollision"/>
+
     <CollisionPipeline verbose="0" />
     <NewProximityIntersection alarmDistance="0.5" contactDistance="0.3" />
     <BruteForceDetection name="N2" />


### PR DESCRIPTION
One good point about ignoring scenes with unmet `RequiredPlugin` dependencies is that we can see what scenes need some `RequiredPlugin`: they are the only left to crash trying to create unknown components.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
