### PR TITLE
[SofaGraphComponent] Update sceneCheckerAPI and deprecate MatrixMass

### DIFF
--- a/SofaKernel/framework/sofa/helper/ComponentChange.cpp
+++ b/SofaKernel/framework/sofa/helper/ComponentChange.cpp
@@ -32,6 +32,7 @@ namespace lifecycle
 std::map<std::string, Deprecated> deprecatedComponents = {
     // SofaMiscForceField
     {"LennardJonesForceField", Deprecated("v17.12", "v18.12")},
+    {"MatrixMass", Deprecated("v19.06", "v19.12")},
 
 };
 

--- a/modules/SofaGraphComponent/SceneCheckAPIChange.cpp
+++ b/modules/SofaGraphComponent/SceneCheckAPIChange.cpp
@@ -117,11 +117,14 @@ void SceneCheckAPIChange::doCheckOn(Node* node)
 
 void SceneCheckAPIChange::installDefaultChangeSets()
 {
-    addHookInChangeSet("19.06", [this](Base* o){
-        if(o->getClassName() == "MatrixMass" )
+    // Template of addHookInChangeSet
+    /*
+    addHookInChangeSet("17.06", [this](Base* o){
+        if(o->getClassName() == "BoxStiffSpringForceField" )
             msg_warning(o) << this->getName() << ": "
-                           << "MatrixMass is deprecated since 19.06 and will be removed in 19.12. Use instead MeshMatrixMass or its lumped version DiagonalMass";
+                           << "BoxStiffSpringForceField have changed since 17.06. To use the old behavior you need to set parameter 'forceOldBehavior=true'";
     });
+    */
 }
 
 void SceneCheckAPIChange::addHookInChangeSet(const std::string& version, ChangeSetHookFunction fct)

--- a/modules/SofaGraphComponent/SceneCheckAPIChange.cpp
+++ b/modules/SofaGraphComponent/SceneCheckAPIChange.cpp
@@ -117,10 +117,10 @@ void SceneCheckAPIChange::doCheckOn(Node* node)
 
 void SceneCheckAPIChange::installDefaultChangeSets()
 {
-    addHookInChangeSet("17.06", [this](Base* o){
-        if(o->getClassName() == "BoxStiffSpringForceField" )
+    addHookInChangeSet("19.06", [this](Base* o){
+        if(o->getClassName() == "MatrixMass" )
             msg_warning(o) << this->getName() << ": "
-                           << "BoxStiffSpringForceField have changed since 17.06. To use the old behavior you need to set parameter 'forceOldBehavior=true'";
+                           << "MatrixMass is deprecated since 19.06 and will be removed in 19.12. Use instead MeshMatrixMass or its lumped version DiagonalMass";
     });
 }
 

--- a/modules/SofaGraphComponent/SceneCheckAPIChange.cpp
+++ b/modules/SofaGraphComponent/SceneCheckAPIChange.cpp
@@ -118,6 +118,8 @@ void SceneCheckAPIChange::doCheckOn(Node* node)
 void SceneCheckAPIChange::installDefaultChangeSets()
 {
     // Template of addHookInChangeSet
+    // addHookInChangeSet warns the user about changes that occured within a component
+    // (change in API, behavior, default values, etc.)
     /*
     addHookInChangeSet("17.06", [this](Base* o){
         if(o->getClassName() == "BoxStiffSpringForceField" )

--- a/modules/SofaGraphComponent/SceneCheckAPIChange.h
+++ b/modules/SofaGraphComponent/SceneCheckAPIChange.h
@@ -66,7 +66,7 @@ public:
     void addHookInChangeSet(const std::string& version, ChangeSetHookFunction fct);
 private:
     std::string m_currentApiLevel;
-    std::string m_selectedApiLevel {"17.06"};
+    std::string m_selectedApiLevel {"19.06"};
 
     std::map<std::string, std::vector<ChangeSetHookFunction>> m_changesets;
 };

--- a/modules/SofaMiscForceField/MatrixMass.h
+++ b/modules/SofaMiscForceField/MatrixMass.h
@@ -46,7 +46,7 @@ It is possible to use lumped matrices.
 */
 
 template <class DataTypes, class MassType>
-class MatrixMass : public core::behavior::Mass<DataTypes>
+class [[deprecated("Class MatrixMass is deprecated and will be removed after 19.12")]] MatrixMass : public core::behavior::Mass<DataTypes>
 {
 public:
     SOFA_CLASS(SOFA_TEMPLATE2(MatrixMass,DataTypes,MassType), SOFA_TEMPLATE(core::behavior::Mass,DataTypes));


### PR DESCRIPTION
This PR:
- updates the sceneCheckerAPI by setting the default leve at 19.06 and removing the warning for BoxStiffSpringFF
- set as deprecated MatrixMass for developers
- warns users about the deprecation



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
