### PR TITLE
FIX: useless sofa_create_target breaking external project import

### DIFF
--- a/applications/plugins/SofaPython/SofaPythonConfig.cmake.in
+++ b/applications/plugins/SofaPython/SofaPythonConfig.cmake.in
@@ -3,7 +3,7 @@
 @PACKAGE_INIT@
 
 find_package(PythonLibs 2.7 REQUIRED)
-sofa_create_target(PythonLibs SofaPython "${PYTHON_LIBRARIES}" "${PYTHON_INCLUDE_DIRS}")
+# sofa_create_target(PythonLibs SofaPython "${PYTHON_LIBRARIES}" "${PYTHON_INCLUDE_DIRS}")
 find_package(SofaGui REQUIRED)
 find_package(SofaGeneral REQUIRED)
 find_package(SofaMisc REQUIRED)

--- a/applications/plugins/SofaPython/SofaPythonConfig.cmake.in
+++ b/applications/plugins/SofaPython/SofaPythonConfig.cmake.in
@@ -3,7 +3,6 @@
 @PACKAGE_INIT@
 
 find_package(PythonLibs 2.7 REQUIRED)
-# sofa_create_target(PythonLibs SofaPython "${PYTHON_LIBRARIES}" "${PYTHON_INCLUDE_DIRS}")
 find_package(SofaGui REQUIRED)
 find_package(SofaGeneral REQUIRED)
 find_package(SofaMisc REQUIRED)


### PR DESCRIPTION
The removed line prevents referencing this plugin in another, externally built SOFA plugin.
(doing a `find_package(SofaPython)` from the CMakeLists.txt of another plugin, built as a standalone project did not work)

I don't know the side-effect of simply removing this line, but I also don't see in which case this could (or should) work anyway: there is no reason to create a target during the import of a package. the targets are created at install, and loaded during the package import, not created, to my understanding.


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
