### PR TITLE
[CMake] FIX build/install plugins directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,7 +321,7 @@ if(SOFA_INSTALL_RESOURCES_FILES)
 endif()
 
 file(WRITE "${CMAKE_BINARY_DIR}/plugins/README.txt" "This folder will be automatically scanned by the Plugin Manager.")
-install(DIRECTORY applications/plugins/ DESTINATION plugins COMPONENT resources)
+install(DIRECTORY ${CMAKE_BINARY_DIR}/plugins/ DESTINATION plugins COMPONENT resources)
 
 
 #######################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,7 +321,7 @@ if(SOFA_INSTALL_RESOURCES_FILES)
 endif()
 
 file(WRITE "${CMAKE_BINARY_DIR}/plugins/README.txt" "This folder will be automatically scanned by the Plugin Manager.")
-install(DIRECTORY plugins/ DESTINATION plugins COMPONENT resources)
+install(DIRECTORY applications/plugins/ DESTINATION plugins COMPONENT resources)
 
 
 #######################


### PR DESCRIPTION
There was an error in the name of the (origin) directory to install. Not sure about the destination though. This fix has no impact on building Sofa, only on its installation.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
