### PR TITLE
[SofaFramework] Remove (painful) check/warning with Rigids

### DIFF
--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/RigidTypes.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/RigidTypes.h
@@ -643,6 +643,7 @@ public:
     inline friend std::istream& operator >> ( std::istream& in, RigidCoord<3,real>& v )
     {
         in>>v.center>>v.orientation;
+#if !defined(NDEBUG)
         if (!v.orientation.isNormalized())
         {
             std::stringstream text;
@@ -652,6 +653,7 @@ public:
             text << "New value is: " << v.orientation;
             msg_warning("Rigid") << text.str();
         }
+#endif // NDEBUG
         return in;
     }
     static int max_size()

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/Quater.inl
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/Quater.inl
@@ -252,7 +252,7 @@ template<class Real>
 bool Quater<Real>::isNormalized()
 {
     Real mag = (_q[0] * _q[0] + _q[1] * _q[1] + _q[2] * _q[2] + _q[3] * _q[3]);
-    double epsilon = 1.0e-10;
+    Real epsilon = std::numeric_limits<Real>::epsilon();
     return (std::abs(mag - 1.0) < epsilon);
 }
 


### PR DESCRIPTION
Context: If creating a Rigid from a stream (typically deserializing a Rigid):
 - it checks if the rotation is normalized
 - if the case, warns the user that it is not
 - normalize it

Several problems:
 - even if the serialized rigid is perfectly normalized, there will be an unnecessary check (if you have a lots of it and you read it at each time step, it can be bothersome) 
 - the normalization of the Quaternion is set with a fixed bound
 - the most painful: it will write a warning for EVERY rigid not normalized, every time...

 Proposed solution:
 - only check/print if you are debugging



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
