### PR TITLE
[SofaGeneralEngine] Added Rigid to Euler orientation export

### DIFF
--- a/modules/SofaGeneralEngine/RigidToQuatEngine.h
+++ b/modules/SofaGeneralEngine/RigidToQuatEngine.h
@@ -82,6 +82,7 @@ public:
     //
     Data<helper::vector<Vec3 > > f_positions; ///< Positions (Vector of 3)
     Data<helper::vector<Quat> > f_orientations; ///< Orientations (Quaternion)
+    Data<helper::vector<Vec3> > f_orientationsEuler; ///< Orientation (Euler angle)
     Data<helper::vector<RigidVec3> > f_rigids; ///< Rigid (Position + Orientation)
 };
 

--- a/modules/SofaGeneralEngine/RigidToQuatEngine.inl
+++ b/modules/SofaGeneralEngine/RigidToQuatEngine.inl
@@ -37,6 +37,7 @@ template <class DataTypes>
 RigidToQuatEngine<DataTypes>::RigidToQuatEngine()
     : f_positions( initData (&f_positions, "positions", "Positions (Vector of 3)") )
     , f_orientations( initData (&f_orientations, "orientations", "Orientations (Quaternion)") )
+    , f_orientationsEuler( initData (&f_orientationsEuler, "orientationsEuler", "Orientations (Euler angle)") )
     , f_rigids( initData (&f_rigids, "rigids", "Rigid (Position + Orientation)") )
 {
     //
@@ -58,6 +59,7 @@ void RigidToQuatEngine<DataTypes>::init()
 
     addOutput(&f_positions);
     addOutput(&f_orientations);
+    addOutput(&f_orientationsEuler);
 
     setDirtyValue();
 }
@@ -72,18 +74,20 @@ template <class DataTypes>
 void RigidToQuatEngine<DataTypes>::doUpdate()
 {
     helper::ReadAccessor< Data< helper::vector<RigidVec3> > > rigids = f_rigids;
-
     helper::WriteOnlyAccessor< Data< helper::vector<Vec3> > > positions = f_positions;
     helper::WriteOnlyAccessor< Data< helper::vector<Quat> > > orientations = f_orientations;
+    helper::WriteOnlyAccessor< Data< helper::vector<Vec3> > > orientationsEuler = f_orientationsEuler;
 
     unsigned int sizeRigids = rigids.size();
     positions.resize(sizeRigids);
     orientations.resize(sizeRigids);
+    orientationsEuler.resize(sizeRigids);
     for (unsigned int i=0 ; i< sizeRigids ; i++)
     {
         RigidVec3 r = rigids[i];
         positions[i] = r.getCenter();
         orientations[i] = r.getOrientation();
+        orientationsEuler[i] = orientations[i].toEulerVector();
     }
 }
 


### PR DESCRIPTION
Adds export from Rigid to Euler angles. One of the use case scenarios is attachment of a spotlight to a rigid body, described in [this thread](https://www.sofa-framework.org/community/forum/topic/attach-a-spotlight-to-a-rigid-body/)

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
