### PR TITLE
[SofaBaseLinearSolver][FullMatrix]  Restore fast clear function

### DIFF
--- a/SofaKernel/modules/SofaBaseLinearSolver/FullMatrix.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/FullMatrix.h
@@ -287,8 +287,6 @@ public:
 
     void clear() override
     {
-        if (data == nullptr)
-            return;
         if (pitch == nCol)
             std::fill(data, data+nRow*pitch, (Real)0);
         else

--- a/SofaKernel/modules/SofaBaseLinearSolver/FullMatrix.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/FullMatrix.h
@@ -287,12 +287,16 @@ public:
 
     void clear() override
     {
-        //if (pitch == nCol)
-        //    std::fill(data, data+nRow*pitch, (Real)0);
-        //else
-        for (Index i=0; i<nRow; ++i)
-            for (Index j=0; j<nCol; ++j)
-                data[i*pitch+j] = (Real)0;
+        if (data == nullptr)
+            return;
+        if (pitch == nCol)
+            std::fill(data, data+nRow*pitch, (Real)0);
+        else
+        {
+            for (Index i = 0; i<nRow; ++i)
+                for (Index j = 0; j<nCol; ++j)
+                    data[i*pitch + j] = (Real)0;
+        }
     }
 
     /// matrix-vector product

--- a/SofaKernel/modules/SofaBaseLinearSolver/MatrixExpr.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/MatrixExpr.h
@@ -328,7 +328,6 @@ public:
     template<class Dest>
     void addTo(Dest* d) const
     {
-        std::cout << "EXPR using transposed computation: " << expr() << std::endl;
         MyDest<Dest> myd(d);
         m1.addTo(&myd);
     }


### PR DESCRIPTION
A few minor change in matrix class to improve performance 

FullMatrix:  Restore fast matrix clear function
MatExpr:    Remove console output in addTo function


Clear function in visual studio profiler

current: 0.51% inclusive samples
![doubleForLoopClear](https://user-images.githubusercontent.com/3921764/63861622-85081200-c9ab-11e9-8192-e536e4c5b4eb.jpg)

std::fill:  0.18% inclusive samples 
![stdfillClear](https://user-images.githubusercontent.com/3921764/63861635-89ccc600-c9ab-11e9-9e87-2cac821888cf.jpg)



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
