### PR TITLE
[MultiThreading] Add a virtual function in TaskScheduler interface

### DIFF
--- a/SofaKernel/framework/sofa/simulation/TaskScheduler.h
+++ b/SofaKernel/framework/sofa/simulation/TaskScheduler.h
@@ -76,6 +76,7 @@ namespace sofa
 
             virtual Task::Allocator* getTaskAllocator() = 0;
 
+            virtual void keepThreadsActive(bool active) {};
 
         protected:
 


### PR DESCRIPTION
The TaskScheduler keepThreadsActive virtual function  can be overridden to allow to change worker threads waiting policy when there are no tasks to steal.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
