### PR TITLE
[SofaPreconditioner] FIX ShewchukPCGLinearSolver

### DIFF
--- a/modules/SofaPreconditioner/src/SofaPreconditioner/ShewchukPCGLinearSolver.cpp
+++ b/modules/SofaPreconditioner/src/SofaPreconditioner/ShewchukPCGLinearSolver.cpp
@@ -61,6 +61,7 @@ ShewchukPCGLinearSolver<TMatrix,TVector>::ShewchukPCGLinearSolver()
     , f_build_precond( initData(&f_build_precond,true,"build_precond","Build the preconditioners, if false build the preconditioner only at the initial step") )
     , f_preconditioners( initData(&f_preconditioners, "preconditioners", "If not empty: path to the solvers to use as preconditioners") )
     , f_graph( initData(&f_graph,"graph","Graph of residuals at each iteration") )
+    , preconditioners(0)
 {
     f_graph.setWidget("graph");
 //    f_graph.setReadOnly(true);

--- a/modules/SofaPreconditioner/src/SofaPreconditioner/ShewchukPCGLinearSolver.cpp
+++ b/modules/SofaPreconditioner/src/SofaPreconditioner/ShewchukPCGLinearSolver.cpp
@@ -77,8 +77,8 @@ void ShewchukPCGLinearSolver<TMatrix,TVector>::init()
 
         c->get(m_preconditioners, f_preconditioners.getValue());
 
-        if (m_preconditioners) sout << "Found " << f_preconditioners.getValue() << sendl;
-        else serr << "Solver \"" << f_preconditioners.getValue() << "\" not found." << sendl;
+        if (m_preconditioners) msg_info() << "Found " << f_preconditioners.getValue();
+        else msg_error() << "Solver \"" << f_preconditioners.getValue() << "\" not found.";
     }
 
     first = true;
@@ -230,7 +230,6 @@ SOFA_DECL_CLASS(ShewchukPCGLinearSolver)
 int ShewchukPCGLinearSolverClass = core::RegisterObject("Linear system solver using the conjugate gradient iterative algorithm")
 .add< ShewchukPCGLinearSolver<GraphScatteredMatrix,GraphScatteredVector> >(true)
 .addAlias("PCGLinearSolver");
-;
 
 } // namespace linearsolver
 

--- a/modules/SofaPreconditioner/src/SofaPreconditioner/ShewchukPCGLinearSolver.h
+++ b/modules/SofaPreconditioner/src/SofaPreconditioner/ShewchukPCGLinearSolver.h
@@ -70,7 +70,7 @@ public:
 
 private :
     unsigned next_refresh_step;
-    sofa::core::behavior::LinearSolver* preconditioners;
+    sofa::core::behavior::LinearSolver* m_preconditioners;
     bool first;
     int newton_iter;
 


### PR DESCRIPTION
This PR fixes ShewchukPCGLinearSolver member `preconditioners` initialization.
Should fix the failing scene test `FEMBAR-PCGLinearSolver.scn`

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
