### PR TITLE
[SofaOpenglVisual] Fix ogl perf problem

### DIFF
--- a/modules/SofaOpenglVisual/OglModel.cpp
+++ b/modules/SofaOpenglVisual/OglModel.cpp
@@ -368,18 +368,13 @@ void OglModel::internalDraw(const core::visual::VisualParams* vparams, bool tran
     glLightModeli(GL_LIGHT_MODEL_TWO_SIDE, GL_TRUE);
     glColor3f(1.0 , 1.0, 1.0);
 
-    /// Default values for the vbo
-    GLuint datatype = glType<DataTypes::Real>();
-    GLuint vertexdatasize = sizeof(vertices[0]);
-    GLuint normaldatasize = sizeof(vnormals[0]);
-
     /// Force the data to be of float type before sending to opengl...
-    datatype = GL_FLOAT;
-    vertexdatasize = sizeof(verticesTmpBuffer[0]);
-    normaldatasize = sizeof(normalsTmpBuffer[0]);
+    GLuint datatype = GL_FLOAT;
+    GLuint vertexdatasize = sizeof(verticesTmpBuffer[0]);
+    GLuint normaldatasize = sizeof(normalsTmpBuffer[0]);
 
-    GLuint vertexArrayByteSize = vertices.size() * vertexdatasize;
-    GLuint normalArrayByteSize = vnormals.size() * normaldatasize;
+    GLulong vertexArrayByteSize = vertices.size() * vertexdatasize;
+    GLulong normalArrayByteSize = vnormals.size() * normaldatasize;
 
     //// Update the vertex buffers.
     glBindBuffer(GL_ARRAY_BUFFER, vbo);

--- a/modules/SofaOpenglVisual/OglModel.cpp
+++ b/modules/SofaOpenglVisual/OglModel.cpp
@@ -940,7 +940,6 @@ void OglModel::updateBuffers()
     {
         if(!VBOGenDone)
         {
-            std::cout << "INIT BUFFERS..." << std::endl;
             createVertexBuffer();
             //Index Buffer Object
             //Edges indices

--- a/modules/SofaOpenglVisual/OglModel.cpp
+++ b/modules/SofaOpenglVisual/OglModel.cpp
@@ -44,7 +44,7 @@ namespace visualmodel
 using namespace sofa::defaulttype;
 using namespace sofa::core::loader;
 
-int OglModelClass = core::RegisterObject("Generic visual model for OpenGL display")
+static int OglModelClass = core::RegisterObject("Generic visual model for OpenGL display")
         .add< OglModel >()
         ;
 
@@ -67,7 +67,6 @@ OglModel::OglModel()
     , lineSmooth(initData(&lineSmooth, (bool) false, "lineSmooth", "Enable smooth line rendering"))
     , pointSmooth(initData(&pointSmooth, (bool) false, "pointSmooth", "Enable smooth point rendering"))
     , isEnabled( initData(&isEnabled, true, "isEnabled", "Activate/deactive the component."))
-    , forceFloat( initData(&forceFloat, false, "forceFloat", "Convert data to float befor sending to opengl."))
     , primitiveType( initData(&primitiveType, "primitiveType", "Select types of primitives to send (necessary for some shader types such as geometry or tesselation)"))
     , blendEquation( initData(&blendEquation, "blendEquation", "if alpha blending is enabled this specifies how source and destination colors are combined") )
     , sourceFactor( initData(&sourceFactor, "sfactor", "if alpha blending is enabled this specifies how the red, green, blue, and alpha source blending factors are computed") )
@@ -374,14 +373,10 @@ void OglModel::internalDraw(const core::visual::VisualParams* vparams, bool tran
     GLuint vertexdatasize = sizeof(vertices[0]);
     GLuint normaldatasize = sizeof(vnormals[0]);
 
-
-    /// In case we are forcing to float before sending to opengl...
-    if(forceFloat.getValue())
-    {
-        datatype = GL_FLOAT;
-        vertexdatasize = sizeof(verticesTmpBuffer[0]);
-        normaldatasize = sizeof(normalsTmpBuffer[0]);
-    }
+    /// Force the data to be of float type before sending to opengl...
+    datatype = GL_FLOAT;
+    vertexdatasize = sizeof(verticesTmpBuffer[0]);
+    normaldatasize = sizeof(normalsTmpBuffer[0]);
 
     GLuint vertexArrayByteSize = vertices.size() * vertexdatasize;
     GLuint normalArrayByteSize = vnormals.size() * normaldatasize;
@@ -770,15 +765,8 @@ void OglModel::initVertexBuffer()
     const VecCoord& vbitangents= this->getVbitangents();
     bool hasTangents = vtangents.size() && vbitangents.size();
 
-    if(forceFloat.getValue())
-    {
-        positionsBufferSize = (vertices.size()*sizeof(Vec3f));
-        normalsBufferSize = (vnormals.size()*sizeof(Vec3f));
-    }else
-    {
-        positionsBufferSize = (vertices.size()*sizeof(vertices[0]));
-        normalsBufferSize = (vnormals.size()*sizeof(vnormals[0]));
-    }
+    positionsBufferSize = (vertices.size()*sizeof(Vec3f));
+    normalsBufferSize = (vnormals.size()*sizeof(Vec3f));
 
     if (tex || putOnlyTexCoords.getValue() || !textures.empty())
     {
@@ -854,19 +842,16 @@ void OglModel::updateVertexBuffer()
     const void* normalBuffer = vnormals.getData();
 
 
-    if(forceFloat.getValue())
-    {
-        verticesTmpBuffer.resize( vertices.size() );
-        normalsTmpBuffer.resize( vnormals.size() );
+    verticesTmpBuffer.resize( vertices.size() );
+    normalsTmpBuffer.resize( vnormals.size() );
 
-        copyVector(vertices, verticesTmpBuffer);
-        copyVector(vnormals, normalsTmpBuffer);
+    copyVector(vertices, verticesTmpBuffer);
+    copyVector(vnormals, normalsTmpBuffer);
 
-        positionsBufferSize = (vertices.size()*sizeof(Vec3f));
-        normalsBufferSize = (vnormals.size()*sizeof(Vec3f));
-        positionBuffer = verticesTmpBuffer.data();
-        normalBuffer = normalsTmpBuffer.data();
-    }
+    positionsBufferSize = (vertices.size()*sizeof(Vec3f));
+    normalsBufferSize = (vnormals.size()*sizeof(Vec3f));
+    positionBuffer = verticesTmpBuffer.data();
+    normalBuffer = normalsTmpBuffer.data();
 
     if (tex || putOnlyTexCoords.getValue() || !textures.empty())
     {

--- a/modules/SofaOpenglVisual/OglModel.cpp
+++ b/modules/SofaOpenglVisual/OglModel.cpp
@@ -133,6 +133,19 @@ OglModel::~OglModel()
 
 }
 
+void OglModel::parse(core::objectmodel::BaseObjectDescription* arg)
+{
+    if (arg->getAttribute("isToPrint")!=nullptr)
+    {
+        msg_deprecated() << "The 'isToPrint' data field has been deprecated in Sofa 19.06 due to lack of consistency in how it should work." << msgendl
+                            "Please contact sofa-dev team in case you need similar.";
+    }
+    Inherit1::parse(arg);
+}
+
+
+
+
 void OglModel::drawGroup(int ig, bool transparent)
 {
     glEnable(GL_NORMALIZE);
@@ -316,6 +329,7 @@ void OglModel::drawGroups(bool transparent)
             drawGroup(i, transparent);
     }
 }
+
 
 void glVertex3v(const float* d){ glVertex3fv(d); }
 void glVertex3v(const double* d){ glVertex3dv(d); }

--- a/modules/SofaOpenglVisual/OglModel.cpp
+++ b/modules/SofaOpenglVisual/OglModel.cpp
@@ -31,7 +31,6 @@
 #include <cstring>
 #include <sofa/helper/types/RGBAColor.h>
 
-//#define NO_VBO
 //#define DEBUG_DRAW
 namespace sofa
 {
@@ -59,11 +58,6 @@ const T* getData(const sofa::helper::vector<T>& v) { return &v[0]; }
 OglModel::OglModel()
     : blendTransparency(initData(&blendTransparency, (bool) true, "blendTranslucency", "Blend transparent parts"))
     , premultipliedAlpha(initData(&premultipliedAlpha, (bool) false, "premultipliedAlpha", "is alpha premultiplied ?"))
-    #ifndef SOFA_HAVE_GLEW
-    , useVBO(initData(&useVBO, (bool) false, "useVBO", "Use VBO for rendering"))
-    #else
-    , useVBO(initData(&useVBO, (bool) true, "useVBO", "Use VBO for rendering"))
-    #endif
     , writeZTransparent(initData(&writeZTransparent, (bool) false, "writeZTransparent", "Write into Z Buffer for Transparent Object"))
     , alphaBlend(initData(&alphaBlend, (bool) false, "alphaBlend", "Enable alpha blending"))
     , depthTest(initData(&depthTest, (bool) true, "depthTest", "Enable depth testing"))
@@ -72,14 +66,15 @@ OglModel::OglModel()
     , pointSize(initData(&pointSize, (GLfloat) 1, "pointSize", "Point size (set if != 1, only for points rendering)"))
     , lineSmooth(initData(&lineSmooth, (bool) false, "lineSmooth", "Enable smooth line rendering"))
     , pointSmooth(initData(&pointSmooth, (bool) false, "pointSmooth", "Enable smooth point rendering"))
-    , isToPrint( initData(&isToPrint, false, "isToPrint", "suppress somes data before using save as function"))
+    , isEnabled( initData(&isEnabled, true, "isEnabled", "Activate/deactive the component."))
+    , forceFloat( initData(&forceFloat, false, "forceFloat", "Convert data to float befor sending to opengl."))
     , primitiveType( initData(&primitiveType, "primitiveType", "Select types of primitives to send (necessary for some shader types such as geometry or tesselation)"))
     , blendEquation( initData(&blendEquation, "blendEquation", "if alpha blending is enabled this specifies how source and destination colors are combined") )
     , sourceFactor( initData(&sourceFactor, "sfactor", "if alpha blending is enabled this specifies how the red, green, blue, and alpha source blending factors are computed") )
     , destFactor( initData(&destFactor, "dfactor", "if alpha blending is enabled this specifies how the red, green, blue, and alpha destination blending factors are computed") )
     , tex(NULL)
     , vbo(0), iboEdges(0), iboTriangles(0), iboQuads(0)
-    , canUseVBO(false), VBOGenDone(false), initDone(false), useEdges(false), useTriangles(false), useQuads(false), canUsePatches(false)
+    , VBOGenDone(false), initDone(false), useEdges(false), useTriangles(false), useQuads(false), canUsePatches(false)
     , oldVerticesSize(0), oldNormalsSize(0), oldTexCoordsSize(0), oldTangentsSize(0), oldBitangentsSize(0), oldEdgesSize(0), oldTrianglesSize(0), oldQuadsSize(0)
 {
 
@@ -116,28 +111,26 @@ OglModel::~OglModel()
         delete textures[i];
     }
 
-#ifdef GL_ARB_vertex_buffer_object
     // NB fjourdes : I don t know why gDEBugger still reports
     // graphics memory leaks after destroying the GLContext
     // even if the vbos destruction is claimed with the following
     // lines...
     if( vbo > 0 )
     {
-        glDeleteBuffersARB(1,&vbo);
+        glDeleteBuffers(1,&vbo);
     }
     if( iboEdges > 0)
     {
-        glDeleteBuffersARB(1,&iboEdges);
+        glDeleteBuffers(1,&iboEdges);
     }
     if( iboTriangles > 0)
     {
-        glDeleteBuffersARB(1,&iboTriangles);
+        glDeleteBuffers(1,&iboTriangles);
     }
     if( iboQuads > 0 )
     {
-        glDeleteBuffersARB(1,&iboQuads);
+        glDeleteBuffers(1,&iboQuads);
     }
-#endif
 
 }
 
@@ -186,22 +179,11 @@ void OglModel::drawGroup(int ig, bool transparent)
         }
 
         glEnable(GL_TEXTURE_2D);
-#ifdef SOFA_HAVE_GLEW
-        if(VBOGenDone && useVBO.getValue())
-        {
-            glBindBufferARB(GL_ARRAY_BUFFER, vbo);
-            glTexCoordPointer(2, GL_FLOAT, 0, (char*)NULL + (vertices.size()*sizeof(vertices[0]))
-                    + (vnormals.size()*sizeof(vnormals[0]))
-                    );
-            glBindBufferARB(GL_ARRAY_BUFFER, 0);
-        }
-        else
-#endif // SOFA_HAVE_GLEW
-        {
-            //get the texture coordinates
-            const VecTexCoord& vtexcoords = this->getVtexcoords();
-            glTexCoordPointer(2, GL_FLOAT, 0, getData(vtexcoords));
-        }
+        glBindBuffer(GL_ARRAY_BUFFER, vbo);
+        glTexCoordPointer(2, GL_FLOAT, 0, (char*)NULL + (vertices.size()*sizeof(vertices[0]))
+                + (vnormals.size()*sizeof(vnormals[0]))
+                );
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
         glEnableClientState(GL_TEXTURE_COORD_ARRAY);
     }
 
@@ -230,7 +212,6 @@ void OglModel::drawGroup(int ig, bool transparent)
     glMaterialfv (GL_FRONT_AND_BACK, GL_SPECULAR, specular.data());
     glMaterialfv (GL_FRONT_AND_BACK, GL_EMISSION, emissive.data());
     glMaterialf (GL_FRONT_AND_BACK, GL_SHININESS, shininess);
-    const bool useBufferObjects = (VBOGenDone && useVBO.getValue());
     const bool drawPoints = (primitiveType.getValue().getSelectedId() == 3);
     if (drawPoints)
     {
@@ -244,12 +225,7 @@ void OglModel::drawGroup(int ig, bool transparent)
     if (g.nbe > 0 && !drawPoints)
     {
         const Edge* indices = NULL;
-#ifdef SOFA_HAVE_GLEW
-        if (useBufferObjects)
-            glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, iboEdges);
-        else
-#endif
-            indices = edges.getData();
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, iboEdges);
 
         GLenum prim = GL_LINES;
         switch (primitiveType.getValue().getSelectedId())
@@ -258,13 +234,8 @@ void OglModel::drawGroup(int ig, bool transparent)
             msg_warning() << "LINES_ADJACENCY primitive type invalid for edge topologies" ;
             break;
         case 2:
-#if defined(GL_PATCHES) && defined(SOFA_HAVE_GLEW)
-            if (canUsePatches)
-            {
-                prim = GL_PATCHES;
-                glPatchParameteri(GL_PATCH_VERTICES,2);
-            }
-#endif
+            prim = GL_PATCHES;
+            glPatchParameteri(GL_PATCH_VERTICES,2);
             break;
         default:
             break;
@@ -272,20 +243,12 @@ void OglModel::drawGroup(int ig, bool transparent)
 
         glDrawElements(prim, g.nbe * 2, GL_UNSIGNED_INT, indices + g.edge0);
 
-#ifdef SOFA_HAVE_GLEW
-        if (useBufferObjects)
-            glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, 0);
-#endif
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
     }
     if (g.nbt > 0 && !drawPoints)
     {
         const Triangle* indices = NULL;
-#ifdef SOFA_HAVE_GLEW
-        if (useBufferObjects)
-            glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, iboTriangles);
-        else
-#endif
-            indices = triangles.getData();
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, iboTriangles);
 
         GLenum prim = GL_TRIANGLES;
         switch (primitiveType.getValue().getSelectedId())
@@ -294,56 +257,30 @@ void OglModel::drawGroup(int ig, bool transparent)
             msg_warning() << "LINES_ADJACENCY primitive type invalid for triangular topologies" ;
             break;
         case 2:
-#if defined(GL_PATCHES) && defined(SOFA_HAVE_GLEW)
-            if (canUsePatches)
-            {
-                prim = GL_PATCHES;
-                glPatchParameteri(GL_PATCH_VERTICES,3);
-            }
-#endif
+            prim = GL_PATCHES;
+            glPatchParameteri(GL_PATCH_VERTICES,3);
             break;
         default:
             break;
         }
 
         glDrawElements(prim, g.nbt * 3, GL_UNSIGNED_INT, indices + g.tri0);
-
-#ifdef SOFA_HAVE_GLEW
-        if (useBufferObjects)
-            glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, 0);
-#endif
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
     }
     if (g.nbq > 0 && !drawPoints)
     {
         const Quad* indices = NULL;
-#ifdef SOFA_HAVE_GLEW
-        if (useBufferObjects)
-            glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, iboQuads);
-        else
-#endif
-            indices = quads.getData();
-
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, iboQuads);
 
         GLenum prim = GL_QUADS;
         switch (primitiveType.getValue().getSelectedId())
         {
         case 1:
-#ifndef GL_LINES_ADJACENCY_EXT
-            msg_warning() << "GL_LINES_ADJACENCY_EXT not defined, please activage GLEW" ;
-#else
-        {
             prim = GL_LINES_ADJACENCY_EXT;
-        }
-#endif
             break;
         case 2:
-#if defined(GL_PATCHES) && defined(SOFA_HAVE_GLEW)
-            if (canUsePatches)
-            {
-                prim = GL_PATCHES;
-                glPatchParameteri(GL_PATCH_VERTICES,4);
-            }
-#endif
+            prim = GL_PATCHES;
+            glPatchParameteri(GL_PATCH_VERTICES,4);
             break;
         default:
             break;
@@ -351,10 +288,7 @@ void OglModel::drawGroup(int ig, bool transparent)
 
         glDrawElements(prim, g.nbq * 4, GL_UNSIGNED_INT, indices + g.quad0);
 
-#ifdef SOFA_HAVE_GLEW
-        if (useBufferObjects)
-            glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, 0);
-#endif
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
     }
 
     if (!tex && m.useTexture && m.activated)
@@ -371,12 +305,6 @@ void OglModel::drawGroup(int ig, bool transparent)
 
 void OglModel::drawGroups(bool transparent)
 {
-    if(isToPrint.getValue()==true) {
-        m_positions.setPersistent(false);
-        m_vnormals.setPersistent(false);
-        m_vtexcoords.setPersistent(false);
-        m_triangles.setPersistent(false);}
-
     helper::ReadAccessor< Data< helper::vector<FaceGroup> > > groups = this->groups;
 
     if (groups.empty())
@@ -402,10 +330,28 @@ GLuint glType<double>(){ return GL_DOUBLE; }
 template<>
 GLuint glType<float>(){ return GL_FLOAT; }
 
+template<class InType, class OutType>
+void copyVector(const InType& src, OutType& dst)
+{
+    unsigned int i=0;
+    for(auto& item : src)
+    {
+        dst[i].set(item);
+        ++i;
+    }
+}
 
 void OglModel::internalDraw(const core::visual::VisualParams* vparams, bool transparent)
 {
-    if (!vparams->displayFlags().getShowVisualModels()) return;
+    if (!vparams->displayFlags().getShowVisualModels())
+        return;
+
+    if(!isEnabled.getValue())
+        return;
+
+    /// Checks that the VBO's are ready.
+    if(!VBOGenDone)
+        return;
 
     if (vparams->displayFlags().getShowWireFrame())
         glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
@@ -417,29 +363,34 @@ void OglModel::internalDraw(const core::visual::VisualParams* vparams, bool tran
     const VecCoord& vbitangents= this->getVbitangents();
     bool hasTangents = vtangents.size() && vbitangents.size();
 
+
     glEnable(GL_LIGHTING);
 
     glLightModeli(GL_LIGHT_MODEL_TWO_SIDE, GL_TRUE);
     glColor3f(1.0 , 1.0, 1.0);
 
+    /// Default values for the vbo
     GLuint datatype = glType<DataTypes::Real>();
+    GLuint vertexdatasize = sizeof(vertices[0]);
+    GLuint normaldatasize = sizeof(vnormals[0]);
 
-#ifdef SOFA_HAVE_GLEW
-    if(VBOGenDone && useVBO.getValue())
+
+    /// In case we are forcing to float before sending to opengl...
+    if(forceFloat.getValue())
     {
-        glBindBufferARB(GL_ARRAY_BUFFER, vbo);
-
-        glVertexPointer(3, datatype, 0, (char*)NULL + 0);
-        glNormalPointer(datatype, 0, (char*)NULL + (vertices.size()*sizeof(vertices[0])));
-
-        glBindBufferARB(GL_ARRAY_BUFFER, 0);
+        datatype = GL_FLOAT;
+        vertexdatasize = sizeof(verticesTmpBuffer[0]);
+        normaldatasize = sizeof(normalsTmpBuffer[0]);
     }
-    else
-#endif // SOFA_HAVE_GLEW
-    {
-        glVertexPointer (3, datatype, 0, vertices.getData());
-        glNormalPointer (datatype, 0, vnormals.getData());
-    }
+
+    GLuint vertexArrayByteSize = vertices.size() * vertexdatasize;
+    GLuint normalArrayByteSize = vnormals.size() * normaldatasize;
+
+    //// Update the vertex buffers.
+    glBindBuffer(GL_ARRAY_BUFFER, vbo);
+    glVertexPointer(3, datatype, 0, (char*)NULL + 0);
+    glNormalPointer(datatype, 0, (char*)NULL + vertexArrayByteSize);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
 
     glEnableClientState(GL_NORMAL_ARRAY);
     glEnableClientState(GL_VERTEX_ARRAY);
@@ -451,54 +402,35 @@ void OglModel::internalDraw(const core::visual::VisualParams* vparams, bool tran
             glEnable(GL_TEXTURE_2D);
             tex->bind();
         }
-#ifdef SOFA_HAVE_GLEW
-        if(VBOGenDone && useVBO.getValue())
-        {
-            glBindBufferARB(GL_ARRAY_BUFFER, vbo);
-            glTexCoordPointer(2, GL_FLOAT, 0, (char*)NULL + (vertices.size()*sizeof(vertices[0])) + (vnormals.size()*sizeof(vnormals[0])) );
-            glBindBufferARB(GL_ARRAY_BUFFER, 0);
-        }
-        else
-#endif // SOFA_HAVE_GLEW
-        {
-            glTexCoordPointer(2, GL_FLOAT, 0, getData(vtexcoords));
-        }
+
+        GLuint textureArrayByteSize = vtexcoords.size()*sizeof(vtexcoords[0]);
+        glBindBuffer(GL_ARRAY_BUFFER, vbo);
+        glTexCoordPointer(2, GL_FLOAT, 0, (char*)NULL + vertexArrayByteSize + normalArrayByteSize );
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
         glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 
         if (hasTangents)
         {
-#ifdef SOFA_HAVE_GLEW
+            GLuint tangentArrayByteSize = vtangents.size()*sizeof(vtangents[0]);
+
             glClientActiveTexture(GL_TEXTURE1);
             glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-            if(VBOGenDone && useVBO.getValue())
-            {
-                glBindBufferARB(GL_ARRAY_BUFFER, vbo);
-                glTexCoordPointer(3, GL_FLOAT, 0,
-                                  (char*)NULL + (vertices.size()*sizeof(vertices[0])) +
-                        (vnormals.size()*sizeof(vnormals[0])) +
-                        (vtexcoords.size()*sizeof(vtexcoords[0])));
-                glBindBufferARB(GL_ARRAY_BUFFER, 0);
-            }
-            else
-                glTexCoordPointer(3, GL_FLOAT, 0, vtangents.getData());
+
+            glBindBuffer(GL_ARRAY_BUFFER, vbo);
+            glTexCoordPointer(3, GL_FLOAT, 0,
+                              (char*)NULL + vertexArrayByteSize + normalArrayByteSize + textureArrayByteSize);
+            glBindBuffer(GL_ARRAY_BUFFER, 0);
 
             glClientActiveTexture(GL_TEXTURE2);
             glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-            if(VBOGenDone && useVBO.getValue())
-            {
-                glBindBufferARB(GL_ARRAY_BUFFER, vbo);
-                glTexCoordPointer(3, GL_FLOAT, 0,
-                                  (char*)NULL + (vertices.size()*sizeof(vertices[0])) +
-                        (vnormals.size()*sizeof(vnormals[0])) +
-                        (vtexcoords.size()*sizeof(vtexcoords[0])) +
-                        (vtangents.size()*sizeof(vtangents[0])));
-                glBindBufferARB(GL_ARRAY_BUFFER, 0);
-            }
-            else
-                glTexCoordPointer(3, GL_FLOAT, 0, vbitangents.getData());
+
+            glBindBuffer(GL_ARRAY_BUFFER, vbo);
+            glTexCoordPointer(3, GL_FLOAT, 0,
+                              (char*)NULL + vertexArrayByteSize + normalArrayByteSize
+                              + textureArrayByteSize + tangentArrayByteSize);
+            glBindBuffer(GL_ARRAY_BUFFER, 0);
 
             glClientActiveTexture(GL_TEXTURE0);
-#endif //  SOFA_HAVE_GLEW
         }
     }
 
@@ -522,9 +454,7 @@ void OglModel::internalDraw(const core::visual::VisualParams* vparams, bool tran
     if (alphaBlend.getValue())
     {
         glDepthMask(GL_FALSE);
-#ifdef SOFA_HAVE_GLEW
         glBlendEquation( blendEq );
-#endif // SOFA_HAVE_GLEW
         glBlendFunc( sfactor, dfactor );
         glEnable(GL_BLEND);
     }
@@ -601,9 +531,7 @@ void OglModel::internalDraw(const core::visual::VisualParams* vparams, bool tran
     if (alphaBlend.getValue())
     {
         // restore Default value
-#ifdef SOFA_HAVE_GLEW
         glBlendEquation( GL_FUNC_ADD );
-#endif // SOFA_HAVE_GLEW
         glBlendFunc( GL_ONE, GL_ONE );
         glDisable(GL_BLEND);
         glDepthMask(GL_TRUE);
@@ -617,7 +545,6 @@ void OglModel::internalDraw(const core::visual::VisualParams* vparams, bool tran
             glDisable(GL_TEXTURE_2D);
         }
         glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-#ifdef SOFA_HAVE_GLEW
         if (hasTangents)
         {
             glClientActiveTexture(GL_TEXTURE1);
@@ -626,7 +553,6 @@ void OglModel::internalDraw(const core::visual::VisualParams* vparams, bool tran
             glDisableClientState(GL_TEXTURE_COORD_ARRAY);
             glClientActiveTexture(GL_TEXTURE0);
         }
-#endif // SOFA_HAVE_GLEW
     }
     glDisableClientState(GL_NORMAL_ARRAY);
     glDisable(GL_LIGHTING);
@@ -740,9 +666,6 @@ void OglModel::initVisual()
     initTextures();
 
     initDone = true;
-#ifdef NO_VBO
-    canUseVBO = false;
-#else
     static bool vboAvailable = false; // check the vbo availability
 
     static bool init = false;
@@ -752,16 +675,11 @@ void OglModel::initVisual()
         init = true;
     }
 
-    canUseVBO = vboAvailable;
-
-    if (useVBO.getValue() && !canUseVBO)
+    if (!vboAvailable)
     {
         msg_warning() << "OglModel : VBO is not supported by your GPU" ;
     }
 
-#endif
-
-#if defined(SOFA_HAVE_GLEW)
     if (primitiveType.getValue().getSelectedId() == 1 && !GLEW_EXT_geometry_shader4)
     {
         msg_warning() << "GL_EXT_geometry_shader4 not supported by your graphics card and/or OpenGL driver." ;
@@ -771,16 +689,11 @@ void OglModel::initVisual()
 
     if (primitiveType.getValue().getSelectedId() == 2 && !canUsePatches)
     {
-#ifdef GL_ARB_tessellation_shader
         msg_warning() << "GL_ARB_tessellation_shader not supported by your graphics card and/or OpenGL driver." ;
-#else
-        msg_warning() << "GL_ARB_tessellation_shader not defined, please update GLEW to 1.5.4+" ;
-#endif
         msg_warning() << "GL Version: " << glGetString(GL_VERSION) ;
         msg_warning() << "GL Vendor : " << glGetString(GL_VENDOR) ;
         msg_warning() << "GL Extensions: " << glGetString(GL_EXTENSIONS) ;
     }
-#endif
 
     updateBuffers();
 
@@ -797,7 +710,6 @@ void OglModel::initVisual()
         sfactor = getGLenum( sourceFactor.getValue().getSelectedItem().c_str() );
         dfactor = getGLenum( destFactor.getValue().getSelectedItem().c_str() );
     }
-
 }
 
 void OglModel::initTextures()
@@ -817,24 +729,24 @@ void OglModel::initTextures()
         }
     }
 }
-#ifdef SOFA_HAVE_GLEW
+
 void OglModel::createVertexBuffer()
 {
-    glGenBuffersARB(1, &vbo);
+    glGenBuffers(1, &vbo);
     initVertexBuffer();
     VBOGenDone = true;
 }
 
 void OglModel::createEdgesIndicesBuffer()
 {
-    glGenBuffersARB(1, &iboEdges);
+    glGenBuffers(1, &iboEdges);
     initEdgesIndicesBuffer();
     useEdges = true;
 }
 
 void OglModel::createTrianglesIndicesBuffer()
 {
-    glGenBuffersARB(1, &iboTriangles);
+    glGenBuffers(1, &iboTriangles);
     initTrianglesIndicesBuffer();
     useTriangles = true;
 }
@@ -842,11 +754,10 @@ void OglModel::createTrianglesIndicesBuffer()
 
 void OglModel::createQuadsIndicesBuffer()
 {
-    glGenBuffersARB(1, &iboQuads);
+    glGenBuffers(1, &iboQuads);
     initQuadsIndicesBuffer();
     useQuads = true;
 }
-
 
 void OglModel::initVertexBuffer()
 {
@@ -859,8 +770,16 @@ void OglModel::initVertexBuffer()
     const VecCoord& vbitangents= this->getVbitangents();
     bool hasTangents = vtangents.size() && vbitangents.size();
 
-    positionsBufferSize = (vertices.size()*sizeof(vertices[0]));
-    normalsBufferSize = (vnormals.size()*sizeof(vnormals[0]));
+    if(forceFloat.getValue())
+    {
+        positionsBufferSize = (vertices.size()*sizeof(Vec3f));
+        normalsBufferSize = (vnormals.size()*sizeof(Vec3f));
+    }else
+    {
+        positionsBufferSize = (vertices.size()*sizeof(vertices[0]));
+        normalsBufferSize = (vnormals.size()*sizeof(vnormals[0]));
+    }
+
     if (tex || putOnlyTexCoords.getValue() || !textures.empty())
     {
         textureCoordsBufferSize = vtexcoords.size() * sizeof(vtexcoords[0]);
@@ -875,17 +794,14 @@ void OglModel::initVertexBuffer()
     unsigned int totalSize = positionsBufferSize + normalsBufferSize + textureCoordsBufferSize +
             tangentsBufferSize + bitangentsBufferSize;
 
-    glBindBufferARB(GL_ARRAY_BUFFER, vbo);
-    //Vertex Buffer creation
-    glBufferDataARB(GL_ARRAY_BUFFER,
-                    totalSize,
-                    NULL,
-                    GL_DYNAMIC_DRAW);
-
+    glBindBuffer(GL_ARRAY_BUFFER, vbo);
+    glBufferData(GL_ARRAY_BUFFER,
+                 totalSize,
+                 NULL,
+                 GL_DYNAMIC_DRAW);
 
     updateVertexBuffer();
-
-    glBindBufferARB(GL_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 
@@ -893,38 +809,35 @@ void OglModel::initEdgesIndicesBuffer()
 {
     const ResizableExtVector<Edge>& edges = this->getEdges();
 
-    glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, iboEdges);
-
-    glBufferDataARB(GL_ELEMENT_ARRAY_BUFFER, edges.size()*sizeof(edges[0]), NULL, GL_DYNAMIC_DRAW);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, iboEdges);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, edges.size()*sizeof(edges[0]), NULL, GL_DYNAMIC_DRAW);
     updateEdgesIndicesBuffer();
-
-    glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 }
 
 void OglModel::initTrianglesIndicesBuffer()
 {
     const ResizableExtVector<Triangle>& triangles = this->getTriangles();
 
-    glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, iboTriangles);
-
-    glBufferDataARB(GL_ELEMENT_ARRAY_BUFFER, triangles.size()*sizeof(triangles[0]), NULL, GL_DYNAMIC_DRAW);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, iboTriangles);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, triangles.size()*sizeof(triangles[0]), NULL, GL_DYNAMIC_DRAW);
     updateTrianglesIndicesBuffer();
-
-    glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 }
 
 void OglModel::initQuadsIndicesBuffer()
 {
     const ResizableExtVector<Quad>& quads = this->getQuads();
 
-    glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, iboQuads);
-    glBufferDataARB(GL_ELEMENT_ARRAY_BUFFER, quads.size()*sizeof(quads[0]), NULL, GL_DYNAMIC_DRAW);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, iboQuads);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, quads.size()*sizeof(quads[0]), NULL, GL_DYNAMIC_DRAW);
     updateQuadsIndicesBuffer();
-    glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 }
 
 void OglModel::updateVertexBuffer()
 {
+
     const VecCoord& vertices = this->getVertices();
     const VecCoord& vnormals = this->getVnormals();
     const VecTexCoord& vtexcoords= this->getVtexcoords();
@@ -937,6 +850,24 @@ void OglModel::updateVertexBuffer()
 
     positionsBufferSize = (vertices.size()*sizeof(vertices[0]));
     normalsBufferSize = (vnormals.size()*sizeof(vnormals[0]));
+    const void* positionBuffer = vertices.getData();
+    const void* normalBuffer = vnormals.getData();
+
+
+    if(forceFloat.getValue())
+    {
+        verticesTmpBuffer.resize( vertices.size() );
+        normalsTmpBuffer.resize( vnormals.size() );
+
+        copyVector(vertices, verticesTmpBuffer);
+        copyVector(vnormals, normalsTmpBuffer);
+
+        positionsBufferSize = (vertices.size()*sizeof(Vec3f));
+        normalsBufferSize = (vnormals.size()*sizeof(Vec3f));
+        positionBuffer = verticesTmpBuffer.data();
+        normalBuffer = normalsTmpBuffer.data();
+    }
+
     if (tex || putOnlyTexCoords.getValue() || !textures.empty())
     {
         textureCoordsBufferSize = vtexcoords.size() * sizeof(vtexcoords[0]);
@@ -948,69 +879,67 @@ void OglModel::updateVertexBuffer()
         }
     }
 
-    glBindBufferARB(GL_ARRAY_BUFFER, vbo);
+    glBindBuffer(GL_ARRAY_BUFFER, vbo);
     //Positions
-    glBufferSubDataARB(GL_ARRAY_BUFFER,
-                       0,
-                       positionsBufferSize,
-                       vertices.getData());
+    glBufferSubData(GL_ARRAY_BUFFER,
+                    0,
+                    positionsBufferSize,
+                    positionBuffer);
 
     //Normals
-    glBufferSubDataARB(GL_ARRAY_BUFFER,
-                       positionsBufferSize,
-                       normalsBufferSize,
-                       vnormals.getData());
+    glBufferSubData(GL_ARRAY_BUFFER,
+                    positionsBufferSize,
+                    normalsBufferSize,
+                    normalBuffer);
 
     //Texture coords
     if(tex || putOnlyTexCoords.getValue() ||!textures.empty())
     {
-        glBufferSubDataARB(GL_ARRAY_BUFFER,
-                           positionsBufferSize + normalsBufferSize,
-                           textureCoordsBufferSize,
-                           getData(vtexcoords));
+        glBufferSubData(GL_ARRAY_BUFFER,
+                        positionsBufferSize + normalsBufferSize,
+                        textureCoordsBufferSize,
+                        getData(vtexcoords));
 
         if (hasTangents)
         {
-            glBufferSubDataARB(GL_ARRAY_BUFFER,
-                               positionsBufferSize + normalsBufferSize + textureCoordsBufferSize,
-                               tangentsBufferSize,
-                               vtangents.getData());
+            glBufferSubData(GL_ARRAY_BUFFER,
+                            positionsBufferSize + normalsBufferSize + textureCoordsBufferSize,
+                            tangentsBufferSize,
+                            vtangents.getData());
 
-            glBufferSubDataARB(GL_ARRAY_BUFFER,
-                               positionsBufferSize + normalsBufferSize + textureCoordsBufferSize + tangentsBufferSize,
-                               bitangentsBufferSize,
-                               vbitangents.getData());
+            glBufferSubData(GL_ARRAY_BUFFER,
+                            positionsBufferSize + normalsBufferSize + textureCoordsBufferSize + tangentsBufferSize,
+                            bitangentsBufferSize,
+                            vbitangents.getData());
         }
     }
 
-    glBindBufferARB(GL_ARRAY_BUFFER, 0);
-
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 void OglModel::updateEdgesIndicesBuffer()
 {
     const ResizableExtVector<Edge>& edges = this->getEdges();
-    glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, iboEdges);
-    glBufferSubDataARB(GL_ELEMENT_ARRAY_BUFFER, 0, edges.size()*sizeof(edges[0]), &edges[0]);
-    glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, iboEdges);
+    glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, 0, edges.size()*sizeof(edges[0]), &edges[0]);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 }
 
 void OglModel::updateTrianglesIndicesBuffer()
 {
     const ResizableExtVector<Triangle>& triangles = this->getTriangles();
-    glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, iboTriangles);
-    glBufferSubDataARB(GL_ELEMENT_ARRAY_BUFFER, 0, triangles.size()*sizeof(triangles[0]), &triangles[0]);
-    glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, iboTriangles);
+    glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, 0, triangles.size()*sizeof(triangles[0]), &triangles[0]);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 }
 
 void OglModel::updateQuadsIndicesBuffer()
 {
     const ResizableExtVector<Quad>& quads = this->getQuads();
-    glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, iboQuads);
-    glBufferSubDataARB(GL_ELEMENT_ARRAY_BUFFER, 0, quads.size()*sizeof(quads[0]), &quads[0]);
-    glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, iboQuads);
+    glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, 0, quads.size()*sizeof(quads[0]), &quads[0]);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 }
-#endif
 void OglModel::updateBuffers()
 {
     const ResizableExtVector<Edge>& edges = this->getEdges();
@@ -1024,74 +953,71 @@ void OglModel::updateBuffers()
 
     if (initDone)
     {
-#ifdef SOFA_HAVE_GLEW
-        if (useVBO.getValue() && canUseVBO)
+        if(!VBOGenDone)
         {
-            if(!VBOGenDone)
-            {
-                createVertexBuffer();
-                //Index Buffer Object
-                //Edges indices
-                if(edges.size() > 0)
-                    createEdgesIndicesBuffer();
-                //Triangles indices
-                if(triangles.size() > 0)
-                    createTrianglesIndicesBuffer();
-                //Quads indices
-                if(quads.size() > 0)
-                    createQuadsIndicesBuffer();
-            }
-            //Update VBO & IBO
-            else
-            {
-                if(oldVerticesSize != vertices.size() ||
-                        oldNormalsSize != normals.size() ||
-                        oldTexCoordsSize != texCoords.size() ||
-                        oldTangentsSize != tangents.size() ||
-                        oldBitangentsSize != bitangents.size())
-                    initVertexBuffer();
-                else
-                    updateVertexBuffer();
-                //Indices
-                //Edges
-                if(useEdges)
-                    if(oldEdgesSize != edges.size())
-                        initEdgesIndicesBuffer();
-                    else
-                        updateEdgesIndicesBuffer();
-                else if (edges.size() > 0)
-                    createEdgesIndicesBuffer();
-
-                //Triangles
-                if(useTriangles)
-                    if(oldTrianglesSize != triangles.size())
-                        initTrianglesIndicesBuffer();
-                    else
-                        updateTrianglesIndicesBuffer();
-                else if (triangles.size() > 0)
-                    createTrianglesIndicesBuffer();
-
-                //Quads
-                if (useQuads)
-                    if(oldQuadsSize != quads.size())
-                        initQuadsIndicesBuffer();
-                    else
-                        updateQuadsIndicesBuffer();
-                else if (quads.size() > 0)
-                    createQuadsIndicesBuffer();
-            }
-            oldVerticesSize = vertices.size();
-            oldNormalsSize = normals.size();
-            oldTexCoordsSize = texCoords.size();
-            oldTangentsSize = tangents.size();
-            oldBitangentsSize = bitangents.size();
-            oldEdgesSize = edges.size();
-            oldTrianglesSize = triangles.size();
-            oldQuadsSize = quads.size();
+            std::cout << "INIT BUFFERS..." << std::endl;
+            createVertexBuffer();
+            //Index Buffer Object
+            //Edges indices
+            if(edges.size() > 0)
+                createEdgesIndicesBuffer();
+            //Triangles indices
+            if(triangles.size() > 0)
+                createTrianglesIndicesBuffer();
+            //Quads indices
+            if(quads.size() > 0)
+                createQuadsIndicesBuffer();
         }
-#endif
-    }
+        //Update VBO & IBO
+        else
+        {
+            if(oldVerticesSize != vertices.size() ||
+                    oldNormalsSize != normals.size() ||
+                    oldTexCoordsSize != texCoords.size() ||
+                    oldTangentsSize != tangents.size() ||
+                    oldBitangentsSize != bitangents.size())
+                initVertexBuffer();
+            else
+                updateVertexBuffer();
 
+
+            //Indices
+            //Edges
+            if(useEdges)
+                if(oldEdgesSize != edges.size())
+                    initEdgesIndicesBuffer();
+                else
+                    updateEdgesIndicesBuffer();
+            else if (edges.size() > 0)
+                createEdgesIndicesBuffer();
+
+            //Triangles
+            if(useTriangles)
+                if(oldTrianglesSize != triangles.size())
+                    initTrianglesIndicesBuffer();
+                else
+                    updateTrianglesIndicesBuffer();
+            else if (triangles.size() > 0)
+                createTrianglesIndicesBuffer();
+
+            //Quads
+            if (useQuads)
+                if(oldQuadsSize != quads.size())
+                    initQuadsIndicesBuffer();
+                else
+                    updateQuadsIndicesBuffer();
+            else if (quads.size() > 0)
+                createQuadsIndicesBuffer();
+        }
+        oldVerticesSize = vertices.size();
+        oldNormalsSize = normals.size();
+        oldTexCoordsSize = texCoords.size();
+        oldTangentsSize = tangents.size();
+        oldBitangentsSize = bitangents.size();
+        oldEdgesSize = edges.size();
+        oldTrianglesSize = triangles.size();
+        oldQuadsSize = quads.size();
+    }
 }
 
 
@@ -1114,7 +1040,6 @@ GLenum OglModel::getGLenum(const char* c ) const
     {
         return GL_ONE_MINUS_SRC_ALPHA;
     }
-#ifdef SOFA_HAVE_GLEW
     // .... add ohter OGL symbolic constants
     // glBlendEquation Value
     else if  ( strcmp( c, "GL_FUNC_ADD") == 0)
@@ -1133,14 +1058,11 @@ GLenum OglModel::getGLenum(const char* c ) const
     {
         return GL_MIN;
     }
-#endif // SOFA_HAVE_GLEW
     else
     {
         msg_warning() << " OglModel - not valid or not supported openGL enum value: " << c ;
         return GL_ZERO;
     }
-
-
 }
 
 

--- a/modules/SofaOpenglVisual/OglModel.h
+++ b/modules/SofaOpenglVisual/OglModel.h
@@ -69,7 +69,6 @@ protected:
     Data<bool> lineSmooth; ///< Enable smooth line rendering
     Data<bool> pointSmooth; ///< Enable smooth point rendering
     /// Suppress field for save as function
-    Data < bool > isToPrint;
     Data < bool > isEnabled;
 
     // primitive types
@@ -118,6 +117,7 @@ public:
     void initVisual() override;
 
     void init() override { VisualModelImpl::init(); }
+    void parse(core::objectmodel::BaseObjectDescription* arg) override;
 
     void updateBuffers() override;
 

--- a/modules/SofaOpenglVisual/OglModel.h
+++ b/modules/SofaOpenglVisual/OglModel.h
@@ -60,7 +60,6 @@ public:
     Data<bool> blendTransparency; ///< Blend transparent parts
 protected:
     Data<bool> premultipliedAlpha; ///< is alpha premultiplied ?
-    Data<bool> useVBO; ///< Use VBO for rendering
     Data<bool> writeZTransparent; ///< Write into Z Buffer for Transparent Object
     Data<bool> alphaBlend; ///< Enable alpha blending
     Data<bool> depthTest; ///< Enable depth testing
@@ -71,6 +70,8 @@ protected:
     Data<bool> pointSmooth; ///< Enable smooth point rendering
     /// Suppress field for save as function
     Data < bool > isToPrint;
+    Data < bool > isEnabled;
+    Data < bool > forceFloat;
 
     // primitive types
     Data<sofa::helper::OptionsGroup> primitiveType; ///< Select types of primitives to send (necessary for some shader types such as geometry or tesselation)
@@ -83,8 +84,15 @@ protected:
 
     helper::gl::Texture *tex; //this texture is used only if a texture name is specified in the scn
     GLuint vbo, iboEdges, iboTriangles, iboQuads;
-    bool canUseVBO, VBOGenDone, initDone, useEdges, useTriangles, useQuads, canUsePatches;
+    bool VBOGenDone, initDone, useEdges, useTriangles, useQuads, canUsePatches;
     unsigned int oldVerticesSize, oldNormalsSize, oldTexCoordsSize, oldTangentsSize, oldBitangentsSize, oldEdgesSize, oldTrianglesSize, oldQuadsSize;
+
+    /// These two buffers are used with the "forceFloat" data field is activated.
+    /// When this is the case the data types send to openGL is always converted to floating points
+    /// values before touching opengl.
+    std::vector<sofa::defaulttype::Vec3f> verticesTmpBuffer;
+    std::vector<sofa::defaulttype::Vec3f> normalsTmpBuffer;
+
     void internalDraw(const core::visual::VisualParams* vparams, bool transparent) override;
 
     void drawGroup(int ig, bool transparent);
@@ -122,7 +130,6 @@ public:
     bool isUseEdges()	{ return useEdges; }
     bool isUseTriangles()	{ return useTriangles; }
     bool isUseQuads()	{ return useQuads; }
-    bool isUseVbo()	{ return useVBO.getValue(); }
 
     helper::gl::Texture* getTex() const	{ return tex; }
     GLuint getVbo()	{ return vbo;	}
@@ -131,7 +138,6 @@ public:
     GLuint getIboQuads()    { return iboQuads; }
     const std::vector<helper::gl::Texture*>& getTextures() const { return textures;	}
 
-#ifdef SOFA_HAVE_GLEW
     void createVertexBuffer();
     void createEdgesIndicesBuffer();
     void createTrianglesIndicesBuffer();
@@ -144,7 +150,6 @@ public:
     void updateEdgesIndicesBuffer();
     void updateTrianglesIndicesBuffer();
     void updateQuadsIndicesBuffer();
-#endif
 };
 
 typedef sofa::defaulttype::Vec<3,GLfloat> GLVec3f;

--- a/modules/SofaOpenglVisual/OglModel.h
+++ b/modules/SofaOpenglVisual/OglModel.h
@@ -71,7 +71,6 @@ protected:
     /// Suppress field for save as function
     Data < bool > isToPrint;
     Data < bool > isEnabled;
-    Data < bool > forceFloat;
 
     // primitive types
     Data<sofa::helper::OptionsGroup> primitiveType; ///< Select types of primitives to send (necessary for some shader types such as geometry or tesselation)
@@ -87,9 +86,8 @@ protected:
     bool VBOGenDone, initDone, useEdges, useTriangles, useQuads, canUsePatches;
     unsigned int oldVerticesSize, oldNormalsSize, oldTexCoordsSize, oldTangentsSize, oldBitangentsSize, oldEdgesSize, oldTrianglesSize, oldQuadsSize;
 
-    /// These two buffers are used with the "forceFloat" data field is activated.
-    /// When this is the case the data types send to openGL is always converted to floating points
-    /// values before touching opengl.
+    /// These two buffers are used to convert the data field to float type before being sent to
+    /// opengl
     std::vector<sofa::defaulttype::Vec3f> verticesTmpBuffer;
     std::vector<sofa::defaulttype::Vec3f> normalsTmpBuffer;
 

--- a/testgl.py
+++ b/testgl.py
@@ -1,3 +1,0 @@
-def createScene(root):
-        for i in range(10):
-                root.createObject("OglModel", name="armadille"+str(i), filename="mesh/Armadillo_simplified.obj", forceFloat=True)

--- a/testgl.py
+++ b/testgl.py
@@ -1,0 +1,3 @@
+def createScene(root):
+        for i in range(10):
+                root.createObject("OglModel", name="armadille"+str(i), filename="mesh/Armadillo_simplified.obj", forceFloat=True)


### PR DESCRIPTION
This PR fix the opengl performance issue reported in #https://github.com/sofa-framework/sofa/issues/1070

The fix is in OglModel.cpp/OglModel.h and  is very simple, when the positions and normals array are containg double precision numbers they are converted into single precision one before sending the data to OpenGL. I'm sure we can optimize further the conversion loop...but I have not time for that (volunteer needed). 

Because the code in OglModel was hard to read because of the #ifdef GLEW all around I first cleaned the whole SofaOpenglVisual code, by removing the #ifdef. I also updated the call to function with name *ARB because they are now part of any baseline opengl implementation since nearly a decade. 


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
