### PR TITLE
[SofaKernel] Clean output data when doUpdate in BoxROI

### DIFF
--- a/SofaKernel/modules/SofaEngine/BoxROI.inl
+++ b/SofaKernel/modules/SofaEngine/BoxROI.inl
@@ -510,37 +510,6 @@ bool BoxROI<DataTypes>::isQuadInBoxes(const Quad& q)
 template <class DataTypes>
 void BoxROI<DataTypes>::doUpdate()
 {
-    if(m_componentstate==ComponentState::Invalid){
-        return ;
-    }
-
-    if(!d_doUpdate.getValue()){
-        return ;
-    }
-    if (d_X0.getValue().size() == 0)
-    {
-        msg_warning() << "No rest position yet defined. Box might not work properly. \n"
-                         "This may be caused by an early call of init() on the box before  \n"
-                         "the mesh or the MechanicalObject of the node was initialized too";
-        return;
-    }
-
-
-    const vector<Vec6>&  alignedBoxes  = d_alignedBoxes.getValue();
-    const vector<Vec10>& orientedBoxes = d_orientedBoxes.getValue();
-
-    if (alignedBoxes.empty() && orientedBoxes.empty()) { return; }
-
-
-    // Read accessor for input topology
-    ReadAccessor< Data<vector<Edge> > > edges = d_edges;
-    ReadAccessor< Data<vector<Triangle> > > triangles = d_triangles;
-    ReadAccessor< Data<vector<Tetra> > > tetrahedra = d_tetrahedra;
-    ReadAccessor< Data<vector<Hexa> > > hexahedra = d_hexahedra;
-    ReadAccessor< Data<vector<Quad> > > quad = d_quad;
-
-    const VecCoord& x0 = d_X0.getValue();
-
     // Write accessor for topological element indices in BOX
     SetIndex& indices = *d_indices.beginWriteOnly();
     SetIndex& edgeIndices = *d_edgeIndices.beginWriteOnly();
@@ -573,6 +542,37 @@ void BoxROI<DataTypes>::doUpdate()
     tetrahedraInROI.clear();
     hexahedraInROI.clear();
     quadInROI.clear();
+
+
+    if(m_componentstate==ComponentState::Invalid){
+        return ;
+    }
+
+    if(!d_doUpdate.getValue()){
+        return ;
+    }
+    if (d_X0.getValue().size() == 0)
+    {
+        msg_warning() << "No rest position yet defined. Box might not work properly. \n"
+                         "This may be caused by an early call of init() on the box before  \n"
+                         "the mesh or the MechanicalObject of the node was initialized too";
+        return;
+    }
+
+    const vector<Vec6>&  alignedBoxes  = d_alignedBoxes.getValue();
+    const vector<Vec10>& orientedBoxes = d_orientedBoxes.getValue();
+
+    if (alignedBoxes.empty() && orientedBoxes.empty()) { return; }
+
+
+    // Read accessor for input topology
+    ReadAccessor< Data<vector<Edge> > > edges = d_edges;
+    ReadAccessor< Data<vector<Triangle> > > triangles = d_triangles;
+    ReadAccessor< Data<vector<Tetra> > > tetrahedra = d_tetrahedra;
+    ReadAccessor< Data<vector<Hexa> > > hexahedra = d_hexahedra;
+    ReadAccessor< Data<vector<Quad> > > quad = d_quad;
+
+    const VecCoord& x0 = d_X0.getValue();
 
 
     //Points


### PR DESCRIPTION
Fix crash on CI with scene _HexahedronForceFieldTopologyChangeHandling.scn_
Further to PR #1031 , the case where topo changes occur and X0 (points) size becomes zero (all points removed) the doUpdte() directly led to `return` without actually updating the output data field as being empty !
Now, all data are by default cleaned at the begin of the doUpdate() and filled only if X0.size is not zero and topology is not empty neither


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
