### PR TITLE
[SofaBaseTopology] Pr change api numerical integration

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetGeometryAlgorithms.inl
@@ -64,7 +64,7 @@ void EdgeSetGeometryAlgorithms< DataTypes >::defineEdgeCubaturePoints() {
     // Gauss Legendre method : low  number of integration points for a given order
     // for order > 5 no closed form expression exists and therefore use values from http://www.holoborodko.com/pavel/numerical-methods/numerical-integration/#gauss_quadrature_abscissas_table
 
-    typename NumericalIntegrationDescriptor<typename EdgeSetGeometryAlgorithms< DataTypes >::Real,1>::QuadratureMethod m=NumericalIntegrationDescriptor<typename EdgeSetGeometryAlgorithms< DataTypes >::Real,1>::GAUSS_LEGENDRE_METHOD;
+    typename NumericalIntegrationDescriptor<typename EdgeSetGeometryAlgorithms< DataTypes >::Real,1>::QuadratureMethod m="Edge Gauss Legendre";
     typename NumericalIntegrationDescriptor<typename EdgeSetGeometryAlgorithms< DataTypes >::Real,1>::QuadraturePointArray qpa;
     BarycentricCoordinatesType v;
     Real div2 = 0.5;

--- a/SofaKernel/modules/SofaBaseTopology/HexahedronSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/HexahedronSetGeometryAlgorithms.inl
@@ -55,7 +55,7 @@ void HexahedronSetGeometryAlgorithms< DataTypes >::defineHexahedronCubaturePoint
 	typedef typename NumericalIntegrationDescriptor<typename HexahedronSetGeometryAlgorithms< DataTypes >::Real,3>::QuadraturePoint QuadraturePoint;
 	typedef typename NumericalIntegrationDescriptor<typename HexahedronSetGeometryAlgorithms< DataTypes >::Real,3>::BarycentricCoordinatesType BarycentricCoordinatesType;
 	// Gauss method
-	typename NumericalIntegrationDescriptor<typename HexahedronSetGeometryAlgorithms< DataTypes >::Real,3>::QuadratureMethod m=NumericalIntegrationDescriptor<typename HexahedronSetGeometryAlgorithms< DataTypes >::Real,3>::GAUSS_LEGENDRE_METHOD;
+	typename NumericalIntegrationDescriptor<typename HexahedronSetGeometryAlgorithms< DataTypes >::Real, 3>::QuadratureMethod m = "Hexahedron Gauss Legendre";
 	typename NumericalIntegrationDescriptor<typename HexahedronSetGeometryAlgorithms< DataTypes >::Real,3>::QuadraturePointArray qpa;
 	typename NumericalIntegrationDescriptor<typename EdgeSetGeometryAlgorithms< DataTypes >::Real,1>::QuadraturePointArray qpa1D;
 
@@ -70,7 +70,7 @@ void HexahedronSetGeometryAlgorithms< DataTypes >::defineHexahedronCubaturePoint
 	size_t o,i,j,k;
 	for (o=1;o<8;++o) {
 		qpa.clear();
-		qpa1D=nide.getQuadratureMethod(NumericalIntegrationDescriptor<typename EdgeSetGeometryAlgorithms< DataTypes >::Real,1>::GAUSS_LEGENDRE_METHOD,o);
+		qpa1D=nide.getQuadratureMethod("Edge Gauss Legendre",o);
 		for (i=0;i<qpa1D.size();++i) {
 			for (j=0;j<qpa1D.size();++j) {
 				for (k=0;k<qpa1D.size();++k) {

--- a/SofaKernel/modules/SofaBaseTopology/NumericalIntegrationDescriptor.h
+++ b/SofaKernel/modules/SofaBaseTopology/NumericalIntegrationDescriptor.h
@@ -45,20 +45,17 @@ public:
     typedef sofa::defaulttype::Vec<N, Real> BarycentricCoordinatesType;
 	typedef std::pair<BarycentricCoordinatesType,Real> QuadraturePoint;
 	typedef sofa::helper::vector<QuadraturePoint> QuadraturePointArray;
-	
-	typedef enum {
-		GAUSS_LEGENDRE_METHOD =0,
-		GAUSS_LOBATO_METHOD=1,
-		NEWTON_COTES_METHOD=2,
-		GAUSS_SIMPLEX_METHOD=3,
-		GAUSS_QUAD_METHOD=4,
-		GAUSS_CUBE_METHOD=5
-	} QuadratureMethod; 
+	typedef std::string QuadratureMethod;
+
 	typedef size_t IntegrationOrder;
 	typedef std::pair<QuadratureMethod,IntegrationOrder> QuadratureMethodKey;
-
+	/// prototype of function to compute on the fly the quadrature at a given order
+	typedef QuadraturePointArray(*QuadratureMethodFunction)(const IntegrationOrder);
 protected:
+	// map which stores the set of quadrature points for a given method and a given order
 	std::map<QuadratureMethodKey, QuadraturePointArray>  quadratureMap;
+	/// map which stores the function computing the quadrature point at a given order for a given  method 
+	std::map<QuadratureMethod, QuadratureMethodFunction>  quadratureFunctionMap;
 public:
 	/// empty constructor
 	NumericalIntegrationDescriptor(){}
@@ -70,6 +67,8 @@ public:
     std::set<IntegrationOrder> getIntegrationOrders(const QuadratureMethod qt) const;
 	/// add a quadrature method in the map
 	void addQuadratureMethod(const QuadratureMethod qt, const IntegrationOrder order, QuadraturePointArray qpa);
+	/// add a quadrature function in the dedicated map
+	void addQuadratureMethodFunction(const QuadratureMethod qt, const QuadratureMethodFunction fn);
 };
 
 #if  !defined(SOFA_COMPONENT_TOPOLOGY_NUMERICALINTEGRATIONDESCRIPTOR_CPP)

--- a/SofaKernel/modules/SofaBaseTopology/NumericalIntegrationDescriptor.inl
+++ b/SofaKernel/modules/SofaBaseTopology/NumericalIntegrationDescriptor.inl
@@ -42,7 +42,11 @@ typename NumericalIntegrationDescriptor<Real,N>::QuadraturePointArray NumericalI
 	if (it!=quadratureMap.end())
 		return ((*it).second);
 	else {
+		typename std::map<QuadratureMethod, QuadratureMethodFunction>::const_iterator itf = quadratureFunctionMap.find(qt);
 		QuadraturePointArray qpa;
+		if (itf != quadratureFunctionMap.end()) {
+			qpa = (*(*itf).second)(order);
+		}
 		return(qpa);
 	}
 
@@ -74,7 +78,13 @@ void NumericalIntegrationDescriptor<Real,N>::addQuadratureMethod(const Quadratur
 {
 	quadratureMap.insert(std::pair<QuadratureMethodKey,QuadraturePointArray>(QuadratureMethodKey(qt,order),qpa));
 }
-
+template< typename Real, int N>
+void NumericalIntegrationDescriptor<Real, N>::addQuadratureMethodFunction(const QuadratureMethod qt,  const QuadratureMethodFunction fn)
+{
+	if (fn) {
+		quadratureFunctionMap.insert(std::make_pair(qt, fn));
+	}
+}
 } // namespace topology
 
 } // namespace component

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetGeometryAlgorithms.inl
@@ -54,7 +54,7 @@ void TetrahedronSetGeometryAlgorithms< DataTypes >::defineTetrahedronCubaturePoi
     typedef typename NumericalIntegrationDescriptor<typename TetrahedronSetGeometryAlgorithms< DataTypes >::Real,4>::QuadraturePoint QuadraturePoint;
     typedef typename NumericalIntegrationDescriptor<typename TetrahedronSetGeometryAlgorithms< DataTypes >::Real,4>::BarycentricCoordinatesType BarycentricCoordinatesType;
     // Gauss method
-    typename NumericalIntegrationDescriptor<typename TetrahedronSetGeometryAlgorithms< DataTypes >::Real,4>::QuadratureMethod m=NumericalIntegrationDescriptor<typename TetrahedronSetGeometryAlgorithms< DataTypes >::Real,4>::GAUSS_SIMPLEX_METHOD;
+    typename NumericalIntegrationDescriptor<typename TetrahedronSetGeometryAlgorithms< DataTypes >::Real,4>::QuadratureMethod m="Tetrahedron Gauss";
     typename NumericalIntegrationDescriptor<typename TetrahedronSetGeometryAlgorithms< DataTypes >::Real,4>::QuadraturePointArray qpa;
     BarycentricCoordinatesType v;
     /// integration with linear accuracy.

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetGeometryAlgorithms.inl
@@ -59,7 +59,7 @@ void TriangleSetGeometryAlgorithms< DataTypes >::defineTetrahedronCubaturePoints
     typedef typename NumericalIntegrationDescriptor<typename TriangleSetGeometryAlgorithms< DataTypes >::Real,3>::QuadraturePoint QuadraturePoint;
     typedef typename NumericalIntegrationDescriptor<typename TriangleSetGeometryAlgorithms< DataTypes >::Real,3>::BarycentricCoordinatesType BarycentricCoordinatesType;
     // Gauss method
-    typename NumericalIntegrationDescriptor<typename TriangleSetGeometryAlgorithms< DataTypes >::Real,3>::QuadratureMethod m=NumericalIntegrationDescriptor<typename TriangleSetGeometryAlgorithms< DataTypes >::Real,3>::GAUSS_SIMPLEX_METHOD;
+	typename NumericalIntegrationDescriptor<typename TriangleSetGeometryAlgorithms< DataTypes >::Real, 3>::QuadratureMethod m = "Triangle Gauss";
     typename NumericalIntegrationDescriptor<typename TriangleSetGeometryAlgorithms< DataTypes >::Real,3>::QuadraturePointArray qpa;
     BarycentricCoordinatesType v;
     /// integration with linear accuracy.

--- a/applications/plugins/Flexible/quadrature/TopologyGaussPointSampler.h
+++ b/applications/plugins/Flexible/quadrature/TopologyGaussPointSampler.h
@@ -268,7 +268,7 @@ protected:
                 if(tetraGeoAlgo)  // retrieve gauss points from geometry algorithm
                 {
                     typedef topology::NumericalIntegrationDescriptor<Real,4> IntegrationDescriptor;
-                    IntegrationDescriptor::QuadraturePointArray qpa=tetraGeoAlgo->getTetrahedronNumericalIntegrationDescriptor().getQuadratureMethod( (IntegrationDescriptor::QuadratureMethod)3,this->f_order.getValue());
+                    IntegrationDescriptor::QuadraturePointArray qpa=tetraGeoAlgo->getTetrahedronNumericalIntegrationDescriptor().getQuadratureMethod("Tetrahedron Gauss",this->f_order.getValue());
                     for ( unsigned int i = 0; i < tetrahedra.size(); i++ ) if(isInIndices(indices,i))
                     {
                         const Coord p[4]={parent[tetrahedra[i][0]],parent[tetrahedra[i][1]],parent[tetrahedra[i][2]],parent[tetrahedra[i][3]]};

--- a/applications/plugins/Flexible/shapeFunction/BezierShapeFunction.cpp
+++ b/applications/plugins/Flexible/shapeFunction/BezierShapeFunction.cpp
@@ -36,10 +36,10 @@ using namespace core::behavior;
 
 // Register in the Factory
 int BezierShapeFunctionClass = core::RegisterObject("Computes Bezier shape functions")
-        .add< BezierShapeFunction<ShapeFunctiond> >(true)
+        .add< BezierShapeFunction<ShapeFunction3d> >(true)
         ;
 
-template class SOFA_Flexible_API BezierShapeFunction<ShapeFunctiond>;
+template class SOFA_Flexible_API BezierShapeFunction<ShapeFunction3d>;
 
 }
 }


### PR DESCRIPTION
ADD : use a string instead of an enum to specify an integration method as it easier for user to add new ones. This slightly changes the API of numerical integration.
ADD : add the possibility to add a function to create on the fly the required integration points (when an analytical formula is available).
UPDATE : modified the name of the integration methods for edges, triangles, tetrahedra and hexahedra.
UPDATE : use of numerical integration in Flexible
FIX : bug corrected when using of BezierShapeFunction with plugin HighOrderMeshes 



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
