### PR TITLE
[SofaKernel] Improve Displayflags

### DIFF
--- a/SofaKernel/framework/sofa/core/visual/DisplayFlags.cpp
+++ b/SofaKernel/framework/sofa/core/visual/DisplayFlags.cpp
@@ -115,7 +115,7 @@ std::istream& FlagTreeItem::read(std::istream &in)
 
             if(string1 != token)
             {
-                msg_warning("DisplayFlags") << "FlagTreeItem case is not correct: please use '" << string1 << "' instead of '"<<token<<"'";
+                msg_warning("DisplayFlags") << "Case of FlagTreeItem '" << token << "' is not correct, please use '"<< string1 <<"' instead";
             }
 
             parse_map[token] = true;
@@ -172,6 +172,11 @@ void FlagTreeItem::read_recursive(FlagTreeItem *root, const std::map<std::string
                 bool hide = iter_hide->second;
                 if(hide)
                 {
+                    if(i != 0)
+                    {
+                        msg_warning("DisplayFlags") << "FlagTreeItem '" << (*iter)->m_hideName[i] << "' is deprecated, please use '"<<(*iter)->m_hideName[0]<<"' instead";
+                    }
+
                     tristate merge_showhide;
                     if (hide) merge_showhide = tristate::false_value;
                     (*iter)->setValue(merge_showhide);
@@ -187,6 +192,11 @@ void FlagTreeItem::read_recursive(FlagTreeItem *root, const std::map<std::string
                 bool show  = iter_show->second;
                 if(show)
                 {
+                    if(i != 0)
+                    {
+                        msg_warning("DisplayFlags") << "FlagTreeItem '" << (*iter)->m_showName[i] << "' is deprecated, please use '"<<(*iter)->m_showName[0]<<"' instead";
+                    }
+
                     tristate merge_showhide;
                     if (show) merge_showhide = tristate::true_value;
                     (*iter)->setValue(merge_showhide);
@@ -240,7 +250,7 @@ DisplayFlags::DisplayFlags():
     m_showVisualMappings(FlagTreeItem("showMappings","hideMappings",&m_showMapping)),
     m_showMechanicalMappings(FlagTreeItem("showMechanicalMappings","hideMechanicalMappings",&m_showMapping)),
     m_showOptions(FlagTreeItem("showOptions","hideOptions",&m_root)),
-    m_showRendering(FlagTreeItem("showRendering","hideRendering",&m_showOptions)),
+    m_showAdvancedRendering(FlagTreeItem("showAdvancedRendering","hideAdvancedRendering",&m_showOptions)),
     m_showWireframe(FlagTreeItem("showWireframe","hideWireframe",&m_showOptions)),
     m_showNormals(FlagTreeItem("showNormals","hideNormals",&m_showOptions))
 {
@@ -252,16 +262,12 @@ DisplayFlags::DisplayFlags():
     m_showBoundingCollisionModels.setValue(tristate::neutral_value);
     m_showVisualMappings.setValue(tristate::neutral_value);
     m_showMechanicalMappings.setValue(tristate::neutral_value);
-    m_showRendering.setValue(tristate::neutral_value);
+    m_showAdvancedRendering.setValue(tristate::neutral_value);
     m_showWireframe.setValue(tristate::neutral_value);
     m_showNormals.setValue(tristate::neutral_value);
 
-    m_showInteractionForceFields.addAliasShow("showInteractions");
-    m_showInteractionForceFields.addAliasHide("hideInteractions");
-    m_showBoundingCollisionModels.addAliasShow("showBoundingTrees");
-    m_showBoundingCollisionModels.addAliasHide("hideBoundingTrees");
-    m_showRendering.addAliasShow("showAdvancedRendering");
-    m_showRendering.addAliasHide("hideAdvancedRendering");
+    m_showAdvancedRendering.addAliasShow("showRendering");
+    m_showAdvancedRendering.addAliasHide("hideRendering");
 }
 
 DisplayFlags::DisplayFlags(const DisplayFlags & other):
@@ -280,7 +286,7 @@ DisplayFlags::DisplayFlags(const DisplayFlags & other):
     m_showVisualMappings(FlagTreeItem("showMappings","hideMappings",&m_showMapping)),
     m_showMechanicalMappings(FlagTreeItem("showMechanicalMappings","hideMechanicalMappings",&m_showMapping)),
     m_showOptions(FlagTreeItem("showOptions","hideOptions",&m_root)),
-    m_showRendering(FlagTreeItem("showRendering","hideRendering",&m_showOptions)),
+    m_showAdvancedRendering(FlagTreeItem("showAdvancedRendering","hideAdvancedRendering",&m_showOptions)),
     m_showWireframe(FlagTreeItem("showWireframe","hideWireframe",&m_showOptions)),
     m_showNormals(FlagTreeItem("showNormals","hideNormals",&m_showOptions))
 {
@@ -292,16 +298,12 @@ DisplayFlags::DisplayFlags(const DisplayFlags & other):
     m_showBoundingCollisionModels.setValue(other.m_showBoundingCollisionModels.state());
     m_showVisualMappings.setValue(other.m_showVisualMappings.state());
     m_showMechanicalMappings.setValue(other.m_showMechanicalMappings.state());
-    m_showRendering.setValue(other.m_showRendering.state());
+    m_showAdvancedRendering.setValue(other.m_showAdvancedRendering.state());
     m_showWireframe.setValue(other.m_showWireframe.state());
     m_showNormals.setValue(other.m_showNormals.state());
 
-    m_showInteractionForceFields.addAliasShow("showInteractions");
-    m_showInteractionForceFields.addAliasHide("hideInteractions");
-    m_showBoundingCollisionModels.addAliasShow("showBoundingTrees");
-    m_showBoundingCollisionModels.addAliasHide("hideBoundingTrees");
-    m_showRendering.addAliasShow("showAdvancedRendering");
-    m_showRendering.addAliasHide("hideAdvancedRendering");
+    m_showAdvancedRendering.addAliasShow("showRendering");
+    m_showAdvancedRendering.addAliasHide("hideRendering");
 }
 
 DisplayFlags& DisplayFlags::operator =(const DisplayFlags& other)
@@ -316,7 +318,7 @@ DisplayFlags& DisplayFlags::operator =(const DisplayFlags& other)
         m_showBoundingCollisionModels.setValue(other.m_showBoundingCollisionModels.state());
         m_showVisualMappings.setValue(other.m_showVisualMappings.state());
         m_showMechanicalMappings.setValue(other.m_showMechanicalMappings.state());
-        m_showRendering.setValue(other.m_showRendering.state());
+        m_showAdvancedRendering.setValue(other.m_showAdvancedRendering.state());
         m_showWireframe.setValue(other.m_showWireframe.state());
         m_showNormals.setValue(other.m_showNormals.state());
     }
@@ -333,7 +335,7 @@ bool DisplayFlags::isNeutral() const
             && m_showCollisionModels.state().state == tristate::neutral_value
             && m_showVisualMappings.state().state == tristate::neutral_value
             && m_showMechanicalMappings.state().state == tristate::neutral_value
-            && m_showRendering.state().state == tristate::neutral_value
+            && m_showAdvancedRendering.state().state == tristate::neutral_value
             && m_showWireframe.state().state == tristate::neutral_value
             && m_showNormals.state().state == tristate::neutral_value
             ;
@@ -350,7 +352,7 @@ DisplayFlags merge_displayFlags(const DisplayFlags &previous, const DisplayFlags
     merge.m_showBoundingCollisionModels.setValue( merge_tristate(previous.m_showBoundingCollisionModels.state(),current.m_showBoundingCollisionModels.state()) );
     merge.m_showVisualMappings.setValue( merge_tristate(previous.m_showVisualMappings.state(),current.m_showVisualMappings.state()) );
     merge.m_showMechanicalMappings.setValue( merge_tristate(previous.m_showMechanicalMappings.state(),current.m_showMechanicalMappings.state()) );
-    merge.m_showRendering.setValue( merge_tristate(previous.m_showRendering.state(),current.m_showRendering.state()) );
+    merge.m_showAdvancedRendering.setValue( merge_tristate(previous.m_showAdvancedRendering.state(),current.m_showAdvancedRendering.state()) );
     merge.m_showWireframe.setValue( merge_tristate(previous.m_showWireframe.state(),current.m_showWireframe.state()) );
     merge.m_showNormals.setValue( merge_tristate(previous.m_showNormals.state(),current.m_showNormals.state()) );
     return merge;
@@ -367,7 +369,7 @@ DisplayFlags difference_displayFlags(const DisplayFlags& previous, const Display
     difference.m_showBoundingCollisionModels.setValue( difference_tristate(previous.m_showBoundingCollisionModels.state(),current.m_showBoundingCollisionModels.state()) );
     difference.m_showVisualMappings.setValue( difference_tristate(previous.m_showVisualMappings.state(),current.m_showVisualMappings.state()) );
     difference.m_showMechanicalMappings.setValue( difference_tristate(previous.m_showMechanicalMappings.state(),current.m_showMechanicalMappings.state()) );
-    difference.m_showRendering.setValue( difference_tristate(previous.m_showRendering.state(),current.m_showRendering.state()) );
+    difference.m_showAdvancedRendering.setValue( difference_tristate(previous.m_showAdvancedRendering.state(),current.m_showAdvancedRendering.state()) );
     difference.m_showWireframe.setValue( difference_tristate(previous.m_showWireframe.state(),current.m_showWireframe.state()) );
     difference.m_showNormals.setValue( difference_tristate(previous.m_showNormals.state(),current.m_showNormals.state()) );
     return difference;

--- a/SofaKernel/framework/sofa/core/visual/DisplayFlags.h
+++ b/SofaKernel/framework/sofa/core/visual/DisplayFlags.h
@@ -97,8 +97,25 @@ inline tristate difference_tristate(const tristate& previous, const tristate& cu
 class SOFA_CORE_API FlagTreeItem
 {
 protected:
-    std::string m_showName;
-    std::string m_hideName;
+    // Creating a case insensitive "find" function for map
+    struct ci_comparison
+    {
+        // case-independent (ci) comparison
+        struct nocase_compare
+        {
+            bool operator() (const unsigned char& c1, const unsigned char& c2) const
+            {
+              return tolower (c1) < tolower (c2);
+            }
+        };
+        bool operator() (const std::string & s1, const std::string & s2) const
+        {
+            return std::lexicographical_compare(s1.begin (), s1.end (), s2.begin (), s2.end (), nocase_compare ());
+        }
+    };
+
+    sofa::helper::vector<std::string> m_showName;
+    sofa::helper::vector<std::string> m_hideName;
     tristate m_state;
 
     FlagTreeItem* m_parent;
@@ -126,13 +143,19 @@ public:
 
     void setValue(const tristate& state);
 
+    void addAliasShow(const std::string& newAlias);
+    void addAliasHide(const std::string& newAlias);
+    void addAlias(sofa::helper::vector<std::string> &name, const std::string &newAlias);
+
 protected:
     void propagateStateDown(FlagTreeItem* origin);
     void propagateStateUp(FlagTreeItem* origin);
-    static std::map<std::string,bool> create_flagmap(FlagTreeItem* root);
-    static void create_parse_map(FlagTreeItem* root, std::map<std::string,bool>& map);
-    static void read_recursive(FlagTreeItem* root, const std::map<std::string,bool>& map);
+    static std::map<std::string,bool, ci_comparison> create_flagmap(FlagTreeItem* root);
+    static void create_parse_map(FlagTreeItem* root, std::map<std::string,bool,ci_comparison>& map);
+    static void read_recursive(FlagTreeItem* root, const std::map<std::string,bool,ci_comparison>& map);
     static void write_recursive(const FlagTreeItem* root,  std::string& str);
+
+
 };
 
 /** \brief Class which describes the display of components in a hierarchical fashion

--- a/SofaKernel/framework/sofa/core/visual/DisplayFlags.h
+++ b/SofaKernel/framework/sofa/core/visual/DisplayFlags.h
@@ -205,7 +205,7 @@ public:
     tristate getShowMappings() const { return m_showVisualMappings.state(); }
     tristate getShowMechanicalMappings() const { return m_showMechanicalMappings.state(); }
     tristate getShowOptions() const { return m_showOptions.state(); }
-    tristate getShowRendering() const { return m_showRendering.state(); }
+    tristate getShowAdvancedRendering() const { return m_showAdvancedRendering.state(); }
     tristate getShowWireFrame() const { return m_showWireframe.state(); }
     tristate getShowNormals() const { return m_showNormals.state(); }
 
@@ -223,7 +223,7 @@ public:
     DisplayFlags& setShowMappings(tristate v=true) { m_showVisualMappings.setValue(v); return (*this); }
     DisplayFlags& setShowMechanicalMappings(tristate v=true) { m_showMechanicalMappings.setValue(v); return (*this); }
     DisplayFlags& setShowOptions(tristate v=true) { m_showOptions.setValue(v); return (*this); }
-    DisplayFlags& setShowRendering(tristate v=true) { m_showRendering.setValue(v); return (*this); }
+    DisplayFlags& setShowAdvancedRendering(tristate v=true) { m_showAdvancedRendering.setValue(v); return (*this); }
     DisplayFlags& setShowWireFrame(tristate v=true) { m_showWireframe.setValue(v); return (*this); }
     DisplayFlags& setShowNormals(tristate v=true) { m_showNormals.setValue(v); return (*this); }
     friend std::ostream& operator<< ( std::ostream& os, const DisplayFlags& flags )
@@ -262,7 +262,7 @@ protected:
 
     FlagTreeItem m_showOptions;
 
-    FlagTreeItem m_showRendering;
+    FlagTreeItem m_showAdvancedRendering;
     FlagTreeItem m_showWireframe;
     FlagTreeItem m_showNormals;
 };

--- a/applications/sofa/gui/qt/DisplayFlagsDataWidget.cpp
+++ b/applications/sofa/gui/qt/DisplayFlagsDataWidget.cpp
@@ -84,7 +84,7 @@ DisplayFlagWidget::DisplayFlagWidget(QWidget* parent, const char* name,  Qt::Win
     itemShowFlag[COLLISIONMODELS]   = new QTreeWidgetItem(itemShowCollision);
     this->setTreeWidgetCheckable(itemShowFlag[COLLISIONMODELS], "Collision Models");
     itemShowFlag[BOUNDINGCOLLISIONMODELS]   = new QTreeWidgetItem(itemShowCollision, itemShowFlag[COLLISIONMODELS]);
-    this->setTreeWidgetCheckable(itemShowFlag[BOUNDINGCOLLISIONMODELS], "Bounding Trees");
+    this->setTreeWidgetCheckable(itemShowFlag[BOUNDINGCOLLISIONMODELS], "Bounding Collision Models");
     QTreeWidgetItem* itemShowMapping   = new QTreeWidgetItem(itemShowAll, itemShowCollision);
     this->setTreeWidgetNodeCheckable(itemShowMapping, "Mapping");
     itemShowFlag[MAPPINGS]   = new QTreeWidgetItem(itemShowMapping);
@@ -193,7 +193,7 @@ void DisplayFlagsDataWidget::readFromData()
     flags->setFlag(DisplayFlagWidget::MECHANICALMAPPINGS, displayFlags.getShowMechanicalMappings());
     flags->setFlag(DisplayFlagWidget::FORCEFIELDS, displayFlags.getShowForceFields());
     flags->setFlag(DisplayFlagWidget::INTERACTIONFORCEFIELDS, displayFlags.getShowInteractionForceFields());
-    flags->setFlag(DisplayFlagWidget::RENDERING, displayFlags.getShowRendering());
+    flags->setFlag(DisplayFlagWidget::RENDERING, displayFlags.getShowAdvancedRendering());
     flags->setFlag(DisplayFlagWidget::WIREFRAME, displayFlags.getShowWireFrame());
     flags->setFlag(DisplayFlagWidget::NORMALS, displayFlags.getShowNormals());
 }
@@ -210,7 +210,7 @@ void DisplayFlagsDataWidget::writeToData()
     displayFlags.setShowMechanicalMappings(flags->getFlag(DisplayFlagWidget::MECHANICALMAPPINGS));
     displayFlags.setShowForceFields(flags->getFlag(DisplayFlagWidget::FORCEFIELDS));
     displayFlags.setShowInteractionForceFields(flags->getFlag(DisplayFlagWidget::INTERACTIONFORCEFIELDS));
-    displayFlags.setShowRendering(flags->getFlag(DisplayFlagWidget::RENDERING));
+    displayFlags.setShowAdvancedRendering(flags->getFlag(DisplayFlagWidget::RENDERING));
     displayFlags.setShowWireFrame(flags->getFlag(DisplayFlagWidget::WIREFRAME));
     displayFlags.setShowNormals(flags->getFlag(DisplayFlagWidget::NORMALS));
     this->getData()->endEdit();

--- a/applications/sofa/gui/qt/DisplayFlagsDataWidget.cpp
+++ b/applications/sofa/gui/qt/DisplayFlagsDataWidget.cpp
@@ -73,7 +73,7 @@ DisplayFlagWidget::DisplayFlagWidget(QWidget* parent, const char* name,  Qt::Win
     this->setTreeWidgetNodeCheckable(itemShowBehavior, "Behavior");
 
     itemShowFlag[BEHAVIORMODELS]   = new QTreeWidgetItem(itemShowBehavior);
-    this->setTreeWidgetCheckable(itemShowFlag[BEHAVIORMODELS], "Behavior Model");
+    this->setTreeWidgetCheckable(itemShowFlag[BEHAVIORMODELS], "Behavior Models");
     itemShowFlag[FORCEFIELDS]   = new QTreeWidgetItem(itemShowBehavior, itemShowFlag[BEHAVIORMODELS]);
     this->setTreeWidgetCheckable(itemShowFlag[FORCEFIELDS], "Force Fields");
     itemShowFlag[INTERACTIONFORCEFIELDS]   = new QTreeWidgetItem(itemShowBehavior, itemShowFlag[FORCEFIELDS]);

--- a/modules/SofaOpenglVisual/CompositingVisualLoop.cpp
+++ b/modules/SofaOpenglVisual/CompositingVisualLoop.cpp
@@ -91,9 +91,9 @@ void CompositingVisualLoop::drawStep(sofa::core::visual::VisualParams* vparams)
     const sofa::core::visual::DisplayFlags &backupFlags = vparams->displayFlags();
     const sofa::core::visual::DisplayFlags &currentFlags = visualStyle->displayFlags.getValue();
     vparams->displayFlags() = sofa::core::visual::merge_displayFlags(backupFlags, currentFlags);
-    renderingState = vparams->displayFlags().getShowRendering();
+    renderingState = vparams->displayFlags().getShowAdvancedRendering();
 
-    if (!(vparams->displayFlags().getShowRendering()))
+    if (!(vparams->displayFlags().getShowAdvancedRendering()))
     {
         dmsg_info() << "Advanced Rendering is OFF" ;
 

--- a/modules/SofaOpenglVisual/OglViewport.cpp
+++ b/modules/SofaOpenglVisual/OglViewport.cpp
@@ -101,7 +101,7 @@ bool OglViewport::isVisible(const core::visual::VisualParams*)
     {
         VisualStyle* vstyle = NULL;
         this->getContext()->get(vstyle);
-        if (vstyle && !vstyle->displayFlags.getValue().getShowRendering())
+        if (vstyle && !vstyle->displayFlags.getValue().getShowAdvancedRendering())
             return false;
     }
     return true;


### PR DESCRIPTION
This PR allows to add aliases in C++ in DisplayFlags.
Moreover, DisplayFlags are now case insensitive but a warning is given.
The DisplayFlagsDataWidget is now fixed to correspond to the FlagTreeItem names.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
