### PR TITLE
[All] up change on GetMeshTopology

### DIFF
--- a/SofaKernel/modules/SofaBaseCollision/CapsuleModel.h
+++ b/SofaKernel/modules/SofaBaseCollision/CapsuleModel.h
@@ -171,12 +171,21 @@ public:
         return DataTypes::Name();
     }
 
+    sofa::core::topology::BaseMeshTopology* getCollisionTopology() override
+    {
+        return l_topology.get();
+    }
+
     /**
       *Returns true if capsules at indexes i1 and i2 share the same vertex.
       */
     bool shareSameVertex(int i1,int i2)const;
 
     Data<VecReal > & writeRadii();
+
+    /// Link to be set to the topology container in the component graph.
+    SingleLink<TCapsuleModel<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
+
 protected:
     core::behavior::MechanicalState<DataTypes>* _mstate;
 };

--- a/SofaKernel/modules/SofaBaseCollision/CapsuleModel.inl
+++ b/SofaKernel/modules/SofaBaseCollision/CapsuleModel.inl
@@ -44,19 +44,18 @@ namespace collision
 {
 
 template<class DataTypes>
-TCapsuleModel<DataTypes>::TCapsuleModel():
-      _capsule_radii(initData(&_capsule_radii, "listCapsuleRadii","Radius of each capsule")),
-      _default_radius(initData(&_default_radius,(Real)0.5,"defaultRadius","The default radius")),
-      _mstate(nullptr)
+TCapsuleModel<DataTypes>::TCapsuleModel()
+    : TCapsuleModel(nullptr)
 {
     enum_type = CAPSULE_TYPE;
 }
 
 template<class DataTypes>
-TCapsuleModel<DataTypes>::TCapsuleModel(core::behavior::MechanicalState<DataTypes>* mstate):
-    _capsule_radii(initData(&_capsule_radii, "listCapsuleRadii","Radius of each capsule")),
-    _default_radius(initData(&_default_radius,(Real)0.5,"defaultRadius","The default radius")),
-    _mstate(mstate)
+TCapsuleModel<DataTypes>::TCapsuleModel(core::behavior::MechanicalState<DataTypes>* mstate)
+    : _capsule_radii(initData(&_capsule_radii, "listCapsuleRadii", "Radius of each capsule"))
+    , _default_radius(initData(&_default_radius, (Real)0.5, "defaultRadius", "The default radius"))
+    , l_topology(initLink("topology", "link to the topology container"))
+    , _mstate(mstate)
 {
     enum_type = CAPSULE_TYPE;
 }
@@ -94,10 +93,19 @@ void TCapsuleModel<DataTypes>::init()
         return;
     }
 
-    core::topology::BaseMeshTopology *bmt = getContext()->getMeshTopology();
+    if (l_topology.empty())
+    {
+        msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
+        l_topology.set(this->getContext()->getMeshTopologyLink());
+    }
+
+    core::topology::BaseMeshTopology *bmt = l_topology.get();
+    msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
+
     if (!bmt)
     {
-        msg_error()<<"CapsuleModel requires a MeshTopology";
+        msg_error() << "No topology component found at path: " << l_topology.getLinkedPath() << ", nor in current context: " << this->getContext()->name;
+        sofa::core::objectmodel::BaseObject::d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         return;
     }
 
@@ -122,7 +130,7 @@ void TCapsuleModel<DataTypes>::computeBoundingTree(int maxDepth)
 {
     using namespace sofa::defaulttype;
     CubeModel* cubeModel = createPrevious<CubeModel>();
-    const int ncap = getContext()->getMeshTopology()->getNbEdges();
+    const int ncap = l_topology.get()->getNbEdges();
     bool updated = false;
     if (ncap != size)
     {

--- a/SofaKernel/modules/SofaBaseCollision/OBBModel.inl
+++ b/SofaKernel/modules/SofaBaseCollision/OBBModel.inl
@@ -36,7 +36,6 @@
 #include <SofaBaseCollision/CubeModel.h>
 #include <sofa/core/ObjectFactory.h>
 
-#include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/simulation/Simulation.h>
 
 namespace sofa

--- a/SofaKernel/modules/SofaBaseCollision/RigidCapsuleModel.inl
+++ b/SofaKernel/modules/SofaBaseCollision/RigidCapsuleModel.inl
@@ -33,7 +33,6 @@
 #include <SofaBaseCollision/CubeModel.h>
 #include <sofa/core/ObjectFactory.h>
 
-#include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/simulation/Simulation.h>
 
 namespace sofa
@@ -186,7 +185,6 @@ void TCapsuleModel<sofa::defaulttype::StdRigidTypes<3,MyReal> >::draw(const core
         vparams->drawTool()->setPolygonMode(0,vparams->displayFlags().getShowWireFrame());//maybe ??
         vparams->drawTool()->setLightingEnabled(true); //Enable lightning
 
-        // Check topological modifications
         for (int i=0; i<size; i++){
             vparams->drawTool()->drawCapsule(point1(i),point2(i),(float)radius(i),col4f);
         }

--- a/SofaKernel/modules/SofaBaseCollision/SphereModel.inl
+++ b/SofaKernel/modules/SofaBaseCollision/SphereModel.inl
@@ -33,7 +33,6 @@
 #include <SofaBaseCollision/CubeModel.h>
 #include <sofa/core/ObjectFactory.h>
 
-#include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/simulation/Simulation.h>
 
 #include <sofa/core/objectmodel/BaseObject.h>

--- a/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.cpp
@@ -153,7 +153,7 @@ void DiagonalMass<RigidTypes, RigidMass>::initRigidImpl()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.inl
@@ -569,7 +569,8 @@ bool DiagonalMass<DataTypes, MassType>::checkTopology()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
+
     }
 
     m_topology = l_topology.get();

--- a/SofaKernel/modules/SofaBaseMechanics/MappedObject.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/MappedObject.inl
@@ -52,7 +52,7 @@ void MappedObject<DataTypes>::init()
 {
     if (getSize() == 0)
     {
-        sofa::core::topology::BaseMeshTopology* topo = this->getContext()->getActiveMeshTopology();
+        sofa::core::topology::BaseMeshTopology* topo = this->getContext()->getMeshTopology();
         if (topo!=nullptr && topo->hasPos())
         {
             VecCoord& x = *getX();

--- a/SofaKernel/modules/SofaBaseMechanics/MappedObject.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/MappedObject.inl
@@ -24,7 +24,7 @@
 
 #include <SofaBaseMechanics/MappedObject.h>
 #include <sofa/core/visual/VisualParams.h>
-#include <sofa/core/topology/BaseMeshTopology.h>
+#include <sofa/core/behavior/BaseMechanicalState.h>
 
 namespace sofa
 {
@@ -51,16 +51,16 @@ template <class DataTypes>
 void MappedObject<DataTypes>::init()
 {
     if (getSize() == 0)
-    {
-        sofa::core::topology::BaseMeshTopology* topo = this->getContext()->getMeshTopology();
-        if (topo!=nullptr && topo->hasPos())
+    {        
+        sofa::core::behavior::BaseMechanicalState* mstate = this->getContext()->getMechanicalState();
+        int nbp = mstate->getSize();
+        if (nbp > 0)
         {
             VecCoord& x = *getX();
-            int nbp = topo->getNbPoints();
             x.resize(nbp);
             for (int i=0; i<nbp; i++)
             {
-                DataTypes::set(x[i], topo->getPX(i), topo->getPY(i), topo->getPZ(i));
+                DataTypes::set(x[i], mstate->getPX(i), mstate->getPY(i), mstate->getPZ(i));
             }
         }
     }

--- a/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.inl
@@ -1082,7 +1082,7 @@ void MechanicalObject<DataTypes>::init()
 {
     if (!l_topology && d_useTopology.getValue())
     {
-        l_topology.set( this->getContext()->getActiveMeshTopology() );
+        l_topology.set( this->getContext()->getMeshTopology(sofa::simulation::Node::Local) );
     }
 
     if (l_topology)

--- a/SofaKernel/modules/SofaBaseMechanics/SubsetMapping.h
+++ b/SofaKernel/modules/SofaBaseMechanics/SubsetMapping.h
@@ -103,6 +103,9 @@ public:
     Data < bool > f_resizeToModel; ///< True to resize the output MechanicalState to match the size of indices
     SubsetMappingInternalData<In, Out> data;
     void postInit();
+    /// Link to be set to the topology container in the component graph. 
+    SingleLink<SubsetMapping<In, Out>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
+
 protected:
     SubsetMapping();
 public:
@@ -137,9 +140,6 @@ public:
 protected:
     std::unique_ptr<MatrixType> matrixJ;
     bool updateJ;
-
-    /// Pointer to the current topology
-    sofa::core::topology::BaseMeshTopology* topology;
 };
 
 #if  !defined(SOFA_COMPONENT_MAPPING_SUBSETMAPPING_CPP)

--- a/SofaKernel/modules/SofaBaseMechanics/SubsetMapping.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/SubsetMapping.inl
@@ -175,6 +175,7 @@ void SubsetMapping<TIn, TOut>::init()
         else
         {
             msg_error() << "f_handleTopologyChange set to True but no topology component found at path: " << l_topology.getLinkedPath() << ", nor in current context: " << this->getContext()->name;
+            sofa::core::objectmodel::BaseObject::d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         }
     }
 

--- a/SofaKernel/modules/SofaBaseMechanics/SubsetMapping.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/SubsetMapping.inl
@@ -48,6 +48,7 @@ SubsetMapping<TIn, TOut>::SubsetMapping()
     , f_resizeToModel( initData(&f_resizeToModel, false, "resizeToModel", "True to resize the output MechanicalState to match the size of indices"))
     , matrixJ()
     , updateJ(false)
+    , l_topology(initLink("topology", "link to the topology container"))
 {
 }
 
@@ -152,14 +153,29 @@ void SubsetMapping<TIn, TOut>::init()
         f_indices.endEdit();
     }
     this->Inherit::init();
-
-    topology = this->getContext()->getMeshTopology();
-
+    
     if (f_handleTopologyChange.getValue())
     {
-        // Initialize functions and parameters for topological changes
-        f_indices.createTopologicalEngine(topology);
-        f_indices.registerTopologicalData();
+        if (l_topology.empty())
+        {
+            msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
+            l_topology.set(this->getContext()->getMeshTopologyLink());
+
+        }
+
+        sofa::core::topology::BaseMeshTopology* topology = l_topology.get();
+        msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
+
+        if (topology)
+        {
+            // Initialize functions and parameters for topological changes
+            f_indices.createTopologicalEngine(topology);
+            f_indices.registerTopologicalData();
+        }
+        else
+        {
+            msg_error() << "f_handleTopologyChange set to True but no topology component found at path: " << l_topology.getLinkedPath() << ", nor in current context: " << this->getContext()->name;
+        }
     }
 
     postInit();

--- a/SofaKernel/modules/SofaBaseMechanics/SubsetMapping.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/SubsetMapping.inl
@@ -174,7 +174,7 @@ void SubsetMapping<TIn, TOut>::init()
         }
         else
         {
-            msg_error() << "f_handleTopologyChange set to True but no topology component found at path: " << l_topology.getLinkedPath() << ", nor in current context: " << this->getContext()->name;
+            msg_error() << "No topology component found at path: " << l_topology.getLinkedPath() << ", nor in current context: " << this->getContext()->name << " Set handleTopologyChange to false if topology is not needed.";
             sofa::core::objectmodel::BaseObject::d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         }
     }

--- a/SofaKernel/modules/SofaBaseMechanics/UniformMass.h
+++ b/SofaKernel/modules/SofaBaseMechanics/UniformMass.h
@@ -28,6 +28,7 @@
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/defaulttype/BaseVector.h>
 #include <sofa/core/objectmodel/DataFileName.h>
+#include <sofa/core/topology/BaseMeshTopology.h>
 
 namespace sofa
 {
@@ -87,6 +88,8 @@ public:
 
     bool m_doesTopoChangeAffect;
 
+    /// Link to be set to the topology container in the component graph.
+    SingleLink <UniformMass<DataTypes, MassType>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
 protected:
     UniformMass();

--- a/SofaKernel/modules/SofaBaseMechanics/UniformMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/UniformMass.inl
@@ -88,6 +88,7 @@ UniformMass<DataTypes, MassType>::UniformMass()
     , d_indices ( initData ( &d_indices, "indices", "optional local DOF indices. Any computation involving only indices outside of this list are discarded" ) )
     , d_handleTopoChange ( initData ( &d_handleTopoChange, false, "handleTopoChange", "The mass and totalMass are recomputed on particles add/remove." ) )
     , d_preserveTotalMass( initData ( &d_preserveTotalMass, false, "preserveTotalMass", "Prevent totalMass from decreasing when removing particles."))
+    , l_topology(initLink("topology", "link to the topology container"))
 {
     constructor_message();
 }
@@ -354,7 +355,15 @@ void UniformMass<DataTypes, MassType>::initFromTotalMass()
 template <class DataTypes, class MassType>
 void UniformMass<DataTypes, MassType>::handleTopologyChange()
 {
-    BaseMeshTopology *meshTopology = getContext()->getMeshTopology();
+    if (l_topology.empty())
+    {
+        msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
+        l_topology.set(this->getContext()->getMeshTopologyLink());
+    }
+
+    BaseMeshTopology *meshTopology = l_topology.get();
+    msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
+
     WriteAccessor<Data<vector<int> > > indices = d_indices;
 
     if(m_doesTopoChangeAffect)

--- a/SofaKernel/modules/SofaBaseTopology/PointSetGeometryAlgorithms.h
+++ b/SofaKernel/modules/SofaBaseTopology/PointSetGeometryAlgorithms.h
@@ -130,6 +130,9 @@ protected:
     Data<bool> d_showPointIndices; ///< Debug : view Point indices
     /// Tage of the Mechanical State associated with the vertex position
     Data<std::string> d_tagMechanics;
+
+    /// Link to be set to the topology container in the component graph.
+    SingleLink<PointSetGeometryAlgorithms<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 };
 
 #if  !defined(SOFA_COMPONENT_TOPOLOGY_POINTSETGEOMETRYALGORITHMS_CPP)

--- a/SofaKernel/modules/SofaBaseVisual/VisualModelImpl.h
+++ b/SofaKernel/modules/SofaBaseVisual/VisualModelImpl.h
@@ -226,6 +226,9 @@ public:
 
     Data< helper::vector<sofa::core::loader::Material> > materials;
     Data< helper::vector<FaceGroup> > groups;
+
+    /// Link to be set to the topology container in the component graph.
+    SingleLink <VisualModelImpl, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 protected:
     /// Default constructor.
     VisualModelImpl();

--- a/SofaKernel/modules/SofaCore/src/sofa/core/CollisionModel.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/CollisionModel.h
@@ -344,12 +344,8 @@ public:
     void setGroups(const std::set<int>& ids) { group.setValue(ids); }
     /// @}
 
-
-    /// Topology associated to the collision model
-    virtual Topology* getTopology() { return getContext()->getMeshTopology(); }
-
-    /// BaseMeshTopology associated to the collision model
-    virtual sofa::core::topology::BaseMeshTopology* getMeshTopology() { return getContext()->getMeshTopology(); }
+    /// BaseMeshTopology associated to the collision model. TODO: epernod remove virtual pure method by l_topology.get as soons as new link will be available
+    virtual sofa::core::topology::BaseMeshTopology* getCollisionTopology() { return nullptr; }
 
     /// Get a color that can be used to display this CollisionModel
     const float* getColor4f();

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseContext.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseContext.cpp
@@ -170,22 +170,14 @@ core::topology::Topology* BaseContext::getTopology() const
 }
 
 /// Mesh Topology (unified interface for both static and dynamic topologies)
-core::topology::BaseMeshTopology* BaseContext::getMeshTopology() const
+core::topology::BaseMeshTopology* BaseContext::getMeshTopology(SearchDirection dir) const
 {
-    return this->get<sofa::core::topology::BaseMeshTopology>();
+    return this->get<sofa::core::topology::BaseMeshTopology>(dir);
 }
 
-/// Mesh Topology that is local to this context (i.e. not within parent contexts)
-core::topology::BaseMeshTopology* BaseContext::getLocalMeshTopology() const
+core::topology::BaseMeshTopology* BaseContext::getMeshTopologyLink(SearchDirection dir) const
 {
-    return this->get<sofa::core::topology::BaseMeshTopology>(Local);
-}
-
-/// Mesh Topology that is relevant for this context
-/// (within it or its parents until a mapping is reached that does not preserve topologies).
-core::topology::BaseMeshTopology* BaseContext::getActiveMeshTopology() const
-{
-    return this->get<sofa::core::topology::BaseMeshTopology>(Local);
+    return this->get<sofa::core::topology::BaseMeshTopology>(dir);
 }
 
 /// Shader

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseContext.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseContext.h
@@ -135,14 +135,10 @@ public:
     virtual core::topology::Topology* getTopology() const;
 
     /// Mesh Topology (unified interface for both static and dynamic topologies)
-    virtual core::topology::BaseMeshTopology* getMeshTopology() const;
+    virtual core::topology::BaseMeshTopology* getMeshTopology(SearchDirection dir = SearchUp) const;
 
-    /// Mesh Topology that is local to this context (i.e. not within parent contexts)
-    virtual core::topology::BaseMeshTopology* getLocalMeshTopology() const;
-
-    /// Mesh Topology that is relevant for this context, either local or within
-    /// a parent until a mapping is reached that does not preserve topologies.
-    virtual core::topology::BaseMeshTopology* getActiveMeshTopology() const;
+    /// Mesh Topology (unified interface for both static and dynamic topologies)
+    virtual core::topology::BaseMeshTopology* getMeshTopologyLink(SearchDirection dir = SearchUp) const;
 
     /// Mass
     virtual core::behavior::BaseMass* getMass() const;

--- a/SofaKernel/modules/SofaDeformable/MeshSpringForceField.inl
+++ b/SofaKernel/modules/SofaDeformable/MeshSpringForceField.inl
@@ -111,7 +111,7 @@ void MeshSpringForceField<DataTypes>::init()
         if (l_topology.empty())
         {
             msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-            l_topology.set(this->getContext()->getMeshTopology());
+            l_topology.set(this->getContext()->getMeshTopologyLink());
         }
 
         sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();

--- a/SofaKernel/modules/SofaMeshCollision/BarycentricContactMapper.h
+++ b/SofaKernel/modules/SofaMeshCollision/BarycentricContactMapper.h
@@ -151,13 +151,13 @@ public:
     typedef typename DataTypes::Coord Coord;
     int addPoint(const Coord& P, int index, Real&)
     {
-        int nbt = this->model->getMeshTopology()->getNbTriangles();
+        int nbt = this->model->getCollisionTopology()->getNbTriangles();
         if (index < nbt)
             return this->mapper->createPointInTriangle(P, index, &this->model->getMechanicalState()->read(core::ConstVecCoordId::position())->getValue());
         else
         {
             int qindex = (index - nbt)/2;
-            int nbq = this->model->getMeshTopology()->getNbQuads();
+            int nbq = this->model->getCollisionTopology()->getNbQuads();
             if (qindex < nbq)
                 return this->mapper->createPointInQuad(P, qindex, &this->model->getMechanicalState()->read(core::ConstVecCoordId::position())->getValue());
             else
@@ -171,14 +171,14 @@ public:
     int addPointB(const Coord& P, int index, Real& /*r*/, const defaulttype::Vector3& baryP)
     {
 
-        int nbt = this->model->getMeshTopology()->getNbTriangles();
+        int nbt = this->model->getCollisionTopology()->getNbTriangles();
         if (index < nbt)
             return this->mapper->addPointInTriangle(index, baryP.ptr());
         else
         {
             // TODO: barycentric coordinates usage for quads
             int qindex = (index - nbt)/2;
-            int nbq = this->model->getMeshTopology()->getNbQuads();
+            int nbq = this->model->getCollisionTopology()->getNbQuads();
             if (qindex < nbq)
                 return this->mapper->createPointInQuad(P, qindex, &this->model->getMechanicalState()->read(core::ConstVecCoordId::position())->getValue());
             else

--- a/SofaKernel/modules/SofaMeshCollision/BarycentricContactMapper.inl
+++ b/SofaKernel/modules/SofaMeshCollision/BarycentricContactMapper.inl
@@ -70,9 +70,8 @@ typename BarycentricContactMapper<TCollisionModel,DataTypes>::MMechanicalState* 
     simulation::Node::SPtr child = parent->createChild(name);
     typename MMechanicalObject::SPtr mstate = sofa::core::objectmodel::New<MMechanicalObject>();
     child->addObject(mstate);
-    //mapping = new MMapping(model->getMechanicalState(), mstate, model->getMeshTopology());
     //mapper = mapping->getMapper();
-    mapper = sofa::core::objectmodel::New<mapping::BarycentricMapperMeshTopology<InDataTypes, typename BarycentricContactMapper::DataTypes> >(model->getMeshTopology(), (topology::PointSetTopologyContainer*)nullptr);
+    mapper = sofa::core::objectmodel::New<mapping::BarycentricMapperMeshTopology<InDataTypes, typename BarycentricContactMapper::DataTypes> >(model->getCollisionTopology(), (topology::PointSetTopologyContainer*)nullptr);
     mapper->maskFrom = &model->getMechanicalState()->forceMask;
     mapper->maskTo = &mstate->forceMask;
     mapping =  sofa::core::objectmodel::New<MMapping>(model->getMechanicalState(), mstate.get(), mapper);

--- a/SofaKernel/modules/SofaMeshCollision/LineModel.h
+++ b/SofaKernel/modules/SofaMeshCollision/LineModel.h
@@ -181,19 +181,25 @@ public:
         return DataTypes::Name();
     }
 
+    sofa::core::topology::BaseMeshTopology* getCollisionTopology() override
+    {
+        return l_topology.get();
+    }
+
     void computeBBox(const core::ExecParams* params, bool onlyVisible) override;
 
+    Data< std::string  > LineActiverPath; ///< path of a component LineActiver that activates or deactivates collision line during execution
+    Data<bool> m_displayFreePosition; ///< Display Collision Model Points free position(in green)
+
+    /// Link to be set to the topology container in the component graph.
+    SingleLink<LineCollisionModel<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
 protected:
-
     core::behavior::MechanicalState<DataTypes>* mstate;
     Topology* topology;
     PointModel* mpoints;
     int meshRevision;
     LineLocalMinDistanceFilter *m_lmdFilter;
-
-    Data< std::string  > LineActiverPath; ///< path of a component LineActiver that activates or deactivates collision line during execution
-    Data<bool> m_displayFreePosition; ///< Display Collision Model Points free position(in green)
 
     LineActiver *myActiver;
 

--- a/SofaKernel/modules/SofaMeshCollision/PointModel.h
+++ b/SofaKernel/modules/SofaMeshCollision/PointModel.h
@@ -151,6 +151,11 @@ public:
     void computeBBox(const core::ExecParams* params, bool onlyVisible) override;
     void updateNormals();
 
+    sofa::core::topology::BaseMeshTopology* getCollisionTopology() override
+    {
+        return l_topology.get();
+    }
+
 protected:
 
     core::behavior::MechanicalState<DataTypes>* mstate;
@@ -164,7 +169,11 @@ protected:
     PointLocalMinDistanceFilter *m_lmdFilter;
     EmptyFilter m_emptyFilter;
 
-    Data<bool> m_displayFreePosition; ///< Display Collision Model Points free position(in green)    
+    Data<bool> m_displayFreePosition; ///< Display Collision Model Points free position(in green)
+                                      
+    /// Link to be set to the topology container in the component graph.
+    SingleLink<PointCollisionModel<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
+
 
     PointActiver *myActiver;
 };

--- a/SofaKernel/modules/SofaMeshCollision/PointModel.inl
+++ b/SofaKernel/modules/SofaMeshCollision/PointModel.inl
@@ -364,7 +364,7 @@ bool TPoint<DataTypes>::testLMD(const defaulttype::Vector3 &PQ, double &coneFact
 
     defaulttype::Vector3 pt = p();
 
-    sofa::core::topology::BaseMeshTopology* mesh = l_topology.get();
+    sofa::core::topology::BaseMeshTopology* mesh = this->model->l_topology.get();
     const typename DataTypes::VecCoord& x = (*this->model->mstate->read(sofa::core::ConstVecCoordId::position())->getValue());
 
     const helper::vector <unsigned int>& trianglesAroundVertex = mesh->getTrianglesAroundVertex(this->index);

--- a/SofaKernel/modules/SofaMeshCollision/TriangleLocalMinDistanceFilter.cpp
+++ b/SofaKernel/modules/SofaMeshCollision/TriangleLocalMinDistanceFilter.cpp
@@ -83,6 +83,7 @@ TriangleLocalMinDistanceFilter::TriangleLocalMinDistanceFilter()
     , pointInfoHandler(nullptr)
     , lineInfoHandler(nullptr)
     , triangleInfoHandler(nullptr)
+    , l_topology(initLink("topology", "link to the topology container"))
     , bmt(nullptr)
 {
 }
@@ -96,8 +97,14 @@ TriangleLocalMinDistanceFilter::~TriangleLocalMinDistanceFilter()
 
 void TriangleLocalMinDistanceFilter::init()
 {
-    bmt = getContext()->getMeshTopology();
-    msg_info() << "Mesh Topology found :" << bmt->getName();
+    if (l_topology.empty())
+    {
+        msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
+        l_topology.set(this->getContext()->getMeshTopologyLink());
+    }
+
+    bmt = l_topology.get();
+    msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
     component::container::MechanicalObject<sofa::defaulttype::Vec3Types>*  mstateVec3d= dynamic_cast<component::container::MechanicalObject<Vec3Types>*>(getContext()->getMechanicalState());
 
 

--- a/SofaKernel/modules/SofaMeshCollision/TriangleLocalMinDistanceFilter.h
+++ b/SofaKernel/modules/SofaMeshCollision/TriangleLocalMinDistanceFilter.h
@@ -185,7 +185,7 @@ public:
     };
 
     /// Link to be set to the topology container in the component graph.
-    SingleLink<LineCollisionModel<TriangleLocalMinDistanceFilter>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
+    SingleLink<TriangleLocalMinDistanceFilter, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
 private:
     topology::PointData< sofa::helper::vector<PointInfo> > m_pointInfo; ///< point filter data

--- a/SofaKernel/modules/SofaMeshCollision/TriangleLocalMinDistanceFilter.h
+++ b/SofaKernel/modules/SofaMeshCollision/TriangleLocalMinDistanceFilter.h
@@ -184,6 +184,9 @@ public:
         TriangleLocalMinDistanceFilter* f;
     };
 
+    /// Link to be set to the topology container in the component graph.
+    SingleLink<LineCollisionModel<TriangleLocalMinDistanceFilter>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
+
 private:
     topology::PointData< sofa::helper::vector<PointInfo> > m_pointInfo; ///< point filter data
     topology::EdgeData< sofa::helper::vector<LineInfo> > m_lineInfo; ///< line filter data

--- a/SofaKernel/modules/SofaMeshCollision/TriangleModel.h
+++ b/SofaKernel/modules/SofaMeshCollision/TriangleModel.h
@@ -140,6 +140,9 @@ public:
 
     Data<bool> d_bothSide; ///< to activate collision on both side of the triangle model
     Data<bool> d_computeNormals; ///< set to false to disable computation of triangles normal
+    
+    /// Link to be set to the topology container in the component graph.
+    SingleLink<TriangleCollisionModel<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
 protected:
     core::behavior::MechanicalState<DataTypes>* m_mstate; ///< Pointer to the corresponding MechanicalState
@@ -223,6 +226,11 @@ public:
     }
 
     void computeBBox(const core::ExecParams* params, bool onlyVisible=false) override;
+
+    sofa::core::topology::BaseMeshTopology* getCollisionTopology() override
+    {
+        return l_topology.get();
+    }
 };
 
 template <class TDataTypes> using TTriangleModel [[deprecated("The TTriangleModel is now deprecated please use TriangleCollisionModel instead.")]] = TriangleCollisionModel<TDataTypes>;

--- a/SofaKernel/modules/SofaSimpleFem/HexahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/HexahedronFEMForceField.inl
@@ -123,7 +123,7 @@ void HexahedronFEMForceField<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/SofaKernel/modules/SofaSimpleFem/TetrahedronDiffusionFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/TetrahedronDiffusionFEMForceField.inl
@@ -174,7 +174,7 @@ void TetrahedronDiffusionFEMForceField<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/SofaKernel/modules/SofaSimpleFem/TetrahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/TetrahedronFEMForceField.inl
@@ -1354,7 +1354,7 @@ void TetrahedronFEMForceField<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.cpp
@@ -557,7 +557,7 @@ void* Node::findLinkDestClass(const core::objectmodel::BaseClass* destType, cons
         if (destType->hasParent(sofa::core::BaseState::GetClass()))
             return destType->dynamicCast(node->getState());
         else if (destType->hasParent(core::topology::BaseMeshTopology::GetClass()))
-            return destType->dynamicCast(node->getMeshTopology());
+            return destType->dynamicCast(node->getMeshTopologyLink());
         else if (destType->hasParent(core::topology::Topology::GetClass()))
             return destType->dynamicCast(node->getTopology());
         else if (destType->hasParent(core::visual::Shader::GetClass()))
@@ -620,18 +620,13 @@ core::topology::Topology* Node::getTopology() const
 }
 
 /// Mesh Topology (unified interface for both static and dynamic topologies)
-core::topology::BaseMeshTopology* Node::getMeshTopology() const
+core::topology::BaseMeshTopology* Node::getMeshTopologyLink(SearchDirection dir) const
 {
+    SOFA_UNUSED(dir);
     if (this->meshTopology)
         return this->meshTopology;
     else
         return get<core::topology::BaseMeshTopology>(SearchParents);
-}
-
-/// Mesh Topology that is local to this context (i.e. not within parent contexts)
-core::topology::BaseMeshTopology* Node::getLocalMeshTopology() const
-{
-    return this->meshTopology;
 }
 
 /// Degrees-of-Freedom

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.h
@@ -476,10 +476,7 @@ public:
     sofa::core::topology::Topology* getTopology() const override;
 
     /// Mesh Topology (unified interface for both static and dynamic topologies)
-    sofa::core::topology::BaseMeshTopology* getMeshTopology() const override;
-
-    /// Mesh Topology that is local to this context (i.e. not within parent contexts)
-    core::topology::BaseMeshTopology* getLocalMeshTopology() const override;
+    sofa::core::topology::BaseMeshTopology* getMeshTopologyLink(SearchDirection dir = SearchUp) const override;
 
     /// Degrees-of-Freedom
     sofa::core::BaseState* getState() const override;

--- a/SofaKernel/modules/SofaSimulationGraph/DAGNode.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/DAGNode.cpp
@@ -474,10 +474,16 @@ bool DAGNode::hasAncestor(const BaseContext* context) const
 
 /// Mesh Topology that is relevant for this context
 /// (within it or its parents until a mapping is reached that does not preserve topologies).
-core::topology::BaseMeshTopology* DAGNode::getActiveMeshTopology() const
+core::topology::BaseMeshTopology* DAGNode::getMeshTopologyLink(SearchDirection dir) const
 {
     if (this->meshTopology)
         return this->meshTopology;
+
+    if (dir != Local)
+        return Node::getMeshTopologyLink(dir);
+
+    //local case similar to getActiveMeshTopology ...
+
     // Check if a local mapping stops the search
     if (this->mechanicalMapping && !this->mechanicalMapping->sameTopology())
     {
@@ -497,7 +503,7 @@ core::topology::BaseMeshTopology* DAGNode::getActiveMeshTopology() const
         // if the visitor is run from a sub-graph containing a multinode linked with a node outside of the subgraph, do not consider the outside node by looking on the sub-graph descendancy
         if ( parents[i] )
         {
-            core::topology::BaseMeshTopology* res = parents[i]->getActiveMeshTopology();
+            core::topology::BaseMeshTopology* res = parents[i]->getMeshTopologyLink(Local);
             if (res)
                 return res;
         }

--- a/SofaKernel/modules/SofaSimulationGraph/DAGNode.h
+++ b/SofaKernel/modules/SofaSimulationGraph/DAGNode.h
@@ -111,7 +111,7 @@ public:
 
     /// Mesh Topology that is relevant for this context
     /// (within it or its parents until a mapping is reached that does not preserve topologies).
-    core::topology::BaseMeshTopology* getActiveMeshTopology() const override;
+    core::topology::BaseMeshTopology* getMeshTopologyLink(SearchDirection dir = SearchUp) const override;
 
 
     /// Called during initialization to corectly propagate the visual context to the children

--- a/SofaKernel/modules/SofaSimulationTree/GNode.cpp
+++ b/SofaKernel/modules/SofaSimulationTree/GNode.cpp
@@ -352,10 +352,16 @@ bool GNode::hasAncestor(const BaseContext* context) const
 
 /// Mesh Topology that is relevant for this context
 /// (within it or its parents until a mapping is reached that does not preserve topologies).
-core::topology::BaseMeshTopology* GNode::getActiveMeshTopology() const
+core::topology::BaseMeshTopology* GNode::getMeshTopologyLink(SearchDirection dir) const
 {
     if (this->meshTopology)
         return this->meshTopology;
+
+    if (dir != Local)
+        return Node::getMeshTopologyLink(dir);
+
+    //local case similar to getActiveMeshTopology ...
+
     // Check if a local mapping stops the search
     if (this->mechanicalMapping && !this->mechanicalMapping->sameTopology())
     {
@@ -376,7 +382,7 @@ core::topology::BaseMeshTopology* GNode::getActiveMeshTopology() const
     }
     else
     {
-        return p->getActiveMeshTopology();
+        return p->getMeshTopologyLink(Local);
     }
 }
 

--- a/SofaKernel/modules/SofaSimulationTree/GNode.h
+++ b/SofaKernel/modules/SofaSimulationTree/GNode.h
@@ -120,7 +120,7 @@ public:
 
     /// Mesh Topology that is relevant for this context
     /// (within it or its parents until a mapping is reached that does not preserve topologies).
-    core::topology::BaseMeshTopology* getActiveMeshTopology() const override;
+    core::topology::BaseMeshTopology* getMeshTopologyLink(SearchDirection dir = SearchUp) const override;
 
 
     /// Called during initialization to corectly propagate the visual context to the children

--- a/applications/plugins/Sensable/examples/SimpleBox-Method2.scn
+++ b/applications/plugins/Sensable/examples/SimpleBox-Method2.scn
@@ -24,7 +24,7 @@
             <NewOmniDriver name="omniDriver1" tags="Omni" scale="300" permanent="true" listening="true" alignOmniWithCamera="true"/>
             <Node name="Tool1">
                 <MechanicalObject template="Rigid" name="RealPosition"/>
-                <SubsetMapping indices="0"/>
+                <SubsetMapping indices="0" handleTopologyChange="0"/>
             </Node>
         </Node>
     </Node>

--- a/applications/plugins/SensableEmulation/examples/SimpleBox-Method2.scn
+++ b/applications/plugins/SensableEmulation/examples/SimpleBox-Method2.scn
@@ -25,7 +25,7 @@
           <!--<NewOmniDriver name="omniDriver1" tags="Omni" scale="300" permanent="true" listening="true" alignOmniWithCamera="true"/>-->
             <Node name="Tool1">
                 <MechanicalObject template="Rigid3" name="RealPosition"/>
-                <SubsetMapping indices="0"/>
+                <SubsetMapping indices="0" handleTopologyChange="0"/>
             </Node>
         </Node>
     </Node>

--- a/applications/plugins/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.h
+++ b/applications/plugins/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.h
@@ -464,7 +464,7 @@ public:
 
     /// alias used by ContactMapper
     core::behavior::MechanicalState<DataTypes>* getMechanicalState() { return ffd; }
-    core::topology::BaseMeshTopology* getMeshTopology() override { return ffdMesh; }
+    core::topology::BaseMeshTopology* getCollisionTopology() override { return ffdMesh; }
 
     void init() override;
 

--- a/applications/plugins/SofaMiscCollision/TetrahedronModel.cpp
+++ b/applications/plugins/SofaMiscCollision/TetrahedronModel.cpp
@@ -50,7 +50,9 @@ int TetrahedronModelClass = core::RegisterObject("collision model using a tetrah
         ;
 
 TetrahedronModel::TetrahedronModel()
-    : tetra(nullptr), mstate(nullptr)
+    : tetra(nullptr)
+    , mstate(nullptr)
+    , l_topology(initLink("topology", "link to the topology container"))
 {
     enum_type = TETRAHEDRON_TYPE;
 }
@@ -64,7 +66,21 @@ void TetrahedronModel::resize(int size)
 
 void TetrahedronModel::init()
 {
-    _topology = this->getContext()->getMeshTopology();
+    if (l_topology.empty())
+    {
+        msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
+        l_topology.set(this->getContext()->getMeshTopologyLink());
+    }
+
+    _topology = l_topology.get();
+    msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
+
+    if (!_topology)
+    {
+        msg_error() << "No topology component found at path: " << l_topology.getLinkedPath() << ", nor in current context: " << this->getContext()->name << ". TetrahedronModel requires a BaseMeshTopology";
+        sofa::core::objectmodel::BaseObject::d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+        return;
+    }
 
     this->CollisionModel::init();
     mstate = dynamic_cast< core::behavior::MechanicalState<Vec3Types>* > (getContext()->getMechanicalState());
@@ -72,12 +88,6 @@ void TetrahedronModel::init()
     if (mstate==nullptr)
     {
         serr<<"TetrahedronModel requires a Vec3 Mechanical Model" << sendl;
-        return;
-    }
-
-    if (!_topology)
-    {
-        serr<<"TetrahedronModel requires a BaseMeshTopology" << sendl;
         return;
     }
 

--- a/applications/plugins/SofaMiscCollision/TetrahedronModel.h
+++ b/applications/plugins/SofaMiscCollision/TetrahedronModel.h
@@ -128,6 +128,9 @@ public:
 
     core::behavior::MechanicalState<defaulttype::Vec3Types>* getMechanicalState() { return mstate; }
 
+    /// Link to be set to the topology container in the component graph.
+    SingleLink<TetrahedronModel, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
+
 };
 
 inline Tetrahedron::Tetrahedron(TetrahedronModel* model, int index)

--- a/modules/SofaBoundaryCondition/AffineMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/AffineMovementConstraint.inl
@@ -122,7 +122,7 @@ void AffineMovementConstraint<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();

--- a/modules/SofaBoundaryCondition/ConstantForceField.inl
+++ b/modules/SofaBoundaryCondition/ConstantForceField.inl
@@ -95,7 +95,7 @@ void ConstantForceField<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     // temprory pointer to topology

--- a/modules/SofaBoundaryCondition/EdgePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/EdgePressureForceField.inl
@@ -72,7 +72,7 @@ void EdgePressureForceField<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaBoundaryCondition/FixedConstraint.inl
+++ b/modules/SofaBoundaryCondition/FixedConstraint.inl
@@ -134,7 +134,7 @@ void FixedConstraint<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();

--- a/modules/SofaBoundaryCondition/FixedPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/FixedPlaneConstraint.inl
@@ -248,7 +248,7 @@ void FixedPlaneConstraint<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();

--- a/modules/SofaBoundaryCondition/FixedTranslationConstraint.inl
+++ b/modules/SofaBoundaryCondition/FixedTranslationConstraint.inl
@@ -107,7 +107,7 @@ void FixedTranslationConstraint<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();

--- a/modules/SofaBoundaryCondition/HermiteSplineConstraint.inl
+++ b/modules/SofaBoundaryCondition/HermiteSplineConstraint.inl
@@ -80,7 +80,7 @@ void HermiteSplineConstraint<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();

--- a/modules/SofaBoundaryCondition/LinearForceField.inl
+++ b/modules/SofaBoundaryCondition/LinearForceField.inl
@@ -59,7 +59,7 @@ void LinearForceField<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();

--- a/modules/SofaBoundaryCondition/LinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/LinearMovementConstraint.inl
@@ -139,7 +139,7 @@ void LinearMovementConstraint<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();

--- a/modules/SofaBoundaryCondition/LinearVelocityConstraint.inl
+++ b/modules/SofaBoundaryCondition/LinearVelocityConstraint.inl
@@ -135,7 +135,7 @@ void LinearVelocityConstraint<TDataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();

--- a/modules/SofaBoundaryCondition/OscillatingTorsionPressureForceField.inl
+++ b/modules/SofaBoundaryCondition/OscillatingTorsionPressureForceField.inl
@@ -70,7 +70,7 @@ void OscillatingTorsionPressureForceField<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaBoundaryCondition/ParabolicConstraint.inl
+++ b/modules/SofaBoundaryCondition/ParabolicConstraint.inl
@@ -70,7 +70,7 @@ void ParabolicConstraint<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();

--- a/modules/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
@@ -153,7 +153,7 @@ void PartialLinearMovementConstraint<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();

--- a/modules/SofaBoundaryCondition/PatchTestMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/PatchTestMovementConstraint.inl
@@ -121,7 +121,7 @@ void PatchTestMovementConstraint<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();

--- a/modules/SofaBoundaryCondition/ProjectDirectionConstraint.inl
+++ b/modules/SofaBoundaryCondition/ProjectDirectionConstraint.inl
@@ -118,7 +118,7 @@ void ProjectDirectionConstraint<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();

--- a/modules/SofaBoundaryCondition/ProjectToLineConstraint.inl
+++ b/modules/SofaBoundaryCondition/ProjectToLineConstraint.inl
@@ -118,7 +118,7 @@ void ProjectToLineConstraint<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();

--- a/modules/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
@@ -119,7 +119,7 @@ void ProjectToPlaneConstraint<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();

--- a/modules/SofaBoundaryCondition/ProjectToPointConstraint.inl
+++ b/modules/SofaBoundaryCondition/ProjectToPointConstraint.inl
@@ -119,7 +119,7 @@ void ProjectToPointConstraint<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();

--- a/modules/SofaBoundaryCondition/QuadPressureForceField.inl
+++ b/modules/SofaBoundaryCondition/QuadPressureForceField.inl
@@ -67,7 +67,7 @@ void QuadPressureForceField<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaBoundaryCondition/SurfacePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/SurfacePressureForceField.inl
@@ -78,7 +78,7 @@ void SurfacePressureForceField<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaBoundaryCondition/TaitSurfacePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/TaitSurfacePressureForceField.inl
@@ -111,7 +111,7 @@ void TaitSurfacePressureForceField<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaBoundaryCondition/TrianglePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/TrianglePressureForceField.inl
@@ -67,7 +67,7 @@ template <class DataTypes> void TrianglePressureForceField<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaConstraint/DOFBlockerLMConstraint.inl
+++ b/modules/SofaConstraint/DOFBlockerLMConstraint.inl
@@ -94,7 +94,7 @@ void DOFBlockerLMConstraint<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();

--- a/modules/SofaConstraint/DistanceLMConstraint.h
+++ b/modules/SofaConstraint/DistanceLMConstraint.h
@@ -108,6 +108,8 @@ public:
     //Edges involving a distance constraint
     Data< SeqEdges > vecConstraint; ///< List of the edges to constrain
 
+    /// Link to be set to the topology container in the component graph.
+    SingleLink <DistanceLMConstraint<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 protected :
 
     ///Compute the length of an edge given the vector of coordinates corresponding
@@ -117,7 +119,7 @@ protected :
     void updateRestLength();
 
     // Base Components of the current context
-    core::topology::BaseMeshTopology *topology;
+    core::topology::BaseMeshTopology *m_topology;
 
     helper::vector<  unsigned int > registeredConstraints;
 

--- a/modules/SofaConstraint/DistanceLMConstraint.h
+++ b/modules/SofaConstraint/DistanceLMConstraint.h
@@ -118,9 +118,6 @@ protected :
     Deriv getDirection(const Edge &e, const VecCoord &x1, const VecCoord &x2) const;
     void updateRestLength();
 
-    // Base Components of the current context
-    core::topology::BaseMeshTopology *m_topology;
-
     helper::vector<  unsigned int > registeredConstraints;
 
     // rest length pre-computated

--- a/modules/SofaConstraint/DistanceLMConstraint.inl
+++ b/modules/SofaConstraint/DistanceLMConstraint.inl
@@ -49,7 +49,6 @@ DistanceLMConstraint<DataTypes>::DistanceLMConstraint( MechanicalState *dof1, Me
     : core::behavior::LMConstraint<DataTypes,DataTypes>(dof1,dof2)
     , vecConstraint(sofa::core::objectmodel::Base::initData(&vecConstraint, "vecConstraint", "List of the edges to constrain"))
     , l_topology(initLink("topology", "link to the topology container"))
-    , m_topology(nullptr)
 {
 }
 
@@ -70,16 +69,23 @@ void DistanceLMConstraint<DataTypes>::init()
 {
     sofa::core::behavior::LMConstraint<DataTypes,DataTypes>::init();
     
+    // TODO epenod 2019-12-05: Adapt code to not look for topology if constraint is manually set. Need to dig more in the code to understand how topology is used.
+    if (vecConstraint.getValue().size() != 0)
+    {
+        // nothing to do in this case
+        return;
+    }
+
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
-
-    m_topology = l_topology.get();
+    
+    core::topology::BaseMeshTopology *_topology = l_topology.get();
     msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 
-    if (!m_topology)
+    if (!_topology)
     {
         msg_error() << "No topology component found at path: " << l_topology.getLinkedPath() << ", nor in current context: " << this->getContext()->name;
         sofa::core::objectmodel::BaseObject::d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Invalid);
@@ -87,7 +93,7 @@ void DistanceLMConstraint<DataTypes>::init()
     }
 
     if (vecConstraint.getValue().size() == 0 && (this->constrainedObject1==this->constrainedObject2) ) 
-        vecConstraint.setValue(m_topology->getEdges());
+        vecConstraint.setValue(_topology->getEdges());
 }
 
 template <class DataTypes>

--- a/modules/SofaConstraint/FixedLMConstraint.inl
+++ b/modules/SofaConstraint/FixedLMConstraint.inl
@@ -118,7 +118,7 @@ void FixedLMConstraint<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();

--- a/modules/SofaConstraint/LMDNewProximityIntersection.cpp
+++ b/modules/SofaConstraint/LMDNewProximityIntersection.cpp
@@ -57,7 +57,7 @@ using namespace helper;
 
 void GetPosOfEdgeVertexOnTriangle(Vector3& pv1, Vector3& pv2, int edge_number, Triangle &t)
 {
-    sofa::core::topology::BaseMeshTopology::Edge edge = t.getCollisionModel()->getTopology()->getEdge(edge_number);
+    sofa::core::topology::BaseMeshTopology::Edge edge = t.getCollisionModel()->getCollisionTopology()->getEdge(edge_number);
     core::behavior::MechanicalState<Vec3Types>* mState= t.getCollisionModel()->getMechanicalState();
     pv1= (mState->read(core::ConstVecCoordId::position())->getValue())[edge[0]];
     pv2= (mState->read(core::ConstVecCoordId::position())->getValue())[edge[1]];
@@ -225,7 +225,7 @@ int LMDNewProximityIntersection::computeIntersection(Triangle& e1, Point& e2, Ou
 {
 
 // index of lines:
-    const fixed_array<unsigned int,3>& edgesInTriangle1 = e1.getCollisionModel()->getTopology()->getEdgesInTriangle(e1.getIndex());
+    const fixed_array<unsigned int,3>& edgesInTriangle1 = e1.getCollisionModel()->getCollisionTopology()->getEdgesInTriangle(e1.getIndex());
     unsigned int E1edge1verif, E1edge2verif, E1edge3verif;
     E1edge1verif=0; E1edge2verif=0; E1edge3verif=0;
 
@@ -234,7 +234,7 @@ int LMDNewProximityIntersection::computeIntersection(Triangle& e1, Point& e2, Ou
     for (int i=0; i<3; i++)
     {
         // Verify for E1: convention: Edge1 = P1 P2    Edge2 = P2 P3    Edge3 = P3 P1
-        edge[i] = e1.getCollisionModel()->getTopology()->getEdge(edgesInTriangle1[i]);
+        edge[i] = e1.getCollisionModel()->getCollisionTopology()->getEdge(edgesInTriangle1[i]);
         if(((int)edge[i][0]==e1.p1Index() && (int)edge[i][1]==e1.p2Index()) || ((int)edge[i][0]==e1.p2Index() && (int)edge[i][1]==e1.p1Index()))
         {
             E1edge1verif = edgesInTriangle1[i]; /*std::cout<<"- e1 1: "<<i ;*/
@@ -286,7 +286,7 @@ int LMDNewProximityIntersection::computeIntersection(Triangle& e1, Line& e2, Out
 {
 
 // index of lines:
-    const fixed_array<unsigned int,3>& edgesInTriangle1 = e1.getCollisionModel()->getTopology()->getEdgesInTriangle(e1.getIndex());
+    const fixed_array<unsigned int,3>& edgesInTriangle1 = e1.getCollisionModel()->getCollisionTopology()->getEdgesInTriangle(e1.getIndex());
     unsigned int E1edge1verif, E1edge2verif, E1edge3verif;
     E1edge1verif=0; E1edge2verif=0; E1edge3verif=0;
 
@@ -295,7 +295,7 @@ int LMDNewProximityIntersection::computeIntersection(Triangle& e1, Line& e2, Out
     for (int i=0; i<3; i++)
     {
         // Verify for E1: convention: Edge1 = P1 P2    Edge2 = P2 P3    Edge3 = P3 P1
-        edge[i] = e1.getCollisionModel()->getTopology()->getEdge(edgesInTriangle1[i]);
+        edge[i] = e1.getCollisionModel()->getCollisionTopology()->getEdge(edgesInTriangle1[i]);
         if(((int)edge[i][0]==e1.p1Index() && (int)edge[i][1]==e1.p2Index()) || ((int)edge[i][0]==e1.p2Index() && (int)edge[i][1]==e1.p1Index()))
         {
             E1edge1verif = edgesInTriangle1[i]; /*std::cout<<"- e1 1: "<<i ;*/
@@ -404,8 +404,8 @@ int LMDNewProximityIntersection::computeIntersection(Triangle& e1, Triangle& e2,
 
 
     // index of lines:
-    const fixed_array<unsigned int,3>& edgesInTriangle1 = e1.getCollisionModel()->getTopology()->getEdgesInTriangle(e1.getIndex());
-    const fixed_array<unsigned int,3>& edgesInTriangle2 = e2.getCollisionModel()->getTopology()->getEdgesInTriangle(e2.getIndex());
+    const fixed_array<unsigned int,3>& edgesInTriangle1 = e1.getCollisionModel()->getCollisionTopology()->getEdgesInTriangle(e1.getIndex());
+    const fixed_array<unsigned int,3>& edgesInTriangle2 = e2.getCollisionModel()->getCollisionTopology()->getEdgesInTriangle(e2.getIndex());
 
     unsigned int E1edge1verif, E1edge2verif, E1edge3verif;
     unsigned int E2edge1verif, E2edge2verif, E2edge3verif;
@@ -418,7 +418,7 @@ int LMDNewProximityIntersection::computeIntersection(Triangle& e1, Triangle& e2,
     for (int i=0; i<3; i++)
     {
         // Verify for E1: convention: Edge1 = P1 P2    Edge2 = P2 P3    Edge3 = P3 P1
-        edge[i] = e1.getCollisionModel()->getTopology()->getEdge(edgesInTriangle1[i]);
+        edge[i] = e1.getCollisionModel()->getCollisionTopology()->getEdge(edgesInTriangle1[i]);
         if(((int)edge[i][0]==e1.p1Index() && (int)edge[i][1]==e1.p2Index()) || ((int)edge[i][0]==e1.p2Index() && (int)edge[i][1]==e1.p1Index()))
         {
             E1edge1verif = edgesInTriangle1[i]; /*std::cout<<"- e1 1: "<<i ;*/
@@ -432,7 +432,7 @@ int LMDNewProximityIntersection::computeIntersection(Triangle& e1, Triangle& e2,
             E1edge3verif = edgesInTriangle1[i]; /*std::cout<<"- e1 3: "<<i ;*/
         }
         // Verify for E2: convention: Edge1 = P1 P2    Edge2 = P2 P3    Edge3 = P3 P1
-        edge[i] = e2.getCollisionModel()->getTopology()->getEdge(edgesInTriangle2[i]);
+        edge[i] = e2.getCollisionModel()->getCollisionTopology()->getEdge(edgesInTriangle2[i]);
         if(((int)edge[i][0]==e2.p1Index() && (int)edge[i][1]==e2.p2Index()) || ((int)edge[i][0]==e2.p2Index() && (int)edge[i][1]==e2.p1Index()))
         {
             E2edge1verif = edgesInTriangle2[i];/*std::cout<<"- e2 1: "<<i ;*/

--- a/modules/SofaConstraint/LMDNewProximityIntersection.inl
+++ b/modules/SofaConstraint/LMDNewProximityIntersection.inl
@@ -474,7 +474,7 @@ int LMDNewProximityIntersection::computeIntersection(Triangle& e1, TSphere<T>& e
 {
 
 // index of lines:
-    const sofa::helper::fixed_array<unsigned int,3>& edgesInTriangle1 = e1.getCollisionModel()->getTopology()->getEdgesInTriangle(e1.getIndex());
+    const sofa::helper::fixed_array<unsigned int,3>& edgesInTriangle1 = e1.getCollisionModel()->getCollisionTopology()->getEdgesInTriangle(e1.getIndex());
     unsigned int E1edge1verif, E1edge2verif, E1edge3verif;
     E1edge1verif=0; E1edge2verif=0; E1edge3verif=0;
 
@@ -485,7 +485,7 @@ int LMDNewProximityIntersection::computeIntersection(Triangle& e1, TSphere<T>& e
     for (int i=0; i<3; i++)
     {
         // Verify for E1: convention: Edge1 = P1 P2    Edge2 = P2 P3    Edge3 = P3 P1
-        edge[i] = e1.getCollisionModel()->getTopology()->getEdge(edgesInTriangle1[i]);
+        edge[i] = e1.getCollisionModel()->getCollisionTopology()->getEdge(edgesInTriangle1[i]);
         if(((int)edge[i][0]==e1.p1Index() && (int)edge[i][1]==e1.p2Index()) || ((int)edge[i][0]==e1.p2Index() && (int)edge[i][1]==e1.p1Index()))
         {
             E1edge1verif = edgesInTriangle1[i]; /*std::cout<<"- e1 1: "<<i ;*/

--- a/modules/SofaConstraint/LocalMinDistance.cpp
+++ b/modules/SofaConstraint/LocalMinDistance.cpp
@@ -1228,7 +1228,7 @@ bool LocalMinDistance::testValidity(Point &p, const Vector3 &PQ)
     if ( !(node->get< LineModel >()) )
         return true;
 
-    BaseMeshTopology* topology = p.getCollisionModel()->getMeshTopology();
+    BaseMeshTopology* topology = p.getCollisionModel()->getCollisionTopology();
     const helper::vector<Vector3>& x =(p.getCollisionModel()->getMechanicalState()->read(core::ConstVecCoordId::position())->getValue());
 
     const helper::vector <unsigned int>& trianglesAroundVertex = topology->getTrianglesAroundVertex(p.getIndex());
@@ -1307,7 +1307,7 @@ bool LocalMinDistance::testValidity(Line &l, const Vector3 &PQ)
     Vector3 AB = pt2 - pt1;
     AB.normalize();
 
-    BaseMeshTopology* topology = l.getCollisionModel()->getMeshTopology();
+    BaseMeshTopology* topology = l.getCollisionModel()->getCollisionTopology();
     const helper::vector<Vector3>& x =(l.getCollisionModel()->getMechanicalState()->read(core::ConstVecCoordId::position())->getValue());
     const sofa::helper::vector<unsigned int>& trianglesAroundEdge = topology->getTrianglesAroundEdge(l.getIndex());
 

--- a/modules/SofaConstraint/UncoupledConstraintCorrection.inl
+++ b/modules/SofaConstraint/UncoupledConstraintCorrection.inl
@@ -164,7 +164,7 @@ void UncoupledConstraintCorrection<DataTypes>::init()
             if (l_topology.empty())
             {
                 msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-                l_topology.set(this->getContext()->getMeshTopology());
+                l_topology.set(this->getContext()->getMeshTopologyLink());
             }
 
             sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();

--- a/modules/SofaExporter/src/SofaExporter/WriteTopology.cpp
+++ b/modules/SofaExporter/src/SofaExporter/WriteTopology.cpp
@@ -74,7 +74,7 @@ WriteTopologyCreator::WriteTopologyCreator(const std::string &n, bool _writeCont
 //Create a Write Topology component each time a BaseMeshTopology is found
 simulation::Visitor::Result WriteTopologyCreator::processNodeTopDown( simulation::Node* gnode)
 {
-    sofa::core::topology::BaseMeshTopology* topo = dynamic_cast<sofa::core::topology::BaseMeshTopology *>( gnode->getMeshTopology());
+    sofa::core::topology::BaseMeshTopology* topo = dynamic_cast<sofa::core::topology::BaseMeshTopology *>( gnode->getMeshTopologyLink());
     if (!topo)   return simulation::Visitor::RESULT_CONTINUE;
     //We have a meshTopology
     addWriteTopology(topo, gnode);

--- a/modules/SofaExporter/src/SofaExporter/WriteTopology.h
+++ b/modules/SofaExporter/src/SofaExporter/WriteTopology.h
@@ -95,7 +95,7 @@ public:
     template<class T>
     static bool canCreate(T*& obj, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
     {
-        if (context->getMeshTopology() == nullptr)
+        if (context->getMeshTopologyLink() == nullptr)
             return false;
         return BaseObject::canCreate(obj, context, arg);
     }

--- a/modules/SofaExporter/src/SofaExporter/WriteTopology.inl
+++ b/modules/SofaExporter/src/SofaExporter/WriteTopology.inl
@@ -77,7 +77,7 @@ void WriteTopology::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaGeneralDeformable/FastTriangularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/FastTriangularBendingSprings.inl
@@ -375,7 +375,7 @@ void FastTriangularBendingSprings<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaGeneralDeformable/QuadBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/QuadBendingSprings.inl
@@ -103,7 +103,7 @@ void QuadBendingSprings<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();

--- a/modules/SofaGeneralDeformable/QuadularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/QuadularBendingSprings.inl
@@ -521,7 +521,7 @@ void QuadularBendingSprings<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaGeneralDeformable/TriangleBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/TriangleBendingSprings.inl
@@ -134,7 +134,7 @@ void TriangleBendingSprings<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     sofa::core::topology::BaseMeshTopology* topology = l_topology.get();

--- a/modules/SofaGeneralDeformable/TriangularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/TriangularBendingSprings.inl
@@ -485,7 +485,7 @@ void TriangularBendingSprings<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.inl
+++ b/modules/SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.inl
@@ -190,7 +190,7 @@ template <class DataTypes> void TriangularBiquadraticSpringsForceField<DataTypes
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.inl
+++ b/modules/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.inl
@@ -169,7 +169,7 @@ template <class DataTypes> void TriangularQuadraticSpringsForceField<DataTypes>:
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaGeneralDeformable/TriangularTensorMassForceField.inl
+++ b/modules/SofaGeneralDeformable/TriangularTensorMassForceField.inl
@@ -290,7 +290,7 @@ template <class DataTypes> void TriangularTensorMassForceField<DataTypes>::init(
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaGeneralDeformable/VectorSpringForceField.inl
+++ b/modules/SofaGeneralDeformable/VectorSpringForceField.inl
@@ -172,7 +172,7 @@ void VectorSpringForceField<DataTypes>::init()
         if (l_topology.empty())
         {
             msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-            l_topology.set(this->getContext()->getMeshTopology());
+            l_topology.set(this->getContext()->getMeshTopologyLink());
         }
 
         m_topology = l_topology.get();

--- a/modules/SofaGeneralEngine/SmoothMeshEngine.inl
+++ b/modules/SofaGeneralEngine/SmoothMeshEngine.inl
@@ -59,7 +59,7 @@ void SmoothMeshEngine<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaGeneralLoader/ReadTopology.cpp
+++ b/modules/SofaGeneralLoader/ReadTopology.cpp
@@ -67,7 +67,7 @@ ReadTopologyCreator::ReadTopologyCreator(const std::string &n, bool _createInMap
 //Create a Read Topology component each time a BaseMeshTopology is found
 simulation::Visitor::Result ReadTopologyCreator::processNodeTopDown( simulation::Node* gnode)
 {
-    sofa::core::topology::BaseMeshTopology* topo = gnode->getMeshTopology();
+    sofa::core::topology::BaseMeshTopology* topo = gnode->getMeshTopologyLink();
     if (!topo)   return simulation::Visitor::RESULT_CONTINUE;
     //We have a meshTopology
     addReadTopology(topo, gnode);

--- a/modules/SofaGeneralLoader/ReadTopology.h
+++ b/modules/SofaGeneralLoader/ReadTopology.h
@@ -54,6 +54,9 @@ public:
     Data < double > f_shift; ///< shift between times in the file and times when they will be read
     Data < bool > f_loop; ///< set to 'true' to re-read the file when reaching the end
 
+    /// Link to be set to the topology container in the component graph.
+    SingleLink <ReadTopology, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
+
 protected:
     core::topology::BaseMeshTopology* m_topology;
     std::ifstream* infile;
@@ -87,7 +90,7 @@ public:
     template<class T>
     static bool canCreate(T* obj, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
     {
-        if (context->getMeshTopology() == nullptr)
+        if (context->getMeshTopologyLink() == nullptr)
             return false;
         return BaseObject::canCreate(obj, context, arg);
     }

--- a/modules/SofaGeneralLoader/ReadTopology.inl
+++ b/modules/SofaGeneralLoader/ReadTopology.inl
@@ -74,12 +74,21 @@ void ReadTopology::init()
 
 void ReadTopology::reset()
 {
-    m_topology = this->getContext()->getMeshTopology();
+    if (l_topology.empty())
+    {
+        msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
+        l_topology.set(this->getContext()->getMeshTopologyLink());
+    }
+
+    m_topology = l_topology.get();
+    msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
+    
     if (infile)
     {
         delete infile;
         infile = nullptr;
     }
+
 #if SOFAGENERALLOADER_HAVE_ZLIB
     if (gzfile)
     {

--- a/modules/SofaGeneralRigid/LineSetSkinningMapping.h
+++ b/modules/SofaGeneralRigid/LineSetSkinningMapping.h
@@ -105,7 +105,7 @@ public:
 
 protected:
 
-    sofa::core::topology::BaseMeshTopology* t;
+    sofa::core::topology::BaseMeshTopology* m_topology;
 
     /*!
     	Set the neighborhood line level

--- a/modules/SofaGeneralSimpleFem/BeamFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/BeamFEMForceField.inl
@@ -125,7 +125,7 @@ void BeamFEMForceField<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaGeneralSimpleFem/TetrahedralCorotationalFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/TetrahedralCorotationalFEMForceField.inl
@@ -114,7 +114,7 @@ void TetrahedralCorotationalFEMForceField<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.inl
+++ b/modules/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.inl
@@ -112,7 +112,7 @@ void TriangularFEMForceFieldOptim<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaMiscFem/FastTetrahedralCorotationalForceField.inl
+++ b/modules/SofaMiscFem/FastTetrahedralCorotationalForceField.inl
@@ -178,7 +178,7 @@ template <class DataTypes> void FastTetrahedralCorotationalForceField<DataTypes>
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaMiscFem/StandardTetrahedralFEMForceField.inl
+++ b/modules/SofaMiscFem/StandardTetrahedralFEMForceField.inl
@@ -148,7 +148,7 @@ template <class DataTypes> void StandardTetrahedralFEMForceField<DataTypes>::ini
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaMiscFem/TetrahedralTensorMassForceField.inl
+++ b/modules/SofaMiscFem/TetrahedralTensorMassForceField.inl
@@ -288,7 +288,7 @@ template <class DataTypes> void TetrahedralTensorMassForceField<DataTypes>::init
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.inl
+++ b/modules/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.inl
@@ -152,7 +152,7 @@ template <class DataTypes> void TetrahedronHyperelasticityFEMForceField<DataType
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaMiscFem/TriangleFEMForceField.inl
+++ b/modules/SofaMiscFem/TriangleFEMForceField.inl
@@ -82,7 +82,7 @@ void TriangleFEMForceField<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaMiscFem/TriangularAnisotropicFEMForceField.inl
+++ b/modules/SofaMiscFem/TriangularAnisotropicFEMForceField.inl
@@ -97,7 +97,7 @@ void TriangularAnisotropicFEMForceField<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaMiscFem/TriangularFEMForceField.inl
+++ b/modules/SofaMiscFem/TriangularFEMForceField.inl
@@ -166,7 +166,7 @@ void TriangularFEMForceField<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/MeshMatrixMass.inl
@@ -947,7 +947,7 @@ bool MeshMatrixMass<DataTypes, MassType>::checkTopology()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaMiscMapping/DistanceMapping.h
+++ b/modules/SofaMiscMapping/DistanceMapping.h
@@ -95,6 +95,11 @@ public:
     Data< defaulttype::RGBAColor > d_color;         ///< drawing color
     Data< unsigned >       d_geometricStiffness; ///< how to compute geometric stiffness (0->no GS, 1->exact GS, 2->stabilized GS)
 
+    /// Link to be set to the topology container in the component graph. 
+    SingleLink<DistanceMapping<TIn, TOut>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
+
+
+
     void init() override;
 
     using Inherit::apply;
@@ -123,7 +128,7 @@ protected:
     DistanceMapping();
     virtual ~DistanceMapping();
 
-    topology::EdgeSetTopologyContainer* edgeContainer;  ///< where the edges are defined
+    topology::EdgeSetTopologyContainer* m_edgeContainer;  ///< where the edges are defined
     SparseMatrixEigen jacobian;                         ///< Jacobian of the mapping
     helper::vector<defaulttype::BaseMatrix*> baseMatrices;      ///< Jacobian of the mapping, in a vector
     SparseKMatrixEigen K;                               ///< Assembled geometric stiffness matrix
@@ -189,6 +194,10 @@ public:
     Data< defaulttype::RGBAColor >             d_color;         ///< drawing color
     Data< helper::vector<defaulttype::Vec2i> > d_indexPairs;  ///< for each child, its parent and index in parent
     Data< unsigned >                           d_geometricStiffness; ///< how to compute geometric stiffness (0->no GS, 1->exact GS, 2->stabilized GS)
+
+    /// Link to be set to the topology container in the component graph. 
+    SingleLink<DistanceMultiMapping<TIn, TOut>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
+
 
     // Append particle of given index within the given model to the subset.
     void addPoint(const core::BaseState* fromModel, int index);
@@ -279,7 +288,7 @@ protected:
     DistanceMultiMapping();
     virtual ~DistanceMultiMapping();
 
-    topology::EdgeSetTopologyContainer* edgeContainer;  ///< where the edges are defined
+    topology::EdgeSetTopologyContainer* m_edgeContainer;  ///< where the edges are defined
     helper::vector<defaulttype::BaseMatrix*> baseMatrices;      ///< Jacobian of the mapping, in a vector
     helper::vector<Direction> directions;                         ///< Unit vectors in the directions of the lines
     helper::vector< Real > invlengths;                          ///< inverse of current distances. Null represents the infinity (null distance)

--- a/modules/SofaMiscMapping/DistanceMapping.inl
+++ b/modules/SofaMiscMapping/DistanceMapping.inl
@@ -50,6 +50,8 @@ DistanceMapping<TIn, TOut>::DistanceMapping()
     , d_showObjectScale(initData(&d_showObjectScale, Real(0), "showObjectScale", "Scale for object display"))
     , d_color(initData(&d_color,defaulttype::RGBAColor(1,1,0,1), "showColor", "Color for object display. (default=[1.0,1.0,0.0,1.0])"))
     , d_geometricStiffness(initData(&d_geometricStiffness, 2u, "geometricStiffness", "0 -> no GS, 1 -> exact GS, 2 -> stabilized GS (default)"))
+    , l_topology(initLink("topology", "link to the topology container"))
+    , m_edgeContainer(nullptr)
 {
 }
 
@@ -62,10 +64,24 @@ DistanceMapping<TIn, TOut>::~DistanceMapping()
 template <class TIn, class TOut>
 void DistanceMapping<TIn, TOut>::init()
 {
-    edgeContainer = dynamic_cast<topology::EdgeSetTopologyContainer*>( this->getContext()->getMeshTopology() );
-    if( !edgeContainer ) serr<<"No EdgeSetTopologyContainer found ! "<<sendl;
+    if (l_topology.empty())
+    {
+        msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
+        l_topology.set(this->getContext()->getMeshTopologyLink());
 
-    SeqEdges links = edgeContainer->getEdges();
+    }
+
+    m_edgeContainer = dynamic_cast<topology::EdgeSetTopologyContainer*>(l_topology.get());
+    msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
+
+    if (m_edgeContainer == nullptr)
+    {
+        msg_error() << "No EdgeSetTopologyContainer component found at path: " << l_topology.getLinkedPath() << ", nor in current context: " << this->getContext()->name;
+        sofa::core::objectmodel::BaseObject::d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+        return;
+    }
+
+    SeqEdges links = m_edgeContainer->getEdges();
     typename core::behavior::MechanicalState<In>::ReadVecCoord pos = this->getFromModel()->readPositions();
 
     this->getToModel()->resize( links.size() );
@@ -124,7 +140,7 @@ void DistanceMapping<TIn, TOut>::apply(const core::MechanicalParams * /*mparams*
     helper::WriteOnlyAccessor< Data<OutVecCoord> >  out = dOut;
     helper::ReadAccessor< Data<InVecCoord> >  in = dIn;
     helper::ReadAccessor<Data<helper::vector<Real> > > restLengths(f_restLengths);
-    SeqEdges links = edgeContainer->getEdges();
+    SeqEdges links = m_edgeContainer->getEdges();
 
     jacobian.clear();
 
@@ -218,7 +234,7 @@ void DistanceMapping<TIn, TOut>::applyDJT(const core::MechanicalParams* mparams,
     }
     else
     {
-        const SeqEdges& links = edgeContainer->getEdges();
+        const SeqEdges& links = m_edgeContainer->getEdges();
 
         for(unsigned i=0; i<links.size(); i++ )
         {
@@ -290,7 +306,7 @@ void DistanceMapping<TIn, TOut>::updateK(const core::MechanicalParams *mparams, 
 
 
     helper::ReadAccessor<Data<OutVecDeriv> > childForce( *childForceId[this->toModel.get(mparams)].read() );
-    const SeqEdges& links = edgeContainer->getEdges();
+    const SeqEdges& links = m_edgeContainer->getEdges();
 
     unsigned int size = this->fromModel->getSize();
     K.resizeBlocks(size,size);
@@ -339,7 +355,7 @@ void DistanceMapping<TIn, TOut>::draw(const core::visual::VisualParams* vparams)
     glPushAttrib(GL_LIGHTING_BIT);
 
     typename core::behavior::MechanicalState<In>::ReadVecCoord pos = this->getFromModel()->readPositions();
-    const SeqEdges& links = edgeContainer->getEdges();
+    const SeqEdges& links = m_edgeContainer->getEdges();
 
 
 
@@ -374,7 +390,7 @@ void DistanceMapping<TIn, TOut>::draw(const core::visual::VisualParams* vparams)
 template <class TIn, class TOut>
 void DistanceMapping<TIn, TOut>::updateForceMask()
 {
-    const SeqEdges& links = edgeContainer->getEdges();
+    const SeqEdges& links = m_edgeContainer->getEdges();
 
     for(size_t i=0; i<links.size(); i++ )
     {
@@ -404,6 +420,8 @@ DistanceMultiMapping<TIn, TOut>::DistanceMultiMapping()
     , d_color(initData(&d_color, defaulttype::RGBAColor(1,1,0,1), "showColor", "Color for object display. (default=[1.0,1.0,0.0,1.0])"))
     , d_indexPairs(initData(&d_indexPairs, "indexPairs", "list of couples (parent index + index in the parent)"))
     , d_geometricStiffness(initData(&d_geometricStiffness, (unsigned)2, "geometricStiffness", "0 -> no GS, 1 -> exact GS, 2 -> stabilized GS (default)"))
+    , l_topology(initLink("topology", "link to the topology container"))
+    , m_edgeContainer(nullptr)
 {
 }
 
@@ -445,10 +463,24 @@ void DistanceMultiMapping<TIn, TOut>::addPoint( int from, int index)
 template <class TIn, class TOut>
 void DistanceMultiMapping<TIn, TOut>::init()
 {
-    edgeContainer = dynamic_cast<topology::EdgeSetTopologyContainer*>( this->getContext()->getMeshTopology() );
-    if( !edgeContainer ) serr<<"No EdgeSetTopologyContainer found ! "<<sendl;
+    if (l_topology.empty())
+    {
+        msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
+        l_topology.set(this->getContext()->getMeshTopologyLink());
 
-    const SeqEdges& links = edgeContainer->getEdges();
+    }
+
+    m_edgeContainer = dynamic_cast<topology::EdgeSetTopologyContainer*>(l_topology.get());
+    msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
+    
+    if (m_edgeContainer == nullptr)
+    {
+        msg_error() << "No EdgeSetTopologyContainer component found at path: " << l_topology.getLinkedPath() << ", nor in current context: " << this->getContext()->name;
+        sofa::core::objectmodel::BaseObject::d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+        return;
+    }
+    
+    const SeqEdges& links = m_edgeContainer->getEdges();
 
     this->getToModels()[0]->resize( links.size() );
 
@@ -510,7 +542,7 @@ void DistanceMultiMapping<TIn, TOut>::apply(const helper::vector<OutVecCoord*>& 
 
     const helper::vector<defaulttype::Vec2i>& pairs = d_indexPairs.getValue();
     helper::ReadAccessor<Data<helper::vector<Real> > > restLengths(f_restLengths);
-    const SeqEdges& links = edgeContainer->getEdges();
+    const SeqEdges& links = m_edgeContainer->getEdges();
 
 
     unsigned totalInSize = 0;
@@ -625,7 +657,7 @@ void DistanceMultiMapping<TIn, TOut>::applyDJT(const core::MechanicalParams* mpa
 
     const SReal kfactor = mparams->kFactor();
     const OutVecDeriv& childForce = this->getToModels()[0]->readForces().ref();
-    const SeqEdges& links = edgeContainer->getEdges();
+    const SeqEdges& links = m_edgeContainer->getEdges();
     const helper::vector<defaulttype::Vec2i>& pairs = d_indexPairs.getValue();
 
     unsigned size = this->getFromModels().size();
@@ -710,7 +742,7 @@ void DistanceMultiMapping<TIn, TOut>::updateK(const core::MechanicalParams* /*mp
     if( !geometricStiffness ) { K.resize(0,0); return; }
 
     helper::ReadAccessor<Data<OutVecDeriv> > childForce( *childForceId[(const core::State<TOut>*)this->getToModels()[0]].read() );
-    const SeqEdges& links = edgeContainer->getEdges();
+    const SeqEdges& links = m_edgeContainer->getEdges();
     const helper::vector<defaulttype::Vec2i>& pairs = d_indexPairs.getValue();
 
     for(size_t i=0; i<links.size(); i++)
@@ -776,7 +808,7 @@ void DistanceMultiMapping<TIn, TOut>::draw(const core::visual::VisualParams* vpa
 {
     if( !vparams->displayFlags().getShowMechanicalMappings() ) return;
 
-    const SeqEdges& links = edgeContainer->getEdges();
+    const SeqEdges& links = m_edgeContainer->getEdges();
 
     const helper::vector<defaulttype::Vec2i>& pairs = d_indexPairs.getValue();
 
@@ -817,7 +849,7 @@ void DistanceMultiMapping<TIn, TOut>::draw(const core::visual::VisualParams* vpa
 template <class TIn, class TOut>
 void DistanceMultiMapping<TIn, TOut>::updateForceMask()
 {
-    const SeqEdges& links = edgeContainer->getEdges();
+    const SeqEdges& links = m_edgeContainer->getEdges();
     const helper::vector<defaulttype::Vec2i>& pairs = d_indexPairs.getValue();
 
     for(size_t i=0; i<links.size(); i++ )

--- a/modules/SofaMiscTopology/TopologicalChangeProcessor.cpp
+++ b/modules/SofaMiscTopology/TopologicalChangeProcessor.cpp
@@ -110,7 +110,7 @@ void TopologicalChangeProcessor::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     m_topology = l_topology.get();

--- a/modules/SofaMiscTopology/TopologicalChangeProcessor.h
+++ b/modules/SofaMiscTopology/TopologicalChangeProcessor.h
@@ -127,7 +127,7 @@ public:
     template<class T>
     static bool canCreate(T*& obj, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
     {
-        if (context->getMeshTopology() == nullptr)
+        if (context->getMeshTopologyLink() == nullptr)
             return false;
 
         return BaseObject::canCreate(obj, context, arg);

--- a/modules/SofaNonUniformFem/NonUniformHexahedronFEMForceFieldAndMass.inl
+++ b/modules/SofaNonUniformFem/NonUniformHexahedronFEMForceFieldAndMass.inl
@@ -61,7 +61,7 @@ void NonUniformHexahedronFEMForceFieldAndMass<DataTypes>::init()
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
-        l_topology.set(this->getContext()->getMeshTopology());
+        l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
     this->m_topology = l_topology.get();

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/DataDisplay.h
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/DataDisplay.h
@@ -66,7 +66,11 @@ public:
 
     visualmodel::OglColorMap *colorMap;
     core::State<DataTypes> *state;
-    core::topology::BaseMeshTopology* topology;
+    core::topology::BaseMeshTopology* m_topology;
+
+    /// Link to be set to the topology container in the component graph.
+    SingleLink <DataDisplay, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
+
     Real oldMin, oldMax;
 
     void init() override;

--- a/modules/SofaUserInteraction/InciseAlongPathPerformer.cpp
+++ b/modules/SofaUserInteraction/InciseAlongPathPerformer.cpp
@@ -48,8 +48,8 @@ void InciseAlongPathPerformer::start()
     {
         firstIncisionBody = startBody;
         cpt++;
-        initialNbTriangles = startBody.body->getMeshTopology()->getNbTriangles();
-        initialNbPoints = startBody.body->getMeshTopology()->getNbPoints();
+        initialNbTriangles = startBody.body->getCollisionTopology()->getNbTriangles();
+        initialNbPoints = startBody.body->getCollisionTopology()->getNbPoints();
     }
 }
 
@@ -146,7 +146,7 @@ void InciseAlongPathPerformer::PerformCompleteIncision()
 
     // Initial point could have move due to gravity: looking for new coordinates of first incision point and triangle index.
     bool findTri = false;
-    sofa::helper::vector <unsigned int> triAroundVertex = startBody.body->getMeshTopology()->getTrianglesAroundVertex(initialNbPoints);
+    sofa::helper::vector <unsigned int> triAroundVertex = startBody.body->getCollisionTopology()->getTrianglesAroundVertex(initialNbPoints);
 
     // Check if point index and triangle index are consistent.
     for (unsigned int j = 0; j<triAroundVertex.size(); ++j)

--- a/modules/SofaUserInteraction/RemovePrimitivePerformer.inl
+++ b/modules/SofaUserInteraction/RemovePrimitivePerformer.inl
@@ -160,7 +160,7 @@ template <class DataTypes>
 bool RemovePrimitivePerformer<DataTypes>::createElementList()
 {
     // - STEP 1: Looking for current topology type
-    topo_curr = picked.body->getContext()->getMeshTopology();
+    topo_curr = picked.body->getCollisionTopology();
     if (topo_curr->getNbHexahedra())
         topoType = sofa::core::topology::HEXAHEDRON;
     else if (topo_curr->getNbTetrahedra())
@@ -310,7 +310,7 @@ bool RemovePrimitivePerformer<DataTypes>::createElementList()
             }
 
             // Switching variables to initial topology (topotype, topology) clear list of surfacique elements selected
-            topo_curr = picked.body->getMeshTopology();
+            topo_curr = picked.body->getCollisionTopology();
             topoType = topoTypeTmp;
             selectedElem.clear();
 

--- a/modules/SofaUserInteraction/TopologicalChangeManager.cpp
+++ b/modules/SofaUserInteraction/TopologicalChangeManager.cpp
@@ -69,7 +69,7 @@ TopologicalChangeManager::~TopologicalChangeManager()
 int TopologicalChangeManager::removeItemsFromTriangleModel(sofa::component::collision::TriangleModel* model, const helper::vector<int>& indices) const
 {
     sofa::core::topology::BaseMeshTopology* topo_curr;
-    topo_curr = model->getContext()->getMeshTopology();
+    topo_curr = model->getCollisionTopology();
 
     if(topo_curr == nullptr)
         return 0;
@@ -146,7 +146,7 @@ int TopologicalChangeManager::removeItemsFromTriangleModel(sofa::component::coll
                         }
                     }
                 }
-                topo_curr = topoMap->getFrom()->getContext()->getMeshTopology();
+                topo_curr = topoMap->getFrom();
                 node_curr = dynamic_cast<simulation::Node*>(topo_curr->getContext());
 
                 break;
@@ -177,7 +177,7 @@ int TopologicalChangeManager::removeItemsFromTriangleModel(sofa::component::coll
 int TopologicalChangeManager::removeItemsFromPointModel(sofa::component::collision::PointModel* model, const helper::vector<int>& indices) const
 {
     sofa::core::topology::BaseMeshTopology* topo_curr;
-    topo_curr = model->getContext()->getMeshTopology();
+    topo_curr = model->getCollisionTopology();
 
     if (topo_curr == nullptr)
         return 0;
@@ -273,7 +273,7 @@ int TopologicalChangeManager::removeItemsFromPointModel(sofa::component::collisi
                         }
                     }
                 }
-                topo_curr = topoMap->getFrom()->getContext()->getMeshTopology();
+                topo_curr = topoMap->getFrom();
                 node_curr = dynamic_cast<simulation::Node*>(topo_curr->getContext());
                 break;
             }
@@ -301,7 +301,7 @@ int TopologicalChangeManager::removeItemsFromPointModel(sofa::component::collisi
 int TopologicalChangeManager::removeItemsFromSphereModel(sofa::component::collision::SphereModel* model, const helper::vector<int>& indices) const
 {
     sofa::core::topology::BaseMeshTopology* topo_curr;
-    topo_curr = model->getContext()->getMeshTopology();
+    topo_curr = model->getCollisionTopology();
 
     if(dynamic_cast<PointSetTopologyContainer*>(topo_curr) == nullptr)
         return 0;
@@ -350,7 +350,7 @@ int TopologicalChangeManager::removeItemsFromSphereModel(sofa::component::collis
                         }
                     }
                 }
-                topo_curr = topoMap->getFrom()->getContext()->getMeshTopology();
+                topo_curr = topoMap->getFrom();
                 node_curr = dynamic_cast<simulation::Node*>(topo_curr->getContext());
 
                 break;
@@ -493,7 +493,7 @@ bool TopologicalChangeManager::incisionTriangleModel(TriangleModel *firstModel ,
     }
 
 
-    sofa::core::topology::BaseMeshTopology* currentTopology = firstCollisionModel->getContext()->getMeshTopology();
+    sofa::core::topology::BaseMeshTopology* currentTopology = firstCollisionModel->getCollisionTopology();
     simulation::Node* collisionNode = dynamic_cast<simulation::Node*>(firstCollisionModel->getContext());
 
     // Test if a TopologicalMapping (by default from TetrahedronSetTopology to TriangleSetTopology) exists :


### PR DESCRIPTION
Last and maybe least PR on adding SingleLink to Topology in all components.
Following PR #1183 and #1199 
<br>
**Addition change done in this PR:**
- Add new method getMeshTopologyLink() to quickly search for all component updated. (to replace all by next link generation)
- Replace methods getLocalMeshTopology and getActiveMeshTopology by getMeshTopologyLink with imposed searchDir (temporary change)
- Replace getMeshTopology method in collision model by getCollisionTopology using the l_topology

<br>

**Change done in all compoents:**
As discuss in #744 . The idea at the end is to remove all GetMeshTopology. 
1. Add SingleLink in all component accessing GetMeshTopology from context
2. Update all scenes but keep backward compability:
```
if (linkTopology.empty()){
  msg_warning() <<"set the link";
  linkTopology.set((this->getContext()->getMeshTopologyLink());
}
```
3. Flag all getXXXMeshTopology to Depreciate 20.06 ?
4. after 20.06 Remove all getMeshTopology()

<br>

**Full list update: in the 3 PR**
- [SofaBaseCollision] 
  - CapsuleModel
- [SofaBaseMechanics]
  - DiagonalMass
  - MechanicalObject
  - SubsetMapping
  - UniformMass
- [SofaBaseTopology] 
  - PointSetGeometryAlgorithms
- [SofaBaseVisual] 
  - VisualModelImpl
- [SofaBoundaryCondition]
  - AffineMovementConstraint
  - ConstantForceField
  - EdgePressureForceField
  - FixedConstraint
  - FixedPlaneConstraint
  - FixedTranslationConstraint
  - HermiteSplineConstraint
  - LinearForceField
  - LinearMovementConstraint
  - LinearVelocityConstraint
  - OscillatingTorsionPressureForceField
  - ParabolicConstraint
  - PartialLinearMovementConstraint
  - PatchTestMovementConstraint
  - ProjectDirectionConstraint
  - ProjectToLineConstraint
  - ProjectToPlaneConstraint
  - ProjectToPointConstraint
  - QuadPressureForceField
  - SurfacePressureForceField
  - TaitSurfacePressureForceField
  - TrianglePressureForceField
- [SofaConstraint]
  - DistanceLMConstraint
  - DOFBlockerLMConstraint
  - FixedLMConstraint
  - UncoupledConstraintCorrection
- [SofaDeformable] 
  - MeshSpringForceField
- [SofaExporter] 
  - WriteTopology
- [SofaGeneralDeformable]
  - FastTriangularBendingSprings
  - QuadBendingSprings
  - QuadularBendingSprings
  - TriangleBendingSprings
  - TriangularBendingSprings
  - TriangularBiquadraticSpringsForceField
  - TriangularQuadraticSpringsForceField
  - TriangularTensorMassForceField
  - VectorSpringForceField
- [SofaGeneralEngine] 
  - SmoothMeshEngine
- [SofaGeneralLoader] 
  - ReadTopology
- [SofaGeneralSimpleFem]
  - BeamFEMForceField
  - TetrahedralCorotationalFEMForceField
  - TriangularFEMForceFieldOptim
- [SofaMeshCollision]
  - LineModel
  - PointModel
  - TriangleModel
  - TriangleLocalMinDistanceFilter
- [SofaMiscCollision] 
  - TetrahedronModel
- [SofaMiscFem]
  - FastTetrahedralCorotationalForceField
  - StandardTetrahedralFEMForceField
  - TetrahedralTensorMassForceField
  - TetrahedronHyperelasticityFEMForceField
  - TriangleFEMForceField
  - TriangularAnisotropicFEMForceField
  - TriangularFEMForceField
- [SofaMiscForceField] 
  - MeshMatrixMass
- [SofaMiscMapping]
  - DistanceMapping
  - DistanceMapping
- [SofaMiscTopology] 
  - TopologicalChangeProcessor
- [SofaNonUniformFem] 
  - NonUniformHexahedronFEMForceFieldAndMass
- [SofaOpenglVisual] 
  - DataDisplay
- [SofaSimpleFem]
  - HexahedronFEMForceField
  - TetrahedronDiffusionFEMForceField
  - TetrahedronFEMForceField

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
