### PR TITLE
[SofaKernel] Some small changes in debug topology drawing

### DIFF
--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.cpp
@@ -82,7 +82,7 @@ void DrawToolGL::drawPoints(const std::vector<Vector3> &points, float size, cons
 {
     setMaterial(color);
     glPointSize(size);
-    disableLighting();
+    if (getLightEnabled()) disableLighting();
     glBegin(GL_POINTS);
     {
         for (std::size_t i=0; i<points.size(); ++i)
@@ -98,17 +98,17 @@ void DrawToolGL::drawPoints(const std::vector<Vector3> &points, float size, cons
 void DrawToolGL::drawPoints(const std::vector<Vector3> &points, float size, const std::vector<Vec4f>& color)
 {
     glPointSize(size);
-    disableLighting();
+    if (getLightEnabled()) disableLighting();
     glBegin(GL_POINTS);
     {
         for (std::size_t i=0; i<points.size(); ++i)
         {
             setMaterial(color[i]);
             internalDrawPoint(points[i], color[i]);
-            if (getLightEnabled()) enableLighting();
             resetMaterial(color[i]);
         }
     } glEnd();
+    if (getLightEnabled()) enableLighting();
     glPointSize(1);
 }
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -129,7 +129,7 @@ void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const
 {
     setMaterial(color);
     glLineWidth(size);
-    disableLighting();
+    if (getLightEnabled()) disableLighting();
     glBegin(GL_LINES);
     {
         for (std::size_t i=0; i<points.size()/2; ++i)
@@ -138,8 +138,8 @@ void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const
         }
     } glEnd();
     if (getLightEnabled()) enableLighting();
-    resetMaterial(color);
     glLineWidth(1);
+    resetMaterial(color);
 }
 
 void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const std::vector<Vec<4,float> >& colors)
@@ -151,7 +151,7 @@ void DrawToolGL::drawLines(const std::vector<Vector3> &points, float size, const
     }
 
     glLineWidth(size);
-    disableLighting();
+    if (getLightEnabled()) disableLighting();
     glBegin(GL_LINES);
     {
         for (std::size_t i=0; i<points.size()/2; ++i)
@@ -171,7 +171,7 @@ void DrawToolGL::drawLines(const std::vector<Vector3> &points, const std::vector
 {
     setMaterial(color);
     glLineWidth(size);
-    disableLighting();
+    if (getLightEnabled()) disableLighting();
     glBegin(GL_LINES);
     {
         for (std::size_t i=0; i<index.size(); ++i)
@@ -190,7 +190,7 @@ void DrawToolGL::drawLineStrip(const std::vector<Vector3> &points, float size, c
 {
     setMaterial(color);
     glLineWidth(size);
-    disableLighting();
+    if (getLightEnabled()) disableLighting();
     glBegin(GL_LINE_STRIP);
     {
         for (std::size_t i=0; i<points.size(); ++i)
@@ -209,7 +209,7 @@ void DrawToolGL::drawLineLoop(const std::vector<Vector3> &points, float size, co
 {
     setMaterial(color);
     glLineWidth(size);
-    disableLighting();
+    if (getLightEnabled()) disableLighting();
     glBegin(GL_LINE_LOOP);
     {
         for (std::size_t i=0; i<points.size(); ++i)

--- a/SofaKernel/framework/sofa/core/visual/DrawToolGL.h
+++ b/SofaKernel/framework/sofa/core/visual/DrawToolGL.h
@@ -166,6 +166,10 @@ public:
 
     virtual void writeOverlayText( int x, int y, unsigned fontSize, const Vec4f &color, const char* text );
 
+    /** Set the scale and units used to add depth values
+    * @param factor : Specifies a scale factor that is used to create a variable depth offset for each polygon. The initial value is 0.
+    * @param units : Is multiplied by an implementation-specific value to create a constant depth offset. The initial value is 0.
+    */
     virtual void enablePolygonOffset(float factor, float units);
     virtual void disablePolygonOffset();
 

--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetGeometryAlgorithms.h
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetGeometryAlgorithms.h
@@ -80,7 +80,7 @@ protected:
         : PointSetGeometryAlgorithms<DataTypes>()
         ,initializedEdgeCubatureTables(false)
         , showEdgeIndices(core::objectmodel::Base::initData(&showEdgeIndices, (bool) false, "showEdgeIndices", "Debug : view Edge indices."))
-        , _draw(core::objectmodel::Base::initData(&_draw, false, "drawEdges","if true, draw the edges in the topology."))
+        , d_drawEdges(core::objectmodel::Base::initData(&d_drawEdges, false, "drawEdges","if true, draw the edges in the topology."))
         , _drawColor(initData(&_drawColor, RGBAColor(0.4f,1.0f,0.3f, 1.0f), "drawColorEdges", "RGB code color used to draw edges."))
     {
     }
@@ -166,7 +166,7 @@ public:
 
 protected:
     Data<bool> showEdgeIndices; ///< Debug : view Edge indices.
-    Data<bool>  _draw; ///< if true, draw the edges in the topology.
+    Data<bool>  d_drawEdges; ///< if true, draw the edges in the topology.
     Data<RGBAColor> _drawColor; ///< RGB code color used to draw edges.
     /// include cubature points
     NumericalIntegrationDescriptor<Real,1> edgeNumericalIntegration;

--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetGeometryAlgorithms.inl
@@ -713,8 +713,8 @@ void EdgeSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
     PointSetGeometryAlgorithms<DataTypes>::draw(vparams);
 
     // Draw Edges indices
-    if (showEdgeIndices.getValue())
-    {
+    if (showEdgeIndices.getValue() && this->m_topology->getNbEdges() != 0)
+    {        
         const VecCoord& coords =(this->object->read(core::ConstVecCoordId::position())->getValue());
         float scale = this->getIndicesScale();
 
@@ -740,25 +740,22 @@ void EdgeSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
 
 
     // Draw edges
-    if (_draw.getValue())
+    if (_draw.getValue() && this->m_topology->getNbEdges() != 0)
     {
         const sofa::helper::vector<Edge> &edgeArray = this->m_topology->getEdges();
 
-        if (!edgeArray.empty())
-        {
-            const VecCoord& coords =(this->object->read(core::ConstVecCoordId::position())->getValue());
+        const VecCoord& coords =(this->object->read(core::ConstVecCoordId::position())->getValue());
 
-            std::vector<defaulttype::Vector3> positions;
-            positions.reserve(edgeArray.size()*2u);
-            for (size_t i = 0; i<edgeArray.size(); i++)
-            {
-                const Edge& e = edgeArray[i];
-                positions.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[e[0]])));
-                positions.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[e[1]])));
-            }
-            vparams->drawTool()->drawLines(positions,1.0f, _drawColor.getValue());
-            vparams->drawTool()->drawPoints(positions, 4.0f, _drawColor.getValue());
+        std::vector<defaulttype::Vector3> positions;
+        positions.reserve(edgeArray.size()*2u);
+        for (size_t i = 0; i<edgeArray.size(); i++)
+        {
+            const Edge& e = edgeArray[i];
+            positions.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[e[0]])));
+            positions.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[e[1]])));
         }
+        vparams->drawTool()->drawLines(positions,1.0f, _drawColor.getValue());
+        vparams->drawTool()->drawPoints(positions, 4.0f, _drawColor.getValue());
     }
 
 }

--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetGeometryAlgorithms.inl
@@ -740,7 +740,7 @@ void EdgeSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
 
 
     // Draw edges
-    if (_draw.getValue() && this->m_topology->getNbEdges() != 0)
+    if (d_drawEdges.getValue() && this->m_topology->getNbEdges() != 0)
     {
         const sofa::helper::vector<Edge> &edgeArray = this->m_topology->getEdges();
 
@@ -754,7 +754,7 @@ void EdgeSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
             positions.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[e[0]])));
             positions.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[e[1]])));
         }
-        vparams->drawTool()->drawLines(positions,1.0f, _drawColor.getValue());
+        vparams->drawTool()->drawLines(positions, 1.0f, _drawColor.getValue());
         vparams->drawTool()->drawPoints(positions, 4.0f, _drawColor.getValue());
     }
 

--- a/SofaKernel/modules/SofaBaseTopology/HexahedronSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/HexahedronSetGeometryAlgorithms.inl
@@ -836,9 +836,8 @@ void HexahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visual
     QuadSetGeometryAlgorithms<DataTypes>::draw(vparams);
 
     // Draw Hexa indices
-    if (d_showHexaIndices.getValue())
+    if (d_showHexaIndices.getValue() && this->m_topology->getNbHexahedra() != 0)
     {
-
         const VecCoord& coords =(this->object->read(core::ConstVecCoordId::position())->getValue());
         float scale = this->getIndicesScale();
 
@@ -869,7 +868,7 @@ void HexahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visual
 
 
     //Draw hexahedra
-    if (d_drawHexahedra.getValue())
+    if (d_drawHexahedra.getValue() && this->m_topology->getNbHexahedra() != 0)
     {
         if (vparams->displayFlags().getShowWireFrame())
             vparams->drawTool()->setPolygonMode(0, true);

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetGeometryAlgorithms.inl
@@ -387,6 +387,9 @@ void QuadSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
     // Draw Quads
     if (_drawQuads.getValue() && this->m_topology->getNbQuads() != 0)
     {
+        if (vparams->displayFlags().getShowWireFrame())
+            vparams->drawTool()->setPolygonMode(0, true);
+
         const sofa::helper::vector<Quad>& quadArray = this->m_topology->getQuads();
 
         // Draw Quad surfaces
@@ -415,6 +418,7 @@ void QuadSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
             vparams->drawTool()->drawQuads(pos, _drawColor.getValue());
         }
 
+        if (!vparams->displayFlags().getShowWireFrame())
         { // drawing edges
             const sofa::helper::vector<Edge> &edgeArray = this->m_topology->getEdges();
             sofa::helper::types::RGBAColor edge_color = _drawColor.getValue();
@@ -446,6 +450,9 @@ void QuadSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams
             }
             vparams->drawTool()->drawLines(pos,1.0f, edge_color );
         }
+
+        if (vparams->displayFlags().getShowWireFrame())
+            vparams->drawTool()->setPolygonMode(0, false);
     }
 }
 

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetGeometryAlgorithms.inl
@@ -929,7 +929,7 @@ void TetrahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visua
 
     const VecCoord& coords =(this->object->read(core::ConstVecCoordId::position())->getValue());
     //Draw tetra indices
-    if (d_showTetrahedraIndices.getValue())
+    if (d_showTetrahedraIndices.getValue() && this->m_topology->getNbTetrahedra() != 0)
     {
         const sofa::defaulttype::Vec4f& color_tmp = d_drawColorTetrahedra.getValue();
         defaulttype::Vec4f color4(color_tmp[0] - 0.2f, color_tmp[1] - 0.2f, color_tmp[2] - 0.2f, 1.0);
@@ -958,10 +958,11 @@ void TetrahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visua
     }
 
     // Draw Tetra
-    if (d_drawTetrahedra.getValue())
+    if (d_drawTetrahedra.getValue() && this->m_topology->getNbTetrahedra() != 0)
     {
         if (vparams->displayFlags().getShowWireFrame())
             vparams->drawTool()->setPolygonMode(0, true);
+
         const sofa::defaulttype::Vec4f& color_tmp = d_drawColorTetrahedra.getValue();
         defaulttype::Vec4f color4(color_tmp[0] - 0.2f, color_tmp[1] - 0.2f, color_tmp[2] - 0.2f, 1.0);
 

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetGeometryAlgorithms.inl
@@ -968,24 +968,37 @@ void TetrahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::Visua
 
         const sofa::helper::vector<Tetrahedron> &tetraArray = this->m_topology->getTetrahedra();
         std::vector<defaulttype::Vector3>   pos;
-        pos.reserve(tetraArray.size()*4u);
+        pos.reserve(tetraArray.size() * 4u);
 
-        for (size_t i = 0; i<tetraArray.size(); ++i)
+        for (size_t i = 0; i < tetraArray.size(); ++i)
         {
             const Tetrahedron& tet = tetraArray[i];
-            for (unsigned int j = 0u; j<4u; ++j)
+            for (unsigned int j = 0u; j < 4u; ++j)
             {
                 pos.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[tet[j]])));
             }
         }
 
         const float& scale = d_drawScaleTetrahedra.getValue();
-
-        if (scale >= 1.0 && scale < 0.001)
+        
+        if (scale >= 1.0 || scale < 0.001)
             vparams->drawTool()->drawTetrahedra(pos, color4);
         else
             vparams->drawTool()->drawScaledTetrahedra(pos, color4, scale);
 
+        // Draw Tetra border
+        if (!vparams->displayFlags().getShowWireFrame())
+        {
+            vparams->drawTool()->setPolygonMode(0, true);
+            //vparams->drawTool()->enablePolygonOffset(0.0, -1.0);
+            if (scale >= 1.0 || scale < 0.001)
+                vparams->drawTool()->drawTetrahedra(pos, sofa::helper::types::RGBAColor::gray());
+            else
+                vparams->drawTool()->drawScaledTetrahedra(pos, sofa::helper::types::RGBAColor::gray(), scale);
+            //vparams->drawTool()->disablePolygonOffset();
+            vparams->drawTool()->setPolygonMode(0, false);
+        }
+       
         if (vparams->displayFlags().getShowWireFrame())
             vparams->drawTool()->setPolygonMode(0, false);
     }

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetGeometryAlgorithms.inl
@@ -2422,6 +2422,9 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
 
     if (_draw.getValue() && this->m_topology->getNbTriangles() != 0)
     {
+        if (vparams->displayFlags().getShowWireFrame())
+            vparams->drawTool()->setPolygonMode(0, true);
+
         const sofa::helper::vector<Triangle> &triangleArray = this->m_topology->getTriangles();
 
         // Draw triangle surfaces
@@ -2451,7 +2454,7 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
             vparams->drawTool()->drawTriangles(pos,_drawColor.getValue());
         }
 
-
+        if (!vparams->displayFlags().getShowWireFrame())
         {//   Draw triangle edges for better display
             const sofa::helper::vector<Edge> &edgeArray = this->m_topology->getEdges();
             std::vector<defaulttype::Vector3> pos;
@@ -2481,6 +2484,9 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
                 c /= 2;
             vparams->drawTool()->drawLines(pos, 1.0f, colorL);
         }
+
+        if (vparams->displayFlags().getShowWireFrame())
+            vparams->drawTool()->setPolygonMode(0, false);
     }
 
 

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetGeometryAlgorithms.inl
@@ -2392,7 +2392,7 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
     EdgeSetGeometryAlgorithms<DataTypes>::draw(vparams);
 
     // Draw Triangles indices
-    if (showTriangleIndices.getValue())
+    if (showTriangleIndices.getValue() && this->m_topology->getNbTriangles() != 0)
     {
         const VecCoord& coords =(this->object->read(core::ConstVecCoordId::position())->getValue());
         float scale = this->getIndicesScale();
@@ -2420,73 +2420,71 @@ void TriangleSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualPa
 
 
 
-    if (_draw.getValue())
+    if (_draw.getValue() && this->m_topology->getNbTriangles() != 0)
     {
         const sofa::helper::vector<Triangle> &triangleArray = this->m_topology->getTriangles();
 
-        if (!triangleArray.empty()) // Draw triangle surfaces
-        {
-            const VecCoord& coords =(this->object->read(core::ConstVecCoordId::position())->getValue());
+        // Draw triangle surfaces
+        const VecCoord& coords =(this->object->read(core::ConstVecCoordId::position())->getValue());
 
-            {//   Draw Triangles
-                std::vector<defaulttype::Vector3> pos;
-                pos.reserve(triangleArray.size()*3);
+        {//   Draw Triangles
+            std::vector<defaulttype::Vector3> pos;
+            pos.reserve(triangleArray.size()*3);
+            for (size_t i = 0; i<triangleArray.size(); i++)
+            {
+                const Triangle& t = triangleArray[i];
+
+                defaulttype::Vector3 bary = defaulttype::Vector3(0.0, 0.0, 0.0);
+                std::vector<defaulttype::Vector3> tmpPos;
+                tmpPos.resize(3);
+
+                for (unsigned int j = 0; j<3; j++)
+                {
+                    tmpPos[j] = defaulttype::Vector3(DataTypes::getCPos(coords[t[j]]));
+                    bary += tmpPos[j];
+                }
+                bary /= 3;
+
+                for (unsigned int j = 0; j<3; j++)
+                    pos.push_back(bary*0.1 + tmpPos[j]*0.9);
+            }
+            vparams->drawTool()->drawTriangles(pos,_drawColor.getValue());
+        }
+
+
+        {//   Draw triangle edges for better display
+            const sofa::helper::vector<Edge> &edgeArray = this->m_topology->getEdges();
+            std::vector<defaulttype::Vector3> pos;
+            if (!edgeArray.empty())
+            {
+                for (size_t i = 0; i<edgeArray.size(); i++)
+                {
+                    const Edge& e = edgeArray[i];
+                    pos.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[e[0]])));
+                    pos.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[e[1]])));
+                }
+            } else {
                 for (size_t i = 0; i<triangleArray.size(); i++)
                 {
                     const Triangle& t = triangleArray[i];
 
-                    defaulttype::Vector3 bary = defaulttype::Vector3(0.0, 0.0, 0.0);
-                    std::vector<defaulttype::Vector3> tmpPos;
-                    tmpPos.resize(3);
-
                     for (unsigned int j = 0; j<3; j++)
                     {
-                        tmpPos[j] = defaulttype::Vector3(DataTypes::getCPos(coords[t[j]]));
-                        bary += tmpPos[j];
-                    }
-                    bary /= 3;
-
-                    for (unsigned int j = 0; j<3; j++)
-                        pos.push_back(bary*0.1 + tmpPos[j]*0.9);
-                }
-                vparams->drawTool()->drawTriangles(pos,_drawColor.getValue());
-            }
-
-
-            {//   Draw triangle edges for better display
-                const sofa::helper::vector<Edge> &edgeArray = this->m_topology->getEdges();
-                std::vector<defaulttype::Vector3> pos;
-                if (!edgeArray.empty())
-                {
-                    for (size_t i = 0; i<edgeArray.size(); i++)
-                    {
-                        const Edge& e = edgeArray[i];
-                        pos.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[e[0]])));
-                        pos.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[e[1]])));
-                    }
-                } else {
-                    for (size_t i = 0; i<triangleArray.size(); i++)
-                    {
-                        const Triangle& t = triangleArray[i];
-
-                        for (unsigned int j = 0; j<3; j++)
-                        {
-                            pos.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[t[j]])));
-                            pos.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[t[(j+1u)%3u]])));
-                        }
+                        pos.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[t[j]])));
+                        pos.push_back(defaulttype::Vector3(DataTypes::getCPos(coords[t[(j+1u)%3u]])));
                     }
                 }
-
-                sofa::helper::types::RGBAColor colorL = _drawColor.getValue();
-                for (auto& c: colorL)
-                    c /= 2;
-                vparams->drawTool()->drawLines(pos, 1.0f, colorL);
             }
+
+            sofa::helper::types::RGBAColor colorL = _drawColor.getValue();
+            for (auto& c: colorL)
+                c /= 2;
+            vparams->drawTool()->drawLines(pos, 1.0f, colorL);
         }
     }
 
 
-    if (_drawNormals.getValue())
+    if (_drawNormals.getValue() && this->m_topology->getNbTriangles() != 0)
     {
         const VecCoord& coords =(this->object->read(core::ConstVecCoordId::position())->getValue());
         const sofa::helper::vector<Triangle> &triangleArray = this->m_topology->getTriangles();


### PR DESCRIPTION
- Add: Display border of tetrahedra, 
- Update: draw methods to check the number of elements and reduce the number of indent in code.
- Add: handle wireframe for triangles and quads
- Fix: Bad lighting disable without corresponding enable in drawTools

![simpletesselatedtetratopologicalmapping_00000001](https://user-images.githubusercontent.com/21199245/53704580-155f0300-3e1e-11e9-9e55-edd39145af29.png)

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
