### PR TITLE
[CMAKE] Add check to prevent the inclusion of non-existant file in cmake 3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,7 +307,7 @@ endif()
 ################
 # Package config
 include(CPackComponent)
-if(WIN32)
+if(WIN32 AND ${CMAKE_VERSION} VERSION_LESS "3.13.0")
     include(CPackNSIS)
 endif()
 include(CPackIFW)


### PR DESCRIPTION
Cmake 3.13 does not seem to allow the inclusion of `CPackNSIS` anymore.
This add a simple check on cmake version to prevent cmake configure failure.
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
