### PR TITLE
[SofaCore] Collision visitor primitive tests count

### DIFF
--- a/SofaKernel/framework/sofa/core/collision/NarrowPhaseDetection.h
+++ b/SofaKernel/framework/sofa/core/collision/NarrowPhaseDetection.h
@@ -99,7 +99,9 @@ public:
 
     //sofa::helper::vector<std::pair<core::CollisionElementIterator, core::CollisionElementIterator> >& getCollisionElementPairs() { return elemPairs; }
 
-    const DetectionOutputMap& getDetectionOutputs()
+    const size_t getPrimitiveTestCount() const { return m_primitiveTestCount; }
+
+    const DetectionOutputMap& getDetectionOutputs() const
     {
         return m_outputsMap;
     }
@@ -137,6 +139,8 @@ private:
     std::map<Instance, DetectionOutputMap> m_storedOutputsMap;
 
     DetectionOutputMap m_outputsMap;
+
+    size_t m_primitiveTestCount;
 };
 
 } // namespace collision

--- a/SofaKernel/framework/sofa/core/collision/NarrowPhaseDetection.h
+++ b/SofaKernel/framework/sofa/core/collision/NarrowPhaseDetection.h
@@ -141,6 +141,7 @@ protected:
 private:
     std::map<Instance, DetectionOutputMap> m_storedOutputsMap;
 
+protected:
     DetectionOutputMap m_outputsMap;
 
     size_t m_primitiveTestCount; // used only for statistics purpose

--- a/SofaKernel/framework/sofa/core/collision/NarrowPhaseDetection.h
+++ b/SofaKernel/framework/sofa/core/collision/NarrowPhaseDetection.h
@@ -72,6 +72,9 @@ public:
     {
         for (sofa::helper::vector< std::pair<core::CollisionModel*, core::CollisionModel*> >::const_iterator it = v.begin(); it!=v.end(); it++)
             addCollisionPair(*it);
+
+        // m_outputsMap should just be filled in addCollisionPair function
+        m_primitiveTestCount = m_outputsMap.size();
     }
 
     virtual void endNarrowPhase()
@@ -99,7 +102,7 @@ public:
 
     //sofa::helper::vector<std::pair<core::CollisionElementIterator, core::CollisionElementIterator> >& getCollisionElementPairs() { return elemPairs; }
 
-    const size_t getPrimitiveTestCount() const { return m_primitiveTestCount; }
+    size_t getPrimitiveTestCount() const { return m_primitiveTestCount; }
 
     const DetectionOutputMap& getDetectionOutputs() const
     {
@@ -140,7 +143,7 @@ private:
 
     DetectionOutputMap m_outputsMap;
 
-    size_t m_primitiveTestCount;
+    size_t m_primitiveTestCount; // used only for statistics purpose
 };
 
 } // namespace collision

--- a/SofaKernel/framework/sofa/simulation/CollisionVisitor.cpp
+++ b/SofaKernel/framework/sofa/simulation/CollisionVisitor.cpp
@@ -74,7 +74,7 @@ void CollisionVisitor::processCollisionPipeline(simulation::Node*
     t0=begin(node, obj);
 #endif
     obj->computeCollisionDetection();
-    m_primitivesTest += obj->getNarrowPhaseDetection()->getPrimitiveTestCount();
+    m_primitiveTestCount += obj->getNarrowPhaseDetection()->getPrimitiveTestCount();
 #ifdef SOFA_DUMP_VISITOR_INFO
     end(node, obj,t0);
 #endif

--- a/SofaKernel/framework/sofa/simulation/CollisionVisitor.cpp
+++ b/SofaKernel/framework/sofa/simulation/CollisionVisitor.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #include <sofa/simulation/CollisionVisitor.h>
 #include <sofa/simulation/Node.h>
+#include <sofa/core/collision/NarrowPhaseDetection.h>
 
 namespace sofa
 {
@@ -73,6 +74,7 @@ void CollisionVisitor::processCollisionPipeline(simulation::Node*
     t0=begin(node, obj);
 #endif
     obj->computeCollisionDetection();
+    m_primitivesTest += obj->getNarrowPhaseDetection()->getPrimitiveTestCount();
 #ifdef SOFA_DUMP_VISITOR_INFO
     end(node, obj,t0);
 #endif

--- a/SofaKernel/framework/sofa/simulation/CollisionVisitor.h
+++ b/SofaKernel/framework/sofa/simulation/CollisionVisitor.h
@@ -38,7 +38,7 @@ namespace simulation
 class SOFA_SIMULATION_CORE_API CollisionVisitor : public Visitor
 {
 public:
-    CollisionVisitor(const core::ExecParams* params) :Visitor(params) {}
+    CollisionVisitor(const core::ExecParams* params) :Visitor(params) , m_primitivesTest(0) {}
 
     virtual void fwdConstraintSet(simulation::Node* node, core::behavior::BaseConstraintSet* cSet);
 
@@ -50,6 +50,10 @@ public:
     /// Only used for debugging / profiling purposes
     virtual const char* getCategoryName() const { return "collision"; }
     virtual const char* getClassName() const { return "CollisionVisitor"; }
+
+    const size_t getPrimitiveTestCount() const {return m_primitivesTest;}
+private:
+    size_t m_primitivesTest;
 };
 
 /// Remove collision response from last step

--- a/SofaKernel/framework/sofa/simulation/CollisionVisitor.h
+++ b/SofaKernel/framework/sofa/simulation/CollisionVisitor.h
@@ -38,7 +38,7 @@ namespace simulation
 class SOFA_SIMULATION_CORE_API CollisionVisitor : public Visitor
 {
 public:
-    CollisionVisitor(const core::ExecParams* params) :Visitor(params) , m_primitivesTest(0) {}
+    CollisionVisitor(const core::ExecParams* params) :Visitor(params) , m_primitiveTestCount(0) {}
 
     virtual void fwdConstraintSet(simulation::Node* node, core::behavior::BaseConstraintSet* cSet);
 
@@ -51,9 +51,9 @@ public:
     virtual const char* getCategoryName() const { return "collision"; }
     virtual const char* getClassName() const { return "CollisionVisitor"; }
 
-    const size_t getPrimitiveTestCount() const {return m_primitivesTest;}
+    const size_t getPrimitiveTestCount() const {return m_primitiveTestCount;}
 private:
-    size_t m_primitivesTest;
+    size_t m_primitiveTestCount;
 };
 
 /// Remove collision response from last step


### PR DESCRIPTION
Add a variable to count the number of primitve tests performed during the narrow phase of the collision detection.
This variable is only for statistics purpose



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
