### PR TITLE
[CImgPlugin] CMake/Mac: lower priority for XCode's libpng

### DIFF
--- a/applications/plugins/CImgPlugin/CMakeLists.txt
+++ b/applications/plugins/CImgPlugin/CMakeLists.txt
@@ -22,6 +22,10 @@ add_subdirectory(extlibs/CImg extlibs/CImg)
 find_package(CImg REQUIRED)
 find_package(SofaFramework REQUIRED)
 
+# OS X only: if the user installed its own JPEG/PNG lib (typically with homebrew/port),
+# it will allow to use those instead of those present in XCode's frameworks
+set(CMAKE_FIND_FRAMEWORK LAST)
+
 find_package(JPEG QUIET)
 find_package(TIFF QUIET)
 find_package(PNG QUIET)


### PR DESCRIPTION
This commit adds a directive to instruct CMake to find/use XCode's framework lastly.
E.g if you have installed libpng with homebrew/macport, CMake will use those first instead of the Apple's (old) ones.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
