### PR TITLE
[SofaKernel] Quater from 2 direction vectors

### DIFF
--- a/SofaKernel/framework/framework_test/helper/Quater_test.cpp
+++ b/SofaKernel/framework/framework_test/helper/Quater_test.cpp
@@ -650,3 +650,30 @@ TEST(QuaterTest, QuaterdSlerp2)
     EXPECT_NEAR(0.263984148784687, quatinterp[2], errorThreshold);
     EXPECT_NEAR(0.872287312333299, quatinterp[3], errorThreshold);
 }
+
+TEST(QuaterTest, QuaterdFromUnitVectors)
+{
+    sofa::defaulttype::Vec<3, double> vFrom(1, 0, 0);
+    sofa::defaulttype::Vec<3, double> vTo(0, 1, 0);
+
+    Quater<double> quat1;
+    quat1.setFromUnitVectors(vFrom, vTo);
+
+    EXPECT_NEAR(0, quat1[0], errorThreshold);
+    EXPECT_NEAR(0, quat1[1], errorThreshold);
+    EXPECT_NEAR(0.7071067811865475, quat1[2], errorThreshold);
+    EXPECT_NEAR(0.7071067811865475, quat1[3], errorThreshold);
+
+    vFrom = sofa::defaulttype::Vec<3, double>(0.5, 0.4, 0.3);
+    vTo = sofa::defaulttype::Vec<3, double>(0, 0.2, -1);
+    vFrom.normalize();
+    vTo.normalize();
+    quat1.setFromUnitVectors(vFrom, vTo);
+
+    EXPECT_NEAR(-0.5410972822985042, quat1[0], errorThreshold);
+    EXPECT_NEAR(0.5881492198896785, quat1[1], errorThreshold);
+    EXPECT_NEAR(0.11762984397793572, quat1[2], errorThreshold);
+    EXPECT_NEAR(0.5894552112230939, quat1[3], errorThreshold);
+}
+
+

--- a/SofaKernel/framework/sofa/helper/Quater.h
+++ b/SofaKernel/framework/sofa/helper/Quater.h
@@ -55,6 +55,11 @@ public:
     Quater(const Quater<Real2>& q) { for (int i=0; i<4; i++) _q[i] = (Real)q[i]; }
     Quater( const defaulttype::Vec<3,Real>& axis, Real angle );
 
+    /** Sets this quaternion to the rotation required to rotate direction vector vFrom to direction vector vTo.        
+        vFrom and vTo are assumed to be normalized.
+    */
+    Quater(const defaulttype::Vec<3, Real>& vFrom, const defaulttype::Vec<3, Real>& vTo);
+
     static Quater identity()
     {
         return Quater(0,0,0,1);
@@ -289,6 +294,9 @@ public:
                                                         // this is done to keep the old behavior (before the
                                                         // correction of the toEulerVector function).
     }
+
+    /// Sets this quaternion to the rotation required to rotate direction vector vFrom to direction vector vTo. vFrom and vTo are assumed to be normalized.
+    void setFromUnitVectors(const defaulttype::Vec<3, Real>& vFrom, const defaulttype::Vec<3, Real>& vTo);
 
 
     // Print the quaternion (C style)

--- a/SofaKernel/framework/sofa/helper/Quater.inl
+++ b/SofaKernel/framework/sofa/helper/Quater.inl
@@ -56,6 +56,12 @@ Quater<Real>::Quater( const defaulttype::Vec<3,Real>& axis, Real angle )
     axisToQuat(axis,angle);
 }
 
+template<class Real>
+inline Quater<Real>::Quater(const defaulttype::Vec<3, Real>& vFrom, const defaulttype::Vec<3, Real>& vTo)
+{
+    setFromUnitVectors(vFrom, vTo);
+}
+
 // Destructor
 template<class Real>
 Quater<Real>::~Quater()
@@ -682,6 +688,34 @@ Quater<Real> Quater<Real>::createQuaterFromFrame(const defaulttype::Vec<3, Real>
     }
     q.fromMatrix(m);
     return q;
+}
+
+template<class Real>
+inline void Quater<Real>::setFromUnitVectors(const defaulttype::Vec<3, Real>& vFrom, const defaulttype::Vec<3, Real>& vTo)
+{
+    sofa::defaulttype::Vec<3, Real> v1;
+    Real epsilon = 0.0001;
+    
+    Real res_dot = sofa::defaulttype::dot(vFrom, vTo) + 1;
+    if (res_dot < epsilon)
+    {
+        res_dot = 0;
+        if (fabs(vFrom[0]) > fabs(vFrom[2])) 
+            v1 = sofa::defaulttype::Vec<3, Real>(-vFrom[1], vFrom[0], 0);
+        else
+            v1 = sofa::defaulttype::Vec<3, Real>(0, -vFrom[2], vFrom[1]);
+    }
+    else
+    {
+        v1 = vFrom.cross(vTo);
+    }
+
+    _q[0] = v1[0];
+    _q[1] = v1[1];
+    _q[2] = v1[2];
+    _q[3] = res_dot;
+
+    this->normalize();
 }
 
 /// Print quaternion (C style)


### PR DESCRIPTION
ADD: constructor and method in Quater to compute quaternion so it represents the rotation required to rotate from one direction vector to a second one.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
