### PR TITLE
[all] remove #ifdef SOFA_HAVE_GLEW

### DIFF
--- a/SofaKernel/framework/sofa/helper/gl/FrameBufferObject.h
+++ b/SofaKernel/framework/sofa/helper/gl/FrameBufferObject.h
@@ -31,7 +31,6 @@
 
 #include <sofa/helper/helper.h>
 
-#ifdef SOFA_HAVE_GLEW
 
 #include <sofa/helper/helper.h>
 #include <sofa/helper/system/gl.h>
@@ -111,6 +110,5 @@ public:
 
 } //sofa
 
-#endif /* SOFA_HAVE_GLEW */
 
 #endif /* FRAMEBUFFEROBJECT_H_ */

--- a/SofaKernel/framework/sofa/helper/gl/GLSLShader.cpp
+++ b/SofaKernel/framework/sofa/helper/gl/GLSLShader.cpp
@@ -355,7 +355,7 @@ void GLSLShader::InitShaders()
         glAttachObjectARB(m_hProgramObject, it->second);
     }
 
-#if defined(GL_EXT_geometry_shader4) && defined(SOFA_HAVE_GLEW)
+#if defined(GL_EXT_geometry_shader4)
     if (GetGeometryShaderID())
     {
         if (geometry_input_type != -1) glProgramParameteriEXT(m_hProgramObject, GL_GEOMETRY_INPUT_TYPE_EXT, geometry_input_type );

--- a/SofaKernel/framework/sofa/helper/gl/GLSLShader.h
+++ b/SofaKernel/framework/sofa/helper/gl/GLSLShader.h
@@ -34,11 +34,7 @@ namespace sofa {
     }
 }
 
-#ifndef SOFA_HAVE_GLEW
-#error GL Shader support requires GLEW. Please define SOFA_HAVE_GLEW to use shaders.
-#endif
 
-#ifdef SOFA_HAVE_GLEW
 
 #include <sofa/helper/system/gl.h>
 #include <sofa/helper/system/glu.h>
@@ -294,6 +290,5 @@ protected:
 
 } // namespace sofa
 
-#endif /* SOFA_HAVE_GLEW */
 
 #endif /* SOFA_HELPER_GL_GLSLSHADER_H */

--- a/SofaKernel/framework/sofa/helper/gl/Texture.cpp
+++ b/SofaKernel/framework/sofa/helper/gl/Texture.cpp
@@ -237,7 +237,7 @@ void Texture::update()
         unsigned internalFormatSRGB = internalFormatTableSRGB[image->getDataType()][image->getChannelFormat()];
         if (internalFormatSRGB)
         {
-#if defined(SOFA_HAVE_GLEW) && defined(GLEW_EXT_texture_sRGB) && defined(GLEW_ARB_framebuffer_sRGB)
+#if defined(GLEW_EXT_texture_sRGB) && defined(GLEW_ARB_framebuffer_sRGB)
             if (GLEW_EXT_texture_sRGB && GLEW_ARB_framebuffer_sRGB)
                 internalFormat = internalFormatSRGB;
             else
@@ -259,7 +259,7 @@ void Texture::update()
     switch (textureType)
     {
     case io::Image::TEXTURE_2D:
-#if defined(SOFA_HAVE_GLEW) && defined(GLEW_VERSION_1_3)
+#if defined(GLEW_VERSION_1_3)
         if (image->getDataType() == io::Image::UCOMPRESSED)
             for (unsigned i = 0; i < mipmaps; i++)
                 glCompressedTexImage2D(target, i, internalFormat, image->getWidth(i), image->getHeight(i), 0,
@@ -272,8 +272,8 @@ void Texture::update()
         break;
 
     case io::Image::TEXTURE_3D:
-#if defined(SOFA_HAVE_GLEW) && defined(GLEW_VERSION_1_2)
-#if defined(SOFA_HAVE_GLEW) && defined(GLEW_VERSION_1_3)
+#if defined(GLEW_VERSION_1_2)
+#if defined(GLEW_VERSION_1_3)
         if (image->getDataType() == io::Image::UCOMPRESSED)
             for (unsigned i = 0; i < mipmaps; i++)
                 glCompressedTexImage3D(target, i, internalFormat, image->getWidth(i), image->getHeight(i),
@@ -287,7 +287,7 @@ void Texture::update()
         break;
 
     case io::Image::TEXTURE_CUBE:
-#if defined(SOFA_HAVE_GLEW) && defined(GLEW_VERSION_1_3)
+#if defined(GLEW_VERSION_1_3)
         if (image->getDataType() == io::Image::UCOMPRESSED)
             for (unsigned j = 0; j < 6; j++)
                 for (unsigned i = 0; i < mipmaps; i++)
@@ -319,7 +319,7 @@ void Texture::init()
         !isPowerOfTwo(image->getHeight()) ||
         (image->getDepth() != 0 && !isPowerOfTwo(image->getDepth())))
     {
-#if defined(SOFA_HAVE_GLEW) && defined(GLEW_VERSION_2_0)
+#if defined(GLEW_VERSION_2_0)
         if (!GLEW_VERSION_2_0)
 #endif
         {
@@ -336,7 +336,7 @@ void Texture::init()
         return;
 
     case io::Image::TEXTURE_3D:
-#if defined(SOFA_HAVE_GLEW) && defined(GLEW_VERSION_1_2)
+#if defined(GLEW_VERSION_1_2)
         if (!GLEW_VERSION_1_2)
 #endif
         {
@@ -346,7 +346,7 @@ void Texture::init()
         break;
 
     case io::Image::TEXTURE_CUBE:
-#if defined(SOFA_HAVE_GLEW) && defined(GLEW_VERSION_1_3)
+#if defined(GLEW_VERSION_1_3)
         if (!GLEW_VERSION_1_3)
 #endif
         {
@@ -363,7 +363,7 @@ void Texture::init()
     case io::Image::UINT32:
         if (image->getChannelFormat() <= io::Image::LA)
         {
-#if defined(SOFA_HAVE_GLEW) && defined(GLEW_EXT_texture_integer)
+#if defined(GLEW_EXT_texture_integer)
             if (!GLEW_EXT_texture_integer)
 #endif
             {
@@ -372,7 +372,7 @@ void Texture::init()
             }
         }
         else
-#if defined(SOFA_HAVE_GLEW) && defined(GLEW_VERSION_3_0)
+#if defined(GLEW_VERSION_3_0)
             if (!GLEW_VERSION_3_0)
 #endif
             {
@@ -382,7 +382,7 @@ void Texture::init()
         break;
 
     case io::Image::HALF:
-#if defined(SOFA_HAVE_GLEW) && defined(GLEW_VERSION_3_0)
+#if defined(GLEW_VERSION_3_0)
         if (!GLEW_VERSION_3_0)
 #endif
         {
@@ -394,7 +394,7 @@ void Texture::init()
     case io::Image::FLOAT:
         if (image->getChannelFormat() <= io::Image::LA)
         {
-#if defined(SOFA_HAVE_GLEW) && defined(GLEW_ARB_texture_float)
+#if defined(GLEW_ARB_texture_float)
             if (!GLEW_ARB_texture_float)
 #endif
             {
@@ -403,7 +403,7 @@ void Texture::init()
             }
         }
         else
-#if defined(SOFA_HAVE_GLEW) && defined(GLEW_VERSION_3_0)
+#if defined(GLEW_VERSION_3_0)
             if (!GLEW_VERSION_3_0)
 #endif
             {
@@ -417,7 +417,7 @@ void Texture::init()
         {
         case io::Image::L:
         case io::Image::LA:
-#if defined(SOFA_HAVE_GLEW) && defined(GLEW_EXT_texture_compression_latc)
+#if defined(GLEW_EXT_texture_compression_latc)
             if (!GLEW_EXT_texture_compression_latc)
 #endif
             {
@@ -428,7 +428,7 @@ void Texture::init()
 
         case io::Image::R:
         case io::Image::RG:
-#if defined(SOFA_HAVE_GLEW) && defined(GLEW_VERSION_3_0)
+#if defined(GLEW_VERSION_3_0)
             if (!GLEW_VERSION_3_0)
 #endif
             {
@@ -439,7 +439,7 @@ void Texture::init()
 
         case io::Image::RGB:
         case io::Image::RGBA:
-#if defined(SOFA_HAVE_GLEW) && defined(GLEW_EXT_texture_compression_s3tc)
+#if defined(GLEW_EXT_texture_compression_s3tc)
             if (!GLEW_EXT_texture_compression_s3tc)
 #endif
             {
@@ -460,7 +460,7 @@ void Texture::init()
     glGenTextures(1, &id); // Create the texture.
     glBindTexture(target, id);
 
-#if defined(SOFA_HAVE_GLEW) && defined(GLEW_VERSION_1_4)
+#if defined(GLEW_VERSION_1_4)
     if (generateMipmaps)
         glTexParameteri(target, GL_GENERATE_MIPMAP, GL_TRUE);
     else
@@ -475,7 +475,7 @@ void Texture::init()
             glTexParameteri(target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
         glTexParameteri(target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
-#if defined(SOFA_HAVE_GLEW) && defined(GLEW_EXT_texture_filter_anisotropic)
+#if defined(GLEW_EXT_texture_filter_anisotropic)
         GLint maxAniso;
         glGetIntegerv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &maxAniso);
         glTexParameteri(target, GL_TEXTURE_MAX_ANISOTROPY_EXT, maxAniso);
@@ -498,7 +498,7 @@ void Texture::init()
     }
     else
     {
-#if defined(SOFA_HAVE_GLEW) && defined(GLEW_VERSION_1_2)
+#if defined(GLEW_VERSION_1_2)
         glTexParameteri( target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
         glTexParameteri( target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
         glTexParameteri( target, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE );
@@ -507,14 +507,14 @@ void Texture::init()
 #endif
     }
 
-#if defined(SOFA_HAVE_GLEW) && defined(GLEW_ARB_seamless_cube_map)
+#if defined(GLEW_ARB_seamless_cube_map)
     // This is a global state so probably should be moved to a more appropriate location.
     if (textureType == io::Image::TEXTURE_CUBE)
         if (GLEW_ARB_seamless_cube_map)
             glEnable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
 #endif
 
-#if defined(SOFA_HAVE_GLEW) && defined(GLEW_VERSION_1_2)
+#if defined(GLEW_VERSION_1_2)
     if ((generateMipmaps || mipmaps > 1))
     {
         glTexParameterf(target, GL_TEXTURE_MIN_LOD, minLod);

--- a/SofaKernel/framework/sofa/helper/gl/Texture.cpp
+++ b/SofaKernel/framework/sofa/helper/gl/Texture.cpp
@@ -494,9 +494,7 @@ void Texture::init()
     {
         glTexParameteri( target, GL_TEXTURE_WRAP_S, GL_REPEAT );
         glTexParameteri( target, GL_TEXTURE_WRAP_T, GL_REPEAT );
-#ifdef SOFA_HAVE_GLEW
         glTexParameteri( target, GL_TEXTURE_WRAP_R, GL_REPEAT );
-#endif // SOFA_HAVE_GLEW
     }
     else
     {

--- a/SofaKernel/framework/sofa/helper/system/gl.h
+++ b/SofaKernel/framework/sofa/helper/system/gl.h
@@ -28,19 +28,7 @@
 #include <sofa/helper/system/config.h>
 #include <string>
 
-#if defined(SOFA_HAVE_GLEW)
 #  include <GL/glew.h>
-#elif defined(__APPLE__)
-#  include <OpenGL/gl.h>
-#else
-#  define GL_GLEXT_PROTOTYPES // for glext.h : necessary to use glBindBuffer without glew and make GLSLShader file
-#  if defined(WIN32)
-#    include <gl/GL.h>
-#  else
-#    include <GL/gl.h>
-#    include <GL/glext.h> // necessary when you don't have glew
-#  endif // WIN32
-#endif
 
 extern SOFA_HELPER_API const char* GetGlExtensionsList();
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaDistanceGridCollisionModel.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaDistanceGridCollisionModel.cpp
@@ -19,9 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifdef SOFA_HAVE_GLEW
 #include <GL/glew.h>
-#endif
 #ifdef SOFA_HAVE_MINIFLOWVR
     #include <flowvr/render/mesh.h>
 #endif // SOFA_HAVE_MINIFLOWVR
@@ -430,7 +428,6 @@ void CudaDistanceGrid::calcCubeDistance(Real dim, int np)
 /// Compute distance field from given mesh
 void CudaDistanceGrid::calcDistance()
 {
-#ifdef SOFA_HAVE_GLEW
 
     if (GLEW_EXT_framebuffer_object && GLEW_ARB_vertex_buffer_object)
     {
@@ -474,10 +471,6 @@ void CudaDistanceGrid::calcDistance()
         std::cerr << "ERROR: Unsupported OpenGL extensions EXT_framebuffer_object ARB_vertex_buffer_object" << std::endl;
     }
 
-#else
-    std::cerr << "ERROR: CudaDistanceGrid::calcDistance requires GLEW to access OpenGL extensions" << std::endl;
-
-#endif
 }
 
 CudaDistanceGrid* CudaDistanceGrid::loadShared(const std::string& filename, double scale, double sampling, int nx, int ny, int nz, Coord pmin, Coord pmax)

--- a/applications/projects/SofaGuiGlut/MultithreadGUI.cpp
+++ b/applications/projects/SofaGuiGlut/MultithreadGUI.cpp
@@ -500,11 +500,9 @@ void MultithreadGUI::initializeGL(void)
         specref[2] = 1.0f;
         specref[3] = 1.0f;
         // Here we initialize our multi-texturing functions
-#ifdef SOFA_HAVE_GLEW
         glewInit();
         if (!GLEW_ARB_multitexture)
             std::cerr << "Error: GL_ARB_multitexture not supported\n";
-#endif
 
         _clearBuffer = GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT;
         _lightModelTwoSides = false;

--- a/applications/projects/SofaGuiGlut/SimpleGUI.cpp
+++ b/applications/projects/SofaGuiGlut/SimpleGUI.cpp
@@ -429,11 +429,9 @@ void SimpleGUI::initializeGL(void)
         specref[2] = 1.0f;
         specref[3] = 1.0f;
         // Here we initialize our multi-texturing functions
-#if defined(SOFA_HAVE_GLEW)
         glewInit();
         if (!GLEW_ARB_multitexture)
             std::cerr << "Error: GL_ARB_multitexture not supported\n";
-#endif
 
         _clearBuffer = GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT;
         _lightModelTwoSides = false;

--- a/applications/projects/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
+++ b/applications/projects/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
@@ -644,9 +644,7 @@ void SofaPhysicsSimulation::drawGL()
 
     if (!initGLDone)
     {
-#ifdef SOFA_HAVE_GLEW
         glewInit();
-#endif
         //Load texture for logo
         std::string imageFileName = "textures/SOFA_logo.bmp";
         if (sofa::helper::system::DataRepository.findFile(imageFileName))

--- a/applications/sofa/gui/PickHandler.cpp
+++ b/applications/sofa/gui/PickHandler.cpp
@@ -100,7 +100,6 @@ void PickHandler::allocateSelectionBuffer(int width, int height)
     static bool firstTime=true;
     if (firstTime)
     {
-#if defined (SOFA_HAVE_GLEW)
         _fboParams.depthInternalformat = GL_DEPTH_COMPONENT24;
 #if defined(GL_VERSION_3_0)
         if (GLEW_VERSION_3_0)
@@ -116,12 +115,9 @@ void PickHandler::allocateSelectionBuffer(int width, int height)
         _fboParams.colorType           = GL_FLOAT;
 
         _fbo.setFormat(_fboParams);
-#endif //  (SOFA_HAVE_GLEW)
         firstTime=false;
     }
-#if defined (SOFA_HAVE_GLEW)
     _fbo.init(width,height);
-#endif //  (SOFA_HAVE_GLEW)
 #endif /* SOFA_NO_OPENGL */
     _fboAllocated = true;
 }
@@ -131,9 +127,7 @@ void PickHandler::destroySelectionBuffer()
     /*called when shift key is released */
     assert(_fboAllocated);
 #ifndef SOFA_NO_OPENGL
-#ifdef SOFA_HAVE_GLEW
     _fbo.destroy();
-#endif // SOFA_HAVE_GLEW
 #endif // SOFA_NO_OPENGL
     _fboAllocated = false;
 }
@@ -520,7 +514,6 @@ component::collision::BodyPicked PickHandler::findCollisionUsingColourCoding(con
     int y = mousePosition.screenHeight - mousePosition.y;
     TriangleModel* tmodel;
     SphereModel* smodel;
-#ifdef SOFA_HAVE_GLEW
     _fbo.start();
     if(renderCallback)
     {
@@ -540,7 +533,6 @@ component::collision::BodyPicked PickHandler::findCollisionUsingColourCoding(con
         result.rayLength = (result.point-origin)*direction;
     }
     _fbo.stop();
-#endif // SOFA_HAVE_GLEW
 #endif // SOFA_NO_OPENGL
     return result;
 }

--- a/applications/sofa/gui/PickHandler.h
+++ b/applications/sofa/gui/PickHandler.h
@@ -139,10 +139,8 @@ protected:
     MousePosition             mousePosition;
 
 #ifndef SOFA_NO_OPENGL
-#ifdef SOFA_HAVE_GLEW // because FrameBufferObject is defined only for this case
     sofa::helper::gl::FrameBufferObject _fbo;
     sofa::helper::gl::fboParameters     _fboParams;
-#endif /* SOFA_HAVE_GLEW */
 #endif /* SOFA_NO_OPENGL */
 
     ComponentMouseInteraction *interaction;

--- a/applications/sofa/gui/qt/viewer/qgl/QtGLViewer.cpp
+++ b/applications/sofa/gui/qt/viewer/qgl/QtGLViewer.cpp
@@ -200,9 +200,7 @@ void QtGLViewer::init(void)
         specref[3] = 1.0f;
 
         // Here we initialize our multi-texturing functions
-#ifdef SOFA_HAVE_GLEW
         glewInit();
-#endif
 
         _clearBuffer = GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT;
         _lightModelTwoSides = false;

--- a/applications/sofa/gui/qt/viewer/qt/QtViewer.cpp
+++ b/applications/sofa/gui/qt/viewer/qt/QtViewer.cpp
@@ -281,11 +281,9 @@ void QtViewer::initializeGL(void)
         specref[3] = 1.0f;
 
         // Here we initialize our multi-texturing functions
-#ifdef SOFA_HAVE_GLEW
         glewInit();
         if (!GLEW_ARB_multitexture)
             msg_error("QtViewer") << "GL_ARB_multitexture not supported.";
-#endif
 
         _clearBuffer = GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT;
         _lightModelTwoSides = false;

--- a/applications/sofa/gui/qt/viewer/qt/QtViewer.cpp
+++ b/applications/sofa/gui/qt/viewer/qt/QtViewer.cpp
@@ -282,7 +282,7 @@ void QtViewer::initializeGL(void)
 
         // Here we initialize our multi-texturing functions
         glewInit();
-        if (!GLEW_ARB_multitexture)
+        if (!GL_ARB_multitexture)
             msg_error("QtViewer") << "GL_ARB_multitexture not supported.";
 
         _clearBuffer = GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT;

--- a/modules/SofaOpenglVisual/CompositingVisualLoop.cpp
+++ b/modules/SofaOpenglVisual/CompositingVisualLoop.cpp
@@ -111,7 +111,6 @@ void CompositingVisualLoop::drawStep(sofa::core::visual::VisualParams* vparams)
     //rendering sequence: call each VisualManagerPass elements, then composite the frames
     else
     {
-#ifdef SOFA_HAVE_GLEW
         if (renderingState == sofa::core::visual::tristate::false_value || renderingState == sofa::core::visual::tristate::neutral_value) return;
 
         sofa::simulation::Node::Sequence<core::visual::VisualManager>::iterator begin = gRoot->visualManager.begin(), end = gRoot->visualManager.end(), it;
@@ -155,7 +154,6 @@ void CompositingVisualLoop::drawStep(sofa::core::visual::VisualParams* vparams)
         glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, 0);
         glBindBufferARB(GL_ARRAY_BUFFER, 0);
         //glViewport(vparams->viewport()[0],vparams->viewport()[1],vparams->viewport()[2],vparams->viewport()[3]);
-#endif
     }
 }
 

--- a/modules/SofaOpenglVisual/CompositingVisualLoop.h
+++ b/modules/SofaOpenglVisual/CompositingVisualLoop.h
@@ -33,10 +33,8 @@
 #include <sofa/simulation/DefaultVisualManagerLoop.h>
 #include <sofa/core/visual/VisualParams.h>
 
-#ifdef SOFA_HAVE_GLEW
 #include <SofaOpenglVisual/OglShader.h>
 #include <SofaOpenglVisual/VisualManagerPass.h>
-#endif
 
 #include <sofa/core/objectmodel/DataFileName.h>
 #include <sofa/core/objectmodel/Event.h>

--- a/modules/SofaOpenglVisual/Light.cpp
+++ b/modules/SofaOpenglVisual/Light.cpp
@@ -67,13 +67,11 @@ int SpotLightClass = core::RegisterObject("A spot light illuminating the scene."
 
 using sofa::defaulttype::Vector3;
 
-#ifdef SOFA_HAVE_GLEW
 const std::string Light::PATH_TO_GENERATE_DEPTH_TEXTURE_VERTEX_SHADER = "shaders/softShadows/VSM/generate_depth_texture.vert";
 const std::string Light::PATH_TO_GENERATE_DEPTH_TEXTURE_FRAGMENT_SHADER = "shaders/softShadows/VSM/generate_depth_texture.frag";
 
 const std::string Light::PATH_TO_BLUR_TEXTURE_VERTEX_SHADER = "shaders/softShadows/VSM/blur_texture.vert";
 const std::string Light::PATH_TO_BLUR_TEXTURE_FRAGMENT_SHADER = "shaders/softShadows/VSM/blur_texture.frag";
-#endif
 
 Light::Light()
     : m_lightID(0), m_shadowTexWidth(0),m_shadowTexHeight(0)
@@ -208,7 +206,6 @@ void Light::initVisual()
     computeShadowMapSize();
     //Shadow part
     //Shadow texture init
-#ifdef SOFA_HAVE_GLEW
     m_shadowFBO = std::unique_ptr<helper::gl::FrameBufferObject>(
                 new helper::gl::FrameBufferObject(true, true, true));
     m_blurHFBO = std::unique_ptr<helper::gl::FrameBufferObject>(
@@ -229,7 +226,6 @@ void Light::initVisual()
     m_blurShader->fragFilename.addPath(PATH_TO_BLUR_TEXTURE_FRAGMENT_SHADER,true);
     m_blurShader->init();
     m_blurShader->initVisual();
-#endif // SOFA_HAVE_GLEW
 }
 
 void Light::updateVisual()
@@ -266,14 +262,12 @@ void Light::preDrawShadow(core::visual::VisualParams* /* vp */)
     glMatrixMode(GL_MODELVIEW);
     glPushMatrix();
 
-#ifdef SOFA_HAVE_GLEW
     m_depthShader->setFloat(0, "u_zFar", this->getZFar());
     m_depthShader->setFloat(0, "u_zNear", this->getZNear());
     m_depthShader->setInt(0, "u_lightType", this->getLightType());
     m_depthShader->setFloat(0, "u_shadowFactor", d_shadowFactor.getValue());
     m_depthShader->start();
     m_shadowFBO->start();
-#endif
 }
 
 
@@ -291,11 +285,9 @@ const GLfloat* Light::getOpenGLModelViewMatrix()
 
 void Light::postDrawShadow()
 {
-#ifdef SOFA_HAVE_GLEW
     //Unbind fbo
     m_shadowFBO->stop();
     m_depthShader->stop();
-#endif
 
     glMatrixMode(GL_PROJECTION);
     glPopMatrix();
@@ -308,7 +300,6 @@ void Light::postDrawShadow()
 
 void Light::blurDepthTexture()
 {
-#ifdef SOFA_HAVE_GLEW
     float vxmax, vymax;
     float vxmin, vymin;
     float txmax, tymax;
@@ -372,7 +363,6 @@ void Light::blurDepthTexture()
     glPopMatrix();
     glMatrixMode(GL_MODELVIEW);
     glPopMatrix();
-#endif
 }
 
 void Light::computeShadowMapSize()
@@ -615,23 +605,15 @@ GLuint DirectionalLight::getDepthTexture()
 {
     //return debugVisualShadowTexture;
     //return shadowTexture;
-#ifdef SOFA_HAVE_GLEW
     return m_shadowFBO->getDepthTexture();
-#else
-    return 0;
-#endif
 }
 
 GLuint DirectionalLight::getColorTexture()
 {
-#ifdef SOFA_HAVE_GLEW
     if (d_softShadows.getValue())
         return m_blurVFBO->getColorTexture();
     else
         return m_shadowFBO->getColorTexture();
-#else
-    return 0;
-#endif
 }
 
 PositionalLight::PositionalLight()
@@ -1003,23 +985,15 @@ void SpotLight::computeOpenGLProjectionMatrix(GLfloat mat[16], float width, floa
 
 GLuint SpotLight::getDepthTexture()
 {
-#ifdef SOFA_HAVE_GLEW
     return m_shadowFBO->getDepthTexture();
-#else
-    return 0;
-#endif
 }
 
 GLuint SpotLight::getColorTexture()
 {
-#ifdef SOFA_HAVE_GLEW
     if(d_softShadows.getValue())
         return m_blurVFBO->getColorTexture();
     else
         return m_shadowFBO->getColorTexture();
-#else
-    return 0;
-#endif
 }
 
 }

--- a/modules/SofaOpenglVisual/Light.h
+++ b/modules/SofaOpenglVisual/Light.h
@@ -30,10 +30,8 @@
 #include <sofa/helper/gl/template.h>
 #include <sofa/core/visual/VisualModel.h>
 
-#ifdef SOFA_HAVE_GLEW
 #include <sofa/helper/gl/FrameBufferObject.h>
 #include <SofaOpenglVisual/OglShader.h>
-#endif
 
 namespace sofa
 {
@@ -65,7 +63,6 @@ protected:
     GLint m_lightID;
     GLuint m_shadowTexWidth, m_shadowTexHeight;
 
-#ifdef SOFA_HAVE_GLEW
     std::unique_ptr<helper::gl::FrameBufferObject> m_shadowFBO;
     std::unique_ptr<helper::gl::FrameBufferObject> m_blurHFBO;
     std::unique_ptr<helper::gl::FrameBufferObject> m_blurVFBO;
@@ -75,7 +72,6 @@ protected:
     static const std::string PATH_TO_BLUR_TEXTURE_FRAGMENT_SHADER;
     OglShader::SPtr m_depthShader;
     OglShader::SPtr m_blurShader;
-#endif
     GLfloat m_lightMatProj[16];
     GLfloat m_lightMatModelview[16];
 

--- a/modules/SofaOpenglVisual/LightManager.cpp
+++ b/modules/SofaOpenglVisual/LightManager.cpp
@@ -32,10 +32,8 @@ using sofa::core::visual::VisualParams ;
 #include <sofa/core/objectmodel/KeypressedEvent.h>
 #include <sofa/core/objectmodel/KeyreleasedEvent.h>
 
-#ifdef SOFA_HAVE_GLEW
 #include <SofaOpenglVisual/OglTexture.h>
 using sofa::component::visualmodel::OglTexture ;
-#endif // SOFA_HAVE_GLEW
 
 using sofa::core::objectmodel::BaseContext ;
 using sofa::core::RegisterObject ;
@@ -83,7 +81,6 @@ LightManager::~LightManager()
 void LightManager::init()
 {
     BaseContext* context = this->getContext();
-#ifdef SOFA_HAVE_GLEW
     context->get<OglShadowShader, helper::vector<OglShadowShader::SPtr> >(&m_shadowShaders, BaseContext::SearchRoot);
 
     if (m_shadowShaders.empty() && d_shadowsEnabled.getValue())
@@ -97,23 +94,19 @@ void LightManager::init()
         m_shadowShaders[i]->initShaders((unsigned int)m_lights.size(), d_softShadowsEnabled.getValue());
         m_shadowShaders[i]->setCurrentIndex(d_shadowsEnabled.getValue() ? 1 : 0);
     }
-#endif
     m_lightModelViewMatrix.resize(m_lights.size());
 }
 
 void LightManager::bwdInit()
 {
-#ifdef SOFA_HAVE_GLEW
     for(unsigned int i=0 ; i<m_shadowShaders.size() ; ++i)
     {
         m_shadowShaders[i]->setCurrentIndex(d_shadowsEnabled.getValue() ? 1 : 0);
     }
-#endif
 }
 
 void LightManager::initVisual()
 {
-#ifdef SOFA_HAVE_GLEW
     for(unsigned int i=0 ; i<m_shadowShaders.size() ; ++i)
         m_shadowShaders[i]->initVisual();
 
@@ -161,7 +154,6 @@ void LightManager::initVisual()
         }
     }
 
-#endif // SOFA_HAVE_GLEW
 }
 
 void LightManager::putLight(Light::SPtr light)
@@ -228,7 +220,6 @@ void LightManager::fwdDraw(core::visual::VisualParams* vp)
         ++id;
     }
 
-#ifdef SOFA_HAVE_GLEW
     const core::visual::VisualParams::Pass pass = vp->pass();
     GLint lightFlags[MAX_NUMBER_OF_LIGHTS];
     GLint lightTypes[MAX_NUMBER_OF_LIGHTS];
@@ -333,12 +324,10 @@ void LightManager::fwdDraw(core::visual::VisualParams* vp)
     }
 
     glActiveTexture(GL_TEXTURE0);
-#endif
 }
 
 void LightManager::bwdDraw(core::visual::VisualParams* )
 {
-#ifdef SOFA_HAVE_GLEW
     for(unsigned int i=0 ; i<m_lights.size() ; ++i)
     {
         unsigned short shadowTextureUnit = m_lights[i]->getShadowTextureUnit();
@@ -348,7 +337,6 @@ void LightManager::bwdDraw(core::visual::VisualParams* )
     }
 
     glActiveTexture(GL_TEXTURE0);
-#endif // SOFA_HAVE_GLEW
 
     for (unsigned int i=0 ; i<MAX_NUMBER_OF_LIGHTS ; ++i)
         glDisable(GL_LIGHT0+i);
@@ -425,7 +413,6 @@ void LightManager::reinit()
 
 void LightManager::preDrawScene(VisualParams* vp)
 {
-#ifdef SOFA_HAVE_GLEW
     if(d_shadowsEnabled.getValue())
     {
         for (std::vector<Light::SPtr>::iterator itl = m_lights.begin(); itl != m_lights.end() ; ++itl)
@@ -442,7 +429,6 @@ void LightManager::preDrawScene(VisualParams* vp)
         //restore viewport
         glViewport(viewport[0], viewport[1], viewport[2] , viewport[3]);
     }
-#endif
 }
 
 bool LightManager::drawScene(VisualParams* /*vp*/)
@@ -513,7 +499,6 @@ void LightManager::handleEvent(sofa::core::objectmodel::Event* event)
 
         case 'l':
         case 'L':
-#ifdef SOFA_HAVE_GLEW
             if (!m_shadowShaders.empty())
             {
                 bool b = d_shadowsEnabled.getValue();
@@ -534,7 +519,6 @@ void LightManager::handleEvent(sofa::core::objectmodel::Event* event)
 
                 sout << "Shadows : "<<(d_shadowsEnabled.getValue()?"ENABLED":"DISABLED")<<sendl;
             }
-#endif
             break;
         }
     }

--- a/modules/SofaOpenglVisual/LightManager.cpp
+++ b/modules/SofaOpenglVisual/LightManager.cpp
@@ -51,10 +51,6 @@ namespace component
 namespace visualmodel
 {
 
-
-//TODO(dmarchal): There is a large amount of #ifdef SOFA_HAVE_GLEW why ? Too much #ifdef is
-//a sign it is time to refactor the code.
-
 //Register LightManager in the Object Factory
 int LightManagerClass = RegisterObject
         ("Manage a set of lights that can cast hard and soft shadows.Soft Shadows is done using Variance Shadow Mapping "

--- a/modules/SofaOpenglVisual/LightManager.h
+++ b/modules/SofaOpenglVisual/LightManager.h
@@ -30,9 +30,7 @@
 #include <sofa/defaulttype/Mat.h>
 #include <sofa/helper/types/RGBAColor.h>
 
-#ifdef SOFA_HAVE_GLEW
 #include <SofaOpenglVisual/OglShadowShader.h>
-#endif
 
 namespace sofa
 {
@@ -61,10 +59,8 @@ private:
     std::vector<defaulttype::Mat4x4f> m_lightProjectionMatrix;
     std::vector<unsigned short>       m_mapShadowTextureUnit;
 
-#ifdef SOFA_HAVE_GLEW
     //OglShadowShader* shadowShader;
     helper::vector<OglShadowShader::SPtr> m_shadowShaders;
-#endif
     void makeShadowMatrix(unsigned int i);
 
 public:

--- a/modules/SofaOpenglVisual/OglColorMap.cpp
+++ b/modules/SofaOpenglVisual/OglColorMap.cpp
@@ -25,9 +25,7 @@
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/visual/VisualParams.h>
 
-#ifdef SOFA_HAVE_GLEW
 #include <sofa/helper/gl/GLSLShader.h>
-#endif // SOFA_HAVE_GLEW
 
 #include <string>
 #include <iostream>
@@ -204,7 +202,6 @@ void OglColorMap::drawVisual(const core::visual::VisualParams* vparams)
     glPushMatrix();
     glLoadIdentity();
 
-#ifdef SOFA_HAVE_GLEW
     for(int i = 0; i < 8; ++i)
     {
         glActiveTexture(GL_TEXTURE0 + i);
@@ -220,7 +217,6 @@ void OglColorMap::drawVisual(const core::visual::VisualParams* vparams)
 
     GLhandleARB currentShader = sofa::helper::gl::GLSLShader::GetActiveShaderProgram();
     sofa::helper::gl::GLSLShader::SetActiveShaderProgram(0);
-#endif // SOFA_HAVE_GLEW
 
     glBegin(GL_QUADS);
 
@@ -289,9 +285,7 @@ void OglColorMap::drawVisual(const core::visual::VisualParams* vparams)
                                           textcolor,
                                           smin.str().c_str());
 
-#ifdef SOFA_HAVE_GLEW
     sofa::helper::gl::GLSLShader::SetActiveShaderProgram(currentShader);
-#endif // SOFA_HAVE_GLEW
 
     // Restore state
     glPopAttrib();

--- a/modules/SofaOpenglVisual/OglRenderingSRGB.cpp
+++ b/modules/SofaOpenglVisual/OglRenderingSRGB.cpp
@@ -55,7 +55,6 @@ int OglRenderingSRGBClass = core::RegisterObject("OglRenderingSRGB")
 void OglRenderingSRGB::fwdDraw(core::visual::VisualParams* /*vp*/)
 {
 #if defined(GL_FRAMEBUFFER_SRGB)
-//    if (GLEW_ARB_framebuffer_sRGB)
     glEnable(GL_FRAMEBUFFER_SRGB);
 #endif
 }
@@ -63,7 +62,6 @@ void OglRenderingSRGB::fwdDraw(core::visual::VisualParams* /*vp*/)
 void OglRenderingSRGB::bwdDraw(core::visual::VisualParams* /*vp*/)
 {
 #if defined(GL_FRAMEBUFFER_SRGB)
-//    if (GLEW_ARB_framebuffer_sRGB)
     glDisable(GL_FRAMEBUFFER_SRGB);
 #endif
 }

--- a/modules/SofaOpenglVisual/OglShader.cpp
+++ b/modules/SofaOpenglVisual/OglShader.cpp
@@ -285,7 +285,7 @@ void OglShader::start()
             glClampColorARB(GL_CLAMP_VERTEX_COLOR, GL_FALSE);
         if ( backfaceWriting.getValue() )
             glEnable(GL_VERTEX_PROGRAM_TWO_SIDE);
-#if defined(SOFA_HAVE_GLEW) && defined(GL_TESS_CONTROL_SHADER)
+#if defined(GL_TESS_CONTROL_SHADER)
         if (shaderVector[indexActiveShader.getValue()]->GetTessellationEvaluationShaderID() && !shaderVector[indexActiveShader.getValue()]->GetTessellationControlShaderID() && GLEW_ARB_tessellation_shader)
         {
             helper::fixed_array<GLfloat,4> levels;

--- a/modules/SofaOpenglVisual/SlicedVolumetricModel.cpp
+++ b/modules/SofaOpenglVisual/SlicedVolumetricModel.cpp
@@ -155,9 +155,7 @@ void SlicedVolumetricModel::drawTransparent(const core::visual::VisualParams* vp
 
         _first = false;
 
-#if defined(SOFA_HAVE_GLEW)
         glewInit();
-#endif
         glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
 
         // request 1 texture name from OpenGL

--- a/modules/SofaOpenglVisual/initOpenGLVisual.cpp
+++ b/modules/SofaOpenglVisual/initOpenGLVisual.cpp
@@ -39,8 +39,6 @@ void initOpenGLVisual()
     }
 }
 
-#ifdef SOFA_HAVE_GLEW
-#endif
 
 
 } // namespace component


### PR DESCRIPTION

Because #ifdef based software architecture is just bad. If you don't understand why...please ask.


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
