### PR TITLE
[SofaKernel] Set BaseData to non-persistant by default

### DIFF
--- a/SofaKernel/framework/sofa/core/objectmodel/BaseData.cpp
+++ b/SofaKernel/framework/sofa/core/objectmodel/BaseData.cpp
@@ -45,6 +45,7 @@ BaseData::BaseData(const char* h, DataFlags dataflags)
     addLink(&outputs);
     m_counters.assign(0);
     m_isSets.assign(false);
+    setFlag(FLAG_PERSISTENT, false);
 }
 
 BaseData::BaseData( const char* h, bool isDisplayed, bool isReadOnly)
@@ -58,6 +59,7 @@ BaseData::BaseData( const char* h, bool isDisplayed, bool isReadOnly)
     m_isSets.assign(false);
     setFlag(FLAG_DISPLAYED,isDisplayed);
     setFlag(FLAG_READONLY,isReadOnly);
+    setFlag(FLAG_PERSISTENT, false);
 }
 
 BaseData::BaseData( const BaseInitData& init)
@@ -70,6 +72,7 @@ BaseData::BaseData( const BaseInitData& init)
     addLink(&outputs);
     m_counters.assign(0);
     m_isSets.assign(false);
+
     if (init.data && init.data != this)
     {
         {
@@ -82,6 +85,7 @@ BaseData::BaseData( const BaseInitData& init)
         exit( EXIT_FAILURE );
     }
     if (m_owner) m_owner->addData(this, m_name);
+    setFlag(FLAG_PERSISTENT, false);
 }
 
 BaseData::~BaseData()

--- a/applications/plugins/SofaPython/SofaPython_test/python/test_BindingData.py
+++ b/applications/plugins/SofaPython/SofaPython_test/python/test_BindingData.py
@@ -9,9 +9,9 @@ def createScene(rootNode):
     ASSERT_NEQ(field, None)
 
     ### Check isPersistant/setPersistant
-    ASSERT_TRUE( field.isPersistant() )
-    field.setPersistant(False)
     ASSERT_FALSE( field.isPersistant() )
+    field.setPersistant(True)
+    ASSERT_TRUE( field.isPersistant() )
 
     ### Check isSet/unset
     ASSERT_TRUE( field.isSet() )


### PR DESCRIPTION
This is a long standing issue in Sofa about not being able to save 'usable' scene in runSofa. 

This is the result of multiple problems combined together among which:
- there is keywords that are not Data field but parsing hook (eg: src, compatbility hook) and they needs to be converted into Data.
- the Data have a persistant field. But it is let to the component to specify which are or not depending on some object property but depend on their context of "use".
Eg:
   *) a data changed in the GUI should be saved
   *) a data filled with a script shouldn't
etc...

To allow to control fine grain the state of a data is now set to non persitant
by default and should only be activated specifically (by the GUI, or the script)
if it is needed to save it.

This is what this PR do, and despiste this is a behavior change...it is on a totally broken feature.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
