### PR TITLE
[SofaBoundaryCondition] Fix FixedRotationConstraint when using more than one locked axis

### DIFF
--- a/examples/Components/constraint/FixedRotationConstraint.scn
+++ b/examples/Components/constraint/FixedRotationConstraint.scn
@@ -9,26 +9,26 @@
         <EulerImplicitSolver name="cg_odesolver" printLog="0"  rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver template="GraphScattered" name="linear solver" iterations="25" tolerance="1e-12" threshold="1e-09" />
         <Node name="Rotation around Z axis not authorized" gravity="0 -9.81 0">
-            <MechanicalObject template="Rigid" name="default0" translation="0 0 0" rotation="0 0 0" restScale="1" position="0 0 0 0 0 0 1 1 0 0 0 0 0 1" />
-            <FixedConstraint template="Rigid" name="default1" indices="0" />
-            <FixedRotationConstraint template="Rigid" name="default2" FixedXRotation="0" FixedYRotation="0" FixedZRotation="1" />
-            <UniformMass template="Rigid" name="default3" showAxisSizeFactor="1" />
+            <MechanicalObject template="Rigid3d" name="default0" translation="0 0 0" rotation="0 0 0" restScale="1" position="0 0 0 0 0 0 1 1 0 0 0 0 0 1" />
+            <FixedConstraint template="Rigid3d" name="default1" indices="0" />
+            <FixedRotationConstraint template="Rigid3d" name="default2" FixedXRotation="0" FixedYRotation="0" FixedZRotation="1" />
+            <UniformMass template="Rigid3d" name="default3" showAxisSizeFactor="1" />
             <Node name="spring" gravity="0 -9.81 0">
-                <MechanicalObject template="Rigid" name="default4" translation="0 0 0" rotation="0 0 0" restScale="1" position="0 0 0 0 0 0 1 -1 0 0 0 0 0 1" />
-                <UniformMass template="Rigid" name="default54" showAxisSizeFactor="1" />
-                <RigidRigidMapping template="Rigid,Rigid" name="default1" repartition="1 1" axisLength="0.001" />
-                <JointSpringForceField template="Rigid" name="default5" spring="BEGIN_SPRING  0 1  KS_T 1e+06 100000  KS_R 0 1000  KS_B 100  END_SPRING&#x0A;" />
+                <MechanicalObject template="Rigid3d" name="default4" translation="0 0 0" rotation="0 0 0" restScale="1" position="0 0 0 0 0 0 1 -1 0 0 0 0 0 1" />
+                <UniformMass template="Rigid3d" name="default54" showAxisSizeFactor="1" />
+                <RigidRigidMapping template="Rigid3d,Rigid3d" name="default1" repartition="1 1" axisLength="0.001" />
+                <JointSpringForceField template="Rigid3d" name="default5" spring="BEGIN_SPRING  0 1  KS_T 1e+06 100000  KS_R 0 1000  KS_B 100  END_SPRING&#x0A;" />
             </Node>
         </Node>
         <Node name="Rotation around Z axis is free" gravity="0 -9.81 0">
-            <MechanicalObject template="Rigid" name="default6" translation="0 0 0" rotation="0 0 0" restScale="1" position="3 0 0 0 0 0 1 4 0 0 0 0 0 1" />
-            <FixedConstraint template="Rigid" name="default7" indices="0" />
-            <UniformMass template="Rigid" name="default54" showAxisSizeFactor="1" />
+            <MechanicalObject template="Rigid3d" name="default6" translation="0 0 0" rotation="0 0 0" restScale="1" position="3 0 0 0 0 0 1 4 0 0 0 0 0 1" />
+            <FixedConstraint template="Rigid3d" name="default7" indices="0" />
+            <UniformMass template="Rigid3d" name="default54" showAxisSizeFactor="1" />
             <Node name="spring" gravity="0 -9.81 0">
-                <MechanicalObject template="Rigid" name="default9" translation="0 0 0" rotation="0 0 0" restScale="1" position="0 0 0 0 0 0 1 -1 0 0 0 0 0 1" />
-                <UniformMass template="Rigid" name="default10" showAxisSizeFactor="1" />
-                <RigidRigidMapping template="Rigid,Rigid" name="default11" repartition="1 1" axisLength="0.001" />
-                <JointSpringForceField template="Rigid" name="default12" spring="BEGIN_SPRING  0 1  END_SPRING&#x0A;" />
+                <MechanicalObject template="Rigid3d" name="default9" translation="0 0 0" rotation="0 0 0" restScale="1" position="0 0 0 0 0 0 1 -1 0 0 0 0 0 1" />
+                <UniformMass template="Rigid3d" name="default10" showAxisSizeFactor="1" />
+                <RigidRigidMapping template="Rigid3d,Rigid3d" name="default11" repartition="1 1" axisLength="0.001" />
+                <JointSpringForceField template="Rigid3d" name="default12" spring="BEGIN_SPRING  0 1  END_SPRING&#x0A;" />
             </Node>
         </Node>
     </Node>

--- a/modules/SofaBoundaryCondition/FixedRotationConstraint.inl
+++ b/modules/SofaBoundaryCondition/FixedRotationConstraint.inl
@@ -120,7 +120,7 @@ void FixedRotationConstraint<DataTypes>::projectPosition(const core::MechanicalP
         sofa::defaulttype::Quat Qp_remaining = Q_prev;
         sofa::defaulttype::Quat to_keep = sofa::defaulttype::Quat::identity();
 
-        auto remove_rotation = [&Q_remaining, &Qp_remaining, &to_keep](const Vec3 axis) {
+        auto remove_rotation = [&](const Vec3 axis) {
             Q_remaining = decompose_ts(Q_remaining, axis).second;
             sofa::defaulttype::Quat twist;
             std::tie(twist, Qp_remaining) = decompose_ts(Qp_remaining, axis);


### PR DESCRIPTION
Current implementation has weird behavior when more than one axis is locked. Current implementation may make the objects rotate 180° when they should not.

Current PR aims to prevent this issue using swing-twist decomposition algorithm.
As a bonus, code is now shorter.

Everything was done inside the class, but the swing twist decomposition could be move to the main quaternion class.


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
