### PR TITLE
[SofaPython] Fix duplicate symbol

### DIFF
--- a/applications/plugins/SofaPython/PythonScriptControllerHelper.cpp
+++ b/applications/plugins/SofaPython/PythonScriptControllerHelper.cpp
@@ -27,6 +27,9 @@ namespace helper {
 
 namespace internal {
 
+
+void PythonScriptController_parametersToVector(std::vector<PyObject*> & /*vecParam*/) {return;}
+
 PyObject* PythonScriptController_valueToPyObject(bool param)
 {
     PyObject* value = nullptr;

--- a/applications/plugins/SofaPython/PythonScriptControllerHelper.h
+++ b/applications/plugins/SofaPython/PythonScriptControllerHelper.h
@@ -54,7 +54,7 @@ SOFA_SOFAPYTHON_API void PythonScriptController_pyObjectToValue(PyObject* pyObje
 SOFA_SOFAPYTHON_API void PythonScriptController_pyObjectToValue(PyObject* pyObject, std::string & val);
 
 
-void PythonScriptController_parametersToVector(std::vector<PyObject*> & /*vecParam*/);
+SOFA_SOFAPYTHON_API void PythonScriptController_parametersToVector(std::vector<PyObject*> & /*vecParam*/);
 
 template<typename T, typename... ParametersType>
 void PythonScriptController_parametersToVector(std::vector<PyObject*> & vecParam, T param, ParametersType... otherParameters)

--- a/applications/plugins/SofaPython/PythonScriptControllerHelper.h
+++ b/applications/plugins/SofaPython/PythonScriptControllerHelper.h
@@ -54,7 +54,7 @@ SOFA_SOFAPYTHON_API void PythonScriptController_pyObjectToValue(PyObject* pyObje
 SOFA_SOFAPYTHON_API void PythonScriptController_pyObjectToValue(PyObject* pyObject, std::string & val);
 
 
-void PythonScriptController_parametersToVector(std::vector<PyObject*> & /*vecParam*/) {return;}
+void PythonScriptController_parametersToVector(std::vector<PyObject*> & /*vecParam*/);
 
 template<typename T, typename... ParametersType>
 void PythonScriptController_parametersToVector(std::vector<PyObject*> & vecParam, T param, ParametersType... otherParameters)


### PR DESCRIPTION
In some (very) rare cases, if the user links two libs (in which was included the header PythonScriptControllerHelper.h), compilation should throw an error of duplicate symbol for PythonScriptController_parametersToVector().
I got the problem while making static libraries.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**