### PR TITLE
[SofaCUDA] Compilation without OpenGL

### DIFF
--- a/applications/plugins/SofaCUDA/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/CMakeLists.txt
@@ -10,11 +10,6 @@ if(NOT WIN32)
     set(CUDA_PROPAGATE_HOST_FLAGS OFF)
 endif()
 
-if(${SOFA_NO_OPENGL})
-    message(WARNING "CMake flag SOFA_NO_OPENGL is active.")
-    message("OpenGL-related code wont be enabled (Sharing OpenGL buffers with CUDA)")
-endif()
-
 set(HEADER_FILES
     config.h.in
     sofa/gpu/cuda/CudaBarycentricMapping.h
@@ -78,8 +73,6 @@ set(HEADER_FILES
     sofa/gpu/cuda/CudaTypes.h
     sofa/gpu/cuda/CudaUniformMass.h
     sofa/gpu/cuda/CudaUniformMass.inl
-    sofa/gpu/cuda/CudaVisualModel.h
-    sofa/gpu/cuda/CudaVisualModel.inl
     sofa/gpu/cuda/mycuda.h
 )
 
@@ -130,7 +123,6 @@ set(SOURCE_FILES
     sofa/gpu/cuda/CudaTriangularFEMForceFieldOptim.cpp
     sofa/gpu/cuda/CudaTypes.cpp
     sofa/gpu/cuda/CudaUniformMass.cpp
-    sofa/gpu/cuda/CudaVisualModel.cpp
     sofa/gpu/cuda/mycuda.cpp
 )
 
@@ -159,10 +151,24 @@ set(CUDA_SOURCES
     sofa/gpu/cuda/CudaTetrahedronTLEDForceField.cu
     sofa/gpu/cuda/CudaTriangularFEMForceFieldOptim.cu
     sofa/gpu/cuda/CudaUniformMass.cu
-    sofa/gpu/cuda/CudaVisualModel.cu
     sofa/gpu/cuda/mycuda.cu
 )
 
+if(SOFA_NO_OPENGL)
+    message(WARNING "CMake flag SOFA_NO_OPENGL is active.")
+    message("OpenGL-related code wont be enabled (Sharing OpenGL buffers with CUDA)")
+else()
+    list(APPEND HEADER_FILES
+        sofa/gpu/cuda/CudaVisualModel.h
+        sofa/gpu/cuda/CudaVisualModel.inl
+    )
+    list(APPEND SOURCE_FILES
+        sofa/gpu/cuda/CudaVisualModel.cpp
+    )
+    list(APPEND CUDA_SOURCES
+        sofa/gpu/cuda/CudaVisualModel.cu
+    )
+endif()
 
 set(README_FILES SofaCUDA.txt)
 

--- a/applications/plugins/SofaCUDA/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/CMakeLists.txt
@@ -11,8 +11,8 @@ if(NOT WIN32)
 endif()
 
 if(${SOFA_NO_OPENGL})
-    message(SEND_ERROR "Warning: CMake flag SOFA_NO_OPENGL is active.")
-    message("Flag SOFA_NO_OPENGL incompatible with the SofaCUDA plugin.")
+    message(WARNING "CMake flag SOFA_NO_OPENGL is active.")
+    message("OpenGL-related code wont be enabled (Sharing OpenGL buffers with CUDA)")
 endif()
 
 set(HEADER_FILES
@@ -315,7 +315,11 @@ target_include_directories(${PROJECT_NAME} PUBLIC "$<INSTALL_INTERFACE:include>"
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>")
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "${SOFACUDA_COMPILE_DEFINITIONS}")
-target_link_libraries(${PROJECT_NAME} SofaOpenglVisual SofaGeneralEngine SofaGeneralDeformable SofaEngine SofaUserInteraction SofaComponentAdvanced SofaComponentMisc)
+target_link_libraries(${PROJECT_NAME} SofaGeneralEngine SofaGeneralDeformable SofaEngine SofaUserInteraction SofaComponentAdvanced SofaComponentMisc)
+
+if(NOT SOFA_NO_OPENGL)
+    target_link_libraries(${PROJECT_NAME} SofaOpenglVisual)
+endif()
 
 if(SofaDistanceGrid_FOUND)
     target_link_libraries(${PROJECT_NAME} SofaDistanceGrid)

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaDistanceGridCollisionModel.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaDistanceGridCollisionModel.cpp
@@ -674,6 +674,7 @@ void CudaRigidDistanceGridCollisionModel::draw(const core::visual::VisualParams*
 
 void CudaRigidDistanceGridCollisionModel::draw(const core::visual::VisualParams* ,int index)
 {
+#ifndef SOFA_NO_OPENGL
     if (elems[index].isTransformed)
     {
         glPushMatrix();
@@ -803,6 +804,7 @@ void CudaRigidDistanceGridCollisionModel::draw(const core::visual::VisualParams*
     {
         glPopMatrix();
     }
+#endif // SOFA_NO_OPENGL
 }
 
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaFixedTranslationConstraint.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaFixedTranslationConstraint.cpp
@@ -49,6 +49,7 @@ void FixedTranslationConstraint<gpu::cuda::CudaVec6dTypes>::draw(const core::vis
 template <>
 void component::projectiveconstraintset::FixedTranslationConstraint<gpu::cuda::CudaVec6fTypes>::draw(const core::visual::VisualParams* vparams)
 {
+#ifndef SOFA_NO_OPENGL
     const SetIndexArray & indices = f_indices.getValue();
     if (!vparams->displayFlags().getShowBehaviorModels())
         return;
@@ -72,6 +73,7 @@ void component::projectiveconstraintset::FixedTranslationConstraint<gpu::cuda::C
         }
     }
     glEnd();
+#endif //   SOFA_NO_OPENGL
 }
 
 #ifdef SOFA_GPU_CUDA_DOUBLE

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMemoryManager.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMemoryManager.h
@@ -26,8 +26,9 @@
 #include <cstring>
 #include "mycuda.h"
 
+#ifndef  SOFA_NO_OPENGL
 #include <sofa/helper/system/gl.h>
-
+#endif // SOFA_NO_OPENGL
 
 namespace sofa
 {
@@ -51,7 +52,9 @@ public :
 
     typedef T* host_pointer;
     typedef /*mutable*/ void* device_pointer;
+#ifndef  SOFA_NO_OPENGL
     typedef GLuint gl_buffer;
+#endif // SOFA_NO_OPENGL
 
     enum { MAX_DEVICES = 8 };
     enum { BSIZE = 64 };
@@ -113,6 +116,7 @@ public :
 
     static bool bufferAlloc(gl_buffer* bId, int n)
     {
+#ifndef SOFA_NO_OPENGL
         if (n > 0)
         {
             glGenBuffers(1, bId);
@@ -121,34 +125,47 @@ public :
             glBindBuffer( GL_ARRAY_BUFFER, 0);
             return true;
         }
+#endif // SOFA_NO_OPENGL
         return false;
     }
 
     static void bufferFree(const gl_buffer bId)
     {
+#ifndef SOFA_NO_OPENGL
         glDeleteBuffers( 1, &bId);
+#endif // SOFA_NO_OPENGL
     }
 
     static bool bufferRegister(const gl_buffer bId)
     {
+#ifndef SOFA_NO_OPENGL
         mycudaGLRegisterBufferObject(bId);
+#endif // SOFA_NO_OPENGL
         return true;
     }
 
     static void bufferUnregister(const gl_buffer bId)
     {
+#ifndef SOFA_NO_OPENGL
         mycudaGLUnregisterBufferObject(bId);
+#endif // SOFA_NO_OPENGL
     }
 
     static bool bufferMapToDevice(device_pointer * dDestPointer, const gl_buffer bSrcId)
     {
+#ifndef SOFA_NO_OPENGL
         mycudaGLMapBufferObject(dDestPointer, bSrcId);
         return true;
+#else
+        return false;
+#endif // SOFA_NO_OPENGL
     }
 
     static void bufferUnmapToDevice(device_pointer * /*dDestPointer*/, const gl_buffer bSrcId)
     {
+#ifndef SOFA_NO_OPENGL
         mycudaGLUnmapBufferObject(bSrcId);
+#endif // SOFA_NO_OPENGL
     }
 
     static device_pointer deviceOffset(device_pointer dPointer,size_t offset)

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPenalityContactForceField.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPenalityContactForceField.inl
@@ -217,6 +217,7 @@ SReal PenalityContactForceField<CudaVec3fTypes>::getPotentialEnergy(const core::
 //template<>
 void PenalityContactForceField<CudaVec3fTypes>::draw(const core::visual::VisualParams* vparams)
 {
+#ifndef SOFA_NO_OPENGL
     if (!((this->mstate1 == this->mstate2)?  vparams->displayFlags().getShowForceFields():vparams->displayFlags().getShowInteractionForceFields())) return;
     const VecCoord& p1 = this->mstate1->read(core::ConstVecCoordId::position())->getValue();
     const VecCoord& p2 = this->mstate2->read(core::ConstVecCoordId::position())->getValue();
@@ -262,6 +263,7 @@ void PenalityContactForceField<CudaVec3fTypes>::draw(const core::visual::VisualP
         }
         glEnd();
     }
+#endif // SOFA_NO_OPENGL
 }
 
 } // namespace interactionforcefield

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPointModel.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPointModel.cpp
@@ -72,6 +72,7 @@ void CudaPointModel::init()
 
 void CudaPointModel::draw(const core::visual::VisualParams* ,int index)
 {
+#ifndef SOFA_NO_OPENGL
     const int gsize = groupSize.getValue();
     CudaPoint t(this,index);
     glBegin(GL_POINTS);
@@ -83,10 +84,12 @@ void CudaPointModel::draw(const core::visual::VisualParams* ,int index)
         glVertex3fv(x[i0+p].ptr());
     }
     glEnd();
+#endif // SOFA_NO_OPENGL
 }
 
 void CudaPointModel::draw(const core::visual::VisualParams* vparams)
 {
+#ifndef SOFA_NO_OPENGL
     if (isActive() && vparams->displayFlags().getShowCollisionModels())
     {
         if (vparams->displayFlags().getShowWireFrame())
@@ -109,6 +112,7 @@ void CudaPointModel::draw(const core::visual::VisualParams* vparams)
     }
     if (isActive() && getPrevious()!=NULL && vparams->displayFlags().getShowBoundingCollisionModels())
         getPrevious()->draw(vparams);
+#endif // SOFA_NO_OPENGL
 }
 
 using sofa::component::collision::CubeModel;

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSPHFluidForceField.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSPHFluidForceField.inl
@@ -242,6 +242,7 @@ void SPHFluidForceField<gpu::cuda::CudaVec3dTypes>::addDForce(const core::Mechan
 template <>
 void SPHFluidForceField<gpu::cuda::CudaVec3fTypes>::draw(const core::visual::VisualParams* vparams)
 {
+#ifdef SOFA_NO_OPENGL
     if (!vparams->displayFlags().getShowForceFields()) return;
     //if (m_grid != NULL)
     //	grid->draw(vparams);
@@ -271,6 +272,7 @@ void SPHFluidForceField<gpu::cuda::CudaVec3fTypes>::draw(const core::visual::Vis
     }
     glEnd();
     glPointSize(1);
+#endif // SOFA_NO_OPENGL
 }
 
 } // namespace forcefield

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSpatialGridContainer.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSpatialGridContainer.inl
@@ -300,6 +300,7 @@ void SpatialGrid< SpatialGridTypes < gpu::cuda::CudaVectorTypes<TCoord,TDeriv,TR
 template<class TCoord, class TDeriv, class TReal>
 void SpatialGrid< SpatialGridTypes < gpu::cuda::CudaVectorTypes<TCoord,TDeriv,TReal> > >::draw(const core::visual::VisualParams* )
 {
+#ifdef SOFA_NO_OPENGL
     if (!lastX) return;
     int nbPoints = particleHash.size();
     int index0 = nbCells+BSIZE;
@@ -330,6 +331,7 @@ void SpatialGrid< SpatialGridTypes < gpu::cuda::CudaVectorTypes<TCoord,TDeriv,TR
     }
     glEnd();
     glPointSize(1);
+#endif // SOFA_NO_OPENGL
 }
 
 } // namespace container

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaUniformMass.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaUniformMass.inl
@@ -219,6 +219,7 @@ SReal UniformMass<gpu::cuda::CudaRigid3fTypes,sofa::defaulttype::RigidMass<3,flo
 template <>
 void UniformMass<gpu::cuda::CudaRigid3fTypes, defaulttype::RigidMass<3,float> >::draw(const core::visual::VisualParams* vparams)
 {
+#ifndef SOFA_NO_OPENGL
     if (!vparams->displayFlags().getShowBehaviorModels())
         return;
     const VecCoord& x = mstate->read(core::ConstVecCoordId::position())->getValue();
@@ -242,6 +243,7 @@ void UniformMass<gpu::cuda::CudaRigid3fTypes, defaulttype::RigidMass<3,float> >:
     {
         helper::gl::Axis::draw(x[i].getCenter(), x[i].getOrientation(), len);
     }
+#endif // SOFA_NO_OPENGL
 }
 
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaVisualModel.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaVisualModel.inl
@@ -311,6 +311,7 @@ void CudaVisualModel< TDataTypes >::drawShadow(const core::visual::VisualParams*
 template<class TDataTypes>
 void CudaVisualModel< TDataTypes >::internalDraw(const core::visual::VisualParams* vparams)
 {
+#ifndef SOFA_NO_OPENGL
     if (!vparams->displayFlags().getShowVisualModels()) return;
 
     if (!topology || !state || !state->getSize()) return;
@@ -443,6 +444,7 @@ void CudaVisualModel< TDataTypes >::internalDraw(const core::visual::VisualParam
     }
 
     d_x->endEdit();
+#endif // SOFA_NO_OPENGL
 }
 
 template<class TDataTypes>


### PR DESCRIPTION
Small PR to allow compilation of SofaCUDA plugin with SOFA_NO_OPENGL flag (i.e disabling OpenGL)
Remarks:
- The components' draw() functions in SofaCUDA should share their code with their "normal"  version.
For example, CudaUniformMass with cudarigid3f should call the draw() of UniformMass<Rigid3>
Some work has to be done further in Sofa itself, that's why I just add preprocessor tests (#ifdef SOFA_NO_OPENGL) and did not use the drawtool functions 👅 
- Obviously, if you compile without OpenGL, you wont be able to share OpenGL buffer in CUDA. In other words it is useless to use CudaVisualModel without SOFA_NO_OPENGL.
(Actually CudaVisualModel should be renamed CudaOglModel)

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
