### PR TITLE
[SofaSimulationGraph] Fix CollisionGroupManager wrong search of deformable object node

### DIFF
--- a/SofaKernel/modules/SofaSimulationGraph/DAGNode.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/DAGNode.cpp
@@ -822,33 +822,27 @@ void DAGNode::updateSimulationContext()
 
 Node* DAGNode::findCommonParent( simulation::Node* node2 )
 {
-    DAGNode* root = static_cast<DAGNode*>(getRoot());
-    DAGNode* commonParent = root->findCommonParent(this, static_cast<DAGNode*>(node2));
-    return commonParent != nullptr ? commonParent : root;
+    return static_cast<DAGNode*>(getRoot())->findCommonParent(this, static_cast<DAGNode*>(node2));
 }
 
 DAGNode* DAGNode::findCommonParent(DAGNode* node1, DAGNode* node2)
 {
     updateDescendancy();
 
-    if ( _descendancy.find(node1) != _descendancy.end() && _descendancy.find(node2) != _descendancy.end() )
-    {
-        // this node is a parent of both node1 and node2
-        for (unsigned int i = 0; i<child.size(); ++i)
-        {
-            DAGNode* childcommon = static_cast<DAGNode*>(child[i].get())->findCommonParent(node1, node2);
+    if (_descendancy.find(node1) == _descendancy.end() || _descendancy.find(node2) == _descendancy.end())
+        return nullptr; // this is NOT a parent
 
-            if (childcommon != nullptr) 
-                return childcommon;
-        }   
-        
-        return this;
-    }
-    else
+    // this is a parent
+    for (unsigned int i = 0; i<child.size(); ++i)
     {
-        // this node is NOT a parent of both node1 and node2
-        return nullptr;
-    } 
+        // look for closer parents
+        DAGNode* childcommon = static_cast<DAGNode*>(child[i].get())->findCommonParent(node1, node2);
+
+        if (childcommon != nullptr)
+            return childcommon;
+    }
+    // NO closer parents found
+    return this;
 }
 
 void DAGNode::getLocalObjects( const sofa::core::objectmodel::ClassInfo& class_info, DAGNode::GetObjectsCallBack& container, const sofa::core::objectmodel::TagSet& tags ) const

--- a/SofaKernel/modules/SofaSimulationGraph/DAGNode.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/DAGNode.cpp
@@ -822,23 +822,33 @@ void DAGNode::updateSimulationContext()
 
 Node* DAGNode::findCommonParent( simulation::Node* node2 )
 {
-    return static_cast<DAGNode*>(getRoot())->findCommonParent( this, static_cast<DAGNode*>(node2) );
+    DAGNode* root = static_cast<DAGNode*>(getRoot());
+    DAGNode* commonParent = root->findCommonParent(this, static_cast<DAGNode*>(node2));
+    return commonParent != nullptr ? commonParent : root;//  static_cast<DAGNode*>(getRoot())->findCommonParent(this, static_cast<DAGNode*>(node2));
 }
 
-
-DAGNode* DAGNode::findCommonParent( DAGNode* node1, DAGNode* node2 )
+DAGNode* DAGNode::findCommonParent(DAGNode* node1, DAGNode* node2)
 {
     updateDescendancy();
 
-    for(unsigned int i = 0; i<child.size(); ++i)
+    if ( _descendancy.find(node1) != _descendancy.end() || _descendancy.find(node2) != _descendancy.end() )
     {
-        DAGNode* childcommon = static_cast<DAGNode*>(child[i].get())->findCommonParent( node1, node2 );
+        // this is a parent
+        for (unsigned int i = 0; i<child.size(); ++i)
+        {
+            DAGNode* childcommon = static_cast<DAGNode*>(child[i].get())->findCommonParent(node1, node2);
 
-        if( childcommon ) return childcommon;
-        else if( _descendancy.find(node1)!=_descendancy.end() && _descendancy.find(node2)!=_descendancy.end() ) return this;
+            if (childcommon != nullptr) 
+                return childcommon;
+        }   
+        
+        return this;
     }
-
-    return nullptr;
+    else
+    {
+        // this is not a paarent of both node1 and node2
+        return nullptr;
+    } 
 }
 
 void DAGNode::getLocalObjects( const sofa::core::objectmodel::ClassInfo& class_info, DAGNode::GetObjectsCallBack& container, const sofa::core::objectmodel::TagSet& tags ) const

--- a/SofaKernel/modules/SofaSimulationGraph/DAGNode.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/DAGNode.cpp
@@ -831,9 +831,9 @@ DAGNode* DAGNode::findCommonParent(DAGNode* node1, DAGNode* node2)
 {
     updateDescendancy();
 
-    if ( _descendancy.find(node1) != _descendancy.end() || _descendancy.find(node2) != _descendancy.end() )
+    if ( _descendancy.find(node1) != _descendancy.end() && _descendancy.find(node2) != _descendancy.end() )
     {
-        // this is a parent
+        // this node is a parent of both node1 and node2
         for (unsigned int i = 0; i<child.size(); ++i)
         {
             DAGNode* childcommon = static_cast<DAGNode*>(child[i].get())->findCommonParent(node1, node2);
@@ -846,7 +846,7 @@ DAGNode* DAGNode::findCommonParent(DAGNode* node1, DAGNode* node2)
     }
     else
     {
-        // this is not a parent of both node1 and node2
+        // this node is NOT a parent of both node1 and node2
         return nullptr;
     } 
 }

--- a/SofaKernel/modules/SofaSimulationGraph/DAGNode.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/DAGNode.cpp
@@ -824,7 +824,7 @@ Node* DAGNode::findCommonParent( simulation::Node* node2 )
 {
     DAGNode* root = static_cast<DAGNode*>(getRoot());
     DAGNode* commonParent = root->findCommonParent(this, static_cast<DAGNode*>(node2));
-    return commonParent != nullptr ? commonParent : root;//  static_cast<DAGNode*>(getRoot())->findCommonParent(this, static_cast<DAGNode*>(node2));
+    return commonParent != nullptr ? commonParent : root;
 }
 
 DAGNode* DAGNode::findCommonParent(DAGNode* node1, DAGNode* node2)
@@ -846,7 +846,7 @@ DAGNode* DAGNode::findCommonParent(DAGNode* node1, DAGNode* node2)
     }
     else
     {
-        // this is not a paarent of both node1 and node2
+        // this is not a parent of both node1 and node2
         return nullptr;
     } 
 }

--- a/SofaKernel/modules/SofaSimulationGraph/DAGNode.h
+++ b/SofaKernel/modules/SofaSimulationGraph/DAGNode.h
@@ -132,6 +132,8 @@ public:
 
 
     /// return the smallest common parent between this and node2 (returns NULL if separated sub-graphes)
+    /// it assumes that the DAG node is a tree node. In case of multiple parents it returns any of the parents.
+    /// it uses the node descendancy informations.
     Node* findCommonParent( Node* node2 ) override;
 
     /// compute the traversal order from this Node

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/CMakeLists.txt
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/CMakeLists.txt
@@ -4,6 +4,7 @@ project (SofaSimulationGraph_test)
 
 set (SOURCE_FILES
   MutationListener_test.cpp
+  DAGNode_test.cpp
   )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DAGNode_test.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DAGNode_test.cpp
@@ -1,24 +1,23 @@
-//#include <SceneCreator/SceneCreator.h>
-
 #include <SofaTest/Sofa_test.h>
 
 #include <SofaSimulationGraph/DAGNode.h>
 
-using sofa::simulation::graph::DAGNode;
+using namespace sofa;
+using namespace simulation::graph;
 
-struct DAGNode_test : public sofa::BaseTest
+struct DAGNode_test : public BaseTest
 {
     DAGNode_test() {}
 
     void test_findCommonParent()
     {
-        DAGNode::SPtr root = sofa::core::objectmodel::New<DAGNode>("root");
-        DAGNode::SPtr node1 = sofa::core::objectmodel::New<DAGNode>("node1");
-        DAGNode::SPtr node2 = sofa::core::objectmodel::New<DAGNode>("node2");
-        DAGNode::SPtr node3 = sofa::core::objectmodel::New<DAGNode>("node3");
-        DAGNode::SPtr node11 = sofa::core::objectmodel::New<DAGNode>("node11");
-        DAGNode::SPtr node12 = sofa::core::objectmodel::New<DAGNode>("node12");
-        DAGNode::SPtr node31 = sofa::core::objectmodel::New<DAGNode>("node31");
+        DAGNode::SPtr root = core::objectmodel::New<DAGNode>("root");
+        DAGNode::SPtr node1 = core::objectmodel::New<DAGNode>("node1");
+        DAGNode::SPtr node2 = core::objectmodel::New<DAGNode>("node2");
+        DAGNode::SPtr node3 = core::objectmodel::New<DAGNode>("node3");
+        DAGNode::SPtr node11 = core::objectmodel::New<DAGNode>("node11");
+        DAGNode::SPtr node12 = core::objectmodel::New<DAGNode>("node12");
+        DAGNode::SPtr node31 = core::objectmodel::New<DAGNode>("node31");
 
         root->addChild(node1);
         root->addChild(node2);
@@ -29,24 +28,24 @@ struct DAGNode_test : public sofa::BaseTest
 
         node3->addChild(node31);
 
-        sofa::simulation::Node* commonParent = node12->findCommonParent(static_cast<sofa::simulation::Node*>(node11.get()) );
+        simulation::Node* commonParent = node12->findCommonParent(static_cast<simulation::Node*>(node11.get()) );
         EXPECT_STREQ(node1->getName().c_str(), commonParent->getName().c_str());
 
-        commonParent = node12->findCommonParent(static_cast<sofa::simulation::Node*>(node31.get()));
+        commonParent = node12->findCommonParent(static_cast<simulation::Node*>(node31.get()));
         EXPECT_STREQ(root->getName().c_str(), commonParent->getName().c_str());
 
-        commonParent = node12->findCommonParent(static_cast<sofa::simulation::Node*>(node1.get()));
+        commonParent = node12->findCommonParent(static_cast<simulation::Node*>(node1.get()));
         EXPECT_STREQ(root->getName().c_str(), commonParent->getName().c_str());
     }
 
     void test_findCommonParent_MultipleParents()
     {
-        DAGNode::SPtr root = sofa::core::objectmodel::New<DAGNode>("root");
-        DAGNode::SPtr node1 = sofa::core::objectmodel::New<DAGNode>("node1");
-        DAGNode::SPtr node2 = sofa::core::objectmodel::New<DAGNode>("node2");
-        DAGNode::SPtr node11 = sofa::core::objectmodel::New<DAGNode>("node11");
-        DAGNode::SPtr node22 = sofa::core::objectmodel::New<DAGNode>("node22");
-        DAGNode::SPtr node23 = sofa::core::objectmodel::New<DAGNode>("node23");
+        DAGNode::SPtr root = core::objectmodel::New<DAGNode>("root");
+        DAGNode::SPtr node1 = core::objectmodel::New<DAGNode>("node1");
+        DAGNode::SPtr node2 = core::objectmodel::New<DAGNode>("node2");
+        DAGNode::SPtr node11 = core::objectmodel::New<DAGNode>("node11");
+        DAGNode::SPtr node22 = core::objectmodel::New<DAGNode>("node22");
+        DAGNode::SPtr node23 = core::objectmodel::New<DAGNode>("node23");
 
         root->addChild(node1);
         root->addChild(node2);
@@ -58,7 +57,7 @@ struct DAGNode_test : public sofa::BaseTest
         node2->addChild(node22);  
         node2->addChild(node23);
 
-        sofa::simulation::Node* commonParent = node11->findCommonParent(static_cast<sofa::simulation::Node*>(node22.get()));
+        simulation::Node* commonParent = node11->findCommonParent(static_cast<simulation::Node*>(node22.get()));
 
         bool result = false;
         if (commonParent->getName().compare(node1->getName()) == 0 || commonParent->getName().compare(node2->getName()) == 0)
@@ -67,7 +66,7 @@ struct DAGNode_test : public sofa::BaseTest
         }
         EXPECT_TRUE(result);
 
-        commonParent = node11->findCommonParent(static_cast<sofa::simulation::Node*>(node23.get()));
+        commonParent = node11->findCommonParent(static_cast<simulation::Node*>(node23.get()));
         EXPECT_STREQ(node2->getName().c_str(), commonParent->getName().c_str());
     }
 };

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DAGNode_test.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DAGNode_test.cpp
@@ -1,0 +1,76 @@
+//#include <SceneCreator/SceneCreator.h>
+
+#include <SofaTest/Sofa_test.h>
+
+#include <SofaSimulationGraph/DAGNode.h>
+
+using sofa::simulation::graph::DAGNode;
+
+struct DAGNode_test : public sofa::BaseTest
+{
+    DAGNode_test() {}
+
+    void test_findCommonParent()
+    {
+        DAGNode::SPtr root = sofa::core::objectmodel::New<DAGNode>("root");
+        DAGNode::SPtr node1 = sofa::core::objectmodel::New<DAGNode>("node1");
+        DAGNode::SPtr node2 = sofa::core::objectmodel::New<DAGNode>("node2");
+        DAGNode::SPtr node3 = sofa::core::objectmodel::New<DAGNode>("node3");
+        DAGNode::SPtr node11 = sofa::core::objectmodel::New<DAGNode>("node11");
+        DAGNode::SPtr node12 = sofa::core::objectmodel::New<DAGNode>("node12");
+        DAGNode::SPtr node31 = sofa::core::objectmodel::New<DAGNode>("node31");
+
+        root->addChild(node1);
+        root->addChild(node2);
+        root->addChild(node3);
+
+        node1->addChild(node11);
+        node1->addChild(node12);
+
+        node3->addChild(node31);
+
+        sofa::simulation::Node* commonParent = node12->findCommonParent(static_cast<sofa::simulation::Node*>(node11.get()) );
+        EXPECT_STREQ(node1->getName().c_str(), commonParent->getName().c_str());
+
+        commonParent = node12->findCommonParent(static_cast<sofa::simulation::Node*>(node31.get()));
+        EXPECT_STREQ(root->getName().c_str(), commonParent->getName().c_str());
+
+        commonParent = node12->findCommonParent(static_cast<sofa::simulation::Node*>(node1.get()));
+        EXPECT_STREQ(root->getName().c_str(), commonParent->getName().c_str());
+    }
+
+    void test_findCommonParent_MultipleParents()
+    {
+        DAGNode::SPtr root = sofa::core::objectmodel::New<DAGNode>("root");
+        DAGNode::SPtr node1 = sofa::core::objectmodel::New<DAGNode>("node1");
+        DAGNode::SPtr node2 = sofa::core::objectmodel::New<DAGNode>("node2");
+        DAGNode::SPtr node11 = sofa::core::objectmodel::New<DAGNode>("node11");
+        DAGNode::SPtr node22 = sofa::core::objectmodel::New<DAGNode>("node22");
+        DAGNode::SPtr node23 = sofa::core::objectmodel::New<DAGNode>("node23");
+
+        root->addChild(node1);
+        root->addChild(node2);
+
+        node1->addChild(node11);
+        node1->addChild(node22);
+
+        node2->addChild(node11);
+        node2->addChild(node22);  
+        node2->addChild(node23);
+
+        sofa::simulation::Node* commonParent = node11->findCommonParent(static_cast<sofa::simulation::Node*>(node22.get()));
+
+        bool result = false;
+        if (commonParent->getName().compare(node1->getName()) == 0 || commonParent->getName().compare(node2->getName()) == 0)
+        {
+            result = true;
+        }
+        EXPECT_TRUE(result);
+
+        commonParent = node11->findCommonParent(static_cast<sofa::simulation::Node*>(node23.get()));
+        EXPECT_STREQ(node2->getName().c_str(), commonParent->getName().c_str());
+    }
+};
+
+TEST_F(DAGNode_test, test_findCommonParent) { test_findCommonParent(); }
+TEST_F(DAGNode_test, test_findCommonParent_MultipleParents) { test_findCommonParent_MultipleParents(); }

--- a/applications/plugins/SofaMiscCollision/DefaultCollisionGroupManager.cpp
+++ b/applications/plugins/SofaMiscCollision/DefaultCollisionGroupManager.cpp
@@ -180,6 +180,7 @@ void DefaultCollisionGroupManager::createGroups(core::objectmodel::BaseContext* 
                     collGroup = group2Iter->second;
                     // group1 is not a collision group while group2 is
                     collGroup->moveChild(BaseNode::SPtr(group1));
+                    groupMap[group1] = collGroup.get();
                 }
                 if (!collGroup->solver.empty())
                 {

--- a/applications/plugins/SofaMiscCollision/DefaultCollisionGroupManager.cpp
+++ b/applications/plugins/SofaMiscCollision/DefaultCollisionGroupManager.cpp
@@ -135,6 +135,14 @@ void DefaultCollisionGroupManager::createGroups(core::objectmodel::BaseContext* 
                     else
                     {
                         simulation::Node::SPtr collGroup2 = group2Iter->second;
+                        if (collGroup == collGroup2)
+                        {
+                            // already in the same collision group
+                            groupMap[group1Iter->first] = group1Iter->second;
+                            groupMap[group2Iter->first] = group2Iter->second;
+                            contactGroup.push_back(collGroup);
+                            continue;
+                        }
                         groupMap[group2] = collGroup.get();
                         // merge groups and remove collGroup2
                         SolverSet solver2;

--- a/applications/plugins/SofaMiscCollision/DefaultCollisionGroupManager.cpp
+++ b/applications/plugins/SofaMiscCollision/DefaultCollisionGroupManager.cpp
@@ -123,6 +123,7 @@ void DefaultCollisionGroupManager::createGroups(core::objectmodel::BaseContext* 
                     collGroup->moveChild(BaseNode::SPtr(group2));
                     groupMap[group1] = collGroup.get();
                     groupMap[group2] = collGroup.get();
+                    groupMap[collGroup.get()] = collGroup.get();
                 }
                 else if (group1IsColl)
                 {

--- a/applications/plugins/SofaMiscCollision/DefaultCollisionGroupManager.h
+++ b/applications/plugins/SofaMiscCollision/DefaultCollisionGroupManager.h
@@ -44,7 +44,8 @@ public:
     SOFA_CLASS(DefaultCollisionGroupManager,sofa::core::collision::CollisionGroupManager);
 
     typedef std::map<simulation::Node*, simulation::Node*> GroupMap; 
-    GroupMap groupSet; // <deformable object node*, collison group node*>
+    // this map stores the deformable object node and its collision group <deformable object node*, collison group node*>
+    GroupMap groupMap; 
 
 public:
     void createGroups(core::objectmodel::BaseContext* scene, const sofa::helper::vector<core::collision::Contact::SPtr>& contacts) override;

--- a/applications/plugins/SofaMiscCollision/DefaultCollisionGroupManager.h
+++ b/applications/plugins/SofaMiscCollision/DefaultCollisionGroupManager.h
@@ -43,8 +43,8 @@ class SOFA_MISC_COLLISION_API DefaultCollisionGroupManager : public core::collis
 public:
     SOFA_CLASS(DefaultCollisionGroupManager,sofa::core::collision::CollisionGroupManager);
 
-    typedef std::set<simulation::Node::SPtr> GroupSet;
-    GroupSet groupSet;
+    typedef std::map<simulation::Node*, simulation::Node*> GroupMap; 
+    GroupMap groupSet; // <deformable object node*, collison group node*>
 
 public:
     void createGroups(core::objectmodel::BaseContext* scene, const sofa::helper::vector<core::collision::Contact::SPtr>& contacts) override;
@@ -59,10 +59,9 @@ protected:
 
     void changeInstance(Instance inst) override;
 
-    template <typename Container>
-    void clearGroup(const Container &inNodes, simulation::Node::SPtr group);
+    void clearCollisionGroup(simulation::Node::SPtr group);
 
-    std::map<Instance,GroupSet> storedGroupSet;
+    std::map<Instance,GroupMap> storedGroupSet;
 
 private:
     DefaultCollisionGroupManager(const DefaultCollisionGroupManager& n) ;

--- a/examples/Demos/chainHybrid.scn
+++ b/examples/Demos/chainHybrid.scn
@@ -4,7 +4,7 @@
     <BruteForceDetection name="N2" />
     <NewProximityIntersection name="Proximity" alarmDistance="0.3" contactDistance="0.2" />
     <DefaultContactManager name="Response" response="default" />
-	<CollisionGroupManager name="Group" />
+    <CollisionGroupManager name="Group" />
     <Node name="Chain">
         <Node name="Fixed">
             <MeshObjLoader name="loaderMeca" filename="mesh/torus_for_collision.obj" />

--- a/examples/Demos/chainHybrid.scn
+++ b/examples/Demos/chainHybrid.scn
@@ -17,6 +17,6 @@
         <include name="FEM" href="Objects/TorusFEM.xml" dx="2.5" />
         <include name="Spring" href="Objects/TorusSpring.xml" dx="5" rx="90" />
         <include name="FFD" href="Objects/TorusFFD.xml" dx="7.5" />
-        <!-- <include name="TorusRigid" href="Objects/TorusRigid.xml" dx="10" rx="90" /> -->
+        <include name="TorusRigid" href="Objects/TorusRigid.xml" dx="10" rx="90" />
     </Node>
 </Node>

--- a/examples/Demos/chainHybrid.scn
+++ b/examples/Demos/chainHybrid.scn
@@ -4,6 +4,7 @@
     <BruteForceDetection name="N2" />
     <NewProximityIntersection name="Proximity" alarmDistance="0.3" contactDistance="0.2" />
     <DefaultContactManager name="Response" response="default" />
+	<CollisionGroupManager name="Group" />
     <Node name="Chain">
         <Node name="Fixed">
             <MeshObjLoader name="loaderMeca" filename="mesh/torus_for_collision.obj" />
@@ -16,6 +17,6 @@
         <include name="FEM" href="Objects/TorusFEM.xml" dx="2.5" />
         <include name="Spring" href="Objects/TorusSpring.xml" dx="5" rx="90" />
         <include name="FFD" href="Objects/TorusFFD.xml" dx="7.5" />
-        <include name="TorusRigid" href="Objects/TorusRigid.xml" dx="10" rx="90" />
+        <!-- <include name="TorusRigid" href="Objects/TorusRigid.xml" dx="10" rx="90" /> -->
     </Node>
 </Node>


### PR DESCRIPTION
Fix in DefaultCollisionGroupManager::createGroups the wrong search of deformable object nodes in collision group nodes already created. 

The search was always failing and a new collision group was always created and added in the scene graph.

This PR is supposed to explain the wrong behavior issue #994






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
