### PR TITLE
[SofaKernel] FIX segfault created by static initialisers on OSX/clang compiler

### DIFF
--- a/SofaKernel/framework/framework_test/helper/logging/logging_test.cpp
+++ b/SofaKernel/framework/framework_test/helper/logging/logging_test.cpp
@@ -584,7 +584,7 @@ TEST(LoggingTest, checkRoutingMessageHandler)
     std::vector<Message::Type> errortypes = {Message::Error, Message::Warning, Message::Info,
                                              Message::Advice, Message::Deprecated, Message::Fatal} ;
 
-    RichConsoleStyleMessageFormatter* fmt = new RichConsoleStyleMessageFormatter();
+    RichConsoleStyleMessageFormatter* fmt = &RichConsoleStyleMessageFormatter::getInstance();
     ConsoleMessageHandler* consolehandler = new ConsoleMessageHandler(fmt) ;
 
     /// Install a simple message filter that always call the ConsoleMessageHandler.

--- a/SofaKernel/framework/sofa/core/logging/RichConsoleStyleMessageFormatter.cpp
+++ b/SofaKernel/framework/sofa/core/logging/RichConsoleStyleMessageFormatter.cpp
@@ -39,6 +39,13 @@ using sofa::helper::logging::SofaComponentInfo ;
 #include <boost/token_functions.hpp>
 #include <boost/token_iterator.hpp>
 
+#ifdef WIN32
+#undef min
+#undef max
+#endif
+
+#include <algorithm>
+
 namespace sofa
 {
 
@@ -84,7 +91,7 @@ void simpleFormat(int jsize, const std::string& text, size_t line_length,
             if(isInItalic)
             {
                 isInItalic=false;
-                wrapped << Console::Code(Console::DEFAULT) ;
+                wrapped << console::Style::Reset;
                 wrapped << "'";
                 continue;
             }
@@ -98,13 +105,13 @@ void simpleFormat(int jsize, const std::string& text, size_t line_length,
                         numspaces = 0;
                         space_left--;
                     }else{
-                        wrapped << Console::Code(Console::DEFAULT) << emptyspace ;
+                        wrapped << console::Style::Reset << emptyspace ;
                     }
                 }
 
                 wrapped << "'";
-                wrapped << Console::Code(Console::ITALIC) ;
-                wrapped << Console::Code(Console::UNDERLINE) ;
+                wrapped << console::Style::Italic;
+                wrapped << console::Style::Underline;
                 continue;
             }
         }else if(word==" ")
@@ -128,11 +135,11 @@ void simpleFormat(int jsize, const std::string& text, size_t line_length,
                     numspaces = 0;
                     space_left--;
                 }else{
-                    wrapped << Console::Code(Console::DEFAULT);
+                    wrapped << console::Style::Reset;
                     wrapped << emptyspace ;
                     if(isInItalic){
-                        wrapped << Console::Code(Console::ITALIC);
-                        wrapped << Console::Code(Console::UNDERLINE);
+                        wrapped << console::Style::Italic;
+                        wrapped << console::Style::Underline;
                     }
                 }
             }
@@ -151,11 +158,11 @@ void simpleFormat(int jsize, const std::string& text, size_t line_length,
                     first=word.substr(curidx,endidx);
 
                     if(beginOfLine){
-                        wrapped << Console::Code(Console::DEFAULT);
+                        wrapped << console::Style::Reset;
                         wrapped << emptyspace ;
                         if(isInItalic){
-                            wrapped << Console::Code(Console::ITALIC);
-                            wrapped << Console::Code(Console::UNDERLINE);
+                            wrapped << console::Style::Italic;
+                            wrapped << console::Style::Underline;
                         }
                     }
                     beginOfLine=false;
@@ -175,11 +182,11 @@ void simpleFormat(int jsize, const std::string& text, size_t line_length,
             else
             {
                 wrapped << "\n";
-                wrapped << Console::Code(Console::DEFAULT);
+                wrapped << console::Style::Reset;
                 wrapped << emptyspace ;
                 if(isInItalic){
-                    wrapped << Console::Code(Console::ITALIC);
-                    wrapped << Console::Code(Console::UNDERLINE);
+                    wrapped << console::Style::Italic;
+                    wrapped << console::Style::Underline;
                 }
                 wrapped << word ;
                 space_left = line_length-word.length();
@@ -188,11 +195,11 @@ void simpleFormat(int jsize, const std::string& text, size_t line_length,
         else
         {
             if(beginOfLine){
-                wrapped << Console::Code(Console::DEFAULT);
+                wrapped << console::Style::Reset;
                 wrapped << emptyspace ;
                 if(isInItalic){
-                    wrapped << Console::Code(Console::ITALIC);
-                    wrapped << Console::Code(Console::UNDERLINE);
+                    wrapped << console::Style::Italic;
+                    wrapped << console::Style::Underline;
                 }
             }
             beginOfLine=false;
@@ -210,7 +217,7 @@ void RichConsoleStyleMessageFormatter::formatMessage(const Message& m, std::ostr
 {
     size_t psize = getPrefixText(m.type()).size() ;
 
-    out << getPrefixCode(m.type()) << getPrefixText(m.type());
+    setColor(out, m.type()) << getPrefixText(m.type());
 
     SofaComponentInfo* nfo = dynamic_cast<SofaComponentInfo*>(m.componentInfo().get()) ;
     if( nfo != nullptr )
@@ -218,29 +225,29 @@ void RichConsoleStyleMessageFormatter::formatMessage(const Message& m, std::ostr
         const std::string& classname= nfo->sender();
         const std::string& name = nfo->name();
         psize +=classname.size()+name.size()+5 ;
-        out << Console::Code(Console::BLUE) << "[" << classname << "(" << name << ")] ";
+        out << console::Foreground::Normal::Blue << "[" << classname << "(" << name << ")] ";
     }
     else
     {
         psize +=m.sender().size()+3 ;
-        out << Console::Code(Console::BLUE) << "[" << m.sender()<< "] ";
+        out << console::Foreground::Normal::Blue << "[" << m.sender()<< "] ";
     }
 
-    out << Console::Code(Console::DEFAULT);
+    out << console::Style::Reset;
 
     /// Format & align the text and write the result into 'out'.
-    simpleFormat(psize , m.message().str(), Console::getColumnCount()-psize, out) ;
+    simpleFormat(psize , m.message().str(), console::getColumnCount()-psize, out) ;
 
     if(m_showFileInfo && m.fileInfo()){
         std::stringstream buf;
         std::string emptyspace(psize, ' ') ;
         buf << "Emitted from '" << m.fileInfo()->filename << "' line " << m.fileInfo()->line ;
-        out << "\n" << Console::Code(Console::DEFAULT) << emptyspace ;
-        simpleFormat(psize , buf.str(), Console::getColumnCount()-psize, out) ;
+        out << "\n" << console::Style::Reset << emptyspace ;
+        simpleFormat(psize , buf.str(), console::getColumnCount()-psize, out) ;
     }
 
     ///Restore the console rendering attribute.
-    out << Console::Code(Console::DEFAULT);
+    out << console::Style::Reset;
     out << std::endl ;
 }
 

--- a/SofaKernel/framework/sofa/core/logging/RichConsoleStyleMessageFormatter.h
+++ b/SofaKernel/framework/sofa/core/logging/RichConsoleStyleMessageFormatter.h
@@ -48,10 +48,10 @@ class Message;
 ///     - automatic reading of the console number of column for prettier display.
 ///
 ///
-class SOFA_HELPER_API RichConsoleStyleMessageFormatter : public MessageFormatter
+class SOFA_CORE_API RichConsoleStyleMessageFormatter : public MessageFormatter
 {
 public:
-    static RichConsoleStyleMessageFormatter &getInstance ()
+    static inline RichConsoleStyleMessageFormatter &getInstance ()
     {
         static RichConsoleStyleMessageFormatter instance;
         return instance;

--- a/SofaKernel/framework/sofa/helper/CMakeLists.txt
+++ b/SofaKernel/framework/sofa/helper/CMakeLists.txt
@@ -91,6 +91,7 @@ set(HEADER_FILES
     system/atomic.h
     system/config.h
     system/console.h
+    system/console_internal.h
     system/gl.h
     system/glu.h
     system/thread/CTime.h

--- a/SofaKernel/framework/sofa/helper/CMakeLists.txt
+++ b/SofaKernel/framework/sofa/helper/CMakeLists.txt
@@ -192,6 +192,7 @@ set(SOURCE_FILES
     types/Material.cpp
     logging/Message.cpp
     logging/MessageDispatcher.cpp
+    logging/MessageFormatter.cpp
     logging/ComponentInfo.cpp
     logging/ClangMessageHandler.cpp
     logging/ClangStyleMessageFormatter.cpp

--- a/SofaKernel/framework/sofa/helper/init.cpp
+++ b/SofaKernel/framework/sofa/helper/init.cpp
@@ -39,7 +39,6 @@ SOFA_HELPER_API void init()
 {
     if (!s_initialized)
     {
-        Console::init();
         s_initialized = true;
     }
 }

--- a/SofaKernel/framework/sofa/helper/logging/ClangStyleMessageFormatter.cpp
+++ b/SofaKernel/framework/sofa/helper/logging/ClangStyleMessageFormatter.cpp
@@ -38,19 +38,19 @@ namespace helper
 namespace logging
 {
 
-helper::fixed_array<std::string,Message::TypeCount> s_messageTypeStrings;
-ClangStyleMessageFormatter ClangStyleMessageFormatter::s_instance;
+std::string ClangStyleMessageFormatter::getPrefixText(unsigned int type) const {
+    switch (type) {
+        case Message::Advice     : return "suggestion";
+        case Message::Deprecated : return "info";
+        case Message::Warning    : return "deprecated";
+        case Message::Info       : return "warning";
+        case Message::Error      : return "error";
+        case Message::Fatal      : return "fatal";
+        case Message::TEmpty     : return "empty";
 
-
-ClangStyleMessageFormatter::ClangStyleMessageFormatter()
-{
-    s_messageTypeStrings[Message::Advice]       = "suggestion";
-    s_messageTypeStrings[Message::Info]       = "info";
-    s_messageTypeStrings[Message::Deprecated] = "deprecated";
-    s_messageTypeStrings[Message::Warning]    = "warning";
-    s_messageTypeStrings[Message::Error]      = "error";
-    s_messageTypeStrings[Message::Fatal]      = "fatal";
-    s_messageTypeStrings[Message::TEmpty]     = "empty";
+        default:
+            return "";
+    }
 }
 
 
@@ -58,14 +58,14 @@ void ClangStyleMessageFormatter::formatMessage(const Message& m,std::ostream& ou
 {
     if(m.fileInfo()){
         if(m.sender()!="")
-            out << m.fileInfo()->filename << ":" << m.fileInfo()->line << ":1: " << s_messageTypeStrings[m.type()] << ": " << m.message().str() << std::endl ;
+            out << m.fileInfo()->filename << ":" << m.fileInfo()->line << ":1: " << getPrefixText(m.type()) << ": " << m.message().str() << std::endl ;
         else
-            out << m.fileInfo()->filename << ":" << m.fileInfo()->line << ":1: " << s_messageTypeStrings[m.type()] << ": ["<< m.sender() <<"] " << m.message().str() << std::endl ;
+            out << m.fileInfo()->filename << ":" << m.fileInfo()->line << ":1: " << getPrefixText(m.type()) << ": ["<< m.sender() <<"] " << m.message().str() << std::endl ;
     }else{
         if(m.sender()!="")
-            out << s_messageTypeStrings[m.type()] << ": " << m.message().str() << std::endl ;
+            out << getPrefixText(m.type()) << ": " << m.message().str() << std::endl ;
         else
-            out << s_messageTypeStrings[m.type()] << ": ["<< m.sender() <<"] " << m.message().str() << std::endl ;
+            out << getPrefixText(m.type()) << ": ["<< m.sender() <<"] " << m.message().str() << std::endl ;
 
     }
 }

--- a/SofaKernel/framework/sofa/helper/logging/ClangStyleMessageFormatter.h
+++ b/SofaKernel/framework/sofa/helper/logging/ClangStyleMessageFormatter.h
@@ -26,7 +26,6 @@
 #ifndef CLANGSTYLEMESSAGEFORMATTER_H
 #define CLANGSTYLEMESSAGEFORMATTER_H
 #include <sstream>
-#include "Message.h"
 #include "MessageFormatter.h"
 #include <sofa/helper/helper.h>
 
@@ -39,19 +38,27 @@ namespace helper
 namespace logging
 {
 
+class Message;
 
 class SOFA_HELPER_API ClangStyleMessageFormatter : public MessageFormatter
 {
 public:
-    virtual void formatMessage(const Message& m,std::ostream& out);
-    static ClangStyleMessageFormatter& getInstance() { return s_instance; }
+    static ClangStyleMessageFormatter &getInstance ()
+    {
+        static ClangStyleMessageFormatter instance;
+        return instance;
+    }
+
+    void formatMessage(const Message& m,std::ostream& out) override;
+
+protected:
+    std::string getPrefixText(unsigned int type) const override;
 
 private:
     // singleton API
-    ClangStyleMessageFormatter();
+    ClangStyleMessageFormatter() {}
     ClangStyleMessageFormatter(const ClangStyleMessageFormatter&);
     void operator=(const ClangStyleMessageFormatter&);
-    static ClangStyleMessageFormatter s_instance;
 };
 
 

--- a/SofaKernel/framework/sofa/helper/logging/ClangStyleMessageFormatter.h
+++ b/SofaKernel/framework/sofa/helper/logging/ClangStyleMessageFormatter.h
@@ -43,7 +43,7 @@ class Message;
 class SOFA_HELPER_API ClangStyleMessageFormatter : public MessageFormatter
 {
 public:
-    static ClangStyleMessageFormatter &getInstance ()
+    static inline ClangStyleMessageFormatter &getInstance ()
     {
         static ClangStyleMessageFormatter instance;
         return instance;

--- a/SofaKernel/framework/sofa/helper/logging/DefaultStyleMessageFormatter.cpp
+++ b/SofaKernel/framework/sofa/helper/logging/DefaultStyleMessageFormatter.cpp
@@ -24,12 +24,9 @@
 * in the messaging.h file.
 ******************************************************************************/
 
-
+#include <sofa/helper/system/console.h>
 #include "DefaultStyleMessageFormatter.h"
 #include "Message.h"
-
-#include <sofa/helper/system/console.h>
-#include <sofa/helper/fixed_array.h>
 
 
 namespace sofa
@@ -44,12 +41,12 @@ namespace logging
 void DefaultStyleMessageFormatter::formatMessage(const Message & m, std::ostream & out)
 {
 
-    out << getPrefixCode(m.type()) << getPrefixText(m.type());
+    setColor(out, m.type()) << getPrefixText(m.type());
 
     if (!m.sender().empty())
-        out << Console::Code(Console::BLUE) << "[" << m.componentInfo() << "] ";
+        out << console::Foreground::Normal::Blue << "[" << m.componentInfo() << "] ";
 
-    out << Console::Code(Console::DEFAULT) << m.message().str() << std::endl;
+    out << console::Foreground::Normal::Reset << m.message().str() << std::endl;
 }
 
 

--- a/SofaKernel/framework/sofa/helper/logging/DefaultStyleMessageFormatter.cpp
+++ b/SofaKernel/framework/sofa/helper/logging/DefaultStyleMessageFormatter.cpp
@@ -41,41 +41,15 @@ namespace helper
 namespace logging
 {
 
-
-helper::fixed_array<std::string,Message::TypeCount> s_messageTypePrefixes;
-helper::fixed_array<Console::ColorType,Message::TypeCount> s_messageTypeColors;
-DefaultStyleMessageFormatter DefaultStyleMessageFormatter::s_instance;
-
-
-
-
-DefaultStyleMessageFormatter::DefaultStyleMessageFormatter()
+void DefaultStyleMessageFormatter::formatMessage(const Message & m, std::ostream & out)
 {
-    s_messageTypePrefixes[Message::Advice]      = "[SUGGESTION] ";
-    s_messageTypePrefixes[Message::Info]        = "[INFO]    ";
-    s_messageTypePrefixes[Message::Deprecated]  = "[DEPRECATED] ";
-    s_messageTypePrefixes[Message::Warning]     = "[WARNING] ";
-    s_messageTypePrefixes[Message::Error]       = "[ERROR]   ";
-    s_messageTypePrefixes[Message::Fatal]       = "[FATAL]   ";
-    s_messageTypePrefixes[Message::TEmpty]      = "[EMPTY]   ";
 
-    s_messageTypeColors[Message::Advice]     = Console::BRIGHT_GREEN;
-    s_messageTypeColors[Message::Info]       = Console::BRIGHT_GREEN;
-    s_messageTypeColors[Message::Deprecated] = Console::BRIGHT_YELLOW;
-    s_messageTypeColors[Message::Warning]    = Console::BRIGHT_CYAN;
-    s_messageTypeColors[Message::Error]      = Console::BRIGHT_RED;
-    s_messageTypeColors[Message::Fatal]      = Console::BRIGHT_PURPLE;
-    s_messageTypeColors[Message::TEmpty]     = Console::DEFAULT_COLOR;
-}
-
-void DefaultStyleMessageFormatter::formatMessage(const Message& m,std::ostream& out)
-{
-    out << s_messageTypeColors[m.type()] << s_messageTypePrefixes[m.type()];
+    out << getPrefixCode(m.type()) << getPrefixText(m.type());
 
     if (!m.sender().empty())
-        out << Console::BLUE << "[" << m.componentInfo() << "] ";
+        out << Console::Code(Console::BLUE) << "[" << m.componentInfo() << "] ";
 
-    out << Console::DEFAULT_COLOR << m.message().str() << std::endl;
+    out << Console::Code(Console::DEFAULT) << m.message().str() << std::endl;
 }
 
 

--- a/SofaKernel/framework/sofa/helper/logging/DefaultStyleMessageFormatter.h
+++ b/SofaKernel/framework/sofa/helper/logging/DefaultStyleMessageFormatter.h
@@ -48,16 +48,19 @@ namespace logging
 class SOFA_HELPER_API DefaultStyleMessageFormatter : public MessageFormatter
 {
 public:
-    static MessageFormatter& getInstance() { return s_instance; }
-    virtual void formatMessage(const Message& m,std::ostream& out);
+    static MessageFormatter &getInstance ()
+    {
+        static DefaultStyleMessageFormatter instance;
+        return instance;
+    }
+
+    void formatMessage (const Message &m, std::ostream &out) override;
 
 private:
-        // singleton API
-        DefaultStyleMessageFormatter();
-        DefaultStyleMessageFormatter(const DefaultStyleMessageFormatter&);
-
-        void operator=(const DefaultStyleMessageFormatter&);
-        static DefaultStyleMessageFormatter s_instance;
+    // singleton API
+    DefaultStyleMessageFormatter () {}
+    DefaultStyleMessageFormatter (const DefaultStyleMessageFormatter &);
+    void operator= (const DefaultStyleMessageFormatter &);
 };
 
 } // logging

--- a/SofaKernel/framework/sofa/helper/logging/DefaultStyleMessageFormatter.h
+++ b/SofaKernel/framework/sofa/helper/logging/DefaultStyleMessageFormatter.h
@@ -27,9 +27,7 @@
 #define DEFAULTSTYLEMESSAGEFORMATTER_H
 #include <sstream>
 #include <string>
-#include "Message.h"
 #include "MessageFormatter.h"
-#include <sofa/helper/helper.h>
 
 
 namespace sofa
@@ -41,6 +39,8 @@ namespace helper
 namespace logging
 {
 
+class Message;
+
 /// Format the message using a very simple sofa style. For more advanced formatting style
 /// have a look at RichStyleMessageFormatter.
 /// Example:
@@ -48,7 +48,7 @@ namespace logging
 class SOFA_HELPER_API DefaultStyleMessageFormatter : public MessageFormatter
 {
 public:
-    static MessageFormatter &getInstance ()
+    static inline MessageFormatter &getInstance ()
     {
         static DefaultStyleMessageFormatter instance;
         return instance;

--- a/SofaKernel/framework/sofa/helper/logging/MessageFormatter.cpp
+++ b/SofaKernel/framework/sofa/helper/logging/MessageFormatter.cpp
@@ -23,9 +23,10 @@
 * User of this library should read the documentation
 * in the messaging.h file.
 ******************************************************************************/
-#ifndef RICHCONSOLESTYLEMESSAGEFORMATTER_H
-#define RICHCONSOLESTYLEMESSAGEFORMATTER_H
-#include <sofa/helper/logging/MessageFormatter.h>
+
+#include <sofa/helper/system/console.h>
+#include "Message.h"
+#include "MessageFormatter.h"
 
 namespace sofa
 {
@@ -36,40 +37,38 @@ namespace helper
 namespace logging
 {
 
-class Message;
+std::string MessageFormatter::getPrefixText(unsigned int type) const {
+    switch (type) {
+        case Message::Advice     : return "[SUGGESTION] ";
+        case Message::Deprecated : return "[DEPRECATED] ";
+        case Message::Warning    : return "[WARNING] ";
+        case Message::Info       : return "[INFO]    ";
+        case Message::Error      : return "[ERROR]   ";
+        case Message::Fatal      : return "[FATAL]   ";
+        case Message::TEmpty     : return "[EMPTY]   ";
 
-///
-/// \brief The RichConsoleStyleMessageFormatter class
-///
-///  The class implement a message formatter dedicated to console pretty printing on a console
-///  Among other thing it feature formatting using a markdown like syntax:
-///     - color rendering, 'italics' or *italics*
-///     - alignement and wrapping for long message that are then much easier to read.
-///     - automatic reading of the console number of column for prettier display.
-///
-///
-class SOFA_HELPER_API RichConsoleStyleMessageFormatter : public MessageFormatter
-{
-public:
-    static RichConsoleStyleMessageFormatter &getInstance ()
-    {
-        static RichConsoleStyleMessageFormatter instance;
-        return instance;
+        default:
+            return "";
     }
+}
 
-    void formatMessage(const Message& m,std::ostream& out) override;
+std::string MessageFormatter::getPrefixCode(unsigned int type) const {
+    switch (type) {
+        case Message::Advice     : return Console::Code(Console::BRIGHT_GREEN);
+        case Message::Info       : return Console::Code(Console::BRIGHT_GREEN);
+        case Message::Deprecated : return Console::Code(Console::BRIGHT_YELLOW);
+        case Message::Warning    : return Console::Code(Console::BRIGHT_CYAN);
+        case Message::Error      : return Console::Code(Console::BRIGHT_RED);
+        case Message::Fatal      : return Console::Code(Console::BRIGHT_PURPLE);
 
-private:
-    // singleton API
-    RichConsoleStyleMessageFormatter() : m_showFileInfo(false) {}
-    RichConsoleStyleMessageFormatter(const RichConsoleStyleMessageFormatter&);
-    void operator=(const RichConsoleStyleMessageFormatter&);
+        case Message::TEmpty:
+        default:
+            return Console::Code(Console::DEFAULT);
+    }
+}
 
-    bool m_showFileInfo ;
-};
+} // namespace logging
 
-} // logging
-} // helper
-} // sofa
+} // namespace helper
 
-#endif // DEFAULTSTYLEMESSAGEFORMATTER_H
+} // namespace sofa

--- a/SofaKernel/framework/sofa/helper/logging/MessageFormatter.cpp
+++ b/SofaKernel/framework/sofa/helper/logging/MessageFormatter.cpp
@@ -52,18 +52,18 @@ std::string MessageFormatter::getPrefixText(unsigned int type) const {
     }
 }
 
-std::string MessageFormatter::getPrefixCode(unsigned int type) const {
+std::ostream & MessageFormatter::setColor(std::ostream &os, unsigned int type) const {
     switch (type) {
-        case Message::Advice     : return Console::Code(Console::BRIGHT_GREEN);
-        case Message::Info       : return Console::Code(Console::BRIGHT_GREEN);
-        case Message::Deprecated : return Console::Code(Console::BRIGHT_YELLOW);
-        case Message::Warning    : return Console::Code(Console::BRIGHT_CYAN);
-        case Message::Error      : return Console::Code(Console::BRIGHT_RED);
-        case Message::Fatal      : return Console::Code(Console::BRIGHT_PURPLE);
+        case Message::Advice     : return os << console::Foreground::Bright::Green;
+        case Message::Info       : return os << console::Foreground::Bright::Green;
+        case Message::Deprecated : return os << console::Foreground::Bright::Yellow;
+        case Message::Warning    : return os << console::Foreground::Bright::Cyan;
+        case Message::Error      : return os << console::Foreground::Bright::Red;
+        case Message::Fatal      : return os << console::Foreground::Bright::Magenta;
 
         case Message::TEmpty:
         default:
-            return Console::Code(Console::DEFAULT);
+            return os << console::Foreground::Normal::Reset;
     }
 }
 

--- a/SofaKernel/framework/sofa/helper/logging/MessageFormatter.h
+++ b/SofaKernel/framework/sofa/helper/logging/MessageFormatter.h
@@ -28,6 +28,7 @@
 
 #include <sstream>
 #include <sofa/helper/helper.h>
+#include <sofa/helper/system/console.h>
 
 namespace sofa
 {
@@ -49,7 +50,8 @@ protected:
     MessageFormatter() {} // no public default constructor, it should be enough to have singleton for MessageFormatters
 
     virtual std::string getPrefixText(unsigned int type) const;
-    virtual std::string getPrefixCode(unsigned int type) const;
+
+    virtual std::ostream & setColor(std::ostream &stream, unsigned int type) const;
 
 };
 

--- a/SofaKernel/framework/sofa/helper/logging/MessageFormatter.h
+++ b/SofaKernel/framework/sofa/helper/logging/MessageFormatter.h
@@ -46,7 +46,10 @@ public:
     virtual void formatMessage(const Message& m,std::ostream& out) = 0 ;
 
 protected:
-    MessageFormatter(){} // no public default constructor, it should be enough to have singleton for MessageFormatters
+    MessageFormatter() {} // no public default constructor, it should be enough to have singleton for MessageFormatters
+
+    virtual std::string getPrefixText(unsigned int type) const;
+    virtual std::string getPrefixCode(unsigned int type) const;
 
 };
 

--- a/SofaKernel/framework/sofa/helper/system/console.cpp
+++ b/SofaKernel/framework/sofa/helper/system/console.cpp
@@ -20,190 +20,34 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include "console.h"
-#include <sofa/helper/Utils.h>
-#include <sofa/helper/logging/Messaging.h>
-#include <cstdlib>
-
-#ifdef __linux__
-
-#include <sys/ioctl.h>
-
-#endif
-
 
 #ifndef WIN32
 
-#  include <unistd.h>           // for isatty()
+#include <unistd.h>
 
+#ifdef __linux__
+#include <sys/ioctl.h>
+#endif
 #endif
 
 
 namespace sofa {
 namespace helper {
 
-using SystemCodeType = Console::SystemCodeType;
-Console::ColorsStatus Console::s_colorsStatus = Console::ColorsAuto;
+namespace console {
 
-#ifdef WIN32
-static SystemCodeType getDefaultColor();
-#endif
-
-void Console::init()
+void setStatus(Status status) noexcept
 {
-    // Change s_colorsStatus based on the SOFA_COLOR_TERMINAL environnement variable.
-    const char *sofa_color_terminal = std::getenv("SOFA_COLOR_TERMINAL");
-    if (sofa_color_terminal != nullptr) {
-        const std::string colors(sofa_color_terminal);
-        if (colors == "yes" || colors == "on" || colors == "always")
-            s_colorsStatus = Console::ColorsEnabled;
-        else if (colors == "no" || colors == "off" || colors == "never")
-            s_colorsStatus = Console::ColorsDisabled;
-        else if (colors == "auto")
-            s_colorsStatus = Console::ColorsAuto;
-        else
-            msg_warning("Console::init()") << "Bad value for environnement variable SOFA_COLOR_TERMINAL (" << colors
-                                           << ")";
-    }
+    internal::get_status() = status;
 }
 
-SystemCodeType Console::Code(Style s)
+Status getStatus() noexcept
 {
-#ifdef WIN32
-    static const SystemCodeType default_style_code = getDefaultColor();
-    switch (s) {
-        case BLACK         : return 0;
-        case BLUE          : return 1;
-        case GREEN         : return 2;
-        case CYAN          : return 3;
-        case RED           : return 4;
-        case PURPLE        : return 5;
-        case YELLOW        : return 6;
-        case WHITE         : return 7;
-        case BRIGHT_BLACK  : return 8;
-        case BRIGHT_BLUE   : return 9;
-        case BRIGHT_GREEN  : return 10;
-        case BRIGHT_CYAN   : return 11;
-        case BRIGHT_RED    : return 12;
-        case BRIGHT_PURPLE : return 13;
-        case BRIGHT_YELLOW : return 14;
-        case BRIGHT_WHITE  : return 15;
-
-        //TODO(dmarchal): Implement the rich text on windows...
-        case ITALIC:
-        case UNDERLINE:
-        case DEFAULT:
-        default:
-        return default_style_code;;
-    }
-
-#else
-    switch (s) {
-        case BLACK         : return "\033[0;30m";
-        case RED           : return "\033[0;31m";
-        case GREEN         : return "\033[0;32m";
-        case YELLOW        : return "\033[0;33m";
-        case BLUE          : return "\033[0;34m";
-        case PURPLE        : return "\033[0;35m";
-        case CYAN          : return "\033[0;36m";
-        case WHITE         : return "\033[0;37m";
-        case BRIGHT_BLACK  : return "\033[1;30m";
-        case BRIGHT_RED    : return "\033[1;31m";
-        case BRIGHT_GREEN  : return "\033[1;32m";
-        case BRIGHT_YELLOW : return "\033[1;33m";
-        case BRIGHT_BLUE   : return "\033[1;34m";
-        case BRIGHT_PURPLE : return "\033[1;35m";
-        case BRIGHT_CYAN   : return "\033[1;36m";
-        case BRIGHT_WHITE  : return "\033[1;37m";
-        case ITALIC        : return "\033[3m";
-        case UNDERLINE     : return "\033[4m";
-
-        case DEFAULT:
-        default:
-            return "\033[0m";
-    }
-#endif
+    return internal::get_status();
 }
 
-#ifdef WIN32
 
-static HANDLE getOutputHandle()
-{
-    static bool first = true;
-    static HANDLE s_console = NULL;
-    if (first)
-    {
-        s_console = GetStdHandle(STD_OUTPUT_HANDLE);
-        if (s_console == INVALID_HANDLE_VALUE)
-        {
-            std::cerr << "Console::getOutputHandle(): " << Utils::GetLastError() << std::endl;
-        }
-        if (s_console == NULL)
-        {
-            std::cerr << "Console::getOutputHandle(): no stdout handle!" << std::endl;
-        }
-        first = false;
-    }
-    return s_console;
-}
-
-static SystemCodeType getDefaultColor()
-{
-    CONSOLE_SCREEN_BUFFER_INFO currentInfo;
-    GetConsoleScreenBufferInfo(getOutputHandle(), &currentInfo);
-    return currentInfo.wAttributes;
-}
-
-void Console::setColorsStatus(ColorsStatus status)
-{
-    s_colorsStatus = status;
-}
-
-bool Console::shouldUseColors(std::ostream& stream)
-{
-    // On Windows, colors are not handled with control characters, so we can
-    // probably always use them unless explicitely disabled.
-    return getColorsStatus() != ColorsDisabled;
-}
-
-#else
-
-static bool s_stdoutIsRedirected = false;
-static bool s_stderrIsRedirected = false;
-
-void Console::setColorsStatus(ColorsStatus status)
-{
-    s_colorsStatus = status;
-    // Check for redirections and save the result.  (This assumes that
-    // stdout and stderr won't be redirected in the middle of the execution
-    // of the program, which seems reasonable to me.)
-    s_stdoutIsRedirected = isatty(STDOUT_FILENO) == 0;
-    s_stderrIsRedirected = isatty(STDERR_FILENO) == 0;
-}
-
-bool Console::shouldUseColors(std::ostream &stream)
-{
-    if (s_colorsStatus == Console::ColorsAuto)
-        return (&stream == &std::cout && !s_stdoutIsRedirected)
-               || (&stream == &std::cerr && !s_stderrIsRedirected);
-    else
-        return s_colorsStatus == Console::ColorsEnabled;
-}
-
-#endif
-
-std::ostream &operator<<(std::ostream &stream, const SystemCodeType & code)
-{
-    if (Console::shouldUseColors(stream))
-#ifdef WIN32
-        SetConsoleTextAttribute(getOutputHandle(), code);
-#else
-        return stream << code;
-    else
-#endif
-        return stream;
-}
-
-size_t Console::getColumnCount()
+size_t getColumnCount()
 {
 #ifdef __linux__
     struct winsize w;
@@ -215,10 +59,6 @@ size_t Console::getColumnCount()
 #endif
 }
 
-Console::ColorsStatus Console::getColorsStatus()
-{
-    return s_colorsStatus;
 }
-
 }
 }

--- a/SofaKernel/framework/sofa/helper/system/console.cpp
+++ b/SofaKernel/framework/sofa/helper/system/console.cpp
@@ -22,209 +22,199 @@
 #include "console.h"
 #include <sofa/helper/Utils.h>
 #include <sofa/helper/logging/Messaging.h>
-#include <stdlib.h>             // For getenv()
+#include <cstdlib>
 
 #ifdef __linux__
+
 #include <sys/ioctl.h>
-#include <unistd.h>
+
 #endif
 
 
 #ifndef WIN32
+
 #  include <unistd.h>           // for isatty()
+
 #endif
 
 
 namespace sofa {
 namespace helper {
 
-    Console::ColorsStatus Console::s_colorsStatus = Console::ColorsAuto;
+using SystemCodeType = Console::SystemCodeType;
+Console::ColorsStatus Console::s_colorsStatus = Console::ColorsAuto;
 
-    void Console::init()
-    {
-        // Change s_colorsStatus based on the SOFA_COLOR_TERMINAL environnement variable.
-        const char *sofa_color_terminal = getenv("SOFA_COLOR_TERMINAL");
-        if (sofa_color_terminal != NULL)
-        {
-            const std::string colors(sofa_color_terminal);
-            if (colors == "yes" || colors == "on" || colors == "always")
-                s_colorsStatus = Console::ColorsEnabled;
-            else if (colors == "no" || colors == "off" || colors == "never")
-                s_colorsStatus = Console::ColorsDisabled;
-            else if (colors == "auto")
-                s_colorsStatus = Console::ColorsAuto;
-            else
-                msg_warning("Console::init()") << "Bad value for environnement variable SOFA_COLOR_TERMINAL (" << colors << ")";
-        }
+void Console::init()
+{
+    // Change s_colorsStatus based on the SOFA_COLOR_TERMINAL environnement variable.
+    const char *sofa_color_terminal = std::getenv("SOFA_COLOR_TERMINAL");
+    if (sofa_color_terminal != nullptr) {
+        const std::string colors(sofa_color_terminal);
+        if (colors == "yes" || colors == "on" || colors == "always")
+            s_colorsStatus = Console::ColorsEnabled;
+        else if (colors == "no" || colors == "off" || colors == "never")
+            s_colorsStatus = Console::ColorsDisabled;
+        else if (colors == "auto")
+            s_colorsStatus = Console::ColorsAuto;
+        else
+            msg_warning("Console::init()") << "Bad value for environnement variable SOFA_COLOR_TERMINAL (" << colors
+                                           << ")";
     }
+}
+
+SystemCodeType Console::Code(Style s)
+{
+#ifdef WIN32
+    static const SystemCodeType default_style_code = getDefaultColor();
+    switch (s) {
+        case BLACK         : return 0;
+        case BLUE          : return 1;
+        case GREEN         : return 2;
+        case CYAN          : return 3;
+        case RED           : return 4;
+        case PURPLE        : return 5;
+        case YELLOW        : return 6;
+        case WHITE         : return 7;
+        case BRIGHT_BLACK  : return 8;
+        case BRIGHT_BLUE   : return 9;
+        case BRIGHT_GREEN  : return 10;
+        case BRIGHT_CYAN   : return 11;
+        case BRIGHT_RED    : return 12;
+        case BRIGHT_PURPLE : return 13;
+        case BRIGHT_YELLOW : return 14;
+        case BRIGHT_WHITE  : return 15;
+
+        //TODO(dmarchal): Implement the rich text on windows...
+        case ITALIC:
+        case UNDERLINE:
+        case DEFAULT:
+        default:
+        return default_style_code;;
+    }
+
+#else
+    switch (s) {
+        case BLACK         : return "\033[0;30m";
+        case RED           : return "\033[0;31m";
+        case GREEN         : return "\033[0;32m";
+        case YELLOW        : return "\033[0;33m";
+        case BLUE          : return "\033[0;34m";
+        case PURPLE        : return "\033[0;35m";
+        case CYAN          : return "\033[0;36m";
+        case WHITE         : return "\033[0;37m";
+        case BRIGHT_BLACK  : return "\033[1;30m";
+        case BRIGHT_RED    : return "\033[1;31m";
+        case BRIGHT_GREEN  : return "\033[1;32m";
+        case BRIGHT_YELLOW : return "\033[1;33m";
+        case BRIGHT_BLUE   : return "\033[1;34m";
+        case BRIGHT_PURPLE : return "\033[1;35m";
+        case BRIGHT_CYAN   : return "\033[1;36m";
+        case BRIGHT_WHITE  : return "\033[1;37m";
+        case ITALIC        : return "\033[3m";
+        case UNDERLINE     : return "\033[4m";
+
+        case DEFAULT:
+        default:
+            return "\033[0m";
+    }
+#endif
+}
 
 #ifdef WIN32
 
-    static HANDLE getOutputHandle()
+static HANDLE getOutputHandle()
+{
+    static bool first = true;
+    static HANDLE s_console = NULL;
+    if (first)
     {
-        static bool first = true;
-        static HANDLE s_console = NULL;
-        if (first)
+        s_console = GetStdHandle(STD_OUTPUT_HANDLE);
+        if (s_console == INVALID_HANDLE_VALUE)
         {
-            s_console = GetStdHandle(STD_OUTPUT_HANDLE);
-            if (s_console == INVALID_HANDLE_VALUE)
-            {
-                std::cerr << "Console::getOutputHandle(): " << Utils::GetLastError() << std::endl;
-            }
-            if (s_console == NULL)
-            {
-                std::cerr << "Console::getOutputHandle(): no stdout handle!" << std::endl;
-            }
-            first = false;
+            std::cerr << "Console::getOutputHandle(): " << Utils::GetLastError() << std::endl;
         }
-        return s_console;
+        if (s_console == NULL)
+        {
+            std::cerr << "Console::getOutputHandle(): no stdout handle!" << std::endl;
+        }
+        first = false;
     }
+    return s_console;
+}
 
-    static Console::ColorType getDefaultColor()
-    {
-        CONSOLE_SCREEN_BUFFER_INFO currentInfo;
-        GetConsoleScreenBufferInfo(getOutputHandle(), &currentInfo);
-        return currentInfo.wAttributes;
-    }
-    static Console::CodeType getDefaultCode()
-    {
-        CONSOLE_SCREEN_BUFFER_INFO currentInfo;
-        GetConsoleScreenBufferInfo(getOutputHandle(), &currentInfo);
-        return currentInfo.wAttributes;
-    }
+static SystemCodeType getDefaultColor()
+{
+    CONSOLE_SCREEN_BUFFER_INFO currentInfo;
+    GetConsoleScreenBufferInfo(getOutputHandle(), &currentInfo);
+    return currentInfo.wAttributes;
+}
 
+void Console::setColorsStatus(ColorsStatus status)
+{
+    s_colorsStatus = status;
+}
 
-
-    const Console::ColorType Console::BLACK         = Console::ColorType(0);
-    const Console::ColorType Console::BLUE          = Console::ColorType(1);
-    const Console::ColorType Console::GREEN         = Console::ColorType(2);
-    const Console::ColorType Console::CYAN          = Console::ColorType(3);
-    const Console::ColorType Console::RED           = Console::ColorType(4);
-    const Console::ColorType Console::PURPLE        = Console::ColorType(5);
-    const Console::ColorType Console::YELLOW        = Console::ColorType(6);
-    const Console::ColorType Console::WHITE         = Console::ColorType(7);
-    const Console::ColorType Console::BRIGHT_BLACK  = Console::ColorType(8);
-    const Console::ColorType Console::BRIGHT_BLUE   = Console::ColorType(9);
-    const Console::ColorType Console::BRIGHT_GREEN  = Console::ColorType(10);
-    const Console::ColorType Console::BRIGHT_CYAN   = Console::ColorType(11);
-    const Console::ColorType Console::BRIGHT_RED    = Console::ColorType(12);
-    const Console::ColorType Console::BRIGHT_PURPLE = Console::ColorType(13);
-    const Console::ColorType Console::BRIGHT_YELLOW = Console::ColorType(14);
-    const Console::ColorType Console::BRIGHT_WHITE  = Console::ColorType(15);
-    const Console::ColorType Console::DEFAULT_COLOR = getDefaultColor();
-
-    //TODO(dmarchal): Implement the rich text on windows...
-    const Console::CodeType Console::ITALIC = getDefaultCode();
-    const Console::CodeType Console::UNDERLINE = getDefaultCode();
-    const Console::CodeType Console::DEFAULT_CODE = getDefaultCode();
-
-    void Console::setColorsStatus(ColorsStatus status)
-    {
-        s_colorsStatus = status;
-    }
-
-    bool Console::shouldUseColors(std::ostream& stream)
-    {
-        // On Windows, colors are not handled with control characters, so we can
-        // probably always use them unless explicitely disabled.
-        return getColorsStatus() != ColorsDisabled;
-    }
-
-    SOFA_HELPER_API std::ostream& operator<<( std::ostream& stream, Console::ColorType color )
-    {
-        if (Console::shouldUseColors(stream))
-            SetConsoleTextAttribute(getOutputHandle(), color.value);
-        return stream;
-    }
-
-    SOFA_HELPER_API std::ostream& operator<<( std::ostream& stream, Console::CodeType code )
-    {
-        if (Console::shouldUseColors(stream))
-            SetConsoleTextAttribute(getOutputHandle(), code.value);
-        return stream;
-    }
+bool Console::shouldUseColors(std::ostream& stream)
+{
+    // On Windows, colors are not handled with control characters, so we can
+    // probably always use them unless explicitely disabled.
+    return getColorsStatus() != ColorsDisabled;
+}
 
 #else
 
-    const Console::ColorType Console::BLACK         = Console::ColorType("\033[0;30m");
-    const Console::ColorType Console::RED           = Console::ColorType("\033[0;31m");
-    const Console::ColorType Console::GREEN         = Console::ColorType("\033[0;32m");
-    const Console::ColorType Console::YELLOW        = Console::ColorType("\033[0;33m");
-    const Console::ColorType Console::BLUE          = Console::ColorType("\033[0;34m");
-    const Console::ColorType Console::PURPLE        = Console::ColorType("\033[0;35m");
-    const Console::ColorType Console::CYAN          = Console::ColorType("\033[0;36m");
-    const Console::ColorType Console::WHITE         = Console::ColorType("\033[0;37m");
-    const Console::ColorType Console::BRIGHT_BLACK  = Console::ColorType("\033[1;30m");
-    const Console::ColorType Console::BRIGHT_RED    = Console::ColorType("\033[1;31m");
-    const Console::ColorType Console::BRIGHT_GREEN  = Console::ColorType("\033[1;32m");
-    const Console::ColorType Console::BRIGHT_YELLOW = Console::ColorType("\033[1;33m");
-    const Console::ColorType Console::BRIGHT_BLUE   = Console::ColorType("\033[1;34m");
-    const Console::ColorType Console::BRIGHT_PURPLE = Console::ColorType("\033[1;35m");
-    const Console::ColorType Console::BRIGHT_CYAN   = Console::ColorType("\033[1;36m");
-    const Console::ColorType Console::BRIGHT_WHITE  = Console::ColorType("\033[1;37m");
-    const Console::ColorType Console::DEFAULT_COLOR = Console::ColorType("\033[0m");
+static bool s_stdoutIsRedirected = false;
+static bool s_stderrIsRedirected = false;
 
-    const Console::CodeType Console::UNDERLINE = Console::CodeType("\033[4m");
-    const Console::CodeType Console::ITALIC = Console::CodeType("\033[3m");
-    const Console::CodeType Console::DEFAULT_CODE = Console::CodeType("\033[0m");
+void Console::setColorsStatus(ColorsStatus status)
+{
+    s_colorsStatus = status;
+    // Check for redirections and save the result.  (This assumes that
+    // stdout and stderr won't be redirected in the middle of the execution
+    // of the program, which seems reasonable to me.)
+    s_stdoutIsRedirected = isatty(STDOUT_FILENO) == 0;
+    s_stderrIsRedirected = isatty(STDERR_FILENO) == 0;
+}
 
-
-    static bool s_stdoutIsRedirected = false;
-    static bool s_stderrIsRedirected = false;
-
-    void Console::setColorsStatus(ColorsStatus status)
-    {
-        s_colorsStatus = status;
-        // Check for redirections and save the result.  (This assumes that
-        // stdout and stderr won't be redirected in the middle of the execution
-        // of the program, which seems reasonable to me.)
-        s_stdoutIsRedirected = isatty(STDOUT_FILENO) == 0;
-        s_stderrIsRedirected = isatty(STDERR_FILENO) == 0;
-    }
-
-    bool Console::shouldUseColors(std::ostream& stream)
-    {
-        if (s_colorsStatus == Console::ColorsAuto)
-            return (&stream == &std::cout && !s_stdoutIsRedirected)
-                || (&stream == &std::cerr && !s_stderrIsRedirected);
-        else
-            return s_colorsStatus == Console::ColorsEnabled;
-    }
-
-    std::ostream& operator<<( std::ostream& stream, Console::ColorType color )
-    {
-        if (Console::shouldUseColors(stream))
-            return stream << color.value;
-        else
-            return stream;
-    }
-
-    std::ostream& operator<<( std::ostream& stream, Console::CodeType code )
-    {
-        if (Console::shouldUseColors(stream))
-            return stream << code.value;
-        else
-            return stream;
-    }
-
+bool Console::shouldUseColors(std::ostream &stream)
+{
+    if (s_colorsStatus == Console::ColorsAuto)
+        return (&stream == &std::cout && !s_stdoutIsRedirected)
+               || (&stream == &std::cerr && !s_stderrIsRedirected);
+    else
+        return s_colorsStatus == Console::ColorsEnabled;
+}
 
 #endif
 
-    size_t Console::getColumnCount(){
+std::ostream &operator<<(std::ostream &stream, const SystemCodeType & code)
+{
+    if (Console::shouldUseColors(stream))
+#ifdef WIN32
+        SetConsoleTextAttribute(getOutputHandle(), color.value);
+#else
+        return stream << code;
+    else
+#endif
+        return stream;
+}
+
+size_t Console::getColumnCount()
+{
 #ifdef __linux__
-        struct winsize w;
-        ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
-        return w.ws_col;
+    struct winsize w;
+    ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
+    return w.ws_col;
 #else
-        //TODO(dmarchal): implement macOS and Windows or a portable version of this function.
-        return 80;
+    //TODO(dmarchal): implement macOS and Windows or a portable version of this function.
+    return 80;
 #endif
-    }
+}
 
-    Console::ColorsStatus Console::getColorsStatus()
-    {
-        return s_colorsStatus;
-    }
+Console::ColorsStatus Console::getColorsStatus()
+{
+    return s_colorsStatus;
+}
 
 }
 }

--- a/SofaKernel/framework/sofa/helper/system/console.cpp
+++ b/SofaKernel/framework/sofa/helper/system/console.cpp
@@ -44,6 +44,10 @@ namespace helper {
 using SystemCodeType = Console::SystemCodeType;
 Console::ColorsStatus Console::s_colorsStatus = Console::ColorsAuto;
 
+#ifdef WIN32
+static SystemCodeType getDefaultColor();
+#endif
+
 void Console::init()
 {
     // Change s_colorsStatus based on the SOFA_COLOR_TERMINAL environnement variable.
@@ -191,7 +195,7 @@ std::ostream &operator<<(std::ostream &stream, const SystemCodeType & code)
 {
     if (Console::shouldUseColors(stream))
 #ifdef WIN32
-        SetConsoleTextAttribute(getOutputHandle(), color.value);
+        SetConsoleTextAttribute(getOutputHandle(), code);
 #else
         return stream << code;
     else

--- a/SofaKernel/framework/sofa/helper/system/console.h
+++ b/SofaKernel/framework/sofa/helper/system/console.h
@@ -22,86 +22,174 @@
 #ifndef __HELPER_SYSTEM_console_H_
 #define __HELPER_SYSTEM_console_H_
 
+#include <cstdlib>
+#include <algorithm>
+#include <atomic>
+#include <cstring>
+#include <iostream>
+
+#ifndef WIN32
+
+#include <unistd.h>
+
+#ifdef __linux__
+#include <sys/ioctl.h>
+#endif
+
+#else
+
+#if defined(_WIN32_WINNT) && (_WIN32_WINNT < 0x0600)
+#error                                                                         \
+  "Please include this before any windows system headers or set _WIN32_WINNT at least to _WIN32_WINNT_VISTA"
+#elif !defined(_WIN32_WINNT)
+#define _WIN32_WINNT _WIN32_WINNT_VISTA
+#endif
+
+#include <windows.h>
+#include <io.h>
+#include <memory>
+
+// Only defined in windows 10 onwards, redefining in lower windows since it
+// doesn't gets used in lower versions
+// https://docs.microsoft.com/en-us/windows/console/getconsolemode
+#ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+#define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+#endif
+
+#endif
 
 #include <sofa/helper/helper.h>
-#include <string.h>
-#include <iostream>
 #include <sofa/helper/system/config.h>
 
 namespace sofa {
 namespace helper {
 
+/**
+ * Utility that manages the output style of a stream into a terminal. It is based heavily on the work
+ * of https://github.com/agauniyal/rang
+ */
+namespace console {
 
-
-
-class SOFA_HELPER_API Console
-{
-
-    Console() {} // private constructor
-
-public:
-
-#ifdef WIN32
-    typedef unsigned SystemCodeType;
-#else
-    typedef std::string SystemCodeType;
-#endif
-
-    enum Style {
-        DEFAULT,
-        BLUE,
-        GREEN,
-        CYAN,
-        RED,
-        PURPLE,
-        YELLOW,
-        WHITE,
-        BLACK,
-        BRIGHT_BLUE,
-        BRIGHT_GREEN,
-        BRIGHT_CYAN,
-        BRIGHT_RED,
-        BRIGHT_PURPLE,
-        BRIGHT_YELLOW,
-        BRIGHT_WHITE,
-        BRIGHT_BLACK,
-        ITALIC,
-        UNDERLINE
-    };
-
-    enum ColorsStatus {ColorsEnabled, ColorsDisabled, ColorsAuto};
-
-    /// @brief Initialize Console.
-    ///
-    /// Enable or disable colors based on the value of the SOFA_COLOR_TERMINAL
-    /// environnement variable (possible values: yes, no, auto).
-    static void init();
-
-    /// @brief Get the console code for a given style format
-    static SystemCodeType Code(Style s);
-
-    /// to use stream operator with a color on any system
-    SOFA_HELPER_API friend std::ostream& operator<<(std::ostream &stream, const SystemCodeType & color);
-
-    /// Enable or disable colors in stdout / stderr.
-    ///
-    /// This controls whether using ColorType values in streams will actually do
-    /// anything.  Passing ColorsAuto means that colors will be used for stdout
-    /// only if it hasn't been redirected (on Unix only). Same thing for stderr.
-    /// By default, colors are disabled.
-    static void setColorsStatus(ColorsStatus status);
-    static ColorsStatus getColorsStatus();
-
-    static size_t getColumnCount() ;
-
-private:
-    static ColorsStatus s_colorsStatus;
-    /// Internal helper function that determines whether colors should be used.
-    static bool shouldUseColors(std::ostream& stream);
+enum class Status {  // Toggle the status of the output style
+    Auto = 0, // (Default) automatically detects whether the terminal supports styled output
+    On   = 1,
+    Off  = 2
 };
 
-}
+#ifdef WIN32
+enum class Mode {  // Windows Terminal Mode
+    Auto   = 0, // (Default) automatically detects whether Ansi or Native API
+    Ansi   = 1, // Force use Ansi API
+    Native = 2  // Force use Native API
+};
+#endif
+
+enum class Style {
+    Reset     = 0,
+    Bold      = 1,
+    Dim       = 2,
+    Italic    = 3,
+    Underline = 4,
+    Blink     = 5,
+    Rblink    = 6,
+    Reversed  = 7,
+    Conceal   = 8,
+    Crossed   = 9
+};
+
+struct Foreground {
+    enum class Normal {
+        Black   = 30,
+        Red     = 31,
+        Green   = 32,
+        Yellow  = 33,
+        Blue    = 34,
+        Magenta = 35,
+        Cyan    = 36,
+        Gray    = 37,
+        Reset   = 39
+    };
+
+    enum class Bright {
+        Black   = 90,
+        Red     = 91,
+        Green   = 92,
+        Yellow  = 93,
+        Blue    = 94,
+        Magenta = 95,
+        Cyan    = 96,
+        Gray    = 97
+    };
+};
+
+struct Background {
+    enum class Normal {
+        Black   = 40,
+        Red     = 41,
+        Green   = 42,
+        Yellow  = 43,
+        Blue    = 44,
+        Magenta = 45,
+        Cyan    = 46,
+        Gray    = 47,
+        Reset   = 49
+    };
+
+    enum class Bright {
+        Black   = 100,
+        Red     = 101,
+        Green   = 102,
+        Yellow  = 103,
+        Blue    = 104,
+        Magenta = 105,
+        Cyan    = 106,
+        Gray    = 107
+    };
+};
+
+template<typename T>
+using enableStd = typename std::enable_if<
+    std::is_same<T, sofa::helper::console::Style>::value ||
+    std::is_same<T, sofa::helper::console::Foreground::Normal>::value ||
+    std::is_same<T, sofa::helper::console::Foreground::Bright>::value ||
+    std::is_same<T, sofa::helper::console::Background::Normal>::value ||
+    std::is_same<T, sofa::helper::console::Background::Bright>::value,
+    std::ostream &>::type;
+
+#define __CONSOLE_INTERNAL__
+#include "console_internal.h"
+#undef __CONSOLE_INTERNAL__
+
+/// Enable or disable colors in stdout / stderr.
+///
+/// This controls whether using styled values in streams will actually do
+/// anything.  Passing Auto means that styled output will be used for the stream
+/// only if it hasn't been redirected (on Unix only).
+/// By default, colors are enabled if supported (auto).
+SOFA_HELPER_API void setStatus(Status status) noexcept ;
+SOFA_HELPER_API Status getStatus() noexcept ;
+
+SOFA_HELPER_API size_t getColumnCount() ;
+
+/// to use stream operator with a styled output on any system
+template <typename T>
+inline enableStd<T> operator<<(std::ostream &os, const T & value)
+{
+    const Status status = internal::get_status();
+    switch (status) {
+        case sofa::helper::console::Status ::Auto:
+            return sofa::helper::console::internal::supportsColor()
+                   && sofa::helper::console::internal::isTerminal(os.rdbuf())
+                   ? sofa::helper::console::internal::setColor(os, value)
+                   : os;
+        case sofa::helper::console::Status::On : return sofa::helper::console::internal::setColor(os, value);
+        default: return os;
+    }
 }
 
+}; // namespace console
+
+} // namespace helper
+} // namespace sofa
 
 #endif

--- a/SofaKernel/framework/sofa/helper/system/console.h
+++ b/SofaKernel/framework/sofa/helper/system/console.h
@@ -41,68 +41,48 @@ class SOFA_HELPER_API Console
 
 public:
 
+#ifdef WIN32
+    typedef unsigned SystemCodeType;
+#else
+    typedef std::string SystemCodeType;
+#endif
+
+    enum Style {
+        DEFAULT,
+        BLUE,
+        GREEN,
+        CYAN,
+        RED,
+        PURPLE,
+        YELLOW,
+        WHITE,
+        BLACK,
+        BRIGHT_BLUE,
+        BRIGHT_GREEN,
+        BRIGHT_CYAN,
+        BRIGHT_RED,
+        BRIGHT_PURPLE,
+        BRIGHT_YELLOW,
+        BRIGHT_WHITE,
+        BRIGHT_BLACK,
+        ITALIC,
+        UNDERLINE
+    };
+
+    enum ColorsStatus {ColorsEnabled, ColorsDisabled, ColorsAuto};
+
     /// @brief Initialize Console.
     ///
     /// Enable or disable colors based on the value of the SOFA_COLOR_TERMINAL
     /// environnement variable (possible values: yes, no, auto).
     static void init();
 
-#ifdef WIN32
-    typedef unsigned SystemColorType;
-    typedef unsigned SystemCodeType;
-#else
-    typedef std::string SystemColorType;
-    typedef std::string SystemCodeType;
-#endif
-
-    /// this color type can be used with stream operator on any system
-    struct ColorType
-    {
-        Console::SystemColorType value;
-        ColorType() : value(DEFAULT_COLOR.value) {}
-        ColorType( const ColorType& c ) : value(c.value) {}
-        ColorType( const Console::SystemColorType& v ) : value(v) {}
-        void operator= ( const ColorType& c ) { value=c.value; }
-        void operator= ( const Console::SystemColorType& v ) { value=v; }
-    };
-
-    struct CodeType
-    {
-        Console::SystemCodeType value;
-        CodeType() : value(DEFAULT_CODE.value) {}
-        CodeType( const CodeType& c ) : value(c.value) {}
-        CodeType( const Console::SystemCodeType& v ) : value(v) {}
-        void operator= ( const CodeType& c ) { value=c.value; }
-        void operator= ( const Console::SystemCodeType& v ) { value=v; }
-    };
+    /// @brief Get the console code for a given style format
+    static SystemCodeType Code(Style s);
 
     /// to use stream operator with a color on any system
-    SOFA_HELPER_API friend std::ostream& operator<<(std::ostream &stream, ColorType color);
-    SOFA_HELPER_API friend std::ostream& operator<<(std::ostream &stream, CodeType color);
+    SOFA_HELPER_API friend std::ostream& operator<<(std::ostream &stream, const SystemCodeType & color);
 
-    static const ColorType BLUE;
-    static const ColorType GREEN;
-    static const ColorType CYAN;
-    static const ColorType RED;
-    static const ColorType PURPLE;
-    static const ColorType YELLOW;
-    static const ColorType WHITE;
-    static const ColorType BLACK;
-    static const ColorType BRIGHT_BLUE;
-    static const ColorType BRIGHT_GREEN;
-    static const ColorType BRIGHT_CYAN;
-    static const ColorType BRIGHT_RED;
-    static const ColorType BRIGHT_PURPLE;
-    static const ColorType BRIGHT_YELLOW;
-    static const ColorType BRIGHT_WHITE;
-    static const ColorType BRIGHT_BLACK;
-    static const ColorType DEFAULT_COLOR;
-
-    static const CodeType ITALIC;
-    static const CodeType UNDERLINE;
-    static const CodeType DEFAULT_CODE;
-
-    enum ColorsStatus {ColorsEnabled, ColorsDisabled, ColorsAuto};
     /// Enable or disable colors in stdout / stderr.
     ///
     /// This controls whether using ColorType values in streams will actually do

--- a/SofaKernel/framework/sofa/helper/system/console_internal.h
+++ b/SofaKernel/framework/sofa/helper/system/console_internal.h
@@ -1,0 +1,373 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#ifndef __HELPER_SYSTEM_console_internal_H_
+#define __HELPER_SYSTEM_console_internal_H_
+
+#ifndef __CONSOLE_INTERNAL__
+#error "The console internal header must be exclusively included inside console.h and nowhere else."
+#endif
+
+namespace internal {
+
+#ifdef WIN32
+
+inline bool isMsysPty(int fd) noexcept
+{
+    // Dynamic load for binary compability with old Windows
+    const auto ptrGetFileInformationByHandleEx
+      = reinterpret_cast<decltype(&GetFileInformationByHandleEx)>(
+        GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")),
+                       "GetFileInformationByHandleEx"));
+    if (!ptrGetFileInformationByHandleEx) {
+        return false;
+    }
+
+    HANDLE h = reinterpret_cast<HANDLE>(_get_osfhandle(fd));
+    if (h == INVALID_HANDLE_VALUE) {
+        return false;
+    }
+
+    // Check that it's a pipe:
+    if (GetFileType(h) != FILE_TYPE_PIPE) {
+        return false;
+    }
+
+    // POD type is binary compatible with FILE_NAME_INFO from WinBase.h
+    // It have the same alignment and used to avoid UB in caller code
+    struct MY_FILE_NAME_INFO {
+        DWORD FileNameLength;
+        WCHAR FileName[MAX_PATH];
+    };
+
+    auto pNameInfo = std::unique_ptr<MY_FILE_NAME_INFO>(
+      new (std::nothrow) MY_FILE_NAME_INFO());
+    if (!pNameInfo) {
+        return false;
+    }
+
+    // Check pipe name is template of
+    // {"cygwin-","msys-"}XXXXXXXXXXXXXXX-ptyX-XX
+    if (!ptrGetFileInformationByHandleEx(h, FileNameInfo, pNameInfo.get(),
+                                         sizeof(MY_FILE_NAME_INFO))) {
+        return false;
+    }
+    std::wstring name(pNameInfo->FileName, pNameInfo->FileNameLength / sizeof(WCHAR));
+    if ((name.find(L"msys-") == std::wstring::npos
+         && name.find(L"cygwin-") == std::wstring::npos)
+        || name.find(L"-pty") == std::wstring::npos) {
+        return false;
+    }
+
+    return true;
+}
+
+struct SGR {  // Select Graphic Rendition parameters for Windows console
+    BYTE fgColor;  // foreground color (0-15) lower 3 rgb bits + intense bit
+    BYTE bgColor;  // background color (0-15) lower 3 rgb bits + intense bit
+    BYTE bold;  // emulated as FOREGROUND_INTENSITY bit
+    BYTE underline;  // emulated as BACKGROUND_INTENSITY bit
+    BOOLEAN inverse;  // swap foreground/bold & background/underline
+    BOOLEAN conceal;  // set foreground/bold to background/underline
+};
+
+enum class AttrColor : BYTE {  // Color attributes for console screen buffer
+    black   = 0,
+    red     = 4,
+    green   = 2,
+    yellow  = 6,
+    blue    = 1,
+    magenta = 5,
+    cyan    = 3,
+    gray    = 7
+};
+
+inline HANDLE getConsoleHandle(const std::streambuf *osbuf) noexcept
+{
+    if (osbuf == std::cout.rdbuf()) {
+        static const HANDLE hStdout = GetStdHandle(STD_OUTPUT_HANDLE);
+        return hStdout;
+    } else if (osbuf == std::cerr.rdbuf() || osbuf == std::clog.rdbuf()) {
+        static const HANDLE hStderr = GetStdHandle(STD_ERROR_HANDLE);
+        return hStderr;
+    }
+    return INVALID_HANDLE_VALUE;
+}
+
+inline bool setWinTermAnsiColors(const std::streambuf *osbuf) noexcept
+{
+    HANDLE h = getConsoleHandle(osbuf);
+    if (h == INVALID_HANDLE_VALUE) {
+        return false;
+    }
+    DWORD dwMode = 0;
+    if (!GetConsoleMode(h, &dwMode)) {
+        return false;
+    }
+    dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+    if (!SetConsoleMode(h, dwMode)) {
+        return false;
+    }
+    return true;
+}
+
+inline bool supportsAnsi(const std::streambuf *osbuf) noexcept
+{
+    using std::cerr;
+    using std::clog;
+    using std::cout;
+    if (osbuf == cout.rdbuf()) {
+        static const bool cout_ansi
+          = (isMsysPty(_fileno(stdout)) || setWinTermAnsiColors(osbuf));
+        return cout_ansi;
+    } else if (osbuf == cerr.rdbuf() || osbuf == clog.rdbuf()) {
+        static const bool cerr_ansi
+          = (isMsysPty(_fileno(stderr)) || setWinTermAnsiColors(osbuf));
+        return cerr_ansi;
+    }
+    return false;
+}
+
+inline const SGR &defaultState() noexcept
+{
+    static const SGR defaultSgr = []() -> SGR {
+        CONSOLE_SCREEN_BUFFER_INFO info;
+        WORD attrib = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
+        if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE),
+                                       &info)
+            || GetConsoleScreenBufferInfo(GetStdHandle(STD_ERROR_HANDLE),
+                                          &info)) {
+            attrib = info.wAttributes;
+        }
+        SGR sgr     = { 0, 0, 0, 0, FALSE, FALSE };
+        sgr.fgColor = attrib & 0x0F;
+        sgr.bgColor = (attrib & 0xF0) >> 4;
+        return sgr;
+    }();
+    return defaultSgr;
+}
+
+inline BYTE ansi2attr(BYTE rgb) noexcept
+{
+    static const AttrColor rev[8]
+      = { AttrColor::black,  AttrColor::red,  AttrColor::green,
+          AttrColor::yellow, AttrColor::blue, AttrColor::magenta,
+          AttrColor::cyan,   AttrColor::gray };
+    return static_cast<BYTE>(rev[rgb]);
+}
+
+inline void setWinSGR(Background::Normal color, SGR &state) noexcept
+{
+    if (color != Background::Normal::Reset) {
+        state.bgColor = ansi2attr(static_cast<BYTE>(color) - 40);
+    } else {
+        state.bgColor = defaultState().bgColor;
+    }
+}
+
+inline void setWinSGR(Foreground::Normal color, SGR &state) noexcept
+{
+    if (color != Foreground::Normal::Reset) {
+        state.fgColor = ansi2attr(static_cast<BYTE>(color) - 30);
+    } else {
+        state.fgColor = defaultState().fgColor;
+    }
+}
+
+inline void setWinSGR(Background::Bright color, SGR &state) noexcept
+{
+    state.bgColor = (BACKGROUND_INTENSITY >> 4)
+      | ansi2attr(static_cast<BYTE>(color) - 100);
+}
+
+inline void setWinSGR(Foreground::Bright color, SGR &state) noexcept
+{
+    state.fgColor
+      = FOREGROUND_INTENSITY | ansi2attr(static_cast<BYTE>(color) - 90);
+}
+
+inline void setWinSGR(Style style, SGR &state) noexcept
+{
+    switch (style) {
+        case Style::Reset: state = defaultState(); break;
+        case Style::Bold: state.bold = FOREGROUND_INTENSITY; break;
+        case Style::Underline:
+        case Style::Blink:
+            state.underline = BACKGROUND_INTENSITY;
+            break;
+        case Style::Reversed: state.inverse = TRUE; break;
+        case Style::Conceal: state.conceal = TRUE; break;
+        default: break;
+    }
+}
+
+inline SGR &current_state() noexcept
+{
+    static SGR state = defaultState();
+    return state;
+}
+
+inline WORD SGR2Attr(const SGR &state) noexcept
+{
+    WORD attrib = 0;
+    if (state.conceal) {
+        if (state.inverse) {
+            attrib = (state.fgColor << 4) | state.fgColor;
+            if (state.bold)
+                attrib |= FOREGROUND_INTENSITY | BACKGROUND_INTENSITY;
+        } else {
+            attrib = (state.bgColor << 4) | state.bgColor;
+            if (state.underline)
+                attrib |= FOREGROUND_INTENSITY | BACKGROUND_INTENSITY;
+        }
+    } else if (state.inverse) {
+        attrib = (state.fgColor << 4) | state.bgColor;
+        if (state.bold) attrib |= BACKGROUND_INTENSITY;
+        if (state.underline) attrib |= FOREGROUND_INTENSITY;
+    } else {
+        attrib = state.fgColor | (state.bgColor << 4) | state.bold
+          | state.underline;
+    }
+    return attrib;
+}
+
+template <typename T>
+inline void setWinColorAnsi(std::ostream &os, T const value)
+{
+    os << "\033[" << static_cast<int>(value) << "m";
+}
+
+template <typename T>
+inline void setWinColorNative(std::ostream &os, T const value)
+{
+    const HANDLE h = getConsoleHandle(os.rdbuf());
+    if (h != INVALID_HANDLE_VALUE) {
+        setWinSGR(value, current_state());
+        // Out all buffered text to console with previous settings:
+        os.flush();
+        SetConsoleTextAttribute(h, SGR2Attr(current_state()));
+    }
+}
+
+#endif
+
+inline std::atomic<Status> &get_status() noexcept
+{
+    static std::atomic<Status > status(Status ::Auto);
+    return status;
+}
+
+#ifdef WIN32
+inline std::atomic<Mode> &get_mode() noexcept
+{
+    static std::atomic<Mode> mode(Mode::Auto);
+    return mode;
+}
+#endif
+
+inline bool supportsColor() noexcept
+{
+#ifndef WIN32
+
+    static const bool result = [] {
+        const char *Terms[]
+            = { "ansi",    "color",  "console", "cygwin", "gnome",
+                "konsole", "kterm",  "linux",   "msys",   "putty",
+                "rxvt",    "screen", "vt100",   "xterm" };
+
+        const char *env_p = std::getenv("TERM");
+        if (env_p == nullptr) {
+            return false;
+        }
+        return std::any_of(std::begin(Terms), std::end(Terms),
+                           [&](const char *term) {
+                               return std::strstr(env_p, term) != nullptr;
+                           });
+    }();
+
+#else
+    // All windows versions support colors through native console methods
+        static constexpr bool result = true;
+#endif
+    return result;
+}
+
+inline bool isTerminal(const std::streambuf *osbuf) noexcept
+{
+    using std::cerr;
+    using std::clog;
+    using std::cout;
+
+#ifndef WIN32
+    if (osbuf == cout.rdbuf()) {
+        static const bool cout_term = isatty(fileno(stdout)) != 0;
+        return cout_term;
+    } else if (osbuf == cerr.rdbuf() || osbuf == clog.rdbuf()) {
+        static const bool cerr_term = isatty(fileno(stderr)) != 0;
+        return cerr_term;
+    }
+#else
+    if (osbuf == cout.rdbuf()) {
+            static const bool cout_term
+              = (_isatty(_fileno(stdout)) || isMsysPty(_fileno(stdout)));
+            return cout_term;
+        } else if (osbuf == cerr.rdbuf() || osbuf == clog.rdbuf()) {
+            static const bool cerr_term
+              = (_isatty(_fileno(stderr)) || isMsysPty(_fileno(stderr)));
+            return cerr_term;
+        }
+#endif
+    return false;
+}
+
+#ifndef WIN32
+
+template <typename T>
+inline enableStd<T> setColor(std::ostream &os, T const value)
+{
+    return os << "\033[" << static_cast<int>(value) << "m";
+}
+
+#else
+
+template <typename T>
+inline enableStd<T> setColor(std::ostream &os, T const value)
+{
+    if (get_mode() == Mode::Auto) {
+        if (supportsAnsi(os.rdbuf())) {
+            setWinColorAnsi(os, value);
+        } else {
+            setWinColorNative(os, value);
+        }
+    } else if (get_mode() == Mode::Ansi) {
+        setWinColorAnsi(os, value);
+    } else {
+        setWinColorNative(os, value);
+    }
+    return os;
+}
+
+#endif
+
+} // namespace internal
+
+#endif //__HELPER_SYSTEM_console_internal_H_

--- a/SofaKernel/framework/sofa/helper/testing/BaseTest.cpp
+++ b/SofaKernel/framework/sofa/helper/testing/BaseTest.cpp
@@ -38,7 +38,6 @@ using sofa::helper::Utils;
 using sofa::helper::BackTrace;
 
 #include <sofa/helper/system/console.h>
-using sofa::helper::Console ;
 
 #include <sofa/helper/testing/TestMessageHandler.h>
 using sofa::helper::logging::MessageDispatcher ;
@@ -56,7 +55,7 @@ void initializeOnce()
 {
     static bool initialized = false ;
     if(!initialized){
-        Console::setColorsStatus(Console::ColorsDisabled) ;
+        console::setStatus(console::Status::Off) ;
 
         MessageDispatcher::addHandler( MainGtestMessageHandler::getInstance() ) ;
         BackTrace::autodump() ;
@@ -82,7 +81,7 @@ BaseTest::BaseTest() :
 
     ///gtest already use color so we remove the color from the sofa message to make the distinction
     ///clean and avoid ambiguity.
-    Console::setColorsStatus(Console::ColorsDisabled) ;
+    console::setStatus(console::Status::Off);
 
     ///Repeating this for each class is harmless because addHandler test if the handler is already installed and
     ///if so it don't install it again.

--- a/SofaKernel/modules/SofaComponentBase/SofaComponentBase_test/MakeAliasComponent_test.cpp
+++ b/SofaKernel/modules/SofaComponentBase/SofaComponentBase_test/MakeAliasComponent_test.cpp
@@ -79,7 +79,7 @@ void perTestInit()
     }
 
     if(defaultHandler==nullptr)
-        defaultHandler=new ConsoleMessageHandler(new RichConsoleStyleMessageFormatter) ;
+        defaultHandler=new ConsoleMessageHandler(&RichConsoleStyleMessageFormatter::getInstance()) ;
 
     /// THE TESTS HERE ARE NOT INHERITING FROM SOFA TEST SO WE NEED TO MANUALLY INSTALL THE HANDLER
     /// DO NO REMOVE

--- a/SofaKernel/modules/SofaComponentBase/SofaComponentBase_test/MakeDataAliasComponent_test.cpp
+++ b/SofaKernel/modules/SofaComponentBase/SofaComponentBase_test/MakeDataAliasComponent_test.cpp
@@ -79,7 +79,7 @@ void perTestInit()
     }
 
     if(defaultHandler==nullptr)
-        defaultHandler=new ConsoleMessageHandler(new RichConsoleStyleMessageFormatter) ;
+        defaultHandler=new ConsoleMessageHandler(&RichConsoleStyleMessageFormatter::getInstance()) ;
 
     /// THE TESTS HERE ARE NOT INHERITING FROM SOFA TEST SO WE NEED TO MANUALLY INSTALL THE HANDLER
     /// DO NO REMOVE

--- a/SofaKernel/modules/SofaComponentBase/messageHandlerComponent.cpp
+++ b/SofaKernel/modules/SofaComponentBase/messageHandlerComponent.cpp
@@ -91,7 +91,7 @@ void MessageHandlerComponent::parse ( core::objectmodel::BaseObjectDescription* 
 //    }else if(stype=="log"){
 //        MessageDispatcher::addHandler(new LoggerMessageHandler()) ;
     }else if(stype=="rich"){
-         MessageDispatcher::addHandler(new ConsoleMessageHandler(new RichConsoleStyleMessageFormatter())) ;
+         MessageDispatcher::addHandler(new ConsoleMessageHandler(&RichConsoleStyleMessageFormatter::getInstance())) ;
     }else if(stype=="silent"){
         MessageDispatcher::clearHandlers() ;
     }else{

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -307,7 +307,7 @@ int main(int argc, char** argv)
     else if (messageHandler == "rich")
     {
         MessageDispatcher::clearHandlers() ;
-        MessageDispatcher::addHandler( new ConsoleMessageHandler(new RichConsoleStyleMessageFormatter()) ) ;
+        MessageDispatcher::addHandler( new ConsoleMessageHandler(&RichConsoleStyleMessageFormatter::getInstance()) ) ;
     }
     else if (messageHandler == "test"){
         MessageDispatcher::addHandler( new ExceptionMessageHandler() ) ;

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -70,7 +70,6 @@ using sofa::core::ExecParams ;
 
 #include <sofa/helper/system/console.h>
 using sofa::helper::Utils;
-using sofa::helper::Console;
 
 using sofa::component::misc::CompareStateCreator;
 using sofa::component::misc::ReadStateActivator;
@@ -204,7 +203,7 @@ int main(int argc, char** argv)
     bool        disableStealing = false;
     bool        affinity = false;
 #endif
-    string colorsStatus = "auto";
+    string colorsStatus = "unset";
     string messageHandler = "auto";
     bool enableInteraction = false ;
     int width = 800;
@@ -239,7 +238,7 @@ int main(int argc, char** argv)
     argParser->addArgument(po::value<bool>(&temporaryFile)->default_value(false)->implicit_value(true),             "tmp", "the loaded scene won't appear in history of opened files");
     argParser->addArgument(po::value<bool>(&testMode)->default_value(false)->implicit_value(true),                  "test", "select test mode with xml output after N iteration");
     argParser->addArgument(po::value<std::string>(&verif)->default_value(""), "verification,v",                     "load verification data for the scene");
-    argParser->addArgument(po::value<std::string>(&colorsStatus)->default_value("auto")->implicit_value("yes"),     "colors,c", "use colors on stdout and stderr (yes, no, auto)");
+    argParser->addArgument(po::value<std::string>(&colorsStatus)->default_value("unset", "auto")->implicit_value("yes"),     "colors,c", "use colors on stdout and stderr (yes, no, auto)");
     argParser->addArgument(po::value<std::string>(&messageHandler)->default_value("auto"), "formatting,f",          "select the message formatting to use (auto, clang, sofa, rich, test)");
     argParser->addArgument(po::value<bool>(&enableInteraction)->default_value(false)->implicit_value(true),         "interactive,i", "enable interactive mode for the GUI which includes idle and mouse events (EXPERIMENTAL)");
     argParser->addArgument(po::value<std::vector<std::string> >()->multitoken(), "argv",                            "forward extra args to the python interpreter");
@@ -281,12 +280,24 @@ int main(int argc, char** argv)
     sofa::simulation::setSimulation(new TreeSimulation());
 #endif
 
-    if (colorsStatus == "auto")
-        Console::setColorsStatus(Console::ColorsAuto);
+    if (colorsStatus == "unset") {
+        // If the parameter is unset, check the environment variable
+        const char * colorStatusEnvironment = std::getenv("SOFA_COLOR_TERMINAL");
+        if (colorStatusEnvironment != nullptr) {
+            const std::string status (colorStatusEnvironment);
+            if (status == "yes" || status == "on" || status == "always")
+                sofa::helper::console::setStatus(sofa::helper::console::Status::On);
+            else if (status == "no" || status == "off" || status == "never")
+                sofa::helper::console::setStatus(sofa::helper::console::Status::Off);
+            else
+                sofa::helper::console::setStatus(sofa::helper::console::Status::Auto);
+        }
+    } else if (colorsStatus == "auto")
+        sofa::helper::console::setStatus(sofa::helper::console::Status::Auto);
     else if (colorsStatus == "yes")
-        Console::setColorsStatus(Console::ColorsEnabled);
+        sofa::helper::console::setStatus(sofa::helper::console::Status::On);
     else if (colorsStatus == "no")
-        Console::setColorsStatus(Console::ColorsDisabled);
+        sofa::helper::console::setStatus(sofa::helper::console::Status::Off);
 
     //TODO(dmarchal): Use smart pointer there to avoid memory leaks !!
     if (messageHandler == "auto" )


### PR DESCRIPTION
To reproduce the bug, simply add a `msg_error()` at the first line of `static std::string computeSofaPathPrefix()` (sofa/helper/Utils.cpp) on a mac OSX system.

I believe this bug  was due to an order mixup of global static initializer since this bug wasn't affecting Linux (not sure about Windows). I would need more time to prove this though. I moved the faulty global static intializer to local static initializer and that fixed the crashes.

It may be a good idea in the future to minimize the uses of static objects (singletons, static global variables, etc) since they are pretty hard to debug and can cause behaviors dependent of the compiler used.

@guparan could you test this in your PR #635  (by reinserting the msg_error) and make sure that the seg fault is gone?

Fixes #636 


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
