### PR TITLE
[SofaTopologyMapping] Fix crashes in Tetra2TriangleTopologicalMapping 

### DIFF
--- a/examples/Components/topology/Tetra2TriangleTopologicalMapping_NoInitialTriangle_option.scn
+++ b/examples/Components/topology/Tetra2TriangleTopologicalMapping_NoInitialTriangle_option.scn
@@ -1,3 +1,4 @@
+<?xml version="1.0" ?>
 <Node name="root" dt="0.05" showBoundingTree="0" gravity="0 0 0">
     <VisualStyle displayFlags="showBehaviorModels showVisual" />
     <CollisionPipeline verbose="0" />
@@ -21,7 +22,6 @@
             <Tetra2TriangleTopologicalMapping input="@../Container" output="@Container" noNewTriangles="1" />
             <TriangularFEMForceField name="FEM" youngModulus="60" poissonRatio="0.3" method="large" />
             <TriangularBendingSprings name="FEM-Bend" stiffness="300" damping="1.0" />
-            <TrianglePressureForceField normal="0 0 1" dmin="0.9" dmax="1.1" pressure="0.4 0 0" />
             <Node name="Visu">
                 <OglModel name="Visual" color="blue" />
                 <IdentityMapping input="@../../Volume" output="@Visual" />

--- a/examples/Components/topology/TopologicalModifiers/RemovingTetra2TriangleProcess2.txt
+++ b/examples/Components/topology/TopologicalModifiers/RemovingTetra2TriangleProcess2.txt
@@ -1,0 +1,147 @@
+T= 0.1
+  REMOVE= 1
+0
+T= 0.15
+  REMOVE= 1
+0
+T= 0.2
+  REMOVE= 1
+0
+T= 0.25
+  REMOVE= 1
+0
+T= 0.3
+  REMOVE= 1
+0
+T= 0.35
+  REMOVE= 1
+0
+T= 0.4
+  REMOVE= 1
+0
+T= 0.45
+  REMOVE= 1
+0
+T= 0.50
+  REMOVE= 1
+0
+T= 0.55
+  REMOVE= 1
+0
+T= 0.6
+  REMOVE= 1
+0
+T= 0.65
+  REMOVE= 1
+0
+T= 0.7
+  REMOVE= 1
+0
+T= 0.75
+  REMOVE= 1
+0
+T= 0.8
+  REMOVE= 1
+0
+T= 0.85
+  REMOVE= 1
+0
+T= 0.9
+  REMOVE= 1
+0
+T= 0.95
+  REMOVE= 1
+0
+T= 1.0
+  REMOVE= 1
+0
+T= 1.05
+  REMOVE= 1
+0
+T= 1.1
+  REMOVE= 1
+0
+T= 1.15
+  REMOVE= 1
+0
+T= 1.2
+  REMOVE= 1
+0
+T= 1.25
+  REMOVE= 1
+0
+T= 1.3
+  REMOVE= 1
+0
+T= 1.35
+  REMOVE= 1
+0
+T= 1.4
+  REMOVE= 1
+0
+T= 1.45
+  REMOVE= 1
+0
+T= 1.5
+  REMOVE= 1
+0
+T= 1.55
+  REMOVE= 1
+0
+T= 1.6
+  REMOVE= 1
+0
+T= 1.65
+  REMOVE= 1
+0
+T= 1.7
+  REMOVE= 1
+0
+T= 1.75
+  REMOVE= 1
+0
+T= 1.8
+  REMOVE= 1
+0
+T= 1.85
+  REMOVE= 1
+0
+T= 1.9
+  REMOVE= 1
+0
+T= 1.95
+  REMOVE= 1
+0
+T= 2.0
+  REMOVE= 1
+0
+T= 2.05
+  REMOVE= 1
+0
+T= 2.1
+  REMOVE= 1
+0
+T= 2.15
+  REMOVE= 1
+0
+T= 2.2
+  REMOVE= 1
+0
+T= 2.25
+  REMOVE= 1
+0
+T= 2.3
+  REMOVE= 1
+0
+T= 2.35
+  REMOVE= 1
+0
+T= 2.4
+  REMOVE= 1
+0
+T= 2.45
+  REMOVE= 1
+0
+T= 2.5
+  REMOVE= 1
+0

--- a/examples/Components/topology/TopologicalModifiers/RemovingTetra2TriangleProcess_withOptions.scn
+++ b/examples/Components/topology/TopologicalModifiers/RemovingTetra2TriangleProcess_withOptions.scn
@@ -16,25 +16,28 @@
         <TetrahedronSetTopologyContainer name="Tetra_topo" tetrahedra="@../loader.tetrahedra" />
         <TetrahedronSetTopologyModifier name="Modifier" />
         <TetrahedronSetTopologyAlgorithms name="TopoAlgo" template="Vec3d" />
-        <TetrahedronSetGeometryAlgorithms name="GeomAlgo" template="Vec3d" drawTetrahedra="0" showTetrahedraIndices="0"/>
+        <TetrahedronSetGeometryAlgorithms name="GeomAlgo" template="Vec3d" />
         
         <DiagonalMass massDensity="1.0" />
         <FixedConstraint name="fix" indices="7 8 14 15" />
         <TetrahedralCorotationalFEMForceField name="FEM" youngModulus="360" poissonRatio="0.3" method="large" />
-        
-        <Node name="T">
-            <TriangleSetTopologyContainer name="Triangle_topo" />
-            <TriangleSetTopologyModifier name="Modifier" />
-            <TriangleSetTopologyAlgorithms template="Vec3d" name="TopoAlgo" />
-            <TriangleSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" drawTriangles="1" drawNormals="1" drawNormalLength="1.0"/>
-            <Tetra2TriangleTopologicalMapping input="@../Tetra_topo" output="@Triangle_topo" printLog="1"/>
 
+	<Node name="T_out">
+            <include href="Objects/TriangleSetTopology.xml" src="@" tags=" " />
+            <Tetra2TriangleTopologicalMapping input="@../Tetra_topo" output="@Container" noNewTriangles="1" />
             <TriangularFEMForceField name="FEM" youngModulus="60" poissonRatio="0.3" method="large" />
             <TriangularBendingSprings name="FEM-Bend" stiffness="300" damping="1.0" />
-            
             <Node name="Visu">
-                <OglModel name="Visual" color="yellow" />
-                <IdentityMapping input="@../" output="@Visual" />
+                <OglModel name="Visual" color="blue" />
+                <IdentityMapping input="@../../Volume" output="@Visual" />
+            </Node>
+        </Node>
+        <Node name="T_in">
+            <include href="Objects/TriangleSetTopology.xml" src="@" tags=" " />
+            <Tetra2TriangleTopologicalMapping input="@../Tetra_topo" output="@Container" noInitialTriangles="1" />
+            <Node name="Visu">
+                <OglModel name="Visual" color="red" />
+                <IdentityMapping input="@../../Volume" output="@Visual" />
             </Node>
         </Node>
 
@@ -42,7 +45,7 @@
     </Node>
 
 
-    <Node name="TT_2">
+    <Node name="TT">
         <EulerImplicitSolver name="cg_odesolver" rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver iterations="25" name="linear solver" />
 
@@ -50,25 +53,28 @@
         <TetrahedronSetTopologyContainer name="Tetra_topo" tetrahedra="@../loader.tetrahedra" />
         <TetrahedronSetTopologyModifier name="Modifier" />
         <TetrahedronSetTopologyAlgorithms name="TopoAlgo" template="Vec3d" />
-        <TetrahedronSetGeometryAlgorithms name="GeomAlgo" template="Vec3d" drawTetrahedra="0" showTetrahedraIndices="0"/>
+        <TetrahedronSetGeometryAlgorithms name="GeomAlgo" template="Vec3d" />
         
         <DiagonalMass massDensity="1.0" />
         <FixedConstraint name="fix" indices="7 8 14 15" />
         <TetrahedralCorotationalFEMForceField name="FEM" youngModulus="360" poissonRatio="0.3" method="large" />
         
-        <Node name="T_2">
-            <TriangleSetTopologyContainer name="Triangle_topo" />
-            <TriangleSetTopologyModifier name="Modifier" />
-            <TriangleSetTopologyAlgorithms template="Vec3d" name="TopoAlgo" />
-            <TriangleSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" drawTriangles="1" drawNormals="1" drawNormalLength="1.0"/>
-            <Tetra2TriangleTopologicalMapping input="@../Tetra_topo" output="@Triangle_topo" printLog="1"/>
-
+	<Node name="T_out">
+            <include href="Objects/TriangleSetTopology.xml" src="@" tags=" " />
+            <Tetra2TriangleTopologicalMapping input="@../Tetra_topo" output="@Container" noNewTriangles="1" />
             <TriangularFEMForceField name="FEM" youngModulus="60" poissonRatio="0.3" method="large" />
             <TriangularBendingSprings name="FEM-Bend" stiffness="300" damping="1.0" />
-                
-            <Node name="Visu_2">
-                <OglModel name="Visual" color="yellow" />
-                <IdentityMapping input="@../" output="@Visual" />
+            <Node name="Visu">
+                <OglModel name="Visual" color="blue" />
+                <IdentityMapping input="@../../Volume" output="@Visual" />
+            </Node>
+        </Node>
+        <Node name="T_in">
+            <include href="Objects/TriangleSetTopology.xml" src="@" tags=" " />
+            <Tetra2TriangleTopologicalMapping input="@../Tetra_topo" output="@Container" noInitialTriangles="1" />
+            <Node name="Visu">
+                <OglModel name="Visual" color="red" />
+                <IdentityMapping input="@../../Volume" output="@Visual" />
             </Node>
         </Node>
 

--- a/examples/RegressionTopologyScenes.regression-tests
+++ b/examples/RegressionTopologyScenes.regression-tests
@@ -2,21 +2,25 @@
 Components/topology/Tetra2TriangleTopologicalMapping.scn 30 1e-4 1
 
 ### Topology Modifier scenes ###
+# Triangle and Triangle2Edge tests
 Components/topology/TopologicalModifiers/RemovingTrianglesProcess.scn 30 1e-4 1
 Components/topology/TopologicalModifiers/RemovingTriangle2EdgeProcess.scn 30 1e-4 
 Components/topology/TopologicalModifiers/AddingTrianglesProcess.scn 30 1e-4 1
 Components/topology/TopologicalModifiers/AddingTriangle2EdgeProcess.scn 30 1e-4 1
 
+# Tetra and Tetra2Triangle tests
 Components/topology/TopologicalModifiers/RemovingTetraProcess.scn 30 1e-4 1
 Components/topology/TopologicalModifiers/RemovingTetra2TriangleProcess.scn 30 1e-4 1
+Components/topology/TopologicalModifiers/RemovingTetra2TriangleProcess_withOptions.scn 30 1e-4 1
 Components/topology/TopologicalModifiers/AddingTetraProcess.scn 30 1e-4 1
 Components/topology/TopologicalModifiers/AddingTetra2TriangleProcess.scn 30 1e-4 1
 
+# Hexa and Hexa2Quand tests
 Components/topology/TopologicalModifiers/RemovingHexa2QuadProcess.scn 30 1e-4 1
 Components/topology/TopologicalModifiers/RemovingQuad2TriangleProcess.scn 30 1e-4 1
+Components/topology/TopologicalModifiers/AddingHexa2QuadProcess.scn 30 1e-4 1
+Components/topology/TopologicalModifiers/AddingQuad2TriangleProcess.scn 30 1e-4 1
 
 #never worked: Components/topology/TopologicalModifiers/RemovingHexa2TetraProcess.scn
 
-Components/topology/TopologicalModifiers/AddingHexa2QuadProcess.scn 30 1e-4 1
-Components/topology/TopologicalModifiers/AddingQuad2TriangleProcess.scn 30 1e-4 1
 

--- a/modules/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.cpp
@@ -235,7 +235,8 @@ void Tetra2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
                     iter_last = Glob2LocMap.find(oldGlobTriId);
                     if(iter_last == Glob2LocMap.end())
                     {
-                        msg_error() << "Could not find last triangle id in Glob2LocMap: " << lastGlobId << " nor removed triangle id: " << oldGlobTriId;
+                        msg_warning() << "Could not find last triangle id in Glob2LocMap: " << lastGlobId << " nor removed triangle id: " << oldGlobTriId;
+                        lastGlobId--;
                         continue;
                     }
                 }

--- a/modules/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.h
+++ b/modules/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.h
@@ -80,11 +80,14 @@ public:
     void updateTopologicalMappingTopDown() override;
 
     unsigned int getFromIndex(unsigned int ind) override;
+
+    /// Method to check the topology mapping maps regarding the upper topology
+    bool checkTopologies();
+
 protected:
     Data<bool> flipNormals; ///< Flip Normal ? (Inverse point order when creating triangle)
     Data<bool> noNewTriangles; ///< If true no new triangles are being created
     Data<bool> noInitialTriangles; ///< If true the list of initial triangles is initially empty. Only additional triangles will be added in the list
-
     sofa::helper::vector<unsigned int> addedTriangleIndex;
     TriangleSetTopologyModifier* m_outTopoModifier; ///< Pointer to the output topology modifier
 };


### PR DESCRIPTION
Several crashes possible in Tetra2TriangleTopologicalMapping when removing tetrahedron.
- When removing the last elements
- When using noInitialTriangles or noNewTriangles options.

Will fix issue #954 


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
