### PR TITLE
[CGALPlugin] Fix compilation for cgal 4.12+ (cgal::polyhedron_3 is now forward declared)

### DIFF
--- a/applications/plugins/CGALPlugin/TriangularConvexHull3D.inl
+++ b/applications/plugins/CGALPlugin/TriangularConvexHull3D.inl
@@ -34,6 +34,7 @@
 #include <CGAL/algorithm.h>
 #include <CGAL/Convex_hull_traits_3.h>
 #include <CGAL/convex_hull_3.h>
+#include <CGAL/Polyhedron_3.h>
 
 
 using namespace sofa;


### PR DESCRIPTION
CGAL 4.12+ now forward declares its package Polyhedron (see https://github.com/CGAL/cgal/commit/76ccc9a , hence the implicit
 instantiation of undefined template compilation error.

This PR fixes this.


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
