### PR TITLE
[SofaSphFluid] Update rendering & other

### DIFF
--- a/applications/plugins/SofaSphFluid/examples/SPHParticleSink.scn
+++ b/applications/plugins/SofaSphFluid/examples/SPHParticleSink.scn
@@ -37,13 +37,6 @@
         <SpatialGridContainer cellWidth="0.75" />
         <SPHFluidForceField radius="0.7" density="25" kernelType="1" viscosityType="2" viscosity="10" pressure="1000" surfaceTension="-1000" printLog="0" />
 
-        <!--
-        <PlaneForceField normal="1 0 0" d="-4" showPlane="1" />        
-        <PlaneForceField normal="0.5 1 0.1" d="-4" showPlane="1" />
-        <PlaneForceField normal="0 0 1" d="-4" showPlane="1" />
-        <PlaneForceField normal="0 0 -1" d="-4" showPlane="1" />
-        
-        <BoxROI name="ROI1" box="10 -20 -20 20 20 20" drawBoxes="1" drawPoints="1" position="@MModel.position"/>-->
         <ParticleSink name="sink" normal="0 1 0" d0="0" d1="-1" showPlane="1" printLog="0" />
         
     </Node>

--- a/applications/plugins/SofaSphFluid/examples/SPHParticleSink_obstacle.scn
+++ b/applications/plugins/SofaSphFluid/examples/SPHParticleSink_obstacle.scn
@@ -1,0 +1,76 @@
+<?xml version="1.0" ?>
+<Node dt="0.01" gravity="0 -10 0" bbox="-4 -4 -4 4 4 4">
+    <RequiredPlugin name="SofaOpenglVisual"/> 
+    <RequiredPlugin name='SofaSphFluid' />
+    <VisualStyle displayFlags="hideBehaviorModels hideForceFields hideWireframe" />
+
+    <DefaultPipeline depth="15" verbose="0" draw="0" />
+    <BruteForceDetection name="N2" />
+    <NewProximityIntersection name="Proximity" alarmDistance="1.0" contactDistance="0.5" />
+    <DefaultContactManager name="Response" response="default" /> 
+
+    <Node name="Particles">
+        <EulerSolver symplectic="1" />
+        <MechanicalObject name="MModel" />
+        <ParticleSource name="Source" translation="0 10 0" radius="0.01 0.1 0.01" velocity="0 -10 0" delay="0.02" start="-0.1" stop="4" printLog="0"
+        center="-0.375 0 -0.75 
+            0.0 0.0 -0.75 
+            0.375 0.0 -0.75 
+            -0.75  0.0 -0.375 
+            -0.375 0.0 -0.375 
+            0.0 0.0 -0.375 
+            0.375 0.0 -0.375 
+            0.75 0.0 -0.375 
+            -0.75 0.0 0.0 
+            -0.375 0.0 0.0 
+            0.0 0.0 0.0 
+            0.375 0.0 0.0 
+            0.75 0.0 0.0 
+            -0.75 0.0 0.375 
+            -0.375 0.0 0.375 
+            0.0 0.0 0.375 
+            0.375 0.0 0.375 
+            0.75 0.0 0.375 
+            -0.375 0.0 0.75 
+            0.0 0.0 0.75 
+            0.375 0.0 0.75"  />
+        
+        
+        <PointSetTopologyContainer name="con" />
+        <PointSetTopologyModifier name="mod" />
+        <UniformMass name="M1" totalMass="1.0" />
+        <SpatialGridContainer cellWidth="0.75" />
+        <SPHFluidForceField radius="0.7" density="25" kernelType="1" viscosityType="2" viscosity="10" pressure="1000" surfaceTension="-1000" printLog="0" />
+
+        <!--
+        <PlaneForceField normal="1 0 0" d="-4" showPlane="1" />        
+        <PlaneForceField normal="0.5 1 0.1" d="-4" showPlane="1" />
+        <PlaneForceField normal="0 0 1" d="-4" showPlane="1" />
+        <PlaneForceField normal="0 0 -1" d="-4" showPlane="1" />
+        
+        <BoxROI name="ROI1" box="10 -20 -20 20 20 20" drawBoxes="1" drawPoints="1" position="@MModel.position"/>-->
+        <ParticleSink name="sink" normal="0 1 0" d0="0" d1="-1" showPlane="1" printLog="0" />
+        <Node name="Collision">
+            <MechanicalObject />
+            <SphereCollisionModel radius="0.05" showImpostors="true" />
+            <IdentityMapping />
+        </Node>
+        <Node name="Fluid" >            
+            <OglFluidModel template="Vec3d" position="@../MModel.position" 
+            debugFBO="9" 
+            spriteRadius="0.5" spriteThickness="0.015" spriteBlurRadius="10" spriteBlurScale="10" spriteBlurDepthFalloff="1"  />
+        </Node>
+        
+    </Node>
+
+    <Node name="Obstacle" >            
+        <Node name="Collision" >            
+            <MechanicalObject template="Vec3d" position="0 0 0" />
+            <SphereCollisionModel radius="1.0" showImpostors="false" contactStiffness="100" />
+        </Node>    
+        <Node name="Visual" >   
+            <MeshObjLoader name="loader" filename="mesh/sphere.obj" />         
+            <OglModel src="@loader" />
+        </Node>   
+    </Node>
+</Node>

--- a/applications/plugins/SofaSphFluid/examples/SPHParticleSink_obstacle.scn
+++ b/applications/plugins/SofaSphFluid/examples/SPHParticleSink_obstacle.scn
@@ -42,13 +42,6 @@
         <SpatialGridContainer cellWidth="0.75" />
         <SPHFluidForceField radius="0.7" density="25" kernelType="1" viscosityType="2" viscosity="10" pressure="1000" surfaceTension="-1000" printLog="0" />
 
-        <!--
-        <PlaneForceField normal="1 0 0" d="-4" showPlane="1" />        
-        <PlaneForceField normal="0.5 1 0.1" d="-4" showPlane="1" />
-        <PlaneForceField normal="0 0 1" d="-4" showPlane="1" />
-        <PlaneForceField normal="0 0 -1" d="-4" showPlane="1" />
-        
-        <BoxROI name="ROI1" box="10 -20 -20 20 20 20" drawBoxes="1" drawPoints="1" position="@MModel.position"/>-->
         <ParticleSink name="sink" normal="0 1 0" d0="0" d1="-1" showPlane="1" printLog="0" />
         <Node name="Collision">
             <MechanicalObject />

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/OglFluidModel.h
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/OglFluidModel.h
@@ -53,6 +53,7 @@ private:
     helper::gl::GLSLShader m_spriteBlurDepthShader;
     helper::gl::GLSLShader m_spriteBlurThicknessShader;
     helper::gl::GLSLShader m_spriteShadeShader;
+    helper::gl::GLSLShader m_spriteFinalPassShader;
 
     void drawSprites(const core::visual::VisualParams* vparams);
     void updateVertexBuffer();
@@ -74,6 +75,7 @@ public:
     void fwdDraw(core::visual::VisualParams*) override;
     void bwdDraw(core::visual::VisualParams*) override;
     void drawVisual(const core::visual::VisualParams* vparams) override;
+    void drawTransparent(const core::visual::VisualParams* vparams) override;
     void computeBBox(const core::ExecParams* params, bool onlyVisible = false) override;
 
     virtual void updateVisual() override;

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/shaders/spriteFinalPass.cppglsl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/shaders/spriteFinalPass.cppglsl
@@ -1,0 +1,57 @@
+
+namespace sofa
+{
+
+namespace component
+{
+
+namespace visualmodel
+{
+
+namespace shader
+{
+
+const std::string spriteFinalPassVS = R"SHADER_DELIM(
+#version 120
+
+varying vec2 v_texcoord;
+
+void main(void)
+{
+	v_texcoord = (gl_Vertex.xy + 1.0) / 2.0;
+    gl_Position = ftransform();
+}
+
+)SHADER_DELIM";
+
+//////////////////////
+const std::string spriteFinalPassFS = R"SHADER_DELIM(
+#version 120
+
+uniform sampler2D u_colorTexture;
+uniform sampler2D u_depthTexture;
+
+varying vec2 v_texcoord;
+
+void main(void)
+{
+	vec4 color = texture2D(u_colorTexture, v_texcoord);
+	float depth = texture2D(u_depthTexture, v_texcoord).x;
+
+	if(depth > 0.999999)
+		discard;
+
+	gl_FragDepth = depth;
+	gl_FragColor = color;
+
+}
+
+)SHADER_DELIM";
+
+} //shader
+
+} //visualmodel
+
+} //component
+
+} //sofa

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/shaders/spriteShade.cppglsl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/shaders/spriteShade.cppglsl
@@ -87,7 +87,9 @@ void main(void)
 	diffuse = (1 - distPwr) * diffuse + distPwr * backgroundDistorsion;
 
 	vec4 finalColor = diffuse + specular;
-
+	finalColor.a = thickness;
+    
+	gl_FragDepth = depth;
 	gl_FragColor = finalColor;
 
 }


### PR DESCRIPTION
* Add blending, therefore keeps background and other opaque models (but rendering is still better with a whitish background)
* Add scene with collisions
* Add an example of the execution policy (std::execution::par) introduced by c++17 in the brute-force findNeighbors() in the forcefield (faster than the spatialgrid if nbParticles is approx less than 5K)


Blending should be temporary, and having a multi pass would be better (refraction, etc)
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
