### PR TITLE
[SofaKernel] Add a "sofa_add_module" in SofaMacro.cmake

### DIFF
--- a/SofaKernel/SofaFramework/SofaMacros.cmake
+++ b/SofaKernel/SofaFramework/SofaMacros.cmake
@@ -148,6 +148,15 @@ macro(sofa_add_plugin_experimental directory plugin_name)
 endmacro()
 
 
+macro(sofa_add_module directory module_name)
+    sofa_add_generic( ${directory} ${module_name} "Module" ${ARGV2} )
+endmacro()
+
+macro(sofa_add_module_experimental directory module_name)
+    sofa_add_generic( ${directory} ${module_name} "Module" ${ARGV2} )
+    message("-- ${module_name} is an experimental feature, use it at your own risk.")
+endmacro()
+
 macro(sofa_add_application directory app_name)
     sofa_add_generic( ${directory} ${app_name} "Application" ${ARGV2} )
 endmacro()

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -1,7 +1,7 @@
 ### These are real modules. If you need components from there you
 ### need to first add find_package(XXX) in your CMakeLists.txt
-sofa_add_plugin(SofaSparseSolver SofaSparseSolver ON)      #
-sofa_add_plugin(SofaPreconditioner SofaPreconditioner ON)  # depends on SofaSparseSolver
+sofa_add_module(SofaSparseSolver SofaSparseSolver ON)      #
+sofa_add_module(SofaPreconditioner SofaPreconditioner ON)  # depends on SofaSparseSolver
 
 ### All the other targets visible in "modules" are not real module
 ### and are contained in the SofaGeneral, SofaMisc, SofaAdvanced


### PR DESCRIPTION
As in SofaNG we are calling the activable/deactivable 'plugins' modules
I added a macro that have the right "name" instead of hijacking the
sofa_add_plugin's one.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
