### PR TITLE
[SofaMacros] FIX default module version

### DIFF
--- a/SofaKernel/SofaFramework/SofaMacros.cmake
+++ b/SofaKernel/SofaFramework/SofaMacros.cmake
@@ -487,11 +487,11 @@ macro(sofa_install_targets package_name the_targets include_install_dir)
 
     foreach(target ${the_targets})
         set(version ${${target}_VERSION})
+        string(TOUPPER "${package_name}" package_name_upper)
         if(version VERSION_GREATER "0.0")
             set_target_properties(${target} PROPERTIES VERSION "${version}")
-        elseif(target MATCHES "^Sofa" AND SofaFramework_VERSION)
-            set_target_properties(${target} PROPERTIES VERSION "${SofaFramework_VERSION}")
-        elseif(target MATCHES "^Sofa" AND Sofa_VERSION)
+        elseif(target MATCHES "^Sofa" AND NOT PLUGIN_${package_name_upper} AND Sofa_VERSION)
+            # Default to Sofa_VERSION for all SOFA modules
             set_target_properties(${target} PROPERTIES VERSION "${Sofa_VERSION}")
         endif()
 


### PR DESCRIPTION
This should fix the CUDA issue on CI.

Issue was due to SofaCUDA having a version number (instead of NO_VERSION) and thus not being deactivated for scene tests by CI scripts (main.sh).

We chose to deactivate SofaCUDA for scene tests because VMs can't run CUDA (or can they?).
In CI, SofaCUDA is only compiled, never executed.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
