### PR TITLE
[All] Replace deprecated c++ standard binder component

### DIFF
--- a/SofaKernel/extlibs/eigen-3.2.7/Eigen/src/Core/Functors.h
+++ b/SofaKernel/extlibs/eigen-3.2.7/Eigen/src/Core/Functors.h
@@ -975,6 +975,8 @@ template<typename T>
 struct functor_traits<std::not_equal_to<T> >
 { enum { Cost = 1, PacketAccess = false }; };
 
+#if (__cplusplus < 201103L) && (EIGEN_COMP_MSVC <= 1900)
+// std::binder* are deprecated since c++11 and will be removed in c++17
 template<typename T>
 struct functor_traits<std::binder2nd<T> >
 { enum { Cost = functor_traits<T>::Cost, PacketAccess = false }; };
@@ -982,6 +984,7 @@ struct functor_traits<std::binder2nd<T> >
 template<typename T>
 struct functor_traits<std::binder1st<T> >
 { enum { Cost = functor_traits<T>::Cost, PacketAccess = false }; };
+#endif
 
 template<typename T>
 struct functor_traits<std::unary_negate<T> >

--- a/SofaKernel/framework/sofa/simulation/MechanicalVisitor.h
+++ b/SofaKernel/framework/sofa/simulation/MechanicalVisitor.h
@@ -70,14 +70,6 @@ protected:
     virtual Result processNodeTopDown(simulation::Node* node, VisitorContext* ctx);
     virtual void processNodeBottomUp(simulation::Node* node, VisitorContext* ctx);
 
-    struct forceMaskActivator : public std::binary_function<core::behavior::BaseMechanicalState*, bool , void >
-    {
-        void operator()( core::behavior::BaseMechanicalState* m, bool activate ) const
-        {
-            m->forceMask.activate(activate);
-        }
-    };
-
 public:
 
     BaseMechanicalVisitor(const core::ExecParams* params)
@@ -109,12 +101,16 @@ public:
 
     static inline void ForceMaskActivate( const helper::vector<core::behavior::BaseMechanicalState*>& v )
     {
-        std::for_each( v.begin(), v.end(), std::bind2nd( forceMaskActivator(), true ) );
+        std::for_each( v.begin(), v.end(), [](core::behavior::BaseMechanicalState* m) {
+            m->forceMask.activate(true);
+        });
     }
 
     static inline void ForceMaskDeactivate( const helper::vector<core::behavior::BaseMechanicalState*>& v)
     {
-        std::for_each( v.begin(), v.end(), std::bind2nd( forceMaskActivator(), false ) );
+        std::for_each( v.begin(), v.end(), [](core::behavior::BaseMechanicalState* m) {
+            m->forceMask.activate(false);
+        });
     }
 
 


### PR DESCRIPTION
When compiling a project/plugin with c++17, it fails due to std::binder used in Sofa and Eigen. This functionality was depreciated in c++11 and was removed in c++17 (lambda expressions are now the cool way to do this).

This PR removes the use of std::binder and, as a side effect, brings us closer to be able to compile Sofa with c++ > 11 if we wish to do some modern c++ someday :-) .

Small note: The version of Eigen used in Sofa is a little bit old (2015)... Might be a good idea to add this in the Sofa's to do list.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
