### PR TITLE
[Topology Test][Mass] Fix some recent compilation warnings

### DIFF
--- a/SofaKernel/framework/sofa/helper/io/MeshTopologyLoader.cpp
+++ b/SofaKernel/framework/sofa/helper/io/MeshTopologyLoader.cpp
@@ -56,22 +56,22 @@ bool MeshTopologyLoader::addMeshtoTopology()
     const sofa::helper::vector< Topology::Tetrahedron > & tetra = m_mesh->getTetrahedra();
     const sofa::helper::vector< Topology::Hexahedron > & hexa = m_mesh->getHexahedra();
 
-    for (int i = 0; i < vertices.size(); ++i)
+    for (size_t i = 0; i < vertices.size(); ++i)
         addPoint(vertices[i][0], vertices[i][1], vertices[i][2]);
 
-    for (int i = 0; i < edges.size(); ++i)
+    for (size_t i = 0; i < edges.size(); ++i)
         addLine(edges[i][0], edges[i][1]);
 
-    for (int i = 0; i < triangles.size(); ++i)
+    for (size_t i = 0; i < triangles.size(); ++i)
         addTriangle(triangles[i][0], triangles[i][1], triangles[i][2]);
 
-    for (int i = 0; i < quads.size(); ++i)
+    for (size_t i = 0; i < quads.size(); ++i)
         addQuad(quads[i][0], quads[i][1], quads[i][2], quads[i][3]);
 
-    for (int i = 0; i < tetra.size(); ++i)
+    for (size_t i = 0; i < tetra.size(); ++i)
         addTetra(tetra[i][0], tetra[i][1], tetra[i][2], tetra[i][3]);
 
-    for (int i = 0; i < hexa.size(); ++i)
+    for (size_t i = 0; i < hexa.size(); ++i)
         addCube(hexa[i][0], hexa[i][1], hexa[i][2], hexa[i][3],
             hexa[i][4], hexa[i][5], hexa[i][6], hexa[i][7]);
 

--- a/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.h
+++ b/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.h
@@ -240,7 +240,7 @@ public:
     virtual void init() override;
     virtual void handleEvent(sofa::core::objectmodel::Event* ) override;
 
-    void update();
+    bool update();
 
     TopologyType getMassTopologyType() const
     {

--- a/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.inl
@@ -763,6 +763,9 @@ void DiagonalMass<DataTypes, MassType>::massInitialization()
 template <class DataTypes, class MassType>
 void DiagonalMass<DataTypes, MassType>::printMass()
 {
+    if (this->f_printLog.getValue() == false)
+        return;
+
     const MassVector &vertexM = d_vertexMass.getValue();
 
     Real average_vertex = 0.0;
@@ -1183,7 +1186,7 @@ const typename DiagonalMass<DataTypes, MassType>::Real &DiagonalMass<DataTypes, 
 
 
 template <class DataTypes, class MassType>
-void DiagonalMass<DataTypes, MassType>::update()
+bool DiagonalMass<DataTypes, MassType>::update()
 {
     bool update = false;
 
@@ -1221,6 +1224,8 @@ void DiagonalMass<DataTypes, MassType>::update()
         msg_info() << "mass information updated";
         printMass();
     }
+
+    return update;
 }
 
 

--- a/SofaKernel/modules/SofaBaseMechanics/UniformMass.h
+++ b/SofaKernel/modules/SofaBaseMechanics/UniformMass.h
@@ -121,7 +121,7 @@ public:
     void reinit() override;
     void init() override;
     void initDefaultImpl() ;
-    void update();
+    bool update();
     virtual void handleEvent(sofa::core::objectmodel::Event */*event*/) override;
 
     /// @name Check and standard initialization functions from mass information

--- a/SofaKernel/modules/SofaBaseMechanics/UniformMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/UniformMass.inl
@@ -250,7 +250,7 @@ void UniformMass<DataTypes, MassType>::reinit()
 
 
 template <class DataTypes, class MassType>
-void UniformMass<DataTypes, MassType>::update()
+bool UniformMass<DataTypes, MassType>::update()
 {
     bool update = false;
 
@@ -276,6 +276,8 @@ void UniformMass<DataTypes, MassType>::update()
     //Info post-reinit
     msg_info() << "totalMass  = " << d_totalMass.getValue() << " \n"
                   "vertexMass = " << d_vertexMass.getValue();
+
+    return update;
 }
 
 

--- a/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/EdgeSetTopology_test.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/EdgeSetTopology_test.cpp
@@ -149,9 +149,9 @@ bool EdgeSetTopology_test::testVertexBuffers()
     EXPECT_EQ(edgeAroundVertices.size(), nbrVertex);
     const EdgeSetTopologyContainer::EdgesAroundVertex& edgeAVertex = edgeAroundVertices[0];
     const EdgeSetTopologyContainer::EdgesAroundVertex& edgeAVertexM = topoCon->getEdgesAroundVertex(0);
-
+    
     EXPECT_EQ(edgeAVertex.size(), edgeAVertexM.size());
-    for (int i = 0; i < edgeAVertex.size(); i++)
+    for (size_t i = 0; i < edgeAVertex.size(); i++)
         EXPECT_EQ(edgeAVertex[i], edgeAVertexM[i]);
 
     // check EdgesAroundVertex buffer element for this file    

--- a/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/HexahedronSetTopology_test.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/HexahedronSetTopology_test.cpp
@@ -181,7 +181,7 @@ bool HexahedronSetTopology_test::testQuadBuffers()
     const HexahedronSetTopologyContainer::HexahedraAroundQuad& elemAQuadM = topoCon->getHexahedraAroundQuad(3);
 
     EXPECT_EQ(elemAQuad.size(), elemAQuadM.size());
-    for (int i = 0; i < elemAQuad.size(); i++)
+    for (size_t i = 0; i < elemAQuad.size(); i++)
         EXPECT_EQ(elemAQuad[i], elemAQuadM[i]);
 
     // check HexahedraAroundQuad buffer element for this file
@@ -197,32 +197,32 @@ bool HexahedronSetTopology_test::testQuadBuffers()
     const HexahedronSetTopologyContainer::QuadsInHexahedron& quadInElemM = topoCon->getQuadsInHexahedron(1);
 
     EXPECT_EQ(quadInElem.size(), quadInElemM.size());
-    for (int i = 0; i < quadInElem.size(); i++)
+    for (size_t i = 0; i < quadInElem.size(); i++)
         EXPECT_EQ(quadInElem[i], quadInElemM[i]);
 
     sofa::helper::fixed_array<int, 6> quadInElemTruth(6, 7, 8, 9, 10, 3);
-    for (int i = 0; i<quadInElemTruth.size(); ++i)
+    for (size_t i = 0; i<quadInElemTruth.size(); ++i)
         EXPECT_EQ(quadInElem[i], quadInElemTruth[i]);
 
 
     // Check Quad Index in Hexahedron
-    for (int i = 0; i<quadInElemTruth.size(); ++i)
+    for (size_t i = 0; i<quadInElemTruth.size(); ++i)
         EXPECT_EQ(topoCon->getQuadIndexInHexahedron(quadInElem, quadInElemTruth[i]), i);
 
     int quadId = topoCon->getQuadIndexInHexahedron(quadInElem, 20000);
     EXPECT_EQ(quadId, -1);
 
     // check link between HexahedraAroundQuad and QuadsInHexahedron
-    for (int i = 0; i < 4; ++i)
+    for (unsigned int i = 0; i < 4; ++i)
     {
         HexahedronSetTopologyContainer::QuadID quadId = i;
         const HexahedronSetTopologyContainer::HexahedraAroundQuad& _elemAQuad = elemAroundQuads[quadId];
-        for (int j = 0; j < _elemAQuad.size(); ++j)
+        for (size_t j = 0; j < _elemAQuad.size(); ++j)
         {
             HexahedronSetTopologyContainer::HexahedronID triId = _elemAQuad[j];
             const HexahedronSetTopologyContainer::QuadsInHexahedron& _quadInElem = quadInHexahedra[triId];
             bool found = false;
-            for (int k = 0; k < _quadInElem.size(); ++k)
+            for (size_t k = 0; k < _quadInElem.size(); ++k)
             {
                 if (_quadInElem[k] == quadId)
                 {
@@ -276,7 +276,7 @@ bool HexahedronSetTopology_test::testEdgeBuffers()
     const HexahedronSetTopologyContainer::HexahedraAroundEdge& elemAEdgeM = topoCon->getHexahedraAroundEdge(13);
 
     EXPECT_EQ(elemAEdge.size(), elemAEdgeM.size());
-    for (int i = 0; i < elemAEdge.size(); i++)
+    for (size_t i = 0; i < elemAEdge.size(); i++)
         EXPECT_EQ(elemAEdge[i], elemAEdgeM[i]);
 
     // check HexahedronAroundEdge buffer element for this file
@@ -292,16 +292,16 @@ bool HexahedronSetTopology_test::testEdgeBuffers()
     const HexahedronSetTopologyContainer::EdgesInHexahedron& edgeInElemM = topoCon->getEdgesInHexahedron(2);
 
     EXPECT_EQ(edgeInElem.size(), edgeInElemM.size());
-    for (int i = 0; i < edgeInElem.size(); i++)
+    for (size_t i = 0; i < edgeInElem.size(); i++)
         EXPECT_EQ(edgeInElem[i], edgeInElemM[i]);
     
     sofa::helper::fixed_array<int, 10> edgeInElemTruth(20, 13, 14, 21, 22, 23, 24, 16, 25, 18); // Test only 10 out of 12 edges as no fixed_array<12>
-    for (int i = 0; i<edgeInElemTruth.size(); ++i)
+    for (size_t i = 0; i<edgeInElemTruth.size(); ++i)
         EXPECT_EQ(edgeInElem[i], edgeInElemTruth[i]);
     
     
     // Check Edge Index in Hexahedron
-    for (int i = 0; i<edgeInElemTruth.size(); ++i)
+    for (size_t i = 0; i<edgeInElemTruth.size(); ++i)
         EXPECT_EQ(topoCon->getEdgeIndexInHexahedron(edgeInElem, edgeInElemTruth[i]), i);
 
     int edgeId = topoCon->getEdgeIndexInHexahedron(edgeInElem, 20000);
@@ -312,12 +312,12 @@ bool HexahedronSetTopology_test::testEdgeBuffers()
     {
         HexahedronSetTopologyContainer::EdgeID edgeId = i;
         const HexahedronSetTopologyContainer::HexahedraAroundEdge& _elemAEdge = elemAroundEdges[edgeId];
-        for (int j = 0; j < _elemAEdge.size(); ++j)
+        for (size_t j = 0; j < _elemAEdge.size(); ++j)
         {
             HexahedronSetTopologyContainer::HexahedronID triId = _elemAEdge[j];
             const HexahedronSetTopologyContainer::EdgesInHexahedron& _edgeInElem = edgeInHexahedra[triId];
             bool found = false;
-            for (int k = 0; k < _edgeInElem.size(); ++k)
+            for (size_t k = 0; k < _edgeInElem.size(); ++k)
             {
                 if (_edgeInElem[k] == edgeId)
                 {
@@ -366,7 +366,7 @@ bool HexahedronSetTopology_test::testVertexBuffers()
     const HexahedronSetTopologyContainer::HexahedraAroundVertex& elemAVertexM = topoCon->getHexahedraAroundVertex(1);
 
     EXPECT_EQ(elemAVertex.size(), elemAVertexM.size());
-    for (int i = 0; i < elemAVertex.size(); i++)
+    for (size_t i = 0; i < elemAVertex.size(); i++)
         EXPECT_EQ(elemAVertex[i], elemAVertexM[i]);
 
     // check HexahedraAroundVertex buffer element for this file    

--- a/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/MeshTopology_test.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/MeshTopology_test.cpp
@@ -156,31 +156,31 @@ bool MeshTopology_test::testHexahedronTopology()
         const HexahedronSetTopologyContainer::HexahedraAroundQuad& HaQ1 = hexahedraAroundQuad1[i];
         const BaseMeshTopology::HexahedraAroundQuad& HaQ2 = hexahedraAroundQuad2[i];
         EXPECT_EQ(HaQ1.size(), HaQ2.size());
-        for (int j = 0; j<HaQ1.size(); ++j)
+        for (size_t j = 0; j<HaQ1.size(); ++j)
             EXPECT_EQ(HaQ1[j], HaQ2[j]);
 
         const HexahedronSetTopologyContainer::QuadsInHexahedron& QiH1 = trianglesInHexahedron1[i];
         const BaseMeshTopology::QuadsInHexahedron& QiH2 = trianglesInHexahedron2[i];
         EXPECT_EQ(QiH1.size(), QiH2.size());
-        for (int j = 0; j<QiH1.size(); ++j)
+        for (size_t j = 0; j<QiH1.size(); ++j)
             EXPECT_EQ(QiH1[j], QiH1[j]);
 
         const HexahedronSetTopologyContainer::HexahedraAroundEdge& HaE1 = hexahedraAroundEdge1[i];
         const BaseMeshTopology::HexahedraAroundEdge& HaE2 = hexahedraAroundEdge2[i];
         EXPECT_EQ(HaE1.size(), HaE2.size());
-        for (int j = 0; j<HaE1.size(); ++j)
+        for (size_t j = 0; j<HaE1.size(); ++j)
             EXPECT_EQ(HaE1[j], HaE2[j]);
 
         const HexahedronSetTopologyContainer::EdgesInHexahedron& EiH1 = edgesInHexahedron1[i];
         const BaseMeshTopology::EdgesInHexahedron& EiH2 = edgesInHexahedron2[i];
         EXPECT_EQ(EiH1.size(), EiH2.size());
-        for (int j = 0; j<EiH1.size(); ++j)
+        for (size_t j = 0; j<EiH1.size(); ++j)
             EXPECT_EQ(EiH1[j], EiH2[j]);
 
         const HexahedronSetTopologyContainer::HexahedraAroundVertex& HaV1 = hexahedraAroundVertex1[i];
         const BaseMeshTopology::HexahedraAroundVertex& HaV2 = hexahedraAroundVertex2[i];
         EXPECT_EQ(HaV1.size(), HaV2.size());
-        for (int j = 0; j<HaV1.size(); ++j)
+        for (size_t j = 0; j<HaV1.size(); ++j)
             EXPECT_EQ(HaV1[j], HaV2[j]);
 
         const HexahedronSetTopologyContainer::Edge& e1 = edges1[i];
@@ -270,31 +270,31 @@ bool MeshTopology_test::testTetrahedronTopology()
         const TetrahedronSetTopologyContainer::TetrahedraAroundTriangle& TaT1 = tetrahedraAroundTriangle1[i];
         const BaseMeshTopology::TetrahedraAroundTriangle& TaT2 = tetrahedraAroundTriangle2[i];
         EXPECT_EQ(TaT1.size(), TaT2.size());
-        for (int j = 0; j<TaT1.size(); ++j)
+        for (size_t j = 0; j<TaT1.size(); ++j)
             EXPECT_EQ(TaT1[j], TaT2[j]);
 
         const TetrahedronSetTopologyContainer::TrianglesInTetrahedron& TiT1 = trianglesInTetrahedron1[i];
         const BaseMeshTopology::TrianglesInTetrahedron& TiT2 = trianglesInTetrahedron2[i];
         EXPECT_EQ(TiT1.size(), TiT2.size());
-        for (int j = 0; j<TiT1.size(); ++j)
+        for (size_t j = 0; j<TiT1.size(); ++j)
             EXPECT_EQ(TiT1[j], TiT1[j]);
 
         const TetrahedronSetTopologyContainer::TetrahedraAroundEdge& TaE1 = tetrahedraAroundEdge1[i];
         const BaseMeshTopology::TetrahedraAroundEdge& TaE2 = tetrahedraAroundEdge2[i];
         EXPECT_EQ(TaE1.size(), TaE2.size());
-        for (int j = 0; j<TaE1.size(); ++j)
+        for (size_t j = 0; j<TaE1.size(); ++j)
             EXPECT_EQ(TaE1[j], TaE2[j]);
 
         const TetrahedronSetTopologyContainer::EdgesInTetrahedron& EiT1 = edgesInTetrahedron1[i];
         const BaseMeshTopology::EdgesInTetrahedron& EiT2 = edgesInTetrahedron2[i];
         EXPECT_EQ(EiT1.size(), EiT2.size());
-        for (int j = 0; j<EiT1.size(); ++j)
+        for (size_t j = 0; j<EiT1.size(); ++j)
             EXPECT_EQ(EiT1[j], EiT2[j]);
 
         const TetrahedronSetTopologyContainer::TetrahedraAroundVertex& TaV1 = tetrahedraAroundVertex1[i];
         const BaseMeshTopology::TetrahedraAroundVertex& TaV2 = tetrahedraAroundVertex2[i];
         EXPECT_EQ(TaV1.size(), TaV2.size());
-        for (int j = 0; j<TaV1.size(); ++j)
+        for (size_t j = 0; j<TaV1.size(); ++j)
             EXPECT_EQ(TaV1[j], TaV2[j]);
         
         const TetrahedronSetTopologyContainer::Edge& e1 = edges1[i];
@@ -378,19 +378,19 @@ bool MeshTopology_test::testQuadTopology()
         const QuadSetTopologyContainer::EdgesInQuad& EiQ1 = edgesInQuad1[i];
         const BaseMeshTopology::EdgesInQuad& EiQ2 = edgesInQuad2[i];
         EXPECT_EQ(EiQ1.size(), EiQ2.size());
-        for (int j = 0; j<EiQ1.size(); ++j)
+        for (size_t j = 0; j<EiQ1.size(); ++j)
             EXPECT_EQ(EiQ1[j], EiQ2[j]);
 
         const QuadSetTopologyContainer::QuadsAroundVertex& QaV1 = quadsAroundVertex1[i];
         const BaseMeshTopology::QuadsAroundVertex& QaV2 = quadsAroundVertex2[i];
         EXPECT_EQ(QaV1.size(), QaV2.size());
-        for (int j = 0; j<QaV1.size(); ++j)
+        for (size_t j = 0; j<QaV1.size(); ++j)
             EXPECT_EQ(QaV1[j], QaV2[j]);
 
         const QuadSetTopologyContainer::QuadsAroundEdge& QaE1 = quadsAroundEdge1[i];
         const BaseMeshTopology::QuadsAroundEdge& QaE2 = quadsAroundEdge2[i];
         EXPECT_EQ(QaE1.size(), QaE2.size());
-        for (int j = 0; j<QaE1.size(); ++j)
+        for (size_t j = 0; j<QaE1.size(); ++j)
             EXPECT_EQ(QaE1[j], QaE2[j]);
 
         const QuadSetTopologyContainer::Edge& e1 = edges1[i];
@@ -429,8 +429,6 @@ bool MeshTopology_test::testTriangleTopology()
     }
 
     int nbrTriangle = 26;
-    int nbrEdge = 45;
-    int nbrVertex = 20;
     int elemSize = 3;
 
     // Check triangles container buffers size
@@ -481,19 +479,19 @@ bool MeshTopology_test::testTriangleTopology()
         const TriangleSetTopologyContainer::EdgesInTriangle& EiT1 = edgesInTriangle1[i];
         const BaseMeshTopology::EdgesInTriangle& EiT2 = edgesInTriangle2[i];
         EXPECT_EQ(EiT1.size(), EiT2.size());
-        for (int j=0; j<EiT1.size(); ++j)
+        for (size_t j=0; j<EiT1.size(); ++j)
             EXPECT_EQ(EiT1[j], EiT2[j]);
 
         const TriangleSetTopologyContainer::TrianglesAroundVertex& TaV1 = trianglesAroundVertex1[i];
         const BaseMeshTopology::TrianglesAroundVertex& TaV2 = trianglesAroundVertex2[i];
         EXPECT_EQ(TaV1.size(), TaV2.size());
-        for (int j = 0; j<TaV1.size(); ++j)
+        for (size_t j = 0; j<TaV1.size(); ++j)
             EXPECT_EQ(TaV1[j], TaV2[j]);
 
         const TriangleSetTopologyContainer::TrianglesAroundEdge& TaE1 = trianglesAroundEdge1[i];
         const BaseMeshTopology::TrianglesAroundEdge& TaE2 = trianglesAroundEdge2[i];
         EXPECT_EQ(TaE1.size(), TaE2.size());
-        for (int j = 0; j<TaE1.size(); ++j)
+        for (size_t j = 0; j<TaE1.size(); ++j)
             EXPECT_EQ(TaE1[j], TaE2[j]);
     }
 
@@ -558,7 +556,7 @@ bool MeshTopology_test::testEdgeTopology()
         const BaseMeshTopology::EdgesAroundVertex & edgeAV2 = topo->getEdgesAroundVertex(i);
         EXPECT_EQ(edgeAV1.size(), edgeAV2.size());
 
-        for (int j = 0; j < edgeAV1.size(); ++j)
+        for (size_t j = 0; j < edgeAV1.size(); ++j)
             EXPECT_EQ(edgeAV1[j], edgeAV2[j]);
     }
 

--- a/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/QuadSetTopology_test.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/QuadSetTopology_test.cpp
@@ -167,7 +167,7 @@ bool QuadSetTopology_test::testEdgeBuffers()
     const QuadSetTopologyContainer::QuadsAroundEdge& elemAEdgeM = topoCon->getQuadsAroundEdge(0);
 
     EXPECT_EQ(elemAEdge.size(), elemAEdgeM.size());
-    for (int i = 0; i < elemAEdge.size(); i++)
+    for (size_t i = 0; i < elemAEdge.size(); i++)
         EXPECT_EQ(elemAEdge[i], elemAEdgeM[i]);
 
     // check QuadAroundEdge buffer element for this file
@@ -183,7 +183,7 @@ bool QuadSetTopology_test::testEdgeBuffers()
     const QuadSetTopologyContainer::EdgesInQuad& edgeInElemM = topoCon->getEdgesInQuad(2);
 
     EXPECT_EQ(edgeInElem.size(), edgeInElemM.size());
-    for (int i = 0; i < edgeInElem.size(); i++)
+    for (size_t i = 0; i < edgeInElem.size(); i++)
         EXPECT_EQ(edgeInElem[i], edgeInElemM[i]);
 
     sofa::helper::fixed_array<int, 4> edgeInElemTruth(7, 8, 4, 9);
@@ -199,16 +199,16 @@ bool QuadSetTopology_test::testEdgeBuffers()
     EXPECT_EQ(edgeId, -1);
 
     // check link between QuadsAroundEdge and EdgesInQuad
-    for (int i = 0; i < 4; ++i)
+    for (unsigned int i = 0; i < 4; ++i)
     {
         QuadSetTopologyContainer::EdgeID edgeId = i;
         const QuadSetTopologyContainer::QuadsAroundEdge& _elemAEdge = elemAroundEdges[edgeId];
-        for (int j = 0; j < _elemAEdge.size(); ++j)
+        for (size_t j = 0; j < _elemAEdge.size(); ++j)
         {
             QuadSetTopologyContainer::QuadID triId = _elemAEdge[j];
             const QuadSetTopologyContainer::EdgesInQuad& _edgeInElem = edgeInQuads[triId];
             bool found = false;
-            for (int k = 0; k < _edgeInElem.size(); ++k)
+            for (size_t k = 0; k < _edgeInElem.size(); ++k)
             {
                 if (_edgeInElem[k] == edgeId)
                 {
@@ -257,7 +257,7 @@ bool QuadSetTopology_test::testVertexBuffers()
     const QuadSetTopologyContainer::QuadsAroundVertex& elemAVertexM = topoCon->getQuadsAroundVertex(1);
 
     EXPECT_EQ(elemAVertex.size(), elemAVertexM.size());
-    for (int i = 0; i < elemAVertex.size(); i++)
+    for (size_t i = 0; i < elemAVertex.size(); i++)
         EXPECT_EQ(elemAVertex[i], elemAVertexM[i]);
 
     // check QuadsAroundVertex buffer element for this file    

--- a/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/TetrahedronSetTopology_test.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/TetrahedronSetTopology_test.cpp
@@ -180,7 +180,7 @@ bool TetrahedronSetTopology_test::testTriangleBuffers()
     const TetrahedronSetTopologyContainer::TetrahedraAroundTriangle& elemATriangleM = topoCon->getTetrahedraAroundTriangle(0);
 
     EXPECT_EQ(elemATriangle.size(), elemATriangleM.size());
-    for (int i = 0; i < elemATriangle.size(); i++)
+    for (size_t i = 0; i < elemATriangle.size(); i++)
         EXPECT_EQ(elemATriangle[i], elemATriangleM[i]);
 
     // check TetrahedraAroundTriangle buffer element for this file
@@ -196,32 +196,32 @@ bool TetrahedronSetTopology_test::testTriangleBuffers()
     const TetrahedronSetTopologyContainer::TrianglesInTetrahedron& triangleInElemM = topoCon->getTrianglesInTetrahedron(0);
 
     EXPECT_EQ(triangleInElem.size(), triangleInElemM.size());
-    for (int i = 0; i < triangleInElem.size(); i++)
+    for (size_t i = 0; i < triangleInElem.size(); i++)
         EXPECT_EQ(triangleInElem[i], triangleInElemM[i]);
 
     sofa::helper::fixed_array<int, 4> triangleInElemTruth(0, 1, 2, 3);
-    for (int i = 0; i<triangleInElemTruth.size(); ++i)
+    for (size_t i = 0; i<triangleInElemTruth.size(); ++i)
         EXPECT_EQ(triangleInElem[i], triangleInElemTruth[i]);
 
 
     // Check Triangle Index in Tetrahedron
-    for (int i = 0; i<triangleInElemTruth.size(); ++i)
+    for (size_t i = 0; i<triangleInElemTruth.size(); ++i)
         EXPECT_EQ(topoCon->getTriangleIndexInTetrahedron(triangleInElem, triangleInElemTruth[i]), i);
 
     int triangleId = topoCon->getTriangleIndexInTetrahedron(triangleInElem, 20000);
     EXPECT_EQ(triangleId, -1);
 
     // check link between TetrahedraAroundTriangle and TrianglesInTetrahedron
-    for (int i = 0; i < 4; ++i)
+    for (unsigned int i = 0; i < 4; ++i)
     {
         TetrahedronSetTopologyContainer::TriangleID triangleId = i;
         const TetrahedronSetTopologyContainer::TetrahedraAroundTriangle& _elemATriangle = elemAroundTriangles[triangleId];
-        for (int j = 0; j < _elemATriangle.size(); ++j)
+        for (size_t j = 0; j < _elemATriangle.size(); ++j)
         {
             TetrahedronSetTopologyContainer::TetrahedronID triId = _elemATriangle[j];
             const TetrahedronSetTopologyContainer::TrianglesInTetrahedron& _triangleInElem = triangleInTetrahedra[triId];
             bool found = false;
-            for (int k = 0; k < _triangleInElem.size(); ++k)
+            for (size_t k = 0; k < _triangleInElem.size(); ++k)
             {
                 if (_triangleInElem[k] == triangleId)
                 {
@@ -275,7 +275,7 @@ bool TetrahedronSetTopology_test::testEdgeBuffers()
     const TetrahedronSetTopologyContainer::TetrahedraAroundEdge& elemAEdgeM = topoCon->getTetrahedraAroundEdge(0);
 
     EXPECT_EQ(elemAEdge.size(), elemAEdgeM.size());
-    for (int i = 0; i < elemAEdge.size(); i++)
+    for (size_t i = 0; i < elemAEdge.size(); i++)
         EXPECT_EQ(elemAEdge[i], elemAEdgeM[i]);
 
     // check TetrahedronAroundEdge buffer element for this file
@@ -293,32 +293,32 @@ bool TetrahedronSetTopology_test::testEdgeBuffers()
     const TetrahedronSetTopologyContainer::EdgesInTetrahedron& edgeInElemM = topoCon->getEdgesInTetrahedron(2);
 
     EXPECT_EQ(edgeInElem.size(), edgeInElemM.size());
-    for (int i = 0; i < edgeInElem.size(); i++)
+    for (size_t i = 0; i < edgeInElem.size(); i++)
         EXPECT_EQ(edgeInElem[i], edgeInElemM[i]);
     
     sofa::helper::fixed_array<int, 6> edgeInElemTruth(7, 9, 8, 10, 3, 11);
-    for (int i = 0; i<edgeInElemTruth.size(); ++i)
+    for (size_t i = 0; i<edgeInElemTruth.size(); ++i)
         EXPECT_EQ(edgeInElem[i], edgeInElemTruth[i]);
     
     
     // Check Edge Index in Tetrahedron
-    for (int i = 0; i<edgeInElemTruth.size(); ++i)
+    for (size_t i = 0; i<edgeInElemTruth.size(); ++i)
         EXPECT_EQ(topoCon->getEdgeIndexInTetrahedron(edgeInElem, edgeInElemTruth[i]), i);
 
     int edgeId = topoCon->getEdgeIndexInTetrahedron(edgeInElem, 20000);
     EXPECT_EQ(edgeId, -1);
 
     // check link between TetrahedraAroundEdge and EdgesInTetrahedron
-    for (int i = 0; i < 4; ++i)
+    for (unsigned int i = 0; i < 4; ++i)
     {
         TetrahedronSetTopologyContainer::EdgeID edgeId = i;
         const TetrahedronSetTopologyContainer::TetrahedraAroundEdge& _elemAEdge = elemAroundEdges[edgeId];
-        for (int j = 0; j < _elemAEdge.size(); ++j)
+        for (size_t j = 0; j < _elemAEdge.size(); ++j)
         {
             TetrahedronSetTopologyContainer::TetrahedronID triId = _elemAEdge[j];
             const TetrahedronSetTopologyContainer::EdgesInTetrahedron& _edgeInElem = edgeInTetrahedra[triId];
             bool found = false;
-            for (int k = 0; k < _edgeInElem.size(); ++k)
+            for (size_t k = 0; k < _edgeInElem.size(); ++k)
             {
                 if (_edgeInElem[k] == edgeId)
                 {
@@ -367,7 +367,7 @@ bool TetrahedronSetTopology_test::testVertexBuffers()
     const TetrahedronSetTopologyContainer::TetrahedraAroundVertex& elemAVertexM = topoCon->getTetrahedraAroundVertex(1);
 
     EXPECT_EQ(elemAVertex.size(), elemAVertexM.size());
-    for (int i = 0; i < elemAVertex.size(); i++)
+    for (size_t i = 0; i < elemAVertex.size(); i++)
         EXPECT_EQ(elemAVertex[i], elemAVertexM[i]);
 
     // check TetrahedraAroundVertex buffer element for this file    

--- a/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/TriangleSetTopology_test.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/TriangleSetTopology_test.cpp
@@ -166,7 +166,7 @@ bool TriangleSetTopology_test::testEdgeBuffers()
     const TriangleSetTopologyContainer::TrianglesAroundEdge& triAEdgeM = topoCon->getTrianglesAroundEdge(0);
 
     EXPECT_EQ(triAEdge.size(), triAEdgeM.size());
-    for (int i = 0; i < triAEdge.size(); i++)
+    for (size_t i = 0; i < triAEdge.size(); i++)
         EXPECT_EQ(triAEdge[i], triAEdgeM[i]);
 
     // check TriangleAroundEdge buffer element for this file
@@ -182,32 +182,32 @@ bool TriangleSetTopology_test::testEdgeBuffers()
     const TriangleSetTopologyContainer::EdgesInTriangle& edgeInTriM = topoCon->getEdgesInTriangle(2);
 
     EXPECT_EQ(edgeInTri.size(), edgeInTriM.size());
-    for (int i = 0; i < edgeInTri.size(); i++)
+    for (size_t i = 0; i < edgeInTri.size(); i++)
         EXPECT_EQ(edgeInTri[i], edgeInTriM[i]);
 
     sofa::helper::fixed_array<int, 3> edgeInTriTruth(5, 6, 3);
-    for (int i = 0; i<edgeInTriTruth.size(); ++i)
+    for (size_t i = 0; i<edgeInTriTruth.size(); ++i)
         EXPECT_EQ(edgeInTri[i], edgeInTriTruth[i]);
     
     
     // Check Edge Index in Triangle
-    for (int i = 0; i<edgeInTriTruth.size(); ++i)
+    for (size_t i = 0; i<edgeInTriTruth.size(); ++i)
         EXPECT_EQ(topoCon->getEdgeIndexInTriangle(edgeInTri, edgeInTriTruth[i]), i);
 
     int edgeId = topoCon->getEdgeIndexInTriangle(edgeInTri, 20000);
     EXPECT_EQ(edgeId, -1);
 
     // check link between TrianglesAroundEdge and EdgesInTriangle
-    for (int i = 0; i < 4; ++i)
+    for (unsigned int i = 0; i < 4; ++i)
     {
         TriangleSetTopologyContainer::EdgeID edgeId = i;
         const TriangleSetTopologyContainer::TrianglesAroundEdge& _triAEdge = triAroundEdges[edgeId];
-        for (int j = 0; j < _triAEdge.size(); ++j)
+        for (size_t j = 0; j < _triAEdge.size(); ++j)
         {
             TriangleSetTopologyContainer::TriangleID triId = _triAEdge[j];
             const TriangleSetTopologyContainer::EdgesInTriangle& _edgeInTri = edgeInTriangles[triId];
             bool found = false;
-            for (int k = 0; k < _edgeInTri.size(); ++k)
+            for (size_t k = 0; k < _edgeInTri.size(); ++k)
             {
                 if (_edgeInTri[k] == edgeId)
                 {
@@ -256,7 +256,7 @@ bool TriangleSetTopology_test::testVertexBuffers()
     const TriangleSetTopologyContainer::TrianglesAroundVertex& triAVertexM = topoCon->getTrianglesAroundVertex(0);
 
     EXPECT_EQ(triAVertex.size(), triAVertexM.size());
-    for (int i = 0; i < triAVertex.size(); i++)
+    for (size_t i = 0; i < triAVertex.size(); i++)
         EXPECT_EQ(triAVertex[i], triAVertexM[i]);
 
     // check TrianglesAroundVertex buffer element for this file    

--- a/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/fake_TopologyScene.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/fake_TopologyScene.cpp
@@ -30,8 +30,8 @@ using namespace sofa::simpleapi::components;
 using namespace sofa::core::topology;
 
 fake_TopologyScene::fake_TopologyScene(const std::string& filename, TopologyObjectType topoType, bool staticTopo)
-    : m_filename(filename)
-    , m_topoType(topoType)
+    : m_topoType(topoType)
+    , m_filename(filename)
     , m_staticTopology(staticTopo)
 {
     sofa::helper::system::DataRepository.addFirstPath(SOFABASETOPOLOGY_TEST_RESOURCES_DIR);

--- a/SofaKernel/modules/SofaLoader/MeshObjLoader.cpp
+++ b/SofaKernel/modules/SofaLoader/MeshObjLoader.cpp
@@ -48,8 +48,8 @@ int MeshObjLoaderClass = core::RegisterObject("Specific mesh loader for Obj file
 
 MeshObjLoader::MeshObjLoader()
     : MeshLoader()
-    , loadMaterial(initData(&loadMaterial, (bool) true, "loadMaterial", "Load the related MTL file or use a default one?"))
-    , d_handleSeams(initData(&d_handleSeams, (bool) false, "handleSeams", "Preserve UV and normal seams information (vertices with multiple UV and/or normals)"))
+    , d_handleSeams(initData(&d_handleSeams, (bool)false, "handleSeams", "Preserve UV and normal seams information (vertices with multiple UV and/or normals)"))
+    , loadMaterial(initData(&loadMaterial, (bool) true, "loadMaterial", "Load the related MTL file or use a default one?"))    
     , faceType(MeshObjLoader::TRIANGLE)
     , d_material(initData(&d_material,"material","Default material") )
     , materials(initData(&materials,"materials","List of materials") )

--- a/applications/plugins/SceneCreator/sceneCreatorExamples/SceneCreatorBenchmarks.cpp
+++ b/applications/plugins/SceneCreator/sceneCreatorExamples/SceneCreatorBenchmarks.cpp
@@ -109,7 +109,7 @@ int main(int argc, char** argv)
     argParser->addArgument(po::value<bool>(&showHelp)->default_value(false)->implicit_value(true),                  "help,h", "Display this help message");
     argParser->addArgument(po::value<unsigned int>(&idExample)->default_value(0)->notifier([](unsigned int value)
     {
-        if (value < 0 || value > 9) {
+        if (value > 9) {
             std::cerr << "Example Number to enter from (0 - 9), current value: " << value << std::endl;
             exit( EXIT_FAILURE );
         }

--- a/modules/SofaGeneralLoader/MeshGmshLoader.cpp
+++ b/modules/SofaGeneralLoader/MeshGmshLoader.cpp
@@ -98,6 +98,7 @@ bool MeshGmshLoader::load()
     {
         // TODO 2018-04-06: temporary change to unify loader API
         //fileRead = readGmsh(file, gmshFormat);
+        (void)gmshFormat;
         file.close();
         helper::io::Mesh* _mesh = helper::io::Mesh::Create("gmsh", filename);
 

--- a/modules/SofaMiscForceField/MeshMatrixMass.h
+++ b/modules/SofaMiscForceField/MeshMatrixMass.h
@@ -172,7 +172,7 @@ public:
     virtual void reinit() override;
     virtual void init() override;
     virtual void handleEvent(sofa::core::objectmodel::Event */*event*/) override;
-    void update();
+    bool update();
 
     TopologyType getMassTopologyType() const
     {

--- a/modules/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/MeshMatrixMass.inl
@@ -1149,6 +1149,9 @@ void MeshMatrixMass<DataTypes, MassType>::massInitialization()
 template <class DataTypes, class MassType>
 void MeshMatrixMass<DataTypes, MassType>::printMass()
 {
+    if (this->f_printLog.getValue() == false)
+        return;
+
     //Info post-init
     const MassVector &vertexM = d_vertexMass.getValue();
     const MassVector &mDensity = d_massDensity.getValue();
@@ -1299,7 +1302,7 @@ void MeshMatrixMass<DataTypes, MassType>::reinit()
 
 
 template <class DataTypes, class MassType>
-void MeshMatrixMass<DataTypes, MassType>::update()
+bool MeshMatrixMass<DataTypes, MassType>::update()
 {
     bool update = false;
 
@@ -1357,6 +1360,8 @@ void MeshMatrixMass<DataTypes, MassType>::update()
         msg_info() << "mass information updated";
         printMass();
     }
+
+    return update;
 }
 
 


### PR DESCRIPTION
- use some size_t instead of int in the topology_test
- Change the update method from the mass to return the bool update as result.
- some small warning fix in other classes.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
