### PR TITLE
[SofaKernel] Several changes in Topology components

### DIFF
--- a/SofaKernel/framework/sofa/core/topology/TopologicalMapping.h
+++ b/SofaKernel/framework/sofa/core/topology/TopologicalMapping.h
@@ -137,6 +137,9 @@ public:
         msg_info() << "#################";
     }
 
+    /// Method to check the topology mapping maps regarding the upper topology
+    virtual bool checkTopologies() {return false;}
+
     /** return all the from indices in the 'In' topology corresponding to the index in the 'Out' topology.
     *   This function is used instead of  the previous one when the function isTheOutputTopologySubdividingTheInputOne() returns false.
     */

--- a/SofaKernel/framework/sofa/defaulttype/Mat.h
+++ b/SofaKernel/framework/sofa/defaulttype/Mat.h
@@ -866,7 +866,7 @@ bool invertMatrix(Mat<S,S,real>& dest, const Mat<S,S,real>& from)
 
         if (pivot <= (real) MIN_DETERMINANT)
         {
-            msg_error("Mat") << "invertMatrix finds too small determinant, matrix = "<<from;
+            msg_error("Mat") << "invertMatrix (general case) finds too small determinant: " << pivot << " for matrix = " << from;
             return false;
         }
 
@@ -908,7 +908,7 @@ bool invertMatrix(Mat<3,3,real>& dest, const Mat<3,3,real>& from)
 
     if ( -(real) MIN_DETERMINANT<=det && det<=(real) MIN_DETERMINANT)
     {
-        msg_error("Mat") << "invertMatrix finds too small determinant, matrix = "<<from;
+        msg_error("Mat") << "invertMatrix (special case 3x3) finds too small determinant: " << det << " for matrix = " << from;
         return false;
     }
 
@@ -933,7 +933,7 @@ bool invertMatrix(Mat<2,2,real>& dest, const Mat<2,2,real>& from)
 
     if ( -(real) MIN_DETERMINANT<=det && det<=(real) MIN_DETERMINANT)
     {
-        msg_error("Mat") << "invertMatrix finds too small determinant, matrix = "<<from;
+        msg_error("Mat") << "invertMatrix (special case 2x2) finds too small determinant: " << det << " for matrix = " << from;
         return false;
     }
 

--- a/SofaKernel/framework/sofa/defaulttype/MatSym.h
+++ b/SofaKernel/framework/sofa/defaulttype/MatSym.h
@@ -461,7 +461,7 @@ bool invertMatrix(MatSym<S,real>& dest, const MatSym<S,real>& from)
 
         if (pivot <= (real) MIN_DETERMINANT)
         {
-            msg_error("MatSym") << "invertMatrix finds too small determinant, matrix = "<<from;
+            msg_error("MatSym") << "invertMatrix (general case) finds too small determinant: " << pivot << " for matrix = " << from;
             return false;
         }
 
@@ -516,7 +516,7 @@ bool invertMatrix(MatSym<3,real>& dest, const MatSym<3,real>& from)
 
     if ( -(real) MIN_DETERMINANT<=det && det<=(real) MIN_DETERMINANT)
     {
-        msg_error("MatSym") << "invertMatrix finds too small determinant, matrix = "<<from;
+        msg_error("MatSym") << "invertMatrix (special case 3x3) finds too small determinant: " << det << " for matrix = " << from;
         return false;
     }
 
@@ -538,7 +538,7 @@ bool invertMatrix(MatSym<2,real>& dest, const MatSym<2,real>& from)
 
     if ( -(real) MIN_DETERMINANT<=det && det<=(real) MIN_DETERMINANT)
     {
-        msg_error("MatSym") << "invertMatrix finds too small determinant, matrix = "<<from;
+        msg_error("MatSym") << "invertMatrix (special case 2x2) finds too small determinant: " << det << " for matrix = " << from;
         return false;
     }
 

--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyContainer.cpp
@@ -231,32 +231,28 @@ bool EdgeSetTopologyContainer::checkTopology() const
 		{
 			helper::ReadAccessor< Data< sofa::helper::vector<Edge> > > m_edge = d_edge;
 			std::set<int> edgeSet;
-			std::set<int>::iterator it;
 
+            // loop on all edges around vertex
             for (size_t i = 0; i < m_edgesAroundVertex.size(); ++i)
 			{
-
 				const sofa::helper::vector<EdgeID> &es = m_edgesAroundVertex[i];
 				for (size_t j = 0; j < es.size(); ++j)
 				{
-					bool check_edge_vertex_shell = (m_edge[es[j]][0] == i) || (m_edge[es[j]][1] == i);
-					if (!check_edge_vertex_shell)
+                    const Edge& edge = m_edge[es[j]];
+                    if (!(edge[0] == i || edge[1] == i))
 					{
-						msg_warning() << "*** CHECK FAILED : check_edge_vertex_shell, i = " << i << " , j = " << j;
+                        msg_error() << "EdgeSetTopologyContainer::checkTopology() failed: edge " << es[j] << ": [" << edge << "] not around vertex: " << i;
 						ret = false;
 					}
 
-					it = edgeSet.find(es[j]);
-					if (it == edgeSet.end())
-					{
-						edgeSet.insert(es[j]);
-					}
+                    // count number of edge
+                    edgeSet.insert(es[j]);
 				}
 			}
 
 			if (edgeSet.size() != m_edge.size())
 			{
-				msg_warning() << "*** CHECK FAILED : check_edge_vertex_shell, edge are missing in m_edgesAroundVertex";
+                msg_error() << "EdgeSetTopologyContainer::checkTopology() failed: found " << edgeSet.size() << " edges in m_edgesAroundVertex out of " << m_edge.size();
 				ret = false;
             }
         }

--- a/SofaKernel/modules/SofaBaseTopology/MeshTopology.h
+++ b/SofaKernel/modules/SofaBaseTopology/MeshTopology.h
@@ -135,42 +135,102 @@ public:
     void addUV(SReal u, SReal v);
     //
 
-    /// @name neighbors queries
+    /// @name neighbors queries for Edge Topology
     /// @{
     /// Returns the set of edges adjacent to a given vertex.
     const EdgesAroundVertex &getEdgesAroundVertex(PointID i) override;
-    /// Returns the set of edges adjacent to a given triangle.
-    const EdgesInTriangle &getEdgesInTriangle(TriangleID i) override;
-    /// Returns the set of edges adjacent to a given quad.
-    const EdgesInQuad &getEdgesInQuad(QuadID i) override;
-    /// Returns the set of edges adjacent to a given tetrahedron.
-    const EdgesInTetrahedron& getEdgesInTetrahedron(TetraID i) override;
-    /// Returns the set of edges adjacent to a given hexahedron.
-    const EdgesInHexahedron& getEdgesInHexahedron(HexaID i) override;
+    /** \brief Returns the TrianglesAroundVertex array (i.e. provide the triangles indices adjacent to each vertex). */
+    const helper::vector< EdgesAroundVertex > &getEdgesAroundVertexArray();
+    /// @}
+
+
+    /// @name neighbors queries for Triangle Topology
+    /// @{
     /// Returns the set of triangle adjacent to a given vertex.
     const TrianglesAroundVertex &getTrianglesAroundVertex(PointID i) override;
+    /** \brief Returns the TrianglesAroundVertex array (i.e. provide the triangles indices adjacent to each vertex). */
+    const helper::vector< TrianglesAroundVertex > &getTrianglesAroundVertexArray();
+
+    /// Returns the set of 3 edge indices of a given triangle.
+    const EdgesInTriangle &getEdgesInTriangle(TriangleID i) override;
+    /** \brief Returns the EdgesInTriangle array (i.e. provide the 3 edge indices for each triangle). */
+    const helper::vector< EdgesInTriangle > &getEdgesInTriangleArray();
     /// Returns the set of triangle adjacent to a given edge.
     const TrianglesAroundEdge &getTrianglesAroundEdge(EdgeID i) override;
-    /// Returns the set of triangles adjacent to a given tetrahedron.
-    const TrianglesInTetrahedron& getTrianglesInTetrahedron(TetraID i) override;
+    /** \brief Returns the TrianglesAroundEdge array (i.e. provide the triangles indices adjacent to each edge). */
+    const helper::vector< TrianglesAroundEdge > &getTrianglesAroundEdgeArray();
+    /// @}
+
+
+    /// @name neighbors queries for Quad Topology
+    /// @{
     /// Returns the set of quad adjacent to a given vertex.
     const QuadsAroundVertex &getQuadsAroundVertex(PointID i) override;
+    /** \brief Returns the QuadsAroundVertex array (i.e. provide the quad indices adjacent to each vertex). */
+    const helper::vector< QuadsAroundVertex > &getQuadsAroundVertexArray();
+
+    /// Returns the set of edges adjacent to a given quad.
+    const EdgesInQuad &getEdgesInQuad(QuadID i) override;
+    /** \brief Returns the EdgesInQuadArray array (i.e. provide the 4 edge indices for each quad) */
+    const helper::vector< EdgesInQuad > &getEdgesInQuadArray();
     /// Returns the set of quad adjacent to a given edge.
     const QuadsAroundEdge &getQuadsAroundEdge(EdgeID i) override;
-    /// Returns the set of quads adjacent to a given hexahedron.
-    const QuadsInHexahedron& getQuadsInHexahedron(HexaID i) override;
+    /** \brief Returns the QuadsAroundEdge array (i.e. provide the quad indices adjacent to each edge). */
+    const helper::vector< QuadsAroundEdge > &getQuadsAroundEdgeArray();
+    /// @}
+
+
+    /// @name neighbors queries for Tetrahedron Topology
+    /// @{
     /// Returns the set of tetrahedra adjacent to a given vertex.
     const TetrahedraAroundVertex& getTetrahedraAroundVertex(PointID i) override;
+    /** \brief Returns the TetrahedraAroundVertex array (i.e. provide the tetrahedron indices adjacent to each vertex). */
+    const helper::vector< TetrahedraAroundVertex > &getTetrahedraAroundVertexArray();
+
+    /// Returns the set of edges adjacent to a given tetrahedron.
+    const EdgesInTetrahedron& getEdgesInTetrahedron(TetraID i) override;
+    /** \brief Returns the EdgesInTetrahedron array (i.e. provide the 6 edge indices for each tetrahedron). */
+    const helper::vector< EdgesInTetrahedron > &getEdgesInTetrahedronArray();
     /// Returns the set of tetrahedra adjacent to a given edge.
     const TetrahedraAroundEdge& getTetrahedraAroundEdge(EdgeID i) override;
+    /** \brief Returns the TetrahedraAroundEdge array (i.e. provide the tetrahedron indices adjacent to each edge). */
+    const helper::vector< TetrahedraAroundEdge > &getTetrahedraAroundEdgeArray();
+
+    /// Returns the set of triangles adjacent to a given tetrahedron.
+    const TrianglesInTetrahedron& getTrianglesInTetrahedron(TetraID i) override;
+    /** \brief Returns the TrianglesInTetrahedron array (i.e. provide the 4 triangle indices for each tetrahedron). */
+    const helper::vector< TrianglesInTetrahedron > &getTrianglesInTetrahedronArray();
     /// Returns the set of tetrahedra adjacent to a given triangle.
     const TetrahedraAroundTriangle& getTetrahedraAroundTriangle(TriangleID i) override;
+    /** \brief Returns the TetrahedraAroundTriangle array (i.e. provide the tetrahedron indices adjacent to each triangle). */
+    const helper::vector< TetrahedraAroundTriangle > &getTetrahedraAroundTriangleArray();
+    /// @}
+
+
+    /// @name neighbors queries for Hexhaedron Topology
+    /// @{
     /// Returns the set of hexahedra adjacent to a given vertex.
     const HexahedraAroundVertex& getHexahedraAroundVertex(PointID i) override;
+    /** \brief Returns the HexahedraAroundVertex array (i.e. provide the hexahedron indices adjacent to each vertex).*/
+    const helper::vector< HexahedraAroundVertex > &getHexahedraAroundVertexArray();
+
+    /// Returns the set of edges adjacent to a given hexahedron.
+    const EdgesInHexahedron& getEdgesInHexahedron(HexaID i) override;
+    /** \brief Returns the EdgesInHexahedron array (i.e. provide the 12 edge indices for each hexahedron).	*/
+    const helper::vector< EdgesInHexahedron > &getEdgesInHexahedronArray();
     /// Returns the set of hexahedra adjacent to a given edge.
     const HexahedraAroundEdge& getHexahedraAroundEdge(EdgeID i) override;
+    /** \brief Returns the HexahedraAroundEdge array (i.e. provide the hexahedron indices adjacent to each edge). */
+    const helper::vector< HexahedraAroundEdge > &getHexahedraAroundEdgeArray();
+
+    /// Returns the set of quads adjacent to a given hexahedron.
+    const QuadsInHexahedron& getQuadsInHexahedron(HexaID i) override;
+    /** \brief Returns the QuadsInHexahedron array (i.e. provide the 8 quad indices for each hexahedron).	*/
+    const helper::vector< QuadsInHexahedron > &getQuadsInHexahedronArray();
     /// Returns the set of hexahedra adjacent to a given quad.
     const HexahedraAroundQuad& getHexahedraAroundQuad(QuadID i) override;
+    /** \brief Returns the HexahedraAroundQuad array (i.e. provide the hexahedron indices adjacent to each quad). */
+    const helper::vector< HexahedraAroundQuad > &getHexahedraAroundQuadArray();
     /// @}
 
 
@@ -261,63 +321,6 @@ public:
     //virtual const helper::vector <EdgeID>& getEdgesOnBorder();
 
     //virtual const helper::vector <PointID>& getPointsOnBorder();
-
-    /** \brief Returns the TrianglesAroundVertex array (i.e. provide the triangles indices adjacent to each vertex). */
-    const helper::vector< EdgesAroundVertex > &getEdgesAroundVertexArray();
-
-    /** \brief Returns the EdgesInTriangle array (i.e. provide the 3 edge indices for each triangle). */
-    const helper::vector< EdgesInTriangle > &getEdgesInTriangleArray();
-
-    /** \brief Returns the TrianglesAroundVertex array (i.e. provide the triangles indices adjacent to each vertex). */
-    const helper::vector< TrianglesAroundVertex > &getTrianglesAroundVertexArray();
-
-    /** \brief Returns the TrianglesAroundEdge array (i.e. provide the triangles indices adjacent to each edge). */
-    const helper::vector< TrianglesAroundEdge > &getTrianglesAroundEdgeArray();
-
-
-
-    /** \brief Returns the EdgesInQuadArray array (i.e. provide the 4 edge indices for each quad) */
-    const helper::vector< EdgesInQuad > &getEdgesInQuadArray();
-
-    /** \brief Returns the QuadsAroundVertex array (i.e. provide the quad indices adjacent to each vertex). */
-    const helper::vector< QuadsAroundVertex > &getQuadsAroundVertexArray();
-
-    /** \brief Returns the QuadsAroundEdge array (i.e. provide the quad indices adjacent to each edge). */
-    const helper::vector< QuadsAroundEdge > &getQuadsAroundEdgeArray();
-
-
-
-    /** \brief Returns the EdgesInHexahedron array (i.e. provide the 12 edge indices for each hexahedron).	*/
-    const helper::vector< EdgesInHexahedron > &getEdgesInHexahedronArray();
-
-    /** \brief Returns the QuadsInHexahedron array (i.e. provide the 8 quad indices for each hexahedron).	*/
-    const helper::vector< QuadsInHexahedron > &getQuadsInHexahedronArray();
-
-    /** \brief Returns the HexahedraAroundVertex array (i.e. provide the hexahedron indices adjacent to each vertex).*/
-    const helper::vector< HexahedraAroundVertex > &getHexahedraAroundVertexArray();
-
-    /** \brief Returns the HexahedraAroundEdge array (i.e. provide the hexahedron indices adjacent to each edge). */
-    const helper::vector< HexahedraAroundEdge > &getHexahedraAroundEdgeArray();
-
-    /** \brief Returns the HexahedraAroundQuad array (i.e. provide the hexahedron indices adjacent to each quad). */
-    const helper::vector< HexahedraAroundQuad > &getHexahedraAroundQuadArray();
-
-
-
-    /** \brief Returns the EdgesInTetrahedron array (i.e. provide the 6 edge indices for each tetrahedron). */
-    const helper::vector< EdgesInTetrahedron > &getEdgesInTetrahedronArray();
-
-    /** \brief Returns the TrianglesInTetrahedron array (i.e. provide the 4 triangle indices for each tetrahedron). */
-    const helper::vector< TrianglesInTetrahedron > &getTrianglesInTetrahedronArray();
-
-    /** \brief Returns the TetrahedraAroundVertex array (i.e. provide the tetrahedron indices adjacent to each vertex). */
-    const helper::vector< TetrahedraAroundVertex > &getTetrahedraAroundVertexArray();
-
-    /** \brief Returns the TetrahedraAroundEdge array (i.e. provide the tetrahedron indices adjacent to each edge). */
-    const helper::vector< TetrahedraAroundEdge > &getTetrahedraAroundEdgeArray();
-
-    /** \brief Returns the TetrahedraAroundTriangle array (i.e. provide the tetrahedron indices adjacent to each triangle). */
-    const helper::vector< TetrahedraAroundTriangle > &getTetrahedraAroundTriangleArray();
 
 public:
     typedef helper::vector<defaulttype::Vec<3, SReal > > SeqPoints;

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
@@ -951,6 +951,47 @@ const TetrahedronSetTopologyContainer::VecTetraID TetrahedronSetTopologyContaine
     return elemAll;
 }
 
+
+const TetrahedronSetTopologyContainer::VecTetraID TetrahedronSetTopologyContainer::getOppositeElement(TetraID elemID)
+{
+    VecTetraID elems;
+    if (!hasTetrahedraAroundTriangle())
+    {
+        if(CHECK_TOPOLOGY)
+            msg_warning() << "In getOppositeElement: TetrahedraAroundTriangle shell array is empty.";
+        return elems;
+    }
+
+    if (!hasTrianglesInTetrahedron())
+    {
+        if(CHECK_TOPOLOGY)
+            msg_warning() << "In getOppositeElement: TrianglesInTetrahedron shell array is empty.";
+        return elems;
+    }
+
+    if (elemID > m_trianglesInTetrahedron.size())
+        return elems;
+
+    const TrianglesInTetrahedron& triInTetra = m_trianglesInTetrahedron[elemID];
+    elems.reserve(4);
+    for (auto triID: triInTetra) // loop on the 4 triangles
+    {
+        const TetrahedraAroundTriangle& tetraATri = m_tetrahedraAroundTriangle[triID];
+        if (tetraATri.size() > 2 )
+            msg_warning() << "In getOppositeElement: more than 2 tetrahedron around triangle: " << triID << " -> " << tetraATri;
+
+        if (tetraATri.size() == 1) // triangle on border
+            continue;
+
+        if (tetraATri[0] == elemID)
+            elems.push_back(tetraATri[1]);
+        else
+            elems.push_back(tetraATri[0]);
+    }
+
+    return elems;
+}
+
 /// @}
 
 

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
@@ -658,63 +658,157 @@ bool TetrahedronSetTopologyContainer::checkTopology() const
 
         if (hasTetrahedraAroundVertex())
         {
+            std::set <int> tetrahedronSet;
             for (size_t i = 0; i < m_tetrahedraAroundVertex.size(); ++i)
             {
                 const sofa::helper::vector<TetrahedronID> &tvs = m_tetrahedraAroundVertex[i];
                 for (size_t j = 0; j < tvs.size(); ++j)
                 {
-                    bool check_tetra_vertex_shell = (m_tetrahedron[tvs[j]][0] == i)
-                        || (m_tetrahedron[tvs[j]][1] == i)
-                        || (m_tetrahedron[tvs[j]][2] == i)
-                        || (m_tetrahedron[tvs[j]][3] == i);
+                    const Tetrahedron& tetrahedron = m_tetrahedron[tvs[j]];
+                    bool check_tetra_vertex_shell = (tetrahedron[0] == i)
+                        || (tetrahedron[1] == i)
+                        || (tetrahedron[2] == i)
+                        || (tetrahedron[3] == i);
                     if (!check_tetra_vertex_shell)
                     {
-                        msg_error() << "*** CHECK FAILED : check_tetra_vertex_shell, i = " << i << " , j = " << j ;
+                        msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: tetrahedron " << tvs[j] << ": [" << tetrahedron << "] not around vertex: " << i;
                         ret = false;
                     }
+
+                    tetrahedronSet.insert(tvs[j]);
                 }
             }
-        }
 
-        if (hasTetrahedraAroundEdge())
-        {
-            for (size_t i = 0; i < m_tetrahedraAroundEdge.size(); ++i)
+            if (tetrahedronSet.size() != m_tetrahedron.size())
             {
-                const sofa::helper::vector<TetrahedronID> &tes = m_tetrahedraAroundEdge[i];
-                for (size_t j = 0; j < tes.size(); ++j)
+                msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: found " << tetrahedronSet.size() << " tetrahedra in m_tetrahedraAroundVertex out of " << m_tetrahedron.size();
+                ret = false;
+            }
+        }
+
+
+        if (hasTetrahedraAroundTriangle() && hasTrianglesInTetrahedron())
+        {
+            // check first m_trianglesInTetrahedron
+            helper::ReadAccessor< Data< sofa::helper::vector<Triangle> > > m_triangle = d_triangle;
+
+            if (m_trianglesInTetrahedron.size() != m_tetrahedron.size())
+            {
+                msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: m_trianglesInTetrahedron size: " << m_trianglesInTetrahedron.size() << " not equal to " << m_tetrahedron.size();
+                ret = false;
+            }
+
+            for (size_t i=0; i<m_trianglesInTetrahedron.size(); ++i)
+            {
+                const Tetrahedron& tetrahedron = m_tetrahedron[i];
+                const TrianglesInTetrahedron& triInTetra = m_trianglesInTetrahedron[i];
+
+                for (unsigned int j=0; j<4; j++)
                 {
-                    bool check_tetra_edge_shell = (m_edgesInTetrahedron[tes[j]][0] == i)
-                        || (m_edgesInTetrahedron[tes[j]][1] == i)
-                        || (m_edgesInTetrahedron[tes[j]][2] == i)
-                        || (m_edgesInTetrahedron[tes[j]][3] == i)
-                        || (m_edgesInTetrahedron[tes[j]][4] == i)
-                        || (m_edgesInTetrahedron[tes[j]][5] == i);
-                    if (!check_tetra_edge_shell)
+                    const Triangle& triangle = m_triangle[triInTetra[j]];
+                    int cptFound = 0;
+                    for (unsigned int k=0; k<4; k++)
+                        if (triangle[0] == tetrahedron[k] || triangle[1] == tetrahedron[k] || triangle[2] == tetrahedron[k])
+                            cptFound++;
+
+                    if (cptFound != 3)
                     {
-                        msg_error() << "*** CHECK FAILED : check_tetra_edge_shell, i = " << i << " , j = " << j ;
+                        msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: triangle: " << triInTetra[j] << ": [" << triangle << "] not found in tetrahedron: " << i << ": " << tetrahedron;
                         ret = false;
                     }
                 }
             }
-        }
 
-        if (hasTetrahedraAroundTriangle())
-        {
+            // check m_tetrahedraAroundTriangle using checked m_trianglesInTetrahedron
+            std::set <int> tetrahedronSet;
             for (size_t i = 0; i < m_tetrahedraAroundTriangle.size(); ++i)
             {
                 const sofa::helper::vector<TetrahedronID> &tes = m_tetrahedraAroundTriangle[i];
                 for (size_t j = 0; j < tes.size(); ++j)
                 {
-                    bool check_tetra_triangle_shell = (m_trianglesInTetrahedron[tes[j]][0] == i)
-                        || (m_trianglesInTetrahedron[tes[j]][1] == i)
-                        || (m_trianglesInTetrahedron[tes[j]][2] == i)
-                        || (m_trianglesInTetrahedron[tes[j]][3] == i);
+                    const TrianglesInTetrahedron& triInTetra = m_trianglesInTetrahedron[tes[j]];
+                    bool check_tetra_triangle_shell = (triInTetra[0] == i)
+                        || (triInTetra[1] == i)
+                        || (triInTetra[2] == i)
+                        || (triInTetra[3] == i);
                     if (!check_tetra_triangle_shell)
                     {
-                        msg_error() << "*** CHECK FAILED : check_tetra_triangle_shell, i = " << i << " , j = " << j ;
+                        msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: tetrahedron: " << tes[j] << " with triangle: [" << triInTetra << "] not found around triangle: " << i;
+                        ret = false;
+                    }
+
+                    tetrahedronSet.insert(tes[j]);
+                }
+            }
+
+            if (tetrahedronSet.size() != m_tetrahedron.size())
+            {
+                msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: found " << tetrahedronSet.size() << " tetrahedra in m_tetrahedraAroundTriangle out of " << m_tetrahedron.size();
+                ret = false;
+            }
+        }
+
+
+        if (hasTetrahedraAroundEdge() && hasEdgesInTetrahedron())
+        {
+            // check first m_edgesInTetrahedron
+            helper::ReadAccessor< Data< sofa::helper::vector<Edge> > > m_edge = d_edge;
+
+            if (m_edgesInTetrahedron.size() != m_tetrahedron.size())
+            {
+                msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: m_edgesInTetrahedron size: " << m_edgesInTetrahedron.size() << " not equal to " << m_tetrahedron.size();
+                ret = false;
+            }
+
+            for (size_t i=0; i<m_edgesInTetrahedron.size(); ++i)
+            {
+                const Tetrahedron& tetrahedron = m_tetrahedron[i];
+                const EdgesInTetrahedron& eInTetra = m_edgesInTetrahedron[i];
+
+                for (unsigned int j=0; j<6; j++)
+                {
+                    const Edge& edge = m_edge[eInTetra[j]];
+                    int cptFound = 0;
+                    for (unsigned int k=0; k<4; k++)
+                        if (edge[0] == tetrahedron[k] || edge[1] == tetrahedron[k])
+                            cptFound++;
+
+                    if (cptFound != 2)
+                    {
+                        msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: edge: " << eInTetra[j] << ": [" << edge << "] not found in tetrahedron: " << i << ": " << tetrahedron;
                         ret = false;
                     }
                 }
+            }
+
+            // check m_tetrahedraAroundEdge using checked m_edgesInTetrahedron
+            std::set <int> tetrahedronSet;
+            for (size_t i = 0; i < m_tetrahedraAroundEdge.size(); ++i)
+            {
+                const sofa::helper::vector<TetrahedronID> &tes = m_tetrahedraAroundEdge[i];
+                for (size_t j = 0; j < tes.size(); ++j)
+                {
+                    const EdgesInTetrahedron& eInTetra = m_edgesInTetrahedron[tes[j]];
+                    bool check_tetra_edge_shell = (eInTetra[0] == i)
+                        || (eInTetra[1] == i)
+                        || (eInTetra[2] == i)
+                        || (eInTetra[3] == i)
+                        || (eInTetra[4] == i)
+                        || (eInTetra[5] == i);
+                    if (!check_tetra_edge_shell)
+                    {
+                        msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: tetrahedron: " << tes[j] << " with edges: [" << eInTetra << "] not found around edge: " << i;
+                        ret = false;
+                    }
+
+                    tetrahedronSet.insert(tes[j]);
+                }
+            }
+
+            if (tetrahedronSet.size() != m_tetrahedron.size())
+            {
+                msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: found " << tetrahedronSet.size() << " tetrahedra in m_tetrahedraAroundTriangle out of " << m_tetrahedron.size();
+                ret = false;
             }
         }
 

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.h
@@ -238,6 +238,9 @@ public:
     const VecTetraID getElementAroundElement(TetraID elem) override;
     /// Returns the set of element indices adjacent to a given list of elements (i.e. sharing a link)
     const VecTetraID getElementAroundElements(VecTetraID elems) override;
+
+    /// Returns the set of element indices adjacent to a given element with direct link from n-1 order element type (i.e triangle for tetrahedron)
+    const VecTetraID getOppositeElement(TetraID elemID);
     /// @}
 
 

--- a/modules/SofaTopologyMapping/Hexa2QuadTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/Hexa2QuadTopologicalMapping.cpp
@@ -35,6 +35,7 @@
 #include <sofa/defaulttype/Vec.h>
 #include <map>
 #include <sofa/defaulttype/VecTypes.h>
+#include <sofa/helper/AdvancedTimer.h>
 
 namespace sofa
 {
@@ -70,63 +71,74 @@ Hexa2QuadTopologicalMapping::~Hexa2QuadTopologicalMapping()
 
 void Hexa2QuadTopologicalMapping::init()
 {
-    //sout << "INFO_print : init Hexa2QuadTopologicalMapping" << sendl;
-
-    // INITIALISATION of QUADULAR mesh from HEXAHEDRAL mesh :
-
-    if (fromModel)
+    // recheck models
+    bool modelsOk = true;
+    if (!fromModel)
     {
-
-        sout << "INFO_print : Hexa2QuadTopologicalMapping - from = hexa" << sendl;
-
-        if (toModel)
-        {
-
-            sout << "INFO_print : Hexa2QuadTopologicalMapping - to = quad" << sendl;
-
-            QuadSetTopologyContainer *to_tstc;
-            toModel->getContext()->get(to_tstc);
-            // Clear output topology
-            to_tstc->clear();
-
-            // Set the same number of points
-            toModel->setNbPoints(fromModel->getNbPoints());
-
-            QuadSetTopologyModifier *to_tstm;
-            toModel->getContext()->get(to_tstm);
-
-            const sofa::helper::vector<core::topology::BaseMeshTopology::Quad> &quadArray=fromModel->getQuads();
-            sofa::helper::vector <unsigned int>& Loc2GlobVec = *(Loc2GlobDataVec.beginEdit());
-            Loc2GlobVec.clear();
-            Glob2LocMap.clear();
-
-            const bool flipN = flipNormals.getValue();
-
-            for (unsigned int i=0; i<quadArray.size(); ++i)
-            {
-                if (fromModel->getHexahedraAroundQuad(i).size()==1)
-                {
-                    core::topology::BaseMeshTopology::Quad q = quadArray[i];
-
-                    if(flipN)
-                        to_tstc->addQuad(q[3], q[2], q[1], q[0]);
-                    else
-                        to_tstc->addQuad(q[0], q[1], q[2], q[3]);
-
-                    Loc2GlobVec.push_back(i);
-                    Glob2LocMap[i]= (unsigned int)Loc2GlobVec.size()-1;
-                }
-            }
-
-            //to_tstm->propagateTopologicalChanges();
-            Loc2GlobDataVec.endEdit();
-
-            // Need to fully init the target topology
-            toModel->init();
-        }
-
+        msg_error() << "Pointer to input topology is invalid.";
+        modelsOk = false;
     }
 
+    if (!toModel)
+    {
+        msg_error() << "Pointer to output topology is invalid.";
+        modelsOk = false;
+    }
+    else
+    {
+        QuadSetTopologyModifier *to_tstm;
+        toModel->getContext()->get(to_tstm);
+        if (!to_tstm)
+        {
+            msg_error() << "No QuadSetTopologyModifier found in the Quad topology Node.";
+            modelsOk = false;
+        }
+    }
+
+    if (!modelsOk)
+    {
+        this->m_componentstate = sofa::core::objectmodel::ComponentState::Invalid;
+        return;
+    }
+
+    QuadSetTopologyContainer *to_tstc;
+    toModel->getContext()->get(to_tstc);
+    // Clear output topology
+    to_tstc->clear();
+
+    // Set the same number of points
+    toModel->setNbPoints(fromModel->getNbPoints());
+
+    const sofa::helper::vector<core::topology::BaseMeshTopology::Quad> &quadArray=fromModel->getQuads();
+    sofa::helper::vector <unsigned int>& Loc2GlobVec = *(Loc2GlobDataVec.beginEdit());
+    Loc2GlobVec.clear();
+    Glob2LocMap.clear();
+
+    const bool flipN = flipNormals.getValue();
+
+    for (unsigned int i=0; i<quadArray.size(); ++i)
+    {
+        if (fromModel->getHexahedraAroundQuad(i).size()==1)
+        {
+            core::topology::BaseMeshTopology::Quad q = quadArray[i];
+
+            if(flipN)
+                to_tstc->addQuad(q[3], q[2], q[1], q[0]);
+            else
+                to_tstc->addQuad(q[0], q[1], q[2], q[3]);
+
+            Loc2GlobVec.push_back(i);
+            Glob2LocMap[i]= (unsigned int)Loc2GlobVec.size()-1;
+        }
+    }
+
+    //to_tstm->propagateTopologicalChanges();
+    Loc2GlobDataVec.endEdit();
+
+    // Need to fully init the target topology
+    toModel->init();
+
+    this->m_componentstate = sofa::core::objectmodel::ComponentState::Valid;
 }
 
 unsigned int Hexa2QuadTopologicalMapping::getFromIndex(unsigned int ind)
@@ -144,289 +156,265 @@ unsigned int Hexa2QuadTopologicalMapping::getFromIndex(unsigned int ind)
 
 void Hexa2QuadTopologicalMapping::updateTopologicalMappingTopDown()
 {
+    if (this->m_componentstate != sofa::core::objectmodel::ComponentState::Valid)
+        return;
 
-    // INITIALISATION of QUADULAR mesh from HEXAHEDRAL mesh :
+    sofa::helper::AdvancedTimer::stepBegin("Update Hexa2QuadTopologicalMapping");
+    QuadSetTopologyModifier *to_tstm;
+    toModel->getContext()->get(to_tstm);
 
-    if (fromModel)
+    std::list<const TopologyChange *>::const_iterator itBegin=fromModel->beginChange();
+    std::list<const TopologyChange *>::const_iterator itEnd=fromModel->endChange();
+
+    sofa::helper::vector <unsigned int>& Loc2GlobVec = *(Loc2GlobDataVec.beginEdit());
+
+    while( itBegin != itEnd )
     {
+        TopologyChangeType changeType = (*itBegin)->getChangeType();
+        std::string topoChangeType = "Hexa2QuadTopologicalMapping - " + parseTopologyChangeTypeToString(changeType);
+        sofa::helper::AdvancedTimer::stepBegin(topoChangeType);
 
-        QuadSetTopologyModifier *to_tstm;
-        toModel->getContext()->get(to_tstm);
-
-        if (toModel)
+        switch( changeType )
         {
 
-            std::list<const TopologyChange *>::const_iterator itBegin=fromModel->beginChange();
-            std::list<const TopologyChange *>::const_iterator itEnd=fromModel->endChange();
+        case core::topology::ENDING_EVENT:
+        {
+            to_tstm->propagateTopologicalChanges();
+            to_tstm->notifyEndingEvent();
+            to_tstm->propagateTopologicalChanges();
+            break;
+        }
 
-            sofa::helper::vector <unsigned int>& Loc2GlobVec = *(Loc2GlobDataVec.beginEdit());
+        case core::topology::QUADSREMOVED:
+        {
+            unsigned int last = (unsigned int)fromModel->getNbQuads() - 1;
+            unsigned int ind_last = (unsigned int)toModel->getNbQuads();
 
-            while( itBegin != itEnd )
+            const sofa::helper::vector<unsigned int> &tab = ( static_cast< const QuadsRemoved *>( *itBegin ) )->getArray();
+
+            unsigned int ind_tmp;
+
+            unsigned int ind_real_last;
+
+            for (unsigned int i = 0; i <tab.size(); ++i)
             {
-                TopologyChangeType changeType = (*itBegin)->getChangeType();
+                unsigned int k = tab[i];
 
-                switch( changeType )
+                std::map<unsigned int, unsigned int>::iterator iter_1 = Glob2LocMap.find(k);
+                if(iter_1 != Glob2LocMap.end())
                 {
 
-                case core::topology::ENDING_EVENT:
-                {
-                    //sout << "INFO_print : Hexa2QuadTopologicalMapping - ENDING_EVENT" << sendl;
-                    to_tstm->propagateTopologicalChanges();
-                    to_tstm->notifyEndingEvent();
-                    to_tstm->propagateTopologicalChanges();
-                    break;
-                }
+                    ind_last = ind_last - 1;
 
-                case core::topology::QUADSREMOVED:
-                {
-                    //sout << "INFO_print : Hexa2QuadTopologicalMapping - QUADSREMOVED" << sendl;
-
-                    unsigned int last = (unsigned int)fromModel->getNbQuads() - 1;
-                    unsigned int ind_last = (unsigned int)toModel->getNbQuads();
-
-                    const sofa::helper::vector<unsigned int> &tab = ( static_cast< const QuadsRemoved *>( *itBegin ) )->getArray();
-
-                    unsigned int ind_tmp;
-
-                    unsigned int ind_real_last;
-
-                    for (unsigned int i = 0; i <tab.size(); ++i)
-                    {
-                        unsigned int k = tab[i];
-
-                        std::map<unsigned int, unsigned int>::iterator iter_1 = Glob2LocMap.find(k);
-                        if(iter_1 != Glob2LocMap.end())
-                        {
-
-                            ind_last = ind_last - 1;
-
-                            unsigned int ind_k = Glob2LocMap[k];
+                    unsigned int ind_k = Glob2LocMap[k];
 //                            ind_real_last = ind_k;
 
-                            std::map<unsigned int, unsigned int>::iterator iter_2 = Glob2LocMap.find(last);
-                            if(iter_2 != Glob2LocMap.end())
-                            {
+                    std::map<unsigned int, unsigned int>::iterator iter_2 = Glob2LocMap.find(last);
+                    if(iter_2 != Glob2LocMap.end())
+                    {
 
-                                ind_real_last = Glob2LocMap[last];
+                        ind_real_last = Glob2LocMap[last];
 
-                                if(k != last)
-                                {
-
-                                    Glob2LocMap.erase(Glob2LocMap.find(k));
-                                    Glob2LocMap[k] = ind_real_last;
-
-                                    Glob2LocMap.erase(Glob2LocMap.find(last));
-                                    Glob2LocMap[last] = ind_k;
-
-                                    ind_tmp = Loc2GlobVec[ind_real_last];
-                                    Loc2GlobVec[ind_real_last] = Loc2GlobVec[ind_k];
-                                    Loc2GlobVec[ind_k] = ind_tmp;
-                                }
-                            }
-
-                            if(ind_k != ind_last)
-                            {
-
-                                Glob2LocMap.erase(Glob2LocMap.find(Loc2GlobVec[ind_last]));
-                                Glob2LocMap[Loc2GlobVec[ind_last]] = ind_k;
-
-                                Glob2LocMap.erase(Glob2LocMap.find(Loc2GlobVec[ind_k]));
-                                Glob2LocMap[Loc2GlobVec[ind_k]] = ind_last;
-
-                                ind_tmp = Loc2GlobVec[ind_k];
-                                Loc2GlobVec[ind_k] = Loc2GlobVec[ind_last];
-                                Loc2GlobVec[ind_last] = ind_tmp;
-
-                            }
-
-                            Glob2LocMap.erase(Glob2LocMap.find(Loc2GlobVec[Loc2GlobVec.size() - 1]));
-                            Loc2GlobVec.resize( Loc2GlobVec.size() - 1 );
-
-                            sofa::helper::vector< unsigned int > quads_to_remove;
-                            quads_to_remove.push_back(ind_k);
-
-                            to_tstm->removeQuads(quads_to_remove, true, false);
-
-                        }
-                        else
+                        if(k != last)
                         {
 
-                            sout << "INFO_print : Hexa2QuadTopologicalMapping - Glob2LocMap should have the visible quad " << tab[i] << sendl;
-                            sout << "INFO_print : Hexa2QuadTopologicalMapping - nb quads = " << ind_last << sendl;
+                            Glob2LocMap.erase(Glob2LocMap.find(k));
+                            Glob2LocMap[k] = ind_real_last;
+
+                            Glob2LocMap.erase(Glob2LocMap.find(last));
+                            Glob2LocMap[last] = ind_k;
+
+                            ind_tmp = Loc2GlobVec[ind_real_last];
+                            Loc2GlobVec[ind_real_last] = Loc2GlobVec[ind_k];
+                            Loc2GlobVec[ind_k] = ind_tmp;
                         }
-
-                        --last;
                     }
-                    break;
-                }
 
-                case core::topology::HEXAHEDRAREMOVED:
-                {
-                    //sout << "INFO_print : Hexa2QuadTopologicalMapping - HEXAHEDRAREMOVED" << sendl;
-
-                    if (fromModel)
+                    if(ind_k != ind_last)
                     {
 
-                        const sofa::helper::vector<core::topology::BaseMeshTopology::Hexahedron> &hexahedronArray=fromModel->getHexahedra();
+                        Glob2LocMap.erase(Glob2LocMap.find(Loc2GlobVec[ind_last]));
+                        Glob2LocMap[Loc2GlobVec[ind_last]] = ind_k;
 
-                        const sofa::helper::vector<unsigned int> &tab = ( static_cast< const HexahedraRemoved *>( *itBegin ) )->getArray();
+                        Glob2LocMap.erase(Glob2LocMap.find(Loc2GlobVec[ind_k]));
+                        Glob2LocMap[Loc2GlobVec[ind_k]] = ind_last;
 
-                        sofa::helper::vector< core::topology::BaseMeshTopology::Quad > quads_to_create;
-                        sofa::helper::vector< unsigned int > quadsIndexList;
-                        unsigned int nb_elems = (unsigned int)toModel->getNbQuads();
-                        const bool flipN = flipNormals.getValue();
-
-                        for (unsigned int i = 0; i < tab.size(); ++i)
-                        {
-
-                            for (unsigned int j = 0; j < 6; ++j)
-                            {
-                                unsigned int k = (fromModel->getQuadsInHexahedron(tab[i]))[j];
-
-                                if (fromModel->getHexahedraAroundQuad(k).size()==1)   // remove as visible the quad indexed by k
-                                {
-
-                                    // do nothing
-
-                                }
-                                else   // fromModel->getHexahedraAroundQuad(k).size()==2 // add as visible the quad indexed by k
-                                {
-
-                                    unsigned int ind_test;
-                                    if(tab[i] == fromModel->getHexahedraAroundQuad(k)[0])
-                                    {
-
-                                        ind_test = fromModel->getHexahedraAroundQuad(k)[1];
-
-                                    }
-                                    else   // tab[i] == fromModel->getHexahedraAroundQuad(k)[1]
-                                    {
-
-                                        ind_test = fromModel->getHexahedraAroundQuad(k)[0];
-                                    }
-
-                                    bool is_present = false;
-                                    unsigned int k0 = 0;
-                                    while((!is_present) && k0 < i)
-                                    {
-                                        is_present = (ind_test == tab[k0]);
-                                        k0+=1;
-                                    }
-                                    if(!is_present)
-                                    {
-
-                                        core::topology::BaseMeshTopology::Quad q;
-
-                                        const core::topology::BaseMeshTopology::Hexahedron &he=hexahedronArray[ind_test];
-                                        int h = fromModel->getQuadIndexInHexahedron(fromModel->getQuadsInHexahedron(ind_test),k);
-                                        //unsigned int hh = (fromModel->getQuadsInHexahedron(ind_test))[h];
-
-                                        //t=from_qstc->getQuad(hh);
-                                        static const int hexaQuads[6][4] = { { 0,3,2,1 }, {4,5,6,7}, {0,1,5,4}, {1,2,6,5}, {2,3,7,6}, {3,0,4,7} };
-                                        q[0] = he[hexaQuads[h][0]];
-                                        q[1] = he[hexaQuads[h][1]];
-                                        q[2] = he[hexaQuads[h][2]];
-                                        q[3] = he[hexaQuads[h][3]];
-
-                                        if(flipN)
-                                        {
-                                            unsigned int tmp3 = q[3];
-                                            unsigned int tmp2 = q[2];
-                                            q[3] = q[0];
-                                            q[2] = q[1];
-                                            q[1] = tmp2;
-                                            q[0] = tmp3;
-                                        }
-                                        quads_to_create.push_back(q);
-                                        quadsIndexList.push_back(nb_elems);
-                                        nb_elems+=1;
-
-                                        Loc2GlobVec.push_back(k);
-                                        std::map<unsigned int, unsigned int>::iterator iter_1 = Glob2LocMap.find(k);
-                                        if(iter_1 != Glob2LocMap.end() )
-                                        {
-                                            sout << "INFO_print : Hexa2QuadTopologicalMapping - fail to add quad " << k << " which already exists" << sendl;
-                                            Glob2LocMap.erase(Glob2LocMap.find(k));
-                                        }
-                                        Glob2LocMap[k]=(unsigned int)Loc2GlobVec.size()-1;
-                                    }
-                                }
-                            }
-                        }
-
-                        to_tstm->addQuadsProcess(quads_to_create) ;
-                        to_tstm->addQuadsWarning(quads_to_create.size(), quads_to_create, quadsIndexList) ;
+                        ind_tmp = Loc2GlobVec[ind_k];
+                        Loc2GlobVec[ind_k] = Loc2GlobVec[ind_last];
+                        Loc2GlobVec[ind_last] = ind_tmp;
 
                     }
 
-                    break;
-                }
+                    Glob2LocMap.erase(Glob2LocMap.find(Loc2GlobVec[Loc2GlobVec.size() - 1]));
+                    Loc2GlobVec.resize( Loc2GlobVec.size() - 1 );
 
-                case core::topology::POINTSREMOVED:
+                    sofa::helper::vector< unsigned int > quads_to_remove;
+                    quads_to_remove.push_back(ind_k);
+
+                    to_tstm->removeQuads(quads_to_remove, true, false);
+
+                }
+                else
                 {
-                    //sout << "INFO_print : Hexa2QuadTopologicalMapping - POINTSREMOVED" << sendl;
-
-                    const sofa::helper::vector<unsigned int> tab = ( static_cast< const sofa::component::topology::PointsRemoved * >( *itBegin ) )->getArray();
-
-                    sofa::helper::vector<unsigned int> indices;
-
-                    for(unsigned int i = 0; i < tab.size(); ++i)
-                    {
-
-                        //sout << "INFO_print : Hexa2QuadTopologicalMapping - point = " << tab[i] << sendl;
-                        indices.push_back(tab[i]);
-                    }
-
-                    sofa::helper::vector<unsigned int>& tab_indices = indices;
-
-                    to_tstm->removePointsWarning(tab_indices, false);
-                    to_tstm->propagateTopologicalChanges();
-                    to_tstm->removePointsProcess(tab_indices, false);
-
-                    break;
+                    msg_warning() << "Glob2LocMap should have the visible quad " << tab[i] << " - nb quads = " << ind_last;
                 }
 
-                case core::topology::POINTSRENUMBERING:
-                {
-                    //sout << "INFO_print : Hexa2QuadTopologicalMapping - POINTSREMOVED" << sendl;
-
-                    const sofa::helper::vector<unsigned int> &tab = ( static_cast< const PointsRenumbering * >( *itBegin ) )->getIndexArray();
-                    const sofa::helper::vector<unsigned int> &inv_tab = ( static_cast< const PointsRenumbering * >( *itBegin ) )->getinv_IndexArray();
-
-                    sofa::helper::vector<unsigned int> indices;
-                    sofa::helper::vector<unsigned int> inv_indices;
-
-                    for(unsigned int i = 0; i < tab.size(); ++i)
-                    {
-
-                        //sout << "INFO_print : Hexa2QuadTopologicalMapping - point = " << tab[i] << sendl;
-                        indices.push_back(tab[i]);
-                        inv_indices.push_back(inv_tab[i]);
-                    }
-
-                    sofa::helper::vector<unsigned int>& tab_indices = indices;
-                    sofa::helper::vector<unsigned int>& inv_tab_indices = inv_indices;
-
-                    to_tstm->renumberPointsWarning(tab_indices, inv_tab_indices, false);
-                    to_tstm->propagateTopologicalChanges();
-                    to_tstm->renumberPointsProcess(tab_indices, inv_tab_indices, false);
-
-                    break;
-                }
-
-                default:
-                    // Ignore events that are not Quad  related.
-                    break;
-                };
-
-                ++itBegin;
+                --last;
             }
-            to_tstm->propagateTopologicalChanges();
-            Loc2GlobDataVec.endEdit();
+            break;
         }
-    }
 
-    return;
+        case core::topology::HEXAHEDRAREMOVED:
+        {
+            const sofa::helper::vector<core::topology::BaseMeshTopology::Hexahedron> &hexahedronArray=fromModel->getHexahedra();
+
+            const sofa::helper::vector<unsigned int> &tab = ( static_cast< const HexahedraRemoved *>( *itBegin ) )->getArray();
+
+            sofa::helper::vector< core::topology::BaseMeshTopology::Quad > quads_to_create;
+            sofa::helper::vector< unsigned int > quadsIndexList;
+            unsigned int nb_elems = (unsigned int)toModel->getNbQuads();
+            const bool flipN = flipNormals.getValue();
+
+            for (unsigned int i = 0; i < tab.size(); ++i)
+            {
+
+                for (unsigned int j = 0; j < 6; ++j)
+                {
+                    unsigned int k = (fromModel->getQuadsInHexahedron(tab[i]))[j];
+
+                    if (fromModel->getHexahedraAroundQuad(k).size()==1)   // remove as visible the quad indexed by k
+                    {
+
+                        // do nothing
+
+                    }
+                    else   // fromModel->getHexahedraAroundQuad(k).size()==2 // add as visible the quad indexed by k
+                    {
+
+                        unsigned int ind_test;
+                        if(tab[i] == fromModel->getHexahedraAroundQuad(k)[0])
+                        {
+
+                            ind_test = fromModel->getHexahedraAroundQuad(k)[1];
+
+                        }
+                        else   // tab[i] == fromModel->getHexahedraAroundQuad(k)[1]
+                        {
+
+                            ind_test = fromModel->getHexahedraAroundQuad(k)[0];
+                        }
+
+                        bool is_present = false;
+                        unsigned int k0 = 0;
+                        while((!is_present) && k0 < i)
+                        {
+                            is_present = (ind_test == tab[k0]);
+                            k0+=1;
+                        }
+                        if(!is_present)
+                        {
+
+                            core::topology::BaseMeshTopology::Quad q;
+
+                            const core::topology::BaseMeshTopology::Hexahedron &he=hexahedronArray[ind_test];
+                            int h = fromModel->getQuadIndexInHexahedron(fromModel->getQuadsInHexahedron(ind_test),k);
+                            //unsigned int hh = (fromModel->getQuadsInHexahedron(ind_test))[h];
+
+                            //t=from_qstc->getQuad(hh);
+                            static const int hexaQuads[6][4] = { { 0,3,2,1 }, {4,5,6,7}, {0,1,5,4}, {1,2,6,5}, {2,3,7,6}, {3,0,4,7} };
+                            q[0] = he[hexaQuads[h][0]];
+                            q[1] = he[hexaQuads[h][1]];
+                            q[2] = he[hexaQuads[h][2]];
+                            q[3] = he[hexaQuads[h][3]];
+
+                            if(flipN)
+                            {
+                                unsigned int tmp3 = q[3];
+                                unsigned int tmp2 = q[2];
+                                q[3] = q[0];
+                                q[2] = q[1];
+                                q[1] = tmp2;
+                                q[0] = tmp3;
+                            }
+                            quads_to_create.push_back(q);
+                            quadsIndexList.push_back(nb_elems);
+                            nb_elems+=1;
+
+                            Loc2GlobVec.push_back(k);
+                            std::map<unsigned int, unsigned int>::iterator iter_1 = Glob2LocMap.find(k);
+                            if(iter_1 != Glob2LocMap.end() )
+                            {
+                                msg_warning() << "Failed to add quad " << k << " which already exists";
+                                Glob2LocMap.erase(Glob2LocMap.find(k));
+                            }
+                            Glob2LocMap[k]=(unsigned int)Loc2GlobVec.size()-1;
+                        }
+                    }
+                }
+            }
+
+            to_tstm->addQuadsProcess(quads_to_create) ;
+            to_tstm->addQuadsWarning(quads_to_create.size(), quads_to_create, quadsIndexList) ;
+
+            break;
+        }
+
+        case core::topology::POINTSREMOVED:
+        {
+            const sofa::helper::vector<unsigned int> tab = ( static_cast< const sofa::component::topology::PointsRemoved * >( *itBegin ) )->getArray();
+
+            sofa::helper::vector<unsigned int> indices;
+
+            for(unsigned int i = 0; i < tab.size(); ++i)
+            {
+                indices.push_back(tab[i]);
+            }
+
+            sofa::helper::vector<unsigned int>& tab_indices = indices;
+
+            to_tstm->removePointsWarning(tab_indices, false);
+            to_tstm->propagateTopologicalChanges();
+            to_tstm->removePointsProcess(tab_indices, false);
+
+            break;
+        }
+
+        case core::topology::POINTSRENUMBERING:
+        {
+            const sofa::helper::vector<unsigned int> &tab = ( static_cast< const PointsRenumbering * >( *itBegin ) )->getIndexArray();
+            const sofa::helper::vector<unsigned int> &inv_tab = ( static_cast< const PointsRenumbering * >( *itBegin ) )->getinv_IndexArray();
+
+            sofa::helper::vector<unsigned int> indices;
+            sofa::helper::vector<unsigned int> inv_indices;
+
+            for(unsigned int i = 0; i < tab.size(); ++i)
+            {
+                indices.push_back(tab[i]);
+                inv_indices.push_back(inv_tab[i]);
+            }
+
+            sofa::helper::vector<unsigned int>& tab_indices = indices;
+            sofa::helper::vector<unsigned int>& inv_tab_indices = inv_indices;
+
+            to_tstm->renumberPointsWarning(tab_indices, inv_tab_indices, false);
+            to_tstm->propagateTopologicalChanges();
+            to_tstm->renumberPointsProcess(tab_indices, inv_tab_indices, false);
+
+            break;
+        }
+
+        default:
+            // Ignore events that are not Quad  related.
+            break;
+        };
+
+        sofa::helper::AdvancedTimer::stepEnd(topoChangeType);
+        ++itBegin;
+    }
+    to_tstm->propagateTopologicalChanges();
+    Loc2GlobDataVec.endEdit();
+
+    sofa::helper::AdvancedTimer::stepEnd("Update Hexa2QuadTopologicalMapping");
 }
 
 } // namespace topology

--- a/modules/SofaTopologyMapping/Hexa2TetraTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/Hexa2TetraTopologicalMapping.cpp
@@ -70,135 +70,147 @@ Hexa2TetraTopologicalMapping::~Hexa2TetraTopologicalMapping()
 }
 
 void Hexa2TetraTopologicalMapping::init()
-{
-    //sout << "INFO_print : init Hexa2TetraTopologicalMapping" << sendl;
-
+{    
     // INITIALISATION of TETRAHEDRAL mesh from HEXAHEDRAL mesh :
 
-    if (fromModel)
+    // recheck models
+    bool modelsOk = true;
+    if (!fromModel)
     {
-
-        sout << "INFO_print : Hexa2TetraTopologicalMapping - from = hexa" << sendl;
-
-        if (toModel)
-        {
-
-            sout << "INFO_print : Hexa2TetraTopologicalMapping - to = tetra" << sendl;
-
-            TetrahedronSetTopologyContainer *to_tstc;
-            toModel->getContext()->get(to_tstc);
-            to_tstc->clear();
-
-            toModel->setNbPoints(fromModel->getNbPoints());
-
-            TetrahedronSetTopologyModifier *to_tstm;
-            toModel->getContext()->get(to_tstm);
-
-            sofa::helper::vector <unsigned int>& Loc2GlobVec = *(Loc2GlobDataVec.beginEdit());
-
-            Loc2GlobVec.clear();
-            Glob2LocMap.clear();
-
-            size_t nbcubes = fromModel->getNbHexahedra();
-
-            // These values are only correct if the mesh is a grid topology
-            int nx = 2;
-            int ny = 1;
-            //int nz = 1;
-            {
-                topology::GridTopology* grid = dynamic_cast<topology::GridTopology*>(fromModel.get());
-                if (grid != NULL)
-                {
-                    nx = grid->getNx()-1;
-                    ny = grid->getNy()-1;
-                    //nz = grid->getNz()-1;
-                }
-            }
-
-            // Tesselation of each cube into 6 tetrahedra
-            for (size_t i=0; i<nbcubes; i++)
-            {
-                core::topology::BaseMeshTopology::Hexa c = fromModel->getHexahedron(i);
-#define swap(a,b) { int t = a; a = b; b = t; }
-                // TODO : swap indexes where needed (currently crash in TriangleSetContainer)
-                bool swapped = false;
-
-                if(swapping.getValue())
-                {
-                    if (!((i%nx)&1))
-                    {
-                        // swap all points on the X edges
-                        swap(c[0],c[1]);
-                        swap(c[3],c[2]);
-                        swap(c[4],c[5]);
-                        swap(c[7],c[6]);
-                        swapped = !swapped;
-                    }
-                    if (((i/nx)%ny)&1)
-                    {
-                        // swap all points on the Y edges
-                        swap(c[0],c[3]);
-                        swap(c[1],c[2]);
-                        swap(c[4],c[7]);
-                        swap(c[5],c[6]);
-                        swapped = !swapped;
-                    }
-                    if ((i/(nx*ny))&1)
-                    {
-                        // swap all points on the Z edges
-                        swap(c[0],c[4]);
-                        swap(c[1],c[5]);
-                        swap(c[2],c[6]);
-                        swap(c[3],c[7]);
-                        swapped = !swapped;
-                    }
-                }
-#undef swap
-                typedef core::topology::BaseMeshTopology::Tetra Tetra;
-
-                if(!swapped)
-                {
-                    to_tstm->addTetrahedronProcess(Tetra(c[0],c[5],c[1],c[6]));
-                    to_tstm->addTetrahedronProcess(Tetra(c[0],c[1],c[3],c[6]));
-                    to_tstm->addTetrahedronProcess(Tetra(c[1],c[3],c[6],c[2]));
-                    to_tstm->addTetrahedronProcess(Tetra(c[6],c[3],c[0],c[7]));
-                    to_tstm->addTetrahedronProcess(Tetra(c[6],c[7],c[0],c[5]));
-                    to_tstm->addTetrahedronProcess(Tetra(c[7],c[5],c[4],c[0]));
-                }
-                else
-                {
-                    to_tstm->addTetrahedronProcess(Tetra(c[0],c[5],c[6],c[1]));
-                    to_tstm->addTetrahedronProcess(Tetra(c[0],c[1],c[6],c[3]));
-                    to_tstm->addTetrahedronProcess(Tetra(c[1],c[3],c[2],c[6]));
-                    to_tstm->addTetrahedronProcess(Tetra(c[6],c[3],c[7],c[0]));
-                    to_tstm->addTetrahedronProcess(Tetra(c[6],c[7],c[5],c[0]));
-                    to_tstm->addTetrahedronProcess(Tetra(c[7],c[5],c[0],c[4]));
-                }
-                for(int j=0; j<6; j++)
-                    Loc2GlobVec.push_back(i);
-                Glob2LocMap[i] = (unsigned int)Loc2GlobVec.size()-1;
-            }
-
-            //to_tstm->propagateTopologicalChanges();
-            to_tstm->notifyEndingEvent();
-            //to_tstm->propagateTopologicalChanges();
-            Loc2GlobDataVec.endEdit();
-
-            // Need to fully init the target topology
-            toModel->init();
-        }
-
+        msg_error() << "Pointer to input topology is invalid.";
+        modelsOk = false;
     }
+
+    if (!toModel)
+    {
+        msg_error() << "Pointer to output topology is invalid.";
+        modelsOk = false;
+    }
+    else
+    {
+        TetrahedronSetTopologyModifier *to_tstm;
+        toModel->getContext()->get(to_tstm);
+        if (!to_tstm)
+        {
+            msg_error() << "No TetrahedronSetTopologyModifier found in the Tetrahedron topology Node.";
+            modelsOk = false;
+        }
+    }
+
+    if (!modelsOk)
+    {
+        this->m_componentstate = sofa::core::objectmodel::ComponentState::Invalid;
+        return;
+    }
+
+    TetrahedronSetTopologyContainer *to_tstc;
+    toModel->getContext()->get(to_tstc);
+    // Clear output topology
+    to_tstc->clear();
+
+    // Set the same number of points
+    toModel->setNbPoints(fromModel->getNbPoints());
+
+    sofa::helper::vector <unsigned int>& Loc2GlobVec = *(Loc2GlobDataVec.beginEdit());
+
+    Loc2GlobVec.clear();
+    Glob2LocMap.clear();
+
+    size_t nbcubes = fromModel->getNbHexahedra();
+
+    // These values are only correct if the mesh is a grid topology
+    int nx = 2;
+    int ny = 1;
+    //int nz = 1;
+    {
+        topology::GridTopology* grid = dynamic_cast<topology::GridTopology*>(fromModel.get());
+        if (grid != NULL)
+        {
+            nx = grid->getNx()-1;
+            ny = grid->getNy()-1;
+            //nz = grid->getNz()-1;
+        }
+    }
+
+    // Tesselation of each cube into 6 tetrahedra
+    for (size_t i=0; i<nbcubes; i++)
+    {
+        core::topology::BaseMeshTopology::Hexa c = fromModel->getHexahedron(i);
+#define swap(a,b) { int t = a; a = b; b = t; }
+        // TODO : swap indexes where needed (currently crash in TriangleSetContainer)
+        bool swapped = false;
+
+        if(swapping.getValue())
+        {
+            if (!((i%nx)&1))
+            {
+                // swap all points on the X edges
+                swap(c[0],c[1]);
+                swap(c[3],c[2]);
+                swap(c[4],c[5]);
+                swap(c[7],c[6]);
+                swapped = !swapped;
+            }
+            if (((i/nx)%ny)&1)
+            {
+                // swap all points on the Y edges
+                swap(c[0],c[3]);
+                swap(c[1],c[2]);
+                swap(c[4],c[7]);
+                swap(c[5],c[6]);
+                swapped = !swapped;
+            }
+            if ((i/(nx*ny))&1)
+            {
+                // swap all points on the Z edges
+                swap(c[0],c[4]);
+                swap(c[1],c[5]);
+                swap(c[2],c[6]);
+                swap(c[3],c[7]);
+                swapped = !swapped;
+            }
+        }
+#undef swap
+        if(!swapped)
+        {
+            to_tstc->addTetra(c[0],c[5],c[1],c[6]);
+            to_tstc->addTetra(c[0],c[1],c[3],c[6]);
+            to_tstc->addTetra(c[1],c[3],c[6],c[2]);
+            to_tstc->addTetra(c[6],c[3],c[0],c[7]);
+            to_tstc->addTetra(c[6],c[7],c[0],c[5]);
+            to_tstc->addTetra(c[7],c[5],c[4],c[0]);
+        }
+        else
+        {
+            to_tstc->addTetra(c[0],c[5],c[6],c[1]);
+            to_tstc->addTetra(c[0],c[1],c[6],c[3]);
+            to_tstc->addTetra(c[1],c[3],c[2],c[6]);
+            to_tstc->addTetra(c[6],c[3],c[7],c[0]);
+            to_tstc->addTetra(c[6],c[7],c[5],c[0]);
+            to_tstc->addTetra(c[7],c[5],c[0],c[4]);
+        }
+        for(int j=0; j<6; j++)
+            Loc2GlobVec.push_back(i);
+        Glob2LocMap[i] = (unsigned int)Loc2GlobVec.size()-1;
+    }
+
+    Loc2GlobDataVec.endEdit();
+
+    // Need to fully init the target topology
+    toModel->init();
+
+    this->m_componentstate = sofa::core::objectmodel::ComponentState::Valid;
 }
 
 unsigned int Hexa2TetraTopologicalMapping::getFromIndex(unsigned int /*ind*/)
 {
 
-    return 0;
+    return Topology::InvalidID;
 }
 
 void Hexa2TetraTopologicalMapping::updateTopologicalMappingTopDown()
 {
+    msg_warning() << "Method Hexa2TetraTopologicalMapping::updateTopologicalMappingTopDown() not yet implemented!";
 // TODO...
 }
 

--- a/modules/SofaTopologyMapping/Quad2TriangleTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/Quad2TriangleTopologicalMapping.cpp
@@ -436,12 +436,13 @@ void Quad2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
             break;
         };
 
+        sofa::helper::AdvancedTimer::stepEnd(topoChangeType);
         ++itBegin;
     }
     to_tstm->propagateTopologicalChanges();
     Loc2GlobDataVec.endEdit();
 
-    return;
+    sofa::helper::AdvancedTimer::stepEnd("Update Quad2TriangleTopologicalMapping");
 }
 
 

--- a/modules/SofaTopologyMapping/Quad2TriangleTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/Quad2TriangleTopologicalMapping.cpp
@@ -36,7 +36,7 @@
 #include <sofa/defaulttype/Vec.h>
 #include <map>
 #include <sofa/defaulttype/VecTypes.h>
-
+#include <sofa/helper/AdvancedTimer.h>
 
 namespace sofa
 {
@@ -76,97 +76,114 @@ Quad2TriangleTopologicalMapping::~Quad2TriangleTopologicalMapping()
 
 void Quad2TriangleTopologicalMapping::init()
 {
-    //sout << "INFO_print : init Quad2TriangleTopologicalMapping" << sendl;
-
     // INITIALISATION of TRIANGULAR mesh from QUADULAR mesh :
 
-    if (fromModel)
+    // recheck models
+    bool modelsOk = true;
+    if (!fromModel)
     {
+        msg_error() << "Pointer to input topology is invalid.";
+        modelsOk = false;
+    }
 
-        sout << "INFO_print : Quad2TriangleTopologicalMapping - from = quad" << sendl;
-
-        if (toModel)
+    if (!toModel)
+    {
+        msg_error() << "Pointer to output topology is invalid.";
+        modelsOk = false;
+    }
+    else
+    {
+        TriangleSetTopologyModifier *to_tstm;
+        toModel->getContext()->get(to_tstm);
+        if (!to_tstm)
         {
+            msg_error() << "No TriangleSetTopologyModifier found in the Triangle topology Node.";
+            modelsOk = false;
+        }
+    }
 
-            sout << "INFO_print : Quad2TriangleTopologicalMapping - to = triangle" << sendl;
-
-            TriangleSetTopologyContainer *to_tstc;
-            toModel->getContext()->get(to_tstc);
-            to_tstc->clear();
-
-            toModel->setNbPoints(fromModel->getNbPoints());
-
-            TriangleSetTopologyModifier *to_tstm;
-            toModel->getContext()->get(to_tstm);
-
-            const sofa::helper::vector<core::topology::BaseMeshTopology::Quad> &quadArray=fromModel->getQuads();
-
-            sofa::helper::vector <unsigned int>& Loc2GlobVec = *(Loc2GlobDataVec.beginEdit());
-
-            Loc2GlobVec.clear();
-            In2OutMap.clear();
-
-            // These values are only correct if the mesh is a grid topology
-            int nx = 2;
-            int ny = 1;
-            //int nz = 1;
-
-            {
-                topology::GridTopology* grid = dynamic_cast<topology::GridTopology*>(fromModel.get());
-                if (grid != NULL)
-                {
-                    nx = grid->getNx()-1;
-                    ny = grid->getNy()-1;
-                    //nz = grid->getNz()-1;
-                }
-            }
-
-            int scale = nx;
-
-            if (nx == 0)
-                scale = ny;
-
-            if (nx == 0 && ny == 0)
-            {
-                serr<<"Error: Input topology is only 1D, this topology can't be mapped into a triangulation." <<sendl;
-                return;
-            }
+    if (!modelsOk)
+    {
+        this->m_componentstate = sofa::core::objectmodel::ComponentState::Invalid;
+        return;
+    }
 
 
-            for (unsigned int i=0; i<quadArray.size(); ++i)
-            {
-                unsigned int p0 = quadArray[i][0];
-                unsigned int p1 = quadArray[i][1];
-                unsigned int p2 = quadArray[i][2];
-                unsigned int p3 = quadArray[i][3];
-                if (((i%scale) ^ (i/scale)) & 1)
-                {
-                    to_tstc->addTriangle(p0, p1, p3);
-                    to_tstc->addTriangle(p2, p3, p1);
-                }
-                else
-                {
-                    to_tstc->addTriangle(p1, p2, p0);
-                    to_tstc->addTriangle(p3, p0, p2);
-                }
+    TriangleSetTopologyContainer *to_tstc;
+    toModel->getContext()->get(to_tstc);
+    // Clear output topology
+    to_tstc->clear();
 
-                Loc2GlobVec.push_back(i);
-                Loc2GlobVec.push_back(i);
-                sofa::helper::vector<unsigned int> out_info;
-                out_info.push_back((unsigned int)Loc2GlobVec.size()-2);
-                out_info.push_back((unsigned int)Loc2GlobVec.size()-1);
-                In2OutMap[i]=out_info;
-            }
+    // Set the same number of points
+    toModel->setNbPoints(fromModel->getNbPoints());
 
-            // Need to fully init the target topology
-            to_tstc->init();
 
-            //to_tstm->propagateTopologicalChanges();
-            Loc2GlobDataVec.endEdit();
+    const sofa::helper::vector<core::topology::BaseMeshTopology::Quad> &quadArray=fromModel->getQuads();
+    sofa::helper::vector <unsigned int>& Loc2GlobVec = *(Loc2GlobDataVec.beginEdit());
 
+    Loc2GlobVec.clear();
+    In2OutMap.clear();
+
+    // These values are only correct if the mesh is a grid topology
+    int nx = 2;
+    int ny = 1;
+    //int nz = 1;
+
+    {
+        topology::GridTopology* grid = dynamic_cast<topology::GridTopology*>(fromModel.get());
+        if (grid != NULL)
+        {
+            nx = grid->getNx()-1;
+            ny = grid->getNy()-1;
+            //nz = grid->getNz()-1;
+        }
+    }
+
+    int scale = nx;
+
+    if (nx == 0)
+        scale = ny;
+
+    if (nx == 0 && ny == 0)
+    {
+        msg_error() << "Input topology is only 1D, this topology can't be mapped into a triangulation.";
+        this->m_componentstate = sofa::core::objectmodel::ComponentState::Invalid;
+        return;
+    }
+
+
+    for (unsigned int i=0; i<quadArray.size(); ++i)
+    {
+        unsigned int p0 = quadArray[i][0];
+        unsigned int p1 = quadArray[i][1];
+        unsigned int p2 = quadArray[i][2];
+        unsigned int p3 = quadArray[i][3];
+        if (((i%scale) ^ (i/scale)) & 1)
+        {
+            to_tstc->addTriangle(p0, p1, p3);
+            to_tstc->addTriangle(p2, p3, p1);
+        }
+        else
+        {
+            to_tstc->addTriangle(p1, p2, p0);
+            to_tstc->addTriangle(p3, p0, p2);
         }
 
+        Loc2GlobVec.push_back(i);
+        Loc2GlobVec.push_back(i);
+        sofa::helper::vector<unsigned int> out_info;
+        out_info.push_back((unsigned int)Loc2GlobVec.size()-2);
+        out_info.push_back((unsigned int)Loc2GlobVec.size()-1);
+        In2OutMap[i]=out_info;
     }
+
+    // Need to fully init the target topology
+    to_tstc->init();
+
+    //to_tstm->propagateTopologicalChanges();
+    Loc2GlobDataVec.endEdit();
+
+    this->m_componentstate = sofa::core::objectmodel::ComponentState::Valid;
 }
 
 unsigned int Quad2TriangleTopologicalMapping::getFromIndex(unsigned int ind)
@@ -177,281 +194,252 @@ unsigned int Quad2TriangleTopologicalMapping::getFromIndex(unsigned int ind)
 void Quad2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
 {
 
-    // INITIALISATION of TRIANGULAR mesh from QUADULAR mesh :
+    if (this->m_componentstate != sofa::core::objectmodel::ComponentState::Valid)
+        return;
 
-    if (fromModel)
+    sofa::helper::AdvancedTimer::stepBegin("Update Quad2TriangleTopologicalMapping");
+
+    TriangleSetTopologyModifier *to_tstm;
+    toModel->getContext()->get(to_tstm);
+
+    std::list<const TopologyChange *>::const_iterator itBegin=fromModel->beginChange();
+    std::list<const TopologyChange *>::const_iterator itEnd=fromModel->endChange();
+
+    sofa::helper::vector <unsigned int>& Loc2GlobVec = *(Loc2GlobDataVec.beginEdit());
+
+    while( itBegin != itEnd )
     {
+        TopologyChangeType changeType = (*itBegin)->getChangeType();
+        std::string topoChangeType = "Tetra2TriangleTopologicalMapping - " + parseTopologyChangeTypeToString(changeType);
+        sofa::helper::AdvancedTimer::stepBegin(topoChangeType);
 
-        TriangleSetTopologyModifier *to_tstm;
-        toModel->getContext()->get(to_tstm);
-
-        if (toModel)
+        switch( changeType )
         {
 
-            std::list<const TopologyChange *>::const_iterator itBegin=fromModel->beginChange();
-            std::list<const TopologyChange *>::const_iterator itEnd=fromModel->endChange();
-
-            sofa::helper::vector <unsigned int>& Loc2GlobVec = *(Loc2GlobDataVec.beginEdit());
-
-            while( itBegin != itEnd )
-            {
-                TopologyChangeType changeType = (*itBegin)->getChangeType();
-
-                switch( changeType )
-                {
-
-                case core::topology::ENDING_EVENT:
-                {
-                    //sout << "INFO_print : TopologicalMapping - ENDING_EVENT" << sendl;
-                    to_tstm->propagateTopologicalChanges();
-                    to_tstm->notifyEndingEvent();
-                    to_tstm->propagateTopologicalChanges();
-                    break;
-                }
-
-                case core::topology::QUADSADDED:
-                {
-                    //sout << "INFO_print : TopologicalMapping - QUADSADDED" << sendl;
-                    if (fromModel)
-                    {
-
-                        const sofa::helper::vector<core::topology::BaseMeshTopology::Quad> &quadArray=fromModel->getQuads();
-
-                        const sofa::helper::vector<unsigned int> &tab = ( static_cast< const QuadsAdded *>( *itBegin ) )->getArray();
-
-                        sofa::helper::vector< core::topology::BaseMeshTopology::Triangle > triangles_to_create;
-                        sofa::helper::vector< unsigned int > trianglesIndexList;
-                        unsigned int nb_elems = (unsigned int)toModel->getNbTriangles();
-
-                        for (unsigned int i = 0; i < tab.size(); ++i)
-                        {
-                            unsigned int k = tab[i];
-
-                            unsigned int p0 = quadArray[k][0];
-                            unsigned int p1 = quadArray[k][1];
-                            unsigned int p2 = quadArray[k][2];
-                            unsigned int p3 = quadArray[k][3];
-                            core::topology::BaseMeshTopology::Triangle t1 = core::topology::BaseMeshTopology::Triangle((unsigned int) p0, (unsigned int) p1, (unsigned int) p2);
-                            core::topology::BaseMeshTopology::Triangle t2 = core::topology::BaseMeshTopology::Triangle((unsigned int) p0, (unsigned int) p2, (unsigned int) p3);
-
-                            triangles_to_create.push_back(t1);
-                            trianglesIndexList.push_back(nb_elems);
-                            triangles_to_create.push_back(t2);
-                            trianglesIndexList.push_back(nb_elems+1);
-                            nb_elems+=2;
-
-                            Loc2GlobVec.push_back(k);
-                            Loc2GlobVec.push_back(k);
-                            sofa::helper::vector<unsigned int> out_info;
-                            out_info.push_back((unsigned int)Loc2GlobVec.size()-2);
-                            out_info.push_back((unsigned int)Loc2GlobVec.size()-1);
-                            In2OutMap[k]=out_info;
-
-                        }
-
-                        to_tstm->addTrianglesProcess(triangles_to_create) ;
-                        to_tstm->addTrianglesWarning(triangles_to_create.size(), triangles_to_create, trianglesIndexList) ;
-                        to_tstm->propagateTopologicalChanges();
-                    }
-                    break;
-                }
-                case core::topology::QUADSREMOVED:
-                {
-                    //sout << "INFO_print : TopologicalMapping - QUADSREMOVED" << sendl;
-
-                    if (fromModel)
-                    {
-
-                        const sofa::helper::vector<unsigned int> &tab = ( static_cast< const QuadsRemoved *>( *itBegin ) )->getArray();
-
-                        unsigned int last = (unsigned int)fromModel->getNbQuads() - 1;
-
-                        int ind_tmp;
-
-                        sofa::helper::vector<unsigned int> ind_real_last;
-                        unsigned int ind_last = (unsigned int)toModel->getNbTriangles();
-
-                        for (unsigned int i = 0; i < tab.size(); ++i)
-                        {
-                            //sout << "INFO_print : Quad2TriangleTopologicalMapping - remove quad " << tab[i] << sendl;
-
-                            unsigned int k = tab[i];
-                            sofa::helper::vector<unsigned int> ind_k;
-
-                            std::map<unsigned int, sofa::helper::vector<unsigned int> >::iterator iter_1 = In2OutMap.find(k);
-                            if(iter_1 != In2OutMap.end())
-                            {
-
-                                unsigned int t1 = In2OutMap[k][0];
-                                unsigned int t2 = In2OutMap[k][1];
-
-                                ind_last = ind_last - 1;
-
-                                ind_k = In2OutMap[k];
-                                ind_real_last = ind_k;
-
-                                std::map<unsigned int, sofa::helper::vector<unsigned int> >::iterator iter_2 = In2OutMap.find(last);
-                                if(iter_2 != In2OutMap.end())
-                                {
-
-                                    ind_real_last = In2OutMap[last];
-
-                                    if (k != last)
-                                    {
-
-                                        In2OutMap.erase(In2OutMap.find(k));
-                                        In2OutMap[k] = ind_real_last;
-
-                                        In2OutMap.erase(In2OutMap.find(last));
-                                        In2OutMap[last] = ind_k;
-
-                                        ind_tmp = Loc2GlobVec[ind_real_last[0]];
-                                        Loc2GlobVec[ind_real_last[0]] = Loc2GlobVec[ind_k[0]];
-                                        Loc2GlobVec[ind_k[0]] = ind_tmp;
-
-                                        ind_tmp = Loc2GlobVec[ind_real_last[1]];
-                                        Loc2GlobVec[ind_real_last[1]] = Loc2GlobVec[ind_k[1]];
-                                        Loc2GlobVec[ind_k[1]] = ind_tmp;
-                                    }
-                                }
-                                else
-                                {
-                                    sout << "INFO_print : Quad2TriangleTopologicalMapping - In2OutMap should have the quad " << last << sendl;
-                                }
-
-                                if (ind_k[1] != ind_last)
-                                {
-
-                                    In2OutMap.erase(In2OutMap.find(Loc2GlobVec[ind_last]));
-                                    In2OutMap[Loc2GlobVec[ind_last]] = ind_k;
-
-                                    sofa::helper::vector<unsigned int> out_info;
-                                    out_info.push_back(ind_last);
-                                    out_info.push_back(ind_last-1);
-
-                                    In2OutMap.erase(In2OutMap.find(Loc2GlobVec[ind_k[1]]));
-                                    In2OutMap[Loc2GlobVec[ind_k[1]]] = out_info;
-
-                                    ind_tmp = Loc2GlobVec[ind_k[1]];
-                                    Loc2GlobVec[ind_k[1]] = Loc2GlobVec[ind_last];
-                                    Loc2GlobVec[ind_last] = ind_tmp;
-
-                                }
-
-                                ind_last = ind_last-1;
-
-                                if (ind_k[0] != ind_last)
-                                {
-
-                                    ind_tmp = Loc2GlobVec[ind_k[0]];
-                                    Loc2GlobVec[ind_k[0]] = Loc2GlobVec[ind_last];
-                                    Loc2GlobVec[ind_last] = ind_tmp;
-
-                                }
-
-                                In2OutMap.erase(In2OutMap.find(Loc2GlobVec[Loc2GlobVec.size() - 1]));
-
-                                Loc2GlobVec.resize( Loc2GlobVec.size() - 2 );
-
-                                sofa::helper::vector< unsigned int > triangles_to_remove;
-                                triangles_to_remove.push_back(t1);
-                                triangles_to_remove.push_back(t2);
-
-                                to_tstm->removeTriangles(triangles_to_remove, true, false);
-
-                            }
-                            else
-                            {
-                                sout << "INFO_print : Quad2TriangleTopologicalMapping - In2OutMap should have the quad " << k << sendl;
-                            }
-
-                            --last;
-                        }
-                    }
-
-                    break;
-                }
-
-                case core::topology::POINTSREMOVED:
-                {
-                    //sout << "INFO_print : TopologicalMapping - POINTSREMOVED" << sendl;
-
-                    const sofa::helper::vector<unsigned int> tab = ( static_cast< const sofa::component::topology::PointsRemoved * >( *itBegin ) )->getArray();
-
-                    sofa::helper::vector<unsigned int> indices;
-
-                    for(unsigned int i = 0; i < tab.size(); ++i)
-                    {
-
-                        //sout << "INFO_print : Quad2TriangleTopologicalMapping - point = " << tab[i] << sendl;
-                        indices.push_back(tab[i]);
-                    }
-
-                    sofa::helper::vector<unsigned int>& tab_indices = indices;
-
-                    to_tstm->removePointsWarning(tab_indices, false);
-                    to_tstm->propagateTopologicalChanges();
-                    to_tstm->removePointsProcess(tab_indices, false);
-
-                    break;
-                }
-
-
-                case core::topology::POINTSRENUMBERING:
-                {
-                    //sout << "INFO_print : Hexa2QuadTopologicalMapping - POINTSREMOVED" << sendl;
-
-                    const sofa::helper::vector<unsigned int> &tab = ( static_cast< const PointsRenumbering * >( *itBegin ) )->getIndexArray();
-                    const sofa::helper::vector<unsigned int> &inv_tab = ( static_cast< const PointsRenumbering * >( *itBegin ) )->getinv_IndexArray();
-
-                    sofa::helper::vector<unsigned int> indices;
-                    sofa::helper::vector<unsigned int> inv_indices;
-
-                    for(unsigned int i = 0; i < tab.size(); ++i)
-                    {
-
-                        //sout << "INFO_print : Hexa2QuadTopologicalMapping - point = " << tab[i] << sendl;
-                        indices.push_back(tab[i]);
-                        inv_indices.push_back(inv_tab[i]);
-                    }
-
-                    sofa::helper::vector<unsigned int>& tab_indices = indices;
-                    sofa::helper::vector<unsigned int>& inv_tab_indices = inv_indices;
-
-                    to_tstm->renumberPointsWarning(tab_indices, inv_tab_indices, false);
-                    to_tstm->propagateTopologicalChanges();
-                    to_tstm->renumberPointsProcess(tab_indices, inv_tab_indices, false);
-
-                    break;
-                }
-
-
-                case core::topology::POINTSADDED:
-                {
-                    //sout << "INFO_print : Quad2TriangleTopologicalMapping - POINTSADDED" << sendl;
-
-                    const sofa::component::topology::PointsAdded *ta=static_cast< const sofa::component::topology::PointsAdded * >( *itBegin );
-
-                    to_tstm->addPointsProcess(ta->getNbAddedVertices());
-                    to_tstm->addPointsWarning(ta->getNbAddedVertices(), ta->ancestorsList, ta->coefs, false);
-                    to_tstm->propagateTopologicalChanges();
-
-                    break;
-                }
-
-
-
-                default:
-                    // Ignore events that are not Triangle  related.
-                    break;
-                };
-
-                ++itBegin;
-            }
+        case core::topology::ENDING_EVENT:
+        {
             to_tstm->propagateTopologicalChanges();
-            Loc2GlobDataVec.endEdit();
+            to_tstm->notifyEndingEvent();
+            to_tstm->propagateTopologicalChanges();
+            break;
         }
+
+        case core::topology::QUADSADDED:
+        {
+            const sofa::helper::vector<core::topology::BaseMeshTopology::Quad> &quadArray=fromModel->getQuads();
+
+            const sofa::helper::vector<unsigned int> &tab = ( static_cast< const QuadsAdded *>( *itBegin ) )->getArray();
+
+            sofa::helper::vector< core::topology::BaseMeshTopology::Triangle > triangles_to_create;
+            sofa::helper::vector< unsigned int > trianglesIndexList;
+            unsigned int nb_elems = (unsigned int)toModel->getNbTriangles();
+
+            for (unsigned int i = 0; i < tab.size(); ++i)
+            {
+                unsigned int k = tab[i];
+
+                unsigned int p0 = quadArray[k][0];
+                unsigned int p1 = quadArray[k][1];
+                unsigned int p2 = quadArray[k][2];
+                unsigned int p3 = quadArray[k][3];
+                core::topology::BaseMeshTopology::Triangle t1 = core::topology::BaseMeshTopology::Triangle((unsigned int) p0, (unsigned int) p1, (unsigned int) p2);
+                core::topology::BaseMeshTopology::Triangle t2 = core::topology::BaseMeshTopology::Triangle((unsigned int) p0, (unsigned int) p2, (unsigned int) p3);
+
+                triangles_to_create.push_back(t1);
+                trianglesIndexList.push_back(nb_elems);
+                triangles_to_create.push_back(t2);
+                trianglesIndexList.push_back(nb_elems+1);
+                nb_elems+=2;
+
+                Loc2GlobVec.push_back(k);
+                Loc2GlobVec.push_back(k);
+                sofa::helper::vector<unsigned int> out_info;
+                out_info.push_back((unsigned int)Loc2GlobVec.size()-2);
+                out_info.push_back((unsigned int)Loc2GlobVec.size()-1);
+                In2OutMap[k]=out_info;
+
+            }
+
+            to_tstm->addTrianglesProcess(triangles_to_create) ;
+            to_tstm->addTrianglesWarning(triangles_to_create.size(), triangles_to_create, trianglesIndexList) ;
+            to_tstm->propagateTopologicalChanges();
+            break;
+        }
+        case core::topology::QUADSREMOVED:
+        {
+            const sofa::helper::vector<unsigned int> &tab = ( static_cast< const QuadsRemoved *>( *itBegin ) )->getArray();
+
+            unsigned int last = (unsigned int)fromModel->getNbQuads() - 1;
+
+            int ind_tmp;
+
+            sofa::helper::vector<unsigned int> ind_real_last;
+            unsigned int ind_last = (unsigned int)toModel->getNbTriangles();
+
+            for (unsigned int i = 0; i < tab.size(); ++i)
+            {
+                //sout << "INFO_print : Quad2TriangleTopologicalMapping - remove quad " << tab[i] << sendl;
+
+                unsigned int k = tab[i];
+                sofa::helper::vector<unsigned int> ind_k;
+
+                std::map<unsigned int, sofa::helper::vector<unsigned int> >::iterator iter_1 = In2OutMap.find(k);
+                if(iter_1 != In2OutMap.end())
+                {
+
+                    unsigned int t1 = In2OutMap[k][0];
+                    unsigned int t2 = In2OutMap[k][1];
+
+                    ind_last = ind_last - 1;
+
+                    ind_k = In2OutMap[k];
+                    ind_real_last = ind_k;
+
+                    std::map<unsigned int, sofa::helper::vector<unsigned int> >::iterator iter_2 = In2OutMap.find(last);
+                    if(iter_2 != In2OutMap.end())
+                    {
+
+                        ind_real_last = In2OutMap[last];
+
+                        if (k != last)
+                        {
+
+                            In2OutMap.erase(In2OutMap.find(k));
+                            In2OutMap[k] = ind_real_last;
+
+                            In2OutMap.erase(In2OutMap.find(last));
+                            In2OutMap[last] = ind_k;
+
+                            ind_tmp = Loc2GlobVec[ind_real_last[0]];
+                            Loc2GlobVec[ind_real_last[0]] = Loc2GlobVec[ind_k[0]];
+                            Loc2GlobVec[ind_k[0]] = ind_tmp;
+
+                            ind_tmp = Loc2GlobVec[ind_real_last[1]];
+                            Loc2GlobVec[ind_real_last[1]] = Loc2GlobVec[ind_k[1]];
+                            Loc2GlobVec[ind_k[1]] = ind_tmp;
+                        }
+                    }
+                    else
+                    {
+                        sout << "INFO_print : Quad2TriangleTopologicalMapping - In2OutMap should have the quad " << last << sendl;
+                    }
+
+                    if (ind_k[1] != ind_last)
+                    {
+
+                        In2OutMap.erase(In2OutMap.find(Loc2GlobVec[ind_last]));
+                        In2OutMap[Loc2GlobVec[ind_last]] = ind_k;
+
+                        sofa::helper::vector<unsigned int> out_info;
+                        out_info.push_back(ind_last);
+                        out_info.push_back(ind_last-1);
+
+                        In2OutMap.erase(In2OutMap.find(Loc2GlobVec[ind_k[1]]));
+                        In2OutMap[Loc2GlobVec[ind_k[1]]] = out_info;
+
+                        ind_tmp = Loc2GlobVec[ind_k[1]];
+                        Loc2GlobVec[ind_k[1]] = Loc2GlobVec[ind_last];
+                        Loc2GlobVec[ind_last] = ind_tmp;
+
+                    }
+
+                    ind_last = ind_last-1;
+
+                    if (ind_k[0] != ind_last)
+                    {
+
+                        ind_tmp = Loc2GlobVec[ind_k[0]];
+                        Loc2GlobVec[ind_k[0]] = Loc2GlobVec[ind_last];
+                        Loc2GlobVec[ind_last] = ind_tmp;
+
+                    }
+
+                    In2OutMap.erase(In2OutMap.find(Loc2GlobVec[Loc2GlobVec.size() - 1]));
+
+                    Loc2GlobVec.resize( Loc2GlobVec.size() - 2 );
+
+                    sofa::helper::vector< unsigned int > triangles_to_remove;
+                    triangles_to_remove.push_back(t1);
+                    triangles_to_remove.push_back(t2);
+
+                    to_tstm->removeTriangles(triangles_to_remove, true, false);
+
+                }
+                else
+                {
+                    sout << "INFO_print : Quad2TriangleTopologicalMapping - In2OutMap should have the quad " << k << sendl;
+                }
+
+                --last;
+            }
+
+            break;
+        }
+
+        case core::topology::POINTSREMOVED:
+        {
+            const sofa::helper::vector<unsigned int> tab = ( static_cast< const sofa::component::topology::PointsRemoved * >( *itBegin ) )->getArray();
+
+            sofa::helper::vector<unsigned int> indices;
+
+            for(unsigned int i = 0; i < tab.size(); ++i)
+            {
+                indices.push_back(tab[i]);
+            }
+
+            sofa::helper::vector<unsigned int>& tab_indices = indices;
+
+            to_tstm->removePointsWarning(tab_indices, false);
+            to_tstm->propagateTopologicalChanges();
+            to_tstm->removePointsProcess(tab_indices, false);
+
+            break;
+        }
+
+
+        case core::topology::POINTSRENUMBERING:
+        {
+            const sofa::helper::vector<unsigned int> &tab = ( static_cast< const PointsRenumbering * >( *itBegin ) )->getIndexArray();
+            const sofa::helper::vector<unsigned int> &inv_tab = ( static_cast< const PointsRenumbering * >( *itBegin ) )->getinv_IndexArray();
+
+            sofa::helper::vector<unsigned int> indices;
+            sofa::helper::vector<unsigned int> inv_indices;
+
+            for(unsigned int i = 0; i < tab.size(); ++i)
+            {
+                indices.push_back(tab[i]);
+                inv_indices.push_back(inv_tab[i]);
+            }
+
+            sofa::helper::vector<unsigned int>& tab_indices = indices;
+            sofa::helper::vector<unsigned int>& inv_tab_indices = inv_indices;
+
+            to_tstm->renumberPointsWarning(tab_indices, inv_tab_indices, false);
+            to_tstm->propagateTopologicalChanges();
+            to_tstm->renumberPointsProcess(tab_indices, inv_tab_indices, false);
+
+            break;
+        }
+
+
+        case core::topology::POINTSADDED:
+        {
+            const sofa::component::topology::PointsAdded *ta=static_cast< const sofa::component::topology::PointsAdded * >( *itBegin );
+
+            to_tstm->addPointsProcess(ta->getNbAddedVertices());
+            to_tstm->addPointsWarning(ta->getNbAddedVertices(), ta->ancestorsList, ta->coefs, false);
+            to_tstm->propagateTopologicalChanges();
+
+            break;
+        }
+        default:
+            break;
+        };
+
+        ++itBegin;
     }
+    to_tstm->propagateTopologicalChanges();
+    Loc2GlobDataVec.endEdit();
 
     return;
 }

--- a/modules/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.cpp
@@ -87,12 +87,14 @@ void Tetra2TriangleTopologicalMapping::init()
         msg_error() << "Pointer to output topology is invalid.";
         modelsOk = false;
     }
-
-    toModel->getContext()->get(m_outTopoModifier);
-    if (!m_outTopoModifier)
+    else
     {
-        msg_error() << "No TriangleSetTopologyModifier found in the Edge topology Node.";
-        modelsOk = false;
+        toModel->getContext()->get(m_outTopoModifier);
+        if (!m_outTopoModifier)
+        {
+            msg_error() << "No TriangleSetTopologyModifier found in the Triangle topology Node.";
+            modelsOk = false;
+        }
     }
 
     if (!modelsOk)

--- a/modules/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.cpp
@@ -537,7 +537,23 @@ bool Tetra2TriangleTopologicalMapping::checkTopologies()
 
         itM = Glob2LocMap.find(i);
         if (itM == Glob2LocMap.end()){
-            msg_error() << "Top triangle: " << i << " -> " << tri[0] << " " << tri[1] << " " << tri[2] << " NOT FOUND";
+            msg_error() << "Top triangle: " << i << " -> " << tri[0] << " " << tri[1] << " " << tri[2] << " NOT FOUND in Glob2LocMap";
+            for (unsigned int k=0; k<triangleArray_bot.size(); k++)
+            {
+                const BaseMeshTopology::Triangle& triBot = triangleArray_bot[k];
+                int cptFound = 0;
+                for (unsigned int j=0; j<3; j++)
+                {
+                    if (triBot[j] == tri[0] || triBot[j] == tri[1] || triBot[j] == tri[2])
+                        cptFound++;
+                }
+
+                if (cptFound == 3){
+                    msg_error() << "Top triangle: " << i << " -> " << tri << " found at bottom id: " << k << " -> " << triBot << " | Loc2GlobDataVec: " << buffer[k];
+                    break;
+                }
+            }
+
             allOk = false;
             continue;
         }

--- a/modules/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.h
+++ b/modules/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.h
@@ -82,7 +82,7 @@ public:
     unsigned int getFromIndex(unsigned int ind) override;
 
     /// Method to check the topology mapping maps regarding the upper topology
-    bool checkTopologies();
+    bool checkTopologies() override;
 
 protected:
     Data<bool> flipNormals; ///< Flip Normal ? (Inverse point order when creating triangle)


### PR DESCRIPTION
Several changes from my working branch:
- **TopologicalMapping**: Add method checkTopology. Can be called from outside the component. Need to be overwritten by children. Implement only the tetra2TriangleTopologicalMapping version.
- **Quad2TriangleTopologycalMapping**, **Hexa2TetraTopologicalMapping**, **Hexa2QuadTopologicalMapping**: clean component init and model check in  methods.
- **MeshTopology**: reorder methods declaration in header for clarity.
- **EdgeSetTopologyContainer**, **TriangleSetTopologyContainer**, **TetrahedronSetTopologyContainer**: Improve checkTopology methods in container.
- **Mat**, **MatSym**: Improve invertMatrix error logs.


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
