### PR TITLE
[SofaKernel] Fix: remove unwanted AdvanceTimer::begin command

### DIFF
--- a/SofaKernel/framework/sofa/simulation/Simulation.cpp
+++ b/SofaKernel/framework/sofa/simulation/Simulation.cpp
@@ -366,7 +366,6 @@ void Simulation::updateVisualContext (Node* root)
 /// Render the scene
 void Simulation::draw ( sofa::core::visual::VisualParams* vparams, Node* root )
 {
-    sofa::helper::AdvancedTimer::begin("Animate");
     sofa::helper::AdvancedTimer::stepBegin("Simulation::draw");
 
     sofa::core::visual::VisualLoop* vloop = root->getVisualLoop();
@@ -384,7 +383,6 @@ void Simulation::draw ( sofa::core::visual::VisualParams* vparams, Node* root )
     }
 
     sofa::helper::AdvancedTimer::stepEnd("Simulation::draw");
-    sofa::helper::AdvancedTimer::end("Animate");
 }
 
 /// Export a scene to an OBJ 3D Scene


### PR DESCRIPTION
If I understand well how AdvanceTimer is working (which I'm still not sure), this Begin("animate") command should not be there.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
