### PR TITLE
[Gui][HeadlessRecorder]Remove avcodec dependency in HeadlessRecorder.h

### DIFF
--- a/applications/sofa/gui/headlessRecorder/HeadlessRecorder.cpp
+++ b/applications/sofa/gui/headlessRecorder/HeadlessRecorder.cpp
@@ -20,7 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include "HeadlessRecorder.h"
-
+#include "VideoRecorderFFMpeg.h"
 namespace sofa
 {
 

--- a/applications/sofa/gui/headlessRecorder/HeadlessRecorder.h
+++ b/applications/sofa/gui/headlessRecorder/HeadlessRecorder.h
@@ -47,8 +47,6 @@
 #include <sofa/helper/io/Image.h>
 #include <sofa/helper/system/SetDirectory.h>
 
-#include "VideoRecorderFFMpeg.h"
-
 namespace sofa
 {
 
@@ -59,6 +57,8 @@ namespace hRecorder
 {
 
 enum class RecordMode { wallclocktime, simulationtime, timeinterval };
+
+class VideoRecorderFFmpeg;
 
 class HeadlessRecorder : public sofa::gui::BaseGUI
 {


### PR DESCRIPTION
Forward declare a class, so that avcodecs headers are only required when compiling the cpp.
That way, this header can be included even if FFmpeg headers are not in context (which lead to compilation failure).

--> Can this change be also backported to 18.06 branch ?


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
