### PR TITLE
[SofaKernel] Add new events to detect Initialization & Simulation start.

### DIFF
--- a/SofaKernel/framework/sofa/simulation/CMakeLists.txt
+++ b/SofaKernel/framework/sofa/simulation/CMakeLists.txt
@@ -69,6 +69,10 @@ set(HEADER_FILES
     InitTasks.h
     Locks.h
     VisitorAsync.h
+    events/SimulationInitDoneEvent.h
+    events/SimulationInitStartEvent.h
+    events/SimulationStartEvent.h
+    events/SimulationStopEvent.h
 )
 
 set(SOURCE_FILES
@@ -131,6 +135,10 @@ set(SOURCE_FILES
     DefaultTaskScheduler.cpp
     Task.cpp
     InitTasks.cpp
+    events/SimulationInitDoneEvent.cpp
+    events/SimulationInitStartEvent.cpp
+    events/SimulationStartEvent.cpp
+    events/SimulationStopEvent.cpp
 )
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})

--- a/SofaKernel/framework/sofa/simulation/events/SimulationInitDoneEvent.cpp
+++ b/SofaKernel/framework/sofa/simulation/events/SimulationInitDoneEvent.cpp
@@ -1,0 +1,37 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2019 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/simulation/events/SimulationInitDoneEvent.h>
+
+namespace sofa
+{
+
+namespace simulation
+{
+
+SOFA_EVENT_CPP( SimulationInitDoneEvent )
+
+SimulationInitDoneEvent::SimulationInitDoneEvent(){}
+SimulationInitDoneEvent::~SimulationInitDoneEvent(){}
+
+} // namespace simulation
+
+} // namespace sofa

--- a/SofaKernel/framework/sofa/simulation/events/SimulationInitDoneEvent.h
+++ b/SofaKernel/framework/sofa/simulation/events/SimulationInitDoneEvent.h
@@ -1,0 +1,52 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2019 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/core/objectmodel/Event.h>
+#include <sofa/simulation/simulationcore.h>
+
+namespace sofa
+{
+
+namespace simulation
+{
+
+/**
+  Event fired when needed to stop the animation.
+*/
+class SOFA_SIMULATION_CORE_API SimulationInitDoneEvent : public sofa::core::objectmodel::Event
+{
+public:
+
+    SOFA_EVENT_H( SimulationInitDoneEvent )
+
+    SimulationInitDoneEvent();
+    ~SimulationInitDoneEvent() override;
+
+    inline static const char* GetClassName() { return "SimulationInitDoneEvent"; }
+
+};
+
+} // namespace simulation
+
+} // namespace sofa
+

--- a/SofaKernel/framework/sofa/simulation/events/SimulationInitStartEvent.cpp
+++ b/SofaKernel/framework/sofa/simulation/events/SimulationInitStartEvent.cpp
@@ -1,0 +1,38 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2019 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/simulation/events/SimulationInitStartEvent.h>
+
+namespace sofa
+{
+
+namespace simulation
+{
+
+SOFA_EVENT_CPP( SimulationInitStartEvent )
+
+SimulationInitStartEvent::SimulationInitStartEvent(){}
+SimulationInitStartEvent::~SimulationInitStartEvent(){}
+
+
+} // namespace simulation
+
+} // namespace sofa

--- a/SofaKernel/framework/sofa/simulation/events/SimulationInitStartEvent.h
+++ b/SofaKernel/framework/sofa/simulation/events/SimulationInitStartEvent.h
@@ -1,0 +1,52 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2019 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/core/objectmodel/Event.h>
+#include <sofa/simulation/simulationcore.h>
+
+namespace sofa
+{
+
+namespace simulation
+{
+
+/**
+  Event fired when needed to stop the animation.
+*/
+class SOFA_SIMULATION_CORE_API SimulationInitStartEvent : public sofa::core::objectmodel::Event
+{
+public:
+
+    SOFA_EVENT_H( SimulationInitStartEvent )
+
+    SimulationInitStartEvent();
+    ~SimulationInitStartEvent() override;
+
+    inline static const char* GetClassName() { return "SimulationInitStartEvent"; }
+
+};
+
+} // namespace simulation
+
+} // namespace sofa
+

--- a/SofaKernel/framework/sofa/simulation/events/SimulationStartEvent.cpp
+++ b/SofaKernel/framework/sofa/simulation/events/SimulationStartEvent.cpp
@@ -1,0 +1,37 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2019 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/simulation/events/SimulationStartEvent.h>
+
+namespace sofa
+{
+
+namespace simulation
+{
+
+SOFA_EVENT_CPP( SimulationStartEvent )
+
+SimulationStartEvent::SimulationStartEvent(){}
+SimulationStartEvent::~SimulationStartEvent(){}
+
+} // namespace simulation
+
+} // namespace sofa

--- a/SofaKernel/framework/sofa/simulation/events/SimulationStartEvent.h
+++ b/SofaKernel/framework/sofa/simulation/events/SimulationStartEvent.h
@@ -1,0 +1,50 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2019 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/core/objectmodel/Event.h>
+#include <sofa/simulation/simulationcore.h>
+
+namespace sofa
+{
+
+namespace simulation
+{
+
+/**
+  Event fired when needed to stop the animation.
+*/
+class SOFA_SIMULATION_CORE_API SimulationStartEvent : public sofa::core::objectmodel::Event
+{
+public:
+
+    SOFA_EVENT_H( SimulationStartEvent )
+
+    SimulationStartEvent();
+    ~SimulationStartEvent() override;
+
+    inline static const char* GetClassName() { return "SimulationStartEvent"; }
+};
+
+} // namespace simulation
+
+} // namespace sofa

--- a/SofaKernel/framework/sofa/simulation/events/SimulationStopEvent.cpp
+++ b/SofaKernel/framework/sofa/simulation/events/SimulationStopEvent.cpp
@@ -1,0 +1,37 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2019 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/simulation/events/SimulationStopEvent.h>
+
+namespace sofa
+{
+
+namespace simulation
+{
+
+SOFA_EVENT_CPP( SimulationStopEvent )
+
+SimulationStopEvent::SimulationStopEvent(){}
+SimulationStopEvent::~SimulationStopEvent(){}
+
+} // namespace simulation
+
+} // namespace sofa

--- a/SofaKernel/framework/sofa/simulation/events/SimulationStopEvent.h
+++ b/SofaKernel/framework/sofa/simulation/events/SimulationStopEvent.h
@@ -1,0 +1,51 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2019 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/core/objectmodel/Event.h>
+#include <sofa/simulation/simulationcore.h>
+
+namespace sofa
+{
+
+namespace simulation
+{
+
+/**
+  Event fired when needed to stop the animation.
+*/
+class SOFA_SIMULATION_CORE_API SimulationStopEvent : public sofa::core::objectmodel::Event
+{
+public:
+
+    SOFA_EVENT_H( SimulationStopEvent )
+
+    SimulationStopEvent() ;
+    ~SimulationStopEvent() override ;
+
+    inline static const char* GetClassName() { return "SimulationStopEvent"; }
+};
+
+} // namespace simulation
+
+} // namespace sofa
+

--- a/applications/sofa/gui/qt/RealGUI.cpp
+++ b/applications/sofa/gui/qt/RealGUI.cpp
@@ -2034,32 +2034,33 @@ void RealGUI::fileRecentlyOpened(QAction *action)
 
 //------------------------------------
 
-void RealGUI::playpauseGUI ( bool value )
+void RealGUI::playpauseGUI ( bool startSimulation )
 {
-    startButton->setChecked ( value );
-    if ( currentSimulation() )
-        currentSimulation()->getContext()->setAnimate ( value );
+    startButton->setChecked ( startSimulation );
 
+    /// If there is no root node we do nothing.
     Node* root = currentSimulation();
-    if(!value)
-    {
-        if ( root != nullptr )
-        {
-            SimulationStartEvent startEvt;
-            root->propagateEvent(core::ExecParams::defaultInstance(), &startEvt);
-        }
+    if (root==nullptr)
+        return;
 
-        timerStep->stop();
+    /// Set the animation 'on' in the getContext()
+    currentSimulation()->getContext()->setAnimate ( startSimulation );
+
+    if(startSimulation)
+    {
+        SimulationStopEvent startEvt;
+        root->propagateEvent(core::ExecParams::defaultInstance(), &startEvt);
+        m_clockBeforeLastStep = 0;
+        frameCounter=0;
+        timerStep->start(0);
         return;
     }
 
-    if ( root != nullptr )
-    {
-        SimulationStopEvent stopEvt;
-        root->propagateEvent(core::ExecParams::defaultInstance(), &stopEvt);
-    }
+    SimulationStartEvent stopEvt;
+    root->propagateEvent(core::ExecParams::defaultInstance(), &stopEvt);
 
-    timerStep->start(0);
+    timerStep->stop();
+    return;
 }
 
 //------------------------------------

--- a/applications/sofa/gui/qt/RealGUI.cpp
+++ b/applications/sofa/gui/qt/RealGUI.cpp
@@ -2060,7 +2060,6 @@ void RealGUI::playpauseGUI ( bool value )
     }
 
     timerStep->start(0);
-    return;
 }
 
 //------------------------------------


### PR DESCRIPTION
And use them in the Simulation.cpp component

Follow the discussion in this PR: 
https://github.com/SofaDefrost/plugin.SofaPython3/pull/110



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
