### PR TITLE
[SofaPython] ADD a custom __dir__ method in Binding_Base.

### DIFF
--- a/applications/plugins/SofaPython/Binding_Base.cpp
+++ b/applications/plugins/SofaPython/Binding_Base.cpp
@@ -587,7 +587,7 @@ static PyObject * Base_getListOfLinks(PyObject *self, PyObject * /*args*/) {
 
 
 /// This function is called by the Python interpreter when calling (dir).
-/// It add to the default behavior all the data fields and links of the object.
+/// It adds to the default behavior all the data fields and links of the object.
 static PyObject * Base___dir__(PyObject *self, PyObject * /*args*/) {
     Base * component = get_base(self);
 
@@ -609,10 +609,10 @@ static PyObject * Base___dir__(PyObject *self, PyObject * /*args*/) {
     }
 
     /// The the other names out of data & links
-    const sofa::helper::vector<BaseData*> dataFields = component->getDataFields();
-    const sofa::helper::vector<BaseLink*> links = component->getLinks() ;
+    const sofa::helper::vector<BaseData*>& dataFields = component->getDataFields();
+    const sofa::helper::vector<BaseLink*>& links = component->getLinks() ;
 
-    /// Create a list big enough to store evreyone.
+    /// Create a list big enough to store everyone.
     unsigned int size = links.size() + dataFields.size() + listMethodsSize;
     PyObject * pyList = PyList_New(size);
 

--- a/applications/plugins/SofaPython/Binding_Base.cpp
+++ b/applications/plugins/SofaPython/Binding_Base.cpp
@@ -554,7 +554,6 @@ static PyObject * Base_getDataFields(PyObject *self, PyObject * /*args*/) {
     return pyDict;
 }
 
-
 /// This function is named this way because someone give the getDataFields to the one
 /// that returns a dictionary of (name, value) which is not coherente with the c++
 /// name of the function.
@@ -582,6 +581,67 @@ static PyObject * Base_getListOfLinks(PyObject *self, PyObject * /*args*/) {
     for (unsigned int i = 0; i < links.size(); ++i) {
         PyList_SetItem(pyList, i, SP_BUILD_PYPTR(Link, BaseLink, links[i], false)) ;
     }
+
+    return pyList;
+}
+
+
+/// This function is called by the Python interpreter when calling (dir).
+/// It add to the default behavior all the data fields and links of the object.
+static PyObject * Base___dir__(PyObject *self, PyObject * /*args*/) {
+    Base * component = get_base(self);
+
+    PyObject* listMethods = nullptr;
+    unsigned int listMethodsSize = 0;
+
+    /// Get the method lists
+    PyObject* pclass = PyObject_GetAttrString(self, "__class__");
+    if(pclass!=nullptr){
+        /// Returns a lists that contains the 'class' specific names (eg: method)
+        /// The list is a new reference which must be destroyed when not needed.
+        listMethods = PyObject_Dir(pclass);
+        if(listMethods==nullptr)
+        {
+            Py_XDECREF(pclass);
+            return nullptr;
+        }
+        listMethodsSize=PyList_Size(listMethods);
+    }
+
+    /// The the other names out of data & links
+    const sofa::helper::vector<BaseData*> dataFields = component->getDataFields();
+    const sofa::helper::vector<BaseLink*> links = component->getLinks() ;
+
+    /// Create a list big enough to store evreyone.
+    unsigned int size = links.size() + dataFields.size() + listMethodsSize;
+    PyObject * pyList = PyList_New(size);
+
+    /// Fill this lists
+    unsigned int dstIndex=0;
+
+    /// From methods..
+    for (unsigned int i = 0; i < listMethodsSize; ++i, ++dstIndex) {
+          PyObject* tmp = PyList_GetItem(listMethods, i);
+
+          /// Increment the reference counter to getItem because according to the documentation
+          /// the PyList_SetItem will steal it.
+          Py_INCREF(tmp);
+          PyList_SetItem(pyList, dstIndex, tmp);
+    }
+
+    /// From links
+    for (unsigned int i = 0; i < links.size(); ++i, ++dstIndex) {
+        PyList_SetItem(pyList, dstIndex, PyString_FromString(links[i]->getName().c_str())) ;
+    }
+
+    /// From datas
+    for (unsigned int i = 0; i < dataFields.size(); ++i, ++dstIndex) {
+        PyList_SetItem(pyList, dstIndex, PyString_FromString(dataFields[i]->getName().c_str())) ;
+    }
+
+    /// We release temporary object.
+    Py_XDECREF(pclass);
+    Py_XDECREF(listMethods);
 
     return pyList;
 }
@@ -615,16 +675,19 @@ SP_CLASS_METHOD_DOC(Base,getLink, "Returns the link field if there is one associ
 SP_CLASS_METHOD(Base,getClassName)
 SP_CLASS_METHOD(Base,getTemplateName)
 SP_CLASS_METHOD(Base,getName)
-
+SP_CLASS_METHOD(Base,__dir__)
 SP_CLASS_METHOD_DOC(Base,getDataFields, "Returns a list with the *content* of all the data fields converted in python"
                                         " type. \n")
 SP_CLASS_METHOD_DOC(Base,getListOfDataFields, "Returns the list of data fields.")
 SP_CLASS_METHOD_DOC(Base,getListOfLinks, "Returns the list of link fields.")
 SP_CLASS_METHOD(Base,downCast)
+
 SP_CLASS_METHODS_END;
 
 
 SP_CLASS_ATTRS_BEGIN(Base)
 SP_CLASS_ATTRS_END;
+
+
 
 SP_CLASS_TYPE_BASE_SPTR_ATTR_GETATTR(Base, Base)

--- a/applications/plugins/SofaPython/SofaPython_test/python/test_BindingBaseObject.py
+++ b/applications/plugins/SofaPython/SofaPython_test/python/test_BindingBaseObject.py
@@ -7,5 +7,7 @@ def createScene(rootNode):
     rootNode.createObject("MechanicalObject", name="dofs")
 
     ASSERT_EQ(type(rootNode.dofs.getCategories()), list)
-
+    ASSERT_EQ(type(dir(rootNode)), list)
     ASSERT_EQ(type(rootNode.dofs.getTarget()), str)
+
+    print(dir(rootNode.dofs))


### PR DESCRIPTION
This methods override the default behavior of python.

Now when writing: dir(myObject) this will returns the list of methods available in myObject but also the list with the Datas and the Links.

Example with:
```py
print(dir(myMechanicalObject))
```
Will prints:
```
['__class__', '__delattr__', '__dir__', '__doc__', '__format__', '__getattribute__', '__hash__', '__init__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', 'addData', 'addNewData', 'applyRotation', 'applyScale', 'applyTranslation', 'bbox', 'bwdInit', 'cleanup', 'computeBBox', 'constraint', 'context', 'derivX', 'downCast', 'drawMode', 'externalForce', 'findData', 'findLink', 'force', 'free_position', 'free_velocity', 'getAsACreateObjectParameter', 'getCategories', 'getClassName', 'getContext', 'getData', 'getDataFields', 'getLink', 'getLinkPath', 'getListOfDataFields', 'getListOfLinks', 'getMaster', 'getName', 'getPathName', 'getSize', 'getSlaves', 'getTarget', 'getTemplateName', 'init', 'isToPrint', 'listening', 'mappingJacobian', 'master', 'name', 'position', 'printLog', 'reinit', 'reserve', 'reset', 'reset_position', 'reset_velocity', 'resize', 'restScale', 'rest_position', 'rotation', 'rotation2', 'scale3d', 'setSrc', 'showColor', 'showIndices', 'showIndicesScale', 'showObject', 'showObjectScale', 'showVectors', 'showVectorsScale', 'size', 'slaves', 'storeResetState', 'tags', 'topology', 'translation', 'translation2', 'useTopology', 'velocity']
```

NB: There is minimal test to be sure this work.
NB2: I'm not found of this big list but didn't want to change the semantics to visually separate the links, the data and the methods. 






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
