### PR TITLE
[image] Fix image_gui plugin loading

### DIFF
--- a/applications/plugins/image/CMakeLists.txt
+++ b/applications/plugins/image/CMakeLists.txt
@@ -79,7 +79,6 @@ find_package(SofaBase REQUIRED)
 find_package(SofaGeneral REQUIRED)
 find_package(Newmat REQUIRED)
 find_package(CImgPlugin REQUIRED)
-
 find_package(MultiThreading QUIET)
 
 if(MultiThreading_FOUND)
@@ -102,14 +101,13 @@ if(NOT ${SOFA_NO_OPENGL})
     list(APPEND HEADER_FILES ImageViewer.h)
     list(APPEND SOURCE_FILES ImageViewer.cpp)
 
-if(FREENECT_FOUND)
-    list(APPEND HEADER_FILES Kinect.h)
-    list(APPEND SOURCE_FILES Kinect.cpp)
-    message(STATUS "image: found the freenect library")
-else()
-    message(STATUS "image: could not find the freenect library, won't build the Kinect component")
-endif()
-
+    if(FREENECT_FOUND)
+        list(APPEND HEADER_FILES Kinect.h)
+        list(APPEND SOURCE_FILES Kinect.cpp)
+        message(STATUS "image: found the freenect library")
+    else()
+        message(STATUS "image: could not find the freenect library, won't build the Kinect component")
+    endif()
 endif()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
@@ -133,7 +131,6 @@ if(SOFA_OPENMP)
     string(REPLACE "${OpenMP_CXX_FLAGS}" "" CMAKE_CXX_LINK_FLAGS ${CMAKE_CXX_LINK_FLAGS})
 endif()
 
-
 find_package(DiffusionSolver CONFIG REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${README_FILES} ${PYTHON_FILES})
@@ -150,15 +147,15 @@ target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_BIN
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>")
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CImgPlugin_INCLUDE_DIRS}>")
 target_include_directories(${PROJECT_NAME} PUBLIC "$<INSTALL_INTERFACE:include>")
+
 if(FREENECT_FOUND)
     target_include_directories(${PROJECT_NAME} PUBLIC "${FREENECT_INCLUDE_DIR}")
 endif()
+
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${IMAGE_VERSION})
 set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${HEADER_FILES}")
 
-
 set(IMAGE_COMPILER_FLAGS "-DSOFA_BUILD_IMAGE")
-
 
 if( SofaPython_FOUND )
     target_link_libraries(${PROJECT_NAME} SofaPython)    

--- a/applications/plugins/image/image_gui/CMakeLists.txt
+++ b/applications/plugins/image/image_gui/CMakeLists.txt
@@ -23,8 +23,8 @@ set(SOURCE_FILES
 include(../imagetoolbox/imagetoolbox.cmake)
 
 find_package(SofaGui REQUIRED QUIET)
-
 find_package(Qt5 COMPONENTS Core Gui Widgets QUIET)
+
 if(Qt5Core_FOUND)
     qt5_wrap_cpp(MOC_FILES ${MOC_HEADER_FILES})
 else()

--- a/applications/plugins/image/initImage.cpp
+++ b/applications/plugins/image/initImage.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #include <image/config.h>
 #include <sofa/helper/system/config.h>
+#include <sofa/helper/system/PluginManager.h>
 
 #ifdef SOFA_HAVE_SOFAPYTHON
     #include <SofaPython/PythonFactory.h>
@@ -71,6 +72,16 @@ void initExternalModule()
             SP_ADD_CLASS_IN_FACTORY(ImageBData,sofa::core::objectmodel::Data<sofa::defaulttype::ImageB>)
         }
 #endif
+
+        std::string pluginPath = sofa::helper::system::PluginManager::getInstance().findPlugin("image_gui");
+        if (!pluginPath.empty())
+        {
+            sofa::helper::system::PluginManager::getInstance().loadPluginByPath(pluginPath);
+        }
+        else
+        {
+            msg_warning("initImage") << "the sub-plugin image_gui was not successfully loaded";
+        }
     }
 }
 


### PR DESCRIPTION
Coming from [Mei remark on the forum](https://www.sofa-framework.org/community/forum/topic/image-viewer-in-image-plugin/)

- Add the automatic loading of the image_gui library when the plugin image is loaded (if the library is well there)
- Add formating in associated CMakeLists

With the correct loading of image_gui, now the ImagePlaneWidget will work fine when opening a ImageViewer component

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
