### PR TITLE
[SofaMeshCollision] TriangleModel optimization when topology changes occur

### DIFF
--- a/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
+++ b/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
@@ -237,8 +237,8 @@ template<class DataTypes>
 void TTriangleModel<DataTypes>::handleTopologyChange()
 {
     //bool debug_mode = false;
-    updateFromTopology();
-    if (triangles != &mytriangles)
+    //updateFromTopology();
+    //if (triangles != &mytriangles)
     {
         // We use the same triangle array as the topology -> only resize and recompute flags
 
@@ -259,8 +259,8 @@ void TTriangleModel<DataTypes>::handleTopologyChange()
                 sout << "TriangleModel: now "<<_topology->getNbTriangles()<<" triangles." << sendl;
                 resize(_topology->getNbTriangles());
                 needsUpdate=true;
-                updateFlags();
-
+                //updateFlags();
+                updateFromTopology();
                 //                 updateNormals();
                 break;
             }

--- a/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
+++ b/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
@@ -252,11 +252,12 @@ void TTriangleModel<DataTypes>::handleTopologyChange()
 
         case core::topology::ENDING_EVENT:
         {
+            updateFromTopology();
+
             sout << "TriangleModel: now "<<_topology->getNbTriangles()<<" triangles." << sendl;
             resize(_topology->getNbTriangles());
             needsUpdate=true;
-
-            updateFromTopology();
+            updateFlags();            
             break;
         }
         /*

--- a/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
+++ b/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
@@ -236,37 +236,32 @@ void TTriangleModel<DataTypes>::updateFlags(int /*ntri*/)
 template<class DataTypes>
 void TTriangleModel<DataTypes>::handleTopologyChange()
 {
-    //bool debug_mode = false;
-    //updateFromTopology();
-    //if (triangles != &mytriangles)
+
+    // We use the same triangle array as the topology -> only resize and recompute flags
+    std::list<const sofa::core::topology::TopologyChange *>::const_iterator itBegin=_topology->beginChange();
+    std::list<const sofa::core::topology::TopologyChange *>::const_iterator itEnd=_topology->endChange();
+    //elems.handleTopologyEvents(itBegin,itEnd);
+
+    while( itBegin != itEnd )
     {
-        // We use the same triangle array as the topology -> only resize and recompute flags
+        core::topology::TopologyChangeType changeType = (*itBegin)->getChangeType();
 
-        std::list<const sofa::core::topology::TopologyChange *>::const_iterator itBegin=_topology->beginChange();
-        std::list<const sofa::core::topology::TopologyChange *>::const_iterator itEnd=_topology->endChange();
-        //elems.handleTopologyEvents(itBegin,itEnd);
-
-        while( itBegin != itEnd )
+        switch( changeType )
         {
-            core::topology::TopologyChangeType changeType = (*itBegin)->getChangeType();
-
-            switch( changeType )
-            {
 
 
-            case core::topology::ENDING_EVENT:
-            {
-                sout << "TriangleModel: now "<<_topology->getNbTriangles()<<" triangles." << sendl;
-                resize(_topology->getNbTriangles());
-                needsUpdate=true;
-                //updateFlags();
-                updateFromTopology();
-                //                 updateNormals();
-                break;
-            }
-                /*
-            case core::topology::TRIANGLESADDED:
-            {
+        case core::topology::ENDING_EVENT:
+        {
+            sout << "TriangleModel: now "<<_topology->getNbTriangles()<<" triangles." << sendl;
+            resize(_topology->getNbTriangles());
+            needsUpdate=true;
+
+            updateFromTopology();
+            break;
+        }
+        /*
+        case core::topology::TRIANGLESADDED:
+        {
             //sout << "INFO_print : Vis - TRIANGLESADDED" << sendl;
             const sofa::component::topology::TrianglesAdded *ta=static_cast< const sofa::component::topology::TrianglesAdded * >( *itBegin );
             for (unsigned int i=0;i<ta->getNbAddedTriangles();++i) {
@@ -276,15 +271,14 @@ void TTriangleModel<DataTypes>::handleTopologyChange()
             const defaulttype::Vector3& pt3 = t.p3();
             t.n() = cross(pt2-pt1,pt3-pt1);
             t.n().normalize();
-            }
-            break;
-            }*/
-            default: break;
-            }
-            ++itBegin;
         }
-        return;
+        break;
+        }*/
+        default: break;
+        }
+        ++itBegin;
     }
+    return;
 #if 0
     sofa::core::topology::TopologyModifier* topoMod;
     this->getContext()->get(topoMod);


### PR DESCRIPTION
[Collision] Optimization: it prevents the normals of the triangles to be recomputed everytime a topological change happens.
The normals of the triangles are computed only once after all the topology changes occur (on the topology::ENDING_EVENT)





______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
