### PR TITLE
CLEAN: Adding a singleLink for the mass in CenterOfMassMapping

### DIFF
--- a/modules/SofaMiscMapping/CenterOfMassMapping.h
+++ b/modules/SofaMiscMapping/CenterOfMassMapping.h
@@ -100,14 +100,16 @@ public:
 
 protected :
     CenterOfMassMapping ( )
-        : Inherit ()
+        : l_mass(initLink("mass", "link to the mass associated with the parent model")),
+          Inherit ()
     {}
 
     virtual ~CenterOfMassMapping()
     {}
 
     ///pointer on the input DOFs mass
-    sofa::core::behavior::BaseMass * masses;
+//    sofa::core::behavior::BaseMass * masses;
+    SingleLink<CenterOfMassMapping<TIn,TOut>, sofa::core::behavior::BaseMass, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_mass;
 
     /// the total mass of the input object
     double totalMass;

--- a/modules/SofaMiscMapping/CenterOfMassMapping.inl
+++ b/modules/SofaMiscMapping/CenterOfMassMapping.inl
@@ -73,7 +73,7 @@ void CenterOfMassMapping<TIn, TOut>::apply( const sofa::core::MechanicalParams* 
     OutVecCoord& childPositions = *outData.beginEdit(mparams);
     const InVecCoord& parentPositions = inData.getValue();
 
-    if(!l_mass || totalMass==0.0)
+    if(!l_mass.get() || totalMass==0.0)
     {
         serr<<"Error in CenterOfMassMapping : no mass found corresponding to the DOFs"<<sendl;
         return;
@@ -100,7 +100,7 @@ void CenterOfMassMapping<TIn, TOut>::applyJ( const sofa::core::MechanicalParams*
     OutVecDeriv& childForces = *outData.beginEdit(mparams);
     const InVecDeriv& parentForces = inData.getValue();
 
-    if(!l_mass || totalMass==0.0)
+    if(!l_mass.get() || totalMass==0.0)
     {
         serr<<"Error in CenterOfMassMapping : no mass found corresponding to the DOFs"<<sendl;
         return;
@@ -127,7 +127,7 @@ void CenterOfMassMapping<TIn, TOut>::applyJT( const sofa::core::MechanicalParams
     InVecDeriv& parentForces = *outData.beginEdit(mparams);
     const OutVecDeriv& childForces = inData.getValue();
 
-    if(!l_mass || totalMass==0.0)
+    if(!l_mass.get() || totalMass==0.0)
     {
         serr<<"Error in CenterOfMassMapping : no mass found corresponding to the DOFs"<<sendl;
         return;

--- a/modules/SofaMiscMapping/CenterOfMassMapping.inl
+++ b/modules/SofaMiscMapping/CenterOfMassMapping.inl
@@ -48,6 +48,7 @@ void CenterOfMassMapping<TIn, TOut>::init()
     //get the pointer on the input dofs mass
     if (!l_mass)
     {
+        msg_warning() << "link to the mass should be set to ensure right behavior. First mass found in current context will be used.";
         l_mass.set(this->fromModel->getContext()->getMass());
         if(!l_mass.get())
             msg_error(this) << "Could not retrieve mass from context.";
@@ -61,7 +62,7 @@ void CenterOfMassMapping<TIn, TOut>::init()
 
     //compute the total mass of the object
     for (unsigned int i=0, size = this->fromModel->getSize() ; i< size; i++)
-        totalMass += l_mass->getElementMass(i);
+        totalMass += l_mass.get()->getElementMass(i);
 
     Inherit::init();
 }
@@ -85,7 +86,7 @@ void CenterOfMassMapping<TIn, TOut>::apply( const sofa::core::MechanicalParams* 
     //with Xi: position of the dof i, Mi: mass of the dof i, and Mt : total mass of the object
     for (unsigned int i=0 ; i<parentPositions.size() ; i++)
     {
-        outX += parentPositions[i].getCenter() * l_mass->getElementMass(i);
+        outX += parentPositions[i].getCenter() * l_mass.get()->getElementMass(i);
     }
 
     childPositions[0] = outX / totalMass;
@@ -112,7 +113,7 @@ void CenterOfMassMapping<TIn, TOut>::applyJ( const sofa::core::MechanicalParams*
     //with Fi: force of the dof i, Mi: mass of the dof i, and Mt : total mass of the object
     for (unsigned int i=0 ; i<parentForces.size() ; i++)
     {
-        outF += getVCenter(parentForces[i]) * l_mass->getElementMass(i);
+        outF += getVCenter(parentForces[i]) * l_mass.get()->getElementMass(i);
     }
 
     childForces[0] = outF / totalMass;
@@ -137,7 +138,7 @@ void CenterOfMassMapping<TIn, TOut>::applyJT( const sofa::core::MechanicalParams
     //the force on a dof is proportional to its mass
     //relation is Fi = Fc * (Mi/Mt), with Fc: force of center of mass, Mi: dof mass, Mt: total mass
     for (unsigned int i=0 ; i<parentForces.size() ; i++)
-        getVCenter(parentForces[i]) += childForces[0] * (l_mass->getElementMass(i) / totalMass);
+        getVCenter(parentForces[i]) += childForces[0] * (l_mass.get()->getElementMass(i) / totalMass);
 
     outData.endEdit(mparams);
 }


### PR DESCRIPTION
The CenterOfMassMapping, requires a Mass associated with its parent MechanicalState.
The initial code relies on a call to fromModel()->getContext()->getMass() to retrieve the associated mass, and did not propose a way to set explicitely the mass to use.
The mass was stored in a pointer during init(), and we want to use singleLinks instead, to keep track of how components interact with each other.

The initial goal of this PR was to get rid of getMass in BaseContext(), but we want your opinion on how to do this, especially for the case of MultiMapping (CenterOfMassMultiMapping):

1. add a SingleLink to the mass in the MechanicalState
2. store a list of the masses associated to the list of models in CenterOfMassMultiMapping


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
