### PR TITLE
[CI] ADD output on scene-test crash

### DIFF
--- a/scripts/ci/scene-tests.sh
+++ b/scripts/ci/scene-tests.sh
@@ -404,11 +404,13 @@ extract-crashes() {
             local status="$(cat "$output_dir/$scene/status.txt")"
             if [[ "$status" != 0 ]]; then
                 echo "$scene: error: $status"
+                if [[ -e "$output_dir/$scene/output.txt" ]]; then
+                    cat "$output_dir/$scene/output.txt"
+                fi
+                echo "### END OF OUTPUT ###"
             fi
         fi
-    done < "$output_dir/all-tested-scenes.txt" > "$output_dir/crashes.tmp"
-    sort "$output_dir/crashes.tmp" | uniq > "$output_dir/crashes.txt"
-    rm -f "$output_dir/crashes.tmp"
+    done < "$output_dir/all-tested-scenes.txt" > "$output_dir/crashes.txt"
 }
 
 extract-successes() {


### PR DESCRIPTION
Crash dump will now appear on Jenkins scene-test crash summary.

TODO (after merge): change Jenkins detection regex to  
`([^:]*): (error:.*)(([\r\n].*?)*?)### END OF OUTPUT ###`

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
