### PR TITLE
[SofaGuiQt] FIX: component/nodes ordering in runSofa scene graph

### DIFF
--- a/applications/sofa/gui/qt/GraphListenerQListView.cpp
+++ b/applications/sofa/gui/qt/GraphListenerQListView.cpp
@@ -411,10 +411,10 @@ void GraphListenerQListView::onBeginAddChild(Node* parent, Node* child)
         item->setExpanded(true);
         items[child] = item;
     }
-    for (Node::SPtr node : child->child)
-        onBeginAddChild(child, node.get());
     for (BaseObject::SPtr obj : child->object)
         onBeginAddObject(child, obj.get());
+    for (Node::SPtr node : child->child)
+        onBeginAddChild(child, node.get());
 }
 
 /*****************************************************************************************************************/


### PR DESCRIPTION
As @epernod noticed, my PR #917 introduced a side effect in runSofa's scene graph UI.
This PR fixes it



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
