### PR TITLE
[runSofa] Fix DataWidget display Speicherleck and long loading

### DIFF
--- a/applications/sofa/gui/qt/DataWidget.cpp
+++ b/applications/sofa/gui/qt/DataWidget.cpp
@@ -46,7 +46,12 @@ namespace qt
 using namespace core::objectmodel;
 
 DataWidget::DataWidget(QWidget* parent,const char* name, MyData* d)
-:QWidget(parent /*,name */), baseData(d), dirty(false), counter(-1)
+    : QWidget(parent /*,name */)
+    , baseData(d)
+    , dirty(false)
+    , counter(-1)
+    , m_isFilled(true)
+    , m_toFill(false)
 {
     this->setObjectName(name);
 }
@@ -129,15 +134,33 @@ DataWidget::updateDataValue()
 
 }
 
+void DataWidget::fillFromData()
+{
+    if (!m_isFilled) // only activate toFill if only is not already filled
+    {
+        m_toFill = true;
+    }
+    else
+    {
+        m_toFill = false;
+    }
+}
+
 void
 DataWidget::updateWidgetValue()
 {
     if(!dirty)
     {
-        if(counter != baseData->getCounter())
+        if(m_toFill || counter != baseData->getCounter())
         {
             readFromData();
             this->update();
+
+            if (m_toFill) // update parameters to avoid other force fill
+            {
+                m_toFill = false;
+                m_isFilled = true;
+            }
         }
     }
 }

--- a/applications/sofa/gui/qt/DataWidget.h
+++ b/applications/sofa/gui/qt/DataWidget.h
@@ -121,6 +121,10 @@ public slots:
     /// value is out of sync with the underlying data value.
     void setWidgetDirty(bool b=true);
 
+    /// slot to be called if DataWidget has not been filled at constructor and need to be filled 
+    /// at first call. Will turn toFill to true only if isFilled == false
+    void fillFromData();
+
 signals:
     /// Emitted each time setWidgetDirty is called. You can also emit
     /// it if you want to tell the widget value is out of sync with
@@ -148,6 +152,11 @@ public:
 
     inline bool isDirty() { return dirty; }
 
+    /// return if DataWidget as been filled
+    bool isFilled() { return m_isFilled; }
+    /// method to warn if Data has not been filled at constructor. 
+    void setFilled(bool value) { m_isFilled = value; }
+
     /// The implementation of this method holds the widget creation and the signal / slot
     /// connections.
     virtual bool createWidgets() = 0;
@@ -168,6 +177,8 @@ protected:
     core::objectmodel::BaseData* baseData;
     bool dirty;
     int counter;
+    bool m_isFilled; ///< tell if DataWidget has been filled from Data true by default
+    bool m_toFill; ///< bool to warn action is needed to fill Data, false by default
 };
 
 

--- a/applications/sofa/gui/qt/QDisplayDataWidget.cpp
+++ b/applications/sofa/gui/qt/QDisplayDataWidget.cpp
@@ -247,7 +247,6 @@ void QDataSimpleEdit::writeToData()
     {
         value = innerWidget_.widget.lineEdit->text().toStdString();
     }
-    getBaseData()->read(value);
 }
 
 /* QPoissonRatioWidget */

--- a/applications/sofa/gui/qt/QModelViewTableDataContainer.h
+++ b/applications/sofa/gui/qt/QModelViewTableDataContainer.h
@@ -424,7 +424,7 @@ public:
         if(displayDataWidget)
             propertyWidgetFlagOn = displayDataWidget->flag().PROPERTY_WIDGET_FLAG;
 
-        fillTable(d);
+        parent->setFilled(false);
         rows = dataRows;
 
         wSize->setValue(dataRows);
@@ -454,7 +454,7 @@ public:
         }
         parent->connect(wDisplay, SIGNAL( toggled(bool) ), wTableView,   SLOT(setDisplayed(bool)));
         parent->connect(wDisplay, SIGNAL( toggled(bool) ), wDisplay, SLOT(setDisplayed(bool)));
-        parent->connect(wDisplay, SIGNAL( toggled(bool) ), parent, SLOT( updateWidgetValue() ));
+        parent->connect(wDisplay, SIGNAL( toggled(bool) ), parent, SLOT(fillFromData() ));
         
         if (!propertyWidgetFlagOn)
             wDisplay->setChecked(dataRows < MAX_NUM_ELEM && dataRows != 0);

--- a/applications/sofa/gui/qt/QModelViewTableDataContainer.h
+++ b/applications/sofa/gui/qt/QModelViewTableDataContainer.h
@@ -424,13 +424,8 @@ public:
         if(displayDataWidget)
             propertyWidgetFlagOn = displayDataWidget->flag().PROPERTY_WIDGET_FLAG;
 
-        processTableModifications(d);
         fillTable(d);
         rows = dataRows;
-
-        if(!propertyWidgetFlagOn)
-            wDisplay->setChecked(dataRows < MAX_NUM_ELEM && dataRows != 0 );
-        wDisplay->setAutoDefault(false);
 
         wSize->setValue(dataRows);
 
@@ -460,12 +455,13 @@ public:
         parent->connect(wDisplay, SIGNAL( toggled(bool) ), wTableView,   SLOT(setDisplayed(bool)));
         parent->connect(wDisplay, SIGNAL( toggled(bool) ), wDisplay, SLOT(setDisplayed(bool)));
         parent->connect(wDisplay, SIGNAL( toggled(bool) ), parent, SLOT( updateWidgetValue() ));
-
-        wDisplay->toggle();
-        if(propertyWidgetFlagOn)
-            wDisplay->setChecked(false);
+        
+        if (!propertyWidgetFlagOn)
+            wDisplay->setChecked(dataRows < MAX_NUM_ELEM && dataRows != 0);
         else
-            wDisplay->toggle();
+            wDisplay->setChecked(false);
+
+        wDisplay->setAutoDefault(false);
 
         return true;
     }


### PR DESCRIPTION
- Fix memory problem of #1178
- Add mecanism to load Data vector only when clicking on "show values"

Fix #1178

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
