### PR TITLE
[SofaGuiQt] Change the keyboard shortcut associated to camera mode

### DIFF
--- a/applications/sofa/gui/qt/viewer/qgl/QtGLViewer.cpp
+++ b/applications/sofa/gui/qt/viewer/qgl/QtGLViewer.cpp
@@ -143,6 +143,7 @@ QtGLViewer::QtGLViewer(QWidget* parent, const char* name, const unsigned int nbM
 
     connect( &captureTimer, SIGNAL(timeout()), this, SLOT(captureEvent()) );
 
+    //change shortcut (now M key) for camera mode to avoid double effects of shortcut
     setShortcut(CAMERA_MODE, Qt::Key_M);
 }
 

--- a/applications/sofa/gui/qt/viewer/qgl/QtGLViewer.cpp
+++ b/applications/sofa/gui/qt/viewer/qgl/QtGLViewer.cpp
@@ -142,6 +142,8 @@ QtGLViewer::QtGLViewer(QWidget* parent, const char* name, const unsigned int nbM
     vparams->zFar()  = camera()->zFar();
 
     connect( &captureTimer, SIGNAL(timeout()), this, SLOT(captureEvent()) );
+
+    setShortcut(CAMERA_MODE, Qt::Key_M);
 }
 
 

--- a/extlibs/libQGLViewer-2.7.1/QGLViewer/qglviewer.cpp
+++ b/extlibs/libQGLViewer-2.7.1/QGLViewer/qglviewer.cpp
@@ -510,7 +510,7 @@ void QGLViewer::setDefaultShortcuts() {
   setShortcut(ENABLE_TEXT, Qt::SHIFT + Qt::Key_Question);
   setShortcut(EXIT_VIEWER, Qt::Key_Escape);
   setShortcut(SAVE_SCREENSHOT, Qt::CTRL + Qt::Key_S);
-  setShortcut(CAMERA_MODE, Qt::Key_M);
+  setShortcut(CAMERA_MODE, Qt::Key_Space);
   setShortcut(FULL_SCREEN, Qt::ALT + Qt::Key_Return);
   setShortcut(STEREO, Qt::Key_S);
   setShortcut(ANIMATION, Qt::Key_Return);

--- a/extlibs/libQGLViewer-2.7.1/QGLViewer/qglviewer.cpp
+++ b/extlibs/libQGLViewer-2.7.1/QGLViewer/qglviewer.cpp
@@ -510,7 +510,7 @@ void QGLViewer::setDefaultShortcuts() {
   setShortcut(ENABLE_TEXT, Qt::SHIFT + Qt::Key_Question);
   setShortcut(EXIT_VIEWER, Qt::Key_Escape);
   setShortcut(SAVE_SCREENSHOT, Qt::CTRL + Qt::Key_S);
-  setShortcut(CAMERA_MODE, Qt::Key_Space);
+  setShortcut(CAMERA_MODE, Qt::Key_M);
   setShortcut(FULL_SCREEN, Qt::ALT + Qt::Key_Return);
   setShortcut(STEREO, Qt::Key_S);
   setShortcut(ANIMATION, Qt::Key_Return);


### PR DESCRIPTION
Simply change the keyboard shortcut associated to camera mode: M key instead of Space key, because the latter is already used to interact with the GUI buttons.
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
