### PR TITLE
[SofaBaseTopology] Fix right setDirty/clean topologyData 

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/UniformMass.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/UniformMass.cpp
@@ -324,7 +324,6 @@ void UniformMass<Vec6Types, MassType>::drawVec6Impl(const core::visual::VisualPa
             vertices.push_back(p);
             vertices.push_back(p + R.col(j)*len[j]);
             colors.push_back(colorSet[j]);
-            colors.push_back(colorSet[j]);;
         }
     }
 

--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyContainer.cpp
@@ -577,7 +577,37 @@ void EdgeSetTopologyContainer::clear()
 //    PointSetTopologyContainer::clear();
 }
 
+void EdgeSetTopologyContainer::setEdgeTopologyToDirty()
+{
+    // set this container to dirty
+    m_edgeTopologyDirty = true;
 
+    std::list<sofa::core::topology::TopologyEngine *>::iterator it;
+    for (it = m_enginesList.begin(); it!=m_enginesList.end(); ++it)
+    {
+        sofa::core::topology::TopologyEngine* topoEngine = (*it);
+        topoEngine->setDirtyValue();
+        if (CHECK_TOPOLOGY)
+            msg_info() << "Edge Topology Set dirty engine: " << topoEngine->name;
+    }
+}
+
+void EdgeSetTopologyContainer::cleanEdgeTopologyFromDirty()
+{
+    m_edgeTopologyDirty = false;
+
+    // security, clean all engines to avoid loops
+    std::list<sofa::core::topology::TopologyEngine *>::iterator it;
+    for ( it = m_enginesList.begin(); it!=m_enginesList.end(); ++it)
+    {
+        if ((*it)->isDirty())
+        {
+            if (CHECK_TOPOLOGY)
+                msg_warning() << "Edge Topology update did not clean engine: " << (*it)->name;
+            (*it)->cleanDirty();
+        }
+    }
+}
 
 void EdgeSetTopologyContainer::updateTopologyEngineGraph()
 {

--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyContainer.h
@@ -220,8 +220,8 @@ protected:
 
     /// Use a specific boolean @see m_triangleTopologyDirty in order to know if topology Data is dirty or not.
     /// Set/Get function access to this boolean
-    void setEdgeTopologyToDirty() {m_edgeTopologyDirty = true;}
-    void cleanEdgeTopologyFromDirty() {m_edgeTopologyDirty = false;}
+    void setEdgeTopologyToDirty();
+    void cleanEdgeTopologyFromDirty();
     const bool& isEdgeTopologyDirty() {return m_edgeTopologyDirty;}
 
 protected:

--- a/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyContainer.cpp
@@ -1205,7 +1205,38 @@ void HexahedronSetTopologyContainer::clear()
     QuadSetTopologyContainer::clear();
 }
 
+void HexahedronSetTopologyContainer::setHexahedronTopologyToDirty()
+{
+    // set this container to dirty
+    m_hexahedronTopologyDirty = true;
 
+    // set all engines link to this container to dirty
+    std::list<sofa::core::topology::TopologyEngine *>::iterator it;
+    for (it = m_enginesList.begin(); it!=m_enginesList.end(); ++it)
+    {
+        sofa::core::topology::TopologyEngine* topoEngine = (*it);
+        topoEngine->setDirtyValue();
+        if (CHECK_TOPOLOGY)
+            msg_info() << "Hexahedron Topology Set dirty engine: " << topoEngine->name;
+    }
+}
+
+void HexahedronSetTopologyContainer::cleanHexahedronTopologyFromDirty()
+{
+    m_hexahedronTopologyDirty = false;
+
+    // security, clean all engines to avoid loops
+    std::list<sofa::core::topology::TopologyEngine *>::iterator it;
+    for ( it = m_enginesList.begin(); it!=m_enginesList.end(); ++it)
+    {
+        if ((*it)->isDirty())
+        {
+            if (CHECK_TOPOLOGY)
+                msg_warning() << "Hexahedron Topology update did not clean engine: " << (*it)->name;
+            (*it)->cleanDirty();
+        }
+    }
+}
 
 void HexahedronSetTopologyContainer::updateTopologyEngineGraph()
 {

--- a/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyContainer.h
@@ -428,8 +428,8 @@ protected:
 
     /// Use a specific boolean @see m_hexahedronTopologyDirty in order to know if topology Data is dirty or not.
     /// Set/Get function access to this boolean
-    void setHexahedronTopologyToDirty() {m_hexahedronTopologyDirty = true;}
-    void cleanHexahedronTopologyFromDirty() {m_hexahedronTopologyDirty = false;}
+    void setHexahedronTopologyToDirty();
+    void cleanHexahedronTopologyFromDirty();
     const bool& isHexahedronTopologyDirty() {return m_hexahedronTopologyDirty;}
 
 public:

--- a/SofaKernel/modules/SofaBaseTopology/PointSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/PointSetTopologyContainer.cpp
@@ -205,6 +205,39 @@ const sofa::helper::vector< PointSetTopologyContainer::PointID >& PointSetTopolo
     return points.getValue();
 }
 
+void PointSetTopologyContainer::setPointTopologyToDirty()
+{
+    // set this container to dirty
+    m_pointTopologyDirty = true;
+
+    // set all engines link to this container to dirty
+    std::list<sofa::core::topology::TopologyEngine *>::iterator it;
+    for (it = m_enginesList.begin(); it!=m_enginesList.end(); ++it)
+    {
+        sofa::core::topology::TopologyEngine* topoEngine = (*it);
+        topoEngine->setDirtyValue();
+        if (CHECK_TOPOLOGY)
+            msg_info() << "Point Topology Set dirty engine: " << topoEngine->name;
+    }
+}
+
+void PointSetTopologyContainer::cleanPointTopologyFromDirty()
+{
+    m_pointTopologyDirty = false;
+
+    // security, clean all engines to avoid loops
+    std::list<sofa::core::topology::TopologyEngine *>::iterator it;
+    for ( it = m_enginesList.begin(); it!=m_enginesList.end(); ++it)
+    {
+        if ((*it)->isDirty())
+        {
+            if (CHECK_TOPOLOGY)
+                msg_warning() << "Point Topology update did not clean engine: " << (*it)->name;
+            (*it)->cleanDirty();
+        }
+    }
+}
+
 
 void PointSetTopologyContainer::updateDataEngineGraph(sofa::core::objectmodel::BaseData &my_Data, std::list<sofa::core::topology::TopologyEngine *> &my_enginesList)
 {

--- a/SofaKernel/modules/SofaBaseTopology/PointSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/PointSetTopologyContainer.h
@@ -161,8 +161,8 @@ protected:
 
     /// Use a specific boolean @see m_pointTopologyDirty in order to know if topology Data is dirty or not.
     /// Set/Get function access to this boolean
-    void setPointTopologyToDirty() {m_pointTopologyDirty = true;}
-    void cleanPointTopologyFromDirty() {m_pointTopologyDirty = false;}
+    void setPointTopologyToDirty();
+    void cleanPointTopologyFromDirty();
     const bool& isPointTopologyDirty() {return m_pointTopologyDirty;}
 
     /// \brief function to add a topologyEngine to the current list of engines.

--- a/SofaKernel/modules/SofaBaseTopology/PointSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/PointSetTopologyModifier.cpp
@@ -400,17 +400,8 @@ void PointSetTopologyModifier::propagateTopologicalChanges()
 
     // Declare all engines to dirty:
     std::list<sofa::core::topology::TopologyEngine *>::iterator it;
-    for ( it = m_container->m_topologyEngineList.begin(); it!=m_container->m_topologyEngineList.end(); ++it)
-    {
-        sofa::core::topology::TopologyEngine* topoEngine = (*it);
-        topoEngine->setDirtyValue();
-    }
 
     this->propagateTopologicalEngineChanges();
-
-    // security to avoid loops
-    for ( it = m_container->m_topologyEngineList.begin(); it!=m_container->m_topologyEngineList.end(); ++it)
-        (*it)->cleanDirty();
     
     sofa::core::ExecParams* params = sofa::core::ExecParams::defaultInstance();
     sofa::simulation::TopologyChangeVisitor a(params, m_container);
@@ -453,6 +444,7 @@ void PointSetTopologyModifier::propagateTopologicalEngineChanges()
         sofa::core::topology::TopologyEngine* topoEngine = (*it);
         if (topoEngine->isDirty())
         {
+            std::cout << "PointSetTopologyModifier:update " << topoEngine->name << std::endl;
             topoEngine->update();
         }
     }

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyContainer.cpp
@@ -817,6 +817,39 @@ void QuadSetTopologyContainer::clear()
     EdgeSetTopologyContainer::clear();
 }
 
+void QuadSetTopologyContainer::setQuadTopologyToDirty()
+{
+    // set this container to dirty
+    m_quadTopologyDirty = true;
+
+    // set all engines link to this container to dirty
+    std::list<sofa::core::topology::TopologyEngine *>::iterator it;
+    for (it = m_enginesList.begin(); it!=m_enginesList.end(); ++it)
+    {
+        sofa::core::topology::TopologyEngine* topoEngine = (*it);
+        topoEngine->setDirtyValue();
+        if (CHECK_TOPOLOGY)
+            msg_info() << "Quad Topology Set dirty engine: " << topoEngine->name;
+    }
+}
+
+void QuadSetTopologyContainer::cleanQuadTopologyFromDirty()
+{
+    m_quadTopologyDirty = false;
+
+    // security, clean all engines to avoid loops
+    std::list<sofa::core::topology::TopologyEngine *>::iterator it;
+    for ( it = m_enginesList.begin(); it!=m_enginesList.end(); ++it)
+    {
+        if ((*it)->isDirty())
+        {
+            if (CHECK_TOPOLOGY)
+                msg_warning() << "Quad Topology update did not clean engine: " << (*it)->name;
+            (*it)->cleanDirty();
+        }
+    }
+}
+
 void QuadSetTopologyContainer::updateTopologyEngineGraph()
 {
     // calling real update Data graph function implemented once in PointSetTopologyModifier

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyContainer.h
@@ -300,8 +300,8 @@ protected:
 
     /// Use a specific boolean @see m_quadTopologyDirty in order to know if topology Data is dirty or not.
     /// Set/Get function access to this boolean
-    void setQuadTopologyToDirty() {m_quadTopologyDirty = true;}
-    void cleanQuadTopologyFromDirty() {m_quadTopologyDirty = false;}
+    void setQuadTopologyToDirty();
+    void cleanQuadTopologyFromDirty();
     const bool& isQuadTopologyDirty() {return m_quadTopologyDirty;}
 
 protected:

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
@@ -1052,6 +1052,38 @@ sofa::helper::vector< TetrahedronSetTopologyContainer::TetrahedronID >& Tetrahed
     return m_removedTetraIndex;
 }
 
+void TetrahedronSetTopologyContainer::setTetrahedronTopologyToDirty()
+{
+    // set this container to dirty
+    m_tetrahedronTopologyDirty = true;
+
+    // set all engines link to this container to dirty
+    std::list<sofa::core::topology::TopologyEngine *>::iterator it;
+    for (it = m_enginesList.begin(); it!=m_enginesList.end(); ++it)
+    {
+        sofa::core::topology::TopologyEngine* topoEngine = (*it);
+        topoEngine->setDirtyValue();
+        if (CHECK_TOPOLOGY)
+            msg_info() << "Tetrahedron Topology Set dirty engine: " << topoEngine->name;
+    }
+}
+
+void TetrahedronSetTopologyContainer::cleanTetrahedronTopologyFromDirty()
+{
+    m_tetrahedronTopologyDirty = false;
+
+    // security, clean all engines to avoid loops
+    std::list<sofa::core::topology::TopologyEngine *>::iterator it;
+    for ( it = m_enginesList.begin(); it!=m_enginesList.end(); ++it)
+    {
+        if ((*it)->isDirty())
+        {
+            if (CHECK_TOPOLOGY)
+                msg_warning() << "Tetrahedron Topology update did not clean engine: " << (*it)->name;
+            (*it)->cleanDirty();
+        }
+    }
+}
 
 void TetrahedronSetTopologyContainer::updateTopologyEngineGraph()
 {

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.h
@@ -458,8 +458,8 @@ protected:
 
     /// Use a specific boolean @see m_tetrahedronTopologyDirty in order to know if topology Data is dirty or not.
     /// Set/Get function access to this boolean
-    void setTetrahedronTopologyToDirty() {m_tetrahedronTopologyDirty = true;}
-    void cleanTetrahedronTopologyFromDirty() {m_tetrahedronTopologyDirty = false;}
+    void setTetrahedronTopologyToDirty();
+    void cleanTetrahedronTopologyFromDirty();
     const bool& isTetrahedronTopologyDirty() {return m_tetrahedronTopologyDirty;}
 
 public:

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.cpp
@@ -1069,6 +1069,38 @@ void TriangleSetTopologyContainer::clear()
     EdgeSetTopologyContainer::clear();
 }
 
+void TriangleSetTopologyContainer::setTriangleTopologyToDirty()
+{
+    // set this container to dirty
+    m_triangleTopologyDirty = true;
+
+    // set all engines link to this container to dirty
+    std::list<sofa::core::topology::TopologyEngine *>::iterator it;
+    for (it = m_enginesList.begin(); it!=m_enginesList.end(); ++it)
+    {
+        sofa::core::topology::TopologyEngine* topoEngine = (*it);
+        topoEngine->setDirtyValue();
+        if (CHECK_TOPOLOGY)
+            msg_info() << "Triangle Topology Set dirty engine: " << topoEngine->name;
+    }
+}
+
+void TriangleSetTopologyContainer::cleanTriangleTopologyFromDirty()
+{
+    m_triangleTopologyDirty = false;
+
+    // security, clean all engines to avoid loops
+    std::list<sofa::core::topology::TopologyEngine *>::iterator it;
+    for ( it = m_enginesList.begin(); it!=m_enginesList.end(); ++it)
+    {
+        if ((*it)->isDirty())
+        {
+            if (CHECK_TOPOLOGY)
+                msg_warning() << "Triangle Topology update did not clean engine: " << (*it)->name;
+            (*it)->cleanDirty();
+        }
+    }
+}
 
 
 void TriangleSetTopologyContainer::updateTopologyEngineGraph()

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.h
@@ -46,8 +46,6 @@ class SOFA_BASE_TOPOLOGY_API TriangleSetTopologyContainer : public EdgeSetTopolo
 public:
     SOFA_CLASS(TriangleSetTopologyContainer,EdgeSetTopologyContainer);
 
-
-
     typedef core::topology::BaseMeshTopology::PointID                      PointID;
     typedef core::topology::BaseMeshTopology::EdgeID                       EdgeID;
     typedef core::topology::BaseMeshTopology::TriangleID                   TriangleID;
@@ -334,8 +332,8 @@ protected:
 
     /// Use a specific boolean @see m_triangleTopologyDirty in order to know if topology Data is dirty or not.
     /// Set/Get function access to this boolean
-    void setTriangleTopologyToDirty() {m_triangleTopologyDirty = true;}
-    void cleanTriangleTopologyFromDirty() {m_triangleTopologyDirty = false;}
+    void setTriangleTopologyToDirty();
+    void cleanTriangleTopologyFromDirty();
     const bool& isTriangleTopologyDirty() {return m_triangleTopologyDirty;}
 
 public:

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyModifier.cpp
@@ -718,12 +718,12 @@ void TriangleSetTopologyModifier::propagateTopologicalEngineChanges()
 
     sofa::helper::AdvancedTimer::stepBegin("TriangleSetTopologyModifier::propagateTopologicalEngineChanges");
     std::list<sofa::core::topology::TopologyEngine *>::iterator it;
- //   for ( it = m_container->m_enginesList.begin(); it!=m_container->m_enginesList.end(); ++it)
-	 for ( it = m_container->m_topologyEngineList.begin(); it!=m_container->m_topologyEngineList.end(); ++it)
+
+    for ( it = m_container->m_enginesList.begin(); it!=m_container->m_enginesList.end(); ++it)
     {
         sofa::core::topology::TopologyEngine* topoEngine = (*it);
         if (topoEngine->isDirty())
-        {
+        {            
             topoEngine->update();
         }
     }

--- a/examples/Components/topology/TopologicalModifiers/HexahedronForceFieldTopologyChangeHandling.scn
+++ b/examples/Components/topology/TopologicalModifiers/HexahedronForceFieldTopologyChangeHandling.scn
@@ -1,24 +1,25 @@
+<?xml version="1.0" ?>
 <!-- Automatic Triangle removing with Triangle2Edge mapping example: Element removed are define in: ./RemovingTrianglesProcess.txt -->
 <Node name="root" gravity="0 -9 1" dt="0.01">
-    <VisualStyle displayFlags="showBehavior showVisual" />
-    <DefaultPipeline name="default0" verbose="0" />
+    <VisualStyle displayFlags="showBehaviorModels showVisual showForceFields" />
+    <DefaultPipeline verbose="0" />
     <BruteForceDetection name="N2" />
-    <DefaultContactManager name="default1" response="default" />
+    <DefaultContactManager response="default" />
     <MinProximityIntersection name="Proximity" alarmDistance="0.8" contactDistance="0.5" />
-    <TreeCollisionGroupManager name="default2" />
 
+    <RegularGridTopology name="grid" n="6 6 6" min="-10 -10 -10" max="10 10 10" p0="-10 -10 -10" />
     <Node name="HexahedralFEMForceField">
         <EulerImplicitSolver name="cg_odesolver" printLog="0"  rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver template="GraphScattered" name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" />
-        <RegularGridTopology name="grid" n="6 6 6" min="-10 -10 -10" max="10 10 10" p0="-10 -10 -10" />
-        <MechanicalObject template="Vec3d" name="HexahedralFEMForceField" src="@grid" topology="@grid"/>
-	<include href="Objects/HexahedronSetTopology.xml" src="@grid" />
-	<HexahedralFEMForceField name="FEM" youngModulus="100" poissonRatio="0.1" method="large" />
-        <UniformMass template="Vec3d" name="default25" vertexMass="0.25" />
+        
+        <MechanicalObject template="Vec3d" name="HexahedralFEMForceField" src="@../grid"/>
+        <include href="Objects/HexahedronSetTopology.xml" src="@../grid" />
+        <HexahedralFEMForceField name="FEM" youngModulus="100" poissonRatio="0.1" method="large" />
+        <DiagonalMass massDensity="1.0" />
         <BoxROI template="Vec3d" name="box_roi" box="-11 11 -11 11 9 11" indices="0" drawSize="0" drawBoxes="1" drawPoints="1" drawEdges="1"  />
         <FixedConstraint template="Vec3d" name="default27" indices="@box_roi.indices" drawSize="0" />
 
-	<TopologicalChangeProcessor listening="1" filename="RemovingHexaProcess.txt" />
+        <TopologicalChangeProcessor listening="1" filename="RemovingHexaProcess.txt" />
     </Node>
 
 </Node>

--- a/examples/Components/topology/TopologicalModifiers/QuadForceFieldTopologyChangeHandling.scn
+++ b/examples/Components/topology/TopologicalModifiers/QuadForceFieldTopologyChangeHandling.scn
@@ -1,63 +1,61 @@
+<?xml version="1.0" ?>
 <!-- Automatic Triangle removing with Triangle2Edge mapping example: Element removed are define in: ./RemovingTrianglesProcess.txt -->
 <Node name="root" gravity="0 -9 1" dt="0.01">
-    <VisualStyle displayFlags="showBehaviorModels showVisual" />
-    <DefaultPipeline name="default0" verbose="0" />
+    <VisualStyle displayFlags="showBehaviorModels showVisual showForceFields" />
+    <DefaultPipeline verbose="0" />
     <BruteForceDetection name="N2" />
-    <DefaultContactManager name="default1" response="default" />
+    <DefaultContactManager response="default" />
     <MinProximityIntersection name="Proximity" alarmDistance="0.8" contactDistance="0.5" />
-    <TreeCollisionGroupManager name="default2" />
-
-    <Node name="QuadularSprings">
+    
+    <RegularGrid name="grid" nx="20" ny="1" nz="20" xmin="12" xmax="-12" ymin="7" ymax="7" zmin="-12" zmax="12" />
+    <Node name="QuadularBendingSprings">
         <EulerImplicit name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-        <RegularGrid name="grid" nx="20" ny="1" nz="20" xmin="12" xmax="-12" ymin="7" ymax="7" zmin="-12" zmax="12" />
-        <MechanicalObject src="@grid" topology="@grid"/>
-	<include href="Objects/QuadSetTopology.xml" src="@grid" />
-        <UniformMass totalMass="100" />
-<RegularGridSpringForceField name="Springs" stiffness="200" damping="2" />
+        
+        <MechanicalObject src="@../grid"/>
+        <include href="Objects/QuadSetTopology.xml" src="@../grid" />
+        <DiagonalMass massDensity="1.0" />
         <QuadularBendingSprings name="FEM-Bend" stiffness="3000" damping="1.0" />
         <FixedConstraint name="FixedConstraint" indices="0 19" />
-
+        
         <Node name="Surf">
             <include href="Objects/TriangleSetTopology.xml" />
             <Quad2TriangleTopologicalMapping input="@../Container" output="@Container" />
             <TriangularFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.3" method="large" />
-            <TriangleSet />
-
-	    <Node name="Visu">
-		<OglModel name="Visual" color="green" />
-		<IdentityMapping input="@.." output="@Visual" />
-	    </Node>
         </Node>
 
-	<TopologicalChangeProcessor listening="1" filename="RemovingQuadProcess.txt" />
+        <Node name="Visu">
+            <OglModel name="Visual" color="green" />
+            <IdentityMapping input="@.." output="@Visual" />
+        </Node>
+
+        <TopologicalChangeProcessor listening="1" filename="RemovingQuadProcess.txt" />
     </Node>
 
 
-    <Node name="QuadularSprings">
+    <Node name="RegularGridSprings">
         <EulerImplicit name="cg_odesolver" printLog="false" />
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-        <RegularGrid name="grid" nx="20" ny="1" nz="20" xmin="14" xmax="38" ymin="7" ymax="7" zmin="-12" zmax="12" />
-        <MechanicalObject src="@grid" topology="@grid"/>
-	<include href="Objects/QuadSetTopology.xml" src="@grid" />
-        <UniformMass totalMass="100" />
-	<RegularGridSpringForceField name="Springs" stiffness="200" damping="2" />
+        <MechanicalObject src="@../grid" translation="30 0 0"/>
+        <include href="Objects/QuadSetTopology.xml" src="@../grid" />
+        <DiagonalMass massDensity="1.0" />
+        
+        <RegularGridSpringForceField name="Springs" stiffness="200" damping="2" />
         <FixedConstraint name="FixedConstraint" indices="0 19" />
 
         <Node name="Surf">
             <include href="Objects/TriangleSetTopology.xml" />
             <Quad2TriangleTopologicalMapping input="@../Container" output="@Container" />
             <TriangularFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.3" method="large" />
-            <TriangleSet />
+            
 
-	    <Node name="Visu">
-		<OglModel name="Visual" color="green" />
-		<IdentityMapping input="@.." output="@Visual" />
-	    </Node>
+            <Node name="Visu">
+                <OglModel name="Visual" color="red" />
+                <IdentityMapping input="@.." output="@Visual" />
+            </Node>
         </Node>
 
-	<TopologicalChangeProcessor listening="1" filename="RemovingQuadProcess.txt" />
+        <TopologicalChangeProcessor listening="1" filename="RemovingQuadProcess.txt" />
     </Node>
-
 
 </Node>

--- a/modules/SofaGeneralDeformable/QuadularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/QuadularBendingSprings.inl
@@ -803,28 +803,16 @@ void QuadularBendingSprings<DataTypes>::draw(const core::visual::VisualParams* v
             if (external)
             {
                 if (d1<edgeInf[i].restlength2*0.9999)
-                {
                     colors.push_back(red_color);
-                    colors.push_back(red_color);
-                }
                 else
-                {
                     colors.push_back(green_color);
-                    colors.push_back(green_color);
-                }
             }
             else
             {
                 if (d1<edgeInf[i].restlength1*0.9999)
-                {
                     colors.push_back(color1);
-                    colors.push_back(color1);
-                }
                 else
-                {
                     colors.push_back(color2);
-                    colors.push_back(color2);
-                }
             }
 
             vertices.push_back( x[edgeInf[i].m1] );
@@ -834,28 +822,16 @@ void QuadularBendingSprings<DataTypes>::draw(const core::visual::VisualParams* v
             if (external)
             {
                 if (d2<edgeInf[i].restlength2*0.9999)
-                {
                     colors.push_back(red_color);
-                    colors.push_back(red_color);
-                }
                 else
-                {
                     colors.push_back(green_color);
-                    colors.push_back(green_color);
-                }
             }
             else
             {
                 if (d2<edgeInf[i].restlength2*0.9999)
-                {
                     colors.push_back(color1);
-                    colors.push_back(color1);
-                }
                 else
-                {
                     colors.push_back(color2);
-                    colors.push_back(color2);
-                }
             }
 
             vertices.push_back( x[edgeInf[i].m3] );


### PR DESCRIPTION
Cherry pick last useful changes from PR #788

All topologyData were set to dirty as soon as a topology modification was done. Check the Data link and set/clean dirty only topologyData link to the topology array modified.

NB: factorisation will be done as soon as everything work fine. Having several methods per topology make my eyes cry but it helps to follow the data link for debug.


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
