### PR TITLE
[SofaHelper] Add the obj id to labels when available

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.cpp
@@ -1411,11 +1411,17 @@ helper::vector<Record> AdvancedTimer::getRecords(IdTimer id)
             case Record::RBEGIN: // Timer begins
             case Record::REND: // Timer ends
                 r.label = IdTimer::IdFactory::getName(r.id);
+                if (r.obj != 0 || (!IdObj::IdFactory::getName(r.obj).empty() && IdObj::IdFactory::getName(r.obj) != "0")) {
+                    r.label += " (" + IdObj::IdFactory::getName(r.obj) + ")";
+                }
                 break;
             case Record::RSTEP_BEGIN: // Step begins
             case Record::RSTEP_END: // Step ends
             case Record::RSTEP: // Step
                 r.label = IdStep::IdFactory::getName(r.id);
+                if (r.obj != 0 || (!IdObj::IdFactory::getName(r.obj).empty() && IdObj::IdFactory::getName(r.obj) != "0")) {
+                    r.label += " (" + IdObj::IdFactory::getName(r.obj) + ")";
+                }
                 break;
             case Record::RVAL_SET: // Sets a value
             case Record::RVAL_ADD: // Adds a value


### PR DESCRIPTION
Some advanced timer steps also pass the node as an "obj" data to the timer's record. This allows one to differentiate a timer call from another one in another node. I guess one picture is worth a lot or words here:

<img width="675" alt="advanced_timer_graph" src="https://user-images.githubusercontent.com/6951981/74366929-3e7b6800-4dd1-11ea-82de-c4631ee7e857.png">




This PR adds these obj ids to the timer labels.




______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
