### PR TITLE
[SofaSparseSolver] FIX SparseLDL crash and add proper SOFA_FLOAT/DOUBLE mangement

### DIFF
--- a/modules/SofaSparseSolver/SparseLDLSolver.cpp
+++ b/modules/SofaSparseSolver/SparseLDLSolver.cpp
@@ -35,18 +35,26 @@ namespace linearsolver
 
 SOFA_DECL_CLASS(SparseLDLSolver)
 
-int SparseLDLSolverClass = core::RegisterObject("Direct linear solver based on Sparse LDL^T factorization, implemented with the CSPARSE library")
+int SparseLDLSolverClass = core::RegisterObject("Direct Linear Solver using a Sparse LDL^T factorization.")
+#ifdef SOFA_WITH_DOUBLE
         .add< SparseLDLSolver< CompressedRowSparseMatrix<double>,FullVector<double> > >(true)
-        .add< SparseLDLSolver< CompressedRowSparseMatrix<defaulttype::Mat<3,3,double> >,FullVector<double> > >(true)
+        .add< SparseLDLSolver< CompressedRowSparseMatrix<defaulttype::Mat<3,3,double> >,FullVector<double> > >()
+#endif
+#ifdef SOFA_WITH_FLOAT
         .add< SparseLDLSolver< CompressedRowSparseMatrix<float>,FullVector<float> > >(true)
-        .add< SparseLDLSolver< CompressedRowSparseMatrix<defaulttype::Mat<3,3,float> >,FullVector<float> > >(true)
-        ;
+        .add< SparseLDLSolver< CompressedRowSparseMatrix<defaulttype::Mat<3,3,float> >,FullVector<float> > >()
+#endif
+;
 
+#ifdef SOFA_WITH_DOUBLE
 template class SOFA_SPARSE_SOLVER_API SparseLDLSolver< CompressedRowSparseMatrix<double>,FullVector<double> >;
 template class SOFA_SPARSE_SOLVER_API SparseLDLSolver< CompressedRowSparseMatrix< defaulttype::Mat<3,3,double> >,FullVector<double> >;
+#endif
+
+#ifdef SOFA_WITH_FLOAT
 template class SOFA_SPARSE_SOLVER_API SparseLDLSolver< CompressedRowSparseMatrix<float>,FullVector<float> >;
 template class SOFA_SPARSE_SOLVER_API SparseLDLSolver< CompressedRowSparseMatrix< defaulttype::Mat<3,3,float> >,FullVector<float> >;
-
+#endif
 } // namespace linearsolver
 
 } // namespace component

--- a/modules/SofaSparseSolver/SparseLDLSolver.h
+++ b/modules/SofaSparseSolver/SparseLDLSolver.h
@@ -73,14 +73,17 @@ protected :
 
     FullMatrix<Real> Jminv,Jdense;
     sofa::component::linearsolver::CompressedRowSparseMatrix<Real> Mfiltered;
-//    helper::vector<Real> line,res;
 };
 
 #if defined(SOFA_EXTERN_TEMPLATE) && !defined(SOFA_COMPONENT_LINEARSOLVER_SPARSELDLSOLVER_CPP)
+#ifdef SOFA_WITH_DOUBLE
 extern template class SOFA_SPARSE_SOLVER_API SparseLDLSolver< CompressedRowSparseMatrix< double>,FullVector<double> >;
 extern template class SOFA_SPARSE_SOLVER_API SparseLDLSolver< CompressedRowSparseMatrix< defaulttype::Mat<3,3,double> >,FullVector<double> >;
+#endif
+#ifdef SOFA_WITH_FLOAT
 extern template class SOFA_SPARSE_SOLVER_API SparseLDLSolver< CompressedRowSparseMatrix< float>,FullVector<float> >;
 extern template class SOFA_SPARSE_SOLVER_API SparseLDLSolver< CompressedRowSparseMatrix< defaulttype::Mat<3,3,float> >,FullVector<float> >;
+#endif
 #endif
 
 

--- a/modules/SofaSparseSolver/SparseLDLSolver.inl
+++ b/modules/SofaSparseSolver/SparseLDLSolver.inl
@@ -72,6 +72,12 @@ void SparseLDLSolver<TMatrix,TVector,TThreadManager>::invert(Matrix& M) {
     int * M_rowind = (int *) &Mfiltered.getColsIndex()[0];
     Real * M_values = (Real *) &Mfiltered.getColsValue()[0];
 
+    if(M_colptr==nullptr || M_rowind==nullptr || M_values==nullptr || Mfiltered.getRowBegin().size() < n )
+    {
+        msg_warning() << "Invalid Linear System to solve. Please insure that there is enough constraints (not rank deficient)." ;
+        return ;
+    }
+
     Inherit::factorize(n,M_colptr,M_rowind,M_values,(InvertData *) this->getMatrixInvertData(&M));
 
     numStep++;
@@ -134,55 +140,6 @@ bool SparseLDLSolver<TMatrix,TVector,TThreadManager>::addJMInvJtLocal(TMatrix * 
             if(i!=j) result->add(i,j,acc*fact);
         }
     }
-
-
-//    //Solve the lower triangular system
-//    res.resize(data->n);
-//    for (typename SparseMatrix<Real>::LineConstIterator jit = J->begin() , jitend = J->end(); jit != jitend; ++jit) {
-//        int row = jit->first;
-
-//        line.clear();
-//        line.resize(data->n);
-
-//        for (typename SparseMatrix<Real>::LElementConstIterator it = jit->second.begin(), i2end = jit->second.end(); it != i2end; ++it) {
-//            int col = data->invperm[it->first];
-//            double val = it->second;
-//            line[col] = val;
-//        }
-
-//        for (int j=0; j<data->n; j++) {
-//            for (int p = data->LT_colptr[j] ; p<data->LT_colptr[j+1] ; p++) {
-//                int col = data->LT_rowind[p];
-//                double val = data->LT_values[p];
-//                line[j] -= val * line[col];
-//            }
-//        }
-
-//        for (int j = data->n-1 ; j >= 0 ; j--) {
-//            line[j] *= data->invD[j];
-
-//            for (int p = data->L_colptr[j] ; p < data->L_colptr[j+1] ; p++) {
-//                int col = data->L_rowind[p];
-//                double val = data->L_values[p];
-//                line[j] -= val * line[col];
-//            }
-
-//            res[data->perm[j]] = line[j];
-//        }
-
-//        for (typename SparseMatrix<Real>::LineConstIterator jit = J->begin() , jitend = J->end(); jit != jitend; ++jit) {
-//            int row2 = jit->first;
-//            double acc = 0.0;
-//            for (typename SparseMatrix<Real>::LElementConstIterator i2 = jit->second.begin(), i2end = jit->second.end(); i2 != i2end; ++i2) {
-//                int col2 = i2->first;
-//                double val2 = i2->second;
-//                acc += val2 * res[col2];
-//            }
-//            acc *= fact;
-//            result->add(row2,row,acc);
-//        }
-//    }
-
 
     return true;
 }


### PR DESCRIPTION
The solver crash if the system is rank deficient because it read memory at indices like xxx[0]. 

This PR:
- adds a conditional test prevent that. 
- adds SOFA_WITH_FLOAT, SOFA_WITH_DOUBLE to make it consistant with the rest of sofa.
- removes commented code. 


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
