### PR TITLE
[SofaKernel] Add bloc access in basematrix

### DIFF
--- a/SofaKernel/framework/sofa/defaulttype/BaseMatrix.h
+++ b/SofaKernel/framework/sofa/defaulttype/BaseMatrix.h
@@ -25,6 +25,7 @@
 #include <sofa/helper/system/config.h>
 #include <sofa/defaulttype/defaulttype.h>
 #include <sofa/defaulttype/BaseVector.h>
+#include <sofa/defaulttype/Mat.h>
 #include <sofa/helper/logging/Messaging.h>
 #include <utility> // for std::pair
 #include <cstddef> // for NULL and std::size_t
@@ -72,6 +73,35 @@ public:
     virtual void set(Index i, Index j, double v) = 0;
     /// Add v to the existing value of the element at row i, column j (using 0-based indices)
     virtual void add(Index i, Index j, double v) = 0;
+
+    ///Adding values from a 3x3d matrix this function may be overload to obtain better performances
+    virtual void add(Index _i, Index _j, const defaulttype::Mat3x3d & _M) {
+        for (unsigned i=0;i<3;i++)
+            for (unsigned j=0;j<3;j++)
+                add(_i+i,_j+j,_M[i][j]);
+    }
+
+    ///Adding values from a 3x3f matrix this function may be overload to obtain better performances
+    virtual void add(Index _i, Index _j, const defaulttype::Mat3x3f & _M) {
+        for (unsigned i=0;i<3;i++)
+            for (unsigned j=0;j<3;j++)
+                add(_i+i,_j+j,_M[i][j]);
+    }
+
+    ///Adding values from a 2x2d matrix this function may be overload to obtain better performances
+    virtual void add(Index _i, Index _j, const defaulttype::Mat2x2d & _M) {
+        for (unsigned i=0;i<2;i++)
+            for (unsigned j=0;j<2;j++)
+                add(_i+i,_j+j,_M[i][j]);
+    }
+
+    ///Adding values from a 2x2f matrix this function may be overload to obtain better performances
+    virtual void add(Index _i, Index _j, const defaulttype::Mat2x2f & _M) {
+        for (unsigned i=0;i<2;i++)
+            for (unsigned j=0;j<2;j++)
+                add(_i+i,_j+j,_M[i][j]);
+    }
+
     /*    /// Write the value of the element at row i, column j (using 0-based indices)
         virtual void set(Index i, Index j, float v) { set(i,j,(double)v); }
         /// Add v to the existing value of the element at row i, column j (using 0-based indices)


### PR DESCRIPTION
This PR adds the possibility to add bloc matrices in a basematrix. By default this function calls the add function with a scalar but it can also be overlaoaded to reduce the number of virtual function calls. 

With the combination of 1x1, 2x2 and 3x3 matrices, it covers most of needs for simulations (the other matrix dimension can be implemented as a combination of the implemented functions).

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
