### PR TITLE
[examples] Fix the examples  missing a <RequiredPlugin name="SofaSparseSolver"/>

### DIFF
--- a/examples/Components/constraint/InextensiblePendulum.scn
+++ b/examples/Components/constraint/InextensiblePendulum.scn
@@ -3,6 +3,7 @@
 <!-- A pendulum made of a string of particles connected by distance constraints -->
 <!-- Inspired by the CompliantPendulum.scn from the Compliant plugin -->
 <Node   name="Root" gravity="0 -10 0" time="0" animate="0"  dt="0.01" >
+    <RequiredPlugin name="SofaSparseSolver"/>
     <VisualStyle displayFlags="hideVisualModels showBehaviorModels showMappings showForceFields" />
     <FreeMotionAnimationLoop solveVelocityConstraintFirst="true" />
     <GenericConstraintSolver tolerance="1e-9" iterations="1000"/>
@@ -25,7 +26,7 @@
         <MechanicalObject name="defoDOF" template="Vec3d"  />
         <EdgeSetGeometryAlgorithms drawEdges="true" />
         <FixedConstraint indices="0" />
-        <! -- 1 g for the total mass of the wire --> 
+        <!-- 1 g for the total mass of the wire -->
         <DiagonalMass  name="mass" totalMass="1e-3"/>
         <MappingGeometricStiffnessForceField mapping="@./extensionsNode/distanceMapping" />
         <Node name="extensionsNode" >
@@ -46,7 +47,7 @@
         <MechanicalObject name="defoDOF" template="Vec3d"  />
         <EdgeSetGeometryAlgorithms drawEdges="true" />
         <FixedConstraint indices="0" />
-        <! -- 1 g for the total mass of the wire --> 
+        <!-- 1 g for the total mass of the wire -->
         <DiagonalMass  name="mass" totalMass="1e-3"/>
         <Node name="extensionsNode" >
             <MechanicalObject template="Vec1d"  name="extensionsDOF" />

--- a/examples/Components/forcefield/RestShapeSpringsForceField2.scn
+++ b/examples/Components/forcefield/RestShapeSpringsForceField2.scn
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 
 <Node name="root" dt="0.01" gravity="0 0 0" >
+      <RequiredPlugin name="SofaSparseSolver"/>
       <VisualStyle displayFlags=" showCollisionModels showForceFields" />
 
       <FreeMotionAnimationLoop />
@@ -22,5 +23,4 @@
 		    
 		<LinearSolverConstraintCorrection /> 
 	</Node> 
-	
-</Node>   
+</Node>

--- a/examples/Components/linearsolver/FEMBAR-PCGLinearSolver.scn
+++ b/examples/Components/linearsolver/FEMBAR-PCGLinearSolver.scn
@@ -1,4 +1,5 @@
 <Node name="root" dt="0.02" gravity="0 -10 0">
+    <RequiredPlugin name="SofaSparseSolver"/>
     <VisualStyle displayFlags="showBehaviorModels showForceFields" />
     <CollisionPipeline depth="6" verbose="0" draw="0" />
     <BruteForceDetection name="N2" />

--- a/examples/Components/linearsolver/FEMBAR-SparseCholeskySolver.scn
+++ b/examples/Components/linearsolver/FEMBAR-SparseCholeskySolver.scn
@@ -1,4 +1,5 @@
 <Node name="root" dt="0.02" gravity="0 -10 0">
+    <RequiredPlugin name="SofaSparseSolver"/>
     <VisualStyle displayFlags="showBehaviorModels showForceFields" />
     <CollisionPipeline depth="6" verbose="0" draw="0" />
     <BruteForceDetection name="N2" />

--- a/examples/Components/linearsolver/FEMBAR-SparseLDLSolver.scn
+++ b/examples/Components/linearsolver/FEMBAR-SparseLDLSolver.scn
@@ -1,4 +1,5 @@
 <Node name="root" dt="0.02" gravity="0 -10 0">
+    <RequiredPlugin name="SofaSparseSolver"/>
     <VisualStyle displayFlags="showBehaviorModels showForceFields" />
     <CollisionPipeline depth="6" verbose="0" draw="0" />
     <BruteForceDetection name="N2" />

--- a/examples/Components/linearsolver/FEMBAR-SparseLUSolver.scn
+++ b/examples/Components/linearsolver/FEMBAR-SparseLUSolver.scn
@@ -1,4 +1,5 @@
 <Node name="root" dt="0.02" gravity="0 -10 0">
+    <RequiredPlugin name="SofaSparseSolver"/>
     <VisualStyle displayFlags="showBehaviorModels showForceFields" />
     <CollisionPipeline depth="6" verbose="0" draw="0" />
     <BruteForceDetection name="N2" />


### PR DESCRIPTION
There is examples which relies on SparseSolver without having the corresponding RequiredPlugin. 
This PR fix this (to make the CI happy). 





______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
