### PR TITLE
[SofaHelper] Fix unloading with PluginManager

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
@@ -214,9 +214,9 @@ bool PluginManager::loadPlugin(const std::string& plugin, const std::string& suf
     }
 }
 
-bool PluginManager::unloadPlugin(const std::string &pluginPath, std::ostream* errlog)
+bool PluginManager::unloadPlugin(const std::string& pluginPath, std::ostream* errlog)
 {
-    if(!pluginIsLoaded(pluginPath))
+    if (!pluginIsLoaded(pluginPath))
     {
         const std::string msg = "Plugin not loaded: " + pluginPath;
         msg_error("PluginManager::unloadPlugin()") << msg;
@@ -225,8 +225,19 @@ bool PluginManager::unloadPlugin(const std::string &pluginPath, std::ostream* er
     }
     else
     {
-        m_pluginMap.erase(m_pluginMap.find(pluginPath));
-        return true;
+        auto pluginMapEntry = m_pluginMap.find(pluginPath);
+        int ret = DynamicLibrary::unload(pluginMapEntry->second.dynamicLibrary);
+        if (ret)
+        {
+            msg_error("PluginManager::unloadPlugin()") << "Error while unloading " << pluginPath << " : "
+                << DynamicLibrary::getLastError();
+            return false;
+        }
+        else
+        {
+            m_pluginMap.erase(m_pluginMap.find(pluginPath));
+            return true;
+        }
     }
 }
 


### PR DESCRIPTION
Reopening of #1274

> unload() function of PluginManager was just removing the entry of the plugin in its map, but this one was effectively still loaded in the process memory. (on Windows, you could still see it using ProcessExplorer)
> This PR fixes it (i.e really unloads from memory)

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
