### PR TITLE
[Multithreading] FIX compiling error on Mac

### DIFF
--- a/applications/plugins/MultiThreading/src/TaskScheduler.cpp
+++ b/applications/plugins/MultiThreading/src/TaskScheduler.cpp
@@ -8,7 +8,7 @@ namespace sofa
 	namespace simulation
 	{
         
-        static thread_local WorkerThread* _workerThreadIndex = nullptr;
+        static thread_local WorkerThread* workerThreadIndex = nullptr;
 
         
 		TaskScheduler& TaskScheduler::getInstance()
@@ -24,9 +24,9 @@ namespace sofa
 			_isClosing = false;
 
             // init global static thread local var
-            _workerThreadIndex = new WorkerThread(this);
+            workerThreadIndex = new WorkerThread(this);
 
-			_threads[std::this_thread::get_id()] = _workerThreadIndex;
+			_threads[std::this_thread::get_id()] = workerThreadIndex;
            
 		}
 
@@ -207,13 +207,13 @@ namespace sofa
 
         WorkerThread* WorkerThread::getCurrent()
         {
-            return _workerThreadIndex;
+            return workerThreadIndex;
         }
 
 		void WorkerThread::run(void)
 		{
             
-            _workerThreadIndex = this;
+            workerThreadIndex = this;
 
 			// main loop
             while ( !_taskScheduler->isClosing() )

--- a/applications/plugins/MultiThreading/src/TaskScheduler.cpp
+++ b/applications/plugins/MultiThreading/src/TaskScheduler.cpp
@@ -8,8 +8,10 @@ namespace sofa
 	namespace simulation
 	{
         
-        static thread_local WorkerThread* workerThreadIndex = nullptr;
+        // mac clang 3.5 doesn't support thread_local vars
+        //static thread_local WorkerThread* workerThreadIndex = nullptr;
 
+        std::map< std::thread::id, WorkerThread*> TaskScheduler::_threads;
         
 		TaskScheduler& TaskScheduler::getInstance()
 		{
@@ -24,9 +26,8 @@ namespace sofa
 			_isClosing = false;
 
             // init global static thread local var
-            workerThreadIndex = new WorkerThread(this);
-
-			_threads[std::this_thread::get_id()] = workerThreadIndex;
+            //workerThreadIndex = new WorkerThread(this);
+            _threads[std::this_thread::get_id()] = new WorkerThread(this);;
            
 		}
 
@@ -207,13 +208,20 @@ namespace sofa
 
         WorkerThread* WorkerThread::getCurrent()
         {
-            return workerThreadIndex;
+            //return workerThreadIndex;
+            auto thread = TaskScheduler::_threads.find(std::this_thread::get_id());
+            if (thread == TaskScheduler::_threads.end())
+            {
+                return nullptr;
+            }
+            return thread->second;
         }
 
 		void WorkerThread::run(void)
 		{
             
-            workerThreadIndex = this;
+            //workerThreadIndex = this;
+            TaskScheduler::_threads[std::this_thread::get_id()] = this;
 
 			// main loop
             while ( !_taskScheduler->isClosing() )

--- a/applications/plugins/MultiThreading/src/TaskScheduler.h
+++ b/applications/plugins/MultiThreading/src/TaskScheduler.h
@@ -170,7 +170,7 @@ namespace sofa
 			
             //static thread_local WorkerThread* _workerThreadIndex;
 
-			std::map< std::thread::id, WorkerThread*> _threads;
+			static std::map< std::thread::id, WorkerThread*> _threads;
 
 			Task::Status*	_mainTaskStatus;
 

--- a/applications/plugins/MultiThreading/test/TaskSchedulerTests.cpp
+++ b/applications/plugins/MultiThreading/test/TaskSchedulerTests.cpp
@@ -51,12 +51,13 @@ namespace sofa
         //  6 : 8
         // 13 : 233
         // 23 : 28657
+        // 27 : 196418
         // 35 : 9227465
         // 41 : 165580141
         // 43 : 433494437
         // 47 : 2971215073
-        const int64_t res = Fibonacci(43, 1);
-        EXPECT_EQ(res, 433494437);
+        const int64_t res = Fibonacci(27, 1);
+        EXPECT_EQ(res, 196418);
 		return;
 	}
 
@@ -68,12 +69,13 @@ namespace sofa
         //  6 : 8
         // 13 : 233
         // 23 : 28657
+        // 27 : 196418
         // 35 : 9227465
         // 41 : 165580141
         // 43 : 433494437
         // 47 : 2971215073
-        const int64_t res = Fibonacci(43);
-        EXPECT_EQ(res, 433494437);
+        const int64_t res = Fibonacci(27);
+        EXPECT_EQ(res, 196418);
 		return;
 	}
 


### PR DESCRIPTION
No support of thread local vars in mac_Clang 3.5 compiler.
This looks like a mac_Clang 3.5 compiler limitation.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
