### PR TITLE
[SofaKernel] ADD: static method in events to retrieve the classname

### DIFF
--- a/SofaKernel/framework/sofa/core/objectmodel/DetachNodeEvent.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/DetachNodeEvent.h
@@ -55,7 +55,7 @@ public:
 
     bool contains(BaseObject* o) const;
 
-    const char* getClassName() const override { return "DetachNodeEvent"; }
+    inline static const char* GetClassName() { return "DetachNodeEvent"; }
 protected:
     BaseNode* node;
 };

--- a/SofaKernel/framework/sofa/core/objectmodel/Event.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/Event.h
@@ -40,7 +40,8 @@ namespace objectmodel
     static const size_t s_eventTypeIndex; \
     public:\
     virtual size_t getEventTypeIndex() const override { return T::s_eventTypeIndex; } \
-    static bool checkEventType( const Event* event ) { return event->getEventTypeIndex() == T::s_eventTypeIndex; }
+    static bool checkEventType( const Event* event ) { return event->getEventTypeIndex() == T::s_eventTypeIndex; } \
+    virtual const char* getClassName() const override { return T::GetClassName(); }
 
 
 /// this has to be added in the Event implementation file
@@ -68,8 +69,15 @@ public:
     /// Returns true of the event has been handled
     bool isHandled() const;
 
-    virtual const char* getClassName() const { return "Event"; }
 
+    /// \returns the class name from an instance.
+    /// Do not override directly. Instead, add the SOFA_EVENT_H in your class definition
+    virtual const char* getClassName() const { return Event::GetClassName(); }
+
+    /// \returns the name of the event type.
+    /// As the method is static the name can be retrieved without instantiation.
+    /// Must be reimplemented in each subclasse
+    inline static const char* GetClassName() { return "Event"; }
 
     /// \returns unique type index
     /// for fast Event type comparison with unique indices (see function 'checkEventType')

--- a/SofaKernel/framework/sofa/core/objectmodel/GUIEvent.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/GUIEvent.h
@@ -70,7 +70,7 @@ public:
     const std::string getValue(void) const {return m_value;}
 
 
-    const char* getClassName() const override { return "GUIEvent"; }
+    inline static const char* GetClassName() { return "GUIEvent"; }
 private:
 
     std::string     m_controlID;

--- a/SofaKernel/framework/sofa/core/objectmodel/HapticDeviceEvent.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/HapticDeviceEvent.h
@@ -105,7 +105,7 @@ public:
      */
     unsigned int getDeviceId() const {return m_deviceId;}
 
-    const char* getClassName() const override { return "HapticDeviceEvent"; }
+    inline static const char* GetClassName() { return "HapticDeviceEvent"; }
 private:
 
     unsigned int	m_deviceId;

--- a/SofaKernel/framework/sofa/core/objectmodel/IdleEvent.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/IdleEvent.cpp
@@ -35,8 +35,7 @@ SOFA_EVENT_CPP( IdleEvent )
 
 IdleEvent::IdleEvent() {}
 IdleEvent::~IdleEvent() {}
-const char* IdleEvent::getClassName() const { return "IdleEvent"; }
 
-}
-}
-}
+}  // objectmodel
+}  // core
+}  // sofa

--- a/SofaKernel/framework/sofa/core/objectmodel/IdleEvent.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/IdleEvent.h
@@ -44,7 +44,7 @@ public:
     ~IdleEvent() override;
     SOFA_EVENT_H( IdleEvent )
 
-    const char* getClassName() const override;
+    inline static const char* GetClassName() { return "IdleEvent"; }
 protected:
 };
 

--- a/SofaKernel/framework/sofa/core/objectmodel/JoystickEvent.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/JoystickEvent.h
@@ -263,7 +263,7 @@ public:
      */
     ~JoystickEvent() override;
 
-    const char* getClassName() const override { return "JoystickEvent"; }
+    inline static const char* GetClassName() { return "JoystickEvent"; }
 protected:
 
     std::vector< AxisEvent* > axisEvents; ///< State of the Analogic Pad

--- a/SofaKernel/framework/sofa/core/objectmodel/KeypressedEvent.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/KeypressedEvent.h
@@ -50,7 +50,7 @@ public:
     /// Return the key pressed
     char getKey() const;
 
-    const char* getClassName() const override { return "KeypressedEvent"; }
+    inline static const char* GetClassName() { return "KeypressedEvent"; }
 protected:
     /// Store the key
     char m_char;

--- a/SofaKernel/framework/sofa/core/objectmodel/KeyreleasedEvent.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/KeyreleasedEvent.h
@@ -50,7 +50,7 @@ public:
     /// Return the key released
     char getKey() const;
 
-    const char* getClassName() const override { return "KeyreleasedEvent"; }
+    inline static const char* GetClassName() { return "KeyreleasedEvent"; }
 protected:
     /// Store the key
     char m_char;

--- a/SofaKernel/framework/sofa/core/objectmodel/MouseEvent.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/MouseEvent.h
@@ -104,7 +104,7 @@ public:
     State getState(void) const {return m_state;}
     //}@
 
-    const char* getClassName() const override { return "MouseEvent"; }
+    inline static const char* GetClassName() { return "MouseEvent"; }
 private:
 
     State m_state; ///< Mouse State on the event propagation.

--- a/SofaKernel/framework/sofa/core/objectmodel/ScriptEvent.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/ScriptEvent.h
@@ -63,9 +63,9 @@ public:
     /**
      * @brief Get the event name
      */
-    const std::string getEventName(void) const {return m_eventName;}
+    const std::string& getEventName(void) const { return m_eventName; }
 
-    const char* getClassName() const override { return "ScriptEvent"; }
+    inline static const char* GetClassName() { return "ScriptEvent"; }
 private:
 
     sofa::simulation::Node::SPtr m_sender;

--- a/SofaKernel/framework/sofa/simulation/AnimateBeginEvent.h
+++ b/SofaKernel/framework/sofa/simulation/AnimateBeginEvent.h
@@ -57,7 +57,7 @@ public:
     ~AnimateBeginEvent() override;
 
     SReal getDt() const { return dt; }
-    const char* getClassName() const override { return "AnimateBeginEvent"; }
+    inline static const char* GetClassName() { return "AnimateBeginEvent"; }
 protected:
     SReal dt;
 };

--- a/SofaKernel/framework/sofa/simulation/AnimateEndEvent.h
+++ b/SofaKernel/framework/sofa/simulation/AnimateEndEvent.h
@@ -59,7 +59,7 @@ public:
 
     SReal getDt() const { return dt; }
 
-    const char* getClassName() const override { return "AnimateEndEvent"; }
+    inline static const char* GetClassName() { return "AnimateEndEvent"; }
 protected:
     SReal dt;
 };

--- a/SofaKernel/framework/sofa/simulation/CollisionBeginEvent.h
+++ b/SofaKernel/framework/sofa/simulation/CollisionBeginEvent.h
@@ -40,7 +40,7 @@ public:
 
     SOFA_EVENT_H( CollisionBeginEvent )
 
-    const char* getClassName() const override { return "CollisionBeginEvent"; }
+    inline static const char* GetClassName() { return "CollisionBeginEvent"; }
 };
 
 } // namespace simulation

--- a/SofaKernel/framework/sofa/simulation/CollisionEndEvent.h
+++ b/SofaKernel/framework/sofa/simulation/CollisionEndEvent.h
@@ -42,7 +42,7 @@ public:
 
     SOFA_EVENT_H( CollisionEndEvent )
 
-    const char* getClassName() const override { return "CollisionEndEvent"; }
+    static const char* GetClassName() { return "CollisionEndEvent"; }
 };
 
 } // namespace simulation

--- a/SofaKernel/framework/sofa/simulation/IntegrateBeginEvent.h
+++ b/SofaKernel/framework/sofa/simulation/IntegrateBeginEvent.h
@@ -40,7 +40,7 @@ public:
 
     SOFA_EVENT_H( IntegrateBeginEvent )
 
-    const char* getClassName() const override { return "IntegrateBeginEvent"; }
+    inline static const char* GetClassName() { return "IntegrateBeginEvent"; }
 };
 
 } // namespace simulation

--- a/SofaKernel/framework/sofa/simulation/IntegrateEndEvent.h
+++ b/SofaKernel/framework/sofa/simulation/IntegrateEndEvent.h
@@ -40,7 +40,7 @@ public:
 
     SOFA_EVENT_H( IntegrateEndEvent )
 
-    const char* getClassName() const override { return "IntegrateEndEvent"; }
+    inline static const char* GetClassName() { return "IntegrateEndEvent"; }
 };
 
 } // namespace simulation

--- a/SofaKernel/framework/sofa/simulation/PauseEvent.h
+++ b/SofaKernel/framework/sofa/simulation/PauseEvent.h
@@ -44,7 +44,7 @@ public:
 
     ~PauseEvent() override;
 
-    const char* getClassName() const override { return "PauseEvent"; }
+    inline static const char* GetClassName() { return "PauseEvent"; }
 
 };
 

--- a/SofaKernel/framework/sofa/simulation/PositionEvent.h
+++ b/SofaKernel/framework/sofa/simulation/PositionEvent.h
@@ -44,7 +44,7 @@ public:
 
     ~PositionEvent() override;
 
-    const char* getClassName() const override { return "PositionEvent"; }
+    inline static const char* GetClassName() { return "PositionEvent"; }
 
 };
 

--- a/SofaKernel/framework/sofa/simulation/UpdateMappingEndEvent.h
+++ b/SofaKernel/framework/sofa/simulation/UpdateMappingEndEvent.h
@@ -57,7 +57,7 @@ public:
     ~UpdateMappingEndEvent() override;
 
     SReal getDt() const { return dt; }
-    const char* getClassName() const override { return "UpdateMappingEndEvent"; }
+    inline static const char* GetClassName() { return "UpdateMappingEndEvent"; }
 protected:
     SReal dt;
 };

--- a/applications/plugins/ARTrack/ARTrackEvent.h
+++ b/applications/plugins/ARTrack/ARTrackEvent.h
@@ -61,6 +61,7 @@ public:
     const Quat getOrientation() const;
     const sofa::helper::fixed_array<double,3> getAngles() const;
     const Vector3 getFingerposition(const unsigned int i) const;
+    static inline const char* GetClassName() { return "ARTrackEvent"; }
 
 private:
     Vector3 m_position; ///< ARTrack coordinates in a Vec3d type.

--- a/applications/plugins/MultiThreading/src/DataExchange.h
+++ b/applications/plugins/MultiThreading/src/DataExchange.h
@@ -52,7 +52,7 @@ namespace sofa
 			~DataExchangeEvent() override {}
 
 			double getDt() const { return dt; }
-			const char* getClassName() const override { return "DataExchangeEvent"; }
+			static inline const char* GetClassName() { return "DataExchangeEvent"; }
 		protected:
 			double dt;
 		};

--- a/applications/plugins/SofaPython/PythonScriptEvent.h
+++ b/applications/plugins/SofaPython/PythonScriptEvent.h
@@ -61,7 +61,7 @@ public:
      */
     PyObject* getUserData(void) const {return m_userData;}
 
-    const char* getClassName() const override { return "PythonScriptEvent"; }
+    static inline const char* GetClassName() { return "PythonScriptEvent"; }
 private:
 
     PyObject* m_userData;


### PR DESCRIPTION
This PR changes the API of the Event class slightly so that there's no need to instantiate an Event to get its classname.
The getClassName method that was previously implemented by each of Event's subclasses is moved in the SOFA_EVENT_H macro, and a static GetClassName method becomes the one to override.

This is important as Events do not have a default ctor and it is thus impossible to instantiate a dummy event to check its type without knowing the signature of the subclass's ctor.

This allows me to implement better and cleaner bindings for events in SofaPython3.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
