### PR TITLE
[SofaKernel] FIX in TetrahedronFEMForceField & TetrahedronSetTopologyAlgorithm

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/BarycentricMapping.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/BarycentricMapping.inl
@@ -70,6 +70,8 @@ using sofa::defaulttype::Vector3;
 using sofa::defaulttype::Matrix3;
 using sofa::defaulttype::Mat3x3d;
 using sofa::defaulttype::Vec3d;
+using sofa::core::objectmodel::ComponentState;
+
 // 10/18 E.Coevoet: what's the difference between edge/line, tetra/tetrahedron, hexa/hexahedron?
 typedef typename sofa::core::topology::BaseMeshTopology::Line Edge;
 typedef typename sofa::core::topology::BaseMeshTopology::Edge Edge;
@@ -217,6 +219,8 @@ void BarycentricMapping<TIn, TOut>::createMapperFromTopology ( BaseMeshTopology 
 template <class TIn, class TOut>
 void BarycentricMapping<TIn, TOut>::init()
 {
+    this->m_componentstate = ComponentState::Invalid ;
+
     topology_from = this->fromModel->getContext()->getMeshTopology();
     topology_to = this->toModel->getContext()->getMeshTopology();
 
@@ -230,18 +234,18 @@ void BarycentricMapping<TIn, TOut>::init()
         }
     }
 
-    if ( m_mapper != NULL )
-    {
-        if (useRestPosition.getValue())
-            m_mapper->init ( ((const core::State<Out> *)this->toModel)->read(core::ConstVecCoordId::restPosition())->getValue(), ((const core::State<In> *)this->fromModel)->read(core::ConstVecCoordId::restPosition())->getValue() );
-        else
-            m_mapper->init (((const core::State<Out> *)this->toModel)->read(core::ConstVecCoordId::position())->getValue(), ((const core::State<In> *)this->fromModel)->read(core::ConstVecCoordId::position())->getValue() );
-    }
-    else
+    if ( m_mapper == NULL )
     {
         msg_error() << "Barycentric mapping does not understand topology.";
+        return;
     }
 
+    if (useRestPosition.getValue())
+        m_mapper->init ( ((const core::State<Out> *)this->toModel)->read(core::ConstVecCoordId::restPosition())->getValue(), ((const core::State<In> *)this->fromModel)->read(core::ConstVecCoordId::restPosition())->getValue() );
+    else
+        m_mapper->init (((const core::State<Out> *)this->toModel)->read(core::ConstVecCoordId::position())->getValue(), ((const core::State<In> *)this->fromModel)->read(core::ConstVecCoordId::position())->getValue() );
+
+    this->m_componentstate = ComponentState::Valid ;
 }
 
 template <class TIn, class TOut>
@@ -316,6 +320,7 @@ template <class TIn, class TOut>
 void BarycentricMapping<TIn, TOut>::draw(const core::visual::VisualParams* vparams)
 {
     if ( !vparams->displayFlags().getShowMappings() ) return;
+    if (this->m_componentstate != ComponentState::Valid ) return;
 
     // Draw model (out) points
     const OutVecCoord& out = this->toModel->read(core::ConstVecCoordId::position())->getValue();

--- a/SofaKernel/modules/SofaBaseTopology/PointSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/PointSetGeometryAlgorithms.inl
@@ -40,6 +40,8 @@ namespace component
 namespace topology
 {
 
+using sofa::core::objectmodel::ComponentState;
+
 template <class DataTypes>
  PointSetGeometryAlgorithms< DataTypes >::PointSetGeometryAlgorithms()        : GeometryAlgorithms()
         ,d_showIndicesScale (core::objectmodel::Base::initData(&d_showIndicesScale, (float) 0.02, "showIndicesScale", "Debug : scale for view topology indices"))
@@ -50,6 +52,7 @@ template <class DataTypes>
 template <class DataTypes>
 void PointSetGeometryAlgorithms< DataTypes >::init()
 {
+    this->m_componentstate = ComponentState::Invalid;
     if ( this->d_tagMechanics.getValue().size()>0) {
         sofa::core::objectmodel::Tag mechanicalTag(this->d_tagMechanics.getValue());
         object = this->getContext()->core::objectmodel::BaseContext::template get< core::behavior::MechanicalState< DataTypes > >(mechanicalTag,sofa::core::objectmodel::BaseContext::SearchUp);
@@ -58,6 +61,18 @@ void PointSetGeometryAlgorithms< DataTypes >::init()
     }
     core::topology::GeometryAlgorithms::init();
     this->m_topology = this->getContext()->getMeshTopology();
+    if(this->m_topology==nullptr)
+    {
+        msg_error() << "Unable to get a valid topology from the context";
+        return;
+    }
+
+    if(this->object ==nullptr)
+    {
+        msg_error() << "Unable to get a valid mechanical object from the context";
+        return;
+    }
+    this->m_componentstate = ComponentState::Valid;
 }
 
 template <class DataTypes>

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetGeometryAlgorithms.h
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetGeometryAlgorithms.h
@@ -146,14 +146,10 @@ protected:
     NumericalIntegrationDescriptor<Real,4> tetrahedronNumericalIntegration;
 };
 
-#if  !defined(SOFA_COMPONENT_TOPOLOGY_TETRAHEDRONSETGEOMETRYALGORITHMS_CPP)
+#if !defined(SOFA_COMPONENT_TOPOLOGY_TETRAHEDRONSETGEOMETRYALGORITHMS_CPP)
 extern template class SOFA_BASE_TOPOLOGY_API TetrahedronSetGeometryAlgorithms<defaulttype::Vec3Types>;
 extern template class SOFA_BASE_TOPOLOGY_API TetrahedronSetGeometryAlgorithms<defaulttype::Vec2Types>;
 extern template class SOFA_BASE_TOPOLOGY_API TetrahedronSetGeometryAlgorithms<defaulttype::Vec1Types>;
-//extern template class SOFA_BASE_TOPOLOGY_API TetrahedronSetGeometryAlgorithms<defaulttype::Rigid3Types>;
-//extern template class SOFA_BASE_TOPOLOGY_API TetrahedronSetGeometryAlgorithms<defaulttype::Rigid2Types>;
-
-
 #endif
 
 } // namespace topology

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetGeometryAlgorithms.inl
@@ -36,6 +36,8 @@ namespace component
 namespace topology
 {
 
+using sofa::core::objectmodel::ComponentState;
+
 const unsigned int edgesInTetrahedronArray[6][2] = {{0,1}, {0,2}, {0,3}, {1,2}, {1,3}, {2,3}};
 
 template< class DataTypes>
@@ -138,35 +140,6 @@ void TetrahedronSetGeometryAlgorithms< DataTypes >::defineTetrahedronCubaturePoi
     }
     tetrahedronNumericalIntegration.addQuadratureMethod(m,5,qpa);
 
-/*
-    v=BarycentricCoordinatesType(0.25,0.25,0.25,0.25);
-    qpa.push_back(QuadraturePoint(v,(Real) 8/405));
-    a=(7+sqrt((Real)15))/34;
-    b=(13+3*sqrt((Real)15))/34;
-     c=(2665-14*sqrt((Real)15))/226800;
-    for (i=0;i<4;++i) {
-        v=BarycentricCoordinatesType(a,a,a,a);
-        v[i]=b;
-        qpa.push_back(QuadraturePoint(v,c));
-    }
-    a=(7-sqrt((Real)15))/34;
-    b=(13-3*sqrt((Real)15))/34;
-    c=(2665+14*sqrt((Real)15))/226800;
-    for (i=0;i<4;++i) {
-        v=BarycentricCoordinatesType(a,a,a,a);
-        v[i]=b;
-        qpa.push_back(QuadraturePoint(v,c));
-    }
-    a=(5-sqrt((Real)15))/20;
-    b=(5+sqrt((Real)15))/20;
-    c=(Real)5/567;
-    for (i=0;i<6;++i) {
-        v=BarycentricCoordinatesType(a,a,a,a);
-        v[edgesInTetrahedronArray[i][0]]=b;
-        v[edgesInTetrahedronArray[i][1]]=b;
-        qpa.push_back(QuadraturePoint(v,c));
-    }
-    tetrahedronNumericalIntegration.addQuadratureMethod(m,5,qpa); */
     /// integration with sixtic accuracy with 24 points
     // This rule is originally from Keast:
     // Patrick Keast,
@@ -925,6 +898,9 @@ void TetrahedronSetGeometryAlgorithms<DataTypes>::writeMSHfile(const char *filen
 template<class DataTypes>
 void TetrahedronSetGeometryAlgorithms<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
+    if(this->m_componentstate == ComponentState::Invalid)
+        return;
+
     TriangleSetGeometryAlgorithms<DataTypes>::draw(vparams);
 
     const VecCoord& coords =(this->object->read(core::ConstVecCoordId::position())->getValue());

--- a/SofaKernel/modules/SofaSimpleFem/TetrahedronFEMForceField.h
+++ b/SofaKernel/modules/SofaSimpleFem/TetrahedronFEMForceField.h
@@ -104,9 +104,9 @@ public:
     typedef core::topology::BaseMeshTopology::Tetrahedron Tetrahedron;
 
     enum { SMALL = 0,   ///< Symbol of small displacements tetrahedron solver
-            LARGE = 1,   ///< Symbol of corotational large displacements tetrahedron solver based on a QR decomposition    -> Nesme et al 2005 "Efficient, Physically Plausible Finite Elements"
-            POLAR = 2,   ///< Symbol of corotational large displacements tetrahedron solver based on a polar decomposition -> Muller et al 2004 "Interactive Virtual Materials"
-            SVD = 3      ///< Symbol of corotational large displacements tetrahedron solver based on a SVD decomposition   -> inspired from Irving et al 2004 "Invertible Finite Element for Robust Simulation of Large Deformation"
+           LARGE = 1,   ///< Symbol of corotational large displacements tetrahedron solver based on a QR decomposition    -> Nesme et al 2005 "Efficient, Physically Plausible Finite Elements"
+           POLAR = 2,   ///< Symbol of corotational large displacements tetrahedron solver based on a polar decomposition -> Muller et al 2004 "Interactive Virtual Materials"
+           SVD = 3      ///< Symbol of corotational large displacements tetrahedron solver based on a SVD decomposition   -> inspired from Irving et al 2004 "Invertible Finite Element for Robust Simulation of Large Deformation"
          };
 
 protected:
@@ -230,6 +230,8 @@ public:
     Data<bool>  isToPrint;
     Data<bool>  _updateStiffness; ///< udpate structures (precomputed in init) using stiffness parameters in each iteration (set listening=1)
 
+    SingleLink<TetrahedronFEMForceField<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_topology;
+
     helper::vector<defaulttype::Vec<6,Real> > elemDisplacements;
 
     bool updateVonMisesStress;
@@ -325,7 +327,6 @@ protected:
 
 #if !defined(SOFA_COMPONENT_FORCEFIELD_TETRAHEDRONFEMFORCEFIELD_CPP)
 extern template class SOFA_SIMPLE_FEM_API TetrahedronFEMForceField<defaulttype::Vec3Types>;
-
 #endif
 
 } // namespace forcefield

--- a/SofaKernel/modules/SofaSimpleFem/TetrahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/TetrahedronFEMForceField.inl
@@ -74,6 +74,7 @@ TetrahedronFEMForceField<DataTypes>::TetrahedronFEMForceField()
     , _showVonMisesStressPerNode(initData(&_showVonMisesStressPerNode,false,"showVonMisesStressPerNode","draw points  showing vonMises stress interpolated in nodes"))
     , isToPrint( initData(&isToPrint, false, "isToPrint", "suppress somes data before using save as function"))
     , _updateStiffness(initData(&_updateStiffness,false,"updateStiffness","udpate structures (precomputed in init) using stiffness parameters in each iteration (set listening=1)"))
+    , l_topology(initLink("topology", "link to the tetrahedron topology container"))
 {
     _poissonRatio.setRequired(true);
     _youngModulus.setRequired(true);
@@ -1349,7 +1350,13 @@ void TetrahedronFEMForceField<DataTypes>::init()
     // At init parallelDataSimu == parallelDataThrd (and it's the case since handleEvent is called)
 
     this->core::behavior::ForceField<DataTypes>::init();
-    _mesh = this->getContext()->getMeshTopology();
+
+    /// Take the user provide topology.
+    _mesh = l_topology.get();
+
+    /// If not possible try to find one in the current context.
+    if(_mesh == nullptr)
+        _mesh = this->getContext()->getMeshTopology();
 
     if (_mesh==NULL)
     {

--- a/examples/Components/forcefield/FastTriangularBendingSprings.scn
+++ b/examples/Components/forcefield/FastTriangularBendingSprings.scn
@@ -1,12 +1,12 @@
 <?xml version="1.0" ?>
 <Node name="root" dt="0.01" gravity="0 0 -1">
     <VisualStyle displayFlags="showBehavior hideCollision hideVisual " />
-    <EdgeSetGeometryAlgorithms />
     <EulerImplicitSolver  rayleighStiffness="0.1" rayleighMass="0.1" />
     <CGLinearSolver iterations="25" tolerance="1e-5" threshold="1e-5"/>
     <Node name="Thin shell">
                 <MeshObjLoader name="loader" filename="mesh/triangleGrid_10_10.obj" />
                 <MeshTopology src="@loader" />
+                <EdgeSetGeometryAlgorithms />
                 <MechanicalObject name="defoDOF" template="Vec3d"  src="@loader" />
                 <BoxROI name="box1" box="-0.5 -0.5 -0.5  100.5 0.005 0.005  " />
                 <FixedConstraint indices="@box1.indices"/>

--- a/examples/Components/loader/GridMeshCreator.scn
+++ b/examples/Components/loader/GridMeshCreator.scn
@@ -1,13 +1,13 @@
 <?xml version="1.0" ?>
 <Node name="root" dt="0.04" gravity="0 -1 0">
-    <VisualStyle displayFlags="showBehavior hideCollision hideVisual " />
-    <EdgeSetGeometryAlgorithms />
+    <VisualStyle displayFlags="showBehavior hideCollision hideVisual " />    
     <EulerImplicitSolver  rayleighStiffness="0.1" rayleighMass="0.1" />
     <CGLinearSolver iterations="25" tolerance="1e-5" threshold="1e-5" />
     <Node name="Thin shell">
                 <GridMeshCreator name="loader" filename="nofile" resolution="2 2" trianglePattern="1" rotation="180 0 0 " scale="10 10 0" />
                 <MeshTopology src="@loader" />
                 <MechanicalObject name="defoDOF" template="Vec3d"  src="@loader" />
+                <EdgeSetGeometryAlgorithms />
                 <BoxConstraint box="-0.5 -0.5 -0.5  10.5 0.005 0.005  " />
                 <TriangleFEMForceField name="FEM1" youngModulus="20000" poissonRatio="0.3" method="large" />
                 <FastTriangularBendingSprings bendingStiffness="1000" />

--- a/modules/SofaConstraint/BilateralInteractionConstraint.h
+++ b/modules/SofaConstraint/BilateralInteractionConstraint.h
@@ -200,10 +200,9 @@ void BilateralInteractionConstraint<Rigid3Types>::addContact(Deriv /*norm*/,
 
 
 
-#if  !defined(SOFA_BUILD_CONSTRAINT)
+#if !defined(SOFA_COMPONENT_CONSTRAINTSET_BILATERALINTERACTIONCONSTRAINT_CPP)
 extern template class SOFA_CONSTRAINT_API BilateralInteractionConstraint< Vec3Types >;
 extern template class SOFA_CONSTRAINT_API BilateralInteractionConstraint< Rigid3Types >;
-
 #endif
 
 } // namespace bilateralinteractionconstraint


### PR DESCRIPTION
Hi, here is the content:

1) [SofaKernel] FIX segfault in TetrahedronSetGeometryAlgorithms
The segfault happens when the component is located in a node without
a topology and a mechanical object. Then the 'draw' function is crashing.

2)  [SofaKernel] ADD a link to manually set the topology in TetrahedronFEMForceField
The component was searching the topology in the context which was:
- implicit
- constraining the organization of components the scene graph.

To solve this I added a SingleLink that allows to specify the topology.
If the link is not set then the existing behavior is used.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
