### PR TITLE
[SofaBaseLinearSolver] Add ability to activate printing of debug information at runtime

### DIFF
--- a/SofaKernel/modules/SofaBaseLinearSolver/DefaultMultiMatrixAccessor.cpp
+++ b/SofaKernel/modules/SofaBaseLinearSolver/DefaultMultiMatrixAccessor.cpp
@@ -38,7 +38,6 @@ namespace component
 namespace linearsolver
 {
 
-#define MULTIMATRIX_VERBOSE 0
 
 DefaultMultiMatrixAccessor::DefaultMultiMatrixAccessor()
     : globalMatrix(NULL)
@@ -83,7 +82,7 @@ void DefaultMultiMatrixAccessor::addMechanicalState(const sofa::core::behavior::
     realStateOffsets[mstate] = globalDim;
     globalDim += dim;
 
-    if( MULTIMATRIX_VERBOSE)/////////////////////////////////////////////////////////
+    if(m_doPrintInfo)/////////////////////////////////////////////////////////
     {
         msg_info() << "Adding '" << mstate->getPathName()
                 << "' in the global matrix ["<<dim<<"."<<dim
@@ -108,7 +107,7 @@ void DefaultMultiMatrixAccessor::addMechanicalMapping(sofa::core::BaseMapping* m
 
         mappingList.push_back(mapping);
 
-        if( MULTIMATRIX_VERBOSE)/////////////////////////////////////////////////////////
+        if(m_doPrintInfo)/////////////////////////////////////////////////////////
         {
             msg_info() << "Adding validated MechanicalMapping '" << mapping->getPathName()
                        << "' with J["<< jmatrix->rowSize()<<"."<<jmatrix->colSize()<<"]" ;
@@ -147,7 +146,7 @@ void DefaultMultiMatrixAccessor::setupMatrices()
         }
     }
 
-    if( MULTIMATRIX_VERBOSE)
+    if(m_doPrintInfo)
     {
         msg_info() << "Setting up the Global Matrix [" << globalDim << "." << globalDim << "] for " << realStateOffsets.size() << " real mechanical state(s)." ;
     }
@@ -190,7 +189,7 @@ DefaultMultiMatrixAccessor::MatrixRef DefaultMultiMatrixAccessor::getMatrix(cons
         else // this mapped state and its matrix hasnt been created we creat it and its matrix by "createMatrix"
         {
 
-            defaulttype::BaseMatrix* m = createMatrix(mstate,mstate);
+            defaulttype::BaseMatrix* m = createMatrixImpl(mstate,mstate, m_doPrintInfo);
             r.matrix = m;
             r.offset = 0;
             //when creating an matrix, it dont have to be added before
@@ -201,7 +200,7 @@ DefaultMultiMatrixAccessor::MatrixRef DefaultMultiMatrixAccessor::getMatrix(cons
 
     diagonalStiffnessBloc[mstate] = r;
 
-    if( MULTIMATRIX_VERBOSE)
+    if(m_doPrintInfo)
     {
         if (r.matrix != NULL)
         {
@@ -224,7 +223,7 @@ DefaultMultiMatrixAccessor::InteractionMatrixRef DefaultMultiMatrixAccessor::get
         r2.offRow = r.offset;
         r2.offCol = r.offset;
 
-        if( MULTIMATRIX_VERBOSE)///////////////////////////////////////////
+        if(m_doPrintInfo)///////////////////////////////////////////
         {
             if (r2.matrix != NULL)
             {
@@ -251,7 +250,7 @@ DefaultMultiMatrixAccessor::InteractionMatrixRef DefaultMultiMatrixAccessor::get
                 r2 = it->second;
             }
 
-            if( MULTIMATRIX_VERBOSE)///////////////////////////////////////////
+            if(m_doPrintInfo)///////////////////////////////////////////
             {
                 if(r2.matrix != NULL)
                 {
@@ -280,7 +279,7 @@ DefaultMultiMatrixAccessor::InteractionMatrixRef DefaultMultiMatrixAccessor::get
                     r2.offRow = it1->second;
                     r2.offCol = it2->second;
 
-                    if( MULTIMATRIX_VERBOSE)/////////////////////////////////////////////////////////
+                    if(m_doPrintInfo)/////////////////////////////////////////////////////////
                     {
                         if (r2.matrix != NULL)
                         {
@@ -298,14 +297,14 @@ DefaultMultiMatrixAccessor::InteractionMatrixRef DefaultMultiMatrixAccessor::get
             }
             else //case where at least one ms is a mapped
             {
-                defaulttype::BaseMatrix* m = createMatrix(mstate1,mstate2);
+                defaulttype::BaseMatrix* m = createMatrixImpl(mstate1,mstate2,m_doPrintInfo);
                 r2.matrix = m;
                 r2.offRow = 0;
                 r2.offCol = 0;
                 //when creating an matrix, it dont have to be added before
                 assert(interactionStiffnessBloc.find(pairMS) == interactionStiffnessBloc.end());
 
-                if( MULTIMATRIX_VERBOSE)/////////////////////////////////////////////////////////
+                if(m_doPrintInfo)/////////////////////////////////////////////////////////
                 {
                     if (r2.matrix != NULL)
                     {
@@ -329,7 +328,7 @@ DefaultMultiMatrixAccessor::InteractionMatrixRef DefaultMultiMatrixAccessor::get
     }//end of case where state1 # state2
 
 
-    if( MULTIMATRIX_VERBOSE && r2.matrix == NULL)
+    if(m_doPrintInfo && r2.matrix == NULL)
     {
         msg_warning() << "NULL matrix found for interaction " << mstate1->getName()<<" --- "<<mstate2->getName() ;
     }
@@ -350,7 +349,7 @@ void DefaultMultiMatrixAccessor::computeGlobalMatrix()
         const unsigned int nbR_J = matrixJ->rowSize();
         const unsigned int nbC_J = matrixJ->colSize();
 
-        if( MULTIMATRIX_VERBOSE)/////////////////////////////////////////////////////////
+        if(m_doPrintInfo)/////////////////////////////////////////////////////////
         {
             msg_info() << "[CONTRIBUTION] of " << id << "-th mapping named : " << m_mapping->getName()
                     << " with fromModel : "<< instate->getName()
@@ -361,7 +360,7 @@ void DefaultMultiMatrixAccessor::computeGlobalMatrix()
         //for toModel -----------------------------------------------------------
         if(mappedMatrices.find(outstate) == mappedMatrices.end())
         {
-            if( MULTIMATRIX_VERBOSE)
+            if(m_doPrintInfo)
             {
                 msg_info() << "	[Propa.Stiff] WARNING toModel : "<< outstate->getName()<< " dont have stiffness matrix" ;
             }
@@ -380,7 +379,7 @@ void DefaultMultiMatrixAccessor::computeGlobalMatrix()
             const unsigned int sizeK1 = K1.matrix->rowSize() - offset1;
             const unsigned int sizeK2 = K2.matrix->rowSize() - offset2;
 
-            if( MULTIMATRIX_VERBOSE)/////////////////////////////////////////////////////////
+            if(m_doPrintInfo)/////////////////////////////////////////////////////////
             {
                 msg_info() << "	[Propa.Stiff] propagating stiffness of : "<< outstate->getName()<< " to stifness "<<instate->getName()<< msgendl;
                 msg_info() <<"	                    **multiplication of "
@@ -432,7 +431,7 @@ void DefaultMultiMatrixAccessor::computeGlobalMatrix()
         for(size_t i=0; i< nbInteraction; i++)
         {
 
-            if( MULTIMATRIX_VERBOSE)/////////////////////////////////////////////////////////
+            if(m_doPrintInfo)/////////////////////////////////////////////////////////
             {
                 msg_info() << "	[Propa.Interac.Stiff] detected interaction between toModel : "<<interactionList[i].first->getName()
                         << " and : " <<interactionList[i].second->getName() ;
@@ -467,7 +466,7 @@ void DefaultMultiMatrixAccessor::computeGlobalMatrix()
                 const unsigned int nbC_I_32 = I_32.matrix->colSize() - offC_I_32;//number of colums of I32 matrix
 
 
-                if( MULTIMATRIX_VERBOSE)/////////////////////////////////////////////////////////
+                if(m_doPrintInfo)/////////////////////////////////////////////////////////
                 {
                     msg_info() << "	[Propa.Interac.Stiff] propagating interaction "
                             <<outstate->getName() << "--" <<interactionList[i].second->getName()
@@ -515,7 +514,7 @@ void DefaultMultiMatrixAccessor::computeGlobalMatrix()
                 const unsigned int nbR_I_23   = I_23.matrix->rowSize() - offR_I_23;
                 const unsigned int nbC_I_23   = I_23.matrix->colSize() - offC_I_23;
 
-                if( MULTIMATRIX_VERBOSE)/////////////////////////////////////////////////////////
+                if(m_doPrintInfo)/////////////////////////////////////////////////////////
                 {
                     msg_info() << "	[Propa.Interac.Stiff] propagating interaction "
                             <<interactionList[i].first->getName()<< "--" <<outstate->getName()
@@ -549,7 +548,7 @@ void DefaultMultiMatrixAccessor::computeGlobalMatrix()
 
             //after propagating the interaction, we remove the older interaction
             interactionStiffnessBloc.erase( interactionStiffnessBloc.find(interactionList[i]) );
-            if( MULTIMATRIX_VERBOSE)
+            if(m_doPrintInfo)
             {
                 msg_info() << "	--[Propa.Interac.Stiff] remove interaction of : "<<interactionList[i].first->getName()
                         << " and : " << interactionList[i].second->getName() ;
@@ -562,12 +561,17 @@ void DefaultMultiMatrixAccessor::computeGlobalMatrix()
 
 defaulttype::BaseMatrix* DefaultMultiMatrixAccessor::createMatrix(const sofa::core::behavior::BaseMechanicalState* mstate1, const sofa::core::behavior::BaseMechanicalState* mstate2)
 {
+    return createMatrixImpl(mstate1, mstate2, false) ;
+}
+
+defaulttype::BaseMatrix* DefaultMultiMatrixAccessor::createMatrixImpl(const sofa::core::behavior::BaseMechanicalState* mstate1, const sofa::core::behavior::BaseMechanicalState* mstate2, bool doPrintInfo)
+{
     component::linearsolver::CompressedRowSparseMatrix<SReal>* m = new component::linearsolver::CompressedRowSparseMatrix<SReal>;
     if(mstate1 == mstate2)
     {
         m->resize( mstate1->getMatrixSize(),mstate1->getMatrixSize());
 
-        if( MULTIMATRIX_VERBOSE)/////////////////////////////////////////////////////////
+        if(doPrintInfo)/////////////////////////////////////////////////////////
         {
             msg_info("DefaultMultiMatrixAccessor") << "			++ Creating matrix["<< m->rowSize() <<"."<< m->colSize() <<"]   for mapped state " << mstate1->getName() << "[" << mstate1->getMatrixSize()<<"]" ;
         }
@@ -576,7 +580,7 @@ defaulttype::BaseMatrix* DefaultMultiMatrixAccessor::createMatrix(const sofa::co
     {
         m->resize( mstate1->getMatrixSize(),mstate2->getMatrixSize() );
 
-        if( MULTIMATRIX_VERBOSE)/////////////////////////////////////////////////////////
+        if(doPrintInfo)/////////////////////////////////////////////////////////
         {
             msg_info("DefaultMultiMatrixAccessor") << "			++ Creating interraction matrix["<< m->rowSize() <<"x"<< m->colSize()
                       << "] for interaction " << mstate1->getName() << "[" << mstate1->getMatrixSize()
@@ -604,7 +608,7 @@ void CRSMultiMatrixAccessor::addMechanicalMapping(sofa::core::BaseMapping* mappi
 
         mappingList.push_back(mapping);
 
-        if( MULTIMATRIX_VERBOSE)/////////////////////////////////////////////////////////
+        if(m_doPrintInfo)/////////////////////////////////////////////////////////
         {
             std::cout << "Mapping Visitor : adding validated MechanicalMapping " << mapping->getName()
                     << " with J["<< jmatrix->rowSize()<<"."<<jmatrix->colSize()<<"]" <<std::endl;
@@ -629,7 +633,7 @@ defaulttype::BaseMatrix* CRSMultiMatrixAccessor::createMatrix(const sofa::core::
 
     if (mstate1 == mstate2)
     {
-        if( MULTIMATRIX_VERBOSE)/////////////////////////////////////////////////////////
+        if(m_doPrintInfo)/////////////////////////////////////////////////////////
         {
             std::cout << "			++ Creating matrix Mapped Mechanical State  : "<< mstate1->getName()
                     <<" associated to K["<< mstate1->getMatrixSize() <<"x"<< mstate1->getMatrixSize() << "] in the format _"
@@ -643,7 +647,7 @@ defaulttype::BaseMatrix* CRSMultiMatrixAccessor::createMatrix(const sofa::core::
     else
     {
 
-        if( MULTIMATRIX_VERBOSE)/////////////////////////////////////////////////////////
+        if(m_doPrintInfo)/////////////////////////////////////////////////////////
         {
             std::cout << "			++ Creating matrix Interaction: "
                     << mstate1->getName() <<" -- "<< mstate2->getName()
@@ -659,7 +663,7 @@ defaulttype::BaseMatrix* CRSMultiMatrixAccessor::createMatrix(const sofa::core::
 
 void CRSMultiMatrixAccessor::computeGlobalMatrix()
 {
-    if( MULTIMATRIX_VERBOSE)/////////////////////////////////////////////////////////
+    if(m_doPrintInfo)/////////////////////////////////////////////////////////
     {
         std::cout << "==========================     VERIFICATION BLOC MATRIX FORMATS    ========================" <<std::endl << std::endl;
 
@@ -728,7 +732,7 @@ void CRSMultiMatrixAccessor::computeGlobalMatrix()
         const unsigned int nbR_J = matrixJ->rowSize();
         const unsigned int nbC_J = matrixJ->colSize();
 
-        if( MULTIMATRIX_VERBOSE)/////////////////////////////////////////////////////////
+        if(m_doPrintInfo)/////////////////////////////////////////////////////////
         {
             std::cout << "[CONTRIBUTION] of " << id << "-th mapping named : " << m_mapping->getName()
                     << " with fromModel : "<< instate->getName()
@@ -739,7 +743,7 @@ void CRSMultiMatrixAccessor::computeGlobalMatrix()
         //for toModel -----------------------------------------------------------
         if(mappedMatrices.find(outstate) == mappedMatrices.end())
         {
-            if( MULTIMATRIX_VERBOSE)
+            if(m_doPrintInfo)
                 std::cout << "	[Propa.Stiff] WARNING toModel : "<< outstate->getName()<< " dont have stiffness matrix"<<std::endl;
         }
 
@@ -781,7 +785,7 @@ void CRSMultiMatrixAccessor::computeGlobalMatrix()
 
 
 
-            if( MULTIMATRIX_VERBOSE)/////////////////////////////////////////////////////////
+            if(m_doPrintInfo)/////////////////////////////////////////////////////////
             {
                 std::cout << "	[Propa.Stiff] propagating stiffness of : "<< outstate->getName()<< " to stifness "<<instate->getName()<<std::endl;
                 std::cout <<"	                    **multiplication of "
@@ -808,7 +812,7 @@ void CRSMultiMatrixAccessor::computeGlobalMatrix()
         for(unsigned i=0; i< nbInteraction; i++)
         {
 
-            if( MULTIMATRIX_VERBOSE)/////////////////////////////////////////////////////////
+            if(m_doPrintInfo)/////////////////////////////////////////////////////////
             {
                 std::cout << "	[Propa.Interac.Stiff] detected interaction between toModel : "<<interactionList[i].first->getName()
                         << " and : " <<interactionList[i].second->getName()<<std::endl;
@@ -843,7 +847,7 @@ void CRSMultiMatrixAccessor::computeGlobalMatrix()
                 const unsigned int nbC_I_32 = I_32.matrix->colSize() - offC_I_32;//number of colums of I32 matrix
 
 
-                if( MULTIMATRIX_VERBOSE)/////////////////////////////////////////////////////////
+                if(m_doPrintInfo)/////////////////////////////////////////////////////////
                 {
                     std::cout << "	[Propa.Interac.Stiff] propagating interaction "
                             <<outstate->getName() << "--" <<interactionList[i].second->getName()
@@ -885,7 +889,7 @@ void CRSMultiMatrixAccessor::computeGlobalMatrix()
                 const unsigned int nbR_I_23   = I_23.matrix->rowSize() - offR_I_23;
                 const unsigned int nbC_I_23   = I_23.matrix->colSize() - offC_I_23;
 
-                if( MULTIMATRIX_VERBOSE)/////////////////////////////////////////////////////////
+                if(m_doPrintInfo)/////////////////////////////////////////////////////////
                 {
                     std::cout << "	[Propa.Interac.Stiff] propagating interaction "
                             <<interactionList[i].first->getName()<< "--" <<outstate->getName()
@@ -912,7 +916,7 @@ void CRSMultiMatrixAccessor::computeGlobalMatrix()
 
             //after propagating the interaction, we remove the older interaction
             interactionStiffnessBloc.erase( interactionStiffnessBloc.find(interactionList[i]) );
-            if( MULTIMATRIX_VERBOSE)
+            if(m_doPrintInfo)
             {
                 std::cout << "	--[Propa.Interac.Stiff] remove interaction of : "<<interactionList[i].first->getName()
                         << " and : " << interactionList[i].second->getName()<<std::endl;

--- a/SofaKernel/modules/SofaBaseLinearSolver/DefaultMultiMatrixAccessor.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/DefaultMultiMatrixAccessor.h
@@ -104,11 +104,15 @@ public:
     //the stiffness and interaction stiffness of this state couldn't directly described on the principal matrix
     //then it demande to create a new matrix
     static defaulttype::BaseMatrix* createMatrix(const sofa::core::behavior::BaseMechanicalState* mstate1, const sofa::core::behavior::BaseMechanicalState* mstate2);
+    static defaulttype::BaseMatrix* createMatrixImpl(const sofa::core::behavior::BaseMechanicalState* mstate1, const sofa::core::behavior::BaseMechanicalState* mstate2, bool doPrintInfo);
+
+    //Activate/deactive the printing of extra information related to the numerical system that is being solved.
+    void setDoPrintInfo(bool value){ m_doPrintInfo = value; }
 
 protected:
-
-    defaulttype::BaseMatrix* globalMatrix;
-    unsigned int globalDim;
+    bool m_doPrintInfo {false} ;
+    defaulttype::BaseMatrix* globalMatrix {nullptr} ;
+    unsigned int globalDim {0} ;
 
     //           case1                                           case2
     //      |               |                                  |       |

--- a/SofaKernel/modules/SofaBaseLinearSolver/MatrixLinearSolver.inl
+++ b/SofaKernel/modules/SofaBaseLinearSolver/MatrixLinearSolver.inl
@@ -86,6 +86,7 @@ void MatrixLinearSolver<Matrix,Vector>::createGroups(const core::MechanicalParam
             if (gdim <= 0) continue;
             groups.push_back(n);
             gData[n].systemSize = (int)gdim;
+            gData[n].matrixAccessor.setDoPrintInfo( this->f_printLog.getValue() ) ;
             dim += gdim;
         }
         defaultGroup.systemSize = (int)dim;
@@ -96,6 +97,7 @@ void MatrixLinearSolver<Matrix,Vector>::createGroups(const core::MechanicalParam
         SReal dim = 0;
         simulation::MechanicalGetDimensionVisitor(mparams, &dim).execute(root);
         defaultGroup.systemSize = (int)dim;
+        defaultGroup.matrixAccessor.setDoPrintInfo( this->f_printLog.getValue() ) ;
     }
     currentNode = root;
     currentGroup = &defaultGroup;

--- a/examples/Components/linearsolver/FEMBAR-PCGLinearSolver.scn
+++ b/examples/Components/linearsolver/FEMBAR-PCGLinearSolver.scn
@@ -1,0 +1,17 @@
+<Node name="root" dt="0.02" gravity="0 -10 0">
+    <VisualStyle displayFlags="showBehaviorModels showForceFields" />
+    <CollisionPipeline depth="6" verbose="0" draw="0" />
+    <BruteForceDetection name="N2" />
+    <MinProximityIntersection name="Proximity" alarmDistance="0.5" contactDistance="0.3" />
+    <CollisionResponse name="Response" response="default" />
+    <CollisionGroup name="Group" />
+    <Node name="M1">
+        <EulerImplicit name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <PCGLinearSolver iterations="1000" threshold="1.0e-9" printLog="0" refresh="0" verbose="0" />
+        <MechanicalObject />
+        <UniformMass mass="1" />
+        <RegularGrid nx="4" ny="4" nz="20" xmin="-9" xmax="-6" ymin="0" ymax="3" zmin="0" zmax="19" />
+        <FixedConstraint indices="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15" />
+        <HexahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" method="large" />
+    </Node>
+</Node>

--- a/examples/Components/linearsolver/FEMBAR-SparseCholeskySolver.scn
+++ b/examples/Components/linearsolver/FEMBAR-SparseCholeskySolver.scn
@@ -1,0 +1,17 @@
+<Node name="root" dt="0.02" gravity="0 -10 0">
+    <VisualStyle displayFlags="showBehaviorModels showForceFields" />
+    <CollisionPipeline depth="6" verbose="0" draw="0" />
+    <BruteForceDetection name="N2" />
+    <MinProximityIntersection name="Proximity" alarmDistance="0.5" contactDistance="0.3" />
+    <CollisionResponse name="Response" response="default" />
+    <CollisionGroup name="Group" />
+    <Node name="M1">
+        <EulerImplicit name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <SparseCholeskySolver printLog="0" verbose="0" />
+        <MechanicalObject />
+        <UniformMass mass="1" />
+        <RegularGrid nx="4" ny="4" nz="20" xmin="-9" xmax="-6" ymin="0" ymax="3" zmin="0" zmax="19" />
+        <FixedConstraint indices="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15" />
+        <HexahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" method="large" />
+    </Node>
+</Node>

--- a/examples/Components/linearsolver/FEMBAR-SparseLDLSolver.scn
+++ b/examples/Components/linearsolver/FEMBAR-SparseLDLSolver.scn
@@ -1,0 +1,17 @@
+<Node name="root" dt="0.02" gravity="0 -10 0">
+    <VisualStyle displayFlags="showBehaviorModels showForceFields" />
+    <CollisionPipeline depth="6" verbose="0" draw="0" />
+    <BruteForceDetection name="N2" />
+    <MinProximityIntersection name="Proximity" alarmDistance="0.5" contactDistance="0.3" />
+    <CollisionResponse name="Response" response="default" />
+    <CollisionGroup name="Group" />
+    <Node name="M1">
+        <EulerImplicit name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <SparseLDLSolver printLog="1"/>
+        <MechanicalObject />
+        <UniformMass mass="1" />
+        <RegularGrid nx="4" ny="4" nz="20" xmin="-9" xmax="-6" ymin="0" ymax="3" zmin="0" zmax="19" />
+        <FixedConstraint indices="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15" />
+        <HexahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" method="large" />
+    </Node>
+</Node>

--- a/examples/Components/linearsolver/FEMBAR-SparseLUSolver.scn
+++ b/examples/Components/linearsolver/FEMBAR-SparseLUSolver.scn
@@ -1,0 +1,17 @@
+<Node name="root" dt="0.02" gravity="0 -10 0">
+    <VisualStyle displayFlags="showBehaviorModels showForceFields" />
+    <CollisionPipeline depth="6" verbose="0" draw="0" />
+    <BruteForceDetection name="N2" />
+    <MinProximityIntersection name="Proximity" alarmDistance="0.5" contactDistance="0.3" />
+    <CollisionResponse name="Response" response="default" />
+    <CollisionGroup name="Group" />
+    <Node name="M1">
+        <EulerImplicit name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <SparseLUSolver printLog="1" verbose="0"/>
+        <MechanicalObject />
+        <UniformMass mass="1" />
+        <RegularGrid nx="4" ny="4" nz="20" xmin="-9" xmax="-6" ymin="0" ymax="3" zmin="0" zmax="19" />
+        <FixedConstraint indices="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15" />
+        <HexahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" method="large" />
+    </Node>
+</Node>

--- a/modules/SofaSparseSolver/SparseLDLSolverImpl.h
+++ b/modules/SofaSparseSolver/SparseLDLSolverImpl.h
@@ -290,7 +290,7 @@ protected :
 
         // we test if the matrix has the same struct as previous factorized matrix
         if (data->new_factorization_needed) {
-            sout << "RECOMPUTE NEW FACTORIZATION" << sendl;
+            msg_info() << "Recomputing new factorization" ;
 
             data->perm.clear();data->perm.fastResize(data->n);
             data->invperm.clear();data->invperm.fastResize(data->n);


### PR DESCRIPTION
Here is a very simple implementation that enable extra printing to help in understanding why some scenes are failing/crashing. 

I also add few scenes with single solvers because those components where not tested anywhere in our CI. 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
