### PR TITLE
[SofaBaseMechanics] BarycentricMapping: spatial hashing, handle limit cases

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h
@@ -39,6 +39,7 @@ namespace _barycentricmappertopologycontainer_
 
 using sofa::defaulttype::Mat3x3d;
 using sofa::defaulttype::Vector3;
+using sofa::defaulttype::Vec3i;
 using sofa::defaulttype::Vec3dTypes;
 using sofa::defaulttype::Vec3fTypes;
 using sofa::defaulttype::ExtVec3fTypes;
@@ -127,20 +128,16 @@ protected:
     virtual void addPointInElement(const int elementIndex, const SReal* baryCoords)=0;
     virtual void computeDistance(double& d, const Vector3& v)=0;
 
-    void exhaustiveSearch ( defaulttype::Vec3d outPos,
-                            const typename In::VecCoord& in,
-                            const helper::vector<Mat3x3d>& bases,
-                            const helper::vector<Vector3>& centers);
-
     // Spacial hashing following paper:
     // M.Teschner et al "Optimized Spatial Hashing for Collision Detection of Deformable Objects" (2003)
     unsigned int getHashIndexFromCoord(const Vector3& pos);
+    unsigned int getHashIndexFromIndices(const Vec3i& ids);
     unsigned int getHashIndexFromIndices(const int& x, const int& y, const int& z);
     defaulttype::Vec3i getGridIndices(const Vector3& pos);
     void initHashing(const typename In::VecCoord& in);
     void computeHashingCellSize(const typename In::VecCoord& in);
     void computeHashTable(const typename In::VecCoord& in);
-    bool sameGridCell(const HashEntry& entry, const Vector3& pos);
+    bool sameGridCell(const HashEntry& entry, const Vec3i& gridIds);
 };
 
 #if !defined(SOFA_COMPONENT_MAPPING_BARYCENTRICMAPPERTOPOLOGYCONTAINER_CPP)

--- a/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h
@@ -90,6 +90,20 @@ public:
 
 protected:
 
+    struct HashEntry
+    {
+      HashEntry(const int& xId, const int& yId, const int& zId, const int& elementId)
+      {
+          this->xId=xId;
+          this->yId=yId;
+          this->zId=zId;
+          this->elementId=elementId;
+      }
+
+      int xId,yId,zId; // cell indices
+      int elementId;
+    };
+
     using Inherit1::m_fromTopology;
 
     topology::PointData< helper::vector<MappingDataType > > d_map;
@@ -100,7 +114,7 @@ protected:
     Real m_gridCellSize;
     Real m_convFactor;
     unsigned int m_hashTableSize;
-    helper::vector<helper::vector<unsigned int>> m_hashTable;
+    helper::vector<helper::vector<HashEntry>> m_hashTable;
 
     BarycentricMapperTopologyContainer(core::topology::BaseMeshTopology* fromTopology, topology::PointSetTopologyContainer* toTopology);
 
@@ -120,13 +134,13 @@ protected:
 
     // Spacial hashing following paper:
     // M.Teschner et al "Optimized Spatial Hashing for Collision Detection of Deformable Objects" (2003)
-    unsigned int getHashIndexFromCoord(const Vector3& x);
+    unsigned int getHashIndexFromCoord(const Vector3& pos);
     unsigned int getHashIndexFromIndices(const int& x, const int& y, const int& z);
-    defaulttype::Vec3i getGridIndices(const Vector3& x);
-    void addToHashTable(const unsigned int& hId, const unsigned int& vertexId);
+    defaulttype::Vec3i getGridIndices(const Vector3& pos);
     void initHashing(const typename In::VecCoord& in);
     void computeHashingCellSize(const typename In::VecCoord& in);
     void computeHashTable(const typename In::VecCoord& in);
+    bool sameGridCell(const HashEntry& entry, const Vector3& pos);
 };
 
 #if !defined(SOFA_COMPONENT_MAPPING_BARYCENTRICMAPPERTOPOLOGYCONTAINER_CPP)

--- a/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h
@@ -93,16 +93,29 @@ protected:
 
     struct HashEntry
     {
-      HashEntry(const int& xId, const int& yId, const int& zId, const int& elementId)
-      {
-          this->xId=xId;
-          this->yId=yId;
-          this->zId=zId;
-          this->elementId=elementId;
-      }
+        HashEntry(const int& xId, const int& yId, const int& zId, const int& elementId)
+        {
+            this->xId=xId;
+            this->yId=yId;
+            this->zId=zId;
+            this->elementId=elementId;
+        }
 
-      int xId,yId,zId; // cell indices
-      int elementId;
+        int xId,yId,zId; // cell indices
+        int elementId;
+    };
+
+    struct NearestParams
+    {
+        NearestParams()
+        {
+            distance = std::numeric_limits<double>::max();
+            elementIndex = -1;
+        }
+
+        Vector3 baryCoords;
+        double distance;
+        int elementIndex;
     };
 
     using Inherit1::m_fromTopology;
@@ -110,6 +123,9 @@ protected:
     topology::PointData< helper::vector<MappingDataType > > d_map;
     MatrixType* m_matrixJ {nullptr};
     bool m_updateJ {false};
+
+    helper::vector<Mat3x3d> m_bases;
+    helper::vector<Vector3> m_centers;
 
     // Spacial hashing utils
     Real m_gridCellSize;
@@ -128,6 +144,13 @@ protected:
     virtual void addPointInElement(const int elementIndex, const SReal* baryCoords)=0;
     virtual void computeDistance(double& d, const Vector3& v)=0;
 
+    void checkDistanceFromElement(unsigned int e,
+                                  const Vector3& outPos,
+                                  const Vector3& inPos,
+                                  NearestParams& nearestParams);
+
+    void computeBasesAndCenters( const typename In::VecCoord& in );
+
     // Spacial hashing following paper:
     // M.Teschner et al "Optimized Spatial Hashing for Collision Detection of Deformable Objects" (2003)
     unsigned int getHashIndexFromCoord(const Vector3& pos);
@@ -138,6 +161,7 @@ protected:
     void computeHashingCellSize(const typename In::VecCoord& in);
     void computeHashTable(const typename In::VecCoord& in);
     bool sameGridCell(const HashEntry& entry, const Vec3i& gridIds);
+
 };
 
 #if !defined(SOFA_COMPONENT_MAPPING_BARYCENTRICMAPPERTOPOLOGYCONTAINER_CPP)

--- a/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h
@@ -102,7 +102,7 @@ protected:
         }
 
         int xId,yId,zId; // cell indices
-        int elementId;
+        unsigned int elementId;
     };
 
     struct NearestParams
@@ -110,12 +110,12 @@ protected:
         NearestParams()
         {
             distance = std::numeric_limits<double>::max();
-            elementIndex = -1;
+            elementId = UINT_MAX;
         }
 
         Vector3 baryCoords;
         double distance;
-        int elementIndex;
+        unsigned int elementId;
     };
 
     using Inherit1::m_fromTopology;
@@ -144,11 +144,20 @@ protected:
     virtual void addPointInElement(const int elementIndex, const SReal* baryCoords)=0;
     virtual void computeDistance(double& d, const Vector3& v)=0;
 
+    /// Compute the distance between outPos and the element e. If this distance is smaller than the previously stored one,
+    /// update nearestParams.
+    /// \param e id of the element
+    /// \param outPos position of the point we want to compute the barycentric coordinates
+    /// \param inPos position of one point of the element
+    /// \param nearestParams output parameters (nearest element id, distance, and barycentric coordinates)
     void checkDistanceFromElement(unsigned int e,
                                   const Vector3& outPos,
                                   const Vector3& inPos,
                                   NearestParams& nearestParams);
 
+
+    /// Compute the datas needed to find the nearest element
+    /// \param in is the vector of points
     void computeBasesAndCenters( const typename In::VecCoord& in );
 
     // Spacial hashing following paper:

--- a/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h
@@ -110,7 +110,7 @@ protected:
         NearestParams()
         {
             distance = std::numeric_limits<double>::max();
-            elementId = UINT_MAX;
+            elementId = std::numeric_limits<unsigned int>::max();
         }
 
         Vector3 baryCoords;

--- a/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.inl
@@ -39,7 +39,7 @@ namespace _barycentricmappertopologycontainer_
 
 using defaulttype::Vec3d;
 using defaulttype::Vec3i;
-typedef typename sofa::core::topology::BaseMeshTopology::SeqEdges SeqEdges;
+typedef typename core::topology::BaseMeshTopology::SeqEdges SeqEdges;
 
 template <class In, class Out, class MappingDataType, class Element>
 BarycentricMapperTopologyContainer<In,Out,MappingDataType,Element>::BarycentricMapperTopologyContainer(core::topology::BaseMeshTopology* fromTopology,
@@ -266,7 +266,7 @@ void BarycentricMapperTopologyContainer<In,Out,MappingDataType,Element>::applyJT
             for ( ; colIt != colItEnd; ++colIt)
             {
                 unsigned indexIn = colIt.index();
-                InDeriv data = (InDeriv) Out::getDPos(colIt.val());
+                InDeriv data = InDeriv(Out::getDPos(colIt.val()));
 
                 const Element& element = elements[d_map.getValue()[indexIn].in_index];
 
@@ -281,13 +281,13 @@ void BarycentricMapperTopologyContainer<In,Out,MappingDataType,Element>::applyJT
 
 
 template <class In, class Out, class MappingDataType, class Element>
-const sofa::defaulttype::BaseMatrix* BarycentricMapperTopologyContainer<In,Out,MappingDataType, Element>::getJ(int outSize, int inSize)
+const defaulttype::BaseMatrix* BarycentricMapperTopologyContainer<In,Out,MappingDataType, Element>::getJ(int outSize, int inSize)
 {
     if (m_matrixJ && !m_updateJ)
         return m_matrixJ;
 
     if (!m_matrixJ) m_matrixJ = new MatrixType;
-    if (m_matrixJ->rowBSize() != (MatrixTypeIndex)outSize || m_matrixJ->colBSize() != (MatrixTypeIndex)inSize)
+    if (m_matrixJ->rowBSize() != MatrixTypeIndex(outSize) || m_matrixJ->colBSize() != MatrixTypeIndex(inSize))
         m_matrixJ->resize(outSize*NOut, inSize*NIn);
     else
         m_matrixJ->clear();
@@ -420,7 +420,7 @@ void BarycentricMapperTopologyContainer<In,Out,MappingDataType,Element>::draw  (
             }
         }
     }
-    vparams->drawTool()->drawLines ( points, 1, sofa::defaulttype::Vec<4,float> ( 0,1,0,1 ) );
+    vparams->drawTool()->drawLines ( points, 1, defaulttype::Vec<4,float> ( 0,1,0,1 ) );
 }
 
 
@@ -434,7 +434,7 @@ unsigned int BarycentricMapperTopologyContainer<In,Out,MappingDataType,Element>:
 template <class In, class Out, class MappingDataType, class Element>
 unsigned int BarycentricMapperTopologyContainer<In,Out,MappingDataType,Element>::getHashIndexFromIndices(const Vec3i& ids)
 {
-    getHashIndexFromIndices(ids[0],ids[1],ids[2]);
+    return getHashIndexFromIndices(ids[0],ids[1],ids[2]);
 }
 
 template <class In, class Out, class MappingDataType, class Element>
@@ -446,7 +446,7 @@ unsigned int BarycentricMapperTopologyContainer<In,Out,MappingDataType,Element>:
     if(h<0)
         h += m_hashTableSize;
 
-    return h;
+    return static_cast<unsigned int>(h);
 }
 
 template <class In, class Out, class MappingDataType, class Element>
@@ -472,7 +472,7 @@ std::istream& operator >> ( std::istream& in, BarycentricMapperTopologyContainer
     unsigned int size_vec;
 
     in >> size_vec;
-    sofa::helper::vector<MappingData>& m = *(b.d_map.beginEdit());
+    helper::vector<MappingData>& m = *(b.d_map.beginEdit());
     m.clear();
 
     MappingData value;

--- a/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.inl
@@ -171,13 +171,14 @@ void BarycentricMapperTopologyContainer<In,Out,MappingDataType,Element>::init ( 
             }
         }
 
-        if(nearestParams.elementIndex==-1) // No element in grid cell, perform exhaustive search
+        if(nearestParams.elementId==UINT_MAX) // No element in grid cell, perform exhaustive search
         {
             for ( unsigned int e = 0; e < elements.size(); e++ )
             {
                 Vector3 inPos = in[elements[e][0]];
                 checkDistanceFromElement(e, outPos, inPos, nearestParams);
             }
+            addPointInElement(nearestParams.elementId, nearestParams.baryCoords.ptr());
         }
         else if(abs(nearestParams.distance)>m_gridCellSize/2.) // Nearest element in grid cell may not be optimal, check neighbors
         {
@@ -199,9 +200,10 @@ void BarycentricMapperTopologyContainer<In,Out,MappingDataType,Element>::init ( 
                             }
                         }
                     }
+            addPointInElement(nearestParams.elementId, nearestParams.baryCoords.ptr());
         }
-
-        addPointInElement(nearestParams.elementIndex, nearestParams.baryCoords.ptr());
+        else
+            addPointInElement(nearestParams.elementId, nearestParams.baryCoords.ptr());
     }
 }
 
@@ -243,7 +245,7 @@ void BarycentricMapperTopologyContainer<In,Out,MappingDataType,Element>::checkDi
     {
         nearestParams.baryCoords = bary;
         nearestParams.distance = dist;
-        nearestParams.elementIndex = int(e);
+        nearestParams.elementId = e;
     }
 };
 

--- a/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/BarycentricMapping_test.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/BarycentricMapping_test.cpp
@@ -68,7 +68,6 @@ struct BarycentricMapperTriangleSetTopologyTest :  public Test, public Barycentr
     using Inherit::getHashIndexFromCoord;
     using Inherit::getHashIndexFromIndices;
     using Inherit::getGridIndices;
-    using Inherit::addToHashTable;
     using Inherit::initHashing;
     using Inherit::init;
 
@@ -130,25 +129,6 @@ struct BarycentricMapperTriangleSetTopologyTest :  public Test, public Barycentr
 
         EXPECT_EQ(m_convFactor,1./m_gridCellSize);
     }
-
-    void addToHashTable_test()
-    {
-        m_hashTableSize = 1;
-        m_hashTable.resize(m_hashTableSize);
-        m_hashTable[0].resize(2);
-
-        addToHashTable(0, 12);
-        EXPECT_EQ(m_hashTable[0].size(), 3);
-        EXPECT_EQ(m_hashTable[0][1], 0);
-        EXPECT_EQ(m_hashTable[0][2], 12);
-
-        addToHashTable(1, 12);
-        EXPECT_EQ(m_hashTable[0].size(), 3);
-
-        addToHashTable(-1, 12);
-        EXPECT_EQ(m_hashTable[0].size(), 3);
-    }
-
 };
 
 
@@ -164,15 +144,5 @@ TEST_F(BarycentricMapperTriangleSetTopologyTest_d, initHashing)
 {
     initHashing_test();
 }
-
-TEST_F(BarycentricMapperTriangleSetTopologyTest_d, addToHashTable)
-{
-    addToHashTable_test();
-}
-
-/*TEST_F(BarycentricMapperTriangleSetTopologyTest_d, scene)
-{
-    EXPECT_NO_THROW(scene_test());
-}*/
 
 

--- a/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/BarycentricMapping_test.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/BarycentricMapping_test.cpp
@@ -65,8 +65,6 @@ struct BarycentricMapperTriangleSetTopologyTest :  public Test, public Barycentr
     using Inherit::d_map;
 
     using Inherit::computeHashTable;
-    using Inherit::getHashIndexFromCoord;
-    using Inherit::getHashIndexFromIndices;
     using Inherit::getGridIndices;
     using Inherit::initHashing;
     using Inherit::init;


### PR DESCRIPTION
Hi, 

This PR follows the changes made in BarycentricMapping (i.e use of spatial hashing to find the nearest points instead of an exhaustive search). This new PR:

1. Handle cases of several grid cells having the same h index. In such case, the distance between two points, that have the same h index, should be computed only if the points are in the same grid cell. This PR add this implementation. Each element is now stored in the hash table with its corresponding grid cell indices.

2. The nearest point, in a shared grid cell, may not be the global nearest point. To improve that, we detect when neighboring cells may contain a better solution, and do the check. These additional computations are still far better than the exhaustive search. 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
