### PR TITLE
[SofaHelper] REMOVE PluginManager::m_searchPaths

### DIFF
--- a/SofaKernel/framework/sofa/helper/system/PluginManager.cpp
+++ b/SofaKernel/framework/sofa/helper/system/PluginManager.cpp
@@ -77,7 +77,6 @@ PluginManager & PluginManager::getInstance()
 
 PluginManager::PluginManager()
 {
-    m_searchPaths = PluginRepository.getPaths();
 }
 
 PluginManager::~PluginManager()
@@ -295,12 +294,14 @@ void PluginManager::init(const std::string& pluginPath)
 
 std::string PluginManager::findPlugin(const std::string& pluginName, const std::string& suffix, bool ignoreCase, bool recursive, int maxRecursiveDepth)
 {
+    std::vector<std::string> searchPaths = PluginRepository.getPaths();
+
     std::string name(pluginName);
     name  += suffix;
     const std::string libName = DynamicLibrary::prefix + name + "." + DynamicLibrary::extension;
 
     // First try: case sensitive
-    for (std::vector<std::string>::iterator i = m_searchPaths.begin(); i!=m_searchPaths.end(); i++)
+    for (std::vector<std::string>::iterator i = searchPaths.begin(); i!=searchPaths.end(); i++)
     {
         const std::string path = *i + "/" + libName;
         if (FileSystem::isFile(path))
@@ -312,7 +313,7 @@ std::string PluginManager::findPlugin(const std::string& pluginName, const std::
         if(!recursive) maxRecursiveDepth = 0;
         const std::string downcaseLibName = Utils::downcaseString(libName);
 
-        for (std::vector<std::string>::iterator i = m_searchPaths.begin(); i!=m_searchPaths.end(); i++)
+        for (std::vector<std::string>::iterator i = searchPaths.begin(); i!=searchPaths.end(); i++)
         {
             const std::string& dir = *i;
 

--- a/SofaKernel/framework/sofa/helper/system/PluginManager.h
+++ b/SofaKernel/framework/sofa/helper/system/PluginManager.h
@@ -184,8 +184,6 @@ public:
 
     Plugin* getPlugin(const std::string& plugin, const std::string& = getDefaultSuffix(), bool = true);
 
-    std::vector<std::string>& getSearchPaths() { return m_searchPaths; }
-
     void readFromIniFile(const std::string& path);
     void writeToIniFile(const std::string& path);
 
@@ -199,7 +197,6 @@ private:
     std::istream& readFromStream( std::istream& );
 private:
     PluginMap m_pluginMap;
-    std::vector<std::string> m_searchPaths;
 };
 
 

--- a/modules/SofaMisc/AddResourceRepository.cpp
+++ b/modules/SofaMisc/AddResourceRepository.cpp
@@ -79,6 +79,7 @@ void BaseAddResourceRepository::parse(sofa::core::objectmodel::BaseObjectDescrip
 
     m_currentAddedPath = FileSystem::cleanPath(tmpAddedPath);
     m_repository->addLastPath(m_currentAddedPath);
+    msg_info(this) << "Added path: " << m_currentAddedPath;
 
     if(this->f_printLog.getValue())
         m_repository->print();


### PR DESCRIPTION
This member was an error prone copy of `PluginRepository::vpath`.
PluginManager is now always in sync with PluginRepository.

AddPluginRepository component has no effect without this change.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
