### PR TITLE
FIX: wrong paths of installed headers in SofaBaseMechanics

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/CMakeLists.txt
+++ b/SofaKernel/modules/SofaBaseMechanics/CMakeLists.txt
@@ -74,11 +74,5 @@ add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} SofaBaseTopology)
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-DSOFA_BUILD_BASE_MECHANICS")
 
-## Hand-crafted install rules for the headers, to preserve the directory structure
-foreach(HEADER ${HEADER_FILES})
-    string(REGEX MATCH "(.*)[/\\]" DIR ${HEADER})
-    install(FILES ${HEADER} DESTINATION "include/${PROJECT_NAME}/${DIR}")
-endforeach(HEADER HEADERS)
-
 ## Will create duplicates of SofaBaseMechanics/BarycentricMappers/*.{h,inl} in SofaBaseMechanics/
 sofa_install_targets(SofaBase ${PROJECT_NAME} ${PROJECT_NAME})

--- a/SofaKernel/modules/SofaBaseMechanics/CMakeLists.txt
+++ b/SofaKernel/modules/SofaBaseMechanics/CMakeLists.txt
@@ -74,5 +74,4 @@ add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} SofaBaseTopology)
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-DSOFA_BUILD_BASE_MECHANICS")
 
-## Will create duplicates of SofaBaseMechanics/BarycentricMappers/*.{h,inl} in SofaBaseMechanics/
 sofa_install_targets(SofaBase ${PROJECT_NAME} ${PROJECT_NAME})

--- a/SofaKernel/modules/SofaBaseMechanics/CMakeLists.txt
+++ b/SofaKernel/modules/SofaBaseMechanics/CMakeLists.txt
@@ -75,4 +75,11 @@ target_link_libraries(${PROJECT_NAME} SofaBaseTopology)
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-DSOFA_BUILD_BASE_MECHANICS")
 set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${HEADER_FILES}")
 
+## Hand-crafted install rules for the headers, to preserve the directory structure
+foreach(HEADER ${HEADER_FILES})
+    string(REGEX MATCH "(.*)[/\\]" DIR ${HEADER})
+    install(FILES ${HEADER} DESTINATION "include/${PROJECT_NAME}/${DIR}")
+endforeach(HEADER HEADERS)
+
+## Will create duplicates of SofaBaseMechanics/BarycentricMappers/*.{h,inl} in SofaBaseMechanics/
 sofa_install_targets(SofaBase ${PROJECT_NAME} ${PROJECT_NAME})

--- a/SofaKernel/modules/SofaBaseMechanics/CMakeLists.txt
+++ b/SofaKernel/modules/SofaBaseMechanics/CMakeLists.txt
@@ -73,7 +73,6 @@ set(SOURCE_FILES
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} SofaBaseTopology)
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-DSOFA_BUILD_BASE_MECHANICS")
-set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${HEADER_FILES}")
 
 ## Hand-crafted install rules for the headers, to preserve the directory structure
 foreach(HEADER ${HEADER_FILES})


### PR DESCRIPTION
I noticed that installed headers for SofaBaseMechanics aren't where they're supposed to be because the header's directory structure is not properly respected in SOFA's sofa_install_targets macro.

This commit fixes the issue for the specific case of SofaBaseMechanics/BarycentricMappers/*.{h,inl} but doesn't offer a definitive fix. Additionally, it duplicates headers in SofaBaseMechanics/ since the sofa_install_targets  is still in use.

A definitive solution would be to embed the fix in the sofa_install_targets macro, but I wanted your input first. @damienmarchal  @guparan  
 


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
