### PR TITLE
[SofaPython] ADD: Bindings for BoundingBox

### DIFF
--- a/applications/plugins/SofaPython/Binding.cpp
+++ b/applications/plugins/SofaPython/Binding.cpp
@@ -26,6 +26,7 @@
 #include "Binding_Data.h"
 #include "Binding_DisplayFlagsData.h"
 #include "Binding_OptionsGroupData.h"
+#include "Binding_BoundingBoxData.h"
 #include "Binding_DataFileName.h"
 #include "Binding_DataFileNameVector.h"
 #include "Binding_VectorLinearSpringData.h"
@@ -82,6 +83,7 @@ void bindSofaPythonModule()
     /// special Data cases
     SP_ADD_CLASS_IN_FACTORY(DisplayFlagsData,sofa::core::objectmodel::Data<sofa::core::visual::DisplayFlags>)
     SP_ADD_CLASS_IN_FACTORY(OptionsGroupData,sofa::core::objectmodel::Data<sofa::helper::OptionsGroup>)
+    SP_ADD_CLASS_IN_FACTORY(BoundingBox,sofa::core::objectmodel::Data<sofa::defaulttype::BoundingBox>)
     SP_ADD_CLASS_IN_FACTORY(DataFileName,sofa::core::objectmodel::DataFileName)
     SP_ADD_CLASS_IN_FACTORY(DataFileNameVector,sofa::core::objectmodel::DataFileNameVector)
     SP_ADD_CLASS_IN_SOFAMODULE(PointAncestorElem)

--- a/applications/plugins/SofaPython/Binding_BaseObject.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseObject.cpp
@@ -250,6 +250,12 @@ static PyObject * BaseObject_getTarget(PyObject *self, PyObject * args)
     return nullptr ;
 }
 
+static PyObject * BaseObject_computeBBox(PyObject *self, PyObject * /*args*/)
+{
+    BaseObject* obj = get_baseobject( self );
+    obj->computeBBox(sofa::core::ExecParams::defaultInstance(), false);
+    Py_RETURN_NONE;
+}
 
 SP_CLASS_METHODS_BEGIN(BaseObject)
 SP_CLASS_METHOD(BaseObject,init)
@@ -270,6 +276,7 @@ SP_CLASS_METHOD_DOC(BaseObject, getCategories,
 SP_CLASS_METHOD_DOC(BaseObject, getTarget,
                     "Returns the target (plugin) that contains the current object.")
 SP_CLASS_METHOD(BaseObject,getAsACreateObjectParameter)
+SP_CLASS_METHOD(BaseObject,computeBBox)
 SP_CLASS_METHODS_END
 
 

--- a/applications/plugins/SofaPython/Binding_BaseObject.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseObject.cpp
@@ -276,7 +276,7 @@ SP_CLASS_METHOD_DOC(BaseObject, getCategories,
 SP_CLASS_METHOD_DOC(BaseObject, getTarget,
                     "Returns the target (plugin) that contains the current object.")
 SP_CLASS_METHOD(BaseObject,getAsACreateObjectParameter)
-SP_CLASS_METHOD(BaseObject,computeBBox)
+SP_CLASS_METHOD_DOC(BaseObject, computeBBox, "Recomputes the bounding box of the object")
 SP_CLASS_METHODS_END
 
 

--- a/applications/plugins/SofaPython/Binding_BoundingBoxData.cpp
+++ b/applications/plugins/SofaPython/Binding_BoundingBoxData.cpp
@@ -46,15 +46,13 @@ SP_CLASS_ATTR_GET(BoundingBox, maxBBox)(PyObject *self, void*)
 
 SP_CLASS_ATTR_SET(BoundingBox, minBBox)(PyObject */*self*/, PyObject * /*args*/, void*)
 {
-    SP_MESSAGE_ERROR("BoundingBox attributes are read-only")
-        PyErr_BadArgument();
+    PyErr_SetString(PyExc_RuntimeError, "BoundingBox attributes are read-only");
     return -1;
 }
 
 SP_CLASS_ATTR_SET(BoundingBox, maxBBox)(PyObject */*self*/, PyObject * /*args*/, void*)
 {
-    SP_MESSAGE_ERROR("BoundingBox attributes are read-only")
-        PyErr_BadArgument();
+    PyErr_SetString(PyExc_RuntimeError, "BoundingBox attributes are read-only");
     return -1;
 }
 

--- a/applications/plugins/SofaPython/Binding_BoundingBoxData.cpp
+++ b/applications/plugins/SofaPython/Binding_BoundingBoxData.cpp
@@ -1,0 +1,70 @@
+#include "Binding_BoundingBoxData.h"
+#include "Binding_Data.h"
+#include "PythonToSofa.inl"
+
+using sofa::defaulttype::BoundingBox;
+using namespace sofa::core::objectmodel;
+
+static inline Data<BoundingBox>* get_boundingbox(PyObject* obj) {
+    return sofa::py::unwrap<Data<sofa::defaulttype::BoundingBox> >(obj);
+}
+
+
+SP_CLASS_ATTR_GET(BoundingBox, minBBox)(PyObject *self, void*)
+{
+    Data<BoundingBox>* obj = get_boundingbox( self );
+    if (!obj)
+    {
+        PyErr_BadArgument();
+        return NULL;
+    }
+
+    PyObject* shape = PyList_New(3);
+    PyList_SetItem(shape, 0, PyFloat_FromDouble(obj->getValue().minBBox().x()));
+    PyList_SetItem(shape, 1, PyFloat_FromDouble(obj->getValue().minBBox().y()));
+    PyList_SetItem(shape, 2, PyFloat_FromDouble(obj->getValue().minBBox().z()));
+
+    return shape;
+}
+
+SP_CLASS_ATTR_GET(BoundingBox, maxBBox)(PyObject *self, void*)
+{
+    Data<BoundingBox>* obj = get_boundingbox( self );
+    if (!obj)
+    {
+        PyErr_BadArgument();
+        return NULL;
+    }
+
+    PyObject* shape = PyList_New(3);
+    PyList_SetItem(shape, 0, PyFloat_FromDouble(obj->getValue().maxBBox().x()));
+    PyList_SetItem(shape, 1, PyFloat_FromDouble(obj->getValue().maxBBox().y()));
+    PyList_SetItem(shape, 2, PyFloat_FromDouble(obj->getValue().maxBBox().z()));
+
+    return shape;
+}
+
+SP_CLASS_ATTR_SET(BoundingBox, minBBox)(PyObject */*self*/, PyObject * /*args*/, void*)
+{
+    SP_MESSAGE_ERROR("BoundingBox attributes are read-only")
+        PyErr_BadArgument();
+    return -1;
+}
+
+SP_CLASS_ATTR_SET(BoundingBox, maxBBox)(PyObject */*self*/, PyObject * /*args*/, void*)
+{
+    SP_MESSAGE_ERROR("BoundingBox attributes are read-only")
+        PyErr_BadArgument();
+    return -1;
+}
+
+
+SP_CLASS_METHODS_BEGIN(BoundingBox)
+SP_CLASS_METHODS_END
+
+SP_CLASS_ATTRS_BEGIN(BoundingBox)
+SP_CLASS_ATTR(BoundingBox, minBBox)
+SP_CLASS_ATTR(BoundingBox, maxBBox)
+SP_CLASS_ATTRS_END
+
+SP_CLASS_TYPE_PTR_ATTR(BoundingBox, BaseData, Data)

--- a/applications/plugins/SofaPython/Binding_BoundingBoxData.h
+++ b/applications/plugins/SofaPython/Binding_BoundingBoxData.h
@@ -1,0 +1,32 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#ifndef BINDING_BOUNDINGBOX_H
+#define BINDING_BOUNDINGBOX_H
+
+#include "PythonMacros.h"
+
+#include <sofa/defaulttype/Vec.h>
+#include <sofa/defaulttype/BoundingBox.h>
+
+SP_DECLARE_CLASS_TYPE(BoundingBox)
+
+#endif // BINDING_BOUNDINGBOX_H

--- a/applications/plugins/SofaPython/CMakeLists.txt
+++ b/applications/plugins/SofaPython/CMakeLists.txt
@@ -29,6 +29,7 @@ set(HEADER_FILES
     Binding_DataFileNameVector.h
     Binding_DisplayFlagsData.h
     Binding_OptionsGroupData.h
+    Binding_BoundingBoxData.h
     Binding_GridTopology.h
     Binding_LinearSpring.h
     Binding_Link.h
@@ -90,6 +91,7 @@ set(SOURCE_FILES
     Binding_DataFileNameVector.cpp
     Binding_DisplayFlagsData.cpp
     Binding_OptionsGroupData.cpp
+    Binding_BoundingBoxData.cpp
     Binding_GridTopology.cpp
     Binding_LinearSpring.cpp
     Binding_Link.cpp

--- a/applications/plugins/SofaPython/examples/RegularGridFromMesh.py
+++ b/applications/plugins/SofaPython/examples/RegularGridFromMesh.py
@@ -5,71 +5,45 @@ import os
 import math
 import numpy as np
 
-class CreateGrid(Sofa.PythonScriptController):
-
-    mesh = "mesh/liver.obj"
-    nx = 10
-    ny = 10
-    nz = 10
-    
-    def __init__(self, node, argv):
-        try:
-            parser = argparse.ArgumentParser(
-                description='Loads a 3D model a generates a regular grid using its bounding box')
-            parser.add_argument(
-                '-x','--gridx', dest='nx', type=int, default=self.nx, help='')
-            parser.add_argument(
-                '-y','--gridy', dest='ny', type=int, default=self.ny, help='')
-            parser.add_argument(
-                '-z', '--gridz', dest='nz', type=int, default=self.nz, help='')
-            parser.add_argument(
-                '-m', '--mesh', dest='mesh', type=str, default=self.mesh, help='')
-            parser.add_argument(
-                '-o', '--output', dest='name', type=str, default="", help='')
-            args = parser.parse_args(argv)
-            
-            self.nx = args.nx
-            self.ny = args.ny
-            self.nz = args.nz
-            self.mesh = args.mesh
-            self.name = args.name
-        except:
-            pass
-        self.root = node
-        self.createGraph(node)
-        return None
-
-    
-    def createGraph(self,root):
-        root.createObject('MeshObjLoader', name="loader", filename=self.mesh)
-        model = root.createObject('OglModel', name="model", src="@loader")
-        model.init()
-        model.computeBBox()
+def createGrid(root, x, y, z, mesh, name):
+    root.createObject('MeshObjLoader', name="loader", filename=mesh)
+    model = root.createObject('OglModel', name="model", src="@loader")
+    model.init()
+    model.computeBBox()
         
-        root.createObject('RegularGrid', name="grid", nx=self.nx, ny=self.ny, nz=self.nz,
-                          min=model.bbox.minBBox, max=model.bbox.maxBBox)
-        root.createObject('MechanicalObject', name="DOFs")
+    grid = root.createObject('RegularGrid', name="grid", nx=x, ny=y, nz=z, min=model.bbox.minBBox, max=model.bbox.maxBBox)
+    root.createObject('MechanicalObject', name="DOFs")
 
-        topoExporter = root.createChild('Topo')
-        topoExporter.createObject('TetrahedronSetTopologyContainer', name="Container")
-        topoExporter.createObject('TetrahedronSetTopologyModifier')
-        topoExporter.createObject('TetrahedronSetTopologyAlgorithms', template="Vec3d")
-        topoExporter.createObject('TetrahedronSetGeometryAlgorithms', template="Vec3d", drawTetrahedra="0")
-        topoExporter.createObject('Hexa2TetraTopologicalMapping', name="default28", input="@../grid", output="@Container")
-        # topoExporter.createObject('VTKExporter', position="@../DOFs.position", edges="0", tetras="1",
-        #                           filename=self.name, exportAtBegin="true")
+    topoExporter = root.createChild('Topo')
+    topoContainer = topoExporter.createObject('TetrahedronSetTopologyContainer')
+    topoExporter.createObject('TetrahedronSetTopologyModifier')
+    topoExporter.createObject('TetrahedronSetTopologyAlgorithms', template="Vec3d")
+    topoExporter.createObject('TetrahedronSetGeometryAlgorithms', template="Vec3d", drawTetrahedra="0")
+    topoExporter.createObject('Hexa2TetraTopologicalMapping', name="default28", input="@" + grid.getPathName(),
+                              output="@" + topoContainer.getPathName())
+    # topoExporter.createObject('VTKExporter', position="@../DOFs.position", edges="0", tetras="1",
+    #                           filename=self.name, exportAtBegin="true")
 
-        root.createObject('TetrahedronFEMForceField', name="FEM", youngModulus=5000, poissonRatio="0.4", method="large")
+    root.createObject('TetrahedronFEMForceField', name="FEM", youngModulus=5000, poissonRatio="0.4", method="large")
         
 def createScene(node):
-    try :
-        sys.argv[0]
-    except :
+    if len (sys.argv) > 1:
         sys.argv = sys.argv[1].split()
-    else:
-        sys.argv = ['-h']
 
-    pyController = CreateGrid(node,sys.argv)
+    parser = argparse.ArgumentParser(
+        description='Loads a 3D model a generates a regular grid using its bounding box')
+    parser.add_argument(
+        '-x','--gridx', dest='nx', type=int, default=10, help='')
+    parser.add_argument(
+        '-y','--gridy', dest='ny', type=int, default=10, help='')
+    parser.add_argument(
+        '-z', '--gridz', dest='nz', type=int, default=10, help='')
+    parser.add_argument(
+        '-m', '--mesh', dest='mesh', type=str, default="mesh/liver.obj", help='')
+    parser.add_argument(
+        '-o', '--output', dest='name', type=str, default="liverGrid", help='')
+    args, unknown = parser.parse_known_args(sys.argv)
+    createGrid(node, args.nx, args.ny, args.nz, args.mesh, args.name)
     return
 
 

--- a/applications/plugins/SofaPython/examples/RegularGridFromMesh.py
+++ b/applications/plugins/SofaPython/examples/RegularGridFromMesh.py
@@ -19,8 +19,8 @@ def createGrid(root, x, y, z, mesh, name):
     topoExporter.createObject('TetrahedronSetTopologyModifier')
     topoExporter.createObject('TetrahedronSetTopologyAlgorithms', template="Vec3d")
     topoExporter.createObject('TetrahedronSetGeometryAlgorithms', template="Vec3d", drawTetrahedra="0")
-    topoExporter.createObject('Hexa2TetraTopologicalMapping', name="default28", input="@" + grid.getPathName(),
-                              output="@" + topoContainer.getPathName())
+    topoExporter.createObject('Hexa2TetraTopologicalMapping', name="default28", input=grid.getLinkPath(),
+                              output=topoContainer.getLinkPath())
     # topoExporter.createObject('VTKExporter', position="@../DOFs.position", edges="0", tetras="1",
     #                           filename=self.name, exportAtBegin="true")
 

--- a/applications/plugins/SofaPython/examples/RegularGridFromMesh.py
+++ b/applications/plugins/SofaPython/examples/RegularGridFromMesh.py
@@ -1,0 +1,75 @@
+import argparse
+import Sofa
+import sys
+import os
+import math
+import numpy as np
+
+class CreateGrid(Sofa.PythonScriptController):
+
+    mesh = "mesh/liver.obj"
+    nx = 10
+    ny = 10
+    nz = 10
+    
+    def __init__(self, node, argv):
+        try:
+            parser = argparse.ArgumentParser(
+                description='Loads a 3D model a generates a regular grid using its bounding box')
+            parser.add_argument(
+                '-x','--gridx', dest='nx', type=int, default=self.nx, help='')
+            parser.add_argument(
+                '-y','--gridy', dest='ny', type=int, default=self.ny, help='')
+            parser.add_argument(
+                '-z', '--gridz', dest='nz', type=int, default=self.nz, help='')
+            parser.add_argument(
+                '-m', '--mesh', dest='mesh', type=str, default=self.mesh, help='')
+            parser.add_argument(
+                '-o', '--output', dest='name', type=str, default="", help='')
+            args = parser.parse_args(argv)
+            
+            self.nx = args.nx
+            self.ny = args.ny
+            self.nz = args.nz
+            self.mesh = args.mesh
+            self.name = args.name
+        except:
+            pass
+        self.root = node
+        self.createGraph(node)
+        return None
+
+    
+    def createGraph(self,root):
+        root.createObject('MeshObjLoader', name="loader", filename=self.mesh)
+        model = root.createObject('OglModel', name="model", src="@loader")
+        model.init()
+        model.computeBBox()
+        
+        root.createObject('RegularGrid', name="grid", nx=self.nx, ny=self.ny, nz=self.nz,
+                          min=model.bbox.minBBox, max=model.bbox.maxBBox)
+        root.createObject('MechanicalObject', name="DOFs")
+
+        topoExporter = root.createChild('Topo')
+        topoExporter.createObject('TetrahedronSetTopologyContainer', name="Container")
+        topoExporter.createObject('TetrahedronSetTopologyModifier')
+        topoExporter.createObject('TetrahedronSetTopologyAlgorithms', template="Vec3d")
+        topoExporter.createObject('TetrahedronSetGeometryAlgorithms', template="Vec3d", drawTetrahedra="0")
+        topoExporter.createObject('Hexa2TetraTopologicalMapping', name="default28", input="@../grid", output="@Container")
+        # topoExporter.createObject('VTKExporter', position="@../DOFs.position", edges="0", tetras="1",
+        #                           filename=self.name, exportAtBegin="true")
+
+        root.createObject('TetrahedronFEMForceField', name="FEM", youngModulus=5000, poissonRatio="0.4", method="large")
+        
+def createScene(node):
+    try :
+        sys.argv[0]
+    except :
+        sys.argv = sys.argv[1].split()
+    else:
+        sys.argv = ['-h']
+
+    pyController = CreateGrid(node,sys.argv)
+    return
+
+


### PR DESCRIPTION
This PR contains the code required to retrieve a component's bounding box in Python, and to manually call for a BaseObject's computeBBox method.

This was necessary in my case to create a RegularGrid from a mesh, since contrary to the sparseGrid, the regularGrid does not look at the node's MechanicalObject to create the grid.
An example scene in this PR shows my specific use case.

Concerning the bindings, I made the BoundingBox's minBBox and maxBBox read only since this should be computed by the component, and not set externally IMHO.

Could be useful to bind the different methods of BoundingBox too, but this is not covered in this PR




______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
