### PR TITLE
[SofaKernel] Fix error in MapperHexahedron and MapperQuad barycentric coef computation

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.inl
@@ -117,12 +117,13 @@ helper::vector<SReal> BarycentricMapperHexahedronSetTopology<In,Out>::getBaryCoe
 {
     helper::vector<SReal> hexahedronCoef{(1-fx)*(1-fy)*(1-fz),
                 (fx)*(1-fy)*(1-fz),
-                (1-fx)*(fy)*(1-fz),
-                (fx)*(fy)*(1-fz),
+                (fx)*(fy)*(1 - fz),
+                (1 - fx)*(fy)*(1 - fz),
                 (1-fx)*(1-fy)*(fz),
                 (fx)*(1-fy)*(fz),
-                (1-fx)*(fy)*(fz),
-                (fx)*(fy)*(fz)};
+                (fx)*(fy)*(fz),
+                (1 - fx)*(fy)*(fz)
+    };
     return hexahedronCoef;
 }
 

--- a/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperQuadSetTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperQuadSetTopology.inl
@@ -99,8 +99,8 @@ helper::vector<SReal> BarycentricMapperQuadSetTopology<In,Out>::getBaryCoef(cons
 {
     helper::vector<SReal> quadCoef{(1-fx)*(1-fy),
                 (fx)*(1-fy),
-                (1-fx)*(fy),
-                (fx)*(fy)};
+                (fx)*(fy),
+                (1 - fx)*(fy)};
     return quadCoef;
 }
 


### PR DESCRIPTION
fix #988 

tada!
![barycentric_00000001](https://user-images.githubusercontent.com/21199245/58172989-64d50280-7c9a-11e9-87e6-472d08feb97e.png)




______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
