### PR TITLE
[Geomagic] ADD an inputForceFeedback data in Geomagic

### DIFF
--- a/applications/plugins/Geomagic/scenes/Geomagic-Demo.scn
+++ b/applications/plugins/Geomagic/scenes/Geomagic-Demo.scn
@@ -5,7 +5,7 @@
 
 	<VisualStyle displayFlags="showVisualModels showBehaviorModels hideCollisionModels hideBoundingCollisionModels hideMappings hideMechanicalMappings hideForceFields hideInteractionForceFields hideWireframe hideNormals" />
 
-    <GeomagicDriver name="GeomagicDevice" deviceName="Default Device" scale="1" drawDeviceFrame="1" positionBase="0 0 0" orientationBase="0 0 0 1"  />
+    <GeomagicDriver name="GeomagicDevice" deviceName="Default Device" scale="1" drawDevice="1" drawDeviceFrame="1" positionBase="0 0 0" orientationBase="0 0 0 1"  />
 
 	<MechanicalObject template="Rigid" name="GeomagicMO" position="@GeomagicDevice.positionDevice" />
 

--- a/applications/plugins/Geomagic/scenes/Geomagic-Demo.scn
+++ b/applications/plugins/Geomagic/scenes/Geomagic-Demo.scn
@@ -5,7 +5,7 @@
 
 	<VisualStyle displayFlags="showVisualModels showBehaviorModels hideCollisionModels hideBoundingCollisionModels hideMappings hideMechanicalMappings hideForceFields hideInteractionForceFields hideWireframe hideNormals" />
 
-    <GeomagicDriver name="GeomagicDevice" deviceName="Default Device" scale="1" drawDevice="1" drawDeviceFrame="1" positionBase="0 0 0" orientationBase="0 0 0 1"  />
+    <GeomagicDriver name="GeomagicDevice" deviceName="Default Device" scale="1" drawDevice="1" drawDeviceFrame="0" positionBase="0 0 0" orientationBase="0 0 0 1"  />
 
 	<MechanicalObject template="Rigid" name="GeomagicMO" position="@GeomagicDevice.positionDevice" />
 

--- a/applications/plugins/Geomagic/scenes/Geomagic-FEMLiver.scn
+++ b/applications/plugins/Geomagic/scenes/Geomagic-FEMLiver.scn
@@ -8,7 +8,7 @@
     <LocalMinDistance name="proximity" alarmDistance="0.15" contactDistance="0.05" angleCone="0.0" />
     <FreeMotionAnimationLoop/>
     <LCPConstraintSolver tolerance="0.001" maxIt="1000"/>
-    <GeomagicDriver name="GeomagicDevice" deviceName="Default Device" scale="1" drawDeviceFrame="1" positionBase="0 0 0" orientationBase="0 0.707 0 -0.707"  />
+    <GeomagicDriver name="GeomagicDevice" deviceName="Default Device" scale="1" drawDeviceFrame="1" positionBase="0 0 0" drawDevice="0" orientationBase="0 0.707 0 -0.707"  />
 
 
     <Node name="Liver" gravity="0 -9.81 0">

--- a/applications/plugins/Geomagic/src/GeomagicDriver.cpp
+++ b/applications/plugins/Geomagic/src/GeomagicDriver.cpp
@@ -462,7 +462,7 @@ void GeomagicDriver::updatePosition()
     d_button_1.endEdit();
     d_button_2.endEdit();
 
-    if(d_omniVisu.getValue() && m_initVisuDone)
+    if(m_initVisuDone)
     {
         sofa::defaulttype::SolidTypes<double>::Transform tampon;
         m_posDeviceVisu[0] = posDevice;

--- a/applications/plugins/Geomagic/src/GeomagicDriver.cpp
+++ b/applications/plugins/Geomagic/src/GeomagicDriver.cpp
@@ -87,11 +87,11 @@ using namespace sofa::defaulttype;
 
 void printError(const HDErrorInfo *error, const char *message)
 {
-    msg_error("GeomagicDriver") << hdGetErrorString(error->errorCode);
-    msg_error("GeomagicDriver") << "HHD: "<< error->hHD;
-    msg_error("GeomagicDriver") << "Error Code: "<< error->hHD;
-    msg_error("GeomagicDriver") << "Internal Error Code: "<< error->internalErrorCode;
-    msg_error("GeomagicDriver") << "Message: " << message;
+    msg_error("GeomagicDriver::HD_DEVICE_ERROR") << hdGetErrorString(error->errorCode);
+    msg_error("GeomagicDriver::HD_DEVICE_ERROR") << "HHD: "<< error->hHD;
+    msg_error("GeomagicDriver::HD_DEVICE_ERROR") << "Error Code: "<< error->hHD;
+    msg_error("GeomagicDriver::HD_DEVICE_ERROR") << "Internal Error Code: "<< error->internalErrorCode;
+    msg_error("GeomagicDriver::HD_DEVICE_ERROR") << "Message: " << message;
 }
 
 HDCallbackCode HDCALLBACK copyDeviceDataCallback(void * pUserData)
@@ -138,7 +138,7 @@ HDCallbackCode HDCALLBACK stateCallback(void * userData)
         {
             if( normValue > maxInputForceFeedback )
             {
-                msg_warning("GeomagicDriver") << "Force given to applied inputForceFeedback (norm = "<< normValue <<") exceeds the maxInputForceFeedback ("<< maxInputForceFeedback <<")";
+                msg_warning(driver) << "Force given to applied inputForceFeedback (norm = "<< normValue <<") exceeds the maxInputForceFeedback ("<< maxInputForceFeedback <<")";
 
                 inputForceFeedback[0] *= maxInputForceFeedback/normValue;
                 inputForceFeedback[1] *= maxInputForceFeedback/normValue;
@@ -150,7 +150,7 @@ HDCallbackCode HDCALLBACK stateCallback(void * userData)
         }
         else
         {
-            msg_error("GeomagicDriver") << "maxInputForceFeedback value ("<< maxInputForceFeedback <<") is negative or 0, it should be strictly positive";
+            msg_error(driver) << "maxInputForceFeedback value ("<< maxInputForceFeedback <<") is negative or 0, it should be strictly positive";
         }
     }
 

--- a/applications/plugins/Geomagic/src/GeomagicDriver.cpp
+++ b/applications/plugins/Geomagic/src/GeomagicDriver.cpp
@@ -563,8 +563,6 @@ void GeomagicDriver::draw(const sofa::core::visual::VisualParams* vparams)
 
     if (d_omniVisu.getValue() && m_initVisuDone)
     {
-        //----------------
-
         //Reactivate visual node
         if(!m_visuActive)
         {

--- a/applications/plugins/Geomagic/src/GeomagicDriver.cpp
+++ b/applications/plugins/Geomagic/src/GeomagicDriver.cpp
@@ -106,6 +106,9 @@ HDCallbackCode HDCALLBACK stateCallback(void * userData)
     HDErrorInfo error;
     GeomagicDriver * driver = (GeomagicDriver * ) userData;
 
+    if (!driver->m_simulationStarted)
+        return HD_CALLBACK_CONTINUE;
+
     hdMakeCurrentDevice(driver->m_hHD);
     if (HD_DEVICE_ERROR(error = hdGetError())) return HD_CALLBACK_CONTINUE;
 
@@ -188,6 +191,7 @@ GeomagicDriver::GeomagicDriver()
     , d_button_2(initData(&d_button_2,"button2","Button state 2"))
     , d_inputForceFeedback(initData(&d_inputForceFeedback, Vec3d(0,0,0), "inputForceFeedback","Input force feedback in case of no LCPForceFeedback is found (manual setting)"))
     , d_maxInputForceFeedback(initData(&d_maxInputForceFeedback, double(1.0), "maxInputForceFeedback","Maximum value of the normed input force feedback for device security"))
+    , m_simulationStarted(false)
 {
     this->f_listening.setValue(true);
     m_forceFeedback = NULL;
@@ -645,6 +649,8 @@ void GeomagicDriver::handleEvent(core::objectmodel::Event *event)
     {
         if (m_hStateHandles.size() && m_hStateHandles[0] == HD_INVALID_HANDLE)
             return;
+
+        m_simulationStarted = true;
         updatePosition();
     }
 }

--- a/applications/plugins/Geomagic/src/GeomagicDriver.cpp
+++ b/applications/plugins/Geomagic/src/GeomagicDriver.cpp
@@ -222,7 +222,7 @@ void GeomagicDriver::init()
 
     if (HD_DEVICE_ERROR(error = hdGetError()))
     {
-        msg_error("GeomagicDriver") << "Failed to initialize the device called " << d_deviceName.getValue().c_str();
+        msg_error() << "Failed to initialize the device called " << d_deviceName.getValue().c_str();
         d_omniVisu.setValue(false);
         m_errorDevice = true;
         //init the positionDevice data to avoid any crash in the scene
@@ -251,11 +251,11 @@ void GeomagicDriver::init()
 
     if(d_maxInputForceFeedback.isSet())
     {
-        msg_info("GeomagicDriver") << "maxInputForceFeedback value ("<< d_maxInputForceFeedback.getValue() <<") is set, carefully set the max force regarding your haptic device";
+        msg_info() << "maxInputForceFeedback value ("<< d_maxInputForceFeedback.getValue() <<") is set, carefully set the max force regarding your haptic device";
 
         if(d_maxInputForceFeedback.getValue() <= 0.0)
         {
-            msg_error("GeomagicDriver") << "maxInputForceFeedback value ("<< d_maxInputForceFeedback.getValue() <<") is negative or 0, it should be strictly positive";
+            msg_error() << "maxInputForceFeedback value ("<< d_maxInputForceFeedback.getValue() <<") is negative or 0, it should be strictly positive";
             d_maxInputForceFeedback.setValue(0.0);
         }
     }
@@ -358,7 +358,7 @@ void GeomagicDriver::bwdInit()
 
     if (HD_DEVICE_ERROR(error = hdGetError()))
     {
-        msg_info("GeomagicDriver") <<"Failed to start the scheduler";
+        msg_info() <<"Failed to start the scheduler";
         m_errorDevice = true;
         if (m_hStateHandles.size()) m_hStateHandles[0] = HD_INVALID_HANDLE;
             return;

--- a/applications/plugins/Geomagic/src/GeomagicDriver.h
+++ b/applications/plugins/Geomagic/src/GeomagicDriver.h
@@ -135,10 +135,7 @@ public:
         VN_arm1   = 4,
         VN_joint0 = 5,
         VN_base   = 6,
-        VN_X      = 7,
-        VN_Y      = 8,
-        VN_Z      = 9,
-        NVISUALNODE = 10
+        NVISUALNODE = 7
     };
     VisualComponent visualNode[NVISUALNODE];
     static const char* visualNodeNames[NVISUALNODE];

--- a/applications/plugins/Geomagic/src/GeomagicDriver.h
+++ b/applications/plugins/Geomagic/src/GeomagicDriver.h
@@ -22,7 +22,7 @@
 #ifndef SOFA_GEOMAGIC_H
 #define SOFA_GEOMAGIC_H
 
-//Sensable include
+//Geomagic include
 #include <sofa/helper/LCPcalc.h>
 #include <sofa/defaulttype/SolidTypes.h>
 #include <sofa/defaulttype/RigidTypes.h>
@@ -53,6 +53,10 @@
 #include <HD/hdExport.h>
 #include <HD/hdScheduler.h>
 
+//Visualization
+#include <SofaRigid/RigidMapping.h>
+#include <SofaBaseMechanics/MechanicalObject.h>
+
 
 namespace sofa {
 
@@ -79,6 +83,12 @@ public:
 
     typedef defaulttype::Vec4f Vec4f;
     typedef defaulttype::Vector3 Vector3;
+    struct VisualComponent
+    {
+        simulation::Node::SPtr node;
+        sofa::component::visualmodel::OglModel::SPtr visu;
+        sofa::component::mapping::RigidMapping< Rigid3dTypes , ExtVec3fTypes  >::SPtr mapping;
+    };
 
     Data< std::string > d_deviceName; ///< Name of device Configuration
     Data<Vec3d> d_positionBase; ///< Position of the interface base in the scene world coordinates
@@ -93,8 +103,9 @@ public:
     Data<Vector6> d_angle; ///< Angluar values of joint (rad)
     Data<double> d_scale; ///< Default scale applied to the Phantom Coordinates
     Data<double> d_forceScale; ///< Default forceScale applied to the force feedback. 
+    Data<bool> d_frameVisu; ///< Visualize the frame corresponding to the device tooltip
     Data<bool> d_omniVisu; ///< Visualize the frame of the interface in the virtual scene
-    Data< Coord > d_posDevice; ///< position of the base of the part of the device
+    Data< VecCoord > d_posDevice; ///< position of the base of the part of the device
     Data<bool> d_button_1; ///< Button state 1
     Data<bool> d_button_2; ///< Button state 2
     Data<Vector3> d_inputForceFeedback; ///< Input force feedback in case of no LCPForceFeedback is found (manual setting)
@@ -113,6 +124,29 @@ public:
     void onAnimateBeginEvent();
 
     ForceFeedback * m_forceFeedback;
+
+    /// variable pour affichage graphique
+    enum
+    {
+        VN_stylus = 0,
+        VN_joint2 = 1,
+        VN_joint1 = 2,
+        VN_arm2   = 3,
+        VN_arm1   = 4,
+        VN_joint0 = 5,
+        VN_base   = 6,
+        VN_X      = 7,
+        VN_Y      = 8,
+        VN_Z      = 9,
+        NVISUALNODE = 10
+    };
+    VisualComponent visualNode[NVISUALNODE];
+    static const char* visualNodeNames[NVISUALNODE];
+    static const char* visualNodeFiles[NVISUALNODE];
+    simulation::Node::SPtr nodePrincipal;
+    component::container::MechanicalObject<sofa::defaulttype::Rigid3dTypes>::SPtr rigidDOF;
+    bool m_visuActive; ///< Internal boolean to detect activation switch of the draw
+    bool m_initVisuDone; ///< Internal boolean activated only if visu initialization done without return
 
 private:
     void handleEvent(core::objectmodel::Event *) override;
@@ -136,7 +170,7 @@ public:
     OmniData m_omniData;
     OmniData m_simuData;
     HHD m_hHD;
-	std::vector< HDCallbackCode > m_hStateHandles;
+    std::vector< HDCallbackCode > m_hStateHandles;
 
 };
 

--- a/applications/plugins/Geomagic/src/GeomagicDriver.h
+++ b/applications/plugins/Geomagic/src/GeomagicDriver.h
@@ -105,11 +105,14 @@ public:
     Data<double> d_forceScale; ///< Default forceScale applied to the force feedback. 
     Data<bool> d_frameVisu; ///< Visualize the frame corresponding to the device tooltip
     Data<bool> d_omniVisu; ///< Visualize the frame of the interface in the virtual scene
-    Data< VecCoord > d_posDevice; ///< position of the base of the part of the device
+    Data< Coord > d_posDevice; ///< position of the base of the part of the device
+    
     Data<bool> d_button_1; ///< Button state 1
     Data<bool> d_button_2; ///< Button state 2
     Data<Vector3> d_inputForceFeedback; ///< Input force feedback in case of no LCPForceFeedback is found (manual setting)
     Data<double> d_maxInputForceFeedback; ///< Maximum value of the normed input force feedback for device security
+
+    VecCoord m_posDeviceVisu; ///< position of the hpatic devices for rendering. first pos is equal to d_posDevice
 
     GeomagicDriver();
 

--- a/applications/plugins/Geomagic/src/GeomagicDriver.h
+++ b/applications/plugins/Geomagic/src/GeomagicDriver.h
@@ -148,6 +148,7 @@ public:
     bool m_visuActive; ///< Internal boolean to detect activation switch of the draw
     bool m_initVisuDone; ///< Internal boolean activated only if visu initialization done without return
     bool m_errorDevice; ///< Boolean detecting any error coming from device / detection
+    bool m_simulationStarted; /// <Boolean storing hte information if Sofa has started the simulation (changed by AnimateBeginEvent)
 
 private:
     void handleEvent(core::objectmodel::Event *) override;

--- a/applications/plugins/Geomagic/src/GeomagicDriver.h
+++ b/applications/plugins/Geomagic/src/GeomagicDriver.h
@@ -121,9 +121,7 @@ public:
     virtual void draw(const sofa::core::visual::VisualParams* vparams) override;
     void updatePosition();
 
-    void onAnimateBeginEvent();
-
-    ForceFeedback * m_forceFeedback;
+    ForceFeedback::SPtr m_forceFeedback;
 
     /// variable pour affichage graphique
     enum

--- a/applications/plugins/Geomagic/src/GeomagicDriver.h
+++ b/applications/plugins/Geomagic/src/GeomagicDriver.h
@@ -97,6 +97,7 @@ public:
     Data< Coord > d_posDevice; ///< position of the base of the part of the device
     Data<bool> d_button_1; ///< Button state 1
     Data<bool> d_button_2; ///< Button state 2
+    Data<Vector3> d_inputForceFeedback; ///< Input force feedback in case of no LCPForceFeedback is found (manual setting)
 
     GeomagicDriver();
 

--- a/applications/plugins/Geomagic/src/GeomagicDriver.h
+++ b/applications/plugins/Geomagic/src/GeomagicDriver.h
@@ -137,13 +137,16 @@ public:
         VN_base   = 6,
         NVISUALNODE = 7
     };
+
     VisualComponent visualNode[NVISUALNODE];
     static const char* visualNodeNames[NVISUALNODE];
     static const char* visualNodeFiles[NVISUALNODE];
     simulation::Node::SPtr nodePrincipal;
     component::container::MechanicalObject<sofa::defaulttype::Rigid3dTypes>::SPtr rigidDOF;
+
     bool m_visuActive; ///< Internal boolean to detect activation switch of the draw
     bool m_initVisuDone; ///< Internal boolean activated only if visu initialization done without return
+    bool m_errorDevice; ///< Boolean detecting any error coming from device / detection
 
 private:
     void handleEvent(core::objectmodel::Event *) override;
@@ -151,7 +154,6 @@ private:
     void getMatrix( Mat<4,4, GLdouble> & M, int index, double teta);
 
     Mat<4,4, GLdouble> compute_dh_Matrix(double theta,double alpha, double a, double d);
-
     Mat<4,4, GLdouble> m_dh_matrices[NBJOINT];
 
     //These data are written by the omni they cnnot be accessed in the simulation loop

--- a/applications/plugins/Geomagic/src/GeomagicDriver.h
+++ b/applications/plugins/Geomagic/src/GeomagicDriver.h
@@ -98,15 +98,16 @@ public:
     Data<bool> d_button_1; ///< Button state 1
     Data<bool> d_button_2; ///< Button state 2
     Data<Vector3> d_inputForceFeedback; ///< Input force feedback in case of no LCPForceFeedback is found (manual setting)
+    Data<double> d_maxInputForceFeedback; ///< Maximum value of the normed input force feedback for device security
 
     GeomagicDriver();
 
 	virtual ~GeomagicDriver();
 
-    virtual void init();
-    virtual void bwdInit();
-    virtual void reinit();
-    virtual void draw(const sofa::core::visual::VisualParams* vparams);
+    virtual void init() override;
+    virtual void bwdInit() override;
+    virtual void reinit() override;
+    virtual void draw(const sofa::core::visual::VisualParams* vparams) override;
     void updatePosition();
 
     void onAnimateBeginEvent();
@@ -114,8 +115,8 @@ public:
     ForceFeedback * m_forceFeedback;
 
 private:
-    void handleEvent(core::objectmodel::Event *);
-    void computeBBox(const core::ExecParams*  params, bool onlyVisible=false );
+    void handleEvent(core::objectmodel::Event *) override;
+    void computeBBox(const core::ExecParams*  params, bool onlyVisible=false ) override;
     void getMatrix( Mat<4,4, GLdouble> & M, int index, double teta);
 
     Mat<4,4, GLdouble> compute_dh_Matrix(double theta,double alpha, double a, double d);


### PR DESCRIPTION
An inputForceFeedback data is added in Geomagic so that a force
can be specified as input of the driver.
This force is used only if no LCP is found.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
