### PR TITLE
[SofaKernel] Fix: correct path writing in sofa_set_python_directory macro

### DIFF
--- a/SofaKernel/SofaFramework/SofaMacros.cmake
+++ b/SofaKernel/SofaFramework/SofaMacros.cmake
@@ -277,7 +277,7 @@ macro(sofa_set_python_directory plugin_name directory)
 
     ## Python configuration file (build tree)
     file(WRITE "${CMAKE_BINARY_DIR}/etc/sofa/python.d/${plugin_name}"
-         "${CMAKE_CURRENT_SOURCE_DIR}/python")
+         "${CMAKE_CURRENT_SOURCE_DIR}/${directory}")
     ## Python configuration file (install tree)
      file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/installed-SofaPython-config"
          "lib/python2.7/site-packages")


### PR DESCRIPTION
__set_python_directory__ was writing a "hard-coded" _CMAKE_CURRENT_SOURCE_DIR/python_ path in _etc/sofa/python.d/_ instead of the provided path. 
So if your python code was located in, say, _<plugin_dir>/src/python_ instead of _<plugin_dir>/python_ the macro would write an invalid path.





______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
