### PR TITLE
[SofaGeneralEngine] Add update on begin animation

### DIFF
--- a/modules/SofaGeneralEngine/NearestPointROI.h
+++ b/modules/SofaGeneralEngine/NearestPointROI.h
@@ -86,6 +86,7 @@ public:
     void reinit() override;
 
     void doUpdate() override;
+    void handleEvent(core::objectmodel::Event *event) override;
 
     virtual std::string getTemplateName() const override
     {

--- a/modules/SofaGeneralEngine/NearestPointROI.inl
+++ b/modules/SofaGeneralEngine/NearestPointROI.inl
@@ -29,6 +29,7 @@
 #include <iostream>
 #include <SofaBaseTopology/TopologySubsetData.inl>
 #include <sofa/simulation/Node.h>
+#include <sofa/simulation/AnimateBeginEvent.h>
 
 namespace sofa
 {
@@ -120,6 +121,16 @@ void NearestPointROI<DataTypes>::doUpdate()
     if(f_indices1.getValue().size() != f_indices2.getValue().size())
     {
         msg_error() << "Size mismatch between indices1 and indices2";
+    }
+}
+
+template<class DataTypes>
+void NearestPointROI<DataTypes>::handleEvent(core::objectmodel::Event *event)
+{
+    if (simulation::AnimateBeginEvent::checkEventType(event))
+    {
+        setDirtyValue();
+        doUpdate();
     }
 }
 


### PR DESCRIPTION
Added update of ROI indices at the beginning of each time step using the listening option.

todo:
- drawing selected points and ROI radius
- define number of indices of object 1 to consider
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
