### PR TITLE
[SofaCuda] Fix several Cuda example scenes

### DIFF
--- a/applications/plugins/SofaCUDA/examples/CudaDiagonalMass3f.scn
+++ b/applications/plugins/SofaCUDA/examples/CudaDiagonalMass3f.scn
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<Node name="lroot" gravity="0 -9.81 0" dt="0.02">
+<Node name="root" gravity="0 -9.81 0" dt="0.02">
     <RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
 	
     <Node name="Liver" gravity="0 -9.81 0">

--- a/applications/plugins/SofaCUDA/examples/CudaTetrahedronTLEDForceField.scn
+++ b/applications/plugins/SofaCUDA/examples/CudaTetrahedronTLEDForceField.scn
@@ -13,7 +13,7 @@
         <TetrahedronSetTopologyContainer name="volume" points="@../Liver_surface/stuffing.outputPoints" tetras="@../Liver_surface/stuffing.outputTetras"/>
         <MechanicalObject name="TetraLiverMO" template="CudaVec3f"/>
         <TetrahedronSetGeometryAlgorithms name="GeomAlgo" template="CudaVec3f"/>
-	<UniformMass mass="1 1 [0.0001 0 0 0 0.0001 0 0 0 0.0001]" printLog="false" totalmass="1.5" />
+	<UniformMass mass="1 1 [0.0001 0 0 0 0.0001 0 0 0 0.0001]" printLog="false" totalMass="1.5" />
         <CudaTetrahedronTLEDForceField name="FEM" youngModulus="6567" poissonRatio="0.45" isViscoelastic="0" isAnisotropic="0" preferredDirection="0 0.707 0.707"/>
 
 	<!-- Constraints -->

--- a/applications/plugins/SofaCUDA/examples/SPHFluidForceFieldCUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/SPHFluidForceFieldCUDA.scn
@@ -7,7 +7,7 @@
         <CGLinearSolver/>-->
 		<MechanicalObject name="MModel" template="CudaVec3f" />
 		<!-- A topology is used here just to set initial particles positions. It is a bad idea because this object has no real topology, but it works... -->
-		<RegularGrid
+		<RegularGridTopology
 			nx="5" ny="40" nz="5"
 			xmin="-1.5" xmax="0"
 			ymin="-3" ymax="12"

--- a/applications/plugins/SofaCUDA/examples/StandardTetrahedralFEMForceFieldCPU.scn
+++ b/applications/plugins/SofaCUDA/examples/StandardTetrahedralFEMForceFieldCPU.scn
@@ -1,8 +1,8 @@
 <Node name="root" dt="0.01">
-    <CollisionPipeline depth="6" verbose="0" draw="0" />
+    <DefaultPipeline depth="6" verbose="0" draw="0" />
     <BruteForceDetection name="N2" />
     <NewProximityIntersection name="Proximity" alarmDistance="0.3" contactDistance="0.2" />
-    <CollisionResponse name="Response" response="default" />
+    <DefaultContactManager name="Response" response="default" />
     <CollisionGroup name="Group" />
     <Node name="ChainFEM">
         <Node name="TorusFixed">
@@ -13,7 +13,7 @@
             <OglModel name="Visual" fileMesh="mesh/torus2.obj" color="gray" />
         </Node>
         <Node name="TorusTensorMass">
-            <EulerImplicit name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+            <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
             <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
             <MeshGmshLoader name="loader" filename="mesh/torus_low_res.msh" createSubelements="true"/>
             <Mesh src="@loader" />
@@ -33,7 +33,7 @@
             </Node>
         </Node>
         <Node name="TorusFEM_POLAR">
-            <EulerImplicit name="cg_odesolver" printLog="false" />
+            <EulerImplicitSolver name="cg_odesolver" printLog="false" />
             <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
             <MeshGmshLoader name="loader" filename="mesh/torus2_low_res.msh" createSubelements="true"/>
             <Mesh src="@loader" />
@@ -53,7 +53,7 @@
             </Node>
         </Node>
         <Node name="TorusFEM_SVD">
-            <EulerImplicit name="cg_odesolver" printLog="false" />
+            <EulerImplicitSolver name="cg_odesolver" printLog="false" />
             <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
             <MeshGmshLoader name="loader" filename="mesh/torus_low_res.msh" createSubelements="true"/>
             <Mesh src="@loader" />

--- a/applications/plugins/SofaCUDA/examples/StandardTetrahedralFEMForceFieldCUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/StandardTetrahedralFEMForceFieldCUDA.scn
@@ -1,9 +1,9 @@
 <Node name="root" dt="0.01">
     <RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
-    <CollisionPipeline depth="6" verbose="0" draw="0" />
+    <DefaultPipeline depth="6" verbose="0" draw="0" />
     <BruteForceDetection name="N2" />
     <NewProximityIntersection name="Proximity" alarmDistance="0.3" contactDistance="0.2" />
-    <CollisionResponse name="Response" response="default" />
+    <DefaultContactManager name="Response" response="default" />
     <CollisionGroup name="Group" />
     <Node name="ChainFEM">
         <Node name="TorusFixed">
@@ -14,7 +14,7 @@
             <OglModel name="Visual" fileMesh="mesh/torus2.obj" color="gray" />
         </Node>
         <Node name="TorusTensorMass">
-            <EulerImplicit name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+            <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
             <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
             <MeshGmshLoader name="loader" filename="mesh/torus_low_res.msh" />
             <Mesh src="@loader" />
@@ -34,7 +34,7 @@
             </Node>
         </Node>
         <Node name="TorusFEM_POLAR">
-            <EulerImplicit name="cg_odesolver" printLog="false" />
+            <EulerImplicitSolver name="cg_odesolver" printLog="false" />
             <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
             <MeshGmshLoader name="loader" filename="mesh/torus2_low_res.msh" />
             <Mesh src="@loader" />
@@ -54,7 +54,7 @@
             </Node>
         </Node>
         <Node name="TorusFEM_SVD">
-            <EulerImplicit name="cg_odesolver" printLog="false" />
+            <EulerImplicitSolver name="cg_odesolver" printLog="false" />
             <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
             <MeshGmshLoader name="loader" filename="mesh/torus_low_res.msh" />
             <Mesh src="@loader" />

--- a/applications/plugins/SofaCUDA/examples/TetrahedralTensorMassForceFieldCPU.scn
+++ b/applications/plugins/SofaCUDA/examples/TetrahedralTensorMassForceFieldCPU.scn
@@ -1,8 +1,8 @@
 <Node name="root" dt="0.01">
-    <CollisionPipeline depth="6" verbose="0" draw="0" />
+    <DefaultPipeline depth="6" verbose="0" draw="0" />
     <BruteForceDetection name="N2" />
     <NewProximityIntersection name="Proximity" alarmDistance="0.3" contactDistance="0.2" />
-    <CollisionResponse name="Response" response="default" />
+    <DefaultContactManager name="Response" response="default" />
     <CollisionGroup name="Group" />
     <Node name="ChainFEM">
         <Node name="TorusFixed">
@@ -13,7 +13,7 @@
             <OglModel name="Visual" fileMesh="mesh/torus2.obj" color="gray" />
         </Node>
         <Node name="TorusTensorMass">
-            <EulerImplicit name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+            <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
             <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
             <MeshGmshLoader name="loader" filename="mesh/torus_low_res.msh" createSubelements="true"/>
             <Mesh src="@loader" />
@@ -33,7 +33,7 @@
             </Node>
         </Node>
         <Node name="TorusFEM_POLAR">
-            <EulerImplicit name="cg_odesolver" printLog="false" />
+            <EulerImplicitSolver name="cg_odesolver" printLog="false" />
             <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
             <MeshGmshLoader name="loader" filename="mesh/torus2_low_res.msh" createSubelements="true"/>
             <Mesh src="@loader" />
@@ -53,7 +53,7 @@
             </Node>
         </Node>
         <Node name="TorusFEM_SVD">
-            <EulerImplicit name="cg_odesolver" printLog="false" />
+            <EulerImplicitSolver name="cg_odesolver" printLog="false" />
             <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
             <MeshGmshLoader name="loader" filename="mesh/torus_low_res.msh" createSubelements="true" />
             <Mesh src="@loader" />

--- a/applications/plugins/SofaCUDA/examples/TetrahedralTensorMassForceFieldCUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/TetrahedralTensorMassForceFieldCUDA.scn
@@ -1,9 +1,9 @@
 <Node name="root" dt="0.01">
     <RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
-    <CollisionPipeline depth="6" verbose="0" draw="0" />
+    <DefaultPipeline depth="6" verbose="0" draw="0" />
     <BruteForceDetection name="N2" />
     <NewProximityIntersection name="Proximity" alarmDistance="0.3" contactDistance="0.2" />
-    <CollisionResponse name="Response" response="default" />
+    <DefaultContactManager name="Response" response="default" />
     <CollisionGroup name="Group" />
     <Node name="ChainFEM">
         <Node name="TorusFixed">
@@ -14,7 +14,7 @@
             <OglModel name="Visual" fileMesh="mesh/torus2.obj" color="gray" />
         </Node>
         <Node name="TorusTensorMass">
-            <EulerImplicit name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+            <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
             <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
             <MeshGmshLoader name="loader" filename="mesh/torus_low_res.msh" />
             <Mesh src="@loader" />
@@ -34,7 +34,7 @@
             </Node>
         </Node>
         <Node name="TorusFEM_POLAR">
-            <EulerImplicit name="cg_odesolver" printLog="false" />
+            <EulerImplicitSolver name="cg_odesolver" printLog="false" />
             <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
             <MeshGmshLoader name="loader" filename="mesh/torus2_low_res.msh" />
             <Mesh src="@loader" />
@@ -54,7 +54,7 @@
             </Node>
         </Node>
         <Node name="TorusFEM_SVD">
-            <EulerImplicit name="cg_odesolver" printLog="false" />
+            <EulerImplicitSolver name="cg_odesolver" printLog="false" />
             <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
             <MeshGmshLoader name="loader" filename="mesh/torus_low_res.msh" />
             <Mesh src="@loader" />

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-fem-implicit-CPU.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-fem-implicit-CPU.scn
@@ -1,4 +1,5 @@
-<Node name="root" dt="0.04" showBehaviorModels="1" showCollisionModels="0" showMappings="0" showForceFields="0">
+<Node name="root" dt="0.04">
+	<VisualStyle displayFlags="showBehaviorModels" />
 	<DefaultPipeline verbose="0" />
 	<BruteForceDetection name="N2" />
 	<DefaultContactManager name="Response" />
@@ -31,7 +32,7 @@
 		<BoxConstraint box="-1.6 -0.1 -7.6 1.6 3.1 -7.4" />
 		<!--		<MeshSpringForceField stiffness="2333" /> -->
 		<TetrahedronFEMForceField name="FEM" youngModulus="10000" poissonRatio="0.4" method="large" />
-		<PlaneForceField normal="0 1 0" d="-3" stiffness="10000"  draw="1" />
+		<PlaneForceField normal="0 1 0" d="-3" stiffness="10000"  showPlane="1" />
 		<Node>
 			<RegularGridTopology
 				nx="2" ny="2" nz="9"
@@ -40,7 +41,7 @@
 				zmin="-5.5" zmax="6.5"
 			/>
 			<MechanicalObject/>
-			<SphereModel radius="1.0" />
+			<TSphereModel radius="1.0" />
 			<BarycentricMapping />
 		</Node>
 		<Node>
@@ -50,7 +51,7 @@
 				ymin="0" ymax="3"
 				zmin="-7.5" zmax="7.5"
 			/>
-			<VisualModel name="Visual"/>
+			<OglModel name="Visual"/>
 			<SubsetMapping input="@.." output="@Visual" />
 		</Node>
 	</Node>

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-fem-implicit-CPU.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-fem-implicit-CPU.scn
@@ -1,11 +1,11 @@
 <Node name="root" dt="0.04" showBehaviorModels="1" showCollisionModels="0" showMappings="0" showForceFields="0">
-	<CollisionPipeline verbose="0" />
+	<DefaultPipeline verbose="0" />
 	<BruteForceDetection name="N2" />
-	<CollisionResponse name="Response" />
+	<DefaultContactManager name="Response" />
 	<NewProximityIntersection alarmDistance="0.002" contactDistance="0.001" />
 
 	<Node name="Floor">
-		<RegularGrid
+		<RegularGridTopology
 			nx="2" ny="1" nz="2"
 			xmin="10" xmax="-10"
 			ymin="-3.05" ymax="-3.05"
@@ -18,9 +18,9 @@
 	</Node>
 	<Node name="M1">
 		<!--<CGImplicit iterations="10" />-->
-		<EulerImplicit  rayleighStiffness="0.1" rayleighMass="0.1" />
+		<EulerImplicitSolver rayleighStiffness="0.1" rayleighMass="0.1" />
 		<CGLinearSolver iterations="10"/>
-		<RegularGrid
+		<RegularGridTopology
 			nx="10" ny="10" nz="46"
 			xmin="-1.5" xmax="1.5"
 			ymin="0" ymax="3"
@@ -33,7 +33,7 @@
 		<TetrahedronFEMForceField name="FEM" youngModulus="10000" poissonRatio="0.4" method="large" />
 		<PlaneForceField normal="0 1 0" d="-3" stiffness="10000"  draw="1" />
 		<Node>
-			<RegularGrid
+			<RegularGridTopology
 				nx="2" ny="2" nz="9"
 				xmin="-0.75" xmax="0.75"
 				ymin="0.75" ymax="2.25"

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-fem-implicit-CPU.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-fem-implicit-CPU.scn
@@ -27,7 +27,7 @@
 			zmin="-7.5" zmax="7.5"
 		/>
 		<MechanicalObject />
-		<UniformMass totalmass="400" />
+		<UniformMass totalMass="400" />
 		<BoxConstraint box="-1.6 -0.1 -7.6 1.6 3.1 -7.4" />
 		<!--		<MeshSpringForceField stiffness="2333" /> -->
 		<TetrahedronFEMForceField name="FEM" youngModulus="10000" poissonRatio="0.4" method="large" />

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-fem-implicit-CUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-fem-implicit-CUDA.scn
@@ -1,12 +1,12 @@
 <Node name="root" dt="0.04" showBehaviorModels="1" showCollisionModels="0" showMappings="0" showForceFields="0">
     <RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
-	<CollisionPipeline verbose="0" />
+	<DefaultPipeline verbose="0" />
 	<BruteForceDetection name="N2" />
-	<CollisionResponse name="Response" />
+	<DefaultContactManager name="Response" />
 	<CudaProximityIntersection alarmDistance="0.002" contactDistance="0.001" />
 
 	<Node name="Floor">
-		<RegularGrid
+		<RegularGridTopology
 			nx="2" ny="1" nz="2"
 			xmin="10" xmax="-10"
 			ymin="-3.05" ymax="-3.05"
@@ -19,9 +19,9 @@
 	</Node>
 	<Node name="M1">
 		<!--<CGImplicit iterations="10" />-->
-		<EulerImplicit  rayleighStiffness="0.1" rayleighMass="0.1" />
+		<EulerImplicitSolver rayleighStiffness="0.1" rayleighMass="0.1" />
 		<CGLinearSolver iterations="10"/>
-		<RegularGrid
+		<RegularGridTopology
 			nx="10" ny="10" nz="46"
 			xmin="-1.5" xmax="1.5"
 			ymin="0" ymax="3"
@@ -35,7 +35,7 @@
 		<PlaneForceField normal="0 1 0" d="-3" stiffness="10000"  draw="1" />
 		<!-- <PlaneForceField normal="0 0 1" d="-7.5" stiffness="10000"  draw="1" color="0.2 0.2 0.7" /> -->
 		<Node>
-			<RegularGrid
+			<RegularGridTopology
 				nx="2" ny="2" nz="9"
 				xmin="-0.75" xmax="0.75"
 				ymin="0.75" ymax="2.25"

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-fem-implicit-CUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-fem-implicit-CUDA.scn
@@ -28,7 +28,7 @@
 			zmin="-7.5" zmax="7.5"
 		/>
 		<MechanicalObject template="CudaVec3f" />
-		<UniformMass totalmass="400" />
+		<UniformMass totalMass="400" />
 		<BoxConstraint box="-1.6 -0.1 -7.6 1.6 3.1 -7.4" />
 		<!--		<MeshSpringForceField stiffness="2333" /> -->
 		<TetrahedronFEMForceField name="FEM" youngModulus="10000" poissonRatio="0.4" method="large" />

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-fem-implicit-CUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-fem-implicit-CUDA.scn
@@ -1,4 +1,4 @@
-<Node name="root" dt="0.04" showBehaviorModels="1" showCollisionModels="0" showMappings="0" showForceFields="0">
+<Node name="root" dt="0.04">
     <RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
 	<DefaultPipeline verbose="0" />
 	<BruteForceDetection name="N2" />
@@ -32,7 +32,7 @@
 		<BoxConstraint box="-1.6 -0.1 -7.6 1.6 3.1 -7.4" />
 		<!--		<MeshSpringForceField stiffness="2333" /> -->
 		<TetrahedronFEMForceField name="FEM" youngModulus="10000" poissonRatio="0.4" method="large" />
-		<PlaneForceField normal="0 1 0" d="-3" stiffness="10000"  draw="1" />
+		<PlaneForceField normal="0 1 0" d="-3" stiffness="10000"  showPlane="1" />
 		<!-- <PlaneForceField normal="0 0 1" d="-7.5" stiffness="10000"  draw="1" color="0.2 0.2 0.7" /> -->
 		<Node>
 			<RegularGridTopology
@@ -42,7 +42,7 @@
 				zmin="-5.5" zmax="6.5"
 			/>
 			<MechanicalObject template="CudaVec3f"/> 
-			<CudaSphereModel radius="1.0" />
+			<TSphereModel radius="1.0" />
 			<BarycentricMapping />
 		</Node>
 		<Node>

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-hexafem-implicit-CPU.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-hexafem-implicit-CPU.scn
@@ -10,7 +10,7 @@
 		<EulerImplicitSolver rayleighStiffness="0.1" rayleighMass="0.1" />
 		<CGLinearSolver iterations="10"/>
 		<MechanicalObject template="Vec3f"/>
-		<UniformMass totalmass="200" />
+		<UniformMass totalMass="200" />
 		<RegularGridTopology
 			nx="10" ny="10" nz="46"
 			xmin="-9" xmax="-6"

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-hexafem-implicit-CPU.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-hexafem-implicit-CPU.scn
@@ -1,17 +1,17 @@
 <Node name="root" dt="0.02" showBehaviorModels="1" showCollisionModels="0" showMappings="0" showForceFields="0">
 	
-	<CollisionPipeline depth="6" verbose="0" draw="0"/>
+	<DefaultPipeline depth="6" verbose="0" draw="0"/>
 	<BruteForceDetection name="N2" />
 	<MinProximityIntersection name="Proximity" alarmDistance="0.5" contactDistance="0.3" />
-	<CollisionResponse name="Response" response="default" />
+	<DefaultContactManager name="Response" response="default" />
 	<CollisionGroup name="Group" />
 	
 	<Node name="M1" processor="0">
-		<EulerImplicit  rayleighStiffness="0.1" rayleighMass="0.1" />
+		<EulerImplicitSolver rayleighStiffness="0.1" rayleighMass="0.1" />
 		<CGLinearSolver iterations="10"/>
 		<MechanicalObject template="Vec3f"/>
 		<UniformMass totalmass="200" />
-		<RegularGrid
+		<RegularGridTopology
 			nx="10" ny="10" nz="46"
 			xmin="-9" xmax="-6"
 			ymin="0" ymax="3"

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-hexafem-implicit-CPU.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-hexafem-implicit-CPU.scn
@@ -1,15 +1,15 @@
-<Node name="root" dt="0.02" showBehaviorModels="1" showCollisionModels="0" showMappings="0" showForceFields="0">
-	
+<Node name="root" dt="0.02">
+	<VisualStyle displayFlags="showBehaviorModels" />
 	<DefaultPipeline depth="6" verbose="0" draw="0"/>
 	<BruteForceDetection name="N2" />
 	<MinProximityIntersection name="Proximity" alarmDistance="0.5" contactDistance="0.3" />
 	<DefaultContactManager name="Response" response="default" />
-	<CollisionGroup name="Group" />
+	<DefaultCollisionGroupManager name="Group" />
 	
 	<Node name="M1" processor="0">
 		<EulerImplicitSolver rayleighStiffness="0.1" rayleighMass="0.1" />
 		<CGLinearSolver iterations="10"/>
-		<MechanicalObject template="Vec3f"/>
+		<MechanicalObject template="Vec3"/>
 		<UniformMass totalMass="200" />
 		<RegularGridTopology
 			nx="10" ny="10" nz="46"
@@ -26,7 +26,7 @@
 		  		ymin="0" ymax="3"
 		  		zmin="0" zmax="15"
 		  	/>
-      <VisualModel name="Visual" />
+		  <OglModel name="Visual" />
 		  <SubsetMapping input="@.." output="@Visual" />
 		</Node>
 	</Node>

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-hexafem-implicit-CUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-hexafem-implicit-CUDA.scn
@@ -1,18 +1,18 @@
 <Node name="root" dt="0.02" showBehaviorModels="1" showCollisionModels="0" showMappings="0" showForceFields="0">
     <RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
 	
-	<CollisionPipeline depth="6" verbose="0" draw="0"/>
+	<DefaultPipeline depth="6" verbose="0" draw="0"/>
 	<BruteForceDetection name="N2" />
 	<MinProximityIntersection name="Proximity" alarmDistance="0.5" contactDistance="0.3" />
-	<CollisionResponse name="Response" response="default" />
+	<DefaultContactManager name="Response" response="default" />
 	<CollisionGroup name="Group" />
 	
 	<Node name="M1" processor="0">
-		<EulerImplicit  rayleighStiffness="0.1" rayleighMass="0.1" />
+		<EulerImplicitSolver rayleighStiffness="0.1" rayleighMass="0.1" />
 		<CGLinearSolver iterations="10"/>
 		<MechanicalObject template="CudaVec3f"/>
 		<UniformMass totalmass="200" />
-		<RegularGrid
+		<RegularGridTopology
 			nx="10" ny="10" nz="46"
 			xmin="-9" xmax="-6"
 			ymin="0" ymax="3"

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-hexafem-implicit-CUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-hexafem-implicit-CUDA.scn
@@ -1,5 +1,6 @@
-<Node name="root" dt="0.02" showBehaviorModels="1" showCollisionModels="0" showMappings="0" showForceFields="0">
+<Node name="root" dt="0.02">
     <RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
+	<VisualStyle displayFlags="showBehaviorModels" />
 	
 	<DefaultPipeline depth="6" verbose="0" draw="0"/>
 	<BruteForceDetection name="N2" />

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-hexafem-implicit-CUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-hexafem-implicit-CUDA.scn
@@ -11,7 +11,7 @@
 		<EulerImplicitSolver rayleighStiffness="0.1" rayleighMass="0.1" />
 		<CGLinearSolver iterations="10"/>
 		<MechanicalObject template="CudaVec3f"/>
-		<UniformMass totalmass="200" />
+		<UniformMass totalMass="200" />
 		<RegularGridTopology
 			nx="10" ny="10" nz="46"
 			xmin="-9" xmax="-6"

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-hexafem-rk4-CPU.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-hexafem-rk4-CPU.scn
@@ -1,14 +1,13 @@
-<Node name="root" dt="0.002" showBehaviorModels="1" showCollisionModels="0" showMappings="0" showForceFields="0">
-	
+<Node name="root" dt="0.002">
 	<DefaultPipeline depth="6" verbose="0" draw="0"/>
 	<BruteForceDetection name="N2" />
 	<MinProximityIntersection name="Proximity" alarmDistance="0.5" contactDistance="0.3" />
 	<DefaultContactManager name="Response" response="default" />
-	<CollisionGroup name="Group" />
+	<DefaultCollisionGroupManager name="Group" />
 	
 	<Node name="M1" processor="0">
     <RungeKutta4 />
-		<MechanicalObject template="Vec3f"/>
+		<MechanicalObject template="Vec3"/>
 		<UniformMass totalMass="200" />
 		<RegularGridTopology
 			nx="10" ny="10" nz="46"
@@ -25,7 +24,7 @@
 		  		ymin="0" ymax="3"
 		  		zmin="0" zmax="15"
 		  	/>
-      <VisualModel name="Visual" />
+		  <OglModel name="Visual" />
 		  <SubsetMapping input="@.." output="@Visual" />
 		</Node>
 	</Node>

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-hexafem-rk4-CPU.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-hexafem-rk4-CPU.scn
@@ -9,7 +9,7 @@
 	<Node name="M1" processor="0">
     <RungeKutta4 />
 		<MechanicalObject template="Vec3f"/>
-		<UniformMass totalmass="200" />
+		<UniformMass totalMass="200" />
 		<RegularGridTopology
 			nx="10" ny="10" nz="46"
 			xmin="-9" xmax="-6"

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-hexafem-rk4-CPU.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-hexafem-rk4-CPU.scn
@@ -1,16 +1,16 @@
 <Node name="root" dt="0.002" showBehaviorModels="1" showCollisionModels="0" showMappings="0" showForceFields="0">
 	
-	<CollisionPipeline depth="6" verbose="0" draw="0"/>
+	<DefaultPipeline depth="6" verbose="0" draw="0"/>
 	<BruteForceDetection name="N2" />
 	<MinProximityIntersection name="Proximity" alarmDistance="0.5" contactDistance="0.3" />
-	<CollisionResponse name="Response" response="default" />
+	<DefaultContactManager name="Response" response="default" />
 	<CollisionGroup name="Group" />
 	
 	<Node name="M1" processor="0">
     <RungeKutta4 />
 		<MechanicalObject template="Vec3f"/>
 		<UniformMass totalmass="200" />
-		<RegularGrid
+		<RegularGridTopology
 			nx="10" ny="10" nz="46"
 			xmin="-9" xmax="-6"
 			ymin="0" ymax="3"

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-hexafem-rk4-CUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-hexafem-rk4-CUDA.scn
@@ -10,7 +10,7 @@
 	<Node name="M1" processor="0">
     <RungeKutta4 />
 		<MechanicalObject template="CudaVec3f"/>
-		<UniformMass totalmass="200" />
+		<UniformMass totalMass="200" />
 		<RegularGridTopology
 			nx="10" ny="10" nz="46"
 			xmin="-9" xmax="-6"

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-hexafem-rk4-CUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-hexafem-rk4-CUDA.scn
@@ -1,17 +1,17 @@
 <Node name="root" dt="0.002" showBehaviorModels="1" showCollisionModels="0" showMappings="0" showForceFields="0">
     <RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
 	
-	<CollisionPipeline depth="6" verbose="0" draw="0"/>
+	<DefaultPipeline depth="6" verbose="0" draw="0"/>
 	<BruteForceDetection name="N2" />
 	<MinProximityIntersection name="Proximity" alarmDistance="0.5" contactDistance="0.3" />
-	<CollisionResponse name="Response" response="default" />
+	<DefaultContactManager name="Response" response="default" />
 	<CollisionGroup name="Group" />
 	
 	<Node name="M1" processor="0">
     <RungeKutta4 />
 		<MechanicalObject template="CudaVec3f"/>
 		<UniformMass totalmass="200" />
-		<RegularGrid
+		<RegularGridTopology
 			nx="10" ny="10" nz="46"
 			xmin="-9" xmax="-6"
 			ymin="0" ymax="3"

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-spring-rk4-CPU.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-spring-rk4-CPU.scn
@@ -1,12 +1,12 @@
 <Node name="root" dt="0.0025" showBehaviorModels="1" showCollisionModels="0" showMappings="0" showForceFields="0">
     <RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
-	<CollisionPipeline verbose="0" />
+	<DefaultPipeline verbose="0" />
 	<BruteForceDetection name="N2" />
-	<CollisionResponse name="Response" />
+	<DefaultContactManager name="Response" />
 	<CudaProximityIntersection alarmDistance="0.002" contactDistance="0.001" />
 
 	<Node name="Floor">
-		<RegularGrid
+		<RegularGridTopology
 			nx="2" ny="1" nz="2"
 			xmin="10" xmax="-10"
 			ymin="-3.05" ymax="-3.05"
@@ -19,7 +19,7 @@
 	</Node>
 	<Node name="M1">
 		<RungeKutta4 />
-		<RegularGrid
+		<RegularGridTopology
 			nx="10" ny="10" nz="46"
 			xmin="-1.5" xmax="1.5"
 			ymin="0" ymax="3"
@@ -31,7 +31,7 @@
 		<MeshSpringForceField stiffness="2333" />
 		<PlaneForceField normal="0 1 0" d="-3" stiffness="10000"  draw="1" />
 		<Node>
-			<RegularGrid
+			<RegularGridTopology
 				nx="2" ny="2" nz="9"
 				xmin="-0.75" xmax="0.75"
 				ymin="0.75" ymax="2.25"

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-spring-rk4-CPU.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-spring-rk4-CPU.scn
@@ -26,7 +26,7 @@
 			zmin="-7.5" zmax="7.5"
 		/>
 		<MechanicalObject />
-		<UniformMass totalmass="400" />
+		<UniformMass totalMass="400" />
 		<BoxConstraint box="-1.6 -0.1 -7.6 1.6 3.1 -7.4" />
 		<MeshSpringForceField stiffness="2333" />
 		<PlaneForceField normal="0 1 0" d="-3" stiffness="10000"  draw="1" />

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-spring-rk4-CUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-spring-rk4-CUDA.scn
@@ -1,12 +1,12 @@
 <Node name="root" dt="0.0025" showBehaviorModels="1" showCollisionModels="0" showMappings="0" showForceFields="0">
     <RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
-	<CollisionPipeline verbose="0" />
+	<DefaultPipeline verbose="0" />
 	<BruteForceDetection name="N2" />
-	<CollisionResponse name="Response" />
+	<DefaultContactManager name="Response" />
 	<CudaProximityIntersection alarmDistance="0.002" contactDistance="0.001" />
 
 	<Node name="Floor">
-		<RegularGrid
+		<RegularGridTopology
 			nx="2" ny="1" nz="2"
 			xmin="10" xmax="-10"
 			ymin="-3.05" ymax="-3.05"
@@ -19,7 +19,7 @@
 	</Node>
 	<Node name="M1">
 		<RungeKutta4 />
-		<RegularGrid
+		<RegularGridTopology
 			nx="10" ny="10" nz="46"
 			xmin="-1.5" xmax="1.5"
 			ymin="0" ymax="3"
@@ -31,7 +31,7 @@
 		<MeshSpringForceField stiffness="2333" />
 		<PlaneForceField normal="0 1 0" d="-3" stiffness="10000"  draw="1" />
 		<Node>
-			<RegularGrid
+			<RegularGridTopology
 				nx="2" ny="2" nz="9"
 				xmin="-0.75" xmax="0.75"
 				ymin="0.75" ymax="2.25"

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-spring-rk4-CUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-spring-rk4-CUDA.scn
@@ -26,7 +26,7 @@
 			zmin="-7.5" zmax="7.5"
 		/>
 		<MechanicalObject template="CudaVec3f" />
-		<UniformMass totalmass="400" />
+		<UniformMass totalMass="400" />
 		<BoxConstraint box="-1.6 -0.1 -7.6 1.6 3.1 -7.4" />
 		<MeshSpringForceField stiffness="2333" />
 		<PlaneForceField normal="0 1 0" d="-3" stiffness="10000"  draw="1" />

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-warp-preconditioner-CUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-warp-preconditioner-CUDA.scn
@@ -33,7 +33,7 @@
 		<!--<SparseCholeskySolver name="initsolver" printLog="true" />-->
 		<SparseTAUCSSolver name="initsolver" symmetric="true" options="taucs.factor.LLT=true taucs.factor.ordering=metis" printLog="false" />
 
-		<UniformMass totalmass="400" />
+		<UniformMass totalMass="400" />
 		<BoxConstraint box="-1.6 -0.1 7.4 1.6 3.1 7.6" />
 		<!--		<MeshSpringForceField stiffness="2333" /> -->
 		<TetrahedronFEMForceField name="FEM" youngModulus="10000" poissonRatio="0.4" method="large" />

--- a/applications/plugins/SofaCUDA/examples/beam10x10x46-warp-preconditioner-CUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/beam10x10x46-warp-preconditioner-CUDA.scn
@@ -1,12 +1,12 @@
 <Node name="root" dt="0.04" showBehaviorModels="1" showCollisionModels="0" showMappings="0" showForceFields="0">
     <RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
-	<CollisionPipeline verbose="0" />
+	<DefaultPipeline verbose="0" />
 	<BruteForceDetection name="N2" />
-	<CollisionResponse name="Response" />
+	<DefaultContactManager name="Response" />
 	<CudaProximityIntersection alarmDistance="0.002" contactDistance="0.001" />
 
 	<Node name="Floor">
-		<RegularGrid
+		<RegularGridTopology
 			nx="2" ny="1" nz="2"
 			xmin="10" xmax="-10"
 			ymin="-3.05" ymax="-3.05"
@@ -19,9 +19,9 @@
 	</Node>
 	<Node name="M1">
 		<!--<CGImplicit iterations="10" />-->
-		<EulerImplicit name="odesolver"  rayleighStiffness="0.1" rayleighMass="0.1" />
+		<EulerImplicitSolver name="odesolver"  rayleighStiffness="0.1" rayleighMass="0.1" />
 		<PCGLinearSolver name="linearsolver" iterations="100" preconditioners="preconditioner"/>
-		<RegularGrid
+		<RegularGridTopology
 			nx="10" ny="10" nz="46"
 			xmin="-1.5" xmax="1.5"
 			ymin="0" ymax="3"
@@ -40,7 +40,7 @@
 		<!--<PlaneForceField normal="0 1 0" d="-3" stiffness="10000"  draw="1" />-->
 		<!-- <PlaneForceField normal="0 0 1" d="-7.5" stiffness="10000"  draw="1" color="0.2 0.2 0.7" /> -->
 		<Node>
-			<RegularGrid
+			<RegularGridTopology
 				nx="2" ny="2" nz="9"
 				xmin="-0.75" xmax="0.75"
 				ymin="0.75" ymax="2.25"

--- a/applications/plugins/SofaCUDA/examples/beam16x16x76-fem-implicit-CPU.scn
+++ b/applications/plugins/SofaCUDA/examples/beam16x16x76-fem-implicit-CPU.scn
@@ -1,11 +1,11 @@
 <Node name="root" dt="0.04" showBehaviorModels="1" showCollisionModels="0" showMappings="0" showForceFields="0">
-	<CollisionPipeline verbose="0" />
+	<DefaultPipeline verbose="0" />
 	<BruteForceDetection name="N2" />
-	<CollisionResponse name="Response" />
+	<DefaultContactManager name="Response" />
 	<NewProximityIntersection alarmDistance="0.002" contactDistance="0.001" />
 
 	<Node name="Floor">
-		<RegularGrid
+		<RegularGridTopology
 			nx="2" ny="1" nz="2"
 			xmin="10" xmax="-10"
 			ymin="-3.05" ymax="-3.05"
@@ -18,9 +18,9 @@
 	</Node>
 	<Node name="M1">
 		<!--<CGImplicit iterations="10" />-->
-		<EulerImplicit  rayleighStiffness="0.1" rayleighMass="0.1" />
+		<EulerImplicitSolver rayleighStiffness="0.1" rayleighMass="0.1" />
 		<CGLinearSolver iterations="10"/>
-		<RegularGrid
+		<RegularGridTopology
 			nx="16" ny="16" nz="76"
 			xmin="-1.5" xmax="1.5"
 			ymin="0" ymax="3"
@@ -34,7 +34,7 @@
 		<PlaneForceField normal="0 1 0" d="-3" stiffness="10000"  draw="1" />
 		<PlaneForceField normal="0 0 1" d="-7.5" stiffness="10000"  draw="1" color="0.2 0.2 0.7" />
 		<Node>
-			<RegularGrid
+			<RegularGridTopology
 				nx="2" ny="2" nz="9"
 				xmin="-0.75" xmax="0.75"
 				ymin="0.75" ymax="2.25"

--- a/applications/plugins/SofaCUDA/examples/beam16x16x76-fem-implicit-CPU.scn
+++ b/applications/plugins/SofaCUDA/examples/beam16x16x76-fem-implicit-CPU.scn
@@ -27,7 +27,7 @@
 			zmin="-7.5" zmax="7.5"
 		/>
 		<MechanicalObject />
-		<UniformMass totalmass="400" />
+		<UniformMass totalMass="400" />
 		<BoxConstraint box="-1.6 -0.1 -7.6 1.6 3.1 -7.4" />
 		<!--		<MeshSpringForceField stiffness="2333" /> -->
 		<TetrahedronFEMForceField name="FEM" youngModulus="10000" poissonRatio="0.4" method="large" />

--- a/applications/plugins/SofaCUDA/examples/beam16x16x76-fem-implicit-CUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/beam16x16x76-fem-implicit-CUDA.scn
@@ -28,7 +28,7 @@
 			zmin="-7.5" zmax="7.5"
 		/>
 		<MechanicalObject template="CudaVec3f" />
-		<UniformMass totalmass="400" />
+		<UniformMass totalMass="400" />
 		<BoxConstraint box="-1.6 -0.1 -7.6 1.6 3.1 -7.4" />
 		<!--		<MeshSpringForceField stiffness="2333" /> -->
 		<TetrahedronFEMForceField name="FEM" youngModulus="10000" poissonRatio="0.4" method="large" />

--- a/applications/plugins/SofaCUDA/examples/beam16x16x76-fem-implicit-CUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/beam16x16x76-fem-implicit-CUDA.scn
@@ -1,12 +1,12 @@
 <Node name="root" dt="0.04" showBehaviorModels="1" showCollisionModels="0" showMappings="0" showForceFields="0">
     <RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
-	<CollisionPipeline verbose="0" />
+	<DefaultPipeline verbose="0" />
 	<BruteForceDetection name="N2" />
-	<CollisionResponse name="Response" />
+	<DefaultContactManager name="Response" />
 	<CudaProximityIntersection alarmDistance="0.002" contactDistance="0.001" />
 
 	<Node name="Floor">
-		<RegularGrid
+		<RegularGridTopology
 			nx="2" ny="1" nz="2"
 			xmin="10" xmax="-10"
 			ymin="-3.05" ymax="-3.05"
@@ -19,9 +19,9 @@
 	</Node>
 	<Node name="M1">
 		<!--<CGImplicit iterations="10" />-->
-		<EulerImplicit  rayleighStiffness="0.1" rayleighMass="0.1" />
+		<EulerImplicitSolver rayleighStiffness="0.1" rayleighMass="0.1" />
 		<CGLinearSolver iterations="10"/>
-		<RegularGrid
+		<RegularGridTopology
 			nx="16" ny="16" nz="76"
 			xmin="-1.5" xmax="1.5"
 			ymin="0" ymax="3"
@@ -35,7 +35,7 @@
 		<PlaneForceField normal="0 1 0" d="-3" stiffness="10000"  draw="1" />
 		<PlaneForceField normal="0 0 1" d="-7.5" stiffness="10000"  draw="1" color="0.2 0.2 0.7" />
 		<Node>
-			<RegularGrid
+			<RegularGridTopology
 				nx="2" ny="2" nz="9"
 				xmin="-0.75" xmax="0.75"
 				ymin="0.75" ymax="2.25"

--- a/applications/plugins/SofaCUDA/examples/beam16x16x76-hexafem-rk4-CPU.scn
+++ b/applications/plugins/SofaCUDA/examples/beam16x16x76-hexafem-rk4-CPU.scn
@@ -9,7 +9,7 @@
 	<Node name="M1" processor="0">
     <RungeKutta4 />
 		<MechanicalObject template="Vec3f"/>
-		<UniformMass totalmass="200" />
+		<UniformMass totalMass="200" />
 		<RegularGridTopology
 			nx="16" ny="16" nz="76"
 			xmin="-9" xmax="-6"

--- a/applications/plugins/SofaCUDA/examples/beam16x16x76-hexafem-rk4-CPU.scn
+++ b/applications/plugins/SofaCUDA/examples/beam16x16x76-hexafem-rk4-CPU.scn
@@ -1,16 +1,16 @@
 <Node name="root" dt="0.002" showBehaviorModels="1" showCollisionModels="0" showMappings="0" showForceFields="0">
 	
-	<CollisionPipeline depth="6" verbose="0" draw="0"/>
+	<DefaultPipeline depth="6" verbose="0" draw="0"/>
 	<BruteForceDetection name="N2" />
 	<MinProximityIntersection name="Proximity" alarmDistance="0.5" contactDistance="0.3" />
-	<CollisionResponse name="Response" response="default" />
+	<DefaultContactManager name="Response" response="default" />
 	<CollisionGroup name="Group" />
 	
 	<Node name="M1" processor="0">
     <RungeKutta4 />
 		<MechanicalObject template="Vec3f"/>
 		<UniformMass totalmass="200" />
-		<RegularGrid
+		<RegularGridTopology
 			nx="16" ny="16" nz="76"
 			xmin="-9" xmax="-6"
 			ymin="0" ymax="3"

--- a/applications/plugins/SofaCUDA/examples/beam16x16x76-hexafem-rk4-CUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/beam16x16x76-hexafem-rk4-CUDA.scn
@@ -1,17 +1,17 @@
 <Node name="root" dt="0.002" showBehaviorModels="1" showCollisionModels="0" showMappings="0" showForceFields="0">
     <RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
 	
-	<CollisionPipeline depth="6" verbose="0" draw="0"/>
+	<DefaultPipeline depth="6" verbose="0" draw="0"/>
 	<BruteForceDetection name="N2" />
 	<MinProximityIntersection name="Proximity" alarmDistance="0.5" contactDistance="0.3" />
-	<CollisionResponse name="Response" response="default" />
+	<DefaultContactManager name="Response" response="default" />
 	<CollisionGroup name="Group" />
 	
 	<Node name="M1" processor="0">
     <RungeKutta4 />
 		<MechanicalObject template="CudaVec3f"/>
 		<UniformMass totalmass="200" />
-		<RegularGrid
+		<RegularGridTopology
 			nx="16" ny="16" nz="76"
 			xmin="-9" xmax="-6"
 			ymin="0" ymax="3"

--- a/applications/plugins/SofaCUDA/examples/beam16x16x76-hexafem-rk4-CUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/beam16x16x76-hexafem-rk4-CUDA.scn
@@ -10,7 +10,7 @@
 	<Node name="M1" processor="0">
     <RungeKutta4 />
 		<MechanicalObject template="CudaVec3f"/>
-		<UniformMass totalmass="200" />
+		<UniformMass totalMass="200" />
 		<RegularGridTopology
 			nx="16" ny="16" nz="76"
 			xmin="-9" xmax="-6"

--- a/applications/plugins/SofaCUDA/examples/quadSelfCollisCUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/quadSelfCollisCUDA.scn
@@ -26,7 +26,7 @@
 		<EulerImplicitSolver rayleighMass="0.05" rayleighStiffness="0.1" />
 		<CGLinearSolver iterations="10" threshold="0.000001"/>
 		<MechanicalObject template="CudaVec3f" />
-		<UniformMass totalmass="100" />
+		<UniformMass totalMass="100" />
 		<RegularGridTopology
 			nx="100" ny="1" nz="100"
 			xmin="12" xmax="-12"

--- a/applications/plugins/SofaCUDA/examples/quadSelfCollisCUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/quadSelfCollisCUDA.scn
@@ -1,11 +1,11 @@
 <Node name="root" gravity="0.0 -2.0 0.0" dt="0.04" showBehaviorModels="0" showCollisionModels="0" showMappings="0" showForceFields="0">
     <RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
-	<CollisionPipeline verbose="0" />
+	<DefaultPipeline verbose="0" />
 	<BruteForceDetection name="N2" />
-	<CollisionResponse name="Response" />
+	<DefaultContactManager name="Response" />
 	<CudaProximityIntersection alarmDistance="0.002" contactDistance="0.001" />
 	<Node name="Floor">
-		<RegularGrid
+		<RegularGridTopology
 			nx="2" ny="1" nz="2"
 			xmin="20" xmax="-20"
 			ymin="-3.05" ymax="-3.05"
@@ -23,11 +23,11 @@
 	</Node>
 	<Node name="SquareCloth1">
 		<!--<CGImplicit rayleighMass="0.05"  iterations="10" threshold="0.000001"/>-->
-		<EulerImplicit rayleighMass="0.05" rayleighStiffness="0.1" />
+		<EulerImplicitSolver rayleighMass="0.05" rayleighStiffness="0.1" />
 		<CGLinearSolver iterations="10" threshold="0.000001"/>
 		<MechanicalObject template="CudaVec3f" />
 		<UniformMass totalmass="100" />
-		<RegularGrid
+		<RegularGridTopology
 			nx="100" ny="1" nz="100"
 			xmin="12" xmax="-12"
 			ymin="7" ymax="7"
@@ -45,7 +45,7 @@
 			<CudaVisualModel template="CudaVec3f" diffuse="0 0.8 0 1.0" computeNormals="true" />
 		</Node>
 		<Node>
-			<RegularGrid
+			<RegularGridTopology
 				nx="4" ny="1" nz="4"
 			xmin="12" xmax="-12"
 			ymin="7" ymax="7"
@@ -58,7 +58,7 @@
 		<!--
 		<Node name="Surf">
 			<MechanicalObject />
-			<RegularGrid
+			<RegularGridTopology
 				nx="100" ny="1" nz="100"
 				xmin="12" xmax="-12"
 				ymin="7" ymax="7"

--- a/applications/plugins/SofaCUDA/examples/quadSelfCollisCUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/quadSelfCollisCUDA.scn
@@ -1,4 +1,4 @@
-<Node name="root" gravity="0.0 -2.0 0.0" dt="0.04" showBehaviorModels="0" showCollisionModels="0" showMappings="0" showForceFields="0">
+<Node name="root" gravity="0.0 -2.0 0.0" dt="0.04" >
     <RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
 	<DefaultPipeline verbose="0" />
 	<BruteForceDetection name="N2" />

--- a/applications/plugins/SofaCUDA/examples/quadSpringSphere.scn
+++ b/applications/plugins/SofaCUDA/examples/quadSpringSphere.scn
@@ -29,7 +29,7 @@
 			ymin="7" ymax="7"
 			zmin="-12" zmax="12" />
 		<MechanicalObject />
-		<UniformMass totalmass="100" />
+		<UniformMass totalMass="100" />
 		<BoxConstraint box="-12 7 12 -10 7 12    10 7 12 12 7 12"/>
 		<MeshSpringForceField name="Springs" stiffness="1000" damping="0"/>
 		<QuadBendingSprings name="Bend" stiffness="2000" damping="1"/>

--- a/applications/plugins/SofaCUDA/examples/quadSpringSphere.scn
+++ b/applications/plugins/SofaCUDA/examples/quadSpringSphere.scn
@@ -1,10 +1,10 @@
 <Node name="root" gravity="0.0 -2.0 0.0" dt="0.04" showBehaviorModels="0" showCollisionModels="0" showMappings="0" showForceFields="0">
-	<CollisionPipeline verbose="0" />
+	<DefaultPipeline verbose="0" />
 	<BruteForceDetection name="N2" />
-	<CollisionResponse name="Response" />
+	<DefaultContactManager name="Response" />
 	<NewProximityIntersection alarmDistance="0.002" contactDistance="0.001" />
 	<Node name="Floor">
-		<RegularGrid
+		<RegularGridTopology
 			nx="2" ny="1" nz="2"
 			xmin="20" xmax="-20"
 			ymin="-3.05" ymax="-3.05"
@@ -21,9 +21,9 @@
 		</Node>
 	</Node>
 	<Node name="SquareCloth1">
-		<EulerImplicit  rayleighStiffness="0.1" />
+		<EulerImplicitSolver rayleighStiffness="0.1" />
 		<CGLinearSolver iterations="10" rayleighMass="0.05" threshold="0.000001"/>
-		<RegularGrid
+		<RegularGridTopology
 			nx="100" ny="1" nz="100"
 			xmin="12" xmax="-12"
 			ymin="7" ymax="7"
@@ -40,7 +40,7 @@
 			<IdentityMapping input="@.." output="@Visual"/>
 		</Node>
 		<Node>
-			<RegularGrid
+			<RegularGridTopology
 				nx="4" ny="1" nz="4"
 			xmin="12" xmax="-12"
 			ymin="7" ymax="7"
@@ -53,7 +53,7 @@
 		<!--
 		<Node name="Surf">
 			<MechanicalObject />
-			<RegularGrid
+			<RegularGridTopology
 				nx="100" ny="1" nz="100"
 				xmin="12" xmax="-12"
 				ymin="7" ymax="7"

--- a/applications/plugins/SofaCUDA/examples/quadSpringSphere.scn
+++ b/applications/plugins/SofaCUDA/examples/quadSpringSphere.scn
@@ -1,4 +1,4 @@
-<Node name="root" gravity="0.0 -2.0 0.0" dt="0.04" showBehaviorModels="0" showCollisionModels="0" showMappings="0" showForceFields="0">
+<Node name="root" gravity="0.0 -2.0 0.0" dt="0.04">
 	<DefaultPipeline verbose="0" />
 	<BruteForceDetection name="N2" />
 	<DefaultContactManager name="Response" />
@@ -21,8 +21,8 @@
 		</Node>
 	</Node>
 	<Node name="SquareCloth1">
-		<EulerImplicitSolver rayleighStiffness="0.1" />
-		<CGLinearSolver iterations="10" rayleighMass="0.05" threshold="0.000001"/>
+		<EulerImplicitSolver rayleighMass="0.05" rayleighStiffness="0.1" />
+		<CGLinearSolver iterations="10" threshold="0.000001"/>
 		<RegularGridTopology
 			nx="100" ny="1" nz="100"
 			xmin="12" xmax="-12"

--- a/applications/plugins/SofaCUDA/examples/quadSpringSphere2CUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/quadSpringSphere2CUDA.scn
@@ -1,4 +1,4 @@
-<Node name="root" gravity="0.0 -2.0 0.0" dt="0.04" showBehaviorModels="0" showCollisionModels="0" showMappings="0" showForceFields="0">
+<Node name="root" gravity="0.0 -2.0 0.0" dt="0.04">
     <RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
 <!--	<DefaultPipeline verbose="0" />
 	<BruteForceDetection name="N2" />

--- a/applications/plugins/SofaCUDA/examples/quadSpringSphere2CUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/quadSpringSphere2CUDA.scn
@@ -1,11 +1,11 @@
 <Node name="root" gravity="0.0 -2.0 0.0" dt="0.04" showBehaviorModels="0" showCollisionModels="0" showMappings="0" showForceFields="0">
     <RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
-<!--	<CollisionPipeline verbose="0" />
+<!--	<DefaultPipeline verbose="0" />
 	<BruteForceDetection name="N2" />
-	<CollisionResponse name="Response" />
+	<DefaultContactManager name="Response" />
 	<CudaProximityIntersection alarmDistance="0.002" contactDistance="0.001" />-->
 	<Node name="Floor">
-		<RegularGrid
+		<RegularGridTopology
 			nx="2" ny="1" nz="2"
 			xmin="20" xmax="-20"
 			ymin="-3.05" ymax="-3.05"
@@ -23,12 +23,12 @@
 	</Node>
 	<Node name="SquareCloth">
 		<!--<CGImplicit rayleighMass="0.05"  iterations="10" threshold="0.000001"/>-->
-		<EulerImplicit rayleighMass="0.05" rayleighStiffness="0.1" />
+		<EulerImplicitSolver rayleighMass="0.05" rayleighStiffness="0.1" />
 		<CGLinearSolver iterations="10" threshold="0.000001"/>
 	<Node name="SquareCloth1">
 		<MechanicalObject template="CudaVec3f" />
 		<UniformMass totalmass="100" />
-		<RegularGrid
+		<RegularGridTopology
 			nx="20" ny="1" nz="20"
 			xmin="12" xmax="-12"
 			ymin="7" ymax="7"
@@ -47,7 +47,7 @@
 		<!--
 		<Node name="Surf">
 			<MechanicalObject />
-			<RegularGrid
+			<RegularGridTopology
 				nx="100" ny="1" nz="100"
 				xmin="12" xmax="-12"
 				ymin="7" ymax="7"
@@ -60,7 +60,7 @@
 	<Node name="SquareCloth2">
 		<MechanicalObject template="CudaVec3f" />
 		<UniformMass totalmass="100" />
-		<RegularGrid
+		<RegularGridTopology
 			nx="20" ny="1" nz="20"
 			xmin="12" xmax="-12"
 			ymin="7" ymax="7"
@@ -79,7 +79,7 @@
 		<!--
 		<Node name="Surf">
 			<MechanicalObject />
-			<RegularGrid
+			<RegularGridTopology
 				nx="100" ny="1" nz="100"
 				xmin="12" xmax="-12"
 				ymin="7" ymax="7"
@@ -92,7 +92,7 @@
 	<Node name="SquareCloth3">
 		<MechanicalObject template="CudaVec3f" />
 		<UniformMass totalmass="100" />
-		<RegularGrid
+		<RegularGridTopology
 			nx="20" ny="1" nz="20"
 			xmin="12" xmax="-12"
 			ymin="7" ymax="7"
@@ -111,7 +111,7 @@
 		<!--
 		<Node name="Surf">
 			<MechanicalObject />
-			<RegularGrid
+			<RegularGridTopology
 				nx="100" ny="1" nz="100"
 				xmin="12" xmax="-12"
 				ymin="7" ymax="7"
@@ -124,7 +124,7 @@
 	<Node name="SquareCloth4">
 		<MechanicalObject template="CudaVec3f" />
 		<UniformMass totalmass="100" />
-		<RegularGrid
+		<RegularGridTopology
 			nx="20" ny="1" nz="20"
 			xmin="12" xmax="-12"
 			ymin="7" ymax="7"
@@ -143,7 +143,7 @@
 		<!--
 		<Node name="Surf">
 			<MechanicalObject />
-			<RegularGrid
+			<RegularGridTopology
 				nx="100" ny="1" nz="100"
 				xmin="12" xmax="-12"
 				ymin="7" ymax="7"

--- a/applications/plugins/SofaCUDA/examples/quadSpringSphere2CUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/quadSpringSphere2CUDA.scn
@@ -27,7 +27,7 @@
 		<CGLinearSolver iterations="10" threshold="0.000001"/>
 	<Node name="SquareCloth1">
 		<MechanicalObject template="CudaVec3f" />
-		<UniformMass totalmass="100" />
+		<UniformMass totalMass="100" />
 		<RegularGridTopology
 			nx="20" ny="1" nz="20"
 			xmin="12" xmax="-12"
@@ -59,7 +59,7 @@
 	</Node>
 	<Node name="SquareCloth2">
 		<MechanicalObject template="CudaVec3f" />
-		<UniformMass totalmass="100" />
+		<UniformMass totalMass="100" />
 		<RegularGridTopology
 			nx="20" ny="1" nz="20"
 			xmin="12" xmax="-12"
@@ -91,7 +91,7 @@
 	</Node>
 	<Node name="SquareCloth3">
 		<MechanicalObject template="CudaVec3f" />
-		<UniformMass totalmass="100" />
+		<UniformMass totalMass="100" />
 		<RegularGridTopology
 			nx="20" ny="1" nz="20"
 			xmin="12" xmax="-12"
@@ -123,7 +123,7 @@
 	</Node>
 	<Node name="SquareCloth4">
 		<MechanicalObject template="CudaVec3f" />
-		<UniformMass totalmass="100" />
+		<UniformMass totalMass="100" />
 		<RegularGridTopology
 			nx="20" ny="1" nz="20"
 			xmin="12" xmax="-12"

--- a/applications/plugins/SofaCUDA/examples/quadSpringSphereCUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/quadSpringSphereCUDA.scn
@@ -1,11 +1,11 @@
 <Node name="root" gravity="0.0 -2.0 0.0" dt="0.04" showBehaviorModels="0" showCollisionModels="0" showMappings="0" showForceFields="0">
     <RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
-	<CollisionPipeline verbose="0" />
+	<DefaultPipeline verbose="0" />
 	<BruteForceDetection name="N2" />
-	<CollisionResponse name="Response" />
+	<DefaultContactManager name="Response" />
 	<CudaProximityIntersection alarmDistance="0.002" contactDistance="0.001" />
 	<Node name="Floor">
-		<RegularGrid
+		<RegularGridTopology
 			nx="2" ny="1" nz="2"
 			xmin="20" xmax="-20"
 			ymin="-3.05" ymax="-3.05"
@@ -23,11 +23,11 @@
 	</Node>
 	<Node name="SquareCloth1">
 		<!--<CGImplicit rayleighMass="0.05"  iterations="10" threshold="0.000001"/>-->
-		<EulerImplicit rayleighMass="0.05" rayleighStiffness="0.1" />
+		<EulerImplicitSolver rayleighMass="0.05" rayleighStiffness="0.1" />
 		<CGLinearSolver iterations="10" threshold="0.000001"/>
 		<MechanicalObject template="CudaVec3f" />
 		<UniformMass totalmass="100" />
-		<RegularGrid
+		<RegularGridTopology
 			nx="100" ny="1" nz="100"
 			xmin="12" xmax="-12"
 			ymin="7" ymax="7"
@@ -43,7 +43,7 @@
 			<CudaVisualModel template="CudaVec3f" diffuse="0 0.8 0 1.0" computeNormals="true" />
 		</Node>
 		<Node>
-			<RegularGrid
+			<RegularGridTopology
 				nx="4" ny="1" nz="4"
 			xmin="12" xmax="-12"
 			ymin="7" ymax="7"
@@ -56,7 +56,7 @@
 		<!--
 		<Node name="Surf">
 			<MechanicalObject />
-			<RegularGrid
+			<RegularGridTopology
 				nx="100" ny="1" nz="100"
 				xmin="12" xmax="-12"
 				ymin="7" ymax="7"

--- a/applications/plugins/SofaCUDA/examples/quadSpringSphereCUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/quadSpringSphereCUDA.scn
@@ -26,7 +26,7 @@
 		<EulerImplicitSolver rayleighMass="0.05" rayleighStiffness="0.1" />
 		<CGLinearSolver iterations="10" threshold="0.000001"/>
 		<MechanicalObject template="CudaVec3f" />
-		<UniformMass totalmass="100" />
+		<UniformMass totalMass="100" />
 		<RegularGridTopology
 			nx="100" ny="1" nz="100"
 			xmin="12" xmax="-12"

--- a/applications/plugins/SofaCUDA/examples/quadSpringSphereCUDA.scn
+++ b/applications/plugins/SofaCUDA/examples/quadSpringSphereCUDA.scn
@@ -1,4 +1,4 @@
-<Node name="root" gravity="0.0 -2.0 0.0" dt="0.04" showBehaviorModels="0" showCollisionModels="0" showMappings="0" showForceFields="0">
+<Node name="root" gravity="0.0 -2.0 0.0" dt="0.04">
     <RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
 	<DefaultPipeline verbose="0" />
 	<BruteForceDetection name="N2" />

--- a/applications/plugins/SofaCUDA/examples/raptor-cpu.scn
+++ b/applications/plugins/SofaCUDA/examples/raptor-cpu.scn
@@ -3,7 +3,7 @@
   <Node name="M1">
     <MeshVTKLoader name="volume" filename="mesh/raptorTetra_19409.vtu" onlyAttachedPoints="false" />
 <!--    <MeshObjLoader name="surface" filename="mesh/raptor8k1.obj" />-->
-    <EulerImplicit rayleighMass="0.01" rayleighStiffness="0.01" />
+    <EulerImplicitSolver rayleighMass="0.01" rayleighStiffness="0.01" />
     <CGLinearSolver iterations="25" tolerance="1e-6" threshold="1e-20"/>
 <!--	<ShewchukPCGLinearSolver iterations="25" tolerance="1e-3" preconditioners="precond" />
 	<JacobiPreconditioner template="CudaDiagonalMatrixf" name="precond" /> -->

--- a/applications/plugins/SofaCUDA/examples/raptor-cpu.scn
+++ b/applications/plugins/SofaCUDA/examples/raptor-cpu.scn
@@ -1,30 +1,32 @@
-<Node name="root" dt="0.04" showBehaviorModels="0" showCollisionModels="0" showMappings="0" showForceFields="1">
-    <RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
-  <Node name="M1">
-    <MeshVTKLoader name="volume" filename="mesh/raptorTetra_19409.vtu" onlyAttachedPoints="false" />
+<Node name="root" dt="0.04">
+	<VisualStyle displayFlags="showBehaviorModels showForceFields" />
+	<RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
+	
+	<Node name="M1">
+		<MeshVTKLoader name="volume" filename="mesh/raptorTetra_19409.vtu" onlyAttachedPoints="false" />
 <!--    <MeshObjLoader name="surface" filename="mesh/raptor8k1.obj" />-->
-    <EulerImplicitSolver rayleighMass="0.01" rayleighStiffness="0.01" />
-    <CGLinearSolver iterations="25" tolerance="1e-6" threshold="1e-20"/>
+		<EulerImplicitSolver rayleighMass="0.01" rayleighStiffness="0.01" />
+		<CGLinearSolver iterations="25" tolerance="1e-6" threshold="1e-20"/>
 <!--	<ShewchukPCGLinearSolver iterations="25" tolerance="1e-3" preconditioners="precond" />
-	<JacobiPreconditioner template="CudaDiagonalMatrixf" name="precond" /> -->
-    <MeshTopology src="@volume" />
-	<MechanicalObject template="Vec3f" />
+		<JacobiPreconditioner template="CudaDiagonalMatrixf" name="precond" /> -->
+		<MeshTopology src="@volume" />
+		<MechanicalObject template="Vec3" />
 
-	<UniformMass mass="0.01" />
+		<UniformMass vertexMass="0.01" />
 
-	<BoxROI name="box0" box="-2.2 -1 -10 2.2  10  10" drawBoxes="1" />
-	<BoxROI name="box1" box="-2.2 -1  -1 2.2 2.5 1.5" drawBoxes="1" />
-	<IndexValueMapper name="ind_box0"                                      indices="@box0.tetrahedronIndices" value="100000" />
-	<IndexValueMapper name="ind_box1" inputValues="@ind_box0.outputValues" indices="@box1.tetrahedronIndices" value="1000000" />
+		<BoxROI name="box0" box="-2.2 -1 -10 2.2  10  10" drawBoxes="1" />
+		<BoxROI name="box1" box="-2.2 -1  -1 2.2 2.5 1.5" drawBoxes="1" />
+		<IndexValueMapper name="ind_box0"                                      indices="@box0.tetrahedronIndices" value="100000" />
+		<IndexValueMapper name="ind_box1" inputValues="@ind_box0.outputValues" indices="@box1.tetrahedronIndices" value="1000000" />
 
-	<TetrahedronFEMForceField name="FEM" youngModulus="@ind_box1.outputValues" poissonRatio="0.4" listening="true" />
+		<TetrahedronFEMForceField name="FEM" youngModulus="@ind_box1.outputValues" poissonRatio="0.4" listening="true" />
 
-	<BoxROI name="box3" box="-2.2 -0.3 -9.2    2.2 0.110668 2.88584" drawBoxes="1" drawSize="2" />
-	<FixedConstraint indices="@box3.indices" />	  
+		<BoxROI name="box3" box="-2.2 -0.3 -9.2    2.2 0.110668 2.88584" drawBoxes="1" drawSize="2" />
+		<FixedConstraint indices="@box3.indices" />	  
 
-	<BoxROI name="boxF" box="-2.2 -1 6.88 2.2  10  10" drawBoxes="true" />
-    <ConstantForceField points="@boxF.indices" force="7.5 -6.63 -15" arrowSizeCoef="0.1" />
-	<PlaneForceField normal="0 1 0" d="-0.2" stiffness="100"  draw="1" drawSize="20" />
+		<BoxROI name="boxF" box="-2.2 -1 6.88 2.2  10  10" drawBoxes="true" />
+		<ConstantForceField indices="@boxF.indices" force="7.5 -6.63 -15" arrowSizeCoef="0.1" />
+		<PlaneForceField normal="0 1 0" d="-0.2" stiffness="100"  showPlane="1" showPlaneSize="20" />
 <!--
 		<Node name="Surf">
 			<Mesh filename="mesh/raptor_35kp.obj"/>

--- a/applications/plugins/SofaCUDA/examples/raptor-cuda.scn
+++ b/applications/plugins/SofaCUDA/examples/raptor-cuda.scn
@@ -1,30 +1,32 @@
-<Node name="root" dt="0.04" showBehaviorModels="0" showCollisionModels="0" showMappings="0" showForceFields="1">
-    <RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
-  <Node name="M1">
-    <MeshVTKLoader name="volume" filename="mesh/raptorTetra_19409.vtu" onlyAttachedPoints="false" />
-<!--    <MeshObjLoader name="surface" filename="mesh/raptor8k1.obj" />-->
-    <EulerImplicitSolver rayleighStiffness="0.1" rayleighMass="0.1" />
-    <CGLinearSolver iterations="25" tolerance="1e-6" threshold="1e-20"/>
-<!--	<ShewchukPCGLinearSolver iterations="25" tolerance="1e-3" preconditioners="precond" />
-	<JacobiPreconditioner template="CudaDiagonalMatrixf" name="precond" /> -->
-    <MeshTopology src="@volume" />
-	<MechanicalObject template="CudaVec3f" />
+<Node name="root" dt="0.04">
+	<VisualStyle displayFlags="showBehaviorModels showForceFields" />
+	<RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
+	
+	<Node name="M1">
+		<MeshVTKLoader name="volume" filename="mesh/raptorTetra_19409.vtu" onlyAttachedPoints="false" />
+	<!--    <MeshObjLoader name="surface" filename="mesh/raptor8k1.obj" />-->
+		<EulerImplicitSolver rayleighStiffness="0.1" rayleighMass="0.1" />
+		<CGLinearSolver iterations="25" tolerance="1e-6" threshold="1e-20"/>
+	<!--	<ShewchukPCGLinearSolver iterations="25" tolerance="1e-3" preconditioners="precond" />
+		<JacobiPreconditioner template="CudaDiagonalMatrixf" name="precond" /> -->
+		<MeshTopology src="@volume" />
+		<MechanicalObject template="CudaVec3f" />
 
-	<UniformMass mass="0.01" />
+		<UniformMass vertexMass="0.01" />
 
-	<BoxROI name="box0" box="-2.2 -1 -10 2.2  10  10" drawBoxes="1" />
-	<BoxROI name="box1" box="-2.2 -1  -1 2.2 2.5 1.5" drawBoxes="1" />
-	<IndexValueMapper name="ind_box0"                                      indices="@box0.tetrahedronIndices" value="100000" />
-	<IndexValueMapper name="ind_box1" inputValues="@ind_box0.outputValues" indices="@box1.tetrahedronIndices" value="1000000" />
+		<BoxROI name="box0" box="-2.2 -1 -10 2.2  10  10" drawBoxes="1" />
+		<BoxROI name="box1" box="-2.2 -1  -1 2.2 2.5 1.5" drawBoxes="1" />
+		<IndexValueMapper name="ind_box0"                                      indices="@box0.tetrahedronIndices" value="100000" />
+		<IndexValueMapper name="ind_box1" inputValues="@ind_box0.outputValues" indices="@box1.tetrahedronIndices" value="1000000" />
 
-	<TetrahedronFEMForceField name="FEM" youngModulus="@ind_box1.outputValues" poissonRatio="0.4" listening="true" />
+		<TetrahedronFEMForceField name="FEM" youngModulus="@ind_box1.outputValues" poissonRatio="0.4" listening="true" />
 
-	<BoxROI name="box3" box="-2.2 -0.3 -9.2    2.2 0.110668 2.88584" drawBoxes="1" drawSize="2" />
-	<FixedConstraint indices="@box3.indices" />	  
+		<BoxROI name="box3" box="-2.2 -0.3 -9.2    2.2 0.110668 2.88584" drawBoxes="1" drawSize="2" />
+		<FixedConstraint indices="@box3.indices" />	  
 
-	<BoxROI name="boxF" box="-2.2 -1 6.88 2.2  10  10" drawBoxes="true" />
-    <ConstantForceField points="@boxF.indices" force="7.5 -6.63 -15" arrowSizeCoef="0.1" />
-	<PlaneForceField normal="0 1 0" d="-0.2" stiffness="100"  draw="1" drawSize="20" />
+		<BoxROI name="boxF" box="-2.2 -1 6.88 2.2  10  10" drawBoxes="true" />
+		<ConstantForceField indices="@boxF.indices" force="7.5 -6.63 -15" arrowSizeCoef="0.1" />
+		<PlaneForceField normal="0 1 0" d="-0.2" stiffness="100"  showPlane="1" showPlaneSize="20" />
 <!--
 		<Node name="Surf">
 			<Mesh filename="mesh/raptor_35kp.obj"/>

--- a/applications/plugins/SofaCUDA/examples/raptor-cuda.scn
+++ b/applications/plugins/SofaCUDA/examples/raptor-cuda.scn
@@ -3,7 +3,7 @@
   <Node name="M1">
     <MeshVTKLoader name="volume" filename="mesh/raptorTetra_19409.vtu" onlyAttachedPoints="false" />
 <!--    <MeshObjLoader name="surface" filename="mesh/raptor8k1.obj" />-->
-    <EulerImplicit  rayleighStiffness="0.1" rayleighMass="0.1" />
+    <EulerImplicitSolver rayleighStiffness="0.1" rayleighMass="0.1" />
     <CGLinearSolver iterations="25" tolerance="1e-6" threshold="1e-20"/>
 <!--	<ShewchukPCGLinearSolver iterations="25" tolerance="1e-3" preconditioners="precond" />
 	<JacobiPreconditioner template="CudaDiagonalMatrixf" name="precond" /> -->

--- a/applications/plugins/SofaCUDA/examples/raptor-surface-cpu.scn
+++ b/applications/plugins/SofaCUDA/examples/raptor-surface-cpu.scn
@@ -5,7 +5,7 @@
     <MeshObjLoader name="surface" filename="mesh/raptor_8kp.obj" triangulate="1" />
 <!--    <MeshObjLoader name="surface" filename="mesh/raptor8k1.obj" triangulate="1" />-->
 <!--    <MeshObjLoader name="surface" filename="mesh/raptor_35kp.obj" triangulate="1" />-->
-    <EulerImplicit  rayleighStiffness="0.1" rayleighMass="0.1" />
+    <EulerImplicitSolver rayleighStiffness="0.1" rayleighMass="0.1" />
     <CGLinearSolver iterations="25" tolerance="1e-6" threshold="1e-20"/>
     <MeshTopology src="@surface" />
 	<MechanicalObject template="Vec3d" />

--- a/applications/plugins/SofaCUDA/examples/raptor-surface-cpu.scn
+++ b/applications/plugins/SofaCUDA/examples/raptor-surface-cpu.scn
@@ -1,5 +1,5 @@
 <Node name="root" dt="0.04">
-    <RequiredPlugin name="CUDA computing" pluginName="SofaCUDA" />
+    
   <Node name="M1">
     <MeshVTKLoader name="volume" filename="mesh/raptorTetra_19409.vtu" onlyAttachedPoints="false" />
     <MeshObjLoader name="surface" filename="mesh/raptor_8kp.obj" triangulate="1" />
@@ -10,16 +10,16 @@
     <MeshTopology src="@surface" />
 	<MechanicalObject template="Vec3d" />
 
-	<UniformMass mass="0.1" />
+	<UniformMass totalMass="0.1" />
 
 	<TriangularFEMForceFieldOptim name="FEM" youngModulus="10000" poissonRatio="0.4" />
 
 	<BoxROI name="box3" box="-2.2 -0.3 -9.2    2.2 0.110668 2.88584" drawBoxes="1" drawSize="2" />
 	<FixedConstraint indices="@box3.indices" />	  
-	<PlaneForceField normal="0 1 0" d="-0.2" stiffness="100"  draw="1" drawSize="20" />
-<!--	<CudaVisualModel template="CudaVec3f" diffuse="0.2 0.8 0.1 1.0" computeNormals="true" />-->
+	<PlaneForceField normal="0 1 0" d="-0.2" stiffness="100"  showPlane="1" showPlaneSize="20" />
+
 	<Node name="Surf">
-		<VisualModel src="@../surface" diffuse="0.2 0.8 0.1 1.0" computeNormals="true" />
+		<OglModel src="@../surface" diffuse="0.2 0.8 0.1 1.0" />
 		<IdentityMapping />
 	</Node>
   </Node>

--- a/applications/plugins/SofaCUDA/examples/raptor-surface-cuda.scn
+++ b/applications/plugins/SofaCUDA/examples/raptor-surface-cuda.scn
@@ -5,7 +5,7 @@
     <MeshObjLoader name="surface" filename="mesh/raptor_8kp.obj" triangulate="1" />
 <!--    <MeshObjLoader name="surface" filename="mesh/raptor8k1.obj" triangulate="1" />-->
 <!--    <MeshObjLoader name="surface" filename="mesh/raptor_35kp.obj" triangulate="1" />-->
-    <EulerImplicit  rayleighStiffness="0.1" rayleighMass="0.1" />
+    <EulerImplicitSolver rayleighStiffness="0.1" rayleighMass="0.1" />
     <CGLinearSolver iterations="25" tolerance="1e-6" threshold="1e-20"/>
     <MeshTopology src="@surface" />
 	<MechanicalObject template="CudaVec3f" />

--- a/applications/plugins/SofaCUDA/examples/raptor-surface-cuda.scn
+++ b/applications/plugins/SofaCUDA/examples/raptor-surface-cuda.scn
@@ -10,19 +10,18 @@
     <MeshTopology src="@surface" />
 	<MechanicalObject template="CudaVec3f" />
 
-	<UniformMass mass="0.1" />
+	<UniformMass totalMass="0.1" />
 
 	<TriangularFEMForceFieldOptim name="FEM" youngModulus="10000" poissonRatio="0.4" />
 
 	<BoxROI name="box3" box="-2.2 -0.3 -9.2    2.2 0.110668 2.88584" drawBoxes="1" drawSize="2" />
 	<FixedConstraint indices="@box3.indices" />	  
-	<PlaneForceField normal="0 1 0" d="-0.2" stiffness="100"  draw="1" drawSize="20" />
-	<CudaVisualModel template="CudaVec3f" diffuse="0.2 0.8 0.1 1.0" computeNormals="true" />
-<!--
+	<PlaneForceField normal="0 1 0" d="-0.2" stiffness="100"  showPlane="1" showPlaneSize="20" />
+
 	<Node name="Surf">
-		<VisualModel src="@../surface" diffuse="0.2 0.8 0.1 1.0" computeNormals="true" />
+		<OglModel src="@../surface" diffuse="0.2 0.8 0.1 1.0" computeNormals="true" />
 		<IdentityMapping />
 	</Node>
--->
+
   </Node>
 </Node>

--- a/applications/plugins/SofaCUDA/examples/raptor.scn
+++ b/applications/plugins/SofaCUDA/examples/raptor.scn
@@ -3,7 +3,7 @@
   <Node name="M1">
     <MeshVTKLoader name="volume" filename="mesh/raptorTetra_12580.vtu" onlyAttachedPoints="true" />
 <!--    <MeshObjLoader name="surface" filename="mesh/raptor8k1.obj" />-->
-    <EulerImplicit  rayleighStiffness="0.1" rayleighMass="0.1" />
+    <EulerImplicitSolver rayleighStiffness="0.1" rayleighMass="0.1" />
 <!--    <CGLinearSolver iterations="30" tolerance="1e-10" threshold="1e-10"/>-->
 	<ShewchukPCGLinearSolver iterations="30" tolerance="1e-10" preconditioners="precond" />
 	<JacobiPreconditioner template="CudaDiagonalMatrixf" name="precond" />
@@ -41,7 +41,7 @@
 	</Node>
   </Node>
 	<Node name="Floor">
-		<RegularGrid
+		<RegularGridTopology
 			nx="2" ny="1" nz="2"
 			xmin="20" xmax="-20"
 			ymin="-0.2" ymax="-0.2"

--- a/applications/plugins/SofaCUDA/examples/raptor.scn
+++ b/applications/plugins/SofaCUDA/examples/raptor.scn
@@ -10,7 +10,7 @@
     <MeshTopology src="@volume" />
 	<MechanicalObject template="CudaVec3f" />
 
-	<UniformMass totalmass="1" />
+	<UniformMass totalMass="1" />
 
 	<BoxROI name="box0" box="-2.2 -1 -10 2.2  10  10" drawBoxes="1" />
 	<BoxROI name="box1" box="-2.2 -1  -1 2.2 2.5 1.5" drawBoxes="1" />

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaBarycentricMapping-3f.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaBarycentricMapping-3f.cpp
@@ -281,7 +281,7 @@ using namespace sofa::component::mapping;
 
 int BarycentricMappingCudaClass_3f = core::RegisterObject("Supports GPU-side computations using CUDA")
         .add< BarycentricMapping< CudaVec3fTypes, CudaVec3fTypes> >()
-        .add< BarycentricMapping< CudaVec3fTypes, ExtVec3fTypes> >()
+        .add< BarycentricMapping< CudaVec3fTypes, ExtVec3Types> >()
         ;
 
 } // namespace cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaBarycentricMapping-3f1.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaBarycentricMapping-3f1.cpp
@@ -236,7 +236,7 @@ void BarycentricMapperMeshTopology<CudaVec3f1Types,CudaVec3f1Types>::resize( cor
 // instanciations involving only CudaVec3f1Types with CudaVec3f1Types or ExtVec3fTypes
 
 template class SOFA_GPU_CUDA_API BarycentricMapping< CudaVec3f1Types, CudaVec3f1Types>;
-template class SOFA_GPU_CUDA_API BarycentricMapping< CudaVec3f1Types, ExtVec3fTypes>;
+template class SOFA_GPU_CUDA_API BarycentricMapping< CudaVec3f1Types, ExtVec3Types>;
 
 
 
@@ -257,7 +257,7 @@ using namespace sofa::component::mapping;
 
 int BarycentricMappingCudaClass_3f1 = core::RegisterObject("Supports GPU-side computations using CUDA")
         .add< BarycentricMapping< CudaVec3f1Types, CudaVec3f1Types> >()
-        .add< BarycentricMapping< CudaVec3f1Types, ExtVec3fTypes> >()
+        .add< BarycentricMapping< CudaVec3f1Types, ExtVec3Types> >()
         ;
 
 } // namespace cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaDiagonalMass.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaDiagonalMass.cpp
@@ -19,6 +19,9 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#ifndef SOFA_GPU_CUDA_CUDADIAGONALMASS_CPP
+#define SOFA_GPU_CUDA_CUDADIAGONALMASS_CPP
+
 #include "CudaTypes.h"
 #include "CudaDiagonalMass.inl"
 #include <sofa/core/behavior/Mass.inl>
@@ -39,11 +42,17 @@ namespace gpu
 namespace cuda
 {
 
+template class SOFA_GPU_CUDA_API component::mass::DiagonalMass<CudaVec3fTypes, float>;
+#ifdef SOFA_GPU_CUDA_DOUBLE
+template class SOFA_GPU_CUDA_API component::mass::DiagonalMass<CudaVec3dTypes, double>;
+#endif
 
 // Register in the Factory
 int DiagonalMassCudaClass = core::RegisterObject("Supports GPU-side computations using CUDA")
+    .add< component::mass::DiagonalMass<CudaVec3fTypes, float> >()
+
 #ifdef SOFA_GPU_CUDA_DOUBLE
-        .add< component::mass::DiagonalMass<CudaVec3Types,double> >()
+    .add< component::mass::DiagonalMass<CudaVec3dTypes,double> >()
 // .add< component::mass::DiagonalMass<CudaVec3d1Types,double> >()
 // .add< component::mass::DiagonalMass<CudaRigid3Types,sofa::defaulttype::Rigid3Mass> >()
  // SOFA_GPU_CUDA_DOUBLE
@@ -57,3 +66,4 @@ int DiagonalMassCudaClass = core::RegisterObject("Supports GPU-side computations
 
 } // namespace sofa
 
+#endif // SOFA_GPU_CUDA_CUDADIAGONALMASS_CPP

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaDiagonalMass.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaDiagonalMass.cpp
@@ -36,16 +36,29 @@
 namespace sofa
 {
 
+namespace component
+{
+
+namespace mass
+{
+
+template class SOFA_GPU_CUDA_API DiagonalMass<sofa::gpu::cuda::CudaVec3fTypes, float>;
+
+#ifdef SOFA_GPU_CUDA_DOUBLE
+template class SOFA_GPU_CUDA_API DiagonalMass<sofa::gpu::cuda::CudaVec3dTypes, double>;
+#endif
+
+} // namespace mass
+
+} // namespace component
+
+
 namespace gpu
 {
 
 namespace cuda
 {
 
-template class SOFA_GPU_CUDA_API component::mass::DiagonalMass<CudaVec3fTypes, float>;
-#ifdef SOFA_GPU_CUDA_DOUBLE
-template class SOFA_GPU_CUDA_API component::mass::DiagonalMass<CudaVec3dTypes, double>;
-#endif
 
 // Register in the Factory
 int DiagonalMassCudaClass = core::RegisterObject("Supports GPU-side computations using CUDA")
@@ -60,9 +73,9 @@ int DiagonalMassCudaClass = core::RegisterObject("Supports GPU-side computations
         ;
 
 
-} // namespace mass
+} // namespace cuda
 
-} // namespace component
+} // namespace gpu
 
 } // namespace sofa
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaDiagonalMass.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaDiagonalMass.h
@@ -84,6 +84,13 @@ void DiagonalMass<gpu::cuda::CudaVec3dTypes, double>::addForce(const core::Mecha
 
 #endif // SOFA_GPU_CUDA_DOUBLE
 
+#ifndef SOFA_GPU_CUDA_CUDADIAGONALMASS_CPP
+extern template class SOFA_GPU_CUDA_API component::mass::DiagonalMass<CudaVec3fTypes, float>;
+#ifdef SOFA_GPU_CUDA_DOUBLE
+extern template class SOFA_GPU_CUDA_API component::mass::DiagonalMass<CudaVec3dTypes, double>;
+#endif
+#endif
+
 } // namespace mass
 
 } // namespace component

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaIdentityMapping.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaIdentityMapping.cpp
@@ -58,9 +58,6 @@ template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, Vec3Types>;
 template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, ExtVec3Types >;
 template class SOFA_GPU_CUDA_API  IdentityMapping< Vec3dTypes, CudaVec3f1Types>;
 
-template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3Types, Vec3Types>;
-template class SOFA_GPU_CUDA_API  IdentityMapping< Vec3Types, CudaVec3Types>;
-
 
 #ifdef SOFA_GPU_CUDA_DOUBLE
 // CudaVec3dTypes

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaIdentityMapping.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaIdentityMapping.cpp
@@ -43,29 +43,39 @@ using namespace sofa::core;
 using namespace sofa::core::behavior;
 using namespace sofa::gpu::cuda;
 
+
+// CudaVec3fTypes
 template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3fTypes, CudaVec3fTypes>;
+template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3fTypes, CudaVec3f1Types>;
+template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3fTypes, Vec3Types>;
+template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3fTypes, ExtVec3Types>;
+template class SOFA_GPU_CUDA_API  IdentityMapping< Vec3Types, CudaVec3fTypes>;
+
+// CudaVec3f1Types
+template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, CudaVec3f1Types>;
+template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, CudaVec3fTypes>;
+template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, Vec3Types>;
+template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, ExtVec3Types >;
+template class SOFA_GPU_CUDA_API  IdentityMapping< Vec3dTypes, CudaVec3f1Types>;
+
 template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3Types, Vec3Types>;
 template class SOFA_GPU_CUDA_API  IdentityMapping< Vec3Types, CudaVec3Types>;
 
 
 #ifdef SOFA_GPU_CUDA_DOUBLE
-template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3fTypes, CudaVec3dTypes>;
-template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3dTypes, CudaVec3fTypes>;
+// CudaVec3dTypes
 template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3dTypes, CudaVec3dTypes>;
-template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3dTypes, Vec3fTypes>;
-template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3dTypes, Vec3dTypes>;
-template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3d1Types, ExtVec3dTypes >;
-template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3dTypes, ExtVec3dTypes >;
-#endif
-template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, ExtVec3fTypes >;
-template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, CudaVec3f1Types>;
-template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, Vec3fTypes>;
-template class SOFA_GPU_CUDA_API  IdentityMapping< Vec3dTypes, CudaVec3f1Types>;
-template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, Vec3dTypes>;
-template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, ExtVec3Types >;
+template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3dTypes, CudaVec3fTypes>;
+template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3dTypes, Vec3Types>;
+template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3dTypes, ExtVec3Types >;
 
-template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, CudaVec3fTypes>;
-template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3fTypes, CudaVec3f1Types>;
+template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3fTypes, CudaVec3dTypes>;
+template class SOFA_GPU_CUDA_API  IdentityMapping< Vec3Types, CudaVec3dTypes>;
+
+template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3d1Types, ExtVec3Types >;
+
+#endif
+
 
 } // namespace mapping
 
@@ -82,35 +92,34 @@ using namespace sofa::core::behavior;
 using namespace sofa::component::mapping;
 
 int IdentityMappingCudaClass = core::RegisterObject("Supports GPU-side computations using CUDA")
-        .add< IdentityMapping< CudaVec3fTypes, CudaVec3fTypes> >()
-        .add< IdentityMapping< CudaVec3fTypes, Vec3fTypes> >()
-        .add< IdentityMapping< Vec3fTypes, CudaVec3fTypes> >()
-        .add< IdentityMapping< CudaVec3Types, Vec3Types> >()
-        .add< IdentityMapping< Vec3Types, CudaVec3Types> >()
 
-
+    // CudaVec3fTypes
+    .add< IdentityMapping< CudaVec3fTypes, CudaVec3fTypes> >()
+    .add< IdentityMapping< CudaVec3fTypes, CudaVec3f1Types> >()
+    .add< IdentityMapping< CudaVec3fTypes, Vec3Types> >()
+    .add< IdentityMapping< CudaVec3fTypes, ExtVec3Types> >()
+    .add< IdentityMapping< Vec3Types, CudaVec3fTypes> >()
+    
+    // CudaVec3f1Types
+    .add< IdentityMapping< CudaVec3f1Types, CudaVec3f1Types> >()
+    .add< IdentityMapping< CudaVec3f1Types, CudaVec3fTypes> >()
+    .add< IdentityMapping< CudaVec3f1Types, Vec3Types> >()
+    .add< IdentityMapping< CudaVec3f1Types, ExtVec3Types> >()
+    .add< IdentityMapping< Vec3Types, CudaVec3f1Types> >()
+          
 #ifdef SOFA_GPU_CUDA_DOUBLE
-        .add< IdentityMapping< CudaVec3fTypes, CudaVec3dTypes> >()
-        .add< IdentityMapping< CudaVec3dTypes, CudaVec3fTypes> >()
-        .add< IdentityMapping< CudaVec3dTypes, CudaVec3dTypes> >()
-        .add< IdentityMapping< CudaVec3dTypes, Vec3fTypes> >()
-        .add< IdentityMapping< CudaVec3dTypes, Vec3dTypes> >()
-        .add< IdentityMapping< Vec3fTypes, CudaVec3dTypes> >()
-        .add< IdentityMapping< Vec3dTypes, CudaVec3dTypes> >()
-        .add< IdentityMapping< CudaVec3d1Types, ExtVec3fTypes> >()
-        .add< IdentityMapping< CudaVec3dTypes, ExtVec3fTypes> >()
+    // CudaVec3dTypes
+    .add< IdentityMapping< CudaVec3dTypes, CudaVec3dTypes> >()
+    .add< IdentityMapping< CudaVec3dTypes, CudaVec3fTypes> >()
+    .add< IdentityMapping< CudaVec3dTypes, Vec3Types> >()
+    .add< IdentityMapping< CudaVec3dTypes, ExtVec3Types> >()
+
+    .add< IdentityMapping< CudaVec3fTypes, CudaVec3dTypes> >()
+    .add< IdentityMapping< Vec3Types, CudaVec3dTypes> >()
+    
+    .add< IdentityMapping< CudaVec3d1Types, ExtVec3Types> >()    
 #endif
-
-        .add< IdentityMapping< CudaVec3fTypes, ExtVec3fTypes> >()
-        .add< IdentityMapping< CudaVec3f1Types, CudaVec3f1Types> >()
-        .add< IdentityMapping< CudaVec3f1Types, Vec3fTypes> >()
-        .add< IdentityMapping< Vec3fTypes, CudaVec3f1Types> >()
-        .add< IdentityMapping< CudaVec3f1Types, Vec3Types> >()        
-        .add< IdentityMapping< Vec3Types, CudaVec3f1Types> >()
-
-        .add< IdentityMapping< CudaVec3f1Types, ExtVec3fTypes> >()
-        .add< IdentityMapping< CudaVec3f1Types, CudaVec3fTypes> >()
-        .add< IdentityMapping< CudaVec3fTypes, CudaVec3f1Types> >()
+        
         ;
 
 } // namespace cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaIdentityMapping.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaIdentityMapping.h
@@ -88,9 +88,6 @@ extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, Vec3T
 extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, ExtVec3Types >;
 extern template class SOFA_GPU_CUDA_API  IdentityMapping< Vec3dTypes, CudaVec3f1Types>;
 
-extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3Types, Vec3Types>;
-extern template class SOFA_GPU_CUDA_API  IdentityMapping< Vec3Types, CudaVec3Types>;
-
 
 #ifdef SOFA_GPU_CUDA_DOUBLE
 // CudaVec3dTypes

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaIdentityMapping.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaIdentityMapping.h
@@ -74,32 +74,36 @@ using namespace sofa::defaulttype;
 using namespace sofa::component::mapping;
 using namespace sofa::gpu::cuda;
 
+// CudaVec3fTypes
 extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3fTypes, CudaVec3fTypes>;
+extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3fTypes, CudaVec3f1Types>;
+extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3fTypes, Vec3Types>;
+extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3fTypes, ExtVec3Types>;
+extern template class SOFA_GPU_CUDA_API  IdentityMapping< Vec3Types, CudaVec3fTypes>;
+
+// CudaVec3f1Types
+extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, CudaVec3f1Types>;
+extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, CudaVec3fTypes>;
+extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, Vec3Types>;
+extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, ExtVec3Types >;
+extern template class SOFA_GPU_CUDA_API  IdentityMapping< Vec3dTypes, CudaVec3f1Types>;
+
 extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3Types, Vec3Types>;
 extern template class SOFA_GPU_CUDA_API  IdentityMapping< Vec3Types, CudaVec3Types>;
 
 
 #ifdef SOFA_GPU_CUDA_DOUBLE
-extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3fTypes, CudaVec3dTypes>;
-extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3dTypes, CudaVec3fTypes>;
+// CudaVec3dTypes
 extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3dTypes, CudaVec3dTypes>;
-extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3dTypes, Vec3fTypes>;
-extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3dTypes, Vec3dTypes>;
-extern template class SOFA_GPU_CUDA_API  IdentityMapping< Vec3Types, CudaVec3Types>;
+extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3dTypes, CudaVec3fTypes>;
+extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3dTypes, Vec3Types>;
+extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3dTypes, ExtVec3Types >;
 
+extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3fTypes, CudaVec3dTypes>;
+extern template class SOFA_GPU_CUDA_API  IdentityMapping< Vec3Types, CudaVec3dTypes>;
 
-extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3d1Types, ExtVec3dTypes >;
-extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3dTypes, ExtVec3dTypes >;
+extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3d1Types, ExtVec3Types >;
 #endif
-extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, ExtVec3fTypes >;
-extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, CudaVec3f1Types>;
-extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, Vec3fTypes>;
-extern template class SOFA_GPU_CUDA_API  IdentityMapping< Vec3dTypes, CudaVec3f1Types>;
-extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, Vec3dTypes>;
-extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, ExtVec3Types >;
-
-extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3f1Types, CudaVec3fTypes>;
-extern template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3fTypes, CudaVec3f1Types>;
 
 #endif
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMeshMatrixMass.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMeshMatrixMass.cpp
@@ -19,6 +19,9 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#ifndef SOFA_GPU_CUDA_CUDAMESHMATRIXMASS_CPP
+#define SOFA_GPU_CUDA_CUDAMESHMATRIXMASS_CPP
+
 #include <sofa/gpu/cuda/CudaMeshMatrixMass.inl>
 #include <SofaMiscForceField/MeshMatrixMass.inl>
 #include <sofa/core/behavior/Mass.inl>
@@ -44,21 +47,15 @@ namespace mass
 {
 
 template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec3fTypes, float>;
+template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2fTypes, float>;
+template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1fTypes, float>;
+
 #ifdef SOFA_GPU_CUDA_DOUBLE
 template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec3dTypes, double>;
-#endif // SOFA_GPU_CUDA_DOUBLE
-
-
-template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2fTypes, float>;
-#ifdef SOFA_GPU_CUDA_DOUBLE
 template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2dTypes, double>;
-#endif // SOFA_GPU_CUDA_DOUBLE
-
-
-template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1fTypes, float>;
-#ifdef SOFA_GPU_CUDA_DOUBLE
 template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1dTypes, double>;
 #endif // SOFA_GPU_CUDA_DOUBLE
+
 
 } // namespace mass
 
@@ -86,4 +83,6 @@ int MeshMatrixMassClassCudaClass = core::RegisterObject("Supports GPU-side compu
 } // namespace gpu
 
 } // namespace sofa
+
+#endif //SOFA_GPU_CUDA_CUDAMESHMATRIXMASS_CPP
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMeshMatrixMass.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMeshMatrixMass.h
@@ -110,6 +110,20 @@ void MeshMatrixMass<sofa::gpu::cuda::CudaVec1fTypes, float>::addForce(const core
 template<>
 void MeshMatrixMass<sofa::gpu::cuda::CudaVec1fTypes, float>::accFromF(const core::MechanicalParams*, DataVecDeriv& a, const DataVecDeriv& f);
 
+
+#ifndef SOFA_GPU_CUDA_CUDAMESHMATRIXMASS_CPP
+template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec3fTypes, float>;
+template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2fTypes, float>;
+template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1fTypes, float>;
+
+#ifdef SOFA_GPU_CUDA_DOUBLE
+template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec3dTypes, double>;
+template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2dTypes, double>;
+template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1dTypes, double>;
+#endif // SOFA_GPU_CUDA_DOUBLE
+
+#endif //SOFA_GPU_CUDA_CUDAMESHMATRIXMASS_CPP
+
 } // namespace mass
 
 } // namespace component


### PR DESCRIPTION
- Clean all Cuda/Cpu scene examples from aliases.
- Fix **DiagonalMass**, **MeshMatrixMass**, **IdentityMapping** and **BarycentricMapping** class template declaration.
- Fix several scenes behavior.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
