### PR TITLE
[SofaTopologyMapping] Cleanups of some topological mappings + better initialization

### DIFF
--- a/modules/SofaTopologyMapping/Hexa2QuadTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/Hexa2QuadTopologicalMapping.cpp
@@ -169,7 +169,7 @@ void Hexa2QuadTopologicalMapping::updateTopologicalMappingTopDown()
     auto itBegin=fromModel->beginChange();
     auto itEnd=fromModel->endChange();
 
-    auto & Loc2GlobVec = *(Loc2GlobDataVec.beginEdit());
+    Topology::SetIndices & Loc2GlobVec = *(Loc2GlobDataVec.beginEdit());
 
     while( itBegin != itEnd )
     {
@@ -193,7 +193,7 @@ void Hexa2QuadTopologicalMapping::updateTopologicalMappingTopDown()
             auto last = (unsigned int)fromModel->getNbQuads() - 1;
             auto ind_last = (unsigned int)toModel->getNbQuads();
 
-            const auto & tab = ( static_cast< const QuadsRemoved *>( *itBegin ) )->getArray();
+            const Topology::SetIndices & tab = ( static_cast< const QuadsRemoved *>( *itBegin ) )->getArray();
 
             unsigned int ind_tmp;
 
@@ -271,7 +271,7 @@ void Hexa2QuadTopologicalMapping::updateTopologicalMappingTopDown()
         {
             const sofa::helper::vector<core::topology::BaseMeshTopology::Hexahedron> &hexahedronArray=fromModel->getHexahedra();
 
-            const auto & tab = ( static_cast< const HexahedraRemoved *>( *itBegin ) )->getArray();
+            const Topology::SetIndices & tab = ( static_cast< const HexahedraRemoved *>( *itBegin ) )->getArray();
 
             sofa::helper::vector< core::topology::BaseMeshTopology::Quad > quads_to_create;
             sofa::helper::vector< unsigned int > quadsIndexList;
@@ -364,16 +364,16 @@ void Hexa2QuadTopologicalMapping::updateTopologicalMappingTopDown()
 
         case core::topology::POINTSREMOVED:
         {
-            const auto & tab = ( static_cast< const sofa::component::topology::PointsRemoved * >( *itBegin ) )->getArray();
+            const Topology::SetIndices & tab = ( static_cast< const sofa::component::topology::PointsRemoved * >( *itBegin ) )->getArray();
 
-            sofa::helper::vector<unsigned int> indices;
+            Topology::SetIndices indices;
 
             for(unsigned int i = 0; i < tab.size(); ++i)
             {
                 indices.push_back(tab[i]);
             }
 
-            auto & tab_indices = indices;
+            Topology::SetIndices & tab_indices = indices;
 
             to_tstm->removePointsWarning(tab_indices, false);
             to_tstm->propagateTopologicalChanges();
@@ -384,8 +384,8 @@ void Hexa2QuadTopologicalMapping::updateTopologicalMappingTopDown()
 
         case core::topology::POINTSRENUMBERING:
         {
-            const auto & tab = ( static_cast< const PointsRenumbering * >( *itBegin ) )->getIndexArray();
-            const auto & inv_tab = ( static_cast< const PointsRenumbering * >( *itBegin ) )->getinv_IndexArray();
+            const Topology::SetIndices & tab = ( static_cast< const PointsRenumbering * >( *itBegin ) )->getIndexArray();
+            const Topology::SetIndices & inv_tab = ( static_cast< const PointsRenumbering * >( *itBegin ) )->getinv_IndexArray();
 
             sofa::helper::vector<unsigned int> indices;
             sofa::helper::vector<unsigned int> inv_indices;
@@ -396,8 +396,8 @@ void Hexa2QuadTopologicalMapping::updateTopologicalMappingTopDown()
                 inv_indices.push_back(inv_tab[i]);
             }
 
-            auto & tab_indices = indices;
-            auto & inv_tab_indices = inv_indices;
+            Topology::SetIndices & tab_indices = indices;
+            Topology::SetIndices & inv_tab_indices = inv_indices;
 
             to_tstm->renumberPointsWarning(tab_indices, inv_tab_indices, false);
             to_tstm->propagateTopologicalChanges();

--- a/modules/SofaTopologyMapping/Hexa2QuadTopologicalMapping.h
+++ b/modules/SofaTopologyMapping/Hexa2QuadTopologicalMapping.h
@@ -63,7 +63,7 @@ protected:
     *
     * Does nothing.
     */
-    ~Hexa2QuadTopologicalMapping() override;
+    ~Hexa2QuadTopologicalMapping() override = default;
 public:
     /** \brief Initializes the target BaseTopology from the source BaseTopology.
     */

--- a/modules/SofaTopologyMapping/Quad2TriangleTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/Quad2TriangleTopologicalMapping.cpp
@@ -233,7 +233,7 @@ void Quad2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
         {
             const auto & quadArray=fromModel->getQuads();
 
-            const auto & tab = ( static_cast< const QuadsAdded *>( *itBegin ) )->getArray();
+            const Topology::SetIndices & tab = ( static_cast< const QuadsAdded *>( *itBegin ) )->getArray();
 
             sofa::helper::vector< core::topology::BaseMeshTopology::Triangle > triangles_to_create;
             sofa::helper::vector< unsigned int > trianglesIndexList;
@@ -247,12 +247,12 @@ void Quad2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
                 const auto & p1 = quadArray[k][1];
                 const auto & p2 = quadArray[k][2];
                 const auto & p3 = quadArray[k][3];
-                const auto t1 = core::topology::BaseMeshTopology::Triangle((unsigned int) p0, (unsigned int) p1, (unsigned int) p2);
-                const auto t2 = core::topology::BaseMeshTopology::Triangle((unsigned int) p0, (unsigned int) p2, (unsigned int) p3);
+                const auto tri1 = core::topology::BaseMeshTopology::Triangle((unsigned int) p0, (unsigned int) p1, (unsigned int) p2);
+                const auto tri2 = core::topology::BaseMeshTopology::Triangle((unsigned int) p0, (unsigned int) p2, (unsigned int) p3);
 
-                triangles_to_create.push_back(t1);
+                triangles_to_create.push_back(tri1);
                 trianglesIndexList.push_back(nb_elems);
-                triangles_to_create.push_back(t2);
+                triangles_to_create.push_back(tri2);
                 trianglesIndexList.push_back(nb_elems+1);
                 nb_elems+=2;
 
@@ -272,7 +272,7 @@ void Quad2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
         }
         case core::topology::QUADSREMOVED:
         {
-            const auto & tab = ( static_cast< const QuadsRemoved *>( *itBegin ) )->getArray();
+            const Topology::SetIndices & tab = ( static_cast< const QuadsRemoved *>( *itBegin ) )->getArray();
 
             unsigned int last = (unsigned int)fromModel->getNbQuads() - 1;
 
@@ -383,7 +383,7 @@ void Quad2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
 
         case core::topology::POINTSREMOVED:
         {
-            const auto & tab = ( static_cast< const sofa::component::topology::PointsRemoved * >( *itBegin ) )->getArray();
+            const Topology::SetIndices & tab = ( static_cast< const sofa::component::topology::PointsRemoved * >( *itBegin ) )->getArray();
 
             sofa::helper::vector<unsigned int> indices;
 
@@ -404,8 +404,8 @@ void Quad2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
 
         case core::topology::POINTSRENUMBERING:
         {
-            const auto & tab = ( static_cast< const PointsRenumbering * >( *itBegin ) )->getIndexArray();
-            const auto & inv_tab = ( static_cast< const PointsRenumbering * >( *itBegin ) )->getinv_IndexArray();
+            const Topology::SetIndices & tab = ( static_cast< const PointsRenumbering * >( *itBegin ) )->getIndexArray();
+            const Topology::SetIndices & inv_tab = ( static_cast< const PointsRenumbering * >( *itBegin ) )->getinv_IndexArray();
 
             sofa::helper::vector<unsigned int> indices;
             sofa::helper::vector<unsigned int> inv_indices;
@@ -416,8 +416,8 @@ void Quad2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
                 inv_indices.push_back(inv_tab[i]);
             }
 
-            sofa::helper::vector<unsigned int>& tab_indices = indices;
-            sofa::helper::vector<unsigned int>& inv_tab_indices = inv_indices;
+            Topology::SetIndices& tab_indices = indices;
+            Topology::SetIndices& inv_tab_indices = inv_indices;
 
             to_tstm->renumberPointsWarning(tab_indices, inv_tab_indices, false);
             to_tstm->propagateTopologicalChanges();

--- a/modules/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.h
+++ b/modules/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.h
@@ -64,7 +64,7 @@ protected:
      *
      * Does nothing.
      */
-    ~Tetra2TriangleTopologicalMapping() override;
+    ~Tetra2TriangleTopologicalMapping() override = default;
 public:
     /** \brief Initializes the target BaseTopology from the source BaseTopology.
      */


### PR DESCRIPTION
Various cleanup and better checks at the init stage to make sure the topological mappings have everything they need.

Only Hexa2Quad, Quad2Triangle and Tetra2Triangle for now.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
