### PR TITLE
[SofaDefaulttype] FIX too many ExtVec warnings

### DIFF
--- a/SofaKernel/framework/sofa/defaulttype/VecTypes.h
+++ b/SofaKernel/framework/sofa/defaulttype/VecTypes.h
@@ -196,9 +196,9 @@ public:
     }
 };
 
-template <class TCoord, class TDeriv, class TReal> using ExtVectorTypes
-[[deprecated("since 19.06, ExtVector is deprecated. Use helper::vector instead. Will be removed in 19.12")]]
-= StdVectorTypes<TCoord, TDeriv, TReal>;
+template <class TCoord, class TDeriv, class TReal>
+struct [[deprecated("since 19.06, ExtVector is deprecated. Use helper::vector instead. Will be removed in 19.12")]]
+    ExtVectorTypes : public StdVectorTypes<TCoord, TDeriv, TReal> {};
 
 
 /// 3D DOFs, double precision
@@ -270,13 +270,13 @@ typedef ExtVectorTypes<Vec1,Vec1,Vec1::value_type> ExtVec1Types;
 
 
 
-template <class T> using ExtVector
-[[deprecated("since 19.06, ExtVector is deprecated. Use helper::vector instead. Will be removed in 19.12")]]
-= helper::vector<T>;
+template <class T>
+struct [[deprecated("since 19.06, ExtVector is deprecated. Use helper::vector instead. Will be removed in 19.12")]]
+    ExtVector : public helper::vector<T> {};
 
-template <class T> using ResizableExtVector
-[[deprecated("since 19.06, ResizableExtVector is deprecated. Use helper::vector instead. Will be removed in 19.12")]]
-  = helper::vector<T>;
+template <class T>
+struct [[deprecated("since 19.06, ResizableExtVector is deprecated. Use helper::vector instead. Will be removed in 19.12")]]
+    ResizableExtVector : public helper::vector<T> {};
 
 
 } // namespace defaulttype


### PR DESCRIPTION
Deprecation warnings were displayed at every `#include <sofa/defaulttype/VecTypes.h>`
They are now emitted only when using the deprecated types ExtVec*

@fredroy Is there a reason you did not use inherited structs in the first place?

Also, could someone explain why putting the `[[deprecated]]` attribute on a `using` alias does not emit a warning only when the alias is used?

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
