### PR TITLE
[SofaKernel] replace all serr by msg_error/msg_warning

### DIFF
--- a/SofaKernel/modules/SofaBaseCollision/DefaultContactManager.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/DefaultContactManager.cpp
@@ -130,6 +130,7 @@ void DefaultContactManager::createContacts(const DetectionOutputMap& outputsMap)
     size_t nbContact = 0;
 
     // First iterate on the collision detection outputs and look for existing or new contacts
+    std::stringstream errorStream;
     for (DetectionOutputMap::const_iterator outputsIt = outputsMap.begin(),
         outputsItEnd = outputsMap.end(); outputsIt != outputsItEnd ; ++outputsIt)
     {
@@ -161,21 +162,21 @@ void DefaultContactManager::createContacts(const DetectionOutputMap& outputsMap)
                         std::make_pair(model1class, model2class))];
                     if (count <= 10)
                     {
-                        msg_error() << "Contact " << responseUsed << " between " << model1->getClassName()
-                                    << " and " << model2->getClassName() << " creation failed";
+                        errorStream << "Contact " << responseUsed << " between " << model1->getClassName()
+                            << " and " << model2->getClassName() << " creation failed \n";
                         if (count == 1)
                         {
-                            msg_error()<< "Supported models for contact " << responseUsed << ":";
+                            errorStream << "Supported models for contact " << responseUsed << ":\n";
                             for (Contact::Factory::const_iterator it =
                                 Contact::Factory::getInstance()->begin(),
                                 itend = Contact::Factory::getInstance()->end(); it != itend; ++it)
                             {
                                 if (it->first != responseUsed) continue;
-                                msg_error() << "   " << helper::gettypename(it->second->type());
+                                errorStream << "   " << helper::gettypename(it->second->type()) << "\n";
                             }
-                            msg_error() << "error..."; // was previously "serr << sendl", no idea why ??;
+                            errorStream << "\n";
                         }
-                        if (count == 10) msg_error() << "further messages suppressed";
+                        if (count == 10) errorStream << "further messages suppressed.\n";
                     }
                     contactMap.erase(contactIt);
                 }
@@ -198,6 +199,8 @@ void DefaultContactManager::createContacts(const DetectionOutputMap& outputsMap)
             ++nbContact;
         }
     }
+
+    msg_error_when(!errorStream.str().empty()) << errorStream.str();
 
     // Then look at previous contacts
     // and remove inactive contacts

--- a/SofaKernel/modules/SofaBaseLinearSolver/CompressedRowSparseMatrix.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/CompressedRowSparseMatrix.h
@@ -704,7 +704,7 @@ public:
 #ifdef SPARSEMATRIX_CHECK
         if (i >= rowSize() || j >= colSize())
         {
-            std::cerr << "ERROR: invalid read access to element ("<<i<<","<<j<<") in "<</* this->Name() <<*/" of size ("<<rowSize()<<","<<colSize()<<")"<<std::endl;
+            msg_error() << "Invalid read access to element (" << i << "," << j << ") in " <</* this->Name() <<*/" of size (" << rowSize() << "," << colSize() << ")";
             return 0.0;
         }
 #endif
@@ -716,19 +716,19 @@ public:
     void set(Index i, Index j, double v) override
     {
         dmsg_info_when(EMIT_EXTRA_MESSAGE)
-                << "("<<rowSize()<<","<<colSize()<<"): element("<<i<<","<<j<<") = "<<v ;
+            << "(" << rowSize() << "," << colSize() << "): element(" << i << "," << j << ") = " << v;
 
 #ifdef SPARSEMATRIX_CHECK
         if (i >= rowSize() || j >= colSize())
         {
-            std::cerr << "ERROR: invalid write access to element ("<<i<<","<<j<<") in "<</* this->Name() <<*/" of size ("<<rowSize()<<","<<colSize()<<")"<<std::endl;
+            msg_error() << "Invalid write access to element (" << i << "," << j << ") in " <</* this->Name() <<*/" of size (" << rowSize() << "," << colSize() << ")";
             return;
         }
 #endif
         Index bi=0, bj=0; split_row_index(i, bi); split_col_index(j, bj);
 
         dmsg_info_when(EMIT_EXTRA_MESSAGE)
-                << "("<<rowBSize()<<"*"<<NL<<","<<colBSize()<<"*"<<NC<<"): bloc("<<i<<","<<j<<")["<<bi<<","<<bj<<"] = "<<v ;
+            << "(" << rowBSize() << "*" << NL << "," << colBSize() << "*" << NC << "): bloc(" << i << "," << j << ")[" << bi << "," << bj << "] = " << v;
 
         traits::v(*wbloc(i,j,true), bi, bj) = (Real)v;
     }
@@ -736,19 +736,19 @@ public:
     void add(Index i, Index j, double v) override
     {
         dmsg_info_when(EMIT_EXTRA_MESSAGE)
-                << "("<<rowSize()<<","<<colSize()<<"): element("<<i<<","<<j<<") += "<<v ;
+            << "(" << rowSize() << "," << colSize() << "): element(" << i << "," << j << ") += " << v;
 
 #ifdef SPARSEMATRIX_CHECK
         if (i >= rowSize() || j >= colSize())
         {
-            std::cerr << "ERROR: invalid write access to element ("<<i<<","<<j<<") in "<</* this->Name() <<*/" of size ("<<rowSize()<<","<<colSize()<<")"<<std::endl;
+            msg_error() << "Invalid write access to element (" << i << "," << j << ") in " <</* this->Name() <<*/" of size (" << rowSize() << "," << colSize() << ")";
             return;
         }
 #endif
         Index bi=0, bj=0; split_row_index(i, bi); split_col_index(j, bj);
 
         dmsg_info_when(EMIT_EXTRA_MESSAGE)
-                << "("<<rowBSize()<<"*"<<NL<<","<<colBSize()<<"*"<<NC<<"): bloc("<<i<<","<<j<<")["<<bi<<","<<bj<<"] += "<<v ;
+            << "(" << rowBSize() << "*" << NL << "," << colBSize() << "*" << NC << "): bloc(" << i << "," << j << ")[" << bi << "," << bj << "] += " << v;
 
         traits::v(*wbloc(i,j,true), bi, bj) += (Real)v;
     }
@@ -761,7 +761,7 @@ public:
 #ifdef SPARSEMATRIX_CHECK
         if (i >= rowSize() || j >= colSize())
         {
-            std::cerr << "ERROR: invalid write access to element ("<<i<<","<<j<<") in "<</* this->Name() <<*/" of size ("<<rowSize()<<","<<colSize()<<")"<<std::endl;
+            msg_error() << "Invalid write access to element (" << i << "," << j << ") in " <</* this->Name() <<*/" of size (" << rowSize() << "," << colSize() << ")";
             return;
         }
 #endif
@@ -775,12 +775,12 @@ public:
     void clearRow(Index i) override
     {
         dmsg_info_when(EMIT_EXTRA_MESSAGE)
-                << "("<<rowSize()<<","<<colSize()<<"): row("<<i<<") = 0" ;
+            << "(" << rowSize() << "," << colSize() << "): row(" << i << ") = 0";
 
 #ifdef SPARSEMATRIX_CHECK
         if (i >= rowSize())
         {
-            std::cerr << "ERROR: invalid write access to row "<<i<<" in "<</* this->Name() <<*/" of size ("<<rowSize()<<","<<colSize()<<")"<<std::endl;
+            msg_error() << "Invalid write access to row " << i << " in " <</* this->Name() <<*/" of size (" << rowSize() << "," << colSize() << ")";
             return;
         }
 #endif
@@ -802,12 +802,12 @@ public:
     void clearCol(Index j) override
     {
         dmsg_info_when(EMIT_EXTRA_MESSAGE)
-                << "("<<rowSize()<<","<<colSize()<<"): col("<<j<<") = 0" ;
+            << "(" << rowSize() << "," << colSize() << "): col(" << j << ") = 0";
 
 #ifdef SPARSEMATRIX_CHECK
         if (j >= colSize())
         {
-            std::cerr << "ERROR: invalid write access to column "<<j<<" in "<</* this->Name() <<*/" of size ("<<rowSize()<<","<<colSize()<<")"<<std::endl;
+            msg_error() << "Invalid write access to column " << j << " in " <</* this->Name() <<*/" of size (" << rowSize() << "," << colSize() << ")";
             return;
         }
 #endif
@@ -827,12 +827,12 @@ public:
     void clearRowCol(Index i) override
     {
         dmsg_info_when(EMIT_EXTRA_MESSAGE)
-                << "("<<rowSize()<<","<<colSize()<<"): row("<<i<<") = 0 and col("<<i<<") = 0" ;
+            << "(" << rowSize() << "," << colSize() << "): row(" << i << ") = 0 and col(" << i << ") = 0";
 
 #ifdef SPARSEMATRIX_CHECK
         if (i >= rowSize() || i >= colSize())
         {
-            std::cerr << "ERROR: invalid write access to row and column "<<i<<" in "<</* this->Name() <<*/" of size ("<<rowSize()<<","<<colSize()<<")"<<std::endl;
+            msg_error() << "Invalid write access to row and column " << i << " in " <</* this->Name() <<*/" of size (" << rowSize() << "," << colSize() << ")";
             return;
         }
 #endif

--- a/SofaKernel/modules/SofaBaseLinearSolver/FullMatrix.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/FullMatrix.h
@@ -148,7 +148,7 @@ public:
             {
                 if (nbRow*nbCol > -allocsize)
                 {
-                    std::cerr << "ERROR: cannot resize preallocated matrix to size ("<<nbRow<<","<<nbCol<<")"<<std::endl;
+                    msg_error() << "Cannot resize preallocated matrix to size (" << nbRow << "," << nbCol << ")";
                     return;
                 }
             }
@@ -185,7 +185,7 @@ public:
 #ifdef FULLMATRIX_CHECK
         if (i >= rowSize() || j >= colSize())
         {
-            std::cerr << "ERROR: invalid read access to element ("<<i<<","<<j<<") in "<</*this->Name()<<*/" of size ("<<rowSize()<<","<<colSize()<<")"<<std::endl;
+            msg_error() << "Invalid read access to element (" << i << "," << j << ") in " <</*this->Name()<<*/" of size (" << rowSize() << "," << colSize() << ")";
             return 0.0;
         }
 #endif
@@ -200,7 +200,7 @@ public:
 #ifdef FULLMATRIX_CHECK
         if (i >= rowSize() || j >= colSize())
         {
-            std::cerr << "ERROR: invalid write access to element ("<<i<<","<<j<<") in "<</*this->Name()<<*/" of size ("<<rowSize()<<","<<colSize()<<")"<<std::endl;
+            msg_error() << "Invalid write access to element (" << i << "," << j << ") in " <</*this->Name()<<*/" of size (" << rowSize() << "," << colSize() << ")";
             return;
         }
 #endif
@@ -215,7 +215,7 @@ public:
 #ifdef FULLMATRIX_CHECK
         if (i >= rowSize() || j >= colSize())
         {
-            std::cerr << "ERROR: invalid write access to element ("<<i<<","<<j<<") in "/*<<this->Name()*/<<" of size ("<<rowSize()<<","<<colSize()<<")"<<std::endl;
+            msg_error() << "Invalid write access to element (" << i << "," << j << ") in "/*<<this->Name()*/ << " of size (" << rowSize() << "," << colSize() << ")";
             return;
         }
 #endif
@@ -230,7 +230,7 @@ public:
 #ifdef FULLMATRIX_CHECK
         if (i >= rowSize() || j >= colSize())
         {
-            std::cerr << "ERROR: invalid write access to element ("<<i<<","<<j<<") in "<</*this->Name()<<*/" of size ("<<rowSize()<<","<<colSize()<<")"<<std::endl;
+            msg_error() << "Invalid write access to element (" << i << "," << j << ") in " <</*this->Name()<<*/" of size (" << rowSize() << "," << colSize() << ")";
             return;
         }
 #endif
@@ -245,7 +245,7 @@ public:
 #ifdef FULLMATRIX_CHECK
         if (i >= rowSize())
         {
-            std::cerr << "ERROR: invalid write access to row "<<i<<" in "<</*this->Name()<<*/" of size ("<<rowSize()<<","<<colSize()<<")"<<std::endl;
+            msg_error() << "Invalid write access to row " << i << " in " <</*this->Name()<<*/" of size (" << rowSize() << "," << colSize() << ")";
             return;
         }
 #endif
@@ -261,7 +261,7 @@ public:
 #ifdef FULLMATRIX_CHECK
         if (j >= colSize())
         {
-            std::cerr << "ERROR: invalid write access to column "<<j<<" in "<</*this->Name()<<*/" of size ("<<rowSize()<<","<<colSize()<<")"<<std::endl;
+            msg_error() << "Invalid write access to column " << j << " in " <</*this->Name()<<*/" of size (" << rowSize() << "," << colSize() << ")";
             return;
         }
 #endif
@@ -277,7 +277,7 @@ public:
 #ifdef FULLMATRIX_CHECK
         if (i >= rowSize() || i >= colSize())
         {
-            std::cerr << "ERROR: invalid write access to row and column "<<i<<" in "<</*this->Name()<<*/" of size ("<<rowSize()<<","<<colSize()<<")"<<std::endl;
+            msg_error() << "Invalid write access to row and column " << i << " in " <</*this->Name()<<*/" of size (" << rowSize() << "," << colSize() << ")";
             return;
         }
 #endif

--- a/SofaKernel/modules/SofaBaseLinearSolver/SingleMatrixAccessor.cpp
+++ b/SofaKernel/modules/SofaBaseLinearSolver/SingleMatrixAccessor.cpp
@@ -51,7 +51,6 @@ SingleMatrixAccessor::InteractionMatrixRef SingleMatrixAccessor::getMatrix(const
 
 SingleMatrixAccessor::MatrixRef SingleMatrixAccessor::getMatrix(const core::behavior::BaseMechanicalState*) const
 {
-//    cerr<<"SingleMatrixAccessor::getMatrix" << endl;
     return matRef;
 }
 

--- a/SofaKernel/modules/SofaBaseTopology/TopologyDataHandler.inl
+++ b/SofaKernel/modules/SofaBaseTopology/TopologyDataHandler.inl
@@ -60,11 +60,11 @@ void TopologyDataHandler <TopologyElementType, VecT>::add(const sofa::helper::ve
     unsigned int i0 = (unsigned)data.size();
     if (i0 != index[0])
     {
-        this->m_topologyData->getOwner()->serr << "TopologyDataHandler SIZE MISMATCH in Data "
+        msg_error(this->m_topologyData->getOwner()) << "TopologyDataHandler SIZE MISMATCH in Data "
             << this->m_topologyData->getName() << ": " << nbElements << " "
             << core::topology::TopologyElementInfo<TopologyElementType>::name()
             << " ADDED starting from index " << index[0]
-            << " while vector size is " << i0 << this->m_topologyData->getOwner()->sendl;
+            << " while vector size is " << i0;
         i0 = index[0];
     }
     data.resize(i0+nbElements);

--- a/SofaKernel/modules/SofaBaseVisual/BaseCamera.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/BaseCamera.cpp
@@ -585,15 +585,15 @@ void BaseCamera::computeZ()
     {
         if (p_zNear.getValue() >= p_zFar.getValue())
         {
-            serr << "ZNear > ZFar !" << sendl;
+            msg_error() << "ZNear > ZFar !";
         }
         else if (p_zNear.getValue() <= 0.0)
         {
-            serr << "ZNear is negative!" << sendl;
+            msg_error() << "ZNear is negative!";
         }
         else if (p_zFar.getValue() <= 0.0)
         {
-            serr << "ZFar is negative!" << sendl;
+            msg_error() << "ZFar is negative!";
         }
         else
         {
@@ -732,24 +732,24 @@ bool BaseCameraXMLImportSingleParameter(TiXmlElement* root, core::objectmodel::B
                     std::string m_string; m_string.assign(attrValue);
                     bool retvalue = data.read(m_string);
                     if(!retvalue)
-                        c->serr << "Unreadable value for " << data.getName() << " field." << c->sendl;
+                        msg_error(c) << "Unreadable value for " << data.getName() << " field.";
                     return retvalue;
                 }
                 else
                 {
-                    c->serr << "Attribute value has not been found for " << data.getName() << " field." << c->sendl;
+                    msg_error(c) << "Attribute value has not been found for " << data.getName() << " field.";
                     return false;
                 }
             }
             else
             {
-                c->serr << "Unknown error occured for " << data.getName() << " field." << c->sendl;
+                msg_error(c) << "Unknown error occured for " << data.getName() << " field.";
                 return false;
             }
         }
         else
         {
-            c->serr << "Field " << data.getName() << " has not been found." << c->sendl;
+            msg_error(c) << "Field " << data.getName() << " has not been found.";
             return false;
         }
     }
@@ -760,7 +760,7 @@ bool BaseCamera::importParametersFromFile(const std::string& viewFilename)
 {
     bool result = true;
 
-    sout << "Reading " << viewFilename << " for view parameters." << sendl;
+    msg_info() << "Reading " << viewFilename << " for view parameters.";
     TiXmlDocument doc(viewFilename.c_str());
     if (!doc.LoadFile())
     {
@@ -788,7 +788,7 @@ bool BaseCamera::importParametersFromFile(const std::string& viewFilename)
     }
     else
     {
-        sout << "Error while reading " << viewFilename << "." << sendl;
+        msg_info() << "Error while reading " << viewFilename << ".";
     }
     return result;
 }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/Mapping.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/Mapping.h
@@ -152,7 +152,7 @@ public:
     /// This method must be reimplemented by all mappings if they need to support constraints.
     virtual void applyJT( const ConstraintParams* /* mparams */, InDataMatrixDeriv& /* out */, const OutDataMatrixDeriv& /* in */)
     {
-        serr << "This mapping does not support certain constraints because Mapping::applyJT( const ConstraintParams* , InDataMatrixDeriv&, const OutDataMatrixDeriv&) is not overloaded." << sendl;
+        msg_error() << "This mapping does not support certain constraints because Mapping::applyJT( const ConstraintParams* , InDataMatrixDeriv&, const OutDataMatrixDeriv&) is not overloaded.";
     }
 
     /// computeAccFromMapping
@@ -228,8 +228,8 @@ public:
         if (static_cast<BaseObject*>(stin) == static_cast<BaseObject*>(stout))
         {
             // we should refuse to create mappings with the same input and output model, which may happen if a State object is missing in the child node
-            context->serr << "Creation of " << className(obj) << " mapping failed because the same object \"" << stin->getName() << "\" is linked as both input and output." << context->sendl;
-            context->serr << "  Maybe a MechanicalObject should be added before this mapping." << context->sendl;
+            msg_error(context) << "Creation of " << className(obj) << " mapping failed because the same object \"" << stin->getName() << "\" is linked as both input and output.";
+            msg_error(context) << "  Maybe a MechanicalObject should be added before this mapping.";
             return false;
         }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/Mapping.inl
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/Mapping.inl
@@ -265,7 +265,7 @@ bool Mapping<In,Out>::setFrom(BaseState* from)
     State<In>* in = dynamic_cast< State<In>* >(from);
     if( !in )
     {
-        serr<<"setFrom "<<from->getName()<<" should be of type "<<State<In>::template typeName< State<In> >()<<sendl;
+        msg_error() << "setFrom " << from->getName() << " should be of type " << State<In>::template typeName< State<In> >();
         return false;
     }
 
@@ -281,7 +281,7 @@ bool Mapping<In,Out>::setTo(BaseState* to)
     State<Out>* out = dynamic_cast< State<Out>* >(to);
     if( !out )
     {
-        serr<<"setTo "<<to->getName()<<" should be of type "<<State<Out>::template typeName< State<Out> >()<<sendl;
+        msg_error() << "setTo " << to->getName() << " should be of type " << State<Out>::template typeName< State<Out> >();
         return false;
     }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/Multi2Mapping.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/Multi2Mapping.h
@@ -195,7 +195,7 @@ public:
         const helper::vector< In2DataMatrixDeriv*>&  /* dataMatOut2Const */,
         const helper::vector<const OutDataMatrixDeriv*>& /* dataMatInConst */)
     {
-        serr << "This mapping does not support constraint because Multi2Mapping::applyJT(const ConstraintParams*, const helper::vector< In1DataMatrixDeriv*>&, const helper::vector< In2DataMatrixDeriv*>&, const helper::vector<const OutDataMatrixDeriv*>&) is not overloaded." << sendl;
+        msg_error() << "This mapping does not support constraint because Multi2Mapping::applyJT(const ConstraintParams*, const helper::vector< In1DataMatrixDeriv*>&, const helper::vector< In2DataMatrixDeriv*>&, const helper::vector<const OutDataMatrixDeriv*>&) is not overloaded.";
     }
 
     /// computeAccFromMapping

--- a/SofaKernel/modules/SofaCore/src/sofa/core/MultiMapping.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/MultiMapping.h
@@ -153,7 +153,7 @@ public:
     /// This method must be reimplemented by all mappings if they need to support constraints.
     virtual void applyJT( const ConstraintParams* /* cparams */, const helper::vector< InDataMatrixDeriv* >& /* dataMatOutConst */, const helper::vector< const OutDataMatrixDeriv* >& /* dataMatInConst */ )
     {
-        serr << "This mapping does not support certain constraints since MultiMapping::applyJT( const ConstraintParams*, const helper::vector< InDataMatrixDeriv* >& , const helper::vector< const OutDataMatrixDeriv* >&  ) is not overloaded" << sendl;
+        msg_error() << "This mapping does not support certain constraints since MultiMapping::applyJT( const ConstraintParams*, const helper::vector< InDataMatrixDeriv* >& , const helper::vector< const OutDataMatrixDeriv* >&  ) is not overloaded";
     }
 
     /// computeAccFromMapping

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseInteractionForceField.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseInteractionForceField.h
@@ -59,18 +59,18 @@ public:
 
     void addKToMatrix(const MechanicalParams* /* mparams */, const sofa::core::behavior::MultiMatrixAccessor* /* matrix */ ) override
     {
-        serr << "ERROR("<<getClassName()<<"): addKToMatrix not implemented." << sendl;
+        msg_error() << "addKToMatrix not implemented.";
     }
 
 
     /// initialization to export potential energy to gnuplot files format
     virtual void initGnuplot(const std::string path){
-        sout << path << std::endl << "Warning ::: initGnuplot not implemented for all interaction force field" << sendl;
+        msg_warning() << path << msgendl << "initGnuplot not implemented for all interaction force field";
     }
 
     /// export kinetic and potential energy state at "time" to a gnuplot file
     virtual void exportGnuplot(SReal time){
-        sout << time << std::endl << "Warning ::: exportGnuplot not implemented for all interaction force field" << sendl;
+        msg_warning() << time << msgendl << "exportGnuplot not implemented for all interaction force field";
     }
 
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseMechanicalState.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseMechanicalState.h
@@ -244,7 +244,10 @@ public:
 
     /// Compute the error given a state vector and a line of the Jacobian (line in vector C)
     virtual SReal getConstraintJacobianTimesVecDeriv( unsigned int /*line*/, ConstVecId /*id*/)
-    {  this->serr << "NOT IMPLEMENTED YET" << this->sendl; return (SReal)0;  }
+    {  
+        msg_error() << "getConstraintJacobianTimesVecDeriv not implemented yet.";
+        return SReal(0.0);
+    }
 
     /// @}
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseProjectiveConstraintSet.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseProjectiveConstraintSet.h
@@ -111,7 +111,10 @@ public:
       Typically, M is the (generalized) mass matrix of the whole system, offset is the starting index of the local state in this global matrix, and P is the identity matrix with a block on the diagonal replaced by the projection matrix.
       If M is the matrix of the local state, then offset should be 0.
       */
-    virtual void projectMatrix( sofa::defaulttype::BaseMatrix* /*M*/, unsigned /*offset*/ ) { serr<<"projectMatrix not implemented, projection will not be handled appropriately"<<sendl; }
+    virtual void projectMatrix( sofa::defaulttype::BaseMatrix* /*M*/, unsigned /*offset*/ ) 
+    { 
+        msg_error() << "projectMatrix not implemented, projection will not be handled appropriately";
+    }
 
     /// @}
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/LinearSolver.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/LinearSolver.h
@@ -105,10 +105,10 @@ public:
     virtual void solveSystem() = 0;
 
     ///
-    virtual void init_partial_solve() {serr<<"WARNING : partial_solve is not implemented yet"<<sendl; }
+    virtual void init_partial_solve() { msg_warning() << "partial_solve is not implemented yet."; }
 
     ///
-    virtual void partial_solve(std::list<int>& /*I_last_Disp*/, std::list<int>& /*I_last_Dforce*/, bool /*NewIn*/) {serr<<"WARNING : partial_solve is not implemented yet"<<sendl; }
+    virtual void partial_solve(std::list<int>& /*I_last_Disp*/, std::list<int>& /*I_last_Dforce*/, bool /*NewIn*/) { msg_warning() << "partial_solve is not implemented yet"; }
 
     /// Invert the system, this method is optional because it's called when solveSystem() is called for the first time
     virtual void invertSystem() {}
@@ -139,20 +139,20 @@ public:
         SOFA_UNUSED(cparams);
         SOFA_UNUSED(result);
         SOFA_UNUSED(fact);
-        serr << "Error buildComplianceMatrix has not been implemented" << sendl;
+        msg_error() << "buildComplianceMatrix has not been implemented.";
         return false;
     }
 
     /// Apply the contactforce dx = Minv * J^t * f and store the resut in dx VecId
     virtual void applyConstraintForce(const sofa::core::ConstraintParams* /*cparams*/,sofa::core::MultiVecDerivId /*dx*/, const defaulttype::BaseVector* /*f*/) {
-        serr << "Error applyConstraintForce has not been implemented" << sendl;
+        msg_error() << "applyConstraintForce has not been implemented.";
     }
 
     /// Compute the residual in the newton iterations due to the constraints forces
     /// i.e. compute mparams->dF() = J^t lambda
     /// the result is written in mparams->dF()
     virtual void computeResidual(const core::ExecParams* /*params*/, defaulttype::BaseVector* /*f*/) {
-        serr << "Error computeResidual has not been implemented" << sendl;
+        msg_error() << "computeResidual has not been implemented.";
     }
 
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/Mass.inl
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/Mass.inl
@@ -68,7 +68,7 @@ void Mass<DataTypes>::addMDx(const MechanicalParams* mparams, MultiVecDerivId fi
 template<class DataTypes>
 void Mass<DataTypes>::addMDx(const MechanicalParams* /*mparams*/, DataVecDeriv& /*f*/, const DataVecDeriv& /*dx*/ , SReal /*factor*/ )
 {
-    msg_error()<< getClassName()<< ": addMDx(const MechanicalParams* , DataVecDeriv& , const DataVecDeriv&  , SReal  ) not implemented.";
+    msg_warning() << "Method addMDx(const MechanicalParams* , DataVecDeriv& , const DataVecDeriv&  , SReal  ) not implemented.";
 }
 
 
@@ -85,7 +85,7 @@ void Mass<DataTypes>::accFromF(const MechanicalParams* mparams, MultiVecDerivId 
 template<class DataTypes>
 void Mass<DataTypes>::accFromF(const MechanicalParams* /*mparams*/, DataVecDeriv& /*a*/, const DataVecDeriv& /*f*/)
 {
-    msg_error()<<getClassName()<<": accFromF(const MechanicalParams* , DataVecDeriv& , const DataVecDeriv& ) not implemented.";
+    msg_warning() << "Method accFromF(const MechanicalParams* , DataVecDeriv& , const DataVecDeriv& ) not implemented.";
 }
 
 
@@ -125,7 +125,7 @@ SReal Mass<DataTypes>::getKineticEnergy(const MechanicalParams* mparams) const
 template<class DataTypes>
 SReal Mass<DataTypes>::getKineticEnergy(const MechanicalParams* /*mparams*/, const DataVecDeriv& /*v*/) const
 {
-    msg_error() <<getClassName()<<": getKineticEnergy(const MechanicalParams*, const DataVecDeriv& ) not implemented.";
+    msg_warning() << "Method getKineticEnergy(const MechanicalParams*, const DataVecDeriv& ) not implemented.";
     return 0.0;
 }
 
@@ -141,7 +141,7 @@ SReal Mass<DataTypes>::getPotentialEnergy(const MechanicalParams* mparams) const
 template<class DataTypes>
 SReal Mass<DataTypes>::getPotentialEnergy(const MechanicalParams* /*mparams*/, const DataVecCoord& /*x*/) const
 {
-    msg_error() << getClassName()<<": getPotentialEnergy( const MechanicalParams*, const DataVecCoord& ) not implemented.";
+    msg_warning() << "Method getPotentialEnergy( const MechanicalParams*, const DataVecCoord& ) not implemented.";
     return 0.0;
 }
 
@@ -157,7 +157,7 @@ defaulttype::Vector6 Mass<DataTypes>::getMomentum( const MechanicalParams* mpara
 template<class DataTypes>
 defaulttype::Vector6 Mass<DataTypes>::getMomentum( const MechanicalParams* /*mparams*/, const DataVecCoord& /*x*/, const DataVecDeriv& /*v*/ ) const
 {
-    msg_error() << getClassName()<<": getMomentum( const MechanicalParams*, const DataVecCoord&, const DataVecDeriv& ) not implemented.";
+    msg_warning() << "Method getMomentum( const MechanicalParams*, const DataVecCoord&, const DataVecDeriv& ) not implemented.";
     return defaulttype::Vector6();
 }
 
@@ -176,7 +176,7 @@ void Mass<DataTypes>::addMToMatrix(sofa::defaulttype::BaseMatrix * /*mat*/, SRea
 {
     static int i=0;
     if (i < 10) {
-        msg_error() <<getClassName()<<": addMToMatrix not implemented.";
+        msg_warning() << "Method addMToMatrix with Scalar not implemented";
         i++;
     }
 }
@@ -209,7 +209,7 @@ void Mass<DataTypes>::addGravityToV(const MechanicalParams* /* mparams */, DataV
 {
     static int i=0;
     if (i < 10) {
-        msg_error() <<getClassName()<<": addGravityToV not implemented.";
+        msg_warning() << "Method addGravityToV with Scalar not implemented";
         i++;
     }
 }
@@ -242,7 +242,7 @@ void Mass<DataTypes>::exportGnuplot(const MechanicalParams* mparams, SReal time)
 template <class DataTypes>
 SReal Mass<DataTypes>::getElementMass(unsigned int ) const
 {
-    msg_error() <<getClassName()<<": getElementMass with Scalar not implemented";
+    msg_warning() << "Method getElementMass with Scalar not implemented";
     return 0.0;
 }
 
@@ -253,7 +253,7 @@ void Mass<DataTypes>::getElementMass(unsigned int , defaulttype::BaseMatrix *m) 
     if (m->rowSize() != dimension || m->colSize() != dimension) m->resize(dimension,dimension);
 
     m->clear();
-     msg_error()<<getClassName()<<": getElementMass with Matrix not implemented";
+    msg_warning() << "Method getElementMass with Matrix not implemented";
 }
 
 } // namespace behavior

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/OdeSolver.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/OdeSolver.h
@@ -71,7 +71,7 @@ public:
     ///
     /// Specify and execute all computation for timestep integration, i.e.
     /// advancing the state from time t to t+dt, putting the resulting position and velocity in the provided vectors.
-    virtual void solve(const core::ExecParams* /*params*/, SReal /*dt*/, MultiVecCoordId /*xResult*/, MultiVecDerivId /*vResult*/) = 0; // { serr << "ERROR: " << getClassName() << " don't implement solve on custom x and v" << sendl; }
+    virtual void solve(const core::ExecParams* /*params*/, SReal /*dt*/, MultiVecCoordId /*xResult*/, MultiVecDerivId /*vResult*/) = 0;
 
     /// Main computation method.
     ///
@@ -84,7 +84,7 @@ public:
     ///
     /// pos_t and vel_t are the position and velocities at the begining of the time step
     /// the result is accumulated in Vecid::force()
-    virtual void computeResidual(const core::ExecParams* /*params*/, SReal /*dt*/, sofa::core::MultiVecCoordId /*pos_t*/, sofa::core::MultiVecDerivId /*vel_t*/) { serr << "ComputeResidual is not implemented in " << this->getName() << sendl; }
+    virtual void computeResidual(const core::ExecParams* /*params*/, SReal /*dt*/, sofa::core::MultiVecCoordId /*pos_t*/, sofa::core::MultiVecDerivId /*vel_t*/) { msg_error() << "ComputeResidual is not implemented in " << this->getName(); }
 
 
     /// Given an input derivative order (0 for position, 1 for velocity, 2 for acceleration),
@@ -104,13 +104,13 @@ public:
     /// The last column is returned by the getSolutionIntegrationFactor method.
     ///
     /// FF: What is the meaning of the parameters ?
-    virtual double getIntegrationFactor(int /*inputDerivative*/, int /*outputDerivative*/) const { serr<<"getIntegrationFactor not implemented !"<<sendl; return 0; }
+    virtual double getIntegrationFactor(int /*inputDerivative*/, int /*outputDerivative*/) const { msg_error() << "getIntegrationFactor not implemented !"; return 0; }
 
     /// Given a solution of the linear system,
     /// how much will it affect the output derivative of the given order.
     ///
     /// FF: What is the meaning of the parameters ?
-    virtual double getSolutionIntegrationFactor(int /*outputDerivative*/) const { serr<<"getSolutionIntegrationFactor not implemented !"<<sendl; return 0; }
+    virtual double getSolutionIntegrationFactor(int /*outputDerivative*/) const { msg_error() << "getSolutionIntegrationFactor not implemented !"; return 0; }
 
 
     /// Given the solution dx of the linear system inversion, how much will it affect the velocity

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/PairInteractionForceField.inl
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/PairInteractionForceField.inl
@@ -61,7 +61,7 @@ void PairInteractionForceField<DataTypes>::init()
 
     if (mstate1.get() == nullptr || mstate2.get() == nullptr)
     {
-        serr<< "Init of PairInteractionForceField " << getContext()->getName() << " failed!" << sendl;
+        msg_error() << "Init of PairInteractionForceField " << getContext()->getName() << " failed!";
         //getContext()->removeObject(this);
         return;
     }
@@ -73,14 +73,14 @@ void PairInteractionForceField<DataTypes>::addForce(const MechanicalParams* mpar
 {
     if (mstate1 && mstate2)
     {
-            addForce( mparams, *fId[mstate1.get(mparams)].write()   , *fId[mstate2.get(mparams)].write()   ,
-                    *mparams->readX(mstate1), *mparams->readX(mstate2),
-                    *mparams->readV(mstate1), *mparams->readV(mstate2) );
+        addForce(mparams, *fId[mstate1.get(mparams)].write(), *fId[mstate2.get(mparams)].write(),
+            *mparams->readX(mstate1), *mparams->readX(mstate2),
+            *mparams->readV(mstate1), *mparams->readV(mstate2));
 
         updateForceMask();
     }
     else
-        serr<<"PairInteractionForceField<DataTypes>::addForce(const MechanicalParams* /*mparams*/, MultiVecDerivId /*fId*/ ), mstate missing"<<sendl;
+        msg_error() << "PairInteractionForceField<DataTypes>::addForce(const MechanicalParams* /*mparams*/, MultiVecDerivId /*fId*/ ), mstate missing";
 }
 
 template<class DataTypes>
@@ -88,12 +88,12 @@ void PairInteractionForceField<DataTypes>::addDForce(const MechanicalParams* mpa
 {
     if (mstate1 && mstate2)
     {
-            addDForce(
-                mparams, *dfId[mstate1.get(mparams)].write()    , *dfId[mstate2.get(mparams)].write()   ,
-                *mparams->readDx(mstate1) , *mparams->readDx(mstate2) );
+        addDForce(
+            mparams, *dfId[mstate1.get(mparams)].write(), *dfId[mstate2.get(mparams)].write(),
+            *mparams->readDx(mstate1), *mparams->readDx(mstate2));
     }
     else
-        serr<<"PairInteractionForceField<DataTypes>::addDForce(const MechanicalParams* /*mparams*/, MultiVecDerivId /*fId*/ ), mstate missing"<<sendl;
+        msg_error() << "PairInteractionForceField<DataTypes>::addDForce(const MechanicalParams* /*mparams*/, MultiVecDerivId /*fId*/ ), mstate missing";
 }
 
 template<class DataTypes>

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ProjectiveConstraintSet.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ProjectiveConstraintSet.h
@@ -149,14 +149,14 @@ public:
     /// Project the global Mechanical Matrix to constrained space using offset parameter
     void applyConstraint(const MechanicalParams* /*mparams*/, const sofa::core::behavior::MultiMatrixAccessor* /*matrix*/) override
     {
-        serr << "applyConstraint(mparams, matrix) not implemented" << sendl;
+        msg_error() << "applyConstraint(mparams, matrix) not implemented.";
     }
 
 
     /// Project the global Mechanical Vector to constrained space using offset parameter
     void applyConstraint(const MechanicalParams* /*mparams*/, defaulttype::BaseVector* /*vector*/, const sofa::core::behavior::MultiMatrixAccessor* /*matrix*/) override
     {
-        serr << "applyConstraint(mparams, vector, matrix) not implemented" << sendl;
+        msg_error() << "applyConstraint(mparams, vector, matrix) not implemented.";
     }
 
     /// Pre-construction check method called by ObjectFactory.

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ProjectiveConstraintSet.inl
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ProjectiveConstraintSet.inl
@@ -59,7 +59,7 @@ void ProjectiveConstraintSet<DataTypes>::init()
 {
     BaseProjectiveConstraintSet::init();
     mstate = dynamic_cast< MechanicalState<DataTypes>* >(getContext()->getMechanicalState());
-    if(!mstate) this->serr<<"ProjectiveConstraintSet<DataTypes>::init(), no mstate . This may be because there is no MechanicalState in the local context, or because the type is not compatible." << this->sendl;
+    msg_error_when(!mstate) << "ProjectiveConstraintSet<DataTypes>::init(), no mstate . This may be because there is no MechanicalState in the local context, or because the type is not compatible.";
 }
 
 template<class DataTypes>
@@ -85,7 +85,7 @@ void ProjectiveConstraintSet<DataTypes>::projectResponse(const MechanicalParams*
     {
             projectResponse(mparams, *dxId[mstate.get(mparams)].write());
     }
-    else serr << "ProjectiveConstraintSet<DataTypes>::projectResponse(const MechanicalParams* mparams, MultiVecDerivId dxId), no mstate for " << this->getName() << sendl;
+    msg_error_when(!mstate) << "ProjectiveConstraintSet<DataTypes>::projectResponse(const MechanicalParams* mparams, MultiVecDerivId dxId), no mstate for " << this->getName();
 }
 
 template<class DataTypes>
@@ -99,7 +99,7 @@ void ProjectiveConstraintSet<DataTypes>::projectVelocity(const MechanicalParams*
 
             projectVelocity(mparams, *vId[mstate.get(mparams)].write());
     }
-    else serr << "ProjectiveConstraintSet<DataTypes>::projectVelocity(const MechanicalParams* mparams, MultiVecDerivId dxId), no mstate for " << this->getName() << sendl;
+    msg_error_when(!mstate) << "ProjectiveConstraintSet<DataTypes>::projectVelocity(const MechanicalParams* mparams, MultiVecDerivId dxId), no mstate for " << this->getName();
 }
 
 template<class DataTypes>

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.cpp
@@ -123,11 +123,10 @@ bool BaseData::setParent(BaseData* parent, const std::string& path)
     {
         if (m_owner)
         {
-            m_owner->serr << "Invalid Data link from " << (parent->m_owner ? parent->m_owner->getName() : std::string("?")) << "." << parent->getName() << " to " << m_owner->getName() << "." << getName() << m_owner->sendl;
-            if (!this->getValueTypeInfo()->ValidInfo())
-                m_owner->serr << "  Possible reason: destination Data " << getName() << " has an unknown type" << m_owner->sendl;
-            if (!parent->getValueTypeInfo()->ValidInfo())
-                m_owner->serr << "  Possible reason: source Data " << parent->getName() << " has an unknown type" << m_owner->sendl;
+            msg_error(m_owner) << "Invalid Data link from " << (parent->m_owner ? parent->m_owner->getName() : std::string("?")) << "." << parent->getName() << " to " << m_owner->getName() << "." << getName();
+            
+            msg_error_when(!this->getValueTypeInfo()->ValidInfo(), m_owner) << "Possible reason: destination Data " << getName() << " has an unknown type";
+            msg_error_when(!parent->getValueTypeInfo()->ValidInfo(), m_owner) << "Possible reason: source Data " << parent->getName() << " has an unknown type";
         }
         return false;
     }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Context.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Context.cpp
@@ -83,7 +83,6 @@ void Context::setChangeSleepingState(bool val)
 /// Simulation timestep
 SReal Context::getDt() const
 {
-//    cerr << "Context::getDt() is " << dt_.getValue() << endl;
     return dt_.getValue();
 }
 
@@ -110,7 +109,6 @@ bool Context::getAnimate() const
 /// Simulation timestep
 void Context::setDt(SReal val)
 {
-//    cerr << "Context::setDt("<< val <<")" << endl;
     dt_.setValue(val);
 }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseMeshTopology.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseMeshTopology.cpp
@@ -290,14 +290,14 @@ bool BaseMeshTopology::load(const char* filename)
     std::string meshFilename(filename);
     if (!sofa::helper::system::DataRepository.findFile (meshFilename))
     {
-        serr << "Mesh \""<< filename <<"\" not found"<< sendl;
+        msg_error() << "Mesh \"" << filename << "\" not found";
         return false;
     }
     this->fileTopology.setValue( filename );
     DefaultMeshTopologyLoader loader(this);
     if (!loader.load(meshFilename.c_str()))
     {
-        serr << "Unable to load Mesh \""<<filename << "\"";
+        msg_error() << "Unable to load Mesh \"" << filename << "\"";
         return false;
     }
     return true;
@@ -346,7 +346,7 @@ void BaseMeshTopology::reOrientateTriangle(TriangleID /*id*/)
 
 std::list<const TopologyChange *>::const_iterator BaseMeshTopology::beginChange() const
 {
-    serr << "beginChange() not supported.";
+    msg_error() << "beginChange() not supported.";
     std::list<const TopologyChange *>::const_iterator l;
     return l;
 }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologicalMapping.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologicalMapping.h
@@ -175,20 +175,20 @@ public:
 
         if (stin == nullptr)
         {
-            context->serr << "Creation of " << className(obj) << " topology mapping failed as input topology model is missing or invalid." << context->sendl;
+            msg_error(context) << "Creation of " << className(obj) << " topology mapping failed as input topology model is missing or invalid.";
             return false;
         }
 
         if (stout == nullptr)
         {
-            context->serr << "Creation of " << className(obj) <<" topology mapping failed as output topology model is missing or invalid." << context->sendl;
+            msg_error(context) << "Creation of " << className(obj) << " topology mapping failed as output topology model is missing or invalid.";
             return false;
         }
 
         if (static_cast<BaseObject*>(stin) == static_cast<BaseObject*>(stout))
         {
             // we should refuse to create mappings with the same input and output model, which may happen if a State object is missing in the child node
-            context->serr <<  "Creation of " << className(obj) << " topology mapping failed as the same object \"" << stin->getName() << "\" is linked as input and output." << context->sendl;
+            msg_error(context) << "Creation of " << className(obj) << " topology mapping failed as the same object \"" << stin->getName() << "\" is linked as input and output.";
             return false;
         }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/visual/VisualLoop.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/visual/VisualLoop.h
@@ -63,7 +63,7 @@ public:
     virtual void drawStep(sofa::core::visual::VisualParams* /*vparams*/) {}
 
     /// Compute the bounding box of the scene. If init is set to "true", then minBBox and maxBBox will be initialised to a default value
-    virtual void computeBBoxStep(sofa::core::visual::VisualParams* /*vparams*/, SReal* /*minBBox*/, SReal* /*maxBBox*/, bool /*init*/) { serr << "WARNING, VisualLoop::computeBBoxStep does nothing" << sendl; }
+    virtual void computeBBoxStep(sofa::core::visual::VisualParams* /*vparams*/, SReal* /*minBBox*/, SReal* /*maxBBox*/, bool /*init*/) { msg_warning() << "VisualLoop::computeBBoxStep does nothing"; }
 
     bool insertInNode( objectmodel::BaseNode* node ) override;
     bool removeInNode( objectmodel::BaseNode* node ) override;

--- a/SofaKernel/modules/SofaDeformable/AngularSpringForceField.h
+++ b/SofaKernel/modules/SofaDeformable/AngularSpringForceField.h
@@ -95,7 +95,7 @@ public:
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& df, const DataVecDeriv& dx) override;
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        msg_error() << "Get potentialEnergy not implemented";
+        msg_warning() << "Method getPotentialEnergy not implemented yet.";
         return 0.0;
     }
 

--- a/SofaKernel/modules/SofaDeformable/AngularSpringForceField.h
+++ b/SofaKernel/modules/SofaDeformable/AngularSpringForceField.h
@@ -95,7 +95,7 @@ public:
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& df, const DataVecDeriv& dx) override;
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        serr << "Get potentialEnergy not implemented" << sendl;
+        msg_error() << "Get potentialEnergy not implemented";
         return 0.0;
     }
 

--- a/SofaKernel/modules/SofaDeformable/RestShapeSpringsForceField.h
+++ b/SofaKernel/modules/SofaDeformable/RestShapeSpringsForceField.h
@@ -108,7 +108,7 @@ public:
         SOFA_UNUSED(mparams);
         SOFA_UNUSED(x);
 
-        msg_error() << "Get potentialEnergy not implemented";
+        msg_warning() << "Method getPotentialEnergy not implemented yet.";
         return 0.0;
     }
 

--- a/SofaKernel/modules/SofaEigen2Solver/EigenBaseSparseMatrix.h
+++ b/SofaKernel/modules/SofaEigen2Solver/EigenBaseSparseMatrix.h
@@ -387,7 +387,6 @@ public:
         int getGlobalOffset(const core::behavior::BaseMechanicalState*) const override { return 0; }
         MatrixRef getMatrix(const core::behavior::BaseMechanicalState*) const override
         {
-            //    cerr<<"SingleMatrixAccessor::getMatrix" << endl;
             return matRef;
         }
 

--- a/SofaKernel/modules/SofaEigen2Solver/EigenSparseMatrix.h
+++ b/SofaKernel/modules/SofaEigen2Solver/EigenSparseMatrix.h
@@ -150,10 +150,7 @@ public:
 
 //        if( incomingBlocks.empty() ) return;
 //        compress_incomingBlocks();
-//        //        cerr<<"compress, before incoming blocks " << this->eigenMatrix << endl;
-//        //        cerr<<"compress, incoming blocks " << this->compressedIncoming << endl;
 //        this->compressedMatrix += this->compressedIncoming;
-//        //        cerr<<"compress, final value " << this->eigenMatrix << endl;
 //        this->compressedMatrix.finalize();
 //    }
 
@@ -280,8 +277,6 @@ public:
     void copyFrom( const CompressedRowSparseMatrix< defaulttype::Mat<Nout,Nin, AnyReal> >& crs )
     {
         this->resize( crs.rowSize(), crs.colSize() );
-//        cerr<<"copyFrom, size " << crs.rowSize() << ", " << crs.colSize()<< ", block rows: " << crs.rowIndex.size() << endl;
-//        cerr<<"copyFrom, crs = " << crs << endl;
 
 //        int rowStarted = 0;
         for (unsigned int xi = 0; xi < crs.rowIndex.size(); ++xi)  // for each non-null block row
@@ -299,7 +294,6 @@ public:
             for( unsigned r=0; r<Nout; r++ )   // process one scalar row after another
             {
                 if(r+ blRow*Nout >= (unsigned)this->rowSize() ) break;
-//                cerr<<"copyFrom,  startVec " << rowStarted << endl;
 //                this->compressedMatrix.startVec(rowStarted++);
 
 
@@ -311,7 +305,6 @@ public:
                         {
                         this->add(r + blRow*Nout, c + blCol*Nin, b[r][c]);
 //                        this->compressedMatrix.insertBack(r + blRow*Nout, c + blCol*Nin) = b[r][c];
-//                        cerr<<"copyFrom,  insert at " << r + blRow*Nout << ", " << c + blCol*Nin << endl;
                         }
 
                 }

--- a/SofaKernel/modules/SofaEigen2Solver/EigenVector.h
+++ b/SofaKernel/modules/SofaEigen2Solver/EigenVector.h
@@ -91,7 +91,7 @@ public:
 #ifdef EigenVector_CHECK
         if (i >= rowSize() || j >= colSize())
         {
-            std::cerr << "ERROR: invalid read access to element ("<<i<<","<<j<<") in "<</*this->Name()<<*/" of size ("<<rowSize()<<","<<colSize()<<")"<<std::endl;
+            msg_error("EigenVector") << "Invalid read access to element (" << i << "," << j << ") in " <</*this->Name()<<*/" of size (" << rowSize() << "," << colSize() << ")";
             return 0.0;
         }
 #endif
@@ -103,7 +103,7 @@ public:
 #ifdef EigenVector_CHECK
         if (i >= rowSize() || j >= colSize())
         {
-            std::cerr << "ERROR: invalid write access to element ("<<i<<","<<j<<") in "<</*this->Name()<<*/" of size ("<<rowSize()<<","<<colSize()<<")"<<std::endl;
+            msg_error("EigenVector") << "Invalid write access to element (" << i << "," << j << ") in " <</*this->Name()<<*/" of size (" << rowSize() << "," << colSize() << ")";
             return;
         }
 #endif
@@ -115,7 +115,7 @@ public:
 #ifdef EigenVector_CHECK
         if (i >= rowSize()/Nout || j >= colSize()/Nin )
         {
-            std::cerr << "ERROR: invalid write access to element ("<<i<<","<<j<<") in "<</*this->Name()<<*/" of size ("<<rowSize()/Nout<<","<<colSize()/Nin<<")"<<std::endl;
+            msg_error("EigenVector") << "Invalid write access to element (" << i << "," << j << ") in " <</*this->Name()<<*/" of size (" << rowSize() / Nout << "," << colSize() / Nin << ")";
             return;
         }
 #endif
@@ -131,7 +131,7 @@ public:
 #ifdef EigenVector_CHECK
         if (i >= rowSize() || j >= colSize())
         {
-            std::cerr << "ERROR: invalid write access to element ("<<i<<","<<j<<") in "/*<<this->Name()*/<<" of size ("<<rowSize()<<","<<colSize()<<")"<<std::endl;
+            msg_error("EigenVector") << "Invalid write access to element (" << i << "," << j << ") in "/*<<this->Name()*/ << " of size (" << rowSize() << "," << colSize() << ")";
             return;
         }
 #endif
@@ -143,7 +143,7 @@ public:
 #ifdef EigenVector_CHECK
         if (i >= rowSize() || j >= colSize())
         {
-            std::cerr << "ERROR: invalid write access to element ("<<i<<","<<j<<") in "<</*this->Name()<<*/" of size ("<<rowSize()<<","<<colSize()<<")"<<std::endl;
+            msg_error("EigenVector") << "Invalid write access to element (" << i << "," << j << ") in " <</*this->Name()<<*/" of size (" << rowSize() << "," << colSize() << ")";
             return;
         }
 #endif
@@ -222,7 +222,7 @@ public:
 #ifdef EigenVector_CHECK
         if (i >= rowSize() || j >= colSize())
         {
-            std::cerr << "ERROR: invalid read access to element ("<<i<<","<<j<<") in "<</*this->Name()<<*/" of size ("<<rowSize()<<","<<colSize()<<")"<<std::endl;
+            msg_error("EigenVector") << "Invalid read access to element (" << i << "," << j << ") in " <</*this->Name()<<*/" of size (" << rowSize() << "," << colSize() << ")";
             return 0.0;
         }
 #endif
@@ -234,7 +234,7 @@ public:
 #ifdef EigenVector_CHECK
         if (i >= rowSize() || j >= colSize())
         {
-            std::cerr << "ERROR: invalid write access to element ("<<i<<","<<j<<") in "<</*this->Name()<<*/" of size ("<<rowSize()<<","<<colSize()<<")"<<std::endl;
+            msg_error("EigenVector") << "Invalid write access to element (" << i << "," << j << ") in " <</*this->Name()<<*/" of size (" << rowSize() << "," << colSize() << ")";
             return;
         }
 #endif
@@ -250,7 +250,7 @@ public:
 #ifdef EigenVector_CHECK
         if (i >= rowSize() || j >= colSize())
         {
-            std::cerr << "ERROR: invalid write access to element ("<<i<<","<<j<<") in "/*<<this->Name()*/<<" of size ("<<rowSize()<<","<<colSize()<<")"<<std::endl;
+            msg_error("EigenVector") << "Invalid write access to element (" << i << "," << j << ") in "/*<<this->Name()*/ << " of size (" << rowSize() << "," << colSize() << ")";
             return;
         }
 #endif
@@ -262,7 +262,7 @@ public:
 #ifdef EigenVector_CHECK
         if (i >= rowSize() || j >= colSize())
         {
-            std::cerr << "ERROR: invalid write access to element ("<<i<<","<<j<<") in "<</*this->Name()<<*/" of size ("<<rowSize()<<","<<colSize()<<")"<<std::endl;
+            msg_error("EigenVector") << "Invalid write access to element (" << i << "," << j << ") in " <</*this->Name()<<*/" of size (" << rowSize() << "," << colSize() << ")";
             return;
         }
 #endif

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/ArgumentParser.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/ArgumentParser.cpp
@@ -64,7 +64,7 @@ void ArgumentParser::parse()
             extra = vm.at("argv").as<std::vector<std::string> >();
     }
     catch (boost::program_options::error const& e) {
-        std::cerr << e.what() << '\n';
+        msg_error("ArgumentParser") << e.what();
         exit( EXIT_FAILURE );
     }
     boost::program_options::notify(vm);

--- a/SofaKernel/modules/SofaImplicitOdeSolver/EulerImplicitSolver.cpp
+++ b/SofaKernel/modules/SofaImplicitOdeSolver/EulerImplicitSolver.cpp
@@ -120,14 +120,14 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
         tr = 1.0;
 
     if (verbose)
-        std::cout<<"trapezoidal factor = "<< tr <<std::endl;
+        msg_info() << "trapezoidal factor = " << tr;
 
     sofa::helper::AdvancedTimer::stepBegin("ComputeForce");
     mop->setImplicit(true); // this solver is implicit
     // compute the net forces at the beginning of the time step
     mop.computeForce(f);
-    if( verbose )
-        serr<<"EulerImplicitSolver, initial f = "<< f <<sendl;
+    if (verbose)
+        msg_info() << "EulerImplicitSolver, initial f = " << f;
 
     sofa::helper::AdvancedTimer::stepNext ("ComputeForce", "ComputeRHTerm");
     if( firstOrder )
@@ -140,8 +140,8 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
 
         // force in the current configuration
         b.eq(f,1.0/tr);                                                                         // b = f0
-        if( verbose )
-            serr<<"EulerImplicitSolver, f = "<< f <<sendl;
+        if (verbose)
+            msg_info() << "EulerImplicitSolver, f = " << f;
 
         // add the change of force due to stiffness + Rayleigh damping
         mop.addMBKv(b, -f_rayleighMass.getValue(), 1, h+f_rayleighStiffness.getValue()); // b =  f0 + ( rm M + B + (h+rs) K ) v
@@ -150,13 +150,13 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
         b.teq(h*tr);                                                                        // b = h(f0 + ( rm M + B + (h+rs) K ) v )
     }
 
-    if( verbose )
-        serr<<"EulerImplicitSolver, b = "<< b <<sendl;
+    if (verbose)
+        msg_info() << "EulerImplicitSolver, b = " << b;
 
     mop.projectResponse(b);          // b is projected to the constrained space
 
-    if( verbose )
-        serr<<"EulerImplicitSolver, projected b = "<< b <<sendl;
+    if (verbose)
+        msg_info() << "EulerImplicitSolver, projected b = " << b;
 
     sofa::helper::AdvancedTimer::stepNext ("ComputeRHTerm", "MBKBuild");
 
@@ -169,8 +169,8 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
 
     if( verbose )
     {
-        serr<<"EulerImplicitSolver, matrix = "<< (MechanicalMatrix::K * (-h*(h+f_rayleighStiffness.getValue())) + MechanicalMatrix::M * (1+h*f_rayleighMass.getValue())) << " = " << matrix <<sendl;
-        serr<<"EulerImplicitSolver, Matrix K = " << MechanicalMatrix::K << sendl;
+        msg_info() << "EulerImplicitSolver, matrix = " << (MechanicalMatrix::K * (-h * (h + f_rayleighStiffness.getValue())) + MechanicalMatrix::M * (1 + h * f_rayleighMass.getValue())) << " = " << matrix;
+        msg_info() << "EulerImplicitSolver, Matrix K = " << MechanicalMatrix::K;
     }
 
 #ifdef SOFA_DUMP_VISITOR_INFO
@@ -300,10 +300,10 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
         mop.projectVelocity(newVel);
         mop.propagateX(newPos);
         mop.propagateV(newVel);
-        serr<<"EulerImplicitSolver, final x = "<< newPos <<sendl;
-        serr<<"EulerImplicitSolver, final v = "<< newVel <<sendl;
+        msg_info() << "EulerImplicitSolver, final x = " << newPos;
+        msg_info() << "EulerImplicitSolver, final v = " << newVel;
         mop.computeForce(f);
-        serr<<"EulerImplicitSolver, final f = "<< f <<sendl;
+        msg_info() << "EulerImplicitSolver, final f = " << f;
     }
 }
 

--- a/SofaKernel/modules/SofaLoader/MeshObjLoader.cpp
+++ b/SofaKernel/modules/SofaLoader/MeshObjLoader.cpp
@@ -367,7 +367,7 @@ bool MeshObjLoader::readOBJ (std::ifstream &file, const char* filename)
         }
         else
         {
-            // std::cerr << "readObj : Unknown token for line " << line << std::endl;
+
         }
     }
 

--- a/SofaKernel/modules/SofaLoader/MeshObjLoader.cpp
+++ b/SofaKernel/modules/SofaLoader/MeshObjLoader.cpp
@@ -641,7 +641,9 @@ bool MeshObjLoader::readMTL(const char* filename, helper::vector <Material>& mat
 
     file = fopen(filename, "r");
     Material *mat = nullptr;
-    if (!file);//serr << "readMTL() failed: can't open material file " << filename << sendl;
+    if (!file) {
+        msg_error() << "readMTL() failed: can't open material file " << filename;
+    }
     else
     {
         /* now, read in the data */

--- a/SofaKernel/modules/SofaMeshCollision/LocalMinDistanceFilter.cpp
+++ b/SofaKernel/modules/SofaMeshCollision/LocalMinDistanceFilter.cpp
@@ -65,13 +65,13 @@ void LocalMinDistanceFilter::bwdInit()
 
         if(r_mapping==nullptr)
         {
-            serr<<"No RigidMapping were found in the same or child node: maybe a template problem (only works for double)"<<sendl;
+            msg_error() << "No RigidMapping were found in the same or child node: maybe a template problem (only works for double)";
             this->setRigid(false);
             return;
         }
         if(!r_mapping->useX0.getValue())
         {
-            serr<<"optimization for rigid can not be used if the RigidMapping.useX0=false : cancel optim"<<sendl;
+            msg_error() << "optimization for rigid can not be used if the RigidMapping.useX0=false : cancel optim";
             this->setRigid(false);
             return;
         }

--- a/SofaKernel/modules/SofaMeshCollision/MeshNewProximityIntersection.cpp
+++ b/SofaKernel/modules/SofaMeshCollision/MeshNewProximityIntersection.cpp
@@ -200,15 +200,15 @@ int MeshNewProximityIntersection::computeIntersection(Triangle& e1, Triangle& e2
 {
     if (e1.getIndex() >= e1.getCollisionModel()->getSize())
     {
-        intersection->serr << "NewProximityIntersection::computeIntersection(Triangle, Triangle): ERROR invalid e1 index "
-                << e1.getIndex() << " on CM " << e1.getCollisionModel()->getName() << " of size " << e1.getCollisionModel()->getSize()<<intersection->sendl;
+        msg_error(intersection) << "computeIntersection(Triangle, Triangle): ERROR invalid e1 index "
+            << e1.getIndex() << " on CM " << e1.getCollisionModel()->getName() << " of size " << e1.getCollisionModel()->getSize();
         return 0;
     }
 
     if (e2.getIndex() >= e2.getCollisionModel()->getSize())
     {
-        intersection->serr << "NewProximityIntersection::computeIntersection(Triangle, Triangle): ERROR invalid e2 index "
-                << e2.getIndex() << " on CM " << e2.getCollisionModel()->getName() << " of size " << e2.getCollisionModel()->getSize()<<intersection->sendl;
+        msg_error(intersection) << "computeIntersection(Triangle, Triangle): ERROR invalid e2 index "
+            << e2.getIndex() << " on CM " << e2.getCollisionModel()->getName() << " of size " << e2.getCollisionModel()->getSize();
         return 0;
     }
 

--- a/SofaKernel/modules/SofaObjectInteraction/PenalityContactForceField.inl
+++ b/SofaKernel/modules/SofaObjectInteraction/PenalityContactForceField.inl
@@ -145,7 +145,7 @@ void PenalityContactForceField<DataTypes>::addDForce(const sofa::core::Mechanica
 template <class DataTypes>
 SReal PenalityContactForceField<DataTypes>::getPotentialEnergy(const sofa::core::MechanicalParams*, const DataVecCoord&, const DataVecCoord& ) const
 {
-    serr<<"PenalityContactForceField::getPotentialEnergy-not-implemented !!!"<<sendl;
+    msg_error() << "PenalityContactForceField::getPotentialEnergy-not-implemented !!!";
     return 0;
 }
 

--- a/SofaKernel/modules/SofaRigid/RigidMapping.cpp
+++ b/SofaKernel/modules/SofaRigid/RigidMapping.cpp
@@ -59,7 +59,7 @@ void RigidMapping< sofa::defaulttype::Rigid2Types, sofa::defaulttype::Vec2Types 
 template<>
 const defaulttype::BaseMatrix* RigidMapping< sofa::defaulttype::Rigid2Types, sofa::defaulttype::Vec2Types >::getK()
 {
-    serr<<"TODO: assembled geometric stiffness not implemented"<<sendl;
+    msg_error() << "TODO: assembled geometric stiffness not implemented";
     return nullptr;
 }
 

--- a/SofaKernel/modules/SofaRigid/RigidMapping.inl
+++ b/SofaKernel/modules/SofaRigid/RigidMapping.inl
@@ -755,7 +755,7 @@ void RigidMapping<TIn, TOut>::parse(core::objectmodel::BaseObjectDescription* ar
     const char* repartitionChar = arg->getAttribute("repartition");
     if( repartitionChar )
     {
-        msg_error() << helper::logging::Message::Deprecated << "parse: You are using a deprecated Data 'repartition', please use the new structure data rigidIndexPerPoint";
+        msg_deprecated() << "parse: You are using a deprecated Data 'repartition', please use the new structure data rigidIndexPerPoint";
 
         helper::vector< unsigned int > repartition;
         std::istringstream ss( repartitionChar );

--- a/SofaKernel/modules/SofaRigid/RigidMapping.inl
+++ b/SofaKernel/modules/SofaRigid/RigidMapping.inl
@@ -755,7 +755,7 @@ void RigidMapping<TIn, TOut>::parse(core::objectmodel::BaseObjectDescription* ar
     const char* repartitionChar = arg->getAttribute("repartition");
     if( repartitionChar )
     {
-        serr<<helper::logging::Message::Deprecated<<"parse: You are using a deprecated Data 'repartition', please use the new structure data rigidIndexPerPoint"<<sendl;
+        msg_error() << helper::logging::Message::Deprecated << "parse: You are using a deprecated Data 'repartition', please use the new structure data rigidIndexPerPoint";
 
         helper::vector< unsigned int > repartition;
         std::istringstream ss( repartitionChar );

--- a/SofaKernel/modules/SofaSimpleFem/HexahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/HexahedronFEMForceField.inl
@@ -994,7 +994,7 @@ template<class DataTypes>
 SReal HexahedronFEMForceField<DataTypes>::getPotentialEnergy(const core::MechanicalParams* /*mparams*/,
                                                              const DataVecCoord&  /* x */) const
 {
-    msg_error() << "Get potentialEnergy not implemented";
+    msg_warning() << "Method getPotentialEnergy not implemented yet.";
     return 0.0;
 }
 

--- a/SofaKernel/modules/SofaSimpleFem/TetrahedronDiffusionFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/TetrahedronDiffusionFEMForceField.inl
@@ -253,7 +253,7 @@ void TetrahedronDiffusionFEMForceField<DataTypes>::reinit()
 template <class DataTypes>
 SReal TetrahedronDiffusionFEMForceField<DataTypes>::getPotentialEnergy(const core::MechanicalParams*, const DataVecCoord&) const
 {
-    msg_error() <<"GetPotentialEnergy not implemented (yet, report on github)." ;
+    msg_warning() <<"Method getPotentialEnergy not implemented yet." ;
     return 0;
 }
 

--- a/SofaKernel/modules/SofaSimpleFem/TetrahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/TetrahedronFEMForceField.inl
@@ -1286,11 +1286,7 @@ inline void TetrahedronFEMForceField<DataTypes>::applyStiffnessCorotational( Vec
 
     Displacement F;
 
-    //serr<<"X : "<<X<<sendl;
-
     computeForce( F, X, materialsStiffnesses[i], strainDisplacements[i], fact );
-
-    //serr<<"F : "<<F<<sendl;
 
 
     // rotate by rotations[i]

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/AnimateVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/AnimateVisitor.cpp
@@ -68,7 +68,6 @@ void AnimateVisitor::processBehaviorModel(simulation::Node*, core::BehaviorModel
 
 void AnimateVisitor::fwdInteractionForceField(simulation::Node*, core::behavior::BaseInteractionForceField* obj)
 {
-    //cerr<<"AnimateVisitor::IFF "<<obj->getName()<<endl;
     sofa::helper::AdvancedTimer::stepBegin("InteractionFF",obj);
 
     MultiVecDerivId   ffId      = VecDerivId::externalForce();
@@ -110,7 +109,7 @@ void AnimateVisitor::processOdeSolver(simulation::Node* node, core::behavior::Od
     sofa::helper::AdvancedTimer::stepBegin("Mechanical",node);
     /*    MechanicalIntegrationVisitor act(getDt());
         node->execute(&act);*/
-    //  cerr<<"AnimateVisitor::processOdeSolver "<<solver->getName()<<endl;
+
     solver->solve(params, getDt());
     sofa::helper::AdvancedTimer::stepEnd("Mechanical",node);
 }

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DefaultVisualManagerLoop.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DefaultVisualManagerLoop.cpp
@@ -139,7 +139,7 @@ void DefaultVisualManagerLoop::computeBBoxStep(sofa::core::visual::VisualParams*
     VisualComputeBBoxVisitor act(vparams);
     if ( gRoot )
         gRoot->execute ( act );
-//    cerr<<"DefaultVisualManagerLoop::computeBBoxStep, xm= " << act.minBBox[0] <<", xM= " << act.maxBBox[0] << endl;
+
     if (init)
     {
         minBBox[0] = (SReal)(act.minBBox[0]);

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalOperations.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalOperations.cpp
@@ -391,17 +391,14 @@ void MechanicalOperations::solveConstraint(MultiVecId id, core::ConstraintParams
 {
     cparams.setOrder(order);
 
-//	ctx->serr << "MechanicalOperations::solveConstraint" << ctx->sendl;
     helper::vector< core::behavior::ConstraintSolver* > constraintSolverList;
 
     ctx->get<core::behavior::ConstraintSolver>(&constraintSolverList, ctx->getTags(), BaseContext::Local);
     if (constraintSolverList.empty())
     {
-        //ctx->sout << "No ConstraintSolver found." << ctx->sendl;
         return;
     }
 
-//	ctx->serr << "MechanicalOperations::solveConstraint found solvers" << ctx->sendl;
     for (helper::vector< core::behavior::ConstraintSolver* >::iterator it=constraintSolverList.begin(); it!=constraintSolverList.end(); ++it)
     {
         (*it)->solveConstraint(&cparams, id);
@@ -413,7 +410,7 @@ void MechanicalOperations::m_resetSystem()
     LinearSolver* s = ctx->get<LinearSolver>(ctx->getTags(), BaseContext::SearchDown);
     if (!s)
     {
-        ctx->serr << "ERROR: requires a LinearSolver."<<ctx->sendl;
+        msg_error(ctx) << "Requires a LinearSolver.";
         return;
     }
     s->resetSystem();
@@ -424,7 +421,7 @@ void MechanicalOperations::m_setSystemMBKMatrix(SReal mFact, SReal bFact, SReal 
     LinearSolver* s = ctx->get<LinearSolver>(ctx->getTags(), BaseContext::SearchDown);
     if (!s)
     {
-        ctx->serr << "ERROR:  requires a LinearSolver."<<ctx->sendl;
+        msg_error(ctx) << "Requires a LinearSolver.";
         return;
     }
     mparams.setMFactor(mFact);
@@ -438,7 +435,7 @@ void MechanicalOperations::m_setSystemRHVector(core::MultiVecDerivId v)
     LinearSolver* s = ctx->get<LinearSolver>(ctx->getTags(), BaseContext::SearchDown);
     if (!s)
     {
-        ctx->serr << "ERROR:  requires a LinearSolver."<<ctx->sendl;
+        msg_error(ctx) << "Requires a LinearSolver.";
         return;
     }
     s->setSystemRHVector(v);
@@ -449,7 +446,7 @@ void MechanicalOperations::m_setSystemLHVector(core::MultiVecDerivId v)
     LinearSolver* s = ctx->get<LinearSolver>(ctx->getTags(), BaseContext::SearchDown);
     if (!s)
     {
-        ctx->serr << "ERROR:  requires a LinearSolver."<<ctx->sendl;
+        msg_error(ctx) << "Requires a LinearSolver.";
         return;
     }
     s->setSystemLHVector(v);
@@ -461,7 +458,7 @@ void MechanicalOperations::m_solveSystem()
     LinearSolver* s = ctx->get<LinearSolver>(ctx->getTags(), BaseContext::SearchDown);
     if (!s)
     {
-        ctx->serr << "ERROR:  requires a LinearSolver."<<ctx->sendl;
+        msg_error(ctx) << "Requires a LinearSolver.";
         return;
     }
     s->solveSystem();
@@ -472,7 +469,7 @@ void MechanicalOperations::m_print( std::ostream& out )
     LinearSolver* s = ctx->get<LinearSolver>(ctx->getTags(), BaseContext::SearchDown);
     if (!s)
     {
-        ctx->serr << "ERROR: requires a LinearSolver."<<ctx->sendl;
+        msg_error(ctx) << "Requires a LinearSolver.";
         return;
     }
     defaulttype::BaseMatrix* m = s->getSystemBaseMatrix();

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.cpp
@@ -403,7 +403,7 @@ void* Node::findLinkDestClass(const core::objectmodel::BaseClass* destType, cons
     {
         if (pathStr[psize-1] != ']')
         {
-            serr << "Invalid index-based path \"" << path << "\"" << sendl;
+            msg_error() << "Invalid index-based path \"" << path << "\"";
             return nullptr;
         }
         int index = atoi(pathStr.c_str()+ppos+1);
@@ -919,70 +919,74 @@ void Node::printComponents()
     using core::collision::Pipeline;
     using core::BaseState;
 
-    serr<<"BaseAnimationLoop: ";
-    for ( Single<BaseAnimationLoop>::iterator i=animationManager.begin(), iend=animationManager.end(); i!=iend; ++i )
-        serr<<(*i)->getName()<<" ";
-    serr<<sendl<<"OdeSolver: ";
-    for ( Sequence<OdeSolver>::iterator i=solver.begin(), iend=solver.end(); i!=iend; ++i )
-        serr<<(*i)->getName()<<" ";
-    serr<<sendl<<"LinearSolver: ";
-    for ( Sequence<BaseLinearSolver>::iterator i=linearSolver.begin(), iend=linearSolver.end(); i!=iend; i++ )
-        serr<<(*i)->getName()<<" ";
-    serr<<sendl<<"ConstraintSolver: ";
-    for ( Sequence<ConstraintSolver>::iterator i=constraintSolver.begin(), iend=constraintSolver.end(); i!=iend; ++i )
-        serr<<(*i)->getName()<<" ";
-    serr<<"VisualLoop: ";
-    for ( Single<VisualLoop>::iterator i=visualLoop.begin(), iend=visualLoop.end(); i!=iend; ++i )
-        serr<<(*i)->getName()<<" ";
-    serr<<sendl<<"InteractionForceField: ";
-    for ( Sequence<BaseInteractionForceField>::iterator i=interactionForceField.begin(), iend=interactionForceField.end(); i!=iend; ++i )
-        serr<<(*i)->getName()<<" ";
-    serr<<sendl<<"ForceField: ";
-    for ( Sequence<BaseForceField>::iterator i=forceField.begin(), iend=forceField.end(); i!=iend; ++i )
-        serr<<(*i)->getName()<<" ";
-    serr<<sendl<<"State: ";
-    for ( Single<BaseState>::iterator i=state.begin(), iend=state.end(); i!=iend; ++i )
-        serr<<(*i)->getName()<<" ";
-    serr<<sendl<<"MechanicalState: ";
-    for ( Single<BaseMechanicalState>::iterator i=mechanicalState.begin(), iend=mechanicalState.end(); i!=iend; ++i )
-        serr<<(*i)->getName()<<" ";
-    serr<<sendl<<"Mechanical Mapping: ";
-    for ( Single<BaseMapping>::iterator i=mechanicalMapping.begin(), iend=mechanicalMapping.end(); i!=iend; ++i )
-        serr<<(*i)->getName()<<" ";
-    serr<<sendl<<"Mapping: ";
-    for ( Sequence<BaseMapping>::iterator i=mapping.begin(), iend=mapping.end(); i!=iend; ++i )
-        serr<<(*i)->getName()<<" ";
-    serr<<sendl<<"Topology: ";
-    for ( Single<Topology>::iterator i=topology.begin(), iend=topology.end(); i!=iend; ++i )
-        serr<<(*i)->getName()<<" ";
-    serr<<sendl<<"MeshTopology: ";
-    for ( Single<BaseMeshTopology>::iterator i=meshTopology.begin(), iend=meshTopology.end(); i!=iend; ++i )
-        serr<<(*i)->getName()<<" ";
-    serr<<sendl<<"Shader: ";
-    for ( Sequence<Shader>::iterator i=shaders.begin(), iend=shaders.end(); i!=iend; ++i )
-        serr<<(*i)->getName()<<" ";
-    serr<<sendl<<"ProjectiveConstraintSet: ";
-    for ( Sequence<BaseProjectiveConstraintSet>::iterator i=projectiveConstraintSet.begin(), iend=projectiveConstraintSet.end(); i!=iend; ++i )
-        serr<<(*i)->getName()<<" ";
-    serr<<sendl<<"ConstraintSet: ";
-    for ( Sequence<BaseConstraintSet>::iterator i=constraintSet.begin(), iend=constraintSet.end(); i!=iend; ++i )
-        serr<<(*i)->getName()<<" ";
-    serr<<sendl<<"BehaviorModel: ";
-    for ( Sequence<BehaviorModel>::iterator i=behaviorModel.begin(), iend=behaviorModel.end(); i!=iend; ++i )
-        serr<<(*i)->getName()<<" ";
-    serr<<sendl<<"VisualModel: ";
-    for ( Sequence<VisualModel>::iterator i=visualModel.begin(), iend=visualModel.end(); i!=iend; ++i )
-        serr<<(*i)->getName()<<" ";
-    serr<<sendl<<"CollisionModel: ";
-    for ( Sequence<CollisionModel>::iterator i=collisionModel.begin(), iend=collisionModel.end(); i!=iend; ++i )
-        serr<<(*i)->getName()<<" ";
-    serr<<sendl<<"ContextObject: ";
-    for ( Sequence<ContextObject>::iterator i=contextObject.begin(), iend=contextObject.end(); i!=iend; ++i )
-        serr<<(*i)->getName()<<" ";
-    serr<<sendl<<"Pipeline: ";
-    for ( Single<Pipeline>::iterator i=collisionPipeline.begin(), iend=collisionPipeline.end(); i!=iend; ++i )
-        serr<<(*i)->getName()<<" ";
-    serr<<sendl;
+    std::stringstream sstream;
+
+    sstream << "BaseAnimationLoop: ";
+    for (Single<BaseAnimationLoop>::iterator i = animationManager.begin(), iend = animationManager.end(); i != iend; ++i)
+        sstream << (*i)->getName() << " ";
+    sstream << "\n" << "OdeSolver: ";
+    for (Sequence<OdeSolver>::iterator i = solver.begin(), iend = solver.end(); i != iend; ++i)
+        sstream << (*i)->getName() << " ";
+    sstream << "\n" << "LinearSolver: ";
+    for (Sequence<BaseLinearSolver>::iterator i = linearSolver.begin(), iend = linearSolver.end(); i != iend; i++)
+        sstream << (*i)->getName() << " ";
+    sstream << "\n" << "ConstraintSolver: ";
+    for (Sequence<ConstraintSolver>::iterator i = constraintSolver.begin(), iend = constraintSolver.end(); i != iend; ++i)
+        sstream << (*i)->getName() << " ";
+    sstream << "VisualLoop: ";
+    for (Single<VisualLoop>::iterator i = visualLoop.begin(), iend = visualLoop.end(); i != iend; ++i)
+        sstream << (*i)->getName() << " ";
+    sstream << "\n" << "InteractionForceField: ";
+    for (Sequence<BaseInteractionForceField>::iterator i = interactionForceField.begin(), iend = interactionForceField.end(); i != iend; ++i)
+        sstream << (*i)->getName() << " ";
+    sstream << "\n" << "ForceField: ";
+    for (Sequence<BaseForceField>::iterator i = forceField.begin(), iend = forceField.end(); i != iend; ++i)
+        sstream << (*i)->getName() << " ";
+    sstream << "\n" << "State: ";
+    for (Single<BaseState>::iterator i = state.begin(), iend = state.end(); i != iend; ++i)
+        sstream << (*i)->getName() << " ";
+    sstream << "\n" << "MechanicalState: ";
+    for (Single<BaseMechanicalState>::iterator i = mechanicalState.begin(), iend = mechanicalState.end(); i != iend; ++i)
+        sstream << (*i)->getName() << " ";
+    sstream << "\n" << "Mechanical Mapping: ";
+    for (Single<BaseMapping>::iterator i = mechanicalMapping.begin(), iend = mechanicalMapping.end(); i != iend; ++i)
+        sstream << (*i)->getName() << " ";
+    sstream << "\n" << "Mapping: ";
+    for (Sequence<BaseMapping>::iterator i = mapping.begin(), iend = mapping.end(); i != iend; ++i)
+        sstream << (*i)->getName() << " ";
+    sstream << "\n" << "Topology: ";
+    for (Single<Topology>::iterator i = topology.begin(), iend = topology.end(); i != iend; ++i)
+        sstream << (*i)->getName() << " ";
+    sstream << "\n" << "MeshTopology: ";
+    for (Single<BaseMeshTopology>::iterator i = meshTopology.begin(), iend = meshTopology.end(); i != iend; ++i)
+        sstream << (*i)->getName() << " ";
+    sstream << "\n" << "Shader: ";
+    for (Sequence<Shader>::iterator i = shaders.begin(), iend = shaders.end(); i != iend; ++i)
+        sstream << (*i)->getName() << " ";
+    sstream << "\n" << "ProjectiveConstraintSet: ";
+    for (Sequence<BaseProjectiveConstraintSet>::iterator i = projectiveConstraintSet.begin(), iend = projectiveConstraintSet.end(); i != iend; ++i)
+        sstream << (*i)->getName() << " ";
+    sstream << "\n" << "ConstraintSet: ";
+    for (Sequence<BaseConstraintSet>::iterator i = constraintSet.begin(), iend = constraintSet.end(); i != iend; ++i)
+        sstream << (*i)->getName() << " ";
+    sstream << "\n" << "BehaviorModel: ";
+    for (Sequence<BehaviorModel>::iterator i = behaviorModel.begin(), iend = behaviorModel.end(); i != iend; ++i)
+        sstream << (*i)->getName() << " ";
+    sstream << "\n" << "VisualModel: ";
+    for (Sequence<VisualModel>::iterator i = visualModel.begin(), iend = visualModel.end(); i != iend; ++i)
+        sstream << (*i)->getName() << " ";
+    sstream << "\n" << "CollisionModel: ";
+    for (Sequence<CollisionModel>::iterator i = collisionModel.begin(), iend = collisionModel.end(); i != iend; ++i)
+        sstream << (*i)->getName() << " ";
+    sstream << "\n" << "ContextObject: ";
+    for (Sequence<ContextObject>::iterator i = contextObject.begin(), iend = contextObject.end(); i != iend; ++i)
+        sstream << (*i)->getName() << " ";
+    sstream << "\n" << "Pipeline: ";
+    for (Single<Pipeline>::iterator i = collisionPipeline.begin(), iend = collisionPipeline.end(); i != iend; ++i)
+        sstream << (*i)->getName() << " ";
+    sstream << "\n";
+
+    msg_info() << sstream.str();
 }
 
 /** @name Dependency graph

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/UpdateBoundingBoxVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/UpdateBoundingBoxVisitor.cpp
@@ -58,9 +58,9 @@ Visitor::Result UpdateBoundingBoxVisitor::processNodeTopDown(Node* node)
         // if some objects does not participate to the bounding box where they should,
         // you should overload their computeBBox function to correct that
         (*object)->computeBBox(params, true);
-//        cerr<<"UpdateBoundingBoxVisitor::processNodeTopDown object " << (*object)->getName() << " = "<< (*object)->f_bbox.getValue(params) << endl;
+
         nodeBBox->include((*object)->f_bbox.getValue(params));
-//        cerr << "   new bbox = " << *nodeBBox << endl;
+
         sofa::helper::AdvancedTimer::stepEnd("ComputeBBox: " + (*object)->getName());
     }
     node->f_bbox.endEdit(params);
@@ -76,7 +76,6 @@ void UpdateBoundingBoxVisitor::processNodeBottomUp(simulation::Node* node)
     Node::ChildIterator childNode;
     for( childNode = node->child.begin(); childNode!=node->child.end(); ++childNode)
     {
-//        cerr<<"   UpdateBoundingBoxVisitor::processNodeBottomUpDown object " << (*childNode)->getName() << endl;
         nodeBBox->include((*childNode)->f_bbox.getValue(params));
     }
     node->f_bbox.endEdit(params);

--- a/SofaKernel/modules/SofaSimulationGraph/DAGNodeMultiMappingElement.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/DAGNodeMultiMappingElement.cpp
@@ -51,8 +51,8 @@ void DAGNodeMultiMappingElement::updateSceneGraph(
     helper::vector<simulation::Node*>::const_iterator it;
     for( it = otherInputs.begin(); it != otherInputs.end(); ++it)
     {
-        multiMapping->serr << "Node: " << (*it)->getName() << " does not belong to "
-                << multiMapping->getContext()->getName() << "ancestors" << multiMapping->sendl;
+        msg_error(multiMapping) << "Node: " << (*it)->getName() << " does not belong to "
+            << multiMapping->getContext()->getName() << "ancestors.";
     }
 }
 


### PR DESCRIPTION
Tried not to go too quickly....
- Replaced serr by msg_error/msg_warning and msg_info regarding the case.
- Remove all commented serr.
- Use stringstream to accumulate errors when inside a loop.

This PR only trigger classes in SofaKernel. See #1236 for changes in Sofa Modules



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
