### PR TITLE
[SofaConstraint] Fix crash with PrecomputedConstraintCorrection

### DIFF
--- a/modules/SofaConstraint/PrecomputedConstraintCorrection.inl
+++ b/modules/SofaConstraint/PrecomputedConstraintCorrection.inl
@@ -302,9 +302,8 @@ void PrecomputedConstraintCorrection<DataTypes>::bwdInit()
         }
 
 
-        helper::WriteAccessor< Data< VecCoord > > posData = *this->mstate->write(core::VecCoordId::position());
-        VecCoord& pos = posData.wref();
-        const VecCoord prev_pos = pos;
+        helper::ReadAccessor< Data< VecCoord > > rposData = *this->mstate->read(core::ConstVecCoordId::position());
+        const VecCoord prev_pos = rposData.ref();
 
         helper::WriteAccessor< Data< VecDeriv > > velocityData = *this->mstate->write(core::VecDerivId::velocity());
         VecDeriv& velocity = velocityData.wref();
@@ -331,8 +330,6 @@ void PrecomputedConstraintCorrection<DataTypes>::bwdInit()
             sout << "Precomputing constraint correction : " << std::fixed << (float)f / (float)nbNodes * 100.0f << " %   " << '\xd';
             sout.precision(prevPrecision);
 
-            // Deriv unitary_force;
-
             for (unsigned int i = 0; i < dof_on_node; i++)
             {
                 unitary_force.clear();
@@ -343,6 +340,10 @@ void PrecomputedConstraintCorrection<DataTypes>::bwdInit()
                 // Reset positions and velocities
                 velocity.clear();
                 velocity.resize(nbNodes);
+
+                // Actualize ref to the position vector ; it seems it is changed at every eulerSolver->solve()
+                helper::WriteAccessor< Data< VecCoord > > wposData = *this->mstate->write(core::VecCoordId::position());
+                VecCoord& pos = wposData.wref();
 
                 for (unsigned int n = 0; n < nbNodes; n++)
                     pos[n] = prev_pos[n];
@@ -392,6 +393,9 @@ void PrecomputedConstraintCorrection<DataTypes>::bwdInit()
         // Retore velocity
         for (unsigned int i = 0; i < velocity.size(); i++)
             velocity[i] = prev_velocity[i];
+
+        helper::WriteAccessor< Data< VecCoord > > wposData = *this->mstate->write(core::VecCoordId::position());
+        VecCoord& pos = wposData.wref();
 
         // Restore position
         for (unsigned int i = 0; i < pos.size(); i++)

--- a/modules/SofaConstraint/PrecomputedConstraintCorrection.inl
+++ b/modules/SofaConstraint/PrecomputedConstraintCorrection.inl
@@ -394,7 +394,7 @@ void PrecomputedConstraintCorrection<DataTypes>::bwdInit()
         for (unsigned int i = 0; i < velocity.size(); i++)
             velocity[i] = prev_velocity[i];
 
-        helper::WriteAccessor< Data< VecCoord > > wposData = *this->mstate->write(core::VecCoordId::position());
+        helper::WriteOnlyAccessor< Data< VecCoord > > wposData = *this->mstate->write(core::VecCoordId::position());
         VecCoord& pos = wposData.wref();
 
         // Restore position

--- a/modules/SofaConstraint/PrecomputedConstraintCorrection.inl
+++ b/modules/SofaConstraint/PrecomputedConstraintCorrection.inl
@@ -342,7 +342,7 @@ void PrecomputedConstraintCorrection<DataTypes>::bwdInit()
                 velocity.resize(nbNodes);
 
                 // Actualize ref to the position vector ; it seems it is changed at every eulerSolver->solve()
-                helper::WriteAccessor< Data< VecCoord > > wposData = *this->mstate->write(core::VecCoordId::position());
+                helper::WriteOnlyAccessor< Data< VecCoord > > wposData = *this->mstate->write(core::VecCoordId::position());
                 VecCoord& pos = wposData.wref();
 
                 for (unsigned int n = 0; n < nbNodes; n++)


### PR DESCRIPTION
Fix crash when solver was not in the same context (node)
I am not really an expert of solvers and Vectors (VecId stuff) but the reference to the vector of position is changed everytime the odesolver solves if this one (and I guess the linearsolver) is not in the same context.
I roughly guess that it is because the system has not the same number of nodes and everything.
Anyway, reviews/comments from @ChristianDuriez would be most welcome 😺 


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
