### PR TITLE
Remove unjustified Assert in getSimulation()

### DIFF
--- a/SofaKernel/framework/sofa/simulation/Simulation.cpp
+++ b/SofaKernel/framework/sofa/simulation/Simulation.cpp
@@ -95,9 +95,6 @@ void setSimulation ( Simulation* s )
 
 Simulation* getSimulation()
 {
-    //TODO(damien):  replace that with an assert system that use the messaging API.
-    assert(Simulation::theSimulation.get()!=NULL && "There is no simulation initialized.") ;
-
     return Simulation::theSimulation.get();
 }
 


### PR DESCRIPTION
This assert is annoying:
In a better world, a singleton should never return null in the first place, so getSimulation() should create the simulation if it doesn't exist. but then in a better world, the Simulation class would not be a singleton in the first place..
Meanwhile, this assert prevents us from coding things like this:

```cpp
    if(!sofa::simulation::getSimulation())
        sofa::simulation::setSimulation(new DAGSimulation());
```
And that's a problem to initialize the Simulation singleton, because without the test, it would be recreated all the time.
So I vote for removing it entirely.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
