### PR TITLE
Corrected the CMakeLists because the build of the tests is not always…

### DIFF
--- a/modules/SofaOpenglVisual/CMakeLists.txt
+++ b/modules/SofaOpenglVisual/CMakeLists.txt
@@ -90,4 +90,6 @@ sofa_generate_package(NAME ${PROJECT_NAME}
     TARGETS ${PROJECT_NAME}
     INCLUDE_INSTALL_DIR ${PROJECT_NAME})
 
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/SofaOpenglVisual_test tests/SofaOpenglVisual)
+if(SOFAGUI_BUILD_TESTS)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/SofaOpenglVisual_test tests/SofaOpenglVisual)
+endif()


### PR DESCRIPTION
The modules/SofaOpenglVisual/CMakeLists.txt has been changed because it always tried to generate the tests even if SOFAGUI_BUILD_TEST is set false. It makes the compilation fail. 






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
