### PR TITLE
[SofaTest] ADD a PrintTo method so test failure shows human readable informations.

### DIFF
--- a/applications/plugins/SofaTest/Python_test.cpp
+++ b/applications/plugins/SofaTest/Python_test.cpp
@@ -24,6 +24,19 @@ struct fail {
         : message(message) { }
 };
 
+
+/// This function is used by gtest to print the content of the struct in a meaninfull way
+void SOFA_SOFATEST_API PrintTo(const sofa::Python_test_data& d, ::std::ostream *os)
+{
+  (*os) << d.filepath  ;
+  (*os) << " with args {" ;
+  for(auto& v : d.arguments)
+  {
+      (*os) << v << ", " ;
+  }
+  (*os) << "}";
+}
+
 static PyObject* operator||(PyObject* obj, const fail& error) {
     if(obj) return obj;
     throw std::runtime_error(error.message);

--- a/applications/plugins/SofaTest/Python_test.h
+++ b/applications/plugins/SofaTest/Python_test.h
@@ -21,6 +21,13 @@ struct SOFA_SOFATEST_API Python_test_data
     std::vector<std::string> arguments; // argc/argv in the python script
 };
 
+/// This function is used by gtest to print the content of the struct in a human friendly way
+/// eg:
+///        test.all_tests/2, where GetParam() = /path/to/file.py with args {1,2,3}
+/// instead of the defautl googletest printer that output things like the following:
+///        test.all_tests/2, where GetParam() = 56-byte object <10-48 EC-37 18-56 00-00 67-00-00-00>
+void SOFA_SOFATEST_API PrintTo(const sofa::Python_test_data& d, ::std::ostream* os);
+
 /// utility to build a static list of Python_test_data
 struct SOFA_SOFATEST_API Python_test_list
 {


### PR DESCRIPTION
But default google test prints raw values when the tests cases are provided by GetParams. 
By adding a PrintTo function this behavior can be changed so that custom types are easier 
to read. 

In the PR i adds a PrintTo for the Python_test_data object. 
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
