### PR TITLE
[CMake] Use cmake_dependent_option for plugin tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release")
 endif()
 
+include(CMakeDependentOption)
 
 # Enable the organisation in folders for generators that support
 # it. (E.g. some versions of Visual Studio have 'solution folders')

--- a/applications/sofa/gui/headlessRecorder/CMakeLists.txt
+++ b/applications/sofa/gui/headlessRecorder/CMakeLists.txt
@@ -36,7 +36,7 @@ set(SOURCE_FILES
     HeadlessRecorder.cpp
     VideoRecorderFFMpeg.cpp)
 
-if(SOFAGUI_BUILD_TESTS)
+if(SOFA_BUILD_TESTS)
     configure_file(headlessRecorder_test ${CMAKE_BINARY_DIR}/bin/headlessRecorder_test COPYONLY)
 endif()
 

--- a/modules/SofaExporter/CMakeLists.txt
+++ b/modules/SofaExporter/CMakeLists.txt
@@ -81,13 +81,8 @@ sofa_generate_package(
     )
 
 # Tests
-find_package(SofaTest QUIET)
-if (NOT SofaTest_FOUND)
-    message(STATUS "- SofaTest not found. SofaExporter_test will not be built." )
-    return()
-endif()
-
-option(SOFAEXPORTER_BUILD_TESTS "Compile the automatic tests" ON)
+# If SOFA_BUILD_TESTS exists and is OFF, then these tests will be auto-disabled
+cmake_dependent_option(SOFAEXPORTER_BUILD_TESTS "Compile the automatic tests" ON "SOFA_BUILD_TESTS OR NOT DEFINED SOFA_BUILD_TESTS" OFF)
 if(SOFAEXPORTER_BUILD_TESTS)
     enable_testing()
     add_subdirectory(SofaExporter_test)

--- a/modules/SofaOpenglVisual/CMakeLists.txt
+++ b/modules/SofaOpenglVisual/CMakeLists.txt
@@ -94,12 +94,8 @@ sofa_generate_package(
     )
 
 # Tests
-find_package(SofaTest QUIET)
-if (NOT SofaTest_FOUND)
-    message(STATUS "- SofaTest not found. SofaOpenglVisual_test will not be built." )
-    return()
-endif()
-
+# If SOFA_BUILD_TESTS exists and is OFF, then these tests will be auto-disabled
+cmake_dependent_option(SOFAOPENGLVISUAL_BUILD_TESTS "Compile the automatic tests" ON "SOFA_BUILD_TESTS OR NOT DEFINED SOFA_BUILD_TESTS" OFF)
 if(SOFAOPENGLVISUAL_BUILD_TESTS)
     enable_testing()
     add_subdirectory(SofaOpenglVisual_test)


### PR DESCRIPTION
This CMake macro permits to create dependent options for tests that will automatically be hidden and set to OFF if SOFA_BUILD_TESTS is defined and FALSE.
If SOFA_BUILD_TESTS goes back to TRUE, the option is shown again with its old value.

This way of adding a tests subdirectory should be propagated to all plugins.

See [CMake documentation](https://cmake.org/cmake/help/v3.10/module/CMakeDependentOption.html) for more details.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
