### PR TITLE
[CMake] Fix SHARE_DIR and EXAMPLES_DIR

### DIFF
--- a/SofaKernel/SofaFramework/CMakeLists.txt
+++ b/SofaKernel/SofaFramework/CMakeLists.txt
@@ -202,9 +202,9 @@ set(SHARE_DIR \"${CMAKE_SOURCE_DIR}/share\")
 set(EXAMPLES_DIR \"${CMAKE_SOURCE_DIR}/examples\")
 configure_file("config.h.in" "${CMAKE_BINARY_DIR}/include/sofa/config.h")
 
-## Paths to share/ and examples/, this one contains relative paths to the installed resources directory.
-set(SHARE_DIR \"../../share/sofa\")
-set(EXAMPLES_DIR \"../../share/sofa/examples\")
+## Paths to share/ and examples/, this one contains absolute paths to the installed resources directory.
+set(SHARE_DIR \"${CMAKE_INSTALL_PREFIX}/share/sofa\")
+set(EXAMPLES_DIR \"${CMAKE_INSTALL_PREFIX}/share/sofa/examples\")
 configure_file("config.h.in" "${CMAKE_BINARY_DIR}/include/sofa/installedSofaConfig.h")
 install(FILES "${CMAKE_BINARY_DIR}/include/sofa/installedSofaConfig.h" DESTINATION "include/sofa/" RENAME "config.h")
 

--- a/SofaKernel/SofaFramework/CMakeLists.txt
+++ b/SofaKernel/SofaFramework/CMakeLists.txt
@@ -196,8 +196,17 @@ foreach(NAME ${SOFA_BUILD_OPTIONS_SRC})
     install(FILES "${CMAKE_BINARY_DIR}/include/sofa/config/${NAME}" DESTINATION "include/sofa/config")
 endforeach()
 
+# Paths to share/ and examples/. In the
+# build directory, it points to the source tree
+set(SHARE_DIR \"${CMAKE_SOURCE_DIR}/share\")
+set(EXAMPLES_DIR \"${CMAKE_SOURCE_DIR}/examples\")
 configure_file("config.h.in" "${CMAKE_BINARY_DIR}/include/sofa/config.h")
-install(FILES "${CMAKE_BINARY_DIR}/include/sofa/config.h" DESTINATION "include/sofa/")
+
+## Paths to share/ and examples/, this one contains relative paths to the installed resources directory.
+set(SHARE_DIR \"../../share/sofa\")
+set(EXAMPLES_DIR \"../../share/sofa/examples\")
+configure_file("config.h.in" "${CMAKE_BINARY_DIR}/include/sofa/installedSofaConfig.h")
+install(FILES "${CMAKE_BINARY_DIR}/include/sofa/installedSofaConfig.h" DESTINATION "include/sofa/" RENAME "config.h")
 
 # make sure everyone in the build tree can see <sofa/config.h>
 #list(APPEND SOFAFRAMEWORK_DEPENDENCY_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_BINARY_DIR})

--- a/SofaKernel/SofaFramework/config.h.in
+++ b/SofaKernel/SofaFramework/config.h.in
@@ -27,6 +27,10 @@
 #include <sofa/config/build_option_opengl.h>
 #include <sofa/config/build_option_threading.h>
 
+// Defines paths to examples and shared resources
+#define SOFA_SHARE_DIR @SHARE_DIR@
+#define SOFA_EXAMPLES_DIR @EXAMPLES_DIR@
+
 // fixes CGAL plugin build errors (default value: 5)
 #define BOOST_PARAMETER_MAX_ARITY 12
 

--- a/applications/sofa/gui/GUIManager.cpp
+++ b/applications/sofa/gui/GUIManager.cpp
@@ -206,26 +206,11 @@ int GUIManager::Init(const char* argv0, const char* name)
         first = false;
     }
 
-    // Read the paths to the share/ and examples/ directories from etc/sofa.ini,
-    const std::string etcDir = Utils::getSofaPathPrefix() + "/etc";
-    const std::string sofaIniFilePath = etcDir + "/sofa.ini";
-    std::map<std::string, std::string> iniFileValues = Utils::readBasicIniFile(sofaIniFilePath);
+    std::string shareDir = SOFA_SHARE_DIR;
+    sofa::helper::system::DataRepository.addFirstPath(shareDir);
 
-    // and add them to DataRepository
-    if (iniFileValues.find("SHARE_DIR") != iniFileValues.end())
-    {
-        std::string shareDir = iniFileValues["SHARE_DIR"];
-        if (!FileSystem::isAbsolute(shareDir))
-            shareDir = etcDir + "/" + shareDir;
-        sofa::helper::system::DataRepository.addFirstPath(shareDir);
-    }
-    if (iniFileValues.find("EXAMPLES_DIR") != iniFileValues.end())
-    {
-        std::string examplesDir = iniFileValues["EXAMPLES_DIR"];
-        if (!FileSystem::isAbsolute(examplesDir))
-            examplesDir = etcDir + "/" + examplesDir;
-        sofa::helper::system::DataRepository.addFirstPath(examplesDir);
-    }
+    std::string examplesDir = SOFA_EXAMPLES_DIR;
+    sofa::helper::system::DataRepository.addFirstPath(examplesDir);
 
     if (currentGUI)
         return 0; // already initialized


### PR DESCRIPTION
This PR makes it easier & more reliable for plugins / external projects to find paths to the "examples/" and the "share/" folders in both the build directory and install directory.

The current system was filling a file (sofa.ini) for this single purpose, that GUIManager was then parsing to retrieve those paths. if another project (tests for instance) would want to retrieve those paths, they would have to first locate this sofa.ini file (which can be very tricky if not part of the SOFA project tree), parse it and add it to the DataRepository.

Now, preprocessor defines holds the paths and you just have to add it to the DataRepository as such:
sofa::helper::system::DataRepository.addFirstPath(SOFA_SHARE_DIR)
sofa::helper::system::DataRepository.addFirstPath(SOFA_EXAMPLES_DIR)

In both cases, the paths are *absolute* which is great (and what I needed) when building an external project, but generating distributable binaries with absolute paths will not work out well...
I realise this PR is not mergeable until this issue is resolved, but don't know how to change that.
With relative paths, finding the install directory from external projects is impossible, and with absolute paths, redistribution of binaries is not feasible. 

Looking fwd to your inputs!