### PR TITLE
FIX: removing PythonLibs target from SofaPython

### DIFF
--- a/applications/plugins/SofaPython/CMakeLists.txt
+++ b/applications/plugins/SofaPython/CMakeLists.txt
@@ -150,7 +150,6 @@ set(PYTHON_FILES
 
 
 find_package(PythonLibs 2.7 REQUIRED)
-sofa_create_target(PythonLibs SofaPython "${PYTHON_LIBRARIES}" "${PYTHON_INCLUDE_DIRS}")
 find_package(SofaGui REQUIRED)
 find_package(SofaGeneral REQUIRED)
 find_package(SofaMisc REQUIRED)
@@ -175,7 +174,14 @@ if(${CMAKE_COMPILER_IS_GNUCC})
 endif()
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${PYTHON_FILES})
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaSimulationCommon SofaUserInteraction SofaGuiCommon SofaComponentMisc SofaComponentGeneral ${PythonLibs_Target})
+
+target_include_directories(${PROJECT_NAME}
+    PUBLIC ${PYTHON_INCLUDE_DIRS}
+    PUBLIC "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/>"
+    PUBLIC "$<INSTALL_INTERFACE:include>"
+    )
+
+target_link_libraries(${PROJECT_NAME} PUBLIC SofaSimulationCommon SofaUserInteraction SofaGuiCommon SofaComponentMisc SofaComponentGeneral ${PYTHON_LIBRARIES})
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     # dlopen() is used on Linux for a workaround (see PythonEnvironnement.cpp)
     target_link_libraries(${PROJECT_NAME} PRIVATE dl)

--- a/applications/plugins/SofaPython/SofaPythonConfig.cmake.in
+++ b/applications/plugins/SofaPython/SofaPythonConfig.cmake.in
@@ -3,7 +3,7 @@
 @PACKAGE_INIT@
 
 find_package(PythonLibs 2.7 REQUIRED)
-sofa_create_target(PythonLibs SofaPython "${PYTHON_LIBRARIES}" "${PYTHON_INCLUDE_DIRS}")
+# sofa_create_target(PythonLibs SofaPython "${PYTHON_LIBRARIES}" "${PYTHON_INCLUDE_DIRS}")
 find_package(SofaGui REQUIRED)
 find_package(SofaGeneral REQUIRED)
 find_package(SofaMisc REQUIRED)

--- a/applications/plugins/SofaPython/SofaPythonConfig.cmake.in
+++ b/applications/plugins/SofaPython/SofaPythonConfig.cmake.in
@@ -3,7 +3,6 @@
 @PACKAGE_INIT@
 
 find_package(PythonLibs 2.7 REQUIRED)
-# sofa_create_target(PythonLibs SofaPython "${PYTHON_LIBRARIES}" "${PYTHON_INCLUDE_DIRS}")
 find_package(SofaGui REQUIRED)
 find_package(SofaGeneral REQUIRED)
 find_package(SofaMisc REQUIRED)


### PR DESCRIPTION
This PR links PythonLibs 2.7 to SofaPython "the proper way":

Until now, a target was created within SofaPython, in order to expose PythonLibs' leaders & libraries to linked projects. This led to issues when trying to link an external project to SofaPython, since the targets were not properly installed (see #888)

Since there's not reason to create a separated target for PythonLibs anyway, I removed it, and simply linked PythonLibs as you would do for any other lib.

It should not cause any issue to plugins using SofaPython, since PythonLibs' headers / lib are exposed publicly through the SofaPython target anyway.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
