### PR TITLE
[SofaKernel] Minor code refactor in BaseData & new StringUtils functions.

### DIFF
--- a/SofaKernel/framework/sofa/core/objectmodel/BaseData.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseData.h
@@ -180,19 +180,8 @@ public:
     /// Set widget
     void setWidget(const char* val) { widget = val; }
 
-    /// True if the value has been modified
-    /// If this data is linked, the value of this data will be considered as modified
-    /// (even if the parent's value has not been modified)
-    bool isSet() const { return m_isSets[currentAspect()]; }
-
     /// True if the counter of modification gives valid information.
     virtual bool isCounterValid() const = 0;
-
-    /// Reset the isSet flag to false, to indicate that the current value is the default for this %Data.
-    void unset() { m_isSets[currentAspect()] = false; }
-
-    /// Reset the isSet flag to true, to indicate that the current value has been modified.
-    void forceSet() { m_isSets[currentAspect()] = true; }
 
     /// @name Flags
     /// @{
@@ -253,10 +242,6 @@ public:
     /// This method should not be called directly, the %Data registration methods in Base should be used instead.
     void setName(const std::string& name) { m_name=name; }
 
-    /// Return the number of changes since creation.
-    /// This can be used to efficiently detect changes.
-    int getCounter() const { return m_counters[currentAspect()]; }
-
 
     /// @name Optimized edition and retrieval API (for multi-threading performances)
     /// @{
@@ -264,17 +249,17 @@ public:
     /// True if the value has been modified
     /// If this data is linked, the value of this data will be considered as modified
     /// (even if the parent's value has not been modified)
-    bool isSet(const core::ExecParams* params) const { return m_isSets[currentAspect(params)]; }
+    bool isSet(const core::ExecParams* params=nullptr) const { return m_isSets[currentAspect(params)]; }
 
     /// Reset the isSet flag to false, to indicate that the current value is the default for this %Data.
-    void unset(const core::ExecParams* params) { m_isSets[currentAspect(params)] = false; }
+    void unset(const core::ExecParams* params=nullptr) { m_isSets[currentAspect(params)] = false; }
 
     /// Reset the isSet flag to true, to indicate that the current value has been modified.
-    void forceSet(const core::ExecParams* params) { m_isSets[currentAspect(params)] = true; }
+    void forceSet(const core::ExecParams* params=nullptr) { m_isSets[currentAspect(params)] = true; }
 
     /// Return the number of changes since creation
     /// This can be used to efficiently detect changes
-    int getCounter(const core::ExecParams* params) const { return m_counters[currentAspect(params)]; }
+    int getCounter(const core::ExecParams* params=nullptr) const { return m_counters[currentAspect(params)]; }
 
     /// @}
 

--- a/SofaKernel/framework/sofa/helper/CMakeLists.txt
+++ b/SofaKernel/framework/sofa/helper/CMakeLists.txt
@@ -145,6 +145,7 @@ set(SOURCE_FILES
     Polynomial_LD.cpp
     Quater.cpp
     RandomGenerator.cpp
+    StringUtils.cpp
     TagFactory.cpp
     UnitTest.cpp
     Utils.cpp

--- a/SofaKernel/framework/sofa/helper/StringUtils.cpp
+++ b/SofaKernel/framework/sofa/helper/StringUtils.cpp
@@ -19,54 +19,66 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_HELPER_STRING_UTILS_H
-#define SOFA_HELPER_STRING_UTILS_H
+#include <cstring>
+#include "StringUtils.h"
 
-#include <string>
-#include <vector>
-#include <sstream>
-#include <sofa/config.h>
 namespace sofa
 {
 
 namespace helper
 {
 
-///@brief Split one string by a given delimiter and returns that into a std::vector
-std::vector<std::string> SOFA_HELPER_API split(const std::string& s, char delimiter);
-
-///@brief Join a std::vector into a single string, separated by the provided delimiter.
-///
-/// Taken from https://github.com/ekg/split/blob/master/join.h (I don't know what is the licence
-/// but thank for the author.
-template<class S, class T>
-std::string join(std::vector<T>& elems, S& delim) {
-    std::stringstream ss;
-    if(elems.empty())
-        return "";
-    typename std::vector<T>::iterator e = elems.begin();
-    ss << *e++;
-    for (; e != elems.end(); ++e) {
-        ss << delim << *e;
-    }
-    return ss.str();
+/// Taken from https://www.fluentcpp.com/2017/04/21/how-to-split-a-string-in-c/
+std::vector<std::string> split(const std::string& s, char delimiter)
+{
+   std::vector<std::string> tokens;
+   std::string token;
+   std::istringstream tokenStream(s);
+   while (std::getline(tokenStream, token, delimiter))
+   {
+      tokens.push_back(token);
+   }
+   return tokens;
 }
-///@brief returns a copy of the string given in argument.
-SOFA_HELPER_API char* getAStringCopy(const char *c);
 
-///@brief replace all occurence of "search" by the "replace" string.
-SOFA_HELPER_API void replaceAll(std::string& str,
-                                const std::string& search,
-                                const std::string& replace);
+char* getAStringCopy(const char *c)
+{
+    char* tmp = new char[strlen(c)+1] ;
+    strcpy(tmp,c);
+    return tmp ;
+}
 
-///@brief returns true if the prefix if located at the beginning of the "full" string.
-SOFA_HELPER_API bool starts_with(const std::string& prefix, const std::string& full);
+void replaceAll(std::string& str, const std::string& search, const std::string& replace)
+{
+    size_t pos = 0;
+    while((pos = str.find(search, pos)) != std::string::npos)
+    {
+        str.replace(pos, search.length(), replace);
+        pos += replace.length();
+    }
+}
 
-///@brief returns true if the suffix if located at the end of the "full" string.
-SOFA_HELPER_API bool ends_with(const std::string& suffix, const std::string& full);
+bool ends_with(const std::string& suffix, const std::string& full)
+{
+    const std::size_t lf = full.length();
+    const std::size_t ls = suffix.length();
+
+    if(lf < ls) return false;
+
+    return (0 == full.compare(lf - ls, ls, suffix));
+}
+
+bool starts_with(const std::string& prefix, const std::string& full)
+{
+    const std::size_t lf = full.length();
+    const std::size_t lp = prefix.length();
+
+    if(lf < lp) return false;
+
+    return (0 == full.compare(0, lp, prefix));
+}
 
 } // namespace helper
 
 } // namespace sofa
 
-#endif //SOFA_HELPER_STRING_UTILS_H

--- a/SofaKernel/modules/SofaSimulationGraph/SimpleApi.h
+++ b/SofaKernel/modules/SofaSimulationGraph/SimpleApi.h
@@ -33,14 +33,15 @@
 
 #include <sofa/simulation/Node.h>
 #include <sofa/simulation/Simulation.h>
-#include <sofa/core/objectmodel/BaseObject.h>
 
 namespace sofa
 {
 namespace simpleapi
 {
 
-using sofa::core::objectmodel::BaseObject ;
+using sofa::core::objectmodel::BaseObject;
+using sofa::core::objectmodel::BaseObjectDescription;
+
 using sofa::simulation::Simulation ;
 using sofa::simulation::Node ;
 
@@ -51,11 +52,24 @@ Simulation::SPtr SOFA_SIMULATION_GRAPH_API createSimulation(const std::string& t
 Node::SPtr SOFA_SIMULATION_GRAPH_API createRootNode( Simulation::SPtr, const std::string& name,
     const std::map<std::string, std::string>& params = std::map<std::string, std::string>{} );
 
-BaseObject::SPtr SOFA_SIMULATION_GRAPH_API createObject( Node::SPtr parent, const std::string& type,
+///@brief Create a sofa object in the provided node.
+///The parameter "params" is for passing specific data argument to the created object including the
+///object's type.
+BaseObject::SPtr SOFA_SIMULATION_GRAPH_API createObject(Node::SPtr node, BaseObjectDescription& params);
+
+///@brief create a sofa object in the provided node of the given type.
+///The parameter "params" is for passing specific data argument to the created object.
+BaseObject::SPtr SOFA_SIMULATION_GRAPH_API createObject( Node::SPtr node, const std::string& type,
     const std::map<std::string, std::string>& params = std::map<std::string, std::string>{} );
 
+///@brief create a child to the provided nodeof given name.
+///The parameter "params" is for passing specific data argument to the created object.
 Node::SPtr SOFA_SIMULATION_GRAPH_API createChild( Node::SPtr& node, const std::string& name,
     const std::map<std::string, std::string>& params = std::map<std::string, std::string>{} );
+
+///@brief create a child to the provided node.
+///The parameter "params" is for passing specific data argument to the created object (including the node name).
+Node::SPtr SOFA_SIMULATION_GRAPH_API createChild(Node::SPtr node, BaseObjectDescription& desc);
 
 void SOFA_SIMULATION_GRAPH_API dumpScene(Node::SPtr root) ;
 


### PR DESCRIPTION
Two change needed by the SofaPython3 plugin. 

- In BaseData Some method have two version, one without arguments the other with an ExecParm. In pybind11 we need to differentiate explicitely the two version making the code more complex. As I see no good reason why to keep the two version in Sofa I merged these two into one by using a default param = nullptr.  

- I have added a join/split function in the StringUtils class. 

- In SimpleAPI I found allowing BaseObjectDescription useful to create object and node. So I added new functions.
_____________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
