### PR TITLE
[SofaPython] FIX the broken Binding_Data::setValue() 

### DIFF
--- a/SofaKernel/framework/sofa/core/objectmodel/BaseData.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseData.h
@@ -367,6 +367,36 @@ public:
     static sofa::core::objectmodel::BaseData* getData(sofa::core::objectmodel::BaseData* d) { return d; }
 };
 
+/** A WriteAccessWithRawPtr is a RAII class, holding a reference to a given container
+ *  and providing access to its data through a non-const void* ptr taking care of the
+ * beginEdit/endEdit pairs.
+ *
+ *  Advantadges of using a WriteAccessWithRawPtr are :
+ *
+ *  - It can be faster that the default methods and operators of the container,
+ *  as verifications and changes notifications can be handled in the accessor's
+ *  constructor and destructor instead of at each item access.
+ */
+class WriteAccessWithRawPtr
+{
+public:
+    WriteAccessWithRawPtr(BaseData* data)
+    {
+        m_data = data;
+        ptr = data->beginEditVoidPtr();
+    }
+
+    ~WriteAccessWithRawPtr()
+    {
+        m_data->endEditVoidPtr();
+    }
+
+    void*     ptr;
+private:
+    WriteAccessWithRawPtr(){}
+    BaseData* m_data;
+};
+
 } // namespace objectmodel
 
 } // namespace core

--- a/applications/plugins/SofaPython/Binding_Data.cpp
+++ b/applications/plugins/SofaPython/Binding_Data.cpp
@@ -25,9 +25,11 @@
 #include "Binding_LinearSpring.h"
 
 #include <sofa/core/objectmodel/BaseData.h>
+using sofa::core::objectmodel::BaseData ;
+using sofa::core::objectmodel::WriteAccessWithRawPtr;
+
 #include <sofa/core/objectmodel/Data.h>
 using sofa::core::objectmodel::BaseObject ;
-using sofa::core::objectmodel::BaseData ;
 using sofa::core::objectmodel::Base ;
 
 #include <sofa/defaulttype/DataTypeInfo.h>
@@ -481,19 +483,18 @@ static PyObject * Data_getValue(PyObject *self, PyObject * args)
     return nullptr;
 }
 
-
 static PyObject * Data_setValue(PyObject *self, PyObject * args)
 {
     BaseData* data = get_basedata( self );
     const AbstractTypeInfo *typeinfo = data->getValueTypeInfo(); /// info about the data value
-    int index;
+    unsigned int index;
     PyObject *value;
 
     if (!PyArg_ParseTuple(args, "iO", &index, &value)) {
         return nullptr;
     }
 
-    if ((unsigned int)index >= typeinfo->size())
+    if (index >= typeinfo->size())
     {
         SP_PYERR_SETSTRING_OUTOFBOUND(0);
         return nullptr;
@@ -501,17 +502,20 @@ static PyObject * Data_setValue(PyObject *self, PyObject * args)
 
     if (typeinfo->Scalar() && PyFloat_Check(value))
     {
-        typeinfo->setScalarValue((void*)data->getValueVoidPtr(),index,PyFloat_AsDouble(value));
+        WriteAccessWithRawPtr access {data} ;
+        typeinfo->setScalarValue(access.ptr,index,PyFloat_AsDouble(value));
         return PyInt_FromLong(0);
     }
     if (typeinfo->Integer() && PyInt_Check(value))
     {
-        typeinfo->setIntegerValue((void*)data->getValueVoidPtr(),index,PyInt_AsLong(value));
+        WriteAccessWithRawPtr access {data} ;
+        typeinfo->setIntegerValue(access.ptr,index,PyInt_AsLong(value));
         return PyInt_FromLong(0);
     }
     if (typeinfo->Text() && PyString_Check(value))
     {
-        typeinfo->setTextValue((void*)data->getValueVoidPtr(),index,PyString_AsString(value));
+        WriteAccessWithRawPtr access {data} ;
+        typeinfo->setTextValue(access.ptr,index,PyString_AsString(value));
         return PyInt_FromLong(0);
     }
 
@@ -573,13 +577,14 @@ static PyObject * Data_getSize(PyObject *self, PyObject * args)
 static PyObject * Data_setSize(PyObject *self, PyObject * args)
 {
     BaseData* data = get_basedata( self );
-    int size;
+    unsigned int size;
     if (!PyArg_ParseTuple(args, "i",&size))
     {
         return nullptr;
     }
     const AbstractTypeInfo *typeinfo = data->getValueTypeInfo();
-    typeinfo->setSize((void*)data->getValueVoidPtr(),size);
+    WriteAccessWithRawPtr access {data};
+    typeinfo->setSize(access.ptr,size);
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
The problem the PR solve is related to how data are changed by the setValue function.

When writing in data through an opaque pointer it is important to properly notify the data successors that a data has changed. This is why write access *must* be done using beginEdit/endEdit and absolutely not
by removing the const qualifier from q getValueVoidPtr using a cast (what was done in the setValue function).  Doing it the wrong way break the data update mechanism. 

The PR fix that.
To ease the writing of the beginEdit/endEdit pair it also add a RAII WriteAccessWithRawPtr. It is in BaseData...because it is for BaseData. 



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
