### PR TITLE
[SofaViewer] Prevent the GUI to ouput every CTRL actions in the console

### DIFF
--- a/applications/sofa/gui/qt/viewer/SofaViewer.cpp
+++ b/applications/sofa/gui/qt/viewer/SofaViewer.cpp
@@ -242,7 +242,7 @@ void SofaViewer::keyPressEvent(QKeyEvent * e)
     case Qt::Key_Control:
     {
         m_isControlPressed = true;
-        msg_info("SofaViewer")<<"QtViewer::keyPressEvent, CONTROL pressed";
+        dmsg_info("SofaViewer")<<"QtViewer::keyPressEvent, CONTROL pressed";
         break;
     }
     default:


### PR DESCRIPTION
Significant improvement.
Just removing msg coming in the console in release due to CTRL key pressed.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
