### PR TITLE
[SofaKernel] FIX regex in SofaMacros.cmake

### DIFF
--- a/SofaKernel/SofaFramework/SofaMacros.cmake
+++ b/SofaKernel/SofaFramework/SofaMacros.cmake
@@ -567,7 +567,7 @@ macro(sofa_install_targets package_name the_targets include_install_dir)
         get_target_property(target_sources ${target} SOURCES)
         #list(FILTER ${target_sources} INCLUDE REGEX ".*\.h\.in$") # CMake >= 3.6
         foreach(filepath ${target_sources})
-            if(${filepath} MATCHES ".*\.h\.in$")
+            if("${filepath}" MATCHES "\\.*\\.h\\.in$")
                 get_filename_component(filename ${filepath} NAME_WE)
 
                 set(configure_dir "${CMAKE_BINARY_DIR}/include/${include_install_dir}")


### PR DESCRIPTION
I don't know how it was working before but we need double antislash in
regex-string. 






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
