### PR TITLE
[SofaKernel] Make componentState a real data field

### DIFF
--- a/SofaKernel/SofaFramework/SofaMacros.cmake
+++ b/SofaKernel/SofaFramework/SofaMacros.cmake
@@ -663,31 +663,35 @@ function(sofa_set_install_relocatable target install_dir)
     # Hack to make installed plugin independant and keep the add_subdirectory mechanism
     # Does not fail if cmakepatch file already exists thanks to "|| true"
     if(WIN32)
+        set(escaped_dollar "\$")
+        if(CMAKE_SYSTEM_VERSION VERSION_LESS 10 ) # before Windows 10
+            set(escaped_dollar "\$\$")
+        endif()
         string(REGEX REPLACE "/" "\\\\" target_binary_dir_windows "${target_binary_dir}")
         add_custom_target(${target}_relocatable_install ALL
             COMMENT "${target}: Patching cmake_install.cmake"
             COMMAND
                 if not exist \"${target_binary_dir}/cmake_install.cmakepatch\"
-                echo set ( CMAKE_INSTALL_PREFIX_BACK \"\$$\{CMAKE_INSTALL_PREFIX\}\" )
-                    > "${target_binary_dir}/cmake_install.cmakepatch"
-                && echo set ( CMAKE_INSTALL_PREFIX \"\$$\{CMAKE_INSTALL_PREFIX\}/${install_dir}/${target}\" )
-                    >> "${target_binary_dir}/cmake_install.cmakepatch"
-                && type \"${target_binary_dir_windows}\\\\cmake_install.cmake\" >> \"${target_binary_dir_windows}\\\\cmake_install.cmakepatch\"
-                && echo set ( CMAKE_INSTALL_PREFIX \"\$$\{CMAKE_INSTALL_PREFIX_BACK\}\" )
-                    >> "${target_binary_dir}/cmake_install.cmakepatch"
-                && ${CMAKE_COMMAND} -E copy ${target_binary_dir}/cmake_install.cmakepatch ${target_binary_dir}/cmake_install.cmake
+                echo set ( CMAKE_INSTALL_PREFIX_BACK \"${escaped_dollar}\{CMAKE_INSTALL_PREFIX\}\" )
+                    > \"${target_binary_dir}/cmake_install.cmakepatch\"
+                && echo set ( CMAKE_INSTALL_PREFIX \"${escaped_dollar}\{CMAKE_INSTALL_PREFIX\}/${install_dir}/${target}\" )
+                    >> \"${target_binary_dir}/cmake_install.cmakepatch\"
+                && type \"${target_binary_dir_windows}\\cmake_install.cmake\" >> \"${target_binary_dir_windows}\\cmake_install.cmakepatch\"
+                && echo set ( CMAKE_INSTALL_PREFIX \"${escaped_dollar}\{CMAKE_INSTALL_PREFIX_BACK\}\" )
+                    >> \"${target_binary_dir}/cmake_install.cmakepatch\"
+                && ${CMAKE_COMMAND} -E copy \"${target_binary_dir}/cmake_install.cmakepatch\" \"${target_binary_dir}/cmake_install.cmake\"
             )
     else()
         add_custom_target(${target}_relocatable_install ALL
             COMMENT "${target}: Patching cmake_install.cmake"
             COMMAND
                 test ! -e ${target_binary_dir}/cmake_install.cmakepatch
-                && echo \" set ( CMAKE_INSTALL_PREFIX_BACK \\\"\\\$$\{CMAKE_INSTALL_PREFIX\}\\\" ) \"
+                && echo \" set ( CMAKE_INSTALL_PREFIX_BACK \\"\\$$\{CMAKE_INSTALL_PREFIX\}\\" ) \"
                     > "${target_binary_dir}/cmake_install.cmakepatch"
-                && echo \" set ( CMAKE_INSTALL_PREFIX \\\"\\\$$\{CMAKE_INSTALL_PREFIX\}/${install_dir}/${target}\\\" ) \"
+                && echo \" set ( CMAKE_INSTALL_PREFIX \\"\\$$\{CMAKE_INSTALL_PREFIX\}/${install_dir}/${target}\\" ) \"
                     >> "${target_binary_dir}/cmake_install.cmakepatch"
                 && cat ${target_binary_dir}/cmake_install.cmake >> ${target_binary_dir}/cmake_install.cmakepatch
-                && echo \" set ( CMAKE_INSTALL_PREFIX \\\"\\\$$\{CMAKE_INSTALL_PREFIX_BACK\}\\\" ) \"
+                && echo \" set ( CMAKE_INSTALL_PREFIX \\"\\$$\{CMAKE_INSTALL_PREFIX_BACK\}\\" ) \"
                     >> "${target_binary_dir}/cmake_install.cmakepatch"
                 && ${CMAKE_COMMAND} -E copy ${target_binary_dir}/cmake_install.cmakepatch ${target_binary_dir}/cmake_install.cmake
                 || true

--- a/SofaKernel/framework/sofa/core/CMakeLists.txt
+++ b/SofaKernel/framework/sofa/core/CMakeLists.txt
@@ -102,6 +102,7 @@ set(HEADER_FILES
     objectmodel/BaseObject.h
     objectmodel/BaseObjectDescription.h
     objectmodel/ClassInfo.h
+    objectmodel/ComponentState.h
     objectmodel/ConfigurationSetting.h
     objectmodel/Context.h
     objectmodel/ContextObject.h
@@ -208,6 +209,7 @@ set(SOURCE_FILES
     objectmodel/BaseObject.cpp
     objectmodel/BaseObjectDescription.cpp
     objectmodel/ClassInfo.cpp
+    objectmodel/ComponentState.cpp
     objectmodel/ConfigurationSetting.cpp
     objectmodel/ContextObject.cpp
     objectmodel/Context.cpp

--- a/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
@@ -56,13 +56,13 @@ Base::Base()
     , f_printLog(initData(&f_printLog, false, "printLog", "if true, emits extra messages at runtime."))
     , f_tags(initData( &f_tags, "tags", "list of the subsets the objet belongs to"))
     , f_bbox(initData( &f_bbox, "bbox", "this object bounding box"))
-    , m_componentstate(initData(&m_componentstate, ComponentState::Undefined, "componentState", "The state of the component among (Dirty, Valid, Undefined, Loading, Invalid)."))
+    , d_componentstate(initData(&d_componentstate, ComponentState::Undefined, "componentState", "The state of the component among (Dirty, Valid, Undefined, Loading, Invalid)."))
 {
     name.setOwnerClass("Base");
     name.setAutoLink(false);
     name.setReadOnly(true);
-    m_componentstate.setAutoLink(false);
-    m_componentstate.setReadOnly(true);
+    d_componentstate.setAutoLink(false);
+    d_componentstate.setReadOnly(true);
     f_printLog.setOwnerClass("Base");
     f_printLog.setAutoLink(false);
     f_tags.setOwnerClass("Base");

--- a/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
@@ -56,10 +56,13 @@ Base::Base()
     , f_printLog(initData(&f_printLog, false, "printLog", "if true, emits extra messages at runtime."))
     , f_tags(initData( &f_tags, "tags", "list of the subsets the objet belongs to"))
     , f_bbox(initData( &f_bbox, "bbox", "this object bounding box"))
+    , m_componentstate(initData(&m_componentstate, ComponentState::Undefined, "componentState", "The state of the component among (Dirty, Valid, Undefined, Loading, Invalid)."))
 {
     name.setOwnerClass("Base");
     name.setAutoLink(false);
     name.setReadOnly(true);
+    m_componentstate.setAutoLink(false);
+    m_componentstate.setReadOnly(true);
     f_printLog.setOwnerClass("Base");
     f_printLog.setAutoLink(false);
     f_tags.setOwnerClass("Base");
@@ -154,8 +157,8 @@ void Base::addLink(BaseLink* l)
     const std::string& name = l->getName();
     if (name.size() > 0 && (findData(name) || findLink(name)))
     {
-        msg_warning() << "Link name " << name
-                << " already used in this class or in a parent class !";
+        msg_warning() << "Link name '" << name
+                << "' already used in this class or in a parent class !";
     }
     m_vecLink.push_back(l);
     m_aliasLink.insert(std::make_pair(name, l));

--- a/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/Base.cpp
@@ -63,6 +63,7 @@ Base::Base()
     name.setReadOnly(true);
     d_componentstate.setAutoLink(false);
     d_componentstate.setReadOnly(true);
+    d_componentstate.setOwnerClass("Base");
     f_printLog.setOwnerClass("Base");
     f_printLog.setAutoLink(false);
     f_tags.setOwnerClass("Base");

--- a/SofaKernel/framework/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/Base.h
@@ -488,7 +488,11 @@ public:
 
     Data< sofa::defaulttype::BoundingBox > f_bbox; ///< this object bounding box
 
-    Data< ComponentState > m_componentstate; ///< the object state
+    Data< ComponentState >  d_componentstate; ///< the object state
+
+    [[deprecated("m_componentstate was renamed to d_componentstate. Please upgrade your code")]]
+    Data< ComponentState >& m_componentstate{d_componentstate}; ///< the object state
+
 
     std::string m_definitionSourceFileName        {""};
     int         m_definitionSourceFilePos         {-1};

--- a/SofaKernel/framework/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/Base.h
@@ -466,6 +466,16 @@ public:
         return shortname;
     }
 
+    /// @name componentstate
+    ///   Methods related to component state
+    /// @{
+
+    ComponentState getComponentState() const { return d_componentstate.getValue() ; }
+    bool isComponentStateValid() const { return d_componentstate == ComponentState::Valid; }
+
+    ///@}
+
+
 protected:
     /// List of fields (Data instances)
     VecData m_vecData;

--- a/SofaKernel/framework/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/Base.h
@@ -500,7 +500,8 @@ public:
 
     Data< ComponentState >  d_componentstate; ///< the object state
 
-    [[deprecated("m_componentstate was renamed to d_componentstate. Please upgrade your code")]]
+    /// TODO @marques bruno: uncomment once c++17 is enabled in SOFA 
+    // [[deprecated("m_componentstate was renamed to d_componentstate. Please upgrade your code")]]
     Data< ComponentState >& m_componentstate{d_componentstate}; ///< the object state
 
 

--- a/SofaKernel/framework/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/Base.h
@@ -32,6 +32,7 @@
 
 #include <deque>
 
+#include <sofa/core/objectmodel/ComponentState.h>
 
 // forward declaration of castable classes
 // @author Matthieu Nesme, 2015
@@ -486,6 +487,8 @@ public:
     Data< sofa::core::objectmodel::TagSet > f_tags; ///< list of the subsets the objet belongs to
 
     Data< sofa::defaulttype::BoundingBox > f_bbox; ///< this object bounding box
+
+    Data< ComponentState > m_componentstate; ///< the object state
 
     std::string m_definitionSourceFileName        {""};
     int         m_definitionSourceFilePos         {-1};

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseObject.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseObject.h
@@ -50,14 +50,6 @@ namespace objectmodel
 class Event;
 class BaseNode;
 
-/// enum class is a C++ x11 feature (http://en.cppreference.com/w/cpp/language/enum),
-/// Indicate the state of an object.
-enum class ComponentState {
-    Undefined,
-    Valid,
-    Invalid
-};
-
 /**
  *  \brief Base class for simulation components.
  *
@@ -458,7 +450,7 @@ public:
     ///   Methods related to component state
     /// @{
 
-    ComponentState getComponentState() const { return m_componentstate ; }
+    ComponentState getComponentState() const { return m_componentstate.getValue() ; }
     bool isComponentStateValid() const { return m_componentstate != ComponentState::Invalid; }
 
     ///@}
@@ -479,9 +471,6 @@ protected:
     bool hasDataChanged(const BaseData &data);
     ///@}
     ///
-
-    /// Enum defining the state of the component
-    ComponentState m_componentstate { ComponentState::Undefined } ;
 
     SingleLink<BaseObject, BaseContext, BaseLink::FLAG_DOUBLELINK> l_context;
     LinkSlaves l_slaves;

--- a/SofaKernel/framework/sofa/core/objectmodel/BaseObject.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseObject.h
@@ -446,16 +446,6 @@ public:
     /// Return the full path name of this object
     virtual std::string getPathName() const;
 
-    /// @name componentstate
-    ///   Methods related to component state
-    /// @{
-
-    ComponentState getComponentState() const { return m_componentstate.getValue() ; }
-    bool isComponentStateValid() const { return m_componentstate != ComponentState::Invalid; }
-
-    ///@}
-
-
     /// @name internalupdate
     ///   Methods related to tracking of data and the internal update
     /// @{

--- a/SofaKernel/framework/sofa/core/objectmodel/ComponentState.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/ComponentState.cpp
@@ -1,0 +1,59 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2019 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <map>
+#include <sofa/core/objectmodel/ComponentState.h>
+
+namespace sofa::core::objectmodel
+{
+
+std::ostream& operator<<(std::ostream& o, const ComponentState& s)
+{
+    static std::map<ComponentState, std::string> s2str= {{ComponentState::Undefined, "Undefined"},
+                                                          {ComponentState::Loading, "Loading"},
+                                                          {ComponentState::Valid, "Valid"},
+                                                          {ComponentState::Dirty, "Dirty"},
+                                                          {ComponentState::Busy, "Busy"},
+                                                          {ComponentState::Invalid, "Invalid"}};
+    return o << s2str[s];
+}
+
+
+std::istream& operator>>(std::istream& i, ComponentState& s)
+{
+    static std::map<std::string, ComponentState> str2s= {{"Undefined", ComponentState::Undefined},
+                                                          {"Loading", ComponentState::Loading},
+                                                          {"Valid", ComponentState::Valid},
+                                                          {"Dirty", ComponentState::Dirty},
+                                                          {"Busy", ComponentState::Busy},
+                                                          {"Invalid", ComponentState::Invalid}};
+    std::string tmp;
+    i >> tmp;
+    if(str2s.find(tmp) == str2s.end())
+    {
+        i.setstate(std::ios::failbit);
+        return i;
+    }
+    s = str2s[tmp];
+    return i;
+}
+
+} /// sofa::core::objectmodel

--- a/SofaKernel/framework/sofa/core/objectmodel/ComponentState.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/ComponentState.cpp
@@ -20,6 +20,8 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <map>
+#include <iostream>
+#include <string>
 #include <sofa/core/objectmodel/ComponentState.h>
 
 namespace sofa
@@ -28,6 +30,7 @@ namespace core
 {
 namespace objectmodel
 {
+
 
 std::ostream& operator<<(std::ostream& o, const ComponentState& s)
 {
@@ -60,6 +63,8 @@ std::istream& operator>>(std::istream& i, ComponentState& s)
     return i;
 }
 
-}  // namespace objectmodel
-}  // namespace core
-}  // namespace sofa
+}  /// namespace objectmodel
+}  /// namespace core
+}  /// namespace sofa
+
+

--- a/SofaKernel/framework/sofa/core/objectmodel/ComponentState.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/ComponentState.cpp
@@ -22,7 +22,11 @@
 #include <map>
 #include <sofa/core/objectmodel/ComponentState.h>
 
-namespace sofa::core::objectmodel
+namespace sofa
+{
+namespace core
+{
+namespace objectmodel
 {
 
 std::ostream& operator<<(std::ostream& o, const ComponentState& s)
@@ -56,4 +60,6 @@ std::istream& operator>>(std::istream& i, ComponentState& s)
     return i;
 }
 
-} /// sofa::core::objectmodel
+}  // namespace objectmodel
+}  // namespace core
+}  // namespace sofa

--- a/SofaKernel/framework/sofa/core/objectmodel/ComponentState.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/ComponentState.h
@@ -1,0 +1,44 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2019 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <iostream>
+
+namespace sofa::core::objectmodel
+{
+
+/// enum class is a C++ x11 feature (http://en.cppreference.com/w/cpp/language/enum),
+/// Indicate the state of a sofa object.
+enum class ComponentState {
+    Undefined,                        ///< component that does not make use of this field have this one
+    Loading,                          ///< the component is loading but never passed successfully its init() function
+    Valid,                            ///< the component has passed successfully its init function
+    Dirty,                            ///< the component is ready to be used but requires a call to reinit
+    Busy,                             ///< the component is doing "something", don't trust its values for doing your computation
+    Invalid                           ///< the component reached an error and is thus unable to behave normally.
+};
+
+/// Defining the in/ou operator for use of component status with Data<>
+std::ostream& operator<<(std::ostream& o, const ComponentState& s);
+std::istream& operator>>(std::istream& i, ComponentState& s);
+
+} /// sofa::core::objectmodel

--- a/SofaKernel/framework/sofa/core/objectmodel/ComponentState.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/ComponentState.h
@@ -23,7 +23,11 @@
 
 #include <iostream>
 
-namespace sofa::core::objectmodel
+namespace sofa
+{
+namespace core
+{
+namespace objectmodel
 {
 
 /// enum class is a C++ x11 feature (http://en.cppreference.com/w/cpp/language/enum),
@@ -41,4 +45,6 @@ enum class ComponentState {
 std::ostream& operator<<(std::ostream& o, const ComponentState& s);
 std::istream& operator>>(std::istream& i, ComponentState& s);
 
-} /// sofa::core::objectmodel
+}  // namespace objectmodel
+}  // namespace core
+}  // namespace sofa

--- a/SofaKernel/framework/sofa/core/objectmodel/ComponentState.h
+++ b/SofaKernel/framework/sofa/core/objectmodel/ComponentState.h
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 
+#include <sofa/config.h>
 #include <iostream>
 
 namespace sofa
@@ -42,9 +43,13 @@ enum class ComponentState {
 };
 
 /// Defining the in/ou operator for use of component status with Data<>
-std::ostream& operator<<(std::ostream& o, const ComponentState& s);
-std::istream& operator>>(std::istream& i, ComponentState& s);
+SOFA_CORE_API std::ostream& operator<<(std::ostream& o, const ComponentState& s);
+SOFA_CORE_API std::istream& operator>>(std::istream& i, ComponentState& s);
 
-}  // namespace objectmodel
-}  // namespace core
-}  // namespace sofa
+
+}  /// namespace objectmodel
+}  /// namespace core
+}  /// namespace sofa
+
+
+

--- a/SofaKernel/framework/sofa/core/objectmodel/Context.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/Context.cpp
@@ -40,7 +40,9 @@ Context::Context()
 	, d_isSleeping(initData(&d_isSleeping, false, "sleeping", "The node is sleeping, and thus ignored by visitors."))
 	, d_canChangeSleepingState(initData(&d_canChangeSleepingState, false, "canChangeSleepingState", "The node can change its sleeping state."))
 {
-
+    animate_.setReadOnly(true);
+    dt_.setReadOnly(true);
+    time_.setReadOnly(true);
 }
 
 /// The Context is active

--- a/SofaKernel/modules/sofa/frameworkextra/frameworkextra_test/CMakeLists.txt
+++ b/SofaKernel/modules/sofa/frameworkextra/frameworkextra_test/CMakeLists.txt
@@ -4,6 +4,7 @@ project(SofaFrameworkExtra_test)
 
 set(SOURCE_FILES
     core/TrackedData_test.cpp
+    core/objectmodel/Base_test.cpp
     core/objectmodel/BaseContext_test.cpp
     defaulttype/TemplateAliases_test.cpp
     helper/AdvancedTimer_test.cpp

--- a/SofaKernel/modules/sofa/frameworkextra/frameworkextra_test/core/objectmodel/Base_test.cpp
+++ b/SofaKernel/modules/sofa/frameworkextra/frameworkextra_test/core/objectmodel/Base_test.cpp
@@ -1,0 +1,71 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2019 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+/******************************************************************************
+ * Contributors:
+ *     - damien.marchal@univ-lille.fr
+ *****************************************************************************/
+
+#include <sofa/core/objectmodel/Base.h>
+using sofa::core::objectmodel::Base ;
+using sofa::core::objectmodel::ComponentState;
+
+#include <SofaSimulationGraph/testing/BaseSimulationTest.h>
+using sofa::helper::testing::BaseSimulationTest ;
+using sofa::simulation::Node ;
+
+class Base_test: public BaseSimulationTest
+{
+public:
+    virtual ~Base_test(){}
+    void testComponentState()
+    {
+        EXPECT_MSG_NOEMIT(Error, Warning) ;
+        importPlugin("SofaAllCommonComponents") ;
+        std::stringstream scene ;
+        scene << "<?xml version='1.0'?>"
+                 "<Node name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
+                 "   <Node name='child1'>                                                    \n"
+                 "      <MechanicalObject />                                                 \n"
+                 "      <Node name='child2'>                                                 \n"
+                 "      </Node>                                                              \n"
+                 "   </Node>                                                                 \n"
+                 "</Node>                                                                    \n" ;
+
+        SceneInstance c("xml", scene.str()) ;
+        c.initScene() ;
+
+        Node* root = c.root.get() ;
+        ASSERT_NE(root, nullptr) ;
+
+        ASSERT_NE(root->findData("componentState"), nullptr);
+        root->m_componentstate = ComponentState::Valid;
+        ASSERT_EQ(root->m_componentstate, ComponentState::Valid);
+        root->m_componentstate = ComponentState::Loading;
+        ASSERT_EQ(root->m_componentstate, ComponentState::Loading);
+    }
+};
+
+TEST_F(Base_test , testComponentState )
+{
+    this->testComponentState();
+}
+


### PR DESCRIPTION
Currently in Sofa the attribute m_componentstate is not a data field. By transformating it into a data field allows different components to track each-other state (and changes) through the data tracker's mechanisms. 

The implementation is focus on minimize the amount of change and is not breaking.  
There is a basic test for the feature.
There is a non-breaking deprecation mechanism implemented to ease the renaming of m_componentstate to d_componentstate.
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
