### PR TITLE
[SofaFramework] Install the SofaSimulationCore target back into the SofaFramework package

### DIFF
--- a/SofaKernel/framework/sofa/simulation/CMakeLists.txt
+++ b/SofaKernel/framework/sofa/simulation/CMakeLists.txt
@@ -145,4 +145,4 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread" )
 endif()
 
-sofa_install_targets(SofaSimulation ${PROJECT_NAME} "SofaSimulation/sofa/simulation")
+sofa_install_targets(SofaFramework ${PROJECT_NAME} "SofaFramework/sofa/simulation")

--- a/SofaKernel/framework/sofa/simulation/simulationcore.h
+++ b/SofaKernel/framework/sofa/simulation/simulationcore.h
@@ -22,6 +22,6 @@
 #ifndef SOFA_SIMULATION_CORE_H
 #define SOFA_SIMULATION_CORE_H
 
-#include <sofa/simulation/config.h>
+#include <sofa/config.h>
 
 #endif


### PR DESCRIPTION
See #1180 for details.

Fixes #1180
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
