### PR TITLE
[SofaHelper] FIX Eigen install path

### DIFF
--- a/SofaKernel/modules/SofaHelper/CMakeLists.txt
+++ b/SofaKernel/modules/SofaHelper/CMakeLists.txt
@@ -422,7 +422,7 @@ if(EIGEN3_FOUND)
         )
     install(DIRECTORY ${EIGEN3_INCLUDE_DIR}/unsupported/Eigen
         COMPONENT headers
-        DESTINATION "include/extlibs/Eigen"
+        DESTINATION "include/extlibs/Eigen/unsupported/Eigen"
         PATTERN "*.in" EXCLUDE
         PATTERN "*.txt" EXCLUDE
         PATTERN "*.cpp" EXCLUDE


### PR DESCRIPTION
FIX install path for headers in `unsupported/Eigen`


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
