### PR TITLE
[SofaCUDA] Compilation error fix (CudaStandardTetrahedralFEMForceField.cu)

### DIFF
--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaStandardTetrahedralFEMForceField.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaStandardTetrahedralFEMForceField.cu
@@ -73,12 +73,15 @@ void StandardTetrahedralFEMForceFieldCuda3d_addDForce(int nbTetra, int nbEdges, 
 // GPU-side methods //
 //////////////////////
 
+/// Declaration of two functions, implemented below
 template <class real>
 __device__ void StandardTetrahedralFEMForceFieldCuda_BoyceAndArruda_deriveSPKTensor(int tetraIndex, real* tetraInfo, float paramArray0, float paramArray1);
 
 template <class real>
 __device__ void StandardTetrahedralFEMForceFieldCuda_BoyceAndArruda_ElasticityTensor(int tetraIndex, real* tetraInfo, real outputTensor[][6], real param0, real param1);
 
+	
+	
 template <class real>
 __device__ real dot(real* A, real* B, int n)
 {

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaStandardTetrahedralFEMForceField.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaStandardTetrahedralFEMForceField.cu
@@ -72,6 +72,13 @@ void StandardTetrahedralFEMForceFieldCuda3d_addDForce(int nbTetra, int nbEdges, 
 //////////////////////
 // GPU-side methods //
 //////////////////////
+
+template <class real>
+__device__ void StandardTetrahedralFEMForceFieldCuda_BoyceAndArruda_deriveSPKTensor(int tetraIndex, real* tetraInfo, float paramArray0, float paramArray1);
+
+template <class real>
+__device__ void StandardTetrahedralFEMForceFieldCuda_BoyceAndArruda_ElasticityTensor(int tetraIndex, real* tetraInfo, real outputTensor[][6], real param0, real param1);
+
 template <class real>
 __device__ real dot(real* A, real* B, int n)
 {


### PR DESCRIPTION
Compilation error fix. When CMake variables PLUGIN_SOFACUDA and SOFACUDA_DOUBLE are enabled, CudaStandardTetrahedralFEMForceField.cu try to be compiled through NVCC (Nvidia compiler). It was leading to a compile error because of 2 missing function prototypes in the .cu file. This commit fixes the issue. Compilation was tested on my side on Fedora 29 with CUDA Toolkit v10.1

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
