### PR TITLE
ADD: static method to retrieve the count number of all Events

### DIFF
--- a/SofaKernel/framework/sofa/core/objectmodel/Event.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/Event.h
@@ -78,6 +78,7 @@ public:
     /// Should be implemented by using macros SOFA_EVENT_H / SOFA_EVENT_CPP
     virtual size_t getEventTypeIndex() const = 0;
 
+    /// \returns the total number of events available in SOFA
     static size_t getEventTypeCount() { return s_lastEventTypeIndex; }
 protected:
     bool m_handled;

--- a/SofaKernel/framework/sofa/core/objectmodel/Event.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/Event.h
@@ -78,6 +78,7 @@ public:
     /// Should be implemented by using macros SOFA_EVENT_H / SOFA_EVENT_CPP
     virtual size_t getEventTypeIndex() const = 0;
 
+    static size_t getEventTypeCount() { return s_lastEventTypeIndex; }
 protected:
     bool m_handled;
 


### PR DESCRIPTION

A micro PR to add a method that allows me to retrieve the count of all SOFA Events.
I need this to manipulate the Event UIDs as enum values & initialize a vector of Event bindings  in SofaPython3 


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
