### PR TITLE
[SofaHelper] AdvancedTimer wasn't using the good timer ids for the label assignments

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.cpp
@@ -1410,19 +1410,19 @@ helper::vector<Record> AdvancedTimer::getRecords(IdTimer id)
         switch (r.type) {
             case Record::RBEGIN: // Timer begins
             case Record::REND: // Timer ends
-                r.label = (std::string) AdvancedTimer::IdTimer(r.id);
+                r.label = IdTimer::IdFactory::getName(r.id);
                 break;
             case Record::RSTEP_BEGIN: // Step begins
             case Record::RSTEP_END: // Step ends
             case Record::RSTEP: // Step
-                r.label = (std::string) AdvancedTimer::IdStep(r.id);
+                r.label = IdStep::IdFactory::getName(r.id);
                 break;
             case Record::RVAL_SET: // Sets a value
             case Record::RVAL_ADD: // Adds a value
-                r.label = (std::string) AdvancedTimer::IdVal(r.id);
+                r.label = IdVal::IdFactory::getName(r.id);
                 break;
             default:
-                r.label = (std::string) AdvancedTimer::IdObj(r.id);
+                r.label = "Unknown";
                 break;
         }
     }

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.cpp
@@ -1406,8 +1406,27 @@ std::map<AdvancedTimer::IdStep, StepData> AdvancedTimer::getStepData(IdTimer id,
 helper::vector<Record> AdvancedTimer::getRecords(IdTimer id)
 {
     TimerData& data = timers[id];
-    for (unsigned int i=0; i<data.records.size(); ++i)
-        data.records[i].label = std::string(AdvancedTimer::IdStep(data.records[i].id));
+    for (Record & r : data.records) {
+        switch (r.type) {
+            case Record::RBEGIN: // Timer begins
+            case Record::REND: // Timer ends
+                r.label = (std::string) AdvancedTimer::IdTimer(r.id);
+                break;
+            case Record::RSTEP_BEGIN: // Step begins
+            case Record::RSTEP_END: // Step ends
+            case Record::RSTEP: // Step
+                r.label = (std::string) AdvancedTimer::IdStep(r.id);
+                break;
+            case Record::RVAL_SET: // Sets a value
+            case Record::RVAL_ADD: // Adds a value
+                r.label = (std::string) AdvancedTimer::IdVal(r.id);
+                break;
+            default:
+                r.label = (std::string) AdvancedTimer::IdObj(r.id);
+                break;
+        }
+    }
+
     return data.records;
 }
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.h
@@ -349,9 +349,9 @@ public:
     static std::map<AdvancedTimer::IdStep, StepData> getStepData(IdTimer id, bool processData = false);
 
     /**
-     * @brief getRecords the vector of \sa Record of the AdvancedTimer given execution id.
+     * @brief getRecords the vector of Record of the AdvancedTimer given execution id.
      * @param id IdTimer, id of the timer
-     * @return The timer full records inside a vector of \sa Record
+     * @return The timer full records inside a vector of Record
      */
     static helper::vector<Record> getRecords(IdTimer id);
 


### PR DESCRIPTION
PR #1028 added a getter for the records of the advanced timer that automatically assigns the string version of the record's **id** to a new field called **label**.

There was a small problem with this, records can have different types of ids (IdTimer, IdStep, IdVal or IdObj). Casting a record id to a wrong type causes the wrong string version of the id to be assigned to the label.

This PR fixes this.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
