### PR TITLE
[SofaKernel/SofaHelper] Add auto-friendly getWriteAccessors/getReadAcessor...

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/accessor.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/accessor.h
@@ -287,6 +287,35 @@ public:
 };
 
 
+/// Returns a read accessor from the provided Data<>
+/// Example of use:
+///   auto points = getReadAccessor(d_points)
+template<class D>
+sofa::helper::ReadAccessor<D> getReadAccessor(D& c)
+{
+    return sofa::helper::ReadAccessor<D>{ c };
+}
+
+/// Returns a write only accessor from the provided Data<>
+/// Example of use:
+///   auto points = getWriteOnlyAccessor(d_points)
+template<class D>
+sofa::helper::WriteAccessor<D> getWriteAccessor(D& c)
+{
+    return sofa::helper::WriteAccessor<D>{ c };
+}
+
+/// Returns a write only accessor from the provided Data<>
+/// WriteOnly accessors are faster than WriteAccessor because
+/// as the data is only read this means there is no need to pull
+/// the data from the parents
+/// Example of use:
+///   auto points = getWriteOnlyAccessor(d_points)
+template<class D>
+sofa::helper::WriteOnlyAccessor<D> getWriteOnlyAccessor(D& c)
+{
+    return sofa::helper::WriteOnlyAccessor<D>{ c };
+}
 
 } // namespace helper
 


### PR DESCRIPTION
In SOFA not using an accessor is really bad (I mean really really bad), but the syntax is not really
friendly and thus discourage ppl to use it. 

The PR adds few easing function smooth the syntax. 
So you can now type:
auto points = getReadAccessor(d_points);
in place of:
ReadAccessor<Data<Vec3> points = d_points;

In also make code update more manageable, as the whole code based does not need to be changed if the d_points type change.


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
