### PR TITLE
[SofaPython] add getLinkedBase to the binding of a link.

### DIFF
--- a/applications/plugins/SofaPython/Binding_Link.cpp
+++ b/applications/plugins/SofaPython/Binding_Link.cpp
@@ -25,6 +25,7 @@
 #include <sofa/core/objectmodel/Link.h>
 #include "PythonToSofa.inl"
 
+#include <SofaPython/PythonFactory.h>
 
 using namespace sofa::core::objectmodel;
 using namespace sofa::defaulttype;
@@ -118,6 +119,15 @@ static PyObject * Link_setValueString(PyObject* self, PyObject* args)
     Py_RETURN_NONE;
 }
 
+static PyObject * Link_getLinkedBase(PyObject *self, PyObject * /*args*/)
+{
+    BaseLink* link = get_baselink( self );
+
+    if( link->getLinkedBase() )
+        return sofa::PythonFactory::toPython(link->getLinkedBase()) ;
+
+    Py_RETURN_NONE;
+}
 
 static PyObject * Link_getSize(PyObject *self, PyObject * /*args*/)
 {
@@ -162,6 +172,9 @@ SP_CLASS_METHOD_DOC(Link,isPersistant, "Returns True if the PERSISTANT(STORE) fl
                                        "indicate that the field should be saved.")
 SP_CLASS_METHOD_DOC(Link,setPersistant,  "Change the value of the PERSISTANT(STORE) flag. This is used to \n"
                                          "control if the field should be saved.")
+SP_CLASS_METHOD_DOC(Link,getLinkedBase,  "Return the sofa object pointed by the link")
+
+
 SP_CLASS_METHOD(Link,getSize)
 SP_CLASS_METHODS_END
 

--- a/applications/plugins/SofaPython/Binding_Link.cpp
+++ b/applications/plugins/SofaPython/Binding_Link.cpp
@@ -129,6 +129,17 @@ static PyObject * Link_getLinkedBase(PyObject *self, PyObject * /*args*/)
     Py_RETURN_NONE;
 }
 
+
+static PyObject * Link_getLinkedData(PyObject *self, PyObject * /*args*/)
+{
+    BaseLink* link = get_baselink( self );
+
+    if( link->getLinkedData() )
+        return SP_BUILD_PYPTR(Data,BaseData,link->getLinkedData(),false);
+
+    Py_RETURN_NONE;
+}
+
 static PyObject * Link_getSize(PyObject *self, PyObject * /*args*/)
 {
     BaseLink* link = get_baselink( self );
@@ -173,6 +184,7 @@ SP_CLASS_METHOD_DOC(Link,isPersistant, "Returns True if the PERSISTANT(STORE) fl
 SP_CLASS_METHOD_DOC(Link,setPersistant,  "Change the value of the PERSISTANT(STORE) flag. This is used to \n"
                                          "control if the field should be saved.")
 SP_CLASS_METHOD_DOC(Link,getLinkedBase,  "Return the sofa object pointed by the link")
+SP_CLASS_METHOD_DOC(Link,getLinkedData,  "Return the sofa data pointed by the link")
 
 
 SP_CLASS_METHOD(Link,getSize)


### PR DESCRIPTION
The method exists in Sofa and is useful to explore the graph between components.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
