### PR TITLE
[SofaGui] FIX missing find_package in SofaGuiConfig.cmake.in

### DIFF
--- a/SofaGui/SofaGuiConfig.cmake.in
+++ b/SofaGui/SofaGuiConfig.cmake.in
@@ -15,6 +15,7 @@ set(SOFAGUIQT_HAVE_QWT @SOFAGUIQT_HAVE_QWT@)
 find_package(SofaGeneral REQUIRED)
 find_package(SofaMisc REQUIRED)
 find_package(SofaAdvanced REQUIRED)
+find_package(SofaComponentAll REQUIRED) # Needed by SofaGuiCommon
 
 if(SOFAGUI_HAVE_SOFAGUIQT)
     if(SOFAGUIQT_HAVE_QTVIEWER)


### PR DESCRIPTION
find_package(SofaGui) was failing because of SofaGuiCommon's dependency on SofaComponentAll


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
