### PR TITLE
[CMake] ADD the CMAKE_WARN_DEPRECATED option in SOFA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,7 +337,10 @@ if(NOT "${SOFA_EXTERNAL_DIRECTORIES}" STREQUAL "")
 endif()
 
 ### Deprecated components
-option(SOFA_WITH_DEPRECATED_COMPONENTS "Compile sofa with all deprecated components" ON)
+option(SOFA_WITH_DEPRECATED_COMPONENTS "Compile SOFA with all deprecated components" ON)
+if(SOFA_WITH_DEPRECATED_COMPONENTS)
+    message(DEPRECATION "Deprecated components are activated (SOFA_WITH_DEPRECATED_COMPONENTS variable is ON)")
+endif()
 
 ## Custom
 if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/custom.cmake")

--- a/SofaGeneral/CMakeLists.txt
+++ b/SofaGeneral/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.1)
 project(SofaGeneral)
 
+# Send warnings when deprecated CMake project is activated
+option(CMAKE_WARN_DEPRECATED "Send warning when deprecated projects are found" ON)
+
 ## Dependencies
 find_package(SofaCommon REQUIRED)
 find_package(Newmat)

--- a/applications/projects/Modeler/CMakeLists.txt
+++ b/applications/projects/Modeler/CMakeLists.txt
@@ -1,2 +1,4 @@
+message(DEPRECATION "Modeler project is deprecated")
+
 add_subdirectory("exec")
 add_subdirectory("lib")


### PR DESCRIPTION
CMAKE_WARN_DEPRECATED sends warning when deprecated project is found.
This warning appears now for the Modeler and when the option
SOFA_WITH_DEPRECATED_COMPONENTS is activated.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
