### PR TITLE
[SofaKernel] FIX: force name data to contain something

### DIFF
--- a/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
@@ -69,8 +69,6 @@ Base::Base()
     f_bbox.setDisplayed(false);
     f_bbox.setAutoLink(false);
     sendl.setParent(this);
-
-
 }
 
 Base::~Base()
@@ -534,6 +532,13 @@ void  Base::parse ( BaseObjectDescription* arg )
         // the same name cannot be extracted from BaseObjectDescription
         if (attrName == std::string("type")) continue;
 
+        if (attrName == std::string("name") && std::string(it.second.c_str()).empty())
+        {
+            msg_warning(getName()) << "Empty name given: Renaming to \"unnamed\""
+                                      " as this can lead to unexpected behaviors.";
+            parseField(attrName, "unnamed");
+            continue;
+        }
         if (!hasField(attrName)) continue;
 
         parseField(attrName, it.second);

--- a/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
@@ -22,6 +22,7 @@
 #define SOFA_CORE_OBJECTMODEL_BASE_CPP
 #include <sofa/core/objectmodel/Base.h>
 #include <sofa/helper/Factory.h>
+#include <sofa/core/ObjectFactory.h>
 #include <sofa/helper/logging/Messaging.h>
 using sofa::helper::logging::MessageDispatcher ;
 using sofa::helper::logging::Message ;
@@ -530,15 +531,8 @@ void  Base::parse ( BaseObjectDescription* arg )
 
         // FIX: "type" is already used to define the type of object to instanciate, any Data with
         // the same name cannot be extracted from BaseObjectDescription
-        if (attrName == std::string("type")) continue;
-
-        if (attrName == std::string("name") && std::string(it.second.c_str()).empty())
-        {
-            msg_warning(getName()) << "Empty name given: Renaming to \"unnamed\""
-                                      " as this can lead to unexpected behaviors.";
-            parseField(attrName, "unnamed");
+        if (attrName == std::string("type"))
             continue;
-        }
         if (!hasField(attrName)) continue;
 
         parseField(attrName, it.second);

--- a/SofaKernel/modules/SofaSimulationGraph/DAGNode.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/DAGNode.cpp
@@ -132,8 +132,38 @@ DAGNode::~DAGNode()
 /// Create, add, then return the new child of this Node
 Node::SPtr DAGNode::createChild(const std::string& nodeName)
 {
-    msg_warning_when(nodeName.empty(), getName()) << "Empty name given to child: Renaming to \"unnamed\" as this can lead to unexpected behaviors.";
-    DAGNode::SPtr newchild = sofa::core::objectmodel::New<DAGNode>(nodeName.empty()?"unnamed":nodeName);
+    DAGNode::SPtr newchild;
+    if (nodeName.empty())
+    {
+        int i = 0;
+        std::string newName = "unnamed";
+        bool uid_found = false;
+        while (!uid_found)
+        {
+            uid_found = true;
+            for (const auto& c : this->child)
+            {
+                if (c->getName() == newName)
+                {
+                    newName = "unnamed" + std::to_string(++i);
+                    uid_found = true;
+                }
+            }
+            for (const auto& o : this->object)
+            {
+                if (o->getName() == newName)
+                {
+                    newName = "unnamed" + std::to_string(++i);
+                    uid_found = true;
+                }
+            }
+        }
+        msg_error("Node::createChild()") << "Empty string given to property 'name': Forcefully setting an empty name is forbidden.\n"
+                                      "Renaming to " + newName + " to avoid unexpected behaviors.";
+        newchild = sofa::core::objectmodel::New<DAGNode>(newName);
+    }
+    else
+        newchild = sofa::core::objectmodel::New<DAGNode>(nodeName);
     this->addChild(newchild); newchild->updateSimulationContext();
     return std::move(newchild);
 }

--- a/SofaKernel/modules/SofaSimulationGraph/DAGNode.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/DAGNode.cpp
@@ -132,7 +132,8 @@ DAGNode::~DAGNode()
 /// Create, add, then return the new child of this Node
 Node::SPtr DAGNode::createChild(const std::string& nodeName)
 {
-    DAGNode::SPtr newchild = sofa::core::objectmodel::New<DAGNode>(nodeName);
+    msg_warning_when(nodeName.empty(), getName()) << "Empty name given to child: Renaming to \"unnamed\" as this can lead to unexpected behaviors.";
+    DAGNode::SPtr newchild = sofa::core::objectmodel::New<DAGNode>(nodeName.empty()?"unnamed":nodeName);
     this->addChild(newchild); newchild->updateSimulationContext();
     return std::move(newchild);
 }

--- a/SofaKernel/modules/SofaSimulationTree/GNode.cpp
+++ b/SofaKernel/modules/SofaSimulationTree/GNode.cpp
@@ -54,7 +54,8 @@ GNode::~GNode()
 /// Create, add, then return the new child of this Node
 Node::SPtr GNode::createChild(const std::string& nodeName)
 {
-    GNode::SPtr newchild = sofa::core::objectmodel::New<GNode>(nodeName);
+    msg_warning_when(nodeName.empty(), getName()) << "Empty name given to child: Renaming to \"unnamed\" as this can lead to unexpected behaviors.";
+    GNode::SPtr newchild = sofa::core::objectmodel::New<GNode>(nodeName.empty()?"unnamed":nodeName);
     this->addChild(newchild); newchild->updateSimulationContext();
     return std::move(newchild);
 }

--- a/SofaKernel/modules/SofaSimulationTree/GNode.cpp
+++ b/SofaKernel/modules/SofaSimulationTree/GNode.cpp
@@ -54,8 +54,38 @@ GNode::~GNode()
 /// Create, add, then return the new child of this Node
 Node::SPtr GNode::createChild(const std::string& nodeName)
 {
-    msg_warning_when(nodeName.empty(), getName()) << "Empty name given to child: Renaming to \"unnamed\" as this can lead to unexpected behaviors.";
-    GNode::SPtr newchild = sofa::core::objectmodel::New<GNode>(nodeName.empty()?"unnamed":nodeName);
+    GNode::SPtr newchild;
+    if (nodeName.empty())
+    {
+        int i = 0;
+        std::string newName = "unnamed";
+        bool uid_found = false;
+        while (!uid_found)
+        {
+            uid_found = true;
+            for (const auto& c : this->child)
+            {
+                if (c->getName() == newName)
+                {
+                    newName = "unnamed" + std::to_string(++i);
+                    uid_found = true;
+                }
+            }
+            for (const auto& o : this->object)
+            {
+                if (o->getName() == newName)
+                {
+                    newName = "unnamed" + std::to_string(++i);
+                    uid_found = true;
+                }
+            }
+        }
+        msg_error("Node::createChild()") << "Empty string given to property 'name': Forcefully setting an empty name is forbidden.\n"
+                                      "Renaming to " + newName + " to avoid unexpected behaviors.";
+        newchild = sofa::core::objectmodel::New<GNode>(newName);
+    }
+    else
+        newchild = sofa::core::objectmodel::New<GNode>(nodeName);
     this->addChild(newchild); newchild->updateSimulationContext();
     return std::move(newchild);
 }

--- a/applications/plugins/SofaPython/Binding_BaseContext.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseContext.cpp
@@ -81,8 +81,6 @@ static PyObject * BaseContext_getRootContext(PyObject *self, PyObject * /*args*/
     return sofa::PythonFactory::toPython(obj->getRootContext());
 }
 
-
-
 /// object factory
 static PyObject * BaseContext_createObject_Impl(PyObject * self, PyObject * args, PyObject * kw, bool printWarnings)
 {
@@ -124,8 +122,24 @@ static PyObject * BaseContext_createObject_Impl(PyObject * self, PyObject * args
         Py_DecRef(values);
     }
 
+    // Same system as in ElementNameHelper (XML parser)
+    static std::map<std::string, int> instanceCounter;
+
+    if (std::string(desc.getAttribute("name")).empty())
+    {
+        std::string type = desc.getAttribute("type");
+        std::string shortName = sofa::core::ObjectFactory::ShortName(type);
+        if (instanceCounter.find(shortName) != instanceCounter.end())
+            shortName += std::to_string(instanceCounter[shortName]++);
+        else
+            instanceCounter[shortName] = 1;
+        msg_error("createObject") << "Empty string given to property 'name': Forcefully setting an empty name is forbidden.\n"
+                                      "Renaming to " + shortName +" to avoid unexpected behaviors.";
+        desc.setAttribute("name", shortName);
+    }
+
     BaseObject::SPtr obj = ObjectFactory::getInstance()->createObject(context,&desc);
-    if (obj==0)
+    if (obj == nullptr)
     {
         std::stringstream msg;
         msg << "Unable to create '" << desc.getName() << "' of type '" << desc.getAttribute("type","")<< "' in node '"<<context->getName()<<"'." ;


### PR DESCRIPTION
This prevents creation of nodes / components with empty `names`, when instantiated in a "non-conventional" way:

```py
py:
node.createChild('')
node.createObject('MyComponent', name='')
```

```xml
xml:
<Node name=""></Node>
```

By default, if `name` is not provided, unnamed is set in `name`. but if `name` is forcefully set to `""`, there's currently no safeguards.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
