### PR TITLE
[SofaKernel] Move ScriptEvent class from SofaPython to core/objectModel

### DIFF
--- a/SofaKernel/framework/sofa/core/CMakeLists.txt
+++ b/SofaKernel/framework/sofa/core/CMakeLists.txt
@@ -118,6 +118,7 @@ set(HEADER_FILES
     objectmodel/IdleEvent.h
     objectmodel/Link.h
     objectmodel/MouseEvent.h
+    objectmodel/ScriptEvent.h
     objectmodel/SPtr.h
     objectmodel/Tag.h
     topology/BaseMeshTopology.h
@@ -219,6 +220,7 @@ set(SOURCE_FILES
     objectmodel/KeypressedEvent.cpp
     objectmodel/KeyreleasedEvent.cpp
     objectmodel/MouseEvent.cpp
+    objectmodel/ScriptEvent.cpp
     objectmodel/IdleEvent.cpp
     objectmodel/Tag.cpp
     topology/BaseMeshTopology.cpp

--- a/SofaKernel/framework/sofa/core/objectmodel/ScriptEvent.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/ScriptEvent.cpp
@@ -19,7 +19,8 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "ScriptEvent.h"
+
+#include <sofa/core/objectmodel/ScriptEvent.h>
 
 namespace sofa
 {

--- a/SofaKernel/framework/sofa/core/objectmodel/ScriptEvent.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/ScriptEvent.h
@@ -19,10 +19,9 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SCRIPTEVENT_H
-#define SCRIPTEVENT_H
+#ifndef SOFA_CORE_OBJECTMODEL_SCRIPTEVENT_H
+#define SOFA_CORE_OBJECTMODEL_SCRIPTEVENT_H
 
-#include <SofaPython/config.h>
 #include <sofa/core/objectmodel/Event.h>
 #include <string>
 #include <sofa/simulation/Node.h>
@@ -38,9 +37,9 @@ namespace objectmodel
 {
 
 /**
- * @brief This event notifies about GUI interaction.
- */
-class SOFA_SOFAPYTHON_API ScriptEvent : public sofa::core::objectmodel::Event
+* @brief Generic Event class to send a message through the simulation graph.
+*/
+class SOFA_CORE_API ScriptEvent : public sofa::core::objectmodel::Event
 {
 public:
 
@@ -80,4 +79,4 @@ private:
 
 } // namespace sofa
 
-#endif // SCRIPTEVENT_H
+#endif // SOFA_CORE_OBJECTMODEL_SCRIPTEVENT_H

--- a/applications/plugins/SofaPython/CMakeLists.txt
+++ b/applications/plugins/SofaPython/CMakeLists.txt
@@ -69,7 +69,6 @@ set(HEADER_FILES
     SceneLoaderPY.h
     ScriptController.h
     ScriptDataEngine.h
-    ScriptEvent.h
     ScriptFunction.h
 )
 
@@ -129,7 +128,6 @@ set(SOURCE_FILES
     SceneLoaderPY.cpp
     ScriptController.cpp
     ScriptDataEngine.cpp
-    ScriptEvent.cpp
     ScriptFunction.cpp
     initSofaPython.cpp
     ctypes.cpp

--- a/applications/plugins/SofaPython/PythonScriptEvent.h
+++ b/applications/plugins/SofaPython/PythonScriptEvent.h
@@ -25,7 +25,7 @@
 #include "PythonCommon.h"
 
 #include <SofaPython/config.h>
-#include "ScriptEvent.h"
+#include <sofa/core/objectmodel/ScriptEvent.h>
 
 
 namespace sofa

--- a/applications/plugins/SofaPython/ScriptController.h
+++ b/applications/plugins/SofaPython/ScriptController.h
@@ -26,7 +26,7 @@
 #include <sofa/core/objectmodel/Context.h>
 #include <sofa/core/objectmodel/BaseObjectDescription.h>
 #include <sofa/simulation/Node.h>
-#include "ScriptEvent.h"
+#include <sofa/core/objectmodel/ScriptEvent.h>
 #include "ScriptFunction.h"
 
 /// fwd declaration

--- a/applications/plugins/SofaPython/ScriptDataEngine.h
+++ b/applications/plugins/SofaPython/ScriptDataEngine.h
@@ -5,7 +5,7 @@
 #include <sofa/core/objectmodel/Context.h>
 #include <sofa/core/objectmodel/BaseObjectDescription.h>
 #include <sofa/simulation/Node.h>
-#include "ScriptEvent.h"
+#include <sofa/core/objectmodel/ScriptEvent.h>
 #include "ScriptFunction.h"
 
 namespace sofa


### PR DESCRIPTION
Like the port salut, everything is in the title. 



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
