### PR TITLE
[cmake] Add a findCython.cmake

### DIFF
--- a/cmake/Modules/FindCython.cmake
+++ b/cmake/Modules/FindCython.cmake
@@ -37,9 +37,12 @@ else()
     )
 endif()
 
-
 include( FindPackageHandleStandardArgs )
-FIND_PACKAGE_HANDLE_STANDARD_ARGS( Cython REQUIRED_VARS CYTHON_EXECUTABLE )
+FIND_PACKAGE_HANDLE_STANDARD_ARGS( Cython REQUIRED_VARS CYTHON_EXECUTABLE)
+
+if(CYTHON_FOUND)
+        set(Cython_FOUND TRUE)
+endif()
 
 mark_as_advanced( CYTHON_EXECUTABLE )
 

--- a/cmake/Modules/findCython.cmake
+++ b/cmake/Modules/findCython.cmake
@@ -1,0 +1,45 @@
+# Find the Cython compiler.
+#
+# This code sets the following variables:
+#
+#  CYTHON_EXECUTABLE
+#
+# See also UseCython.cmake
+
+#=============================================================================
+# Copyright 2011 Kitware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+# Use the Cython executable that lives next to the Python executable
+# if it is a local installation.
+find_package( PythonInterp )
+if( PYTHONINTERP_FOUND )
+  get_filename_component( _python_path ${PYTHON_EXECUTABLE} PATH )
+  find_program( CYTHON_EXECUTABLE
+    NAMES cython cython.bat cython3
+    HINTS ${_python_path}
+    )
+else()
+  find_program( CYTHON_EXECUTABLE
+    NAMES cython cython.bat cython3
+    )
+endif()
+
+
+include( FindPackageHandleStandardArgs )
+FIND_PACKAGE_HANDLE_STANDARD_ARGS( Cython REQUIRED_VARS CYTHON_EXECUTABLE )
+
+mark_as_advanced( CYTHON_EXECUTABLE )
+


### PR DESCRIPTION
Cython is a de-facto standard to make ease binding between C++ and python.

I use it to make 'per plugin' binding and will probably submit some in future PR. 
To ease the writing of cmake of these binding it is nice to detect if cython is installed what this file is doing. 

The file is taken from (all credit should go to them):
https://github.com/thewtex/cython-cmake-example






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
