### PR TITLE
[SofaCore] Making BaseData::setParent() virtual

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
@@ -273,7 +273,7 @@ public:
 
     /// Link to a parent data. The value of this data will automatically duplicate the value of the parent data.
     bool setParent(BaseData* parent, const std::string& path = std::string());
-    bool setParent(const std::string& path);
+    virtual bool setParent(const std::string& path);
 
     /// Check if a given Data can be linked as a parent of this data
     virtual bool validParent(BaseData* parent);


### PR DESCRIPTION
setParent is called on Datas when parsing BaseObjectDescriptions on BaseObjects.
The default behavior is incompatible with the Data-based API we want to substitute to the current Link system between components.

I thus want to be able to override the default setParent() behavior in my ObjectLink POC (see [here](https://github.com/SofaDefrost/ComponentData_POC/pull/1) for draft implementation)

Please, don't hesitate to comment on the PR on the POC repository's pull request mentioned above

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
