### PR TITLE
[SofaKernel] Fix alloc size

### DIFF
--- a/SofaKernel/framework/sofa/helper/vector_device.h
+++ b/SofaKernel/framework/sofa/helper/vector_device.h
@@ -296,7 +296,7 @@ public:
         if (s <= 2*allocSize && 2*allocSize <= s+SOFA_VECTOR_HOST_STEP_SIZE)
             allocSize *= 2;
         else
-            allocSize = s;
+            allocSize = s+SOFA_VECTOR_HOST_STEP_SIZE;
         // always allocate multiples of WARP_SIZE values
         allocSize = ((allocSize+WARP_SIZE-1 ) / WARP_SIZE) * WARP_SIZE;
 


### PR DESCRIPTION
Small fix to allocate memory on cuda_device much faster for large vectors.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
