### PR TITLE
[SofaFramework] Fix plugin list configuration

### DIFF
--- a/SofaKernel/SofaFramework/CMakeLists.txt
+++ b/SofaKernel/SofaFramework/CMakeLists.txt
@@ -4,7 +4,9 @@ project(SofaFramework)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 
 include(SofaMacros)
-
+# Clear internal target list (set by the macro sofa_add_generic() )
+set_property(GLOBAL PROPERTY __GlobalTargetList__ "")
+set_property(GLOBAL PROPERTY __GlobalTargetNameList__ "")
 
 ### Options
 

--- a/SofaKernel/SofaFramework/SofaMacros.cmake
+++ b/SofaKernel/SofaFramework/SofaMacros.cmake
@@ -185,8 +185,21 @@ macro(sofa_add_generic directory name type)
             endif()
         endif()
 
-        set_property(GLOBAL APPEND PROPERTY __GlobalTargetList__ ${name})
-        set_property(GLOBAL APPEND PROPERTY __GlobalTargetNameList__ ${option})
+        # Add current target in the internal list only if not present already
+        get_property(_allTargets GLOBAL PROPERTY __GlobalTargetList__)
+        get_property(_allTargetNames GLOBAL PROPERTY __GlobalTargetNameList__)
+
+        # if(NOT ${name} IN_LIST _allTargets) # ONLY CMAKE >= 3.3 and policy to NEW
+        list (FIND _allTargets ${name} _index)
+        if(NOT ${_index} GREATER -1)
+            set_property(GLOBAL APPEND PROPERTY __GlobalTargetList__ ${name})
+        endif()
+
+        #if(NOT ${option} IN_LIST _allTargetNames)# ONLY CMAKE >= 3.3 and policy to NEW
+        list (FIND _allTargetNames ${option} _index)
+        if(NOT ${_index} GREATER -1)
+            set_property(GLOBAL APPEND PROPERTY __GlobalTargetNameList__ ${option})
+        endif()
     else()
         message("${type} ${name} (${CMAKE_CURRENT_LIST_DIR}/${directory}) does not exist and will be ignored.")
     endif()


### PR DESCRIPTION
Fix #632 

The plugin list was never updated if we removed a plugin in the cmake configuration.
Plus, it was possible to append several identical targets.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
