### PR TITLE
[Compliant] update se3.h license to make it compatible with core

### DIFF
--- a/applications/plugins/Compliant/utils/se3.h
+++ b/applications/plugins/Compliant/utils/se3.h
@@ -4,7 +4,7 @@
 // SE(3) kinematics
 
 // author: tournier.maxime@gmail.com
-// license: LGPL 2.1 and later
+// license: LGPL 2.1-or-later
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>

--- a/applications/plugins/Compliant/utils/se3.h
+++ b/applications/plugins/Compliant/utils/se3.h
@@ -3,8 +3,8 @@
 
 // SE(3) kinematics
 
-// author: maxime.tournier@inria.fr
-// license: LGPL 2.1
+// author: tournier.maxime@gmail.com
+// license: LGPL 2.1 and later
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -258,8 +258,8 @@ struct SE3 {
         real sin_half_theta; // note that sin(theta/2) == norm of the imaginary part for unit quaternion
         real theta;
 
-        // to avoid numerical instabilities of acos for theta < 5°
-        if(w>0.999) // theta < 5° -> _q[3] = cos(theta/2) > 0.999
+        // to avoid numerical instabilities of acos for theta < 5Â°
+        if(w>0.999) // theta < 5Â° -> _q[3] = cos(theta/2) > 0.999
         {
             sin_half_theta = q.vec().norm();
             theta = (real)(2.0 * asin(sin_half_theta)); // in (0, pi)


### PR DESCRIPTION
Dear all,

Just a quick PR to change the license for a file in the Compliant plugin.

The file in question is `Compliant/utils/se3.h`, which I originally licensed under LGPL 2.1 only. 

All of its contributors (@matthieu-nesme, @RomainTestylier  and myself) are currently working at Anatoscope, and we would like to change the license to match that of Sofa's core. 

Of course, all the contributors agree with this change.

The license would change from "LGPL 2.1" to "LGPL 2.1-or-later".

Best regards,
