### PR TITLE
[SofaSimulationCore] FIX CollisionVisitor::processCollisionPipeline

### DIFF
--- a/SofaKernel/framework/sofa/simulation/CollisionVisitor.cpp
+++ b/SofaKernel/framework/sofa/simulation/CollisionVisitor.cpp
@@ -74,7 +74,9 @@ void CollisionVisitor::processCollisionPipeline(simulation::Node*
     t0=begin(node, obj);
 #endif
     obj->computeCollisionDetection();
-    m_primitiveTestCount += obj->getNarrowPhaseDetection()->getPrimitiveTestCount();
+
+    if (obj->getNarrowPhaseDetection())
+        m_primitiveTestCount += obj->getNarrowPhaseDetection()->getPrimitiveTestCount();
 #ifdef SOFA_DUMP_VISITOR_INFO
     end(node, obj,t0);
 #endif


### PR DESCRIPTION
Fix bug in collision visitor. 
Check if the narrow phase is null before calling getNarrowPhaseDetection






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
