### PR TITLE
[SofaCore] Add new (simpler) DataEngine implementation

### DIFF
--- a/SofaKernel/framework/framework_test/core/DataEngine_test.cpp
+++ b/SofaKernel/framework/framework_test/core/DataEngine_test.cpp
@@ -114,12 +114,12 @@ public:
 private:
     void doUpdate() override
     {
-        // true only if the DataTracker associated to the Data 'input' is Dirty
-        // that could only happen if 'input' was dirtied since last update
-        if( m_dataTracker.isDirty( input ) )
-            output.setValue(CHANGED);
-        else
+        // SimpleDataEngines cannot check whether a datafield is dirty or not:
+        // all input fields must be considered dirty in update.
+        if (output.getValue() != NO_CHANGED)
             output.setValue(NO_CHANGED);
+        else
+            output.setValue(CHANGED);
     }
 };
 
@@ -162,12 +162,12 @@ struct DataEngine_test: public BaseTest
 
 
 // Test
-TEST_F(DataEngine_test, testTrackedData )
+TEST_F(DataEngine_test, testDataEngine )
 {
     this->testTrackedData<TestEngine>(this->engine);
 }
 
-TEST_F(DataEngine_test, testSimpleEngine )
+TEST_F(DataEngine_test, testSimpleDataEngine )
 {
     this->testTrackedData<SimpleTestEngine>(this->simpleEngine);
 }

--- a/SofaKernel/framework/framework_test/core/DataEngine_test.cpp
+++ b/SofaKernel/framework/framework_test/core/DataEngine_test.cpp
@@ -114,12 +114,12 @@ public:
 private:
     void doUpdate() override
     {
-        // SimpleDataEngines cannot check whether a datafield is dirty or not:
-        // all input fields must be considered dirty in update.
-        if (output.getValue() != NO_CHANGED)
-            output.setValue(NO_CHANGED);
-        else
+        // true only iff the DataTracker associated to the Data 'input' is Dirty
+        // that could only happen if 'input' was dirtied since last update
+        if( m_dataTracker.isDirty( input ) )
             output.setValue(CHANGED);
+        else
+            output.setValue(NO_CHANGED);
     }
 };
 

--- a/SofaKernel/framework/framework_test/core/DataEngine_test.cpp
+++ b/SofaKernel/framework/framework_test/core/DataEngine_test.cpp
@@ -111,6 +111,7 @@ public:
         update();
     }
 
+private:
     void doUpdate() override
     {
         // true only if the DataTracker associated to the Data 'input' is Dirty

--- a/SofaKernel/framework/framework_test/core/DataEngine_test.cpp
+++ b/SofaKernel/framework/framework_test/core/DataEngine_test.cpp
@@ -111,7 +111,7 @@ public:
         update();
     }
 
-    void Update() override
+    void doUpdate() override
     {
         // true only if the DataTracker associated to the Data 'input' is Dirty
         // that could only happen if 'input' was dirtied since last update

--- a/SofaKernel/framework/sofa/core/DataEngine.h
+++ b/SofaKernel/framework/sofa/core/DataEngine.h
@@ -238,7 +238,7 @@ public:
         sofa::core::objectmodel::DDGNode::addInput(data);
     }
 
-private:
+protected:
     /// Where you put your engine's impl
     virtual void doUpdate() = 0;
 };

--- a/SofaKernel/framework/sofa/core/DataEngine.h
+++ b/SofaKernel/framework/sofa/core/DataEngine.h
@@ -235,7 +235,7 @@ public:
     void addInput(sofa::core::objectmodel::BaseData* data)
     {
         m_dataTracker.trackData(*data);
-        sofa::core::objectmodel::DDGNode::addInput(data);
+        Inherit1::addInput(data);
     }
 
 protected:

--- a/SofaKernel/framework/sofa/core/DataEngine.h
+++ b/SofaKernel/framework/sofa/core/DataEngine.h
@@ -184,6 +184,66 @@ public:
 
 };
 
+/**
+ *  \brief A simpler API for your DataEngines
+ *
+ * Implementation good rules:
+ *
+ * void init()
+ * {
+ *    addInput // indicate all inputs
+ *    addOutput // indicate all outputs
+ *    setDirtyValue(); // You still have to set that manually, sorry
+ * }
+ *
+ * // optional (called each time a data is modified in the gui)
+ * // it is not always desired
+ * void reinit()
+ * {
+ *    update();
+ * }
+ *
+ * void Update() override
+ * {
+ *    don't overthink it, just code. acces your inputs, set your outputs
+ *    No cleanDirty() required
+ * }
+ *
+ */
+class SOFA_CORE_API SimpleDataEngine : public sofa::core::DataEngine
+{
+ public:
+  SOFA_CLASS(SimpleDataEngine, sofa::core::DataEngine);
+
+  SimpleDataEngine() : Inherit1() {}
+  virtual ~SimpleDataEngine() {}
+
+  /// Updates your inputs and calls cleanDirty() for you.
+  /// User implementation moved to Update()
+  virtual void update() final
+  {
+      for(auto& input : getInputs())
+      {
+          static_cast<sofa::core::objectmodel::BaseData*>(input)
+                  ->updateIfDirty();
+      }
+      cleanDirty();
+      Update();
+  }
+
+  /// Where you put your engine's impl
+  virtual void Update() = 0;
+
+  /// Automatically adds the input fields to the datatracker
+  void addInput(sofa::core::objectmodel::BaseData* data)
+  {
+      m_dataTracker.trackData(*data);
+      sofa::core::objectmodel::DDGNode::addInput(data);
+  }
+
+};
+
+
 } // namespace core
 
 } // namespace sofa

--- a/SofaKernel/framework/sofa/core/DataEngine.h
+++ b/SofaKernel/framework/sofa/core/DataEngine.h
@@ -203,7 +203,7 @@ public:
  *    update();
  * }
  *
- * void Update() override
+ * void doUpdate() override
  * {
  *    don't overthink it, just code. acces your inputs, set your outputs
  *    No cleanDirty() required
@@ -219,7 +219,7 @@ class SOFA_CORE_API SimpleDataEngine : public sofa::core::DataEngine
   virtual ~SimpleDataEngine() {}
 
   /// Updates your inputs and calls cleanDirty() for you.
-  /// User implementation moved to Update()
+  /// User implementation moved to doUpdate()
   virtual void update() final
   {
       for(auto& input : getInputs())
@@ -228,11 +228,11 @@ class SOFA_CORE_API SimpleDataEngine : public sofa::core::DataEngine
                   ->updateIfDirty();
       }
       cleanDirty();
-      Update();
+      doUpdate();
   }
 
   /// Where you put your engine's impl
-  virtual void Update() = 0;
+  virtual void doUpdate() = 0;
 
   /// Automatically adds the input fields to the datatracker
   void addInput(sofa::core::objectmodel::BaseData* data)

--- a/SofaKernel/framework/sofa/core/DataEngine.h
+++ b/SofaKernel/framework/sofa/core/DataEngine.h
@@ -218,17 +218,23 @@ public:
     SimpleDataEngine() : Inherit1() {}
     virtual ~SimpleDataEngine() {}
 
-    /// Updates your inputs and calls cleanDirty() for you.
-    /// User implementation moved to doUpdate()
-    virtual void update() final
+
+    virtual void updateAllInputs()
     {
         for(auto& input : getInputs())
         {
             static_cast<sofa::core::objectmodel::BaseData*>(input)
                     ->updateIfDirty();
         }
-        cleanDirty();
+    }
+    /// Updates your inputs and calls cleanDirty() for you.
+    /// User implementation moved to doUpdate()
+    virtual void update() final
+    {
+        updateAllInputs();
+        DDGNode::cleanDirty();
         doUpdate();
+        m_dataTracker.clean();
     }
 
     /// Automatically adds the input fields to the datatracker

--- a/SofaKernel/framework/sofa/core/DataEngine.h
+++ b/SofaKernel/framework/sofa/core/DataEngine.h
@@ -212,35 +212,35 @@ public:
  */
 class SOFA_CORE_API SimpleDataEngine : public sofa::core::DataEngine
 {
- public:
-  SOFA_CLASS(SimpleDataEngine, sofa::core::DataEngine);
+public:
+    SOFA_CLASS(SimpleDataEngine, sofa::core::DataEngine);
 
-  SimpleDataEngine() : Inherit1() {}
-  virtual ~SimpleDataEngine() {}
+    SimpleDataEngine() : Inherit1() {}
+    virtual ~SimpleDataEngine() {}
 
-  /// Updates your inputs and calls cleanDirty() for you.
-  /// User implementation moved to doUpdate()
-  virtual void update() final
-  {
-      for(auto& input : getInputs())
-      {
-          static_cast<sofa::core::objectmodel::BaseData*>(input)
-                  ->updateIfDirty();
-      }
-      cleanDirty();
-      doUpdate();
-  }
+    /// Updates your inputs and calls cleanDirty() for you.
+    /// User implementation moved to doUpdate()
+    virtual void update() final
+    {
+        for(auto& input : getInputs())
+        {
+            static_cast<sofa::core::objectmodel::BaseData*>(input)
+                    ->updateIfDirty();
+        }
+        cleanDirty();
+        doUpdate();
+    }
 
-  /// Where you put your engine's impl
-  virtual void doUpdate() = 0;
+    /// Automatically adds the input fields to the datatracker
+    void addInput(sofa::core::objectmodel::BaseData* data)
+    {
+        m_dataTracker.trackData(*data);
+        sofa::core::objectmodel::DDGNode::addInput(data);
+    }
 
-  /// Automatically adds the input fields to the datatracker
-  void addInput(sofa::core::objectmodel::BaseData* data)
-  {
-      m_dataTracker.trackData(*data);
-      sofa::core::objectmodel::DDGNode::addInput(data);
-  }
-
+private:
+    /// Where you put your engine's impl
+    virtual void doUpdate() = 0;
 };
 
 

--- a/applications/plugins/SofaTest/DataEngine_test.h
+++ b/applications/plugins/SofaTest/DataEngine_test.h
@@ -25,9 +25,11 @@
 
 #include "Sofa_test.h"
 
+#include <sofa/core/DataEngine.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <SofaBaseMechanics/MechanicalObject.h>
 
+using sofa::core::SimpleDataEngine;
 
 namespace sofa {
 
@@ -48,10 +50,19 @@ public:
     {}
 
 
-    virtual void update() override
+    template <class T = DataEngineType, typename std::enable_if<
+                  std::is_base_of<SimpleDataEngine, T>::value, int>::type = 0>
+    void update()
     {
         DataEngineType::update();
+        ++m_counter;
+    }
 
+    template <class T = DataEngineType, typename std::enable_if<
+                  std::is_base_of<SimpleDataEngine, T>::value, int>::type = 1>
+    void doUpdate()
+    {
+        SimpleDataEngine::doUpdate();
         ++m_counter;
     }
 
@@ -80,7 +91,7 @@ struct DataEngine_test : public Sofa_test<>
     typedef DDGNode::DDGLinkContainer DDGLinkContainer;
 
     typename Engine::SPtr m_engine; ///< the real tested engine
-    typename DataEngineType::SPtr m_engineInput; ///< an other identical engine, where only inputs are used (not the engine itself). It is an easy way to create all inputs of the right type, to be able to link wuth them.
+    typename DataEngineType::SPtr m_engineInput; ///< an other identical engine, where only inputs are used (not the engine itself). It is an easy way to create all inputs of the right type, to be able to link with them.
 
     ///
     DataEngine_test()

--- a/modules/SofaGeneralEngine/TransformEngine.h
+++ b/modules/SofaGeneralEngine/TransformEngine.h
@@ -48,10 +48,10 @@ namespace engine
 This transformation can be either translation, rotation, scale
  */
 template <class DataTypes>
-class TransformEngine : public core::DataEngine
+class TransformEngine : public core::SimpleDataEngine
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE(TransformEngine,DataTypes),core::DataEngine);
+    SOFA_CLASS(SOFA_TEMPLATE(TransformEngine,DataTypes),core::SimpleDataEngine);
     typedef typename DataTypes::VecCoord VecCoord;
     typedef typename DataTypes::Coord Coord;
     typedef typename DataTypes::Real Real;
@@ -66,7 +66,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     virtual std::string getTemplateName() const override
     {

--- a/modules/SofaGeneralEngine/TransformEngine.h
+++ b/modules/SofaGeneralEngine/TransformEngine.h
@@ -66,8 +66,6 @@ public:
 
     void reinit() override;
 
-    void doUpdate() override;
-
     virtual std::string getTemplateName() const override
     {
         return templateName(this);
@@ -76,9 +74,10 @@ public:
     static std::string templateName(const TransformEngine<DataTypes>* = NULL)
     {
         return DataTypes::Name();
-    }
-
+    }    
 protected:
+    void doUpdate() override;
+
     Data<VecCoord> f_inputX; ///< input position
     Data<VecCoord> f_outputX; ///< ouput position
     Data<defaulttype::Vector3> translation; ///< translation

--- a/modules/SofaGeneralEngine/TransformEngine.inl
+++ b/modules/SofaGeneralEngine/TransformEngine.inl
@@ -270,7 +270,7 @@ private:
 
 
 template <class DataTypes>
-void TransformEngine<DataTypes>::update()
+void TransformEngine<DataTypes>::doUpdate()
 {
     const defaulttype::Vector3 &s=scale.getValue();
     const defaulttype::Vector3 &r=rotation.getValue();
@@ -294,9 +294,6 @@ void TransformEngine<DataTypes>::update()
 
     //Get input
     const VecCoord& in = f_inputX.getValue();
-
-    cleanDirty();
-
     VecCoord& out = *(f_outputX.beginWriteOnly());
 
     //Set Output
@@ -313,7 +310,6 @@ void TransformEngine<DataTypes>::update()
         delete operations.back();
         operations.pop_back();
     }
-
     f_outputX.endEdit();
 }
 


### PR DESCRIPTION
Here's a simpler implementation of sofa::core::DataEngine. This implementation hides the code related to updating datafields and calling cleanDirty() in an attempt to reduce human errors.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
