### PR TITLE
[SofaPython] FIX allow the derivTypeFromParentValue to work with node.

### DIFF
--- a/SofaKernel/framework/sofa/simulation/Node.cpp
+++ b/SofaKernel/framework/sofa/simulation/Node.cpp
@@ -661,6 +661,34 @@ Node* Node::getTreeNode(const std::string& name) const
     return result;
 }
 
+Node* Node::getNodeInGraph(const std::string& absolutePath) const
+{
+    if (absolutePath[0] != '/')
+        return nullptr;
+
+    std::string p = absolutePath.substr(1);
+    if (p == "")
+        return dynamic_cast<Node*>(this->getRootContext());
+
+    Node* ret = nullptr;
+    Node* parent = dynamic_cast<Node*>(this->getRootContext());
+    while (p != "")
+    {
+        std::string nodeName = p.substr(0, p.find('/'));
+        ret = parent->getChild(nodeName);
+        if (!ret)
+            return nullptr;
+        if (p.find('/') == std::string::npos)
+            p = "";
+        else
+            p = p.substr(p.find('/') +1);
+        parent = ret;
+    }
+    if (!ret)
+        return nullptr;
+    return ret;
+}
+
 /// Get parent node (or NULL if no hierarchy or for root node)
 sofa::core::objectmodel::BaseNode::Children Node::getChildren() const
 {

--- a/SofaKernel/framework/sofa/simulation/Node.h
+++ b/SofaKernel/framework/sofa/simulation/Node.h
@@ -486,6 +486,7 @@ public:
 
     /// Get a descendant node given its name
     Node* getTreeNode(const std::string& name) const;
+    Node* getNodeInGraph(const std::string& absolutePath) const;
 
     /// Get children nodes
     Children getChildren() const override;

--- a/applications/plugins/SofaPython/Binding_Base.cpp
+++ b/applications/plugins/SofaPython/Binding_Base.cpp
@@ -207,13 +207,19 @@ BaseData* deriveTypeFromParentValue(Base* obj, const std::string& value)
 
         if (!o->getContext())
         {
-	    msg_warning("SofaPython") << "No context created. Cannot find data link to derive input type.";
+            msg_error("SofaPython") << "No context created. Cannot find data link to derive input type.";
             return nullptr;
         }
-        BaseObject* component;
+        Base* component;
         component = o->getContext()->get<BaseObject>(componentPath);
         if (!component)
-	    msg_warning("SofaPython") << "No object with path " << componentPath << " in scene graph.";
+            component = static_cast<sofa::simulation::Node*>(o->getContext())->getNodeInGraph(componentPath);
+
+        if(!component)
+        {
+            msg_error("SofaPython") << "No object or node with path " << componentPath << " in scene graph.";
+            return nullptr;
+        }
         BaseData* parentData = component->findData(parentDataName);
         return parentData->getNewInstance();
     }
@@ -260,7 +266,7 @@ BaseData* helper_addNewData(PyObject *args, PyObject * kw, Base * obj) {
     else
     {
         return nullptr;
-    }    
+    }
     BaseData* bd = nullptr;
     if(KwargsOrArgs) // parse kwargs
     {
@@ -322,14 +328,14 @@ BaseData* helper_addNewData(PyObject *args, PyObject * kw, Base * obj) {
         }
         else if (std::string(dataName) != "type")
         {
-  	        sofa::helper::vector<std::string> validTypes;
-	          getFactoryInstance()->uniqueKeys(std::back_inserter(validTypes));
-	          std::string typesString = "[";
-	          for (const auto& i : validTypes)
-	              typesString += i + ", ";
-	          typesString += "\b\b]";
-	          msg_error(obj) << dataRawType << " is not a known type. Available "
-	                            "types are:\n" << typesString;
+            sofa::helper::vector<std::string> validTypes;
+            getFactoryInstance()->uniqueKeys(std::back_inserter(validTypes));
+            std::string typesString = "[";
+            for (const auto& i : validTypes)
+                typesString += i + ", ";
+            typesString += "\b\b]";
+            msg_error(obj) << dataRawType << " is not a known type. Available "
+                                             "types are:\n" << typesString;
             return nullptr;
         }
         else return new EmptyData;
@@ -621,12 +627,12 @@ static PyObject * Base___dir__(PyObject *self, PyObject * /*args*/) {
 
     /// From methods..
     for (unsigned int i = 0; i < listMethodsSize; ++i, ++dstIndex) {
-          PyObject* tmp = PyList_GetItem(listMethods, i);
+        PyObject* tmp = PyList_GetItem(listMethods, i);
 
-          /// Increment the reference counter to getItem because according to the documentation
-          /// the PyList_SetItem will steal it.
-          Py_INCREF(tmp);
-          PyList_SetItem(pyList, dstIndex, tmp);
+        /// Increment the reference counter to getItem because according to the documentation
+        /// the PyList_SetItem will steal it.
+        Py_INCREF(tmp);
+        PyList_SetItem(pyList, dstIndex, tmp);
     }
 
     /// From links
@@ -655,11 +661,11 @@ static PyObject * Base_downCast(PyObject *self, PyObject * /*args*/) {
 
 SP_CLASS_METHODS_BEGIN(Base)
 SP_CLASS_METHOD_DOC(Base,addNewData, "Add a new Data field to the current object. \n"
-                                        "Eg:                                         \n"
-                                        "  obj.addNewData('myDataName1','theDataGroupA','help message','float',1.0)  \n"
-                                        "  obj.addNewData('myDataName2','theDataGroupA','help message','','@otherComponent.datafield) \n"
-                                        "  obj.addNewData('myDataName3','theDataGroupB','help message','vector<Vec3d>', '@loader.position')     \n"
-                                        "  obj.addNewData('myDataName4','theDataGroupB','help message','string','hello') \n")
+                                     "Eg:                                         \n"
+                                     "  obj.addNewData('myDataName1','theDataGroupA','help message','float',1.0)  \n"
+                                     "  obj.addNewData('myDataName2','theDataGroupA','help message','','@otherComponent.datafield) \n"
+                                     "  obj.addNewData('myDataName3','theDataGroupB','help message','vector<Vec3d>', '@loader.position')     \n"
+                                     "  obj.addNewData('myDataName4','theDataGroupB','help message','string','hello') \n")
 SP_CLASS_METHOD_DOC(Base,addData, "Adds an existing data field to the current object")
 SP_CLASS_METHOD_DOC(Base,findData, "Returns the data field if there is one associated \n"
                                    "with the provided name and downcasts it to the lowest known type. \n"
@@ -667,11 +673,11 @@ SP_CLASS_METHOD_DOC(Base,findData, "Returns the data field if there is one assoc
 SP_CLASS_METHOD_DOC(Base,findLink, "Returns a link field if there is one associated \n"
                                    "with the provided name, returns None otherwhise")
 SP_CLASS_METHOD_DOC(Base,getData, "Returns the data field if there is one associated \n"
-                              "with the provided name but don't downcasts it to the lowest known type. \n"
-                              "Returns None is there is no field with this name.")
+                                  "with the provided name but don't downcasts it to the lowest known type. \n"
+                                  "Returns None is there is no field with this name.")
 SP_CLASS_METHOD_DOC(Base,getLink, "Returns the link field if there is one associated \n"
-                              "with the provided name but. \n"
-                              "Returns None is there is no field with this name.")
+                                  "with the provided name but. \n"
+                                  "Returns None is there is no field with this name.")
 SP_CLASS_METHOD(Base,getClassName)
 SP_CLASS_METHOD(Base,getTemplateName)
 SP_CLASS_METHOD(Base,getName)


### PR DESCRIPTION
Currently only object are supported by this function which is not consistant
with the rest of Sofa.

Eg of consequence you cannot make a PythonScriptDataEngine connecting
data field from nodes (as only object are possible).







______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
