### PR TITLE
[SofaBaseTopology] Fix Crash when loading a vtk file generated by Gmsh using TetrahedronSetTopologyContainer as container

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
@@ -180,13 +180,11 @@ void TetrahedronSetTopologyContainer::createEdgesInTetrahedronArray()
             edgesAroundVertexMap.insert(std::pair<PointID, EdgeID> (m_edge[edge][0],edge));
             edgesAroundVertexMap.insert(std::pair<PointID, EdgeID> (m_edge[edge][1],edge));
         }
-        size_t i=0;
-        while(i<numTetra && foundEdge == true)
+        for ( size_t i = 0 ; (i < numTetra) && (foundEdge == true) ; ++i )
         {
             const Tetrahedron &t = m_tetrahedron[i];
             // adding edge i in the edge shell of both points
-            EdgeID j=0;
-            while(j<6 && foundEdge == true)
+            for ( EdgeID j = 0 ; (j < 6) && (foundEdge == true) ; ++j )
             {
 
                 //finding edge i in edge array
@@ -204,9 +202,7 @@ void TetrahedronSetTopologyContainer::createEdgesInTetrahedronArray()
                 }
                 if (CHECK_TOPOLOGY)
                     msg_warning_when(!foundEdge) << " In getTetrahedronArray, cannot find edge for tetrahedron " << i << "and edge "<< j;
-                j++;
             }
-            i++;
         }
     }
 
@@ -388,14 +384,15 @@ void TetrahedronSetTopologyContainer::createTetrahedraAroundTriangleArray ()
         createTrianglesInTetrahedronArray();
     m_tetrahedraAroundTriangle.resize( getNumberOfTriangles());
     if (m_trianglesInTetrahedron.size() !=0){
-    for (size_t i=0; i<getNumberOfTetrahedra(); ++i)
-    {
-        // adding tetrahedron i in the shell of all neighbors triangles
-        for (TriangleID j=0; j<4; ++j)
+        for (size_t i=0; i<getNumberOfTetrahedra(); ++i)
         {
-            m_tetrahedraAroundTriangle[ m_trianglesInTetrahedron[i][j] ].push_back( (TetrahedronID)i );
+            // adding tetrahedron i in the shell of all neighbors triangles
+            for (TriangleID j=0; j<4; ++j)
+            {
+                m_tetrahedraAroundTriangle[ m_trianglesInTetrahedron[i][j] ].push_back( (TetrahedronID)i );
+            }
         }
-    }}
+    }
 }
 
 const sofa::helper::vector<TetrahedronSetTopologyContainer::Tetrahedron> &TetrahedronSetTopologyContainer::getTetrahedronArray()

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
@@ -160,10 +160,56 @@ void TetrahedronSetTopologyContainer::createEdgesInTetrahedronArray()
     if (hasEdgesInTetrahedron()) // created by upper topology
         return;
 
+    bool foundEdge = true;
 
     helper::ReadAccessor< Data< sofa::helper::vector<Tetrahedron> > > m_tetrahedron = d_tetrahedron;
+    if (hasEdges())
+    {
+        /// there are already existing edges : must use an inefficient method. Parse all triangles and find the edge that match each triangle edge
+        const size_t numTetra = getNumberOfTetrahedra();
+        const EdgeID numEdges = (EdgeID)getNumberOfEdges();
+        helper::ReadAccessor< Data< sofa::helper::vector<Edge> > > m_edge = d_edge;
 
-    if(!hasEdges()) // To optimize, this method should be called without creating edgesArray before.
+        m_edgesInTetrahedron.resize(numTetra);
+        /// create a multi map where the key is a vertex index and the content is the indices of edges adjacent to that vertex.
+        std::multimap<PointID, EdgeID> edgesAroundVertexMap;
+        std::multimap<PointID, EdgeID>::iterator it;
+
+        for (EdgeID edge=0; edge<numEdges; ++edge)  //Todo: check if not better using multimap <PointID ,TriangleID> and for each edge, push each triangle present in both shell
+        {
+            edgesAroundVertexMap.insert(std::pair<PointID, EdgeID> (m_edge[edge][0],edge));
+            edgesAroundVertexMap.insert(std::pair<PointID, EdgeID> (m_edge[edge][1],edge));
+        }
+        for(size_t i=0; i<numTetra; ++i)
+        {
+            const Tetrahedron &t = m_tetrahedron[i];
+            // adding edge i in the edge shell of both points
+            for(EdgeID j=0; j<6; ++j)
+            {
+                //finding edge i in edge array
+                std::pair<std::multimap<PointID, EdgeID>::iterator, std::multimap<PointID, EdgeID>::iterator > itPair=edgesAroundVertexMap.equal_range(t[edgesInTetrahedronArray[j][0]]);
+
+                foundEdge=false;
+                for(it=itPair.first; (it!=itPair.second) && (foundEdge==false); ++it)
+                {
+                    EdgeID edge = (*it).second;
+                    if ( (m_edge[edge][0] == t[edgesInTetrahedronArray[j][0]] && m_edge[edge][1] == t[edgesInTetrahedronArray[j][1]]) || (m_edge[edge][0] == t[edgesInTetrahedronArray[j][1]] && m_edge[edge][1] == t[edgesInTetrahedronArray[j][0]]))
+                    {
+                        m_edgesInTetrahedron[i][j] = edge;
+                        foundEdge=true;
+                    }
+                }
+                if (foundEdge == false)  // The edges and triangles in this mesh are only on the border: this mesh was probably created using Gmsh
+                    break;
+                if (CHECK_TOPOLOGY)
+                    msg_warning_when(!foundEdge) << " In getTetrahedronArray, cannot find edge for tetrahedron " << i << "and edge "<< j;
+            }
+            if (foundEdge == false)  // The edges and triangles in this mesh are only on the border: this mesh was probably created using Gmsh
+                break;
+        }
+    }
+
+    if(!hasEdges() || foundEdge == false) // To optimize, this method should be called without creating edgesArray before.
     {
         /// create edge array and triangle edge array at the same time
         const size_t numTetra = getNumberOfTetrahedra();
@@ -196,50 +242,7 @@ void TetrahedronSetTopologyContainer::createEdgesInTetrahedronArray()
             }
         }
     }
-    else
-    {
-        /// there are already existing edges : must use an inefficient method. Parse all triangles and find the edge that match each triangle edge
-        const size_t numTetra = getNumberOfTetrahedra();
-        const EdgeID numEdges = (EdgeID)getNumberOfEdges();
-        helper::ReadAccessor< Data< sofa::helper::vector<Edge> > > m_edge = d_edge;
 
-        m_edgesInTetrahedron.resize(numTetra);
-        /// create a multi map where the key is a vertex index and the content is the indices of edges adjacent to that vertex.
-        std::multimap<PointID, EdgeID> edgesAroundVertexMap;
-        std::multimap<PointID, EdgeID>::iterator it;
-        bool foundEdge;
-
-        for (EdgeID edge=0; edge<numEdges; ++edge)  //Todo: check if not better using multimap <PointID ,TriangleID> and for each edge, push each triangle present in both shell
-        {
-            edgesAroundVertexMap.insert(std::pair<PointID, EdgeID> (m_edge[edge][0],edge));
-            edgesAroundVertexMap.insert(std::pair<PointID, EdgeID> (m_edge[edge][1],edge));
-        }
-
-        for(size_t i=0; i<numTetra; ++i)
-        {
-            const Tetrahedron &t = m_tetrahedron[i];
-            // adding edge i in the edge shell of both points
-            for(EdgeID j=0; j<6; ++j)
-            {
-                //finding edge i in edge array
-                std::pair<std::multimap<PointID, EdgeID>::iterator, std::multimap<PointID, EdgeID>::iterator > itPair=edgesAroundVertexMap.equal_range(t[edgesInTetrahedronArray[j][0]]);
-
-                foundEdge=false;
-                for(it=itPair.first; (it!=itPair.second) && (foundEdge==false); ++it)
-                {
-                    EdgeID edge = (*it).second;
-                    if ( (m_edge[edge][0] == t[edgesInTetrahedronArray[j][0]] && m_edge[edge][1] == t[edgesInTetrahedronArray[j][1]]) || (m_edge[edge][0] == t[edgesInTetrahedronArray[j][1]] && m_edge[edge][1] == t[edgesInTetrahedronArray[j][0]]))
-                    {
-                        m_edgesInTetrahedron[i][j] = edge;
-                        foundEdge=true;
-                    }
-                }
-
-                if (CHECK_TOPOLOGY)
-                    msg_warning_when(!foundEdge) << " In getTetrahedronArray, cannot find edge for tetrahedron " << i << "and edge "<< j;
-            }
-        }
-    }
 }
 
 void TetrahedronSetTopologyContainer::createTriangleSetArray()
@@ -314,7 +317,6 @@ void TetrahedronSetTopologyContainer::createTrianglesInTetrahedronArray()
 
     m_trianglesInTetrahedron.resize( getNumberOfTetrahedra());
     helper::ReadAccessor< Data< sofa::helper::vector<Tetrahedron> > > m_tetrahedron = d_tetrahedron;
-
     for(size_t i = 0; i < m_tetrahedron.size(); ++i)
     {
         const Tetrahedron &t=m_tetrahedron[i];
@@ -323,7 +325,15 @@ void TetrahedronSetTopologyContainer::createTrianglesInTetrahedronArray()
         for (TriangleID j=0; j<4; ++j)
         {
             TriangleID triangleIndex = getTriangleIndex(t[(j+1)%4], t[(j+2)%4], t[(j+3)%4]);
-            m_trianglesInTetrahedron[i][j] = triangleIndex;
+            if (triangleIndex != InvalidID){
+                   m_trianglesInTetrahedron[i][j] = triangleIndex;
+            }
+            else
+            {
+                m_trianglesInTetrahedron.clear();
+                return;
+            }
+
         }
     }
 }
@@ -375,9 +385,8 @@ void TetrahedronSetTopologyContainer::createTetrahedraAroundTriangleArray ()
 
     if(!hasTrianglesInTetrahedron())
         createTrianglesInTetrahedronArray();
-
     m_tetrahedraAroundTriangle.resize( getNumberOfTriangles());
-
+    if (m_trianglesInTetrahedron.size() !=0){
     for (size_t i=0; i<getNumberOfTetrahedra(); ++i)
     {
         // adding tetrahedron i in the shell of all neighbors triangles
@@ -385,7 +394,7 @@ void TetrahedronSetTopologyContainer::createTetrahedraAroundTriangleArray ()
         {
             m_tetrahedraAroundTriangle[ m_trianglesInTetrahedron[i][j] ].push_back( (TetrahedronID)i );
         }
-    }
+    }}
 }
 
 const sofa::helper::vector<TetrahedronSetTopologyContainer::Tetrahedron> &TetrahedronSetTopologyContainer::getTetrahedronArray()

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
@@ -180,12 +180,15 @@ void TetrahedronSetTopologyContainer::createEdgesInTetrahedronArray()
             edgesAroundVertexMap.insert(std::pair<PointID, EdgeID> (m_edge[edge][0],edge));
             edgesAroundVertexMap.insert(std::pair<PointID, EdgeID> (m_edge[edge][1],edge));
         }
-        for(size_t i=0; i<numTetra; ++i)
+        size_t i=0;
+        while(i<numTetra && foundEdge == true)
         {
             const Tetrahedron &t = m_tetrahedron[i];
             // adding edge i in the edge shell of both points
-            for(EdgeID j=0; j<6; ++j)
+            EdgeID j=0;
+            while(j<6 && foundEdge == true)
             {
+
                 //finding edge i in edge array
                 std::pair<std::multimap<PointID, EdgeID>::iterator, std::multimap<PointID, EdgeID>::iterator > itPair=edgesAroundVertexMap.equal_range(t[edgesInTetrahedronArray[j][0]]);
 
@@ -199,13 +202,11 @@ void TetrahedronSetTopologyContainer::createEdgesInTetrahedronArray()
                         foundEdge=true;
                     }
                 }
-                if (foundEdge == false)  // The edges and triangles in this mesh are only on the border: this mesh was probably created using Gmsh
-                    break;
                 if (CHECK_TOPOLOGY)
                     msg_warning_when(!foundEdge) << " In getTetrahedronArray, cannot find edge for tetrahedron " << i << "and edge "<< j;
+                j++;
             }
-            if (foundEdge == false)  // The edges and triangles in this mesh are only on the border: this mesh was probably created using Gmsh
-                break;
+            i++;
         }
     }
 

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.cpp
@@ -265,12 +265,13 @@ void TriangleSetTopologyContainer::createEdgesInTriangleArray()
             edgesAroundVertexMap.insert(std::pair<PointID, EdgeID> (m_edge[edge][0], (EdgeID)edge));
             edgesAroundVertexMap.insert(std::pair<PointID, EdgeID> (m_edge[edge][1], (EdgeID)edge));
         }
-
-        for(size_t i=0; i<numTriangles; ++i)
+        size_t i=0;
+        while(i<numTriangles && foundEdge==true)
         {
             const Triangle &t = m_triangle[i];
             // adding edge i in the edge shell of both points
-            for(unsigned int j=0; j<3; ++j)
+            int j=0;
+            while(j<3 && foundEdge==true)
             {
                 //finding edge i in edge array
                 std::pair<std::multimap<PointID, EdgeID>::iterator, std::multimap<PointID, EdgeID>::iterator > itPair=edgesAroundVertexMap.equal_range(t[(j+1)%3]);
@@ -285,15 +286,11 @@ void TriangleSetTopologyContainer::createEdgesInTriangleArray()
                         foundEdge=true;
                     }
                 }
-                if (foundEdge == false)  // The edges and triangles given here are only on the border of the mesh: this mesh was probably created using Gmsh. These lists are hence incomplete..
-                    break;
-
-
                 if (CHECK_TOPOLOGY)
                     msg_warning_when(!foundEdge) << "Cannot find edge for triangle " << i << " and edge "<< j;
+                j++;
             }
-            if (foundEdge == false) // The edges and triangles in this mesh are only on the border: this mesh was probably created using Gmsh
-                break;
+            i++;
         }
     }
     if(!hasEdges() || foundEdge == false) // To optimize, this method should be called without creating edgesArray before.

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.cpp
@@ -265,13 +265,11 @@ void TriangleSetTopologyContainer::createEdgesInTriangleArray()
             edgesAroundVertexMap.insert(std::pair<PointID, EdgeID> (m_edge[edge][0], (EdgeID)edge));
             edgesAroundVertexMap.insert(std::pair<PointID, EdgeID> (m_edge[edge][1], (EdgeID)edge));
         }
-        size_t i=0;
-        while(i<numTriangles && foundEdge==true)
+        for ( size_t i = 0 ; (i < numTriangles) && (foundEdge == true) ; ++i )
         {
             const Triangle &t = m_triangle[i];
             // adding edge i in the edge shell of both points
-            int j=0;
-            while(j<3 && foundEdge==true)
+            for ( unsigned int j = 0 ; (j < 3) && (foundEdge == true) ; ++j )
             {
                 //finding edge i in edge array
                 std::pair<std::multimap<PointID, EdgeID>::iterator, std::multimap<PointID, EdgeID>::iterator > itPair=edgesAroundVertexMap.equal_range(t[(j+1)%3]);
@@ -288,9 +286,7 @@ void TriangleSetTopologyContainer::createEdgesInTriangleArray()
                 }
                 if (CHECK_TOPOLOGY)
                     msg_warning_when(!foundEdge) << "Cannot find edge for triangle " << i << " and edge "<< j;
-                j++;
             }
-            i++;
         }
     }
     if(!hasEdges() || foundEdge == false) // To optimize, this method should be called without creating edgesArray before.

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.cpp
@@ -284,8 +284,15 @@ void TriangleSetTopologyContainer::createEdgesInTriangleArray()
                         foundEdge=true;
                     }
                 }
-                if (CHECK_TOPOLOGY)
-                    msg_warning_when(!foundEdge) << "Cannot find edge for triangle " << i << " and edge "<< j;
+
+                if (!foundEdge)
+                {
+                    msg_error() << "Cannot find edge " << j
+                        << " [" << t[(j + 1) % 3] << ", " << t[(j + 2) % 3] << "]"
+                        << " in triangle " << i;
+                    m_edgesInTriangle.clear();
+                    return;
+                }
             }
         }
     }


### PR DESCRIPTION
Good afternoon!
This PR proposes a fix for a crash when loading a vtk file that was generated by Gmsh.

`
 myNode.createObject('MeshVTKLoader', name='loader', filename='gmshMesh.vtk')
 myNode.createObject('TetrahedronSetTopologyContainer', src="@loader")
`

The mesh generated by default with Gmsh gives a list of edges and triangles that is incomplete and contains only edges and triangles on the boundary of the mesh. However the list of Tetrahedra is complete. This leads to a crash when using a TetrahedronSetTopologyContainer.
This PR tries to address this problem.

Cheers!
Olivier


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
