### PR TITLE
[SofaKernel] FIX operator>> in Mat.h and add corresponding test.

### DIFF
--- a/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
@@ -109,16 +109,6 @@ void Base::initData0( BaseData* field, BaseData::BaseInitData& res, const char* 
     static uint32_t draw_prefix = *reinterpret_cast<const uint32_t*>(draw_str);
     static uint32_t show_prefix = *reinterpret_cast<const uint32_t*>(show_str);
 
-    /*
-        std::string ln(name);
-        if( ln.size()>0 && findField(ln) )
-        {
-            serr << "field name " << ln << " already used in this class or in a parent class !...aborting" << sendl;
-            exit( 1 );
-        }
-        m_fieldVec.push_back( std::make_pair(ln,field));
-        m_aliasData.insert(std::make_pair(ln,field));
-    */
     res.owner = this;
     res.data = field;
     res.name = name;
@@ -144,9 +134,8 @@ void Base::addData(BaseData* f, const std::string& name)
 {
     if (name.size() > 0 && (findData(name) || findLink(name)))
     {
-        serr << "Data field name " << name
-                << " already used in this class or in a parent class !"
-                << sendl;
+        msg_warning() << "Data field name " << name
+                << " already used in this class or in a parent class !";
     }
     m_vecData.push_back(f);
     m_aliasData.insert(std::make_pair(name, f));
@@ -166,9 +155,8 @@ void Base::addLink(BaseLink* l)
     const std::string& name = l->getName();
     if (name.size() > 0 && (findData(name) || findLink(name)))
     {
-        serr << "Link name " << name
-                << " already used in this class or in a parent class !"
-                << sendl;
+        msg_warning() << "Link name " << name
+                << " already used in this class or in a parent class !";
     }
     m_vecLink.push_back(l);
     m_aliasLink.insert(std::make_pair(name, l));
@@ -418,7 +406,7 @@ bool Base::findDataLinkDest(BaseData*& ptr, const std::string& path, const BaseL
 
 void* Base::findLinkDestClass(const BaseClass* /*destType*/, const std::string& /*path*/, const BaseLink* /*link*/)
 {
-    serr << "Base: calling unimplemented findLinkDest method" << sendl;
+    msg_error() << "Base: calling unimplemented findLinkDest method" ;
     return nullptr;
 }
 
@@ -435,7 +423,7 @@ bool Base::parseField( const std::string& attribute, const std::string& value)
     std::vector< BaseLink* > linkVec = findLinks(attribute);
     if (dataVec.empty() && linkVec.empty())
     {
-        serr << "Unknown Data field or Link: " << attribute << sendl;
+        msg_warning() << "Unknown Data field or Link: " << attribute ;
         return false; // no field found
     }
     bool ok = true;
@@ -464,14 +452,14 @@ bool Base::parseField( const std::string& attribute, const std::string& value)
                     ok = true;
                     continue;
                 }
-                serr<<"Could not setup Data link between "<< value << " and " << attribute << "." << sendl;
+                msg_warning()<<"Could not setup Data link between "<< value << " and " << attribute << "." ;
                 ok = false;
                 continue;
             }
             else
             {
                 BaseData* parentData = dataVec[d]->getParent();
-                sout<<"Link from parent Data " << value << " (" << parentData->getValueTypeInfo()->name() << ") to Data " << attribute << "(" << dataVec[d]->getValueTypeInfo()->name() << ") OK" << sendl;
+                msg_info() << "Link from parent Data " << value << " (" << parentData->getValueTypeInfo()->name() << ") to Data " << attribute << "(" << dataVec[d]->getValueTypeInfo()->name() << ") OK";
             }
             /* children Data cannot be modified changing the parent Data value */
             dataVec[d]->setReadOnly(true);
@@ -479,7 +467,7 @@ bool Base::parseField( const std::string& attribute, const std::string& value)
         }
         if( !(dataVec[d]->read( value )) && !value.empty())
         {
-            serr<<"Could not read value for data field "<< attribute <<": " << value << sendl;
+            msg_warning()<<"Could not read value for data field "<< attribute <<": " << value ;
             ok = false;
         }
     }
@@ -487,19 +475,20 @@ bool Base::parseField( const std::string& attribute, const std::string& value)
     {
         if( !(linkVec[l]->read( value )) && !value.empty())
         {
-            serr<<"Could not read value for link "<< attribute <<": " << value << sendl;
+            msg_warning()<<"Could not read value for link "<< attribute <<": " << value;
             ok = false;
         }
-        sout << "Link " << linkVec[l]->getName() << " = " << linkVec[l]->getValueString() << sendl;
+        msg_info() << "Link " << linkVec[l]->getName() << " = " << linkVec[l]->getValueString();
         unsigned int s = unsigned(linkVec[l]->getSize());
         for (unsigned int i=0; i<s; ++i)
         {
-            sout  << "  " << linkVec[l]->getLinkedPath(i) << " = ";
+            std::stringstream tmp;
+            tmp << "  " << linkVec[l]->getLinkedPath(i) << " = ";
             Base* b = linkVec[l]->getLinkedBase(i);
             BaseData* d = linkVec[l]->getLinkedData(i);
-            if (b) sout << b->getTypeName() << " " << b->getName();
-            if (d) sout << " . " << d->getValueTypeString() << " " << d->getName();
-            sout << sendl;
+            if (b) tmp << b->getTypeName() << " " << b->getName();
+            if (d) tmp << " . " << d->getValueTypeString() << " " << d->getName();
+            msg_info() << tmp.str();
         }
     }
     return ok;
@@ -561,7 +550,7 @@ void Base::updateLinks(bool logErrors)
         bool ok = (*iLink)->updateLinks();
         if (!ok && (*iLink)->storePath() && logErrors)
         {
-            serr << "Link update failed for " << (*iLink)->getName() << " = " << (*iLink)->getValueString() << sendl;
+            msg_warning() << "Link update failed for " << (*iLink)->getName() << " = " << (*iLink)->getValueString() ;
         }
     }
 }

--- a/SofaKernel/framework/sofa/defaulttype/Mat.h
+++ b/SofaKernel/framework/sofa/defaulttype/Mat.h
@@ -1022,11 +1022,13 @@ std::istream& operator>>(std::istream& in, sofa::defaulttype::Mat<L,C,real>& m)
         }
         in >> m[i];
     }
+    if(in.eof()) return in;
     c = in.peek();
     while (c==' ' || c=='\n' || c==']')
     {
         in.get();
         if( c==']' ) break;
+        if(in.eof()) break;
         c = in.peek();
     }
     return in;

--- a/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/UniformMass_test.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/UniformMass_test.cpp
@@ -149,6 +149,38 @@ struct UniformMassTest :  public BaseTest
         }
     }
 
+    /// totalMass, mass and localRange..
+    /// case where NO mass info give, default totalMass = 1.0
+    void checkRigidAttribute()
+    {
+        EXPECT_MSG_NOEMIT(Error, Warning);
+        string scene =
+                "<?xml version='1.0'?>"
+                "<Node 	name='Root' gravity='0 0 0' time='0' animate='0'   > "
+                "   <MechanicalObject template='Rigid3' position='0 0 0 0 0 0 1'/>"
+                "   <UniformMass name='mass' vertexMass='1.0 1.0 2.0 0.0 0.0 0.0 4.0 0.0 7.0 8.0 9.0'/>"
+                "</Node>                                                     " ;
+
+        Node::SPtr root = SceneLoaderXML::loadFromMemory ("loadWithNoParam",
+                                                          scene.c_str(),
+                                                          scene.size()) ;
+
+        root->init(ExecParams::defaultInstance()) ;
+
+        UniformMassRigid* mass = root->getTreeObject<UniformMassRigid>() ;
+        EXPECT_TRUE( mass != nullptr ) ;
+
+        std::vector<double> values={2.0,0.0,0.0,0.0,4.0,0.0,7.0,8.0,9.0};
+        for(unsigned int i=0;i<3;i++)
+        {
+            for(unsigned int j=0;j<3;j++)
+            {
+                ASSERT_EQ(mass->d_vertexMass.getValue().inertiaMatrix[i][j],
+                          values[i*3+j]);
+            }
+        }
+    }
+
     /// totalMass is well defined
     /// vertexMass will be computed from it using the formulat :  vertexMass = totalMass / number of particules
     void checkVertexMassFromTotalMass(){
@@ -501,6 +533,10 @@ TYPED_TEST(UniformMassTest, loadFromAnInvalidPathname) {
 
 TYPED_TEST(UniformMassTest, loadFromAFileForRigid) {
     ASSERT_NO_THROW(this->loadFromAFileForRigid()) ;
+}
+
+TYPED_TEST(UniformMassTest, checkRigidAttribute) {
+    ASSERT_NO_THROW(this->checkRigidAttribute()) ;
 }
 
 TYPED_TEST(UniformMassTest, reinitTest) {


### PR DESCRIPTION
The operator>> was not functionning properly as it was returning
with a failbit set because of the in.peek() on empty string. This error
was generating a warning in UniformMass.

The PR:
- fix this error
- adds a test that validate that the code is correct and does not generate error anymore.
- makes some sout/serr cleaning in uniformmass.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
