### PR TITLE
[SofaPython] ADD forwarding of onMouseMove event into the script controller

### DIFF
--- a/applications/plugins/SofaPython/Binding_PythonScriptController.cpp
+++ b/applications/plugins/SofaPython/Binding_PythonScriptController.cpp
@@ -417,8 +417,22 @@ static PyObject * PythonScriptController_new(PyTypeObject * cls, PyObject * args
     };
 }
        
+static PyObject * PythonScriptController_onMouseMove(PyObject * /*self*/, PyObject * args)
+{
+    int x,y;
+    if (!PyArg_ParseTuple(args, "ii",&x,&y))
+    {
+        PyErr_BadArgument();
+        Py_RETURN_NONE;
+    }
 
+#ifdef LOG_UNIMPLEMENTED_METHODS
+    PythonScriptController* obj=dynamic_cast<PythonScriptController*>(((PySPtr<Base>*)self)->object.get());
+    std::cerr << obj->m_classname.getValueString() << ".onMouseMove not implemented in " << obj->name.getValueString() << std::endl;
+#endif
 
+    Py_RETURN_NONE;
+}
 
 
 SP_CLASS_METHODS_BEGIN(PythonScriptController)
@@ -428,6 +442,7 @@ SP_CLASS_METHOD(PythonScriptController,initGraph)
 SP_CLASS_METHOD(PythonScriptController,bwdInitGraph)
 SP_CLASS_METHOD(PythonScriptController,onKeyPressed)
 SP_CLASS_METHOD(PythonScriptController,onKeyReleased)
+SP_CLASS_METHOD(PythonScriptController,onMouseMove)
 SP_CLASS_METHOD(PythonScriptController,onMouseButtonLeft)
 SP_CLASS_METHOD(PythonScriptController,onMouseButtonRight)
 SP_CLASS_METHOD(PythonScriptController,onMouseButtonMiddle)

--- a/applications/plugins/SofaPython/PythonMainScriptController.cpp
+++ b/applications/plugins/SofaPython/PythonMainScriptController.cpp
@@ -252,6 +252,11 @@ void PythonMainScriptController::script_draw(const VisualParams*)
     SP_CALL_MODULEFUNC_NOPARAM(m_Func_draw)
 }
 
+void PythonMainScriptController::script_onMouseMove(const int posX,const int posY)
+{
+     SP_CALL_FILEFUNC(const_cast<char*>("onMouseMove"),const_cast<char*>("(ii)"), posX,posY)
+}
+
 void PythonMainScriptController::handleEvent(Event *event)
 {
     if (PythonScriptEvent::checkEventType(event))

--- a/applications/plugins/SofaPython/PythonMainScriptController.h
+++ b/applications/plugins/SofaPython/PythonMainScriptController.h
@@ -78,7 +78,7 @@ protected:
     virtual bool script_onKeyPressed(const char c) override;
     virtual bool script_onKeyReleased(const char c) override ;
 
-    virtual void script_onMouseMove(const int posX,const int posY);
+    virtual void script_onMouseMove(const int posX,const int posY) override;
     virtual void script_onMouseButtonLeft(const int posX,const int posY,const bool pressed) override;
     virtual void script_onMouseButtonRight(const int posX,const int posY,const bool pressed) override;
     virtual void script_onMouseButtonMiddle(const int posX,const int posY,const bool pressed) override;

--- a/applications/plugins/SofaPython/PythonMainScriptController.h
+++ b/applications/plugins/SofaPython/PythonMainScriptController.h
@@ -78,6 +78,7 @@ protected:
     virtual bool script_onKeyPressed(const char c) override;
     virtual bool script_onKeyReleased(const char c) override ;
 
+    virtual void script_onMouseMove(const int posX,const int posY);
     virtual void script_onMouseButtonLeft(const int posX,const int posY,const bool pressed) override;
     virtual void script_onMouseButtonRight(const int posX,const int posY,const bool pressed) override;
     virtual void script_onMouseButtonMiddle(const int posX,const int posY,const bool pressed) override;

--- a/applications/plugins/SofaPython/PythonScriptController.cpp
+++ b/applications/plugins/SofaPython/PythonScriptController.cpp
@@ -169,6 +169,7 @@ void PythonScriptController::refreshBinding()
             BIND_OBJECT_METHOD(bwdInitGraph)
             BIND_OBJECT_METHOD(onKeyPressed)
             BIND_OBJECT_METHOD(onKeyReleased)
+            BIND_OBJECT_METHOD(onMouseMove)
             BIND_OBJECT_METHOD(onMouseButtonLeft)
             BIND_OBJECT_METHOD(onMouseButtonRight)
             BIND_OBJECT_METHOD(onMouseButtonMiddle)
@@ -300,6 +301,15 @@ bool PythonScriptController::script_onKeyReleased(const char c)
     PythonEnvironment::gil lock(__func__);    
     SP_CALL_MODULEBOOLFUNC(m_Func_onKeyReleased,"(c)", c);
     return b;
+}
+
+void PythonScriptController::script_onMouseMove(const int posX,const int posY)
+{
+     ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(),
+                                                "PythonScriptController_onMouseMove",this);
+
+     PythonEnvironment::gil lock(__func__);
+     SP_CALL_MODULEFUNC(m_Func_onMouseMove, "(ii)", posX, posY);
 }
 
 void PythonScriptController::script_onMouseButtonLeft(const int posX,const int posY,const bool pressed)

--- a/applications/plugins/SofaPython/PythonScriptController.h
+++ b/applications/plugins/SofaPython/PythonScriptController.h
@@ -88,6 +88,7 @@ protected:
     virtual bool script_onKeyPressed(const char c) override;
     virtual bool script_onKeyReleased(const char c) override;
 
+    virtual void script_onMouseMove(const int posX,const int posY) override;
     virtual void script_onMouseButtonLeft(const int posX,const int posY,const bool pressed) override;
     virtual void script_onMouseButtonRight(const int posX,const int posY,const bool pressed) override;
     virtual void script_onMouseButtonMiddle(const int posX,const int posY,const bool pressed) override;
@@ -127,6 +128,7 @@ protected:
     // optionnal script entry points:
     PyObject *m_Func_onKeyPressed          {nullptr} ;
     PyObject *m_Func_onKeyReleased         {nullptr} ;
+    PyObject *m_Func_onMouseMove           {nullptr} ;
     PyObject *m_Func_onMouseButtonLeft     {nullptr} ;
     PyObject *m_Func_onMouseButtonRight    {nullptr} ;
     PyObject *m_Func_onMouseButtonMiddle   {nullptr} ;

--- a/applications/plugins/SofaPython/ScriptController.cpp
+++ b/applications/plugins/SofaPython/ScriptController.cpp
@@ -114,6 +114,7 @@ void ScriptController::onMouseEvent(core::objectmodel::MouseEvent * evt)
     switch(evt->getState())
     {
     case core::objectmodel::MouseEvent::Move:
+        script_onMouseMove(evt->getPosX(),evt->getPosY());
         break;
     case core::objectmodel::MouseEvent::LeftPressed:
         script_onMouseButtonLeft(evt->getPosX(),evt->getPosY(),true);

--- a/applications/plugins/SofaPython/ScriptController.h
+++ b/applications/plugins/SofaPython/ScriptController.h
@@ -171,6 +171,7 @@ protected:
     virtual bool script_onKeyPressed(const char c) = 0;
     virtual bool script_onKeyReleased(const char c) = 0;
 
+    virtual void script_onMouseMove(const int posX, const int posY) = 0;
     virtual void script_onMouseButtonLeft(const int posX,const int posY,const bool pressed) = 0;
     virtual void script_onMouseButtonRight(const int posX,const int posY,const bool pressed) = 0;
     virtual void script_onMouseButtonMiddle(const int posX,const int posY,const bool pressed) = 0;

--- a/applications/plugins/SofaPython/examples/ExampleController.py
+++ b/applications/plugins/SofaPython/examples/ExampleController.py
@@ -149,6 +149,10 @@ class ExampleController(Sofa.PythonScriptController):
 		sys.stdout.flush()
 		return 0
 
+        def onMouseMove(self,x,y):
+		print 'onMouseMove x='+str(x)+' y='+str(y)
+		sys.stdout.flush()
+		return 0
 
 	# called at each draw (possibility to use PyOpenGL)
 	def draw(self):


### PR DESCRIPTION
This is very useful to implement any kind of 3D interaction in the python controllers. 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
