### PR TITLE
[SofaKernel] ADD instantiation point in Base.h

### DIFF
--- a/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
@@ -70,7 +70,6 @@ Base::Base()
     f_bbox.setAutoLink(false);
     sendl.setParent(this);
 
-
 }
 
 Base::~Base()
@@ -677,6 +676,59 @@ void Base::clearOutputs()
                               " To remove this warning you need to use clearLoggedMessages() instead. ";
     clearLoggedMessages();
 }
+
+/// Set the source filename (where the component is implemented)
+void Base::setSourceFileName(const std::string& sourceFileName)
+{
+    m_sourceFileName = sourceFileName;
+}
+
+/// Get the source filename (where the component is implemented)
+const std::string& Base::getSourceFileName() const
+{
+    return m_sourceFileName;
+}
+
+/// Set the source location (where the component is implemented)
+void Base::setSourceFilePos(const int linenum)
+{
+    m_sourceFileLoc = linenum;
+}
+
+/// Get the source location (where the component is implemented)
+int Base::getSourceFilePos() const
+{
+    return m_sourceFileLoc;
+}
+
+/// Set the file where the instance has been created
+/// This is useful to store where the component was emitted from
+void Base::setInstanciationFileName(const std::string& filename)
+{
+    m_instanciationFileName = filename;
+}
+
+/// Get the file where the instance has been created
+/// This is useful to store where the component was emitted from
+const std::string& Base::getInstanciationFileName() const
+{
+    return m_instanciationFileName;
+}
+
+/// Set the file location (line number) where the instance has been created
+/// This is useful to store where the component was emitted from
+void Base::setInstanciationFilePos(const int lineco)
+{
+    m_instanciationFileLoc = lineco;
+}
+
+/// Get the file location (line number) where the instance has been created
+/// This is useful to store where the component was emitted from
+int Base::getInstanciationFilePos() const
+{
+    return m_instanciationFileLoc;
+}
+
 
 
 

--- a/SofaKernel/framework/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/Base.h
@@ -192,6 +192,34 @@ public:
     /// Get the template type names (if any) used to instantiate this object
     virtual std::string getTemplateName() const;
 
+    /// Set the source filename (where the component is implemented)
+    void setSourceFileName(const std::string& sourceFileName);
+
+    /// Get the source filename (where the component is implemented)
+    const std::string& getSourceFileName() const;
+
+    /// Set the source location (where the component is implemented)
+    void setSourceFilePos(const int);
+
+    /// Get the source location (where the component is implemented)
+    int getSourceFilePos() const;
+
+    /// Set the file where the instance has been created
+    /// This is useful to store where the component was emitted from
+    void setInstanciationFileName(const std::string& sourceFileName);
+
+    /// Get the file where the instance has been created
+    /// This is useful to store where the component was emitted from
+    const std::string& getInstanciationFileName() const;
+
+    /// Set the file location (line number) where the instance has been created
+    /// This is useful to store where the component was emitted from
+    void setInstanciationFilePos(const int);
+
+    /// Get the file location (line number) where the instance has been created
+    /// This is useful to store where the component was emitted from
+    int getInstanciationFilePos() const;
+
     /// @name fields
     ///   Data fields management
     /// @{
@@ -458,6 +486,11 @@ public:
     Data< sofa::core::objectmodel::TagSet > f_tags; ///< list of the subsets the objet belongs to
 
     Data< sofa::defaulttype::BoundingBox > f_bbox; ///< this object bounding box
+
+    std::string m_sourceFileName        {""};
+    int         m_sourceFileLoc         {-1};
+    std::string m_instanciationFileName {""};
+    int         m_instanciationFileLoc  {-1};
 
     /// @name casting
     ///   trivial cast to a few base components

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseClass.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseClass.h
@@ -270,7 +270,8 @@ public:
     static const MyClass* GetClass() { return MyClass::get(); }         \
     virtual const ::sofa::core::objectmodel::BaseClass* getClass() const override \
     { return GetClass(); }                                              \
-	static const char* HeaderFileLocation() { return __FILE__; }         \
+    static const char* HeaderFileLocation() { return __FILE__; }        \
+    virtual const char* getHeaderFileLocation() { return __FILE__; }    \
     template<class SOFA_T> ::sofa::core::objectmodel::BaseData::BaseInitData \
     initData(::sofa::core::objectmodel::Data<SOFA_T>* field, const char* name, const char* help,   \
              ::sofa::core::objectmodel::BaseData::DataFlags dataflags)  \

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseObject.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseObject.cpp
@@ -49,6 +49,8 @@ BaseObject::BaseObject()
     l_context.set(BaseContext::getDefault());
     l_slaves.setValidator(&sofa::core::objectmodel::BaseObject::changeSlavesLink);
     f_listening.setAutoLink(false);
+    setSourceFilePos(0);
+    setSourceFileName( HeaderFileLocation() );
 }
 
 BaseObject::~BaseObject()

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseObject.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseObject.cpp
@@ -50,7 +50,7 @@ BaseObject::BaseObject()
     l_slaves.setValidator(&sofa::core::objectmodel::BaseObject::changeSlavesLink);
     f_listening.setAutoLink(false);
     setSourceFilePos(0);
-    setSourceFileName( HeaderFileLocation() );
+    setSourceFileName("");
 }
 
 BaseObject::~BaseObject()

--- a/SofaKernel/framework/sofa/helper/logging/Messaging.h
+++ b/SofaKernel/framework/sofa/helper/logging/Messaging.h
@@ -278,6 +278,13 @@
 #define dmsg_advice(...) DMSGADVICE_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
 #define dmsg_advice_when(cond, ...) if(cond) dmsg_advice(__VA_ARGS__)
 
+#define dmsg_info_withfile(emitter, file, line)       sofa::helper::logging::MessageDispatcher::info(sofa::helper::logging::Message::Dev, sofa::helper::logging::getComponentInfo(emitter), SOFA_FILE_INFO_COPIED_FROM(file,line))
+#define dmsg_deprecated_withfile(emitter, file, line) sofa::helper::logging::MessageDispatcher::deprecated(sofa::helper::logging::Message::Dev, sofa::helper::logging::getComponentInfo(emitter), SOFA_FILE_INFO_COPIED_FROM(file,line))
+#define dmsg_warning_withfile(emitter, file,line)    sofa::helper::logging::MessageDispatcher::warning(sofa::helper::logging::Message::Dev, sofa::helper::logging::getComponentInfo(emitter), SOFA_FILE_INFO_COPIED_FROM(file,line))
+#define dmsg_error_withfile(emitter, file,line)      sofa::helper::logging::MessageDispatcher::error(sofa::helper::logging::Message::Dev, sofa::helper::logging::getComponentInfo(emitter), SOFA_FILE_INFO_COPIED_FROM(file,line))
+#define dmsg_fatal_withfile(emitter, file,line)      sofa::helper::logging::MessageDispatcher::fatal(sofa::helper::logging::Message::Dev, sofa::helper::logging::getComponentInfo(emitter), SOFA_FILE_INFO_COPIED_FROM(file,line))
+#define dmsg_advice_withfile(emitter, file,line)      sofa::helper::logging::MessageDispatcher::advice(sofa::helper::logging::Message::Dev, sofa::helper::logging::getComponentInfo(emitter), SOFA_FILE_INFO_COPIED_FROM(file,line))
+
 #define MSG_REGISTER_CLASS(classType, nameName) \
     namespace sofa {         \
     namespace helper {       \

--- a/SofaKernel/modules/SofaSimulationCommon/xml/NodeElement.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/xml/NodeElement.cpp
@@ -63,6 +63,8 @@ bool NodeElement::initNode()
         core::objectmodel::BaseNode* baseNode;
         if (getTypedObject()!=NULL && getParentElement()!=NULL && (baseNode = getParentElement()->getObject()->toBaseNode()))
         {
+            getTypedObject()->setInstanciationFilePos(getSrcLine());
+            getTypedObject()->setInstanciationFileName(getSrcFile());
             baseNode->addChild(getTypedObject());
         }
         return true;

--- a/SofaKernel/modules/SofaSimulationCommon/xml/ObjectElement.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/xml/ObjectElement.cpp
@@ -110,6 +110,8 @@ bool ObjectElement::initNode()
 
             msg_warning(obj.get()) << SOFA_FILE_INFO_COPIED_FROM(getSrcFile(), getSrcLine()) << "Unused Attribute: \""<<it->first <<"\" with value: \"" <<it->second.c_str() <<"\"" ;        }
     }
+    obj->setInstanciationFilePos(getSrcLine());
+    obj->setInstanciationFileName(getSrcFile());
     return true;
 }
 

--- a/applications/plugins/SofaPython/Binding_BaseContext.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseContext.cpp
@@ -163,7 +163,9 @@ static PyObject * BaseContext_createObject_Impl(PyObject * self, PyObject * args
         if (node && node->isInitialized())
             msg_warning(node) << "Sofa.Node.createObject("<<type<<") called on a node("<<node->getName()<<") that is already initialized";
     }
-
+    auto fileinfo = PythonEnvironment::getPythonCallingPointAsFileInfo();
+    obj->setInstanciationFilePos(fileinfo->line);
+    obj->setInstanciationFileName(fileinfo->filename);
     return sofa::PythonFactory::toPython(obj.get());
 }
 

--- a/applications/plugins/SofaPython/Binding_Node.cpp
+++ b/applications/plugins/SofaPython/Binding_Node.cpp
@@ -211,6 +211,13 @@ static PyObject * Node_createChild(PyObject *self, PyObject * args) {
         return nullptr;
     }
     Node* child = obj->createChild(nodeName).get();
+
+    /// retrieve the creation location from python and pass it to Sofa so we
+    /// can locate easily where the node has been instantiated.
+    auto fileinfo = PythonEnvironment::getPythonCallingPointAsFileInfo();
+    child->setInstanciationFilePos(fileinfo->line);
+    child->setInstanciationFileName(fileinfo->filename);
+
     return sofa::PythonFactory::toPython(child);
 }
 


### PR DESCRIPTION
It is very useful to store and be able to retieve, for each object/node 
where it is implemented and where it was instanciated. This PR implements that.

Having this allows to implement cool feature like in to jump from the selected object/node in scene graph straight in the scene file (python or xml) or to the implementation file (cpp or python). 

We have such a feature in SofaQtQuick. We will backport this feature in a second PR soon. 

The change in dmsg_* are a "passager clandestin" but a small one :)

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
