### PR TITLE
[CMake] FIX unknown compiler option on VS2015

### DIFF
--- a/SofaKernel/cmake/CompilerOptions.cmake
+++ b/SofaKernel/cmake/CompilerOptions.cmake
@@ -36,7 +36,10 @@ endif()
 ## Windows-specific
 if(WIN32)
     add_definitions("-wd4250 -wd4251 -wd4275 -wd4675 -wd4996 -D_USE_MATH_DEFINES")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /Zc:__cplusplus")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+    if(MSVC_TOOLSET_VERSION GREATER 140) # > VS 2015
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus")
+    endif()
 endif()
 
 # Mac specific


### PR DESCRIPTION
I know we are planning to drop VS2015 support in a very near future (I'm actually working on it) but this "unknown option" warning bothers me at each compilation (yes, I'm still under VS2015 myself).

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
