### PR TITLE
[MultiThreading] Fix Livers scenes crash 

### DIFF
--- a/SofaKernel/framework/sofa/helper/AdvancedTimer.cpp
+++ b/SofaKernel/framework/sofa/helper/AdvancedTimer.cpp
@@ -23,7 +23,6 @@
 #include <sofa/helper/AdvancedTimer.h>
 
 #include <sofa/helper/system/thread/CTime.h>
-#include <sofa/helper/system/thread/thread_specific_ptr.h>
 #include <sofa/helper/system/atomic.h>
 #include <sofa/helper/vector.h>
 #include <sofa/helper/map.h>

--- a/SofaKernel/framework/sofa/helper/AdvancedTimer.h
+++ b/SofaKernel/framework/sofa/helper/AdvancedTimer.h
@@ -23,7 +23,7 @@
 #define SOFA_HELPER_ADVANCEDTIMER_H
 #include <sofa/helper/helper.h>
 #include <sofa/simulation/Simulation.h>
-
+#include <sofa/helper/system/thread/thread_specific_ptr.h>
 
 #include <iostream>
 #include <string>
@@ -143,7 +143,7 @@ public:
             }
 
         public:
-
+            
             /**
                @return the Id corresponding to the name of the id given in parameter
                If the name isn't found in the list, it is added to it and return the new id.
@@ -188,8 +188,12 @@ public:
             /// return the instance of the factory. Creates it if doesn't exist yet.
             static IdFactory& getInstance()
             {
-                static IdFactory instance;
-                return instance;
+                static sofa::helper::system::thread::thread_specific_ptr<IdFactory> instance;
+                if (instance == nullptr)
+                {
+                    instance = new IdFactory;
+                }
+                return *instance;
             }
         };
 

--- a/SofaKernel/framework/sofa/helper/AdvancedTimer.h
+++ b/SofaKernel/framework/sofa/helper/AdvancedTimer.h
@@ -186,7 +186,7 @@ public:
             }
 
             /// return the instance of the factory. Creates it if doesn't exist yet.
-            static AdvancedTimer::Id<Base>::IdFactory& getInstance()
+            static IdFactory& getInstance()
             {
                 SOFA_THREAD_SPECIFIC_PTR(IdFactory, instance);
                 if (instance == nullptr)

--- a/SofaKernel/framework/sofa/helper/AdvancedTimer.h
+++ b/SofaKernel/framework/sofa/helper/AdvancedTimer.h
@@ -188,14 +188,10 @@ public:
             }
 
             /// return the instance of the factory. Creates it if doesn't exist yet.
-            static AdvancedTimer::Id<Base>::IdFactory& getInstance()
+            static IdFactory& getInstance()
             {
-                static sofa::helper::system::thread::thread_specific_ptr<AdvancedTimer::Id<Base>::IdFactory> instance;
-                if (instance == nullptr)
-                {
-                    instance = new AdvancedTimer::Id<Base>::IdFactory;
-                }
-                return *instance;
+                static thread_local IdFactory instance;
+                return instance;
             }
         };
 

--- a/SofaKernel/framework/sofa/helper/AdvancedTimer.h
+++ b/SofaKernel/framework/sofa/helper/AdvancedTimer.h
@@ -141,8 +141,6 @@ public:
             {
                 idsList.push_back(std::string("0")); // ID 0 == "0" or empty string
             }
-
-            static sofa::helper::system::thread::thread_specific_ptr<Id<Base>::IdFactory> instance;
             
         public:
             
@@ -188,10 +186,14 @@ public:
             }
 
             /// return the instance of the factory. Creates it if doesn't exist yet.
-            static IdFactory& getInstance()
+            static AdvancedTimer::Id<Base>::IdFactory& getInstance()
             {
-                static thread_local IdFactory instance;
-                return instance;
+                static sofa::helper::system::thread::thread_specific_ptr<AdvancedTimer::Id<Base>::IdFactory> instance;
+                if (instance == nullptr)
+                {
+                    instance = new AdvancedTimer::Id<Base>::IdFactory;
+                }
+                return *instance;
             }
         };
 

--- a/SofaKernel/framework/sofa/helper/AdvancedTimer.h
+++ b/SofaKernel/framework/sofa/helper/AdvancedTimer.h
@@ -188,10 +188,10 @@ public:
             /// return the instance of the factory. Creates it if doesn't exist yet.
             static AdvancedTimer::Id<Base>::IdFactory& getInstance()
             {
-                static sofa::helper::system::thread::thread_specific_ptr<AdvancedTimer::Id<Base>::IdFactory> instance;
+                SOFA_THREAD_SPECIFIC_PTR(IdFactory, instance);
                 if (instance == nullptr)
                 {
-                    instance = new AdvancedTimer::Id<Base>::IdFactory;
+                    instance = new IdFactory;
                 }
                 return *instance;
             }

--- a/SofaKernel/framework/sofa/helper/AdvancedTimer.h
+++ b/SofaKernel/framework/sofa/helper/AdvancedTimer.h
@@ -142,6 +142,8 @@ public:
                 idsList.push_back(std::string("0")); // ID 0 == "0" or empty string
             }
 
+            static sofa::helper::system::thread::thread_specific_ptr<Id<Base>::IdFactory> instance;
+            
         public:
             
             /**
@@ -186,12 +188,12 @@ public:
             }
 
             /// return the instance of the factory. Creates it if doesn't exist yet.
-            static IdFactory& getInstance()
+            static AdvancedTimer::Id<Base>::IdFactory& getInstance()
             {
-                static sofa::helper::system::thread::thread_specific_ptr<IdFactory> instance;
+                static sofa::helper::system::thread::thread_specific_ptr<AdvancedTimer::Id<Base>::IdFactory> instance;
                 if (instance == nullptr)
                 {
-                    instance = new IdFactory;
+                    instance = new AdvancedTimer::Id<Base>::IdFactory;
                 }
                 return *instance;
             }

--- a/applications/plugins/MultiThreading/src/DefaultTaskScheduler.cpp
+++ b/applications/plugins/MultiThreading/src/DefaultTaskScheduler.cpp
@@ -21,7 +21,7 @@ namespace sofa
 
         std::map< std::thread::id, WorkerThread*> TaskSchedulerDefault::_threads;
         
-        const bool TaskSchedulerDefault::isRegistered = TaskScheduler::registerScheduler(TaskSchedulerDefault::name(), &TaskSchedulerDefault::create);
+//        const bool TaskSchedulerDefault::isRegistered = TaskScheduler::registerScheduler(TaskSchedulerDefault::name(), &TaskSchedulerDefault::create);
 
 
         TaskSchedulerDefault* TaskSchedulerDefault::create()

--- a/applications/plugins/MultiThreading/src/DefaultTaskScheduler.cpp
+++ b/applications/plugins/MultiThreading/src/DefaultTaskScheduler.cpp
@@ -19,17 +19,15 @@ namespace sofa
         //static  WorkerThread* WorkerThread::_workerThreadIndex = nullptr;
         SOFA_THREAD_SPECIFIC_PTR(WorkerThread, workerThreadIndex);
 
-        std::map< std::thread::id, WorkerThread*> TaskSchedulerDefault::_threads;
-        
-//        const bool TaskSchedulerDefault::isRegistered = TaskScheduler::registerScheduler(TaskSchedulerDefault::name(), &TaskSchedulerDefault::create);
+        std::map< std::thread::id, WorkerThread*> DefaultTaskScheduler::_threads;
 
 
-        TaskSchedulerDefault* TaskSchedulerDefault::create()
+        DefaultTaskScheduler* DefaultTaskScheduler::create()
         {
-            return new TaskSchedulerDefault();
+            return new DefaultTaskScheduler();
         }
 
-        TaskSchedulerDefault::TaskSchedulerDefault()
+        DefaultTaskScheduler::DefaultTaskScheduler()
             : TaskScheduler()
 		{
 			_isInitialized = false;
@@ -42,7 +40,7 @@ namespace sofa
            
 		}
 
-        TaskSchedulerDefault::~TaskSchedulerDefault()
+        DefaultTaskScheduler::~DefaultTaskScheduler()
 		{
 			if ( _isInitialized ) 
 			{
@@ -51,13 +49,13 @@ namespace sofa
 		}
 
 
-		unsigned TaskSchedulerDefault::GetHardwareThreadsCount()
+		unsigned DefaultTaskScheduler::GetHardwareThreadsCount()
 		{
 			return std::thread::hardware_concurrency() / 2;
 		}
 
 
-		const WorkerThread* TaskSchedulerDefault::getWorkerThread(const std::thread::id id)
+		const WorkerThread* DefaultTaskScheduler::getWorkerThread(const std::thread::id id)
 		{
 			auto thread =_threads.find(id);
 			if (thread == _threads.end() )
@@ -67,7 +65,7 @@ namespace sofa
 			return thread->second;
 		}
 
-        void TaskSchedulerDefault::init(const unsigned int NbThread )
+        void DefaultTaskScheduler::init(const unsigned int NbThread )
         {
             if ( _isInitialized )
             {
@@ -81,7 +79,7 @@ namespace sofa
             start(NbThread);
         }
         
-		void TaskSchedulerDefault::start(const unsigned int NbThread )
+		void DefaultTaskScheduler::start(const unsigned int NbThread )
 		{
 			stop();
 
@@ -113,7 +111,7 @@ namespace sofa
 
 
 
-		void TaskSchedulerDefault::stop()
+		void DefaultTaskScheduler::stop()
 		{
 			_isClosing = true;
 
@@ -157,37 +155,37 @@ namespace sofa
 			return;
 		}
 
-        const char* TaskSchedulerDefault::getCurrentThreadName()
+        const char* DefaultTaskScheduler::getCurrentThreadName()
         {
             WorkerThread* thread = WorkerThread::getCurrent();
             return thread->getName();
         }
 
-        bool TaskSchedulerDefault::addTask(Task* task)
+        bool DefaultTaskScheduler::addTask(Task* task)
         {
             WorkerThread* thread = WorkerThread::getCurrent();
             return thread->addTask(task);
         }
 
-        void TaskSchedulerDefault::workUntilDone(Task::Status* status)
+        void DefaultTaskScheduler::workUntilDone(Task::Status* status)
         {
             WorkerThread* thread = WorkerThread::getCurrent();
             thread->workUntilDone(status);
         }
 
-        void* TaskSchedulerDefault::allocateTask(size_t size)
+        void* DefaultTaskScheduler::allocateTask(size_t size)
         {
             return std::malloc(size);
         }
 
-        void TaskSchedulerDefault::releaseTask(Task* task)
+        void DefaultTaskScheduler::releaseTask(Task* task)
         {
             delete task;
         }
 
 
 
-		void TaskSchedulerDefault::wakeUpWorkers()
+		void DefaultTaskScheduler::wakeUpWorkers()
 		{
 			{
 				std::lock_guard<std::mutex> guard(_wakeUpMutex);
@@ -196,7 +194,7 @@ namespace sofa
 			_wakeUpEvent.notify_all();
 		}
 
-		void TaskSchedulerDefault::WaitForWorkersToBeReady()
+		void DefaultTaskScheduler::WaitForWorkersToBeReady()
 		{
 			_workerThreadsIdle = true;
 		}
@@ -209,7 +207,7 @@ namespace sofa
 
 
 
-        WorkerThread::WorkerThread(TaskSchedulerDefault* const& pScheduler, const int index, const std::string& name)
+        WorkerThread::WorkerThread(DefaultTaskScheduler* const& pScheduler, const int index, const std::string& name)
             : _tasks()
             , _index(index)
             , _name(name + std::to_string(index))
@@ -235,7 +233,7 @@ namespace sofa
             return _finished;
         }
 
-		bool WorkerThread::start(TaskSchedulerDefault* const& taskScheduler)
+		bool WorkerThread::start(DefaultTaskScheduler* const& taskScheduler)
 		{
 			assert(taskScheduler);
 			_taskScheduler = taskScheduler;
@@ -244,7 +242,7 @@ namespace sofa
 			return  true;
 		}
 
-        std::thread* WorkerThread::create_and_attach(TaskSchedulerDefault* const & taskScheduler)
+        std::thread* WorkerThread::create_and_attach(DefaultTaskScheduler* const & taskScheduler)
         {
             _stdThread = std::thread(std::bind(&WorkerThread::run, this));
             return &_stdThread;
@@ -253,8 +251,8 @@ namespace sofa
         WorkerThread* WorkerThread::getCurrent()
         {
             //return workerThreadIndex;
-            auto thread = TaskSchedulerDefault::_threads.find(std::this_thread::get_id());
-            if (thread == TaskSchedulerDefault::_threads.end())
+            auto thread = DefaultTaskScheduler::_threads.find(std::this_thread::get_id());
+            if (thread == DefaultTaskScheduler::_threads.end())
             {
                 return nullptr;
             }

--- a/applications/plugins/MultiThreading/src/DefaultTaskScheduler.h
+++ b/applications/plugins/MultiThreading/src/DefaultTaskScheduler.h
@@ -64,7 +64,7 @@ namespace sofa  {
 #endif
 
 
-        class TaskSchedulerDefault;
+        class DefaultTaskScheduler;
         class WorkerThread;
 
 
@@ -72,7 +72,7 @@ namespace sofa  {
         {
         public:
 
-            WorkerThread(TaskSchedulerDefault* const& taskScheduler, const int index, const std::string& name = "Worker");
+            WorkerThread(DefaultTaskScheduler* const& taskScheduler, const int index, const std::string& name = "Worker");
 
             ~WorkerThread();
 
@@ -104,9 +104,9 @@ namespace sofa  {
 
         private:
 
-            bool start(TaskSchedulerDefault* const& taskScheduler);
+            bool start(DefaultTaskScheduler* const& taskScheduler);
 
-            std::thread* create_and_attach(TaskSchedulerDefault* const& taskScheduler);
+            std::thread* create_and_attach(DefaultTaskScheduler* const& taskScheduler);
 
             void runTask(Task* task);
 
@@ -148,17 +148,17 @@ namespace sofa  {
 
             Task::Status*	_currentStatus;
 
-            TaskSchedulerDefault*     _taskScheduler;
+            DefaultTaskScheduler*     _taskScheduler;
 
             // The following members may be accessed by _multiple_ threads at the same time:
             volatile bool	_finished;
 
-            friend class TaskSchedulerDefault;
+            friend class DefaultTaskScheduler;
         };
 
 
 
-        class SOFA_MULTITHREADING_PLUGIN_API TaskSchedulerDefault : public TaskScheduler
+        class SOFA_MULTITHREADING_PLUGIN_API DefaultTaskScheduler : public TaskScheduler
         {
             enum
             {
@@ -184,9 +184,9 @@ namespace sofa  {
             // factory methods: name, creator function
             static const char* name() { return "_default"; }
 
-            static TaskSchedulerDefault* create();
+            static DefaultTaskScheduler* create();
 
-            static bool isRegistered;
+            static const bool isRegistered;
 
         private:
 
@@ -221,11 +221,11 @@ namespace sofa  {
 
         private:
 
-            TaskSchedulerDefault();
+            DefaultTaskScheduler();
 
-            TaskSchedulerDefault(const TaskSchedulerDefault&) {}
+            DefaultTaskScheduler(const DefaultTaskScheduler&) {}
 
-            virtual ~TaskSchedulerDefault();
+            virtual ~DefaultTaskScheduler();
 
             void start(unsigned int NbThread);
 

--- a/applications/plugins/MultiThreading/src/DefaultTaskScheduler.h
+++ b/applications/plugins/MultiThreading/src/DefaultTaskScheduler.h
@@ -186,7 +186,7 @@ namespace sofa  {
 
             static TaskSchedulerDefault* create();
 
-            static const bool isRegistered;
+            static bool isRegistered;
 
         private:
 

--- a/applications/plugins/MultiThreading/src/TaskScheduler.cpp
+++ b/applications/plugins/MultiThreading/src/TaskScheduler.cpp
@@ -17,6 +17,10 @@ namespace sofa
         std::string TaskScheduler::_currentSchedulerName;
         TaskScheduler* TaskScheduler::_currentScheduler = nullptr;
 
+        // register default task scheduler
+        bool TaskSchedulerDefault::isRegistered = TaskScheduler::registerScheduler(TaskSchedulerDefault::name(), &TaskSchedulerDefault::create);
+
+        
         TaskScheduler* TaskScheduler::create(const char* name)
         {
             // is already the current scheduler

--- a/applications/plugins/MultiThreading/src/TaskScheduler.cpp
+++ b/applications/plugins/MultiThreading/src/TaskScheduler.cpp
@@ -12,13 +12,14 @@ namespace sofa
 	namespace simulation
 	{
         
-
+        // the order of initialization of these static vars is important
+        // the TaskScheduler::_schedulers must be initialized before any call to TaskScheduler::registerScheduler
         std::map<std::string, std::function<TaskScheduler*()> > TaskScheduler::_schedulers;
         std::string TaskScheduler::_currentSchedulerName;
         TaskScheduler* TaskScheduler::_currentScheduler = nullptr;
 
         // register default task scheduler
-        bool TaskSchedulerDefault::isRegistered = TaskScheduler::registerScheduler(TaskSchedulerDefault::name(), &TaskSchedulerDefault::create);
+        const bool DefaultTaskScheduler::isRegistered = TaskScheduler::registerScheduler(DefaultTaskScheduler::name(), &DefaultTaskScheduler::create);
 
         
         TaskScheduler* TaskScheduler::create(const char* name)

--- a/applications/plugins/MultiThreading/test/TaskSchedulerTests.cpp
+++ b/applications/plugins/MultiThreading/test/TaskSchedulerTests.cpp
@@ -10,7 +10,7 @@ namespace sofa
 	// compute the Fibonacci number for input N
 	static int64_t Fibonacci(int64_t N, int nbThread = 0)
 	{
-        simulation::TaskScheduler* scheduler = simulation::TaskScheduler::create(simulation::TaskSchedulerDefault::name());
+        simulation::TaskScheduler* scheduler = simulation::TaskScheduler::create(simulation::DefaultTaskScheduler::name());
         scheduler->init(nbThread);
 
         simulation::Task::Status status;
@@ -28,7 +28,7 @@ namespace sofa
 	// compute the sum of integers from 1 to N
 	static int64_t IntSum1ToN(const int64_t N, int nbThread = 0)
 	{
-        simulation::TaskScheduler* scheduler = simulation::TaskScheduler::create(simulation::TaskSchedulerDefault::name());
+        simulation::TaskScheduler* scheduler = simulation::TaskScheduler::create(simulation::DefaultTaskScheduler::name());
         scheduler->init(nbThread);
 
         simulation::Task::Status status;


### PR DESCRIPTION
CHANGE: AdvanceTimer::Id::IdFactory is no more a singleton static class but  a thread local class to prevent different threads to share the same instance of the class.

FIX: DefaultTaskScheduler registration to TaskScheduler factory is forced to be executed after the TaskScheduler static initialization.




______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
