### PR TITLE
[SofaKernel] Refactoring in Camera, BackgroundSetting and Light

### DIFF
--- a/SofaKernel/framework/sofa/defaulttype/DataTypeInfo.h
+++ b/SofaKernel/framework/sofa/defaulttype/DataTypeInfo.h
@@ -26,6 +26,7 @@
 #include <sofa/helper/fixed_array.h>
 #include <sofa/helper/vector.h>
 #include <sofa/helper/set.h>
+#include <sofa/helper/types/RGBAColor.h>
 #include <sstream>
 #include <typeinfo>
 #include <sofa/helper/logging/Messaging.h>
@@ -1289,6 +1290,11 @@ struct DataTypeInfo< std::set<T,Compare,Alloc> > : public SetTypeInfo<std::set<T
     static std::string name() { std::ostringstream o; o << "std::set<" << DataTypeName<T>::name() << ">"; return o.str(); }
 };
 
+template<>
+struct DataTypeInfo< sofa::helper::types::RGBAColor > : public FixedArrayTypeInfo<sofa::helper::fixed_array<float,4>>
+{
+    static std::string name() { return "RGBAColor"; }
+};
 
 } // namespace defaulttype
 

--- a/SofaKernel/framework/sofa/helper/types/RGBAColor.h
+++ b/SofaKernel/framework/sofa/helper/types/RGBAColor.h
@@ -37,6 +37,8 @@ namespace helper
 namespace types
 {
 
+using sofa::helper::fixed_array ;
+
 #define RGBACOLOR_EQUALITY_THRESHOLD 1e-6
 
 /**

--- a/SofaKernel/framework/sofa/simulation/DefaultVisualManagerLoop.cpp
+++ b/SofaKernel/framework/sofa/simulation/DefaultVisualManagerLoop.cpp
@@ -80,18 +80,6 @@ void DefaultVisualManagerLoop::updateStep(sofa::core::ExecParams* params)
 #endif
     sofa::helper::AdvancedTimer::begin("UpdateVisual");
 
-    // 03/09/14: mapping update should already be performed by animation
-//    sofa::helper::AdvancedTimer::stepBegin("UpdateMapping");
-//    gRoot->execute<UpdateMappingVisitor>(params);
-//    sofa::helper::AdvancedTimer::step("UpdateMappingEndEvent");
-//    {
-//        SReal dt=gRoot->getDt();
-//        UpdateMappingEndEvent ev ( dt );
-//        PropagateEventVisitor act ( params, &ev );
-//        gRoot->execute ( act );
-//    }
-//    sofa::helper::AdvancedTimer::stepEnd("UpdateMapping");
-
     gRoot->execute<VisualUpdateVisitor>(params);
     sofa::helper::AdvancedTimer::end("UpdateVisual");
 #ifdef SOFA_DUMP_VISITOR_INFO

--- a/SofaKernel/modules/SofaBaseVisual/BackgroundSetting.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/BackgroundSetting.cpp
@@ -1,0 +1,52 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <SofaBaseVisual/BackgroundSetting.h>
+#include <sofa/core/visual/VisualParams.h>
+#include <sofa/core/ObjectFactory.h>
+
+namespace sofa
+{
+
+namespace component
+{
+
+namespace configurationsetting
+{
+
+SOFA_DECL_CLASS(BackgroundSetting)
+int BackgroundSettingClass = core::RegisterObject("Backgrounds setting")
+        .add< BackgroundSetting >()
+        .addAlias("Background")
+        ;
+
+BackgroundSetting::BackgroundSetting():
+      color(initData(&color, "color", "Color of the background"))
+    , image(initData(&image, "image", "Image to be used as background"))
+{
+}
+
+}
+
+}
+
+}

--- a/SofaKernel/modules/SofaBaseVisual/BackgroundSetting.h
+++ b/SofaKernel/modules/SofaBaseVisual/BackgroundSetting.h
@@ -38,14 +38,16 @@ namespace configurationsetting
 {
 
 ///Class for the configuration of background settings.
-class SOFA_GRAPH_COMPONENT_API BackgroundSetting: public core::objectmodel::ConfigurationSetting
+class SOFA_BASE_VISUAL_API BackgroundSetting: public core::objectmodel::ConfigurationSetting
 {
 public:
     SOFA_CLASS(BackgroundSetting,core::objectmodel::ConfigurationSetting);  ///< Sofa macro to define typedef.
+
 protected:
-    BackgroundSetting();    ///< Default constructor
+    BackgroundSetting();                                         ///< Default constructor
+
 public:
-    Data<defaulttype::RGBAColor> color;   ///< Color of the Background of the Viewer.
+    Data<defaulttype::RGBAColor> color;                          ///< Color of the Background of the Viewer.
     sofa::core::objectmodel::DataFileName image;                 ///< Image to be used as background of the viewer.
 
 };

--- a/SofaKernel/modules/SofaBaseVisual/BackgroundSetting.h
+++ b/SofaKernel/modules/SofaBaseVisual/BackgroundSetting.h
@@ -19,10 +19,14 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#ifndef SOFA_COMPONENT_CONFIGURATIONSETTING_BACKGROUND_H
+#define SOFA_COMPONENT_CONFIGURATIONSETTING_BACKGROUND_H
+#include "config.h"
 
-#include <SofaGraphComponent/BackgroundSetting.h>
-#include <sofa/core/visual/VisualParams.h>
-#include <sofa/core/ObjectFactory.h>
+#include <sofa/core/objectmodel/ConfigurationSetting.h>
+#include <sofa/core/objectmodel/DataFileName.h>
+#include <sofa/defaulttype/Vec.h>
+#include <sofa/defaulttype/RGBAColor.h>
 
 namespace sofa
 {
@@ -33,20 +37,22 @@ namespace component
 namespace configurationsetting
 {
 
-SOFA_DECL_CLASS(BackgroundSetting)
-int BackgroundSettingClass = core::RegisterObject("Background colour setting")
-        .add< BackgroundSetting >()
-        .addAlias("Background")
-        ;
-
-BackgroundSetting::BackgroundSetting():
-      color(initData(&color, "color", "Color of the Background of the Viewer"))
-    , image(initData(&image, "image", "Image to be used as background of the viewer"))
+///Class for the configuration of background settings.
+class SOFA_GRAPH_COMPONENT_API BackgroundSetting: public core::objectmodel::ConfigurationSetting
 {
-}
+public:
+    SOFA_CLASS(BackgroundSetting,core::objectmodel::ConfigurationSetting);  ///< Sofa macro to define typedef.
+protected:
+    BackgroundSetting();    ///< Default constructor
+public:
+    Data<defaulttype::RGBAColor> color;   ///< Color of the Background of the Viewer.
+    sofa::core::objectmodel::DataFileName image;                 ///< Image to be used as background of the viewer.
+
+};
 
 }
 
 }
 
 }
+#endif

--- a/SofaKernel/modules/SofaBaseVisual/BaseCamera.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/BaseCamera.cpp
@@ -834,8 +834,6 @@ void BaseCamera::handleEvent(sofa::core::objectmodel::Event* event)
 
 void BaseCamera::draw(const sofa::core::visual::VisualParams* params)
 {
-    params->drawTool()->drawPoint( p_position.getValue(), RGBAColor::red() );
-    params->drawTool()->drawLine( p_position.getValue(), p_lookAt.getValue(), RGBAColor::red() );
 }
 
 

--- a/SofaKernel/modules/SofaBaseVisual/BaseCamera.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/BaseCamera.cpp
@@ -62,6 +62,7 @@ BaseCamera::BaseCamera()
     ,p_fixedLookAtPoint(initData(&p_fixedLookAtPoint, false, "fixedLookAt", "keep the lookAt point always fixed"))
     ,p_modelViewMatrix(initData(&p_modelViewMatrix,  "modelViewMatrix", "ModelView Matrix"))
     ,p_projectionMatrix(initData(&p_projectionMatrix,  "projectionMatrix", "Projection Matrix"))
+    ,l_background(initLink("backgroundSetting", "Link pointing to a BackgroundSetting object set the background parameters for this camera."))
     ,b_setDefaultParameters(false)
 {
     this->f_listening.setValue(true);
@@ -89,7 +90,6 @@ BaseCamera::BaseCamera()
 
 BaseCamera::~BaseCamera()
 {
-
 }
 
 void BaseCamera::activate()
@@ -108,7 +108,7 @@ bool BaseCamera::isActivated()
 }
 
 void BaseCamera::init()
-{
+{    
     if(p_position.isSet())
     {
         if(!p_orientation.isSet())
@@ -153,8 +153,6 @@ void BaseCamera::init()
     currentDistance = p_distance.getValue();
     currentZNear = p_zNear.getValue();
     currentZFar = p_zFar.getValue();
-    std::cout << currentZNear << std::endl ;
-    std::cout << currentZFar << std::endl ;
 }
 
 void BaseCamera::reinit()

--- a/SofaKernel/modules/SofaBaseVisual/BaseCamera.h
+++ b/SofaKernel/modules/SofaBaseVisual/BaseCamera.h
@@ -194,7 +194,7 @@ public:
     Vec3 getLookAtFromOrientation(const Vec3 &pos, const double &distance,const Quat & orientation);
     Vec3 getPositionFromOrientation(const Vec3 &lookAt, const double &distance, const Quat& orientation);
 
-    virtual void manageEvent(core::objectmodel::Event* e)=0;
+    virtual void manageEvent(core::objectmodel::Event* event) = 0 ;
     virtual void internalUpdate() {}
 
     void handleEvent(sofa::core::objectmodel::Event* event) override;
@@ -244,6 +244,8 @@ public:
     {
         return 1.0;
     }
+
+    virtual void draw(const core::visual::VisualParams*) override ;
 
 protected:
     void updateOutputData();

--- a/SofaKernel/modules/SofaBaseVisual/BaseCamera.h
+++ b/SofaKernel/modules/SofaBaseVisual/BaseCamera.h
@@ -32,6 +32,8 @@
 #include <sofa/helper/system/config.h>
 #include <sofa/helper/OptionsGroup.h>
 
+#include "BackgroundSetting.h"
+
 namespace sofa
 {
 
@@ -94,6 +96,9 @@ public:
     
     Data<helper::vector<float> > p_modelViewMatrix; ///< ModelView Matrix
     Data<helper::vector<float> > p_projectionMatrix; ///< Projection Matrix
+
+    SingleLink<BaseCamera, sofa::component::configurationsetting::BackgroundSetting,
+               BaseLink::FLAG_STOREPATH> l_background ;
 
     BaseCamera();
     virtual ~BaseCamera();

--- a/SofaKernel/modules/SofaBaseVisual/CMakeLists.txt
+++ b/SofaKernel/modules/SofaBaseVisual/CMakeLists.txt
@@ -3,6 +3,7 @@ project(SofaBaseVisual)
 
 set(HEADER_FILES
     BaseCamera.h
+    BackgroundSetting.h
     Camera.h
     InteractiveCamera.h
     VisualModelImpl.h
@@ -13,6 +14,7 @@ set(HEADER_FILES
 
 set(SOURCE_FILES
     BaseCamera.cpp
+    BackgroundSetting.cpp
     Camera.cpp
     InteractiveCamera.cpp
     VisualModelImpl.cpp

--- a/SofaKernel/modules/SofaBaseVisual/CMakeLists.txt
+++ b/SofaKernel/modules/SofaBaseVisual/CMakeLists.txt
@@ -3,6 +3,7 @@ project(SofaBaseVisual)
 
 set(HEADER_FILES
     BaseCamera.h
+    Camera.h
     InteractiveCamera.h
     VisualModelImpl.h
     VisualStyle.h
@@ -12,6 +13,7 @@ set(HEADER_FILES
 
 set(SOURCE_FILES
     BaseCamera.cpp
+    Camera.cpp
     InteractiveCamera.cpp
     VisualModelImpl.cpp
     VisualStyle.cpp

--- a/SofaKernel/modules/SofaBaseVisual/Camera.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/Camera.cpp
@@ -1,0 +1,52 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/core/ObjectFactory.h>
+#include <SofaBaseVisual/Camera.h>
+
+namespace sofa
+{
+
+namespace component
+{
+
+namespace visualmodel
+{
+
+SOFA_DECL_CLASS(Camera)
+
+int CameraClass = core::RegisterObject("A Camera that render the scene from a given location & orientation.")
+                    .add<Camera>() ;
+
+Camera::Camera()
+{
+    p_computeZClip.setValue(false) ;
+}
+
+Camera::~Camera()
+{
+}
+
+} // namespace visualmodel
+
+} // namespace component
+
+} // namespace sofa

--- a/SofaKernel/modules/SofaBaseVisual/Camera.h
+++ b/SofaKernel/modules/SofaBaseVisual/Camera.h
@@ -1,0 +1,59 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#ifndef SOFA_COMPONENT_VISUALMODEL_CAMERA_H
+#define SOFA_COMPONENT_VISUALMODEL_CAMERA_H
+#include "config.h"
+
+#include <SofaBaseVisual/BaseCamera.h>
+
+namespace sofa
+{
+
+namespace component
+{
+
+namespace visualmodel
+{
+
+class SOFA_BASE_VISUAL_API Camera : public BaseCamera
+{
+public:
+    SOFA_CLASS(Camera, BaseCamera);
+
+protected:
+    Camera();
+    virtual ~Camera();
+
+public:
+    virtual void manageEvent(core::objectmodel::Event* e) override { SOFA_UNUSED(e); }
+
+private:
+
+};
+
+} // namespace visualmodel
+
+} // namespace component
+
+} // namespace sofa
+
+#endif // SOFA_COMPONENT_VISUALMODEL_CAMERA_H

--- a/SofaKernel/modules/SofaBaseVisual/InteractiveCamera.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/InteractiveCamera.cpp
@@ -36,7 +36,6 @@ SOFA_DECL_CLASS(InteractiveCamera)
 
 int InteractiveCameraClass = core::RegisterObject("InteractiveCamera")
         .add< InteractiveCamera >()
-        .addAlias("Camera")
         ;
 
 
@@ -47,7 +46,7 @@ InteractiveCamera::InteractiveCamera()
     ,currentMode(InteractiveCamera::NONE_MODE)
     ,isMoving(false)
     {
-}
+    }
 
 InteractiveCamera::~InteractiveCamera()
 {

--- a/examples/Demos/caduceus.scn
+++ b/examples/Demos/caduceus.scn
@@ -7,7 +7,7 @@
     <CollisionPipeline depth="15" verbose="0" draw="0" />
     <BruteForceDetection name="N2" />
     <MinProximityIntersection name="Proximity" alarmDistance="1.5" contactDistance="1" />
-    <InteractiveCamera position="0 30 90" lookAt="0 30 0"/>
+    <Camera position="0 30 90" lookAt="0 30 0"/>
     <LightManager />
     <SpotLight name="light1" color="1 1 1" position="0 80 25" direction="0 -1 -0.8" cutoff="30" exponent="1" />
     <SpotLight name="light2" color="1 1 1" position="0 40 100" direction="0 0 -1" cutoff="30" exponent="1" />

--- a/modules/SofaGraphComponent/BackgroundSetting.h
+++ b/modules/SofaGraphComponent/BackgroundSetting.h
@@ -19,40 +19,18 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_COMPONENT_CONFIGURATIONSETTING_BACKGROUND_H
-#define SOFA_COMPONENT_CONFIGURATIONSETTING_BACKGROUND_H
-#include "config.h"
+#ifndef SOFA_GRAPH_COMPONENT_BACKGROUNDSETTING_H
+#define SOFA_GRAPH_COMPONENT_BACKGROUNDSETTING_H
 
-#include <sofa/core/objectmodel/ConfigurationSetting.h>
-#include <sofa/core/objectmodel/DataFileName.h>
-#include <sofa/defaulttype/Vec.h>
-#include <sofa/defaulttype/RGBAColor.h>
+#include <SofaBaseVisual/BackgroundSetting.h>
 
 namespace sofa
 {
-
-namespace component
+namespace defaulttype
 {
+    using sofa::component::configurationsetting::BackgroundSetting ;
+} // namespace defaulttype
+} // namespace sofa
 
-namespace configurationsetting
-{
 
-///Class for the configuration of background settings.
-class SOFA_GRAPH_COMPONENT_API BackgroundSetting: public core::objectmodel::ConfigurationSetting
-{
-public:
-    SOFA_CLASS(BackgroundSetting,core::objectmodel::ConfigurationSetting);  ///< Sofa macro to define typedef.
-protected:
-    BackgroundSetting();    ///< Default constructor
-public:
-    Data<defaulttype::RGBAColor> color;   ///< Color of the Background of the Viewer.
-    sofa::core::objectmodel::DataFileName image;                 ///< Image to be used as background of the viewer.
-
-};
-
-}
-
-}
-
-}
 #endif

--- a/modules/SofaGraphComponent/CMakeLists.txt
+++ b/modules/SofaGraphComponent/CMakeLists.txt
@@ -14,7 +14,6 @@ list(APPEND HEADER_FILES
     AddFrameButtonSetting.h
     AddRecordedCameraButtonSetting.h
     AttachBodyButtonSetting.h
-    BackgroundSetting.h
     FixPickedParticleButtonSetting.h
     Gravity.h
     InteractingBehaviorModel.h
@@ -34,7 +33,6 @@ list(APPEND SOURCE_FILES
     AddFrameButtonSetting.cpp
     AddRecordedCameraButtonSetting.cpp
     AttachBodyButtonSetting.cpp
-    BackgroundSetting.cpp
     FixPickedParticleButtonSetting.cpp
     Gravity.cpp
     MouseButtonSetting.cpp

--- a/modules/SofaOpenglVisual/Light.cpp
+++ b/modules/SofaOpenglVisual/Light.cpp
@@ -141,59 +141,59 @@ void Light::init()
     if(!d_shadowsEnabled.getValue() && d_softShadows.getValue()){
         if(d_softShadows.isSet() && d_shadowsEnabled.isSet()){
             msg_warning() << "Soft shadow is specified but 'shadowEnable' is set to false. " << msgendl
-                                 "To remove this warning message you need to synchronize the softShadow & shadowEnable parameters." << msgendl ;
+                             "To remove this warning message you need to synchronize the softShadow & shadowEnable parameters." << msgendl ;
         }
     }
 
     if(!d_shadowsEnabled.getValue()){
         if( d_shadowTextureSize.isSet() ){
             msg_warning() << "Shadow is not enabled. The 'shadowTextureSize' parameter is not used but has been set." << msgendl
-                                 "To remove this warning message you can:" << msgendl
-                                 " - set the 'shadowEnabled' parameter to true." << msgendl
-                                 " - unset the 'shadowTextureSize' values.";
+                             "To remove this warning message you can:" << msgendl
+                             " - set the 'shadowEnabled' parameter to true." << msgendl
+                             " - unset the 'shadowTextureSize' values.";
         }
 
         if( d_shadowFactor.isSet() ){
             msg_warning() << "Shadow is not enabled. The 'shadowFactor' parameter is not used but has been set." << msgendl
-                                 "To remove this warning message you can:" << msgendl
-                                 " - set the 'shadowEnabled' parameter to true." << msgendl
-                                 " - unset the 'shadowFactor' values.";
+                             "To remove this warning message you can:" << msgendl
+                             " - set the 'shadowEnabled' parameter to true." << msgendl
+                             " - unset the 'shadowFactor' values.";
         }
 
         if( d_textureUnit.isSet() ){
             msg_warning() << "Shadow is not enabled. The 'textureUnit' parameter is not used but has been set." << msgendl
-                                 "To remove this warning message you can:" << msgendl
-                                 " - set the 'shadowEnabled' parameter to true." << msgendl
-                                 " - unset the 'textureUnit' values.";
+                             "To remove this warning message you can:" << msgendl
+                             " - set the 'shadowEnabled' parameter to true." << msgendl
+                             " - unset the 'textureUnit' values.";
         }
 
         if( d_zNear.isSet() ){
             msg_warning() << "Shadow is not enabled. The 'zNear' parameter is not used but has been set." << msgendl
-                                 "To remove this warning message you can:" << msgendl
-                                 " - set the 'shadowEnabled' parameter to true." << msgendl
-                                 " - unset the 'zNear' values.";
+                             "To remove this warning message you can:" << msgendl
+                             " - set the 'shadowEnabled' parameter to true." << msgendl
+                             " - unset the 'zNear' values.";
         }
 
         if( d_zFar.isSet() ){
             msg_warning() << "Shadow is not enabled. The 'zFar' parameter is not used but has been set." << msgendl
-                                 "To remove this warning message you can:" << msgendl
-                                 " - set the 'shadowEnabled' parameter to true." << msgendl
-                                 " - unset the 'zFar' values.";
+                             "To remove this warning message you can:" << msgendl
+                             " - set the 'shadowEnabled' parameter to true." << msgendl
+                             " - unset the 'zFar' values.";
         }
     }
 
     if(!d_softShadows.getValue()){
         if( d_VSMLightBleeding.isSet() ){
             msg_warning() << "Soft shadow is not enabled. The 'VSMLightBleeding' parameter is not used but has been set." << msgendl
-                                 "To remove this warning message you can:" << msgendl
-                                 " - set the 'softShadows' parameter to true." << msgendl
-                                 " - unset the 'VSMLightBleeding' values.";
+                             "To remove this warning message you can:" << msgendl
+                             " - set the 'softShadows' parameter to true." << msgendl
+                             " - unset the 'VSMLightBleeding' values.";
         }
         if( d_VSMMinVariance.isSet() ){
             msg_warning() << "Soft shadow is not enabled. The 'VSMMinVariance' parameter is not used but has been set." << msgendl
-                                 "To remove this warning message you can:" << msgendl
-                                 " - set the 'softShadows' parameter to true." << msgendl
-                                 " - unset the 'VMSMinVariance' values.";
+                             "To remove this warning message you can:" << msgendl
+                             " - set the 'softShadows' parameter to true." << msgendl
+                             " - unset the 'VMSMinVariance' values.";
         }
     }
 
@@ -454,8 +454,13 @@ void DirectionalLight::drawLight()
 
 void DirectionalLight::draw(const core::visual::VisualParams* )
 {
-
 }
+
+void DirectionalLight::drawSource(const core::visual::VisualParams* vparams)
+{
+    SOFA_UNUSED(vparams);
+}
+
 void DirectionalLight::computeOpenGLModelViewMatrix(GLfloat mat[16], const sofa::defaulttype::Vector3 &direction)
 {
     //1-compute bounding box
@@ -672,28 +677,33 @@ void PositionalLight::drawLight()
 
 }
 
+void PositionalLight::drawSource(const core::visual::VisualParams* vparams)
+{
+    Vector3 sceneMinBBox, sceneMaxBBox;
+    sofa::simulation::getSimulation()->computeBBox((sofa::simulation::Node*)this->getContext(), sceneMinBBox.ptr(), sceneMaxBBox.ptr());
+    float scale = (float)((sceneMaxBBox - sceneMinBBox).norm());
+    scale *= 0.01f;
+
+    GLUquadric* quad = gluNewQuadric();
+    const Vector3& pos = d_position.getValue();
+    const auto& col = d_color.getValue();
+
+    glDisable(GL_LIGHTING);
+    glColor3fv((float*)col.data());
+
+    glPushMatrix();
+    glTranslated(pos[0], pos[1], pos[2]);
+    gluSphere(quad, 1.0f*scale, 16, 16);
+    glPopMatrix();
+
+    glEnable(GL_LIGHTING);
+}
+
 void PositionalLight::draw(const core::visual::VisualParams* vparams)
 {
     if (d_drawSource.getValue() && vparams->displayFlags().getShowVisualModels())
     {
-        Vector3 sceneMinBBox, sceneMaxBBox;
-        sofa::simulation::getSimulation()->computeBBox((sofa::simulation::Node*)this->getContext(), sceneMinBBox.ptr(), sceneMaxBBox.ptr());
-        float scale = (float)((sceneMaxBBox - sceneMinBBox).norm());
-        scale *= 0.01f;
-
-        GLUquadric* quad = gluNewQuadric();
-        const Vector3& pos = d_position.getValue();
-        const auto& col = d_color.getValue();
-
-        glDisable(GL_LIGHTING);
-        glColor3fv((float*)col.data());
-
-        glPushMatrix();
-        glTranslated(pos[0], pos[1], pos[2]);
-        gluSphere(quad, 1.0f*scale, 16, 16);
-        glPopMatrix();
-
-        glEnable(GL_LIGHTING);
+        drawSource(vparams) ;
     }
 }
 
@@ -734,8 +744,43 @@ void SpotLight::drawLight()
         glPopMatrix();
         glMatrixMode(GL_MODELVIEW);
     }
-
 }
+
+void SpotLight::drawSource(const core::visual::VisualParams* vparams)
+{
+    float zNear, zFar;
+
+    computeClippingPlane(vparams, zNear, zFar);
+
+    Vector3 dir = d_direction.getValue();
+    if (d_lookat.getValue())
+        dir -= d_position.getValue();
+
+    computeOpenGLProjectionMatrix(m_lightMatProj, m_shadowTexWidth, m_shadowTexHeight, 2 * d_cutoff.getValue(), zNear, zFar);
+    computeOpenGLModelViewMatrix(m_lightMatModelview, d_position.getValue(), dir);
+
+    float baseLength = zFar * tanf(this->d_cutoff.getValue() * M_PI / 180);
+    float tipLength = (baseLength*0.5) * (zNear/ zFar);
+
+    Vector3 direction;
+    if(d_lookat.getValue())
+        direction = this->d_direction.getValue() - this->d_position.getValue();
+    else
+        direction = this->d_direction.getValue();
+
+    direction.normalize();
+    Vector3 base = this->getPosition() + direction*zFar;
+    Vector3 tip = this->getPosition() + direction*zNear;
+    std::vector<Vector3> centers;
+    centers.push_back(this->getPosition());
+    vparams->drawTool()->setPolygonMode(0, true);
+    vparams->drawTool()->setLightingEnabled(false);
+    vparams->drawTool()->drawSpheres(centers, zNear*0.1,d_color.getValue());
+    vparams->drawTool()->drawCone(base, tip, baseLength, tipLength, d_color.getValue());
+    vparams->drawTool()->setLightingEnabled(true);
+    vparams->drawTool()->setPolygonMode(0, false);
+}
+
 
 void SpotLight::draw(const core::visual::VisualParams* vparams)
 {
@@ -752,26 +797,7 @@ void SpotLight::draw(const core::visual::VisualParams* vparams)
 
     if (d_drawSource.getValue() && vparams->displayFlags().getShowVisualModels())
     {
-        float baseLength = zFar * tanf(this->d_cutoff.getValue() * M_PI / 180);
-        float tipLength = (baseLength*0.5) * (zNear/ zFar);
-
-        Vector3 direction;
-        if(d_lookat.getValue())
-            direction = this->d_direction.getValue() - this->d_position.getValue();
-        else
-            direction = this->d_direction.getValue();
-
-        direction.normalize();
-        Vector3 base = this->getPosition() + direction*zFar;
-        Vector3 tip = this->getPosition() + direction*zNear;
-        std::vector<Vector3> centers;
-        centers.push_back(this->getPosition());
-        vparams->drawTool()->setPolygonMode(0, true);
-        vparams->drawTool()->setLightingEnabled(false);
-        vparams->drawTool()->drawSpheres(centers, zNear*0.1,d_color.getValue());
-        vparams->drawTool()->drawCone(base, tip, baseLength, tipLength, d_color.getValue());
-        vparams->drawTool()->setLightingEnabled(true);
-        vparams->drawTool()->setPolygonMode(0, false);
+        drawSource(vparams) ;
     }
 }
 

--- a/modules/SofaOpenglVisual/Light.h
+++ b/modules/SofaOpenglVisual/Light.h
@@ -110,6 +110,9 @@ public:
     virtual void reinit() override;
     virtual void updateVisual() override;
 
+    /// Draw the light source from an external point of view.
+    virtual void drawSource(const sofa::core::visual::VisualParams*) = 0;
+
     GLfloat getZNear();
     GLfloat getZFar();
 
@@ -147,6 +150,7 @@ public:
     virtual void preDrawShadow(core::visual::VisualParams* vp) override;
     virtual void drawLight() override;
     virtual void draw(const core::visual::VisualParams* vparams) override;
+    virtual void drawSource(const core::visual::VisualParams* vparams) override;
     virtual GLuint getDepthTexture() override;
     virtual GLuint getColorTexture() override;
     virtual defaulttype::Vector3 getDirection() override { return d_direction.getValue(); }
@@ -171,6 +175,7 @@ public:
     virtual ~PositionalLight();
     virtual void drawLight() override;
     virtual void draw(const core::visual::VisualParams* vparams) override;
+    virtual void drawSource(const core::visual::VisualParams* vparams) override;
     virtual const sofa::defaulttype::Vector3 getPosition() override { return d_position.getValue(); }
     LightType getLightType() override { return LightType::POSITIONAL; }
 };
@@ -189,6 +194,7 @@ public:
     virtual ~SpotLight();
     virtual void drawLight() override;
     virtual void draw(const core::visual::VisualParams* vparams) override;
+    virtual void drawSource(const core::visual::VisualParams* vparams) override;
 
     void preDrawShadow(core::visual::VisualParams*  vp) override;
     GLuint getDepthTexture() override;


### PR DESCRIPTION
To prepare for runSofa2 i feel the need to refactor some aspects. 

CHANGELOG:
- ADD a Camera object inheriting from BaseCamera so that it become possible to render a scene. The difference with InteractionCamera is that the Camera component is not having any interaction so you can implement your own 'application specific behavior' by using an external Controller (eg: PythonScriptController).
- ADD a link in  BaseCamera to a BackgroundSetting so different camera can have different background. 
- the Camera alias is not anymore creating an InteractionCamera but a Camera object
- Update the caduceus example.
- Light object now have a drawSource so that it is possible to draw the source from without having to change the d_drawSource data field.
 
This PR replace #674 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
