### PR TITLE
[Geomagic] Fix broken behavior

### DIFF
--- a/applications/plugins/Geomagic/src/GeomagicDriver.cpp
+++ b/applications/plugins/Geomagic/src/GeomagicDriver.cpp
@@ -337,7 +337,7 @@ void GeomagicDriver::init()
     for(int j=0; j<NVISUALNODE; j++)
     {
         sofa::defaulttype::ResizableExtVector< sofa::defaulttype::Vec<3,float> > &scaleMapping = *(visualNode[j].mapping->points.beginEdit());
-        for(unsigned int i=0; i<scaleMapping.size(); i++)
+        for(size_t i=0; i<scaleMapping.size(); i++)
             scaleMapping[i] *= (float)(d_scale.getValue());
         visualNode[j].mapping->points.endEdit();
     }
@@ -412,7 +412,8 @@ void GeomagicDriver::reinit()
         q_t->normalize();
         d_orientationTool.endEdit();
 
-        for (int i=0;i<NBJOINT;i++) m_dh_matrices[i] = compute_dh_Matrix(d_dh_theta.getValue()[i],d_dh_alpha.getValue()[i],d_dh_a.getValue()[i],d_dh_d.getValue()[i]);
+        for (int i=0;i<NBJOINT;i++) 
+            m_dh_matrices[i] = compute_dh_Matrix(d_dh_theta.getValue()[i],d_dh_alpha.getValue()[i],d_dh_a.getValue()[i],d_dh_d.getValue()[i]);
     }
 }
 
@@ -556,9 +557,10 @@ void GeomagicDriver::draw(const sofa::core::visual::VisualParams* vparams)
     {
         vparams->drawTool()->disableLighting();
 
-        vparams->drawTool()->drawArrow(m_posDeviceVisu[0].getCenter(), m_posDeviceVisu[0].getCenter() + m_posDeviceVisu[0].getOrientation().rotate(Vector3(2,0,0)*d_scale.getValue()), d_scale.getValue()*0.1, Vec4f(1,0,0,1) );
-        vparams->drawTool()->drawArrow(m_posDeviceVisu[0].getCenter(), m_posDeviceVisu[0].getCenter() + m_posDeviceVisu[0].getOrientation().rotate(Vector3(0,2,0)*d_scale.getValue()), d_scale.getValue()*0.1, Vec4f(0,1,0,1) );
-        vparams->drawTool()->drawArrow(m_posDeviceVisu[0].getCenter(), m_posDeviceVisu[0].getCenter() + m_posDeviceVisu[0].getOrientation().rotate(Vector3(0,0,2)*d_scale.getValue()), d_scale.getValue()*0.1, Vec4f(0,0,1,1) );
+        float glRadius = (float)d_scale.getValue()*0.1f;
+        vparams->drawTool()->drawArrow(m_posDeviceVisu[0].getCenter(), m_posDeviceVisu[0].getCenter() + m_posDeviceVisu[0].getOrientation().rotate(Vector3(2,0,0)*d_scale.getValue()), glRadius, Vec4f(1,0,0,1) );
+        vparams->drawTool()->drawArrow(m_posDeviceVisu[0].getCenter(), m_posDeviceVisu[0].getCenter() + m_posDeviceVisu[0].getOrientation().rotate(Vector3(0,2,0)*d_scale.getValue()), glRadius, Vec4f(0,1,0,1) );
+        vparams->drawTool()->drawArrow(m_posDeviceVisu[0].getCenter(), m_posDeviceVisu[0].getCenter() + m_posDeviceVisu[0].getOrientation().rotate(Vector3(0,0,2)*d_scale.getValue()), glRadius, Vec4f(0,0,1,1) );
     }
 
     if (d_omniVisu.getValue() && m_initVisuDone)

--- a/applications/plugins/Geomagic/src/GeomagicDriver.h
+++ b/applications/plugins/Geomagic/src/GeomagicDriver.h
@@ -142,7 +142,7 @@ public:
     VisualComponent visualNode[NVISUALNODE];
     static const char* visualNodeNames[NVISUALNODE];
     static const char* visualNodeFiles[NVISUALNODE];
-    simulation::Node::SPtr nodePrincipal;
+    simulation::Node::SPtr m_omniVisualNode;
     component::container::MechanicalObject<sofa::defaulttype::Rigid3dTypes>::SPtr rigidDOF;
 
     bool m_visuActive; ///< Internal boolean to detect activation switch of the draw


### PR DESCRIPTION
Fix **one** of the bugs breaking the Geomagic behavior.

When updating the position of the Omni visual node, visitor update was call on the Omni->getContext() which is usually the Root node, thus all node where updated outside of the normal mechanical step leading to bad physic behavior. 
Call the update on the Omni visual node only.

+ some small change and warning fix. 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
