### PR TITLE
[examples] Fix SurfacePressureForceField example

### DIFF
--- a/examples/Components/forcefield/SurfacePressureForceField.scn
+++ b/examples/Components/forcefield/SurfacePressureForceField.scn
@@ -20,7 +20,7 @@
         </Node>
         <Node name="TriangleSurf">
             <MeshObjLoader name="loader" filename="mesh/frog.obj" />
-            <Mesh />
+            <MeshTopology src="@loader" />
             <MechanicalObject src="@loader" />
             <TriangleCollisionModel group="1" />
             <LineCollisionModel group="1" />
@@ -44,7 +44,7 @@
         </Node>
         <Node name="QuadSurf">
             <MeshObjLoader name="loader" filename="mesh/frog_quads.obj" />
-            <Mesh />
+            <MeshTopology src="@loader" />
             <MechanicalObject src="@loader" />
             <TriangleCollisionModel group="1" />
             <LineCollisionModel group="1" />


### PR DESCRIPTION
MeshTopology doesn't load the topology from the mesh loader implicitely anymore






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
