### PR TITLE
[SofaGraphComponent] ADD SceneCheck for required Datas

### DIFF
--- a/SofaKernel/framework/sofa/core/objectmodel/BaseObject.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseObject.cpp
@@ -267,15 +267,6 @@ void BaseObject::releaseAspect(int aspect)
 
 void BaseObject::init()
 {
-
-
-	for(VecData::const_iterator iData = this->m_vecData.begin(); iData != this->m_vecData.end(); ++iData)
-	{
-		if ((*iData)->isRequired() && !(*iData)->isSet())
-		{
-            serr << "Required data \"" << (*iData)->getName() << "\" has not been set. (Current value is " << (*iData)->getValueString() << ")" << sendl;
-		}
-	}
 }
 
 void BaseObject::bwdInit()

--- a/applications/sofa/gui/BaseGUI.cpp
+++ b/applications/sofa/gui/BaseGUI.cpp
@@ -30,6 +30,17 @@
 #include <SofaGraphComponent/BackgroundSetting.h>
 #include <SofaGraphComponent/StatsSetting.h>
 
+#include <SofaGraphComponent/SceneCheckAPIChange.h>
+using sofa::simulation::scenechecking::SceneCheckAPIChange;
+#include <SofaGraphComponent/SceneCheckMissingRequiredPlugin.h>
+using sofa::simulation::scenechecking::SceneCheckMissingRequiredPlugin;
+#include <SofaGraphComponent/SceneCheckDuplicatedName.h>
+using sofa::simulation::scenechecking::SceneCheckDuplicatedName;
+#include <SofaGraphComponent/SceneCheckUsingAlias.h>
+using sofa::simulation::scenechecking::SceneCheckUsingAlias;
+#include <SofaGraphComponent/SceneCheckRequiredData.h>
+using sofa::simulation::scenechecking::SceneCheckRequiredData;
+
 #include <algorithm>
 #include <string.h>
 
@@ -54,8 +65,13 @@ std::string BaseGUI::screenshotDirectoryPath = ".";
 ArgumentParser* BaseGUI::mArgumentParser = NULL;
 
 BaseGUI::BaseGUI()
+    : m_checker(sofa::core::ExecParams::defaultInstance())
 {
-
+    m_checker.addCheck(SceneCheckAPIChange::newSPtr());
+    m_checker.addCheck(SceneCheckDuplicatedName::newSPtr());
+    m_checker.addCheck(SceneCheckMissingRequiredPlugin::newSPtr());
+    m_checker.addCheck(SceneCheckUsingAlias::newSPtr());
+    m_checker.addCheck(SceneCheckRequiredData::newSPtr());
 }
 
 BaseGUI::~BaseGUI()
@@ -177,6 +193,11 @@ void BaseGUI::setConfigDirectoryPath(const std::string& path, bool createIfNeces
 void BaseGUI::setScreenshotDirectoryPath(const std::string& path, bool createIfNecessary)
 {
     setDirectoryPath(screenshotDirectoryPath, path, createIfNecessary);
+}
+
+void BaseGUI::setScene(Node::SPtr groot, const char *filename, bool temporaryFile)
+{
+    m_checker.validate(groot.get());
 }
 
 

--- a/applications/sofa/gui/BaseGUI.h
+++ b/applications/sofa/gui/BaseGUI.h
@@ -30,6 +30,9 @@
 #include <sofa/helper/ArgumentParser.h>
 using sofa::helper::ArgumentParser;
 
+#include <SofaGraphComponent/SceneCheckerVisitor.h>
+using sofa::simulation::scenechecking::SceneCheckerVisitor;
+
 #include <list>
 
 
@@ -55,7 +58,7 @@ public:
     /// Close the GUI
     virtual int closeGUI()=0;
     /// Register the scene in our GUI
-    virtual void setScene(sofa::simulation::Node::SPtr groot, const char* filename=NULL, bool temporaryFile=false)=0;
+    virtual void setScene(sofa::simulation::Node::SPtr groot, const char* filename=NULL, bool temporaryFile=false);
     /// Get the rootNode of the sofa scene
     virtual sofa::simulation::Node* currentSimulation() = 0;
     /// @}
@@ -121,6 +124,8 @@ protected:
     static std::string screenshotDirectoryPath;
     static const char* mProgramName;
     static ArgumentParser* mArgumentParser;
+
+    SceneCheckerVisitor m_checker;
 };
 
 ////// TO declare into BaseViewer

--- a/applications/sofa/gui/BatchGUI.cpp
+++ b/applications/sofa/gui/BatchGUI.cpp
@@ -108,6 +108,8 @@ int BatchGUI::closeGUI()
 
 void BatchGUI::setScene(sofa::simulation::Node::SPtr groot, const char* filename, bool )
 {
+    BaseGUI::setScene(groot);
+
     this->groot = groot;
     this->filename = (filename?filename:"");
 

--- a/applications/sofa/gui/qt/RealGUI.cpp
+++ b/applications/sofa/gui/qt/RealGUI.cpp
@@ -113,18 +113,6 @@ using sofa::core::objectmodel::IdleEvent;
 #include <sofa/helper/system/FileMonitor.h>
 using sofa::helper::system::FileMonitor;
 
-#include <SofaGraphComponent/SceneCheckerVisitor.h>
-using sofa::simulation::scenechecking::SceneCheckerVisitor;
-
-#include <SofaGraphComponent/SceneCheckAPIChange.h>
-using sofa::simulation::scenechecking::SceneCheckAPIChange;
-#include <SofaGraphComponent/SceneCheckMissingRequiredPlugin.h>
-using sofa::simulation::scenechecking::SceneCheckMissingRequiredPlugin;
-#include <SofaGraphComponent/SceneCheckDuplicatedName.h>
-using sofa::simulation::scenechecking::SceneCheckDuplicatedName;
-#include <SofaGraphComponent/SceneCheckUsingAlias.h>
-using sofa::simulation::scenechecking::SceneCheckUsingAlias;
-
 #include <sofa/core/ObjectFactory.h>
 using sofa::core::ObjectFactory;
 
@@ -744,7 +732,6 @@ sofa::simulation::Node* RealGUI::currentSimulation()
 
 void RealGUI::fileOpen ( std::string filename, bool temporaryFile, bool reload )
 {
-    SceneCheckerVisitor checker(ExecParams::defaultInstance());
     std::vector<std::string> expandedNodes;
 
     if(reload)
@@ -753,13 +740,6 @@ void RealGUI::fileOpen ( std::string filename, bool temporaryFile, bool reload )
 
         if(simulationGraph)
             simulationGraph->getExpandedNodes(expandedNodes);
-    }
-    else
-    {
-        checker.addCheck(SceneCheckAPIChange::newSPtr());
-        checker.addCheck(SceneCheckDuplicatedName::newSPtr());
-        checker.addCheck(SceneCheckMissingRequiredPlugin::newSPtr());
-        checker.addCheck(SceneCheckUsingAlias::newSPtr());
     }
 
     const std::string &extension=SetDirectory::GetExtension(filename.c_str());
@@ -804,14 +784,6 @@ void RealGUI::fileOpen ( std::string filename, bool temporaryFile, bool reload )
     if(!expandedNodes.empty())
     {
         simulationGraph->expandPathFrom(expandedNodes);
-    }
-
-    /// We want to warn user that there is component that are implemented in specific plugin
-    /// and that there is no RequiredPlugin in their scene.
-    /// But we don't want that to happen each reload in interactive mode.
-    if(!reload)
-    {
-        checker.validate(mSimulation.get());
     }
 }
 
@@ -947,15 +919,6 @@ void RealGUI::setSceneWithoutMonitor (Node::SPtr root, const char* filename, boo
 
     if (root)
     {
-        /// We want to warn user that there is component that are implemented in specific plugin
-        /// and that there is no RequiredPlugin in their scene.
-//        SceneCheckerVisitor checker(ExecParams::defaultInstance());
-//        checker.addCheck(SceneCheckAPIChange::newSPtr());
-//        checker.addCheck(SceneCheckDuplicatedName::newSPtr());
-//        checker.addCheck(SceneCheckMissingRequiredPlugin::newSPtr());
-//        checker.addCheck(SceneCheckUsingAlias::newSPtr());
-//        checker.validate(root.get());
-
         //Check the validity of the BBox
         const sofa::defaulttype::BoundingBox& nodeBBox = root->getContext()->f_bbox.getValue();
         if(nodeBBox.isNegligeable())
@@ -999,6 +962,8 @@ void RealGUI::setSceneWithoutMonitor (Node::SPtr root, const char* filename, boo
 
 void RealGUI::setScene(Node::SPtr root, const char* filename, bool temporaryFile)
 {
+    BaseGUI::setScene(root);
+
     if(m_enableInteraction &&  filename){
         FileMonitor::removeListener(m_filelistener);
         FileMonitor::addFile(filename, m_filelistener);

--- a/modules/SofaGraphComponent/CMakeLists.txt
+++ b/modules/SofaGraphComponent/CMakeLists.txt
@@ -28,6 +28,7 @@ list(APPEND HEADER_FILES
     SceneCheckDuplicatedName.h
     SceneCheckMissingRequiredPlugin.h
     SceneCheckAPIChange.h
+    SceneCheckRequiredData.h
     SceneCheckUsingAlias.h
     SceneCheckerVisitor.h
     APIVersion.h
@@ -48,6 +49,7 @@ list(APPEND SOURCE_FILES
     SceneCheckDuplicatedName.cpp
     SceneCheckMissingRequiredPlugin.cpp
     SceneCheckAPIChange.cpp
+    SceneCheckRequiredData.cpp
     SceneCheckUsingAlias.cpp
     SceneCheckerVisitor.cpp
     APIVersion.cpp

--- a/modules/SofaGraphComponent/SceneCheckRequiredData.cpp
+++ b/modules/SofaGraphComponent/SceneCheckRequiredData.cpp
@@ -1,0 +1,113 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include "SceneCheckRequiredData.h"
+
+#include <sofa/version.h>
+#include <sofa/core/ObjectFactory.h>
+#include <sofa/core/objectmodel/BaseObjectDescription.h>
+#include <sofa/simulation/Node.h>
+
+
+namespace sofa
+{
+namespace simulation
+{
+namespace _scenechecking_
+{
+
+using sofa::core::objectmodel::Base;
+using sofa::core::objectmodel::BaseObject;
+using sofa::core::objectmodel::BaseObjectDescription;
+using sofa::core::ObjectFactory;
+
+
+SceneCheckRequiredData::SceneCheckRequiredData()
+{
+
+}
+
+SceneCheckRequiredData::~SceneCheckRequiredData()
+{
+
+}
+
+const std::string SceneCheckRequiredData::getName()
+{
+    return "SceneCheckRequiredData";
+}
+
+const std::string SceneCheckRequiredData::getDesc()
+{
+    return "Check if a Component has required Datas that are not set.";
+}
+
+void SceneCheckRequiredData::doInit(Node* node)
+{
+    m_missingDatas.clear();
+}
+
+void SceneCheckRequiredData::doCheckOn(Node* node)
+{
+    for (auto& object : node->object )
+    {
+        Base::VecData vecData = object->getDataFields();
+        for(Base::VecData::const_iterator iData = vecData.begin(); iData != vecData.end(); ++iData)
+        {
+            if ((*iData)->isRequired() && !(*iData)->isSet())
+            {
+                std::vector<sofa::core::objectmodel::BaseData*> v = m_missingDatas[object.get()];
+                if ( v.empty() || std::find(v.begin(), v.end(), *iData) == v.end() )
+                {
+                    m_missingDatas[object.get()].push_back(*iData);
+                }
+            }
+        }
+    }
+}
+
+void SceneCheckRequiredData::doPrintSummary()
+{
+    if(m_missingDatas.empty())
+    {
+        return;
+    }
+
+    for (auto &i : m_missingDatas)
+    {
+        std::stringstream errorStr;
+        errorStr << "Required datas have not been set: ";
+
+        bool first = true;
+        for (auto &data : i.second)
+        {
+             if (first) first = false;
+             else errorStr << ", ";
+             errorStr << "\"" << data->getName() << "\" (current value is " << data->getValueString() << ")";
+        }
+
+        msg_warning(i.first) << this->getName() << ": " << errorStr.str();
+    }
+}
+
+} // namespace _scenechecking_
+} // namespace simulation
+} // namespace sofa

--- a/modules/SofaGraphComponent/SceneCheckRequiredData.h
+++ b/modules/SofaGraphComponent/SceneCheckRequiredData.h
@@ -1,0 +1,69 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#ifndef SOFA_SIMULATION_SCENECHECKREQUIREDDATA_H
+#define SOFA_SIMULATION_SCENECHECKREQUIREDDATA_H
+
+#include "SceneCheck.h"
+
+#include "config.h"
+#include <sofa/core/objectmodel/BaseObject.h>
+#include <sofa/core/objectmodel/BaseData.h>
+
+#include <map>
+#include <vector>
+
+namespace sofa
+{
+namespace simulation
+{
+namespace _scenechecking_
+{
+    
+class SOFA_GRAPH_COMPONENT_API SceneCheckRequiredData : public SceneCheck
+{
+public:
+    SceneCheckRequiredData();
+    virtual ~SceneCheckRequiredData();
+
+    typedef std::shared_ptr<SceneCheckRequiredData> SPtr;
+    static SPtr newSPtr() { return SPtr(new SceneCheckRequiredData()); }
+    virtual const std::string getName() override;
+    virtual const std::string getDesc() override;
+    virtual void doInit(Node* node) override;
+    virtual void doCheckOn(Node* node) override;
+    virtual void doPrintSummary() override;
+
+private:
+    std::map<sofa::core::objectmodel::BaseObject*, std::vector<sofa::core::objectmodel::BaseData*>> m_missingDatas;
+};
+
+} // namespace _scenechecking_
+
+namespace scenechecking
+{
+    using _scenechecking_::SceneCheckRequiredData;
+}
+
+} // namespace simulation
+} // namespace sofa
+
+#endif // SOFA_SIMULATION_SCENECHECKREQUIREDDATA_H

--- a/modules/SofaGraphComponent/SceneCheckUsingAlias.h
+++ b/modules/SofaGraphComponent/SceneCheckUsingAlias.h
@@ -44,7 +44,7 @@ public:
     static SPtr newSPtr() { return SPtr(new SceneCheckUsingAlias()); }
     virtual const std::string getName() override;
     virtual const std::string getDesc() override;
-    virtual void doInit(Node* node) override { SOFA_UNUSED(node); }
+    virtual void doInit(Node* node) override;
     virtual void doCheckOn(Node* node) override { SOFA_UNUSED(node); }
     virtual void doPrintSummary() override;
 


### PR DESCRIPTION
This PR moves required Data check from BaseObject::init() to a new SceneCheck loaded by default.
The starting problem for this work was that having the check in BaseObject::init() forces every Component that overrides init() to call the parent init().

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
