### PR TITLE
[SofaBaseTopology] Change triangles orientation in tetrahedron

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/MeshTopology.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/MeshTopology.cpp
@@ -255,26 +255,22 @@ void MeshTopology::TriangleUpdate::doUpdate()
     Triangle tr;
     unsigned int triangleIndex;
     unsigned int v[3],val;
+    const unsigned int trianglesInTetrahedronArray[4][3]= {{0,2,1}, {0,1,3}, {1,2,3}, {0,3,2}};
     /// create the m_edge array at the same time than it fills the m_trianglesInTetrahedron array
     for (unsigned int i = 0; i < tetrahedra.size(); ++i)
     {
         const Tetra &t=topology->seqTetrahedra.getValue()[i];
-        for (unsigned int j=0; j<4; ++j)
+        for (TriangleID j=0; j<4; ++j)
         {
-            if (j%2)
-            {
-                v[0]=t[(j+1)%4]; v[1]=t[(j+2)%4]; v[2]=t[(j+3)%4];
-            }
-            else
-            {
-                v[0]=t[(j+1)%4]; v[2]=t[(j+2)%4]; v[1]=t[(j+3)%4];
-            }
-            //		std::sort(v,v+2);
+            for (PointID k=0; k<3; ++k)
+                v[k] = t[trianglesInTetrahedronArray[j][k]];
+
             // sort v such that v[0] is the smallest one
             while ((v[0]>v[1]) || (v[0]>v[2]))
             {
                 val=v[0]; v[0]=v[1]; v[1]=v[2]; v[2]=val;
             }
+
             // check if a triangle with an opposite orientation already exists
             tr=Triangle(v[0],v[2],v[1]);
             itt=triangleMap.find(tr);
@@ -286,16 +282,10 @@ void MeshTopology::TriangleUpdate::doUpdate()
                 triangleMap[tr]=triangleIndex;
                 seqTriangles.push_back(tr);
             }
-//            else
-//            {
-//                triangleIndex=(*itt).second;
-//            }
-            //m_trianglesInTetrahedron[i][j]=triangleIndex;
         }
     }
 
     topology->seqTriangles.endEdit();
-
 }
 
 MeshTopology::QuadUpdate::QuadUpdate(MeshTopology *t)

--- a/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/TetrahedronSetTopology_test.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/TetrahedronSetTopology_test.cpp
@@ -170,7 +170,7 @@ bool TetrahedronSetTopology_test::testTriangleBuffers()
     // check triangle created element
     TetrahedronSetTopologyContainer::Triangle triangle = topoCon->getTriangle(0);
     EXPECT_EQ(triangle[0], 2);
-    EXPECT_EQ(triangle[1], 25);
+    EXPECT_EQ(triangle[1], 22);
     EXPECT_EQ(triangle[2], 11);
 
 
@@ -185,7 +185,7 @@ bool TetrahedronSetTopology_test::testTriangleBuffers()
 
     // check TetrahedraAroundTriangle buffer element for this file
     EXPECT_EQ(elemATriangle[0], 0);
-    EXPECT_EQ(elemATriangle[1], 3);
+    EXPECT_EQ(elemATriangle[1], 1);
 
 
     // check TrianglesInTetrahedron buffer acces
@@ -199,7 +199,7 @@ bool TetrahedronSetTopology_test::testTriangleBuffers()
     for (size_t i = 0; i < triangleInElem.size(); i++)
         EXPECT_EQ(triangleInElem[i], triangleInElemM[i]);
 
-    sofa::helper::fixed_array<int, 4> triangleInElemTruth(0, 1, 2, 3);
+    sofa::helper::fixed_array<int, 4> triangleInElemTruth(2, 3, 1, 0);
     for (size_t i = 0; i<triangleInElemTruth.size(); ++i)
         EXPECT_EQ(triangleInElem[i], triangleInElemTruth[i]);
 

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
@@ -43,7 +43,7 @@ int TetrahedronSetTopologyContainerClass = core::RegisterObject("Tetrahedron set
 
 const unsigned int edgesInTetrahedronArray[6][2] = {{0,1}, {0,2}, {0,3}, {1,2}, {1,3}, {2,3}};
 ///convention triangles in tetra (orientation interior)
-const unsigned int trianglesInTetrahedronArray[4][3]= {{1,2,3}, {0,3,2}, {1,3,0},{0,2,1}};
+const unsigned int trianglesInTetrahedronArray[4][3]= {{0,2,1}, {0,1,3}, {1,2,3}, {0,3,2}};
 
 
 TetrahedronSetTopologyContainer::TetrahedronSetTopologyContainer()
@@ -262,22 +262,11 @@ void TetrahedronSetTopologyContainer::createTriangleSetArray()
     {
         const Tetrahedron &t = m_tetrahedron[i];
 
-        for (PointID j=0; j<4; ++j)
+        for (TriangleID j=0; j<4; ++j)
         {
             PointID v[3];
-
-            if (j%2)
-            {
-                v[0]=t[(j+1)%4];
-                v[1]=t[(j+2)%4];
-                v[2]=t[(j+3)%4];
-            }
-            else
-            {
-                v[0]=t[(j+1)%4];
-                v[2]=t[(j+2)%4];
-                v[1]=t[(j+3)%4];
-            }
+            for (PointID k=0; k<3; ++k)
+                v[k] = t[trianglesInTetrahedronArray[j][k]];
 
             // sort v such that v[0] is the smallest one
             while ((v[0]>v[1]) || (v[0]>v[2]))


### PR DESCRIPTION
Right now for a tetrahedron: [P0, P1, P2, P3] (see picture below)
The 4 triangles saved in the tetrahedron are:
- T0: [P1, P3, P2]
- T1: [P2, P3, P0]
- T2: [P3, P1, P0]
- T3: [P0, P1, P2]

This means the 4 triangles are clockwised oriented and thus their normals are going inside the tetrahedron. If there is a special reason for that I couldn't find it in the doc. 

![image](https://user-images.githubusercontent.com/21199245/50616906-cf072980-0eea-11e9-8bf0-72a4d2d584d7.png)

As Gmsh nice ascii picture (from gmsh full doc) and the 2nd picture suggest. I changed to have counter-clockwise orientation so triangles on borders are by default well oriented to have normals going out.

Then, T0 being the 2D plan [u,v], T1 sharing vector u and then T2 and T3 to close the tetrahedron
So new triangles are:
- T0: [P0, P2, P1]
- T1: [P0, P1, P3]
- T2: [P1, P2, P3]
- T3: [P0, P3, P2]

![image](https://user-images.githubusercontent.com/21199245/50616994-4937ae00-0eeb-11e9-9aca-87385530a7ea.png)








______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
