### PR TITLE
[runSofa] ADD possibility to jump to source/instanciation of selected component

### DIFF
--- a/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
@@ -70,7 +70,6 @@ Base::Base()
     f_bbox.setAutoLink(false);
     sendl.setParent(this);
 
-
 }
 
 Base::~Base()
@@ -677,6 +676,59 @@ void Base::clearOutputs()
                               " To remove this warning you need to use clearLoggedMessages() instead. ";
     clearLoggedMessages();
 }
+
+/// Set the source filename (where the component is implemented)
+void Base::setSourceFileName(const std::string& sourceFileName)
+{
+    m_sourceFileName = sourceFileName;
+}
+
+/// Get the source filename (where the component is implemented)
+const std::string& Base::getSourceFileName() const
+{
+    return m_sourceFileName;
+}
+
+/// Set the source location (where the component is implemented)
+void Base::setSourceFilePos(const int linenum)
+{
+    m_sourceFileLoc = linenum;
+}
+
+/// Get the source location (where the component is implemented)
+int Base::getSourceFilePos() const
+{
+    return m_sourceFileLoc;
+}
+
+/// Set the file where the instance has been created
+/// This is useful to store where the component was emitted from
+void Base::setInstanciationFileName(const std::string& filename)
+{
+    m_instanciationFileName = filename;
+}
+
+/// Get the file where the instance has been created
+/// This is useful to store where the component was emitted from
+const std::string& Base::getInstanciationFileName() const
+{
+    return m_instanciationFileName;
+}
+
+/// Set the file location (line number) where the instance has been created
+/// This is useful to store where the component was emitted from
+void Base::setInstanciationFilePos(const int lineco)
+{
+    m_instanciationFileLoc = lineco;
+}
+
+/// Get the file location (line number) where the instance has been created
+/// This is useful to store where the component was emitted from
+int Base::getInstanciationFilePos() const
+{
+    return m_instanciationFileLoc;
+}
+
 
 
 

--- a/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
@@ -678,55 +678,55 @@ void Base::clearOutputs()
 }
 
 /// Set the source filename (where the component is implemented)
-void Base::setSourceFileName(const std::string& sourceFileName)
+void Base::setDefinitionSourceFileName(const std::string& sourceFileName)
 {
-    m_sourceFileName = sourceFileName;
+    m_definitionSourceFileName = sourceFileName;
 }
 
 /// Get the source filename (where the component is implemented)
-const std::string& Base::getSourceFileName() const
+const std::string& Base::getDefinitionSourceFileName() const
 {
-    return m_sourceFileName;
+    return m_definitionSourceFileName;
 }
 
 /// Set the source location (where the component is implemented)
-void Base::setSourceFilePos(const int linenum)
+void Base::setDefinitionSourceFilePos(const int linenum)
 {
-    m_sourceFileLoc = linenum;
+    m_definitionSourceFilePos = linenum;
 }
 
 /// Get the source location (where the component is implemented)
-int Base::getSourceFilePos() const
+int Base::getDefinitionSourceFilePos() const
 {
-    return m_sourceFileLoc;
+    return m_definitionSourceFilePos;
 }
 
 /// Set the file where the instance has been created
 /// This is useful to store where the component was emitted from
-void Base::setInstanciationFileName(const std::string& filename)
+void Base::setInstanciationSourceFileName(const std::string& filename)
 {
-    m_instanciationFileName = filename;
+    m_instanciationSourceFileName = filename;
 }
 
 /// Get the file where the instance has been created
 /// This is useful to store where the component was emitted from
-const std::string& Base::getInstanciationFileName() const
+const std::string& Base::getInstanciationSourceFileName() const
 {
-    return m_instanciationFileName;
+    return m_instanciationSourceFileName;
 }
 
 /// Set the file location (line number) where the instance has been created
 /// This is useful to store where the component was emitted from
-void Base::setInstanciationFilePos(const int lineco)
+void Base::setInstanciationSourceFilePos(const int lineco)
 {
-    m_instanciationFileLoc = lineco;
+    m_instanciationSourceFilePos = lineco;
 }
 
 /// Get the file location (line number) where the instance has been created
 /// This is useful to store where the component was emitted from
-int Base::getInstanciationFilePos() const
+int Base::getInstanciationSourceFilePos() const
 {
-    return m_instanciationFileLoc;
+    return m_instanciationSourceFilePos;
 }
 
 

--- a/SofaKernel/framework/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/Base.h
@@ -193,32 +193,32 @@ public:
     virtual std::string getTemplateName() const;
 
     /// Set the source filename (where the component is implemented)
-    void setSourceFileName(const std::string& sourceFileName);
+    void setDefinitionSourceFileName(const std::string& sourceFileName);
 
     /// Get the source filename (where the component is implemented)
-    const std::string& getSourceFileName() const;
+    const std::string& getDefinitionSourceFileName() const;
 
     /// Set the source location (where the component is implemented)
-    void setSourceFilePos(const int);
+    void setDefinitionSourceFilePos(const int);
 
     /// Get the source location (where the component is implemented)
-    int getSourceFilePos() const;
+    int getDefinitionSourceFilePos() const;
 
     /// Set the file where the instance has been created
     /// This is useful to store where the component was emitted from
-    void setInstanciationFileName(const std::string& sourceFileName);
+    void setInstanciationSourceFileName(const std::string& sourceFileName);
 
     /// Get the file where the instance has been created
     /// This is useful to store where the component was emitted from
-    const std::string& getInstanciationFileName() const;
+    const std::string& getInstanciationSourceFileName() const;
 
     /// Set the file location (line number) where the instance has been created
     /// This is useful to store where the component was emitted from
-    void setInstanciationFilePos(const int);
+    void setInstanciationSourceFilePos(const int);
 
     /// Get the file location (line number) where the instance has been created
     /// This is useful to store where the component was emitted from
-    int getInstanciationFilePos() const;
+    int getInstanciationSourceFilePos() const;
 
     /// @name fields
     ///   Data fields management
@@ -487,10 +487,10 @@ public:
 
     Data< sofa::defaulttype::BoundingBox > f_bbox; ///< this object bounding box
 
-    std::string m_sourceFileName        {""};
-    int         m_sourceFileLoc         {-1};
-    std::string m_instanciationFileName {""};
-    int         m_instanciationFileLoc  {-1};
+    std::string m_definitionSourceFileName        {""};
+    int         m_definitionSourceFilePos         {-1};
+    std::string m_instanciationSourceFileName     {""};
+    int         m_instanciationSourceFilePos      {-1};
 
     /// @name casting
     ///   trivial cast to a few base components

--- a/SofaKernel/framework/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/Base.h
@@ -192,6 +192,34 @@ public:
     /// Get the template type names (if any) used to instantiate this object
     virtual std::string getTemplateName() const;
 
+    /// Set the source filename (where the component is implemented)
+    void setSourceFileName(const std::string& sourceFileName);
+
+    /// Get the source filename (where the component is implemented)
+    const std::string& getSourceFileName() const;
+
+    /// Set the source location (where the component is implemented)
+    void setSourceFilePos(const int);
+
+    /// Get the source location (where the component is implemented)
+    int getSourceFilePos() const;
+
+    /// Set the file where the instance has been created
+    /// This is useful to store where the component was emitted from
+    void setInstanciationFileName(const std::string& sourceFileName);
+
+    /// Get the file where the instance has been created
+    /// This is useful to store where the component was emitted from
+    const std::string& getInstanciationFileName() const;
+
+    /// Set the file location (line number) where the instance has been created
+    /// This is useful to store where the component was emitted from
+    void setInstanciationFilePos(const int);
+
+    /// Get the file location (line number) where the instance has been created
+    /// This is useful to store where the component was emitted from
+    int getInstanciationFilePos() const;
+
     /// @name fields
     ///   Data fields management
     /// @{
@@ -458,6 +486,11 @@ public:
     Data< sofa::core::objectmodel::TagSet > f_tags; ///< list of the subsets the objet belongs to
 
     Data< sofa::defaulttype::BoundingBox > f_bbox; ///< this object bounding box
+
+    std::string m_sourceFileName        {""};
+    int         m_sourceFileLoc         {-1};
+    std::string m_instanciationFileName {""};
+    int         m_instanciationFileLoc  {-1};
 
     /// @name casting
     ///   trivial cast to a few base components

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseClass.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseClass.h
@@ -270,7 +270,8 @@ public:
     static const MyClass* GetClass() { return MyClass::get(); }         \
     virtual const ::sofa::core::objectmodel::BaseClass* getClass() const override \
     { return GetClass(); }                                              \
-	static const char* HeaderFileLocation() { return __FILE__; }         \
+    static const char* HeaderFileLocation() { return __FILE__; }        \
+    virtual const char* getHeaderFileLocation() { return __FILE__; }    \
     template<class SOFA_T> ::sofa::core::objectmodel::BaseData::BaseInitData \
     initData(::sofa::core::objectmodel::Data<SOFA_T>* field, const char* name, const char* help,   \
              ::sofa::core::objectmodel::BaseData::DataFlags dataflags)  \

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseObject.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseObject.cpp
@@ -49,6 +49,8 @@ BaseObject::BaseObject()
     l_context.set(BaseContext::getDefault());
     l_slaves.setValidator(&sofa::core::objectmodel::BaseObject::changeSlavesLink);
     f_listening.setAutoLink(false);
+    setSourceFilePos(0);
+    setSourceFileName( HeaderFileLocation() );
 }
 
 BaseObject::~BaseObject()

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseObject.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseObject.cpp
@@ -49,8 +49,6 @@ BaseObject::BaseObject()
     l_context.set(BaseContext::getDefault());
     l_slaves.setValidator(&sofa::core::objectmodel::BaseObject::changeSlavesLink);
     f_listening.setAutoLink(false);
-    setSourceFilePos(0);
-    setSourceFileName("");
 }
 
 BaseObject::~BaseObject()

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseObject.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseObject.cpp
@@ -50,7 +50,7 @@ BaseObject::BaseObject()
     l_slaves.setValidator(&sofa::core::objectmodel::BaseObject::changeSlavesLink);
     f_listening.setAutoLink(false);
     setSourceFilePos(0);
-    setSourceFileName( HeaderFileLocation() );
+    setSourceFileName("");
 }
 
 BaseObject::~BaseObject()

--- a/SofaKernel/framework/sofa/helper/logging/Messaging.h
+++ b/SofaKernel/framework/sofa/helper/logging/Messaging.h
@@ -278,6 +278,13 @@
 #define dmsg_advice(...) DMSGADVICE_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
 #define dmsg_advice_when(cond, ...) if(cond) dmsg_advice(__VA_ARGS__)
 
+#define dmsg_info_withfile(emitter, file, line)       sofa::helper::logging::MessageDispatcher::info(sofa::helper::logging::Message::Dev, sofa::helper::logging::getComponentInfo(emitter), SOFA_FILE_INFO_COPIED_FROM(file,line))
+#define dmsg_deprecated_withfile(emitter, file, line) sofa::helper::logging::MessageDispatcher::deprecated(sofa::helper::logging::Message::Dev, sofa::helper::logging::getComponentInfo(emitter), SOFA_FILE_INFO_COPIED_FROM(file,line))
+#define dmsg_warning_withfile(emitter, file,line)    sofa::helper::logging::MessageDispatcher::warning(sofa::helper::logging::Message::Dev, sofa::helper::logging::getComponentInfo(emitter), SOFA_FILE_INFO_COPIED_FROM(file,line))
+#define dmsg_error_withfile(emitter, file,line)      sofa::helper::logging::MessageDispatcher::error(sofa::helper::logging::Message::Dev, sofa::helper::logging::getComponentInfo(emitter), SOFA_FILE_INFO_COPIED_FROM(file,line))
+#define dmsg_fatal_withfile(emitter, file,line)      sofa::helper::logging::MessageDispatcher::fatal(sofa::helper::logging::Message::Dev, sofa::helper::logging::getComponentInfo(emitter), SOFA_FILE_INFO_COPIED_FROM(file,line))
+#define dmsg_advice_withfile(emitter, file,line)      sofa::helper::logging::MessageDispatcher::advice(sofa::helper::logging::Message::Dev, sofa::helper::logging::getComponentInfo(emitter), SOFA_FILE_INFO_COPIED_FROM(file,line))
+
 #define MSG_REGISTER_CLASS(classType, nameName) \
     namespace sofa {         \
     namespace helper {       \

--- a/SofaKernel/modules/SofaSimulationCommon/xml/NodeElement.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/xml/NodeElement.cpp
@@ -63,6 +63,8 @@ bool NodeElement::initNode()
         core::objectmodel::BaseNode* baseNode;
         if (getTypedObject()!=NULL && getParentElement()!=NULL && (baseNode = getParentElement()->getObject()->toBaseNode()))
         {
+            getTypedObject()->setInstanciationFilePos(getSrcLine());
+            getTypedObject()->setInstanciationFileName(getSrcFile());
             baseNode->addChild(getTypedObject());
         }
         return true;

--- a/SofaKernel/modules/SofaSimulationCommon/xml/NodeElement.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/xml/NodeElement.cpp
@@ -63,8 +63,8 @@ bool NodeElement::initNode()
         core::objectmodel::BaseNode* baseNode;
         if (getTypedObject()!=NULL && getParentElement()!=NULL && (baseNode = getParentElement()->getObject()->toBaseNode()))
         {
-            getTypedObject()->setInstanciationFilePos(getSrcLine());
-            getTypedObject()->setInstanciationFileName(getSrcFile());
+            getTypedObject()->setInstanciationSourceFilePos(getSrcLine());
+            getTypedObject()->setInstanciationSourceFileName(getSrcFile());
             baseNode->addChild(getTypedObject());
         }
         return true;

--- a/SofaKernel/modules/SofaSimulationCommon/xml/ObjectElement.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/xml/ObjectElement.cpp
@@ -110,8 +110,8 @@ bool ObjectElement::initNode()
 
             msg_warning(obj.get()) << SOFA_FILE_INFO_COPIED_FROM(getSrcFile(), getSrcLine()) << "Unused Attribute: \""<<it->first <<"\" with value: \"" <<it->second.c_str() <<"\"" ;        }
     }
-    obj->setInstanciationFilePos(getSrcLine());
-    obj->setInstanciationFileName(getSrcFile());
+    obj->setInstanciationSourceFilePos(getSrcLine());
+    obj->setInstanciationSourceFileName(getSrcFile());
     return true;
 }
 

--- a/SofaKernel/modules/SofaSimulationCommon/xml/ObjectElement.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/xml/ObjectElement.cpp
@@ -110,6 +110,8 @@ bool ObjectElement::initNode()
 
             msg_warning(obj.get()) << SOFA_FILE_INFO_COPIED_FROM(getSrcFile(), getSrcLine()) << "Unused Attribute: \""<<it->first <<"\" with value: \"" <<it->second.c_str() <<"\"" ;        }
     }
+    obj->setInstanciationFilePos(getSrcLine());
+    obj->setInstanciationFileName(getSrcFile());
     return true;
 }
 

--- a/applications/plugins/SofaPython/Binding_BaseContext.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseContext.cpp
@@ -164,8 +164,8 @@ static PyObject * BaseContext_createObject_Impl(PyObject * self, PyObject * args
             msg_warning(node) << "Sofa.Node.createObject("<<type<<") called on a node("<<node->getName()<<") that is already initialized";
     }
     auto fileinfo = PythonEnvironment::getPythonCallingPointAsFileInfo();
-    obj->setInstanciationFilePos(fileinfo->line);
-    obj->setInstanciationFileName(fileinfo->filename);
+    obj->setInstanciationSourceFilePos(fileinfo->line);
+    obj->setInstanciationSourceFileName(fileinfo->filename);
     return sofa::PythonFactory::toPython(obj.get());
 }
 

--- a/applications/plugins/SofaPython/Binding_BaseContext.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseContext.cpp
@@ -163,7 +163,9 @@ static PyObject * BaseContext_createObject_Impl(PyObject * self, PyObject * args
         if (node && node->isInitialized())
             msg_warning(node) << "Sofa.Node.createObject("<<type<<") called on a node("<<node->getName()<<") that is already initialized";
     }
-
+    auto fileinfo = PythonEnvironment::getPythonCallingPointAsFileInfo();
+    obj->setInstanciationFilePos(fileinfo->line);
+    obj->setInstanciationFileName(fileinfo->filename);
     return sofa::PythonFactory::toPython(obj.get());
 }
 

--- a/applications/plugins/SofaPython/Binding_Node.cpp
+++ b/applications/plugins/SofaPython/Binding_Node.cpp
@@ -215,8 +215,8 @@ static PyObject * Node_createChild(PyObject *self, PyObject * args) {
     /// retrieve the creation location from python and pass it to Sofa so we
     /// can locate easily where the node has been instantiated.
     auto fileinfo = PythonEnvironment::getPythonCallingPointAsFileInfo();
-    child->setInstanciationFilePos(fileinfo->line);
-    child->setInstanciationFileName(fileinfo->filename);
+    child->setInstanciationSourceFilePos(fileinfo->line);
+    child->setInstanciationSourceFileName(fileinfo->filename);
 
     return sofa::PythonFactory::toPython(child);
 }

--- a/applications/plugins/SofaPython/Binding_Node.cpp
+++ b/applications/plugins/SofaPython/Binding_Node.cpp
@@ -211,6 +211,13 @@ static PyObject * Node_createChild(PyObject *self, PyObject * args) {
         return nullptr;
     }
     Node* child = obj->createChild(nodeName).get();
+
+    /// retrieve the creation location from python and pass it to Sofa so we
+    /// can locate easily where the node has been instantiated.
+    auto fileinfo = PythonEnvironment::getPythonCallingPointAsFileInfo();
+    child->setInstanciationFilePos(fileinfo->line);
+    child->setInstanciationFileName(fileinfo->filename);
+
     return sofa::PythonFactory::toPython(child);
 }
 

--- a/applications/sofa/gui/qt/QSofaListView.cpp
+++ b/applications/sofa/gui/qt/QSofaListView.cpp
@@ -461,9 +461,9 @@ void QSofaListView::RunSofaRightClicked( const QPoint& point)
     {
         contextMenu->addSeparator();
         act = contextMenu->addAction("Go to Scene...", this, SLOT(openInstanciation()));
-        act->setEnabled(object_.asBase()->getInstanciationFileName() != "");
+        act->setEnabled(object_.asBase()->getInstanciationSourceFileName() != "");
         act = contextMenu->addAction("Go to Implementation...", this, SLOT(openImplementation()));
-        act->setEnabled(object_.asBase()->getSourceFileName() != "");
+        act->setEnabled(object_.asBase()->getDefinitionSourceFileName() != "");
     }
 
     contextMenu->addSeparator();
@@ -691,8 +691,8 @@ void QSofaListView::openInstanciation()
 {
     if(object_.isBase())
     {
-        openInExternalEditor(object_.asBase()->getInstanciationFileName(),
-                             object_.asBase()->getInstanciationFilePos());
+        openInExternalEditor(object_.asBase()->getInstanciationSourceFileName(),
+                             object_.asBase()->getInstanciationSourceFilePos());
     }
 }
 
@@ -700,8 +700,8 @@ void QSofaListView::openImplementation()
 {
     if(object_.isBase())
     {
-        openInExternalEditor(object_.asBase()->getSourceFileName(),
-                             object_.asBase()->getSourceFilePos());
+        openInExternalEditor(object_.asBase()->getDefinitionSourceFileName(),
+                             object_.asBase()->getDefinitionSourceFilePos());
     }
 }
 

--- a/applications/sofa/gui/qt/QSofaListView.cpp
+++ b/applications/sofa/gui/qt/QSofaListView.cpp
@@ -31,7 +31,6 @@
 #include <SofaSimulationCommon/xml/BaseElement.h>
 #include <SofaSimulationCommon/xml/XML.h>
 #include <sofa/helper/cast.h>
-#include <sofa/helper/Utils.h>
 
 #include <QMenu>
 #include <QtGlobal> // version macro

--- a/applications/sofa/gui/qt/QSofaListView.cpp
+++ b/applications/sofa/gui/qt/QSofaListView.cpp
@@ -459,9 +459,9 @@ void QSofaListView::RunSofaRightClicked( const QPoint& point)
     if( object_.isBase() )
     {
         contextMenu->addSeparator();
-        act = contextMenu->addAction("Find in scene file", this, SLOT(openInstanciation()));
+        act = contextMenu->addAction("Go to Scene...", this, SLOT(openInstanciation()));
         act->setEnabled(object_.asBase()->getInstanciationFileName() != "");
-        act = contextMenu->addAction("Find in source file", this, SLOT(openImplementation()));
+        act = contextMenu->addAction("Go to Implementation...", this, SLOT(openImplementation()));
         act->setEnabled(object_.asBase()->getSourceFileName() != "");
     }
 

--- a/applications/sofa/gui/qt/QSofaListView.h
+++ b/applications/sofa/gui/qt/QSofaListView.h
@@ -66,6 +66,15 @@ public:
     bool isNode()   { return type == typeNode;   }
     bool isObject() { return type == typeObject; }
     bool isData()   { return type == typeData;   }
+    bool isBase()   { return isNode() || isObject(); }
+    sofa::core::objectmodel::Base* asBase()
+    {
+        if( isNode() )
+            return dynamic_cast<sofa::core::objectmodel::Base*>(ptr.Node);
+        if( isObject() )
+            return dynamic_cast<sofa::core::objectmodel::Base*>(ptr.Object);
+        return nullptr;
+    }
 } ObjectModel;
 
 enum SofaListViewAttribute
@@ -131,6 +140,8 @@ protected Q_SLOTS:
     void HideDatas();
     void ShowDatas();
     void openInEditor();
+    void openInstanciation();
+    void openImplementation();
     void copyFilePathToClipBoard();
     void DeactivateNode();
     void ActivateNode();

--- a/applications/sofa/gui/qt/RealGUI.cpp
+++ b/applications/sofa/gui/qt/RealGUI.cpp
@@ -150,7 +150,11 @@ class QSOFAApplication : public QApplication
 public:
     QSOFAApplication(int &argc, char ** argv)
         : QApplication(argc,argv)
-    { }
+    {
+        QCoreApplication::setOrganizationName("Sofa Consortium");
+        QCoreApplication::setOrganizationDomain("sofa");
+        QCoreApplication::setApplicationName("runSofa");
+    }
 
 #if QT_VERSION < 0x050000
     static inline QString translate(const char * context, const char * key, const char * disambiguation,
@@ -206,6 +210,7 @@ public:
 
 BaseGUI* RealGUI::CreateGUI ( const char* name, sofa::simulation::Node::SPtr root, const char* filename )
 {
+
     CreateApplication();
 
     // create interface
@@ -728,7 +733,6 @@ int RealGUI::closeGUI()
     settings.beginGroup("viewer");
     settings.setValue("screenNumber", QApplication::desktop()->screenNumber(this));
     settings.endGroup();
-
     delete this;
     return 0;
 }


### PR DESCRIPTION
Two new menu entry are added in the SceneGraph view to jump to the source file location corresponding to the selected object.

This PR is based on #1012 to get the file location. 
By default qtcreator will be used  to open the file. 
But this can be changed by editting the config file saved by the QSetting mecanism. 

NB: The "Go To implementation" really make sense when using STLIB as it allows 
to jump where a prefab is implemented.  It would be nice if we could do the same for c++ 
but this is of lesser interest ...because we need to compile sofa to see a change :) 

EDIT: small video show how it works 
[![video](http://img.youtube.com/vi/zzOY-Lt0vgM/0.jpg)](http://www.youtube.com/watch?v=zzOY-Lt0vgM)
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
