### PR TITLE
[SofaEngine] Avoid Crash in BoxROI when rest_position is not yet defined

### DIFF
--- a/SofaKernel/modules/SofaEngine/BoxROI.inl
+++ b/SofaKernel/modules/SofaEngine/BoxROI.inl
@@ -517,6 +517,14 @@ void BoxROI<DataTypes>::doUpdate()
     if(!d_doUpdate.getValue()){
         return ;
     }
+    if (d_X0.getValue().size() == 0)
+    {
+        msg_warning() << "No rest position yet defined. Box might not work properly. \n"
+                         "This may be caused by an early call of init() on the box before  \n"
+                         "the mesh or the MechanicalObject of the node was initialized too";
+        return;
+    }
+
 
     const vector<Vec6>&  alignedBoxes  = d_alignedBoxes.getValue();
     const vector<Vec10>& orientedBoxes = d_orientedBoxes.getValue();


### PR DESCRIPTION
Hello,
A very small PR to perform a check at the start of the doUpdate function to make sure the rest-position is defined and avoid a crash when it is not the case. This typically happens when calling init() on a boxROI in the SOFA scene without calling init() on the associated mesh loader for example.





______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
