### PR TITLE
[SofaKernel/CMakeLists.txt] Set the default compilation mode to c++17.

### DIFF
--- a/SofaKernel/cmake/CompilerOptions.cmake
+++ b/SofaKernel/cmake/CompilerOptions.cmake
@@ -66,9 +66,9 @@ endif()
 
 
 
-# C++11 is now mandatory
+# C++17 is now mandatory
 # TODO how to propagate such properties to dependents?
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # An important C++11 feature may be not enabled due to

--- a/applications/plugins/ARTrack/extlibs/ARTrackLib/mainTracker.cpp
+++ b/applications/plugins/ARTrack/extlibs/ARTrackLib/mainTracker.cpp
@@ -19,7 +19,6 @@
 
 #include <iostream>
 
-using namespace std;
 #ifndef _WIN32
 #define OS_UNIX  // for Unix (Linux, Irix)
 #else

--- a/applications/plugins/SofaSimpleGUI/SpringInteractor.cpp
+++ b/applications/plugins/SofaSimpleGUI/SpringInteractor.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-using namespace std;
 #include "SpringInteractor.h"
 #include "PickedPoint.h"
 #include <sofa/core/SofaLibrary.h>

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/SPHFluidForceField.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/SPHFluidForceField.inl
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <sofa/helper/AdvancedTimer.h>
 
-#if __cplusplus >= 201703L
+#if __has_include(<execution>)
 #include <execution>
 #endif
 
@@ -154,7 +154,7 @@ void SPHFluidForceField<DataTypes>::computeNeighbors(const core::MechanicalParam
     // This is an O(n2) step, except if a hash-grid is used to optimize it
     if (m_grid == nullptr)
     {
-#if __cplusplus < 201703L
+#if not __has_include(<execution>)
         for (int i=0; i<n; i++)
         {
             const Coord& ri = x[i];


### PR DESCRIPTION
Because most compiler handle it properly and we are in 2020.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
