### PR TITLE
[image] Add warning guiding users regarding pluginization of DiffusionSolver

### DIFF
--- a/applications/plugins/image/CMakeLists.txt
+++ b/applications/plugins/image/CMakeLists.txt
@@ -123,7 +123,7 @@ if(SOFA_OPENMP)
 endif()
 
 
-find_package(DiffusionSolver REQUIRED)
+find_package(DiffusionSolver QUIET)
 # warning to remove at v19.12
 if(NOT DiffusionSolver_FOUND)
     message( WARNING "image: DiffusionSolver is now a plugin, make sure you activated the associated CMake option (PLUGIN_DIFFUSIONSOLVER)")

--- a/applications/plugins/image/CMakeLists.txt
+++ b/applications/plugins/image/CMakeLists.txt
@@ -126,7 +126,7 @@ endif()
 find_package(DiffusionSolver QUIET)
 # warning to remove at v19.12
 if(NOT DiffusionSolver_FOUND)
-    message( WARNING "image: DiffusionSolver is now a plugin, make sure you activated the associated CMake option (PLUGIN_DIFFUSIONSOLVER)")
+    message(SEND_ERROR "image: DiffusionSolver is now a plugin, make sure you activated the associated CMake option (PLUGIN_DIFFUSIONSOLVER)")
 endif()
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${README_FILES} ${PYTHON_FILES})

--- a/applications/plugins/image/CMakeLists.txt
+++ b/applications/plugins/image/CMakeLists.txt
@@ -124,6 +124,10 @@ endif()
 
 
 find_package(DiffusionSolver REQUIRED)
+# warning to remove at v19.12
+if(NOT DiffusionSolver_FOUND)
+    message( WARNING "image: DiffusionSolver is now a plugin, make sure you activated the associated CMake option (PLUGIN_DIFFUSIONSOLVER)")
+endif()
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${README_FILES} ${PYTHON_FILES})
 target_link_libraries(${PROJECT_NAME} SofaCore SofaComponentBase SofaGeneralVisual CImgPlugin ${MultiThreading_LIBRARY})


### PR DESCRIPTION
When compiling image, you might now have an issue when updating since DiffusionSolver has been made a separate plugin. This PR provides a warning for the users.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
