### PR TITLE
[CMake] use ccache if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,7 +236,7 @@ if(SOFA_USE_CCACHE)
         set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${CCACHE_PROGRAM}")
     else()
         message(WARNING "ccache not found, disabling option")
-        set(SOFA_USE_CCACHE OFF)
+        set(SOFA_USE_CCACHE OFF CACHE bool FORCE)
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,7 +236,7 @@ if(SOFA_USE_CCACHE)
         set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${CCACHE_PROGRAM}")
     else()
         message(WARNING "ccache not found, disabling option")
-        set(SOFA_USE_CCACHE OFF CACHE bool FORCE)
+        set(SOFA_USE_CCACHE OFF CACHE bool "Compile using ccache optimization" FORCE)
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 project(Sofa)
 
-find_program(CCACHE_PROGRAM ccache)
-if(CCACHE_PROGRAM)
-    # Support Unix Makefiles and Ninja
-    #TODO replace by <LANG>_COMPILER_LAUNCHER when min cmake version > 3.4
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
-endif()
-
 set(SOFA_KERNEL_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/SofaKernel" CACHE STRING "Path to SofaKernel")
 
 if(NOT EXISTS ${SOFA_KERNEL_SOURCE_DIR}/framework)
@@ -230,6 +223,21 @@ if(SOFA_BUILD_TESTS)
     # Enable testing features of cmake, like the add_test() command.
     enable_testing()
     add_subdirectory(extlibs/gtest)
+endif()
+
+## Active or not the use of ccache
+option(SOFA_USE_CCACHE "Compile using ccache optimization" OFF)
+if(SOFA_USE_CCACHE)
+    find_program(CCACHE_PROGRAM ccache)
+    if(CCACHE_PROGRAM)
+        # Support Unix Makefiles and Ninja
+        #TODO replace by <LANG>_COMPILER_LAUNCHER when min cmake version > 3.4
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${CCACHE_PROGRAM}")
+    else()
+        message(WARNING "ccache not found, disabling option")
+        set(SOFA_USE_CCACHE OFF)
+    endif()
 endif()
 
 ### Ninja build pools

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 3.1)
 project(Sofa)
 
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    # Support Unix Makefiles and Ninja
+    #TODO replace by <LANG>_COMPILER_LAUNCHER when min cmake version > 3.4
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif()
+
 set(SOFA_KERNEL_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/SofaKernel" CACHE STRING "Path to SofaKernel")
 
 if(NOT EXISTS ${SOFA_KERNEL_SOURCE_DIR}/framework)


### PR DESCRIPTION
This PR makes so that the user can activate an option to look for and use CCACHE for compilation.
If the option is activated, then CMake looks for ccache. If ccache is found, it is used for compilation.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
