### PR TITLE
[SofaSparseSolver] ADD saveMatrixToFile to SparseLDLSolver

### DIFF
--- a/modules/SofaSparseSolver/src/SofaSparseSolver/SparseLDLSolver.h
+++ b/modules/SofaSparseSolver/src/SofaSparseSolver/SparseLDLSolver.h
@@ -32,6 +32,7 @@
 #include <math.h>
 #include <SofaSparseSolver/SparseLDLSolverImpl.h>
 #include <sofa/defaulttype/BaseMatrix.h>
+#include <sofa/core/objectmodel/DataFileName.h>
 
 namespace sofa
 {
@@ -57,12 +58,14 @@ public :
     typedef typename Inherit::JMatrixType JMatrixType;
     typedef SparseLDLImplInvertData<helper::vector<int>, helper::vector<Real> > InvertData;
 
-    void solve (Matrix& M, Vector& x, Vector& b) override ;
-    void invert(Matrix& M) override;
-    bool addJMInvJtLocal(TMatrix * M, ResMatrixType * result,const JMatrixType * J, double fact) override;
+    virtual void solve (Matrix& M, Vector& x, Vector& b) override ;
+    virtual void invert(Matrix& M) override;
+    virtual bool addJMInvJtLocal(TMatrix * M, ResMatrixType * result,const JMatrixType * J, double fact) override;
     int numStep;
 
-    Data<bool> f_saveMatrixToFile; ///< save matrix to a text file (can be very slow, as full matrix is stored
+    Data<bool> f_saveMatrixToFile;      ///< save matrix to a text file (can be very slow, as full matrix is stored)
+    sofa::core::objectmodel::DataFileName d_filename;   ///< file where this matrix will be saved
+    Data<int> d_precision;      ///< number of digits used to save system's matrix, default is 6
 
     MatrixInvertData * createInvertData() override {
         return new InvertData();

--- a/modules/SofaSparseSolver/src/SofaSparseSolver/SparseLDLSolver.h
+++ b/modules/SofaSparseSolver/src/SofaSparseSolver/SparseLDLSolver.h
@@ -58,9 +58,9 @@ public :
     typedef typename Inherit::JMatrixType JMatrixType;
     typedef SparseLDLImplInvertData<helper::vector<int>, helper::vector<Real> > InvertData;
 
-    virtual void solve (Matrix& M, Vector& x, Vector& b) override ;
-    virtual void invert(Matrix& M) override;
-    virtual bool addJMInvJtLocal(TMatrix * M, ResMatrixType * result,const JMatrixType * J, double fact) override;
+    void solve (Matrix& M, Vector& x, Vector& b) override ;
+    void invert(Matrix& M) override;
+    bool addJMInvJtLocal(TMatrix * M, ResMatrixType * result,const JMatrixType * J, double fact) override;
     int numStep;
 
     Data<bool> f_saveMatrixToFile;      ///< save matrix to a text file (can be very slow, as full matrix is stored)

--- a/modules/SofaSparseSolver/src/SofaSparseSolver/SparseLDLSolver.inl
+++ b/modules/SofaSparseSolver/src/SofaSparseSolver/SparseLDLSolver.inl
@@ -34,6 +34,12 @@
 #include <sofa/helper/system/thread/CTime.h>
 #include <SofaBaseLinearSolver/CompressedRowSparseMatrix.inl>
 #include <fstream>
+#include <iomanip>      // std::setprecision
+
+//
+#include <string>
+using namespace std;
+//
 
 namespace sofa {
 
@@ -44,7 +50,9 @@ namespace linearsolver {
 template<class TMatrix, class TVector, class TThreadManager>
 SparseLDLSolver<TMatrix,TVector,TThreadManager>::SparseLDLSolver()
     : numStep(0)
-    , f_saveMatrixToFile( initData(&f_saveMatrixToFile, false, "saveMatrixToFile", "save matrix to a text file (can be very slow, as full matrix is stored"))
+    , f_saveMatrixToFile( initData(&f_saveMatrixToFile, false, "savingMatrixToFile", "save matrix to a text file (can be very slow, as full matrix is stored"))
+    , d_filename( initData(&d_filename, std::string("MatrixInLDL_%04d.txt"),"savingFilename", "Name of file where system matrix (mass, stiffness and damping) will be stored."))
+    , d_precision( initData(&d_precision, 6, "savingPrecision", "Number of digits used to store system's matrix. Default is 6."))
 {}
 
 template<class TMatrix, class TVector, class TThreadManager>
@@ -54,12 +62,18 @@ void SparseLDLSolver<TMatrix,TVector,TThreadManager>::solve (Matrix& M, Vector& 
 
 template<class TMatrix, class TVector, class TThreadManager>
 void SparseLDLSolver<TMatrix,TVector,TThreadManager>::invert(Matrix& M) {
-    if (f_saveMatrixToFile.getValue()) {
+    if (f_saveMatrixToFile.getValue())
+    {
         std::ofstream f;
-        char name[100];
-        sprintf(name, "matrixInLDLInvert_%04d.txt", numStep);
+        std::string name=d_filename.getValue().c_str();
+        if (d_filename.getValue().find("%d"))
+        {
+            char bname[100];
+            snprintf(bname, 100, d_filename.getValue().c_str(), numStep);
+            name=bname;
+        }
         f.open(name);
-        f << M;
+        f << std::scientific << std::setprecision(d_precision.getValue()) << M;
         f.close();
     }
 
@@ -72,7 +86,7 @@ void SparseLDLSolver<TMatrix,TVector,TThreadManager>::invert(Matrix& M) {
     int * M_rowind = (int *) &Mfiltered.getColsIndex()[0];
     Real * M_values = (Real *) &Mfiltered.getColsValue()[0];
 
-    if(M_colptr==nullptr || M_rowind==nullptr || M_values==nullptr || (int) Mfiltered.getRowBegin().size() < n )
+    if(M_colptr==nullptr || M_rowind==nullptr || M_values==nullptr || Mfiltered.getRowBegin().size() < n )
     {
         msg_warning() << "Invalid Linear System to solve. Please insure that there is enough constraints (not rank deficient)." ;
         return ;

--- a/modules/SofaSparseSolver/src/SofaSparseSolver/SparseLDLSolver.inl
+++ b/modules/SofaSparseSolver/src/SofaSparseSolver/SparseLDLSolver.inl
@@ -35,11 +35,7 @@
 #include <SofaBaseLinearSolver/CompressedRowSparseMatrix.inl>
 #include <fstream>
 #include <iomanip>      // std::setprecision
-
-//
 #include <string>
-using namespace std;
-//
 
 namespace sofa {
 


### PR DESCRIPTION
If savingMatrixToFile is set to true, the system matrix is saved during each time step with the name "MatrixInLDL_%04d", where %d is the value of the time.
I added two new input data:

- savingFilename
	The filename where the matrix is stored can be changed using the input data d_filename. 
	If it contains "%d", it will keep the previously described behavior, else it will always save in the same file overwriting it.

- savingPrecision
	The second new input is d_precision. It is the precision with which the matrix will be stored.

These options are useful to save the system matrix from SOFA and read it from another software.                                      



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
