### PR TITLE
[SofaKernel] Remove usage of helper::system::atomic<int> (replaced by STL's)

### DIFF
--- a/SofaKernel/framework/sofa/core/ExecParams.cpp
+++ b/SofaKernel/framework/sofa/core/ExecParams.cpp
@@ -29,7 +29,7 @@ namespace sofa
 namespace core
 {
 
-sofa::helper::system::atomic<int> ExecParams::g_nbThreads = 0;
+std::atomic<int> ExecParams::g_nbThreads(0);
 
 ExecParams::ExecParamsThreadStorage::ExecParamsThreadStorage(int tid)
     : execMode(EXEC_DEFAULT)
@@ -45,7 +45,7 @@ ExecParams* ExecParams::defaultInstance()
     ExecParams* ptr = threadParams;
     if (!ptr)
     {
-        ptr = new ExecParams(new ExecParamsThreadStorage(g_nbThreads.exchange_and_add(1)));
+        ptr = new ExecParams(new ExecParamsThreadStorage(g_nbThreads.fetch_add(1)));
         threadParams = ptr;
         if (ptr->threadID())
             msg_info("ExecParams") << "[THREAD " << ptr->threadID() << "]: local ExecParams storage created.";

--- a/SofaKernel/framework/sofa/core/ExecParams.h
+++ b/SofaKernel/framework/sofa/core/ExecParams.h
@@ -22,8 +22,8 @@
 #ifndef SOFA_CORE_EXEC_PARAMS_H
 #define SOFA_CORE_EXEC_PARAMS_H
 
-#include <sofa/helper/system/atomic.h>
 #include <sofa/core/core.h>
+#include <atomic>
 
 namespace sofa
 {
@@ -58,7 +58,7 @@ public:
 
 private:
 
-    static sofa::helper::system::atomic<int> g_nbThreads;
+    static std::atomic<int> g_nbThreads;
 
     class SOFA_CORE_API ExecParamsThreadStorage
     {

--- a/SofaKernel/framework/sofa/core/objectmodel/AspectPool.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/AspectPool.cpp
@@ -52,12 +52,12 @@ Aspect::~Aspect()
 
 void Aspect::add_ref()
 {
-    counter.inc();
+    counter++;
 }
 
 void Aspect::release()
 {
-    if(counter.dec_and_test_null())
+    if(counter.fetch_sub(1) == 1)
     {
         // release the aspect from the pool.
         pool.release(id);

--- a/SofaKernel/framework/sofa/core/objectmodel/AspectPool.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/AspectPool.h
@@ -76,7 +76,7 @@ private:
 
     AspectPool& pool;
     const int id;
-    helper::system::atomic<int> counter;
+    std::atomic<int> counter;
 };
 
 
@@ -121,7 +121,7 @@ private:
     AspectPool(const AspectPool& r);
     AspectPool& operator=(const AspectPool& r);
 
-    typedef helper::system::atomic<int> AtomicInt;
+    typedef std::atomic<int> AtomicInt;
     typedef helper::system::thread::CircularQueue<
     AtomicInt,
     helper::system::thread::FixedPower2Size<SOFA_DATA_MAX_ASPECTS>::type,
@@ -156,7 +156,7 @@ public:
     void clear();
 
 protected:
-    typedef helper::system::atomic<int> AtomicInt;
+    typedef std::atomic<int> AtomicInt;
 
     AspectPool& pool;
     AtomicInt latestID; ///< -1 or aspect ID of the last version sent

--- a/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
@@ -83,7 +83,7 @@ void Base::addRef()
 
 void Base::release()
 {
-    if (ref_counter.dec_and_test_null())
+    if (ref_counter.fetch_sub(1) == 1)
     {
         delete this;
     }

--- a/SofaKernel/framework/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/Base.h
@@ -153,7 +153,7 @@ private:
     Base(const Base& b);
     Base& operator=(const Base& b);
 
-    sofa::helper::system::atomic<int> ref_counter;
+    std::atomic<int> ref_counter;
     void addRef();
     void release();
 

--- a/SofaKernel/framework/sofa/helper/AdvancedTimer.cpp
+++ b/SofaKernel/framework/sofa/helper/AdvancedTimer.cpp
@@ -23,7 +23,6 @@
 #include <sofa/helper/AdvancedTimer.h>
 
 #include <sofa/helper/system/thread/CTime.h>
-#include <sofa/helper/system/atomic.h>
 #include <sofa/helper/vector.h>
 #include <sofa/helper/map.h>
 #include <../extlibs/json/json.h>
@@ -139,7 +138,7 @@ public:
 
 std::map< AdvancedTimer::IdTimer, TimerData > timers;
 
-helper::system::atomic<int> activeTimers;
+std::atomic<int> activeTimers;
 SOFA_THREAD_SPECIFIC_PTR(std::stack<AdvancedTimer::IdTimer>, curTimerThread);
 SOFA_THREAD_SPECIFIC_PTR(helper::vector<Record>, curRecordsThread);
 

--- a/SofaKernel/framework/sofa/helper/system/thread/CircularQueue.h
+++ b/SofaKernel/framework/sofa/helper/system/thread/CircularQueue.h
@@ -171,7 +171,7 @@ class SOFA_HELPER_API ManyThreadsPerEnd
 public:
 
 protected:
-    typedef helper::system::atomic<int> AtomicInt;
+    typedef std::atomic<int> AtomicInt;
 
     ManyThreadsPerEnd();
     

--- a/SofaKernel/framework/sofa/helper/system/thread/CircularQueue.h
+++ b/SofaKernel/framework/sofa/helper/system/thread/CircularQueue.h
@@ -23,7 +23,7 @@
 #ifndef SOFA_HELPER_SYSTEM_THREAD_CIRCULARQUEUE_H
 #define SOFA_HELPER_SYSTEM_THREAD_CIRCULARQUEUE_H
 
-#include "../atomic.h"
+#include <atomic>
 #include <sofa/helper/fixed_array.h>
 
 namespace sofa

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -69,7 +69,6 @@ using sofa::gui::GUIManager;
 #include <sofa/gui/Main.h>
 #include <sofa/gui/BatchGUI.h>  // For the default number of iterations
 #include <sofa/helper/system/gl.h>
-#include <sofa/helper/system/atomic.h>
 
 using sofa::core::ExecParams ;
 


### PR DESCRIPTION
helper::system::atomic<int> was introduced long time ago (before std::atomic I guess).
This code is compiling only for i386 and x86_64 code with gcc/clang (and msvc)
Now that std::atomic is here (and we are using c+>11), I guess it is time to use std::atomic where we can.

Those modifications mostly appeared in multithreading-related code, so it would be good that @fspadoni could take a look :octocat: 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**