### PR TITLE
[SofaGui] Prevent the GuiManager to store a pointer for the valid gui name

### DIFF
--- a/applications/sofa/gui/GUIManager.cpp
+++ b/applications/sofa/gui/GUIManager.cpp
@@ -46,7 +46,7 @@ namespace gui
 /*STATIC FIELD DEFINITIONS */
 BaseGUI* GUIManager::currentGUI = nullptr;
 std::list<GUIManager::GUICreator> GUIManager::guiCreators;
-const char* GUIManager::valid_guiname = nullptr;
+std::string GUIManager::valid_guiname = "";
 ArgumentParser* GUIManager::currentArgumentParser = nullptr;
 
 
@@ -234,12 +234,12 @@ int GUIManager::createGUI(sofa::simulation::Node::SPtr groot, const char* filena
 {
     if (!currentGUI)
     {
-        GUICreator* creator = GetGUICreator(valid_guiname);
+        GUICreator* creator = GetGUICreator(valid_guiname.c_str());
         if (!creator)
         {
             return 1;
         }
-        currentGUI = (*creator->creator)(valid_guiname, groot, filename);
+        currentGUI = (*creator->creator)(valid_guiname.c_str(), groot, filename);
         if (!currentGUI)
         {
             msg_error("GUIManager") << "GUI '"<<valid_guiname<<"' creation failed." ;

--- a/applications/sofa/gui/GUIManager.h
+++ b/applications/sofa/gui/GUIManager.h
@@ -100,7 +100,7 @@ protected:
 
     static std::vector<std::string> guiOptions;
     static BaseGUI* currentGUI;
-    static const char* valid_guiname;
+    static std::string valid_guiname;
     static ArgumentParser* currentArgumentParser;
 public:
     static BaseGUI* getGUI();


### PR DESCRIPTION
This fixes a segmentation fault I had with the SofaPython3 where the valid gui name was a python string variable. Since the GUI manager was storing a raw pointer to it, and since the python variable was later destroyed, the GUI manager was seg faulting when accessing the pointer.

This PR simply creates a copy of the string instead of storing a raw pointer to it.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
