### PR TITLE
[SofaCore] Add DDGLinks

### DIFF
--- a/SofaKernel/modules/SofaCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/CMakeLists.txt
@@ -110,6 +110,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/objectmodel/ContextObject.h
     ${SRC_ROOT}/objectmodel/DDGNode.h
     ${SRC_ROOT}/objectmodel/Data.h
+    ${SRC_ROOT}/objectmodel/DDGLink.h
     ${SRC_ROOT}/objectmodel/DataFileName.h
     ${SRC_ROOT}/objectmodel/DetachNodeEvent.h
     ${SRC_ROOT}/objectmodel/Event.h
@@ -217,6 +218,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/objectmodel/Context.cpp
     ${SRC_ROOT}/objectmodel/DDGNode.cpp
     ${SRC_ROOT}/objectmodel/Data.cpp
+    ${SRC_ROOT}/objectmodel/DDGLink.cpp
     ${SRC_ROOT}/objectmodel/DataCallback.cpp
     ${SRC_ROOT}/objectmodel/DataFileName.cpp
     ${SRC_ROOT}/objectmodel/DetachNodeEvent.cpp

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -371,7 +371,7 @@ std::vector< BaseData* > Base::findGlobalField( const std::string &name ) const
     std::vector<BaseData*> result;
     //Search in the aliases
     auto range = m_aliasData.equal_range(name);
-    for (mapIterator itAlias=range.first; itAlias!=range.second; ++itAlias)
+    for (auto itAlias=range.first; itAlias!=range.second; ++itAlias)
         result.push_back(itAlias->second);
     return result;
 }
@@ -382,7 +382,7 @@ std::vector< BaseDDGLink* > Base::findGlobalDDGLink( const std::string &name ) c
     std::vector<BaseDDGLink*> result;
     //Search in the aliases
     auto range = m_aliasDDGLink.equal_range(name);
-    for (mapIterator itAlias=range.first; itAlias!=range.second; ++itAlias)
+    for (auto itAlias=range.first; itAlias!=range.second; ++itAlias)
         result.push_back(itAlias->second);
     return result;
 }
@@ -418,7 +418,7 @@ std::vector< BaseLink* > Base::findLinks( const std::string &name ) const
     std::vector<BaseLink*> result;
     //Search in the aliases
     auto range = m_aliasLink.equal_range(name);
-    for (mapIterator itAlias=range.first; itAlias!=range.second; ++itAlias)
+    for (auto itAlias=range.first; itAlias!=range.second; ++itAlias)
         result.push_back(itAlias->second);
     return result;
 }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -339,16 +339,14 @@ void Base::removeTag(Tag t)
 void Base::removeData(BaseData* d)
 {
     m_vecData.erase(std::find(m_vecData.begin(), m_vecData.end(), d));
-    typedef MapData::const_iterator mapIterator;
-    std::pair< mapIterator, mapIterator> range = m_aliasData.equal_range(d->getName());
+    auto range = m_aliasData.equal_range(d->getName());
     m_aliasData.erase(range.first, range.second);
 }
 
 void Base::removeDDGLink(BaseDDGLink* d)
 {
     m_vecDDGLink.erase(std::find(m_vecDDGLink.begin(), m_vecDDGLink.end(), d));
-    typedef MapDDGLink::const_iterator mapIterator;
-    std::pair< mapIterator, mapIterator> range = m_aliasDDGLink.equal_range(d->getName());
+    auto range = m_aliasDDGLink.equal_range(d->getName());
     m_aliasDDGLink.erase(range.first, range.second);
 }
 /// Find a data field given its name.
@@ -358,8 +356,7 @@ BaseData* Base::findData( const std::string &name ) const
     //Search in the aliases
     if(m_aliasData.size())
     {
-        typedef MapData::const_iterator mapIterator;
-        std::pair< mapIterator, mapIterator> range = m_aliasData.equal_range(name);
+        auto range = m_aliasData.equal_range(name);
         if (range.first != range.second)
             return range.first->second;
         else
@@ -373,8 +370,7 @@ std::vector< BaseData* > Base::findGlobalField( const std::string &name ) const
 {
     std::vector<BaseData*> result;
     //Search in the aliases
-    typedef MapData::const_iterator mapIterator;
-    std::pair< mapIterator, mapIterator> range = m_aliasData.equal_range(name);
+    auto range = m_aliasData.equal_range(name);
     for (mapIterator itAlias=range.first; itAlias!=range.second; ++itAlias)
         result.push_back(itAlias->second);
     return result;
@@ -385,8 +381,7 @@ std::vector< BaseDDGLink* > Base::findGlobalDDGLink( const std::string &name ) c
 {
     std::vector<BaseDDGLink*> result;
     //Search in the aliases
-    typedef MapDDGLink::const_iterator mapIterator;
-    std::pair< mapIterator, mapIterator> range = m_aliasDDGLink.equal_range(name);
+    auto range = m_aliasDDGLink.equal_range(name);
     for (mapIterator itAlias=range.first; itAlias!=range.second; ++itAlias)
         result.push_back(itAlias->second);
     return result;
@@ -398,8 +393,7 @@ std::vector< BaseDDGLink* > Base::findGlobalDDGLink( const std::string &name ) c
 BaseLink* Base::findLink( const std::string &name ) const
 {
     //Search in the aliases
-    typedef MapLink::const_iterator mapIterator;
-    std::pair< mapIterator, mapIterator> range = m_aliasLink.equal_range(name);
+    auto range = m_aliasLink.equal_range(name);
     if (range.first != range.second)
         return range.first->second;
     else
@@ -411,8 +405,7 @@ BaseLink* Base::findLink( const std::string &name ) const
 BaseDDGLink* Base::findDDGLink( const std::string &name ) const
 {
     //Search in the aliases
-    typedef MapDDGLink::const_iterator mapIterator;
-    std::pair< mapIterator, mapIterator> range = m_aliasDDGLink.equal_range(name);
+    auto range = m_aliasDDGLink.equal_range(name);
     if (range.first != range.second)
         return range.first->second;
     else
@@ -424,8 +417,7 @@ std::vector< BaseLink* > Base::findLinks( const std::string &name ) const
 {
     std::vector<BaseLink*> result;
     //Search in the aliases
-    typedef MapLink::const_iterator mapIterator;
-    std::pair< mapIterator, mapIterator> range = m_aliasLink.equal_range(name);
+    auto range = m_aliasLink.equal_range(name);
     for (mapIterator itAlias=range.first; itAlias!=range.second; ++itAlias)
         result.push_back(itAlias->second);
     return result;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -349,6 +349,12 @@ void Base::removeDDGLink(BaseDDGLink* d)
     auto range = m_aliasDDGLink.equal_range(d->getName());
     m_aliasDDGLink.erase(range.first, range.second);
 }
+
+void Base::addComponentStateOutput(BaseDDGLink* output) const
+{
+    output->addInput(&const_cast<Base*>(this)->d_componentstate);
+}
+
 /// Find a data field given its name.
 /// Return nullptr if not found. If more than one field is found (due to aliases), only the first is returned.
 BaseData* Base::findData( const std::string &name ) const

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -350,11 +350,6 @@ void Base::removeDDGLink(BaseDDGLink* d)
     m_aliasDDGLink.erase(range.first, range.second);
 }
 
-void Base::addComponentStateOutput(BaseDDGLink* output) const
-{
-    output->addInput(&const_cast<Base*>(this)->d_componentstate);
-}
-
 /// Find a data field given its name.
 /// Return nullptr if not found. If more than one field is found (due to aliases), only the first is returned.
 BaseData* Base::findData( const std::string &name ) const

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -317,9 +317,6 @@ public:
     /// Remove a DDGLink.
     void removeDDGLink(BaseDDGLink* l);
 
-    /// a helper method to add the componentState of a const Base* to a DDGLink.
-    void addComponentStateOutput(BaseDDGLink* output) const;
-
     typedef helper::vector<BaseData*> VecData;
     typedef std::multimap<std::string, BaseData*> MapData;
     typedef helper::vector<BaseLink*> VecLink;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -171,8 +171,6 @@ private:
 
 public:
 
-
-
     /// Accessor to the object name
     const std::string& getName() const
     {
@@ -318,6 +316,9 @@ public:
     void addDDGLink(BaseDDGLink* l, const std::string& name);
     /// Remove a DDGLink.
     void removeDDGLink(BaseDDGLink* l);
+
+    /// a helper method to add the componentState of a const Base* to a DDGLink.
+    void addComponentStateOutput(BaseDDGLink* output) const;
 
     typedef helper::vector<BaseData*> VecData;
     typedef std::multimap<std::string, BaseData*> MapData;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -25,6 +25,7 @@
 #include <sofa/helper/StringUtils.h>
 #include <sofa/defaulttype/BoundingBox.h>
 #include <sofa/core/objectmodel/Data.h>
+#include <sofa/core/objectmodel/DDGLink.h>
 #include <sofa/core/objectmodel/BaseObjectDescription.h>
 #include <sofa/core/objectmodel/Tag.h>
 
@@ -193,6 +194,8 @@ public:
     /// Get the template type names (if any) used to instantiate this object
     virtual std::string getTemplateName() const;
 
+    virtual std::string getPathName() const;
+
     /// Set the source filename (where the component is implemented)
     void setDefinitionSourceFileName(const std::string& sourceFileName);
 
@@ -255,10 +258,15 @@ public:
 
     /// Find data fields given a name: several can be found as we look into the alias map
     std::vector< BaseData* > findGlobalField( const std::string &name ) const;
+    std::vector< BaseDDGLink* > findGlobalDDGLink( const std::string &name ) const;
 
     /// Find a link given its name. Return nullptr if not found.
     /// If more than one link is found (due to aliases), only the first is returned.
     BaseLink* findLink( const std::string &name ) const;
+
+    /// Find a link given its name. Return nullptr if not found.
+    /// If more than one link is found (due to aliases), only the first is returned.
+    BaseDDGLink* findDDGLink( const std::string &name ) const;
 
     /// Find link fields given a name: several can be found as we look into the alias map
     std::vector< BaseLink* > findLinks( const std::string &name ) const;
@@ -288,6 +296,7 @@ public:
     /// Note that this method should only be called if the Data was not initialized with the initData method
     void addData(BaseData* f, const std::string& name);
 
+
     /// Add a data field.
     /// Note that this method should only be called if the Data was not initialized with the initData method
     void addData(BaseData* f);
@@ -302,21 +311,30 @@ public:
     /// Add a link.
     void addLink(BaseLink* l);
 
-    /// Remove a link.
-    void removeLink(BaseLink* l);
-
     /// Add an alias to a Link
     void addAlias( BaseLink* link, const char* alias);
+
+    /// Registers a DDGLink.
+    void addDDGLink(BaseDDGLink* l, const std::string& name);
+    /// Remove a DDGLink.
+    void removeDDGLink(BaseDDGLink* l);
 
     typedef helper::vector<BaseData*> VecData;
     typedef std::multimap<std::string, BaseData*> MapData;
     typedef helper::vector<BaseLink*> VecLink;
     typedef std::multimap<std::string, BaseLink*> MapLink;
+    typedef helper::vector<BaseDDGLink*> VecDDGLink;
+    typedef std::map<std::string, BaseDDGLink*> MapDDGLink;
 
     /// Accessor to the vector containing all the fields of this object
     const VecData& getDataFields() const { return m_vecData; }
     /// Accessor to the map containing all the aliases of this object
     const MapData& getDataAliases() const { return m_aliasData; }
+
+    /// Accessor to the vector containing all the fields of this object
+    const VecDDGLink& getDDGLinks() const { return m_vecDDGLink; }
+    /// Accessor to the vector containing all the fields of this object
+    const MapDDGLink& getDDGLinkAliases() const { return m_aliasDDGLink; }
 
     /// Accessor to the vector containing all the fields of this object
     const VecLink& getLinks() const { return m_vecLink; }
@@ -487,6 +505,8 @@ protected:
     /// name -> Link multi-map (includes names and aliases)
     MapLink m_aliasLink;
 
+    VecDDGLink m_vecDDGLink;
+    MapDDGLink m_aliasDDGLink;
 public:
     /// Name of the object.
     Data<std::string> name;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseClass.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseClass.h
@@ -308,12 +308,14 @@ public:
     }                                                                   \
     ::sofa::core::objectmodel::BaseDDGLink::InitDDGLink                 \
     initDDGLink(::sofa::core::objectmodel::Base* owner, std::string name, \
-                std::string help, std::string group = "")               \
+                std::string help, ::sofa::core::objectmodel::Base::SPtr   \
+                linkedBase = nullptr, std::string group = "")           \
     {                                                                   \
         ::sofa::core::objectmodel::BaseDDGLink::InitDDGLink init;       \
         init.owner = owner;                                             \
         init.name = name;                                               \
         init.help = help;                                               \
+        init.linkedBase = linkedBase.get();                             \
         init.group = group;                                             \
         return init;                                                    \
     }                                                                   \

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseClass.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseClass.h
@@ -306,6 +306,17 @@ public:
         return ::sofa::core::objectmodel::BaseLink::InitLink<MyType>    \
             (this, name, help);                                         \
     }                                                                   \
+    ::sofa::core::objectmodel::BaseDDGLink::InitDDGLink                 \
+    initDDGLink(::sofa::core::objectmodel::Base* owner, std::string name, \
+                std::string help, std::string group = "")               \
+    {                                                                   \
+        ::sofa::core::objectmodel::BaseDDGLink::InitDDGLink init;       \
+        init.owner = owner;                                             \
+        init.name = name;                                               \
+        init.help = help;                                               \
+        init.group = group;                                             \
+        return init;                                                    \
+    }                                                                   \
     using Inherit1::sout;                                               \
     using Inherit1::serr;                                               \
     using Inherit1::sendl

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
@@ -36,6 +36,7 @@ namespace objectmodel
 
 class Base;
 class BaseData;
+class BaseDDGLink;
 
 /**
  *  \brief Abstract base class for Data.

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
@@ -273,7 +273,7 @@ public:
 
     /// Link to a parent data. The value of this data will automatically duplicate the value of the parent data.
     bool setParent(BaseData* parent, const std::string& path = std::string());
-    bool setParent(const std::string& path);
+    virtual bool setParent(const std::string& path);
 
     /// Check if a given Data can be linked as a parent of this data
     virtual bool validParent(BaseData* parent);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseNode.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseNode.h
@@ -131,7 +131,7 @@ public:
     virtual const BaseContext* getContext() const = 0;
 
     /// Return the full path name of this node
-    virtual std::string getPathName() const;
+    virtual std::string getPathName() const override;
 
     /// Return the path from this node to the root node
     virtual std::string getRootPath() const;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.h
@@ -444,7 +444,7 @@ public:
 
 
     /// Return the full path name of this object
-    virtual std::string getPathName() const;
+    virtual std::string getPathName() const override;
 
     /// @name internalupdate
     ///   Methods related to tracking of data and the internal update

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.cpp
@@ -46,11 +46,28 @@ void BaseDDGLink::set(Base* linkedBase)
     setDirtyOutputs();
 }
 
+void BaseDDGLink::set(const Base* linkedBase)
+{
+    /// storing the ptr as non-const.. but nowhere should the ptr be modified afterwards if manipulating a DDGLink<T>
+    /// When manipulating BaseDDGLinks, be careful to use the correct getter or undefined behavior will occur.
+    m_linkedBase = const_cast<Base*>(linkedBase);
+    addInput(&m_linkedBase->d_componentstate);
+    ++m_counters[size_t(currentAspect())];
+    setDirtyOutputs();
+}
+
+const Base* BaseDDGLink::get() const
+{
+    const_cast <BaseDDGLink*> (this)->update();
+    return m_linkedBase;
+}
+
 Base* BaseDDGLink::get()
 {
     update();
     return m_linkedBase;
 }
+
 
 void BaseDDGLink::update()
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.cpp
@@ -48,10 +48,11 @@ void BaseDDGLink::set(Base* linkedBase)
 
 void BaseDDGLink::set(const Base* linkedBase)
 {
-    /// storing the ptr as non-const.. but nowhere should the ptr be modified afterwards if manipulating a DDGLink<T>
-    /// When manipulating BaseDDGLinks, be careful to use the correct getter or undefined behavior will occur.
+    /// UNSAFE: storing the ptr as non-const.. not a problem when manipulating a DDGLink<T> / DDGLink<const T>
+    /// but when manipulating a DDGLink<const T> through its abstract type BaseDDGLink, we must be careful to use
+    /// the correct getter or undefined behavior will occur.
     m_linkedBase = const_cast<Base*>(linkedBase);
-    addInput(&m_linkedBase->d_componentstate);
+    linkedBase->addComponentStateOutput(this);
     ++m_counters[size_t(currentAspect())];
     setDirtyOutputs();
 }
@@ -65,6 +66,8 @@ const Base* BaseDDGLink::get() const
 Base* BaseDDGLink::get()
 {
     update();
+    /// Dangerous: this method could have an undefined behavior if the linkedBase is a const_cast'ed pointer!
+    /// See BaseDDGLink::set(const Base*)
     return m_linkedBase;
 }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.cpp
@@ -46,28 +46,9 @@ void BaseDDGLink::set(Base* linkedBase)
     setDirtyOutputs();
 }
 
-void BaseDDGLink::set(const Base* linkedBase)
-{
-    /// UNSAFE: storing the ptr as non-const.. not a problem when manipulating a DDGLink<T> / DDGLink<const T>
-    /// but when manipulating a DDGLink<const T> through its abstract type BaseDDGLink, we must be careful to use
-    /// the correct getter or undefined behavior will occur.
-    m_linkedBase = const_cast<Base*>(linkedBase);
-    linkedBase->addComponentStateOutput(this);
-    ++m_counters[size_t(currentAspect())];
-    setDirtyOutputs();
-}
-
-const Base* BaseDDGLink::get() const
-{
-    const_cast <BaseDDGLink*> (this)->update();
-    return m_linkedBase;
-}
-
 Base* BaseDDGLink::get()
 {
     update();
-    /// Dangerous: this method could have an undefined behavior if the linkedBase is a const_cast'ed pointer!
-    /// See BaseDDGLink::set(const Base*)
     return m_linkedBase;
 }
 
@@ -108,6 +89,7 @@ std::string BaseDDGLink::getPathName() const
     std::string pathname = m_owner->name.getLinkPath();
     return pathname.substr(0, pathname.find_last_of(".")) + getName();
 }
+
 
 } // namespace objectmodel
 } // namespace core

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.cpp
@@ -1,0 +1,94 @@
+#include "DDGLink.h"
+
+namespace sofa
+{
+namespace core
+{
+namespace objectmodel
+{
+
+BaseDDGLink::BaseDDGLink(const BaseDDGLink::InitDDGLink &init)
+    : m_name(init.name),
+      m_help(init.help),
+      m_group(init.group),
+      m_linkedBase(init.linkedBase),
+      m_owner(init.owner),
+      m_dataFlags(init.dataFlags)
+{
+    addLink(&inputs);
+    addLink(&outputs);
+    m_counters.assign(0);
+
+    std::cout << "constructing ddglink with name " << m_name << std::endl;
+    if (m_owner)
+    {
+        std::cout << "adding ddglink with name " << m_name << " to " << m_owner->getName() << std::endl;
+        m_owner->addDDGLink(this, m_name);
+        std::cout << m_owner->findGlobalDDGLink(m_name).size() << std::endl;
+    }
+}
+
+BaseDDGLink::~BaseDDGLink()
+{
+
+}
+
+void BaseDDGLink::setOwner(Base* owner)
+{
+    m_owner = owner;
+}
+
+void BaseDDGLink::set(Base* linkedBase)
+{
+    m_linkedBase = linkedBase;
+    addInput(&m_linkedBase->d_componentstate);
+    ++m_counters[size_t(currentAspect())];
+    setDirtyOutputs();
+}
+
+Base* BaseDDGLink::get()
+{
+    update();
+    return m_linkedBase;
+}
+
+void BaseDDGLink::update()
+{
+    for(DDGLinkIterator it=inputs.begin(); it!=inputs.end(); ++it)
+    {
+        if ((*it)->isDirty())
+        {
+            (*it)->update();
+        }
+    }
+    ++m_counters[size_t(currentAspect())];
+    cleanDirty();
+}
+
+const std::string& BaseDDGLink::getName() const
+{
+    return m_name;
+}
+
+Base* BaseDDGLink::getOwner() const
+{
+    return m_owner;
+}
+
+BaseData* BaseDDGLink::getData() const
+{
+    return nullptr;
+}
+
+std::string BaseDDGLink::getPathName() const
+{
+    if (!m_owner)
+        return getName();
+
+    std::string pathname = m_owner->name.getLinkPath();
+    return pathname.substr(0, pathname.find_last_of(".")) + getName();
+}
+
+} // namespace objectmodel
+} // namespace core
+} // namespace sofa

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <sofa/core/objectmodel/DDGNode.h>
+#include <sofa/core/objectmodel/Base.h>
+#include <sofa/core/ExecParams.h>
+
+namespace sofa
+{
+namespace core
+{
+namespace objectmodel
+{
+
+
+/**
+ * @brief The BaseLink class
+ *
+ * BaseLink inherits DDGNode, thus is part of the data dependency graph, thus can have inputs and outputs.
+ * When setting a link, the linked base's componentState data is added as an input to the BaseLink,
+ * which creates the connection between the BaseLink and the DDG.
+ * any data, engine, etc. can then be connected as output.
+ */
+class BaseDDGLink : public DDGNode
+{
+public:
+    /// Flags that describe some properties of a Data, and that can be OR'd together.
+    /// \todo Probably remove FLAG_PERSISTENT, FLAG_ANIMATION_INSTANCE, FLAG_VISUAL_INSTANCE and FLAG_HAPTICS_INSTANCE, it looks like they are not used anywhere.
+    enum DataFlagsEnum
+    {
+        FLAG_NONE       = 0,      ///< Means "no flag" when a value is required.
+        FLAG_READONLY   = 1 << 0, ///< The Data will be read-only in GUIs.
+        FLAG_DISPLAYED  = 1 << 1, ///< The Data will be displayed in GUIs.
+        FLAG_PERSISTENT = 1 << 2, ///< The Data contains persistent information.
+        FLAG_AUTOLINK   = 1 << 3, ///< The Data should be autolinked when using the src="..." syntax.
+        FLAG_REQUIRED = 1 << 4, ///< True if the Data has to be set for the owner component to be valid (a warning is displayed at init otherwise)
+        FLAG_ANIMATION_INSTANCE = 1 << 10,
+        FLAG_VISUAL_INSTANCE = 1 << 11,
+        FLAG_HAPTICS_INSTANCE = 1 << 12,
+    };
+    /// Bit field that holds flags value.
+    typedef unsigned DataFlags;
+
+    /// Default value used for flags.
+    enum { FLAG_DEFAULT = FLAG_DISPLAYED | FLAG_PERSISTENT | FLAG_AUTOLINK };
+
+    /// This internal class is used by the initLink() methods to store initialization parameters of a Data
+    class InitDDGLink
+    {
+    public:
+        InitDDGLink()
+            : name(""),
+              help(""),
+              group(""),
+              linkedBase(nullptr),
+              owner(nullptr),
+              dataFlags(FLAG_DEFAULT) {}
+        std::string name;
+        std::string help;
+        std::string group;
+        Base* linkedBase;
+        Base* owner;
+        DataFlags dataFlags;
+    };
+
+    explicit BaseDDGLink(const InitDDGLink& init);
+
+    virtual ~BaseDDGLink() override;
+
+    void setOwner(Base* owner);
+
+    void set(Base* linkedBase);
+
+    Base* get();
+
+    virtual void update() override;
+
+    virtual const std::string& getName() const override;
+
+    virtual Base* getOwner() const override;
+
+    virtual BaseData* getData() const override;
+
+    std::string getPathName() const;
+
+protected:
+    std::string m_name {""};
+    std::string m_help {""};
+    std::string m_group {""};
+    Base* m_linkedBase {nullptr};
+    Base* m_owner {nullptr};
+    BaseData::DataFlags m_dataFlags {BaseData::FLAG_DEFAULT};
+
+private:
+    /// Number of changes since creation
+    sofa::helper::fixed_array<int, sofa::core::SOFA_DATA_MAX_ASPECTS> m_counters;
+};
+
+
+template <class T>
+class DDGLink : public BaseDDGLink
+{
+  public:
+
+    explicit DDGLink(const DDGLink::InitDDGLink& init)
+        : BaseDDGLink(init)
+    {
+    }
+
+    virtual ~DDGLink()
+    {
+    }
+
+    void set(T* linkedBase)
+    {
+        BaseDDGLink::set(linkedBase);
+    }
+
+    T* get()
+    {
+        return dynamic_cast<T*>(m_linkedBase);
+    }
+};
+
+} // namespace objectmodel
+} // namespace core
+} // namespace sofa

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
@@ -101,7 +101,7 @@ class DDGLink : public BaseDDGLink
 {
   public:
 
-    explicit DDGLink(const DDGLink::InitDDGLink& init)
+    explicit DDGLink(const BaseDDGLink::InitDDGLink& init)
         : BaseDDGLink(init)
     {
     }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
@@ -70,9 +70,7 @@ public:
     void setOwner(Base* owner);
 
     void set(Base* linkedBase);
-    void set(const Base* linkedBase);
 
-    const Base* get() const;
     Base* get();
 
     virtual void update() override;
@@ -123,6 +121,12 @@ class DDGLink : public BaseDDGLink
     {
         return dynamic_cast<T*>(m_linkedBase);
     }
+
+    T* operator->() { return get(); }
+    T* operator*() { return get(); }
+
+    void operator=(T* o) { this->set(o); }
+    void operator=(typename T::SPtr o) { this->set(o.get()); }
 };
 
 } // namespace objectmodel

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
@@ -89,6 +89,7 @@ protected:
     std::string m_name {""};
     std::string m_help {""};
     std::string m_group {""};
+
     Base* m_linkedBase {nullptr};
     Base* m_owner {nullptr};
     BaseData::DataFlags m_dataFlags {BaseData::FLAG_DEFAULT};

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
@@ -20,7 +20,7 @@ namespace objectmodel
  * which creates the connection between the BaseLink and the DDG.
  * any data, engine, etc. can then be connected as output.
  */
-class BaseDDGLink : public DDGNode
+class SOFA_CORE_API BaseDDGLink : public DDGNode
 {
 public:
     /// Flags that describe some properties of a Data, and that can be OR'd together.

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
@@ -69,7 +69,9 @@ public:
     void setOwner(Base* owner);
 
     void set(Base* linkedBase);
+    void set(const Base* linkedBase);
 
+    const Base* get() const;
     Base* get();
 
     virtual void update() override;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
@@ -3,6 +3,7 @@
 #include <sofa/core/objectmodel/DDGNode.h>
 #include <sofa/core/objectmodel/Base.h>
 #include <sofa/core/ExecParams.h>
+#include <sofa/core/core.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/CMakeLists.txt
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(SofaTest REQUIRED)
 set(SOURCE_FILES
     DAG_test.cpp
     DAGNode_test.cpp
+    DDGLink_test.cpp
     MutationListener_test.cpp
     Node_test.cpp
     SimpleApi_test.cpp

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
@@ -26,6 +26,7 @@ public:
     {
         engine.addInput(&input);
         engine.addCallback([&](sofa::core::DataTrackerEngine* e){
+            std::cout << "plop" << std::endl;
             e->updateAllInputsIfDirty();
             output.setValue(input.getValue());
             d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Valid);
@@ -50,6 +51,7 @@ public:
     {
         engine.addInput(&inputLink);
         engine.addCallback([&](sofa::core::DataTrackerEngine* e){
+            std::cout << "plop" << std::endl;
             e->updateAllInputsIfDirty();
             output.setValue(inputLink.get()->output.getValue());
             d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Valid);
@@ -98,25 +100,11 @@ struct DDGLink_test: public BaseTest
         bodB.setAttribute("in", "@/A");
         bodB.setAttribute("out", "false");
         b->parse(&bodB);
-
     }
-
-
-    void dumpGraph(sofa::core::objectmodel::DDGNode* n, int depth=0)
-    {
-        for (int i = 0 ; i < depth ; ++i)
-            std::cout << " ";
-        std::cout << n->getOwner()->getName() << "::" << n->getName() << " : " << n->isDirty() << std::endl;
-        depth += 3;
-        for (auto output : n->getOutputs())
-            dumpGraph(output, depth);
-    }
-
 
     void testGraphConsistency()
     {
         std::cout << "INITIAL STATE (everything but A::in should be dirty):" << std::endl;
-        dumpGraph(&a->input);
         ASSERT_FALSE(a->input.isDirty());
         ASSERT_TRUE(a->output.isDirty());
         ASSERT_TRUE(a->d_componentstate.isDirty());
@@ -126,7 +114,6 @@ struct DDGLink_test: public BaseTest
 
         b->output.getValue();
         std::cout << "\nAFTER accessing B::out (only B::componentState should be dirty):" << std::endl;
-        dumpGraph(&a->input);
         ASSERT_FALSE(a->input.isDirty());
         ASSERT_FALSE(a->engine.isDirty());
         ASSERT_FALSE(a->output.isDirty());
@@ -140,7 +127,6 @@ struct DDGLink_test: public BaseTest
 
         a->input.setValue(true); // Changing input value should dirtify all descendency...
         std::cout << "\nAFTER modifying A::in (should dirtify all but A::in):" << std::endl;
-        dumpGraph(&a->input);
         ASSERT_FALSE(a->input.isDirty());
         ASSERT_TRUE(a->engine.isDirty());
         ASSERT_TRUE(a->output.isDirty());
@@ -164,7 +150,6 @@ struct DDGLink_test: public BaseTest
 
         b->inputLink.set(c.get());
         ASSERT_TRUE(b->inputLink.get() == c.get());
-        ASSERT_EQ(b->inputLink.getPathName(), "/B.in");
     }
 
 };

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
@@ -63,7 +63,7 @@ public:
 
     ~ClassB() override {}
 
-    sofa::core::objectmodel::DDGLink<ClassA> inputLink;
+    sofa::core::objectmodel::DDGLink<const ClassA> inputLink;
     sofa::core::DataTrackerEngine engine;
     sofa::Data<bool> output;
 };

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
@@ -64,6 +64,7 @@ public:
     ~ClassB() override {}
 
     sofa::core::objectmodel::DDGLink<ClassA> inputLink;
+    sofa::core::DataTrackerEngine engine;
     sofa::Data<bool> output;
 };
 

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
@@ -24,11 +24,15 @@ public:
           input(initData(&input, false, "in", "in")),
           output(initData(&output, "out", "out"))
     {
-        addUpdateCallback("engine", {&input}, [&]() -> ComponentState {
-            std::cout << "in engineA" << std::endl;
+        engine.addInput(&input);
+        engine.addCallback([&](sofa::core::DataTrackerEngine* e){
+            e->updateAllInputsIfDirty();
             output.setValue(input.getValue());
-            return ComponentState::Valid;
-        }, {&output});
+            d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Valid);
+            e->cleanDirty();
+        });
+        engine.addOutput(&output);
+        engine.addOutput(&d_componentstate);
     }
 
     ~ClassA() override {}
@@ -44,11 +48,15 @@ public:
           inputLink(initDDGLink(this, "in", "help string")),
           output(initData(&output, "out", "out"))
     {
-        addUpdateCallback("engine", {&inputLink}, [&]() -> ComponentState {
-            std::cout << "in engineB" << std::endl;
+        engine.addInput(&inputLink);
+        engine.addCallback([&](sofa::core::DataTrackerEngine* e){
+            e->updateAllInputsIfDirty();
             output.setValue(inputLink.get()->output.getValue());
-            return ComponentState::Valid;
-        }, {&output});
+            d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Valid);
+            e->cleanDirty();
+        });
+        engine.addOutput(&output);
+        engine.addOutput(&d_componentstate);
     }
 
     ~ClassB() override {}

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
@@ -63,8 +63,7 @@ public:
 
     ~ClassB() override {}
 
-    sofa::core::objectmodel::DDGLink<const ClassA> inputLink;
-    sofa::core::DataTrackerEngine engine;
+    sofa::core::objectmodel::DDGLink<ClassA> inputLink;
     sofa::Data<bool> output;
 };
 

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
@@ -1,0 +1,175 @@
+#include <string>
+using std::string ;
+
+#include <SofaTest/Sofa_test.h>
+#include <sofa/core/objectmodel/BaseObject.h>
+using sofa::core::objectmodel::BaseObject;
+using sofa::core::objectmodel::ComponentState;
+
+#include <sofa/simulation/Simulation.h>
+#include <SofaSimulationGraph/DAGSimulation.h>
+
+
+class ClassA : public BaseObject
+{
+public:
+    SOFA_CLASS(ClassA, BaseObject);
+    
+    sofa::Data<bool> input;
+    sofa::Data<bool> output;
+    sofa::core::DataTrackerEngine engine;
+
+    ClassA()
+        : Inherit1(),
+          input(initData(&input, false, "in", "in")),
+          output(initData(&output, "out", "out"))
+    {
+        addUpdateCallback("engine", {&input}, [&]() -> ComponentState {
+            std::cout << "in engineA" << std::endl;
+            output.setValue(input.getValue());
+            return ComponentState::Valid;
+        }, {&output});
+    }
+
+    ~ClassA() override {}
+};
+
+class ClassB : public BaseObject
+{
+public:
+    SOFA_CLASS(ClassB, BaseObject);
+
+    ClassB()
+        : Inherit1(),
+          inputLink(initDDGLink(this, "in", "help string")),
+          output(initData(&output, "out", "out"))
+    {
+        addUpdateCallback("engine", {&inputLink}, [&]() -> ComponentState {
+            std::cout << "in engineB" << std::endl;
+            output.setValue(inputLink.get()->output.getValue());
+            return ComponentState::Valid;
+        }, {&output});
+    }
+
+    ~ClassB() override {}
+
+    sofa::core::objectmodel::DDGLink<ClassA> inputLink;
+    sofa::core::DataTrackerEngine engine;
+    sofa::Data<bool> output;
+};
+
+
+
+namespace sofa
+{
+
+struct DDGLink_test: public BaseTest
+{
+    ClassA::SPtr a;
+    ClassB::SPtr b;
+    Node::SPtr node;
+
+    void SetUp() override
+    {
+        sofa::simulation::Simulation* simu;
+        setSimulation(simu = new sofa::simulation::graph::DAGSimulation());
+
+        node = simu->createNewGraph("root");
+
+        a = sofa::core::objectmodel::New<ClassA>();
+        a->setName("A");
+        node->addObject(a);
+        sofa::core::objectmodel::BaseObjectDescription bodA("A");
+        bodA.setAttribute("in", "false");
+        a->parse(&bodA);
+
+        b = sofa::core::objectmodel::New<ClassB>();
+        b->setName("B");
+        node->addObject(b);
+        sofa::core::objectmodel::BaseObjectDescription bodB("B");
+        bodB.setAttribute("in", "@/A");
+        bodB.setAttribute("out", "false");
+        b->parse(&bodB);
+
+    }
+
+
+    void dumpGraph(sofa::core::objectmodel::DDGNode* n, int depth=0)
+    {
+        for (int i = 0 ; i < depth ; ++i)
+            std::cout << " ";
+        std::cout << n->getOwner()->getName() << "::" << n->getName() << " : " << n->isDirty() << std::endl;
+        depth += 3;
+        for (auto output : n->getOutputs())
+            dumpGraph(output, depth);
+    }
+
+
+    void testGraphConsistency()
+    {
+        std::cout << "INITIAL STATE (everything but A::in should be dirty):" << std::endl;
+        dumpGraph(&a->input);
+        ASSERT_FALSE(a->input.isDirty());
+        ASSERT_TRUE(a->output.isDirty());
+        ASSERT_TRUE(a->d_componentstate.isDirty());
+        ASSERT_TRUE(b->inputLink.isDirty());
+        ASSERT_TRUE(b->output.isDirty());
+        ASSERT_TRUE(b->d_componentstate.isDirty());
+
+        b->output.getValue();
+        std::cout << "\nAFTER accessing B::out (only B::componentState should be dirty):" << std::endl;
+        dumpGraph(&a->input);
+        ASSERT_FALSE(a->input.isDirty());
+        ASSERT_FALSE(a->engine.isDirty());
+        ASSERT_FALSE(a->output.isDirty());
+        ASSERT_FALSE(a->d_componentstate.isDirty());
+        ASSERT_FALSE(b->inputLink.isDirty());
+        ASSERT_FALSE(b->engine.isDirty());
+        ASSERT_FALSE(b->output.isDirty());
+        ASSERT_TRUE(b->d_componentstate.isDirty());
+
+
+
+        a->input.setValue(true); // Changing input value should dirtify all descendency...
+        std::cout << "\nAFTER modifying A::in (should dirtify all but A::in):" << std::endl;
+        dumpGraph(&a->input);
+        ASSERT_FALSE(a->input.isDirty());
+        ASSERT_TRUE(a->engine.isDirty());
+        ASSERT_TRUE(a->output.isDirty());
+        ASSERT_TRUE(a->d_componentstate.isDirty());
+        ASSERT_TRUE(b->inputLink.isDirty());
+        ASSERT_TRUE(b->engine.isDirty());
+        ASSERT_TRUE(b->output.isDirty());
+        ASSERT_TRUE(b->d_componentstate.isDirty());
+    }
+
+
+    void testDDGLink_methods()
+    {
+
+        ASSERT_TRUE(a.get() == b->inputLink.get());
+        ASSERT_TRUE(b.get() == b->inputLink.getOwner());
+
+        ClassA::SPtr c = sofa::core::objectmodel::New<ClassA>();
+        c->setName("C");
+        node->addObject(c);
+
+        b->inputLink.set(c.get());
+        ASSERT_TRUE(b->inputLink.get() == c.get());
+        ASSERT_EQ(b->inputLink.getPathName(), "/B.in");
+    }
+
+};
+
+// Test
+TEST_F(DDGLink_test, testGraphConsistency )
+{
+    this->testGraphConsistency();
+}
+
+TEST_F(DDGLink_test, testDDGLink_methods )
+{
+    this->testDDGLink_methods();
+}
+}  // namespace sofa
+


### PR DESCRIPTION
Hey!

First PR with a POC of Object links that aren't based on SingleLinks

Here, a new template class (with its base class) is introduced: DDGLink.
Just like BaseDatas, DDGLink inherits DDGNode.
A DDGLink thus benefits from the whole dirty flag propagation thingy, and implements the update() function to clean its dirty flag, and update from its inputs.
Just like Datas, a DDGLink also possesses a counter, that is incremented when the link value changes.

Just like BaseLinks, and SPtrs, to retrieve the object linked with a DDGLink, you need to call the get() method. The set() method will set the link.

When a link is set within a DDGLink, the componentState of the linked object is set as input to that DDGLink. It's up to you to connect your DDGLink to some datas to connect your dependency graph.

Contrary to the current link implementation in SOFA, these links, can be very easily manipulated as their base class (BaseDDGLink), or as DDGNodes even.

DDGLinks are parsed in Base::parseField just like BaseLinks and BaseDatas, which makes them usable with the BaseObjectDescriptions. (they really mirror the behavior of all other field types.)

A very simple test case is present in this PR to show you how it's used.

You can reference your links with their pathnames, just like normal datas or links, by calling the getPathName() method

There's not bi-directionality implemented in this PR, (because I didn't have time in the end...) but it's not rocket science:
- all there is to do is add a vector of Base* in Base with helper methods to add, remove retrieve the list of link owners. Then in DDGLink::set(), call the add() method of your link to register`this`. (maybe in another PR...) 


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
