### PR TITLE
[CMake] Fix compilation issues due to CPackNSIS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,7 +307,9 @@ endif()
 ################
 # Package config
 include(CPackComponent)
-include(CPackNSIS)
+if(WIN32)
+    include(CPackNSIS)
+endif()
 include(CPackIFW)
 set(CPACK_PACKAGE_VERSION "${Sofa_VERSION}")
 set(CPACK_PACKAGE_NAME "SOFA v${CPACK_PACKAGE_VERSION}")


### PR DESCRIPTION
Short fix in main CMakeList regarding compilation with other than Win
CPackNSIS preventing from compiling



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
