### PR TITLE
[SofaMisc] Fix compilation with SOFA_NO_OPENGL

### DIFF
--- a/modules/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.inl
+++ b/modules/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.inl
@@ -23,7 +23,6 @@
 #ifndef SOFA_COMPONENT_FORCEFIELD_TETRAHEDRONHYPERELASTICITYFEMFORCEFIELD_INL
 #define SOFA_COMPONENT_FORCEFIELD_TETRAHEDRONHYPERELASTICITYFEMFORCEFIELD_INL
 
-#include <sofa/helper/system/gl.h>
 #include <SofaMiscFem/BoyceAndArruda.h>
 #include <SofaMiscFem/NeoHookean.h>
 #include <SofaMiscFem/MooneyRivlin.h>


### PR DESCRIPTION
in TetrahedronHyperelasticityFEMForceField.inl , gl.h was included before anything, so the macros defined in build_option_opengl.h were ignored.
The inclusion of gl.h was useless anyway so it was removed.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
