### PR TITLE
[SofaConstraint] allow call of constraints' storeLambda()

### DIFF
--- a/modules/SofaConstraint/ConstraintStoreLambdaVisitor.cpp
+++ b/modules/SofaConstraint/ConstraintStoreLambdaVisitor.cpp
@@ -23,12 +23,22 @@ Visitor::Result ConstraintStoreLambdaVisitor::fwdConstraintSet(simulation::Node*
     return RESULT_CONTINUE;
 }
 
-void ConstraintStoreLambdaVisitor::bwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map)
+void ConstraintStoreLambdaVisitor::bwdMechanicalMapping(simulation::Node* node, core::BaseMapping* map)
 {
+    SOFA_UNUSED(node);
+
     sofa::core::MechanicalParams mparams(*m_cParams);
     mparams.setDx(m_cParams->dx());
     mparams.setF(m_cParams->lambda());
     map->applyJT(&mparams, m_cParams->lambda(), m_cParams->lambda());
+}
+
+bool ConstraintStoreLambdaVisitor::stopAtMechanicalMapping(simulation::Node* node, core::BaseMapping* map)
+{
+    SOFA_UNUSED(node);
+    SOFA_UNUSED(map);
+
+    return false;
 }
 
 }

--- a/modules/SofaConstraint/ConstraintStoreLambdaVisitor.h
+++ b/modules/SofaConstraint/ConstraintStoreLambdaVisitor.h
@@ -18,6 +18,8 @@ public:
 
     void bwdMechanicalMapping(simulation::Node* node, core::BaseMapping* map) override;
 
+    bool stopAtMechanicalMapping(simulation::Node* node, core::BaseMapping* map) override;
+
 private:
     const sofa::core::ConstraintParams* m_cParams;
     const sofa::defaulttype::BaseVector* m_lambda;


### PR DESCRIPTION
In the DEFROST team we need our constraints to provide the computed forces as outputs. These forces are now provided to the constraints using the method `storeLambda()`. 

Our constraints node usually looks like this: 
```
cavity = accordion.createChild('cavity')
cavity.createObject('MechanicalObject')
cavity.createObject('SurfacePressureConstraint')
cavity.createObject('BarycentricMapping', name='mapping',  mapForces=False, mapMasses=False)
``` 
As no forces have to be mapped, we set `mapForces=False` to avoid unnecessary computations. Yet in the current code, this disables the call to `storeLambda()`. 

This PR changes this behavior by overriding the method `stopAtMechanicalMapping()` of `ConstraintStoreLambdaVisitor`.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
