### PR TITLE
[SofaSimulationGraph] Stop DAGNode get parent topology process in BarycentricMapping

### DIFF
--- a/SofaKernel/modules/SofaSimulationGraph/DAGNode.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/DAGNode.cpp
@@ -159,7 +159,7 @@ Node::SPtr DAGNode::createChild(const std::string& nodeName)
             }
         }
         msg_error("Node::createChild()") << "Empty string given to property 'name': Forcefully setting an empty name is forbidden.\n"
-                                      "Renaming to " + newName + " to avoid unexpected behaviors.";
+                                            "Renaming to " + newName + " to avoid unexpected behaviors.";
         newchild = sofa::core::objectmodel::New<DAGNode>(newName);
     }
     else
@@ -229,29 +229,18 @@ void* DAGNode::getObject(const sofa::core::objectmodel::ClassInfo& class_info, c
         else dir = SearchDown; // we are the root, search down from here.
     }
     void *result = nullptr;
-#ifdef DEBUG_GETOBJECT
-    std::string cname = class_info.name();
-    if (cname != std::string("N4sofa4core6ShaderE"))
-        std::cout << "DAGNode: search for object of type " << class_info.name() ;
-    std::string gname = "N4sofa9component8topology32TetrahedronSetGeometryAlgorithms";
-    bool isg = cname.length() >= gname.length() && std::string(cname, 0, gname.length()) == gname;
-#endif
+
     if (dir != SearchParents)
         for (ObjectIterator it = this->object.begin(); it != this->object.end(); ++it)
         {
             core::objectmodel::BaseObject* obj = it->get();
             if (tags.empty() || (obj)->getTags().includes(tags))
             {
-#ifdef DEBUG_GETOBJECT
-                if (isg)
-                    std::cout << "DAGNode: testing object " << (obj)->getName() << " of type " << (obj)->getClassName() ;
-#endif
+
                 result = class_info.dynamicCast(obj);
                 if (result != nullptr)
                 {
-#ifdef DEBUG_GETOBJECT
-                    std::cout << "DAGNode: found object " << (obj)->getName() << " of type " << (obj)->getClassName() ;
-#endif
+
                     break;
                 }
             }
@@ -267,10 +256,12 @@ void* DAGNode::getObject(const sofa::core::objectmodel::ClassInfo& class_info, c
         case SearchUp:
         {
             const LinkParents::Container& parents = l_parents.getValue();
-            for ( unsigned int i = 0; i < parents.size() ; ++i)
+            for ( unsigned int i = 0; i < parents.size() ; ++i){
                 result = parents[i]->getObject(class_info, tags, SearchUp);
+                if (result != nullptr) break;
+            }
         }
-        break;
+            break;
         case SearchDown:
             for(ChildIterator it = child.begin(); it != child.end(); ++it)
             {
@@ -388,30 +379,30 @@ void DAGNode::getObjects(const sofa::core::objectmodel::ClassInfo& class_info, G
 
     switch( dir )
     {
-        case Local:
-            this->getLocalObjects( class_info, container, tags );
-            break;
-
-        case SearchUp:
-            this->getLocalObjects( class_info, container, tags ); // add locals then SearchParents
-            // no break here, we want to execute the SearchParents code.
-        case SearchParents:
-        {
-            // a visitor executed from top but only run for this' parents will enforce the selected object unicity due even with diamond graph setups
-            GetUpObjectsVisitor vis( const_cast<DAGNode*>(this), class_info, container, tags);
-            getRootContext()->executeVisitor(&vis);
-        }
+    case Local:
+        this->getLocalObjects( class_info, container, tags );
         break;
 
-        case SearchDown:
-        {
-            // a regular visitor is enforcing the selected object unicity
-            GetDownObjectsVisitor vis(class_info, container, tags);
-            (const_cast<DAGNode*>(this))->executeVisitor(&vis);
-            break;
-        }
-        default:
-            break;
+    case SearchUp:
+        this->getLocalObjects( class_info, container, tags ); // add locals then SearchParents
+        // no break here, we want to execute the SearchParents code.
+    case SearchParents:
+    {
+        // a visitor executed from top but only run for this' parents will enforce the selected object unicity due even with diamond graph setups
+        GetUpObjectsVisitor vis( const_cast<DAGNode*>(this), class_info, container, tags);
+        getRootContext()->executeVisitor(&vis);
+    }
+        break;
+
+    case SearchDown:
+    {
+        // a regular visitor is enforcing the selected object unicity
+        GetDownObjectsVisitor vis(class_info, container, tags);
+        (const_cast<DAGNode*>(this))->executeVisitor(&vis);
+        break;
+    }
+    default:
+        break;
     }
 }
 
@@ -475,7 +466,7 @@ bool DAGNode::hasAncestor(const BaseContext* context) const
     const LinkParents::Container& parents = l_parents.getValue();
     for ( unsigned int i = 0; i < parents.size() ; ++i)
         if (context == parents[i]->getContext()
-            || parents[i]->hasAncestor(context))
+                || parents[i]->hasAncestor(context))
             return true;
     return false;
 }

--- a/SofaKernel/modules/SofaSimulationGraph/DAGNode.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/DAGNode.cpp
@@ -250,28 +250,28 @@ void* DAGNode::getObject(const sofa::core::objectmodel::ClassInfo& class_info, c
     {
         switch(dir)
         {
-        case Local:
-            break;
-        case SearchParents:
-        case SearchUp:
-        {
-            const LinkParents::Container& parents = l_parents.getValue();
-            for ( unsigned int i = 0; i < parents.size() ; ++i){
-                result = parents[i]->getObject(class_info, tags, SearchUp);
-                if (result != nullptr) break;
-            }
-        }
-            break;
-        case SearchDown:
-            for(ChildIterator it = child.begin(); it != child.end(); ++it)
+            case Local:
+                break;
+            case SearchParents:
+            case SearchUp:
             {
-                result = (*it)->getObject(class_info, tags, dir);
-                if (result != nullptr) break;
+                const LinkParents::Container& parents = l_parents.getValue();
+                for ( unsigned int i = 0; i < parents.size() ; ++i){
+                    result = parents[i]->getObject(class_info, tags, SearchUp);
+                    if (result != nullptr) break;
+                }
             }
-            break;
-        case SearchRoot:
-            dmsg_error("DAGNode") << "SearchRoot SHOULD NOT BE POSSIBLE HERE.";
-            break;
+                break;
+            case SearchDown:
+                for(ChildIterator it = child.begin(); it != child.end(); ++it)
+                {
+                    result = (*it)->getObject(class_info, tags, dir);
+                    if (result != nullptr) break;
+                }
+                break;
+            case SearchRoot:
+                dmsg_error("DAGNode") << "SearchRoot SHOULD NOT BE POSSIBLE HERE.";
+                break;
         }
     }
 
@@ -379,30 +379,30 @@ void DAGNode::getObjects(const sofa::core::objectmodel::ClassInfo& class_info, G
 
     switch( dir )
     {
-    case Local:
-        this->getLocalObjects( class_info, container, tags );
-        break;
+        case Local:
+            this->getLocalObjects( class_info, container, tags );
+            break;
 
-    case SearchUp:
-        this->getLocalObjects( class_info, container, tags ); // add locals then SearchParents
-        // no break here, we want to execute the SearchParents code.
-    case SearchParents:
-    {
-        // a visitor executed from top but only run for this' parents will enforce the selected object unicity due even with diamond graph setups
-        GetUpObjectsVisitor vis( const_cast<DAGNode*>(this), class_info, container, tags);
-        getRootContext()->executeVisitor(&vis);
-    }
-        break;
+        case SearchUp:
+            this->getLocalObjects( class_info, container, tags ); // add locals then SearchParents
+            // no break here, we want to execute the SearchParents code.
+        case SearchParents:
+        {
+            // a visitor executed from top but only run for this' parents will enforce the selected object unicity due even with diamond graph setups
+            GetUpObjectsVisitor vis( const_cast<DAGNode*>(this), class_info, container, tags);
+            getRootContext()->executeVisitor(&vis);
+        }
+            break;
 
-    case SearchDown:
-    {
-        // a regular visitor is enforcing the selected object unicity
-        GetDownObjectsVisitor vis(class_info, container, tags);
-        (const_cast<DAGNode*>(this))->executeVisitor(&vis);
-        break;
-    }
-    default:
-        break;
+        case SearchDown:
+        {
+            // a regular visitor is enforcing the selected object unicity
+            GetDownObjectsVisitor vis(class_info, container, tags);
+            (const_cast<DAGNode*>(this))->executeVisitor(&vis);
+            break;
+        }
+        default:
+            break;
     }
 }
 

--- a/SofaKernel/modules/SofaSimulationGraph/DAGNode.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/DAGNode.cpp
@@ -159,7 +159,7 @@ Node::SPtr DAGNode::createChild(const std::string& nodeName)
             }
         }
         msg_error("Node::createChild()") << "Empty string given to property 'name': Forcefully setting an empty name is forbidden.\n"
-                                            "Renaming to " + newName + " to avoid unexpected behaviors.";
+                                        "Renaming to " + newName + " to avoid unexpected behaviors.";
         newchild = sofa::core::objectmodel::New<DAGNode>(newName);
     }
     else


### PR DESCRIPTION
Stop the search of the Container/BaseTopology when one is found (using break)



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new scene test failures.
- [ ] does not generate new unit test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
