### PR TITLE
[runSofa] Add data field value change on mouse move

### DIFF
--- a/applications/sofa/gui/qt/WDoubleLineEdit.cpp
+++ b/applications/sofa/gui/qt/WDoubleLineEdit.cpp
@@ -12,12 +12,9 @@
 * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for    *
 * more details.                                                               *
 *                                                                             *
-* You should have received a copy of the GNU General Public License along     *
-* with this program; if not, write to the Free Software Foundation, Inc., 51  *
-* Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.                   *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
 *******************************************************************************
-*                            SOFA :: Applications                             *
-*                                                                             *
 * Authors: The SOFA Team and external contributors (see Authors.txt)          *
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *

--- a/applications/sofa/gui/qt/WDoubleLineEdit.cpp
+++ b/applications/sofa/gui/qt/WDoubleLineEdit.cpp
@@ -46,7 +46,6 @@ WDoubleLineEdit::WDoubleLineEdit(QWidget *parent,const char *name) : QLineEdit(p
             this,SLOT  (slotReturnPressed()));
 
     m_bInternal=false;
-    //validateAndSet(QString("%1").arg(m_fValue),0,0,0);
     this->setText(QString("%1").arg(m_fValue));
     this->setCursorPosition(0);
     this->setSelection(0, 0);
@@ -54,7 +53,6 @@ WDoubleLineEdit::WDoubleLineEdit(QWidget *parent,const char *name) : QLineEdit(p
 /* -------------------------------------------------------- */
 void WDoubleLineEdit::slotReturnPressed()
 {
-    //cerr<<"WDoubleLineEdit::slotReturnPressed"<<endl;
     m_bInternal=true;
 
     slotCalcValue(text().toDouble());
@@ -105,9 +103,9 @@ void WDoubleLineEdit::setValue(double f)
 
 void WDoubleLineEdit::setIntValue(int f)
 {
-    std::cout << "TO INT CASTER..." << std::endl ;
     setValue(static_cast<double>(f));
 }
+
 /* -------------------------------------------------------- */
 void WDoubleLineEdit::setValuePercent(int p)
 {
@@ -116,32 +114,28 @@ void WDoubleLineEdit::setValuePercent(int p)
     else
         m_bInternal=false;
 }
+
 /* -------------------------------------------------------- */
 int WDoubleLineEdit::valuePercent()
 {
     return ((int)(99.0*(m_fValue - m_fMinValue)/(m_fMaxValue - m_fMinValue)));
 }
+
 /* -------------------------------------------------------- */
 void WDoubleLineEdit::keyPressEvent(QKeyEvent *e)
 {
-    std::cout << "Key Pressed: " << e->key() << std::endl ;
-
     if (e->key() == Qt::Key_Escape)
     {
-//        validateAndSet(QString("%1").arg(m_fValue),0,0,0);
         this->setText(QString("%1").arg(m_fValue));
         this->setCursorPosition(0);
         this->setSelection(0, 0);
     }
     else
         QLineEdit::keyPressEvent(e);
-
-    std::cout << "VALUE IS: " << getValue() << std::endl ;
 }
 /* -------------------------------------------------------- */
 void WDoubleLineEdit::mouseMoveEvent(QMouseEvent *event) {
     if(m_isDragging){
-        //TODO(damien) This hardcoded value sucks.
         double dt=(event->x() - m_prevMousePosition.x())/100.0 ;
         m_prevMousePosition = event->pos() ;
         slotCalcValue(dt + m_fValue, false) ;
@@ -164,5 +158,4 @@ void WDoubleLineEdit::mouseReleaseEvent(QMouseEvent *event) {
         m_prevMousePosition = event->pos() ;
     }
     QLineEdit::mouseReleaseEvent(event) ;
-
 }

--- a/applications/sofa/gui/qt/WDoubleLineEdit.cpp
+++ b/applications/sofa/gui/qt/WDoubleLineEdit.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
 *       SOFA, Simulation Open-Framework Architecture, development version     *
-*                (c) 2006-2015 INRIA, USTL, UJF, CNRS, MGH                    *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
 *                                                                             *
 * This program is free software; you can redistribute it and/or modify it     *
 * under the terms of the GNU General Public License as published by the Free  *

--- a/applications/sofa/gui/qt/WDoubleLineEdit.cpp
+++ b/applications/sofa/gui/qt/WDoubleLineEdit.cpp
@@ -12,8 +12,8 @@
 * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for    *
 * more details.                                                               *
 *                                                                             *
-* You should have received a copy of the GNU Lesser General Public License    *
-* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+* You should have received a copy of the GNU General Public License along     *
+* with this program. If not, see <http://www.gnu.org/licenses/>.              *
 *******************************************************************************
 * Authors: The SOFA Team and external contributors (see Authors.txt)          *
 *                                                                             *

--- a/applications/sofa/gui/qt/WDoubleLineEdit.h
+++ b/applications/sofa/gui/qt/WDoubleLineEdit.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 *       SOFA, Simulation Open-Framework Architecture, development version     *
-*                (c) 2006-2015 INRIA, USTL, UJF, CNRS, MGH                    *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
 *                                                                             *
 * This program is free software; you can redistribute it and/or modify it     *
 * under the terms of the GNU General Public License as published by the Free  *

--- a/applications/sofa/gui/qt/WDoubleLineEdit.h
+++ b/applications/sofa/gui/qt/WDoubleLineEdit.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 *       SOFA, Simulation Open-Framework Architecture, development version     *
-*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
+*                (c) 2006-2015 INRIA, USTL, UJF, CNRS, MGH                    *
 *                                                                             *
 * This program is free software; you can redistribute it and/or modify it     *
 * under the terms of the GNU General Public License as published by the Free  *
@@ -13,8 +13,11 @@
 * more details.                                                               *
 *                                                                             *
 * You should have received a copy of the GNU General Public License along     *
-* with this program. If not, see <http://www.gnu.org/licenses/>.              *
+* with this program; if not, write to the Free Software Foundation, Inc., 51  *
+* Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.                   *
 *******************************************************************************
+*                            SOFA :: Applications                             *
+*                                                                             *
 * Authors: The SOFA Team and external contributors (see Authors.txt)          *
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
@@ -50,8 +53,16 @@ protected:
     QDoubleValidator *m_DblValid;
     double            m_bInternal;
 
+    bool              m_isDragging ;
+    QPoint            m_prevMousePosition ;
+
     void              checkValue();
     virtual void      keyPressEvent(QKeyEvent *);
+
+    virtual void      mouseMoveEvent(QMouseEvent *) ;
+    virtual void      mousePressEvent(QMouseEvent *) ;
+    virtual void      mouseReleaseEvent(QMouseEvent *) ;
+
 public:
 
     WDoubleLineEdit(QWidget *parent,const char *name);
@@ -80,14 +91,14 @@ public:
     int     getIntDisplayedValue() {return static_cast<int>(text().toDouble());}
 
 signals:
-
-    void ValueChanged(double);
+    void valueEdited(double) ;
+    void valueChanged(double);
     void valuePercentChanged(int);
 
 protected slots:
 
     void slotCalcValue(const QString&);
-    void slotCalcValue(double);
+    void slotCalcValue(double, bool isEditted=false);
     void slotReturnPressed();
 
 public slots:

--- a/applications/sofa/gui/qt/WDoubleLineEdit.h
+++ b/applications/sofa/gui/qt/WDoubleLineEdit.h
@@ -33,8 +33,6 @@
 #include <QKeyEvent>
 
 /* -------------------------------------------------------- */
-
-
 class SOFA_SOFAGUIQT_API WDoubleLineEdit : public QLineEdit
 {
     Q_OBJECT

--- a/applications/sofa/gui/qt/WDoubleLineEdit.h
+++ b/applications/sofa/gui/qt/WDoubleLineEdit.h
@@ -13,11 +13,8 @@
 * more details.                                                               *
 *                                                                             *
 * You should have received a copy of the GNU General Public License along     *
-* with this program; if not, write to the Free Software Foundation, Inc., 51  *
-* Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.                   *
+* with this program. If not, see <http://www.gnu.org/licenses/>.              *
 *******************************************************************************
-*                            SOFA :: Applications                             *
-*                                                                             *
 * Authors: The SOFA Team and external contributors (see Authors.txt)          *
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *


### PR DESCRIPTION
The workflow is really slow when changing simple values in the data inspectors 
(validating by clicking on update). In this pr we allows the user to change the numeric values
by moving the mouse left&right to decrease/increase with immediate update.

I will do a small video to show the results to make that more clear. 
https://www.youtube.com/watch?v=fuWz3Dn1-oM
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
