### PR TITLE
[SofaModules] replace all serr by msg_error/msg_warning

### DIFF
--- a/applications/plugins/Compliant/assembly/AssemblyVisitor.h
+++ b/applications/plugins/Compliant/assembly/AssemblyVisitor.h
@@ -119,7 +119,7 @@ public:
     struct InteractionForceField
     {
         InteractionForceField( rmat H, core::behavior::BaseInteractionForceField* ff ) : H(H), ff(ff) {
-//        std::cerr<<"Assembly InteractionForceField "<<H<<std::endl;
+
         }
         rmat H; ///< linear combinaison of M,B,K (mass, damping, stiffness matrices)
         core::behavior::BaseInteractionForceField* ff;
@@ -333,8 +333,6 @@ struct AssemblyVisitor::process_helper {
                     }
                 }
             }
-
-//            std::cerr<<"Assembly::geometricStiffnessJc "<<geometricStiffnessJc<<" "<<curr->getName()<<std::endl;
         }
 
 //        if( zero(Jc) && curr->getSize() !=0 )  {

--- a/applications/plugins/SceneCreator/src/SceneCreator/GetVectorVisitor.cpp
+++ b/applications/plugins/SceneCreator/src/SceneCreator/GetVectorVisitor.cpp
@@ -52,10 +52,8 @@ void GetVectorVisitor::setIndependentOnly(bool b){ independentOnly=b; }
 
 Visitor::Result GetVectorVisitor::processNodeTopDown( simulation::Node* gnode )
 {
-//    cerr << "GetVectorVisitor::processNodeTopDown, node "<< gnode->getName() << endl;
     if (gnode->mechanicalState != nullptr && ( gnode->mechanicalMapping ==nullptr || independentOnly==false) )
     {
-//        cerr << "GetVectorVisitor::processNodeTopDown, node has mechanical state "<< endl;
         gnode->mechanicalState->copyToBaseVector(vec,src,offset);
     }
     return Visitor::RESULT_CONTINUE;

--- a/applications/plugins/SofaDistanceGrid/components/forcefield/DistanceGridForceField.h
+++ b/applications/plugins/SofaDistanceGrid/components/forcefield/DistanceGridForceField.h
@@ -216,7 +216,7 @@ public:
     void addKToMatrix(const sofa::core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        serr << "Get potentialEnergy not implemented" << sendl;
+        msg_warning() << "Get potentialEnergy not implemented" << sendl;
         return 0.0;
     }
     void draw(const core::visual::VisualParams* vparams) override;

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -389,7 +389,7 @@ int main(int argc, char** argv)
         ->default_value(1)
         ->notifier([](unsigned int value) {
             if (value < 1) {
-                std::cerr << "msaa sample cannot be lower than 1" << std::endl;
+                msg_error("runSofa") << "msaa sample cannot be lower than 1";
                 exit( EXIT_FAILURE );
             }
         }),

--- a/applications/sofa/gui/qt/WDoubleLineEdit.cpp
+++ b/applications/sofa/gui/qt/WDoubleLineEdit.cpp
@@ -23,7 +23,6 @@
 #include <cmath>
 #include "WDoubleLineEdit.h"
 #include <iostream>
-using std::cerr; using std::endl;
 /* -------------------------------------------------------- */
 
 WDoubleLineEdit::WDoubleLineEdit(QWidget *parent,const char *name) : QLineEdit(parent /*,name */)

--- a/applications/sofa/gui/qt/viewer/qt/QtViewer.cpp
+++ b/applications/sofa/gui/qt/viewer/qt/QtViewer.cpp
@@ -1171,7 +1171,6 @@ void QtViewer::keyPressEvent(QKeyEvent * e)
 {
     if (isControlPressed()) // pass event to the scene data structure
     {
-        //	cerr<<"QtViewer::keyPressEvent, key = "<<e->key()<<" with Control pressed "<<endl;
         if (groot)
         {
             sofa::core::objectmodel::KeypressedEvent keyEvent(e->key());

--- a/modules/SofaBoundaryCondition/AffineMovementConstraint.h
+++ b/modules/SofaBoundaryCondition/AffineMovementConstraint.h
@@ -136,7 +136,7 @@ public:
 
     void projectJacobianMatrix(const core::MechanicalParams* /*mparams*/, DataMatrixDeriv& /* cData */) override
     {
-        serr << "projectJacobianMatrix not implemented" << sendl;
+        msg_error() << "projectJacobianMatrix not implemented";
     }
 
     /// Compute the theoretical final positions

--- a/modules/SofaBoundaryCondition/ConicalForceField.h
+++ b/modules/SofaBoundaryCondition/ConicalForceField.h
@@ -124,7 +124,7 @@ public:
     void addDForce(const sofa::core::MechanicalParams* /*mparams*/, DataVecDeriv&   datadF , const DataVecDeriv&   datadX ) override;
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        serr << "Get potentialEnergy not implemented" << sendl;
+        msg_error() << "Get potentialEnergy not implemented";
         return 0.0;
     }
 

--- a/modules/SofaBoundaryCondition/ConicalForceField.h
+++ b/modules/SofaBoundaryCondition/ConicalForceField.h
@@ -124,7 +124,7 @@ public:
     void addDForce(const sofa::core::MechanicalParams* /*mparams*/, DataVecDeriv&   datadF , const DataVecDeriv&   datadX ) override;
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        msg_error() << "Get potentialEnergy not implemented";
+        msg_warning() << "Method getPotentialEnergy not implemented yet.";
         return 0.0;
     }
 

--- a/modules/SofaBoundaryCondition/ConicalForceField.inl
+++ b/modules/SofaBoundaryCondition/ConicalForceField.inl
@@ -165,7 +165,7 @@ void ConicalForceField<DataTypes>::addDForce(const sofa::core::MechanicalParams*
 template<class DataTypes>
 void ConicalForceField<DataTypes>::updateStiffness( const VecCoord&  )
 {
-    serr<<"SphereForceField::updateStiffness-not-implemented !!!"<<sendl;
+    msg_error() << "SphereForceField::updateStiffness-not-implemented !!!";
 }
 
 template<class DataTypes>

--- a/modules/SofaBoundaryCondition/EdgePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/EdgePressureForceField.inl
@@ -154,7 +154,7 @@ void EdgePressureForceField<DataTypes>::addDForce(const core::MechanicalParams* 
 template <class DataTypes>
 SReal EdgePressureForceField<DataTypes>::getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const
 {
-    msg_error() << "Get potentialEnergy not implemented" ;
+    msg_warning() << "Method getPotentialEnergy not implemented yet.";
     return 0.0;
 }
 

--- a/modules/SofaBoundaryCondition/EllipsoidForceField.inl
+++ b/modules/SofaBoundaryCondition/EllipsoidForceField.inl
@@ -167,7 +167,7 @@ void EllipsoidForceField<DataTypes>::addDForce(const sofa::core::MechanicalParam
 template<class DataTypes>
 SReal EllipsoidForceField<DataTypes>::getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const
 {
-    msg_error()<< "Get potentialEnergy not implemented";
+    msg_warning() << "Method getPotentialEnergy not implemented yet.";
     return 0.0;
 }
 

--- a/modules/SofaBoundaryCondition/OscillatingTorsionPressureForceField.inl
+++ b/modules/SofaBoundaryCondition/OscillatingTorsionPressureForceField.inl
@@ -191,7 +191,7 @@ void OscillatingTorsionPressureForceField<DataTypes>::addDForce(const core::Mech
 template <class DataTypes>
 SReal OscillatingTorsionPressureForceField<DataTypes>::getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const
 {
-    msg_error() << "Get potentialEnergy not implemented";
+    msg_warning() << "Method getPotentialEnergy not implemented yet.";
     return 0.0;
 }
 

--- a/modules/SofaBoundaryCondition/OscillatingTorsionPressureForceField.inl
+++ b/modules/SofaBoundaryCondition/OscillatingTorsionPressureForceField.inl
@@ -191,7 +191,7 @@ void OscillatingTorsionPressureForceField<DataTypes>::addDForce(const core::Mech
 template <class DataTypes>
 SReal OscillatingTorsionPressureForceField<DataTypes>::getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const
 {
-    serr << "Get potentialEnergy not implemented" << sendl;
+    msg_error() << "Get potentialEnergy not implemented";
     return 0.0;
 }
 

--- a/modules/SofaBoundaryCondition/PlaneForceField.inl
+++ b/modules/SofaBoundaryCondition/PlaneForceField.inl
@@ -122,9 +122,7 @@ template<class DataTypes>
 SReal PlaneForceField<DataTypes>::getPotentialEnergy(const core::MechanicalParams* /*mparams*/,
                                                      const DataVecCoord&  /* x */) const
 {
-    msg_error(this) << "Function potentialEnergy is not implemented. " << msgendl
-                    << "To remove this errore message you need to implement a proper calculus of "
-                       "the plane force field potential energy.";
+    msg_warning() << "Method getPotentialEnergy not implemented yet.";
     return 0.0;
 }
 

--- a/modules/SofaBoundaryCondition/PositionBasedDynamicsConstraint.cpp
+++ b/modules/SofaBoundaryCondition/PositionBasedDynamicsConstraint.cpp
@@ -69,7 +69,7 @@ void PositionBasedDynamicsConstraint<Rigid3Types>::projectPosition(const core::M
     helper::ReadAccessor<DataVecCoord> tpos = position ;
 	helper::WriteAccessor<DataVecDeriv> vel ( mparams, velocity );
 	helper::WriteAccessor<DataVecCoord> old_pos ( mparams, old_position );
-    if (tpos.size() != res.size()) 	{ serr << "Invalid target position vector size." << sendl;		return; }
+    if (tpos.size() != res.size()) { msg_error() << "Invalid target position vector size."; return; }
 
     Real dt =  (Real)this->getContext()->getDt();
     if(!dt) return;

--- a/modules/SofaBoundaryCondition/ProjectDirectionConstraint.inl
+++ b/modules/SofaBoundaryCondition/ProjectDirectionConstraint.inl
@@ -146,7 +146,7 @@ void ProjectDirectionConstraint<DataTypes>::init()
         const unsigned int index=indices[i];
         if (index >= maxIndex)
         {
-            serr << "Index " << index << " not valid!" << sendl;
+            msg_error() << "Index " << index << " not valid!";
             removeConstraint(index);
         }
     }
@@ -229,7 +229,7 @@ void ProjectDirectionConstraint<DataTypes>::projectResponse(const core::Mechanic
 template <class DataTypes>
 void ProjectDirectionConstraint<DataTypes>::projectJacobianMatrix(const core::MechanicalParams* /*mparams*/ , DataMatrixDeriv& /*cData*/)
 {
-    serr<<"projectJacobianMatrix(const core::MechanicalParams*, DataMatrixDeriv& ) is not implemented" << sendl;
+    msg_error() << "projectJacobianMatrix(const core::MechanicalParams*, DataMatrixDeriv& ) is not implemented";
 }
 
 template <class DataTypes>
@@ -260,13 +260,13 @@ void ProjectDirectionConstraint<DataTypes>::projectPosition(const core::Mechanic
 template <class DataTypes>
 void ProjectDirectionConstraint<DataTypes>::applyConstraint(defaulttype::BaseMatrix * /*mat*/, unsigned int /*offset*/)
 {
-    serr << "applyConstraint is not implemented " << sendl;
+    msg_error() << "applyConstraint is not implemented ";
 }
 
 template <class DataTypes>
 void ProjectDirectionConstraint<DataTypes>::applyConstraint(defaulttype::BaseVector * /*vect*/, unsigned int /*offset*/)
 {
-    serr<<"ProjectDirectionConstraint<DataTypes>::applyConstraint(defaulttype::BaseVector *vect, unsigned int offset) is not implemented "<< sendl;
+    msg_error() << "ProjectDirectionConstraint<DataTypes>::applyConstraint(defaulttype::BaseVector *vect, unsigned int offset) is not implemented ";
 }
 
 

--- a/modules/SofaBoundaryCondition/ProjectToLineConstraint.inl
+++ b/modules/SofaBoundaryCondition/ProjectToLineConstraint.inl
@@ -145,7 +145,7 @@ void ProjectToLineConstraint<DataTypes>::init()
         const unsigned int index=indices[i];
         if (index >= maxIndex)
         {
-            serr << "Index " << index << " not valid!" << sendl;
+            msg_error() << "Index " << index << " not valid!";
             removeConstraint(index);
         }
     }
@@ -220,7 +220,7 @@ void ProjectToLineConstraint<DataTypes>::projectResponse(const core::MechanicalP
 template <class DataTypes>
 void ProjectToLineConstraint<DataTypes>::projectJacobianMatrix(const core::MechanicalParams* /*mparams*/ , DataMatrixDeriv& /*cData*/)
 {
-    serr<<"projectJacobianMatrix(const core::MechanicalParams*, DataMatrixDeriv& ) is not implemented" << sendl;
+    msg_error() << "projectJacobianMatrix(const core::MechanicalParams*, DataMatrixDeriv& ) is not implemented";
 }
 
 template <class DataTypes>
@@ -253,13 +253,13 @@ void ProjectToLineConstraint<DataTypes>::projectPosition(const core::MechanicalP
 template <class DataTypes>
 void ProjectToLineConstraint<DataTypes>::applyConstraint(defaulttype::BaseMatrix * /*mat*/, unsigned int /*offset*/)
 {
-    serr << "applyConstraint is not implemented " << sendl;
+    msg_error() << "applyConstraint is not implemented ";
 }
 
 template <class DataTypes>
 void ProjectToLineConstraint<DataTypes>::applyConstraint(defaulttype::BaseVector * /*vect*/, unsigned int /*offset*/)
 {
-    serr<<"ProjectToLineConstraint<DataTypes>::applyConstraint(defaulttype::BaseVector *vect, unsigned int offset) is not implemented "<< sendl;
+    msg_error() << "ProjectToLineConstraint<DataTypes>::applyConstraint(defaulttype::BaseVector *vect, unsigned int offset) is not implemented ";
 }
 
 
@@ -280,7 +280,7 @@ void ProjectToLineConstraint<DataTypes>::draw(const core::visual::VisualParams* 
     {
         std::vector< sofa::defaulttype::Vector3 > points;
         sofa::defaulttype::Vector3 point;
-        //serr<<"ProjectToLineConstraint<DataTypes>::draw(), indices = "<<indices<<sendl;
+        
         for (Indices::const_iterator it = indices.begin();
                 it != indices.end();
                 ++it)

--- a/modules/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
@@ -146,7 +146,7 @@ void ProjectToPlaneConstraint<DataTypes>::init()
         const unsigned int index=indices[i];
         if (index >= maxIndex)
         {
-            serr << "Index " << index << " not valid!" << sendl;
+            msg_error() << "Index " << index << " not valid!";
             removeConstraint(index);
         }
     }
@@ -230,7 +230,7 @@ void ProjectToPlaneConstraint<DataTypes>::projectResponse(const core::Mechanical
 template <class DataTypes>
 void ProjectToPlaneConstraint<DataTypes>::projectJacobianMatrix(const core::MechanicalParams* /*mparams*/ , DataMatrixDeriv& /*cData*/)
 {
-    serr<<"projectJacobianMatrix(const core::MechanicalParams*, DataMatrixDeriv& ) is not implemented" << sendl;
+    msg_error() << "projectJacobianMatrix(const core::MechanicalParams*, DataMatrixDeriv& ) is not implemented";
 }
 
 template <class DataTypes>
@@ -262,13 +262,13 @@ void ProjectToPlaneConstraint<DataTypes>::projectPosition(const core::Mechanical
 template <class DataTypes>
 void ProjectToPlaneConstraint<DataTypes>::applyConstraint(defaulttype::BaseMatrix * /*mat*/, unsigned int /*offset*/)
 {
-    serr << "applyConstraint is not implemented " << sendl;
+    msg_error() << "applyConstraint is not implemented ";
 }
 
 template <class DataTypes>
 void ProjectToPlaneConstraint<DataTypes>::applyConstraint(defaulttype::BaseVector * /*vect*/, unsigned int /*offset*/)
 {
-    serr<<"ProjectToPlaneConstraint<DataTypes>::applyConstraint(defaulttype::BaseVector *vect, unsigned int offset) is not implemented "<< sendl;
+    msg_error() << "ProjectToPlaneConstraint<DataTypes>::applyConstraint(defaulttype::BaseVector *vect, unsigned int offset) is not implemented ";
 }
 
 template <class DataTypes>

--- a/modules/SofaBoundaryCondition/ProjectToPointConstraint.inl
+++ b/modules/SofaBoundaryCondition/ProjectToPointConstraint.inl
@@ -140,16 +140,18 @@ void ProjectToPointConstraint<DataTypes>::init()
 
     const SetIndexArray & indices = f_indices.getValue();
 
+    std::stringstream sstream;
     unsigned int maxIndex=this->mstate->getSize();
     for (unsigned int i=0; i<indices.size(); ++i)
     {
         const unsigned int index=indices[i];
         if (index >= maxIndex)
         {
-            serr << "Index " << index << " not valid!" << sendl;
+            sstream << "Index " << index << " not valid!\n";
             removeConstraint(index);
         }
     }
+    msg_error_when(!sstream.str().empty()) << sstream.str();
 
     reinit();
 }

--- a/modules/SofaBoundaryCondition/QuadPressureForceField.h
+++ b/modules/SofaBoundaryCondition/QuadPressureForceField.h
@@ -119,7 +119,7 @@ public:
     /// Constant pressure has null variation
     void addKToMatrix(const core::MechanicalParams* /*mparams*/, const sofa::core::behavior::MultiMatrixAccessor* /*matrix*/ ) override {}
 
-    SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override { serr << "Get potentialEnergy not implemented" << sendl; return 0.0; }
+    SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override { msg_error() << "Get potentialEnergy not implemented"; return 0.0; }
 
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/modules/SofaBoundaryCondition/QuadPressureForceField.h
+++ b/modules/SofaBoundaryCondition/QuadPressureForceField.h
@@ -119,7 +119,7 @@ public:
     /// Constant pressure has null variation
     void addKToMatrix(const core::MechanicalParams* /*mparams*/, const sofa::core::behavior::MultiMatrixAccessor* /*matrix*/ ) override {}
 
-    SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override { msg_error() << "Get potentialEnergy not implemented"; return 0.0; }
+    SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override { msg_warning() << "Method getPotentialEnergy not implemented yet."; return 0.0; }
 
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/modules/SofaBoundaryCondition/QuadPressureForceField.inl
+++ b/modules/SofaBoundaryCondition/QuadPressureForceField.inl
@@ -137,8 +137,10 @@ void QuadPressureForceField<DataTypes>::initQuadInformation()
     sofa::component::topology::QuadSetGeometryAlgorithms<DataTypes>* quadGeo;
     this->getContext()->get(quadGeo);
 
-    if(!quadGeo)
-        serr << "Missing component: Unable to get QuadSetGeometryAlgorithms from the current context." << sendl;
+    if (!quadGeo)
+    {
+        msg_error() << "Missing component: Unable to get QuadSetGeometryAlgorithms from the current context.";
+    }
 
     // FIXME: a dirty way to avoid a crash
     if(!quadGeo)

--- a/modules/SofaBoundaryCondition/SphereForceField.inl
+++ b/modules/SofaBoundaryCondition/SphereForceField.inl
@@ -206,7 +206,7 @@ void SphereForceField<DataTypes>::draw(const core::visual::VisualParams* vparams
 template<class DataTypes>
 SReal SphereForceField<DataTypes>::getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const
 {
-    serr << "Get potentialEnergy not implemented" << sendl;
+    msg_error() << "Get potentialEnergy not implemented";
     return 0.0;
 }
 

--- a/modules/SofaBoundaryCondition/SphereForceField.inl
+++ b/modules/SofaBoundaryCondition/SphereForceField.inl
@@ -206,7 +206,7 @@ void SphereForceField<DataTypes>::draw(const core::visual::VisualParams* vparams
 template<class DataTypes>
 SReal SphereForceField<DataTypes>::getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const
 {
-    msg_error() << "Get potentialEnergy not implemented";
+    msg_warning() << "Method getPotentialEnergy not implemented yet.";
     return 0.0;
 }
 

--- a/modules/SofaBoundaryCondition/SurfacePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/SurfacePressureForceField.inl
@@ -275,7 +275,7 @@ void SurfacePressureForceField<DataTypes>::addKToMatrix(const core::MechanicalPa
 template<class DataTypes>
 SReal SurfacePressureForceField<DataTypes>::getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const
 {
-    serr << "Get potentialEnergy not implemented" << sendl;
+    msg_error() << "Get potentialEnergy not implemented";
     return 0.0;
 }
 

--- a/modules/SofaBoundaryCondition/SurfacePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/SurfacePressureForceField.inl
@@ -275,7 +275,7 @@ void SurfacePressureForceField<DataTypes>::addKToMatrix(const core::MechanicalPa
 template<class DataTypes>
 SReal SurfacePressureForceField<DataTypes>::getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const
 {
-    msg_error() << "Get potentialEnergy not implemented";
+    msg_warning() << "Method getPotentialEnergy not implemented yet.";
     return 0.0;
 }
 

--- a/modules/SofaBoundaryCondition/TaitSurfacePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/TaitSurfacePressureForceField.inl
@@ -333,7 +333,7 @@ void TaitSurfacePressureForceField<DataTypes>::addKToMatrix(const core::Mechanic
 template<class DataTypes>
 SReal TaitSurfacePressureForceField<DataTypes>::getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const
 {
-    msg_error() << "Get potentialEnergy not implemented";
+    msg_warning() << "Method getPotentialEnergy not implemented yet.";
     return 0.0;
 }
 

--- a/modules/SofaBoundaryCondition/TorsionForceField.inl
+++ b/modules/SofaBoundaryCondition/TorsionForceField.inl
@@ -150,7 +150,7 @@ void TorsionForceField<DataTypes>::addKToMatrix(defaulttype::BaseMatrix* matrix,
 template<typename DataTypes>
 SReal TorsionForceField<DataTypes>::getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const
 {
-    serr << "Get potentialEnergy not implemented" << sendl;
+    msg_error() << "Get potentialEnergy not implemented";
     return 0.0;
 }
 

--- a/modules/SofaBoundaryCondition/TorsionForceField.inl
+++ b/modules/SofaBoundaryCondition/TorsionForceField.inl
@@ -150,7 +150,7 @@ void TorsionForceField<DataTypes>::addKToMatrix(defaulttype::BaseMatrix* matrix,
 template<typename DataTypes>
 SReal TorsionForceField<DataTypes>::getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const
 {
-    msg_error() << "Get potentialEnergy not implemented";
+    msg_warning() << "Method getPotentialEnergy not implemented yet.";
     return 0.0;
 }
 

--- a/modules/SofaBoundaryCondition/TrianglePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/TrianglePressureForceField.inl
@@ -287,7 +287,7 @@ void TrianglePressureForceField<DataTypes>::draw(const core::visual::VisualParam
 template<class DataTypes>
 SReal TrianglePressureForceField<DataTypes>::getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const
 {
-    msg_error() << "Get potentialEnergy not implemented";
+    msg_warning() << "Method getPotentialEnergy not implemented yet.";
     return 0.0;
 }
 

--- a/modules/SofaBoundaryCondition/TrianglePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/TrianglePressureForceField.inl
@@ -152,8 +152,10 @@ void TrianglePressureForceField<DataTypes>::initTriangleInformation()
 {
    this->getContext()->get(triangleGeo);
 
-    if(!triangleGeo)
-        serr << "Missing component: Unable to get TriangleSetGeometryAlgorithms from the current context." << sendl;
+   if (!triangleGeo)
+   {
+       msg_error() << "Missing component: Unable to get TriangleSetGeometryAlgorithms from the current context.";
+   }
 
     // FIXME: a dirty way to avoid a crash
     if(!triangleGeo)
@@ -285,7 +287,7 @@ void TrianglePressureForceField<DataTypes>::draw(const core::visual::VisualParam
 template<class DataTypes>
 SReal TrianglePressureForceField<DataTypes>::getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const
 {
-    serr << "Get potentialEnergy not implemented" << sendl;
+    msg_error() << "Get potentialEnergy not implemented";
     return 0.0;
 }
 

--- a/modules/SofaConstraint/ConstraintAttachBodyPerformer.inl
+++ b/modules/SofaConstraint/ConstraintAttachBodyPerformer.inl
@@ -131,7 +131,7 @@ bool ConstraintAttachBodyPerformer<DataTypes>::start_partial(const BodyPicked& p
         mapper = MouseContactMapper::Create(picked.body);
         if (!mapper)
         {
-            this->interactor->serr << "Problem with Mouse Mapper creation : " << this->interactor->sendl;
+            msg_error(this->interactor) << "Problem with Mouse Mapper creation.";
             return false;
         }
         std::string name = "contactMouse";
@@ -167,7 +167,7 @@ bool ConstraintAttachBodyPerformer<DataTypes>::start_partial(const BodyPicked& p
         index = picked.indexCollisionElement;
         if (!mstateCollision)
         {
-            this->interactor->serr << "incompatible MState during Mouse Interaction " << this->interactor->sendl;
+            msg_error(this->interactor) << "incompatible MState during Mouse Interaction.";
             return false;
         }
     }

--- a/modules/SofaConstraint/DistanceLMContactConstraint.inl
+++ b/modules/SofaConstraint/DistanceLMContactConstraint.inl
@@ -211,9 +211,9 @@ void DistanceLMContactConstraint<DataTypes>::writeConstraintEquations(unsigned i
                 this->getContext()->get(intersection);
 
             if (intersection)
-                minDistance=intersection->getContactDistance();
+                minDistance = intersection->getContactDistance();
             else
-                serr << "No intersection component found!!" << sendl;
+                msg_error() << "No intersection component found!!";
 
             const VecCoord &x1 = this->constrainedObject1->read(core::ConstVecCoordId(id.getId(this->constrainedObject1)))->getValue();
             const VecCoord &x2 = this->constrainedObject2->read(core::ConstVecCoordId(id.getId(this->constrainedObject2)))->getValue();
@@ -286,7 +286,7 @@ void DistanceLMContactConstraint<DataTypes>::LagrangeMultiplierEvaluation(const 
 
             if (value == 0)
             {
-                serr << "ERROR DIVISION BY ZERO AVOIDED: w=[" << W[0]  << "," << W[1] << "," << W[2]  << "] " << " DIRECTION CONE: " << directionCone << " BARY COEFF: " << contact.coeff[0] << ", " <<  contact.coeff[1] << ", " <<  contact.coeff[2] << std::endl;
+                msg_error() << "DIVISION BY ZERO AVOIDED: w=[" << W[0] << "," << W[1] << "," << W[2] << "] " << " DIRECTION CONE: " << directionCone << " BARY COEFF: " << contact.coeff[0] << ", " << contact.coeff[1] << ", " << contact.coeff[2];
                 group->setActive(false);
                 out.contactForce=Deriv();
                 return;

--- a/modules/SofaConstraint/FrictionContact.inl
+++ b/modules/SofaConstraint/FrictionContact.inl
@@ -105,7 +105,7 @@ void FrictionContact<TCollisionModel1,TCollisionModel2,ResponseDataTypes>::setDe
 
     if (model1->getContactStiffness(0) == 0 || model2->getContactStiffness(0) == 0)
     {
-        serr << "Disabled FrictionContact with " << (outputs.size()) << " collision points." << sendl;
+        msg_error() << "Disabled FrictionContact with " << (outputs.size()) << " collision points.";
         return;
     }
 
@@ -215,7 +215,7 @@ void FrictionContact<TCollisionModel1,TCollisionModel2,ResponseDataTypes>::creat
     const double mu_ = this->mu.getValue();
     // Checks if friction is considered
     if ( mu_ < 0.0 )
-        serr << sendl << "Error: mu has to take positive values" << sendl;
+        msg_error() << "mu has to take positive values";
 
     int i=0;
     if (m_constraint)

--- a/modules/SofaConstraint/LCPConstraintSolver.cpp
+++ b/modules/SofaConstraint/LCPConstraintSolver.cpp
@@ -410,7 +410,7 @@ void LCPConstraintSolver::MultigridConstraintsMerge()
         MultigridConstraintsMerge_Spatial();
         break;
     default:
-        serr << "Unsupported merge method " << merge_method.getValue() << sendl;
+        msg_error() << "Unsupported merge method " << merge_method.getValue();
     }
 }
 
@@ -525,12 +525,12 @@ void LCPConstraintSolver::MultigridConstraintsMerge_Spatial()
                     << " : c0 = " << info.const0 << " nbl = " << info.nbLines << " nbg = " << info.nbGroups << " offsetPosition = " << info.offsetPosition << " offsetDirection = " << info.offsetDirection << " offsetArea = " << info.offsetArea;
             if (!info.hasPosition)
             {
-                serr << "MultigridConstraintsMerge_Spatial: constraints from " << (info.parent ? info.parent->getName() : std::string("nullptr")) << " have no position data" << sendl;
+                msg_error() << "MultigridConstraintsMerge_Spatial: constraints from " << (info.parent ? info.parent->getName() : std::string("nullptr")) << " have no position data";
                 continue;
             }
             if (!info.hasDirection)
             {
-                serr << "MultigridConstraintsMerge_Spatial: constraints from " << (info.parent ? info.parent->getName() : std::string("nullptr")) << " have no direction data" << sendl;
+                msg_error() << "MultigridConstraintsMerge_Spatial: constraints from " << (info.parent ? info.parent->getName() : std::string("nullptr")) << " have no direction data";
                 continue;
             }
             ConstraintBlockInfo newInfo;
@@ -547,12 +547,12 @@ void LCPConstraintSolver::MultigridConstraintsMerge_Spatial()
                 int idFine = c0 + c*nbl;
                 if (idFine + 2 >= numConstraints)
                 {
-                    serr << "MultigridConstraintsMerge_Spatial level " << level << ": constraint " << idFine << " from " << (info.parent ? info.parent->getName() : std::string("nullptr")) << " has invalid index" << sendl;
+                    msg_error() << "MultigridConstraintsMerge_Spatial level " << level << ": constraint " << idFine << " from " << (info.parent ? info.parent->getName() : std::string("nullptr")) << " has invalid index";
                     break;
                 }
                 if ((unsigned)(info.offsetPosition + c) >= constraintPositions.size())
                 {
-                    serr << "MultigridConstraintsMerge_Spatial level " << level << ": constraint " << idFine << " from " << (info.parent ? info.parent->getName() : std::string("nullptr")) << " has invalid position index" << sendl;
+                    msg_error() << "MultigridConstraintsMerge_Spatial level " << level << ": constraint " << idFine << " from " << (info.parent ? info.parent->getName() : std::string("nullptr")) << " has invalid position index";
                     break;
                 }
                 ConstCoord posFine = constraintPositions[info.offsetPosition + c];
@@ -848,13 +848,13 @@ int LCPConstraintSolver::nlcp_gaussseidel_unbuilt(double *dfree, double *f, std:
 
     if(_mu==0.0)
     {
-        serr<<"WARNING: frictionless case with unbuilt nlcp is not implemented"<<sendl;
+        msg_error() << "WARNING: frictionless case with unbuilt nlcp is not implemented";
         return 0;
     }
 
     if (_numConstraints%3 != 0)
     {
-        serr<<" WARNING dim should be dividable by 3 in nlcp_gaussseidel"<<sendl;
+        msg_error() << " WARNING dim should be dividable by 3 in nlcp_gaussseidel";
         return 0;
     }
     int numContacts =  _numConstraints/3;
@@ -924,8 +924,8 @@ int LCPConstraintSolver::nlcp_gaussseidel_unbuilt(double *dfree, double *f, std:
 
             }
         }
-        if(!elem1)
-            serr<<"WARNING: no constraintCorrection found for contact"<<c1<<sendl;
+        if (!elem1)
+            msg_error() << "WARNING: no constraintCorrection found for contact" << c1;
         if(!elem2)
             _cclist_elem2.push_back(nullptr);
 

--- a/modules/SofaConstraint/LMDNewProximityIntersection.cpp
+++ b/modules/SofaConstraint/LMDNewProximityIntersection.cpp
@@ -133,7 +133,7 @@ bool LMDNewProximityIntersection::testIntersection(Point& e1, Point& e2)
 int LMDNewProximityIntersection::computeIntersection(Point& e1, Point& e2, OutputVector* contacts)
 {
     const double alarmDist = getAlarmDistance() + e1.getProximity() + e2.getProximity();
-    std::cout<<"computeIntersection(Point& e1, Point& e2... is called"<<std::endl;
+    msg_info()<<"computeIntersection(Point& e1, Point& e2... is called";
     int n = doIntersectionPointPoint(alarmDist*alarmDist, e1.p(), e2.p(), contacts
             , (e1.getCollisionModel()->getSize() > e2.getCollisionModel()->getSize()) ? e1.getIndex() : e2.getIndex()
             , e1.getIndex(), e2.getIndex(), *(e1.getCollisionModel()->getFilter())
@@ -154,7 +154,7 @@ int LMDNewProximityIntersection::computeIntersection(Point& e1, Point& e2, Outpu
 
 bool LMDNewProximityIntersection::testIntersection(Line&, Point&)
 {
-    serr << "Unnecessary call to NewProximityIntersection::testIntersection(Line,Point)."<<sendl;
+    msg_error() << "Unnecessary call to NewProximityIntersection::testIntersection(Line,Point).";
     return true;
 }
 
@@ -163,7 +163,7 @@ int LMDNewProximityIntersection::computeIntersection(Line& e1, Point& e2, Output
 {
     const double alarmDist = getAlarmDistance() + e1.getProximity() + e2.getProximity();
 
-    std::cout<<"computeIntersection(Line& e1, Point& e2... is called"<<std::endl;
+    msg_info()<<"computeIntersection(Line& e1, Point& e2... is called";
     int id = e2.getIndex();
     int n = doIntersectionLinePoint(alarmDist*alarmDist, e1.p1(), e1.p2(), e2.p(), contacts, id
             , e1.getIndex(), e2.getIndex(), *(e1.getCollisionModel()->getFilter())
@@ -184,14 +184,14 @@ int LMDNewProximityIntersection::computeIntersection(Line& e1, Point& e2, Output
 
 bool LMDNewProximityIntersection::testIntersection(Line&, Line&)
 {
-    serr << "Unnecessary call to NewProximityIntersection::testIntersection(Line,Line)."<<sendl;
+    msg_error() << "Unnecessary call to NewProximityIntersection::testIntersection(Line,Line).";
     return true;
 }
 
 
 int LMDNewProximityIntersection::computeIntersection(Line& e1, Line& e2, OutputVector* contacts)
 {
-    std::cout<<"computeIntersection(Line& e1, Line& e2... is called"<<std::endl;
+    msg_info() << "computeIntersection(Line& e1, Line& e2... is called";
     const double alarmDist = getAlarmDistance() + e1.getProximity() + e2.getProximity();
     const double dist2 = alarmDist*alarmDist;
     const int id = (e1.getCollisionModel()->getSize() > e2.getCollisionModel()->getSize()) ? e1.getIndex() : e2.getIndex();
@@ -216,7 +216,7 @@ int LMDNewProximityIntersection::computeIntersection(Line& e1, Line& e2, OutputV
 
 bool LMDNewProximityIntersection::testIntersection(Triangle&, Point&)
 {
-    serr << "Unnecessary call to NewProximityIntersection::testIntersection(Triangle,Point)."<<sendl;
+    msg_error() << "Unnecessary call to NewProximityIntersection::testIntersection(Triangle,Point).";
     return true;
 }
 
@@ -237,15 +237,15 @@ int LMDNewProximityIntersection::computeIntersection(Triangle& e1, Point& e2, Ou
         edge[i] = e1.getCollisionModel()->getCollisionTopology()->getEdge(edgesInTriangle1[i]);
         if(((int)edge[i][0]==e1.p1Index() && (int)edge[i][1]==e1.p2Index()) || ((int)edge[i][0]==e1.p2Index() && (int)edge[i][1]==e1.p1Index()))
         {
-            E1edge1verif = edgesInTriangle1[i]; /*std::cout<<"- e1 1: "<<i ;*/
+            E1edge1verif = edgesInTriangle1[i]; /*msg_info()<<"- e1 1: "<<i ;*/
         }
         if(((int)edge[i][0]==e1.p2Index() && (int)edge[i][1]==e1.p3Index()) || ((int)edge[i][0]==e1.p3Index() && (int)edge[i][1]==e1.p2Index()))
         {
-            E1edge2verif = edgesInTriangle1[i]; /*std::cout<<"- e1 2: "<<i ;*/
+            E1edge2verif = edgesInTriangle1[i]; /*msg_info()<<"- e1 2: "<<i ;*/
         }
         if(((int)edge[i][0]==e1.p1Index() && (int)edge[i][1]==e1.p3Index()) || ((int)edge[i][0]==e1.p3Index() && (int)edge[i][1]==e1.p1Index()))
         {
-            E1edge3verif = edgesInTriangle1[i]; /*std::cout<<"- e1 3: "<<i ;*/
+            E1edge3verif = edgesInTriangle1[i]; /*msg_info()<<"- e1 3: "<<i ;*/
         }
     }
 
@@ -253,7 +253,7 @@ int LMDNewProximityIntersection::computeIntersection(Triangle& e1, Point& e2, Ou
     e1_edgesIndex[0]=E1edge1verif; e1_edgesIndex[1]=E1edge2verif; e1_edgesIndex[2]=E1edge3verif;
 
 
-    std::cout<<"computeIntersection(Triangle& e1, Point& e2... is called"<<std::endl;
+    msg_info()<<"computeIntersection(Triangle& e1, Point& e2... is called";
     const double alarmDist = getAlarmDistance() + e1.getProximity() + e2.getProximity();
     const double dist2 = alarmDist*alarmDist;
 
@@ -277,7 +277,7 @@ int LMDNewProximityIntersection::computeIntersection(Triangle& e1, Point& e2, Ou
 
 bool LMDNewProximityIntersection::testIntersection(Triangle&, Line&)
 {
-    serr << "Unnecessary call to NewProximityIntersection::testIntersection(Triangle& e1, Line& e2)."<<sendl;
+    msg_error() << "Unnecessary call to NewProximityIntersection::testIntersection(Triangle& e1, Line& e2).";
     return true;
 }
 
@@ -298,15 +298,15 @@ int LMDNewProximityIntersection::computeIntersection(Triangle& e1, Line& e2, Out
         edge[i] = e1.getCollisionModel()->getCollisionTopology()->getEdge(edgesInTriangle1[i]);
         if(((int)edge[i][0]==e1.p1Index() && (int)edge[i][1]==e1.p2Index()) || ((int)edge[i][0]==e1.p2Index() && (int)edge[i][1]==e1.p1Index()))
         {
-            E1edge1verif = edgesInTriangle1[i]; /*std::cout<<"- e1 1: "<<i ;*/
+            E1edge1verif = edgesInTriangle1[i]; /*msg_info()<<"- e1 1: "<<i ;*/
         }
         if(((int)edge[i][0]==e1.p2Index() && (int)edge[i][1]==e1.p3Index()) || ((int)edge[i][0]==e1.p3Index() && (int)edge[i][1]==e1.p2Index()))
         {
-            E1edge2verif = edgesInTriangle1[i]; /*std::cout<<"- e1 2: "<<i ;*/
+            E1edge2verif = edgesInTriangle1[i]; /*msg_info()<<"- e1 2: "<<i ;*/
         }
         if(((int)edge[i][0]==e1.p1Index() &&(int) edge[i][1]==e1.p3Index()) || ((int)edge[i][0]==e1.p3Index() && (int)edge[i][1]==e1.p1Index()))
         {
-            E1edge3verif = edgesInTriangle1[i]; /*std::cout<<"- e1 3: "<<i ;*/
+            E1edge3verif = edgesInTriangle1[i]; /*msg_info()<<"- e1 3: "<<i ;*/
         }
     }
 
@@ -315,7 +315,7 @@ int LMDNewProximityIntersection::computeIntersection(Triangle& e1, Line& e2, Out
 
 
 
-    std::cout<<"computeIntersection(Triangle& e1, Line& e2... is called"<<std::endl;
+    msg_info()<<"computeIntersection(Triangle& e1, Line& e2... is called";
     const double alarmDist = getAlarmDistance() + e1.getProximity() + e2.getProximity();
     const double dist2 = alarmDist*alarmDist;
     const Vector3& p1 = e1.p1();
@@ -380,7 +380,7 @@ int LMDNewProximityIntersection::computeIntersection(Triangle& e1, Line& e2, Out
 
 bool LMDNewProximityIntersection::testIntersection(Triangle&, Triangle&)
 {
-    serr << "Unnecessary call to NewProximityIntersection::testIntersection(Triangle& e1, Triangle& e2)."<<sendl;
+    msg_error() << "Unnecessary call to NewProximityIntersection::testIntersection(Triangle& e1, Triangle& e2).";
     return true;
 }
 
@@ -389,15 +389,15 @@ int LMDNewProximityIntersection::computeIntersection(Triangle& e1, Triangle& e2,
 {
     if (e1.getIndex() >= e1.getCollisionModel()->getSize())
     {
-        serr << "NewProximityIntersection::computeIntersection(Triangle, Triangle): ERROR invalid e1 index "
-                << e1.getIndex() << " on CM " << e1.getCollisionModel()->getName() << " of size " << e1.getCollisionModel()->getSize()<<sendl;
+        msg_error() << "NewProximityIntersection::computeIntersection(Triangle, Triangle): ERROR invalid e1 index "
+            << e1.getIndex() << " on CM " << e1.getCollisionModel()->getName() << " of size " << e1.getCollisionModel()->getSize();
         return 0;
     }
 
     if (e2.getIndex() >= e2.getCollisionModel()->getSize())
     {
-        serr << "NewProximityIntersection::computeIntersection(Triangle, Triangle): ERROR invalid e2 index "
-                << e2.getIndex() << " on CM " << e2.getCollisionModel()->getName() << " of size " << e2.getCollisionModel()->getSize()<<sendl;
+        msg_error() << "NewProximityIntersection::computeIntersection(Triangle, Triangle): ERROR invalid e2 index "
+            << e2.getIndex() << " on CM " << e2.getCollisionModel()->getName() << " of size " << e2.getCollisionModel()->getSize();
         return 0;
     }
 
@@ -421,29 +421,29 @@ int LMDNewProximityIntersection::computeIntersection(Triangle& e1, Triangle& e2,
         edge[i] = e1.getCollisionModel()->getCollisionTopology()->getEdge(edgesInTriangle1[i]);
         if(((int)edge[i][0]==e1.p1Index() && (int)edge[i][1]==e1.p2Index()) || ((int)edge[i][0]==e1.p2Index() && (int)edge[i][1]==e1.p1Index()))
         {
-            E1edge1verif = edgesInTriangle1[i]; /*std::cout<<"- e1 1: "<<i ;*/
+            E1edge1verif = edgesInTriangle1[i]; /*msg_info()<<"- e1 1: "<<i ;*/
         }
         if(((int)edge[i][0]==e1.p2Index() && (int)edge[i][1]==e1.p3Index()) || ((int)edge[i][0]==e1.p3Index() && (int)edge[i][1]==e1.p2Index()))
         {
-            E1edge2verif = edgesInTriangle1[i]; /*std::cout<<"- e1 2: "<<i ;*/
+            E1edge2verif = edgesInTriangle1[i]; /*msg_info()<<"- e1 2: "<<i ;*/
         }
         if(((int)edge[i][0]==e1.p1Index() && (int)edge[i][1]==e1.p3Index()) || ((int)edge[i][0]==e1.p3Index() && (int)edge[i][1]==e1.p1Index()))
         {
-            E1edge3verif = edgesInTriangle1[i]; /*std::cout<<"- e1 3: "<<i ;*/
+            E1edge3verif = edgesInTriangle1[i]; /*msg_info()<<"- e1 3: "<<i ;*/
         }
         // Verify for E2: convention: Edge1 = P1 P2    Edge2 = P2 P3    Edge3 = P3 P1
         edge[i] = e2.getCollisionModel()->getCollisionTopology()->getEdge(edgesInTriangle2[i]);
         if(((int)edge[i][0]==e2.p1Index() && (int)edge[i][1]==e2.p2Index()) || ((int)edge[i][0]==e2.p2Index() && (int)edge[i][1]==e2.p1Index()))
         {
-            E2edge1verif = edgesInTriangle2[i];/*std::cout<<"- e2 1: "<<i ;*/
+            E2edge1verif = edgesInTriangle2[i];/*msg_info()<<"- e2 1: "<<i ;*/
         }
         if(((int)edge[i][0]==e2.p2Index() && (int)edge[i][1]==e2.p3Index()) || ((int)edge[i][0]==e2.p3Index() && (int)edge[i][1]==e2.p2Index()))
         {
-            E2edge2verif = edgesInTriangle2[i];/*std::cout<<"- e2 2: "<<i ;*/
+            E2edge2verif = edgesInTriangle2[i];/*msg_info()<<"- e2 2: "<<i ;*/
         }
         if(((int)edge[i][0]==e2.p1Index() && (int)edge[i][1]==e2.p3Index()) || ((int)edge[i][0]==e2.p3Index() && (int)edge[i][1]==e2.p1Index()))
         {
-            E2edge3verif = edgesInTriangle2[i]; /*std::cout<<"- e2 3: "<<i ;*/
+            E2edge3verif = edgesInTriangle2[i]; /*msg_info()<<"- e2 3: "<<i ;*/
         }
     }
 

--- a/modules/SofaConstraint/LMDNewProximityIntersection.inl
+++ b/modules/SofaConstraint/LMDNewProximityIntersection.inl
@@ -437,7 +437,7 @@ int LMDNewProximityIntersection::computeIntersection(TSphere<T1>& e1, TSphere<T2
 template<class T>
 bool LMDNewProximityIntersection::testIntersection(Line&, TSphere<T>&)
 {
-    serr << "Unnecessary call to NewProximityIntersection::testIntersection(Line,Sphere)."<<sendl;
+    msg_error() << "Unnecessary call to NewProximityIntersection::testIntersection(Line,Sphere).";
     return true;
 }
 
@@ -465,7 +465,7 @@ int LMDNewProximityIntersection::computeIntersection(Line& e1, TSphere<T>& e2, O
 template<class T>
 bool LMDNewProximityIntersection::testIntersection(Triangle&, TSphere<T>&)
 {
-    serr << "Unnecessary call to NewProximityIntersection::testIntersection(Triangle,Sphere)."<<sendl;
+    msg_error() << "Unnecessary call to NewProximityIntersection::testIntersection(Triangle,Sphere).";
     return true;
 }
 

--- a/modules/SofaConstraint/PrecomputedConstraintCorrection.h
+++ b/modules/SofaConstraint/PrecomputedConstraintCorrection.h
@@ -167,10 +167,10 @@ public:
 public:
     Real* getInverse()
     {
-        if(invM->data)
+        if (invM->data)
             return invM->data;
         else
-            serr<<"Inverse is not computed yet"<<sendl;
+            msg_error() << "Inverse is not computed yet";
         return nullptr;
     }
 

--- a/modules/SofaConstraint/PrecomputedConstraintCorrection.inl
+++ b/modules/SofaConstraint/PrecomputedConstraintCorrection.inl
@@ -1057,8 +1057,7 @@ void PrecomputedConstraintCorrection<DataTypes>::resetForUnbuiltResolution(doubl
         if (cId >= id_to_localIndex.size())
             id_to_localIndex.resize(cId + 1, -1);
 
-        if (id_to_localIndex[cId] != -1)
-            serr << "duplicate entry in constraints for id " << cId << " : " << id_to_localIndex[cId] << " + " << cpt ;
+        msg_error_when(id_to_localIndex[cId] != -1) << "duplicate entry in constraints for id " << cId << " : " << id_to_localIndex[cId] << " + " << cpt;
 
         id_to_localIndex[cId] = cpt;
         localIndex_to_id.push_back(cId);
@@ -1073,7 +1072,7 @@ void PrecomputedConstraintCorrection<DataTypes>::resetForUnbuiltResolution(doubl
         {
             if(error_message_not_displayed)
             {
-                serr<<"Initial_guess not supported yet in unbuilt mode with NEW_METHOD_UNBUILT!=> PUT F to 0"<<sendl;
+                msg_error() << "Initial_guess not supported yet in unbuilt mode with NEW_METHOD_UNBUILT!=> PUT F to 0";
                 error_message_not_displayed = false;
             }
 

--- a/modules/SofaConstraint/UncoupledConstraintCorrection.cpp
+++ b/modules/SofaConstraint/UncoupledConstraintCorrection.cpp
@@ -58,7 +58,7 @@ SOFA_CONSTRAINT_API void UncoupledConstraintCorrection< defaulttype::Rigid3Types
     {
         if (d_useOdeSolverIntegrationFactors.getValue() == true)
         {
-            serr << "Can't find any odeSolver" << sendl;
+            msg_error() << "Can't find any odeSolver";
             d_useOdeSolverIntegrationFactors.setValue(false);
         }
         d_useOdeSolverIntegrationFactors.setReadOnly(true);
@@ -92,11 +92,11 @@ SOFA_CONSTRAINT_API void UncoupledConstraintCorrection< defaulttype::Rigid3Types
             if (um)
                 massValue = um->getVertexMass();
             else
-                serr << "WARNING : no mass found" << sendl;
+                msg_warning() << "No mass found.";
         }
         else
         {
-            serr << "\n WARNING : node is not found => massValue could be incorrect in addComplianceInConstraintSpace function" << sendl;
+            msg_warning() << "Node is not found => massValue could be incorrect in addComplianceInConstraintSpace function.";
         }
         
 

--- a/modules/SofaConstraint/UnilateralInteractionConstraint.inl
+++ b/modules/SofaConstraint/UnilateralInteractionConstraint.inl
@@ -315,7 +315,7 @@ void UnilateralInteractionConstraint<DataTypes>::getConstraintViolation(const co
         break;
 
     default :
-        serr << "UnilateralInteractionConstraint doesn't implement " << cparams->getName() << " constraint violation\n";
+        msg_error() << "UnilateralInteractionConstraint doesn't implement " << cparams->getName() << " constraint violation\n";
         break;
     }
 }

--- a/modules/SofaDenseSolver/LULinearSolver.cpp
+++ b/modules/SofaDenseSolver/LULinearSolver.cpp
@@ -75,8 +75,8 @@ void LULinearSolver<Matrix,Vector>::solve (Matrix& M, Vector& x, Vector& b)
 
     if( verbose )
     {
-        serr<<"LULinearSolver, b = "<< b <<sendl;
-        serr<<"LULinearSolver, M = "<< M <<sendl;
+        msg_info() << "LULinearSolver, b = " << b;
+        msg_info() << "LULinearSolver, M = " << M;
     }
     if (solver)
         M.solve(&x,&b, solver);
@@ -86,7 +86,7 @@ void LULinearSolver<Matrix,Vector>::solve (Matrix& M, Vector& x, Vector& b)
     // x is the solution of the system
     if( verbose )
     {
-        serr<<"LULinearSolver::solve, solution = "<<x<<sendl;
+        msg_info() << "LULinearSolver::solve, solution = " << x;
     }
 }
 
@@ -117,7 +117,7 @@ bool LULinearSolver<Matrix, Vector>::addJMInvJt(RMatrix& result, JMatrix& J, dou
     const unsigned int Jcols = J.colSize();
     if (Jcols != (unsigned int)this->currentGroup->systemMatrix->rowSize())
     {
-        serr << "LULinearSolver::addJMInvJt ERROR: incompatible J matrix size." << sendl;
+        msg_error() << "AddJMInvJt ERROR: incompatible J matrix size.";
         return false;
     }
 

--- a/modules/SofaGeneralDeformable/FrameSpringForceField.inl
+++ b/modules/SofaGeneralDeformable/FrameSpringForceField.inl
@@ -97,11 +97,6 @@ void FrameSpringForceField<DataTypes>::addSpringForce ( SReal& /*potentialEnergy
 
     f1[a] += Deriv ( fT, C1);
     f2[b] -= Deriv ( fT, C2);
-
-    /*serr << "f1: " << fT1 << ", " << fR1 << sendl;
-    serr << "f2: " << fT2 << ", " << fR2 << sendl;
-    serr << "sum: " << fT2 + fT1 << ", " << fR2 + fR1 << sendl;
-    serr << "diff: " << fT2 - fT1 << ", " << fR2 - fR1 << sendl;*/
 }
 
 template<class DataTypes>

--- a/modules/SofaGeneralDeformable/TriangleBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/TriangleBendingSprings.inl
@@ -49,9 +49,9 @@ namespace interactionforcefield
 
 template<class DataTypes>
 TriangleBendingSprings<DataTypes>::TriangleBendingSprings()
-: l_topology(initLink("topology", "link to the topology container"))
+    : l_topology(initLink("topology", "link to the topology container"))
 {
-    //serr<<"TriangleBendingSprings<DataTypes>::TriangleBendingSprings"<<sendl;
+    
 }
 
 

--- a/modules/SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.h
+++ b/modules/SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.h
@@ -164,7 +164,7 @@ public:
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        msg_error() << "Get potentialEnergy not implemented";
+        msg_warning() << "Method getPotentialEnergy not implemented yet.";
         return 0.0;
     }
 

--- a/modules/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.h
+++ b/modules/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.h
@@ -150,7 +150,7 @@ public:
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        msg_error() << "Get potentialEnergy not implemented";
+        msg_warning() << "Method getPotentialEnergy not implemented yet.";
         return 0.0;
     }
 

--- a/modules/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.inl
+++ b/modules/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.inl
@@ -185,7 +185,7 @@ template <class DataTypes> void TriangularQuadraticSpringsForceField<DataTypes>:
 
     if (m_topology->getNbTriangles()==0)
     {
-        serr << "ERROR(TriangularQuadraticSpringsForceField): object must have a Triangular Set Topology."<<sendl;
+        msg_error() << "ERROR(TriangularQuadraticSpringsForceField): object must have a Triangular Set Topology.";
         return;
     }
     updateLameCoefficients();
@@ -261,7 +261,6 @@ void TriangularQuadraticSpringsForceField<DataTypes>::addForce(const core::Mecha
         val=einfo->stiffness*(einfo->dl)/L;
         f[v1]+=dp*val;
         f[v0]-=dp*val;
-        //	serr << "einfo->stiffness= "<<einfo->stiffness<<sendl;
     }
     if (f_useAngularSprings.getValue()==true)
     {
@@ -284,14 +283,12 @@ void TriangularQuadraticSpringsForceField<DataTypes>::addForce(const core::Mecha
                 f[ta[k]]-=force;
             }
         }
-        //	serr << "tinfo->gamma[0] "<<tinfo->gamma[0]<<sendl;
 
     }
     edgeInfo.endEdit();
     triangleInfo.endEdit();
     updateMatrix=true;
     d_f.endEdit();
-    //serr << "end addForce" << sendl;
 }
 
 
@@ -310,8 +307,6 @@ void TriangularQuadraticSpringsForceField<DataTypes>::addDForce(const core::Mech
     TriangleRestInformation *tinfo;
 
     helper::vector<typename TriangularQuadraticSpringsForceField<DataTypes>::TriangleRestInformation>& triangleInf = *(triangleInfo.beginEdit());
-
-    //	serr << "start addDForce" << sendl;
     helper::vector<typename TriangularQuadraticSpringsForceField<DataTypes>::EdgeRestInformation>& edgeInf = *(edgeInfo.beginEdit());
 
     assert(this->mstate);
@@ -326,7 +321,6 @@ void TriangularQuadraticSpringsForceField<DataTypes>::addDForce(const core::Mech
         Real val1,val2,vali,valj,valk;
         Coord dpj,dpk,dpi;
 
-        //	serr <<"updating matrix"<<sendl;
         updateMatrix=false;
         for(int l=0; l<nbTriangles; l++ )
         {
@@ -428,7 +422,6 @@ void TriangularQuadraticSpringsForceField<DataTypes>::updateLameCoefficients()
 {
     lambda= f_youngModulus.getValue()*f_poissonRatio.getValue()/(1-f_poissonRatio.getValue()*f_poissonRatio.getValue());
     mu = f_youngModulus.getValue()*(1-f_poissonRatio.getValue())/(1-f_poissonRatio.getValue()*f_poissonRatio.getValue());
-    //	serr << "initialized Lame coef : lambda=" <<lambda<< " mu="<<mu<<sendl;
 }
 
 

--- a/modules/SofaGeneralDeformable/TriangularTensorMassForceField.h
+++ b/modules/SofaGeneralDeformable/TriangularTensorMassForceField.h
@@ -162,7 +162,7 @@ public:
 
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        serr << "Get potentialEnergy not implemented" << sendl;
+        msg_error() << "Get potentialEnergy not implemented";
         return 0.0;
     }
 

--- a/modules/SofaGeneralDeformable/TriangularTensorMassForceField.h
+++ b/modules/SofaGeneralDeformable/TriangularTensorMassForceField.h
@@ -162,7 +162,7 @@ public:
 
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        msg_error() << "Get potentialEnergy not implemented";
+        msg_warning() << "Method getPotentialEnergy not implemented yet.";
         return 0.0;
     }
 

--- a/modules/SofaGeneralDeformable/TriangularTensorMassForceField.inl
+++ b/modules/SofaGeneralDeformable/TriangularTensorMassForceField.inl
@@ -421,7 +421,6 @@ void TriangularTensorMassForceField<DataTypes>::updateLameCoefficients()
 {
     lambda= f_youngModulus.getValue()*f_poissonRatio.getValue()/(1-f_poissonRatio.getValue()*f_poissonRatio.getValue());
     mu = f_youngModulus.getValue()*(1-f_poissonRatio.getValue())/(1-f_poissonRatio.getValue()*f_poissonRatio.getValue());
-    //	serr << "initialized Lame coef : lambda=" <<lambda<< " mu="<<mu<<sendl;
 }
 
 

--- a/modules/SofaGeneralEngine/ComplementaryROI.inl
+++ b/modules/SofaGeneralEngine/ComplementaryROI.inl
@@ -118,8 +118,8 @@ void ComplementaryROI<DataTypes>::doUpdate()
         ReadAccessor< Data<SetIndex> > setIndices(vd_setIndices[i]);
         for (unsigned int j=0;j<setIndices.size();++j) {
             set<index_type>::iterator it = myIndices.find(setIndices[j]);
-            if (it==myIndices.end())
-                serr << "index " << setIndices[j] << " does not exist" << sendl;
+            if (it == myIndices.end())
+                msg_error() << "index " << setIndices[j] << " does not exist";
             else
                 myIndices.erase(it);
         }

--- a/modules/SofaGeneralEngine/GenerateCylinder.inl
+++ b/modules/SofaGeneralEngine/GenerateCylinder.inl
@@ -373,7 +373,7 @@ void GenerateCylinder<DataTypes>::doUpdate()
                         }
                         else
                         {
-                            serr << "ERROR: duplicate triangle " << tr << " in tetra " << i <<" : " << (*itt) << sendl;
+                            msg_error() << "Duplicate triangle " << tr << " in tetra " << i << " : " << (*itt);
                         }
                         // tests if all vertices are on the circular surface
                         nbSurfaceNodes=0;

--- a/modules/SofaGeneralEngine/GenerateGrid.inl
+++ b/modules/SofaGeneralEngine/GenerateGrid.inl
@@ -81,11 +81,11 @@ void GenerateGrid<DataTypes>::doUpdate()
     size_t freqW=d_resolution.getValue()[1];
 
     if (freqL==0) {
-        serr<<" Number of cubes in the x direction cannot be 0; Changed to 1"<<sendl;
+        msg_error() << " Number of cubes in the x direction cannot be 0; Changed to 1";
         freqL=1;
     }
     if (freqW==0) {
-        serr<<" Number of cubes in the y direction cannot be 0; Changed to 1"<<sendl;
+        msg_error() << " Number of cubes in the y direction cannot be 0; Changed to 1";
         freqW=1;
     }
     const Real length = size[0]/freqL;

--- a/modules/SofaGeneralEngine/GenerateSphere.inl
+++ b/modules/SofaGeneralEngine/GenerateSphere.inl
@@ -168,8 +168,8 @@ void GenerateSphere<DataTypes>::init()
 	} else if (f_platonicSolidName.getValue() == "octahedron"){
 		platonicSolid=OCTAHEDRON;
 	} else {
-		serr << "Wrong Platonic Solid Name : "<< f_platonicSolidName <<sendl;
-		serr << "It should be either \"tetrahedron\", \"octahedron\" or \"icosahedron\" "<<sendl;
+        msg_error() << "Wrong Platonic Solid Name : "<< f_platonicSolidName << msgendl
+		 << "It should be either \"tetrahedron\", \"octahedron\" or \"icosahedron\" ";
 	}
 
 }

--- a/modules/SofaGeneralEngine/GroupFilterYoungModulus.inl
+++ b/modules/SofaGeneralEngine/GroupFilterYoungModulus.inl
@@ -110,7 +110,7 @@ void GroupFilterYoungModulus<DataTypes>::doUpdate()
                     }
 
                     if (!found)
-                        serr << "Group " << groupName << " not found" << sendl;
+                        msg_error() << "Group " << groupName << " not found";
                     else
                     {
                         mapMG[groups[gid]] = youngModulus;
@@ -119,7 +119,10 @@ void GroupFilterYoungModulus<DataTypes>::doUpdate()
                             maxSize = groups[gid].p0+ groups[gid].nbp;
                     }
                 }
-                else serr << "Error while parsing mapping" << sendl;
+                else
+                {
+                    msg_error() << "Error while parsing mapping";
+                }
             }
             //build YM vector
             youngModulusVector.clear();

--- a/modules/SofaGeneralEngine/IndicesFromValues.inl
+++ b/modules/SofaGeneralEngine/IndicesFromValues.inl
@@ -114,10 +114,12 @@ void IndicesFromValues<T>::doUpdate()
                     break;
                 }
             }
-            if (index >= 0)
+            if (index >= 0) {
                 indices.push_back(index);
-            else
-                serr << "Input value " << i <<" not found : " << v << sendl;
+            }
+            else {
+                msg_error() << "Input value " << i << " not found : " << v;
+            }
         }
     }
 }

--- a/modules/SofaGeneralEngine/JoinPoints.inl
+++ b/modules/SofaGeneralEngine/JoinPoints.inl
@@ -104,7 +104,7 @@ void JoinPoints<DataTypes>::doUpdate()
 
     if (points.size() < 1)
     {
-        serr << "Error, no point defined" << sendl;
+        msg_error() << "Error, no point defined";
         return ;
     }
 

--- a/modules/SofaGeneralEngine/MathOp.inl
+++ b/modules/SofaGeneralEngine/MathOp.inl
@@ -452,7 +452,7 @@ void MathOp<VecT>::init()
     std::string op = f_op.getValue().getSelectedItem();
     bool result = MathOpApply< typename MathOpTraits<Value>::Ops >::isSupported(op);
     if (!result)
-        serr << "Operation " << op << " NOT SUPPORTED" << sendl;
+        msg_error() << "Operation " << op << " NOT SUPPORTED";
 
     setDirtyValue();
 }
@@ -474,7 +474,7 @@ void MathOp<VecT>::doUpdate()
     bool result = MathOpApply< typename MathOpTraits<Value>::Ops >::apply(
         op, &f_output, vf_inputs);
     if (!result)
-        serr << "Operation " << op << " FAILED" << sendl;
+        msg_error() << "Operation " << op << " FAILED";
 }
 
 } // namespace engine

--- a/modules/SofaGeneralEngine/MergePoints.inl
+++ b/modules/SofaGeneralEngine/MergePoints.inl
@@ -98,7 +98,7 @@ void MergePoints<DataTypes>::doUpdate()
             if (posX < points.size()) // new point to insert
                 points[posX] = x2[i]; // insert X2 inside X1
             else
-                serr << "Error Trying to insert vertex from mapping at pos: " <<  posX << " which is out of bounds of X1." << sendl;
+                msg_error() << "Error Trying to insert vertex from mapping at pos: " << posX << " which is out of bounds of X1.";
         }
 
         // fill indice1 & indice2 buffers

--- a/modules/SofaGeneralEngine/MeshBarycentricMapperEngine.inl
+++ b/modules/SofaGeneralEngine/MeshBarycentricMapperEngine.inl
@@ -98,7 +98,7 @@ void MeshBarycentricMapperEngine<DataTypes>::doUpdate()
 
     if(TopoInput==nullptr)
     {
-        serr<<"no TopoInput found !!"<<sendl;
+        msg_error() << "no TopoInput found !!";
         return;
     }
     /*

--- a/modules/SofaGeneralEngine/ProximityROI.inl
+++ b/modules/SofaGeneralEngine/ProximityROI.inl
@@ -138,13 +138,13 @@ void ProximityROI<DataTypes>::doUpdate()
 
     if (rad.empty())
     {
-        serr << "The parameter 'Radius' must at least contains one value. This ROI is then disabled/useless." << sendl;
+        msg_error() << "The parameter 'Radius' must at least contains one value. This ROI is then disabled/useless.";
         return;
     }
 
     if (f_num.getValue()==0)
     {
-        serr << "The parameter 'N' must have a value greater than zero. This ROI is then disabled/useless." << sendl;
+        msg_error() << "The parameter 'N' must have a value greater than zero. This ROI is then disabled/useless.";
         return;
     }
 
@@ -162,7 +162,7 @@ void ProximityROI<DataTypes>::doUpdate()
 
     if(cen.size() < rad.size())
     {
-        serr << "There parameter 'Radius' has more elements than parameters 'center'." << sendl;
+        msg_error() << "There parameter 'Radius' has more elements than parameters 'center'.";
     }
 
     const VecCoord* x0 = &f_X0.getValue();

--- a/modules/SofaGeneralEngine/QuatToRigidEngine.inl
+++ b/modules/SofaGeneralEngine/QuatToRigidEngine.inl
@@ -86,7 +86,7 @@ void QuatToRigidEngine<DataTypes>::doUpdate()
     int nbOrientations = orientations.size();
     if (!nbOrientations)
     {
-        serr << "Warnings : no orientations" << sendl;
+        msg_warning() << "No orientations";
         sizeRigids = 0;
     }
     else if (nbOrientations == 1)
@@ -95,7 +95,7 @@ void QuatToRigidEngine<DataTypes>::doUpdate()
     }
     else if(nbOrientations > 1 && nbPositions != nbOrientations)
     {
-        serr << "Warnings : size of positions and orientations are not equal" << sendl;
+        msg_warning() << "Size of positions and orientations are not equal";
         sizeRigids = std::min(nbPositions, nbOrientations);
     }
 

--- a/modules/SofaGeneralEngine/RandomPointDistributionInSurface.inl
+++ b/modules/SofaGeneralEngine/RandomPointDistributionInSurface.inl
@@ -206,7 +206,7 @@ void RandomPointDistributionInSurface<DataTypes>::doUpdate()
 
     if (triangles.size() <= 1 ||  vertices.size() <= 1)
     {
-        serr << "Error in input data (number of vertices of triangles is less than 1)." << sendl;
+        msg_error() << "In input data (number of vertices of triangles is less than 1).";
         return;
     }
 
@@ -247,7 +247,7 @@ void RandomPointDistributionInSurface<DataTypes>::doUpdate()
     }
 
     if (safeCounter == safeLimit)
-        sout << "ERROR while generating point ; cancelling to break infinite loop" << sendl;
+        msg_error() << "While generating point ; cancelling to break infinite loop";
 
     f_inPoints.endEdit();
     f_outPoints.endEdit();

--- a/modules/SofaGeneralEngine/SphereROI.inl
+++ b/modules/SofaGeneralEngine/SphereROI.inl
@@ -288,7 +288,7 @@ void SphereROI<DataTypes>::doUpdate()
 		}
 		else
 		{
-			serr << "WARNING: number of sphere centers and radius doesn't match." << sendl;
+			msg_warning() << "Number of sphere centers and radius doesn't match.";
 			return;
 		}
     }
@@ -676,7 +676,7 @@ void SphereROI<defaulttype::Rigid3Types>::doUpdate()
 
 	if (cen.size() != rad.size())
 	{
-		serr << "WARNING: number of sphere centers and radius doesn't match." <<sendl;
+		msg_warning() << "Number of sphere centers and radius doesn't match.";
 		return;
 	}
 

--- a/modules/SofaGeneralEngine/SubsetTopology.inl
+++ b/modules/SofaGeneralEngine/SubsetTopology.inl
@@ -405,7 +405,7 @@ void SubsetTopology<DataTypes>::doUpdate()
 
         if (cen.size() != rad.size())
         {
-            serr << "WARNING: number of sphere centers and radius doesn't match." <<sendl;
+            msg_warning() << "Number of sphere centers and radius doesn't match.";
             return;
         }
         ROInum = cen.size();

--- a/modules/SofaGeneralEngine/TextureInterpolation.inl
+++ b/modules/SofaGeneralEngine/TextureInterpolation.inl
@@ -124,13 +124,13 @@ void TextureInterpolation<DataTypes>::doUpdate()
     // Check min and max values:
     if(_changeScale.getValue())
     {
-        if( _minVal.getValue() < _maxVal.getValue() )
+        if (_minVal.getValue() < _maxVal.getValue())
         {
             minVal = _minVal.getValue();
             maxVal = _maxVal.getValue();
         }
         else
-            serr << "Error: in scale for TextureInterpolation, min_value is not smaller than max_value." << sendl;
+            msg_error() << "In scale for TextureInterpolation, min_value is not smaller than max_value.";
     }
     else
     {

--- a/modules/SofaGeneralEngine/TransformEngine.inl
+++ b/modules/SofaGeneralEngine/TransformEngine.inl
@@ -167,7 +167,7 @@ struct RotationSpecialized<DataTypes, 2, false> : public TransformOperation<Data
     void configure(const defaulttype::Quaternion &/*qi*/, bool /*inverse*/, sofa::core::objectmodel::Base* pBase)
     {
         assert(pBase);
-        pBase->serr << "'void RotationSpecialized::configure(const defaulttype::Quaternion &qi, bool inverse)' is not implemented for two-dimensional data types" << pBase->sendl;
+        msg_error(pBase) << "'void RotationSpecialized::configure(const defaulttype::Quaternion &qi, bool inverse)' is not implemented for two-dimensional data types";
         assert(false && "This method should not be called without been implemented");
     }
 

--- a/modules/SofaGeneralLinearSolver/BTDLinearSolver.inl
+++ b/modules/SofaGeneralLinearSolver/BTDLinearSolver.inl
@@ -662,7 +662,6 @@ void BTDLinearSolver<Matrix,Vector>::invert(Matrix& M)
         //	nHn_1.resize(1);
         //	nHn_1[0] = B[i] *alpha_inv[i-1];
         //	H.insert(make_pair(IndexPair(i,i-1),nHn_1[0])); //IndexPair(i+1,i) ??
-        //	serr<<" Add pair ("<<i<<","<<i-1<<")"<<sendl;
         //}
 
         msg_info_when(this->f_verbose.getValue()) << "alpha_inv["<<i<<"] = " << alpha_inv[i] ;
@@ -780,17 +779,14 @@ void BTDLinearSolver<Matrix,Vector>::computeMinvBlock(Index i, Index j)
 
 
         H_it = H.find( IndexPair(i0,j0+1) );
-        //serr<<" find pair ("<<i<<","<<j0+1<<")"<<sendl;
 
         if (H_it == H.end())
         {
             my_identity(iHj, bsize);
-            if (i0!=j0+1)
-                serr<<"WARNING !! element("<<i0<<","<<j0+1<<") not found : nBlockComputedMinv[i] = "<<nBlockComputedMinv[i]<<sendl;
+            msg_error_when(i0 != j0 + 1) << "element(" << i0 << "," << j0 + 1 << ") not found : nBlockComputedMinv[i] = " << nBlockComputedMinv[i];
         }
         else
         {
-            //serr<<"element("<<i0<<","<<j0+1<<")  found )!"<<sendl;
             iHj = H_it->second;
         }
 
@@ -1295,7 +1291,7 @@ bool BTDLinearSolver<Matrix,Vector>::addJMInvJt(RMatrix& result, JMatrix& J, dou
     const Index Jcols = J.colSize();
     if (Jcols != Minv.rowSize())
     {
-        serr << "BTDLinearSolver::addJMInvJt ERROR: incompatible J matrix size." << sendl;
+        msg_error() << "AddJMInvJt: incompatible J matrix size.";
         return false;
     }
 

--- a/modules/SofaGeneralLinearSolver/CholeskySolver.inl
+++ b/modules/SofaGeneralLinearSolver/CholeskySolver.inl
@@ -90,7 +90,8 @@ void CholeskySolver<TMatrix,TVector>::invert(Matrix& M)
     double ss,d;
 
     L.resize(n,n);
-    if( M.element(0,0) <= 0 ) serr<<"CholeskySolver<TMatrix,TVector>::invert, matrix is not positive definite " << sendl;
+    msg_error_when(M.element(0, 0) <= 0) << "Invert, matrix is not positive definite ";
+
     d = 1.0 / sqrt(M.element(0,0));
     for (int i=0; i<n; i++)
     {
@@ -102,7 +103,8 @@ void CholeskySolver<TMatrix,TVector>::invert(Matrix& M)
         ss=0;
         for (int k=0; k<j; k++) ss+=L.element(k,j)*L.element(k,j);
 
-        if( M.element(j,j)-ss <= 0 ) serr<<"CholeskySolver<TMatrix,TVector>::invert, matrix is not positive definite " << sendl;
+        msg_error_when(M.element(j, j) - ss <= 0) << "Invert, matrix is not positive definite ";
+
         d = 1.0 / sqrt(M.element(j,j)-ss);
         L.set(j,j,(M.element(j,j)-ss) * d);
 

--- a/modules/SofaGeneralLoader/InputEventReader.cpp
+++ b/modules/SofaGeneralLoader/InputEventReader.cpp
@@ -64,7 +64,7 @@ void InputEventReader::init()
 {
 #ifdef __linux__
     if((fd = open(filename.getFullPath().c_str(), O_RDONLY)) < 0)
-        sout << "ERROR: impossible to open the file: " << filename.getValue() << sendl;
+        msg_info() << "ERROR: impossible to open the file: " << filename.getValue();
 #endif
 
     if(p_outputFilename.isSet())
@@ -75,7 +75,7 @@ void InputEventReader::init()
             outFile->open(p_outputFilename.getFullPath().c_str());
             if( !outFile->is_open() )
             {
-                serr << "File " <<p_outputFilename.getFullPath() << " not writable" << sendl;
+                msg_error() << "File " <<p_outputFilename.getFullPath() << " not writable";
                 delete outFile;
                 outFile = nullptr;
             }
@@ -85,7 +85,7 @@ void InputEventReader::init()
             inFile = new std::ifstream(p_outputFilename.getFullPath().c_str(), std::ifstream::in | std::ifstream::binary);
             if( !inFile->is_open() )
             {
-                serr << "File " <<p_outputFilename.getFullPath() << " not readable" << sendl;
+                msg_error() << "File " <<p_outputFilename.getFullPath() << " not readable";
                 delete inFile;
                 inFile = nullptr;
             }
@@ -108,7 +108,7 @@ void InputEventReader::manageEvent(const input_event &ev)
 #endif
 #ifdef __linux__
     if (p_printEvent.getValue())
-        serr << "event type 0x" << std::hex << ev.type << std::dec << " code 0x" << std::hex << ev.code << std::dec << " value " << ev.value << sendl;
+        msg_error() << "event type 0x" << std::hex << ev.type << std::dec << " code 0x" << std::hex << ev.code << std::dec << " value " << ev.value;
 
     if (ev.type == EV_REL)
     {
@@ -182,7 +182,7 @@ void InputEventReader::getInputEvents()
         while (poll(&pfd, 1, 0 /*timeout.getValue()*/)>0 && (pfd.revents & POLLIN))
         {
             if (read(fd, &temp, sizeof(struct input_event)) == -1)
-                serr << "Error: read function return an error." << sendl;
+                msg_error() << "Error: read function return an error.";
 
             memcpy(&ev, &temp, sizeof(struct input_event));
 

--- a/modules/SofaGeneralLoader/InputEventReader.cpp
+++ b/modules/SofaGeneralLoader/InputEventReader.cpp
@@ -64,7 +64,7 @@ void InputEventReader::init()
 {
 #ifdef __linux__
     if((fd = open(filename.getFullPath().c_str(), O_RDONLY)) < 0)
-        msg_info() << "ERROR: impossible to open the file: " << filename.getValue();
+        msg_error() << "Impossible to open the file: " << filename.getValue();
 #endif
 
     if(p_outputFilename.isSet())
@@ -182,7 +182,7 @@ void InputEventReader::getInputEvents()
         while (poll(&pfd, 1, 0 /*timeout.getValue()*/)>0 && (pfd.revents & POLLIN))
         {
             if (read(fd, &temp, sizeof(struct input_event)) == -1)
-                msg_error() << "Error: read function return an error.";
+                msg_error() << "Read function return an error.";
 
             memcpy(&ev, &temp, sizeof(struct input_event));
 

--- a/modules/SofaGeneralLoader/OffSequenceLoader.cpp
+++ b/modules/SofaGeneralLoader/OffSequenceLoader.cpp
@@ -154,14 +154,14 @@ bool OffSequenceLoader::load(const char * filename)
 
     if (!file.good())
     {
-        serr << "Cannot read file '" << m_filename << "'." << sendl;
+        msg_error() << "Cannot read file '" << m_filename << "'.";
         return false;
     }
 
     file >> cmd;
     if (cmd != "OFF")
     {
-        serr << "Not a OFF file (header problem) '" << m_filename << "'." << sendl;
+        msg_error() << "Not a OFF file (header problem) '" << m_filename << "'.";
         return false;
     }
 

--- a/modules/SofaGeneralLoader/ReadTopology.inl
+++ b/modules/SofaGeneralLoader/ReadTopology.inl
@@ -100,7 +100,7 @@ void ReadTopology::reset()
     const std::string& filename = f_filename.getFullPath();
     if (filename.empty())
     {
-        serr << "ERROR: empty filename"<<sendl;
+        msg_error() << "Empty filename";
     }
 #if SOFAGENERALLOADER_HAVE_ZLIB
     else if (filename.size() >= 3 && filename.substr(filename.size()-3)==".gz")
@@ -108,7 +108,7 @@ void ReadTopology::reset()
         gzfile = gzopen(filename.c_str(),"rb");
         if( !gzfile )
         {
-            serr << "Error opening compressed file "<<filename<<sendl;
+            msg_error() << "Opening compressed file " << filename;
         }
     }
 #endif
@@ -117,7 +117,7 @@ void ReadTopology::reset()
         infile = new std::ifstream(filename.c_str());
         if( !infile->is_open() )
         {
-            serr << "Error opening file "<<filename<<sendl;
+            msg_error() << "Opening file " << filename;
             delete infile;
             infile = nullptr;
         }

--- a/modules/SofaGeneralLoader/VoxelGridLoader.cpp
+++ b/modules/SofaGeneralLoader/VoxelGridLoader.cpp
@@ -95,7 +95,7 @@ void VoxelGridLoader::init()
 
     if ( image == nullptr )
     {
-        serr << "Error while loading the file " << m_filename.getValue() << this->sendl;
+        msg_error() << "Error while loading the file " << m_filename.getValue();
         return;
     }
 

--- a/modules/SofaGeneralMeshCollision/MeshMinProximityIntersection.cpp
+++ b/modules/SofaGeneralMeshCollision/MeshMinProximityIntersection.cpp
@@ -198,7 +198,7 @@ int MeshMinProximityIntersection::computeIntersection(Line& e1, Line& e2, Output
     }
     else
     {
-        intersection->serr<<"WARNING: null distance between contact detected"<<intersection->sendl;
+        msg_warning(intersection) << "Null distance between contact detected";
         detection->normal= Vector3(1,0,0);
     }
     detection->value -= contactDist;
@@ -323,7 +323,7 @@ int MeshMinProximityIntersection::computeIntersection(Triangle& e2, Point& e1, O
     }
     else
     {
-        intersection->serr<<"WARNING: null distance between contact detected"<<intersection->sendl;
+        msg_warning(intersection) << "Null distance between contact detected";
         detection->normal= Vector3(1,0,0);
     }
     detection->value -= contactDist;
@@ -427,7 +427,7 @@ int MeshMinProximityIntersection::computeIntersection(Line& e2, Point& e1, Outpu
     }
     else
     {
-        intersection->serr<<"WARNING: null distance between contact detected"<<intersection->sendl;
+        msg_warning(intersection) << "Null distance between contact detected";
         detection->normal= Vector3(1,0,0);
     }
     detection->value -= contactDist;
@@ -489,7 +489,7 @@ int MeshMinProximityIntersection::computeIntersection(Point& e1, Point& e2, Outp
     }
     else
     {
-        intersection->serr<<"WARNING: null distance between contact detected"<<intersection->sendl;
+        msg_warning(intersection) << "Null distance between contact detected";
         detection->normal= Vector3(1,0,0);
     }
     detection->value -= contactDist;

--- a/modules/SofaGeneralMeshCollision/MeshMinProximityIntersection.h
+++ b/modules/SofaGeneralMeshCollision/MeshMinProximityIntersection.h
@@ -173,7 +173,7 @@ int MeshMinProximityIntersection::computeIntersection(Triangle& e2, TSphere<T>& 
     }
     else
     {
-        intersection->serr<<"WARNING: null distance between contact detected"<<intersection->sendl;
+        msg_warning(intersection) << "Null distance between contact detected";
         detection->normal= defaulttype::Vector3(1,0,0);
     }
     detection->value -= contactDist;
@@ -259,7 +259,7 @@ int MeshMinProximityIntersection::computeIntersection(Line& e2, TSphere<T>& e1, 
     }
     else
     {
-        intersection->serr<<"WARNING: null distance between contact detected"<<intersection->sendl;
+        msg_warning(intersection) << "Null distance between contact detected";
         detection->normal= defaulttype::Vector3(1,0,0);
     }
     detection->point[0]=Q;
@@ -313,7 +313,7 @@ int MeshMinProximityIntersection::computeIntersection(TSphere<T>& e1, Point& e2,
     }
     else
     {
-        intersection->serr<<"WARNING: null distance between contact detected"<<intersection->sendl;
+        msg_warning(intersection) << "Null distance between contact detected";
         detection->normal= defaulttype::Vector3(1,0,0);
     }
     detection->value -= contactDist;

--- a/modules/SofaGeneralObjectInteraction/InteractionEllipsoidForceField.inl
+++ b/modules/SofaGeneralObjectInteraction/InteractionEllipsoidForceField.inl
@@ -354,7 +354,7 @@ void InteractionEllipsoidForceField<DataTypes1, DataTypes2>::addDForce(
 template <class DataTypes1, class DataTypes2>
 SReal InteractionEllipsoidForceField<DataTypes1, DataTypes2>::getPotentialEnergy(const sofa::core::MechanicalParams* /*mparams*/, const DataVecCoord1& /*x1*/, const DataVecCoord2& /*x2*/) const
 {
-    serr<<"InteractionEllipsoidForceField::getPotentialEnergy-not-implemented !!!"<<sendl;
+    msg_error() << "InteractionEllipsoidForceField::getPotentialEnergy-not-implemented !!!";
     return 0;
 }
 

--- a/modules/SofaGeneralObjectInteraction/RepulsiveSpringForceField.inl
+++ b/modules/SofaGeneralObjectInteraction/RepulsiveSpringForceField.inl
@@ -98,7 +98,7 @@ void RepulsiveSpringForceField<DataTypes>::addForce(const sofa::core::Mechanical
 template <class DataTypes>
 SReal RepulsiveSpringForceField<DataTypes>::getPotentialEnergy(const sofa::core::MechanicalParams*, const DataVecCoord&, const DataVecCoord& ) const
 {
-    serr<<"RepulsiveSpringForceField::getPotentialEnergy-not-implemented !!!"<<sendl;
+    msg_error() << "RepulsiveSpringForceField::getPotentialEnergy-not-implemented !!!";
     return 0;
 }
 

--- a/modules/SofaGeneralRigid/ArticulatedSystemMapping.h
+++ b/modules/SofaGeneralRigid/ArticulatedSystemMapping.h
@@ -174,7 +174,7 @@ public:
 
     void applyDJT(const core::MechanicalParams* /*mparams*/, core::MultiVecDerivId /*inForce*/, core::ConstMultiVecDerivId /*outForce*/) override
     {
-//                     serr<<"Warning ! ArticulatedSystemMapping::applyDJT(const MechanicalParams* mparams, MultiVecDerivId inForce, ConstMultiVecDerivId outForce)  not implemented !"<< sendl;
+
     }
 
 

--- a/modules/SofaGeneralRigid/ArticulatedSystemMapping.inl
+++ b/modules/SofaGeneralRigid/ArticulatedSystemMapping.inl
@@ -54,13 +54,13 @@ void ArticulatedSystemMapping<TIn, TInRoot, TOut>::init()
 
     if(this->getFromModels1().empty())
     {
-        serr << "Error while iniatilizing ; input Model not found" << sendl;
+        msg_error() << "While iniatilizing ; input Model not found.";
         return;
     }
 
     if(this->getToModels().empty())
     {
-        serr << "Error while iniatilizing ; output Model not found" << sendl;
+        msg_error() << "While iniatilizing ; output Model not found.";
         return;
     }
 

--- a/modules/SofaGeneralSimpleFem/BeamFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/BeamFEMForceField.inl
@@ -667,7 +667,7 @@ SReal BeamFEMForceField<DataTypes>::getPotentialEnergy(const core::MechanicalPar
 {
     SOFA_UNUSED(x);
     SOFA_UNUSED(mparams);
-    dmsg_warning() << "Get potentialEnergy not implemented";
+    msg_warning() << "Method getPotentialEnergy not implemented yet.";
     return 0.0;
 }
 

--- a/modules/SofaGeneralSimpleFem/HexahedralFEMForceField.h
+++ b/modules/SofaGeneralSimpleFem/HexahedralFEMForceField.h
@@ -162,7 +162,7 @@ public:
 
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        serr << "Get potentialEnergy not implemented" << sendl;
+        msg_error() << "Get potentialEnergy not implemented";
         return 0.0;
     }
 

--- a/modules/SofaGeneralSimpleFem/HexahedralFEMForceField.h
+++ b/modules/SofaGeneralSimpleFem/HexahedralFEMForceField.h
@@ -162,7 +162,7 @@ public:
 
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        msg_error() << "Get potentialEnergy not implemented";
+        msg_warning() << "Method getPotentialEnergy not implemented yet.";
         return 0.0;
     }
 

--- a/modules/SofaGeneralSimpleFem/HexahedralFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/HexahedralFEMForceField.inl
@@ -119,7 +119,7 @@ void HexahedralFEMForceField<DataTypes>::init()
 
     if (_topology==nullptr)
     {
-        serr << "ERROR(HexahedralFEMForceField): object must have a HexahedronSetTopology."<<sendl;
+        msg_error() << "Object must have a HexahedronSetTopology.";
         return;
     }
 

--- a/modules/SofaGeneralSimpleFem/HexahedralFEMForceFieldAndMass.h
+++ b/modules/SofaGeneralSimpleFem/HexahedralFEMForceFieldAndMass.h
@@ -94,12 +94,15 @@ public:
 
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        serr << "Get potentialEnergy not implemented" << sendl;
+        msg_error() << "Get potentialEnergy not implemented";
         return 0.0;
     }
 
     SReal getKineticEnergy(const core::MechanicalParams* /* mparams */, const DataVecDeriv& /*v*/)  const override ///< vMv/2 using dof->getV() override
-    {serr<<"HexahedralFEMForceFieldAndMass<DataTypes>::getKineticEnergy not yet implemented"<<sendl; return 0;}
+    {
+        msg_error() << "HexahedralFEMForceFieldAndMass<DataTypes>::getKineticEnergy not yet implemented"; 
+        return 0;
+    }
 
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& df, const DataVecDeriv& dx) override;
 

--- a/modules/SofaGeneralSimpleFem/HexahedralFEMForceFieldAndMass.h
+++ b/modules/SofaGeneralSimpleFem/HexahedralFEMForceFieldAndMass.h
@@ -94,7 +94,7 @@ public:
 
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        msg_error() << "Get potentialEnergy not implemented";
+        msg_warning() << "Method getPotentialEnergy not implemented yet.";
         return 0.0;
     }
 

--- a/modules/SofaGeneralSimpleFem/HexahedralFEMForceFieldAndMass.inl
+++ b/modules/SofaGeneralSimpleFem/HexahedralFEMForceFieldAndMass.inl
@@ -61,7 +61,7 @@ void HexahedralFEMForceFieldAndMass<DataTypes>::init( )
 
     if(this->_topology == nullptr)
     {
-        serr << "ERROR(HexahedralFEMForceField): object must have a HexahedronSetTopology."<<sendl;
+        msg_error() << "ERROR(HexahedralFEMForceField): object must have a HexahedronSetTopology.";
         return;
     }
 
@@ -403,7 +403,7 @@ void HexahedralFEMForceFieldAndMass<DataTypes>::addMBKToMatrix (const core::Mech
 template<class DataTypes>
 void HexahedralFEMForceFieldAndMass<DataTypes>::accFromF(const core::MechanicalParams*, DataVecDeriv& /*a*/, const DataVecDeriv& /*f*/)
 {
-    serr<<"HexahedralFEMForceFieldAndMass<DataTypes>::accFromF not yet implemented"<<sendl;
+    msg_error() << "HexahedralFEMForceFieldAndMass<DataTypes>::accFromF not yet implemented";
     // need to built the big global mass matrix and to inverse it...
 }
 
@@ -454,7 +454,8 @@ void HexahedralFEMForceFieldAndMass<DataTypes>::addDForce(const core::Mechanical
 template<class DataTypes>
 SReal HexahedralFEMForceFieldAndMass<DataTypes>::getElementMass(unsigned int /*index*/) const
 {
-    serr<<"HexahedralFEMForceFieldAndMass<DataTypes>::getElementMass not yet implemented"<<sendl; return 0.0;
+    msg_error() << "HexahedralFEMForceFieldAndMass<DataTypes>::getElementMass not yet implemented";
+    return 0.0;
 }
 
 

--- a/modules/SofaGeneralSimpleFem/HexahedronFEMForceFieldAndMass.h
+++ b/modules/SofaGeneralSimpleFem/HexahedronFEMForceFieldAndMass.h
@@ -102,13 +102,13 @@ public:
 
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        msg_warning() << "HexahedronFEMForceFieldAndMass::getPotentialEnergy() not implemented" << msgendl;
+        msg_warning() << "Method getPotentialEnergy not implemented yet.";
         return 0.0;
     }
 
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/) const override
     {
-        msg_warning() << "HexahedronFEMForceFieldAndMass::getPotentialEnergy() not implemented" << msgendl;
+        msg_warning() << "Method getPotentialEnergy not implemented yet.";
         return 0.0;
     }
 

--- a/modules/SofaGeneralSimpleFem/TetrahedralCorotationalFEMForceField.h
+++ b/modules/SofaGeneralSimpleFem/TetrahedralCorotationalFEMForceField.h
@@ -208,7 +208,7 @@ public:
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        serr << "Get potentialEnergy not implemented" << sendl;
+        msg_error() << "Get potentialEnergy not implemented";
         return 0.0;
     }
 

--- a/modules/SofaGeneralSimpleFem/TetrahedralCorotationalFEMForceField.h
+++ b/modules/SofaGeneralSimpleFem/TetrahedralCorotationalFEMForceField.h
@@ -208,7 +208,7 @@ public:
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        msg_error() << "Get potentialEnergy not implemented";
+        msg_warning() << "Method getPotentialEnergy not implemented yet.";
         return 0.0;
     }
 

--- a/modules/SofaGeneralSimpleFem/TetrahedralCorotationalFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/TetrahedralCorotationalFEMForceField.inl
@@ -412,7 +412,7 @@ void TetrahedralCorotationalFEMForceField<DataTypes>::computeMaterialStiffness(M
     Real volumes6 = fabs( dot( AB, C ) );
     if (volumes6<0)
     {
-        serr << "ERROR: Negative volume for tetra "<<a<<','<<b<<','<<c<<','<<d<<"> = "<<volumes6/6<<sendl;
+        msg_error() << "Negative volume for tetra " << a << ',' << b << ',' << c << ',' << d << "> = " << volumes6 / 6;
     }
     //	materialMatrix  /= (volumes6);//*6 christian
     // @TODO: in TetrahedronFEMForceField, the stiffness matrix is divided by 6 compared to the code in TetrahedralCorotationalFEMForceField. Check which is the correct one...
@@ -577,8 +577,7 @@ inline void TetrahedralCorotationalFEMForceField<DataTypes>::computeForce( Displ
             J[ 3][5]*Depl[ 3]+/*J[ 4][5]*Depl[ 4]*/ J[ 5][5]*Depl[ 5]+
             J[ 6][5]*Depl[ 6]+/*J[ 7][5]*Depl[ 7]*/ J[ 8][5]*Depl[ 8]+
             J[ 9][5]*Depl[ 9]+/*J[10][5]*Depl[10]*/ J[11][5]*Depl[11];
-//         serr<<"TetrahedronFEMForceField<DataTypes>::computeForce, D = "<<Depl<<sendl;
-//         serr<<"TetrahedronFEMForceField<DataTypes>::computeForce, JtD = "<<JtD<<sendl;
+
 
     defaulttype::VecNoInit<6,Real> KJtD;
     KJtD[0] =   K[0][0]*JtD[0]+  K[0][1]*JtD[1]+  K[0][2]*JtD[2]
@@ -1174,7 +1173,6 @@ void TetrahedralCorotationalFEMForceField<DataTypes>::accumulateForcePolar( Vect
     D[9] = tetrahedronInf[elementIndex].rotatedInitialElements[3][0] - deforme[3][0];
     D[10] = tetrahedronInf[elementIndex].rotatedInitialElements[3][1] - deforme[3][1];
     D[11] = tetrahedronInf[elementIndex].rotatedInitialElements[3][2] - deforme[3][2];
-    //serr<<"D : "<<D<<sendl;
 
     Displacement F;
     if(_updateStiffnessMatrix.getValue())
@@ -1191,7 +1189,7 @@ void TetrahedralCorotationalFEMForceField<DataTypes>::accumulateForcePolar( Vect
     }
     else
     {
-        serr << "TODO(TetrahedralCorotationalFEMForceField): support for assembling system matrix when using polar method."<<sendl;
+        msg_error() << "TODO(TetrahedralCorotationalFEMForceField): support for assembling system matrix when using polar method.";
     }
 
     tetrahedronInfo.endEdit();

--- a/modules/SofaMisc/MeshTetraStuffing.cpp
+++ b/modules/SofaMisc/MeshTetraStuffing.cpp
@@ -76,7 +76,7 @@ void MeshTetraStuffing::init()
     const SeqQuads& inQ = inputQuads.getValue();
     if (inP.empty() || (inT.empty() && inQ.empty()))
     {
-        serr << "Empty input mesh. Use data dependency to link them to a loaded Topology or MeshLoader";
+        msg_error() << "Empty input mesh. Use data dependency to link them to a loaded Topology or MeshLoader";
         return;
     }
     if (!inQ.empty())
@@ -402,7 +402,7 @@ void MeshTetraStuffing::init()
             int p = *it;
             if (pInside[p] == 0)
             {
-                serr << "ERROR: inside point " << p << " already wrapped.";
+                msg_error() << "Inside point " << p << " already wrapped.";
                 continue;
             }
             Real minDist = 0;
@@ -427,7 +427,7 @@ void MeshTetraStuffing::init()
             }
             if (minEdge == -1) // no violated edge
             {
-                serr << "ERROR: inside point " << p << " has no violated edges.";
+                msg_error() << "Inside point " << p << " has no violated edges.";
                 continue;
             }
             int e = minEdge;
@@ -556,7 +556,7 @@ void MeshTetraStuffing::init()
         Real vol6 = a*(b.cross(c));
         if (vol6 < 0)
         {
-            msg_info() << "WARNING: tetra " << t << " is inverted.";
+            msg_warning() << "tetra " << t << " is inverted.";
             int tmp = outT[t][2]; outT[t][2] = outT[t][3]; outT[t][3] = tmp;
         }
         for (int i=0; i<4; ++i)
@@ -568,7 +568,7 @@ void MeshTetraStuffing::init()
             if (i%2) { int tmp = tr[1]; tr[1] = tr[2]; tr[2] = tmp; }
             if (!triSet.insert(tr).second)
             {
-                serr << "ERROR: duplicate triangle " << tr << " in tetra " << t <<" : " << outT[t];
+                msg_error() << "Duplicate triangle " << tr << " in tetra " << t <<" : " << outT[t];
             }
         }
     }
@@ -708,7 +708,7 @@ void MeshTetraStuffing::addTetra(SeqTetrahedra& outT, SeqPoints& outP, int p1, i
         }
         else
         {
-            serr << "Invalid tetra split: flipA = " << flipA << "   flipB = " << flipB;
+            msg_error() << "Invalid tetra split: flipA = " << flipA << "   flipB = " << flipB;
         }
     }
     else // npos == 3 && nneg == 1
@@ -721,7 +721,7 @@ void MeshTetraStuffing::addTetra(SeqTetrahedra& outT, SeqPoints& outP, int p1, i
         bool flip3 = flipDiag(outP, ppos[2],ppos[0],cut1,cut3,pneg[0]);
         if (flip1 == flip2 && flip2 == flip3)
         {
-            serr << "Invalid tetra split";
+            msg_error() << "Invalid tetra split";
             flip3 = !flip1;
         }
         int pp0;
@@ -806,7 +806,7 @@ int MeshTetraStuffing::getSplitPoint(int from, int to)
     if (it != splitPoints.end()) return it->second;
     it = splitPoints.find(std::make_pair(to, from));
     if (it != splitPoints.end()) return it->second;
-    serr << "ERROR: cut point between " << from << " and " << to << " not found.";
+    msg_error() << "Cut point between " << from << " and " << to << " not found.";
     return from;
 }
 

--- a/modules/SofaMiscEngine/DisplacementMatrixEngine.inl
+++ b/modules/SofaMiscEngine/DisplacementMatrixEngine.inl
@@ -80,7 +80,7 @@ void DisplacementTransformEngine< DataTypes, OutputType >::doUpdate()
     // Check the size of x0
     if( size != size0 )
     {
-        serr << "x and x0 have not the same size: respectively " << size << " and " << size0 << sendl;
+        msg_error() << "x and x0 have not the same size: respectively " << size << " and " << size0;
         return;
     }
 
@@ -93,7 +93,6 @@ void DisplacementTransformEngine< DataTypes, OutputType >::doUpdate()
         mult( displacements[i], inverses[i], x[i] );
     }
     d_displacements.endEdit();
-    //serr << "update(), displaceMats  = " << d_displaceMats.getValue() << sendl;
 }
 
 ///////////////////////////////////////////////////////////////
@@ -142,7 +141,7 @@ void DisplacementMatrixEngine< DataTypes >::reinit()
 
     if( size0 != sizeS)
     {
-        serr << "x0 and S have not the same size: respectively " << ", " << size0 << " and " << sizeS << sendl;
+        msg_error() << "x0 and S have not the same size: respectively " << ", " << size0 << " and " << sizeS;
         return;
     }
 
@@ -174,7 +173,7 @@ void DisplacementMatrixEngine< DataTypes >::doUpdate()
     // Check the size of x0
     if( size != size0 || size != sizeS)
     {
-        serr << "x, x0 and S have not the same size: respectively " << size << ", " << size0 << " and " << sizeS << sendl;
+        msg_error() << "x, x0 and S have not the same size: respectively " << size << ", " << size0 << " and " << sizeS;
         return;
     }
 

--- a/modules/SofaMiscEngine/Distances.h
+++ b/modules/SofaMiscEngine/Distances.h
@@ -146,10 +146,12 @@ public:
     template<class T>
     static bool canCreate ( T*& obj, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg )
     {
-        if ( arg->findObject ( arg->getAttribute ( "hexaContainerPath","../.." ) ) == nullptr )
-            context->serr << "Cannot create "<<className ( obj ) <<" as the hexas container is missing."<<context->sendl;
-        if ( arg->findObject ( arg->getAttribute ( "targetPath",".." ) ) == nullptr )
-            context->serr << "Cannot create "<<className ( obj ) <<" as the target point set is missing."<<context->sendl;
+        if (arg->findObject(arg->getAttribute("hexaContainerPath", "../..")) == nullptr) {
+            msg_error(context) << "Cannot create " << className(obj) << " as the hexas container is missing.";
+        }
+        if (arg->findObject(arg->getAttribute("targetPath", "..")) == nullptr) {
+            msg_error(context) << "Cannot create " << className(obj) << " as the target point set is missing.";
+        }
         if ( dynamic_cast<sofa::component::topology::DynamicSparseGridTopologyContainer*> ( arg->findObject ( arg->getAttribute ( "hexaContainerPath","../.." ) ) ) == nullptr )
             return false;
         if ( dynamic_cast<core::behavior::MechanicalState<DataTypes>*> ( arg->findObject ( arg->getAttribute ( "targetPath",".." ) ) ) == nullptr )

--- a/modules/SofaMiscFem/FastTetrahedralCorotationalForceField.h
+++ b/modules/SofaMiscFem/FastTetrahedralCorotationalForceField.h
@@ -177,7 +177,7 @@ public:
     void addDForce(const sofa::core::MechanicalParams* /*mparams*/, DataVecDeriv&   datadF , const DataVecDeriv&   datadX ) override;
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        serr << "Get potentialEnergy not implemented" << sendl;
+        msg_error() << "Get potentialEnergy not implemented";
         return 0.0;
     }
 

--- a/modules/SofaMiscFem/FastTetrahedralCorotationalForceField.h
+++ b/modules/SofaMiscFem/FastTetrahedralCorotationalForceField.h
@@ -177,7 +177,7 @@ public:
     void addDForce(const sofa::core::MechanicalParams* /*mparams*/, DataVecDeriv&   datadF , const DataVecDeriv&   datadX ) override;
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        msg_error() << "Get potentialEnergy not implemented";
+        msg_warning() << "Method getPotentialEnergy not implemented yet.";
         return 0.0;
     }
 

--- a/modules/SofaMiscFem/FastTetrahedralCorotationalForceField.inl
+++ b/modules/SofaMiscFem/FastTetrahedralCorotationalForceField.inl
@@ -209,7 +209,7 @@ template <class DataTypes> void FastTetrahedralCorotationalForceField<DataTypes>
         decompositionMethod= LINEAR_ELASTIC;
     else
     {
-        serr << "cannot recognize method "<< f_method.getValue() << ". Must be either qr, polar, polar2 or none" << sendl;
+        msg_error() << "cannot recognize method " << f_method.getValue() << ". Must be either qr, polar, polar2 or none";
     }
 
 
@@ -509,7 +509,7 @@ void FastTetrahedralCorotationalForceField<DataTypes>::addKToMatrix(const core::
     if (r)
         addKToMatrix(r.matrix, mparams->kFactorIncludingRayleighDamping(this->rayleighStiffness.getValue()), r.offset);
     else
-        serr<<"addKToMatrix found no valid matrix accessor." << sendl;
+        msg_error() << "addKToMatrix found no valid matrix accessor.";
 }
 
 

--- a/modules/SofaMiscFem/StandardTetrahedralFEMForceField.h
+++ b/modules/SofaMiscFem/StandardTetrahedralFEMForceField.h
@@ -191,7 +191,7 @@ public:
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        msg_error() << "Get potentialEnergy not implemented";
+        msg_warning() << "Method getPotentialEnergy not implemented yet.";
         return 0.0;
     }
 

--- a/modules/SofaMiscFem/StandardTetrahedralFEMForceField.h
+++ b/modules/SofaMiscFem/StandardTetrahedralFEMForceField.h
@@ -191,7 +191,7 @@ public:
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        serr << "Get potentialEnergy not implemented" << sendl;
+        msg_error() << "Get potentialEnergy not implemented";
         return 0.0;
     }
 

--- a/modules/SofaMiscFem/TetrahedralTensorMassForceField.h
+++ b/modules/SofaMiscFem/TetrahedralTensorMassForceField.h
@@ -129,7 +129,7 @@ public:
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        serr << "Get potentialEnergy not implemented" << sendl;
+        msg_error() << "Get potentialEnergy not implemented";
         return 0.0;
     }
 

--- a/modules/SofaMiscFem/TetrahedralTensorMassForceField.h
+++ b/modules/SofaMiscFem/TetrahedralTensorMassForceField.h
@@ -129,7 +129,7 @@ public:
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        msg_error() << "Get potentialEnergy not implemented";
+        msg_warning() << "Method getPotentialEnergy not implemented yet.";
         return 0.0;
     }
 

--- a/modules/SofaMiscFem/TetrahedralTensorMassForceField.inl
+++ b/modules/SofaMiscFem/TetrahedralTensorMassForceField.inl
@@ -477,7 +477,6 @@ void TetrahedralTensorMassForceField<DataTypes>::updateLameCoefficients()
 {
     lambda= f_youngModulus.getValue()*f_poissonRatio.getValue()/((1-2*f_poissonRatio.getValue())*(1+f_poissonRatio.getValue()));
     mu = f_youngModulus.getValue()/(2*(1+f_poissonRatio.getValue()));
-//	serr << "initialized Lame coef : lambda=" <<lambda<< " mu="<<mu<<sendl;
 }
 
 

--- a/modules/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.inl
+++ b/modules/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.inl
@@ -494,7 +494,7 @@ void TetrahedronHyperelasticityFEMForceField<DataTypes>::addDForce(const core::M
 template<class DataTypes>
 SReal TetrahedronHyperelasticityFEMForceField<DataTypes>::getPotentialEnergy(const core::MechanicalParams*, const DataVecCoord&) const
 {
-    msg_error() << "ERROR("<<this->getClassName()<<"): getPotentialEnergy( const MechanicalParams*, const DataVecCoord& ) not implemented.";
+    msg_warning() << "Method getPotentialEnergy not implemented yet.";
     return 0.0;
 }
 

--- a/modules/SofaMiscFem/TriangleFEMForceField.h
+++ b/modules/SofaMiscFem/TriangleFEMForceField.h
@@ -116,7 +116,7 @@ public:
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& df, const DataVecDeriv& dx) override;
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        serr << "Get potentialEnergy not implemented" << sendl;
+        msg_error() << "Get potentialEnergy not implemented";
         return 0.0;
     }
 

--- a/modules/SofaMiscFem/TriangleFEMForceField.h
+++ b/modules/SofaMiscFem/TriangleFEMForceField.h
@@ -116,7 +116,7 @@ public:
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& df, const DataVecDeriv& dx) override;
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        msg_error() << "Get potentialEnergy not implemented";
+        msg_warning() << "Method getPotentialEnergy not implemented yet.";
         return 0.0;
     }
 

--- a/modules/SofaMiscFem/TriangularFEMForceField.inl
+++ b/modules/SofaMiscFem/TriangularFEMForceField.inl
@@ -368,7 +368,7 @@ void TriangularFEMForceField<DataTypes>::reinit()
 template <class DataTypes>
 SReal TriangularFEMForceField<DataTypes>::getPotentialEnergy(const core::MechanicalParams* /* mparams */, const DataVecCoord& /* x */) const
 {
-    serr<<"TriangularFEMForceField::getPotentialEnergy-not-implemented !!!"<<sendl;
+    msg_error() << "TriangularFEMForceField::getPotentialEnergy-not-implemented !!!";
     return 0;
 }
 

--- a/modules/SofaMiscForceField/GearSpringForceField.inl
+++ b/modules/SofaMiscForceField/GearSpringForceField.inl
@@ -111,7 +111,7 @@ void GearSpringForceField<DataTypes>::init()
         outfile = new std::ofstream(filename.c_str());
         if( !outfile->is_open() )
         {
-            msg_error() << "Error creating file " << filename;
+            msg_error() << "Creating file " << filename << " failed.";
             delete outfile;
             outfile = nullptr;
         }

--- a/modules/SofaMiscForceField/GearSpringForceField.inl
+++ b/modules/SofaMiscForceField/GearSpringForceField.inl
@@ -111,7 +111,7 @@ void GearSpringForceField<DataTypes>::init()
         outfile = new std::ofstream(filename.c_str());
         if( !outfile->is_open() )
         {
-            serr << "Error creating file "<<filename<<sendl;
+            msg_error() << "Error creating file " << filename;
             delete outfile;
             outfile = nullptr;
         }

--- a/modules/SofaMiscForceField/LennardJonesForceField.inl
+++ b/modules/SofaMiscForceField/LennardJonesForceField.inl
@@ -81,11 +81,13 @@ void LennardJonesForceField<DataTypes>::init()
         // Debug
         if (this->f_printLog.getValue())
         {
+            std::stringstream tmp;
             for (Real d = 0; d<dmax.getValue(); d += dmax.getValue() / 60)
             {
                 Real f = a * alpha.getValue()*(Real)pow(d, -alpha.getValue() - 1) - b * beta.getValue()*(Real)pow(d, -beta.getValue() - 1);
-                msg_info() << "f(" << d << ")=" << f;
+                tmp << "f(" << d << ")=" << f;
             }
+            msg_info() << tmp.str();
         }        
     }
 }

--- a/modules/SofaMiscForceField/LennardJonesForceField.inl
+++ b/modules/SofaMiscForceField/LennardJonesForceField.inl
@@ -72,17 +72,21 @@ void LennardJonesForceField<DataTypes>::init()
 
         // Validity check: compute force and potential at d0
         Real f0 = a*alpha.getValue()*(Real)pow(d0.getValue(),-alpha.getValue()-1)-b*beta.getValue()*(Real)pow(d0.getValue(),-beta.getValue()-1);
-        if (fabs(f0)>0.001)
-            serr << "Lennard-Jones initialization failed: f0="<<f0<<sendl;
+
+        msg_error_when(fabs(f0) > 0.001) << "Lennard-Jones initialization failed: f0=" << f0;
         Real cp0 = (a*(Real)pow(d0.getValue(),-alpha.getValue())-b*(Real)pow(d0.getValue(),-beta.getValue()));
-        if (fabs(cp0/p0.getValue()-1)>0.001)
-            serr << "Lennard-Jones initialization failed: cp0="<<cp0<<sendl;
+
+        msg_error_when(fabs(cp0 / p0.getValue() - 1) > 0.001) << "Lennard-Jones initialization failed: cp0=" << cp0;
+
         // Debug
-        for (Real d = 0; d<dmax.getValue(); d+= dmax.getValue()/60)
+        if (this->f_printLog.getValue())
         {
-            Real f = a*alpha.getValue()*(Real)pow(d,-alpha.getValue()-1)-b*beta.getValue()*(Real)pow(d,-beta.getValue()-1);
-            msg_info() << "f("<<d<<")="<<f;
-        }
+            for (Real d = 0; d<dmax.getValue(); d += dmax.getValue() / 60)
+            {
+                Real f = a * alpha.getValue()*(Real)pow(d, -alpha.getValue() - 1) - b * beta.getValue()*(Real)pow(d, -beta.getValue() - 1);
+                msg_info() << "f(" << d << ")=" << f;
+            }
+        }        
     }
 }
 

--- a/modules/SofaMiscForceField/MatrixMass.inl
+++ b/modules/SofaMiscForceField/MatrixMass.inl
@@ -106,20 +106,20 @@ void MatrixMass<DataTypes, MassType>::addMDx(const core::MechanicalParams*, Data
 template <class DataTypes, class MassType>
 void MatrixMass<DataTypes, MassType>::accFromF(const core::MechanicalParams*, DataVecDeriv& , const DataVecDeriv&)
 {
-    serr<<"void MatrixMass<DataTypes, MassType>::accFromF(VecDeriv& a, const VecDeriv& f) not yet implemented (need the matrix assembly and inversion)"<<sendl;
+    msg_error() << "void MatrixMass<DataTypes, MassType>::accFromF(VecDeriv& a, const VecDeriv& f) not yet implemented (need the matrix assembly and inversion)";
 }
 
 template <class DataTypes, class MassType>
 SReal MatrixMass<DataTypes, MassType>::getKineticEnergy( const core::MechanicalParams*, const DataVecDeriv& ) const
 {
-    serr<<"void MatrixMass<DataTypes, MassType>::getKineticEnergy not yet implemented"<<sendl;
+    msg_error() << "void MatrixMass<DataTypes, MassType>::getKineticEnergy not yet implemented";
     return 0;
 }
 
 template <class DataTypes, class MassType>
 SReal MatrixMass<DataTypes, MassType>::getPotentialEnergy( const core::MechanicalParams*, const DataVecCoord& ) const
 {
-    serr<<"void MatrixMass<DataTypes, MassType>::getPotentialEnergy not yet implemented"<<sendl;
+    msg_error() << "void MatrixMass<DataTypes, MassType>::getPotentialEnergy not yet implemented";
     return 0;
 }
 
@@ -127,7 +127,7 @@ SReal MatrixMass<DataTypes, MassType>::getPotentialEnergy( const core::Mechanica
 template <class DataTypes, class MassType>
 sofa::defaulttype::Vector6 MatrixMass<DataTypes, MassType>::getMomentum ( const core::MechanicalParams*, const DataVecCoord& /*vx*/, const DataVecDeriv& /*vv*/  ) const
 {
-    serr<<"void MatrixMass<DataTypes, MassType>::getMomentum not yet implemented"<<sendl;
+    msg_error() << "void MatrixMass<DataTypes, MassType>::getMomentum not yet implemented";
     return sofa::defaulttype::Vector6();
 }
 

--- a/modules/SofaMiscMapping/CenterOfMassMapping.h
+++ b/modules/SofaMiscMapping/CenterOfMassMapping.h
@@ -90,7 +90,7 @@ public:
 
     void applyJT( const sofa::core::ConstraintParams* /*cparams*/, InDataMatrixDeriv& /*out*/, const OutDataMatrixDeriv& /*in*/) override
     {
-        serr << "applyJT(constraint ) not implemented" << sendl;
+        msg_error() << "applyJT(constraint ) not implemented";
     }
 
     //void applyJT( typename In::MatrixDeriv& out, const typename Out::MatrixDeriv& in );

--- a/modules/SofaMiscMapping/CenterOfMassMapping.h
+++ b/modules/SofaMiscMapping/CenterOfMassMapping.h
@@ -90,7 +90,7 @@ public:
 
     void applyJT( const sofa::core::ConstraintParams* /*cparams*/, InDataMatrixDeriv& /*out*/, const OutDataMatrixDeriv& /*in*/) override
     {
-        msg_error() << "applyJT(constraint ) not implemented";
+        msg_warning() << "This object only support Direct Solving but an Indirect Solver in the scene is calling method applyJT(constraint) which is not implemented. This will produce un-expected behavior.";
     }
 
     //void applyJT( typename In::MatrixDeriv& out, const typename Out::MatrixDeriv& in );

--- a/modules/SofaMiscMapping/CenterOfMassMapping.inl
+++ b/modules/SofaMiscMapping/CenterOfMassMapping.inl
@@ -68,7 +68,7 @@ void CenterOfMassMapping<TIn, TOut>::apply( const sofa::core::MechanicalParams* 
 
     if(!masses || totalMass==0.0)
     {
-        serr<<"Error in CenterOfMassMapping : no mass found corresponding to the DOFs"<<sendl;
+        msg_error() << "CenterOfMassMapping : no mass found corresponding to the DOFs";
         return;
     }
 
@@ -95,7 +95,7 @@ void CenterOfMassMapping<TIn, TOut>::applyJ( const sofa::core::MechanicalParams*
 
     if(!masses || totalMass==0.0)
     {
-        serr<<"Error in CenterOfMassMapping : no mass found corresponding to the DOFs"<<sendl;
+        msg_error() << "CenterOfMassMapping : no mass found corresponding to the DOFs";
         return;
     }
 
@@ -122,7 +122,7 @@ void CenterOfMassMapping<TIn, TOut>::applyJT( const sofa::core::MechanicalParams
 
     if(!masses || totalMass==0.0)
     {
-        serr<<"Error in CenterOfMassMapping : no mass found corresponding to the DOFs"<<sendl;
+        msg_error() << "CenterOfMassMapping : no mass found corresponding to the DOFs";
         return;
     }
 

--- a/modules/SofaMiscMapping/CenterOfMassMulti2Mapping.h
+++ b/modules/SofaMiscMapping/CenterOfMassMulti2Mapping.h
@@ -101,7 +101,7 @@ public:
         const helper::vector< In2DataMatrixDeriv*>&  /*dataMatOut2Const*/ ,
         const helper::vector<const OutDataMatrixDeriv*>& /*dataMatInConst*/) override
     {
-        serr << "applyJT(constraint) not implemented" << sendl;
+        msg_error() << "applyJT(constraint) not implemented";
     }
 
 

--- a/modules/SofaMiscMapping/CenterOfMassMulti2Mapping.h
+++ b/modules/SofaMiscMapping/CenterOfMassMulti2Mapping.h
@@ -101,7 +101,7 @@ public:
         const helper::vector< In2DataMatrixDeriv*>&  /*dataMatOut2Const*/ ,
         const helper::vector<const OutDataMatrixDeriv*>& /*dataMatInConst*/) override
     {
-        msg_error() << "applyJT(constraint) not implemented";
+        msg_warning() << "This object only support Direct Solving but an Indirect Solver in the scene is calling method applyJT(constraint) which is not implemented. This will produce un-expected behavior.";
     }
 
 

--- a/modules/SofaMiscMapping/DistanceMapping.inl
+++ b/modules/SofaMiscMapping/DistanceMapping.inl
@@ -104,23 +104,25 @@ void DistanceMapping<TIn, TOut>::init()
             {
                 restLengths[i] = (pos[links[i][0]] - pos[links[i][1]]).norm();
 
-                if( restLengths[i]<=s_null_distance_epsilon && compliance ) serr<<"Null rest Length cannot be used for stable compliant constraint, prefer to use a DifferenceMapping for this dof "<<i<<" if used with a compliance"<<sendl;
+                msg_error_when(restLengths[i] <= s_null_distance_epsilon && compliance) << "Null rest Length cannot be used for stable compliant constraint, prefer to use a DifferenceMapping for this dof " << i << " if used with a compliance";
             }
         }
         else
         {
-            if( compliance ) serr<<"Null rest Lengths cannot be used for stable compliant constraint, prefer to use a DifferenceMapping if those dofs are used with a compliance"<<sendl;
+            msg_error_when(compliance) << "Null rest Lengths cannot be used for stable compliant constraint, prefer to use a DifferenceMapping if those dofs are used with a compliance";
             for(unsigned i=0; i<links.size(); i++ )
                 restLengths[i] = (Real)0.;
         }
     }
-    else // manually set
-        if( compliance ) // for warning message
-        {
-            helper::ReadAccessor< Data<helper::vector<Real> > > restLengths(f_restLengths);
-            for(unsigned i=0; i<links.size(); i++ )
-                if( restLengths[i]<=s_null_distance_epsilon ) serr<<"Null rest Length cannot be used for stable compliant constraint, prefer to use a DifferenceMapping for this dof "<<i<<" if used with a compliance"<<sendl;
-        }
+    else if (compliance) // for warning message
+    {
+        helper::ReadAccessor< Data<helper::vector<Real> > > restLengths(f_restLengths);
+        std::stringstream sstream;
+        for (unsigned i = 0; i < links.size(); i++)
+            if (restLengths[i] <= s_null_distance_epsilon) 
+                sstream << "Null rest Length cannot be used for stable compliant constraint, prefer to use a DifferenceMapping for this dof " << i << " if used with a compliance \n";
+        msg_error_when(!sstream.str().empty()) << sstream.str();
+    }
 
     baseMatrices.resize( 1 );
     baseMatrices[0] = &jacobian;
@@ -198,8 +200,6 @@ void DistanceMapping<TIn, TOut>::apply(const core::MechanicalParams * /*mparams*
     }
 
     jacobian.compress();
-//    serr<<"apply, jacobian: "<<std::endl<< jacobian << sendl;
-
 }
 
 
@@ -443,7 +443,7 @@ void DistanceMultiMapping<TIn, TOut>::addPoint( const core::BaseState* from, int
             break;
     if(i==this->fromModels.size())
     {
-        serr<<"SubsetMultiMapping<TIn, TOut>::addPoint, parent "<<from->getName()<<" not found !"<< sendl;
+        msg_error() << "SubsetMultiMapping<TIn, TOut>::addPoint, parent " << from->getName() << " not found !";
         assert(0);
     }
 
@@ -506,23 +506,24 @@ void DistanceMultiMapping<TIn, TOut>::init()
 
                 restLengths[i] = (pos0 - pos1).norm();
 
-                if( restLengths[i]==0 && compliance ) serr<<"Null rest Length cannot be used for stable compliant constraint, prefer to use a DifferenceMapping for this dof "<<i<<" if used with a compliance"<<sendl;
+                msg_error_when(restLengths[i] == 0 && compliance) << "Null rest Length cannot be used for stable compliant constraint, prefer to use a DifferenceMapping for this dof " << i << " if used with a compliance";
             }
         }
         else
         {
-            if( compliance ) serr<<"Null rest Lengths cannot be used for stable compliant constraint, prefer to use a DifferenceMapping if those dofs are used with a compliance"<<sendl;
+            msg_error_when(compliance) << "Null rest Lengths cannot be used for stable compliant constraint, prefer to use a DifferenceMapping if those dofs are used with a compliance";
             for(unsigned i=0; i<links.size(); i++ )
                 restLengths[i] = (Real)0.;
         }
     }
-    else // manually set
-        if( compliance ) // for warning message
-        {
-            helper::ReadAccessor< Data<helper::vector<Real> > > restLengths(f_restLengths);
-            for(unsigned i=0; i<links.size(); i++ )
-                if( restLengths[i]<=s_null_distance_epsilon ) serr<<"Null rest Length cannot be used for stable compliant constraint, prefer to use a DifferenceMapping for this dof "<<i<<" if used with a compliance"<<sendl;
-        }
+    else if( compliance ) // manually set // for warning message
+    {
+        helper::ReadAccessor< Data<helper::vector<Real> > > restLengths(f_restLengths);
+        std::stringstream sstream;
+        for(unsigned i=0; i<links.size(); i++ )
+            if( restLengths[i]<=s_null_distance_epsilon ) sstream <<"Null rest Length cannot be used for stable compliant constraint, prefer to use a DifferenceMapping for this dof "<<i<<" if used with a compliance \n";
+        msg_error_when(!sstream.str().empty()) << sstream.str();
+    }
 
     alloc();
 

--- a/modules/SofaMiscMapping/IdentityMultiMapping.inl
+++ b/modules/SofaMiscMapping/IdentityMultiMapping.inl
@@ -168,7 +168,7 @@ void IdentityMultiMapping<TIn, TOut>::applyJT(const core::MechanicalParams* mpar
 template <class TIn, class TOut>
 void IdentityMultiMapping<TIn, TOut>::applyJT( const core::ConstraintParams* /*cparams*/, const helper::vector< InDataMatrixDeriv* >& /*dOut*/, const helper::vector< const OutDataMatrixDeriv* >& /*dIn*/)
 {
-//    serr<<"applyJT on matrix is not implemented"<<sendl;
+
 }
 
 

--- a/modules/SofaMiscMapping/SquareDistanceMapping.inl
+++ b/modules/SofaMiscMapping/SquareDistanceMapping.inl
@@ -62,7 +62,7 @@ template <class TIn, class TOut>
 void SquareDistanceMapping<TIn, TOut>::init()
 {
     edgeContainer = dynamic_cast<topology::EdgeSetTopologyContainer*>( this->getContext()->getMeshTopology() );
-    if( !edgeContainer ) serr<<"No EdgeSetTopologyContainer found ! "<<sendl;
+    msg_error_when(!edgeContainer) << "No EdgeSetTopologyContainer found ! ";
 
     SeqEdges links = edgeContainer->getEdges();
 
@@ -70,37 +70,7 @@ void SquareDistanceMapping<TIn, TOut>::init()
 
     // only used for warning message
     bool compliance = ((simulation::Node*)(this->getContext()))->forceField.size() && ((simulation::Node*)(this->getContext()))->forceField[0]->isCompliance.getValue();
-    if( compliance ) serr<<"Null rest Lengths cannot be used for stable compliant constraint, prefer to use a DifferenceMapping if those dofs are used with a compliance"<<sendl;
-
-    // compute the rest lengths if they are not known
-//    if( f_restLengths.getValue().size() != links.size() )
-//    {
-//        helper::WriteOnlyAccessor< Data<helper::vector<Real> > > restLengths(f_restLengths);
-//        typename core::behavior::MechanicalState<In>::ReadVecCoord pos = this->getFromModel()->readPositions();
-//        restLengths.resize( links.size() );
-//        if(!(f_computeDistance.getValue()))
-//        {
-//            for(unsigned i=0; i<links.size(); i++ )
-//            {
-//                restLengths[i] = (pos[links[i][0]] - pos[links[i][1]]).norm();
-
-//                if( restLengths[i]<=s_null_distance_epsilon && compliance ) serr<<"Null rest Length cannot be used for stable compliant constraint, prefer to use a DifferenceMapping for this dof "<<i<<" if used with a compliance"<<sendl;
-//            }
-//        }
-//        else
-//        {
-//            if( compliance ) serr<<"Null rest Lengths cannot be used for stable compliant constraint, prefer to use a DifferenceMapping if those dofs are used with a compliance"<<sendl;
-//            for(unsigned i=0; i<links.size(); i++ )
-//                restLengths[i] = (Real)0.;
-//        }
-//    }
-//    else // manually set
-//        if( compliance ) // for warning message
-//        {
-//            helper::ReadAccessor< Data<helper::vector<Real> > > restLengths(f_restLengths);
-//            for(unsigned i=0; i<links.size(); i++ )
-//                if( restLengths[i]<=s_null_distance_epsilon ) serr<<"Null rest Length cannot be used for stable compliant constraint, prefer to use a DifferenceMapping for this dof "<<i<<" if used with a compliance"<<sendl;
-//        }
+    msg_error_when(compliance) << "Null rest Lengths cannot be used for stable compliant constraint, prefer to use a DifferenceMapping if those dofs are used with a compliance";
 
     baseMatrices.resize( 1 );
     baseMatrices[0] = &jacobian;

--- a/modules/SofaMiscMapping/SquareMapping.inl
+++ b/modules/SofaMiscMapping/SquareMapping.inl
@@ -130,7 +130,7 @@ void SquareMapping<TIn, TOut>::applyDJT(const core::MechanicalParams* mparams, c
 template <class TIn, class TOut>
 void SquareMapping<TIn, TOut>::applyJT(const core::ConstraintParams*, Data<InMatrixDeriv>& , const Data<OutMatrixDeriv>& )
 {
-//    serr<<"applyJT(const core::ConstraintParams*, Data<InMatrixDeriv>& , const Data<OutMatrixDeriv>& ) is not implemented"<<sendl;
+
 }
 
 

--- a/modules/SofaMiscMapping/SubsetMultiMapping.inl
+++ b/modules/SofaMiscMapping/SubsetMultiMapping.inl
@@ -113,7 +113,7 @@ void SubsetMultiMapping<TIn, TOut>::addPoint( const core::BaseState* from, int i
             break;
     if(i==this->fromModels.size())
     {
-        serr<<"SubsetMultiMapping<TIn, TOut>::addPoint, parent "<<from->getName()<<" not found !"<< sendl;
+        msg_error() << "SubsetMultiMapping<TIn, TOut>::addPoint, parent " << from->getName() << " not found !";
         assert(0);
     }
 
@@ -173,7 +173,7 @@ void SubsetMultiMapping<TIn, TOut>::applyJT( const core::ConstraintParams* /*cpa
 
     if (dOut.size() != this->fromModels.size())
     {
-        serr<<"problem with number of output constraint matrices"<<sendl;
+        msg_error() << "Problem with number of output constraint matrices";
         return;
     }
 

--- a/modules/SofaMiscMapping/TubularMapping.inl
+++ b/modules/SofaMiscMapping/TubularMapping.inl
@@ -49,11 +49,14 @@ void TubularMapping<TIn, TOut>::init()
     if (!m_radius.isSet())
     {
         this->getContext()->get(radiusContainer);
-        sout << "get Radius Container" << sendl;
-        if(!radiusContainer)
-            serr << "TubularMapping : No Radius defined" << sendl;
+        msg_info() << "get Radius Container";
+        if (!radiusContainer)
+            msg_error() << "TubularMapping : No Radius defined";
     }
-    else sout << "get Radius tout court" << sendl;
+    else
+    {
+        msg_info() << "get Radius tout court";
+    }
 
     Inherit::init();
 

--- a/modules/SofaMiscSolver/NewmarkImplicitSolver.cpp
+++ b/modules/SofaMiscSolver/NewmarkImplicitSolver.cpp
@@ -126,9 +126,9 @@ void NewmarkImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa
 
     if( verbose )
      {
-        serr<<"NewmarkImplicitSolver, aPrevious = "<< a <<sendl;
-        serr<<"NewmarkImplicitSolver, xPrevious = "<< pos <<sendl;
-        serr<<"NewmarkImplicitSolver, vPrevious = "<< vel <<sendl;
+        msg_info() << "NewmarkImplicitSolver, aPrevious = " << a;
+        msg_info() << "NewmarkImplicitSolver, xPrevious = " << pos;
+        msg_info() << "NewmarkImplicitSolver, vPrevious = " << vel;
     }
 
     // 2. Compute right hand term of equation on a_{t+h}
@@ -148,13 +148,13 @@ void NewmarkImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa
     mop.addMBKv(b, -rM, 1,rK+h);
     // b += -h K v
 
-    if( verbose )
-        serr<<"NewmarkImplicitSolver, b = "<< b <<sendl;
+    if (verbose)
+        msg_info() << "NewmarkImplicitSolver, b = " << b;
 
     mop.projectResponse(b);          // b is projected to the constrained space
 
-    if( verbose )
-        serr<<"NewmarkImplicitSolver, projected b = "<< b <<sendl;
+    if (verbose)
+        msg_info() << "NewmarkImplicitSolver, projected b = " << b;
 
     // 3. Solve system of equations on a_{t+h}
 
@@ -163,14 +163,14 @@ void NewmarkImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa
     matrix = MechanicalMatrix::K * (-h*h*beta - h*rK*gamma) + MechanicalMatrix::B*(-h)*gamma + MechanicalMatrix::M * (1 + h*gamma*rM);
 
  //   if( verbose )
- //       serr<<"NewmarkImplicitSolver, matrix = "<< MechanicalMatrix::K *(-h*h*beta + -h*rK*gamma) + MechanicalMatrix::M * (1 + h*gamma*rM) << " = " << matrix<<sendl;
+ //       msg_info()<<"NewmarkImplicitSolver, matrix = "<< MechanicalMatrix::K *(-h*h*beta + -h*rK*gamma) + MechanicalMatrix::M * (1 + h*gamma*rM) << " = " << matrix<<sendl;
 
 
     matrix.solve(aResult, b);
     //mop.projectResponse(aResult);
 
-    if( verbose )
-        serr<<"NewmarkImplicitSolver, a1 = "<< aResult <<sendl;
+    if (verbose)
+        msg_info() << "NewmarkImplicitSolver, a1 = " << aResult;
 
 
     // 4. Compute the new position and velocity
@@ -213,8 +213,8 @@ void NewmarkImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa
 
     if( verbose )
     {
-        serr<<"NewmarkImplicitSolver, final x = "<< newPos <<sendl;
-        serr<<"NewmarkImplicitSolver, final v = "<< newVel <<sendl;
+        msg_info() << "NewmarkImplicitSolver, final x = " << newPos;
+        msg_info() << "NewmarkImplicitSolver, final v = " << newVel;
     }
 
     // Increment

--- a/modules/SofaMiscTopology/TopologicalChangeProcessor.cpp
+++ b/modules/SofaMiscTopology/TopologicalChangeProcessor.cpp
@@ -153,7 +153,7 @@ void TopologicalChangeProcessor::readDataFile()
     const std::string& filename = m_filename.getFullPath();
     if (filename.empty())
     {
-        serr << "TopologicalChangeProcessor: ERROR: empty filename"<<sendl;
+        msg_error() << "empty filename";
     }
 #if SOFAMISCTOPOLOGY_HAVE_ZLIB
     else if (filename.size() >= 3 && filename.substr(filename.size()-3)==".gz")
@@ -161,7 +161,7 @@ void TopologicalChangeProcessor::readDataFile()
         gzfile = gzopen(filename.c_str(),"rb");
         if( !gzfile )
         {
-            serr << "TopologicalChangeProcessor: Error opening compressed file "<<filename<<sendl;
+            msg_error() << "TopologicalChangeProcessor: Error opening compressed file " << filename;
         }
     }
 #endif
@@ -170,7 +170,7 @@ void TopologicalChangeProcessor::readDataFile()
         infile = new std::ifstream(filename.c_str());
         if( !infile->is_open() )
         {
-            serr << "TopologicalChangeProcessor: Error opening file "<<filename<<sendl;
+            msg_error() << "TopologicalChangeProcessor: Error opening file " << filename;
             delete infile;
             infile = nullptr;
         }
@@ -242,7 +242,7 @@ void TopologicalChangeProcessor::processTopologicalChanges(double time)
             if (topoMod)
                 topoMod->removeItems(vitems);
             else
-                serr<< "TopologicalChangeProcessor: Error: No HexahedraTopology available" << sendl;
+                msg_error() << "No HexahedraTopology available";
         }
 
         if (!tetrahedra.empty())
@@ -255,7 +255,7 @@ void TopologicalChangeProcessor::processTopologicalChanges(double time)
             if (topoMod)
                 topoMod->removeItems(vitems);
             else
-                serr<< "TopologicalChangeProcessor: Error: No TetrahedraTopology available" << sendl;
+                msg_error() << "No TetrahedraTopology available";
         }
 
         if (!quads.empty())
@@ -268,7 +268,7 @@ void TopologicalChangeProcessor::processTopologicalChanges(double time)
             if (topoMod)
                 topoMod->removeItems(vitems);
             else
-                serr<< "TopologicalChangeProcessor: Error: No QuadTopology available" << sendl;
+                msg_error() << "No QuadTopology available";
         }
 
         if (!triangles.empty())
@@ -281,7 +281,7 @@ void TopologicalChangeProcessor::processTopologicalChanges(double time)
             if (topoMod)
                 topoMod->removeItems(vitems);
             else
-                serr<< "TopologicalChangeProcessor: Error: No TriangleTopology available" << sendl;
+                msg_error() << "No TriangleTopology available";
         }
 
         if (!edges.empty())
@@ -294,7 +294,7 @@ void TopologicalChangeProcessor::processTopologicalChanges(double time)
             if (topoMod)
                 topoMod->removeItems(vitems);
             else
-                serr<< "TopologicalChangeProcessor: Error: No EdgeTopology available" << sendl;
+                msg_error() << "No EdgeTopology available";
         }
 
         // iterate, time set to infini if no interval.
@@ -425,7 +425,7 @@ void TopologicalChangeProcessor::processTopologicalChanges()
 
                 if(!topoMod)
                 {
-                    serr << "No PointSetTopologyModifier available" << sendl;
+                    msg_error() << "No PointSetTopologyModifier available";
                     continue;
                 }
 
@@ -468,7 +468,7 @@ void TopologicalChangeProcessor::processTopologicalChanges()
 
                 if (!topoMod)
                 {
-                    serr<< "TopologicalChangeProcessor: Error: No QuadTopology available" << sendl;
+                    msg_error() << "No QuadTopology available";
                     continue;
                 }
 
@@ -507,7 +507,7 @@ void TopologicalChangeProcessor::processTopologicalChanges()
 
                 if (!topoMod)
                 {
-                    serr<< "TopologicalChangeProcessor: Error: No TriangleTopology available" << sendl;
+                    msg_error() << "No TriangleTopology available";
                     continue;
                 }
 
@@ -533,7 +533,7 @@ void TopologicalChangeProcessor::processTopologicalChanges()
 
                 if (!topoMod)
                 {
-                    serr<< "TopologicalChangeProcessor: Error: No QuadTopology available" << sendl;
+                    msg_error() << "No QuadTopology available";
                     continue;
                 }
 
@@ -552,7 +552,7 @@ void TopologicalChangeProcessor::processTopologicalChanges()
 
                 if (!topoMod)
                 {
-                    serr<< "TopologicalChangeProcessor: Error: No TetrahedraTopology available" << sendl;
+                    msg_error() << "No TetrahedraTopology available";
                     continue;
                 }
 
@@ -571,7 +571,7 @@ void TopologicalChangeProcessor::processTopologicalChanges()
 
                 if (!topoMod)
                 {
-                    serr<< "TopologicalChangeProcessor: Error: No HexahedraTopology available" << sendl;
+                    msg_error() << "No HexahedraTopology available";
                     continue;
                 }
 
@@ -586,7 +586,7 @@ void TopologicalChangeProcessor::processTopologicalChanges()
             }
             else
             {
-                serr<< "TopologicalChangeProcessor: Error: keyword: '" << EleType <<"' not expected."<< sendl;
+                msg_error() << "keyword: '" << EleType << "' not expected.";
                 continue;
             }
 
@@ -619,7 +619,7 @@ void TopologicalChangeProcessor::processTopologicalChanges()
         }
         else if ( buff == "INCISE=" )
         {
-            msg_info() << "processTopologicalChanges: about to make a incision with time = " << time ;
+            msg_info() << "processTopologicalChanges: about to make a incision with time = " << time;
 
             if (m_saveIndicesAtInit.getValue())
             {
@@ -716,7 +716,7 @@ void TopologicalChangeProcessor::processTopologicalChanges()
 
                 if (!isPathOk)
                 {
-                    dmsg_error() << "Invalid path in computeIntersectedPointsList" ;
+                    msg_error() << "Invalid path in computeIntersectedPointsList";
                     break;
                 }
 
@@ -795,20 +795,20 @@ void TopologicalChangeProcessor::saveIndices()
         if (found!=std::string::npos)
         {
             size_t foundT = listInTheFile[i-1].find("T=");
-            if (foundT!=std::string::npos)
+            if (foundT != std::string::npos)
             {
-                linesAboutIncision.push_back(listInTheFile[i-1]);
+                linesAboutIncision.push_back(listInTheFile[i - 1]);
                 linesAboutIncision.push_back(listInTheFile[i]);
-                linesAboutIncision.push_back(listInTheFile[i+1]);
+                linesAboutIncision.push_back(listInTheFile[i + 1]);
             }
             else
-                dmsg_error() << " Error in line " << i << " : " << listInTheFile[i-1] ;
+                msg_error() << " Error in line " << i << " : " << listInTheFile[i - 1];
         }
     }
 
     if (linesAboutIncision.size() % 3)
     {
-        dmsg_error() << " Problem (Bug) while saving the lines about incision." ;
+        msg_error() << " Problem (Bug) while saving the lines about incision.";
     }
 
     for (std::vector<std::string>::iterator it=linesAboutIncision.begin(); it!=linesAboutIncision.end();)
@@ -853,17 +853,14 @@ void TopologicalChangeProcessor::saveIndices()
 
         std::vector<SReal> values = getValuesInLine(*it, nbElements);
 
-        dmsg_error_when(values.empty())
-                <<  "Error while saving the indices. Cannot get the values of line " << *it ;
+        msg_error_when(values.empty()) << "Error while saving the indices. Cannot get the values of line " << *it;
 
         bool onlyCoordinates = false;
 
         if (values.size() == nbElements * 3)
         {
             onlyCoordinates = true;
-
-            if(DEBUG_MSG)
-                dmsg_info() << "Use only coordinates. Triangles indices will be computed. " ;
+            msg_info() << "Use only coordinates. Triangles indices will be computed. ";
         }
 
         unsigned int increment = ( onlyCoordinates ) ? 3 : 4; // 3 if only the coordinates, 4 if there is also a triangle index
@@ -934,8 +931,7 @@ void TopologicalChangeProcessor::saveIndices()
 
             if (equal &&  triangleIncisionInformation[i].coordinates.size() > 1)
             {
-                if(DEBUG_MSG)
-                    dmsg_warning() << "Two consecutives values are equal" ;
+                msg_warning() << "Two consecutives values are equal" ;
 
                 Vector3 direction =  triangleIncisionInformation[i].coordinates[1] - triangleIncisionInformation[i].coordinates[0];
                 direction *= epsilon;
@@ -948,8 +944,7 @@ void TopologicalChangeProcessor::saveIndices()
                 int triIndex;
                 findElementIndex(Vector3(newPosition), triIndex, -1);
 
-                msg_error_when( (triIndex==-1) )
-                        << "Error while searching triangle index." ;
+                msg_error_when( (triIndex==-1) ) << "Error while searching triangle index." ;
 
                 triangleIncisionInformation[i].triangleIndices[0] = (unsigned int) triIndex;
 
@@ -1008,7 +1003,7 @@ std::vector<SReal> TopologicalChangeProcessor::getValuesInLine(std::string line,
             {
                 if (nbElements*4 < values.size())
                 {
-                    msg_warning() << "Incorrect input in '" << m_filename.getValue() <<"'. Too much values (" << values.size()<< ") in input in " << std::string(line) ;
+                    msg_warning() << "Incorrect input in '" << m_filename.getValue() << "'. Too much values (" << values.size() << ") in input in " << std::string(line);
                 }
                 else if (nbElements*3 > values.size())
                 {
@@ -1245,14 +1240,14 @@ void TopologicalChangeProcessor::inciseWithSavedIndices()
     {
         if (triangleIncisionInformation[indexOfTime].triangleIndices.empty())
         {
-            msg_error() << "List of triangles indices cannot be empty. Aborting. " ;
+            msg_error() << "List of triangles indices cannot be empty. Aborting. ";
             return;
         }
         ind_ta = triangleIncisionInformation[indexOfTime].triangleIndices[0];
     }
     else
     {
-        msg_error() <<  "found index '" << indexOfTime << "' which is larger than the vector size '" << triangleIncisionInformation.size() <<"'" ;
+        msg_error() << "found index '" << indexOfTime << "' which is larger than the vector size '" << triangleIncisionInformation.size() << "'";
         return;
     }
 
@@ -1293,14 +1288,11 @@ void TopologicalChangeProcessor::inciseWithSavedIndices()
 
         if (!isPathOk)
         {
-            dmsg_error() << "While computing computeIntersectedPointsList between triangles '"
+            msg_error() << "While computing computeIntersectedPointsList between triangles '"
                     << errorTrianglesIndices[errorTrianglesIndices.size() - 1] << "' and '" << errorTrianglesIndices[errorTrianglesIndices.size() - 2]  << "' at time = '" << getContext()->getTime()  << "'" ;
 
-            if(DEBUG_MSG)
-            {
-                dmsg_error() << " a = " << a << " b = " << b << msgendl
+            msg_error() << " a = " << a << " b = " << b << msgendl
                              << "ind_ta = " << ind_ta << " ind_tb = " << ind_tb ;
-            }
 
             break;
         }

--- a/modules/SofaNonUniformFem/DynamicSparseGridGeometryAlgorithms.inl
+++ b/modules/SofaNonUniformFem/DynamicSparseGridGeometryAlgorithms.inl
@@ -42,13 +42,13 @@ void DynamicSparseGridGeometryAlgorithms<DataTypes>::init()
     this->getContext()->get ( topoContainer );
     if ( !topoContainer )
     {
-        serr << "buildTriangleMesh(). Error: can't find the mapping on the triangular topology." << sendl;
+        msg_error() << "buildTriangleMesh(). Error: can't find the mapping on the triangular topology.";
         exit(EXIT_FAILURE);
     }
     this->getContext()->get( dof);
     if( !dof)
     {
-        serr << "Can not find the dof" << sendl;
+        msg_error() << "Can not find the dof";
         return;
     }
 }
@@ -60,7 +60,6 @@ core::topology::BaseMeshTopology::HexaID DynamicSparseGridGeometryAlgorithms<Dat
     existing = !(it == topoContainer->idInRegularGrid2IndexInTopo.getValue().end());
     if( !existing)
     {
-        //serr << "getTopoIndexFromRegularGridIndex(): Warning ! unexisting given index " << index << " !" << sendl;
         return 0;
     }
     return it->second;
@@ -119,7 +118,7 @@ int DynamicSparseGridGeometryAlgorithms<DataTypes>::findNearestElementInRestPos(
     if( index == -1)
     {
         // Dans le cas de projection ou autre.... il se peut que la zone ciblée ne contienne pas d'hexahedra, il faut alors tous les parcourrir.
-        serr << "findNearestElementInRestPos(). Index not found" << sendl;
+        msg_error() << "findNearestElementInRestPos(). Index not found";
         return HexahedronSetGeometryAlgorithms<DataTypes>::findNearestElementInRestPos( pos, baryC, distance);
     }
 

--- a/modules/SofaNonUniformFem/DynamicSparseGridTopologyContainer.cpp
+++ b/modules/SofaNonUniformFem/DynamicSparseGridTopologyContainer.cpp
@@ -63,7 +63,7 @@ void DynamicSparseGridTopologyContainer::init()
     this->getContext()->get(VoxelLoader);
     if ( !VoxelLoader )
     {
-        this->serr << "DynamicSparseGridTopologyContainer::init(): No VoxelLoader found! Aborting..." << this->sendl;
+        msg_error() << "DynamicSparseGridTopologyContainer::init(): No VoxelLoader found! Aborting...";
         exit(EXIT_FAILURE);
     }
 

--- a/modules/SofaNonUniformFem/DynamicSparseGridTopologyModifier.cpp
+++ b/modules/SofaNonUniformFem/DynamicSparseGridTopologyModifier.cpp
@@ -44,7 +44,7 @@ void DynamicSparseGridTopologyModifier::init()
     this->getContext()->get ( m_DynContainer );
     if ( ! m_DynContainer )
     {
-        serr << "ERROR in DynamicSparseGridTopologyModifier::init(): DynamicSparseGridTopologyContainer was not found !" << sendl;
+        msg_error() << "init(): DynamicSparseGridTopologyContainer was not found !";
     }
     everRenumbered = false;
 }
@@ -55,7 +55,7 @@ void DynamicSparseGridTopologyModifier::init()
 void DynamicSparseGridTopologyModifier::addHexahedraProcess ( const sofa::helper::vector< Hexahedron > &hexahedra )
 {
     HexahedronSetTopologyModifier::addHexahedraProcess ( hexahedra );
-    serr << "DynamicSparseGridTopologyModifier::addHexahedraProcess( const sofa::helper::vector< Hexahedron > &hexahedra ). You must not use this method. To add some voxels to the topology, you must use addHexahedraProcess ( const sofa::helper::vector< Hexahedron > &hexahedra, const sofa::helper::vector< unsigned int> &indices ) because, for the moment, indices maps can not be updated !" << sendl;
+    msg_error() << "addHexahedraProcess( const sofa::helper::vector< Hexahedron > &hexahedra ). You must not use this method. To add some voxels to the topology, you must use addHexahedraProcess ( const sofa::helper::vector< Hexahedron > &hexahedra, const sofa::helper::vector< unsigned int> &indices ) because, for the moment, indices maps can not be updated !";
 }
 
 

--- a/modules/SofaNonUniformFem/HexahedronCompositeFEMMapping.h
+++ b/modules/SofaNonUniformFem/HexahedronCompositeFEMMapping.h
@@ -109,7 +109,7 @@ public:
 
     void applyJT( const sofa::core::ConstraintParams* /*cparams*/, InDataMatrixDeriv& /*out*/, const OutDataMatrixDeriv& /*in*/) override
     {
-        msg_error() << "applyJT(constraint) not implemented";
+        msg_warning() << "This object only support Direct Solving but an Indirect Solver in the scene is calling method applyJT(constraint) which is not implemented. This will produce un-expected behavior.";
     }
 
     //void applyJT( typename In::MatrixDeriv& out, const typename Out::MatrixDeriv& in );

--- a/modules/SofaNonUniformFem/HexahedronCompositeFEMMapping.h
+++ b/modules/SofaNonUniformFem/HexahedronCompositeFEMMapping.h
@@ -109,7 +109,7 @@ public:
 
     void applyJT( const sofa::core::ConstraintParams* /*cparams*/, InDataMatrixDeriv& /*out*/, const OutDataMatrixDeriv& /*in*/) override
     {
-        serr << "applyJT(constraint) not implemented" << sendl;
+        msg_error() << "applyJT(constraint) not implemented";
     }
 
     //void applyJT( typename In::MatrixDeriv& out, const typename Out::MatrixDeriv& in );

--- a/modules/SofaNonUniformFem/HexahedronCompositeFEMMapping.inl
+++ b/modules/SofaNonUniformFem/HexahedronCompositeFEMMapping.inl
@@ -54,7 +54,7 @@ void HexahedronCompositeFEMMapping<BasicMapping>::init()
     _sparseGrid = dynamic_cast<SparseGridTopologyT*> (this->fromModel->getContext()->getTopology());
     if(!_sparseGrid)
     {
-        serr<<"HexahedronCompositeFEMMapping can only be used with a SparseGridTopology"<<sendl;
+        msg_error() << "HexahedronCompositeFEMMapping can only be used with a SparseGridTopology";
         exit(EXIT_FAILURE);
     }
 
@@ -62,7 +62,7 @@ void HexahedronCompositeFEMMapping<BasicMapping>::init()
     this->fromModel->getContext()->get(_forcefield);
     if(!_forcefield)
     {
-        serr<<"HexahedronCompositeFEMMapping can only be used with a HexahedronCompositeFEMForceFieldAndMass"<<sendl;
+        msg_error() << "HexahedronCompositeFEMMapping can only be used with a HexahedronCompositeFEMForceFieldAndMass";
         exit(EXIT_FAILURE);
     }
 
@@ -82,13 +82,6 @@ void HexahedronCompositeFEMMapping<BasicMapping>::init()
         _qFine0.push_back( _finestSparseGrid->getPointPos(i)+translation0 );
 
     _qFine = _qFine0;
-
-
-// 	serr<<_qCoarse0[0]<<sendl;
-
-// 	for(int i=0;i<_qFine0.size();++i)
-// 		serr<<i<<" : "<<_qFine0[i]<<sendl;
-
 
 // 	_pointsCorrespondingToElem.resize(_sparseGrid->getNbHexahedra());
 
@@ -135,25 +128,23 @@ void HexahedronCompositeFEMMapping<BasicMapping>::init()
                 elementIdx = _finestSparseGrid->findNearestCube( _p0[i] , coefs[0], coefs[1], coefs[2] );
             }
 
-            if( elementIdx!=-1)
+            if (elementIdx != -1)
             {
-                helper::fixed_array<Real,8> baryCoefs;
-                baryCoefs[0] = (Real)((1-coefs[0]) * (1-coefs[1]) * (1-coefs[2]));
-                baryCoefs[1] = (Real)((coefs[0]) * (1-coefs[1]) * (1-coefs[2]));
-                baryCoefs[2] = (Real)((coefs[0]) * (coefs[1]) * (1-coefs[2]));
-                baryCoefs[3] = (Real)((1-coefs[0]) * (coefs[1]) * (1-coefs[2]));
-                baryCoefs[4] = (Real)((1-coefs[0]) * (1-coefs[1]) * (coefs[2]));
-                baryCoefs[5] = (Real)((coefs[0]) * (1-coefs[1]) * (coefs[2]));
+                helper::fixed_array<Real, 8> baryCoefs;
+                baryCoefs[0] = (Real)((1 - coefs[0]) * (1 - coefs[1]) * (1 - coefs[2]));
+                baryCoefs[1] = (Real)((coefs[0]) * (1 - coefs[1]) * (1 - coefs[2]));
+                baryCoefs[2] = (Real)((coefs[0]) * (coefs[1]) * (1 - coefs[2]));
+                baryCoefs[3] = (Real)((1 - coefs[0]) * (coefs[1]) * (1 - coefs[2]));
+                baryCoefs[4] = (Real)((1 - coefs[0]) * (1 - coefs[1]) * (coefs[2]));
+                baryCoefs[5] = (Real)((coefs[0]) * (1 - coefs[1]) * (coefs[2]));
                 baryCoefs[6] = (Real)((coefs[0]) * (coefs[1]) * (coefs[2]));
-                baryCoefs[7] = (Real)((1-coefs[0]) * (coefs[1]) * (coefs[2]));
+                baryCoefs[7] = (Real)((1 - coefs[0]) * (coefs[1]) * (coefs[2]));
 
-                _finestBarycentricCoord[i] = std::pair<int,helper::fixed_array<Real,8> >(elementIdx, baryCoefs);
+                _finestBarycentricCoord[i] = std::pair<int, helper::fixed_array<Real, 8> >(elementIdx, baryCoefs);
             }
             else
-                serr<<"HexahedronCompositeFEMMapping::init()   error finding the corresponding finest cube of vertex "<<_p0[i]<<sendl;
+                msg_error() << "HexahedronCompositeFEMMapping::init()   error finding the corresponding finest cube of vertex " << _p0[i];
         }
-// 		else
-// 			serr<<"HexahedronCompositeFEMMapping::init()   error finding the corresponding coarse cube of vertex "<<_p0[i]<<sendl;
     }
 
 
@@ -174,28 +165,6 @@ void HexahedronCompositeFEMMapping<BasicMapping>::init()
             _finestWeights[ finehexa[w] ][_forcefield->_finalWeights[i].first] =  W ;
         }
     }
-
-
-
-// 	serr<<_finestWeights[17].size( )<<sendl;
-// 	for(int i=0;i<_finestWeights[17].size( );++i)
-// 		serr<<_finestWeights[17][i].second<<""<<sendl;
-
-
-
-// 	for (unsigned int i=0;i<_forcefield->_finalWeights.size();i++)
-// 	{
-// 		const SparseGridTopologyT::Hexa& finehexa = _finestSparseGrid->getHexahedron(i);
-// 		serr<<_finestWeights[ finehexa[i] ].size()<<sendl;
-// 		for(int w=0;w<_finestWeights[ finehexa[w] ].size();++w)
-// 		{
-// 			serr<< _finestWeights[ finehexa[w] ][w].first<<sendl;
-// 			serr<< _finestWeights[ finehexa[w] ][w].second<<sendl;
-// 			serr<<"-------"<<sendl;
-// 		}
-// 		serr<<"****************"<<sendl;
-// 	}
-
 
     // non necessary memory optimisation
 // 	_forcefield->_finalWeights.resize(0);

--- a/modules/SofaNonUniformFem/MultilevelHexahedronSetTopologyContainer.cpp
+++ b/modules/SofaNonUniformFem/MultilevelHexahedronSetTopologyContainer.cpp
@@ -305,7 +305,7 @@ int MultilevelHexahedronSetTopologyContainer::getHexaParent(const unsigned int h
             return i;
     }
 
-    serr << "ERROR(MultilevelHexahedronSetTopologyContainer) No hexa parent found. \n";
+    msg_error() << "No hexa parent found.";
     return 0;
 }
 

--- a/modules/SofaNonUniformFem/NonUniformHexahedralFEMForceFieldAndMass.inl
+++ b/modules/SofaNonUniformFem/NonUniformHexahedralFEMForceFieldAndMass.inl
@@ -55,7 +55,7 @@ void NonUniformHexahedralFEMForceFieldAndMass<DataTypes>::init()
 
     if(this->_topology == nullptr)
     {
-        serr << "ERROR(NonUniformHexahedralFEMForceFieldAndMass): object must have a HexahedronSetTopology."<<sendl;
+        msg_error() << "Object must have a HexahedronSetTopology.";
         return;
     }
 
@@ -63,7 +63,7 @@ void NonUniformHexahedralFEMForceFieldAndMass<DataTypes>::init()
 
     if(_multilevelTopology == nullptr)
     {
-        serr << "ERROR(NonUniformHexahedralFEMForceFieldAndMass): object must have a MultilevelHexahedronSetTopologyContainer";
+        msg_error() << "Object must have a MultilevelHexahedronSetTopologyContainer";
     }
 
     this->reinit();
@@ -94,7 +94,7 @@ void NonUniformHexahedralFEMForceFieldAndMass<T>::reinit()
 
     if (!this->_topology->getNbHexahedra())
     {
-        serr << "Topology is empty !" << sendl;
+        msg_error() << "Topology is empty !";
         return;
     }
 

--- a/modules/SofaNonUniformFem/SparseGridMultipleTopology.cpp
+++ b/modules/SofaNonUniformFem/SparseGridMultipleTopology.cpp
@@ -55,7 +55,7 @@ void SparseGridMultipleTopology::buildAsFinest()
 {
     if( _dataStiffnessCoefs.getValue().size() < _fileTopologies.getValue().size() )
     {
-        serr<<"WARNING: SparseGridMultipleTopology: not enough stiffnessCoefs"<<sendl;
+        msg_warning() << "SparseGridMultipleTopology: not enough stiffnessCoefs";
         for(unsigned i=_dataStiffnessCoefs.getValue().size(); i<_fileTopologies.getValue().size(); ++i)
             _dataStiffnessCoefs.beginEdit()->push_back( 1.0 );
         //           return;
@@ -63,7 +63,7 @@ void SparseGridMultipleTopology::buildAsFinest()
 
     if( _dataMassCoefs.getValue().size() < _fileTopologies.getValue().size() )
     {
-        serr<<"WARNING: SparseGridMultipleTopology: not enough massCoefs\n";
+        msg_warning() << "SparseGridMultipleTopology: not enough massCoefs\n";
         for(unsigned i=_dataMassCoefs.getValue().size(); i<_fileTopologies.getValue().size(); ++i)
             _dataMassCoefs.beginEdit()->push_back( 1.0 );
         // 			return;
@@ -101,7 +101,7 @@ void SparseGridMultipleTopology::buildAsFinest()
 
         std::string filename = _fileTopologies.getValue()[i];
 
-        sout<<"SparseGridMultipleTopology open "<<filename<<sendl;
+        msg_info() << "SparseGridMultipleTopology open " << filename;
 
         if (! sofa::helper::system::DataRepository.findFile ( filename ))
             continue;
@@ -112,7 +112,7 @@ void SparseGridMultipleTopology::buildAsFinest()
 
             if(meshes[i] == nullptr)
             {
-                serr << "SparseGridTopology: loading mesh " << filename << " failed." <<sendl;
+                msg_error() << "SparseGridTopology: loading mesh " << filename << " failed.";
                 return;
             }
 

--- a/modules/SofaNonUniformFem/SparseGridRamificationTopology.cpp
+++ b/modules/SofaNonUniformFem/SparseGridRamificationTopology.cpp
@@ -72,8 +72,6 @@ void SparseGridRamificationTopology::init()
 
 void SparseGridRamificationTopology::buildAsFinest()
 {
-// 				serr<<"SparseGridRamificationTopology::buildAsFinest()"<<sendl;
-
     SparseGridTopology::buildAsFinest();
 
 
@@ -108,13 +106,13 @@ void SparseGridRamificationTopology::findConnexionsAtFinestLevel()
             mesh = helper::io::Mesh::Create(filename.c_str());
             if (!mesh)
             {
-                serr<<"Warning: SparseGridRamificationTopology::findConnexionsAtFinestLevel Can't create mesh from file=\""<< fileTopology.getValue()<<"\" is valid)"<<sendl;
+                msg_warning() << "FindConnexionsAtFinestLevel Can't create mesh from file=\"" << fileTopology.getValue() << "\" is valid)";
                 return;
             }
         }
         if(filename.empty() && seqPoints.getValue().empty()) // No vertices buffer set, nor mesh file => impossible to create mesh
         {
-            serr<<"Warning: SparseGridRamificationTopology::findConnexionsAtFinestLevel -- mesh is nullptr (check if fileTopology=\""<< fileTopology.getValue()<<"\" is valid)"<<sendl;
+            msg_warning() << "FindConnexionsAtFinestLevel -- mesh is nullptr (check if fileTopology=\"" << fileTopology.getValue() << "\" is valid)";
             return;
         }
         else if(filename.empty() && !seqPoints.getValue().empty()) // no file given but vertex buffer. We can rebuild the mesh
@@ -624,8 +622,6 @@ void SparseGridRamificationTopology::buildFromFiner()
                                 Connexion* coarseConnexion2 = fineConnexion2->_parent;
                                 int coarseHexa2 = coarseConnexion2->_tmp;
 
-// 											serr<<"coarseHexa : "<<coarseHexa1<<" "<<coarseHexa2<<sendl;
-
 // 											if( coarseConnexion1 != coarseConnexion2 )
                                 if( coarseHexa1 != coarseHexa2 ) // the both fine hexahedra are not in the same coarse hexa
                                 {
@@ -1011,7 +1007,7 @@ void SparseGridRamificationTopology::changeIndices(unsigned oldidx, unsigned new
 void SparseGridRamificationTopology::printNeighborhood()
 {
     // 				// print draw neighbors
-    serr<<sendl<<sendl;
+    sout <<sendl<<sendl;
     for(int z=0; z<getNz()-1; ++z)
     {
         for(int y=getNy()-2; y>=0; --y)
@@ -1124,11 +1120,11 @@ void SparseGridRamificationTopology::printNbConnexions()
 
 void SparseGridRamificationTopology::printParents()
 {
-    serr<<"\n\nPARENTS\n"<<sendl;
+    sout <<"\n\nPARENTS\n"<<sendl;
 
     for( unsigned i=0; i<_virtualFinerLevels.size(); ++i)
     {
-        serr<<"level "<<i<<" :"<<sendl;
+        sout <<"level "<<i<<" :"<<sendl;
 
         SparseGridRamificationTopology* finestSGRT = dynamic_cast<SparseGridRamificationTopology*>(_virtualFinerLevels[i].get());
 

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/CompositingVisualLoop.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/CompositingVisualLoop.cpp
@@ -104,7 +104,7 @@ void CompositingVisualLoop::drawStep(sofa::core::visual::VisualParams* vparams)
     //should not happen: the compositing loop relies on one or more rendered passes done by the VisualManagerPass component
     if (gRoot->visualManager.empty())
     {
-        serr << "CompositingVisualLoop: no VisualManagerPass found. Disable multipass rendering." << sendl;
+        msg_error() << "CompositingVisualLoop: no VisualManagerPass found. Disable multipass rendering.";
         defaultRendering(vparams);
     }
 

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/DataDisplay.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/DataDisplay.cpp
@@ -91,7 +91,7 @@ void DataDisplay::init()
 
     this->getContext()->get(colorMap);
     if (!colorMap) {
-        serr << "No ColorMap found, using default." << sendl;
+        msg_error() << "No ColorMap found, using default.";
         colorMap = OglColorMap::getDefault();
     }
 }
@@ -124,27 +124,27 @@ void DataDisplay::drawVisual(const core::visual::VisualParams* vparams)
     // TODO: can this go to updateVisual()?
     if (ptData.size() > 0) {
         if (ptData.size() != x.size()) {
-            serr << "Size of pointData does not mach number of nodes" << sendl;
+            msg_error() << "Size of pointData does not mach number of nodes";
         } else {
             bDrawPointData = true;
         }
     } else if (triData.size() > 0 || quadData.size()>0 ) {
         if (!m_topology ) {
-            serr << "Topology is necessary for drawing cell data" << sendl;
+            msg_error() << "Topology is necessary for drawing cell data";
         } else if (triData.size() != m_topology->getNbTriangles()) {
-            serr << "Size of triangleData does not match number of triangles" << sendl;
+            msg_error() << "Size of triangleData does not match number of triangles";
         } else if (quadData.size() != m_topology->getNbQuads()) {
-            serr << "Size of quadData does not match number of quads" << sendl;
+            msg_error() << "Size of quadData does not match number of quads";
         } else {
             bDrawCellData = true;
         }
     } else if (pointTriData.size()>0 || pointQuadData.size()>0) {
         if (!m_topology ) {
-            serr << "Topology is necessary for drawing cell data" << sendl;
+            msg_error() << "Topology is necessary for drawing cell data";
         } else if (pointTriData.size() != m_topology->getNbTriangles()*3) {
-            serr << "Size of pointTriData does not match number of triangles" << sendl;
+            msg_error() << "Size of pointTriData does not match number of triangles";
         } else if (pointQuadData.size() != m_topology->getNbQuads()*4) {
-            serr << "Size of pointQuadData does not match number of quads" << sendl;
+            msg_error() << "Size of pointQuadData does not match number of quads";
         } else {
             bDrawCellData = true;
         }

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglAttribute.inl
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglAttribute.inl
@@ -104,11 +104,11 @@ void OglAttribute< size, type, DataTypes>::initVisual ()
     _index =  (*shaders.begin())->getAttribute ( indexShader.getValue(), id.getValue().c_str() ); //shader->getAttribute ( indexShader.getValue(), id.getValue().c_str() );
     if (_index == GLuint(-1) )
     {
-        serr << "Variable \""<<id.getValue()<<"\" NOT FOUND in shader \"" << (*shaders.begin())->vertFilename.getValue() << "\""<< sendl;
+        msg_error() << "Variable \"" << id.getValue() << "\" NOT FOUND in shader \"" << (*shaders.begin())->vertFilename.getValue() << "\"";
     }
     else
     {
-        sout << "Variable \""<<id.getValue()<<"\" in shader \"" << (*shaders.begin())->vertFilename.getValue() << "\" with index: " << _index << sendl;
+        msg_info() << "Variable \"" << id.getValue() << "\" in shader \"" << (*shaders.begin())->vertFilename.getValue() << "\" with index: " << _index;
     }
     glBindBufferARB(GL_ARRAY_BUFFER,0);
 }

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglCylinderModel.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglCylinderModel.cpp
@@ -154,7 +154,7 @@ void OglCylinderModel::setColor(std::string color)
     else if (color == "gray")     { r = 0.5f; g = 0.5f; b = 0.5f; }
     else
     {
-        serr << "Unknown color "<<color<<sendl;
+        msg_error() << "Unknown color " << color;
         return;
     }
     setColor(r,g,b,a);

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglGrid.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglGrid.cpp
@@ -90,7 +90,7 @@ void OglGrid::updateVisual()
     }
     else
     {
-        serr << "Plane parameter " << plane.getValue() << " not recognized. Set to z instead" << sendl;
+        msg_error() << "Plane parameter " << plane.getValue() << " not recognized. Set to z instead";
         plane.setValue("z");
         internalPlane = PLANE_Z;
     }
@@ -98,7 +98,7 @@ void OglGrid::updateVisual()
     int nb = nbSubdiv.getValue();
     if (nb < 2)
     {
-        serr << "nbSubdiv should be > 2" << sendl;
+        msg_error() << "nbSubdiv should be > 2";
         nbSubdiv.setValue(2);
     }
 

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglShader.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglShader.cpp
@@ -211,7 +211,7 @@ void OglShader::parse(core::objectmodel::BaseObjectDescription* arg)
     const char* fileVertexShaderAlias = arg->getAttribute("vertFilename");
     if( fileVertexShader || fileVertexShaderAlias )
     {
-        msg_error() << helper::logging::Message::Deprecated << "parse: You are using a deprecated Data<vector<string>> 'fileVertexShader' or 'vertFilename', please use the new Data<SVector<string>>'fileVertexShaders'";
+        msg_deprecated() << "Parse: You are using a deprecated Data<vector<string>> 'fileVertexShader' or 'vertFilename', please use the new Data<SVector<string>>'fileVertexShaders'";
         helper::vector<std::string> simplevector;
         std::istringstream( fileVertexShader ? fileVertexShader : fileVertexShaderAlias ) >> simplevector;
         vertFilename.setValue( simplevector );
@@ -220,7 +220,7 @@ void OglShader::parse(core::objectmodel::BaseObjectDescription* arg)
     const char* fileFragmentShaderAlias = arg->getAttribute("fragFilename");
     if( fileFragmentShader || fileFragmentShaderAlias )
     {
-        msg_error() << helper::logging::Message::Deprecated << "parse: You are using a deprecated Data<vector<string>> 'fileFragmentShader' or 'fragFilename', please use the new Data<SVector<string>>'fileFragmentShaders'";
+        msg_deprecated() << "Parse: You are using a deprecated Data<vector<string>> 'fileFragmentShader' or 'fragFilename', please use the new Data<SVector<string>>'fileFragmentShaders'";
         helper::vector<std::string> simplevector;
         std::istringstream( fileFragmentShader ? fileFragmentShader : fileFragmentShaderAlias ) >> simplevector;
         fragFilename.setValue( simplevector );
@@ -230,7 +230,7 @@ void OglShader::parse(core::objectmodel::BaseObjectDescription* arg)
     const char* fileGeometryShaderAlias = arg->getAttribute("geoFilename");
     if( fileGeometryShader || fileGeometryShaderAlias )
     {
-        msg_error() << helper::logging::Message::Deprecated << "parse: You are using a deprecated Data<vector<string>> 'fileGeometryShader' or 'geoFilename', please use the new Data<SVector<string>>'fileGeometryShaders'";
+        msg_deprecated() << "Parse: You are using a deprecated Data<vector<string>> 'fileGeometryShader' or 'geoFilename', please use the new Data<SVector<string>>'fileGeometryShaders'";
         helper::vector<std::string> simplevector;
         std::istringstream( fileGeometryShader ? fileGeometryShader : fileGeometryShaderAlias ) >> simplevector;
         geoFilename.setValue( simplevector );
@@ -240,7 +240,7 @@ void OglShader::parse(core::objectmodel::BaseObjectDescription* arg)
     const char* fileTessellationControlShader = arg->getAttribute("fileTessellationControlShader");
     if( fileTessellationControlShader )
     {
-        msg_error() << helper::logging::Message::Deprecated << "parse: You are using a deprecated Data<vector<string>> 'fileTessellationControlShader', please use the new Data<SVector<string>>'fileTessellationControlShaders'";
+        msg_deprecated() << "Parse: You are using a deprecated Data<vector<string>> 'fileTessellationControlShader', please use the new Data<SVector<string>>'fileTessellationControlShaders'";
         helper::vector<std::string> simplevector;
         std::istringstream( fileTessellationControlShader ) >> simplevector;
         tessellationControlFilename.setValue( simplevector );
@@ -250,7 +250,7 @@ void OglShader::parse(core::objectmodel::BaseObjectDescription* arg)
     const char* fileTessellationEvaluationShader = arg->getAttribute("fileTessellationEvaluationShader");
     if( fileTessellationEvaluationShader )
     {
-        msg_error() << helper::logging::Message::Deprecated << "parse: You are using a deprecated Data<vector<string>> 'fileTessellationEvaluationShader', please use the new Data<SVector<string>>'fileTessellationEvaluationShaders'";
+        msg_deprecated() << "Parse: You are using a deprecated Data<vector<string>> 'fileTessellationEvaluationShader', please use the new Data<SVector<string>>'fileTessellationEvaluationShaders'";
         helper::vector<std::string> simplevector;
         std::istringstream( fileTessellationEvaluationShader ) >> simplevector;
         tessellationEvaluationFilename.setValue( simplevector );

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglShader.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglShader.cpp
@@ -163,7 +163,7 @@ void OglShader::initVisual()
 
     if (!sofa::helper::gl::GLSLShader::InitGLSL())
     {
-        serr << "InitGLSL failed" << sendl;
+        msg_error() << "InitGLSL failed";
         return;
     }
     unsigned int nshaders = (unsigned int)shaderVector.size();
@@ -211,7 +211,7 @@ void OglShader::parse(core::objectmodel::BaseObjectDescription* arg)
     const char* fileVertexShaderAlias = arg->getAttribute("vertFilename");
     if( fileVertexShader || fileVertexShaderAlias )
     {
-        serr<<helper::logging::Message::Deprecated<<"parse: You are using a deprecated Data<vector<string>> 'fileVertexShader' or 'vertFilename', please use the new Data<SVector<string>>'fileVertexShaders'"<<sendl;
+        msg_error() << helper::logging::Message::Deprecated << "parse: You are using a deprecated Data<vector<string>> 'fileVertexShader' or 'vertFilename', please use the new Data<SVector<string>>'fileVertexShaders'";
         helper::vector<std::string> simplevector;
         std::istringstream( fileVertexShader ? fileVertexShader : fileVertexShaderAlias ) >> simplevector;
         vertFilename.setValue( simplevector );
@@ -220,7 +220,7 @@ void OglShader::parse(core::objectmodel::BaseObjectDescription* arg)
     const char* fileFragmentShaderAlias = arg->getAttribute("fragFilename");
     if( fileFragmentShader || fileFragmentShaderAlias )
     {
-        serr<<helper::logging::Message::Deprecated<<"parse: You are using a deprecated Data<vector<string>> 'fileFragmentShader' or 'fragFilename', please use the new Data<SVector<string>>'fileFragmentShaders'"<<sendl;
+        msg_error() << helper::logging::Message::Deprecated << "parse: You are using a deprecated Data<vector<string>> 'fileFragmentShader' or 'fragFilename', please use the new Data<SVector<string>>'fileFragmentShaders'";
         helper::vector<std::string> simplevector;
         std::istringstream( fileFragmentShader ? fileFragmentShader : fileFragmentShaderAlias ) >> simplevector;
         fragFilename.setValue( simplevector );
@@ -230,7 +230,7 @@ void OglShader::parse(core::objectmodel::BaseObjectDescription* arg)
     const char* fileGeometryShaderAlias = arg->getAttribute("geoFilename");
     if( fileGeometryShader || fileGeometryShaderAlias )
     {
-        serr<<helper::logging::Message::Deprecated<<"parse: You are using a deprecated Data<vector<string>> 'fileGeometryShader' or 'geoFilename', please use the new Data<SVector<string>>'fileGeometryShaders'"<<sendl;
+        msg_error() << helper::logging::Message::Deprecated << "parse: You are using a deprecated Data<vector<string>> 'fileGeometryShader' or 'geoFilename', please use the new Data<SVector<string>>'fileGeometryShaders'";
         helper::vector<std::string> simplevector;
         std::istringstream( fileGeometryShader ? fileGeometryShader : fileGeometryShaderAlias ) >> simplevector;
         geoFilename.setValue( simplevector );
@@ -240,7 +240,7 @@ void OglShader::parse(core::objectmodel::BaseObjectDescription* arg)
     const char* fileTessellationControlShader = arg->getAttribute("fileTessellationControlShader");
     if( fileTessellationControlShader )
     {
-        serr<<helper::logging::Message::Deprecated<<"parse: You are using a deprecated Data<vector<string>> 'fileTessellationControlShader', please use the new Data<SVector<string>>'fileTessellationControlShaders'"<<sendl;
+        msg_error() << helper::logging::Message::Deprecated << "parse: You are using a deprecated Data<vector<string>> 'fileTessellationControlShader', please use the new Data<SVector<string>>'fileTessellationControlShaders'";
         helper::vector<std::string> simplevector;
         std::istringstream( fileTessellationControlShader ) >> simplevector;
         tessellationControlFilename.setValue( simplevector );
@@ -250,7 +250,7 @@ void OglShader::parse(core::objectmodel::BaseObjectDescription* arg)
     const char* fileTessellationEvaluationShader = arg->getAttribute("fileTessellationEvaluationShader");
     if( fileTessellationEvaluationShader )
     {
-        serr<<helper::logging::Message::Deprecated<<"parse: You are using a deprecated Data<vector<string>> 'fileTessellationEvaluationShader', please use the new Data<SVector<string>>'fileTessellationEvaluationShaders'"<<sendl;
+        msg_error() << helper::logging::Message::Deprecated << "parse: You are using a deprecated Data<vector<string>> 'fileTessellationEvaluationShader', please use the new Data<SVector<string>>'fileTessellationEvaluationShaders'";
         helper::vector<std::string> simplevector;
         std::istringstream( fileTessellationEvaluationShader ) >> simplevector;
         tessellationEvaluationFilename.setValue( simplevector );
@@ -598,7 +598,7 @@ void OglShaderElement::init()
 
     if (shaders.empty())
     {
-        serr << this->getTypeName() <<" \"" << this->getName() << "\": no relevant shader found. please check tags validity"<< sendl;
+        msg_error() << this->getTypeName() <<" \"" << this->getName() << "\": no relevant shader found. please check tags validity"<< sendl;
         return;
     }
 }

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglTexture.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglTexture.cpp
@@ -278,7 +278,7 @@ void OglTexture::unbind()
 OglTexture2D::OglTexture2D()
     :texture2DFilename(initData(&texture2DFilename, (std::string) "", "texture2DFilename", "Texture2D Filename"))
 {
-    msg_error() << helper::logging::Message::Deprecated << "OglTexture2D is deprecated. Please use OglTexture instead.";
+    msg_deprecated() << "OglTexture2D is deprecated. Please use OglTexture instead.";
 }
 
 OglTexture2D::~OglTexture2D()

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglTexture.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglTexture.cpp
@@ -182,7 +182,7 @@ void OglTexture::init()
         }
         else
         {
-            serr << "OglTexture file " << textureFilename.getFullPath() << " not found." << sendl;
+            msg_error() << "OglTexture file " << textureFilename.getFullPath() << " not found.";
             //create dummy texture
             if (img) { delete img; img=nullptr; }
             img = new helper::io::Image();
@@ -213,15 +213,9 @@ void OglTexture::initVisual()
 
     if (textureUnit.getValue() > MAX_NUMBER_OF_TEXTURE_UNIT)
     {
-        serr << "Unit Texture too high ; set it at the unit texture n°1 (MAX_NUMBER_OF_TEXTURE_UNIT=" << MAX_NUMBER_OF_TEXTURE_UNIT << ")" << sendl;
+        msg_error() << "Unit Texture too high ; set it at the unit texture n°1 (MAX_NUMBER_OF_TEXTURE_UNIT=" << MAX_NUMBER_OF_TEXTURE_UNIT << ")";
         textureUnit.setValue(1);
     }
-//    if (!img)
-//    {
-//        serr << "OglTexture: Error : OglTexture file " << textureFilename.getFullPath() << " not found." << sendl;
-//        return;
-//    }
-
 
     if (texture) delete texture;
     texture = new helper::gl::Texture(img, repeat.getValue(), linearInterpolation.getValue(),
@@ -233,7 +227,6 @@ void OglTexture::initVisual()
     for(std::set<OglShader*>::iterator it = shaders.begin(), iend = shaders.end(); it!=iend; ++it)
     {
         (*it)->setTexture(indexShader.getValue(), id.getValue().c_str(), textureUnit.getValue());
-        //serr << "OGLTextureDEBUG: shader textured:" << (*it)->getName() << sendl;
     }
     setActiveTexture(0);
 }
@@ -242,7 +235,7 @@ void OglTexture::reinit()
 {
     if (textureUnit.getValue() > MAX_NUMBER_OF_TEXTURE_UNIT)
     {
-        serr << "Unit Texture too high ; set it at the unit texture n°1" << sendl;
+        msg_error() << "Unit Texture too high ; set it at the unit texture n°1";
         textureUnit.setValue(1);
     }
 }
@@ -285,7 +278,7 @@ void OglTexture::unbind()
 OglTexture2D::OglTexture2D()
     :texture2DFilename(initData(&texture2DFilename, (std::string) "", "texture2DFilename", "Texture2D Filename"))
 {
-    serr << helper::logging::Message::Deprecated << "OglTexture2D is deprecated. Please use OglTexture instead." << sendl;
+    msg_error() << helper::logging::Message::Deprecated << "OglTexture2D is deprecated. Please use OglTexture instead.";
 }
 
 OglTexture2D::~OglTexture2D()

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglVariable.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglVariable.cpp
@@ -311,7 +311,7 @@ void OglIntVector2Variable::init()
     helper::vector<GLint> temp = value.getValue();
     if (temp.size() %2 != 0)
     {
-        serr << "The number of values is not even ; padding with one zero" << sendl;
+        msg_error() << "The number of values is not even ; padding with one zero";
         temp.push_back(0);
         value.setValue(temp);
 
@@ -325,7 +325,7 @@ void OglIntVector3Variable::init()
 
     if (temp.size() %3 != 0)
     {
-        serr << "The number of values is not a multiple of 3 ; padding with zero(s)" << sendl;
+        msg_error() << "The number of values is not a multiple of 3 ; padding with zero(s)";
         while (temp.size() %3 != 0)
             temp.push_back(0);
         value.setValue(temp);
@@ -339,7 +339,7 @@ void OglIntVector4Variable::init()
 
     if (temp.size() %4 != 0)
     {
-        serr << "The number of values is not a multiple of 4 ; padding with zero(s)" << sendl;
+        msg_error() << "The number of values is not a multiple of 4 ; padding with zero(s)";
         while (temp.size() %4 != 0)
             temp.push_back(0);
         value.setValue(temp);
@@ -484,7 +484,7 @@ void OglMatrix2Variable::init()
 
     if (temp.size() %4 != 0)
     {
-        serr << "The number of values is not a multiple of 4 ; padding with zero(s)" << sendl;
+        msg_error() << "The number of values is not a multiple of 4 ; padding with zero(s)";
         while (temp.size() %4 != 0)
             temp.push_back(0.0);
         value.setValue(temp);
@@ -516,7 +516,7 @@ void OglMatrix3Variable::init()
 
     if (temp.size() %9 != 0)
     {
-        serr << "The number of values is not a multiple of 9 ; padding with zero(s)" << sendl;
+        msg_error() << "The number of values is not a multiple of 9 ; padding with zero(s)";
         while (temp.size() %9 != 0)
             temp.push_back(0.0);
         value.setValue(temp);
@@ -548,7 +548,7 @@ void OglMatrix4Variable::init()
 
     if (temp.size() %16 != 0)
     {
-        serr << "The number of values is not a multiple of 16 ; padding with zero(s)" << sendl;
+        msg_error() << "The number of values is not a multiple of 16 ; padding with zero(s)";
         while (temp.size() %16 != 0)
             temp.push_back(0.0);
         value.setValue(temp);
@@ -580,7 +580,7 @@ void OglMatrix2x3Variable::init()
 
     if (temp.size() %6 != 0)
     {
-        serr << "The number of values is not a multiple of 6 ; padding with zero(s)" << sendl;
+        msg_error() << "The number of values is not a multiple of 6 ; padding with zero(s)";
         while (temp.size() %6 != 0)
             temp.push_back(0.0);
         value.setValue(temp);
@@ -613,7 +613,7 @@ void OglMatrix3x2Variable::init()
 
     if (temp.size() %6 != 0)
     {
-        serr << "The number of values is not a multiple of 6 ; padding with zero(s)" << sendl;
+        msg_error() << "The number of values is not a multiple of 6 ; padding with zero(s)";
         while (temp.size() %6 != 0)
             temp.push_back(0.0);
         value.setValue(temp);
@@ -645,7 +645,7 @@ void OglMatrix2x4Variable::init()
 
     if (temp.size() %8 != 0)
     {
-        serr << "The number of values is not a multiple of 8 ; padding with zero(s)" << sendl;
+        msg_error() << "The number of values is not a multiple of 8 ; padding with zero(s)";
         while (temp.size() %8 != 0)
             temp.push_back(0.0);
         value.setValue(temp);
@@ -677,7 +677,7 @@ void OglMatrix4x2Variable::init()
 
     if (temp.size() %8 != 0)
     {
-        serr << "The number of values is not a multiple of 8 ; padding with zero(s)" << sendl;
+        msg_error() << "The number of values is not a multiple of 8 ; padding with zero(s)";
         while (temp.size() %8 != 0)
             temp.push_back(0.0);
         value.setValue(temp);
@@ -709,7 +709,7 @@ void OglMatrix3x4Variable::init()
 
     if (temp.size() %12 != 0)
     {
-        serr << "The number of values is not a multiple of 12 ; padding with zero(s)" << sendl;
+        msg_error() << "The number of values is not a multiple of 12 ; padding with zero(s)";
         while (temp.size() %12 != 0)
             temp.push_back(0.0);
         value.setValue(temp);
@@ -741,7 +741,7 @@ void OglMatrix4x3Variable::init()
 
     if (temp.size() %12 != 0)
     {
-        serr << "The number of values is not a multiple of 12 ; padding with zero(s)" << sendl;
+        msg_error() << "The number of values is not a multiple of 12 ; padding with zero(s)";
         while (temp.size() %12 != 0)
             temp.push_back(0.0);
         value.setValue(temp);
@@ -773,7 +773,7 @@ void OglMatrix4VectorVariable::initVisual()
     const unsigned int idShader = indexShader.getValue();
     const std::string& idstr = id.getValue();
     const helper::vector<defaulttype::Mat4x4f>& v = value.getValue();
-    //serr << "OglMatrix4VectorVariable::initVisual(), v = " << v << sendl;
+
     const float* vptr = v.empty() ? nullptr : &(v[0][0][0]);
     bool transp = transpose.getValue();
     for(std::set<OglShader*>::iterator it = shaders.begin(), iend = shaders.end(); it!=iend; ++it)

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/PostProcessManager.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/PostProcessManager.cpp
@@ -73,7 +73,7 @@ void PostProcessManager::init()
 
     if (!dofShader)
     {
-        serr << "PostProcessingManager: OglShader not found ; no post process applied."<< sendl;
+        msg_error() << "PostProcessingManager: OglShader not found ; no post process applied.";
         postProcessEnabled = false;
         return;
     }

--- a/modules/SofaPreconditioner/src/SofaPreconditioner/PrecomputedWarpPreconditioner.inl
+++ b/modules/SofaPreconditioner/src/SofaPreconditioner/PrecomputedWarpPreconditioner.inl
@@ -279,7 +279,7 @@ void PrecomputedWarpPreconditioner<TDataTypes>::loadMatrixWithSolver()
 
     if (mstate==nullptr)
     {
-        serr << "PrecomputedWarpPreconditioner can't find Mstate" << sendl;
+        msg_error() << "PrecomputedWarpPreconditioner can't find Mstate";
         return;
     }
 
@@ -322,7 +322,7 @@ void PrecomputedWarpPreconditioner<TDataTypes>::loadMatrixWithSolver()
     }
     else
     {
-        serr<<"PrecomputedContactCorrection must be associated with EulerImplicitSolver+LinearSolver for the precomputation\nNo Precomputation" << sendl;
+        msg_error() << "PrecomputedContactCorrection must be associated with EulerImplicitSolver+LinearSolver for the precomputation\nNo Precomputation";
         return;
     }
     sofa::core::VecDerivId lhId = core::VecDerivId::velocity();
@@ -530,7 +530,7 @@ void PrecomputedWarpPreconditioner<TDataTypes>::rotateConstraints()
     }
     else
     {
-        serr << "No rotation defined : use Identity !!";
+        msg_error() << "No rotation defined : use Identity !!";
         for(unsigned int k = 0; k < nb_dofs; k++)
         {
             R[k*9] = R[k*9+4] = R[k*9+8] = 1.0f;

--- a/modules/SofaPreconditioner/src/SofaPreconditioner/WarpPreconditioner.inl
+++ b/modules/SofaPreconditioner/src/SofaPreconditioner/WarpPreconditioner.inl
@@ -82,7 +82,9 @@ template<class TMatrix, class TVector,class ThreadManager>
 void WarpPreconditioner<TMatrix,TVector,ThreadManager >::bwdInit() {
     this->getContext()->get(realSolver, solverName.getValue());
 
-    if (realSolver==nullptr) serr << "Error the cannot find the solver " << solverName.getValue() << sendl;
+    if (realSolver == nullptr) {
+        msg_error() << "The cannot find the solver " << solverName.getValue();
+    }
 
     sofa::core::objectmodel::BaseContext * c = this->getContext();
     c->get<sofa::core::behavior::BaseRotationFinder >(&rotationFinders, sofa::core::objectmodel::BaseContext::Local);

--- a/modules/SofaUserInteraction/MechanicalStateController.inl
+++ b/modules/SofaUserInteraction/MechanicalStateController.inl
@@ -72,8 +72,8 @@ void MechanicalStateController<DataTypes>::init()
 {
     using core::behavior::MechanicalState;
     mState = dynamic_cast<MechanicalState<DataTypes> *> (this->getContext()->getMechanicalState());
-    if (!mState)
-        serr << "MechanicalStateController has no binding MechanicalState" << sendl;
+    
+    msg_error_when(!mState) << "MechanicalStateController has no binding MechanicalState";
     device = false;
 }
 

--- a/modules/SofaUserInteraction/RayModel.cpp
+++ b/modules/SofaUserInteraction/RayModel.cpp
@@ -77,7 +77,7 @@ void RayModel::init()
     mstate = dynamic_cast< core::behavior::MechanicalState<Vec3Types>* > (getContext()->getMechanicalState());
     if (mstate==nullptr)
     {
-        serr<<"RayModel requires a Vec3 Mechanical Model" << sendl;
+        msg_error() << "RayModel requires a Vec3 Mechanical Model";
         return;
     }
 

--- a/modules/SofaUserInteraction/SleepController.cpp
+++ b/modules/SofaUserInteraction/SleepController.cpp
@@ -161,8 +161,7 @@ void SleepController::init()
             }
         }
 
-        if (!found)
-            serr << "SleepController can not control node " << state->getContext()->getName() << " of type " << state->getClass()->templateName << sendl;
+        msg_error_when(!found) << "SleepController can not control node " << state->getContext()->getName() << " of type " << state->getClass()->templateName;
     }
 
     m_timeSinceWakeUp.assign(m_contextsThatCanSleep.size(), 0.0);

--- a/modules/SofaUserInteraction/SuturePointPerformer.inl
+++ b/modules/SofaUserInteraction/SuturePointPerformer.inl
@@ -55,7 +55,7 @@ void SuturePointPerformer<DataTypes>::start()
 
         if (picked.body == nullptr || CollisionModel == nullptr)
         {
-            this->interactor->serr << "Error: SuturePointPerformer no picked body in first clic." << this->interactor->sendl;
+            msg_error(this->interactor) << "No picked body in first clic.";
             return;
         }
 
@@ -69,7 +69,7 @@ void SuturePointPerformer<DataTypes>::start()
 
         if (picked.body == nullptr || CollisionModel == nullptr)
         {
-            this->interactor->serr << "Error: SuturePointPerformer no picked body in second clic." << this->interactor->sendl;
+            msg_error(this->interactor) << "No picked body in second clic.";
             return;
         }
 
@@ -85,22 +85,22 @@ void SuturePointPerformer<DataTypes>::start()
 
         if (!SpringObject)
         {
-            this->interactor->serr << "Error: can't find StiffSpringForceField." << this->interactor->sendl;
+            msg_error(this->interactor) << "Can't find StiffSpringForceField.";
             return;
         }
         else if (!triangleContainer)
         {
-            this->interactor->serr << "Error: can't find triangleContainer." << this->interactor->sendl;
+            msg_error(this->interactor) << "Can't find triangleContainer.";
             return;
         }
         else if (!MechanicalObject)
         {
-            this->interactor->serr << "Error: can't find MechanicalObject." << this->interactor->sendl;
+            msg_error(this->interactor) << "Can't find MechanicalObject.";
             return;
         }
         else if (!FixObject)
         {
-            this->interactor->serr << "Error: can't find FixObject." << this->interactor->sendl;
+            msg_error(this->interactor) << "Can't find FixObject.";
             return;
         }
 

--- a/modules/SofaValidation/CompareTopology.cpp
+++ b/modules/SofaValidation/CompareTopology.cpp
@@ -77,7 +77,7 @@ void CompareTopology::processCompareTopology()
 
     if (!topo)
     {
-        serr << "Error, compareTopology can't acces to the Topology." << sendl;
+        msg_error() << "CompareTopology can't acces to the Topology.";
         return;
     }
 

--- a/modules/SofaValidation/DevAngleCollisionMonitor.inl
+++ b/modules/SofaValidation/DevAngleCollisionMonitor.inl
@@ -46,7 +46,7 @@ void DevAngleCollisionMonitor<DataTypes>::init()
 {
     if (!this->mstate1 || !this->mstate2)
     {
-        serr << "DevAngleCollisionMonitor ERROR: mstate1 or mstate2 not found."<<sendl;
+        msg_error() << "Init: mstate1 or mstate2 not found.";
         return;
     }
 
@@ -54,14 +54,14 @@ void DevAngleCollisionMonitor<DataTypes>::init()
     c1->get(pointsCM, core::objectmodel::BaseContext::SearchDown);
     if (pointsCM == nullptr)
     {
-        serr << "DevAngleCollisionMonitor ERROR: object1 PointModel not found."<<sendl;
+        msg_error() << "Init: object1 PointModel not found.";
         return;
     }
     sofa::core::objectmodel::BaseContext* c2 = this->mstate2->getContext();
     c2->get(surfaceCM, core::objectmodel::BaseContext::SearchDown);
     if (surfaceCM == nullptr)
     {
-        serr << "DevAngleCollisionMonitor ERROR: object2 TriangleModel not found."<<sendl;
+        msg_error() << "Init: object2 TriangleModel not found.";
         return;
     }
 


### PR DESCRIPTION
Tried not to go too quickly....
- Replaced serr by msg_error/msg_warning and msg_info regarding the case.
- Remove all commented serr.
- Use stringstream to accumulate errors when inside a loop.

This PR only trigger classes in Sofa modules see #1237 for changes in SofaKernel

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
