### PR TITLE
[MultiThreading] New components and Task scheduler classes refactoring 

### DIFF
--- a/SofaKernel/modules/SofaExplicitOdeSolver/EulerSolver.cpp
+++ b/SofaKernel/modules/SofaExplicitOdeSolver/EulerSolver.cpp
@@ -59,7 +59,7 @@ SOFA_DECL_CLASS(Euler);
 
 EulerSolver::EulerSolver()
     : symplectic( initData( &symplectic, true, "symplectic", "If true, the velocities are updated before the positions and the method is symplectic (more robust). If false, the positions are updated before the velocities (standard Euler, less robust).") )
-    , d_threadsafevisitor(initData(&d_threadsafevisitor, false, "threadsafevisitor", "If true, do not use realloc and free visitors in fwdInteractionForceField."))
+    , d_threadSafeVisitor(initData(&d_threadSafeVisitor, false, "threadSafeVisitor", "If true, do not use realloc and free visitors in fwdInteractionForceField."))
 {
 }
 
@@ -72,7 +72,7 @@ void EulerSolver::solve(const core::ExecParams* params, SReal dt, sofa::core::Mu
     mop->setImplicit(false); // this solver is explicit only
     MultiVecCoord pos(&vop, core::VecCoordId::position() );
     MultiVecDeriv vel(&vop, core::VecDerivId::velocity() );
-    MultiVecDeriv acc(&vop, core::VecDerivId::dx()); acc.realloc(&vop, !d_threadsafevisitor.getValue(), true); // dx is no longer allocated by default (but it will be deleted automatically by the mechanical objects)
+    MultiVecDeriv acc(&vop, core::VecDerivId::dx()); acc.realloc(&vop, !d_threadSafeVisitor.getValue(), true); // dx is no longer allocated by default (but it will be deleted automatically by the mechanical objects)
     MultiVecDeriv f  (&vop, core::VecDerivId::force() );
     MultiVecCoord pos2(&vop, xResult /*core::VecCoordId::position()*/ );
     MultiVecDeriv vel2(&vop, vResult /*core::VecDerivId::velocity()*/ );

--- a/SofaKernel/modules/SofaExplicitOdeSolver/EulerSolver.cpp
+++ b/SofaKernel/modules/SofaExplicitOdeSolver/EulerSolver.cpp
@@ -59,6 +59,7 @@ SOFA_DECL_CLASS(Euler);
 
 EulerSolver::EulerSolver()
     : symplectic( initData( &symplectic, true, "symplectic", "If true, the velocities are updated before the positions and the method is symplectic (more robust). If false, the positions are updated before the velocities (standard Euler, less robust).") )
+    , d_threadsafevisitor(initData(&d_threadsafevisitor, false, "threadsafevisitor", "If true, do not use realloc and free visitors in fwdInteractionForceField."))
 {
 }
 
@@ -71,7 +72,7 @@ void EulerSolver::solve(const core::ExecParams* params, SReal dt, sofa::core::Mu
     mop->setImplicit(false); // this solver is explicit only
     MultiVecCoord pos(&vop, core::VecCoordId::position() );
     MultiVecDeriv vel(&vop, core::VecDerivId::velocity() );
-    MultiVecDeriv acc(&vop, core::VecDerivId::dx() ); acc.realloc( &vop, true, true ); // dx is no longer allocated by default (but it will be deleted automatically by the mechanical objects)
+    MultiVecDeriv acc(&vop, core::VecDerivId::dx()); acc.realloc(&vop, !d_threadsafevisitor.getValue(), true); // dx is no longer allocated by default (but it will be deleted automatically by the mechanical objects)
     MultiVecDeriv f  (&vop, core::VecDerivId::force() );
     MultiVecCoord pos2(&vop, xResult /*core::VecCoordId::position()*/ );
     MultiVecDeriv vel2(&vop, vResult /*core::VecDerivId::velocity()*/ );

--- a/SofaKernel/modules/SofaExplicitOdeSolver/EulerSolver.h
+++ b/SofaKernel/modules/SofaExplicitOdeSolver/EulerSolver.h
@@ -49,6 +49,7 @@ public:
     void solve(const core::ExecParams* params, SReal dt, sofa::core::MultiVecCoordId xResult, sofa::core::MultiVecDerivId vResult) override;
 
     Data<bool> symplectic; ///< If true, the velocities are updated before the positions and the method is symplectic (more robust). If false, the positions are updated before the velocities (standard Euler, less robust).
+    Data<bool> d_threadsafevisitor;
 
     /// Given an input derivative order (0 for position, 1 for velocity, 2 for acceleration),
     /// how much will it affect the output derivative of the given order.

--- a/SofaKernel/modules/SofaExplicitOdeSolver/EulerSolver.h
+++ b/SofaKernel/modules/SofaExplicitOdeSolver/EulerSolver.h
@@ -49,7 +49,7 @@ public:
     void solve(const core::ExecParams* params, SReal dt, sofa::core::MultiVecCoordId xResult, sofa::core::MultiVecDerivId vResult) override;
 
     Data<bool> symplectic; ///< If true, the velocities are updated before the positions and the method is symplectic (more robust). If false, the positions are updated before the velocities (standard Euler, less robust).
-    Data<bool> d_threadsafevisitor;
+    Data<bool> d_threadSafeVisitor;
 
     /// Given an input derivative order (0 for position, 1 for velocity, 2 for acceleration),
     /// how much will it affect the output derivative of the given order.

--- a/SofaKernel/modules/SofaImplicitOdeSolver/EulerImplicitSolver.cpp
+++ b/SofaKernel/modules/SofaImplicitOdeSolver/EulerImplicitSolver.cpp
@@ -54,7 +54,7 @@ EulerImplicitSolver::EulerImplicitSolver()
     , f_verbose( initData(&f_verbose,false,"verbose","Dump system state at each iteration") )
     , d_trapezoidalScheme( initData(&d_trapezoidalScheme,false,"trapezoidalScheme","Optional: use the trapezoidal scheme instead of the implicit Euler scheme and get second order accuracy in time") )
     , f_solveConstraint( initData(&f_solveConstraint,false,"solveConstraint","Apply ConstraintSolver (requires a ConstraintSolver in the same node as this solver, disabled by by default for now)") )
-    , d_threadsafevisitor(initData(&d_threadsafevisitor, false, "threadsafevisitor", "If true, do not use realloc and free visitors in fwdInteractionForceField."))
+    , d_threadSafeVisitor(initData(&d_threadSafeVisitor, false, "threadSafeVisitor", "If true, do not use realloc and free visitors in fwdInteractionForceField."))
 {
 }
 
@@ -75,7 +75,7 @@ void EulerImplicitSolver::cleanup()
 {
     // free the locally created vector x (including eventual external mechanical states linked by an InteractionForceField)
     sofa::simulation::common::VectorOperations vop( core::ExecParams::defaultInstance(), this->getContext() );
-    vop.v_free(x.id(), !d_threadsafevisitor.getValue(), true);
+    vop.v_free(x.id(), !d_threadSafeVisitor.getValue(), true);
 }
 
 void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::core::MultiVecCoordId xResult, sofa::core::MultiVecDerivId vResult)
@@ -97,9 +97,9 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
     mop.cparams.setV(vResult);
 
     // dx is no longer allocated by default (but it will be deleted automatically by the mechanical objects)
-    MultiVecDeriv dx(&vop, core::VecDerivId::dx()); dx.realloc(&vop, !d_threadsafevisitor.getValue(), true);
+    MultiVecDeriv dx(&vop, core::VecDerivId::dx()); dx.realloc(&vop, !d_threadSafeVisitor.getValue(), true);
 
-    x.realloc(&vop, !d_threadsafevisitor.getValue(), true);
+    x.realloc(&vop, !d_threadSafeVisitor.getValue(), true);
 
 
 #ifdef SOFA_DUMP_VISITOR_INFO

--- a/SofaKernel/modules/SofaImplicitOdeSolver/EulerImplicitSolver.h
+++ b/SofaKernel/modules/SofaImplicitOdeSolver/EulerImplicitSolver.h
@@ -112,7 +112,7 @@ public:
     Data<bool> f_verbose; ///< Dump system state at each iteration
     Data<bool> d_trapezoidalScheme; ///< Optional: use the trapezoidal scheme instead of the implicit Euler scheme and get second order accuracy in time
     Data<bool> f_solveConstraint; ///< Apply ConstraintSolver (requires a ConstraintSolver in the same node as this solver, disabled by by default for now)
-    Data<bool> d_threadsafevisitor;
+    Data<bool> d_threadSafeVisitor;
 
 protected:
     EulerImplicitSolver();

--- a/SofaKernel/modules/SofaImplicitOdeSolver/EulerImplicitSolver.h
+++ b/SofaKernel/modules/SofaImplicitOdeSolver/EulerImplicitSolver.h
@@ -112,6 +112,8 @@ public:
     Data<bool> f_verbose; ///< Dump system state at each iteration
     Data<bool> d_trapezoidalScheme; ///< Optional: use the trapezoidal scheme instead of the implicit Euler scheme and get second order accuracy in time
     Data<bool> f_solveConstraint; ///< Apply ConstraintSolver (requires a ConstraintSolver in the same node as this solver, disabled by by default for now)
+    Data<bool> d_threadsafevisitor;
+
 protected:
     EulerImplicitSolver();
 public:

--- a/SofaKernel/modules/SofaImplicitOdeSolver/StaticSolver.cpp
+++ b/SofaKernel/modules/SofaImplicitOdeSolver/StaticSolver.cpp
@@ -52,7 +52,7 @@ StaticSolver::StaticSolver()
     , dampingCoef( initData(&dampingCoef,(SReal)0.0,"dampingCoef","factor associated with the mass matrix in the equation system") )
     , stiffnessCoef( initData(&stiffnessCoef,(SReal)1.0,"stiffnessCoef","factor associated with the mass matrix in the equation system") )
     , applyIncrementFactor( initData(&applyIncrementFactor,false,"applyIncrementFactor","multiply the solution by dt before adding it to the current state") )
-    , d_threadsafevisitor(initData(&d_threadsafevisitor, false, "threadsafevisitor", "If true, do not use realloc and free visitors in fwdInteractionForceField."))
+    , d_threadSafeVisitor(initData(&d_threadSafeVisitor, false, "threadSafeVisitor", "If true, do not use realloc and free visitors in fwdInteractionForceField."))
 {
 }
 
@@ -69,7 +69,7 @@ void StaticSolver::solve(const core::ExecParams* params, SReal dt, sofa::core::M
     MultiVecDeriv x(&vop);
 
     // dx is no longer allocated by default (but it will be deleted automatically by the mechanical objects)
-    MultiVecDeriv dx(&vop, core::VecDerivId::dx()); dx.realloc(&vop, !d_threadsafevisitor.getValue(), true);
+    MultiVecDeriv dx(&vop, core::VecDerivId::dx()); dx.realloc(&vop, !d_threadSafeVisitor.getValue(), true);
     mop->setImplicit(true); // this solver is implicit
     mop.addSeparateGravity(dt);	// v += dt*g . Used if mass wants to add G to v separately from the other forces.
 

--- a/SofaKernel/modules/SofaImplicitOdeSolver/StaticSolver.cpp
+++ b/SofaKernel/modules/SofaImplicitOdeSolver/StaticSolver.cpp
@@ -52,6 +52,7 @@ StaticSolver::StaticSolver()
     , dampingCoef( initData(&dampingCoef,(SReal)0.0,"dampingCoef","factor associated with the mass matrix in the equation system") )
     , stiffnessCoef( initData(&stiffnessCoef,(SReal)1.0,"stiffnessCoef","factor associated with the mass matrix in the equation system") )
     , applyIncrementFactor( initData(&applyIncrementFactor,false,"applyIncrementFactor","multiply the solution by dt before adding it to the current state") )
+    , d_threadsafevisitor(initData(&d_threadsafevisitor, false, "threadsafevisitor", "If true, do not use realloc and free visitors in fwdInteractionForceField."))
 {
 }
 

--- a/SofaKernel/modules/SofaImplicitOdeSolver/StaticSolver.cpp
+++ b/SofaKernel/modules/SofaImplicitOdeSolver/StaticSolver.cpp
@@ -68,7 +68,7 @@ void StaticSolver::solve(const core::ExecParams* params, SReal dt, sofa::core::M
     MultiVecDeriv x(&vop);
 
     // dx is no longer allocated by default (but it will be deleted automatically by the mechanical objects)
-    MultiVecDeriv dx(&vop, core::VecDerivId::dx() ); dx.realloc( &vop, true, true );
+    MultiVecDeriv dx(&vop, core::VecDerivId::dx()); dx.realloc(&vop, !d_threadsafevisitor.getValue(), true);
     mop->setImplicit(true); // this solver is implicit
     mop.addSeparateGravity(dt);	// v += dt*g . Used if mass wants to add G to v separately from the other forces.
 

--- a/SofaKernel/modules/SofaImplicitOdeSolver/StaticSolver.h
+++ b/SofaKernel/modules/SofaImplicitOdeSolver/StaticSolver.h
@@ -80,7 +80,7 @@ public:
     Data<SReal> dampingCoef; ///< factor associated with the mass matrix in the equation system
     Data<SReal> stiffnessCoef; ///< factor associated with the mass matrix in the equation system
     Data<bool> applyIncrementFactor; ///< multiply the solution by dt. Default: false
-    Data<bool> d_threadsafevisitor;
+    Data<bool> d_threadSafeVisitor;
 };
 
 } // namespace odesolver

--- a/SofaKernel/modules/SofaImplicitOdeSolver/StaticSolver.h
+++ b/SofaKernel/modules/SofaImplicitOdeSolver/StaticSolver.h
@@ -80,6 +80,7 @@ public:
     Data<SReal> dampingCoef; ///< factor associated with the mass matrix in the equation system
     Data<SReal> stiffnessCoef; ///< factor associated with the mass matrix in the equation system
     Data<bool> applyIncrementFactor; ///< multiply the solution by dt. Default: false
+    Data<bool> d_threadsafevisitor;
 };
 
 } // namespace odesolver

--- a/applications/plugins/MultiThreading/CMakeLists.txt
+++ b/applications/plugins/MultiThreading/CMakeLists.txt
@@ -9,6 +9,7 @@ set(HEADER_FILES
     config.h
     src/TaskScheduler.h
     src/Tasks.h
+	src/InitTasks.h
     src/Locks.h
     src/AnimationLoopParallelScheduler.h
     src/AnimationLoopTasks.h
@@ -17,6 +18,9 @@ set(HEADER_FILES
     src/BeamLinearMapping_tasks.inl
     src/DataExchange.h
     src/DataExchange.inl
+	src/VisitorAsync.h
+	src/MeanComputation.h
+	src/MeanComputation.inl
     
 )
 
@@ -24,18 +28,18 @@ set(SOURCE_FILES
     src/initMultiThreading.cpp
     src/TaskScheduler.cpp
     src/Tasks.cpp
+	src/InitTasks.cpp
     src/AnimationLoopParallelScheduler.cpp
     src/AnimationLoopTasks.cpp
     src/BeamLinearMapping_mt.cpp
     src/DataExchange.cpp    
+	src/MeanComputation.cpp
 )
 
 find_package(SofaMisc REQUIRED)
-find_package(Boost QUIET COMPONENTS system thread date_time chrono)
-
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} SofaBaseMechanics SofaMiscMapping)
+target_link_libraries(${PROJECT_NAME} SofaBaseMechanics SofaMiscMapping SofaConstraint)
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>")
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>")
 target_include_directories(${PROJECT_NAME} PUBLIC "$<INSTALL_INTERFACE:include>")
@@ -52,9 +56,9 @@ sofa_create_package(MultiThreading ${MULTITHREADING_VERSION} MultiThreading Mult
 install(DIRECTORY examples/ DESTINATION share/sofa/plugins/${PROJECT_NAME})
 
 
-if(Boost_FOUND)
-  include_directories(${Boost_INCLUDE_DIRS})
-endif()
+# if(Boost_FOUND)
+#	include_directories(${Boost_INCLUDE_DIRS})
+# endif()
 
 if(SOFA_BUILD_TESTS)
     find_package(SofaTest QUIET)

--- a/applications/plugins/MultiThreading/examples/liversMeanPositions.scn
+++ b/applications/plugins/MultiThreading/examples/liversMeanPositions.scn
@@ -10,7 +10,7 @@
     <DefaultPipeline name="CollisionPipeline" verbose="0" />
     <BruteForceDetection name="N2" />
     <DefaultContactManager name="collision response" response="default" />
-	<LCPConstraintSolver tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
+	<LCPConstraintSolverAsync tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
     <Node name="liver1" gravity="0 -9.81 0">
       <EulerImplicitSolver name="cg_odesolver"   rayleighStiffness="0.1" rayleighMass="0.1" />
       <CGLinearSolver name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" />
@@ -40,7 +40,7 @@
     <DefaultPipeline name="CollisionPipeline" verbose="0" />
     <BruteForceDetection name="N2" />
     <DefaultContactManager name="collision response" response="default" />
-	<LCPConstraintSolver tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
+	<LCPConstraintSolverAsync tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
     <Node name="liver2" gravity="0 -9.81 0">
       <EulerImplicitSolver name="cg_odesolver"  />
       <CGLinearSolver name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" />
@@ -70,7 +70,7 @@
     <DefaultPipeline name="CollisionPipeline" verbose="0" />
     <BruteForceDetection name="N2" />
     <DefaultContactManager name="collision response" response="default" />
-	<LCPConstraintSolver tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
+	<LCPConstraintSolverAsync tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
     <Node name="liver3" gravity="0 -9.81 0">
       <EulerImplicitSolver name="cg_odesolver"  />
       <CGLinearSolver name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" />
@@ -101,7 +101,7 @@
     <DefaultPipeline name="CollisionPipeline" verbose="0" />
     <BruteForceDetection name="N2" />
     <DefaultContactManager name="collision response" response="default" />
-	<LCPConstraintSolver tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
+	<LCPConstraintSolverAsync tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
     <Node name="liver4" gravity="0 -9.81 0">
       <EulerImplicitSolver name="cg_odesolver"  />
       <CGLinearSolver name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" />
@@ -132,7 +132,7 @@
     <DefaultPipeline name="CollisionPipeline" verbose="0" />
     <BruteForceDetection name="N2" />
     <DefaultContactManager name="collision response" response="default" />
-	<LCPConstraintSolver tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
+	<LCPConstraintSolverAsync tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
     <Node name="Liver" gravity="0 -9.81 0">
       <!-- <EulerImplicitSolver name="cg_odesolver"  /> -->
       <!-- <CGLinearSolver name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" /> -->

--- a/applications/plugins/MultiThreading/examples/liversMeanPositions.scn
+++ b/applications/plugins/MultiThreading/examples/liversMeanPositions.scn
@@ -10,7 +10,7 @@
     <DefaultPipeline name="CollisionPipeline" verbose="0" />
     <BruteForceDetection name="N2" />
     <DefaultContactManager name="collision response" response="default" />
-	<LCPConstraintSolverAsync tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
+	  <LCPConstraintSolver tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
     <Node name="liver1" gravity="0 -9.81 0">
       <EulerImplicitSolver name="cg_odesolver"   rayleighStiffness="0.1" rayleighMass="0.1" />
       <CGLinearSolver name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" />
@@ -40,7 +40,7 @@
     <DefaultPipeline name="CollisionPipeline" verbose="0" />
     <BruteForceDetection name="N2" />
     <DefaultContactManager name="collision response" response="default" />
-	<LCPConstraintSolverAsync tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
+	  <LCPConstraintSolver tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
     <Node name="liver2" gravity="0 -9.81 0">
       <EulerImplicitSolver name="cg_odesolver"  />
       <CGLinearSolver name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" />
@@ -51,7 +51,7 @@
       <DiagonalMass  name="computed using mass density" massDensity="1" />
       <TetrahedralCorotationalFEMForceField template="Vec3d" name="FEM" method="large" poissonRatio="0.3" youngModulus="3000" computeGlobalMatrix="0" />
       <FixedConstraint  name="FixedConstraint" indices="64" />
-	  <UncoupledConstraintCorrection name="liver2_ConstraintCorrection"/>
+	    <UncoupledConstraintCorrection name="liver2_ConstraintCorrection"/>
       <Node name="Visu2" tags="Visual" gravity="0 -9.81 0">
         <OglModel  name="VisualModel" fileMesh="mesh/liver-smooth.obj" translation="-10 0 0"/>
         <BarycentricMapping name="visual mapping" input="@../dofs2" output="@VisualModel" />
@@ -70,7 +70,7 @@
     <DefaultPipeline name="CollisionPipeline" verbose="0" />
     <BruteForceDetection name="N2" />
     <DefaultContactManager name="collision response" response="default" />
-	<LCPConstraintSolverAsync tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
+	  <LCPConstraintSolver tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
     <Node name="liver3" gravity="0 -9.81 0">
       <EulerImplicitSolver name="cg_odesolver"  />
       <CGLinearSolver name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" />
@@ -101,7 +101,7 @@
     <DefaultPipeline name="CollisionPipeline" verbose="0" />
     <BruteForceDetection name="N2" />
     <DefaultContactManager name="collision response" response="default" />
-	<LCPConstraintSolverAsync tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
+	  <LCPConstraintSolver tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
     <Node name="liver4" gravity="0 -9.81 0">
       <EulerImplicitSolver name="cg_odesolver"  />
       <CGLinearSolver name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" />
@@ -132,25 +132,25 @@
     <DefaultPipeline name="CollisionPipeline" verbose="0" />
     <BruteForceDetection name="N2" />
     <DefaultContactManager name="collision response" response="default" />
-	<LCPConstraintSolverAsync tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
+	  <LCPConstraintSolver tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
     <Node name="Liver" gravity="0 -9.81 0">
       <!-- <EulerImplicitSolver name="cg_odesolver"  /> -->
       <!-- <CGLinearSolver name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" /> -->
       <MeshGmshLoader name="meshLoader" filename="mesh/liver.msh" translation="0 0 0"/>
       <TetrahedronSetTopologyContainer name="topo" src="@meshLoader" />
-	  <!-- <Node name="Result"> -->
-	  <MechanicalObject name="dofs1" />
-	  <MechanicalObject name="dofs2" />
-	  <MechanicalObject name="dofs3" />
-	  <MechanicalObject name="dofs4" />
-	  <MeanComputation name="LiverEngine"/>
-	  <!-- </Node> -->
-	  <MechanicalObject name="ResultDofs" position="@LiverEngine.result" tags="MeanOutput"/>
+	    <!-- <Node name="Result"> -->
+	    <MechanicalObject name="dofs1" />
+	    <MechanicalObject name="dofs2" />
+	    <MechanicalObject name="dofs3" />
+	    <MechanicalObject name="dofs4" />
+	    <MeanComputation name="LiverEngine"/>
+	    <!-- </Node> -->
+	    <MechanicalObject name="ResultDofs" position="@LiverEngine.result" tags="MeanOutput"/>
       <!-- <TetrahedronSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" /> -->
       <!-- <DiagonalMass  name="computed using mass density" massDensity="1" /> -->
       <!-- <TetrahedralCorotationalFEMForceField template="Vec3d" name="FEM" method="large" poissonRatio="0.3" youngModulus="3000" computeGlobalMatrix="0" /> -->
       <!-- <FixedConstraint  name="FixedConstraint" indices="96" /> -->
-	  <!-- <UncoupledConstraintCorrection name="liver4_ConstraintCorrection"/> -->
+	    <!-- <UncoupledConstraintCorrection name="liver4_ConstraintCorrection"/> -->
       <Node name="ResultVisu" tags="Visual" gravity="0 -9.81 0">
         <OglModel  name="VisualModel" fileMesh="mesh/liver-smooth.obj" translation="0 0 0" color="blue"/>
         <BarycentricMapping name="visual mapping" input="@../ResultDofs" output="@VisualModel" />

--- a/applications/plugins/MultiThreading/examples/liversMeanPositions.scn
+++ b/applications/plugins/MultiThreading/examples/liversMeanPositions.scn
@@ -10,7 +10,7 @@
     <DefaultPipeline name="CollisionPipeline" verbose="0" />
     <BruteForceDetection name="N2" />
     <DefaultContactManager name="collision response" response="default" />
-	<LCPConstraintSolverAsync tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
+	<LCPConstraintSolver tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
     <Node name="liver1" gravity="0 -9.81 0">
       <EulerImplicitSolver name="cg_odesolver"   rayleighStiffness="0.1" rayleighMass="0.1" />
       <CGLinearSolver name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" />
@@ -40,7 +40,7 @@
     <DefaultPipeline name="CollisionPipeline" verbose="0" />
     <BruteForceDetection name="N2" />
     <DefaultContactManager name="collision response" response="default" />
-	<LCPConstraintSolverAsync tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
+	<LCPConstraintSolver tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
     <Node name="liver2" gravity="0 -9.81 0">
       <EulerImplicitSolver name="cg_odesolver"  />
       <CGLinearSolver name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" />
@@ -70,7 +70,7 @@
     <DefaultPipeline name="CollisionPipeline" verbose="0" />
     <BruteForceDetection name="N2" />
     <DefaultContactManager name="collision response" response="default" />
-	<LCPConstraintSolverAsync tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
+	<LCPConstraintSolver tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
     <Node name="liver3" gravity="0 -9.81 0">
       <EulerImplicitSolver name="cg_odesolver"  />
       <CGLinearSolver name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" />
@@ -101,7 +101,7 @@
     <DefaultPipeline name="CollisionPipeline" verbose="0" />
     <BruteForceDetection name="N2" />
     <DefaultContactManager name="collision response" response="default" />
-	<LCPConstraintSolverAsync tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
+	<LCPConstraintSolver tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
     <Node name="liver4" gravity="0 -9.81 0">
       <EulerImplicitSolver name="cg_odesolver"  />
       <CGLinearSolver name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" />
@@ -132,7 +132,7 @@
     <DefaultPipeline name="CollisionPipeline" verbose="0" />
     <BruteForceDetection name="N2" />
     <DefaultContactManager name="collision response" response="default" />
-	<LCPConstraintSolverAsync tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
+	<LCPConstraintSolver tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
     <Node name="Liver" gravity="0 -9.81 0">
       <!-- <EulerImplicitSolver name="cg_odesolver"  /> -->
       <!-- <CGLinearSolver name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" /> -->

--- a/applications/plugins/MultiThreading/examples/liversMeanPositions.scn
+++ b/applications/plugins/MultiThreading/examples/liversMeanPositions.scn
@@ -1,0 +1,175 @@
+<?xml version="1.0" ?>
+<Node name="root" gravity="0 -9.81 0" dt="0.02">
+  <!--<RequiredPlugin pluginName="PluginXiCath_1_0.dll" />-->
+  <RequiredPlugin pluginName="MultiThreading" />
+  
+  <AnimationLoopParallelScheduler name="mainLoop" threadNumber="0" />
+
+  <Node name="scene1" gravity="0 -9.81 0" dt="0.02">
+    <FreeMotionAnimationLoop name="loop1" />
+    <DefaultPipeline name="CollisionPipeline" verbose="0" />
+    <BruteForceDetection name="N2" />
+    <DefaultContactManager name="collision response" response="default" />
+	<LCPConstraintSolverAsync tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
+    <Node name="liver1" gravity="0 -9.81 0">
+      <EulerImplicitSolver name="cg_odesolver"   rayleighStiffness="0.1" rayleighMass="0.1" />
+      <CGLinearSolver name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" />
+      <MeshGmshLoader name="meshLoader" filename="mesh/liver.msh" translation="10 0 0" />
+      <TetrahedronSetTopologyContainer name="topo" src="@meshLoader" />
+      <MechanicalObject name="dofs1" src="@meshLoader" />
+      <TetrahedronSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
+      <DiagonalMass  name="computed using mass density" massDensity="1" />
+      <TetrahedralCorotationalFEMForceField template="Vec3d" name="FEM" method="large" poissonRatio="0.3" youngModulus="3000" computeGlobalMatrix="0" />
+      <FixedConstraint  name="FixedConstraint" indices="39" />
+	  <UncoupledConstraintCorrection name="liver1_ConstraintCorrection"/>	
+      <Node name="Visu1" tags="Visual" gravity="0 -9.81 0">
+        <OglModel  name="VisualModel" fileMesh="mesh/liver-smooth.obj"  translation="10 0 0"/>
+        <BarycentricMapping name="visual mapping" input="@../dofs1" output="@VisualModel" />
+      </Node>
+      <Node name="Surf1" gravity="0 -9.81 0">
+        <SphereLoader filename="mesh/liver.sph" />
+        <MechanicalObject name="spheres" position="@[-1].position" />
+        <TSphereModel name="CollisionModel" listRadius="@[-2].listRadius"/>
+        <BarycentricMapping name="sphere mapping" input="@../dofs1" output="@spheres" />
+      </Node>
+    </Node>
+  </Node>
+
+  <Node name="scene2" gravity="0 -9.81 0" dt="0.02">
+    <FreeMotionAnimationLoop name="loop2" />
+    <DefaultPipeline name="CollisionPipeline" verbose="0" />
+    <BruteForceDetection name="N2" />
+    <DefaultContactManager name="collision response" response="default" />
+	<LCPConstraintSolverAsync tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
+    <Node name="liver2" gravity="0 -9.81 0">
+      <EulerImplicitSolver name="cg_odesolver"  />
+      <CGLinearSolver name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" />
+      <MeshGmshLoader name="meshLoader" filename="mesh/liver.msh" translation="-10 0 0"/>
+      <TetrahedronSetTopologyContainer name="topo" src="@meshLoader" />
+      <MechanicalObject name="dofs2" src="@meshLoader" />
+      <TetrahedronSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
+      <DiagonalMass  name="computed using mass density" massDensity="1" />
+      <TetrahedralCorotationalFEMForceField template="Vec3d" name="FEM" method="large" poissonRatio="0.3" youngModulus="3000" computeGlobalMatrix="0" />
+      <FixedConstraint  name="FixedConstraint" indices="64" />
+	  <UncoupledConstraintCorrection name="liver2_ConstraintCorrection"/>
+      <Node name="Visu2" tags="Visual" gravity="0 -9.81 0">
+        <OglModel  name="VisualModel" fileMesh="mesh/liver-smooth.obj" translation="-10 0 0"/>
+        <BarycentricMapping name="visual mapping" input="@../dofs2" output="@VisualModel" />
+      </Node>
+      <Node name="Surf2" gravity="0 -9.81 0">
+        <SphereLoader filename="mesh/liver.sph" />
+        <MechanicalObject name="spheres" position="@[-1].position" />
+        <TSphereModel name="CollisionModel" listRadius="@[-2].listRadius"/>
+        <BarycentricMapping name="sphere mapping" input="@../dofs2" output="@spheres" />
+      </Node>
+    </Node>
+  </Node>
+
+  <Node name="scene3" gravity="0 -9.81 0" dt="0.02">
+    <FreeMotionAnimationLoop name="loop2" />
+    <DefaultPipeline name="CollisionPipeline" verbose="0" />
+    <BruteForceDetection name="N2" />
+    <DefaultContactManager name="collision response" response="default" />
+	<LCPConstraintSolverAsync tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
+    <Node name="liver3" gravity="0 -9.81 0">
+      <EulerImplicitSolver name="cg_odesolver"  />
+      <CGLinearSolver name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" />
+      <MeshGmshLoader name="meshLoader" filename="mesh/liver.msh" translation="10 10 0"/>
+      <TetrahedronSetTopologyContainer name="topo" src="@meshLoader" />
+      <MechanicalObject name="dofs3" src="@meshLoader" />
+      <TetrahedronSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
+      <DiagonalMass  name="computed using mass density" massDensity="1" />
+      <TetrahedralCorotationalFEMForceField template="Vec3d" name="FEM" method="large" poissonRatio="0.3" youngModulus="3000" computeGlobalMatrix="0" />
+      <FixedConstraint  name="FixedConstraint" indices="72" />
+	  <UncoupledConstraintCorrection name="liver3_ConstraintCorrection"/>
+      <Node name="Visu3" tags="Visual" gravity="0 -9.81 0">
+        <OglModel  name="VisualModel" fileMesh="mesh/liver-smooth.obj" translation="10 10 0"/>
+        <BarycentricMapping name="visual mapping" input="@../dofs3" output="@VisualModel" />
+      </Node>
+      <Node name="Surf3" gravity="0 -9.81 0">
+        <SphereLoader filename="mesh/liver.sph" />
+        <MechanicalObject name="spheres" position="@[-1].position" />
+        <TSphereModel name="CollisionModel" listRadius="@[-2].listRadius"/>
+        <BarycentricMapping name="sphere mapping" input="@../dofs3" output="@spheres" />
+      </Node>
+    </Node>
+  </Node>
+
+
+  <Node name="scene4" gravity="0 -9.81 0" dt="0.02">
+    <FreeMotionAnimationLoop name="loop2" />
+    <DefaultPipeline name="CollisionPipeline" verbose="0" />
+    <BruteForceDetection name="N2" />
+    <DefaultContactManager name="collision response" response="default" />
+	<LCPConstraintSolverAsync tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
+    <Node name="liver4" gravity="0 -9.81 0">
+      <EulerImplicitSolver name="cg_odesolver"  />
+      <CGLinearSolver name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" />
+      <MeshGmshLoader name="meshLoader" filename="mesh/liver.msh" translation="-10 10 0"/>
+      <TetrahedronSetTopologyContainer name="topo" src="@meshLoader" />
+      <MechanicalObject name="dofs4" src="@meshLoader" />
+      <TetrahedronSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
+      <DiagonalMass  name="computed using mass density" massDensity="1" />
+      <TetrahedralCorotationalFEMForceField template="Vec3d" name="FEM" method="large" poissonRatio="0.3" youngModulus="3000" computeGlobalMatrix="0" />
+      <FixedConstraint  name="FixedConstraint" indices="96" />
+	  <UncoupledConstraintCorrection name="liver4_ConstraintCorrection"/>
+      <Node name="Visu4" tags="Visual" gravity="0 -9.81 0">
+        <OglModel  name="VisualModel" fileMesh="mesh/liver-smooth.obj" translation="-10 10 0"/>
+        <BarycentricMapping name="visual mapping" input="@../dofs4" output="@VisualModel" />
+      </Node>
+      <Node name="Surf4" gravity="0 -9.81 0">
+        <SphereLoader filename="mesh/liver.sph" />
+        <MechanicalObject name="spheres" position="@[-1].position" />
+        <TSphereModel name="CollisionModel" listRadius="@[-2].listRadius"/>
+        <BarycentricMapping name="sphere mapping" input="@../dofs4" output="@spheres" />
+      </Node>
+    </Node>
+  </Node>
+
+  
+  <Node name="ResultScene" gravity="0 -9.81 0" dt="0.02">
+    <FreeMotionAnimationLoop name="ResultAnimationLoop" />
+    <DefaultPipeline name="CollisionPipeline" verbose="0" />
+    <BruteForceDetection name="N2" />
+    <DefaultContactManager name="collision response" response="default" />
+	<LCPConstraintSolverAsync tolerance="1e-3" maxIt="100" initial_guess="false" build_lcp="true"  printLog="0" mu="0.2"/>
+    <Node name="Liver" gravity="0 -9.81 0">
+      <!-- <EulerImplicitSolver name="cg_odesolver"  /> -->
+      <!-- <CGLinearSolver name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" /> -->
+      <MeshGmshLoader name="meshLoader" filename="mesh/liver.msh" translation="0 0 0"/>
+      <TetrahedronSetTopologyContainer name="topo" src="@meshLoader" />
+	  <!-- <Node name="Result"> -->
+	  <MechanicalObject name="dofs1" />
+	  <MechanicalObject name="dofs2" />
+	  <MechanicalObject name="dofs3" />
+	  <MechanicalObject name="dofs4" />
+	  <MeanComputation name="LiverEngine"/>
+	  <!-- </Node> -->
+	  <MechanicalObject name="ResultDofs" position="@LiverEngine.result" tags="MeanOutput"/>
+      <!-- <TetrahedronSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" /> -->
+      <!-- <DiagonalMass  name="computed using mass density" massDensity="1" /> -->
+      <!-- <TetrahedralCorotationalFEMForceField template="Vec3d" name="FEM" method="large" poissonRatio="0.3" youngModulus="3000" computeGlobalMatrix="0" /> -->
+      <!-- <FixedConstraint  name="FixedConstraint" indices="96" /> -->
+	  <!-- <UncoupledConstraintCorrection name="liver4_ConstraintCorrection"/> -->
+      <Node name="ResultVisu" tags="Visual" gravity="0 -9.81 0">
+        <OglModel  name="VisualModel" fileMesh="mesh/liver-smooth.obj" translation="0 0 0" color="blue"/>
+        <BarycentricMapping name="visual mapping" input="@../ResultDofs" output="@VisualModel" />
+      </Node>
+      <Node name="ResultSurf" gravity="0 -9.81 0">
+        <SphereLoader filename="mesh/liver.sph" />
+        <MechanicalObject name="spheres" position="@[-1].position" />
+        <TSphereModel name="CollisionModel" listRadius="@[-2].listRadius"/>
+        <BarycentricMapping name="sphere mapping" input="@../ResultDofs" output="@spheres" />
+      </Node>
+    </Node>
+  </Node>
+  
+  <!-- <DataExchange name="exchangeData0" template="vector<Vec3d>" from="@scene1/liver1/dofs1.position" to="@ResultScene/ResultLiver/LiverEngine.Inputs" /> -->
+  <DataExchange name="exchangeData1" template="vector<Vec3d>" from="@scene1/liver1/dofs1.position" to="@ResultScene/Liver/dofs1.position" />
+  <DataExchange name="exchangeData2" template="vector<Vec3d>" from="@scene2/liver2/dofs2.position" to="@ResultScene/Liver/dofs2.position" />
+  <DataExchange name="exchangeData3" template="vector<Vec3d>" from="@scene3/liver3/dofs3.position" to="@ResultScene/Liver/dofs3.position" />
+  <DataExchange name="exchangeData4" template="vector<Vec3d>" from="@scene4/liver4/dofs4.position" to="@ResultScene/Liver/dofs4.position" />
+  <!--<DataExchange name="exchangeData2" template="vector<Vec3d>" from="@scene1/liver1/dofs1.free_position" to="@scene2/liver2/dofs2.free_position" />-->
+    
+
+</Node>

--- a/applications/plugins/MultiThreading/src/AnimationLoopTasks.cpp
+++ b/applications/plugins/MultiThreading/src/AnimationLoopTasks.cpp
@@ -34,61 +34,7 @@ namespace sofa
         {
             animationloop->step( core::ExecParams::defaultInstance(), dt);
             return true;
-        }
-        
-        
-        
-        
-        //InitPerThreadDataTask::InitPerThreadDataTask(volatile long* atomicCounter, boost::mutex* mutex, TaskStatus* pStatus )
-        InitPerThreadDataTask::InitPerThreadDataTask(std::atomic<int>* atomicCounter, std::mutex* mutex, Task::Status* pStatus )
-        : Task(pStatus), IdFactorygetIDMutex(mutex), _atomicCounter(atomicCounter)
-        {}
-        
-        InitPerThreadDataTask::~InitPerThreadDataTask()
-        {
-        }
-        
-        bool InitPerThreadDataTask::run(WorkerThread* )
-        {
-            
-            core::ExecParams::defaultInstance();
-            
-            core::ConstraintParams::defaultInstance();
-            
-            core::MechanicalParams::defaultInstance();
-            
-            core::visual::VisualParams::defaultInstance();
-            
-            // init curTimerThread
-            //helper::getCurTimer();
-            //std::stack<AdvancedTimer::IdTimer>& getCurTimer();
-            {
-                // to solve IdFactory<Base>::getID() problem in AdvancedTimer functions
-                std::lock_guard<std::mutex> lock(*IdFactorygetIDMutex);
-                
-                //spinMutexLock lock( IdFactorygetIDMutex );
-                
-                helper::AdvancedTimer::begin("Animate");
-                helper::AdvancedTimer::end("Animate");
-                //helper::AdvancedTimer::stepBegin("AnimationStep");
-                //helper::AdvancedTimer::stepEnd("AnimationStep");
-            }
-            
-            
-            //BOOST_INTERLOCKED_DECREMENT( mAtomicCounter );
-            //BOOST_COMPILER_FENCE;
-            
-            _atomicCounter->fetch_sub(1, std::memory_order_acq_rel);
-            
-            
-            while(_atomicCounter->load(std::memory_order_relaxed) > 0)
-            {
-                // yield while waiting
-                std::this_thread::yield();
-            }
-            return false;
-        }
-        
+        }        
         
     } // namespace simulation
     

--- a/applications/plugins/MultiThreading/src/AnimationLoopTasks.h
+++ b/applications/plugins/MultiThreading/src/AnimationLoopTasks.h
@@ -63,30 +63,6 @@ namespace sofa
         };
         
         
-        
-        
-        class InitPerThreadDataTask : public Task
-        {
-            
-        public:
-            
-            //InitPerThreadDataTask(volatile long* atomicCounter, boost::mutex* mutex, TaskStatus* pStatus );
-            InitPerThreadDataTask(std::atomic<int>* atomicCounter, std::mutex* mutex, Task::Status* pStatus );
-            
-            virtual ~InitPerThreadDataTask();
-            
-            virtual bool run(WorkerThread* );
-            
-            
-        private:
-            
-            std::mutex*     IdFactorygetIDMutex;
-            
-            std::atomic<int>* _atomicCounter;
-            
-        };
-        
-        
     } // namespace simulation
     
 } // namespace sofa

--- a/applications/plugins/MultiThreading/src/BeamLinearMapping_tasks.inl
+++ b/applications/plugins/MultiThreading/src/BeamLinearMapping_tasks.inl
@@ -79,7 +79,7 @@ namespace mapping
 			fact = 3*(fact*fact)-2*(fact*fact*fact);
 			(*_out)[i] = out0 * (1-fact) + out1 * (fact);
 		}
-		return true;
+		return false;
 	}
 
 
@@ -128,7 +128,7 @@ namespace mapping
 			
 			(*_out)[i] = out0 * (1-fact) + out1 * (fact);
 		}
-		return true;
+		return false;
 	}
 
 
@@ -183,7 +183,7 @@ namespace mapping
 			getVOrientation(_out1) += cross( rotatedPoint1, f) * (fact);
 
 		}
-		return true;
+		return false;
 	}
 
 

--- a/applications/plugins/MultiThreading/src/DataExchange.h
+++ b/applications/plugins/MultiThreading/src/DataExchange.h
@@ -84,6 +84,16 @@ namespace sofa
 
 			virtual void handleEvent( core::objectmodel::Event* event );
 
+            virtual std::string getTemplateName() const  override
+            { 
+                return templateName(this);
+            }
+
+            static std::string templateName(const DataExchange<DataTypes>* = nullptr)
+            { 
+                return sofa::defaulttype::DataTypeName<DataTypes>::name();
+            }
+
 			template<class T>
 			static bool canCreate(T*& obj, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
 			{

--- a/applications/plugins/MultiThreading/src/InitTasks.cpp
+++ b/applications/plugins/MultiThreading/src/InitTasks.cpp
@@ -6,7 +6,6 @@
 #include <sofa/core/MechanicalParams.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/AdvancedTimer.h>
-//#include <sofa/helper/system/atomic.h>
 
 
 namespace sofa
@@ -34,9 +33,6 @@ namespace sofa
 
             core::visual::VisualParams::defaultInstance();
 
-            // init curTimerThread
-            //helper::getCurTimer();
-            //std::stack<AdvancedTimer::IdTimer>& getCurTimer();
             {
                 // to solve IdFactory<Base>::getID() problem in AdvancedTimer functions
                 std::lock_guard<std::mutex> lock(*IdFactorygetIDMutex);
@@ -45,16 +41,9 @@ namespace sofa
 
                 helper::AdvancedTimer::begin("Animate");
                 helper::AdvancedTimer::end("Animate");
-                //helper::AdvancedTimer::stepBegin("AnimationStep");
-                //helper::AdvancedTimer::stepEnd("AnimationStep");
             }
 
-
-            //BOOST_INTERLOCKED_DECREMENT( mAtomicCounter );
-            //BOOST_COMPILER_FENCE;
-
             _atomicCounter->fetch_sub(1, std::memory_order_acq_rel);
-
 
             while (_atomicCounter->load(std::memory_order_relaxed) > 0)
             {
@@ -87,135 +76,6 @@ namespace sofa
             
             return;
         }
-        
-
-#ifdef _WIN32
-        
-
-        static HDC glGlobalDevice = nullptr;
-        static thread_local HGLRC glGlobalContext = nullptr;
-        
-        
-        InitOGLcontextTask::InitOGLcontextTask(HDC& glDevice, HGLRC& workerThreadContext, std::atomic<int>* atomicCounter, std::mutex* mutex, Task::Status* pStatus)
-            : Task(pStatus), _glDevice(glDevice), _workerThreadContext(workerThreadContext), IdFactorygetIDMutex(mutex), _atomicCounter(atomicCounter)
-        {}
-
-        InitOGLcontextTask::~InitOGLcontextTask()
-        {
-        }
-
-        bool InitOGLcontextTask::run(sofa::simulation::WorkerThread*)
-        {
-            //glGlobalContext = wglCreateContext(_hdc);
-            //wglShareLists(_mainContext, glGlobalContext);
-            glGlobalContext = _workerThreadContext;
-            wglMakeCurrent(_glDevice, _workerThreadContext);
-
-            _atomicCounter->fetch_sub(1, std::memory_order_acq_rel);
-            while (_atomicCounter->load(std::memory_order_relaxed) > 0)
-            {
-                // yield while waiting  
-                std::this_thread::yield();
-            }
-            return true;
-        }
-
-
-        DeleteOGLcontextTask::DeleteOGLcontextTask(std::atomic<int>* atomicCounter, std::mutex* mutex, Task::Status* pStatus)
-            : Task(pStatus), IdFactorygetIDMutex(mutex), _atomicCounter(atomicCounter)
-        {}
-
-        DeleteOGLcontextTask::~DeleteOGLcontextTask()
-        {
-        }
-
-        bool DeleteOGLcontextTask::run(sofa::simulation::WorkerThread*)
-        {
-            wglDeleteContext(glGlobalContext);
-
-            _atomicCounter->fetch_sub(1, std::memory_order_acq_rel);
-            while (_atomicCounter->load(std::memory_order_relaxed) > 0)
-            {
-                // yield while waiting  
-                std::this_thread::yield();
-            }
-            return true;
-        }
-
-        // temp remove this function to use the global one
-        void initOGLcontext()
-        {
-            HWND hwin = FindWindow(0, L"GLEWTest");
-            glGlobalDevice = wglGetCurrentDC();// GetDC(hwin);
-                                               //main thread context
-                                               // share this context with worker thread contexts
-            glGlobalContext = wglGetCurrentContext();// wglCreateContext(glGlobalDevice);
-            HGLRC mainContext = glGlobalContext;
-
-            // drop the main context before sharing the context
-            // http://hacksoflife.blogspot.com/2008/02/creating-opengl-objects-in-second.html
-            wglMakeCurrent(NULL, NULL);
-
-            std::atomic<int> atomicCounter;
-            atomicCounter = sofa::simulation::TaskScheduler::getInstance().size() - 1;
-
-            std::mutex  InitThreadSpecificMutex;
-
-            sofa::simulation::Task::Status status;
-
-            const int nbWorkerThread = sofa::simulation::TaskScheduler::getInstance().size() - 1;
-            sofa::simulation::WorkerThread* thread = sofa::simulation::WorkerThread::getCurrent();
-
-            for (int i = 0; i<nbWorkerThread; ++i)
-            {
-                // creqte a new context and share it with the main thread context
-                HGLRC workerThreadContexts = wglCreateContext(glGlobalDevice);
-                wglShareLists(mainContext, workerThreadContexts);
-
-                thread->addTask(new InitOGLcontextTask(glGlobalDevice, workerThreadContexts, &atomicCounter, &InitThreadSpecificMutex, &status));
-            }
-
-            // wait for worker thread to complete the per-thread task
-            while (status.isBusy())
-            {
-                std::this_thread::sleep_for(std::chrono::milliseconds(1));
-            }
-
-            // set the main context back after sharing the context
-            // http://hacksoflife.blogspot.com/2008/02/creating-opengl-objects-in-second.html
-            wglMakeCurrent(glGlobalDevice, glGlobalContext);
-
-
-            return;
-        }
-
-        // temp remove this function to use the global one
-        void deleteOGLcontext()
-        {
-            std::atomic<int> atomicCounter;
-            atomicCounter = sofa::simulation::TaskScheduler::getInstance().size() - 1;
-
-            std::mutex  InitThreadSpecificMutex;
-
-            sofa::simulation::Task::Status status;
-
-            const int nbWorkerThread = sofa::simulation::TaskScheduler::getInstance().size() - 1;
-            sofa::simulation::WorkerThread* thread = sofa::simulation::WorkerThread::getCurrent();
-
-            for (int i = 0; i<nbWorkerThread; ++i)
-            {
-                thread->addTask(new DeleteOGLcontextTask(&atomicCounter, &InitThreadSpecificMutex, &status));
-            }
-
-            // wait for worker thread to complete the per-thread task
-            while (status.isBusy())
-            {
-                std::this_thread::sleep_for(std::chrono::milliseconds(1));
-            }
-            return;
-        }
-
-#endif // _WIN32
         
         
     } // namespace simulation

--- a/applications/plugins/MultiThreading/src/InitTasks.cpp
+++ b/applications/plugins/MultiThreading/src/InitTasks.cpp
@@ -1,0 +1,217 @@
+#include "InitTasks.h"
+
+#include <sofa/core/behavior/BaseAnimationLoop.h>
+#include <sofa/core/ExecParams.h>
+#include <sofa/core/ConstraintParams.h>
+#include <sofa/core/MechanicalParams.h>
+#include <sofa/core/visual/VisualParams.h>
+#include <sofa/helper/AdvancedTimer.h>
+//#include <sofa/helper/system/atomic.h>
+
+
+namespace sofa
+{
+
+    namespace simulation
+    {
+
+        static HDC glGlobalDevice = nullptr;
+        static thread_local HGLRC glGlobalContext = nullptr;
+
+
+        InitPerThreadDataTask::InitPerThreadDataTask(std::atomic<int>* atomicCounter, std::mutex* mutex, Task::Status* pStatus)
+            : Task(pStatus), IdFactorygetIDMutex(mutex), _atomicCounter(atomicCounter)
+        {}
+
+        InitPerThreadDataTask::~InitPerThreadDataTask()
+        {
+        }
+
+        bool InitPerThreadDataTask::run(WorkerThread*)
+        {
+
+            core::ExecParams::defaultInstance();
+
+            core::ConstraintParams::defaultInstance();
+
+            core::MechanicalParams::defaultInstance();
+
+            core::visual::VisualParams::defaultInstance();
+
+            // init curTimerThread
+            //helper::getCurTimer();
+            //std::stack<AdvancedTimer::IdTimer>& getCurTimer();
+            {
+                // to solve IdFactory<Base>::getID() problem in AdvancedTimer functions
+                std::lock_guard<std::mutex> lock(*IdFactorygetIDMutex);
+
+                //spinMutexLock lock( IdFactorygetIDMutex );
+
+                helper::AdvancedTimer::begin("Animate");
+                helper::AdvancedTimer::end("Animate");
+                //helper::AdvancedTimer::stepBegin("AnimationStep");
+                //helper::AdvancedTimer::stepEnd("AnimationStep");
+            }
+
+
+            //BOOST_INTERLOCKED_DECREMENT( mAtomicCounter );
+            //BOOST_COMPILER_FENCE;
+
+            _atomicCounter->fetch_sub(1, std::memory_order_acq_rel);
+
+
+            while (_atomicCounter->load(std::memory_order_relaxed) > 0)
+            {
+                // yield while waiting  
+                std::this_thread::yield();
+            }
+            return true;
+        }
+
+
+
+        InitOGLcontextTask::InitOGLcontextTask(HDC& glDevice, HGLRC& workerThreadContext, std::atomic<int>* atomicCounter, std::mutex* mutex, Task::Status* pStatus)
+            : Task(pStatus), _glDevice(glDevice), _workerThreadContext(workerThreadContext), IdFactorygetIDMutex(mutex), _atomicCounter(atomicCounter)
+        {}
+
+        InitOGLcontextTask::~InitOGLcontextTask()
+        {
+        }
+
+        bool InitOGLcontextTask::run(sofa::simulation::WorkerThread*)
+        {
+            //glGlobalContext = wglCreateContext(_hdc);
+            //wglShareLists(_mainContext, glGlobalContext);
+            glGlobalContext = _workerThreadContext;
+            wglMakeCurrent(_glDevice, _workerThreadContext);
+
+            _atomicCounter->fetch_sub(1, std::memory_order_acq_rel);
+            while (_atomicCounter->load(std::memory_order_relaxed) > 0)
+            {
+                // yield while waiting  
+                std::this_thread::yield();
+            }
+            return true;
+        }
+
+
+        DeleteOGLcontextTask::DeleteOGLcontextTask(std::atomic<int>* atomicCounter, std::mutex* mutex, Task::Status* pStatus)
+            : Task(pStatus), IdFactorygetIDMutex(mutex), _atomicCounter(atomicCounter)
+        {}
+
+        DeleteOGLcontextTask::~DeleteOGLcontextTask()
+        {
+        }
+
+        bool DeleteOGLcontextTask::run(sofa::simulation::WorkerThread*)
+        {
+            wglDeleteContext(glGlobalContext);
+
+            _atomicCounter->fetch_sub(1, std::memory_order_acq_rel);
+            while (_atomicCounter->load(std::memory_order_relaxed) > 0)
+            {
+                // yield while waiting  
+                std::this_thread::yield();
+            }
+            return true;
+        }
+
+        // temp remove this function to use the global one
+        void initThreadLocalData()
+        {
+            std::atomic<int> atomicCounter;
+            atomicCounter = TaskScheduler::getInstance().size();
+
+            std::mutex  InitThreadSpecificMutex;
+
+            Task::Status status;
+
+            const int nbThread = TaskScheduler::getInstance().size();
+            WorkerThread* thread = WorkerThread::getCurrent();
+
+            for (int i = 0; i<nbThread; ++i)
+            {
+                thread->addTask(new InitPerThreadDataTask(&atomicCounter, &InitThreadSpecificMutex, &status));
+            }
+
+            thread->workUntilDone(&status);
+
+            return;
+        }
+
+        // temp remove this function to use the global one
+        void initOGLcontext()
+        {
+            HWND hwin = FindWindow(0, L"GLEWTest");
+            glGlobalDevice = wglGetCurrentDC();// GetDC(hwin);
+                                               //main thread context
+                                               // share this context with worker thread contexts
+            glGlobalContext = wglGetCurrentContext();// wglCreateContext(glGlobalDevice);
+            HGLRC mainContext = glGlobalContext;
+
+            // drop the main context before sharing the context
+            // http://hacksoflife.blogspot.com/2008/02/creating-opengl-objects-in-second.html
+            wglMakeCurrent(NULL, NULL);
+
+            std::atomic<int> atomicCounter;
+            atomicCounter = sofa::simulation::TaskScheduler::getInstance().size() - 1;
+
+            std::mutex  InitThreadSpecificMutex;
+
+            sofa::simulation::Task::Status status;
+
+            const int nbWorkerThread = sofa::simulation::TaskScheduler::getInstance().size() - 1;
+            sofa::simulation::WorkerThread* thread = sofa::simulation::WorkerThread::getCurrent();
+
+            for (int i = 0; i<nbWorkerThread; ++i)
+            {
+                // creqte a new context and share it with the main thread context
+                HGLRC workerThreadContexts = wglCreateContext(glGlobalDevice);
+                wglShareLists(mainContext, workerThreadContexts);
+
+                thread->addTask(new InitOGLcontextTask(glGlobalDevice, workerThreadContexts, &atomicCounter, &InitThreadSpecificMutex, &status));
+            }
+
+            // wait for worker thread to complete the per-thread task
+            while (status.isBusy())
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+
+            // set the main context back after sharing the context
+            // http://hacksoflife.blogspot.com/2008/02/creating-opengl-objects-in-second.html
+            wglMakeCurrent(glGlobalDevice, glGlobalContext);
+
+
+            return;
+        }
+
+        // temp remove this function to use the global one
+        void deleteOGLcontext()
+        {
+            std::atomic<int> atomicCounter;
+            atomicCounter = sofa::simulation::TaskScheduler::getInstance().size() - 1;
+
+            std::mutex  InitThreadSpecificMutex;
+
+            sofa::simulation::Task::Status status;
+
+            const int nbWorkerThread = sofa::simulation::TaskScheduler::getInstance().size() - 1;
+            sofa::simulation::WorkerThread* thread = sofa::simulation::WorkerThread::getCurrent();
+
+            for (int i = 0; i<nbWorkerThread; ++i)
+            {
+                thread->addTask(new DeleteOGLcontextTask(&atomicCounter, &InitThreadSpecificMutex, &status));
+            }
+
+            // wait for worker thread to complete the per-thread task
+            while (status.isBusy())
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+            return;
+        }
+
+    } // namespace simulation
+
+} // namespace sofa

--- a/applications/plugins/MultiThreading/src/InitTasks.h
+++ b/applications/plugins/MultiThreading/src/InitTasks.h
@@ -1,0 +1,103 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#ifndef InitTasks_h__
+#define InitTasks_h__
+
+#include "TaskScheduler.h"
+
+//#include <sofa/helper/system/atomic.h>
+
+namespace sofa
+{
+    namespace simulation
+    {
+
+        using namespace sofa;
+
+
+
+        class InitPerThreadDataTask : public Task
+        {
+
+        public:
+
+            //InitPerThreadDataTask(volatile long* atomicCounter, boost::mutex* mutex, TaskStatus* pStatus );
+            InitPerThreadDataTask(std::atomic<int>* atomicCounter, std::mutex* mutex, Task::Status* pStatus);
+
+            virtual ~InitPerThreadDataTask();
+
+            virtual bool run(WorkerThread*) override;
+
+        private:
+
+            std::mutex*	 IdFactorygetIDMutex;
+            std::atomic<int>* _atomicCounter;
+        };
+
+
+
+        class InitOGLcontextTask : public Task
+        {
+        public:
+            InitOGLcontextTask::InitOGLcontextTask(HDC& glDevice, HGLRC& workerThreadContext, std::atomic<int>* atomicCounter, std::mutex* mutex, Task::Status* pStatus);
+
+            InitOGLcontextTask::~InitOGLcontextTask();
+
+            virtual bool run(sofa::simulation::WorkerThread*) override;
+
+        private:
+
+            HDC & _glDevice;
+            HGLRC& _workerThreadContext;
+            std::mutex*	 IdFactorygetIDMutex;
+            std::atomic<int>* _atomicCounter;
+        };
+
+
+        class DeleteOGLcontextTask : public sofa::simulation::Task
+        {
+        public:
+            DeleteOGLcontextTask::DeleteOGLcontextTask(std::atomic<int>* atomicCounter, std::mutex* mutex, Task::Status* pStatus);
+
+            DeleteOGLcontextTask::~DeleteOGLcontextTask();
+
+            virtual bool run(sofa::simulation::WorkerThread*) override;
+
+        private:
+            std::mutex*	 IdFactorygetIDMutex;
+            std::atomic<int>* _atomicCounter;
+        };
+
+
+        //fix and prefer using the global runThreadSpecificTask
+        SOFA_MULTITHREADING_PLUGIN_API void initThreadLocalData();
+
+        SOFA_MULTITHREADING_PLUGIN_API void initOGLcontext();
+
+        SOFA_MULTITHREADING_PLUGIN_API void deleteOGLcontext();
+
+
+    } // namespace simulation
+
+} // namespace sofa
+
+#endif // InitTasks_h__

--- a/applications/plugins/MultiThreading/src/InitTasks.h
+++ b/applications/plugins/MultiThreading/src/InitTasks.h
@@ -54,7 +54,12 @@ namespace sofa
         };
 
 
-
+        //fix and prefer using the global runThreadSpecificTask
+        SOFA_MULTITHREADING_PLUGIN_API void initThreadLocalData();
+        
+        
+#ifdef _WIN32
+        
         class InitOGLcontextTask : public Task
         {
         public:
@@ -88,14 +93,13 @@ namespace sofa
         };
 
 
-        //fix and prefer using the global runThreadSpecificTask
-        SOFA_MULTITHREADING_PLUGIN_API void initThreadLocalData();
-
         SOFA_MULTITHREADING_PLUGIN_API void initOGLcontext();
 
         SOFA_MULTITHREADING_PLUGIN_API void deleteOGLcontext();
+        
+#endif // _WIN32
 
-
+        
     } // namespace simulation
 
 } // namespace sofa

--- a/applications/plugins/MultiThreading/src/InitTasks.h
+++ b/applications/plugins/MultiThreading/src/InitTasks.h
@@ -24,8 +24,6 @@
 
 #include "TaskScheduler.h"
 
-//#include <sofa/helper/system/atomic.h>
-
 namespace sofa
 {
     namespace simulation
@@ -40,7 +38,6 @@ namespace sofa
 
         public:
 
-            //InitPerThreadDataTask(volatile long* atomicCounter, boost::mutex* mutex, TaskStatus* pStatus );
             InitPerThreadDataTask(std::atomic<int>* atomicCounter, std::mutex* mutex, Task::Status* pStatus);
 
             virtual ~InitPerThreadDataTask();
@@ -57,47 +54,6 @@ namespace sofa
         //fix and prefer using the global runThreadSpecificTask
         SOFA_MULTITHREADING_PLUGIN_API void initThreadLocalData();
         
-        
-#ifdef _WIN32
-        
-        class InitOGLcontextTask : public Task
-        {
-        public:
-            InitOGLcontextTask::InitOGLcontextTask(HDC& glDevice, HGLRC& workerThreadContext, std::atomic<int>* atomicCounter, std::mutex* mutex, Task::Status* pStatus);
-
-            InitOGLcontextTask::~InitOGLcontextTask();
-
-            virtual bool run(sofa::simulation::WorkerThread*) override;
-
-        private:
-
-            HDC & _glDevice;
-            HGLRC& _workerThreadContext;
-            std::mutex*	 IdFactorygetIDMutex;
-            std::atomic<int>* _atomicCounter;
-        };
-
-
-        class DeleteOGLcontextTask : public sofa::simulation::Task
-        {
-        public:
-            DeleteOGLcontextTask::DeleteOGLcontextTask(std::atomic<int>* atomicCounter, std::mutex* mutex, Task::Status* pStatus);
-
-            DeleteOGLcontextTask::~DeleteOGLcontextTask();
-
-            virtual bool run(sofa::simulation::WorkerThread*) override;
-
-        private:
-            std::mutex*	 IdFactorygetIDMutex;
-            std::atomic<int>* _atomicCounter;
-        };
-
-
-        SOFA_MULTITHREADING_PLUGIN_API void initOGLcontext();
-
-        SOFA_MULTITHREADING_PLUGIN_API void deleteOGLcontext();
-        
-#endif // _WIN32
 
         
     } // namespace simulation

--- a/applications/plugins/MultiThreading/src/MeanComputation.cpp
+++ b/applications/plugins/MultiThreading/src/MeanComputation.cpp
@@ -1,0 +1,62 @@
+#include "MeanComputation.inl"
+
+#include <sofa/core/ObjectFactory.h>
+
+#include <sofa/defaulttype/Vec.h>
+#include <sofa/defaulttype/VecTypes.h>
+
+namespace sofa
+{
+
+    namespace component
+    {
+
+        namespace engine
+        {
+
+            SOFA_DECL_CLASS(MeanComputation)
+
+                int MeanComputationEngineClass = core::RegisterObject("Compute the mean of the input elements")
+#ifdef SOFA_FLOAT
+                .add< MeanComputationEngine<defaulttype::Vec3fTypes> >(true) // default template
+#else
+                .add< MeanComputation<defaulttype::Vec3dTypes> >(true) // default template
+#ifndef SOFA_DOUBLE
+                .add< MeanComputation<defaulttype::Vec3fTypes> >()
+#endif
+#endif
+#ifndef SOFA_FLOAT
+                .add< MeanComputation<defaulttype::Vec1dTypes> >()
+                .add< MeanComputation<defaulttype::Vec2dTypes> >()
+                .add< MeanComputation<defaulttype::Rigid2dTypes> >()
+                .add< MeanComputation<defaulttype::Rigid3dTypes> >()
+#endif //SOFA_FLOAT
+#ifndef SOFA_DOUBLE
+                .add< MeanComputation<defaulttype::Vec1fTypes> >()
+                .add< MeanComputation<defaulttype::Vec2fTypes> >()
+                .add< MeanComputation<defaulttype::Rigid2fTypes> >()
+                .add< MeanComputation<defaulttype::Rigid3fTypes> >()
+#endif //SOFA_DOUBLE
+                ;
+
+#ifndef SOFA_FLOAT
+            template class MeanComputation<defaulttype::Vec1dTypes>;
+            template class MeanComputation<defaulttype::Vec2dTypes>;
+            template class MeanComputation<defaulttype::Vec3dTypes>;
+            template class MeanComputation<defaulttype::Rigid2dTypes>;
+            template class MeanComputation<defaulttype::Rigid3dTypes>;
+#endif //SOFA_FLOAT
+#ifndef SOFA_DOUBLE
+            template class MeanComputation<defaulttype::Vec1fTypes>;
+            template class MeanComputation<defaulttype::Vec2fTypes>;
+            template class MeanComputation<defaulttype::Vec3fTypes>;
+            template class MeanComputation<defaulttype::Rigid2fTypes>;
+            template class MeanComputation<defaulttype::Rigid3fTypes>;
+#endif //SOFA_DOUBLE
+
+
+        } // namespace constraint
+
+    } // namespace component
+
+} // namespace sofa

--- a/applications/plugins/MultiThreading/src/MeanComputation.h
+++ b/applications/plugins/MultiThreading/src/MeanComputation.h
@@ -74,8 +74,6 @@ namespace sofa
             public:
                 void init() override;
 
-                void bwdInit() override;
-
                 void reinit() override;
 
                 virtual void handleEvent(core::objectmodel::Event* event) override;

--- a/applications/plugins/MultiThreading/src/MeanComputation.h
+++ b/applications/plugins/MultiThreading/src/MeanComputation.h
@@ -1,0 +1,113 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#ifndef SOFA_COMPONENT_ENGINE_MEAN_COMPUTATION_H
+#define SOFA_COMPONENT_ENGINE_MEAN_COMPUTATION_H
+
+#include <MultiThreading/config.h>
+
+
+#include <sofa/core/DataEngine.h>
+#include <sofa/core/objectmodel/BaseObject.h>
+//#include <sofa/defaulttype/Vec.h>
+//#include <sofa/core/topology/BaseMeshTopology.h>
+//#include <sofa/defaulttype/VecTypes.h>
+//#include <sofa/defaulttype/RigidTypes.h>
+
+#include <SofaBaseMechanics/MechanicalObject.h>
+
+namespace sofa
+{
+
+    namespace component
+    {
+
+        namespace engine
+        {
+
+            /**
+            * This class merge 2 coordinate vectors.
+            */
+            template <class DataTypes>
+            class MeanComputation : public virtual core::objectmodel::BaseObject
+            {
+                typedef typename DataTypes::Coord         Coord;
+                typedef typename DataTypes::VecCoord      VecCoord;
+                typedef typename DataTypes::Real          Real;
+                //typedef sofa::defaulttype::Vec<1, Real>                       Coord1D;
+                //typedef sofa::defaulttype::Vec<2, Real>                       Coord2D;
+                //typedef sofa::defaulttype::Vec<3, Real>                       Coord3D;
+                typedef sofa::defaulttype::ResizableExtVector <Coord>       ResizableExtVectorCoord;
+                typedef sofa::defaulttype::ResizableExtVector <VecCoord>    ResizableExtVectorVecCoord;
+                //typedef sofa::helper::vector <Coord3D>    VecCoord3D;
+
+            public:
+                SOFA_CLASS(SOFA_TEMPLATE(MeanComputation, DataTypes), core::objectmodel::BaseObject);
+                //typedef typename DataTypes::VecCoord VecCoord;
+
+            protected:
+
+                MeanComputation();
+
+                ~MeanComputation() {}
+
+                void compute();
+
+            public:
+                void init() override;
+
+                void bwdInit() override;
+
+                void reinit() override;
+
+                virtual void handleEvent(core::objectmodel::Event* event) override;
+
+                virtual std::string getTemplateName() const override
+                {
+                    return templateName(this);
+                }
+
+                static std::string templateName(const MeanComputation<DataTypes>* = NULL)
+                {
+                    return DataTypes::Name();
+                }
+
+            private:
+
+                Data<VecCoord> d_result;
+
+                //std::vector<component::container::MechanicalObject<DataTypes>*> _inputMechObjs;
+                
+                sofa::helper::vector< Data< VecCoord >* > _inputs;
+                
+                size_t _resultSize;
+          
+            };
+
+
+        } // namespace engine
+
+    } // namespace component
+
+} // namespace sofa
+
+
+#endif  /* SOFA_COMPONENT_ENGINE_MEAN_COMPUTATION_H */

--- a/applications/plugins/MultiThreading/src/MeanComputation.inl
+++ b/applications/plugins/MultiThreading/src/MeanComputation.inl
@@ -34,7 +34,7 @@ namespace sofa
                 helper::ReadAccessor< Data<VecCoord> > output = d_result;
 
                 std::vector<component::container::MechanicalObject<DataTypes>*> mechObjs;
-                this->getContext()->get<component::container::MechanicalObject<DataTypes> >(
+                this->getContext()->template get<component::container::MechanicalObject<DataTypes> >(
                     &mechObjs,
                     BaseContext::Local);
 

--- a/applications/plugins/MultiThreading/src/MeanComputation.inl
+++ b/applications/plugins/MultiThreading/src/MeanComputation.inl
@@ -46,8 +46,6 @@ namespace sofa
                     core::objectmodel::TagSet tags = mObj->getTags();
                     if (tags.find(Tag("MeanOutput")) != tags.end())
                     {
-                        helper::ReadAccessor<Data<VecCoord> >  inputpos = mObj->readPositions();
-
                         mObj->x.setValue(*d_result.beginEdit());
                         mObj->x.setParent(&d_result, std::string("to"));
 
@@ -59,7 +57,7 @@ namespace sofa
 
                         const VecCoord& positions = inputpos.ref();
 
-                        if (&output[0] == &positions[0])
+                        if (output.size() > 0 && &output[0] == &positions[0])
                         {
                             continue;
                         }
@@ -96,35 +94,6 @@ namespace sofa
             }
 
             template <class DataTypes>
-            void MeanComputation<DataTypes>::bwdInit()
-            {
-                //const size_t nbInputs = _inputs.size();
-                //if (nbInputs == 0)
-                //    return;
-
-                //// check for input vector size different
-                //const size_t vecSize = _inputs[0]->beginEdit()->size();
-                //size_t minVecSize = vecSize;
-
-                //for (size_t i = 1; i<nbInputs; ++i)
-                //{
-                //    const size_t i_size = _inputs[i]->beginEdit()->size();
-
-                //    if (vecSize != i_size)
-                //    {
-                //        minVecSize = (vecSize < i_size) ? vecSize : i_size;
-                //    }
-                //}
-
-                //_resultSize = minVecSize;
-
-                //// set result to 0
-                //d_result.beginEdit()->resize(_resultSize, Coord());
-
-                //compute();
-            }
-
-            template <class DataTypes>
             void MeanComputation<DataTypes>::reinit()
             {
                 compute();
@@ -153,23 +122,23 @@ namespace sofa
                 const double invNbInputs = 1.0 / nbInputs;
 
                 // accumulate all the input elems in result
-                for (int j = 0; j<nbInputs; ++j)
+                for (size_t j = 0; j<nbInputs; ++j)
                 {
                     const VecCoord& pos = *_inputs[j]->beginEdit();
 
-                    for (int i = 0; i<_resultSize; ++i)
+                    for (size_t i = 0; i<_resultSize; ++i)
                     {
                         result[i] += pos[i];
                     }
                 }
 
-                for (int i = 0; i<_resultSize; ++i)
+                for (size_t i = 0; i<_resultSize; ++i)
                 {
                     result[i] *= invNbInputs;
                 }    
                 
                 d_result.endEdit();
-                d_result.setDirtyValue();
+//                d_result.setDirtyValue();
             }
 
         } // namespace engine

--- a/applications/plugins/MultiThreading/src/MeanComputation.inl
+++ b/applications/plugins/MultiThreading/src/MeanComputation.inl
@@ -1,0 +1,179 @@
+#include "MeanComputation.h"
+
+//#include <SofaBaseMechanics/MechanicalObject.h>
+
+#include <sofa/simulation/AnimateBeginEvent.h>
+
+using namespace sofa::core::objectmodel;
+using namespace sofa::core::behavior;
+using namespace sofa::component::container;
+
+namespace sofa
+{
+
+    namespace component
+    {
+
+        namespace engine
+        {
+
+            template <class DataTypes>
+            MeanComputation<DataTypes>::MeanComputation()
+                //: d_inputs(initData(&d_inputs, "input", "List of all input values for mean computation"))
+                : d_result(initData(&d_result, "result", "Result: mean computed from the input values"))
+            {
+
+            }
+
+            template <class DataTypes>
+            void MeanComputation<DataTypes>::init()
+            {
+                f_listening.setValue(true);
+
+                //helper::WriteOnlyAccessor< Data<sofa::defaulttype::ResizableExtVector<VecCoord> > > inputsVec = d_inputs;
+                helper::ReadAccessor< Data<VecCoord> > output = d_result;
+
+                std::vector<component::container::MechanicalObject<DataTypes>*> mechObjs;
+                this->getContext()->get<component::container::MechanicalObject<DataTypes> >(
+                    &mechObjs,
+                    BaseContext::Local);
+
+                // temp map to check Mech obj data input size
+                std::map<size_t, std::string> MechObjSizeMap;
+
+                for (auto mObj : mechObjs)
+                {
+                    core::objectmodel::TagSet tags = mObj->getTags();
+                    if (tags.find(Tag("MeanOutput")) != tags.end())
+                    {
+                        helper::ReadAccessor<Data<VecCoord> >  inputpos = mObj->readPositions();
+
+                        mObj->x.setValue(*d_result.beginEdit());
+                        mObj->x.setParent(&d_result, std::string("to"));
+
+                    }
+                    else
+                    {
+                        helper::ReadAccessor<Data<VecCoord> >  inputpos = mObj->readPositions();
+                        //helper::WriteAccessor<Data<VecCoord> >  output =  mObj->writePositions();
+
+                        const VecCoord& positions = inputpos.ref();
+
+                        if (&output[0] == &positions[0])
+                        {
+                            continue;
+                        }
+
+                        const size_t size = mObj->x.beginEdit()->size();
+                        auto iter = MechObjSizeMap.find(size);
+
+                        if (MechObjSizeMap.size() > 0 && iter== MechObjSizeMap.end())
+                        {
+                            dmsg_warning("Different input data size detected. MechanicalObject name " +
+                                iter->second + " and " + MechObjSizeMap.begin()->second +
+                                ". The lower size will be used.\n");
+                            //serr << "Different input data size. The lower size will be used.\n";
+                        }
+
+                        MechObjSizeMap[size] = mObj->getName();
+
+                        // create and add a new input data for mechanical object positions (mObj->x)
+                        Data<VecCoord>* input = new Data<VecCoord>();
+                        input->setValue(*mObj->x.beginEdit());
+                        input->setParent(&mObj->x, std::string("to"));
+                        input->setReadOnly(true);
+                        input->setDirtyValue();
+
+                        _inputs.push_back(input);
+                    }
+                }
+
+                // get the lowest size
+                _resultSize = MechObjSizeMap.begin()->first;
+                d_result.beginEdit()->resize(_resultSize);
+
+                compute();
+            }
+
+            template <class DataTypes>
+            void MeanComputation<DataTypes>::bwdInit()
+            {
+                //const size_t nbInputs = _inputs.size();
+                //if (nbInputs == 0)
+                //    return;
+
+                //// check for input vector size different
+                //const size_t vecSize = _inputs[0]->beginEdit()->size();
+                //size_t minVecSize = vecSize;
+
+                //for (size_t i = 1; i<nbInputs; ++i)
+                //{
+                //    const size_t i_size = _inputs[i]->beginEdit()->size();
+
+                //    if (vecSize != i_size)
+                //    {
+                //        minVecSize = (vecSize < i_size) ? vecSize : i_size;
+                //    }
+                //}
+
+                //_resultSize = minVecSize;
+
+                //// set result to 0
+                //d_result.beginEdit()->resize(_resultSize, Coord());
+
+                //compute();
+            }
+
+            template <class DataTypes>
+            void MeanComputation<DataTypes>::reinit()
+            {
+                compute();
+            }
+
+
+            template <class DataTypes>
+            void MeanComputation<DataTypes>::handleEvent(core::objectmodel::Event* event)
+            {
+                if (dynamic_cast<simulation::AnimateBeginEvent*>(event) != NULL)
+                {
+                    compute();
+                }
+            }
+
+           
+            template <class DataTypes>
+            void MeanComputation<DataTypes>::compute()
+            {
+                VecCoord& result = *d_result.beginEdit();
+
+                const size_t nbInputs = _inputs.size();
+                if (nbInputs == 0)
+                    return;
+
+                const double invNbInputs = 1.0 / nbInputs;
+
+                // accumulate all the input elems in result
+                for (int j = 0; j<nbInputs; ++j)
+                {
+                    const VecCoord& pos = *_inputs[j]->beginEdit();
+
+                    for (int i = 0; i<_resultSize; ++i)
+                    {
+                        result[i] += pos[i];
+                    }
+                }
+
+                for (int i = 0; i<_resultSize; ++i)
+                {
+                    result[i] *= invNbInputs;
+                }    
+                
+                d_result.endEdit();
+                d_result.setDirtyValue();
+            }
+
+        } // namespace engine
+
+    } // namespace component
+
+} // namespace sofa

--- a/applications/plugins/MultiThreading/src/TaskScheduler.cpp
+++ b/applications/plugins/MultiThreading/src/TaskScheduler.cpp
@@ -83,7 +83,7 @@ namespace sofa
             _workerThreadsIdle = true;
             _mainTaskStatus	= nullptr;          
 
-            // only physicsal cores. no advantage from hyperthreading.
+            // default number of thread: only physicsal cores. no advantage from hyperthreading.
             _threadCount = GetHardwareThreadsCount() / 2;
             
             if ( NbThread > 0 && NbThread <= MAX_THREADS  )

--- a/applications/plugins/MultiThreading/src/TaskScheduler.cpp
+++ b/applications/plugins/MultiThreading/src/TaskScheduler.cpp
@@ -235,7 +235,7 @@ namespace sofa
 		{
             
             //workerThreadIndex = this;
-            TaskScheduler::_threads[std::this_thread::get_id()] = this;
+//            TaskScheduler::_threads[std::this_thread::get_id()] = this;
 
 			// main loop
             while ( !_taskScheduler->isClosing() )
@@ -268,12 +268,12 @@ namespace sofa
         {
             {
                 std::unique_lock<std::mutex> lock( _taskScheduler->_wakeUpMutex );
-				if (!_taskScheduler->_workerThreadsIdle)
-				{
-					return;
-				}
+//                if (!_taskScheduler->_workerThreadsIdle)
+//                {
+//                    return;
+//                }
                 // cpu free wait
-                _taskScheduler->_wakeUpEvent.wait(lock);
+                _taskScheduler->_wakeUpEvent.wait(lock, [&]{return !_taskScheduler->_workerThreadsIdle;} );
             }
             return;
         }

--- a/applications/plugins/MultiThreading/src/TaskScheduler.cpp
+++ b/applications/plugins/MultiThreading/src/TaskScheduler.cpp
@@ -287,7 +287,7 @@ namespace sofa
 
                 while (popTask(&task))
                 {
-                    // run
+                    // run task in the queue
                     runTask(task);
 
 
@@ -295,14 +295,14 @@ namespace sofa
                         return;
                 }
 
-                /* check if main work is finished */
+                // check if main work is finished 
                 if (_taskScheduler->_mainTaskStatus == nullptr)
                     return;
 
                 if (!stealTask(&task))
                     return;
 
-                // run stolen task
+                // run the stolen task
                 runTask(task);
 
             } //;;while (stealTasks());	
@@ -400,21 +400,6 @@ namespace sofa
 			return false;
 		}
 
-        //bool WorkerThread::giveUpSomeWork(Task** stolenTask)
-        //{
-        //    TASK_SCHEDULER_PROFILER(Steal);
-
-        //    ScopedLock lock(_taskMutex);
-        //    if (!_tasks.empty())
-        //    {
-        //        *stolenTask = _tasks.front();
-        //        _tasks.pop_front();
-        //        return true;
-        //    }
-        //    *stolenTask = nullptr;
-        //    return false;
-        //}
-
         bool WorkerThread::stealTask(Task** task)
         {
             {
@@ -429,10 +414,7 @@ namespace sofa
                     }
 
                     WorkerThread* otherThread = it.second;
-                    //if (it.second->giveUpSomeWork(task))
-                    //{
-                    //    return true;
-                    //}
+
                     {
                         TASK_SCHEDULER_PROFILER(Steal);
 
@@ -481,8 +463,6 @@ namespace sofa
 		{
 			return runThreadSpecificTask(WorkerThread::getCurrent(), task );
 		}
-
-
 
 
 	} // namespace simulation

--- a/applications/plugins/MultiThreading/src/Tasks.cpp
+++ b/applications/plugins/MultiThreading/src/Tasks.cpp
@@ -16,6 +16,7 @@ namespace sofa
 
 		Task::Task(const Task::Status* pStatus)
 			: _status(pStatus)
+            , _id(0)
 		{
             
 		}

--- a/applications/plugins/MultiThreading/src/Tasks.h
+++ b/applications/plugins/MultiThreading/src/Tasks.h
@@ -53,21 +53,19 @@ namespace sofa
                 bool isBusy() const
                 {
                     return (_busy.load(std::memory_order_relaxed) > 0);
-                }
-                
-                
-                
+                }         
+        
             private:
                 
-                void markBusy(bool busy)
+                int setBusy(bool busy)
                 {
                     if (busy)
                     {
-                        _busy.fetch_add(1, std::memory_order_relaxed);
+                        return _busy.fetch_add(1, std::memory_order_relaxed);
                     }
                     else
                     {
-                        _busy.fetch_sub(1, std::memory_order_relaxed);
+                        return _busy.fetch_sub(1, std::memory_order_relaxed);
                     }
                 }
                 
@@ -101,6 +99,8 @@ namespace sofa
             }
 
 			const Task::Status*	_status;
+
+            int _id;
 
 			friend class WorkerThread;
 

--- a/applications/plugins/MultiThreading/src/VisitorAsync.h
+++ b/applications/plugins/MultiThreading/src/VisitorAsync.h
@@ -1,0 +1,61 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#ifndef Sofa_VisitorAsync_h__
+#define Sofa_VisitorAsync_h__
+
+#include <Multithreading/config.h>
+
+#include <sofa/simulation/Visitor.h>
+#include <MultiThreading/src/Tasks.h>
+
+namespace sofa
+{
+
+    namespace simulation
+    {
+
+        /**
+        * Used to execute async tasks
+        */
+
+        class SOFA_MULTITHREADING_PLUGIN_API VisitorAsync : public Visitor
+        {
+        public:
+            VisitorAsync(const sofa::core::ExecParams* params, Task::Status* status)
+                : Visitor(params)
+                , _status(status)
+            {}
+
+            const Task::Status* getStatus() { return _status; }
+
+        protected:
+
+            Task::Status* _status;
+
+        };
+
+
+    } // namespace simulation
+
+} // namespace sofa
+
+#endif // Sofa_VisitorAsync_h__

--- a/modules/SofaConstraint/FreeMotionAnimationLoop.cpp
+++ b/modules/SofaConstraint/FreeMotionAnimationLoop.cpp
@@ -57,6 +57,7 @@ using namespace sofa::simulation;
 FreeMotionAnimationLoop::FreeMotionAnimationLoop(simulation::Node* gnode)
     : Inherit(gnode)
     , m_solveVelocityConstraintFirst(initData(&m_solveVelocityConstraintFirst , false, "solveVelocityConstraintFirst", "solve separately velocity constraint violations before position constraint violations"))
+    , d_threadsafevisitor(initData(&d_threadsafevisitor, false, "threadsafevisitor", "If true, do not use realloc and free visitors in fwdInteractionForceField."))
     , constraintSolver(NULL)
     , defaultSolver(NULL)
 {
@@ -82,8 +83,8 @@ void FreeMotionAnimationLoop::init()
 
     {
     simulation::common::VectorOperations vop(core::ExecParams::defaultInstance(), this->getContext());
-    MultiVecDeriv dx(&vop, core::VecDerivId::dx() ); dx.realloc( &vop, true, true );
-    MultiVecDeriv df(&vop, core::VecDerivId::dforce() ); df.realloc( &vop, true, true );
+    MultiVecDeriv dx(&vop, core::VecDerivId::dx()); dx.realloc(&vop, !d_threadsafevisitor.getValue(), true);
+    MultiVecDeriv df(&vop, core::VecDerivId::dforce()); df.realloc(&vop, !d_threadsafevisitor.getValue(), true);
     }
 
 
@@ -127,8 +128,8 @@ void FreeMotionAnimationLoop::step(const sofa::core::ExecParams* params, SReal d
     cparams.setOrder(m_solveVelocityConstraintFirst.getValue() ? core::ConstraintParams::VEL : core::ConstraintParams::POS_AND_VEL);
 
     {
-        MultiVecDeriv dx(&vop, core::VecDerivId::dx() ); dx.realloc( &vop, true, true );
-        MultiVecDeriv df(&vop, core::VecDerivId::dforce() ); df.realloc( &vop, true, true );
+        MultiVecDeriv dx(&vop, core::VecDerivId::dx()); dx.realloc(&vop, !d_threadsafevisitor.getValue(), true);
+        MultiVecDeriv df(&vop, core::VecDerivId::dforce()); df.realloc(&vop, !d_threadsafevisitor.getValue(), true);
     }
 
     // This solver will work in freePosition and freeVelocity vectors.

--- a/modules/SofaConstraint/FreeMotionAnimationLoop.cpp
+++ b/modules/SofaConstraint/FreeMotionAnimationLoop.cpp
@@ -57,7 +57,7 @@ using namespace sofa::simulation;
 FreeMotionAnimationLoop::FreeMotionAnimationLoop(simulation::Node* gnode)
     : Inherit(gnode)
     , m_solveVelocityConstraintFirst(initData(&m_solveVelocityConstraintFirst , false, "solveVelocityConstraintFirst", "solve separately velocity constraint violations before position constraint violations"))
-    , d_threadsafevisitor(initData(&d_threadsafevisitor, false, "threadsafevisitor", "If true, do not use realloc and free visitors in fwdInteractionForceField."))
+    , d_threadSafeVisitor(initData(&d_threadSafeVisitor, false, "threadSafeVisitor", "If true, do not use realloc and free visitors in fwdInteractionForceField."))
     , constraintSolver(NULL)
     , defaultSolver(NULL)
 {
@@ -83,8 +83,8 @@ void FreeMotionAnimationLoop::init()
 
     {
     simulation::common::VectorOperations vop(core::ExecParams::defaultInstance(), this->getContext());
-    MultiVecDeriv dx(&vop, core::VecDerivId::dx()); dx.realloc(&vop, !d_threadsafevisitor.getValue(), true);
-    MultiVecDeriv df(&vop, core::VecDerivId::dforce()); df.realloc(&vop, !d_threadsafevisitor.getValue(), true);
+    MultiVecDeriv dx(&vop, core::VecDerivId::dx()); dx.realloc(&vop, !d_threadSafeVisitor.getValue(), true);
+    MultiVecDeriv df(&vop, core::VecDerivId::dforce()); df.realloc(&vop, !d_threadSafeVisitor.getValue(), true);
     }
 
 
@@ -128,8 +128,8 @@ void FreeMotionAnimationLoop::step(const sofa::core::ExecParams* params, SReal d
     cparams.setOrder(m_solveVelocityConstraintFirst.getValue() ? core::ConstraintParams::VEL : core::ConstraintParams::POS_AND_VEL);
 
     {
-        MultiVecDeriv dx(&vop, core::VecDerivId::dx()); dx.realloc(&vop, !d_threadsafevisitor.getValue(), true);
-        MultiVecDeriv df(&vop, core::VecDerivId::dforce()); df.realloc(&vop, !d_threadsafevisitor.getValue(), true);
+        MultiVecDeriv dx(&vop, core::VecDerivId::dx()); dx.realloc(&vop, !d_threadSafeVisitor.getValue(), true);
+        MultiVecDeriv df(&vop, core::VecDerivId::dforce()); df.realloc(&vop, !d_threadSafeVisitor.getValue(), true);
     }
 
     // This solver will work in freePosition and freeVelocity vectors.

--- a/modules/SofaConstraint/FreeMotionAnimationLoop.h
+++ b/modules/SofaConstraint/FreeMotionAnimationLoop.h
@@ -67,6 +67,8 @@ public:
 
     Data<bool> m_solveVelocityConstraintFirst; ///< solve separately velocity constraint violations before position constraint violations
 
+    Data<bool> d_threadsafevisitor;
+
 protected :
 
     sofa::core::behavior::ConstraintSolver *constraintSolver;

--- a/modules/SofaConstraint/FreeMotionAnimationLoop.h
+++ b/modules/SofaConstraint/FreeMotionAnimationLoop.h
@@ -67,7 +67,7 @@ public:
 
     Data<bool> m_solveVelocityConstraintFirst; ///< solve separately velocity constraint violations before position constraint violations
 
-    Data<bool> d_threadsafevisitor;
+    Data<bool> d_threadSafeVisitor;
 
 protected :
 

--- a/modules/SofaGeneralExplicitOdeSolver/CentralDifferenceSolver.cpp
+++ b/modules/SofaGeneralExplicitOdeSolver/CentralDifferenceSolver.cpp
@@ -44,6 +44,7 @@ using namespace core::behavior;
 
 CentralDifferenceSolver::CentralDifferenceSolver()
     : f_rayleighMass( initData(&f_rayleighMass,(SReal)0.0,"rayleighMass","Rayleigh damping coefficient related to mass"))
+    , d_threadsafevisitor(initData(&d_threadsafevisitor, false, "threadsafevisitor", "If true, do not use realloc and free visitors in fwdInteractionForceField."))
 {
 }
 
@@ -91,7 +92,7 @@ void CentralDifferenceSolver::solve(const core::ExecParams* params, SReal dt, so
     MultiVecDeriv vel(&vop, core::VecDerivId::velocity() );
     MultiVecCoord pos2(&vop, xResult /*core::VecCoordId::position()*/ );
     MultiVecDeriv vel2(&vop, vResult /*core::VecDerivId::velocity()*/ );
-    MultiVecDeriv dx (&vop, core::VecDerivId::dx() ); dx.realloc( &vop, true, true );
+    MultiVecDeriv dx(&vop, core::VecDerivId::dx()); dx.realloc(&vop, !d_threadsafevisitor.getValue(), true);
     MultiVecDeriv f  (&vop, core::VecDerivId::force() );
 
     const SReal r = f_rayleighMass.getValue();

--- a/modules/SofaGeneralExplicitOdeSolver/CentralDifferenceSolver.cpp
+++ b/modules/SofaGeneralExplicitOdeSolver/CentralDifferenceSolver.cpp
@@ -44,7 +44,7 @@ using namespace core::behavior;
 
 CentralDifferenceSolver::CentralDifferenceSolver()
     : f_rayleighMass( initData(&f_rayleighMass,(SReal)0.0,"rayleighMass","Rayleigh damping coefficient related to mass"))
-    , d_threadsafevisitor(initData(&d_threadsafevisitor, false, "threadsafevisitor", "If true, do not use realloc and free visitors in fwdInteractionForceField."))
+    , d_threadSafeVisitor(initData(&d_threadSafeVisitor, false, "threadSafeVisitor", "If true, do not use realloc and free visitors in fwdInteractionForceField."))
 {
 }
 
@@ -92,7 +92,7 @@ void CentralDifferenceSolver::solve(const core::ExecParams* params, SReal dt, so
     MultiVecDeriv vel(&vop, core::VecDerivId::velocity() );
     MultiVecCoord pos2(&vop, xResult /*core::VecCoordId::position()*/ );
     MultiVecDeriv vel2(&vop, vResult /*core::VecDerivId::velocity()*/ );
-    MultiVecDeriv dx(&vop, core::VecDerivId::dx()); dx.realloc(&vop, !d_threadsafevisitor.getValue(), true);
+    MultiVecDeriv dx(&vop, core::VecDerivId::dx()); dx.realloc(&vop, !d_threadSafeVisitor.getValue(), true);
     MultiVecDeriv f  (&vop, core::VecDerivId::force() );
 
     const SReal r = f_rayleighMass.getValue();

--- a/modules/SofaGeneralExplicitOdeSolver/CentralDifferenceSolver.h
+++ b/modules/SofaGeneralExplicitOdeSolver/CentralDifferenceSolver.h
@@ -50,7 +50,7 @@ public:
     void solve (const core::ExecParams* params, SReal dt, sofa::core::MultiVecCoordId xResult, sofa::core::MultiVecDerivId vResult) override;
 
     Data<SReal> f_rayleighMass; ///< Rayleigh damping coefficient related to mass
-
+    Data<bool> d_threadsafevisitor;
 
     /// Given an input derivative order (0 for position, 1 for velocity, 2 for acceleration),
     /// how much will it affect the output derivative of the given order.

--- a/modules/SofaGeneralExplicitOdeSolver/CentralDifferenceSolver.h
+++ b/modules/SofaGeneralExplicitOdeSolver/CentralDifferenceSolver.h
@@ -50,7 +50,7 @@ public:
     void solve (const core::ExecParams* params, SReal dt, sofa::core::MultiVecCoordId xResult, sofa::core::MultiVecDerivId vResult) override;
 
     Data<SReal> f_rayleighMass; ///< Rayleigh damping coefficient related to mass
-    Data<bool> d_threadsafevisitor;
+    Data<bool> d_threadSafeVisitor;
 
     /// Given an input derivative order (0 for position, 1 for velocity, 2 for acceleration),
     /// how much will it affect the output derivative of the given order.

--- a/modules/SofaGeneralImplicitOdeSolver/VariationalSymplecticSolver.cpp
+++ b/modules/SofaGeneralImplicitOdeSolver/VariationalSymplecticSolver.cpp
@@ -57,7 +57,7 @@ VariationalSymplecticSolver::VariationalSymplecticSolver()
     , f_computeHamiltonian( initData(&f_computeHamiltonian,true,"computeHamiltonian","Compute hamiltonian") )
     , f_hamiltonianEnergy( initData(&f_hamiltonianEnergy,0.0,"hamiltonianEnergy","hamiltonian energy") )
     , f_useIncrementalPotentialEnergy( initData(&f_useIncrementalPotentialEnergy,true,"useIncrementalPotentialEnergy","use real potential energy, if false use approximate potential energy"))
-    , d_threadsafevisitor(initData(&d_threadsafevisitor, false, "threadsafevisitor", "If true, do not use realloc and free visitors in fwdInteractionForceField."))
+    , d_threadSafeVisitor(initData(&d_threadSafeVisitor, false, "threadSafeVisitor", "If true, do not use realloc and free visitors in fwdInteractionForceField."))
 {
     cpt=0;
 }
@@ -91,7 +91,7 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
     MultiVecDeriv vel_1(&vop, vResult); // vector of final  velocity
     MultiVecDeriv p(&vop); // vector of momemtum
     // dx is no longer allocated by default (but it will be deleted automatically by the mechanical objects)
-    MultiVecDeriv dx(&vop, core::VecDerivId::dx()); dx.realloc(&vop, !d_threadsafevisitor.getValue(), true);
+    MultiVecDeriv dx(&vop, core::VecDerivId::dx()); dx.realloc(&vop, !d_threadSafeVisitor.getValue(), true);
 
     const SReal& h = dt;
     const SReal rM = f_rayleighMass.getValue();
@@ -130,7 +130,7 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
 	if (f_explicit.getValue()) {
 		mop->setImplicit(false); // this solver is explicit only
 
-        MultiVecDeriv acc(&vop, core::VecDerivId::dx()); acc.realloc(&vop, !d_threadsafevisitor.getValue(), true); // dx is no longer allocated by default (but it will be deleted automatically by the mechanical objects)
+        MultiVecDeriv acc(&vop, core::VecDerivId::dx()); acc.realloc(&vop, !d_threadSafeVisitor.getValue(), true); // dx is no longer allocated by default (but it will be deleted automatically by the mechanical objects)
 
 		sofa::helper::AdvancedTimer::stepBegin("ComputeForce");
 		mop.computeForce(f);

--- a/modules/SofaGeneralImplicitOdeSolver/VariationalSymplecticSolver.cpp
+++ b/modules/SofaGeneralImplicitOdeSolver/VariationalSymplecticSolver.cpp
@@ -57,6 +57,7 @@ VariationalSymplecticSolver::VariationalSymplecticSolver()
     , f_computeHamiltonian( initData(&f_computeHamiltonian,true,"computeHamiltonian","Compute hamiltonian") )
     , f_hamiltonianEnergy( initData(&f_hamiltonianEnergy,0.0,"hamiltonianEnergy","hamiltonian energy") )
     , f_useIncrementalPotentialEnergy( initData(&f_useIncrementalPotentialEnergy,true,"useIncrementalPotentialEnergy","use real potential energy, if false use approximate potential energy"))
+    , d_threadsafevisitor(initData(&d_threadsafevisitor, false, "threadsafevisitor", "If true, do not use realloc and free visitors in fwdInteractionForceField."))
 {
     cpt=0;
 }
@@ -90,7 +91,7 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
     MultiVecDeriv vel_1(&vop, vResult); // vector of final  velocity
     MultiVecDeriv p(&vop); // vector of momemtum
     // dx is no longer allocated by default (but it will be deleted automatically by the mechanical objects)
-    MultiVecDeriv dx(&vop, core::VecDerivId::dx() ); dx.realloc( &vop, true, true );
+    MultiVecDeriv dx(&vop, core::VecDerivId::dx()); dx.realloc(&vop, !d_threadsafevisitor.getValue(), true);
 
     const SReal& h = dt;
     const SReal rM = f_rayleighMass.getValue();
@@ -129,7 +130,7 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
 	if (f_explicit.getValue()) {
 		mop->setImplicit(false); // this solver is explicit only
 
-		MultiVecDeriv acc(&vop, core::VecDerivId::dx() ); acc.realloc( &vop, true, true ); // dx is no longer allocated by default (but it will be deleted automatically by the mechanical objects)
+        MultiVecDeriv acc(&vop, core::VecDerivId::dx()); acc.realloc(&vop, !d_threadsafevisitor.getValue(), true); // dx is no longer allocated by default (but it will be deleted automatically by the mechanical objects)
 
 		sofa::helper::AdvancedTimer::stepBegin("ComputeForce");
 		mop.computeForce(f);

--- a/modules/SofaGeneralImplicitOdeSolver/VariationalSymplecticSolver.h
+++ b/modules/SofaGeneralImplicitOdeSolver/VariationalSymplecticSolver.h
@@ -60,7 +60,7 @@ public:
     Data<bool> f_computeHamiltonian; ///< Compute hamiltonian
     Data<double> f_hamiltonianEnergy; ///< hamiltonian energy
     Data<bool> f_useIncrementalPotentialEnergy; ///< use real potential energy, if false use approximate potential energy
-    Data<bool> d_threadsafevisitor;
+    Data<bool> d_threadSafeVisitor;
 
 	VariationalSymplecticSolver();
 

--- a/modules/SofaGeneralImplicitOdeSolver/VariationalSymplecticSolver.h
+++ b/modules/SofaGeneralImplicitOdeSolver/VariationalSymplecticSolver.h
@@ -60,6 +60,7 @@ public:
     Data<bool> f_computeHamiltonian; ///< Compute hamiltonian
     Data<double> f_hamiltonianEnergy; ///< hamiltonian energy
     Data<bool> f_useIncrementalPotentialEnergy; ///< use real potential energy, if false use approximate potential energy
+    Data<bool> d_threadsafevisitor;
 
 	VariationalSymplecticSolver();
 

--- a/modules/SofaMiscSolver/NewmarkImplicitSolver.cpp
+++ b/modules/SofaMiscSolver/NewmarkImplicitSolver.cpp
@@ -51,7 +51,7 @@ NewmarkImplicitSolver::NewmarkImplicitSolver()
     , f_verbose( initData(&f_verbose,false,"verbose","Dump system state at each iteration") )
     , f_gamma( initData(&f_gamma, 0.5, "gamma", "Newmark scheme gamma coefficient"))
     , f_beta( initData(&f_beta, 0.25, "beta", "Newmark scheme beta coefficient") )
-    , d_threadsafevisitor(initData(&d_threadsafevisitor, false, "threadsafevisitor", "If true, do not use realloc and free visitors in fwdInteractionForceField."))
+    , d_threadSafeVisitor(initData(&d_threadSafeVisitor, false, "threadSafeVisitor", "If true, do not use realloc and free visitors in fwdInteractionForceField."))
 {
     cpt=0;
 }
@@ -71,7 +71,7 @@ void NewmarkImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa
 
 
     // dx is no longer allocated by default (but it will be deleted automatically by the mechanical objects)
-    MultiVecDeriv dx(&vop, core::VecDerivId::dx()); dx.realloc(&vop, !d_threadsafevisitor.getValue(), true);
+    MultiVecDeriv dx(&vop, core::VecDerivId::dx()); dx.realloc(&vop, !d_threadSafeVisitor.getValue(), true);
 
     const SReal h = dt;
     const double gamma = f_gamma.getValue();
@@ -116,7 +116,7 @@ void NewmarkImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa
 
     // Define a
     MultiVecDeriv a(&vop, pID);
-    a.realloc(&vop, !d_threadsafevisitor.getValue(), true);
+    a.realloc(&vop, !d_threadSafeVisitor.getValue(), true);
     if(cpt ==0)
     {
         a.clear();

--- a/modules/SofaMiscSolver/NewmarkImplicitSolver.cpp
+++ b/modules/SofaMiscSolver/NewmarkImplicitSolver.cpp
@@ -51,6 +51,7 @@ NewmarkImplicitSolver::NewmarkImplicitSolver()
     , f_verbose( initData(&f_verbose,false,"verbose","Dump system state at each iteration") )
     , f_gamma( initData(&f_gamma, 0.5, "gamma", "Newmark scheme gamma coefficient"))
     , f_beta( initData(&f_beta, 0.25, "beta", "Newmark scheme beta coefficient") )
+    , d_threadsafevisitor(initData(&d_threadsafevisitor, false, "threadsafevisitor", "If true, do not use realloc and free visitors in fwdInteractionForceField."))
 {
     cpt=0;
 }
@@ -70,7 +71,7 @@ void NewmarkImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa
 
 
     // dx is no longer allocated by default (but it will be deleted automatically by the mechanical objects)
-    MultiVecDeriv dx(&vop, core::VecDerivId::dx() ); dx.realloc( &vop, true, true );
+    MultiVecDeriv dx(&vop, core::VecDerivId::dx()); dx.realloc(&vop, !d_threadsafevisitor.getValue(), true);
 
     const SReal h = dt;
     const double gamma = f_gamma.getValue();
@@ -115,7 +116,7 @@ void NewmarkImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa
 
     // Define a
     MultiVecDeriv a(&vop, pID);
-    a.realloc( &vop, true, true );
+    a.realloc(&vop, !d_threadsafevisitor.getValue(), true);
     if(cpt ==0)
     {
         a.clear();

--- a/modules/SofaMiscSolver/NewmarkImplicitSolver.h
+++ b/modules/SofaMiscSolver/NewmarkImplicitSolver.h
@@ -70,6 +70,8 @@ public:
     Data<double> f_gamma; ///< Newmark scheme gamma coefficient
     Data<double> f_beta; ///< Newmark scheme beta coefficient
 
+    Data<bool> d_threadsafevisitor;
+
     void solve (const core::ExecParams* params, SReal dt, sofa::core::MultiVecCoordId xResult, sofa::core::MultiVecDerivId vResult) override;
 
     /// Given a displacement as computed by the linear system inversion, how much will it affect the velocity

--- a/modules/SofaMiscSolver/NewmarkImplicitSolver.h
+++ b/modules/SofaMiscSolver/NewmarkImplicitSolver.h
@@ -70,7 +70,7 @@ public:
     Data<double> f_gamma; ///< Newmark scheme gamma coefficient
     Data<double> f_beta; ///< Newmark scheme beta coefficient
 
-    Data<bool> d_threadsafevisitor;
+    Data<bool> d_threadSafeVisitor;
 
     void solve (const core::ExecParams* params, SReal dt, sofa::core::MultiVecCoordId xResult, sofa::core::MultiVecDerivId vResult) override;
 


### PR DESCRIPTION
Recover a commit in is_sofa_multithreading branch (3da9e50752d6aead487f0b5f8897bfc4249f9404) to allow OdeSolver concurrent execution:

A new data<bool> is added (d_threadsafevisitor) to disable allocation and writing in the mechanical object component used by the OdeSolver 
The same change is applied to all the OdeSolver derived class and it doesn't affect the default behavior and the scenes.
EulerSolver
EulerImplicitSolver
StaticSolver
CentralDifferenceSolver
VariationalSymplecticSolver
NewmarkImplicitSolver

Task Scheduler refactoring;
- improve task stealing between worker threads.
- add worker thread name to make the debugging and profiling easier.
- group and move the initialization tasks in a dedicated file.

New component and scene to show off the performance improvement of multithreading execution.
- MeanComputation




______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
