### PR TITLE
[SofaLoader] Fix positions when handleSeams is activated in MeshObjLoader

### DIFF
--- a/SofaKernel/modules/SofaLoader/MeshObjLoader.cpp
+++ b/SofaKernel/modules/SofaLoader/MeshObjLoader.cpp
@@ -454,7 +454,6 @@ bool MeshObjLoader::readOBJ (std::ifstream &file, const char* filename)
 
         // Then we can create the final arrays
         helper::vector<sofa::defaulttype::Vector3> vertices2;
-        //helper::WriteAccessor<Data<helper::vector<sofa::defaulttype::Vector3> > > vertices2 = d_positions;
         helper::WriteAccessor<Data<helper::vector<sofa::defaulttype::Vector3> > > vnormals = d_normals;
         helper::WriteAccessor<Data<helper::vector<sofa::defaulttype::Vector2> > > vtexcoords = texCoords;
         helper::WriteAccessor<Data<helper::vector<int> > > vertPosIdx = d_vertPosIdx;

--- a/SofaKernel/modules/SofaLoader/MeshObjLoader.cpp
+++ b/SofaKernel/modules/SofaLoader/MeshObjLoader.cpp
@@ -418,7 +418,7 @@ bool MeshObjLoader::readOBJ (std::ifstream &file, const char* filename)
     else
     { // handleSeam mode : vertices are duplicated in case they have different texcoords and/or normals
         // This code was initially in VisualModelImpl::setMesh()
-        
+
         int nbVIn = (int)my_positions.size();
         // First we compute for each point how many pair of normal/texcoord indices are used
         // The map store the final index of each combinaison
@@ -453,7 +453,8 @@ bool MeshObjLoader::readOBJ (std::ifstream &file, const char* filename)
             vsplit = true;
 
         // Then we can create the final arrays
-        helper::WriteAccessor<Data<helper::vector<sofa::defaulttype::Vector3> > > vertices2 = d_positions;
+        helper::vector<sofa::defaulttype::Vector3> vertices2;
+        //helper::WriteAccessor<Data<helper::vector<sofa::defaulttype::Vector3> > > vertices2 = d_positions;
         helper::WriteAccessor<Data<helper::vector<sofa::defaulttype::Vector3> > > vnormals = d_normals;
         helper::WriteAccessor<Data<helper::vector<sofa::defaulttype::Vector2> > > vtexcoords = texCoords;
         helper::WriteAccessor<Data<helper::vector<int> > > vertPosIdx = d_vertPosIdx;
@@ -497,6 +498,11 @@ bool MeshObjLoader::readOBJ (std::ifstream &file, const char* filename)
                 it->second = j++;
             }
         }
+
+        // replace the original (non duplicated) vector with the new one
+        my_positions.clear();
+        for(const sofa::defaulttype::Vector3& c : vertices2)
+            my_positions.push_back(c);
 
         if( vsplit && nbNOut == nbVOut )
             vertNormIdx.resize(0);


### PR DESCRIPTION
The option handleSeams was supposed to mimic the same mechanism as in the OglModel, i.e duplicated vertices when texture coordinates are present (as it is possible that one vertex has multiple texture coordinates).
This option never worked because of references errors ; this PR corrects it.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**