### PR TITLE
[SofaBaseMechanics] Add topological change in barycentric mapping

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h
@@ -70,103 +70,9 @@ protected:
     void addPointInElement(const int elementIndex, const SReal* baryCoords) override;
 
     //handle topology changes depending on the topology
-    void processTopologicalChanges(const typename Out::VecCoord& out, const typename In::VecCoord& in, core::topology::Topology* t) {
-        using sofa::core::behavior::MechanicalState;
-        
-        if (t != m_toTopology) return;
+    void processTopologicalChanges(const typename Out::VecCoord& out, const typename In::VecCoord& in, core::topology::Topology* t);
 
-        if ( m_toTopology->beginChange() == m_toTopology->endChange() )
-            return;
-
-        auto itBegin = m_toTopology->beginChange();
-        auto itEnd = m_toTopology->endChange();
-
-        helper::WriteAccessor < Data< helper::vector<MappingData > > > vectorData = d_map;
-        vectorData.resize (out.size());
-
-        for (auto changeIt = itBegin; changeIt != itEnd; ++changeIt ) {
-            const core::topology::TopologyChangeType changeType = ( *changeIt )->getChangeType();
-            switch ( changeType )
-            {
-            //TODO: implementation of BarycentricMapperHexahedronSetTopology<In,Out>::handleTopologyChange()
-            case core::topology::POINTSINDICESSWAP:  ///< For PointsIndicesSwap.
-            {
-                const core::topology::PointsIndicesSwap * ps = static_cast<const core::topology::PointsIndicesSwap*>(*changeIt);
-                MappingData copy = vectorData[ps->index[0]];
-                vectorData[ps->index[0]] = vectorData[ps->index[1]];
-                vectorData[ps->index[1]] = copy;
-                break;
-            }
-            case core::topology::POINTSADDED:        ///< For PointsAdded.
-            {
-                const core::topology::PointsAdded * pa = static_cast<const core::topology::PointsAdded*>(*changeIt);
-                auto& array = pa->getElementArray();
-
-                for (unsigned i=0;i<array.size();i++) {
-                    unsigned pid = array[i];
-                    processAddPoint(Out::getCPos(out[pid]),
-                                    in,
-                                    vectorData[pid]);
-                }
-
-                break;
-            }
-            case core::topology::POINTSREMOVED:      ///< For PointsRemoved.
-            {
-                // nothing to do
-                break;
-            }
-            case core::topology::POINTSRENUMBERING:  ///< For PointsRenumbering.
-            {
-                const core::topology::PointsRenumbering * pr = static_cast<const core::topology::PointsRenumbering*>(*changeIt);
-                auto& array = pr->getIndexArray();
-                auto& inv_array = pr->getinv_IndexArray();
-                for (unsigned i=0;i<array.size();i++) {
-                    MappingData copy = vectorData[array[i]];
-                    vectorData[inv_array[i]] = vectorData[array[i]];
-                    vectorData[array[i]] = copy;
-                }
-                break;
-            }
-            default:
-            {
-                break;
-            }
-            }
-        }
-    }
-
-    void processAddPoint(const sofa::defaulttype::Vec3d & pos, const typename In::VecCoord& in, MappingData & vectorData){
-        const sofa::helper::vector<core::topology::BaseMeshTopology::Tetrahedron>& tetrahedra = this->m_fromTopology->getTetrahedra();
-
-        sofa::defaulttype::Vector3 coefs;
-        int index = -1;
-        double distance = std::numeric_limits<double>::max();
-        for ( unsigned int t = 0; t < tetrahedra.size(); t++ )
-        {
-            sofa::defaulttype::Mat3x3d base;
-            sofa::defaulttype::Vector3 center;
-            computeBase(base,in,tetrahedra[t]);
-            computeCenter(center,in,tetrahedra[t]);
-
-            sofa::defaulttype::Vec3d v = base * ( pos - in[tetrahedra[t][0]] );
-            double d = std::max ( std::max ( -v[0],-v[1] ),std::max ( -v[2],v[0]+v[1]+v[2]-1 ) );
-
-            if ( d>0 ) d = ( pos-center ).norm2();
-
-            if ( d<distance )
-            {
-                coefs = v;
-                distance = d;
-                index = t;
-            }
-        }
-
-        vectorData.in_index = index;
-        vectorData.baryCoords[0] = ( Real ) coefs[0];
-        vectorData.baryCoords[1] = ( Real ) coefs[1];
-        vectorData.baryCoords[2] = ( Real ) coefs[2];
-    }
+    void processAddPoint(const sofa::defaulttype::Vec3d & pos, const typename In::VecCoord& in, MappingData & vectorData);
 
     topology::TetrahedronSetTopologyContainer*      m_fromContainer {nullptr};
     topology::TetrahedronSetGeometryAlgorithms<In>*	m_fromGeomAlgo  {nullptr};
@@ -179,10 +85,12 @@ protected:
 
 #if !defined(SOFA_COMPONENT_MAPPING_BARYCENTRICMAPPERTETRAHEDRONSETTOPOLOGY_CPP)
 extern template class SOFA_BASE_MECHANICS_API BarycentricMapperTetrahedronSetTopology< Vec3dTypes, Vec3dTypes >;
-
-
 #endif
 
-}}}
+} // namespace mapping
 
-#endif
+} // namespace component
+
+} // namespace sofa
+
+#endif // SOFA_COMPONENT_MAPPING_BARYCENTRICMAPPERTETRAHEDRONSETTOPOLOGY_H

--- a/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h
@@ -52,6 +52,7 @@ public:
     SOFA_CLASS(SOFA_TEMPLATE2(BarycentricMapperTetrahedronSetTopology,In,Out),SOFA_TEMPLATE4(BarycentricMapperTopologyContainer,In,Out,MappingData,Tetrahedron));
     typedef typename Inherit1::Real Real;
     typedef typename In::VecCoord VecCoord;
+    using Inherit1::m_toTopology;
 
     int addPointInTetra(const int index, const SReal* baryCoords) override ;
 
@@ -71,16 +72,16 @@ protected:
     //handle topology changes depending on the topology
     void processTopologicalChanges(const typename Out::VecCoord& out, const typename In::VecCoord& in, core::topology::Topology* t) {
         using sofa::core::behavior::MechanicalState;
+        
+        if (t != m_toTopology) return;
 
-        if (t != this->m_toTopology) return;
-
-        if ( this->m_toTopology->beginChange() == this->m_toTopology->endChange() )
+        if ( m_toTopology->beginChange() == m_toTopology->endChange() )
             return;
 
-        std::list<const core::topology::TopologyChange *>::const_iterator itBegin = this->m_toTopology->beginChange();
-        std::list<const core::topology::TopologyChange *>::const_iterator itEnd = this->m_toTopology->endChange();
+        auto itBegin = m_toTopology->beginChange();
+        auto itEnd = m_toTopology->endChange();
 
-        helper::vector<MappingData>& vectorData = *(d_map.beginEdit());
+        helper::WriteAccessor < Data< helper::vector<MappingData > > > vectorData = d_map;
         vectorData.resize (out.size());
 
         for (auto changeIt = itBegin; changeIt != itEnd; ++changeIt ) {
@@ -133,8 +134,6 @@ protected:
             }
             }
         }
-
-        d_map.endEdit();
     }
 
     void processAddPoint(const sofa::defaulttype::Vec3d & pos, const typename In::VecCoord& in, MappingData & vectorData){

--- a/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h
@@ -68,6 +68,107 @@ protected:
     void computeDistance(double& d, const Vector3& v) override;
     void addPointInElement(const int elementIndex, const SReal* baryCoords) override;
 
+    //handle topology changes depending on the topology
+    void processTopologicalChanges(const typename Out::VecCoord& out, const typename In::VecCoord& in, core::topology::Topology* t) {
+        using sofa::core::behavior::MechanicalState;
+
+        if (t != this->m_toTopology) return;
+
+        if ( this->m_toTopology->beginChange() == this->m_toTopology->endChange() )
+            return;
+
+        std::list<const core::topology::TopologyChange *>::const_iterator itBegin = this->m_toTopology->beginChange();
+        std::list<const core::topology::TopologyChange *>::const_iterator itEnd = this->m_toTopology->endChange();
+
+        helper::vector<MappingData>& vectorData = *(d_map.beginEdit());
+        vectorData.resize (out.size());
+
+        for (auto changeIt = itBegin; changeIt != itEnd; ++changeIt ) {
+            const core::topology::TopologyChangeType changeType = ( *changeIt )->getChangeType();
+            switch ( changeType )
+            {
+            //TODO: implementation of BarycentricMapperHexahedronSetTopology<In,Out>::handleTopologyChange()
+            case core::topology::POINTSINDICESSWAP:  ///< For PointsIndicesSwap.
+            {
+                const core::topology::PointsIndicesSwap * ps = static_cast<const core::topology::PointsIndicesSwap*>(*changeIt);
+                MappingData copy = vectorData[ps->index[0]];
+                vectorData[ps->index[0]] = vectorData[ps->index[1]];
+                vectorData[ps->index[1]] = copy;
+                break;
+            }
+            case core::topology::POINTSADDED:        ///< For PointsAdded.
+            {
+                const core::topology::PointsAdded * pa = static_cast<const core::topology::PointsAdded*>(*changeIt);
+                auto& array = pa->getElementArray();
+
+                for (unsigned i=0;i<array.size();i++) {
+                    unsigned pid = array[i];
+                    processAddPoint(Out::getCPos(out[pid]),
+                                    in,
+                                    vectorData[pid]);
+                }
+
+                break;
+            }
+            case core::topology::POINTSREMOVED:      ///< For PointsRemoved.
+            {
+                // nothing to do
+                break;
+            }
+            case core::topology::POINTSRENUMBERING:  ///< For PointsRenumbering.
+            {
+                const core::topology::PointsRenumbering * pr = static_cast<const core::topology::PointsRenumbering*>(*changeIt);
+                auto& array = pr->getIndexArray();
+                auto& inv_array = pr->getinv_IndexArray();
+                for (unsigned i=0;i<array.size();i++) {
+                    MappingData copy = vectorData[array[i]];
+                    vectorData[inv_array[i]] = vectorData[array[i]];
+                    vectorData[array[i]] = copy;
+                }
+                break;
+            }
+            default:
+            {
+                break;
+            }
+            }
+        }
+
+        d_map.endEdit();
+    }
+
+    void processAddPoint(const sofa::defaulttype::Vec3d & pos, const typename In::VecCoord& in, MappingData & vectorData){
+        const sofa::helper::vector<core::topology::BaseMeshTopology::Tetrahedron>& tetrahedra = this->m_fromTopology->getTetrahedra();
+
+        sofa::defaulttype::Vector3 coefs;
+        int index = -1;
+        double distance = std::numeric_limits<double>::max();
+        for ( unsigned int t = 0; t < tetrahedra.size(); t++ )
+        {
+            sofa::defaulttype::Mat3x3d base;
+            sofa::defaulttype::Vector3 center;
+            computeBase(base,in,tetrahedra[t]);
+            computeCenter(center,in,tetrahedra[t]);
+
+            sofa::defaulttype::Vec3d v = base * ( pos - in[tetrahedra[t][0]] );
+            double d = std::max ( std::max ( -v[0],-v[1] ),std::max ( -v[2],v[0]+v[1]+v[2]-1 ) );
+
+            if ( d>0 ) d = ( pos-center ).norm2();
+
+            if ( d<distance )
+            {
+                coefs = v;
+                distance = d;
+                index = t;
+            }
+        }
+
+        vectorData.in_index = index;
+        vectorData.baryCoords[0] = ( Real ) coefs[0];
+        vectorData.baryCoords[1] = ( Real ) coefs[1];
+        vectorData.baryCoords[2] = ( Real ) coefs[2];
+    }
+
     topology::TetrahedronSetTopologyContainer*      m_fromContainer {nullptr};
     topology::TetrahedronSetGeometryAlgorithms<In>*	m_fromGeomAlgo  {nullptr};
 

--- a/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.inl
@@ -103,6 +103,112 @@ void BarycentricMapperTetrahedronSetTopology<In,Out>::addPointInElement(const in
     addPointInTetra(elementIndex,baryCoords);
 }
 
-}}}
+template <class In, class Out>
+void BarycentricMapperTetrahedronSetTopology<In, Out>::processTopologicalChanges(const typename Out::VecCoord& out, const typename In::VecCoord& in, core::topology::Topology* t)
+{
+    using sofa::core::behavior::MechanicalState;
+
+    if (t != m_toTopology) return;
+
+    if (m_toTopology->beginChange() == m_toTopology->endChange())
+        return;
+
+    auto itBegin = m_toTopology->beginChange();
+    auto itEnd = m_toTopology->endChange();
+
+    helper::WriteAccessor < Data< helper::vector<MappingData > > > vectorData = d_map;
+    vectorData.resize(out.size());
+
+    for (auto changeIt = itBegin; changeIt != itEnd; ++changeIt) {
+        const core::topology::TopologyChangeType changeType = (*changeIt)->getChangeType();
+        switch (changeType)
+        {
+            //TODO: implementation of BarycentricMapperHexahedronSetTopology<In,Out>::handleTopologyChange()
+        case core::topology::POINTSINDICESSWAP:  ///< For PointsIndicesSwap.
+        {
+            const core::topology::PointsIndicesSwap * ps = static_cast<const core::topology::PointsIndicesSwap*>(*changeIt);
+            MappingData copy = vectorData[ps->index[0]];
+            vectorData[ps->index[0]] = vectorData[ps->index[1]];
+            vectorData[ps->index[1]] = copy;
+            break;
+        }
+        case core::topology::POINTSADDED:        ///< For PointsAdded.
+        {
+            const core::topology::PointsAdded * pa = static_cast<const core::topology::PointsAdded*>(*changeIt);
+            auto& array = pa->getElementArray();
+
+            for (unsigned i = 0; i<array.size(); i++) {
+                unsigned pid = array[i];
+                processAddPoint(Out::getCPos(out[pid]),
+                    in,
+                    vectorData[pid]);
+            }
+
+            break;
+        }
+        case core::topology::POINTSREMOVED:      ///< For PointsRemoved.
+        {
+            // nothing to do
+            break;
+        }
+        case core::topology::POINTSRENUMBERING:  ///< For PointsRenumbering.
+        {
+            const core::topology::PointsRenumbering * pr = static_cast<const core::topology::PointsRenumbering*>(*changeIt);
+            auto& array = pr->getIndexArray();
+            auto& inv_array = pr->getinv_IndexArray();
+            for (unsigned i = 0; i<array.size(); i++) {
+                MappingData copy = vectorData[array[i]];
+                vectorData[inv_array[i]] = vectorData[array[i]];
+                vectorData[array[i]] = copy;
+            }
+            break;
+        }
+        default:
+        {
+            break;
+        }
+        }
+    }
+}
+
+template <class In, class Out>
+void BarycentricMapperTetrahedronSetTopology<In, Out>::processAddPoint(const sofa::defaulttype::Vec3d & pos, const typename In::VecCoord& in, MappingData & vectorData)
+{
+    const sofa::helper::vector<core::topology::BaseMeshTopology::Tetrahedron>& tetrahedra = this->m_fromTopology->getTetrahedra();
+
+    sofa::defaulttype::Vector3 coefs;
+    int index = -1;
+    double distance = std::numeric_limits<double>::max();
+    for (unsigned int t = 0; t < tetrahedra.size(); t++)
+    {
+        sofa::defaulttype::Mat3x3d base;
+        sofa::defaulttype::Vector3 center;
+        computeBase(base, in, tetrahedra[t]);
+        computeCenter(center, in, tetrahedra[t]);
+
+        sofa::defaulttype::Vec3d v = base * (pos - in[tetrahedra[t][0]]);
+        double d = std::max(std::max(-v[0], -v[1]), std::max(-v[2], v[0] + v[1] + v[2] - 1));
+
+        if (d>0) d = (pos - center).norm2();
+
+        if (d<distance)
+        {
+            coefs = v;
+            distance = d;
+            index = t;
+        }
+    }
+
+    vectorData.in_index = index;
+    vectorData.baryCoords[0] = (Real)coefs[0];
+    vectorData.baryCoords[1] = (Real)coefs[1];
+    vectorData.baryCoords[2] = (Real)coefs[2];
+}
+
+} // namespace mapping
+
+} // namespace component
+
+} // namespace sofa
 
 #endif

--- a/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/TopologyBarycentricMapper.h
+++ b/SofaKernel/modules/SofaBaseMechanics/BarycentricMappers/TopologyBarycentricMapper.h
@@ -79,6 +79,12 @@ public:
     virtual void updateForceMask(){/*mask is already filled in the mapper's applyJT*/}
     virtual void resize( core::State<Out>* toModel ) = 0;
 
+    void processTopologicalChanges(const typename Out::VecCoord& out, const typename In::VecCoord& in, core::topology::Topology* t) {
+        SOFA_UNUSED(t);
+        this->clear();
+        this->init(out,in);
+    }
+
 protected:
     TopologyBarycentricMapper(core::topology::BaseMeshTopology* fromTopology,
                               topology::PointSetTopologyContainer* toTopology = nullptr)

--- a/SofaKernel/modules/SofaBaseMechanics/BarycentricMapping.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/BarycentricMapping.inl
@@ -384,8 +384,12 @@ void BarycentricMapping<TIn, TOut>::applyJT(const core::ConstraintParams * cpara
 template <class TIn, class TOut>
 void BarycentricMapping<TIn, TOut>::handleTopologyChange ( core::topology::Topology* t )
 {
-    SOFA_UNUSED(t);
-    reinit(); // we now recompute the entire mapping when there is a topologychange
+    //foward topological modifications to the mapper
+    if (this->d_mapper.get()){
+        this->d_mapper->processTopologicalChanges(((const core::State<Out> *)this->toModel)->read(core::ConstVecCoordId::position())->getValue(),
+                                                  ((const core::State<In> *)this->fromModel)->read(core::ConstVecCoordId::position())->getValue(),
+                                                  t);
+    }
 }
 
 #ifdef BARYCENTRIC_MAPPER_TOPOCHANGE_REINIT

--- a/SofaKernel/modules/SofaBaseMechanics/BarycentricMapping.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/BarycentricMapping.inl
@@ -183,21 +183,26 @@ void BarycentricMapping<TIn, TOut>::createMapperFromTopology ()
     // Regular Grid Topology
     if (is_a<RegularGridTopology>(input_topology_container) ) {
         rgt = dynamic_cast<RegularGridTopology*>(input_topology_container);
-        if (rgt->hasVolume())
+        if (rgt->hasVolume()) {
+            msg_info() << "Creating RegularGridMapper";
             d_mapper = sofa::core::objectmodel::New<RegularGridMapper>(rgt, output_topology_container);
+        }
         goto end;
     }
 
     // Sparse Grid Topology
     if (is_a<SparseGridTopology>(input_topology_container) ) {
         sgt = dynamic_cast<SparseGridTopology*>(input_topology_container);
-        if (sgt->hasVolume())
+        if (sgt->hasVolume()) {
+            msg_info() << "Creating SparseGridMapper";
             d_mapper = sofa::core::objectmodel::New<SparseGridMapper>(sgt, output_topology_container);
+        }
         goto end;
     }
 
     // Hexahedron Topology
     if (is_a<HexahedronSetTopologyContainer>(input_topology_container)) {
+        msg_info() << "Creating HexahedronSetMapper";
         d_mapper = sofa::core::objectmodel::New<HexahedronSetMapper>(
             dynamic_cast<HexahedronSetTopologyContainer*>(input_topology_container), output_topology_container);
         goto end;
@@ -205,6 +210,7 @@ void BarycentricMapping<TIn, TOut>::createMapperFromTopology ()
 
     // Tetrahedron Topology
     if (is_a<TetrahedronSetTopologyContainer>(input_topology_container)) {
+        msg_info() << "Creating TetrahedronSetMapper";
         d_mapper = sofa::core::objectmodel::New<TetrahedronSetMapper >(
             dynamic_cast<TetrahedronSetTopologyContainer*>(input_topology_container), output_topology_container);
         goto end;
@@ -212,6 +218,7 @@ void BarycentricMapping<TIn, TOut>::createMapperFromTopology ()
 
     // Quad Topology
     if (is_a<QuadSetTopologyContainer>(input_topology_container)) {
+        msg_info() << "Creating QuadSetMapper";
         d_mapper = sofa::core::objectmodel::New<QuadSetMapper >(
             dynamic_cast<QuadSetTopologyContainer*>(input_topology_container), output_topology_container);
         goto end;
@@ -219,6 +226,7 @@ void BarycentricMapping<TIn, TOut>::createMapperFromTopology ()
 
     // Triangle Topology
     if (is_a<TriangleSetTopologyContainer>(input_topology_container)) {
+        msg_info() << "Creating TriangleSetMapper";
         d_mapper = sofa::core::objectmodel::New<TriangleSetMapper >(
             dynamic_cast<TriangleSetTopologyContainer*>(input_topology_container), output_topology_container);
         goto end;
@@ -226,6 +234,7 @@ void BarycentricMapping<TIn, TOut>::createMapperFromTopology ()
 
     // Edge Topology
     if (is_a<EdgeSetTopologyContainer>(input_topology_container)) {
+        msg_info() << "Creating EdgeSetMapper";
         d_mapper = sofa::core::objectmodel::New<EdgeSetMapper >(
             dynamic_cast<EdgeSetTopologyContainer*>(input_topology_container), output_topology_container);
         goto end;

--- a/examples/Components/mapping/BarycentricTetraMapping.scn
+++ b/examples/Components/mapping/BarycentricTetraMapping.scn
@@ -1,0 +1,39 @@
+<!-- Mechanical MassSpring Group Basic Example -->
+<Node name="root" dt="0.05" showBoundingTree="0" gravity="0 -9 1">
+    <RequiredPlugin name="SofaOpenglVisual"/>
+    <VisualStyle displayFlags="showVisual showBehaviorModels showMappings" />
+    <DefaultPipeline verbose="0" />
+    <BruteForceDetection name="N2" />
+    <DefaultContactManager response="default" />
+    <MinProximityIntersection name="Proximity" alarmDistance="0.8" contactDistance="0.5" />
+    
+    <Node name="MeshVolume" >
+        <RegularGridTopology name="HexaTop" n="7 7 7" min="-10 0 -10" max="10 20 10" />
+        <TetrahedronSetTopologyContainer name="Container" position="@HexaTop.position" />
+        <TetrahedronSetTopologyModifier name="Modifier"/>
+        <Hexa2TetraTopologicalMapping input="@HexaTop" output="@Container" swapping="false" />
+    </Node>
+
+    
+    <Node name="Deformable">
+        <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
+
+        <TetrahedronSetTopologyContainer name="Container" src="@../MeshVolume/Container" />
+        <TetrahedronSetTopologyModifier name="Modifier" />
+        <TetrahedronSetTopologyAlgorithms name="TopoAlgo"  template="Vec3d" />
+        <TetrahedronSetGeometryAlgorithms name="GeomAlgo"  template="Vec3d" />
+        
+        <MechanicalObject />
+        <DiagonalMass massDensity="10.0" />
+        <TetrahedronFEMForceField youngModulus="4000" poissonRatio="0.45" />
+        <BoxROI name="box" box="-10 19 -10 10 21 10" drawBoxes="true" />
+        <FixedConstraint  name="FixedConstraint" indices="@box.indices" activate_projectVelocity="1"/>
+     
+        <Node name="Visu">
+            <MeshObjLoader name="meshLoader_3" filename="mesh/torus.obj" handleSeams="1" translation="0 10 0" scale3d="4 4 4" />
+            <OglModel name="Visual" src="@meshLoader_3" color="red" />
+            <BarycentricMapping input="@.." output="@Visual" />
+        </Node>
+    </Node>
+</Node>


### PR DESCRIPTION
Modify the mapper in tetra barycentric mapping in order to listen for topological changes and only compute the added points. Previously the behaviour was to call reinit and recompute all the barycentric coordinates for the entire mesh at each topological modification.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
