### PR TITLE
[SofaKernel] minor cleaning in mesh loader

### DIFF
--- a/SofaKernel/framework/sofa/core/loader/MeshLoader.cpp
+++ b/SofaKernel/framework/sofa/core/loader/MeshLoader.cpp
@@ -35,39 +35,39 @@ namespace loader
 using namespace sofa::defaulttype;
 
 MeshLoader::MeshLoader() : BaseLoader()
-    , d_positions(initData(&d_positions, "position", "Vertices of the mesh loaded"))
-    , d_polylines(initData(&d_polylines, "polylines", "Polylines of the mesh loaded"))
-    , d_edges(initData(&d_edges, "edges", "Edges of the mesh loaded"))
-    , d_triangles(initData(&d_triangles, "triangles", "Triangles of the mesh loaded"))
-    , d_quads(initData(&d_quads, "quads", "Quads of the mesh loaded"))
-    , d_polygons(initData(&d_polygons, "polygons", "Polygons of the mesh loaded"))
-    , d_highOrderEdgePositions(initData(&d_highOrderEdgePositions, "highOrderEdgePositions", "High order edge points of the mesh loaded"))
-    , d_highOrderTrianglePositions(initData(&d_highOrderTrianglePositions, "highOrderTrianglePositions", "High order triangle points of the mesh loaded"))
-    , d_highOrderQuadPositions(initData(&d_highOrderQuadPositions, "highOrderQuadPositions", "High order quad points of the mesh loaded"))
-    , d_tetrahedra(initData(&d_tetrahedra, "tetrahedra", "Tetrahedra of the mesh loaded"))
-    , d_hexahedra(initData(&d_hexahedra, "hexahedra", "Hexahedra of the mesh loaded"))
-    , d_pentahedra(initData(&d_pentahedra, "pentahedra", "Pentahedra of the mesh loaded"))
-    , d_highOrderTetrahedronPositions(initData(&d_highOrderTetrahedronPositions, "highOrderTetrahedronPositions", "High order tetrahedron points of the mesh loaded"))
-    , d_highOrderHexahedronPositions(initData(&d_highOrderHexahedronPositions, "highOrderHexahedronPositions", "High order hexahedron points of the mesh loaded"))
-    , d_pyramids(initData(&d_pyramids, "pyramids", "Pyramids of the mesh loaded"))
-    , d_normals(initData(&d_normals, "normals", "Normals of the mesh loaded"))
-    , d_edgesGroups(initData(&d_edgesGroups, "edgesGroups", "Groups of Edges"))
-    , d_trianglesGroups(initData(&d_trianglesGroups, "trianglesGroups", "Groups of Triangles"))
-    , d_quadsGroups(initData(&d_quadsGroups, "quadsGroups", "Groups of Quads"))
-    , d_polygonsGroups(initData(&d_polygonsGroups, "polygonsGroups", "Groups of Polygons"))
-    , d_tetrahedraGroups(initData(&d_tetrahedraGroups, "tetrahedraGroups", "Groups of Tetrahedra"))
-    , d_hexahedraGroups(initData(&d_hexahedraGroups, "hexahedraGroups", "Groups of Hexahedra"))
-    , d_pentahedraGroups(initData(&d_pentahedraGroups, "pentahedraGroups", "Groups of Pentahedra"))
-    , d_pyramidsGroups(initData(&d_pyramidsGroups, "pyramidsGroups", "Groups of Pyramids"))
-    , d_flipNormals(initData(&d_flipNormals, false, "flipNormals", "Flip Normals"))
-    , d_triangulate(initData(&d_triangulate, false, "triangulate", "Divide all polygons into triangles"))
-    , d_createSubelements(initData(&d_createSubelements, false, "createSubelements", "Divide all n-D elements into their (n-1)-D boundary elements (e.g. tetrahedra to triangles)"))
-    , d_onlyAttachedPoints(initData(&d_onlyAttachedPoints, false, "onlyAttachedPoints", "Only keep points attached to elements of the mesh"))
-    , d_translation(initData(&d_translation, Vec3(), "translation", "Translation of the DOFs"))
-    , d_rotation(initData(&d_rotation, Vec3(), "rotation", "Rotation of the DOFs"))
-    , d_scale(initData(&d_scale, Vec3(1.0, 1.0, 1.0), "scale3d", "Scale of the DOFs in 3 dimensions"))
-    , d_transformation(initData(&d_transformation, Matrix4::s_identity, "transformation", "4x4 Homogeneous matrix to transform the DOFs (when present replace any)"))
-    , d_previousTransformation( Matrix4::s_identity )
+  , d_positions(initData(&d_positions, "position", "Vertices of the mesh loaded"))
+  , d_polylines(initData(&d_polylines, "polylines", "Polylines of the mesh loaded"))
+  , d_edges(initData(&d_edges, "edges", "Edges of the mesh loaded"))
+  , d_triangles(initData(&d_triangles, "triangles", "Triangles of the mesh loaded"))
+  , d_quads(initData(&d_quads, "quads", "Quads of the mesh loaded"))
+  , d_polygons(initData(&d_polygons, "polygons", "Polygons of the mesh loaded"))
+  , d_highOrderEdgePositions(initData(&d_highOrderEdgePositions, "highOrderEdgePositions", "High order edge points of the mesh loaded"))
+  , d_highOrderTrianglePositions(initData(&d_highOrderTrianglePositions, "highOrderTrianglePositions", "High order triangle points of the mesh loaded"))
+  , d_highOrderQuadPositions(initData(&d_highOrderQuadPositions, "highOrderQuadPositions", "High order quad points of the mesh loaded"))
+  , d_tetrahedra(initData(&d_tetrahedra, "tetrahedra", "Tetrahedra of the mesh loaded"))
+  , d_hexahedra(initData(&d_hexahedra, "hexahedra", "Hexahedra of the mesh loaded"))
+  , d_pentahedra(initData(&d_pentahedra, "pentahedra", "Pentahedra of the mesh loaded"))
+  , d_highOrderTetrahedronPositions(initData(&d_highOrderTetrahedronPositions, "highOrderTetrahedronPositions", "High order tetrahedron points of the mesh loaded"))
+  , d_highOrderHexahedronPositions(initData(&d_highOrderHexahedronPositions, "highOrderHexahedronPositions", "High order hexahedron points of the mesh loaded"))
+  , d_pyramids(initData(&d_pyramids, "pyramids", "Pyramids of the mesh loaded"))
+  , d_normals(initData(&d_normals, "normals", "Normals of the mesh loaded"))
+  , d_edgesGroups(initData(&d_edgesGroups, "edgesGroups", "Groups of Edges"))
+  , d_trianglesGroups(initData(&d_trianglesGroups, "trianglesGroups", "Groups of Triangles"))
+  , d_quadsGroups(initData(&d_quadsGroups, "quadsGroups", "Groups of Quads"))
+  , d_polygonsGroups(initData(&d_polygonsGroups, "polygonsGroups", "Groups of Polygons"))
+  , d_tetrahedraGroups(initData(&d_tetrahedraGroups, "tetrahedraGroups", "Groups of Tetrahedra"))
+  , d_hexahedraGroups(initData(&d_hexahedraGroups, "hexahedraGroups", "Groups of Hexahedra"))
+  , d_pentahedraGroups(initData(&d_pentahedraGroups, "pentahedraGroups", "Groups of Pentahedra"))
+  , d_pyramidsGroups(initData(&d_pyramidsGroups, "pyramidsGroups", "Groups of Pyramids"))
+  , d_flipNormals(initData(&d_flipNormals, false, "flipNormals", "Flip Normals"))
+  , d_triangulate(initData(&d_triangulate, false, "triangulate", "Divide all polygons into triangles"))
+  , d_createSubelements(initData(&d_createSubelements, false, "createSubelements", "Divide all n-D elements into their (n-1)-D boundary elements (e.g. tetrahedra to triangles)"))
+  , d_onlyAttachedPoints(initData(&d_onlyAttachedPoints, false, "onlyAttachedPoints", "Only keep points attached to elements of the mesh"))
+  , d_translation(initData(&d_translation, Vec3(), "translation", "Translation of the DOFs"))
+  , d_rotation(initData(&d_rotation, Vec3(), "rotation", "Rotation of the DOFs"))
+  , d_scale(initData(&d_scale, Vec3(1.0, 1.0, 1.0), "scale3d", "Scale of the DOFs in 3 dimensions"))
+  , d_transformation(initData(&d_transformation, Matrix4::s_identity, "transformation", "4x4 Homogeneous matrix to transform the DOFs (when present replace any)"))
+  , d_previousTransformation( Matrix4::s_identity )
 {
     addAlias(&d_tetrahedra, "tetras");
     addAlias(&d_hexahedra, "hexas");
@@ -94,6 +94,32 @@ MeshLoader::MeshLoader() : BaseLoader()
     d_pentahedra.setPersistent(false);
     d_pyramids.setPersistent(false);
     d_normals.setPersistent(false);
+
+    d_positions.setGroup("Vectors");
+    d_polylines.setGroup("Vectors");
+    d_edges.setGroup("Vectors");
+    d_triangles.setGroup("Vectors");
+    d_quads.setGroup("Vectors");
+    d_polygons.setGroup("Vectors");
+    d_tetrahedra.setGroup("Vectors");
+    d_hexahedra.setGroup("Vectors");
+    d_pentahedra.setGroup("Vectors");
+    d_pyramids.setGroup("Vectors");
+    d_normals.setGroup("Vectors");
+    d_highOrderTetrahedronPositions.setGroup("Vectors");
+    d_highOrderEdgePositions.setGroup("Vectors");
+    d_highOrderHexahedronPositions.setGroup("Vectors");
+    d_highOrderQuadPositions.setGroup("Vectors");
+    d_highOrderTrianglePositions.setGroup("Vectors");
+
+    d_edgesGroups.setGroup("Groups");
+    d_quadsGroups.setGroup("Groups");
+    d_polygonsGroups.setGroup("Groups");
+    d_pyramidsGroups.setGroup("Groups");
+    d_hexahedraGroups.setGroup("Groups");
+    d_trianglesGroups.setGroup("Groups");
+    d_pentahedraGroups.setGroup("Groups");
+    d_tetrahedraGroups.setGroup("Groups");
 }
 
 
@@ -147,8 +173,8 @@ void MeshLoader::reinit()
         // is applied to the points to implement the matrix product TRSx
 
         transformation = Matrix4::transformTranslation(translation) *
-                         Matrix4::transformRotation(helper::Quater< SReal >::createQuaterFromEuler(rotation * M_PI / 180.0)) *
-                         Matrix4::transformScale(scale);
+                Matrix4::transformRotation(helper::Quater< SReal >::createQuaterFromEuler(rotation * M_PI / 180.0)) *
+                Matrix4::transformScale(scale);
     }
 
     if (transformation != Matrix4::s_identity)

--- a/SofaKernel/framework/sofa/core/loader/MeshLoader.cpp
+++ b/SofaKernel/framework/sofa/core/loader/MeshLoader.cpp
@@ -63,9 +63,9 @@ MeshLoader::MeshLoader() : BaseLoader()
     , d_triangulate(initData(&d_triangulate, false, "triangulate", "Divide all polygons into triangles"))
     , d_createSubelements(initData(&d_createSubelements, false, "createSubelements", "Divide all n-D elements into their (n-1)-D boundary elements (e.g. tetrahedra to triangles)"))
     , d_onlyAttachedPoints(initData(&d_onlyAttachedPoints, false, "onlyAttachedPoints", "Only keep points attached to elements of the mesh"))
-    , d_translation(initData(&d_translation, Vector3(), "translation", "Translation of the DOFs"))
-    , d_rotation(initData(&d_rotation, Vector3(), "rotation", "Rotation of the DOFs"))
-    , d_scale(initData(&d_scale, Vector3(1.0, 1.0, 1.0), "scale3d", "Scale of the DOFs in 3 dimensions"))
+    , d_translation(initData(&d_translation, Vec3(), "translation", "Translation of the DOFs"))
+    , d_rotation(initData(&d_rotation, Vec3(), "rotation", "Rotation of the DOFs"))
+    , d_scale(initData(&d_scale, Vec3(1.0, 1.0, 1.0), "scale3d", "Scale of the DOFs in 3 dimensions"))
     , d_transformation(initData(&d_transformation, Matrix4::s_identity, "transformation", "4x4 Homogeneous matrix to transform the DOFs (when present replace any)"))
     , d_previousTransformation( Matrix4::s_identity )
 {
@@ -125,9 +125,9 @@ void MeshLoader::init()
 void MeshLoader::reinit()
 {
     Matrix4 transformation = d_transformation.getValue();
-    const Vector3& scale = d_scale.getValue();
-    const Vector3& rotation = d_rotation.getValue();
-    const Vector3& translation = d_translation.getValue();
+    const Vec3& scale = d_scale.getValue();
+    const Vec3& rotation = d_rotation.getValue();
+    const Vec3& translation = d_translation.getValue();
 
 
     this->applyTransformation(d_previousTransformation);
@@ -136,7 +136,7 @@ void MeshLoader::reinit()
 
     if (transformation != Matrix4::s_identity)
     {
-        if (d_scale != Vector3(1.0, 1.0, 1.0) || d_rotation != Vector3(0.0, 0.0, 0.0) || d_translation != Vector3(0.0, 0.0, 0.0))
+        if (d_scale != Vec3(1.0, 1.0, 1.0) || d_rotation != Vec3(0.0, 0.0, 0.0) || d_translation != Vec3(0.0, 0.0, 0.0))
         {
             msg_info() << "Parameters scale, rotation, translation ignored in favor of transformation matrix";
         }
@@ -805,7 +805,7 @@ void MeshLoader::addPyramid(helper::vector< Pyramid >* pPyramids, const Pyramid&
 void MeshLoader::copyMeshToData(sofa::helper::io::Mesh* _mesh)
 {
     // copy vertices
-    helper::vector<sofa::defaulttype::Vector3>& my_positions = *(d_positions.beginEdit());
+    helper::vector<sofa::defaulttype::Vec3>& my_positions = *(d_positions.beginEdit());
     my_positions = _mesh->getVertices();
     d_positions.endEdit();
 

--- a/SofaKernel/framework/sofa/core/loader/MeshLoader.h
+++ b/SofaKernel/framework/sofa/core/loader/MeshLoader.h
@@ -44,8 +44,6 @@ namespace core
 namespace loader
 {
 
-//todo(dmarchal 05/02/2019): This mix of types is bad.
-using sofa::defaulttype::Vector3;
 using sofa::defaulttype::Vec3;
 using topology::Topology;
 
@@ -101,30 +99,30 @@ public:
     /// @{
     void setTranslation(SReal dx, SReal dy, SReal dz)
     {
-        d_translation.setValue(Vector3(dx, dy, dz));
+        d_translation.setValue(Vec3(dx, dy, dz));
     }
     void setRotation(SReal rx, SReal ry, SReal rz)
     {
-        d_rotation.setValue(Vector3(rx, ry, rz));
+        d_rotation.setValue(Vec3(rx, ry, rz));
     }
     void setScale(SReal sx, SReal sy, SReal sz)
     {
-        d_scale.setValue(Vector3(sx, sy, sz));
+        d_scale.setValue(Vec3(sx, sy, sz));
     }
     void setTransformation(const sofa::defaulttype::Matrix4& t)
     {
         d_transformation.setValue(t);
     }
 
-    virtual Vector3 getTranslation() const
+    virtual Vec3 getTranslation() const
     {
         return d_translation.getValue();
     }
-    virtual Vector3 getRotation() const
+    virtual Vec3 getRotation() const
     {
         return d_rotation.getValue();
     }
-    virtual Vector3 getScale() const
+    virtual Vec3 getScale() const
     {
         return d_scale.getValue();
     }
@@ -177,9 +175,9 @@ public:
     Data< bool > d_createSubelements; ///< Divide all n-D elements into their (n-1)-D boundary elements (e.g. tetrahedra to triangles)
     Data< bool > d_onlyAttachedPoints; ///< Only keep points attached to elements of the mesh
 
-    Data< Vector3 > d_translation; ///< Translation of the DOFs
-    Data< Vector3 > d_rotation; ///< Rotation of the DOFs
-    Data< Vector3 > d_scale; ///< Scale of the DOFs in 3 dimensions
+    Data< Vec3 > d_translation; ///< Translation of the DOFs
+    Data< Vec3 > d_rotation; ///< Rotation of the DOFs
+    Data< Vec3 > d_scale; ///< Scale of the DOFs in 3 dimensions
     Data< defaulttype::Matrix4 > d_transformation; ///< 4x4 Homogeneous matrix to transform the DOFs (when present replace any)
 
 

--- a/SofaKernel/framework/sofa/helper/types/RGBAColor.h
+++ b/SofaKernel/framework/sofa/helper/types/RGBAColor.h
@@ -65,6 +65,8 @@ public:
     static RGBAColor magenta() { return RGBAColor(1.0,0.0,1.0,1.0); }
     static RGBAColor yellow()  { return RGBAColor(1.0,1.0,0.0,1.0); }
     static RGBAColor gray()    { return RGBAColor(0.5,0.5,0.5,1.0); }
+    static RGBAColor lightgray() { return RGBAColor(0.25,0.25,0.25,1.0); }
+    static RGBAColor darkgray()  { return RGBAColor(0.75,0.75,0.75,1.0); }
 
     inline float& r(){ return this->elems[0] ; }
     inline float& g(){ return this->elems[1] ; }

--- a/SofaKernel/modules/SofaLoader/MeshObjLoader.cpp
+++ b/SofaKernel/modules/SofaLoader/MeshObjLoader.cpp
@@ -47,35 +47,45 @@ int MeshObjLoaderClass = core::RegisterObject("Specific mesh loader for Obj file
 MeshObjLoader::MeshObjLoader()
     : MeshLoader()
     , d_handleSeams(initData(&d_handleSeams, (bool)false, "handleSeams", "Preserve UV and normal seams information (vertices with multiple UV and/or normals)"))
-    , loadMaterial(initData(&loadMaterial, (bool) true, "loadMaterial", "Load the related MTL file or use a default one?"))    
+    , d_loadMaterial(initData(&d_loadMaterial, (bool) true, "loadMaterial", "Load the related MTL file or use a default one?"))
     , faceType(MeshObjLoader::TRIANGLE)
-    , d_material(initData(&d_material,"material","Default material") )
-    , materials(initData(&materials,"materials","List of materials") )
-    , faceList(initData(&faceList,"faceList","List of face definitions.") )
-    , texIndexList(initData(&texIndexList,"texcoordsIndex","Indices of textures coordinates used in faces definition."))
-    , positionsList(initData(&positionsList,"positionsDefinition", "Vertex positions definition"))
-    , texCoordsList(initData(&texCoordsList,"texcoordsDefinition", "Texture coordinates definition"))
-    , normalsIndexList(initData(&normalsIndexList,"normalsIndex","List of normals of elements of the mesh loaded."))
-    , normalsList(initData(&normalsList,"normalsDefinition","Normals definition"))
-    , texCoords(initData(&texCoords,"texcoords","Texture coordinates of all faces, to be used as the parent data of a VisualModel texcoords data"))
-    , computeMaterialFaces(initData(&computeMaterialFaces, false, "computeMaterialFaces", "True to activate export of Data instances containing list of face indices for each material"))
+    , d_material(initData(&d_material,"defaultMaterial","Default material") )
+    , d_materials(initData(&d_materials,"materials","List of materials") )
+    , d_faceList(initData(&d_faceList,"faceList","List of face definitions.") )
+    , d_texIndexList(initData(&d_texIndexList,"texcoordsIndex","Indices of textures coordinates used in faces definition."))
+    , d_positionsList(initData(&d_positionsList,"positionsDefinition", "Vertex positions definition"))
+    , d_texCoordsList(initData(&d_texCoordsList,"texcoordsDefinition", "Texture coordinates definition"))
+    , d_normalsIndexList(initData(&d_normalsIndexList,"normalsIndex","List of normals of elements of the mesh loaded."))
+    , d_normalsList(initData(&d_normalsList,"normalsDefinition","Normals definition"))
+    , d_texCoords(initData(&d_texCoords,"texcoords","Texture coordinates of all faces, to be used as the parent data of a VisualModel texcoords data"))
+    , d_computeMaterialFaces(initData(&d_computeMaterialFaces, false, "computeMaterialFaces", "True to activate export of Data instances containing list of face indices for each material"))
     , d_vertPosIdx      (initData   (&d_vertPosIdx, "vertPosIdx", "If vertices have multiple normals/texcoords stores vertices position indices"))
     , d_vertNormIdx     (initData   (&d_vertNormIdx, "vertNormIdx", "If vertices have multiple normals/texcoords stores vertices normal indices"))
 {
-    faceList.setGroup("OBJ");
-    texIndexList.setGroup("OBJ");
-    texCoordsList.setGroup("OBJ");
-    normalsIndexList.setGroup("OBJ");
-    normalsList.setGroup("OBJ");
-    positionsList.setGroup("OBJ");
+    addAlias(&d_material, "material");
+
+    d_material.setGroup("Shading");
+    d_materials.setGroup("Shading");
+
+    d_texIndexList.setGroup("Texturing");
+    d_texCoordsList.setGroup("Texturing");
+    d_texCoords.setGroup("Texturing");
+
+    d_faceList.setGroup("Geometry");
+    d_normalsIndexList.setGroup("Geometry");
+    d_normalsList.setGroup("Geometry");
+    d_positionsList.setGroup("Geometry");
+    d_vertPosIdx.setGroup("Geometry");
+    d_vertNormIdx.setGroup("Geometry");
+
     //BUGFIX: data loaded from OBJ file should not be saved to XML
-    faceList.setPersistent(false);
-    texIndexList.setPersistent(false);
-    texCoordsList.setPersistent(false);
-    normalsIndexList.setPersistent(false);
-    normalsList.setPersistent(false);
-    positionsList.setPersistent(false);
-    texCoords.setPersistent(false);
+    d_faceList.setPersistent(false);
+    d_texIndexList.setPersistent(false);
+    d_texCoordsList.setPersistent(false);
+    d_normalsIndexList.setPersistent(false);
+    d_normalsList.setPersistent(false);
+    d_positionsList.setPersistent(false);
+    d_texCoords.setPersistent(false);
     d_positions.setPersistent(false);
     d_normals.setPersistent(false);
     d_edges.setPersistent(false);
@@ -84,7 +94,7 @@ MeshObjLoader::MeshObjLoader()
     d_edgesGroups.setPersistent(false);
     d_trianglesGroups.setPersistent(false);
     d_quadsGroups.setPersistent(false);
-    texCoords.setPersistent(false);
+    d_texCoords.setPersistent(false);
     d_vertPosIdx.setPersistent(false);
     d_vertNormIdx.setPersistent(false);
 }
@@ -150,14 +160,14 @@ bool MeshObjLoader::readOBJ (std::ifstream &file, const char* filename)
  
     const bool handleSeams = d_handleSeams.getValue();
     helper::vector<sofa::defaulttype::Vector3>& my_positions = *(d_positions.beginEdit());
-    helper::vector<sofa::defaulttype::Vector2>& my_texCoords = *(texCoordsList.beginEdit());
-    helper::vector<sofa::defaulttype::Vector3>& my_normals   = *(normalsList.beginEdit());
+    helper::vector<sofa::defaulttype::Vector2>& my_texCoords = *(d_texCoordsList.beginEdit());
+    helper::vector<sofa::defaulttype::Vector3>& my_normals   = *(d_normalsList.beginEdit());
 
     Material& material = *(d_material.beginEdit());
-    helper::vector<Material>& my_materials = *(materials.beginEdit());
-    helper::SVector< helper::SVector <int> >& my_faceList = *(faceList.beginEdit() );
-    helper::SVector< helper::SVector <int> >& my_normalsList = *(normalsIndexList.beginEdit());
-    helper::SVector< helper::SVector <int> >& my_texturesList   = *(texIndexList.beginEdit());
+    helper::vector<Material>& my_materials = *(d_materials.beginEdit());
+    helper::SVector< helper::SVector <int> >& my_faceList = *(d_faceList.beginEdit() );
+    helper::SVector< helper::SVector <int> >& my_normalsList = *(d_normalsIndexList.beginEdit());
+    helper::SVector< helper::SVector <int> >& my_texturesList   = *(d_texIndexList.beginEdit());
     helper::vector<int> nodes, nIndices, tIndices;
 
     helper::vector<Edge >& my_edges = *(d_edges.beginEdit());
@@ -223,7 +233,7 @@ bool MeshObjLoader::readOBJ (std::ifstream &file, const char* filename)
             values >> result[0] >> result[1];
             my_texCoords.push_back(Vector2(result[0],result[1]));
         }
-        else if ((token == "mtllib") && loadMaterial.getValue())
+        else if ((token == "mtllib") && d_loadMaterial.getValue())
         {
             while (!values.eof())
             {
@@ -371,7 +381,7 @@ bool MeshObjLoader::readOBJ (std::ifstream &file, const char* filename)
 
     if (!d_handleSeams.getValue())
     { // default mode, vertices are never duplicated, only one texcoord and normal is used per vertex
-        helper::vector<sofa::defaulttype::Vector2>& vTexCoords = *texCoords.beginEdit();
+        helper::vector<sofa::defaulttype::Vector2>& vTexCoords = *d_texCoords.beginEdit();
         helper::vector<sofa::defaulttype::Vector3>& vNormals   = *d_normals.beginEdit();
         helper::vector<sofa::defaulttype::Vector3>& vVertices  = *d_positions.beginEdit();
         vVertices = my_positions;
@@ -455,7 +465,7 @@ bool MeshObjLoader::readOBJ (std::ifstream &file, const char* filename)
         // Then we can create the final arrays
         helper::vector<sofa::defaulttype::Vector3> vertices2;
         helper::WriteAccessor<Data<helper::vector<sofa::defaulttype::Vector3> > > vnormals = d_normals;
-        helper::WriteAccessor<Data<helper::vector<sofa::defaulttype::Vector2> > > vtexcoords = texCoords;
+        helper::WriteAccessor<Data<helper::vector<sofa::defaulttype::Vector2> > > vtexcoords = d_texCoords;
         helper::WriteAccessor<Data<helper::vector<int> > > vertPosIdx = d_vertPosIdx;
         helper::WriteAccessor<Data<helper::vector<int> > > vertNormIdx = d_vertNormIdx;
 
@@ -552,7 +562,7 @@ bool MeshObjLoader::readOBJ (std::ifstream &file, const char* filename)
     }
 
 
-    if (computeMaterialFaces.getValue())
+    if (d_computeMaterialFaces.getValue())
     {
         // create subset lists
         std::map< std::string, helper::vector<unsigned int> > materialFaces[NBFACETYPE];
@@ -589,7 +599,7 @@ bool MeshObjLoader::readOBJ (std::ifstream &file, const char* filename)
                 this->addData(dOut);
                 dOut->setGroup("Materials");
                 dOut->setValue(faces);
-                subsets_indices.push_back(dOut);
+                d_subsets_indices.push_back(dOut);
             }
         }
     }
@@ -601,14 +611,14 @@ bool MeshObjLoader::readOBJ (std::ifstream &file, const char* filename)
     d_edges.endEdit();
     d_triangles.endEdit();
     d_quads.endEdit();
-    normalsList.endEdit();
-    normalsIndexList.endEdit();
+    d_normalsList.endEdit();
+    d_normalsIndexList.endEdit();
     d_material.endEdit();
-    materials.endEdit();
-    texIndexList.endEdit();
-    texCoordsList.endEdit();
-    texCoords.endEdit();
-    faceList.endEdit();
+    d_materials.endEdit();
+    d_texIndexList.endEdit();
+    d_texCoordsList.endEdit();
+    d_texCoords.endEdit();
+    d_faceList.endEdit();
     //vertices.endEdit();
     d_normals.endEdit();
     return true;

--- a/SofaKernel/modules/SofaLoader/MeshObjLoader.h
+++ b/SofaKernel/modules/SofaLoader/MeshObjLoader.h
@@ -57,26 +57,26 @@ public:
 
 protected:
     bool readOBJ (std::ifstream &file, const char* filename);
-    bool readMTL (const char* filename, helper::vector <sofa::helper::types::Material>& materials);
+    bool readMTL (const char* filename, helper::vector <sofa::helper::types::Material>& d_materials);
     void addGroup (const sofa::core::loader::PrimitiveGroup& g);
 
-    Data<bool> d_handleSeams;
-    Data<bool> loadMaterial;
     std::string textureName;
     FaceType faceType;
 
 public:
+    Data<bool> d_handleSeams;
+    Data<bool> d_loadMaterial;
     Data<sofa::helper::types::Material> d_material;
-    Data <helper::vector <sofa::helper::types::Material> > materials;
-    Data <helper::SVector <helper::SVector <int> > > faceList;
-    Data <helper::SVector <helper::SVector <int> > > texIndexList;
-    Data <helper::vector<sofa::defaulttype::Vector3> > positionsList;
-    Data< helper::vector<sofa::defaulttype::Vector2> > texCoordsList;
-    Data <helper::SVector<helper::SVector<int> > > normalsIndexList;
-    Data <helper::vector<sofa::defaulttype::Vector3> > normalsList;
-    Data< helper::vector<sofa::defaulttype::Vector2> > texCoords;
-    Data< bool > computeMaterialFaces;
-    helper::vector< Data <helper::vector <unsigned int> >* > subsets_indices;
+    Data <helper::vector <sofa::helper::types::Material> > d_materials;
+    Data <helper::SVector <helper::SVector <int> > > d_faceList;
+    Data <helper::SVector <helper::SVector <int> > > d_texIndexList;
+    Data <helper::vector<sofa::defaulttype::Vector3> > d_positionsList;
+    Data< helper::vector<sofa::defaulttype::Vector2> > d_texCoordsList;
+    Data <helper::SVector<helper::SVector<int> > > d_normalsIndexList;
+    Data <helper::vector<sofa::defaulttype::Vector3> > d_normalsList;
+    Data< helper::vector<sofa::defaulttype::Vector2> > d_texCoords;
+    Data< bool > d_computeMaterialFaces;
+    helper::vector< Data <helper::vector <unsigned int> >* > d_subsets_indices;
 
     /// If vertices have multiple normals/texcoords, then we need to separate them
     /// This vector store which input position is used for each vertex


### PR DESCRIPTION

CHANGELOG:
- Replace Vector3 alias by Vec3
- Set groups in MeshLoader. 
- The data field's name are now conformant with Sofa coding style in MeshObjLoader
- Add a light/dark gray in RGBAColor. 


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
