### PR TITLE
[extlibs/gtest] Add character test in gtest paramName to allow dash character

### DIFF
--- a/extlibs/gtest/include/gtest/internal/gtest-param-util.h
+++ b/extlibs/gtest/include/gtest/internal/gtest-param-util.h
@@ -639,7 +639,7 @@ class ParameterizedTestCaseInfo : public ParameterizedTestCaseInfoBase {
 
     // Check for invalid characters
     for (std::string::size_type index = 0; index < name.size(); ++index) {
-      if (!isalnum(name[index]) && name[index] != '_')
+      if (!isalnum(name[index]) && name[index] != '_' && name[index] != '-')
         return false;
     }
 


### PR DESCRIPTION
For Regression-Test to be able to test scenes with name like: EulerExplicitSolver-diagonal.scn 

Solves error:
```
[ FATAL ] /data/Softwares/sofa/src/master/extlibs/gtest/include/gtest/internal/gtest-param-util.h:569:: Condition IsValidParamName(param_name) failed. Parameterized test name 'EulerExplicitSolver-diagonal' is invalid, in /data/Softwares/sofa/src/master/applications/projects/Regression/Regression_test/Regression_test.cpp line 224
```



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
