### PR TITLE
[MultiThreading] TaskAllocator Interface

### DIFF
--- a/SofaKernel/framework/framework_test/simulation/TaskSchedulerTestTasks.cpp
+++ b/SofaKernel/framework/framework_test/simulation/TaskSchedulerTestTasks.cpp
@@ -8,12 +8,12 @@ namespace sofa
 {
 
 
-	bool FibonacciTask::run()
+    Task::MemoryAlloc FibonacciTask::run()
 	{
 		if (_N < 2)
 		{
 			*_sum = _N;
-			return false;
+			return MemoryAlloc::Stack;
 		}
 
 		Task::Status status;
@@ -32,18 +32,18 @@ namespace sofa
 		// Do the sum
 		*_sum = x + y;
 
-		return false;
+		return MemoryAlloc::Stack;
 	}
 
 
 
-	bool IntSumTask::run()
+    Task::MemoryAlloc IntSumTask::run()
 	{
 		const int64_t count = _last - _first;
 		if (count < 1)
 		{
 			*_sum = _first;
-			return false;
+			return MemoryAlloc::Stack;
 		}
 
 		const int64_t mid = _first + (count / 2);
@@ -65,7 +65,7 @@ namespace sofa
 		*_sum = x + y;
 
 
-		return false;
+		return MemoryAlloc::Stack;
 	}
 	
 

--- a/SofaKernel/framework/framework_test/simulation/TaskSchedulerTestTasks.h
+++ b/SofaKernel/framework/framework_test/simulation/TaskSchedulerTestTasks.h
@@ -17,7 +17,7 @@ namespace sofa
 
 		virtual ~FibonacciTask() { }
 
-		virtual bool run() final;
+		virtual MemoryAlloc run() final;
 
 	private:
 
@@ -40,7 +40,7 @@ namespace sofa
 
 		virtual ~IntSumTask() {}
 
-		virtual bool run() final;
+		virtual MemoryAlloc run() final;
 
 
 	private:

--- a/SofaKernel/framework/sofa/simulation/DefaultTaskScheduler.cpp
+++ b/SofaKernel/framework/sofa/simulation/DefaultTaskScheduler.cpp
@@ -1,4 +1,4 @@
-#include "DefaultTaskScheduler.h"
+#include <sofa/simulation/DefaultTaskScheduler.h>
 
 #include <sofa/helper/system/thread/thread_specific_ptr.h>
 

--- a/SofaKernel/framework/sofa/simulation/DefaultTaskScheduler.cpp
+++ b/SofaKernel/framework/sofa/simulation/DefaultTaskScheduler.cpp
@@ -15,7 +15,7 @@ namespace sofa
         DEFINE_TASK_SCHEDULER_PROFILER(Steal);
 
 
-        class DefaultTaskAllocator : public Task::Allocator
+        class StdTaskAllocator : public Task::Allocator
         {
         public:
 
@@ -30,7 +30,7 @@ namespace sofa
             }
         };
 
-        static DefaultTaskAllocator defaultTaskAllocator;
+        static StdTaskAllocator defaultTaskAllocator;
 
 
 

--- a/SofaKernel/framework/sofa/simulation/DefaultTaskScheduler.h
+++ b/SofaKernel/framework/sofa/simulation/DefaultTaskScheduler.h
@@ -177,8 +177,7 @@ namespace sofa  {
             // queue task if there is space, and run it otherwise
             virtual bool addTask(Task* task) final;
             virtual void workUntilDone(Task::Status* status) final;
-            virtual void* allocateTask(size_t size) final;
-            virtual void releaseTask(Task*) final;
+            virtual Task::Allocator* getTaskAllocator() final;
 
         public:
 

--- a/SofaKernel/framework/sofa/simulation/DefaultTaskScheduler.h
+++ b/SofaKernel/framework/sofa/simulation/DefaultTaskScheduler.h
@@ -25,7 +25,7 @@
 #include <sofa/config.h>
 #include <sofa/helper/system/config.h>
 
-#include "TaskScheduler.h"
+#include <sofa/simulation/TaskScheduler.h>
 
 #include <atomic>
 
@@ -40,7 +40,7 @@
 
 
 // workerthread
-#include "Locks.h"
+#include <sofa/simulation/Locks.h>
 
 
 namespace sofa  {

--- a/SofaKernel/framework/sofa/simulation/InitTasks.cpp
+++ b/SofaKernel/framework/sofa/simulation/InitTasks.cpp
@@ -1,4 +1,4 @@
-#include "InitTasks.h"
+#include <sofa/simulation/InitTasks.h>
 
 #include <sofa/core/behavior/BaseAnimationLoop.h>
 #include <sofa/core/ExecParams.h>

--- a/SofaKernel/framework/sofa/simulation/InitTasks.cpp
+++ b/SofaKernel/framework/sofa/simulation/InitTasks.cpp
@@ -22,7 +22,7 @@ namespace sofa
         {
         }
 
-        bool InitPerThreadDataTask::run()
+        Task::MemoryAlloc InitPerThreadDataTask::run()
         {
 
             core::ExecParams::defaultInstance();
@@ -50,7 +50,7 @@ namespace sofa
                 // yield while waiting  
                 std::this_thread::yield();
             }
-            return true;
+            return Task::MemoryAlloc::Dynamic;
         }
 
         

--- a/SofaKernel/framework/sofa/simulation/InitTasks.h
+++ b/SofaKernel/framework/sofa/simulation/InitTasks.h
@@ -22,7 +22,7 @@
 #ifndef InitTasks_h__
 #define InitTasks_h__
 
-#include "TaskScheduler.h"
+#include <sofa/simulation/TaskScheduler.h>
 
 namespace sofa
 {

--- a/SofaKernel/framework/sofa/simulation/InitTasks.h
+++ b/SofaKernel/framework/sofa/simulation/InitTasks.h
@@ -42,7 +42,7 @@ namespace sofa
 
             virtual ~InitPerThreadDataTask();
 
-            virtual bool run() override;
+            virtual MemoryAlloc run() override;
 
         private:
 

--- a/SofaKernel/framework/sofa/simulation/Task.cpp
+++ b/SofaKernel/framework/sofa/simulation/Task.cpp
@@ -1,7 +1,4 @@
-#include "Task.h"
-
-//#include "TaskScheduler.h"
-//#include "TasksAllocator.h"
+#include <sofa/simulation/Task.h>
 
 #include <assert.h>
 #include <thread>

--- a/SofaKernel/framework/sofa/simulation/Task.cpp
+++ b/SofaKernel/framework/sofa/simulation/Task.cpp
@@ -5,12 +5,15 @@
 
 #include <assert.h>
 #include <thread>
-//#include <boost/thread.hpp>
+
 
 namespace sofa
 {
 	namespace simulation
 	{
+        
+
+        Task::Allocator* Task::_allocator = nullptr;
 
 
 		Task::Task(const Task::Status* status)
@@ -34,7 +37,7 @@ namespace sofa
 		{
 		}
 
-		bool ThreadSpecificTask::run()
+        Task::MemoryAlloc ThreadSpecificTask::run()
 		{  
 
 			runThreadSpecific();
@@ -51,7 +54,7 @@ namespace sofa
 				// yield while waiting  
 				std::this_thread::yield();
 			}  
-			return false;
+			return Task::MemoryAlloc::Stack;
 		}  
 
 	

--- a/SofaKernel/framework/sofa/simulation/Task.h
+++ b/SofaKernel/framework/sofa/simulation/Task.h
@@ -117,7 +117,10 @@ namespace sofa
 
             // no array new and delete operators
             static void* operator new[](std::size_t sz) = delete;
-            static void operator delete[](void* ptr) = delete;
+
+            // visual studio 2015 complains about the = delete but it doens't explain where this operator is call
+            // no problem with other sompilers included visual studio 2017
+            //static void operator delete[](void* ptr) = delete;
 
 
         public:

--- a/SofaKernel/framework/sofa/simulation/Task.h
+++ b/SofaKernel/framework/sofa/simulation/Task.h
@@ -27,15 +27,11 @@
 #include <atomic>
 #include <mutex>
 
-#include <boost/pool/singleton_pool.hpp>
-
 
 namespace sofa
 {
 	namespace simulation
     {
-
-
 
 
         class SOFA_SIMULATION_CORE_API Task

--- a/SofaKernel/framework/sofa/simulation/Task.h
+++ b/SofaKernel/framework/sofa/simulation/Task.h
@@ -96,21 +96,28 @@ namespace sofa
             virtual MemoryAlloc run() = 0;
 
 
+
             static void* operator new (std::size_t sz)
             {
                 return _allocator->allocate(sz);
             }
-             
-            // not available now. 
+            
+            // when c++14 is available delete the void  operator delete  (void* ptr)
+            // and define the void operator delete  (void* ptr, std::size_t sz)
+            static void  operator delete  (void* ptr)
+            {
+                _allocator->free(ptr, 0);
+            }
+
+            // only available in c++14. 
             static void operator delete  (void* ptr, std::size_t sz)
             {
                 _allocator->free(ptr, sz);
             }
-            
 
-        private:
-            // to force call to delete (void* ptr, std::size_t sz)
-            static void  operator delete  (void* ptr) = delete;
+            // no array new and delete operators
+            static void* operator new[](std::size_t sz) = delete;
+            static void operator delete[](void* ptr) = delete;
 
 
         public:

--- a/SofaKernel/framework/sofa/simulation/TaskScheduler.cpp
+++ b/SofaKernel/framework/sofa/simulation/TaskScheduler.cpp
@@ -1,6 +1,6 @@
-#include "TaskScheduler.h"
+#include <sofa/simulation/TaskScheduler.h>
 
-#include "DefaultTaskScheduler.h"
+#include <sofa/simulation/DefaultTaskScheduler.h>
 
 //#include <sofa/helper/system/thread/CTime.h>
 

--- a/SofaKernel/framework/sofa/simulation/TaskScheduler.cpp
+++ b/SofaKernel/framework/sofa/simulation/TaskScheduler.cpp
@@ -45,7 +45,10 @@ namespace sofa
 
             TaskSchedulerCreatorFunction& creatorFunc = iter->second;
             _currentScheduler = creatorFunc();
+            
             _currentSchedulerName = iter->first;
+
+            Task::setAllocator(_currentScheduler->getTaskAllocator());
 
             return _currentScheduler;
         }

--- a/SofaKernel/framework/sofa/simulation/TaskScheduler.h
+++ b/SofaKernel/framework/sofa/simulation/TaskScheduler.h
@@ -25,15 +25,14 @@
 #include <sofa/config.h>
 #include <sofa/helper/system/config.h>
 
-#include "Task.h"
-#include "Locks.h"
+#include <sofa/simulation/Task.h>
+#include <sofa/simulation/Locks.h>
 
 #include <thread>
 #include <mutex>
 #include <condition_variable>
 #include <memory>
 #include <map>
-//#include <deque>
 #include <string> 
 
 

--- a/SofaKernel/framework/sofa/simulation/TaskScheduler.h
+++ b/SofaKernel/framework/sofa/simulation/TaskScheduler.h
@@ -34,7 +34,7 @@
 #include <memory>
 #include <map>
 #include <string> 
-
+#include <functional>
 
 namespace sofa
 {

--- a/SofaKernel/framework/sofa/simulation/TaskScheduler.h
+++ b/SofaKernel/framework/sofa/simulation/TaskScheduler.h
@@ -33,7 +33,7 @@
 #include <condition_variable>
 #include <memory>
 #include <map>
-#include <deque>
+//#include <deque>
 #include <string> 
 
 
@@ -75,9 +75,8 @@ namespace sofa
 
             virtual void workUntilDone(Task::Status* status) = 0;
 
-            virtual void* allocateTask(size_t size) = 0;
+            virtual Task::Allocator* getTaskAllocator() = 0;
 
-            virtual void releaseTask(Task*) = 0;
 
         protected:
 

--- a/applications/plugins/MultiThreading/src/AnimationLoopTasks.cpp
+++ b/applications/plugins/MultiThreading/src/AnimationLoopTasks.cpp
@@ -30,10 +30,10 @@ namespace sofa
         }
         
         
-        bool StepTask::run()
+        Task::MemoryAlloc StepTask::run()
         {
             animationloop->step( core::ExecParams::defaultInstance(), dt);
-            return true;
+            return Task::MemoryAlloc::Dynamic;
         }        
         
     } // namespace simulation

--- a/applications/plugins/MultiThreading/src/AnimationLoopTasks.h
+++ b/applications/plugins/MultiThreading/src/AnimationLoopTasks.h
@@ -52,7 +52,7 @@ namespace sofa
             
             virtual ~StepTask();
             
-            virtual bool run() final;
+            virtual MemoryAlloc run() final;
             
             
         private:

--- a/applications/plugins/MultiThreading/src/BeamLinearMapping_mt.h
+++ b/applications/plugins/MultiThreading/src/BeamLinearMapping_mt.h
@@ -111,7 +111,7 @@ private:
 
 	public:
 
-		virtual bool run() final;
+		virtual MemoryAlloc run() final;
 
 	protected:
 
@@ -141,7 +141,7 @@ private:
 	
 		applyJTask( const simulation::Task::Status* status );
 
-		virtual bool run() final;
+		virtual MemoryAlloc run() final;
 
 	private:
 
@@ -166,7 +166,7 @@ private:
 		
 		applyJTmechTask( const simulation::Task::Status* status );
 	
-		virtual bool run() final;
+		virtual MemoryAlloc run() final;
 
 	private:
 

--- a/applications/plugins/MultiThreading/src/BeamLinearMapping_tasks.inl
+++ b/applications/plugins/MultiThreading/src/BeamLinearMapping_tasks.inl
@@ -51,7 +51,7 @@ namespace mapping
 
 
 	template <class TIn, class TOut>
-	bool BeamLinearMapping_mt< TIn, TOut>::applyTask::run()
+    simulation::Task::MemoryAlloc BeamLinearMapping_mt< TIn, TOut>::applyTask::run()
 	{
 		for (size_t i = _firstPoint; i < _lastPoint; ++i )
 		{
@@ -79,7 +79,7 @@ namespace mapping
 			fact = 3*(fact*fact)-2*(fact*fact*fact);
 			(*_out)[i] = out0 * (1-fact) + out1 * (fact);
 		}
-		return false;
+		return MemoryAlloc::Stack;
 	}
 
 
@@ -97,7 +97,7 @@ namespace mapping
 
 
 	template <class TIn, class TOut>
-	bool BeamLinearMapping_mt< TIn, TOut>::applyJTask::run()
+    simulation::Task::MemoryAlloc BeamLinearMapping_mt< TIn, TOut>::applyJTask::run()
 	{
 		for (size_t i = _firstPoint; i < _lastPoint; ++i )
 		{
@@ -128,7 +128,7 @@ namespace mapping
 			
 			(*_out)[i] = out0 * (1-fact) + out1 * (fact);
 		}
-		return false;
+		return MemoryAlloc::Stack;
 	}
 
 
@@ -146,7 +146,7 @@ namespace mapping
 
 
 	template <class TIn, class TOut>
-	bool BeamLinearMapping_mt< TIn, TOut>::applyJTmechTask::run()
+    simulation::Task::MemoryAlloc BeamLinearMapping_mt< TIn, TOut>::applyJTmechTask::run()
 	{
 		for (size_t i = _firstPoint; i < _lastPoint; ++i )
 		{
@@ -183,7 +183,7 @@ namespace mapping
 			getVOrientation(_out1) += cross( rotatedPoint1, f) * (fact);
 
 		}
-		return false;
+		return MemoryAlloc::Stack;
 	}
 
 


### PR DESCRIPTION
Add TaskAllocator interface to customize the task dynamic allocations and its standard implementation using operator new.

The PR also include a change of return type of Task::run() function from bool to enum MemoryAlloc to let the scheduler know if the task must be deallocated or not just after it has been executed.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
