### PR TITLE
[SofaKernel] Refactor DataTrackerEngine so it match the DataCallback

### DIFF
--- a/SofaKernel/framework/sofa/core/DataTracker.cpp
+++ b/SofaKernel/framework/sofa/core/DataTracker.cpp
@@ -63,19 +63,25 @@ void DataTracker::clean()
 
 
 ////////////////////
+void DataTrackerDDGNode::addInputs(std::initializer_list<sofa::core::objectmodel::BaseData*> datas)
+{
+    for(sofa::core::objectmodel::BaseData* d : datas)
+        addInput(d);
+}
 
-
+void DataTrackerDDGNode::addOutputs(std::initializer_list<sofa::core::objectmodel::BaseData*> datas)
+{
+    for(sofa::core::objectmodel::BaseData* d : datas)
+        addOutput(d);
+}
 
 void DataTrackerDDGNode::cleanDirty(const core::ExecParams* params)
 {
     core::objectmodel::DDGNode::cleanDirty(params);
 
-    // it is also time to clean the tracked Data
+    /// it is also time to clean the tracked Data
     m_dataTracker.clean();
-
 }
-
-
 
 void DataTrackerDDGNode::updateAllInputsIfDirty()
 {
@@ -85,16 +91,20 @@ void DataTrackerDDGNode::updateAllInputsIfDirty()
         static_cast<core::objectmodel::BaseData*>(inputs[i])->updateIfDirty();
     }
 }
-
-
-
 ///////////////////////
-
-
-void DataTrackerEngine::setUpdateCallback( void (*f)(DataTrackerEngine*) )
+void DataTrackerEngine::addCallback( std::function<void(DataTrackerEngine*)> f)
 {
-    m_updateCallback = f;
+    m_callbacks.push_back(f);
 }
+
+void DataTrackerEngine::update()
+{
+    for(auto& callback : m_callbacks)
+    {
+        callback(this);
+    }
+}
+
 
 }
 

--- a/SofaKernel/framework/sofa/core/DataTracker.h
+++ b/SofaKernel/framework/sofa/core/DataTracker.h
@@ -87,6 +87,9 @@ namespace core
         void operator=(const DataTrackerDDGNode&);
 
     public:
+        /// Create a DataCallback object associated with multiple Data.
+        void addInputs(std::initializer_list<sofa::core::objectmodel::BaseData*> datas);
+        void addOutputs(std::initializer_list<sofa::core::objectmodel::BaseData*> datas);
 
         /// Set dirty flag to false
         /// for the DDGNode and for all the tracked Data
@@ -160,14 +163,17 @@ namespace core
     class SOFA_CORE_API DataTrackerEngine : public DataTrackerDDGNode
     {
     public:
+        /// set the update function to call
+        /// when asking for an output and any input changed.
+        [[deprecated("This function has been replaced by addCallback with similar signature. Update your code.")]]
+        void setUpdateCallback(std::function<void(DataTrackerEngine*)> f){ addCallback(f); }
 
         /// set the update function to call
         /// when asking for an output and any input changed.
-        void setUpdateCallback( void (*f)(DataTrackerEngine*) );
+        void addCallback(std::function<void(DataTrackerEngine*)> f);
 
-        /// Update this value
-        /// @warning the update callback must have been set with "setUpdateCallback"
-        void update() override { m_updateCallback( this ); }
+        /// Calls the callback when one of the data has changed.
+        void update() override;
 
         /// This method is needed by DDGNode
         const std::string& getName() const override
@@ -181,9 +187,7 @@ namespace core
         objectmodel::BaseData* getData() const override { return nullptr; }
 
     protected:
-
-        void (*m_updateCallback)(DataTrackerEngine*);
-
+        std::vector<std::function<void(DataTrackerEngine*)>> m_callbacks;
     };
 
 

--- a/SofaKernel/modules/sofa/frameworkextra/frameworkextra_test/core/TrackedData_test.cpp
+++ b/SofaKernel/modules/sofa/frameworkextra/frameworkextra_test/core/TrackedData_test.cpp
@@ -159,16 +159,19 @@ public:
 
 
     Data< bool > input;
+    Data< bool > input2;
     Data< bool > depend_on_input;
-
+    Data< bool > depend_on_input2;
 
     TestObject2()
         : Inherit1()
         , input(initData(&input,false,"input","input"))
+        , input2(initData(&input2,false,"input2","input2"))
         , depend_on_input(initData(&depend_on_input,"depend_on_input","depend_on_input"))
+        , depend_on_input2(initData(&depend_on_input2,"depend_on_input2","depend_on_input2"))
     {
-        m_dataTracker.addInput(&input); // several inputs can be added
-        m_dataTracker.addOutput(&depend_on_input); // several output can be added
+        m_dataTracker.addInputs({&input,&input2}); // several inputs can be added
+        m_dataTracker.addOutputs({&depend_on_input, &depend_on_input2}); // several output can be added
         m_dataTracker.setUpdateCallback( &TestObject2::myUpdate );
         m_dataTracker.setDirtyValue();
     }
@@ -194,13 +197,15 @@ protected:
 
         // we known who is who from the order Data were added to the DataTrackerEngine
         bool input = static_cast<Data< bool >*>( inputs[0] )->getValue();
+        bool input2 = static_cast<Data< bool >*>( inputs[1] )->getValue();
 
         dataTrackerEngine->cleanDirty();
 
-
         Data< bool >* output = static_cast<Data< bool >*>( outputs[0] );
+        Data< bool >* output2 = static_cast<Data< bool >*>( outputs[0] );
 
         output->setValue( input );
+        output2->setValue( input2 );
     }
 
 };
@@ -267,6 +272,13 @@ struct DataTrackerEngine_test: public BaseTest
         ASSERT_TRUE(testObject.depend_on_input.getValue()==false);
         ++localCounter;
         ASSERT_EQ( localCounter, TestObject2::s_updateCounter );
+
+        ASSERT_TRUE(testObject.depend_on_input2.getValue()==true);
+        testObject.input2.setValue(false);
+        ASSERT_TRUE(testObject.depend_on_input2.getValue()==false);
+        ++localCounter;
+        ASSERT_EQ( localCounter, TestObject2::s_updateCounter );
+
     }
 
 

--- a/SofaKernel/modules/sofa/frameworkextra/frameworkextra_test/core/TrackedData_test.cpp
+++ b/SofaKernel/modules/sofa/frameworkextra/frameworkextra_test/core/TrackedData_test.cpp
@@ -301,11 +301,8 @@ struct DataTrackerEngine_test: public BaseTest
         core::DataTrackerEngine dataTracker;
         dataTracker.addInput(&testObject.myData); // several inputs can be added
         dataTracker.addOutput(&testObject2.myData); // several output can be added
-        dataTracker.setUpdateCallback( &DataTrackerEngine_test::myUpdate );
+        dataTracker.addCallback( &DataTrackerEngine_test::myUpdate );
         dataTracker.setDirtyValue();
-
-
-
         unsigned localCounter = 0u;
 
         testObject.myData.setValue(true);

--- a/SofaKernel/modules/sofa/frameworkextra/frameworkextra_test/core/TrackedData_test.cpp
+++ b/SofaKernel/modules/sofa/frameworkextra/frameworkextra_test/core/TrackedData_test.cpp
@@ -202,7 +202,7 @@ protected:
         dataTrackerEngine->cleanDirty();
 
         Data< bool >* output = static_cast<Data< bool >*>( outputs[0] );
-        Data< bool >* output2 = static_cast<Data< bool >*>( outputs[0] );
+        Data< bool >* output2 = static_cast<Data< bool >*>( outputs[1] );
 
         output->setValue( input );
         output2->setValue( input2 );

--- a/SofaKernel/modules/sofa/frameworkextra/frameworkextra_test/core/TrackedData_test.cpp
+++ b/SofaKernel/modules/sofa/frameworkextra/frameworkextra_test/core/TrackedData_test.cpp
@@ -166,7 +166,7 @@ public:
     TestObject2()
         : Inherit1()
         , input(initData(&input,false,"input","input"))
-        , input2(initData(&input2,false,"input2","input2"))
+        , input2(initData(&input2,true,"input2","input2"))
         , depend_on_input(initData(&depend_on_input,"depend_on_input","depend_on_input"))
         , depend_on_input2(initData(&depend_on_input2,"depend_on_input2","depend_on_input2"))
     {
@@ -273,9 +273,9 @@ struct DataTrackerEngine_test: public BaseTest
         ++localCounter;
         ASSERT_EQ( localCounter, TestObject2::s_updateCounter );
 
-        ASSERT_TRUE(testObject.depend_on_input2.getValue()==true);
+        ASSERT_TRUE(testObject.depend_on_input2.getValue());
         testObject.input2.setValue(false);
-        ASSERT_TRUE(testObject.depend_on_input2.getValue()==false);
+        ASSERT_FALSE(testObject.depend_on_input2.getValue());
         ++localCounter;
         ASSERT_EQ( localCounter, TestObject2::s_updateCounter );
 


### PR DESCRIPTION
This PR unify the API for DataTrackerEngine and DataCallback
so they match. The difference between the two is that in DataTrackerEngine
the callback is called when the data is needed (so the output is accessed)
while in a DataCallback the update is done each time the data is changed.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
