### PR TITLE
[Geomagic] FIX compilation error in Geomagic plugin with removal of SOFA_FLOAT/DOUBLE

### DIFF
--- a/applications/plugins/Geomagic/src/GeomagicDriver.cpp
+++ b/applications/plugins/Geomagic/src/GeomagicDriver.cpp
@@ -325,7 +325,7 @@ void GeomagicDriver::initDevice()
     m_omniVisualNode = rootContext->createChild("omniVisu " + d_deviceName.getValue());
     m_omniVisualNode->updateContext();
 
-    rigidDOF = sofa::core::objectmodel::New<component::container::MechanicalObject<sofa::defaulttype::Rigid3dTypes> >();
+    rigidDOF = sofa::core::objectmodel::New<component::container::MechanicalObject<sofa::defaulttype::Rigid3Types> >();
     m_omniVisualNode->addObject(rigidDOF);
     rigidDOF->name.setValue("rigidDOF");
 
@@ -356,7 +356,7 @@ void GeomagicDriver::initDevice()
             visualNode[i].visu->updateVisual();
 
             // create the visual mapping and at it to the graph //
-            visualNode[i].mapping = sofa::core::objectmodel::New< sofa::component::mapping::RigidMapping< Rigid3dTypes, ExtVec3fTypes > >();
+            visualNode[i].mapping = sofa::core::objectmodel::New< sofa::component::mapping::RigidMapping< Rigid3Types, ExtVec3Types > >();
             visualNode[i].node->addObject(visualNode[i].mapping);
             visualNode[i].mapping->setModels(rigidDOF.get(), visualNode[i].visu.get());
             visualNode[i].mapping->name.setValue("RigidMapping");
@@ -381,7 +381,7 @@ void GeomagicDriver::initDevice()
 
     for (int j = 0; j<NVISUALNODE; j++)
     {
-        sofa::defaulttype::ResizableExtVector< sofa::defaulttype::Vec<3, float> > &scaleMapping = *(visualNode[j].mapping->points.beginEdit());
+        sofa::defaulttype::ResizableExtVector< sofa::defaulttype::Vec3 > &scaleMapping = *(visualNode[j].mapping->points.beginEdit());
         for (size_t i = 0; i<scaleMapping.size(); i++)
             scaleMapping[i] *= (float)(d_scale.getValue());
         visualNode[j].mapping->points.endEdit();

--- a/applications/plugins/Geomagic/src/GeomagicDriver.h
+++ b/applications/plugins/Geomagic/src/GeomagicDriver.h
@@ -88,7 +88,7 @@ public:
     {
         simulation::Node::SPtr node;
         sofa::component::visualmodel::OglModel::SPtr visu;
-        sofa::component::mapping::RigidMapping< Rigid3dTypes , ExtVec3fTypes  >::SPtr mapping;
+        sofa::component::mapping::RigidMapping< Rigid3Types , ExtVec3Types  >::SPtr mapping;
     };
 
     Data< std::string > d_deviceName; ///< Name of device Configuration


### PR DESCRIPTION
Changed the mixed-precision mappings for generic ones. This fixes issue #892 (and is related to #893)


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
