### PR TITLE
[Camera] Refactoring

### DIFF
--- a/SofaKernel/framework/sofa/defaulttype/DataTypeInfo.h
+++ b/SofaKernel/framework/sofa/defaulttype/DataTypeInfo.h
@@ -26,6 +26,7 @@
 #include <sofa/helper/fixed_array.h>
 #include <sofa/helper/vector.h>
 #include <sofa/helper/set.h>
+#include <sofa/helper/types/RGBAColor.h>
 #include <sstream>
 #include <typeinfo>
 #include <sofa/helper/logging/Messaging.h>
@@ -1289,6 +1290,11 @@ struct DataTypeInfo< std::set<T,Compare,Alloc> > : public SetTypeInfo<std::set<T
     static std::string name() { std::ostringstream o; o << "std::set<" << DataTypeName<T>::name() << ">"; return o.str(); }
 };
 
+template<>
+struct DataTypeInfo< sofa::helper::types::RGBAColor > : public FixedArrayTypeInfo<sofa::helper::fixed_array<float,4>>
+{
+    static std::string name() { return "RGBAColor"; }
+};
 
 } // namespace defaulttype
 

--- a/SofaKernel/framework/sofa/helper/types/RGBAColor.h
+++ b/SofaKernel/framework/sofa/helper/types/RGBAColor.h
@@ -37,6 +37,8 @@ namespace helper
 namespace types
 {
 
+using sofa::helper::fixed_array ;
+
 #define RGBACOLOR_EQUALITY_THRESHOLD 1e-6
 
 /**

--- a/SofaKernel/modules/SofaBaseVisual/BackgroundSetting.h
+++ b/SofaKernel/modules/SofaBaseVisual/BackgroundSetting.h
@@ -19,10 +19,14 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#ifndef SOFA_COMPONENT_CONFIGURATIONSETTING_BACKGROUND_H
+#define SOFA_COMPONENT_CONFIGURATIONSETTING_BACKGROUND_H
+#include "config.h"
 
-#include <SofaGraphComponent/BackgroundSetting.h>
-#include <sofa/core/visual/VisualParams.h>
-#include <sofa/core/ObjectFactory.h>
+#include <sofa/core/objectmodel/ConfigurationSetting.h>
+#include <sofa/core/objectmodel/DataFileName.h>
+#include <sofa/defaulttype/Vec.h>
+#include <sofa/defaulttype/RGBAColor.h>
 
 namespace sofa
 {
@@ -33,20 +37,22 @@ namespace component
 namespace configurationsetting
 {
 
-SOFA_DECL_CLASS(BackgroundSetting)
-int BackgroundSettingClass = core::RegisterObject("Background colour setting")
-        .add< BackgroundSetting >()
-        .addAlias("Background")
-        ;
-
-BackgroundSetting::BackgroundSetting():
-      color(initData(&color, "color", "Color of the Background of the Viewer"))
-    , image(initData(&image, "image", "Image to be used as background of the viewer"))
+///Class for the configuration of background settings.
+class SOFA_GRAPH_COMPONENT_API BackgroundSetting: public core::objectmodel::ConfigurationSetting
 {
-}
+public:
+    SOFA_CLASS(BackgroundSetting,core::objectmodel::ConfigurationSetting);  ///< Sofa macro to define typedef.
+protected:
+    BackgroundSetting();    ///< Default constructor
+public:
+    Data<defaulttype::RGBAColor> color;   ///< Color of the Background of the Viewer.
+    sofa::core::objectmodel::DataFileName image;                 ///< Image to be used as background of the viewer.
+
+};
 
 }
 
 }
 
 }
+#endif

--- a/SofaKernel/modules/SofaBaseVisual/BaseCamera.h
+++ b/SofaKernel/modules/SofaBaseVisual/BaseCamera.h
@@ -194,7 +194,7 @@ public:
     Vec3 getLookAtFromOrientation(const Vec3 &pos, const double &distance,const Quat & orientation);
     Vec3 getPositionFromOrientation(const Vec3 &lookAt, const double &distance, const Quat& orientation);
 
-    virtual void manageEvent(core::objectmodel::Event* e)=0;
+    virtual void manageEvent(core::objectmodel::Event* event) = 0 ;
     virtual void internalUpdate() {}
 
     void handleEvent(sofa::core::objectmodel::Event* event) override;
@@ -244,6 +244,8 @@ public:
     {
         return 1.0;
     }
+
+    virtual void draw(const core::visual::VisualParams*) override ;
 
 protected:
     void updateOutputData();

--- a/SofaKernel/modules/SofaBaseVisual/CMakeLists.txt
+++ b/SofaKernel/modules/SofaBaseVisual/CMakeLists.txt
@@ -3,6 +3,7 @@ project(SofaBaseVisual)
 
 set(HEADER_FILES
     BaseCamera.h
+    BackgroundSetting.h
     Camera.h
     InteractiveCamera.h
     VisualModelImpl.h
@@ -13,6 +14,7 @@ set(HEADER_FILES
 
 set(SOURCE_FILES
     BaseCamera.cpp
+    BackgroundSetting.cpp
     Camera.cpp
     InteractiveCamera.cpp
     VisualModelImpl.cpp

--- a/SofaKernel/modules/SofaBaseVisual/CMakeLists.txt
+++ b/SofaKernel/modules/SofaBaseVisual/CMakeLists.txt
@@ -3,6 +3,7 @@ project(SofaBaseVisual)
 
 set(HEADER_FILES
     BaseCamera.h
+    Camera.h
     InteractiveCamera.h
     VisualModelImpl.h
     VisualStyle.h
@@ -12,6 +13,7 @@ set(HEADER_FILES
 
 set(SOURCE_FILES
     BaseCamera.cpp
+    Camera.cpp
     InteractiveCamera.cpp
     VisualModelImpl.cpp
     VisualStyle.cpp

--- a/SofaKernel/modules/SofaBaseVisual/Camera.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/Camera.cpp
@@ -1,0 +1,52 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/core/ObjectFactory.h>
+#include <SofaBaseVisual/Camera.h>
+
+namespace sofa
+{
+
+namespace component
+{
+
+namespace visualmodel
+{
+
+SOFA_DECL_CLASS(Camera)
+
+int CameraClass = core::RegisterObject("A Camera that render the scene from a given location & orientation.")
+                    .add<Camera>() ;
+
+Camera::Camera()
+{
+    p_computeZClip.setValue(false) ;
+}
+
+Camera::~Camera()
+{
+}
+
+} // namespace visualmodel
+
+} // namespace component
+
+} // namespace sofa

--- a/SofaKernel/modules/SofaBaseVisual/Camera.h
+++ b/SofaKernel/modules/SofaBaseVisual/Camera.h
@@ -1,0 +1,59 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#ifndef SOFA_COMPONENT_VISUALMODEL_CAMERA_H
+#define SOFA_COMPONENT_VISUALMODEL_CAMERA_H
+#include "config.h"
+
+#include <SofaBaseVisual/BaseCamera.h>
+
+namespace sofa
+{
+
+namespace component
+{
+
+namespace visualmodel
+{
+
+class SOFA_BASE_VISUAL_API Camera : public BaseCamera
+{
+public:
+    SOFA_CLASS(Camera, BaseCamera);
+
+protected:
+    Camera();
+    virtual ~Camera();
+
+public:
+    virtual void manageEvent(core::objectmodel::Event* e) override { SOFA_UNUSED(e); }
+
+private:
+
+};
+
+} // namespace visualmodel
+
+} // namespace component
+
+} // namespace sofa
+
+#endif // SOFA_COMPONENT_VISUALMODEL_CAMERA_H

--- a/SofaKernel/modules/SofaBaseVisual/InteractiveCamera.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/InteractiveCamera.cpp
@@ -36,7 +36,6 @@ SOFA_DECL_CLASS(InteractiveCamera)
 
 int InteractiveCameraClass = core::RegisterObject("InteractiveCamera")
         .add< InteractiveCamera >()
-        .addAlias("Camera")
         ;
 
 
@@ -47,7 +46,7 @@ InteractiveCamera::InteractiveCamera()
     ,currentMode(InteractiveCamera::NONE_MODE)
     ,isMoving(false)
     {
-}
+    }
 
 InteractiveCamera::~InteractiveCamera()
 {

--- a/examples/Demos/caduceus.scn
+++ b/examples/Demos/caduceus.scn
@@ -7,7 +7,7 @@
     <CollisionPipeline depth="15" verbose="0" draw="0" />
     <BruteForceDetection name="N2" />
     <MinProximityIntersection name="Proximity" alarmDistance="1.5" contactDistance="1" />
-    <InteractiveCamera position="0 30 90" lookAt="0 30 0"/>
+    <Camera position="0 30 90" lookAt="0 30 0"/>
     <LightManager />
     <SpotLight name="light1" color="1 1 1" position="0 80 25" direction="0 -1 -0.8" cutoff="30" exponent="1" />
     <SpotLight name="light2" color="1 1 1" position="0 40 100" direction="0 0 -1" cutoff="30" exponent="1" />

--- a/modules/SofaGraphComponent/BackgroundSetting.h
+++ b/modules/SofaGraphComponent/BackgroundSetting.h
@@ -19,40 +19,18 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_COMPONENT_CONFIGURATIONSETTING_BACKGROUND_H
-#define SOFA_COMPONENT_CONFIGURATIONSETTING_BACKGROUND_H
-#include "config.h"
+#ifndef SOFA_GRAPH_COMPONENT_BACKGROUNDSETTING_H
+#define SOFA_GRAPH_COMPONENT_BACKGROUNDSETTING_H
 
-#include <sofa/core/objectmodel/ConfigurationSetting.h>
-#include <sofa/core/objectmodel/DataFileName.h>
-#include <sofa/defaulttype/Vec.h>
-#include <sofa/defaulttype/RGBAColor.h>
+#include <SofaBaseVisual/BackgroundSetting.h>
 
 namespace sofa
 {
-
-namespace component
+namespace defaulttype
 {
+    using sofa::component::configurationsetting::BackgroundSetting ;
+} // namespace defaulttype
+} // namespace sofa
 
-namespace configurationsetting
-{
 
-///Class for the configuration of background settings.
-class SOFA_GRAPH_COMPONENT_API BackgroundSetting: public core::objectmodel::ConfigurationSetting
-{
-public:
-    SOFA_CLASS(BackgroundSetting,core::objectmodel::ConfigurationSetting);  ///< Sofa macro to define typedef.
-protected:
-    BackgroundSetting();    ///< Default constructor
-public:
-    Data<defaulttype::RGBAColor> color;   ///< Color of the Background of the Viewer.
-    sofa::core::objectmodel::DataFileName image;                 ///< Image to be used as background of the viewer.
-
-};
-
-}
-
-}
-
-}
 #endif

--- a/modules/SofaGraphComponent/CMakeLists.txt
+++ b/modules/SofaGraphComponent/CMakeLists.txt
@@ -14,7 +14,6 @@ list(APPEND HEADER_FILES
     AddFrameButtonSetting.h
     AddRecordedCameraButtonSetting.h
     AttachBodyButtonSetting.h
-    BackgroundSetting.h
     FixPickedParticleButtonSetting.h
     Gravity.h
     InteractingBehaviorModel.h
@@ -34,7 +33,6 @@ list(APPEND SOURCE_FILES
     AddFrameButtonSetting.cpp
     AddRecordedCameraButtonSetting.cpp
     AttachBodyButtonSetting.cpp
-    BackgroundSetting.cpp
     FixPickedParticleButtonSetting.cpp
     Gravity.cpp
     MouseButtonSetting.cpp


### PR DESCRIPTION
Create a Camera component so that it become possible to render a scene. The difference with InteractionCamera is that the Camera component is not having any interaction so you can implement
your own 'application specific behavior' by using an external Controller (eg: PythonScriptController).

Changes:
- the BaseCamera now has a link to a BackgroundSetting so multiple camera can have multiple background. 
- the BaseCamera now implement a draw() method. If you don't want to see what is drawn...then
  restrict the rendering of your scene graph to only call drawVisuals() which is what it is supposed to do :) 
- the Camera alias is not anymore creating an InteractionCamera but a Camera object

Update the caduceus example.

NB: I know there is much more to refactor but I have not time for that. 
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
