### PR TITLE
[SofaBaseMechanics] FIX DiagonalMass_test

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.inl
@@ -662,8 +662,10 @@ void DiagonalMass<DataTypes, MassType>::init()
 {
     if (!d_fileMass.getValue().empty())
     {
-        load(d_fileMass.getFullPath().c_str());
-
+        if(!load(d_fileMass.getFullPath().c_str())){
+            m_componentstate = ComponentState::Invalid;
+            return;
+        }
         msg_warning() << "File given as input for DiagonalMass, in this a case:" << msgendl
                       << "the topology won't be used to compute the mass" << msgendl
                       << "the update, the coherency and the tracking of mass information data are disable (listening = false)";
@@ -1376,7 +1378,7 @@ bool DiagonalMass<DataTypes, MassType>::load(const char *filename)
         Loader loader(this);
         return loader.load(filename);
     }
-    else return false;
+    return false;
 }
 
 

--- a/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.inl
@@ -45,6 +45,9 @@ namespace component
 namespace mass
 {
 
+using sofa::core::objectmodel::ComponentState;
+
+
 template <class DataTypes, class MassType>
 DiagonalMass<DataTypes, MassType>::DiagonalMass()
     : d_vertexMass( initData(&d_vertexMass, "vertexMass", "Specify a vector giving the mass of each vertex. \n"
@@ -580,7 +583,7 @@ bool DiagonalMass<DataTypes, MassType>::checkTopology()
         {
             if(!hexaGeo)
             {
-                msg_error() << "Hexahedron topology but no geometry algorithms found. Add the component HexahedronSetGeometryAlgorithms.";
+                msg_error() << "Hexahedron topology found but geometry algorithms are missing. Add the component HexahedronSetGeometryAlgorithms.";
                 return false;
             }
             else
@@ -593,7 +596,7 @@ bool DiagonalMass<DataTypes, MassType>::checkTopology()
         {
             if(!tetraGeo)
             {
-                msg_error() << "Tetrahedron topology but no geometry algorithms found. Add the component TetrahedronSetGeometryAlgorithms.";
+                msg_error() << "Tetrahedron topology found but geometry algorithms are missing. Add the component TetrahedronSetGeometryAlgorithms.";
                 return false;
             }
             else
@@ -606,7 +609,7 @@ bool DiagonalMass<DataTypes, MassType>::checkTopology()
         {
             if(!quadGeo)
             {
-                msg_error() << "Quad topology but no geometry algorithms found. Add the component QuadSetGeometryAlgorithms.";
+                msg_error() << "Quad topology found but geometry algorithms are missing. Add the component QuadSetGeometryAlgorithms.";
                 return false;
             }
             else
@@ -619,7 +622,7 @@ bool DiagonalMass<DataTypes, MassType>::checkTopology()
         {
             if(!triangleGeo)
             {
-                msg_error() << "Triangle topology but no geometry algorithms found. Add the component TriangleSetGeometryAlgorithms.";
+                msg_error() << "Triangle topology found but geometry algorithms are missing. Add the component TriangleSetGeometryAlgorithms.";
                 return false;
             }
             else
@@ -632,7 +635,7 @@ bool DiagonalMass<DataTypes, MassType>::checkTopology()
         {
             if(!edgeGeo)
             {
-                msg_error() << "Edge topology but no geometry algorithms found. Add the component EdgeSetGeometryAlgorithms.";
+                msg_error() << "Edge topology found but geometry algorithms are missing. Add the component EdgeSetGeometryAlgorithms.";
                 return false;
             }
             else
@@ -675,12 +678,13 @@ void DiagonalMass<DataTypes, MassType>::init()
 
         if(!checkTopology())
         {
+            m_componentstate = ComponentState::Invalid;
             return;
         }
         Inherited::init();
         initTopologyHandlers();
 
-        // TODO(dmarchal 2017-05-16): this code is duplicated with the one in RigidImpl we should factor it (remove in 1 year if not done or update the dates)
+        // TODO(dmarchal 2018-11-10): this code is duplicated with the one in RigidImpl we should factor it (remove in 1 year if not done or update the dates)
         if (this->mstate && d_vertexMass.getValue().size() > 0 && d_vertexMass.getValue().size() < (unsigned)this->mstate->getSize())
         {
             MassVector &masses= *d_vertexMass.beginEdit();
@@ -694,6 +698,7 @@ void DiagonalMass<DataTypes, MassType>::init()
 
         massInitialization();
     }
+     m_componentstate = ComponentState::Valid;
 }
 
 
@@ -708,8 +713,8 @@ void DiagonalMass<DataTypes, MassType>::massInitialization()
         {
             if(d_vertexMass.isSet() || d_massDensity.isSet())
             {
-                msg_warning(this) << "totalMass value overriding other mass information (vertexMass or massDensity).\n"
-                                  << "To remove this warning you need to define only one single mass information data field.";
+                msg_warning() << "totalMass value overriding other mass information (vertexMass or massDensity).\n"
+                              << "To remove this warning you need to define only one single mass information data field.";
             }
             checkTotalMassInit();
             initFromTotalMass();
@@ -719,8 +724,8 @@ void DiagonalMass<DataTypes, MassType>::massInitialization()
         {
             if(d_vertexMass.isSet())
             {
-                msg_warning(this) << "massDensity value overriding the value of the attribute vertexMass.\n"
-                                  << "To remove this warning you need to set either vertexMass or massDensity data field, but not both.";
+                msg_warning() << "massDensity value overriding the value of the attribute vertexMass.\n"
+                              << "To remove this warning you need to set either vertexMass or massDensity data field, but not both.";
             }
             if(!checkMassDensity())
             {
@@ -984,8 +989,8 @@ bool DiagonalMass<DataTypes, MassType>::checkTotalMass()
     //Check for negative or null value, if wrongly set use the default value totalMass = 1.0
     if(d_totalMass.getValue() <= 0.0)
     {
-        msg_warning(this) << "totalMass data can not have a negative value.\n"
-                          << "To remove this warning, you need to set a strictly positive value to the totalMass data";
+        msg_warning() << "totalMass data can not have a negative value.\n"
+                      << "To remove this warning, you need to set a strictly positive value to the totalMass data";
         return false;
     }
     else
@@ -1001,7 +1006,7 @@ void DiagonalMass<DataTypes, MassType>::checkTotalMassInit()
     //Check for negative or null value, if wrongly set use the default value totalMass = 1.0
     if(!checkTotalMass())
     {
-        msg_warning(this) << "Switching back to default values: totalMass = 1.0\n";
+        msg_warning() << "Switching back to default values: totalMass = 1.0\n";
         d_totalMass.setValue(1.0) ;
     }
 }
@@ -1323,7 +1328,6 @@ void DiagonalMass<DataTypes, MassType>::draw(const core::visual::VisualParams* v
     Real totalMass=0.0;
 
     std::vector<  sofa::defaulttype::Vector3 > points;
-//    std::vector<  sofa::defaulttype::Vec<2,int> > indices;
 
     for (unsigned int i=0; i<x.size(); i++)
     {

--- a/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/CMakeLists.txt
+++ b/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} SofaGTestMain SofaTest)
+target_link_libraries(${PROJECT_NAME} SofaBaseMechanics SofaGTestMain SofaSimulationGraph)
 if(SofaPython_FOUND)
     target_link_libraries(${PROJECT_NAME} SofaPython)
 endif()

--- a/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/CMakeLists.txt
+++ b/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} SofaBaseMechanics SofaGTestMain SofaSimulationGraph)
+target_link_libraries(${PROJECT_NAME} SofaGTestMain SofaTest)
 if(SofaPython_FOUND)
     target_link_libraries(${PROJECT_NAME} SofaPython)
 endif()

--- a/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/DiagonalMass_test.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/DiagonalMass_test.cpp
@@ -627,12 +627,12 @@ public:
         {
             EXPECT_MSG_EMIT(Error);
             root->init(ExecParams::defaultInstance());
-            EXPECT_TRUE( mass->isComponentStateValid() );
+            EXPECT_FALSE( mass->isComponentStateValid() );
         }else
         {
             EXPECT_MSG_NOEMIT(Error);
             root->init(ExecParams::defaultInstance()) ;
-            EXPECT_FALSE( mass->isComponentStateValid() );
+            EXPECT_TRUE( mass->isComponentStateValid() );
         }
 
         if(mass!=nullptr){

--- a/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/DiagonalMass_test.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/DiagonalMass_test.cpp
@@ -42,13 +42,16 @@ using sofa::simulation::Node ;
 #include <sofa/simulation/Simulation.h>
 #include <SofaSimulationGraph/DAGSimulation.h>
 
+#include <SofaSimulationGraph/SimpleApi.h>
+
 #include <SofaSimulationCommon/SceneLoaderXML.h>
 using sofa::simulation::SceneLoaderXML ;
 
 #include <string>
 using std::string ;
 
-#include <gtest/gtest.h>
+#include <sofa/helper/testing/BaseTest.h>
+using sofa::helper::testing::BaseTest;
 
 using namespace sofa::defaulttype;
 using namespace sofa::component::topology;
@@ -70,7 +73,7 @@ namespace sofa {
 // Given the positions and the topology, it then checks the expected values for
 // the mass.
 template <class TDataTypes, class TMassType>
-class DiagonalMass_test : public ::testing::Test
+class DiagonalMass_test : public BaseTest
 {
 public:
     typedef TDataTypes DataTypes;
@@ -88,6 +91,8 @@ public:
 
     virtual void SetUp()
     {
+        sofa::simpleapi::importPlugin("SofaAllCommonComponents") ;
+
         component::initBaseMechanics();
         simulation::setSimulation(simulation = new simulation::graph::DAGSimulation());
         root = simulation::getSimulation()->createNewGraph("root");

--- a/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/DiagonalMass_test.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/DiagonalMass_test.cpp
@@ -50,8 +50,8 @@ using sofa::simulation::SceneLoaderXML ;
 #include <string>
 using std::string ;
 
-#include <sofa/helper/testing/BaseTest.h>
-using sofa::helper::testing::BaseTest;
+#include <SofaTest/Sofa_test.h>
+using BaseTest = sofa::Sofa_test<SReal>;
 
 using namespace sofa::defaulttype;
 using namespace sofa::component::topology;

--- a/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/DiagonalMass_test.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/DiagonalMass_test.cpp
@@ -146,7 +146,9 @@ public:
         string scene =
                 "<?xml version='1.0'?>"
                 "<Node 	name='Root' gravity='0 0 0' time='0' animate='0'   > "
-                "   <MechanicalObject position='0 0 0 4 5 6'/>               "
+                "    <MechanicalObject />                                                                       "
+                "    <RegularGrid nx='2' ny='2' nz='2' xmin='0' xmax='2' ymin='0' ymax='2' zmin='0' zmax='2' /> "
+                "    <HexahedronSetGeometryAlgorithms />                                                        "
                 "   <DiagonalMass name='m_mass'/>                            "
                 "</Node>                                                     " ;
 
@@ -603,7 +605,9 @@ public:
         return ;
     }
 
-    void checkAttributeLoadFromFile(const std::string& filename, int masscount, double totalMass){
+    void checkAttributeLoadFromFile(const std::string& filename, int masscount, double totalMass, bool shouldFail)
+    {
+
         std::stringstream scene;
         scene << "<?xml version='1.0'?>"
                  "<Node 	name='Root' gravity='0 0 0' time='0' animate='0'   > "
@@ -615,10 +619,21 @@ public:
                                                           scene.str().c_str(),
                                                           scene.str().size()) ;
         ASSERT_NE(root.get(), nullptr) ;
-        root->init(ExecParams::defaultInstance()) ;
 
         TheDiagonalMass* mass = root->getTreeObject<TheDiagonalMass>() ;
         EXPECT_TRUE( mass != nullptr ) ;
+
+        if(shouldFail)
+        {
+            EXPECT_MSG_EMIT(Error);
+            root->init(ExecParams::defaultInstance());
+            EXPECT_TRUE( mass->isComponentStateValid() );
+        }else
+        {
+            EXPECT_MSG_NOEMIT(Error);
+            root->init(ExecParams::defaultInstance()) ;
+            EXPECT_FALSE( mass->isComponentStateValid() );
+        }
 
         if(mass!=nullptr){
             // The number of mass in card.rigid is one so this should be
@@ -816,12 +831,12 @@ TEST_F(DiagonalMass3_test, checkWrongSizeVertexMass_Tetra){
 
 
 /// Rigid file are not handled only xs3....
-TEST_F(DiagonalMass3_test, checkAttributeLoadFromXps){
-    checkAttributeLoadFromFile("BehaviorModels/card.rigid", 0, 0);
+TEST_F(DiagonalMass3_test, checkAttributeLoadFromXpsRigid){
+    checkAttributeLoadFromFile("BehaviorModels/card.rigid", 0, 0, true);
 }
 
-TEST_F(DiagonalMass3_test, checkAttributeLoadFromFile){
-    checkAttributeLoadFromFile("BehaviorModels/chain.xs3", 6, 0.6);
+TEST_F(DiagonalMass3_test, checkAttributeLoadFromXpsMassSpring){
+    checkAttributeLoadFromFile("BehaviorModels/chain.xs3", 6, 0.6, false);
 }
 
 

--- a/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/MechanicalObject_test.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/MechanicalObject_test.cpp
@@ -21,8 +21,8 @@
 ******************************************************************************/
 #include <SofaBaseMechanics/MechanicalObject.inl>
 
-#include <sofa/helper/testing/BaseTest.h>
-using sofa::helper::testing::BaseTest;
+#include <SofaTest/Sofa_test.h>
+using BaseTest = sofa::Sofa_test<SReal>;
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/MechanicalObject_test.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/MechanicalObject_test.cpp
@@ -21,8 +21,8 @@
 ******************************************************************************/
 #include <SofaBaseMechanics/MechanicalObject.inl>
 
-#include <gtest/gtest.h>
-
+#include <sofa/helper/testing/BaseTest.h>
+using sofa::helper::testing::BaseTest;
 
 namespace sofa
 {
@@ -37,7 +37,7 @@ struct StubMechanicalObject : public component::container::MechanicalObject<T>
 {};
 
 template<typename T>
-struct MechanicalObject_test :  public ::testing::Test
+struct MechanicalObject_test :  public BaseTest
 {
     typedef typename StubMechanicalObject<T>::DataTypes::Coord  Coord;
     typedef typename StubMechanicalObject<T>::DataTypes::Real   Real;

--- a/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/UniformMass_test.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/UniformMass_test.cpp
@@ -37,6 +37,8 @@ using sofa::component::mass::UniformMass ;
 #include <SofaBaseMechanics/initBaseMechanics.h>
 using sofa::component::initBaseMechanics ;
 
+#include <SofaSimulationGraph/SimpleApi.h>
+
 #include <SofaSimulationGraph/DAGSimulation.h>
 using sofa::simulation::Simulation ;
 using sofa::simulation::graph::DAGSimulation ;
@@ -50,6 +52,10 @@ using sofa::component::container::MechanicalObject ;
 #include <SofaSimulationCommon/SceneLoaderXML.h>
 using sofa::simulation::SceneLoaderXML ;
 
+#include <sofa/helper/testing/BaseTest.h>
+using sofa::helper::testing::BaseTest;
+
+
 template <class TDataTypes, class TMassTypes>
 struct TemplateTypes
 {
@@ -58,7 +64,7 @@ struct TemplateTypes
 };
 
 template <typename TTemplateTypes>
-struct UniformMassTest :  public ::testing::Test
+struct UniformMassTest :  public BaseTest
 {
     typedef UniformMass<typename TTemplateTypes::DataTypes,
     typename TTemplateTypes::MassTypes> TheUniformMass ;
@@ -78,6 +84,8 @@ struct UniformMassTest :  public ::testing::Test
 
     virtual void SetUp()
     {
+        sofa::simpleapi::importPlugin("SofaAllCommonComponents") ;
+
         todo = true ;
         initBaseMechanics();
         setSimulation( m_simu = new DAGSimulation() );

--- a/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/UniformMass_test.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/UniformMass_test.cpp
@@ -52,8 +52,8 @@ using sofa::component::container::MechanicalObject ;
 #include <SofaSimulationCommon/SceneLoaderXML.h>
 using sofa::simulation::SceneLoaderXML ;
 
-#include <sofa/helper/testing/BaseTest.h>
-using sofa::helper::testing::BaseTest;
+#include <SofaTest/Sofa_test.h>
+using BaseTest = sofa::Sofa_test<SReal>;
 
 
 template <class TDataTypes, class TMassTypes>

--- a/SofaKernel/modules/SofaSimulationGraph/SimpleApi.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/SimpleApi.cpp
@@ -35,10 +35,18 @@ using sofa::core::objectmodel::BaseObjectDescription ;
 #include <sofa/simulation/XMLPrintVisitor.h>
 using sofa::simulation::XMLPrintVisitor ;
 
+#include <sofa/helper/system/PluginManager.h>
+using sofa::helper::system::PluginManager ;
+
 namespace sofa
 {
 namespace simpleapi
 {
+
+bool importPlugin(const std::string& name)
+{
+    return PluginManager::getInstance().loadPlugin(name) ;
+}
 
 void dumpScene(Node::SPtr root)
 {

--- a/SofaKernel/modules/SofaSimulationGraph/SimpleApi.h
+++ b/SofaKernel/modules/SofaSimulationGraph/SimpleApi.h
@@ -44,7 +44,7 @@ using sofa::core::objectmodel::BaseObject ;
 using sofa::simulation::Simulation ;
 using sofa::simulation::Node ;
 
-void SOFA_SIMULATION_GRAPH_API importPlugin(const std::string& name) ;
+bool SOFA_SIMULATION_GRAPH_API importPlugin(const std::string& name) ;
 
 Simulation::SPtr SOFA_SIMULATION_GRAPH_API createSimulation(const std::string& type="DAG") ;
 

--- a/applications/plugins/SofaTest/Sofa_test.cpp
+++ b/applications/plugins/SofaTest/Sofa_test.cpp
@@ -31,7 +31,6 @@ using sofa::helper::system::PluginRepository ;
 
 #include <sofa/helper/system/FileSystem.h>
 using sofa::helper::system::PluginRepository;
-using sofa::helper::system::DataRepository;
 using sofa::helper::system::FileSystem;
 
 #include <sofa/helper/Utils.h>

--- a/tools/SofaGTestMain/SofaGTestMain.cpp
+++ b/tools/SofaGTestMain/SofaGTestMain.cpp
@@ -9,11 +9,6 @@
 
 #include <gtest/gtest.h>
 
-using sofa::helper::system::PluginRepository;
-using sofa::helper::system::DataRepository;
-using sofa::helper::system::FileSystem;
-using sofa::helper::Utils;
-
 int main(int argc, char **argv)
 {
     testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
The SofaBaseMechanics_test were probably broken. 
They were not in-heriting from  SofaTest neither BaseTest. This means that uncatched msg_error() should generate test failure while they should. 

In this PR I implement the proper behavior, so now several tests are "correctly failing" :) 
And I fixed the tests.
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
