### PR TITLE
[SofaGuiQt] FIX tooltips segfault

### DIFF
--- a/applications/sofa/gui/qt/QDisplayDataWidget.cpp
+++ b/applications/sofa/gui/qt/QDisplayDataWidget.cpp
@@ -63,11 +63,15 @@ QDisplayDataWidget::QDisplayDataWidget(QWidget* parent,
     if(data_ == nullptr)
         return;
 
+    const char* help = data_->getHelp();
     const std::string valuetype = data_->getValueTypeString();
+    const char* ownerClass = data_->getOwnerClass();
     std::stringstream s;
 
-    s << data_->getHelp()<< "\nData type: " << valuetype
-                         << "\nOwner: "<<data_->getOwnerClass() ;
+    s << (help ? help : "< No help found >")
+      << "\nData type: " << valuetype
+      << "\nOwner: " << (ownerClass ? ownerClass : "< No owner found >");
+
     const std::string fullHelpText = s.str();
     setToolTip(fullHelpText.c_str());
     datainfowidget_ = new QDisplayDataInfoWidget(this,fullHelpText,data_,


### PR DESCRIPTION
There was a segfault when opening MechanicalObject properties in runSofa at least with caduceus.scn
Thanks @remibessard for spotting it :+1: 

Details:
For a reason I don't know, there is a Datafield named "dforce(V_DERIV)" in MechanicalObject that has **no help message**. Thus, when opening MechanicalObject properties, QDisplayDataWidget's constructor runs `data_->getHelp()` which returns nullptr provoking a segfault when used in stringstream creation right after.

Bug introduced by 48395d837474beb67ca4d9721ebb8b7361089fe3

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
