### PR TITLE
[BaseObject::draw()] call the draw function during the Transparent pass

### DIFF
--- a/SofaKernel/framework/sofa/simulation/VisualVisitor.cpp
+++ b/SofaKernel/framework/sofa/simulation/VisualVisitor.cpp
@@ -55,7 +55,7 @@ void VisualDrawVisitor::processNodeBottomUp(simulation::Node* node)
 
 void VisualDrawVisitor::processObject(simulation::Node* /*node*/, core::objectmodel::BaseObject* o)
 {
-    if (vparams->pass() == core::visual::VisualParams::Std || vparams->pass() == core::visual::VisualParams::Shadow)
+    if (vparams->pass() == core::visual::VisualParams::Transparent || vparams->pass() == core::visual::VisualParams::Shadow)
     {
         msg_info_when(DO_DEBUG_DRAW, o) << " entering VisualVisitor::draw()" ;
 


### PR DESCRIPTION
The BaseObject::draw() function should be used only for debugging purposes.
The BaseObject::draw() function is called when pass is standard and it is rendered before any VisualModel. Any overlay text rendered in BaseObject::draw() function is not visible.

This line change allows every component to display overlay text (for debugging purposes) always at the top in the viewport in the draw() functon.  






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
