### PR TITLE
[examples] FIX failing scenes on CI

### DIFF
--- a/applications/plugins/Compliant/examples/.scene-tests
+++ b/applications/plugins/Compliant/examples/.scene-tests
@@ -17,3 +17,6 @@ add "contact/friction_simple.py"
 
 # sml examples
 add "bielle_manivelle/scene_sml.py"
+
+# This runs slowly, so compute only a few iterations
+iterations "FEM-donuts.scn" "50"

--- a/applications/plugins/Flexible/examples/.scene-tests
+++ b/applications/plugins/Flexible/examples/.scene-tests
@@ -18,6 +18,9 @@ timeout "beam/linearQuadratic_flex332.scn" "50"
 iterations "beam/linearRigid_flex332.scn" "10"
 timeout "beam/linearRigid_flex332.scn" "50"
 
+# This runs slowly, so compute only a few iterations 
+iterations "beam/linearAffine_flex331.scn" "50"
+
 # This runs very slowly (generate topologies of armadillo) so compute only a few iterations 
 iterations "demos/linearHexaFEM-armadillo.scn" "10"
 timeout "demos/linearHexaFEM-armadillo.scn" "50"

--- a/examples/Components/engine/GenerateCylinder.scn
+++ b/examples/Components/engine/GenerateCylinder.scn
@@ -1,17 +1,19 @@
 <?xml version="1.0" ?>
 <Node name="root" dt="1" showBoundingTree="0" gravity="0 0 0">
-		<GenerateCylinder template="Vec3d" name="Cylinder" radius="0.2" height="1" resHeight="7" resCircumferential="7" resRadial="3" />
-        <TetrahedronSetTopologyContainer name="Container1" tetrahedra="@[-1].tetrahedra" position="@[-1].output_position" createTriangleArray="1"/>
+    <GenerateCylinder template="Vec3d" name="Cylinder" radius="0.2" height="1" resHeight="7" resCircumferential="7" resRadial="3" />
+    <Node name="Tetra" >
+        <CGLinearSolver iterations="3000" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" /> 
+        <EulerImplicitSolver name="default12" rayleighStiffness="0.01"  rayleighMass="0.1" />
+        <TetrahedronSetTopologyContainer name="Container" tetrahedra="@../Cylinder.tetrahedra" position="@../Cylinder.output_position" createTriangleArray="1" />
         <TetrahedronSetGeometryAlgorithms  drawEdges="1"/>
-		<CGLinearSolver iterations="3000" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" /> 
-		<EulerImplicitSolver name="default12" rayleighStiffness="0.01"  rayleighMass="0.1" />
-        <MechanicalObject name="dofs" rest_position="@[-5].output_position"/>
-		<MeshMatrixMass name="mass" lumping="1" printMass="0" massDensity="1" />	
-		<BoxROI box="-0.01 -0.01 -0.01 0.01 0.01 0.01" drawBoxes="1" name="fixedPoint"  />
-		<FixedConstraint indices="@fixedPoint.indices" />
-		<FixedPlaneConstraint direction="0 0 1" dmin="-0.01" dmax="0.01"  />
-		<BoxROI box="-0.2 -0.2 0.99 0.2 0.2 1.01" trianglesInROI="1" drawBoxes="1" name="pressurePlane"  />
-		<ProjectToLineConstraint direction="1 0 0" origin="0 0 0" indices="15"  />
-		<TrianglePressureForceField  showForces="1"  triangleList="@pressurePlane.triangleIndices" pressure="0.01 0 -0.04" />
-	    <FastTetrahedralCorotationalForceField poissonRatio="0.45" youngModulus="1" method="polar" /> 
+        <MechanicalObject name="dofs" showObject="1" />
+        <MeshMatrixMass name="mass" lumping="1" printMass="0" massDensity="1" />
+        <BoxROI box="-0.01 -0.01 -0.01 0.01 0.01 0.01" drawBoxes="1" name="fixedPoint"  />
+        <FixedConstraint indices="@fixedPoint.indices" />
+        <FixedPlaneConstraint direction="0 0 1" dmin="-0.01" dmax="0.01"  />
+        <BoxROI box="-0.2 -0.2 0.99 0.2 0.2 1.01" trianglesInROI="1" drawBoxes="1" name="pressurePlane"  />
+        <ProjectToLineConstraint direction="1 0 0" origin="0 0 0" indices="15"  />
+        <TrianglePressureForceField  showForces="1"  triangleList="@pressurePlane.triangleIndices" pressure="0.01 0 -0.04" />
+        <FastTetrahedralCorotationalForceField poissonRatio="0.45" youngModulus="1" method="polar" /> 
+    </Node>
 </Node>

--- a/examples/Components/engine/GenerateGrid.scn
+++ b/examples/Components/engine/GenerateGrid.scn
@@ -1,36 +1,34 @@
 <?xml version="1.0" ?>
 <Node name="root" dt="1" showBoundingTree="0" gravity="0 0 0">
     <GenerateGrid template="Vec3d" name="Slab" max="0.5 1.5 1" resolution="5 3 4" />
-		<Node name="Tetra">
-        <TetrahedronSetTopologyContainer name="Container1" tetrahedra="@Slab.tetrahedra" position="@Slab.output_position" createTriangleArray="1"/>
+    <Node name="Tetra">
+        <CGLinearSolver iterations="3000" name="linear solver" tolerance="1.0e-12" threshold="1.0e-12" /> 
+        <EulerImplicitSolver name="default12" rayleighStiffness="0.01"  rayleighMass="0.1" />
+        <TetrahedronSetTopologyContainer name="Container1" tetrahedra="@../Slab.tetrahedra" position="@../Slab.output_position" createTriangleArray="1"/>
         <TetrahedronSetGeometryAlgorithms  drawTriangles="1"/>
-		<!-- <HexahedronSetTopologyContainer name="Container1" hexahedra="@[-1].hexahedra" position="@[-1].output_position" createQuadArray="1"/>
-		<HexahedronSetGeometryAlgorithms  drawQuads="1"/> -->
-		<CGLinearSolver iterations="3000" name="linear solver" tolerance="1.0e-12" threshold="1.0e-12" /> 
-		<EulerImplicitSolver name="default12" rayleighStiffness="0.01"  rayleighMass="0.1" />
-        <MechanicalObject name="dofs" rest_position="@Slab.output_position"/>
-		<MeshMatrixMass name="mass" lumping="1" printMass="0" massDensity="1" />	
-		<BoxROI box="-0.01 -0.01 -0.01 0.01 0.01 0.01" drawBoxes="1" name="fixedPoint"  />
-		<FixedConstraint indices="@fixedPoint.indices" />
-		<FixedPlaneConstraint direction="0 0 1" dmin="-0.01" dmax="0.01"  />
-		<ProjectToLineConstraint direction="1 0 0" origin="0 0 0" indices="4"  />
-		<BoxROI box="-5.2 -5.2 7.49 5.2 5.2 7.51" trianglesInROI="1" drawBoxes="1" name="pressurePlane"  />
-		<TrianglePressureForceField  showForces="1"  triangleList="@pressurePlane.triangleIndices" pressure="0.00 0 -0.04" />
-	    <FastTetrahedralCorotationalForceField poissonRatio="0.45" youngModulus="1" method="polar" /> 
-		</Node>
-		<Node name="Hexa">
-        <HexahedronSetTopologyContainer name="Container1" hexahedra="@Slab.hexahedra" position="@Slab.output_position" createQuadArray="1"/>
+        <MechanicalObject name="dofs" showObject="1"/>
+        <MeshMatrixMass name="mass" lumping="1" printMass="0" massDensity="1" />	
+        <BoxROI box="-0.01 -0.01 -0.01 0.01 0.01 0.01" drawBoxes="1" name="fixedPoint"  />
+        <FixedConstraint indices="@fixedPoint.indices" />
+        <FixedPlaneConstraint direction="0 0 1" dmin="-0.01" dmax="0.01"  />
+        <BoxROI box="-5.2 -5.2 7.49 5.2 5.2 7.51" trianglesInROI="1" drawBoxes="1" name="pressurePlane"  />
+        <ProjectToLineConstraint direction="1 0 0" origin="0 0 0" indices="4"  />
+        <TrianglePressureForceField  showForces="1"  triangleList="@pressurePlane.triangleIndices" pressure="0.00 0 -0.04" />
+        <FastTetrahedralCorotationalForceField poissonRatio="0.45" youngModulus="1" method="polar" /> 
+    </Node>
+    <Node name="Hexa">
+        <CGLinearSolver iterations="3000" name="linear solver" tolerance="1.0e-12" threshold="1.0e-12" /> 
+        <EulerImplicitSolver name="default12" rayleighStiffness="0.01" />
+        <HexahedronSetTopologyContainer name="Container1" hexahedra="@../Slab.hexahedra" position="@../Slab.output_position" createQuadArray="1"/>
         <HexahedronSetGeometryAlgorithms  drawQuads="1"/>
-		<CGLinearSolver iterations="3000" name="linear solver" tolerance="1.0e-12" threshold="1.0e-12" /> 
-		<EulerImplicitSolver name="default12" rayleighStiffness="0.01" />
-        <MechanicalObject name="dofs" translation="5 0 0" rest_position="@Slab.output_position"/>
-		<MeshMatrixMass name="mass" lumping="1" printMass="0" massDensity="1" />	
-		<BoxROI box="-4.99 -0.01 -0.01 5.01 0.01 0.01" drawBoxes="1" name="fixedPointHexa"  />
-		<FixedConstraint indices="@fixedPointHexa.indices" />
-		<ProjectToLineConstraint direction="1 0 0" origin="0 0 0" indices="4"  />
-		<FixedPlaneConstraint direction="0 0 1" dmin="-0.01" dmax="0.01"  />
-		<BoxROI box="-0.2 -5.2 7.49 10.2 5.2 7.51" quadInROI="1" drawBoxes="1" name="pressurePlaneQuad"  />
-		<QuadPressureForceField  showForces="1"  quadList="@pressurePlaneQuad.quadIndices" pressure="0.00 0 -0.04" />
-	    <HexahedronFEMForceField poissonRatio="0.45" youngModulus="1" method="polar" /> 
-		</Node>
+        <MechanicalObject name="dofs" translation="5 0 0" showObject="1"/>
+        <MeshMatrixMass name="mass" lumping="1" printMass="0" massDensity="1" />	
+        <BoxROI box="-4.99 -0.01 -0.01 5.01 0.01 0.01" drawBoxes="1" name="fixedPointHexa"  />
+        <FixedConstraint indices="@fixedPointHexa.indices" />
+        <FixedPlaneConstraint direction="0 0 1" dmin="-0.01" dmax="0.01"  />
+        <BoxROI box="-0.2 -5.2 7.49 10.2 5.2 7.51" quadInROI="1" drawBoxes="1" name="pressurePlaneQuad"  />
+        <ProjectToLineConstraint direction="1 0 0" origin="0 0 0" indices="4"  />
+        <QuadPressureForceField  showForces="1"  quadList="@pressurePlaneQuad.quadIndices" pressure="0.00 0 -0.04" />
+        <HexahedronFEMForceField poissonRatio="0.45" youngModulus="1" method="polar" /> 
+    </Node>
 </Node>


### PR DESCRIPTION
Fix 4 crashing (timeout) scenes on Windows CI:
- GenerateCylinder
- GenerateGrid
- Flexible: linearAffine_flex331.scn
- Compliant: FEM-donuts.scn

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
