### PR TITLE
[SofaKernel] Add fixed_array_algorithm + RGBAColor::lighten

### DIFF
--- a/SofaKernel/framework/framework_test/helper/types/Color_test.cpp
+++ b/SofaKernel/framework/framework_test/helper/types/Color_test.cpp
@@ -43,7 +43,16 @@ public:
     void checkConstructors() ;
     void checkStreamingOperator(const std::vector<std::string>&) ;
     void checkDoubleStreamingOperator(const std::vector<std::string>&) ;
+    void testEnlight();
 };
+
+void Color_Test::testEnlight()
+{
+    EXPECT_EQ( RGBAColor::lighten(RGBAColor::black(), 1.0), RGBAColor(1.0,1.0,1.0,1.0) ) ;
+    EXPECT_EQ( RGBAColor::lighten(RGBAColor::black(), 2.0), RGBAColor(1.0,1.0,1.0,1.0) ) ;
+    EXPECT_EQ( RGBAColor::lighten(RGBAColor::red(), 1.0), RGBAColor(1.0,1.0,1.0,1.0) ) ;
+    EXPECT_EQ( RGBAColor::lighten(RGBAColor::red(), 0.5), RGBAColor(1.0,0.5,0.5,1.0) ) ;
+}
 
 void Color_Test::checkCreateFromString()
 {
@@ -244,6 +253,11 @@ TEST_F(Color_Test, checkCreateFromDouble)
 TEST_F(Color_Test, checkEquality)
 {
     this->checkEquality() ;
+}
+
+TEST_F(Color_Test, checkEnlight)
+{
+    this->testEnlight() ;
 }
 
 std::vector<std::vector<std::string>> testvalues =

--- a/SofaKernel/framework/sofa/helper/CMakeLists.txt
+++ b/SofaKernel/framework/sofa/helper/CMakeLists.txt
@@ -73,6 +73,7 @@ set(HEADER_FILES
     decompose.inl
     deque.h
     fixed_array.h
+    fixed_array_algorithms.h
     hash.h
     gl/Trackball.h
     gl/Transformation.h

--- a/SofaKernel/framework/sofa/helper/fixed_array.h
+++ b/SofaKernel/framework/sofa/helper/fixed_array.h
@@ -374,7 +374,6 @@ private:
             throw std::range_error("fixed_array");
         }
     }
-
 };
 
 template<class T>
@@ -495,7 +494,23 @@ inline fixed_array<T, 10> make_array(const T& v0, const T& v1, const T& v2, cons
 }
 
 #ifndef FIXED_ARRAY_CPP
-extern template class SOFA_HELPER_API fixed_array<float, 4> ;
+extern template class SOFA_HELPER_API fixed_array<float, 2>;
+extern template class SOFA_HELPER_API fixed_array<double, 2>;
+
+extern template class SOFA_HELPER_API fixed_array<float, 3>;
+extern template class SOFA_HELPER_API fixed_array<double, 3>;
+
+extern template class SOFA_HELPER_API fixed_array<float, 4>;
+extern template class SOFA_HELPER_API fixed_array<double, 4>;
+
+extern template class SOFA_HELPER_API fixed_array<float, 5>;
+extern template class SOFA_HELPER_API fixed_array<double, 5>;
+
+extern template class SOFA_HELPER_API fixed_array<float, 6>;
+extern template class SOFA_HELPER_API fixed_array<double, 6>;
+
+extern template class SOFA_HELPER_API fixed_array<float, 7>;
+extern template class SOFA_HELPER_API fixed_array<double, 7>;
 #endif //
 
 } // namespace helper

--- a/SofaKernel/framework/sofa/helper/fixed_array_algorithms.h
+++ b/SofaKernel/framework/sofa/helper/fixed_array_algorithms.h
@@ -1,0 +1,91 @@
+#ifndef SOFA_HELPER_FIXED_ARRAY_ALGORITHMS_H
+#define SOFA_HELPER_FIXED_ARRAY_ALGORITHMS_H
+
+#include <sofa/helper/helper.h>
+#include <sofa/helper/rmath.h>
+#include <sofa/helper/fixed_array.h>
+namespace sofa
+{
+
+namespace helper
+{
+
+namespace pairwise
+{
+
+/// @brief clamp a single value. This function should be removed when std::clamp will be available
+template<class T>
+const T& stdclamp( const T& v, const T& lo, const T& hi )
+{
+    assert( !(hi < lo) );
+    return (v < lo) ? lo : (hi < v) ? hi : v;
+}
+
+/// @brief clamp all the values of a fixed_array to be within a given interval.
+template<class T, class TT=typename T::value_type, size_t TN=T::static_size>
+T clamp(const T& in, const TT& minValue, const TT& maxValue)
+{
+    T result {};
+    for(std::size_t i=0; i < TN; ++i)
+    {
+        result[i] = stdclamp(in[i], minValue, maxValue);
+    }
+    return result;
+}
+
+/// @brief pairwise add of two fixed_array
+template<class T, class TT=typename T::value_type, size_t TN=T::static_size>
+T operator+(const T& l, const T& r)
+{
+    T result {};
+    for(std::size_t i=0; i < TN; ++i)
+    {
+        result[i] = l[i] + r[i];
+    }
+    return result;
+}
+
+/// @brief pairwise subtract of two fixed_array
+template<class T, class TT=typename T::value_type, size_t TN=T::static_size>
+T operator-(const T& l, const T& r)
+{
+    T result {};
+    for(std::size_t i=0; i < TN; ++i)
+    {
+        result[i] = l[i] - r[i];
+    }
+    return result;
+}
+
+/// @brief multiply from l the r components.
+template<class T, class TT=typename T::value_type, size_t TN=T::static_size>
+T operator*(const T& r, const typename T::value_type& f)
+{
+    T result {};
+    for(std::size_t i=0; i < TN; ++i)
+    {
+        result[i] = r[i] * f;
+    }
+    return result;
+}
+
+/// @brief multiply from l the r components.
+template<class T, class TT=typename T::value_type, size_t TN=T::static_size>
+T operator/(const T& r, const typename T::value_type& f)
+{
+    T result {};
+    for(std::size_t i=0; i < TN; ++i)
+    {
+        result[i] = r[i] / f;
+    }
+    return result;
+}
+
+
+} /// namespace pairwise
+
+} /// namespace helper
+
+} /// namespace sofa
+
+#endif

--- a/SofaKernel/framework/sofa/helper/types/RGBAColor.cpp
+++ b/SofaKernel/framework/sofa/helper/types/RGBAColor.cpp
@@ -24,6 +24,12 @@
 #include <sstream>
 #include <locale>         // std::locale, std::isalnum
 
+
+#include <sofa/helper/rmath.h>
+
+#include <sofa/helper/fixed_array_algorithms.h>
+using namespace sofa::helper::pairwise;
+
 namespace sofa
 {
 namespace helper
@@ -267,6 +273,15 @@ SOFA_HELPER_API std::ostream& operator << ( std::ostream& out, const RGBAColor& 
         out<<v[i]<<" ";
     out<<v[3];
     return out;
+}
+
+
+/// @brief enlight a color by a given factor.
+RGBAColor RGBAColor::lighten(const RGBAColor& in, const SReal factor)
+{
+    RGBAColor c = in + ((RGBAColor::white() - clamp(in, 0.0f, 1.0f)) * rclamp(factor, 0.0, 1.0));
+    c.a()=1.0;
+    return c ;
 }
 
 

--- a/SofaKernel/framework/sofa/helper/types/RGBAColor.h
+++ b/SofaKernel/framework/sofa/helper/types/RGBAColor.h
@@ -39,6 +39,7 @@ namespace types
 
 using sofa::helper::fixed_array ;
 
+
 #define RGBACOLOR_EQUALITY_THRESHOLD 1e-6
 
 /**
@@ -67,6 +68,9 @@ public:
     static RGBAColor gray()    { return RGBAColor(0.5,0.5,0.5,1.0); }
     static RGBAColor lightgray() { return RGBAColor(0.25,0.25,0.25,1.0); }
     static RGBAColor darkgray()  { return RGBAColor(0.75,0.75,0.75,1.0); }
+
+    /// @brief enlight a color by a given factor.
+    static RGBAColor lighten(const RGBAColor& in, const SReal factor);
 
     inline float& r(){ return this->elems[0] ; }
     inline float& g(){ return this->elems[1] ; }

--- a/SofaKernel/framework/sofa/helper/types/fixed_array.cpp
+++ b/SofaKernel/framework/sofa/helper/types/fixed_array.cpp
@@ -27,7 +27,23 @@ namespace sofa
 namespace helper
 {
 
+template class SOFA_HELPER_API fixed_array<float, 2>;
+template class SOFA_HELPER_API fixed_array<double, 2>;
+
+template class SOFA_HELPER_API fixed_array<float, 3>;
+template class SOFA_HELPER_API fixed_array<double, 3>;
+
 template class SOFA_HELPER_API fixed_array<float, 4>;
+template class SOFA_HELPER_API fixed_array<double, 4>;
+
+template class SOFA_HELPER_API fixed_array<float, 5>;
+template class SOFA_HELPER_API fixed_array<double, 5>;
+
+template class SOFA_HELPER_API fixed_array<float, 6>;
+template class SOFA_HELPER_API fixed_array<double, 6>;
+
+template class SOFA_HELPER_API fixed_array<float, 7>;
+template class SOFA_HELPER_API fixed_array<double, 7>;
 
 } // namespace helper
 } // namespace sofa


### PR DESCRIPTION
In this PR:
- add some pairwise algorithms on fixed_array<> instead of Vec<> so here is an implementation. To avoid adding to the fixed_array.h I use the stl approach of putting that in a separated "algorithm.h" file. 
- I then use these to implement an enlightening function in RGBAColor with its unittest.

The uses of these will be done in a future PR. 
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
