### PR TITLE
[SofaBoundaryConditions] Apply doInternalUpdate API to ConstantForceField

### DIFF
--- a/applications/plugins/Flexible/examples/beam/generateRefBeam_flex.scn
+++ b/applications/plugins/Flexible/examples/beam/generateRefBeam_flex.scn
@@ -21,7 +21,7 @@
         <FixedConstraint indices="@[-1].indices" />
 
        <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1 "  drawBoxes="0" /> 
-       <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/> 
+       <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/> 
 
 	<UniformMass totalMass="10" />
 

--- a/applications/plugins/Flexible/examples/beam/linearAffine_ext.scn
+++ b/applications/plugins/Flexible/examples/beam/linearAffine_ext.scn
@@ -21,10 +21,10 @@
 
  
         <BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.99" />
-       <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 0 -0.05"/> 
+       <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 0 -0.05"/> 
 
        <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1 "  drawBoxes="0" /> 
-       <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 0 0.05"/> 
+       <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 0 0.05"/> 
 
 
 	<UniformMass totalMass="10" />
@@ -58,10 +58,10 @@
       	<TetrahedronFEMForceField method="polar"  youngModulus="1"  poissonRatio="0"  />
 
         <BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.99" />
-       <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 0 -0.05"/> 
+       <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 0 -0.05"/> 
 
        <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1 "  /> 
-       <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 0 0.05"/> 
+       <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 0 0.05"/> 
 
 
        <Node 	name="VisualNode">
@@ -106,10 +106,10 @@
 		<UniformMass totalMass="10" />
 
        		 <BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.99" />
-      		 <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 0 -0.05"/> 
+      		 <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 0 -0.05"/> 
 
       		 <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1 "  /> 
-       		<ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 0 0.05"/> 
+       		<ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 0 0.05"/> 
 
 	    	<LinearMapping template="Affine,Vec3d"/>
 	    </Node>

--- a/applications/plugins/Flexible/examples/beam/linearAffine_flex331.scn
+++ b/applications/plugins/Flexible/examples/beam/linearAffine_flex331.scn
@@ -28,7 +28,7 @@
         <FixedConstraint indices="@[-1].indices" />
 
        <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1 "  drawBoxes="0" /> 
-       <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/> 
+       <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/> 
 
 	<UniformMass totalMass="10" />
 
@@ -64,7 +64,7 @@
         <FixedConstraint indices="@[-1].indices" />
 
        <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1 "  drawBoxes="0" /> 
-       <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/> 
+       <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/> 
 
        <Node 	name="VisualNode">
             <OglModel template="ExtVec3f" name="Visual" color="red" />
@@ -113,7 +113,7 @@
 	<MechanicalObject  template="Vec3d" name="pts"    />
 	<UniformMass totalMass="10" />
 	<BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1"  position="@mesh.position" /> 
-	<ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/> 
+	<ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/> 
 	<BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.9"  position="@mesh.position" /> 
 	<RestShapeSpringsForceField template="Vec3d" points="@[-1].indices" stiffness="1E5"/> 
 	<LinearMapping template="Affine,Vec3d"/>

--- a/applications/plugins/Flexible/examples/beam/linearAffine_flex332.scn
+++ b/applications/plugins/Flexible/examples/beam/linearAffine_flex332.scn
@@ -28,7 +28,7 @@
     <FixedConstraint indices="@[-1].indices" />
 
     <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1 "  drawBoxes="0" />
-    <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/>
+    <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/>
 
     <UniformMass totalMass="10" />
 
@@ -64,7 +64,7 @@
     <FixedConstraint indices="@[-1].indices" />
 
     <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1 "  drawBoxes="0" />
-    <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/>
+    <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/>
 
     <Node 	name="VisualNode">
       <OglModel template="ExtVec3f" name="Visual" color="red" />
@@ -108,7 +108,7 @@
       <MechanicalObject  template="Vec3d" name="pts"    />
       <UniformMass totalMass="10" />
       <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1"  position="@mesh.position" />
-      <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/>
+      <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/>
       <BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.9"  position="@mesh.position" />
       <RestShapeSpringsForceField template="Vec3d" points="@[-1].indices" stiffness="1E5"/>
       <LinearMapping template="Affine,Vec3d"/>
@@ -156,7 +156,7 @@
       <MechanicalObject  template="Vec3d" name="pts"    />
       <UniformMass totalMass="10" />
       <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1"  position="@mesh.position" />
-      <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/>
+      <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/>
       <BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.9"  position="@mesh.position" />
       <RestShapeSpringsForceField template="Vec3d" points="@[-1].indices" stiffness="1E5"/>
       <LinearMapping template="Affine,Vec3d"/>

--- a/applications/plugins/Flexible/examples/beam/linearComparison_flex332.scn
+++ b/applications/plugins/Flexible/examples/beam/linearComparison_flex332.scn
@@ -52,7 +52,7 @@
 	<MechanicalObject  template="Vec3d" name="pts"    />
 	<UniformMass totalMass="10" />
 	<BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1"  position="@mesh.position" /> 
-	<ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/> 
+	<ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/> 
 	<BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.9"  position="@mesh.position" /> 
 	<RestShapeSpringsForceField template="Vec3d" points="@[-1].indices" stiffness="1E6"/> 
 	<LinearMapping template="Affine,Vec3d"/>
@@ -103,7 +103,7 @@
 	<MechanicalObject  template="Vec3d" name="pts"    />
 	<UniformMass totalMass="10" />
 	<BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1"  position="@mesh.position" /> 
-	<ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/> 
+	<ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/> 
 	<BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.9"  position="@mesh.position" /> 
 	<RestShapeSpringsForceField template="Vec3d" points="@[-1].indices" stiffness="1E6"/> 
 	<LinearMapping template="Rigid,Vec3d"/>
@@ -156,7 +156,7 @@
 	<MechanicalObject  template="Vec3d" name="pts"    />
 	<UniformMass totalMass="10" />
 	<BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1"  position="@mesh.position" /> 
-	<ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/> 
+	<ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/> 
 	<BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.9"  position="@mesh.position" /> 
 	<RestShapeSpringsForceField template="Vec3d" points="@[-1].indices" stiffness="1E6"/> 
 	<LinearMapping template="Quadratic,Vec3d"/>

--- a/applications/plugins/Flexible/examples/beam/linearQuadratic_ext.scn
+++ b/applications/plugins/Flexible/examples/beam/linearQuadratic_ext.scn
@@ -21,10 +21,10 @@
 
  
         <BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.99" />
-       <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 0 -0.05"/> 
+       <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 0 -0.05"/> 
 
        <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1 "  drawBoxes="0" /> 
-       <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 0 0.05"/> 
+       <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 0 0.05"/> 
 
 
 	<UniformMass totalMass="10" />
@@ -58,10 +58,10 @@
       	<TetrahedronFEMForceField method="polar"  youngModulus="1"  poissonRatio="0"  />
 
         <BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.99" />
-       <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 0 -0.05"/> 
+       <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 0 -0.05"/> 
 
        <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1 "  /> 
-       <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 0 0.05"/> 
+       <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 0 0.05"/> 
 
 
        <Node 	name="VisualNode">
@@ -106,10 +106,10 @@
 		<UniformMass totalMass="10" />
 
        		 <BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.99" />
-      		 <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 0 -0.05"/> 
+      		 <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 0 -0.05"/> 
 
       		 <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1 "  /> 
-       		<ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 0 0.05"/> 
+       		<ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 0 0.05"/> 
 
 	    	<LinearMapping template="Quadratic,Vec3d"/>
 	    </Node>

--- a/applications/plugins/Flexible/examples/beam/linearQuadratic_flex331.scn
+++ b/applications/plugins/Flexible/examples/beam/linearQuadratic_flex331.scn
@@ -28,7 +28,7 @@
         <FixedConstraint indices="@[-1].indices" />
 
        <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1 "  drawBoxes="0" /> 
-       <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/> 
+       <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/> 
 
 	<UniformMass totalMass="10" />
 
@@ -64,7 +64,7 @@
         <FixedConstraint indices="@[-1].indices" />
 
        <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1 "  drawBoxes="0" /> 
-       <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/> 
+       <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/> 
 
        <Node 	name="VisualNode">
             <OglModel template="ExtVec3f" name="Visual" color="red" />
@@ -113,7 +113,7 @@
 	<MechanicalObject  template="Vec3d" name="pts"    />
 	<UniformMass totalMass="10" />
 	<BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1"  position="@mesh.position" /> 
-	<ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/> 
+	<ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/> 
 	<BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.9"  position="@mesh.position" /> 
 	<RestShapeSpringsForceField template="Vec3d" points="@[-1].indices" stiffness="1E5"/> 
 	<LinearMapping template="Quadratic,Vec3d"/>

--- a/applications/plugins/Flexible/examples/beam/linearQuadratic_flex332.scn
+++ b/applications/plugins/Flexible/examples/beam/linearQuadratic_flex332.scn
@@ -53,7 +53,7 @@
       <MechanicalObject  template="Vec3d" name="pts"    />
       <UniformMass totalMass="10" />
       <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1"  position="@mesh.position" />
-      <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/>
+      <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/>
       <BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.9"  position="@mesh.position" />
       <RestShapeSpringsForceField template="Vec3d" points="@[-1].indices" stiffness="1E5"/>
       <LinearMapping template="Quadratic,Vec3d"/>

--- a/applications/plugins/Flexible/examples/beam/linearRigid_ext.scn
+++ b/applications/plugins/Flexible/examples/beam/linearRigid_ext.scn
@@ -21,10 +21,10 @@
 
  
         <BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.99" />
-       <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 0 -0.05"/> 
+       <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 0 -0.05"/> 
 
        <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1 "  drawBoxes="0" /> 
-       <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 0 0.05"/> 
+       <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 0 0.05"/> 
 
 
 	<UniformMass totalMass="10" />
@@ -58,10 +58,10 @@
       	<TetrahedronFEMForceField method="polar"  youngModulus="1"  poissonRatio="0"  />
 
         <BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.99" />
-       <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 0 -0.05"/> 
+       <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 0 -0.05"/> 
 
        <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1 "  /> 
-       <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 0 0.05"/> 
+       <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 0 0.05"/> 
 
 
        <Node 	name="VisualNode">
@@ -106,10 +106,10 @@
 		<UniformMass totalMass="10" />
 
        		 <BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.99" />
-      		 <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 0 -0.05"/> 
+      		 <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 0 -0.05"/> 
 
       		 <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1 "  /> 
-       		<ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 0 0.05"/> 
+       		<ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 0 0.05"/> 
 
 	    	<LinearMapping template="Rigid,Vec3d"/>
 	    </Node>

--- a/applications/plugins/Flexible/examples/beam/linearRigid_flex331.scn
+++ b/applications/plugins/Flexible/examples/beam/linearRigid_flex331.scn
@@ -28,7 +28,7 @@
         <FixedConstraint indices="@[-1].indices" />
 
        <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1 "  drawBoxes="0" /> 
-       <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/> 
+       <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/> 
 
 	<UniformMass totalMass="10" />
 
@@ -64,7 +64,7 @@
         <FixedConstraint indices="@[-1].indices" />
 
        <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1 "  drawBoxes="0" /> 
-       <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/> 
+       <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/> 
 
        <Node 	name="VisualNode">
             <OglModel template="ExtVec3f" name="Visual" color="red" />
@@ -113,7 +113,7 @@
 	<MechanicalObject  template="Vec3d" name="pts"    />
 	<UniformMass totalMass="10" />
 	<BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1"  position="@mesh.position" /> 
-	<ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/> 
+	<ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/> 
 	<BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.9"  position="@mesh.position" /> 
 	<RestShapeSpringsForceField template="Vec3d" points="@[-1].indices" stiffness="1E5"/> 
 	<LinearMapping template="Rigid,Vec3d"/>

--- a/applications/plugins/Flexible/examples/beam/linearRigid_flex332.scn
+++ b/applications/plugins/Flexible/examples/beam/linearRigid_flex332.scn
@@ -28,7 +28,7 @@
         <FixedConstraint indices="@[-1].indices" />
 
        <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1 "  drawBoxes="0" /> 
-       <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/> 
+       <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/> 
 
 	<UniformMass totalMass="10" />
 
@@ -64,7 +64,7 @@
         <FixedConstraint indices="@[-1].indices" />
 
        <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1 "  drawBoxes="0" /> 
-       <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/> 
+       <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/> 
 
        <Node 	name="VisualNode">
             <OglModel template="ExtVec3f" name="Visual" color="red" />
@@ -108,7 +108,7 @@
 	<MechanicalObject  template="Vec3d" name="pts"    />
 	<UniformMass totalMass="10" />
 	<BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1"  position="@mesh.position" /> 
-	<ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/> 
+	<ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/> 
 	<BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.9"  position="@mesh.position" /> 
 	<RestShapeSpringsForceField template="Vec3d" points="@[-1].indices" stiffness="1E5"/> 
 	<LinearMapping template="Rigid,Vec3d"/>
@@ -156,7 +156,7 @@
 	<MechanicalObject  template="Vec3d" name="pts"    />
 	<UniformMass totalMass="10" />
 	<BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1"  position="@mesh.position" /> 
-	<ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/> 
+	<ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/> 
 	<BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.9"  position="@mesh.position" /> 
 	<RestShapeSpringsForceField template="Vec3d" points="@[-1].indices" stiffness="1E5"/> 
 	<LinearMapping template="Rigid,Vec3d"/>

--- a/applications/plugins/Flexible/examples/deformation/volumeMapping.scn
+++ b/applications/plugins/Flexible/examples/deformation/volumeMapping.scn
@@ -76,7 +76,7 @@
         <Node 	name="behavior_vol"   >
 	    <MechanicalObject  template="Vec1d" name="Volume"   />
     	    <VolumeMapping template="Vec3d,Vec1d" geometricStiffness="false" triangles="@../mesh.triangles" offset="0"/>
-	    <ConstantForceField points="0" force="1000"/>
+	    <ConstantForceField indices="0" force="1000"/>
         </Node>
 <!--  This is equivalent to      <SurfacePressureForceField pressure="1000" volumeConservationMode="0"/>-->
 

--- a/applications/plugins/Flexible/examples/material/anisotropic2DFEM.scn
+++ b/applications/plugins/Flexible/examples/material/anisotropic2DFEM.scn
@@ -19,10 +19,10 @@
 
         <UniformMass  totalMass="100"/>
 
-	<BoxROI box="-0.005 -0.005 -0.005    1.005 0.005 0.005  " /> <ConstantForceField points="@[-1].indices" force="0 -10 0" arrowSizeCoef="0.02"/>
-	<BoxROI box="-0.005 0.995 -0.005    1.005 1.005 0.005  " /> <ConstantForceField points="@[-1].indices" force="0 10 0" arrowSizeCoef="@[-2].arrowSizeCoef"/>
-	<BoxROI box="-0.005 -0.005 -0.005    0.005 1.005 0.005  " /> <ConstantForceField points="@[-1].indices" force="-10 0 0" arrowSizeCoef="@[-2].arrowSizeCoef"/>
-	<BoxROI box="0.995 -0.005 -0.005    1.005 1.005 0.005  " /> <ConstantForceField points="@[-1].indices" force="10 0 0" arrowSizeCoef="@[-2].arrowSizeCoef"/>
+	<BoxROI box="-0.005 -0.005 -0.005    1.005 0.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="0 -10 0" arrowSizeCoef="0.02"/>
+	<BoxROI box="-0.005 0.995 -0.005    1.005 1.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="0 10 0" arrowSizeCoef="@[-2].arrowSizeCoef"/>
+	<BoxROI box="-0.005 -0.005 -0.005    0.005 1.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="-10 0 0" arrowSizeCoef="@[-2].arrowSizeCoef"/>
+	<BoxROI box="0.995 -0.005 -0.005    1.005 1.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="10 0 0" arrowSizeCoef="@[-2].arrowSizeCoef"/>
 
         <Node name="deformationNode" >
             <TopologyGaussPointSampler name="sampler" inPosition="@../loader.position" method="0" order="1" orientation="0 0 25" useLocalOrientation="0"/>
@@ -60,10 +60,10 @@
 
         <UniformMass totalMass="100"/>
 
-	<BoxROI box="1.995 -0.005 -0.005    3.005 0.005 0.005  " /> <ConstantForceField points="@[-1].indices" force="0 -10 0" arrowSizeCoef="0.02"/>
-	<BoxROI box="1.995 0.995 -0.005    3.005 1.005 0.005  " /> <ConstantForceField points="@[-1].indices" force="0 10 0" arrowSizeCoef="@[-2].arrowSizeCoef"/>
-	<BoxROI box="1.995 -0.005 -0.005    2.005 1.005 0.005  " /> <ConstantForceField points="@[-1].indices" force="-10 0 0" arrowSizeCoef="@[-2].arrowSizeCoef"/>
-	<BoxROI box="2.995 -0.005 -0.005    3.005 1.005 0.005  " /> <ConstantForceField points="@[-1].indices" force="10 0 0" arrowSizeCoef="@[-2].arrowSizeCoef"/>
+	<BoxROI box="1.995 -0.005 -0.005    3.005 0.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="0 -10 0" arrowSizeCoef="0.02"/>
+	<BoxROI box="1.995 0.995 -0.005    3.005 1.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="0 10 0" arrowSizeCoef="@[-2].arrowSizeCoef"/>
+	<BoxROI box="1.995 -0.005 -0.005    2.005 1.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="-10 0 0" arrowSizeCoef="@[-2].arrowSizeCoef"/>
+	<BoxROI box="2.995 -0.005 -0.005    3.005 1.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="10 0 0" arrowSizeCoef="@[-2].arrowSizeCoef"/>
 
         <Node name="deformationNode" >
             <TopologyGaussPointSampler name="sampler" inPosition="@../loader.position" method="0" order="2" orientation="0 0 25" useLocalOrientation="0"/>

--- a/applications/plugins/Flexible/examples/material/anisotropic2DFEM.scn
+++ b/applications/plugins/Flexible/examples/material/anisotropic2DFEM.scn
@@ -19,10 +19,10 @@
 
         <UniformMass  totalMass="100"/>
 
-	<BoxROI box="-0.005 -0.005 -0.005    1.005 0.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="0 -10 0" arrowSizeCoef="0.02"/>
-	<BoxROI box="-0.005 0.995 -0.005    1.005 1.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="0 10 0" arrowSizeCoef="@[-2].arrowSizeCoef"/>
-	<BoxROI box="-0.005 -0.005 -0.005    0.005 1.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="-10 0 0" arrowSizeCoef="@[-2].arrowSizeCoef"/>
-	<BoxROI box="0.995 -0.005 -0.005    1.005 1.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="10 0 0" arrowSizeCoef="@[-2].arrowSizeCoef"/>
+        <BoxROI box="-0.005 -0.005 -0.005    1.005 0.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="0 -10 0" showArrowSize="0.02"/>
+        <BoxROI box="-0.005 0.995 -0.005    1.005 1.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="0 10 0" showArrowSize="@[-2].showArrowSize"/>
+        <BoxROI box="-0.005 -0.005 -0.005    0.005 1.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="-10 0 0" showArrowSize="@[-2].showArrowSize"/>
+        <BoxROI box="0.995 -0.005 -0.005    1.005 1.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="10 0 0" showArrowSize="@[-2].showArrowSize"/>
 
         <Node name="deformationNode" >
             <TopologyGaussPointSampler name="sampler" inPosition="@../loader.position" method="0" order="1" orientation="0 0 25" useLocalOrientation="0"/>
@@ -60,10 +60,10 @@
 
         <UniformMass totalMass="100"/>
 
-	<BoxROI box="1.995 -0.005 -0.005    3.005 0.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="0 -10 0" arrowSizeCoef="0.02"/>
-	<BoxROI box="1.995 0.995 -0.005    3.005 1.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="0 10 0" arrowSizeCoef="@[-2].arrowSizeCoef"/>
-	<BoxROI box="1.995 -0.005 -0.005    2.005 1.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="-10 0 0" arrowSizeCoef="@[-2].arrowSizeCoef"/>
-	<BoxROI box="2.995 -0.005 -0.005    3.005 1.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="10 0 0" arrowSizeCoef="@[-2].arrowSizeCoef"/>
+	<BoxROI box="1.995 -0.005 -0.005    3.005 0.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="0 -10 0" showArrowSize="0.02"/>
+	<BoxROI box="1.995 0.995 -0.005    3.005 1.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="0 10 0" showArrowSize="@[-2].showArrowSize"/>
+	<BoxROI box="1.995 -0.005 -0.005    2.005 1.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="-10 0 0" showArrowSize="@[-2].showArrowSize"/>
+	<BoxROI box="2.995 -0.005 -0.005    3.005 1.005 0.005  " /> <ConstantForceField indices="@[-1].indices" force="10 0 0" showArrowSize="@[-2].showArrowSize"/>
 
         <Node name="deformationNode" >
             <TopologyGaussPointSampler name="sampler" inPosition="@../loader.position" method="0" order="2" orientation="0 0 25" useLocalOrientation="0"/>

--- a/applications/plugins/Flexible/examples/shapeFunction/diffusionShapeFunction.scn
+++ b/applications/plugins/Flexible/examples/shapeFunction/diffusionShapeFunction.scn
@@ -86,7 +86,7 @@
 	<MechanicalObject  template="Vec3d" name="pts"    />
 	<UniformMass totalMass="10" />
 	<BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1"  position="@mesh.position" /> 
-	<ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/> 
+	<ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/> 
 	<BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.9"  position="@mesh.position" /> 
 	<RestShapeSpringsForceField template="Vec3d" points="@[-1].indices" stiffness="1E5"/> 
 	<LinearMapping template="Affine,Vec3d"/>

--- a/applications/plugins/Flexible/examples/shapeFunction/test_linear_Vec3Vec3.scn
+++ b/applications/plugins/Flexible/examples/shapeFunction/test_linear_Vec3Vec3.scn
@@ -10,7 +10,7 @@
     	<UniformMass mass="1" />
 <!--    <ShepardShapeFunction position="@parent.rest_position" power="2"/> -->
     	<BarycentricShapeFunction />
-	   <ConstantForceField points="0" force="0 0 1000 " />
+	   <ConstantForceField indices="0" force="0 0 1000 " />
 	   <FixedConstraint indices="1 2 3 4" />
 
 
@@ -37,7 +37,7 @@
     	<Mesh name="mesh" position="0 0 1   0 1 0   1 0 0   -1 -1 0  2 2 2 " tetrahedra="0 1 2 3 0 1 2 4" />
     	<MechanicalObject  name="parent" src="@mesh"  />
     	<UniformMass mass="1" />
-	   <ConstantForceField points="0" force="0 0 1000" />
+	   <ConstantForceField indices="0" force="0 0 1000" />
 	   <FixedConstraint indices="1 2 3 4" />
 
 

--- a/applications/plugins/Flexible/examples/visualization/comparison.scn
+++ b/applications/plugins/Flexible/examples/visualization/comparison.scn
@@ -55,7 +55,7 @@
                 <MechanicalObject  template="Vec3d" name="pts"    />
                 <UniformMass totalMass="10" />
                 <BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1"  position="@mesh.position" />
-                <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/>
+                <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/>
                 <BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.9"  position="@mesh.position" />
                 <RestShapeSpringsForceField template="Vec3d" points="@[-1].indices" stiffness="1E5"/>
                 <LinearMapping template="Affine,Vec3d"/>
@@ -91,7 +91,7 @@
         <FixedConstraint indices="@[-1].indices" />
 
         <BoxROI template="Vec3d" box="-2 -1 0.99 0 1 1.1 "  drawBoxes="0" /> 
-        <ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/> 
+        <ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/> 
 
         <UniformMass totalMass="10" />
 

--- a/applications/plugins/Flexible/examples/visualization/strainDiscretizer.scn
+++ b/applications/plugins/Flexible/examples/visualization/strainDiscretizer.scn
@@ -77,7 +77,7 @@
       		<MechanicalObject  template="Vec3d" name="pts"    />
       		<UniformMass totalMass="10" />
       		<BoxROI template="Vec3d" box="-1 -1 0.99 1 1 1.1"  position="@mesh.position" />
-      		<ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/>
+      		<ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/>
       		<BoxROI template="Vec3d" box="-1 -1 -1.1 1 1 -0.9"  position="@mesh.position" />
       		<RestShapeSpringsForceField template="Vec3d" points="@[-1].indices" stiffness="1E5"/>
       		<LinearMapping template="Affine,Vec3d"/>
@@ -108,7 +108,7 @@
         <FixedConstraint indices="@[-1].indices" />
 
        	<BoxROI template="Vec3d" box="-2 -1 0.99 0 1 1.1 "  drawBoxes="0" /> 
-       	<ConstantForceField template="Vec3d" points="@[-1].indices" totalForce="0 -1 0"/> 
+       	<ConstantForceField template="Vec3d" indices="@[-1].indices" totalForce="0 -1 0"/> 
 
 	<UniformMass totalMass="10" />
 

--- a/applications/plugins/SofaCUDA/examples/raptor-cpu.scn
+++ b/applications/plugins/SofaCUDA/examples/raptor-cpu.scn
@@ -25,7 +25,7 @@
 		<FixedConstraint indices="@box3.indices" />	  
 
 		<BoxROI name="boxF" box="-2.2 -1 6.88 2.2  10  10" drawBoxes="true" />
-		<ConstantForceField indices="@boxF.indices" force="7.5 -6.63 -15" arrowSizeCoef="0.1" />
+                <ConstantForceField indices="@boxF.indices" force="7.5 -6.63 -15" showArrowSize="0.1" />
 		<PlaneForceField normal="0 1 0" d="-0.2" stiffness="100"  showPlane="1" showPlaneSize="20" />
 <!--
 		<Node name="Surf">

--- a/applications/plugins/SofaCUDA/examples/raptor-cuda.scn
+++ b/applications/plugins/SofaCUDA/examples/raptor-cuda.scn
@@ -25,7 +25,7 @@
 		<FixedConstraint indices="@box3.indices" />	  
 
 		<BoxROI name="boxF" box="-2.2 -1 6.88 2.2  10  10" drawBoxes="true" />
-		<ConstantForceField indices="@boxF.indices" force="7.5 -6.63 -15" arrowSizeCoef="0.1" />
+                <ConstantForceField indices="@boxF.indices" force="7.5 -6.63 -15" showArrowSize="0.1" />
 		<PlaneForceField normal="0 1 0" d="-0.2" stiffness="100"  showPlane="1" showPlaneSize="20" />
 <!--
 		<Node name="Surf">

--- a/applications/plugins/SofaCUDA/examples/raptor.scn
+++ b/applications/plugins/SofaCUDA/examples/raptor.scn
@@ -24,7 +24,7 @@
 	<FixedConstraint indices="@box3.indices" />	  
 
 	<BoxROI name="boxF" box="-2.2 -1 6.88 2.2  10  10" drawBoxes="true" />
-    <ConstantForceField points="@boxF.indices" force="7.5 -6.63 -15" arrowSizeCoef="0.1" />
+    <ConstantForceField points="@boxF.indices" force="7.5 -6.63 -15" showArrowSize="0.1" />
 
 	<PlaneForceField normal="0 1 0" d="-0.2" stiffness="100"  draw="1" drawSize="20" />
 	<Node name="Surf">

--- a/applications/plugins/SofaPython/examples/PythonAdvancedTimer/poutre_grid_sofa.py
+++ b/applications/plugins/SofaPython/examples/PythonAdvancedTimer/poutre_grid_sofa.py
@@ -41,7 +41,7 @@ class poutreGridSofa(Sofa.PythonScriptController):
         poutreRegGridNode.createObject('FixedConstraint', template='Vec3d', name='default6', indices='@FixedROI.indices')
         # BoxROI for constant constraint (on the right)
         poutreRegGridNode.createObject('BoxROI', template='Vec3d', box='2.495 -0.005 0.18 2.535 0.065 0.205', name='box_roi2', position='@mecaObj.rest_position')
-        poutreRegGridNode.createObject('ConstantForceField', indices="@box_roi2.indices", force='0 -0.1 0', arrowSizeCoef='0.01')
+        poutreRegGridNode.createObject('ConstantForceField', indices="@box_roi2.indices", force='0 -0.1 0', showArrowSize='0.01')
 
         # Visual node
         VisualNode = poutreRegGridNode.createChild('Visu')

--- a/examples/Components/constraint/Compare_FixConstraints.scn
+++ b/examples/Components/constraint/Compare_FixConstraints.scn
@@ -10,7 +10,7 @@
 		  <HexahedronFEMForceField  poissonRatio="0"  youngModulus="1000" />
 		  <BoxROI box="0 0.75 0 1 1 1"  position="@[-2].rest_position"   />
 		  <FixedConstraint indices="@[-1].indices" />
-		  <ConstantForceField points="0 1 4 5"  totalForce="0 -1000 0" />
+		  <ConstantForceField indices="0 1 4 5"  totalForce="0 -1000 0" />
 		  <UniformMass  />
 	  </Node>
   </Node>
@@ -25,7 +25,7 @@
 		  <HexahedronFEMForceField  poissonRatio="0"  youngModulus="1000" />
 		  <BoxROI box="2 0.75 0 3 1 1"  position="@[-2].rest_position"   />
 		  <FixedLMConstraint indices="@[-1].indices" />
-		  <ConstantForceField points="0 1 4 5"  totalForce="0 -1000 0" />
+		  <ConstantForceField indices="0 1 4 5"  totalForce="0 -1000 0" />
 		  <UniformMass  />
 	  </Node>
   </Node>
@@ -39,7 +39,7 @@
 		  <MechanicalObject   showIndices="1"  showIndicesScale="0.0004" />
 		  <HexahedronFEMForceField   poissonRatio="0"  youngModulus="1000" />
 		  <BoxROI  box="4 0.75 0 5 1 1"  position="@[-2].rest_position"  indices="0" />
-		  <ConstantForceField  points="0 1 4 5"  totalForce="0 -1000 0" />
+		  <ConstantForceField  indices="0 1 4 5"  totalForce="0 -1000 0" />
 		  <UniformMass   />
 		  <DOFBlockerLMConstraint rotationAxis="1 0 0 0 1 0 0 0 1"  indices="@[-3].indices" />
 	  </Node>

--- a/examples/Components/forcefield/BoxConstantForceField.scn
+++ b/examples/Components/forcefield/BoxConstantForceField.scn
@@ -11,10 +11,10 @@
         <TriangleFEMForceField name="FEM0" youngModulus="100" poissonRatio="0.3" method="large" />
 
         <BoxROI template="Vec3d" name="box_roi1" box="0 0 0  1 0.5 0"/>
-        <ConstantForceField indices="@box_roi1.indices" force="0 -1 0" arrowSizeCoef=".2"/>
+        <ConstantForceField indices="@box_roi1.indices" force="0 -1 0" showArrowSize=".2"/>
 
         <BoxROI template="Vec3d" name="box_roi2" box="0 0.5 0  1 1 0"/>
-        <ConstantForceField indices="@box_roi2.indices" force="0 1 0" arrowSizeCoef=".2"/>
+        <ConstantForceField indices="@box_roi2.indices" force="0 1 0" showArrowSize=".2"/>
 
         <Node name="Visu">
             <OglModel name="Visual" color="red" />

--- a/examples/Components/forcefield/ConstantForceField.scn
+++ b/examples/Components/forcefield/ConstantForceField.scn
@@ -10,7 +10,7 @@
         <MeshTopology triangles="0 1 2  0 2 3" />
         <!--		<FixedConstraint indices="2 3"/>-->
         <TriangleFEMForceField name="FEM0" youngModulus="100" poissonRatio="0.3" method="large" />
-        <ConstantForceField indices="0 1 2 3" forces="-1 -1 0  1 -1 0  1 1 0  -1 1 0" arrowSizeCoef="1" printLog="1"/>
+        <ConstantForceField indices="0 1 2 3" forces="-1 -1 0  1 -1 0  1 1 0  -1 1 0" showArrowSize="0.5" printLog="1"/>
         <Node name="Visu">
             <OglModel name="Visual" color="red" />
             <IdentityMapping input="@.." output="@Visual" />

--- a/examples/Components/forcefield/ConstantForceField.scn
+++ b/examples/Components/forcefield/ConstantForceField.scn
@@ -7,10 +7,10 @@
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
         <MechanicalObject position="0 0 0  1 0 0  1 1 0  0 1 0" velocity="0 0 0  0 0 0  0 0 0  0 0 0" />
         <UniformMass vertexMass="0.1" />
-        <Mesh triangles="0 1 2  0 2 3" />
+        <MeshTopology triangles="0 1 2  0 2 3" />
         <!--		<FixedConstraint indices="2 3"/>-->
         <TriangleFEMForceField name="FEM0" youngModulus="100" poissonRatio="0.3" method="large" />
-        <ConstantForceField points="0 1 2 3" forces="-1 -1 0  1 -1 0  1 1 0  -1 1 0" />
+        <ConstantForceField indices="0 1 2 3" forces="-1 -1 0  1 -1 0  1 1 0  -1 1 0" arrowSizeCoef="1" printLog="1"/>
         <Node name="Visu">
             <OglModel name="Visual" color="red" />
             <IdentityMapping input="@.." output="@Visual" />
@@ -22,7 +22,7 @@
         <MechanicalObject template="Rigid" dx="2" dy="0" dz="0" rx="0" ry="0" rz="0" scale="1.0" />
         <UniformMass />
         <!-- forces for a rigid is composed of two parts translation of the rigid dof [x y z] and a quaternion for the rotation [x y z w] -->
-        <ConstantForceField points="0" forces="0 0.10 0     0 1 0 0" />
+        <ConstantForceField indices="0" forces="0 0.10 0     0 1 0 0" />
         <Node name="Visu">
             <MeshObjLoader name="meshLoader_0" filename="mesh/torus.obj" scale="0.3" handleSeams="1" />
             <OglModel name="Visual" src="@meshLoader_0" color="gray" />

--- a/examples/Components/forcefield/FastTetrahedronCorotationalForceField_validation.scn
+++ b/examples/Components/forcefield/FastTetrahedronCorotationalForceField_validation.scn
@@ -21,7 +21,7 @@
             <BoxROI box="-1.2 -1.2 -0.01 1.2 1.2 0.01" drawBoxes="1" name="fixedPlane2"  />
             <FixedConstraint indices="@fixedPlane2.indices" />
             <BoxROI box="-1.2 -1.2 0.99 1.2 1.2 1.01" drawBoxes="0" name="pressurePlane2"  />
-            <ConstantForceField points="@pressurePlane2.indices" totalForce="0.05 0 -0.2" />
+            <ConstantForceField indices="@pressurePlane2.indices" totalForce="0.05 0 -0.2" />
             <FastTetrahedralCorotationalForceField poissonRatio="0.45" youngModulus="30" method="large" /> 
 		 </Node>
         <Node name="TetrahedronCorotationalForceField">
@@ -35,7 +35,7 @@
 			<BoxROI box="-1.2 -1.2 -0.01 1.2 1.2 0.01" drawBoxes="1" name="fixedPlane"  />
 			<FixedConstraint indices="@fixedPlane.indices" />
 			<BoxROI box="-1.2 -1.2 0.99 1.2 1.2 1.01" drawBoxes="0" name="pressurePlane"  />
-			<ConstantForceField points="@pressurePlane.indices" totalForce="0.05 0 -0.2" />
+			<ConstantForceField indices="@pressurePlane.indices" totalForce="0.05 0 -0.2" />
 			<TetrahedralCorotationalFEMForceField poissonRatio="0.45" youngModulus="30" method="large" /> 
         </Node>
     </Node>

--- a/examples/Components/forcefield/StandardTetrahedralFEMForceField.scn
+++ b/examples/Components/forcefield/StandardTetrahedralFEMForceField.scn
@@ -21,7 +21,7 @@
 			<BoxROI box="-1.2 -1.2 -0.01 1.2 1.2 0.01" drawBoxes="1" name="fixedPlane2"  />
 			<FixedConstraint indices="@fixedPlane2.indices" />
 			<BoxROI box="-1.2 -1.2 0.99 1.2 1.2 1.01" drawBoxes="0" name="pressurePlane2"  />
-			<ConstantForceField points="@pressurePlane2.indices" totalForce="0.001 0 -0.01" />
+			<ConstantForceField indices="@pressurePlane2.indices" totalForce="0.001 0 -0.01" />
 			<StandardTetrahedralFEMForceField materialName="NeoHookean" ParameterSet="0.454545 0.4166667"  /> 
 		 </Node>
       

--- a/examples/Components/mapping/BarycentricMappingTrussBeam.scn
+++ b/examples/Components/mapping/BarycentricMappingTrussBeam.scn
@@ -9,8 +9,6 @@
     <Node name="Truss" activated="true" gravity="0 0 0">
         <EulerImplicitSolver  rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver iterations="125" tolerance="1e-16" threshold="1e-16" />
-        <!--<LULinearSolver/>-->
-        <!--<RegularGrid name="grid" min="0 0 0" max="0.1 0.01 0.01" nx="10" ny="2" nz="2" />-->
         <MeshGmshLoader name="meshLoader0" filename="mesh/truss_tetra.msh" />
         <TetrahedronSetTopologyContainer name="Container" src="@meshLoader0" />
         <TetrahedronSetTopologyModifier name="Modifier" />
@@ -20,33 +18,25 @@
         <UniformMass totalMass="0.05" />
         <BoxConstraint box="-0.001 -0.001 -0.001 0.001 0.011 0.011" />
         <TetrahedronFEMForceField name="FEM" youngModulus="300000" poissonRatio="0.45" method="large" />
-	<BoxROI box="0.099 -0.001 -0.001 0.11 0.011 0.011"/>
-	<ConstantForceField force="0 -0.1 0" />
-        <!--<BoxConstantForceField  force="0 -0.1 0" />-->
-        <!--<TetrahedralCorotationalFEMForceField template="Vec3d" name="FEM" method="large" poissonRatio="0.3" youngModulus="960000" assembling="0"/>-->
-        <!--<ConstantForceField points="449 459 549 559" forces="1000000 0 0"/>-->
-        <!--<BoxConstantForceField box="4.99 -5.01 -5.01 5.01 5.01 5.01" force="-100000 0 0"/>-->
+        <BoxROI box="0.099 -0.001 -0.001 0.11 0.011 0.011"/>
+        <ConstantForceField force="0 -0.1 0" />
+
         <Node name="Triangle">
             <include href="Objects/TriangleSetTopology.xml" />
             <Tetra2TriangleTopologicalMapping input="@/Truss/Container" output="@Container" />
             <TriangleCollisionModel />
             <Node name="TriangleVisual">
-                <OglModel template="ExtVec3f" name="Visual" material="Default Diffuse 1 1 0 0 1 Ambient 1 0.2 0 0 1 Specular 0 1 0 0 1 Emissive 0 1 0 0 1 Shininess 0 45" />
-                <IdentityMapping template="Vec3d,ExtVec3f" name="default12" input="@.." output="@Visual" />
+                <OglModel template="Vec3" name="Visual" material="Default Diffuse 1 1 0 0 1 Ambient 1 0.2 0 0 1 Specular 0 1 0 0 1 Emissive 0 1 0 0 1 Shininess 0 45" />
+                <IdentityMapping template="Vec3d,Vec3" name="default12" input="@.." output="@Visual" />
             </Node>
-            <!--<TrianglePressureForceField name="TrianglePressure" normal="0 1 0" dmin="0.049" dmax="0.051" pressure="0 5000 0"/>-->
         </Node>
         <Node name="Beam">
-            <MechanicalObject template="Rigid" name="BeamMO" position="0 0 0  0 0 0 1  0.02 0 0  0 0 0 1  0.04 0 0  0 0 0 1   0.06 0 0  0 0 0 1  0.08 0 0  0 0 0 1   0.1 0 0  0 0 0 1" />
-            <Mesh name="BeamMesh" lines="0 1 1 2 2 3 3 4 4 5" />
+            <MechanicalObject template="Rigid3d" name="BeamMO" position="0 0 0  0 0 0 1  0.02 0 0  0 0 0 1  0.04 0 0  0 0 0 1   0.06 0 0  0 0 0 1  0.08 0 0  0 0 0 1   0.1 0 0  0 0 0 1" />
+            <MeshTopology name="BeamMesh" lines="0 1 1 2 2 3 3 4 4 5" />
             <FixedConstraint name="BeamFixedConstraint" indices="0" />
-            <UniformMass vertexMass="0.001 0.001 [0.0001 0 0 0 0.0001 0 0 0 0.0001]" totalMass="0.01" />
-            <!--<UniformMass totalMass="1"/>-->
+            <UniformMass vertexMass="0.001 0.001 [0.0001 0 0 0 0.0001 0 0 0 0.0001]" />
             <BeamFEMForceField name="BeamFEM" radius="0.005" youngModulus="3000000000" poissonRatio="0.45" />
-            <ConstantForceField points="5" forces="0 0 0 -10 0 0" />
-            <!--<MechanicalObject template="Rigid" name="BeamMO" position="0 0 0  0 0.0704 0.7036 0.7071  0 0.05 0 0    0.0704    0.7036    0.7071 0 0.1 0 0    0.0704    0.7036    0.7071"/>-->
-            <!--<UniformMass mass="0.001 0.001 [0.0001 0 0 0 0.0001 0 0 0 0.0001]" printLog="false" totalmass="0.005" />-->
-            <!--<MechanicalObject template="Rigid" name="BeamMO" position="0 0 0.01 0 0 0 1 0.05 0 0.01 0 0 0 1 0.1 0 0.01 0 0 0 1"/>-->
+            <ConstantForceField indices="5" forces="0 0 0 -10 0 0" />
             <BarycentricMapping isMechanical="true" input="@TrussMO" output="@BeamMO" />
             <Node name="VisuThread">
                 <MechanicalObject name="Quads" />
@@ -61,11 +51,4 @@
         </Node>
     </Node>
 </Node>
-<!--<Node name="Beam">
-                        <MechanicalObject template="Rigid" name="BeamMO" position="0 0 0  0 0 0 1   0.05 0 0  0 0 0 1   0.1 0 0  0 0 0 1"/>
-                        <Mesh name="BeamMesh" lines="0 1 1 2"/>
-                        <FixedConstraint name="BeamFixedConstraint" indices="0" />
-                        <UniformMass vertexMass="0.001 0.001 [0.0001 0 0 0 0.0001 0 0 0 0.0001]" totalMass="1"/>
-                        <BeamFEMForceField name="BeamFEM" radius="0.1" youngModulus="900" poissonRatio="0.45"/>
-                        <ConstantForceField points="2" forces="0 -1 0 0 0 0"/>
-		</Node>-->
+

--- a/examples/Components/mapping/HexahedronCompositeFEMMapping.scn
+++ b/examples/Components/mapping/HexahedronCompositeFEMMapping.scn
@@ -5,7 +5,7 @@
     <MeshObjLoader name="meshLoader_2" filename="mesh/plane_loop_2.obj" scale="1" handleSeams="1" />
     <OglModel name="plan" src="@meshLoader_2" rx="90" rz="90" dy="-10.2" material="Default Diffuse 1 1 0.4 0.4 1 Ambient 1 0.8 0.8 0.8 1 Specular 0 1 1 1 1 Emissive 0 1 1 1 1 Shininess 0 45"/>
     <Node name="HexahedronCompositeFEMMapping">
-        <SparseGridMultiple n="2 2 2" fileTopology="mesh/grape_out.obj" fileTopologies="mesh/grape_out.obj mesh/grape_in.obj" stiffnessCoefs="1 1000000" massCoefs="1 1" nbVirtualFinerLevels="4" finestConnectivity="false" />
+        <SparseGridMultipleTopology n="2 2 2" fileTopology="mesh/grape_out.obj" fileTopologies="mesh/grape_out.obj mesh/grape_in.obj" stiffnessCoefs="1 1000000" massCoefs="1 1" nbVirtualFinerLevels="4" finestConnectivity="false" />
         <EulerImplicitSolver rayleighMass="0" rayleighStiffness="0" />
         <CGLinearSolver iterations="2000" tolerance="1e-5" threshold="1e-5"/>
         <MechanicalObject dx="15" />
@@ -13,7 +13,7 @@
         <BoxConstraint box="-30 -11 -30   100 -9 30" drawSize="0.75" />
         <Node name="Collinonunif">
             <MeshObjLoader name="loader" filename="mesh/grape_out.obj" />
-            <Mesh src="@loader" />
+            <MeshTopology src="@loader" />
             <MechanicalObject src="@loader" />
             <HexahedronCompositeFEMMapping/>
             <Node name="f1">
@@ -32,7 +32,7 @@
         </Node>
     </Node>
     <Node name="BarycentricMapping">
-        <SparseGridMultiple n="2 2 2" fileTopology="mesh/grape_out.obj" fileTopologies="mesh/grape_out.obj mesh/grape_in.obj" stiffnessCoefs="1 1000000" massCoefs="1 1" nbVirtualFinerLevels="4" finestConnectivity="false" />
+        <SparseGridMultipleTopology n="2 2 2" fileTopology="mesh/grape_out.obj" fileTopologies="mesh/grape_out.obj mesh/grape_in.obj" stiffnessCoefs="1 1000000" massCoefs="1 1" nbVirtualFinerLevels="4" finestConnectivity="false" />
         <EulerImplicitSolver rayleighMass="0" rayleighStiffness="0" />
         <CGLinearSolver iterations="2000" tolerance="1e-5" threshold="1e-5"/>
         <MechanicalObject dx="-15" />
@@ -40,11 +40,11 @@
         <BoxConstraint box="-100 -11 -30   30 -9 30" drawSize="0.75"/>
         <Node name="Collinonunif">
             <MeshObjLoader name="loader" filename="mesh/grape_out.obj"/>
-            <Mesh src="@loader"/>
+            <MeshTopology src="@loader"/>
             <MechanicalObject src="@loader"/>
             <BarycentricMapping/>
             <Node name="f2">
-                <ConstantForceField points="340" forces="1000 8000 0" arrowSizeCoef=".001" />
+                <ConstantForceField indices="340" forces="1000 8000 0" arrowSizeCoef=".001" />
             </Node>
             <Node name="Visu2">
                 <MeshObjLoader name="meshLoader_4" filename="mesh/grape_out.obj" handleSeams="1" />

--- a/examples/Components/mapping/HexahedronCompositeFEMMapping.scn
+++ b/examples/Components/mapping/HexahedronCompositeFEMMapping.scn
@@ -17,7 +17,7 @@
             <MechanicalObject src="@loader" />
             <HexahedronCompositeFEMMapping/>
             <Node name="f1">
-                <ConstantForceField points="340" forces="1000 8000 0" arrowSizeCoef=".001" />
+                <ConstantForceField indices="340" forces="1000 8000 0" arrowSizeCoef=".001" />
             </Node>
             <Node name="Visu2">
                 <MeshObjLoader name="meshLoader_3" filename="mesh/grape_out.obj" handleSeams="1" />

--- a/examples/Components/mapping/HexahedronCompositeFEMMapping.scn
+++ b/examples/Components/mapping/HexahedronCompositeFEMMapping.scn
@@ -17,7 +17,7 @@
             <MechanicalObject src="@loader" />
             <HexahedronCompositeFEMMapping/>
             <Node name="f1">
-                <ConstantForceField indices="340" forces="1000 8000 0" arrowSizeCoef=".001" />
+                <ConstantForceField indices="340" forces="1000 8000 0" showArrowSize=".001" />
             </Node>
             <Node name="Visu2">
                 <MeshObjLoader name="meshLoader_3" filename="mesh/grape_out.obj" handleSeams="1" />
@@ -44,7 +44,7 @@
             <MechanicalObject src="@loader"/>
             <BarycentricMapping/>
             <Node name="f2">
-                <ConstantForceField indices="340" forces="1000 8000 0" arrowSizeCoef=".001" />
+                <ConstantForceField indices="340" forces="1000 8000 0" showArrowSize=".001" />
             </Node>
             <Node name="Visu2">
                 <MeshObjLoader name="meshLoader_4" filename="mesh/grape_out.obj" handleSeams="1" />

--- a/examples/Components/mapping/IdentityMultiMapping.scn
+++ b/examples/Components/mapping/IdentityMultiMapping.scn
@@ -28,7 +28,7 @@
                 <IdentityMultiMapping template="Vec3d,Vec3d" input="@../../dof1 @../dof2" output="@./dofall" />
                 <SphereCollisionModel radius="0.3" selfCollision="1"/>
                 <UniformMass vertexMass="1" />
-                <ConstantForceField points="0" force="1 0 0"/>
+                <ConstantForceField indices="0" force="1 0 0"/>
             </Node>
             
         </Node>

--- a/examples/Components/mapping/RigidMapping-basic.scn
+++ b/examples/Components/mapping/RigidMapping-basic.scn
@@ -11,7 +11,7 @@
         <Node name="child node with DOFs mapped from the parent">
             <MechanicalObject template="Vec3d" name="endpoint coordinates" position="1 -0.0 0"  />
             <RigidMapping name="angle-coord mapping" input="@.." output="@." index="0" />
-            <ConstantForceField force="1 -1 0" points="0" />
+            <ConstantForceField force="1 -1 0" indices="0" />
         </Node>
     </Node>
 </Node>

--- a/examples/Components/mapping/RigidMapping2d-basic.scn
+++ b/examples/Components/mapping/RigidMapping2d-basic.scn
@@ -11,7 +11,7 @@
         <Node name="child node with DOFs mapped from the parent">
             <MechanicalObject template="Vec2d" name="endpoint coordinates" position="1 0 "  />
             <RigidMapping template="" name="angle-coord mapping" input="@.." output="@." index="0" />
-            <ConstantForceField force="1 -1" points="0" />
+            <ConstantForceField force="1 -1" indices="0" />
         </Node>
     </Node>
 </Node>

--- a/examples/Components/mapping/RigidRigidMapping-basic.scn
+++ b/examples/Components/mapping/RigidRigidMapping-basic.scn
@@ -11,7 +11,7 @@
         <Node name="child node with DOFs mapped from the parent">
             <MechanicalObject template="Rigid" name="endpoint coordinates" position="1 0 0 0 0 0 1"  />
             <RigidRigidMapping name="angle-coord mapping" input="@.." output="@." index="0" />
-            <ConstantForceField force="1 -1 0 0 0 0" points="0" />
+            <ConstantForceField force="1 -1 0 0 0 0" indices="0" />
         </Node>
     </Node>
 </Node>

--- a/examples/Components/mapping/SubsetMultiMapping.scn
+++ b/examples/Components/mapping/SubsetMultiMapping.scn
@@ -28,7 +28,7 @@
                 <SubsetMultiMapping template="Vec3d,Vec3d" input="@../../dof1 @../dof2" output="@./dofall" indexPairs="0 0 0 1 1 0 1 1"/>
                 <SphereCollisionModel radius="0.3" selfCollision="1"/>
                 <UniformMass vertexMass="1" />
-                <ConstantForceField points="0" force="1 0 0"/>
+                <ConstantForceField indices="0" force="1 0 0"/>
             </Node>
             
         </Node>
@@ -51,7 +51,7 @@
                 <SubsetMultiMapping template="Rigid3d,Vec3d" input="@../../dof1 @../dof2" output="@./dofall" indexPairs="0 0 0 1 1 0 1 1"/>
                 <SphereCollisionModel radius="0.3" selfCollision="1"/>
                 <UniformMass vertexMass="1" />
-                <ConstantForceField points="0" force="1 0 0"/>
+                <ConstantForceField indices="0" force="1 0 0"/>
             </Node>
 
         </Node>

--- a/examples/Objects/BoxConstantForceField.xml
+++ b/examples/Objects/BoxConstantForceField.xml
@@ -1,4 +1,4 @@
 <Node name="Group">
 	<BoxROI name="box_roi" box="0 0 0 1 1 1" position="" />
-	<ConstantForceField points="@[-1].indices" force="" totalForce="" arrowSizeCoef="" />
+        <ConstantForceField points="@[-1].indices" force="" totalForce="" showArrowSize="" />
 </Node>

--- a/examples/Tutorials/sandbox/explicit_singlehexaFEM.scn
+++ b/examples/Tutorials/sandbox/explicit_singlehexaFEM.scn
@@ -8,7 +8,7 @@
 		<HexahedronFEMForceField  poissonRatio="0"  youngModulus="1000" />
 		<BoxROI box="0 0.75 0 1 1 1"  position="@[-2].rest_position"   />
 		<FixedConstraint indices="@[-1].indices" />
-		<ConstantForceField points="0 1 2 3 4 5 6 7"  totalForce="0 -1000 0" />
+		<ConstantForceField indices="0 1 2 3 4 5 6 7"  totalForce="0 -1000 0" />
 		<UniformMass  />
 	</Node>
 </Node>

--- a/examples/Tutorials/sandbox/implicit_singlehexaFEM.scn
+++ b/examples/Tutorials/sandbox/implicit_singlehexaFEM.scn
@@ -9,7 +9,7 @@
 		<HexahedronFEMForceField  poissonRatio="0"  youngModulus="1000" />
 		<BoxROI box="0 0.75 0 1 1 1"  position="@[-2].rest_position"   />
 		<FixedConstraint indices="@[-1].indices" />
-		<ConstantForceField points="0 1 4 5"  totalForce="0 -1000 0" />
+		<ConstantForceField indices="0 1 4 5"  totalForce="0 -1000 0" />
 		<UniformMass  />
 	</Node>
 </Node>

--- a/examples/Tutorials/sandbox/implicit_singlehexaFEM_2.scn
+++ b/examples/Tutorials/sandbox/implicit_singlehexaFEM_2.scn
@@ -9,7 +9,7 @@
 		<HexahedronFEMForceField  poissonRatio="0"  youngModulus="1000" />
 		<BoxROI box="0 0.75 0 1 1 1"  position="@[-2].rest_position"   />
 		<FixedConstraint indices="@[-1].indices" />
-		<ConstantForceField points="0 1 2 3 4 5 6 7"  totalForce="0 -1000 0" />
+		<ConstantForceField indices="0 1 2 3 4 5 6 7"  totalForce="0 -1000 0" />
 		<UniformMass  />
 	</Node>
 </Node>

--- a/examples/Tutorials/sandbox/rungekutta_singlehexaFEM.scn
+++ b/examples/Tutorials/sandbox/rungekutta_singlehexaFEM.scn
@@ -8,7 +8,7 @@
 		<HexahedronFEMForceField  poissonRatio="0"  youngModulus="1000" />
 		<BoxROI box="0 0.75 0 1 1 1"  position="@[-2].rest_position"   />
 		<FixedConstraint indices="@[-1].indices" />
-		<ConstantForceField points="0 1 2 3 4 5 6 7"  totalForce="0 -1000 0" />
+		<ConstantForceField indices="0 1 2 3 4 5 6 7"  totalForce="0 -1000 0" />
 		<UniformMass  />
 	</Node>
 </Node>

--- a/modules/SofaBoundaryCondition/ConstantForceField.h
+++ b/modules/SofaBoundaryCondition/ConstantForceField.h
@@ -107,7 +107,7 @@ public:
     void updateForceMask() override;
 
     /// Update data and internal vectors
-    void doUpdateInternal() override;
+    void doInternalUpdate() override;
 
     /// Set a force to a given particle
     void setForce( unsigned i, const Deriv& f );

--- a/modules/SofaBoundaryCondition/ConstantForceField.h
+++ b/modules/SofaBoundaryCondition/ConstantForceField.h
@@ -107,7 +107,7 @@ public:
     void updateForceMask() override;
 
     /// Update data and internal vectors
-    void doInternalUpdate() override;
+    void doUpdateInternal() override;
 
     /// Set a force to a given particle
     void setForce( unsigned i, const Deriv& f );

--- a/modules/SofaBoundaryCondition/ConstantForceField.h
+++ b/modules/SofaBoundaryCondition/ConstantForceField.h
@@ -124,13 +124,13 @@ protected:
     sofa::core::topology::BaseMeshTopology* m_topology;
 
     /// Functions checking inputs before update
-    bool checkForce(Deriv force);
-    bool checkForces(VecDeriv forces);
+    bool checkForce(const Deriv&  force);
+    bool checkForces(const VecDeriv& forces);
 
     /// Functions computing and updating the constant force vector
-    void computeForceFromSingleForce(Deriv force);
-    void computeForceFromForceVector(VecDeriv forces);
-    void computeForceFromTotalForce(Deriv totalForce);
+    void computeForceFromSingleForce(const Deriv& force);
+    void computeForceFromForceVector(const VecDeriv& forces);
+    void computeForceFromTotalForce(const Deriv& totalForce);
 
     /// Save system size for update of indices (doUpdateInternal)
     size_t m_systemSize;

--- a/modules/SofaBoundaryCondition/ConstantForceField.h
+++ b/modules/SofaBoundaryCondition/ConstantForceField.h
@@ -27,6 +27,7 @@
 
 #include <SofaBaseTopology/TopologySubsetData.h>
 #include <sofa/defaulttype/RGBAColor.h>
+#include <sofa/core/DataTracker.h>
 
 namespace sofa
 {
@@ -58,68 +59,81 @@ public:
 
 public:
     /// indices of the points the force applies to
-    SetIndex                   d_indices;
+    SetIndex d_indices;
 
     /// Concerned DOFs indices are numbered from the end of the MState DOFs vector
-    Data< bool >               d_indexFromEnd;
+    Data< bool > d_indexFromEnd;
 
     /// Per-point forces.
-    Data< VecDeriv >           d_forces;
+    Data< VecDeriv > d_forces;
 
     /// Force applied at each point, if per-point forces are not specified
-    Data< Deriv >              d_force;
+    Data< Deriv > d_force;
 
     /// Sum of the forces applied at each point, if per-point forces are not specified
-    Data< Deriv >              d_totalForce;
+    Data< Deriv > d_totalForce;
 
     /// S for drawing. The sign changes the direction, 0 doesn't draw arrow
-    Data< SReal >              d_arrowSizeCoef;
+    Data< SReal > d_arrowSizeCoef;
 
     /// display color
     Data< defaulttype::RGBAColor > d_color;
+
     /// Concerned DOFs indices are numbered from the end of the MState DOFs vector
     Data< bool > indexFromEnd;
 
 public:
     /// Init function
     void init() override;
-    void parse(sofa::core::objectmodel::BaseObjectDescription *arg) override;
+
+    /// Re-init function
+    void reinit() override;
 
     /// Add the forces
-    void addForce (const core::MechanicalParams* params, DataVecDeriv& f,
-                           const DataVecCoord& x, const DataVecDeriv& v) override;
+    void addForce (const core::MechanicalParams* params, DataVecDeriv& f, const DataVecCoord& x, const DataVecDeriv& v) override;
 
     /// Constant force has null variation
-    void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df ,
-                           const DataVecDeriv& d_dx) override;
-
-    using Inherit::addKToMatrix;
+    void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df , const DataVecDeriv& d_dx) override;
 
     /// Constant force has null variation
-    void addKToMatrix(sofa::defaulttype::BaseMatrix *m,
-                              SReal kFactor, unsigned int &offset) override;
+    void addKToMatrix(sofa::defaulttype::BaseMatrix *mat, SReal k, unsigned int &offset) override;
 
     /// Constant force has null variation
-    virtual void addKToMatrix(const sofa::core::behavior::MultiMatrixAccessor* /*matrix*/,
-                              SReal /*kFact*/) ;
+    virtual void addKToMatrix(const sofa::core::behavior::MultiMatrixAccessor* /*matrix*/, SReal /*kFact*/) ;
 
-    SReal getPotentialEnergy(const core::MechanicalParams* params,
-                                     const DataVecCoord& x) const override;
+    SReal getPotentialEnergy(const core::MechanicalParams* params, const DataVecCoord& x) const override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 
     void updateForceMask() override;
 
+    /// Update data and internal vectors
+    void doUpdateInternal() override;
+
     /// Set a force to a given particle
     void setForce( unsigned i, const Deriv& f );
 
     using Inherit::addAlias ;
+    using Inherit::addKToMatrix;
+
 
 protected:
     ConstantForceField();
 
     /// Pointer to the current topology
     sofa::core::topology::BaseMeshTopology* m_topology;
+
+    /// Functions checking inputs before update
+    bool checkForce(Deriv force);
+    bool checkForces(VecDeriv forces);
+
+    /// Functions computing and updating the constant force vector
+    void computeForceFromSingleForce(Deriv force);
+    void computeForceFromForceVector(VecDeriv forces);
+    void computeForceFromTotalForce(Deriv totalForce);
+
+    /// Save system size for update of indices (doUpdateInternal)
+    size_t m_systemSize;
 };
 
 template <>

--- a/modules/SofaBoundaryCondition/ConstantForceField.h
+++ b/modules/SofaBoundaryCondition/ConstantForceField.h
@@ -128,9 +128,9 @@ protected:
     bool checkForces(const VecDeriv& forces);
 
     /// Functions computing and updating the constant force vector
-    void computeForceFromSingleForce(const Deriv& force);
-    void computeForceFromForceVector(const VecDeriv& forces);
-    void computeForceFromTotalForce(const Deriv& totalForce);
+    void computeForceFromSingleForce();
+    void computeForceFromForceVector();
+    void computeForceFromTotalForce();
 
     /// Save system size for update of indices (doUpdateInternal)
     size_t m_systemSize;

--- a/modules/SofaBoundaryCondition/ConstantForceField.h
+++ b/modules/SofaBoundaryCondition/ConstantForceField.h
@@ -27,7 +27,6 @@
 
 #include <SofaBaseTopology/TopologySubsetData.h>
 #include <sofa/defaulttype/RGBAColor.h>
-#include <sofa/core/DataTracker.h>
 
 namespace sofa
 {

--- a/modules/SofaBoundaryCondition/ConstantForceField.h
+++ b/modules/SofaBoundaryCondition/ConstantForceField.h
@@ -112,6 +112,9 @@ public:
     /// Set a force to a given particle
     void setForce( unsigned i, const Deriv& f );
 
+    /// Parse function (to be removed after v19.12)
+    void parse(sofa::core::objectmodel::BaseObjectDescription* arg) override;
+
     using Inherit::addAlias ;
     using Inherit::addKToMatrix;
 

--- a/modules/SofaBoundaryCondition/ConstantForceField.h
+++ b/modules/SofaBoundaryCondition/ConstantForceField.h
@@ -73,7 +73,7 @@ public:
     Data< Deriv > d_totalForce;
 
     /// S for drawing. The sign changes the direction, 0 doesn't draw arrow
-    Data< SReal > d_arrowSizeCoef;
+    Data< SReal > d_showArrowSize;
 
     /// display color
     Data< defaulttype::RGBAColor > d_color;

--- a/modules/SofaBoundaryCondition/ConstantForceField.inl
+++ b/modules/SofaBoundaryCondition/ConstantForceField.inl
@@ -75,7 +75,9 @@ void ConstantForceField<DataTypes>::init()
         m_systemSize = state->getSize();
     }
     else
+    {
          m_systemSize = m_topology->getNbPoints();
+    }
 
 
     // Initialize functions and parameters for topology data and handler
@@ -197,7 +199,9 @@ void ConstantForceField<DataTypes>::doUpdateInternal()
             this->m_componentstate = core::objectmodel::ComponentState::Invalid;
         }
         else if( indicesSize==0 )
+        {
             msg_warning() << "Size of vector indices is zero";
+        }
 
         // check each indice of the vector
         for(size_t i=0; i<indicesSize; i++)
@@ -271,7 +275,9 @@ bool ConstantForceField<DataTypes>::checkForce(Deriv force)
     for (size_t i=0; i<size; i++)
     {
         if( std::isnan(force[i]) )
+        {
             return false;
+        }
     }
     return true;
 }
@@ -279,11 +285,12 @@ bool ConstantForceField<DataTypes>::checkForce(Deriv force)
 template<class DataTypes>
 bool ConstantForceField<DataTypes>::checkForces(VecDeriv forces)
 {
-    const auto& force_vector = forces;
-    for (auto&& i : force_vector)
+    for (auto&& i : forces)
     {
         if(! checkForce(i) )
+        {
             return false;
+        }
     }
     return true;
 }

--- a/modules/SofaBoundaryCondition/ConstantForceField.inl
+++ b/modules/SofaBoundaryCondition/ConstantForceField.inl
@@ -53,7 +53,7 @@ ConstantForceField<DataTypes>::ConstantForceField()
     , d_forces(initData(&d_forces, "forces", "applied forces at each point"))
     , d_force(initData(&d_force, "force", "applied force to all points if forces attribute is not specified"))
     , d_totalForce(initData(&d_totalForce, "totalForce", "total force for all points, will be distributed uniformly over points"))
-    , d_showArrowSize(initData(&d_showArrowSize,SReal(0.0), "arrowSizeCoef", "Size of the drawn arrows (0->no arrows, sign->direction of drawing. (default=0)"))
+    , d_showArrowSize(initData(&d_showArrowSize,SReal(0.0), "showArrowSize", "Size of the drawn arrows (0->no arrows, sign->direction of drawing. (default=0)"))
     , d_color(initData(&d_color, defaulttype::RGBAColor(0.2f,0.9f,0.3f,1.0f), "showColor", "Color for object display (default: [0.2,0.9,0.3,1.0])"))
 {
     d_showArrowSize.setGroup("Visualization");

--- a/modules/SofaBoundaryCondition/ConstantForceField.inl
+++ b/modules/SofaBoundaryCondition/ConstantForceField.inl
@@ -183,10 +183,10 @@ void ConstantForceField<DataTypes>::init()
     Inherit::init();
 
     // add to tracker
-    this->trackInternalData(d_indices);
-    this->trackInternalData(d_forces);
-    this->trackInternalData(d_force);
-    this->trackInternalData(d_totalForce);
+    this->trackData(d_indices);
+    this->trackData(d_forces);
+    this->trackData(d_force);
+    this->trackData(d_totalForce);
 
     // if all init passes, component is valid
     this->m_componentstate = core::objectmodel::ComponentState::Valid;
@@ -196,17 +196,17 @@ void ConstantForceField<DataTypes>::init()
 template<class DataTypes>
 void ConstantForceField<DataTypes>::reinit()
 {
-    // Now update is handled through the doUpdateInternal mechanism
-    // called at each begin of step through the UpdateInternalDataVisitor
+    // Now update is handled through the doInternalUpdate mechanism
+    // called at each begin of step through the InternalUpdateDataVisitor
 }
 
 
 template<class DataTypes>
-void ConstantForceField<DataTypes>::doUpdateInternal()
+void ConstantForceField<DataTypes>::doInternalUpdate()
 {
     if (this->hasDataChanged(d_indices))
     {
-        msg_info() << "doUpdateInternal: data indices has changed";
+        msg_info() << "doInternalUpdate: data indices has changed";
 
         const VecIndex & indices = d_indices.getValue();
         size_t indicesSize = indices.size();
@@ -239,7 +239,7 @@ void ConstantForceField<DataTypes>::doUpdateInternal()
 
     if (this->hasDataChanged(d_forces))
     {
-        msg_info() << "doUpdateInternal: data forces has changed";
+        msg_info() << "doInternalUpdate: data forces has changed";
 
         const VecDeriv &forces = d_forces.getValue();
         if( checkForces(forces) )
@@ -257,7 +257,7 @@ void ConstantForceField<DataTypes>::doUpdateInternal()
 
     if (this->hasDataChanged(d_force))
     {
-        msg_info() << "doUpdateInternal: data force has changed";
+        msg_info() << "doInternalUpdate: data force has changed";
 
         const Deriv &force = d_force.getValue();
         if( checkForce(force) )
@@ -275,7 +275,7 @@ void ConstantForceField<DataTypes>::doUpdateInternal()
 
     if (this->hasDataChanged(d_totalForce))
     {
-        msg_info() << "doUpdateInternal: data totalForce has changed";
+        msg_info() << "doInternalUpdate: data totalForce has changed";
 
         const Deriv &totalForce = d_totalForce.getValue();
         if( checkForce(totalForce) )

--- a/modules/SofaBoundaryCondition/ConstantForceField.inl
+++ b/modules/SofaBoundaryCondition/ConstantForceField.inl
@@ -49,11 +49,11 @@ namespace forcefield
 template<class DataTypes>
 ConstantForceField<DataTypes>::ConstantForceField()
     : d_indices(initData(&d_indices, "indices", "indices where the forces are applied"))
-    , d_indexFromEnd(initData(&d_indexFromEnd,(bool)false,"indexFromEnd", "Concerned DOFs indices are numbered from the end of the MState DOFs vector. (default=false)"))
+    , d_indexFromEnd(initData(&d_indexFromEnd,bool(false),"indexFromEnd", "Concerned DOFs indices are numbered from the end of the MState DOFs vector. (default=false)"))
     , d_forces(initData(&d_forces, "forces", "applied forces at each point"))
     , d_force(initData(&d_force, "force", "applied force to all points if forces attribute is not specified"))
     , d_totalForce(initData(&d_totalForce, "totalForce", "total force for all points, will be distributed uniformly over points"))
-    , d_arrowSizeCoef(initData(&d_arrowSizeCoef,(SReal)0.0, "arrowSizeCoef", "Size of the drawn arrows (0->no arrows, sign->direction of drawing. (default=0)"))
+    , d_arrowSizeCoef(initData(&d_arrowSizeCoef,SReal(0.0), "arrowSizeCoef", "Size of the drawn arrows (0->no arrows, sign->direction of drawing. (default=0)"))
     , d_color(initData(&d_color, defaulttype::RGBAColor(0.2f,0.9f,0.3f,1.0f), "showColor", "Color for object display (default: [0.2,0.9,0.3,1.0])"))
 {
     d_arrowSizeCoef.setGroup("Visualization");
@@ -94,6 +94,7 @@ void ConstantForceField<DataTypes>::init()
         {
             msg_error() << "Size mismatch: indices > system size";
             this->m_componentstate = core::objectmodel::ComponentState::Invalid;
+            return;
         }
         // check each indice of the vector
         for(size_t i=0; i<indicesSize; i++)
@@ -102,6 +103,7 @@ void ConstantForceField<DataTypes>::init()
             {
                 msg_error() << "Indices incorrect: indice["<< i <<"] = "<< indices[i] <<" exceeds system size";
                 this->m_componentstate = core::objectmodel::ComponentState::Invalid;
+                return;
             }
         }
     }
@@ -126,6 +128,7 @@ void ConstantForceField<DataTypes>::init()
         {
             msg_error() << " Invalid given vector forces";
             this->m_componentstate = core::objectmodel::ComponentState::Invalid;
+            return;
         }
         msg_info() << "Input vector forces is used for initialization";
     }
@@ -140,6 +143,7 @@ void ConstantForceField<DataTypes>::init()
         {
             msg_error() << " Invalid given force";
             this->m_componentstate = core::objectmodel::ComponentState::Invalid;
+            return;
         }
         msg_info() << "Input force is used for initialization";
     }
@@ -154,6 +158,7 @@ void ConstantForceField<DataTypes>::init()
         {
             msg_error() << " Invalid given totalForce";
             this->m_componentstate = core::objectmodel::ComponentState::Invalid;
+            return;
         }
         msg_info() << "Input totalForce is used for initialization";
     }
@@ -197,6 +202,7 @@ void ConstantForceField<DataTypes>::doUpdateInternal()
         {
             msg_error() << "Size mismatch: indices > system size";
             this->m_componentstate = core::objectmodel::ComponentState::Invalid;
+            return;
         }
         else if( indicesSize==0 )
         {
@@ -210,6 +216,7 @@ void ConstantForceField<DataTypes>::doUpdateInternal()
             {
                 msg_error() << "Indices incorrect: indice["<< i <<"] = "<< indices[i] <<" exceeds system size";
                 this->m_componentstate = core::objectmodel::ComponentState::Invalid;
+                return;
             }
         }
     }
@@ -228,6 +235,7 @@ void ConstantForceField<DataTypes>::doUpdateInternal()
         {
             msg_error() << " Invalid given vector forces";
             this->m_componentstate = core::objectmodel::ComponentState::Invalid;
+            return;
         }
     }
 
@@ -245,6 +253,7 @@ void ConstantForceField<DataTypes>::doUpdateInternal()
         {
             msg_error() << " Invalid given force";
             this->m_componentstate = core::objectmodel::ComponentState::Invalid;
+            return;
         }
     }
 
@@ -262,6 +271,7 @@ void ConstantForceField<DataTypes>::doUpdateInternal()
         {
             msg_error() << " Invalid given totalForce";
             this->m_componentstate = core::objectmodel::ComponentState::Invalid;
+            return;
         }
     }
 }
@@ -306,6 +316,7 @@ void ConstantForceField<DataTypes>::computeForceFromForceVector()
     {
         msg_error() << "Impossible to use the vector forces since its size mismatches with indices size";
         this->m_componentstate = core::objectmodel::ComponentState::Invalid;
+        return;
     }
     else
     {
@@ -353,6 +364,7 @@ void ConstantForceField<DataTypes>::computeForceFromTotalForce()
     {
         msg_error() << "Impossible to compute force from totalForce since vector indices size is zero";
         this->m_componentstate = core::objectmodel::ComponentState::Invalid;
+        return;
     }
 }
 

--- a/modules/SofaBoundaryCondition/ConstantForceField.inl
+++ b/modules/SofaBoundaryCondition/ConstantForceField.inl
@@ -183,10 +183,10 @@ void ConstantForceField<DataTypes>::init()
     Inherit::init();
 
     // add to tracker
-    this->trackData(d_indices);
-    this->trackData(d_forces);
-    this->trackData(d_force);
-    this->trackData(d_totalForce);
+    this->trackInternalData(d_indices);
+    this->trackInternalData(d_forces);
+    this->trackInternalData(d_force);
+    this->trackInternalData(d_totalForce);
 
     // if all init passes, component is valid
     this->m_componentstate = core::objectmodel::ComponentState::Valid;
@@ -202,11 +202,11 @@ void ConstantForceField<DataTypes>::reinit()
 
 
 template<class DataTypes>
-void ConstantForceField<DataTypes>::doInternalUpdate()
+void ConstantForceField<DataTypes>::doUpdateInternal()
 {
     if (this->hasDataChanged(d_indices))
     {
-        msg_info() << "doInternalUpdate: data indices has changed";
+        msg_info() << "doUpdateInternal: data indices has changed";
 
         const VecIndex & indices = d_indices.getValue();
         size_t indicesSize = indices.size();
@@ -239,7 +239,7 @@ void ConstantForceField<DataTypes>::doInternalUpdate()
 
     if (this->hasDataChanged(d_forces))
     {
-        msg_info() << "doInternalUpdate: data forces has changed";
+        msg_info() << "doUpdateInternal: data forces has changed";
 
         const VecDeriv &forces = d_forces.getValue();
         if( checkForces(forces) )
@@ -257,7 +257,7 @@ void ConstantForceField<DataTypes>::doInternalUpdate()
 
     if (this->hasDataChanged(d_force))
     {
-        msg_info() << "doInternalUpdate: data force has changed";
+        msg_info() << "doUpdateInternal: data force has changed";
 
         const Deriv &force = d_force.getValue();
         if( checkForce(force) )
@@ -275,7 +275,7 @@ void ConstantForceField<DataTypes>::doInternalUpdate()
 
     if (this->hasDataChanged(d_totalForce))
     {
-        msg_info() << "doInternalUpdate: data totalForce has changed";
+        msg_info() << "doUpdateInternal: data totalForce has changed";
 
         const Deriv &totalForce = d_totalForce.getValue();
         if( checkForce(totalForce) )

--- a/modules/SofaBoundaryCondition/ConstantForceField.inl
+++ b/modules/SofaBoundaryCondition/ConstantForceField.inl
@@ -53,10 +53,10 @@ ConstantForceField<DataTypes>::ConstantForceField()
     , d_forces(initData(&d_forces, "forces", "applied forces at each point"))
     , d_force(initData(&d_force, "force", "applied force to all points if forces attribute is not specified"))
     , d_totalForce(initData(&d_totalForce, "totalForce", "total force for all points, will be distributed uniformly over points"))
-    , d_arrowSizeCoef(initData(&d_arrowSizeCoef,SReal(0.0), "arrowSizeCoef", "Size of the drawn arrows (0->no arrows, sign->direction of drawing. (default=0)"))
+    , d_showArrowSize(initData(&d_showArrowSize,SReal(0.0), "arrowSizeCoef", "Size of the drawn arrows (0->no arrows, sign->direction of drawing. (default=0)"))
     , d_color(initData(&d_color, defaulttype::RGBAColor(0.2f,0.9f,0.3f,1.0f), "showColor", "Color for object display (default: [0.2,0.9,0.3,1.0])"))
 {
-    d_arrowSizeCoef.setGroup("Visualization");
+    d_showArrowSize.setGroup("Visualization");
     d_color.setGroup("Visualization");
 }
 
@@ -493,7 +493,7 @@ void ConstantForceField<DataTypes>::addKToMatrix(const sofa::core::behavior::Mul
 template<class DataTypes>
 void ConstantForceField<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
-    const SReal aSC = d_arrowSizeCoef.getValue();
+    const SReal aSC = d_showArrowSize.getValue();
 
     if ((!vparams->displayFlags().getShowForceFields() && (aSC==0.0)) || (aSC < 0.0)) return;
 

--- a/modules/SofaBoundaryCondition/ConstantForceField.inl
+++ b/modules/SofaBoundaryCondition/ConstantForceField.inl
@@ -66,8 +66,8 @@ void ConstantForceField<DataTypes>::parse(BaseObjectDescription* arg)
 {
     /// Now warning the user when using old API
     /// TODO: remove for 20.06
-    const char* val=arg->getAttribute("points",nullptr) ;
-    if(val)
+    const char* val1=arg->getAttribute("points",nullptr) ;
+    if(val1)
     {
         msg_error() << "The attribute 'points' is no longer valid."
                     << "It has been converted into 'indices' since Sofa 17.06 '" ;
@@ -75,8 +75,8 @@ void ConstantForceField<DataTypes>::parse(BaseObjectDescription* arg)
     }
     /// Now warning the user when using old API
     /// TODO: remove for 20.06
-    const char* val=arg->getAttribute("arrowSizeCoef",nullptr) ;
-    if(val)
+    const char* val2=arg->getAttribute("arrowSizeCoef",nullptr) ;
+    if(val2)
     {
         msg_error() << "The attribute 'arrowSizeCoef' is no longer valid."
                     << "It has been converted into 'showArrowSize' since Sofa 19.12 '" ;

--- a/modules/SofaBoundaryCondition/ConstantForceField.inl
+++ b/modules/SofaBoundaryCondition/ConstantForceField.inl
@@ -65,12 +65,21 @@ template<class DataTypes>
 void ConstantForceField<DataTypes>::parse(BaseObjectDescription* arg)
 {
     /// Now warning the user when using old API
-    /// point is deprecated since '17.06'
+    /// TODO: remove for 20.06
     const char* val=arg->getAttribute("points",nullptr) ;
     if(val)
     {
         msg_error() << "The attribute 'points' is no longer valid."
-                    << "It has been converted into 'indices since Sofa 17.06 '" ;
+                    << "It has been converted into 'indices' since Sofa 17.06 '" ;
+
+    }
+    /// Now warning the user when using old API
+    /// TODO: remove for 20.06
+    const char* val=arg->getAttribute("arrowSizeCoef",nullptr) ;
+    if(val)
+    {
+        msg_error() << "The attribute 'arrowSizeCoef' is no longer valid."
+                    << "It has been converted into 'showArrowSize' since Sofa 19.12 '" ;
 
     }
     Inherit::parse(arg) ;

--- a/modules/SofaBoundaryCondition/ConstantForceField.inl
+++ b/modules/SofaBoundaryCondition/ConstantForceField.inl
@@ -120,7 +120,7 @@ void ConstantForceField<DataTypes>::init()
         const VecDeriv &forces = d_forces.getValue();
         if( checkForces(forces) )
         {
-            computeForceFromForceVector(forces);
+            computeForceFromForceVector();
         }
         else
         {
@@ -134,7 +134,7 @@ void ConstantForceField<DataTypes>::init()
         const Deriv &force = d_force.getValue();
         if( checkForce(force) )
         {
-            computeForceFromSingleForce(force);
+            computeForceFromSingleForce();
         }
         else
         {
@@ -148,7 +148,7 @@ void ConstantForceField<DataTypes>::init()
         const Deriv &totalForce = d_totalForce.getValue();
         if( checkForce(totalForce) )
         {
-            computeForceFromTotalForce(totalForce);
+            computeForceFromTotalForce();
         }
         else
         {
@@ -221,7 +221,7 @@ void ConstantForceField<DataTypes>::doUpdateInternal()
         const VecDeriv &forces = d_forces.getValue();
         if( checkForces(forces) )
         {
-            computeForceFromForceVector(forces);
+            computeForceFromForceVector();
             this->m_componentstate = core::objectmodel::ComponentState::Valid;
         }
         else
@@ -238,7 +238,7 @@ void ConstantForceField<DataTypes>::doUpdateInternal()
         const Deriv &force = d_force.getValue();
         if( checkForce(force) )
         {
-            computeForceFromSingleForce(force);
+            computeForceFromSingleForce();
             this->m_componentstate = core::objectmodel::ComponentState::Valid;
         }
         else
@@ -255,7 +255,7 @@ void ConstantForceField<DataTypes>::doUpdateInternal()
         const Deriv &totalForce = d_totalForce.getValue();
         if( checkForce(totalForce) )
         {
-            computeForceFromTotalForce(totalForce);
+            computeForceFromTotalForce();
             this->m_componentstate = core::objectmodel::ComponentState::Valid;
         }
         else
@@ -296,10 +296,11 @@ bool ConstantForceField<DataTypes>::checkForces(const VecDeriv& forces)
 }
 
 template<class DataTypes>
-void ConstantForceField<DataTypes>::computeForceFromForceVector(const VecDeriv& forces)
+void ConstantForceField<DataTypes>::computeForceFromForceVector()
 {
-    Deriv& totalForce = *d_totalForce.beginEdit();
+    const VecDeriv& forces = d_forces.getValue();
     const size_t indicesSize = d_indices.getValue().size();
+    Deriv& totalForce = *d_totalForce.beginEdit();
     totalForce.clear();
     if( indicesSize!=forces.size() )
     {
@@ -318,10 +319,11 @@ void ConstantForceField<DataTypes>::computeForceFromForceVector(const VecDeriv& 
 }
 
 template<class DataTypes>
-void ConstantForceField<DataTypes>::computeForceFromSingleForce(const Deriv& singleForce)
+void ConstantForceField<DataTypes>::computeForceFromSingleForce()
 {
-    VecDeriv& forces = *d_forces.beginEdit();
+    const Deriv& singleForce = d_force.getValue();
     const VecIndex & indices = d_indices.getValue();
+    VecDeriv& forces = *d_forces.beginEdit();
     size_t indicesSize = indices.size();
     forces.clear();
     forces.resize(indicesSize);
@@ -336,15 +338,16 @@ void ConstantForceField<DataTypes>::computeForceFromSingleForce(const Deriv& sin
 }
 
 template<class DataTypes>
-void ConstantForceField<DataTypes>::computeForceFromTotalForce(const Deriv& totalForce)
+void ConstantForceField<DataTypes>::computeForceFromTotalForce()
 {
+    const Deriv& totalForce = d_totalForce.getValue();
     const size_t indicesSize = d_indices.getValue().size();
     Deriv singleForce;
     if( indicesSize!=0 )
     {
         singleForce = totalForce / (static_cast<Real>(indicesSize));
         d_force.setValue(singleForce);
-        computeForceFromSingleForce(singleForce);
+        computeForceFromSingleForce();
     }
     else
     {

--- a/modules/SofaBoundaryCondition/ConstantForceField.inl
+++ b/modules/SofaBoundaryCondition/ConstantForceField.inl
@@ -270,7 +270,7 @@ bool ConstantForceField<DataTypes>::checkForce(Deriv force)
 
     for (size_t i=0; i<size; i++)
     {
-        if( isnan(force[i]) )
+        if( std::isnan(force[i]) )
             return false;
     }
     return true;

--- a/modules/SofaBoundaryCondition/ConstantForceField.inl
+++ b/modules/SofaBoundaryCondition/ConstantForceField.inl
@@ -62,6 +62,22 @@ ConstantForceField<DataTypes>::ConstantForceField()
 
 
 template<class DataTypes>
+void ConstantForceField<DataTypes>::parse(BaseObjectDescription* arg)
+{
+    /// Now warning the user when using old API
+    /// point is deprecated since '17.06'
+    const char* val=arg->getAttribute("points",nullptr) ;
+    if(val)
+    {
+        msg_error() << "The attribute 'points' is no longer valid."
+                    << "It has been converted into 'indices since Sofa 17.06 '" ;
+
+    }
+    Inherit::parse(arg) ;
+}
+
+
+template<class DataTypes>
 void ConstantForceField<DataTypes>::init()
 {
     this->m_componentstate = core::objectmodel::ComponentState::Invalid;

--- a/modules/SofaBoundaryCondition/ConstantForceField.inl
+++ b/modules/SofaBoundaryCondition/ConstantForceField.inl
@@ -268,7 +268,7 @@ void ConstantForceField<DataTypes>::doUpdateInternal()
 
 
 template<class DataTypes>
-bool ConstantForceField<DataTypes>::checkForce(Deriv force)
+bool ConstantForceField<DataTypes>::checkForce(const Deriv& force)
 {
     size_t size = Deriv::spatial_dimensions;
 
@@ -283,7 +283,7 @@ bool ConstantForceField<DataTypes>::checkForce(Deriv force)
 }
 
 template<class DataTypes>
-bool ConstantForceField<DataTypes>::checkForces(VecDeriv forces)
+bool ConstantForceField<DataTypes>::checkForces(const VecDeriv& forces)
 {
     for (auto&& i : forces)
     {
@@ -296,7 +296,7 @@ bool ConstantForceField<DataTypes>::checkForces(VecDeriv forces)
 }
 
 template<class DataTypes>
-void ConstantForceField<DataTypes>::computeForceFromForceVector(VecDeriv forces)
+void ConstantForceField<DataTypes>::computeForceFromForceVector(const VecDeriv& forces)
 {
     Deriv& totalForce = *d_totalForce.beginEdit();
     const size_t indicesSize = d_indices.getValue().size();
@@ -318,7 +318,7 @@ void ConstantForceField<DataTypes>::computeForceFromForceVector(VecDeriv forces)
 }
 
 template<class DataTypes>
-void ConstantForceField<DataTypes>::computeForceFromSingleForce(Deriv singleForce)
+void ConstantForceField<DataTypes>::computeForceFromSingleForce(const Deriv& singleForce)
 {
     VecDeriv& forces = *d_forces.beginEdit();
     const VecIndex & indices = d_indices.getValue();
@@ -336,7 +336,7 @@ void ConstantForceField<DataTypes>::computeForceFromSingleForce(Deriv singleForc
 }
 
 template<class DataTypes>
-void ConstantForceField<DataTypes>::computeForceFromTotalForce(Deriv totalForce)
+void ConstantForceField<DataTypes>::computeForceFromTotalForce(const Deriv& totalForce)
 {
     const size_t indicesSize = d_indices.getValue().size();
     Deriv singleForce;
@@ -462,7 +462,7 @@ void ConstantForceField<DataTypes>::addKToMatrix(const sofa::core::behavior::Mul
 template<class DataTypes>
 void ConstantForceField<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
-    SReal aSC = d_arrowSizeCoef.getValue();
+    const SReal aSC = d_arrowSizeCoef.getValue();
 
     if ((!vparams->displayFlags().getShowForceFields() && (aSC==0.0)) || (aSC < 0.0)) return;
 

--- a/modules/SofaBoundaryCondition/SofaBoundaryCondition_test/ConstantForceField_test.cpp
+++ b/modules/SofaBoundaryCondition/SofaBoundaryCondition_test/ConstantForceField_test.cpp
@@ -186,7 +186,7 @@ struct ConstantForceField_test : public Sofa_test<>
         /// List of the supported attributes the user expect to find
         /// This list needs to be updated if you add an attribute.
         vector<string> attrnames = {
-            "indices","forces","force","totalForce","arrowSizeCoef","showColor","indexFromEnd"
+            "indices","forces","force","totalForce","showArrowSize","showColor","indexFromEnd"
         };
 
         for(auto& attrname : attrnames)

--- a/modules/SofaBoundaryCondition/SofaBoundaryCondition_test/ConstantForceField_test.cpp
+++ b/modules/SofaBoundaryCondition/SofaBoundaryCondition_test/ConstantForceField_test.cpp
@@ -141,6 +141,7 @@ struct ConstantForceField_test : public Sofa_test<>
                                                                   scene.str().c_str(),
                                                                   scene.str().size()) ;
                 ASSERT_NE(root.get(), nullptr) << "Problem to load scene: " << scene.str() ;
+                EXPECT_MSG_EMIT(Error) ;
                 root->init(ExecParams::defaultInstance());
 
                 sofa::core::objectmodel::BaseObject* constantff = root->getObject("myForceField") ;

--- a/modules/SofaBoundaryCondition/SofaBoundaryCondition_test/ConstantForceField_test.cpp
+++ b/modules/SofaBoundaryCondition/SofaBoundaryCondition_test/ConstantForceField_test.cpp
@@ -141,7 +141,7 @@ struct ConstantForceField_test : public Sofa_test<>
                                                                   scene.str().c_str(),
                                                                   scene.str().size()) ;
                 ASSERT_NE(root.get(), nullptr) << "Problem to load scene: " << scene.str() ;
-                root->init(ExecParams::defaultInstance()) ;
+                root->init(ExecParams::defaultInstance());
 
                 sofa::core::objectmodel::BaseObject* constantff = root->getObject("myForceField") ;
                 ASSERT_NE( constantff, nullptr) ;
@@ -185,7 +185,7 @@ struct ConstantForceField_test : public Sofa_test<>
         /// List of the supported attributes the user expect to find
         /// This list needs to be updated if you add an attribute.
         vector<string> attrnames = {
-            "points","forces","force","totalForce","arrowSizeCoef","showColor","indexFromEnd"
+            "indices","forces","force","totalForce","arrowSizeCoef","showColor","indexFromEnd"
         };
 
         for(auto& attrname : attrnames)


### PR DESCRIPTION
Apply doUpdateInternal API to ConstantForceField
and also change the behavior: do not extrapolate any info when an mismatch of size is detected.

- Finally, let's not wait the Data update discussion to integrate such an amazing change 
- And .. we could also think about renaming this class as UniformForceField to be consistent with Masses!

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
