### PR TITLE
FIX : for compilation on Visual Studio 2015 with QWT plugin

### DIFF
--- a/SofaKernel/framework/sofa/helper/deque.h
+++ b/SofaKernel/framework/sofa/helper/deque.h
@@ -46,7 +46,7 @@ std::ostream& operator<< ( std::ostream& os, const std::deque<T>& d )
     if( d.size()>0 )
     {
         for( unsigned int i=0, iend=d.size()-1; i<iend; ++i ) os<<d[i]<<" ";
-        os<<d.last();
+        os<<d.back();
     }
     return os;
 }


### PR DESCRIPTION
This is a basic fix when compiling  sofa with Visual Studio 2015 and using the  QWT plugin
last() is replaced by back() for deque




______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
