### PR TITLE
 [SofaEngine] Fix engine unit tests

### DIFF
--- a/SofaKernel/modules/SofaEngine/SofaEngine_test/Engine_test.cpp
+++ b/SofaKernel/modules/SofaEngine/SofaEngine_test/Engine_test.cpp
@@ -251,6 +251,19 @@ TEST_F(Engine_test , check_propagation )
 
 namespace sofa {
 
+// specialization for special cases
+template<>
+void DataEngine_test< TestDataEngine<component::engine::JoinPoints<defaulttype::Vec3Types> > >::preInit()
+{
+    m_engineInput->findData("points")->read("0.0 0.0 0.0");
+}
+
+template<>
+void DataEngine_test< TestDataEngine<component::engine::RandomPointDistributionInSurface<defaulttype::Vec3Types> > >::preInit()
+{
+    m_engineInput->findData("vertices")->read("1 -0.5 -0.5 -0.5  1 0 0  0 1 0  0 0 1");
+    m_engineInput->findData("triangles")->read("0 1 2 0 1 3  0 2 3  1 2 3");
+}
 
 // testing every engines of SofaEngine here
 
@@ -263,7 +276,7 @@ typedef testing::Types<
 TestDataEngine< component::engine::SelectLabelROI<unsigned int> >,
 TestDataEngine< component::engine::SelectConnectedLabelsROI<unsigned int> >,
 TestDataEngine< component::engine::DilateEngine<defaulttype::Vec3Types> >, // DilateEngine only defined for Vec3dTypes
-
+TestDataEngine< component::engine::JoinPoints<defaulttype::Vec3Types> >, 
 TestDataEngine< component::engine::GenerateCylinder<defaulttype::Vec3Types> >,
 TestDataEngine< component::engine::ExtrudeSurface<defaulttype::Vec3Types> >,
 TestDataEngine< component::engine::ExtrudeQuadsAndGenerateHexas<defaulttype::Vec3Types> >,
@@ -286,7 +299,6 @@ TestDataEngine< component::engine::ValuesFromIndices<int> >,
 TestDataEngine< component::engine::IndicesFromValues<int> >,
 TestDataEngine< component::engine::IndexValueMapper<defaulttype::Vec3Types> >,
 TestDataEngine< component::engine::ROIValueMapper >,
-TestDataEngine< component::engine::JoinPoints<defaulttype::Vec3Types> >,
 TestDataEngine< component::engine::MapIndices<int> >,
 TestDataEngine< component::engine::RandomPointDistributionInSurface<defaulttype::Vec3Types> >,
 TestDataEngine< component::engine::SmoothMeshEngine<defaulttype::Vec3Types> >,
@@ -310,7 +322,6 @@ TestDataEngine< component::engine::SumEngine<defaulttype::Vector3> >,
 TestDataEngine< component::engine::DifferenceEngine<defaulttype::Vector3> >
 > TestTypes; // the types to instanciate.
 
-
 //// ========= Tests to run for each instanciated type
 TYPED_TEST_CASE(DataEngine_test, TestTypes);
 
@@ -320,5 +331,6 @@ TYPED_TEST( DataEngine_test , basic_test )
     EXPECT_MSG_NOEMIT(Error) ;
     this->run_basic_test();
 }
+
 
 }// namespace sofa

--- a/applications/plugins/SofaTest/DataEngine_test.h
+++ b/applications/plugins/SofaTest/DataEngine_test.h
@@ -92,6 +92,8 @@ struct DataEngine_test : public Sofa_test<>
 
     virtual void init()
     {
+        preInit();
+
         m_engineInput->init();
         m_engine->init();
 
@@ -128,24 +130,24 @@ struct DataEngine_test : public Sofa_test<>
 
         const DDGLinkContainer& inputs = m_engine->DDGNode::getInputs();
 
-        CHECKCOUNTER( 0 );  // c'est parti mon kiki
+        CHECKCOUNTER( 0 );
         const DDGLinkContainer& parent_inputs = m_engineInput->DDGNode::getInputs();
 
 
-        CHECKCOUNTER( 0 );  // c'est parti mon kiki
+        CHECKCOUNTER( 0 );
         const DDGLinkContainer& outputs = m_engine->DDGNode::getOutputs();
 
 
-        CHECKCOUNTER( 0 );  // c'est parti mon kiki
+        CHECKCOUNTER( 0 );
 
         // modifying inputs to ensure the engine should be evaluated
         for( unsigned i=0, iend=parent_inputs.size() ; i<iend ; ++i )
         {
             parent_inputs[i]->setDirtyValue();
-            CHECKCOUNTER( 0 );  // c'est parti mon kiki
+            CHECKCOUNTER( 0 );
         }
 
-        CHECKCOUNTER( 0 );  // c'est parti mon kiki
+        CHECKCOUNTER( 0 );
 
         outputs[0]->updateIfDirty(); // could call the engine
         CHECKMAXCOUNTER( 1 );
@@ -173,7 +175,11 @@ struct DataEngine_test : public Sofa_test<>
         }
         CHECKMAXCOUNTER( parent_inputs.size() );
     }
-
+private:
+    virtual void preInit()
+    {
+        // stub
+    }
 
 };
 

--- a/examples/Components/engine/ExtrudeSurface.scn
+++ b/examples/Components/engine/ExtrudeSurface.scn
@@ -1,22 +1,18 @@
 <?xml version="1.0"?>
 <Node name="root" dt="0.02">
     <RequiredPlugin name="SofaOpenglVisual"/>
-    <VisualStyle displayFlags="showCollisionModels" />
     <Node name="extrude">
-        <Mesh name="meshLoader" filename="mesh/liver.obj" />
-        <MechanicalObject />
-        <SphereROI name="surface1" centers="2 4 0" radii="0.88" drawSize="0" isVisible="0" />
-        <ExtrudeSurface template="Vec3d" name="extrusion" surfaceVertices="@meshLoader.points" surfaceTriangles="@surface1.triangleIndices" isVisible="0" />
+        <MeshObjLoader name="meshLoader" filename="mesh/liver.obj" />
+        <MechanicalObject src="@meshLoader"/>
+        <SphereROI name="surface1" centers="2 4 0" radii="0.88" drawSize="0" isVisible="0" src="@meshLoader" />
+        <ExtrudeSurface template="Vec3d" name="extrusion" triangles="@meshLoader.triangles" surfaceVertices="@meshLoader.position" surfaceTriangles="@surface1.triangleIndices" isVisible="0" />
         <RandomPointDistributionInSurface template="Vec3d" vertices="@extrusion.extrusionVertices" triangles="@extrusion.extrusionTriangles" numberOfInPoints="100" numberOfTests="3" minDistanceBetweenPoints="0.1" />
     </Node>
-    <!--<Node>
+    <Node name="Extrusion">
         <Mesh points="@../extrude/extrusion.extrusionVertices" triangles="@../extrude/extrusion.extrusionTriangles" />
         <MechanicalObject position="@../extrude/extrusion.extrusionVertices"/>
-        <Point/>
-        <Line/>
-        <Triangle/>
         <OglModel color="red" />
-    </Node>-->
+    </Node>
     <Node>
         <OglModel filename="mesh/liver.obj" />
     </Node>

--- a/examples/Components/engine/RandomPointDistributionInSurface.scn
+++ b/examples/Components/engine/RandomPointDistributionInSurface.scn
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<Node name="root" dt="0.02">
+    <RequiredPlugin name="SofaOpenglVisual"/>
+        <VisualStyle displayFlags="showBehaviorModels" />
+    <Node name="Random">
+        <MeshObjLoader name="meshLoader" filename="mesh/liver.obj" />
+        <MechanicalObject src="@meshLoader"/>
+        <RandomPointDistributionInSurface template="Vec3d" drawOutputPoints="true"
+            vertices="@meshLoader.position" triangles="@meshLoader.triangles" numberOfInPoints="100" numberOfTests="3" minDistanceBetweenPoints="0.1" 
+        />
+    </Node>
+    <Node name="Visu">
+        <VisualStyle displayFlags="showWireFrame" />
+        <OglModel filename="mesh/liver.obj" />
+    </Node>
+</Node>

--- a/modules/SofaGeneralEngine/SofaGeneralEngine_test/CMakeLists.txt
+++ b/modules/SofaGeneralEngine/SofaGeneralEngine_test/CMakeLists.txt
@@ -20,7 +20,10 @@ list(APPEND SOURCE_FILES
     SmoothMeshEngine_test.cpp
     IndicesFromValues_test.cpp
     MergePoints_test.cpp
-    IndexValueMapper_test.cpp)
+    IndexValueMapper_test.cpp
+    JoinPoints_test.cpp
+    RandomPointDistributionInSurface_test.cpp
+    )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} SofaGTestMain SofaTest SofaGeneralEngine)

--- a/modules/SofaGeneralEngine/SofaGeneralEngine_test/IndicesFromValues_test.cpp
+++ b/modules/SofaGeneralEngine/SofaGeneralEngine_test/IndicesFromValues_test.cpp
@@ -64,6 +64,7 @@ struct TestIndicesFromValues : public Sofa_test<>{
         IndicesFromValues<SReal>::SPtr m_thisObject=New<IndicesFromValues<SReal>>();
         m_thisObject->findData("global")->read(" ");
         m_thisObject->findData("values")->read("1");
+        EXPECT_MSG_EMIT(Error); // an error is emitted if the engine does not find the value (purpose of this test)
         m_thisObject->update();
 
         EXPECT_EQ(m_thisObject->findData("indices")->getValueString(),"");
@@ -82,6 +83,7 @@ struct TestIndicesFromValues : public Sofa_test<>{
         IndicesFromValues<SReal>::SPtr m_thisObject=New<IndicesFromValues<SReal>>();
         m_thisObject->findData("global")->read("0. 0.5 0.5  0. 0. 1.  0. -1. 3.");
         m_thisObject->findData("values")->read("1.  4. ");
+        EXPECT_MSG_EMIT(Error); // an error is emitted when it will not found the value
         m_thisObject->update();
 
         EXPECT_EQ(m_thisObject->findData("indices")->getValueString(),"5");
@@ -92,6 +94,7 @@ struct TestIndicesFromValues : public Sofa_test<>{
         IndicesFromValues<SReal>::SPtr m_thisObject=New<IndicesFromValues<SReal>>();
         m_thisObject->findData("global")->read("0. 0.5 0.5  0. 0. 1.  0. -1. 3.");
         m_thisObject->findData("values")->read("4. ");
+        EXPECT_MSG_EMIT(Error); // an error is emitted if the engine does not find the value (purpose of this test)
         m_thisObject->update();
 
         EXPECT_EQ(m_thisObject->findData("indices")->getValueString(), "");

--- a/modules/SofaGeneralEngine/SofaGeneralEngine_test/JoinPoints_test.cpp
+++ b/modules/SofaGeneralEngine/SofaGeneralEngine_test/JoinPoints_test.cpp
@@ -105,9 +105,9 @@ namespace sofa
 
 		// test with merge
 		TYPED_TEST(JoinPoints_test, mergeCase)
-		{
-			VecCoord input { {0.0, 0.0, 0.0}, {1.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0} };
-			VecCoord expectedOutput{ {0.5, 0.5, 0.0} };
+        {
+            typename TestFixture::VecCoord input { {0.0, 0.0, 0.0}, {1.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0} };
+            typename TestFixture::VecCoord expectedOutput{ {0.5, 0.5, 0.0} };
 
 			this->testValue(input, 2.0, expectedOutput);
 		}
@@ -115,8 +115,8 @@ namespace sofa
 		// test with no merge
 		TYPED_TEST(JoinPoints_test, noMergeCase)
 		{
-			VecCoord input{ {0.0, 0.0, 0.0}, {1.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0} };
-			VecCoord expectedOutput{ {0.0, 0.0, 0.0}, {1.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0} };
+            typename TestFixture::VecCoord input{ {0.0, 0.0, 0.0}, {1.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0} };
+            typename TestFixture::VecCoord expectedOutput{ {0.0, 0.0, 0.0}, {1.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0} };
 
 			this->testValue(input, 0.5, expectedOutput);
 		}

--- a/modules/SofaGeneralEngine/SofaGeneralEngine_test/JoinPoints_test.cpp
+++ b/modules/SofaGeneralEngine/SofaGeneralEngine_test/JoinPoints_test.cpp
@@ -29,98 +29,98 @@ using sofa::component::engine::JoinPoints;
 namespace sofa
 {
 
-	using defaulttype::Vector3;
+using defaulttype::Vector3;
 
-	template <typename _DataTypes>
-	class JoinPoints_test : public ::testing::Test, public JoinPoints<_DataTypes>
-	{
-	public:
-		typedef _DataTypes DataTypes;
-		typedef typename DataTypes::VecCoord VecCoord;
-		typedef typename DataTypes::Coord Coord;
-		typedef typename DataTypes::Real Real;
-		typedef sofa::helper::Quater<SReal> Quat;
+template <typename _DataTypes>
+class JoinPoints_test : public ::testing::Test, public JoinPoints<_DataTypes>
+{
+public:
+    typedef _DataTypes DataTypes;
+    typedef typename DataTypes::VecCoord VecCoord;
+    typedef typename DataTypes::Coord Coord;
+    typedef typename DataTypes::Real Real;
+    typedef sofa::helper::Quater<SReal> Quat;
 
-		JoinPoints_test()
-		{
-		}
+    JoinPoints_test()
+    {
+    }
 
-		void testData()
-		{
-			EXPECT_TRUE(this->findData("points") != nullptr);
-			EXPECT_TRUE(this->findData("distance") != nullptr);
-			EXPECT_TRUE(this->findData("mergedPoints") != nullptr);
-		}
+    void testData()
+    {
+        EXPECT_TRUE(this->findData("points") != nullptr);
+        EXPECT_TRUE(this->findData("distance") != nullptr);
+        EXPECT_TRUE(this->findData("mergedPoints") != nullptr);
+    }
 
-		void testNoInput()
-		{
-			EXPECT_MSG_EMIT(Error);
-			this->doUpdate();
-		}
-
-
-		void testValue(const VecCoord& inputPoints, Real inputDistance, const VecCoord& expectedPoints)
-		{
-			EXPECT_MSG_NOEMIT(Error);
-			this->f_points.setValue(inputPoints);
-			this->f_distance.setValue(inputDistance);
-			
-			this->doUpdate();
-			helper::ReadAccessor<Data<VecCoord> > outputPoints = this->f_mergedPoints;
-			ASSERT_EQ(expectedPoints.size(), outputPoints.size());
-
-			for (size_t i = 0; i < expectedPoints.size(); i++)
-			{
-				EXPECT_EQ(expectedPoints[i], outputPoints[i]);
-			}
-
-		}
-
-	};
+    void testNoInput()
+    {
+        EXPECT_MSG_EMIT(Error);
+        this->doUpdate();
+    }
 
 
-	namespace
-	{
+    void testValue(const VecCoord& inputPoints, Real inputDistance, const VecCoord& expectedPoints)
+    {
+        EXPECT_MSG_NOEMIT(Error);
+        this->f_points.setValue(inputPoints);
+        this->f_distance.setValue(inputDistance);
+        
+        this->doUpdate();
+        helper::ReadAccessor<Data<VecCoord> > outputPoints = this->f_mergedPoints;
+        ASSERT_EQ(expectedPoints.size(), outputPoints.size());
 
-		// Define the list of DataTypes to instanciate
-		using testing::Types;
-		typedef Types<
-			defaulttype::Vec3Types
-		> DataTypes; // the types to instanciate.
-
-		// Test suite for all the instanciations
-		TYPED_TEST_CASE(JoinPoints_test, DataTypes);
-
-		// test data setup
-		TYPED_TEST(JoinPoints_test, data_setup)
-		{
-			this->testData();
-		}
-
-		// test no input
-		TYPED_TEST(JoinPoints_test, no_input)
-		{
-			this->testNoInput();
-		}
-
-		// test with merge
-		TYPED_TEST(JoinPoints_test, mergeCase)
+        for (size_t i = 0; i < expectedPoints.size(); i++)
         {
-            typename TestFixture::VecCoord input { {0.0, 0.0, 0.0}, {1.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0} };
-            typename TestFixture::VecCoord expectedOutput{ {0.5, 0.5, 0.0} };
+            EXPECT_EQ(expectedPoints[i], outputPoints[i]);
+        }
 
-			this->testValue(input, 2.0, expectedOutput);
-		}
+    }
 
-		// test with no merge
-		TYPED_TEST(JoinPoints_test, noMergeCase)
-		{
-            typename TestFixture::VecCoord input{ {0.0, 0.0, 0.0}, {1.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0} };
-            typename TestFixture::VecCoord expectedOutput{ {0.0, 0.0, 0.0}, {1.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0} };
+};
 
-			this->testValue(input, 0.5, expectedOutput);
-		}
 
-	}// namespace
+namespace
+{
+
+    // Define the list of DataTypes to instanciate
+    using testing::Types;
+    typedef Types<
+        defaulttype::Vec3Types
+    > DataTypes; // the types to instanciate.
+
+    // Test suite for all the instanciations
+    TYPED_TEST_CASE(JoinPoints_test, DataTypes);
+
+    // test data setup
+    TYPED_TEST(JoinPoints_test, data_setup)
+    {
+        this->testData();
+    }
+
+    // test no input
+    TYPED_TEST(JoinPoints_test, no_input)
+    {
+        this->testNoInput();
+    }
+
+    // test with merge
+    TYPED_TEST(JoinPoints_test, mergeCase)
+    {
+        typename TestFixture::VecCoord input { {0.0, 0.0, 0.0}, {1.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0} };
+        typename TestFixture::VecCoord expectedOutput{ {0.5, 0.5, 0.0} };
+
+        this->testValue(input, 2.0, expectedOutput);
+    }
+
+    // test with no merge
+    TYPED_TEST(JoinPoints_test, noMergeCase)
+    {
+        typename TestFixture::VecCoord input{ {0.0, 0.0, 0.0}, {1.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0} };
+        typename TestFixture::VecCoord expectedOutput{ {0.0, 0.0, 0.0}, {1.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0} };
+
+        this->testValue(input, 0.5, expectedOutput);
+    }
+
+}// namespace
 
 }// namespace sofa

--- a/modules/SofaGeneralEngine/SofaGeneralEngine_test/JoinPoints_test.cpp
+++ b/modules/SofaGeneralEngine/SofaGeneralEngine_test/JoinPoints_test.cpp
@@ -1,0 +1,126 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2019 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <SofaTest/Sofa_test.h>
+#include <sofa/defaulttype/VecTypes.h>
+
+#include <SofaGeneralEngine/JoinPoints.h>
+using sofa::component::engine::JoinPoints;
+
+namespace sofa
+{
+
+	using defaulttype::Vector3;
+
+	template <typename _DataTypes>
+	class JoinPoints_test : public ::testing::Test, public JoinPoints<_DataTypes>
+	{
+	public:
+		typedef _DataTypes DataTypes;
+		typedef typename DataTypes::VecCoord VecCoord;
+		typedef typename DataTypes::Coord Coord;
+		typedef typename DataTypes::Real Real;
+		typedef sofa::helper::Quater<SReal> Quat;
+
+		JoinPoints_test()
+		{
+		}
+
+		void testData()
+		{
+			EXPECT_TRUE(this->findData("points") != nullptr);
+			EXPECT_TRUE(this->findData("distance") != nullptr);
+			EXPECT_TRUE(this->findData("mergedPoints") != nullptr);
+		}
+
+		void testNoInput()
+		{
+			EXPECT_MSG_EMIT(Error);
+			this->doUpdate();
+		}
+
+
+		void testValue(const VecCoord& inputPoints, Real inputDistance, const VecCoord& expectedPoints)
+		{
+			EXPECT_MSG_NOEMIT(Error);
+			this->f_points.setValue(inputPoints);
+			this->f_distance.setValue(inputDistance);
+			
+			this->doUpdate();
+			helper::ReadAccessor<Data<VecCoord> > outputPoints = this->f_mergedPoints;
+			ASSERT_EQ(expectedPoints.size(), outputPoints.size());
+
+			for (size_t i = 0; i < expectedPoints.size(); i++)
+			{
+				EXPECT_EQ(expectedPoints[i], outputPoints[i]);
+			}
+
+		}
+
+	};
+
+
+	namespace
+	{
+
+		// Define the list of DataTypes to instanciate
+		using testing::Types;
+		typedef Types<
+			defaulttype::Vec3Types
+		> DataTypes; // the types to instanciate.
+
+		// Test suite for all the instanciations
+		TYPED_TEST_CASE(JoinPoints_test, DataTypes);
+
+		// test data setup
+		TYPED_TEST(JoinPoints_test, data_setup)
+		{
+			this->testData();
+		}
+
+		// test no input
+		TYPED_TEST(JoinPoints_test, no_input)
+		{
+			this->testNoInput();
+		}
+
+		// test with merge
+		TYPED_TEST(JoinPoints_test, mergeCase)
+		{
+			VecCoord input { {0.0, 0.0, 0.0}, {1.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0} };
+			VecCoord expectedOutput{ {0.5, 0.5, 0.0} };
+
+			this->testValue(input, 2.0, expectedOutput);
+		}
+
+		// test with no merge
+		TYPED_TEST(JoinPoints_test, noMergeCase)
+		{
+			VecCoord input{ {0.0, 0.0, 0.0}, {1.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0} };
+			VecCoord expectedOutput{ {0.0, 0.0, 0.0}, {1.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0} };
+
+			this->testValue(input, 0.5, expectedOutput);
+		}
+
+	}// namespace
+
+}// namespace sofa

--- a/modules/SofaGeneralEngine/SofaGeneralEngine_test/RandomPointDistributionInSurface_test.cpp
+++ b/modules/SofaGeneralEngine/SofaGeneralEngine_test/RandomPointDistributionInSurface_test.cpp
@@ -29,179 +29,179 @@ using sofa::component::engine::RandomPointDistributionInSurface;
 namespace sofa
 {
 
-	using defaulttype::Vector3;
+using defaulttype::Vector3;
 
-	template <typename _DataTypes>
-	class RandomPointDistributionInSurface_test : public ::testing::Test
-	{
-	public:
-		typedef _DataTypes DataTypes;
-		typedef typename DataTypes::VecCoord VecCoord;
-		typedef typename DataTypes::Coord Coord;
-		typedef typename DataTypes::Real Real;
-		typedef sofa::helper::Quater<SReal> Quat;
+template <typename _DataTypes>
+class RandomPointDistributionInSurface_test : public ::testing::Test
+{
+public:
+    typedef _DataTypes DataTypes;
+    typedef typename DataTypes::VecCoord VecCoord;
+    typedef typename DataTypes::Coord Coord;
+    typedef typename DataTypes::Real Real;
+    typedef sofa::helper::Quater<SReal> Quat;
 
-		typedef sofa::core::topology::BaseMeshTopology::Triangle Triangle;
-		typedef helper::vector<Triangle> VecTriangle;
+    typedef sofa::core::topology::BaseMeshTopology::Triangle Triangle;
+    typedef helper::vector<Triangle> VecTriangle;
 
-		typename RandomPointDistributionInSurface<_DataTypes>::SPtr m_randomEngine;
+    typename RandomPointDistributionInSurface<_DataTypes>::SPtr m_randomEngine;
 
-		RandomPointDistributionInSurface_test()
-		{
-		}
+    RandomPointDistributionInSurface_test()
+    {
+    }
 
-		void SetUp() override 
-		{
-			m_randomEngine = sofa::core::objectmodel::New<RandomPointDistributionInSurface<_DataTypes> >();
-		}
+    void SetUp() override 
+    {
+        m_randomEngine = sofa::core::objectmodel::New<RandomPointDistributionInSurface<_DataTypes> >();
+    }
 
-		void testData()
-		{
-			EXPECT_TRUE(m_randomEngine->findData("randomSeed") != nullptr);
-			EXPECT_TRUE(m_randomEngine->findData("isVisible") != nullptr);
-			EXPECT_TRUE(m_randomEngine->findData("drawOutputPoints") != nullptr);
-			EXPECT_TRUE(m_randomEngine->findData("minDistanceBetweenPoints") != nullptr);
-			EXPECT_TRUE(m_randomEngine->findData("numberOfInPoints") != nullptr);
-			EXPECT_TRUE(m_randomEngine->findData("numberOfTests") != nullptr);
-			EXPECT_TRUE(m_randomEngine->findData("vertices") != nullptr);
-			EXPECT_TRUE(m_randomEngine->findData("triangles") != nullptr);
-			EXPECT_TRUE(m_randomEngine->findData("inPoints") != nullptr);
-			EXPECT_TRUE(m_randomEngine->findData("outPoints") != nullptr);
-		}
+    void testData()
+    {
+        EXPECT_TRUE(m_randomEngine->findData("randomSeed") != nullptr);
+        EXPECT_TRUE(m_randomEngine->findData("isVisible") != nullptr);
+        EXPECT_TRUE(m_randomEngine->findData("drawOutputPoints") != nullptr);
+        EXPECT_TRUE(m_randomEngine->findData("minDistanceBetweenPoints") != nullptr);
+        EXPECT_TRUE(m_randomEngine->findData("numberOfInPoints") != nullptr);
+        EXPECT_TRUE(m_randomEngine->findData("numberOfTests") != nullptr);
+        EXPECT_TRUE(m_randomEngine->findData("vertices") != nullptr);
+        EXPECT_TRUE(m_randomEngine->findData("triangles") != nullptr);
+        EXPECT_TRUE(m_randomEngine->findData("inPoints") != nullptr);
+        EXPECT_TRUE(m_randomEngine->findData("outPoints") != nullptr);
+    }
 
-		void testNoInput()
-		{
-			EXPECT_MSG_EMIT(Error);
-			m_randomEngine->doUpdate();
-		}
+    void testNoInput()
+    {
+        EXPECT_MSG_EMIT(Error);
+        m_randomEngine->doUpdate();
+    }
 
-		void generate(const VecCoord& inputPoints, const VecTriangle& inputTriangles, Real minDistance, 
-			unsigned int seed, unsigned int numberOfInPoints, VecCoord& outputPoints)
-		{
-			m_randomEngine->f_vertices.setValue(inputPoints);
-			m_randomEngine->f_triangles.setValue(inputTriangles);
-			m_randomEngine->randomSeed.setValue(seed);
-			m_randomEngine->numberOfInPoints.setValue(numberOfInPoints);
-			m_randomEngine->minDistanceBetweenPoints.setValue(minDistance);
-
-
-			m_randomEngine->init();
-
-			outputPoints = m_randomEngine->f_inPoints.getValue(); //will call doUpdate on its own
-		}
-
-	};
+    void generate(const VecCoord& inputPoints, const VecTriangle& inputTriangles, Real minDistance, 
+        unsigned int seed, unsigned int numberOfInPoints, VecCoord& outputPoints)
+    {
+        m_randomEngine->f_vertices.setValue(inputPoints);
+        m_randomEngine->f_triangles.setValue(inputTriangles);
+        m_randomEngine->randomSeed.setValue(seed);
+        m_randomEngine->numberOfInPoints.setValue(numberOfInPoints);
+        m_randomEngine->minDistanceBetweenPoints.setValue(minDistance);
 
 
-	namespace
-	{
+        m_randomEngine->init();
 
-		// Define the list of DataTypes to instanciate
-		using testing::Types;
-		typedef Types<
-			defaulttype::Vec3Types
-		> DataTypes; // the types to instanciate.
+        outputPoints = m_randomEngine->f_inPoints.getValue(); //will call doUpdate on its own
+    }
 
-		// Test suite for all the instanciations
-		TYPED_TEST_CASE(RandomPointDistributionInSurface_test, DataTypes);
-
-		// test data setup
-		TYPED_TEST(RandomPointDistributionInSurface_test, data_setup)
-		{
-            this->testData();
-		}
-
-		//// test no input
-		TYPED_TEST(RandomPointDistributionInSurface_test, no_input)
-		{
-            this->testNoInput();
-		}
-
-		//// test with a not closed mesh
-		TYPED_TEST(RandomPointDistributionInSurface_test, illFormedMesh)
-		{
-            typename TestFixture::VecCoord vertices{ {1.0, 0.0, 0.0}, {2.0, 0.0, 0.0}, {3.0, 0.0, 0.0}, {4.0, 0.0, 0.0} };
-            typename TestFixture::VecTriangle triangles{ {0, 2, 3}, { 1, 3, 0}, {0, 2, 1}, {1, 2, 3} };
-
-            typename TestFixture::VecCoord outputPoints;
-			const unsigned int randomSeed = 123456789;
-            const unsigned int nbPoints = 10; // just asking for 10 points, otherwise takes forever to not find correct points...
-			EXPECT_MSG_EMIT(Error);
-            this->generate(vertices, triangles, 0.001, randomSeed, nbPoints, outputPoints); // fixed random seed
-			EXPECT_MSG_EMIT(Error);
-            this->generate(vertices, triangles, 0.001, 0, nbPoints, outputPoints); // true random seed
-		}
-
-		// test with closed tetra
-		TYPED_TEST(RandomPointDistributionInSurface_test, closedMesh)
-		{
-            typename TestFixture::VecCoord vertices{ {0.0, 1.0, 0.0}, {1.0, 0.0, 1.0}, {-1.0, 0.0, -1.0}, {1.0, 0.0, -1.0} };
-            typename TestFixture::VecTriangle triangles{ {2, 0, 3}, { 1, 3, 0}, {0, 2, 1}, {1, 2, 3} };
-			
-            typename TestFixture::VecCoord outputPoints;
-			const unsigned int randomSeed = 123456789;
-			const unsigned int nbPoints = 10;
-			EXPECT_MSG_NOEMIT(Error);
-            this->generate(vertices, triangles, 0.1, randomSeed, nbPoints, outputPoints); // fixed random seed
-			ASSERT_EQ(outputPoints.size(), nbPoints);
-
-            this->generate(vertices, triangles, 0.1, 0, nbPoints, outputPoints); // true random seed
-			ASSERT_EQ(outputPoints.size(), nbPoints);
-		}
-
-		// test with seeds
-		TYPED_TEST(RandomPointDistributionInSurface_test, seeds)
-		{
-            typename TestFixture::VecCoord vertices{ {0.0, 1.0, 0.0}, {1.0, 0.0, 1.0}, {-1.0, 0.0, -1.0}, {1.0, 0.0, -1.0} };
-            typename TestFixture::VecTriangle triangles{ {2, 0, 3}, { 1, 3, 0}, {0, 2, 1}, {1, 2, 3} };
-
-            typename TestFixture::VecCoord outputPoints1;
-            typename TestFixture::VecCoord outputPoints2;
-			const unsigned int randomSeed1 = 123456789;
-			const unsigned int randomSeed2 = 987654321;
-			const unsigned int nbPoints = 100;
-			EXPECT_MSG_NOEMIT(Error);
-			// same seed
-            this->generate(vertices, triangles, 0.1, randomSeed1, nbPoints, outputPoints1);
-            this->generate(vertices, triangles, 0.1, randomSeed1, nbPoints, outputPoints2);
-			ASSERT_EQ(outputPoints1.size(), nbPoints);
-			ASSERT_EQ(outputPoints2.size(), nbPoints);
-
-			for (size_t i = 0; i < outputPoints1.size(); i++)
-			{
-				EXPECT_EQ(outputPoints1[i], outputPoints2[i]);
-			}
-
-			// different seed
-            this->generate(vertices, triangles, 0.1, randomSeed1, nbPoints, outputPoints1);
-            this->generate(vertices, triangles, 0.1, randomSeed2, nbPoints, outputPoints2);
-			ASSERT_EQ(outputPoints1.size(), nbPoints);
-			ASSERT_EQ(outputPoints2.size(), nbPoints);
-
-			// test if at least one is different (it could be possible that two points are similar.... but REALLY unlikely)
-			bool isDifferent = false;
-			for (size_t i = 0; i < outputPoints1.size(); i++)
-			{
-				isDifferent = isDifferent || (outputPoints1[i] != outputPoints2[i]);
-			}
-			EXPECT_TRUE(isDifferent);
+};
 
 
-			// true random seeds
-            this->generate(vertices, triangles, 0.1, 0, nbPoints, outputPoints1);
-			sofa::helper::system::thread::CTime::sleep(1.1); // wait a bit in order to change seed  
-            this->generate(vertices, triangles, 0.1, 0, nbPoints, outputPoints2);
-			ASSERT_EQ(outputPoints1.size(), nbPoints);
-			ASSERT_EQ(outputPoints2.size(), nbPoints);
+namespace
+{
 
-			isDifferent = false;
-			for (size_t i = 0; i < outputPoints1.size(); i++)
-			{
-				isDifferent = isDifferent || (outputPoints1[i] != outputPoints2[i]);
-			}
-			EXPECT_TRUE(isDifferent);
-		}
+// Define the list of DataTypes to instanciate
+using testing::Types;
+typedef Types<
+    defaulttype::Vec3Types
+> DataTypes; // the types to instanciate.
 
-	}// namespace
+// Test suite for all the instanciations
+TYPED_TEST_CASE(RandomPointDistributionInSurface_test, DataTypes);
+
+// test data setup
+TYPED_TEST(RandomPointDistributionInSurface_test, data_setup)
+{
+    this->testData();
+}
+
+//// test no input
+TYPED_TEST(RandomPointDistributionInSurface_test, no_input)
+{
+    this->testNoInput();
+}
+
+//// test with a not closed mesh
+TYPED_TEST(RandomPointDistributionInSurface_test, illFormedMesh)
+{
+    typename TestFixture::VecCoord vertices{ {1.0, 0.0, 0.0}, {2.0, 0.0, 0.0}, {3.0, 0.0, 0.0}, {4.0, 0.0, 0.0} };
+    typename TestFixture::VecTriangle triangles{ {0, 2, 3}, { 1, 3, 0}, {0, 2, 1}, {1, 2, 3} };
+
+    typename TestFixture::VecCoord outputPoints;
+    const unsigned int randomSeed = 123456789;
+    const unsigned int nbPoints = 10; // just asking for 10 points, otherwise takes forever to not find correct points...
+    EXPECT_MSG_EMIT(Error);
+    this->generate(vertices, triangles, 0.001, randomSeed, nbPoints, outputPoints); // fixed random seed
+    EXPECT_MSG_EMIT(Error);
+    this->generate(vertices, triangles, 0.001, 0, nbPoints, outputPoints); // true random seed
+}
+
+// test with closed tetra
+TYPED_TEST(RandomPointDistributionInSurface_test, closedMesh)
+{
+    typename TestFixture::VecCoord vertices{ {0.0, 1.0, 0.0}, {1.0, 0.0, 1.0}, {-1.0, 0.0, -1.0}, {1.0, 0.0, -1.0} };
+    typename TestFixture::VecTriangle triangles{ {2, 0, 3}, { 1, 3, 0}, {0, 2, 1}, {1, 2, 3} };
+    
+    typename TestFixture::VecCoord outputPoints;
+    const unsigned int randomSeed = 123456789;
+    const unsigned int nbPoints = 10;
+    EXPECT_MSG_NOEMIT(Error);
+    this->generate(vertices, triangles, 0.1, randomSeed, nbPoints, outputPoints); // fixed random seed
+    ASSERT_EQ(outputPoints.size(), nbPoints);
+
+    this->generate(vertices, triangles, 0.1, 0, nbPoints, outputPoints); // true random seed
+    ASSERT_EQ(outputPoints.size(), nbPoints);
+}
+
+// test with seeds
+TYPED_TEST(RandomPointDistributionInSurface_test, seeds)
+{
+    typename TestFixture::VecCoord vertices{ {0.0, 1.0, 0.0}, {1.0, 0.0, 1.0}, {-1.0, 0.0, -1.0}, {1.0, 0.0, -1.0} };
+    typename TestFixture::VecTriangle triangles{ {2, 0, 3}, { 1, 3, 0}, {0, 2, 1}, {1, 2, 3} };
+
+    typename TestFixture::VecCoord outputPoints1;
+    typename TestFixture::VecCoord outputPoints2;
+    const unsigned int randomSeed1 = 123456789;
+    const unsigned int randomSeed2 = 987654321;
+    const unsigned int nbPoints = 100;
+    EXPECT_MSG_NOEMIT(Error);
+    // same seed
+    this->generate(vertices, triangles, 0.1, randomSeed1, nbPoints, outputPoints1);
+    this->generate(vertices, triangles, 0.1, randomSeed1, nbPoints, outputPoints2);
+    ASSERT_EQ(outputPoints1.size(), nbPoints);
+    ASSERT_EQ(outputPoints2.size(), nbPoints);
+
+    for (size_t i = 0; i < outputPoints1.size(); i++)
+    {
+        EXPECT_EQ(outputPoints1[i], outputPoints2[i]);
+    }
+
+    // different seed
+    this->generate(vertices, triangles, 0.1, randomSeed1, nbPoints, outputPoints1);
+    this->generate(vertices, triangles, 0.1, randomSeed2, nbPoints, outputPoints2);
+    ASSERT_EQ(outputPoints1.size(), nbPoints);
+    ASSERT_EQ(outputPoints2.size(), nbPoints);
+
+    // test if at least one is different (it could be possible that two points are similar.... but REALLY unlikely)
+    bool isDifferent = false;
+    for (size_t i = 0; i < outputPoints1.size(); i++)
+    {
+        isDifferent = isDifferent || (outputPoints1[i] != outputPoints2[i]);
+    }
+    EXPECT_TRUE(isDifferent);
+
+
+    // true random seeds
+    this->generate(vertices, triangles, 0.1, 0, nbPoints, outputPoints1);
+    sofa::helper::system::thread::CTime::sleep(1.1); // wait a bit in order to change seed  
+    this->generate(vertices, triangles, 0.1, 0, nbPoints, outputPoints2);
+    ASSERT_EQ(outputPoints1.size(), nbPoints);
+    ASSERT_EQ(outputPoints2.size(), nbPoints);
+
+    isDifferent = false;
+    for (size_t i = 0; i < outputPoints1.size(); i++)
+    {
+        isDifferent = isDifferent || (outputPoints1[i] != outputPoints2[i]);
+    }
+    EXPECT_TRUE(isDifferent);
+}
+
+}// namespace
 
 }// namespace sofa

--- a/modules/SofaGeneralEngine/SofaGeneralEngine_test/RandomPointDistributionInSurface_test.cpp
+++ b/modules/SofaGeneralEngine/SofaGeneralEngine_test/RandomPointDistributionInSurface_test.cpp
@@ -105,33 +105,33 @@ namespace sofa
 		// Test suite for all the instanciations
 		TYPED_TEST_CASE(RandomPointDistributionInSurface_test, DataTypes);
 
-		//// test data setup
-		//TYPED_TEST(RandomPointDistributionInSurface_test, data_setup)
-		//{
-		//	testData();
-		//}
+		// test data setup
+		TYPED_TEST(RandomPointDistributionInSurface_test, data_setup)
+		{
+			testData();
+		}
 
-		////// test no input
-		//TYPED_TEST(RandomPointDistributionInSurface_test, no_input)
-		//{
-		//	testNoInput();
-		//}
+		//// test no input
+		TYPED_TEST(RandomPointDistributionInSurface_test, no_input)
+		{
+			testNoInput();
+		}
 
-		////// test with a not closed mesh
-		//TYPED_TEST(RandomPointDistributionInSurface_test, illFormedMesh)
-		//{
-		//	VecCoord vertices{ {1.0, 0.0, 0.0}, {2.0, 0.0, 0.0}, {3.0, 0.0, 0.0}, {4.0, 0.0, 0.0} };
-		//	VecTriangle triangles{ {0, 2, 3}, { 1, 3, 0}, {0, 2, 1}, {1, 2, 3} };
+		//// test with a not closed mesh
+		TYPED_TEST(RandomPointDistributionInSurface_test, illFormedMesh)
+		{
+			VecCoord vertices{ {1.0, 0.0, 0.0}, {2.0, 0.0, 0.0}, {3.0, 0.0, 0.0}, {4.0, 0.0, 0.0} };
+			VecTriangle triangles{ {0, 2, 3}, { 1, 3, 0}, {0, 2, 1}, {1, 2, 3} };
 
-		//	VecCoord outputPoints;
-		//	const unsigned int randomSeed = 123456789;
-		//	const unsigned int nbPoints = 100;
-		//	EXPECT_MSG_EMIT(Error);
-		//	generate(vertices, triangles, 0.001, randomSeed, 10, outputPoints); // fixed random seed
-		//	EXPECT_MSG_EMIT(Error);
-		//	generate(vertices, triangles, 0.001, 0, 10, outputPoints); // true random seed
-		//	// just asking for 10 points, otherwise takes forever to not find correct points...
-		//}
+			VecCoord outputPoints;
+			const unsigned int randomSeed = 123456789;
+			const unsigned int nbPoints = 100;
+			EXPECT_MSG_EMIT(Error);
+			generate(vertices, triangles, 0.001, randomSeed, 10, outputPoints); // fixed random seed
+			EXPECT_MSG_EMIT(Error);
+			generate(vertices, triangles, 0.001, 0, 10, outputPoints); // true random seed
+			// just asking for 10 points, otherwise takes forever to not find correct points...
+		}
 
 		// test with closed tetra
 		TYPED_TEST(RandomPointDistributionInSurface_test, closedMesh)

--- a/modules/SofaGeneralEngine/SofaGeneralEngine_test/RandomPointDistributionInSurface_test.cpp
+++ b/modules/SofaGeneralEngine/SofaGeneralEngine_test/RandomPointDistributionInSurface_test.cpp
@@ -1,0 +1,208 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2019 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <SofaTest/Sofa_test.h>
+#include <sofa/defaulttype/VecTypes.h>
+
+#include <SofaGeneralEngine/RandomPointDistributionInSurface.h>
+using sofa::component::engine::RandomPointDistributionInSurface;
+
+namespace sofa
+{
+
+	using defaulttype::Vector3;
+
+	template <typename _DataTypes>
+	class RandomPointDistributionInSurface_test : public ::testing::Test
+	{
+	public:
+		typedef _DataTypes DataTypes;
+		typedef typename DataTypes::VecCoord VecCoord;
+		typedef typename DataTypes::Coord Coord;
+		typedef typename DataTypes::Real Real;
+		typedef sofa::helper::Quater<SReal> Quat;
+
+		typedef sofa::core::topology::BaseMeshTopology::Triangle Triangle;
+		typedef helper::vector<Triangle> VecTriangle;
+
+		typename RandomPointDistributionInSurface<_DataTypes>::SPtr m_randomEngine;
+
+		RandomPointDistributionInSurface_test()
+		{
+		}
+
+		void SetUp() override 
+		{
+			m_randomEngine = sofa::core::objectmodel::New<RandomPointDistributionInSurface<_DataTypes> >();
+		}
+
+		void testData()
+		{
+			EXPECT_TRUE(m_randomEngine->findData("randomSeed") != nullptr);
+			EXPECT_TRUE(m_randomEngine->findData("isVisible") != nullptr);
+			EXPECT_TRUE(m_randomEngine->findData("drawOutputPoints") != nullptr);
+			EXPECT_TRUE(m_randomEngine->findData("minDistanceBetweenPoints") != nullptr);
+			EXPECT_TRUE(m_randomEngine->findData("numberOfInPoints") != nullptr);
+			EXPECT_TRUE(m_randomEngine->findData("numberOfTests") != nullptr);
+			EXPECT_TRUE(m_randomEngine->findData("vertices") != nullptr);
+			EXPECT_TRUE(m_randomEngine->findData("triangles") != nullptr);
+			EXPECT_TRUE(m_randomEngine->findData("inPoints") != nullptr);
+			EXPECT_TRUE(m_randomEngine->findData("outPoints") != nullptr);
+		}
+
+		void testNoInput()
+		{
+			EXPECT_MSG_EMIT(Error);
+			m_randomEngine->doUpdate();
+		}
+
+		void generate(const VecCoord& inputPoints, const VecTriangle& inputTriangles, Real minDistance, 
+			unsigned int seed, unsigned int numberOfInPoints, VecCoord& outputPoints)
+		{
+			m_randomEngine->f_vertices.setValue(inputPoints);
+			m_randomEngine->f_triangles.setValue(inputTriangles);
+			m_randomEngine->randomSeed.setValue(seed);
+			m_randomEngine->numberOfInPoints.setValue(numberOfInPoints);
+			m_randomEngine->minDistanceBetweenPoints.setValue(minDistance);
+
+
+			m_randomEngine->init();
+
+			outputPoints = m_randomEngine->f_inPoints.getValue(); //will call doUpdate on its own
+		}
+
+	};
+
+
+	namespace
+	{
+
+		// Define the list of DataTypes to instanciate
+		using testing::Types;
+		typedef Types<
+			defaulttype::Vec3Types
+		> DataTypes; // the types to instanciate.
+
+		// Test suite for all the instanciations
+		TYPED_TEST_CASE(RandomPointDistributionInSurface_test, DataTypes);
+
+		//// test data setup
+		//TYPED_TEST(RandomPointDistributionInSurface_test, data_setup)
+		//{
+		//	testData();
+		//}
+
+		////// test no input
+		//TYPED_TEST(RandomPointDistributionInSurface_test, no_input)
+		//{
+		//	testNoInput();
+		//}
+
+		////// test with a not closed mesh
+		//TYPED_TEST(RandomPointDistributionInSurface_test, illFormedMesh)
+		//{
+		//	VecCoord vertices{ {1.0, 0.0, 0.0}, {2.0, 0.0, 0.0}, {3.0, 0.0, 0.0}, {4.0, 0.0, 0.0} };
+		//	VecTriangle triangles{ {0, 2, 3}, { 1, 3, 0}, {0, 2, 1}, {1, 2, 3} };
+
+		//	VecCoord outputPoints;
+		//	const unsigned int randomSeed = 123456789;
+		//	const unsigned int nbPoints = 100;
+		//	EXPECT_MSG_EMIT(Error);
+		//	generate(vertices, triangles, 0.001, randomSeed, 10, outputPoints); // fixed random seed
+		//	EXPECT_MSG_EMIT(Error);
+		//	generate(vertices, triangles, 0.001, 0, 10, outputPoints); // true random seed
+		//	// just asking for 10 points, otherwise takes forever to not find correct points...
+		//}
+
+		// test with closed tetra
+		TYPED_TEST(RandomPointDistributionInSurface_test, closedMesh)
+		{
+			VecCoord vertices{ {0.0, 1.0, 0.0}, {1.0, 0.0, 1.0}, {-1.0, 0.0, -1.0}, {1.0, 0.0, -1.0} };
+			VecTriangle triangles{ {2, 0, 3}, { 1, 3, 0}, {0, 2, 1}, {1, 2, 3} };
+			
+			VecCoord outputPoints;			
+			const unsigned int randomSeed = 123456789;
+			const unsigned int nbPoints = 10;
+			EXPECT_MSG_NOEMIT(Error);
+			generate(vertices, triangles, 0.1, randomSeed, nbPoints, outputPoints); // fixed random seed
+			ASSERT_EQ(outputPoints.size(), nbPoints);
+
+			generate(vertices, triangles, 0.1, 0, nbPoints, outputPoints); // true random seed
+			ASSERT_EQ(outputPoints.size(), nbPoints);
+		}
+
+		// test with seeds
+		TYPED_TEST(RandomPointDistributionInSurface_test, seeds)
+		{
+			VecCoord vertices{ {0.0, 1.0, 0.0}, {1.0, 0.0, 1.0}, {-1.0, 0.0, -1.0}, {1.0, 0.0, -1.0} };
+			VecTriangle triangles{ {2, 0, 3}, { 1, 3, 0}, {0, 2, 1}, {1, 2, 3} };
+
+			VecCoord outputPoints1;
+			VecCoord outputPoints2;
+			const unsigned int randomSeed1 = 123456789;
+			const unsigned int randomSeed2 = 987654321;
+			const unsigned int nbPoints = 100;
+			EXPECT_MSG_NOEMIT(Error);
+			// same seed
+			generate(vertices, triangles, 0.1, randomSeed1, nbPoints, outputPoints1);
+			generate(vertices, triangles, 0.1, randomSeed1, nbPoints, outputPoints2);
+			ASSERT_EQ(outputPoints1.size(), nbPoints);
+			ASSERT_EQ(outputPoints2.size(), nbPoints);
+
+			for (size_t i = 0; i < outputPoints1.size(); i++)
+			{
+				EXPECT_EQ(outputPoints1[i], outputPoints2[i]);
+			}
+
+			// different seed
+			generate(vertices, triangles, 0.1, randomSeed1, nbPoints, outputPoints1);
+			generate(vertices, triangles, 0.1, randomSeed2, nbPoints, outputPoints2);
+			ASSERT_EQ(outputPoints1.size(), nbPoints);
+			ASSERT_EQ(outputPoints2.size(), nbPoints);
+
+			// test if at least one is different (it could be possible that two points are similar.... but REALLY unlikely)
+			bool isDifferent = false;
+			for (size_t i = 0; i < outputPoints1.size(); i++)
+			{
+				isDifferent = isDifferent || (outputPoints1[i] != outputPoints2[i]);
+			}
+			EXPECT_TRUE(isDifferent);
+
+
+			// true random seeds
+			generate(vertices, triangles, 0.1, 0, nbPoints, outputPoints1);
+			sofa::helper::system::thread::CTime::sleep(1.1); // wait a bit in order to change seed  
+			generate(vertices, triangles, 0.1, 0, nbPoints, outputPoints2);
+			ASSERT_EQ(outputPoints1.size(), nbPoints);
+			ASSERT_EQ(outputPoints2.size(), nbPoints);
+
+			isDifferent = false;
+			for (size_t i = 0; i < outputPoints1.size(); i++)
+			{
+				isDifferent = isDifferent || (outputPoints1[i] != outputPoints2[i]);
+			}
+			EXPECT_TRUE(isDifferent);
+		}
+
+	}// namespace
+
+}// namespace sofa

--- a/modules/SofaGeneralEngine/SofaGeneralEngine_test/RandomPointDistributionInSurface_test.cpp
+++ b/modules/SofaGeneralEngine/SofaGeneralEngine_test/RandomPointDistributionInSurface_test.cpp
@@ -108,63 +108,62 @@ namespace sofa
 		// test data setup
 		TYPED_TEST(RandomPointDistributionInSurface_test, data_setup)
 		{
-			testData();
+            this->testData();
 		}
 
 		//// test no input
 		TYPED_TEST(RandomPointDistributionInSurface_test, no_input)
 		{
-			testNoInput();
+            this->testNoInput();
 		}
 
 		//// test with a not closed mesh
 		TYPED_TEST(RandomPointDistributionInSurface_test, illFormedMesh)
 		{
-			VecCoord vertices{ {1.0, 0.0, 0.0}, {2.0, 0.0, 0.0}, {3.0, 0.0, 0.0}, {4.0, 0.0, 0.0} };
-			VecTriangle triangles{ {0, 2, 3}, { 1, 3, 0}, {0, 2, 1}, {1, 2, 3} };
+            typename TestFixture::VecCoord vertices{ {1.0, 0.0, 0.0}, {2.0, 0.0, 0.0}, {3.0, 0.0, 0.0}, {4.0, 0.0, 0.0} };
+            typename TestFixture::VecTriangle triangles{ {0, 2, 3}, { 1, 3, 0}, {0, 2, 1}, {1, 2, 3} };
 
-			VecCoord outputPoints;
+            typename TestFixture::VecCoord outputPoints;
 			const unsigned int randomSeed = 123456789;
-			const unsigned int nbPoints = 100;
+            const unsigned int nbPoints = 10; // just asking for 10 points, otherwise takes forever to not find correct points...
 			EXPECT_MSG_EMIT(Error);
-			generate(vertices, triangles, 0.001, randomSeed, 10, outputPoints); // fixed random seed
+            this->generate(vertices, triangles, 0.001, randomSeed, nbPoints, outputPoints); // fixed random seed
 			EXPECT_MSG_EMIT(Error);
-			generate(vertices, triangles, 0.001, 0, 10, outputPoints); // true random seed
-			// just asking for 10 points, otherwise takes forever to not find correct points...
+            this->generate(vertices, triangles, 0.001, 0, nbPoints, outputPoints); // true random seed
 		}
 
 		// test with closed tetra
 		TYPED_TEST(RandomPointDistributionInSurface_test, closedMesh)
 		{
-			VecCoord vertices{ {0.0, 1.0, 0.0}, {1.0, 0.0, 1.0}, {-1.0, 0.0, -1.0}, {1.0, 0.0, -1.0} };
-			VecTriangle triangles{ {2, 0, 3}, { 1, 3, 0}, {0, 2, 1}, {1, 2, 3} };
+            typename TestFixture::VecCoord vertices{ {0.0, 1.0, 0.0}, {1.0, 0.0, 1.0}, {-1.0, 0.0, -1.0}, {1.0, 0.0, -1.0} };
+            typename TestFixture::VecTriangle triangles{ {2, 0, 3}, { 1, 3, 0}, {0, 2, 1}, {1, 2, 3} };
 			
-			VecCoord outputPoints;			
+            typename TestFixture::VecCoord outputPoints;
 			const unsigned int randomSeed = 123456789;
 			const unsigned int nbPoints = 10;
 			EXPECT_MSG_NOEMIT(Error);
-			generate(vertices, triangles, 0.1, randomSeed, nbPoints, outputPoints); // fixed random seed
+            this->generate(vertices, triangles, 0.1, randomSeed, nbPoints, outputPoints); // fixed random seed
 			ASSERT_EQ(outputPoints.size(), nbPoints);
 
-			generate(vertices, triangles, 0.1, 0, nbPoints, outputPoints); // true random seed
+            this->generate(vertices, triangles, 0.1, 0, nbPoints, outputPoints); // true random seed
 			ASSERT_EQ(outputPoints.size(), nbPoints);
 		}
 
 		// test with seeds
 		TYPED_TEST(RandomPointDistributionInSurface_test, seeds)
 		{
-			VecCoord vertices{ {0.0, 1.0, 0.0}, {1.0, 0.0, 1.0}, {-1.0, 0.0, -1.0}, {1.0, 0.0, -1.0} };
-			VecTriangle triangles{ {2, 0, 3}, { 1, 3, 0}, {0, 2, 1}, {1, 2, 3} };
+            typename TestFixture::VecCoord vertices{ {0.0, 1.0, 0.0}, {1.0, 0.0, 1.0}, {-1.0, 0.0, -1.0}, {1.0, 0.0, -1.0} };
+            typename TestFixture::VecTriangle triangles{ {2, 0, 3}, { 1, 3, 0}, {0, 2, 1}, {1, 2, 3} };
 
-			VecCoord outputPoints1;
-			VecCoord outputPoints2;
+            typename TestFixture::VecCoord outputPoints1;
+            typename TestFixture::VecCoord outputPoints2;
 			const unsigned int randomSeed1 = 123456789;
 			const unsigned int randomSeed2 = 987654321;
 			const unsigned int nbPoints = 100;
 			EXPECT_MSG_NOEMIT(Error);
 			// same seed
-			generate(vertices, triangles, 0.1, randomSeed1, nbPoints, outputPoints1);
-			generate(vertices, triangles, 0.1, randomSeed1, nbPoints, outputPoints2);
+            this->generate(vertices, triangles, 0.1, randomSeed1, nbPoints, outputPoints1);
+            this->generate(vertices, triangles, 0.1, randomSeed1, nbPoints, outputPoints2);
 			ASSERT_EQ(outputPoints1.size(), nbPoints);
 			ASSERT_EQ(outputPoints2.size(), nbPoints);
 
@@ -174,8 +173,8 @@ namespace sofa
 			}
 
 			// different seed
-			generate(vertices, triangles, 0.1, randomSeed1, nbPoints, outputPoints1);
-			generate(vertices, triangles, 0.1, randomSeed2, nbPoints, outputPoints2);
+            this->generate(vertices, triangles, 0.1, randomSeed1, nbPoints, outputPoints1);
+            this->generate(vertices, triangles, 0.1, randomSeed2, nbPoints, outputPoints2);
 			ASSERT_EQ(outputPoints1.size(), nbPoints);
 			ASSERT_EQ(outputPoints2.size(), nbPoints);
 
@@ -189,9 +188,9 @@ namespace sofa
 
 
 			// true random seeds
-			generate(vertices, triangles, 0.1, 0, nbPoints, outputPoints1);
+            this->generate(vertices, triangles, 0.1, 0, nbPoints, outputPoints1);
 			sofa::helper::system::thread::CTime::sleep(1.1); // wait a bit in order to change seed  
-			generate(vertices, triangles, 0.1, 0, nbPoints, outputPoints2);
+            this->generate(vertices, triangles, 0.1, 0, nbPoints, outputPoints2);
 			ASSERT_EQ(outputPoints1.size(), nbPoints);
 			ASSERT_EQ(outputPoints2.size(), nbPoints);
 


### PR DESCRIPTION
Following #1237 , some error messages were not expected in some unit tests; triggering a FAILED status.
This PR fixes that, and add two more (real) unit tests for RandomPointDistributionInSurface and JoinPoints engines.
Moreover, it fixes also an example of the ExtrudeEngine scene and adds a example scene for RandomPointDistributionInSurface .


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
