### PR TITLE
[SofaGuiQt] Change method to allow antialiased screenshots in QtViewer

### DIFF
--- a/applications/sofa/gui/qt/viewer/qt/QtViewer.cpp
+++ b/applications/sofa/gui/qt/viewer/qt/QtViewer.cpp
@@ -50,6 +50,8 @@
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/gui/ColourPickingVisitor.h>
 
+#include <QImage>
+
 namespace sofa
 {
 
@@ -1697,6 +1699,19 @@ The captured images are saved in the running project directory under the name fo
 Each time the frame is updated a screenshot is saved<br></li>\
 <li><b>Esc</b>: TO QUIT ::sofa:: <br></li></ul>");
     return text;
+}
+
+
+void QtViewer::screenshot(const std::string& filename, int compression_level)
+{
+    QImage screenshot;
+
+    screenshot = this->grabFramebuffer();
+    bool res = screenshot.save(filename.c_str(), nullptr, (compression_level == -1) ? -1 : compression_level*100); // compression_level is either -1 or [0,100]
+    if(res)
+        msg_info("QtViewer") << "Saved " << screenshot.width() << "x" << screenshot.height() << " screen image to " << filename;
+    else
+        msg_error("QtViewer") << "Unknown error while saving screen image to " << filename;
 }
 
 }// namespace qt

--- a/applications/sofa/gui/qt/viewer/qt/QtViewer.h
+++ b/applications/sofa/gui/qt/viewer/qt/QtViewer.h
@@ -255,6 +255,7 @@ public:
 
     QString helpString() const;
 //    void setCameraMode(core::visual::VisualParams::CameraType mode);
+    void screenshot(const std::string& filename, int compression_level = -1);
 
 private:
 


### PR DESCRIPTION
Capture::screenshot() does not work with anti-aliased (MSAA) OpenGL rendering.
Using instead built-in Qt method.


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
