### PR TITLE
[SofaKernel] Cleaner output when the creation of an object fails

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ForceField.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ForceField.h
@@ -201,8 +201,10 @@ public:
     template<class T>
     static bool canCreate(T*& obj, objectmodel::BaseContext* context, objectmodel::BaseObjectDescription* arg)
     {
-        if (dynamic_cast<MechanicalState<DataTypes>*>(context->getMechanicalState()) == nullptr)
+        if (dynamic_cast<MechanicalState<DataTypes>*>(context->getMechanicalState()) == nullptr) {
+            arg->logError(std::string("No mechanical state with the datatype '") + DataTypes::Name() + "' found in the context node.");
             return false;
+        }
         return BaseObject::canCreate(obj, context, arg);
     }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObjectDescription.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObjectDescription.h
@@ -124,9 +124,11 @@ public:
     /// Get the full name of this object (i.e. concatenation if all the names of its ancestors and itself)
     virtual std::string getFullName();
 
-    virtual void logError(std::string s) {errors.push_back(s);}
+    virtual void logError(const std::string & s) {errors.push_back(s);}
+    virtual void logErrors(const std::vector<std::string> & e) {errors.insert(errors.end(), e.begin(), e.end());}
 
     std::vector< std::string > const& getErrors() const {return errors;}
+    virtual void clearErrors() {errors.clear();}
 
 protected:
     AttributeMap attributes;


### PR DESCRIPTION
Error message when the creation of an object fails are difficult to read and it isn't always obvious where the error is.

With this PR, the message is a little bit more clear. Now we only need to add error message inside the components `canCreate` methods (see the changes I made in the `ForceField` class in this PR).

Before:
![image](https://user-images.githubusercontent.com/6951981/75893831-a9015000-5e33-11ea-8871-ae414f1f8208.png)

After:
![image](https://user-images.githubusercontent.com/6951981/75893859-b0285e00-5e33-11ea-8318-12c484a4852a.png)




______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
