### PR TITLE
[SofaHaptics] Add mutex and option to lock the ForceFeedback computation

### DIFF
--- a/modules/SofaHaptics/src/SofaHaptics/ForceFeedback.h
+++ b/modules/SofaHaptics/src/SofaHaptics/ForceFeedback.h
@@ -61,6 +61,8 @@ public:
     virtual void setReferencePosition(sofa::defaulttype::SolidTypes<SReal>::Transform& referencePosition);
     virtual bool isEnabled();
 
+    virtual void setLock(bool value) {}
+
 protected:
     ForceFeedback();
 };

--- a/modules/SofaHaptics/src/SofaHaptics/ForceFeedback.h
+++ b/modules/SofaHaptics/src/SofaHaptics/ForceFeedback.h
@@ -61,6 +61,7 @@ public:
     virtual void setReferencePosition(sofa::defaulttype::SolidTypes<SReal>::Transform& referencePosition);
     virtual bool isEnabled();
 
+    /// Abstract method to lock or unlock the force feedback computation. To be implemented by child class if needed
     virtual void setLock(bool value) {}
 
 protected:

--- a/modules/SofaHaptics/src/SofaHaptics/LCPForceFeedback.h
+++ b/modules/SofaHaptics/src/SofaHaptics/LCPForceFeedback.h
@@ -122,6 +122,7 @@ public:
         return DataTypes::Name();
     }
 
+    /// Overide method to lock or unlock the force feedback computation. According to parameter, value == true (resp. false) will lock (resp. unlock) mutex @sa lockForce
     void setLock(bool value) override;
 
 protected:
@@ -143,6 +144,8 @@ protected:
     int timer_iterations;
     double haptic_freq;
     unsigned int num_constraints;
+
+    /// mutex used in method @doComputeForce which can be touched from outside using method @sa setLock if components are modified in another thread.
     std::mutex lockForce;
 };
 

--- a/modules/SofaHaptics/src/SofaHaptics/LCPForceFeedback.h
+++ b/modules/SofaHaptics/src/SofaHaptics/LCPForceFeedback.h
@@ -26,6 +26,7 @@
 #include <SofaHaptics/MechanicalStateForceFeedback.h>
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/helper/system/thread/CTime.h>
+#include <mutex>
 
 namespace sofa
 {
@@ -121,6 +122,8 @@ public:
         return DataTypes::Name();
     }
 
+    void setLock(bool value) override;
+
 protected:
     core::behavior::MechanicalState<DataTypes> *mState; ///< The device try to follow this mechanical state.
     VecCoord mVal[3];
@@ -140,6 +143,7 @@ protected:
     int timer_iterations;
     double haptic_freq;
     unsigned int num_constraints;
+    std::mutex lockForce;
 };
 
 #if  !defined(SOFA_COMPONENT_CONTROLLER_LCPFORCEFEEDBACK_CPP)

--- a/modules/SofaHaptics/src/SofaHaptics/LCPForceFeedback.inl
+++ b/modules/SofaHaptics/src/SofaHaptics/LCPForceFeedback.inl
@@ -181,6 +181,12 @@ void LCPForceFeedback<DataTypes>::init()
     }
 }
 
+template <class DataTypes>
+void LCPForceFeedback<DataTypes>::setLock(bool value)
+{
+    value == true ? lockForce.lock() : lockForce.unlock();
+}
+
 static std::mutex s_mtx;
 
 template <class DataTypes>
@@ -191,8 +197,11 @@ void LCPForceFeedback<DataTypes>::computeForce(const VecCoord& state,  VecDeriv&
         return;
     }
     updateStats();
+    
+    lockForce.lock();    
     updateConstraintProblem();
-    doComputeForce(state, forces);
+    doComputeForce(state, forces);    
+    lockForce.unlock();
 }
 template <class DataTypes>
 void LCPForceFeedback<DataTypes>::updateStats()

--- a/modules/SofaHaptics/src/SofaHaptics/LCPForceFeedback.inl
+++ b/modules/SofaHaptics/src/SofaHaptics/LCPForceFeedback.inl
@@ -187,6 +187,7 @@ void LCPForceFeedback<DataTypes>::setLock(bool value)
     value == true ? lockForce.lock() : lockForce.unlock();
 }
 
+
 static std::mutex s_mtx;
 
 template <class DataTypes>
@@ -198,7 +199,7 @@ void LCPForceFeedback<DataTypes>::computeForce(const VecCoord& state,  VecDeriv&
     }
     updateStats();
     
-    lockForce.lock();    
+    lockForce.lock(); // check if computation has not been locked using setLock method.
     updateConstraintProblem();
     doComputeForce(state, forces);    
     lockForce.unlock();


### PR DESCRIPTION
Add abstract method in ForceFeedBack and override in LCPForceFeedback which will lock/unlock a mutex used in doComputeForce.

This allow to lock the ForceFeedback computation, done in a dedicated working thread, from another component which is changing the mechanical system in the main thread of SOFA.


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
