### PR TITLE
[All] Fix some compilation warnings

### DIFF
--- a/SofaKernel/framework/sofa/core/loader/MeshLoader.cpp
+++ b/SofaKernel/framework/sofa/core/loader/MeshLoader.cpp
@@ -472,7 +472,7 @@ void MeshLoader::updatePoints()
 {
     if (d_onlyAttachedPoints.getValue())
     {
-        std::set<unsigned int> attachedPoints;
+        std::set<Topology::ElemID> attachedPoints;
         {
             helper::ReadAccessor<Data< helper::vector< Edge > > > elems = d_edges;
             for (size_t i = 0; i < elems.size(); ++i)
@@ -535,12 +535,12 @@ void MeshLoader::updatePoints()
             return;    // all points are attached
         }
         helper::WriteAccessor<Data<helper::vector<sofa::defaulttype::Vec<3, SReal> > > > waPositions = d_positions;
-        helper::vector<unsigned int> old2new;
+        helper::vector<Topology::ElemID> old2new;
         old2new.resize(waPositions.size());
-        unsigned int p = 0;
-        for (std::set<unsigned int>::const_iterator it = attachedPoints.begin(), itend = attachedPoints.end(); it != itend; ++it)
+        Topology::ElemID p = 0;
+        for (std::set<Topology::ElemID>::const_iterator it = attachedPoints.begin(), itend = attachedPoints.end(); it != itend; ++it)
         {
-            unsigned int newp = *it;
+            Topology::ElemID newp = *it;
             old2new[newp] = p;
             if (p != newp)
             {
@@ -698,7 +698,7 @@ void MeshLoader::addEdge(helper::vector<Edge >* pEdges, const Edge& p)
     pEdges->push_back(p);
 }
 
-void MeshLoader::addEdge(helper::vector<Edge >* pEdges, unsigned int p0, unsigned int p1)
+void MeshLoader::addEdge(helper::vector<Edge >* pEdges, Topology::EdgeID p0, Topology::EdgeID p1)
 {
     addEdge(pEdges, Edge(p0, p1));
 }
@@ -718,7 +718,7 @@ void MeshLoader::addTriangle(helper::vector<Triangle >* pTriangles, const Triang
     }
 }
 
-void MeshLoader::addTriangle(helper::vector<Triangle >* pTriangles, unsigned int p0, unsigned int p1, unsigned int p2)
+void MeshLoader::addTriangle(helper::vector<Triangle >* pTriangles, Topology::TriangleID p0, Topology::TriangleID p1, Topology::TriangleID p2)
 {
     addTriangle(pTriangles, Triangle(p0, p1, p2));
 }
@@ -738,16 +738,16 @@ void MeshLoader::addQuad(helper::vector<Quad >* pQuads, const Quad& p)
     }
 }
 
-void MeshLoader::addQuad(helper::vector<Quad >* pQuads, unsigned int p0, unsigned int p1, unsigned int p2, unsigned int p3)
+void MeshLoader::addQuad(helper::vector<Quad >* pQuads, Topology::QuadID p0, Topology::QuadID p1, Topology::QuadID p2, Topology::QuadID p3)
 {
     addQuad(pQuads, Quad(p0, p1, p2, p3));
 }
 
-void MeshLoader::addPolygon(helper::vector< helper::vector <unsigned int> >* pPolygons, const helper::vector<unsigned int>& p)
+void MeshLoader::addPolygon(helper::vector< helper::vector <Topology::ElemID> >* pPolygons, const helper::vector<Topology::ElemID>& p)
 {
     if (d_flipNormals.getValue())
     {
-        helper::vector<unsigned int> revertP(p.size());
+        helper::vector<Topology::ElemID> revertP(p.size());
         std::reverse_copy(p.begin(), p.end(), revertP.begin());
 
         pPolygons->push_back(revertP);
@@ -764,14 +764,14 @@ void MeshLoader::addTetrahedron(helper::vector< Tetrahedron >* pTetrahedra, cons
     pTetrahedra->push_back(p);
 }
 
-void MeshLoader::addTetrahedron(helper::vector< Tetrahedron >* pTetrahedra, unsigned int p0, unsigned int p1, unsigned int p2, unsigned int p3)
+void MeshLoader::addTetrahedron(helper::vector< Tetrahedron >* pTetrahedra, Topology::TetrahedronID p0, Topology::TetrahedronID p1, Topology::TetrahedronID p2, Topology::TetrahedronID p3)
 {
     addTetrahedron(pTetrahedra, Tetrahedron(p0, p1, p2, p3));
 }
 
 void MeshLoader::addHexahedron(helper::vector< Hexahedron >* pHexahedra,
-                               unsigned int p0, unsigned int p1, unsigned int p2, unsigned int p3,
-                               unsigned int p4, unsigned int p5, unsigned int p6, unsigned int p7)
+                               Topology::HexahedronID p0, Topology::HexahedronID p1, Topology::HexahedronID p2, Topology::HexahedronID p3,
+                               Topology::HexahedronID p4, Topology::HexahedronID p5, Topology::HexahedronID p6, Topology::HexahedronID p7)
 {
     addHexahedron(pHexahedra, Hexahedron(p0, p1, p2, p3, p4, p5, p6, p7));
 }
@@ -782,8 +782,8 @@ void MeshLoader::addHexahedron(helper::vector< Hexahedron >* pHexahedra, const H
 }
 
 void MeshLoader::addPentahedron(helper::vector< Pentahedron >* pPentahedra,
-                                unsigned int p0, unsigned int p1, unsigned int p2, unsigned int p3,
-                                unsigned int p4, unsigned int p5)
+                                Topology::ElemID p0, Topology::ElemID p1, Topology::ElemID p2, Topology::ElemID p3,
+                                Topology::ElemID p4, Topology::ElemID p5)
 {
     addPentahedron(pPentahedra, Pentahedron(p0, p1, p2, p3, p4, p5));
 }
@@ -794,7 +794,7 @@ void MeshLoader::addPentahedron(helper::vector< Pentahedron >* pPentahedra, cons
 }
 
 void MeshLoader::addPyramid(helper::vector< Pyramid >* pPyramids,
-                            unsigned int p0, unsigned int p1, unsigned int p2, unsigned int p3, unsigned int p4)
+                            Topology::ElemID p0, Topology::ElemID p1, Topology::ElemID p2, Topology::ElemID p3, Topology::ElemID p4)
 {
     addPyramid(pPyramids, Pyramid(p0, p1, p2, p3, p4));
 }

--- a/SofaKernel/framework/sofa/core/loader/MeshLoader.h
+++ b/SofaKernel/framework/sofa/core/loader/MeshLoader.h
@@ -45,7 +45,7 @@ namespace loader
 {
 
 using sofa::defaulttype::Vector3;
-
+using topology::Topology;
 
 class SOFA_CORE_API MeshLoader : public BaseLoader
 {
@@ -142,16 +142,16 @@ public:
     Data< helper::vector< Edge > > d_edges; ///< Edges of the mesh loaded
     Data< helper::vector< Triangle > > d_triangles; ///< Triangles of the mesh loaded
     Data< helper::vector< Quad > > d_quads; ///< Quads of the mesh loaded
-    Data< helper::vector< helper::vector <unsigned int> > > d_polygons; ///< Polygons of the mesh loaded
+    Data< helper::vector< helper::vector <Topology::ElemID> > > d_polygons; ///< Polygons of the mesh loaded
     Data< helper::vector< HighOrderEdgePosition > > d_highOrderEdgePositions; ///< High order edge points of the mesh loaded
     Data< helper::vector< HighOrderTrianglePosition > > d_highOrderTrianglePositions; ///< High order triangle points of the mesh loaded
     Data< helper::vector< HighOrderQuadPosition > > d_highOrderQuadPositions; ///< High order quad points of the mesh loaded
-
+    Data< helper::vector< Pyramid > > d_pyramids; ///< Pyramids of the mesh loaded
     // Tab of 3D elements composition
     Data< helper::vector< Tetrahedron > > d_tetrahedra; ///< Tetrahedra of the mesh loaded
-    Data< helper::vector< Hexahedron > > d_hexahedra; ///< Hexahedra of the mesh loaded
+    
     Data< helper::vector< Pentahedron > > d_pentahedra; ///< Pentahedra of the mesh loaded
-    Data< helper::vector< Pyramid > > d_pyramids; ///< Pyramids of the mesh loaded
+    Data< helper::vector< Hexahedron > > d_hexahedra; ///< Hexahedra of the mesh loaded
     Data< helper::vector< HighOrderTetrahedronPosition > > d_highOrderTetrahedronPositions; ///< High order tetrahedron points of the mesh loaded
     Data< helper::vector< HighOrderHexahedronPosition > > d_highOrderHexahedronPositions; ///< High order hexahedron points of the mesh loaded
 
@@ -198,32 +198,32 @@ protected:
     void addPolyline(helper::vector<Polyline>* pPolylines, Polyline p);
 
     void addEdge(helper::vector<Edge>* pEdges, const Edge& p);
-    void addEdge(helper::vector<Edge>* pEdges, unsigned int p0, unsigned int p1);
+    void addEdge(helper::vector<Edge>* pEdges, Topology::EdgeID p0, Topology::EdgeID p1);
 
     void addTriangle(helper::vector<Triangle>* pTriangles, const Triangle& p);
-    void addTriangle(helper::vector<Triangle>* pTriangles, unsigned int p0, unsigned int p1, unsigned int p2);
+    void addTriangle(helper::vector<Triangle>* pTriangles, Topology::TriangleID p0, Topology::TriangleID p1, Topology::TriangleID p2);
 
     void addQuad(helper::vector<Quad>* pQuads, const Quad& p);
-    void addQuad(helper::vector<Quad>* pQuads, unsigned int p0, unsigned int p1, unsigned int p2, unsigned int p3);
+    void addQuad(helper::vector<Quad>* pQuads, Topology::QuadID p0, Topology::QuadID p1, Topology::QuadID p2, Topology::QuadID p3);
 
-    void addPolygon(helper::vector< helper::vector <unsigned int> >* pPolygons, const helper::vector<unsigned int>& p);
+    void addPolygon(helper::vector< helper::vector <Topology::ElemID> >* pPolygons, const helper::vector<Topology::ElemID>& p);
 
     void addTetrahedron(helper::vector<Tetrahedron>* pTetrahedra, const Tetrahedron& p);
-    void addTetrahedron(helper::vector<Tetrahedron>* pTetrahedra, unsigned int p0, unsigned int p1, unsigned int p2, unsigned int p3);
+    void addTetrahedron(helper::vector<Tetrahedron>* pTetrahedra, Topology::TetrahedronID p0, Topology::TetrahedronID p1, Topology::TetrahedronID p2, Topology::TetrahedronID p3);
 
     void addHexahedron(helper::vector< Hexahedron>* pHexahedra, const Hexahedron& p);
     void addHexahedron(helper::vector< Hexahedron>* pHexahedra,
-                       unsigned int p0, unsigned int p1, unsigned int p2, unsigned int p3,
-                       unsigned int p4, unsigned int p5, unsigned int p6, unsigned int p7);
+                       Topology::HexahedronID p0, Topology::HexahedronID p1, Topology::HexahedronID p2, Topology::HexahedronID p3,
+                       Topology::HexahedronID p4, Topology::HexahedronID p5, Topology::HexahedronID p6, Topology::HexahedronID p7);
 
     void addPentahedron(helper::vector< Pentahedron>* pPentahedra, const Pentahedron& p);
     void addPentahedron(helper::vector< Pentahedron>* pPentahedra,
-                        unsigned int p0, unsigned int p1, unsigned int p2, unsigned int p3,
-                        unsigned int p4, unsigned int p5);
+                        Topology::ElemID p0, Topology::ElemID p1, Topology::ElemID p2, Topology::ElemID p3,
+                        Topology::ElemID p4, Topology::ElemID p5);
 
     void addPyramid(helper::vector< Pyramid>* pPyramids, const Pyramid& p);
     void addPyramid(helper::vector< Pyramid>* pPyramids,
-                    unsigned int p0, unsigned int p1, unsigned int p2, unsigned int p3, unsigned int p4);
+                    Topology::ElemID p0, Topology::ElemID p1, Topology::ElemID p2, Topology::ElemID p3, Topology::ElemID p4);
 
     /// Temporary method that will copy all buffers from a io::Mesh into the corresponding Data. Will be removed as soon as work on unifying meshloader is finished
     void copyMeshToData(helper::io::Mesh* _mesh);

--- a/SofaKernel/framework/sofa/core/logging/RichConsoleStyleMessageFormatter.cpp
+++ b/SofaKernel/framework/sofa/core/logging/RichConsoleStyleMessageFormatter.cpp
@@ -65,7 +65,7 @@ typedef boost::tokenizer<boost::char_separator<char> > tokenizer;
 /// \param line_length number of column to render to to
 /// \param wrapped the destination stream where to write the formatted text.
 ///
-void simpleFormat(int jsize, const std::string& text, size_t line_length,
+void simpleFormat(size_t jsize, const std::string& text, size_t line_length,
                   std::ostream& wrapped)
 {
     //TODO(dmarchal): All that code is a mess...need to be done for real.

--- a/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
@@ -466,7 +466,7 @@ bool Base::parseField( const std::string& attribute, const std::string& value)
             ok = false;
         }
         sout << "Link " << linkVec[l]->getName() << " = " << linkVec[l]->getValueString() << sendl;
-        unsigned int s = linkVec[l]->getSize();
+        unsigned int s = (unsigned int)linkVec[l]->getSize();
         for (unsigned int i=0; i<s; ++i)
         {
             sout  << "  " << linkVec[l]->getLinkedPath(i) << " = ";

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseLink.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseLink.cpp
@@ -60,9 +60,9 @@ BaseLink::~BaseLink()
 /// Print the value of the associated variable
 void BaseLink::printValue( std::ostream& o ) const
 {
-    std::size_t size = getSize();
+    unsigned int size = (unsigned int)getSize();
     bool first = true;
-    for (std::size_t i = 0; i<size; ++i)
+    for (unsigned int i = 0; i<size; ++i)
     {
         std::string path = getLinkedPath(i);
         if (path.empty()) continue;

--- a/SofaKernel/framework/sofa/core/topology/BaseMeshTopology.h
+++ b/SofaKernel/framework/sofa/core/topology/BaseMeshTopology.h
@@ -263,7 +263,7 @@ public:
     /// Checks if the topology has only one connected component. @return Return true if so.
     virtual bool checkConnexity() {return true;}
     /// Returns the number of connected component.
-    virtual unsigned int getNumberOfConnectedComponent() {return 0;}
+    virtual size_t getNumberOfConnectedComponent() {return 0;}
     /// Returns the set of element indices connected to an input one (i.e. which can be reached by topological links)
     virtual const sofa::helper::vector<index_type> getConnectedElement(index_type elem);
     /// @}

--- a/SofaKernel/framework/sofa/core/topology/Topology.h
+++ b/SofaKernel/framework/sofa/core/topology/Topology.h
@@ -57,17 +57,18 @@ public:
     //typedef int index_type;
     typedef unsigned int index_type;
     enum { InvalidID = (unsigned)-1 };
-    typedef index_type	        	    PointID;
-    typedef index_type          		    EdgeID;
-    typedef index_type                          TriangleID;
-    typedef index_type                 	    QuadID;
-    typedef index_type	                    TetraID;
-    typedef index_type	                    TetrahedronID;
-    typedef index_type	                    HexaID;
-    typedef index_type	                    HexahedronID;
-    typedef index_type	                    PentahedronID;
-    typedef index_type	                    PentaID;
-    typedef index_type	                    PyramidID;
+    typedef index_type                 ElemID;
+    typedef index_type                 PointID;
+    typedef index_type                 EdgeID;
+    typedef index_type                 TriangleID;
+    typedef index_type                 QuadID;
+    typedef index_type                 TetraID;
+    typedef index_type                 TetrahedronID;
+    typedef index_type                 HexaID;
+    typedef index_type                 HexahedronID;
+    typedef index_type                 PentahedronID;
+    typedef index_type                 PentaID;
+    typedef index_type                 PyramidID;
 
 
     typedef sofa::helper::vector<index_type>                  SetIndex;

--- a/SofaKernel/framework/sofa/core/topology/TopologyChange.h
+++ b/SofaKernel/framework/sofa/core/topology/TopologyChange.h
@@ -131,15 +131,15 @@ class SOFA_CORE_API HexahedraRenumbering;
 /// Topology identification of a primitive element
 struct TopologyElemID
 {
-    TopologyElemID() : type(POINT), index((unsigned int)-1) {}
+    TopologyElemID() : type(POINT), index((Topology::ElemID)-1) {}
 
-    TopologyElemID(TopologyObjectType _type, unsigned int _index)
+    TopologyElemID(TopologyObjectType _type, Topology::ElemID _index)
         : type(_type)
         , index(_index)
     {}
 
     TopologyObjectType type;
-    unsigned int index;
+    Topology::ElemID index;
 };
 
 SOFA_CORE_API std::ostream& operator << (std::ostream& out, const TopologyElemID& d);
@@ -150,16 +150,16 @@ struct PointAncestorElem
 {
     typedef defaulttype::Vec<3, double> LocalCoords;
 
-    PointAncestorElem() : type(POINT), index((unsigned int)-1) {}
+    PointAncestorElem() : type(POINT), index((Topology::ElemID)-1) {}
 
-    PointAncestorElem(TopologyObjectType _type, unsigned int _index, const LocalCoords& _localCoords)
+    PointAncestorElem(TopologyObjectType _type, Topology::ElemID _index, const LocalCoords& _localCoords)
         : type(_type)
         , index(_index)
         , localCoords(_localCoords)
     {}
     
     TopologyObjectType type;
-    unsigned int index;
+    Topology::ElemID index;
     LocalCoords localCoords;
 };
 
@@ -399,7 +399,7 @@ public:
 class SOFA_CORE_API PointsIndicesSwap : public core::topology::TopologyChange
 {
 public:
-    PointsIndicesSwap(const unsigned int i1,const unsigned int i2) : core::topology::TopologyChange(core::topology::POINTSINDICESSWAP)
+    PointsIndicesSwap(const Topology::PointID i1,const Topology::PointID i2) : core::topology::TopologyChange(core::topology::POINTSINDICESSWAP)
     {
         index[0]=i1;
         index[1]=i2;
@@ -408,7 +408,7 @@ public:
     virtual ~PointsIndicesSwap();
 
 public:
-    unsigned int index[2];
+    Topology::PointID index[2];
 };
 
 
@@ -417,35 +417,35 @@ class SOFA_CORE_API PointsAdded : public core::topology::TopologyChange
 {
 public:
 
-    PointsAdded(const unsigned int nV) : core::topology::TopologyChange(core::topology::POINTSADDED)
+    PointsAdded(const size_t nV) : core::topology::TopologyChange(core::topology::POINTSADDED)
         , nVertices(nV)
     { }
 
-    PointsAdded(const unsigned int nV,
-            const sofa::helper::vector< unsigned int >& indices)
+    PointsAdded(const size_t nV,
+            const sofa::helper::vector< Topology::PointID >& indices)
         : core::topology::TopologyChange(core::topology::POINTSADDED)
         , nVertices(nV), pointIndexArray(indices)
     { }
 
-    PointsAdded(const unsigned int nV,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors,
+    PointsAdded(const size_t nV,
+            const sofa::helper::vector< sofa::helper::vector< Topology::PointID > >& ancestors,
             const sofa::helper::vector< sofa::helper::vector< double       > >& baryCoefs)
         : core::topology::TopologyChange(core::topology::POINTSADDED)
         , nVertices(nV), ancestorsList(ancestors), coefs(baryCoefs)
     { }
 
-    PointsAdded(const unsigned int nV,
-            const sofa::helper::vector< unsigned int >& indices,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors,
+    PointsAdded(const size_t nV,
+            const sofa::helper::vector< Topology::PointID >& indices,
+            const sofa::helper::vector< sofa::helper::vector< Topology::PointID > >& ancestors,
             const sofa::helper::vector< sofa::helper::vector< double       > >& baryCoefs)
         : core::topology::TopologyChange(core::topology::POINTSADDED)
         , nVertices(nV), pointIndexArray(indices), ancestorsList(ancestors), coefs(baryCoefs)
     { }
 
-    PointsAdded(const unsigned int nV,
-            const sofa::helper::vector< unsigned int >& indices,
+    PointsAdded(const size_t nV,
+            const sofa::helper::vector< Topology::PointID >& indices,
             const sofa::helper::vector< PointAncestorElem >& srcElems,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors,
+            const sofa::helper::vector< sofa::helper::vector< Topology::PointID > >& ancestors,
             const sofa::helper::vector< sofa::helper::vector< double       > >& baryCoefs)
         : core::topology::TopologyChange(core::topology::POINTSADDED)
         , nVertices(nV)
@@ -458,18 +458,18 @@ public:
 
     virtual ~PointsAdded();
 
-    unsigned int getNbAddedVertices() const {return nVertices;}
+    size_t getNbAddedVertices() const {return nVertices;}
 
-    unsigned int getNbAddedElements() const { return nVertices; }
-    const sofa::helper::vector< unsigned int >& getIndexArray() const { return pointIndexArray; }
+    size_t getNbAddedElements() const { return nVertices; }
+    const sofa::helper::vector< Topology::PointID >& getIndexArray() const { return pointIndexArray; }
     const sofa::helper::vector< Topology::Point >& getElementArray() const { return pointIndexArray; }
 
 
 public:
-    unsigned int nVertices;
-    sofa::helper::vector< unsigned int > pointIndexArray;
-    sofa::helper::vector< sofa::helper::vector< unsigned int > > ancestorsList;
-    sofa::helper::vector< sofa::helper::vector< double       > > coefs;
+    size_t nVertices;
+    sofa::helper::vector< Topology::PointID > pointIndexArray;
+    sofa::helper::vector< sofa::helper::vector< Topology::PointID > > ancestorsList;
+    sofa::helper::vector< sofa::helper::vector< double > > coefs;
     sofa::helper::vector< PointAncestorElem > ancestorElems;
 };
 
@@ -478,16 +478,16 @@ public:
 class SOFA_CORE_API PointsRemoved : public core::topology::TopologyChange
 {
 public:
-    PointsRemoved(const sofa::helper::vector<unsigned int>& _vArray) : core::topology::TopologyChange(core::topology::POINTSREMOVED),
+    PointsRemoved(const sofa::helper::vector<Topology::PointID>& _vArray) : core::topology::TopologyChange(core::topology::POINTSREMOVED),
         removedVertexArray(_vArray)
     { }
 
     virtual ~PointsRemoved();
 
-    const sofa::helper::vector<unsigned int> &getArray() const { return removedVertexArray;	}
+    const sofa::helper::vector<Topology::PointID> &getArray() const { return removedVertexArray;	}
 
 public:
-    sofa::helper::vector<unsigned int> removedVertexArray;
+    sofa::helper::vector<Topology::PointID> removedVertexArray;
 };
 
 
@@ -499,21 +499,21 @@ public:
     PointsRenumbering() : core::topology::TopologyChange(core::topology::POINTSRENUMBERING)
     { }
 
-    PointsRenumbering(const sofa::helper::vector< unsigned int >& indices,
-            const sofa::helper::vector< unsigned int >& inv_indices)
+    PointsRenumbering(const sofa::helper::vector< Topology::PointID >& indices,
+            const sofa::helper::vector< Topology::PointID >& inv_indices)
         : core::topology::TopologyChange(core::topology::POINTSRENUMBERING),
           indexArray(indices), inv_indexArray(inv_indices)
     { }
 
     virtual ~PointsRenumbering();
 
-    const sofa::helper::vector<unsigned int> &getIndexArray() const { return indexArray; }
+    const sofa::helper::vector<Topology::PointID> &getIndexArray() const { return indexArray; }
 
-    const sofa::helper::vector<unsigned int> &getinv_IndexArray() const { return inv_indexArray; }
+    const sofa::helper::vector<Topology::PointID> &getinv_IndexArray() const { return inv_indexArray; }
 
 public:
-    sofa::helper::vector<unsigned int> indexArray;
-    sofa::helper::vector<unsigned int> inv_indexArray;
+    sofa::helper::vector<Topology::PointID> indexArray;
+    sofa::helper::vector<Topology::PointID> inv_indexArray;
 };
 
 
@@ -522,8 +522,8 @@ class SOFA_CORE_API PointsMoved : public core::topology::TopologyChange
 {
 public:
 
-    PointsMoved(const sofa::helper::vector<unsigned int>& indices,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors,
+    PointsMoved(const sofa::helper::vector<Topology::PointID>& indices,
+            const sofa::helper::vector< sofa::helper::vector< Topology::PointID > >& ancestors,
             const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs)
         : core::topology::TopologyChange(core::topology::POINTSMOVED)
         , indicesList(indices), ancestorsList(ancestors), baryCoefsList(baryCoefs)
@@ -531,11 +531,11 @@ public:
 
     virtual ~PointsMoved();
     
-    const sofa::helper::vector<unsigned int> &getIndexArray() const { return indicesList; }
+    const sofa::helper::vector<Topology::PointID> &getIndexArray() const { return indicesList; }
 
 public:
-    sofa::helper::vector<unsigned int> indicesList;
-    sofa::helper::vector< sofa::helper::vector< unsigned int > > ancestorsList;
+    sofa::helper::vector<Topology::PointID> indicesList;
+    sofa::helper::vector< sofa::helper::vector< Topology::PointID > > ancestorsList;
     sofa::helper::vector< sofa::helper::vector< double > > baryCoefsList;
 };
 
@@ -551,7 +551,7 @@ public:
 class SOFA_CORE_API EdgesIndicesSwap : public core::topology::TopologyChange
 {
 public:
-    EdgesIndicesSwap(const unsigned int i1,const unsigned int i2) : core::topology::TopologyChange(core::topology::EDGESINDICESSWAP)
+    EdgesIndicesSwap(const Topology::EdgeID i1,const Topology::EdgeID i2) : core::topology::TopologyChange(core::topology::EDGESINDICESSWAP)
     {
         index[0]=i1;
         index[1]=i2;
@@ -560,7 +560,7 @@ public:
     virtual ~EdgesIndicesSwap();
 
 public:
-    unsigned int index[2];
+    Topology::EdgeID index[2];
 };
 
 
@@ -568,23 +568,23 @@ public:
 class SOFA_CORE_API EdgesAdded : public core::topology::TopologyChange
 {
 public:
-    EdgesAdded(const unsigned int nE) : core::topology::TopologyChange(core::topology::EDGESADDED),
+    EdgesAdded(const size_t nE) : core::topology::TopologyChange(core::topology::EDGESADDED),
         nEdges(nE)
     { }
 
-    EdgesAdded(const unsigned int nE,
+    EdgesAdded(const size_t nE,
             const sofa::helper::vector< Topology::Edge >& edgesList,
-            const sofa::helper::vector< unsigned int >& edgesIndex)
+            const sofa::helper::vector< Topology::EdgeID >& edgesIndex)
         : core::topology::TopologyChange(core::topology::EDGESADDED),
           nEdges(nE),
           edgeArray(edgesList),
           edgeIndexArray(edgesIndex)
     { }
 
-    EdgesAdded(const unsigned int nE,
+    EdgesAdded(const size_t nE,
             const sofa::helper::vector< Topology::Edge >& edgesList,
-            const sofa::helper::vector< unsigned int >& edgesIndex,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors)
+            const sofa::helper::vector< Topology::EdgeID >& edgesIndex,
+            const sofa::helper::vector< sofa::helper::vector< Topology::EdgeID > >& ancestors)
         : core::topology::TopologyChange(core::topology::EDGESADDED),
           nEdges(nE),
           edgeArray(edgesList),
@@ -592,10 +592,10 @@ public:
           ancestorsList(ancestors)
     { }
 
-    EdgesAdded(const unsigned int nE,
+    EdgesAdded(const size_t nE,
             const sofa::helper::vector< Topology::Edge >& edgesList,
-            const sofa::helper::vector< unsigned int >& edgesIndex,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors,
+            const sofa::helper::vector< Topology::EdgeID >& edgesIndex,
+            const sofa::helper::vector< sofa::helper::vector< Topology::EdgeID > >& ancestors,
             const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs)
         : core::topology::TopologyChange(core::topology::EDGESADDED),
           nEdges(nE),
@@ -605,11 +605,11 @@ public:
           coefs(baryCoefs)
     { }
     
-    EdgesAdded(const unsigned int nE,
+    EdgesAdded(const size_t nE,
             const sofa::helper::vector< Topology::Edge >& edgesList,
-            const sofa::helper::vector< unsigned int >& edgesIndex,
+            const sofa::helper::vector< Topology::EdgeID >& edgesIndex,
             const sofa::helper::vector< EdgeAncestorElem >& srcElems,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors,
+            const sofa::helper::vector< sofa::helper::vector< Topology::EdgeID > >& ancestors,
             const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs)
         : core::topology::TopologyChange(core::topology::EDGESADDED),
           nEdges(nE),
@@ -622,8 +622,8 @@ public:
 
     virtual ~EdgesAdded();
 
-    unsigned int getNbAddedEdges() const { return nEdges;}
-    /*	const sofa::helper::vector<unsigned int> &getArray() const
+    size_t getNbAddedEdges() const { return nEdges;}
+    /*	const sofa::helper::vector<Topology::EdgeID> &getArray() const
         {
                 return edgeIndexArray;
         }*/
@@ -632,15 +632,15 @@ public:
         return edgeArray;
     }
 
-    unsigned int getNbAddedElements() const { return nEdges; }
-    const sofa::helper::vector< unsigned int >& getIndexArray() const { return edgeIndexArray; }
+    size_t getNbAddedElements() const { return nEdges; }
+    const sofa::helper::vector< Topology::EdgeID >& getIndexArray() const { return edgeIndexArray; }
     const sofa::helper::vector< Topology::Edge >& getElementArray() const { return edgeArray; }
 
 public:
-    unsigned int nEdges;
+    size_t nEdges;
     sofa::helper::vector< Topology::Edge > edgeArray;
-    sofa::helper::vector< unsigned int > edgeIndexArray;
-    sofa::helper::vector< sofa::helper::vector< unsigned int > > ancestorsList;
+    sofa::helper::vector< Topology::EdgeID > edgeIndexArray;
+    sofa::helper::vector< sofa::helper::vector< Topology::EdgeID > > ancestorsList;
     sofa::helper::vector< sofa::helper::vector< double > > coefs;
     sofa::helper::vector< EdgeAncestorElem > ancestorElems;
 };
@@ -650,13 +650,13 @@ public:
 class SOFA_CORE_API EdgesRemoved : public core::topology::TopologyChange
 {
 public:
-    EdgesRemoved(const sofa::helper::vector<unsigned int> _eArray) : core::topology::TopologyChange(core::topology::EDGESREMOVED),
+    EdgesRemoved(const sofa::helper::vector<Topology::EdgeID> _eArray) : core::topology::TopologyChange(core::topology::EDGESREMOVED),
         removedEdgesArray(_eArray)
     {}
 
     virtual ~EdgesRemoved();
 
-    virtual const sofa::helper::vector<unsigned int> &getArray() const
+    virtual const sofa::helper::vector<Topology::EdgeID> &getArray() const
     {
         return removedEdgesArray;
     }
@@ -667,7 +667,7 @@ public:
     }
 
 public:
-    sofa::helper::vector<unsigned int> removedEdgesArray;
+    sofa::helper::vector<Topology::EdgeID> removedEdgesArray;
 };
 
 
@@ -677,16 +677,16 @@ public:
 class SOFA_CORE_API EdgesMoved_Removing : public core::topology::TopologyChange
 {
 public:
-    EdgesMoved_Removing (const sofa::helper::vector< unsigned int >& edgeShell) : core::topology::TopologyChange (core::topology::EDGESMOVED_REMOVING),
+    EdgesMoved_Removing (const sofa::helper::vector< Topology::EdgeID >& edgeShell) : core::topology::TopologyChange (core::topology::EDGESMOVED_REMOVING),
         edgesAroundVertexMoved (edgeShell)
     {}
 
     virtual ~EdgesMoved_Removing();
     
-    const sofa::helper::vector< unsigned int >& getIndexArray() const { return edgesAroundVertexMoved; }
+    const sofa::helper::vector< Topology::EdgeID >& getIndexArray() const { return edgesAroundVertexMoved; }
 
 public:
-    sofa::helper::vector< unsigned int > edgesAroundVertexMoved;
+    sofa::helper::vector< Topology::EdgeID > edgesAroundVertexMoved;
 };
 
 
@@ -696,7 +696,7 @@ public:
 class SOFA_CORE_API EdgesMoved_Adding : public core::topology::TopologyChange
 {
 public:
-    EdgesMoved_Adding (const sofa::helper::vector< unsigned int >& edgeShell,
+    EdgesMoved_Adding (const sofa::helper::vector< Topology::EdgeID >& edgeShell,
             const sofa::helper::vector< Topology::Edge >& edgeArray)
         : core::topology::TopologyChange (core::topology::EDGESMOVED_ADDING),
           edgesAroundVertexMoved (edgeShell), edgeArray2Moved (edgeArray)
@@ -704,11 +704,11 @@ public:
 
     virtual ~EdgesMoved_Adding();
     
-    const sofa::helper::vector< unsigned int >& getIndexArray() const { return edgesAroundVertexMoved; }
+    const sofa::helper::vector< Topology::EdgeID >& getIndexArray() const { return edgesAroundVertexMoved; }
     const sofa::helper::vector< Topology::Edge >& getElementArray() const { return edgeArray2Moved; }
 
 public:
-    sofa::helper::vector< unsigned int > edgesAroundVertexMoved;
+    sofa::helper::vector< Topology::EdgeID > edgesAroundVertexMoved;
     sofa::helper::vector< Topology::Edge > edgeArray2Moved;
 };
 
@@ -720,21 +720,21 @@ public:
     EdgesRenumbering() : core::topology::TopologyChange(core::topology::EDGESRENUMBERING)
     { }
 
-    EdgesRenumbering(const sofa::helper::vector< unsigned int >& indices,
-            const sofa::helper::vector< unsigned int >& inv_indices)
+    EdgesRenumbering(const sofa::helper::vector< Topology::EdgeID >& indices,
+            const sofa::helper::vector< Topology::EdgeID >& inv_indices)
         : core::topology::TopologyChange(core::topology::EDGESRENUMBERING),
           indexArray(indices), inv_indexArray(inv_indices)
     { }
 
     virtual ~EdgesRenumbering();
 
-    const sofa::helper::vector<unsigned int> &getIndexArray() const { return indexArray; }
+    const sofa::helper::vector<Topology::EdgeID> &getIndexArray() const { return indexArray; }
 
-    const sofa::helper::vector<unsigned int> &getinv_IndexArray() const { return inv_indexArray; }
+    const sofa::helper::vector<Topology::EdgeID> &getinv_IndexArray() const { return inv_indexArray; }
 
 public:
-    sofa::helper::vector<unsigned int> indexArray;
-    sofa::helper::vector<unsigned int> inv_indexArray;
+    sofa::helper::vector<Topology::EdgeID> indexArray;
+    sofa::helper::vector<Topology::EdgeID> inv_indexArray;
 };
 
 
@@ -748,7 +748,7 @@ public:
 class SOFA_CORE_API TrianglesIndicesSwap : public core::topology::TopologyChange
 {
 public:
-    TrianglesIndicesSwap(const unsigned int i1,const unsigned int i2) : core::topology::TopologyChange(core::topology::TRIANGLESINDICESSWAP)
+    TrianglesIndicesSwap(const Topology::TriangleID i1,const Topology::TriangleID i2) : core::topology::TopologyChange(core::topology::TRIANGLESINDICESSWAP)
     {
         index[0]=i1;
         index[1]=i2;
@@ -757,7 +757,7 @@ public:
     virtual ~TrianglesIndicesSwap();
 
 public:
-    unsigned int index[2];
+    Topology::TriangleID index[2];
 };
 
 
@@ -765,23 +765,23 @@ public:
 class SOFA_CORE_API TrianglesAdded : public core::topology::TopologyChange
 {
 public:
-    TrianglesAdded(const unsigned int nT) : core::topology::TopologyChange(core::topology::TRIANGLESADDED),
+    TrianglesAdded(const size_t nT) : core::topology::TopologyChange(core::topology::TRIANGLESADDED),
         nTriangles(nT)
     { }
 
-    TrianglesAdded(const unsigned int nT,
+    TrianglesAdded(const size_t nT,
             const sofa::helper::vector< Topology::Triangle >& _triangleArray,
-            const sofa::helper::vector< unsigned int >& trianglesIndex)
+            const sofa::helper::vector< Topology::TriangleID >& trianglesIndex)
         : core::topology::TopologyChange(core::topology::TRIANGLESADDED),
           nTriangles(nT),
           triangleArray(_triangleArray),
           triangleIndexArray(trianglesIndex)
     { }
 
-    TrianglesAdded(const unsigned int nT,
+    TrianglesAdded(const size_t nT,
             const sofa::helper::vector< Topology::Triangle >& _triangleArray,
-            const sofa::helper::vector< unsigned int >& trianglesIndex,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors,
+            const sofa::helper::vector< Topology::TriangleID >& trianglesIndex,
+            const sofa::helper::vector< sofa::helper::vector< Topology::TriangleID > >& ancestors,
             const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs)
         : core::topology::TopologyChange(core::topology::TRIANGLESADDED),
           nTriangles(nT),
@@ -791,11 +791,11 @@ public:
           coefs(baryCoefs)
     { }
     
-    TrianglesAdded(const unsigned int nT,
+    TrianglesAdded(const size_t nT,
             const sofa::helper::vector< Topology::Triangle >& _triangleArray,
-            const sofa::helper::vector< unsigned int >& trianglesIndex,
+            const sofa::helper::vector< Topology::TriangleID >& trianglesIndex,
             const sofa::helper::vector< TriangleAncestorElem >& srcElems,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors,
+            const sofa::helper::vector< sofa::helper::vector< Topology::TriangleID > >& ancestors,
             const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs)
         : core::topology::TopologyChange(core::topology::TRIANGLESADDED),
           nTriangles(nT),
@@ -808,30 +808,30 @@ public:
 
     virtual ~TrianglesAdded();
 
-    unsigned int getNbAddedTriangles() const
+    size_t getNbAddedTriangles() const
     {
         return nTriangles;
     }
 
-    const sofa::helper::vector<unsigned int> &getArray() const
+    const sofa::helper::vector<Topology::TriangleID> &getArray() const
     {
         return triangleIndexArray;
     }
 
-    const Topology::Triangle &getTriangle(const unsigned int i)
+    const Topology::Triangle &getTriangle(const Topology::TriangleID i)
     {
         return triangleArray[i];
     }
 
-    unsigned int getNbAddedElements() const { return nTriangles; }
-    const sofa::helper::vector< unsigned int >& getIndexArray() const { return triangleIndexArray; }
+    size_t getNbAddedElements() const { return nTriangles; }
+    const sofa::helper::vector< Topology::TriangleID >& getIndexArray() const { return triangleIndexArray; }
     const sofa::helper::vector< Topology::Triangle >& getElementArray() const { return triangleArray; }
 
 public:
-    unsigned int nTriangles;
+    size_t nTriangles;
     sofa::helper::vector< Topology::Triangle > triangleArray;
-    sofa::helper::vector< unsigned int > triangleIndexArray;
-    sofa::helper::vector< sofa::helper::vector< unsigned int > > ancestorsList;
+    sofa::helper::vector< Topology::TriangleID > triangleIndexArray;
+    sofa::helper::vector< sofa::helper::vector< Topology::TriangleID > > ancestorsList;
     sofa::helper::vector< sofa::helper::vector< double > > coefs;
     sofa::helper::vector< TriangleAncestorElem > ancestorElems;
 };
@@ -841,7 +841,7 @@ public:
 class SOFA_CORE_API TrianglesRemoved : public core::topology::TopologyChange
 {
 public:
-    TrianglesRemoved(const sofa::helper::vector<unsigned int> _tArray) : core::topology::TopologyChange(core::topology::TRIANGLESREMOVED),
+    TrianglesRemoved(const sofa::helper::vector<Topology::TriangleID> _tArray) : core::topology::TopologyChange(core::topology::TRIANGLESREMOVED),
         removedTrianglesArray(_tArray)
     {}
 
@@ -852,18 +852,18 @@ public:
         return removedTrianglesArray.size();
     }
 
-    const sofa::helper::vector<unsigned int> &getArray() const
+    const sofa::helper::vector<Topology::TriangleID> &getArray() const
     {
         return removedTrianglesArray;
     }
 
-    unsigned int &getTriangleIndices(const unsigned int i)
+    Topology::TriangleID &getTriangleIndices(const Topology::TriangleID i)
     {
         return removedTrianglesArray[i];
     }
 
 protected:
-    sofa::helper::vector<unsigned int> removedTrianglesArray;
+    sofa::helper::vector<Topology::TriangleID> removedTrianglesArray;
 };
 
 
@@ -873,17 +873,17 @@ protected:
 class SOFA_CORE_API TrianglesMoved_Removing : public core::topology::TopologyChange
 {
 public:
-    TrianglesMoved_Removing (const sofa::helper::vector< unsigned int >& triangleShell)
+    TrianglesMoved_Removing (const sofa::helper::vector< Topology::TriangleID >& triangleShell)
         : core::topology::TopologyChange (core::topology::TRIANGLESMOVED_REMOVING),
           trianglesAroundVertexMoved (triangleShell)
     {}
 
     virtual ~TrianglesMoved_Removing();
     
-    const sofa::helper::vector< unsigned int >& getIndexArray() const { return trianglesAroundVertexMoved; }
+    const sofa::helper::vector< Topology::TriangleID >& getIndexArray() const { return trianglesAroundVertexMoved; }
 
 public:
-    sofa::helper::vector< unsigned int > trianglesAroundVertexMoved;
+    sofa::helper::vector< Topology::TriangleID > trianglesAroundVertexMoved;
 };
 
 
@@ -893,7 +893,7 @@ public:
 class SOFA_CORE_API TrianglesMoved_Adding : public core::topology::TopologyChange
 {
 public:
-    TrianglesMoved_Adding (const sofa::helper::vector< unsigned int >& triangleShell,
+    TrianglesMoved_Adding (const sofa::helper::vector< Topology::TriangleID >& triangleShell,
             const sofa::helper::vector< Topology::Triangle >& triangleArray)
         : core::topology::TopologyChange (core::topology::TRIANGLESMOVED_ADDING),
           trianglesAroundVertexMoved (triangleShell), triangleArray2Moved (triangleArray)
@@ -901,11 +901,11 @@ public:
 
     virtual ~TrianglesMoved_Adding();
     
-    const sofa::helper::vector< unsigned int >& getIndexArray() const { return trianglesAroundVertexMoved; }
+    const sofa::helper::vector< Topology::TriangleID >& getIndexArray() const { return trianglesAroundVertexMoved; }
     const sofa::helper::vector< Topology::Triangle >& getElementArray() const { return triangleArray2Moved; }
 
 public:
-    sofa::helper::vector< unsigned int > trianglesAroundVertexMoved;
+    sofa::helper::vector< Topology::TriangleID > trianglesAroundVertexMoved;
     const sofa::helper::vector< Topology::Triangle > triangleArray2Moved;
 };
 
@@ -918,21 +918,21 @@ public:
     TrianglesRenumbering() : core::topology::TopologyChange(core::topology::TRIANGLESRENUMBERING)
     { }
 
-    TrianglesRenumbering(const sofa::helper::vector< unsigned int >& indices,
-            const sofa::helper::vector< unsigned int >& inv_indices)
+    TrianglesRenumbering(const sofa::helper::vector< Topology::TriangleID >& indices,
+            const sofa::helper::vector< Topology::TriangleID >& inv_indices)
         : core::topology::TopologyChange(core::topology::TRIANGLESRENUMBERING),
           indexArray(indices), inv_indexArray(inv_indices)
     { }
 
     virtual ~TrianglesRenumbering();
 
-    const sofa::helper::vector<unsigned int> &getIndexArray() const { return indexArray; }
+    const sofa::helper::vector<Topology::TriangleID> &getIndexArray() const { return indexArray; }
 
-    const sofa::helper::vector<unsigned int> &getinv_IndexArray() const { return inv_indexArray; }
+    const sofa::helper::vector<Topology::TriangleID> &getinv_IndexArray() const { return inv_indexArray; }
 
 public:
-    sofa::helper::vector<unsigned int> indexArray;
-    sofa::helper::vector<unsigned int> inv_indexArray;
+    sofa::helper::vector<Topology::TriangleID> indexArray;
+    sofa::helper::vector<Topology::TriangleID> inv_indexArray;
 };
 
 
@@ -945,7 +945,7 @@ public:
 class SOFA_CORE_API QuadsIndicesSwap : public core::topology::TopologyChange
 {
 public:
-    QuadsIndicesSwap(const unsigned int i1,const unsigned int i2) : core::topology::TopologyChange(core::topology::QUADSINDICESSWAP)
+    QuadsIndicesSwap(const Topology::QuadID i1,const Topology::QuadID i2) : core::topology::TopologyChange(core::topology::QUADSINDICESSWAP)
     {
         index[0]=i1;
         index[1]=i2;
@@ -954,7 +954,7 @@ public:
     virtual ~QuadsIndicesSwap();
 
 public:
-    unsigned int index[2];
+    Topology::QuadID index[2];
 };
 
 
@@ -962,23 +962,23 @@ public:
 class SOFA_CORE_API QuadsAdded : public core::topology::TopologyChange
 {
 public:
-    QuadsAdded(const unsigned int nT) : core::topology::TopologyChange(core::topology::QUADSADDED),
+    QuadsAdded(const size_t nT) : core::topology::TopologyChange(core::topology::QUADSADDED),
         nQuads(nT)
     { }
 
-    QuadsAdded(const unsigned int nT,
+    QuadsAdded(const size_t nT,
             const sofa::helper::vector< Topology::Quad >& _quadArray,
-            const sofa::helper::vector< unsigned int >& quadsIndex)
+            const sofa::helper::vector< Topology::QuadID >& quadsIndex)
         : core::topology::TopologyChange(core::topology::QUADSADDED),
           nQuads(nT),
           quadArray(_quadArray),
           quadIndexArray(quadsIndex)
     { }
 
-    QuadsAdded(const unsigned int nT,
+    QuadsAdded(const size_t nT,
             const sofa::helper::vector< Topology::Quad >& _quadArray,
-            const sofa::helper::vector< unsigned int >& quadsIndex,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors,
+            const sofa::helper::vector< Topology::QuadID >& quadsIndex,
+            const sofa::helper::vector< sofa::helper::vector< Topology::QuadID > >& ancestors,
             const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs)
         : core::topology::TopologyChange(core::topology::QUADSADDED),
           nQuads(nT),
@@ -988,11 +988,11 @@ public:
           coefs(baryCoefs)
     { }
     
-    QuadsAdded(const unsigned int nT,
+    QuadsAdded(const size_t nT,
             const sofa::helper::vector< Topology::Quad >& _quadArray,
-            const sofa::helper::vector< unsigned int >& quadsIndex,
+            const sofa::helper::vector< Topology::QuadID >& quadsIndex,
             const sofa::helper::vector< QuadAncestorElem >& srcElems,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors,
+            const sofa::helper::vector< sofa::helper::vector< Topology::QuadID > >& ancestors,
             const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs)
         : core::topology::TopologyChange(core::topology::QUADSADDED),
           nQuads(nT),
@@ -1005,30 +1005,30 @@ public:
 
     virtual ~QuadsAdded();
 
-    unsigned int getNbAddedQuads() const
+    size_t getNbAddedQuads() const
     {
         return nQuads;
     }
 
-    const sofa::helper::vector<unsigned int> &getArray() const
+    const sofa::helper::vector<Topology::QuadID> &getArray() const
     {
         return quadIndexArray;
     }
 
-    const Topology::Quad &getQuad(const unsigned int i) const
+    const Topology::Quad &getQuad(const Topology::QuadID i) const
     {
         return quadArray[i];
     }
 
-    unsigned int getNbAddedElements() const { return nQuads; }
-    const sofa::helper::vector< unsigned int >& getIndexArray() const { return quadIndexArray; }
+    size_t getNbAddedElements() const { return nQuads; }
+    const sofa::helper::vector< Topology::QuadID >& getIndexArray() const { return quadIndexArray; }
     const sofa::helper::vector< Topology::Quad >& getElementArray() const { return quadArray; }
 
 public:
-    unsigned int nQuads;
+    size_t nQuads;
     sofa::helper::vector< Topology::Quad > quadArray;
-    sofa::helper::vector< unsigned int > quadIndexArray;
-    sofa::helper::vector< sofa::helper::vector< unsigned int > > ancestorsList;
+    sofa::helper::vector< Topology::QuadID > quadIndexArray;
+    sofa::helper::vector< sofa::helper::vector< Topology::QuadID > > ancestorsList;
     sofa::helper::vector< sofa::helper::vector< double > > coefs;
     sofa::helper::vector< QuadAncestorElem > ancestorElems;
 };
@@ -1038,7 +1038,7 @@ public:
 class SOFA_CORE_API QuadsRemoved : public core::topology::TopologyChange
 {
 public:
-    QuadsRemoved(const sofa::helper::vector<unsigned int> _qArray) : core::topology::TopologyChange(core::topology::QUADSREMOVED),
+    QuadsRemoved(const sofa::helper::vector<Topology::QuadID> _qArray) : core::topology::TopologyChange(core::topology::QUADSREMOVED),
         removedQuadsArray(_qArray)
     { }
 
@@ -1049,18 +1049,18 @@ public:
         return removedQuadsArray.size();
     }
 
-    const sofa::helper::vector<unsigned int> &getArray() const
+    const sofa::helper::vector<Topology::QuadID> &getArray() const
     {
         return removedQuadsArray;
     }
 
-    unsigned int &getQuadIndices(const unsigned int i)
+    Topology::QuadID &getQuadIndices(const Topology::QuadID i)
     {
         return removedQuadsArray[i];
     }
 
 protected:
-    sofa::helper::vector<unsigned int> removedQuadsArray;
+    sofa::helper::vector<Topology::QuadID> removedQuadsArray;
 };
 
 
@@ -1070,16 +1070,16 @@ protected:
 class SOFA_CORE_API QuadsMoved_Removing : public core::topology::TopologyChange
 {
 public:
-    QuadsMoved_Removing (const sofa::helper::vector< unsigned int >& quadShell) : core::topology::TopologyChange (core::topology::QUADSMOVED_REMOVING),
+    QuadsMoved_Removing (const sofa::helper::vector< Topology::QuadID >& quadShell) : core::topology::TopologyChange (core::topology::QUADSMOVED_REMOVING),
         quadsAroundVertexMoved (quadShell)
     {}
 
     virtual ~QuadsMoved_Removing();
     
-    const sofa::helper::vector< unsigned int >& getIndexArray() const { return quadsAroundVertexMoved; }
+    const sofa::helper::vector< Topology::QuadID >& getIndexArray() const { return quadsAroundVertexMoved; }
 
 public:
-    sofa::helper::vector< unsigned int > quadsAroundVertexMoved;
+    sofa::helper::vector< Topology::QuadID > quadsAroundVertexMoved;
 };
 
 
@@ -1089,7 +1089,7 @@ public:
 class SOFA_CORE_API QuadsMoved_Adding : public core::topology::TopologyChange
 {
 public:
-    QuadsMoved_Adding (const sofa::helper::vector< unsigned int >& quadShell,
+    QuadsMoved_Adding (const sofa::helper::vector< Topology::QuadID >& quadShell,
             const sofa::helper::vector< Topology::Quad >& quadArray)
         : core::topology::TopologyChange (core::topology::QUADSMOVED_ADDING),
           quadsAroundVertexMoved (quadShell), quadArray2Moved (quadArray)
@@ -1097,11 +1097,11 @@ public:
 
     virtual ~QuadsMoved_Adding();
     
-    const sofa::helper::vector< unsigned int >& getIndexArray() const { return quadsAroundVertexMoved; }
+    const sofa::helper::vector< Topology::QuadID >& getIndexArray() const { return quadsAroundVertexMoved; }
     const sofa::helper::vector< Topology::Quad >& getElementArray() const { return quadArray2Moved; }
 
 public:
-    sofa::helper::vector< unsigned int > quadsAroundVertexMoved;
+    sofa::helper::vector< Topology::QuadID > quadsAroundVertexMoved;
     const sofa::helper::vector< Topology::Quad > quadArray2Moved;
 };
 
@@ -1116,19 +1116,19 @@ public:
 
     virtual ~QuadsRenumbering();
 
-    QuadsRenumbering(const sofa::helper::vector< unsigned int >& indices,
-            const sofa::helper::vector< unsigned int >& inv_indices)
+    QuadsRenumbering(const sofa::helper::vector< Topology::QuadID >& indices,
+            const sofa::helper::vector< Topology::QuadID >& inv_indices)
         : core::topology::TopologyChange(core::topology::QUADSRENUMBERING),
           indexArray(indices), inv_indexArray(inv_indices)
     { }
 
-    const sofa::helper::vector<unsigned int> &getIndexArray() const { return indexArray; }
+    const sofa::helper::vector<Topology::QuadID> &getIndexArray() const { return indexArray; }
 
-    const sofa::helper::vector<unsigned int> &getinv_IndexArray() const { return inv_indexArray; }
+    const sofa::helper::vector<Topology::QuadID> &getinv_IndexArray() const { return inv_indexArray; }
 
 public:
-    sofa::helper::vector<unsigned int> indexArray;
-    sofa::helper::vector<unsigned int> inv_indexArray;
+    sofa::helper::vector<Topology::QuadID> indexArray;
+    sofa::helper::vector<Topology::QuadID> inv_indexArray;
 };
 
 
@@ -1141,7 +1141,7 @@ public:
 class SOFA_CORE_API TetrahedraIndicesSwap : public core::topology::TopologyChange
 {
 public:
-    TetrahedraIndicesSwap(const unsigned int i1,const unsigned int i2) : core::topology::TopologyChange(core::topology::TETRAHEDRAINDICESSWAP)
+    TetrahedraIndicesSwap(const Topology::TetrahedronID i1,const Topology::TetrahedronID i2) : core::topology::TopologyChange(core::topology::TETRAHEDRAINDICESSWAP)
     {
         index[0]=i1;
         index[1]=i2;
@@ -1150,7 +1150,7 @@ public:
     virtual ~TetrahedraIndicesSwap();
 
 public:
-    unsigned int index[2];
+    Topology::TetrahedronID index[2];
 };
 
 
@@ -1158,23 +1158,23 @@ public:
 class SOFA_CORE_API TetrahedraAdded : public core::topology::TopologyChange
 {
 public:
-    TetrahedraAdded(const unsigned int nT) : core::topology::TopologyChange(core::topology::TETRAHEDRAADDED),
+    TetrahedraAdded(const size_t nT) : core::topology::TopologyChange(core::topology::TETRAHEDRAADDED),
         nTetrahedra(nT)
     { }
 
-    TetrahedraAdded(const unsigned int nT,
+    TetrahedraAdded(const size_t nT,
             const sofa::helper::vector< Topology::Tetrahedron >& _tetrahedronArray,
-            const sofa::helper::vector< unsigned int >& tetrahedraIndex)
+            const sofa::helper::vector< Topology::TetrahedronID >& tetrahedraIndex)
         : core::topology::TopologyChange(core::topology::TETRAHEDRAADDED),
           nTetrahedra(nT),
           tetrahedronArray(_tetrahedronArray),
           tetrahedronIndexArray(tetrahedraIndex)
     { }
 
-    TetrahedraAdded(const unsigned int nT,
+    TetrahedraAdded(const size_t nT,
             const sofa::helper::vector< Topology::Tetrahedron >& _tetrahedronArray,
-            const sofa::helper::vector< unsigned int >& tetrahedraIndex,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors,
+            const sofa::helper::vector< Topology::TetrahedronID >& tetrahedraIndex,
+            const sofa::helper::vector< sofa::helper::vector< Topology::TetrahedronID > >& ancestors,
             const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs)
         : core::topology::TopologyChange(core::topology::TETRAHEDRAADDED),
           nTetrahedra(nT),
@@ -1184,11 +1184,11 @@ public:
           coefs(baryCoefs)
     { }
     
-    TetrahedraAdded(const unsigned int nT,
+    TetrahedraAdded(const size_t nT,
             const sofa::helper::vector< Topology::Tetrahedron >& _tetrahedronArray,
-            const sofa::helper::vector< unsigned int >& tetrahedraIndex,
+            const sofa::helper::vector< Topology::TetrahedronID >& tetrahedraIndex,
             const sofa::helper::vector< TetrahedronAncestorElem >& srcElems,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors,
+            const sofa::helper::vector< sofa::helper::vector< Topology::TetrahedronID > >& ancestors,
             const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs)
         : core::topology::TopologyChange(core::topology::TETRAHEDRAADDED),
           nTetrahedra(nT),
@@ -1201,25 +1201,25 @@ public:
 
     virtual ~TetrahedraAdded();
 
-    const sofa::helper::vector<unsigned int> &getArray() const
+    const sofa::helper::vector<Topology::TetrahedronID> &getArray() const
     {
         return tetrahedronIndexArray;
     }
 
-    unsigned int getNbAddedTetrahedra() const
+    size_t getNbAddedTetrahedra() const
     {
         return nTetrahedra;
     }
 
-    unsigned int getNbAddedElements() const { return nTetrahedra; }
-    const sofa::helper::vector< unsigned int >& getIndexArray() const { return tetrahedronIndexArray; }
+    size_t getNbAddedElements() const { return nTetrahedra; }
+    const sofa::helper::vector< Topology::TetrahedronID >& getIndexArray() const { return tetrahedronIndexArray; }
     const sofa::helper::vector< Topology::Tetrahedron >& getElementArray() const { return tetrahedronArray; }
 
 public:
-    unsigned int nTetrahedra;
+    size_t nTetrahedra;
     sofa::helper::vector< Topology::Tetrahedron > tetrahedronArray;
-    sofa::helper::vector< unsigned int > tetrahedronIndexArray;
-    sofa::helper::vector< sofa::helper::vector< unsigned int > > ancestorsList;
+    sofa::helper::vector< Topology::TetrahedronID > tetrahedronIndexArray;
+    sofa::helper::vector< sofa::helper::vector< Topology::TetrahedronID > > ancestorsList;
     sofa::helper::vector< sofa::helper::vector< double > > coefs;
     sofa::helper::vector< TetrahedronAncestorElem > ancestorElems;
 };
@@ -1228,14 +1228,14 @@ public:
 class SOFA_CORE_API TetrahedraRemoved : public core::topology::TopologyChange
 {
 public:
-    TetrahedraRemoved(const sofa::helper::vector<unsigned int> _tArray)
+    TetrahedraRemoved(const sofa::helper::vector<Topology::TetrahedronID> _tArray)
         : core::topology::TopologyChange(core::topology::TETRAHEDRAREMOVED),
           removedTetrahedraArray(_tArray)
     { }
 
     virtual ~TetrahedraRemoved();
 
-    const sofa::helper::vector<unsigned int> &getArray() const
+    const sofa::helper::vector<Topology::TetrahedronID> &getArray() const
     {
         return removedTetrahedraArray;
     }
@@ -1246,7 +1246,7 @@ public:
     }
 
 public:
-    sofa::helper::vector<unsigned int> removedTetrahedraArray;
+    sofa::helper::vector<Topology::TetrahedronID> removedTetrahedraArray;
 };
 
 
@@ -1256,17 +1256,17 @@ public:
 class SOFA_CORE_API TetrahedraMoved_Removing : public core::topology::TopologyChange
 {
 public:
-    TetrahedraMoved_Removing (const sofa::helper::vector< unsigned int >& tetrahedronShell)
+    TetrahedraMoved_Removing (const sofa::helper::vector< Topology::TetrahedronID >& tetrahedronShell)
         : core::topology::TopologyChange (core::topology::TETRAHEDRAMOVED_REMOVING),
           tetrahedraAroundVertexMoved (tetrahedronShell)
     {}
 
     virtual ~TetrahedraMoved_Removing();
     
-    const sofa::helper::vector< unsigned int >& getIndexArray() const { return tetrahedraAroundVertexMoved; }
+    const sofa::helper::vector< Topology::TetrahedronID >& getIndexArray() const { return tetrahedraAroundVertexMoved; }
 
 public:
-    sofa::helper::vector< unsigned int > tetrahedraAroundVertexMoved;
+    sofa::helper::vector< Topology::TetrahedronID > tetrahedraAroundVertexMoved;
 };
 
 
@@ -1276,7 +1276,7 @@ public:
 class SOFA_CORE_API TetrahedraMoved_Adding : public core::topology::TopologyChange
 {
 public:
-    TetrahedraMoved_Adding (const sofa::helper::vector< unsigned int >& tetrahedronShell,
+    TetrahedraMoved_Adding (const sofa::helper::vector< Topology::TetrahedronID >& tetrahedronShell,
             const sofa::helper::vector< Topology::Tetrahedron >& tetrahedronArray)
         : core::topology::TopologyChange (core::topology::TETRAHEDRAMOVED_ADDING),
           tetrahedraAroundVertexMoved (tetrahedronShell), tetrahedronArray2Moved (tetrahedronArray)
@@ -1284,11 +1284,11 @@ public:
 
     virtual ~TetrahedraMoved_Adding();
     
-    const sofa::helper::vector< unsigned int >& getIndexArray() const { return tetrahedraAroundVertexMoved; }
+    const sofa::helper::vector< Topology::TetrahedronID >& getIndexArray() const { return tetrahedraAroundVertexMoved; }
     const sofa::helper::vector< Topology::Tetrahedron >& getElementArray() const { return tetrahedronArray2Moved; }
 
 public:
-    sofa::helper::vector< unsigned int > tetrahedraAroundVertexMoved;
+    sofa::helper::vector< Topology::TetrahedronID > tetrahedraAroundVertexMoved;
     const sofa::helper::vector< Topology::Tetrahedron > tetrahedronArray2Moved;
 };
 
@@ -1302,21 +1302,21 @@ public:
         : core::topology::TopologyChange(core::topology::TETRAHEDRARENUMBERING)
     { }
 
-    TetrahedraRenumbering(const sofa::helper::vector< unsigned int >& indices,
-            const sofa::helper::vector< unsigned int >& inv_indices)
+    TetrahedraRenumbering(const sofa::helper::vector< Topology::TetrahedronID >& indices,
+            const sofa::helper::vector< Topology::TetrahedronID >& inv_indices)
         : core::topology::TopologyChange(core::topology::TETRAHEDRARENUMBERING),
           indexArray(indices), inv_indexArray(inv_indices)
     { }
 
     virtual ~TetrahedraRenumbering();
 
-    const sofa::helper::vector<unsigned int> &getIndexArray() const { return indexArray; }
+    const sofa::helper::vector<Topology::TetrahedronID> &getIndexArray() const { return indexArray; }
 
-    const sofa::helper::vector<unsigned int> &getinv_IndexArray() const { return inv_indexArray; }
+    const sofa::helper::vector<Topology::TetrahedronID> &getinv_IndexArray() const { return inv_indexArray; }
 
 public:
-    sofa::helper::vector<unsigned int> indexArray;
-    sofa::helper::vector<unsigned int> inv_indexArray;
+    sofa::helper::vector<Topology::TetrahedronID> indexArray;
+    sofa::helper::vector<Topology::TetrahedronID> inv_indexArray;
 };
 
 
@@ -1329,7 +1329,7 @@ public:
 class SOFA_CORE_API HexahedraIndicesSwap : public core::topology::TopologyChange
 {
 public:
-    HexahedraIndicesSwap(const unsigned int i1,const unsigned int i2) : core::topology::TopologyChange(core::topology::HEXAHEDRAINDICESSWAP)
+    HexahedraIndicesSwap(const Topology::HexahedronID i1,const Topology::HexahedronID i2) : core::topology::TopologyChange(core::topology::HEXAHEDRAINDICESSWAP)
     {
         index[0]=i1;
         index[1]=i2;
@@ -1338,7 +1338,7 @@ public:
     virtual ~HexahedraIndicesSwap();
 
 public:
-    unsigned int index[2];
+    Topology::HexahedronID index[2];
 };
 
 
@@ -1346,23 +1346,23 @@ public:
 class SOFA_CORE_API HexahedraAdded : public core::topology::TopologyChange
 {
 public:
-    HexahedraAdded(const unsigned int nT) : core::topology::TopologyChange(core::topology::HEXAHEDRAADDED),
+    HexahedraAdded(const size_t nT) : core::topology::TopologyChange(core::topology::HEXAHEDRAADDED),
         nHexahedra(nT)
     { }
 
-    HexahedraAdded(const unsigned int nT,
+    HexahedraAdded(const size_t nT,
             const sofa::helper::vector< Topology::Hexahedron >& _hexahedronArray,
-            const sofa::helper::vector< unsigned int >& hexahedraIndex)
+            const sofa::helper::vector< Topology::HexahedronID >& hexahedraIndex)
         : core::topology::TopologyChange(core::topology::HEXAHEDRAADDED),
           nHexahedra(nT),
           hexahedronArray(_hexahedronArray),
           hexahedronIndexArray(hexahedraIndex)
     { }
 
-    HexahedraAdded(const unsigned int nT,
+    HexahedraAdded(const size_t nT,
             const sofa::helper::vector< Topology::Hexahedron >& _hexahedronArray,
-            const sofa::helper::vector< unsigned int >& hexahedraIndex,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors,
+            const sofa::helper::vector< Topology::HexahedronID >& hexahedraIndex,
+            const sofa::helper::vector< sofa::helper::vector< Topology::HexahedronID > >& ancestors,
             const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs)
         : core::topology::TopologyChange(core::topology::HEXAHEDRAADDED),
           nHexahedra(nT),
@@ -1372,11 +1372,11 @@ public:
           coefs(baryCoefs)
     { }
     
-    HexahedraAdded(const unsigned int nT,
+    HexahedraAdded(const size_t nT,
             const sofa::helper::vector< Topology::Hexahedron >& _hexahedronArray,
-            const sofa::helper::vector< unsigned int >& hexahedraIndex,
+            const sofa::helper::vector< Topology::HexahedronID >& hexahedraIndex,
             const sofa::helper::vector< HexahedronAncestorElem >& srcElems,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors,
+            const sofa::helper::vector< sofa::helper::vector< Topology::HexahedronID > >& ancestors,
             const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs)
         : core::topology::TopologyChange(core::topology::HEXAHEDRAADDED),
           nHexahedra(nT),
@@ -1389,20 +1389,20 @@ public:
 
     virtual ~HexahedraAdded();
 
-    unsigned int getNbAddedHexahedra() const
+    size_t getNbAddedHexahedra() const
     {
         return nHexahedra;
     }
 
-    unsigned int getNbAddedElements() const { return nHexahedra; }
-    const sofa::helper::vector< unsigned int >& getIndexArray() const { return hexahedronIndexArray; }
+    size_t getNbAddedElements() const { return nHexahedra; }
+    const sofa::helper::vector< Topology::HexahedronID >& getIndexArray() const { return hexahedronIndexArray; }
     const sofa::helper::vector< Topology::Hexahedron >& getElementArray() const { return hexahedronArray; }
 
 public:
-    unsigned int nHexahedra;
+    size_t nHexahedra;
     sofa::helper::vector< Topology::Hexahedron > hexahedronArray;
-    sofa::helper::vector< unsigned int > hexahedronIndexArray;
-    sofa::helper::vector< sofa::helper::vector< unsigned int > > ancestorsList;
+    sofa::helper::vector< Topology::HexahedronID > hexahedronIndexArray;
+    sofa::helper::vector< sofa::helper::vector< Topology::HexahedronID > > ancestorsList;
     sofa::helper::vector< sofa::helper::vector< double > > coefs;
     sofa::helper::vector< HexahedronAncestorElem > ancestorElems;
 };
@@ -1411,14 +1411,14 @@ public:
 class SOFA_CORE_API HexahedraRemoved : public core::topology::TopologyChange
 {
 public:
-    HexahedraRemoved(const sofa::helper::vector<unsigned int> _tArray)
+    HexahedraRemoved(const sofa::helper::vector<Topology::HexahedronID> _tArray)
         : core::topology::TopologyChange(core::topology::HEXAHEDRAREMOVED),
           removedHexahedraArray(_tArray)
     { }
 
     virtual ~HexahedraRemoved();
 
-    const sofa::helper::vector<unsigned int> &getArray() const
+    const sofa::helper::vector<Topology::HexahedronID> &getArray() const
     {
         return removedHexahedraArray;
     }
@@ -1429,7 +1429,7 @@ public:
     }
 
 public:
-    sofa::helper::vector<unsigned int> removedHexahedraArray;
+    sofa::helper::vector<Topology::HexahedronID> removedHexahedraArray;
 };
 
 
@@ -1439,17 +1439,17 @@ public:
 class SOFA_CORE_API HexahedraMoved_Removing : public core::topology::TopologyChange
 {
 public:
-    HexahedraMoved_Removing (const sofa::helper::vector< unsigned int >& hexahedronShell)
+    HexahedraMoved_Removing (const sofa::helper::vector< Topology::HexahedronID >& hexahedronShell)
         : core::topology::TopologyChange (core::topology::HEXAHEDRAMOVED_REMOVING),
           hexahedraAroundVertexMoved (hexahedronShell)
     {}
 
     virtual ~HexahedraMoved_Removing();
 
-    const sofa::helper::vector< unsigned int >& getIndexArray() const { return hexahedraAroundVertexMoved; }
+    const sofa::helper::vector< Topology::HexahedronID >& getIndexArray() const { return hexahedraAroundVertexMoved; }
 
 public:
-    sofa::helper::vector< unsigned int > hexahedraAroundVertexMoved;
+    sofa::helper::vector< Topology::HexahedronID > hexahedraAroundVertexMoved;
 };
 
 
@@ -1459,7 +1459,7 @@ public:
 class SOFA_CORE_API HexahedraMoved_Adding : public core::topology::TopologyChange
 {
 public:
-    HexahedraMoved_Adding (const sofa::helper::vector< unsigned int >& hexahedronShell,
+    HexahedraMoved_Adding (const sofa::helper::vector< Topology::HexahedronID >& hexahedronShell,
             const sofa::helper::vector< Topology::Hexahedron >& hexahedronArray)
         : core::topology::TopologyChange (core::topology::HEXAHEDRAMOVED_ADDING),
           hexahedraAroundVertexMoved (hexahedronShell), hexahedronArray2Moved (hexahedronArray)
@@ -1467,11 +1467,11 @@ public:
 
     virtual ~HexahedraMoved_Adding();
     
-    const sofa::helper::vector< unsigned int >& getIndexArray() const { return hexahedraAroundVertexMoved; }
+    const sofa::helper::vector< Topology::HexahedronID >& getIndexArray() const { return hexahedraAroundVertexMoved; }
     const sofa::helper::vector< Topology::Hexahedron >& getElementArray() const { return hexahedronArray2Moved; }
 
 public:
-    sofa::helper::vector< unsigned int > hexahedraAroundVertexMoved;
+    sofa::helper::vector< Topology::HexahedronID > hexahedraAroundVertexMoved;
     const sofa::helper::vector< Topology::Hexahedron > hexahedronArray2Moved;
 };
 
@@ -1484,21 +1484,21 @@ public:
     HexahedraRenumbering() : core::topology::TopologyChange(core::topology::HEXAHEDRARENUMBERING)
     { }
 
-    HexahedraRenumbering(const sofa::helper::vector< unsigned int >& indices,
-            const sofa::helper::vector< unsigned int >& inv_indices)
+    HexahedraRenumbering(const sofa::helper::vector< Topology::HexahedronID >& indices,
+            const sofa::helper::vector< Topology::HexahedronID >& inv_indices)
         : core::topology::TopologyChange(core::topology::HEXAHEDRARENUMBERING),
           indexArray(indices), inv_indexArray(inv_indices)
     { }
 
     virtual ~HexahedraRenumbering();
 
-    const sofa::helper::vector<unsigned int> &getIndexArray() const { return indexArray; }
+    const sofa::helper::vector<Topology::HexahedronID> &getIndexArray() const { return indexArray; }
 
-    const sofa::helper::vector<unsigned int> &getinv_IndexArray() const { return inv_indexArray; }
+    const sofa::helper::vector<Topology::HexahedronID> &getinv_IndexArray() const { return inv_indexArray; }
 
 public:
-    sofa::helper::vector<unsigned int> indexArray;
-    sofa::helper::vector<unsigned int> inv_indexArray;
+    sofa::helper::vector<Topology::HexahedronID> indexArray;
+    sofa::helper::vector<Topology::HexahedronID> inv_indexArray;
 };
 
 

--- a/SofaKernel/framework/sofa/core/topology/TopologyElementHandler.h
+++ b/SofaKernel/framework/sofa/core/topology/TopologyElementHandler.h
@@ -84,45 +84,45 @@ public:
 
 protected:
     /// Swaps values at indices i1 and i2.
-    virtual void swap( unsigned int /*i1*/, unsigned int /*i2*/ ) {}
+    virtual void swap( Topology::ElemID /*i1*/, Topology::ElemID /*i2*/ ) {}
 
     /// Reorder the values.
-    virtual void renumber( const sofa::helper::vector<unsigned int> &/*index*/ ) {}
+    virtual void renumber( const sofa::helper::vector<Topology::ElemID> &/*index*/ ) {}
 
     /// Add some values. Values are added at the end of the vector.
     /// This is the (old) version, to be deprecated in favor of the next method
-    virtual void add( unsigned int /*nbElements*/,
+    virtual void add( Topology::ElemID /*nbElements*/,
             const sofa::helper::vector< TopologyElementType >& /*elems*/,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > > &/*ancestors*/,
+            const sofa::helper::vector< sofa::helper::vector< Topology::ElemID > > &/*ancestors*/,
             const sofa::helper::vector< sofa::helper::vector< double > >& /*coefs*/) {}
     
     /// Add some values. Values are added at the end of the vector.
     /// This (new) version gives more information for element indices and ancestry
-    virtual void add( const sofa::helper::vector<unsigned int> & index,
+    virtual void add( const sofa::helper::vector<Topology::ElemID> & index,
             const sofa::helper::vector< TopologyElementType >& elems,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > > &ancestors,
+            const sofa::helper::vector< sofa::helper::vector< Topology::ElemID > > &ancestors,
             const sofa::helper::vector< sofa::helper::vector< double > >& coefs,
             const sofa::helper::vector< AncestorElem >& /*ancestorElems*/
             )
     {
         // call old method by default
-        add((unsigned int)index.size(), elems, ancestors, coefs);
+        add((Topology::ElemID)index.size(), elems, ancestors, coefs);
     }
 
     /// Remove the values corresponding to the ELement removed.
-    virtual void remove( const sofa::helper::vector<unsigned int> & /*index */) {}
+    virtual void remove( const sofa::helper::vector<Topology::ElemID> & /*index */) {}
 
     /// Move a list of points
-    virtual void move( const sofa::helper::vector<unsigned int> & /*indexList*/,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > >& /*ancestors*/,
+    virtual void move( const sofa::helper::vector<Topology::ElemID> & /*indexList*/,
+            const sofa::helper::vector< sofa::helper::vector< Topology::ElemID > >& /*ancestors*/,
             const sofa::helper::vector< sofa::helper::vector< double > >& /*coefs*/) {}
 
     /// Add Element after a displacement of vertices, ie. add element based on previous position topology revision.
-    virtual void addOnMovedPosition(const sofa::helper::vector<unsigned int> &/*indexList*/,
+    virtual void addOnMovedPosition(const sofa::helper::vector<Topology::ElemID> &/*indexList*/,
             const sofa::helper::vector< TopologyElementType > & /*elems*/) {}
 
     /// Remove Element after a displacement of vertices, ie. add element based on previous position topology revision.
-    virtual void removeOnMovedPosition(const sofa::helper::vector<unsigned int> &/*indices*/) {}
+    virtual void removeOnMovedPosition(const sofa::helper::vector<Topology::ElemID> &/*indices*/) {}
 
 };
 

--- a/SofaKernel/framework/sofa/core/visual/DisplayFlags.cpp
+++ b/SofaKernel/framework/sofa/core/visual/DisplayFlags.cpp
@@ -134,13 +134,13 @@ std::istream& FlagTreeItem::read(std::istream &in)
 /*static*/
 void FlagTreeItem::create_parse_map(FlagTreeItem *root, std::map<std::string, bool, ci_comparison> &map)
 {
-    int sizeShow = root->m_showName.size();
-    int sizeHide = root->m_hideName.size();
-    for(int i=0; i<sizeShow; i++)
+    size_t sizeShow = root->m_showName.size();
+    size_t sizeHide = root->m_hideName.size();
+    for(size_t i=0; i<sizeShow; i++)
     {
         map[root->m_showName[i]] = false;
     }
-    for(int i=0; i<sizeHide; ++i)
+    for(size_t i=0; i<sizeHide; ++i)
     {
         map[root->m_hideName[i]] = false;
     }
@@ -159,12 +159,12 @@ void FlagTreeItem::read_recursive(FlagTreeItem *root, const std::map<std::string
     std::map<std::string,bool>::const_iterator iter_hide;
     for( iter = root->m_child.begin(); iter != root->m_child.end(); ++iter)
     {
-        int sizeShow = (*iter)->m_showName.size();
-        int sizeHide = (*iter)->m_hideName.size();
+        size_t sizeShow = (*iter)->m_showName.size();
+        size_t sizeHide = (*iter)->m_hideName.size();
 
         bool found = false;
 
-        for(int i=0; i<sizeHide; i++)
+        for(size_t i=0; i<sizeHide; i++)
         {
             iter_hide = parse_map.find((*iter)->m_hideName[i]);
             if( iter_hide != parse_map.end() )
@@ -184,7 +184,7 @@ void FlagTreeItem::read_recursive(FlagTreeItem *root, const std::map<std::string
                 }
             }
         }
-        for(int i=0; i<sizeShow; i++)
+        for(size_t i=0; i<sizeShow; i++)
         {
             iter_show = parse_map.find((*iter)->m_showName[i]);
             if( iter_show != parse_map.end() )

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
@@ -885,7 +885,7 @@ void DrawToolGL::drawQuads(const std::vector<Vector3> &points, const std::vector
             Vec4f average_colour;
             for(int i=0; i<4; i++)
             {
-                average_colour[i] = (col_a[i]+col_b[i]+col_c[i]+col_d[i])*0.25;
+                average_colour[i] = (col_a[i]+col_b[i]+col_c[i]+col_d[i])*0.25f;
             }
 
             Vector3 n = cross((b-a),(c-a));

--- a/SofaKernel/framework/sofa/helper/gl/BasicShapesGL.h
+++ b/SofaKernel/framework/sofa/helper/gl/BasicShapesGL.h
@@ -46,13 +46,13 @@ public:
     struct GLBuffers
     {
         GLuint VBO, IBO;
-        GLuint verticesBufferSize, normalsBufferSize, texcoordsBufferSize, totalSize;
-        GLuint indicesSize;
+        GLuint64 verticesBufferSize, normalsBufferSize, texcoordsBufferSize, totalSize;
+        GLuint64 indicesSize;
     };
     struct CustomGLBuffer
     {
         GLuint VBO;
-        GLuint bufferSize;
+        GLuint64 bufferSize;
         GLint location;
     };
 };

--- a/SofaKernel/framework/sofa/helper/gl/BasicShapesGL.inl
+++ b/SofaKernel/framework/sofa/helper/gl/BasicShapesGL.inl
@@ -23,7 +23,7 @@
 #define SOFA_HELPER_GL_BASICSHAPESGL_INL
 
 #include <sofa/helper/gl/BasicShapesGL.h>
-
+#include <sofa/helper/gl/template.h>
 #include <sofa/helper/gl/shaders/generateSphere.cppglsl>
 
 namespace sofa
@@ -59,10 +59,10 @@ void BasicShapesGL_Sphere<VertexType>::generateBuffer(const SphereDescription &d
     glGenBuffers(1, &buffer.VBO);
     glGenBuffers(1, &buffer.IBO);
 
-    float radius = 1.0;
+    float radius = 1.0f;
 
-    float const R = 1. / (float)(desc.rings - 1);
-    float const S = 1. / (float)(desc.sectors - 1);
+    float const R = 1.f / (float)(desc.rings - 1);
+    float const S = 1.f / (float)(desc.sectors - 1);
     unsigned int r, s;
 
     std::vector<GLfloat> vertices;
@@ -83,20 +83,20 @@ void BasicShapesGL_Sphere<VertexType>::generateBuffer(const SphereDescription &d
     {
         for (s = 0; s < desc.sectors; s++)
         {
-            float const y = sin(-M_PI_2 + M_PI * r * R);
-            float const x = cos(2 * M_PI * s * S) * sin(M_PI * r * R);
-            float const z = sin(2 * M_PI * s * S) * sin(M_PI * r * R);
+            const double y = sin(-M_PI_2 + M_PI * r * R);
+            const double  x = cos(2 * M_PI * s * S) * sin(M_PI * r * R);
+            const double  z = sin(2 * M_PI * s * S) * sin(M_PI * r * R);
 
             *t++ = s*S;
             *t++ = r*R;
 
-            *v++ = x * radius;
-            *v++ = y * radius;
-            *v++ = z * radius;
+            *v++ = (float)x * radius;
+            *v++ = (float)y * radius;
+            *v++ = (float)z * radius;
 
-            *n++ = x;
-            *n++ = y;
-            *n++ = z;
+            *n++ = (float)x;
+            *n++ = (float)y;
+            *n++ = (float)z;
         }
     }
 
@@ -151,10 +151,10 @@ template<class VertexType>
 void BasicShapesGL_Sphere<VertexType>::internalDraw(const GLBuffers &buffer, const VertexType& center, const float& radius)
 {
     glPushMatrix();
-    glTranslatef(center[0], center[1], center[2]);
+    helper::gl::glTranslate(center[0], center[1], center[2]);
     glScalef(radius, radius, radius);
 
-    glDrawElements(GL_QUADS, buffer.indicesSize, GL_UNSIGNED_INT, (void*)0);
+    glDrawElements(GL_QUADS, (GLsizei)buffer.indicesSize, GL_UNSIGNED_INT, (void*)0);
 
     glPopMatrix();
 }
@@ -312,21 +312,21 @@ void BasicShapesGL_FakeSphere<VertexType>::generateBuffer(const std::vector<Vert
         //Should try to avoid this test...
         const float& radius = (p < radii.size()) ? radii[p] : radii[0];
 
-        *v++ = vertex[0];
-        *v++ = vertex[1];
-        *v++ = vertex[2];
+        *v++ = (float)vertex[0];
+        *v++ = (float)vertex[1];
+        *v++ = (float)vertex[2];
 
-        *v++ = vertex[0];
-        *v++ = vertex[1];
-        *v++ = vertex[2];
+        *v++ = (float)vertex[0];
+        *v++ = (float)vertex[1];
+        *v++ = (float)vertex[2];
 
-        *v++ = vertex[0];
-        *v++ = vertex[1];
-        *v++ = vertex[2];
+        *v++ = (float)vertex[0];
+        *v++ = (float)vertex[1];
+        *v++ = (float)vertex[2];
 
-        *v++ = vertex[0];
-        *v++ = vertex[1];
-        *v++ = vertex[2];
+        *v++ = (float)vertex[0];
+        *v++ = (float)vertex[1];
+        *v++ = (float)vertex[2];
 
         *t++ = -1.0;
         *t++ = -1.0;
@@ -419,7 +419,7 @@ void BasicShapesGL_FakeSphere<VertexType>::internalDraw()
     m_shader->TurnOn();
 
     glPushMatrix();
-    glDrawElements(GL_QUADS, m_buffer.indicesSize, GL_UNSIGNED_INT, (void*)0);
+    glDrawElements(GL_QUADS, (GLsizei)m_buffer.indicesSize, GL_UNSIGNED_INT, (void*)0);
     glPopMatrix();
     m_shader->TurnOff();
 }

--- a/SofaKernel/framework/sofa/helper/gl/glText.inl
+++ b/SofaKernel/framework/sofa/helper/gl/glText.inl
@@ -118,7 +118,7 @@ void GlText::draw(const T& text, const defaulttype::Vector3& position, const dou
         char character = str[j] - 32;
 
         float uv_x = (character % nb_char_width) / (float)nb_char_width;
-        float uv_y = 1.0 - ((character / nb_char_height) / (float)nb_char_height);
+        float uv_y = 1.0f - ((character / nb_char_height) / (float)nb_char_height);
 
         Vector2 uv_up_left = Vector2(uv_x, (uv_y - (1.0f / (float)nb_char_height)));
         Vector2 uv_up_right = Vector2(uv_x + (1.0f / (float)nb_char_width), (uv_y - (1.0f / (float)nb_char_height)));

--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetGeometryAlgorithms.h
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetGeometryAlgorithms.h
@@ -115,11 +115,11 @@ public:
     void getRestEdgeVertexCoordinates(const EdgeID i, Coord[2]) const;
 
     // test if a point is on the triangle indexed by ind_e
-    bool isPointOnEdge(const sofa::defaulttype::Vec<3,double> &pt, const unsigned int ind_e) const;
+    bool isPointOnEdge(const sofa::defaulttype::Vec<3, double> &pt, const EdgeID ind_e) const;
 
     // compute barycentric coefficients
-    sofa::helper::vector< double > compute2PointsBarycoefs(const sofa::defaulttype::Vec<3,double> &p, unsigned int ind_p1, unsigned int ind_p2) const;
-    sofa::helper::vector< double > computeRest2PointsBarycoefs(const sofa::defaulttype::Vec<3,double> &p, unsigned int ind_p1, unsigned int ind_p2) const;
+    sofa::helper::vector< double > compute2PointsBarycoefs(const sofa::defaulttype::Vec<3, double> &p, PointID ind_p1, PointID ind_p2) const;
+    sofa::helper::vector< double > computeRest2PointsBarycoefs(const sofa::defaulttype::Vec<3, double> &p, PointID ind_p1, PointID ind_p2) const;
 
     /** \brief Compute the projection coordinate of a point C on the edge i. Using compute2EdgesIntersection().
     * @param i edgeID on which point is projected.
@@ -153,11 +153,11 @@ public:
       \param edges attached to the vertices
       \param weights associated with the edges. Each Vec3d represents the contribution of the associated edge to x,y and z of the deformed basis.
       */
-   void computeLocalFrameEdgeWeights( helper::vector<unsigned>& numEdges, helper::vector<Edge>& edges, helper::vector<Vec3d>& weights ) const;
+   void computeLocalFrameEdgeWeights( helper::vector<EdgeID>& numEdges, helper::vector<Edge>& edges, helper::vector<Vec3d>& weights ) const;
 
     /** \brief Process the added point initialization according to the topology and local coordinates.
     */
-    virtual void initPointAdded(unsigned int indice, const core::topology::PointAncestorElem &ancestorElem
+    virtual void initPointAdded(PointID indice, const core::topology::PointAncestorElem &ancestorElem
         , const helper::vector< VecCoord* >& coordVecs, const helper::vector< VecDeriv* >& derivVecs) override;
 
     /** return a pointer to the container of cubature points */

--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetGeometryAlgorithms.h
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetGeometryAlgorithms.h
@@ -57,7 +57,8 @@ template < class DataTypes >
 class EdgeSetGeometryAlgorithms : public PointSetGeometryAlgorithms<DataTypes>
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE(EdgeSetGeometryAlgorithms,DataTypes),SOFA_TEMPLATE(PointSetGeometryAlgorithms,DataTypes));
+    SOFA_CLASS(SOFA_TEMPLATE(EdgeSetGeometryAlgorithms,DataTypes),SOFA_TEMPLATE(PointSetGeometryAlgorithms,DataTypes));    
+    typedef sofa::core::topology::BaseMeshTopology::PointID PointID;
     typedef sofa::core::topology::BaseMeshTopology::EdgeID EdgeID;
     typedef sofa::core::topology::BaseMeshTopology::Edge Edge;
     typedef sofa::core::topology::BaseMeshTopology::SeqEdges SeqEdges;

--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetGeometryAlgorithms.inl
@@ -293,7 +293,7 @@ void EdgeSetGeometryAlgorithms<DataTypes>::computeEdgeLength( BasicArrayInterfac
     const sofa::helper::vector<Edge> &ea = this->m_topology->getEdges();
     const typename DataTypes::VecCoord& p =(this->object->read(core::ConstVecCoordId::position())->getValue());
 
-    for (unsigned int i=0; i<ea.size(); ++i)
+    for (size_t i=0; i<ea.size(); ++i)
     {
         const Edge &e = ea[i];
         ai[i] = (DataTypes::getCPos(p[e[0]])-DataTypes::getCPos(p[e[1]])).norm();
@@ -359,7 +359,7 @@ typename DataTypes::Coord EdgeSetGeometryAlgorithms<DataTypes>::computeRestEdgeD
 
 // test if a point is on the triangle indexed by ind_e
 template<class DataTypes>
-bool EdgeSetGeometryAlgorithms<DataTypes>::isPointOnEdge(const sofa::defaulttype::Vec<3,double> &pt, const unsigned int ind_e) const
+bool EdgeSetGeometryAlgorithms<DataTypes>::isPointOnEdge(const sofa::defaulttype::Vec<3,double> &pt, const EdgeID ind_e) const
 {
     const double ZERO = 1e-12;
 
@@ -384,9 +384,9 @@ bool EdgeSetGeometryAlgorithms<DataTypes>::isPointOnEdge(const sofa::defaulttype
 //
 template<class DataTypes>
 sofa::helper::vector< double > EdgeSetGeometryAlgorithms<DataTypes>::compute2PointsBarycoefs(
-    const sofa::defaulttype::Vec<3,double> &p,
-    unsigned int ind_p1,
-    unsigned int ind_p2) const
+    const sofa::defaulttype::Vec<3, double> &p,
+    PointID ind_p1,
+    PointID ind_p2) const
 {
     const double ZERO = 1e-6;
 
@@ -450,7 +450,7 @@ void EdgeSetGeometryAlgorithms<DataTypes>::writeMSHfile(const char *filename) co
 
     myfile << edge.size() <<"\n";
 
-    for (unsigned int i=0; i<edge.size(); ++i)
+    for (size_t i=0; i<edge.size(); ++i)
     {
         myfile << i+1 << " 1 1 1 2 " << edge[i][0]+1 << " " << edge[i][1]+1 <<"\n";
     }
@@ -476,8 +476,8 @@ bool is_point_on_edge(const Vec& p, const Vec& a, const Vec& b)
 template<class DataTypes>
 sofa::helper::vector< double > EdgeSetGeometryAlgorithms<DataTypes>::computeRest2PointsBarycoefs(
     const sofa::defaulttype::Vec<3,double> &p,
-    unsigned int ind_p1,
-    unsigned int ind_p2) const
+    PointID ind_p1,
+    PointID ind_p2) const
 {
     const double ZERO = 1e-6;
 
@@ -542,7 +542,7 @@ sofa::helper::vector< double > compute_2points_barycoefs(const Vec& p, const Vec
 
 template<class DataTypes>
 sofa::helper::vector< double > EdgeSetGeometryAlgorithms<DataTypes>::computePointProjectionOnEdge (const EdgeID edgeIndex,
-        sofa::defaulttype::Vec<3,double> c,
+        sofa::defaulttype::Vec<3, double> c,
         bool& intersected)
 {
 
@@ -724,7 +724,7 @@ void EdgeSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
         const sofa::helper::vector <Edge>& edgeArray = this->m_topology->getEdges();
 
         std::vector<defaulttype::Vector3> positions;
-        for (unsigned int i = 0; i < edgeArray.size(); i++)
+        for (size_t i = 0; i < edgeArray.size(); i++)
         {
 
             Edge the_edge = edgeArray[i];
@@ -750,7 +750,7 @@ void EdgeSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
 
             std::vector<defaulttype::Vector3> positions;
             positions.reserve(edgeArray.size()*2u);
-            for (unsigned int i = 0; i<edgeArray.size(); i++)
+            for (size_t i = 0; i<edgeArray.size(); i++)
             {
                 const Edge& e = edgeArray[i];
                 positions.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[e[0]])));
@@ -886,7 +886,7 @@ void EdgeSetGeometryAlgorithms< DataTypes >::computeLocalFrameEdgeWeights( helpe
 
 
 template<class DataTypes>
-void EdgeSetGeometryAlgorithms<DataTypes>::initPointAdded(unsigned int index, const core::topology::PointAncestorElem &ancestorElem
+void EdgeSetGeometryAlgorithms<DataTypes>::initPointAdded(PointID index, const core::topology::PointAncestorElem &ancestorElem
         , const helper::vector< VecCoord* >& coordVecs, const helper::vector< VecDeriv* >& derivVecs)
 {
     using namespace sofa::core::topology;

--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetGeometryAlgorithms.inl
@@ -67,6 +67,7 @@ void EdgeSetGeometryAlgorithms< DataTypes >::defineEdgeCubaturePoints() {
     typename NumericalIntegrationDescriptor<typename EdgeSetGeometryAlgorithms< DataTypes >::Real,1>::QuadratureMethod m=NumericalIntegrationDescriptor<typename EdgeSetGeometryAlgorithms< DataTypes >::Real,1>::GAUSS_LEGENDRE_METHOD;
     typename NumericalIntegrationDescriptor<typename EdgeSetGeometryAlgorithms< DataTypes >::Real,1>::QuadraturePointArray qpa;
     BarycentricCoordinatesType v;
+    Real div2 = 0.5;
 
     /// integration with linear accuracy.
     v=BarycentricCoordinatesType(0.5);
@@ -74,60 +75,61 @@ void EdgeSetGeometryAlgorithms< DataTypes >::defineEdgeCubaturePoints() {
     edgeNumericalIntegration.addQuadratureMethod(m,1,qpa);
     /// integration with quadratic accuracy.
     qpa.clear();
-    Real a=0.5+1/(2*sqrt(3.));
+    
+    Real a= div2 +1/(2*sqrt((Real)3));
     v=BarycentricCoordinatesType(a);
-    qpa.push_back(QuadraturePoint(v,(Real)0.5));
-    Real b=0.5-1/(2*sqrt(3.));
+    qpa.push_back(QuadraturePoint(v, div2));
+    Real b=div2-1/(2*sqrt((Real)3.));
     v=BarycentricCoordinatesType(b);
-    qpa.push_back(QuadraturePoint(v,(Real)0.5));
+    qpa.push_back(QuadraturePoint(v, div2));
     edgeNumericalIntegration.addQuadratureMethod(m,2,qpa);
     /// integration with cubic accuracy.
     qpa.clear();
-    a=0.5*(1-sqrt((Real)3/5.0));
+    a=div2*(1-sqrt((Real)3/5));
     v=BarycentricCoordinatesType(a);
     qpa.push_back(QuadraturePoint(v,(Real)(5.0/18.0)));
-    b=0.5*(1+sqrt((Real)3/5.0));
+    b=div2*(1+sqrt((Real)3/5));
     v=BarycentricCoordinatesType(b);
     qpa.push_back(QuadraturePoint(v,(Real)(5.0/18.0)));
-    v=BarycentricCoordinatesType(0.5);
+    v=BarycentricCoordinatesType(div2);
     qpa.push_back(QuadraturePoint(v,(Real)(8.0/18.0)));
     edgeNumericalIntegration.addQuadratureMethod(m,3,qpa);
     /// integration with quartic accuracy.
     qpa.clear();
-    a=0.5*(1-sqrt((Real)(3+2*sqrt(6.0/5.0))/7));
+    a=div2*(1-sqrt((Real)(3+2*sqrt(6.0/5.0))/7));
     v=BarycentricCoordinatesType(a);
-    Real a2=0.25-sqrt(5.0/6.0)/12;
+    Real a2= 0.25f - (Real)sqrt(5.0/6.0)/12;
     qpa.push_back(QuadraturePoint(v,a2));
-    a=0.5*(1+sqrt((Real)(3+2*sqrt(6.0/5.0))/7));
-    v=BarycentricCoordinatesType(a);
-    qpa.push_back(QuadraturePoint(v,a2));
-    a=0.5*(1-sqrt((Real)(3-2*sqrt(6.0/5.0))/7));
-    a2=0.25+sqrt(5.0/6.0)/12;
+    a=div2*(1+sqrt((Real)(3+2*sqrt(6.0/5.0))/7));
     v=BarycentricCoordinatesType(a);
     qpa.push_back(QuadraturePoint(v,a2));
-    a=0.5*(1+sqrt((Real)(3-2*sqrt(6.0/5.0))/7));
+    a=div2*(1-sqrt((Real)(3-2*sqrt(6.0/5.0))/7));
+    a2= 0.25f + (Real)sqrt(5.0/6.0)/12;
+    v=BarycentricCoordinatesType(a);
+    qpa.push_back(QuadraturePoint(v,a2));
+    a=div2*(1+sqrt((Real)(3-2*sqrt(6.0/5.0))/7));
     v=BarycentricCoordinatesType(a);
     qpa.push_back(QuadraturePoint(v,a2));
     edgeNumericalIntegration.addQuadratureMethod(m,4,qpa);
     /// integration with quintic accuracy.
     qpa.clear();
-    a=0.5*(1-sqrt((Real)(5+2*sqrt(10.0/7.0)))/3);
+    a=div2*(1-sqrt((Real)(5+2*sqrt(10.0/7.0)))/3);
     v=BarycentricCoordinatesType(a);
-    a2=(322-13*sqrt(70.0))/900;
+    a2= (Real)(322-13*sqrt(70.0))/900;
     qpa.push_back(QuadraturePoint(v,a2/2));
-    a=0.5*(1+sqrt((Real)(5+2*sqrt(10.0/7.0)))/3);
-    v=BarycentricCoordinatesType(a);
-    qpa.push_back(QuadraturePoint(v,a2/2));
-
-    a=0.5*(1-sqrt((Real)(5-2*sqrt(10.0/7.0)))/3);
-    v=BarycentricCoordinatesType(a);
-    a2=(322+13*sqrt(70.0))/900;
-    qpa.push_back(QuadraturePoint(v,a2/2));
-    a=0.5*(1+sqrt((Real)(5-2*sqrt(10.0/7.0)))/3);
+    a=div2*(1+sqrt((Real)(5+2*sqrt(10.0/7.0)))/3);
     v=BarycentricCoordinatesType(a);
     qpa.push_back(QuadraturePoint(v,a2/2));
 
-    v=BarycentricCoordinatesType(0.5);
+    a=div2*(1-sqrt((Real)(5-2*sqrt(10.0/7.0)))/3);
+    v=BarycentricCoordinatesType(a);
+    a2= (Real)(322+13*sqrt(70.0))/900;
+    qpa.push_back(QuadraturePoint(v,a2/2));
+    a=div2*(1+sqrt((Real)(5-2*sqrt(10.0/7.0)))/3);
+    v=BarycentricCoordinatesType(a);
+    qpa.push_back(QuadraturePoint(v,a2/2));
+
+    v=BarycentricCoordinatesType(div2);
     qpa.push_back(QuadraturePoint(v,(Real)(512/1800.0)));
     edgeNumericalIntegration.addQuadratureMethod(m,5,qpa);
 
@@ -146,9 +148,9 @@ void EdgeSetGeometryAlgorithms< DataTypes >::defineEdgeCubaturePoints() {
     varray[2]=0.9324695142031520278123016; warray[2]=0.1713244923791703450402961;
 
     for (i=0;i<nbIPs;++i) {
-        v=BarycentricCoordinatesType(0.5*(1+varray[i]));
+        v=BarycentricCoordinatesType(div2*(1+ (Real)varray[i]));
         qpa.push_back(QuadraturePoint(v,(Real)warray[i]/2));
-        v=BarycentricCoordinatesType(0.5*(1-varray[i]));
+        v=BarycentricCoordinatesType(div2*(1- (Real)varray[i]));
         qpa.push_back(QuadraturePoint(v,(Real)warray[i]/2));
     }
     edgeNumericalIntegration.addQuadratureMethod(m,6,qpa);
@@ -160,12 +162,12 @@ void EdgeSetGeometryAlgorithms< DataTypes >::defineEdgeCubaturePoints() {
     varray[2]=0.9491079123427585245261897;	warray[2]=0.1294849661688696932706114;
 
     for (i=0;i<nbIPs;++i) {
-        v=BarycentricCoordinatesType(0.5*(1+varray[i]));
+        v=BarycentricCoordinatesType(div2*(1+ (Real)varray[i]));
         qpa.push_back(QuadraturePoint(v,(Real)warray[i]/2));
-        v=BarycentricCoordinatesType(0.5*(1-varray[i]));
+        v=BarycentricCoordinatesType(div2*(1- (Real)varray[i]));
         qpa.push_back(QuadraturePoint(v,(Real)warray[i]/2));
     }
-    v=BarycentricCoordinatesType(0.5);
+    v=BarycentricCoordinatesType(div2);
     qpa.push_back(QuadraturePoint(v,(Real)warray0/2));
     edgeNumericalIntegration.addQuadratureMethod(m,7,qpa);
     /// integration with  accuracy of order 8.
@@ -178,9 +180,9 @@ void EdgeSetGeometryAlgorithms< DataTypes >::defineEdgeCubaturePoints() {
 
 
     for (i=0;i<nbIPs;++i) {
-        v=BarycentricCoordinatesType(0.5*(1+varray[i]));
+        v=BarycentricCoordinatesType(div2*(1+ (Real)varray[i]));
         qpa.push_back(QuadraturePoint(v,(Real)warray[i]/2));
-        v=BarycentricCoordinatesType(0.5*(1-varray[i]));
+        v=BarycentricCoordinatesType(div2*(1- (Real)varray[i]));
         qpa.push_back(QuadraturePoint(v,(Real)warray[i]/2));
     }
     edgeNumericalIntegration.addQuadratureMethod(m,8,qpa);
@@ -194,12 +196,12 @@ void EdgeSetGeometryAlgorithms< DataTypes >::defineEdgeCubaturePoints() {
 
 
     for (i=0;i<nbIPs;++i) {
-        v=BarycentricCoordinatesType(0.5*(1+varray[i]));
+        v=BarycentricCoordinatesType(div2*(1+ (Real)varray[i]));
         qpa.push_back(QuadraturePoint(v,(Real)warray[i]/2));
-        v=BarycentricCoordinatesType(0.5*(1-varray[i]));
+        v=BarycentricCoordinatesType(div2*(1- (Real)varray[i]));
         qpa.push_back(QuadraturePoint(v,(Real)warray[i]/2));
     }
-    v=BarycentricCoordinatesType(0.5);
+    v=BarycentricCoordinatesType(div2);
     qpa.push_back(QuadraturePoint(v,(Real)warray0/2));
     edgeNumericalIntegration.addQuadratureMethod(m,9,qpa);
 
@@ -213,9 +215,9 @@ void EdgeSetGeometryAlgorithms< DataTypes >::defineEdgeCubaturePoints() {
     nbIPs=5;
 
     for (i=0;i<nbIPs;++i) {
-        v=BarycentricCoordinatesType(0.5*(1+varray[i]));
+        v=BarycentricCoordinatesType(div2*(1+ (Real)varray[i]));
         qpa.push_back(QuadraturePoint(v,(Real)warray[i]/2));
-        v=BarycentricCoordinatesType(0.5*(1-varray[i]));
+        v=BarycentricCoordinatesType(div2*(1- (Real)varray[i]));
         qpa.push_back(QuadraturePoint(v,(Real)warray[i]/2));
     }
     edgeNumericalIntegration.addQuadratureMethod(m,10,qpa);
@@ -229,12 +231,12 @@ void EdgeSetGeometryAlgorithms< DataTypes >::defineEdgeCubaturePoints() {
     varray[4]=0.9782286581460569928039380;	warray[4]=	0.0556685671161736664827537;
 
     for (i=0;i<nbIPs;++i) {
-        v=BarycentricCoordinatesType(0.5*(1+varray[i]));
+        v=BarycentricCoordinatesType(div2*(1+ (Real)varray[i]));
         qpa.push_back(QuadraturePoint(v,(Real)warray[i]/2));
-        v=BarycentricCoordinatesType(0.5*(1-varray[i]));
+        v=BarycentricCoordinatesType(div2*(1- (Real)varray[i]));
         qpa.push_back(QuadraturePoint(v,(Real)warray[i]/2));
     }
-    v=BarycentricCoordinatesType(0.5);
+    v=BarycentricCoordinatesType(div2);
     qpa.push_back(QuadraturePoint(v,(Real)warray0/2));
     edgeNumericalIntegration.addQuadratureMethod(m,11,qpa);
     /// integration with accuracy of order 12.
@@ -247,9 +249,9 @@ void EdgeSetGeometryAlgorithms< DataTypes >::defineEdgeCubaturePoints() {
     nbIPs=6;
 
     for (i=0;i<nbIPs;++i) {
-        v=BarycentricCoordinatesType(0.5*(1+varray[i]));
+        v=BarycentricCoordinatesType(div2*(1+ (Real)varray[i]));
         qpa.push_back(QuadraturePoint(v,(Real)warray[i]/2));
-        v=BarycentricCoordinatesType(0.5*(1-varray[i]));
+        v=BarycentricCoordinatesType(div2*(1- (Real)varray[i]));
         qpa.push_back(QuadraturePoint(v,(Real)warray[i]/2));
     }
     edgeNumericalIntegration.addQuadratureMethod(m,10,qpa);

--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyContainer.cpp
@@ -285,7 +285,7 @@ bool EdgeSetTopologyContainer::checkConnexity()
 }
 
 
-unsigned int EdgeSetTopologyContainer::getNumberOfConnectedComponent()
+size_t EdgeSetTopologyContainer::getNumberOfConnectedComponent()
 {
     size_t nbr = this->getNbEdges();
 
@@ -298,7 +298,7 @@ unsigned int EdgeSetTopologyContainer::getNumberOfConnectedComponent()
     }
 
     VecEdgeID elemAll = this->getConnectedElement(0);
-    unsigned int cpt = 1;
+    size_t cpt = 1;
 
     while (elemAll.size() < nbr)
     {
@@ -486,13 +486,13 @@ const EdgeSetTopologyContainer::VecEdgeID EdgeSetTopologyContainer::getElementAr
 
 
 
-unsigned int EdgeSetTopologyContainer::getNumberOfEdges() const
+size_t EdgeSetTopologyContainer::getNumberOfEdges() const
 {
     d_edge.updateIfDirty();
-    return (unsigned int)d_edge.getValue().size();
+    return d_edge.getValue().size();
 }
 
-unsigned int EdgeSetTopologyContainer::getNumberOfElements() const
+size_t EdgeSetTopologyContainer::getNumberOfElements() const
 {
     return this->getNumberOfEdges();
 }

--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyContainer.cpp
@@ -165,7 +165,7 @@ int EdgeSetTopologyContainer::getEdgeIndex(PointID v1, PointID v2)
     if(!hasEdgesAroundVertex())
         createEdgesAroundVertexArray();
 
-    const sofa::helper::vector< unsigned int > &es1 = getEdgesAroundVertex(v1) ;
+    const sofa::helper::vector< EdgeID > &es1 = getEdgesAroundVertex(v1) ;
     helper::ReadAccessor< Data< sofa::helper::vector<Edge> > > m_edge = d_edge;
 
     int result = -1;
@@ -191,7 +191,7 @@ const EdgeSetTopologyContainer::Edge EdgeSetTopologyContainer::getEdge (EdgeID i
 
 
 // Return the number of connected components from the graph containing all edges and give, for each vertex, which component it belongs to  (use BOOST GRAPH LIBRAIRY)
-int EdgeSetTopologyContainer::getNumberConnectedComponents(sofa::helper::vector<unsigned int>& components)
+int EdgeSetTopologyContainer::getNumberConnectedComponents(sofa::helper::vector<EdgeID>& components)
 {
     using namespace boost;
 
@@ -225,7 +225,7 @@ bool EdgeSetTopologyContainer::checkTopology() const
 
 			for (size_t i = 0; i < m_edgesAroundVertex.size(); ++i)
 			{
-				const sofa::helper::vector<unsigned int> &es = m_edgesAroundVertex[i];
+				const sofa::helper::vector<EdgeID> &es = m_edgesAroundVertex[i];
 
 				for (size_t j = 0; j < es.size(); ++j)
 				{
@@ -303,7 +303,7 @@ size_t EdgeSetTopologyContainer::getNumberOfConnectedComponent()
     while (elemAll.size() < nbr)
     {
         std::sort(elemAll.begin(), elemAll.end());
-        EdgeID other_edgeID = elemAll.size();
+        size_t other_edgeID = elemAll.size();
 
         for (EdgeID i = 0; i<(EdgeID)elemAll.size(); ++i)
             if (elemAll[i] != i)
@@ -312,7 +312,7 @@ size_t EdgeSetTopologyContainer::getNumberOfConnectedComponent()
                 break;
             }
 
-        VecEdgeID elemTmp = this->getConnectedElement(other_edgeID);
+        VecEdgeID elemTmp = this->getConnectedElement((EdgeID)other_edgeID);
         cpt++;
 
         elemAll.insert(elemAll.begin(), elemTmp.begin(), elemTmp.end());
@@ -497,7 +497,7 @@ size_t EdgeSetTopologyContainer::getNumberOfElements() const
     return this->getNumberOfEdges();
 }
 
-const sofa::helper::vector< sofa::helper::vector<unsigned int> > &EdgeSetTopologyContainer::getEdgesAroundVertexArray()
+const sofa::helper::vector< sofa::helper::vector<EdgeSetTopologyContainer::EdgeID> > &EdgeSetTopologyContainer::getEdgesAroundVertexArray()
 {
     if(!hasEdgesAroundVertex())
     {
@@ -529,7 +529,7 @@ const EdgeSetTopologyContainer::EdgesAroundVertex& EdgeSetTopologyContainer::get
     return m_edgesAroundVertex[i];
 }
 
-sofa::helper::vector< unsigned int > &EdgeSetTopologyContainer::getEdgesAroundVertexForModification(const unsigned int i)
+sofa::helper::vector< EdgeSetTopologyContainer::EdgeID > &EdgeSetTopologyContainer::getEdgesAroundVertexForModification(const PointID i)
 {
     if(!hasEdgesAroundVertex())	// this method should only be called when the shell array exists
     {

--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyContainer.h
@@ -128,12 +128,12 @@ public:
      * The difference to getNbEdges() is that this method does not generate the edge array if it does not exist.
      * @return the number of edges.
      */
-    unsigned int getNumberOfEdges() const;
+    size_t getNumberOfEdges() const;
 
     /** \brief Returns the number of topological element of the current topology.
      * This function avoids to know which topological container is in used.
      */
-    virtual unsigned int getNumberOfElements() const override;
+    virtual size_t getNumberOfElements() const override;
 
 
     /** \brief Returns the number of connected components from the graph containing all edges and give, for each vertex, which component it belongs to  (use BOOST GRAPH LIBRAIRY)
@@ -176,7 +176,7 @@ public:
     virtual bool checkConnexity() override;
 
     /// Returns the number of connected component.
-    virtual unsigned int getNumberOfConnectedComponent() override;
+    virtual size_t getNumberOfConnectedComponent() override;
 
     /// Returns the set of element indices connected to an input one (i.e. which can be reached by topological links)
     virtual const VecEdgeID getConnectedElement(EdgeID elem) override;

--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyContainer.h
@@ -43,12 +43,12 @@ class SOFA_BASE_TOPOLOGY_API EdgeSetTopologyContainer : public PointSetTopologyC
 public:
     SOFA_CLASS(EdgeSetTopologyContainer,PointSetTopologyContainer);
 
-    typedef BaseMeshTopology::PointID		   	PointID;
-    typedef BaseMeshTopology::EdgeID			      EdgeID;
-    typedef BaseMeshTopology::Edge				   Edge;
-    typedef BaseMeshTopology::SeqEdges			   SeqEdges;
-    typedef BaseMeshTopology::EdgesAroundVertex	EdgesAroundVertex;
-    typedef sofa::helper::vector<EdgeID>         VecEdgeID;
+    typedef BaseMeshTopology::PointID               PointID;
+    typedef BaseMeshTopology::EdgeID                EdgeID;
+    typedef BaseMeshTopology::Edge                  Edge;
+    typedef BaseMeshTopology::SeqEdges              SeqEdges;
+    typedef BaseMeshTopology::EdgesAroundVertex     EdgesAroundVertex;
+    typedef sofa::helper::vector<EdgeID>            VecEdgeID;
 
 
 protected:
@@ -187,8 +187,8 @@ public:
     virtual const VecEdgeID getElementAroundElements(VecEdgeID elems) override;
     /// @}
 
-	  /** \brief Returns the type of the topology */
-	  virtual sofa::core::topology::TopologyObjectType getTopologyType() const override {return sofa::core::topology::EDGE;}
+      /** \brief Returns the type of the topology */
+      virtual sofa::core::topology::TopologyObjectType getTopologyType() const override {return sofa::core::topology::EDGE;}
     
 
 protected:

--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyModifier.cpp
@@ -277,7 +277,7 @@ void EdgeSetTopologyModifier::removeEdgesProcess(const sofa::helper::vector<unsi
     }
 }
 
-void EdgeSetTopologyModifier::addPointsProcess(const unsigned int nPoints)
+void EdgeSetTopologyModifier::addPointsProcess(const size_t nPoints)
 {
     // start by calling the parent's method.
     PointSetTopologyModifier::addPointsProcess( nPoints );
@@ -286,7 +286,7 @@ void EdgeSetTopologyModifier::addPointsProcess(const unsigned int nPoints)
         m_container->m_edgesAroundVertex.resize( m_container->getNbPoints() );
 }
 
-void EdgeSetTopologyModifier::removePointsProcess(const sofa::helper::vector<unsigned int> &indices,
+void EdgeSetTopologyModifier::removePointsProcess(const sofa::helper::vector<PointID> &indices,
         const bool removeDOF)
 {
     // Note: edges connected to the points being removed are not removed here (this situation should not occur)
@@ -325,8 +325,8 @@ void EdgeSetTopologyModifier::removePointsProcess(const sofa::helper::vector<uns
     PointSetTopologyModifier::removePointsProcess( indices, removeDOF );
 }
 
-void EdgeSetTopologyModifier::renumberPointsProcess( const sofa::helper::vector<unsigned int> &index,
-        const sofa::helper::vector<unsigned int> &inv_index,
+void EdgeSetTopologyModifier::renumberPointsProcess( const sofa::helper::vector<PointID> &index,
+        const sofa::helper::vector<PointID> &inv_index,
         const bool renumberDOF)
 {
     if(m_container->hasEdges())

--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyModifier.cpp
@@ -534,8 +534,8 @@ void EdgeSetTopologyModifier::splitEdgesProcess(sofa::helper::vector<EdgeID> &in
         v[i][1] = p2;
 
         // Adding the new Edges
-        const Edge e1( p1, (PointID)m_container->getNbPoints() + i );
-        const Edge e2( (PointID)m_container->getNbPoints() + i, p2 );
+        const Edge e1( p1, (PointID)(m_container->getNbPoints() + i ));
+        const Edge e2( (PointID)(m_container->getNbPoints() + i), p2 );
         edges.push_back( e1 );
         edges.push_back( e2 );
         edgesIndex.push_back((EdgeID)nbEdges++);
@@ -591,8 +591,8 @@ void EdgeSetTopologyModifier::splitEdgesProcess(sofa::helper::vector<EdgeID> &in
         v[i][1] = p2;
 
         // Adding the new Edges
-        const Edge e1( p1, (PointID)m_container->getNbPoints() + i );
-        const Edge e2( (PointID)m_container->getNbPoints() + i, p2 );
+        const Edge e1( p1, (PointID)(m_container->getNbPoints() + i) );
+        const Edge e2( (PointID)(m_container->getNbPoints() + i), p2 );
         edges.push_back( e1 );
         edges.push_back( e2 );
         edgesIndex.push_back((EdgeID)nbEdges++);
@@ -672,7 +672,7 @@ void EdgeSetTopologyModifier::addEdges(const sofa::helper::vector< Edge >& edges
 
     for (size_t i=0; i<edges.size(); ++i)
     {
-        edgesIndex.push_back((EdgeID)nEdges+i);
+        edgesIndex.push_back((EdgeID)(nEdges+i));
     }
 
     // add topology event in the stack of topological events
@@ -696,7 +696,7 @@ void EdgeSetTopologyModifier::addEdges(const sofa::helper::vector< Edge >& edges
 
     for (size_t i=0; i<edges.size(); ++i)
     {
-        edgesIndex.push_back((EdgeID)nEdges+i);
+        edgesIndex.push_back((EdgeID)(nEdges+i));
     }
 
     // add topology event in the stack of topological events
@@ -709,7 +709,7 @@ void EdgeSetTopologyModifier::addEdges(const sofa::helper::vector< Edge >& edges
 void EdgeSetTopologyModifier::addEdges(const sofa::helper::vector< Edge >& edges,
         const sofa::helper::vector< core::topology::EdgeAncestorElem >& ancestorElems)
 {
-    size_t nEdges = m_container->getNumberOfEdges();
+    size_t nEdge = m_container->getNumberOfEdges();
 
     assert(ancestorElems.size() == edges.size());
 
@@ -720,7 +720,7 @@ void EdgeSetTopologyModifier::addEdges(const sofa::helper::vector< Edge >& edges
     edgesIndex.resize(edges.size());
     for (size_t i=0; i<edges.size(); ++i)
     {
-        edgesIndex[i] = (EdgeID)nEdges+i;
+        edgesIndex[i] = (EdgeID)(nEdge + i);
     }
 
     // add topology event in the stack of topological events

--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyModifier.cpp
@@ -91,13 +91,13 @@ void EdgeSetTopologyModifier::addEdgeProcess(Edge e)
 
     if (m_container->hasEdgesAroundVertex())
     {
-        const unsigned int edgeId = m_container->getNumberOfEdges();
+        size_t edgeId = m_container->getNumberOfEdges();
 
-        sofa::helper::vector< unsigned int > &shell0 = m_container->getEdgesAroundVertexForModification( e[0] );
-        shell0.push_back(edgeId);
+        sofa::helper::vector< EdgeID > &shell0 = m_container->getEdgesAroundVertexForModification( e[0] );
+        shell0.push_back((EdgeID)edgeId);
 
-        sofa::helper::vector< unsigned int > &shell1 = m_container->getEdgesAroundVertexForModification( e[1] );
-        shell1.push_back(edgeId);
+        sofa::helper::vector< EdgeID > &shell1 = m_container->getEdgesAroundVertexForModification( e[1] );
+        shell1.push_back((EdgeID)edgeId);
     }
 
     helper::WriteAccessor< Data< sofa::helper::vector<Edge> > > m_edge = m_container->d_edge;
@@ -107,14 +107,14 @@ void EdgeSetTopologyModifier::addEdgeProcess(Edge e)
 
 void EdgeSetTopologyModifier::addEdgesProcess(const sofa::helper::vector< Edge > &edges)
 {
-    for (unsigned int i=0; i<edges.size(); ++i)
+    for (size_t i=0; i<edges.size(); ++i)
     {
         addEdgeProcess(edges[i]);
     }
 }
 
 
-void EdgeSetTopologyModifier::addEdgesWarning(const unsigned int nEdges)
+void EdgeSetTopologyModifier::addEdgesWarning(const size_t nEdges)
 {
     m_container->setEdgeTopologyToDirty();
 
@@ -124,9 +124,9 @@ void EdgeSetTopologyModifier::addEdgesWarning(const unsigned int nEdges)
 }
 
 
-void EdgeSetTopologyModifier::addEdgesWarning(const unsigned int nEdges,
+void EdgeSetTopologyModifier::addEdgesWarning(const size_t nEdges,
         const sofa::helper::vector< Edge >& edgesList,
-        const sofa::helper::vector< unsigned int >& edgesIndexList)
+        const sofa::helper::vector< EdgeID >& edgesIndexList)
 {
     m_container->setEdgeTopologyToDirty();
 
@@ -136,10 +136,10 @@ void EdgeSetTopologyModifier::addEdgesWarning(const unsigned int nEdges,
 }
 
 
-void EdgeSetTopologyModifier::addEdgesWarning(const unsigned int nEdges,
+void EdgeSetTopologyModifier::addEdgesWarning(const size_t nEdges,
         const sofa::helper::vector< Edge >& edgesList,
-        const sofa::helper::vector< unsigned int >& edgesIndexList,
-        const sofa::helper::vector< sofa::helper::vector< unsigned int > > & ancestors)
+        const sofa::helper::vector< EdgeID >& edgesIndexList,
+        const sofa::helper::vector< sofa::helper::vector< EdgeID > > & ancestors)
 {
     m_container->setEdgeTopologyToDirty();
 
@@ -149,11 +149,11 @@ void EdgeSetTopologyModifier::addEdgesWarning(const unsigned int nEdges,
 }
 
 
-void EdgeSetTopologyModifier::addEdgesWarning(const unsigned int nEdges,
+void EdgeSetTopologyModifier::addEdgesWarning(const size_t nEdges,
         const sofa::helper::vector< Edge >& edgesList,
-        const sofa::helper::vector< unsigned int >& edgesIndexList,
-        const sofa::helper::vector< sofa::helper::vector< unsigned int > > & ancestors,
-        const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs)
+        const sofa::helper::vector< EdgeID >& edgesIndexList,
+        const sofa::helper::vector< sofa::helper::vector< EdgeID > > & ancestors,
+        const sofa::helper::vector< sofa::helper::vector< SReal > >& baryCoefs)
 {
     m_container->setEdgeTopologyToDirty();
 
@@ -162,21 +162,21 @@ void EdgeSetTopologyModifier::addEdgesWarning(const unsigned int nEdges,
     addTopologyChange(e);
 }
 
-void EdgeSetTopologyModifier::addEdgesWarning(const unsigned int nEdges,
+void EdgeSetTopologyModifier::addEdgesWarning(const size_t nEdges,
         const sofa::helper::vector< Edge >& edgesList,
-        const sofa::helper::vector< unsigned int >& edgesIndexList,
+        const sofa::helper::vector< EdgeID >& edgesIndexList,
         const sofa::helper::vector< core::topology::EdgeAncestorElem >& ancestorElems)
 {
     m_container->setEdgeTopologyToDirty();
 
-    sofa::helper::vector< sofa::helper::vector< unsigned int > > ancestors;
-    sofa::helper::vector< sofa::helper::vector< double > > baryCoefs;
+    sofa::helper::vector< sofa::helper::vector< EdgeID > > ancestors;
+    sofa::helper::vector< sofa::helper::vector< SReal > > baryCoefs;
     ancestors.resize(nEdges);
     baryCoefs.resize(nEdges);
 
-    for (unsigned int i=0; i<nEdges; ++i)
+    for (size_t i=0; i<nEdges; ++i)
     {
-        for (unsigned int j=0; j<ancestorElems[i].srcElems.size(); ++j)
+        for (size_t j=0; j<ancestorElems[i].srcElems.size(); ++j)
         {
             sofa::core::topology::TopologyElemID src = ancestorElems[i].srcElems[j];
             if (src.type == sofa::core::topology::EDGE && src.index != sofa::core::topology::Topology::InvalidID)
@@ -194,12 +194,12 @@ void EdgeSetTopologyModifier::addEdgesWarning(const unsigned int nEdges,
 }
 
 
-void EdgeSetTopologyModifier::removeEdgesWarning(sofa::helper::vector<unsigned int> &edges )
+void EdgeSetTopologyModifier::removeEdgesWarning(sofa::helper::vector<EdgeID> &edges )
 {
     m_container->setEdgeTopologyToDirty();
 
     // sort edges to remove in a descendent order
-    std::sort( edges.begin(), edges.end(), std::greater<unsigned int>() );
+    std::sort( edges.begin(), edges.end(), std::greater<EdgeID>() );
 
     // Warning that these edges will be deleted
     EdgesRemoved *e = new EdgesRemoved(edges);
@@ -207,7 +207,7 @@ void EdgeSetTopologyModifier::removeEdgesWarning(sofa::helper::vector<unsigned i
 }
 
 
-void EdgeSetTopologyModifier::removeEdgesProcess(const sofa::helper::vector<unsigned int> &indices,
+void EdgeSetTopologyModifier::removeEdgesProcess(const sofa::helper::vector<EdgeID> &indices,
         const bool removeIsolatedItems)
 {
     if(!m_container->hasEdges())	// this method should only be called when edges exist
@@ -221,11 +221,11 @@ void EdgeSetTopologyModifier::removeEdgesProcess(const sofa::helper::vector<unsi
         m_container->createEdgesAroundVertexArray();
     }
 
-    sofa::helper::vector<unsigned int> vertexToBeRemoved;
+    sofa::helper::vector<EdgeID> vertexToBeRemoved;
     helper::WriteAccessor< Data< sofa::helper::vector<Edge> > > m_edge = m_container->d_edge;
 
-    unsigned int lastEdgeIndex = m_container->getNumberOfEdges() - 1;
-    for (unsigned int i=0; i<indices.size(); ++i, --lastEdgeIndex)
+    size_t lastEdgeIndex = m_container->getNumberOfEdges() - 1;
+    for (size_t i=0; i<indices.size(); ++i, --lastEdgeIndex)
     {
         // now updates the shell information of the edge formely at the end of the array
         if(m_container->hasEdgesAroundVertex())
@@ -234,17 +234,17 @@ void EdgeSetTopologyModifier::removeEdgesProcess(const sofa::helper::vector<unsi
 
             const Edge &e = m_edge[ indices[i] ];
             const Edge &q = m_edge[ lastEdgeIndex ];
-            const unsigned int point0 = e[0], point1 = e[1];
-            const unsigned int point2 = q[0], point3 = q[1];
+            const PointID point0 = e[0], point1 = e[1];
+            const PointID point2 = q[0], point3 = q[1];
 
-            sofa::helper::vector< unsigned int > &shell0 = m_container->m_edgesAroundVertex[ point0 ];
+            sofa::helper::vector< EdgeID > &shell0 = m_container->m_edgesAroundVertex[ point0 ];
             shell0.erase( std::remove( shell0.begin(), shell0.end(), indices[i] ), shell0.end() );
             if(removeIsolatedItems && shell0.empty())
             {
                 vertexToBeRemoved.push_back(point0);
             }
 
-            sofa::helper::vector< unsigned int > &shell1 = m_container->m_edgesAroundVertex[ point1 ];
+            sofa::helper::vector< EdgeID > &shell1 = m_container->m_edgesAroundVertex[ point1 ];
             shell1.erase( std::remove( shell1.begin(), shell1.end(), indices[i] ), shell1.end() );
             if(removeIsolatedItems && shell1.empty())
             {
@@ -254,12 +254,12 @@ void EdgeSetTopologyModifier::removeEdgesProcess(const sofa::helper::vector<unsi
             if(indices[i] < lastEdgeIndex)
             {
                 //replaces the edge index oldEdgeIndex with indices[i] for the first vertex
-                sofa::helper::vector< unsigned int > &shell2 = m_container->m_edgesAroundVertex[ point2 ];
-                replace(shell2.begin(), shell2.end(), lastEdgeIndex, indices[i]);
+                sofa::helper::vector< EdgeID > &shell2 = m_container->m_edgesAroundVertex[ point2 ];
+                replace(shell2.begin(), shell2.end(), (EdgeID)lastEdgeIndex, indices[i]);
 
                 //replaces the edge index oldEdgeIndex with indices[i] for the second vertex
-                sofa::helper::vector< unsigned int > &shell3 = m_container->m_edgesAroundVertex[ point3 ];
-                replace(shell3.begin(), shell3.end(), lastEdgeIndex, indices[i]);
+                sofa::helper::vector< EdgeID > &shell3 = m_container->m_edgesAroundVertex[ point3 ];
+                replace(shell3.begin(), shell3.end(), (EdgeID)lastEdgeIndex, indices[i]);
             }
         }
 
@@ -298,12 +298,12 @@ void EdgeSetTopologyModifier::removePointsProcess(const sofa::helper::vector<Poi
         if(!m_container->hasEdgesAroundVertex())
             m_container->createEdgesAroundVertexArray();
 
-        unsigned int lastPoint = m_container->getNbPoints() - 1;
-        for (unsigned int i=0; i<indices.size(); ++i, --lastPoint)
+        size_t lastPoint = m_container->getNbPoints() - 1;
+        for (size_t i=0; i<indices.size(); ++i, --lastPoint)
         {
             // updating the edges connected to the point replacing the removed one:
             // for all edges connected to the last point
-            for (unsigned int j=0; j<m_container->m_edgesAroundVertex[lastPoint].size(); ++j)
+            for (size_t j=0; j<m_container->m_edgesAroundVertex[lastPoint].size(); ++j)
             {
                 const int edgeId = m_container->m_edgesAroundVertex[lastPoint][j];
                 // change the old index for the new one
@@ -335,18 +335,18 @@ void EdgeSetTopologyModifier::renumberPointsProcess( const sofa::helper::vector<
         if(m_container->hasEdgesAroundVertex())
         {
             // copy of the the edge vertex shell array
-            sofa::helper::vector< sofa::helper::vector< unsigned int > > edgesAroundVertex_cp = m_container->getEdgesAroundVertexArray();
+            sofa::helper::vector< sofa::helper::vector< EdgeID > > edgesAroundVertex_cp = m_container->getEdgesAroundVertexArray();
 
-            for (unsigned int i=0; i<index.size(); ++i)
+            for (size_t i=0; i<index.size(); ++i)
             {
                 m_container->m_edgesAroundVertex[i] = edgesAroundVertex_cp[ index[i] ];
             }
         }
 
-        for (unsigned int i=0; i<m_edge.size(); ++i)
+        for (size_t i=0; i<m_edge.size(); ++i)
         {
-            const unsigned int p0 = inv_index[ m_edge[i][0]  ];
-            const unsigned int p1 = inv_index[ m_edge[i][1]  ];
+            const EdgeID p0 = inv_index[ m_edge[i][0]  ];
+            const EdgeID p1 = inv_index[ m_edge[i][1]  ];
 
             // FIXME : Edges should not be flipped during simulations as it will break code such as FEM storing a rest shape.
             // Commented by pierre-jean.bensoussan@digital-trainers.com
@@ -373,7 +373,7 @@ void EdgeSetTopologyModifier::renumberPointsProcess( const sofa::helper::vector<
 }
 
 
-void EdgeSetTopologyModifier::swapEdgesProcess(const sofa::helper::vector< sofa::helper::vector< unsigned int > >& edgesPairs)
+void EdgeSetTopologyModifier::swapEdgesProcess(const sofa::helper::vector< sofa::helper::vector< EdgeID > >& edgesPairs)
 {
     if(!m_container->hasEdges())
         return;
@@ -382,33 +382,33 @@ void EdgeSetTopologyModifier::swapEdgesProcess(const sofa::helper::vector< sofa:
     sofa::helper::vector< Edge > v;
     v.reserve(2*edgesPairs.size());
 
-    sofa::helper::vector< unsigned int > edgeIndexList;
+    sofa::helper::vector< EdgeID > edgeIndexList;
     edgeIndexList.reserve(2*edgesPairs.size());
 
-    sofa::helper::vector<sofa::helper::vector<unsigned int> > ancestorsArray;
+    sofa::helper::vector<sofa::helper::vector<EdgeID> > ancestorsArray;
     ancestorsArray.reserve(edgesPairs.size());
 
-    unsigned int nbEdges = m_container->getNumberOfEdges();
+    size_t nbEdges = m_container->getNumberOfEdges();
 
-    for (unsigned int i=0; i<edgesPairs.size(); ++i)
+    for (size_t i=0; i<edgesPairs.size(); ++i)
     {
-        const unsigned int i1 = edgesPairs[i][0];
-        const unsigned int i2 = edgesPairs[i][1];
+        const EdgeID i1 = edgesPairs[i][0];
+        const EdgeID i2 = edgesPairs[i][1];
 
-        const unsigned int p11 = m_container->getEdge(i1)[0];
-        const unsigned int p12 = m_container->getEdge(i1)[1];
-        const unsigned int p21 = m_container->getEdge(i2)[0];
-        const unsigned int p22 = m_container->getEdge(i2)[1];
+        const EdgeID p11 = m_container->getEdge(i1)[0];
+        const EdgeID p12 = m_container->getEdge(i1)[1];
+        const EdgeID p21 = m_container->getEdge(i2)[0];
+        const EdgeID p22 = m_container->getEdge(i2)[1];
 
         const Edge e1(p11, p21), e2(p12, p22);
 
         v.push_back(e1);
         v.push_back(e2);
-        edgeIndexList.push_back(nbEdges);
-        edgeIndexList.push_back(nbEdges+1);
+        edgeIndexList.push_back((EdgeID)nbEdges);
+        edgeIndexList.push_back((EdgeID)nbEdges+1);
         nbEdges += 2;
 
-        sofa::helper::vector<unsigned int> ancestors(2);
+        sofa::helper::vector<EdgeID> ancestors(2);
         ancestors[0] = i1;
         ancestors[1] = i2;
         ancestorsArray.push_back(ancestors);
@@ -417,12 +417,12 @@ void EdgeSetTopologyModifier::swapEdgesProcess(const sofa::helper::vector< sofa:
     addEdgesProcess( v );
 
     // now warn about the creation
-    addEdgesWarning((unsigned int)v.size(), v, edgeIndexList, ancestorsArray);
+    addEdgesWarning(v.size(), v, edgeIndexList, ancestorsArray);
 
     // now warn about the destruction of the old edges
-    sofa::helper::vector< unsigned int > indices;
+    sofa::helper::vector< EdgeID > indices;
     indices.reserve(2*edgesPairs.size());
-    for (unsigned int i=0; i<edgesPairs.size(); ++i)
+    for (EdgeID i=0; i<edgesPairs.size(); ++i)
     {
         indices.push_back( edgesPairs[i][0]  );
         indices.push_back( edgesPairs[i][1] );
@@ -437,7 +437,7 @@ void EdgeSetTopologyModifier::swapEdgesProcess(const sofa::helper::vector< sofa:
 }
 
 
-void EdgeSetTopologyModifier::fuseEdgesProcess(const sofa::helper::vector< sofa::helper::vector< unsigned int > >& edgesPairs,
+void EdgeSetTopologyModifier::fuseEdgesProcess(const sofa::helper::vector< sofa::helper::vector< EdgeID > >& edgesPairs,
         const bool removeIsolatedPoints)
 {
     if(!m_container->hasEdges())
@@ -447,21 +447,21 @@ void EdgeSetTopologyModifier::fuseEdgesProcess(const sofa::helper::vector< sofa:
     sofa::helper::vector< Edge > v;
     v.reserve(edgesPairs.size());
 
-    sofa::helper::vector< unsigned int > edgeIndexList;
+    sofa::helper::vector< EdgeID > edgeIndexList;
     edgeIndexList.reserve(edgesPairs.size());
 
-    sofa::helper::vector<sofa::helper::vector<unsigned int> > ancestorsArray;
+    sofa::helper::vector<sofa::helper::vector<EdgeID> > ancestorsArray;
     ancestorsArray.reserve(edgesPairs.size());
 
-    unsigned int nbEdges=m_container->getNumberOfEdges();
+    size_t nbEdges=m_container->getNumberOfEdges();
 
-    for (unsigned int i=0; i<edgesPairs.size(); ++i)
+    for (size_t i=0; i<edgesPairs.size(); ++i)
     {
-        const unsigned int i1 = edgesPairs[i][0];
-        const unsigned int i2 = edgesPairs[i][1];
+        const EdgeID i1 = edgesPairs[i][0];
+        const EdgeID i2 = edgesPairs[i][1];
 
-        unsigned int p11 = m_container->getEdge(i1)[0];
-        unsigned int p22 = m_container->getEdge(i2)[1];
+        EdgeID p11 = m_container->getEdge(i1)[0];
+        EdgeID p22 = m_container->getEdge(i2)[1];
 
         if(p11 == p22)
         {
@@ -472,10 +472,10 @@ void EdgeSetTopologyModifier::fuseEdgesProcess(const sofa::helper::vector< sofa:
         const Edge e (p11, p22);
         v.push_back(e);
 
-        edgeIndexList.push_back(nbEdges);
+        edgeIndexList.push_back((EdgeID)nbEdges);
         nbEdges += 1;
 
-        sofa::helper::vector<unsigned int> ancestors(2);
+        sofa::helper::vector<EdgeID> ancestors(2);
         ancestors[0] = i1;
         ancestors[1] = i2;
         ancestorsArray.push_back(ancestors);
@@ -484,12 +484,12 @@ void EdgeSetTopologyModifier::fuseEdgesProcess(const sofa::helper::vector< sofa:
     addEdgesProcess( v );
 
     // now warn about the creation
-    addEdgesWarning((unsigned int)v.size(), v, edgeIndexList, ancestorsArray);
+    addEdgesWarning(v.size(), v, edgeIndexList, ancestorsArray);
 
     // now warn about the destruction of the old edges
-    sofa::helper::vector< unsigned int > indices;
+    sofa::helper::vector< EdgeID > indices;
     indices.reserve(2*edgesPairs.size());
-    for (unsigned int i=0; i<edgesPairs.size(); ++i)
+    for (size_t i=0; i<edgesPairs.size(); ++i)
     {
         indices.push_back( edgesPairs[i][0] );
         indices.push_back( edgesPairs[i][1] );
@@ -505,28 +505,28 @@ void EdgeSetTopologyModifier::fuseEdgesProcess(const sofa::helper::vector< sofa:
 }
 
 
-void EdgeSetTopologyModifier::splitEdgesProcess(sofa::helper::vector<unsigned int> &indices,
+void EdgeSetTopologyModifier::splitEdgesProcess(sofa::helper::vector<EdgeID> &indices,
         const bool removeIsolatedPoints)
 {
     if(!m_container->hasEdges())
         return;
 
-    sofa::helper::vector< sofa::helper::vector< double > > defaultBaryCoefs(indices.size());
+    sofa::helper::vector< sofa::helper::vector< SReal > > defaultBaryCoefs(indices.size());
 
-    sofa::helper::vector< sofa::helper::vector< unsigned int > > v(indices.size());
+    sofa::helper::vector< sofa::helper::vector< EdgeID > > v(indices.size());
 
     sofa::helper::vector< Edge >  edges;
     edges.reserve(2*indices.size());
 
-    sofa::helper::vector< unsigned int >  edgesIndex;
+    sofa::helper::vector< EdgeID >  edgesIndex;
     edgesIndex.reserve(2*indices.size());
 
-    unsigned int nbEdges = m_container->getNumberOfEdges();
+    size_t nbEdges = m_container->getNumberOfEdges();
 
-    for (unsigned int i=0; i<indices.size(); ++i)
+    for (size_t i=0; i<indices.size(); ++i)
     {
-        const unsigned int p1 = m_container->getEdge( indices[i] )[0];
-        const unsigned int p2 = m_container->getEdge( indices[i] )[1];
+        const EdgeID p1 = m_container->getEdge( indices[i] )[0];
+        const EdgeID p2 = m_container->getEdge( indices[i] )[1];
 
         // Adding the new point
         v[i].resize(2);
@@ -534,24 +534,24 @@ void EdgeSetTopologyModifier::splitEdgesProcess(sofa::helper::vector<unsigned in
         v[i][1] = p2;
 
         // Adding the new Edges
-        const Edge e1( p1, m_container->getNbPoints() + i );
-        const Edge e2( m_container->getNbPoints() + i, p2 );
+        const Edge e1( p1, (PointID)m_container->getNbPoints() + i );
+        const Edge e2( (PointID)m_container->getNbPoints() + i, p2 );
         edges.push_back( e1 );
         edges.push_back( e2 );
-        edgesIndex.push_back(nbEdges++);
-        edgesIndex.push_back(nbEdges++);
+        edgesIndex.push_back((EdgeID)nbEdges++);
+        edgesIndex.push_back((EdgeID)nbEdges++);
 
         defaultBaryCoefs[i].resize(2, 0.5f);
     }
 
-    addPointsProcess((unsigned int)indices.size());
+    addPointsProcess(indices.size());
 
     addEdgesProcess( edges );
 
     // warn about added points and edges
-    addPointsWarning((unsigned int)indices.size(), v, defaultBaryCoefs);
+    addPointsWarning(indices.size(), v, defaultBaryCoefs);
 
-    addEdgesWarning((unsigned int)edges.size(), edges, edgesIndex);
+    addEdgesWarning(edges.size(), edges, edgesIndex);
 
     // warn about old edges about to be removed
     removeEdgesWarning( indices );
@@ -563,27 +563,27 @@ void EdgeSetTopologyModifier::splitEdgesProcess(sofa::helper::vector<unsigned in
 }
 
 
-void EdgeSetTopologyModifier::splitEdgesProcess(sofa::helper::vector<unsigned int> &indices,
-        const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs,
+void EdgeSetTopologyModifier::splitEdgesProcess(sofa::helper::vector<EdgeID> &indices,
+        const sofa::helper::vector< sofa::helper::vector< SReal > >& baryCoefs,
         const bool removeIsolatedPoints)
 {
     if(!m_container->hasEdges())
         return;
 
-    sofa::helper::vector< sofa::helper::vector< unsigned int > > v(indices.size());
+    sofa::helper::vector< sofa::helper::vector< EdgeID > > v(indices.size());
 
     sofa::helper::vector< Edge >  edges;
     edges.reserve(2*indices.size());
 
-    sofa::helper::vector< unsigned int >  edgesIndex;
+    sofa::helper::vector< EdgeID >  edgesIndex;
     edgesIndex.reserve(2*indices.size());
 
-    unsigned int nbEdges = m_container->getNumberOfEdges();
+    size_t nbEdges = m_container->getNumberOfEdges();
 
-    for (unsigned int i=0; i<indices.size(); ++i)
+    for (size_t i=0; i<indices.size(); ++i)
     {
-        const unsigned int p1 = m_container->getEdge( indices[i] )[0];
-        const unsigned int p2 = m_container->getEdge( indices[i] )[1];
+        const EdgeID p1 = m_container->getEdge( indices[i] )[0];
+        const EdgeID p2 = m_container->getEdge( indices[i] )[1];
 
         // Adding the new point
         v[i].resize(2);
@@ -591,22 +591,22 @@ void EdgeSetTopologyModifier::splitEdgesProcess(sofa::helper::vector<unsigned in
         v[i][1] = p2;
 
         // Adding the new Edges
-        const Edge e1( p1, m_container->getNbPoints() + i );
-        const Edge e2( m_container->getNbPoints() + i, p2 );
+        const Edge e1( p1, (PointID)m_container->getNbPoints() + i );
+        const Edge e2( (PointID)m_container->getNbPoints() + i, p2 );
         edges.push_back( e1 );
         edges.push_back( e2 );
-        edgesIndex.push_back(nbEdges++);
-        edgesIndex.push_back(nbEdges++);
+        edgesIndex.push_back((EdgeID)nbEdges++);
+        edgesIndex.push_back((EdgeID)nbEdges++);
     }
 
-    addPointsProcess((unsigned int)indices.size());
+    addPointsProcess(indices.size());
 
     addEdgesProcess( edges );
 
     // warn about added points and edges
-    addPointsWarning((unsigned int)indices.size(), v, baryCoefs);
+    addPointsWarning(indices.size(), v, baryCoefs);
 
-    addEdgesWarning((unsigned int)edges.size(), edges, edgesIndex);
+    addEdgesWarning(edges.size(), edges, edgesIndex);
 
     // warn about old edges about to be removed
     removeEdgesWarning( indices );
@@ -617,11 +617,11 @@ void EdgeSetTopologyModifier::splitEdgesProcess(sofa::helper::vector<unsigned in
     removeEdgesProcess( indices, removeIsolatedPoints );
 }
 
-void EdgeSetTopologyModifier::removeEdges(const sofa::helper::vector< unsigned int >& edgeIds,
+void EdgeSetTopologyModifier::removeEdges(const sofa::helper::vector< EdgeID >& edgeIds,
         const bool removeIsolatedPoints, const bool resetTopoChange)
 {
-    sofa::helper::vector<unsigned int> edgeIds_filtered;
-    for (unsigned int i = 0; i < edgeIds.size(); i++)
+    sofa::helper::vector<EdgeID> edgeIds_filtered;
+    for (size_t i = 0; i < edgeIds.size(); i++)
     {
         if( edgeIds[i] >= m_container->getNumberOfEdges())
             dmsg_error() << "Unable to remoev and edges: "<< edgeIds[i] <<" is out of bound and won't be removed." ;
@@ -642,13 +642,13 @@ void EdgeSetTopologyModifier::removeEdges(const sofa::helper::vector< unsigned i
     m_container->checkTopology();
 }
 
-void EdgeSetTopologyModifier::removeItems(const sofa::helper::vector< unsigned int >& items)
+void EdgeSetTopologyModifier::removeItems(const sofa::helper::vector< EdgeID >& items)
 {
     removeEdges(items);
 }
 
-void EdgeSetTopologyModifier::renumberPoints( const sofa::helper::vector<unsigned int> &index,
-        const sofa::helper::vector<unsigned int> &inv_index)
+void EdgeSetTopologyModifier::renumberPoints( const sofa::helper::vector<EdgeID> &index,
+        const sofa::helper::vector<EdgeID> &inv_index)
 {
     /// add the topological changes in the queue
     renumberPointsWarning(index, inv_index);
@@ -662,45 +662,45 @@ void EdgeSetTopologyModifier::renumberPoints( const sofa::helper::vector<unsigne
 
 void EdgeSetTopologyModifier::addEdges(const sofa::helper::vector< Edge >& edges)
 {
-    unsigned int nEdges = m_container->getNumberOfEdges();
+    size_t nEdges = m_container->getNumberOfEdges();
 
     /// actually add edges in the topology container
     addEdgesProcess(edges);
 
-    sofa::helper::vector<unsigned int> edgesIndex;
+    sofa::helper::vector<EdgeID> edgesIndex;
     edgesIndex.reserve(edges.size());
 
-    for (unsigned int i=0; i<edges.size(); ++i)
+    for (size_t i=0; i<edges.size(); ++i)
     {
-        edgesIndex.push_back(nEdges+i);
+        edgesIndex.push_back((EdgeID)nEdges+i);
     }
 
     // add topology event in the stack of topological events
-    addEdgesWarning((unsigned int)edges.size(), edges, edgesIndex);
+    addEdgesWarning(edges.size(), edges, edgesIndex);
 
     // inform other objects that the edges are already added
     propagateTopologicalChanges();
 }
 
 void EdgeSetTopologyModifier::addEdges(const sofa::helper::vector< Edge >& edges,
-        const sofa::helper::vector< sofa::helper::vector< unsigned int > > & ancestors,
-        const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs)
+        const sofa::helper::vector< sofa::helper::vector< EdgeID > > & ancestors,
+        const sofa::helper::vector< sofa::helper::vector< SReal > >& baryCoefs)
 {
-    unsigned int nEdges = m_container->getNumberOfEdges();
+    size_t nEdges = m_container->getNumberOfEdges();
 
     /// actually add edges in the topology container
     addEdgesProcess(edges);
 
-    sofa::helper::vector<unsigned int> edgesIndex;
+    sofa::helper::vector<EdgeID> edgesIndex;
     edgesIndex.reserve(edges.size());
 
-    for (unsigned int i=0; i<edges.size(); ++i)
+    for (size_t i=0; i<edges.size(); ++i)
     {
-        edgesIndex.push_back(nEdges+i);
+        edgesIndex.push_back((EdgeID)nEdges+i);
     }
 
     // add topology event in the stack of topological events
-    addEdgesWarning((unsigned int)edges.size(), edges, edgesIndex, ancestors, baryCoefs);
+    addEdgesWarning(edges.size(), edges, edgesIndex, ancestors, baryCoefs);
 
     // inform other objects that the edges are already added
     propagateTopologicalChanges();
@@ -709,48 +709,48 @@ void EdgeSetTopologyModifier::addEdges(const sofa::helper::vector< Edge >& edges
 void EdgeSetTopologyModifier::addEdges(const sofa::helper::vector< Edge >& edges,
         const sofa::helper::vector< core::topology::EdgeAncestorElem >& ancestorElems)
 {
-    unsigned int nEdges = m_container->getNumberOfEdges();
+    size_t nEdges = m_container->getNumberOfEdges();
 
     assert(ancestorElems.size() == edges.size());
 
     /// actually add edges in the topology container
     addEdgesProcess(edges);
 
-    sofa::helper::vector<unsigned int> edgesIndex;
+    sofa::helper::vector<EdgeID> edgesIndex;
     edgesIndex.resize(edges.size());
-    for (unsigned int i=0; i<edges.size(); ++i)
+    for (size_t i=0; i<edges.size(); ++i)
     {
-        edgesIndex[i] = nEdges+i;
+        edgesIndex[i] = (EdgeID)nEdges+i;
     }
 
     // add topology event in the stack of topological events
-    addEdgesWarning((unsigned int)edges.size(), edges, edgesIndex, ancestorElems);
+    addEdgesWarning(edges.size(), edges, edgesIndex, ancestorElems);
 
     // inform other objects that the edges are already added
     propagateTopologicalChanges();
 }
 
-void EdgeSetTopologyModifier::swapEdges(const sofa::helper::vector< sofa::helper::vector< unsigned int > >& edgesPairs)
+void EdgeSetTopologyModifier::swapEdges(const sofa::helper::vector< sofa::helper::vector< EdgeID > >& edgesPairs)
 {
     swapEdgesProcess(edgesPairs);
     m_container->checkTopology();
 }
 
-void EdgeSetTopologyModifier::fuseEdges(const sofa::helper::vector< sofa::helper::vector< unsigned int > >& edgesPairs, const bool removeIsolatedPoints)
+void EdgeSetTopologyModifier::fuseEdges(const sofa::helper::vector< sofa::helper::vector< EdgeID > >& edgesPairs, const bool removeIsolatedPoints)
 {
     fuseEdgesProcess(edgesPairs, removeIsolatedPoints);
     m_container->checkTopology();
 }
 
-void EdgeSetTopologyModifier::splitEdges( sofa::helper::vector<unsigned int> &indices,
+void EdgeSetTopologyModifier::splitEdges( sofa::helper::vector<EdgeID> &indices,
         const bool removeIsolatedPoints)
 {
     splitEdgesProcess(indices, removeIsolatedPoints);
     m_container->checkTopology();
 }
 
-void EdgeSetTopologyModifier::splitEdges( sofa::helper::vector<unsigned int> &indices,
-        const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs,
+void EdgeSetTopologyModifier::splitEdges( sofa::helper::vector<EdgeID> &indices,
+        const sofa::helper::vector< sofa::helper::vector< SReal > >& baryCoefs,
         const bool removeIsolatedPoints)
 {
     splitEdgesProcess(indices, baryCoefs, removeIsolatedPoints);
@@ -772,7 +772,7 @@ void EdgeSetTopologyModifier::resortCuthillMckee(sofa::helper::vector<int>& inve
 
     const sofa::helper::vector<Edge> &ea=m_container->getEdgeArray();
 
-    for (unsigned int k=0; k<ea.size(); ++k)
+    for (size_t k=0; k<ea.size(); ++k)
     {
         add_edge(ea[k][0], ea[k][1], G);
     }
@@ -803,27 +803,27 @@ void EdgeSetTopologyModifier::resortCuthillMckee(sofa::helper::vector<int>& inve
 
 
 
-void EdgeSetTopologyModifier::movePointsProcess (const sofa::helper::vector <unsigned int>& id,
-        const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors,
-        const sofa::helper::vector< sofa::helper::vector< double > >& coefs,
+void EdgeSetTopologyModifier::movePointsProcess (const sofa::helper::vector <PointID>& id,
+        const sofa::helper::vector< sofa::helper::vector< PointID > >& ancestors,
+        const sofa::helper::vector< sofa::helper::vector< SReal > >& coefs,
         const bool moveDOF)
 {
     SOFA_UNUSED(moveDOF);
-    unsigned int nbrVertex = (unsigned int)id.size();
+    size_t nbrVertex = id.size();
     bool doublet;
-    sofa::helper::vector<unsigned int> edgesAroundVertex2Move;
+    sofa::helper::vector<EdgeID> edgesAroundVertex2Move;
     sofa::helper::vector< Edge > edgeArray;
 
     // Step 1/4 - Creating trianglesAroundVertex to moved due to moved points:
-    for (unsigned int i = 0; i<nbrVertex; ++i)
+    for (size_t i = 0; i<nbrVertex; ++i)
     {
-        const sofa::helper::vector <unsigned int>& edgesAroundVertex = m_container->getEdgesAroundVertexArray()[ id[i] ];
+        const sofa::helper::vector <EdgeID>& edgesAroundVertex = m_container->getEdgesAroundVertexArray()[ id[i] ];
 
-        for (unsigned int j = 0; j<edgesAroundVertex.size(); ++j)
+        for (size_t j = 0; j<edgesAroundVertex.size(); ++j)
         {
             doublet = false;
 
-            for (unsigned int k =0; k<edgesAroundVertex2Move.size(); ++k) //Avoid double
+            for (size_t k =0; k<edgesAroundVertex2Move.size(); ++k) //Avoid double
             {
                 if (edgesAroundVertex2Move[k] == edgesAroundVertex[j])
                 {
@@ -838,7 +838,7 @@ void EdgeSetTopologyModifier::movePointsProcess (const sofa::helper::vector <uns
         }
     }
 
-    std::sort( edgesAroundVertex2Move.begin(), edgesAroundVertex2Move.end(), std::greater<unsigned int>() );
+    std::sort( edgesAroundVertex2Move.begin(), edgesAroundVertex2Move.end(), std::greater<EdgeID>() );
 
     // Step 2/4 - Create event to delete all elements before moving and propagate it:
     EdgesMoved_Removing *ev1 = new EdgesMoved_Removing (edgesAroundVertex2Move);
@@ -853,7 +853,7 @@ void EdgeSetTopologyModifier::movePointsProcess (const sofa::helper::vector <uns
     // Step 4/4 - Create event to recompute all elements concerned by moving and propagate it:
 
     // Creating the corresponding array of Triangles for ancestors
-    for (unsigned int i = 0; i<edgesAroundVertex2Move.size(); i++)
+    for (size_t i = 0; i<edgesAroundVertex2Move.size(); i++)
         edgeArray.push_back (m_container->getEdgeArray()[ edgesAroundVertex2Move[i] ]);
 
     EdgesMoved_Adding *ev2 = new EdgesMoved_Adding (edgesAroundVertex2Move, edgeArray);
@@ -862,7 +862,7 @@ void EdgeSetTopologyModifier::movePointsProcess (const sofa::helper::vector <uns
 
 
 
-bool EdgeSetTopologyModifier::removeConnectedComponents(unsigned int elemID)
+bool EdgeSetTopologyModifier::removeConnectedComponents(EdgeID elemID)
 {
     if(!m_container)
     {
@@ -870,13 +870,13 @@ bool EdgeSetTopologyModifier::removeConnectedComponents(unsigned int elemID)
         return false;
     }
 
-    sofa::helper::vector <unsigned int> elems = m_container->getConnectedElement(elemID);
+    sofa::helper::vector <EdgeID> elems = m_container->getConnectedElement(elemID);
     this->removeItems(elems);
     return true;
 }
 
 
-bool EdgeSetTopologyModifier::removeConnectedElements(unsigned int elemID)
+bool EdgeSetTopologyModifier::removeConnectedElements(EdgeID elemID)
 {
     if(!m_container)
     {
@@ -884,7 +884,7 @@ bool EdgeSetTopologyModifier::removeConnectedElements(unsigned int elemID)
         return false;
     }
 
-    sofa::helper::vector <unsigned int> elems = m_container->getElementAroundElement(elemID);
+    sofa::helper::vector <EdgeID> elems = m_container->getElementAroundElement(elemID);
     this->removeItems(elems);
     return true;
 }
@@ -896,7 +896,7 @@ bool EdgeSetTopologyModifier::removeIsolatedElements()
 }
 
 
-bool EdgeSetTopologyModifier::removeIsolatedElements(unsigned int scaleElem)
+bool EdgeSetTopologyModifier::removeIsolatedElements(size_t scaleElem)
 {
     if(!m_container)
     {
@@ -904,9 +904,9 @@ bool EdgeSetTopologyModifier::removeIsolatedElements(unsigned int scaleElem)
         return false;
     }
 
-    unsigned int nbr = this->m_container->getNumberOfElements();
-    sofa::helper::vector <unsigned int> elemAll = m_container->getConnectedElement(0);
-    sofa::helper::vector <unsigned int> elem, elemMax, elemToRemove;
+    size_t nbr = this->m_container->getNumberOfElements();
+    sofa::helper::vector <EdgeID> elemAll = m_container->getConnectedElement(0);
+    sofa::helper::vector <EdgeID> elem, elemMax, elemToRemove;
 
     if (nbr == elemAll.size()) // nothing to do
         return true;

--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyModifier.h
@@ -74,8 +74,8 @@ public:
     *
     */
     virtual void addEdges( const sofa::helper::vector< Edge >& edges,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > > & ancestors,
-            const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs) ;
+            const sofa::helper::vector< sofa::helper::vector< EdgeID > > & ancestors,
+            const sofa::helper::vector< sofa::helper::vector< SReal > >& baryCoefs) ;
     
     /** \brief add a set of edges
     @param edges an array of pair of vertex indices describing the edge to be created
@@ -90,42 +90,42 @@ public:
     *
     * \sa addEdgesProcess
     */
-    virtual void addEdgesWarning(const unsigned int nEdges);
+    virtual void addEdgesWarning(const size_t nEdges);
 
     /** \brief Sends a message to warn that some edges were added in this topology.
     *
     * \sa addEdgesProcess
     */
-    virtual void addEdgesWarning(const unsigned int nEdges,
+    virtual void addEdgesWarning(const size_t nEdges,
             const sofa::helper::vector< Edge >& edgesList,
-            const sofa::helper::vector< unsigned int >& edgesIndexList);
+            const sofa::helper::vector< EdgeID >& edgesIndexList);
 
     /** \brief Sends a message to warn that some edges were added in this topology.
     *
     * \sa addEdgesProcess
     */
-    virtual void addEdgesWarning(const unsigned int nEdges,
+    virtual void addEdgesWarning(const size_t nEdges,
             const sofa::helper::vector< Edge >& edgesList,
-            const sofa::helper::vector< unsigned int >& edgesIndexList,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > > & ancestors);
+            const sofa::helper::vector< EdgeID >& edgesIndexList,
+            const sofa::helper::vector< sofa::helper::vector< EdgeID > > & ancestors);
 
     /** \brief Sends a message to warn that some edges were added in this topology.
     *
     * \sa addEdgesProcess
     */
-    virtual void addEdgesWarning(const unsigned int nEdges,
+    virtual void addEdgesWarning(const size_t nEdges,
             const sofa::helper::vector< Edge >& edgesList,
-            const sofa::helper::vector< unsigned int >& edgesIndexList,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > > & ancestors,
-            const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs);
+            const sofa::helper::vector< EdgeID >& edgesIndexList,
+            const sofa::helper::vector< sofa::helper::vector< EdgeID > > & ancestors,
+            const sofa::helper::vector< sofa::helper::vector< SReal > >& baryCoefs);
     
     /** \brief Sends a message to warn that some edges were added in this topology.
     *
     * \sa addEdgesProcess
     */
-    virtual void addEdgesWarning(const unsigned int nEdges,
+    virtual void addEdgesWarning(const size_t nEdges,
             const sofa::helper::vector< Edge >& edgesList,
-            const sofa::helper::vector< unsigned int >& edgesIndexList,
+            const sofa::helper::vector< EdgeID >& edgesIndexList,
             const sofa::helper::vector< core::topology::EdgeAncestorElem >& ancestorElems);
 
     /** \brief Effectively add an edge.
@@ -143,7 +143,7 @@ public:
     * \sa removeEdgesProcess
     */
     // side effect : edges are sorted first
-    virtual void removeEdgesWarning(/*const*/ sofa::helper::vector<unsigned int> &edges);
+    virtual void removeEdgesWarning(/*const*/ sofa::helper::vector<EdgeID> &edges);
 
     /** \brief Effectively Remove a subset of edges. Eventually remove isolated vertices
     *
@@ -156,32 +156,32 @@ public:
     *
     * @param removeIsolatedItems if true isolated vertices are also removed
     */
-    virtual void removeEdgesProcess(const sofa::helper::vector<unsigned int> &indices, const bool removeIsolatedItems = false);
+    virtual void removeEdgesProcess(const sofa::helper::vector<EdgeID> &indices, const bool removeIsolatedItems = false);
 
     /** \brief Swap the edges.
     *
     */
-    virtual void swapEdgesProcess(const sofa::helper::vector< sofa::helper::vector< unsigned int > >& edgesPairs);
+    virtual void swapEdgesProcess(const sofa::helper::vector< sofa::helper::vector< EdgeID > >& edgesPairs);
 
     /** \brief Fuse the edges.
     *
     * @param removeIsolatedItems if true isolated vertices are also removed
     */
-    virtual void fuseEdgesProcess(const sofa::helper::vector< sofa::helper::vector< unsigned int > >& edgesPairs, const bool removeIsolatedPoints = true);
+    virtual void fuseEdgesProcess(const sofa::helper::vector< sofa::helper::vector< EdgeID > >& edgesPairs, const bool removeIsolatedPoints = true);
 
     /** \brief Split the edges.
     *
     * @param removeIsolatedItems if true isolated vertices are also removed
     */
-    virtual void splitEdgesProcess(/*const*/ sofa::helper::vector<unsigned int> &indices,
+    virtual void splitEdgesProcess(/*const*/ sofa::helper::vector<EdgeID> &indices,
             const bool removeIsolatedPoints = true);
 
     /** \brief Split the edges.
     *
     * @param removeIsolatedItems if true isolated vertices are also removed
     */
-    virtual void splitEdgesProcess(/*const*/ sofa::helper::vector<unsigned int> &indices,
-            const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs,
+    virtual void splitEdgesProcess(/*const*/ sofa::helper::vector<EdgeID> &indices,
+            const sofa::helper::vector< sofa::helper::vector< SReal > >& baryCoefs,
             const bool removeIsolatedPoints = true);
 
     /** \brief Add some points to this topology.
@@ -214,35 +214,35 @@ public:
     @param edges an array of edge indices to be removed (note that the array is not const since it needs to be sorted)
     *
     */
-    virtual void removeEdges(const sofa::helper::vector<unsigned int> &edgeIds,
+    virtual void removeEdges(const sofa::helper::vector<EdgeID> &edgeIds,
             const bool removeIsolatedPoints = true, const bool resetTopoChange = true);
 
     /** \brief Generic method to remove a list of items.
     */
-    virtual void removeItems(const sofa::helper::vector<unsigned int> &items) override;
+    virtual void removeItems(const sofa::helper::vector<EdgeID> &items) override;
 
     /** \brief Generic method for points renumbering
     */
-    virtual void renumberPoints( const sofa::helper::vector<unsigned int> & index,
-            const sofa::helper::vector<unsigned int> & inv_index) override;
+    virtual void renumberPoints( const sofa::helper::vector<PointID> & index,
+            const sofa::helper::vector<PointID> & inv_index) override;
 
     /** \brief Swap a list of pair edges, replacing each edge pair ((p11, p12), (p21, p22)) by the edge pair ((p11, p21), (p12, p22))
     *
     */
-    virtual void swapEdges(const sofa::helper::vector< sofa::helper::vector< unsigned int > >& edgesPairs);
+    virtual void swapEdges(const sofa::helper::vector< sofa::helper::vector< EdgeID > >& edgesPairs);
 
     /** \brief Fuse a list of pair edges, replacing each edge pair ((p11, p12), (p21, p22)) by one edge (p11, p22)
     *
     * @param removeIsolatedPoints if true isolated vertices are also removed
     */
-    virtual void fuseEdges(const sofa::helper::vector< sofa::helper::vector< unsigned int > >& edgesPairs, const bool removeIsolatedPoints = true);
+    virtual void fuseEdges(const sofa::helper::vector< sofa::helper::vector< EdgeID > >& edgesPairs, const bool removeIsolatedPoints = true);
 
     /** \brief Split an array of edges, replacing each edge (p1, p2) by two edges (p1, p3) and (p3, p2) where p3 is the new vertex
     * On each edge, a vertex is created based on its barycentric coordinates
     *
     * @param removeIsolatedPoints if true isolated vertices are also removed
     */
-    virtual void splitEdges( sofa::helper::vector<unsigned int> &indices,
+    virtual void splitEdges( sofa::helper::vector<EdgeID> &indices,
             const bool removeIsolatedPoints = true);
 
     /** \brief Split an array of edges, replacing each edge (p1, p2) by two edges (p1, p3) and (p3, p2) where p3 is the new vertex
@@ -250,8 +250,8 @@ public:
     *
     * @param removeIsolatedPoints if true isolated vertices are also removed
     */
-    virtual void splitEdges( sofa::helper::vector<unsigned int> &indices,
-            const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs,
+    virtual void splitEdges( sofa::helper::vector<EdgeID> &indices,
+            const sofa::helper::vector< sofa::helper::vector< SReal > >& baryCoefs,
             const bool removeIsolatedPoints = true);
 
     /** \brief Gives the optimal vertex permutation according to the Reverse CuthillMckee algorithm (use BOOST GRAPH LIBRAIRY)
@@ -280,14 +280,14 @@ public:
     * @param elemID The ID of the input element.
     * @return false if something goes wrong during the process.
     */
-    virtual bool removeConnectedComponents(unsigned int elemID);
+    virtual bool removeConnectedComponents(EdgeID elemID);
 
     /** \brief Given an element indice, it will remove all elements directly connected to the input one.
     *
     * @param elemID The ID of the input element.
     * @return false if something goes wrong during the process.
     */
-    virtual bool removeConnectedElements(unsigned int elemID);
+    virtual bool removeConnectedElements(EdgeID elemID);
 
     /** \brief If several connected components are detected, it will keep only the biggest one and remove all the rest.
     * Warning: if two connected components have the same number of element and are the biggest. It will keep the first one.
@@ -301,7 +301,7 @@ public:
     * @param scaleElem: threshold number size under which connected component will be removed.
     * @return false if something goes wrong during the process.
     */
-    virtual bool removeIsolatedElements(unsigned int scaleElem);
+    virtual bool removeIsolatedElements(size_t scaleElem);
 
 private:
     EdgeSetTopologyContainer* 	m_container;

--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyModifier.h
@@ -188,7 +188,7 @@ public:
     *
     * \sa addPointsWarning
     */
-    virtual void addPointsProcess(const unsigned int nPoints) override;
+    virtual void addPointsProcess(const size_t nPoints) override;
 
     /** \brief Remove a subset of points
     *
@@ -198,7 +198,7 @@ public:
     * \sa removePointsWarning
     * Important : the points are actually deleted from the mechanical object's state vectors iff (removeDOF == true)
     */
-    virtual void removePointsProcess(const sofa::helper::vector<unsigned int> &indices,
+    virtual void removePointsProcess(const sofa::helper::vector<PointID> &indices,
             const bool removeDOF = true) override;
 
     /** \brief Reorder this topology.
@@ -206,8 +206,8 @@ public:
     * Important : the points are actually renumbered in the mechanical object's state vectors iff (renumberDOF == true)
     * \see MechanicalObject::renumberValues
     */
-    virtual void renumberPointsProcess( const sofa::helper::vector<unsigned int> &index,
-            const sofa::helper::vector<unsigned int> &/*inv_index*/,
+    virtual void renumberPointsProcess( const sofa::helper::vector<PointID> &index,
+            const sofa::helper::vector<PointID> &/*inv_index*/,
             const bool renumberDOF = true) override;
 
     /** \brief Remove a set of edges
@@ -267,9 +267,9 @@ public:
      * @param coefs The barycoef to locate new coord relatively to ancestors.
      * @moveDOF bool allowing the move (default true)
      */
-    virtual void movePointsProcess (const sofa::helper::vector <unsigned int>& id,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors,
-            const sofa::helper::vector< sofa::helper::vector< double > >& coefs,
+    virtual void movePointsProcess (const sofa::helper::vector <PointID>& id,
+            const sofa::helper::vector< sofa::helper::vector< PointID > >& ancestors,
+            const sofa::helper::vector< sofa::helper::vector< SReal > >& coefs,
             const bool moveDOF = true) override;
 
 

--- a/SofaKernel/modules/SofaBaseTopology/HexahedronSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/HexahedronSetGeometryAlgorithms.inl
@@ -671,7 +671,7 @@ void HexahedronSetGeometryAlgorithms< DataTypes >::findNearestElements(const Vec
         helper::vector<defaulttype::Vector3>& baryC,
         helper::vector<Real>& dist) const
 {
-    for(unsigned int i=0; i<pos.size(); ++i)
+    for(size_t i=0; i<pos.size(); ++i)
     {
         elem[i] = findNearestElement(pos[i], baryC[i], dist[i]);
     }
@@ -703,7 +703,7 @@ int HexahedronSetGeometryAlgorithms< DataTypes >::findNearestElementInRestPos(co
 template< class DataTypes>
 void HexahedronSetGeometryAlgorithms< DataTypes >::findNearestElementsInRestPos( const VecCoord& pos, helper::vector<int>& elem, helper::vector<defaulttype::Vector3>& baryC, helper::vector<Real>& dist) const
 {
-    for(unsigned int i=0; i<pos.size(); ++i)
+    for(size_t i=0; i<pos.size(); ++i)
     {
         elem[i] = findNearestElementInRestPos(pos[i], baryC[i], dist[i]);
     }
@@ -817,7 +817,7 @@ void HexahedronSetGeometryAlgorithms<DataTypes>::writeMSHfile(const char *filena
 
     myfile << hea.size() <<"\n";
 
-    for(unsigned int i=0; i<hea.size(); ++i)
+    for(size_t i=0; i<hea.size(); ++i)
     {
         myfile << i+1 << " 5 1 1 8 " << hea[i][4]+1 << " " << hea[i][5]+1 << " "
                 << hea[i][1]+1 << " " << hea[i][0]+1 << " "
@@ -851,7 +851,7 @@ void HexahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visual
         const sofa::helper::vector<Hexahedron> &hexaArray = this->m_topology->getHexahedra();
 
         std::vector<defaulttype::Vector3> positions;
-        for (unsigned int i =0; i<hexaArray.size(); i++)
+        for (size_t i =0; i<hexaArray.size(); i++)
         {
 
             Hexahedron the_hexa = hexaArray[i];
@@ -886,7 +886,7 @@ void HexahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visual
 
         sofa::helper::vector <sofa::defaulttype::Vector3> hexaCoords;
 
-        for (unsigned int i = 0; i<hexaArray.size(); i++)
+        for (size_t i = 0; i<hexaArray.size(); i++)
         {
             const Hexahedron& H = hexaArray[i];
 

--- a/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyContainer.cpp
@@ -101,25 +101,25 @@ void HexahedronSetTopologyContainer::createEdgeSetArray()
     }
 
     // create a temporary map to find redundant edges
-    std::map<Edge,unsigned int> edgeMap;
+    std::map<Edge,EdgeID> edgeMap;
     helper::WriteAccessor< Data< sofa::helper::vector<Edge> > > m_edge = d_edge;
     helper::ReadAccessor< Data< sofa::helper::vector<Hexahedron> > > m_hexahedron = d_hexahedron;
 
     /// create the m_edge array at the same time than it fills the m_edgesInHexahedron array
-    for(unsigned int i=0; i<m_hexahedron.size(); ++i)
+    for(size_t i=0; i<m_hexahedron.size(); ++i)
     {
         const Hexahedron &t = m_hexahedron[i];
-        for(unsigned int j=0; j<12; ++j)
+        for(PointID j=0; j<12; ++j)
         {
-            unsigned int v1 = t[edgesInHexahedronArray[j][0]];
-            unsigned int v2 = t[edgesInHexahedronArray[j][1]];
+            PointID v1 = t[edgesInHexahedronArray[j][0]];
+            PointID v2 = t[edgesInHexahedronArray[j][1]];
             const Edge e((v1<v2) ? Edge(v1,v2) : Edge(v2,v1));
 
             if(edgeMap.find(e)==edgeMap.end())
             {
                 // edge not in edgeMap so create a new one
-                const unsigned int edgeIndex = (unsigned int)edgeMap.size();
-                edgeMap[e] = edgeIndex;
+                const size_t edgeIndex = edgeMap.size();
+                edgeMap[e] = (EdgeID)edgeIndex;
                 m_edge.push_back(e);
             }
         }
@@ -137,12 +137,12 @@ void HexahedronSetTopologyContainer::createEdgesInHexahedronArray()
     m_edgesInHexahedron.resize( getNumberOfHexahedra());
     helper::ReadAccessor< Data< sofa::helper::vector<Hexahedron> > > m_hexahedron = d_hexahedron;
 
-    for(unsigned int i=0; i<m_hexahedron.size(); ++i)
+    for(size_t i=0; i<m_hexahedron.size(); ++i)
     {
         const Hexahedron &t = m_hexahedron[i];
 
         // adding edge i in the edge shell of both points
-        for(unsigned int j=0; j<12; ++j)
+        for(PointID j=0; j<12; ++j)
         {
             const int edgeIndex = getEdgeIndex(t[edgesInHexahedronArray[j][0]],
                     t[edgesInHexahedronArray[j][1]]);
@@ -163,11 +163,11 @@ void HexahedronSetTopologyContainer::createQuadSetArray()
     }
 
     // create a temporary map to find redundant quads
-    std::map<Quad,unsigned int> quadMap;
+    std::map<Quad, QuadID> quadMap;
     helper::WriteAccessor< Data< sofa::helper::vector<Quad> > > m_quad = d_quad;
     helper::ReadAccessor< Data< sofa::helper::vector<Hexahedron> > > m_hexahedron = d_hexahedron;
 
-    for(unsigned int i=0; i<m_hexahedron.size(); ++i)
+    for(size_t i=0; i<m_hexahedron.size(); ++i)
     {
         const Hexahedron &h = m_hexahedron[i];
 
@@ -190,13 +190,13 @@ void HexahedronSetTopologyContainer::createQuadSetArray()
         }
 
         // sort vertices in lexicographics order
-        unsigned int quadIndex;
+        QuadID quadIndex;
         Quad qu(v[0],v[3],v[2],v[1]);
-        std::map<Quad,unsigned int>::iterator itt = quadMap.find(qu);
+        std::map<Quad,QuadID>::iterator itt = quadMap.find(qu);
         if(itt==quadMap.end())
         {
             // quad not in edgeMap so create a new one
-            quadIndex=(unsigned int)m_quad.size();
+            quadIndex=(QuadID)m_quad.size();
             quadMap[qu]=quadIndex;
             qu=Quad(v[0],v[1],v[2],v[3]);
             quadMap[qu]=quadIndex;
@@ -223,7 +223,7 @@ void HexahedronSetTopologyContainer::createQuadSetArray()
         if(itt==quadMap.end())
         {
             // quad not in edgeMap so create a new one
-            quadIndex=(unsigned int)m_quad.size();
+            quadIndex=(QuadID)m_quad.size();
             quadMap[qu]=quadIndex;
             qu=Quad(v[0],v[1],v[2],v[3]);
             quadMap[qu]=quadIndex;
@@ -247,7 +247,7 @@ void HexahedronSetTopologyContainer::createQuadSetArray()
         if(itt==quadMap.end())
         {
             // quad not in edgeMap so create a new one
-            quadIndex=(unsigned int)m_quad.size();
+            quadIndex=(QuadID)m_quad.size();
             quadMap[qu]=quadIndex;
             qu=Quad(v[0],v[1],v[2],v[3]);
             quadMap[qu]=quadIndex;
@@ -271,7 +271,7 @@ void HexahedronSetTopologyContainer::createQuadSetArray()
         if(itt==quadMap.end())
         {
             // quad not in edgeMap so create a new one
-            quadIndex=(unsigned int)m_quad.size();
+            quadIndex=(QuadID)m_quad.size();
             quadMap[qu]=quadIndex;
             qu=Quad(v[0],v[1],v[2],v[3]);
             quadMap[qu]=quadIndex;
@@ -298,7 +298,7 @@ void HexahedronSetTopologyContainer::createQuadSetArray()
         if(itt==quadMap.end())
         {
             // quad not in edgeMap so create a new one
-            quadIndex=(unsigned int)m_quad.size();
+            quadIndex=(QuadID)m_quad.size();
             quadMap[qu]=quadIndex;
             qu=Quad(v[0],v[1],v[2],v[3]);
             quadMap[qu]=quadIndex;
@@ -325,7 +325,7 @@ void HexahedronSetTopologyContainer::createQuadSetArray()
         if(itt==quadMap.end())
         {
             // quad not in edgeMap so create a new one
-            quadIndex=(unsigned int)m_quad.size();
+            quadIndex=(QuadID)m_quad.size();
             quadMap[qu]=quadIndex;
             qu=Quad(v[0],v[1],v[2],v[3]);
             quadMap[qu]=quadIndex;
@@ -346,7 +346,7 @@ void HexahedronSetTopologyContainer::createQuadsInHexahedronArray()
     m_quadsInHexahedron.resize( getNumberOfHexahedra());
     helper::ReadAccessor< Data< sofa::helper::vector<Hexahedron> > > m_hexahedron = d_hexahedron;
 
-    for(unsigned int i = 0; i < getNumberOfHexahedra(); ++i)
+    for(size_t i = 0; i < getNumberOfHexahedra(); ++i)
     {
         const Hexahedron &h=m_hexahedron[i];
         int quadIndex;
@@ -390,11 +390,12 @@ void HexahedronSetTopologyContainer::createHexahedraAroundVertexArray()
     m_hexahedraAroundVertex.resize( getNbPoints() );
     helper::ReadAccessor< Data< sofa::helper::vector<Hexahedron> > > m_hexahedron = d_hexahedron;
 
-    for(unsigned int i=0; i<m_hexahedron.size(); ++i)
+    for(size_t i=0; i<m_hexahedron.size(); ++i)
     {
+        HexahedronID hexaID = (HexahedronID)i;
         // adding vertex i in the vertex shell
         for(unsigned int j=0; j<8; ++j)
-            m_hexahedraAroundVertex[ m_hexahedron[i][j]  ].push_back( i );
+            m_hexahedraAroundVertex[ m_hexahedron[i][j]  ].push_back(hexaID);
     }
 }
 
@@ -408,12 +409,13 @@ void HexahedronSetTopologyContainer::createHexahedraAroundEdgeArray ()
 
     m_hexahedraAroundEdge.resize(getNumberOfEdges());
 
-    for(unsigned int i=0; i<getNumberOfHexahedra(); ++i)
+    for(size_t i=0; i<getNumberOfHexahedra(); ++i)
     {
+        HexahedronID hexaID = (HexahedronID)i;
         // adding edge i in the edge shell
         for(unsigned int j=0; j<12; ++j)
         {
-            m_hexahedraAroundEdge[ m_edgesInHexahedron[i][j] ].push_back( i );
+            m_hexahedraAroundEdge[ m_edgesInHexahedron[i][j] ].push_back(hexaID);
         }
     }
 }
@@ -428,12 +430,13 @@ void HexahedronSetTopologyContainer::createHexahedraAroundQuadArray()
 
     m_hexahedraAroundQuad.resize( getNumberOfQuads());
 
-    for(unsigned int i=0; i<getNumberOfHexahedra(); ++i)
+    for(size_t i=0; i<getNumberOfHexahedra(); ++i)
     {
+        HexahedronID hexaID = (HexahedronID)i;
         // adding quad i in the edge shell of both points
         for(unsigned int j=0; j<6; ++j)
         {
-            m_hexahedraAroundQuad[ m_quadsInHexahedron[i][j] ].push_back( i );
+            m_hexahedraAroundQuad[ m_quadsInHexahedron[i][j] ].push_back(hexaID);
         }
     }
 }
@@ -457,14 +460,14 @@ int HexahedronSetTopologyContainer::getHexahedronIndex(PointID v1, PointID v2, P
     if(!hasHexahedraAroundVertex())
         createHexahedraAroundVertexArray();
 
-    sofa::helper::vector<unsigned int> set1 = getHexahedraAroundVertex(v1);
-    sofa::helper::vector<unsigned int> set2 = getHexahedraAroundVertex(v2);
-    sofa::helper::vector<unsigned int> set3 = getHexahedraAroundVertex(v3);
-    sofa::helper::vector<unsigned int> set4 = getHexahedraAroundVertex(v4);
-    sofa::helper::vector<unsigned int> set5 = getHexahedraAroundVertex(v5);
-    sofa::helper::vector<unsigned int> set6 = getHexahedraAroundVertex(v6);
-    sofa::helper::vector<unsigned int> set7 = getHexahedraAroundVertex(v7);
-    sofa::helper::vector<unsigned int> set8 = getHexahedraAroundVertex(v8);
+    sofa::helper::vector<HexahedronID> set1 = getHexahedraAroundVertex(v1);
+    sofa::helper::vector<HexahedronID> set2 = getHexahedraAroundVertex(v2);
+    sofa::helper::vector<HexahedronID> set3 = getHexahedraAroundVertex(v3);
+    sofa::helper::vector<HexahedronID> set4 = getHexahedraAroundVertex(v4);
+    sofa::helper::vector<HexahedronID> set5 = getHexahedraAroundVertex(v5);
+    sofa::helper::vector<HexahedronID> set6 = getHexahedraAroundVertex(v6);
+    sofa::helper::vector<HexahedronID> set7 = getHexahedraAroundVertex(v7);
+    sofa::helper::vector<HexahedronID> set8 = getHexahedraAroundVertex(v8);
 
     sort(set1.begin(), set1.end());
     sort(set2.begin(), set2.end());
@@ -476,38 +479,38 @@ int HexahedronSetTopologyContainer::getHexahedronIndex(PointID v1, PointID v2, P
     sort(set8.begin(), set8.end());
 
     // The destination vector must be large enough to contain the result.
-    sofa::helper::vector<unsigned int> out1(set1.size()+set2.size());
-    sofa::helper::vector<unsigned int>::iterator result1;
+    sofa::helper::vector<HexahedronID> out1(set1.size()+set2.size());
+    sofa::helper::vector<HexahedronID>::iterator result1;
     result1 = std::set_intersection(set1.begin(),set1.end(),set2.begin(),set2.end(),out1.begin());
     out1.erase(result1,out1.end());
 
-    sofa::helper::vector<unsigned int> out2(set3.size()+out1.size());
-    sofa::helper::vector<unsigned int>::iterator result2;
+    sofa::helper::vector<HexahedronID> out2(set3.size()+out1.size());
+    sofa::helper::vector<HexahedronID>::iterator result2;
     result2 = std::set_intersection(set3.begin(),set3.end(),out1.begin(),out1.end(),out2.begin());
     out2.erase(result2,out2.end());
 
-    sofa::helper::vector<unsigned int> out3(set4.size()+out2.size());
-    sofa::helper::vector<unsigned int>::iterator result3;
+    sofa::helper::vector<HexahedronID> out3(set4.size()+out2.size());
+    sofa::helper::vector<HexahedronID>::iterator result3;
     result3 = std::set_intersection(set4.begin(),set4.end(),out2.begin(),out2.end(),out3.begin());
     out3.erase(result3,out3.end());
 
-    sofa::helper::vector<unsigned int> out4(set5.size()+out3.size());
-    sofa::helper::vector<unsigned int>::iterator result4;
+    sofa::helper::vector<HexahedronID> out4(set5.size()+out3.size());
+    sofa::helper::vector<HexahedronID>::iterator result4;
     result4 = std::set_intersection(set5.begin(),set5.end(),out3.begin(),out3.end(),out4.begin());
     out4.erase(result4,out4.end());
 
-    sofa::helper::vector<unsigned int> out5(set6.size()+out4.size());
-    sofa::helper::vector<unsigned int>::iterator result5;
+    sofa::helper::vector<HexahedronID> out5(set6.size()+out4.size());
+    sofa::helper::vector<HexahedronID>::iterator result5;
     result5 = std::set_intersection(set6.begin(),set6.end(),out4.begin(),out4.end(),out5.begin());
     out5.erase(result5,out5.end());
 
-    sofa::helper::vector<unsigned int> out6(set7.size()+out5.size());
-    sofa::helper::vector<unsigned int>::iterator result6;
+    sofa::helper::vector<HexahedronID> out6(set7.size()+out5.size());
+    sofa::helper::vector<HexahedronID>::iterator result6;
     result6 = std::set_intersection(set7.begin(),set7.end(),out5.begin(),out5.end(),out6.begin());
     out6.erase(result6,out6.end());
 
-    sofa::helper::vector<unsigned int> out7(set8.size()+out6.size());
-    sofa::helper::vector<unsigned int>::iterator result7;
+    sofa::helper::vector<HexahedronID> out7(set8.size()+out6.size());
+    sofa::helper::vector<HexahedronID>::iterator result7;
     result7 = std::set_intersection(set8.begin(),set8.end(),out6.begin(),out6.end(),out7.begin());
     out7.erase(result7,out7.end());
 
@@ -529,9 +532,9 @@ const HexahedronSetTopologyContainer::Hexahedron HexahedronSetTopologyContainer:
         return (d_hexahedron.getValue())[i];
 }
 
-unsigned int HexahedronSetTopologyContainer::getNumberOfHexahedra() const
+size_t HexahedronSetTopologyContainer::getNumberOfHexahedra() const
 {
-    return (unsigned int)d_hexahedron.getValue().size();
+    return d_hexahedron.getValue().size();
 }
 
 
@@ -541,7 +544,7 @@ size_t HexahedronSetTopologyContainer::getNumberOfElements() const
 }
 
 
-const sofa::helper::vector< sofa::helper::vector<unsigned int> > &HexahedronSetTopologyContainer::getHexahedraAroundVertexArray()
+const sofa::helper::vector< HexahedronSetTopologyContainer::HexahedraAroundVertex > &HexahedronSetTopologyContainer::getHexahedraAroundVertexArray()
 {
     if(!hasHexahedraAroundVertex())
         createHexahedraAroundVertexArray();
@@ -549,7 +552,7 @@ const sofa::helper::vector< sofa::helper::vector<unsigned int> > &HexahedronSetT
     return m_hexahedraAroundVertex;
 }
 
-const sofa::helper::vector< sofa::helper::vector<unsigned int> > &HexahedronSetTopologyContainer::getHexahedraAroundEdgeArray()
+const sofa::helper::vector< HexahedronSetTopologyContainer::HexahedraAroundEdge > &HexahedronSetTopologyContainer::getHexahedraAroundEdgeArray()
 {
     if(!hasHexahedraAroundEdge())
         createHexahedraAroundEdgeArray();
@@ -557,7 +560,7 @@ const sofa::helper::vector< sofa::helper::vector<unsigned int> > &HexahedronSetT
     return m_hexahedraAroundEdge;
 }
 
-const sofa::helper::vector< sofa::helper::vector<unsigned int> > &HexahedronSetTopologyContainer::getHexahedraAroundQuadArray()
+const sofa::helper::vector< HexahedronSetTopologyContainer::HexahedraAroundQuad > &HexahedronSetTopologyContainer::getHexahedraAroundQuadArray()
 {
     if(!hasHexahedraAroundQuad())
         createHexahedraAroundQuadArray();
@@ -633,7 +636,7 @@ QuadSetTopologyContainer::QuadID HexahedronSetTopologyContainer::getNextAdjacent
     }
     else
     {
-        for (unsigned int i=0; i<QaroundE.size(); ++i)
+        for (size_t i=0; i<QaroundE.size(); ++i)
         {
             int res = this->getQuadIndexInHexahedron(QinH, QaroundE[i]);
             if (res != -1 && QaroundE[i] != the_quadID)
@@ -653,7 +656,7 @@ const sofa::helper::vector< QuadSetTopologyContainer::QuadsInHexahedron> &Hexahe
     return m_quadsInHexahedron;
 }
 
-const sofa::helper::vector< unsigned int > &HexahedronSetTopologyContainer::getHexahedraAroundVertex(const unsigned int i)
+const HexahedronSetTopologyContainer::HexahedraAroundVertex &HexahedronSetTopologyContainer::getHexahedraAroundVertex(const unsigned int i)
 {
     if(!hasHexahedraAroundVertex())
         createHexahedraAroundVertexArray();
@@ -663,7 +666,7 @@ const sofa::helper::vector< unsigned int > &HexahedronSetTopologyContainer::getH
     return m_hexahedraAroundVertex[i];
 }
 
-const sofa::helper::vector< unsigned int > &HexahedronSetTopologyContainer::getHexahedraAroundEdge(const unsigned int i)
+const HexahedronSetTopologyContainer::HexahedraAroundEdge &HexahedronSetTopologyContainer::getHexahedraAroundEdge(const unsigned int i)
 {
     if(!hasHexahedraAroundEdge())
         createHexahedraAroundEdgeArray();
@@ -673,7 +676,7 @@ const sofa::helper::vector< unsigned int > &HexahedronSetTopologyContainer::getH
     return m_hexahedraAroundEdge[i];
 }
 
-const sofa::helper::vector< unsigned int > &HexahedronSetTopologyContainer::getHexahedraAroundQuad(const unsigned int i)
+const HexahedronSetTopologyContainer::HexahedraAroundQuad &HexahedronSetTopologyContainer::getHexahedraAroundQuad(const unsigned int i)
 {
     if(!hasHexahedraAroundQuad())
         createHexahedraAroundQuadArray();
@@ -726,7 +729,7 @@ int HexahedronSetTopologyContainer::getVertexIndexInHexahedron(const Hexahedron 
 }
 
 int HexahedronSetTopologyContainer::getEdgeIndexInHexahedron(const EdgesInHexahedron &t,
-        const unsigned int edgeIndex) const
+        const EdgeID edgeIndex) const
 {
     if(t[0]==edgeIndex)
         return 0;
@@ -813,10 +816,10 @@ bool HexahedronSetTopologyContainer::checkTopology() const
     helper::ReadAccessor< Data< sofa::helper::vector<Hexahedron> > > m_hexahedron = d_hexahedron;
     if(hasHexahedraAroundVertex())
     {
-        for(unsigned int i=0; i<m_hexahedraAroundVertex.size(); ++i)
+        for(size_t i=0; i<m_hexahedraAroundVertex.size(); ++i)
         {
-            const sofa::helper::vector<unsigned int> &tvs = m_hexahedraAroundVertex[i];
-            for(unsigned int j=0; j<tvs.size(); ++j)
+            const sofa::helper::vector<HexahedronID> &tvs = m_hexahedraAroundVertex[i];
+            for(size_t j=0; j<tvs.size(); ++j)
             {
                 bool check_hexa_vertex_shell = (m_hexahedron[tvs[j]][0]==i)
                         || (m_hexahedron[tvs[j]][1]==i)
@@ -838,10 +841,10 @@ bool HexahedronSetTopologyContainer::checkTopology() const
 
     if(hasHexahedraAroundEdge())
     {
-        for(unsigned int i=0; i<m_hexahedraAroundEdge.size(); ++i)
+        for(size_t i=0; i<m_hexahedraAroundEdge.size(); ++i)
         {
-            const sofa::helper::vector<unsigned int> &tes=m_hexahedraAroundEdge[i];
-            for(unsigned int j=0; j<tes.size(); ++j)
+            const sofa::helper::vector<HexahedronID> &tes=m_hexahedraAroundEdge[i];
+            for(size_t j=0; j<tes.size(); ++j)
             {
                 bool check_hexa_edge_shell =   (m_edgesInHexahedron[tes[j]][0]==i)
                         || (m_edgesInHexahedron[tes[j]][1]==i)
@@ -866,10 +869,10 @@ bool HexahedronSetTopologyContainer::checkTopology() const
 
     if(hasHexahedraAroundQuad())
     {
-        for(unsigned int i=0; i<m_hexahedraAroundQuad.size(); ++i)
+        for(size_t i=0; i<m_hexahedraAroundQuad.size(); ++i)
         {
-            const sofa::helper::vector<unsigned int> &tes=m_hexahedraAroundQuad[i];
-            for(unsigned int j=0; j<tes.size(); ++j)
+            const sofa::helper::vector<HexahedronID> &tes=m_hexahedraAroundQuad[i];
+            for(size_t j=0; j<tes.size(); ++j)
             {
                 bool check_hexa_quad_shell =   (m_quadsInHexahedron[tes[j]][0]==i)
                         || (m_quadsInHexahedron[tes[j]][1]==i)
@@ -936,7 +939,7 @@ size_t HexahedronSetTopologyContainer::getNumberOfConnectedComponent()
     }
 
     VecHexaID elemAll = this->getConnectedElement(0);
-    unsigned int cpt = 1;
+    size_t cpt = 1;
 
     while (elemAll.size() < nbr)
     {
@@ -973,7 +976,7 @@ const HexahedronSetTopologyContainer::VecHexaID HexahedronSetTopologyContainer::
     VecHexaID elemAll;
     VecHexaID elemOnFront, elemPreviousFront, elemNextFront;
     bool end = false;
-    unsigned int cpt = 0;
+    size_t cpt = 0;
     size_t nbr = this->getNbHexahedra();
 
     // init algo
@@ -988,7 +991,7 @@ const HexahedronSetTopologyContainer::VecHexaID HexahedronSetTopologyContainer::
         elemNextFront = this->getElementAroundElements(elemOnFront); // for each HexaID on the propagation front
 
         // Second Step - Avoid backward direction
-        for (unsigned int i = 0; i<elemNextFront.size(); ++i)
+        for (size_t i = 0; i<elemNextFront.size(); ++i)
         {
             bool find = false;
             HexaID id = elemNextFront[i];
@@ -1008,7 +1011,7 @@ const HexahedronSetTopologyContainer::VecHexaID HexahedronSetTopologyContainer::
         }
 
         // cpt for connexity
-        cpt += (unsigned int)elemPreviousFront.size();
+        cpt += elemPreviousFront.size();
 
         if (elemPreviousFront.empty())
         {
@@ -1045,7 +1048,7 @@ const HexahedronSetTopologyContainer::VecHexaID HexahedronSetTopologyContainer::
     {
         HexahedraAroundVertex hexaAV = this->getHexahedraAroundVertex(the_hexa[i]);
 
-        for (unsigned int j = 0; j<hexaAV.size(); ++j) // for each hexahedron around the node
+        for (size_t j = 0; j<hexaAV.size(); ++j) // for each hexahedron around the node
         {
             bool find = false;
             HexaID id = hexaAV[j];
@@ -1053,7 +1056,7 @@ const HexahedronSetTopologyContainer::VecHexaID HexahedronSetTopologyContainer::
             if (id == elem)
                 continue;
 
-            for (unsigned int k = 0; k<elems.size(); ++k) // check no redundancy
+            for (size_t k = 0; k<elems.size(); ++k) // check no redundancy
                 if (id == elems[k])
                 {
                     find = true;
@@ -1082,19 +1085,19 @@ const HexahedronSetTopologyContainer::VecHexaID HexahedronSetTopologyContainer::
         createHexahedraAroundVertexArray();
     }
 
-    for (unsigned int i = 0; i <elems.size(); ++i) // for each HexaID of input vector
+    for (size_t i = 0; i <elems.size(); ++i) // for each HexaID of input vector
     {
         VecHexaID elemTmp2 = this->getElementAroundElement(elems[i]);
 
         elemTmp.insert(elemTmp.end(), elemTmp2.begin(), elemTmp2.end());
     }
 
-    for (unsigned int i = 0; i<elemTmp.size(); ++i) // for each hexahedron Id found
+    for (size_t i = 0; i<elemTmp.size(); ++i) // for each hexahedron Id found
     {
         bool find = false;
         HexaID id = elemTmp[i];
 
-        for (unsigned int j = 0; j<elems.size(); ++j) // check no redundancy with input vector
+        for (size_t j = 0; j<elems.size(); ++j) // check no redundancy with input vector
             if (id == elems[j])
             {
                 find = true;
@@ -1103,7 +1106,7 @@ const HexahedronSetTopologyContainer::VecHexaID HexahedronSetTopologyContainer::
 
         if (!find)
         {
-            for (unsigned int j = 0; j<elemAll.size(); ++j) // check no redundancy in output vector
+            for (size_t j = 0; j<elemAll.size(); ++j) // check no redundancy in output vector
                 if (id == elemAll[j])
                 {
                     find = true;

--- a/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyContainer.cpp
@@ -535,7 +535,7 @@ unsigned int HexahedronSetTopologyContainer::getNumberOfHexahedra() const
 }
 
 
-unsigned int HexahedronSetTopologyContainer::getNumberOfElements() const
+size_t HexahedronSetTopologyContainer::getNumberOfElements() const
 {
     return this->getNumberOfHexahedra();
 }
@@ -923,7 +923,7 @@ bool HexahedronSetTopologyContainer::checkConnexity()
 }
 
 
-unsigned int HexahedronSetTopologyContainer::getNumberOfConnectedComponent()
+size_t HexahedronSetTopologyContainer::getNumberOfConnectedComponent()
 {
     size_t nbr = this->getNbHexahedra();
 

--- a/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyContainer.h
@@ -254,7 +254,7 @@ public:
     virtual bool checkConnexity() override;
 
     /// Returns the number of connected component.
-    virtual unsigned int getNumberOfConnectedComponent() override;
+    virtual size_t getNumberOfConnectedComponent() override;
 
     /// Returns the set of element indices connected to an input one (i.e. which can be reached by topological links)
     virtual const VecHexaID getConnectedElement(HexaID elem) override;
@@ -275,7 +275,7 @@ public:
     /** \brief Returns the number of topological element of the current topology.
      * This function avoids to know which topological container is in used.
      */
-    virtual unsigned int getNumberOfElements() const override;
+    virtual size_t getNumberOfElements() const override;
 
 
     /** \brief Returns the Hexahedron array. */

--- a/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyContainer.h
@@ -269,7 +269,7 @@ public:
     /** \brief Returns the number of hexahedra in this topology.
      *	The difference to getNbHexahedra() is that this method does not generate the hexa array if it does not exist.
      */
-    unsigned int getNumberOfHexahedra() const;
+    size_t getNumberOfHexahedra() const;
 
 
     /** \brief Returns the number of topological element of the current topology.

--- a/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyModifier.cpp
@@ -507,7 +507,7 @@ void HexahedronSetTopologyModifier::removeHexahedraProcess( const sofa::helper::
     }
 }
 
-void HexahedronSetTopologyModifier::addPointsProcess(const unsigned int nPoints)
+void HexahedronSetTopologyModifier::addPointsProcess(const size_t nPoints)
 {
     // start by calling the parent's method.
     QuadSetTopologyModifier::addPointsProcess( nPoints );

--- a/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyModifier.cpp
@@ -54,19 +54,19 @@ void HexahedronSetTopologyModifier::init()
 
 void HexahedronSetTopologyModifier::addHexahedra(const sofa::helper::vector<Hexahedron> &hexahedra)
 {
-    unsigned int nhexa = m_container->getNbHexahedra();
+    size_t nhexa = m_container->getNbHexahedra();
 
     /// effectively add triangles in the topology container
     addHexahedraProcess(hexahedra);
 
-    sofa::helper::vector<unsigned int> hexahedraIndex;
+    sofa::helper::vector<HexahedronID> hexahedraIndex;
     hexahedraIndex.reserve(hexahedra.size());
 
-    for (unsigned int i=0; i<hexahedra.size(); ++i)
-        hexahedraIndex.push_back(nhexa+i);
+    for (size_t i=0; i<hexahedra.size(); ++i)
+        hexahedraIndex.push_back(HexahedronID(nhexa+i));
 
     // add topology event in the stack of topological events
-    addHexahedraWarning((unsigned int)hexahedra.size(), hexahedra, hexahedraIndex);
+    addHexahedraWarning(hexahedra.size(), hexahedra, hexahedraIndex);
 
     // inform other objects that the edges are already added
     propagateTopologicalChanges();
@@ -74,22 +74,22 @@ void HexahedronSetTopologyModifier::addHexahedra(const sofa::helper::vector<Hexa
 
 
 void HexahedronSetTopologyModifier::addHexahedra(const sofa::helper::vector<Hexahedron> &hexahedra,
-        const sofa::helper::vector<sofa::helper::vector<unsigned int> > &ancestors,
+        const sofa::helper::vector<sofa::helper::vector<HexahedronID> > &ancestors,
         const sofa::helper::vector<sofa::helper::vector<double> > &baryCoefs)
 {
-    unsigned int nhexa = m_container->getNbHexahedra();
+    size_t nhexa = m_container->getNbHexahedra();
 
     /// effectively add triangles in the topology container
     addHexahedraProcess(hexahedra);
 
-    sofa::helper::vector<unsigned int> hexahedraIndex;
+    sofa::helper::vector<HexahedronID> hexahedraIndex;
     hexahedraIndex.reserve(hexahedra.size());
 
-    for (unsigned int i=0; i<hexahedra.size(); ++i)
-        hexahedraIndex.push_back(nhexa+i);
+    for (size_t i=0; i<hexahedra.size(); ++i)
+        hexahedraIndex.push_back(HexahedronID(nhexa+i));
 
     // add topology event in the stack of topological events
-    addHexahedraWarning((unsigned int)hexahedra.size(), hexahedra, hexahedraIndex, ancestors, baryCoefs);
+    addHexahedraWarning(hexahedra.size(), hexahedra, hexahedraIndex, ancestors, baryCoefs);
 
     // inform other objects that the edges are already added
     propagateTopologicalChanges();
@@ -112,7 +112,7 @@ void HexahedronSetTopologyModifier::addHexahedronProcess(Hexahedron t)
     // check if there already exists a hexahedron with the same indices
     assert(m_container->getHexahedronIndex(t[0],t[1],t[2],t[3],t[4],t[5],t[6],t[7])== -1);
 #endif
-    const unsigned int hexahedronIndex = m_container->getNumberOfHexahedra();
+    const HexahedronID hexahedronIndex = (HexahedronID)m_container->getNumberOfHexahedra();
     helper::WriteAccessor< Data< sofa::helper::vector<Hexahedron> > > m_hexahedron = m_container->d_hexahedron;
 
     if(m_container->hasQuadsInHexahedron())
@@ -132,9 +132,9 @@ void HexahedronSetTopologyModifier::addHexahedronProcess(Hexahedron t)
             addQuadsProcess((const sofa::helper::vector< Quad > &) v);
 
             quadIndex=m_container->getQuadIndex(t[0],t[3],t[2],t[1]);
-            sofa::helper::vector< unsigned int > quadIndexList;
+            sofa::helper::vector< QuadID > quadIndexList;
             quadIndexList.push_back(quadIndex);
-            addQuadsWarning((unsigned int)v.size(), v, quadIndexList);
+            addQuadsWarning(v.size(), v, quadIndexList);
         }
         m_container->m_quadsInHexahedron.resize(hexahedronIndex+1);
         m_container->m_quadsInHexahedron[hexahedronIndex][0]=quadIndex;
@@ -152,9 +152,9 @@ void HexahedronSetTopologyModifier::addHexahedronProcess(Hexahedron t)
             addQuadsProcess((const sofa::helper::vector< Quad > &) v);
 
             quadIndex=m_container->getQuadIndex(t[4],t[5],t[6],t[7]);
-            sofa::helper::vector< unsigned int > quadIndexList;
+            sofa::helper::vector< QuadID > quadIndexList;
             quadIndexList.push_back(quadIndex);
-            addQuadsWarning((unsigned int)v.size(), v, quadIndexList);
+            addQuadsWarning(v.size(), v, quadIndexList);
         }
         m_container->m_quadsInHexahedron.resize(hexahedronIndex+1);
         m_container->m_quadsInHexahedron[hexahedronIndex][1]=quadIndex;
@@ -172,9 +172,9 @@ void HexahedronSetTopologyModifier::addHexahedronProcess(Hexahedron t)
             addQuadsProcess((const sofa::helper::vector< Quad > &) v);
 
             quadIndex=m_container->getQuadIndex(t[0],t[1],t[5],t[4]);
-            sofa::helper::vector< unsigned int > quadIndexList;
+            sofa::helper::vector< QuadID > quadIndexList;
             quadIndexList.push_back(quadIndex);
-            addQuadsWarning((unsigned int)v.size(), v, quadIndexList);
+            addQuadsWarning(v.size(), v, quadIndexList);
         }
         m_container->m_quadsInHexahedron.resize(hexahedronIndex+1);
         m_container->m_quadsInHexahedron[hexahedronIndex][2]=quadIndex;
@@ -192,9 +192,9 @@ void HexahedronSetTopologyModifier::addHexahedronProcess(Hexahedron t)
             addQuadsProcess((const sofa::helper::vector< Quad > &) v);
 
             quadIndex=m_container->getQuadIndex(t[1],t[2],t[6],t[5]);
-            sofa::helper::vector< unsigned int > quadIndexList;
+            sofa::helper::vector< QuadID > quadIndexList;
             quadIndexList.push_back(quadIndex);
-            addQuadsWarning((unsigned int)v.size(), v, quadIndexList);
+            addQuadsWarning(v.size(), v, quadIndexList);
         }
         m_container->m_quadsInHexahedron.resize(hexahedronIndex+1);
         m_container->m_quadsInHexahedron[hexahedronIndex][3]=quadIndex;
@@ -212,9 +212,9 @@ void HexahedronSetTopologyModifier::addHexahedronProcess(Hexahedron t)
             addQuadsProcess((const sofa::helper::vector< Quad > &) v);
 
             quadIndex=m_container->getQuadIndex(t[2],t[3],t[7],t[6]);
-            sofa::helper::vector< unsigned int > quadIndexList;
+            sofa::helper::vector< QuadID > quadIndexList;
             quadIndexList.push_back(quadIndex);
-            addQuadsWarning((unsigned int)v.size(), v, quadIndexList);
+            addQuadsWarning(v.size(), v, quadIndexList);
         }
         m_container->m_quadsInHexahedron.resize(hexahedronIndex+1);
         m_container->m_quadsInHexahedron[hexahedronIndex][4]=quadIndex;
@@ -232,18 +232,18 @@ void HexahedronSetTopologyModifier::addHexahedronProcess(Hexahedron t)
             addQuadsProcess((const sofa::helper::vector< Quad > &) v);
 
             quadIndex=m_container->getQuadIndex(t[3],t[0],t[4],t[7]);
-            sofa::helper::vector< unsigned int > quadIndexList;
+            sofa::helper::vector< QuadID > quadIndexList;
             quadIndexList.push_back(quadIndex);
-            addQuadsWarning((unsigned int)v.size(), v, quadIndexList);
+            addQuadsWarning(v.size(), v, quadIndexList);
         }
         m_container->m_quadsInHexahedron.resize(hexahedronIndex+1);
         m_container->m_quadsInHexahedron[hexahedronIndex][5]=quadIndex;
 
         if(m_container->hasHexahedraAroundQuad())
         {
-            for(unsigned int q=0; q<6; ++q)
+            for(QuadID q=0; q<6; ++q)
             {
-                sofa::helper::vector< unsigned int > &shell = m_container->m_hexahedraAroundQuad[m_container->m_quadsInHexahedron[hexahedronIndex][q]];
+                sofa::helper::vector< HexahedronID > &shell = m_container->m_hexahedraAroundQuad[m_container->m_quadsInHexahedron[hexahedronIndex][q]];
                 shell.push_back( hexahedronIndex );
             }
         }
@@ -252,10 +252,10 @@ void HexahedronSetTopologyModifier::addHexahedronProcess(Hexahedron t)
     if(m_container->hasEdgesInHexahedron())
     {
         m_container->m_edgesInHexahedron.resize(hexahedronIndex+1);
-        for(unsigned int edgeIdx=0; edgeIdx<12; ++edgeIdx)
+        for(EdgeID edgeIdx=0; edgeIdx<12; ++edgeIdx)
         {
-            unsigned p0 = edgesInHexahedronArray[edgeIdx][0];
-            unsigned p1 = edgesInHexahedronArray[edgeIdx][1];
+            EdgeID p0 = edgesInHexahedronArray[edgeIdx][0];
+            EdgeID p1 = edgesInHexahedronArray[edgeIdx][1];
 
             int edgeIndex=m_container->getEdgeIndex(t[p0],t[p1]);
 
@@ -270,9 +270,9 @@ void HexahedronSetTopologyModifier::addHexahedronProcess(Hexahedron t)
 
                 edgeIndex=m_container->getEdgeIndex(t[p0],t[p1]);
 
-                sofa::helper::vector< unsigned int > edgeIndexList;
+                sofa::helper::vector< EdgeID > edgeIndexList;
                 edgeIndexList.push_back(edgeIndex);
-                addEdgesWarning((unsigned int)v.size(), v, edgeIndexList);
+                addEdgesWarning(v.size(), v, edgeIndexList);
             }
 
             m_container->m_edgesInHexahedron[hexahedronIndex][edgeIdx]= edgeIndex;
@@ -280,9 +280,9 @@ void HexahedronSetTopologyModifier::addHexahedronProcess(Hexahedron t)
 
         if(m_container->hasHexahedraAroundEdge())
         {
-            for(unsigned int e=0; e<12; ++e)
+            for(EdgeID e=0; e<12; ++e)
             {
-                sofa::helper::vector< unsigned int > &shell = m_container->m_hexahedraAroundEdge[m_container->m_edgesInHexahedron[hexahedronIndex][e]];
+                sofa::helper::vector< HexahedronID > &shell = m_container->m_hexahedraAroundEdge[m_container->m_edgesInHexahedron[hexahedronIndex][e]];
                 shell.push_back( hexahedronIndex );
             }
         }
@@ -290,9 +290,9 @@ void HexahedronSetTopologyModifier::addHexahedronProcess(Hexahedron t)
 
     if(m_container->hasHexahedraAroundVertex())
     {
-        for(unsigned int v=0; v<8; ++v)
+        for(PointID v=0; v<8; ++v)
         {
-            sofa::helper::vector< unsigned int > &shell = m_container->getHexahedraAroundVertexForModification( t[v] );
+            sofa::helper::vector< HexahedronID > &shell = m_container->getHexahedraAroundVertexForModification( t[v] );
             shell.push_back( hexahedronIndex );
         }
     }
@@ -303,16 +303,16 @@ void HexahedronSetTopologyModifier::addHexahedronProcess(Hexahedron t)
 
 void HexahedronSetTopologyModifier::addHexahedraProcess(const sofa::helper::vector< Hexahedron > &hexahedra)
 {
-    for(unsigned int i = 0; i < hexahedra.size(); ++i)
+    for(size_t i = 0; i < hexahedra.size(); ++i)
     {
         addHexahedronProcess(hexahedra[i]);
     }
 }
 
 
-void HexahedronSetTopologyModifier::addHexahedraWarning(const unsigned int nHexahedra,
+void HexahedronSetTopologyModifier::addHexahedraWarning(const size_t nHexahedra,
         const sofa::helper::vector< Hexahedron >& hexahedraList,
-        const sofa::helper::vector< unsigned int >& hexahedraIndexList)
+        const sofa::helper::vector< HexahedronID >& hexahedraIndexList)
 {
     m_container->setHexahedronTopologyToDirty();
     // Warning that hexahedra just got created
@@ -321,10 +321,10 @@ void HexahedronSetTopologyModifier::addHexahedraWarning(const unsigned int nHexa
 }
 
 
-void HexahedronSetTopologyModifier::addHexahedraWarning(const unsigned int nHexahedra,
+void HexahedronSetTopologyModifier::addHexahedraWarning(const size_t nHexahedra,
         const sofa::helper::vector< Hexahedron >& hexahedraList,
-        const sofa::helper::vector< unsigned int >& hexahedraIndexList,
-        const sofa::helper::vector< sofa::helper::vector< unsigned int > > & ancestors,
+        const sofa::helper::vector< HexahedronID >& hexahedraIndexList,
+        const sofa::helper::vector< sofa::helper::vector< HexahedronID > > & ancestors,
         const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs)
 {
     m_container->setHexahedronTopologyToDirty();
@@ -334,11 +334,11 @@ void HexahedronSetTopologyModifier::addHexahedraWarning(const unsigned int nHexa
 }
 
 
-void HexahedronSetTopologyModifier::removeHexahedraWarning( sofa::helper::vector<unsigned int> &hexahedra )
+void HexahedronSetTopologyModifier::removeHexahedraWarning( sofa::helper::vector<HexahedronID> &hexahedra )
 {
     m_container->setHexahedronTopologyToDirty();
     /// sort vertices to remove in a descendent order
-    std::sort( hexahedra.begin(), hexahedra.end(), std::greater<unsigned int>() );
+    std::sort( hexahedra.begin(), hexahedra.end(), std::greater<HexahedronID>() );
 
     // Warning that these edges will be deleted
     HexahedraRemoved *e = new HexahedraRemoved(hexahedra);
@@ -346,7 +346,7 @@ void HexahedronSetTopologyModifier::removeHexahedraWarning( sofa::helper::vector
 }
 
 
-void HexahedronSetTopologyModifier::removeHexahedraProcess( const sofa::helper::vector<unsigned int> &indices,
+void HexahedronSetTopologyModifier::removeHexahedraProcess( const sofa::helper::vector<HexahedronID> &indices,
         const bool removeIsolatedItems)
 {
     if(!m_container->hasHexahedra())
@@ -374,24 +374,24 @@ void HexahedronSetTopologyModifier::removeHexahedraProcess( const sofa::helper::
             m_container->createHexahedraAroundQuadArray();
     }
 
-    sofa::helper::vector<unsigned int> quadToBeRemoved;
-    sofa::helper::vector<unsigned int> edgeToBeRemoved;
-    sofa::helper::vector<unsigned int> vertexToBeRemoved;
+    sofa::helper::vector<QuadID> quadToBeRemoved;
+    sofa::helper::vector<EdgeID> edgeToBeRemoved;
+    sofa::helper::vector<PointID> vertexToBeRemoved;
 
-    unsigned int lastHexahedron = m_container->getNumberOfHexahedra() - 1;
+    HexahedronID lastHexahedron = (HexahedronID)m_container->getNumberOfHexahedra() - 1;
 
     helper::WriteAccessor< Data< sofa::helper::vector<Hexahedron> > > m_hexahedron = m_container->d_hexahedron;
 
-    for(unsigned int i=0; i<indices.size(); ++i, --lastHexahedron)
+    for(size_t i=0; i<indices.size(); ++i, --lastHexahedron)
     {
         const Hexahedron &t = m_hexahedron[ indices[i] ];
         const Hexahedron &h = m_hexahedron[ lastHexahedron ];
 
         if(m_container->hasHexahedraAroundVertex())
         {
-            for(unsigned int v=0; v<8; ++v)
+            for(PointID v=0; v<8; ++v)
             {
-                sofa::helper::vector< unsigned int > &shell = m_container->m_hexahedraAroundVertex[ t[v] ];
+                sofa::helper::vector< HexahedronID > &shell = m_container->m_hexahedraAroundVertex[ t[v] ];
                 shell.erase(remove(shell.begin(), shell.end(), indices[i]), shell.end());
                 if(removeIsolatedVertices && shell.empty())
                     vertexToBeRemoved.push_back(t[v]);
@@ -400,9 +400,9 @@ void HexahedronSetTopologyModifier::removeHexahedraProcess( const sofa::helper::
 
         if(m_container->hasHexahedraAroundEdge())
         {
-            for(unsigned int e=0; e<12; ++e)
+            for(EdgeID e=0; e<12; ++e)
             {
-                sofa::helper::vector< unsigned int > &shell = m_container->m_hexahedraAroundEdge[ m_container->m_edgesInHexahedron[indices[i]][e]];
+                sofa::helper::vector< HexahedronID > &shell = m_container->m_hexahedraAroundEdge[ m_container->m_edgesInHexahedron[indices[i]][e]];
                 shell.erase(remove(shell.begin(), shell.end(), indices[i]), shell.end());
                 if(removeIsolatedEdges && shell.empty())
                     edgeToBeRemoved.push_back(m_container->m_edgesInHexahedron[indices[i]][e]);
@@ -411,9 +411,9 @@ void HexahedronSetTopologyModifier::removeHexahedraProcess( const sofa::helper::
 
         if(m_container->hasHexahedraAroundQuad())
         {
-            for(unsigned int q=0; q<6; ++q)
+            for(QuadID q=0; q<6; ++q)
             {
-                sofa::helper::vector< unsigned int > &shell = m_container->m_hexahedraAroundQuad[ m_container->m_quadsInHexahedron[indices[i]][q]];
+                sofa::helper::vector< HexahedronID > &shell = m_container->m_hexahedraAroundQuad[ m_container->m_quadsInHexahedron[indices[i]][q]];
                 shell.erase(remove(shell.begin(), shell.end(), indices[i]), shell.end());
                 if(removeIsolatedQuads && shell.empty())
                     quadToBeRemoved.push_back(m_container->m_quadsInHexahedron[indices[i]][q]);
@@ -425,27 +425,27 @@ void HexahedronSetTopologyModifier::removeHexahedraProcess( const sofa::helper::
         {
             if(m_container->hasHexahedraAroundVertex())
             {
-                for(unsigned int v=0; v<8; ++v)
+                for(PointID v=0; v<8; ++v)
                 {
-                    sofa::helper::vector< unsigned int > &shell = m_container->m_hexahedraAroundVertex[ h[v] ];
+                    sofa::helper::vector< HexahedronID > &shell = m_container->m_hexahedraAroundVertex[ h[v] ];
                     replace(shell.begin(), shell.end(), lastHexahedron, indices[i]);
                 }
             }
 
             if(m_container->hasHexahedraAroundEdge())
             {
-                for(unsigned int e=0; e<12; ++e)
+                for(EdgeID e=0; e<12; ++e)
                 {
-                    sofa::helper::vector< unsigned int > &shell =  m_container->m_hexahedraAroundEdge[ m_container->m_edgesInHexahedron[lastHexahedron][e]];
+                    sofa::helper::vector< HexahedronID > &shell =  m_container->m_hexahedraAroundEdge[ m_container->m_edgesInHexahedron[lastHexahedron][e]];
                     replace(shell.begin(), shell.end(), lastHexahedron, indices[i]);
                 }
             }
 
             if(m_container->hasHexahedraAroundQuad())
             {
-                for(unsigned int q=0; q<6; ++q)
+                for(QuadID q=0; q<6; ++q)
                 {
-                    sofa::helper::vector< unsigned int > &shell =  m_container->m_hexahedraAroundQuad[ m_container->m_quadsInHexahedron[lastHexahedron][q]];
+                    sofa::helper::vector< HexahedronID > &shell =  m_container->m_hexahedraAroundQuad[ m_container->m_quadsInHexahedron[lastHexahedron][q]];
                     replace(shell.begin(), shell.end(), lastHexahedron, indices[i]);
                 }
             }
@@ -534,7 +534,7 @@ void HexahedronSetTopologyModifier::addQuadsProcess(const sofa::helper::vector< 
         m_container->m_hexahedraAroundQuad.resize( m_container->getNumberOfQuads() );
 }
 
-void HexahedronSetTopologyModifier::removePointsProcess(const sofa::helper::vector<unsigned int> &indices,
+void HexahedronSetTopologyModifier::removePointsProcess(const sofa::helper::vector<PointID> &indices,
         const bool removeDOF)
 {
     if(m_container->hasHexahedra())
@@ -546,15 +546,15 @@ void HexahedronSetTopologyModifier::removePointsProcess(const sofa::helper::vect
 
         helper::WriteAccessor< Data< sofa::helper::vector<Hexahedron> > > m_hexahedron = m_container->d_hexahedron;
 
-        unsigned int lastPoint = m_container->getNbPoints() - 1;
-        for(unsigned int i = 0; i < indices.size(); ++i, --lastPoint)
+        PointID lastPoint = (PointID)m_container->getNbPoints() - 1;
+        for(size_t i = 0; i < indices.size(); ++i, --lastPoint)
         {
             // updating the edges connected to the point replacing the removed one:
             // for all edges connected to the last point
-            for(sofa::helper::vector<unsigned int>::iterator itt=m_container->m_hexahedraAroundVertex[lastPoint].begin();
+            for(sofa::helper::vector<HexahedronID>::iterator itt=m_container->m_hexahedraAroundVertex[lastPoint].begin();
                 itt!=m_container->m_hexahedraAroundVertex[lastPoint].end(); ++itt)
             {
-                unsigned int vertexIndex = m_container->getVertexIndexInHexahedron(m_hexahedron[*itt], lastPoint);
+                PointID vertexIndex = m_container->getVertexIndexInHexahedron(m_hexahedron[*itt], lastPoint);
                 m_hexahedron[*itt][ vertexIndex] = indices[i];
             }
 
@@ -570,7 +570,7 @@ void HexahedronSetTopologyModifier::removePointsProcess(const sofa::helper::vect
     QuadSetTopologyModifier::removePointsProcess(  indices, removeDOF );
 }
 
-void HexahedronSetTopologyModifier::removeEdgesProcess( const sofa::helper::vector<unsigned int> &indices,
+void HexahedronSetTopologyModifier::removeEdgesProcess( const sofa::helper::vector<EdgeID> &indices,
         const bool removeIsolatedItems)
 {
     if(!m_container->hasEdges()) // this method should only be called when edges exist
@@ -581,13 +581,13 @@ void HexahedronSetTopologyModifier::removeEdgesProcess( const sofa::helper::vect
         if(!m_container->hasHexahedraAroundEdge())
             m_container->createHexahedraAroundEdgeArray();
 
-        unsigned int lastEdge = m_container->getNumberOfEdges() - 1;
-        for(unsigned int i=0; i<indices.size(); ++i, --lastEdge)
+        EdgeID lastEdge = (EdgeID)m_container->getNumberOfEdges() - 1;
+        for(size_t i=0; i<indices.size(); ++i, --lastEdge)
         {
-            for(sofa::helper::vector<unsigned int>::iterator itt=m_container->m_hexahedraAroundEdge[lastEdge].begin();
+            for(sofa::helper::vector<HexahedronID>::iterator itt=m_container->m_hexahedraAroundEdge[lastEdge].begin();
                 itt!=m_container->m_hexahedraAroundEdge[lastEdge].end(); ++itt)
             {
-                unsigned int edgeIndex = m_container->getEdgeIndexInHexahedron(m_container->m_edgesInHexahedron[*itt], lastEdge);
+                EdgeID edgeIndex = m_container->getEdgeIndexInHexahedron(m_container->m_edgesInHexahedron[*itt], lastEdge);
                 m_container->m_edgesInHexahedron[*itt][edgeIndex] = indices[i];
             }
 
@@ -602,7 +602,7 @@ void HexahedronSetTopologyModifier::removeEdgesProcess( const sofa::helper::vect
     QuadSetTopologyModifier::removeEdgesProcess(  indices, removeIsolatedItems );
 }
 
-void HexahedronSetTopologyModifier::removeQuadsProcess( const sofa::helper::vector<unsigned int> &indices,
+void HexahedronSetTopologyModifier::removeQuadsProcess( const sofa::helper::vector<QuadID> &indices,
         const bool removeIsolatedEdges,
         const bool removeIsolatedPoints)
 {
@@ -614,13 +614,13 @@ void HexahedronSetTopologyModifier::removeQuadsProcess( const sofa::helper::vect
         if(!m_container->hasHexahedraAroundQuad())
             m_container->createHexahedraAroundQuadArray();
 
-        unsigned int lastQuad = m_container->getNumberOfQuads() - 1;
-        for(unsigned int i=0; i<indices.size(); ++i, --lastQuad)
+        QuadID lastQuad = (QuadID)m_container->getNumberOfQuads() - 1;
+        for(size_t i=0; i<indices.size(); ++i, --lastQuad)
         {
-            for(sofa::helper::vector<unsigned int>::iterator itt=m_container->m_hexahedraAroundQuad[lastQuad].begin();
+            for(sofa::helper::vector<HexahedronID>::iterator itt=m_container->m_hexahedraAroundQuad[lastQuad].begin();
                 itt!=m_container->m_hexahedraAroundQuad[lastQuad].end(); ++itt)
             {
-                unsigned int quadIndex=m_container->getQuadIndexInHexahedron(m_container->m_quadsInHexahedron[*itt],lastQuad);
+                QuadID quadIndex=m_container->getQuadIndexInHexahedron(m_container->m_quadsInHexahedron[*itt],lastQuad);
                 m_container->m_quadsInHexahedron[*itt][quadIndex]=indices[i];
             }
 
@@ -634,14 +634,14 @@ void HexahedronSetTopologyModifier::removeQuadsProcess( const sofa::helper::vect
     QuadSetTopologyModifier::removeQuadsProcess( indices, removeIsolatedEdges, removeIsolatedPoints );
 }
 
-void HexahedronSetTopologyModifier::renumberPointsProcess( const sofa::helper::vector<unsigned int> &index, const sofa::helper::vector<unsigned int> &inv_index, const bool renumberDOF)
+void HexahedronSetTopologyModifier::renumberPointsProcess( const sofa::helper::vector<PointID> &index, const sofa::helper::vector<PointID> &inv_index, const bool renumberDOF)
 {
     if(m_container->hasHexahedra())
     {
         if(m_container->hasHexahedraAroundVertex())
         {
-            sofa::helper::vector< sofa::helper::vector< unsigned int > > hexahedraAroundVertex_cp = m_container->m_hexahedraAroundVertex;
-            for(unsigned int i=0; i<index.size(); ++i)
+            sofa::helper::vector< sofa::helper::vector< HexahedronID > > hexahedraAroundVertex_cp = m_container->m_hexahedraAroundVertex;
+            for(size_t i=0; i<index.size(); ++i)
             {
                 m_container->m_hexahedraAroundVertex[i] = hexahedraAroundVertex_cp[ index[i] ];
             }
@@ -649,7 +649,7 @@ void HexahedronSetTopologyModifier::renumberPointsProcess( const sofa::helper::v
 
         helper::WriteAccessor< Data< sofa::helper::vector<Hexahedron> > > m_hexahedron = m_container->d_hexahedron;
 
-        for(unsigned int i=0; i<m_hexahedron.size(); ++i)
+        for(size_t i=0; i<m_hexahedron.size(); ++i)
         {
             m_hexahedron[i][0]  = inv_index[ m_hexahedron[i][0]  ];
             m_hexahedron[i][1]  = inv_index[ m_hexahedron[i][1]  ];
@@ -666,10 +666,10 @@ void HexahedronSetTopologyModifier::renumberPointsProcess( const sofa::helper::v
     QuadSetTopologyModifier::renumberPointsProcess( index, inv_index, renumberDOF );
 }
 
-void HexahedronSetTopologyModifier::removeHexahedra(const sofa::helper::vector< unsigned int >& hexahedraIds)
+void HexahedronSetTopologyModifier::removeHexahedra(const sofa::helper::vector< HexahedronID >& hexahedraIds)
 {
-    sofa::helper::vector<unsigned int> hexahedraIds_filtered;
-    for (unsigned int i = 0; i < hexahedraIds.size(); i++)
+    sofa::helper::vector<HexahedronID> hexahedraIds_filtered;
+    for (size_t i = 0; i < hexahedraIds.size(); i++)
     {
         if( hexahedraIds[i] >= m_container->getNumberOfHexahedra())
             msg_error() << "Unable to remove the hexahedra: "<< hexahedraIds[i] <<" its index is out of bound." ;
@@ -687,13 +687,13 @@ void HexahedronSetTopologyModifier::removeHexahedra(const sofa::helper::vector< 
     m_container->checkTopology();
 }
 
-void HexahedronSetTopologyModifier::removeItems(const sofa::helper::vector< unsigned int >& items)
+void HexahedronSetTopologyModifier::removeItems(const sofa::helper::vector< HexahedronID >& items)
 {
     removeHexahedra(items);
 }
 
-void HexahedronSetTopologyModifier::renumberPoints(const sofa::helper::vector<unsigned int> &index,
-        const sofa::helper::vector<unsigned int> &inv_index)
+void HexahedronSetTopologyModifier::renumberPoints(const sofa::helper::vector<PointID> &index,
+        const sofa::helper::vector<PointID> &inv_index)
 {
     /// add the topological changes in the queue
     renumberPointsWarning(index, inv_index);

--- a/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyModifier.h
@@ -169,7 +169,7 @@ public:
     *
     * \sa addPointsWarning
     */
-    virtual void addPointsProcess(const unsigned int nPoints) override;
+    virtual void addPointsProcess(const size_t nPoints) override;
 
     /** \brief Remove a subset of points
     *

--- a/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyModifier.h
@@ -44,6 +44,7 @@ public:
 
 
     typedef core::topology::BaseMeshTopology::HexaID HexaID;
+    typedef core::topology::BaseMeshTopology::HexahedronID HexahedronID;
     typedef core::topology::BaseMeshTopology::Hexa Hexa;
     typedef core::topology::BaseMeshTopology::SeqHexahedra SeqHexahedra;
     typedef core::topology::BaseMeshTopology::HexahedraAroundVertex HexahedraAroundVertex;
@@ -82,25 +83,25 @@ public:
     *
     */
     virtual void addHexahedra(const sofa::helper::vector< Hexahedron > &hexahedra,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > > & ancestors,
+            const sofa::helper::vector< sofa::helper::vector< HexahedronID > > & ancestors,
             const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs) ;
 
     /** \brief Sends a message to warn that some hexahedra were added in this topology.
     *
     * \sa addHexahedraProcess
     */
-    void addHexahedraWarning(const unsigned int nHexahedra,
+    void addHexahedraWarning(const size_t nHexahedra,
             const sofa::helper::vector< Hexahedron >& hexahedraList,
-            const sofa::helper::vector< unsigned int >& hexahedraIndexList);
+            const sofa::helper::vector< HexahedronID >& hexahedraIndexList);
 
     /** \brief Sends a message to warn that some hexahedra were added in this topology.
     *
     * \sa addHexahedraProcess
     */
-    void addHexahedraWarning(const unsigned int nHexahedra,
+    void addHexahedraWarning(const size_t nHexahedra,
             const sofa::helper::vector< Hexahedron >& hexahedraList,
-            const sofa::helper::vector< unsigned int >& hexahedraIndexList,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > > & ancestors,
+            const sofa::helper::vector< HexahedronID >& hexahedraIndexList,
+            const sofa::helper::vector< sofa::helper::vector< HexahedronID > > & ancestors,
             const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs);
 
     /** \brief Add a hexahedron.
@@ -119,7 +120,7 @@ public:
     *
     * Important : parameter indices is not const because it is actually sorted from the highest index to the lowest one.
     */
-    virtual void removeHexahedraWarning( sofa::helper::vector<unsigned int> &hexahedra);
+    virtual void removeHexahedraWarning( sofa::helper::vector<HexahedronID> &hexahedra);
 
     /** \brief Remove a subset of hexahedra
     *
@@ -129,7 +130,7 @@ public:
     * \sa removeHexahedraWarning
     * @param removeIsolatedItems if true remove isolated quads, edges and vertices
     */
-    virtual void removeHexahedraProcess(const sofa::helper::vector<unsigned int>&indices,
+    virtual void removeHexahedraProcess(const sofa::helper::vector<HexahedronID>&indices,
             const bool removeIsolatedItems = false);
 
     /** \brief Actually Add some quads to this topology.
@@ -144,7 +145,7 @@ public:
     * @param removeIsolatedEdges if true isolated edges are also removed
     * @param removeIsolatedPoints if true isolated vertices are also removed
     */
-    virtual void removeQuadsProcess(const sofa::helper::vector<unsigned int> &indices,
+    virtual void removeQuadsProcess(const sofa::helper::vector<QuadID> &indices,
             const bool removeIsolatedEdges = false,
             const bool removeIsolatedPoints = false) override;
 
@@ -162,7 +163,7 @@ public:
     * Important : parameter indices is not const because it is actually sorted from the highest index to the lowest one.
     * @param removeIsolatedItems if true remove isolated vertices
     */
-    virtual void removeEdgesProcess(const sofa::helper::vector<unsigned int> &indices,
+    virtual void removeEdgesProcess(const sofa::helper::vector<EdgeID> &indices,
             const bool removeIsolatedItems = false) override;
 
     /** \brief Add some points to this topology.
@@ -179,31 +180,31 @@ public:
     * \sa removePointsWarning
     * Important : the points are actually deleted from the mechanical object's state vectors iff (removeDOF == true)
     */
-    virtual void removePointsProcess(const sofa::helper::vector<unsigned int> &indices, const bool removeDOF = true) override;
+    virtual void removePointsProcess(const sofa::helper::vector<PointID> &indices, const bool removeDOF = true) override;
 
     /** \brief Reorder this topology.
     *
     * Important : the points are actually renumbered in the mechanical object's state vectors iff (renumberDOF == true)
     * \see MechanicalObject::renumberValues
     */
-    virtual void renumberPointsProcess( const sofa::helper::vector<unsigned int> &index,
-            const sofa::helper::vector<unsigned int>& inv_index,
+    virtual void renumberPointsProcess( const sofa::helper::vector<PointID> &index,
+            const sofa::helper::vector<PointID>& inv_index,
             const bool renumberDOF = true) override;
 
     /** \brief Remove a set  of hexahedra
     @param hexahedra an array of hexahedron indices to be removed (note that the array is not const since it needs to be sorted)
     *
     */
-    virtual void removeHexahedra(const sofa::helper::vector<unsigned int> &hexahedraIds);
+    virtual void removeHexahedra(const sofa::helper::vector<HexahedronID> &hexahedraIds);
 
     /** \brief Generic method to remove a list of items.
     */
-    virtual void removeItems(const sofa::helper::vector<unsigned int> &items) override;
+    virtual void removeItems(const sofa::helper::vector<HexahedronID> &items) override;
 
     /** \brief Generic method for points renumbering
     */
-    virtual void renumberPoints( const sofa::helper::vector<unsigned int>& index,
-            const sofa::helper::vector<unsigned int>& inv_index) override;
+    virtual void renumberPoints( const sofa::helper::vector<PointID>& index,
+            const sofa::helper::vector<PointID>& inv_index) override;
 
 
 private:

--- a/SofaKernel/modules/SofaBaseTopology/MeshTopology.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/MeshTopology.cpp
@@ -2350,7 +2350,7 @@ bool MeshTopology::checkConnexity()
 }
 
 
-unsigned int MeshTopology::getNumberOfConnectedComponent()
+size_t MeshTopology::getNumberOfConnectedComponent()
 {
     size_t nbr = 0;
 

--- a/SofaKernel/modules/SofaBaseTopology/MeshTopology.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/MeshTopology.cpp
@@ -2641,7 +2641,7 @@ void MeshTopology::draw(const core::visual::VisualParams* vparams)
     {
         std::vector<defaulttype::Vector3> pos;
         pos.reserve(this->getNbEdges()*2u);
-        for (int i=0; i<getNbEdges(); i++)
+        for (EdgeID i=0; i<getNbEdges(); i++)
         {
             const Edge& c = getEdge(i);
             pos.push_back(defaulttype::Vector3(getPosX(c[0]), getPosY(c[0]), getPosZ(c[0])));
@@ -2655,7 +2655,7 @@ void MeshTopology::draw(const core::visual::VisualParams* vparams)
     {
         std::vector<defaulttype::Vector3> pos;
         pos.reserve(this->getNbTriangles()*3u);
-        for (int i=0; i<getNbTriangles(); i++)
+        for (TriangleID i=0; i<getNbTriangles(); i++)
         {
             const Triangle& c = getTriangle(i);
             pos.push_back(defaulttype::Vector3(getPosX(c[0]), getPosY(c[0]), getPosZ(c[0])));
@@ -2670,7 +2670,7 @@ void MeshTopology::draw(const core::visual::VisualParams* vparams)
     {
         std::vector<defaulttype::Vector3> pos;
         pos.reserve(this->getNbQuads()*4u);
-        for (int i=0; i<getNbQuads(); i++)
+        for (QuadID i=0; i<getNbQuads(); i++)
         {
             const Quad& c = getQuad(i);
             pos.push_back(defaulttype::Vector3(getPosX(c[0]), getPosY(c[0]), getPosZ(c[0])));
@@ -2688,7 +2688,7 @@ void MeshTopology::draw(const core::visual::VisualParams* vparams)
         std::vector<defaulttype::Vector3> pos2;
         pos1.reserve(this->getNbHexahedra()*8u);
         pos2.reserve(this->getNbHexahedra()*8u);
-        for (int i=0; i<getNbHexahedra(); i++)
+        for (HexahedronID i=0; i<getNbHexahedra(); i++)
         {
             const Hexa& c = getHexahedron(i);
             pos1.push_back(defaulttype::Vector3(getPosX(c[0]), getPosY(c[0]), getPosZ(c[0])));
@@ -2718,7 +2718,7 @@ void MeshTopology::draw(const core::visual::VisualParams* vparams)
     {
         std::vector<defaulttype::Vector3> pos;
         pos.reserve(this->getNbTetrahedra()*12u);
-        for (int i=0; i<getNbTetras(); i++)
+        for (TetrahedronID i=0; i<getNbTetras(); i++)
         {
             const Tetra& t = getTetra(i);
             pos.push_back(defaulttype::Vector3(getPosX(t[0]), getPosY(t[0]), getPosZ(t[0])));

--- a/SofaKernel/modules/SofaBaseTopology/MeshTopology.h
+++ b/SofaKernel/modules/SofaBaseTopology/MeshTopology.h
@@ -183,7 +183,7 @@ public:
     virtual bool checkConnexity() override;
 
     /// Returns the number of connected component.
-    virtual unsigned int getNumberOfConnectedComponent() override;
+    virtual size_t getNumberOfConnectedComponent() override;
 
     /// Returns the set of element indices connected to an input one (i.e. which can be reached by topological links)
     virtual const helper::vector<unsigned int> getConnectedElement(unsigned int elem) override;

--- a/SofaKernel/modules/SofaBaseTopology/PointSetGeometryAlgorithms.h
+++ b/SofaKernel/modules/SofaBaseTopology/PointSetGeometryAlgorithms.h
@@ -120,7 +120,7 @@ public:
 
     /** \brief Process the added point initialization according to the topology and local coordinates.
     */
-    virtual void initPointAdded(unsigned int indice, const core::topology::PointAncestorElem &ancestorElem, const helper::vector< VecCoord* >& coordVecs, const helper::vector< VecDeriv* >& derivVecs);
+    virtual void initPointAdded(PointID indice, const core::topology::PointAncestorElem &ancestorElem, const helper::vector< VecCoord* >& coordVecs, const helper::vector< VecDeriv* >& derivVecs);
 
 protected:
     /** the object where the mechanical DOFs are stored */

--- a/SofaKernel/modules/SofaBaseTopology/PointSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/PointSetGeometryAlgorithms.inl
@@ -228,7 +228,7 @@ void PointSetGeometryAlgorithms<DataTypes>::initPointsAdded(const helper::vector
 
 
 template<class DataTypes>
-void PointSetGeometryAlgorithms<DataTypes>::initPointAdded(unsigned int index, const core::topology::PointAncestorElem &ancestorElem
+void PointSetGeometryAlgorithms<DataTypes>::initPointAdded(PointID index, const core::topology::PointAncestorElem &ancestorElem
     , const helper::vector< VecCoord* >& coordVecs, const helper::vector< VecDeriv* >& /*derivVecs*/)
 
 {

--- a/SofaKernel/modules/SofaBaseTopology/PointSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/PointSetTopologyContainer.cpp
@@ -87,7 +87,7 @@ void PointSetTopologyContainer::setNbPoints(int n)
     nbPoints.setValue(n);  
 }
 
-unsigned int PointSetTopologyContainer::getNumberOfElements() const
+size_t PointSetTopologyContainer::getNumberOfElements() const
 {
     return nbPoints.getValue();
 }

--- a/SofaKernel/modules/SofaBaseTopology/PointSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/PointSetTopologyContainer.h
@@ -76,7 +76,7 @@ public:
     /** \brief Returns the number of topological element of the current topology.
      * This function avoids to know which topological container is in used.
      */
-    virtual unsigned int getNumberOfElements() const;
+    virtual size_t getNumberOfElements() const;
 
     /** \brief Returns a reference to the Data of points array container. */
     Data<InitTypes::VecCoord>& getPointDataArray() {return d_initPoints;}

--- a/SofaKernel/modules/SofaBaseTopology/PointSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/PointSetTopologyModifier.cpp
@@ -72,10 +72,10 @@ void PointSetTopologyModifier::addPointsProcess(const size_t nPoints)
 void PointSetTopologyModifier::addPointsWarning(const size_t nPoints, const bool addDOF)
 {
     m_container->setPointTopologyToDirty();
-    const PointID startIndex = m_container->getNbPoints()-nPoints;
+    const size_t startIndex = m_container->getNbPoints()-nPoints;
     sofa::helper::vector <PointID> indices; indices.resize(nPoints);
     for(size_t i=0; i<nPoints; ++i)
-        indices[i] = startIndex+i;
+        indices[i] = PointID(startIndex+i);
 
     if(addDOF)
     {
@@ -96,10 +96,10 @@ void PointSetTopologyModifier::addPointsWarning(const size_t nPoints,
         const bool addDOF)
 {
     m_container->setPointTopologyToDirty();
-    const PointID startIndex = m_container->getNbPoints()-nPoints;
+    const size_t startIndex = m_container->getNbPoints()-nPoints;
     sofa::helper::vector <PointID> indices; indices.resize(nPoints);
     for(size_t i=0; i<nPoints; ++i)
-        indices[i] = startIndex+i;
+        indices[i] = PointID(startIndex+i);
 
     if(addDOF)
     {
@@ -127,7 +127,7 @@ void PointSetTopologyModifier::addPointsWarning(const size_t nPoints,
     // Compute standard points construction info based on ancestor points
     // related to topology elems and local coordinates
 
-    const PointID startIndex = m_container->getNbPoints() - nPoints;
+    const size_t startIndex = m_container->getNbPoints() - nPoints;
 
     helper::vector< PointID > newPointIndices;
     helper::vector< helper::vector< PointID > > ancestorPointIndices;
@@ -139,7 +139,7 @@ void PointSetTopologyModifier::addPointsWarning(const size_t nPoints,
 
     for(size_t i = 0; i < nPoints; ++i)
     {
-        newPointIndices[i] = startIndex + i;
+        newPointIndices[i] = PointID(startIndex + i);
         PointID ancestorIndex = ancestorElems[i].index;
         // check if this new point has indeed an ancestor.
         if (ancestorIndex != core::topology::BaseMeshTopology::InvalidID )

--- a/SofaKernel/modules/SofaBaseTopology/PointSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/PointSetTopologyModifier.cpp
@@ -64,17 +64,17 @@ void PointSetTopologyModifier::swapPoints(const int i1, const int i2)
 }
 
 
-void PointSetTopologyModifier::addPointsProcess(const unsigned int nPoints)
+void PointSetTopologyModifier::addPointsProcess(const size_t nPoints)
 {
     m_container->addPoints(nPoints);
 }
 
-void PointSetTopologyModifier::addPointsWarning(const unsigned int nPoints, const bool addDOF)
+void PointSetTopologyModifier::addPointsWarning(const size_t nPoints, const bool addDOF)
 {
     m_container->setPointTopologyToDirty();
-    const unsigned int startIndex = m_container->getNbPoints()-nPoints;
-    sofa::helper::vector <unsigned int> indices; indices.resize(nPoints);
-    for(unsigned int i=0; i<nPoints; ++i)
+    const PointID startIndex = m_container->getNbPoints()-nPoints;
+    sofa::helper::vector <PointID> indices; indices.resize(nPoints);
+    for(size_t i=0; i<nPoints; ++i)
         indices[i] = startIndex+i;
 
     if(addDOF)
@@ -90,15 +90,15 @@ void PointSetTopologyModifier::addPointsWarning(const unsigned int nPoints, cons
 }
 
 
-void PointSetTopologyModifier::addPointsWarning(const unsigned int nPoints,
-        const sofa::helper::vector< sofa::helper::vector< unsigned int > > &ancestors,
+void PointSetTopologyModifier::addPointsWarning(const size_t nPoints,
+        const sofa::helper::vector< sofa::helper::vector< PointID > > &ancestors,
         const sofa::helper::vector< sofa::helper::vector< double       > >& coefs,
         const bool addDOF)
 {
     m_container->setPointTopologyToDirty();
-    const unsigned int startIndex = m_container->getNbPoints()-nPoints;
-    sofa::helper::vector <unsigned int> indices; indices.resize(nPoints);
-    for(unsigned int i=0; i<nPoints; ++i)
+    const PointID startIndex = m_container->getNbPoints()-nPoints;
+    sofa::helper::vector <PointID> indices; indices.resize(nPoints);
+    for(size_t i=0; i<nPoints; ++i)
         indices[i] = startIndex+i;
 
     if(addDOF)
@@ -114,7 +114,7 @@ void PointSetTopologyModifier::addPointsWarning(const unsigned int nPoints,
 }
 
 
-void PointSetTopologyModifier::addPointsWarning(const unsigned int nPoints,
+void PointSetTopologyModifier::addPointsWarning(const size_t nPoints,
         const sofa::helper::vector< core::topology::PointAncestorElem >& ancestorElems,
         const bool addDOF)
 {
@@ -127,20 +127,20 @@ void PointSetTopologyModifier::addPointsWarning(const unsigned int nPoints,
     // Compute standard points construction info based on ancestor points
     // related to topology elems and local coordinates
 
-    const unsigned int startIndex = m_container->getNbPoints() - nPoints;
+    const PointID startIndex = m_container->getNbPoints() - nPoints;
 
-    helper::vector< unsigned int > newPointIndices;
-    helper::vector< helper::vector< unsigned int > > ancestorPointIndices;
+    helper::vector< PointID > newPointIndices;
+    helper::vector< helper::vector< PointID > > ancestorPointIndices;
     helper::vector< helper::vector< double       > > baryCoefs;
 
     newPointIndices.resize(nPoints);
     ancestorPointIndices.resize(nPoints);
     baryCoefs.resize(nPoints);
 
-    for(unsigned int i = 0; i < nPoints; ++i)
+    for(size_t i = 0; i < nPoints; ++i)
     {
         newPointIndices[i] = startIndex + i;
-        unsigned int ancestorIndex = ancestorElems[i].index;
+        PointID ancestorIndex = ancestorElems[i].index;
         // check if this new point has indeed an ancestor.
         if (ancestorIndex != core::topology::BaseMeshTopology::InvalidID )
         {
@@ -263,7 +263,7 @@ void PointSetTopologyModifier::addPointsWarning(const unsigned int nPoints,
 }
 
 
-void PointSetTopologyModifier::addPoints(const unsigned int nPoints,
+void PointSetTopologyModifier::addPoints(const size_t nPoints,
                                          const bool addDOF)
 {
     addPointsProcess(nPoints);
@@ -271,8 +271,8 @@ void PointSetTopologyModifier::addPoints(const unsigned int nPoints,
     propagateTopologicalChanges();
 }
 
-void PointSetTopologyModifier::addPoints(const unsigned int nPoints,
-     const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors,
+void PointSetTopologyModifier::addPoints(const size_t nPoints,
+     const sofa::helper::vector< sofa::helper::vector< PointID > >& ancestors,
      const sofa::helper::vector< sofa::helper::vector< double> >& coefs,
      const bool addDOF)
 {
@@ -281,7 +281,7 @@ void PointSetTopologyModifier::addPoints(const unsigned int nPoints,
     propagateTopologicalChanges();
 }
 
-void PointSetTopologyModifier::addPoints(const unsigned int nPoints,
+void PointSetTopologyModifier::addPoints(const size_t nPoints,
      const sofa::helper::vector< core::topology::PointAncestorElem >& srcElems,
      const bool addDOF)
 {
@@ -290,8 +290,8 @@ void PointSetTopologyModifier::addPoints(const unsigned int nPoints,
     propagateTopologicalChanges();
 }
 
-void PointSetTopologyModifier::movePointsProcess (const sofa::helper::vector <unsigned int>& id,
-        const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors,
+void PointSetTopologyModifier::movePointsProcess (const sofa::helper::vector <PointID>& id,
+        const sofa::helper::vector< sofa::helper::vector< PointID > >& ancestors,
         const sofa::helper::vector< sofa::helper::vector< double > >& coefs,
         const bool moveDOF)
 {
@@ -314,13 +314,13 @@ void PointSetTopologyModifier::movePointsProcess (const sofa::helper::vector <un
 
 
 
-void PointSetTopologyModifier::removePointsWarning(sofa::helper::vector<unsigned int> &indices,
+void PointSetTopologyModifier::removePointsWarning(sofa::helper::vector<PointID> &indices,
         const bool removeDOF)
 {
     m_container->setPointTopologyToDirty();
 
     // sort points so that they are removed in a descending order
-    std::sort( indices.begin(), indices.end(), std::greater<unsigned int>() );
+    std::sort( indices.begin(), indices.end(), std::greater<PointID>() );
 
     // Warning that these vertices will be deleted
     PointsRemoved *e = new PointsRemoved(indices);
@@ -334,19 +334,19 @@ void PointSetTopologyModifier::removePointsWarning(sofa::helper::vector<unsigned
 }
 
 
-void PointSetTopologyModifier::removePointsProcess(const sofa::helper::vector<unsigned int> & indices,
+void PointSetTopologyModifier::removePointsProcess(const sofa::helper::vector<PointID> & indices,
         const bool removeDOF)
 {
     if(removeDOF)
     {
         propagateStateChanges();
     }
-    m_container->removePoints((unsigned int)indices.size());
+    m_container->removePoints(indices.size());
 }
 
 
-void PointSetTopologyModifier::renumberPointsWarning( const sofa::helper::vector<unsigned int> &index,
-        const sofa::helper::vector<unsigned int> &inv_index,
+void PointSetTopologyModifier::renumberPointsWarning( const sofa::helper::vector<PointID> &index,
+        const sofa::helper::vector<PointID> &inv_index,
         const bool renumberDOF)
 {
     // Warning that these vertices will be deleted
@@ -361,8 +361,8 @@ void PointSetTopologyModifier::renumberPointsWarning( const sofa::helper::vector
 }
 
 
-void PointSetTopologyModifier::renumberPointsProcess( const sofa::helper::vector<unsigned int> &/*index*/,
-        const sofa::helper::vector<unsigned int> &/*inv_index*/,
+void PointSetTopologyModifier::renumberPointsProcess( const sofa::helper::vector<PointID> &/*index*/,
+        const sofa::helper::vector<PointID> &/*inv_index*/,
         const bool renumberDOF)
 {
     if(renumberDOF)

--- a/SofaKernel/modules/SofaBaseTopology/PointSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/PointSetTopologyModifier.h
@@ -44,6 +44,9 @@ class SOFA_BASE_TOPOLOGY_API PointSetTopologyModifier : public core::topology::T
 {
 public:
     SOFA_CLASS(PointSetTopologyModifier,core::topology::TopologyModifier);
+    
+    typedef core::topology::BaseMeshTopology::PointID PointID;
+
 protected:
     PointSetTopologyModifier()
         : TopologyModifier()
@@ -62,22 +65,22 @@ public:
     *
     * \sa addPointsProcess
     */
-    void addPointsWarning(const unsigned int nPoints, const bool addDOF = true);
+    void addPointsWarning(const size_t nPoints, const bool addDOF = true);
 
     /** \brief Sends a message to warn that some points were added in this topology.
     *
     * \sa addPointsProcess
     */
-    void addPointsWarning(const unsigned int nPoints,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors,
-            const sofa::helper::vector< sofa::helper::vector< double       > >& coefs,
+    void addPointsWarning(const size_t nPoints,
+            const sofa::helper::vector< sofa::helper::vector< PointID > >& ancestors,
+            const sofa::helper::vector< sofa::helper::vector< SReal > >& coefs,
             const bool addDOF = true);
 
     /** \brief Sends a message to warn that some points were added in this topology.
     *
     * \sa addPointsProcess
     */
-    void addPointsWarning(const unsigned int nPoints,
+    void addPointsWarning(const size_t nPoints,
             const sofa::helper::vector< core::topology::PointAncestorElem >& ancestorElems,
             const bool addDOF = true);
 
@@ -86,28 +89,28 @@ public:
     *
     * \sa addPointsWarning
     */
-    virtual void addPointsProcess(const unsigned int nPoints);
+    virtual void addPointsProcess(const size_t nPoints);
 
     /** \brief Add a set of points
     * 
     * \sa addPoints
     */
-    virtual void addPoints(const unsigned int nPoints, const bool addDOF = true);
+    virtual void addPoints(const size_t nPoints, const bool addDOF = true);
  
     /** \brief Add a set of points
     * 
     * \sa addPoints
     */
-    virtual void addPoints(const unsigned int nPoints,
-                           const sofa::helper::vector< sofa::helper::vector< unsigned int> >& ancestors,
-                           const sofa::helper::vector< sofa::helper::vector< double      > >& coefs,
+    virtual void addPoints(const size_t nPoints,
+                           const sofa::helper::vector< sofa::helper::vector< PointID > >& ancestors,
+                           const sofa::helper::vector< sofa::helper::vector< SReal > >& coefs,
                            const bool addDOF = true);
 
     /** \brief Add a set of points according to their ancestors topology elements
      *
      * \sa addPoints
      */
-    void addPoints( const unsigned int nPoints,
+    void addPoints( const size_t nPoints,
                     const sofa::helper::vector< core::topology::PointAncestorElem >& ancestorElems,
                     const bool addDOF = true);
 
@@ -117,7 +120,7 @@ public:
     * \sa removePointsProcess
     */
     // side effect: indices are sorted first
-    void removePointsWarning(/*const*/ sofa::helper::vector<unsigned int> &indices,
+    void removePointsWarning(/*const*/ sofa::helper::vector< PointID > &indices,
             const bool removeDOF = true);
 
 
@@ -131,7 +134,7 @@ public:
     * @param indices is not const because it is actually sorted from the highest index to the lowest one.
     * @param removeDOF if true the points are actually deleted from the mechanical object's state vectors
     */
-    virtual void removePointsProcess(const sofa::helper::vector<unsigned int> &indices,
+    virtual void removePointsProcess(const sofa::helper::vector< PointID > &indices,
             const bool removeDOF = true);
 
     /** \brief move input points indices to input new coords. Also propagate event
@@ -141,17 +144,17 @@ public:
      * @param coefs : barycoef to locate new coord relatively to ancestors.
      * @moveDOF bool allowing the move (default true)
      */
-    virtual void movePointsProcess (const sofa::helper::vector <unsigned int>& id,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors,
-            const sofa::helper::vector< sofa::helper::vector< double > >& coefs,
+    virtual void movePointsProcess (const sofa::helper::vector < PointID >& id,
+            const sofa::helper::vector< sofa::helper::vector< PointID > >& ancestors,
+            const sofa::helper::vector< sofa::helper::vector< SReal > >& coefs,
             const bool moveDOF = true);
 
     /** \brief Sends a message to warn that points are about to be reordered.
     *
     * \sa renumberPointsProcess
     */
-    void renumberPointsWarning( const sofa::helper::vector<unsigned int> &index,
-            const sofa::helper::vector<unsigned int> &inv_index,
+    void renumberPointsWarning( const sofa::helper::vector< PointID > &index,
+            const sofa::helper::vector< PointID > &inv_index,
             const bool renumberDOF = true);
 
     /** \brief Reorder this topology.
@@ -159,8 +162,8 @@ public:
     * Important : the points are actually renumbered in the mechanical object's state vectors iff (renumberDOF == true)
     * \see MechanicalObject::renumberValues
     */
-    virtual void renumberPointsProcess( const sofa::helper::vector<unsigned int> &index,
-            const sofa::helper::vector<unsigned int> &/*inv_index*/,
+    virtual void renumberPointsProcess( const sofa::helper::vector< PointID > &index,
+            const sofa::helper::vector< PointID > &/*inv_index*/,
             const bool renumberDOF = true);
 
     /** \brief Called by a topology to warn specific topologies linked to it that TopologyChange objects happened.
@@ -200,13 +203,13 @@ public:
 
     /** \brief Generic method to remove a list of items.
     */
-    virtual void removeItems(const sofa::helper::vector< unsigned int >& /*items*/) override
+    virtual void removeItems(const sofa::helper::vector<  PointID  >& /*items*/) override
     { }
 
     /** \brief Generic method for points renumbering
     */
-    virtual void renumberPoints( const sofa::helper::vector<unsigned int> &/*index*/,
-            const sofa::helper::vector<unsigned int> &/*inv_index*/)
+    virtual void renumberPoints( const sofa::helper::vector< PointID > &/*index*/,
+            const sofa::helper::vector< PointID > &/*inv_index*/)
     { }
 
 private:

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetGeometryAlgorithms.h
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetGeometryAlgorithms.h
@@ -98,7 +98,7 @@ public:
     * is included or not in the plane defined by (ind_p, plane_vect)
     *
     */
-    bool isQuadInPlane(const QuadID ind_q, const unsigned int ind_p,
+    bool isQuadInPlane(const QuadID ind_q, const PointID ind_p,
             const defaulttype::Vec<3,Real>& plane_vect) const;
 
     bool isPointInQuad(const QuadID ind_q, const sofa::defaulttype::Vec<3,Real>& p) const;

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetGeometryAlgorithms.h
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetGeometryAlgorithms.h
@@ -40,6 +40,7 @@ class QuadSetGeometryAlgorithms : public EdgeSetGeometryAlgorithms<DataTypes>
 public:
     SOFA_CLASS(SOFA_TEMPLATE(QuadSetGeometryAlgorithms,DataTypes),SOFA_TEMPLATE(EdgeSetGeometryAlgorithms,DataTypes));
 
+    typedef sofa::core::topology::BaseMeshTopology::PointID PointID;
     typedef sofa::core::topology::BaseMeshTopology::EdgeID EdgeID;
     typedef sofa::core::topology::BaseMeshTopology::Edge Edge;
     typedef sofa::core::topology::BaseMeshTopology::SeqEdges SeqEdges;

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetGeometryAlgorithms.inl
@@ -150,7 +150,7 @@ sofa::defaulttype::Vec<3,double> QuadSetGeometryAlgorithms< DataTypes >::compute
 // Test if a quad indexed by ind_quad (and incident to the vertex indexed by ind_p) is included or not in the plane defined by (ind_p, plane_vect)
 template<class DataTypes>
 bool QuadSetGeometryAlgorithms< DataTypes >::isQuadInPlane(const QuadID ind_q,
-        const unsigned int ind_p,
+        const PointID ind_p,
         const sofa::defaulttype::Vec<3,Real>&plane_vect) const
 {
     const Quad &q = this->m_topology->getQuad(ind_q);
@@ -159,9 +159,9 @@ bool QuadSetGeometryAlgorithms< DataTypes >::isQuadInPlane(const QuadID ind_q,
 
     const typename DataTypes::VecCoord& vect_c =(this->object->read(core::ConstVecCoordId::position())->getValue());
 
-    unsigned int ind_1;
-    unsigned int ind_2;
-    unsigned int ind_3;
+    PointID ind_1;
+    PointID ind_2;
+    PointID ind_3;
 
     if(ind_p==q[0])
     {
@@ -268,7 +268,7 @@ void QuadSetGeometryAlgorithms<DataTypes>::writeMSHfile(const char *filename) co
     myfile << "$NOD\n";
     myfile << numVertices <<"\n";
 
-    for(unsigned int i=0; i<numVertices; ++i)
+    for(size_t i=0; i<numVertices; ++i)
     {
         double x = (double) vect_c[i][0];
         double y = (double) vect_c[i][1];
@@ -284,7 +284,7 @@ void QuadSetGeometryAlgorithms<DataTypes>::writeMSHfile(const char *filename) co
 
     myfile << qa.size() <<"\n";
 
-    for(unsigned int i=0; i<qa.size(); ++i)
+    for(size_t i=0; i<qa.size(); ++i)
     {
         myfile << i+1 << " 3 1 1 4 " << qa[i][0]+1 << " " << qa[i][1]+1 << " " << qa[i][2]+1 << " " << qa[i][3]+1 << "\n";
     }
@@ -365,7 +365,7 @@ void QuadSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
         const sofa::helper::vector<Quad>& quadArray = this->m_topology->getQuads();
 
         std::vector<defaulttype::Vector3> positions;
-        for (unsigned int i =0; i<quadArray.size(); i++)
+        for (size_t i =0; i<quadArray.size(); i++)
         {
 
             Quad the_quad = quadArray[i];
@@ -396,10 +396,10 @@ void QuadSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
             { // drawing quads
                 std::vector<defaulttype::Vector3> pos;
                 pos.reserve(quadArray.size()*4u);
-                for (unsigned int i=0u; i< quadArray.size(); i++)
+                for (size_t i=0u; i< quadArray.size(); i++)
                 {
                     const Quad& q = quadArray[i];
-                    for (unsigned int j = 0u; j<4u; j++)
+                    for (unsigned int j = 0; j<4; j++)
                     {
                         pos.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[q[j]])));
                     }
@@ -415,17 +415,17 @@ void QuadSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
 
                 if (!edgeArray.empty())
                 {
-                    for (unsigned int i = 0u; i<edgeArray.size(); i++)
+                    for (size_t i = 0u; i<edgeArray.size(); i++)
                     {
                         const Edge& e = edgeArray[i];
                         pos.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[e[0]])));
                         pos.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[e[1]])));
                     }
                 } else {
-                    for (unsigned int i = 0u; i<quadArray.size(); i++)
+                    for (size_t i = 0u; i<quadArray.size(); i++)
                     {
                         const Quad& q = quadArray[i];
-                        for (unsigned int j = 0u; j<4u; j++)
+                        for (unsigned int j = 0; j<4; j++)
                         {
                             pos.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[q[j]])));
                             pos.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[q[(j+1u)%4u]])));

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyContainer.cpp
@@ -310,7 +310,7 @@ unsigned int QuadSetTopologyContainer::getNumberOfQuads() const
 }
 
 
-unsigned int QuadSetTopologyContainer::getNumberOfElements() const
+size_t QuadSetTopologyContainer::getNumberOfElements() const
 {
     return this->getNumberOfQuads();
 }
@@ -557,7 +557,7 @@ bool QuadSetTopologyContainer::checkConnexity()
 }
 
 
-unsigned int QuadSetTopologyContainer::getNumberOfConnectedComponent()
+size_t QuadSetTopologyContainer::getNumberOfConnectedComponent()
 {
     size_t nbr = this->getNbQuads();
 

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyContainer.cpp
@@ -99,7 +99,7 @@ void QuadSetTopologyContainer::createQuadsAroundVertexArray()
         // adding quad i in the quad shell of all points
         for (size_t j=0; j<4; ++j)
         {
-            m_quadsAroundVertex[ m_quad[i][j] ].push_back((unsigned int)i);
+            m_quadsAroundVertex[ m_quad[i][j] ].push_back((QuadID)i);
         }
     }
 }
@@ -140,7 +140,7 @@ void QuadSetTopologyContainer::createQuadsAroundEdgeArray()
         // adding quad i in the quad shell of all edges
         for (size_t j=0; j<4; ++j)
         {
-            m_quadsAroundEdge[ m_edgesInQuad[i][j] ].push_back((unsigned int)i);
+            m_quadsAroundEdge[ m_edgesInQuad[i][j] ].push_back((QuadID)i);
         }
     }
 }
@@ -172,7 +172,7 @@ void QuadSetTopologyContainer::createEdgeSetArray()
     }
 
     // create a temporary map to find redundant edges
-    std::map<Edge, unsigned int> edgeMap;
+    std::map<Edge, EdgeID> edgeMap;
     helper::WriteAccessor< Data< sofa::helper::vector<Edge> > > m_edge = d_edge;
     helper::ReadAccessor< Data< sofa::helper::vector<Quad> > > m_quad = d_quad;
 
@@ -181,8 +181,8 @@ void QuadSetTopologyContainer::createEdgeSetArray()
         const Quad &t = m_quad[i];
         for(size_t j=0; j<4; ++j)
         {
-            const unsigned int v1 = t[(j+1)%4];
-            const unsigned int v2 = t[(j+2)%4];
+            const PointID v1 = t[(j+1)%4];
+            const PointID v2 = t[(j+2)%4];
 
             // sort vertices in lexicographic order
             const Edge e = ((v1<v2) ? Edge(v1,v2) : Edge(v2,v1));
@@ -190,7 +190,7 @@ void QuadSetTopologyContainer::createEdgeSetArray()
             if(edgeMap.find(e) == edgeMap.end())
             {
                 // edge not in edgeMap so create a new one
-                const unsigned int edgeIndex = (unsigned int)edgeMap.size();
+                const EdgeID edgeIndex = (EdgeID)edgeMap.size();
                 edgeMap[e] = edgeIndex;
                 m_edge.push_back(e);
             }
@@ -266,10 +266,10 @@ int QuadSetTopologyContainer::getQuadIndex(PointID v1, PointID v2, PointID v3, P
     if(!hasQuadsAroundVertex())
         createQuadsAroundVertexArray();
 
-    sofa::helper::vector<unsigned int> set1 = getQuadsAroundVertex(v1);
-    sofa::helper::vector<unsigned int> set2 = getQuadsAroundVertex(v2);
-    sofa::helper::vector<unsigned int> set3 = getQuadsAroundVertex(v3);
-    sofa::helper::vector<unsigned int> set4 = getQuadsAroundVertex(v4);
+    sofa::helper::vector<QuadID> set1 = getQuadsAroundVertex(v1);
+    sofa::helper::vector<QuadID> set2 = getQuadsAroundVertex(v2);
+    sofa::helper::vector<QuadID> set3 = getQuadsAroundVertex(v3);
+    sofa::helper::vector<QuadID> set4 = getQuadsAroundVertex(v4);
 
     sort(set1.begin(), set1.end());
     sort(set2.begin(), set2.end());
@@ -277,18 +277,18 @@ int QuadSetTopologyContainer::getQuadIndex(PointID v1, PointID v2, PointID v3, P
     sort(set4.begin(), set4.end());
 
     // The destination vector must be large enough to contain the result.
-    sofa::helper::vector<unsigned int> out1(set1.size()+set2.size());
-    sofa::helper::vector<unsigned int>::iterator result1;
+    sofa::helper::vector<QuadID> out1(set1.size()+set2.size());
+    sofa::helper::vector<QuadID>::iterator result1;
     result1 = std::set_intersection(set1.begin(),set1.end(),set2.begin(),set2.end(),out1.begin());
     out1.erase(result1,out1.end());
 
-    sofa::helper::vector<unsigned int> out2(set3.size()+out1.size());
-    sofa::helper::vector<unsigned int>::iterator result2;
+    sofa::helper::vector<QuadID> out2(set3.size()+out1.size());
+    sofa::helper::vector<QuadID>::iterator result2;
     result2 = std::set_intersection(set3.begin(),set3.end(),out1.begin(),out1.end(),out2.begin());
     out2.erase(result2,out2.end());
 
-    sofa::helper::vector<unsigned int> out3(set4.size()+out2.size());
-    sofa::helper::vector<unsigned int>::iterator result3;
+    sofa::helper::vector<QuadID> out3(set4.size()+out2.size());
+    sofa::helper::vector<QuadID>::iterator result3;
     result3 = std::set_intersection(set4.begin(),set4.end(),out2.begin(),out2.end(),out3.begin());
     out3.erase(result3,out3.end());
 
@@ -303,10 +303,10 @@ int QuadSetTopologyContainer::getQuadIndex(PointID v1, PointID v2, PointID v3, P
         return -1;
 }
 
-unsigned int QuadSetTopologyContainer::getNumberOfQuads() const
+size_t QuadSetTopologyContainer::getNumberOfQuads() const
 {
     helper::ReadAccessor< Data< sofa::helper::vector<Quad> > > m_quad = d_quad;
-    return (unsigned int)m_quad.size();
+    return m_quad.size();
 }
 
 
@@ -316,7 +316,7 @@ size_t QuadSetTopologyContainer::getNumberOfElements() const
 }
 
 
-const sofa::helper::vector< sofa::helper::vector<unsigned int> > &QuadSetTopologyContainer::getQuadsAroundVertexArray()
+const sofa::helper::vector< QuadSetTopologyContainer::QuadsAroundVertex > &QuadSetTopologyContainer::getQuadsAroundVertexArray()
 {
     if(!hasQuadsAroundVertex())	// this method should only be called when the shell array exists
     {
@@ -329,7 +329,7 @@ const sofa::helper::vector< sofa::helper::vector<unsigned int> > &QuadSetTopolog
     return m_quadsAroundVertex;
 }
 
-const sofa::helper::vector< sofa::helper::vector<unsigned int> > &QuadSetTopologyContainer::getQuadsAroundEdgeArray()
+const sofa::helper::vector< QuadSetTopologyContainer::QuadsAroundEdge > &QuadSetTopologyContainer::getQuadsAroundEdgeArray()
 {
     if(!hasQuadsAroundEdge())	// this method should only be called when the shell array exists
     {
@@ -390,7 +390,7 @@ const QuadSetTopologyContainer::QuadsAroundEdge& QuadSetTopologyContainer::getQu
     return m_quadsAroundEdge[i];
 }
 
-const QuadSetTopologyContainer::EdgesInQuad &QuadSetTopologyContainer::getEdgesInQuad(const unsigned int i)
+const QuadSetTopologyContainer::EdgesInQuad &QuadSetTopologyContainer::getEdgesInQuad(QuadID i)
 {
     if(m_edgesInQuad.empty())
         createEdgesInQuadArray();
@@ -406,7 +406,7 @@ const QuadSetTopologyContainer::EdgesInQuad &QuadSetTopologyContainer::getEdgesI
     return m_edgesInQuad[i];
 }
 
-int QuadSetTopologyContainer::getVertexIndexInQuad(const Quad &t, unsigned int vertexIndex) const
+int QuadSetTopologyContainer::getVertexIndexInQuad(const Quad &t, PointID vertexIndex) const
 {
     if(t[0]==vertexIndex)
         return 0;
@@ -420,7 +420,7 @@ int QuadSetTopologyContainer::getVertexIndexInQuad(const Quad &t, unsigned int v
         return -1;
 }
 
-int QuadSetTopologyContainer::getEdgeIndexInQuad(const EdgesInQuad &t, unsigned int edgeIndex) const
+int QuadSetTopologyContainer::getEdgeIndexInQuad(const EdgesInQuad &t, EdgeID edgeIndex) const
 {
     if(t[0]==edgeIndex)
         return 0;
@@ -434,7 +434,7 @@ int QuadSetTopologyContainer::getEdgeIndexInQuad(const EdgesInQuad &t, unsigned 
         return -1;
 }
 
-sofa::helper::vector< unsigned int > &QuadSetTopologyContainer::getQuadsAroundEdgeForModification(const unsigned int i)
+QuadSetTopologyContainer::QuadsAroundEdge &QuadSetTopologyContainer::getQuadsAroundEdgeForModification(const EdgeID i)
 {
     if(!hasQuadsAroundEdge())	// this method should only be called when the shell array exists
     {
@@ -455,7 +455,7 @@ sofa::helper::vector< unsigned int > &QuadSetTopologyContainer::getQuadsAroundEd
     return m_quadsAroundEdge[i];
 }
 
-sofa::helper::vector< unsigned int > &QuadSetTopologyContainer::getQuadsAroundVertexForModification(const unsigned int i)
+QuadSetTopologyContainer::QuadsAroundVertex &QuadSetTopologyContainer::getQuadsAroundVertexForModification(const PointID i)
 {
     if(!hasQuadsAroundVertex())	// this method should only be called when the shell array exists
     {
@@ -487,7 +487,7 @@ bool QuadSetTopologyContainer::checkTopology() const
     {
         for (size_t i=0; i<m_quadsAroundVertex.size(); ++i)
         {
-            const sofa::helper::vector<unsigned int> &tvs = m_quadsAroundVertex[i];
+            const sofa::helper::vector<QuadID> &tvs = m_quadsAroundVertex[i];
             for (size_t j=0; j<tvs.size(); ++j)
             {
                 if((m_quad[tvs[j]][0]!=i)
@@ -506,7 +506,7 @@ bool QuadSetTopologyContainer::checkTopology() const
     {
         for (size_t i=0; i<m_quadsAroundEdge.size(); ++i)
         {
-            const sofa::helper::vector<unsigned int> &tes = m_quadsAroundEdge[i];
+            const sofa::helper::vector<QuadID> &tes = m_quadsAroundEdge[i];
             for (size_t j=0; j<tes.size(); ++j)
             {
                 if((m_edgesInQuad[tes[j]][0]!=i)
@@ -570,7 +570,7 @@ size_t QuadSetTopologyContainer::getNumberOfConnectedComponent()
     }
 
     VecQuadID elemAll = this->getConnectedElement(0);
-    unsigned int cpt = 1;
+    size_t cpt = 1;
 
     while (elemAll.size() < nbr)
     {

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyContainer.h
@@ -188,7 +188,7 @@ public:
     /** \brief Returns the number of quads in this topology.
      * The difference to getNbQuads() is that this method does not generate the quad array if it does not exist.
      */
-    unsigned int getNumberOfQuads() const;
+    size_t getNumberOfQuads() const;
 
 
     /** \brief Returns the number of topological element of the current topology.

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyContainer.h
@@ -173,7 +173,7 @@ public:
     virtual bool checkConnexity() override;
 
     /// Returns the number of connected component.
-    virtual unsigned int getNumberOfConnectedComponent() override;
+    virtual size_t getNumberOfConnectedComponent() override;
 
     /// Returns the set of element indices connected to an input one (i.e. which can be reached by topological links)
     virtual const VecQuadID getConnectedElement(QuadID elem) override;
@@ -194,7 +194,7 @@ public:
     /** \brief Returns the number of topological element of the current topology.
      * This function avoids to know which topological container is in used.
      */
-    virtual unsigned int getNumberOfElements() const override;
+    virtual size_t getNumberOfElements() const override;
 
 
     /** \brief Returns the Quad array. */

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyModifier.cpp
@@ -53,19 +53,19 @@ void QuadSetTopologyModifier::init()
 
 void QuadSetTopologyModifier::addQuads(const sofa::helper::vector<Quad> &quads)
 {
-    unsigned int nQuads = m_container->getNbQuads();
+    size_t nQuads = m_container->getNbQuads();
 
     /// effectively add triangles in the topology container
     addQuadsProcess(quads);
 
-    sofa::helper::vector<unsigned int> quadsIndex;
+    sofa::helper::vector<QuadID> quadsIndex;
     quadsIndex.reserve(quads.size());
 
-    for (unsigned int i=0; i<quads.size(); ++i)
-        quadsIndex.push_back(nQuads+i);
+    for (size_t i=0; i<quads.size(); ++i)
+        quadsIndex.push_back(QuadID(nQuads+i));
 
     // add topology event in the stack of topological events
-    addQuadsWarning((unsigned int)quads.size(), quads, quadsIndex);
+    addQuadsWarning(quads.size(), quads, quadsIndex);
 
     // inform other objects that the edges are already added
     propagateTopologicalChanges();
@@ -74,7 +74,7 @@ void QuadSetTopologyModifier::addQuads(const sofa::helper::vector<Quad> &quads)
 
 
 void QuadSetTopologyModifier::addQuads(const sofa::helper::vector<Quad> &quads,
-        const sofa::helper::vector<sofa::helper::vector<unsigned int> > &ancestors,
+        const sofa::helper::vector<sofa::helper::vector<QuadID> > &ancestors,
         const sofa::helper::vector<sofa::helper::vector<double> > &baryCoefs)
 {
     size_t nQuads = m_container->getNbQuads();
@@ -82,14 +82,14 @@ void QuadSetTopologyModifier::addQuads(const sofa::helper::vector<Quad> &quads,
     /// effectively add triangles in the topology container
     addQuadsProcess(quads);
 
-    sofa::helper::vector<unsigned int> quadsIndex;
+    sofa::helper::vector<QuadID> quadsIndex;
     quadsIndex.reserve(quads.size());
 
-    for (unsigned int i=0; i<quads.size(); ++i)
-        quadsIndex.push_back(nQuads+i);
+    for (size_t i=0; i<quads.size(); ++i)
+        quadsIndex.push_back(QuadID(nQuads+i));
 
     // add topology event in the stack of topological events
-    addQuadsWarning((unsigned int)quads.size(), quads, quadsIndex, ancestors, baryCoefs);
+    addQuadsWarning(quads.size(), quads, quadsIndex, ancestors, baryCoefs);
 
     // inform other objects that the edges are already added
     propagateTopologicalChanges();
@@ -122,13 +122,13 @@ void QuadSetTopologyModifier::addQuadProcess(Quad t)
     }
 #endif
 
-    const unsigned int quadIndex = m_container->getNumberOfQuads();
+    const QuadID quadIndex = (QuadID)m_container->getNumberOfQuads();
 
     if(m_container->hasQuadsAroundVertex())
     {
-        for(unsigned int j=0; j<4; ++j)
+        for(PointID j=0; j<4; ++j)
         {
-            sofa::helper::vector< unsigned int > &shell = m_container->getQuadsAroundVertexForModification( t[j] );
+            sofa::helper::vector< QuadID > &shell = m_container->getQuadsAroundVertexForModification( t[j] );
             shell.push_back( quadIndex );
         }
     }
@@ -137,7 +137,7 @@ void QuadSetTopologyModifier::addQuadProcess(Quad t)
 
     if(m_container->hasEdges())
     {
-        for(unsigned int j=0; j<4; ++j)
+        for(PointID j=0; j<4; ++j)
         {
             int edgeIndex = m_container->getEdgeIndex(t[(j+1)%4], t[(j+2)%4]);
 
@@ -151,9 +151,9 @@ void QuadSetTopologyModifier::addQuadProcess(Quad t)
                 addEdgesProcess((const sofa::helper::vector< Edge > &) v);
 
                 edgeIndex = m_container->getEdgeIndex(t[(j+1)%4],t[(j+2)%4]);
-                sofa::helper::vector< unsigned int > edgeIndexList;
-                edgeIndexList.push_back((unsigned int) edgeIndex);
-                addEdgesWarning((unsigned int)v.size(), v, edgeIndexList);
+                sofa::helper::vector< EdgeID > edgeIndexList;
+                edgeIndexList.push_back((EdgeID) edgeIndex);
+                addEdgesWarning(v.size(), v, edgeIndexList);
             }
 
             if(m_container->hasEdgesInQuad())
@@ -164,7 +164,7 @@ void QuadSetTopologyModifier::addQuadProcess(Quad t)
 
             if(m_container->hasQuadsAroundEdge())
             {
-                sofa::helper::vector< unsigned int > &shell = m_container->m_quadsAroundEdge[m_container->m_edgesInQuad[quadIndex][j]];
+                sofa::helper::vector< QuadID > &shell = m_container->m_quadsAroundEdge[m_container->m_edgesInQuad[quadIndex][j]];
                 shell.push_back( quadIndex );
             }
         }
@@ -179,16 +179,16 @@ void QuadSetTopologyModifier::addQuadsProcess(const sofa::helper::vector< Quad >
     helper::WriteAccessor< Data< sofa::helper::vector<Quad> > > m_quad = m_container->d_quad;
     m_quad.reserve(m_quad.size() + quads.size());
 
-    for(unsigned int i=0; i<quads.size(); ++i)
+    for(size_t i=0; i<quads.size(); ++i)
     {
         addQuadProcess(quads[i]);
     }
 }
 
 
-void QuadSetTopologyModifier::addQuadsWarning(const unsigned int nQuads,
+void QuadSetTopologyModifier::addQuadsWarning(const size_t nQuads,
         const sofa::helper::vector< Quad >& quadsList,
-        const sofa::helper::vector< unsigned int >& quadsIndexList)
+        const sofa::helper::vector< QuadID >& quadsIndexList)
 {
     m_container->setQuadTopologyToDirty();
     // Warning that quads just got created
@@ -197,10 +197,10 @@ void QuadSetTopologyModifier::addQuadsWarning(const unsigned int nQuads,
 }
 
 
-void QuadSetTopologyModifier::addQuadsWarning(const unsigned int nQuads,
+void QuadSetTopologyModifier::addQuadsWarning(const size_t nQuads,
         const sofa::helper::vector< Quad >& quadsList,
-        const sofa::helper::vector< unsigned int >& quadsIndexList,
-        const sofa::helper::vector< sofa::helper::vector< unsigned int > > & ancestors,
+        const sofa::helper::vector< QuadID >& quadsIndexList,
+        const sofa::helper::vector< sofa::helper::vector< QuadID > > & ancestors,
         const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs)
 {
     m_container->setQuadTopologyToDirty();
@@ -210,11 +210,11 @@ void QuadSetTopologyModifier::addQuadsWarning(const unsigned int nQuads,
 }
 
 
-void QuadSetTopologyModifier::removeQuadsWarning( sofa::helper::vector<unsigned int> &quads)
+void QuadSetTopologyModifier::removeQuadsWarning( sofa::helper::vector<QuadID> &quads)
 {
     m_container->setQuadTopologyToDirty();
     /// sort vertices to remove in a descendent order
-    std::sort( quads.begin(), quads.end(), std::greater<unsigned int>() );
+    std::sort( quads.begin(), quads.end(), std::greater<QuadID>() );
 
     // Warning that these quads will be deleted
     QuadsRemoved *e=new QuadsRemoved(quads);
@@ -222,7 +222,7 @@ void QuadSetTopologyModifier::removeQuadsWarning( sofa::helper::vector<unsigned 
 }
 
 
-void QuadSetTopologyModifier::removeQuadsProcess(const sofa::helper::vector<unsigned int> &indices,
+void QuadSetTopologyModifier::removeQuadsProcess(const sofa::helper::vector<QuadID> &indices,
         const bool removeIsolatedEdges,
         const bool removeIsolatedPoints)
 {
@@ -249,12 +249,12 @@ void QuadSetTopologyModifier::removeQuadsProcess(const sofa::helper::vector<unsi
             m_container->createQuadsAroundVertexArray();
     }
 
-    sofa::helper::vector<unsigned int> edgeToBeRemoved;
-    sofa::helper::vector<unsigned int> vertexToBeRemoved;
+    sofa::helper::vector<EdgeID> edgeToBeRemoved;
+    sofa::helper::vector<PointID> vertexToBeRemoved;
     helper::WriteAccessor< Data< sofa::helper::vector<Quad> > > m_quad = m_container->d_quad;
 
-    unsigned int lastQuad = m_container->getNumberOfQuads() - 1;
-    for(unsigned int i=0; i<indices.size(); ++i, --lastQuad)
+    size_t lastQuad = m_container->getNumberOfQuads() - 1;
+    for(size_t i=0; i<indices.size(); ++i, --lastQuad)
     {
         const Quad &t = m_quad[ indices[i] ];
         const Quad &q = m_quad[ lastQuad ];
@@ -262,9 +262,9 @@ void QuadSetTopologyModifier::removeQuadsProcess(const sofa::helper::vector<unsi
         // first check that the quad vertex shell array has been initialized
         if(m_container->hasQuadsAroundVertex())
         {
-            for(unsigned int v=0; v<4; ++v)
+            for(PointID v=0; v<4; ++v)
             {
-                sofa::helper::vector< unsigned int > &shell = m_container->m_quadsAroundVertex[ t[v] ];
+                sofa::helper::vector< QuadID > &shell = m_container->m_quadsAroundVertex[ t[v] ];
                 shell.erase(remove(shell.begin(), shell.end(), indices[i]), shell.end());
                 if(removeIsolatedPoints && shell.empty())
                     vertexToBeRemoved.push_back(t[v]);
@@ -273,9 +273,9 @@ void QuadSetTopologyModifier::removeQuadsProcess(const sofa::helper::vector<unsi
 
         if(m_container->hasQuadsAroundEdge())
         {
-            for(unsigned int e=0; e<4; ++e)
+            for(EdgeID e=0; e<4; ++e)
             {
-                sofa::helper::vector< unsigned int > &shell = m_container->m_quadsAroundEdge[ m_container->m_edgesInQuad[indices[i]][e]];
+                sofa::helper::vector< QuadID > &shell = m_container->m_quadsAroundEdge[ m_container->m_edgesInQuad[indices[i]][e]];
                 shell.erase(remove(shell.begin(), shell.end(), indices[i]), shell.end());
                 if(removeIsolatedEdges && shell.empty())
                     edgeToBeRemoved.push_back(m_container->m_edgesInQuad[indices[i]][e]);
@@ -287,19 +287,19 @@ void QuadSetTopologyModifier::removeQuadsProcess(const sofa::helper::vector<unsi
             // now updates the shell information of the quad at the end of the array
             if(m_container->hasQuadsAroundVertex())
             {
-                for(unsigned int v=0; v<4; ++v)
+                for(PointID v=0; v<4; ++v)
                 {
-                    sofa::helper::vector< unsigned int > &shell = m_container->m_quadsAroundVertex[ q[v] ];
-                    replace(shell.begin(), shell.end(), lastQuad, indices[i]);
+                    sofa::helper::vector< QuadID > &shell = m_container->m_quadsAroundVertex[ q[v] ];
+                    replace(shell.begin(), shell.end(), (QuadID)lastQuad, indices[i]);
                 }
             }
 
             if(m_container->hasQuadsAroundEdge())
             {
-                for(unsigned int e=0; e<4; ++e)
+                for(EdgeID e=0; e<4; ++e)
                 {
-                    sofa::helper::vector< unsigned int > &shell =  m_container->m_quadsAroundEdge[ m_container->m_edgesInQuad[lastQuad][e]];
-                    replace(shell.begin(), shell.end(), lastQuad, indices[i]);
+                    sofa::helper::vector< QuadID > &shell =  m_container->m_quadsAroundEdge[ m_container->m_edgesInQuad[lastQuad][e]];
+                    replace(shell.begin(), shell.end(), (QuadID)lastQuad, indices[i]);
                 }
             }
         }
@@ -358,7 +358,7 @@ void QuadSetTopologyModifier::addEdgesProcess(const sofa::helper::vector< Edge >
         m_container->m_quadsAroundEdge.resize( m_container->m_quadsAroundEdge.size() + edges.size() );
 }
 
-void QuadSetTopologyModifier::removePointsProcess(const sofa::helper::vector<unsigned int> &indices,
+void QuadSetTopologyModifier::removePointsProcess(const sofa::helper::vector<PointID> &indices,
         const bool removeDOF)
 {
     if(m_container->hasQuads())
@@ -366,19 +366,19 @@ void QuadSetTopologyModifier::removePointsProcess(const sofa::helper::vector<uns
         if(!m_container->hasQuadsAroundVertex())
             m_container->createQuadsAroundVertexArray();
 
-        unsigned int lastPoint = m_container->getNbPoints() - 1;
+        size_t lastPoint = m_container->getNbPoints() - 1;
         helper::WriteAccessor< Data< sofa::helper::vector<Quad> > > m_quad = m_container->d_quad;
 
-        for(unsigned int i=0; i<indices.size(); ++i, --lastPoint)
+        for(size_t i=0; i<indices.size(); ++i, --lastPoint)
         {
             // updating the quads connected to the point replacing the removed one:
             // for all quads connected to the last point
 
-            sofa::helper::vector<unsigned int> &shell = m_container->m_quadsAroundVertex[lastPoint];
-            for(unsigned int j=0; j<shell.size(); ++j)
+            sofa::helper::vector<QuadID> &shell = m_container->m_quadsAroundVertex[lastPoint];
+            for(size_t j=0; j<shell.size(); ++j)
             {
-                const unsigned int q = shell[j];
-                for(unsigned int k=0; k<4; ++k)
+                const QuadID q = shell[j];
+                for(PointID k=0; k<4; ++k)
                 {
                     if(m_quad[q][k] == lastPoint)
                         m_quad[q][k] = indices[i];
@@ -397,7 +397,7 @@ void QuadSetTopologyModifier::removePointsProcess(const sofa::helper::vector<uns
     EdgeSetTopologyModifier::removePointsProcess( indices, removeDOF );
 }
 
-void QuadSetTopologyModifier::removeEdgesProcess( const sofa::helper::vector<unsigned int> &indices,
+void QuadSetTopologyModifier::removeEdgesProcess( const sofa::helper::vector<EdgeID> &indices,
         const bool removeIsolatedItems)
 {
     // Note: this does not check if an edge is removed from an existing quad (it should never happen)
@@ -407,15 +407,15 @@ void QuadSetTopologyModifier::removeEdgesProcess( const sofa::helper::vector<uns
         if(!m_container->hasQuadsAroundEdge())
             m_container->createQuadsAroundEdgeArray();
 
-        unsigned int lastEdge = m_container->getNumberOfEdges() - 1;
-        for(unsigned int i = 0; i < indices.size(); ++i, --lastEdge)
+        size_t lastEdge = m_container->getNumberOfEdges() - 1;
+        for(size_t i = 0; i < indices.size(); ++i, --lastEdge)
         {
             // updating the quads connected to the edge replacing the removed one:
             // for all quads connected to the last point
-            for(sofa::helper::vector<unsigned int>::iterator itt = m_container->m_quadsAroundEdge[lastEdge].begin();
+            for(sofa::helper::vector<QuadID>::iterator itt = m_container->m_quadsAroundEdge[lastEdge].begin();
                 itt != m_container->m_quadsAroundEdge[lastEdge].end(); ++itt)
             {
-                unsigned int edgeIndex = m_container->getEdgeIndexInQuad(m_container->m_edgesInQuad[*itt], lastEdge);
+                EdgeID edgeIndex = m_container->getEdgeIndexInQuad(m_container->m_edgesInQuad[*itt], (EdgeID)lastEdge);
                 m_container->m_edgesInQuad[*itt][edgeIndex] = indices[i];
             }
 
@@ -430,8 +430,8 @@ void QuadSetTopologyModifier::removeEdgesProcess( const sofa::helper::vector<uns
     EdgeSetTopologyModifier::removeEdgesProcess(indices, removeIsolatedItems);
 }
 
-void QuadSetTopologyModifier::renumberPointsProcess( const sofa::helper::vector<unsigned int> &index,
-        const sofa::helper::vector<unsigned int> &inv_index,
+void QuadSetTopologyModifier::renumberPointsProcess( const sofa::helper::vector<PointID> &index,
+        const sofa::helper::vector<PointID> &inv_index,
         const bool renumberDOF)
 {
     if(m_container->hasQuads())
@@ -440,14 +440,14 @@ void QuadSetTopologyModifier::renumberPointsProcess( const sofa::helper::vector<
 
         if(m_container->hasQuadsAroundVertex())
         {
-            sofa::helper::vector< sofa::helper::vector< unsigned int > > quadsAroundVertex_cp = m_container->m_quadsAroundVertex;
-            for(unsigned int i=0; i<index.size(); ++i)
+            sofa::helper::vector< sofa::helper::vector< QuadID > > quadsAroundVertex_cp = m_container->m_quadsAroundVertex;
+            for(size_t i=0; i<index.size(); ++i)
             {
                 m_container->m_quadsAroundVertex[i] = quadsAroundVertex_cp[ index[i] ];
             }
         }
 
-        for(unsigned int i=0; i<m_quad.size(); ++i)
+        for(size_t i=0; i<m_quad.size(); ++i)
         {
             m_quad[i][0]  = inv_index[ m_quad[i][0]  ];
             m_quad[i][1]  = inv_index[ m_quad[i][1]  ];
@@ -460,12 +460,12 @@ void QuadSetTopologyModifier::renumberPointsProcess( const sofa::helper::vector<
     EdgeSetTopologyModifier::renumberPointsProcess( index, inv_index, renumberDOF );
 }
 
-void QuadSetTopologyModifier::removeQuads(const sofa::helper::vector< unsigned int >& quadIds,
+void QuadSetTopologyModifier::removeQuads(const sofa::helper::vector< QuadID >& quadIds,
         const bool removeIsolatedEdges,
         const bool removeIsolatedPoints)
 {
-    sofa::helper::vector<unsigned int> quadIds_filtered;
-    for (unsigned int i = 0; i < quadIds.size(); i++)
+    sofa::helper::vector<QuadID> quadIds_filtered;
+    for (size_t i = 0; i < quadIds.size(); i++)
     {
         if( quadIds[i] >= m_container->getNumberOfQuads())
             std::cout << "Error: QuadSetTopologyModifier::removeQuads: quad: "<< quadIds[i] <<" is out of bound and won't be removed." << std::endl;
@@ -483,13 +483,13 @@ void QuadSetTopologyModifier::removeQuads(const sofa::helper::vector< unsigned i
     m_container->checkTopology();
 }
 
-void QuadSetTopologyModifier::removeItems(const sofa::helper::vector<unsigned int> &items)
+void QuadSetTopologyModifier::removeItems(const sofa::helper::vector<QuadID> &items)
 {
     removeQuads(items, true, true);
 }
 
-void QuadSetTopologyModifier::renumberPoints( const sofa::helper::vector<unsigned int> &index,
-        const sofa::helper::vector<unsigned int> &inv_index)
+void QuadSetTopologyModifier::renumberPoints( const sofa::helper::vector<PointID> &index,
+        const sofa::helper::vector<PointID> &inv_index)
 {
     /// add the topological changes in the queue
     renumberPointsWarning(index, inv_index);

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyModifier.cpp
@@ -334,7 +334,7 @@ void QuadSetTopologyModifier::removeQuadsProcess(const sofa::helper::vector<unsi
     }
 }
 
-void QuadSetTopologyModifier::addPointsProcess(const unsigned int nPoints)
+void QuadSetTopologyModifier::addPointsProcess(const size_t nPoints)
 {
     // start by calling the parent's method.
     EdgeSetTopologyModifier::addPointsProcess( nPoints );

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyModifier.h
@@ -147,7 +147,7 @@ public:
     *
     * \sa addPointsWarning
     */
-    virtual void addPointsProcess(const unsigned int nPoints) override;
+    virtual void addPointsProcess(const size_t nPoints) override;
 
     /** \brief Remove a subset of points
     *

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyModifier.h
@@ -74,7 +74,7 @@ public:
     *
     */
     virtual void addQuads(const sofa::helper::vector< Quad > &quads,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > > & ancestors,
+            const sofa::helper::vector< sofa::helper::vector< QuadID > > & ancestors,
             const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs) ;
 
 
@@ -82,18 +82,18 @@ public:
     *
     * \sa addQuadsProcess
     */
-    void addQuadsWarning(const unsigned int nQuads,
+    void addQuadsWarning(const size_t nQuads,
             const sofa::helper::vector< Quad >& quadsList,
-            const sofa::helper::vector< unsigned int >& quadsIndexList);
+            const sofa::helper::vector< QuadID >& quadsIndexList);
 
     /** \brief Sends a message to warn that some quads were added in this topology.
     *
     * \sa addQuadsProcess
     */
-    void addQuadsWarning(const unsigned int nQuads,
+    void addQuadsWarning(const size_t nQuads,
             const sofa::helper::vector< Quad >& quadsList,
-            const sofa::helper::vector< unsigned int >& quadsIndexList,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > > & ancestors,
+            const sofa::helper::vector< QuadID >& quadsIndexList,
+            const sofa::helper::vector< sofa::helper::vector< QuadID > > & ancestors,
             const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs);
 
     /** \brief Effectively Add a quad.
@@ -112,7 +112,7 @@ public:
     *
     * Important : parameter indices is not const because it is actually sorted from the highest index to the lowest one.
     */
-    virtual void removeQuadsWarning( sofa::helper::vector<unsigned int> &quads);
+    virtual void removeQuadsWarning( sofa::helper::vector<QuadID> &quads);
 
     /** \brief Remove a subset of  quads. Eventually remove isolated edges and vertices
     *
@@ -122,7 +122,7 @@ public:
     * @param removeIsolatedEdges if true isolated edges are also removed
     * @param removeIsolatedPoints if true isolated vertices are also removed
     */
-    virtual void removeQuadsProcess( const sofa::helper::vector<unsigned int> &indices,
+    virtual void removeQuadsProcess( const sofa::helper::vector<QuadID> &indices,
             const bool removeIsolatedEdges=false,
             const bool removeIsolatedPoints=false);
 
@@ -140,7 +140,7 @@ public:
     * @param removeIsolatedItems if true isolated vertices are also removed
     * Important : parameter indices is not const because it is actually sorted from the highest index to the lowest one.
     */
-    virtual void removeEdgesProcess( const sofa::helper::vector<unsigned int> &indices,
+    virtual void removeEdgesProcess( const sofa::helper::vector<QuadID> &indices,
             const bool removeIsolatedItems=false) override;
 
     /** \brief Add some points to this topology.
@@ -157,7 +157,7 @@ public:
     * \sa removePointsWarning
     * Important : the points are actually deleted from the mechanical object's state vectors iff (removeDOF == true)
     */
-    virtual void removePointsProcess(const sofa::helper::vector<unsigned int> &indices,
+    virtual void removePointsProcess(const sofa::helper::vector<PointID> &indices,
             const bool removeDOF = true) override;
 
     /** \brief Reorder this topology.
@@ -165,8 +165,8 @@ public:
     * Important : the points are actually renumbered in the mechanical object's state vectors iff (renumberDOF == true)
     * \see MechanicalObject::renumberValues
     */
-    virtual void renumberPointsProcess( const sofa::helper::vector<unsigned int>& index,
-            const sofa::helper::vector<unsigned int>& inv_index,
+    virtual void renumberPointsProcess( const sofa::helper::vector<PointID>& index,
+            const sofa::helper::vector<PointID>& inv_index,
             const bool renumberDOF = true) override;
 
     /** \brief Remove a set  of quads
@@ -176,18 +176,18 @@ public:
     @param removeIsolatedPoints if true isolated vertices are also removed
     *
     */
-    virtual void removeQuads(const sofa::helper::vector<unsigned int> &quadIds,
+    virtual void removeQuads(const sofa::helper::vector<QuadID> &quadIds,
             const bool removeIsolatedEdges,
             const bool removeIsolatedPoints);
 
     /** \brief Generic method to remove a list of items.
     */
-    virtual void removeItems(const sofa::helper::vector< unsigned int >& items) override;
+    virtual void removeItems(const sofa::helper::vector< QuadID >& items) override;
 
     /** \brief Generic method for points renumbering
     */
-    virtual void renumberPoints( const sofa::helper::vector<unsigned int>& index,
-            const sofa::helper::vector<unsigned int>& inv_index) override;
+    virtual void renumberPoints( const sofa::helper::vector<PointID>& index,
+            const sofa::helper::vector<PointID>& inv_index) override;
 
 
 private:

--- a/SofaKernel/modules/SofaBaseTopology/SparseGridTopology.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/SparseGridTopology.cpp
@@ -388,7 +388,7 @@ void SparseGridTopology::buildFromVoxelFile(const std::string& filename)
 
     _regularGrid->setSize(getNx(), getNy(), getNz());
     _regularGrid->setPos(getXmin(), getXmax(), getYmin(), getYmax(), getZmin(), getZmax());
-    int nbCubesRG = _regularGrid->getNbHexahedra();
+    size_t nbCubesRG = _regularGrid->getNbHexahedra();
     _indicesOfRegularCubeInSparseGrid.resize(nbCubesRG, -1); // to redirect an indice of a cube in the regular grid to its indice in the sparse grid
 
     vector<Type> regularGridTypes(nbCubesRG, OUTSIDE); // to compute filling types (OUTSIDE, INSIDE, BOUNDARY)
@@ -441,7 +441,7 @@ void SparseGridTopology::buildFromData( Vec3i numPoints, BoundingBox box, const 
 
     _regularGrid->setSize(getNx(), getNy(), getNz());
     _regularGrid->setPos(getXmin(), getXmax(), getYmin(), getYmax(), getZmin(), getZmax());
-    int nbCubesRG = _regularGrid->getNbHexahedra();
+    size_t nbCubesRG = _regularGrid->getNbHexahedra();
     _indicesOfRegularCubeInSparseGrid.resize(nbCubesRG, -1); // to redirect an indice of a cube in the regular grid to its indice in the sparse grid
 
     vector<Type> regularGridTypes(nbCubesRG, OUTSIDE); // to compute filling types (OUTSIDE, INSIDE, BOUNDARY)
@@ -476,7 +476,7 @@ void SparseGridTopology::buildFromData( Vec3i numPoints, BoundingBox box, const 
 void SparseGridTopology::buildFromRawVoxelFile(const std::string& filename)
 {
     _regularGrid->setSize(getNx(),getNy(),getNz());
-    const int nbCubesRG = _regularGrid->getNbHexahedra();
+    const size_t nbCubesRG = _regularGrid->getNbHexahedra();
 
     _indicesOfRegularCubeInSparseGrid.resize(nbCubesRG, -1); // to redirect an indice of a cube in the regular grid to its indice in the sparse grid
     vector<Type> regularGridTypes(nbCubesRG, OUTSIDE); // to compute filling types (OUTSIDE, INSIDE, BOUNDARY)
@@ -545,7 +545,7 @@ void SparseGridTopology::buildFromVoxelLoader(VoxelLoader * loader)
     _min.setValue( Vector3(0,0,0) );
     _max.setValue( Vector3(width*vsize[0],height*vsize[1],depth*vsize[2]) );
 
-    const int nbCubesRG = _regularGrid->getNbHexahedra();
+    const size_t nbCubesRG = _regularGrid->getNbHexahedra();
 
     _indicesOfRegularCubeInSparseGrid.resize(nbCubesRG, -1); // to redirect an indice of a cube in the regular grid to its indice in the sparse grid
     vector<Type> regularGridTypes(nbCubesRG, OUTSIDE); // to compute filling types (OUTSIDE, INSIDE, BOUNDARY)

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetGeometryAlgorithms.h
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetGeometryAlgorithms.h
@@ -52,6 +52,7 @@ public:
 
 
     typedef core::topology::BaseMeshTopology::TetraID TetraID;
+    typedef core::topology::BaseMeshTopology::TetrahedronID TetrahedronID;
     typedef core::topology::BaseMeshTopology::Tetra Tetra;
     typedef core::topology::BaseMeshTopology::SeqTetrahedra SeqTetrahedra;
     typedef core::topology::BaseMeshTopology::SeqEdges SeqEdges;
@@ -110,13 +111,13 @@ public:
 
     /// finds the indices of all tetrahedra in the ball of center ind_ta and of radius dist(ind_ta, ind_tb)
     void getTetraInBall(const TetraID ind_ta, const TetraID ind_tb,
-            sofa::helper::vector<unsigned int> &indices) const;
+            sofa::helper::vector<TetrahedronID> &indices) const;
 
     /// finds the indices of all tetrahedra in the ball of center ind_ta and of radius dist(ind_ta, ind_tb)
     void getTetraInBall(const TetraID ind_ta, Real r,
-            sofa::helper::vector<unsigned int> &indices) const;
+            sofa::helper::vector<TetrahedronID> &indices) const;
     void getTetraInBall(const Coord& c, Real r,
-            sofa::helper::vector<unsigned int> &indices) const;
+            sofa::helper::vector<TetrahedronID> &indices) const;
     /** \brief Write the current mesh into a msh file
     */
     void writeMSHfile(const char *filename) const;

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetGeometryAlgorithms.inl
@@ -87,11 +87,11 @@ void TetrahedronSetGeometryAlgorithms< DataTypes >::defineTetrahedronCubaturePoi
     /// integration with quadric accuracy.
     qpa.clear();
     v=BarycentricCoordinatesType(0.25,0.25,0.25,0.25);
-    Real c= -0.131555555555555556e-01;
+    Real c= (Real)-0.131555555555555556e-01;
     qpa.push_back(QuadraturePoint(v,(Real)c ));
     a=(Real)0.714285714285714285e-01;
     b=(Real)1-3*a;
-    Real c1=0.762222222222222222e-02;
+    Real c1=(Real)0.762222222222222222e-02;
     for (i=0;i<4;++i) {
         v=BarycentricCoordinatesType(a,a,a,a);
         v[i]=b;
@@ -297,12 +297,12 @@ void TetrahedronSetGeometryAlgorithms< DataTypes >::defineTetrahedronCubaturePoi
     // See software PHG http://lsec.cc.ac.cn/phg/
     qpa.clear();
     v=BarycentricCoordinatesType(0.25,0.25,0.25,0.25);
-    c1= (Real).04574189830483037077884770618329337/6.0;
+    c1= (Real)(.04574189830483037077884770618329337/6.0);
     qpa.push_back(QuadraturePoint(v,(Real)c1 ));
     // 4 points
     a=(Real).11425191803006935688146412277598412;
     b=1-3*a;
-    c3=(Real)0.01092727610912416907498417206565671/6.0;
+    c3=(Real)(0.01092727610912416907498417206565671/6.0);
     for (i=0;i<4;++i) {
         v=BarycentricCoordinatesType(a,a,a,a);
         v[i]=b;
@@ -311,7 +311,7 @@ void TetrahedronSetGeometryAlgorithms< DataTypes >::defineTetrahedronCubaturePoi
     // 4 points
     a=(Real).01063790234539248531264164411274776;
     b=1-3*a;
-    c3=(Real).00055352334192264689534558564012282/6.0;
+    c3=(Real)(.00055352334192264689534558564012282/6.0);
     for (i=0;i<4;++i) {
         v=BarycentricCoordinatesType(a,a,a,a);
         v[i]=b;
@@ -320,7 +320,7 @@ void TetrahedronSetGeometryAlgorithms< DataTypes >::defineTetrahedronCubaturePoi
     // 4 points
     a=(Real).31274070833535645859816704980806110;
     b=1-3*a;
-    c3=(Real).02569337913913269580782688316792080/6.0;
+    c3=(Real)(.02569337913913269580782688316792080/6.0);
     for (i=0;i<4;++i) {
         v=BarycentricCoordinatesType(a,a,a,a);
         v[i]=b;
@@ -340,7 +340,7 @@ void TetrahedronSetGeometryAlgorithms< DataTypes >::defineTetrahedronCubaturePoi
     a=(Real).03430622963180452385835196582344460;
     b=(Real) .59830121060139461905983787517050400;
     c=(Real) 1-2*a-b;
-    d=(Real) .01044842402938294329072628200105773/6.0;
+    d=(Real) (.01044842402938294329072628200105773/6.0);
     for (i=0;i<6;++i) {
         v=BarycentricCoordinatesType(a,a,a,a);
         v[edgesInTetrahedronArray[i][0]]=b;
@@ -368,7 +368,7 @@ void TetrahedronSetGeometryAlgorithms< DataTypes >::defineTetrahedronCubaturePoi
     a=(Real).40991962933181117418479812480531207;
     b=(Real).16546413290740130923509687990363569;
     c=(Real) 1-2*a-b;
-    d=(Real) .01178620679249594711782155323755017/6.0;
+    d=(Real) (.01178620679249594711782155323755017/6.0);
     for (i=0;i<6;++i) {
         v=BarycentricCoordinatesType(a,a,a,a);
         v[edgesInTetrahedronArray[i][0]]=b;

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetGeometryAlgorithms.inl
@@ -591,7 +591,7 @@ void TetrahedronSetGeometryAlgorithms<DataTypes>::computeTetrahedronVolume( Basi
 /// Finds the indices of all tetrahedra in the ball of center ind_ta and of radius dist(ind_ta, ind_tb)
 template<class DataTypes>
 void TetrahedronSetGeometryAlgorithms< DataTypes >::getTetraInBall(const TetraID ind_ta, const TetraID ind_tb,
-        sofa::helper::vector<unsigned int> &indices) const
+        sofa::helper::vector<TetrahedronID> &indices) const
 {
     const typename DataTypes::VecCoord& vect_c =(this->object->read(core::ConstVecCoordId::position())->getValue());
 
@@ -617,7 +617,7 @@ void TetrahedronSetGeometryAlgorithms< DataTypes >::getTetraInBall(const TetraID
 /// Finds the indices of all tetrahedra in the ball of center ind_ta and of radius dist(ind_ta, ind_tb)
 template<class DataTypes>
 void TetrahedronSetGeometryAlgorithms< DataTypes >::getTetraInBall(const TetraID ind_ta, Real r,
-        sofa::helper::vector<unsigned int> &indices) const
+        sofa::helper::vector<TetrahedronID> &indices) const
 {
     Real d = r;
     const Tetrahedron ta=this->m_topology->getTetrahedron(ind_ta);
@@ -629,29 +629,29 @@ void TetrahedronSetGeometryAlgorithms< DataTypes >::getTetraInBall(const TetraID
     pa[1] = (Real) (ca[1]);
     pa[2] = (Real) (ca[2]);
 
-    unsigned int t_test=ind_ta;
+    TetrahedronID t_test=ind_ta;
     indices.push_back(t_test);
 
-    std::map<unsigned int, unsigned int> IndexMap;
+    std::map<TetrahedronID, TetrahedronID> IndexMap;
     IndexMap.clear();
     IndexMap[t_test]=0;
 
-    sofa::helper::vector<unsigned int> ind2test;
+    sofa::helper::vector<TetrahedronID> ind2test;
     ind2test.push_back(t_test);
-    sofa::helper::vector<unsigned int> ind2ask;
+    sofa::helper::vector<TetrahedronID> ind2ask;
     ind2ask.push_back(t_test);
 
     while(ind2test.size()>0)
     {
         ind2test.clear();
-        for (unsigned int t=0; t<ind2ask.size(); t++)
+        for (size_t t=0; t<ind2ask.size(); t++)
         {
-            unsigned int ind_t = ind2ask[t];
+            TetrahedronID ind_t = ind2ask[t];
             core::topology::BaseMeshTopology::TrianglesInTetrahedron adjacent_triangles = this->m_topology->getTrianglesInTetrahedron(ind_t);
 
-            for (unsigned int i=0; i<adjacent_triangles.size(); i++)
+            for (size_t i=0; i<adjacent_triangles.size(); i++)
             {
-                sofa::helper::vector< unsigned int > tetrahedra_to_remove = this->m_topology->getTetrahedraAroundTriangle(adjacent_triangles[i]);
+                sofa::helper::vector< TetrahedronID > tetrahedra_to_remove = this->m_topology->getTetrahedraAroundTriangle(adjacent_triangles[i]);
 
                 if(tetrahedra_to_remove.size()==2)
                 {
@@ -664,7 +664,7 @@ void TetrahedronSetGeometryAlgorithms< DataTypes >::getTetraInBall(const TetraID
                         t_test=tetrahedra_to_remove[0];
                     }
 
-                    std::map<unsigned int, unsigned int>::iterator iter_1 = IndexMap.find(t_test);
+                    std::map<TetrahedronID, TetrahedronID>::iterator iter_1 = IndexMap.find(t_test);
                     if(iter_1 == IndexMap.end())
                     {
                         IndexMap[t_test]=0;
@@ -692,7 +692,7 @@ void TetrahedronSetGeometryAlgorithms< DataTypes >::getTetraInBall(const TetraID
         }
 
         ind2ask.clear();
-        for (unsigned int t=0; t<ind2test.size(); t++)
+        for (size_t t=0; t<ind2test.size(); t++)
         {
             ind2ask.push_back(ind2test[t]);
         }
@@ -704,7 +704,7 @@ void TetrahedronSetGeometryAlgorithms< DataTypes >::getTetraInBall(const TetraID
 /// Finds the indices of all tetrahedra in the ball of center c and of radius r
 template<class DataTypes>
 void TetrahedronSetGeometryAlgorithms< DataTypes >::getTetraInBall(const Coord& c, Real r,
-        sofa::helper::vector<unsigned int> &indices) const
+        sofa::helper::vector<TetrahedronID> &indices) const
 {
     TetraID ind_ta = core::topology::BaseMeshTopology::InvalidID;
     sofa::defaulttype::Vec<3,Real> pa;
@@ -725,29 +725,29 @@ void TetrahedronSetGeometryAlgorithms< DataTypes >::getTetraInBall(const Coord& 
 //      const Tetrahedron &ta=this->m_topology->getTetrahedron(ind_ta);
     const typename DataTypes::VecCoord& vect_c =(this->object->read(core::ConstVecCoordId::position())->getValue());
 
-    unsigned int t_test=ind_ta;
+    TetrahedronID t_test=ind_ta;
     indices.push_back(t_test);
 
-    std::map<unsigned int, unsigned int> IndexMap;
+    std::map<TetrahedronID, TetrahedronID> IndexMap;
     IndexMap.clear();
     IndexMap[t_test]=0;
 
-    sofa::helper::vector<unsigned int> ind2test;
+    sofa::helper::vector<TetrahedronID> ind2test;
     ind2test.push_back(t_test);
-    sofa::helper::vector<unsigned int> ind2ask;
+    sofa::helper::vector<TetrahedronID> ind2ask;
     ind2ask.push_back(t_test);
 
     while(ind2test.size()>0)
     {
         ind2test.clear();
-        for (unsigned int t=0; t<ind2ask.size(); t++)
+        for (size_t t=0; t<ind2ask.size(); t++)
         {
-            unsigned int ind_t = ind2ask[t];
+            TetrahedronID ind_t = ind2ask[t];
             core::topology::BaseMeshTopology::TrianglesInTetrahedron adjacent_triangles = this->m_topology->getTrianglesInTetrahedron(ind_t);
 
-            for (unsigned int i=0; i<adjacent_triangles.size(); i++)
+            for (size_t i=0; i<adjacent_triangles.size(); i++)
             {
-                sofa::helper::vector< unsigned int > tetrahedra_to_remove = this->m_topology->getTetrahedraAroundTriangle(adjacent_triangles[i]);
+                sofa::helper::vector< TetrahedronID > tetrahedra_to_remove = this->m_topology->getTetrahedraAroundTriangle(adjacent_triangles[i]);
 
                 if(tetrahedra_to_remove.size()==2)
                 {
@@ -760,7 +760,7 @@ void TetrahedronSetGeometryAlgorithms< DataTypes >::getTetraInBall(const Coord& 
                         t_test=tetrahedra_to_remove[0];
                     }
 
-                    std::map<unsigned int, unsigned int>::iterator iter_1 = IndexMap.find(t_test);
+                    std::map<TetrahedronID, TetrahedronID>::iterator iter_1 = IndexMap.find(t_test);
                     if(iter_1 == IndexMap.end())
                     {
                         IndexMap[t_test]=0;
@@ -788,7 +788,7 @@ void TetrahedronSetGeometryAlgorithms< DataTypes >::getTetraInBall(const Coord& 
         }
 
         ind2ask.clear();
-        for (unsigned int t=0; t<ind2test.size(); t++)
+        for (size_t t=0; t<ind2test.size(); t++)
         {
             ind2ask.push_back(ind2test[t]);
         }
@@ -810,7 +810,7 @@ void TetrahedronSetGeometryAlgorithms<DataTypes>::getIntersectionPointWithPlane(
     sofa::defaulttype::Vec<3,Real> intersection;
 
     //intersection with edge
-    for(unsigned int i=0; i<edgesInTetra.size(); i++)
+    for(size_t i=0; i<edgesInTetra.size(); i++)
     {
         p1=vect_c[edges[edgesInTetra[i]][0]]; p2=vect_c[edges[edgesInTetra[i]][1]];
         if(computeIntersectionEdgeWithPlane(p1,p2,c,normal,intersection))
@@ -829,7 +829,7 @@ void TetrahedronSetGeometryAlgorithms<DataTypes>::getIntersectionPointWithPlane(
             p1=vect_c[ta[i]];
             fprintf(f1,"%d %f %f %f\n",ta[i],p1[0],p1[1],p1[2]);
         }
-        for(unsigned int i=0; i<intersectedPoint.size(); i++)
+        for(size_t i=0; i<intersectedPoint.size(); i++)
         {
             fprintf(f2,"%f %f %f\n",intersectedPoint[i][0],intersectedPoint[i][1],intersectedPoint[i][2]);
         }
@@ -909,7 +909,7 @@ void TetrahedronSetGeometryAlgorithms<DataTypes>::writeMSHfile(const char *filen
 
     myfile << tea.size() <<"\n";
 
-    for (unsigned int i=0; i<tea.size(); ++i)
+    for (size_t i=0; i<tea.size(); ++i)
     {
         myfile << i+1 << " 4 1 1 4 " << tea[i][0]+1 << " " << tea[i][1]+1 << " " << tea[i][2]+1 << " " << tea[i][3]+1 <<"\n";
     }
@@ -941,7 +941,7 @@ void TetrahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visua
         const sofa::helper::vector<Tetrahedron> &tetraArray = this->m_topology->getTetrahedra();
 
         std::vector<defaulttype::Vector3> positions;
-        for (unsigned int i =0; i<tetraArray.size(); i++)
+        for (size_t i =0; i<tetraArray.size(); i++)
         {
 
             Tetrahedron the_tetra = tetraArray[i];
@@ -969,7 +969,7 @@ void TetrahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visua
         std::vector<defaulttype::Vector3>   pos;
         pos.reserve(tetraArray.size()*4u);
 
-        for (unsigned int i = 0; i<tetraArray.size(); ++i)
+        for (size_t i = 0; i<tetraArray.size(); ++i)
         {
             const Tetrahedron& tet = tetraArray[i];
             for (unsigned int j = 0u; j<4u; ++j)

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyAlgorithms.h
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyAlgorithms.h
@@ -52,8 +52,11 @@ public:
 
     typedef typename DataTypes::Real Real;
     typedef core::topology::BaseMeshTopology::Edge Edge;
+    typedef core::topology::BaseMeshTopology::PointID PointID;
     typedef core::topology::BaseMeshTopology::EdgeID EdgeID;
+    typedef core::topology::BaseMeshTopology::TriangleID TriangleID;
     typedef core::topology::BaseMeshTopology::TetraID TetraID;
+    typedef core::topology::BaseMeshTopology::TetrahedronID TetrahedronID;    
     typedef core::topology::BaseMeshTopology::Tetra Tetra;
     typedef core::topology::BaseMeshTopology::SeqTetrahedra SeqTetrahedra;
     typedef core::topology::BaseMeshTopology::EdgesInTetrahedron EdgesInTetrahedron;
@@ -72,11 +75,11 @@ public:
 
     void subDivideTetrahedronsWithPlane(sofa::helper::vector< sofa::helper::vector<double> >& coefs, sofa::helper::vector<EdgeID>& intersectedEdgeID, Coord /*planePos*/, Coord planeNormal);
     void subDivideTetrahedronsWithPlane(sofa::helper::vector<Coord>& intersectedPoints, sofa::helper::vector<EdgeID>& intersectedEdgeID, Coord planePos, Coord planeNormal);
-    int subDivideTetrahedronWithPlane(TetraID tetraIdx, sofa::helper::vector<EdgeID>& intersectedEdgeID, sofa::helper::vector<unsigned int>& intersectedPointID, Coord planeNormal, sofa::helper::vector<Tetra>& toBeAddedTetra);
+    int subDivideTetrahedronWithPlane(TetraID tetraIdx, sofa::helper::vector<EdgeID>& intersectedEdgeID, sofa::helper::vector<PointID>& intersectedPointID, Coord planeNormal, sofa::helper::vector<Tetra>& toBeAddedTetra);
 
     void subDivideRestTetrahedronsWithPlane(sofa::helper::vector< sofa::helper::vector<double> >& coefs, sofa::helper::vector<EdgeID>& intersectedEdgeID, Coord /*planePos*/, Coord planeNormal);
     void subDivideRestTetrahedronsWithPlane(sofa::helper::vector<Coord>& intersectedPoints, sofa::helper::vector<EdgeID>& intersectedEdgeID, Coord planePos, Coord planeNormal);
-    int subDivideRestTetrahedronWithPlane(TetraID tetraIdx, sofa::helper::vector<EdgeID>& intersectedEdgeID, sofa::helper::vector<unsigned int>& intersectedPointID, Coord planeNormal, sofa::helper::vector<Tetra>& toBeAddedTetra);
+    int subDivideRestTetrahedronWithPlane(TetraID tetraIdx, sofa::helper::vector<EdgeID>& intersectedEdgeID, sofa::helper::vector<PointID>& intersectedPointID, Coord planeNormal, sofa::helper::vector<Tetra>& toBeAddedTetra);
 
 
 protected:

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyAlgorithms.inl
@@ -61,17 +61,17 @@ void TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideTetrahedronsWithPla
 {
     //Current topological state
     int nbPoint=this->m_container->getNbPoints();
-    size_t nbTetra=this->m_container->getNbTetrahedra();
+    TetrahedronID nbTetra = (TetrahedronID)this->m_container->getNbTetrahedra();
 
     //Number of to be added points
-    unsigned int nbTobeAddedPoints=(unsigned int)intersectedEdgeID.size()*2;
+    size_t nbTobeAddedPoints = intersectedEdgeID.size()*2;
 
     //barycentric coodinates of to be added points
-    sofa::helper::vector< sofa::helper::vector<unsigned int> > ancestors;
-    for( unsigned int i=0; i<intersectedEdgeID.size(); i++)
+    sofa::helper::vector< sofa::helper::vector<PointID> > ancestors;
+    for( size_t i=0; i<intersectedEdgeID.size(); i++)
     {
         Edge theEdge=m_container->getEdge(intersectedEdgeID[i]);
-        sofa::helper::vector< unsigned int > ancestor;
+        sofa::helper::vector< EdgeID > ancestor;
         ancestor.push_back(theEdge[0]); ancestor.push_back(theEdge[1]);
         ancestors.push_back(ancestor); ancestors.push_back(ancestor);
     }
@@ -91,14 +91,14 @@ void TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideTetrahedronsWithPla
     int nbIntersectedTetras=0;
 
     //Getting intersected tetrahedron
-    for( unsigned int i=0; i<intersectedEdgeID.size(); i++)
+    for( size_t i=0; i<intersectedEdgeID.size(); i++)
     {
         //Getting the tetrahedron around each intersected edge
         TetrahedraAroundEdge tetrasIdx=m_container->getTetrahedraAroundEdge(intersectedEdgeID[i]);
-        for( unsigned int j=0; j<tetrasIdx.size(); j++)
+        for( size_t j=0; j<tetrasIdx.size(); j++)
         {
             bool flag=true;
-            for( unsigned int k=0; k<intersectedTetras.size(); k++)
+            for( size_t k=0; k<intersectedTetras.size(); k++)
             {
                 if(intersectedTetras[k]==tetrasIdx[j])
                 {
@@ -121,18 +121,18 @@ void TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideTetrahedronsWithPla
     m_modifier->addPointsWarning(nbTobeAddedPoints, ancestors, coefs, true);
 
     //sub divide the each intersected tetrahedron
-    for( unsigned int i=0; i<intersectedTetras.size(); i++)
+    for( size_t i=0; i<intersectedTetras.size(); i++)
     {
         //determine the index of intersected point
-        sofa::helper::vector<unsigned int> intersectedPointID;
+        sofa::helper::vector<PointID> intersectedPointID;
         intersectedPointID.resize(intersectedEdgesInTetra[i].size());
-        for( unsigned int j=0; j<intersectedEdgesInTetra[i].size(); j++)
+        for( size_t j=0; j<intersectedEdgesInTetra[i].size(); j++)
         {
-            for( unsigned int k=0; k<intersectedEdgeID.size(); k++)
+            for( size_t k=0; k<intersectedEdgeID.size(); k++)
             {
                 if(intersectedEdgesInTetra[i][j]==intersectedEdgeID[k])
                 {
-                    intersectedPointID[j]=nbPoint+k*2;
+                    intersectedPointID[j] = (PointID)(nbPoint+k*2);
                 }
             }
         }
@@ -147,7 +147,7 @@ void TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideTetrahedronsWithPla
 
     //tetrahedron addition
     m_modifier->addTetrahedraProcess(toBeAddedTetra);
-    m_modifier->addTetrahedraWarning((unsigned int)toBeAddedTetra.size(), (const sofa::helper::vector< Tetra >&) toBeAddedTetra, toBeAddedTetraIndex);
+    m_modifier->addTetrahedraWarning(toBeAddedTetra.size(), (const sofa::helper::vector< Tetra >&) toBeAddedTetra, toBeAddedTetraIndex);
 
     m_modifier->propagateTopologicalChanges();
 
@@ -164,22 +164,22 @@ void TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideTetrahedronsWithPla
 {
     //Current topological state
     int nbPoint=this->m_container->getNbPoints();
-    size_t nbTetra=this->m_container->getNbTetrahedra();
+    TetrahedronID nbTetra = (TetrahedronID)this->m_container->getNbTetrahedra();
 
     //Number of to be added points
-    unsigned int nbTobeAddedPoints=(unsigned int)intersectedEdgeID.size()*2;
+   size_t nbTobeAddedPoints = intersectedEdgeID.size()*2;
 
     //barycentric coodinates of to be added points
-    sofa::helper::vector< sofa::helper::vector<unsigned int> > ancestors;
+    sofa::helper::vector< sofa::helper::vector<PointID> > ancestors;
     sofa::helper::vector< sofa::helper::vector<double> > coefs;
-    for( unsigned int i=0; i<intersectedPoints.size(); i++)
+    for( size_t i=0; i<intersectedPoints.size(); i++)
     {
         Edge theEdge=m_container->getEdge(intersectedEdgeID[i]);
         sofa::defaulttype::Vec<3,double> p;
         p[0]=intersectedPoints[i][0]; p[1]=intersectedPoints[i][1]; p[2]=intersectedPoints[i][2];
         sofa::helper::vector< double > coef = m_geometryAlgorithms->compute2PointsBarycoefs(p, theEdge[0], theEdge[1]);
 
-        sofa::helper::vector< unsigned int > ancestor;
+        sofa::helper::vector< EdgeID > ancestor;
         ancestor.push_back(theEdge[0]); ancestor.push_back(theEdge[1]);
 
         ancestors.push_back(ancestor); ancestors.push_back(ancestor);
@@ -201,14 +201,14 @@ void TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideTetrahedronsWithPla
     int nbIntersectedTetras=0;
 
     //Getting intersected tetrahedron
-    for( unsigned int i=0; i<intersectedEdgeID.size(); i++)
+    for( size_t i=0; i<intersectedEdgeID.size(); i++)
     {
         //Getting the tetrahedron around each intersected edge
         TetrahedraAroundEdge tetrasIdx=m_container->getTetrahedraAroundEdge(intersectedEdgeID[i]);
-        for( unsigned int j=0; j<tetrasIdx.size(); j++)
+        for( size_t j=0; j<tetrasIdx.size(); j++)
         {
             bool flag=true;
-            for( unsigned int k=0; k<intersectedTetras.size(); k++)
+            for( size_t k=0; k<intersectedTetras.size(); k++)
             {
                 if(intersectedTetras[k]==tetrasIdx[j])
                 {
@@ -231,18 +231,18 @@ void TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideTetrahedronsWithPla
     m_modifier->addPointsWarning(nbTobeAddedPoints, ancestors, coefs, true);
 
     //sub divide the each intersected tetrahedron
-    for( unsigned int i=0; i<intersectedTetras.size(); i++)
+    for( size_t i=0; i<intersectedTetras.size(); i++)
     {
         //determine the index of intersected point
-        sofa::helper::vector<unsigned int> intersectedPointID;
+        sofa::helper::vector<PointID> intersectedPointID;
         intersectedPointID.resize(intersectedEdgesInTetra[i].size());
-        for( unsigned int j=0; j<intersectedEdgesInTetra[i].size(); j++)
+        for( size_t j=0; j<intersectedEdgesInTetra[i].size(); j++)
         {
-            for( unsigned int k=0; k<intersectedEdgeID.size(); k++)
+            for( size_t k=0; k<intersectedEdgeID.size(); k++)
             {
                 if(intersectedEdgesInTetra[i][j]==intersectedEdgeID[k])
                 {
-                    intersectedPointID[j]=nbPoint+k*2;
+                    intersectedPointID[j]=(PointID)(nbPoint+k*2);
                 }
             }
         }
@@ -257,7 +257,7 @@ void TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideTetrahedronsWithPla
 
     //tetrahedron addition
     m_modifier->addTetrahedraProcess(toBeAddedTetra);
-    m_modifier->addTetrahedraWarning((unsigned int)toBeAddedTetra.size(), (const sofa::helper::vector< Tetra >&) toBeAddedTetra, toBeAddedTetraIndex);
+    m_modifier->addTetrahedraWarning(toBeAddedTetra.size(), (const sofa::helper::vector< Tetra >&) toBeAddedTetra, toBeAddedTetraIndex);
 
     m_modifier->propagateTopologicalChanges();
 
@@ -270,7 +270,7 @@ void TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideTetrahedronsWithPla
 }
 
 template<class DataTypes>
-int TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideTetrahedronWithPlane(TetraID tetraIdx, sofa::helper::vector<EdgeID>& intersectedEdgeID, sofa::helper::vector<unsigned int>& intersectedPointID, Coord planeNormal, sofa::helper::vector<Tetra>& toBeAddedTetra)
+int TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideTetrahedronWithPlane(TetraID tetraIdx, sofa::helper::vector<EdgeID>& intersectedEdgeID, sofa::helper::vector<PointID>& intersectedPointID, Coord planeNormal, sofa::helper::vector<Tetra>& toBeAddedTetra)
 {
     Tetra intersectedTetra=this->m_container->getTetra(tetraIdx);
     int nbAddedTetra;
@@ -280,7 +280,7 @@ int TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideTetrahedronWithPlane
     if(intersectedEdgeID.size()==1)
     {
         Edge intersectedEdge=this->m_container->getEdge(intersectedEdgeID[0]);
-        sofa::helper::vector<unsigned int> pointsID;
+        sofa::helper::vector<PointID> pointsID;
 
         //find the point index of tetrahedron which are not included to the intersected edge
         for(int j=0; j<4; j++)
@@ -407,7 +407,7 @@ int TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideTetrahedronWithPlane
         {
             if(!(m_geometryAlgorithms->checkNodeSequence(subTetra[i])))
             {
-                unsigned int temp=subTetra[i][1];
+                TetrahedronID temp=subTetra[i][1];
                 subTetra[i][1]=subTetra[i][2];
                 subTetra[i][2]=temp;
             }
@@ -434,7 +434,7 @@ int TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideTetrahedronWithPlane
         intersectedEdge[0]=this->m_container->getEdge(intersectedEdgeID[0]);
         intersectedEdge[1]=this->m_container->getEdge(intersectedEdgeID[1]);
 
-        sofa::helper::vector<unsigned int> pointsID;
+        sofa::helper::vector<PointID> pointsID;
         pointsID.resize(4);
 
         //find the point index which included both intersected edge
@@ -545,7 +545,7 @@ int TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideTetrahedronWithPlane
         {
             if(!(m_geometryAlgorithms->checkNodeSequence(subTetra[i])))
             {
-                unsigned int temp=subTetra[i][1];
+                TetrahedronID temp=subTetra[i][1];
                 subTetra[i][1]=subTetra[i][2];
                 subTetra[i][2]=temp;
             }
@@ -597,7 +597,7 @@ int TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideTetrahedronWithPlane
         intersectedEdge[1]=this->m_container->getEdge(intersectedEdgeID[1]);
         intersectedEdge[2]=this->m_container->getEdge(intersectedEdgeID[2]);
 
-        sofa::helper::vector<unsigned int> pointsID;
+        sofa::helper::vector<PointID> pointsID;
         pointsID.resize(4);
 
         for(int i=1; i<3; i++)
@@ -678,7 +678,7 @@ int TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideTetrahedronWithPlane
             {
                 if(!(m_geometryAlgorithms->checkNodeSequence(subTetra[i])))
                 {
-                    unsigned int temp=subTetra[i][1];
+                    TetrahedronID temp=subTetra[i][1];
                     subTetra[i][1]=subTetra[i][2];
                     subTetra[i][2]=temp;
                 }
@@ -908,7 +908,7 @@ int TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideTetrahedronWithPlane
             {
                 if(!(m_geometryAlgorithms->checkNodeSequence(subTetra[i])))
                 {
-                    unsigned int temp=subTetra[i][1];
+                    TetrahedronID temp=subTetra[i][1];
                     subTetra[i][1]=subTetra[i][2];
                     subTetra[i][2]=temp;
                 }
@@ -929,10 +929,10 @@ int TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideTetrahedronWithPlane
         intersectedEdge[2]=this->m_container->getEdge(intersectedEdgeID[2]);
         intersectedEdge[3]=this->m_container->getEdge(intersectedEdgeID[3]);
 
-        sofa::helper::vector<unsigned int> pointsID;
+        sofa::helper::vector<PointID> pointsID;
         pointsID.resize(4);
 
-        sofa::helper::vector<unsigned int> localIndex;
+        sofa::helper::vector<PointID> localIndex;
         localIndex.resize(4);
         localIndex[0]=0;
 
@@ -1116,7 +1116,7 @@ int TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideTetrahedronWithPlane
         {
             if(!(m_geometryAlgorithms->checkNodeSequence(subTetra[i])))
             {
-                unsigned int temp=subTetra[i][1];
+                TetrahedronID temp=subTetra[i][1];
                 subTetra[i][1]=subTetra[i][2];
                 subTetra[i][2]=temp;
             }
@@ -1172,17 +1172,17 @@ void TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideRestTetrahedronsWit
 {
     //Current topological state
     int nbPoint=this->m_container->getNbPoints();
-    size_t nbTetra=this->m_container->getNbTetrahedra();
+    TetrahedronID nbTetra = (TetrahedronID)this->m_container->getNbTetrahedra();
 
     //Number of to be added points
-    unsigned int nbTobeAddedPoints=(unsigned int)intersectedEdgeID.size()*2;
+    size_t nbTobeAddedPoints = intersectedEdgeID.size()*2;
 
     //barycentric coodinates of to be added points
-    sofa::helper::vector< sofa::helper::vector<unsigned int> > ancestors;
-    for( unsigned int i=0; i<intersectedEdgeID.size(); i++)
+    sofa::helper::vector< sofa::helper::vector<PointID> > ancestors;
+    for( size_t i=0; i<intersectedEdgeID.size(); i++)
     {
         Edge theEdge=m_container->getEdge(intersectedEdgeID[i]);
-        sofa::helper::vector< unsigned int > ancestor;
+        sofa::helper::vector< EdgeID > ancestor;
         ancestor.push_back(theEdge[0]); ancestor.push_back(theEdge[1]);
         ancestors.push_back(ancestor); ancestors.push_back(ancestor);
     }
@@ -1202,14 +1202,14 @@ void TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideRestTetrahedronsWit
     int nbIntersectedTetras=0;
 
     //Getting intersected tetrahedron
-    for( unsigned int i=0; i<intersectedEdgeID.size(); i++)
+    for( size_t i=0; i<intersectedEdgeID.size(); i++)
     {
         //Getting the tetrahedron around each intersected edge
         TetrahedraAroundEdge tetrasIdx=m_container->getTetrahedraAroundEdge(intersectedEdgeID[i]);
-        for( unsigned int j=0; j<tetrasIdx.size(); j++)
+        for( size_t j=0; j<tetrasIdx.size(); j++)
         {
             bool flag=true;
-            for( unsigned int k=0; k<intersectedTetras.size(); k++)
+            for( size_t k=0; k<intersectedTetras.size(); k++)
             {
                 if(intersectedTetras[k]==tetrasIdx[j])
                 {
@@ -1232,18 +1232,18 @@ void TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideRestTetrahedronsWit
     m_modifier->addPointsWarning(nbTobeAddedPoints, ancestors, coefs, true);
 
     //sub divide the each intersected tetrahedron
-    for( unsigned int i=0; i<intersectedTetras.size(); i++)
+    for( size_t i=0; i<intersectedTetras.size(); i++)
     {
         //determine the index of intersected point
-        sofa::helper::vector<unsigned int> intersectedPointID;
+        sofa::helper::vector<PointID> intersectedPointID;
         intersectedPointID.resize(intersectedEdgesInTetra[i].size());
-        for( unsigned int j=0; j<intersectedEdgesInTetra[i].size(); j++)
+        for( size_t j=0; j<intersectedEdgesInTetra[i].size(); j++)
         {
-            for( unsigned int k=0; k<intersectedEdgeID.size(); k++)
+            for( size_t k=0; k<intersectedEdgeID.size(); k++)
             {
                 if(intersectedEdgesInTetra[i][j]==intersectedEdgeID[k])
                 {
-                    intersectedPointID[j]=nbPoint+k*2;
+                    intersectedPointID[j]= (PointID)(nbPoint+k*2);
                 }
             }
         }
@@ -1258,7 +1258,7 @@ void TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideRestTetrahedronsWit
 
     //tetrahedron addition
     m_modifier->addTetrahedraProcess(toBeAddedTetra);
-    m_modifier->addTetrahedraWarning((unsigned int)toBeAddedTetra.size(), (const sofa::helper::vector< Tetra >&) toBeAddedTetra, toBeAddedTetraIndex);
+    m_modifier->addTetrahedraWarning(toBeAddedTetra.size(), (const sofa::helper::vector< Tetra >&) toBeAddedTetra, toBeAddedTetraIndex);
 
     m_modifier->propagateTopologicalChanges();
 
@@ -1275,22 +1275,22 @@ void TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideRestTetrahedronsWit
 {
     //Current topological state
     int nbPoint=this->m_container->getNbPoints();
-    size_t nbTetra=this->m_container->getNbTetrahedra();
+    TetrahedronID nbTetra = (TetrahedronID)this->m_container->getNbTetrahedra();
 
     //Number of to be added points
-    unsigned int nbTobeAddedPoints=(unsigned int)intersectedEdgeID.size()*2;
+    size_t nbTobeAddedPoints = intersectedEdgeID.size()*2;
 
     //barycentric coodinates of to be added points
-    sofa::helper::vector< sofa::helper::vector<unsigned int> > ancestors;
+    sofa::helper::vector< sofa::helper::vector<PointID> > ancestors;
     sofa::helper::vector< sofa::helper::vector<double> > coefs;
-    for( unsigned int i=0; i<intersectedPoints.size(); i++)
+    for( size_t i=0; i<intersectedPoints.size(); i++)
     {
         Edge theEdge=m_container->getEdge(intersectedEdgeID[i]);
         sofa::defaulttype::Vec<3,double> p;
         p[0]=intersectedPoints[i][0]; p[1]=intersectedPoints[i][1]; p[2]=intersectedPoints[i][2];
         sofa::helper::vector< double > coef = m_geometryAlgorithms->computeRest2PointsBarycoefs(p, theEdge[0], theEdge[1]);
 
-        sofa::helper::vector< unsigned int > ancestor;
+        sofa::helper::vector< EdgeID > ancestor;
         ancestor.push_back(theEdge[0]); ancestor.push_back(theEdge[1]);
 
         ancestors.push_back(ancestor); ancestors.push_back(ancestor);
@@ -1312,14 +1312,14 @@ void TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideRestTetrahedronsWit
     int nbIntersectedTetras=0;
 
     //Getting intersected tetrahedron
-    for( unsigned int i=0; i<intersectedEdgeID.size(); i++)
+    for( size_t i=0; i<intersectedEdgeID.size(); i++)
     {
         //Getting the tetrahedron around each intersected edge
         TetrahedraAroundEdge tetrasIdx=m_container->getTetrahedraAroundEdge(intersectedEdgeID[i]);
-        for( unsigned int j=0; j<tetrasIdx.size(); j++)
+        for( size_t j=0; j<tetrasIdx.size(); j++)
         {
             bool flag=true;
-            for( unsigned int k=0; k<intersectedTetras.size(); k++)
+            for( size_t k=0; k<intersectedTetras.size(); k++)
             {
                 if(intersectedTetras[k]==tetrasIdx[j])
                 {
@@ -1342,18 +1342,18 @@ void TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideRestTetrahedronsWit
     m_modifier->addPointsWarning(nbTobeAddedPoints, ancestors, coefs, true);
 
     //sub divide the each intersected tetrahedron
-    for( unsigned int i=0; i<intersectedTetras.size(); i++)
+    for( size_t i=0; i<intersectedTetras.size(); i++)
     {
         //determine the index of intersected point
-        sofa::helper::vector<unsigned int> intersectedPointID;
+        sofa::helper::vector<PointID> intersectedPointID;
         intersectedPointID.resize(intersectedEdgesInTetra[i].size());
-        for( unsigned int j=0; j<intersectedEdgesInTetra[i].size(); j++)
+        for( size_t j=0; j<intersectedEdgesInTetra[i].size(); j++)
         {
-            for( unsigned int k=0; k<intersectedEdgeID.size(); k++)
+            for( size_t k=0; k<intersectedEdgeID.size(); k++)
             {
                 if(intersectedEdgesInTetra[i][j]==intersectedEdgeID[k])
                 {
-                    intersectedPointID[j]=nbPoint+k*2;
+                    intersectedPointID[j]=(PointID)(nbPoint+k*2);
                 }
             }
         }
@@ -1368,7 +1368,7 @@ void TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideRestTetrahedronsWit
 
     //tetrahedron addition
     m_modifier->addTetrahedraProcess(toBeAddedTetra);
-    m_modifier->addTetrahedraWarning((unsigned int)toBeAddedTetra.size(), (const sofa::helper::vector< Tetra >&) toBeAddedTetra, toBeAddedTetraIndex);
+    m_modifier->addTetrahedraWarning(toBeAddedTetra.size(), (const sofa::helper::vector< Tetra >&) toBeAddedTetra, toBeAddedTetraIndex);
 
     m_modifier->propagateTopologicalChanges();
 
@@ -1381,7 +1381,7 @@ void TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideRestTetrahedronsWit
 }
 
 template<class DataTypes>
-int TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideRestTetrahedronWithPlane(TetraID tetraIdx, sofa::helper::vector<EdgeID>& intersectedEdgeID, sofa::helper::vector<unsigned int>& intersectedPointID, Coord planeNormal, sofa::helper::vector<Tetra>& toBeAddedTetra)
+int TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideRestTetrahedronWithPlane(TetraID tetraIdx, sofa::helper::vector<EdgeID>& intersectedEdgeID, sofa::helper::vector<PointID>& intersectedPointID, Coord planeNormal, sofa::helper::vector<Tetra>& toBeAddedTetra)
 {
     Tetra intersectedTetra=this->m_container->getTetra(tetraIdx);
     int nbAddedTetra;
@@ -1391,7 +1391,7 @@ int TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideRestTetrahedronWithP
     if(intersectedEdgeID.size()==1)
     {
         Edge intersectedEdge=this->m_container->getEdge(intersectedEdgeID[0]);
-        sofa::helper::vector<unsigned int> pointsID;
+        sofa::helper::vector<PointID> pointsID;
 
         //find the point index of tetrahedron which are not included to the intersected edge
         for(int j=0; j<4; j++)
@@ -1518,7 +1518,7 @@ int TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideRestTetrahedronWithP
         {
             if(!(m_geometryAlgorithms->checkNodeSequence(subTetra[i])))
             {
-                unsigned int temp=subTetra[i][1];
+                TetrahedronID temp=subTetra[i][1];
                 subTetra[i][1]=subTetra[i][2];
                 subTetra[i][2]=temp;
             }
@@ -1545,7 +1545,7 @@ int TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideRestTetrahedronWithP
         intersectedEdge[0]=this->m_container->getEdge(intersectedEdgeID[0]);
         intersectedEdge[1]=this->m_container->getEdge(intersectedEdgeID[1]);
 
-        sofa::helper::vector<unsigned int> pointsID;
+        sofa::helper::vector<PointID> pointsID;
         pointsID.resize(4);
 
         //find the point index which included both intersected edge
@@ -1656,7 +1656,7 @@ int TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideRestTetrahedronWithP
         {
             if(!(m_geometryAlgorithms->checkNodeSequence(subTetra[i])))
             {
-                unsigned int temp=subTetra[i][1];
+                TetrahedronID temp=subTetra[i][1];
                 subTetra[i][1]=subTetra[i][2];
                 subTetra[i][2]=temp;
             }
@@ -1708,7 +1708,7 @@ int TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideRestTetrahedronWithP
         intersectedEdge[1]=this->m_container->getEdge(intersectedEdgeID[1]);
         intersectedEdge[2]=this->m_container->getEdge(intersectedEdgeID[2]);
 
-        sofa::helper::vector<unsigned int> pointsID;
+        sofa::helper::vector<PointID> pointsID;
         pointsID.resize(4);
 
         for(int i=1; i<3; i++)
@@ -1789,7 +1789,7 @@ int TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideRestTetrahedronWithP
             {
                 if(!(m_geometryAlgorithms->checkNodeSequence(subTetra[i])))
                 {
-                    unsigned int temp=subTetra[i][1];
+                    TetrahedronID temp=subTetra[i][1];
                     subTetra[i][1]=subTetra[i][2];
                     subTetra[i][2]=temp;
                 }
@@ -2019,7 +2019,7 @@ int TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideRestTetrahedronWithP
             {
                 if(!(m_geometryAlgorithms->checkNodeSequence(subTetra[i])))
                 {
-                    unsigned int temp=subTetra[i][1];
+                    TetrahedronID temp=subTetra[i][1];
                     subTetra[i][1]=subTetra[i][2];
                     subTetra[i][2]=temp;
                 }
@@ -2040,10 +2040,10 @@ int TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideRestTetrahedronWithP
         intersectedEdge[2]=this->m_container->getEdge(intersectedEdgeID[2]);
         intersectedEdge[3]=this->m_container->getEdge(intersectedEdgeID[3]);
 
-        sofa::helper::vector<unsigned int> pointsID;
+        sofa::helper::vector<PointID> pointsID;
         pointsID.resize(4);
 
-        sofa::helper::vector<unsigned int> localIndex;
+        sofa::helper::vector<PointID> localIndex;
         localIndex.resize(4);
         localIndex[0]=0;
 
@@ -2227,7 +2227,7 @@ int TetrahedronSetTopologyAlgorithms< DataTypes >::subDivideRestTetrahedronWithP
         {
             if(!(m_geometryAlgorithms->checkNodeSequence(subTetra[i])))
             {
-                unsigned int temp=subTetra[i][1];
+                TetrahedronID temp=subTetra[i][1];
                 subTetra[i][1]=subTetra[i][2];
                 subTetra[i][2]=temp;
             }

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
@@ -480,7 +480,7 @@ unsigned int TetrahedronSetTopologyContainer::getNumberOfTetrahedra() const
     return (unsigned int)m_tetrahedron.size();
 }
 
-unsigned int TetrahedronSetTopologyContainer::getNumberOfElements() const
+size_t TetrahedronSetTopologyContainer::getNumberOfElements() const
 {
     return this->getNumberOfTetrahedra();
 }
@@ -774,7 +774,7 @@ bool TetrahedronSetTopologyContainer::checkConnexity()
 }
 
 
-unsigned int TetrahedronSetTopologyContainer::getNumberOfConnectedComponent()
+size_t TetrahedronSetTopologyContainer::getNumberOfConnectedComponent()
 {
     size_t nbr = this->getNbTetrahedra();
 

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
@@ -74,9 +74,9 @@ void TetrahedronSetTopologyContainer::init()
 	TriangleSetTopologyContainer::init();
     if (!m_tetrahedron.empty())
     {
-        for (unsigned int i=0; i<m_tetrahedron.size(); ++i)
+        for (size_t i=0; i<m_tetrahedron.size(); ++i)
         {
-            for(unsigned int j=0; j<4; ++j)
+            for(PointID j=0; j<4; ++j)
             {
                 int a = m_tetrahedron[i][j];
                 if (a >= getNbPoints()) setNbPoints(a+1);
@@ -91,7 +91,7 @@ void TetrahedronSetTopologyContainer::init()
 
     /*===========  TEST   EDGES IN TETRAHEDRON ARRAY  =================*
     createEdgesInTetrahedronArray();
-      for (unsigned int i = 0; i < m_tetrahedron.size(); ++i)
+      for (size_t i = 0; i < m_tetrahedron.size(); ++i)
       {
     	  std::cout<<"tetra : "<<i<<"   edges : ";
     	  for(int j=0;j<6;j++)
@@ -128,18 +128,18 @@ void TetrahedronSetTopologyContainer::createEdgeSetArray()
     }
 
     // create a temporary map to find redundant edges
-    std::map<Edge,unsigned int> edgeMap;
+    std::map<Edge,EdgeID> edgeMap;
     helper::WriteAccessor< Data< sofa::helper::vector<Edge> > > m_edge = d_edge;
     helper::ReadAccessor< Data< sofa::helper::vector<Tetrahedron> > > m_tetrahedron = d_tetrahedron;
 
     /// create the m_edge array at the same time than it fills the m_edgesInTetrahedron array
-    for (unsigned int i = 0; i < m_tetrahedron.size(); ++i)
+    for (size_t i = 0; i < m_tetrahedron.size(); ++i)
     {
         const Tetrahedron &t = m_tetrahedron[i];
-        for (unsigned int j=0; j<6; ++j)
+        for (EdgeID j=0; j<6; ++j)
         {
-            const unsigned int v1 = t[edgesInTetrahedronArray[j][0]];
-            const unsigned int v2 = t[edgesInTetrahedronArray[j][1]];
+            const PointID v1 = t[edgesInTetrahedronArray[j][0]];
+            const PointID v2 = t[edgesInTetrahedronArray[j][1]];
 
             // sort vertices in lexicographic order
             const Edge e((v1<v2) ? Edge(v1,v2) : Edge(v2,v1));
@@ -147,8 +147,8 @@ void TetrahedronSetTopologyContainer::createEdgeSetArray()
             if (edgeMap.find(e)==edgeMap.end())
             {
                 // edge not in edgeMap so create a new one
-                const unsigned int edgeIndex = (unsigned int)edgeMap.size();
-                edgeMap[e] = edgeIndex;
+                const size_t edgeIndex = edgeMap.size();
+                edgeMap[e] = (EdgeID)edgeIndex;
                 m_edge.push_back(e);
             }
         }
@@ -177,21 +177,21 @@ void TetrahedronSetTopologyContainer::createEdgesInTetrahedronArray()
 #endif
 
         /// create edge array and triangle edge array at the same time
-        const unsigned int numTetra = getNumberOfTetrahedra();
+        const size_t numTetra = getNumberOfTetrahedra();
         m_edgesInTetrahedron.resize (numTetra);
 
         // create a temporary map to find redundant edges
-        std::map<Edge,unsigned int> edgeMap;
+        std::map<Edge,EdgeID> edgeMap;
         helper::WriteAccessor< Data< sofa::helper::vector<Edge> > > m_edge = d_edge;
 
         /// create the m_edge array at the same time than it fills the m_edgesInTetrahedron array
-        for (unsigned int i = 0; i < m_tetrahedron.size(); ++i)
+        for (size_t i = 0; i < m_tetrahedron.size(); ++i)
         {
             const Tetrahedron &t = m_tetrahedron[i];
-            for (unsigned int j=0; j<6; ++j)
+            for (EdgeID j=0; j<6; ++j)
             {
-                const unsigned int v1 = t[edgesInTetrahedronArray[j][0]];
-                const unsigned int v2 = t[edgesInTetrahedronArray[j][1]];
+                const PointID v1 = t[edgesInTetrahedronArray[j][0]];
+                const PointID v2 = t[edgesInTetrahedronArray[j][1]];
 
                 // sort vertices in lexicographic order
                 const Edge e((v1<v2) ? Edge(v1,v2) : Edge(v2,v1));
@@ -199,8 +199,8 @@ void TetrahedronSetTopologyContainer::createEdgesInTetrahedronArray()
                 if (edgeMap.find(e)==edgeMap.end())
                 {
                     // edge not in edgeMap so create a new one
-                    const unsigned int edgeIndex = (unsigned int)edgeMap.size();
-                    edgeMap[e] = edgeIndex;
+                    const size_t edgeIndex = edgeMap.size();
+                    edgeMap[e] = (EdgeID)edgeIndex;
                     m_edge.push_back(e);
                 }
                 m_edgesInTetrahedron[i][j] = edgeMap[e];
@@ -210,8 +210,8 @@ void TetrahedronSetTopologyContainer::createEdgesInTetrahedronArray()
     else
     {
         /// there are already existing edges : must use an inefficient method. Parse all triangles and find the edge that match each triangle edge
-        const unsigned int numTetra = getNumberOfTetrahedra();
-        const unsigned int numEdges = getNumberOfEdges();
+        const size_t numTetra = getNumberOfTetrahedra();
+        const EdgeID numEdges = (EdgeID)getNumberOfEdges();
         helper::ReadAccessor< Data< sofa::helper::vector<Edge> > > m_edge = d_edge;
 
         m_edgesInTetrahedron.resize(numTetra);
@@ -220,17 +220,17 @@ void TetrahedronSetTopologyContainer::createEdgesInTetrahedronArray()
         std::multimap<PointID, EdgeID>::iterator it;
         bool foundEdge;
 
-        for (unsigned int edge=0; edge<numEdges; ++edge)  //Todo: check if not better using multimap <PointID ,TriangleID> and for each edge, push each triangle present in both shell
+        for (EdgeID edge=0; edge<numEdges; ++edge)  //Todo: check if not better using multimap <PointID ,TriangleID> and for each edge, push each triangle present in both shell
         {
             edgesAroundVertexMap.insert(std::pair<PointID, EdgeID> (m_edge[edge][0],edge));
             edgesAroundVertexMap.insert(std::pair<PointID, EdgeID> (m_edge[edge][1],edge));
         }
 
-        for(unsigned int i=0; i<numTetra; ++i)
+        for(size_t i=0; i<numTetra; ++i)
         {
             const Tetrahedron &t = m_tetrahedron[i];
             // adding edge i in the edge shell of both points
-            for(unsigned int j=0; j<6; ++j)
+            for(EdgeID j=0; j<6; ++j)
             {
                 //finding edge i in edge array
                 std::pair<std::multimap<PointID, EdgeID>::iterator, std::multimap<PointID, EdgeID>::iterator > itPair=edgesAroundVertexMap.equal_range(t[edgesInTetrahedronArray[j][0]]);
@@ -238,7 +238,7 @@ void TetrahedronSetTopologyContainer::createEdgesInTetrahedronArray()
                 foundEdge=false;
                 for(it=itPair.first; (it!=itPair.second) && (foundEdge==false); ++it)
                 {
-                    unsigned int edge = (*it).second;
+                    EdgeID edge = (*it).second;
                     if ( (m_edge[edge][0] == t[edgesInTetrahedronArray[j][0]] && m_edge[edge][1] == t[edgesInTetrahedronArray[j][1]]) || (m_edge[edge][0] == t[edgesInTetrahedronArray[j][1]] && m_edge[edge][1] == t[edgesInTetrahedronArray[j][0]]))
                     {
                         m_edgesInTetrahedron[i][j] = edge;
@@ -266,18 +266,18 @@ void TetrahedronSetTopologyContainer::createTriangleSetArray()
     }
 
     // create a temporary map to find redundant triangles
-    std::map<Triangle,unsigned int> triangleMap;
+    std::map<Triangle,TriangleID> triangleMap;
     helper::WriteAccessor< Data< sofa::helper::vector<Triangle> > > m_triangle = d_triangle;
     helper::ReadAccessor< Data< sofa::helper::vector<Tetrahedron> > > m_tetrahedron = d_tetrahedron;
 
     /// create the m_edge array at the same time than it fills the m_edgesInTetrahedron array
-    for (unsigned int i=0; i<m_tetrahedron.size(); ++i)
+    for (size_t i=0; i<m_tetrahedron.size(); ++i)
     {
         const Tetrahedron &t = m_tetrahedron[i];
 
-        for (unsigned int j=0; j<4; ++j)
+        for (PointID j=0; j<4; ++j)
         {
-            unsigned int v[3];
+            PointID v[3];
 
             if (j%2)
             {
@@ -295,7 +295,7 @@ void TetrahedronSetTopologyContainer::createTriangleSetArray()
             // sort v such that v[0] is the smallest one
             while ((v[0]>v[1]) || (v[0]>v[2]))
             {
-                unsigned int val=v[0];
+                PointID val=v[0];
                 v[0]=v[1];
                 v[1]=v[2];
                 v[2]=val;
@@ -310,7 +310,7 @@ void TetrahedronSetTopologyContainer::createTriangleSetArray()
                 tr = Triangle(v[0], v[1], v[2]);
                 if (triangleMap.find(tr) == triangleMap.end())
                 {
-                    triangleMap[tr] = (unsigned int)m_triangle.size();
+                    triangleMap[tr] = (TriangleID)m_triangle.size();
                     m_triangle.push_back(tr);
                 }
                 else
@@ -334,15 +334,15 @@ void TetrahedronSetTopologyContainer::createTrianglesInTetrahedronArray()
     m_trianglesInTetrahedron.resize( getNumberOfTetrahedra());
     helper::ReadAccessor< Data< sofa::helper::vector<Tetrahedron> > > m_tetrahedron = d_tetrahedron;
 
-    for(unsigned int i = 0; i < m_tetrahedron.size(); ++i)
+    for(size_t i = 0; i < m_tetrahedron.size(); ++i)
     {
         const Tetrahedron &t=m_tetrahedron[i];
 
         // adding triangles in the triangle list of the ith tetrahedron  i
-        for (unsigned int j=0; j<4; ++j)
+        for (TriangleID j=0; j<4; ++j)
         {
             const int triangleIndex = getTriangleIndex(t[(j+1)%4], t[(j+2)%4], t[(j+3)%4]);
-            m_trianglesInTetrahedron[i][j] = (unsigned int) triangleIndex;
+            m_trianglesInTetrahedron[i][j] = (TriangleID) triangleIndex;
         }
     }
 }
@@ -358,12 +358,12 @@ void TetrahedronSetTopologyContainer::createTetrahedraAroundVertexArray ()
     m_tetrahedraAroundVertex.resize( getNbPoints() );
     helper::ReadAccessor< Data< sofa::helper::vector<Tetrahedron> > > m_tetrahedron = d_tetrahedron;
 
-    for (unsigned int i = 0; i < getNumberOfTetrahedra(); ++i)
+    for (size_t i = 0; i < getNumberOfTetrahedra(); ++i)
     {
         // adding edge i in the edge shell of both points
-        for (unsigned int j=0; j<4; ++j)
+        for (PointID j=0; j<4; ++j)
         {
-            m_tetrahedraAroundVertex[ m_tetrahedron[i][j]  ].push_back( i );
+            m_tetrahedraAroundVertex[ m_tetrahedron[i][j]  ].push_back( (TetrahedronID)i );
         }
     }
 }
@@ -378,12 +378,12 @@ void TetrahedronSetTopologyContainer::createTetrahedraAroundEdgeArray ()
 
     m_tetrahedraAroundEdge.resize(getNumberOfEdges());
 
-    for (unsigned int i=0; i< getNumberOfTetrahedra(); ++i)
+    for (size_t i=0; i< getNumberOfTetrahedra(); ++i)
     {
         // adding edge i in the edge shell of both points
-        for (unsigned int j=0; j<6; ++j)
+        for (EdgeID j=0; j<6; ++j)
         {
-            m_tetrahedraAroundEdge[ m_edgesInTetrahedron[i][j] ].push_back( i );
+            m_tetrahedraAroundEdge[ m_edgesInTetrahedron[i][j] ].push_back( (TetrahedronID)i );
         }
     }
 }
@@ -398,12 +398,12 @@ void TetrahedronSetTopologyContainer::createTetrahedraAroundTriangleArray ()
 
     m_tetrahedraAroundTriangle.resize( getNumberOfTriangles());
 
-    for (unsigned int i=0; i<getNumberOfTetrahedra(); ++i)
+    for (size_t i=0; i<getNumberOfTetrahedra(); ++i)
     {
         // adding tetrahedron i in the shell of all neighbors triangles
-        for (unsigned int j=0; j<4; ++j)
+        for (TriangleID j=0; j<4; ++j)
         {
-            m_tetrahedraAroundTriangle[ m_trianglesInTetrahedron[i][j] ].push_back( i );
+            m_tetrahedraAroundTriangle[ m_trianglesInTetrahedron[i][j] ].push_back( (TetrahedronID)i );
         }
     }
 }
@@ -440,10 +440,10 @@ int TetrahedronSetTopologyContainer::getTetrahedronIndex(PointID v1, PointID v2,
     if(!hasTetrahedraAroundVertex())
         createTetrahedraAroundVertexArray();
 
-    sofa::helper::vector<unsigned int> set1 = getTetrahedraAroundVertex(v1);
-    sofa::helper::vector<unsigned int> set2 = getTetrahedraAroundVertex(v2);
-    sofa::helper::vector<unsigned int> set3 = getTetrahedraAroundVertex(v3);
-    sofa::helper::vector<unsigned int> set4 = getTetrahedraAroundVertex(v4);
+    sofa::helper::vector<TetrahedronID> set1 = getTetrahedraAroundVertex(v1);
+    sofa::helper::vector<TetrahedronID> set2 = getTetrahedraAroundVertex(v2);
+    sofa::helper::vector<TetrahedronID> set3 = getTetrahedraAroundVertex(v3);
+    sofa::helper::vector<TetrahedronID> set4 = getTetrahedraAroundVertex(v4);
 
     sort(set1.begin(), set1.end());
     sort(set2.begin(), set2.end());
@@ -451,18 +451,18 @@ int TetrahedronSetTopologyContainer::getTetrahedronIndex(PointID v1, PointID v2,
     sort(set4.begin(), set4.end());
 
     // The destination vector must be large enough to contain the result.
-    sofa::helper::vector<unsigned int> out1(set1.size()+set2.size());
-    sofa::helper::vector<unsigned int>::iterator result1;
+    sofa::helper::vector<TetrahedronID> out1(set1.size()+set2.size());
+    sofa::helper::vector<TetrahedronID>::iterator result1;
     result1 = std::set_intersection(set1.begin(),set1.end(),set2.begin(),set2.end(),out1.begin());
     out1.erase(result1,out1.end());
 
-    sofa::helper::vector<unsigned int> out2(set3.size()+out1.size());
-    sofa::helper::vector<unsigned int>::iterator result2;
+    sofa::helper::vector<TetrahedronID> out2(set3.size()+out1.size());
+    sofa::helper::vector<TetrahedronID>::iterator result2;
     result2 = std::set_intersection(set3.begin(),set3.end(),out1.begin(),out1.end(),out2.begin());
     out2.erase(result2,out2.end());
 
-    sofa::helper::vector<unsigned int> out3(set4.size()+out2.size());
-    sofa::helper::vector<unsigned int>::iterator result3;
+    sofa::helper::vector<TetrahedronID> out3(set4.size()+out2.size());
+    sofa::helper::vector<TetrahedronID>::iterator result3;
     result3 = std::set_intersection(set4.begin(),set4.end(),out2.begin(),out2.end(),out3.begin());
     out3.erase(result3,out3.end());
 
@@ -474,10 +474,10 @@ int TetrahedronSetTopologyContainer::getTetrahedronIndex(PointID v1, PointID v2,
         return -1;
 }
 
-unsigned int TetrahedronSetTopologyContainer::getNumberOfTetrahedra() const
+size_t TetrahedronSetTopologyContainer::getNumberOfTetrahedra() const
 {
     helper::ReadAccessor< Data< sofa::helper::vector<Tetrahedron> > > m_tetrahedron = d_tetrahedron;
-    return (unsigned int)m_tetrahedron.size();
+    return m_tetrahedron.size();
 }
 
 size_t TetrahedronSetTopologyContainer::getNumberOfElements() const
@@ -485,7 +485,7 @@ size_t TetrahedronSetTopologyContainer::getNumberOfElements() const
     return this->getNumberOfTetrahedra();
 }
 
-const sofa::helper::vector< sofa::helper::vector<unsigned int> > &TetrahedronSetTopologyContainer::getTetrahedraAroundVertexArray()
+const sofa::helper::vector< TetrahedronSetTopologyContainer::TetrahedraAroundVertex > &TetrahedronSetTopologyContainer::getTetrahedraAroundVertexArray()
 {
     if (!hasTetrahedraAroundVertex())
         createTetrahedraAroundVertexArray();
@@ -493,7 +493,7 @@ const sofa::helper::vector< sofa::helper::vector<unsigned int> > &TetrahedronSet
     return m_tetrahedraAroundVertex;
 }
 
-const sofa::helper::vector< sofa::helper::vector<unsigned int> > &TetrahedronSetTopologyContainer::getTetrahedraAroundEdgeArray()
+const sofa::helper::vector< TetrahedronSetTopologyContainer::TetrahedraAroundEdge > &TetrahedronSetTopologyContainer::getTetrahedraAroundEdgeArray()
 {
     if (!hasTetrahedraAroundEdge())
         createTetrahedraAroundEdgeArray();
@@ -501,7 +501,7 @@ const sofa::helper::vector< sofa::helper::vector<unsigned int> > &TetrahedronSet
     return m_tetrahedraAroundEdge;
 }
 
-const sofa::helper::vector< sofa::helper::vector<unsigned int> > &TetrahedronSetTopologyContainer::getTetrahedraAroundTriangleArray()
+const sofa::helper::vector< TetrahedronSetTopologyContainer::TetrahedraAroundTriangle > &TetrahedronSetTopologyContainer::getTetrahedraAroundTriangleArray()
 {
     if (!hasTetrahedraAroundTriangle())
         createTetrahedraAroundTriangleArray();
@@ -517,13 +517,13 @@ const sofa::helper::vector< TetrahedronSetTopologyContainer::EdgesInTetrahedron>
     return m_edgesInTetrahedron;
 }
 
-TetrahedronSetTopologyContainer::Edge TetrahedronSetTopologyContainer::getLocalEdgesInTetrahedron (const unsigned int i) const
+TetrahedronSetTopologyContainer::Edge TetrahedronSetTopologyContainer::getLocalEdgesInTetrahedron (const EdgeID i) const
 {
     assert(i<6);
     return Edge (edgesInTetrahedronArray[i][0], edgesInTetrahedronArray[i][1]);
 }
 
-TetrahedronSetTopologyContainer::Triangle TetrahedronSetTopologyContainer::getLocalTrianglesInTetrahedron (const unsigned int i) const
+TetrahedronSetTopologyContainer::Triangle TetrahedronSetTopologyContainer::getLocalTrianglesInTetrahedron (const TriangleID i) const
 {
     assert(i<4);
     return Triangle (trianglesInTetrahedronArray[i][0],
@@ -539,7 +539,7 @@ const sofa::helper::vector< TetrahedronSetTopologyContainer::TrianglesInTetrahed
     return m_trianglesInTetrahedron;
 }
 
-const sofa::helper::vector< unsigned int > &TetrahedronSetTopologyContainer::getTetrahedraAroundVertex(const unsigned int i)
+const TetrahedronSetTopologyContainer::TetrahedraAroundVertex &TetrahedronSetTopologyContainer::getTetrahedraAroundVertex(const PointID i)
 {
     if (!hasTetrahedraAroundVertex())
         createTetrahedraAroundVertexArray();
@@ -549,7 +549,7 @@ const sofa::helper::vector< unsigned int > &TetrahedronSetTopologyContainer::get
     return m_tetrahedraAroundVertex[i];
 }
 
-const sofa::helper::vector< unsigned int > &TetrahedronSetTopologyContainer::getTetrahedraAroundEdge(const unsigned int i)
+const TetrahedronSetTopologyContainer::TetrahedraAroundEdge &TetrahedronSetTopologyContainer::getTetrahedraAroundEdge(const EdgeID i)
 {
     if (!hasTetrahedraAroundEdge())
         createTetrahedraAroundEdgeArray();
@@ -559,7 +559,7 @@ const sofa::helper::vector< unsigned int > &TetrahedronSetTopologyContainer::get
     return m_tetrahedraAroundEdge[i];
 }
 
-const sofa::helper::vector< unsigned int > &TetrahedronSetTopologyContainer::getTetrahedraAroundTriangle(const unsigned int i)
+const TetrahedronSetTopologyContainer::TetrahedraAroundTriangle &TetrahedronSetTopologyContainer::getTetrahedraAroundTriangle(const TriangleID i)
 {
     if (!hasTetrahedraAroundTriangle())
         createTetrahedraAroundTriangleArray();
@@ -569,7 +569,7 @@ const sofa::helper::vector< unsigned int > &TetrahedronSetTopologyContainer::get
     return m_tetrahedraAroundTriangle[i];
 }
 
-const TetrahedronSetTopologyContainer::EdgesInTetrahedron &TetrahedronSetTopologyContainer::getEdgesInTetrahedron(const unsigned int i)
+const TetrahedronSetTopologyContainer::EdgesInTetrahedron &TetrahedronSetTopologyContainer::getEdgesInTetrahedron(const EdgeID i)
 {
     if (!hasEdgesInTetrahedron())
         createEdgesInTetrahedronArray();
@@ -579,7 +579,7 @@ const TetrahedronSetTopologyContainer::EdgesInTetrahedron &TetrahedronSetTopolog
     return m_edgesInTetrahedron[i];
 }
 
-const TetrahedronSetTopologyContainer::TrianglesInTetrahedron &TetrahedronSetTopologyContainer::getTrianglesInTetrahedron(const unsigned int i)
+const TetrahedronSetTopologyContainer::TrianglesInTetrahedron &TetrahedronSetTopologyContainer::getTrianglesInTetrahedron(const TriangleID i)
 {
     if (!hasTrianglesInTetrahedron())
         createTrianglesInTetrahedronArray();
@@ -590,7 +590,7 @@ const TetrahedronSetTopologyContainer::TrianglesInTetrahedron &TetrahedronSetTop
 }
 
 int TetrahedronSetTopologyContainer::getVertexIndexInTetrahedron(const Tetrahedron &t,
-        unsigned int vertexIndex) const
+        PointID vertexIndex) const
 {
     if (t[0]==vertexIndex)
         return 0;
@@ -605,7 +605,7 @@ int TetrahedronSetTopologyContainer::getVertexIndexInTetrahedron(const Tetrahedr
 }
 
 int TetrahedronSetTopologyContainer::getEdgeIndexInTetrahedron(const EdgesInTetrahedron &t,
-        const unsigned int edgeIndex) const
+        const EdgeID edgeIndex) const
 {
     if (t[0]==edgeIndex)
         return 0;
@@ -624,7 +624,7 @@ int TetrahedronSetTopologyContainer::getEdgeIndexInTetrahedron(const EdgesInTetr
 }
 
 int TetrahedronSetTopologyContainer::getTriangleIndexInTetrahedron(const TrianglesInTetrahedron &t,
-        const unsigned int triangleIndex) const
+        const TriangleID triangleIndex) const
 {
     if (t[0]==triangleIndex)
         return 0;
@@ -638,7 +638,7 @@ int TetrahedronSetTopologyContainer::getTriangleIndexInTetrahedron(const Triangl
         return -1;
 }
 
-sofa::helper::vector< unsigned int > &TetrahedronSetTopologyContainer::getTetrahedraAroundEdgeForModification(const unsigned int i)
+TetrahedronSetTopologyContainer::TetrahedraAroundEdge &TetrahedronSetTopologyContainer::getTetrahedraAroundEdgeForModification(const EdgeID i)
 {
     if (!hasTetrahedraAroundEdge())
         createTetrahedraAroundEdgeArray();
@@ -648,7 +648,7 @@ sofa::helper::vector< unsigned int > &TetrahedronSetTopologyContainer::getTetrah
     return m_tetrahedraAroundEdge[i];
 }
 
-sofa::helper::vector< unsigned int > &TetrahedronSetTopologyContainer::getTetrahedraAroundVertexForModification(const unsigned int i)
+TetrahedronSetTopologyContainer::TetrahedraAroundVertex &TetrahedronSetTopologyContainer::getTetrahedraAroundVertexForModification(const PointID i)
 {
     if (!hasTetrahedraAroundVertex())
         createTetrahedraAroundVertexArray();
@@ -658,7 +658,7 @@ sofa::helper::vector< unsigned int > &TetrahedronSetTopologyContainer::getTetrah
     return m_tetrahedraAroundVertex[i];
 }
 
-sofa::helper::vector< unsigned int > &TetrahedronSetTopologyContainer::getTetrahedraAroundTriangleForModification(const unsigned int i)
+TetrahedronSetTopologyContainer::TetrahedraAroundTriangle &TetrahedronSetTopologyContainer::getTetrahedraAroundTriangleForModification(const TriangleID i)
 {
     if (!hasTetrahedraAroundTriangle())
         createTetrahedraAroundTriangleArray();
@@ -677,10 +677,10 @@ bool TetrahedronSetTopologyContainer::checkTopology() const
 
     if(hasTetrahedraAroundVertex())
     {
-        for (unsigned int i=0; i<m_tetrahedraAroundVertex.size(); ++i)
+        for (size_t i=0; i<m_tetrahedraAroundVertex.size(); ++i)
         {
-            const sofa::helper::vector<unsigned int> &tvs = m_tetrahedraAroundVertex[i];
-            for (unsigned int j=0; j<tvs.size(); ++j)
+            const sofa::helper::vector<TetrahedronID> &tvs = m_tetrahedraAroundVertex[i];
+            for (size_t j=0; j<tvs.size(); ++j)
             {
                 bool check_tetra_vertex_shell = (m_tetrahedron[tvs[j]][0]==i)
                         ||  (m_tetrahedron[tvs[j]][1]==i)
@@ -697,10 +697,10 @@ bool TetrahedronSetTopologyContainer::checkTopology() const
 
     if (hasTetrahedraAroundEdge())
     {
-        for (unsigned int i=0; i<m_tetrahedraAroundEdge.size(); ++i)
+        for (size_t i=0; i<m_tetrahedraAroundEdge.size(); ++i)
         {
-            const sofa::helper::vector<unsigned int> &tes=m_tetrahedraAroundEdge[i];
-            for (unsigned int j=0; j<tes.size(); ++j)
+            const sofa::helper::vector<TetrahedronID> &tes=m_tetrahedraAroundEdge[i];
+            for (size_t j=0; j<tes.size(); ++j)
             {
                 bool check_tetra_edge_shell =  (m_edgesInTetrahedron[tes[j]][0]==i)
                         || (m_edgesInTetrahedron[tes[j]][1]==i)
@@ -719,10 +719,10 @@ bool TetrahedronSetTopologyContainer::checkTopology() const
 
     if (hasTetrahedraAroundTriangle())
     {
-        for (unsigned int i=0; i<m_tetrahedraAroundTriangle.size(); ++i)
+        for (size_t i=0; i<m_tetrahedraAroundTriangle.size(); ++i)
         {
-            const sofa::helper::vector<unsigned int> &tes=m_tetrahedraAroundTriangle[i];
-            for (unsigned int j=0; j<tes.size(); ++j)
+            const sofa::helper::vector<TetrahedronID> &tes=m_tetrahedraAroundTriangle[i];
+            for (size_t j=0; j<tes.size(); ++j)
             {
                 bool check_tetra_triangle_shell =  (m_trianglesInTetrahedron[tes[j]][0]==i)
                         || (m_trianglesInTetrahedron[tes[j]][1]==i)
@@ -787,7 +787,7 @@ size_t TetrahedronSetTopologyContainer::getNumberOfConnectedComponent()
     }
 
     VecTetraID elemAll = this->getConnectedElement(0);
-    unsigned int cpt = 1;
+    size_t cpt = 1;
 
     while (elemAll.size() < nbr)
     {
@@ -892,11 +892,11 @@ const TetrahedronSetTopologyContainer::VecTetraID TetrahedronSetTopologyContaine
 
     Tetra the_tetra = this->getTetra(elem);
 
-    for(unsigned int i = 0; i<4; ++i) // for each node of the tetra
+    for(PointID i = 0; i<4; ++i) // for each node of the tetra
     {
         TetrahedraAroundVertex tetraAV = this->getTetrahedraAroundVertex(the_tetra[i]);
 
-        for (unsigned int j = 0; j<tetraAV.size(); ++j) // for each tetra around the node
+        for (size_t j = 0; j<tetraAV.size(); ++j) // for each tetra around the node
         {
             bool find = false;
             TetraID id = tetraAV[j];
@@ -904,7 +904,7 @@ const TetrahedronSetTopologyContainer::VecTetraID TetrahedronSetTopologyContaine
             if (id == elem)
                 continue;
 
-            for (unsigned int k = 0; k<elems.size(); ++k) // check no redundancy
+            for (size_t k = 0; k<elems.size(); ++k) // check no redundancy
                 if (id == elems[k])
                 {
                     find = true;
@@ -933,19 +933,19 @@ const TetrahedronSetTopologyContainer::VecTetraID TetrahedronSetTopologyContaine
         createTetrahedraAroundVertexArray();
     }
 
-    for (unsigned int i = 0; i <elems.size(); ++i) // for each TetraID of input vector
+    for (size_t i = 0; i <elems.size(); ++i) // for each TetraID of input vector
     {
         VecTetraID elemTmp2 = this->getElementAroundElement(elems[i]);
 
         elemTmp.insert(elemTmp.end(), elemTmp2.begin(), elemTmp2.end());
     }
 
-    for (unsigned int i = 0; i<elemTmp.size(); ++i) // for each tetra Id found
+    for (size_t i = 0; i<elemTmp.size(); ++i) // for each tetra Id found
     {
         bool find = false;
         TetraID id = elemTmp[i];
 
-        for (unsigned int j = 0; j<elems.size(); ++j) // check no redundancy with input vector
+        for (size_t j = 0; j<elems.size(); ++j) // check no redundancy with input vector
             if (id == elems[j])
             {
                 find = true;
@@ -954,7 +954,7 @@ const TetrahedronSetTopologyContainer::VecTetraID TetrahedronSetTopologyContaine
 
         if (!find)
         {
-            for (unsigned int j = 0; j<elemAll.size(); ++j) // check no redundancy in output vector
+            for (size_t j = 0; j<elemAll.size(); ++j) // check no redundancy in output vector
                 if (id == elemAll[j])
                 {
                     find = true;
@@ -1048,14 +1048,14 @@ void TetrahedronSetTopologyContainer::clear()
 }
 
 //add removed tetrahedron index
-void TetrahedronSetTopologyContainer::addRemovedTetraIndex(sofa::helper::vector< unsigned int >& tetrahedra)
+void TetrahedronSetTopologyContainer::addRemovedTetraIndex(sofa::helper::vector< TetrahedronID >& tetrahedra)
 {
-    for(unsigned int i=0; i<tetrahedra.size(); i++)
+    for(size_t i=0; i<tetrahedra.size(); i++)
         m_removedTetraIndex.push_back(tetrahedra[i]);
 }
 
 //get removed tetrahedron index
-sofa::helper::vector< unsigned int >& TetrahedronSetTopologyContainer::getRemovedTetraIndex()
+sofa::helper::vector< TetrahedronSetTopologyContainer::TetrahedronID >& TetrahedronSetTopologyContainer::getRemovedTetraIndex()
 {
     return m_removedTetraIndex;
 }

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.h
@@ -46,22 +46,23 @@ public:
     SOFA_CLASS(TetrahedronSetTopologyContainer,TriangleSetTopologyContainer);
 
 
-    typedef core::topology::BaseMeshTopology::PointID			         PointID;
-    typedef core::topology::BaseMeshTopology::EdgeID			            EdgeID;
-    typedef core::topology::BaseMeshTopology::TriangleID		         TriangleID;
-    typedef core::topology::BaseMeshTopology::TetraID			         TetraID;
-    typedef core::topology::BaseMeshTopology::Edge				         Edge;
-    typedef core::topology::BaseMeshTopology::Triangle			         Triangle;
-    typedef core::topology::BaseMeshTopology::Tetra				         Tetra;
-    typedef core::topology::BaseMeshTopology::SeqTetrahedra			   SeqTetrahedra;
-    typedef core::topology::BaseMeshTopology::TetrahedraAroundVertex	TetrahedraAroundVertex;
-    typedef core::topology::BaseMeshTopology::TetrahedraAroundEdge		TetrahedraAroundEdge;
-    typedef core::topology::BaseMeshTopology::TetrahedraAroundTriangle	TetrahedraAroundTriangle;
-    typedef core::topology::BaseMeshTopology::EdgesInTetrahedron		   EdgesInTetrahedron;
-    typedef core::topology::BaseMeshTopology::TrianglesInTetrahedron	TrianglesInTetrahedron;
+    typedef core::topology::BaseMeshTopology::PointID                     PointID;
+    typedef core::topology::BaseMeshTopology::EdgeID                      EdgeID;
+    typedef core::topology::BaseMeshTopology::TriangleID                  TriangleID;
+    typedef core::topology::BaseMeshTopology::TetraID                     TetraID;
+    typedef core::topology::BaseMeshTopology::TetrahedronID               TetrahedronID;
+    typedef core::topology::BaseMeshTopology::Edge                        Edge;
+    typedef core::topology::BaseMeshTopology::Triangle                    Triangle;
+    typedef core::topology::BaseMeshTopology::Tetra                       Tetra;
+    typedef core::topology::BaseMeshTopology::SeqTetrahedra               SeqTetrahedra;
+    typedef core::topology::BaseMeshTopology::TetrahedraAroundVertex      TetrahedraAroundVertex;
+    typedef core::topology::BaseMeshTopology::TetrahedraAroundEdge        TetrahedraAroundEdge;
+    typedef core::topology::BaseMeshTopology::TetrahedraAroundTriangle    TetrahedraAroundTriangle;
+    typedef core::topology::BaseMeshTopology::EdgesInTetrahedron          EdgesInTetrahedron;
+    typedef core::topology::BaseMeshTopology::TrianglesInTetrahedron      TrianglesInTetrahedron;
 
 
-    typedef Tetra			Tetrahedron;
+    typedef Tetra            Tetrahedron;
     typedef sofa::helper::vector<TetraID>         VecTetraID;
 
 protected:
@@ -72,10 +73,10 @@ public:
     virtual void init() override;
 
     //add removed tetrahedron index
-    void addRemovedTetraIndex(sofa::helper::vector< unsigned int >& tetrahedra);
+    void addRemovedTetraIndex(sofa::helper::vector< TetrahedronID >& tetrahedra);
 
     //get removed tetrahedron index
-    sofa::helper::vector< unsigned int >& getRemovedTetraIndex();
+    sofa::helper::vector< TetrahedronID >& getRemovedTetraIndex();
 
     /// Procedural creation methods
     /// @{
@@ -188,13 +189,13 @@ public:
     /** \brief Returns for each index (between 0 and 5) the two vertex indices that are adjacent to that edge.
      *
      */
-    virtual Edge getLocalEdgesInTetrahedron (const unsigned int i) const override;
+    virtual Edge getLocalEdgesInTetrahedron (const EdgeID i) const override;
 
 
     /** \brief Returns for each index (between 0 and 3) the three local vertices indices that are adjacent to that triangle
      *
      */
-    virtual Triangle getLocalTrianglesInTetrahedron (const PointID i) const override;
+    virtual Triangle getLocalTrianglesInTetrahedron (const TriangleID i) const override;
 
     /// @}
 
@@ -239,9 +240,9 @@ public:
 
 
     /** \brief Returns the number of tetrahedra in this topology.
-     *	The difference to getNbTetrahedra() is that this method does not generate the tetra array if it does not exist.
+     *    The difference to getNbTetrahedra() is that this method does not generate the tetra array if it does not exist.
      */
-    unsigned int getNumberOfTetrahedra() const;
+    size_t getNumberOfTetrahedra() const;
 
     /** \brief Returns the number of topological element of the current topology.
      * This function avoids to know which topological container is in used.
@@ -287,8 +288,8 @@ public:
 
     /// @}
 
-   	/** \brief Returns the type of the topology */
-   	virtual sofa::core::topology::TopologyObjectType getTopologyType() const override {return sofa::core::topology::TETRAHEDRON;}
+       /** \brief Returns the type of the topology */
+       virtual sofa::core::topology::TopologyObjectType getTopologyType() const override {return sofa::core::topology::TETRAHEDRON;}
 
     inline friend std::ostream& operator<< (std::ostream& out, const TetrahedronSetTopologyContainer& t)
     {
@@ -298,17 +299,17 @@ public:
                 << t.m_trianglesInTetrahedron;
 
         out << " "<< t.m_tetrahedraAroundVertex.size();
-        for (unsigned int i=0; i<t.m_tetrahedraAroundVertex.size(); i++)
+        for (size_t i=0; i<t.m_tetrahedraAroundVertex.size(); i++)
         {
             out << " " << t.m_tetrahedraAroundVertex[i];
         }
         out <<" "<< t.m_tetrahedraAroundEdge.size();
-        for (unsigned int i=0; i<t.m_tetrahedraAroundEdge.size(); i++)
+        for (size_t i=0; i<t.m_tetrahedraAroundEdge.size(); i++)
         {
             out << " " << t.m_tetrahedraAroundEdge[i];
         }
         out <<" "<< t.m_tetrahedraAroundTriangle.size();
-        for (unsigned int i=0; i<t.m_tetrahedraAroundTriangle.size(); i++)
+        for (size_t i=0; i<t.m_tetrahedraAroundTriangle.size(); i++)
         {
             out << " " << t.m_tetrahedraAroundTriangle[i];
         }
@@ -462,8 +463,8 @@ protected:
     const bool& isTetrahedronTopologyDirty() {return m_tetrahedronTopologyDirty;}
 
 public:
-	/// force the creation of triangles
-	Data<bool>  d_createTriangleArray;
+    /// force the creation of triangles
+    Data<bool>  d_createTriangleArray;
 
     /// provides the set of tetrahedra.
     Data< sofa::helper::vector<Tetrahedron> > d_tetrahedron;

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.h
@@ -225,7 +225,7 @@ public:
     virtual bool checkConnexity() override;
 
     /// Returns the number of connected component.
-    virtual unsigned int getNumberOfConnectedComponent() override;
+    virtual size_t getNumberOfConnectedComponent() override;
 
     /// Returns the set of element indices connected to an input one (i.e. which can be reached by topological links)
     virtual const VecTetraID getConnectedElement(TetraID elem) override;
@@ -246,7 +246,7 @@ public:
     /** \brief Returns the number of topological element of the current topology.
      * This function avoids to know which topological container is in used.
      */
-    virtual unsigned int getNumberOfElements() const override;
+    virtual size_t getNumberOfElements() const override;
 
 
     /** \brief Returns the Tetrahedron array. */

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyModifier.cpp
@@ -428,7 +428,7 @@ void TetrahedronSetTopologyModifier::removeTetrahedraProcess( const sofa::helper
     }
 }
 
-void TetrahedronSetTopologyModifier::addPointsProcess(const unsigned int nPoints)
+void TetrahedronSetTopologyModifier::addPointsProcess(const size_t nPoints)
 {
     // start by calling the parent's method.
     TriangleSetTopologyModifier::addPointsProcess( nPoints );

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyModifier.cpp
@@ -67,14 +67,14 @@ void TetrahedronSetTopologyModifier::addTetrahedra(const sofa::helper::vector<Te
     /// effectively add triangles in the topology container
     addTetrahedraProcess(tetrahedra);
 
-    sofa::helper::vector<unsigned int> tetrahedraIndex;
+    sofa::helper::vector<TetrahedronID> tetrahedraIndex;
     tetrahedraIndex.reserve(tetrahedra.size());
 
-    for (unsigned int i=0; i<tetrahedra.size(); ++i)
+    for (size_t i=0; i<tetrahedra.size(); ++i)
         tetrahedraIndex.push_back(ntetra+i);
 
     // add topology event in the stack of topological events
-    addTetrahedraWarning((unsigned int)tetrahedra.size(), tetrahedra, tetrahedraIndex);
+    addTetrahedraWarning(tetrahedra.size(), tetrahedra, tetrahedraIndex);
 
     // inform other objects that the edges are already added
     propagateTopologicalChanges();
@@ -82,7 +82,7 @@ void TetrahedronSetTopologyModifier::addTetrahedra(const sofa::helper::vector<Te
 
 
 void TetrahedronSetTopologyModifier::addTetrahedra(const sofa::helper::vector<Tetrahedron> &tetrahedra,
-        const sofa::helper::vector<sofa::helper::vector<unsigned int> > &ancestors,
+        const sofa::helper::vector<sofa::helper::vector<TetrahedronID> > &ancestors,
         const sofa::helper::vector<sofa::helper::vector<double> > &baryCoefs)
 {
     size_t ntetra = m_container->getNbTetrahedra();
@@ -90,14 +90,14 @@ void TetrahedronSetTopologyModifier::addTetrahedra(const sofa::helper::vector<Te
     /// effectively add triangles in the topology container
     addTetrahedraProcess(tetrahedra);
 
-    sofa::helper::vector<unsigned int> tetrahedraIndex;
+    sofa::helper::vector<TetrahedronID> tetrahedraIndex;
     tetrahedraIndex.reserve(tetrahedra.size());
 
-    for (unsigned int i=0; i<tetrahedra.size(); ++i)
+    for (size_t i=0; i<tetrahedra.size(); ++i)
         tetrahedraIndex.push_back(ntetra+i);
 
     // add topology event in the stack of topological events
-    addTetrahedraWarning((unsigned int)tetrahedra.size(), tetrahedra, tetrahedraIndex, ancestors, baryCoefs);
+    addTetrahedraWarning(tetrahedra.size(), tetrahedra, tetrahedraIndex, ancestors, baryCoefs);
 
     // inform other objects that the edges are already added
     propagateTopologicalChanges();
@@ -118,11 +118,11 @@ void TetrahedronSetTopologyModifier::addTetrahedronProcess(Tetrahedron t)
     // assert(m_container->getTetrahedronIndex(t[0], t[1], t[2], t[3])== -1);
 #endif
     helper::WriteAccessor< Data< sofa::helper::vector<Tetrahedron> > > m_tetrahedron = m_container->d_tetrahedron;
-    const unsigned int tetrahedronIndex = (unsigned int)m_tetrahedron.size();
+    const TetrahedronID tetrahedronIndex = (TetrahedronID)m_tetrahedron.size();
 
     if (m_container->hasTrianglesInTetrahedron())
     {
-        for (unsigned int j=0; j<4; ++j)
+        for (PointID j=0; j<4; ++j)
         {
             int triangleIndex = m_container->getTriangleIndex(t[(j+1)%4], t[(j+2)%4], t[(j+3)%4]);
 
@@ -137,9 +137,9 @@ void TetrahedronSetTopologyModifier::addTetrahedronProcess(Tetrahedron t)
 
                 triangleIndex = m_container->getTriangleIndex(t[(j+1)%4], t[(j+2)%4], t[(j+3)%4]);
 
-                sofa::helper::vector< unsigned int > triangleIndexList;
+                sofa::helper::vector< TriangleID > triangleIndexList;
                 triangleIndexList.push_back(triangleIndex);
-                addTrianglesWarning((unsigned int)v.size(), v, triangleIndexList);
+                addTrianglesWarning(v.size(), v, triangleIndexList);
             }
 
             //m_container->m_trianglesInTetrahedron.resize(triangleIndex+1);
@@ -150,7 +150,7 @@ void TetrahedronSetTopologyModifier::addTetrahedronProcess(Tetrahedron t)
 
     if (m_container->hasEdgesInTetrahedron())
     {
-        for (unsigned int j=0; j<6; ++j)
+        for (EdgeID j=0; j<6; ++j)
         {
             int p0=-1,p1=-1;
 
@@ -180,9 +180,9 @@ void TetrahedronSetTopologyModifier::addTetrahedronProcess(Tetrahedron t)
 
                 edgeIndex=m_container->getEdgeIndex(t[p0],t[p1]);
 
-                sofa::helper::vector< unsigned int > edgeIndexList;
+                sofa::helper::vector< EdgeID > edgeIndexList;
                 edgeIndexList.push_back(edgeIndex);
-                addEdgesWarning((unsigned int)v.size(), v, edgeIndexList);
+                addEdgesWarning(v.size(), v, edgeIndexList);
             }
 
             m_container->m_edgesInTetrahedron.resize(tetrahedronIndex+1);
@@ -192,27 +192,27 @@ void TetrahedronSetTopologyModifier::addTetrahedronProcess(Tetrahedron t)
 
     if (m_container->hasTetrahedraAroundVertex())
     {
-        for (unsigned int j=0; j<4; ++j)
+        for (PointID j=0; j<4; ++j)
         {
-            sofa::helper::vector< unsigned int > &shell = m_container->getTetrahedraAroundVertexForModification( t[j] );
+            sofa::helper::vector< TetrahedronID > &shell = m_container->getTetrahedraAroundVertexForModification( t[j] );
             shell.push_back( tetrahedronIndex );
         }
     }
 
     if (m_container->hasTetrahedraAroundEdge())
     {
-        for (unsigned int j=0; j<6; ++j)
+        for (EdgeID j=0; j<6; ++j)
         {
-            sofa::helper::vector< unsigned int > &shell = m_container->m_tetrahedraAroundEdge[m_container->m_edgesInTetrahedron[tetrahedronIndex][j]];
+            sofa::helper::vector< TetrahedronID > &shell = m_container->m_tetrahedraAroundEdge[m_container->m_edgesInTetrahedron[tetrahedronIndex][j]];
             shell.push_back( tetrahedronIndex );
         }
     }
 
     if (m_container->hasTetrahedraAroundTriangle())
     {
-        for (unsigned int j=0; j<4; ++j)
+        for (TriangleID j=0; j<4; ++j)
         {
-            sofa::helper::vector< unsigned int > &shell = m_container->m_tetrahedraAroundTriangle[m_container->m_trianglesInTetrahedron[tetrahedronIndex][j]];
+            sofa::helper::vector< TetrahedronID > &shell = m_container->m_tetrahedraAroundTriangle[m_container->m_trianglesInTetrahedron[tetrahedronIndex][j]];
             shell.push_back( tetrahedronIndex );
         }
     }
@@ -223,16 +223,16 @@ void TetrahedronSetTopologyModifier::addTetrahedronProcess(Tetrahedron t)
 
 void TetrahedronSetTopologyModifier::addTetrahedraProcess(const sofa::helper::vector< Tetrahedron > &tetrahedra)
 {
-    for (unsigned int i = 0; i < tetrahedra.size(); ++i)
+    for (size_t i = 0; i < tetrahedra.size(); ++i)
     {
         addTetrahedronProcess(tetrahedra[i]);
     }
 }
 
 
-void TetrahedronSetTopologyModifier::addTetrahedraWarning(const unsigned int nTetrahedra,
+void TetrahedronSetTopologyModifier::addTetrahedraWarning(const size_t nTetrahedra,
         const sofa::helper::vector< Tetrahedron >& tetrahedraList,
-        const sofa::helper::vector< unsigned int >& tetrahedraIndexList)
+        const sofa::helper::vector< TetrahedronID >& tetrahedraIndexList)
 {
     m_container->setTetrahedronTopologyToDirty();
     // Warning that tetrahedra just got created
@@ -241,10 +241,10 @@ void TetrahedronSetTopologyModifier::addTetrahedraWarning(const unsigned int nTe
 }
 
 
-void TetrahedronSetTopologyModifier::addTetrahedraWarning(const unsigned int nTetrahedra,
+void TetrahedronSetTopologyModifier::addTetrahedraWarning(const size_t nTetrahedra,
         const sofa::helper::vector< Tetrahedron >& tetrahedraList,
-        const sofa::helper::vector< unsigned int >& tetrahedraIndexList,
-        const sofa::helper::vector< sofa::helper::vector< unsigned int > > & ancestors,
+        const sofa::helper::vector< TetrahedronID >& tetrahedraIndexList,
+        const sofa::helper::vector< sofa::helper::vector< TetrahedronID > > & ancestors,
         const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs)
 {
     m_container->setTetrahedronTopologyToDirty();
@@ -254,18 +254,18 @@ void TetrahedronSetTopologyModifier::addTetrahedraWarning(const unsigned int nTe
 }
 
 
-void TetrahedronSetTopologyModifier::removeTetrahedraWarning( sofa::helper::vector<unsigned int> &tetrahedra )
+void TetrahedronSetTopologyModifier::removeTetrahedraWarning( sofa::helper::vector<TetrahedronID> &tetrahedra )
 {
     m_container->setTetrahedronTopologyToDirty();
     /// sort vertices to remove in a descendent order
-    std::sort( tetrahedra.begin(), tetrahedra.end(), std::greater<unsigned int>() );
+    std::sort( tetrahedra.begin(), tetrahedra.end(), std::greater<TetrahedronID>() );
 
     // Warning that these edges will be deleted
     TetrahedraRemoved *e=new TetrahedraRemoved(tetrahedra);
     addTopologyChange(e);
 }
 
-void TetrahedronSetTopologyModifier::removeTetrahedraProcess( const sofa::helper::vector<unsigned int> &indices,
+void TetrahedronSetTopologyModifier::removeTetrahedraProcess( const sofa::helper::vector<TetrahedronID> &indices,
         const bool removeIsolatedItems)
 {
     if(!m_container->hasTetrahedra())
@@ -293,23 +293,23 @@ void TetrahedronSetTopologyModifier::removeTetrahedraProcess( const sofa::helper
             m_container->createTetrahedraAroundTriangleArray();
     }
 
-    sofa::helper::vector<unsigned int> triangleToBeRemoved;
-    sofa::helper::vector<unsigned int> edgeToBeRemoved;
-    sofa::helper::vector<unsigned int> vertexToBeRemoved;
+    sofa::helper::vector<TriangleID> triangleToBeRemoved;
+    sofa::helper::vector<EdgeID> edgeToBeRemoved;
+    sofa::helper::vector<PointID> vertexToBeRemoved;
 
     helper::WriteAccessor< Data< sofa::helper::vector<Tetrahedron> > > m_tetrahedron = m_container->d_tetrahedron;
 
-    unsigned int lastTetrahedron = m_container->getNumberOfTetrahedra() - 1;
-    for (unsigned int i=0; i<indices.size(); ++i, --lastTetrahedron)
+    TetrahedronID lastTetrahedron = (TetrahedronID)m_container->getNumberOfTetrahedra() - 1;
+    for (size_t i=0; i<indices.size(); ++i, --lastTetrahedron)
     {
         const Tetrahedron &t = m_tetrahedron[ indices[i] ];
         const Tetrahedron &h = m_tetrahedron[ lastTetrahedron ];
 
         if (m_container->hasTetrahedraAroundVertex())
         {
-            for(unsigned int j=0; j<4; ++j)
+            for(PointID j=0; j<4; ++j)
             {
-                sofa::helper::vector< unsigned int > &shell = m_container->m_tetrahedraAroundVertex[ t[j] ];
+                sofa::helper::vector< TetrahedronID > &shell = m_container->m_tetrahedraAroundVertex[ t[j] ];
                 shell.erase(remove(shell.begin(), shell.end(), indices[i]), shell.end());
                 if(removeIsolatedVertices && shell.empty())
                 {
@@ -320,9 +320,9 @@ void TetrahedronSetTopologyModifier::removeTetrahedraProcess( const sofa::helper
 
         if(m_container->hasTetrahedraAroundEdge())
         {
-            for(unsigned int j=0; j<6; ++j)
+            for(EdgeID j=0; j<6; ++j)
             {
-                sofa::helper::vector< unsigned int > &shell = m_container->m_tetrahedraAroundEdge[ m_container->m_edgesInTetrahedron[indices[i]][j]];
+                sofa::helper::vector< TetrahedronID > &shell = m_container->m_tetrahedraAroundEdge[ m_container->m_edgesInTetrahedron[indices[i]][j]];
                 shell.erase(remove(shell.begin(), shell.end(), indices[i]), shell.end());
                 if(removeIsolatedEdges && shell.empty())
                     edgeToBeRemoved.push_back(m_container->m_edgesInTetrahedron[indices[i]][j]);
@@ -331,9 +331,9 @@ void TetrahedronSetTopologyModifier::removeTetrahedraProcess( const sofa::helper
 
         if(m_container->hasTetrahedraAroundTriangle())
         {
-            for(unsigned int j=0; j<4; ++j)
+            for(TriangleID j=0; j<4; ++j)
             {
-                sofa::helper::vector< unsigned int > &shell = m_container->m_tetrahedraAroundTriangle[ m_container->m_trianglesInTetrahedron[indices[i]][j]];
+                sofa::helper::vector< TetrahedronID > &shell = m_container->m_tetrahedraAroundTriangle[ m_container->m_trianglesInTetrahedron[indices[i]][j]];
                 shell.erase(remove(shell.begin(), shell.end(), indices[i]), shell.end());
                 if(removeIsolatedTriangles && shell.empty())
                     triangleToBeRemoved.push_back(m_container->m_trianglesInTetrahedron[indices[i]][j]);
@@ -345,27 +345,27 @@ void TetrahedronSetTopologyModifier::removeTetrahedraProcess( const sofa::helper
         {
             if (m_container->hasTetrahedraAroundVertex())
             {
-                for(unsigned int j=0; j<4; ++j)
+                for(PointID j=0; j<4; ++j)
                 {
-                    sofa::helper::vector< unsigned int > &shell = m_container->m_tetrahedraAroundVertex[ h[j] ];
+                    sofa::helper::vector< TetrahedronID > &shell = m_container->m_tetrahedraAroundVertex[ h[j] ];
                     replace(shell.begin(), shell.end(), lastTetrahedron, indices[i]);
                 }
             }
 
             if (m_container->hasTetrahedraAroundEdge())
             {
-                for(unsigned int j=0; j<6; ++j)
+                for(EdgeID j=0; j<6; ++j)
                 {
-                    sofa::helper::vector< unsigned int > &shell =  m_container->m_tetrahedraAroundEdge[ m_container->m_edgesInTetrahedron[lastTetrahedron][j]];
+                    sofa::helper::vector< TetrahedronID > &shell =  m_container->m_tetrahedraAroundEdge[ m_container->m_edgesInTetrahedron[lastTetrahedron][j]];
                     replace(shell.begin(), shell.end(), lastTetrahedron, indices[i]);
                 }
             }
 
             if (m_container->hasTetrahedraAroundTriangle())
             {
-                for(unsigned int j=0; j<4; ++j)
+                for(TriangleID j=0; j<4; ++j)
                 {
-                    sofa::helper::vector< unsigned int > &shell =  m_container->m_tetrahedraAroundTriangle[ m_container->m_trianglesInTetrahedron[lastTetrahedron][j]];
+                    sofa::helper::vector< TetrahedronID > &shell =  m_container->m_tetrahedraAroundTriangle[ m_container->m_trianglesInTetrahedron[lastTetrahedron][j]];
                     replace(shell.begin(), shell.end(), lastTetrahedron, indices[i]);
                 }
             }
@@ -454,7 +454,7 @@ void TetrahedronSetTopologyModifier::addTrianglesProcess(const sofa::helper::vec
         m_container->m_tetrahedraAroundTriangle.resize( m_container->getNumberOfTriangles() );
 }
 
-void TetrahedronSetTopologyModifier::removePointsProcess(const sofa::helper::vector<unsigned int> &indices,
+void TetrahedronSetTopologyModifier::removePointsProcess(const sofa::helper::vector<PointID> &indices,
         const bool removeDOF)
 {
     if(m_container->hasTetrahedra())
@@ -465,15 +465,15 @@ void TetrahedronSetTopologyModifier::removePointsProcess(const sofa::helper::vec
         }
 
         helper::WriteAccessor< Data< sofa::helper::vector<Tetrahedron> > > m_tetrahedron = m_container->d_tetrahedron;
-        unsigned int lastPoint = m_container->getNbPoints() - 1;
-        for (unsigned int i=0; i<indices.size(); ++i, --lastPoint)
+        PointID lastPoint = (PointID)m_container->getNbPoints() - 1;
+        for (size_t i=0; i<indices.size(); ++i, --lastPoint)
         {
             // updating the edges connected to the point replacing the removed one:
             // for all edges connected to the last point
-            for (sofa::helper::vector<unsigned int>::iterator itt=m_container->m_tetrahedraAroundVertex[lastPoint].begin();
+            for (sofa::helper::vector<TetrahedronID>::iterator itt=m_container->m_tetrahedraAroundVertex[lastPoint].begin();
                     itt!=m_container->m_tetrahedraAroundVertex[lastPoint].end(); ++itt)
             {
-                unsigned int vertexIndex = m_container->getVertexIndexInTetrahedron(m_tetrahedron[(*itt)],lastPoint);
+                PointID vertexIndex = m_container->getVertexIndexInTetrahedron(m_tetrahedron[(*itt)],lastPoint);
                 m_tetrahedron[(*itt)][vertexIndex]=indices[i];
             }
 
@@ -489,7 +489,7 @@ void TetrahedronSetTopologyModifier::removePointsProcess(const sofa::helper::vec
     TriangleSetTopologyModifier::removePointsProcess(  indices, removeDOF );
 }
 
-void TetrahedronSetTopologyModifier::removeEdgesProcess( const sofa::helper::vector<unsigned int> &indices,
+void TetrahedronSetTopologyModifier::removeEdgesProcess( const sofa::helper::vector<EdgeID> &indices,
         const bool removeIsolatedItems)
 {
     if(!m_container->hasEdges()) // this method should only be called when edges exist
@@ -500,13 +500,13 @@ void TetrahedronSetTopologyModifier::removeEdgesProcess( const sofa::helper::vec
         if(!m_container->hasTetrahedraAroundEdge())
             m_container->createTetrahedraAroundEdgeArray();
 
-        unsigned int lastEdge = m_container->getNumberOfEdges() - 1;
-        for (unsigned int i=0; i<indices.size(); ++i, --lastEdge)
+        EdgeID lastEdge = (EdgeID)m_container->getNumberOfEdges() - 1;
+        for (size_t i=0; i<indices.size(); ++i, --lastEdge)
         {
-            for (sofa::helper::vector<unsigned int>::iterator itt=m_container->m_tetrahedraAroundEdge[lastEdge].begin();
+            for (sofa::helper::vector<TetrahedronID>::iterator itt=m_container->m_tetrahedraAroundEdge[lastEdge].begin();
                     itt!=m_container->m_tetrahedraAroundEdge[lastEdge].end(); ++itt)
             {
-                unsigned int edgeIndex=m_container->getEdgeIndexInTetrahedron(m_container->m_edgesInTetrahedron[(*itt)],lastEdge);
+                EdgeID edgeIndex=m_container->getEdgeIndexInTetrahedron(m_container->m_edgesInTetrahedron[(*itt)],lastEdge);
                 m_container->m_edgesInTetrahedron[(*itt)][edgeIndex]=indices[i];
             }
 
@@ -521,7 +521,7 @@ void TetrahedronSetTopologyModifier::removeEdgesProcess( const sofa::helper::vec
     TriangleSetTopologyModifier::removeEdgesProcess( indices, removeIsolatedItems );
 }
 
-void TetrahedronSetTopologyModifier::removeTrianglesProcess( const sofa::helper::vector<unsigned int> &indices,
+void TetrahedronSetTopologyModifier::removeTrianglesProcess( const sofa::helper::vector<TriangleID> &indices,
         const bool removeIsolatedEdges,
         const bool removeIsolatedPoints)
 {
@@ -533,13 +533,13 @@ void TetrahedronSetTopologyModifier::removeTrianglesProcess( const sofa::helper:
         if(!m_container->hasTetrahedraAroundTriangle())
             m_container->createTetrahedraAroundTriangleArray();
 
-        size_t lastTriangle = m_container->m_tetrahedraAroundTriangle.size() - 1;
-        for (unsigned int i = 0; i < indices.size(); ++i, --lastTriangle)
+        TriangleID lastTriangle = (TriangleID)m_container->m_tetrahedraAroundTriangle.size() - 1;
+        for (size_t i = 0; i < indices.size(); ++i, --lastTriangle)
         {
-            for (sofa::helper::vector<unsigned int>::iterator itt=m_container->m_tetrahedraAroundTriangle[lastTriangle].begin();
+            for (sofa::helper::vector<TetrahedronID>::iterator itt=m_container->m_tetrahedraAroundTriangle[lastTriangle].begin();
                     itt!=m_container->m_tetrahedraAroundTriangle[lastTriangle].end(); ++itt)
             {
-                unsigned int triangleIndex=m_container->getTriangleIndexInTetrahedron(m_container->m_trianglesInTetrahedron[(*itt)],lastTriangle);
+                TriangleID triangleIndex=m_container->getTriangleIndexInTetrahedron(m_container->m_trianglesInTetrahedron[(*itt)],lastTriangle);
                 m_container->m_trianglesInTetrahedron[(*itt)][triangleIndex] = indices[i];
             }
 
@@ -553,8 +553,8 @@ void TetrahedronSetTopologyModifier::removeTrianglesProcess( const sofa::helper:
     TriangleSetTopologyModifier::removeTrianglesProcess( indices, removeIsolatedEdges, removeIsolatedPoints );
 }
 
-void TetrahedronSetTopologyModifier::renumberPointsProcess( const sofa::helper::vector<unsigned int> &index,
-        const sofa::helper::vector<unsigned int> &inv_index,
+void TetrahedronSetTopologyModifier::renumberPointsProcess( const sofa::helper::vector<PointID> &index,
+        const sofa::helper::vector<PointID> &inv_index,
         const bool renumberDOF)
 {
     if(m_container->hasTetrahedra())
@@ -562,14 +562,14 @@ void TetrahedronSetTopologyModifier::renumberPointsProcess( const sofa::helper::
         helper::WriteAccessor< Data< sofa::helper::vector<Tetrahedron> > > m_tetrahedron = m_container->d_tetrahedron;
         if(m_container->hasTetrahedraAroundVertex())
         {
-            sofa::helper::vector< sofa::helper::vector< unsigned int > > tetrahedraAroundVertex_cp = m_container->m_tetrahedraAroundVertex;
-            for (unsigned int i = 0; i < index.size(); ++i)
+            sofa::helper::vector< sofa::helper::vector< TetrahedronID > > tetrahedraAroundVertex_cp = m_container->m_tetrahedraAroundVertex;
+            for (size_t i = 0; i < index.size(); ++i)
             {
                 m_container->m_tetrahedraAroundVertex[i] = tetrahedraAroundVertex_cp[ index[i] ];
             }
         }
 
-        for (unsigned int i=0; i<m_tetrahedron.size(); ++i)
+        for (size_t i=0; i<m_tetrahedron.size(); ++i)
         {
             m_tetrahedron[i][0]  = inv_index[ m_tetrahedron[i][0]  ];
             m_tetrahedron[i][1]  = inv_index[ m_tetrahedron[i][1]  ];
@@ -582,10 +582,10 @@ void TetrahedronSetTopologyModifier::renumberPointsProcess( const sofa::helper::
     TriangleSetTopologyModifier::renumberPointsProcess( index, inv_index, renumberDOF );
 }
 
-void TetrahedronSetTopologyModifier::removeTetrahedra(const sofa::helper::vector<unsigned int> &tetrahedraIds)
+void TetrahedronSetTopologyModifier::removeTetrahedra(const sofa::helper::vector<TetrahedronID> &tetrahedraIds)
 {
-    sofa::helper::vector<unsigned int> tetrahedraIds_filtered;
-    for (unsigned int i = 0; i < tetrahedraIds.size(); i++)
+    sofa::helper::vector<TetrahedronID> tetrahedraIds_filtered;
+    for (size_t i = 0; i < tetrahedraIds.size(); i++)
     {
         if( tetrahedraIds[i] >= m_container->getNumberOfTetrahedra())
             std::cout << "Error: TetrahedronSetTopologyModifier::removeTetrahedra: tetrahedra: "<< tetrahedraIds[i] <<" is out of bound and won't be removed." << std::endl;
@@ -606,13 +606,13 @@ void TetrahedronSetTopologyModifier::removeTetrahedra(const sofa::helper::vector
     m_container->addRemovedTetraIndex(tetrahedraIds_filtered);
 }
 
-void TetrahedronSetTopologyModifier::removeItems(const sofa::helper::vector< unsigned int >& items)
+void TetrahedronSetTopologyModifier::removeItems(const sofa::helper::vector< TetrahedronID >& items)
 {
     removeTetrahedra(items);
 }
 
-void TetrahedronSetTopologyModifier::renumberPoints( const sofa::helper::vector<unsigned int> &index,
-        const sofa::helper::vector<unsigned int> &inv_index)
+void TetrahedronSetTopologyModifier::renumberPoints( const sofa::helper::vector<PointID> &index,
+        const sofa::helper::vector<PointID> &inv_index)
 {
     /// add the topological changes in the queue
     renumberPointsWarning(index, inv_index);

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyModifier.cpp
@@ -71,7 +71,7 @@ void TetrahedronSetTopologyModifier::addTetrahedra(const sofa::helper::vector<Te
     tetrahedraIndex.reserve(tetrahedra.size());
 
     for (size_t i=0; i<tetrahedra.size(); ++i)
-        tetrahedraIndex.push_back(ntetra+i);
+        tetrahedraIndex.push_back(TetrahedronID(ntetra+i));
 
     // add topology event in the stack of topological events
     addTetrahedraWarning(tetrahedra.size(), tetrahedra, tetrahedraIndex);
@@ -94,7 +94,7 @@ void TetrahedronSetTopologyModifier::addTetrahedra(const sofa::helper::vector<Te
     tetrahedraIndex.reserve(tetrahedra.size());
 
     for (size_t i=0; i<tetrahedra.size(); ++i)
-        tetrahedraIndex.push_back(ntetra+i);
+        tetrahedraIndex.push_back(TetrahedronID(ntetra+i));
 
     // add topology event in the stack of topological events
     addTetrahedraWarning(tetrahedra.size(), tetrahedra, tetrahedraIndex, ancestors, baryCoefs);

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyModifier.h
@@ -46,6 +46,7 @@ public:
 
 
     typedef core::topology::BaseMeshTopology::TetraID TetraID;
+    typedef core::topology::BaseMeshTopology::TetrahedronID TetrahedronID;
     typedef core::topology::BaseMeshTopology::Tetra Tetra;
     typedef core::topology::BaseMeshTopology::SeqTetrahedra SeqTetrahedra;
     typedef core::topology::BaseMeshTopology::TetrahedraAroundVertex TetrahedraAroundVertex;
@@ -84,7 +85,7 @@ public:
     *
     */
     virtual void addTetrahedra(const sofa::helper::vector< Tetrahedron > &tetrahedra,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > > & ancestors,
+            const sofa::helper::vector< sofa::helper::vector< TetrahedronID > > & ancestors,
             const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs) ;
 
 
@@ -92,18 +93,18 @@ public:
     *
     * \sa addTetrahedraProcess
     */
-    void addTetrahedraWarning(const unsigned int nTetrahedra,
+    void addTetrahedraWarning(const size_t nTetrahedra,
             const sofa::helper::vector< Tetrahedron >& tetrahedraList,
-            const sofa::helper::vector< unsigned int >& tetrahedraIndexList);
+            const sofa::helper::vector< TetrahedronID >& tetrahedraIndexList);
 
     /** \brief Sends a message to warn that some tetrahedra were added in this topology.
     *
     * \sa addTetrahedraProcess
     */
-    void addTetrahedraWarning(const unsigned int nTetrahedra,
+    void addTetrahedraWarning(const size_t nTetrahedra,
             const sofa::helper::vector< Tetrahedron >& tetrahedraList,
-            const sofa::helper::vector< unsigned int >& tetrahedraIndexList,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > > & ancestors,
+            const sofa::helper::vector< TetrahedronID >& tetrahedraIndexList,
+            const sofa::helper::vector< sofa::helper::vector< TetrahedronID > > & ancestors,
             const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs);
 
     /** \brief Add a tetrahedron.
@@ -123,7 +124,7 @@ public:
     *
     * Important : parameter indices is not const because it is actually sorted from the highest index to the lowest one.
     */
-    void removeTetrahedraWarning( sofa::helper::vector<unsigned int> &tetrahedra);
+    void removeTetrahedraWarning( sofa::helper::vector<TetrahedronID> &tetrahedra);
 
     /** \brief Remove a subset of tetrahedra
     *
@@ -133,7 +134,7 @@ public:
     * \sa removeTetrahedraWarning
     * @param removeIsolatedItems if true remove isolated triangles, edges and vertices
     */
-    virtual void removeTetrahedraProcess( const sofa::helper::vector<unsigned int> &indices,
+    virtual void removeTetrahedraProcess( const sofa::helper::vector<TetrahedronID> &indices,
             const bool removeIsolatedItems=false);
 
     /** \brief Actually Add some triangles to this topology.
@@ -148,7 +149,7 @@ public:
     * @param removeIsolatedEdges if true isolated edges are also removed
     * @param removeIsolatedPoints if true isolated vertices are also removed
     */
-    virtual void removeTrianglesProcess(const sofa::helper::vector<unsigned int> &indices,
+    virtual void removeTrianglesProcess(const sofa::helper::vector<TriangleID> &indices,
             const bool removeIsolatedEdges=false,
             const bool removeIsolatedPoints=false) override;
 
@@ -166,7 +167,7 @@ public:
     * Important : parameter indices is not const because it is actually sorted from the highest index to the lowest one.
     * @param removeIsolatedItems if true remove isolated vertices
     */
-    virtual void removeEdgesProcess( const sofa::helper::vector<unsigned int> &indices,
+    virtual void removeEdgesProcess( const sofa::helper::vector<EdgeID> &indices,
             const bool removeIsolatedItems=false) override;
 
     /** \brief Add some points to this topology.
@@ -183,35 +184,35 @@ public:
     * \sa removePointsWarning
     * Important : the points are actually deleted from the mechanical object's state vectors iff (removeDOF == true)
     */
-    virtual void removePointsProcess(const sofa::helper::vector<unsigned int> &indices, const bool removeDOF = true) override;
+    virtual void removePointsProcess(const sofa::helper::vector<PointID> &indices, const bool removeDOF = true) override;
 
     /** \brief Reorder this topology.
     *
     * Important : the points are actually renumbered in the mechanical object's state vectors iff (renumberDOF == true)
     * \see MechanicalObject::renumberValues
     */
-    virtual void renumberPointsProcess( const sofa::helper::vector<unsigned int> &index,
-            const sofa::helper::vector<unsigned int> &/*inv_index*/,
+    virtual void renumberPointsProcess( const sofa::helper::vector<PointID> &index,
+            const sofa::helper::vector<PointID> &/*inv_index*/,
             const bool renumberDOF = true) override;
 
     /** \brief Remove a set  of tetrahedra
     @param tetrahedra an array of tetrahedron indices to be removed (note that the array is not const since it needs to be sorted)
     *
     */
-    virtual void removeTetrahedra(const sofa::helper::vector< unsigned int >& tetrahedraIds);
+    virtual void removeTetrahedra(const sofa::helper::vector< TetrahedronID >& tetrahedraIds);
 
     /** \brief Generic method to remove a list of items.
     */
-    virtual void removeItems(const sofa::helper::vector<unsigned int> &items) override;
+    virtual void removeItems(const sofa::helper::vector<TetrahedronID> &items) override;
 
     /** \brief  Removes all tetrahedra in the ball of center "ind_ta" and of radius dist(ind_ta, ind_tb)
     */
-    void RemoveTetraBall(unsigned int ind_ta, unsigned int ind_tb);
+    void RemoveTetraBall(TetrahedronID ind_ta, TetrahedronID ind_tb);
 
     /** \brief Generic method for points renumbering
     */
-    virtual void renumberPoints( const sofa::helper::vector<unsigned int> &/*index*/,
-            const sofa::helper::vector<unsigned int> &/*inv_index*/) override;
+    virtual void renumberPoints( const sofa::helper::vector<PointID> &/*index*/,
+            const sofa::helper::vector<PointID> &/*inv_index*/) override;
 
 
 private:

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyModifier.h
@@ -173,7 +173,7 @@ public:
     *
     * \sa addPointsWarning
     */
-    virtual void addPointsProcess(const unsigned int nPoints) override;
+    virtual void addPointsProcess(const size_t nPoints) override;
 
     /** \brief Remove a subset of points
     *

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetGeometryAlgorithms.h
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetGeometryAlgorithms.h
@@ -47,6 +47,8 @@ public:
 
     typedef sofa::core::topology::BaseMeshTopology::PointID PointID;
     typedef sofa::core::topology::BaseMeshTopology::EdgeID EdgeID;
+    typedef sofa::core::topology::BaseMeshTopology::QuadID QuadID;
+    typedef sofa::core::topology::BaseMeshTopology::ElemID ElemID;
     typedef sofa::core::topology::BaseMeshTopology::Edge Edge;
     typedef sofa::core::topology::BaseMeshTopology::SeqEdges SeqEdges;
     typedef sofa::core::topology::BaseMeshTopology::EdgesAroundVertex EdgesAroundVertex;
@@ -126,30 +128,30 @@ public:
      *
      */
     sofa::helper::vector< double > compute3PointsBarycoefs( const sofa::defaulttype::Vec<3,double> &p,
-            unsigned int ind_p1,
-            unsigned int ind_p2,
-            unsigned int ind_p3,
+            PointID ind_p1,
+            PointID ind_p2,
+            PointID ind_p3,
             bool bRest=false) const;
 
     /** \brief Finds the two closest points from two triangles (each of the point belonging to one triangle)
      *
      */
     void computeClosestIndexPair(const TriangleID ind_ta, const TriangleID ind_tb,
-            unsigned int &ind1, unsigned int &ind2) const;
+        PointID &ind1, PointID &ind2) const;
 
     /** \brief Tests if a point is included in the triangle indexed by ind_t
      *
      */
-    bool isPointInsideTriangle(const TriangleID ind_t, bool is_tested, const sofa::defaulttype::Vec<3,Real>& p, unsigned int &ind_t_test, bool bRest=false) const;
+    bool isPointInsideTriangle(const TriangleID ind_t, bool is_tested, const sofa::defaulttype::Vec<3,Real>& p, TriangleID &ind_t_test, bool bRest=false) const;
 
-    bool isPointInTriangle(const TriangleID ind_t, bool is_tested, const sofa::defaulttype::Vec<3,Real>& p, unsigned int &ind_t_test) const;
+    bool isPointInTriangle(const TriangleID ind_t, bool is_tested, const sofa::defaulttype::Vec<3,Real>& p, TriangleID &ind_t_test) const;
 
 
 
     /** \brief Computes the point defined by 2 indices of vertex and 1 barycentric coordinate
      *
      */
-    sofa::defaulttype::Vec<3,double> computeBaryEdgePoint(unsigned int p0, unsigned int p1, double coord_p) const;
+    sofa::defaulttype::Vec<3,double> computeBaryEdgePoint(PointID p0, PointID p1, double coord_p) const;
     sofa::defaulttype::Vec<3,double> computeBaryEdgePoint(Edge e, double coord_p) const
     {
         return computeBaryEdgePoint(e[0], e[1], coord_p);
@@ -158,7 +160,7 @@ public:
     /** \brief Computes the point defined by 3 indices of vertex and 1 barycentric coordinate
      *
      */
-    sofa::defaulttype::Vec<3,double> computeBaryTrianglePoint(unsigned int p0, unsigned int p1, unsigned int p2, sofa::defaulttype::Vec<3,double>& coord_p) const;
+    sofa::defaulttype::Vec<3,double> computeBaryTrianglePoint(PointID p0, PointID p1, PointID p2, sofa::defaulttype::Vec<3,double>& coord_p) const;
     sofa::defaulttype::Vec<3,double> computeBaryTrianglePoint(Triangle& t, sofa::defaulttype::Vec<3,double>& coord_p) const
     {
         return computeBaryTrianglePoint(t[0], t[1], t[2], coord_p);
@@ -175,7 +177,7 @@ public:
     */
     bool isQuadDeulaunayOriented(const typename DataTypes::Coord& p_q1,
             const typename DataTypes::Coord& p_q2,
-            unsigned int ind_q3, unsigned int ind_q4);
+            QuadID ind_q3, QuadID ind_q4);
 
     /** \brief Tests how to triangularize a quad whose vertices are defined by (p1, p2, p3, p4) according to the Delaunay criterion
      *
@@ -198,23 +200,23 @@ public:
     /** \brief Computes the opposite point to ind_p
      *
      */
-    sofa::defaulttype::Vec<3,double> getOppositePoint(unsigned int ind_p, const Edge& indices, double coord_p) const;
+    sofa::defaulttype::Vec<3,double> getOppositePoint(PointID ind_p, const Edge& indices, double coord_p) const;
 
     /** \brief Tests if a triangle indexed by ind_t (and incident to the vertex indexed by ind_p) is included or not in the plane defined by (ind_p, plane_vect)
      *
     */
-    bool isTriangleInPlane(const TriangleID ind_t, const unsigned int ind_p,
+    bool isTriangleInPlane(const TriangleID ind_t, const PointID ind_p,
             const sofa::defaulttype::Vec<3,Real>& plane_vect) const;
 
     /** \brief Prepares the duplication of a vertex
      *
      */
-    void prepareVertexDuplication(const unsigned int ind_p,
+    void prepareVertexDuplication(const PointID ind_p,
             const TriangleID ind_t_from, const TriangleID ind_t_to,
             const Edge& indices_from, const double &coord_from,
             const Edge& indices_to, const double &coord_to,
-            sofa::helper::vector< unsigned int > &triangles_list_1,
-            sofa::helper::vector< unsigned int > &triangles_list_2) const;
+            sofa::helper::vector< TriangleID > &triangles_list_1,
+            sofa::helper::vector< TriangleID > &triangles_list_2) const;
 
     /** \brief Computes the intersection of the vector from point a to point b and the triangle indexed by t
      *
@@ -229,7 +231,7 @@ public:
             const sofa::defaulttype::Vec<3,double>& a,
             const sofa::defaulttype::Vec<3,double>& b,
             const TriangleID ind_t,
-            sofa::helper::vector<unsigned int> &indices,
+            sofa::helper::vector<PointID> &indices,
             double &baryCoef, double& coord_kmin) const;
 
     /** \brief Computes the list of points (ind_edge,coord) intersected by the segment from point a to point b and the triangular mesh
@@ -238,9 +240,9 @@ public:
     bool computeIntersectedPointsList(const PointID last_point,
             const sofa::defaulttype::Vec<3,double>& a,
             const sofa::defaulttype::Vec<3,double>& b,
-            unsigned int& ind_ta, unsigned int& ind_tb,
-            sofa::helper::vector< unsigned int > &triangles_list,
-            sofa::helper::vector< unsigned int > &edges_list,
+            TriangleID& ind_ta, TriangleID& ind_tb,
+            sofa::helper::vector< TriangleID > &triangles_list,
+            sofa::helper::vector< EdgeID > &edges_list,
             sofa::helper::vector< double >& coords_list,
             bool& is_on_boundary) const;
 
@@ -253,9 +255,9 @@ public:
      */
     bool computeIntersectedObjectsList (const PointID last_point,
             const sofa::defaulttype::Vec<3,double>& a, const sofa::defaulttype::Vec<3,double>& b,
-            unsigned int& ind_ta, unsigned int& ind_tb,
+            TriangleID& ind_ta, TriangleID& ind_tb,
             sofa::helper::vector< sofa::core::topology::TopologyObjectType>& topoPath_list,
-            sofa::helper::vector<unsigned int>& indices_list,
+            sofa::helper::vector<ElemID>& indices_list,
             sofa::helper::vector< sofa::defaulttype::Vec<3, double> >& coords_list) const;
 
 
@@ -275,7 +277,7 @@ public:
 
     /** \brief Process the added point initialization according to the topology and local coordinates.
     */
-    virtual void initPointAdded(unsigned int indice, const core::topology::PointAncestorElem &ancestorElem
+    virtual void initPointAdded(PointID indice, const core::topology::PointAncestorElem &ancestorElem
         , const helper::vector< VecCoord* >& coordVecs, const helper::vector< VecDeriv* >& derivVecs) override;
 
     /// return a pointer to the container of cubature points

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetGeometryAlgorithms.inl
@@ -81,8 +81,8 @@ void TriangleSetGeometryAlgorithms< DataTypes >::defineTetrahedronCubaturePoints
     qpa.clear();
     v=BarycentricCoordinatesType(1/(Real)3.0,1/(Real)3.0,1/(Real)3.0);
     qpa.push_back(QuadraturePoint(v,(Real) -9/32));
-    a=(Real)1/5.0;
-    b=(Real)3/5.0;
+    a=(Real)1/5;
+    b=(Real)3/5;
     for (i=0;i<3;++i) {
         v=BarycentricCoordinatesType(a,a,a);
         v[i]=b;
@@ -93,7 +93,7 @@ void TriangleSetGeometryAlgorithms< DataTypes >::defineTetrahedronCubaturePoints
     qpa.clear();
     a=(Real)0.445948490915965;
     b=(Real)1-2*a;
-    Real c1=0.111690794839005;
+    Real c1= (Real)0.111690794839005;
     for (i=0;i<3;++i) {
         v=BarycentricCoordinatesType(a,a,a);
         v[i]=b;
@@ -101,7 +101,7 @@ void TriangleSetGeometryAlgorithms< DataTypes >::defineTetrahedronCubaturePoints
     }
     a=(Real)0.091576213509771;
     b=(Real)1-2*a;
-    Real c2=0.054975871827661;
+    Real c2= (Real)0.054975871827661;
     for (i=0;i<3;++i) {
         v=BarycentricCoordinatesType(a,a,a);
         v[i]=b;
@@ -112,17 +112,17 @@ void TriangleSetGeometryAlgorithms< DataTypes >::defineTetrahedronCubaturePoints
     qpa.clear();
     v=BarycentricCoordinatesType(1/(Real)3.0,1/(Real)3.0,1/(Real)3.0);
     qpa.push_back(QuadraturePoint(v,9/(Real)80));
-    a=(Real)(6.0+sqrt(15.0))/21.0;
+    a=(Real)(6+sqrt(15))/21;
     b=(Real)1-2*a;
-    c1=(Real)(155.0+sqrt(15.0))/2400.0;
+    c1=(Real)(155+sqrt(15))/2400;
     for (i=0;i<3;++i) {
         v=BarycentricCoordinatesType(a,a,a);
         v[i]=b;
         qpa.push_back(QuadraturePoint(v,c1));
     }
-    a=(Real)4/7.0-a;
+    a=(Real)4/7-a;
     b=(Real)1-2*a;
-     c2=(Real)31/240.0 -c1;
+     c2=(Real)31/240 -c1;
     for (i=0;i<3;++i) {
         v=BarycentricCoordinatesType(a,a,a);
         v[i]=b;
@@ -299,7 +299,7 @@ void TriangleSetGeometryAlgorithms< DataTypes >::computeTriangleAABB(const Trian
     const Triangle &t = this->m_topology->getTriangle(i);
     const typename DataTypes::VecCoord& p =(this->object->read(core::ConstVecCoordId::position())->getValue());
 
-    for(unsigned int i=0; i<3; ++i)
+    for(PointID i=0; i<3; ++i)
     {
         minCoord[i] = std::min(p[t[0]][i], std::min(p[t[1]][i], p[t[2]][i]));
         maxCoord[i] = std::max(p[t[0]][i], std::max(p[t[1]][i], p[t[2]][i]));
@@ -363,7 +363,7 @@ void TriangleSetGeometryAlgorithms< DataTypes >::getTriangleVertexCoordinates(co
     const Triangle &t = this->m_topology->getTriangle(i);
     const typename DataTypes::VecCoord& p =(this->object->read(core::ConstVecCoordId::position())->getValue());
 
-    for(unsigned int i=0; i<3; ++i)
+    for(PointID i=0; i<3; ++i)
     {
         pnt[i] = p[t[i]];
     }
@@ -375,7 +375,7 @@ void TriangleSetGeometryAlgorithms< DataTypes >::getRestTriangleVertexCoordinate
     const Triangle &t = this->m_topology->getTriangle(i);
     const typename DataTypes::VecCoord& p = (this->object->read(core::ConstVecCoordId::restPosition())->getValue());
 
-    for(unsigned int i=0; i<3; ++i)
+    for(PointID i=0; i<3; ++i)
     {
         pnt[i] = p[t[i]];
     }
@@ -406,16 +406,18 @@ void TriangleSetGeometryAlgorithms<DataTypes>::computeTriangleArea( BasicArrayIn
     const sofa::helper::vector<Triangle> &ta = this->m_topology->getTriangles();
     const typename DataTypes::VecCoord& p =(this->object->read(core::ConstVecCoordId::position())->getValue());
 
-    for (unsigned int i=0; i<ta.size(); ++i)
+    for (size_t i=0; i<ta.size(); ++i)
     {
         const Triangle &t=ta[i];
-        ai[i]=(Real)(areaProduct(p[t[1]]-p[t[0]],p[t[2]]-p[t[0]]) * 0.5);
+        Coord vec1 = p[t[1]] - p[t[0]];
+        Coord vec2 = p[t[2]] - p[t[0]];
+        ai[(int)i]=(Real)(areaProduct(vec1, vec2) * 0.5);
     }
 }
 
 // Computes the point defined by 2 indices of vertex and 1 barycentric coordinate
 template<class DataTypes>
-sofa::defaulttype::Vec<3,double> TriangleSetGeometryAlgorithms< DataTypes >::computeBaryEdgePoint(unsigned int p0, unsigned int p1, double coord_p) const
+sofa::defaulttype::Vec<3,double> TriangleSetGeometryAlgorithms< DataTypes >::computeBaryEdgePoint(PointID p0, PointID p1, double coord_p) const
 {
     const typename DataTypes::VecCoord& vect_c =(this->object->read(core::ConstVecCoordId::position())->getValue());
 
@@ -425,7 +427,7 @@ sofa::defaulttype::Vec<3,double> TriangleSetGeometryAlgorithms< DataTypes >::com
 }
 
 template<class DataTypes>
-sofa::defaulttype::Vec<3,double> TriangleSetGeometryAlgorithms< DataTypes >::computeBaryTrianglePoint(unsigned int p0, unsigned int p1, unsigned int p2, sofa::defaulttype::Vec<3,double>& coord_p) const
+sofa::defaulttype::Vec<3,double> TriangleSetGeometryAlgorithms< DataTypes >::computeBaryTrianglePoint(PointID p0, PointID p1, PointID p2, sofa::defaulttype::Vec<3,double>& coord_p) const
 {
     const typename DataTypes::VecCoord& vect_c =(this->object->read(core::ConstVecCoordId::position())->getValue());
 
@@ -438,7 +440,7 @@ sofa::defaulttype::Vec<3,double> TriangleSetGeometryAlgorithms< DataTypes >::com
 
 // Computes the opposite point to ind_p
 template<class DataTypes>
-sofa::defaulttype::Vec<3,double> TriangleSetGeometryAlgorithms< DataTypes >::getOppositePoint(unsigned int ind_p,
+sofa::defaulttype::Vec<3,double> TriangleSetGeometryAlgorithms< DataTypes >::getOppositePoint(PointID ind_p,
         const Edge& indices,
         double coord_p) const
 {
@@ -517,9 +519,9 @@ sofa::helper::vector< double > TriangleSetGeometryAlgorithms< DataTypes >::compu
 template<class DataTypes>
 sofa::helper::vector< double > TriangleSetGeometryAlgorithms< DataTypes >::compute3PointsBarycoefs(
     const sofa::defaulttype::Vec<3,double> &p,
-    unsigned int ind_p1,
-    unsigned int ind_p2,
-    unsigned int ind_p3,
+    PointID ind_p1,
+    PointID ind_p2,
+    PointID ind_p3,
     bool bRest) const
 {
     const double ZERO = 1e-12;
@@ -575,7 +577,7 @@ sofa::helper::vector< double > TriangleSetGeometryAlgorithms< DataTypes >::compu
 // Find the two closest points from two triangles (each of the point belonging to one triangle)
 template<class DataTypes>
 void TriangleSetGeometryAlgorithms< DataTypes >::computeClosestIndexPair(const TriangleID ind_ta, const TriangleID ind_tb,
-        unsigned int &ind1, unsigned int &ind2) const
+        PointID &ind1, PointID &ind2) const
 {
     const typename DataTypes::VecCoord& vect_c =(this->object->read(core::ConstVecCoordId::position())->getValue());
 
@@ -629,7 +631,7 @@ template<class DataTypes>
 bool TriangleSetGeometryAlgorithms< DataTypes >::isPointInsideTriangle(const TriangleID ind_t,
         bool is_tested,
         const sofa::defaulttype::Vec<3,Real>& p,
-        unsigned int &ind_t_test,
+        TriangleID &ind_t_test,
         bool bRest) const
 {
     const double ZERO = -1e-12;
@@ -674,26 +676,26 @@ bool TriangleSetGeometryAlgorithms< DataTypes >::isPointInsideTriangle(const Tri
 
         if(is_tested && (!is_inside))
         {
-            sofa::helper::vector< unsigned int > shell;
-            unsigned int ind_edge = 0;
+            sofa::helper::vector< TriangleID > shell;
+            EdgeID ind_edge = 0;
 
             if(v_01 < 0.0)
             {
                 if(v_12 < 0.0) /// vertex 1
                 {
-                    shell =(sofa::helper::vector< unsigned int >) (this->m_topology->getTrianglesAroundVertex(t[1]));
+                    shell =(sofa::helper::vector< TriangleID >) (this->m_topology->getTrianglesAroundVertex(t[1]));
                 }
                 else
                 {
                     if(v_20 < 0.0) /// vertex 0
                     {
-                        shell =(sofa::helper::vector< unsigned int >) (this->m_topology->getTrianglesAroundVertex(t[0]));
+                        shell =(sofa::helper::vector< TriangleID >) (this->m_topology->getTrianglesAroundVertex(t[0]));
 
                     }
                     else // v_01 < 0.0
                     {
                         ind_edge=this->m_topology->getEdgeIndex(t[0],t[1]);
-                        shell =(sofa::helper::vector< unsigned int >) (this->m_topology->getTrianglesAroundEdge(ind_edge));
+                        shell =(sofa::helper::vector< TriangleID >) (this->m_topology->getTrianglesAroundEdge(ind_edge));
                     }
                 }
             }
@@ -703,27 +705,27 @@ bool TriangleSetGeometryAlgorithms< DataTypes >::isPointInsideTriangle(const Tri
                 {
                     if(v_20 < 0.0) /// vertex 2
                     {
-                        shell =(sofa::helper::vector< unsigned int >) (this->m_topology->getTrianglesAroundVertex(t[2]));
+                        shell =(sofa::helper::vector< TriangleID >) (this->m_topology->getTrianglesAroundVertex(t[2]));
 
                     }
                     else // v_12 < 0.0
                     {
                         ind_edge=this->m_topology->getEdgeIndex(t[1],t[2]);
-                        shell =(sofa::helper::vector< unsigned int >) (this->m_topology->getTrianglesAroundEdge(ind_edge));
+                        shell =(sofa::helper::vector< TriangleID >) (this->m_topology->getTrianglesAroundEdge(ind_edge));
                     }
                 }
                 else // v_20 < 0.0
                 {
                     ind_edge=this->m_topology->getEdgeIndex(t[2],t[0]);
-                    shell =(sofa::helper::vector< unsigned int >) (this->m_topology->getTrianglesAroundEdge(ind_edge));
+                    shell =(sofa::helper::vector< TriangleID >) (this->m_topology->getTrianglesAroundEdge(ind_edge));
                 }
             }
 
-            unsigned int i =0;
+            size_t i =0;
             bool is_in_next_triangle=false;
-            unsigned int ind_triangle=0;
-            unsigned ind_t_false_init;
-            unsigned int &ind_t_false = ind_t_false_init;
+            TriangleID ind_triangle=0;
+            TriangleID ind_t_false_init;
+            TriangleID &ind_t_false = ind_t_false_init;
 
             if(shell.size()>1)
             {
@@ -769,7 +771,7 @@ template<class DataTypes>
 bool TriangleSetGeometryAlgorithms< DataTypes >::isPointInTriangle(const TriangleID ind_t,
         bool is_tested,
         const sofa::defaulttype::Vec<3,Real>& p,
-        unsigned int &ind_t_test) const
+        TriangleID &ind_t_test) const
 {
     const double ZERO = 1e-12;
     const typename DataTypes::VecCoord& vect_c =(this->object->read(core::ConstVecCoordId::position())->getValue());
@@ -813,8 +815,8 @@ bool TriangleSetGeometryAlgorithms< DataTypes >::isPointInTriangle(const Triangl
 
         if(is_tested && (!is_inside))
         {
-            sofa::helper::vector< unsigned int > shell;
-            unsigned int ind_edge = 0;
+            sofa::helper::vector< TriangleID > shell;
+            EdgeID ind_edge = 0;
 
             //if(v_01 < 0.0)
             if(v_01 < -ZERO)
@@ -822,20 +824,20 @@ bool TriangleSetGeometryAlgorithms< DataTypes >::isPointInTriangle(const Triangl
                 //if(v_12 < 0.0) /// vertex 1
                 if(v_12 < -ZERO) /// vertex 1
                 {
-                    shell =(sofa::helper::vector< unsigned int >) (this->m_topology->getTrianglesAroundVertex(t[1]));
+                    shell =(sofa::helper::vector< TriangleID >) (this->m_topology->getTrianglesAroundVertex(t[1]));
                 }
                 else
                 {
                     //if(v_20 < 0.0) /// vertex 0
                     if(v_20 < -ZERO) /// vertex 0
                     {
-                        shell =(sofa::helper::vector< unsigned int >) (this->m_topology->getTrianglesAroundVertex(t[0]));
+                        shell =(sofa::helper::vector< TriangleID >) (this->m_topology->getTrianglesAroundVertex(t[0]));
 
                     }
                     else // v_01 < 0.0
                     {
                         ind_edge=this->m_topology->getEdgeIndex(t[0],t[1]);
-                        shell =(sofa::helper::vector< unsigned int >) (this->m_topology->getTrianglesAroundEdge(ind_edge));
+                        shell =(sofa::helper::vector< TriangleID >) (this->m_topology->getTrianglesAroundEdge(ind_edge));
                     }
                 }
             }
@@ -847,27 +849,27 @@ bool TriangleSetGeometryAlgorithms< DataTypes >::isPointInTriangle(const Triangl
                     //if(v_20 < 0.0) /// vertex 2
                     if(v_20 < -ZERO) /// vertex 2
                     {
-                        shell =(sofa::helper::vector< unsigned int >) (this->m_topology->getTrianglesAroundVertex(t[2]));
+                        shell =(sofa::helper::vector< TriangleID >) (this->m_topology->getTrianglesAroundVertex(t[2]));
 
                     }
                     else // v_12 < 0.0
                     {
                         ind_edge=this->m_topology->getEdgeIndex(t[1],t[2]);
-                        shell =(sofa::helper::vector< unsigned int >) (this->m_topology->getTrianglesAroundEdge(ind_edge));
+                        shell =(sofa::helper::vector< TriangleID >) (this->m_topology->getTrianglesAroundEdge(ind_edge));
                     }
                 }
                 else // v_20 < 0.0
                 {
                     ind_edge=this->m_topology->getEdgeIndex(t[2],t[0]);
-                    shell =(sofa::helper::vector< unsigned int >) (this->m_topology->getTrianglesAroundEdge(ind_edge));
+                    shell =(sofa::helper::vector< TriangleID >) (this->m_topology->getTrianglesAroundEdge(ind_edge));
                 }
             }
 
-            unsigned int i =0;
+            size_t i =0;
             bool is_in_next_triangle=false;
-            unsigned int ind_triangle=0;
+            TriangleID ind_triangle=0;
             unsigned ind_t_false_init;
-            unsigned int &ind_t_false = ind_t_false_init;
+            TriangleID &ind_t_false = ind_t_false_init;
 
             if(shell.size()>1)
             {
@@ -912,8 +914,8 @@ bool TriangleSetGeometryAlgorithms< DataTypes >::isPointInTriangle(const Triangl
 template<class DataTypes>
 bool TriangleSetGeometryAlgorithms< DataTypes >::isQuadDeulaunayOriented(const typename DataTypes::Coord& p_q1,
         const typename DataTypes::Coord& p_q2,
-        unsigned int ind_q3,
-        unsigned int ind_q4)
+        QuadID ind_q3,
+        QuadID ind_q4)
 {
     sofa::helper::vector< double > baryCoefs;
 
@@ -1050,7 +1052,7 @@ bool TriangleSetGeometryAlgorithms< DataTypes >::isDiagonalsIntersectionInQuad (
 // Test if a triangle indexed by ind_triangle (and incident to the vertex indexed by ind_p) is included or not in the plane defined by (ind_p, plane_vect)
 template<class DataTypes>
 bool TriangleSetGeometryAlgorithms< DataTypes >::isTriangleInPlane(const TriangleID ind_t,
-        const unsigned int ind_p,
+        const PointID ind_p,
         const sofa::defaulttype::Vec<3,Real>&plane_vect) const
 {
     const Triangle &t=this->m_topology->getTriangle(ind_t);
@@ -1059,8 +1061,8 @@ bool TriangleSetGeometryAlgorithms< DataTypes >::isTriangleInPlane(const Triangl
 
     const typename DataTypes::VecCoord& vect_c =(this->object->read(core::ConstVecCoordId::position())->getValue());
 
-    unsigned int ind_1;
-    unsigned int ind_2;
+    PointID ind_1;
+    PointID ind_2;
 
     if(ind_p==t[0])
     {
@@ -1103,15 +1105,15 @@ bool TriangleSetGeometryAlgorithms< DataTypes >::isTriangleInPlane(const Triangl
 
 // Prepares the duplication of a vertex
 template<class DataTypes>
-void TriangleSetGeometryAlgorithms< DataTypes >::prepareVertexDuplication(const unsigned int ind_p,
+void TriangleSetGeometryAlgorithms< DataTypes >::prepareVertexDuplication(const PointID ind_p,
         const TriangleID ind_t_from,
         const TriangleID ind_t_to,
         const Edge& indices_from,
         const double &coord_from,
         const Edge& indices_to,
         const double &coord_to,
-        sofa::helper::vector< unsigned int > &triangles_list_1,
-        sofa::helper::vector< unsigned int > &triangles_list_2) const
+        sofa::helper::vector< TriangleID > &triangles_list_1,
+        sofa::helper::vector< TriangleID > &triangles_list_2) const
 {
     //HYP : if coord_from or coord_to == 0.0 or 1.0, ind_p is distinct from ind_from and from ind_to
 
@@ -1126,8 +1128,8 @@ void TriangleSetGeometryAlgorithms< DataTypes >::prepareVertexDuplication(const 
     sofa::defaulttype::Vec<3,Real> point_from=(sofa::defaulttype::Vec<3,Real>) getOppositePoint(ind_p, indices_from, coord_from);
     sofa::defaulttype::Vec<3,Real> point_to=(sofa::defaulttype::Vec<3,Real>) getOppositePoint(ind_p, indices_to, coord_to);
 
-    //Vec<3,Real> point_from=(Vec<3,Real>) computeBaryEdgePoint((sofa::helper::vector< unsigned int>&) indices_from, coord_from);
-    //Vec<3,Real> point_to=(Vec<3,Real>) computeBaryEdgePoint((sofa::helper::vector< unsigned int>&) indices_to, coord_to);
+    //Vec<3,Real> point_from=(Vec<3,Real>) computeBaryEdgePoint((sofa::helper::vector< TriangleID>&) indices_from, coord_from);
+    //Vec<3,Real> point_to=(Vec<3,Real>) computeBaryEdgePoint((sofa::helper::vector< TriangleID>&) indices_to, coord_to);
 
     sofa::defaulttype::Vec<3,Real> vect_from = point_from - point_p;
     sofa::defaulttype::Vec<3,Real> vect_to = point_p - point_to;
@@ -1150,7 +1152,7 @@ void TriangleSetGeometryAlgorithms< DataTypes >::prepareVertexDuplication(const 
     {
         // HYP : only 2 edges maximum are adjacent to the same triangle (otherwise : compute the one which minimizes the normed dotProduct and which gives the positive cross)
 
-        unsigned int ind_edge;
+        EdgeID ind_edge;
 
         if(coord_from==0.0)
         {
@@ -1163,9 +1165,9 @@ void TriangleSetGeometryAlgorithms< DataTypes >::prepareVertexDuplication(const 
 
         if (this->m_topology->getNbEdges()>0)
         {
-            sofa::helper::vector< unsigned int > shell =(sofa::helper::vector< unsigned int >) (this->m_topology->getTrianglesAroundEdge(ind_edge));
-            unsigned int ind_triangle=shell[0];
-            unsigned int i=0;
+            sofa::helper::vector< TriangleID > shell =(sofa::helper::vector< TriangleID >) (this->m_topology->getTrianglesAroundEdge(ind_edge));
+            TriangleID ind_triangle=shell[0];
+            size_t i=0;
             bool is_in_next_triangle=false;
 
             if(shell.size()>1)
@@ -1210,7 +1212,7 @@ void TriangleSetGeometryAlgorithms< DataTypes >::prepareVertexDuplication(const 
     {
         // HYP : only 2 edges maximum are adjacent to the same triangle (otherwise : compute the one which minimizes the normed dotProduct and which gives the positive cross)
 
-        unsigned int ind_edge;
+        EdgeID ind_edge;
 
         if(coord_to==0.0)
         {
@@ -1223,9 +1225,9 @@ void TriangleSetGeometryAlgorithms< DataTypes >::prepareVertexDuplication(const 
 
         if (this->m_topology->getNbEdges()>0)
         {
-            sofa::helper::vector< unsigned int > shell =(sofa::helper::vector< unsigned int >) (this->m_topology->getTrianglesAroundEdge(ind_edge));
-            unsigned int ind_triangle=shell[0];
-            unsigned int i=0;
+            sofa::helper::vector< TriangleID > shell =(sofa::helper::vector< TriangleID >) (this->m_topology->getTrianglesAroundEdge(ind_edge));
+            TriangleID ind_triangle=shell[0];
+            size_t i=0;
             bool is_in_next_triangle=false;
 
             if(shell.size()>1)
@@ -1262,9 +1264,9 @@ void TriangleSetGeometryAlgorithms< DataTypes >::prepareVertexDuplication(const 
 
     if (this->m_topology->getNbPoints()>0)
     {
-        sofa::helper::vector< unsigned int > shell =(sofa::helper::vector< unsigned int >) (this->m_topology->getTrianglesAroundVertex(ind_p));
-        unsigned int ind_triangle=shell[0];
-        unsigned int i=0;
+        sofa::helper::vector< TriangleID > shell =(sofa::helper::vector< TriangleID >) (this->m_topology->getTrianglesAroundVertex(ind_p));
+        TriangleID ind_triangle=shell[0];
+        size_t i=0;
 
         bool is_in_plane_from;
         bool is_in_plane_to;
@@ -1344,7 +1346,7 @@ bool TriangleSetGeometryAlgorithms< DataTypes >::computeSegmentTriangleIntersect
         const sofa::defaulttype::Vec<3,double>& a,
         const sofa::defaulttype::Vec<3,double>& b,
         const TriangleID ind_t,
-        sofa::helper::vector<unsigned int> &indices,
+        sofa::helper::vector<TriangleID> &indices,
         double &baryCoef, double& coord_kmin) const
 {
     // HYP : point a is in triangle indexed by t
@@ -1354,8 +1356,8 @@ bool TriangleSetGeometryAlgorithms< DataTypes >::computeSegmentTriangleIntersect
 
 
 
-    unsigned int ind_first=0;
-    unsigned int ind_second=0;
+    TriangleID ind_first=0;
+    TriangleID ind_second=0;
 
     if(indices.size()>1)
     {
@@ -1651,10 +1653,10 @@ template<class DataTypes>
 bool TriangleSetGeometryAlgorithms< DataTypes >::computeIntersectedPointsList(const PointID last_point,
         const sofa::defaulttype::Vec<3,double>& a,
         const sofa::defaulttype::Vec<3,double>& b,
-        unsigned int& ind_ta,
-        unsigned int& ind_tb,
-        sofa::helper::vector< unsigned int > &triangles_list,
-        sofa::helper::vector<unsigned int> &edges_list,
+        TriangleID& ind_ta,
+        TriangleID& ind_tb,
+        sofa::helper::vector< TriangleID > &triangles_list,
+        sofa::helper::vector< EdgeID> &edges_list,
         sofa::helper::vector< double >& coords_list,
         bool& is_on_boundary) const
 {
@@ -1666,7 +1668,7 @@ bool TriangleSetGeometryAlgorithms< DataTypes >::computeIntersectedPointsList(co
 
     is_on_boundary = false;
 
-    sofa::helper::vector<unsigned int> indices;
+    sofa::helper::vector<PointID> indices;
 
     double coord_t=0.0;
     double coord_k=0.0;
@@ -1679,16 +1681,16 @@ bool TriangleSetGeometryAlgorithms< DataTypes >::computeIntersectedPointsList(co
     EdgeID ind_edge;
     PointID ind_index;
     TriangleID ind_triangle = ind_ta;
-    is_intersected=computeSegmentTriangleIntersection(false, p_current, b, (const unsigned int) ind_t_current, indices, coord_t, coord_k);
+    is_intersected=computeSegmentTriangleIntersection(false, p_current, b, ind_t_current, indices, coord_t, coord_k);
 
 
     // In case the ind_t is not the good one.
     if ( (!is_intersected || indices[0] == last_point || indices[1] == last_point) && (last_point != core::topology::BaseMeshTopology::InvalidID))
     {
 
-        const sofa::helper::vector< unsigned int >& shell = this->m_topology->getTrianglesAroundVertex (last_point);
+        const sofa::helper::vector< TriangleID >& shell = this->m_topology->getTrianglesAroundVertex (last_point);
 
-        for (unsigned int i = 0; i<shell.size(); i++)
+        for (size_t i = 0; i<shell.size(); i++)
         {
             if (shell [i] != ind_t_current)
                 is_intersected=computeSegmentTriangleIntersection(false, p_current, b, shell[i], indices, coord_t, coord_k);
@@ -1768,12 +1770,12 @@ bool TriangleSetGeometryAlgorithms< DataTypes >::computeIntersectedPointsList(co
 
             if (this->m_topology->getNbPoints() >0)
             {
-                sofa::helper::vector< unsigned int > shell =(sofa::helper::vector< unsigned int >) (this->m_topology->getTrianglesAroundVertex(ind_index));
+                sofa::helper::vector< TriangleID > shell =(sofa::helper::vector< TriangleID >) (this->m_topology->getTrianglesAroundVertex(ind_index));
                 ind_triangle=shell[0];
-                unsigned int i=0;
+                TriangleID i=0;
                 bool is_test_init=false;
 
-                unsigned int ind_from = ind_t_current;
+                TriangleID ind_from = ind_t_current;
 
                 if(shell.size()>1) // at leat one neighbor triangle which is not indexed by ind_t_current
                 {
@@ -1857,14 +1859,14 @@ bool TriangleSetGeometryAlgorithms< DataTypes >::computeIntersectedPointsList(co
 
             if (this->m_topology->getNbEdges()>0)
             {
-                sofa::helper::vector< unsigned int > shell =(sofa::helper::vector< unsigned int >) (this->m_topology->getTrianglesAroundEdge(ind_edge));
+                sofa::helper::vector< TriangleID > shell =(sofa::helper::vector< TriangleID >) (this->m_topology->getTrianglesAroundEdge(ind_edge));
 
                 ind_triangle=shell[0];
-                unsigned int i=0;
+                TriangleID i=0;
 
                 bool is_test_init=false;
 
-                unsigned int ind_from = ind_t_current;
+                TriangleID ind_from = ind_t_current;
 
                 if(shell.size()>0) // at leat one neighbor triangle which is not indexed by ind_t_current
                 {
@@ -1973,9 +1975,9 @@ bool TriangleSetGeometryAlgorithms< DataTypes >::computeIntersectedPointsList(co
 template <typename DataTypes>
 bool TriangleSetGeometryAlgorithms<DataTypes>::computeIntersectedObjectsList (const PointID last_point,
         const sofa::defaulttype::Vec<3,double>& a, const sofa::defaulttype::Vec<3,double>& b,
-        unsigned int& ind_ta, unsigned int& ind_tb,// A verifier pourquoi la ref!
+        TriangleID& ind_ta, TriangleID& ind_tb,// A verifier pourquoi la ref!
         sofa::helper::vector< sofa::core::topology::TopologyObjectType>& topoPath_list,
-        sofa::helper::vector<unsigned int>& indices_list,
+        sofa::helper::vector<ElemID>& indices_list,
         sofa::helper::vector< sofa::defaulttype::Vec<3, double> >& coords_list) const
 {
     //// QUICK FIX TO USE THE NEW PATH DECLARATION (WITH ONLY EDGES COMING FROM PREVIOUS FUNCTION)
@@ -1983,8 +1985,8 @@ bool TriangleSetGeometryAlgorithms<DataTypes>::computeIntersectedObjectsList (co
     // QUICK FIX for fracture: border points (a and b) can be a point.
 
     // Output declarations
-    sofa::helper::vector<unsigned int> triangles_list;
-    sofa::helper::vector<unsigned int> edges_list;
+    sofa::helper::vector<TriangleID> triangles_list;
+    sofa::helper::vector<EdgeID> edges_list;
     sofa::helper::vector< double > coordsEdge_list;
     bool pathOK;
     bool isOnPoint = false;
@@ -2031,7 +2033,7 @@ bool TriangleSetGeometryAlgorithms<DataTypes>::computeIntersectedObjectsList (co
 
 
         // 2 - All edges intersected (only edges for now)
-        for (unsigned int i = 0; i< edges_list.size(); i++)
+        for (size_t i = 0; i< edges_list.size(); i++)
         {
             topoPath_list.push_back (core::topology::EDGE);
             indices_list.push_back (edges_list[i]);
@@ -2077,7 +2079,7 @@ int TriangleSetGeometryAlgorithms<DataTypes>::getTriangleInDirection(PointID p, 
     const typename DataTypes::VecCoord& vect_c =(this->object->read(core::ConstVecCoordId::position())->getValue());
     const sofa::helper::vector<TriangleID> &shell=this->m_topology->getTrianglesAroundVertex(p);
     sofa::defaulttype::Vec<3,Real> dtest = dir;
-    for (unsigned int i=0; i<shell.size(); ++i)
+    for (size_t i=0; i<shell.size(); ++i)
     {
         unsigned int ind_t = shell[i];
         const Triangle &t=this->m_topology->getTriangle(ind_t);
@@ -2151,7 +2153,7 @@ void TriangleSetGeometryAlgorithms<DataTypes>::writeMSHfile(const char *filename
 
     myfile << ta.size() <<"\n";
 
-    for (unsigned int i=0; i<ta.size(); ++i)
+    for (size_t i=0; i<ta.size(); ++i)
     {
         myfile << i+1 << " 2 6 6 3 " << ta[i][0]+1 << " " << ta[i][1]+1 << " " << ta[i][2]+1 <<"\n";
     }
@@ -2179,9 +2181,9 @@ void TriangleSetGeometryAlgorithms<DataTypes>::reorderTrianglesOrientationFromNo
 
     while (!_neighTri.empty() && cpt_secu < max)
     {
-        for (unsigned int i=0; i<_neighTri.size(); ++i)
+        for (size_t i=0; i<_neighTri.size(); ++i)
         {
-            unsigned int triId = _neighTri[i];
+            TriangleID triId = _neighTri[i];
             triNormal = this->computeTriangleNormal(triId);
             double prod = (firstNormal*triNormal)/(firstNormal.norm()*triNormal.norm());
             if (prod < 0.15) //change orientation
@@ -2196,11 +2198,11 @@ void TriangleSetGeometryAlgorithms<DataTypes>::reorderTrianglesOrientationFromNo
             pair = false;
 
             _neighTri.clear();
-            for (unsigned int i=0; i<_neighTri2.size(); ++i)
+            for (size_t i=0; i<_neighTri2.size(); ++i)
             {
                 bool find = false;
-                unsigned int id = _neighTri2[i];
-                for (unsigned int j=0; j<buffKK.size(); ++j)
+                TriangleID id = _neighTri2[i];
+                for (size_t j=0; j<buffKK.size(); ++j)
                     if (id == buffKK[j])
                     {
                         find = true;
@@ -2217,11 +2219,11 @@ void TriangleSetGeometryAlgorithms<DataTypes>::reorderTrianglesOrientationFromNo
             pair = true;
 
             _neighTri.clear();
-            for (unsigned int i=0; i<_neighTri2.size(); ++i)
+            for (size_t i=0; i<_neighTri2.size(); ++i)
             {
                 bool find = false;
-                unsigned int id = _neighTri2[i];
-                for (unsigned int j=0; j<buffK.size(); ++j)
+                TriangleID id = _neighTri2[i];
+                for (size_t j=0; j<buffK.size(); ++j)
                     if (id == buffK[j])
                     {
                         find = true;
@@ -2341,7 +2343,7 @@ bool is_point_in_halfplane(const sofa::defaulttype::Vec<3,Real>& p, unsigned int
 
 
 template<class DataTypes>
-void TriangleSetGeometryAlgorithms<DataTypes>::initPointAdded(unsigned int index, const core::topology::PointAncestorElem &ancestorElem
+void TriangleSetGeometryAlgorithms<DataTypes>::initPointAdded(PointID index, const core::topology::PointAncestorElem &ancestorElem
         , const helper::vector< VecCoord* >& coordVecs, const helper::vector< VecDeriv* >& derivVecs)
 {
     using namespace sofa::core::topology;
@@ -2354,7 +2356,7 @@ void TriangleSetGeometryAlgorithms<DataTypes>::initPointAdded(unsigned int index
     {
         const Triangle &t = this->m_topology->getTriangle(ancestorElem.index);
 
-        for (unsigned int i = 0; i < coordVecs.size(); i++)
+        for (size_t i = 0; i < coordVecs.size(); i++)
         {
             VecCoord &curVecCoord = *coordVecs[i];
             Coord& curCoord = curVecCoord[index];
@@ -2402,7 +2404,7 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
         const sofa::helper::vector<Triangle> &triangleArray = this->m_topology->getTriangles();
 
         std::vector<defaulttype::Vector3> positions;
-        for (unsigned int i =0; i<triangleArray.size(); i++)
+        for (size_t i =0; i<triangleArray.size(); i++)
         {
 
             Triangle the_tri = triangleArray[i];
@@ -2431,7 +2433,7 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
 
             {//   Draw Triangles
                 std::vector<defaulttype::Vector3> pos;
-                for (unsigned int i = 0; i<triangleArray.size(); i++)
+                for (size_t i = 0; i<triangleArray.size(); i++)
                 {
                     const Triangle& t = triangleArray[i];
 
@@ -2450,14 +2452,14 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
                 std::vector<defaulttype::Vector3> pos;
                 if (!edgeArray.empty())
                 {
-                    for (unsigned int i = 0; i<edgeArray.size(); i++)
+                    for (size_t i = 0; i<edgeArray.size(); i++)
                     {
                         const Edge& e = edgeArray[i];
                         pos.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[e[0]])));
                         pos.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[e[1]])));
                     }
                 } else {
-                    for (unsigned int i = 0; i<triangleArray.size(); i++)
+                    for (size_t i = 0; i<triangleArray.size(); i++)
                     {
                         const Triangle& t = triangleArray[i];
 
@@ -2489,7 +2491,7 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
         sofa::helper::vector<sofa::defaulttype::Vector3> vertices;
         sofa::helper::vector<sofa::defaulttype::Vec4f> colors;
 
-        for (unsigned int i =0; i<nbrTtri; i++)
+        for (size_t i =0; i<nbrTtri; i++)
         {
             Triangle _tri = triangleArray[i];
             sofa::defaulttype::Vec<3,double> normal = this->computeTriangleNormal((TriangleID)i);

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyAlgorithms.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyAlgorithms.cpp
@@ -78,9 +78,9 @@ template class SOFA_BASE_TOPOLOGY_API TriangleSetTopologyAlgorithms<Vec1fTypes>;
 
 
 template<> SOFA_BASE_TOPOLOGY_API
-int TriangleSetTopologyAlgorithms<defaulttype::Vec2dTypes>::SplitAlongPath(unsigned int , Coord& , unsigned int , Coord& ,
+int TriangleSetTopologyAlgorithms<defaulttype::Vec2dTypes>::SplitAlongPath(PointID , Coord& , PointID , Coord& ,
                                                               sofa::helper::vector< sofa::core::topology::TopologyObjectType>& ,
-                                                              sofa::helper::vector<unsigned int>& ,
+                                                              sofa::helper::vector<ElemID>& ,
                                                               sofa::helper::vector< sofa::defaulttype::Vec<3, double> >& ,
                                                               sofa::helper::vector<EdgeID>& , double  , double )
 {
@@ -88,9 +88,9 @@ int TriangleSetTopologyAlgorithms<defaulttype::Vec2dTypes>::SplitAlongPath(unsig
     return 0;
 }
 template<> SOFA_BASE_TOPOLOGY_API
-int TriangleSetTopologyAlgorithms<defaulttype::Vec1dTypes>::SplitAlongPath(unsigned int , Coord& , unsigned int , Coord& ,
+int TriangleSetTopologyAlgorithms<defaulttype::Vec1dTypes>::SplitAlongPath(PointID , Coord& , PointID , Coord& ,
                                                               sofa::helper::vector< sofa::core::topology::TopologyObjectType>& ,
-                                                              sofa::helper::vector<unsigned int>& ,
+                                                              sofa::helper::vector<ElemID>& ,
                                                               sofa::helper::vector< sofa::defaulttype::Vec<3, double> >& ,
                                                               sofa::helper::vector<EdgeID>& , double  , double )
 {
@@ -104,9 +104,9 @@ int TriangleSetTopologyAlgorithms<defaulttype::Vec1dTypes>::SplitAlongPath(unsig
 #ifndef SOFA_DOUBLE
 
 template<> SOFA_BASE_TOPOLOGY_API
-int TriangleSetTopologyAlgorithms<defaulttype::Vec2fTypes>::SplitAlongPath(unsigned int , Coord& , unsigned int , Coord& ,
+int TriangleSetTopologyAlgorithms<defaulttype::Vec2fTypes>::SplitAlongPath(PointID , Coord& , PointID , Coord& ,
                                                               sofa::helper::vector< sofa::core::topology::TopologyObjectType>& ,
-                                                              sofa::helper::vector<unsigned int>& ,
+                                                              sofa::helper::vector<ElemID>& ,
                                                               sofa::helper::vector< sofa::defaulttype::Vec<3, double> >& ,
                                                               sofa::helper::vector<EdgeID>& , double  , double )
 {
@@ -114,9 +114,9 @@ int TriangleSetTopologyAlgorithms<defaulttype::Vec2fTypes>::SplitAlongPath(unsig
     return 0;
 }
 template<> SOFA_BASE_TOPOLOGY_API
-int TriangleSetTopologyAlgorithms<defaulttype::Vec1fTypes>::SplitAlongPath(unsigned int , Coord& , unsigned int , Coord& ,
+int TriangleSetTopologyAlgorithms<defaulttype::Vec1fTypes>::SplitAlongPath(PointID , Coord& , PointID , Coord& ,
                                                               sofa::helper::vector< sofa::core::topology::TopologyObjectType>& ,
-                                                              sofa::helper::vector<unsigned int>& ,
+                                                              sofa::helper::vector<ElemID>& ,
                                                               sofa::helper::vector< sofa::defaulttype::Vec<3, double> >& ,
                                                               sofa::helper::vector<EdgeID>& , double  , double )
 {

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyAlgorithms.h
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyAlgorithms.h
@@ -57,6 +57,7 @@ public:
     typedef core::topology::BaseMeshTopology::Edge Edge;
     typedef core::topology::BaseMeshTopology::PointID PointID;
     typedef core::topology::BaseMeshTopology::EdgeID EdgeID;
+    typedef core::topology::BaseMeshTopology::ElemID ElemID;
     typedef core::topology::BaseMeshTopology::TriangleID TriangleID;
     typedef core::topology::BaseMeshTopology::Triangle Triangle;
     typedef core::topology::BaseMeshTopology::SeqTriangles SeqTriangles;
@@ -81,32 +82,32 @@ public:
 
     /** \brief  Moves and fixes the two closest points of two triangles to their median point
      */
-    bool Suture2Points(unsigned int ind_ta, unsigned int ind_tb, unsigned int &ind1, unsigned int &ind2);
+    bool Suture2Points(TriangleID ind_ta, TriangleID ind_tb, PointID &ind1, PointID &ind2);
 
     /** \brief Removes triangles along the list of points (ind_edge,coord) intersected by the vector from point a to point b and the triangular mesh
      */
     void RemoveAlongTrianglesList(const sofa::defaulttype::Vec<3,double>& a,
             const sofa::defaulttype::Vec<3,double>& b,
-            const unsigned int ind_ta, const unsigned int ind_tb);
+            const TriangleID ind_ta, const TriangleID ind_tb);
 
     /** \brief Incises along the list of points (ind_edge,coord) intersected by the sequence of input segments (list of input points) and the triangular mesh
      */
     void InciseAlongLinesList(const sofa::helper::vector< sofa::defaulttype::Vec<3,double> >& input_points,
-            const sofa::helper::vector< unsigned int > &input_triangles);
+            const sofa::helper::vector< TriangleID > &input_triangles);
 
     /** \brief Duplicates the given edge. Only works if at least one of its points is adjacent to a border.
      * @returns the number of newly created points, or -1 if the incision failed.
      */
-    virtual int InciseAlongEdge(unsigned int edge, int* createdPoints = NULL);
+    virtual int InciseAlongEdge(EdgeID edge, int* createdPoints = NULL);
 
 
     /** \brief Split triangles to create edges along a path given as a the list of existing edges and triangles crossed by it.
      * Each end of the path is given either by an existing point or a point inside the first/last triangle. If the first/last triangle is (TriangleID)-1, it means that to path crosses the boundary of the surface.
      * @returns the indice of the end point, or -1 if the incision failed.
      */
-    virtual int SplitAlongPath(unsigned int pa, Coord& a, unsigned int pb, Coord& b,
+    virtual int SplitAlongPath(PointID pa, Coord& a, PointID pb, Coord& b,
             sofa::helper::vector< sofa::core::topology::TopologyObjectType>& topoPath_list,
-            sofa::helper::vector<unsigned int>& indices_list,
+            sofa::helper::vector<ElemID>& indices_list,
             sofa::helper::vector< sofa::defaulttype::Vec<3, double> >& coords_list,
             sofa::helper::vector<EdgeID>& new_edges, double epsilonSnapPath = 0.0, double epsilonSnapBorder = 0.0);
 
@@ -116,13 +117,13 @@ public:
       sofa::helper::vector<double>& coords_list, sofa::helper::vector<double>& points2Snap);*/
 
     void SnapAlongPath (sofa::helper::vector< sofa::core::topology::TopologyObjectType>& topoPath_list,
-            sofa::helper::vector<unsigned int>& indices_list, sofa::helper::vector< sofa::defaulttype::Vec<3, double> >& coords_list,
+            sofa::helper::vector<ElemID>& indices_list, sofa::helper::vector< sofa::defaulttype::Vec<3, double> >& coords_list,
             sofa::helper::vector< sofa::helper::vector<double> >& points2Snap,
             double epsilonSnapPath);
 
-    void SnapBorderPath (unsigned int pa, Coord& a, unsigned int pb, Coord& b,
+    void SnapBorderPath (PointID pa, Coord& a, PointID pb, Coord& b,
             sofa::helper::vector< sofa::core::topology::TopologyObjectType>& topoPath_list,
-            sofa::helper::vector<unsigned int>& indices_list,
+            sofa::helper::vector<ElemID>& indices_list,
             sofa::helper::vector< sofa::defaulttype::Vec<3, double> >& coords_list,
             sofa::helper::vector< sofa::helper::vector<double> >& points2Snap,
             double epsilonSnapBorder);
@@ -132,9 +133,9 @@ public:
     /** \brief Duplicates the given edges. Only works if at least the first or last point is adjacent to a border.
      * @returns true if the incision succeeded.
      */
-    virtual bool InciseAlongEdgeList(const sofa::helper::vector<unsigned int>& edges, sofa::helper::vector<unsigned int>& new_points, sofa::helper::vector<unsigned int>& end_points, bool& reachBorder);
+    virtual bool InciseAlongEdgeList(const sofa::helper::vector<EdgeID>& edges, sofa::helper::vector<PointID>& new_points, sofa::helper::vector<PointID>& end_points, bool& reachBorder);
 
-    unsigned int getOtherPointInTriangle(const Triangle& t, unsigned int p1, unsigned int p2) const
+    PointID getOtherPointInTriangle(const Triangle& t, PointID p1, PointID p2) const
     {
         if (t[0] != p1 && t[0] != p2) return t[0];
         else if (t[1] != p1 && t[1] != p2) return t[1];
@@ -143,7 +144,7 @@ public:
 
 
 protected:
-    Data< sofa::helper::vector< unsigned int> > m_listTriRemove; ///< Debug : Remove a triangle or a list of triangles by using their indices (only while animate).
+    Data< sofa::helper::vector< TriangleID> > m_listTriRemove; ///< Debug : Remove a triangle or a list of triangles by using their indices (only while animate).
     Data< sofa::helper::vector< Triangle> > m_listTriAdd; ///< Debug : Add a triangle or a list of triangles by using their indices (only while animate).
 
 private:
@@ -157,29 +158,29 @@ private:
 
 #ifndef SOFA_FLOAT
 template<>
-int TriangleSetTopologyAlgorithms<defaulttype::Vec2dTypes>::SplitAlongPath(unsigned int pa, Coord& a, unsigned int pb, Coord& b,
+int TriangleSetTopologyAlgorithms<defaulttype::Vec2dTypes>::SplitAlongPath(PointID pa, Coord& a, PointID pb, Coord& b,
                                                               sofa::helper::vector< sofa::core::topology::TopologyObjectType>& topoPath_list,
-                                                              sofa::helper::vector<unsigned int>& indices_list,
+                                                              sofa::helper::vector<ElemID>& indices_list,
                                                               sofa::helper::vector< sofa::defaulttype::Vec<3, double> >& coords_list,
                                                               sofa::helper::vector<EdgeID>& new_edges, double epsilonSnapPath, double epsilonSnapBorder);
 template<>
-int TriangleSetTopologyAlgorithms<defaulttype::Vec1dTypes>::SplitAlongPath(unsigned int pa, Coord& a, unsigned int pb, Coord& b,
+int TriangleSetTopologyAlgorithms<defaulttype::Vec1dTypes>::SplitAlongPath(PointID pa, Coord& a, PointID pb, Coord& b,
                                                               sofa::helper::vector< sofa::core::topology::TopologyObjectType>& topoPath_list,
-                                                              sofa::helper::vector<unsigned int>& indices_list,
+                                                              sofa::helper::vector<ElemID>& indices_list,
                                                               sofa::helper::vector< sofa::defaulttype::Vec<3, double> >& coords_list,
                                                               sofa::helper::vector<EdgeID>& new_edges, double epsilonSnapPath, double epsilonSnapBorder);
 #endif
 #ifndef SOFA_DOUBLE
 template<>
-int TriangleSetTopologyAlgorithms<defaulttype::Vec2fTypes>::SplitAlongPath(unsigned int pa, Coord& a, unsigned int pb, Coord& b,
+int TriangleSetTopologyAlgorithms<defaulttype::Vec2fTypes>::SplitAlongPath(PointID pa, Coord& a, PointID pb, Coord& b,
                                                               sofa::helper::vector< sofa::core::topology::TopologyObjectType>& topoPath_list,
-                                                              sofa::helper::vector<unsigned int>& indices_list,
+                                                              sofa::helper::vector<ElemID>& indices_list,
                                                               sofa::helper::vector< sofa::defaulttype::Vec<3, double> >& coords_list,
                                                               sofa::helper::vector<EdgeID>& new_edges, double epsilonSnapPath, double epsilonSnapBorder);
 template<>
-int TriangleSetTopologyAlgorithms<defaulttype::Vec1fTypes>::SplitAlongPath(unsigned int pa, Coord& a, unsigned int pb, Coord& b,
+int TriangleSetTopologyAlgorithms<defaulttype::Vec1fTypes>::SplitAlongPath(PointID pa, Coord& a, PointID pb, Coord& b,
                                                               sofa::helper::vector< sofa::core::topology::TopologyObjectType>& topoPath_list,
-                                                              sofa::helper::vector<unsigned int>& indices_list,
+                                                              sofa::helper::vector<ElemID>& indices_list,
                                                               sofa::helper::vector< sofa::defaulttype::Vec<3, double> >& coords_list,
                                                               sofa::helper::vector<EdgeID>& new_edges, double epsilonSnapPath, double epsilonSnapBorder);
 #endif

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.cpp
@@ -488,7 +488,7 @@ unsigned int TriangleSetTopologyContainer::getNumberOfTriangles() const
     return (unsigned int)d_triangle.getValue().size();
 }
 
-unsigned int TriangleSetTopologyContainer::getNumberOfElements() const
+size_t TriangleSetTopologyContainer::getNumberOfElements() const
 {
     return this->getNumberOfTriangles();
 }
@@ -802,7 +802,7 @@ bool TriangleSetTopologyContainer::checkConnexity()
 }
 
 
-unsigned int TriangleSetTopologyContainer::getNumberOfConnectedComponent()
+size_t TriangleSetTopologyContainer::getNumberOfConnectedComponent()
 {
     size_t nbr = this->getNbTriangles();
 

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.cpp
@@ -99,11 +99,11 @@ void TriangleSetTopologyContainer::createTrianglesAroundVertexArray ()
     
     helper::ReadAccessor< Data< sofa::helper::vector<Triangle> > > m_triangle = d_triangle;
 
-    for (unsigned int i = 0; i < m_triangle.size(); ++i)
+    for (size_t i = 0; i < m_triangle.size(); ++i)
     {
         // adding edge i in the edge shell of both points
         for (unsigned int j=0; j<3; ++j)
-            m_trianglesAroundVertex[ m_triangle[i][j]  ].push_back( i );
+            m_trianglesAroundVertex[ m_triangle[i][j]  ].push_back( (TriangleID)i );
     }
 }
 
@@ -128,8 +128,8 @@ void TriangleSetTopologyContainer::createTrianglesAroundEdgeArray ()
     if(!hasEdgesInTriangle())
         createEdgesInTriangleArray();
 
-    const unsigned int numTriangles = getNumberOfTriangles();
-    const unsigned int numEdges = getNumberOfEdges();
+    const size_t numTriangles = getNumberOfTriangles();
+    const size_t numEdges = getNumberOfEdges();
 
     if(hasTrianglesAroundEdge())
     {
@@ -138,16 +138,16 @@ void TriangleSetTopologyContainer::createTrianglesAroundEdgeArray ()
 
     m_trianglesAroundEdge.resize( numEdges );
 
-    for (unsigned int i = 0; i < numTriangles; ++i)
+    for (size_t i = 0; i < numTriangles; ++i)
     {
-        const Triangle &t = getTriangle(i);
+        const Triangle &t = getTriangle((TriangleID)i);
         // adding triangle i in the triangle shell of all edges
         for (unsigned int j=0; j<3; ++j)
         {
             if (d_edge.getValue()[m_edgesInTriangle[i][j]][0] == t[(j + 1) % 3])
-                m_trianglesAroundEdge[m_edgesInTriangle[i][j]].insert(m_trianglesAroundEdge[m_edgesInTriangle[i][j]].begin(), i); // triangle is on the left of the edge
+                m_trianglesAroundEdge[m_edgesInTriangle[i][j]].insert(m_trianglesAroundEdge[m_edgesInTriangle[i][j]].begin(), (TriangleID)i); // triangle is on the left of the edge
             else
-                m_trianglesAroundEdge[m_edgesInTriangle[i][j]].push_back(i); // triangle is on the right of the edge
+                m_trianglesAroundEdge[m_edgesInTriangle[i][j]].push_back((TriangleID)i); // triangle is on the right of the edge
         }
     }
 }
@@ -180,17 +180,17 @@ void TriangleSetTopologyContainer::createEdgeSetArray()
     }
 
     // create a temporary map to find redundant edges
-    std::map<Edge, unsigned int> edgeMap;
+    std::map<Edge, EdgeID> edgeMap;
     helper::WriteAccessor< Data< sofa::helper::vector<Edge> > > m_edge = d_edge;
     helper::ReadAccessor< Data< sofa::helper::vector<Triangle> > > m_triangle = d_triangle;
 
-    for (unsigned int i=0; i<m_triangle.size(); ++i)
+    for (size_t i=0; i<m_triangle.size(); ++i)
     {
         const Triangle &t = m_triangle[i];
         for(unsigned int j=0; j<3; ++j)
         {
-            const unsigned int v1 = t[(j+1)%3];
-            const unsigned int v2 = t[(j+2)%3];
+            const PointID v1 = t[(j+1)%3];
+            const PointID v2 = t[(j+2)%3];
 
             // sort vertices in lexicographic order
             const Edge e = ((v1<v2) ? Edge(v1,v2) : Edge(v2,v1));
@@ -198,8 +198,8 @@ void TriangleSetTopologyContainer::createEdgeSetArray()
             if(edgeMap.find(e) == edgeMap.end())
             {
                 // edge not in edgeMap so create a new one
-                const unsigned int edgeIndex = (unsigned int)edgeMap.size();
-                edgeMap[e] = edgeIndex;
+                const size_t edgeIndex = edgeMap.size();
+                edgeMap[e] = (EdgeID)edgeIndex;
                 //m_edge.push_back(e); Changed to have oriented edges on the border of the triangulation
                 m_edge.push_back(Edge(v1,v2));
             }
@@ -230,21 +230,21 @@ void TriangleSetTopologyContainer::createEdgesInTriangleArray()
 
 
         /// create edge array and triangle edge array at the same time
-        const unsigned int numTriangles = getNumberOfTriangles();
+        const size_t numTriangles = getNumberOfTriangles();
         m_edgesInTriangle.resize(numTriangles);
 
 
         // create a temporary map to find redundant edges
-        std::map<Edge, unsigned int> edgeMap;
+        std::map<Edge, EdgeID> edgeMap;
         helper::WriteAccessor< Data< sofa::helper::vector<Edge> > > m_edge = d_edge;
 
-        for (unsigned int i=0; i<m_triangle.size(); ++i)
+        for (size_t i=0; i<m_triangle.size(); ++i)
         {
             const Triangle &t = m_triangle[i];
             for(unsigned int j=0; j<3; ++j)
             {
-                const unsigned int v1 = t[(j+1)%3];
-                const unsigned int v2 = t[(j+2)%3];
+                const PointID v1 = t[(j+1)%3];
+                const PointID v2 = t[(j+2)%3];
 
                 // sort vertices in lexicographic order
                 const Edge e = ((v1<v2) ? Edge(v1,v2) : Edge(v2,v1));
@@ -252,9 +252,9 @@ void TriangleSetTopologyContainer::createEdgesInTriangleArray()
                 if(edgeMap.find(e) == edgeMap.end())
                 {
                     // edge not in edgeMap so create a new one
-                    const unsigned int edgeIndex = (unsigned int)edgeMap.size();
+                    const size_t edgeIndex = edgeMap.size();
                     /// add new edge
-                    edgeMap[e] = edgeIndex;
+                    edgeMap[e] = (EdgeID)edgeIndex;
 //			  m_edge.push_back(e);
                     m_edge.push_back(Edge(v1,v2));
 
@@ -267,8 +267,8 @@ void TriangleSetTopologyContainer::createEdgesInTriangleArray()
     {
         /// there are already existing edges : must use an inefficient method. Parse all triangles and find the edge that match each triangle edge
         helper::ReadAccessor< Data< sofa::helper::vector<Edge> > > m_edge = d_edge;
-        const unsigned int numTriangles = getNumberOfTriangles();
-        const unsigned int numEdges = getNumberOfEdges();
+        const size_t numTriangles = getNumberOfTriangles();
+        const size_t numEdges = getNumberOfEdges();
 
         m_edgesInTriangle.resize(numTriangles);
         /// create a multi map where the key is a vertex index and the content is the indices of edges adjacent to that vertex.
@@ -276,13 +276,13 @@ void TriangleSetTopologyContainer::createEdgesInTriangleArray()
         std::multimap<PointID, EdgeID>::iterator it;
         bool foundEdge;
 
-        for (unsigned int edge=0; edge<numEdges; ++edge)  //Todo: check if not better using multimap <PointID ,TriangleID> and for each edge, push each triangle present in both shell
+        for (size_t edge=0; edge<numEdges; ++edge)  //Todo: check if not better using multimap <PointID ,TriangleID> and for each edge, push each triangle present in both shell
         {
-            edgesAroundVertexMap.insert(std::pair<PointID, EdgeID> (m_edge[edge][0],edge));
-            edgesAroundVertexMap.insert(std::pair<PointID, EdgeID> (m_edge[edge][1],edge));
+            edgesAroundVertexMap.insert(std::pair<PointID, EdgeID> (m_edge[edge][0], (EdgeID)edge));
+            edgesAroundVertexMap.insert(std::pair<PointID, EdgeID> (m_edge[edge][1], (EdgeID)edge));
         }
 
-        for(unsigned int i=0; i<numTriangles; ++i)
+        for(size_t i=0; i<numTriangles; ++i)
         {
             const Triangle &t = m_triangle[i];
             // adding edge i in the edge shell of both points
@@ -294,7 +294,7 @@ void TriangleSetTopologyContainer::createEdgesInTriangleArray()
                 foundEdge=false;
                 for(it=itPair.first; (it!=itPair.second) && (foundEdge==false); ++it)
                 {
-                    unsigned int edge = (*it).second;
+                    EdgeID edge = (*it).second;
                     if ( (m_edge[edge][0] == t[(j+1)%3] && m_edge[edge][1] == t[(j+2)%3]) || (m_edge[edge][0] == t[(j+2)%3] && m_edge[edge][1] == t[(j+1)%3]))
                     {
                         m_edgesInTriangle[i][j] = edge;
@@ -334,19 +334,19 @@ void TriangleSetTopologyContainer::createElementsOnBorder()
     if(!m_pointsOnBorder.empty())
         m_pointsOnBorder.clear();
 
-    const unsigned int nbrEdges = getNumberOfEdges();
+    const size_t nbrEdges = getNumberOfEdges();
     bool newTriangle = true;
     bool newEdge = true;
     bool newPoint = true;
 
     helper::ReadAccessor< Data< sofa::helper::vector<Edge> > > m_edge = d_edge;
-    for (unsigned int i = 0; i < nbrEdges; i++)
+    for (size_t i = 0; i < nbrEdges; i++)
     {
         if (m_trianglesAroundEdge[i].size() == 1) // I.e this edge is on a border
         {
 
             // --- Triangle case ---
-            for (unsigned int j = 0; j < m_trianglesOnBorder.size(); j++) // Loop to avoid duplicated indices
+            for (size_t j = 0; j < m_trianglesOnBorder.size(); j++) // Loop to avoid duplicated indices
             {
                 if (m_trianglesOnBorder[j] == m_trianglesAroundEdge[i][0])
                 {
@@ -362,7 +362,7 @@ void TriangleSetTopologyContainer::createElementsOnBorder()
 
 
             // --- Edge case ---
-            for (unsigned int j = 0; j < m_edgesOnBorder.size(); j++) // Loop to avoid duplicated indices
+            for (size_t j = 0; j < m_edgesOnBorder.size(); j++) // Loop to avoid duplicated indices
             {
                 if (m_edgesOnBorder[j] == i)
                 {
@@ -373,13 +373,13 @@ void TriangleSetTopologyContainer::createElementsOnBorder()
 
             if(newEdge) // If index doesn't already exist, add it to the list of edges On border.
             {
-                m_edgesOnBorder.push_back (i);
+                m_edgesOnBorder.push_back ((EdgeID)i);
             }
 
 
             // --- Point case ---
             PointID firstVertex = m_edge[i][0];
-            for (unsigned int j = 0; j < m_pointsOnBorder.size(); j++) // Loop to avoid duplicated indices
+            for (size_t j = 0; j < m_pointsOnBorder.size(); j++) // Loop to avoid duplicated indices
             {
                 if (m_pointsOnBorder[j] == firstVertex)
                 {
@@ -404,7 +404,7 @@ void TriangleSetTopologyContainer::createElementsOnBorder()
 
 void TriangleSetTopologyContainer::reOrientateTriangle(TriangleID id)
 {
-    if (id >= (unsigned int)this->getNbTriangles())
+    if (id >= (TriangleID)this->getNbTriangles())
     {
 		if (CHECK_TOPOLOGY)
 			msg_warning() << "Triangle ID out of bounds.";
@@ -412,7 +412,7 @@ void TriangleSetTopologyContainer::reOrientateTriangle(TriangleID id)
         return;
     }
     Triangle& tri = (*d_triangle.beginEdit())[id];
-    unsigned int tmp = tri[1];
+    PointID tmp = tri[1];
     tri[1] = tri[2];
     tri[2] = tmp;
     d_triangle.endEdit();
@@ -453,22 +453,22 @@ int TriangleSetTopologyContainer::getTriangleIndex(PointID v1, PointID v2, Point
     if(!hasTrianglesAroundVertex())
         createTrianglesAroundVertexArray();
 
-    sofa::helper::vector<unsigned int> set1 = getTrianglesAroundVertex(v1);
-    sofa::helper::vector<unsigned int> set2 = getTrianglesAroundVertex(v2);
-    sofa::helper::vector<unsigned int> set3 = getTrianglesAroundVertex(v3);
+    sofa::helper::vector<TriangleID> set1 = getTrianglesAroundVertex(v1);
+    sofa::helper::vector<TriangleID> set2 = getTrianglesAroundVertex(v2);
+    sofa::helper::vector<TriangleID> set3 = getTrianglesAroundVertex(v3);
 
     sort(set1.begin(), set1.end());
     sort(set2.begin(), set2.end());
     sort(set3.begin(), set3.end());
 
     // The destination vector must be large enough to contain the result.
-    sofa::helper::vector<unsigned int> out1(set1.size()+set2.size());
-    sofa::helper::vector<unsigned int>::iterator result1;
+    sofa::helper::vector<TriangleID> out1(set1.size()+set2.size());
+    sofa::helper::vector<TriangleID>::iterator result1;
     result1 = std::set_intersection(set1.begin(),set1.end(),set2.begin(),set2.end(),out1.begin());
     out1.erase(result1,out1.end());
 
-    sofa::helper::vector<unsigned int> out2(set3.size()+out1.size());
-    sofa::helper::vector<unsigned int>::iterator result2;
+    sofa::helper::vector<TriangleID> out2(set3.size()+out1.size());
+    sofa::helper::vector<TriangleID>::iterator result2;
     result2 = std::set_intersection(set3.begin(),set3.end(),out1.begin(),out1.end(),out2.begin());
     out2.erase(result2,out2.end());
 
@@ -483,9 +483,9 @@ int TriangleSetTopologyContainer::getTriangleIndex(PointID v1, PointID v2, Point
         return -1;
 }
 
-unsigned int TriangleSetTopologyContainer::getNumberOfTriangles() const
+size_t TriangleSetTopologyContainer::getNumberOfTriangles() const
 {
-    return (unsigned int)d_triangle.getValue().size();
+    return d_triangle.getValue().size();
 }
 
 size_t TriangleSetTopologyContainer::getNumberOfElements() const
@@ -493,7 +493,7 @@ size_t TriangleSetTopologyContainer::getNumberOfElements() const
     return this->getNumberOfTriangles();
 }
 
-const sofa::helper::vector< sofa::helper::vector<unsigned int> > &TriangleSetTopologyContainer::getTrianglesAroundVertexArray()
+const sofa::helper::vector< TriangleSetTopologyContainer::TrianglesAroundVertex > &TriangleSetTopologyContainer::getTrianglesAroundVertexArray()
 {
     if(!hasTrianglesAroundVertex())	// this method should only be called when the shell array exists
     {
@@ -506,7 +506,7 @@ const sofa::helper::vector< sofa::helper::vector<unsigned int> > &TriangleSetTop
     return m_trianglesAroundVertex;
 }
 
-const sofa::helper::vector< sofa::helper::vector<unsigned int> > &TriangleSetTopologyContainer::getTrianglesAroundEdgeArray()
+const sofa::helper::vector< TriangleSetTopologyContainer::TrianglesAroundEdge > &TriangleSetTopologyContainer::getTrianglesAroundEdgeArray()
 {
     if(!hasTrianglesAroundEdge())	// this method should only be called when the shell array exists
     {
@@ -567,7 +567,7 @@ const TriangleSetTopologyContainer::TrianglesAroundEdge& TriangleSetTopologyCont
     return m_trianglesAroundEdge[i];
 }
 
-const TriangleSetTopologyContainer::EdgesInTriangle &TriangleSetTopologyContainer::getEdgesInTriangle(const unsigned int i)
+const TriangleSetTopologyContainer::EdgesInTriangle &TriangleSetTopologyContainer::getEdgesInTriangle(const TriangleID i)
 {
     if(m_edgesInTriangle.empty())
         createEdgesInTriangleArray();
@@ -650,7 +650,7 @@ const sofa::helper::vector <TriangleSetTopologyContainer::PointID>& TriangleSetT
 }
 
 
-sofa::helper::vector< unsigned int > &TriangleSetTopologyContainer::getTrianglesAroundEdgeForModification(const unsigned int i)
+TriangleSetTopologyContainer::TrianglesAroundEdge &TriangleSetTopologyContainer::getTrianglesAroundEdgeForModification(const EdgeID i)
 {
     if(!hasTrianglesAroundEdge())	// this method should only be called when the shell array exists
     {
@@ -671,7 +671,7 @@ sofa::helper::vector< unsigned int > &TriangleSetTopologyContainer::getTriangles
     return m_trianglesAroundEdge[i];
 }
 
-sofa::helper::vector< unsigned int > &TriangleSetTopologyContainer::getTrianglesAroundVertexForModification(const unsigned int i)
+TriangleSetTopologyContainer::TrianglesAroundVertex &TriangleSetTopologyContainer::getTrianglesAroundVertexForModification(const PointID i)
 {
     if(!hasTrianglesAroundVertex())	// this method should only be called when the shell array exists
     {
@@ -704,10 +704,10 @@ bool TriangleSetTopologyContainer::checkTopology() const
 			std::set <int> triangleSet;
 			std::set<int>::iterator it;
 
-			for (unsigned int i = 0; i < m_trianglesAroundVertex.size(); ++i)
+			for (size_t i = 0; i < m_trianglesAroundVertex.size(); ++i)
 			{
-				const sofa::helper::vector<unsigned int> &tvs = m_trianglesAroundVertex[i];
-				for (unsigned int j = 0; j < tvs.size(); ++j)
+				const sofa::helper::vector<TriangleID> &tvs = m_trianglesAroundVertex[i];
+				for (size_t j = 0; j < tvs.size(); ++j)
 				{
 					bool check_triangle_vertex_shell = (m_triangle[tvs[j]][0] == i)
 						|| (m_triangle[tvs[j]][1] == i)
@@ -738,10 +738,10 @@ bool TriangleSetTopologyContainer::checkTopology() const
 			std::set <int> triangleSet;
 			std::set<int>::iterator it;
 
-			for (unsigned int i = 0; i < m_trianglesAroundEdge.size(); ++i)
+			for (size_t i = 0; i < m_trianglesAroundEdge.size(); ++i)
 			{
-				const sofa::helper::vector<unsigned int> &tes = m_trianglesAroundEdge[i];
-				for (unsigned int j = 0; j < tes.size(); ++j)
+				const sofa::helper::vector<TriangleID> &tes = m_trianglesAroundEdge[i];
+				for (size_t j = 0; j < tes.size(); ++j)
 				{
 					bool check_triangle_edge_shell = (m_edgesInTriangle[tes[j]][0] == i)
 						|| (m_edgesInTriangle[tes[j]][1] == i)
@@ -815,21 +815,21 @@ size_t TriangleSetTopologyContainer::getNumberOfConnectedComponent()
     }
 
     VecTriangleID elemAll = this->getConnectedElement(0);
-    unsigned int cpt = 1;
+    size_t cpt = 1;
 
     while (elemAll.size() < nbr)
     {
         std::sort(elemAll.begin(), elemAll.end());
-        TriangleID other_triangleID = elemAll.size();
+        size_t other_triangleID = elemAll.size();
 
-        for (TriangleID i = 0; i<elemAll.size(); ++i)
+        for (size_t i = 0; i<elemAll.size(); ++i)
             if (elemAll[i] != i)
             {
                 other_triangleID = i;
                 break;
             }
 
-        VecTriangleID elemTmp = this->getConnectedElement(other_triangleID);
+        VecTriangleID elemTmp = this->getConnectedElement((TriangleID)other_triangleID);
         cpt++;
 
         elemAll.insert(elemAll.begin(), elemTmp.begin(), elemTmp.end());
@@ -865,12 +865,12 @@ const TriangleSetTopologyContainer::VecTriangleID TriangleSetTopologyContainer::
         // First Step - Create new region
         elemNextFront = this->getElementAroundElements(elemOnFront); // for each triangleID on the propagation front
         // Second Step - Avoid backward direction
-        for (unsigned int i = 0; i<elemNextFront.size(); ++i)
+        for (size_t i = 0; i<elemNextFront.size(); ++i)
         {
             bool find = false;
             TriangleID id = elemNextFront[i];
 
-            for (unsigned int j = 0; j<elemAll.size(); ++j)
+            for (size_t j = 0; j<elemAll.size(); ++j)
                 if (id == elemAll[j])
                 {
                     find = true;
@@ -916,11 +916,11 @@ const TriangleSetTopologyContainer::VecTriangleID TriangleSetTopologyContainer::
 
     Triangle the_tri = this->getTriangle(elem);
 
-    for(unsigned int i = 0; i<3; ++i) // for each node of the triangle
+    for(PointID i = 0; i<3; ++i) // for each node of the triangle
     {
         TrianglesAroundVertex triAV = this->getTrianglesAroundVertex(the_tri[i]);
 
-        for (unsigned int j = 0; j<triAV.size(); ++j) // for each triangle around the node
+        for (size_t j = 0; j<triAV.size(); ++j) // for each triangle around the node
         {
             bool find = false;
             TriangleID id = triAV[j];
@@ -928,7 +928,7 @@ const TriangleSetTopologyContainer::VecTriangleID TriangleSetTopologyContainer::
             if (id == elem)
                 continue;
 
-            for (unsigned int k = 0; k<elems.size(); ++k) // check no redundancy
+            for (size_t k = 0; k<elems.size(); ++k) // check no redundancy
                 if (id == elems[k])
                 {
                     find = true;
@@ -956,19 +956,19 @@ const TriangleSetTopologyContainer::VecTriangleID TriangleSetTopologyContainer::
         createTrianglesAroundVertexArray();
     }
 
-    for (unsigned int i = 0; i <elems.size(); ++i) // for each triangleId of input vector
+    for (size_t i = 0; i <elems.size(); ++i) // for each triangleId of input vector
     {
         VecTriangleID elemTmp2 = this->getElementAroundElement(elems[i]);
 
         elemTmp.insert(elemTmp.end(), elemTmp2.begin(), elemTmp2.end());
     }
 
-    for (unsigned int i = 0; i<elemTmp.size(); ++i) // for each Triangle Id found
+    for (size_t i = 0; i<elemTmp.size(); ++i) // for each Triangle Id found
     {
         bool find = false;
         TriangleID id = elemTmp[i];
 
-        for (unsigned int j = 0; j<elems.size(); ++j) // check no redundancy with input vector
+        for (size_t j = 0; j<elems.size(); ++j) // check no redundancy with input vector
             if (id == elems[j])
             {
                 find = true;
@@ -977,7 +977,7 @@ const TriangleSetTopologyContainer::VecTriangleID TriangleSetTopologyContainer::
 
         if (!find)
         {
-            for (unsigned int j = 0; j<elemAll.size(); ++j) // check no redundancy in output vector
+            for (size_t j = 0; j<elemAll.size(); ++j) // check no redundancy in output vector
                 if (id == elemAll[j])
                 {
                     find = true;
@@ -1025,7 +1025,7 @@ bool TriangleSetTopologyContainer::hasBorderElementLists() const
 
 void TriangleSetTopologyContainer::clearTrianglesAroundVertex()
 {
-    for(unsigned int i=0; i<m_trianglesAroundVertex.size(); ++i)
+    for(size_t i=0; i<m_trianglesAroundVertex.size(); ++i)
         m_trianglesAroundVertex[i].clear();
 
     m_trianglesAroundVertex.clear();
@@ -1033,7 +1033,7 @@ void TriangleSetTopologyContainer::clearTrianglesAroundVertex()
 
 void TriangleSetTopologyContainer::clearTrianglesAroundEdge()
 {
-    for(unsigned int i=0; i<m_trianglesAroundEdge.size(); ++i)
+    for(size_t i=0; i<m_trianglesAroundEdge.size(); ++i)
         m_trianglesAroundEdge[i].clear();
 
     m_trianglesAroundEdge.clear();

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.h
@@ -178,7 +178,7 @@ public:
     /** \brief Returns the number of topological element of the current topology.
      * This function avoids to know which topological container is in used.
      */
-    virtual unsigned int getNumberOfElements() const override;
+    virtual size_t getNumberOfElements() const override;
 
     /** \brief Returns the Triangle array. */
     const sofa::helper::vector<Triangle> &getTriangleArray();
@@ -223,7 +223,7 @@ public:
     virtual bool checkConnexity() override;
 
     /// Returns the number of connected component.
-    virtual unsigned int getNumberOfConnectedComponent() override;
+    virtual size_t getNumberOfConnectedComponent() override;
 
     /// Returns the set of element indices connected to an input one (i.e. which can be reached by topological links)
     virtual const VecTriangleID getConnectedElement(TriangleID elem) override;

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.h
@@ -48,16 +48,16 @@ public:
 
 
 
-    typedef core::topology::BaseMeshTopology::PointID		            	PointID;
-    typedef core::topology::BaseMeshTopology::EdgeID		               	EdgeID;
-    typedef core::topology::BaseMeshTopology::TriangleID	               TriangleID;
-    typedef core::topology::BaseMeshTopology::Edge		        	         Edge;
-    typedef core::topology::BaseMeshTopology::Triangle	        	         Triangle;
-    typedef core::topology::BaseMeshTopology::SeqTriangles	        	      SeqTriangles;
-    typedef core::topology::BaseMeshTopology::EdgesInTriangle	         	EdgesInTriangle;
-    typedef core::topology::BaseMeshTopology::TrianglesAroundVertex    	TrianglesAroundVertex;
-    typedef core::topology::BaseMeshTopology::TrianglesAroundEdge        	TrianglesAroundEdge;
-    typedef sofa::helper::vector<TriangleID>                  VecTriangleID;
+    typedef core::topology::BaseMeshTopology::PointID                      PointID;
+    typedef core::topology::BaseMeshTopology::EdgeID                       EdgeID;
+    typedef core::topology::BaseMeshTopology::TriangleID                   TriangleID;
+    typedef core::topology::BaseMeshTopology::Edge                         Edge;
+    typedef core::topology::BaseMeshTopology::Triangle                     Triangle;
+    typedef core::topology::BaseMeshTopology::SeqTriangles                 SeqTriangles;
+    typedef core::topology::BaseMeshTopology::EdgesInTriangle              EdgesInTriangle;
+    typedef core::topology::BaseMeshTopology::TrianglesAroundVertex        TrianglesAroundVertex;
+    typedef core::topology::BaseMeshTopology::TrianglesAroundEdge          TrianglesAroundEdge;
+    typedef sofa::helper::vector<TriangleID>                               VecTriangleID;
 
 
 protected:
@@ -171,9 +171,9 @@ public:
 
 
     /** \brief Returns the number of triangles in this topology.
-     *	The difference to getNbTriangles() is that this method does not generate the triangle array if it does not exist.
+     *    The difference to getNbTriangles() is that this method does not generate the triangle array if it does not exist.
      */
-    unsigned int getNumberOfTriangles() const;
+    size_t getNumberOfTriangles() const;
 
     /** \brief Returns the number of topological element of the current topology.
      * This function avoids to know which topological container is in used.

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyModifier.cpp
@@ -258,7 +258,7 @@ void TriangleSetTopologyModifier::addTrianglesWarning(const unsigned int nTriang
 }
 
 
-void TriangleSetTopologyModifier::addPointsProcess(const unsigned int nPoints)
+void TriangleSetTopologyModifier::addPointsProcess(const size_t nPoints)
 {
     // start by calling the parent's method.
     EdgeSetTopologyModifier::addPointsProcess( nPoints );

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyModifier.cpp
@@ -55,20 +55,20 @@ void TriangleSetTopologyModifier::init()
 
 void TriangleSetTopologyModifier::reinit()
 {
-    const sofa::helper::vector <unsigned int>& vertexToBeRemoved = this->list_Out.getValue();
+    const sofa::helper::vector <TriangleID>& vertexToBeRemoved = this->list_Out.getValue();
 
 
-    sofa::helper::vector <unsigned int> trianglesToBeRemoved;
+    sofa::helper::vector <TriangleID> trianglesToBeRemoved;
     const sofa::helper::vector<Triangle>& listTri = this->m_container->d_triangle.getValue();
 
-    for (unsigned int i = 0; i<listTri.size(); ++i)
+    for (size_t i = 0; i<listTri.size(); ++i)
     {
         Triangle the_tri = listTri[i];
         bool find = false;
         for (unsigned int j = 0; j<3; ++j)
         {
-            unsigned int the_point = the_tri[j];
-            for (unsigned int k = 0; k<vertexToBeRemoved.size(); ++k)
+            PointID the_point = the_tri[j];
+            for (size_t k = 0; k<vertexToBeRemoved.size(); ++k)
                 if (the_point == vertexToBeRemoved[k])
                 {
                     find = true;
@@ -77,7 +77,7 @@ void TriangleSetTopologyModifier::reinit()
 
             if (find)
             {
-                trianglesToBeRemoved.push_back(i);
+                trianglesToBeRemoved.push_back((TriangleID)i);
                 break;
             }
         }
@@ -90,7 +90,7 @@ void TriangleSetTopologyModifier::reinit()
 
 void TriangleSetTopologyModifier::addTriangles(const sofa::helper::vector<Triangle> &triangles)
 {
-    unsigned int nTriangles = m_container->getNbTriangles();
+    size_t nTriangles = m_container->getNbTriangles();
 
     // Test if the topology will still fulfill the conditions if this triangles is added.
     if (addTrianglesPreconditions(triangles))
@@ -101,14 +101,14 @@ void TriangleSetTopologyModifier::addTriangles(const sofa::helper::vector<Triang
         // Apply postprocessing to arrange the topology.
         addTrianglesPostProcessing(triangles);
 
-        sofa::helper::vector<unsigned int> trianglesIndex;
+        sofa::helper::vector<TriangleID> trianglesIndex;
         trianglesIndex.reserve(triangles.size());
 
-        for (unsigned int i=0; i<triangles.size(); ++i)
-            trianglesIndex.push_back(nTriangles+i);
+        for (size_t i=0; i<triangles.size(); ++i)
+            trianglesIndex.push_back((TriangleID)(nTriangles+i));
 
         // add topology event in the stack of topological events
-        addTrianglesWarning((unsigned int)triangles.size(), triangles, trianglesIndex);
+        addTrianglesWarning(triangles.size(), triangles, trianglesIndex);
 
         // inform other objects that the edges are already added
         propagateTopologicalChanges();
@@ -121,10 +121,10 @@ void TriangleSetTopologyModifier::addTriangles(const sofa::helper::vector<Triang
 
 
 void TriangleSetTopologyModifier::addTriangles(const sofa::helper::vector<Triangle> &triangles,
-        const sofa::helper::vector<sofa::helper::vector<unsigned int> > &ancestors,
-        const sofa::helper::vector<sofa::helper::vector<double> > &baryCoefs)
+        const sofa::helper::vector<sofa::helper::vector<TriangleID> > &ancestors,
+        const sofa::helper::vector<sofa::helper::vector<SReal> > &baryCoefs)
 {
-    unsigned int nTriangles = m_container->getNbTriangles();
+    size_t nTriangles = m_container->getNbTriangles();
 
     // Test if the topology will still fulfill the conditions if this triangles is added.
     if (addTrianglesPreconditions(triangles))
@@ -135,14 +135,14 @@ void TriangleSetTopologyModifier::addTriangles(const sofa::helper::vector<Triang
         // Apply postprocessing to arrange the topology.
         addTrianglesPostProcessing(triangles);
 
-        sofa::helper::vector<unsigned int> trianglesIndex;
+        sofa::helper::vector<TriangleID> trianglesIndex;
         trianglesIndex.reserve(triangles.size());
 
-        for (unsigned int i=0; i<triangles.size(); ++i)
-            trianglesIndex.push_back(nTriangles+i);
+        for (size_t i=0; i<triangles.size(); ++i)
+            trianglesIndex.push_back((TriangleID)(nTriangles+i));
 
         // add topology event in the stack of topological events
-        addTrianglesWarning((unsigned int)triangles.size(), triangles, trianglesIndex, ancestors, baryCoefs);
+        addTrianglesWarning(triangles.size(), triangles, trianglesIndex, ancestors, baryCoefs);
 
         // inform other objects that the edges are already added
         propagateTopologicalChanges();
@@ -156,7 +156,7 @@ void TriangleSetTopologyModifier::addTriangles(const sofa::helper::vector<Triang
 
 void TriangleSetTopologyModifier::addTrianglesProcess(const sofa::helper::vector< Triangle > &triangles)
 {
-    for(unsigned int i=0; i<triangles.size(); ++i)
+    for(size_t i=0; i<triangles.size(); ++i)
         addTriangleProcess(triangles[i]); //add triangle one by one.
 }
 
@@ -184,14 +184,14 @@ void TriangleSetTopologyModifier::addTriangleProcess(Triangle t)
 		}
 	}
 
-    const unsigned int triangleIndex = m_container->getNumberOfTriangles();
+    const TriangleID triangleIndex = (TriangleID)m_container->getNumberOfTriangles();
     helper::WriteAccessor< Data< sofa::helper::vector<Triangle> > > m_triangle = m_container->d_triangle;
 
     if(m_container->hasTrianglesAroundVertex())
     {
         for(unsigned int j=0; j<3; ++j)
         {
-            sofa::helper::vector< unsigned int > &shell = m_container->getTrianglesAroundVertexForModification( t[j] );
+            sofa::helper::vector< TriangleID > &shell = m_container->getTrianglesAroundVertexForModification( t[j] );
             shell.push_back( triangleIndex );
         }
     }
@@ -210,8 +210,8 @@ void TriangleSetTopologyModifier::addTriangleProcess(Triangle t)
             addEdgesProcess((const sofa::helper::vector< Edge > &) v);
 
             edgeIndex = m_container->getEdgeIndex(t[(j+1)%3],t[(j+2)%3]);
-            sofa::helper::vector< unsigned int > edgeIndexList;
-            edgeIndexList.push_back((unsigned int) edgeIndex);
+            sofa::helper::vector< EdgeID > edgeIndexList;
+            edgeIndexList.push_back((EdgeID) edgeIndex);
             addEdgesWarning( v.size(), v, edgeIndexList);
         }
 
@@ -223,7 +223,7 @@ void TriangleSetTopologyModifier::addTriangleProcess(Triangle t)
 
         if(m_container->hasTrianglesAroundEdge())
         {
-            sofa::helper::vector< unsigned int > &shell = m_container->m_trianglesAroundEdge[m_container->m_edgesInTriangle[triangleIndex][j]];
+            sofa::helper::vector< TriangleID > &shell = m_container->m_trianglesAroundEdge[m_container->m_edgesInTriangle[triangleIndex][j]];
             shell.push_back( triangleIndex );
         }
     }
@@ -232,9 +232,9 @@ void TriangleSetTopologyModifier::addTriangleProcess(Triangle t)
 }
 
 
-void TriangleSetTopologyModifier::addTrianglesWarning(const unsigned int nTriangles,
+void TriangleSetTopologyModifier::addTrianglesWarning(const size_t nTriangles,
         const sofa::helper::vector< Triangle >& trianglesList,
-        const sofa::helper::vector< unsigned int >& trianglesIndexList)
+        const sofa::helper::vector< TriangleID >& trianglesIndexList)
 {
     m_container->setTriangleTopologyToDirty();
 
@@ -244,11 +244,11 @@ void TriangleSetTopologyModifier::addTrianglesWarning(const unsigned int nTriang
 }
 
 
-void TriangleSetTopologyModifier::addTrianglesWarning(const unsigned int nTriangles,
+void TriangleSetTopologyModifier::addTrianglesWarning(const size_t nTriangles,
         const sofa::helper::vector< Triangle >& trianglesList,
-        const sofa::helper::vector< unsigned int >& trianglesIndexList,
-        const sofa::helper::vector< sofa::helper::vector< unsigned int > > & ancestors,
-        const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs)
+        const sofa::helper::vector< TriangleID >& trianglesIndexList,
+        const sofa::helper::vector< sofa::helper::vector< TriangleID > > & ancestors,
+        const sofa::helper::vector< sofa::helper::vector< SReal > >& baryCoefs)
 {
     m_container->setTriangleTopologyToDirty();
 
@@ -285,18 +285,18 @@ void TriangleSetTopologyModifier::addEdgesProcess(const sofa::helper::vector< Ed
 
 
 
-void TriangleSetTopologyModifier::removeItems(const sofa::helper::vector<unsigned int> &items)
+void TriangleSetTopologyModifier::removeItems(const sofa::helper::vector<TriangleID> &items)
 {
     removeTriangles(items, true, true); // remove triangles
 }
 
 
-void TriangleSetTopologyModifier::removeTriangles(const sofa::helper::vector<unsigned int> &triangleIds,
+void TriangleSetTopologyModifier::removeTriangles(const sofa::helper::vector<TriangleID> &triangleIds,
         const bool removeIsolatedEdges,
         const bool removeIsolatedPoints)
 {    
-    sofa::helper::vector<unsigned int> triangleIds_filtered;
-    for (unsigned int i = 0; i < triangleIds.size(); i++)
+    sofa::helper::vector<TriangleID> triangleIds_filtered;
+    for (size_t i = 0; i < triangleIds.size(); i++)
     {
         if( triangleIds[i] >= m_container->getNumberOfTriangles())
             msg_warning() << "RemoveTriangles: Triangle: "<< triangleIds[i] <<" is out of bound and won't be removed.";
@@ -323,13 +323,13 @@ void TriangleSetTopologyModifier::removeTriangles(const sofa::helper::vector<uns
 }
 
 
-void TriangleSetTopologyModifier::removeTrianglesWarning(sofa::helper::vector<unsigned int> &triangles)
+void TriangleSetTopologyModifier::removeTrianglesWarning(sofa::helper::vector<TriangleID> &triangles)
 {
     m_container->setTriangleTopologyToDirty();
 
 
     /// sort vertices to remove in a descendent order
-    std::sort( triangles.begin(), triangles.end(), std::greater<unsigned int>() );
+    std::sort( triangles.begin(), triangles.end(), std::greater<TriangleID>() );
 
     // Warning that these triangles will be deleted
     TrianglesRemoved *e=new TrianglesRemoved(triangles);
@@ -337,7 +337,7 @@ void TriangleSetTopologyModifier::removeTrianglesWarning(sofa::helper::vector<un
 }
 
 
-void TriangleSetTopologyModifier::removeTrianglesProcess(const sofa::helper::vector<unsigned int> &indices,
+void TriangleSetTopologyModifier::removeTrianglesProcess(const sofa::helper::vector<TriangleID> &indices,
         const bool removeIsolatedEdges,
         const bool removeIsolatedPoints)
 {
@@ -368,12 +368,12 @@ void TriangleSetTopologyModifier::removeTrianglesProcess(const sofa::helper::vec
             m_container->createTrianglesAroundVertexArray();
     }
 
-    sofa::helper::vector<unsigned int> edgeToBeRemoved;
-    sofa::helper::vector<unsigned int> vertexToBeRemoved;
+    sofa::helper::vector<EdgeID> edgeToBeRemoved;
+    sofa::helper::vector<PointID> vertexToBeRemoved;
     helper::WriteAccessor< Data< sofa::helper::vector<Triangle> > > m_triangle = m_container->d_triangle;
 
-    unsigned int lastTriangle = m_container->getNumberOfTriangles() - 1;
-    for(unsigned int i = 0; i<indices.size(); ++i, --lastTriangle)
+    size_t lastTriangle = m_container->getNumberOfTriangles() - 1;
+    for(size_t i = 0; i<indices.size(); ++i, --lastTriangle)
     {
         Triangle &t = m_triangle[ indices[i] ];
         Triangle &q = m_triangle[ lastTriangle ];
@@ -382,7 +382,7 @@ void TriangleSetTopologyModifier::removeTrianglesProcess(const sofa::helper::vec
         {
             for(unsigned int j=0; j<3; ++j)
             {
-                sofa::helper::vector< unsigned int > &shell = m_container->m_trianglesAroundVertex[ t[j] ];
+                sofa::helper::vector< TriangleID > &shell = m_container->m_trianglesAroundVertex[ t[j] ];
                 shell.erase(remove(shell.begin(), shell.end(), indices[i]), shell.end());
                 if(removeIsolatedPoints && shell.empty())
                     vertexToBeRemoved.push_back(t[j]);
@@ -393,7 +393,7 @@ void TriangleSetTopologyModifier::removeTrianglesProcess(const sofa::helper::vec
         {
             for(unsigned int j=0; j<3; ++j)
             {
-                sofa::helper::vector< unsigned int > &shell = m_container->m_trianglesAroundEdge[ m_container->m_edgesInTriangle[indices[i]][j]];
+                sofa::helper::vector< TriangleID > &shell = m_container->m_trianglesAroundEdge[ m_container->m_edgesInTriangle[indices[i]][j]];
                 shell.erase(remove(shell.begin(), shell.end(), indices[i]), shell.end());
                 if(removeIsolatedEdges && shell.empty())
                     edgeToBeRemoved.push_back(m_container->m_edgesInTriangle[indices[i]][j]);
@@ -408,8 +408,8 @@ void TriangleSetTopologyModifier::removeTrianglesProcess(const sofa::helper::vec
 
                 for(unsigned int j=0; j<3; ++j)
                 {
-                    sofa::helper::vector< unsigned int > &shell = m_container->m_trianglesAroundVertex[ q[j] ];
-                    replace(shell.begin(), shell.end(), lastTriangle, indices[i]);
+                    sofa::helper::vector< TriangleID > &shell = m_container->m_trianglesAroundVertex[ q[j] ];
+                    replace(shell.begin(), shell.end(), (TriangleID)lastTriangle, indices[i]);
                 }
             }
 
@@ -418,8 +418,8 @@ void TriangleSetTopologyModifier::removeTrianglesProcess(const sofa::helper::vec
 
                 for(unsigned int j=0; j<3; ++j)
                 {
-                    sofa::helper::vector< unsigned int > &shell = m_container->m_trianglesAroundEdge[ m_container->m_edgesInTriangle[lastTriangle][j]];
-                    replace(shell.begin(), shell.end(), lastTriangle, indices[i]);
+                    sofa::helper::vector< TriangleID > &shell = m_container->m_trianglesAroundEdge[ m_container->m_edgesInTriangle[lastTriangle][j]];
+                    replace(shell.begin(), shell.end(), (TriangleID)lastTriangle, indices[i]);
                 }
             }
         }
@@ -459,7 +459,7 @@ void TriangleSetTopologyModifier::removeTrianglesProcess(const sofa::helper::vec
 
 
 
-void TriangleSetTopologyModifier::removeEdgesProcess( const sofa::helper::vector<unsigned int> &indices,
+void TriangleSetTopologyModifier::removeEdgesProcess( const sofa::helper::vector<EdgeID> &indices,
         const bool removeIsolatedItems)
 {
 
@@ -470,15 +470,15 @@ void TriangleSetTopologyModifier::removeEdgesProcess( const sofa::helper::vector
         if(!m_container->hasTrianglesAroundEdge())
             m_container->createTrianglesAroundEdgeArray();
 
-        unsigned int lastEdge = m_container->getNumberOfEdges() - 1;
-        for(unsigned int i = 0; i < indices.size(); ++i, --lastEdge)
+        size_t lastEdge = m_container->getNumberOfEdges() - 1;
+        for(size_t i = 0; i < indices.size(); ++i, --lastEdge)
         {
             // updating the triangles connected to the edge replacing the removed one:
             // for all triangles connected to the last point
-            for(sofa::helper::vector<unsigned int>::iterator itt = m_container->m_trianglesAroundEdge[lastEdge].begin();
+            for(sofa::helper::vector<TriangleID>::iterator itt = m_container->m_trianglesAroundEdge[lastEdge].begin();
                 itt != m_container->m_trianglesAroundEdge[lastEdge].end(); ++itt)
             {
-                unsigned int edgeIndex = m_container->getEdgeIndexInTriangle(m_container->m_edgesInTriangle[(*itt)], lastEdge);
+                EdgeID edgeIndex = m_container->getEdgeIndexInTriangle(m_container->m_edgesInTriangle[(*itt)], (EdgeID)lastEdge);
                 m_container->m_edgesInTriangle[(*itt)][edgeIndex] = indices[i];
             }
 
@@ -495,7 +495,7 @@ void TriangleSetTopologyModifier::removeEdgesProcess( const sofa::helper::vector
 
 
 
-void TriangleSetTopologyModifier::removePointsProcess(const sofa::helper::vector<unsigned int> &indices,
+void TriangleSetTopologyModifier::removePointsProcess(const sofa::helper::vector<PointID> &indices,
         const bool removeDOF)
 {
 
@@ -506,16 +506,16 @@ void TriangleSetTopologyModifier::removePointsProcess(const sofa::helper::vector
 
         helper::WriteAccessor< Data< sofa::helper::vector<Triangle> > > m_triangle = m_container->d_triangle;
 
-        unsigned int lastPoint = m_container->getNbPoints() - 1;
-        for(unsigned int i=0; i<indices.size(); ++i, --lastPoint)
+        size_t lastPoint = m_container->getNbPoints() - 1;
+        for(size_t i=0; i<indices.size(); ++i, --lastPoint)
         {
             // updating the triangles connected to the point replacing the removed one:
             // for all triangles connected to the last point
 
-            sofa::helper::vector<unsigned int> &shell = m_container->m_trianglesAroundVertex[lastPoint];
-            for(unsigned int j=0; j<shell.size(); ++j)
+            sofa::helper::vector<TriangleID> &shell = m_container->m_trianglesAroundVertex[lastPoint];
+            for(size_t j=0; j<shell.size(); ++j)
             {
-                const unsigned int q = shell[j];
+                const TriangleID q = shell[j];
                 for(unsigned int k=0; k<3; ++k)
                 {
                     if(m_triangle[q][k] == lastPoint)
@@ -536,8 +536,8 @@ void TriangleSetTopologyModifier::removePointsProcess(const sofa::helper::vector
 }
 
 
-void TriangleSetTopologyModifier::renumberPointsProcess( const sofa::helper::vector<unsigned int> &index,
-        const sofa::helper::vector<unsigned int> &inv_index,
+void TriangleSetTopologyModifier::renumberPointsProcess( const sofa::helper::vector<PointID> &index,
+        const sofa::helper::vector<PointID> &inv_index,
         const bool renumberDOF)
 {
 
@@ -545,15 +545,15 @@ void TriangleSetTopologyModifier::renumberPointsProcess( const sofa::helper::vec
     {
         if(m_container->hasTrianglesAroundVertex())
         {
-            sofa::helper::vector< sofa::helper::vector< unsigned int > > trianglesAroundVertex_cp = m_container->m_trianglesAroundVertex;
-            for(unsigned int i=0; i<index.size(); ++i)
+            sofa::helper::vector< sofa::helper::vector< TriangleID > > trianglesAroundVertex_cp = m_container->m_trianglesAroundVertex;
+            for(size_t i=0; i<index.size(); ++i)
             {
                 m_container->m_trianglesAroundVertex[i] = trianglesAroundVertex_cp[ index[i] ];
             }
         }
         helper::WriteAccessor< Data< sofa::helper::vector<Triangle> > > m_triangle = m_container->d_triangle;
 
-        for(unsigned int i=0; i<m_triangle.size(); ++i)
+        for(size_t i=0; i<m_triangle.size(); ++i)
         {
             m_triangle[i][0] = inv_index[ m_triangle[i][0] ];
             m_triangle[i][1] = inv_index[ m_triangle[i][1] ];
@@ -568,8 +568,8 @@ void TriangleSetTopologyModifier::renumberPointsProcess( const sofa::helper::vec
 
 
 
-void TriangleSetTopologyModifier::renumberPoints( const sofa::helper::vector<unsigned int> &index,
-        const sofa::helper::vector<unsigned int> &inv_index)
+void TriangleSetTopologyModifier::renumberPoints( const sofa::helper::vector<PointID> &index,
+        const sofa::helper::vector<PointID> &inv_index)
 {
 
     /// add the topological changes in the queue
@@ -584,12 +584,12 @@ void TriangleSetTopologyModifier::renumberPoints( const sofa::helper::vector<uns
 
 
 
-void TriangleSetTopologyModifier::addRemoveTriangles( const unsigned int nTri2Add,
+void TriangleSetTopologyModifier::addRemoveTriangles( const size_t nTri2Add,
         const sofa::helper::vector< Triangle >& triangles2Add,
-        const sofa::helper::vector< unsigned int >& trianglesIndex2Add,
-        const sofa::helper::vector< sofa::helper::vector< unsigned int > > & ancestors,
-        const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs,
-        sofa::helper::vector< unsigned int >& trianglesIndex2remove)
+        const sofa::helper::vector< TriangleID >& trianglesIndex2Add,
+        const sofa::helper::vector< sofa::helper::vector< TriangleID > > & ancestors,
+        const sofa::helper::vector< sofa::helper::vector< SReal > >& baryCoefs,
+        sofa::helper::vector< TriangleID >& trianglesIndex2remove)
 {
 
     // Create all the triangles registered to be created
@@ -607,9 +607,9 @@ void TriangleSetTopologyModifier::addRemoveTriangles( const unsigned int nTri2Ad
 }
 
 
-void TriangleSetTopologyModifier::movePointsProcess (const sofa::helper::vector <unsigned int>& id,
-        const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors,
-        const sofa::helper::vector< sofa::helper::vector< double > >& coefs,
+void TriangleSetTopologyModifier::movePointsProcess (const sofa::helper::vector <PointID>& id,
+        const sofa::helper::vector< sofa::helper::vector< PointID > >& ancestors,
+        const sofa::helper::vector< sofa::helper::vector< SReal > >& coefs,
         const bool moveDOF)
 {
     m_container->setTriangleTopologyToDirty();
@@ -617,20 +617,20 @@ void TriangleSetTopologyModifier::movePointsProcess (const sofa::helper::vector 
     (void)moveDOF;
     const size_t nbrVertex = id.size();
     bool doublet;
-    sofa::helper::vector< unsigned int > trianglesAroundVertex2Move;
+    sofa::helper::vector< TriangleID > trianglesAroundVertex2Move;
     sofa::helper::vector< Triangle > trianglesArray;
 
 
     // Step 1/4 - Creating trianglesAroundVertex to moved due to moved points:
-    for (unsigned int i = 0; i<nbrVertex; ++i)
+    for (size_t i = 0; i<nbrVertex; ++i)
     {
-        const sofa::helper::vector <unsigned int>& trianglesAroundVertex = m_container->getTrianglesAroundVertex( id[i] );
+        const sofa::helper::vector <TriangleID>& trianglesAroundVertex = m_container->getTrianglesAroundVertex( id[i] );
 
-        for (unsigned int j = 0; j<trianglesAroundVertex.size(); ++j)
+        for (size_t j = 0; j<trianglesAroundVertex.size(); ++j)
         {
             doublet = false;
 
-            for (unsigned int k =0; k<trianglesAroundVertex2Move.size(); ++k) //Avoid double
+            for (size_t k =0; k<trianglesAroundVertex2Move.size(); ++k) //Avoid double
             {
                 if (trianglesAroundVertex2Move[k] == trianglesAroundVertex[j])
                 {
@@ -645,7 +645,7 @@ void TriangleSetTopologyModifier::movePointsProcess (const sofa::helper::vector 
         }
     }
 
-    std::sort( trianglesAroundVertex2Move.begin(), trianglesAroundVertex2Move.end(), std::greater<unsigned int>() );
+    std::sort( trianglesAroundVertex2Move.begin(), trianglesAroundVertex2Move.end(), std::greater<TriangleID>() );
 
 
     // Step 2/4 - Create event to delete all elements before moving and propagate it:
@@ -662,7 +662,7 @@ void TriangleSetTopologyModifier::movePointsProcess (const sofa::helper::vector 
     // Step 4/4 - Create event to recompute all elements concerned by moving and propagate it:
 
     // Creating the corresponding array of Triangles for ancestors
-    for (unsigned int i = 0; i<trianglesAroundVertex2Move.size(); i++)
+    for (TriangleID i = 0; i<trianglesAroundVertex2Move.size(); i++)
         trianglesArray.push_back (m_container->getTriangleArray()[ trianglesAroundVertex2Move[i] ]);
 
     TrianglesMoved_Adding *ev2 = new TrianglesMoved_Adding (trianglesAroundVertex2Move, trianglesArray);
@@ -672,13 +672,13 @@ void TriangleSetTopologyModifier::movePointsProcess (const sofa::helper::vector 
 
 
 
-bool TriangleSetTopologyModifier::removeTrianglesPreconditions(const sofa::helper::vector< unsigned int >& items)
+bool TriangleSetTopologyModifier::removeTrianglesPreconditions(const sofa::helper::vector< TriangleID >& items)
 {
     (void)items;
     return true;
 }
 
-void TriangleSetTopologyModifier::removeTrianglesPostProcessing(const sofa::helper::vector< unsigned int >& edgeToBeRemoved, const sofa::helper::vector< unsigned int >& vertexToBeRemoved )
+void TriangleSetTopologyModifier::removeTrianglesPostProcessing(const sofa::helper::vector< TriangleID >& edgeToBeRemoved, const sofa::helper::vector< TriangleID >& vertexToBeRemoved )
 {
     (void)vertexToBeRemoved;
     (void)edgeToBeRemoved;

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyModifier.h
@@ -117,7 +117,7 @@ public:
      *
      * \sa addEdgesProcess
      */
-    void addEdgesWarning(const unsigned int nEdges,
+    void addEdgesWarning(const size_t nEdges,
             const sofa::helper::vector< Edge >& edgesList,
             const sofa::helper::vector< unsigned int >& edgesIndexList) override
     {
@@ -128,7 +128,7 @@ public:
      *
      * \sa addEdgesProcess
      */
-    void addEdgesWarning(const unsigned int nEdges,
+    void addEdgesWarning(const size_t nEdges,
             const sofa::helper::vector< Edge >& edgesList,
             const sofa::helper::vector< unsigned int >& edgesIndexList,
             const sofa::helper::vector< sofa::helper::vector< unsigned int > > & ancestors,

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyModifier.h
@@ -111,7 +111,7 @@ public:
      *
      * \sa addPointsWarning
      */
-    virtual void addPointsProcess(const unsigned int nPoints) override;
+    virtual void addPointsProcess(const size_t nPoints) override;
 
     /** \brief Sends a message to warn that some edges were added in this topology.
      *

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyModifier.h
@@ -77,27 +77,27 @@ public:
     *
     */
     virtual void addTriangles(const sofa::helper::vector< Triangle > &triangles,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > > & ancestors,
-            const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs) ;
+            const sofa::helper::vector< sofa::helper::vector< TriangleID > > & ancestors,
+            const sofa::helper::vector< sofa::helper::vector< SReal > >& baryCoefs) ;
 
 
     /** \brief Sends a message to warn that some triangles were added in this topology.
      *
      * \sa addTrianglesProcess
      */
-    void addTrianglesWarning(const unsigned int nTriangles,
+    void addTrianglesWarning(const size_t nTriangles,
             const sofa::helper::vector< Triangle >& trianglesList,
-            const sofa::helper::vector< unsigned int >& trianglesIndexList) ;
+            const sofa::helper::vector< TriangleID >& trianglesIndexList) ;
 
     /** \brief Sends a message to warn that some triangles were added in this topology.
      *
      * \sa addTrianglesProcess
      */
-    void addTrianglesWarning(const unsigned int nTriangles,
+    void addTrianglesWarning(const size_t nTriangles,
             const sofa::helper::vector< Triangle >& trianglesList,
-            const sofa::helper::vector< unsigned int >& trianglesIndexList,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > > & ancestors,
-            const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs) ;
+            const sofa::helper::vector< TriangleID >& trianglesIndexList,
+            const sofa::helper::vector< sofa::helper::vector< TriangleID > > & ancestors,
+            const sofa::helper::vector< sofa::helper::vector< SReal > >& baryCoefs) ;
 
     /** \brief Effectively add a triangle to the topology.
      */
@@ -119,7 +119,7 @@ public:
      */
     void addEdgesWarning(const size_t nEdges,
             const sofa::helper::vector< Edge >& edgesList,
-            const sofa::helper::vector< unsigned int >& edgesIndexList) override
+            const sofa::helper::vector< EdgeID >& edgesIndexList) override
     {
         EdgeSetTopologyModifier::addEdgesWarning( nEdges, edgesList, edgesIndexList);
     }
@@ -130,9 +130,9 @@ public:
      */
     void addEdgesWarning(const size_t nEdges,
             const sofa::helper::vector< Edge >& edgesList,
-            const sofa::helper::vector< unsigned int >& edgesIndexList,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > > & ancestors,
-            const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs) override
+            const sofa::helper::vector< EdgeID >& edgesIndexList,
+            const sofa::helper::vector< sofa::helper::vector< EdgeID > > & ancestors,
+            const sofa::helper::vector< sofa::helper::vector< SReal > >& baryCoefs) override
     {
         EdgeSetTopologyModifier::addEdgesWarning( nEdges, edgesList, edgesIndexList, ancestors, baryCoefs);
     }
@@ -146,7 +146,7 @@ public:
 
     /** \brief Generic method to remove a list of items.
      */
-    virtual void removeItems(const sofa::helper::vector< unsigned int >& items) override;
+    virtual void removeItems(const sofa::helper::vector< TriangleID >& items) override;
 
     /** \brief Remove a set  of triangles
         @param triangles an array of triangle indices to be removed (note that the array is not const since it needs to be sorted)
@@ -155,7 +155,7 @@ public:
         @param removeIsolatedPoints if true isolated vertices are also removed
         *
         */
-    virtual void removeTriangles(const sofa::helper::vector< unsigned int >& triangleIds,
+    virtual void removeTriangles(const sofa::helper::vector< TriangleID >& triangleIds,
             const bool removeIsolatedEdges,
             const bool removeIsolatedPoints);
 
@@ -166,7 +166,7 @@ public:
      *
      * Important : parameter indices is not const because it is actually sorted from the highest index to the lowest one.
      */
-    virtual void removeTrianglesWarning(sofa::helper::vector<unsigned int> &triangles);
+    virtual void removeTrianglesWarning(sofa::helper::vector<TriangleID> &triangles);
 
 
     /** \brief Remove a subset of  triangles. Eventually remove isolated edges and vertices
@@ -177,7 +177,7 @@ public:
      * @param removeIsolatedEdges if true isolated edges are also removed
      * @param removeIsolatedPoints if true isolated vertices are also removed
      */
-    virtual void removeTrianglesProcess( const sofa::helper::vector<unsigned int> &indices,
+    virtual void removeTrianglesProcess( const sofa::helper::vector<TriangleID> &indices,
             const bool removeIsolatedEdges=false,
             const bool removeIsolatedPoints=false);
 
@@ -197,12 +197,12 @@ public:
      * @param baryCoefs - their barycoefs related to these ancestors.
      * @param trianglesIndex2remove - List of triangle indices to remove.
      */
-    virtual void addRemoveTriangles(const unsigned int nTri2Add,
+    virtual void addRemoveTriangles(const size_t nTri2Add,
             const sofa::helper::vector< Triangle >& triangles2Add,
-            const sofa::helper::vector< unsigned int >& trianglesIndex2Add,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > > & ancestors,
-            const sofa::helper::vector< sofa::helper::vector< double > >& baryCoefs,
-            sofa::helper::vector< unsigned int >& trianglesIndex2remove);
+            const sofa::helper::vector< TriangleID >& trianglesIndex2Add,
+            const sofa::helper::vector< sofa::helper::vector< TriangleID > > & ancestors,
+            const sofa::helper::vector< sofa::helper::vector< SReal > >& baryCoefs,
+            sofa::helper::vector< TriangleID >& trianglesIndex2remove);
 
 
 
@@ -214,7 +214,7 @@ public:
      * @param removeIsolatedItems if true isolated vertices are also removed
      * Important : parameter indices is not const because it is actually sorted from the highest index to the lowest one.
      */
-    virtual void removeEdgesProcess( const sofa::helper::vector<unsigned int> &indices,
+    virtual void removeEdgesProcess( const sofa::helper::vector<EdgeID> &indices,
             const bool removeIsolatedItems=false) override;
 
 
@@ -226,7 +226,7 @@ public:
      * \sa removePointsWarning
      * Important : the points are actually deleted from the mechanical object's state vectors iff (removeDOF == true)
      */
-    virtual void removePointsProcess(const sofa::helper::vector<unsigned int> &indices,
+    virtual void removePointsProcess(const sofa::helper::vector<PointID> &indices,
             const bool removeDOF = true) override;
 
 
@@ -235,15 +235,15 @@ public:
      * Important : the points are actually renumbered in the mechanical object's state vectors iff (renumberDOF == true)
      * \see MechanicalObject::renumberValues
      */
-    virtual void renumberPointsProcess( const sofa::helper::vector<unsigned int> &index,
-            const sofa::helper::vector<unsigned int> &inv_index,
+    virtual void renumberPointsProcess( const sofa::helper::vector<PointID> &index,
+            const sofa::helper::vector<PointID> &inv_index,
             const bool renumberDOF = true) override;
 
 
     /** \brief Generic method for points renumbering
      */
-    virtual void renumberPoints( const sofa::helper::vector<unsigned int> &index,
-            const sofa::helper::vector<unsigned int> &inv_index) override;
+    virtual void renumberPoints( const sofa::helper::vector<PointID> &index,
+            const sofa::helper::vector<PointID> &inv_index) override;
 
 
     /** \brief Move input points indices to input new coords.
@@ -254,9 +254,9 @@ public:
      * @param coefs : barycoef to locate new coord relatively to ancestors.
      * @moveDOF bool allowing the move (default true)
      */
-    virtual void movePointsProcess (const sofa::helper::vector <unsigned int>& id,
-            const sofa::helper::vector< sofa::helper::vector< unsigned int > >& ancestors,
-            const sofa::helper::vector< sofa::helper::vector< double > >& coefs,
+    virtual void movePointsProcess (const sofa::helper::vector < PointID >& id,
+            const sofa::helper::vector< sofa::helper::vector< PointID > >& ancestors,
+            const sofa::helper::vector< sofa::helper::vector< SReal > >& coefs,
             const bool moveDOF = true) override;
 
 
@@ -265,13 +265,13 @@ protected:
     /** \brief Precondition to fulfill before removing triangles. No preconditions are needed in this class. This function should be inplemented in children classes.
      *
      */
-    virtual bool removeTrianglesPreconditions(const sofa::helper::vector< unsigned int >& items);
+    virtual bool removeTrianglesPreconditions(const sofa::helper::vector< TriangleID >& items);
 
 
     /**\brief: Postprocessing to apply to topology triangles. Nothing to do in this class. This function should be inplemented in children classes.
      *
      */
-    virtual void removeTrianglesPostProcessing(const sofa::helper::vector< unsigned int >& edgeToBeRemoved, const sofa::helper::vector< unsigned int >& vertexToBeRemoved );
+    virtual void removeTrianglesPostProcessing(const sofa::helper::vector< TriangleID >& edgeToBeRemoved, const sofa::helper::vector< TriangleID >& vertexToBeRemoved );
 
 
     /** \brief Precondition to fulfill before adding triangles. No preconditions are needed in this class. This function should be inplemented in children classes.
@@ -285,7 +285,7 @@ protected:
      */
     virtual void addTrianglesPostProcessing(const sofa::helper::vector <Triangle>& triangles);
 
-    Data<sofa::helper::vector <unsigned int> > list_Out; ///< triangles with at least one null values.
+    Data<sofa::helper::vector <TriangleID> > list_Out; ///< triangles with at least one null values.
 private:
     TriangleSetTopologyContainer*	m_container;
 };

--- a/modules/SofaExporter/MeshExporter.cpp
+++ b/modules/SofaExporter/MeshExporter.cpp
@@ -151,14 +151,14 @@ bool MeshExporter::writeMesh()
 
 std::string MeshExporter::getMeshFilename(const char* ext)
 {
-    int nbp = d_position.getValue().size();
-    unsigned int nbce;
+    size_t nbp = d_position.getValue().size();
+    size_t nbce;
     nbce = ( (d_writeEdges.getValue()) ? m_inputtopology->getNbEdges() : 0 )
             + ( (d_writeTriangles.getValue()) ? m_inputtopology->getNbTriangles() : 0 )
             + ( (d_writeQuads.getValue()) ? m_inputtopology->getNbQuads() : 0 )
             + ( (d_writeTetras.getValue()) ? m_inputtopology->getNbTetras() : 0 )
             + ( (d_writeHexas.getValue()) ? m_inputtopology->getNbHexas() : 0 );
-    unsigned int nbe = 0;
+    size_t nbe = 0;
     nbe = ( (d_writeTetras.getValue()) ? m_inputtopology->getNbTetras() : 0 )
             + ( (d_writeHexas.getValue()) ? m_inputtopology->getNbHexas() : 0 );
     if (!nbe)
@@ -215,9 +215,9 @@ bool MeshExporter::writeMeshVTKXML()
 
     helper::ReadAccessor<Data<defaulttype::Vec3Types::VecCoord> > pointsPos = d_position;
 
-    const int nbp = pointsPos.size();
+    const size_t nbp = pointsPos.size();
 
-    unsigned int numberOfCells;
+    size_t numberOfCells;
     numberOfCells = ( (d_writeEdges.getValue()) ? m_inputtopology->getNbEdges() : 0 )
             +( (d_writeTriangles.getValue()) ? m_inputtopology->getNbTriangles() : 0 )
             +( (d_writeQuads.getValue()) ? m_inputtopology->getNbQuads() : 0 )
@@ -246,28 +246,28 @@ bool MeshExporter::writeMeshVTKXML()
     outfile << "        <DataArray type=\"Int32\" Name=\"connectivity\" format=\"ascii\">\n";
     if (d_writeEdges.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbEdges() ; i++)
+        for (unsigned int i=0 ; i<m_inputtopology->getNbEdges() ; i++)
             outfile << "          " << m_inputtopology->getEdge(i) << "\n";
     }
 
     if (d_writeTriangles.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbTriangles() ; i++)
+        for (unsigned int i=0 ; i<m_inputtopology->getNbTriangles() ; i++)
             outfile << "          " <<  m_inputtopology->getTriangle(i) << "\n";
     }
     if (d_writeQuads.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbQuads() ; i++)
+        for (unsigned int i=0 ; i<m_inputtopology->getNbQuads() ; i++)
             outfile << "          " << m_inputtopology->getQuad(i) << "\n";
     }
     if (d_writeTetras.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbTetras() ; i++)
+        for (unsigned int i=0 ; i<m_inputtopology->getNbTetras() ; i++)
             outfile << "          " <<  m_inputtopology->getTetra(i) << "\n";
     }
     if (d_writeHexas.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbHexas() ; i++)
+        for (unsigned int i=0 ; i<m_inputtopology->getNbHexas() ; i++)
             outfile << "          " <<  m_inputtopology->getHexa(i) << "\n";
     }
     outfile << "        </DataArray>\n";
@@ -277,7 +277,7 @@ bool MeshExporter::writeMeshVTKXML()
     outfile << "          ";
     if (d_writeEdges.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbEdges() ; i++)
+        for (unsigned int i=0 ; i<m_inputtopology->getNbEdges() ; i++)
         {
             num += 2;
             outfile << num << ' ';
@@ -285,7 +285,7 @@ bool MeshExporter::writeMeshVTKXML()
     }
     if (d_writeTriangles.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbTriangles() ; i++)
+        for (unsigned int i=0 ; i<m_inputtopology->getNbTriangles() ; i++)
         {
             num += 3;
             outfile << num << ' ';
@@ -293,7 +293,7 @@ bool MeshExporter::writeMeshVTKXML()
     }
     if (d_writeQuads.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbQuads() ; i++)
+        for (unsigned int i=0 ; i<m_inputtopology->getNbQuads() ; i++)
         {
             num += 4;
             outfile << num << ' ';
@@ -301,7 +301,7 @@ bool MeshExporter::writeMeshVTKXML()
     }
     if (d_writeTetras.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbTetras() ; i++)
+        for (unsigned int i=0 ; i<m_inputtopology->getNbTetras() ; i++)
         {
             num += 4;
             outfile << num << ' ';
@@ -309,7 +309,7 @@ bool MeshExporter::writeMeshVTKXML()
     }
     if (d_writeHexas.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbHexas() ; i++)
+        for (unsigned int i=0 ; i<m_inputtopology->getNbHexas() ; i++)
         {
             num += 6;
             outfile << num << ' ';
@@ -322,27 +322,27 @@ bool MeshExporter::writeMeshVTKXML()
     outfile << "          ";
     if (d_writeEdges.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbEdges() ; i++)
+        for (size_t i=0 ; i<m_inputtopology->getNbEdges() ; i++)
             outfile << 3 << ' ';
     }
     if (d_writeTriangles.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbTriangles() ; i++)
+        for (size_t i=0 ; i<m_inputtopology->getNbTriangles() ; i++)
             outfile << 5 << ' ';
     }
     if (d_writeQuads.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbQuads() ; i++)
+        for (size_t i=0 ; i<m_inputtopology->getNbQuads() ; i++)
             outfile << 9 << ' ';
     }
     if (d_writeTetras.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbTetras() ; i++)
+        for (size_t i=0 ; i<m_inputtopology->getNbTetras() ; i++)
             outfile << 10 << ' ';
     }
     if (d_writeHexas.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbHexas() ; i++)
+        for (size_t i=0 ; i<m_inputtopology->getNbHexas() ; i++)
             outfile << 12 << ' ';
     }
     outfile << "\n";
@@ -376,7 +376,7 @@ bool MeshExporter::writeMeshVTK()
 
     helper::ReadAccessor<Data<defaulttype::Vec3Types::VecCoord> > pointsPos = d_position;
 
-    const int nbp = pointsPos.size();
+    const size_t nbp = pointsPos.size();
 
     //Write header
     outfile << "# vtk DataFile Version 2.0\n";
@@ -399,7 +399,7 @@ bool MeshExporter::writeMeshVTK()
     }
 
     //Write Cells
-    unsigned int numberOfCells, totalSize;
+    size_t numberOfCells, totalSize;
     numberOfCells = ( (d_writeEdges.getValue()) ? m_inputtopology->getNbEdges() : 0 )
             +( (d_writeTriangles.getValue()) ? m_inputtopology->getNbTriangles() : 0 )
             +( (d_writeQuads.getValue()) ? m_inputtopology->getNbQuads() : 0 )
@@ -416,29 +416,29 @@ bool MeshExporter::writeMeshVTK()
 
     if (d_writeEdges.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbEdges() ; i++)
+        for (unsigned int i=0 ; i<m_inputtopology->getNbEdges() ; i++)
             outfile << 2 << ' ' << m_inputtopology->getEdge(i) << "\n";
     }
 
     if (d_writeTriangles.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbTriangles() ; i++)
+        for (unsigned int i=0 ; i<m_inputtopology->getNbTriangles() ; i++)
             outfile << 3 << ' ' <<  m_inputtopology->getTriangle(i) << "\n";
     }
     if (d_writeQuads.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbQuads() ; i++)
+        for (unsigned int i=0 ; i<m_inputtopology->getNbQuads() ; i++)
             outfile << 4 << ' ' << m_inputtopology->getQuad(i) << "\n";
     }
 
     if (d_writeTetras.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbTetras() ; i++)
+        for (unsigned int i=0 ; i<m_inputtopology->getNbTetras() ; i++)
             outfile << 4 << ' ' <<  m_inputtopology->getTetra(i) << "\n";
     }
     if (d_writeHexas.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbHexas() ; i++)
+        for (unsigned int i=0 ; i<m_inputtopology->getNbHexas() ; i++)
             outfile << 8 << ' ' <<  m_inputtopology->getHexa(i) << "\n";
     }
 
@@ -446,29 +446,29 @@ bool MeshExporter::writeMeshVTK()
 
     if (d_writeEdges.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbEdges() ; i++)
+        for (size_t i=0 ; i<m_inputtopology->getNbEdges() ; i++)
             outfile << 3 << "\n";
     }
 
     if (d_writeTriangles.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbTriangles() ; i++)
+        for (size_t i=0 ; i<m_inputtopology->getNbTriangles() ; i++)
             outfile << 5 << "\n";
     }
     if (d_writeQuads.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbQuads() ; i++)
+        for (size_t i=0 ; i<m_inputtopology->getNbQuads() ; i++)
             outfile << 9 << "\n";
     }
 
     if (d_writeTetras.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbTetras() ; i++)
+        for (size_t i=0 ; i<m_inputtopology->getNbTetras() ; i++)
             outfile << 10 << "\n";
     }
     if (d_writeHexas.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbHexas() ; i++)
+        for (size_t i=0 ; i<m_inputtopology->getNbHexas() ; i++)
             outfile << 12 << "\n";
     }
     msg_info() << filename << " written. " ;
@@ -495,7 +495,7 @@ bool MeshExporter::writeMeshGmsh()
 
     helper::ReadAccessor<Data<defaulttype::Vec3Types::VecCoord> > pointsPos = d_position;
 
-    const int nbp = pointsPos.size();
+    const size_t nbp = pointsPos.size();
 
     //Write header
     outfile << "$MeshFormat\n";
@@ -515,7 +515,7 @@ bool MeshExporter::writeMeshGmsh()
 
     //Write Cells
     outfile << "$Elements\n";
-    unsigned int numberOfCells/*, totalSize*/;
+    size_t numberOfCells/*, totalSize*/;
     numberOfCells = ( (d_writeEdges.getValue()) ? m_inputtopology->getNbEdges() : 0 )
             +( (d_writeTriangles.getValue()) ? m_inputtopology->getNbTriangles() : 0 )
             +( (d_writeQuads.getValue()) ? m_inputtopology->getNbQuads() : 0 )
@@ -532,7 +532,7 @@ bool MeshExporter::writeMeshGmsh()
     unsigned int elem = 0;
     if (d_writeEdges.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbEdges() ; i++)
+        for (unsigned int i=0 ; i<m_inputtopology->getNbEdges() ; i++)
         {
             outfile << ++elem << ' ' << 1 << ' ' << 0;
             sofa::core::topology::BaseMeshTopology::Edge t = m_inputtopology->getEdge(i);
@@ -544,7 +544,7 @@ bool MeshExporter::writeMeshGmsh()
 
     if (d_writeTriangles.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbTriangles() ; i++)
+        for (unsigned int i=0 ; i<m_inputtopology->getNbTriangles() ; i++)
         {
             outfile << ++elem << ' ' << 2 << ' ' << 0;
             sofa::core::topology::BaseMeshTopology::Triangle t = m_inputtopology->getTriangle(i);
@@ -555,7 +555,7 @@ bool MeshExporter::writeMeshGmsh()
     }
     if (d_writeQuads.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbQuads() ; i++)
+        for (unsigned int i=0 ; i<m_inputtopology->getNbQuads() ; i++)
         {
             outfile << ++elem << ' ' << 3 << ' ' << 0;
             sofa::core::topology::BaseMeshTopology::Quad t = m_inputtopology->getQuad(i);
@@ -567,7 +567,7 @@ bool MeshExporter::writeMeshGmsh()
 
     if (d_writeTetras.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbTetras() ; i++)
+        for (unsigned int i=0 ; i<m_inputtopology->getNbTetras() ; i++)
         {
             outfile << ++elem << ' ' << 4 << ' ' << 0;
             sofa::core::topology::BaseMeshTopology::Tetra t = m_inputtopology->getTetra(i);
@@ -578,7 +578,7 @@ bool MeshExporter::writeMeshGmsh()
     }
     if (d_writeHexas.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbHexas() ; i++)
+        for (unsigned int i=0 ; i<m_inputtopology->getNbHexas() ; i++)
         {
             outfile << ++elem << ' ' << 5 << ' ' << 0;
             sofa::core::topology::BaseMeshTopology::Hexa t = m_inputtopology->getHexa(i);
@@ -612,7 +612,7 @@ bool MeshExporter::writeMeshNetgen()
 
     helper::ReadAccessor<Data<defaulttype::Vec3Types::VecCoord> > pointsPos = d_position;
 
-    const int nbp = pointsPos.size();
+    const size_t nbp = pointsPos.size();
 
     //Write Points
     outfile << nbp << "\n";
@@ -625,7 +625,7 @@ bool MeshExporter::writeMeshNetgen()
     outfile << ((d_writeTetras.getValue()) ? m_inputtopology->getNbTetras() : 0) << "\n";
     if (d_writeTetras.getValue())
     {
-        for (int i=0 ; i<m_inputtopology->getNbTetras() ; i++)
+        for (unsigned int i=0 ; i<m_inputtopology->getNbTetras() ; i++)
         {
             sofa::core::topology::BaseMeshTopology::Tetra t = m_inputtopology->getTetra(i);
             outfile << 0; // subdomain
@@ -636,7 +636,7 @@ bool MeshExporter::writeMeshNetgen()
     }
 
     //Write Surface Elements
-    int nbtri = 0;
+    size_t nbtri = 0;
     if (d_writeTriangles.getValue())
     {
         if (m_inputtopology->getNbTetras() == 0)
@@ -645,7 +645,7 @@ bool MeshExporter::writeMeshNetgen()
         }
         else
         {
-            for (int i=0; i<m_inputtopology->getNbTriangles(); ++i)
+            for (unsigned int i=0; i<m_inputtopology->getNbTriangles(); ++i)
             {
                 if (m_inputtopology->getTetrahedraAroundTriangle(i).size() < 2)
                     ++nbtri;
@@ -657,7 +657,7 @@ bool MeshExporter::writeMeshNetgen()
     {
         if (m_inputtopology->getNbTetras() == 0)
         {
-            for (int i=0 ; i<m_inputtopology->getNbTriangles() ; i++)
+            for (unsigned int i=0 ; i<m_inputtopology->getNbTriangles() ; i++)
             {
                 sofa::core::topology::BaseMeshTopology::Triangle t = m_inputtopology->getTriangle(i);
                 outfile << 0; // subdomain
@@ -668,7 +668,7 @@ bool MeshExporter::writeMeshNetgen()
         }
         else
         {
-            for (int i=0; i<m_inputtopology->getNbTriangles(); ++i)
+            for (unsigned int i=0; i<m_inputtopology->getNbTriangles(); ++i)
             {
                 if (m_inputtopology->getTetrahedraAroundTriangle(i).size() < 2)
                     ++nbtri;
@@ -706,7 +706,7 @@ bool MeshExporter::writeMeshTetgen()
 
     // Write Points
 
-    const int nbp = pointsPos.size();
+    const size_t nbp = pointsPos.size();
 
     // http://tetgen.berlios.de/fformats.node.html
     // <# of points> <dimension (must be 3)> <# of attributes> <# of boundary markers (0 or 1)>
@@ -737,7 +737,7 @@ bool MeshExporter::writeMeshTetgen()
         // <tetrahedron #> <node> <node> <node> <node> ... [attributes]
         if (d_writeTetras.getValue())
         {
-            for (int i=0 ; i<m_inputtopology->getNbTetras() ; i++)
+            for (unsigned int i=0 ; i<m_inputtopology->getNbTetras() ; i++)
             {
                 sofa::core::topology::BaseMeshTopology::Tetra t = m_inputtopology->getTetra(i);
                 // check tetra inversion
@@ -768,7 +768,7 @@ bool MeshExporter::writeMeshTetgen()
             msg_error() << "Unable to create file '"<<filename << "'";
             return false;
         }
-        int nbtri = 0;
+        size_t nbtri = 0;
         if (d_writeTriangles.getValue())
         {
             if (m_inputtopology->getNbTetras() == 0)
@@ -777,7 +777,7 @@ bool MeshExporter::writeMeshTetgen()
             }
             else
             {
-                for (int i=0; i<m_inputtopology->getNbTriangles(); ++i)
+                for (unsigned int i=0; i<m_inputtopology->getNbTriangles(); ++i)
                 {
                     if (m_inputtopology->getTetrahedraAroundTriangle(i).size() < 2)
                         ++nbtri;
@@ -789,7 +789,7 @@ bool MeshExporter::writeMeshTetgen()
         // <face #> <node> <node> <node> [boundary marker]
         if (m_inputtopology->getNbTetras() == 0)
         {
-            for (int i=0 ; i<m_inputtopology->getNbTriangles() ; i++)
+            for (unsigned int i=0 ; i<m_inputtopology->getNbTriangles() ; i++)
             {
                 sofa::core::topology::BaseMeshTopology::Triangle t = m_inputtopology->getTriangle(i);
                 outfile << 1+i; // id
@@ -800,7 +800,7 @@ bool MeshExporter::writeMeshTetgen()
         }
         else
         {
-            for (int i=0; i<m_inputtopology->getNbTriangles(); ++i)
+            for (unsigned int i=0; i<m_inputtopology->getNbTriangles(); ++i)
             {
                 if (m_inputtopology->getTetrahedraAroundTriangle(i).size() < 2)
                     ++nbtri;

--- a/modules/SofaExporter/VTKExporter.cpp
+++ b/modules/SofaExporter/VTKExporter.cpp
@@ -407,7 +407,7 @@ void VTKExporter::writeVTKSimple()
 
     helper::ReadAccessor<Data<defaulttype::Vec3Types::VecCoord> > pointsPos = position;
 
-    const int nbp = (!pointsPos.empty()) ? pointsPos.size() : topology->getNbPoints();
+    const size_t nbp = (!pointsPos.empty()) ? pointsPos.size() : topology->getNbPoints();
 
     //Write header
     *outfile << "# vtk DataFile Version 2.0" << std::endl;
@@ -450,7 +450,7 @@ void VTKExporter::writeVTKSimple()
     *outfile << std::endl;
 
     //Write Cells
-    unsigned int numberOfCells, totalSize;
+    size_t numberOfCells, totalSize;
     numberOfCells = ( (writeEdges.getValue()) ? topology->getNbEdges() : 0 )
             +( (writeTriangles.getValue()) ? topology->getNbTriangles() : 0 )
             +( (writeQuads.getValue()) ? topology->getNbQuads() : 0 )
@@ -467,29 +467,29 @@ void VTKExporter::writeVTKSimple()
 
     if (writeEdges.getValue())
     {
-        for (int i=0 ; i<topology->getNbEdges() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbEdges() ; i++)
             *outfile << 2 << " " << topology->getEdge(i) << std::endl;
     }
 
     if (writeTriangles.getValue())
     {
-        for (int i=0 ; i<topology->getNbTriangles() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbTriangles() ; i++)
             *outfile << 3 << " " <<  topology->getTriangle(i) << std::endl;
     }
     if (writeQuads.getValue())
     {
-        for (int i=0 ; i<topology->getNbQuads() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbQuads() ; i++)
             *outfile << 4 << " " << topology->getQuad(i) << std::endl;
     }
 
     if (writeTetras.getValue())
     {
-        for (int i=0 ; i<topology->getNbTetras() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbTetras() ; i++)
             *outfile << 4 << " " <<  topology->getTetra(i) << std::endl;
     }
     if (writeHexas.getValue())
     {
-        for (int i=0 ; i<topology->getNbHexas() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbHexas() ; i++)
             *outfile << 8 << " " <<  topology->getHexa(i) << std::endl;
     }
 
@@ -499,29 +499,29 @@ void VTKExporter::writeVTKSimple()
 
     if (writeEdges.getValue())
     {
-        for (int i=0 ; i<topology->getNbEdges() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbEdges() ; i++)
             *outfile << 3 << std::endl;
     }
 
     if (writeTriangles.getValue())
     {
-        for (int i=0 ; i<topology->getNbTriangles() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbTriangles() ; i++)
             *outfile << 5 << std::endl;
     }
     if (writeQuads.getValue())
     {
-        for (int i=0 ; i<topology->getNbQuads() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbQuads() ; i++)
             *outfile << 9 << std::endl;
     }
 
     if (writeTetras.getValue())
     {
-        for (int i=0 ; i<topology->getNbTetras() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbTetras() ; i++)
             *outfile << 10 << std::endl;
     }
     if (writeHexas.getValue())
     {
-        for (int i=0 ; i<topology->getNbHexas() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbHexas() ; i++)
             *outfile << 12 << std::endl;
     }
 
@@ -579,9 +579,9 @@ void VTKExporter::writeVTKXML()
 
     helper::ReadAccessor<Data<defaulttype::Vec3Types::VecCoord> > pointsPos = position;
 
-    const int nbp = (!pointsPos.empty()) ? pointsPos.size() : topology->getNbPoints();
+    const size_t nbp = (!pointsPos.empty()) ? pointsPos.size() : topology->getNbPoints();
 
-    unsigned int numberOfCells;
+    size_t numberOfCells;
     numberOfCells = ( (writeEdges.getValue()) ? topology->getNbEdges() : 0 )
             +( (writeTriangles.getValue()) ? topology->getNbTriangles() : 0 )
             +( (writeQuads.getValue()) ? topology->getNbQuads() : 0 )
@@ -651,28 +651,28 @@ void VTKExporter::writeVTKXML()
     *outfile << "        <DataArray type=\"Int32\" Name=\"connectivity\" format=\"ascii\">" << std::endl;
     if (writeEdges.getValue())
     {
-        for (int i=0 ; i<topology->getNbEdges() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbEdges() ; i++)
             *outfile << "          " << topology->getEdge(i) << std::endl;
     }
 
     if (writeTriangles.getValue())
     {
-        for (int i=0 ; i<topology->getNbTriangles() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbTriangles() ; i++)
             *outfile << "          " <<  topology->getTriangle(i) << std::endl;
     }
     if (writeQuads.getValue())
     {
-        for (int i=0 ; i<topology->getNbQuads() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbQuads() ; i++)
             *outfile << "          " << topology->getQuad(i) << std::endl;
     }
     if (writeTetras.getValue())
     {
-        for (int i=0 ; i<topology->getNbTetras() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbTetras() ; i++)
             *outfile << "          " <<  topology->getTetra(i) << std::endl;
     }
     if (writeHexas.getValue())
     {
-        for (int i=0 ; i<topology->getNbHexas() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbHexas() ; i++)
             *outfile << "          " <<  topology->getHexa(i) << std::endl;
     }
     *outfile << "        </DataArray>" << std::endl;
@@ -682,7 +682,7 @@ void VTKExporter::writeVTKXML()
     *outfile << "          ";
     if (writeEdges.getValue())
     {
-        for (int i=0 ; i<topology->getNbEdges() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbEdges() ; i++)
         {
             num += 2;
             *outfile << num << " ";
@@ -690,7 +690,7 @@ void VTKExporter::writeVTKXML()
     }
     if (writeTriangles.getValue())
     {
-        for (int i=0 ; i<topology->getNbTriangles() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbTriangles() ; i++)
         {
             num += 3;
             *outfile << num << " ";
@@ -698,7 +698,7 @@ void VTKExporter::writeVTKXML()
     }
     if (writeQuads.getValue())
     {
-        for (int i=0 ; i<topology->getNbQuads() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbQuads() ; i++)
         {
             num += 4;
             *outfile << num << " ";
@@ -706,7 +706,7 @@ void VTKExporter::writeVTKXML()
     }
     if (writeTetras.getValue())
     {
-        for (int i=0 ; i<topology->getNbTetras() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbTetras() ; i++)
         {
             num += 4;
             *outfile << num << " ";
@@ -714,7 +714,7 @@ void VTKExporter::writeVTKXML()
     }
     if (writeHexas.getValue())
     {
-        for (int i=0 ; i<topology->getNbHexas() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbHexas() ; i++)
         {
             num += 8;
             *outfile << num << " ";
@@ -727,27 +727,27 @@ void VTKExporter::writeVTKXML()
     *outfile << "          ";
     if (writeEdges.getValue())
     {
-        for (int i=0 ; i<topology->getNbEdges() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbEdges() ; i++)
             *outfile << 3 << " ";
     }
     if (writeTriangles.getValue())
     {
-        for (int i=0 ; i<topology->getNbTriangles() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbTriangles() ; i++)
             *outfile << 5 << " ";
     }
     if (writeQuads.getValue())
     {
-        for (int i=0 ; i<topology->getNbQuads() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbQuads() ; i++)
             *outfile << 9 << " ";
     }
     if (writeTetras.getValue())
     {
-        for (int i=0 ; i<topology->getNbTetras() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbTetras() ; i++)
             *outfile << 10 << " ";
     }
     if (writeHexas.getValue())
     {
-        for (int i=0 ; i<topology->getNbHexas() ; i++)
+        for (unsigned int i=0 ; i<topology->getNbHexas() ; i++)
             *outfile << 12 << " ";
     }
     *outfile << std::endl;

--- a/modules/SofaGeneralDeformable/FastTriangularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/FastTriangularBendingSprings.inl
@@ -325,7 +325,7 @@ void FastTriangularBendingSprings<DataTypes>::TriangularBSEdgeHandler::applyPoin
     if(ff)
     {
         helper::vector<EdgeSpring>& edgeInf = *(ff->edgeSprings.beginEdit());
-        for (int i = 0; i < ff->_topology->getNbEdges(); ++i)
+        for (unsigned int i = 0; i < ff->_topology->getNbEdges(); ++i)
         {
             if(edgeInf[i].is_activated)
             {
@@ -398,9 +398,9 @@ void FastTriangularBendingSprings<DataTypes>::reinit()
     /// prepare to store info in the edge array
     helper::vector<EdgeSpring>& edgeInf = *(edgeSprings.beginEdit());
     edgeInf.resize(_topology->getNbEdges());
-    int i;
+
     // set edge tensor to 0
-    for (i=0; i<_topology->getNbEdges(); ++i)
+    for (unsigned int i=0; i<_topology->getNbEdges(); ++i)
     {
 
         edgeHandler->applyCreateFunction(i, edgeInf[i],
@@ -410,7 +410,7 @@ void FastTriangularBendingSprings<DataTypes>::reinit()
 
     // create edge tensor by calling the triangle creation function
     sofa::helper::vector<unsigned int> triangleAdded;
-    for (i=0; i<_topology->getNbTriangles(); ++i)
+    for (unsigned int i=0; i<_topology->getNbTriangles(); ++i)
         triangleAdded.push_back(i);
 
     edgeHandler->applyTriangleCreation(triangleAdded,

--- a/modules/SofaGeneralDeformable/QuadularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/QuadularBendingSprings.inl
@@ -461,7 +461,7 @@ void QuadularBendingSprings<DataTypes>::EdgeBSHandler::applyPointRenumbering(con
     if(ff)
     {
         helper::vector<EdgeInformation>& edgeInf = *(ff->edgeInfo.beginEdit());
-        for ( int i = 0; i < ff->_topology->getNbEdges(); ++i)
+        for (unsigned  int i = 0; i < ff->_topology->getNbEdges(); ++i)
         {
             if(edgeInf[i].is_activated)
             {
@@ -534,7 +534,7 @@ void QuadularBendingSprings<DataTypes>::init()
     edgeInf.resize(_topology->getNbEdges());
 
     // set edge tensor to 0
-    for (int i=0; i<_topology->getNbEdges(); ++i)
+    for (unsigned int i=0; i<_topology->getNbEdges(); ++i)
     {
         edgeHandler->applyCreateFunction(i, edgeInf[i],
                 _topology->getEdge(i),  (const sofa::helper::vector< unsigned int > )0,
@@ -543,7 +543,7 @@ void QuadularBendingSprings<DataTypes>::init()
 
     // create edge tensor by calling the quad creation function
     sofa::helper::vector<unsigned int> quadAdded;
-    for (int i=0; i<_topology->getNbQuads(); ++i)
+    for (unsigned int i=0; i<_topology->getNbQuads(); ++i)
         quadAdded.push_back(i);
 
     edgeHandler->applyQuadCreation(quadAdded,
@@ -597,7 +597,7 @@ void QuadularBendingSprings<DataTypes>::addForce(const core::MechanicalParams* /
     const VecCoord& x = d_x.getValue();
     const VecDeriv& v = d_v.getValue();
 
-    int nbEdges=_topology->getNbEdges();
+    size_t nbEdges=_topology->getNbEdges();
 
     EdgeInformation *einfo;
 
@@ -609,7 +609,7 @@ void QuadularBendingSprings<DataTypes>::addForce(const core::MechanicalParams* /
     m_potentialEnergy = 0;
     /*        serr<<"QuadularBendingSprings<DataTypes>::addForce()"<<sendl;*/
 
-    for(int i=0; i<nbEdges; i++ )
+    for(unsigned int i=0; i<nbEdges; i++ )
     {
         einfo=&edgeInf[i];
 
@@ -730,7 +730,7 @@ void QuadularBendingSprings<DataTypes>::addDForce(const core::MechanicalParams* 
     const VecDeriv& dx = d_dx.getValue();
     Real kFactor = (Real)mparams->kFactorIncludingRayleighDamping(this->rayleighStiffness.getValue());
 
-    int nbEdges=_topology->getNbEdges();
+    size_t nbEdges=_topology->getNbEdges();
 
     const EdgeInformation *einfo;
 
@@ -741,7 +741,7 @@ void QuadularBendingSprings<DataTypes>::addDForce(const core::MechanicalParams* 
     //serr<<"QuadularBendingSprings<DataTypes>::addDForce, df1 before = "<<f1<<sendl;
     //const helper::vector<Spring>& springs = this->springs.getValue();
 
-    for(int i=0; i<nbEdges; i++ )
+    for(unsigned int i=0; i<nbEdges; i++ )
     {
         einfo=&edgeInf[i];
 
@@ -870,7 +870,7 @@ void QuadularBendingSprings<DataTypes>::draw(const core::visual::VisualParams* v
 
     ////
     vertices.clear();
-    for(int i=0; i<_topology->getNbQuads(); ++i)
+    for(unsigned int i=0; i<_topology->getNbQuads(); ++i)
     {
         for(unsigned int j = 0 ; j<4 ; j++)
             vertices.push_back(x[_topology->getQuad(i)[j]]);

--- a/modules/SofaGeneralDeformable/TriangularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/TriangularBendingSprings.inl
@@ -427,7 +427,7 @@ void TriangularBendingSprings<DataTypes>::TriangularBSEdgeHandler::applyPointRen
     if(ff)
     {
         helper::vector<EdgeInformation>& edgeInf = *(ff->edgeInfo.beginEdit());
-        for (int i = 0; i < ff->_topology->getNbEdges(); ++i)
+        for (unsigned int i = 0; i < ff->_topology->getNbEdges(); ++i)
         {
             if(edgeInf[i].is_activated)
             {
@@ -503,7 +503,7 @@ void TriangularBendingSprings<DataTypes>::reinit()
     /// prepare to store info in the edge array
     helper::vector<EdgeInformation>& edgeInf = *(edgeInfo.beginEdit());
     edgeInf.resize(_topology->getNbEdges());
-    int i;
+    unsigned int i;
     // set edge tensor to 0
     for (i=0; i<_topology->getNbEdges(); ++i)
     {
@@ -541,7 +541,7 @@ void TriangularBendingSprings<DataTypes>::addForce(const core::MechanicalParams*
     const VecCoord& x = d_x.getValue();
     const VecDeriv& v = d_v.getValue();
 
-    int nbEdges=_topology->getNbEdges();
+    size_t nbEdges=_topology->getNbEdges();
     EdgeInformation *einfo;
     helper::vector<EdgeInformation>& edgeInf = *(edgeInfo.beginEdit());
 
@@ -555,7 +555,7 @@ void TriangularBendingSprings<DataTypes>::addForce(const core::MechanicalParams*
     const VecCoord& x_rest = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
 #endif
 
-    for(int i=0; i<nbEdges; i++ )
+    for(unsigned int i=0; i<nbEdges; i++ )
     {
         einfo=&edgeInf[i];
 
@@ -664,7 +664,7 @@ void TriangularBendingSprings<DataTypes>::addDForce(const core::MechanicalParams
     const VecDeriv& dx = d_dx.getValue();
     Real kFactor = (Real)mparams->kFactorIncludingRayleighDamping(this->rayleighStiffness.getValue());
 
-    int nbEdges=_topology->getNbEdges();
+    size_t nbEdges=_topology->getNbEdges();
     const EdgeInformation *einfo;
     const helper::vector<EdgeInformation>& edgeInf = edgeInfo.getValue();
 
@@ -673,7 +673,7 @@ void TriangularBendingSprings<DataTypes>::addDForce(const core::MechanicalParams
     //serr<<"TriangularBendingSprings<DataTypes>::addDForce, df1 before = "<<f1<<sendl;
     //const helper::vector<Spring>& springs = this->springs.getValue();
 
-    for(int i=0; i<nbEdges; i++ )
+    for(unsigned int i=0; i<nbEdges; i++ )
     {
         einfo=&edgeInf[i];
 

--- a/modules/SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.inl
+++ b/modules/SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.inl
@@ -208,7 +208,7 @@ template <class DataTypes> void TriangularBiquadraticSpringsForceField<DataTypes
         const VecCoord& p = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
         _initialPoints.setValue(p);
     }
-    int i;
+    unsigned int i;
     for (i=0; i<_topology->getNbEdges(); ++i)
     {
         edgeHandler->applyCreateFunction(i,edgeInf[i], _topology->getEdge(i),  (const sofa::helper::vector< unsigned int > )0,
@@ -242,8 +242,8 @@ void TriangularBiquadraticSpringsForceField<DataTypes>::addForce(const core::Mec
     const VecDeriv& v = d_v.getValue();
 
     unsigned int j,k,l,v0,v1;
-    int nbEdges=_topology->getNbEdges();
-    int nbTriangles=_topology->getNbTriangles();
+    size_t nbEdges=_topology->getNbEdges();
+    size_t nbTriangles=_topology->getNbTriangles();
     bool compressible=f_compressible.getValue();
     Real areaStiffness=(getLambda()+getMu())*3;
 
@@ -262,7 +262,7 @@ void TriangularBiquadraticSpringsForceField<DataTypes>::addForce(const core::Mec
     Real _dampingRatio=f_dampingRatio.getValue();
 
 
-    for(int i=0; i<nbEdges; i++ )
+    for(unsigned int i=0; i<nbEdges; i++ )
     {
         einfo=&edgeInf[i];
         v0=_topology->getEdge(i)[0];
@@ -281,7 +281,7 @@ void TriangularBiquadraticSpringsForceField<DataTypes>::addForce(const core::Mec
     {
         Real JJ;
         std::vector<int> flippedTriangles ;
-        for(int i=0; i<nbTriangles; i++ )
+        for(unsigned int i=0; i<nbTriangles; i++ )
         {
             tinfo=&triangleInf[i];
             /// describe the jth edge index of triangle no i
@@ -544,7 +544,7 @@ void TriangularBiquadraticSpringsForceField<DataTypes>::draw(const core::visual:
         vparams->drawTool()->setPolygonMode(0, true);
 
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
-    int nbTriangles=_topology->getNbTriangles();
+    size_t nbTriangles=_topology->getNbTriangles();
 
     std::vector<sofa::defaulttype::Vector3> vertices;
     std::vector<sofa::defaulttype::Vec4f> colors;
@@ -552,7 +552,7 @@ void TriangularBiquadraticSpringsForceField<DataTypes>::draw(const core::visual:
 
     vparams->drawTool()->disableLighting();
 
-    for(int i=0; i<nbTriangles; ++i)
+    for(unsigned int i=0; i<nbTriangles; ++i)
     {
         int a = _topology->getTriangle(i)[0];
         int b = _topology->getTriangle(i)[1];

--- a/modules/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.inl
+++ b/modules/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.inl
@@ -194,7 +194,7 @@ template <class DataTypes> void TriangularQuadraticSpringsForceField<DataTypes>:
         const VecCoord& p = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
         _initialPoints.setValue(p);
     }
-    int i;
+    unsigned int i;
     for (i=0; i<_topology->getNbEdges(); ++i)
     {
         edgeHandler->applyCreateFunction(i, edgeInf[i],
@@ -219,8 +219,8 @@ void TriangularQuadraticSpringsForceField<DataTypes>::addForce(const core::Mecha
     const VecDeriv& v = d_v.getValue();
 
     unsigned int j,k,l,v0,v1;
-    int nbEdges=_topology->getNbEdges();
-    int nbTriangles=_topology->getNbTriangles();
+    size_t nbEdges=_topology->getNbEdges();
+    size_t nbTriangles=_topology->getNbTriangles();
 
     Real val,L;
     TriangleRestInformation *tinfo;
@@ -237,7 +237,7 @@ void TriangularQuadraticSpringsForceField<DataTypes>::addForce(const core::Mecha
     Real _dampingRatio=f_dampingRatio.getValue();
 
 
-    for(int i=0; i<nbEdges; i++ )
+    for(unsigned int i=0; i<nbEdges; i++ )
     {
         einfo=&edgeInf[i];
         v0=_topology->getEdge(i)[0];
@@ -254,7 +254,7 @@ void TriangularQuadraticSpringsForceField<DataTypes>::addForce(const core::Mecha
     }
     if (f_useAngularSprings.getValue()==true)
     {
-        for(int i=0; i<nbTriangles; i++ )
+        for(unsigned int i=0; i<nbTriangles; i++ )
         {
             tinfo=&triangleInf[i];
             /// describe the jth edge index of triangle no i
@@ -433,14 +433,14 @@ void TriangularQuadraticSpringsForceField<DataTypes>::draw(const core::visual::V
         vparams->drawTool()->setPolygonMode(0, true);
 
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
-    int nbTriangles=_topology->getNbTriangles();
+    size_t nbTriangles=_topology->getNbTriangles();
     std::vector<sofa::defaulttype::Vector3> vertices;
     std::vector<sofa::defaulttype::Vec4f> colors;
     std::vector<sofa::defaulttype::Vector3> normals;
 
     vparams->drawTool()->disableLighting();
 
-    for(int i=0; i<nbTriangles; ++i)
+    for(unsigned int i=0; i<nbTriangles; ++i)
     {
         int a = _topology->getTriangle(i)[0];
         int b = _topology->getTriangle(i)[1];

--- a/modules/SofaGeneralDeformable/TriangularTensorMassForceField.inl
+++ b/modules/SofaGeneralDeformable/TriangularTensorMassForceField.inl
@@ -308,7 +308,7 @@ template <class DataTypes> void TriangularTensorMassForceField<DataTypes>::init(
         _initialPoints=p;
     }
 
-    int i;
+    unsigned int i;
     // set edge tensor to 0
     for (i=0; i<_topology->getNbEdges(); ++i)
     {
@@ -375,7 +375,7 @@ void TriangularTensorMassForceField<DataTypes>::addDForce(const core::Mechanical
     Real kFactor = (Real)mparams->kFactorIncludingRayleighDamping(this->rayleighStiffness.getValue());
 
     unsigned int v0,v1;
-    int nbEdges=_topology->getNbEdges();
+    size_t nbEdges=_topology->getNbEdges();
     EdgeRestInformation *einfo;
 
     helper::vector<EdgeRestInformation>& edgeInf = *(edgeInfo.beginEdit());
@@ -383,7 +383,7 @@ void TriangularTensorMassForceField<DataTypes>::addDForce(const core::Mechanical
     Deriv force;
     Coord dp0,dp1,dp;
 
-    for(int i=0; i<nbEdges; i++ )
+    for(unsigned int i=0; i<nbEdges; i++ )
     {
         einfo=&edgeInf[i];
         v0=_topology->getEdge(i)[0];
@@ -422,7 +422,7 @@ void TriangularTensorMassForceField<DataTypes>::draw(const core::visual::VisualP
         vparams->drawTool()->setPolygonMode(0, true);
 
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
-    int nbTriangles=_topology->getNbTriangles();
+    size_t nbTriangles=_topology->getNbTriangles();
 
     std::vector<sofa::defaulttype::Vector3> vertices;
     std::vector<sofa::defaulttype::Vec4f> colors;
@@ -430,7 +430,7 @@ void TriangularTensorMassForceField<DataTypes>::draw(const core::visual::VisualP
 
     vparams->drawTool()->disableLighting();
 
-    for(int i=0; i<nbTriangles; ++i)
+    for(unsigned int i=0; i<nbTriangles; ++i)
     {
         int a = _topology->getTriangle(i)[0];
         int b = _topology->getTriangle(i)[1];

--- a/modules/SofaGeneralDeformable/VectorSpringForceField.inl
+++ b/modules/SofaGeneralDeformable/VectorSpringForceField.inl
@@ -240,7 +240,7 @@ void VectorSpringForceField<DataTypes>::createDefaultSprings()
     //EdgeLengthArrayInterface<Real,DataTypes> elai(springArray);
     //edgeGEO->computeEdgeLength(elai);
     const VecCoord& x0 = this->mstate1->read(core::ConstVecCoordId::restPosition())->getValue();
-    int i;
+    unsigned int i;
     for (i=0; i<_topology->getNbEdges(); ++i)
     {
         springArrayData[i].ks=(Real)m_stiffness.getValue();
@@ -301,7 +301,7 @@ void VectorSpringForceField<DataTypes>::addForce(const core::MechanicalParams* /
     {
 
         Deriv force;
-        for (int i=0; i<_topology->getNbEdges(); i++)
+        for (unsigned int i=0; i<_topology->getNbEdges(); i++)
         {
             const core::topology::BaseMeshTopology::Edge &e=_topology->getEdge(i);
             const Spring &s=springArrayData[i];
@@ -359,7 +359,7 @@ void VectorSpringForceField<DataTypes>::addDForce(const core::MechanicalParams* 
     if(useTopology)
     {
 
-        for (int i=0; i<_topology->getNbEdges(); i++)
+        for (unsigned int i=0; i<_topology->getNbEdges(); i++)
         {
             const core::topology::BaseMeshTopology::Edge &e=_topology->getEdge(i);
             const Spring &s=springArrayData[i];
@@ -436,7 +436,7 @@ void VectorSpringForceField<DataTypes>::updateForceMask()
 {
     if(useTopology)
     {
-        for (int i=0; i<_topology->getNbEdges(); i++)
+        for (unsigned int i=0; i<_topology->getNbEdges(); i++)
         {
             const core::topology::BaseMeshTopology::Edge &e=_topology->getEdge(i);
             this->mstate1->forceMask.insertEntry(e[0]);

--- a/modules/SofaMiscTopology/TopologicalChangeProcessor.cpp
+++ b/modules/SofaMiscTopology/TopologicalChangeProcessor.cpp
@@ -325,7 +325,7 @@ bool TopologicalChangeProcessor::readNext(double time, std::vector<std::string>&
             buf[0] = '\0';
             while (gzgets(gzfile,buf,sizeof(buf))!=NULL && buf[0])
             {
-                int l = strlen(buf);
+                size_t l = strlen(buf);
                 if (buf[l-1] == '\n')
                 {
                     buf[l-1] = '\0';
@@ -378,7 +378,7 @@ void TopologicalChangeProcessor::processTopologicalChanges()
     std::vector<std::string> validLines;
     if (!readNext(time, validLines)) return;
 
-    unsigned int nbElements = 0;
+    size_t nbElements = 0;
     for (std::vector<std::string>::iterator it=validLines.begin(); it!=validLines.end();)
     {
         //For one Timestep store all topology data available.
@@ -421,7 +421,7 @@ void TopologicalChangeProcessor::processTopologicalChanges()
                 helper::vector < unsigned int > triangles;
                 triangles.resize(nbElements);
 
-                for(unsigned int i=0;i<nbElements;++i)
+                for(size_t i=0;i<nbElements;++i)
                 {
                     Sin >> triangles[i];
                     Vector2& baryCoord = baryCoords[i];
@@ -431,7 +431,7 @@ void TopologicalChangeProcessor::processTopologicalChanges()
 
                 helper::vector< helper::vector< unsigned int > > p_ancestors(nbElements);
                 sofa::helper::vector< helper::vector< double > > p_baryCoefs(nbElements);
-                for(unsigned int i=0; i<nbElements; ++i)
+                for(size_t i=0; i<nbElements; ++i)
                 {
                     helper::vector<unsigned int>& ancestor = p_ancestors[i];
                     ancestor.resize(3);
@@ -462,7 +462,7 @@ void TopologicalChangeProcessor::processTopologicalChanges()
                 helper::vector<core::topology::Topology::Edge > vitems;
                 vitems.resize (nbElements);
 
-                for (unsigned int i = 0; i<nbElements; ++i)
+                for (size_t i = 0; i<nbElements; ++i)
                     Sin >> vitems[i][0] >> vitems[i][1];
 
                 topoMod->addEdges(vitems);
@@ -480,7 +480,7 @@ void TopologicalChangeProcessor::processTopologicalChanges()
                     str >> token;
                     if(token == "Ancestors" || token == "Ancestor")
                     {
-                        for(unsigned int i = 0; i<nbElements; ++i)
+                        for(size_t i = 0; i<nbElements; ++i)
                         {
                             helper::vector<unsigned int>& ancestor = p_ancestors[i];
                             ancestor.resize(1);
@@ -501,7 +501,7 @@ void TopologicalChangeProcessor::processTopologicalChanges()
                 helper::vector<core::topology::Topology::Triangle > vitems;
                 vitems.resize (nbElements);
 
-                for (unsigned int i = 0; i<nbElements; ++i)
+                for (size_t i = 0; i<nbElements; ++i)
                     Sin >> vitems[i][0] >> vitems[i][1] >> vitems[i][2];
 
                 if(!p_ancestors.empty())
@@ -527,7 +527,7 @@ void TopologicalChangeProcessor::processTopologicalChanges()
                 helper::vector<core::topology::Topology::Quad > vitems;
                 vitems.resize (nbElements);
 
-                for (unsigned int i = 0; i<nbElements; ++i)
+                for (size_t i = 0; i<nbElements; ++i)
                     Sin >> vitems[i][0] >> vitems[i][1] >> vitems[i][2] >> vitems[i][3];
 
                 topoMod->addQuads(vitems);
@@ -546,7 +546,7 @@ void TopologicalChangeProcessor::processTopologicalChanges()
                 helper::vector<core::topology::Topology::Tetrahedron > vitems;
                 vitems.resize (nbElements);
 
-                for (unsigned int i = 0; i<nbElements; ++i)
+                for (size_t i = 0; i<nbElements; ++i)
                     Sin >> vitems[i][0] >> vitems[i][1] >> vitems[i][2] >> vitems[i][3];
 
                 topoMod->addTetrahedra(vitems);
@@ -565,7 +565,7 @@ void TopologicalChangeProcessor::processTopologicalChanges()
                 helper::vector<core::topology::Topology::Hexahedron > vitems;
                 vitems.resize (nbElements);
 
-                for (unsigned int i = 0; i<nbElements; ++i)
+                for (size_t i = 0; i<nbElements; ++i)
                     Sin >> vitems[i][0] >> vitems[i][1] >> vitems[i][2] >> vitems[i][3]
                         >> vitems[i][4] >> vitems[i][5] >> vitems[i][6] >> vitems[i][7];
 
@@ -594,7 +594,7 @@ void TopologicalChangeProcessor::processTopologicalChanges()
             helper::vector <unsigned int> vitems;
             vitems.resize (nbElements);
 
-            for (unsigned int i = 0; i<nbElements; ++i)
+            for (size_t i = 0; i<nbElements; ++i)
                 Sin >> vitems[i];
 
             topoMod->removeItems(vitems);
@@ -660,7 +660,7 @@ void TopologicalChangeProcessor::processTopologicalChanges()
                 findElementIndex(a, ind_ta, -1);
             }
 
-            for (unsigned int i = 1; i < nbElements; ++i)
+            for (size_t i = 1; i < nbElements; ++i)
             {
                 if (!onlyCoordinates)
                 {
@@ -771,7 +771,7 @@ void TopologicalChangeProcessor::saveIndices()
     }
 
     //filter only the lines about incision and put them in the linesAboutIncision
-    for (unsigned int i = 0 ; i < listInTheFile.size() ; i++)
+    for (size_t i = 0 ; i < listInTheFile.size() ; i++)
     {
         std::string currentString(listInTheFile[i]);
 
@@ -855,7 +855,7 @@ void TopologicalChangeProcessor::saveIndices()
 
         unsigned int increment = ( onlyCoordinates ) ? 3 : 4; // 3 if only the coordinates, 4 if there is also a triangle index
 
-        for (unsigned int i = 0 ; i < values.size() ; i+=increment)
+        for (size_t i = 0 ; i < values.size() ; i+=increment)
         {
             Vector3 coord;
             int triangleIndex;
@@ -905,7 +905,7 @@ void TopologicalChangeProcessor::saveIndices()
      * The hack consists in gently modify the first point of the line if both the points are equal (within epsilon)
      * Note : the crash is due to the computeIntersectedObjectsList algorithm in TriangleSetGeometryAlgorithm
      * */
-    for ( unsigned int i = 0 ; i < triangleIncisionInformation.size() ; i++)
+    for ( size_t i = 0 ; i < triangleIncisionInformation.size() ; i++)
     {
         triangleIncisionInformation[i].computeCoordinates(m_topology);
         if ( i )
@@ -955,7 +955,7 @@ void TopologicalChangeProcessor::saveIndices()
 int TopologicalChangeProcessor::findIndexInListOfTime(Real time)
 {
     double epsilon = 1e-10;
-    for (unsigned int i = 0 ; i < triangleIncisionInformation.size() ; i++)
+    for (size_t i = 0 ; i < triangleIncisionInformation.size() ; i++)
     {
         if ( fabs(time - triangleIncisionInformation[i].timeToIncise) < epsilon )
         {
@@ -965,7 +965,7 @@ int TopologicalChangeProcessor::findIndexInListOfTime(Real time)
     return -1;
 }
 
-std::vector<Real> TopologicalChangeProcessor::getValuesInLine(std::string line, unsigned int nbElements)
+std::vector<Real> TopologicalChangeProcessor::getValuesInLine(std::string line, size_t nbElements)
 {
     std::vector<Real> values;
     values.clear();
@@ -1034,7 +1034,7 @@ void  TopologicalChangeProcessor::findElementIndex(Vector3 coord, int& triangleI
         return;
 
     //get the number of triangle in the topology
-    unsigned int nbTriangle = m_topology->getNbTriangles();
+    size_t nbTriangle = m_topology->getNbTriangles();
 
     sofa::component::topology::TriangleSetTopologyAlgorithms<Vec3Types>* triangleAlg;
     m_topology->getContext()->get(triangleAlg);
@@ -1080,7 +1080,7 @@ void  TopologicalChangeProcessor::findElementIndex(Vector3 coord, int& triangleI
     std::vector<unsigned int> finalTriIndices;
     finalTriIndices.clear();
 
-    for (unsigned int i = 0 ; i < triIndices.size() ; i++)
+    for (size_t i = 0 ; i < triIndices.size() ; i++)
     {
         const bool is_tested = false;
         unsigned int indTest = 0;
@@ -1168,7 +1168,7 @@ void  TopologicalChangeProcessor::findElementIndex(Vector3 coord, int& triangleI
 
     //TODO(dmarchal 2017-05-03) So what ? Can we remove this ?
     //beastly way
-//                for( unsigned int i = 0 ; i < nbTriangle ; i++)
+//                for( size_t i = 0 ; i < nbTriangle ; i++)
 //                {
 //                    bool isPointInTriangle = false;
 //
@@ -1202,7 +1202,7 @@ void TopologicalChangeProcessor::inciseWithSavedIndices()
     {
         std::stringstream tmp ;
         tmp <<" Unable to find a time index with time " <<  getContext()->getTime() << ". The possible values are ";
-        for (unsigned int i = 0 ; i < triangleIncisionInformation.size() ; i++)
+        for (size_t i = 0 ; i < triangleIncisionInformation.size() ; i++)
             tmp << triangleIncisionInformation[i].timeToIncise << " | ";
         tmp << ". Aborting." ;
         msg_error() << tmp.str() ;
@@ -1219,7 +1219,7 @@ void TopologicalChangeProcessor::inciseWithSavedIndices()
     bool firstCut= true;
 
     std::vector<Vector3> coordinates;
-    for (unsigned int i = 0 ; i < triangleIncisionInformation.size() ; i++)
+    for (size_t i = 0 ; i < triangleIncisionInformation.size() ; i++)
     {
         if ( (int) i == indexOfTime)
             coordinates = triangleIncisionInformation[indexOfTime].computeCoordinates(m_topology);
@@ -1249,7 +1249,7 @@ void TopologicalChangeProcessor::inciseWithSavedIndices()
     a = coordinates[0];
 
     unsigned int ind_tb = 0;
-    for (unsigned int i =1; i < triangleIncisionInformation[indexOfTime].triangleIndices.size(); ++i)
+    for (size_t i =1; i < triangleIncisionInformation[indexOfTime].triangleIndices.size(); ++i)
     {
         ind_tb = triangleIncisionInformation[indexOfTime].triangleIndices[i];
 
@@ -1335,11 +1335,11 @@ void TopologicalChangeProcessor::inciseWithSavedIndices()
  */
 void TopologicalChangeProcessor::updateTriangleIncisionInformation()
 {
-    unsigned int nbTriangleInfo = triangleIncisionInformation.size();
+    size_t nbTriangleInfo = triangleIncisionInformation.size();
     sofa::component::topology::TriangleSetGeometryAlgorithms<Vec3Types>* triangleGeo;
     m_topology->getContext()->get(triangleGeo);
 
-    for ( unsigned int i = 0 ; i < nbTriangleInfo ; i++)
+    for ( size_t i = 0 ; i < nbTriangleInfo ; i++)
     {
         for (unsigned int j = 0 ; j < triangleIncisionInformation[i].triangleIndices.size() ; j++ )
         {
@@ -1393,14 +1393,14 @@ void TopologicalChangeProcessor::draw(const core::visual::VisualParams* vparams)
     if (!triangleGeo)
         return;
 
-    unsigned int nbTriangles = m_topology->getNbTriangles();
+    size_t nbTriangles = m_topology->getNbTriangles();
 
     std::vector< Vector3 > trianglesToDraw;
     std::vector< Vector3 > pointsToDraw;
 
-    for (unsigned int i = 0 ; i < triangleIncisionInformation.size() ; i++)
+    for (size_t i = 0 ; i < triangleIncisionInformation.size() ; i++)
     {
-        for (unsigned int j = 0 ; j < triangleIncisionInformation[i].triangleIndices.size() ; j++)
+        for (size_t j = 0 ; j < triangleIncisionInformation[i].triangleIndices.size() ; j++)
         {
             unsigned int triIndex = triangleIncisionInformation[i].triangleIndices[j];
 
@@ -1431,7 +1431,7 @@ void TopologicalChangeProcessor::draw(const core::visual::VisualParams* vparams)
         /* initialize random seed: */
         srand ( (unsigned int)time(NULL) );
 
-        for (unsigned int i = 0 ; i < errorTrianglesIndices.size() ; i++)
+        for (size_t i = 0 ; i < errorTrianglesIndices.size() ; i++)
         {
             Vec3Types::Coord coord[3];
             triangleGeo->getTriangleVertexCoordinates(errorTrianglesIndices[i], coord);

--- a/modules/SofaMiscTopology/TopologicalChangeProcessor.h
+++ b/modules/SofaMiscTopology/TopologicalChangeProcessor.h
@@ -143,7 +143,7 @@ public:
 
 protected:
 
-    std::vector<Real> getValuesInLine(std::string line, unsigned int nbElements);
+    std::vector<Real> getValuesInLine(std::string line, size_t nbElements);
 
     void findElementIndex(defaulttype::Vector3 coord, int& triangleIndex, int oldTriangleIndex);
     void saveIndices();//only for incision

--- a/modules/SofaTopologyMapping/CenterPointTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/CenterPointTopologicalMapping.cpp
@@ -90,7 +90,7 @@ void CenterPointTopologicalMapping::updateTopologicalMappingTopDown()
             {
             case core::topology::HEXAHEDRAADDED:
             {
-                const unsigned int nbHexaAdded = ( static_cast< const HexahedraAdded *>( *changeIt ) )->getNbAddedHexahedra();
+                const size_t nbHexaAdded = ( static_cast< const HexahedraAdded *>( *changeIt ) )->getNbAddedHexahedra();
                 to_pstm->addPointsProcess(nbHexaAdded);
                 to_pstm->addPointsWarning(nbHexaAdded, true);
                 to_pstm->propagateTopologicalChanges();

--- a/modules/SofaTopologyMapping/Edge2QuadTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/Edge2QuadTopologicalMapping.cpp
@@ -167,7 +167,7 @@ void Edge2QuadTopologicalMapping::init()
             if(edgeList.getValue().size()==0)
             {
 
-                int nb_elems = toModel->getNbQuads();
+                unsigned int nb_elems = (unsigned int)toModel->getNbQuads();
 
                 for (unsigned int i=0; i<edgeArray.size(); ++i)
                 {
@@ -200,7 +200,7 @@ void Edge2QuadTopologicalMapping::init()
                         }
 
                         Loc2GlobVec.push_back(i);
-                        out_info.push_back(Loc2GlobVec.size()-1);
+                        out_info.push_back((unsigned int)Loc2GlobVec.size()-1);
                     }
 
 
@@ -233,7 +233,7 @@ void Edge2QuadTopologicalMapping::init()
                         else
                             to_tstm->addQuadProcess(Quad((unsigned int) q0, (unsigned int) q1, (unsigned int) q2, (unsigned int) q3));
                         Loc2GlobVec.push_back(i);
-                        out_info.push_back(Loc2GlobVec.size()-1);
+                        out_info.push_back((unsigned int)Loc2GlobVec.size()-1);
                     }
 
                     In2OutMap[i]=out_info;
@@ -306,7 +306,7 @@ void Edge2QuadTopologicalMapping::updateTopologicalMappingTopDown()
 
                         sofa::helper::vector< Quad > quads_to_create;
                         sofa::helper::vector< unsigned int > quadsIndexList;
-                        int nb_elems = toModel->getNbQuads();
+                        unsigned int nb_elems = (unsigned int)toModel->getNbQuads();
 
                         for (unsigned int i = 0; i < tab.size(); ++i)
                         {
@@ -335,7 +335,7 @@ void Edge2QuadTopologicalMapping::updateTopologicalMappingTopDown()
                                 nb_elems+=1;
 
                                 Loc2GlobVec.push_back(k);
-                                out_info.push_back(Loc2GlobVec.size()-1);
+                                out_info.push_back((unsigned int)Loc2GlobVec.size()-1);
 
                                 //to_tstm->addQuadsProcess(quads_to_create) ;
                                 //to_tstm->addQuadsWarning(quads_to_create.size(), quads_to_create, quadsIndexList) ;
@@ -360,12 +360,12 @@ void Edge2QuadTopologicalMapping::updateTopologicalMappingTopDown()
 
                         const sofa::helper::vector<unsigned int> &tab = ( static_cast< const EdgesRemoved *>( *itBegin ) )->getArray();
 
-                        int last= fromModel->getNbEdges() - 1;
+                        unsigned int last = (unsigned int)fromModel->getNbEdges() - 1;
 
                         unsigned int ind_tmp;
 
                         sofa::helper::vector<unsigned int> ind_real_last;
-                        int ind_last=toModel->getNbQuads();
+                        unsigned int ind_last = (unsigned int)toModel->getNbQuads();
 
                         for (unsigned int i = 0; i < tab.size(); ++i)
                         {
@@ -514,7 +514,7 @@ void Edge2QuadTopologicalMapping::updateTopologicalMappingTopDown()
 
                     const sofa::component::topology::PointsAdded *ta=static_cast< const sofa::component::topology::PointsAdded * >( *itBegin );
 
-                    unsigned int to_nVertices = ta->getNbAddedVertices() * N;
+                    unsigned int to_nVertices = (unsigned int)ta->getNbAddedVertices() * N;
                     sofa::helper::vector< sofa::helper::vector< unsigned int > > to_ancestorsList;
                     sofa::helper::vector< sofa::helper::vector< double > > to_coefs;
 

--- a/modules/SofaTopologyMapping/Hexa2QuadTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/Hexa2QuadTopologicalMapping.cpp
@@ -124,7 +124,7 @@ void Hexa2QuadTopologicalMapping::init()
                     to_tstm->addQuadProcess(q);
 
                     Loc2GlobVec.push_back(i);
-                    Glob2LocMap[i]=Loc2GlobVec.size()-1;
+                    Glob2LocMap[i]= (unsigned int)Loc2GlobVec.size()-1;
                 }
             }
 
@@ -189,17 +189,14 @@ void Hexa2QuadTopologicalMapping::updateTopologicalMappingTopDown()
                 {
                     //sout << "INFO_print : Hexa2QuadTopologicalMapping - QUADSREMOVED" << sendl;
 
-                    int last;
-                    int ind_last;
-
-                    last= fromModel->getNbQuads() - 1;
+                    unsigned int last = (unsigned int)fromModel->getNbQuads() - 1;
+                    unsigned int ind_last = (unsigned int)toModel->getNbQuads();
 
                     const sofa::helper::vector<unsigned int> &tab = ( static_cast< const QuadsRemoved *>( *itBegin ) )->getArray();
 
                     unsigned int ind_tmp;
 
                     unsigned int ind_real_last;
-                    ind_last=toModel->getNbQuads();
 
                     for (unsigned int i = 0; i <tab.size(); ++i)
                     {
@@ -284,7 +281,7 @@ void Hexa2QuadTopologicalMapping::updateTopologicalMappingTopDown()
 
                         sofa::helper::vector< core::topology::BaseMeshTopology::Quad > quads_to_create;
                         sofa::helper::vector< unsigned int > quadsIndexList;
-                        int nb_elems = toModel->getNbQuads();
+                        unsigned int nb_elems = (unsigned int)toModel->getNbQuads();
                         const bool flipN = flipNormals.getValue();
 
                         for (unsigned int i = 0; i < tab.size(); ++i)
@@ -359,7 +356,7 @@ void Hexa2QuadTopologicalMapping::updateTopologicalMappingTopDown()
                                             sout << "INFO_print : Hexa2QuadTopologicalMapping - fail to add quad " << k << " which already exists" << sendl;
                                             Glob2LocMap.erase(Glob2LocMap.find(k));
                                         }
-                                        Glob2LocMap[k]=Loc2GlobVec.size()-1;
+                                        Glob2LocMap[k]=(unsigned int)Loc2GlobVec.size()-1;
                                     }
                                 }
                             }

--- a/modules/SofaTopologyMapping/Hexa2TetraTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/Hexa2TetraTopologicalMapping.cpp
@@ -101,7 +101,7 @@ void Hexa2TetraTopologicalMapping::init()
             Loc2GlobVec.clear();
             Glob2LocMap.clear();
 
-            int nbcubes = fromModel->getNbHexahedra();
+            size_t nbcubes = fromModel->getNbHexahedra();
 
             // These values are only correct if the mesh is a grid topology
             int nx = 2;
@@ -178,7 +178,7 @@ void Hexa2TetraTopologicalMapping::init()
                 }
                 for(int j=0; j<6; j++)
                     Loc2GlobVec.push_back(i);
-                Glob2LocMap[i]=Loc2GlobVec.size()-1;
+                Glob2LocMap[i] = (unsigned int)Loc2GlobVec.size()-1;
             }
 
             //to_tstm->propagateTopologicalChanges();

--- a/modules/SofaTopologyMapping/Mesh2PointTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/Mesh2PointTopologicalMapping.cpp
@@ -118,7 +118,7 @@ void Mesh2PointTopologicalMapping::init()
                 pointsMappedFrom[POINT].resize(fromModel->getNbPoints());
                 for (int i=0; i<fromModel->getNbPoints(); i++)
                 {
-                    toModelLastPointIndex+=addInputPoint(i);
+                    toModelLastPointIndex+=(int)addInputPoint((unsigned int)i);
                 }
             }
 
@@ -277,7 +277,7 @@ void Mesh2PointTopologicalMapping::init()
 }
 
 /// Check consistency of internal maps and output topology
-bool Mesh2PointTopologicalMapping::internalCheck(const char* step, const helper::fixed_array <int, NB_ELEMENTS >& nbInputRemoved)
+bool Mesh2PointTopologicalMapping::internalCheck(const char* step, const helper::fixed_array <size_t, NB_ELEMENTS >& nbInputRemoved)
 {
     bool ok = true;
     unsigned int nbPOut = (unsigned int)toModel->getNbPoints();
@@ -286,13 +286,13 @@ bool Mesh2PointTopologicalMapping::internalCheck(const char* step, const helper:
         serr << "Internal Error after " << step << ": pointSource size " << pointSource.size() << " != output topology size " << nbPOut << sendl;
         ok = false;
     }
-    unsigned int nbPMapped = 0;
+    size_t nbPMapped = 0;
     for (int type=0; type<NB_ELEMENTS; ++type)
     {
         const vector< vector<int> >& pointsMapped = pointsMappedFrom[type];
         std::string typestr;
-        unsigned int nbEIn = 0;
-        unsigned int nbEPOut = 0;
+        size_t nbEIn = 0;
+        size_t nbEPOut = 0;
         switch (type)
         {
         case POINT :    typestr="Point";    nbEIn = fromModel->getNbPoints();     nbEPOut = pointBaryCoords.getValue().size(); break;
@@ -410,7 +410,7 @@ size_t Mesh2PointTopologicalMapping::addInputPoint(unsigned int i, PointSetTopol
     
     for (unsigned int j = 0; j < pBaryCoords.size(); j++)
     {        
-        pointsMappedFrom[POINT][i].push_back(pointSource.size());
+        pointsMappedFrom[POINT][i].push_back((unsigned int)pointSource.size());
         pointSource.push_back(std::make_pair(POINT, i));
     }
     
@@ -440,7 +440,7 @@ void Mesh2PointTopologicalMapping::addInputEdge(unsigned int i, PointSetTopology
 
     for (unsigned int j = 0; j < eBaryCoords.size(); j++)
     {
-        pointsMappedFrom[EDGE][i].push_back(pointSource.size());
+        pointsMappedFrom[EDGE][i].push_back((unsigned int)pointSource.size());
         pointSource.push_back(std::make_pair(EDGE, i));
     }
 
@@ -484,7 +484,7 @@ void Mesh2PointTopologicalMapping::addInputTriangle(unsigned int i, PointSetTopo
 
     for (unsigned int j = 0; j < tBaryCoords.size(); j++)
     {
-        pointsMappedFrom[TRIANGLE][i].push_back(pointSource.size());
+        pointsMappedFrom[TRIANGLE][i].push_back((unsigned int)pointSource.size());
         pointSource.push_back(std::make_pair(TRIANGLE,i));
     }
 
@@ -531,7 +531,7 @@ void Mesh2PointTopologicalMapping::addInputTetrahedron(unsigned int i, PointSetT
 
     for (unsigned int j = 0; j < tBaryCoords.size(); j++)
     {
-        pointsMappedFrom[TETRA][i].push_back(pointSource.size());
+        pointsMappedFrom[TETRA][i].push_back((unsigned int)pointSource.size());
         pointSource.push_back(std::make_pair(TETRA,i));
     }
 
@@ -576,7 +576,7 @@ void Mesh2PointTopologicalMapping::updateTopologicalMappingTopDown()
         //HexahedronSetTopologyModifier *toHexahedronMod = NULL;
         toModel->getContext()->get(toPointMod, sofa::core::objectmodel::BaseContext::Local);
         bool check = false;
-        helper::fixed_array <int, NB_ELEMENTS > nbInputRemoved;
+        helper::fixed_array <size_t, NB_ELEMENTS > nbInputRemoved;
         nbInputRemoved.assign(0);
         std::string laststep = "";
         while( changeIt != itEnd )
@@ -875,7 +875,7 @@ void Mesh2PointTopologicalMapping::swapInput(Element elem, int i1, int i2)
 void Mesh2PointTopologicalMapping::removeInput(Element elem,  const sofa::helper::vector<unsigned int>& index )
 {
     if (pointsMappedFrom[elem].empty()) return;
-    unsigned int last = pointsMappedFrom[elem].size() -1;
+    unsigned int last = (unsigned int)pointsMappedFrom[elem].size() -1;
 
     for (unsigned int i = 0; i < index.size(); ++i)
     {
@@ -950,7 +950,7 @@ void Mesh2PointTopologicalMapping::swapOutputPoints(int i1, int i2, bool removeL
 
 void Mesh2PointTopologicalMapping::removeOutputPoints( const sofa::helper::vector<unsigned int>& index )
 {
-    unsigned int last = pointSource.size() - 1;
+    unsigned int last = (unsigned int)pointSource.size() - 1;
 
     for (unsigned int i = 0; i < index.size(); ++i)
     {

--- a/modules/SofaTopologyMapping/Mesh2PointTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/Mesh2PointTopologicalMapping.cpp
@@ -126,7 +126,7 @@ void Mesh2PointTopologicalMapping::init()
             if (!edgeBaryCoords.getValue().empty())
             {
                 pointsMappedFrom[EDGE].resize(fromModel->getNbEdges());
-                for (int i=0; i<fromModel->getNbEdges(); i++)
+                for (unsigned int i=0; i<fromModel->getNbEdges(); i++)
                 {
                     addInputEdge(i, NULL);
                 }
@@ -136,7 +136,7 @@ void Mesh2PointTopologicalMapping::init()
             if (copyEdges.getValue())
             {
                 sout << "Copying " << fromModel->getNbEdges() << " edges" << sendl;
-                for (int i=0; i<fromModel->getNbEdges(); i++)
+                for (unsigned int i=0; i<fromModel->getNbEdges(); i++)
                 {
                     Edge e = fromModel->getEdge(i);
                     for (unsigned int j=0; j<e.size(); ++j)
@@ -152,7 +152,7 @@ void Mesh2PointTopologicalMapping::init()
             if (!triangleBaryCoords.getValue().empty())
             {
                 pointsMappedFrom[TRIANGLE].resize(fromModel->getNbTriangles());
-                for (int i=0; i<fromModel->getNbTriangles(); i++)
+                for (unsigned int i=0; i<fromModel->getNbTriangles(); i++)
                 {
                     addInputTriangle(i, NULL);
                 }
@@ -162,7 +162,7 @@ void Mesh2PointTopologicalMapping::init()
             if (copyTriangles.getValue())
             {
                 sout << "Copying " << fromModel->getNbTriangles() << " triangles" << sendl;
-                for (int i=0; i<fromModel->getNbTriangles(); i++)
+                for (unsigned int i=0; i<fromModel->getNbTriangles(); i++)
                 {
                     Triangle t = fromModel->getTriangle(i);
                     for (unsigned int j=0; j<t.size(); ++j)
@@ -178,7 +178,7 @@ void Mesh2PointTopologicalMapping::init()
             if (!quadBaryCoords.getValue().empty())
             {
                 pointsMappedFrom[QUAD].resize(fromModel->getNbQuads());
-                for (int i=0; i<fromModel->getNbQuads(); i++)
+                for (unsigned int i=0; i<fromModel->getNbQuads(); i++)
                 {
                     for (unsigned int j=0; j<quadBaryCoords.getValue().size(); j++)
                     {
@@ -210,7 +210,7 @@ void Mesh2PointTopologicalMapping::init()
             if (!tetraBaryCoords.getValue().empty())
             {
                 pointsMappedFrom[TETRA].resize(fromModel->getNbTetrahedra());
-                for (int i=0; i<fromModel->getNbTetrahedra(); i++)
+                for (unsigned int i=0; i<fromModel->getNbTetrahedra(); i++)
                 {
 					addInputTetrahedron(i, NULL);
                 }
@@ -220,7 +220,7 @@ void Mesh2PointTopologicalMapping::init()
             {
 
                 sout << "Copying " << fromModel->getNbTetrahedra() << " tetrahedra" << sendl;
-                for (int i=0; i<fromModel->getNbTetrahedra(); i++)
+                for (unsigned int i=0; i<fromModel->getNbTetrahedra(); i++)
                 {
                     Tetrahedron t = fromModel->getTetrahedron(i);
                     for (unsigned int j=0; j<t.size(); ++j)
@@ -235,7 +235,7 @@ void Mesh2PointTopologicalMapping::init()
             if (!hexaBaryCoords.getValue().empty())
             {
                 pointsMappedFrom[HEXA].resize(fromModel->getNbHexahedra());
-                for (int i=0; i<fromModel->getNbHexahedra(); i++)
+                for (unsigned int i=0; i<fromModel->getNbHexahedra(); i++)
                 {
                     for (unsigned int j=0; j<hexaBaryCoords.getValue().size(); j++)
                     {

--- a/modules/SofaTopologyMapping/Mesh2PointTopologicalMapping.h
+++ b/modules/SofaTopologyMapping/Mesh2PointTopologicalMapping.h
@@ -153,11 +153,11 @@ protected:
     void removeOutputPoints( const sofa::helper::vector<unsigned int>& tab );
 
 protected:
-    bool internalCheck(const char* step, const helper::fixed_array <int, NB_ELEMENTS >& nbInputRemoved);
+    bool internalCheck(const char* step, const helper::fixed_array <size_t, NB_ELEMENTS >& nbInputRemoved);
     
     bool internalCheck(const char* step)
     {
-        helper::fixed_array <int, NB_ELEMENTS > nbInputRemoved;
+        helper::fixed_array <size_t, NB_ELEMENTS > nbInputRemoved;
         nbInputRemoved.assign(0);
         return internalCheck(step, nbInputRemoved);
     }

--- a/modules/SofaTopologyMapping/Quad2TriangleTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/Quad2TriangleTopologicalMapping.cpp
@@ -155,8 +155,8 @@ void Quad2TriangleTopologicalMapping::init()
                 Loc2GlobVec.push_back(i);
                 Loc2GlobVec.push_back(i);
                 sofa::helper::vector<unsigned int> out_info;
-                out_info.push_back(Loc2GlobVec.size()-2);
-                out_info.push_back(Loc2GlobVec.size()-1);
+                out_info.push_back((unsigned int)Loc2GlobVec.size()-2);
+                out_info.push_back((unsigned int)Loc2GlobVec.size()-1);
                 In2OutMap[i]=out_info;
             }
 
@@ -222,7 +222,7 @@ void Quad2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
 
                         sofa::helper::vector< core::topology::BaseMeshTopology::Triangle > triangles_to_create;
                         sofa::helper::vector< unsigned int > trianglesIndexList;
-                        int nb_elems = toModel->getNbTriangles();
+                        unsigned int nb_elems = (unsigned int)toModel->getNbTriangles();
 
                         for (unsigned int i = 0; i < tab.size(); ++i)
                         {
@@ -244,8 +244,8 @@ void Quad2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
                             Loc2GlobVec.push_back(k);
                             Loc2GlobVec.push_back(k);
                             sofa::helper::vector<unsigned int> out_info;
-                            out_info.push_back(Loc2GlobVec.size()-2);
-                            out_info.push_back(Loc2GlobVec.size()-1);
+                            out_info.push_back((unsigned int)Loc2GlobVec.size()-2);
+                            out_info.push_back((unsigned int)Loc2GlobVec.size()-1);
                             In2OutMap[k]=out_info;
 
                         }
@@ -265,12 +265,12 @@ void Quad2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
 
                         const sofa::helper::vector<unsigned int> &tab = ( static_cast< const QuadsRemoved *>( *itBegin ) )->getArray();
 
-                        int last= fromModel->getNbQuads() - 1;
+                        unsigned int last = (unsigned int)fromModel->getNbQuads() - 1;
 
                         int ind_tmp;
 
                         sofa::helper::vector<unsigned int> ind_real_last;
-                        int ind_last=toModel->getNbTriangles();
+                        unsigned int ind_last = (unsigned int)toModel->getNbTriangles();
 
                         for (unsigned int i = 0; i < tab.size(); ++i)
                         {

--- a/modules/SofaTopologyMapping/SimpleTesselatedHexaTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/SimpleTesselatedHexaTopologicalMapping.cpp
@@ -74,7 +74,7 @@ void SimpleTesselatedHexaTopologicalMapping::init()
             size_t pointIndex = pointMappedFromPoint.size();
             Vector3 pA, pB, p;
 
-            for (int i=0; i<fromModel->getNbHexahedra(); ++i)
+            for (unsigned int i=0; i<fromModel->getNbHexahedra(); ++i)
             {
                 core::topology::BaseMeshTopology::Hexa h = fromModel->getHexahedron(i);
 
@@ -242,7 +242,7 @@ void SimpleTesselatedHexaTopologicalMapping::init()
                 pointIndex++;
             }
 
-            for (int i=0; i<fromModel->getNbHexahedra(); ++i)
+            for (unsigned int i=0; i<fromModel->getNbHexahedra(); ++i)
             {
                 core::topology::BaseMeshTopology::Hexa h = fromModel->getHexahedron(i);
 

--- a/modules/SofaTopologyMapping/SimpleTesselatedHexaTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/SimpleTesselatedHexaTopologicalMapping.cpp
@@ -71,7 +71,7 @@ void SimpleTesselatedHexaTopologicalMapping::init()
                 toModel->addPoint(fromModel->getPX(i), fromModel->getPY(i), fromModel->getPZ(i));
             }
 
-            int pointIndex = pointMappedFromPoint.size();
+            size_t pointIndex = pointMappedFromPoint.size();
             Vector3 pA, pB, p;
 
             for (int i=0; i<fromModel->getNbHexahedra(); ++i)
@@ -236,7 +236,7 @@ void SimpleTesselatedHexaTopologicalMapping::init()
                 }
 
                 // points mapped from hexahedra
-                pointMappedFromHexa.push_back(pointIndex);
+                pointMappedFromHexa.push_back((int)pointIndex);
                 p = (p0+p1+p2+p3+p4+p5+p6+p7)/8;
                 toModel->addPoint(p[0], p[1], p[2]);
                 pointIndex++;

--- a/modules/SofaTopologyMapping/SimpleTesselatedTetraTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/SimpleTesselatedTetraTopologicalMapping.cpp
@@ -105,7 +105,7 @@ void SimpleTesselatedTetraTopologicalMapping::init()
 
             int newPointIndex = to_tstc->getNbPoints();
 
-            for (int i=0; i<from_tstc->getNbEdges(); i++)
+            for (unsigned int i=0; i<from_tstc->getNbEdges(); i++)
             {
                 Edge e = from_tstc->getEdge(i);
 
@@ -125,7 +125,7 @@ void SimpleTesselatedTetraTopologicalMapping::init()
 
             tetraSourceData.resize(8*from_tstc->getNbTetrahedra());
 
-            for (int i=0; i<from_tstc->getNbTetrahedra(); i++)
+            for (unsigned int i=0; i<from_tstc->getNbTetrahedra(); i++)
             {
                 core::topology::BaseMeshTopology::Tetra t = from_tstc->getTetrahedron(i);
                 core::topology::BaseMeshTopology::EdgesInTetrahedron e = from_tstc->getEdgesInTetrahedron(i);

--- a/modules/SofaTopologyMapping/SimpleTesselatedTetraTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/SimpleTesselatedTetraTopologicalMapping.cpp
@@ -121,7 +121,7 @@ void SimpleTesselatedTetraTopologicalMapping::init()
             }
 
             fixed_array <int, 8> newTetrahedraIndices;
-            int newTetraIndex = to_tstc->getNbTetrahedra();
+            unsigned int newTetraIndex = (unsigned int)to_tstc->getNbTetrahedra();
 
             tetraSourceData.resize(8*from_tstc->getNbTetrahedra());
 
@@ -273,7 +273,7 @@ void SimpleTesselatedTetraTopologicalMapping::removeOutputPoints( const sofa::he
     helper::WriteAccessor< Data< sofa::helper::vector<int> > > pointMappedFromPointData = d_pointMappedFromPoint;
     helper::WriteAccessor< Data< sofa::helper::vector<int> > > pointMappedFromEdgeData = d_pointMappedFromEdge;
 
-    unsigned int last = pointSourceData.size() -1;
+    int last = (int)pointSourceData.size() -1;
 
     for (unsigned int i = 0; i < index.size(); ++i)
     {
@@ -343,7 +343,7 @@ void SimpleTesselatedTetraTopologicalMapping::removeOutputTetrahedra( const sofa
     helper::vector< fixed_array<int, 8> >& tetrahedraMappedFromTetraData = *(tetrahedraMappedFromTetra.beginEdit());
     helper::vector<int>& tetraSourceData = *(tetraSource.beginEdit());
 
-    int last = tetraSourceData.size() -1;
+    int last = (int)tetraSourceData.size() -1;
     for (unsigned int i = 0; i < index.size(); ++i)
     {
         swapOutputTetrahedra( index[i], last );
@@ -488,7 +488,7 @@ void SimpleTesselatedTetraTopologicalMapping::removeInputPoints( const sofa::hel
     helper::WriteAccessor< Data< sofa::helper::vector<int> > > pointSourceData = d_pointSource;
     helper::WriteAccessor< Data< sofa::helper::vector<int> > > pointMappedFromPointData = d_pointMappedFromPoint;
 
-    unsigned int last = pointMappedFromPointData.size() -1;
+    int last = (int)pointMappedFromPointData.size() -1;
 
     for (unsigned int i = 0; i < index.size(); ++i)
     {
@@ -537,7 +537,7 @@ void SimpleTesselatedTetraTopologicalMapping::removeInputEdges( const sofa::help
     helper::WriteAccessor< Data< sofa::helper::vector<int> > > pointSourceData = d_pointSource;
     helper::WriteAccessor< Data< sofa::helper::vector<int> > > pointMappedFromEdgeData = d_pointMappedFromEdge;
 
-    unsigned int last = pointMappedFromEdgeData.size() -1;
+    int last = (int)pointMappedFromEdgeData.size() -1;
 
     for (unsigned int i = 0; i < index.size(); ++i)
     {
@@ -577,7 +577,7 @@ void SimpleTesselatedTetraTopologicalMapping::removeInputTetrahedra( const sofa:
     helper::vector< fixed_array<int, 8> >& tetrahedraMappedFromTetraData = *(tetrahedraMappedFromTetra.beginEdit());
     helper::vector<int>& tetraSourceData = *(tetraSource.beginEdit());
 
-    unsigned int last = tetrahedraMappedFromTetraData.size() -1;
+    int last = (int)tetrahedraMappedFromTetraData.size() -1;
 
     for (unsigned int i = 0; i < index.size(); ++i)
     {

--- a/modules/SofaTopologyMapping/SubsetTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/SubsetTopologicalMapping.cpp
@@ -494,8 +494,8 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
         case core::topology::POINTSADDED:
         {
             const PointsAdded * pAdd = static_cast< const PointsAdded * >( topoChange );
-            unsigned int pS0 = (samePoints.getValue() ? toModel->getNbPoints() : pS2D.size());
-            unsigned int nSadd = pAdd->getNbAddedVertices();
+            size_t pS0 = (samePoints.getValue() ? toModel->getNbPoints() : pS2D.size());
+            size_t nSadd = pAdd->getNbAddedVertices();
             sout << "[" << count << "]POINTSADDED : " << nSadd << " : " << pS0 << " - " << (pS0 + nSadd-1) << sendl;
             if (samePoints.getValue())
             {
@@ -507,14 +507,14 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
             {
                 helper::vector< helper::vector<Index> > ancestors;
                 helper::vector< helper::vector<double> > coefs;
-                unsigned int nDadd = 0;
-                unsigned int pD0 = pD2S.size();
+                size_t nDadd = 0;
+                size_t pD0 = pD2S.size();
                 pS2D.resize(pS0+nSadd);
                 ancestors.reserve(pAdd->ancestorsList.size());
                 coefs.reserve(pAdd->coefs.size());
                 for (Index pi = 0; pi < nSadd; ++pi)
                 {
-                    Index ps = pS0+pi;
+                    size_t ps = pS0+pi;
                     pS2D[ps] = core::topology::Topology::InvalidID;
                     bool inDst = true;
                     if (!pAdd->ancestorsList.empty())
@@ -525,10 +525,10 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
                                 inDst = false;
                         }
                     if (!inDst) continue;
-                    Index pd = pD0+nDadd;
+                    size_t pd = pD0+nDadd;
                     pD2S.resize(pd+1);
-                    pS2D[ps] = pd;
-                    pD2S[pd] = ps;
+                    pS2D[ps] = (unsigned int)pd;
+                    pD2S[pd] = (unsigned int)ps;
 
                     if (!pAdd->ancestorsList.empty())
                     {
@@ -579,7 +579,7 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
                 sout << "[" << count << "]POINTSREMOVED : " << tab.size() << " -> " << tab2.size() << " : " << tab << " -> " << tab2 << sendl;
                 // apply removals in pS2D
                 {
-                    unsigned int last = pS2D.size() -1;
+                    size_t last = pS2D.size() -1;
                     for (unsigned int i = 0; i < tab.size(); ++i)
                     {
                         Index ps = tab[i];
@@ -601,7 +601,7 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
                     toPointMod->removePointsProcess(tab2, true);
                     // apply removals in pD2S
                     {
-                        unsigned int last = pD2S.size() -1;
+                        size_t last = pD2S.size() -1;
                         for (unsigned int i = 0; i < tab2.size(); ++i)
                         {
                             Index pd = tab2[i];
@@ -685,10 +685,10 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
             helper::vector< Index > edgeIndexArray;
             helper::vector< helper::vector<Index> > ancestors;
             helper::vector< helper::vector<double> > coefs;
-            unsigned int nSadd = eAdd->getNbAddedEdges();
+            size_t nSadd = eAdd->getNbAddedEdges();
             unsigned int nDadd = 0;
-            unsigned int eS0 = eS2D.size();
-            unsigned int eD0 = eD2S.size();
+            size_t eS0 = eS2D.size();
+            size_t eD0 = eD2S.size();
             eS2D.resize(eS0+nSadd);
             edgeArray.reserve(eAdd->edgeArray.size());
             edgeIndexArray.reserve(eAdd->edgeIndexArray.size());
@@ -711,7 +711,7 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
                             inDst = false;
                     }
                 if (!inDst) continue;
-                Index ed = eD0+nDadd;
+                unsigned int ed = unsigned int(eD0+nDadd);
                 edgeArray.push_back(data);
                 edgeIndexArray.push_back(ed);
                 eD2S.resize(ed+1);
@@ -763,7 +763,7 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
             sout << "[" << count << "]EDGESREMOVED : " << tab.size() << " -> " << tab2.size() << " : " << tab << " -> " << tab2 << sendl;
             // apply removals in eS2D
             {
-                unsigned int last = eS2D.size() -1;
+                size_t last = eS2D.size() -1;
                 for (unsigned int i = 0; i < tab.size(); ++i)
                 {
                     Index es = tab[i];
@@ -785,7 +785,7 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
                 toEdgeMod->removeEdgesProcess(tab2, false);
                 // apply removals in eD2S
                 {
-                    unsigned int last = eD2S.size() -1;
+                    size_t last = eD2S.size() -1;
                     for (unsigned int i = 0; i < tab2.size(); ++i)
                     {
                         Index ed = tab2[i];
@@ -814,7 +814,7 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
             sout << "[" << count << "]TRIANGLESADDED : " << tAdd->getNbAddedTriangles() << " : " << tAdd->triangleIndexArray << " : " << tAdd->triangleArray << sendl;
             if (!tAdd->ancestorsList.empty())
             {
-                int count = 0;
+                size_t count = 0;
                 double sum = 0.0;
                 sout << "   ";
                 for (unsigned int i = 0; i < tAdd->ancestorsList.size(); ++i)
@@ -834,10 +834,10 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
             helper::vector< Index > triangleIndexArray;
             helper::vector< helper::vector<Index> > ancestors;
             helper::vector< helper::vector<double> > coefs;
-            unsigned int nSadd = tAdd->getNbAddedTriangles();
+            size_t nSadd = tAdd->getNbAddedTriangles();
             unsigned int nDadd = 0;
-            unsigned int tS0 = tS2D.size();
-            unsigned int tD0 = tD2S.size();
+            size_t tS0 = tS2D.size();
+            size_t tD0 = tD2S.size();
             tS2D.resize(tS0+nSadd);
             triangleArray.reserve(tAdd->triangleArray.size());
             triangleIndexArray.reserve(tAdd->triangleIndexArray.size());
@@ -860,7 +860,7 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
                             inDst = false;
                     }
                 if (!inDst) continue;
-                Index td = tD0+nDadd;
+                unsigned int td = unsigned int(tD0+nDadd);
                 triangleArray.push_back(data);
                 triangleIndexArray.push_back(td);
                 tD2S.resize(td+1);
@@ -912,7 +912,7 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
             sout << "[" << count << "]TRIANGLESREMOVED : " << tab.size() << " -> " << tab2.size() << " : " << tab << " -> " << tab2 << sendl;
             // apply removals in tS2D
             {
-                unsigned int last = tS2D.size() -1;
+                size_t last = tS2D.size() -1;
                 for (unsigned int i = 0; i < tab.size(); ++i)
                 {
                     Index ts = tab[i];
@@ -934,7 +934,7 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
                 toTriangleMod->removeTrianglesProcess(tab2, !handleEdges.getValue());
                 // apply removals in tD2S
                 {
-                    unsigned int last = tD2S.size() -1;
+                    size_t last = tD2S.size() -1;
                     for (unsigned int i = 0; i < tab2.size(); ++i)
                     {
                         Index td = tab2[i];

--- a/modules/SofaTopologyMapping/SubsetTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/SubsetTopologicalMapping.cpp
@@ -711,7 +711,7 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
                             inDst = false;
                     }
                 if (!inDst) continue;
-                unsigned int ed = unsigned int(eD0+nDadd);
+                unsigned int ed = (unsigned int)(eD0+nDadd);
                 edgeArray.push_back(data);
                 edgeIndexArray.push_back(ed);
                 eD2S.resize(ed+1);
@@ -860,7 +860,7 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
                             inDst = false;
                     }
                 if (!inDst) continue;
-                unsigned int td = unsigned int(tD0+nDadd);
+                unsigned int td = (unsigned int)(tD0+nDadd);
                 triangleArray.push_back(data);
                 triangleIndexArray.push_back(td);
                 tD2S.resize(td+1);

--- a/modules/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.cpp
@@ -125,7 +125,7 @@ void Tetra2TriangleTopologicalMapping::init()
                         else	to_tstm->addTriangleProcess(triangleArray[i]);
 
                         Loc2GlobVec.push_back(i);
-                        Glob2LocMap[i]=Loc2GlobVec.size()-1;
+                        Glob2LocMap[i]= (unsigned int)Loc2GlobVec.size()-1;
                     }
                 }
 
@@ -184,17 +184,13 @@ void Tetra2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
 
                 case core::topology::TRIANGLESREMOVED:
                 {
-                    int last;
-                    int ind_last;
-
-                    last= fromModel->getNbTriangles() - 1;
+                    unsigned int last = (unsigned int)fromModel->getNbTriangles() - 1;
+                    unsigned int ind_last = (unsigned int)toModel->getNbTriangles();
 
                     const sofa::helper::vector<unsigned int> &tab = ( static_cast< const TrianglesRemoved *>( *itBegin ) )->getArray();
 
                     unsigned int ind_tmp;
-
                     unsigned int ind_real_last;
-                    ind_last=toModel->getNbTriangles();
 
                     for (unsigned int i = 0; i <tab.size(); ++i)
                     {
@@ -291,7 +287,7 @@ void Tetra2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
                     const sofa::helper::vector<core::topology::BaseMeshTopology::Tetrahedron> &tetrahedronArray=fromModel->getTetrahedra();
                     sofa::helper::vector< core::topology::BaseMeshTopology::Triangle > triangles_to_create;
                     sofa::helper::vector< unsigned int > trianglesIndexList;
-                    int nb_elems = toModel->getNbTriangles();
+                    unsigned int nb_elems = (unsigned int)toModel->getNbTriangles();
                     const bool flipN = flipNormals.getValue();
 
                     for (unsigned int i = 0; i <tab.size(); ++i)
@@ -353,7 +349,7 @@ void Tetra2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
                                 nb_elems+=1;
 
                                 Loc2GlobVec.push_back(tab[i]);
-                                Glob2LocMap[tab[i]]=Loc2GlobVec.size()-1;
+                                Glob2LocMap[tab[i]]= (unsigned int)Loc2GlobVec.size()-1;
                             }
                         }
                     }
@@ -399,9 +395,8 @@ void Tetra2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
                             }
                         }
 
-                        int ind_last;
+                        unsigned int ind_last = (unsigned int)toModel->getNbTriangles();
                         unsigned int ind_tmp;
-                        ind_last=toModel->getNbTriangles();
 
                         for (unsigned int i = 0; i <triangles_to_remove.size(); ++i)
                         {
@@ -468,7 +463,7 @@ void Tetra2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
 
                         sofa::helper::vector< core::topology::BaseMeshTopology::Triangle > triangles_to_create;
                         sofa::helper::vector< unsigned int > trianglesIndexList;
-                        int nb_elems = toModel->getNbTriangles();
+                        unsigned int nb_elems = (unsigned int)toModel->getNbTriangles();
                         const bool flipN = flipNormals.getValue();
 
                         for (unsigned int i = 0; i < tab.size(); ++i)
@@ -591,7 +586,7 @@ void Tetra2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
                                         {
                                             addedTriangleIndex.push_back(nb_elems-1);
                                         }
-                                        Glob2LocMap[k]=Loc2GlobVec.size()-1;
+                                        Glob2LocMap[k]= (unsigned int)Loc2GlobVec.size()-1;
                                     }
                                 }
                             }
@@ -617,7 +612,7 @@ void Tetra2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
                 case core::topology::POINTSADDED:
                 {
 
-                    int nbAddedPoints = ( static_cast< const sofa::component::topology::PointsAdded * >( *itBegin ) )->getNbAddedVertices();
+                    size_t nbAddedPoints = ( static_cast< const sofa::component::topology::PointsAdded * >( *itBegin ) )->getNbAddedVertices();
                     to_tstm->addPointsProcess(nbAddedPoints);
                     to_tstm->addPointsWarning(nbAddedPoints, true);
 

--- a/modules/SofaTopologyMapping/Triangle2EdgeTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/Triangle2EdgeTopologicalMapping.cpp
@@ -213,7 +213,7 @@ void Triangle2EdgeTopologicalMapping::updateTopologicalMappingTopDown()
                                 }
                             }
 
-                            if((int) ind_k != ind_last)
+                            if(ind_k != ind_last)
                             {
 
                                 Glob2LocMap.erase(Glob2LocMap.find(Loc2GlobVec[ind_last]));

--- a/modules/SofaTopologyMapping/Triangle2EdgeTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/Triangle2EdgeTopologicalMapping.cpp
@@ -107,7 +107,7 @@ void Triangle2EdgeTopologicalMapping::init()
                     to_tstm->addEdgeProcess(edgeArray[i]);
 
                     Loc2GlobVec.push_back(i);
-                    Glob2LocMap[i]=Loc2GlobVec.size()-1;
+                    Glob2LocMap[i]=(unsigned int)Loc2GlobVec.size()-1;
                 }
             }
 
@@ -171,17 +171,13 @@ void Triangle2EdgeTopologicalMapping::updateTopologicalMappingTopDown()
                 {
                     //sout << "INFO_print : Triangle2EdgeTopologicalMapping - EDGESREMOVED" << sendl;
 
-                    int last;
-                    int ind_last;
-
-                    last= fromModel->getNbEdges() - 1;
+                    unsigned int last = (unsigned int)fromModel->getNbEdges() - 1;
+                    unsigned int ind_last = (unsigned int)toModel->getNbEdges();
 
                     const sofa::helper::vector<unsigned int> &tab = ( static_cast< const EdgesRemoved *>( *itBegin ) )->getArray();
 
                     unsigned int ind_tmp;
-
                     unsigned int ind_real_last;
-                    ind_last=toModel->getNbEdges();
 
                     for (unsigned int i = 0; i <tab.size(); ++i)
                     {
@@ -269,7 +265,7 @@ void Triangle2EdgeTopologicalMapping::updateTopologicalMappingTopDown()
 
                         sofa::helper::vector< core::topology::BaseMeshTopology::Edge > edges_to_create;
                         sofa::helper::vector< unsigned int > edgesIndexList;
-                        int nb_elems = toModel->getNbEdges();
+                        unsigned int nb_elems = (unsigned int)toModel->getNbEdges();
 
                         for (unsigned int i = 0; i < tab.size(); ++i)
                         {
@@ -333,7 +329,7 @@ void Triangle2EdgeTopologicalMapping::updateTopologicalMappingTopDown()
                                             sout << "INFO_print : Triangle2EdgeTopologicalMapping - fail to add edge " << k << "which already exists" << sendl;
                                             Glob2LocMap.erase(Glob2LocMap.find(k));
                                         }
-                                        Glob2LocMap[k]=Loc2GlobVec.size()-1;
+                                        Glob2LocMap[k]= (unsigned int)Loc2GlobVec.size()-1;
                                     }
                                 }
                             }
@@ -473,8 +469,7 @@ void Triangle2EdgeTopologicalMapping::updateTopologicalMappingTopDown()
                                 {
 
                                     unsigned int ind_k = Glob2LocMap[k];
-                                    unsigned int ind_last = Loc2GlobVec.size() - 1;
-                                    unsigned int ind_real_last = Loc2GlobVec[ind_last];
+                                    unsigned int ind_real_last = Loc2GlobVec[Loc2GlobVec.size() - 1];
 
                                     Glob2LocMap.erase(Glob2LocMap.find(ind_real_last));
                                     Glob2LocMap[ind_real_last] = ind_k;
@@ -506,7 +501,7 @@ void Triangle2EdgeTopologicalMapping::updateTopologicalMappingTopDown()
                                         */
 
                                         edges_to_create.push_back(t);
-                                        edgesIndexList.push_back(Loc2GlobVec.size());
+                                        edgesIndexList.push_back((unsigned int)Loc2GlobVec.size());
 
                                         Loc2GlobVec.push_back(k);
                                         std::map<unsigned int, unsigned int>::iterator iter_1 = Glob2LocMap.find(k);
@@ -515,7 +510,7 @@ void Triangle2EdgeTopologicalMapping::updateTopologicalMappingTopDown()
                                             sout << "INFO_print : Triangle2EdgeTopologicalMapping - fail to add edge " << k << "which already exists" << sendl;
                                             Glob2LocMap.erase(Glob2LocMap.find(k));
                                         }
-                                        Glob2LocMap[k]=Loc2GlobVec.size()-1;
+                                        Glob2LocMap[k]= (unsigned int)Loc2GlobVec.size()-1;
 
                                         //to_tstm->addEdgesProcess(edges_to_create) ;
                                         //to_tstm->addEdgesWarning(edges_to_create.size(), edges_to_create, edgesIndexList) ;


### PR DESCRIPTION
- Fix some size_t to uint int conversion warnings
- Fix some double to float warnings

- When looping on topology buffer, use the typedef corresponding to id instead of using uint or int. 



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
