### PR TITLE
[runSofa] FIX the opening of ModifyObject view.

### DIFF
--- a/applications/sofa/gui/qt/ModifyObject.cpp
+++ b/applications/sofa/gui/qt/ModifyObject.cpp
@@ -119,7 +119,9 @@ void ModifyObject::createDialog(core::objectmodel::Base* base)
     QScrollArea* m_scrollArea = new QScrollArea();
 
     //    const int screenHeight = QApplication::desktop()->height();
-    m_scrollArea->setMinimumSize(600,QApplication::desktop()->height() * 0.75);
+    QRect geometry = QApplication::desktop()->screenGeometry(this);
+
+    m_scrollArea->setMinimumSize(600, geometry.height() * 0.75);
     m_scrollArea->setWidgetResizable(true);
     dialogTab->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     m_scrollArea->setWidget(dialogTab);


### PR DESCRIPTION
On desktop with multiple screen the existing code to dimmension the
windows is wrong as it report the largest size. This FIX the problem
by using the correct way to get he screen geometry associated with a
widget.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
