### PR TITLE
[SofaCore][ExecParams] Remove thread specific declaration

### DIFF
--- a/SofaKernel/framework/sofa/core/ExecParams.cpp
+++ b/SofaKernel/framework/sofa/core/ExecParams.cpp
@@ -41,7 +41,7 @@ ExecParams::ExecParamsThreadStorage::ExecParamsThreadStorage(int tid)
 /// Get the default ExecParams, to be used to provide a default values for method parameters
 ExecParams* ExecParams::defaultInstance()
 {
-    SOFA_THREAD_SPECIFIC_PTR(ExecParams, threadParams);
+    static ExecParams* threadParams;
     ExecParams* ptr = threadParams;
     if (!ptr)
     {

--- a/SofaKernel/framework/sofa/simulation/Node.cpp
+++ b/SofaKernel/framework/sofa/simulation/Node.cpp
@@ -871,12 +871,6 @@ void Node::executeVisitor(Visitor* action, bool precomputedOrder)
     // if the current node is sleeping and the visitor can't access it, don't do anything
     if (this->isSleeping() && !action->canAccessSleepingNode) return;
 
-    if (!action->execParams()->checkValidStorage())
-    {
-        dmsg_info() << "IN " << sofa::core::objectmodel::BaseClass::decodeClassName(typeid(*action)) << " at " << this->getPathName() ;
-    }
-
-
     static int level = 0;
     if(DEBUG_VISITOR)
     {


### PR DESCRIPTION
Remove thread specific declaration for ExecParams class.

accessing thread local variables is slow and if the thread-local variable is accessed very frequently, the cost may become an issue. 
https://software.intel.com/en-us/blogs/2011/05/02/the-hidden-performance-cost-of-accessing-thread-local-variables

The ExecParams global pointer is declared thread specific but it is often passed in a function call as argument.
A function executed in a second thread can receive as argument the thread local variable of the first thread and it is allowed to use it.
In this situation there is no need of use the thread local variable.







______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
