### PR TITLE
[SpringForceField] Merge 2 ctor into a templated one

### DIFF
--- a/SofaKernel/modules/SofaDeformable/SpringForceField.h
+++ b/SofaKernel/modules/SofaDeformable/SpringForceField.h
@@ -56,13 +56,8 @@ public:
     bool elongationOnly;    ///< only forbid elongation, not compression
     bool enabled;           ///< false to disable this spring (i.e. broken)
 
-    LinearSpring(int m1=0, int m2=0, double ks=0.0, double kd=0.0, double initpos=0.0, bool noCompression=false, bool enabled=true)
-        : m1(m1), m2(m2), ks((Real)ks), kd((Real)kd), initpos((Real)initpos), elongationOnly(noCompression), enabled(enabled)
-    {
-    }
-
-    LinearSpring(int m1, int m2, float ks, float kd=0, float initpos=0, bool noCompression=false, bool enabled=true)
-        : m1(m1), m2(m2), ks((Real)ks), kd((Real)kd), initpos((Real)initpos), elongationOnly(noCompression), enabled(enabled)
+    LinearSpring(int m1=0, int m2=0, Real ks=0.0, Real kd=0.0, Real initpos=0.0, bool noCompression=false, bool enabled=true)
+        : m1(m1), m2(m2), ks(ks), kd(kd), initpos(initpos), elongationOnly(noCompression), enabled(enabled)
     {
     }
 


### PR DESCRIPTION
As a result, It is now no longer possible to instantiate `LinearSpring<double>` from `float` (without explicit casting)


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
