### PR TITLE
[SofaComponent] Fix computeBBox()

### DIFF
--- a/SofaKernel/modules/SofaEngine/BoxROI.inl
+++ b/SofaKernel/modules/SofaEngine/BoxROI.inl
@@ -984,7 +984,7 @@ void BoxROI<DataTypes>::computeBBox(const ExecParams*  params , bool onlyVisible
     const vector<Vec10>& orientedBoxes=d_orientedBoxes.getValue(params);
 
     const Real max_real = std::numeric_limits<Real>::max();
-    const Real min_real = std::numeric_limits<Real>::min();
+    const Real min_real = std::numeric_limits<Real>::lowest();
     Real maxBBox[3] = {min_real,min_real,min_real};
     Real minBBox[3] = {max_real,max_real,max_real};
 

--- a/modules/SofaBoundaryCondition/PlaneForceField.inl
+++ b/modules/SofaBoundaryCondition/PlaneForceField.inl
@@ -371,7 +371,7 @@ void PlaneForceField<DataTypes>::computeBBox(const core::ExecParams * params, bo
     if (onlyVisible && !d_drawIsEnabled.getValue()) return;
 
     const Real max_real = std::numeric_limits<Real>::max();
-    const Real min_real = std::numeric_limits<Real>::min();
+    const Real min_real = std::numeric_limits<Real>::lowest();
     Real maxBBox[3] = {min_real,min_real,min_real};
     Real minBBox[3] = {max_real,max_real,max_real};
 

--- a/modules/SofaGeneralEngine/SubsetTopology.inl
+++ b/modules/SofaGeneralEngine/SubsetTopology.inl
@@ -935,7 +935,7 @@ void SubsetTopology<DataTypes>::computeBBox(const core::ExecParams*  params , bo
 {
     const helper::vector<Vec6>& vb=boxes.getValue();
     const Real max_real = std::numeric_limits<Real>::max();
-    const Real min_real = std::numeric_limits<Real>::min();
+    const Real min_real = std::numeric_limits<Real>::lowest();
     Real maxBBox[3] = {min_real,min_real,min_real};
     Real minBBox[3] = {max_real,max_real,max_real};
 


### PR DESCRIPTION
Some computeBBox() functions were still using numeric_limits<Real>::min() instead of lowest().

numeric_limits<T>::min() returns 0 (more precisely a value very close to it) if T is a floating-point type, whereas   numeric_limits<T>::lowest() returns -inf(more precisely -max of T), which is the expected behavior in computeBBox().

http://en.cppreference.com/w/cpp/types/numeric_limits/min
http://en.cppreference.com/w/cpp/types/numeric_limits/lowest

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**