### PR TITLE
[SofaBoundaryCondition] Refactor FixedPlaneConstraint (breaking) 

### DIFF
--- a/applications/plugins/SofaTest/Elasticity_test.inl
+++ b/applications/plugins/SofaTest/Elasticity_test.inl
@@ -218,9 +218,9 @@ CylinderTractionStruct<DataTypes>  Elasticity_test<DataTypes>::createCylinderTra
     // FixedPlaneConstraint
     typename component::projectiveconstraintset::FixedPlaneConstraint<DataTypes>::SPtr fpc=
             modeling::addNew<typename component::projectiveconstraintset::FixedPlaneConstraint<DataTypes> >(root);
-    fpc->dmin= -0.01;
-    fpc->dmax= 0.01;
-    fpc->direction=Coord(0,0,1);
+    fpc->d_dmin= -0.01;
+    fpc->d_dmax= 0.01;
+    fpc->d_direction=Coord(0,0,1);
     /// box pressure
     box[0]= -0.2;box[1]= -0.2;box[2]= 0.99;box[3]= 0.2;box[4]= 0.2;box[5]= 1.01;
     vecBox[0]=box;

--- a/modules/SofaBoundaryCondition/FixedPlaneConstraint.cpp
+++ b/modules/SofaBoundaryCondition/FixedPlaneConstraint.cpp
@@ -41,81 +41,21 @@ using namespace sofa::helper;
 SOFA_DECL_CLASS(FixedPlaneConstraint)
 
 int FixedPlaneConstraintClass = core::RegisterObject("Project particles on a given plane")
-#ifndef SOFA_FLOAT
-        .add< FixedPlaneConstraint<Vec3dTypes> >()
-        .add< FixedPlaneConstraint<Vec6dTypes> >()
-        .add< FixedPlaneConstraint<Rigid3dTypes> >()
-#endif
-#ifndef SOFA_DOUBLE
+#ifdef SOFA_WITH_FLOAT
         .add< FixedPlaneConstraint<Vec3fTypes> >()
         .add< FixedPlaneConstraint<Vec6fTypes> >()
         .add< FixedPlaneConstraint<Rigid3fTypes> >()
-#endif
+#endif /// SOFA_WITH_FLOAT
+#ifdef SOFA_WITH_DOUBLE
+        .add< FixedPlaneConstraint<Rigid3dTypes> >()
+        .add< FixedPlaneConstraint<Vec3dTypes> >()
+        .add< FixedPlaneConstraint<Vec6dTypes> >()
+#endif /// SOFA_WITH_DOUBLE
         ;
 
+} /// namespace projectiveconstraintset
 
-#ifndef SOFA_FLOAT
-template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<Rigid3dTypes>;
-template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<Vec3dTypes>;
-template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<Vec6dTypes>;
-#endif
-#ifndef SOFA_DOUBLE
-template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<Rigid3fTypes>;
-template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<Vec3fTypes>;
-template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<Vec6fTypes>;
-#endif
+} /// namespace component
 
-#ifndef SOFA_FLOAT
-template <> template <class DataDeriv>
-void FixedPlaneConstraint<Rigid3dTypes>::projectResponseT(const core::MechanicalParams* /*mparams*/, DataDeriv& res)
-{
-    Vec<Coord::spatial_dimensions,Real> dir=direction.getValue().getCenter();
-
-    for (helper::vector< unsigned int > ::const_iterator it = this->indices.getValue().begin(); it != this->indices.getValue().end(); ++it)
-    {
-        getVCenter(res[*it]) -= dir*(dir*(getVCenter(res[*it])));
-    }
-}
-
-template <>
-bool FixedPlaneConstraint<Rigid3dTypes>::isPointInPlane(Rigid3dTypes::Coord p)
-{
-    Vec<Coord::spatial_dimensions,Real> pos = p.getCenter();
-    Real d=pos*direction.getValue().getCenter();
-    if ((d>dmin.getValue())&& (d<dmax.getValue()))
-        return true;
-    else
-        return false;
-}
-#endif
-
-#ifndef SOFA_DOUBLE
-template <> template <class DataDeriv>
-void FixedPlaneConstraint<Rigid3fTypes>::projectResponseT(const core::MechanicalParams* /*mparams*/, DataDeriv& res)
-{
-    Vec<Coord::spatial_dimensions,Real> dir=direction.getValue().getCenter();
-
-    for (helper::vector< unsigned int > ::const_iterator it = this->indices.getValue().begin(); it != this->indices.getValue().end(); ++it)
-    {
-        getVCenter(res[*it]) -= dir*(dir*(getVCenter(res[*it])));
-    }
-}
-
-template <>
-bool FixedPlaneConstraint<Rigid3fTypes>::isPointInPlane(Coord p)
-{
-    Vec<Coord::spatial_dimensions,Real> pos = p.getCenter();
-    Real d=pos*direction.getValue().getCenter();
-    if ((d>dmin.getValue())&& (d<dmax.getValue()))
-        return true;
-    else
-        return false;
-}
-#endif
-
-} // namespace projectiveconstraintset
-
-} // namespace component
-
-} // namespace sofa
+} /// namespace sofa
 

--- a/modules/SofaBoundaryCondition/FixedPlaneConstraint.cpp
+++ b/modules/SofaBoundaryCondition/FixedPlaneConstraint.cpp
@@ -19,6 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#define SOFA_COMPONENT_PROJECTIVECONSTRAINTSET_FIXEDPLANECONSTRAINT_CPP
 #include <SofaBoundaryCondition/FixedPlaneConstraint.inl>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/defaulttype/Vec3Types.h>

--- a/modules/SofaBoundaryCondition/FixedPlaneConstraint.cpp
+++ b/modules/SofaBoundaryCondition/FixedPlaneConstraint.cpp
@@ -53,6 +53,17 @@ int FixedPlaneConstraintClass = core::RegisterObject("Project particles on a giv
 #endif /// SOFA_WITH_DOUBLE
         ;
 
+#ifdef SOFA_WITH_DOUBLE
+template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<defaulttype::Rigid3dTypes>;
+template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<defaulttype::Vec3dTypes>;
+template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<defaulttype::Vec6dTypes>;
+#endif /// SOFA_WITH_DOUBLE
+#ifdef SOFA_WITH_FLOAT
+template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<defaulttype::Rigid3fTypes>;
+template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<defaulttype::Vec3fTypes>;
+template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<defaulttype::Vec6fTypes>;
+#endif /// SOFA_WITH_FLOAT
+
 } /// namespace projectiveconstraintset
 
 } /// namespace component

--- a/modules/SofaBoundaryCondition/FixedPlaneConstraint.cpp
+++ b/modules/SofaBoundaryCondition/FixedPlaneConstraint.cpp
@@ -19,8 +19,6 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#define SOFA_COMPONENT_PROJECTIVECONSTRAINTSET_FIXEDPLANECONSTRAINT_CPP
-
 #include <SofaBoundaryCondition/FixedPlaneConstraint.inl>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/defaulttype/Vec3Types.h>
@@ -34,11 +32,8 @@ namespace component
 
 namespace projectiveconstraintset
 {
-
 using namespace sofa::defaulttype;
 using namespace sofa::helper;
-
-SOFA_DECL_CLASS(FixedPlaneConstraint)
 
 int FixedPlaneConstraintClass = core::RegisterObject("Project particles on a given plane")
 #ifdef SOFA_WITH_FLOAT

--- a/modules/SofaBoundaryCondition/FixedPlaneConstraint.h
+++ b/modules/SofaBoundaryCondition/FixedPlaneConstraint.h
@@ -117,13 +117,13 @@ protected:
     class FCPointHandler;
 
     /// Handler for subset Data
-    FCPointHandler* m_pointHandler;
+    FCPointHandler* m_pointHandler {nullptr};
 
     /// whether vertices should be selected from 2 parallel planes
-    bool m_selectVerticesFromPlanes;
+    bool m_selectVerticesFromPlanes {false};
 
     /// Pointer to the current topology
-    BaseMeshTopology* m_topology;
+    BaseMeshTopology* m_topology {nullptr};
 
     ////////////////////////// Inherited attributes ////////////////////////////
     /// https://gcc.gnu.org/onlinedocs/gcc/Name-lookup.html
@@ -140,6 +140,7 @@ protected:
     template<class T>
     void projectResponseImpl(const MechanicalParams* mparams, T& dx) const ;
 };
+
 
 #if !defined(SOFA_COMPONENT_PROJECTIVECONSTRAINTSET_FIXEDPLANECONSTRAINT_CPP)
 #ifdef SOFA_WITH_DOUBLE

--- a/modules/SofaBoundaryCondition/FixedPlaneConstraint.h
+++ b/modules/SofaBoundaryCondition/FixedPlaneConstraint.h
@@ -142,7 +142,6 @@ protected:
 };
 
 
-#if !defined(SOFA_COMPONENT_PROJECTIVECONSTRAINTSET_FIXEDPLANECONSTRAINT_CPP)
 #ifdef SOFA_WITH_DOUBLE
 extern template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<defaulttype::Rigid3dTypes>;
 extern template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<defaulttype::Vec3dTypes>;
@@ -153,7 +152,6 @@ extern template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<defaultty
 extern template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<defaulttype::Vec3fTypes>;
 extern template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<defaulttype::Vec6fTypes>;
 #endif /// SOFA_WITH_FLOAT
-#endif
 
 } // namespace projectiveconstraintset
 

--- a/modules/SofaBoundaryCondition/FixedPlaneConstraint.h
+++ b/modules/SofaBoundaryCondition/FixedPlaneConstraint.h
@@ -141,7 +141,7 @@ protected:
     void projectResponseImpl(const MechanicalParams* mparams, T& dx) const ;
 };
 
-
+#if !defined(SOFA_COMPONENT_PROJECTIVECONSTRAINTSET_FIXEDPLANECONSTRAINT_CPP)
 #ifdef SOFA_WITH_DOUBLE
 extern template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<defaulttype::Rigid3dTypes>;
 extern template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<defaulttype::Vec3dTypes>;
@@ -152,6 +152,7 @@ extern template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<defaultty
 extern template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<defaulttype::Vec3fTypes>;
 extern template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<defaulttype::Vec6fTypes>;
 #endif /// SOFA_WITH_FLOAT
+#endif
 
 } // namespace projectiveconstraintset
 

--- a/modules/SofaBoundaryCondition/FixedPlaneConstraint.h
+++ b/modules/SofaBoundaryCondition/FixedPlaneConstraint.h
@@ -23,12 +23,12 @@
 #define SOFA_COMPONENT_PROJECTIVECONSTRAINTSET_FIXEDPLANECONSTRAINT_H
 #include "config.h"
 
+#include <set>
+
 #include <sofa/core/behavior/ProjectiveConstraintSet.h>
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
-#include <set>
 #include <SofaBaseTopology/TopologySubsetData.h>
-
 
 namespace sofa
 {
@@ -38,6 +38,12 @@ namespace component
 
 namespace projectiveconstraintset
 {
+using sofa::defaulttype::BaseVector;
+using sofa::core::MechanicalParams;
+using sofa::core::visual::VisualParams;
+using sofa::core::topology::BaseMeshTopology;
+using sofa::core::behavior::MultiMatrixAccessor;
+using sofa::core::behavior::ProjectiveConstraintSet;
 
 /// This class can be overriden if needed for additionnal storage within template specilizations.
 template <class DataTypes>
@@ -46,10 +52,11 @@ class FixedPlaneConstraintInternalData
 };
 
 template <class DataTypes>
-class FixedPlaneConstraint : public core::behavior::ProjectiveConstraintSet<DataTypes>
+class FixedPlaneConstraint : public ProjectiveConstraintSet<DataTypes>
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE(FixedPlaneConstraint,DataTypes),SOFA_TEMPLATE(sofa::core::behavior::ProjectiveConstraintSet, DataTypes));
+    SOFA_CLASS(SOFA_TEMPLATE(FixedPlaneConstraint,DataTypes),
+               SOFA_TEMPLATE(ProjectiveConstraintSet, DataTypes));
 
     typedef typename DataTypes::VecCoord VecCoord;
     typedef typename DataTypes::VecDeriv VecDeriv;
@@ -63,120 +70,88 @@ public:
     typedef Data<VecDeriv> DataVecDeriv;
     typedef Data<MatrixDeriv> DataMatrixDeriv;
     typedef helper::vector<unsigned int> SetIndexArray;
-    typedef sofa::component::topology::PointSubsetData< SetIndexArray > SetIndex;
+    typedef component::topology::PointSubsetData< SetIndexArray > SetIndex;
 public:
     /// direction on which the constraint applies
-    Data<Coord> direction;
+    Data<Coord> d_direction;
 
-    Data<Real> dmin; ///< coordinates min of the plane for the vertex selection
-    Data<Real> dmax;///< coordinates max of the plane for the vertex selection
-protected:
-    FixedPlaneConstraintInternalData<DataTypes> data;
-    friend class FixedPlaneConstraintInternalData<DataTypes>;
+    Data<Real> d_dmin; ///< coordinates min of the plane for the vertex selection
+    Data<Real> d_dmax; ///< coordinates max of the plane for the vertex selection
+    SetIndex   d_indices; ///< the set of vertex indices
 
-    template <class DataDeriv>
-    void projectResponseT(const core::MechanicalParams* mparams, DataDeriv& dx);
-
-    SetIndex indices; ///< the set of vertex indices
-
-    /// whether vertices should be selected from 2 parallel planes
-    bool selectVerticesFromPlanes;
-
-
-    FixedPlaneConstraint();
-
-    ~FixedPlaneConstraint();
-public:
-    void addConstraint(int index);
-
-    void removeConstraint(int index);
-
-    // -- Constraint interface
-
-    void projectResponse(const core::MechanicalParams* mparams, DataVecDeriv& resData) override;
-    void projectVelocity(const core::MechanicalParams* mparams, DataVecDeriv& vData) override;
-    void projectPosition(const core::MechanicalParams* mparams, DataVecCoord& xData) override;
-    // Implement projectMatrix for assembled solver of compliant
-    virtual void projectMatrix( sofa::defaulttype::BaseMatrix* /*M*/, unsigned /*offset*/ ) override;
-    void projectJacobianMatrix(const core::MechanicalParams* mparams, DataMatrixDeriv& cData) override;
-
-	// Implement applyConstraint for direct solvers
-    virtual void applyConstraint(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
-    virtual void applyConstraint(const core::MechanicalParams* mparams, defaulttype::BaseVector* vector, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
-
-
+    /// inherited from the BaseObject interface
     virtual void init() override;
+    virtual void draw(const VisualParams* vparams) override;
+
+    /// -- Constraint interface
+    virtual void projectResponse(const MechanicalParams* mparams, DataVecDeriv& resData) override;
+    virtual void projectVelocity(const MechanicalParams* mparams, DataVecDeriv& vData) override;
+    virtual void projectPosition(const MechanicalParams* mparams, DataVecCoord& xData) override;
+
+    /// Implement projectMatrix for assembled solver of compliant
+    virtual void projectMatrix( sofa::defaulttype::BaseMatrix* M, unsigned offset) override;
+    virtual void projectJacobianMatrix(const MechanicalParams* mparams, DataMatrixDeriv& cData) override;
+
+    /// Implement applyConstraint for direct solvers
+    virtual void applyConstraint(const MechanicalParams* mparams,
+                                 const MultiMatrixAccessor* matrix) override;
+
+    virtual void applyConstraint(const MechanicalParams* mparams, BaseVector* vector,
+                                 const MultiMatrixAccessor* matrix) override;
 
     void setDirection (Coord dir);
     void selectVerticesAlongPlane();
-    void setDminAndDmax(const Real _dmin,const Real _dmax) {dmin=_dmin; dmax=_dmax; selectVerticesFromPlanes=true;}
+    void setDminAndDmax(const Real _dmin,const Real _dmax);
 
-    void draw(const core::visual::VisualParams* vparams) override;
-
-    class FCPointHandler : public sofa::component::topology::TopologySubsetDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >
-    {
-    public:
-        typedef typename FixedPlaneConstraint<DataTypes>::SetIndexArray SetIndexArray;
-
-        FCPointHandler(FixedPlaneConstraint<DataTypes>* _fc, sofa::component::topology::PointSubsetData<SetIndexArray>* _data)
-            : sofa::component::topology::TopologySubsetDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >(_data), fc(_fc) {}
-
-
-
-        void applyDestroyFunction(unsigned int /*index*/, value_type& /*T*/);
-
-
-        bool applyTestCreateFunction(unsigned int /*index*/,
-                const sofa::helper::vector< unsigned int > & /*ancestors*/,
-                const sofa::helper::vector< double > & /*coefs*/);
-    protected:
-        FixedPlaneConstraint<DataTypes> *fc;
-    };
+    void addConstraint(int index);
+    void removeConstraint(int index);
 
 protected:
-    /// Pointer to the current topology
-    sofa::core::topology::BaseMeshTopology* topology;
+    FixedPlaneConstraint();
+    ~FixedPlaneConstraint();
+
+    FixedPlaneConstraintInternalData<DataTypes> data;
+    friend class FixedPlaneConstraintInternalData<DataTypes>;
+
+    /// Forward class declaration, definition is in the .inl
+    class FCPointHandler;
 
     /// Handler for subset Data
-    FCPointHandler* pointHandler;
+    FCPointHandler* m_pointHandler;
 
-    bool isPointInPlane(Coord p)
-    {
-        Real d=dot(p,direction.getValue());
-        if ((d>dmin.getValue())&& (d<dmax.getValue()))
-            return true;
-        else
-            return false;
-    }
+    /// whether vertices should be selected from 2 parallel planes
+    bool m_selectVerticesFromPlanes;
+
+    /// Pointer to the current topology
+    BaseMeshTopology* m_topology;
+
+    ////////////////////////// Inherited attributes ////////////////////////////
+    /// https://gcc.gnu.org/onlinedocs/gcc/Name-lookup.html
+    /// Bring inherited attributes and function in the current lookup context.
+    /// otherwise any access to the base::attribute would require
+    /// the "this->" approach.
+    using ProjectiveConstraintSet<DataTypes>::mstate;
+    using ProjectiveConstraintSet<DataTypes>::getContext;
+
+    /// These two are implemented depending on the templates
+    bool isPointInPlane(Coord p) const ;
+
+    /// These two are implemented depending on the templates
+    template<class T>
+    void projectResponseImpl(const MechanicalParams* mparams, T& dx) const ;
 };
 
-#ifndef SOFA_FLOAT
-template <> template <class DataDeriv>
-void FixedPlaneConstraint<defaulttype::Rigid3dTypes>::projectResponseT(const core::MechanicalParams* mparams, DataDeriv& /*res*/);
-
-template <>
-bool FixedPlaneConstraint<defaulttype::Rigid3dTypes>::isPointInPlane(Coord /*p*/);
-#endif
-
-#ifndef SOFA_DOUBLE
-template <> template <class DataDeriv>
-void FixedPlaneConstraint<defaulttype::Rigid3fTypes>::projectResponseT(const core::MechanicalParams* mparams, DataDeriv& /*res*/);
-
-template <>
-bool FixedPlaneConstraint<defaulttype::Rigid3fTypes>::isPointInPlane(Coord /*p*/);
-#endif
-
-#if defined(SOFA_EXTERN_TEMPLATE) && !defined(SOFA_COMPONENT_PROJECTIVECONSTRAINTSET_FIXEDPLANECONSTRAINT_CPP)
-#ifndef SOFA_FLOAT
+#if !defined(SOFA_COMPONENT_PROJECTIVECONSTRAINTSET_FIXEDPLANECONSTRAINT_CPP)
+#ifdef SOFA_WITH_DOUBLE
 extern template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<defaulttype::Rigid3dTypes>;
 extern template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<defaulttype::Vec3dTypes>;
 extern template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<defaulttype::Vec6dTypes>;
-#endif
-#ifndef SOFA_DOUBLE
+#endif /// SOFA_WITH_DOUBLE
+#ifdef SOFA_WITH_FLOAT
 extern template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<defaulttype::Rigid3fTypes>;
 extern template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<defaulttype::Vec3fTypes>;
 extern template class SOFA_BOUNDARY_CONDITION_API FixedPlaneConstraint<defaulttype::Vec6fTypes>;
-#endif
+#endif /// SOFA_WITH_FLOAT
 #endif
 
 } // namespace projectiveconstraintset

--- a/modules/SofaBoundaryCondition/FixedPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/FixedPlaneConstraint.inl
@@ -39,27 +39,45 @@ namespace component
 namespace projectiveconstraintset
 {
 
-template <class DataTypes>
-FixedPlaneConstraint<DataTypes>::FixedPlaneConstraint()
-    : direction( initData(&direction,"direction","normal direction of the plane"))
-    , dmin( initData(&dmin,(Real)0,"dmin","Minimum plane distance from the origin"))
-    , dmax( initData(&dmax,(Real)0,"dmax","Maximum plane distance from the origin") )
-    , indices( initData(&indices,"indices","Indices of the fixed points"))
-{
-    selectVerticesFromPlanes=false;
-    pointHandler = new FCPointHandler(this, &indices);
-}
+using sofa::helper::WriteAccessor;
+using sofa::defaulttype::Vec;
+using sofa::component::topology::PointSubsetData;
+using sofa::component::topology::TopologySubsetDataHandler;
 
-template <class DataTypes>
-FixedPlaneConstraint<DataTypes>::~FixedPlaneConstraint()
-{
-    if (pointHandler)
-        delete pointHandler;
-}
 
-// Define TestNewPointFunction
+/////////////////////////// DEFINITION OF FCPointHandler (INNER CLASS) /////////////////////////////
+template <class DataTypes>
+class FixedPlaneConstraint<DataTypes>::FCPointHandler :
+        public TopologySubsetDataHandler<BaseMeshTopology::Point, SetIndexArray >
+{
+public:
+    typedef typename FixedPlaneConstraint<DataTypes>::SetIndexArray SetIndexArray;
+
+    FCPointHandler(FixedPlaneConstraint<DataTypes>* _fc, PointSubsetData<SetIndexArray>* _data)
+        : TopologySubsetDataHandler<BaseMeshTopology::Point, SetIndexArray >(_data), fc(_fc) {}
+
+    void applyDestroyFunction(unsigned int /*index*/, value_type& /*T*/);
+
+    bool applyTestCreateFunction(unsigned int /*index*/,
+                                 const helper::vector< unsigned int > & /*ancestors*/,
+                                 const helper::vector< double > & /*coefs*/);
+protected:
+    FixedPlaneConstraint<DataTypes> *fc;
+};
+
+/// Define RemovalFunction
 template< class DataTypes>
-bool FixedPlaneConstraint<DataTypes>::FCPointHandler::applyTestCreateFunction(unsigned int, const sofa::helper::vector<unsigned int> &, const sofa::helper::vector<double> &)
+void FixedPlaneConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(unsigned int pointIndex, value_type &)
+{
+    if (fc)
+    {
+        fc->removeConstraint((unsigned int) pointIndex);
+    }
+}
+
+/// Define TestNewPointFunction
+template< class DataTypes>
+bool FixedPlaneConstraint<DataTypes>::FCPointHandler::applyTestCreateFunction(unsigned int, const helper::vector<unsigned int> &, const helper::vector<double> &)
 {
     if (fc)
     {
@@ -71,117 +89,106 @@ bool FixedPlaneConstraint<DataTypes>::FCPointHandler::applyTestCreateFunction(un
     }
 }
 
-// Matrix Integration interface
+/////////////////////////// DEFINITION OF FixedPlaneConstraint /////////////////////////////////////
 template <class DataTypes>
-void FixedPlaneConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix)
+FixedPlaneConstraint<DataTypes>::FixedPlaneConstraint()
+    : d_direction( initData(&d_direction,"direction","normal direction of the plane"))
+    , d_dmin( initData(&d_dmin,(Real)0,"dmin","Minimum plane distance from the origin"))
+    , d_dmax( initData(&d_dmax,(Real)0,"dmax","Maximum plane distance from the origin") )
+    , d_indices( initData(&d_indices,"indices","Indices of the fixed points"))
 {
-    core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate.get(mparams));
+    m_selectVerticesFromPlanes=false;
+    m_pointHandler = new FCPointHandler(this, &d_indices);
+}
+
+template <class DataTypes>
+FixedPlaneConstraint<DataTypes>::~FixedPlaneConstraint()
+{
+    if (m_pointHandler)
+        delete m_pointHandler;
+}
+
+/// Matrix Integration interface
+template <class DataTypes>
+void FixedPlaneConstraint<DataTypes>::applyConstraint(const MechanicalParams* mparams, const MultiMatrixAccessor* matrix)
+{
+    MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(mstate.get(mparams));
     if(r)
     {
-        //sout << "applyConstraint in Matrix with offset = " << offset << sendl;
-        //cerr<<"FixedConstraint<DataTypes>::applyConstraint(defaulttype::BaseMatrix *mat, unsigned int offset) is called "<<endl;
+        /// Implement plane constraint only when the direction is along the coordinates directions
+        // TODO : generalize projection to any direction
+
         const unsigned int N = Deriv::size();
-        const SetIndexArray & ind = indices.getValue();
-
-        // IMplement plane constraint only when the direction is along the coordinates directions
-		// TODO : generalize projection to any direction
-		 Coord dir=direction.getValue();
-
-        for (SetIndexArray::const_iterator it = ind.begin(); it != ind.end(); ++it)
+        Coord dir=d_direction.getValue();
+        for (auto& index : d_indices.getValue())
         {
-            // Reset Fixed Row and Col
+            /// Reset Fixed Row and Col
             for (unsigned int c=0; c<N; ++c)
-				if (dir[c]!=0.0)
-                r.matrix->clearRowCol(r.offset + N * (*it) + c);
-            // Set Fixed Vertex
+                if (dir[c]!=0.0)
+                    r.matrix->clearRowCol(r.offset + N * index + c);
+            /// Set Fixed Vertex
             for (unsigned int c=0; c<N; ++c)
-				if (dir[c]!=0.0)
-                r.matrix->set(r.offset + N * (*it) + c, r.offset + N * (*it) + c, 1.0);
+                if (dir[c]!=0.0)
+                    r.matrix->set(r.offset + N * index + c, r.offset + N * index + c, 1.0);
         }
     }
 }
 
 template <class DataTypes>
-void FixedPlaneConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* mparams, defaulttype::BaseVector* vect, const sofa::core::behavior::MultiMatrixAccessor* matrix)
+void FixedPlaneConstraint<DataTypes>::applyConstraint(const MechanicalParams* mparams,
+                                                      BaseVector* vect,
+                                                      const MultiMatrixAccessor* matrix)
 {
-    int o = matrix->getGlobalOffset(this->mstate.get(mparams));
+    int o = matrix->getGlobalOffset(mstate.get(mparams));
     if (o >= 0)
     {
         unsigned int offset = (unsigned int)o;
-		// IMplement plane constraint only when the direction is along the coordinates directions
-		// TODO : generalize projection to any direction
-		Coord dir=direction.getValue();
+        /// Implement plane constraint only when the direction is along the coordinates directions
+        // TODO : generalize projection to any direction
+        Coord dir=d_direction.getValue();
 
         const unsigned int N = Deriv::size();
 
-      
-
-
-        const SetIndexArray & ind = indices.getValue();
-        for (SetIndexArray::const_iterator it = ind.begin(); it != ind.end(); ++it)
+        for (auto& index : d_indices.getValue())
         {
             for (unsigned int c=0; c<N; ++c)
-				if (dir[c]!=0.0)
-                vect->clear(offset + N * (*it) + c);
+                if (dir[c]!=0.0)
+                    vect->clear(offset + N * index + c);
         }
     }
 }
 
-// Define RemovalFunction
-template< class DataTypes>
-void FixedPlaneConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(unsigned int pointIndex, value_type &)
-{
-    if (fc)
-    {
-        fc->removeConstraint((unsigned int) pointIndex);
-    }
-}
 template <class DataTypes>
 void FixedPlaneConstraint<DataTypes>::addConstraint(int index)
 {
-    indices.beginEdit()->push_back(index);
-    indices.endEdit();
+    d_indices.beginEdit()->push_back(index);
+    d_indices.endEdit();
 }
 
 template <class DataTypes>
 void FixedPlaneConstraint<DataTypes>::removeConstraint(int index)
 {
-    removeValue(*indices.beginEdit(),(unsigned int)index);
-    indices.endEdit();
-}
-
-// -- Mass interface
-
-
-template <class DataTypes> template <class DataDeriv>
-void FixedPlaneConstraint<DataTypes>::projectResponseT(const core::MechanicalParams* /*mparams*/, DataDeriv& res)
-{
-    Coord dir=direction.getValue();
-
-    for (helper::vector< unsigned int >::const_iterator it = this->indices.getValue().begin(); it != this->indices.getValue().end(); ++it)
-    {
-        /// only constraint one projection of the displacement to be zero
-        res[*it]-= dir*dot(res[*it],dir);
-    }
+    removeValue(*d_indices.beginEdit(),(unsigned int)index);
+    d_indices.endEdit();
 }
 
 template <class DataTypes>
-void FixedPlaneConstraint<DataTypes>::projectResponse(const core::MechanicalParams* mparams, DataVecDeriv& resData)
+void FixedPlaneConstraint<DataTypes>::projectResponse(const MechanicalParams* mparams, DataVecDeriv& resData)
 {
-    helper::WriteAccessor<DataVecDeriv> res = resData;
-    projectResponseT<VecDeriv>(mparams, res.wref());
+    WriteAccessor<DataVecDeriv> res = resData;
+    projectResponseImpl(mparams, res.wref());
 }
 
 /// project dx to constrained space (dx models a velocity)
 template <class DataTypes>
-void FixedPlaneConstraint<DataTypes>::projectVelocity(const core::MechanicalParams* /*mparams*/, DataVecDeriv& /*vData*/)
+void FixedPlaneConstraint<DataTypes>::projectVelocity(const MechanicalParams* /*mparams*/, DataVecDeriv& /*vData*/)
 {
 
 }
 
 /// project x to constrained space (x models a position)
 template <class DataTypes>
-void FixedPlaneConstraint<DataTypes>::projectPosition(const core::MechanicalParams* /*mparams*/, DataVecCoord& /*xData*/)
+void FixedPlaneConstraint<DataTypes>::projectPosition(const MechanicalParams* /*mparams*/, DataVecCoord& /*xData*/)
 {
 
 }
@@ -189,26 +196,25 @@ void FixedPlaneConstraint<DataTypes>::projectPosition(const core::MechanicalPara
 template <class DataTypes>
 void FixedPlaneConstraint<DataTypes>::projectMatrix( sofa::defaulttype::BaseMatrix* M, unsigned /*offset*/ )
 {
-    // clears the rows and columns associated with constrained particles
+    /// clears the rows and columns associated with constrained particles
     unsigned blockSize = DataTypes::deriv_total_size;
 
-    for(SetIndexArray::const_iterator it= indices.getValue().begin(), iend=indices.getValue().end(); it!=iend; it++ )
+    for(auto& index : d_indices.getValue())
     {
-        M->clearRowsCols((*it) * blockSize,(*it+1) * (blockSize) );
+        M->clearRowsCols((index) * blockSize,(index+1) * (blockSize) );
     }
-
 }
-template <class DataTypes>
-void FixedPlaneConstraint<DataTypes>::projectJacobianMatrix(const core::MechanicalParams* mparams, DataMatrixDeriv& cData)
-{
-    helper::WriteAccessor<DataMatrixDeriv> c = cData;
 
+template <class DataTypes>
+void FixedPlaneConstraint<DataTypes>::projectJacobianMatrix(const MechanicalParams* mparams, DataMatrixDeriv& cData)
+{
+    WriteAccessor<DataMatrixDeriv> c = cData;
     MatrixDerivRowIterator rowIt = c->begin();
     MatrixDerivRowIterator rowItEnd = c->end();
 
     while (rowIt != rowItEnd)
     {
-        projectResponseT<MatrixDerivRowType>(mparams, rowIt.row());
+        projectResponseImpl(mparams, rowIt.row());
         ++rowIt;
     }
 }
@@ -218,57 +224,108 @@ void FixedPlaneConstraint<DataTypes>::setDirection(Coord dir)
 {
     if (dir.norm2()>0)
     {
-        direction.setValue(dir);
+        d_direction.setValue(dir);
     }
 }
 
 template <class DataTypes>
 void FixedPlaneConstraint<DataTypes>::selectVerticesAlongPlane()
 {
-    const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
-    unsigned int i;
-    for(i=0; i<x.size(); ++i)
+    const VecCoord& x = mstate->read(core::ConstVecCoordId::position())->getValue();
+    for(unsigned int i=0; i<x.size(); ++i)
     {
         if (isPointInPlane(x[i]))
             addConstraint(i);
     }
-
 }
+
 template <class DataTypes>
 void FixedPlaneConstraint<DataTypes>::init()
 {
-    this->core::behavior::ProjectiveConstraintSet<DataTypes>::init();
+    ProjectiveConstraintSet<DataTypes>::init();
 
-    topology = this->getContext()->getMeshTopology();
+    m_topology = getContext()->getMeshTopology();
 
     /// test that dmin or dmax are different from zero
-    if (dmin.getValue()!=dmax.getValue())
-        selectVerticesFromPlanes=true;
+    if (d_dmin.getValue()!=d_dmax.getValue())
+        m_selectVerticesFromPlanes=true;
 
-    if (selectVerticesFromPlanes)
+    if (m_selectVerticesFromPlanes)
         selectVerticesAlongPlane();
 
-    // Initialize functions and parameters
-    indices.createTopologicalEngine(topology, pointHandler);
-    indices.registerTopologicalData();
-
+    /// Initialize functions and parameters
+    d_indices.createTopologicalEngine(m_topology, m_pointHandler);
+    d_indices.registerTopologicalData();
 }
 
+template <class DataTypes>
+void FixedPlaneConstraint<DataTypes>::setDminAndDmax(const Real _dmin,const Real _dmax)
+{
+    d_dmin=_dmin;
+    d_dmax=_dmax;
+    m_selectVerticesFromPlanes=true;
+}
 
 template <class DataTypes>
-void FixedPlaneConstraint<DataTypes>::draw(const core::visual::VisualParams* vparams)
+void FixedPlaneConstraint<DataTypes>::draw(const VisualParams* vparams)
 {
     if (!vparams->displayFlags().getShowBehaviorModels()) return;
-    const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
+    const VecCoord& x = mstate->read(core::ConstVecCoordId::position())->getValue();
     vparams->drawTool()->disableLighting();
 
-    sofa::helper::vector<sofa::defaulttype::Vector3> points;
-    for (helper::vector< unsigned int >::const_iterator it = this->indices.getValue().begin(); it != this->indices.getValue().end(); ++it)
+    helper::vector<sofa::defaulttype::Vector3> points;
+    for(auto& index : d_indices.getValue())
     {
-        points.push_back({x[*it][0], x[*it][1], x[*it][2]});
+        points.push_back({x[index][0], x[index][1], x[index][2]});
     }
 
     vparams->drawTool()->drawPoints(points, 10, {1,1.0,0.5,1});
+}
+
+/// This function are there to provide kind of type translation to the vector one so we can
+/// implement the algorithm as is the different objects where of similar type.
+/// this solution is not really satisfactory but for the moment it does the job.
+/// A better solution would that all the used types are following the same iterface which
+/// requires to touch core sofa classes.
+sofa::defaulttype::Vec3d& getVec(sofa::defaulttype::Rigid3dTypes::Deriv& i){ return i.getVCenter(); }
+sofa::defaulttype::Vec3d& getVec(sofa::defaulttype::Rigid3dTypes::Coord& i){ return i.getCenter(); }
+const sofa::defaulttype::Vec3d& getVec(const sofa::defaulttype::Rigid3dTypes::Coord& i){ return i.getCenter(); }
+sofa::defaulttype::Vec3d& getVec(sofa::defaulttype::Vec3dTypes::Deriv& i){ return i; }
+const sofa::defaulttype::Vec3d& getVec(const sofa::defaulttype::Vec3dTypes::Deriv& i){ return i; }
+sofa::defaulttype::Vec6d& getVec(sofa::defaulttype::Vec6dTypes::Deriv& i){ return i; }
+const sofa::defaulttype::Vec6d& getVec(const sofa::defaulttype::Vec6dTypes::Deriv& i){ return i; }
+
+sofa::defaulttype::Vec3f& getVec(sofa::defaulttype::Rigid3fTypes::Deriv& i){ return i.getVCenter(); }
+sofa::defaulttype::Vec3f& getVec(sofa::defaulttype::Rigid3fTypes::Coord& i){ return i.getCenter(); }
+const sofa::defaulttype::Vec3f& getVec(const sofa::defaulttype::Rigid3fTypes::Coord& i){ return i.getCenter(); }
+sofa::defaulttype::Vec3f& getVec(sofa::defaulttype::Vec3fTypes::Deriv& i){ return i; }
+const sofa::defaulttype::Vec3f& getVec(const sofa::defaulttype::Vec3fTypes::Deriv& i){ return i; }
+sofa::defaulttype::Vec6f& getVec(sofa::defaulttype::Vec6fTypes::Deriv& i){ return i; }
+const sofa::defaulttype::Vec6f& getVec(const sofa::defaulttype::Vec6fTypes::Deriv& i){ return i; }
+
+template<class DataTypes>
+bool FixedPlaneConstraint<DataTypes>::isPointInPlane(Coord p) const
+{
+    Vec<Coord::spatial_dimensions,Real> pos = getVec(p) ;
+    Real d=pos*getVec(d_direction.getValue());
+    if ((d>d_dmin.getValue())&& (d<d_dmax.getValue()))
+        return true;
+    else
+        return false;
+}
+
+template <class DataTypes>
+template <class T>
+void FixedPlaneConstraint<DataTypes>::projectResponseImpl(const MechanicalParams* mparams, T& res) const
+{
+    SOFA_UNUSED(mparams);
+
+    Coord dir=d_direction.getValue();
+    for (auto& index : d_indices.getValue())
+    {
+        /// only constraint one projection of the displacement to be zero
+        getVec(res[index]) -= getVec(dir) * dot( getVec(res[index]), getVec(dir));
+    }
 }
 
 } // namespace constraint


### PR DESCRIPTION
Initially I wanted to fix issue #673 that prevents compilation with gcc > 8.1. But I was not able to prevent myself to refactore the class in the process. 

CHANGELOG:
- Move the implementation from .h to .inl
- Move the definition of the inner class FCPHandler from the .h to .inl
- Group the class member according their visibility (public, protected, private) to avoid interleaving.
- Uniformize the source code comments
- Rename the class members (attributes) to make them consistent with the sofa coding style.
- Factorize the code that was "duplicated" in the .cpp between rigid3dtype, rigid3ftype, vec3d, vec3f (I welcome an alternative implementation).

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
