### PR TITLE
[SofaBaseTopology][DrawTools] Some fix/update in topology internal draw methods.

### DIFF
--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
@@ -145,7 +145,10 @@ void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const
 void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const std::vector<Vec<4,float> >& colors)
 {
     if (points.size() != colors.size()*2)
+    {
+        msg_warning("DrawToolGL") << "Sizes mismatch between points.size() and colors.size().";
         return drawLines(points, size, RGBAColor::red());
+    }
 
     glLineWidth(size);
     disableLighting();

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
@@ -144,6 +144,9 @@ void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const
 
 void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const std::vector<Vec<4,float> >& colors)
 {
+    if (points.size() != colors.size()*2)
+        return drawLines(points, size, RGBAColor::red());
+
     glLineWidth(size);
     disableLighting();
     glBegin(GL_LINES);

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
@@ -78,24 +78,24 @@ void DrawToolGL::init()
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void DrawToolGL::drawPoints(const std::vector<Vector3> &points, float size, const Vec<4,float>& colour=Vec<4,float>(1.0f,1.0f,1.0f,1.0f))
+void DrawToolGL::drawPoints(const std::vector<Vector3> &points, float size, const Vec<4,float>& color=Vec<4,float>(1.0f,1.0f,1.0f,1.0f))
 {
-    setMaterial(colour);
+    setMaterial(color);
     glPointSize(size);
     disableLighting();
     glBegin(GL_POINTS);
     {
         for (std::size_t i=0; i<points.size(); ++i)
         {
-            internalDrawPoint(points[i], colour);
+            internalDrawPoint(points[i], color);
         }
     } glEnd();
     if (getLightEnabled()) enableLighting();
-    resetMaterial(colour);
+    resetMaterial(color);
     glPointSize(1);
 }
 
-void DrawToolGL::drawPoints(const std::vector<Vector3> &points, float size, const std::vector<Vec4f>& colour)
+void DrawToolGL::drawPoints(const std::vector<Vector3> &points, float size, const std::vector<Vec4f>& color)
 {
     glPointSize(size);
     disableLighting();
@@ -103,46 +103,46 @@ void DrawToolGL::drawPoints(const std::vector<Vector3> &points, float size, cons
     {
         for (std::size_t i=0; i<points.size(); ++i)
         {
-            setMaterial(colour[i]);
-            internalDrawPoint(points[i], colour[i]);
+            setMaterial(color[i]);
+            internalDrawPoint(points[i], color[i]);
             if (getLightEnabled()) enableLighting();
-            resetMaterial(colour[i]);
+            resetMaterial(color[i]);
         }
     } glEnd();
     glPointSize(1);
 }
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-void DrawToolGL::internalDrawLine(const Vector3 &p1, const Vector3 &p2, const Vec4f& colour)
+void DrawToolGL::internalDrawLine(const Vector3 &p1, const Vector3 &p2, const Vec4f& color)
 {
-    internalDrawPoint(p1, colour );
-    internalDrawPoint(p2, colour );
+    internalDrawPoint(p1, color );
+    internalDrawPoint(p2, color );
 }
 
-void DrawToolGL::drawLine(const Vector3 &p1, const Vector3 &p2, const Vec4f& colour)
+void DrawToolGL::drawLine(const Vector3 &p1, const Vector3 &p2, const Vec4f& color)
 {
     glBegin(GL_LINES);
-    internalDrawLine(p1,p2,colour);
+    internalDrawLine(p1,p2,color);
     glEnd();
 }
 
-void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const Vec<4,float>& colour)
+void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const Vec<4,float>& color)
 {
-    setMaterial(colour);
+    setMaterial(color);
     glLineWidth(size);
     disableLighting();
     glBegin(GL_LINES);
     {
         for (std::size_t i=0; i<points.size()/2; ++i)
         {
-            internalDrawLine(points[2*i],points[2*i+1]  , colour );
+            internalDrawLine(points[2*i],points[2*i+1]  , color );
         }
     } glEnd();
     if (getLightEnabled()) enableLighting();
-    resetMaterial(colour);
+    resetMaterial(color);
     glLineWidth(1);
 }
 
-void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const std::vector<Vec<4,float> >& colours)
+void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const std::vector<Vec<4,float> >& colors)
 {
     glLineWidth(size);
     disableLighting();
@@ -150,9 +150,9 @@ void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const
     {
         for (std::size_t i=0; i<points.size()/2; ++i)
         {
-            setMaterial(colours[i]);
-            internalDrawLine(points[2*i],points[2*i+1]  , colours[i] );
-            resetMaterial(colours[i]);
+            setMaterial(colors[i]);
+            internalDrawLine(points[2*i],points[2*i+1], colors[i] );
+            resetMaterial(colors[i]);
         }
     } glEnd();
     if (getLightEnabled()) enableLighting();
@@ -161,66 +161,66 @@ void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void DrawToolGL::drawLines(const std::vector<Vector3> &points, const std::vector< defaulttype::Vec<2,int> > &index, float size, const Vec<4,float>& colour=Vec<4,float>(1.0f,1.0f,1.0f,1.0f))
+void DrawToolGL::drawLines(const std::vector<Vector3> &points, const std::vector< defaulttype::Vec<2,int> > &index, float size, const Vec<4,float>& color=Vec<4,float>(1.0f,1.0f,1.0f,1.0f))
 {
-    setMaterial(colour);
+    setMaterial(color);
     glLineWidth(size);
     disableLighting();
     glBegin(GL_LINES);
     {
         for (std::size_t i=0; i<index.size(); ++i)
         {
-            internalDrawLine(points[ index[i][0] ],points[ index[i][1] ], colour );
+            internalDrawLine(points[ index[i][0] ],points[ index[i][1] ], color );
         }
     } glEnd();
     if (getLightEnabled()) enableLighting();
-    resetMaterial(colour);
+    resetMaterial(color);
     glLineWidth(1);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void DrawToolGL::drawLineStrip(const std::vector<Vector3> &points, float size, const Vec<4,float>& colour)
+void DrawToolGL::drawLineStrip(const std::vector<Vector3> &points, float size, const Vec<4,float>& color)
 {
-    setMaterial(colour);
+    setMaterial(color);
     glLineWidth(size);
     disableLighting();
     glBegin(GL_LINE_STRIP);
     {
         for (std::size_t i=0; i<points.size(); ++i)
         {
-            internalDrawPoint(points[i]  , colour );
+            internalDrawPoint(points[i]  , color );
         }
     } glEnd();
     if (getLightEnabled()) enableLighting();
-    resetMaterial(colour);
+    resetMaterial(color);
     glLineWidth(1);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void DrawToolGL::drawLineLoop(const std::vector<Vector3> &points, float size, const Vec<4,float>& colour)
+void DrawToolGL::drawLineLoop(const std::vector<Vector3> &points, float size, const Vec<4,float>& color)
 {
-    setMaterial(colour);
+    setMaterial(color);
     glLineWidth(size);
     disableLighting();
     glBegin(GL_LINE_LOOP);
     {
         for (std::size_t i=0; i<points.size(); ++i)
         {
-            internalDrawPoint(points[i]  , colour );
+            internalDrawPoint(points[i]  , color );
         }
     } glEnd();
     if (getLightEnabled()) enableLighting();
-    resetMaterial(colour);
+    resetMaterial(color);
     glLineWidth(1);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void DrawToolGL::drawTriangles(const std::vector<Vector3> &points, const Vec<4,float>& colour)
+void DrawToolGL::drawTriangles(const std::vector<Vector3> &points, const Vec<4,float>& color)
 {
-    setMaterial(colour);
+    setMaterial(color);
     glBegin(GL_TRIANGLES);
     {
         for (std::size_t i=0; i<points.size()/3; ++i)
@@ -230,59 +230,59 @@ void DrawToolGL::drawTriangles(const std::vector<Vector3> &points, const Vec<4,f
             const Vector3& c = points[ 3*i+2 ];
             Vector3 n = cross((b-a),(c-a));
             n.normalize();
-            internalDrawTriangle(a,b,c,n,colour);
+            internalDrawTriangle(a,b,c,n,color);
         }
     } glEnd();
-    resetMaterial(colour);
+    resetMaterial(color);
 }
 
-void DrawToolGL::drawTriangles(const std::vector<Vector3> &points, const std::vector< Vec4f > &colour)
+void DrawToolGL::drawTriangles(const std::vector<Vector3> &points, const std::vector< Vec4f > &color)
 {
     std::vector<Vector3> normal;
     normal.clear();
-    this->drawTriangles(points,normal,colour);
+    this->drawTriangles(points,normal,color);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void DrawToolGL::drawTriangles(const std::vector<Vector3> &points, const Vector3& normal, const Vec<4,float>& colour)
+void DrawToolGL::drawTriangles(const std::vector<Vector3> &points, const Vector3& normal, const Vec<4,float>& color)
 {
-    setMaterial(colour);
+    setMaterial(color);
     glBegin(GL_TRIANGLES);
     {
         for (std::size_t i=0; i<points.size()/3; ++i)
-            internalDrawTriangle(points[ 3*i+0 ],points[ 3*i+1 ],points[ 3*i+2 ], normal, colour);
+            internalDrawTriangle(points[ 3*i+0 ],points[ 3*i+1 ],points[ 3*i+2 ], normal, color);
     } glEnd();
-    resetMaterial(colour);
+    resetMaterial(color);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void DrawToolGL::drawTriangles(const std::vector<Vector3> &points, const std::vector< defaulttype::Vec<3,int> > &index,
-        const std::vector<Vector3> &normal, const Vec<4,float>& colour=Vec<4,float>(1.0f,1.0f,1.0f,1.0f))
+        const std::vector<Vector3> &normal, const Vec<4,float>& color=Vec<4,float>(1.0f,1.0f,1.0f,1.0f))
 {
-    setMaterial(colour);
+    setMaterial(color);
     glBegin(GL_TRIANGLES);
     {
         for (std::size_t i=0; i<index.size(); ++i)
         {
-            internalDrawTriangle(points[ index[i][0] ],points[ index[i][1] ],points[ index[i][2] ],normal[i],colour);
+            internalDrawTriangle(points[ index[i][0] ],points[ index[i][1] ],points[ index[i][2] ],normal[i],color);
         }
     } glEnd();
-    resetMaterial(colour);
+    resetMaterial(color);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void DrawToolGL::drawTriangles(const std::vector<Vector3> &points,
-        const std::vector<Vector3> &normal, const std::vector< Vec<4,float> > &colour)
+        const std::vector<Vector3> &normal, const std::vector< Vec<4,float> > &color)
 {
     const std::size_t nbTriangles=points.size()/3;
     bool computeNormals= (normal.size() != nbTriangles);
     if (nbTriangles == 0) return;
     glColorMaterial(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE);
     glEnable(GL_COLOR_MATERIAL);
-    setMaterial(colour[0]);
+    setMaterial(color[0]);
     glBegin(GL_TRIANGLES);
     {
         for (std::size_t i=0; i<nbTriangles; ++i)
@@ -290,7 +290,7 @@ void DrawToolGL::drawTriangles(const std::vector<Vector3> &points,
             if (!computeNormals)
             {
                 internalDrawTriangle(points[3*i+0],points[3*i+1],points[3*i+2],normal[i],
-                        colour[3*i+0],colour[3*i+1],colour[3*i+2]);
+                        color[3*i+0],color[3*i+1],color[3*i+2]);
             }
             else
             {
@@ -300,24 +300,24 @@ void DrawToolGL::drawTriangles(const std::vector<Vector3> &points,
                 Vector3 n = cross((b-a),(c-a));
                 n.normalize();
 
-                internalDrawPoint(a,n,colour[3*i+0]);
-                internalDrawPoint(b,n,colour[3*i+1]);
-                internalDrawPoint(c,n,colour[3*i+2]);
+                internalDrawPoint(a,n,color[3*i+0]);
+                internalDrawPoint(b,n,color[3*i+1]);
+                internalDrawPoint(c,n,color[3*i+2]);
 
             }
         }
     } glEnd();
     glDisable(GL_COLOR_MATERIAL);
-    resetMaterial(colour[0]);
+    resetMaterial(color[0]);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void DrawToolGL::drawTriangleStrip(const std::vector<Vector3> &points,
         const std::vector<Vector3>  &normal,
-        const Vec<4,float>& colour)
+        const Vec<4,float>& color)
 {
-    setMaterial(colour);
+    setMaterial(color);
     glBegin(GL_TRIANGLE_STRIP);
     {
         for (std::size_t i=0; i<normal.size(); ++i)
@@ -327,17 +327,17 @@ void DrawToolGL::drawTriangleStrip(const std::vector<Vector3> &points,
             glVertexNv<3>(points[2*i+1].ptr());
         }
     } glEnd();
-    resetMaterial(colour);
+    resetMaterial(color);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void DrawToolGL::drawTriangleFan(const std::vector<Vector3> &points,
         const std::vector<Vector3>  &normal,
-        const Vec<4,float>& colour)
+        const Vec<4,float>& color)
 {
     if (points.size() < 3) return;
-    setMaterial(colour);
+    setMaterial(color);
     glBegin(GL_TRIANGLE_FAN);
 
     glNormalT(normal[0]);
@@ -352,7 +352,7 @@ void DrawToolGL::drawTriangleFan(const std::vector<Vector3> &points,
     }
 
     glEnd();
-    resetMaterial(colour);
+    resetMaterial(color);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -362,59 +362,59 @@ void DrawToolGL::drawFrame(const Vector3& position, const Quaternion &orientatio
     setPolygonMode(0,false);
     helper::gl::Axis::draw(position, orientation, size);
 }
-void DrawToolGL::drawFrame(const Vector3& position, const Quaternion &orientation, const Vec<3,float> &size, const Vec4f &colour)
+void DrawToolGL::drawFrame(const Vector3& position, const Quaternion &orientation, const Vec<3,float> &size, const Vec4f &color)
 {
     setPolygonMode(0,false);
-    helper::gl::Axis::draw(position, orientation, size, colour, colour, colour);
+    helper::gl::Axis::draw(position, orientation, size, color, color, color);
 }
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void DrawToolGL::drawSpheres(const std::vector<Vector3> &points, float radius, const Vec<4,float>& colour)
+void DrawToolGL::drawSpheres(const std::vector<Vector3> &points, float radius, const Vec<4,float>& color)
 {
-    setMaterial(colour);
+    setMaterial(color);
 
     m_sphereUtil.draw(points, radius);
 
-    resetMaterial(colour);
+    resetMaterial(color);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void DrawToolGL::drawSpheres(const std::vector<Vector3> &points, const std::vector<float>& radius, const Vec<4,float>& colour)
+void DrawToolGL::drawSpheres(const std::vector<Vector3> &points, const std::vector<float>& radius, const Vec<4,float>& color)
 {
-    setMaterial(colour);
+    setMaterial(color);
 
     m_sphereUtil.draw(points, radius);
 
-    resetMaterial(colour);
+    resetMaterial(color);
 }
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void DrawToolGL::drawFakeSpheres(const std::vector<Vector3> &points, float radius, const Vec<4, float>& colour)
+void DrawToolGL::drawFakeSpheres(const std::vector<Vector3> &points, float radius, const Vec<4, float>& color)
 {
-    setMaterial(colour);
+    setMaterial(color);
 
     m_fakeSphereUtil.draw(points, radius);
 
-    resetMaterial(colour);
+    resetMaterial(color);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void DrawToolGL::drawFakeSpheres(const std::vector<Vector3> &points, const std::vector<float>& radius, const Vec<4, float>& colour)
+void DrawToolGL::drawFakeSpheres(const std::vector<Vector3> &points, const std::vector<float>& radius, const Vec<4, float>& color)
 {
-    setMaterial(colour);
+    setMaterial(color);
 
     m_fakeSphereUtil.draw(points, radius);
 
-    resetMaterial(colour);
+    resetMaterial(color);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void DrawToolGL::drawCapsule(const Vector3& p1, const Vector3 &p2, float radius,const Vec<4,float>& colour, int subd){
+void DrawToolGL::drawCapsule(const Vector3& p1, const Vector3 &p2, float radius,const Vec<4,float>& color, int subd){
     Vector3 tmp = p2-p1;
-    setMaterial(colour);
+    setMaterial(color);
     /* create Vectors p and q, co-planar with the capsules's cross-sectional disk */
     Vector3 p=tmp;
     if (fabs(p[0]) + fabs(p[1]) < 0.00001*tmp.norm())
@@ -454,22 +454,22 @@ void DrawToolGL::drawCapsule(const Vector3& p1, const Vector3 &p2, float radius,
     }
 
     //we draw here the cylinder part
-    drawTriangleStrip(points, normals,colour);
+    drawTriangleStrip(points, normals,color);
 
     //now we must draw the two hemispheres
     //but it's easier to draw spheres...
     drawSphere(p1,radius);
     drawSphere(p2,radius);
 
-    resetMaterial(colour);
+    resetMaterial(color);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void DrawToolGL::drawCone(const Vector3& p1, const Vector3 &p2, float radius1, float radius2, const Vec<4,float>& colour, int subd)
+void DrawToolGL::drawCone(const Vector3& p1, const Vector3 &p2, float radius1, float radius2, const Vec<4,float>& color, int subd)
 {
     Vector3 tmp = p2-p1;
-    setMaterial(colour);
+    setMaterial(color);
     /* create Vectors p and q, co-planar with the cylinder's cross-sectional disk */
     Vector3 p=tmp;
     if (fabs(p[0]) + fabs(p[1]) < 0.00001*tmp.norm())
@@ -532,70 +532,70 @@ void DrawToolGL::drawCone(const Vector3& p1, const Vector3 &p2, float radius1, f
     normalsCloseCylinder2.push_back(normalsCloseCylinder2[1]);
 
 
-    drawTriangleStrip(points, normals,colour);
-    if (radius1 > 0) drawTriangleFan(pointsCloseCylinder1, normalsCloseCylinder1,colour);
-    if (radius2 > 0) drawTriangleFan(pointsCloseCylinder2, normalsCloseCylinder2,colour);
+    drawTriangleStrip(points, normals,color);
+    if (radius1 > 0) drawTriangleFan(pointsCloseCylinder1, normalsCloseCylinder1,color);
+    if (radius2 > 0) drawTriangleFan(pointsCloseCylinder2, normalsCloseCylinder2,color);
 
-    resetMaterial(colour);
+    resetMaterial(color);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void DrawToolGL::drawCube( const float& radius, const Vec<4,float>& colour, const int& subd)
+void DrawToolGL::drawCube( const float& radius, const Vec<4,float>& color, const int& subd)
 {
     // X Axis
-    drawCylinder( Vector3(-1.0, -1.0, -1.0), Vector3(1.0, -1.0, -1.0), radius, colour, subd);
-    drawCylinder( Vector3(-1.0,  1.0, -1.0), Vector3(1.0,  1.0, -1.0), radius, colour, subd);
-    drawCylinder( Vector3(-1.0, -1.0,  1.0), Vector3(1.0, -1.0,  1.0), radius, colour, subd);
-    drawCylinder( Vector3(-1.0,  1.0,  1.0), Vector3(1.0,  1.0,  1.0), radius, colour, subd);
+    drawCylinder( Vector3(-1.0, -1.0, -1.0), Vector3(1.0, -1.0, -1.0), radius, color, subd);
+    drawCylinder( Vector3(-1.0,  1.0, -1.0), Vector3(1.0,  1.0, -1.0), radius, color, subd);
+    drawCylinder( Vector3(-1.0, -1.0,  1.0), Vector3(1.0, -1.0,  1.0), radius, color, subd);
+    drawCylinder( Vector3(-1.0,  1.0,  1.0), Vector3(1.0,  1.0,  1.0), radius, color, subd);
     // Y Axis
-    drawCylinder( Vector3(-1.0, -1.0, -1.0), Vector3(-1.0, 1.0, -1.0), radius, colour, subd);
-    drawCylinder( Vector3(-1.0, -1.0,  1.0), Vector3(-1.0, 1.0,  1.0), radius, colour, subd);
-    drawCylinder( Vector3( 1.0, -1.0, -1.0), Vector3( 1.0, 1.0, -1.0), radius, colour, subd);
-    drawCylinder( Vector3( 1.0, -1.0,  1.0), Vector3( 1.0, 1.0,  1.0), radius, colour, subd);
+    drawCylinder( Vector3(-1.0, -1.0, -1.0), Vector3(-1.0, 1.0, -1.0), radius, color, subd);
+    drawCylinder( Vector3(-1.0, -1.0,  1.0), Vector3(-1.0, 1.0,  1.0), radius, color, subd);
+    drawCylinder( Vector3( 1.0, -1.0, -1.0), Vector3( 1.0, 1.0, -1.0), radius, color, subd);
+    drawCylinder( Vector3( 1.0, -1.0,  1.0), Vector3( 1.0, 1.0,  1.0), radius, color, subd);
     // Z Axis
-    drawCylinder( Vector3(-1.0, -1.0, -1.0), Vector3(-1.0, -1.0, 1.0), radius, colour, subd);
-    drawCylinder( Vector3(-1.0,  1.0, -1.0), Vector3(-1.0,  1.0, 1.0), radius, colour, subd);
-    drawCylinder( Vector3( 1.0, -1.0, -1.0), Vector3( 1.0, -1.0, 1.0), radius, colour, subd);
-    drawCylinder( Vector3( 1.0,  1.0, -1.0), Vector3( 1.0,  1.0, 1.0), radius, colour, subd);
+    drawCylinder( Vector3(-1.0, -1.0, -1.0), Vector3(-1.0, -1.0, 1.0), radius, color, subd);
+    drawCylinder( Vector3(-1.0,  1.0, -1.0), Vector3(-1.0,  1.0, 1.0), radius, color, subd);
+    drawCylinder( Vector3( 1.0, -1.0, -1.0), Vector3( 1.0, -1.0, 1.0), radius, color, subd);
+    drawCylinder( Vector3( 1.0,  1.0, -1.0), Vector3( 1.0,  1.0, 1.0), radius, color, subd);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void DrawToolGL::drawCylinder(const Vector3& p1, const Vector3 &p2, float radius, const Vec<4,float>& colour, int subd)
+void DrawToolGL::drawCylinder(const Vector3& p1, const Vector3 &p2, float radius, const Vec<4,float>& color, int subd)
 {
-    drawCone( p1,p2,radius,radius,colour,subd);
+    drawCone( p1,p2,radius,radius,color,subd);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void DrawToolGL::drawArrow(const Vector3& p1, const Vector3 &p2, float radius, const Vec<4,float>& colour, int subd)
+void DrawToolGL::drawArrow(const Vector3& p1, const Vector3 &p2, float radius, const Vec<4,float>& color, int subd)
 {
     Vector3 p3 = p1*.2+p2*.8;
-    drawCylinder( p1,p3,radius,colour,subd);
-    drawCone( p3,p2,radius*2.5f,0,colour,subd);
+    drawCylinder( p1,p3,radius,color,subd);
+    drawCone( p3,p2,radius*2.5f,0,color,subd);
 }
 
 
-void DrawToolGL::drawArrow(const Vector3& p1, const Vector3 &p2, float radius, float coneLength, const Vec<4,float>& colour, int subd)
+void DrawToolGL::drawArrow(const Vector3& p1, const Vector3 &p2, float radius, float coneLength, const Vec<4,float>& color, int subd)
 {
     // fixed coneLength ; cone can be stretched or when its length depends on the total arrow length
 
     Vector3 a = p2 - p1;
     SReal n = a.norm();
     if( coneLength >= n )
-        drawCone( p1,p2,radius*2.5f,0,colour,subd);
+        drawCone( p1,p2,radius*2.5f,0,color,subd);
     else
     {
         a /= n; // normalizing
         Vector3 p3 = p2 - coneLength*a;
-        drawCylinder( p1,p3,radius,colour,subd);
-        drawCone( p3,p2,radius*2.5f,0,colour,subd);
+        drawCylinder( p1,p3,radius,color,subd);
+        drawCone( p3,p2,radius*2.5f,0,color,subd);
     }
 
 }
 
-void DrawToolGL::drawCross(const Vector3&p, float length, const Vec4f& colour)
+void DrawToolGL::drawCross(const Vector3&p, float length, const Vec4f& color)
 {
     std::vector<sofa::defaulttype::Vector3> bounds;
 
@@ -610,16 +610,16 @@ void DrawToolGL::drawCross(const Vector3&p, float length, const Vec4f& colour)
         bounds.push_back(p0);
         bounds.push_back(p1);
     }
-    drawLines(bounds, 1, colour);
+    drawLines(bounds, 1, color);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void DrawToolGL::drawPlus ( const float& radius, const Vec<4,float>& colour, const int& subd)
+void DrawToolGL::drawPlus ( const float& radius, const Vec<4,float>& color, const int& subd)
 {
-    drawCylinder( Vector3(-1.0, 0.0, 0.0), Vector3(1.0, 0.0, 0.0), radius, colour, subd);
-    drawCylinder( Vector3(0.0, -1.0, 0.0), Vector3(0.0, 1.0, 0.0), radius, colour, subd);
-    drawCylinder( Vector3(0.0, 0.0, -1.0), Vector3(0.0, 0.0, 1.0), radius, colour, subd);
+    drawCylinder( Vector3(-1.0, 0.0, 0.0), Vector3(1.0, 0.0, 0.0), radius, color, subd);
+    drawCylinder( Vector3(0.0, -1.0, 0.0), Vector3(0.0, 1.0, 0.0), radius, color, subd);
+    drawCylinder( Vector3(0.0, 0.0, -1.0), Vector3(0.0, 0.0, 1.0), radius, color, subd);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -835,9 +835,9 @@ void DrawToolGL::drawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
     glEnd();
 }
 
-void DrawToolGL::drawQuads(const std::vector<Vector3> &points, const Vec4f& colour)
+void DrawToolGL::drawQuads(const std::vector<Vector3> &points, const Vec4f& color)
 {
-    setMaterial(colour);
+    setMaterial(color);
     glBegin(GL_QUADS);
     {
         for (std::size_t i=0; i<points.size()/4; ++i)
@@ -848,13 +848,13 @@ void DrawToolGL::drawQuads(const std::vector<Vector3> &points, const Vec4f& colo
             const Vector3& d = points[ 4*i+3 ];
             Vector3 n = cross((b-a),(c-a));
             n.normalize();
-            internalDrawQuad(a,b,c,d,n,colour);
+            internalDrawQuad(a,b,c,d,n,color);
         }
     } glEnd();
-    resetMaterial(colour);
+    resetMaterial(color);
 }
 
-void DrawToolGL::drawQuads(const std::vector<Vector3> &points, const std::vector<Vec4f>& colours)
+void DrawToolGL::drawQuads(const std::vector<Vector3> &points, const std::vector<Vec4f>& colors)
 {
     glBegin(GL_QUADS);
     {
@@ -865,40 +865,40 @@ void DrawToolGL::drawQuads(const std::vector<Vector3> &points, const std::vector
             const Vector3& c = points[ 4*i+2 ];
             const Vector3& d = points[ 4*i+3 ];
 
-            const Vec4f& col_a = colours[ 4*i+0 ];
-            const Vec4f& col_b = colours[ 4*i+1 ];
-            const Vec4f& col_c = colours[ 4*i+2 ];
-            const Vec4f& col_d = colours[ 4*i+3 ];
+            const Vec4f& col_a = colors[ 4*i+0 ];
+            const Vec4f& col_b = colors[ 4*i+1 ];
+            const Vec4f& col_c = colors[ 4*i+2 ];
+            const Vec4f& col_d = colors[ 4*i+3 ];
 
-            Vec4f average_colour;
+            Vec4f average_color;
             for(int i=0; i<4; i++)
             {
-                average_colour[i] = (col_a[i]+col_b[i]+col_c[i]+col_d[i])*0.25f;
+                average_color[i] = (col_a[i]+col_b[i]+col_c[i]+col_d[i])*0.25f;
             }
 
             Vector3 n = cross((b-a),(c-a));
             n.normalize();
-            internalDrawQuad(a,b,c,d,n,average_colour);
+            internalDrawQuad(a,b,c,d,n,average_color);
         }
     } glEnd();
 }
 
-void DrawToolGL::drawTetrahedron(const Vector3 &p0, const Vector3 &p1, const Vector3 &p2, const Vector3 &p3, const Vec4f &colour)
+void DrawToolGL::drawTetrahedron(const Vector3 &p0, const Vector3 &p1, const Vector3 &p2, const Vector3 &p3, const Vec4f &color)
 {
-    setMaterial(colour);
+    setMaterial(color);
     glBegin(GL_TRIANGLES);
     {
-        this->internalDrawTriangle(p0,p1,p2, cross((p1-p0),(p2-p0)), colour);
-        this->internalDrawTriangle(p0,p1,p3, cross((p1-p0),(p3-p0)), colour);
-        this->internalDrawTriangle(p0,p2,p3, cross((p2-p0),(p3-p0)), colour);
-        this->internalDrawTriangle(p1,p2,p3, cross((p2-p1),(p3-p1)), colour);
+        this->internalDrawTriangle(p0,p1,p2, cross((p1-p0),(p2-p0)), color);
+        this->internalDrawTriangle(p0,p1,p3, cross((p1-p0),(p3-p0)), color);
+        this->internalDrawTriangle(p0,p2,p3, cross((p2-p0),(p3-p0)), color);
+        this->internalDrawTriangle(p1,p2,p3, cross((p2-p1),(p3-p1)), color);
     } glEnd();
-    resetMaterial(colour);
+    resetMaterial(color);
 }
 
-void DrawToolGL::drawTetrahedra(const std::vector<Vector3> &points, const Vec4f &colour)
+void DrawToolGL::drawTetrahedra(const std::vector<Vector3> &points, const Vec4f &color)
 {
-    setMaterial(colour);
+    setMaterial(color);
     glBegin(GL_TRIANGLES);
     for (std::vector<Vector3>::const_iterator it = points.begin(), end = points.end(); it != end;)
     {
@@ -907,19 +907,19 @@ void DrawToolGL::drawTetrahedra(const std::vector<Vector3> &points, const Vec4f 
         const Vector3& p2 = *(it++);
         const Vector3& p3 = *(it++);
 
-        //this->drawTetrahedron(p0,p1,p2,p3,colour); // not recommanded as it will call glBegin/glEnd <number of tetra> times
-        this->internalDrawTriangle(p0, p1, p2, cross((p1 - p0), (p2 - p0)), colour);
-        this->internalDrawTriangle(p0, p1, p3, cross((p1 - p0), (p3 - p0)), colour);
-        this->internalDrawTriangle(p0, p2, p3, cross((p2 - p0), (p3 - p0)), colour);
-        this->internalDrawTriangle(p1, p2, p3, cross((p2 - p1), (p3 - p1)), colour);
+        //this->drawTetrahedron(p0,p1,p2,p3,color); // not recommanded as it will call glBegin/glEnd <number of tetra> times
+        this->internalDrawTriangle(p0, p1, p2, cross((p1 - p0), (p2 - p0)), color);
+        this->internalDrawTriangle(p0, p1, p3, cross((p1 - p0), (p3 - p0)), color);
+        this->internalDrawTriangle(p0, p2, p3, cross((p2 - p0), (p3 - p0)), color);
+        this->internalDrawTriangle(p1, p2, p3, cross((p2 - p1), (p3 - p1)), color);
     }
     glEnd();
-    resetMaterial(colour);
+    resetMaterial(color);
 }
 
-void DrawToolGL::drawScaledTetrahedra(const std::vector<Vector3> &points, const Vec4f &colour, const float scale)
+void DrawToolGL::drawScaledTetrahedra(const std::vector<Vector3> &points, const Vec4f &color, const float scale)
 {
-    setMaterial(colour);
+    setMaterial(color);
     glBegin(GL_TRIANGLES);
     for (std::vector<Vector3>::const_iterator it = points.begin(), end = points.end(); it != end;)
     {
@@ -935,38 +935,38 @@ void DrawToolGL::drawScaledTetrahedra(const std::vector<Vector3> &points, const 
         Vector3 np2 = ((p2 - center)*scale) + center;
         Vector3 np3 = ((p3 - center)*scale) + center;
 
-        //this->drawTetrahedron(p0,p1,p2,p3,colour); // not recommanded as it will call glBegin/glEnd <number of tetra> times
-        this->internalDrawTriangle(np0, np1, np2, cross((p1 - p0), (p2 - p0)), colour);
-        this->internalDrawTriangle(np0, np1, np3, cross((p1 - p0), (p3 - p0)), colour);
-        this->internalDrawTriangle(np0, np2, np3, cross((p2 - p0), (p3 - p0)), colour);
-        this->internalDrawTriangle(np1, np2, np3, cross((p2 - p1), (p3 - p1)), colour);
+        //this->drawTetrahedron(p0,p1,p2,p3,color); // not recommanded as it will call glBegin/glEnd <number of tetra> times
+        this->internalDrawTriangle(np0, np1, np2, cross((p1 - p0), (p2 - p0)), color);
+        this->internalDrawTriangle(np0, np1, np3, cross((p1 - p0), (p3 - p0)), color);
+        this->internalDrawTriangle(np0, np2, np3, cross((p2 - p0), (p3 - p0)), color);
+        this->internalDrawTriangle(np1, np2, np3, cross((p2 - p1), (p3 - p1)), color);
     }
     glEnd();
-    resetMaterial(colour);
+    resetMaterial(color);
 }
 
 
 void DrawToolGL::drawHexahedron(const Vector3 &p0, const Vector3 &p1, const Vector3 &p2, const Vector3 &p3,
                                 const Vector3 &p4, const Vector3 &p5, const Vector3 &p6, const Vector3 &p7,
-                                const Vec4f &colour)
+                                const Vec4f &color)
 {
     //{{0,1,2,3}, {4,7,6,5}, {1,0,4,5},{1,5,6,2},  {2,6,7,3}, {0,3,7,4}}
-    setMaterial(colour);
+    setMaterial(color);
     glBegin(GL_QUADS);
     {
-        this->internalDrawQuad(p0, p1, p2, p3, cross((p1 - p0), (p2 - p0)), colour);
-        this->internalDrawQuad(p4, p7, p6, p5, cross((p7 - p5), (p6 - p5)), colour);
-        this->internalDrawQuad(p1, p0, p4, p5, cross((p0 - p1), (p4 - p1)), colour);
-        this->internalDrawQuad(p1, p5, p6, p2, cross((p5 - p1), (p6 - p1)), colour);
-        this->internalDrawQuad(p2, p6, p7, p3, cross((p6 - p2), (p7 - p2)), colour);
-        this->internalDrawQuad(p0, p3, p7, p4, cross((p3 - p0), (p7 - p0)), colour);
+        this->internalDrawQuad(p0, p1, p2, p3, cross((p1 - p0), (p2 - p0)), color);
+        this->internalDrawQuad(p4, p7, p6, p5, cross((p7 - p5), (p6 - p5)), color);
+        this->internalDrawQuad(p1, p0, p4, p5, cross((p0 - p1), (p4 - p1)), color);
+        this->internalDrawQuad(p1, p5, p6, p2, cross((p5 - p1), (p6 - p1)), color);
+        this->internalDrawQuad(p2, p6, p7, p3, cross((p6 - p2), (p7 - p2)), color);
+        this->internalDrawQuad(p0, p3, p7, p4, cross((p3 - p0), (p7 - p0)), color);
     } glEnd();
-    resetMaterial(colour);
+    resetMaterial(color);
 }
 
-void DrawToolGL::drawHexahedra(const std::vector<Vector3> &points, const Vec4f& colour)
+void DrawToolGL::drawHexahedra(const std::vector<Vector3> &points, const Vec4f& color)
 {
-    setMaterial(colour);
+    setMaterial(color);
 
     glBegin(GL_QUADS);
     for (std::vector<Vector3>::const_iterator it = points.begin(), end = points.end(); it != end;)
@@ -980,21 +980,21 @@ void DrawToolGL::drawHexahedra(const std::vector<Vector3> &points, const Vec4f& 
         const Vector3& p6 = *(it++);
         const Vector3& p7 = *(it++);
 
-        //this->drawHexahedron(p0,p1,p2,p3,p4,p5,p6,p7,colour); // not recommanded as it will call glBegin/glEnd <number of hexa> times
-        this->internalDrawQuad(p0, p1, p2, p3, cross((p1 - p0), (p2 - p0)), colour);
-        this->internalDrawQuad(p4, p7, p6, p5, cross((p7 - p5), (p6 - p5)), colour);
-        this->internalDrawQuad(p1, p0, p4, p5, cross((p0 - p1), (p4 - p1)), colour);
-        this->internalDrawQuad(p1, p5, p6, p2, cross((p5 - p1), (p6 - p1)), colour);
-        this->internalDrawQuad(p2, p6, p7, p3, cross((p6 - p2), (p7 - p2)), colour);
-        this->internalDrawQuad(p0, p3, p7, p4, cross((p3 - p0), (p7 - p0)), colour);
+        //this->drawHexahedron(p0,p1,p2,p3,p4,p5,p6,p7,color); // not recommanded as it will call glBegin/glEnd <number of hexa> times
+        this->internalDrawQuad(p0, p1, p2, p3, cross((p1 - p0), (p2 - p0)), color);
+        this->internalDrawQuad(p4, p7, p6, p5, cross((p7 - p5), (p6 - p5)), color);
+        this->internalDrawQuad(p1, p0, p4, p5, cross((p0 - p1), (p4 - p1)), color);
+        this->internalDrawQuad(p1, p5, p6, p2, cross((p5 - p1), (p6 - p1)), color);
+        this->internalDrawQuad(p2, p6, p7, p3, cross((p6 - p2), (p7 - p2)), color);
+        this->internalDrawQuad(p0, p3, p7, p4, cross((p3 - p0), (p7 - p0)), color);
     }
     glEnd();
-    resetMaterial(colour);
+    resetMaterial(color);
 }
 
-void DrawToolGL::drawScaledHexahedra(const std::vector<Vector3> &points, const Vec4f& colour, const float scale)
+void DrawToolGL::drawScaledHexahedra(const std::vector<Vector3> &points, const Vec4f& color, const float scale)
 {
-    setMaterial(colour);
+    setMaterial(color);
 
     glBegin(GL_QUADS);
     for (std::vector<Vector3>::const_iterator it = points.begin(), end = points.end(); it != end;)
@@ -1020,16 +1020,16 @@ void DrawToolGL::drawScaledHexahedra(const std::vector<Vector3> &points, const V
         Vector3 np6 = ((p6 - center)*scale) + center;
         Vector3 np7 = ((p7 - center)*scale) + center;
 
-        //this->drawHexahedron(p0,p1,p2,p3,p4,p5,p6,p7,colour); // not recommanded as it will call glBegin/glEnd <number of hexa> times
-        this->internalDrawQuad(np0, np1, np2, np3, cross((p1 - p0), (p2 - p0)), colour);
-        this->internalDrawQuad(np4, np7, np6, np5, cross((p7 - p5), (p6 - p5)), colour);
-        this->internalDrawQuad(np1, np0, np4, np5, cross((p0 - p1), (p4 - p1)), colour);
-        this->internalDrawQuad(np1, np5, np6, np2, cross((p5 - p1), (p6 - p1)), colour);
-        this->internalDrawQuad(np2, np6, np7, np3, cross((p6 - p2), (p7 - p2)), colour);
-        this->internalDrawQuad(np0, np3, np7, np4, cross((p3 - p0), (p7 - p0)), colour);
+        //this->drawHexahedron(p0,p1,p2,p3,p4,p5,p6,p7,color); // not recommanded as it will call glBegin/glEnd <number of hexa> times
+        this->internalDrawQuad(np0, np1, np2, np3, cross((p1 - p0), (p2 - p0)), color);
+        this->internalDrawQuad(np4, np7, np6, np5, cross((p7 - p5), (p6 - p5)), color);
+        this->internalDrawQuad(np1, np0, np4, np5, cross((p0 - p1), (p4 - p1)), color);
+        this->internalDrawQuad(np1, np5, np6, np2, cross((p5 - p1), (p6 - p1)), color);
+        this->internalDrawQuad(np2, np6, np7, np3, cross((p6 - p2), (p7 - p2)), color);
+        this->internalDrawQuad(np0, np3, np7, np4, cross((p3 - p0), (p7 - p0)), color);
     }
     glEnd();
-    resetMaterial(colour);
+    resetMaterial(color);
 }
 
 
@@ -1131,16 +1131,16 @@ void DrawToolGL::setLightingEnabled(bool _isAnabled)
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void DrawToolGL::setMaterial(const Vec<4,float> &colour)
+void DrawToolGL::setMaterial(const Vec<4,float> &color)
 {
-    glColor4f(colour[0],colour[1],colour[2],colour[3]);
-    glMaterialfv (GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, &colour[0]);
+    glColor4f(color[0],color[1],color[2],color[3]);
+    glMaterialfv (GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, &color[0]);
     static const float emissive[4] = { 0.0f, 0.0f, 0.0f, 0.0f};
     static const float specular[4] = { 1.0f, 1.0f, 1.0f, 1.0f};
     glMaterialfv (GL_FRONT_AND_BACK, GL_EMISSION, emissive);
     glMaterialfv (GL_FRONT_AND_BACK, GL_SPECULAR, specular);
     glMaterialf  (GL_FRONT_AND_BACK, GL_SHININESS, 20);
-    if (colour[3] < 1)
+    if (color[3] < 1)
     {
         glEnable(GL_BLEND);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -1155,9 +1155,9 @@ void DrawToolGL::setMaterial(const Vec<4,float> &colour)
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void DrawToolGL::resetMaterial(const Vec<4,float> &colour)
+void DrawToolGL::resetMaterial(const Vec<4,float> &color)
 {
-    if (colour[3] < 1)
+    if (color[3] < 1)
     {
         resetMaterial();
     }

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.h
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.h
@@ -55,16 +55,16 @@ public:
     virtual void drawPoint(const Vector3 &p, const Vec4f &c);
     //normal on a point is useless
     virtual void drawPoint(const Vector3 &p, const Vector3 &n, const Vec4f &c);
-    virtual void drawPoints(const std::vector<Vector3> &points, float size,  const Vec4f& colour);
-    virtual void drawPoints(const std::vector<Vector3> &points, float size, const std::vector<Vec4f>& colour);
+    virtual void drawPoints(const std::vector<Vector3> &points, float size,  const Vec4f& color);
+    virtual void drawPoints(const std::vector<Vector3> &points, float size, const std::vector<Vec4f>& color);
 
-    virtual void drawLine(const Vector3 &p1, const Vector3 &p2, const Vec4f& colour);
-    virtual void drawLines(const std::vector<Vector3> &points, float size, const Vec4f& colour);
-    virtual void drawLines(const std::vector<Vector3> &points, float size, const std::vector<Vec4f>& colours);
-    virtual void drawLines(const std::vector<Vector3> &points, const std::vector< Vec2i > &index, float size, const Vec4f& colour);
+    virtual void drawLine(const Vector3 &p1, const Vector3 &p2, const Vec4f& color);
+    virtual void drawLines(const std::vector<Vector3> &points, float size, const Vec4f& color);
+    virtual void drawLines(const std::vector<Vector3> &points, float size, const std::vector<Vec4f>& colors);
+    virtual void drawLines(const std::vector<Vector3> &points, const std::vector< Vec2i > &index, float size, const Vec4f& color);
 
-    virtual void drawLineStrip(const std::vector<Vector3> &points, float size, const Vec4f& colour);
-    virtual void drawLineLoop(const std::vector<Vector3> &points, float size, const Vec4f& colour);
+    virtual void drawLineStrip(const std::vector<Vector3> &points, float size, const Vec4f& color);
+    virtual void drawLineLoop(const std::vector<Vector3> &points, float size, const Vec4f& color);
 
     virtual void drawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
             const Vector3 &normal);
@@ -76,48 +76,48 @@ public:
     virtual void drawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
             const Vector3 &normal1, const Vector3 &normal2, const Vector3 &normal3,
             const Vec4f &c1, const Vec4f &c2, const Vec4f &c3);
-    virtual void drawTriangles(const std::vector<Vector3> &points, const Vec4f& colour);
+    virtual void drawTriangles(const std::vector<Vector3> &points, const Vec4f& color);
     virtual void drawTriangles(const std::vector<Vector3> &points,
-            const std::vector< Vec4f > &colour);
-    virtual void drawTriangles(const std::vector<Vector3> &points, const Vector3& normal, const Vec4f& colour);
+            const std::vector< Vec4f > &color);
+    virtual void drawTriangles(const std::vector<Vector3> &points, const Vector3& normal, const Vec4f& color);
     virtual void drawTriangles(const std::vector<Vector3> &points,
             const std::vector< Vec3i > &index,
             const std::vector<Vector3>  &normal,
-            const Vec4f& colour);
+            const Vec4f& color);
     virtual void drawTriangles(const std::vector<Vector3> &points,
             const std::vector<Vector3>  &normal,
-            const std::vector< Vec4f > &colour);
+            const std::vector< Vec4f > &color);
 
     virtual void drawTriangleStrip(const std::vector<Vector3> &points,
             const std::vector<Vector3>  &normal,
-            const Vec4f& colour);
+            const Vec4f& color);
 
     virtual void drawTriangleFan(const std::vector<Vector3> &points,
             const std::vector<Vector3>  &normal,
-            const Vec4f& colour);
+            const Vec4f& color);
 
     virtual void drawFrame(const Vector3& position, const Quaternion &orientation, const Vec3f &size);
-    virtual void drawFrame(const Vector3& position, const Quaternion &orientation, const Vec3f &size, const Vec4f &colour);
+    virtual void drawFrame(const Vector3& position, const Quaternion &orientation, const Vec3f &size, const Vec4f &color);
 
-    virtual void drawSpheres (const std::vector<Vector3> &points, const std::vector<float>& radius, const Vec4f& colour);
-    virtual void drawSpheres (const std::vector<Vector3> &points, float radius, const Vec4f& colour);
-    virtual void drawFakeSpheres(const std::vector<Vector3> &points, const std::vector<float>& radius, const Vec4f& colour);
-    virtual void drawFakeSpheres(const std::vector<Vector3> &points, float radius, const Vec4f& colour);
+    virtual void drawSpheres (const std::vector<Vector3> &points, const std::vector<float>& radius, const Vec4f& color);
+    virtual void drawSpheres (const std::vector<Vector3> &points, float radius, const Vec4f& color);
+    virtual void drawFakeSpheres(const std::vector<Vector3> &points, const std::vector<float>& radius, const Vec4f& color);
+    virtual void drawFakeSpheres(const std::vector<Vector3> &points, float radius, const Vec4f& color);
 
-    virtual void drawCone    (const Vector3& p1, const Vector3 &p2, float radius1, float radius2, const Vec4f& colour, int subd=16);
+    virtual void drawCone    (const Vector3& p1, const Vector3 &p2, float radius1, float radius2, const Vec4f& color, int subd=16);
 
-    virtual void drawCube    (const float& radius, const Vec4f& colour, const int& subd=16);
+    virtual void drawCube    (const float& radius, const Vec4f& color, const int& subd=16);
 
-    virtual void drawCylinder(const Vector3& p1, const Vector3 &p2, float radius, const Vec4f& colour,  int subd=16);
+    virtual void drawCylinder(const Vector3& p1, const Vector3 &p2, float radius, const Vec4f& color,  int subd=16);
 
-    virtual void drawCapsule(const Vector3& p1, const Vector3 &p2, float radius, const Vec4f& colour,  int subd=16);
+    virtual void drawCapsule(const Vector3& p1, const Vector3 &p2, float radius, const Vec4f& color,  int subd=16);
 
-    virtual void drawArrow   (const Vector3& p1, const Vector3 &p2, float radius, const Vec4f& colour,  int subd=16);
-    virtual void drawArrow   (const Vector3& p1, const Vector3 &p2, float radius, float coneLength, const Vec4f& colour,  int subd=16);
+    virtual void drawArrow   (const Vector3& p1, const Vector3 &p2, float radius, const Vec4f& color,  int subd=16);
+    virtual void drawArrow   (const Vector3& p1, const Vector3 &p2, float radius, float coneLength, const Vec4f& color,  int subd=16);
 
-    virtual void drawCross(const Vector3&p, float length, const Vec4f& colour);
+    virtual void drawCross(const Vector3&p, float length, const Vec4f& color);
 
-    virtual void drawPlus    (const float& radius, const Vec4f& colour, const int& subd=16);
+    virtual void drawPlus    (const float& radius, const Vec4f& color, const int& subd=16);
 
     virtual void drawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,const Vector3 &p4,
             const Vector3 &normal);
@@ -129,18 +129,18 @@ public:
     virtual void drawQuad(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,const Vector3 &p4,
             const Vector3 &normal1, const Vector3 &normal2, const Vector3 &normal3, const Vector3 &normal4,
             const Vec4f &c1, const Vec4f &c2, const Vec4f &c3, const Vec4f &c4);
-    virtual void drawQuads(const std::vector<Vector3> &points, const Vec4f& colour) ;
-    virtual void drawQuads(const std::vector<Vector3> &points, const std::vector<Vec4f>& colours);
+    virtual void drawQuads(const std::vector<Vector3> &points, const Vec4f& color) ;
+    virtual void drawQuads(const std::vector<Vector3> &points, const std::vector<Vec4f>& colors);
 
 
-    virtual void drawTetrahedron(const Vector3 &p0, const Vector3 &p1, const Vector3 &p2, const Vector3 &p3, const Vec4f &colour);
-    virtual void drawTetrahedra(const std::vector<Vector3> &points, const Vec4f& colour);
-    virtual void drawScaledTetrahedra(const std::vector<Vector3> &points, const Vec4f& colour, const float scale);
+    virtual void drawTetrahedron(const Vector3 &p0, const Vector3 &p1, const Vector3 &p2, const Vector3 &p3, const Vec4f &color);
+    virtual void drawTetrahedra(const std::vector<Vector3> &points, const Vec4f& color);
+    virtual void drawScaledTetrahedra(const std::vector<Vector3> &points, const Vec4f& color, const float scale);
 
     virtual void drawHexahedron(const Vector3 &p0, const Vector3 &p1, const Vector3 &p2, const Vector3 &p3,
-        const Vector3 &p4, const Vector3 &p5, const Vector3 &p6, const Vector3 &p7, const Vec4f &colour);
-    virtual void drawHexahedra(const std::vector<Vector3> &points, const Vec4f& colour);
-    virtual void drawScaledHexahedra(const std::vector<Vector3> &points, const Vec4f& colour, const float scale);
+        const Vector3 &p4, const Vector3 &p5, const Vector3 &p6, const Vector3 &p7, const Vec4f &color);
+    virtual void drawHexahedra(const std::vector<Vector3> &points, const Vec4f& color);
+    virtual void drawScaledHexahedra(const std::vector<Vector3> &points, const Vec4f& color, const float scale);
 
     virtual void drawSphere( const Vector3 &p, float radius);
     virtual void drawEllipsoid(const Vector3 &p, const Vector3 &radii);
@@ -153,9 +153,9 @@ public:
 
     virtual void clear();
 
-    virtual void setMaterial(const Vec4f &colour);
+    virtual void setMaterial(const Vec4f &color);
 
-    virtual void resetMaterial(const Vec4f &colour);
+    virtual void resetMaterial(const Vec4f &color);
     virtual void resetMaterial();
 
     virtual void pushMatrix();
@@ -196,7 +196,7 @@ protected:
     virtual void internalDrawPoint(const Vector3 &p, const Vec4f &c);
     virtual void internalDrawPoint(const Vector3 &p, const Vector3 &n, const Vec4f &c);
 
-    virtual void internalDrawLine(const Vector3 &p1, const Vector3 &p2, const Vec4f& colour);
+    virtual void internalDrawLine(const Vector3 &p1, const Vector3 &p2, const Vec4f& color);
 
     virtual void internalDrawTriangle(const Vector3 &p1,const Vector3 &p2,const Vector3 &p3,
             const Vector3 &normal);

--- a/SofaKernel/modules/SofaBaseTopology/HexahedronSetGeometryAlgorithms.h
+++ b/SofaKernel/modules/SofaBaseTopology/HexahedronSetGeometryAlgorithms.h
@@ -67,7 +67,7 @@ protected:
         , d_showHexaIndices(initData(&d_showHexaIndices, (bool)false, "showHexaIndices", "Debug : view Hexa indices"))
         , d_drawHexahedra(initData(&d_drawHexahedra, false, "drawHexahedra", "if true, draw the Hexahedron in the topology"))
         , d_drawScaleHexahedra(initData(&d_drawScaleHexahedra, float(1.0), "drawScaleHexahedra", "Scale of the hexahedra (between 0 and 1; if <1.0, it produces gaps between the hexahedra)"))
-        , d_drawColorHexahedra(initData(&d_drawColorHexahedra, sofa::defaulttype::Vec3f(1.0f,0.5f,0.0f), "drawColorHexahedra", "RGB code color used to draw hexahedra."))
+        , d_drawColorHexahedra(initData(&d_drawColorHexahedra, sofa::helper::types::RGBAColor(1.0f,0.5f,0.0f, 1.0f), "drawColorHexahedra", "RGB code color used to draw hexahedra."))
     {
         core::objectmodel::Base::addAlias(&d_drawHexahedra, "drawHexa");
         core::objectmodel::Base::addAlias(&d_drawHexahedra, "drawHexahedron");
@@ -160,7 +160,7 @@ protected:
     Data<bool> d_showHexaIndices; ///< Debug : view Hexa indices
     Data<bool> d_drawHexahedra; ///< if true, draw the Hexahedron in the topology
     Data<float> d_drawScaleHexahedra; ///< Scale of the hexahedra (between 0 and 1; if <1.0, it produces gaps between the hexahedra)
-    Data<sofa::defaulttype::Vec3f> d_drawColorHexahedra; ///< RGB code color used to draw hexahedra.
+    Data<sofa::helper::types::RGBAColor> d_drawColorHexahedra; ///< RGB code color used to draw hexahedra.
 	/// include cubature points
 	NumericalIntegrationDescriptor<Real,3> hexahedronNumericalIntegration;
 };

--- a/SofaKernel/modules/SofaBaseTopology/HexahedronSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/HexahedronSetGeometryAlgorithms.inl
@@ -840,9 +840,6 @@ void HexahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visual
     {
 
         const VecCoord& coords =(this->object->read(core::ConstVecCoordId::position())->getValue());
-        const sofa::defaulttype::Vec3f& color = d_drawColorHexahedra.getValue();
-        sofa::defaulttype::Vec4f color4(color[0], color[1], color[2], 1.0);
-
         float scale = this->getIndicesScale();
 
         //for hexa:
@@ -867,7 +864,7 @@ void HexahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visual
             positions.push_back(center);
         }
 
-        vparams->drawTool()->draw3DText_Indices(positions, scale, color4);
+        vparams->drawTool()->draw3DText_Indices(positions, scale, d_drawColorHexahedra.getValue());
     }
 
 
@@ -879,11 +876,7 @@ void HexahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visual
 
         const sofa::helper::vector<Hexahedron> &hexaArray = this->m_topology->getHexahedra();
 
-        const sofa::defaulttype::Vec3f& color = d_drawColorHexahedra.getValue();
-        sofa::defaulttype::Vec4f color4(color[0], color[1], color[2], 1.0f);
-
         const VecCoord& coords =(this->object->read(core::ConstVecCoordId::position())->getValue());
-
         sofa::helper::vector <sofa::defaulttype::Vector3> hexaCoords;
 
         for (size_t i = 0; i<hexaArray.size(); i++)
@@ -901,13 +894,12 @@ void HexahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visual
         const float& scale = d_drawScaleHexahedra.getValue();
 
         if(scale >= 1.0 && scale < 0.001)
-            vparams->drawTool()->drawHexahedra(hexaCoords, color4);
+            vparams->drawTool()->drawHexahedra(hexaCoords, d_drawColorHexahedra.getValue());
         else
-            vparams->drawTool()->drawScaledHexahedra(hexaCoords, color4, scale);
+            vparams->drawTool()->drawScaledHexahedra(hexaCoords, d_drawColorHexahedra.getValue(), scale);
 
         if (vparams->displayFlags().getShowWireFrame())
             vparams->drawTool()->setPolygonMode(0, false);
-           
     }
 }
 

--- a/SofaKernel/modules/SofaBaseTopology/PointSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/PointSetGeometryAlgorithms.inl
@@ -69,7 +69,11 @@ template <class DataTypes>
 float PointSetGeometryAlgorithms< DataTypes >::getIndicesScale() const
 {
     const sofa::defaulttype::BoundingBox& bbox = this->getContext()->f_bbox.getValue();
-    return (float)((bbox.maxBBox() - bbox.minBBox()).norm() * d_showIndicesScale.getValue());
+    float bbDiff = (bbox.maxBBox() - bbox.minBBox()).norm();
+    if (std::isinf(bbDiff))
+        return d_showIndicesScale.getValue();
+    else
+        return bbDiff * d_showIndicesScale.getValue();
 }
 
 

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetGeometryAlgorithms.h
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetGeometryAlgorithms.h
@@ -62,7 +62,7 @@ protected:
         : EdgeSetGeometryAlgorithms<DataTypes>()
         , showQuadIndices(core::objectmodel::Base::initData(&showQuadIndices, (bool) false, "showQuadIndices", "Debug : view Quad indices"))
         , _drawQuads(core::objectmodel::Base::initData(&_drawQuads, false, "drawQuads","if true, draw the quads in the topology"))
-        , _drawColor(initData(&_drawColor, sofa::defaulttype::Vec3f(0.0f,0.4f,0.4f), "drawColorQuads", "RGB code color used to draw quads."))
+        , _drawColor(initData(&_drawColor, sofa::helper::types::RGBAColor(0.0f,0.4f,0.4f,1.0f), "drawColorQuads", "RGB code color used to draw quads."))
     { }
 
     virtual ~QuadSetGeometryAlgorithms() {}
@@ -113,7 +113,7 @@ public:
 protected:
     Data<bool> showQuadIndices; ///< Debug : view Quad indices
     Data<bool> _drawQuads; ///< if true, draw the quads in the topology
-    Data<sofa::defaulttype::Vec3f> _drawColor; ///< RGB code color used to draw quads.
+    Data<sofa::helper::types::RGBAColor> _drawColor; ///< RGB code color used to draw quads.
 
 };
 

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetGeometryAlgorithms.inl
@@ -355,8 +355,11 @@ void QuadSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
     {
 
         const VecCoord& coords =(this->object->read(core::ConstVecCoordId::position())->getValue());
-        const sofa::defaulttype::Vec3f& color = _drawColor.getValue();
-        defaulttype::Vec4f color4(color[0] - 0.2f, color[1] - 0.2f, color[2] - 0.2f, 1.0);
+        sofa::helper::types::RGBAColor color = _drawColor.getValue();
+        color[0] -= 0.2f;
+        color[1] -= 0.2f;
+        color[2] -= 0.2f;
+
         float scale = this->getIndicesScale();
 
         //for quads:
@@ -378,7 +381,7 @@ void QuadSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
             positions.push_back(center);
 
         }
-        vparams->drawTool()->draw3DText_Indices(positions, scale, color4);
+        vparams->drawTool()->draw3DText_Indices(positions, scale, color);
     }
 
 
@@ -390,9 +393,6 @@ void QuadSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
         if (!quadArray.empty()) // Draw Quad surfaces
         {
             const VecCoord& coords =(this->object->read(core::ConstVecCoordId::position())->getValue());
-            const sofa::defaulttype::Vec3f& color = _drawColor.getValue();
-            defaulttype::Vec4f color4(color[0], color[1], color[2], 1.0f);
-
             { // drawing quads
                 std::vector<defaulttype::Vector3> pos;
                 pos.reserve(quadArray.size()*4u);
@@ -403,13 +403,16 @@ void QuadSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
                     {
                         pos.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[q[j]])));
                     }
-                }
-                vparams->drawTool()->drawQuads(pos, color4);
+                vparams->drawTool()->drawQuads(pos, _drawColor.getValue());
             }
 
             { // drawing edges
                 const sofa::helper::vector<Edge> &edgeArray = this->m_topology->getEdges();
-                const sofa::defaulttype::Vec4f edge_color(color[0]-0.2f, color[1]-0.2f, color[2]-0.2f,1.0f);
+                sofa::helper::types::RGBAColor edge_color = _drawColor.getValue();
+                edge_color[0] -= 0.2f;
+                edge_color[1] -= 0.2f;
+                edge_color[2] -= 0.2f;
+
                 std::vector<defaulttype::Vector3> pos;
                 pos.reserve(edgeArray.size()*2u);
 

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetGeometryAlgorithms.inl
@@ -399,10 +399,21 @@ void QuadSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
                 for (size_t i=0u; i< quadArray.size(); i++)
                 {
                     const Quad& q = quadArray[i];
+
+                    defaulttype::Vector3 bary = defaulttype::Vector3(0.0, 0.0, 0.0);
+                    std::vector<defaulttype::Vector3> tmpPos;
+                    tmpPos.resize(4);
+
                     for (unsigned int j = 0; j<4; j++)
                     {
-                        pos.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[q[j]])));
+                        tmpPos[j] = defaulttype::Vector3(DataTypes::getCPos(coords[q[j]]));
+                        bary += tmpPos[j];
                     }
+                    bary /= 4;
+
+                    for (unsigned int j = 0; j<4; j++)
+                        pos.push_back(bary*0.1 + tmpPos[j]*0.9);
+                }
                 vparams->drawTool()->drawQuads(pos, _drawColor.getValue());
             }
 

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetGeometryAlgorithms.h
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetGeometryAlgorithms.h
@@ -73,7 +73,7 @@ protected:
         , d_showTetrahedraIndices (initData(&d_showTetrahedraIndices, (bool) false, "showTetrahedraIndices", "Debug : view Tetrahedrons indices"))
         , d_drawTetrahedra(initData(&d_drawTetrahedra, false, "drawTetrahedra","if true, draw the tetrahedra in the topology"))
         , d_drawScaleTetrahedra(initData(&d_drawScaleTetrahedra, (float) 1.0, "drawScaleTetrahedra", "Scale of the terahedra (between 0 and 1; if <1.0, it produces gaps between the tetrahedra)"))
-        , d_drawColorTetrahedra(initData(&d_drawColorTetrahedra, sofa::defaulttype::Vec4f(1.0f,1.0f,0.0f,1.0f), "drawColorTetrahedra", "RGBA code color used to draw tetrahedra."))
+        , d_drawColorTetrahedra(initData(&d_drawColorTetrahedra, sofa::helper::types::RGBAColor(1.0f,1.0f,0.0f,1.0f), "drawColorTetrahedra", "RGBA code color used to draw tetrahedra."))
     {
         core::objectmodel::Base::addAlias(&d_showTetrahedraIndices, "showTetrasIndices");
         core::objectmodel::Base::addAlias(&d_drawTetrahedra, "drawTetra");
@@ -141,7 +141,7 @@ protected:
     Data<bool> d_showTetrahedraIndices; ///< Debug : view Tetrahedrons indices
     Data<bool> d_drawTetrahedra; ///< if true, draw the tetrahedra in the topology
     Data<float> d_drawScaleTetrahedra; ///< Scale of the terahedra (between 0 and 1; if <1.0, it produces gaps between the tetrahedra)
-    Data<sofa::defaulttype::Vec4f> d_drawColorTetrahedra; ///< RGBA code color used to draw tetrahedra.
+    Data<sofa::helper::types::RGBAColor> d_drawColorTetrahedra; ///< RGBA code color used to draw tetrahedra.
     /// include cubature points
     NumericalIntegrationDescriptor<Real,4> tetrahedronNumericalIntegration;
 };

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetGeometryAlgorithms.h
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetGeometryAlgorithms.h
@@ -74,7 +74,7 @@ protected:
         ,initializedCubatureTables(false)
         ,showTriangleIndices (initData(&showTriangleIndices, (bool) false, "showTriangleIndices", "Debug : view Triangle indices"))
         , _draw(initData(&_draw, false, "drawTriangles","if true, draw the triangles in the topology"))
-        , _drawColor(initData(&_drawColor, sofa::defaulttype::Vec4f(0.2f,1.0f,1.0f,1.0f), "drawColorTriangles", "RGBA code color used to draw edges."))
+        , _drawColor(initData(&_drawColor, sofa::helper::types::RGBAColor(0.3f,0.5f,0.8f,1.0f), "drawColorTriangles", "RGBA code color used to draw edges."))
         , _drawNormals(initData(&_drawNormals, false, "drawNormals","if true, draw the triangles in the topology"))
         , _drawNormalLength (initData(&_drawNormalLength, (SReal)10, "drawNormalLength", "Fiber length visualisation."))
         , p_recomputeTrianglesOrientation(initData(&p_recomputeTrianglesOrientation, false, "recomputeTrianglesOrientation","if true, will recompute triangles orientation according to normals."))
@@ -285,7 +285,7 @@ public:
 protected:
     Data<bool> showTriangleIndices; ///< Debug : view Triangle indices
     Data<bool> _draw; ///< if true, draw the triangles in the topology
-    Data<sofa::defaulttype::Vec4f> _drawColor; ///< RGBA code color used to draw edges.
+    Data<sofa::helper::types::RGBAColor> _drawColor; ///< RGBA code color used to draw triangles.
     Data<bool> _drawNormals; ///< if true, draw the triangles in the topology
     Data <SReal> _drawNormalLength; ///< Fiber length visualisation.
     Data<bool> p_recomputeTrianglesOrientation; ///< if true, will recompute triangles orientation according to normals.

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetGeometryAlgorithms.inl
@@ -2430,15 +2430,24 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
 
             {//   Draw Triangles
                 std::vector<defaulttype::Vector3> pos;
+                pos.reserve(triangleArray.size()*3);
                 for (size_t i = 0; i<triangleArray.size(); i++)
                 {
                     const Triangle& t = triangleArray[i];
 
+                    defaulttype::Vector3 bary = defaulttype::Vector3(0.0, 0.0, 0.0);
+                    std::vector<defaulttype::Vector3> tmpPos;
+                    tmpPos.resize(3);
+
                     for (unsigned int j = 0; j<3; j++)
                     {
-                        pos.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[t[j]])));
-
+                        tmpPos[j] = defaulttype::Vector3(DataTypes::getCPos(coords[t[j]]));
+                        bary += tmpPos[j];
                     }
+                    bary /= 3;
+
+                    for (unsigned int j = 0; j<3; j++)
+                        pos.push_back(bary*0.1 + tmpPos[j]*0.9);
                 }
                 vparams->drawTool()->drawTriangles(pos,_drawColor.getValue());
             }
@@ -2483,7 +2492,6 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
         const sofa::helper::vector<Triangle> &triangleArray = this->m_topology->getTriangles();
         size_t nbrTtri = triangleArray.size();
 
-        Coord point2;
         sofa::defaulttype::Vec4f color;
         SReal normalLength = _drawNormalLength.getValue();
 

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetGeometryAlgorithms.inl
@@ -2515,7 +2515,6 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
                 color[j] = (float)fabs(normal[j]);
 
             vertices.push_back(center);
-            colors.push_back(color);
             vertices.push_back(point2);
             colors.push_back(color);
         }

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetGeometryAlgorithms.inl
@@ -2395,7 +2395,6 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
     if (showTriangleIndices.getValue())
     {
         const VecCoord& coords =(this->object->read(core::ConstVecCoordId::position())->getValue());
-        const sofa::defaulttype::Vec4f& color = _drawColor.getValue();
         float scale = this->getIndicesScale();
 
         //for triangles:
@@ -2416,7 +2415,7 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
             positions.push_back(center);
 
         }
-        vparams->drawTool()->draw3DText_Indices(positions, scale, color);
+        vparams->drawTool()->draw3DText_Indices(positions, scale, _drawColor.getValue());
     }
 
 
@@ -2428,8 +2427,6 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
         if (!triangleArray.empty()) // Draw triangle surfaces
         {
             const VecCoord& coords =(this->object->read(core::ConstVecCoordId::position())->getValue());
-
-            const sofa::defaulttype::Vec4f& color = _drawColor.getValue();
 
             {//   Draw Triangles
                 std::vector<defaulttype::Vector3> pos;
@@ -2443,7 +2440,7 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
 
                     }
                 }
-                vparams->drawTool()->drawTriangles(pos,color);
+                vparams->drawTool()->drawTriangles(pos,_drawColor.getValue());
             }
 
 
@@ -2470,7 +2467,11 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
                         }
                     }
                 }
-                vparams->drawTool()->drawLines(pos,1.0f,color);
+
+                sofa::helper::types::RGBAColor colorL = _drawColor.getValue();
+                for (auto& c: colorL)
+                    c /= 2;
+                vparams->drawTool()->drawLines(pos, 1.0f, colorL);
             }
         }
     }
@@ -2485,8 +2486,6 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
         Coord point2;
         sofa::defaulttype::Vec4f color;
         SReal normalLength = _drawNormalLength.getValue();
-
-        vparams->drawTool()->setLightingEnabled(false);
 
         sofa::helper::vector<sofa::defaulttype::Vector3> vertices;
         sofa::helper::vector<sofa::defaulttype::Vec4f> colors;
@@ -2505,7 +2504,7 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
             sofa::defaulttype::Vec3d point2 = center + normal*normalLength;
 
             for(unsigned int j=0; j<3; j++)
-                color[j] = (float)fabs (normal[j]);
+                color[j] = (float)fabs(normal[j]);
 
             vertices.push_back(center);
             colors.push_back(color);


### PR DESCRIPTION
- Update: Set drawColor as Data<RGBAColor> for topology debug drawing.
- Update: triangle and Quad drawing to display them a little smaller to better see the geometry structure.
- Fix: drawing scale indices could be Inf.
- Fix: normal color drawing and check buffer sizes in DrawTool
- Update: replace word colour by color to match openGL spelling in DrawTool

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
