### PR TITLE
ADD: DataTypeInfo for Data type BoundingBox

### DIFF
--- a/SofaKernel/framework/sofa/defaulttype/BoundingBox.h
+++ b/SofaKernel/framework/sofa/defaulttype/BoundingBox.h
@@ -250,6 +250,11 @@ protected:
     bbox_t bbox;
 };
 
+template <>
+struct DataTypeName<BoundingBox>
+{
+  static const char *name() { return "BoundingBox"; }
+};
 
 }
 }


### PR DESCRIPTION
While implementing a binding factory for Data types in SofaPython3, I realised there's no DataTypeName for the BoundingBox data type in Sofa... So here we have it



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
