### PR TITLE
[SOFAGUI] Fix missing profiling timers for BatchGUI and HeadlessRecorder

### DIFF
--- a/applications/sofa/gui/BatchGUI.cpp
+++ b/applications/sofa/gui/BatchGUI.cpp
@@ -73,9 +73,8 @@ int BatchGUI::mainLoop()
         {
             if (i != nbIter)
             {
-                sofa::helper::AdvancedTimer::begin("Animate");
+                sofa::helper::ScopedAdvancedTimer("Animate");
                 sofa::simulation::getSimulation()->animate(groot.get());
-                sofa::helper::AdvancedTimer::end("Animate");
             }
 
             if ( i == nbIter || (nbIter == -1 && i%1000 == 0) )

--- a/applications/sofa/gui/BatchGUI.cpp
+++ b/applications/sofa/gui/BatchGUI.cpp
@@ -58,13 +58,14 @@ int BatchGUI::mainLoop()
         {
             msg_info("BatchGUI") << "Computing infinite iterations." << msgendl;
         }
-            sofa::helper::AdvancedTimer::begin("Animate");
-            sofa::simulation::getSimulation()->animate(groot.get());
-            msg_info("BatchGUI") << "Processing." << sofa::helper::AdvancedTimer::end("Animate", groot.get()) << msgendl;
-            sofa::simulation::Visitor::ctime_t rtfreq = sofa::helper::system::thread::CTime::getRefTicksPerSec();
-            sofa::simulation::Visitor::ctime_t tfreq = sofa::helper::system::thread::CTime::getTicksPerSec();
-            sofa::simulation::Visitor::ctime_t rt = sofa::helper::system::thread::CTime::getRefTime();
-            sofa::simulation::Visitor::ctime_t t = sofa::helper::system::thread::CTime::getFastTime();
+
+        sofa::helper::AdvancedTimer::begin("Animate");
+        sofa::simulation::getSimulation()->animate(groot.get());
+        msg_info("BatchGUI") << "Processing." << sofa::helper::AdvancedTimer::end("Animate", groot.get()) << msgendl;
+        sofa::simulation::Visitor::ctime_t rtfreq = sofa::helper::system::thread::CTime::getRefTicksPerSec();
+        sofa::simulation::Visitor::ctime_t tfreq = sofa::helper::system::thread::CTime::getTicksPerSec();
+        sofa::simulation::Visitor::ctime_t rt = sofa::helper::system::thread::CTime::getRefTime();
+        sofa::simulation::Visitor::ctime_t t = sofa::helper::system::thread::CTime::getFastTime();
           
         signed int i = 1; //one simulatin step is animated above  
        
@@ -74,6 +75,7 @@ int BatchGUI::mainLoop()
             {
                 sofa::helper::AdvancedTimer::begin("Animate");
                 sofa::simulation::getSimulation()->animate(groot.get());
+                sofa::helper::AdvancedTimer::end("Animate");
             }
 
             if ( i == nbIter || (nbIter == -1 && i%1000 == 0) )

--- a/applications/sofa/gui/headlessRecorder/HeadlessRecorder.cpp
+++ b/applications/sofa/gui/headlessRecorder/HeadlessRecorder.cpp
@@ -21,6 +21,8 @@
 ******************************************************************************/
 #include "HeadlessRecorder.h"
 #include "VideoRecorderFFMpeg.h"
+#include <sofa/helper/AdvancedTimer.h>
+
 namespace sofa
 {
 
@@ -480,13 +482,16 @@ void HeadlessRecorder::paintGL()
 
 void HeadlessRecorder::step()
 {
+    sofa::helper::AdvancedTimer::begin("Animate");
 #ifdef SOFA_SMP
     mg->step();
 #else
     getSimulation()->animate(groot.get());
 #endif
+    sofa::helper::AdvancedTimer::end("Animate");
     getSimulation()->updateVisual(groot.get());
     redraw();
+
 }
 
 void HeadlessRecorder::resetView()


### PR DESCRIPTION
Batchgui and HeadlessRecorder were missing a `sofa::helper::AdvancedTimer::end("Animate");`  instruction. Without it, Sofa can't output the profiling statistics.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
