### PR TITLE
[SofaBoundaryCondition] Fix draw function in ConstantForcefield

### DIFF
--- a/modules/SofaBoundaryCondition/ConstantForceField.inl
+++ b/modules/SofaBoundaryCondition/ConstantForceField.inl
@@ -231,9 +231,11 @@ void ConstantForceField<DataTypes>::addKToMatrix(const sofa::core::behavior::Mul
 template<class DataTypes>
 void ConstantForceField<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
-    vparams->drawTool()->saveLastState();
-
     SReal aSC = d_arrowSizeCoef.getValue();
+
+    if ((!vparams->displayFlags().getShowForceFields() && (aSC==0)) || (aSC < 0.0)) return;
+
+    vparams->drawTool()->saveLastState();
 
     Deriv singleForce;
     if (d_totalForce.getValue()*d_totalForce.getValue() > 0.0)
@@ -246,7 +248,6 @@ void ConstantForceField<DataTypes>::draw(const core::visual::VisualParams* vpara
         singleForce = d_force.getValue();
     }
 
-    if ((!vparams->displayFlags().getShowForceFields() && (aSC==0)) || (aSC < 0.0)) return;
     const VecIndex& indices = d_indices.getValue();
     const VecDeriv& f = d_forces.getValue();
     const Deriv f_end = (f.empty()? singleForce : f[f.size()-1]);


### PR DESCRIPTION
In ConstantForcefield, 
if the showForceField flag was not set, the draw() function was not restoring the visual state.
Consequently, some weird visual bugs could happen with some other components.


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
