### PR TITLE
[image] Message API is needed even if no python

### DIFF
--- a/applications/plugins/image/initImage.cpp
+++ b/applications/plugins/image/initImage.cpp
@@ -22,6 +22,7 @@
 #include <image/config.h>
 #include <sofa/helper/system/config.h>
 #include <sofa/helper/system/PluginManager.h>
+#include <sofa/helper/logging/Messaging.h>
 
 #ifdef SOFA_HAVE_SOFAPYTHON
     #include <SofaPython/PythonFactory.h>


### PR DESCRIPTION
Including the Message API (Messaging.h) is needed in image so that the compilation can work independently from the activation of SofaPython



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
