### PR TITLE
[runSofa] Save&restore the scenegraph state when live-code & add info panel

### DIFF
--- a/applications/sofa/gui/qt/ModifyObject.cpp
+++ b/applications/sofa/gui/qt/ModifyObject.cpp
@@ -196,6 +196,11 @@ void ModifyObject::createDialog(core::objectmodel::Base* base)
 
             if (currentGroup.empty()) currentGroup="Property";
 
+            // Ignore the data in group "Infos" so they can be putted in the real Infos panel that is
+            // handled in a different way (see QDataDescriptionWidget)
+            if (currentGroup == "Infos")
+                continue;
+
 #ifdef DEBUG_GUI
             std::cout << "GUI: add Data " << data->getName() << " in " << currentGroup << std::endl;
 #endif

--- a/applications/sofa/gui/qt/QDataDescriptionWidget.cpp
+++ b/applications/sofa/gui/qt/QDataDescriptionWidget.cpp
@@ -41,11 +41,16 @@ void QDataDescriptionWidget::addRow(QGridLayout* grid, const std::string& title,
                                     const std::string& value, unsigned int row,
                                     unsigned int /*minimumWidth*/)
 {
-    QLabel* tmplabel;
-    grid->addWidget(new QLabel(QString(title.c_str())), row, 0);
-    tmplabel = (new QLabel(QString(value.c_str())));
+    QLabel* titlew = new QLabel(QString(title.c_str()));
+    grid->addWidget(titlew, row, 0, Qt::AlignTop);
+
+    QLabel* tmplabel = (new QLabel(QString(value.c_str())));
     tmplabel->setMinimumWidth(20);
-    grid->addWidget(tmplabel, row, 1);
+    tmplabel->setWordWrap(true);
+    tmplabel->setAlignment(Qt::AlignTop);
+    tmplabel->setSizePolicy(QSizePolicy::MinimumExpanding,
+                            QSizePolicy::MinimumExpanding);
+    grid->addWidget(tmplabel, row, 1, Qt::AlignTop);
 }
 
 QDataDescriptionWidget::QDataDescriptionWidget(QWidget* parent, core::objectmodel::Base* object)
@@ -88,7 +93,7 @@ QDataDescriptionWidget::QDataDescriptionWidget(QWidget* parent, core::objectmode
         {
             addRow(boxLayout, "Path", node->getPathName(), nextRow, 20);
             nextRow++;
-         }
+        }
 
         tabLayout->addWidget( box );
     }
@@ -129,6 +134,34 @@ QDataDescriptionWidget::QDataDescriptionWidget(QWidget* parent, core::objectmode
         }
         tabLayout->addWidget( box );
     }
+
+
+
+    //Extra description
+    std::vector<sofa::core::objectmodel::BaseData*> selecteddatum ;
+    for(sofa::core::objectmodel::BaseData* datafield : object->getDataFields())
+    {
+        if( !strcmp(datafield->getGroup(), "Infos" ) )
+            selecteddatum.push_back(datafield) ;
+    }
+
+    if(!selecteddatum.empty())
+    {
+        QGroupBox *box = new QGroupBox(this);
+        tabLayout->addWidget(box);
+        QGridLayout* boxLayout = new QGridLayout();
+
+        box->setLayout(boxLayout);
+
+        box->setTitle(QString("Extra informations"));
+
+        unsigned int row = 0;
+        for(auto& data : selecteddatum)
+        {
+            addRow(boxLayout, data->getName(), data->getValueString(), row++);
+        }
+    }
+
 
     tabLayout->addStretch();
 }

--- a/applications/sofa/gui/qt/QSofaListView.cpp
+++ b/applications/sofa/gui/qt/QSofaListView.cpp
@@ -153,6 +153,49 @@ void QSofaListView::modifyUnlock(void* Id)
     map_modifyObjectWindow.erase( Id );
 }
 
+/// Traverse the item tree and retrive the item that are expanded. The path of the node
+/// that are expanded are stored in the the pathes std::vector::std::string>.
+void QSofaListView::getExpandedNodes(QTreeWidgetItem* item, std::vector<std::string>& pathes)
+{
+    if(!item)
+        return;
+
+    /// We have reached a leaf of the hierarchy or it is closed...so we save the path
+    if( !item->isExpanded() && graphListener_->findObject(item)->toBaseNode() != nullptr )
+        return;
+
+    BaseNode* parentNode = graphListener_->findObject(item)->toBaseNode() ;
+    if(parentNode == nullptr)
+        return;
+
+    std::string path = parentNode->getPathName();
+    pathes.push_back(path);
+
+    for(int i=0 ; i<item->childCount() ; i++)
+    {
+        QTreeWidgetItem* child = item->child(i);
+        BaseNode* childNode = graphListener_->findObject(child)->toBaseNode() ;
+
+        if(childNode==nullptr)
+            continue;
+
+        if( childNode->getParents()[0] == parentNode )
+            getExpandedNodes(child, pathes) ;
+    }
+
+    return ;
+}
+
+void QSofaListView::getExpandedNodes(std::vector<std::string>& pathes)
+{
+    emit Lock(true);
+
+    QTreeWidgetItem* rootitem = this->topLevelItem(0) ;
+    getExpandedNodes(rootitem,pathes) ;
+
+    emit Lock(false);
+}
+
 void QSofaListView::collapseNode()
 {
     collapseNode(currentItem());
@@ -170,6 +213,47 @@ void QSofaListView::collapseNode(QTreeWidgetItem* item)
     item->setExpanded ( true );
     emit Lock(false);
 }
+
+void QSofaListView::expandPath(const std::string& path)
+{
+    if(path.empty())
+        return;
+
+    if(path.data()[0] != '/')
+        return;
+
+    Node* match = down_cast<Node>( graphListener_->findObject(this->topLevelItem(0))->toBaseNode() );
+
+    QStringList tokens = QString::fromStdString(path).split('/') ;
+
+    for(int i=1;i<tokens.size();i++)
+    {
+        match = match->getChild(tokens[i].toStdString());
+
+        if(match == nullptr)
+            return;
+
+        if(graphListener_->items.find(match) != graphListener_->items.end())
+        {
+            QTreeWidgetItem* item = graphListener_->items[match] ;
+            item->setExpanded ( true );
+        }
+    }
+}
+
+void QSofaListView::expandPathFrom(const std::vector<std::string>& pathes)
+{
+    emit Lock(true);
+
+    for(auto& path : pathes)
+    {
+        std::cout << "PATH: " << path << std::endl ;
+        expandPath(path) ;
+    }
+
+    emit Lock(false);
+}
+
 
 void QSofaListView::expandNode()
 {

--- a/applications/sofa/gui/qt/QSofaListView.cpp
+++ b/applications/sofa/gui/qt/QSofaListView.cpp
@@ -247,7 +247,6 @@ void QSofaListView::expandPathFrom(const std::vector<std::string>& pathes)
 
     for(auto& path : pathes)
     {
-        std::cout << "PATH: " << path << std::endl ;
         expandPath(path) ;
     }
 

--- a/applications/sofa/gui/qt/QSofaListView.h
+++ b/applications/sofa/gui/qt/QSofaListView.h
@@ -96,10 +96,14 @@ public:
     SofaListViewAttribute getAttribute() const { return attribute_; }
 
     void contextMenuEvent(QContextMenuEvent *event);
+
+    void expandPathFrom(const std::vector<std::string>& pathes);
+    void getExpandedNodes(std::vector<std::string>&);
 public Q_SLOTS:
     void Export();
     void CloseAllDialogs();
     void UpdateOpenedDialogs();
+
 Q_SIGNALS:
     void Close();
     void Lock(bool);
@@ -143,7 +147,10 @@ protected Q_SLOTS:
     void nodeNameModification( simulation::Node*);
     void focusObject();
     void focusNode();
+
 protected:
+    void expandPath(const std::string& path) ;
+    void getExpandedNodes(QTreeWidgetItem* item, std::vector<std::string>&) ;
     void collapseNode(QTreeWidgetItem* item);
     void expandNode(QTreeWidgetItem* item);
     void transformObject ( sofa::simulation::Node *node, double dx, double dy, double dz,  double rx, double ry, double rz, double scale );

--- a/applications/sofa/gui/qt/RealGUI.cpp
+++ b/applications/sofa/gui/qt/RealGUI.cpp
@@ -738,6 +738,16 @@ sofa::simulation::Node* RealGUI::currentSimulation()
 
 void RealGUI::fileOpen ( std::string filename, bool temporaryFile, bool reload )
 {
+    std::vector<std::string> expandedNodes;
+
+    if(reload)
+    {
+        saveView();
+
+        if(simulationGraph)
+            simulationGraph->getExpandedNodes(expandedNodes) ;
+    }
+
     const std::string &extension=SetDirectory::GetExtension(filename.c_str());
     if (extension == "simu")
     {
@@ -776,6 +786,11 @@ void RealGUI::fileOpen ( std::string filename, bool temporaryFile, bool reload )
     this->setWindowFilePath(filename.c_str());
     setExportGnuplot(exportGnuplotFilesCheckbox->isChecked());
     stopDumpVisitor();
+
+    if(!expandedNodes.empty())
+    {
+        simulationGraph->expandPathFrom(expandedNodes);
+    }
 
     /// We want to warn user that there is component that are implemented in specific plugin
     /// and that there is no RequiredPlugin in their scene.
@@ -944,6 +959,8 @@ void RealGUI::setSceneWithoutMonitor (Node::SPtr root, const char* filename, boo
         startButton->setChecked(root->getContext()->getAnimate() );
         dtEdit->setText ( QString::number ( root->getDt() ) );
         simulationGraph->Clear(root.get());
+        simulationGraph->collapseAll();
+        simulationGraph->expandToDepth(0);
         statWidget->CreateStats(root.get());
 
 #ifndef SOFA_GUI_QT_NO_RECORDER


### PR DESCRIPTION
This PR contains small changes to runSofa. 

One is to save & restore the scenegraph state in the live-coding mode. This fix avoid to constantly have to expand/collapse things to restore the view in a manageable state when we reload. 

The second change is to fix a problem. When Data fields that belong in the "Infos" results in having to "Infos" panel in the object inspector. So this PR add the Data fields which are in the Info groups to the existing "Infos" panel instead of creating a second one with the same name. 



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
