### PR TITLE
[SofaKernel] FIX issue 746  (bug in MeshTopology)

### DIFF
--- a/SofaKernel/framework/sofa/core/topology/BaseMeshTopology.cpp
+++ b/SofaKernel/framework/sofa/core/topology/BaseMeshTopology.cpp
@@ -37,6 +37,40 @@ using namespace sofa::defaulttype;
 using helper::vector;
 using helper::fixed_array;
 
+
+BaseMeshTopology::EdgesInTriangle BaseMeshTopology::InvalidEdgesInTriangles;
+BaseMeshTopology::EdgesInQuad     BaseMeshTopology::InvalidEdgesInQuad;
+BaseMeshTopology::TrianglesInTetrahedron BaseMeshTopology::InvalidTrianglesInTetrahedron;
+BaseMeshTopology::EdgesInTetrahedron BaseMeshTopology::InvalidEdgesInTetrahedron;
+BaseMeshTopology::QuadsInHexahedron BaseMeshTopology::InvalidQuadsInHexahedron;
+BaseMeshTopology::EdgesInHexahedron BaseMeshTopology::InvalidEdgesInHexahedron;
+
+BaseMeshTopology::VerticesAroundVertex BaseMeshTopology::EmptyVerticesAroundVertx;
+BaseMeshTopology::EdgesAroundVertex   BaseMeshTopology::EmptyEdgesAroundVertex;
+BaseMeshTopology::TrianglesAroundVertex BaseMeshTopology::EmptyTrianglesAroundVertex;
+BaseMeshTopology::QuadsAroundVertex  BaseMeshTopology::EmptyQuadsAroundVertex;
+BaseMeshTopology::TetrahedraAroundVertex BaseMeshTopology::EmptyTetrahedraAroundVertex;
+BaseMeshTopology::HexahedraAroundVertex BaseMeshTopology::EmptyHexahedraAroundVertex;
+BaseMeshTopology::TrianglesAroundEdge BaseMeshTopology::EmptyTrianglesAroundEdge;
+BaseMeshTopology::QuadsAroundEdge     BaseMeshTopology::EmptyQuadsAroundEdge;
+BaseMeshTopology::TetrahedraAroundEdge BaseMeshTopology::EmptyTetrahedraAroundEdge;
+BaseMeshTopology::HexahedraAroundEdge  BaseMeshTopology::EmptyHexahedraAroundEdge;
+BaseMeshTopology::TetrahedraAroundTriangle BaseMeshTopology::EmptyTetrahedraAroundTriangle;
+BaseMeshTopology::HexahedraAroundQuad BaseMeshTopology::EmptyHexahedraAroundQuad;
+
+int initStaticStructures()
+{
+    BaseMeshTopology::InvalidEdgesInTriangles.assign(InvalidID);
+    BaseMeshTopology::InvalidEdgesInQuad.assign(InvalidID);
+    BaseMeshTopology::InvalidTrianglesInTetrahedron.assign(InvalidID);
+    BaseMeshTopology::InvalidEdgesInTetrahedron.assign(InvalidID);
+    BaseMeshTopology::InvalidQuadsInHexahedron.assign(InvalidID);
+    BaseMeshTopology::InvalidEdgesInHexahedron.assign(InvalidID);
+}
+
+static int _init_  = initStaticStructures();
+
+
 BaseMeshTopology::BaseMeshTopology()
     : fileTopology(initData(&fileTopology,"fileTopology","Filename of the mesh"))
 {
@@ -47,35 +81,28 @@ BaseMeshTopology::BaseMeshTopology()
 const BaseMeshTopology::EdgesAroundVertex& BaseMeshTopology::getEdgesAroundVertex(PointID)
 {
     if (getNbEdges()) msg_error() << "getEdgesAroundVertex unsupported.";
-    static EdgesAroundVertex empty;
-    return empty;
+    return EmptyEdgesAroundVertex;
 }
 
 /// Returns the set of edges adjacent to a given triangle.
 const BaseMeshTopology::EdgesInTriangle& BaseMeshTopology::getEdgesInTriangle(TriangleID)
 {
-    if (getNbEdges()) msg_error() << "getEdgesInTriangle unsupported.";
-    static EdgesInTriangle empty;
-    empty.assign(InvalidID);
-    return empty;
+    if (getNbEdges()) msg_error() << "getEdgesInTriangle unsupported.";    
+    return InvalidEdgesInTriangles;
 }
 
 /// Returns the set of edges adjacent to a given quad.
 const BaseMeshTopology::EdgesInQuad& BaseMeshTopology::getEdgesInQuad(QuadID)
 {
     if (getNbEdges()) msg_error() << "getEdgesInQuad unsupported.";
-    static EdgesInQuad empty;
-    empty.assign(InvalidID);
-    return empty;
+    return InvalidEdgesInQuad;
 }
 
 /// Returns the set of edges adjacent to a given tetrahedron.
 const BaseMeshTopology::EdgesInTetrahedron& BaseMeshTopology::getEdgesInTetrahedron(TetraID)
 {
     if (getNbEdges()) msg_error() << "getEdgesInTetrahedron unsupported.";
-    static EdgesInTetrahedron empty;
-    empty.assign(InvalidID);
-    return empty;
+    return InvalidEdgesInTetrahedron;
 }
 
 
@@ -83,25 +110,21 @@ const BaseMeshTopology::EdgesInTetrahedron& BaseMeshTopology::getEdgesInTetrahed
 const BaseMeshTopology::EdgesInHexahedron& BaseMeshTopology::getEdgesInHexahedron(HexaID)
 {
     if (getNbEdges()) msg_error() << "getEdgesInHexahedron unsupported.";
-    static EdgesInHexahedron empty;
-    empty.assign(InvalidID);
-    return empty;
+    return InvalidEdgesInHexahedron;
 }
 
 /// Returns the set of triangle adjacent to a given vertex.
 const BaseMeshTopology::TrianglesAroundVertex& BaseMeshTopology::getTrianglesAroundVertex(PointID)
 {
     if (getNbTriangles()) msg_error() << "getTrianglesAroundVertex unsupported.";
-    static TrianglesAroundVertex empty;
-    return empty;
+    return EmptyTrianglesAroundVertex;
 }
 
 /// Returns the set of triangle adjacent to a given edge.
 const BaseMeshTopology::TrianglesAroundEdge& BaseMeshTopology::getTrianglesAroundEdge(EdgeID)
 {
     if (getNbTriangles()) msg_error() << "getEdgesAroundVertex unsupported.";
-    static TrianglesAroundEdge empty;
-    return empty;
+    return EmptyTrianglesAroundEdge;
 }
 
 /// Returns the set of triangle adjacent to a given tetrahedron.
@@ -117,73 +140,63 @@ const BaseMeshTopology::TrianglesInTetrahedron& BaseMeshTopology::getTrianglesIn
 const BaseMeshTopology::QuadsAroundVertex& BaseMeshTopology::getQuadsAroundVertex(PointID)
 {
     if (getNbQuads()) msg_error() << "getQuadsAroundVertex unsupported.";
-    static QuadsAroundVertex empty;
-    return empty;
+    return EmptyQuadsAroundVertex;
 }
 
 /// Returns the set of quad adjacent to a given edge.
 const BaseMeshTopology::QuadsAroundEdge& BaseMeshTopology::getQuadsAroundEdge(EdgeID)
 {
     if (getNbQuads()) msg_error() << "getQuadsAroundEdge unsupported.";
-    static QuadsAroundEdge empty;
-    return empty;
+    return EmptyQuadsAroundEdge;
 }
 
 /// Returns the set of quad adjacent to a given hexahedron.
 const BaseMeshTopology::QuadsInHexahedron& BaseMeshTopology::getQuadsInHexahedron(HexaID)
 {
     if (getNbQuads()) msg_error() << "getQuadsInHexahedron unsupported.";
-    static QuadsInHexahedron empty;
-    empty.assign(InvalidID);
-    return empty;
+    return InvalidQuadsInHexahedron;
 }
 
 /// Returns the set of tetrahedra adjacent to a given vertex.
 const BaseMeshTopology::TetrahedraAroundVertex& BaseMeshTopology::getTetrahedraAroundVertex(PointID)
 {
     if (getNbTetrahedra()) msg_error() << "getTetrahedraAroundVertex unsupported.";
-    static TetrahedraAroundVertex empty;
-    return empty;
+    return EmptyTetrahedraAroundVertex;
 }
 
 /// Returns the set of tetrahedra adjacent to a given edge.
 const BaseMeshTopology::TetrahedraAroundEdge& BaseMeshTopology::getTetrahedraAroundEdge(EdgeID)
 {
     if (getNbTetrahedra()) msg_error() << "getTetrahedraAroundEdge unsupported.";
-    static TetrahedraAroundEdge empty;
-    return empty;
+    return EmptyTetrahedraAroundEdge;
 }
 
 /// Returns the set of tetrahedra adjacent to a given triangle.
 const BaseMeshTopology::TetrahedraAroundTriangle& BaseMeshTopology::getTetrahedraAroundTriangle(TriangleID)
 {
     if (getNbTetrahedra()) msg_error() << "getTetrahedraAroundTriangle unsupported.";
-    static TetrahedraAroundTriangle empty;
-    return empty;
+    return EmptyTetrahedraAroundTriangle;
 }
 
 /// Returns the set of hexahedra adjacent to a given vertex.
 const BaseMeshTopology::HexahedraAroundVertex& BaseMeshTopology::getHexahedraAroundVertex(PointID)
 {
     if (getNbHexahedra()) msg_error() << "getHexahedraAroundVertex unsupported.";
-    static HexahedraAroundVertex empty;
-    return empty;
+    return EmptyHexahedraAroundVertex;
 }
 
 /// Returns the set of hexahedra adjacent to a given edge.
 const BaseMeshTopology::HexahedraAroundEdge& BaseMeshTopology::getHexahedraAroundEdge(EdgeID)
 {
     if (getNbHexahedra()) msg_error() << "getHexahedraAroundEdge unsupported.";
-    static HexahedraAroundEdge empty;
-    return empty;
+    return EmptyHexahedraAroundEdge;
 }
 
 /// Returns the set of hexahedra adjacent to a given quad.
 const BaseMeshTopology::HexahedraAroundQuad& BaseMeshTopology::getHexahedraAroundQuad(QuadID)
 {
     if (getNbHexahedra()) msg_error() << "getHexahedraAroundQuad unsupported.";
-    static HexahedraAroundQuad empty;
-    return empty;
+    return EmptyHexahedraAroundQuad;
 }
 
 

--- a/SofaKernel/framework/sofa/core/topology/BaseMeshTopology.cpp
+++ b/SofaKernel/framework/sofa/core/topology/BaseMeshTopology.cpp
@@ -66,6 +66,7 @@ int initStaticStructures()
     BaseMeshTopology::InvalidEdgesInTetrahedron.assign(InvalidID);
     BaseMeshTopology::InvalidQuadsInHexahedron.assign(InvalidID);
     BaseMeshTopology::InvalidEdgesInHexahedron.assign(InvalidID);
+    return 0;
 }
 
 static int _init_  = initStaticStructures();

--- a/SofaKernel/framework/sofa/core/topology/BaseMeshTopology.h
+++ b/SofaKernel/framework/sofa/core/topology/BaseMeshTopology.h
@@ -68,6 +68,14 @@ public:
     typedef sofa::helper::fixed_array<EdgeID,6>		EdgesInTetrahedron;
     typedef sofa::helper::fixed_array<QuadID,6>		QuadsInHexahedron;
     typedef sofa::helper::fixed_array<EdgeID,12>    EdgesInHexahedron;
+
+    static EdgesInTriangle InvalidEdgesInTriangles;
+    static EdgesInQuad     InvalidEdgesInQuad;
+    static TrianglesInTetrahedron InvalidTrianglesInTetrahedron;
+    static EdgesInTetrahedron InvalidEdgesInTetrahedron;
+    static QuadsInHexahedron InvalidQuadsInHexahedron;
+    static EdgesInHexahedron InvalidEdgesInHexahedron;
+
     /// @}
 
     /// dynamic-size neighbors arrays
@@ -84,6 +92,21 @@ public:
     typedef sofa::helper::vector<HexaID>			HexahedraAroundEdge;
     typedef sofa::helper::vector<TetraID>		    TetrahedraAroundTriangle;
     typedef sofa::helper::vector<HexaID>			HexahedraAroundQuad;
+
+    static VerticesAroundVertex  EmptyVerticesAroundVertx;
+    static EdgesAroundVertex     EmptyEdgesAroundVertex;
+    static TrianglesAroundVertex EmptyTrianglesAroundVertex;
+    static QuadsAroundVertex     EmptyQuadsAroundVertex;
+    static TetrahedraAroundVertex EmptyTetrahedraAroundVertex;
+    static HexahedraAroundVertex  EmptyHexahedraAroundVertex;
+    static TrianglesAroundEdge    EmptyTrianglesAroundEdge;
+    static QuadsAroundEdge        EmptyQuadsAroundEdge;
+    static TetrahedraAroundEdge   EmptyTetrahedraAroundEdge;
+    static HexahedraAroundEdge    EmptyHexahedraAroundEdge;
+    static TetrahedraAroundTriangle        EmptyTetrahedraAroundTriangle;
+    static HexahedraAroundQuad   EmptyHexahedraAroundQuad;
+
+
     /// @}
 protected:
     BaseMeshTopology()	;

--- a/SofaKernel/modules/SofaBaseTopology/MeshTopology.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/MeshTopology.cpp
@@ -1442,7 +1442,11 @@ const MeshTopology::EdgesAroundVertex& MeshTopology::getEdgesAroundVertex(PointI
 {
     if (!m_edgesAroundVertex.size() || i > m_edgesAroundVertex.size()-1)
         createEdgesAroundVertexArray();
-    return m_edgesAroundVertex[i];
+
+    if (i < m_edgesAroundVertex.size())
+        return m_edgesAroundVertex[i];
+
+    return EmptyEdgesAroundVertex;
 }
 
 const MeshTopology::EdgesAroundVertex& MeshTopology::getOrientedEdgesAroundVertex(PointID i)
@@ -1459,7 +1463,11 @@ const MeshTopology::EdgesAroundVertex& MeshTopology::getOrientedEdgesAroundVerte
                 createOrientedQuadsAroundVertexArray();
         }
     }
-    return m_orientedEdgesAroundVertex[i];
+
+    if (i <  m_orientedEdgesAroundVertex.size())
+        return m_orientedEdgesAroundVertex[i];
+
+    return EmptyEdgesAroundVertex;
 }
 
 
@@ -1467,124 +1475,201 @@ const MeshTopology::EdgesInTriangle& MeshTopology::getEdgesInTriangle(TriangleID
 {
     if (m_edgesInTriangle.empty() || i > m_edgesInTriangle.size()-1)
         createEdgesInTriangleArray();
-    return m_edgesInTriangle[i];
+
+    if (i < m_edgesInTriangle.size())
+        return m_edgesInTriangle[i];
+
+    return InvalidEdgesInTriangles;
 }
 
 const MeshTopology::EdgesInQuad& MeshTopology::getEdgesInQuad(QuadID i)
 {
     if (m_edgesInQuad.empty() || i > m_edgesInQuad.size()-1)
         createEdgesInQuadArray();
-    return m_edgesInQuad[i];
+
+    if (i < m_edgesInQuad.size())
+        return m_edgesInQuad[i];
+
+    return InvalidEdgesInQuad;
 }
 
 const MeshTopology::EdgesInTetrahedron& MeshTopology::getEdgesInTetrahedron(TetraID i)
 {
     if (m_edgesInTetrahedron.empty() || i > m_edgesInTetrahedron.size()-1)
         createEdgesInTetrahedronArray();
-    return m_edgesInTetrahedron[i];
+
+    if (i < m_edgesInTetrahedron.size())
+        return m_edgesInTetrahedron[i];
+
+    return InvalidEdgesInTetrahedron;
 }
 
 const MeshTopology::EdgesInHexahedron& MeshTopology::getEdgesInHexahedron(HexaID i)
 {
     if (!m_edgesInHexahedron.size() || i > m_edgesInHexahedron.size()-1)
         createEdgesInHexahedronArray();
-    return m_edgesInHexahedron[i];
+
+    if (i < m_edgesInHexahedron.size())
+        return m_edgesInHexahedron[i];
+
+    return InvalidEdgesInHexahedron;
 }
 
 const MeshTopology::TrianglesAroundVertex& MeshTopology::getTrianglesAroundVertex(PointID i)
 {
+    std::cout << "YYO LO MESHTOPO:" << i  << std::endl;
+
     if (!m_trianglesAroundVertex.size() || i > m_trianglesAroundVertex.size()-1)
         createTrianglesAroundVertexArray();
-    return m_trianglesAroundVertex[i];
+
+    if (i < m_trianglesAroundVertex.size())
+        return m_trianglesAroundVertex[i];
+
+    return EmptyTrianglesAroundVertex;
 }
+
 const MeshTopology::TrianglesAroundVertex& MeshTopology::getOrientedTrianglesAroundVertex(PointID i)
 {
     if (!m_orientedTrianglesAroundVertex.size() || i > m_orientedTrianglesAroundVertex.size()-1)
         createOrientedTrianglesAroundVertexArray();
-    return m_orientedTrianglesAroundVertex[i];
+
+    if (i < m_orientedTrianglesAroundVertex.size())
+        return m_orientedTrianglesAroundVertex[i];
+
+    return EmptyTrianglesAroundVertex;
 }
 
 const MeshTopology::TrianglesAroundEdge& MeshTopology::getTrianglesAroundEdge(EdgeID i)
 {
     if (m_trianglesAroundEdge.empty() || i > m_trianglesAroundEdge.size()-1)
         createTrianglesAroundEdgeArray();
-    return m_trianglesAroundEdge[i];
+
+    if (i < m_trianglesAroundEdge.size())
+        return m_trianglesAroundEdge[i];
+
+    return EmptyTrianglesAroundEdge;
 }
+
 const MeshTopology::TrianglesInTetrahedron& MeshTopology::getTrianglesInTetrahedron(TetraID i)
 {
     if (!m_trianglesInTetrahedron.size() || i > m_trianglesInTetrahedron.size()-1)
         createTrianglesInTetrahedronArray();
-    return m_trianglesInTetrahedron[i];
+
+    if (i < m_trianglesInTetrahedron.size())
+        return m_trianglesInTetrahedron[i];
+
+    return InvalidTrianglesInTetrahedron;
 }
 
 const MeshTopology::QuadsAroundVertex& MeshTopology::getQuadsAroundVertex(PointID i)
 {
     if (m_quadsAroundVertex.empty() || i > m_quadsAroundVertex.size()-1)
         createQuadsAroundVertexArray();
-    return m_quadsAroundVertex[i];
+
+    if (i < m_quadsAroundVertex.size())
+        return m_quadsAroundVertex[i];
+
+    return EmptyQuadsAroundVertex;
 }
 
 const MeshTopology::QuadsAroundVertex& MeshTopology::getOrientedQuadsAroundVertex(PointID i)
 {
     if (m_orientedQuadsAroundVertex.empty() || i > m_orientedQuadsAroundVertex.size()-1)
         createOrientedQuadsAroundVertexArray();
-    return m_orientedQuadsAroundVertex[i];
+
+    if (i < m_orientedQuadsAroundVertex.size())
+        return m_orientedQuadsAroundVertex[i];
+
+    return EmptyQuadsAroundVertex;
 }
 
 const vector< MeshTopology::QuadID >& MeshTopology::getQuadsAroundEdge(EdgeID i)
 {
     if (!m_quadsAroundEdge.size() || i > m_quadsAroundEdge.size()-1)
         createQuadsAroundEdgeArray();
-    return m_quadsAroundEdge[i];
+
+
+    if(i < m_quadsAroundEdge.size())
+        return m_quadsAroundEdge[i];
+
+    return EmptyQuadsAroundEdge;
 }
 
 const MeshTopology::QuadsInHexahedron& MeshTopology::getQuadsInHexahedron(HexaID i)
 {
     if (!m_quadsInHexahedron.size() || i > m_quadsInHexahedron.size()-1)
         createQuadsInHexahedronArray();
-    return m_quadsInHexahedron[i];
+
+    if (i < m_quadsInHexahedron.size())
+        return m_quadsInHexahedron[i];
+
+    return InvalidQuadsInHexahedron;
 }
 
 const MeshTopology::TetrahedraAroundVertex& MeshTopology::getTetrahedraAroundVertex(PointID i)
 {
     if (!m_tetrahedraAroundVertex.size() || i > m_tetrahedraAroundVertex.size()-1)
         createTetrahedraAroundVertexArray();
-    return m_tetrahedraAroundVertex[i];
+
+    if (i < m_tetrahedraAroundVertex.size())
+        return m_tetrahedraAroundVertex[i];
+
+    return EmptyTetrahedraAroundVertex;
 }
 
 const MeshTopology::TetrahedraAroundEdge& MeshTopology::getTetrahedraAroundEdge(EdgeID i)
 {
     if (!m_tetrahedraAroundEdge.size() || i > m_tetrahedraAroundEdge.size()-1)
         createTetrahedraAroundEdgeArray();
-    return m_tetrahedraAroundEdge[i];
+
+    if (i < m_tetrahedraAroundEdge.size())
+        return m_tetrahedraAroundEdge[i];
+
+    return EmptyTetrahedraAroundEdge;
 }
 
 const MeshTopology::TetrahedraAroundTriangle& MeshTopology::getTetrahedraAroundTriangle(TriangleID i)
 {
     if (!m_tetrahedraAroundTriangle.size() || i > m_tetrahedraAroundTriangle.size()-1)
         createTetrahedraAroundTriangleArray();
-    return m_tetrahedraAroundTriangle[i];
+
+    if (i < m_tetrahedraAroundTriangle.size())
+        return m_tetrahedraAroundTriangle[i];
+
+    return EmptyTetrahedraAroundTriangle;
 }
 
 const MeshTopology::HexahedraAroundVertex& MeshTopology::getHexahedraAroundVertex(PointID i)
 {
     if (!m_hexahedraAroundVertex.size() || i > m_hexahedraAroundVertex.size()-1)
         createHexahedraAroundVertexArray();
-    return m_hexahedraAroundVertex[i];
+
+    if (i < m_hexahedraAroundVertex.size())
+        return m_hexahedraAroundVertex[i];
+
+    return EmptyHexahedraAroundVertex;
 }
 
 const MeshTopology::HexahedraAroundEdge& MeshTopology::getHexahedraAroundEdge(EdgeID i)
 {
     if (!m_hexahedraAroundEdge.size() || i > m_hexahedraAroundEdge.size()-1)
         createHexahedraAroundEdgeArray();
-    return m_hexahedraAroundEdge[i];
+
+    if (i < m_hexahedraAroundEdge.size())
+        return m_hexahedraAroundEdge[i];
+
+    return EmptyHexahedraAroundEdge;
 }
 
 const MeshTopology::HexahedraAroundQuad& MeshTopology::getHexahedraAroundQuad(QuadID i)
 {
     if (!m_hexahedraAroundQuad.size() || i > m_hexahedraAroundQuad.size()-1)
         createHexahedraAroundQuadArray();
-    return m_hexahedraAroundQuad[i];
+
+    if (i < m_hexahedraAroundQuad.size())
+        return m_hexahedraAroundQuad[i];
+
+    return EmptyHexahedraAroundQuad;
 }
 
 
@@ -1621,7 +1706,6 @@ const vector< MeshTopology::TrianglesAroundVertex >& MeshTopology::getTrianglesA
     {
         if (CHECK_TOPOLOGY)
             msg_warning() << "GetTrianglesAroundVertexArray TrianglesAroundVertex array is empty.";
-
         createTrianglesAroundVertexArray();
     }
 


### PR DESCRIPTION
In issue #746 is reported a bug when trying trying to simulate
scenes while the underlying topology is containing empty data set.

I narrowed the problem to be in LocalMinDistance::computeIntersection.
In this function we access the trianglesAroundVertex from a MeshTopology.

with code like that:
```cpp
 if (m_edgesInTetrahedron.empty() || i > m_edgesInTetrahedron.size()-1)
         createEdgesInTetrahedronArray();
    return m_edgesInTetrahedron[i];
```

While if there is not "nothing" to create because there is no edges/triangles
it access in there is still a return of m_edgesInTetrahedron[i] with indice = 0

To avoid that I change the code for:
```cpp
  const MeshTopology::EdgesInTetrahedron& MeshTopology::getEdgesInTetrahedron(TetraID i)
 {
     if (m_edgesInTetrahedron.empty() || i > m_edgesInTetrahedron.size()-1)
         createEdgesInTetrahedronArray();

    if (i < m_edgesInTetrahedron.size())
        return m_edgesInTetrahedron[i];

    return InvalidEdgesInTetrahedron;
}
```

So if there is nothing created we returns a valid object indicating either an
empty or one filled with invalid values.





______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
