### PR TITLE
[All] FIX VS2017 build (Windows)

### DIFF
--- a/SofaKernel/modules/SofaBaseCollision/DiscreteIntersection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/DiscreteIntersection.cpp
@@ -29,6 +29,9 @@
 #include <iostream>
 #include <algorithm>
 
+template std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::DiscreteIntersection>* >::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::DiscreteIntersection>* >() noexcept;
+template std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::DiscreteIntersection>* >& std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::DiscreteIntersection>* >::operator=(std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::DiscreteIntersection>* >&&) noexcept;
+
 namespace sofa
 {
 

--- a/SofaKernel/modules/SofaBaseCollision/DiscreteIntersection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/DiscreteIntersection.cpp
@@ -29,11 +29,17 @@
 #include <iostream>
 #include <algorithm>
 
-template std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::DiscreteIntersection>* >::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::DiscreteIntersection>* >() noexcept;
-template std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::DiscreteIntersection>* >& std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::DiscreteIntersection>* >::operator=(std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::DiscreteIntersection>* >&&) noexcept;
-
 namespace sofa
 {
+
+namespace core
+{
+    namespace collision
+    {
+        template class SOFA_BASE_COLLISION_API IntersectorFactory<component::collision::DiscreteIntersection>;
+    }
+}
+
 
 namespace component
 {
@@ -75,7 +81,7 @@ DiscreteIntersection::DiscreteIntersection()
     intersectors.add<RigidCapsuleModel,OBBModel,DiscreteIntersection>(this);
     intersectors.add<RigidCapsuleModel,RigidSphereModel,DiscreteIntersection>(this);
 
-    IntersectorFactory::getInstance()->addIntersectors(this);
+	IntersectorFactory::getInstance()->addIntersectors(this);
 }
 
 /// Return the intersector class handling the given pair of collision models, or NULL if not supported.
@@ -88,14 +94,6 @@ ElementIntersector* DiscreteIntersection::findIntersector(core::CollisionModel* 
 } // namespace collision
 
 } // namespace component
-
-namespace core
-{
-namespace collision
-{
-template class SOFA_BASE_COLLISION_API IntersectorFactory<component::collision::DiscreteIntersection>;
-}
-}
 
 } // namespace sofa
 

--- a/SofaKernel/modules/SofaBaseCollision/MinProximityIntersection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/MinProximityIntersection.cpp
@@ -34,11 +34,16 @@
 
 #define DYNAMIC_CONE_ANGLE_COMPUTATION
 
-template std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::MinProximityIntersection>* >::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::MinProximityIntersection>* >() noexcept;
-template std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::MinProximityIntersection>* >& std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::MinProximityIntersection>* >::operator=(std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::MinProximityIntersection>* >&&) noexcept;
-
 namespace sofa
 {
+
+namespace core
+{
+	namespace collision
+    {
+        template class SOFA_BASE_COLLISION_API IntersectorFactory<component::collision::MinProximityIntersection>;
+    }
+}
 
 namespace component
 {
@@ -99,14 +104,6 @@ void MinProximityIntersection::draw(const core::visual::VisualParams* vparams)
 } // namespace collision
 
 } // namespace component
-
-namespace core
-{
-namespace collision
-{
-template class SOFA_BASE_COLLISION_API IntersectorFactory<component::collision::MinProximityIntersection>;
-}
-}
 
 } // namespace sofa
 

--- a/SofaKernel/modules/SofaBaseCollision/MinProximityIntersection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/MinProximityIntersection.cpp
@@ -34,6 +34,9 @@
 
 #define DYNAMIC_CONE_ANGLE_COMPUTATION
 
+template std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::MinProximityIntersection>* >::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::MinProximityIntersection>* >() noexcept;
+template std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::MinProximityIntersection>* >& std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::MinProximityIntersection>* >::operator=(std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::MinProximityIntersection>* >&&) noexcept;
+
 namespace sofa
 {
 

--- a/SofaKernel/modules/SofaBaseCollision/NewProximityIntersection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/NewProximityIntersection.cpp
@@ -29,11 +29,16 @@
 #include <iostream>
 #include <algorithm>
 
-template std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::NewProximityIntersection>* >::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::NewProximityIntersection>* >() noexcept;
-template std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::NewProximityIntersection>* >& std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::NewProximityIntersection>* >::operator=(std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::NewProximityIntersection>* >&&) noexcept;
-
 namespace sofa
 {
+
+namespace core
+{
+    namespace collision
+    {
+        template class SOFA_BASE_COLLISION_API IntersectorFactory<component::collision::NewProximityIntersection>;
+    }
+}
 
 namespace component
 {
@@ -84,14 +89,6 @@ void NewProximityIntersection::init()
 } // namespace collision
 
 } // namespace component
-
-namespace core
-{
-namespace collision
-{
-template class SOFA_BASE_COLLISION_API IntersectorFactory<component::collision::NewProximityIntersection>;
-}
-}
 
 } // namespace sofa
 

--- a/SofaKernel/modules/SofaBaseCollision/NewProximityIntersection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/NewProximityIntersection.cpp
@@ -29,6 +29,8 @@
 #include <iostream>
 #include <algorithm>
 
+template std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::NewProximityIntersection>* >::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::NewProximityIntersection>* >() noexcept;
+template std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::NewProximityIntersection>* >& std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::NewProximityIntersection>* >::operator=(std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::NewProximityIntersection>* >&&) noexcept;
 
 namespace sofa
 {

--- a/applications/sofa/gui/qt/DataWidget.cpp
+++ b/applications/sofa/gui/qt/DataWidget.cpp
@@ -29,6 +29,14 @@
 #include <QToolTip>
 
 #define SIZE_TEXT     60
+
+
+template std::multimap<std::string, sofa::helper::BaseCreator<sofa::gui::qt::DataWidget, sofa::gui::qt::DataWidget::CreatorArgument, sofa::gui::qt::DataWidget*>*>&
+std::multimap<std::string, sofa::helper::BaseCreator<sofa::gui::qt::DataWidget, sofa::gui::qt::DataWidget::CreatorArgument, sofa::gui::qt::DataWidget*>*>::operator=(
+    std::multimap<std::string, sofa::helper::BaseCreator<sofa::gui::qt::DataWidget, sofa::gui::qt::DataWidget::CreatorArgument, sofa::gui::qt::DataWidget*>*>&&) noexcept;
+
+
+
 namespace sofa
 {
 namespace helper

--- a/applications/sofa/gui/qt/DataWidget.cpp
+++ b/applications/sofa/gui/qt/DataWidget.cpp
@@ -31,12 +31,6 @@
 #define SIZE_TEXT     60
 
 
-template std::multimap<std::string, sofa::helper::BaseCreator<sofa::gui::qt::DataWidget, sofa::gui::qt::DataWidget::CreatorArgument, sofa::gui::qt::DataWidget*>*>&
-std::multimap<std::string, sofa::helper::BaseCreator<sofa::gui::qt::DataWidget, sofa::gui::qt::DataWidget::CreatorArgument, sofa::gui::qt::DataWidget*>*>::operator=(
-    std::multimap<std::string, sofa::helper::BaseCreator<sofa::gui::qt::DataWidget, sofa::gui::qt::DataWidget::CreatorArgument, sofa::gui::qt::DataWidget*>*>&&) noexcept;
-
-
-
 namespace sofa
 {
 namespace helper
@@ -165,6 +159,22 @@ DataWidget::setWidgetDirty(bool b)
     dirty = b;
     Q_EMIT WidgetDirty(b);
 }
+
+typedef sofa::helper::Factory<std::string, DataWidget, DataWidget::CreatorArgument> DataWidgetFactory;
+
+DataWidget *DataWidget::CreateDataWidget(const DataWidget::CreatorArgument &dwarg)
+{
+    DataWidget *datawidget_ = 0;
+    const std::string &widgetName=dwarg.data->getWidget();
+    if (widgetName.empty())
+        datawidget_ = DataWidgetFactory::CreateAnyObject(dwarg);
+    else
+        datawidget_ = DataWidgetFactory::CreateObject(widgetName, dwarg);
+
+    return datawidget_;
+}
+
+
 /*QDisplayDataInfoWidget definitions */
 
 QDisplayDataInfoWidget::QDisplayDataInfoWidget(QWidget* parent, const std::string& helper,

--- a/applications/sofa/gui/qt/DataWidget.h
+++ b/applications/sofa/gui/qt/DataWidget.h
@@ -102,22 +102,8 @@ public:
         }
         return instance;
     }
-
-    typedef sofa::helper::Factory<std::string, DataWidget, DataWidget::CreatorArgument> DataWidgetFactory;
-
-
-    static DataWidget *CreateDataWidget(const DataWidget::CreatorArgument &dwarg)
-    {
-
-        DataWidget *datawidget_=0;
-        const std::string &widgetName=dwarg.data->getWidget();
-        if (widgetName.empty())
-            datawidget_ = DataWidgetFactory::CreateAnyObject(dwarg);
-        else
-            datawidget_ = DataWidgetFactory::CreateObject(widgetName, dwarg);
-
-        return datawidget_;
-    }
+   
+    static DataWidget *CreateDataWidget(const DataWidget::CreatorArgument &dwarg);    
 
 
 public slots:

--- a/modules/SofaConstraint/LocalMinDistance.cpp
+++ b/modules/SofaConstraint/LocalMinDistance.cpp
@@ -32,6 +32,9 @@
 /// To emit extra debug message set this to true.
 #define EMIT_EXTRA_DEBUG_MESSAGE false
 
+template std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::LocalMinDistance>* >::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::LocalMinDistance>* >() noexcept;
+template std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::LocalMinDistance>* >& std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::LocalMinDistance>* >::operator=(std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::LocalMinDistance>* >&&) noexcept;
+
 namespace sofa
 {
 

--- a/modules/SofaConstraint/LocalMinDistance.cpp
+++ b/modules/SofaConstraint/LocalMinDistance.cpp
@@ -32,11 +32,16 @@
 /// To emit extra debug message set this to true.
 #define EMIT_EXTRA_DEBUG_MESSAGE false
 
-template std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::LocalMinDistance>* >::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::LocalMinDistance>* >() noexcept;
-template std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::LocalMinDistance>* >& std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::LocalMinDistance>* >::operator=(std::vector<sofa::core::collision::BaseIntersectorCreator<sofa::component::collision::LocalMinDistance>* >&&) noexcept;
-
 namespace sofa
 {
+
+namespace core
+{
+    namespace collision
+    {
+        template class SOFA_CONSTRAINT_API IntersectorFactory<component::collision::LocalMinDistance>;
+    }
+}
 
 namespace component
 {
@@ -1483,14 +1488,6 @@ void LocalMinDistance::draw(const core::visual::VisualParams* vparams)
 } // namespace collision
 
 } // namespace component
-
-namespace core
-{
-namespace collision
-{
-template class SOFA_CONSTRAINT_API IntersectorFactory<component::collision::LocalMinDistance>;
-}
-}
 
 } // namespace sofa
 

--- a/modules/SofaUserInteraction/ComponentMouseInteraction.cpp
+++ b/modules/SofaUserInteraction/ComponentMouseInteraction.cpp
@@ -28,14 +28,14 @@
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/helper/Factory.inl>
 
-template std::multimap<std::string, sofa::helper::BaseCreator<sofa::component::collision::ComponentMouseInteraction, sofa::core::objectmodel::BaseContext*>* >& 
-std::multimap<std::string, sofa::helper::BaseCreator<sofa::component::collision::ComponentMouseInteraction, sofa::core::objectmodel::BaseContext*>* >::operator=(
-	std::multimap<std::string, sofa::helper::BaseCreator<sofa::component::collision::ComponentMouseInteraction, sofa::core::objectmodel::BaseContext*>* >&&) noexcept;
-
 using namespace sofa::simulation;
 
 namespace sofa
 {
+    namespace helper
+    {
+        template class SOFA_USER_INTERACTION_API Factory<std::string, component::collision::ComponentMouseInteraction, core::objectmodel::BaseContext*>;
+    }
 
 namespace component
 {
@@ -113,9 +113,7 @@ helper::Creator<ComponentMouseInteraction::ComponentMouseInteractionFactory, TCo
 #endif
 
 }
+
 }
-namespace helper
-{
-template class SOFA_USER_INTERACTION_API Factory<std::string, component::collision::ComponentMouseInteraction, core::objectmodel::BaseContext*>;
-}
+
 }

--- a/modules/SofaUserInteraction/ComponentMouseInteraction.cpp
+++ b/modules/SofaUserInteraction/ComponentMouseInteraction.cpp
@@ -28,6 +28,9 @@
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/helper/Factory.inl>
 
+template std::multimap<std::string, sofa::helper::BaseCreator<sofa::component::collision::ComponentMouseInteraction, sofa::core::objectmodel::BaseContext*>* >& 
+std::multimap<std::string, sofa::helper::BaseCreator<sofa::component::collision::ComponentMouseInteraction, sofa::core::objectmodel::BaseContext*>* >::operator=(
+	std::multimap<std::string, sofa::helper::BaseCreator<sofa::component::collision::ComponentMouseInteraction, sofa::core::objectmodel::BaseContext*>* >&&) noexcept;
 
 using namespace sofa::simulation;
 


### PR DESCRIPTION
This PR suggested by @alxbilger fixes build on Windows with VS2017.

Error was `C2057: expected constant expression`

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
