### PR TITLE
[applications] FIX Install files that were ignored by the `make install` command

### DIFF
--- a/applications/packages/SofaAllCommonComponents/CMakeLists.txt
+++ b/applications/packages/SofaAllCommonComponents/CMakeLists.txt
@@ -25,4 +25,4 @@ set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${HEADER_FILES}"
 #include_directories("${CMAKE_CURRENT_SOURCE_DIR}/..")
 
 ## Install rules for the library and headers; CMake package configurations files
-#sofa_create_package(SofaAllCommonComponents ${SOFAALLCOMMONCOMPONENTS_VERSION} ${PROJECT_NAME} SofaAllCommonComponents)
+sofa_create_package(SofaAllCommonComponents ${SOFAALLCOMMONCOMPONENTS_VERSION} ${PROJECT_NAME} SofaAllCommonComponents)

--- a/applications/plugins/Geomagic/CMakeLists.txt
+++ b/applications/plugins/Geomagic/CMakeLists.txt
@@ -31,3 +31,9 @@ target_link_libraries(${PROJECT_NAME} SofaHelper SofaUserInteraction ${OPENHAPTI
 if(NOT ${SOFA_NO_OPENGL})
     target_link_libraries(${PROJECT_NAME} SofaOpenglVisual)
 endif()
+
+install(TARGETS ${PROJECT_NAME}
+        COMPONENT ${PROJECT_NAME}
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)

--- a/applications/projects/runSofa/CMakeLists.txt
+++ b/applications/projects/runSofa/CMakeLists.txt
@@ -3,7 +3,7 @@ project(runSofa)
 
 option(RUNSOFA_INSTALL_AS_BUNDLE "Create a bundle containing all the installation files (Only Mac OS X for now)" OFF)
 
-set(RESSOURCE_FILES
+set(RESOURCE_FILES
     resources/docs/runsofa.html
     )
 
@@ -62,6 +62,6 @@ else()
 endif()
 
 # if MSVC then plugins are located in bin/ instead of lib/ on Mac and Linux
-file(INSTALL "resources" DESTINATION "../../../share/sofa/gui/runSofa")
+install(DIRECTORY "resources" DESTINATION "share/sofa/gui/runSofa")
 install(FILES "${_defaultConfigPluginFilePath}" DESTINATION ${_pluginLocation}/)
 

--- a/applications/sofa/gui/qt/CMakeLists.txt
+++ b/applications/sofa/gui/qt/CMakeLists.txt
@@ -205,6 +205,6 @@ set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-DSOFA_BUILD_SOF
 
 sofa_install_targets(SofaGui SofaGuiQt "")
 
-file(INSTALL "resources" DESTINATION "../../share/sofa/gui/qt")
+install(DIRECTORY "resources" DESTINATION "share/sofa/gui/qt")
 install(FILES ${HEADER_FILES} DESTINATION "include/sofa/gui/qt")
 install(FILES ${MOC_HEADER_FILES} DESTINATION "include/sofa/gui/qt")


### PR DESCRIPTION
This removes warnings that appear when running runSofa from a directory where it was installed from source. This should not affect compilation in any way (but not sure how it would affect packaging Sofa).






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
