### PR TITLE
[SofaKernel] fix root's getPathName

### DIFF
--- a/SofaKernel/framework/sofa/core/objectmodel/BaseNode.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseNode.cpp
@@ -81,19 +81,26 @@ void BaseNode::clearObjectContext(BaseObject::SPtr obj)
         obj->l_context.reset();
 }
 
-std::string BaseNode::getPathName() const {
+std::string BaseNode::_getPathName() const {
     std::string str;
     Parents parents = getParents();
     if (!parents.empty())
     {
         // for the full path name, we arbitrarily take the first parent of the list...
         // no smarter choice without breaking the "Node" heritage
-        str = parents[0]->getPathName();
+        str = parents[0]->_getPathName();
         str += '/';
         str += getName();
     }
-
     return str;
+}
+
+// path name representation of root as "/", as it is done for filesystems
+std::string BaseNode::getPathName() const {
+    Parents parents = getParents();
+    if (parents.empty())
+        return "/";
+    return _getPathName();
 }
 
 std::string BaseNode::getRootPath() const {

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseNode.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseNode.cpp
@@ -81,14 +81,14 @@ void BaseNode::clearObjectContext(BaseObject::SPtr obj)
         obj->l_context.reset();
 }
 
-std::string BaseNode::_getPathName() const {
+std::string BaseNode::internalGetPathName() const {
     std::string str;
     Parents parents = getParents();
     if (!parents.empty())
     {
         // for the full path name, we arbitrarily take the first parent of the list...
         // no smarter choice without breaking the "Node" heritage
-        str = parents[0]->_getPathName();
+        str = parents[0]->internalGetPathName();
         str += '/';
         str += getName();
     }
@@ -100,7 +100,7 @@ std::string BaseNode::getPathName() const {
     Parents parents = getParents();
     if (parents.empty())
         return "/";
-    return _getPathName();
+    return internalGetPathName();
 }
 
 std::string BaseNode::getRootPath() const {

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseNode.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseNode.h
@@ -149,7 +149,7 @@ public:
     virtual core::visual::VisualLoop* getVisualLoop() const;
 
 private:
-    virtual std::string _getPathName() const;
+    virtual std::string internalGetPathName() const;
 
     /// @}
 protected:

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseNode.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseNode.h
@@ -148,6 +148,9 @@ public:
     virtual core::collision::Pipeline* getCollisionPipeline() const;
     virtual core::visual::VisualLoop* getVisualLoop() const;
 
+private:
+    virtual std::string _getPathName() const;
+
     /// @}
 protected:
     /// Set the context of an object to this

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseObject.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseObject.cpp
@@ -352,8 +352,11 @@ std::string BaseObject::getPathName() const {
     if( context )
     {
         const BaseNode* node = context->toBaseNode();
-        if( node )
-            result += node->getPathName() + "/";
+        if( node ) {
+            result += node->getPathName();;
+            if (node->getPathName() != "/")
+                result += "/";
+        }
 
     }
     result += getName();

--- a/SofaKernel/modules/sofa/simulation/simulation_test/graph/Node_test.cpp
+++ b/SofaKernel/modules/sofa/simulation/simulation_test/graph/Node_test.cpp
@@ -35,28 +35,25 @@ struct Node_test : public BaseSimulationTest
     {
         /* create trivial DAG :
          *
-         * R
-         * |
          * A
+         * |\
+         * B C
          * |
-         * B
+         * D
          *
          */
         EXPECT_MSG_NOEMIT(Error, Warning);
 
-        SceneInstance si("R") ;
-        Node::SPtr A = createChild(si.root, "A");
-        Node::SPtr B = createChild(A, "B");
+        SceneInstance si("A") ;
+        Node::SPtr B = createChild(si.root, "B");
+        Node::SPtr D = createChild(B, "D");
         BaseObject::SPtr C = core::objectmodel::New<Dummy>("C");
-        A->addObject(C);
+        si.root->addObject(C);
 
-
-        EXPECT_STREQ(A->getPathName().c_str(), "@/");
-        EXPECT_STREQ(A->findData("name")->getLinkPath().c_str(), "@/.name");
+        EXPECT_STREQ(si.root->getPathName().c_str(), "/");
         EXPECT_STREQ(B->getPathName().c_str(), "/B");
-        EXPECT_STREQ(B->findData("name")->getLinkPath().c_str(), "@/B.name");
         EXPECT_STREQ(C->getPathName().c_str(), "/C");
-        EXPECT_STREQ(C->findData("name")->getLinkPath().c_str(), "@/C.name");
+        EXPECT_STREQ(D->getPathName().c_str(), "/B/D");
     }
 };
 

--- a/SofaKernel/modules/sofa/simulation/simulation_test/graph/Node_test.cpp
+++ b/SofaKernel/modules/sofa/simulation/simulation_test/graph/Node_test.cpp
@@ -25,6 +25,8 @@ using sofa::helper::testing::BaseSimulationTest ;
 #include <SofaSimulationGraph/SimpleApi.h>
 using namespace sofa::simpleapi ;
 
+#include "../Node_test.h"
+
 namespace sofa {
 
 struct Node_test : public BaseSimulationTest
@@ -45,9 +47,16 @@ struct Node_test : public BaseSimulationTest
         SceneInstance si("R") ;
         Node::SPtr A = createChild(si.root, "A");
         Node::SPtr B = createChild(A, "B");
+        BaseObject::SPtr C = core::objectmodel::New<Dummy>("C");
+        A->addObject(C);
 
-        EXPECT_EQ("", si.root->getPathName());
-        EXPECT_EQ("/A/B", B->getPathName());
+
+        EXPECT_STREQ(A->getPathName().c_str(), "@/");
+        EXPECT_STREQ(A->findData("name")->getLinkPath().c_str(), "@/.name");
+        EXPECT_STREQ(B->getPathName().c_str(), "/B");
+        EXPECT_STREQ(B->findData("name")->getLinkPath().c_str(), "@/B.name");
+        EXPECT_STREQ(C->getPathName().c_str(), "/C");
+        EXPECT_STREQ(C->findData("name")->getLinkPath().c_str(), "@/C.name");
     }
 };
 

--- a/applications/plugins/SofaPython/SofaPython_test/PythonFactory_test.cpp
+++ b/applications/plugins/SofaPython/SofaPython_test/PythonFactory_test.cpp
@@ -173,7 +173,7 @@ std::vector<std::vector<std::string>> dataconversionvalues =
      {"'XX_'+first.findData('name').getLinkPath()", "XX_@/theFirst.name"},
      {"first.findData('name').getLinkPath()", "theFirst"},
      {"first.findData('name')", "theFirst"},
-     {"'XX_'+rootNode.getAsACreateObjectParameter()", "XX_@"},
+     {"'XX_'+rootNode.getAsACreateObjectParameter()", "XX_@/"},
      {"CustomObject()", "custom value"}
     } ;
 


### PR DESCRIPTION
This PR proposes an alternative representation of the root path's name.

If we consider a node named "root", with a child node named "child", a component named "object" and a data field named "data", here were the previous values returned by their `getPathName` method:

```
root.getPathName(): ""
root.child.getPathName(): "/child"
root.object.getPathName(): "/object"
root.data.getLinkPath(): ".data"
```

I find this naming convention misleading, as an empty string for the root path does not seem right to me, and ".data" for the path of root.data also look wierd:

- When working with link paths, like we do all the time in Sofa, making a link between a component's data and root.value would look like this:
```
root.createObject('MyComponent', value="@.value")
```

- The same way, if a component for some reason would need a take a node as an input field, passing root would look like:

```
node.createObject("MyComponent", nodePath="@") # passing root to nodePath would lead to syntax errors during parsing.
```

Thus I suggest that, as it is done in FTP clients for instance, or filesystem browsers in general, the root node, regardless of its name be represented as a forward slash `/`:

```
root.getPathName(): "/"
root.child.getPathName(): "/child"
root.object.getPathName(): "/object"
root.data.getLinkPath(): "@/.data" # this cas still looks a bit funny, but makes more sense IMHO

root.createObject('MyComponent', value="@/.value")
root.createObject('MyComponent', nodePath="@/")
```

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
