### PR TITLE
[SofaPython] Restrict the plugin and its dependers to C++11

### DIFF
--- a/applications/plugins/SofaPython/CMakeLists.txt
+++ b/applications/plugins/SofaPython/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 project(SofaPython VERSION 0.1)
 
+set(CMAKE_CXX_STANDARD 11) # Python 2.7 is not compatible with C++17 and later
+
 if(UNIX)
   list(APPEND PYTHON_LIBRARIES dl)
 endif()

--- a/applications/plugins/SofaPython/SofaPythonConfig.cmake.in
+++ b/applications/plugins/SofaPython/SofaPythonConfig.cmake.in
@@ -2,6 +2,8 @@
 
 @PACKAGE_INIT@
 
+set(CMAKE_CXX_STANDARD 11) # Python 2.7 is not compatible with C++17 and later 
+
 find_package(PythonLibs 2.7 REQUIRED)
 find_package(SofaGui REQUIRED)
 find_package(SofaGeneral REQUIRED)


### PR DESCRIPTION
Python 2.7 is not compatible with C++17 and later

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
