### PR TITLE
[SofaMeshCollision] Fix TriangleModel to handle topology changes

### DIFF
--- a/SofaKernel/modules/SofaMeshCollision/TriangleModel.h
+++ b/SofaKernel/modules/SofaMeshCollision/TriangleModel.h
@@ -149,12 +149,12 @@ protected:
 
     /** Pointer to the triangle array of this collision model.
      * Will point directly to the topology triangle buffer if only triangles are present. If topology is using/mixing quads and triangles,
-     * This pointer will target \sa my_triangles
-     * @brief p_triangles
+     * This pointer will target \sa m_internalTriangles
+     * @brief m_triangles
      */
-    const sofa::core::topology::BaseMeshTopology::SeqTriangles* p_triangles;
+    const sofa::core::topology::BaseMeshTopology::SeqTriangles* m_triangles;
 
-    sofa::core::topology::BaseMeshTopology::SeqTriangles my_triangles; ///< Internal Buffer of triangles to combine quads splitted and other triangles.
+    sofa::core::topology::BaseMeshTopology::SeqTriangles m_internalTriangles; ///< Internal Buffer of triangles to combine quads splitted and other triangles.
 
     bool needsUpdate; ///< parameter storing the info boundingTree has to be recomputed.
     int m_topologyRevision; ///< internal revision number to check if topology has changed.
@@ -192,7 +192,7 @@ public:
     const core::behavior::MechanicalState<DataTypes>* getMechanicalState() const { return m_mstate; }
 
     const VecCoord& getX() const { return(getMechanicalState()->read(core::ConstVecCoordId::position())->getValue()); }
-    const sofa::core::topology::BaseMeshTopology::SeqTriangles& getTriangles() const { return *p_triangles; }
+    const sofa::core::topology::BaseMeshTopology::SeqTriangles& getTriangles() const { return *m_triangles; }
     const VecDeriv& getNormals() const { return normals; }
     int getTriangleFlags(sofa::core::topology::BaseMeshTopology::TriangleID i);
 
@@ -245,42 +245,42 @@ inline TTriangle<DataTypes>::TTriangle(ParentModel* model, int index, helper::Re
 {}
 
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p1() const { return this->model->m_mstate->read(core::ConstVecCoordId::position())->getValue()[(*(this->model->p_triangles))[this->index][0]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p1() const { return this->model->m_mstate->read(core::ConstVecCoordId::position())->getValue()[(*(this->model->m_triangles))[this->index][0]]; }
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p2() const { return this->model->m_mstate->read(core::ConstVecCoordId::position())->getValue()[(*(this->model->p_triangles))[this->index][1]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p2() const { return this->model->m_mstate->read(core::ConstVecCoordId::position())->getValue()[(*(this->model->m_triangles))[this->index][1]]; }
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p3() const { return this->model->m_mstate->read(core::ConstVecCoordId::position())->getValue()[(*(this->model->p_triangles))[this->index][2]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p3() const { return this->model->m_mstate->read(core::ConstVecCoordId::position())->getValue()[(*(this->model->m_triangles))[this->index][2]]; }
 template<class DataTypes>
 inline const typename DataTypes::Coord& TTriangle<DataTypes>::p(int i) const {
-    return this->model->m_mstate->read(core::ConstVecCoordId::position())->getValue()[(*(this->model->p_triangles))[this->index][i]];
+    return this->model->m_mstate->read(core::ConstVecCoordId::position())->getValue()[(*(this->model->m_triangles))[this->index][i]];
 }
 template<class DataTypes>
 inline const typename DataTypes::Coord& TTriangle<DataTypes>::operator[](int i) const {
-    return this->model->m_mstate->read(core::ConstVecCoordId::position())->getValue()[(*(this->model->p_triangles))[this->index][i]];
+    return this->model->m_mstate->read(core::ConstVecCoordId::position())->getValue()[(*(this->model->m_triangles))[this->index][i]];
 }
 
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p1Free() const { return (*this->model->m_mstate->read(sofa::core::ConstVecCoordId::freePosition())->getValue())[(*(this->model->p_triangles))[this->index][0]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p1Free() const { return (*this->model->m_mstate->read(sofa::core::ConstVecCoordId::freePosition())->getValue())[(*(this->model->m_triangles))[this->index][0]]; }
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p2Free() const { return (*this->model->m_mstate->read(sofa::core::ConstVecCoordId::freePosition())->getValue())[(*(this->model->p_triangles))[this->index][1]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p2Free() const { return (*this->model->m_mstate->read(sofa::core::ConstVecCoordId::freePosition())->getValue())[(*(this->model->m_triangles))[this->index][1]]; }
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p3Free() const { return (*this->model->m_mstate->read(sofa::core::ConstVecCoordId::freePosition())->getValue())[(*(this->model->p_triangles))[this->index][2]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p3Free() const { return (*this->model->m_mstate->read(sofa::core::ConstVecCoordId::freePosition())->getValue())[(*(this->model->m_triangles))[this->index][2]]; }
 
 template<class DataTypes>
-inline int TTriangle<DataTypes>::p1Index() const { return (*(this->model->p_triangles))[this->index][0]; }
+inline int TTriangle<DataTypes>::p1Index() const { return (*(this->model->m_triangles))[this->index][0]; }
 template<class DataTypes>
-inline int TTriangle<DataTypes>::p2Index() const { return (*(this->model->p_triangles))[this->index][1]; }
+inline int TTriangle<DataTypes>::p2Index() const { return (*(this->model->m_triangles))[this->index][1]; }
 template<class DataTypes>
-inline int TTriangle<DataTypes>::p3Index() const { return (*(this->model->p_triangles))[this->index][2]; }
+inline int TTriangle<DataTypes>::p3Index() const { return (*(this->model->m_triangles))[this->index][2]; }
 
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v1() const { return (this->model->m_mstate->read(core::ConstVecDerivId::velocity())->getValue())[(*(this->model->p_triangles))[this->index][0]]; }
+inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v1() const { return (this->model->m_mstate->read(core::ConstVecDerivId::velocity())->getValue())[(*(this->model->m_triangles))[this->index][0]]; }
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v2() const { return this->model->m_mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(this->model->p_triangles))[this->index][1]]; }
+inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v2() const { return this->model->m_mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(this->model->m_triangles))[this->index][1]]; }
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v3() const { return this->model->m_mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(this->model->p_triangles))[this->index][2]]; }
+inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v3() const { return this->model->m_mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(this->model->m_triangles))[this->index][2]]; }
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v(int i) const { return this->model->m_mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(this->model->p_triangles))[this->index][i]]; }
+inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v(int i) const { return this->model->m_mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(this->model->m_triangles))[this->index][i]]; }
 
 template<class DataTypes>
 inline const typename DataTypes::Deriv& TTriangle<DataTypes>::n() const { return this->model->normals[this->index]; }
@@ -294,8 +294,8 @@ template<class DataTypes>
 inline bool TTriangle<DataTypes>::hasFreePosition() const { return this->model->m_mstate->read(core::ConstVecCoordId::freePosition())->isSet(); }
 
 template<class DataTypes>
-inline typename DataTypes::Deriv TTriangleModel<DataTypes>::velocity(int index) const { return (m_mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(p_triangles))[index][0]] + m_mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(p_triangles))[index][1]] +
-                                                                                                m_mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(p_triangles))[index][2]])/((Real)(3.0)); }
+inline typename DataTypes::Deriv TTriangleModel<DataTypes>::velocity(int index) const { return (m_mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(m_triangles))[index][0]] + m_mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(m_triangles))[index][1]] +
+                                                                                                m_mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(m_triangles))[index][2]])/((Real)(3.0)); }
 typedef TTriangleModel<sofa::defaulttype::Vec3Types> TriangleModel;
 typedef TTriangle<sofa::defaulttype::Vec3Types> Triangle;
 

--- a/SofaKernel/modules/SofaMeshCollision/TriangleModel.h
+++ b/SofaKernel/modules/SofaMeshCollision/TriangleModel.h
@@ -188,8 +188,6 @@ public:
 
     virtual bool canCollideWithElement(int index, CollisionModel* model2, int index2) override;
 
-    virtual void handleTopologyChange() override;
-
     core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return m_mstate; }
     const core::behavior::MechanicalState<DataTypes>* getMechanicalState() const { return m_mstate; }
 

--- a/SofaKernel/modules/SofaMeshCollision/TriangleModel.h
+++ b/SofaKernel/modules/SofaMeshCollision/TriangleModel.h
@@ -138,14 +138,14 @@ public:
 
 	enum { NBARY = 2 };
 
-    Data<bool> bothSide; ///< to activate collision on both side of the triangle model
-    Data<bool> computeNormals; ///< set to false to disable computation of triangles normal
+    Data<bool> d_bothSide; ///< to activate collision on both side of the triangle model
+    Data<bool> d_computeNormals; ///< set to false to disable computation of triangles normal
 
 protected:
     core::behavior::MechanicalState<DataTypes>* m_mstate; ///< Pointer to the corresponding MechanicalState
     sofa::core::topology::BaseMeshTopology* m_topology; ///< Pointer to the corresponding Topology
 
-    VecDeriv normals; ///< Vector of normal direction per triangle.
+    VecDeriv m_normals; ///< Vector of normal direction per triangle.
 
     /** Pointer to the triangle array of this collision model.
      * Will point directly to the topology triangle buffer if only triangles are present. If topology is using/mixing quads and triangles,
@@ -156,7 +156,7 @@ protected:
 
     sofa::core::topology::BaseMeshTopology::SeqTriangles m_internalTriangles; ///< Internal Buffer of triangles to combine quads splitted and other triangles.
 
-    bool needsUpdate; ///< parameter storing the info boundingTree has to be recomputed.
+    bool m_needsUpdate; ///< parameter storing the info boundingTree has to be recomputed.
     int m_topologyRevision; ///< internal revision number to check if topology has changed.
 
     PointModel* m_pointModels;
@@ -193,7 +193,7 @@ public:
 
     const VecCoord& getX() const { return(getMechanicalState()->read(core::ConstVecCoordId::position())->getValue()); }
     const sofa::core::topology::BaseMeshTopology::SeqTriangles& getTriangles() const { return *m_triangles; }
-    const VecDeriv& getNormals() const { return normals; }
+    const VecDeriv& getNormals() const { return m_normals; }
     int getTriangleFlags(sofa::core::topology::BaseMeshTopology::TriangleID i);
 
     TriangleLocalMinDistanceFilter *getFilter() const;
@@ -283,9 +283,9 @@ template<class DataTypes>
 inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v(int i) const { return this->model->m_mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(this->model->m_triangles))[this->index][i]]; }
 
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TTriangle<DataTypes>::n() const { return this->model->normals[this->index]; }
+inline const typename DataTypes::Deriv& TTriangle<DataTypes>::n() const { return this->model->m_normals[this->index]; }
 template<class DataTypes>
-inline       typename DataTypes::Deriv& TTriangle<DataTypes>::n()       { return this->model->normals[this->index]; }
+inline       typename DataTypes::Deriv& TTriangle<DataTypes>::n()       { return this->model->m_normals[this->index]; }
 
 template<class DataTypes>
 inline int TTriangle<DataTypes>::flags() const { return this->model->getTriangleFlags(this->index); }

--- a/SofaKernel/modules/SofaMeshCollision/TriangleModel.h
+++ b/SofaKernel/modules/SofaMeshCollision/TriangleModel.h
@@ -137,9 +137,9 @@ public:
 protected:
     VecDeriv normals;
 
-    const sofa::core::topology::BaseMeshTopology::SeqTriangles* triangles;
+    const sofa::core::topology::BaseMeshTopology::SeqTriangles* p_triangles;
 
-    sofa::core::topology::BaseMeshTopology::SeqTriangles mytriangles;
+    sofa::core::topology::BaseMeshTopology::SeqTriangles my_triangles;
 
     bool needsUpdate;
     virtual void updateFromTopology();
@@ -147,13 +147,13 @@ protected:
     virtual void updateNormals();
     int getTriangleFlags(sofa::core::topology::BaseMeshTopology::TriangleID i);
 
-    core::behavior::MechanicalState<DataTypes>* mstate;
+    core::behavior::MechanicalState<DataTypes>* m_mstate;
     Data<bool> computeNormals; ///< set to false to disable computation of triangles normal
     int meshRevision;
 
-    sofa::core::topology::BaseMeshTopology* _topology;
+    sofa::core::topology::BaseMeshTopology* m_topology;
 
-    PointModel* mpoints;
+    PointModel* m_pointModels;
 
     TriangleLocalMinDistanceFilter *m_lmdFilter;
 
@@ -179,11 +179,11 @@ public:
 
     virtual void handleTopologyChange() override;
 
-    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return mstate; }
-    const core::behavior::MechanicalState<DataTypes>* getMechanicalState() const { return mstate; }
+    core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return m_mstate; }
+    const core::behavior::MechanicalState<DataTypes>* getMechanicalState() const { return m_mstate; }
 
     const VecCoord& getX() const { return(getMechanicalState()->read(core::ConstVecCoordId::position())->getValue()); }
-    const sofa::core::topology::BaseMeshTopology::SeqTriangles& getTriangles() const { return *triangles; }
+    const sofa::core::topology::BaseMeshTopology::SeqTriangles& getTriangles() const { return *p_triangles; }
     const VecDeriv& getNormals() const { return normals; }
 
     TriangleLocalMinDistanceFilter *getFilter() const;
@@ -232,42 +232,42 @@ inline TTriangle<DataTypes>::TTriangle(ParentModel* model, int index, helper::Re
 {}
 
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p1() const { return this->model->mstate->read(core::ConstVecCoordId::position())->getValue()[(*(this->model->triangles))[this->index][0]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p1() const { return this->model->m_mstate->read(core::ConstVecCoordId::position())->getValue()[(*(this->model->p_triangles))[this->index][0]]; }
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p2() const { return this->model->mstate->read(core::ConstVecCoordId::position())->getValue()[(*(this->model->triangles))[this->index][1]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p2() const { return this->model->m_mstate->read(core::ConstVecCoordId::position())->getValue()[(*(this->model->p_triangles))[this->index][1]]; }
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p3() const { return this->model->mstate->read(core::ConstVecCoordId::position())->getValue()[(*(this->model->triangles))[this->index][2]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p3() const { return this->model->m_mstate->read(core::ConstVecCoordId::position())->getValue()[(*(this->model->p_triangles))[this->index][2]]; }
 template<class DataTypes>
 inline const typename DataTypes::Coord& TTriangle<DataTypes>::p(int i) const {
-    return this->model->mstate->read(core::ConstVecCoordId::position())->getValue()[(*(this->model->triangles))[this->index][i]];
+    return this->model->m_mstate->read(core::ConstVecCoordId::position())->getValue()[(*(this->model->p_triangles))[this->index][i]];
 }
 template<class DataTypes>
 inline const typename DataTypes::Coord& TTriangle<DataTypes>::operator[](int i) const {
-    return this->model->mstate->read(core::ConstVecCoordId::position())->getValue()[(*(this->model->triangles))[this->index][i]];
+    return this->model->m_mstate->read(core::ConstVecCoordId::position())->getValue()[(*(this->model->p_triangles))[this->index][i]];
 }
 
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p1Free() const { return (*this->model->mstate->read(sofa::core::ConstVecCoordId::freePosition())->getValue())[(*(this->model->triangles))[this->index][0]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p1Free() const { return (*this->model->m_mstate->read(sofa::core::ConstVecCoordId::freePosition())->getValue())[(*(this->model->p_triangles))[this->index][0]]; }
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p2Free() const { return (*this->model->mstate->read(sofa::core::ConstVecCoordId::freePosition())->getValue())[(*(this->model->triangles))[this->index][1]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p2Free() const { return (*this->model->m_mstate->read(sofa::core::ConstVecCoordId::freePosition())->getValue())[(*(this->model->p_triangles))[this->index][1]]; }
 template<class DataTypes>
-inline const typename DataTypes::Coord& TTriangle<DataTypes>::p3Free() const { return (*this->model->mstate->read(sofa::core::ConstVecCoordId::freePosition())->getValue())[(*(this->model->triangles))[this->index][2]]; }
+inline const typename DataTypes::Coord& TTriangle<DataTypes>::p3Free() const { return (*this->model->m_mstate->read(sofa::core::ConstVecCoordId::freePosition())->getValue())[(*(this->model->p_triangles))[this->index][2]]; }
 
 template<class DataTypes>
-inline int TTriangle<DataTypes>::p1Index() const { return (*(this->model->triangles))[this->index][0]; }
+inline int TTriangle<DataTypes>::p1Index() const { return (*(this->model->p_triangles))[this->index][0]; }
 template<class DataTypes>
-inline int TTriangle<DataTypes>::p2Index() const { return (*(this->model->triangles))[this->index][1]; }
+inline int TTriangle<DataTypes>::p2Index() const { return (*(this->model->p_triangles))[this->index][1]; }
 template<class DataTypes>
-inline int TTriangle<DataTypes>::p3Index() const { return (*(this->model->triangles))[this->index][2]; }
+inline int TTriangle<DataTypes>::p3Index() const { return (*(this->model->p_triangles))[this->index][2]; }
 
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v1() const { return (this->model->mstate->read(core::ConstVecDerivId::velocity())->getValue())[(*(this->model->triangles))[this->index][0]]; }
+inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v1() const { return (this->model->m_mstate->read(core::ConstVecDerivId::velocity())->getValue())[(*(this->model->p_triangles))[this->index][0]]; }
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v2() const { return this->model->mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(this->model->triangles))[this->index][1]]; }
+inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v2() const { return this->model->m_mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(this->model->p_triangles))[this->index][1]]; }
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v3() const { return this->model->mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(this->model->triangles))[this->index][2]]; }
+inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v3() const { return this->model->m_mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(this->model->p_triangles))[this->index][2]]; }
 template<class DataTypes>
-inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v(int i) const { return this->model->mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(this->model->triangles))[this->index][i]]; }
+inline const typename DataTypes::Deriv& TTriangle<DataTypes>::v(int i) const { return this->model->m_mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(this->model->p_triangles))[this->index][i]]; }
 
 template<class DataTypes>
 inline const typename DataTypes::Deriv& TTriangle<DataTypes>::n() const { return this->model->normals[this->index]; }
@@ -278,11 +278,11 @@ template<class DataTypes>
 inline int TTriangle<DataTypes>::flags() const { return this->model->getTriangleFlags(this->index); }
 
 template<class DataTypes>
-inline bool TTriangle<DataTypes>::hasFreePosition() const { return this->model->mstate->read(core::ConstVecCoordId::freePosition())->isSet(); }
+inline bool TTriangle<DataTypes>::hasFreePosition() const { return this->model->m_mstate->read(core::ConstVecCoordId::freePosition())->isSet(); }
 
 template<class DataTypes>
-inline typename DataTypes::Deriv TTriangleModel<DataTypes>::velocity(int index) const { return (mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(triangles))[index][0]] + mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(triangles))[index][1]] +
-                                                                                                mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(triangles))[index][2]])/((Real)(3.0)); }
+inline typename DataTypes::Deriv TTriangleModel<DataTypes>::velocity(int index) const { return (m_mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(p_triangles))[index][0]] + m_mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(p_triangles))[index][1]] +
+                                                                                                m_mstate->read(core::ConstVecDerivId::velocity())->getValue()[(*(p_triangles))[index][2]])/((Real)(3.0)); }
 typedef TTriangleModel<sofa::defaulttype::Vec3Types> TriangleModel;
 typedef TTriangle<sofa::defaulttype::Vec3Types> Triangle;
 

--- a/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
+++ b/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
@@ -81,13 +81,13 @@ void TTriangleModel<DataTypes>::init()
 
     if (mstate==NULL)
     {
-        serr << "TriangleModel requires a Vec3 Mechanical Model" << sendl;
+        msg_error() << "No MechanicalObject found. TriangleModel requires a Vec3 Mechanical Model in the same Node.";
         return;
     }
 
     if (!_topology)
     {
-        serr << "TriangleModel requires a BaseMeshTopology" << sendl;
+        msg_error() << "No Topology found. TriangleModel requires a Triangular Topology in the same Node.";
         return;
     }
 
@@ -155,7 +155,7 @@ void TTriangleModel<DataTypes>::updateFromTopology()
             core::topology::BaseMeshTopology::Triangle idx = _topology->getTriangle(i);
             if (idx[0] >= npoints || idx[1] >= npoints || idx[2] >= npoints)
             {
-                serr << "ERROR: Out of range index in triangle "<<i<<": "<<idx[0]<<" "<<idx[1]<<" "<<idx[2]<<" ( total points="<<npoints<<")"<<sendl;
+                msg_error() << "Vertex index out of range in triangle " << i << ": " << idx[0] << " " << idx[1] << " " << idx[2] <<" ( total points=" << npoints << ")";
                 if (idx[0] >= npoints) idx[0] = npoints-1;
                 if (idx[1] >= npoints) idx[1] = npoints-1;
                 if (idx[2] >= npoints) idx[2] = npoints-1;
@@ -168,7 +168,7 @@ void TTriangleModel<DataTypes>::updateFromTopology()
             core::topology::BaseMeshTopology::Quad idx = _topology->getQuad(i);
             if (idx[0] >= npoints || idx[1] >= npoints || idx[2] >= npoints || idx[3] >= npoints)
             {
-                serr << "ERROR: Out of range index in quad "<<i<<": "<<idx[0]<<" "<<idx[1]<<" "<<idx[2]<<" "<<idx[3]<<" ( total points="<<npoints<<")"<<sendl;
+                msg_error() << "Vertex index out of range in quad " << i << ": " << idx[0] << " " << idx[1] << " " << idx[2] << " " << idx[3] << " ( total points=" << npoints << ")";
                 if (idx[0] >= npoints) idx[0] = npoints-1;
                 if (idx[1] >= npoints) idx[1] = npoints-1;
                 if (idx[2] >= npoints) idx[2] = npoints-1;

--- a/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
+++ b/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
@@ -150,19 +150,12 @@ void TTriangleModel<DataTypes>::updateFromTopology()
 
     if (nquads == 0) // only triangles
     {
-        if (ntris == (unsigned)size) // revision changed but no changes on the triangulation.
-            return;
-
         resize(ntris);
         p_triangles = & m_topology->getTriangles();
     }
     else
     {
         const unsigned newsize = ntris+2*nquads;
-
-        if (newsize==(unsigned)size) // revision changed but no changes on the triangulation/quads.
-            return;
-
         const unsigned npoints = m_mstate->getSize();
 
         p_triangles = &my_triangles;

--- a/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
+++ b/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
@@ -58,7 +58,7 @@ TTriangleModel<DataTypes>::TTriangleModel()
     , m_pointModels(NULL)
     , m_lmdFilter(NULL)
 {
-    p_triangles = &my_triangles;
+    m_triangles = &m_internalTriangles;
     enum_type = TRIANGLE_TYPE;
 }
 
@@ -115,7 +115,7 @@ void TTriangleModel<DataTypes>::init()
     else
     {
         // just redirect to the topology buffer.
-        p_triangles = &m_topology->getTriangles();
+        m_triangles = &m_topology->getTriangles();
         resize(m_topology->getNbTriangles());
         updateNormals();
     }
@@ -151,15 +151,15 @@ void TTriangleModel<DataTypes>::updateFromTopology()
     if (nquads == 0) // only triangles
     {
         resize(ntris);
-        p_triangles = & m_topology->getTriangles();
+        m_triangles = & m_topology->getTriangles();
     }
     else
     {
         const unsigned newsize = ntris+2*nquads;
         const unsigned npoints = m_mstate->getSize();
 
-        p_triangles = &my_triangles;
-        my_triangles.resize(newsize);
+        m_triangles = &m_internalTriangles;
+        m_internalTriangles.resize(newsize);
         int index = 0;
         for (unsigned i=0; i<ntris; i++)
         {
@@ -171,7 +171,7 @@ void TTriangleModel<DataTypes>::updateFromTopology()
                 if (idx[1] >= npoints) idx[1] = npoints-1;
                 if (idx[2] >= npoints) idx[2] = npoints-1;
             }
-            my_triangles[index] = idx;
+            m_internalTriangles[index] = idx;
             ++index;
         }
         for (unsigned i=0; i<nquads; i++)
@@ -185,13 +185,13 @@ void TTriangleModel<DataTypes>::updateFromTopology()
                 if (idx[2] >= npoints) idx[2] = npoints-1;
                 if (idx[3] >= npoints) idx[3] = npoints-1;
             }
-            my_triangles[index][0] = idx[1];
-            my_triangles[index][1] = idx[2];
-            my_triangles[index][2] = idx[0];
+            m_internalTriangles[index][0] = idx[1];
+            m_internalTriangles[index][1] = idx[2];
+            m_internalTriangles[index][2] = idx[0];
             ++index;
-            my_triangles[index][0] = idx[3];
-            my_triangles[index][1] = idx[0];
-            my_triangles[index][2] = idx[2];
+            m_internalTriangles[index][0] = idx[3];
+            m_internalTriangles[index][1] = idx[0];
+            m_internalTriangles[index][2] = idx[2];
             ++index;
         }
     }
@@ -206,15 +206,15 @@ template<class DataTypes>
 void TTriangleModel<DataTypes>::updateFlags(int /*ntri*/)
 {
 #if 0
-    if (ntri < 0) ntri = p_triangles->size();
+    if (ntri < 0) ntri = m_triangles->size();
     //VecCoord& x =m_mstate->read(core::ConstVecCoordId::position())->getValue();
     //VecDeriv& v = m_mstate->read(core::ConstVecDerivId::velocity())->getValue();
     vector<bool> pflags(m_mstate->getSize());
     std::set<std::pair<int,int> > eflags;
-    for (unsigned i=0; i<p_triangles->size(); i++)
+    for (unsigned i=0; i<m_triangles->size(); i++)
     {
         int f = 0;
-        topology::Triangle t = (*p_triangles)[i];
+        topology::Triangle t = (*m_triangles)[i];
         if (!pflags[t[0]])
         {
             f |= FLAG_P1;
@@ -423,7 +423,7 @@ template<class DataTypes>
 int TTriangleModel<DataTypes>::getTriangleFlags(Topology::TriangleID i)
 {
     int f = 0;
-    sofa::core::topology::BaseMeshTopology::Triangle t = (*p_triangles)[i];
+    sofa::core::topology::BaseMeshTopology::Triangle t = (*m_triangles)[i];
 
     if (i < m_topology->getNbTriangles())
     {

--- a/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
+++ b/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
@@ -160,6 +160,8 @@ void TTriangleModel<DataTypes>::updateFromTopology()
 
         m_triangles = &m_internalTriangles;
         m_internalTriangles.resize(newsize);
+        resize(newsize);
+
         int index = 0;
         for (unsigned i=0; i<ntris; i++)
         {

--- a/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
+++ b/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
@@ -49,11 +49,11 @@ namespace collision
 
 template<class DataTypes>
 TTriangleModel<DataTypes>::TTriangleModel()
-    : bothSide(initData(&bothSide, false, "bothSide", "activate collision on both side of the triangle model") )
-    , computeNormals(initData(&computeNormals, true, "computeNormals", "set to false to disable computation of triangles normal"))
+    : d_bothSide(initData(&d_bothSide, false, "bothSide", "activate collision on both side of the triangle model") )
+    , d_computeNormals(initData(&d_computeNormals, true, "computeNormals", "set to false to disable computation of triangles normal"))
     , m_mstate(NULL)
     , m_topology(NULL)
-    , needsUpdate(true)
+    , m_needsUpdate(true)
     , m_topologyRevision(-1)
     , m_pointModels(NULL)
     , m_lmdFilter(NULL)
@@ -66,7 +66,7 @@ template<class DataTypes>
 void TTriangleModel<DataTypes>::resize(int size)
 {
     this->core::CollisionModel::resize(size);
-    normals.resize(size);
+    m_normals.resize(size);
 }
 
 template<class DataTypes>
@@ -199,7 +199,7 @@ void TTriangleModel<DataTypes>::updateFromTopology()
     updateNormals();
 
     // topology has changed, force boudingTree recomputation
-    needsUpdate = true;
+    m_needsUpdate = true;
 }
 
 template<class DataTypes>
@@ -294,17 +294,17 @@ void TTriangleModel<DataTypes>::computeBoundingTree(int maxDepth)
     if (m_topology->getRevision() != m_topologyRevision)
         updateFromTopology();
 
-    if (needsUpdate && !cubeModel->empty()) cubeModel->resize(0);
+    if (m_needsUpdate && !cubeModel->empty()) cubeModel->resize(0);
 
-    if (!isMoving() && !cubeModel->empty() && !needsUpdate) return; // No need to recompute BBox if immobile nor if mesh didn't change.
+    if (!isMoving() && !cubeModel->empty() && !m_needsUpdate) return; // No need to recompute BBox if immobile nor if mesh didn't change.
 
     // set to false to avoid excesive loop
-    needsUpdate=false;
+    m_needsUpdate=false;
 
     defaulttype::Vector3 minElem, maxElem;
     const VecCoord& x = this->m_mstate->read(core::ConstVecCoordId::position())->getValue();
 
-    const bool calcNormals = computeNormals.getValue();
+    const bool calcNormals = d_computeNormals.getValue();
 
     cubeModel->resize(size);  // size = number of triangles
     if (!empty())
@@ -356,10 +356,10 @@ void TTriangleModel<DataTypes>::computeContinuousBoundingTree(double dt, int max
     if (m_topology->getRevision() != m_topologyRevision)
         updateFromTopology();
 
-    if (needsUpdate) cubeModel->resize(0);
-    if (!isMoving() && !cubeModel->empty() && !needsUpdate) return; // No need to recompute BBox if immobile nor if mesh didn't change.
+    if (m_needsUpdate) cubeModel->resize(0);
+    if (!isMoving() && !cubeModel->empty() && !m_needsUpdate) return; // No need to recompute BBox if immobile nor if mesh didn't change.
 
-    needsUpdate=false;
+    m_needsUpdate=false;
     defaulttype::Vector3 minElem, maxElem;
 
     cubeModel->resize(size);
@@ -507,7 +507,7 @@ void TTriangleModel<DataTypes>::draw(const core::visual::VisualParams* vparams)
         if (m_topology->getRevision() != m_topologyRevision)
             return;
 
-        if (bothSide.getValue() || vparams->displayFlags().getShowWireFrame())
+        if (d_bothSide.getValue() || vparams->displayFlags().getShowWireFrame())
             vparams->drawTool()->setPolygonMode(0,vparams->displayFlags().getShowWireFrame());
         else
         {

--- a/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
+++ b/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
@@ -50,10 +50,12 @@ namespace collision
 template<class DataTypes>
 TTriangleModel<DataTypes>::TTriangleModel()
     : bothSide(initData(&bothSide, false, "bothSide", "activate collision on both side of the triangle model") )
+    , computeNormals(initData(&computeNormals, true, "computeNormals", "set to false to disable computation of triangles normal"))
     , m_mstate(NULL)
     , m_topology(NULL)
-    , computeNormals(initData(&computeNormals, true, "computeNormals", "set to false to disable computation of triangles normal"))
-    , meshRevision(-1)
+    , needsUpdate(true)
+    , m_topologyRevision(-1)
+    , m_pointModels(NULL)
     , m_lmdFilter(NULL)
 {
     p_triangles = &my_triangles;
@@ -64,9 +66,6 @@ template<class DataTypes>
 void TTriangleModel<DataTypes>::resize(int size)
 {
     this->core::CollisionModel::resize(size);
-    //helper::vector<TriangleInfo>& e = *(elems.beginEdit());
-    //e.resize(size);
-    //elems.endEdit();
     normals.resize(size);
 }
 

--- a/applications/plugins/SofaMiscCollision/TriangleModelInRegularGrid.cpp
+++ b/applications/plugins/SofaMiscCollision/TriangleModelInRegularGrid.cpp
@@ -71,17 +71,17 @@ void TriangleModelInRegularGrid::init()
     TriangleModel::init();
 
     _topology = this->getContext()->getMeshTopology();
-    mstate = dynamic_cast< core::behavior::MechanicalState<Vec3Types>* > (getContext()->getMechanicalState());
+    m_mstate = dynamic_cast< core::behavior::MechanicalState<Vec3Types>* > (getContext()->getMechanicalState());
 
-    if( !mstate) { serr << "TriangleModelInRegularGrid requires a Vec3 Mechanical Model" << sendl; return;}
-    if (!_topology) { serr << "TriangleModelInRegularGrid requires a BaseMeshTopology" << sendl; return;}
+    if( !m_mstate) { serr << "TriangleModelInRegularGrid requires a Vec3 Mechanical Model" << sendl; return;}
+    if (!m_topology) { serr << "TriangleModelInRegularGrid requires a BaseMeshTopology" << sendl; return;}
 
     // Test if _topology depend on an higher topology (to compute Bounding Tree faster) and get it
     TopologicalMapping* _topoMapping = NULL;
     vector<TopologicalMapping*> topoVec;
     getContext()->get<TopologicalMapping> ( &topoVec, core::objectmodel::BaseContext::SearchRoot );
-    _higher_topo = _topology;
-    _higher_mstate = mstate;
+    _higher_topo = m_topology;
+    _higher_mstate = m_mstate;
     bool found = true;
     while ( found )
     {
@@ -114,7 +114,7 @@ void TriangleModelInRegularGrid::computeBoundingTree ( int )
     needsUpdate=false;
     Vector3 minElem, maxElem;
     const VecCoord& xHigh =_higher_mstate->read(core::ConstVecCoordId::position())->getValue();
-    const VecCoord& x =mstate->read(core::ConstVecCoordId::position())->getValue();
+    const VecCoord& x =m_mstate->read(core::ConstVecCoordId::position())->getValue();
 
     // no hierarchy
     if ( empty() )

--- a/applications/plugins/SofaMiscCollision/TriangleModelInRegularGrid.cpp
+++ b/applications/plugins/SofaMiscCollision/TriangleModelInRegularGrid.cpp
@@ -108,10 +108,10 @@ void TriangleModelInRegularGrid::computeBoundingTree ( int )
 {
     CubeModel* cubeModel = createPrevious<CubeModel>();
     updateFromTopology();
-    if ( needsUpdate && !cubeModel->empty() ) cubeModel->resize ( 0 );
-    if ( !isMoving() && !cubeModel->empty() && !needsUpdate ) return; // No need to recompute BBox if immobile
+    if ( m_needsUpdate && !cubeModel->empty() ) cubeModel->resize ( 0 );
+    if ( !isMoving() && !cubeModel->empty() && !m_needsUpdate ) return; // No need to recompute BBox if immobile
 
-    needsUpdate=false;
+    m_needsUpdate=false;
     Vector3 minElem, maxElem;
     const VecCoord& xHigh =_higher_mstate->read(core::ConstVecCoordId::position())->getValue();
     const VecCoord& x =m_mstate->read(core::ConstVecCoordId::position())->getValue();

--- a/examples/Components/topology/TopologicalModifiers/AddingTrianglesProcess.scn
+++ b/examples/Components/topology/TopologicalModifiers/AddingTrianglesProcess.scn
@@ -18,6 +18,7 @@
         <UniformMass totalMass="0.1" />
         <FixedConstraint template="Vec3" name="default6" indices="0 2 18 20" />
         <TriangularFEMForceField template="Vec3" name="FEM"  method="large"  poissonRatio="0.3"  youngModulus="60" />
+        <TriangleModel name="CollisionModel" />
         
         <OglModel template="ExtVec3f" name="Visual" color="red" />
 		<IdentityMapping template="Vec3d,ExtVec3f" name="default8"  input="@."  output="@Visual" />

--- a/examples/Components/topology/TopologicalModifiers/RemovingTrianglesProcess.scn
+++ b/examples/Components/topology/TopologicalModifiers/RemovingTrianglesProcess.scn
@@ -19,7 +19,7 @@
         <FixedConstraint template="Vec3" name="fix" indices="0 1" />
         <TriangularFEMForceField template="Vec3" name="FEM" method="large" poissonRatio="0.3" youngModulus="60" />
         <TriangularBendingSprings template="Vec3" name="FEM-Bend" stiffness="300" damping="1" />
-        
+        <TriangleModel name="CollisionModel" />
         <Node name="Visu">
             <OglModel template="ExtVec3" name="Visual" color="red" />
             <IdentityMapping template="Vec3,ExtVec3" input="@.." output="@Visual" />

--- a/modules/SofaConstraint/LocalMinDistance.cpp
+++ b/modules/SofaConstraint/LocalMinDistance.cpp
@@ -1429,7 +1429,7 @@ bool LocalMinDistance::testValidity(Line &l, const Vector3 &PQ)
 bool LocalMinDistance::testValidity(Triangle &t, const Vector3 &PQ)
 {
     TriangleModel *tM = t.getCollisionModel();
-    bool bothSide_computation = tM->bothSide.getValue();
+    bool bothSide_computation = tM->d_bothSide.getValue();
 
     if (!filterIntersection.getValue()  || bothSide_computation)
         return true;

--- a/modules/SofaGeneralMeshCollision/TriangleOctreeModel.cpp
+++ b/modules/SofaGeneralMeshCollision/TriangleOctreeModel.cpp
@@ -84,7 +84,7 @@ void TriangleOctreeModel::draw (const core::visual::VisualParams* vparams)
 
 void TriangleOctreeModel::computeBoundingTree(int maxDepth)
 {
-    const helper::vector<topology::Triangle>& tri = *p_triangles;
+    const helper::vector<topology::Triangle>& tri = *m_triangles;
     if(octreeRoot)
     {
         delete octreeRoot;

--- a/modules/SofaGeneralMeshCollision/TriangleOctreeModel.cpp
+++ b/modules/SofaGeneralMeshCollision/TriangleOctreeModel.cpp
@@ -84,7 +84,7 @@ void TriangleOctreeModel::draw (const core::visual::VisualParams* vparams)
 
 void TriangleOctreeModel::computeBoundingTree(int maxDepth)
 {
-    const helper::vector<topology::Triangle>& tri = *triangles;
+    const helper::vector<topology::Triangle>& tri = *p_triangles;
     if(octreeRoot)
     {
         delete octreeRoot;
@@ -95,16 +95,16 @@ void TriangleOctreeModel::computeBoundingTree(int maxDepth)
     updateFromTopology();
 
     if (!isMoving() && !cubeModel->empty()) return; // No need to recompute BBox if immobile
-    int size2=mstate->getSize();
+    int size2=m_mstate->getSize();
     pNorms.resize(size2);
     for(int i=0; i<size2; i++)
     {
         pNorms[i]=defaulttype::Vector3(0,0,0);
     }
     defaulttype::Vector3 minElem, maxElem;
-    maxElem[0]=minElem[0]=mstate->read(core::ConstVecCoordId::position())->getValue()[0][0];
-    maxElem[1]=minElem[1]=mstate->read(core::ConstVecCoordId::position())->getValue()[0][1];
-    maxElem[2]=minElem[2]=mstate->read(core::ConstVecCoordId::position())->getValue()[0][2];
+    maxElem[0]=minElem[0]=m_mstate->read(core::ConstVecCoordId::position())->getValue()[0][0];
+    maxElem[1]=minElem[1]=m_mstate->read(core::ConstVecCoordId::position())->getValue()[0][1];
+    maxElem[2]=minElem[2]=m_mstate->read(core::ConstVecCoordId::position())->getValue()[0][2];
 
     cubeModel->resize(1);  // size = number of triangles
     for (int i=1; i<size; i++)

--- a/modules/SofaGraphComponent/SofaGraphComponent_test/SceneChecker_test.cpp
+++ b/modules/SofaGraphComponent/SofaGraphComponent_test/SceneChecker_test.cpp
@@ -188,6 +188,7 @@ struct SceneChecker_test : public Sofa_test<>
         scene << "<?xml version='1.0'?>                                           \n"
               << "<Node name='Root' gravity='0 -9.81 0' time='0' animate='0' >    \n"
               << "    <MechanicalObject template='Vec3d' />                       \n"
+              << "    <MeshTopology />                                            \n"
               << "    <" << componentName << "/>                                  \n"
               << "</Node>                                                         \n";
 


### PR DESCRIPTION
Fix crash when removing triangles in scene using TriangleModel component.

Clean and comment the class while undusting it (sorry hard to read the diff)

- remove serr/sout
- change all protected members prefix
- rewritte init and updateFromTopology methods
- Remove the handleTopologyChange method. As this class use directly the topology buffers, no need neither for TopologyData. Just check the topology revision and update the component if topology has changed.
- Update RemovingTrianglesProcess and AddingTrianglesProcess tests scenes to test the TriangleModel
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
