### PR TITLE
[CI] Test GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,20 +13,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: build-tools
-        run: apt install build-essential ninja-build clang
+        run: sudo apt install build-essential ninja-build clang
       - name: project-tools
-        run: apt install cmake ccache
+        run: sudo apt install cmake ccache
       - name: qt5-deps
-        run: apt install qt5-default
+        run: sudo apt install qt5-default
       - name: boost-deps
-        run: apt install libboost-atomic-dev libboost-chrono-dev \
+        run: sudo apt install libboost-atomic-dev libboost-chrono-dev \
              libboost-date-time-dev libboost-filesystem-dev \
              libboost-locale-dev libboost-regex-dev libboost-system-dev \
              libboost-thread-dev libboost-program-options-dev
       - name: python2-deps
-        run: apt install python2.7-dev python-numpy python-scipy
+        run: sudo apt install python2.7-dev python-numpy python-scipy
       - name: extra-deps
-        run: apt install libpng-dev libjpeg-dev libtiff-dev zlib1g-dev libglew-dev
+        run: sudo apt install libpng-dev libjpeg-dev libtiff-dev zlib1g-dev libglew-dev
         
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,9 @@ jobs:
   install_deps:
     runs-on: ubuntu-latest
     steps:
+      - name: apt-update
+        run: 
+          sudo apt-get update
       - name: build-tools
         run: sudo apt install build-essential ninja-build clang
       - name: project-tools

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,20 +9,20 @@ on:
       - master
 
 jobs:
-  install-dependencies:
-    runs-on: [self-hosted, linux]
-    steps:
-        - name: install dependencies
-          run: |
-            sudo apt-get -y update
-            sudo apt install -y build-essential ninja-build clang
-            sudo apt install -y cmake ccache
-            sudo apt install -y qt5-default
-            sudo apt install -y libboost-atomic-dev libboost-all-dev
-            sudo apt install -y python2.7-dev python-numpy python-scipy
-            sudo apt install -y libpng-dev libjpeg-dev libtiff-dev zlib1g-dev libglew-dev
+#  install-dependencies:
+#    runs-on: [self-hosted, linux]
+#    steps:
+#        - name: install dependencies
+#          run: |
+#            sudo apt-get -y update
+#            sudo apt install -y build-essential ninja-build clang
+#            sudo apt install -y cmake ccache
+#            sudo apt install -y qt5-default
+#            sudo apt install -y libboost-atomic-dev libboost-all-dev
+#            sudo apt install -y python2.7-dev python-numpy python-scipy
+#            sudo apt install -y libpng-dev libjpeg-dev libtiff-dev zlib1g-dev libglew-dev
   build:
-    needs: [install-dependencies]
+#    needs: [install-dependencies]
     # ideally I'd like this to run in custom docker image instead of running directly in the self-hosted vm:
     runs-on: [self-hosted, linux] # [self-hosted docker://bmarques68/sofa-ubuntu:18.04]
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,10 +29,11 @@ jobs:
           cd build;
           cmake .. -G Ninja -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -DSOFA_BUILD_METIS=ON -DPLUGIN_SOFASPARSESOLVER=ON
           
-      - name: make
+      - name: build
         run:
-          make -j4;
-          make install
+          echo $PWD
+          ninja;
+          ninja install
 
   # run-tests:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     # ideally I'd like this to run in custom docker image instead of running directly in the self-hosted vm:
-    runs-on: [self-hosted, ubuntu-18.04] # [self-hosted docker://bmarques68/sofa-ubuntu:18.04]
+    runs-on: [self-hosted, linux] # [self-hosted docker://bmarques68/sofa-ubuntu:18.04]
     steps:
       # Chechout the project's repo:
       - uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     # ideally I'd like this to run in custom docker image instead of running directly in the self-hosted vm:
-    runs-on: [self-hosted ubuntu-18.04] # [self-hosted docker://bmarques68/sofa-ubuntu:18.04]
+    runs-on: [self-hosted, ubuntu-18.04] # [self-hosted docker://bmarques68/sofa-ubuntu:18.04]
     steps:
       # Chechout the project's repo:
       - uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,20 @@ on:
       - master
 
 jobs:
-  build:
+  install-dependencies:
+    runs-on: [self-hosted, linux]
+    steps:
+        - name: install dependencies
+          run: |
+            sudo apt-get -y update
+            sudo apt install -y build-essential ninja-build clang
+            sudo apt install -y cmake ccache
+            sudo apt install -y qt5-default
+            sudo apt install -y libboost-atomic-dev libboost-all-dev
+            sudo apt install -y python2.7-dev python-numpy python-scipy
+            sudo apt install -y libpng-dev libjpeg-dev libtiff-dev zlib1g-dev libglew-dev
+  cmake:
+    needs: [install-dependencies]
     # ideally I'd like this to run in custom docker image instead of running directly in the self-hosted vm:
     runs-on: [self-hosted, linux] # [self-hosted docker://bmarques68/sofa-ubuntu:18.04]
     steps:
@@ -17,45 +30,30 @@ jobs:
       - uses: actions/checkout@v1
       
       # when running on a self-hosted vm with preinstalled deps this dependency step is not necessary of course...:
-      - name: install dependencies
-        run: |
-          sudo apt-get -y update
-          sudo apt install -y build-essential ninja-build clang
-          sudo apt install -y cmake ccache
-          sudo apt install -y qt5-default
-          sudo apt install -y libboost-atomic-dev libboost-all-dev
-          sudo apt install -y python2.7-dev python-numpy python-scipy
-          sudo apt install -y libpng-dev libjpeg-dev libtiff-dev zlib1g-dev libglew-dev
-        
       - name: configure SOFA
         run: |
           mkdir -p build
           cd build
           cmake .. -G Ninja -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -DSOFA_BUILD_METIS=ON -DPLUGIN_SOFASPARSESOLVER=ON -DPLUGIN_SOFAPYTHON=ON
           
+
+  build:
+    needs: [cmake]
+    runs-on: [self-hosted, linux]
+    steps:
       - name: build SOFA
         run: |
           cd build
           ninja
           ninja install
           
-      - name: Upload build-dir
-        uses: actions/upload-artifact@v1
-        with:
-          name: build-dir
-          path: ./build
-          
   run-tests:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - name: Download build-dir
-        uses: actions/download-artifact@v1
-        with:
-          name: build-dir
       - name: run-tests
         run: |
-          cd build
+          cd build/install/bin
           for f in *_test
           do
             ./$f

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,16 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: apt-update
-        run: 
-          sudo apt-get update;
-          sudo apt install build-essential ninja-build clang;
-          sudo apt install cmake ccache;
-          sudo apt install qt5-default;
-          sudo apt install libboost-atomic-dev libboost-all-dev;
-          sudo apt install python2.7-dev python-numpy python-scipy;
-          sudo apt install libpng-dev libjpeg-dev libtiff-dev zlib1g-dev libglew-dev;
-          
+      - uses: docker://bmarques68/sofa-ubuntu:18.04          
       - uses: actions/checkout@v1
       - name: configure
         run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,12 +43,12 @@ jobs:
           ninja install
           
   run-tests:
-    runs-on: [self-hosted, linux]
     needs: [build]
+    runs-on: [self-hosted, linux]
     steps:
       - name: run-tests
         run: |
-          cd ~/SOFA/bin
+          cd ../build/bin
           for f in *_test
           do
             ./$f

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
           
       - name: build
         run:
-          echo $PWD
+          cd build;
           ninja;
           ninja install
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,50 @@
+name: CMake/C++ CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  install_deps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: build-tools
+        run: apt install build-essential ninja-build clang
+      - name: project-tools
+        run: apt install cmake ccache
+      - name: qt5-deps
+        run: apt install qt5-default
+      - name: boost-deps
+        run: apt install libboost-atomic-dev libboost-chrono-dev \
+             libboost-date-time-dev libboost-filesystem-dev \
+             libboost-locale-dev libboost-regex-dev libboost-system-dev \
+             libboost-thread-dev libboost-program-options-dev
+      - name: python2-deps
+        run: apt install python2.7-dev python-numpy python-scipy
+      - name: extra-deps
+        run: apt install libpng-dev libjpeg-dev libtiff-dev zlib1g-dev libglew-dev
+        
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: create_dir
+      run: mkdir build
+    - name: cmake
+      run: cmake -G Ninja -DCMAKE_CXX_COMPILER="/usr/bin/clang++" \
+           -S . -B ./build \
+           -DSOFA_BUILD_METIS=ON -DPLUGIN_SOFASPARSESOLVER=ON
+    - name: make
+      run: make -j4
+    - name: make install
+      run: make install -j4
+
+  # run-tests:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: run-tests
+  #     run: sh build/bin/run-tests.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,22 +10,22 @@ on:
 
 jobs:
   build:
-    # I want to use a custom docker image on a self-hosted vm on ci.inria.fr, with preinstalled deps. meanwhile, let's stick to a github-hosted docker image:
-    runs-on: ubuntu-18.04 # [self-hosted docker://bmarques68/sofa-ubuntu:18.04]
+    # ideally I'd like this to run in custom docker image instead of running directly in the self-hosted vm:
+    runs-on: [self-hosted ubuntu-18.04] # [self-hosted docker://bmarques68/sofa-ubuntu:18.04]
     steps:
       # Chechout the project's repo:
       - uses: actions/checkout@v1
       
-      # Ideally we would want to use a self-hosted docker with preinstalled deps. meanwhile, let's add a dependency step:
+      # when running on a self-hosted vm with preinstalled deps this dependency step is not necessary of course...:
       - name: install dependencies
-        run: 
-          sudo apt-get update;
-          sudo apt install build-essential ninja-build clang;
-          sudo apt install cmake ccache;
-          sudo apt install qt5-default;
-          sudo apt install libboost-atomic-dev libboost-all-dev;
-          sudo apt install python2.7-dev python-numpy python-scipy;
-          sudo apt install libpng-dev libjpeg-dev libtiff-dev zlib1g-dev libglew-dev;
+        run: |
+          sudo apt-get -y update
+          sudo apt install -y build-essential ninja-build clang
+          sudo apt install -y cmake ccache
+          sudo apt install -y qt5-default
+          sudo apt install -y libboost-atomic-dev libboost-all-dev
+          sudo apt install -y python2.7-dev python-numpy python-scipy
+          sudo apt install -y libpng-dev libjpeg-dev libtiff-dev zlib1g-dev libglew-dev
         
       - name: configure SOFA
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: bmarques68/sofa-ubuntu:18.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - uses: docker://bmarques68/sofa-ubuntu:18.04          

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,16 +10,17 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: bmarques68/sofa-ubuntu:18.04
     steps:
-      - uses: docker://bmarques68/sofa-ubuntu:18.04          
       - uses: actions/checkout@v1
+      - uses: docker://bmarques68/sofa-ubuntu:18.04          
       - name: configure
         run:
           mkdir -p build;
           cd build;
           cmake .. -G Ninja -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -DSOFA_BUILD_METIS=ON -DPLUGIN_SOFASPARSESOLVER=ON
           
+      - uses: docker://bmarques68/sofa-ubuntu:18.04          
       - name: build
         run:
           cd build;

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,7 @@ jobs:
           
   run-tests:
     runs-on: ubuntu-latest
+    needs: [build]
     steps:
       - name: Download build-dir
         uses: actions/download-artifact@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         run:
           mkdir -p build;
           tree $PWD -L 2;
-          cmake -G Ninja -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -S "." -B "./build" -DSOFA_BUILD_METIS=ON -DPLUGIN_SOFASPARSESOLVER=ON
+          cmake -S . -B build #-G Ninja -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -DSOFA_BUILD_METIS=ON -DPLUGIN_SOFASPARSESOLVER=ON
       - name: make
         run:
           make -j4;

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,29 +15,23 @@ jobs:
       - name: apt-update
         run: 
           sudo apt-get update
-      - name: build-tools
-        run: sudo apt install build-essential ninja-build clang
-      - name: project-tools
-        run: sudo apt install cmake ccache
-      - name: qt5-deps
-        run: sudo apt install qt5-default
-      - name: boost-deps
-        run: sudo apt install libboost-atomic-dev libboost-all-dev
-      - name: python2-deps
-        run: sudo apt install python2.7-dev python-numpy python-scipy
-      - name: extra-deps
-        run: sudo apt install libpng-dev libjpeg-dev libtiff-dev zlib1g-dev libglew-dev
+          sudo apt install build-essential ninja-build clang
+          sudo apt install cmake ccache
+          sudo apt install qt5-default
+          sudo apt install libboost-atomic-dev libboost-all-dev
+          sudo apt install python2.7-dev python-numpy python-scipy
+          sudo apt install libpng-dev libjpeg-dev libtiff-dev zlib1g-dev libglew-dev
+
       - uses: actions/checkout@v1
-      - name: create_dir
-        run: mkdir build
-      - name: cmake
-        run: cmake -G Ninja -DCMAKE_CXX_COMPILER="/usr/bin/clang++" \
-             -S . -B ./build \
-             -DSOFA_BUILD_METIS=ON -DPLUGIN_SOFASPARSESOLVER=ON
+      - name: configure
+        run:
+          mkdir -p build
+          echo $PWD
+          cmake -G Ninja -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -S "./sofa" -B "./build" -DSOFA_BUILD_METIS=ON -DPLUGIN_SOFASPARSESOLVER=ON
       - name: make
-        run: make -j4
-      - name: make install
-        run: make install -j4
+        run:
+          make -j4
+          make install
 
   # run-tests:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,19 +14,19 @@ jobs:
     steps:
       - name: apt-update
         run: 
-          sudo apt-get update;
-          sudo apt install build-essential ninja-build clang;
-          sudo apt install cmake ccache;
-          sudo apt install qt5-default;
-          sudo apt install libboost-atomic-dev libboost-all-dev;
-          sudo apt install python2.7-dev python-numpy python-scipy;
-          sudo apt install libpng-dev libjpeg-dev libtiff-dev zlib1g-dev libglew-dev;
-
+          #sudo apt-get update;
+          #sudo apt install build-essential ninja-build clang;
+          #sudo apt install cmake ccache;
+          #sudo apt install qt5-default;
+          #sudo apt install libboost-atomic-dev libboost-all-dev;
+          #sudo apt install python2.7-dev python-numpy python-scipy;
+          #sudo apt install libpng-dev libjpeg-dev libtiff-dev zlib1g-dev libglew-dev;
+          echo "plop"
       - uses: actions/checkout@v1
       - name: configure
         run:
           mkdir -p build;
-          echo $PWD;
+          tree $PWD -L 2;
           cmake -G Ninja -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -S "." -B "./build" -DSOFA_BUILD_METIS=ON -DPLUGIN_SOFASPARSESOLVER=ON
       - name: make
         run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,10 +19,7 @@ jobs:
       - name: qt5-deps
         run: sudo apt install qt5-default
       - name: boost-deps
-        run: sudo apt install libboost-atomic-dev libboost-chrono-dev \
-             libboost-date-time-dev libboost-filesystem-dev \
-             libboost-locale-dev libboost-regex-dev libboost-system-dev \
-             libboost-thread-dev libboost-program-options-dev
+        run: sudo apt install libboost-atomic-dev libboost-all-dev
       - name: python2-deps
         run: sudo apt install python2.7-dev python-numpy python-scipy
       - name: extra-deps

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: run-tests
         run: |
-          cd ~/SOFA/bin
+          cd /builds/SOFA/bin
           for f in *_test
           do
             ./$f

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,23 +14,23 @@ jobs:
     steps:
       - name: apt-update
         run: 
-          sudo apt-get update
-          sudo apt install build-essential ninja-build clang
-          sudo apt install cmake ccache
-          sudo apt install qt5-default
-          sudo apt install libboost-atomic-dev libboost-all-dev
-          sudo apt install python2.7-dev python-numpy python-scipy
-          sudo apt install libpng-dev libjpeg-dev libtiff-dev zlib1g-dev libglew-dev
+          sudo apt-get update;
+          sudo apt install build-essential ninja-build clang;
+          sudo apt install cmake ccache;
+          sudo apt install qt5-default;
+          sudo apt install libboost-atomic-dev libboost-all-dev;
+          sudo apt install python2.7-dev python-numpy python-scipy;
+          sudo apt install libpng-dev libjpeg-dev libtiff-dev zlib1g-dev libglew-dev;
 
       - uses: actions/checkout@v1
       - name: configure
         run:
-          mkdir -p build
-          echo $PWD
+          mkdir -p build;
+          echo $PWD;
           cmake -G Ninja -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -S "./sofa" -B "./build" -DSOFA_BUILD_METIS=ON -DPLUGIN_SOFASPARSESOLVER=ON
       - name: make
         run:
-          make -j4
+          make -j4;
           make install
 
   # run-tests:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
             sudo apt install -y libboost-atomic-dev libboost-all-dev
             sudo apt install -y python2.7-dev python-numpy python-scipy
             sudo apt install -y libpng-dev libjpeg-dev libtiff-dev zlib1g-dev libglew-dev
-  cmake:
+  build:
     needs: [install-dependencies]
     # ideally I'd like this to run in custom docker image instead of running directly in the self-hosted vm:
     runs-on: [self-hosted, linux] # [self-hosted docker://bmarques68/sofa-ubuntu:18.04]
@@ -32,18 +32,13 @@ jobs:
       # when running on a self-hosted vm with preinstalled deps this dependency step is not necessary of course...:
       - name: configure SOFA
         run: |
-          mkdir -p build
-          cd build
-          cmake .. -G Ninja -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -DSOFA_BUILD_METIS=ON -DPLUGIN_SOFASPARSESOLVER=ON -DPLUGIN_SOFAPYTHON=ON -DCMAKE_INSTALL_PREFIX="~/SOFA"
+          mkdir -p ../build
+          cd ../build
+          cmake ../sofa -G Ninja -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -DSOFA_BUILD_METIS=ON -DPLUGIN_SOFASPARSESOLVER=ON -DPLUGIN_SOFAPYTHON=ON -DCMAKE_INSTALL_PREFIX="~/SOFA"
           
-
-  build:
-    needs: [cmake]
-    runs-on: [self-hosted, linux]
-    steps:
       - name: build SOFA
         run: |
-          cd build
+          cd ../build
           ninja
           ninja install
           

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,21 +27,17 @@ jobs:
         run: sudo apt install python2.7-dev python-numpy python-scipy
       - name: extra-deps
         run: sudo apt install libpng-dev libjpeg-dev libtiff-dev zlib1g-dev libglew-dev
-        
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: create_dir
-      run: mkdir build
-    - name: cmake
-      run: cmake -G Ninja -DCMAKE_CXX_COMPILER="/usr/bin/clang++" \
-           -S . -B ./build \
-           -DSOFA_BUILD_METIS=ON -DPLUGIN_SOFASPARSESOLVER=ON
-    - name: make
-      run: make -j4
-    - name: make install
-      run: make install -j4
+      - uses: actions/checkout@v1
+      - name: create_dir
+        run: mkdir build
+      - name: cmake
+        run: cmake -G Ninja -DCMAKE_CXX_COMPILER="/usr/bin/clang++" \
+             -S . -B ./build \
+             -DSOFA_BUILD_METIS=ON -DPLUGIN_SOFASPARSESOLVER=ON
+      - name: make
+        run: make -j4
+      - name: make install
+        run: make install -j4
 
   # run-tests:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,25 +10,52 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    # I want to use a custom docker image on a self-hosted vm on ci.inria.fr, with preinstalled deps. meanwhile, let's stick to a github-hosted docker image:
+    runs-on: ubuntu-18.04 # [self-hosted docker://bmarques68/sofa-ubuntu:18.04]
     steps:
+      # Chechout the project's repo:
       - uses: actions/checkout@v1
-      - uses: docker://bmarques68/sofa-ubuntu:18.04          
-      - name: configure
-        run:
-          mkdir -p build;
-          cd build;
-          cmake .. -G Ninja -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -DSOFA_BUILD_METIS=ON -DPLUGIN_SOFASPARSESOLVER=ON
+      
+      # Ideally we would want to use a self-hosted docker with preinstalled deps. meanwhile, let's add a dependency step:
+      - name: install dependencies
+        run: 
+          sudo apt-get update;
+          sudo apt install build-essential ninja-build clang;
+          sudo apt install cmake ccache;
+          sudo apt install qt5-default;
+          sudo apt install libboost-atomic-dev libboost-all-dev;
+          sudo apt install python2.7-dev python-numpy python-scipy;
+          sudo apt install libpng-dev libjpeg-dev libtiff-dev zlib1g-dev libglew-dev;
+        
+      - name: configure SOFA
+        run: |
+          mkdir -p build
+          cd build
+          cmake .. -G Ninja -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -DSOFA_BUILD_METIS=ON -DPLUGIN_SOFASPARSESOLVER=ON -DPLUGIN_SOFAPYTHON=ON
           
-      - uses: docker://bmarques68/sofa-ubuntu:18.04          
-      - name: build
-        run:
-          cd build;
-          ninja;
+      - name: build SOFA
+        run: |
+          cd build
+          ninja
           ninja install
-
-  # run-tests:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - name: run-tests
-  #     run: sh build/bin/run-tests.sh
+          
+      - name: Upload build-dir
+        uses: actions/upload-artifact@v1
+        with:
+          name: build-dir
+          path: ./build
+          
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build-dir
+        uses: actions/download-artifact@v1
+        with:
+          name: build-dir
+      - name: run-tests
+        run: |
+          cd build
+          for f in *_test
+          do
+            ./$f
+          done

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - name: apt-update
         run: 
+          sudo apt-get install tree;
           #sudo apt-get update;
           #sudo apt install build-essential ninja-build clang;
           #sudo apt install cmake ccache;
@@ -21,7 +22,6 @@ jobs:
           #sudo apt install libboost-atomic-dev libboost-all-dev;
           #sudo apt install python2.7-dev python-numpy python-scipy;
           #sudo apt install libpng-dev libjpeg-dev libtiff-dev zlib1g-dev libglew-dev;
-          echo "plop"
       - uses: actions/checkout@v1
       - name: configure
         run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           mkdir -p build
           cd build
-          cmake .. -G Ninja -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -DSOFA_BUILD_METIS=ON -DPLUGIN_SOFASPARSESOLVER=ON -DPLUGIN_SOFAPYTHON=ON
+          cmake .. -G Ninja -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -DSOFA_BUILD_METIS=ON -DPLUGIN_SOFASPARSESOLVER=ON -DPLUGIN_SOFAPYTHON=ON -DCMAKE_INSTALL_PREFIX="~/SOFA"
           
 
   build:
@@ -53,7 +53,7 @@ jobs:
     steps:
       - name: run-tests
         run: |
-          cd build/install/bin
+          cd ~/SOFA/bin
           for f in *_test
           do
             ./$f

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,20 +14,21 @@ jobs:
     steps:
       - name: apt-update
         run: 
-          sudo apt-get install tree;
-          #sudo apt-get update;
-          #sudo apt install build-essential ninja-build clang;
-          #sudo apt install cmake ccache;
-          #sudo apt install qt5-default;
-          #sudo apt install libboost-atomic-dev libboost-all-dev;
-          #sudo apt install python2.7-dev python-numpy python-scipy;
-          #sudo apt install libpng-dev libjpeg-dev libtiff-dev zlib1g-dev libglew-dev;
+          sudo apt-get update;
+          sudo apt install build-essential ninja-build clang;
+          sudo apt install cmake ccache;
+          sudo apt install qt5-default;
+          sudo apt install libboost-atomic-dev libboost-all-dev;
+          sudo apt install python2.7-dev python-numpy python-scipy;
+          sudo apt install libpng-dev libjpeg-dev libtiff-dev zlib1g-dev libglew-dev;
+          
       - uses: actions/checkout@v1
       - name: configure
         run:
           mkdir -p build;
-          tree $PWD -L 2;
-          cmake -S . -B build #-G Ninja -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -DSOFA_BUILD_METIS=ON -DPLUGIN_SOFASPARSESOLVER=ON
+          cd build;
+          cmake .. -G Ninja -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -DSOFA_BUILD_METIS=ON -DPLUGIN_SOFASPARSESOLVER=ON
+          
       - name: make
         run:
           make -j4;

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,12 +43,12 @@ jobs:
           ninja install
           
   run-tests:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     needs: [build]
     steps:
       - name: run-tests
         run: |
-          cd /builds/SOFA/bin
+          cd ~/SOFA/bin
           for f in *_test
           do
             ./$f

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  install_deps:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: apt-update
@@ -27,7 +27,7 @@ jobs:
         run:
           mkdir -p build;
           echo $PWD;
-          cmake -G Ninja -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -S "./sofa" -B "./build" -DSOFA_BUILD_METIS=ON -DPLUGIN_SOFASPARSESOLVER=ON
+          cmake -G Ninja -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -S "." -B "./build" -DSOFA_BUILD_METIS=ON -DPLUGIN_SOFASPARSESOLVER=ON
       - name: make
         run:
           make -j4;

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,17 @@
+name: test-workflow
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  plop:
+    runs-on: [self-hosted, linux]
+    needs: [build]
+    steps:
+      - name: plop
+        run: echo "pouet pouet"


### PR DESCRIPTION
Been looking into github actions, trying to get it to do what I want... not yet really successfully, but I've got a proof of concept.

Currently, I run the checks on a slave on ci.inria.fr, and the current POC does a minimalist build / install / run tests workflow.

But I think it would be worth asking ourselves what the perfect CI/CD pipeline could be for SOFA & it's plugins. In my mind, I'd like this:

SOFA:
- build / run tests (of course...)
- build documentation (doxygen, sphinx...) & deploy on github pages / readthedocs / website
- build docker image & push on docker hub or equivalent (consistent build environment)
- generate standalone binaries, zip & upload on github pages / website (SOFA-latest / sofa-nightly build...)

PLUGINS:
- load docker image, or wget binaries generated by SOFA
- build / run tests (of course...)
- build documentation (doxygen, sphinx...) & deploy on github pages / readthedocs / website
- build docker image & push on docker hub or equivalent
- generate binaries, zip & upload on github pages / website
 
ADVANTAGES of github actions vs JK2:
- ALL CI/CD config centralized in a .github folder in the git repository
- NO separate tool but Github's interface
- SUPER DUPER KICKASS interface design from github, gives direct access to all logs, checks, status badges etc. for each workflow / job / step in the Github checks processes


![plop2](https://user-images.githubusercontent.com/13734391/69730387-3e4fc280-1128-11ea-8f91-20eeb660d233.png)


DISADVANTAGES:
- Still in beta (some bugs noticed, especially when running in self-hosted slaves...)
- A lot to recode given what @guparan did in JK2
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
