### PR TITLE
[SofaKernel] BREAKING: Replacing DataEngine with SimpleDataEngine

### DIFF
--- a/SofaKernel/framework/framework_test/core/DataEngine_test.cpp
+++ b/SofaKernel/framework/framework_test/core/DataEngine_test.cpp
@@ -53,55 +53,6 @@ public:
     void init() override
     {
         addInput(&input);
-        m_dataTracker.trackData(input); // to connect a DataTracker to the Data 'input'
-
-        addOutput(&output);
-
-        setDirtyValue();
-    }
-
-    void reinit() override
-    {
-        update();
-    }
-
-    void update() override
-    {
-        // true only iff the DataTracker associated to the Data 'input' is Dirty
-        // that could only happen if 'input' was dirtied since last update
-        if( m_dataTracker.isDirty( input ) )
-            output.setValue(CHANGED);
-        else
-            output.setValue(NO_CHANGED);
-
-        cleanDirty();
-    }
-
-};
-
-/// to test tracked Data
-class SimpleTestEngine : public core::SimpleDataEngine
-{
-public:
-    SOFA_CLASS(SimpleTestEngine, core::SimpleDataEngine);
-
-
-    Data< bool > input;
-    Data< int > output;
-
-    enum { UNDEFINED=0, CHANGED, NO_CHANGED };
-
-    SimpleTestEngine()
-        : Inherit1()
-        , input(initData(&input,false,"input","input"))
-        , output(initData(&output,(int)UNDEFINED,"output","output"))
-    {}
-
-    ~SimpleTestEngine() {}
-
-    void init() override
-    {
-        addInput(&input);
         addOutput(&output);
         setDirtyValue();
     }
@@ -111,7 +62,6 @@ public:
         update();
     }
 
-private:
     void doUpdate() override
     {
         // true only iff the DataTracker associated to the Data 'input' is Dirty
@@ -121,18 +71,18 @@ private:
         else
             output.setValue(NO_CHANGED);
     }
+
 };
+
 
 
 struct DataEngine_test: public BaseTest
 {
     TestEngine engine;
-    SimpleTestEngine simpleEngine;
 
     void SetUp()
     {
         engine.init();
-        simpleEngine.init();
     }
 
     /// to test tracked Data
@@ -159,18 +109,10 @@ struct DataEngine_test: public BaseTest
 
 };
 
-
-
 // Test
 TEST_F(DataEngine_test, testDataEngine )
 {
     this->testTrackedData<TestEngine>(this->engine);
 }
-
-TEST_F(DataEngine_test, testSimpleDataEngine )
-{
-    this->testTrackedData<SimpleTestEngine>(this->simpleEngine);
-}
-
 
 }// namespace sofa

--- a/SofaKernel/framework/sofa/core/DataEngine.cpp
+++ b/SofaKernel/framework/sofa/core/DataEngine.cpp
@@ -42,6 +42,7 @@ DataEngine::~DataEngine()
 /// Add a new input to this engine
 void DataEngine::addInput(objectmodel::BaseData* n)
 {
+    m_dataTracker.trackData(*n);
     if (n->getOwner() == this && (!n->getGroup() || !n->getGroup()[0]))
         n->setGroup("Inputs"); // set the group of input Datas if not yet set
     core::objectmodel::DDGNode::addInput(n);
@@ -55,6 +56,22 @@ void DataEngine::addOutput(objectmodel::BaseData* n)
     core::objectmodel::DDGNode::addOutput(n);
 }
 
+void DataEngine::updateAllInputs()
+{
+    for(auto& input : getInputs())
+    {
+        static_cast<sofa::core::objectmodel::BaseData*>(input)
+                ->updateIfDirty();
+    }
+}
+
+void DataEngine::update()
+{
+    updateAllInputs();
+    DDGNode::cleanDirty();
+    doUpdate();
+    m_dataTracker.clean();
+}
 
 
 

--- a/SofaKernel/framework/sofa/core/DataEngine.cpp
+++ b/SofaKernel/framework/sofa/core/DataEngine.cpp
@@ -46,6 +46,7 @@ void DataEngine::addInput(objectmodel::BaseData* n)
     if (n->getOwner() == this && (!n->getGroup() || !n->getGroup()[0]))
         n->setGroup("Inputs"); // set the group of input Datas if not yet set
     core::objectmodel::DDGNode::addInput(n);
+    setDirtyValue();
 }
 
 /// Add a new output to this engine
@@ -54,6 +55,7 @@ void DataEngine::addOutput(objectmodel::BaseData* n)
     if (n->getOwner() == this && (!n->getGroup() || !n->getGroup()[0]))
         n->setGroup("Outputs"); // set the group of output Datas if not yet set
     core::objectmodel::DDGNode::addOutput(n);
+    setDirtyValue();
 }
 
 void DataEngine::updateAllInputs()

--- a/SofaKernel/framework/sofa/core/DataEngine.h
+++ b/SofaKernel/framework/sofa/core/DataEngine.h
@@ -45,7 +45,6 @@ namespace core
  * {
  *    addInput // indicate all inputs
  *    addOutput // indicate all outputs
- *    setDirtyValue(); // You still have to set that manually, sorry
  * }
  *
  * // optional (called each time a data is modified in the gui)
@@ -57,7 +56,7 @@ namespace core
  *
  * void doUpdate() override
  * {
- *    acces your inputs, set your outputs...
+ *    access your inputs, set your outputs...
  * }
  *
  */

--- a/SofaKernel/framework/sofa/core/DataEngine.h
+++ b/SofaKernel/framework/sofa/core/DataEngine.h
@@ -45,7 +45,7 @@ namespace core
  * {
  *    addInput // indicate all inputs
  *    addOutput // indicate all outputs
- *    setDirtyValue(); // the engine must start dirty (of course, no output are up-to-date)
+ *    setDirtyValue(); // You still have to set that manually, sorry
  * }
  *
  * // optional (called each time a data is modified in the gui)
@@ -55,25 +55,16 @@ namespace core
  *    update();
  * }
  *
- * void update()
+ * void doUpdate() override
  * {
- *      // FIRST all inputs must be updated
- *      // can be done by Data::getValue, ReadAccessor, Data::updateIfDirty, DataEngine::updateAllInputsIfDirty
- *
- *      // must be called AFTER updating all inputs, otherwise a modified input will set the engine to dirty again.
- *      // must be called BEFORE read access to an output, otherwise read-accessing the output will call update
- *      cleanDirty();
- *
- *      // FINALLY access and set outputs
- *      // Note that a write-only access has better performance and is enough in 99% engines   Data::beginWriteOnly, WriteOnlyAccessor
- *      // A read access is possible, in that case, be careful the cleanDirty is called before the read-access, otherwise it can call an DataEngine::update itself.  Data::beginEdit, WriteAccessor
+ *    acces your inputs, set your outputs...
  * }
  *
  */
 class SOFA_CORE_API DataEngine : public core::DataTrackerDDGNode, public virtual core::objectmodel::BaseObject
 {
 public:
-    SOFA_ABSTRACT_CLASS(DataEngine, core::objectmodel::BaseObject);
+    SOFA_ABSTRACT_CLASS2(DataEngine, core::objectmodel::BaseObject, core::DataTrackerDDGNode);
     SOFA_BASE_CAST_IMPLEMENTATION(DataEngine)
 protected:
     /// Constructor
@@ -85,10 +76,23 @@ protected:
 private:
 	DataEngine(const DataEngine& n) ;
 	DataEngine& operator=(const DataEngine& n) ;
-	
+
+    /// Called in update(), back-propagates the data update
+    /// in the data dependency graph
+    void updateAllInputs();
+
+protected:
+    /// Where you put your engine's impl
+    virtual void doUpdate() = 0;
+
 public:
+    /// Updates your inputs and calls cleanDirty() for you.
+    /// User implementation moved to doUpdate()
+    virtual void update() final;
+
     /// Add a new input to this engine
-    void addInput(objectmodel::BaseData* n);
+    /// Automatically adds the input fields to the datatracker
+    void addInput(sofa::core::objectmodel::BaseData* data);
 
     /// Add a new output to this engine
     void addOutput(objectmodel::BaseData* n);
@@ -181,74 +185,7 @@ public:
     {
         objectmodel::BaseObject::addLink(l);
     }
-
 };
-
-/**
- *  \brief A simpler API for your DataEngines
- *
- * Implementation good rules:
- *
- * void init()
- * {
- *    addInput // indicate all inputs
- *    addOutput // indicate all outputs
- *    setDirtyValue(); // You still have to set that manually, sorry
- * }
- *
- * // optional (called each time a data is modified in the gui)
- * // it is not always desired
- * void reinit()
- * {
- *    update();
- * }
- *
- * void doUpdate() override
- * {
- *    don't overthink it, just code. acces your inputs, set your outputs
- *    No cleanDirty() required
- * }
- *
- */
-class SOFA_CORE_API SimpleDataEngine : public sofa::core::DataEngine
-{
-public:
-    SOFA_CLASS(SimpleDataEngine, sofa::core::DataEngine);
-
-    SimpleDataEngine() : Inherit1() {}
-    virtual ~SimpleDataEngine() {}
-
-
-    virtual void updateAllInputs()
-    {
-        for(auto& input : getInputs())
-        {
-            static_cast<sofa::core::objectmodel::BaseData*>(input)
-                    ->updateIfDirty();
-        }
-    }
-    /// Updates your inputs and calls cleanDirty() for you.
-    /// User implementation moved to doUpdate()
-    virtual void update() final
-    {
-        updateAllInputs();
-        DDGNode::cleanDirty();
-        doUpdate();
-        m_dataTracker.clean();
-    }
-
-    /// Automatically adds the input fields to the datatracker
-    void addInput(sofa::core::objectmodel::BaseData* data)
-    {
-        m_dataTracker.trackData(*data);
-        Inherit1::addInput(data);
-    }
-
-protected:
-    /// Where you put your engine's impl
-    virtual void doUpdate() = 0;
-};
-
 
 } // namespace core
 

--- a/SofaKernel/modules/SofaBaseTopology/GridTopology.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/GridTopology.cpp
@@ -51,7 +51,7 @@ GridTopology::GridUpdate::GridUpdate(GridTopology *t):
     setDirtyValue();
 }
 
-void GridTopology::GridUpdate::update()
+void GridTopology::GridUpdate::doUpdate()
 {
     updateEdges();
     updateQuads();

--- a/SofaKernel/modules/SofaBaseTopology/GridTopology.h
+++ b/SofaKernel/modules/SofaBaseTopology/GridTopology.h
@@ -71,7 +71,7 @@ private:
         typedef MeshTopology::Hexa Hexa;
         SOFA_CLASS(GridUpdate,sofa::core::DataEngine);
         GridUpdate(GridTopology* t);
-        virtual void update() override;
+        virtual void doUpdate() override;
     protected:
         void updateEdges();
         void updateQuads();

--- a/SofaKernel/modules/SofaBaseTopology/MeshTopology.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/MeshTopology.cpp
@@ -59,7 +59,7 @@ MeshTopology::EdgeUpdate::EdgeUpdate(MeshTopology* t)
 
 }
 
-void MeshTopology::EdgeUpdate::update()
+void MeshTopology::EdgeUpdate::doUpdate()
 {
     if(topology->hasVolume() ) updateFromVolume();
     else if(topology->hasSurface()) updateFromSurface();
@@ -242,7 +242,7 @@ MeshTopology::TriangleUpdate::TriangleUpdate(MeshTopology *t)
 }
 
 
-void MeshTopology::TriangleUpdate::update()
+void MeshTopology::TriangleUpdate::doUpdate()
 {
     typedef MeshTopology::SeqTetrahedra SeqTetrahedra;
     typedef MeshTopology::SeqTriangles SeqTriangles;
@@ -306,7 +306,7 @@ MeshTopology::QuadUpdate::QuadUpdate(MeshTopology *t)
     setDirtyValue();
 }
 
-void MeshTopology::QuadUpdate::update()
+void MeshTopology::QuadUpdate::doUpdate()
 {
     typedef MeshTopology::SeqHexahedra SeqHexahedra;
     typedef MeshTopology::SeqQuads SeqQuads;

--- a/SofaKernel/modules/SofaBaseTopology/MeshTopology.h
+++ b/SofaKernel/modules/SofaBaseTopology/MeshTopology.h
@@ -71,7 +71,7 @@ private:
     public:
         SOFA_CLASS(EdgeUpdate,PrimitiveUpdate);
         EdgeUpdate(MeshTopology* t);
-        void update() override;
+        void doUpdate() override;
     protected:
         void updateFromVolume();
         void updateFromSurface();
@@ -84,7 +84,7 @@ private:
 
         SOFA_CLASS(TriangleUpdate,PrimitiveUpdate);
         TriangleUpdate(MeshTopology* t);
-        void update() override;
+        void doUpdate() override;
     };
 
     class QuadUpdate : public PrimitiveUpdate
@@ -92,7 +92,7 @@ private:
     public:
         SOFA_CLASS(QuadUpdate,PrimitiveUpdate);
         QuadUpdate(MeshTopology* t);
-        void update() override;
+        void doUpdate() override;
     };
 protected:
     MeshTopology();

--- a/SofaKernel/modules/SofaBaseTopology/TopologyEngine.h
+++ b/SofaKernel/modules/SofaBaseTopology/TopologyEngine.h
@@ -80,7 +80,7 @@ public:
 
     virtual void reinit() override;
 
-    virtual void update() override;
+    virtual void doUpdate() override;
 
     void ApplyTopologyChanges();
 

--- a/SofaKernel/modules/SofaBaseTopology/TopologyEngine.inl
+++ b/SofaKernel/modules/SofaBaseTopology/TopologyEngine.inl
@@ -82,13 +82,12 @@ void TopologyEngineImpl< VecT>::reinit()
 
 
 template <typename VecT>
-void TopologyEngineImpl< VecT>::update()
+void TopologyEngineImpl< VecT>::doUpdate()
 {
 #ifndef NDEBUG // too much warnings
     sout << "TopologyEngine::update" << sendl;
     sout<< "Number of topological changes: " << m_changeList.getValue().size() << sendl;
 #endif
-    this->cleanDirty();
     this->ApplyTopologyChanges();
 }
 

--- a/SofaKernel/modules/SofaEngine/BoxROI.h
+++ b/SofaKernel/modules/SofaEngine/BoxROI.h
@@ -93,7 +93,7 @@ public:
 public:
     void init() override;
     void reinit() override;
-    void update() override;
+    void doUpdate() override;
     void draw(const VisualParams*) override;
 
     virtual void computeBBox(const ExecParams*  params, bool onlyVisible=false ) override;

--- a/SofaKernel/modules/SofaEngine/BoxROI.inl
+++ b/SofaKernel/modules/SofaEngine/BoxROI.inl
@@ -512,22 +512,20 @@ bool BoxROI<DataTypes>::isQuadInBoxes(const Quad& q)
 
 // The update method is called when the engine is marked as dirty.
 template <class DataTypes>
-void BoxROI<DataTypes>::update()
+void BoxROI<DataTypes>::doUpdate()
 {
     if(m_componentstate==ComponentState::Invalid){
-        cleanDirty() ;
         return ;
     }
 
     if(!d_doUpdate.getValue()){
-        cleanDirty() ;
         return ;
     }
 
     const vector<Vec6>&  alignedBoxes  = d_alignedBoxes.getValue();
     const vector<Vec10>& orientedBoxes = d_orientedBoxes.getValue();
 
-    if (alignedBoxes.empty() && orientedBoxes.empty()) { cleanDirty(); return; }
+    if (alignedBoxes.empty() && orientedBoxes.empty()) { return; }
 
 
     // Read accessor for input topology
@@ -538,8 +536,6 @@ void BoxROI<DataTypes>::update()
     ReadAccessor< Data<vector<Quad> > > quad = d_quad;
 
     const VecCoord& x0 = d_X0.getValue();
-
-    cleanDirty();
 
     // Write accessor for topological element indices in BOX
     SetIndex& indices = *d_indices.beginWriteOnly();

--- a/SofaKernel/modules/SofaEngine/SofaEngine_test/TestEngine.cpp
+++ b/SofaKernel/modules/SofaEngine/SofaEngine_test/TestEngine.cpp
@@ -62,7 +62,7 @@ void TestEngine::reinit()
     update();
 }
 
-void TestEngine::update()
+void TestEngine::doUpdate()
 {
     // Count how many times the update method is called
     counter ++;

--- a/SofaKernel/modules/SofaEngine/SofaEngine_test/TestEngine.h
+++ b/SofaKernel/modules/SofaEngine/SofaEngine_test/TestEngine.h
@@ -55,7 +55,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     // To see how many times update function is called
     int getCounterUpdate();

--- a/applications/plugins/CGALPlugin/CylinderMesh.h
+++ b/applications/plugins/CGALPlugin/CylinderMesh.h
@@ -76,7 +76,7 @@ public:
     void init();
     void reinit();
 
-    void update();
+    void doUpdate();
     void scale();
     void orientate();
     void draw();

--- a/applications/plugins/CGALPlugin/CylinderMesh.inl
+++ b/applications/plugins/CGALPlugin/CylinderMesh.inl
@@ -67,7 +67,7 @@ void CylinderMesh<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void CylinderMesh<DataTypes>::update()
+void CylinderMesh<DataTypes>::doUpdate()
 {
     d = m_diameter.getValue();
     l = m_length.getValue();

--- a/applications/plugins/CGALPlugin/DecimateMesh.h
+++ b/applications/plugins/CGALPlugin/DecimateMesh.h
@@ -92,7 +92,7 @@ public:
     void init();
     void reinit();
 
-    void update();
+    void doUpdate();
     void draw();
     void writeObj();
     void computeNormals();

--- a/applications/plugins/CGALPlugin/DecimateMesh.inl
+++ b/applications/plugins/CGALPlugin/DecimateMesh.inl
@@ -85,10 +85,8 @@ void DecimateMesh<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void DecimateMesh<DataTypes>::update()
+void DecimateMesh<DataTypes>::doUpdate()
 {
-    cleanDirty();
-
     // Writes topology into CGAL containers
     Surface surface;
     geometry_to_surface(surface);

--- a/applications/plugins/CGALPlugin/MeshGenerationFromImage.h
+++ b/applications/plugins/CGALPlugin/MeshGenerationFromImage.h
@@ -120,7 +120,7 @@ public:
     void init();
     void reinit();
 
-    void update();
+    void doUpdate();
 
     void draw(const sofa::core::visual::VisualParams* vparams);
 

--- a/applications/plugins/CGALPlugin/MeshGenerationFromImage.inl
+++ b/applications/plugins/CGALPlugin/MeshGenerationFromImage.inl
@@ -135,7 +135,7 @@ void printStats(C3t3& c3t3, Obj* obj, const char* step = "")
 }
 
 template <class DataTypes, class _ImageTypes>
-void MeshGenerationFromImage<DataTypes, _ImageTypes>::update()
+void MeshGenerationFromImage<DataTypes, _ImageTypes>::doUpdate()
 {
     helper::WriteAccessor< Data<VecCoord> > newPoints = d_newX0;
     helper::WriteAccessor< Data<SeqTetrahedra> > tetrahedra = d_tetrahedra;

--- a/applications/plugins/CGALPlugin/MeshGenerationFromPolyhedron.h
+++ b/applications/plugins/CGALPlugin/MeshGenerationFromPolyhedron.h
@@ -76,7 +76,7 @@ public:
     void init();
     void reinit();
 
-    void update();
+    void doUpdate();
 
     void draw(const sofa::core::visual::VisualParams* vparams);
 

--- a/applications/plugins/CGALPlugin/MeshGenerationFromPolyhedron.inl
+++ b/applications/plugins/CGALPlugin/MeshGenerationFromPolyhedron.inl
@@ -164,7 +164,7 @@ void printStats(C3t3& c3t3, Obj* obj, const char* step = "")
 }
 
 template <class DataTypes>
-void MeshGenerationFromPolyhedron<DataTypes>::update()
+void MeshGenerationFromPolyhedron<DataTypes>::doUpdate()
 {
     // Domain
     // (we use exact intersection computation with Robust_intersection_traits_3)

--- a/applications/plugins/CGALPlugin/TriangularConvexHull3D.h
+++ b/applications/plugins/CGALPlugin/TriangularConvexHull3D.h
@@ -67,7 +67,7 @@ public:
     void init();
     void reinit();
 
-    void update();
+    void doUpdate();
 
     virtual std::string getTemplateName() const
     {

--- a/applications/plugins/CGALPlugin/TriangularConvexHull3D.inl
+++ b/applications/plugins/CGALPlugin/TriangularConvexHull3D.inl
@@ -83,7 +83,7 @@ void TriangularConvexHull3D<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void TriangularConvexHull3D<DataTypes>::update()
+void TriangularConvexHull3D<DataTypes>::doUpdate()
 {
     helper::ReadAccessor< Data<VecCoord> > cloudPoints = f_X0;
     helper::WriteAccessor< Data<VecCoord> > newPoints = f_newX0;

--- a/applications/plugins/Flexible/deformationMapping/ImageDeformation.h
+++ b/applications/plugins/Flexible/deformationMapping/ImageDeformation.h
@@ -148,7 +148,7 @@ public:
 
 protected:
 
-    virtual void update()
+    virtual void doUpdate()
     {
         if(!deformationMapping) return;
 
@@ -311,7 +311,6 @@ protected:
             break;
         }
 
-        cleanDirty();
     }
 
 

--- a/applications/plugins/Flexible/engine/ComputeDualQuatEngine.h
+++ b/applications/plugins/Flexible/engine/ComputeDualQuatEngine.h
@@ -53,7 +53,7 @@ public:
     }
 
     // Update the engine
-    void update();
+    void doUpdate();
 
     // First position
     Data< VecCoord > d_x0; ///< Rest position

--- a/applications/plugins/Flexible/engine/ComputeDualQuatEngine.inl
+++ b/applications/plugins/Flexible/engine/ComputeDualQuatEngine.inl
@@ -59,7 +59,7 @@ ComputeDualQuatEngine< DataTypes >::ComputeDualQuatEngine()
 
 
 template < class DataTypes >
-void ComputeDualQuatEngine< DataTypes >::update()
+void ComputeDualQuatEngine< DataTypes >::doUpdate()
 {
     typedef sofa::helper::DualQuatCoord3<Real> DualQuat;
 
@@ -67,7 +67,6 @@ void ComputeDualQuatEngine< DataTypes >::update()
     const VecCoord& x = d_x.getValue();
     const VecCoord& x0 = d_x0.getValue();
 
-    cleanDirty();
 
     // Clean the output
     helper::vector< defaulttype::Vec4f >& dualQuats = *d_dualQuats.beginWriteOnly();

--- a/applications/plugins/Flexible/engine/ComputeWeightEngine.cpp
+++ b/applications/plugins/Flexible/engine/ComputeWeightEngine.cpp
@@ -65,7 +65,7 @@ void ComputeWeightEngine::reinit()
 }
 
 
-void ComputeWeightEngine::update()
+void ComputeWeightEngine::doUpdate()
 {
     if( !l_visualModel || !l_shapeFunction )
     {

--- a/applications/plugins/Flexible/engine/ComputeWeightEngine.h
+++ b/applications/plugins/Flexible/engine/ComputeWeightEngine.h
@@ -53,7 +53,7 @@ public:
     void init();
     void reinit();
     // Update the engine
-    void update();
+    void doUpdate();
 
 protected:
 

--- a/applications/plugins/Flexible/mass/MassFromDensity.h
+++ b/applications/plugins/Flexible/mass/MassFromDensity.h
@@ -172,14 +172,10 @@ public:
 
 protected:
 
-    virtual void update()
+    virtual void doUpdate()
     {
         if(!deformationMapping) { serr<<SOFA_CLASS_METHOD<<"can't compute the mass : no mapping found"<<sendl; return; }
         if(!dofs) { serr<<SOFA_CLASS_METHOD<<"can't compute the mass : no MechanicalObject<Vec3> found"<<sendl; return; }
-
-        updateAllInputsIfDirty(); // the easy way...
-
-        cleanDirty();
 
         MassFromDensitySpec::update(this);
 

--- a/applications/plugins/Flexible/quadrature/GaussPointContainer.h
+++ b/applications/plugins/Flexible/quadrature/GaussPointContainer.h
@@ -76,11 +76,8 @@ protected:
     {
     }
 
-    virtual void update()
+    virtual void doUpdate()
     {
-        this->updateAllInputsIfDirty();
-        cleanDirty();
-
         helper::ReadAccessor< Data< helper::vector<Real> > > invol(f_inputVolume);
         if(!invol.size()) serr<<"no volume provided -> use unit default volume"<<sendl;
         waVolume vol(this->f_volume);

--- a/applications/plugins/Flexible/quadrature/GaussPointSmoother.h
+++ b/applications/plugins/Flexible/quadrature/GaussPointSmoother.h
@@ -98,11 +98,8 @@ protected:
     }
 
 
-    virtual void update()
+    virtual void doUpdate()
     {
-        this->updateAllInputsIfDirty();
-        cleanDirty();
-
         BaseShapeFunction* _shapeFunction=NULL;
         this->getContext()->get(_shapeFunction,core::objectmodel::BaseContext::SearchUp);
         if( !_shapeFunction ) { serr<<"Shape function not found"<< sendl; return;}

--- a/applications/plugins/Flexible/quadrature/ImageGaussPointSampler.h
+++ b/applications/plugins/Flexible/quadrature/ImageGaussPointSampler.h
@@ -584,12 +584,8 @@ protected:
     static const int spatial_dimensions=3;
     mapping::BasePointMapper<spatial_dimensions,Real>* deformationMapping; ///< link to local deformation mapping for weights update
 
-    virtual void update()
+    virtual void doUpdate()
     {
-        updateAllInputsIfDirty(); // the easy way...
-
-        cleanDirty();
-
         ImageGaussPointSamplerSpec::init(this);
         ImageGaussPointSamplerSpec::Cluster_SimilarIndices(this);
 

--- a/applications/plugins/Flexible/quadrature/TopologyGaussPointSampler.h
+++ b/applications/plugins/Flexible/quadrature/TopologyGaussPointSampler.h
@@ -123,11 +123,8 @@ protected:
         if(indices.find(index)!=indices.end()) return true; else return false;
     }
 
-    virtual void update()
+    virtual void doUpdate()
     {
-        this->updateAllInputsIfDirty();
-        cleanDirty();
-
         if( !parentTopology ) return;
 
         raPositions parent(f_inPosition);

--- a/applications/plugins/Flexible/shapeFunction/ImageShapeFunctionSelectNode.h
+++ b/applications/plugins/Flexible/shapeFunction/ImageShapeFunctionSelectNode.h
@@ -91,7 +91,7 @@ public:
 
 protected:
 
-    virtual void update()
+    virtual void doUpdate()
     {
         unsigned int nodeIndex = d_nodeIndex.getValue();
         sout << "Update image for node " << nodeIndex << sendl;
@@ -115,8 +115,6 @@ protected:
                     for(int i=0; i<indices.spectrum(); i++)
                         if (indices(x,y,z,i)==d_nodeIndex.getValue())
                             nodeWeigh(x,y,z,0)=weight(x,y,z,i);
-
-        cleanDirty();
     }
 };
 

--- a/applications/plugins/Flexible/shapeFunction/ShapeFunctionDiscretizer.h
+++ b/applications/plugins/Flexible/shapeFunction/ShapeFunctionDiscretizer.h
@@ -122,7 +122,7 @@ public:
 
 protected:
 
-    virtual void update()
+    virtual void doUpdate()
     {
         if( !_shapeFunction ) return;
 
@@ -131,8 +131,6 @@ protected:
         raTransform inT(this->f_transform);
         if(in->isEmpty())  { serr<<"Image not found"<<sendl; return; }
         const cimg_library::CImg<T>& inimg = in->getCImg(0);  // suppose time=0
-
-        cleanDirty();
 
         // init indices and weights images
         const unsigned int nbref=_shapeFunction->f_nbRef.getValue();

--- a/applications/plugins/MeshSTEPLoader/STEPShapeMapping.cpp
+++ b/applications/plugins/MeshSTEPLoader/STEPShapeMapping.cpp
@@ -50,7 +50,7 @@ void STEPShapeExtractor::init()
 }
 
 
-void STEPShapeExtractor::update()
+void STEPShapeExtractor::doUpdate()
 {
     MeshSTEPLoader* input = loader.get();
     MeshTopology* output = topology.get();

--- a/applications/plugins/MeshSTEPLoader/STEPShapeMapping.h
+++ b/applications/plugins/MeshSTEPLoader/STEPShapeMapping.h
@@ -25,7 +25,7 @@ public:
     STEPShapeExtractor(loader::MeshSTEPLoader* loader=NULL,topology::MeshTopology* topology=NULL);
 
     void init();
-    void update();
+    void doUpdate();
 
     Data<unsigned int> shapeNumber; ///< Shape number to be loaded
     Data<unsigned int > indexBegin; ///< The begin index for this shape with respect to the global mesh

--- a/applications/plugins/MeshSTEPLoader/SingleComponent.h
+++ b/applications/plugins/MeshSTEPLoader/SingleComponent.h
@@ -49,7 +49,7 @@ public:
 
     virtual void init();
     virtual void reinit();
-    virtual void update();
+    virtual void doUpdate();
 
     template <class T>
     static bool canCreate(T*& obj, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)

--- a/applications/plugins/MeshSTEPLoader/SingleComponent.inl
+++ b/applications/plugins/MeshSTEPLoader/SingleComponent.inl
@@ -85,9 +85,8 @@ void SingleComponent<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void SingleComponent<DataTypes>::update()
+void SingleComponent<DataTypes>::doUpdate()
 {
-    cleanDirty();
     loadMesh();
 }
 

--- a/applications/plugins/Registration/GroupwiseRegistrationEngine.h
+++ b/applications/plugins/Registration/GroupwiseRegistrationEngine.h
@@ -98,11 +98,8 @@ protected:
     {
     }
 
-    virtual void update()
+    virtual void doUpdate()
     {
-        updateAllInputsIfDirty();
-        cleanDirty();
-
         const unsigned int M = vf_inputs.size();
         if(!M) return;
 

--- a/applications/plugins/Registration/IntensityProfileCreator.h
+++ b/applications/plugins/Registration/IntensityProfileCreator.h
@@ -82,11 +82,9 @@ public:
 
 protected:
 
-    virtual void update()
+    virtual void doUpdate()
     {
         helper::ReadAccessor<Data< helper::vector<T> > > val(this->values);
-
-        cleanDirty();
 
         helper::WriteOnlyAccessor<Data< ImageTypes > > out(this->image);
         imCoord dim(val.size(),1,1,1,1);

--- a/applications/plugins/SofaPython/ScriptDataEngine.h
+++ b/applications/plugins/SofaPython/ScriptDataEngine.h
@@ -18,10 +18,10 @@ namespace controller
 {
 
 
-class SOFA_SOFAPYTHON_API ScriptDataEngine : public core::SimpleDataEngine
+class SOFA_SOFAPYTHON_API ScriptDataEngine : public core::DataEngine
 {
 public:
-    SOFA_CLASS(ScriptDataEngine,core::SimpleDataEngine);
+    SOFA_CLASS(ScriptDataEngine,core::DataEngine);
 
 protected:
     ScriptDataEngine();

--- a/applications/plugins/SofaTest/DataEngine_test.h
+++ b/applications/plugins/SofaTest/DataEngine_test.h
@@ -29,8 +29,6 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <SofaBaseMechanics/MechanicalObject.h>
 
-using sofa::core::SimpleDataEngine;
-
 namespace sofa {
 
 
@@ -50,19 +48,9 @@ public:
     {}
 
 
-    template <class T = DataEngineType, typename std::enable_if<
-                  std::is_base_of<SimpleDataEngine, T>::value, int>::type = 0>
-    void update()
-    {
-        DataEngineType::update();
-        ++m_counter;
-    }
-
-    template <class T = DataEngineType, typename std::enable_if<
-                  std::is_base_of<SimpleDataEngine, T>::value, int>::type = 1>
     void doUpdate()
     {
-        SimpleDataEngine::doUpdate();
+        Inherit1::doUpdate();
         ++m_counter;
     }
 

--- a/applications/plugins/image/CollisionToCarvingEngine.h
+++ b/applications/plugins/image/CollisionToCarvingEngine.h
@@ -139,8 +139,8 @@ protected:
 	
     virtual void doUpdate() override
     {
-        bool updateImage = m_datatracker.isDirty(this->inputImage);	// change of input image -> update output image
-        bool updateTransform = m_datatracker.isDirty(this->inputTransform);	// change of input transform -> update output transform
+        bool updateImage = m_dataTracker.isDirty(this->inputImage);	// change of input image -> update output image
+        bool updateTransform = m_dataTracker.isDirty(this->inputTransform);	// change of input transform -> update output transform
 		
 		if(in==NULL){in = new raImagei(this->inputImage);}
 		if(inT==NULL){inT = new raTransform(this->inputTransform);}

--- a/applications/plugins/image/CollisionToCarvingEngine.h
+++ b/applications/plugins/image/CollisionToCarvingEngine.h
@@ -137,18 +137,16 @@ public:
 
 protected:
 	
-    virtual void update() override
+    virtual void doUpdate() override
     {
-		
-		bool updateImage = this->inputImage.isDirty();	// change of input image -> update output image
-        bool updateTransform = this->inputTransform.isDirty();	// change of input transform -> update output transform
+        bool updateImage = m_datatracker.isDirty(this->inputImage);	// change of input image -> update output image
+        bool updateTransform = m_datatracker.isDirty(this->inputTransform);	// change of input transform -> update output transform
 		
 		if(in==NULL){in = new raImagei(this->inputImage);}
 		if(inT==NULL){inT = new raTransform(this->inputTransform);}
 		if(out==NULL){out = new waImageo(this->outputImage);}
 		if(outT==NULL){outT = new waTransform(this->outputTransform);}
 
-		cleanDirty();
 	
 		if((*in)->isEmpty()) return;
 
@@ -179,7 +177,7 @@ protected:
 			}
 		}
 		else{
-			//cout<< "La collision dans une image rotationné n'est pas encore prise en compte" <<endl;
+			//cout<< "La collision dans une image rotationnÃ© n'est pas encore prise en compte" <<endl;
 		}
 		if (updateTransform) (*outT)->update(); // update internal data
     }

--- a/applications/plugins/image/DepthMapToMeshEngine.h
+++ b/applications/plugins/image/DepthMapToMeshEngine.h
@@ -147,15 +147,12 @@ protected:
     static const unsigned texture_res=256;
 #endif /* SOFA_NO_OPENGL */
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
         raImage in(this->image);
         raTransform inT(this->transform);
         raTexture inTex(this->texImage);
         const unsigned int dimx=in->getDimensions()[0],dimy=in->getDimensions()[1];
-
-
-        cleanDirty();
 
         waPositions pos(this->position);
         waTexCoords tc(this->texCoord);

--- a/applications/plugins/image/GenerateImage.h
+++ b/applications/plugins/image/GenerateImage.h
@@ -81,11 +81,10 @@ public:
 
 protected:
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
         const imCoord& dim = this->dimxyzct.getValue();
         helper::WriteOnlyAccessor<Data< ImageTypes > > out(this->image);
-        cleanDirty();
         out->setDimensions(dim);
     }
 

--- a/applications/plugins/image/ImageAccumulator.h
+++ b/applications/plugins/image/ImageAccumulator.h
@@ -113,7 +113,7 @@ protected:
     ctime_t t0,t;
     int count;
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
         if(SimuTime==this->getContext()->getTime()) return; // check if simutime has changed
         SimuTime=this->getContext()->getTime();
@@ -123,8 +123,6 @@ protected:
         raImage in(this->inputImage);
         if(in->isEmpty()) return;
         raTransform inT(this->inputTransform);
-
-        cleanDirty();
 
         waImage out(this->outputImage);
         waTransform outT(this->outputTransform);

--- a/applications/plugins/image/ImageCoordValuesFromPositions.h
+++ b/applications/plugins/image/ImageCoordValuesFromPositions.h
@@ -213,10 +213,9 @@ protected:
 
     unsigned int time;
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
         ImageCoordValuesFromPositionsSpecialization<ImageTypes>::update( *this );
-        cleanDirty();
     }
 
     void handleEvent(sofa::core::objectmodel::Event *event) override

--- a/applications/plugins/image/ImageDataDisplay.h
+++ b/applications/plugins/image/ImageDataDisplay.h
@@ -92,12 +92,10 @@ public:
 
 protected:
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
         const helper::SVector<helper::SVector<To> >& dat = this->VoxelData.getValue();
         raImagei in(this->inputImage);
-
-        cleanDirty();
 
         waImageo out(this->outputImage);
         imCoordi dim = in->getDimensions();

--- a/applications/plugins/image/ImageFilter.h
+++ b/applications/plugins/image/ImageFilter.h
@@ -176,17 +176,15 @@ public:
 
 protected:
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
-        bool updateImage = this->inputImage.isDirty();	// change of input image -> update output image
-        bool updateTransform = this->inputTransform.isDirty();	// change of input transform -> update output transform
+        bool updateImage = m_dataTracker.isDirty(this->inputImage);	// change of input image -> update output image
+        bool updateTransform = m_dataTracker.isDirty(this->inputTransform);	// change of input transform -> update output transform
         if(!updateImage && !updateTransform) {updateImage=true; updateTransform=true;}  // change of parameters -> update all
 
         raParam p(this->param);
         raTransform inT(this->inputTransform);
         raImagei in(this->inputImage);
-
-        cleanDirty();
 
         waImageo out(this->outputImage);
         waTransform outT(this->outputTransform);

--- a/applications/plugins/image/ImageOperation.h
+++ b/applications/plugins/image/ImageOperation.h
@@ -109,12 +109,10 @@ public:
 
 protected:
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
         raImage in1(this->inputImage1);
         raImage in2(this->inputImage2);
-
-        cleanDirty();
 
         waImage out(this->outputImage);
 

--- a/applications/plugins/image/ImageSampler.h
+++ b/applications/plugins/image/ImageSampler.h
@@ -570,12 +570,8 @@ protected:
 
     unsigned int time;
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
-        updateAllInputsIfDirty(); // easy to ensure that all inputs are up-to-date
-
-        cleanDirty();
-
         raParam params(this->param);
 
         if(this->method.getValue().getSelectedId() == REGULAR)

--- a/applications/plugins/image/ImageToRigidMassEngine.h
+++ b/applications/plugins/image/ImageToRigidMassEngine.h
@@ -120,7 +120,7 @@ protected:
 
     unsigned int time;
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
         raTransform inT(this->transform);
         raImage in(this->image);
@@ -130,8 +130,6 @@ protected:
         Real d = d_density.getValue();
         bool mult = d_mult.getValue();
 
-
-        cleanDirty();
 
         helper::WriteOnlyAccessor<Data< RigidCoord > > pos(this->d_position);
         helper::WriteOnlyAccessor<Data< RigidMass > > rigidMass(this->d_rigidMass);

--- a/applications/plugins/image/ImageTransform.h
+++ b/applications/plugins/image/ImageTransform.h
@@ -112,7 +112,7 @@ protected:
 
     ImageContainer* container;
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
         if (!container) return;
 

--- a/applications/plugins/image/ImageTransformEngine.h
+++ b/applications/plugins/image/ImageTransformEngine.h
@@ -95,7 +95,7 @@ public:
 
 protected:
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
 		raTransform inT(this->inputTransform);
         waTransform outT(this->outputTransform);
@@ -124,8 +124,6 @@ protected:
         outT->getRotation()=q.toEulerVector() * (Real)180.0 / (Real)M_PI ;
 
         outT->update(); // update internal data
-
-        cleanDirty();
     }
 
 };

--- a/applications/plugins/image/ImageValuesFromPositions.h
+++ b/applications/plugins/image/ImageValuesFromPositions.h
@@ -189,10 +189,9 @@ protected:
 
     unsigned int time;
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
         ImageValuesFromPositionsSpecialization<ImageTypes>::update( *this );
-        cleanDirty();
     }
 
     void handleEvent(sofa::core::objectmodel::Event *event) override

--- a/applications/plugins/image/MarchingCubesEngine.h
+++ b/applications/plugins/image/MarchingCubesEngine.h
@@ -119,7 +119,7 @@ protected:
 
     unsigned int time;
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
         raImage in(this->image);
 		raTransform inT(this->transform);
@@ -150,7 +150,6 @@ protected:
         else
             cimglist_for(faces,l) tri[l]=Triangle(faces(l,0),faces(l,1),faces(l,2));
 
-        cleanDirty();
     }
 
     void handleEvent(sofa::core::objectmodel::Event *event) override

--- a/applications/plugins/image/MergeImages.h
+++ b/applications/plugins/image/MergeImages.h
@@ -172,7 +172,7 @@ protected:
         Coord u;
     };
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
         unsigned int nb = nbImages.getValue();
         inputImages.resize(nb);
@@ -321,7 +321,6 @@ protected:
         }
 
         sout << "Created merged image from " << nb << " input images." << sendl;
-        cleanDirty();
     }
 
     defaulttype::Vec<2,Coord> getBB(unsigned int i) // get image corners

--- a/applications/plugins/image/MeshToImageEngine.h
+++ b/applications/plugins/image/MeshToImageEngine.h
@@ -251,11 +251,8 @@ public:
 
 protected:
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
-        updateAllInputsIfDirty();
-        cleanDirty();
-
         // to be backward-compatible, if less than 3 values, fill with the last one
         waVecReal vs( voxelSize ); unsigned vs_lastid=vs.size()-1;
         for( unsigned i=vs.size() ; i<3 ; ++i ) vs.push_back( vs[vs_lastid] );

--- a/applications/plugins/image/TransferFunction.h
+++ b/applications/plugins/image/TransferFunction.h
@@ -157,10 +157,9 @@ public:
 
 protected:
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
         TransferFunctionSpecialization<InImageTypes,OutImageTypes>::update( *this );
-        cleanDirty();
     }
 
 

--- a/applications/plugins/image/VoronoiToMeshEngine.h
+++ b/applications/plugins/image/VoronoiToMeshEngine.h
@@ -228,7 +228,7 @@ protected:
     }
 
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
         raImage in(this->image);
         raImage inb(this->background);
@@ -387,7 +387,6 @@ protected:
         }
 
         if(this->f_printLog.getValue()) std::cout<<this->name<<": done"<<std::endl;
-        cleanDirty();
     }
 
     void handleEvent(sofa::core::objectmodel::Event *event) override

--- a/applications/plugins/image/image_test/TestImageEngine.h
+++ b/applications/plugins/image/image_test/TestImageEngine.h
@@ -85,7 +85,7 @@ public:
         update();
     }
 
-    void update() override
+    void doUpdate() override
     {
         waImage out(this->outputImage);
         raImage in(this->inputImage);
@@ -101,7 +101,6 @@ public:
 
         out->getCImg(0) = in->getCImg(0);
 //        std::cerr << "TestImageEngine input shared: " << in->getCImg(0).is_shared() << std::endl;
-        cleanDirty();
     }
 
     void handleEvent(sofa::core::objectmodel::Event *event) override

--- a/applications/plugins/image/imagetoolbox/depth/averagecatchallvector.h
+++ b/applications/plugins/image/imagetoolbox/depth/averagecatchallvector.h
@@ -85,7 +85,7 @@ public:
 
 protected:
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
     }
 

--- a/applications/plugins/image/imagetoolbox/depth/catchallvector.h
+++ b/applications/plugins/image/imagetoolbox/depth/catchallvector.h
@@ -68,7 +68,7 @@ public:
 
 protected:
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
     }
 

--- a/applications/plugins/image/imagetoolbox/depth/mergedcatchallvector.h
+++ b/applications/plugins/image/imagetoolbox/depth/mergedcatchallvector.h
@@ -90,7 +90,7 @@ public:
 
 protected:
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
     }
 

--- a/applications/plugins/image/imagetoolbox/labelimagetoolbox.h
+++ b/applications/plugins/image/imagetoolbox/labelimagetoolbox.h
@@ -100,10 +100,8 @@ protected:
 
     unsigned int time;
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
-        cleanDirty();
-
     }
 
     void handleEvent(sofa::core::objectmodel::Event * /*event*/) override

--- a/modules/SofaGeneralEngine/AverageCoord.h
+++ b/modules/SofaGeneralEngine/AverageCoord.h
@@ -63,7 +63,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     Data<VecIndex> d_indices;    ///< indices of the coordinates to average
     Data<unsigned> d_vecId;  ///< index of the vector (default value corresponds to core::VecCoordId::position() )

--- a/modules/SofaGeneralEngine/AverageCoord.inl
+++ b/modules/SofaGeneralEngine/AverageCoord.inl
@@ -67,7 +67,7 @@ void AverageCoord<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void AverageCoord<DataTypes>::update()
+void AverageCoord<DataTypes>::doUpdate()
 {
     if(mstate==NULL)
     {
@@ -86,8 +86,6 @@ void AverageCoord<DataTypes>::update()
         c += coord[ (indices.empty()) ? i : indices[i]];
     }
     c *= 1./n;
-
-    cleanDirty();
 
     d_average.setValue(c);
 }

--- a/modules/SofaGeneralEngine/ClusteringEngine.h
+++ b/modules/SofaGeneralEngine/ClusteringEngine.h
@@ -81,7 +81,7 @@ public:
     virtual ~ClusteringEngine() {}
 
     void init() override;
-    void update() override;
+    void doUpdate() override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/modules/SofaGeneralEngine/ClusteringEngine.inl
+++ b/modules/SofaGeneralEngine/ClusteringEngine.inl
@@ -89,7 +89,7 @@ void ClusteringEngine<DataTypes>::init()
 
 
 template <class DataTypes>
-void ClusteringEngine<DataTypes>::update()
+void ClusteringEngine<DataTypes>::doUpdate()
 {
     if(load()) return;
 
@@ -158,7 +158,6 @@ void ClusteringEngine<DataTypes>::update()
     }
 
     save();
-    cleanDirty();
 }
 
 

--- a/modules/SofaGeneralEngine/ClusteringEngine.inl
+++ b/modules/SofaGeneralEngine/ClusteringEngine.inl
@@ -304,7 +304,6 @@ bool ClusteringEngine<DataTypes>::load()
 {
     if (!this->input_filename.isSet()) return false;
 
-    input_filename.update();
     string fname(this->input_filename.getFullPath());
     if(!fname.compare(loadedFilename)) return true;
 

--- a/modules/SofaGeneralEngine/ComplementaryROI.h
+++ b/modules/SofaGeneralEngine/ComplementaryROI.h
@@ -59,7 +59,7 @@ public:
     ~ComplementaryROI();
 
     /// Update
-    virtual void update() override;
+    virtual void doUpdate() override;
 
     /// Parse the given description to assign values to this object's fields and potentially other parameters
     virtual void parse ( sofa::core::objectmodel::BaseObjectDescription* arg ) override;

--- a/modules/SofaGeneralEngine/ComplementaryROI.inl
+++ b/modules/SofaGeneralEngine/ComplementaryROI.inl
@@ -96,10 +96,8 @@ void ComplementaryROI<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void ComplementaryROI<DataTypes>::update()
+void ComplementaryROI<DataTypes>::doUpdate()
 {
-    cleanDirty();
-
     ReadAccessor<Data<VecCoord> > position(d_position);
     ReadAccessor<Data<unsigned int> > nbSet(d_nbSet);
 

--- a/modules/SofaGeneralEngine/DifferenceEngine.h
+++ b/modules/SofaGeneralEngine/DifferenceEngine.h
@@ -57,7 +57,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     virtual std::string getTemplateName() const override
     {

--- a/modules/SofaGeneralEngine/DifferenceEngine.inl
+++ b/modules/SofaGeneralEngine/DifferenceEngine.inl
@@ -61,12 +61,10 @@ void DifferenceEngine<DataType>::reinit()
 }
 
 template <class DataType>
-void DifferenceEngine<DataType>::update()
+void DifferenceEngine<DataType>::doUpdate()
 {
     helper::ReadAccessor<Data<VecData> > in = d_input;
     helper::ReadAccessor<Data<VecData> > sub = d_substractor;
-
-    cleanDirty();
 
     helper::WriteOnlyAccessor<Data<VecData> > out = d_output;
 

--- a/modules/SofaGeneralEngine/DilateEngine.h
+++ b/modules/SofaGeneralEngine/DilateEngine.h
@@ -69,7 +69,7 @@ public:
     virtual void init() override;
     virtual void bwdInit() override;
     virtual void reinit() override;
-    virtual void update() override;
+    virtual void doUpdate() override;
 
     virtual std::string getTemplateName() const override
     {

--- a/modules/SofaGeneralEngine/DilateEngine.inl
+++ b/modules/SofaGeneralEngine/DilateEngine.inl
@@ -90,15 +90,13 @@ void DilateEngine<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void DilateEngine<DataTypes>::update()
+void DilateEngine<DataTypes>::doUpdate()
 {
     ReadAccessor<Data<VecCoord> > in = d_inputX;
     ReadAccessor<Data<SeqTriangles> > triangles = d_triangles;
     ReadAccessor<Data<SeqQuads> > quads = d_quads;
     const Real distance = d_distance.getValue();
     const Real minThickness = d_minThickness.getValue();
-
-    cleanDirty();
 
     WriteOnlyAccessor<Data<VecCoord> > out = d_outputX;
 

--- a/modules/SofaGeneralEngine/ExtrudeEdgesAndGenerateQuads.h
+++ b/modules/SofaGeneralEngine/ExtrudeEdgesAndGenerateQuads.h
@@ -67,7 +67,7 @@ public:
     virtual void init() override;
     virtual void bwdInit() override;
     virtual void reinit() override;
-    virtual void update() override;
+    virtual void doUpdate() override;
 
     virtual std::string getTemplateName() const override
     {

--- a/modules/SofaGeneralEngine/ExtrudeEdgesAndGenerateQuads.inl
+++ b/modules/SofaGeneralEngine/ExtrudeEdgesAndGenerateQuads.inl
@@ -97,7 +97,7 @@ void ExtrudeEdgesAndGenerateQuads<DataTypes>::checkInput()
 }
 
 template <class DataTypes>
-void ExtrudeEdgesAndGenerateQuads<DataTypes>::update()
+void ExtrudeEdgesAndGenerateQuads<DataTypes>::doUpdate()
 {
     const vector<BaseMeshTopology::Edge>& curveEdges = d_curveEdges.getValue();
     const VecCoord& curveVertices = d_curveVertices.getValue();
@@ -109,8 +109,6 @@ void ExtrudeEdgesAndGenerateQuads<DataTypes>::update()
 
         return;
     }
-
-    cleanDirty();
 
     VecCoord* extrudedVertices = d_extrudedVertices.beginWriteOnly();
     extrudedVertices->clear();

--- a/modules/SofaGeneralEngine/ExtrudeQuadsAndGenerateHexas.h
+++ b/modules/SofaGeneralEngine/ExtrudeQuadsAndGenerateHexas.h
@@ -67,7 +67,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     void draw( const core::visual::VisualParams* ) override;
 

--- a/modules/SofaGeneralEngine/ExtrudeQuadsAndGenerateHexas.inl
+++ b/modules/SofaGeneralEngine/ExtrudeQuadsAndGenerateHexas.inl
@@ -76,7 +76,7 @@ void ExtrudeQuadsAndGenerateHexas<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void ExtrudeQuadsAndGenerateHexas<DataTypes>::update()
+void ExtrudeQuadsAndGenerateHexas<DataTypes>::doUpdate()
 {
     using sofa::core::topology::BaseMeshTopology;
 
@@ -88,8 +88,6 @@ void ExtrudeQuadsAndGenerateHexas<DataTypes>::update()
         msg_warning() << "initial mesh does not contain vertices or quads... No extruded mesh will be generated" ;
         return;
     }
-
-    cleanDirty();
 
     VecCoord* extrudedVertices = f_extrudedVertices.beginWriteOnly();
     extrudedVertices->clear();

--- a/modules/SofaGeneralEngine/ExtrudeSurface.h
+++ b/modules/SofaGeneralEngine/ExtrudeSurface.h
@@ -66,7 +66,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/modules/SofaGeneralEngine/ExtrudeSurface.inl
+++ b/modules/SofaGeneralEngine/ExtrudeSurface.inl
@@ -71,10 +71,9 @@ void ExtrudeSurface<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void ExtrudeSurface<DataTypes>::update()
+void ExtrudeSurface<DataTypes>::doUpdate()
 {
     using sofa::core::topology::BaseMeshTopology;
-
 
     const helper::vector<BaseMeshTopology::TriangleID>& surfaceTriangles = f_surfaceTriangles.getValue();
     const VecCoord& surfaceVertices = f_surfaceVertices.getValue();
@@ -83,8 +82,6 @@ void ExtrudeSurface<DataTypes>::update()
         return;
 
     const BaseMeshTopology::SeqTriangles* triangles = &f_triangles.getValue();
-
-    cleanDirty();
 
     VecCoord* extrusionVertices = f_extrusionVertices.beginWriteOnly();
     extrusionVertices->clear();

--- a/modules/SofaGeneralEngine/GenerateCylinder.h
+++ b/modules/SofaGeneralEngine/GenerateCylinder.h
@@ -70,7 +70,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     virtual std::string getTemplateName() const override
     {

--- a/modules/SofaGeneralEngine/GenerateCylinder.inl
+++ b/modules/SofaGeneralEngine/GenerateCylinder.inl
@@ -93,7 +93,7 @@ void GenerateCylinder<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void GenerateCylinder<DataTypes>::update()
+void GenerateCylinder<DataTypes>::doUpdate()
 {
     const Real radius = f_radius.getValue();
     const Real height = f_height.getValue();
@@ -102,8 +102,6 @@ void GenerateCylinder<DataTypes>::update()
     const size_t freqTheta=f_resolutionCircumferential.getValue();
     const size_t freqR=f_resolutionRadial.getValue();
     const size_t freqZ=f_resolutionHeight.getValue();
-
-    cleanDirty();
 
     helper::WriteOnlyAccessor<Data<VecCoord> > out = f_outputTetrahedraPositions;
     helper::WriteOnlyAccessor<Data<SeqTetrahedra> > tetras = f_tetrahedra;

--- a/modules/SofaGeneralEngine/GenerateGrid.h
+++ b/modules/SofaGeneralEngine/GenerateGrid.h
@@ -75,7 +75,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     virtual std::string getTemplateName() const override
     {

--- a/modules/SofaGeneralEngine/GenerateGrid.inl
+++ b/modules/SofaGeneralEngine/GenerateGrid.inl
@@ -70,10 +70,8 @@ void GenerateGrid<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void GenerateGrid<DataTypes>::update()
+void GenerateGrid<DataTypes>::doUpdate()
 {
-    cleanDirty();
-
     helper::WriteAccessor<Data<VecCoord> > out = d_outputX;
 
     Vec3 size=d_maxCorner.getValue()-d_minCorner.getValue();

--- a/modules/SofaGeneralEngine/GenerateRigidMass.h
+++ b/modules/SofaGeneralEngine/GenerateRigidMass.h
@@ -52,7 +52,7 @@ public:
     /// Update method called when variables used in precomputation are modified.
     virtual void reinit() override;
     /// Update the output values
-    virtual void update() override;
+    virtual void doUpdate() override;
 
 protected:
 

--- a/modules/SofaGeneralEngine/GenerateRigidMass.inl
+++ b/modules/SofaGeneralEngine/GenerateRigidMass.inl
@@ -89,10 +89,9 @@ void GenerateRigidMass<DataTypes, MassType>::reinit()
 }
 
 template <class DataTypes, class MassType>
-void GenerateRigidMass<DataTypes, MassType>::update()
+void GenerateRigidMass<DataTypes, MassType>::doUpdate()
 {
     integrateMesh();
-    cleanDirty();
     generateRigid();
 }
 

--- a/modules/SofaGeneralEngine/GenerateSphere.h
+++ b/modules/SofaGeneralEngine/GenerateSphere.h
@@ -78,7 +78,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     virtual std::string getTemplateName() const override
     {

--- a/modules/SofaGeneralEngine/GenerateSphere.inl
+++ b/modules/SofaGeneralEngine/GenerateSphere.inl
@@ -182,15 +182,12 @@ void GenerateSphere<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void GenerateSphere<DataTypes>::update()
+void GenerateSphere<DataTypes>::doUpdate()
 {
     const Real radius = f_radius.getValue();
 	const size_t frequency = f_tessellationDegree.getValue();
 	const Coord origin = f_origin.getValue();
 	const PlatonicTriangulation solid=platonicSolid;
-
-
-    cleanDirty();
 
 	helper::WriteOnlyAccessor<Data<VecCoord> > posTrian = f_outputTrianglesPositions;
     helper::WriteOnlyAccessor<Data<SeqTriangles> > trians = f_triangles;

--- a/modules/SofaGeneralEngine/GroupFilterYoungModulus.h
+++ b/modules/SofaGeneralEngine/GroupFilterYoungModulus.h
@@ -60,7 +60,7 @@ protected:
 public:
     void init() override;
     void reinit() override;
-    void update() override;
+    void doUpdate() override;
 
     //Input
     Data<helper::vector<sofa::core::loader::PrimitiveGroup > > f_groups; ///< Groups

--- a/modules/SofaGeneralEngine/GroupFilterYoungModulus.inl
+++ b/modules/SofaGeneralEngine/GroupFilterYoungModulus.inl
@@ -61,7 +61,7 @@ void GroupFilterYoungModulus<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void GroupFilterYoungModulus<DataTypes>::update()
+void GroupFilterYoungModulus<DataTypes>::doUpdate()
 {
     //Input
     const std::string& strMap = p_mapGroupModulus.getValue();
@@ -70,8 +70,6 @@ void GroupFilterYoungModulus<DataTypes>::update()
     const helper::vector<int >& elementsGroup = f_elementsGroup.getValue();
 
     const Real& defaultModulus =  p_defaultModulus.getValue();
-
-    cleanDirty();
 
     //Output
     helper::vector<Real>& youngModulusVector = *f_youngModulus.beginWriteOnly();

--- a/modules/SofaGeneralEngine/HausdorffDistance.h
+++ b/modules/SofaGeneralEngine/HausdorffDistance.h
@@ -65,7 +65,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     //Input
     Data<VecCoord> f_points_1; ///< Points belonging to the first point cloud

--- a/modules/SofaGeneralEngine/HausdorffDistance.inl
+++ b/modules/SofaGeneralEngine/HausdorffDistance.inl
@@ -73,10 +73,8 @@ void HausdorffDistance<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void HausdorffDistance<DataTypes>::update()
+void HausdorffDistance<DataTypes>::doUpdate()
 {
-    cleanDirty();
-
     if (f_update.getValue())
         computeDistances();
 }

--- a/modules/SofaGeneralEngine/IndexValueMapper.h
+++ b/modules/SofaGeneralEngine/IndexValueMapper.h
@@ -58,7 +58,7 @@ protected:
 public:
     virtual void init() override;
     virtual void reinit() override;
-    virtual void update() override;
+    virtual void doUpdate() override;
 
     virtual std::string getTemplateName() const override
     {

--- a/modules/SofaGeneralEngine/IndexValueMapper.inl
+++ b/modules/SofaGeneralEngine/IndexValueMapper.inl
@@ -64,13 +64,11 @@ void IndexValueMapper<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void IndexValueMapper<DataTypes>::update()
+void IndexValueMapper<DataTypes>::doUpdate()
 {
     helper::ReadAccessor< Data< helper::vector<Real> > > inputValues = f_inputValues;
     helper::ReadAccessor< Data< helper::vector<Index> > > indices = f_indices;
     const Real& value = f_value.getValue();
-
-    cleanDirty();
 
     helper::WriteOnlyAccessor< Data< helper::vector<Real> > > outputValues = f_outputValues;
 

--- a/modules/SofaGeneralEngine/Indices2ValuesMapper.h
+++ b/modules/SofaGeneralEngine/Indices2ValuesMapper.h
@@ -60,7 +60,7 @@ protected:
 public:
     void init() override;
     void reinit() override;
-    void update() override;
+    void doUpdate() override;
 
     virtual std::string getTemplateName() const override
     {

--- a/modules/SofaGeneralEngine/Indices2ValuesMapper.inl
+++ b/modules/SofaGeneralEngine/Indices2ValuesMapper.inl
@@ -68,10 +68,8 @@ void Indices2ValuesMapper<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void Indices2ValuesMapper<DataTypes>::update()
+void Indices2ValuesMapper<DataTypes>::doUpdate()
 {
-    cleanDirty();
-
     helper::ReadAccessor< Data< helper::vector<Real> > > inputValues = f_inputValues;
 
     helper::ReadAccessor< Data< helper::vector<Real> > > indices = f_indices;

--- a/modules/SofaGeneralEngine/IndicesFromValues.h
+++ b/modules/SofaGeneralEngine/IndicesFromValues.h
@@ -62,7 +62,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     core::objectmodel::Data<VecValue> f_values; ///< input values
     core::objectmodel::Data<VecValue> f_global; ///< Global values, in which the input values are searched

--- a/modules/SofaGeneralEngine/IndicesFromValues.inl
+++ b/modules/SofaGeneralEngine/IndicesFromValues.inl
@@ -66,12 +66,10 @@ void IndicesFromValues<T>::reinit()
 }
 
 template <class T>
-void IndicesFromValues<T>::update()
+void IndicesFromValues<T>::doUpdate()
 {
     helper::ReadAccessor<Data<VecValue> > global = f_global;
     helper::ReadAccessor<Data<VecValue> > values = f_values;
-
-    cleanDirty();
 
     helper::WriteOnlyAccessor<Data<VecIndex> > indices = f_indices;
     helper::WriteOnlyAccessor<Data<VecIndex> > otherIndices = f_otherIndices;

--- a/modules/SofaGeneralEngine/JoinPoints.h
+++ b/modules/SofaGeneralEngine/JoinPoints.h
@@ -61,7 +61,7 @@ protected:
 public:
     void init() override;
     void reinit() override;
-    void update() override;
+    void doUpdate() override;
 
     virtual std::string getTemplateName() const override
     {

--- a/modules/SofaGeneralEngine/JoinPoints.inl
+++ b/modules/SofaGeneralEngine/JoinPoints.inl
@@ -97,12 +97,10 @@ bool JoinPoints<DataTypes>::getNearestPoint(const typename std::list<Coord>::ite
 }
 
 template <class DataTypes>
-void JoinPoints<DataTypes>::update()
+void JoinPoints<DataTypes>::doUpdate()
 {
     const VecCoord& points = f_points.getValue();
     const Real distance = f_distance.getValue();
-
-    cleanDirty();
 
     if (points.size() < 1)
     {

--- a/modules/SofaGeneralEngine/MapIndices.h
+++ b/modules/SofaGeneralEngine/MapIndices.h
@@ -61,7 +61,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     core::objectmodel::Data<VecValue> f_in; ///< input indices
     core::objectmodel::Data<VecIndex> f_indices; ///< array containing in ith cell the input index corresponding to the output index i (or reversively if transpose=true)

--- a/modules/SofaGeneralEngine/MapIndices.inl
+++ b/modules/SofaGeneralEngine/MapIndices.inl
@@ -86,13 +86,11 @@ inline void MapIndices<unsigned int>::apply(Value& v, const MapIndex& m)
 }
 
 template <class T>
-void MapIndices<T>::update()
+void MapIndices<T>::doUpdate()
 {
     helper::ReadAccessor<Data<VecValue> > in = f_in;
     helper::ReadAccessor<Data<VecIndex> > indices = f_indices;
     const bool transpose = f_transpose.getValue();
-
-    cleanDirty();
 
     helper::WriteOnlyAccessor<Data<VecValue> > out = f_out;
 

--- a/modules/SofaGeneralEngine/MathOp.h
+++ b/modules/SofaGeneralEngine/MathOp.h
@@ -65,7 +65,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     virtual std::string getTemplateName() const override
     {

--- a/modules/SofaGeneralEngine/MathOp.inl
+++ b/modules/SofaGeneralEngine/MathOp.inl
@@ -466,16 +466,10 @@ void MathOp<VecT>::reinit()
 }
 
 template <class VecT>
-void MathOp<VecT>::update()
+void MathOp<VecT>::doUpdate()
 {
 //    createInputs();
     std::string op = f_op.getValue().getSelectedItem();
-
-    // ensure all inputs are up-to-date before cleaning engine
-    for (unsigned int i=0, iend=vf_inputs.size(); i<iend; ++i)
-        vf_inputs[i]->updateIfDirty();
-
-    cleanDirty();
 
     bool result = MathOpApply< typename MathOpTraits<Value>::Ops >::apply(
         op, &f_output, vf_inputs);

--- a/modules/SofaGeneralEngine/MergeMeshes.h
+++ b/modules/SofaGeneralEngine/MergeMeshes.h
@@ -67,7 +67,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     virtual std::string getTemplateName() const override
     {

--- a/modules/SofaGeneralEngine/MergeMeshes.inl
+++ b/modules/SofaGeneralEngine/MergeMeshes.inl
@@ -133,23 +133,11 @@ void MergeMeshes<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void MergeMeshes<DataTypes>::update()
+void MergeMeshes<DataTypes>::doUpdate()
 {
 //    createInputMeshesData();
 
     unsigned int nb = f_nbMeshes.getValue();
-
-    for (unsigned int i=0; i<nb; ++i)
-    {
-        vf_positions[i]->updateIfDirty();
-        vf_edges[i]->updateIfDirty();
-        vf_triangles[i]->updateIfDirty();
-        vf_quads[i]->updateIfDirty();
-        vf_tetrahedra[i]->updateIfDirty();
-        vf_hexahedra[i]->updateIfDirty();
-    }
-
-    cleanDirty();
 
     mergeInputDataVector(nb, f_output_positions, vf_positions);
     mergeInputDataVector(nb, f_output_edges, vf_edges, vf_positions);

--- a/modules/SofaGeneralEngine/MergePoints.h
+++ b/modules/SofaGeneralEngine/MergePoints.h
@@ -60,7 +60,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     virtual std::string getTemplateName() const override
     {

--- a/modules/SofaGeneralEngine/MergePoints.inl
+++ b/modules/SofaGeneralEngine/MergePoints.inl
@@ -69,7 +69,7 @@ void MergePoints<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void MergePoints<DataTypes>::update()
+void MergePoints<DataTypes>::doUpdate()
 {
     if (f_noUpdate.getValue() && initDone)
         return;
@@ -136,8 +136,6 @@ void MergePoints<DataTypes>::update()
             indices2.push_back(index+i);
         }
     }
-
-    cleanDirty();
 
     f_indices1.endEdit();
     f_indices2.endEdit();

--- a/modules/SofaGeneralEngine/MergeROIs.h
+++ b/modules/SofaGeneralEngine/MergeROIs.h
@@ -103,7 +103,7 @@ protected:
 
     virtual ~MergeROIs() {}
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
         size_t nb = nbROIs.getValue();
         f_indices.resize(nb);
@@ -118,8 +118,6 @@ protected:
             outputIndices[j].resize(indices.size());
             for(size_t i=0 ; i<indices.size() ; i++) outputIndices[j][i]=indices[i];
         }
-
-        cleanDirty();
     }
 
 };

--- a/modules/SofaGeneralEngine/MergeSets.h
+++ b/modules/SofaGeneralEngine/MergeSets.h
@@ -58,7 +58,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     Data<VecIndex> f_in1; ///< first set of indices
     Data<VecIndex> f_in2; ///< second set of indices

--- a/modules/SofaGeneralEngine/MergeSets.inl
+++ b/modules/SofaGeneralEngine/MergeSets.inl
@@ -71,15 +71,13 @@ void MergeSets<T>::reinit()
 }
 
 template <class T>
-void MergeSets<T>::update()
+void MergeSets<T>::doUpdate()
 {
     std::string op = f_op.getValue();
     if (op.empty()) op = "union";
 
     helper::ReadAccessor<Data<VecIndex> > in1 = f_in1;
     helper::ReadAccessor<Data<VecIndex> > in2 = f_in2;
-
-    cleanDirty();
 
     helper::WriteOnlyAccessor<Data<VecIndex> > out = f_out;
 

--- a/modules/SofaGeneralEngine/MergeVectors.h
+++ b/modules/SofaGeneralEngine/MergeVectors.h
@@ -66,7 +66,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     virtual std::string getTemplateName() const override
     {

--- a/modules/SofaGeneralEngine/MergeVectors.inl
+++ b/modules/SofaGeneralEngine/MergeVectors.inl
@@ -80,14 +80,9 @@ void MergeVectors<VecT>::reinit()
 }
 
 template <class VecT>
-void MergeVectors<VecT>::update()
+void MergeVectors<VecT>::doUpdate()
 {
     unsigned int nb = f_nbInputs.getValue();
-
-    for (unsigned int i=0; i<nb; ++i)
-        vf_inputs[i]->updateIfDirty();
-
-    cleanDirty();
 
     helper::vectorData<VecValue>::merge( f_output, vf_inputs );
 }

--- a/modules/SofaGeneralEngine/MeshBarycentricMapperEngine.h
+++ b/modules/SofaGeneralEngine/MeshBarycentricMapperEngine.h
@@ -67,7 +67,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/modules/SofaGeneralEngine/MeshBarycentricMapperEngine.inl
+++ b/modules/SofaGeneralEngine/MeshBarycentricMapperEngine.inl
@@ -82,9 +82,8 @@ void MeshBarycentricMapperEngine<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void MeshBarycentricMapperEngine<DataTypes>::update()
+void MeshBarycentricMapperEngine<DataTypes>::doUpdate()
 {
-
     using sofa::defaulttype::Vector3;
     using sofa::defaulttype::Matrix3;
     using sofa::defaulttype::Mat3x3d;
@@ -119,8 +118,6 @@ void MeshBarycentricMapperEngine<DataTypes>::update()
     const VecCoord* in = &InputPositions.getValue();
     const VecCoord* out = &MappedPointPositions.getValue();
 
-
-    cleanDirty();
 
 
     baryPos =  BarycentricPositions.beginWriteOnly();

--- a/modules/SofaGeneralEngine/MeshBoundaryROI.h
+++ b/modules/SofaGeneralEngine/MeshBoundaryROI.h
@@ -89,12 +89,10 @@ public:
     }
 
     virtual void reinit()    override { update();  }
-    void update() override
+    void doUpdate() override
     {
         helper::ReadAccessor<Data< SeqTriangles > > triangles(this->d_triangles);
         helper::ReadAccessor<Data< SeqQuads > > quads(this->d_quads);
-
-        cleanDirty();
 
         helper::WriteOnlyAccessor<Data< SetIndex > >  indices(this->d_indices);
         indices.clear();

--- a/modules/SofaGeneralEngine/MeshClosingEngine.h
+++ b/modules/SofaGeneralEngine/MeshClosingEngine.h
@@ -113,7 +113,7 @@ public:
     }
 
     virtual void reinit()    override { update();  }
-    void update() override;
+    void doUpdate() override;
 };
 
 #if defined(SOFA_EXTERN_TEMPLATE) && !defined(SOFA_COMPONENT_ENGINE_MeshClosingEngine_CPP)

--- a/modules/SofaGeneralEngine/MeshClosingEngine.inl
+++ b/modules/SofaGeneralEngine/MeshClosingEngine.inl
@@ -34,13 +34,11 @@ namespace engine
 {
 
 template <class DataTypes>
-void MeshClosingEngine<DataTypes>::update()
+void MeshClosingEngine<DataTypes>::doUpdate()
 {
     helper::ReadAccessor<Data< SeqPositions > > pos(this->inputPosition);
     helper::ReadAccessor<Data< SeqTriangles > > tri(this->inputTriangles);
     helper::ReadAccessor<Data< SeqQuads > > qd(this->inputQuads);
-
-    cleanDirty();
 
     helper::WriteOnlyAccessor<Data< SeqPositions > > opos(this->position);
     helper::WriteOnlyAccessor<Data< SeqTriangles > >  otri(this->triangles);

--- a/modules/SofaGeneralEngine/MeshROI.h
+++ b/modules/SofaGeneralEngine/MeshROI.h
@@ -74,7 +74,7 @@ public:
 
     virtual void init() override;
     virtual void reinit() override;
-    virtual void update() override;
+    virtual void doUpdate() override;
     virtual void draw(const core::visual::VisualParams*) override;
 
     /// Pre-construction check method called by ObjectFactory.

--- a/modules/SofaGeneralEngine/MeshROI.inl
+++ b/modules/SofaGeneralEngine/MeshROI.inl
@@ -592,7 +592,7 @@ void MeshROI<DataTypes>::compute()
 
 
 template <class DataTypes>
-void MeshROI<DataTypes>::update()
+void MeshROI<DataTypes>::doUpdate()
 {
     if(d_doUpdate.getValue())
         compute();

--- a/modules/SofaGeneralEngine/MeshSampler.h
+++ b/modules/SofaGeneralEngine/MeshSampler.h
@@ -71,7 +71,7 @@ public:
 
     virtual void reinit()    override { update();  }
     virtual void init() override;
-    void update() override;
+    void doUpdate() override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/modules/SofaGeneralEngine/MeshSampler.inl
+++ b/modules/SofaGeneralEngine/MeshSampler.inl
@@ -67,15 +67,9 @@ void MeshSampler<DataTypes>::init()
 
 
 template <class DataTypes>
-void MeshSampler<DataTypes>::update()
+void MeshSampler<DataTypes>::doUpdate()
 {
     sofa::helper::ReadAccessor< Data< VecCoord > > pos = this->position;
-
-    number.updateIfDirty();
-    f_edges.updateIfDirty();
-    maxIter.updateIfDirty();
-
-    cleanDirty();
 
     VVI ngb;    if(this->f_edges.getValue().size()!=0) computeNeighbors(ngb); // one ring neighbors from edges
     VI voronoi;

--- a/modules/SofaGeneralEngine/MeshSplittingEngine.h
+++ b/modules/SofaGeneralEngine/MeshSplittingEngine.h
@@ -160,7 +160,7 @@ public:
     }
 
 
-    void update() override;
+    void doUpdate() override;
 
 protected:
     void resizeData()

--- a/modules/SofaGeneralEngine/MeshSplittingEngine.inl
+++ b/modules/SofaGeneralEngine/MeshSplittingEngine.inl
@@ -52,11 +52,8 @@ inline void parseIndices(helper::vector<unsigned int>& pairs, const container1& 
 
 
 template <class DataTypes>
-void MeshSplittingEngine<DataTypes>::update()
+void MeshSplittingEngine<DataTypes>::doUpdate()
 {
-    updateAllInputsIfDirty();
-    cleanDirty();
-
     helper::ReadAccessor<Data< SeqPositions > > i_pos(this->inputPosition);
     const size_t& nb = nbInputs.getValue();
 

--- a/modules/SofaGeneralEngine/MeshSubsetEngine.h
+++ b/modules/SofaGeneralEngine/MeshSubsetEngine.h
@@ -110,7 +110,7 @@ public:
     }
 
     virtual void reinit()    override { update();  }
-    void update() override;
+    void doUpdate() override;
 };
 
 #if defined(SOFA_EXTERN_TEMPLATE) && !defined(SOFA_COMPONENT_ENGINE_MeshSubsetEngine_CPP)

--- a/modules/SofaGeneralEngine/MeshSubsetEngine.inl
+++ b/modules/SofaGeneralEngine/MeshSubsetEngine.inl
@@ -34,7 +34,7 @@ namespace engine
 {
 
 template <class DataTypes>
-void MeshSubsetEngine<DataTypes>::update()
+void MeshSubsetEngine<DataTypes>::doUpdate()
 {
     helper::ReadAccessor<Data< SeqPositions > > pos(this->inputPosition);
     helper::ReadAccessor<Data< SeqEdges > > edg(this->inputEdges);
@@ -78,8 +78,6 @@ void MeshSubsetEngine<DataTypes>::update()
         for(size_t j=0; j<4; j++) if(FtoS.find(qd[i][j])==FtoS.end()) { inside=false; break; } else cell[j]=FtoS[qd[i][j]];
         if(inside) oqd.push_back(cell);
     }
-
-    this->cleanDirty();
 }
 
 

--- a/modules/SofaGeneralEngine/NormEngine.h
+++ b/modules/SofaGeneralEngine/NormEngine.h
@@ -56,7 +56,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     virtual std::string getTemplateName() const override
     {

--- a/modules/SofaGeneralEngine/NormEngine.inl
+++ b/modules/SofaGeneralEngine/NormEngine.inl
@@ -60,12 +60,10 @@ void NormEngine<DataType>::reinit()
 }
 
 template <class DataType>
-void NormEngine<DataType>::update()
+void NormEngine<DataType>::doUpdate()
 {
     helper::ReadAccessor<Data<VecData> > in = d_input;
     int l = d_normType.getValue();
-
-    cleanDirty();
 
     helper::WriteOnlyAccessor<Data<VecReal> > out = d_output;
 
@@ -73,7 +71,6 @@ void NormEngine<DataType>::update()
 
     for( size_t i=0 ; i<in.size() ; ++i )
         out[i] = in[i].lNorm(l);
-
 
 }
 

--- a/modules/SofaGeneralEngine/NormalsFromPoints.h
+++ b/modules/SofaGeneralEngine/NormalsFromPoints.h
@@ -61,7 +61,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     Data< VecCoord > position; ///< Vertices of the mesh
     Data< helper::vector< helper::fixed_array <unsigned int,3> > > triangles; ///< Triangles of the mesh

--- a/modules/SofaGeneralEngine/NormalsFromPoints.inl
+++ b/modules/SofaGeneralEngine/NormalsFromPoints.inl
@@ -70,7 +70,7 @@ void NormalsFromPoints<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void NormalsFromPoints<DataTypes>::update()
+void NormalsFromPoints<DataTypes>::doUpdate()
 {
     helper::ReadAccessor<Data< VecCoord > > raPositions = position;
     helper::ReadAccessor<Data< helper::vector< helper::fixed_array <unsigned int,3> > > > raTriangles = triangles;
@@ -141,8 +141,6 @@ void NormalsFromPoints<DataTypes>::update()
 
     for (unsigned int i = 0; i < waNormals.size(); i++)
         waNormals[i].normalize();
-
-    cleanDirty();
 }
 
 } // namespace engine

--- a/modules/SofaGeneralEngine/PairBoxRoi.h
+++ b/modules/SofaGeneralEngine/PairBoxRoi.h
@@ -73,7 +73,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     void draw(const core::visual::VisualParams*) override;
 

--- a/modules/SofaGeneralEngine/PairBoxRoi.inl
+++ b/modules/SofaGeneralEngine/PairBoxRoi.inl
@@ -135,11 +135,9 @@ bool PairBoxROI<DataTypes>::isPointInBox(const PointID& pid, const Vec6& b)
 }
 
 template <class DataTypes>
-void PairBoxROI<DataTypes>::update()
+void PairBoxROI<DataTypes>::doUpdate()
 {
    const VecCoord* x0 = &f_X0.getValue();
-
-   cleanDirty();
 
    Vec6& maxvb = *(inclusiveBox.beginEdit());
    Vec6& minvb = *(includedBox.beginEdit());

--- a/modules/SofaGeneralEngine/PlaneROI.h
+++ b/modules/SofaGeneralEngine/PlaneROI.h
@@ -77,7 +77,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/modules/SofaGeneralEngine/PlaneROI.inl
+++ b/modules/SofaGeneralEngine/PlaneROI.inl
@@ -285,7 +285,7 @@ bool PlaneROI<DataTypes>::isTetrahedronInPlane(const Tetra& t)
 
 
 template <class DataTypes>
-void PlaneROI<DataTypes>::update()
+void PlaneROI<DataTypes>::doUpdate()
 {
     const helper::vector<Vec10>& vp=planes.getValue();
     if (vp.empty())
@@ -296,10 +296,7 @@ void PlaneROI<DataTypes>::update()
     helper::ReadAccessor< Data<helper::vector<Triangle> > > triangles = f_triangles;
     helper::ReadAccessor< Data<helper::vector<Tetra> > > tetrahedra = f_tetrahedra;
 
-
     const VecCoord* x0 = &f_X0.getValue();
-
-    cleanDirty();
 
     // Write accessor for topological element indices in SPHERE
     SetIndex& indices = *(f_indices.beginWriteOnly());

--- a/modules/SofaGeneralEngine/PointsFromIndices.h
+++ b/modules/SofaGeneralEngine/PointsFromIndices.h
@@ -64,7 +64,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     /// Pre-construction check method called by ObjectFactory.
     /// Check that DataTypes matches the MechanicalState.

--- a/modules/SofaGeneralEngine/PointsFromIndices.inl
+++ b/modules/SofaGeneralEngine/PointsFromIndices.inl
@@ -86,12 +86,10 @@ bool PointsFromIndices<DataTypes>::contains(VecCoord& v, Coord c)
 }
 
 template <class DataTypes>
-void PointsFromIndices<DataTypes>::update()
+void PointsFromIndices<DataTypes>::doUpdate()
 {
     const SetIndex& indices = f_indices.getValue();
     const VecCoord& x = f_X.getValue();
-
-    cleanDirty();
 
     VecCoord& indices_position = *(f_indices_position.beginWriteOnly());
 

--- a/modules/SofaGeneralEngine/ProximityROI.h
+++ b/modules/SofaGeneralEngine/ProximityROI.h
@@ -71,7 +71,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/modules/SofaGeneralEngine/ProximityROI.inl
+++ b/modules/SofaGeneralEngine/ProximityROI.inl
@@ -132,7 +132,7 @@ public:
 };
 
 template <class DataTypes>
-void ProximityROI<DataTypes>::update()
+void ProximityROI<DataTypes>::doUpdate()
 {
     const helper::vector<Vec3>& cen = (centers.getValue());
     const helper::vector<Real>& rad = (radii.getValue());
@@ -169,11 +169,7 @@ void ProximityROI<DataTypes>::update()
         serr << "There parameter 'Radius' has more elements than parameters 'center'." << sendl;
     }
 
-
     const VecCoord* x0 = &f_X0.getValue();
-
-    cleanDirty();
-
 
     // Write accessor for topological element indices
     SetIndex& indices = *(f_indices.beginWriteOnly());

--- a/modules/SofaGeneralEngine/QuatToRigidEngine.h
+++ b/modules/SofaGeneralEngine/QuatToRigidEngine.h
@@ -58,7 +58,7 @@ protected:
     QuatToRigidEngine();
     virtual ~QuatToRigidEngine();
 public:
-    void update() override;
+    void doUpdate() override;
     void init() override;
     void reinit() override;
 

--- a/modules/SofaGeneralEngine/QuatToRigidEngine.inl
+++ b/modules/SofaGeneralEngine/QuatToRigidEngine.inl
@@ -72,14 +72,11 @@ void QuatToRigidEngine<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void QuatToRigidEngine<DataTypes>::update()
+void QuatToRigidEngine<DataTypes>::doUpdate()
 {
-
     const helper::vector<Vec3>& positions = f_positions.getValue();
     const helper::vector<Quat>& orientations = f_orientations.getValue();
     const helper::vector<Vec3>& colinearPositions = f_colinearPositions.getValue();
-
-    cleanDirty();
 
     helper::vector<RigidVec3>& rigids = *(f_rigids.beginWriteOnly());
 

--- a/modules/SofaGeneralEngine/ROIValueMapper.h
+++ b/modules/SofaGeneralEngine/ROIValueMapper.h
@@ -114,7 +114,7 @@ protected:
 
     virtual ~ROIValueMapper() {}
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
         size_t nb = nbROIs.getValue();
         f_indices.resize(nb);
@@ -142,8 +142,6 @@ protected:
                 outputValues[ind] = value;
             }
         }
-
-        cleanDirty();
     }
 
 };

--- a/modules/SofaGeneralEngine/RandomPointDistributionInSurface.h
+++ b/modules/SofaGeneralEngine/RandomPointDistributionInSurface.h
@@ -68,7 +68,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/modules/SofaGeneralEngine/RandomPointDistributionInSurface.inl
+++ b/modules/SofaGeneralEngine/RandomPointDistributionInSurface.inl
@@ -203,7 +203,7 @@ bool RandomPointDistributionInSurface<DataTypes>::testDistance(Coord p)
 }
 
 template <class DataTypes>
-void RandomPointDistributionInSurface<DataTypes>::update()
+void RandomPointDistributionInSurface<DataTypes>::doUpdate()
 {
     const VecCoord& vertices = f_vertices.getValue();
     const helper::vector<sofa::core::topology::BaseMeshTopology::Triangle>& triangles = f_triangles.getValue();
@@ -213,8 +213,6 @@ void RandomPointDistributionInSurface<DataTypes>::update()
         serr << "Error in input data (number of vertices of triangles is less than 1)." << sendl;
         return;
     }
-
-    cleanDirty();
 
     VecCoord* inPoints = f_inPoints.beginWriteOnly();
     inPoints->clear();

--- a/modules/SofaGeneralEngine/RigidToQuatEngine.h
+++ b/modules/SofaGeneralEngine/RigidToQuatEngine.h
@@ -58,7 +58,7 @@ protected:
     RigidToQuatEngine();
     virtual ~RigidToQuatEngine();
 public:
-    void update() override;
+    void doUpdate() override;
     void init() override;
     void reinit() override;
 

--- a/modules/SofaGeneralEngine/RigidToQuatEngine.inl
+++ b/modules/SofaGeneralEngine/RigidToQuatEngine.inl
@@ -69,11 +69,9 @@ void RigidToQuatEngine<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void RigidToQuatEngine<DataTypes>::update()
+void RigidToQuatEngine<DataTypes>::doUpdate()
 {
     helper::ReadAccessor< Data< helper::vector<RigidVec3> > > rigids = f_rigids;
-
-    cleanDirty();
 
     helper::WriteOnlyAccessor< Data< helper::vector<Vec3> > > positions = f_positions;
     helper::WriteOnlyAccessor< Data< helper::vector<Quat> > > orientations = f_orientations;

--- a/modules/SofaGeneralEngine/SelectConnectedLabelsROI.h
+++ b/modules/SofaGeneralEngine/SelectConnectedLabelsROI.h
@@ -111,11 +111,8 @@ public:
 protected:
 
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
-        updateAllInputsIfDirty();
-        cleanDirty();
-
         helper::WriteOnlyAccessor< Data< helper::vector<Index> > > indices = d_indices;
         indices.clear();
 

--- a/modules/SofaGeneralEngine/SelectLabelROI.h
+++ b/modules/SofaGeneralEngine/SelectLabelROI.h
@@ -88,7 +88,7 @@ protected:
 
     virtual ~SelectLabelROI() {}
 
-    virtual void update() override
+    virtual void doUpdate() override
     {
         helper::ReadAccessor< Data< helper::vector<T>  > > selectLabels = d_selectLabels;
         // convert to set for efficient look-up
@@ -108,8 +108,6 @@ protected:
                     break;
                 }
         }
-
-        cleanDirty();
     }
 
 };

--- a/modules/SofaGeneralEngine/ShapeMatching.cpp
+++ b/modules/SofaGeneralEngine/ShapeMatching.cpp
@@ -65,7 +65,7 @@ template class SOFA_GENERAL_ENGINE_API ShapeMatching<Rigid3fTypes>;
 
 #ifndef SOFA_FLOAT
 template <>
-void ShapeMatching<Rigid3dTypes>::update()
+void ShapeMatching<Rigid3dTypes>::doUpdate()
 {
     // TO DO: shape matching for rigids as in [Muller11]
 }
@@ -74,7 +74,7 @@ void ShapeMatching<Rigid3dTypes>::update()
 
 #ifndef SOFA_DOUBLE
 template <>
-void ShapeMatching<Rigid3fTypes>::update()
+void ShapeMatching<Rigid3fTypes>::doUpdate()
 {
     // TO DO: shape matching for rigids as in [Muller11]
 }

--- a/modules/SofaGeneralEngine/ShapeMatching.h
+++ b/modules/SofaGeneralEngine/ShapeMatching.h
@@ -75,7 +75,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/modules/SofaGeneralEngine/ShapeMatching.inl
+++ b/modules/SofaGeneralEngine/ShapeMatching.inl
@@ -110,10 +110,8 @@ void ShapeMatching<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void ShapeMatching<DataTypes>::update()
+void ShapeMatching<DataTypes>::doUpdate()
 {
-    bool clusterdirty = this->cluster.isDirty();
-
     const VecCoord& restPositions = mstate->read(core::ConstVecCoordId::restPosition())->getValue();
     helper::ReadAccessor< Data< VecCoord > > fixedPositions0 = this->fixedPosition0;
     helper::ReadAccessor< Data< VecCoord > > fixedPositions = this->fixedPosition;
@@ -133,7 +131,7 @@ void ShapeMatching<DataTypes>::update()
     if(!nbc || !nbp  || !currentPositions.size()) return;
 
     //if mechanical state or cluster have changed, we must compute again xcm0
-    if(oldRestPositionSize != nbp+nbf || oldfixedweight != this->fixedweight.getValue() || clusterdirty)
+    if(oldRestPositionSize != nbp+nbf || oldfixedweight != this->fixedweight.getValue() || m_dataTracker.isDirty(this->cluster))
     {
         dmsg_info() <<"shape matching: update Xcm0" ;
 
@@ -211,18 +209,16 @@ void ShapeMatching<DataTypes>::update()
                 targetPos[i] /= (Real)nbClust[i];
             else targetPos[i]=currentPositions[i];
     }
-
-    cleanDirty();
 }
 
 // Specialization for rigids
 #ifndef SOFA_FLOAT
 template <>
-void ShapeMatching<sofa::defaulttype::Rigid3dTypes >::update();
+void ShapeMatching<sofa::defaulttype::Rigid3dTypes >::doUpdate();
 #endif
 #ifndef SOFA_DOUBLE
 template <>
-void ShapeMatching<sofa::defaulttype::Rigid3fTypes >::update();
+void ShapeMatching<sofa::defaulttype::Rigid3fTypes >::doUpdate();
 #endif
 
 

--- a/modules/SofaGeneralEngine/SmoothMeshEngine.h
+++ b/modules/SofaGeneralEngine/SmoothMeshEngine.h
@@ -60,7 +60,7 @@ protected:
 public:
     void init() override;
     void reinit() override;
-    void update() override;
+    void doUpdate() override;
 	void computeBBox(const core::ExecParams* params, bool onlyVisible) override;
     virtual void draw(const core::visual::VisualParams* vparams) override;
 

--- a/modules/SofaGeneralEngine/SmoothMeshEngine.inl
+++ b/modules/SofaGeneralEngine/SmoothMeshEngine.inl
@@ -72,11 +72,9 @@ void SmoothMeshEngine<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void SmoothMeshEngine<DataTypes>::update()
+void SmoothMeshEngine<DataTypes>::doUpdate()
 {
     using sofa::core::topology::BaseMeshTopology;
-
-    cleanDirty();
 
     if (!m_topo) return;
 

--- a/modules/SofaGeneralEngine/SphereROI.h
+++ b/modules/SofaGeneralEngine/SphereROI.h
@@ -80,7 +80,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 
@@ -179,7 +179,7 @@ template<> bool SphereROI<defaulttype::Rigid3dTypes>::isEdgeInSphere(const Vec3&
 template<> bool SphereROI<defaulttype::Rigid3dTypes>::isTriangleInSphere(const Vec3& c, const Real& r, const sofa::core::topology::BaseMeshTopology::Triangle& triangle);
 template<> bool SphereROI<defaulttype::Rigid3dTypes>::isQuadInSphere(const Vec3& c, const Real& r, const sofa::core::topology::BaseMeshTopology::Quad& quad);
 template<> bool SphereROI<defaulttype::Rigid3dTypes>::isTetrahedronInSphere(const Vec3& c, const Real& r, const sofa::core::topology::BaseMeshTopology::Tetra& tetrahedron);
-template<> void SphereROI<defaulttype::Rigid3dTypes>::update();
+template<> void SphereROI<defaulttype::Rigid3dTypes>::doUpdate();
 #endif
 
 #ifndef SOFA_DOUBLE
@@ -189,7 +189,7 @@ template<> bool SphereROI<defaulttype::Rigid3fTypes>::isEdgeInSphere(const Vec3&
 template<> bool SphereROI<defaulttype::Rigid3fTypes>::isTriangleInSphere(const Vec3& c, const Real& r, const sofa::core::topology::BaseMeshTopology::Triangle& triangle);
 template<> bool SphereROI<defaulttype::Rigid3fTypes>::isQuadInSphere(const Vec3& c, const Real& r, const sofa::core::topology::BaseMeshTopology::Quad& quad);
 template<> bool SphereROI<defaulttype::Rigid3fTypes>::isTetrahedronInSphere(const Vec3& c, const Real& r, const sofa::core::topology::BaseMeshTopology::Tetra& tetrahedron);
-template<> void SphereROI<defaulttype::Rigid3fTypes>::update();
+template<> void SphereROI<defaulttype::Rigid3fTypes>::doUpdate();
 #endif
 
 #if defined(SOFA_EXTERN_TEMPLATE) && !defined(SOFA_COMPONENT_ENGINE_SPHEREROI_CPP)

--- a/modules/SofaGeneralEngine/SphereROI.inl
+++ b/modules/SofaGeneralEngine/SphereROI.inl
@@ -275,7 +275,7 @@ bool SphereROI<DataTypes>::isTetrahedronInSphere(const Vec3& c, const Real& r, c
 
 
 template <class DataTypes>
-void SphereROI<DataTypes>::update()
+void SphereROI<DataTypes>::doUpdate()
 {
     const helper::vector<Vec3>& cen = (centers.getValue());
     const helper::vector<Real>& rad = (radii.getValue());
@@ -316,11 +316,6 @@ void SphereROI<DataTypes>::update()
     helper::ReadAccessor< Data<helper::vector<Tetra> > > tetrahedra = f_tetrahedra;
 
     const VecCoord* x0 = &f_X0.getValue();
-
-
-    cleanDirty();
-
-
 
 
     // Write accessor for topological element indices in SPHERE
@@ -677,10 +672,8 @@ bool SphereROI<defaulttype::Rigid3dTypes>::isTetrahedronInSphere(const Vec3& c, 
 
 
 template <>
-void SphereROI<defaulttype::Rigid3dTypes>::update()
+void SphereROI<defaulttype::Rigid3dTypes>::doUpdate()
 {
-	cleanDirty();
-
 	const helper::vector<Vec3>& cen = (centers.getValue());
 	const helper::vector<Real>& rad = (radii.getValue());
 
@@ -937,10 +930,8 @@ bool SphereROI<defaulttype::Rigid3fTypes>::isTetrahedronInSphere(const Vec3& c, 
 
 
 template <>
-void SphereROI<defaulttype::Rigid3fTypes>::update()
+void SphereROI<defaulttype::Rigid3fTypes>::doUpdate()
 {
-	cleanDirty();
-
 	const helper::vector<Vec3>& cen = (centers.getValue());
 	const helper::vector<Real>& rad = (radii.getValue());
 

--- a/modules/SofaGeneralEngine/Spiral.h
+++ b/modules/SofaGeneralEngine/Spiral.h
@@ -65,7 +65,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/modules/SofaGeneralEngine/Spiral.inl
+++ b/modules/SofaGeneralEngine/Spiral.inl
@@ -66,11 +66,9 @@ void Spiral<DataTypes>::reinit()
 
 
 template <class DataTypes>
-void Spiral<DataTypes>::update()
+void Spiral<DataTypes>::doUpdate()
 {
     const VecCoord x0 = f_X0.getValue();
-
-    cleanDirty();
 
     VecCoord* x = f_X.beginWriteOnly();
     x->clear();

--- a/modules/SofaGeneralEngine/SubsetTopology.h
+++ b/modules/SofaGeneralEngine/SubsetTopology.h
@@ -76,7 +76,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/modules/SofaGeneralEngine/SubsetTopology.inl
+++ b/modules/SofaGeneralEngine/SubsetTopology.inl
@@ -385,9 +385,8 @@ void SubsetTopology<DataTypes>::findVertexOnBorder(const Tetra &t, unsigned int 
 
 
 template <class DataTypes>
-void SubsetTopology<DataTypes>::update()
+void SubsetTopology<DataTypes>::doUpdate()
 {
-
     unsigned int ROInum = 0;
     const helper::vector<Vec3>& cen = (centers.getValue());
     const helper::vector<Real>& rad = (radii.getValue());
@@ -425,18 +424,6 @@ void SubsetTopology<DataTypes>::update()
     helper::ReadAccessor< Data<helper::vector<Hexa> > > hexahedra = f_hexahedra;
 
     const VecCoord* x0 = &f_X0.getValue();
-
-    d_tetrahedraInput.updateIfDirty();
-
-    // Why are they inputs? Are they used somewhere?
-    direction.updateIfDirty();
-    normal.updateIfDirty();
-    edgeAngle.updateIfDirty();
-    triAngle.updateIfDirty();
-
-
-    cleanDirty();
-
 
     // Write accessor for topological element indices in ROI
     SetIndex& indices = *(f_indices.beginWriteOnly());

--- a/modules/SofaGeneralEngine/SumEngine.h
+++ b/modules/SofaGeneralEngine/SumEngine.h
@@ -56,7 +56,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     virtual std::string getTemplateName() const override
     {

--- a/modules/SofaGeneralEngine/SumEngine.inl
+++ b/modules/SofaGeneralEngine/SumEngine.inl
@@ -60,12 +60,9 @@ void SumEngine<DataType>::reinit()
 }
 
 template <class DataType>
-void SumEngine<DataType>::update()
+void SumEngine<DataType>::doUpdate()
 {
-
     helper::ReadAccessor<Data<VecData> > in = d_input;
-
-    cleanDirty();
 
     helper::WriteOnlyAccessor<Data<DataType> > out = d_output;
     out.wref() = std::accumulate(in.begin(), in.end(), DataType() );

--- a/modules/SofaGeneralEngine/TextureInterpolation.h
+++ b/modules/SofaGeneralEngine/TextureInterpolation.h
@@ -70,7 +70,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/modules/SofaGeneralEngine/TextureInterpolation.inl
+++ b/modules/SofaGeneralEngine/TextureInterpolation.inl
@@ -86,14 +86,12 @@ void TextureInterpolation<DataTypes>::reinit()
 
 
 template <class DataTypes>
-void TextureInterpolation<DataTypes>::update()
+void TextureInterpolation<DataTypes>::doUpdate()
 {
     if (!_inputField.isSet())
         return;
 
     const sofa::helper::vector <Coord>& realInputs = _inputField.getValue();
-
-    cleanDirty();
 
     ResizableExtVector2D& outputs = *(_outputCoord.beginWriteOnly());
     outputs.resize (realInputs.size());

--- a/modules/SofaGeneralEngine/TransformEngine.h
+++ b/modules/SofaGeneralEngine/TransformEngine.h
@@ -48,10 +48,10 @@ namespace engine
 This transformation can be either translation, rotation, scale
  */
 template <class DataTypes>
-class TransformEngine : public core::SimpleDataEngine
+class TransformEngine : public core::DataEngine
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE(TransformEngine,DataTypes),core::SimpleDataEngine);
+    SOFA_CLASS(SOFA_TEMPLATE(TransformEngine,DataTypes),core::DataEngine);
     typedef typename DataTypes::VecCoord VecCoord;
     typedef typename DataTypes::Coord Coord;
     typedef typename DataTypes::Real Real;

--- a/modules/SofaGeneralEngine/TransformMatrixEngine.cpp
+++ b/modules/SofaGeneralEngine/TransformMatrixEngine.cpp
@@ -79,12 +79,10 @@ void AbstractTransformMatrixEngine::reinit()
  * InvertTransformMatrixEngine
  */
 
-void InvertTransformMatrixEngine::update()
+void InvertTransformMatrixEngine::doUpdate()
 {
     helper::ReadAccessor< Data<Matrix4> > inT = d_inT;
     helper::WriteAccessor< Data<Matrix4> > outT = d_outT;
-
-    cleanDirty();
 
     /*bool ok = */transformInvertMatrix((*outT), (*inT));
     // TODO print warning if not ok
@@ -106,13 +104,11 @@ void TranslateTransformMatrixEngine::init()
     setDirtyValue();
 }
 
-void TranslateTransformMatrixEngine::update()
+void TranslateTransformMatrixEngine::doUpdate()
 {
     helper::ReadAccessor< Data<Matrix4> > inT = d_inT;
     helper::ReadAccessor< Data<Vector3> > translation = d_translation;
     helper::WriteAccessor< Data<Matrix4> > outT = d_outT;
-
-    cleanDirty();
 
     Matrix4 myT;
     myT.identity();
@@ -137,13 +133,11 @@ void RotateTransformMatrixEngine::init()
     setDirtyValue();
 }
 
-void RotateTransformMatrixEngine::update()
+void RotateTransformMatrixEngine::doUpdate()
 {
     helper::ReadAccessor< Data<Matrix4> > inT = d_inT;
     helper::ReadAccessor< Data<Vector3> > rotation = d_rotation;
     helper::WriteAccessor< Data<Matrix4> > outT = d_outT;
-
-    cleanDirty();
 
     Matrix4 myT;
     myT.identity();
@@ -171,13 +165,11 @@ void ScaleTransformMatrixEngine::init()
     setDirtyValue();
 }
 
-void ScaleTransformMatrixEngine::update()
+void ScaleTransformMatrixEngine::doUpdate()
 {
     helper::ReadAccessor< Data<Matrix4> > inT = d_inT;
     helper::ReadAccessor< Data<Vector3> > scale = d_scale;
     helper::WriteAccessor< Data<Matrix4> > outT = d_outT;
-
-    cleanDirty();
 
     Matrix4 myT;
     myT.identity();

--- a/modules/SofaGeneralEngine/TransformMatrixEngine.h
+++ b/modules/SofaGeneralEngine/TransformMatrixEngine.h
@@ -52,7 +52,7 @@ protected:
     /**
      * Update the transformation, to be implemented in herited classes
      */
-    virtual void update() override = 0;
+    virtual void doUpdate() override = 0;
 
 public:
     virtual void init() override;
@@ -75,7 +75,7 @@ public:
 protected:
     InvertTransformMatrixEngine() {}
     ~InvertTransformMatrixEngine() {}
-    virtual void update() override;
+    virtual void doUpdate() override;
 };
 
 /**
@@ -90,7 +90,7 @@ public:
 protected:
     TranslateTransformMatrixEngine();
     ~TranslateTransformMatrixEngine() {}
-    virtual void update() override;
+    virtual void doUpdate() override;
 
 public:
     virtual void init() override;
@@ -113,7 +113,7 @@ public:
 protected:
     RotateTransformMatrixEngine();
     ~RotateTransformMatrixEngine() {}
-    virtual void update() override;
+    virtual void doUpdate() override;
 
 public:
     virtual void init() override;
@@ -136,7 +136,7 @@ public:
 protected:
     ScaleTransformMatrixEngine();
     ~ScaleTransformMatrixEngine() {}
-    virtual void update() override;
+    virtual void doUpdate() override;
 
 public:
     virtual void init() override;

--- a/modules/SofaGeneralEngine/TransformPosition.h
+++ b/modules/SofaGeneralEngine/TransformPosition.h
@@ -94,7 +94,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/modules/SofaGeneralEngine/TransformPosition.inl
+++ b/modules/SofaGeneralEngine/TransformPosition.inl
@@ -384,7 +384,7 @@ void TransformPosition<DataTypes>::getTransfoFromTxt()
 
 
 template <class DataTypes>
-void TransformPosition<DataTypes>::update()
+void TransformPosition<DataTypes>::doUpdate()
 {
     selectTransformationMethod();
 
@@ -399,8 +399,6 @@ void TransformPosition<DataTypes>::update()
     helper::ReadAccessor< Data<Real> > maxDisplacement = f_maxRandomDisplacement;
     helper::ReadAccessor< Data<long> > seed = f_seed;
     helper::ReadAccessor< Data<SetIndex> > fixedIndices = f_fixedIndices;
-
-    cleanDirty();
 
     helper::WriteOnlyAccessor< Data<VecCoord> > out = f_outputX;
 

--- a/modules/SofaGeneralEngine/ValuesFromIndices.h
+++ b/modules/SofaGeneralEngine/ValuesFromIndices.h
@@ -64,7 +64,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     Data<VecValue> f_in; ///< input values
     Data<VecIndex> f_indices; ///< Indices of the values

--- a/modules/SofaGeneralEngine/ValuesFromIndices.inl
+++ b/modules/SofaGeneralEngine/ValuesFromIndices.inl
@@ -67,12 +67,10 @@ void ValuesFromIndices<T>::reinit()
 }
 
 template <class T>
-void ValuesFromIndices<T>::update()
+void ValuesFromIndices<T>::doUpdate()
 {
     helper::ReadAccessor<Data<VecValue> > in = f_in;
     helper::ReadAccessor<Data<VecIndex> > indices = f_indices;
-
-    cleanDirty();
 
     helper::WriteOnlyAccessor<Data<VecValue> > out = f_out;
 

--- a/modules/SofaGeneralEngine/ValuesFromPositions.h
+++ b/modules/SofaGeneralEngine/ValuesFromPositions.h
@@ -75,7 +75,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/modules/SofaGeneralEngine/ValuesFromPositions.inl
+++ b/modules/SofaGeneralEngine/ValuesFromPositions.inl
@@ -280,12 +280,8 @@ typename ValuesFromPositions<DataTypes>::Vec3 ValuesFromPositions<DataTypes>::ve
 
 
 template <class DataTypes>
-void ValuesFromPositions<DataTypes>::update()
+void ValuesFromPositions<DataTypes>::doUpdate()
 {
-    updateAllInputsIfDirty(); // the easy way to make sure every inputs are up-to-date
-
-    cleanDirty();
-
     TempData data;
     data.dir = f_direction.getValue();
     data.inputValues = f_inputValues.getValue();

--- a/modules/SofaGeneralEngine/Vertex2Frame.h
+++ b/modules/SofaGeneralEngine/Vertex2Frame.h
@@ -64,7 +64,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     virtual std::string getTemplateName() const override
     {

--- a/modules/SofaGeneralEngine/Vertex2Frame.inl
+++ b/modules/SofaGeneralEngine/Vertex2Frame.inl
@@ -76,7 +76,7 @@ void Vertex2Frame<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void Vertex2Frame<DataTypes>::update()
+void Vertex2Frame<DataTypes>::doUpdate()
 {
     const helper::vector<CPos>& fVertices = d_vertices.getValue();
     const helper::vector<CPos>& fNormals = d_normals.getValue();
@@ -91,12 +91,6 @@ void Vertex2Frame<DataTypes>::update()
         msg_info(this) << "Vertex2Frame : no vertices found. Component will not compute anything";
         return ;
     }
-
-    d_texCoords.updateIfDirty();
-    d_rotation.updateIfDirty();
-    d_rotationAngle.updateIfDirty();
-
-    cleanDirty();
 
     VecCoord& fFrames = *(d_frames.beginEdit());
     fFrames.resize(nbVertices);

--- a/modules/SofaMiscEngine/DisplacementMatrixEngine.h
+++ b/modules/SofaMiscEngine/DisplacementMatrixEngine.h
@@ -73,7 +73,7 @@ public:
     // methods
     DisplacementTransformEngine();
     virtual void init() override;   // compute the inverse matrices
-    virtual void update() override; // compute the displacements wrt original positions
+    virtual void doUpdate() override; // compute the displacements wrt original positions
 
     // To simplify the template name in the xml file
     virtual std::string getTemplateName() const override { return templateName(this); }
@@ -123,7 +123,7 @@ public:
 
     virtual void init() override;   // compute the inverse matrices
     virtual void reinit() override; // compute S*inverse and store it once and for all.
-    virtual void update() override; // compute the displacements wrt original positions
+    virtual void doUpdate() override; // compute the displacements wrt original positions
 
     // To simplify the template name in the xml file
     virtual std::string getTemplateName() const override { return templateName(this); }

--- a/modules/SofaMiscEngine/DisplacementMatrixEngine.inl
+++ b/modules/SofaMiscEngine/DisplacementMatrixEngine.inl
@@ -67,7 +67,7 @@ void DisplacementTransformEngine< DataTypes, OutputType >::init()
 }
 
 template < class DataTypes, class OutputType >
-void DisplacementTransformEngine< DataTypes, OutputType >::update()
+void DisplacementTransformEngine< DataTypes, OutputType >::doUpdate()
 {
     // parent method
     Inherit::init();
@@ -83,8 +83,6 @@ void DisplacementTransformEngine< DataTypes, OutputType >::update()
         serr << "x and x0 have not the same size: respectively " << size << " and " << size0 << sendl;
         return;
     }
-
-    cleanDirty();
 
     // Clean the output
     helper::vector< OutputType >& displacements = *d_displacements.beginWriteOnly();
@@ -164,7 +162,7 @@ void DisplacementMatrixEngine< DataTypes >::reinit()
 }
 
 template < class DataTypes >
-void DisplacementMatrixEngine< DataTypes >::update()
+void DisplacementMatrixEngine< DataTypes >::doUpdate()
 {
     const VecCoord& x = this->d_x.getValue();
     const VecCoord& x0 = this->d_x0.getValue();
@@ -179,8 +177,6 @@ void DisplacementMatrixEngine< DataTypes >::update()
         serr << "x, x0 and S have not the same size: respectively " << size << ", " << size0 << " and " << sizeS << sendl;
         return;
     }
-
-    this->cleanDirty();
 
     helper::vector< Matrix4x4 >& displacements = *this->d_displacements.beginWriteOnly();
     displacements.resize(size);

--- a/modules/SofaMiscEngine/Distances.h
+++ b/modules/SofaMiscEngine/Distances.h
@@ -112,7 +112,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     /** \brief Compute the distance map depending ion the distance type.
     *

--- a/modules/SofaMiscEngine/Distances.inl
+++ b/modules/SofaMiscEngine/Distances.inl
@@ -139,11 +139,9 @@ void Distances< DataTypes >::reinit()
 }
 
 template<class DataTypes>
-void Distances< DataTypes >::update()
+void Distances< DataTypes >::doUpdate()
 {
 
-    // tester les data dirty
-    cleanDirty();
 
     /*
     if( true)

--- a/modules/SofaMiscEngine/ProjectiveTransformEngine.h
+++ b/modules/SofaMiscEngine/ProjectiveTransformEngine.h
@@ -68,7 +68,7 @@ public:
 
     void reinit() override;
 
-    void update() override;
+    void doUpdate() override;
 
     virtual std::string getTemplateName() const override
     {

--- a/modules/SofaMiscEngine/ProjectiveTransformEngine.inl
+++ b/modules/SofaMiscEngine/ProjectiveTransformEngine.inl
@@ -61,10 +61,8 @@ void ProjectiveTransformEngine<DataTypes>::reinit()
 }
 
 template <class DataTypes>
-void ProjectiveTransformEngine<DataTypes>::update()
+void ProjectiveTransformEngine<DataTypes>::doUpdate()
 {
-    cleanDirty();
-
     helper::ReadAccessor< Data<VecCoord> > in = f_inputX;
     helper::WriteAccessor< Data<VecCoord> > out = f_outputX;
     helper::ReadAccessor< Data<Real> > fdist = focal_distance;


### PR DESCRIPTION
Fix #809
Following the STC decision to replace the DataEngine with the SimpleDataEngine, here's the PR that does just that.

This replacement involves taking every engine in Sofa and:
- replacing its **update()** method with the new delegate **doUpdate()**.
- Remove the calls to **data.isDirty()** and (smartly) replacing them with **m_dataTracker.isDirty(data)**
- Remove the **cleanDirty()** calls while making sure we don't break the engine's behavior

Most engines present in SOFA are either in SofaGeneralEngine or SofaMiscEngine.


______________________________________________________ 
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
