### PR TITLE
[SofaOpenglVisual] FIX MacOS crash in batch mode

### DIFF
--- a/applications/sofa/gui/BatchGUI.cpp
+++ b/applications/sofa/gui/BatchGUI.cpp
@@ -60,8 +60,6 @@ int BatchGUI::mainLoop()
             sofa::helper::AdvancedTimer::begin("Animate");
             sofa::simulation::getSimulation()->animate(groot.get());
             msg_info("BatchGUI") << "Processing." << sofa::helper::AdvancedTimer::end("Animate", groot.get()) << msgendl;
-            //As no visualization is done by the Batch GUI, these two lines are not necessary.
-            sofa::simulation::getSimulation()->updateVisual(groot.get());
             sofa::simulation::Visitor::ctime_t rtfreq = sofa::helper::system::thread::CTime::getRefTicksPerSec();
             sofa::simulation::Visitor::ctime_t tfreq = sofa::helper::system::thread::CTime::getTicksPerSec();
             sofa::simulation::Visitor::ctime_t rt = sofa::helper::system::thread::CTime::getRefTime();
@@ -75,8 +73,6 @@ int BatchGUI::mainLoop()
             {
                 sofa::helper::AdvancedTimer::begin("Animate");
                 sofa::simulation::getSimulation()->animate(groot.get());
-                //As no visualization is done by the Batch GUI, these two lines are not necessary.
-                sofa::simulation::getSimulation()->updateVisual(groot.get());
             }
 
             if ( i == nbIter || (nbIter == -1 && i%1000 == 0) )

--- a/examples/Components/visualmodel/LightMax.scn
+++ b/examples/Components/visualmodel/LightMax.scn
@@ -1,0 +1,23 @@
+<Node name="root" dt="0.01" gravity="0 0 -10" showBoundingTree="0">
+    <BackgroundSetting color="0.5 0.6 0.7"/>
+    <LightManager ambient="1 1 1"/>
+
+    <SpotLight name="light01" color="1 0 0" cutoff="1" exponent="1" drawSource="true" position="0 3.5 10"/>
+    <SpotLight name="light02" color="1 0 0" cutoff="1" exponent="1" drawSource="true" position="3 3 10"/>
+    <SpotLight name="light03" color="1 0 0" cutoff="1" exponent="1" drawSource="true" position="-3 3 10"/>
+    <SpotLight name="light04" color="1 0 0" cutoff="1" exponent="1" drawSource="true" position="0 2.5 10"/>
+
+    <SpotLight name="light05" color="1 0 0" cutoff="1" exponent="1" drawSource="true" position="0 -3.5 10"/>
+    <SpotLight name="light06" color="1 0 0" cutoff="1" exponent="1" drawSource="true" position="3 -3 10"/>
+    <SpotLight name="light07" color="1 0 0" cutoff="1" exponent="1" drawSource="true" position="-3 -3 10"/>
+    <SpotLight name="light08" color="1 0 0" cutoff="1" exponent="1" drawSource="true" position="0 -2.5 10"/>
+
+    <!-- <SpotLight name="light09" color="1 0 0" cutoff="1" exponent="1" drawSource="true" position="-3.5 0 10"/> -->
+    <!-- <SpotLight name="light10" color="1 0 0" cutoff="1" exponent="1" drawSource="true" position="-4.5 0 10"/> -->
+    <!-- <SpotLight name="light11" color="1 0 0" cutoff="1" exponent="1" drawSource="true" position="3.5 0 10"/> -->
+    <!-- <SpotLight name="light12" color="1 0 0" cutoff="1" exponent="1" drawSource="true" position="4.5 0 10"/> -->
+
+	<Node name="Torus" >
+		<OglModel name="Visual" fileMesh="mesh/torus.obj" color="1 1 1" scale="2" rotation="90 0 0"/>
+	</Node>
+</Node>

--- a/modules/SofaOpenglVisual/CompositingVisualLoop.h
+++ b/modules/SofaOpenglVisual/CompositingVisualLoop.h
@@ -35,7 +35,6 @@
 
 #ifdef SOFA_HAVE_GLEW
 #include <SofaOpenglVisual/OglShader.h>
-#include <sofa/helper/gl/FrameBufferObject.h>
 #include <SofaOpenglVisual/VisualManagerPass.h>
 #endif
 

--- a/modules/SofaOpenglVisual/Light.h
+++ b/modules/SofaOpenglVisual/Light.h
@@ -66,9 +66,9 @@ protected:
     GLuint m_shadowTexWidth, m_shadowTexHeight;
 
 #ifdef SOFA_HAVE_GLEW
-    helper::gl::FrameBufferObject m_shadowFBO;
-    helper::gl::FrameBufferObject m_blurHFBO;
-    helper::gl::FrameBufferObject m_blurVFBO;
+    std::unique_ptr<helper::gl::FrameBufferObject> m_shadowFBO;
+    std::unique_ptr<helper::gl::FrameBufferObject> m_blurHFBO;
+    std::unique_ptr<helper::gl::FrameBufferObject> m_blurVFBO;
     static const std::string PATH_TO_GENERATE_DEPTH_TEXTURE_VERTEX_SHADER;
     static const std::string PATH_TO_GENERATE_DEPTH_TEXTURE_FRAGMENT_SHADER;
     static const std::string PATH_TO_BLUR_TEXTURE_VERTEX_SHADER;

--- a/modules/SofaOpenglVisual/LightManager.cpp
+++ b/modules/SofaOpenglVisual/LightManager.cpp
@@ -170,7 +170,7 @@ void LightManager::putLight(Light::SPtr light)
 {
     if (m_lights.size() >= MAX_NUMBER_OF_LIGHTS)
     {
-        msg_error(this) << "The maximum of lights permitted ( "<< MAX_NUMBER_OF_LIGHTS << " ) has been reached." ;
+        msg_warning(this) << "The maximum of lights permitted ( "<< MAX_NUMBER_OF_LIGHTS << " ) has been reached." ;
         return ;
     }
 

--- a/modules/SofaOpenglVisual/LightManager.h
+++ b/modules/SofaOpenglVisual/LightManager.h
@@ -68,11 +68,7 @@ private:
     void makeShadowMatrix(unsigned int i);
 
 public:
-#ifndef __APPLE__
-    enum { MAX_NUMBER_OF_LIGHTS = /*GL_MAX_LIGHTS*/ 5 };
-#else
-    enum { MAX_NUMBER_OF_LIGHTS = /*GL_MAX_LIGHTS*/ 2 };
-#endif
+    enum { MAX_NUMBER_OF_LIGHTS = /*GL_MAX_LIGHTS*/ 8 };
 
     //TODO(dmarchal): sofa guidelines.
     Data<bool>                  d_shadowsEnabled; ///< Enable Shadow in the scene. (default=0)

--- a/modules/SofaOpenglVisual/OglViewport.cpp
+++ b/modules/SofaOpenglVisual/OglViewport.cpp
@@ -88,7 +88,8 @@ void OglViewport::initVisual()
     if (p_useFBO.getValue())
     {
         const Vec<2, unsigned int> screenSize = p_screenSize.getValue();
-        fbo.init(screenSize[0],screenSize[1]);
+        fbo = std::unique_ptr<helper::gl::FrameBufferObject>(new helper::gl::FrameBufferObject());
+        fbo->init(screenSize[0],screenSize[1]);
     }
 }
 
@@ -233,8 +234,8 @@ void OglViewport::renderToViewport(core::visual::VisualParams* vp)
     int y0 = (screenPosition[1]>=0 ? screenPosition[1] : viewport[3]+screenPosition[1]);
     if (p_useFBO.getValue())
     {
-        fbo.init(screenSize[0],screenSize[1]);
-        fbo.start();
+        fbo->init(screenSize[0],screenSize[1]);
+        fbo->start();
         glViewport(0,0,screenSize[0],screenSize[1]);
     }
     else
@@ -367,7 +368,7 @@ void OglViewport::renderToViewport(core::visual::VisualParams* vp)
 
     if (p_useFBO.getValue())
     {
-        fbo.stop();
+        fbo->stop();
     }
     else
     {
@@ -415,7 +416,7 @@ void OglViewport::renderFBOToScreen(core::visual::VisualParams* vp)
 
     glActiveTexture(GL_TEXTURE0);
     glEnable(GL_TEXTURE_2D);
-    glBindTexture(GL_TEXTURE_2D, fbo.getColorTexture());
+    glBindTexture(GL_TEXTURE_2D, fbo->getColorTexture());
 
     glBegin(GL_QUADS);
     {

--- a/modules/SofaOpenglVisual/OglViewport.h
+++ b/modules/SofaOpenglVisual/OglViewport.h
@@ -62,7 +62,7 @@ public:
     Data<bool> p_swapMainView; ///< Swap this viewport with the main view
     Data<bool> p_drawCamera; ///< Draw a frame representing the camera (see it in main viewport)
 
-    helper::gl::FrameBufferObject fbo;
+    std::unique_ptr<helper::gl::FrameBufferObject> fbo;
 
 protected:
     OglViewport();

--- a/modules/SofaOpenglVisual/OrderIndependentTransparencyManager.h
+++ b/modules/SofaOpenglVisual/OrderIndependentTransparencyManager.h
@@ -38,7 +38,6 @@
 
 #include <sofa/core/visual/VisualManager.h>
 #include <sofa/helper/gl/GLSLShader.h>
-#include <sofa/helper/gl/FrameBufferObject.h>
 #include <SofaOpenglVisual/OglOITShader.h>
 
 namespace sofa

--- a/modules/SofaOpenglVisual/PostProcessManager.cpp
+++ b/modules/SofaOpenglVisual/PostProcessManager.cpp
@@ -89,7 +89,8 @@ void PostProcessManager::initVisual()
         GLint windowWidth = viewport[2];
         GLint windowHeight = viewport[3];
 
-        fbo.init(windowWidth, windowHeight);
+        fbo = std::unique_ptr<helper::gl::FrameBufferObject>(new helper::gl::FrameBufferObject());
+        fbo->init(windowWidth, windowHeight);
 
 
         /*dofShader = new OglShader();
@@ -111,8 +112,8 @@ void PostProcessManager::preDrawScene(VisualParams* vp)
 
     if (postProcessEnabled)
     {
-        fbo.setSize(viewport[2], viewport[3]);
-        fbo.start();
+        fbo->setSize(viewport[2], viewport[3]);
+        fbo->start();
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
 
         glMatrixMode(GL_PROJECTION);
@@ -135,7 +136,7 @@ void PostProcessManager::preDrawScene(VisualParams* vp)
         gluPerspective(60.0,1.0, vp->zNear(), vp->zFar());
         glViewport(viewport[0],viewport[1],viewport[2],viewport[3]);
 
-        fbo.stop();
+        fbo->stop();
     }
 }
 
@@ -166,11 +167,11 @@ bool PostProcessManager::drawScene(VisualParams* vp)
 
         glActiveTexture(GL_TEXTURE0);
         glEnable(GL_TEXTURE_2D);
-        glBindTexture(GL_TEXTURE_2D, fbo.getColorTexture());
+        glBindTexture(GL_TEXTURE_2D, fbo->getColorTexture());
 
         glActiveTexture(GL_TEXTURE1);
         glEnable(GL_TEXTURE_2D);
-        glBindTexture(GL_TEXTURE_2D, fbo.getDepthTexture());
+        glBindTexture(GL_TEXTURE_2D, fbo->getDepthTexture());
         glTexParameteri(GL_TEXTURE_2D, GL_DEPTH_TEXTURE_MODE_ARB, GL_LUMINANCE);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE_ARB, GL_NONE);
 

--- a/modules/SofaOpenglVisual/PostProcessManager.h
+++ b/modules/SofaOpenglVisual/PostProcessManager.h
@@ -55,7 +55,7 @@ private:
     static const std::string DEPTH_OF_FIELD_FRAGMENT_SHADER;
     Data<double> zNear; ///< Set zNear distance (for Depth Buffer)
     Data<double> zFar; ///< Set zFar distance (for Depth Buffer)
-    helper::gl::FrameBufferObject fbo;
+    std::unique_ptr<helper::gl::FrameBufferObject> fbo;
     OglShader* dofShader;
     bool postProcessEnabled;
 

--- a/modules/SofaOpenglVisual/VisualManagerPass.cpp
+++ b/modules/SofaOpenglVisual/VisualManagerPass.cpp
@@ -96,7 +96,6 @@ void VisualManagerPass::init()
 {
     sofa::core::objectmodel::BaseContext* context = this->getContext();
     multiPassEnabled=checkMultipass(context);
-    fbo = new FrameBufferObject(true, true, true, true);
 }
 
 /* herited from VisualModel */
@@ -108,6 +107,8 @@ void VisualManagerPass::initVisual()
     passWidth = (GLint) ((float)viewport[2]*factor.getValue());
     passHeight = (GLint)((float)viewport[3] * factor.getValue());
 
+    fbo = std::unique_ptr<helper::gl::FrameBufferObject>(
+                new FrameBufferObject(true, true, true, true));
     fbo->init(passWidth, passHeight);
 }
 

--- a/modules/SofaOpenglVisual/VisualManagerPass.h
+++ b/modules/SofaOpenglVisual/VisualManagerPass.h
@@ -64,7 +64,7 @@ protected:
     bool checkMultipass(sofa::core::objectmodel::BaseContext* con);
     bool multiPassEnabled;
 
-    helper::gl::FrameBufferObject* fbo;
+    std::unique_ptr<helper::gl::FrameBufferObject> fbo;
     bool prerendered;
 
     GLint passWidth;
@@ -88,9 +88,9 @@ public:
 
     virtual void handleEvent(sofa::core::objectmodel::Event* /*event*/) override;
 
-    virtual bool isPrerendered() {return prerendered;};
+    virtual bool isPrerendered() {return prerendered;}
 
-    virtual helper::gl::FrameBufferObject* getFBO() {return fbo;};
+    virtual helper::gl::FrameBufferObject& getFBO() {return *fbo;}
     bool hasFilledFbo();
     std::string getOutputName();
 };

--- a/modules/SofaOpenglVisual/VisualManagerSecondaryPass.cpp
+++ b/modules/SofaOpenglVisual/VisualManagerSecondaryPass.cpp
@@ -68,7 +68,6 @@ void VisualManagerSecondaryPass::init()
 {
     sofa::core::objectmodel::BaseContext* context = this->getContext();
     multiPassEnabled=checkMultipass(context);
-    fbo = new FrameBufferObject(true, true, true, true);
 }
 
 void VisualManagerSecondaryPass::initVisual()
@@ -105,6 +104,8 @@ void VisualManagerSecondaryPass::initVisual()
     passWidth = (GLint)(viewport[2]*factor.getValue());
     passHeight = (GLint)(viewport[3]*factor.getValue());
 
+    fbo = std::unique_ptr<helper::gl::FrameBufferObject>(
+                new FrameBufferObject(true, true, true, true));
     fbo->init(passWidth, passHeight);
 }
 
@@ -237,7 +238,7 @@ void VisualManagerSecondaryPass::bindInput(core::visual::VisualParams* /*vp*/)
                 }
                 glActiveTexture(GL_TEXTURE0+nbFbo);
                 glEnable(GL_TEXTURE_2D);
-                glBindTexture(GL_TEXTURE_2D, currentSecondaryPass->getFBO()->getColorTexture());
+                glBindTexture(GL_TEXTURE_2D, currentSecondaryPass->getFBO().getColorTexture());
                 glGenerateMipmap(GL_TEXTURE_2D);
 
                 ++nbFbo;
@@ -258,13 +259,13 @@ void VisualManagerSecondaryPass::bindInput(core::visual::VisualParams* /*vp*/)
 
                     glActiveTexture(GL_TEXTURE0+nbFbo);
                     glEnable(GL_TEXTURE_2D);
-                    glBindTexture(GL_TEXTURE_2D, currentPass->getFBO()->getColorTexture());
+                    glBindTexture(GL_TEXTURE_2D, currentPass->getFBO().getColorTexture());
                     glGenerateMipmap(GL_TEXTURE_2D);
                     ++nbFbo;
 
                     glActiveTexture(GL_TEXTURE0+nbFbo);
                     glEnable(GL_TEXTURE_2D);
-                    glBindTexture(GL_TEXTURE_2D, currentPass->getFBO()->getDepthTexture());
+                    glBindTexture(GL_TEXTURE_2D, currentPass->getFBO().getDepthTexture());
                     glTexParameteri(GL_TEXTURE_2D, GL_DEPTH_TEXTURE_MODE_ARB, GL_LUMINANCE);
                     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE_ARB, GL_NONE);
                     ++nbFbo;

--- a/modules/SofaOpenglVisual/VisualManagerSecondaryPass.h
+++ b/modules/SofaOpenglVisual/VisualManagerSecondaryPass.h
@@ -74,9 +74,9 @@ public:
     void bindInput(core::visual::VisualParams* /*vp*/);
     void unbindInput();
 
-    helper::gl::FrameBufferObject* getFBO() override {return fbo;};
+    helper::gl::FrameBufferObject& getFBO() override {return *fbo;}
 
-    const sofa::core::objectmodel::TagSet& getOutputTags() {return output_tags.getValue();};
+    const sofa::core::objectmodel::TagSet& getOutputTags() {return output_tags.getValue();}
 
 private:
 


### PR DESCRIPTION
MacOS crashes in batch mode were due to FrameBufferObject constructor calls during simulation construction.
Fixed by moving those constructor calls to `initVisual()` using `std::unique_ptr`.

WARNING: I changed VisualManagerPass::getFBO(). [See here](https://github.com/sofa-framework/sofa/commit/e910ec1e91e667ce213caeece639120598881940#diff-74e00cdcc25741750d2ed4f6b53398a7R93).

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
