### PR TITLE
[SofaPython][PSDE] Update on demand as designed initially

### DIFF
--- a/applications/plugins/SofaPython/Binding_PythonScriptDataEngine.cpp
+++ b/applications/plugins/SofaPython/Binding_PythonScriptDataEngine.cpp
@@ -68,6 +68,14 @@ static PyObject * PythonScriptDataEngine_parse(PyObject * self, PyObject * /*arg
     Py_RETURN_NONE;
 }
 
+
+static PyObject * PythonScriptDataEngine_cleanDirty(PyObject * self, PyObject */* args*/)
+{
+    ScriptDataEngine* _this = sofa::py::unwrap<ScriptDataEngine>(self);
+    _this->cleanDirty();
+    Py_RETURN_NONE;
+}
+
 struct error { };
 
 template<class T>
@@ -109,7 +117,8 @@ static PyObject * PythonScriptDataEngine_new(PyTypeObject * cls, PyObject * args
 SP_CLASS_METHODS_BEGIN(PythonScriptDataEngine)
 SP_CLASS_METHOD(PythonScriptDataEngine,parse)
 SP_CLASS_METHOD(PythonScriptDataEngine,init)
-SP_CLASS_METHOD(PythonScriptDataEngine,update)
+SP_CLASS_METHOD_DOC(PythonScriptDataEngine, update, "method called everytime a component tries to access one of this engine's outputs while at least one of its inputs is dirty")
+SP_CLASS_METHOD_DOC(PythonScriptDataEngine, cleanDirty, "A method to clean the engine's inputs. To call before trying to access the outputs")
 SP_CLASS_METHODS_END
 
 

--- a/applications/plugins/SofaPython/Binding_PythonScriptDataEngine.cpp
+++ b/applications/plugins/SofaPython/Binding_PythonScriptDataEngine.cpp
@@ -69,13 +69,6 @@ static PyObject * PythonScriptDataEngine_parse(PyObject * self, PyObject * /*arg
 }
 
 
-static PyObject * PythonScriptDataEngine_cleanDirty(PyObject * self, PyObject */* args*/)
-{
-    ScriptDataEngine* _this = sofa::py::unwrap<ScriptDataEngine>(self);
-    _this->cleanDirty();
-    Py_RETURN_NONE;
-}
-
 struct error { };
 
 template<class T>
@@ -118,7 +111,6 @@ SP_CLASS_METHODS_BEGIN(PythonScriptDataEngine)
 SP_CLASS_METHOD(PythonScriptDataEngine,parse)
 SP_CLASS_METHOD(PythonScriptDataEngine,init)
 SP_CLASS_METHOD_DOC(PythonScriptDataEngine, update, "method called everytime a component tries to access one of this engine's outputs while at least one of its inputs is dirty")
-SP_CLASS_METHOD_DOC(PythonScriptDataEngine, cleanDirty, "A method to clean the engine's inputs. To call before trying to access the outputs")
 SP_CLASS_METHODS_END
 
 

--- a/applications/plugins/SofaPython/PythonScriptDataEngine.cpp
+++ b/applications/plugins/SofaPython/PythonScriptDataEngine.cpp
@@ -183,10 +183,6 @@ void PythonScriptDataEngine::setInstance(PyObject* instance) {
     refreshBinding();
 }
 
-// Ok, so in the end we're stuck with using the AnimationBeginEvent? (20.02.2018, sescaida)
-void PythonScriptDataEngine::handleEvent(Event *event)
-{
-}
 void PythonScriptDataEngine::parse( sofa::core::objectmodel::BaseObjectDescription* arg )
 {
     ScriptDataEngine::parse(arg);

--- a/applications/plugins/SofaPython/PythonScriptDataEngine.cpp
+++ b/applications/plugins/SofaPython/PythonScriptDataEngine.cpp
@@ -186,11 +186,6 @@ void PythonScriptDataEngine::setInstance(PyObject* instance) {
 // Ok, so in the end we're stuck with using the AnimationBeginEvent? (20.02.2018, sescaida)
 void PythonScriptDataEngine::handleEvent(Event *event)
 {
-    if (AnimateBeginEvent::checkEventType(event))
-    {
-        setDirtyValue();
-        update();
-    }
 }
 void PythonScriptDataEngine::parse( sofa::core::objectmodel::BaseObjectDescription* arg )
 {

--- a/applications/plugins/SofaPython/PythonScriptDataEngine.cpp
+++ b/applications/plugins/SofaPython/PythonScriptDataEngine.cpp
@@ -112,7 +112,6 @@ void PythonScriptDataEngine::refreshBinding()
     BIND_OBJECT_METHOD_DATA_ENGINE(update)
     BIND_OBJECT_METHOD_DATA_ENGINE(init)
     BIND_OBJECT_METHOD_DATA_ENGINE(parse)
-            //BIND_OBJECT_METHOD(update)
 }
 
 void PythonScriptDataEngine::doLoadScript()

--- a/applications/plugins/SofaPython/PythonScriptDataEngine.h
+++ b/applications/plugins/SofaPython/PythonScriptDataEngine.h
@@ -60,7 +60,6 @@ public:
     void setInstance(PyObject* instance);
     void refreshBinding();
     void doLoadScript();
-    virtual void handleEvent(Event *event) override;
     virtual void parse ( sofa::core::objectmodel::BaseObjectDescription* arg ) override ;
 
 protected:

--- a/applications/plugins/SofaPython/ScriptDataEngine.cpp
+++ b/applications/plugins/SofaPython/ScriptDataEngine.cpp
@@ -11,7 +11,7 @@ namespace controller
 
 void ScriptDataEngine::parse(sofa::core::objectmodel::BaseObjectDescription *arg)
 {
-    DataEngine::parse(arg);
+    Inherit1::parse(arg);
 
     // load & bind script
     loadScript();
@@ -20,7 +20,7 @@ void ScriptDataEngine::parse(sofa::core::objectmodel::BaseObjectDescription *arg
     //script_createGraph( down_cast<simulation::Node>(getContext()) );
 }
 
-ScriptDataEngine::ScriptDataEngine() : DataEngine()
+ScriptDataEngine::ScriptDataEngine() : Inherit1()
 {
     f_listening = true;
 }
@@ -30,14 +30,19 @@ ScriptDataEngine::~ScriptDataEngine()
 
 }
 
-void ScriptDataEngine::update()
+void ScriptDataEngine::call_update()
+{
+    update();
+}
+
+void ScriptDataEngine::doUpdate()
 {
     script_update();
 }
 
 void ScriptDataEngine::init()
 {
-    DataEngine::init();
+    Inherit1::init();
 }
 
 void ScriptDataEngine::reinit()

--- a/applications/plugins/SofaPython/ScriptDataEngine.cpp
+++ b/applications/plugins/SofaPython/ScriptDataEngine.cpp
@@ -32,14 +32,6 @@ ScriptDataEngine::~ScriptDataEngine()
 
 void ScriptDataEngine::update()
 {
-    const DDGLinkContainer& inputs = getInputs();
-    for (size_t i=0, iend=inputs.size() ; i<iend ; ++i)
-    {
-      static_cast<sofa::core::objectmodel::BaseData*>(inputs[i])->updateIfDirty();
-    }
-
-    // DataEngine::update(); doesn't make sense, probably?
-    cleanDirty();
     script_update();
 }
 

--- a/applications/plugins/SofaPython/ScriptDataEngine.cpp
+++ b/applications/plugins/SofaPython/ScriptDataEngine.cpp
@@ -32,6 +32,12 @@ ScriptDataEngine::~ScriptDataEngine()
 
 void ScriptDataEngine::update()
 {
+    const DDGLinkContainer& inputs = getInputs();
+    for (size_t i=0, iend=inputs.size() ; i<iend ; ++i)
+    {
+      static_cast<sofa::core::objectmodel::BaseData*>(inputs[i])->updateIfDirty();
+    }
+
     // DataEngine::update(); doesn't make sense, probably?
     cleanDirty();
     script_update();

--- a/applications/plugins/SofaPython/ScriptDataEngine.h
+++ b/applications/plugins/SofaPython/ScriptDataEngine.h
@@ -18,10 +18,10 @@ namespace controller
 {
 
 
-class SOFA_SOFAPYTHON_API ScriptDataEngine : public core::DataEngine
+class SOFA_SOFAPYTHON_API ScriptDataEngine : public core::SimpleDataEngine
 {
 public:
-    SOFA_CLASS(ScriptDataEngine,core::DataEngine);
+    SOFA_CLASS(ScriptDataEngine,core::SimpleDataEngine);
 
 protected:
     ScriptDataEngine();
@@ -37,7 +37,8 @@ public:
     virtual void reinit() override ;
 
 
-    virtual void update() override ;
+    void call_update();
+    virtual void doUpdate() override ;
 
 
 protected:


### PR DESCRIPTION
Dependency on #760 

This PR mimics the behavior of the DataEngine, by binding the cleanDirty method in python, and not calling cleanDirty before calling update()
Furthermore, update() is not called from OnBeginAnimationStep events anymore, but only through the natural DDGNode update mechanism.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
