### PR TITLE
[SofaKernel] Remove warnings

### DIFF
--- a/SofaKernel/framework/sofa/core/DataTracker.h
+++ b/SofaKernel/framework/sofa/core/DataTracker.h
@@ -170,7 +170,7 @@ namespace core
         void update() override { m_updateCallback( this ); }
 
         /// This method is needed by DDGNode
-        const std::string& getName() const
+        const std::string& getName() const override
         {
             static const std::string emptyName ="";
             return emptyName;

--- a/SofaKernel/framework/sofa/core/ObjectFactory.h
+++ b/SofaKernel/framework/sofa/core/ObjectFactory.h
@@ -199,15 +199,15 @@ class ObjectCreator : public ObjectFactory::Creator
 public:
     bool canCreate(objectmodel::BaseContext* context, objectmodel::BaseObjectDescription* arg) override
     {
-        RealObject* instance = NULL;
+        RealObject* instance = nullptr;
         return RealObject::canCreate(instance, context, arg);
     }
-    objectmodel::BaseObject::SPtr createInstance(objectmodel::BaseContext* context, objectmodel::BaseObjectDescription* arg)
+    objectmodel::BaseObject::SPtr createInstance(objectmodel::BaseContext* context, objectmodel::BaseObjectDescription* arg) override
     {
-        RealObject* instance = NULL;
+        RealObject* instance = nullptr;
         return RealObject::create(instance, context, arg);
     }
-    const std::type_info& type()
+    const std::type_info& type() override
     {
         return typeid(RealObject);
     }
@@ -230,9 +230,9 @@ public:
         return RealObject::HeaderFileLocation();
     }
 
-    virtual std::string shortName(objectmodel::BaseObjectDescription* arg)
+    virtual std::string shortName(objectmodel::BaseObjectDescription* arg) override
     {
-        RealObject* instance = NULL;
+        RealObject* instance = nullptr;
         return RealObject::shortName(instance,arg);
     }
 
@@ -289,7 +289,7 @@ public:
     template<class RealObject>
     RegisterObject& add(bool defaultTemplate=false)
     {
-        RealObject* p = NULL;
+        RealObject* p = nullptr;
         std::string classname = RealObject::className(p);
         std::string templatename = RealObject::templateName(p);
 

--- a/SofaKernel/framework/sofa/core/collision/Intersection.inl
+++ b/SofaKernel/framework/sofa/core/collision/Intersection.inl
@@ -55,7 +55,7 @@ public:
     {
         Model1* m1 = static_cast<Model1*>(model1);
         Model2* m2 = static_cast<Model2*>(model2);
-        if (contacts == NULL)
+        if (contacts == nullptr)
         {
             contacts = impl->createOutputVector(m1,m2);
         }
@@ -70,7 +70,7 @@ public:
         return impl->computeIntersection(e1, e2, impl->getOutputVector(e1.getCollisionModel(), e2.getCollisionModel(), contacts));
     }
 
-    std::string name() const
+    std::string name() const override
     {
         return sofa::helper::gettypename(typeid(Elem1))+std::string("-")+sofa::helper::gettypename(typeid(Elem2));
     }

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseData.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseData.h
@@ -187,10 +187,10 @@ public:
     /// @{
 
     /// Set one of the flags.
-    void setFlag(DataFlagsEnum flag, bool b)  { if(b) m_dataFlags |= (DataFlags)flag;  else m_dataFlags &= ~(DataFlags)flag; }
+    void setFlag(DataFlagsEnum flag, bool b)  { if(b) m_dataFlags |= static_cast<DataFlags>(flag);  else m_dataFlags &= ~static_cast<DataFlags>(flag); }
 
     /// Get one of the flags.
-    bool getFlag(DataFlagsEnum flag) const { return (m_dataFlags&(DataFlags)flag)!=0; }
+    bool getFlag(DataFlagsEnum flag) const { return (m_dataFlags&static_cast<DataFlags>(flag))!=0; }
 
     /// Return whether this %Data has to be displayed in GUIs.
     bool isDisplayed() const  { return getFlag(FLAG_DISPLAYED); }
@@ -236,7 +236,7 @@ public:
     }
 
     /// Return the name of this %Data within the Base component
-    const std::string& getName() const { return m_name; }
+    const std::string& getName() const override { return m_name; }
     /// Set the name of this %Data.
     ///
     /// This method should not be called directly, the %Data registration methods in Base should be used instead.
@@ -249,17 +249,17 @@ public:
     /// True if the value has been modified
     /// If this data is linked, the value of this data will be considered as modified
     /// (even if the parent's value has not been modified)
-    bool isSet(const core::ExecParams* params=nullptr) const { return m_isSets[currentAspect(params)]; }
+    bool isSet(const core::ExecParams* params=nullptr) const { return m_isSets[static_cast<size_t>(currentAspect(params))]; }
 
     /// Reset the isSet flag to false, to indicate that the current value is the default for this %Data.
-    void unset(const core::ExecParams* params=nullptr) { m_isSets[currentAspect(params)] = false; }
+    void unset(const core::ExecParams* params=nullptr) { m_isSets[static_cast<size_t>(currentAspect(params))] = false; }
 
     /// Reset the isSet flag to true, to indicate that the current value has been modified.
-    void forceSet(const core::ExecParams* params=nullptr) { m_isSets[currentAspect(params)] = true; }
+    void forceSet(const core::ExecParams* params=nullptr) { m_isSets[static_cast<size_t>(currentAspect(params))] = true; }
 
     /// Return the number of changes since creation
     /// This can be used to efficiently detect changes
-    int getCounter(const core::ExecParams* params=nullptr) const { return m_counters[currentAspect(params)]; }
+    int getCounter(const core::ExecParams* params=nullptr) const { return m_counters[static_cast<size_t>(currentAspect(params))]; }
 
     /// @}
 
@@ -282,14 +282,14 @@ public:
     /// Accessor to the vector containing all the fields of this object
     const VecLink& getLinks() const { return m_vecLink; }
 
-    virtual bool findDataLinkDest(DDGNode*& ptr, const std::string& path, const BaseLink* link);
+    virtual bool findDataLinkDest(DDGNode*& ptr, const std::string& path, const BaseLink* link) override;
 
     virtual bool findDataLinkDest(BaseData*& ptr, const std::string& path, const BaseLink* link);
 
     template<class DataT>
     bool findDataLinkDest(DataT*& ptr, const std::string& path, const BaseLink* link)
     {
-        BaseData* base = NULL;
+        BaseData* base = nullptr;
         if (!findDataLinkDest(base, path, link)) return false;
         ptr = dynamic_cast<DataT*>(base);
         return (ptr != NULL);
@@ -363,7 +363,7 @@ class LinkTraitsPtrCasts
 public:
     static sofa::core::objectmodel::Base* getBase(sofa::core::objectmodel::Base* b) { return b; }
     static sofa::core::objectmodel::Base* getBase(sofa::core::objectmodel::BaseData* d) { return d->getOwner(); }
-    static sofa::core::objectmodel::BaseData* getData(sofa::core::objectmodel::Base* /*b*/) { return NULL; }
+    static sofa::core::objectmodel::BaseData* getData(sofa::core::objectmodel::Base* /*b*/) { return nullptr; }
     static sofa::core::objectmodel::BaseData* getData(sofa::core::objectmodel::BaseData* d) { return d; }
 };
 

--- a/SofaKernel/framework/sofa/core/objectmodel/Data.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/Data.h
@@ -68,9 +68,9 @@ public:
     ~TData() override
     {}
 
-    inline void printValue(std::ostream& out) const;
-    inline std::string getValueString() const;
-    inline std::string getValueTypeString() const; // { return std::string(typeid(m_value).name()); }
+    inline void printValue(std::ostream& out) const override;
+    inline std::string getValueString() const override;
+    inline std::string getValueTypeString() const override; // { return std::string(typeid(m_value).name()); }
 
     /// Get info about the value type of the associated variable
     const sofa::defaulttype::AbstractTypeInfo* getValueTypeInfo() const override
@@ -105,7 +105,7 @@ public:
     /** Try to read argument value from an input stream.
     Return false if failed
      */
-    virtual bool read( const std::string& s )
+    virtual bool read( const std::string& s ) override
     {
         if (s.empty())
         {
@@ -382,7 +382,7 @@ public:
     /** \copydoc BaseData(const BaseData::BaseInitData& init) */
     explicit Data(const BaseData::BaseInitData& init)
         : TData<T>(init)
-        , shared(NULL)
+        , shared(nullptr)
     {
     }
 
@@ -390,7 +390,7 @@ public:
     explicit Data(const InitData& init)
         : TData<T>(init)
         , m_values()
-        , shared(NULL)
+        , shared(nullptr)
     {
         m_values[DDGNode::currentAspect()] = ValueType(init.value);
     }
@@ -399,7 +399,7 @@ public:
     Data( const char* helpMsg=nullptr, bool isDisplayed=true, bool isReadOnly=false)
         : TData<T>(helpMsg, isDisplayed, isReadOnly)
         , m_values()
-        , shared(NULL)
+        , shared(nullptr)
     {
         ValueType val;
         m_values.assign(val);
@@ -411,7 +411,7 @@ public:
     Data( const T& value, const char* helpMsg=nullptr, bool isDisplayed=true, bool isReadOnly=false)
         : TData<T>(helpMsg, isDisplayed, isReadOnly)
         , m_values()
-        , shared(NULL)
+        , shared(nullptr)
     {
         m_values[DDGNode::currentAspect()] = ValueType(value);
     }
@@ -427,7 +427,7 @@ public:
 
     inline T* beginEdit(const core::ExecParams* params = nullptr)
     {
-        size_t aspect = DDGNode::currentAspect(params);
+        size_t aspect = static_cast<size_t>(DDGNode::currentAspect(params));
         this->updateIfDirty(params);
         ++this->m_counters[aspect];
         this->m_isSets[aspect] = true;
@@ -438,7 +438,7 @@ public:
     /// BeginEdit method if it is only to write the value
     inline T* beginWriteOnly(const core::ExecParams* params = nullptr)
     {
-        size_t aspect = DDGNode::currentAspect(params);
+        size_t aspect = static_cast<size_t>(DDGNode::currentAspect(params));
         ++this->m_counters[aspect];
         this->m_isSets[aspect] = true;
         BaseData::setDirtyOutputs(params);
@@ -493,7 +493,7 @@ public:
         const Data<T>* d = dynamic_cast< const Data<T>* >(&bd);
         if (d)
         {
-            size_t aspect = DDGNode::currentAspect();
+            size_t aspect = static_cast<size_t>(DDGNode::currentAspect());
             this->m_values[aspect] = d->m_values[aspect];
             //FIX: update counter
             ++this->m_counters[aspect];
@@ -648,8 +648,8 @@ protected:
     WriteAccessor( container_type* c, data_container_type& d, const core::ExecParams* params=nullptr ) : Inherit(*c), data(d), dparams(params) {}
 
 public:
-    WriteAccessor(data_container_type& d) : Inherit(*d.beginEdit()), data(d), dparams(NULL) {}
-    WriteAccessor(data_container_type* d) : Inherit(*d->beginEdit()), data(*d), dparams(NULL) {}
+    WriteAccessor(data_container_type& d) : Inherit(*d.beginEdit()), data(d), dparams(nullptr) {}
+    WriteAccessor(data_container_type* d) : Inherit(*d->beginEdit()), data(*d), dparams(nullptr) {}
     WriteAccessor(const core::ExecParams* params, data_container_type& d) : Inherit(*d.beginEdit(params)), data(d), dparams(params) {}
     WriteAccessor(const core::ExecParams* params, data_container_type* d) : Inherit(*d->beginEdit(params)), data(*d), dparams(params) {}
     ~WriteAccessor() { if (dparams) data.endEdit(dparams); else data.endEdit(); }

--- a/SofaKernel/framework/sofa/core/objectmodel/Event.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/Event.h
@@ -39,7 +39,7 @@ namespace objectmodel
     protected:\
     static const size_t s_eventTypeIndex; \
     public:\
-    virtual size_t getEventTypeIndex() const { return T::s_eventTypeIndex; } \
+    virtual size_t getEventTypeIndex() const override { return T::s_eventTypeIndex; } \
     static bool checkEventType( const Event* event ) { return event->getEventTypeIndex() == T::s_eventTypeIndex; }
 
 

--- a/SofaKernel/framework/sofa/core/objectmodel/Link.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/Link.h
@@ -345,7 +345,7 @@ public:
 
     size_t size(const core::ExecParams* params = nullptr) const
     {
-        return (size_t)m_value[core::ExecParams::currentAspect(params)].size();
+        return static_cast<size_t>(m_value[core::ExecParams::currentAspect(params)].size());
     }
 
     bool empty(const core::ExecParams* params = nullptr) const
@@ -493,7 +493,7 @@ public:
     {
         return TraitsDestCasts::getData(getIndex(index));
     }
-    std::string getLinkedPath(unsigned int index=0) const
+    std::string getLinkedPath(unsigned int index=0) const override
     {
         return getPath(index);
     }
@@ -502,7 +502,7 @@ public:
     /// @{
 
     /// Read the command line
-    virtual bool read( const std::string& str )
+    virtual bool read( const std::string& str ) override
     {
         if (str.empty())
             return true;
@@ -566,7 +566,7 @@ public:
             // Remove the objects from the container that are not in the new list
             // TODO epernod 2018-08-01: This cast from size_t to unsigned int remove a large amount of warnings.
             // But need to be rethink in the future. The problem is if index i is a site_t, then we need to template container<size_t> which impact the whole architecture.
-            unsigned int csize = (unsigned int)container.size();
+            unsigned int csize = static_cast<unsigned int>(container.size());
             for (unsigned int i = 0; i != csize; i++)
             {
                 DestPtr dest(container[i]);
@@ -597,7 +597,7 @@ public:
         if (!context)
         {
             std::string p,d;
-            return BaseLink::ParseString( path, &p, (ActiveFlags & FLAG_DATALINK) ? &d : NULL, NULL);
+            return BaseLink::ParseString( path, &p, (ActiveFlags & FLAG_DATALINK) ? &d : nullptr, nullptr);
         }
         else
         {
@@ -719,7 +719,7 @@ public:
         if (!this->m_owner) return false;
         bool ok = true;
         const int aspect = core::ExecParams::currentAspect();
-        unsigned int n = (unsigned int)this->getSize();
+        unsigned int n = static_cast<unsigned int>(this->getSize());
         for (unsigned int i = 0; i<n; ++i)
         {
             ValueType& value = this->m_value[aspect][i];

--- a/SofaKernel/framework/sofa/core/topology/TopologyElementHandler.h
+++ b/SofaKernel/framework/sofa/core/topology/TopologyElementHandler.h
@@ -68,13 +68,13 @@ public:
     using TopologyHandler::ApplyTopologyChange;
 
     /// Apply swap between indices elements.
-    virtual void ApplyTopologyChange(const EIndicesSwap* event);
+    virtual void ApplyTopologyChange(const EIndicesSwap* event) override;
     /// Apply adding elements.
-    virtual void ApplyTopologyChange(const EAdded* event);
+    virtual void ApplyTopologyChange(const EAdded* event) override;
     /// Apply removing elements.
-    virtual void ApplyTopologyChange(const ERemoved* event);
+    virtual void ApplyTopologyChange(const ERemoved* event) override;
     /// Apply renumbering on elements.
-    virtual void ApplyTopologyChange(const ERenumbering* event);
+    virtual void ApplyTopologyChange(const ERenumbering* event) override;
     /// Apply moving elements.
     virtual void ApplyTopologyChange(const EMoved* event);
     /// Apply adding function on moved elements.
@@ -87,7 +87,7 @@ protected:
     void swap( Topology::ElemID /*i1*/, Topology::ElemID /*i2*/ ) override {}
 
     /// Reorder the values.
-    virtual void renumber( const sofa::helper::vector<Topology::ElemID> &/*index*/ ) {}
+    virtual void renumber( const sofa::helper::vector<Topology::ElemID> &/*index*/ ) override {}
 
     /// Add some values. Values are added at the end of the vector.
     /// This is the (old) version, to be deprecated in favor of the next method
@@ -106,7 +106,7 @@ protected:
             )
     {
         // call old method by default
-        add((Topology::ElemID)index.size(), elems, ancestors, coefs);
+        add( static_cast<Topology::ElemID>(index.size()), elems, ancestors, coefs);
     }
 
     /// Remove the values corresponding to the ELement removed.

--- a/SofaKernel/framework/sofa/defaulttype/DataTypeInfo.h
+++ b/SofaKernel/framework/sofa/defaulttype/DataTypeInfo.h
@@ -321,7 +321,7 @@ public:
     const AbstractTypeInfo* BaseType() const override  { return VirtualTypeInfo<typename Info::BaseType>::get(); }
     const AbstractTypeInfo* ValueType() const override { return VirtualTypeInfo<typename Info::ValueType>::get(); }
 
-    virtual std::string name() const { return DataTypeName<DataType>::name(); }
+    virtual std::string name() const override { return DataTypeName<DataType>::name(); }
 
     bool ValidInfo() const override       { return Info::ValidInfo; }
     bool FixedSize() const override       { return Info::FixedSize; }
@@ -365,7 +365,7 @@ public:
         return v;
     }
 
-    virtual std::string getTextValue   (const void* data, size_t index) const
+    virtual std::string getTextValue   (const void* data, size_t index) const override
     {
         std::string v;
         Info::getValueString(*(const DataType*)data, index, v);
@@ -382,7 +382,7 @@ public:
         Info::setValue(*(DataType*)data, index, value);
     }
 
-    virtual void setTextValue(void* data, size_t index, const std::string& value) const
+    virtual void setTextValue(void* data, size_t index, const std::string& value) const override
     {
         Info::setValueString(*(DataType*)data, index, value);
     }
@@ -395,7 +395,7 @@ public:
         return Info::getValuePtr(*(DataType*)data);
     }
 
-    virtual const std::type_info* type_info() const { return &typeid(DataType); }
+    virtual const std::type_info* type_info() const override { return &typeid(DataType); }
 
 
 protected: // only derived types can instantiate this class

--- a/SofaKernel/framework/sofa/simulation/MechanicalComputeEnergyVisitor.h
+++ b/SofaKernel/framework/sofa/simulation/MechanicalComputeEnergyVisitor.h
@@ -78,7 +78,7 @@ public:
     }
 
 #ifdef SOFA_DUMP_VISITOR_INFO
-    virtual void setReadWriteVectors()
+    virtual void setReadWriteVectors() override
     {
     }
 #endif

--- a/SofaKernel/framework/sofa/simulation/MechanicalVisitor.h
+++ b/SofaKernel/framework/sofa/simulation/MechanicalVisitor.h
@@ -368,8 +368,8 @@ public:
     }
 
 #ifdef SOFA_DUMP_VISITOR_INFO
-    ctime_t begin(simulation::Node* node, core::objectmodel::BaseObject* obj, const std::string &info=std::string("type"));
-    void end(simulation::Node* node, core::objectmodel::BaseObject* obj, ctime_t t0);
+    ctime_t begin(simulation::Node* node, core::objectmodel::BaseObject* obj, const std::string &info=std::string("type")) override;
+    void end(simulation::Node* node, core::objectmodel::BaseObject* obj, ctime_t t0) override;
 #endif
 
 #ifdef SOFA_DUMP_VISITOR_INFO
@@ -426,7 +426,7 @@ public:
     }
 
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
     }
 #endif
@@ -455,14 +455,14 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalVAvailVisitor"; }
-    virtual std::string getInfos() const;
+    virtual std::string getInfos() const override;
     /// Specify whether this action can be parallelized.
     bool isThreadSafe() const override
     {
         return false;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         MyMultiVecId mv(v);
         addReadWriteVector( mv );
@@ -518,7 +518,7 @@ public:
         return "MechanicalVInitVisitor";
     }
 
-    virtual std::string getInfos() const;
+    virtual std::string getInfos() const override;
 
     /// Specify whether this action can be parallelized.
     bool isThreadSafe() const override
@@ -527,7 +527,7 @@ public:
     }
 
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addReadVector(vSrc);
         addWriteVector(vDest);
@@ -558,14 +558,14 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalVAllocVisitor"; }
-    virtual std::string getInfos() const;
+    virtual std::string getInfos() const override;
     /// Specify whether this action can be parallelized.
     bool isThreadSafe() const override
     {
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addReadWriteVector(v);
     }
@@ -622,7 +622,7 @@ public:
         return "MechanicalVReallocVisitor";
     }
 
-    virtual std::string getInfos() const;
+    virtual std::string getInfos() const override;
 
     /// Specify whether this action can be parallelized.
     bool isThreadSafe() const override
@@ -631,7 +631,7 @@ public:
     }
 
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addWriteVector(*v);
     }
@@ -668,14 +668,14 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalVFreeVisitor"; }
-    virtual std::string getInfos() const;
+    virtual std::string getInfos() const override;
     /// Specify whether this action can be parallelized.
     bool isThreadSafe() const override
     {
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
     }
 #endif
@@ -718,7 +718,7 @@ public:
     Result fwdMappedMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm) override;
 
     const char* getClassName() const override { return "MechanicalVOpVisitor";}
-    virtual std::string getInfos() const ;
+    virtual std::string getInfos() const override;
 
     /// Specify whether this action can be parallelized.
     bool isThreadSafe() const override
@@ -730,7 +730,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addReadVector(a);
         addReadVector(b);
@@ -763,7 +763,7 @@ public:
     Result fwdMappedMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm) override;
 
     const char* getClassName() const override { return "MechanicalVMultiOpVisitor"; }
-    virtual std::string getInfos() const ;
+    virtual std::string getInfos() const override;
 
     /// Specify whether this action can be parallelized.
     bool isThreadSafe() const override
@@ -775,7 +775,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         for (unsigned int i=0; i<ops.size(); ++i)
         {
@@ -818,7 +818,7 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalVDotVisitor";}
-    virtual std::string getInfos() const
+    virtual std::string getInfos() const override
     {
         std::string name("v= a*b with a[");
         name += a.getName() + "] and b[" + b.getName() + "]";
@@ -835,7 +835,7 @@ public:
     }
 
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addReadVector(a);
         addReadVector(b);
@@ -868,7 +868,7 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalVNormVisitor";}
-    virtual std::string getInfos() const ;
+    virtual std::string getInfos() const override;
 
     /// Specify whether this action can be parallelized.
     bool isThreadSafe() const override
@@ -881,7 +881,7 @@ public:
     }
 
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addReadVector(a);
     }
@@ -924,7 +924,7 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalPropagateDxVisitor"; }
-    virtual std::string getInfos() const
+    virtual std::string getInfos() const override
     {
         std::string name="["+dx.getName()+"]";
         return name;
@@ -935,7 +935,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addReadWriteVector(dx);
     }
@@ -966,7 +966,7 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalPropagateDxAndResetForceVisitor";}
-    virtual std::string getInfos() const { std::string name= "dx["+dx.getName()+"] f["+f.getName()+"]"; return name;}
+    virtual std::string getInfos() const override { std::string name= "dx["+dx.getName()+"] f["+f.getName()+"]"; return name;}
 
     /// Specify whether this action can be parallelized.
     bool isThreadSafe() const override
@@ -974,7 +974,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addReadWriteVector(dx);
         addWriteVector(f);
@@ -1017,7 +1017,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addReadWriteVector(x);
         addWriteVector(f);
@@ -1050,7 +1050,7 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalAddMDxVisitor"; }
-    virtual std::string getInfos() const { std::string name="dx["+dx.getName()+"] in res[" + res.getName()+"]"; return name; }
+    virtual std::string getInfos() const override { std::string name="dx["+dx.getName()+"] in res[" + res.getName()+"]"; return name; }
 
     Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* /*mm*/) override;
@@ -1061,7 +1061,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addReadVector(res);
     }
@@ -1088,7 +1088,7 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalAccFromFVisitor"; }
-    virtual std::string getInfos() const { std::string name="a["+a.getName()+"] f["+mparams->f().getName()+"]"; return name; }
+    virtual std::string getInfos() const override { std::string name="a["+a.getName()+"] f["+mparams->f().getName()+"]"; return name; }
 
     /// Specify whether this action can be parallelized.
     bool isThreadSafe() const override
@@ -1096,7 +1096,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addWriteVector(a);
         addReadVector(mparams->f());
@@ -1131,7 +1131,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
     }
 #endif
@@ -1158,7 +1158,7 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalProjectVelocityVisitor"; }
-    virtual std::string getInfos() const
+    virtual std::string getInfos() const override
     {
         std::string name="["+vel.getName()+"]"; return name;
     }
@@ -1168,7 +1168,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addReadWriteVector(vel);
     }
@@ -1196,7 +1196,7 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalProjectPositionVisitor"; }
-    virtual std::string getInfos() const
+    virtual std::string getInfos() const override
     {
         std::string name="["+pos.getName()+"]"; return name;
     }
@@ -1206,7 +1206,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addReadWriteVector(pos);
     }
@@ -1236,7 +1236,7 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalProjectPositionAndVelocityVisitor"; }
-    virtual std::string getInfos() const
+    virtual std::string getInfos() const override
     {
         std::string name="x["+pos.getName()+"] v["+vel.getName()+"]";
         return name;
@@ -1247,7 +1247,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addReadWriteVector(pos);
         addReadWriteVector(vel);
@@ -1287,7 +1287,7 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalPropagateOnlyPositionVisitor";}
-    virtual std::string getInfos() const
+    virtual std::string getInfos() const override
     {
         std::string name="x["+x.getName()+"]";
         if (ignoreMask) name += " Mask DISABLED";
@@ -1301,7 +1301,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addReadWriteVector(x);
     }
@@ -1343,7 +1343,7 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalPropagateOnlyPositionAndVelocityVisitor";}
-    virtual std::string getInfos() const { std::string name="x["+x.getName()+"] v["+v.getName()+"]"; return name; }
+    virtual std::string getInfos() const override { std::string name="x["+x.getName()+"] v["+v.getName()+"]"; return name; }
 
     /// Specify whether this action can be parallelized.
     bool isThreadSafe() const override
@@ -1351,7 +1351,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addReadWriteVector(x);
         addReadWriteVector(v);
@@ -1392,7 +1392,7 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalPropagateOnlyVelocityVisitor";}
-    virtual std::string getInfos() const { std::string name="v["+v.getName()+"]"; return name; }
+    virtual std::string getInfos() const override { std::string name="v["+v.getName()+"]"; return name; }
 
     /// Specify whether this action can be parallelized.
     bool isThreadSafe() const override
@@ -1400,7 +1400,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addReadWriteVector(v);
     }
@@ -1426,7 +1426,7 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalSetPositionAndVelocityVisitor";}
-    virtual std::string getInfos() const { std::string name="x["+x.getName()+"] v["+v.getName()+"]"; return name; }
+    virtual std::string getInfos() const override { std::string name="x["+x.getName()+"] v["+v.getName()+"]"; return name; }
 
     /// Specify whether this action can be parallelized.
     bool isThreadSafe() const override
@@ -1434,7 +1434,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addReadVector(x);
         addReadVector(v);
@@ -1467,7 +1467,7 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override {  return "MechanicalResetForceVisitor";}
-    virtual std::string getInfos() const
+    virtual std::string getInfos() const override
     {
         std::string name="["+res.getName()+"]";
         if (onlyMapped) name+= " Only Mapped";
@@ -1480,7 +1480,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addWriteVector(res);
     }
@@ -1515,7 +1515,7 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override {return "MechanicalComputeForceVisitor";}
-    virtual std::string getInfos() const
+    virtual std::string getInfos() const override
     {
         std::string name=std::string("[")+res.getName()+std::string("]");
         if (accumulate) name+= " Accumulating";
@@ -1529,7 +1529,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addWriteVector(res);
     }
@@ -1568,7 +1568,7 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override {return "MechanicalComputeDfVisitor";}
-    virtual std::string getInfos() const
+    virtual std::string getInfos() const override
     {
         std::string name="["+res.getName()+"]";
         if (accumulate) name+= " Accumulating";
@@ -1582,7 +1582,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addWriteVector(res);
     }
@@ -1611,7 +1611,7 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override {return "MechanicalComputeGeometricStiffness";}
-    virtual std::string getInfos() const
+    virtual std::string getInfos() const override
     {
         std::string name="["+childForce.getName()+"]";
         return name;
@@ -1623,7 +1623,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
 //        addWriteVector(res);
     }
@@ -1662,7 +1662,7 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalAddMBKdxVisitor"; }
-    virtual std::string getInfos() const { std::string name= "["+res.getName()+"]"; return name; }
+    virtual std::string getInfos() const override { std::string name= "["+res.getName()+"]"; return name; }
 
     /// Specify whether this action can be parallelized.
     bool isThreadSafe() const override
@@ -1670,7 +1670,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addReadWriteVector(res);
     }
@@ -1712,7 +1712,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
     }
 #endif
@@ -1744,11 +1744,11 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalWriteLMConstraint"; }
-    virtual std::string getInfos() const ;
+    virtual std::string getInfos() const override ;
 
     virtual void clear() {datasC.clear(); offset=0;}
     virtual const std::vector< core::behavior::BaseLMConstraint *> &getConstraints() const {return datasC;}
-    virtual unsigned int numConstraint() {return (unsigned int)datasC.size();}
+    virtual unsigned int numConstraint() {return static_cast<unsigned int>(datasC.size());}
 
     virtual void setMultiVecId(core::MultiVecId i) {id=i;}
     core::MultiVecId getMultiVecId() const { return id; }
@@ -1762,7 +1762,7 @@ public:
         return false;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
     }
 #endif
@@ -1815,7 +1815,7 @@ public:
     }
 
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
     }
 #endif
@@ -1862,7 +1862,7 @@ public:
     }
 
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
     }
 #endif
@@ -1912,7 +1912,7 @@ public:
     }
 
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
     }
 #endif
@@ -1952,7 +1952,7 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalApplyConstraintsVisitor"; }
-    virtual std::string getInfos() const { std::string name= "["+res.getName()+"]"; return name; }
+    virtual std::string getInfos() const override { std::string name= "["+res.getName()+"]"; return name; }
 
     /// Specify whether this action can be parallelized.
     bool isThreadSafe() const override
@@ -1960,7 +1960,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addReadWriteVector(res);
     }
@@ -1998,7 +1998,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
     }
 #endif
@@ -2036,7 +2036,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
     }
 #endif
@@ -2071,7 +2071,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
     }
 #endif
@@ -2108,7 +2108,7 @@ public:
         return true;
     }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addReadWriteVector(res);
     }
@@ -2137,9 +2137,9 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalAddSeparateGravityVisitor"; }
-    virtual std::string getInfos() const { std::string name= "["+res.getName()+"]"; return name; }
+    virtual std::string getInfos() const override { std::string name= "["+res.getName()+"]"; return name; }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addReadWriteVector(res);
     }
@@ -2173,7 +2173,7 @@ public:
     const char* getClassName() const override { return "MechanicalPickParticles"; }
 
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
     }
 #endif
@@ -2212,7 +2212,7 @@ public:
 	const char* getClassName() const override { return "MechanicalPickParticlesWithTags"; }
 
 #ifdef SOFA_DUMP_VISITOR_INFO
-	void setReadWriteVectors()
+    void setReadWriteVectors() override
 	{
 	}
 #endif
@@ -2250,7 +2250,7 @@ public:
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalVSizeVisitor";}
-    virtual std::string getInfos() const
+    virtual std::string getInfos() const override
     {
         std::string name = "[" + v.getName() + "]";
         return name;
@@ -2262,7 +2262,7 @@ public:
     }
 
 #ifdef SOFA_DUMP_VISITOR_INFO
-    void setReadWriteVectors()
+    void setReadWriteVectors() override
     {
         addReadVector(v);
     }

--- a/SofaKernel/framework/sofa/simulation/PropagateEventVisitor.h
+++ b/SofaKernel/framework/sofa/simulation/PropagateEventVisitor.h
@@ -60,7 +60,7 @@ public:
     void processObject(simulation::Node*, core::objectmodel::BaseObject* obj);
 
     const char* getClassName() const override { return "PropagateEventVisitor"; }
-    virtual std::string getInfos() const { return std::string(m_event->getClassName());  }
+    virtual std::string getInfos() const override { return std::string(m_event->getClassName());  }
 protected:
     sofa::core::objectmodel::Event* m_event;
 };

--- a/SofaKernel/framework/sofa/simulation/VectorOperations.h
+++ b/SofaKernel/framework/sofa/simulation/VectorOperations.h
@@ -69,7 +69,7 @@ public:
     void v_threshold(core::MultiVecId a, SReal threshold) override; ///< nullify the values below the given threshold
 
     SReal finish() override;
-    void print(sofa::core::ConstMultiVecId v, std::ostream& out, std::string prefix="", std::string suffix="" );
+    void print(sofa::core::ConstMultiVecId v, std::ostream& out, std::string prefix="", std::string suffix="" ) override;
 
     size_t v_size(core::MultiVecId v) override;
 

--- a/SofaKernel/framework/sofa/simulation/VisualVisitor.h
+++ b/SofaKernel/framework/sofa/simulation/VisualVisitor.h
@@ -94,7 +94,7 @@ public:
     virtual void bwdVisualModel(simulation::Node* node, core::visual::VisualModel* vm);
     const char* getClassName() const override { return "VisualDrawVisitor"; }
 #ifdef SOFA_DUMP_VISITOR_INFO
-    virtual void printInfo(const core::objectmodel::BaseContext*,bool )  {return;}
+    virtual void printInfo(const core::objectmodel::BaseContext*,bool ) override {return;}
 #endif
 };
 

--- a/SofaKernel/modules/SofaBaseLinearSolver/CompressedRowSparseMatrix.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/CompressedRowSparseMatrix.h
@@ -886,7 +886,7 @@ public:
     ElementType getElementType() const override { return traits::getElementType(); }
 
     /// @return size of elements stored in this matrix
-    virtual std::size_t getElementSize() const { return sizeof(Real); }
+    virtual std::size_t getElementSize() const override { return sizeof(Real); }
 
     /// @return the category of this matrix
     MatrixCategory getCategory() const override { return MATRIX_SPARSE; }

--- a/modules/SofaGeneralAnimationLoop/MechanicalMatrixMapper.inl
+++ b/modules/SofaGeneralAnimationLoop/MechanicalMatrixMapper.inl
@@ -285,7 +285,7 @@ void MechanicalMatrixMapper<DataTypes1, DataTypes2>::addKToMatrix(const Mechanic
     if(m_componentstate != ComponentState::Valid)
         return ;
 
-    sofa::helper::system::thread::CTime *timer;
+    sofa::helper::system::thread::CTime *timer = new sofa::helper::system::thread::CTime();
     double timeScale, time, totime ;
     timeScale = time = totime = 0;
 
@@ -499,6 +499,8 @@ void MechanicalMatrixMapper<DataTypes1, DataTypes2>::addKToMatrix(const Mechanic
 
     core::objectmodel::BaseContext* context = this->getContext();
     simulation::MechanicalResetConstraintVisitor(&cparams).execute(context);
+
+    delete timer;
 
 }
 


### PR DESCRIPTION
Remove warnings, mostly from missing override keyword.
(+ some old style C cast)

And fix a (potential) crash in MechanicalMatrixMapper (uninitialized pointer) 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
