### PR TITLE
[SofaSimulationCore] Add a way to fill a multi vector from a base vector with a MechanicalOperations (mops).

### DIFF
--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalMatrixVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalMatrixVisitor.h
@@ -359,7 +359,7 @@ public:
 class SOFA_SIMULATION_CORE_API MechanicalMultiVectorFromBaseVectorVisitor : public BaseMechanicalVisitor
 {
 public:
-    sofa::defaulttype::BaseVector *src;
+    const sofa::defaulttype::BaseVector *src;
     sofa::core::MultiVecId dest;
     const sofa::core::behavior::MultiMatrixAccessor* matrix;
     int offset;
@@ -370,7 +370,7 @@ public:
 
     MechanicalMultiVectorFromBaseVectorVisitor(
         const core::ExecParams* params, sofa::core::MultiVecId _dest,
-        defaulttype::BaseVector * _src,
+        const defaulttype::BaseVector * _src,
         const sofa::core::behavior::MultiMatrixAccessor* _matrix = nullptr )
         : BaseMechanicalVisitor(params) , src(_src), dest(_dest), matrix(_matrix), offset(0)
     {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalMatrixVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalMatrixVisitor.h
@@ -325,7 +325,7 @@ public:
 class SOFA_SIMULATION_CORE_API MechanicalMultiVectorPeqBaseVectorVisitor : public BaseMechanicalVisitor
 {
 public:
-    sofa::defaulttype::BaseVector *src;
+    const sofa::defaulttype::BaseVector *src;
     sofa::core::MultiVecDerivId dest;
     const sofa::core::behavior::MultiMatrixAccessor* matrix;
     int offset;
@@ -335,7 +335,7 @@ public:
     const char* getClassName() const override { return "MechanicalMultiVectorPeqBaseVectorVisitor"; }
 
     MechanicalMultiVectorPeqBaseVectorVisitor(
-        const core::ExecParams* params, sofa::core::MultiVecDerivId _dest, defaulttype::BaseVector * _src,
+        const core::ExecParams* params, sofa::core::MultiVecDerivId _dest, const defaulttype::BaseVector * _src,
         const sofa::core::behavior::MultiMatrixAccessor* _matrix = nullptr )
         : BaseMechanicalVisitor(params) , src(_src), dest(_dest), matrix(_matrix), offset(0)
     {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalOperations.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalOperations.cpp
@@ -534,7 +534,7 @@ void MechanicalOperations::multiVector2BaseVector(core::ConstMultiVecId src, def
 }
 
 
-void MechanicalOperations::multiVectorPeqBaseVector(core::MultiVecDerivId dest, defaulttype::BaseVector *src, const sofa::core::behavior::MultiMatrixAccessor* matrix)
+void MechanicalOperations::multiVectorPeqBaseVector(core::MultiVecDerivId dest, const defaulttype::BaseVector *src, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {
     if (src != nullptr)
     {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalOperations.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalOperations.cpp
@@ -517,7 +517,7 @@ void MechanicalOperations::addSubMBK_ToMatrix(const sofa::core::behavior::MultiM
     }
 }
 
-void MechanicalOperations::baseVector2MultiVector(core::MultiVecId dest, defaulttype::BaseVector *src, const sofa::core::behavior::MultiMatrixAccessor* matrix)
+void MechanicalOperations::baseVector2MultiVector(const defaulttype::BaseVector *src, core::MultiVecId dest, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {
     if (src != nullptr)
     {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalOperations.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalOperations.cpp
@@ -517,7 +517,13 @@ void MechanicalOperations::addSubMBK_ToMatrix(const sofa::core::behavior::MultiM
     }
 }
 
-
+void MechanicalOperations::baseVector2MultiVector(core::MultiVecId dest, defaulttype::BaseVector *src, const sofa::core::behavior::MultiMatrixAccessor* matrix)
+{
+    if (src != nullptr)
+    {
+        executeVisitor( MechanicalMultiVectorFromBaseVectorVisitor(&mparams, dest, src, matrix) );
+    }
+}
 
 void MechanicalOperations::multiVector2BaseVector(core::ConstMultiVecId src, defaulttype::BaseVector *dest, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalOperations.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalOperations.h
@@ -137,7 +137,7 @@ public:
 
     void multiVector2BaseVector(core::ConstMultiVecId src, defaulttype::BaseVector *dest, const sofa::core::behavior::MultiMatrixAccessor* matrix);
     void baseVector2MultiVector(const defaulttype::BaseVector *src, core::MultiVecId dest, const sofa::core::behavior::MultiMatrixAccessor* matrix);
-    void multiVectorPeqBaseVector(core::MultiVecDerivId dest, defaulttype::BaseVector *src, const sofa::core::behavior::MultiMatrixAccessor* matrix);
+    void multiVectorPeqBaseVector(core::MultiVecDerivId dest, const defaulttype::BaseVector *src, const sofa::core::behavior::MultiMatrixAccessor* matrix);
 
     /// @}
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalOperations.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalOperations.h
@@ -136,6 +136,7 @@ public:
     void addSubMBK_ToMatrix(const sofa::core::behavior::MultiMatrixAccessor* matrix, const helper::vector<unsigned> & subMatrixIndex, SReal mFact, SReal bFact, SReal kFact);
 
     void multiVector2BaseVector(core::ConstMultiVecId src, defaulttype::BaseVector *dest, const sofa::core::behavior::MultiMatrixAccessor* matrix);
+    void baseVector2MultiVector(core::MultiVecId dest, defaulttype::BaseVector *src, const sofa::core::behavior::MultiMatrixAccessor* matrix);
     void multiVectorPeqBaseVector(core::MultiVecDerivId dest, defaulttype::BaseVector *src, const sofa::core::behavior::MultiMatrixAccessor* matrix);
 
     /// @}

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalOperations.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalOperations.h
@@ -136,7 +136,7 @@ public:
     void addSubMBK_ToMatrix(const sofa::core::behavior::MultiMatrixAccessor* matrix, const helper::vector<unsigned> & subMatrixIndex, SReal mFact, SReal bFact, SReal kFact);
 
     void multiVector2BaseVector(core::ConstMultiVecId src, defaulttype::BaseVector *dest, const sofa::core::behavior::MultiMatrixAccessor* matrix);
-    void baseVector2MultiVector(core::MultiVecId dest, defaulttype::BaseVector *src, const sofa::core::behavior::MultiMatrixAccessor* matrix);
+    void baseVector2MultiVector(const defaulttype::BaseVector *src, core::MultiVecId dest, const sofa::core::behavior::MultiMatrixAccessor* matrix);
     void multiVectorPeqBaseVector(core::MultiVecDerivId dest, defaulttype::BaseVector *src, const sofa::core::behavior::MultiMatrixAccessor* matrix);
 
     /// @}


### PR DESCRIPTION
The MechanicalOperations (mops) already had the method `multiVector2BaseVector` that allows us to fill a BaseVector (one continuous memory vector) from a multi vector (group of vectors contained inside mechanical objects).

However, the were no way to do the inverse (build a multi vector from a continuous vector) beside creating a new visitor, which is now done automatically by the mops.

This PR is only adding a new method, it is non-breaking.


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
