### PR TITLE
[headlessRecorder] Fix headless recorder stream definition

### DIFF
--- a/applications/sofa/gui/headlessRecorder/CMakeLists.txt
+++ b/applications/sofa/gui/headlessRecorder/CMakeLists.txt
@@ -8,7 +8,6 @@ else()
     message(FATAL_ERROR "${PROJECT_NAME} is a Linux only feature.")
 endif()
 
-
 # FFMPEG
 find_package(FFMPEG QUIET)
 if(FFMPEG_FOUND)
@@ -30,10 +29,12 @@ endif()
 
 
 set(HEADER_FILES
-    HeadlessRecorder.h)
+    HeadlessRecorder.h
+    VideoRecorderFFMpeg.h)
 
 set(SOURCE_FILES
-    HeadlessRecorder.cpp)
+    HeadlessRecorder.cpp
+    VideoRecorderFFMpeg.cpp)
 
 if(SOFAGUI_BUILD_TESTS)
     configure_file(headlessRecorder_test ${CMAKE_BINARY_DIR}/bin/headlessRecorder_test COPYONLY)

--- a/applications/sofa/gui/headlessRecorder/HeadlessRecorder.cpp
+++ b/applications/sofa/gui/headlessRecorder/HeadlessRecorder.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
 *       SOFA, Simulation Open-Framework Architecture, development version     *
-*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
 *                                                                             *
 * This program is free software; you can redistribute it and/or modify it     *
 * under the terms of the GNU General Public License as published by the Free  *

--- a/applications/sofa/gui/headlessRecorder/HeadlessRecorder.cpp
+++ b/applications/sofa/gui/headlessRecorder/HeadlessRecorder.cpp
@@ -585,14 +585,13 @@ void HeadlessRecorder::record()
             videoFilename.append(".avi");
             //videoFilename.append(".mp4");
             videorecorder = std::unique_ptr<VideoRecorderFFmpeg>(new VideoRecorderFFmpeg(fps, width, height, videoFilename.c_str(), AV_CODEC_ID_H264));
-            videorecorder->videoEncoderStart();
+            videorecorder->start();
             initVideoRecorder = false;
         }
-        videorecorder->videoGLToFrame();
         if (canRecord())
-            videorecorder->videoFrameEncoder();
+            videorecorder->encodeFrame();
         else
-            videorecorder->videoEncoderStop();
+            videorecorder->stop();
     }
 }
 

--- a/applications/sofa/gui/headlessRecorder/HeadlessRecorder.cpp
+++ b/applications/sofa/gui/headlessRecorder/HeadlessRecorder.cpp
@@ -315,7 +315,7 @@ int HeadlessRecorder::mainLoop()
     while(canRecord())
     {
         if (keepFrame())
-	{
+        {
             redraw();
             m_nFrames++;
             if(m_nFrames % fps == 0)
@@ -326,7 +326,7 @@ int HeadlessRecorder::mainLoop()
                 start = std::chrono::system_clock::now();
             }
             record();
-	}
+        }
 
         if (currentSimulation() && currentSimulation()->getContext()->getAnimate())
         {
@@ -335,7 +335,7 @@ int HeadlessRecorder::mainLoop()
         else
         {
             sleep(0.01);
-	}
+        }
     }
     msg_info("HeadlessRecorder") << "Recording time: " << recordTimeInSeconds << " seconds at: " << fps << " fps.";
     return 0;
@@ -583,14 +583,16 @@ void HeadlessRecorder::record()
         {
             std::string videoFilename = fileName;
             videoFilename.append(".avi");
-            videoEncoderStart(videoFilename.c_str(), AV_CODEC_ID_H264);
+            //videoFilename.append(".mp4");
+            videorecorder = std::unique_ptr<VideoRecorderFFmpeg>(new VideoRecorderFFmpeg(fps, width, height, videoFilename.c_str(), AV_CODEC_ID_H264));
+            videorecorder->videoEncoderStart();
             initVideoRecorder = false;
         }
-        videoGLToFrame();
+        videorecorder->videoGLToFrame();
         if (canRecord())
-            videoFrameEncoder();
+            videorecorder->videoFrameEncoder();
         else
-            videoEncoderStop();
+            videorecorder->videoEncoderStop();
     }
 }
 
@@ -631,152 +633,7 @@ void HeadlessRecorder::screenshotPNG(std::string filename)
     }
 }
 
-// -----------------------------------------------------------------
-// --- Screencast
-// -----------------------------------------------------------------
-
-void HeadlessRecorder::videoEncoderStart(const char *filename, int codec_id)
-{
-    AVCodec *codec;
-    int ret;
-    msg_info("HeadlessRecorder") << "Start recording ... " << filename;
-    avcodec_register_all();
-    codec = avcodec_find_encoder((AVCodecID)codec_id);
-    if (!codec) {
-        msg_error("HeadlessRecorder") << "Codec not found";
-        exit(1);
-    }
-    c = avcodec_alloc_context3(codec);
-    if (!c) {
-        msg_error("HeadlessRecorder") << "Could not allocate video codec context";
-        exit(1);
-    }
-
-    m_avPacket = av_packet_alloc();
-    if (!m_avPacket)
-        exit(1);
-
-    c->bit_rate = 8000000; // maybe I need to adjust it
-    c->width = width;
-    c->height = height;
-    c->time_base = (AVRational){1, fps};
-    c->framerate = (AVRational){fps, 1};
-    c->gop_size = 10;
-    c->max_b_frames = 1;
-    c->pix_fmt = AV_PIX_FMT_YUV420P;
-
-    if (codec_id == AV_CODEC_ID_H264)
-        av_opt_set(c->priv_data, "preset", "slow", 0);
-
-    if (avcodec_open2(c, codec, NULL) < 0)
-    {
-        msg_error("HeadlessRecorder") << "Could not open codec";
-        exit(1);
-    }
-    m_file = fopen(filename, "wb");
-    if (!m_file) {
-        msg_error("HeadlessRecorder") << "Could not open " << filename;
-        exit(1);
-    }
-
-    m_frame = av_frame_alloc();
-    if (!m_frame)
-    {
-        msg_error("HeadlessRecorder") << "Could not allocate video frame";
-        exit(1);
-    }
-    m_frame->format = c->pix_fmt;
-    m_frame->width  = c->width;
-    m_frame->height = c->height;
-
-    ret = av_frame_get_buffer(m_frame, 32);
-    if (ret < 0)
-    {
-        msg_error("HeadlessRecorder") << "Could not allocate the video frame data";
-        exit(1);
-    }
-}
-
-void HeadlessRecorder::encode()
-{
-    int ret;
-    m_frame->pts = m_nFrames;
-    ret = avcodec_send_frame(c, m_frame);
-    if (ret < 0) {
-        msg_error("HeadlessRecorder") << "Error sending a frame for encoding";
-        exit(1);
-    }
-
-    while (ret >= 0) {
-        ret = avcodec_receive_packet(c, m_avPacket);
-        if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF)
-            return;
-        else if (ret < 0) {
-            msg_error("HeadlessRecorder") << "Error during encoding";
-            exit(1);
-        }
-        fwrite(m_avPacket->data, 1, m_avPacket->size, m_file);
-        av_packet_unref(m_avPacket);
-    }
-}
-
-void HeadlessRecorder::videoFrameEncoder()
-{
-    int ret;
-    ret = av_frame_make_writable(m_frame);
-    if (ret < 0)
-    {
-        msg_error("HeadlessRecorder") << "Frame is not writable";
-        exit(1);
-    }
-    videoYUVToRGB();
-    encode();
-}
-
-void HeadlessRecorder::videoEncoderStop()
-{
-    uint8_t endcode[] = { 0, 0, 1, 0xb7 };
-    encode();
-
-    fwrite(endcode, 1, sizeof(endcode), m_file);
-    fclose(m_file);
-
-    avcodec_free_context(&c);
-    av_frame_free(&m_frame);
-    av_packet_free(&m_avPacket);
-}
-
-void HeadlessRecorder::videoGLToFrame()
-{
-    int i, j, k, cur_gl, cur_rgb, nvals;
-    const int format_nchannels = 4;
-    nvals = format_nchannels * width * height;
-    m_rgb = (uint8_t*)realloc(m_rgb, nvals * sizeof(uint8_t));
-    GLubyte *pixels = (GLubyte*)malloc(nvals * sizeof(GLubyte));
-    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
-
-    for (i = 0; i < height; i++) {
-        for (j = 0; j < width; j++) {
-            cur_gl  = format_nchannels * (width * (height - i - 1) + j);
-            cur_rgb = format_nchannels * (width * i + j);
-            for (k = 0; k < format_nchannels; k++)
-                (m_rgb)[cur_rgb + k] = (pixels)[cur_gl + k];
-        }
-    }
-    free(pixels);
-}
-
-void HeadlessRecorder::videoYUVToRGB() {
-    const int in_linesize[1] = { 4 * c->width };
-    sws_context = sws_getCachedContext(sws_context,
-                                       c->width, c->height, AV_PIX_FMT_RGBA,
-                                       c->width, c->height, AV_PIX_FMT_YUV420P,
-                                       0, NULL, NULL, NULL);
-
-    sws_scale(sws_context, (const uint8_t * const *)&m_rgb, in_linesize, 0, c->height, m_frame->data, m_frame->linesize);
-}
-
-} // namespace glut
+} // namespace hRecorder
 
 } // namespace gui
 

--- a/applications/sofa/gui/headlessRecorder/HeadlessRecorder.h
+++ b/applications/sofa/gui/headlessRecorder/HeadlessRecorder.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 *       SOFA, Simulation Open-Framework Architecture, development version     *
-*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
 *                                                                             *
 * This program is free software; you can redistribute it and/or modify it     *
 * under the terms of the GNU General Public License as published by the Free  *

--- a/applications/sofa/gui/headlessRecorder/HeadlessRecorder.h
+++ b/applications/sofa/gui/headlessRecorder/HeadlessRecorder.h
@@ -28,7 +28,6 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/visual/DrawToolGL.h>
 #include <SofaBaseVisual/InteractiveCamera.h>
-#include <sofa/helper/gl/RAII.h>
 #include <sofa/core/ObjectFactory.h>
 
 #include <signal.h>
@@ -37,14 +36,7 @@
 #include <chrono>
 #include <ctime>
 #include <iomanip>
-
-// LIBAV
-extern "C" {
-#include <libavcodec/avcodec.h>
-#include <libavutil/imgutils.h>
-#include <libavutil/opt.h>
-#include <libswscale/swscale.h>
-}
+#include <memory>
 
 // OPENGL
 #define GL_GLEXT_PROTOTYPES 1
@@ -54,6 +46,8 @@ extern "C" {
 // SCREENSHOT
 #include <sofa/helper/io/Image.h>
 #include <sofa/helper/system/SetDirectory.h>
+
+#include "VideoRecorderFFMpeg.h"
 
 namespace sofa
 {
@@ -105,12 +99,7 @@ private:
     bool canRecord();
     bool keepFrame();
     void screenshotPNG(std::string fileName);
-    void videoYUVToRGB();
-    void videoEncoderStart(const char *filename, int codec_id);
-    void encode();
-    void videoEncoderStop(void);
-    void videoFrameEncoder();
-    void videoGLToFrame();
+
     void displayOBJs();
     void drawScene();
     void calcProjection();
@@ -122,14 +111,8 @@ private:
     std::string sceneFileName;
     sofa::component::visualmodel::BaseCamera::SPtr currentCamera;
 
+    std::unique_ptr<VideoRecorderFFmpeg> videorecorder;
     int m_nFrames;
-    FILE* m_file;
-
-    AVCodecContext *c = NULL;
-    AVFrame *m_frame;
-    AVPacket* m_avPacket;
-    struct SwsContext *sws_context = NULL;
-    uint8_t *m_rgb = NULL;
 
     GLuint fbo;
     GLuint rbo_color, rbo_depth;
@@ -147,7 +130,7 @@ private:
     static float skipTime;
 };
 
-} // namespace glut
+} // namespace hRecorder
 
 } // namespace gui
 

--- a/applications/sofa/gui/headlessRecorder/VideoRecorderFFMpeg.cpp
+++ b/applications/sofa/gui/headlessRecorder/VideoRecorderFFMpeg.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
 *       SOFA, Simulation Open-Framework Architecture, development version     *
-*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
 *                                                                             *
 * This program is free software; you can redistribute it and/or modify it     *
 * under the terms of the GNU General Public License as published by the Free  *

--- a/applications/sofa/gui/headlessRecorder/VideoRecorderFFMpeg.cpp
+++ b/applications/sofa/gui/headlessRecorder/VideoRecorderFFMpeg.cpp
@@ -1,0 +1,253 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU General Public License as published by the Free  *
+* Software Foundation; either version 2 of the License, or (at your option)   *
+* any later version.                                                          *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for    *
+* more details.                                                               *
+*                                                                             *
+* You should have received a copy of the GNU General Public License along     *
+* with this program. If not, see <http://www.gnu.org/licenses/>.              *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include "VideoRecorderFFMpeg.h"
+#include <sofa/helper/logging/Messaging.h>
+
+namespace sofa
+{
+
+namespace gui
+{
+
+namespace hRecorder
+{
+
+VideoRecorderFFmpeg::VideoRecorderFFmpeg(const int fps, const int width, const int height, const char* filename, const int codec_id)
+    : fps(fps)
+    , width(width)
+    , height(height)
+    , filename(filename)
+    , codec_id(codec_id)
+    , m_nFrames(0)
+{
+}
+
+VideoRecorderFFmpeg::~VideoRecorderFFmpeg()
+{
+}
+
+void VideoRecorderFFmpeg::videoEncoderStart(void)
+{
+    AVCodec *codec;
+    int ret;
+    msg_info("VideoRecorder") << "Start recording ... " << filename;
+    av_register_all();
+
+    avformat_alloc_output_context2(&oc, NULL, "mp4", filename.c_str());
+    if (!oc) {
+       msg_info("VideoRecorder") << "Could not deduce output format from file extension: using MPEG.";
+       avformat_alloc_output_context2(&oc, NULL, "mpeg", filename.c_str());
+    }
+    if (!oc) {
+        msg_error("VideoRecorder") << "Could not allocate format context.";
+        exit(1);
+    }
+
+    if (oc->oformat->video_codec == AV_CODEC_ID_NONE) {
+        msg_error("VideoRecorder") << "Could not allocate format context.";
+        exit(1);
+    }
+
+    codec = avcodec_find_encoder(oc->oformat->video_codec);
+    if (!codec) {
+        msg_error("VideoRecorder") << "Codec not found";
+        exit(1);
+    }
+
+    //st = avformat_new_stream(oc, NULL);
+    st = avformat_new_stream(oc, codec);
+    if (!st) {
+        fprintf(stderr, "Could not allocate stream\n");
+        exit(1);
+    }
+    st->id = oc->nb_streams-1;
+    //enc = avcodec_alloc_context3(codec);
+    enc = st->codec;
+    if (!enc) {
+        msg_error("VideoRecorder") << "Could not allocate video codec context";
+        exit(1);
+    }
+
+    enc->codec_id = oc->oformat->video_codec;
+    enc->bit_rate = 8000000; // maybe I need to adjust it
+    enc->width = width;
+    enc->height = height;
+    st->time_base = (AVRational){1, fps};
+    enc->time_base = st->time_base;
+    //enc->framerate = (AVRational){fps, 1};
+    enc->gop_size = 10;
+    enc->max_b_frames = 1;
+    enc->pix_fmt = AV_PIX_FMT_YUV420P;
+
+    if (codec_id == AV_CODEC_ID_H264)
+        av_opt_set(enc->priv_data, "preset", "slow", 0);
+
+    /* open the codec */
+    ret = avcodec_open2(enc, codec, NULL);
+    if (ret < 0) {
+        msg_error("VideoRecorder") << "Could not open codec";
+        exit(1);
+    }
+
+    /* copy the stream parameters to the muxer */
+    /*ret = avcodec_parameters_from_context(st->codecpar, enc);
+    if (ret < 0) {
+        fprintf(stderr, "Could not copy the stream parameters\n");
+        exit(1);
+    }*/
+
+    /* open the output file, if needed */
+    if (!(oc->oformat->flags & AVFMT_NOFILE)) {
+        ret = avio_open(&oc->pb, filename.c_str(), AVIO_FLAG_WRITE);
+        if (ret < 0) {
+            msg_error("VideoRecorder") << "Could not open " << filename;
+            exit(1);
+        }
+    }
+    /* Write the stream header, if any. */
+    ret = avformat_write_header(oc, NULL);
+    if (ret < 0) {
+        //fprintf(stderr, "Error occurred when opening output file: %s\n", av_err2str(ret));
+        exit(1);
+    }
+
+    m_frame = av_frame_alloc();
+    if (!m_frame)
+    {
+        msg_error("VideoRecorder") << "Could not allocate video frame";
+        exit(1);
+    }
+    m_frame->format = enc->pix_fmt;
+    m_frame->width  = enc->width;
+    m_frame->height = enc->height;
+
+    ret = av_frame_get_buffer(m_frame, 32);
+    if (ret < 0)
+    {
+        msg_error("VideoRecorder") << "Could not allocate the video frame data";
+        exit(1);
+    }
+}
+
+void VideoRecorderFFmpeg::encode(void)
+{
+    int ret;
+    //AVPacket pkt = { 0 };
+    AVPacket pkt;
+    av_init_packet(&pkt);
+    if(m_frame)
+    {
+        m_frame->pts = av_rescale_q(m_nFrames, (AVRational){1, fps}, st->time_base);
+        m_nFrames++;
+    }
+
+    ret = avcodec_send_frame(enc, m_frame);
+    if (ret < 0) {
+        msg_error("VideoRecorder") << "Error sending a frame for encoding";
+        exit(1);
+    }
+
+    while (ret >= 0) {
+        ret = avcodec_receive_packet(enc, &pkt);
+        if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF)
+            return;
+        else if (ret < 0) {
+            msg_error("VideoRecorder") << "Error during encoding";
+            exit(1);
+        }
+        //av_packet_rescale_ts(pkt, *time_base, st->time_base);
+        pkt.stream_index = st->index;
+        av_interleaved_write_frame(oc, &pkt);
+        av_packet_unref(&pkt);
+    }
+}
+
+void VideoRecorderFFmpeg::videoFrameEncoder(void)
+{
+    int ret = av_frame_make_writable(m_frame);
+    if (ret < 0)
+    {
+        msg_error("VideoRecorder") << "Frame is not writable";
+        exit(1);
+    }
+    videoRGBToYUV();
+    encode();
+}
+
+void VideoRecorderFFmpeg::videoEncoderStop(void)
+{
+    // Free the frame and write remaining frames from the encoder
+    av_frame_free(&m_frame);
+    m_frame = nullptr;
+    encode();
+
+    // Write the file trailer, if any
+    av_write_trailer(oc);
+
+    // Close the codec
+    avcodec_close(st->codec);
+
+    //sws_freeContext(sws_context);
+    if (!(oc->oformat->flags & AVFMT_NOFILE))
+    {
+        avio_closep(&oc->pb);
+    }
+
+    avformat_free_context(oc);
+}
+
+void VideoRecorderFFmpeg::videoGLToFrame(void)
+{
+    int cur_gl, cur_rgb, nvals;
+    const int format_nchannels = 4;
+    nvals = format_nchannels * width * height;
+    m_rgb = (uint8_t*)realloc(m_rgb, nvals * sizeof(uint8_t));
+    GLubyte *pixels = (GLubyte*)malloc(nvals * sizeof(GLubyte));
+    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+
+    for (int i = 0; i < height; i++) {
+        for (int j = 0; j < width; j++) {
+            cur_gl  = format_nchannels * (width * (height - i - 1) + j);
+            cur_rgb = format_nchannels * (width * i + j);
+            for (int k = 0; k < format_nchannels; k++)
+                (m_rgb)[cur_rgb + k] = (pixels)[cur_gl + k];
+        }
+    }
+    free(pixels);
+}
+
+void VideoRecorderFFmpeg::videoRGBToYUV(void)
+{
+    const int in_linesize[1] = { 4 * enc->width };
+    sws_context = sws_getCachedContext(sws_context,
+                                       enc->width, enc->height, AV_PIX_FMT_RGBA,
+                                       enc->width, enc->height, AV_PIX_FMT_YUV420P,
+                                       0, NULL, NULL, NULL);
+
+    sws_scale(sws_context, (const uint8_t * const *)&m_rgb, in_linesize, 0, enc->height, m_frame->data, m_frame->linesize);
+}
+
+} // namespace hRecorder
+
+} // namespace gui
+
+} // namespace sofa

--- a/applications/sofa/gui/headlessRecorder/VideoRecorderFFMpeg.h
+++ b/applications/sofa/gui/headlessRecorder/VideoRecorderFFMpeg.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 *       SOFA, Simulation Open-Framework Architecture, development version     *
-*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
 *                                                                             *
 * This program is free software; you can redistribute it and/or modify it     *
 * under the terms of the GNU General Public License as published by the Free  *

--- a/applications/sofa/gui/headlessRecorder/VideoRecorderFFMpeg.h
+++ b/applications/sofa/gui/headlessRecorder/VideoRecorderFFMpeg.h
@@ -1,0 +1,90 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU General Public License as published by the Free  *
+* Software Foundation; either version 2 of the License, or (at your option)   *
+* any later version.                                                          *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for    *
+* more details.                                                               *
+*                                                                             *
+* You should have received a copy of the GNU General Public License along     *
+* with this program. If not, see <http://www.gnu.org/licenses/>.              *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#ifndef VIDEORECORDERFFMPEG_H
+#define VIDEORECORDERFFMPEG_H
+
+#include <string>
+
+// LIBAV
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavutil/imgutils.h>
+#include <libavutil/opt.h>
+#include <libswscale/swscale.h>
+
+#include <libavutil/channel_layout.h>
+#include <libavutil/mathematics.h>
+#include <libavformat/avformat.h>
+}
+
+// OPENGL
+#define GL_GLEXT_PROTOTYPES 1
+#include <GL/gl.h>
+#include <GL/glx.h>
+
+namespace sofa
+{
+
+namespace gui
+{
+
+namespace hRecorder
+{
+
+class VideoRecorderFFmpeg
+{
+public:
+    VideoRecorderFFmpeg(const int fps, const int width, const int height, const char *filename, const int codec_id);
+    ~VideoRecorderFFmpeg();
+
+    void videoEncoderStart(void);
+    void encode(void);
+    void videoEncoderStop(void);
+    void videoFrameEncoder(void);
+    void videoRGBToYUV(void);
+    void videoGLToFrame(void);
+
+private:
+    int fps;
+    int width;
+    int height;
+    std::string filename;
+    int codec_id;
+
+    int m_nFrames;
+    AVStream *st;
+    AVFormatContext *oc;
+    AVCodecContext *enc = NULL;
+    AVFrame *m_frame;
+    struct SwsContext *sws_context = NULL;
+    uint8_t *m_rgb = NULL;
+
+
+};
+
+} // namespace hRecorder
+
+} // namespace gui
+
+} // namespace sofa
+
+#endif // VIDEORECORDERFFMPEG_H

--- a/applications/sofa/gui/headlessRecorder/VideoRecorderFFMpeg.h
+++ b/applications/sofa/gui/headlessRecorder/VideoRecorderFFMpeg.h
@@ -56,14 +56,15 @@ public:
     VideoRecorderFFmpeg(const int fps, const int width, const int height, const char *filename, const int codec_id);
     ~VideoRecorderFFmpeg();
 
-    void videoEncoderStart(void);
-    void encode(void);
-    void videoEncoderStop(void);
-    void videoFrameEncoder(void);
-    void videoRGBToYUV(void);
-    void videoGLToFrame(void);
+    void start(void);
+    void stop(void);
+    void encodeFrame(void);
 
 private:
+    void videoRGBToYUV(void);
+    void videoGLToFrame(void);
+    void encode(AVFrame* frame);
+
     int fps;
     int width;
     int height;


### PR DESCRIPTION
Current Headless Recorder does not generate files correctly; for that reason, media player can have trouble detecting the format of the file.
Vlc 3.0.2 cannot read the file, except if you specify manually that the file use h264 in advanced options.

This PR solves this shortcomming, and also aims to separate this procedure from the rest of the headless recorder to improve readability.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
