### PR TITLE
[SofaGui] Fix VideoRecorder

### DIFF
--- a/applications/sofa/gui/qt/CMakeLists.txt
+++ b/applications/sofa/gui/qt/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 project(SofaGuiQt)
 
+find_package(FFMPEGexec QUIET)
+
 set(MOC_HEADER_FILES
     AddObject.h
     DataFilenameWidget.h

--- a/applications/sofa/gui/qt/gl/CMakeLists.txt
+++ b/applications/sofa/gui/qt/gl/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 project(SofaGuiQtOpenGL)
 
+find_package(FFMPEGexec QUIET)
+
 set(HEADER_FILES
     ../GLPickHandler.h
     ../viewer/GLBackend.h

--- a/applications/sofa/gui/qt/viewer/EngineBackend.h
+++ b/applications/sofa/gui/qt/viewer/EngineBackend.h
@@ -51,7 +51,7 @@ public:
     virtual void setBackgroundImage(helper::io::Image* image) =0;
     virtual void drawBackgroundImage(const int screenWidth, const int screenHeight)=0;
 
-    virtual bool initRecorder(int width, int height, unsigned int framerate, unsigned int bitrate, const std::string& codec="")  =0;
+    virtual bool initRecorder(int width, int height, unsigned int framerate, unsigned int bitrate, const std::string& codecExtension="", const std::string& codecName="")  =0;
     virtual void endRecorder() =0;
     virtual void addFrameRecorder() =0;
 

--- a/applications/sofa/gui/qt/viewer/GLBackend.cpp
+++ b/applications/sofa/gui/qt/viewer/GLBackend.cpp
@@ -80,13 +80,13 @@ void GLBackend::setBackgroundImage(helper::io::Image* image)
     m_texLogo->init();
 }
 
-bool GLBackend::initRecorder( int width, int height, unsigned int framerate, unsigned int bitrate, const std::string& codec)
+bool GLBackend::initRecorder( int width, int height, unsigned int framerate, unsigned int bitrate, const std::string& codecExtension, const std::string& codecName)
 {
     bool res = true;
 #ifdef SOFA_HAVE_FFMPEG_EXEC
-    std::string videoFilename = m_videoRecorderFFMPEG.findFilename(framerate, bitrate / 1024, codec);
+    std::string videoFilename = m_videoRecorderFFMPEG.findFilename(framerate, bitrate / 1024, codecExtension);
 
-    res = m_videoRecorderFFMPEG.init(videoFilename, width, height, framerate, bitrate, codec);
+    res = m_videoRecorderFFMPEG.init(videoFilename, width, height, framerate, bitrate, codecName);
 #endif // SOFA_HAVE_FFMPEG_EXEC
 
     return res;

--- a/applications/sofa/gui/qt/viewer/GLBackend.h
+++ b/applications/sofa/gui/qt/viewer/GLBackend.h
@@ -61,7 +61,7 @@ public:
     void setBackgroundImage(helper::io::Image* image);
     void drawBackgroundImage(const int screenWidth, const int screenHeight);
 
-    bool initRecorder(int width, int height, unsigned int framerate, unsigned int bitrate, const std::string& codec="");
+    bool initRecorder(int width, int height, unsigned int framerate, unsigned int bitrate,const std::string& codecExtension="",  const std::string& codecName="");
     void endRecorder();
     void addFrameRecorder();
 

--- a/applications/sofa/gui/qt/viewer/SofaViewer.cpp
+++ b/applications/sofa/gui/qt/viewer/SofaViewer.cpp
@@ -119,7 +119,7 @@ void SofaViewer::keyPressEvent(QKeyEvent * e)
 
                     int width = getQWidget()->width();
                     int height = getQWidget()->height();
-                    m_backend->initRecorder(width, height, framerate, bitrate, videoManager->getCodecName());
+                    m_backend->initRecorder(width, height, framerate, bitrate, videoManager->getCodecExtension(), videoManager->getCodecName());
 
                     break;
                 }


### PR DESCRIPTION
Here is a fix for the VideoRecorder broken since #1121 due to change in API and in CMakeLists.

- Add findPackagae for ffmpeg since add_definitions does not propagate SOFA_HAVE_FFMPEG_EXEC above the caller project
- Change function initRecorder including both code extension and code name

Here you are @fspadoni ;)

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
