### PR TITLE
[MultiThreading] Add the utility functions ParallelFor and ParallalFor2d

### DIFF
--- a/SofaKernel/framework/sofa/simulation/CMakeLists.txt
+++ b/SofaKernel/framework/sofa/simulation/CMakeLists.txt
@@ -33,6 +33,8 @@ set(HEADER_FILES
     MutationListener.h
     Node.h
     Node.inl
+	ParallelFor.h
+	ParallelFor2d.h
     ParallelVisitorScheduler.h
     PauseEvent.h
     PipelineImpl.h
@@ -97,6 +99,8 @@ set(SOURCE_FILES
     MechanicalVisitor.cpp
     MutationListener.cpp
     Node.cpp
+	ParallelFor.cpp
+	ParallelFor2d.cpp
     ParallelVisitorScheduler.cpp
     PauseEvent.cpp
     PipelineImpl.cpp

--- a/SofaKernel/framework/sofa/simulation/ParallelFor.cpp
+++ b/SofaKernel/framework/sofa/simulation/ParallelFor.cpp
@@ -1,0 +1,65 @@
+#include <sofa/simulation/ParallelFor.h>
+
+namespace sofa
+{
+	namespace simulation
+	{
+       
+        ForTask::Range ForTask::Range::split(Range& r)
+        {
+            assert(r.is_divisible(), "for range is not divisible");
+            Range second_half(r._first + (r._last - r._first) / 2u, r._last, r._grainsize);
+            r._last = second_half._first;
+            return second_half;
+        }
+
+
+
+        class InternalForTask : public simulation::Task
+        {
+        public:
+
+            InternalForTask(const ForTask* forTask, const ForTask::Range& range, const Task::Status* status)
+                : Task(status)
+                , _range(range)
+                , _forTask(forTask)
+            {}
+
+
+            virtual ~InternalForTask() {}
+
+            virtual bool run() final
+            {
+                if (_range.is_divisible())
+                {
+                    InternalForTask* newInternalTask = new InternalForTask(_forTask, ForTask::Range::split(_range), _status);
+                    simulation::TaskScheduler::getInstance()->addTask(newInternalTask);
+                    // keep running
+                    this->run();
+                }
+                else
+                {
+                    _forTask->operator()(_range);
+                }
+
+                return true;
+            }
+
+        public:
+            const ForTask* _forTask;
+            ForTask::Range _range;
+        };
+
+        void ParallelFor(ForTask& task, const ForTask::Range& range)
+        {
+            simulation::Task::Status status;
+            InternalForTask* internalTask = new InternalForTask(&task, range, &status);
+            simulation::TaskScheduler* currentScheduler = TaskScheduler::getInstance();
+            currentScheduler->addTask(internalTask);
+            currentScheduler->workUntilDone(&status);
+        }
+
+
+	} // namespace simulation
+
+} // namespace sofa

--- a/SofaKernel/framework/sofa/simulation/ParallelFor.cpp
+++ b/SofaKernel/framework/sofa/simulation/ParallelFor.cpp
@@ -7,7 +7,7 @@ namespace sofa
        
         ForTask::Range ForTask::Range::split(Range& r)
         {
-            assert(r.is_divisible(), "for range is not divisible");
+            assert(r.is_divisible()); // for range is not divisible
             Range second_half(r._first + (r._last - r._first) / 2u, r._last, r._grainsize);
             r._last = second_half._first;
             return second_half;

--- a/SofaKernel/framework/sofa/simulation/ParallelFor.h
+++ b/SofaKernel/framework/sofa/simulation/ParallelFor.h
@@ -25,16 +25,6 @@
 #include <sofa/config.h>
 
 #include <sofa/simulation/TaskScheduler.h>
-//#include "Task.h"
-//#include "Locks.h"
-//
-//#include <thread>
-//#include <mutex>
-//#include <condition_variable>
-//#include <memory>
-//#include <map>
-//#include <deque>
-//#include <string> 
 
 
 namespace sofa

--- a/SofaKernel/framework/sofa/simulation/ParallelFor.h
+++ b/SofaKernel/framework/sofa/simulation/ParallelFor.h
@@ -56,7 +56,7 @@ namespace sofa
 
                 uint64_t size() const
                 {
-                    assert(!(_last < _first), "for range size() error");
+                    assert(!(_last < _first));
                     return _last - _first;
                 }
 

--- a/SofaKernel/framework/sofa/simulation/ParallelFor.h
+++ b/SofaKernel/framework/sofa/simulation/ParallelFor.h
@@ -1,0 +1,103 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#ifndef ParallelFor_h__
+#define ParallelFor_h__
+
+#include <sofa/config.h>
+
+#include <sofa/simulation/TaskScheduler.h>
+//#include "Task.h"
+//#include "Locks.h"
+//
+//#include <thread>
+//#include <mutex>
+//#include <condition_variable>
+//#include <memory>
+//#include <map>
+//#include <deque>
+//#include <string> 
+
+
+namespace sofa
+{
+	namespace simulation
+	{
+
+        class ForTask
+        {
+        public:
+
+            class Range
+            {
+            public:
+
+                Range() = default;
+
+                Range(uint64_t first, uint64_t last, uint64_t grainsize = 1)
+                    : _first(first)
+                    , _last(last)
+                    , _grainsize(grainsize)
+                {}
+
+                uint64_t first() const { return _first; }
+                uint64_t last() const { return _last; }
+                uint64_t grainsize() const { return _grainsize; }
+
+                static Range split(Range& r);
+
+                uint64_t size() const
+                {
+                    assert(!(_last < _first), "for range size() error");
+                    return _last - _first;
+                }
+
+                bool is_divisible() const { return _grainsize<size(); }
+
+            private:
+
+                uint64_t _first;
+                uint64_t _last;
+                uint64_t _grainsize;
+            };
+
+
+        public:
+
+            ForTask() {}
+
+            virtual ~ForTask() {}
+
+            virtual void operator()(const ForTask::Range& range) const = 0;
+
+        };
+
+
+        SOFA_SIMULATION_CORE_API void ParallelFor(ForTask& task, const ForTask::Range& range);
+
+
+
+	} // namespace simulation
+
+} // namespace sofa
+
+
+#endif // ParallelFor_h__

--- a/SofaKernel/framework/sofa/simulation/ParallelFor2d.cpp
+++ b/SofaKernel/framework/sofa/simulation/ParallelFor2d.cpp
@@ -1,0 +1,118 @@
+#include <sofa/simulation/ParallelFor2d.h>
+
+namespace sofa
+{
+	namespace simulation
+	{
+
+
+        class InternalForTask2d : public simulation::Task
+        {
+        public:
+
+            InternalForTask2d(const ForTask2d* forTask, const ForTask2d::Range& range, const Task::Status* status)
+                : Task(status)
+                , _range(range)
+                , _forTask(forTask)
+            {}
+
+
+            virtual ~InternalForTask2d() {}
+
+            virtual bool run() final
+            {
+                if (_partition == ForTask2d::Partition::simple)
+                {
+                    simplePartition();
+                }
+                else if (_partition == ForTask2d::Partition::avoid_shared_data)
+                {
+                    preventSharedDataPartition();
+                }
+
+                return true;
+            }
+
+        private:
+
+            void simplePartition()
+            {
+                if (_range.is_divisible())
+                {
+                    Task::Status synchStatus;
+                    InternalForTask2d* newInternalTask = new InternalForTask2d(_forTask, ForTask2d::Range::split(_range), &synchStatus);
+                    simulation::TaskScheduler::getInstance()->addTask(newInternalTask);
+                    // keep running
+                    this->run();
+                    simulation::TaskScheduler::getInstance()->workUntilDone(&synchStatus);
+                }
+                else
+                {
+                    _forTask->operator()(_range);
+                }
+            }
+            
+            void preventSharedDataPartition()
+            {
+                ForTask2d::Range ranges[3];
+                ranges[2] = _range;
+                int newRangeCounter = 0;
+
+                if (_range.rows().is_divisible())
+                {
+                    ranges[newRangeCounter] = ForTask2d::Range(ForTask::Range::split(_range._rows), ranges[2].cols());
+                    ++newRangeCounter;
+                }
+                if (_range.cols().is_divisible())
+                {
+                    ranges[newRangeCounter] = ForTask2d::Range(ranges[2].rows(), ForTask::Range::split(_range._cols));
+                    ++newRangeCounter;
+                }
+
+                if (newRangeCounter == 2)
+                {
+                    ranges[newRangeCounter] = ForTask2d::Range(ForTask::Range::split(ranges[1]._rows), ForTask::Range::split(ranges[0]._cols));
+                    ++newRangeCounter;
+
+                    Task::Status synchStatus;
+                    simulation::TaskScheduler* scheduler = simulation::TaskScheduler::getInstance();
+                    scheduler->addTask(new InternalForTask2d(_forTask, ranges[0], &synchStatus));
+                    scheduler->addTask(new InternalForTask2d(_forTask, ranges[1], &synchStatus));
+                    scheduler->workUntilDone(&synchStatus);
+
+                    scheduler->addTask(new InternalForTask2d(_forTask, ForTask2d::Range(ranges[2]), _status));
+                    this->run();
+                }
+                else if (newRangeCounter == 1)
+                {
+                    simulation::TaskScheduler* scheduler = simulation::TaskScheduler::getInstance();
+                    scheduler->addTask(new InternalForTask2d(_forTask, ranges[0], _status));
+                    this->run();
+
+                }
+                else
+                {
+                    _forTask->operator()(_range);
+                }
+            }
+
+        public:
+            const ForTask2d* _forTask;
+            ForTask2d::Range _range;
+            ForTask2d::Partition _partition;
+        };
+
+        
+        void ParallelFor2d(ForTask2d& task, const ForTask2d::Range& range, ForTask2d::Partition partition)
+        {
+            simulation::Task::Status status;
+            InternalForTask2d* internalTask = new InternalForTask2d(&task, range, &status);
+            simulation::TaskScheduler* currentScheduler = TaskScheduler::getInstance();
+            currentScheduler->addTask(internalTask);
+            currentScheduler->workUntilDone(&status);
+        }
+
+
+	} // namespace simulation
+
+} // namespace sofa

--- a/SofaKernel/framework/sofa/simulation/ParallelFor2d.cpp
+++ b/SofaKernel/framework/sofa/simulation/ParallelFor2d.cpp
@@ -21,11 +21,11 @@ namespace sofa
 
             virtual bool run() final
             {
-                if (_partition == ForTask2d::Partition::simple)
+                if (_partition & ForTask2d::Partition::simple)
                 {
                     simplePartition();
                 }
-                else if (_partition == ForTask2d::Partition::avoid_shared_data)
+                else if (_partition & ForTask2d::Partition::avoid_shared_data)
                 {
                     preventSharedDataPartition();
                 }

--- a/SofaKernel/framework/sofa/simulation/ParallelFor2d.h
+++ b/SofaKernel/framework/sofa/simulation/ParallelFor2d.h
@@ -76,8 +76,8 @@ namespace sofa
 
             enum Partition
             {
-                simple = 0,
-                avoid_shared_data = 1
+                simple              = 0,
+                avoid_shared_data   = 1 << 0
             };
 
         public:

--- a/SofaKernel/framework/sofa/simulation/ParallelFor2d.h
+++ b/SofaKernel/framework/sofa/simulation/ParallelFor2d.h
@@ -1,0 +1,103 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2017 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#ifndef ParallelFor2d_h__
+#define ParallelFor2d_h__
+
+#include <sofa/config.h>
+
+#include <sofa/simulation/TaskScheduler.h>
+#include <sofa/simulation/ParallelFor.h>
+
+namespace sofa
+{
+	namespace simulation
+	{
+
+        class ForTask2d
+        {
+        public:
+
+            class Range
+            {
+            public:
+
+                Range() = default;
+
+                Range(ForTask::Range rows, ForTask::Range cols)
+                    : _rows(rows)
+                    , _cols(cols)
+                {}
+
+                const ForTask::Range& rows() const { return _rows; }
+                const ForTask::Range& cols() const { return _cols; }
+
+                static ForTask2d::Range split(ForTask2d::Range& r)
+                { 
+                    if (r._rows.size()*r._cols.grainsize() < r._cols.size()*r._rows.grainsize()) 
+                    {
+                        return ForTask2d::Range(r._rows, ForTask::Range::split(r._cols) );
+                        //_cols._first = col_range_type::do_split(r._cols);
+                    }
+                    else
+                    {
+                        return ForTask2d::Range(ForTask::Range::split(r._rows), r._cols);
+                    }
+                }
+
+                bool is_divisible() const { return _rows.is_divisible() || _cols.is_divisible(); }
+
+            private:
+
+                ForTask::Range _rows;
+                ForTask::Range _cols;
+
+                friend class InternalForTask2d;
+            };
+
+
+            enum Partition
+            {
+                simple = 0,
+                avoid_shared_data = 1
+            };
+
+        public:
+
+            ForTask2d() {}
+
+            virtual ~ForTask2d() {}
+
+            virtual void operator()(const ForTask2d::Range& range) const = 0;
+
+        };
+
+
+
+        SOFA_SIMULATION_CORE_API void ParallelFor2d(ForTask2d& task, const ForTask2d::Range& range, ForTask2d::Partition partition = ForTask2d::Partition::simple);
+
+
+	} // namespace simulation
+
+} // namespace sofa
+
+
+#endif // ParallelFor2d_h__


### PR DESCRIPTION
The functions ParallelFor and ParallalFor2d make the for loop parallelization easier to write.
They internally used the task scheduler and automatically perform the the tasks partitioning and creation.

ParallelFor is used to parallelize for loops iteration on one index.
ParallelFor2d is used to parallelize for loops iteration on two indices.







______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
