### PR TITLE
[SofaKernel] Remove annoying warning

### DIFF
--- a/SofaKernel/framework/sofa/core/objectmodel/BaseClass.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseClass.h
@@ -271,7 +271,7 @@ public:
     virtual const ::sofa::core::objectmodel::BaseClass* getClass() const override \
     { return GetClass(); }                                              \
     static const char* HeaderFileLocation() { return __FILE__; }        \
-    virtual const char* getHeaderFileLocation() { return __FILE__; }    \
+    const char* getHeaderFileLocation() { return __FILE__; }    \
     template<class SOFA_T> ::sofa::core::objectmodel::BaseData::BaseInitData \
     initData(::sofa::core::objectmodel::Data<SOFA_T>* field, const char* name, const char* help,   \
              ::sofa::core::objectmodel::BaseData::DataFlags dataflags)  \


### PR DESCRIPTION
getHeaderFileLocation() won't probably ever be overridden, so the virtual keyword is removed from the macro (and remove literally thousands lines of warnings in logs)


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
