### PR TITLE
[SofaSphFluid] missing namespace

### DIFF
--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticlesRepulsionForceField.h
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticlesRepulsionForceField.h
@@ -111,8 +111,8 @@ using sofa::defaulttype::Vec2dTypes;
 
 #if  !defined(SOFA_COMPONENT_FORCEFIELD_PARTICLESREPULSIONFORCEFIELD_CPP)
 
-extern template class SOFA_SPH_FLUID_API ParticlesRepulsionForceField<Vec3Types>;
-extern template class SOFA_SPH_FLUID_API ParticlesRepulsionForceField<Vec2Types>;
+extern template class SOFA_SPH_FLUID_API ParticlesRepulsionForceField<sofa::defaulttype::Vec3Types>;
+extern template class SOFA_SPH_FLUID_API ParticlesRepulsionForceField<sofa::defaulttype::Vec2Types>;
 
 
 #endif //  !defined(SOFA_COMPONENT_FORCEFIELD_PARTICLESREPULSIONFORCEFIELD_CPP)


### PR DESCRIPTION

Just a minor fix, as the `VecXTypes` are not visible without the explicit namespace


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
