### PR TITLE
[all] Quick changes diffusion and mass

### DIFF
--- a/examples/Components/forcefield/TetrahedronDiffusionFEMForceField.scn
+++ b/examples/Components/forcefield/TetrahedronDiffusionFEMForceField.scn
@@ -21,7 +21,6 @@
         <TetrahedronDiffusionFEMForceField template="Vec1d" name="DiffusionForceField" constantDiffusionCoefficient="1500" printLog="0" drawConduc="0" tagMechanics="mechanics" tags="heat"/>
         <MeshMatrixMass template="Vec1d" name="Mass" lumping="0" massDensity="1.0" printLog="0" tags="heat"/>
 
-        <FixedConstraint indices="@../box-cold.indices" />
         <LinearMovementConstraint template="Vec1d" keyTimes="0 0.005 0.006" movements="0 0 1" indices="@../box-cold.indices" />
         <LinearMovementConstraint template="Vec1d" keyTimes="0.001 0.002 0.004 0.005 0.006" movements="0 1 0.5 1 0" indices="@../box-hot.indices" />
 

--- a/modules/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/MeshMatrixMass.inl
@@ -1830,7 +1830,7 @@ void MeshMatrixMass<DataTypes, MassType>::accFromF(const core::MechanicalParams*
     {
         (void)a;
         (void)f;
-        msg_error() << "WARNING: the method 'accFromF' can't be used with MeshMatrixMass as this SPARSE mass matrix can't be inversed easily. "
+        msg_error() << "the method 'accFromF' can't be used with MeshMatrixMass as this SPARSE mass matrix can't be inversed easily. "
                     << "Please proceed to mass lumping or use a DiagonalMass (both are equivalent).";
         return;
     }

--- a/modules/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/MeshMatrixMass.inl
@@ -1830,7 +1830,8 @@ void MeshMatrixMass<DataTypes, MassType>::accFromF(const core::MechanicalParams*
     {
         (void)a;
         (void)f;
-        msg_error() << "WARNING: the methode 'accFromF' can't be used with MeshMatrixMass as this SPARSE mass matrix can't be inversed easily. \nPlease proceed to mass lumping.";
+        msg_error() << "WARNING: the method 'accFromF' can't be used with MeshMatrixMass as this SPARSE mass matrix can't be inversed easily. "
+                    << "Please proceed to mass lumping or use a DiagonalMass (both are equivalent).";
         return;
     }
 }


### PR DESCRIPTION
Two minor changes:
- Remove FixedConstraint redundant with LinearMovementConstraint (on same DOFs)
- Improve warning comment in MeshMMass when using explicit resolution (accFromF) with non-lumped sparse matrix

NOTE: I realized no sparse MassMatrix can therefore be used in explicit formulation.


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
