### PR TITLE
[SofaBaseTopology] Topology change propagation to Mechanical State

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyModifier.cpp
@@ -273,7 +273,7 @@ void EdgeSetTopologyModifier::removeEdgesProcess(const sofa::helper::vector<Edge
         removePointsWarning(vertexToBeRemoved);
         // inform other objects that the points are going to be removed
         propagateTopologicalChanges();
-        removePointsProcess(vertexToBeRemoved);
+        removePointsProcess(vertexToBeRemoved, d_propagateToDOF.getValue());
     }
 }
 

--- a/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyModifier.cpp
@@ -503,7 +503,7 @@ void HexahedronSetTopologyModifier::removeHexahedraProcess( const sofa::helper::
     {
         removePointsWarning(vertexToBeRemoved);
         propagateTopologicalChanges();
-        removePointsProcess(vertexToBeRemoved);
+        removePointsProcess(vertexToBeRemoved, d_propagateToDOF.getValue());
     }
 }
 

--- a/SofaKernel/modules/SofaBaseTopology/PointSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/PointSetTopologyModifier.h
@@ -46,7 +46,7 @@ public:
     SOFA_CLASS(PointSetTopologyModifier,core::topology::TopologyModifier);
 
     typedef core::topology::BaseMeshTopology::PointID PointID;
-    Data<bool> d_propagateToDOF;
+    Data<bool> d_propagateToDOF; ///< propagate changes to Mechanical object DOFs
 
 protected:
     PointSetTopologyModifier()

--- a/SofaKernel/modules/SofaBaseTopology/PointSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/PointSetTopologyModifier.h
@@ -44,12 +44,14 @@ class SOFA_BASE_TOPOLOGY_API PointSetTopologyModifier : public core::topology::T
 {
 public:
     SOFA_CLASS(PointSetTopologyModifier,core::topology::TopologyModifier);
-    
+
     typedef core::topology::BaseMeshTopology::PointID PointID;
+    Data<bool> d_propagateToDOF;
 
 protected:
     PointSetTopologyModifier()
         : TopologyModifier()
+        , d_propagateToDOF(initData(&d_propagateToDOF, true, "propagateToDOF", " propagate changes to MEchanical object DOFs if true"))
     {}
 
     virtual ~PointSetTopologyModifier() override {}

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyModifier.cpp
@@ -330,7 +330,7 @@ void QuadSetTopologyModifier::removeQuadsProcess(const sofa::helper::vector<Quad
         removePointsWarning(vertexToBeRemoved);
         /// propagate to all components
         propagateTopologicalChanges();
-        removePointsProcess(vertexToBeRemoved);
+        removePointsProcess(vertexToBeRemoved, d_propagateToDOF.getValue());
     }
 }
 

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyModifier.cpp
@@ -424,7 +424,7 @@ void TetrahedronSetTopologyModifier::removeTetrahedraProcess( const sofa::helper
     {
         removePointsWarning(vertexToBeRemoved);
         propagateTopologicalChanges();
-        removePointsProcess(vertexToBeRemoved);
+        removePointsProcess(vertexToBeRemoved, d_propagateToDOF.getValue());
     }
 }
 

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyModifier.cpp
@@ -453,7 +453,7 @@ void TriangleSetTopologyModifier::removeTrianglesProcess(const sofa::helper::vec
         removePointsWarning(vertexToBeRemoved);
         /// propagate to all components
         propagateTopologicalChanges();
-        removePointsProcess(vertexToBeRemoved);
+        removePointsProcess(vertexToBeRemoved, d_propagateToDOF.getValue());
     }
 }
 


### PR DESCRIPTION
Add a boolean data (d_propagatetoDOF) to allow or not the propagation of the topological changes to the mechanical state immediately as soon as they occure.

Default value (d_propagateToDOF=true)  the topological changes are propagated immediately following the SOFA regular behavior and it should not affect all the Sofa current scenes.

If the boolean is set to false the topological state changes update are not propagated immediately and they can executed in another step of the simulaiton loop.

This modification should make the concurrent execution of the topological changes and the simulation safe.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
