### PR TITLE
[all] For each data field's with a "filename" alias flip it with the data's name. 

### DIFF
--- a/SofaKernel/framework/sofa/core/topology/BaseMeshTopology.cpp
+++ b/SofaKernel/framework/sofa/core/topology/BaseMeshTopology.cpp
@@ -60,9 +60,9 @@ static int _init_  = initStaticStructures();
 
 
 BaseMeshTopology::BaseMeshTopology()
-    : fileTopology(initData(&fileTopology,"fileTopology","Filename of the mesh"))
+    : fileTopology(initData(&fileTopology,"filename","Filename of the mesh"))
 {
-    addAlias(&fileTopology,"filename");
+    addAlias(&fileTopology,"fileTopology");
 }
 
 /// Returns the set of edges adjacent to a given vertex.

--- a/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.inl
@@ -56,11 +56,11 @@ DiagonalMass<DataTypes, MassType>::DiagonalMass()
                                                                   "If unspecified or wrongly set, the default value is used: totalMass = 1.0"))
     , d_showCenterOfGravity( initData(&d_showCenterOfGravity, false, "showGravityCenter", "Display the center of gravity of the system" ) )
     , d_showAxisSize( initData(&d_showAxisSize, 1.0f, "showAxisSizeFactor", "Factor length of the axis displayed (only used for rigids)" ) )
-    , d_fileMass( initData(&d_fileMass,  "fileMass", "Xsp3.0 file to specify the mass parameters" ) )
+    , d_fileMass( initData(&d_fileMass,  "filename", "Xsp3.0 file to specify the mass parameters" ) )
     , m_pointHandler(NULL)
     , m_topologyType(TOPOLOGY_UNKNOWN)
 {
-    this->addAlias(&d_fileMass,"filename");
+    this->addAlias(&d_fileMass,"fileMass");
 }
 
 template <class DataTypes, class MassType>

--- a/SofaKernel/modules/SofaBaseVisual/VisualModelImpl.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/VisualModelImpl.cpp
@@ -202,7 +202,7 @@ VisualModelImpl::VisualModelImpl() //const std::string &name, std::string filena
     , m_quads           (initData   (&m_quads, "quads", "quads of the model"))
     , m_vertPosIdx      (initData   (&m_vertPosIdx, "vertPosIdx", "If vertices have multiple normals/texcoords stores vertices position indices"))
     , m_vertNormIdx     (initData   (&m_vertNormIdx, "vertNormIdx", "If vertices have multiple normals/texcoords stores vertices normal indices"))
-    , fileMesh          (initData   (&fileMesh, "fileMesh"," Path to the model"))
+    , fileMesh          (initData   (&fileMesh, "filename"," Path to an ogl model"))
     , texturename       (initData   (&texturename, "texturename", "Name of the Texture"))
     , m_translation     (initData   (&m_translation, Vec3Real(), "translation", "Initial Translation of the object"))
     , m_rotation        (initData   (&m_rotation, Vec3Real(), "rotation", "Initial Rotation of the object"))
@@ -219,7 +219,7 @@ VisualModelImpl::VisualModelImpl() //const std::string &name, std::string filena
     m_topology = nullptr;
 
     //material.setDisplayed(false);
-    addAlias(&fileMesh, "filename");
+    addAlias(&fileMesh, "fileMesh");
 
     m_vertices2     .setGroup("Vector");
     m_vnormals      .setGroup("Vector");

--- a/SofaKernel/modules/SofaDeformable/SpringForceField.inl
+++ b/SofaKernel/modules/SofaDeformable/SpringForceField.inl
@@ -64,10 +64,10 @@ SpringForceField<DataTypes>::SpringForceField(SReal _ks, SReal _kd)
     , showArrowSize(initData(&showArrowSize,0.01f,"showArrowSize","size of the axis"))
     , drawMode(initData(&drawMode,0,"drawMode","The way springs will be drawn:\n- 0: Line\n- 1:Cylinder\n- 2: Arrow"))
     , springs(initData(&springs,"spring","pairs of indices, stiffness, damping, rest length"))
-    , fileSprings(initData(&fileSprings, "fileSprings", "File describing the springs"))
+    , fileSprings(initData(&fileSprings, "filename", "Xsp file describing the springs."))
     , maskInUse(false)
 {
-    this->addAlias(&fileSprings, "filename");
+    this->addAlias(&fileSprings, "fileSprings");
 }
 
 

--- a/SofaKernel/modules/SofaRigid/RigidMapping.inl
+++ b/SofaKernel/modules/SofaRigid/RigidMapping.inl
@@ -130,7 +130,7 @@ RigidMapping<TIn, TOut>::RigidMapping()
     : Inherit()
     , points(initData(&points, "initialPoints", "Local Coordinates of the points"))
     , index(initData(&index, (unsigned)0, "index", "input DOF index"))
-    , fileRigidMapping(initData(&fileRigidMapping, "fileRigidMapping", "Filename"))
+    , fileRigidMapping(initData(&fileRigidMapping, "filename", "Xsp file where rigid mapping information can be loaded from."))
     , useX0(initData(&useX0, false, "useX0", "Use x0 instead of local copy of initial positions (to support topo changes)"))
     , indexFromEnd(initData(&indexFromEnd, false, "indexFromEnd", "input DOF index starts from the end of input DOFs vector"))
     , rigidIndexPerPoint(initData(&rigidIndexPerPoint, "rigidIndexPerPoint", "For each mapped point, the index of the Rigid it is mapped from"))
@@ -139,7 +139,7 @@ RigidMapping<TIn, TOut>::RigidMapping()
     , matrixJ()
     , updateJ(false)
 {
-    this->addAlias(&fileRigidMapping, "filename");
+    this->addAlias(&fileRigidMapping, "fileRigidMapping");
 }
 
 template <class TIn, class TOut>

--- a/SofaKernel/modules/SofaRigid/RigidRigidMapping.inl
+++ b/SofaKernel/modules/SofaRigid/RigidRigidMapping.inl
@@ -54,12 +54,12 @@ RigidRigidMapping<TIn,TOut>::RigidRigidMapping()
                            "the given number of children frames. Otherwise, the values are the number \n"
                            "of child frames driven by each parent frame. ")),
       index(initData(&index,(unsigned)0,"index","input frame index")),
-      fileRigidRigidMapping(initData(&fileRigidRigidMapping,"fileRigidRigidMapping","Filename")),
+      fileRigidRigidMapping(initData(&fileRigidRigidMapping,"filename","Xsp file where to load rigidrigid mapping description")),
       axisLength(initData( &axisLength, 0.7, "axisLength", "axis length for display")),
       indexFromEnd( initData ( &indexFromEnd,false,"indexFromEnd","input DOF index starts from the end of input DOFs vector") ),
       globalToLocalCoords ( initData ( &globalToLocalCoords,"globalToLocalCoords","are the output DOFs initially expressed in global coordinates" ) )
 {
-    this->addAlias(&fileRigidRigidMapping,"filename");
+    this->addAlias(&fileRigidRigidMapping,"fileRigidRigidMapping");
 }
 
 

--- a/applications/plugins/DEPRECATED/frame/FrameDiagonalMass.inl
+++ b/applications/plugins/DEPRECATED/frame/FrameDiagonalMass.inl
@@ -46,10 +46,10 @@ FrameDiagonalMass<DataTypes, MassType>::FrameDiagonalMass()
     : f_mass0 ( initData ( &f_mass0,"f_mass0","vector of lumped blocks of the mass matrix in the rest position." ) )
     , f_mass ( initData ( &f_mass,"f_mass","vector of lumped blocks of the mass matrix." ) )
     , showAxisSize ( initData ( &showAxisSize, 1.0f, "showAxisSizeFactor", "factor length of the axis displayed (only used for rigids)" ) )
-    , fileMass( initData(&fileMass,  "fileMass", "File to specify the mass" ) )
+    , fileMass( initData(&fileMass,  "filename", "File to specify the mass" ) )
     , damping ( initData ( &damping, 0.0f, "damping", "add a force which is \"- damping * speed\"" ) )
 {
-    this->addAlias(&fileMass,"filename");
+    this->addAlias(&fileMass,"fileMass");
 }
 
 

--- a/applications/plugins/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.cpp
+++ b/applications/plugins/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.cpp
@@ -65,7 +65,7 @@ using namespace defaulttype;
 
 RigidDistanceGridCollisionModel::RigidDistanceGridCollisionModel()
     : modified(true)
-    , fileRigidDistanceGrid( initData( &fileRigidDistanceGrid, "fileRigidDistanceGrid", "load distance grid from specified file"))
+    , fileRigidDistanceGrid( initData( &fileRigidDistanceGrid, "filename", "Load distance grid from specified file"))
     , scale( initData( &scale, 1.0, "scale", "scaling factor for input file"))
     , translation( initData( &translation, "translation", "translation to apply to input file"))
     , rotation( initData( &rotation, "rotation", "rotation to apply to input file"))
@@ -83,7 +83,7 @@ RigidDistanceGridCollisionModel::RigidDistanceGridCollisionModel()
     , showMaxDist ( initData( &showMaxDist, 0.0, "showMaxDist", "Max distance to render gradients"))
 {
     rigid = NULL;
-    addAlias(&fileRigidDistanceGrid,"filename");
+    addAlias(&fileRigidDistanceGrid,"fileRigidDistanceGrid");
 }
 
 RigidDistanceGridCollisionModel::~RigidDistanceGridCollisionModel()
@@ -438,7 +438,7 @@ void RigidDistanceGridCollisionModel::draw(const core::visual::VisualParams* ,in
 ////////////////////////////////////////////////////////////////////////////////
 
 FFDDistanceGridCollisionModel::FFDDistanceGridCollisionModel()
-    : fileFFDDistanceGrid( initData( &fileFFDDistanceGrid, "fileFFDDistanceGrid", "load distance grid from specified file"))
+    : fileFFDDistanceGrid( initData( &fileFFDDistanceGrid, "filename", "Load distance grid from specified file"))
     , scale( initData( &scale, 1.0, "scale", "scaling factor for input file"))
     , sampling( initData( &sampling, 0.0, "sampling", "if not zero: sample the surface with points approximately separated by the given sampling distance (expressed in voxels if the value is negative)"))
     , box( initData( &box, "box", "Field bounding box defined by xmin,ymin,zmin, xmax,ymax,zmax") )
@@ -453,7 +453,7 @@ FFDDistanceGridCollisionModel::FFDDistanceGridCollisionModel()
     ffdMesh = NULL;
     ffdRGrid = NULL;
     ffdSGrid = NULL;
-    addAlias(&fileFFDDistanceGrid,"filename");
+    addAlias(&fileFFDDistanceGrid,"fileFFDDistanceGrid");
     enum_type = FFDDISTANCE_GRIDE_TYPE;
 }
 

--- a/applications/plugins/SofaDistanceGrid/components/forcefield/DistanceGridForceField.h
+++ b/applications/plugins/SofaDistanceGrid/components/forcefield/DistanceGridForceField.h
@@ -171,7 +171,7 @@ public:
 protected:
     DistanceGridForceField()
         : grid(NULL)
-        , fileDistanceGrid( initData( &fileDistanceGrid, "fileDistanceGrid", "load distance grid from specified file"))
+        , fileDistanceGrid( initData( &fileDistanceGrid, "filename", "load distance grid from specified file"))
         , scale( initData( &scale, 1.0, "scale", "scaling factor for input file"))
         , box( initData( &box, "box", "Field bounding box defined by xmin,ymin,zmin, xmax,ymax,zmax") )
         , nx( initData( &nx, 64, "nx", "number of values on X axis") )
@@ -193,7 +193,7 @@ protected:
     {
         this->addAlias(&stiffnessIn,"stiffness");
         this->addAlias(&stiffnessOut,"stiffness");
-        this->addAlias(&fileDistanceGrid,"filename");
+        this->addAlias(&fileDistanceGrid,"fileDistanceGrid");
     }
 public:
     void init() override;

--- a/modules/SofaMiscEngine/Distances.inl
+++ b/modules/SofaMiscEngine/Distances.inl
@@ -59,13 +59,13 @@ Distances< DataTypes >::Distances ( sofa::component::topology::DynamicSparseGrid
     initTargetStep ( initData ( &initTargetStep, 1, "initTargetStep","initialize the target MechanicalObject from the grid using this step." ) ),
     zonesFramePair ( initData ( &zonesFramePair, "zonesFramePair","Correspondance between the segmented value and the frames." ) ),
     harmonicMaxValue ( initData ( &harmonicMaxValue, 100.0, "harmonicMaxValue","Max value used to initialize the harmonic distance grid." ) ),
-    fileDistance( initData(&fileDistance, "fileDistance", "file containing the result of the computation of the distances")),
+    fileDistance( initData(&fileDistance, "filename", "file containing the result of the computation of the distances")),
     targetPath(initData(&targetPath, "targetPath", "path to the goal point set topology")),
     target ( targetPointSet ) ,
     hexaContainerPath(initData(&hexaContainerPath, "hexaContainerPath", "path to the grid used to compute the distances")),
     hexaContainer ( hexaTopoContainer )
 {
-    this->addAlias(&fileDistance, "filename");
+    this->addAlias(&fileDistance, "fileDistance");
     zonesFramePair.setDisplayed( false); // GUI can not display map.
 
     sofa::helper::OptionsGroup distanceTypeOptions(5,"Geodesic","Harmonic","Stiffness Diffusion", "Vorono\xEF", "Harmonic with Stiffness");

--- a/modules/SofaOpenglVisual/OglTexture.cpp
+++ b/modules/SofaOpenglVisual/OglTexture.cpp
@@ -39,7 +39,7 @@ int OglTexture2DClass = core::RegisterObject("OglTexture2D").add< OglTexture2D >
 GLint OglTexture::MAX_NUMBER_OF_TEXTURE_UNIT = 1;
 
 OglTexture::OglTexture()
-    :textureFilename(initData(&textureFilename, (std::string) "", "textureFilename", "Texture Filename"))
+    :textureFilename(initData(&textureFilename, (std::string) "", "filename", "Texture Filename"))
     ,textureUnit(initData(&textureUnit, (unsigned short) 1, "textureUnit", "Set the texture unit"))
     ,enabled(initData(&enabled, (bool) true, "enabled", "enabled ?"))
     ,repeat(initData(&repeat, (bool) false, "repeat", "Repeat Texture ?"))
@@ -61,7 +61,7 @@ OglTexture::OglTexture()
     ,texture(nullptr)
     ,img(nullptr)
 {
-    this->addAlias(&textureFilename, "filename");
+    this->addAlias(&textureFilename, "textureFilename");
 }
 
 OglTexture::~OglTexture()


### PR DESCRIPTION
Now, each data field with a filename alias will show "filename" in the GUI.
 The old names are now the aliases and are just keept for backward compatibility management. 

I didn't do the change for data related to dumping/output filenames.  Because I found that ambigious. 
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
