### PR TITLE
[SofaExporter] Move bindings from SofaPython

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,17 +222,17 @@ add_subdirectory(SofaGeneral)
 add_subdirectory(SofaAdvanced)
 add_subdirectory(SofaMisc)
 
-## Modules
-## in the consortium convention a module is a similar to a plugin the difference is that
-## a module is hosted and managed by the consortium while plugins are hosted and managed by third parties.
-add_subdirectory(modules)
-
 # This is all the applications GUI stuff. As there is a dependency to this one
 # In scene creator and SofaPython...it is located here.
 add_subdirectory(SofaGui)
 
-# SofaTest depends on SofaPython, so we add SofaPython before SofaTest.
+# SofaTest, modules depend on SofaPython, so we add SofaPython before.
 sofa_add_plugin( applications/plugins/SofaPython SofaPython )
+
+## Modules
+## in the consortium convention a module is a similar to a plugin the difference is that
+## a module is hosted and managed by the consortium while plugins are hosted and managed by third parties.
+add_subdirectory(modules)
 
 ## Scene creator option
 option(SOFA_BUILD_SCENECREATOR "Compile the C++ API located in applications/plugins/SceneCreator" OFF)

--- a/applications/plugins/SofaPython/Binding.cpp
+++ b/applications/plugins/SofaPython/Binding.cpp
@@ -58,8 +58,6 @@
 #include "Binding_SparseGridTopology.h"
 #include "Binding_SubsetMultiMapping.h"
 #include "Binding_VisualModel.h"
-#include "Binding_OBJExporter.h"
-#include "Binding_STLExporter.h"
 #include "Binding_DataEngine.h"
 #include "PythonFactory.h"
 
@@ -121,8 +119,6 @@ void bindSofaPythonModule(PyObject * module)
     SP_ADD_CLASS_IN_FACTORY(GridTopology,sofa::component::topology::GridTopology)
     SP_ADD_CLASS_IN_FACTORY(SparseGridTopology,sofa::component::topology::SparseGridTopology)
     SP_ADD_CLASS_IN_FACTORY(RegularGridTopology,sofa::component::topology::RegularGridTopology)
-    SP_ADD_CLASS_IN_FACTORY(OBJExporter,sofa::component::misc::OBJExporter)
-    SP_ADD_CLASS_IN_FACTORY(STLExporter,sofa::component::misc::STLExporter)
     SP_ADD_CLASS_IN_FACTORY(PythonScriptController,sofa::component::controller::PythonScriptController)
     SP_ADD_CLASS_IN_FACTORY(PythonScriptDataEngine,sofa::component::controller::PythonScriptDataEngine)
     SP_ADD_CLASS_IN_FACTORY(PointSetTopologyModifier,sofa::component::topology::PointSetTopologyModifier)

--- a/applications/plugins/SofaPython/CMakeLists.txt
+++ b/applications/plugins/SofaPython/CMakeLists.txt
@@ -170,7 +170,6 @@ endif()
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${PYTHON_FILES})
 
-target_compile_definitions(${PROJECT_NAME} PRIVATE  "${SOFAPYTHON_COMPILER_FLAGS}")
 target_compile_definitions(${PROJECT_NAME} PUBLIC "-DSOFA_HAVE_SOFAPYTHON")
 
 target_include_directories(${PROJECT_NAME}
@@ -188,6 +187,7 @@ endif()
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>")
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>")
 target_include_directories(${PROJECT_NAME} PUBLIC "$<INSTALL_INTERFACE:include>")
+set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "${SOFAPYTHON_COMPILER_FLAGS}")
 set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${HEADER_FILES}")
 
 ## Install rules for the library and headers; CMake package configurations files

--- a/applications/plugins/SofaPython/CMakeLists.txt
+++ b/applications/plugins/SofaPython/CMakeLists.txt
@@ -38,8 +38,6 @@ set(HEADER_FILES
     Binding_MeshTopology.h
     Binding_MultiMapping.h
     Binding_Node.h
-    Binding_OBJExporter.h
-    Binding_STLExporter.h
     Binding_PythonScriptController.h
     Binding_PythonScriptDataEngine.h
     Binding_RegularGridTopology.h
@@ -100,8 +98,6 @@ set(SOURCE_FILES
     Binding_MeshTopology.cpp
     Binding_MultiMapping.cpp
     Binding_Node.cpp
-    Binding_OBJExporter.cpp
-    Binding_STLExporter.cpp
     Binding_PythonScriptController.cpp
     Binding_PythonScriptDataEngine.cpp
     Binding_RegularGridTopology.cpp
@@ -151,19 +147,6 @@ find_package(PythonLibs 2.7 REQUIRED)
 find_package(SofaGui REQUIRED)
 find_package(SofaGeneral REQUIRED)
 find_package(SofaMisc REQUIRED)
-find_package(SofaExporter)
-
-if(SofaExporter_FOUND)
-    list(APPEND SOURCE_FILES
-        Binding_OBJExporter.cpp
-        Binding_STLExporter.cpp
-        )
-
-    list(APPEND HEADER_FILES
-        Binding_OBJExporter.h
-        Binding_STLExporter.h
-        )
-endif()
 
 GET_FILENAME_COMPONENT(LIBRARY_NAME ${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX} NAME_WE)
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -194,7 +177,7 @@ target_include_directories(${PROJECT_NAME}
     )
 
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaSimulationCommon SofaUserInteraction SofaGuiCommon SofaComponentMisc SofaComponentGeneral ${PYTHON_LIBRARIES})
-target_link_libraries(${PROJECT_NAME} PRIVATE SofaExporter)
+
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     # dlopen() is used on Linux for a workaround (see PythonEnvironnement.cpp)
     target_link_libraries(${PROJECT_NAME} PRIVATE dl)

--- a/applications/plugins/SofaPython/CMakeLists.txt
+++ b/applications/plugins/SofaPython/CMakeLists.txt
@@ -188,7 +188,6 @@ endif()
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>")
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>")
 target_include_directories(${PROJECT_NAME} PUBLIC "$<INSTALL_INTERFACE:include>")
-set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "${SOFAPYTHON_COMPILER_FLAGS}")
 set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${HEADER_FILES}")
 
 ## Install rules for the library and headers; CMake package configurations files

--- a/applications/plugins/SofaPython/CMakeLists.txt
+++ b/applications/plugins/SofaPython/CMakeLists.txt
@@ -170,6 +170,9 @@ endif()
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${PYTHON_FILES})
 
+target_compile_definitions(${PROJECT_NAME} PRIVATE  "${SOFAPYTHON_COMPILER_FLAGS}")
+target_compile_definitions(${PROJECT_NAME} PUBLIC "-DSOFA_HAVE_SOFAPYTHON")
+
 target_include_directories(${PROJECT_NAME}
     PUBLIC ${PYTHON_INCLUDE_DIRS}
     PUBLIC "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/>"

--- a/modules/SofaExporter/CMakeLists.txt
+++ b/modules/SofaExporter/CMakeLists.txt
@@ -42,8 +42,25 @@ list(APPEND SOURCE_FILES
     src/SofaExporter/WriteTopology.cpp
     )
 
+find_package(SofaPython QUIET)
+if(SofaPython_FOUND)
+    list(APPEND HEADER_FILES
+        src/SofaExporter/bindings/Binding_OBJExporter.h
+        src/SofaExporter/bindings/Binding_STLExporter.h
+    )
+    list(APPEND SOURCE_FILES
+        src/SofaExporter/bindings/Binding_OBJExporter.cpp
+        src/SofaExporter/bindings/Binding_STLExporter.cpp
+    )
+else()
+    message(STATUS "SofaPython disabled, will not compile python bindings.")
+endif()
+
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${EXTRA_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaSimulationTree)
+if(SofaPython_FOUND)
+target_link_libraries(${PROJECT_NAME} PRIVATE SofaPython)
+endif()
 target_compile_definitions(${PROJECT_NAME} PRIVATE "-DSOFA_BUILD_EXPORTER")
 target_compile_definitions(${PROJECT_NAME} PUBLIC "-DSOFA_HAVE_SOFAEXPORTER")
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>")

--- a/modules/SofaExporter/src/SofaExporter/bindings/Binding_OBJExporter.cpp
+++ b/modules/SofaExporter/src/SofaExporter/bindings/Binding_OBJExporter.cpp
@@ -19,13 +19,34 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef BINDING_OBJEXPORTER_H
-#define BINDING_OBJEXPORTER_H
 
-#include "PythonMacros.h"
 
-#include <SofaExporter/OBJExporter.h>
+#include "Binding_OBJExporter.h"
+#include <SofaPython/Binding_BaseObject.h>
+#include <SofaPython/PythonToSofa.inl>
 
-SP_DECLARE_CLASS_TYPE(OBJExporter)
+using namespace sofa::component::misc;
+using namespace sofa::core::objectmodel;
 
-#endif
+
+/// getting a OBJExporter* from a PyObject*
+static inline OBJExporter* get_OBJExporter(PyObject* obj) {
+    return sofa::py::unwrap<OBJExporter>(obj);
+}
+
+
+static PyObject * OBJExporter_writeOBJ(PyObject *self, PyObject * /*args*/)
+{
+    OBJExporter* obj = get_OBJExporter( self );
+    return PyBool_FromLong( obj->writeOBJ() ) ;
+}
+
+
+SP_CLASS_METHODS_BEGIN(OBJExporter)
+SP_CLASS_METHOD(OBJExporter,writeOBJ)
+SP_CLASS_METHODS_END
+
+
+SP_CLASS_TYPE_SPTR(OBJExporter,OBJExporter,BaseObject)
+
+

--- a/modules/SofaExporter/src/SofaExporter/bindings/Binding_OBJExporter.h
+++ b/modules/SofaExporter/src/SofaExporter/bindings/Binding_OBJExporter.h
@@ -19,41 +19,13 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#ifndef BINDING_OBJEXPORTER_H
+#define BINDING_OBJEXPORTER_H
 
+#include <SofaPython/PythonMacros.h>
 
-#include "Binding_STLExporter.h"
-#include "Binding_BaseObject.h"
-#include "PythonToSofa.inl"
+#include <SofaExporter/OBJExporter.h>
 
-using namespace sofa::component::misc;
-using namespace sofa::core::objectmodel;
+SP_DECLARE_CLASS_TYPE(OBJExporter)
 
-/// getting a STLExporter* from a PyObject*
-static inline STLExporter* get_STLExporter(PyObject* obj) {
-    return sofa::py::unwrap<STLExporter>(obj);
-}
-
-static PyObject * STLExporter_writeSTL(PyObject *self, PyObject * /*args*/)
-{
-    STLExporter* obj = get_STLExporter( self );
-    obj->writeSTL();
-    Py_RETURN_NONE;
-}
-
-static PyObject * STLExporter_writeSTLBinary(PyObject *self, PyObject * /*args*/)
-{
-    STLExporter* obj = get_STLExporter( self );
-    obj->writeSTLBinary();
-    Py_RETURN_NONE;
-}
-
-
-SP_CLASS_METHODS_BEGIN(STLExporter)
-SP_CLASS_METHOD(STLExporter,writeSTL)
-SP_CLASS_METHOD(STLExporter,writeSTLBinary)
-SP_CLASS_METHODS_END
-
-
-SP_CLASS_TYPE_SPTR(STLExporter,STLExporter,BaseObject)
-
-
+#endif

--- a/modules/SofaExporter/src/SofaExporter/bindings/Binding_STLExporter.cpp
+++ b/modules/SofaExporter/src/SofaExporter/bindings/Binding_STLExporter.cpp
@@ -21,32 +21,39 @@
 ******************************************************************************/
 
 
-#include "Binding_OBJExporter.h"
-#include "Binding_BaseObject.h"
-#include "PythonToSofa.inl"
+#include "Binding_STLExporter.h"
+#include <SofaPython/Binding_BaseObject.h>
+#include <SofaPython/PythonToSofa.inl>
 
 using namespace sofa::component::misc;
 using namespace sofa::core::objectmodel;
 
-
-/// getting a OBJExporter* from a PyObject*
-static inline OBJExporter* get_OBJExporter(PyObject* obj) {
-    return sofa::py::unwrap<OBJExporter>(obj);
+/// getting a STLExporter* from a PyObject*
+static inline STLExporter* get_STLExporter(PyObject* obj) {
+    return sofa::py::unwrap<STLExporter>(obj);
 }
 
-
-static PyObject * OBJExporter_writeOBJ(PyObject *self, PyObject * /*args*/)
+static PyObject * STLExporter_writeSTL(PyObject *self, PyObject * /*args*/)
 {
-    OBJExporter* obj = get_OBJExporter( self );
-    return PyBool_FromLong( obj->writeOBJ() ) ;
+    STLExporter* obj = get_STLExporter( self );
+    obj->writeSTL();
+    Py_RETURN_NONE;
+}
+
+static PyObject * STLExporter_writeSTLBinary(PyObject *self, PyObject * /*args*/)
+{
+    STLExporter* obj = get_STLExporter( self );
+    obj->writeSTLBinary();
+    Py_RETURN_NONE;
 }
 
 
-SP_CLASS_METHODS_BEGIN(OBJExporter)
-SP_CLASS_METHOD(OBJExporter,writeOBJ)
+SP_CLASS_METHODS_BEGIN(STLExporter)
+SP_CLASS_METHOD(STLExporter,writeSTL)
+SP_CLASS_METHOD(STLExporter,writeSTLBinary)
 SP_CLASS_METHODS_END
 
 
-SP_CLASS_TYPE_SPTR(OBJExporter,OBJExporter,BaseObject)
+SP_CLASS_TYPE_SPTR(STLExporter,STLExporter,BaseObject)
 
 

--- a/modules/SofaExporter/src/SofaExporter/bindings/Binding_STLExporter.h
+++ b/modules/SofaExporter/src/SofaExporter/bindings/Binding_STLExporter.h
@@ -22,7 +22,7 @@
 #ifndef BINDING_STLEXPORTER_H
 #define BINDING_STLEXPORTER_H
 
-#include "PythonMacros.h"
+#include <SofaPython/PythonMacros.h>
 
 #include <SofaExporter/STLExporter.h>
 

--- a/modules/SofaExporter/src/SofaExporter/initExporter.cpp
+++ b/modules/SofaExporter/src/SofaExporter/initExporter.cpp
@@ -24,10 +24,9 @@
 
 #include <sofa/core/ObjectFactory.h>
 
-#if __has_include(<SofaPython/PythonEnvironment.h>) && __has_include(<SofaPython/PythonFactory.h>)
+#if SOFA_HAVE_SOFAPYTHON
 #include <SofaPython/PythonEnvironment.h>
 #include <SofaPython/PythonFactory.h>
-#define HAVE_PYTHON_ENV 1
 
 using sofa::simulation::PythonEnvironment ;
 using sofa::PythonFactory ;
@@ -35,7 +34,7 @@ using sofa::PythonFactory ;
 #include <SofaExporter/bindings/Binding_OBJExporter.h>
 #include <SofaExporter/bindings/Binding_STLExporter.h>
 
-#endif
+#endif // SOFA_HAVE_SOFAPYTHON
 
 
 using sofa::core::ObjectFactory;
@@ -61,7 +60,7 @@ void initExternalModule()
     if (first)
     {
         first = false;
-#ifdef HAVE_PYTHON_ENV
+#ifdef SOFA_HAVE_SOFAPYTHON
         {
             SP_ADD_CLASS_IN_FACTORY(OBJExporter,sofa::component::misc::OBJExporter)
             SP_ADD_CLASS_IN_FACTORY(STLExporter,sofa::component::misc::STLExporter)

--- a/modules/SofaExporter/src/SofaExporter/initExporter.cpp
+++ b/modules/SofaExporter/src/SofaExporter/initExporter.cpp
@@ -23,6 +23,21 @@
 #include <SofaExporter/config.h>
 
 #include <sofa/core/ObjectFactory.h>
+
+#if __has_include(<SofaPython/PythonEnvironment.h>) && __has_include(<SofaPython/PythonFactory.h>)
+#include <SofaPython/PythonEnvironment.h>
+#include <SofaPython/PythonFactory.h>
+#define HAVE_PYTHON_ENV 1
+
+using sofa::simulation::PythonEnvironment ;
+using sofa::PythonFactory ;
+
+#include <SofaExporter/bindings/Binding_OBJExporter.h>
+#include <SofaExporter/bindings/Binding_STLExporter.h>
+
+#endif
+
+
 using sofa::core::ObjectFactory;
 
 namespace sofa
@@ -46,6 +61,12 @@ void initExternalModule()
     if (first)
     {
         first = false;
+#ifdef HAVE_PYTHON_ENV
+        {
+            SP_ADD_CLASS_IN_FACTORY(OBJExporter,sofa::component::misc::OBJExporter)
+            SP_ADD_CLASS_IN_FACTORY(STLExporter,sofa::component::misc::STLExporter)
+        }
+#endif
     }
 }
 


### PR DESCRIPTION
SofaPython could not compile without having SofaExporter.
To solve that, bindings included in SofaPython are moved into SofaExporter.

Bindings should be included into their respective modules/plugins anyway.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
