### PR TITLE
[SofaGraphComponent] Run SceneChecker at each load

### DIFF
--- a/SofaKernel/framework/sofa/simulation/SceneLoaderFactory.cpp
+++ b/SofaKernel/framework/sofa/simulation/SceneLoaderFactory.cpp
@@ -30,7 +30,7 @@ namespace sofa
 namespace simulation
 {
 
-SceneLoader::Listeners SceneLoader::s_listerners;
+SceneLoader::Listeners SceneLoader::s_listeners;
 
 SceneLoaderFactory* SceneLoaderFactory::getInstance()
 {

--- a/SofaKernel/modules/SofaSimulationCommon/SceneLoaderPHP.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/SceneLoaderPHP.cpp
@@ -60,7 +60,7 @@ void SceneLoaderPHP::getExtensionList(ExtensionList* list)
 }
 
 
-sofa::simulation::Node::SPtr SceneLoaderPHP::load(const char *filename)
+sofa::simulation::Node::SPtr SceneLoaderPHP::doLoad(const char *filename)
 {
     sofa::simulation::Node::SPtr root;
 

--- a/SofaKernel/modules/SofaSimulationCommon/SceneLoaderPHP.h
+++ b/SofaKernel/modules/SofaSimulationCommon/SceneLoaderPHP.h
@@ -37,7 +37,7 @@ public:
     virtual bool canLoadFileExtension(const char *extension);
 
     /// load the file
-    virtual sofa::simulation::Node::SPtr load(const char *filename);
+    virtual sofa::simulation::Node::SPtr doLoad(const char *filename);
 
     /// get the file type description
     virtual std::string getFileTypeDesc();

--- a/SofaKernel/modules/SofaSimulationCommon/SceneLoaderXML.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/SceneLoaderXML.cpp
@@ -66,14 +66,12 @@ void SceneLoaderXML::getExtensionList(ExtensionList* list)
     list->push_back("scn");
 }
 
-sofa::simulation::Node::SPtr SceneLoaderXML::load(const char *filename)
+sofa::simulation::Node::SPtr SceneLoaderXML::doLoad(const char *filename)
 {
     sofa::simulation::Node::SPtr root;
 
     if (!canLoadFileName(filename))
         return 0;
-
-    notifyLoadingScene();
 
     xml::BaseElement* xml = xml::loadFromFile ( filename );
     root = processXML(xml, filename);
@@ -142,13 +140,14 @@ Node::SPtr SceneLoaderXML::processXML(xml::BaseElement* xml, const char *filenam
 /// Load from a string in memory
 Node::SPtr SceneLoaderXML::loadFromMemory ( const char *filename, const char *data, unsigned int size )
 {
-    notifyLoadingScene();
+    notifyLoadingSceneBefore();
 
     xml::BaseElement* xml = xml::loadFromMemory (filename, data, size );
 
     Node::SPtr root = processXML(xml, filename);
 
     delete xml;
+    notifyLoadingSceneAfter(root);
     return root;
 }
 

--- a/SofaKernel/modules/SofaSimulationCommon/SceneLoaderXML.h
+++ b/SofaKernel/modules/SofaSimulationCommon/SceneLoaderXML.h
@@ -41,7 +41,7 @@ public:
     virtual bool canWriteFileExtension(const char *extension);
 
     /// load the file
-    virtual sofa::simulation::Node::SPtr load(const char *filename);
+    virtual sofa::simulation::Node::SPtr doLoad(const char *filename);
 
     /// write the file
     virtual void write(sofa::simulation::Node* node, const char *filename);

--- a/applications/plugins/SofaPython/SceneLoaderPY.cpp
+++ b/applications/plugins/SofaPython/SceneLoaderPY.cpp
@@ -86,12 +86,22 @@ void SceneLoaderPY::getExtensionList(ExtensionList* list)
 sofa::simulation::Node::SPtr SceneLoaderPY::doLoad(const char *filename)
 {
     sofa::simulation::Node::SPtr root;
-    loadSceneWithArguments(filename, helper::ArgumentParser::extra_args(), &root);
+    doLoadSceneWithArguments(filename, helper::ArgumentParser::extra_args(), &root);
     return root;
 }
 
 
 void SceneLoaderPY::loadSceneWithArguments(const char *filename,
+                                           const std::vector<std::string>& arguments,
+                                           Node::SPtr* root_out)
+{
+    notifyLoadingSceneBefore();
+    doLoadSceneWithArguments(filename, arguments, root_out);
+    notifyLoadingSceneAfter(*root_out);
+}
+
+
+void SceneLoaderPY::doLoadSceneWithArguments(const char *filename,
                                            const std::vector<std::string>& arguments,
                                            Node::SPtr* root_out)
 {

--- a/applications/plugins/SofaPython/SceneLoaderPY.cpp
+++ b/applications/plugins/SofaPython/SceneLoaderPY.cpp
@@ -83,7 +83,7 @@ void SceneLoaderPY::getExtensionList(ExtensionList* list)
 }
 
 
-sofa::simulation::Node::SPtr SceneLoaderPY::load(const char *filename)
+sofa::simulation::Node::SPtr SceneLoaderPY::doLoad(const char *filename)
 {
     sofa::simulation::Node::SPtr root;
     loadSceneWithArguments(filename, helper::ArgumentParser::extra_args(), &root);
@@ -111,7 +111,6 @@ void SceneLoaderPY::loadSceneWithArguments(const char *filename,
     // We go the the current file's directory so that all relative path are correct
     SetDirectory chdir ( filename );
 
-    notifyLoadingScene();
     PythonEnvironment::setArguments(SetDirectory::GetFileName(filename), arguments);
     if(!PythonEnvironment::runFile(SetDirectory::GetFileName(filename)))
     {

--- a/applications/plugins/SofaPython/SceneLoaderPY.h
+++ b/applications/plugins/SofaPython/SceneLoaderPY.h
@@ -54,6 +54,7 @@ public:
 
     // max: added out parameter to get the root *before* createScene is called
     void loadSceneWithArguments(const char *filename, const std::vector<std::string>& arguments=std::vector<std::string>(0), Node::SPtr* root_out = 0);
+    virtual void doLoadSceneWithArguments(const char *filename, const std::vector<std::string>& arguments=std::vector<std::string>(0), Node::SPtr* root_out = 0);
     bool loadTestWithArguments(const char *filename, const std::vector<std::string>& arguments=std::vector<std::string>(0));
 
     /// write the file

--- a/applications/plugins/SofaPython/SceneLoaderPY.h
+++ b/applications/plugins/SofaPython/SceneLoaderPY.h
@@ -50,7 +50,7 @@ public:
     virtual bool canWriteFileExtension(const char *extension);
 
     /// load the file
-    virtual Node::SPtr load(const char *filename);
+    virtual Node::SPtr doLoad(const char *filename);
 
     // max: added out parameter to get the root *before* createScene is called
     void loadSceneWithArguments(const char *filename, const std::vector<std::string>& arguments=std::vector<std::string>(0), Node::SPtr* root_out = 0);

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -43,6 +43,9 @@ using std::vector;
 #include <SofaSimulationTree/init.h>
 #include <SofaSimulationTree/TreeSimulation.h>
 using sofa::simulation::Node;
+#include <sofa/simulation/SceneLoaderFactory.h>
+#include <SofaGraphComponent/SceneCheckerListener.h>
+using sofa::simulation::scenechecking::SceneCheckerListener;
 
 #include <SofaComponentCommon/initComponentCommon.h>
 #include <SofaComponentBase/initComponentBase.h>
@@ -198,6 +201,7 @@ int main(int argc, char** argv)
     bool        temporaryFile = false;
     bool        testMode = false;
     bool        noAutoloadPlugins = false;
+    bool        noSceneCheck = false;
     unsigned int nbMSSASamples = 1;
     bool computationTimeAtBegin = false;
     unsigned int computationTimeSampling=0; ///< Frequency of display of the computation time statistics, in number of animation steps. 0 means never.
@@ -238,6 +242,7 @@ int main(int argc, char** argv)
     argParser->addArgument(po::value<std::string>(&gui)->default_value(""),                                         "gui,g", gui_help.c_str());
     argParser->addArgument(po::value<std::vector<std::string>>(&plugins),                                           "load,l", "load given plugins");
     argParser->addArgument(po::value<bool>(&noAutoloadPlugins)->default_value(false)->implicit_value(true),         "noautoload", "disable plugins autoloading");
+    argParser->addArgument(po::value<bool>(&noSceneCheck)->default_value(false)->implicit_value(true),              "noscenecheck", "disable scene checking for each scene loading");
 
     // example of an option using lambda function which ensure the value passed is > 0
     argParser->addArgument(po::value<unsigned int>(&nbMSSASamples)->default_value(1)->notifier([](unsigned int value)
@@ -406,6 +411,12 @@ int main(int argc, char** argv)
 
     //To set a specific resolution for the viewer, use the component ViewerSetting in you scene graph
     GUIManager::SetDimension(width, height);
+
+    // Create and register the SceneCheckerListener before scene loading
+    if(!noSceneCheck)
+    {
+        sofa::simulation::SceneLoader::addListener( SceneCheckerListener::getInstance() );
+    }
 
     Node::SPtr groot = sofa::simulation::getSimulation()->load(fileName.c_str());
     if( !groot )

--- a/applications/sofa/gui/qt/RealGUI.cpp
+++ b/applications/sofa/gui/qt/RealGUI.cpp
@@ -116,14 +116,6 @@ using sofa::helper::system::FileMonitor;
 #include <sofa/helper/system/FileSystem.h>
 using sofa::helper::system::FileSystem;
 
-#include <SofaGraphComponent/SceneCheckAPIChange.h>
-using sofa::simulation::scenechecking::SceneCheckAPIChange;
-#include <SofaGraphComponent/SceneCheckMissingRequiredPlugin.h>
-using sofa::simulation::scenechecking::SceneCheckMissingRequiredPlugin;
-#include <SofaGraphComponent/SceneCheckDuplicatedName.h>
-using sofa::simulation::scenechecking::SceneCheckDuplicatedName;
-#include <SofaGraphComponent/SceneCheckUsingAlias.h>
-using sofa::simulation::scenechecking::SceneCheckUsingAlias;
 
 #include <sofa/core/ObjectFactory.h>
 using sofa::core::ObjectFactory;
@@ -473,11 +465,6 @@ RealGUI::RealGUI ( const char* viewername)
     connect(m_docbrowser, SIGNAL(visibilityChanged(bool)), this, SLOT(docBrowserVisibilityChanged(bool)));
 
     m_filelistener = new RealGUIFileListener(this);
-
-    m_sceneChecker.addCheck(SceneCheckAPIChange::newSPtr());
-    m_sceneChecker.addCheck(SceneCheckDuplicatedName::newSPtr());
-    m_sceneChecker.addCheck(SceneCheckMissingRequiredPlugin::newSPtr());
-    m_sceneChecker.addCheck(SceneCheckUsingAlias::newSPtr());
 }
 
 //------------------------------------
@@ -758,7 +745,6 @@ sofa::simulation::Node* RealGUI::currentSimulation()
 
 void RealGUI::fileOpen ( std::string filename, bool temporaryFile, bool reload )
 {
-    SceneCheckerVisitor checker(ExecParams::defaultInstance());
     std::vector<std::string> expandedNodes;
 
     if(reload)
@@ -983,7 +969,6 @@ void RealGUI::setSceneWithoutMonitor (Node::SPtr root, const char* filename, boo
             getQtViewer()->getQWidget()->update();
         }
 
-        m_sceneChecker.validate(root.get());
         resetScene();
     }
 }

--- a/applications/sofa/gui/qt/RealGUI.h
+++ b/applications/sofa/gui/qt/RealGUI.h
@@ -35,6 +35,9 @@
 #include <sofa/gui/BaseGUI.h>
 #include <sofa/gui/ViewerFactory.h>
 
+#include <SofaGraphComponent/SceneCheckerVisitor.h>
+using sofa::simulation::scenechecking::SceneCheckerVisitor;
+
 #include <set>
 #include <string>
 
@@ -209,6 +212,8 @@ protected:
     std::set<std::string>   m_modifiedLogFiles;
 
     bool m_enableInteraction {false};
+
+    SceneCheckerVisitor m_sceneChecker;
 private:
     //currently unused: scale is experimental
     float object_Scale[2];

--- a/applications/sofa/gui/qt/RealGUI.h
+++ b/applications/sofa/gui/qt/RealGUI.h
@@ -209,7 +209,6 @@ protected:
     std::set<std::string>   m_modifiedLogFiles;
 
     bool m_enableInteraction {false};
-
 private:
     //currently unused: scale is experimental
     float object_Scale[2];

--- a/applications/sofa/gui/qt/RealGUI.h
+++ b/applications/sofa/gui/qt/RealGUI.h
@@ -35,9 +35,6 @@
 #include <sofa/gui/BaseGUI.h>
 #include <sofa/gui/ViewerFactory.h>
 
-#include <SofaGraphComponent/SceneCheckerVisitor.h>
-using sofa::simulation::scenechecking::SceneCheckerVisitor;
-
 #include <set>
 #include <string>
 
@@ -213,7 +210,6 @@ protected:
 
     bool m_enableInteraction {false};
 
-    SceneCheckerVisitor m_sceneChecker;
 private:
     //currently unused: scale is experimental
     float object_Scale[2];

--- a/modules/SofaGraphComponent/CMakeLists.txt
+++ b/modules/SofaGraphComponent/CMakeLists.txt
@@ -30,6 +30,7 @@ list(APPEND HEADER_FILES
     SceneCheckAPIChange.h
     SceneCheckUsingAlias.h
     SceneCheckerVisitor.h
+    SceneCheckerListener.h
     APIVersion.h
     )
 list(APPEND SOURCE_FILES
@@ -50,6 +51,7 @@ list(APPEND SOURCE_FILES
     SceneCheckAPIChange.cpp
     SceneCheckUsingAlias.cpp
     SceneCheckerVisitor.cpp
+    SceneCheckerListener.cpp
     APIVersion.cpp
     )
 

--- a/modules/SofaGraphComponent/SceneCheckAPIChange.cpp
+++ b/modules/SofaGraphComponent/SceneCheckAPIChange.cpp
@@ -77,7 +77,7 @@ void SceneCheckAPIChange::doInit(Node* node)
     node->getTreeObject(apiversion);
     if(!apiversion)
     {
-        msg_info(this->getName()) << "The 'APIVersion' directive is missing in the current scene. Switching to the default APIVersion level '" << m_selectedApiLevel << "' ";
+        msg_info(this->getName()) << "No 'APIVersion' component in scene. Using the default APIVersion level: " << m_selectedApiLevel;
     }
     else
     {
@@ -96,11 +96,19 @@ void SceneCheckAPIChange::doCheckOn(Node* node)
 
     for (auto& object : node->object )
     {
+        Base* o = object.get();
+
+        if( deprecatedComponents.find( o->getClassName() ) != deprecatedComponents.end() )
+        {
+            msg_deprecated(o) << this->getName() << ": "
+                              << deprecatedComponents.at(o->getClassName()).getMessage();
+        }
+
         if(m_selectedApiLevel != m_currentApiLevel && m_changesets.find(m_selectedApiLevel) != m_changesets.end())
         {
             for(auto& hook : m_changesets[m_selectedApiLevel])
             {
-                hook(object.get());
+                hook(o);
             }
         }
     }
@@ -109,16 +117,10 @@ void SceneCheckAPIChange::doCheckOn(Node* node)
 
 void SceneCheckAPIChange::installDefaultChangeSets()
 {
-    addHookInChangeSet("17.06", [](Base* o){
+    addHookInChangeSet("17.06", [this](Base* o){
         if(o->getClassName() == "BoxStiffSpringForceField" )
-            msg_warning(o) << "BoxStiffSpringForceField have changed since 17.06. To use the old behavior you need to set parameter 'forceOldBehavior=true'";
-    });
-
-    addHookInChangeSet("17.06", [](Base* o){
-        if( deprecatedComponents.find( o->getClassName() ) != deprecatedComponents.end() )
-        {
-            msg_deprecated(o) << deprecatedComponents.at(o->getClassName()).getMessage();
-        }
+            msg_warning(o) << this->getName() << ": "
+                           << "BoxStiffSpringForceField have changed since 17.06. To use the old behavior you need to set parameter 'forceOldBehavior=true'";
     });
 }
 

--- a/modules/SofaGraphComponent/SceneCheckUsingAlias.cpp
+++ b/modules/SofaGraphComponent/SceneCheckUsingAlias.cpp
@@ -84,8 +84,11 @@ void SceneCheckUsingAlias::doPrintSummary()
         for(std::string &unique_alias : unique_aliases)
         {
             unsigned int count = std::count(i.second.begin(), i.second.end(), unique_alias);
-            usingAliasesWarning << "  - " << i.first << ": " << count << " created with alias \"" <<  unique_alias << "\"" << msgendl;
+            usingAliasesWarning << "  - " << i.first << ": " << count << " created with alias \"" <<  unique_alias << "\"";
+            if(unique_alias != unique_aliases.back()) usingAliasesWarning << msgendl;
         }
+
+        if(i.first != m_componentsCreatedUsingAlias.rbegin()->first) usingAliasesWarning << msgendl;
     }
     msg_warning(this->getName()) << usingAliasesWarning.str();
 

--- a/modules/SofaGraphComponent/SceneCheckUsingAlias.cpp
+++ b/modules/SofaGraphComponent/SceneCheckUsingAlias.cpp
@@ -42,15 +42,10 @@ SceneCheckUsingAlias::SceneCheckUsingAlias()
 {
     /// Add a callback to be n
     ObjectFactory::getInstance()->setCallback([this](Base* o, BaseObjectDescription *arg) {
-        if (o->getClassName() != arg->getAttribute("type", "") )
+        std::string typeNameInScene = arg->getAttribute("type", "");
+        if ( typeNameInScene != o->getClassName() )
         {
-            std::string alias = arg->getAttribute("type", "");
-
-            std::vector<std::string> v = this->m_componentsCreatedUsingAlias[o->getClassName()];
-            if ( std::find(v.begin(), v.end(), alias) == v.end() )
-            {
-                this->m_componentsCreatedUsingAlias[o->getClassName()].push_back(alias);
-            }
+            this->m_componentsCreatedUsingAlias[o->getClassName()].push_back(typeNameInScene);
         }
     });
 }
@@ -82,24 +77,19 @@ void SceneCheckUsingAlias::doPrintSummary()
                            "use with caution." << msgendl;
     for (auto i : this->m_componentsCreatedUsingAlias)
     {
-        if (i.second.size() > 1)
-            usingAliasesWarning << "  - " << i.first << " have been created using the aliases ";
-        else
-            usingAliasesWarning << "  - " << i.first << " has been created using the alias ";
+        std::vector<std::string> unique_aliases(i.second);
+        std::sort( unique_aliases.begin(), unique_aliases.end() );
+        unique_aliases.erase( std::unique(unique_aliases.begin(), unique_aliases.end()), unique_aliases.end() );
 
-        bool first = true;
-        for (std::string &alias : i.second)
+        for(std::string &unique_alias : unique_aliases)
         {
-            if (first)
-                usingAliasesWarning << "\"" << alias << "\"";
-            else
-                usingAliasesWarning << ", \"" << alias << "\"";
-
-            first = false;
+            unsigned int count = std::count(i.second.begin(), i.second.end(), unique_alias);
+            usingAliasesWarning << "  - " << i.first << ": " << count << " created with alias \"" <<  unique_alias << "\"" << msgendl;
         }
-        usingAliasesWarning << "." << msgendl;
     }
     msg_warning(this->getName()) << usingAliasesWarning.str();
+
+    m_componentsCreatedUsingAlias.clear();
 }
 
 } // namespace _scenechecking_

--- a/modules/SofaGraphComponent/SceneCheckerListener.cpp
+++ b/modules/SofaGraphComponent/SceneCheckerListener.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
 *       SOFA, Simulation Open-Framework Architecture, development version     *
-*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
+*                (c) 2006-2019 INRIA, USTL, UJF, CNRS, MGH                    *
 *                                                                             *
 * This program is free software; you can redistribute it and/or modify it     *
 * under the terms of the GNU Lesser General Public License as published by    *

--- a/modules/SofaGraphComponent/SceneCheckerListener.cpp
+++ b/modules/SofaGraphComponent/SceneCheckerListener.cpp
@@ -19,31 +19,36 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <sofa/helper/system/config.h>
-#include <SofaGraphComponent/initGraphComponent.h>
-
-#include <sofa/simulation/SceneLoaderFactory.h>
-#include <SofaGraphComponent/SceneCheckerListener.h>
-using sofa::simulation::scenechecking::SceneCheckerListener;
+#include "SceneCheckerListener.h"
 
 namespace sofa
 {
-
-namespace component
+namespace simulation
+{
+namespace _scenechecking_
 {
 
 
-void initGraphComponent()
+SceneCheckerListener::SceneCheckerListener()
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
-
-    sofa::simulation::SceneLoader::addListener( SceneCheckerListener::getInstance() );
+    m_sceneChecker.addCheck(SceneCheckAPIChange::newSPtr());
+    m_sceneChecker.addCheck(SceneCheckDuplicatedName::newSPtr());
+    m_sceneChecker.addCheck(SceneCheckMissingRequiredPlugin::newSPtr());
+    m_sceneChecker.addCheck(SceneCheckUsingAlias::newSPtr());
 }
 
-} // namespace component
+SceneCheckerListener* SceneCheckerListener::getInstance()
+{
+    static SceneCheckerListener sceneLoaderListener;
+    return &sceneLoaderListener;
+}
 
+void SceneCheckerListener::rightAfterLoadingScene(sofa::simulation::Node::SPtr node)
+{
+    m_sceneChecker.validate(node.get());
+}
+
+
+} // namespace _scenechecking_
+} // namespace simulation
 } // namespace sofa

--- a/modules/SofaGraphComponent/SceneCheckerListener.cpp
+++ b/modules/SofaGraphComponent/SceneCheckerListener.cpp
@@ -21,6 +21,15 @@
 ******************************************************************************/
 #include "SceneCheckerListener.h"
 
+#include <SofaGraphComponent/SceneCheckAPIChange.h>
+using sofa::simulation::scenechecking::SceneCheckAPIChange;
+#include <SofaGraphComponent/SceneCheckMissingRequiredPlugin.h>
+using sofa::simulation::scenechecking::SceneCheckMissingRequiredPlugin;
+#include <SofaGraphComponent/SceneCheckDuplicatedName.h>
+using sofa::simulation::scenechecking::SceneCheckDuplicatedName;
+#include <SofaGraphComponent/SceneCheckUsingAlias.h>
+using sofa::simulation::scenechecking::SceneCheckUsingAlias;
+
 namespace sofa
 {
 namespace simulation

--- a/modules/SofaGraphComponent/SceneCheckerListener.h
+++ b/modules/SofaGraphComponent/SceneCheckerListener.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 *       SOFA, Simulation Open-Framework Architecture, development version     *
-*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
+*                (c) 2006-2019 INRIA, USTL, UJF, CNRS, MGH                    *
 *                                                                             *
 * This program is free software; you can redistribute it and/or modify it     *
 * under the terms of the GNU Lesser General Public License as published by    *

--- a/modules/SofaGraphComponent/SceneCheckerListener.h
+++ b/modules/SofaGraphComponent/SceneCheckerListener.h
@@ -19,31 +19,56 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <sofa/helper/system/config.h>
-#include <SofaGraphComponent/initGraphComponent.h>
+#ifndef SOFA_SIMULATION_SCENECHECKERLISTENER_H
+#define SOFA_SIMULATION_SCENECHECKERLISTENER_H
+
+#include "config.h"
 
 #include <sofa/simulation/SceneLoaderFactory.h>
-#include <SofaGraphComponent/SceneCheckerListener.h>
-using sofa::simulation::scenechecking::SceneCheckerListener;
+#include <sofa/simulation/Visitor.h>
+
+#include <SofaGraphComponent/SceneCheckerVisitor.h>
+using sofa::simulation::scenechecking::SceneCheckerVisitor;
+#include <SofaGraphComponent/SceneCheckAPIChange.h>
+using sofa::simulation::scenechecking::SceneCheckAPIChange;
+#include <SofaGraphComponent/SceneCheckMissingRequiredPlugin.h>
+using sofa::simulation::scenechecking::SceneCheckMissingRequiredPlugin;
+#include <SofaGraphComponent/SceneCheckDuplicatedName.h>
+using sofa::simulation::scenechecking::SceneCheckDuplicatedName;
+#include <SofaGraphComponent/SceneCheckUsingAlias.h>
+using sofa::simulation::scenechecking::SceneCheckUsingAlias;
+
+#include "SceneCheck.h"
 
 namespace sofa
 {
-
-namespace component
+namespace simulation
+{
+namespace _scenechecking_
 {
 
-
-void initGraphComponent()
+/// to be able to react when a scene is loaded
+class SOFA_GRAPH_COMPONENT_API SceneCheckerListener : public SceneLoader::Listener
 {
-    static bool first = true;
-    if (first)
-    {
-        first = false;
-    }
+public:
+    static SceneCheckerListener* getInstance();
+    virtual ~SceneCheckerListener() {}
 
-    sofa::simulation::SceneLoader::addListener( SceneCheckerListener::getInstance() );
+    virtual void rightAfterLoadingScene(sofa::simulation::Node::SPtr node) override;
+
+private:
+    SceneCheckerListener();
+    SceneCheckerVisitor m_sceneChecker;
+};
+
+} // namespace _scenechecking_
+
+namespace scenechecking
+{
+using _scenechecking_::SceneCheckerListener;
 }
 
-} // namespace component
-
+} // namespace simulation
 } // namespace sofa
+
+#endif

--- a/modules/SofaGraphComponent/SceneCheckerListener.h
+++ b/modules/SofaGraphComponent/SceneCheckerListener.h
@@ -29,16 +29,7 @@
 
 #include <SofaGraphComponent/SceneCheckerVisitor.h>
 using sofa::simulation::scenechecking::SceneCheckerVisitor;
-#include <SofaGraphComponent/SceneCheckAPIChange.h>
-using sofa::simulation::scenechecking::SceneCheckAPIChange;
-#include <SofaGraphComponent/SceneCheckMissingRequiredPlugin.h>
-using sofa::simulation::scenechecking::SceneCheckMissingRequiredPlugin;
-#include <SofaGraphComponent/SceneCheckDuplicatedName.h>
-using sofa::simulation::scenechecking::SceneCheckDuplicatedName;
-#include <SofaGraphComponent/SceneCheckUsingAlias.h>
-using sofa::simulation::scenechecking::SceneCheckUsingAlias;
 
-#include "SceneCheck.h"
 
 namespace sofa
 {

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
@@ -78,6 +78,7 @@ void SceneCheckerVisitor::validate(Node* node)
     {
         check->doPrintSummary() ;
     }
+    msg_info("SceneCheckerVisitor") << "Finished validating node \""<< node->getName() << "\".";
 }
 
 

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.h
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.h
@@ -40,7 +40,7 @@ namespace _scenechecking_
 class SOFA_GRAPH_COMPONENT_API SceneCheckerVisitor : public Visitor
 {
 public:
-    SceneCheckerVisitor(const sofa::core::ExecParams* params) ;
+    SceneCheckerVisitor(const sofa::core::ExecParams* params = sofa::core::ExecParams::defaultInstance()) ;
     virtual ~SceneCheckerVisitor() ;
 
     void validate(Node* node) ;

--- a/modules/SofaGraphComponent/initGraphComponent.cpp
+++ b/modules/SofaGraphComponent/initGraphComponent.cpp
@@ -22,10 +22,6 @@
 #include <sofa/helper/system/config.h>
 #include <SofaGraphComponent/initGraphComponent.h>
 
-#include <sofa/simulation/SceneLoaderFactory.h>
-#include <SofaGraphComponent/SceneCheckerListener.h>
-using sofa::simulation::scenechecking::SceneCheckerListener;
-
 namespace sofa
 {
 
@@ -40,8 +36,6 @@ void initGraphComponent()
     {
         first = false;
     }
-
-    sofa::simulation::SceneLoader::addListener( SceneCheckerListener::getInstance() );
 }
 
 } // namespace component


### PR DESCRIPTION
As discussed in latest dev meeting, we need SceneChecker output even at first load.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
