### PR TITLE
[SofaKernel] FIX deprecation message related to template types.

### DIFF
--- a/SofaKernel/framework/sofa/core/ObjectFactory.cpp
+++ b/SofaKernel/framework/sofa/core/ObjectFactory.cpp
@@ -113,7 +113,7 @@ void ObjectFactory::resetAlias(std::string name, ClassEntry::SPtr previous)
 objectmodel::BaseObject::SPtr ObjectFactory::createObject(objectmodel::BaseContext* context, objectmodel::BaseObjectDescription* arg)
 {
     std::stringstream availabletemplate;
-    objectmodel::BaseObject::SPtr object = NULL;
+    objectmodel::BaseObject::SPtr object = nullptr;
     std::vector< std::pair<std::string, Creator::SPtr> > creators;
     std::string classname = arg->getAttribute( "type", "");
     std::string usertemplatename = arg->getAttribute( "template", "");
@@ -130,6 +130,7 @@ objectmodel::BaseObject::SPtr ObjectFactory::createObject(objectmodel::BaseConte
     ///      type precision into a different one.
     ///  (4) rebuild the template string by joining them all with ','.
     std::vector<std::string> usertemplatenames = sofa::helper::split(usertemplatename, ',');
+    std::vector<std::string> deprecatedTemplates;
     for(auto& name : usertemplatenames)
     {
         const sofa::defaulttype::TemplateAlias* alias;
@@ -139,7 +140,7 @@ objectmodel::BaseObject::SPtr ObjectFactory::createObject(objectmodel::BaseConte
             /// This alias results in "undefined" behavior.
             if( alias->second )
             {
-                arg->logError("The deprecated template '"+name+"' has been replaced by "+alias->first+". As they have different precisions this may result in undefined behavior. To remove this message, please update your scene to remove the use templates.");
+                deprecatedTemplates.push_back("The deprecated template '"+name+"' has been replaced by "+alias->first+". As they have different precisions this may result in undefined behavior. To remove this message, please update your scene to use the generic 'Vec3' templates or one of 'Vec3f/Vec3d' that match your the precision of your Sofa binary.");
             }
 
             name = alias->first;
@@ -238,8 +239,8 @@ objectmodel::BaseObject::SPtr ObjectFactory::createObject(objectmodel::BaseConte
     {
         if(object->findData(kv.first)==nullptr)
         {
-            msg_warning("ObjectFactoy") << "The object '"<< (object->getClassName()) <<"' does not have an alias named '"<< kv.first <<"'.  "
-                                        << "To remove this error message you need to use a valid data name for the 'dataname field'. ";
+            msg_warning(object.get()) << "The object '"<< (object->getClassName()) <<"' does not have an alias named '"<< kv.first <<"'.  "
+                                      << "To remove this error message you need to use a valid data name for the 'dataname field'. ";
 
             todelete.push_back(kv.first);
         }
@@ -267,13 +268,9 @@ objectmodel::BaseObject::SPtr ObjectFactory::createObject(objectmodel::BaseConte
 
     /// We managed to create an object but there is error message in the log. Thus we emit them
     /// as warning to this object.
-    if(!arg->getErrors().empty())
+    if(!deprecatedTemplates.empty())
     {
-        std::stringstream msg;
-        for (std::vector< std::string >::const_iterator it = arg->getErrors().begin(); it != arg->getErrors().end(); ++it)
-            msg << " " << *it << msgendl ;
-
-        msg_deprecated(object.get()) << msg.str() ;
+        msg_deprecated(object.get()) << sofa::helper::join(deprecatedTemplates, msgendl) ;
     }
 
     return object;


### PR DESCRIPTION
The current implementation is printing a deprecation message but the modified "arg"
are also reported by caller's as error.

To avoid that I don't accumulate the deprecation warning in the "arg" arguments
and print them immediately.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
