### PR TITLE
[All] Remove deprecated macro SOFA_TRANGLEFEM

### DIFF
--- a/modules/SofaBoundaryCondition/EdgePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/EdgePressureForceField.inl
@@ -29,9 +29,6 @@
 #include <vector>
 #include <set>
 
-
-// #define DEBUG_TRIANGLEFEM
-
 namespace sofa
 {
 

--- a/modules/SofaBoundaryCondition/OscillatingTorsionPressureForceField.cpp
+++ b/modules/SofaBoundaryCondition/OscillatingTorsionPressureForceField.cpp
@@ -25,8 +25,6 @@
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/defaulttype/VecTypes.h>
 
-// #define DEBUG_TRIANGLEFEM
-
 namespace sofa
 {
 

--- a/modules/SofaBoundaryCondition/TrianglePressureForceField.cpp
+++ b/modules/SofaBoundaryCondition/TrianglePressureForceField.cpp
@@ -25,8 +25,6 @@
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/defaulttype/VecTypes.h>
 
-// #define DEBUG_TRIANGLEFEM
-
 namespace sofa
 {
 

--- a/modules/SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.cpp
+++ b/modules/SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.cpp
@@ -25,10 +25,6 @@
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/defaulttype/VecTypes.h>
 
-
-
-// #define DEBUG_TRIANGLEFEM
-
 namespace sofa
 {
 

--- a/modules/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.cpp
+++ b/modules/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.cpp
@@ -30,9 +30,6 @@
 #include <sofa/defaulttype/VecTypes.h>
 
 
-
-// #define DEBUG_TRIANGLEFEM
-
 namespace sofa
 {
 

--- a/modules/SofaGeneralDeformable/TriangularTensorMassForceField.cpp
+++ b/modules/SofaGeneralDeformable/TriangularTensorMassForceField.cpp
@@ -26,9 +26,6 @@
 #include <sofa/defaulttype/VecTypes.h>
 
 
-
-// #define DEBUG_TRIANGLEFEM
-
 namespace sofa
 {
 

--- a/modules/SofaMiscFem/TetrahedralTensorMassForceField.cpp
+++ b/modules/SofaMiscFem/TetrahedralTensorMassForceField.cpp
@@ -25,7 +25,6 @@
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/defaulttype/VecTypes.h>
 
-// #define DEBUG_TRIANGLEFEM
 
 namespace sofa
 {

--- a/modules/SofaMiscFem/TriangleFEMForceField.cpp
+++ b/modules/SofaMiscFem/TriangleFEMForceField.cpp
@@ -25,7 +25,6 @@
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/defaulttype/VecTypes.h>
 
-// #define DEBUG_TRIANGLEFEM
 
 namespace sofa
 {

--- a/modules/SofaMiscFem/TriangleFEMForceField.inl
+++ b/modules/SofaMiscFem/TriangleFEMForceField.inl
@@ -33,8 +33,6 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include "config.h"
 
-// #define DEBUG_TRIANGLEFEM
-
 namespace sofa
 {
 
@@ -228,10 +226,6 @@ void TriangleFEMForceField<DataTypes>::applyStiffness( VecCoord& v, Real h, cons
 template <class DataTypes>
 void TriangleFEMForceField<DataTypes>::computeStrainDisplacement( StrainDisplacement &J, Coord /*a*/, Coord b, Coord c )
 {
-#ifdef DEBUG_TRIANGLEFEM
-    sout << "TriangleFEMForceField::computeStrainDisplacement"<<sendl;
-#endif
-
     //    //Coord ab_cross_ac = cross(b, c);
     Real determinant = b[0] * c[1]; // Surface * 2
 
@@ -420,11 +414,6 @@ void TriangleFEMForceField<DataTypes>::computeForce( Displacement &F, const Disp
 template <class DataTypes>
 void TriangleFEMForceField<DataTypes>::initSmall()
 {
-
-#ifdef DEBUG_TRIANGLEFEM
-    sout << "TriangleFEMForceField::initSmall"<<sendl;
-#endif
-
     Transformation identity;
     identity[0][0]=identity[1][1]=identity[2][2]=1;
     identity[0][1]=identity[0][2]=0;
@@ -440,11 +429,6 @@ void TriangleFEMForceField<DataTypes>::initSmall()
 template <class DataTypes>
 void TriangleFEMForceField<DataTypes>::accumulateForceSmall( VecCoord &f, const VecCoord &p, Index elementIndex, bool implicit )
 {
-
-#ifdef DEBUG_TRIANGLEFEM
-    sout << "TriangleFEMForceField::accumulateForceSmall"<<sendl;
-#endif
-
     Index a = (*_indexedElements)[elementIndex][0];
     Index b = (*_indexedElements)[elementIndex][1];
     Index c = (*_indexedElements)[elementIndex][2];
@@ -481,11 +465,6 @@ void TriangleFEMForceField<DataTypes>::accumulateForceSmall( VecCoord &f, const 
 template <class DataTypes>
 void TriangleFEMForceField<DataTypes>::applyStiffnessSmall(VecCoord &v, Real h, const VecCoord &x, const SReal &kFactor)
 {
-
-#ifdef DEBUG_TRIANGLEFEM
-    sout << "TriangleFEMForceField::applyStiffnessSmall"<<sendl;
-#endif
-
     typename VecElement::const_iterator it;
     unsigned int i(0);
 
@@ -523,11 +502,6 @@ void TriangleFEMForceField<DataTypes>::applyStiffnessSmall(VecCoord &v, Real h, 
 template <class DataTypes>
 void TriangleFEMForceField<DataTypes>::initLarge()
 {
-
-#ifdef DEBUG_TRIANGLEFEM
-    sout << "TriangleFEMForceField::initLarge"<<sendl;
-#endif
-
     _rotatedInitialElements.resize(_indexedElements->size());
 
     typename VecElement::const_iterator it;
@@ -564,11 +538,6 @@ void TriangleFEMForceField<DataTypes>::initLarge()
 template <class DataTypes>
 void TriangleFEMForceField<DataTypes>::computeRotationLarge( Transformation &r, const VecCoord &p, const Index &a, const Index &b, const Index &c)
 {
-
-#ifdef DEBUG_TRIANGLEFEM
-    sout << "TriangleFEMForceField::computeRotationLarge"<<sendl;
-#endif
-
     // first vector on first edge
     // second vector in the plane of the two first edges
     // third vector orthogonal to first and second
@@ -601,11 +570,6 @@ void TriangleFEMForceField<DataTypes>::computeRotationLarge( Transformation &r, 
 template <class DataTypes>
 void TriangleFEMForceField<DataTypes>::accumulateForceLarge(VecCoord &f, const VecCoord &p, Index elementIndex, bool implicit )
 {
-
-#ifdef DEBUG_TRIANGLEFEM
-    sout << "TriangleFEMForceField::accumulateForceLarge"<<sendl;
-#endif
-
     // triangle vertex indices
     Index a = (*_indexedElements)[elementIndex][0];
     Index b = (*_indexedElements)[elementIndex][1];
@@ -658,21 +622,12 @@ void TriangleFEMForceField<DataTypes>::accumulateForceLarge(VecCoord &f, const V
 //void TriangleFEMForceField<DataTypes>::accumulateDampingLarge(VecCoord &, Index )
 //{
 
-//#ifdef DEBUG_TRIANGLEFEM
-//    sout << "TriangleFEMForceField::accumulateDampingLarge"<<sendl;
-//#endif
-
 //}
 
 
 template <class DataTypes>
 void TriangleFEMForceField<DataTypes>::applyStiffnessLarge(VecCoord &v, Real h, const VecCoord &x, const SReal &kFactor)
 {
-
-#ifdef DEBUG_TRIANGLEFEM
-    sout << "TriangleFEMForceField::applyStiffnessLarge"<<sendl;
-#endif
-
     typename VecElement::const_iterator it;
     unsigned int i(0);
 

--- a/modules/SofaMiscFem/TriangularAnisotropicFEMForceField.cpp
+++ b/modules/SofaMiscFem/TriangularAnisotropicFEMForceField.cpp
@@ -23,7 +23,6 @@
 #include "TriangularAnisotropicFEMForceField.inl"
 #include <sofa/core/ObjectFactory.h>
 
-// #define DEBUG_TRIANGLEFEM
 
 namespace sofa
 {

--- a/modules/SofaMiscFem/TriangularAnisotropicFEMForceField.inl
+++ b/modules/SofaMiscFem/TriangularAnisotropicFEMForceField.inl
@@ -35,8 +35,6 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <cassert>
 
-// #define DEBUG_TRIANGLEFEM
-
 namespace sofa
 {
 

--- a/modules/SofaMiscFem/TriangularFEMForceField.cpp
+++ b/modules/SofaMiscFem/TriangularFEMForceField.cpp
@@ -26,7 +26,6 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <cassert>
 
-// #define DEBUG_TRIANGLEFEM
 
 namespace sofa
 {

--- a/modules/SofaMiscFem/TriangularFEMForceField.inl
+++ b/modules/SofaMiscFem/TriangularFEMForceField.inl
@@ -40,14 +40,6 @@
 #include <algorithm>
 #include <limits>
 
-#ifdef DEBUG_TRIANGLEFEM
-#define DEBUG_TRIANGLEFEM_MSG true
-#else
-#define DEBUG_TRIANGLEFEM_MSG false
-#endif
-
-
-
 namespace sofa
 {
 
@@ -212,9 +204,7 @@ void TriangularFEMForceField<DataTypes>::init()
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::initSmall(int i, Index&a, Index&b, Index&c)
 {
-
-    if(DEBUG_TRIANGLEFEM_MSG)
-        dmsg_info() << "Entering initSmall" ;
+    dmsg_info() << "Entering initSmall" ;
 
     helper::vector<TriangleInformation>& triangleInf = *(triangleInfo.beginEdit());
 
@@ -244,8 +234,7 @@ void TriangularFEMForceField<DataTypes>::initSmall(int i, Index&a, Index&b, Inde
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::initLarge(int i, Index&a, Index&b, Index&c)
 {
-    if(DEBUG_TRIANGLEFEM_MSG)
-        dmsg_info() << "Entering initLarge" ;
+    dmsg_info() << "Entering initLarge" ;
 
     helper::vector<TriangleInformation>& triangleInf = *(triangleInfo.beginEdit());
 
@@ -564,9 +553,7 @@ int TriangularFEMForceField<DataTypes>::getFracturedEdge()
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::computeRotationLarge( Transformation &r, const VecCoord &p, const Index &a, const Index &b, const Index &c)
 {
-
-    if(DEBUG_TRIANGLEFEM_MSG)
-        dmsg_info() << "Entering in computeRotationLarge.";
+    dmsg_info() << "Entering in computeRotationLarge.";
 
     /// check if a, b and c are < size of p
     if (a >= p.size() || b >= p.size() || c >= p.size())
@@ -1162,8 +1149,7 @@ void TriangularFEMForceField<DataTypes>::computeStressAlongDirection(Real &stres
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::applyStiffnessSmall(VecCoord &v, Real h, const VecCoord &x, const SReal &kFactor)
 {
-    if(DEBUG_TRIANGLEFEM_MSG)
-        dmsg_info() << "Entering in applyStiffnessSmall." ;
+    dmsg_info() << "Entering in applyStiffnessSmall." ;
 
     defaulttype::Mat<6,3,Real> J;
     defaulttype::Vec<3,Real> strain, stress;
@@ -1216,8 +1202,7 @@ template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::applyStiffnessLarge(VecCoord &v, Real h, const VecCoord &x, const SReal &kFactor)
 {
 
-    if(DEBUG_TRIANGLEFEM_MSG)
-        msg_info() << "Entering applyStiffnessLarge" ;
+    msg_info() << "Entering applyStiffnessLarge" ;
 
     defaulttype::Mat<6,3,Real> J;
     defaulttype::Vec<3,Real> strain, stress;
@@ -1288,8 +1273,7 @@ void TriangularFEMForceField<DataTypes>::applyStiffnessLarge(VecCoord &v, Real h
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::accumulateDampingSmall(VecCoord&, Index )
 {
-    if(DEBUG_TRIANGLEFEM_MSG)
-        dmsg_info() << "TriangularFEMForceField::accumulateDampingSmall" ;
+    dmsg_info() << "TriangularFEMForceField::accumulateDampingSmall" ;
 }
 
 // --------------------------------------------------------------------------------------
@@ -1298,9 +1282,7 @@ void TriangularFEMForceField<DataTypes>::accumulateDampingSmall(VecCoord&, Index
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::accumulateForceSmall( VecCoord &f, const VecCoord &p, Index elementIndex )
 {
-
-    if(DEBUG_TRIANGLEFEM_MSG)
-        dmsg_info() << "TriangularFEMForceField::accumulateForceSmall" ;
+    dmsg_info() << "TriangularFEMForceField::accumulateForceSmall" ;
 
     Displacement F;
 
@@ -1323,8 +1305,7 @@ void TriangularFEMForceField<DataTypes>::accumulateForceSmall( VecCoord &f, cons
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::accumulateForceLarge(VecCoord &f, const VecCoord &p, Index elementIndex )
 {
-    if(DEBUG_TRIANGLEFEM_MSG)
-        dmsg_info() << "TriangularFEMForceField::accumulateForceLarge" ;
+    dmsg_info() << "TriangularFEMForceField::accumulateForceLarge" ;
 
     Displacement F;
 
@@ -1351,8 +1332,7 @@ void TriangularFEMForceField<DataTypes>::accumulateForceLarge(VecCoord &f, const
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::accumulateDampingLarge(VecCoord &, Index )
 {
-    if(DEBUG_TRIANGLEFEM_MSG)
-        dmsg_info() << "TriangularFEMForceField::accumulateDampingLarge" ;
+    dmsg_info() << "TriangularFEMForceField::accumulateDampingLarge" ;
 }
 
 

--- a/modules/SofaMiscFem/TriangularFEMForceField.inl
+++ b/modules/SofaMiscFem/TriangularFEMForceField.inl
@@ -204,8 +204,6 @@ void TriangularFEMForceField<DataTypes>::init()
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::initSmall(int i, Index&a, Index&b, Index&c)
 {
-    dmsg_info() << "Entering initSmall" ;
-
     helper::vector<TriangleInformation>& triangleInf = *(triangleInfo.beginEdit());
 
     TriangleInformation *tinfo = &triangleInf[i];
@@ -234,8 +232,6 @@ void TriangularFEMForceField<DataTypes>::initSmall(int i, Index&a, Index&b, Inde
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::initLarge(int i, Index&a, Index&b, Index&c)
 {
-    dmsg_info() << "Entering initLarge" ;
-
     helper::vector<TriangleInformation>& triangleInf = *(triangleInfo.beginEdit());
 
     msg_error_when((unsigned int)i >= triangleInf.size())
@@ -553,8 +549,6 @@ int TriangularFEMForceField<DataTypes>::getFracturedEdge()
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::computeRotationLarge( Transformation &r, const VecCoord &p, const Index &a, const Index &b, const Index &c)
 {
-    dmsg_info() << "Entering in computeRotationLarge.";
-
     /// check if a, b and c are < size of p
     if (a >= p.size() || b >= p.size() || c >= p.size())
     {
@@ -951,8 +945,6 @@ void TriangularFEMForceField<DataTypes>::computeMaterialStiffness(int i, Index &
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::computeForce(Displacement &F, Index elementIndex, const VecCoord &p)
 {
-    //	sofa::helper::system::thread::Trace::print(1, "Hello from computeForce()\n");
-
     Displacement D;
     StrainDisplacement J;
     Stiffness K;
@@ -1149,8 +1141,6 @@ void TriangularFEMForceField<DataTypes>::computeStressAlongDirection(Real &stres
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::applyStiffnessSmall(VecCoord &v, Real h, const VecCoord &x, const SReal &kFactor)
 {
-    dmsg_info() << "Entering in applyStiffnessSmall." ;
-
     defaulttype::Mat<6,3,Real> J;
     defaulttype::Vec<3,Real> strain, stress;
     Displacement D, F;
@@ -1201,9 +1191,6 @@ void TriangularFEMForceField<DataTypes>::applyStiffness( VecCoord& v, Real h, co
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::applyStiffnessLarge(VecCoord &v, Real h, const VecCoord &x, const SReal &kFactor)
 {
-
-    msg_info() << "Entering applyStiffnessLarge" ;
-
     defaulttype::Mat<6,3,Real> J;
     defaulttype::Vec<3,Real> strain, stress;
     MaterialStiffness K;
@@ -1273,7 +1260,7 @@ void TriangularFEMForceField<DataTypes>::applyStiffnessLarge(VecCoord &v, Real h
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::accumulateDampingSmall(VecCoord&, Index )
 {
-    dmsg_info() << "TriangularFEMForceField::accumulateDampingSmall" ;
+
 }
 
 // --------------------------------------------------------------------------------------
@@ -1282,8 +1269,6 @@ void TriangularFEMForceField<DataTypes>::accumulateDampingSmall(VecCoord&, Index
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::accumulateForceSmall( VecCoord &f, const VecCoord &p, Index elementIndex )
 {
-    dmsg_info() << "TriangularFEMForceField::accumulateForceSmall" ;
-
     Displacement F;
 
     Index a = m_topology->getTriangle(elementIndex)[0];
@@ -1305,8 +1290,6 @@ void TriangularFEMForceField<DataTypes>::accumulateForceSmall( VecCoord &f, cons
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::accumulateForceLarge(VecCoord &f, const VecCoord &p, Index elementIndex )
 {
-    dmsg_info() << "TriangularFEMForceField::accumulateForceLarge" ;
-
     Displacement F;
 
     Index a = m_topology->getTriangle(elementIndex)[0];
@@ -1332,7 +1315,7 @@ void TriangularFEMForceField<DataTypes>::accumulateForceLarge(VecCoord &f, const
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::accumulateDampingLarge(VecCoord &, Index )
 {
-    dmsg_info() << "TriangularFEMForceField::accumulateDampingLarge" ;
+
 }
 
 


### PR DESCRIPTION
remove deprecated macro:
- SOFA_TRANGLEFEM
- SOFA_TRANGLEFEM_MSG



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
