### PR TITLE
RestShapeSpringsForcefield (partial) cleanup

### DIFF
--- a/SofaKernel/framework/sofa/core/behavior/BaseConstraintCorrection.cpp
+++ b/SofaKernel/framework/sofa/core/behavior/BaseConstraintCorrection.cpp
@@ -45,15 +45,15 @@ void BaseConstraintCorrection::computeResidual(const core::ExecParams* /*params*
     dmsg_warning() << "ComputeResidual is not implemented in " << this->getName() ;
 }
 
-void BaseConstraintCorrection::getBlockDiagonalCompliance(defaulttype::BaseMatrix* /*W*/, int /*begin*/,int /*end*/)
+void BaseConstraintCorrection::getBlockDiagonalCompliance(defaulttype::BaseMatrix* /*W*/, size_t /*begin*/,size_t /*end*/)
 {
     dmsg_warning() << "getBlockDiagonalCompliance(defaulttype::BaseMatrix* W) is not implemented in " << this->getTypeName() ;
 }
 
 bool BaseConstraintCorrection::hasConstraintNumber(int /*index*/) {return true;}
 void BaseConstraintCorrection::resetForUnbuiltResolution(double * /*f*/, std::list<unsigned int>& /*renumbering*/) {}
-void BaseConstraintCorrection::addConstraintDisplacement(double * /*d*/, int /*begin*/, int /*end*/) {}
-void BaseConstraintCorrection::setConstraintDForce(double * /*df*/, int /*begin*/, int /*end*/, bool /*update*/) {}	  // f += df
+void BaseConstraintCorrection::addConstraintDisplacement(double * /*d*/, size_t /*begin*/, size_t /*end*/) {}
+void BaseConstraintCorrection::setConstraintDForce(double * /*df*/, size_t /*begin*/, size_t /*end*/, bool /*update*/) {}	  // f += df
 
 
 } // namespace behavior

--- a/SofaKernel/framework/sofa/core/behavior/BaseConstraintCorrection.h
+++ b/SofaKernel/framework/sofa/core/behavior/BaseConstraintCorrection.h
@@ -139,9 +139,9 @@ public:
     /// @{
     virtual bool hasConstraintNumber(int /*index*/);
     virtual void resetForUnbuiltResolution(double * /*f*/, std::list<unsigned int>& /*renumbering*/);
-    virtual void addConstraintDisplacement(double * /*d*/, int /*begin*/, int /*end*/);
-    virtual void setConstraintDForce(double * /*df*/, int /*begin*/, int /*end*/, bool /*update*/);	  // f += df
-    virtual void getBlockDiagonalCompliance(defaulttype::BaseMatrix* /*W*/, int /*begin*/,int /*end*/);
+    virtual void addConstraintDisplacement(double * /*d*/, size_t /*begin*/, size_t /*end*/);
+    virtual void setConstraintDForce(double * /*df*/, size_t /*begin*/, size_t /*end*/, bool /*update*/);	  // f += df
+    virtual void getBlockDiagonalCompliance(defaulttype::BaseMatrix* /*W*/, size_t /*begin*/,size_t /*end*/);
     /// @}
 
 protected:

--- a/SofaKernel/framework/sofa/core/behavior/ConstraintCorrection.h
+++ b/SofaKernel/framework/sofa/core/behavior/ConstraintCorrection.h
@@ -62,12 +62,12 @@ protected:
     ConstraintCorrection(MechanicalState< DataTypes > *ms = NULL)
         : mstate(ms)
     {
-    };
+    }
 
     /// Default Destructor
     ~ConstraintCorrection() override
     {
-    };
+    }
 public:
     void init() override;
 

--- a/SofaKernel/framework/sofa/core/behavior/LinearSolver.h
+++ b/SofaKernel/framework/sofa/core/behavior/LinearSolver.h
@@ -115,7 +115,7 @@ public:
     virtual void init_partial_solve() {serr<<"WARNING : partial_solve is not implemented yet"<<sendl; }
 
     ///
-    virtual void partial_solve(std::list<int>& /*I_last_Disp*/, std::list<int>& /*I_last_Dforce*/, bool /*NewIn*/) {serr<<"WARNING : partial_solve is not implemented yet"<<sendl; }
+    virtual void partial_solve(std::list<size_t>& /*I_last_Disp*/, std::list<size_t>& /*I_last_Dforce*/, bool /*NewIn*/) {serr<<"WARNING : partial_solve is not implemented yet"<<sendl; }
 
     /// Invert the system, this method is optional because it's called when solveSystem() is called for the first time
     virtual void invertSystem() {}

--- a/SofaKernel/framework/sofa/defaulttype/BaseVector.h
+++ b/SofaKernel/framework/sofa/defaulttype/BaseVector.h
@@ -38,7 +38,7 @@ namespace defaulttype
 class BaseVector
 {
 public:
-    typedef int Index;
+    typedef size_t Index;
 
     virtual ~BaseVector() {}
 

--- a/SofaKernel/framework/sofa/simulation/UpdateBoundingBoxVisitor.cpp
+++ b/SofaKernel/framework/sofa/simulation/UpdateBoundingBoxVisitor.cpp
@@ -39,7 +39,7 @@ UpdateBoundingBoxVisitor::UpdateBoundingBoxVisitor(const sofa::core::ExecParams*
 Visitor::Result UpdateBoundingBoxVisitor::processNodeTopDown(Node* node)
 {
     std::string msg = "BoundingBoxVisitor - ProcessTopDown: " + node->getName();
-    sofa:helper::ScopedAdvancedTimer timer(msg.c_str());
+    sofa::helper::ScopedAdvancedTimer timer(msg.c_str());
     using namespace sofa::core::objectmodel;
     helper::vector<BaseObject*> objectList;
     helper::vector<BaseObject*>::iterator object;
@@ -70,7 +70,7 @@ Visitor::Result UpdateBoundingBoxVisitor::processNodeTopDown(Node* node)
 void UpdateBoundingBoxVisitor::processNodeBottomUp(simulation::Node* node)
 {   
     std::string msg = "BoundingBoxVisitor - ProcessBottomUp: " + node->getName();
-    sofa:helper::ScopedAdvancedTimer timer(msg.c_str());
+    sofa::helper::ScopedAdvancedTimer timer(msg.c_str());
 
     sofa::defaulttype::BoundingBox* nodeBBox = node->f_bbox.beginEdit(params);
     Node::ChildIterator childNode;

--- a/SofaKernel/framework/sofa/simulation/UpdateMappingVisitor.cpp
+++ b/SofaKernel/framework/sofa/simulation/UpdateMappingVisitor.cpp
@@ -32,7 +32,7 @@ namespace simulation
 void UpdateMappingVisitor::processMapping(simulation::Node* /*n*/, core::BaseMapping* obj)
 {
     std::string msg = "MappingVisitor - processMapping: " + obj->getName();
-    sofa:helper::ScopedAdvancedTimer timer(msg.c_str());
+    sofa::helper::ScopedAdvancedTimer timer(msg.c_str());
 
     obj->apply(core::MechanicalParams::defaultInstance(), core::VecCoordId::position(), core::ConstVecCoordId::position());
     obj->applyJ(core::MechanicalParams::defaultInstance(), core::VecDerivId::velocity(), core::ConstVecDerivId::velocity());
@@ -42,7 +42,7 @@ void UpdateMappingVisitor::processMechanicalMapping(simulation::Node* /*n*/, cor
 {
     // mechanical mappings with isMechanical flag not set are now processed by the MechanicalPropagatePositionVisitor visitor
     std::string msg = "MappingVisitor - processMechanicalMapping: " + obj->getName();
-    sofa:helper::ScopedAdvancedTimer timer(msg.c_str());
+    sofa::helper::ScopedAdvancedTimer timer(msg.c_str());
 }
 
 Visitor::Result UpdateMappingVisitor::processNodeTopDown(simulation::Node* node)

--- a/SofaKernel/modules/SofaBaseLinearSolver/matrix_bloc_traits.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/matrix_bloc_traits.h
@@ -35,11 +35,11 @@ namespace component
 namespace linearsolver
 {
 
-template<int TN> class bloc_index_func
+template<size_t TN> class bloc_index_func
 {
 public:
     enum { N = TN };
-    static void split(int& index, int& modulo)
+    static void split(size_t& index, size_t& modulo)
     {
         modulo = index % N;
         index  = index / N;
@@ -50,7 +50,7 @@ template<> class bloc_index_func<1>
 {
 public:
     enum { N = 1 };
-    static void split(int&, int&)
+    static void split(size_t&, size_t&)
     {
     }
 };
@@ -59,7 +59,7 @@ template<> class bloc_index_func<2>
 {
 public:
     enum { N = 2 };
-    static void split(int& index, int& modulo)
+    static void split(size_t& index, size_t& modulo)
     {
         modulo = index & 1;
         index  = index >> 1;
@@ -70,7 +70,7 @@ template<> class bloc_index_func<4>
 {
 public:
     enum { N = 2 };
-    static void split(int& index, int& modulo)
+    static void split(size_t& index, size_t& modulo)
     {
         modulo = index & 3;
         index  = index >> 2;
@@ -81,7 +81,7 @@ template<> class bloc_index_func<8>
 {
 public:
     enum { N = 2 };
-    static void split(int& index, int& modulo)
+    static void split(size_t& index, size_t& modulo)
     {
         modulo = index & 7;
         index  = index >> 3;
@@ -98,8 +98,8 @@ public:
     typedef typename T::Real Real;
     enum { NL = T::nbLines };
     enum { NC = T::nbCols };
-    static Real& v(Bloc& b, int row, int col) { return b[row][col]; }
-    static const Real& v(const Bloc& b, int row, int col) { return b[row][col]; }
+    static Real& v(Bloc& b, size_t row, size_t col) { return b[row][col]; }
+    static const Real& v(const Bloc& b, size_t row, size_t col) { return b[row][col]; }
     static void clear(Bloc& b) { b.clear(); }
     static bool empty(const Bloc& b)
     {
@@ -110,14 +110,14 @@ public:
     }
     static void invert(Bloc& result, const Bloc& b) { result.invert(b); }
 
-    static void split_row_index(int& index, int& modulo) { bloc_index_func<NL>::split(index, modulo); }
-    static void split_col_index(int& index, int& modulo) { bloc_index_func<NC>::split(index, modulo); }
+    static void split_row_index(size_t& index, size_t& modulo) { bloc_index_func<NL>::split(index, modulo); }
+    static void split_col_index(size_t& index, size_t& modulo) { bloc_index_func<NC>::split(index, modulo); }
 
     static sofa::defaulttype::BaseMatrix::ElementType getElementType() { return matrix_bloc_traits<Real>::getElementType(); }
     static const char* Name();
 };
 
-template <int L, int C, class real>
+template <size_t L, size_t C, class real>
 class matrix_bloc_traits < defaulttype::Mat<L,C,real> >
 {
 public:
@@ -125,20 +125,20 @@ public:
     typedef real Real;
     enum { NL = L };
     enum { NC = C };
-    static Real& v(Bloc& b, int row, int col) { return b[row][col]; }
-    static const Real& v(const Bloc& b, int row, int col) { return b[row][col]; }
+    static Real& v(Bloc& b, size_t row, size_t col) { return b[row][col]; }
+    static const Real& v(const Bloc& b, size_t row, size_t col) { return b[row][col]; }
     static void clear(Bloc& b) { b.clear(); }
     static bool empty(const Bloc& b)
     {
-        for (int i=0; i<NL; ++i)
-            for (int j=0; j<NC; ++j)
+        for (size_t i=0; i<NL; ++i)
+            for (size_t j=0; j<NC; ++j)
                 if (b[i][j] != 0) return false;
         return true;
     }
     static void invert(Bloc& result, const Bloc& b) { result.invert(b); }
 
-    static void split_row_index(int& index, int& modulo) { bloc_index_func<NL>::split(index, modulo); }
-    static void split_col_index(int& index, int& modulo) { bloc_index_func<NC>::split(index, modulo); }
+    static void split_row_index(size_t& index, size_t& modulo) { bloc_index_func<NL>::split(index, modulo); }
+    static void split_col_index(size_t& index, size_t& modulo) { bloc_index_func<NC>::split(index, modulo); }
 
     static sofa::defaulttype::BaseMatrix::ElementType getElementType() { return matrix_bloc_traits<Real>::getElementType(); }
     static const char* Name();
@@ -169,8 +169,8 @@ public:
     typedef float Real;
     enum { NL = 1 };
     enum { NC = 1 };
-    static Real& v(Bloc& b, int, int) { return b; }
-    static const Real& v(const Bloc& b, int, int) { return b; }
+    static Real& v(Bloc& b, size_t, size_t) { return b; }
+    static const Real& v(const Bloc& b, size_t, size_t) { return b; }
     static void clear(Bloc& b) { b = 0; }
     static bool empty(const Bloc& b)
     {
@@ -178,8 +178,8 @@ public:
     }
     static void invert(Bloc& result, const Bloc& b) { result = 1.0f/b; }
 
-    static void split_row_index(int& index, int& modulo) { bloc_index_func<NL>::split(index, modulo); }
-    static void split_col_index(int& index, int& modulo) { bloc_index_func<NC>::split(index, modulo); }
+    static void split_row_index(size_t& index, size_t& modulo) { bloc_index_func<NL>::split(index, modulo); }
+    static void split_col_index(size_t& index, size_t& modulo) { bloc_index_func<NC>::split(index, modulo); }
 
     static const char* Name() { return "f"; }
     static sofa::defaulttype::BaseMatrix::ElementType getElementType() { return sofa::defaulttype::BaseMatrix::ELEMENT_FLOAT; }
@@ -194,8 +194,8 @@ public:
     typedef double Real;
     enum { NL = 1 };
     enum { NC = 1 };
-    static Real& v(Bloc& b, int, int) { return b; }
-    static const Real& v(const Bloc& b, int, int) { return b; }
+    static Real& v(Bloc& b, size_t, size_t) { return b; }
+    static const Real& v(const Bloc& b, size_t, size_t) { return b; }
     static void clear(Bloc& b) { b = 0; }
     static bool empty(const Bloc& b)
     {
@@ -203,23 +203,23 @@ public:
     }
     static void invert(Bloc& result, const Bloc& b) { result = 1.0/b; }
 
-    static void split_row_index(int& index, int& modulo) { bloc_index_func<NL>::split(index, modulo); }
-    static void split_col_index(int& index, int& modulo) { bloc_index_func<NC>::split(index, modulo); }
+    static void split_row_index(size_t& index, size_t& modulo) { bloc_index_func<NL>::split(index, modulo); }
+    static void split_col_index(size_t& index, size_t& modulo) { bloc_index_func<NC>::split(index, modulo); }
 
     static sofa::defaulttype::BaseMatrix::ElementType getElementType() { return sofa::defaulttype::BaseMatrix::ELEMENT_FLOAT; }
     static const char* Name() { return "d"; }
 };
 
 template <>
-class matrix_bloc_traits < int >
+class matrix_bloc_traits < size_t >
 {
 public:
     typedef float Bloc;
     typedef float Real;
     enum { NL = 1 };
     enum { NC = 1 };
-    static Real& v(Bloc& b, int, int) { return b; }
-    static const Real& v(const Bloc& b, int, int) { return b; }
+    static Real& v(Bloc& b, size_t, size_t) { return b; }
+    static const Real& v(const Bloc& b, size_t, size_t) { return b; }
     static void clear(Bloc& b) { b = 0; }
     static bool empty(const Bloc& b)
     {
@@ -227,8 +227,8 @@ public:
     }
     static void invert(Bloc& result, const Bloc& b) { result = 1.0f/b; }
 
-    static void split_row_index(int& index, int& modulo) { bloc_index_func<NL>::split(index, modulo); }
-    static void split_col_index(int& index, int& modulo) { bloc_index_func<NC>::split(index, modulo); }
+    static void split_row_index(size_t& index, size_t& modulo) { bloc_index_func<NL>::split(index, modulo); }
+    static void split_col_index(size_t& index, size_t& modulo) { bloc_index_func<NC>::split(index, modulo); }
 
     static sofa::defaulttype::BaseMatrix::ElementType getElementType() { return sofa::defaulttype::BaseMatrix::ELEMENT_INT; }
     static const char* Name() { return "f"; }

--- a/SofaKernel/modules/SofaBaseVisual/VisualModelImpl.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/VisualModelImpl.cpp
@@ -1253,7 +1253,7 @@ void VisualModelImpl::updateVisual()
     {
         if (useTopology)
         {
-            sofa:helper::ScopedAdvancedTimer timer("VisualModelImpl::updateMesh");
+            sofa::helper::ScopedAdvancedTimer timer("VisualModelImpl::updateMesh");
             /** HD : build also a Ogl description from main Topology. But it needs to be build only once since the topology update
             is taken care of by the handleTopologyChange() routine */
 

--- a/SofaKernel/modules/SofaDeformable/AngularSpringForceField.inl
+++ b/SofaKernel/modules/SofaDeformable/AngularSpringForceField.inl
@@ -91,6 +91,8 @@ void AngularSpringForceField<DataTypes>::reinit()
 template<class DataTypes>
 void AngularSpringForceField<DataTypes>::addForce(const core::MechanicalParams* /* mparams */, DataVecDeriv& f, const DataVecCoord& x, const DataVecDeriv& /* v */)
 {
+    std::cout << "AddForce" << std::endl;
+
     if(!mState) {
 		msg_info("AngularSpringForceField") << "No Mechanical State found, no force will be computed..." << "\n";
         return;
@@ -155,6 +157,7 @@ void AngularSpringForceField<DataTypes>::addDForce(const core::MechanicalParams*
 template<class DataTypes>
 void AngularSpringForceField<DataTypes>::addKToMatrix(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix )
 {
+    std::cout << "AddKToMatrix" << std::endl;
     const int N = 6;
     sofa::core::behavior::MultiMatrixAccessor::MatrixRef mref = matrix->getMatrix(this->mstate);
     sofa::defaulttype::BaseMatrix* mat = mref.matrix;
@@ -164,11 +167,12 @@ void AngularSpringForceField<DataTypes>::addKToMatrix(const core::MechanicalPara
     unsigned int curIndex = 0;
     for (unsigned int index = 0; index < indices.getValue().size(); index++)
     {
-//        if (angle <  (angularLimit.getValue()[2*i]/180.0*M_PI) || angle >  (angularLimit.getValue()[2*i+1]/180.0*M_PI))  {
             curIndex = indices.getValue()[index];
-            for(int i = 3; i < 6; i++)
+            for(int i = 3; i < 6; i++) {
+                std::cout << curIndex << std::endl;
+                std::cout << i << " " << N << "\t\t" << offset << std::endl;
                 mat->add(offset + N * curIndex + i, offset + N * curIndex + i, -kFact * (index < this->k.size() ? this->k[index] : this->k[0]));
-//        }
+            }
     }
 }
 

--- a/SofaKernel/modules/SofaDeformable/RestShapeSpringsForceField.h
+++ b/SofaKernel/modules/SofaDeformable/RestShapeSpringsForceField.h
@@ -94,6 +94,7 @@ protected:
 
 public:
     /// BaseObject initialization method.
+    void init() override;
     void bwdInit() override ;
     void parse(core::objectmodel::BaseObjectDescription *arg) override ;
     void reinit() override ;

--- a/examples/Components/forcefield/angularSpringForceField.scn
+++ b/examples/Components/forcefield/angularSpringForceField.scn
@@ -1,109 +1,113 @@
 <?xml version="1.0"?>
 <Node dt="0.02" gravity="9 0 0" name="root">
 
-    <VisualStyle displayFlags="showCollisionModels hideBehaviorModels hideForceFields" />
+  <RequiredPlugin name="SofaSparseSolver"/>
+  <VisualStyle displayFlags="showCollisionModels hideBehaviorModels hideForceFields" />
+  <FreeMotionAnimationLoop />
+  <GenericConstraintSolver printLog="true" />
 
-    <Node activated="true" name="ArticulatedSoftBeam">
-	    <EulerImplicitSolver  rayleighStiffness="0.1" rayleighMass="0.1" />
-		<CGLinearSolver iterations="100" tolerance="1e-7" threshold="1e-7"/>
-        <MechanicalObject name="Articulations" position="0 0  0 0  0 0  0 0  0 0  0 0  0 0  0 0  0 0  0 0" template="Vec1d" />
-		<Node name="TranslPoint">
-            <MechanicalObject name="DOF" position="0.0 0 0  0 0 0 1" showObject="true" template="Rigid" />    
-            <PartialFixedConstraint fixedDirections="1 1 1 1 1 1" indices="0" name="fixOrigin" template="Rigid" />
-        </Node>
-	    <Node name="Mechanics">
-	        <MechanicalObject name="DOFs"  template="Rigid" position="0.0 0 0  0 0 0 1  
-	        															1.42857142857 0 0  0 0 0 1  
-	        															2.85714285714 0 0  0 0 0 1  
-	        															4.28571428571 0 0  0 0 0 1  
-	        															5.71428571429 0 0  0 0 0 1  
-	        															7.14285714286 0 0  0 0 0 1  
-	        															8.57142857143 0 0  0 0 0 1  
-	        															10.0 0 0  0 0 0 1  
-	        															11.4285714286 0 0  0 0 0 1  
-	        															12.8571428571 0 0  0 0 0 1"/>
-	        <AngularSpringForceField angularStiffness="1e4" indices="0 1 2 3 4 5 6 7 8 9" name="ASFF" />
-	        <Mesh lines="0 1  1 2  2 3  3 4  4 5  5 6  6 7  7 8  8 9" name="lines" />
-	        <UniformMass mass="0.1 0.1 [1 0 0,0 1 0,0 0 1]" name="mass" template="Rigid" />
-	            
-	        <ArticulatedSystemMapping input1="@../Articulations" input2="@../TranslPoint/DOF" output="@DOFs" />
-	       
-			<Node name="Collision">
-	            <CubeTopology max="9.2 0.05 0.05" min="0 -0.05 -0.05" nx="70" ny="2" nz="2" />
-	            <MechanicalObject name="skinDOFs" />
-	            <TriangleCollisionModel /> 
-	            <LineCollisionModel />
-	            <PointCollisionModel />
-	            <BeamLinearMapping isMechanical="true" />
-	        </Node>
-	        <RestShapeSpringsForceField stiffness="1200"  angularStiffness="500" drawSpring="1" external_points="0" external_rest_shape="@../TranslPoint/DOF" mstate="@DOFs" points="0" template="Rigid" />
-	    </Node>
-
-        <ArticulatedHierarchyContainer />
-        <Node name="articulationCenters">           
-	        <Node name="articulationCenter1">
-	        	<ArticulationCenter articulationProcess="0" childIndex="1" parentIndex="0" posOnChild="-0.714285714286 0 0" posOnParent="0.714285714286 0 0" />
-	        	<Node name="articulations">
-	        		<Articulation articulationIndex="0" rotation="1" rotationAxis="0 1 0" translation="0" />
-	        		<Articulation articulationIndex="1" rotation="1" rotationAxis="0 0 1" translation="0" />
-	        	</Node>
-	        </Node>
-	     <Node name="articulationCenter2">
-	        <ArticulationCenter articulationProcess="0" childIndex="2" parentIndex="1" posOnChild="-0.714285714286 0 0" posOnParent="0.714285714286 0 0" />
-	        <Node name="articulations">
-	        		<Articulation articulationIndex="2" rotation="1" rotationAxis="0 1 0" translation="0" />
-	        		<Articulation articulationIndex="3" rotation="1" rotationAxis="0 0 1" translation="0" />
-	        	</Node>
-	        </Node>
-	        <Node name="articulationCenter3">
-	        	<ArticulationCenter articulationProcess="0" childIndex="3" parentIndex="2" posOnChild="-0.714285714286 0 0" posOnParent="0.714285714286 0 0" />
-	        	<Node name="articulations">
-	        		<Articulation articulationIndex="4" rotation="1" rotationAxis="0 1 0" translation="0" />
-	        		<Articulation articulationIndex="5" rotation="1" rotationAxis="0 0 1" translation="0" />
-	        	</Node>
-	        </Node>
-	        <Node name="articulationCenter4">
-	        	<ArticulationCenter articulationProcess="0" childIndex="4" parentIndex="3" posOnChild="-0.714285714286 0 0" posOnParent="0.714285714286 0 0" />
-	        	<Node name="articulations">
-	        		<Articulation articulationIndex="6" rotation="1" rotationAxis="0 1 0" translation="0" />
-	        		<Articulation articulationIndex="7" rotation="1" rotationAxis="0 0 1" translation="0" />
-	        	</Node>
-	        </Node>
-	        <Node name="articulationCenter5">
-	        	<ArticulationCenter articulationProcess="0" childIndex="5" parentIndex="4" posOnChild="-0.714285714286 0 0" posOnParent="0.714285714286 0 0" />
-	        	<Node name="articulations">
-	        		<Articulation articulationIndex="8" rotation="1" rotationAxis="0 1 0" translation="0" />
-	        		<Articulation articulationIndex="9" rotation="1" rotationAxis="0 0 1" translation="0" />
-	        	</Node>
-	        </Node>
-	        <Node name="articulationCenter6">
-	        	<ArticulationCenter articulationProcess="0" childIndex="6" parentIndex="5" posOnChild="-0.714285714286 0 0" posOnParent="0.714285714286 0 0" />
-	        	<Node name="articulations">
-	        		<Articulation articulationIndex="10" rotation="1" rotationAxis="0 1 0" translation="0" />
-	        		<Articulation articulationIndex="11" rotation="1" rotationAxis="0 0 1" translation="0" />
-	        	</Node>
-	        </Node>
-	        <Node name="articulationCenter7">
-	        	<ArticulationCenter articulationProcess="0" childIndex="7" parentIndex="6" posOnChild="-0.714285714286 0 0" posOnParent="0.714285714286 0 0" />
-	        	<Node name="articulations">
-	        		<Articulation articulationIndex="12" rotation="1" rotationAxis="0 1 0" translation="0" />
-	        		<Articulation articulationIndex="13" rotation="1" rotationAxis="0 0 1" translation="0" />
-	        	</Node>
-	        </Node>
-	        <Node name="articulationCenter8">
-	        	<ArticulationCenter articulationProcess="0" childIndex="8" parentIndex="7" posOnChild="-0.714285714286 0 0" posOnParent="0.714285714286 0 0" />
-	        	<Node name="articulations">
-	        		<Articulation articulationIndex="14" rotation="1" rotationAxis="0 1 0" translation="0" />
-	        		<Articulation articulationIndex="15" rotation="1" rotationAxis="0 0 1" translation="0" />
-	        	</Node>
-	        </Node>
-	        <Node name="articulationCenter9">
-	        	<ArticulationCenter articulationProcess="0" childIndex="9" parentIndex="8" posOnChild="-0.714285714286 0 0" posOnParent="0.714285714286 0 0" />
-	        	<Node name="articulations">
-	        		<Articulation articulationIndex="16" rotation="1" rotationAxis="0 1 0" translation="0" />
-	        		<Articulation articulationIndex="17" rotation="1" rotationAxis="0 0 1" translation="0" />
-	        	</Node>
-	        </Node>
-    	</Node>
+  <Node activated="true" name="ArticulatedSoftBeam">
+    <EulerImplicitSolver  rayleighStiffness="0.1" rayleighMass="0.1" />
+    <SparseLDLSolver name="ldl" />
+    <GenericConstraintCorrection solverName="ldl" />
+    <MechanicalObject name="Articulations" position="0 0  0 0  0 0  0 0  0 0  0 0  0 0  0 0  0 0  0 0" template="Vec1d" />
+    <Node name="TranslPoint">
+      <MechanicalObject name="DOF" position="0.0 0 0  0 0 0 1" showObject="true" template="Rigid3d" />
+      <!-- <PartialFixedConstraint fixedDirections="1 1 1 1 1 1" indices="0" name="fixOrigin" template="Rigid3d" /> -->
     </Node>
+    <Node name="Mechanics">
+      <MechanicalObject name="DOFs"  template="Rigid3d" position="0.0 0 0  0 0 0 1
+	        						  1.42857142857 0 0  0 0 0 1  
+	        						  2.85714285714 0 0  0 0 0 1  
+	        						  4.28571428571 0 0  0 0 0 1  
+	        						  5.71428571429 0 0  0 0 0 1  
+	        						  7.14285714286 0 0  0 0 0 1  
+	        						  8.57142857143 0 0  0 0 0 1  
+	        						  10.0 0 0  0 0 0 1  
+	        						  11.4285714286 0 0  0 0 0 1  
+	        						  12.8571428571 0 0  0 0 0 1"/>
+        <AngularSpringForceField angularStiffness="1e4" indices="0 1 2 3 4 5 6 7 8 9" name="ASFF" />
+        <Mesh lines="0 1  1 2  2 3  3 4  4 5  5 6  6 7  7 8  8 9" name="lines" />
+        <UniformMass vertexMass="0.1 0.1 [1 0 0,0 1 0,0 0 1]" name="mass" template="Rigid3d" />
+
+        <ArticulatedSystemMapping input1="@../Articulations" input2="@../TranslPoint/DOF" output="@DOFs" />
+
+        <Node name="Collision">
+          <CubeTopology max="9.2 0.05 0.05" min="0 -0.05 -0.05" nx="70" ny="2" nz="2" />
+          <MechanicalObject name="skinDOFs" />
+          <TriangleCollisionModel />
+          <LineCollisionModel />
+          <PointCollisionModel />
+          <BeamLinearMapping isMechanical="true" />
+        </Node>
+        <RestShapeSpringsForceField stiffness="1200"  angularStiffness="500" drawSpring="1" external_points="0" external_rest_shape="@../TranslPoint/DOF" mstate="@DOFs" points="0" template="Rigid" />
+    </Node>
+
+    <ArticulatedHierarchyContainer />
+    <Node name="articulationCenters">           
+      <Node name="articulationCenter1">
+	<ArticulationCenter articulationProcess="0" childIndex="1" parentIndex="0" posOnChild="-0.714285714286 0 0" posOnParent="0.714285714286 0 0" />
+	<Node name="articulations">
+	  <Articulation articulationIndex="0" rotation="1" rotationAxis="0 1 0" translation="0" />
+	  <Articulation articulationIndex="1" rotation="1" rotationAxis="0 0 1" translation="0" />
+	</Node>
+      </Node>
+      <Node name="articulationCenter2">
+	<ArticulationCenter articulationProcess="0" childIndex="2" parentIndex="1" posOnChild="-0.714285714286 0 0" posOnParent="0.714285714286 0 0" />
+	<Node name="articulations">
+	  <Articulation articulationIndex="2" rotation="1" rotationAxis="0 1 0" translation="0" />
+	  <Articulation articulationIndex="3" rotation="1" rotationAxis="0 0 1" translation="0" />
+	</Node>
+      </Node>
+      <Node name="articulationCenter3">
+	<ArticulationCenter articulationProcess="0" childIndex="3" parentIndex="2" posOnChild="-0.714285714286 0 0" posOnParent="0.714285714286 0 0" />
+	<Node name="articulations">
+	  <Articulation articulationIndex="4" rotation="1" rotationAxis="0 1 0" translation="0" />
+	  <Articulation articulationIndex="5" rotation="1" rotationAxis="0 0 1" translation="0" />
+	</Node>
+      </Node>
+      <Node name="articulationCenter4">
+	<ArticulationCenter articulationProcess="0" childIndex="4" parentIndex="3" posOnChild="-0.714285714286 0 0" posOnParent="0.714285714286 0 0" />
+	<Node name="articulations">
+	  <Articulation articulationIndex="6" rotation="1" rotationAxis="0 1 0" translation="0" />
+	  <Articulation articulationIndex="7" rotation="1" rotationAxis="0 0 1" translation="0" />
+	</Node>
+      </Node>
+      <Node name="articulationCenter5">
+	<ArticulationCenter articulationProcess="0" childIndex="5" parentIndex="4" posOnChild="-0.714285714286 0 0" posOnParent="0.714285714286 0 0" />
+	<Node name="articulations">
+	  <Articulation articulationIndex="8" rotation="1" rotationAxis="0 1 0" translation="0" />
+	  <Articulation articulationIndex="9" rotation="1" rotationAxis="0 0 1" translation="0" />
+	</Node>
+      </Node>
+      <Node name="articulationCenter6">
+	<ArticulationCenter articulationProcess="0" childIndex="6" parentIndex="5" posOnChild="-0.714285714286 0 0" posOnParent="0.714285714286 0 0" />
+	<Node name="articulations">
+	  <Articulation articulationIndex="10" rotation="1" rotationAxis="0 1 0" translation="0" />
+	  <Articulation articulationIndex="11" rotation="1" rotationAxis="0 0 1" translation="0" />
+	</Node>
+      </Node>
+      <Node name="articulationCenter7">
+	<ArticulationCenter articulationProcess="0" childIndex="7" parentIndex="6" posOnChild="-0.714285714286 0 0" posOnParent="0.714285714286 0 0" />
+	<Node name="articulations">
+	  <Articulation articulationIndex="12" rotation="1" rotationAxis="0 1 0" translation="0" />
+	  <Articulation articulationIndex="13" rotation="1" rotationAxis="0 0 1" translation="0" />
+	</Node>
+      </Node>
+      <Node name="articulationCenter8">
+	<ArticulationCenter articulationProcess="0" childIndex="8" parentIndex="7" posOnChild="-0.714285714286 0 0" posOnParent="0.714285714286 0 0" />
+	<Node name="articulations">
+	  <Articulation articulationIndex="14" rotation="1" rotationAxis="0 1 0" translation="0" />
+	  <Articulation articulationIndex="15" rotation="1" rotationAxis="0 0 1" translation="0" />
+	</Node>
+      </Node>
+      <Node name="articulationCenter9">
+	<ArticulationCenter articulationProcess="0" childIndex="9" parentIndex="8" posOnChild="-0.714285714286 0 0" posOnParent="0.714285714286 0 0" />
+	<Node name="articulations">
+	  <Articulation articulationIndex="16" rotation="1" rotationAxis="0 1 0" translation="0" />
+	  <Articulation articulationIndex="17" rotation="1" rotationAxis="0 0 1" translation="0" />
+	</Node>
+      </Node>
+    </Node>
+  </Node>
 </Node>

--- a/modules/SofaConstraint/LinearSolverConstraintCorrection.h
+++ b/modules/SofaConstraint/LinearSolverConstraintCorrection.h
@@ -64,7 +64,7 @@ public:
     typedef typename DataTypes::Coord Coord;
     typedef typename DataTypes::Deriv Deriv;
 
-    typedef std::list<int> ListIndex;
+    typedef std::list<size_t> ListIndex;
     typedef sofa::core::behavior::ConstraintCorrection< TDataTypes > Inherit;
 protected:
     LinearSolverConstraintCorrection(sofa::core::behavior::MechanicalState<DataTypes> *mm = nullptr);
@@ -109,11 +109,11 @@ public:
 
     void resetForUnbuiltResolution(double * f, std::list<unsigned int>& renumbering) override;
 
-    void addConstraintDisplacement(double *d, int begin,int end) override;
+    void addConstraintDisplacement(double *d, size_t begin,size_t end) override;
 
-    void setConstraintDForce(double *df, int begin, int end, bool update) override;
+    void setConstraintDForce(double *df, size_t begin, size_t end, bool update) override;
 
-    void getBlockDiagonalCompliance(defaulttype::BaseMatrix* W, int begin, int end) override;
+    void getBlockDiagonalCompliance(defaulttype::BaseMatrix* W, size_t begin, size_t end) override;
 
     /// Pre-construction check method called by ObjectFactory.
 #if 0

--- a/modules/SofaConstraint/LinearSolverConstraintCorrection.inl
+++ b/modules/SofaConstraint/LinearSolverConstraintCorrection.inl
@@ -565,7 +565,7 @@ void LinearSolverConstraintCorrection<DataTypes>::resetForUnbuiltResolution(doub
 }
 
 template<class DataTypes>
-void LinearSolverConstraintCorrection<DataTypes>::addConstraintDisplacement(double *d, int begin, int end)
+void LinearSolverConstraintCorrection<DataTypes>::addConstraintDisplacement(double *d, size_t begin, size_t end)
 {
     const MatrixDeriv& constraints = mstate->read(core::ConstMatrixDerivId::constraintJacobian())->getValue();
     const unsigned int derivDim = Deriv::size();
@@ -578,7 +578,7 @@ void LinearSolverConstraintCorrection<DataTypes>::addConstraintDisplacement(doub
     _new_force = false;
 
     // TODO => optimisation => for each bloc store J[bloc,dof]
-    for (int i = begin; i <= end; i++)
+    for (size_t i = begin; i <= end; i++)
     {
         MatrixDerivRowConstIterator rowIt = constraints.readLine(i);
 
@@ -603,7 +603,7 @@ void LinearSolverConstraintCorrection<DataTypes>::addConstraintDisplacement(doub
 }
 
 template<class DataTypes>
-void LinearSolverConstraintCorrection<DataTypes>::setConstraintDForce(double *df, int begin, int end, bool update)
+void LinearSolverConstraintCorrection<DataTypes>::setConstraintDForce(double *df, size_t begin, size_t end, bool update)
 {
 
 
@@ -639,10 +639,10 @@ void LinearSolverConstraintCorrection<DataTypes>::setConstraintDForce(double *df
     }
 
     // course on indices of the dofs involved invoved in the bloc //
-    std::list<int>::const_iterator it_dof(Vec_I_list_dof[last_force].begin()), it_end(Vec_I_list_dof[last_force].end());
+    ListIndex::const_iterator it_dof(Vec_I_list_dof[last_force].begin()), it_end(Vec_I_list_dof[last_force].end());
     for(; it_dof!=it_end; ++it_dof)
     {
-        int dof =(*it_dof) ;
+        size_t dof =(*it_dof) ;
         for  (unsigned int j=0; j<derivDim; j++)
             systemRHVector_buf->set(dof * derivDim + j, constraint_force[dof][j]);
     }
@@ -650,7 +650,7 @@ void LinearSolverConstraintCorrection<DataTypes>::setConstraintDForce(double *df
 }
 
 template<class DataTypes>
-void LinearSolverConstraintCorrection<DataTypes>::getBlockDiagonalCompliance(defaulttype::BaseMatrix* W, int begin, int end)
+void LinearSolverConstraintCorrection<DataTypes>::getBlockDiagonalCompliance(defaulttype::BaseMatrix* W, size_t begin, size_t end)
 {
     if(m_componentstate!=ComponentState::Valid)
         return ;
@@ -664,11 +664,11 @@ void LinearSolverConstraintCorrection<DataTypes>::getBlockDiagonalCompliance(def
 
     // Compute J
     const MatrixDeriv& constraints = mstate->read(core::ConstMatrixDerivId::constraintJacobian())->getValue();
-    const unsigned int totalNumConstraints = W->rowSize();
+    const size_t totalNumConstraints = W->rowSize();
 
     J.resize(totalNumConstraints, numDOFReals);
 
-    for (int i = begin; i <= end; i++)
+    for (size_t i = begin; i <= end; i++)
     {
 
 
@@ -708,7 +708,7 @@ void LinearSolverConstraintCorrection<DataTypes>::getBlockDiagonalCompliance(def
 
     ListIndex list_dof;
 
-    for (int i = begin; i <= end; i++)
+    for (size_t i = begin; i <= end; i++)
     {
 
 
@@ -728,7 +728,7 @@ void LinearSolverConstraintCorrection<DataTypes>::getBlockDiagonalCompliance(def
     list_dof.sort();
     list_dof.unique();
 
-    for (int i = begin; i <= end; i++)
+    for (size_t i = begin; i <= end; i++)
     {
         Vec_I_list_dof[i] = list_dof;
     }

--- a/modules/SofaConstraint/PrecomputedConstraintCorrection.h
+++ b/modules/SofaConstraint/PrecomputedConstraintCorrection.h
@@ -114,11 +114,11 @@ public:
 
     bool hasConstraintNumber(int index) override;  // virtual ???
 
-    void addConstraintDisplacement(double *d, int begin,int end) override;
+    void addConstraintDisplacement(double *d, size_t begin,size_t end) override;
 
-    void setConstraintDForce(double *df, int begin, int end, bool update) override;
+    void setConstraintDForce(double *df, size_t begin, size_t end, bool update) override;
 
-    void getBlockDiagonalCompliance(defaulttype::BaseMatrix* W, int begin, int end) override;
+    void getBlockDiagonalCompliance(defaulttype::BaseMatrix* W, size_t begin, size_t end) override;
 
     /// @}
 

--- a/modules/SofaConstraint/PrecomputedConstraintCorrection.inl
+++ b/modules/SofaConstraint/PrecomputedConstraintCorrection.inl
@@ -1182,7 +1182,7 @@ bool PrecomputedConstraintCorrection<DataTypes>::hasConstraintNumber(int index)
 
 
 template<class DataTypes>
-void PrecomputedConstraintCorrection<DataTypes>::addConstraintDisplacement(double *d, int begin, int end)
+void PrecomputedConstraintCorrection<DataTypes>::addConstraintDisplacement(double *d, size_t begin, size_t end)
 {
 #ifdef NEW_METHOD_UNBUILT
 
@@ -1232,7 +1232,7 @@ template<class DataTypes>
 #ifdef NEW_METHOD_UNBUILT
 void PrecomputedConstraintCorrection<DataTypes>::setConstraintDForce(double * df, int begin, int end, bool update)
 #else
-void PrecomputedConstraintCorrection<DataTypes>::setConstraintDForce(double * /*df*/, int begin, int end, bool update)
+void PrecomputedConstraintCorrection<DataTypes>::setConstraintDForce(double * /*df*/, size_t begin, size_t end, bool update)
 #endif
 {
 #ifdef NEW_METHOD_UNBUILT
@@ -1298,9 +1298,9 @@ void PrecomputedConstraintCorrection<DataTypes>::setConstraintDForce(double * /*
         return;
 
     /// fill a local table of active forces (non-null forces)
-    for (int i = begin; i <= end; i++)
+    for (size_t i = begin; i <= end; i++)
     {
-        int c = id_to_localIndex[i];
+        size_t c = id_to_localIndex[i];
         active_local_force.push_back(c);
     }
     active_local_force.sort();
@@ -1309,7 +1309,7 @@ void PrecomputedConstraintCorrection<DataTypes>::setConstraintDForce(double * /*
 }
 
 template<class DataTypes>
-void PrecomputedConstraintCorrection<DataTypes>::getBlockDiagonalCompliance(defaulttype::BaseMatrix* W, int begin, int end)
+void PrecomputedConstraintCorrection<DataTypes>::getBlockDiagonalCompliance(defaulttype::BaseMatrix* W, size_t begin, size_t end)
 {
 #ifdef NEW_METHOD_UNBUILT
 
@@ -1428,13 +1428,13 @@ void PrecomputedConstraintCorrection<DataTypes>::getBlockDiagonalCompliance(defa
 
 #else
 
-    for (int id1 = begin; id1<=end; id1++)
+    for (size_t id1 = begin; id1<=end; id1++)
     {
-        int c1 = id_to_localIndex[id1];
-        for (int id2 = id1; id2<=end; id2++)
+        size_t c1 = id_to_localIndex[id1];
+        for (size_t id2 = id1; id2<=end; id2++)
         {
-            int c2 = id_to_localIndex[id2];
-            Real w = (Real)localW.element(c1,c2);
+            size_t c2 = id_to_localIndex[id2];
+            Real w = Real(localW.element(c1,c2));
 
             W->add(id1, id2, w);
             if (id1 != id2)

--- a/modules/SofaConstraint/UncoupledConstraintCorrection.h
+++ b/modules/SofaConstraint/UncoupledConstraintCorrection.h
@@ -111,11 +111,11 @@ public:
 
     void resetForUnbuiltResolution(double * f, std::list<unsigned int>& /*renumbering*/) override;
 
-    void addConstraintDisplacement(double *d, int begin,int end) override;
+    void addConstraintDisplacement(double *d, size_t begin,size_t end) override;
 
-    void setConstraintDForce(double *df, int begin, int end, bool update) override;
+    void setConstraintDForce(double *df, size_t begin, size_t end, bool update) override;
 
-    void getBlockDiagonalCompliance(defaulttype::BaseMatrix* W, int begin, int end) override;
+    void getBlockDiagonalCompliance(defaulttype::BaseMatrix* W, size_t begin, size_t end) override;
 
     /// @}
 

--- a/modules/SofaConstraint/UncoupledConstraintCorrection.inl
+++ b/modules/SofaConstraint/UncoupledConstraintCorrection.inl
@@ -690,7 +690,7 @@ void UncoupledConstraintCorrection<DataTypes>::resetForUnbuiltResolution(double 
 
 
 template<class DataTypes>
-void UncoupledConstraintCorrection<DataTypes>::addConstraintDisplacement(double * d, int begin, int end)
+void UncoupledConstraintCorrection<DataTypes>::addConstraintDisplacement(double * d, size_t begin, size_t end)
 {
 /// in the Vec1Types and Vec3Types case, compliance is a vector of size mstate->getSize()
 /// constraint_force contains the force applied on dof involved with the contact
@@ -719,7 +719,7 @@ void UncoupledConstraintCorrection<DataTypes>::addConstraintDisplacement(double 
 
 
 template<class DataTypes>
-void UncoupledConstraintCorrection<DataTypes>::setConstraintDForce(double * df, int begin, int end, bool update)
+void UncoupledConstraintCorrection<DataTypes>::setConstraintDForce(double * df, size_t begin, size_t end, bool update)
 {
     /// set a force difference on a set of constraints (between constraint number "begin" and constraint number "end"
     /// if update is false, do nothing
@@ -733,7 +733,7 @@ void UncoupledConstraintCorrection<DataTypes>::setConstraintDForce(double * df, 
     if (!update)
         return;
 
-    for (int id = begin; id <= end; id++)
+    for (size_t id = begin; id <= end; id++)
     {
 
         MatrixDerivRowConstIterator curConstraint = constraints.readLine(id);
@@ -761,13 +761,13 @@ void UncoupledConstraintCorrection<DataTypes>::setConstraintDForce(double * df, 
 
 
 template<class DataTypes>
-void UncoupledConstraintCorrection<DataTypes>::getBlockDiagonalCompliance(defaulttype::BaseMatrix* W, int begin, int end)
+void UncoupledConstraintCorrection<DataTypes>::getBlockDiagonalCompliance(defaulttype::BaseMatrix* W, size_t begin, size_t end)
 {
     const MatrixDeriv& constraints = this->mstate->read(core::ConstMatrixDerivId::constraintJacobian())->getValue();
     const VecReal& comp = compliance.getValue();
     const Real comp0 = defaultCompliance.getValue();
 
-    for (int id1 = begin; id1 <= end; id1++)
+    for (size_t id1 = begin; id1 <= end; id1++)
     {
 
         MatrixDerivRowConstIterator curConstraint = constraints.readLine(id1);
@@ -792,7 +792,7 @@ void UncoupledConstraintCorrection<DataTypes>::getBlockDiagonalCompliance(defaul
         }
 
         // Then the compliance with the remaining constraints
-        for (int id2 = id1+1; id2 <= end; id2++)
+        for (size_t id2 = id1+1; id2 <= end; id2++)
         {
             MatrixDerivRowConstIterator curConstraint2 = constraints.readLine(id2);
 


### PR DESCRIPTION
While trying to understand how forcefields work... I initially noticed that there was a bad handling of cases where `stiffness.size() != indices.size()` in the RestShapeSpringsForceField and tried to improve the overall error management on this component.

I ended up doing the following changes:

- Call reinit() in bwdInit
- Using componentState to set the state to invalid when necessary (no stiffness set,  out of bounds indices etc & check for component state in addForce / addDForce / addKToMatrix ..)
- Improvement of warning messages (IMHO)
- refactor code duplication
- remove warnings by changing int -> size_t for BaseMatrix::Index (got carried away here, sorry about that)

**### BREAKING because:**

- Change in behavior in specific cases:

1. empty stiffness vector:  **Before:** setting arbitrary stiffness at 100.0 for all indices ; **Now:** msg_error & invalid state. 
2. stiffness.size() != indices.size(): **Before:** applying stiffness[0] to all indices ; **Now:** 
```py
if len(stiffness) > len(indices): 
    crop(stiffness)
else if len(stiffness) == 1:
    stiffness.resize(len(indices), stiffness[0])
else if len(stiffness < len(indices):
 ```
    Generalized to angularStiffness on Rigids

- size_t in methods signature break API compatibility

I wouldn't call this component "clean" after those changes though, but it's a start. As stuff still to do to improve, I see:

- Using DataTrackers to call reinit() when necessary
- get rid of bwdInit by using componentState + datatrackers to reinit component
- remove those ugly getContext to retrieve the external mstate used for rest shape, by replacing them with a data or a link.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
