### PR TITLE
[SofaHaptics] Replace deprecated INCLUDE_ROOT_DIR in CMakeLists.txt

### DIFF
--- a/modules/SofaHaptics/CMakeLists.txt
+++ b/modules/SofaHaptics/CMakeLists.txt
@@ -35,4 +35,4 @@ target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CUR
 sofa_generate_package(NAME ${PROJECT_NAME}
                       VERSION ${PROJECT_VERSION}
                       TARGETS ${PROJECT_NAME}
-                      INCLUDE_ROOT_DIR ${PROJECT_NAME})
+                      INCLUDE_INSTALL_DIR ${PROJECT_NAME})


### PR DESCRIPTION




______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
