### PR TITLE
[CGALPlugin] FIX compilation issue with recent version of CGAL (4.11) & Ubunu 18.04 LTS

### DIFF
--- a/applications/plugins/CGALPlugin/MeshGenerationFromPolyhedron.cpp
+++ b/applications/plugins/CGALPlugin/MeshGenerationFromPolyhedron.cpp
@@ -27,7 +27,6 @@
  */
 #define CGALPLUGIN_MESHGENERATIONFROMPOLYHEDRON_CPP
 
-#define CGAL_MESH_3_VERBOSE
 
 #include <CGALPlugin/config.h>
 #include "MeshGenerationFromPolyhedron.inl"

--- a/applications/plugins/CGALPlugin/MeshGenerationFromPolyhedron.h
+++ b/applications/plugins/CGALPlugin/MeshGenerationFromPolyhedron.h
@@ -29,7 +29,8 @@
 #ifndef CGALPLUGIN_MESHGENERATIONFROMPOLYHEDRON_H
 #define CGALPLUGIN_MESHGENERATIONFROMPOLYHEDRON_H
 
-#define CGAL_MESH_3_VERBOSE
+#define CGAL_MESH_3_VERBOSE 0
+
 
 #include <sofa/defaulttype/Vec.h>
 #include <sofa/core/DataEngine.h>


### PR DESCRIPTION
The CGAL version provided in Unbuntu 18.04 LTS is 4.11 and it seems this version is now expecting that the CGAL_MESH_3_VERBOSE needs to have a value. 

Otherwise it fails to compile.
The fix is minor so please consider merging it ASAP. 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
