### PR TITLE
[SofaConstraint] Fix UncoupledConstraintCorrection topology change handling

### DIFF
--- a/modules/SofaConstraint/UncoupledConstraintCorrection.cpp
+++ b/modules/SofaConstraint/UncoupledConstraintCorrection.cpp
@@ -43,20 +43,6 @@ namespace constraintset
 using namespace sofa::defaulttype;
 
 template<>
-SOFA_CONSTRAINT_API UncoupledConstraintCorrection< sofa::defaulttype::Rigid3Types >::UncoupledConstraintCorrection(sofa::core::behavior::MechanicalState<sofa::defaulttype::Rigid3Types> *mm)
-    : Inherit(mm)
-    , compliance(initData(&compliance, "compliance", "Rigid compliance value: 1st value for translations, 6 others for upper-triangular part of symmetric 3x3 rotation compliance matrix"))
-    , defaultCompliance(initData(&defaultCompliance, (Real)0.00001, "defaultCompliance", "Default compliance value for new dof or if all should have the same (in which case compliance vector should be empty)"))
-    , f_verbose( initData(&f_verbose,false,"verbose","Dump the constraint matrix at each iteration") )
-    , d_handleTopologyChange(initData(&d_handleTopologyChange, false, "handleTopologyChange", "Enable support of topological changes for compliance vector (should be disabled for rigids)"))
-    , d_correctionVelocityFactor(initData(&d_correctionVelocityFactor, (Real)1.0, "correctionVelocityFactor", "Factor applied to the constraint forces when correcting the velocities"))
-    , d_correctionPositionFactor(initData(&d_correctionPositionFactor, (Real)1.0, "correctionPositionFactor", "Factor applied to the constraint forces when correcting the positions"))
-    , d_useOdeSolverIntegrationFactors(initData(&d_useOdeSolverIntegrationFactors, false, "useOdeSolverIntegrationFactors", "Use odeSolver integration factors instead of correctionVelocityFactor and correctionPositionFactor"))
-    , m_pOdeSolver(NULL)
-{
-}
-
-template<>
 SOFA_CONSTRAINT_API void UncoupledConstraintCorrection< defaulttype::Rigid3Types >::init()
 {
     Inherit::init();
@@ -183,8 +169,7 @@ int UncoupledConstraintCorrectionClass = core::RegisterObject("Component computi
         .add< UncoupledConstraintCorrection< Vec2Types > >()
         .add< UncoupledConstraintCorrection< Vec3Types > >()
         .add< UncoupledConstraintCorrection< Rigid3Types > >()
-
-        ;
+    ;
 
 template class SOFA_CONSTRAINT_API UncoupledConstraintCorrection< Vec1Types >;
 template class SOFA_CONSTRAINT_API UncoupledConstraintCorrection< Vec2Types >;

--- a/modules/SofaConstraint/UncoupledConstraintCorrection.h
+++ b/modules/SofaConstraint/UncoupledConstraintCorrection.h
@@ -25,7 +25,7 @@
 
 #include <sofa/core/behavior/ConstraintCorrection.h>
 #include <sofa/core/behavior/OdeSolver.h>
-
+#include <SofaBaseTopology/TopologyData.h>
 
 namespace sofa
 {
@@ -70,7 +70,7 @@ public:
     void reinit() override;
 
     /// Handle Topological Changes.
-    void handleTopologyChange() override;
+    //void handleTopologyChange() override;
 
     void addComplianceInConstraintSpace(const sofa::core::ConstraintParams *cparams, sofa::defaulttype::BaseMatrix *W) override;
 
@@ -119,7 +119,7 @@ public:
 
     /// @}
 
-    Data< VecReal > compliance; ///< Rigid compliance value: 1st value for translations, 6 others for upper-triangular part of symmetric 3x3 rotation compliance matrix
+    topology::PointData< VecReal > compliance; ///< Rigid compliance value: 1st value for translations, 6 others for upper-triangular part of symmetric 3x3 rotation compliance matrix
 
     Data< Real > defaultCompliance; ///< Default compliance value for new dof or if all should have the same (in which case compliance vector should be empty)
 

--- a/modules/SofaConstraint/UncoupledConstraintCorrection.h
+++ b/modules/SofaConstraint/UncoupledConstraintCorrection.h
@@ -125,8 +125,6 @@ public:
 
     Data<bool> f_verbose; ///< Dump the constraint matrix at each iteration
 
-    Data < bool > d_handleTopologyChange; ///< Enable support of topological changes for compliance vector (disable if another component takes care of this)
-      
     Data< Real > d_correctionVelocityFactor; ///< Factor applied to the constraint forces when correcting the velocities
     Data< Real > d_correctionPositionFactor; ///< Factor applied to the constraint forces when correcting the positions
 

--- a/modules/SofaConstraint/UncoupledConstraintCorrection.h
+++ b/modules/SofaConstraint/UncoupledConstraintCorrection.h
@@ -147,8 +147,6 @@ protected:
     void computeDx(const Data< VecDeriv > &f, VecDeriv& x);
 };
 
-template<>
-UncoupledConstraintCorrection< sofa::defaulttype::Rigid3Types >::UncoupledConstraintCorrection(sofa::core::behavior::MechanicalState<sofa::defaulttype::Rigid3Types> *mm);
 
 template<>
 void UncoupledConstraintCorrection< sofa::defaulttype::Rigid3Types >::init();

--- a/modules/SofaConstraint/UncoupledConstraintCorrection.h
+++ b/modules/SofaConstraint/UncoupledConstraintCorrection.h
@@ -69,9 +69,6 @@ public:
 
     void reinit() override;
 
-    /// Handle Topological Changes.
-    //void handleTopologyChange() override;
-
     void addComplianceInConstraintSpace(const sofa::core::ConstraintParams *cparams, sofa::defaulttype::BaseMatrix *W) override;
 
     void getComplianceMatrix(defaulttype::BaseMatrix* ) const override;

--- a/modules/SofaConstraint/UncoupledConstraintCorrection.inl
+++ b/modules/SofaConstraint/UncoupledConstraintCorrection.inl
@@ -109,8 +109,8 @@ inline sofa::defaulttype::RigidDeriv<3, Real> UncoupledConstraintCorrection_comp
 
 template<class DataTypes>
 UncoupledConstraintCorrection<DataTypes>::UncoupledConstraintCorrection(sofa::core::behavior::MechanicalState<DataTypes> *mm)
-    : Inherit(mm)
-    , compliance(initData(&compliance, "compliance", "compliance value on each dof"))
+    : Inherit(mm)    
+    , compliance(initData(&compliance, "compliance", "compliance value on each dof. If Rigid compliance (7 values): 1st value for translations, 6 others for upper-triangular part of symmetric 3x3 rotation compliance matrix"))
     , defaultCompliance(initData(&defaultCompliance, (Real)0.00001, "defaultCompliance", "Default compliance value for new dof or if all should have the same (in which case compliance vector should be empty)"))
     , f_verbose( initData(&f_verbose,false,"verbose","Dump the constraint matrix at each iteration") )
     , d_handleTopologyChange(initData(&d_handleTopologyChange, true, "handleTopologyChange", "Enable support of topological changes for compliance vector (disable if another component takes care of this)"))

--- a/modules/SofaConstraint/UncoupledConstraintCorrection.inl
+++ b/modules/SofaConstraint/UncoupledConstraintCorrection.inl
@@ -113,7 +113,6 @@ UncoupledConstraintCorrection<DataTypes>::UncoupledConstraintCorrection(sofa::co
     , compliance(initData(&compliance, "compliance", "compliance value on each dof. If Rigid compliance (7 values): 1st value for translations, 6 others for upper-triangular part of symmetric 3x3 rotation compliance matrix"))
     , defaultCompliance(initData(&defaultCompliance, (Real)0.00001, "defaultCompliance", "Default compliance value for new dof or if all should have the same (in which case compliance vector should be empty)"))
     , f_verbose( initData(&f_verbose,false,"verbose","Dump the constraint matrix at each iteration") )
-    , d_handleTopologyChange(initData(&d_handleTopologyChange, true, "handleTopologyChange", "Enable support of topological changes for compliance vector (disable if another component takes care of this)"))
     , d_correctionVelocityFactor(initData(&d_correctionVelocityFactor, (Real)1.0, "correctionVelocityFactor", "Factor applied to the constraint forces when correcting the velocities"))
     , d_correctionPositionFactor(initData(&d_correctionPositionFactor, (Real)1.0, "correctionPositionFactor", "Factor applied to the constraint forces when correcting the positions"))
     , d_useOdeSolverIntegrationFactors(initData(&d_useOdeSolverIntegrationFactors, false, "useOdeSolverIntegrationFactors", "Use odeSolver integration factors instead of correctionVelocityFactor and correctionPositionFactor"))
@@ -146,9 +145,10 @@ void UncoupledConstraintCorrection<DataTypes>::init()
         if (!defaultCompliance.isSet() && !comp.empty())
             defaultCompliance.setValue(comp[0]); // set default compliance to first one in case it was given in the compliance vector
         if (comp.size() > 1)
-            serr << "Warning compliance size ( " << comp.size() << " is not equal to the size of the mstate (" << x.size() << ")" << sendl;
+            msg_warning() << "Compliance size ( " << comp.size() << " is not equal to the size of the mstate (" << x.size() << ")";
         Real comp0 = (!comp.empty()) ? comp[0] : defaultCompliance.getValue();
-        sout << "Using " << comp0 << " as initial compliance" << sendl;
+        msg_warning() << "Using " << comp0 << " as initial compliance";
+
         VecReal UsedComp;
         for (unsigned int i=0; i<x.size(); i++)
         {
@@ -174,7 +174,7 @@ void UncoupledConstraintCorrection<DataTypes>::init()
     {
         if (d_useOdeSolverIntegrationFactors.getValue() == true)
         {
-            serr << "Can't find any odeSolver" << sendl;
+            msg_error() << "Can't find any odeSolver";
             d_useOdeSolverIntegrationFactors.setValue(false);
         }
         d_useOdeSolverIntegrationFactors.setReadOnly(true);
@@ -297,7 +297,7 @@ void UncoupledConstraintCorrection<DataTypes>::addComplianceInConstraintSpace(co
 
         if (verbose)
         {
-            sout << "C[" << indexCurRowConst << "]";
+            dmsg_info() << "C[" << indexCurRowConst << "]";
         }
 
         const MatrixDerivColConstIterator colItBegin = rowIt.begin();
@@ -314,7 +314,7 @@ void UncoupledConstraintCorrection<DataTypes>::addComplianceInConstraintSpace(co
 
                 if (verbose)
                 {
-                    sout << " dof[" << dof << "]=" << n;
+                    dmsg_info() << " dof[" << dof << "]=" << n;
                 }
 
                 //w += (n * n) * (dof < comp.size() ? comp[dof] : comp0);


### PR DESCRIPTION
In UncoupledConstraintCorrection class:
- Use PointData instead of handleTopologyChange method
- Small cleaning
- Remove duplicated constructor

Fix one of the component in #810 
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
