### PR TITLE
[SofaCore] Add ddg callback

### DIFF
--- a/SofaKernel/modules/SofaCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/CMakeLists.txt
@@ -110,6 +110,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/objectmodel/ContextObject.h
     ${SRC_ROOT}/objectmodel/DDGNode.h
     ${SRC_ROOT}/objectmodel/Data.h
+    ${SRC_ROOT}/objectmodel/DDGLink.h
     ${SRC_ROOT}/objectmodel/DataFileName.h
     ${SRC_ROOT}/objectmodel/DetachNodeEvent.h
     ${SRC_ROOT}/objectmodel/Event.h
@@ -217,6 +218,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/objectmodel/Context.cpp
     ${SRC_ROOT}/objectmodel/DDGNode.cpp
     ${SRC_ROOT}/objectmodel/Data.cpp
+    ${SRC_ROOT}/objectmodel/DDGLink.cpp
     ${SRC_ROOT}/objectmodel/DataCallback.cpp
     ${SRC_ROOT}/objectmodel/DataFileName.cpp
     ${SRC_ROOT}/objectmodel/DetachNodeEvent.cpp

--- a/SofaKernel/modules/SofaCore/SofaCore_test/TrackedData_test.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_test/TrackedData_test.cpp
@@ -215,6 +215,7 @@ struct DataTrackerEngine_test: public BaseTest
 {
 
     static unsigned updateCounter;
+    core::DataTrackerEngine dataTracker;
     void SetUp() override
     {
         updateCounter = 0;
@@ -268,13 +269,20 @@ struct DataTrackerEngine_test: public BaseTest
 
     }
 
-
     /// to test DataTrackerEngine between Data in separated components
     void testBetweenComponents()
     {
-
-
         DummyObject testObject, testObject2;
+
+        dataTracker.addInput(&testObject.myData); // several inputs can be added
+        dataTracker.addOutput(&testObject2.myData); // several output can be added
+        dataTracker.addCallback([&](){
+            ++updateCounter;
+            testObject2.myData.setValue(testObject.myData.getValue());
+            return sofa::core::objectmodel::ComponentState::Valid;
+        });
+
+        dataTracker.setDirtyValue();
         unsigned localCounter = 0u;
 
         testObject.myData.setValue(true);

--- a/SofaKernel/modules/SofaCore/SofaCore_test/TrackedData_test.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_test/TrackedData_test.cpp
@@ -103,29 +103,30 @@ protected:
 
 struct DataTracker_test: public ::testing::Test
 {
-    TestObject testObject;
+    TestObject::SPtr testObject;
 
     void SetUp() override
     {
-        testObject.init();
+        testObject = sofa::core::objectmodel::New<TestObject>();
+        testObject->init();
     }
 
     /// to test tracked Data
     void testTrackedData()
     {
         // input did not change, it is not dirtied, so neither its associated DataTracker
-        testObject.updateData();
-        ASSERT_TRUE(testObject.depend_on_input.getValue()==TestObject::NO_CHANGED);
+        testObject->updateData();
+        ASSERT_TRUE(testObject->depend_on_input.getValue()==TestObject::NO_CHANGED);
 
         // modifying input sets it as dirty, so its associated DataTracker too
-        testObject.input.setValue(true);
-        testObject.updateData();
-        ASSERT_TRUE(testObject.depend_on_input.getValue()==TestObject::CHANGED);
+        testObject->input.setValue(true);
+        testObject->updateData();
+        ASSERT_TRUE(testObject->depend_on_input.getValue()==TestObject::CHANGED);
 
-        testObject.input.setValue(false);
-        testObject.input.cleanDirty();
-        testObject.updateData();
-        ASSERT_TRUE(testObject.depend_on_input.getValue()==TestObject::CHANGED);
+        testObject->input.setValue(false);
+        testObject->input.cleanDirty();
+        testObject->updateData();
+        ASSERT_TRUE(testObject->depend_on_input.getValue()==TestObject::CHANGED);
     }
 
 };

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
@@ -63,15 +63,15 @@ void DataTracker::clean()
 
 
 ////////////////////
-void DataTrackerDDGNode::addInputs(std::initializer_list<sofa::core::objectmodel::BaseData*> datas)
+void DataTrackerDDGNode::addInputs(std::initializer_list<sofa::core::objectmodel::DDGNode*> datas)
 {
-    for(sofa::core::objectmodel::BaseData* d : datas)
+    for(sofa::core::objectmodel::DDGNode* d : datas)
         addInput(d);
 }
 
-void DataTrackerDDGNode::addOutputs(std::initializer_list<sofa::core::objectmodel::BaseData*> datas)
+void DataTrackerDDGNode::addOutputs(std::initializer_list<sofa::core::objectmodel::DDGNode*> datas)
 {
-    for(sofa::core::objectmodel::BaseData* d : datas)
+    for(sofa::core::objectmodel::DDGNode* d : datas)
         addOutput(d);
 }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
@@ -110,7 +110,6 @@ void DataTrackerEngine::update()
             cs = state;
     }
     m_owner->d_componentstate.setValue(cs);
-    std::cout << getName() << " cleanDirty()" << std::endl;
     cleanDirty();
 }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
@@ -109,7 +109,8 @@ void DataTrackerEngine::update()
         if (state != sofa::core::objectmodel::ComponentState::Valid)
             cs = state;
     }
-    m_owner->d_componentstate.setValue(cs);
+    if (m_owner)
+        m_owner->d_componentstate.setValue(cs);
     cleanDirty();
 }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #include "DataTracker.h"
 #include "objectmodel/BaseData.h"
+#include "objectmodel/Base.h"
 
 namespace sofa
 {
@@ -92,17 +93,25 @@ void DataTrackerDDGNode::updateAllInputsIfDirty()
     }
 }
 ///////////////////////
-void DataTrackerEngine::addCallback( std::function<void(DataTrackerEngine*)> f)
+void DataTrackerEngine::addCallback( std::function<sofa::core::objectmodel::ComponentState(void)> f)
 {
     m_callbacks.push_back(f);
 }
 
 void DataTrackerEngine::update()
 {
+    updateAllInputsIfDirty();
+
+    sofa::core::objectmodel::ComponentState cs = sofa::core::objectmodel::ComponentState::Valid;
     for(auto& callback : m_callbacks)
     {
-        callback(this);
+        sofa::core::objectmodel::ComponentState state = callback();
+        if (state != sofa::core::objectmodel::ComponentState::Valid)
+            cs = state;
     }
+    m_owner->d_componentstate.setValue(cs);
+    std::cout << getName() << " cleanDirty()" << std::endl;
+    cleanDirty();
 }
 
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.h
@@ -23,6 +23,7 @@
 #define SOFA_CORE_DATATRACKER_H
 
 #include <sofa/core/objectmodel/DDGNode.h>
+#include "objectmodel/ComponentState.h"
 
 namespace sofa
 {
@@ -87,9 +88,9 @@ namespace core
         void operator=(const DataTrackerDDGNode&);
 
     public:
-        /// Create a DataCallback object associated with multiple Data.
-        void addInputs(std::initializer_list<sofa::core::objectmodel::BaseData*> datas);
-        void addOutputs(std::initializer_list<sofa::core::objectmodel::BaseData*> datas);
+        /// Create a DataCallback object associated with multiple Nodes.
+        void addInputs(std::initializer_list<sofa::core::objectmodel::DDGNode*> datas);
+        void addOutputs(std::initializer_list<sofa::core::objectmodel::DDGNode*> datas);
 
         /// Set dirty flag to false
         /// for the DDGNode and for all the tracked Data
@@ -175,19 +176,30 @@ namespace core
         /// Calls the callback when one of the data has changed.
         void update() override;
 
+        void setName(const std::string& n)
+        {
+            m_name = n;
+        }
+
         /// This method is needed by DDGNode
         const std::string& getName() const override
         {
-            static const std::string emptyName ="";
-            return emptyName;
+            return m_name;
+        }
+
+        void setOwner(objectmodel::Base* owner)
+        {
+            m_owner = owner;
         }
         /// This method is needed by DDGNode
-        objectmodel::Base* getOwner() const override { return nullptr; }
+        objectmodel::Base* getOwner() const override { return m_owner; }
         /// This method is needed by DDGNode
         objectmodel::BaseData* getData() const override { return nullptr; }
 
     protected:
         std::vector<std::function<void(DataTrackerEngine*)>> m_callbacks;
+        std::string m_name {""};
+        sofa::core::objectmodel::Base* m_owner {nullptr};
     };
 
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.h
@@ -166,12 +166,12 @@ namespace core
     public:
         /// set the update function to call
         /// when asking for an output and any input changed.
-        [[deprecated("This function has been replaced by addCallback with similar signature. Update your code.")]]
-        void setUpdateCallback(std::function<void(DataTrackerEngine*)> f){ addCallback(f); }
+        [[deprecated("This function has been replaced by addCallback, and will not perform as expected anymore. Update your code.")]]
+        void setUpdateCallback(std::function<void(DataTrackerEngine*)>){}
 
         /// set the update function to call
         /// when asking for an output and any input changed.
-        void addCallback(std::function<void(DataTrackerEngine*)> f);
+        void addCallback(std::function<sofa::core::objectmodel::ComponentState(void)> f);
 
         /// Calls the callback when one of the data has changed.
         void update() override;
@@ -197,7 +197,7 @@ namespace core
         objectmodel::BaseData* getData() const override { return nullptr; }
 
     protected:
-        std::vector<std::function<void(DataTrackerEngine*)>> m_callbacks;
+        std::vector<std::function<sofa::core::objectmodel::ComponentState(void)>> m_callbacks;
         std::string m_name {""};
         sofa::core::objectmodel::Base* m_owner {nullptr};
     };

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -371,7 +371,7 @@ std::vector< BaseData* > Base::findGlobalField( const std::string &name ) const
     std::vector<BaseData*> result;
     //Search in the aliases
     auto range = m_aliasData.equal_range(name);
-    for (mapIterator itAlias=range.first; itAlias!=range.second; ++itAlias)
+    for (auto itAlias=range.first; itAlias!=range.second; ++itAlias)
         result.push_back(itAlias->second);
     return result;
 }
@@ -382,7 +382,7 @@ std::vector< BaseDDGLink* > Base::findGlobalDDGLink( const std::string &name ) c
     std::vector<BaseDDGLink*> result;
     //Search in the aliases
     auto range = m_aliasDDGLink.equal_range(name);
-    for (mapIterator itAlias=range.first; itAlias!=range.second; ++itAlias)
+    for (auto itAlias=range.first; itAlias!=range.second; ++itAlias)
         result.push_back(itAlias->second);
     return result;
 }
@@ -418,7 +418,7 @@ std::vector< BaseLink* > Base::findLinks( const std::string &name ) const
     std::vector<BaseLink*> result;
     //Search in the aliases
     auto range = m_aliasLink.equal_range(name);
-    for (mapIterator itAlias=range.first; itAlias!=range.second; ++itAlias)
+    for (auto itAlias=range.first; itAlias!=range.second; ++itAlias)
         result.push_back(itAlias->second);
     return result;
 }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -102,13 +102,7 @@ void Base::addUpdateCallback(const std::string& name,
     m_internalEngine[name].setName(name);
     m_internalEngine[name].setOwner(this);
     m_internalEngine[name].addInputs(inputs);
-    m_internalEngine[name].addCallback([&](sofa::core::DataTrackerEngine* e){
-        std::cout << "in callback" << std::endl;
-        e->updateAllInputsIfDirty();
-        objectmodel::ComponentState cs = func();
-        d_componentstate.setValue(cs);
-        e->cleanDirty();
-    });
+    m_internalEngine[name].addCallback(func);
     m_internalEngine[name].addOutputs(outputs);
     m_internalEngine[name].addOutput(&d_componentstate);
 }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -339,16 +339,14 @@ void Base::removeTag(Tag t)
 void Base::removeData(BaseData* d)
 {
     m_vecData.erase(std::find(m_vecData.begin(), m_vecData.end(), d));
-    typedef MapData::const_iterator mapIterator;
-    std::pair< mapIterator, mapIterator> range = m_aliasData.equal_range(d->getName());
+    auto range = m_aliasData.equal_range(d->getName());
     m_aliasData.erase(range.first, range.second);
 }
 
 void Base::removeDDGLink(BaseDDGLink* d)
 {
     m_vecDDGLink.erase(std::find(m_vecDDGLink.begin(), m_vecDDGLink.end(), d));
-    typedef MapDDGLink::const_iterator mapIterator;
-    std::pair< mapIterator, mapIterator> range = m_aliasDDGLink.equal_range(d->getName());
+    auto range = m_aliasDDGLink.equal_range(d->getName());
     m_aliasDDGLink.erase(range.first, range.second);
 }
 /// Find a data field given its name.
@@ -358,8 +356,7 @@ BaseData* Base::findData( const std::string &name ) const
     //Search in the aliases
     if(m_aliasData.size())
     {
-        typedef MapData::const_iterator mapIterator;
-        std::pair< mapIterator, mapIterator> range = m_aliasData.equal_range(name);
+        auto range = m_aliasData.equal_range(name);
         if (range.first != range.second)
             return range.first->second;
         else
@@ -373,8 +370,7 @@ std::vector< BaseData* > Base::findGlobalField( const std::string &name ) const
 {
     std::vector<BaseData*> result;
     //Search in the aliases
-    typedef MapData::const_iterator mapIterator;
-    std::pair< mapIterator, mapIterator> range = m_aliasData.equal_range(name);
+    auto range = m_aliasData.equal_range(name);
     for (mapIterator itAlias=range.first; itAlias!=range.second; ++itAlias)
         result.push_back(itAlias->second);
     return result;
@@ -385,8 +381,7 @@ std::vector< BaseDDGLink* > Base::findGlobalDDGLink( const std::string &name ) c
 {
     std::vector<BaseDDGLink*> result;
     //Search in the aliases
-    typedef MapDDGLink::const_iterator mapIterator;
-    std::pair< mapIterator, mapIterator> range = m_aliasDDGLink.equal_range(name);
+    auto range = m_aliasDDGLink.equal_range(name);
     for (mapIterator itAlias=range.first; itAlias!=range.second; ++itAlias)
         result.push_back(itAlias->second);
     return result;
@@ -398,8 +393,7 @@ std::vector< BaseDDGLink* > Base::findGlobalDDGLink( const std::string &name ) c
 BaseLink* Base::findLink( const std::string &name ) const
 {
     //Search in the aliases
-    typedef MapLink::const_iterator mapIterator;
-    std::pair< mapIterator, mapIterator> range = m_aliasLink.equal_range(name);
+    auto range = m_aliasLink.equal_range(name);
     if (range.first != range.second)
         return range.first->second;
     else
@@ -411,8 +405,7 @@ BaseLink* Base::findLink( const std::string &name ) const
 BaseDDGLink* Base::findDDGLink( const std::string &name ) const
 {
     //Search in the aliases
-    typedef MapDDGLink::const_iterator mapIterator;
-    std::pair< mapIterator, mapIterator> range = m_aliasDDGLink.equal_range(name);
+    auto range = m_aliasDDGLink.equal_range(name);
     if (range.first != range.second)
         return range.first->second;
     else
@@ -424,8 +417,7 @@ std::vector< BaseLink* > Base::findLinks( const std::string &name ) const
 {
     std::vector<BaseLink*> result;
     //Search in the aliases
-    typedef MapLink::const_iterator mapIterator;
-    std::pair< mapIterator, mapIterator> range = m_aliasLink.equal_range(name);
+    auto range = m_aliasLink.equal_range(name);
     for (mapIterator itAlias=range.first; itAlias!=range.second; ++itAlias)
         result.push_back(itAlias->second);
     return result;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -349,6 +349,12 @@ void Base::removeDDGLink(BaseDDGLink* d)
     auto range = m_aliasDDGLink.equal_range(d->getName());
     m_aliasDDGLink.erase(range.first, range.second);
 }
+
+void Base::addComponentStateOutput(BaseDDGLink* output) const
+{
+    output->addInput(&const_cast<Base*>(this)->d_componentstate);
+}
+
 /// Find a data field given its name.
 /// Return nullptr if not found. If more than one field is found (due to aliases), only the first is returned.
 BaseData* Base::findData( const std::string &name ) const

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -93,6 +93,26 @@ void Base::release()
     }
 }
 
+
+void Base::addUpdateCallback(const std::string& name,
+                             std::initializer_list<DDGNode*> inputs,
+                             std::function<sofa::core::objectmodel::ComponentState(void)> func,
+                             std::initializer_list<DDGNode*> outputs)
+{
+    m_internalEngine[name].setName(name);
+    m_internalEngine[name].setOwner(this);
+    m_internalEngine[name].addInputs(inputs);
+    m_internalEngine[name].addCallback([&](sofa::core::DataTrackerEngine* e){
+        std::cout << "in callback" << std::endl;
+        e->updateAllInputsIfDirty();
+        objectmodel::ComponentState cs = func();
+        d_componentstate.setValue(cs);
+        e->cleanDirty();
+    });
+    m_internalEngine[name].addOutputs(outputs);
+    m_internalEngine[name].addOutput(&d_componentstate);
+}
+
 /// Helper method used by initData()
 void Base::initData0( BaseData* field, BaseData::BaseInitData& res, const char* name, const char* help, bool isDisplayed, bool isReadOnly )
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -171,8 +171,6 @@ private:
 
 public:
 
-
-
     /// Accessor to the object name
     const std::string& getName() const
     {
@@ -318,6 +316,9 @@ public:
     void addDDGLink(BaseDDGLink* l, const std::string& name);
     /// Remove a DDGLink.
     void removeDDGLink(BaseDDGLink* l);
+
+    /// a helper method to add the componentState of a const Base* to a DDGLink.
+    void addComponentStateOutput(BaseDDGLink* output) const;
 
     typedef helper::vector<BaseData*> VecData;
     typedef std::multimap<std::string, BaseData*> MapData;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -25,6 +25,7 @@
 #include <sofa/helper/StringUtils.h>
 #include <sofa/defaulttype/BoundingBox.h>
 #include <sofa/core/objectmodel/Data.h>
+#include <sofa/core/objectmodel/DDGLink.h>
 #include <sofa/core/objectmodel/BaseObjectDescription.h>
 #include <sofa/core/objectmodel/Tag.h>
 
@@ -193,6 +194,8 @@ public:
     /// Get the template type names (if any) used to instantiate this object
     virtual std::string getTemplateName() const;
 
+    virtual std::string getPathName() const;
+
     /// Set the source filename (where the component is implemented)
     void setDefinitionSourceFileName(const std::string& sourceFileName);
 
@@ -255,10 +258,15 @@ public:
 
     /// Find data fields given a name: several can be found as we look into the alias map
     std::vector< BaseData* > findGlobalField( const std::string &name ) const;
+    std::vector< BaseDDGLink* > findGlobalDDGLink( const std::string &name ) const;
 
     /// Find a link given its name. Return nullptr if not found.
     /// If more than one link is found (due to aliases), only the first is returned.
     BaseLink* findLink( const std::string &name ) const;
+
+    /// Find a link given its name. Return nullptr if not found.
+    /// If more than one link is found (due to aliases), only the first is returned.
+    BaseDDGLink* findDDGLink( const std::string &name ) const;
 
     /// Find link fields given a name: several can be found as we look into the alias map
     std::vector< BaseLink* > findLinks( const std::string &name ) const;
@@ -288,6 +296,7 @@ public:
     /// Note that this method should only be called if the Data was not initialized with the initData method
     void addData(BaseData* f, const std::string& name);
 
+
     /// Add a data field.
     /// Note that this method should only be called if the Data was not initialized with the initData method
     void addData(BaseData* f);
@@ -302,21 +311,30 @@ public:
     /// Add a link.
     void addLink(BaseLink* l);
 
-    /// Remove a link.
-    void removeLink(BaseLink* l);
-
     /// Add an alias to a Link
     void addAlias( BaseLink* link, const char* alias);
+
+    /// Registers a DDGLink.
+    void addDDGLink(BaseDDGLink* l, const std::string& name);
+    /// Remove a DDGLink.
+    void removeDDGLink(BaseDDGLink* l);
 
     typedef helper::vector<BaseData*> VecData;
     typedef std::multimap<std::string, BaseData*> MapData;
     typedef helper::vector<BaseLink*> VecLink;
     typedef std::multimap<std::string, BaseLink*> MapLink;
+    typedef helper::vector<BaseDDGLink*> VecDDGLink;
+    typedef std::map<std::string, BaseDDGLink*> MapDDGLink;
 
     /// Accessor to the vector containing all the fields of this object
     const VecData& getDataFields() const { return m_vecData; }
     /// Accessor to the map containing all the aliases of this object
     const MapData& getDataAliases() const { return m_aliasData; }
+
+    /// Accessor to the vector containing all the fields of this object
+    const VecDDGLink& getDDGLinks() const { return m_vecDDGLink; }
+    /// Accessor to the vector containing all the fields of this object
+    const MapDDGLink& getDDGLinkAliases() const { return m_aliasDDGLink; }
 
     /// Accessor to the vector containing all the fields of this object
     const VecLink& getLinks() const { return m_vecLink; }
@@ -487,6 +505,8 @@ protected:
     /// name -> Link multi-map (includes names and aliases)
     MapLink m_aliasLink;
 
+    VecDDGLink m_vecDDGLink;
+    MapDDGLink m_aliasDDGLink;
 public:
     /// Name of the object.
     Data<std::string> name;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -26,6 +26,7 @@
 #include <sofa/defaulttype/BoundingBox.h>
 #include <sofa/core/objectmodel/Data.h>
 #include <sofa/core/objectmodel/DDGLink.h>
+#include <sofa/core/DataTracker.h>
 #include <sofa/core/objectmodel/BaseObjectDescription.h>
 #include <sofa/core/objectmodel/Tag.h>
 
@@ -171,6 +172,12 @@ private:
 
 public:
 
+    std::map<std::string, sofa::core::DataTrackerEngine> m_internalEngine;
+
+    void addUpdateCallback(const std::string& name,
+                           std::initializer_list<DDGNode*> inputs,
+                           std::function<sofa::core::objectmodel::ComponentState(void)> function,
+                           std::initializer_list<DDGNode*> outputs);
 
 
     /// Accessor to the object name

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseClass.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseClass.h
@@ -306,6 +306,17 @@ public:
         return ::sofa::core::objectmodel::BaseLink::InitLink<MyType>    \
             (this, name, help);                                         \
     }                                                                   \
+    ::sofa::core::objectmodel::BaseDDGLink::InitDDGLink                 \
+    initDDGLink(::sofa::core::objectmodel::Base* owner, std::string name, \
+                std::string help, std::string group = "")               \
+    {                                                                   \
+        ::sofa::core::objectmodel::BaseDDGLink::InitDDGLink init;       \
+        init.owner = owner;                                             \
+        init.name = name;                                               \
+        init.help = help;                                               \
+        init.group = group;                                             \
+        return init;                                                    \
+    }                                                                   \
     using Inherit1::sout;                                               \
     using Inherit1::serr;                                               \
     using Inherit1::sendl

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
@@ -36,6 +36,7 @@ namespace objectmodel
 
 class Base;
 class BaseData;
+class BaseDDGLink;
 
 /**
  *  \brief Abstract base class for Data.

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
@@ -273,7 +273,7 @@ public:
 
     /// Link to a parent data. The value of this data will automatically duplicate the value of the parent data.
     bool setParent(BaseData* parent, const std::string& path = std::string());
-    bool setParent(const std::string& path);
+    virtual bool setParent(const std::string& path);
 
     /// Check if a given Data can be linked as a parent of this data
     virtual bool validParent(BaseData* parent);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseNode.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseNode.h
@@ -131,7 +131,7 @@ public:
     virtual const BaseContext* getContext() const = 0;
 
     /// Return the full path name of this node
-    virtual std::string getPathName() const;
+    virtual std::string getPathName() const override;
 
     /// Return the path from this node to the root node
     virtual std::string getRootPath() const;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.h
@@ -444,7 +444,7 @@ public:
 
 
     /// Return the full path name of this object
-    virtual std::string getPathName() const;
+    virtual std::string getPathName() const override;
 
     /// @name internalupdate
     ///   Methods related to tracking of data and the internal update

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.cpp
@@ -46,11 +46,28 @@ void BaseDDGLink::set(Base* linkedBase)
     setDirtyOutputs();
 }
 
+void BaseDDGLink::set(const Base* linkedBase)
+{
+    /// storing the ptr as non-const.. but nowhere should the ptr be modified afterwards if manipulating a DDGLink<T>
+    /// When manipulating BaseDDGLinks, be careful to use the correct getter or undefined behavior will occur.
+    m_linkedBase = const_cast<Base*>(linkedBase);
+    addInput(&m_linkedBase->d_componentstate);
+    ++m_counters[size_t(currentAspect())];
+    setDirtyOutputs();
+}
+
+const Base* BaseDDGLink::get() const
+{
+    const_cast <BaseDDGLink*> (this)->update();
+    return m_linkedBase;
+}
+
 Base* BaseDDGLink::get()
 {
     update();
     return m_linkedBase;
 }
+
 
 void BaseDDGLink::update()
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.cpp
@@ -48,10 +48,11 @@ void BaseDDGLink::set(Base* linkedBase)
 
 void BaseDDGLink::set(const Base* linkedBase)
 {
-    /// storing the ptr as non-const.. but nowhere should the ptr be modified afterwards if manipulating a DDGLink<T>
-    /// When manipulating BaseDDGLinks, be careful to use the correct getter or undefined behavior will occur.
+    /// UNSAFE: storing the ptr as non-const.. not a problem when manipulating a DDGLink<T> / DDGLink<const T>
+    /// but when manipulating a DDGLink<const T> through its abstract type BaseDDGLink, we must be careful to use
+    /// the correct getter or undefined behavior will occur.
     m_linkedBase = const_cast<Base*>(linkedBase);
-    addInput(&m_linkedBase->d_componentstate);
+    linkedBase->addComponentStateOutput(this);
     ++m_counters[size_t(currentAspect())];
     setDirtyOutputs();
 }
@@ -65,6 +66,8 @@ const Base* BaseDDGLink::get() const
 Base* BaseDDGLink::get()
 {
     update();
+    /// Dangerous: this method could have an undefined behavior if the linkedBase is a const_cast'ed pointer!
+    /// See BaseDDGLink::set(const Base*)
     return m_linkedBase;
 }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.cpp
@@ -85,8 +85,8 @@ std::string BaseDDGLink::getPathName() const
     if (!m_owner)
         return getName();
 
-    std::string pathname = m_owner->name.getLinkPath();
-    return pathname.substr(0, pathname.find_last_of(".")) + getName();
+    std::string pathname = m_owner->getPathName();
+    return pathname + "." + getName();
 }
 
 } // namespace objectmodel

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.cpp
@@ -1,0 +1,94 @@
+#include "DDGLink.h"
+
+namespace sofa
+{
+namespace core
+{
+namespace objectmodel
+{
+
+BaseDDGLink::BaseDDGLink(const BaseDDGLink::InitDDGLink &init)
+    : m_name(init.name),
+      m_help(init.help),
+      m_group(init.group),
+      m_linkedBase(init.linkedBase),
+      m_owner(init.owner),
+      m_dataFlags(init.dataFlags)
+{
+    addLink(&inputs);
+    addLink(&outputs);
+    m_counters.assign(0);
+
+    std::cout << "constructing ddglink with name " << m_name << std::endl;
+    if (m_owner)
+    {
+        std::cout << "adding ddglink with name " << m_name << " to " << m_owner->getName() << std::endl;
+        m_owner->addDDGLink(this, m_name);
+        std::cout << m_owner->findGlobalDDGLink(m_name).size() << std::endl;
+    }
+}
+
+BaseDDGLink::~BaseDDGLink()
+{
+
+}
+
+void BaseDDGLink::setOwner(Base* owner)
+{
+    m_owner = owner;
+}
+
+void BaseDDGLink::set(Base* linkedBase)
+{
+    m_linkedBase = linkedBase;
+    addInput(&m_linkedBase->d_componentstate);
+    ++m_counters[size_t(currentAspect())];
+    setDirtyOutputs();
+}
+
+Base* BaseDDGLink::get()
+{
+    update();
+    return m_linkedBase;
+}
+
+void BaseDDGLink::update()
+{
+    for(DDGLinkIterator it=inputs.begin(); it!=inputs.end(); ++it)
+    {
+        if ((*it)->isDirty())
+        {
+            (*it)->update();
+        }
+    }
+    ++m_counters[size_t(currentAspect())];
+    cleanDirty();
+}
+
+const std::string& BaseDDGLink::getName() const
+{
+    return m_name;
+}
+
+Base* BaseDDGLink::getOwner() const
+{
+    return m_owner;
+}
+
+BaseData* BaseDDGLink::getData() const
+{
+    return nullptr;
+}
+
+std::string BaseDDGLink::getPathName() const
+{
+    if (!m_owner)
+        return getName();
+
+    std::string pathname = m_owner->name.getLinkPath();
+    return pathname.substr(0, pathname.find_last_of(".")) + getName();
+}
+
+} // namespace objectmodel
+} // namespace core
+} // namespace sofa

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <sofa/core/objectmodel/DDGNode.h>
+#include <sofa/core/objectmodel/Base.h>
+#include <sofa/core/ExecParams.h>
+
+namespace sofa
+{
+namespace core
+{
+namespace objectmodel
+{
+
+
+/**
+ * @brief The BaseLink class
+ *
+ * BaseLink inherits DDGNode, thus is part of the data dependency graph, thus can have inputs and outputs.
+ * When setting a link, the linked base's componentState data is added as an input to the BaseLink,
+ * which creates the connection between the BaseLink and the DDG.
+ * any data, engine, etc. can then be connected as output.
+ */
+class BaseDDGLink : public DDGNode
+{
+public:
+    /// Flags that describe some properties of a Data, and that can be OR'd together.
+    /// \todo Probably remove FLAG_PERSISTENT, FLAG_ANIMATION_INSTANCE, FLAG_VISUAL_INSTANCE and FLAG_HAPTICS_INSTANCE, it looks like they are not used anywhere.
+    enum DataFlagsEnum
+    {
+        FLAG_NONE       = 0,      ///< Means "no flag" when a value is required.
+        FLAG_READONLY   = 1 << 0, ///< The Data will be read-only in GUIs.
+        FLAG_DISPLAYED  = 1 << 1, ///< The Data will be displayed in GUIs.
+        FLAG_PERSISTENT = 1 << 2, ///< The Data contains persistent information.
+        FLAG_AUTOLINK   = 1 << 3, ///< The Data should be autolinked when using the src="..." syntax.
+        FLAG_REQUIRED = 1 << 4, ///< True if the Data has to be set for the owner component to be valid (a warning is displayed at init otherwise)
+        FLAG_ANIMATION_INSTANCE = 1 << 10,
+        FLAG_VISUAL_INSTANCE = 1 << 11,
+        FLAG_HAPTICS_INSTANCE = 1 << 12,
+    };
+    /// Bit field that holds flags value.
+    typedef unsigned DataFlags;
+
+    /// Default value used for flags.
+    enum { FLAG_DEFAULT = FLAG_DISPLAYED | FLAG_PERSISTENT | FLAG_AUTOLINK };
+
+    /// This internal class is used by the initLink() methods to store initialization parameters of a Data
+    class InitDDGLink
+    {
+    public:
+        InitDDGLink()
+            : name(""),
+              help(""),
+              group(""),
+              linkedBase(nullptr),
+              owner(nullptr),
+              dataFlags(FLAG_DEFAULT) {}
+        std::string name;
+        std::string help;
+        std::string group;
+        Base* linkedBase;
+        Base* owner;
+        DataFlags dataFlags;
+    };
+
+    explicit BaseDDGLink(const InitDDGLink& init);
+
+    virtual ~BaseDDGLink() override;
+
+    void setOwner(Base* owner);
+
+    void set(Base* linkedBase);
+
+    Base* get();
+
+    virtual void update() override;
+
+    virtual const std::string& getName() const override;
+
+    virtual Base* getOwner() const override;
+
+    virtual BaseData* getData() const override;
+
+    std::string getPathName() const;
+
+protected:
+    std::string m_name {""};
+    std::string m_help {""};
+    std::string m_group {""};
+    Base* m_linkedBase {nullptr};
+    Base* m_owner {nullptr};
+    BaseData::DataFlags m_dataFlags {BaseData::FLAG_DEFAULT};
+
+private:
+    /// Number of changes since creation
+    sofa::helper::fixed_array<int, sofa::core::SOFA_DATA_MAX_ASPECTS> m_counters;
+};
+
+
+template <class T>
+class DDGLink : public BaseDDGLink
+{
+  public:
+
+    explicit DDGLink(const DDGLink::InitDDGLink& init)
+        : BaseDDGLink(init)
+    {
+    }
+
+    virtual ~DDGLink()
+    {
+    }
+
+    void set(T* linkedBase)
+    {
+        BaseDDGLink::set(linkedBase);
+    }
+
+    T* get()
+    {
+        return dynamic_cast<T*>(m_linkedBase);
+    }
+};
+
+} // namespace objectmodel
+} // namespace core
+} // namespace sofa

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
@@ -101,7 +101,7 @@ class DDGLink : public BaseDDGLink
 {
   public:
 
-    explicit DDGLink(const DDGLink::InitDDGLink& init)
+    explicit DDGLink(const BaseDDGLink::InitDDGLink& init)
         : BaseDDGLink(init)
     {
     }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
@@ -89,6 +89,7 @@ protected:
     std::string m_name {""};
     std::string m_help {""};
     std::string m_group {""};
+
     Base* m_linkedBase {nullptr};
     Base* m_owner {nullptr};
     BaseData::DataFlags m_dataFlags {BaseData::FLAG_DEFAULT};

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
@@ -20,7 +20,7 @@ namespace objectmodel
  * which creates the connection between the BaseLink and the DDG.
  * any data, engine, etc. can then be connected as output.
  */
-class BaseDDGLink : public DDGNode
+class SOFA_CORE_API BaseDDGLink : public DDGNode
 {
 public:
     /// Flags that describe some properties of a Data, and that can be OR'd together.

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
@@ -69,7 +69,9 @@ public:
     void setOwner(Base* owner);
 
     void set(Base* linkedBase);
+    void set(const Base* linkedBase);
 
+    const Base* get() const;
     Base* get();
 
     virtual void update() override;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
@@ -45,7 +45,7 @@ public:
     enum { FLAG_DEFAULT = FLAG_DISPLAYED | FLAG_PERSISTENT | FLAG_AUTOLINK };
 
     /// This internal class is used by the initLink() methods to store initialization parameters of a Data
-    class InitDDGLink
+    class SOFA_CORE_API InitDDGLink
     {
     public:
         InitDDGLink()

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGLink.h
@@ -3,6 +3,7 @@
 #include <sofa/core/objectmodel/DDGNode.h>
 #include <sofa/core/objectmodel/Base.h>
 #include <sofa/core/ExecParams.h>
+#include <sofa/core/core.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/CMakeLists.txt
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(SofaTest REQUIRED)
 set(SOURCE_FILES
     DAG_test.cpp
     DAGNode_test.cpp
+    DDGLink_test.cpp
     MutationListener_test.cpp
     Node_test.cpp
     SimpleApi_test.cpp

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
@@ -26,6 +26,7 @@ public:
     {
         engine.addInput(&input);
         engine.addCallback([&](sofa::core::DataTrackerEngine* e){
+            std::cout << "plop" << std::endl;
             e->updateAllInputsIfDirty();
             output.setValue(input.getValue());
             d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Valid);
@@ -50,6 +51,7 @@ public:
     {
         engine.addInput(&inputLink);
         engine.addCallback([&](sofa::core::DataTrackerEngine* e){
+            std::cout << "plop" << std::endl;
             e->updateAllInputsIfDirty();
             output.setValue(inputLink.get()->output.getValue());
             d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Valid);
@@ -98,25 +100,11 @@ struct DDGLink_test: public BaseTest
         bodB.setAttribute("in", "@/A");
         bodB.setAttribute("out", "false");
         b->parse(&bodB);
-
     }
-
-
-    void dumpGraph(sofa::core::objectmodel::DDGNode* n, int depth=0)
-    {
-        for (int i = 0 ; i < depth ; ++i)
-            std::cout << " ";
-        std::cout << n->getOwner()->getName() << "::" << n->getName() << " : " << n->isDirty() << std::endl;
-        depth += 3;
-        for (auto output : n->getOutputs())
-            dumpGraph(output, depth);
-    }
-
 
     void testGraphConsistency()
     {
         std::cout << "INITIAL STATE (everything but A::in should be dirty):" << std::endl;
-        dumpGraph(&a->input);
         ASSERT_FALSE(a->input.isDirty());
         ASSERT_TRUE(a->output.isDirty());
         ASSERT_TRUE(a->d_componentstate.isDirty());
@@ -126,7 +114,6 @@ struct DDGLink_test: public BaseTest
 
         b->output.getValue();
         std::cout << "\nAFTER accessing B::out (only B::componentState should be dirty):" << std::endl;
-        dumpGraph(&a->input);
         ASSERT_FALSE(a->input.isDirty());
         ASSERT_FALSE(a->engine.isDirty());
         ASSERT_FALSE(a->output.isDirty());
@@ -140,7 +127,6 @@ struct DDGLink_test: public BaseTest
 
         a->input.setValue(true); // Changing input value should dirtify all descendency...
         std::cout << "\nAFTER modifying A::in (should dirtify all but A::in):" << std::endl;
-        dumpGraph(&a->input);
         ASSERT_FALSE(a->input.isDirty());
         ASSERT_TRUE(a->engine.isDirty());
         ASSERT_TRUE(a->output.isDirty());
@@ -164,7 +150,6 @@ struct DDGLink_test: public BaseTest
 
         b->inputLink.set(c.get());
         ASSERT_TRUE(b->inputLink.get() == c.get());
-        ASSERT_EQ(b->inputLink.getPathName(), "/B.in");
     }
 
 };

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
@@ -63,7 +63,7 @@ public:
 
     ~ClassB() override {}
 
-    sofa::core::objectmodel::DDGLink<ClassA> inputLink;
+    sofa::core::objectmodel::DDGLink<const ClassA> inputLink;
     sofa::core::DataTrackerEngine engine;
     sofa::Data<bool> output;
 };

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
@@ -24,11 +24,15 @@ public:
           input(initData(&input, false, "in", "in")),
           output(initData(&output, "out", "out"))
     {
-        addUpdateCallback("engine", {&input}, [&]() -> ComponentState {
-            std::cout << "in engineA" << std::endl;
+        engine.addInput(&input);
+        engine.addCallback([&](sofa::core::DataTrackerEngine* e){
+            e->updateAllInputsIfDirty();
             output.setValue(input.getValue());
-            return ComponentState::Valid;
-        }, {&output});
+            d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Valid);
+            e->cleanDirty();
+        });
+        engine.addOutput(&output);
+        engine.addOutput(&d_componentstate);
     }
 
     ~ClassA() override {}
@@ -44,11 +48,15 @@ public:
           inputLink(initDDGLink(this, "in", "help string")),
           output(initData(&output, "out", "out"))
     {
-        addUpdateCallback("engine", {&inputLink}, [&]() -> ComponentState {
-            std::cout << "in engineB" << std::endl;
+        engine.addInput(&inputLink);
+        engine.addCallback([&](sofa::core::DataTrackerEngine* e){
+            e->updateAllInputsIfDirty();
             output.setValue(inputLink.get()->output.getValue());
-            return ComponentState::Valid;
-        }, {&output});
+            d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Valid);
+            e->cleanDirty();
+        });
+        engine.addOutput(&output);
+        engine.addOutput(&d_componentstate);
     }
 
     ~ClassB() override {}

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
@@ -17,14 +17,13 @@ public:
     
     sofa::Data<bool> input;
     sofa::Data<bool> output;
-    sofa::core::DataTrackerEngine engine;
 
     ClassA()
         : Inherit1(),
           input(initData(&input, false, "in", "in")),
           output(initData(&output, "out", "out"))
     {
-        addUpdateCallback("engine", {&input}, [&]() -> ComponentState {
+        addUpdateCallback("engineA", {&input}, [&]() -> ComponentState {
             std::cout << "in engineA" << std::endl;
             output.setValue(input.getValue());
             return ComponentState::Valid;
@@ -44,7 +43,7 @@ public:
           inputLink(initDDGLink(this, "in", "help string")),
           output(initData(&output, "out", "out"))
     {
-        addUpdateCallback("engine", {&inputLink}, [&]() -> ComponentState {
+        addUpdateCallback("engineB", {&inputLink}, [&]() -> ComponentState {
             std::cout << "in engineB" << std::endl;
             output.setValue(inputLink.get()->output.getValue());
             return ComponentState::Valid;
@@ -54,7 +53,6 @@ public:
     ~ClassB() override {}
 
     sofa::core::objectmodel::DDGLink<ClassA> inputLink;
-    sofa::core::DataTrackerEngine engine;
     sofa::Data<bool> output;
 };
 
@@ -96,13 +94,6 @@ struct DDGLink_test: public BaseTest
 
     void dumpGraph(sofa::core::objectmodel::DDGNode* n, int depth=0)
     {
-        // WTF????
-        if (n->getName() == "engine" && n->getOwner()->getName() == "A") {
-            std::cout <<  "Directly from a : " << n->getOwner()->getName() << "::" << n->getName() << " : " << a->engine.isDirty() << " vs " << n->isDirty() << std::endl;
-        }
-        if (n->getName() == "engine" && n->getOwner()->getName() == "B") {
-            std::cout <<  "Directly from b : " << n->getOwner()->getName() << "::" << n->getName() << " : " << b->engine.isDirty() << " vs " << n->isDirty() << std::endl;
-        }
         for (int i = 0 ; i < depth ; ++i)
             std::cout << " ";
         std::cout << n->getOwner()->getName() << "::" << n->getName() << " : " << n->isDirty() << std::endl;
@@ -115,14 +106,11 @@ struct DDGLink_test: public BaseTest
     void testGraphConsistency()
     {
         std::cout << "INITIAL STATE (everything but A::in should be dirty):" << std::endl;
-        std::cout << "A::engine : " << a->engine.isDirty() << std::endl;
         dumpGraph(&a->input);
         ASSERT_FALSE(a->input.isDirty());
-        ASSERT_TRUE(a->engine.isDirty());
         ASSERT_TRUE(a->output.isDirty());
         ASSERT_TRUE(a->d_componentstate.isDirty());
         ASSERT_TRUE(b->inputLink.isDirty());
-        ASSERT_TRUE(b->engine.isDirty());
         ASSERT_TRUE(b->output.isDirty());
         ASSERT_TRUE(b->d_componentstate.isDirty());
 
@@ -130,11 +118,9 @@ struct DDGLink_test: public BaseTest
         std::cout << "\nAFTER accessing B::out (only B::componentState should be dirty):" << std::endl;
         dumpGraph(&a->input);
         ASSERT_FALSE(a->input.isDirty());
-        ASSERT_FALSE(a->engine.isDirty());
         ASSERT_FALSE(a->output.isDirty());
         ASSERT_FALSE(a->d_componentstate.isDirty());
         ASSERT_FALSE(b->inputLink.isDirty());
-        ASSERT_FALSE(b->engine.isDirty());
         ASSERT_FALSE(b->output.isDirty());
         ASSERT_TRUE(b->d_componentstate.isDirty());
 
@@ -144,11 +130,9 @@ struct DDGLink_test: public BaseTest
         std::cout << "\nAFTER modifying A::in (should dirtify all but A::in):" << std::endl;
         dumpGraph(&a->input);
         ASSERT_FALSE(a->input.isDirty());
-        ASSERT_TRUE(a->engine.isDirty());
         ASSERT_TRUE(a->output.isDirty());
         ASSERT_TRUE(a->d_componentstate.isDirty());
         ASSERT_TRUE(b->inputLink.isDirty());
-        ASSERT_TRUE(b->engine.isDirty());
         ASSERT_TRUE(b->output.isDirty());
         ASSERT_TRUE(b->d_componentstate.isDirty());
     }

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
@@ -26,11 +26,8 @@ public:
         addUpdateCallback("engineA", {&input}, [&]() -> ComponentState {
             std::cout << "in engineA" << std::endl;
             output.setValue(input.getValue());
-            d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Valid);
-            e->cleanDirty();
-        });
-        engine.addOutput(&output);
-        engine.addOutput(&d_componentstate);
+            return sofa::core::objectmodel::ComponentState::Valid;
+        }, {&output});
     }
 
     ~ClassA() override {}
@@ -49,11 +46,8 @@ public:
         addUpdateCallback("engineB", {&inputLink}, [&]() -> ComponentState {
             std::cout << "in engineB" << std::endl;
             output.setValue(inputLink.get()->output.getValue());
-            d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Valid);
-            e->cleanDirty();
-        });
-        engine.addOutput(&output);
-        engine.addOutput(&d_componentstate);
+            return sofa::core::objectmodel::ComponentState::Valid;
+        }, {&output});
     }
 
     ~ClassB() override {}

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
@@ -1,0 +1,175 @@
+#include <string>
+using std::string ;
+
+#include <SofaTest/Sofa_test.h>
+#include <sofa/core/objectmodel/BaseObject.h>
+using sofa::core::objectmodel::BaseObject;
+using sofa::core::objectmodel::ComponentState;
+
+#include <sofa/simulation/Simulation.h>
+#include <SofaSimulationGraph/DAGSimulation.h>
+
+
+class ClassA : public BaseObject
+{
+public:
+    SOFA_CLASS(ClassA, BaseObject);
+    
+    sofa::Data<bool> input;
+    sofa::Data<bool> output;
+    sofa::core::DataTrackerEngine engine;
+
+    ClassA()
+        : Inherit1(),
+          input(initData(&input, false, "in", "in")),
+          output(initData(&output, "out", "out"))
+    {
+        addUpdateCallback("engine", {&input}, [&]() -> ComponentState {
+            std::cout << "in engineA" << std::endl;
+            output.setValue(input.getValue());
+            return ComponentState::Valid;
+        }, {&output});
+    }
+
+    ~ClassA() override {}
+};
+
+class ClassB : public BaseObject
+{
+public:
+    SOFA_CLASS(ClassB, BaseObject);
+
+    ClassB()
+        : Inherit1(),
+          inputLink(initDDGLink(this, "in", "help string")),
+          output(initData(&output, "out", "out"))
+    {
+        addUpdateCallback("engine", {&inputLink}, [&]() -> ComponentState {
+            std::cout << "in engineB" << std::endl;
+            output.setValue(inputLink.get()->output.getValue());
+            return ComponentState::Valid;
+        }, {&output});
+    }
+
+    ~ClassB() override {}
+
+    sofa::core::objectmodel::DDGLink<ClassA> inputLink;
+    sofa::core::DataTrackerEngine engine;
+    sofa::Data<bool> output;
+};
+
+
+
+namespace sofa
+{
+
+struct DDGLink_test: public BaseTest
+{
+    ClassA::SPtr a;
+    ClassB::SPtr b;
+    Node::SPtr node;
+
+    void SetUp() override
+    {
+        sofa::simulation::Simulation* simu;
+        setSimulation(simu = new sofa::simulation::graph::DAGSimulation());
+
+        node = simu->createNewGraph("root");
+
+        a = sofa::core::objectmodel::New<ClassA>();
+        a->setName("A");
+        node->addObject(a);
+        sofa::core::objectmodel::BaseObjectDescription bodA("A");
+        bodA.setAttribute("in", "false");
+        a->parse(&bodA);
+
+        b = sofa::core::objectmodel::New<ClassB>();
+        b->setName("B");
+        node->addObject(b);
+        sofa::core::objectmodel::BaseObjectDescription bodB("B");
+        bodB.setAttribute("in", "@/A");
+        bodB.setAttribute("out", "false");
+        b->parse(&bodB);
+
+    }
+
+
+    void dumpGraph(sofa::core::objectmodel::DDGNode* n, int depth=0)
+    {
+        for (int i = 0 ; i < depth ; ++i)
+            std::cout << " ";
+        std::cout << n->getOwner()->getName() << "::" << n->getName() << " : " << n->isDirty() << std::endl;
+        depth += 3;
+        for (auto output : n->getOutputs())
+            dumpGraph(output, depth);
+    }
+
+
+    void testGraphConsistency()
+    {
+        std::cout << "INITIAL STATE (everything but A::in should be dirty):" << std::endl;
+        dumpGraph(&a->input);
+        ASSERT_FALSE(a->input.isDirty());
+        ASSERT_TRUE(a->output.isDirty());
+        ASSERT_TRUE(a->d_componentstate.isDirty());
+        ASSERT_TRUE(b->inputLink.isDirty());
+        ASSERT_TRUE(b->output.isDirty());
+        ASSERT_TRUE(b->d_componentstate.isDirty());
+
+        b->output.getValue();
+        std::cout << "\nAFTER accessing B::out (only B::componentState should be dirty):" << std::endl;
+        dumpGraph(&a->input);
+        ASSERT_FALSE(a->input.isDirty());
+        ASSERT_FALSE(a->engine.isDirty());
+        ASSERT_FALSE(a->output.isDirty());
+        ASSERT_FALSE(a->d_componentstate.isDirty());
+        ASSERT_FALSE(b->inputLink.isDirty());
+        ASSERT_FALSE(b->engine.isDirty());
+        ASSERT_FALSE(b->output.isDirty());
+        ASSERT_TRUE(b->d_componentstate.isDirty());
+
+
+
+        a->input.setValue(true); // Changing input value should dirtify all descendency...
+        std::cout << "\nAFTER modifying A::in (should dirtify all but A::in):" << std::endl;
+        dumpGraph(&a->input);
+        ASSERT_FALSE(a->input.isDirty());
+        ASSERT_TRUE(a->engine.isDirty());
+        ASSERT_TRUE(a->output.isDirty());
+        ASSERT_TRUE(a->d_componentstate.isDirty());
+        ASSERT_TRUE(b->inputLink.isDirty());
+        ASSERT_TRUE(b->engine.isDirty());
+        ASSERT_TRUE(b->output.isDirty());
+        ASSERT_TRUE(b->d_componentstate.isDirty());
+    }
+
+
+    void testDDGLink_methods()
+    {
+
+        ASSERT_TRUE(a.get() == b->inputLink.get());
+        ASSERT_TRUE(b.get() == b->inputLink.getOwner());
+
+        ClassA::SPtr c = sofa::core::objectmodel::New<ClassA>();
+        c->setName("C");
+        node->addObject(c);
+
+        b->inputLink.set(c.get());
+        ASSERT_TRUE(b->inputLink.get() == c.get());
+        ASSERT_EQ(b->inputLink.getPathName(), "/B.in");
+    }
+
+};
+
+// Test
+TEST_F(DDGLink_test, testGraphConsistency )
+{
+    this->testGraphConsistency();
+}
+
+TEST_F(DDGLink_test, testDDGLink_methods )
+{
+    this->testDDGLink_methods();
+}
+}  // namespace sofa
+

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/DDGLink_test.cpp
@@ -96,6 +96,13 @@ struct DDGLink_test: public BaseTest
 
     void dumpGraph(sofa::core::objectmodel::DDGNode* n, int depth=0)
     {
+        // WTF????
+        if (n->getName() == "engine" && n->getOwner()->getName() == "A") {
+            std::cout <<  "Directly from a : " << n->getOwner()->getName() << "::" << n->getName() << " : " << a->engine.isDirty() << " vs " << n->isDirty() << std::endl;
+        }
+        if (n->getName() == "engine" && n->getOwner()->getName() == "B") {
+            std::cout <<  "Directly from b : " << n->getOwner()->getName() << "::" << n->getName() << " : " << b->engine.isDirty() << " vs " << n->isDirty() << std::endl;
+        }
         for (int i = 0 ; i < depth ; ++i)
             std::cout << " ";
         std::cout << n->getOwner()->getName() << "::" << n->getName() << " : " << n->isDirty() << std::endl;
@@ -108,11 +115,14 @@ struct DDGLink_test: public BaseTest
     void testGraphConsistency()
     {
         std::cout << "INITIAL STATE (everything but A::in should be dirty):" << std::endl;
+        std::cout << "A::engine : " << a->engine.isDirty() << std::endl;
         dumpGraph(&a->input);
         ASSERT_FALSE(a->input.isDirty());
+        ASSERT_TRUE(a->engine.isDirty());
         ASSERT_TRUE(a->output.isDirty());
         ASSERT_TRUE(a->d_componentstate.isDirty());
         ASSERT_TRUE(b->inputLink.isDirty());
+        ASSERT_TRUE(b->engine.isDirty());
         ASSERT_TRUE(b->output.isDirty());
         ASSERT_TRUE(b->d_componentstate.isDirty());
 


### PR DESCRIPTION
Depends on #1226 

This PR provides a callback method in Base to easily connect DDGNodes (inputs & outputs) within a component, through the use of DataTrackerEngines.

It is inspired by a POC from @damienmarchal in a branch we have in SofaDefrost/sofa.
The syntax to create a callback is the following:

```cpp
addUpdateCallback("dataTrackerEngineName", {&inputs}, []()->ComponentState{
// Some code in a lambda setting the componentState by return value
}, {&outputs});
```
This method will create a DataTrackerEngine in a map within Base, give it a name, set this as its owner, set the given list of inputs and outputs for the engine, and finally, use the given lambda as a delegate method for the update() function of the engine (delegate, because engine->updateAllInputsIfDirty() is called before the lambda, and engine->cleanDirty() is called after... just like a normal engine.)

The test in SofaSimulationGraph_test/DDGLink_test.cpp has been updated to show how to use it in a simple class with 1 input / 1 output.

Actually, the code doesn't work... I get an ugly exception when my engine tries to call the delegate lambda:
```
unknown file: Failure
C++ exception with description "bad_function_call" thrown in the test body.
```

No idea what this is, if you have suggestions, please don't hesitate to correct me or tell me what I did wrong... ;)
Enjoy the WE =)

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
