### PR TITLE
Add possibilities to draw lines on surfaces in DrawTool

### DIFF
--- a/SofaKernel/framework/sofa/core/visual/DrawTool.h
+++ b/SofaKernel/framework/sofa/core/visual/DrawTool.h
@@ -206,11 +206,11 @@ public:
 
     /// draw 2D text at position (x,y) from top-left corner
     virtual void writeOverlayText( int x, int y, unsigned fontSize, const Vec4f &color, const char* text ) = 0;
-	
-	/// Allow a variable depth offset for polygon drawing  
-	virtual void enablePolygonOffset(float factor, float units) = 0;
-	/// Remove variable depth offset for polygon drawing
-	virtual void disablePolygonOffset() = 0;
+
+    /// Allow a variable depth offset for polygon drawing
+    virtual void enablePolygonOffset(float factor, float units) = 0;
+    /// Remove variable depth offset for polygon drawing
+    virtual void disablePolygonOffset() = 0;
 
     // @name Color Buffer method
     virtual void readPixels(int x, int y, int w, int h, float* rgb, float* z = NULL) = 0;

--- a/SofaKernel/framework/sofa/core/visual/DrawTool.h
+++ b/SofaKernel/framework/sofa/core/visual/DrawTool.h
@@ -206,6 +206,11 @@ public:
 
     /// draw 2D text at position (x,y) from top-left corner
     virtual void writeOverlayText( int x, int y, unsigned fontSize, const Vec4f &color, const char* text ) = 0;
+	
+	/// Allow a variable depth offset for polygon drawing  
+	virtual void enablePolygonOffset(float factor, float units) = 0;
+	/// Remove variable depth offset for polygon drawing
+	virtual void disablePolygonOffset() = 0;
 
     // @name Color Buffer method
     virtual void readPixels(int x, int y, int w, int h, float* rgb, float* z = NULL) = 0;

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
@@ -1268,7 +1268,15 @@ void DrawToolGL::disableBlending()
 {
     glDisable(GL_BLEND);
 }
-
+void DrawToolGL::enablePolygonOffset( float factor, float units)
+{
+	glEnable(GL_POLYGON_OFFSET_LINE);
+	glPolygonOffset(factor, units);
+}
+void DrawToolGL::disablePolygonOffset()
+{
+glDisable(GL_POLYGON_OFFSET_LINE);
+}
 void DrawToolGL::enableLighting()
 {
     glEnable(GL_LIGHTING);

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
@@ -1270,12 +1270,12 @@ void DrawToolGL::disableBlending()
 }
 void DrawToolGL::enablePolygonOffset( float factor, float units)
 {
-	glEnable(GL_POLYGON_OFFSET_LINE);
-	glPolygonOffset(factor, units);
+    glEnable(GL_POLYGON_OFFSET_LINE);
+    glPolygonOffset(factor, units);
 }
 void DrawToolGL::disablePolygonOffset()
 {
-glDisable(GL_POLYGON_OFFSET_LINE);
+    glDisable(GL_POLYGON_OFFSET_LINE);
 }
 void DrawToolGL::enableLighting()
 {

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.h
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.h
@@ -166,6 +166,9 @@ public:
 
     virtual void writeOverlayText( int x, int y, unsigned fontSize, const Vec4f &color, const char* text );
 
+	virtual void enablePolygonOffset(float factor, float units);
+	virtual void disablePolygonOffset();
+
     virtual void enableBlending();
     virtual void disableBlending();
 

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.h
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.h
@@ -166,8 +166,8 @@ public:
 
     virtual void writeOverlayText( int x, int y, unsigned fontSize, const Vec4f &color, const char* text );
 
-	virtual void enablePolygonOffset(float factor, float units);
-	virtual void disablePolygonOffset();
+    virtual void enablePolygonOffset(float factor, float units);
+    virtual void disablePolygonOffset();
 
     virtual void enableBlending();
     virtual void disableBlending();


### PR DESCRIPTION
Add 2 functions void enablePolygonOffset(float factor, float units); and l void disablePolygonOffset();
to handle the depth offset to draw lines on surfaces.


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
