### PR TITLE
[SofaSimulationCore] FIX resizing of bboxes in UpdateBoundingBoxVisitor

### DIFF
--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/UpdateBoundingBoxVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/UpdateBoundingBoxVisitor.cpp
@@ -45,8 +45,7 @@ Visitor::Result UpdateBoundingBoxVisitor::processNodeTopDown(Node* node)
     helper::vector<BaseObject*>::iterator object;
     node->get<BaseObject>(&objectList,BaseContext::Local);
     sofa::defaulttype::BoundingBox* nodeBBox = node->f_bbox.beginEdit(params);
-    if(!node->f_bbox.isSet())
-        nodeBBox->invalidate();
+    nodeBBox->invalidate();
     for ( object = objectList.begin(); object != objectList.end(); ++object)
     {
         sofa::helper::AdvancedTimer::stepBegin("ComputeBBox: " + (*object)->getName());


### PR DESCRIPTION
I don't understand why this check was made:
Without invalidating the bbox, the node's bbox will only be sized up, and never down with this visitor, to my understanding..

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
