### PR TITLE
[SofaKernel] Check if Quaternion has norm 1

### DIFF
--- a/SofaKernel/framework/sofa/defaulttype/RigidTypes.h
+++ b/SofaKernel/framework/sofa/defaulttype/RigidTypes.h
@@ -643,6 +643,15 @@ public:
     inline friend std::istream& operator >> ( std::istream& in, RigidCoord<3,real>& v )
     {
         in>>v.center>>v.orientation;
+        if (!v.orientation.isNormalized())
+        {
+            std::stringstream text;
+            text << "Rigid Object with invalid quaternion (non-unitary norm)! Normalising quaternion value... " << msgendl;
+            text << "Previous value was: " << v.orientation << msgendl ;
+            v.orientation.normalize();
+            text << "New value is: " << v.orientation;
+            msg_warning("Rigid") << text.str();
+        }
         return in;
     }
     static int max_size()

--- a/SofaKernel/framework/sofa/helper/Quater.h
+++ b/SofaKernel/framework/sofa/helper/Quater.h
@@ -327,10 +327,12 @@ public:
         out<<v._q[0]<<" "<<v._q[1]<<" "<<v._q[2]<<" "<<v._q[3];
         return out;
     }
+
     /// read from an input stream
     inline friend std::istream& operator >> ( std::istream& in, Quater& v )
     {
         in>>v._q[0]>>v._q[1]>>v._q[2]>>v._q[3];
+        v.normalize();
         return in;
     }
 

--- a/SofaKernel/framework/sofa/helper/Quater.h
+++ b/SofaKernel/framework/sofa/helper/Quater.h
@@ -87,6 +87,9 @@ public:
         return this->_q;
     }
 
+    /// Returns true if norm of Quaternion is one, false otherwise.
+    bool isNormalized();
+
     /// Normalize a quaternion
     void normalize();
 
@@ -332,7 +335,6 @@ public:
     inline friend std::istream& operator >> ( std::istream& in, Quater& v )
     {
         in>>v._q[0]>>v._q[1]>>v._q[2]>>v._q[3];
-        v.normalize();
         return in;
     }
 

--- a/SofaKernel/framework/sofa/helper/Quater.inl
+++ b/SofaKernel/framework/sofa/helper/Quater.inl
@@ -254,12 +254,24 @@ template<class Real>
 void Quater<Real>::normalize()
 {
     Real mag = (_q[0] * _q[0] + _q[1] * _q[1] + _q[2] * _q[2] + _q[3] * _q[3]);
-    if( mag != 0)
+    double epsilon = 1.0e-10;
+    if (std::abs(mag - 1.0) > epsilon)
     {
-        Real sqr = static_cast<Real>(1.0 / sqrt(mag));
-        for (int i = 0; i < 4; i++)
+        if( mag != 0)
         {
-            _q[i] *= sqr;
+            Real sqr = static_cast<Real>(1.0 / sqrt(mag));
+            for (int i = 0; i < 4; i++)
+            {
+                _q[i] *= sqr;
+            }
+            msg_warning("Quater") << "Rigid Object with invalid quaternion (non-unitary norm)! Normalising quaternion value...";
+            msg_warning("Quater") << "New value is: " << _q[0] << " " << _q[1] << " " << _q[2] << " "<< _q[3];
+        }
+        else
+        {
+            _q[3] = 1;
+            msg_warning("Quater") << "Rigid Object with invalid quaternion (zero norm)! Normalising quaternion value...";
+            msg_warning("Quater") << "New value is: " << _q[0] << " " << _q[1] << " " << _q[2] << " "<< _q[3];
         }
     }
 }

--- a/SofaKernel/framework/sofa/helper/Quater.inl
+++ b/SofaKernel/framework/sofa/helper/Quater.inl
@@ -247,6 +247,16 @@ Quater<Real> Quater<Real>::inverse() const
     return ret;
 }
 
+/// Returns true if norm of Quaternion is one, false otherwise.
+template<class Real>
+bool Quater<Real>::isNormalized()
+{
+    Real mag = (_q[0] * _q[0] + _q[1] * _q[1] + _q[2] * _q[2] + _q[3] * _q[3]);
+    double epsilon = 1.0e-10;
+    return (std::abs(mag - 1.0) < epsilon);
+}
+
+
 /// Quater<Real>s always obey:  a^2 + b^2 + c^2 + d^2 = 1.0
 /// If they don't add up to 1.0, dividing by their magnitude will
 /// renormalize them.
@@ -264,14 +274,10 @@ void Quater<Real>::normalize()
             {
                 _q[i] *= sqr;
             }
-            msg_warning("Quater") << "Rigid Object with invalid quaternion (non-unitary norm)! Normalising quaternion value...";
-            msg_warning("Quater") << "New value is: " << _q[0] << " " << _q[1] << " " << _q[2] << " "<< _q[3];
         }
         else
         {
             _q[3] = 1;
-            msg_warning("Quater") << "Rigid Object with invalid quaternion (zero norm)! Normalising quaternion value...";
-            msg_warning("Quater") << "New value is: " << _q[0] << " " << _q[1] << " " << _q[2] << " "<< _q[3];
         }
     }
 }

--- a/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.inl
@@ -1276,6 +1276,39 @@ void MechanicalObject<DataTypes>::reinit()
 
     if (translation.getValue()[0]!=0.0 || translation.getValue()[1]!=0.0 || translation.getValue()[2]!=0.0)
         this->applyTranslation( translation.getValue()[0],translation.getValue()[1],translation.getValue()[2]);
+
+    if (x.getValue()[0].size() == 7)   // The object is a Rigid3D.
+    {
+        VecCoord rigidPositions = x.getValue();
+        double epsilon = 1.0e-10;
+        for (size_t i = 0; i<x.getValue().size();i++)
+        {
+            double x3 = (double)x.getValue()[i][3];
+            double x4 = (double)x.getValue()[i][4];
+            double x5 = (double)x.getValue()[i][5];
+            double x6 = (double)x.getValue()[i][6];
+            double normQuat = x3*x3 + x4*x4 + x5*x5 + x6*x6;
+            if (std::abs(normQuat - 1.0) > epsilon)
+            {
+                msg_warning() << "Rigid Object with invalid quaternion (non-unitary norm)! Normalising quaternion value.";
+                if (normQuat == 0.0)
+                {
+                    rigidPositions[i][3] = 0;
+                    rigidPositions[i][4] = 0;
+                    rigidPositions[i][5] = 0;
+                    rigidPositions[i][6] = 1;
+                }
+                else
+                {
+                    rigidPositions[i][3] = rigidPositions[i][3]/sqrt(normQuat);
+                    rigidPositions[i][4] = rigidPositions[i][4]/sqrt(normQuat);
+                    rigidPositions[i][5] = rigidPositions[i][5]/sqrt(normQuat);
+                    rigidPositions[i][6] = rigidPositions[i][6]/sqrt(normQuat);
+                }
+            }
+        }
+        x.setValue(rigidPositions);
+    }
 }
 
 template <class DataTypes>

--- a/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.inl
@@ -1276,39 +1276,6 @@ void MechanicalObject<DataTypes>::reinit()
 
     if (translation.getValue()[0]!=0.0 || translation.getValue()[1]!=0.0 || translation.getValue()[2]!=0.0)
         this->applyTranslation( translation.getValue()[0],translation.getValue()[1],translation.getValue()[2]);
-
-    if (x.getValue()[0].size() == 7)   // The object is a Rigid3D.
-    {
-        VecCoord rigidPositions = x.getValue();
-        double epsilon = 1.0e-10;
-        for (size_t i = 0; i<x.getValue().size();i++)
-        {
-            double x3 = (double)x.getValue()[i][3];
-            double x4 = (double)x.getValue()[i][4];
-            double x5 = (double)x.getValue()[i][5];
-            double x6 = (double)x.getValue()[i][6];
-            double normQuat = x3*x3 + x4*x4 + x5*x5 + x6*x6;
-            if (std::abs(normQuat - 1.0) > epsilon)
-            {
-                msg_warning() << "Rigid Object with invalid quaternion (non-unitary norm)! Normalising quaternion value.";
-                if (normQuat == 0.0)
-                {
-                    rigidPositions[i][3] = 0;
-                    rigidPositions[i][4] = 0;
-                    rigidPositions[i][5] = 0;
-                    rigidPositions[i][6] = 1;
-                }
-                else
-                {
-                    rigidPositions[i][3] = rigidPositions[i][3]/sqrt(normQuat);
-                    rigidPositions[i][4] = rigidPositions[i][4]/sqrt(normQuat);
-                    rigidPositions[i][5] = rigidPositions[i][5]/sqrt(normQuat);
-                    rigidPositions[i][6] = rigidPositions[i][6]/sqrt(normQuat);
-                }
-            }
-        }
-        x.setValue(rigidPositions);
-    }
 }
 
 template <class DataTypes>


### PR DESCRIPTION
Hello,
For the case of Rigid Mechanical Object (thus with position marked by the combination of a Vec3D and a quaternion for rotations), this PR adds a check if the quaternion is of unit 1 and normalizes it, if it is not. 
This PR does not handle the case when the user changes the value of the quaternion in the GUI.

Cheerio






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
