### PR TITLE
[plugins] Fix warnings for option compilation

### DIFF
--- a/applications/plugins/CGALPlugin/CylinderMesh.h
+++ b/applications/plugins/CGALPlugin/CylinderMesh.h
@@ -81,7 +81,7 @@ public:
     void orientate();
     void draw(const sofa::core::visual::VisualParams*) override;
 
-    virtual std::string getTemplateName() const
+    virtual std::string getTemplateName() const override
     {
         return templateName(this);
     }

--- a/applications/plugins/Compliant/misc/FailNode.h
+++ b/applications/plugins/Compliant/misc/FailNode.h
@@ -55,6 +55,7 @@ public:
     virtual bool doRemoveObject(core::objectmodel::BaseObject::SPtr obj) override;
 
     /// Move an object from a node to another node
+    using Node::doMoveObject;
     virtual void doMoveObject(core::objectmodel::BaseObject::SPtr obj);
 
     /// Test if the given node is a parent of this node.

--- a/applications/plugins/ManifoldTopologies/ManifoldTetrahedronSetTopologyContainer.cpp
+++ b/applications/plugins/ManifoldTopologies/ManifoldTetrahedronSetTopologyContainer.cpp
@@ -113,7 +113,6 @@ void ManifoldTetrahedronSetTopologyContainer::createTetrahedraAroundEdgeArray ()
     {
 
         sofa::helper::vector <unsigned int> &shell = getTetrahedraAroundEdgeForModification (edgeIndex);
-        sofa::helper::vector <unsigned int>::iterator it;
         sofa::helper::vector < sofa::helper::vector <unsigned int> > vertexTofind;
         sofa::helper::vector <unsigned int> goodShell;
         unsigned int firstVertex =0;

--- a/applications/plugins/ManifoldTopologies/ManifoldTriangleSetTopologyModifier.cpp
+++ b/applications/plugins/ManifoldTopologies/ManifoldTriangleSetTopologyModifier.cpp
@@ -826,7 +826,6 @@ void ManifoldTriangleSetTopologyModifier::reorderingTopologyOnROI (const sofa::h
         sofa::helper::vector <unsigned int>& edgesAroundVertex = m_container->getEdgesAroundVertexForModification( listVertex[vertexIndex] );
         sofa::helper::vector <unsigned int>& trianglesAroundVertex = m_container->getTrianglesAroundVertexForModification( listVertex[vertexIndex] );
 
-        sofa::helper::vector <unsigned int>::iterator it;
         sofa::helper::vector < sofa::helper::vector <unsigned int> > vertexTofind;
 
         sofa::helper::vector <unsigned int> goodEdgeShell;

--- a/applications/plugins/MeshSTEPLoader/MeshSTEPLoader.h
+++ b/applications/plugins/MeshSTEPLoader/MeshSTEPLoader.h
@@ -94,7 +94,7 @@ public:
 
     MeshSTEPLoader();
 
-    virtual bool load();
+    virtual bool load() override;
 
     template <class T>
     static bool canCreate(T*& obj, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)

--- a/applications/plugins/MeshSTEPLoader/ParametricTriangleTopologyContainer.h
+++ b/applications/plugins/MeshSTEPLoader/ParametricTriangleTopologyContainer.h
@@ -19,8 +19,8 @@ public:
     typedef defaulttype::Vector2 UV;
     typedef helper::vector<UV> SeqUV;
 
-    void init();
-    void reinit();
+    void init() override;
+    void reinit() override;
 
 public:
     Data<SeqUV> d_uv; ///< The uv coordinates for every triangle vertices.

--- a/applications/plugins/MeshSTEPLoader/STEPShapeMapping.h
+++ b/applications/plugins/MeshSTEPLoader/STEPShapeMapping.h
@@ -24,8 +24,8 @@ public:
     typedef sofa::core::topology::Topology::Triangle Triangle;
     STEPShapeExtractor(loader::MeshSTEPLoader* loader=NULL,topology::MeshTopology* topology=NULL);
 
-    void init();
-    void doUpdate();
+    void init() override;
+    void doUpdate() override;
 
     Data<unsigned int> shapeNumber; ///< Shape number to be loaded
     Data<unsigned int > indexBegin; ///< The begin index for this shape with respect to the global mesh

--- a/applications/plugins/MeshSTEPLoader/SingleComponent.h
+++ b/applications/plugins/MeshSTEPLoader/SingleComponent.h
@@ -47,9 +47,9 @@ public:
 
     SingleComponent();
 
-    virtual void init();
-    virtual void reinit();
-    virtual void doUpdate();
+    virtual void init() override;
+    virtual void reinit() override;
+    virtual void doUpdate() override;
 
     template <class T>
     static bool canCreate(T*& obj, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
@@ -57,7 +57,7 @@ public:
         return core::DataEngine::canCreate(obj, context, arg);
     }
 
-    virtual std::string getTemplateName() const
+    virtual std::string getTemplateName() const override
     {
         return templateName(this);
     }

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollisionDetection.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollisionDetection.cpp
@@ -358,7 +358,7 @@ void CudaCollisionDetection::RigidRigidTest::fillContacts(DetectionOutputVector&
 }
 */
 
-CudaCollisionDetection::SphereRigidTest::SphereRigidTest(CudaPointCollisionModel *model1, CudaRigidDistanceGridCollisionModel* model2 )
+CudaCollisionDetection::SphereRigidTest::SphereRigidTest(sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types> *model1, CudaRigidDistanceGridCollisionModel* model2 )
     : model1(model1), model2(model2)
 {
     std::cout << "CudaCollisionDetection::SphereRigidTest "<<model1->getClassName()<<" - "<<model2->getClassName()<<std::endl;

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollisionDetection.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollisionDetection.cpp
@@ -176,17 +176,17 @@ CudaCollisionDetection::Test* CudaCollisionDetection::createTest(core::Collision
     {
         if (CudaRigidDistanceGridCollisionModel* rigid2 = dynamic_cast<CudaRigidDistanceGridCollisionModel*>(model2))
             return new RigidRigidTest(rigid1, rigid2);
-        else if (CudaSphereModel* sphere2 = dynamic_cast<CudaSphereModel*>(model2))
+        else if (sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>* sphere2 = dynamic_cast<sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>*>(model2))
             return new SphereRigidTest(sphere2, rigid1);
-        else if (CudaPointModel* point2 = dynamic_cast<CudaPointModel*>(model2))
+        else if (CudaPointCollisionModel* point2 = dynamic_cast<CudaPointCollisionModel*>(model2))
             return new PointRigidTest(point2, rigid1);
     }
-    else if (CudaSphereModel* sphere1 = dynamic_cast<CudaSphereModel*>(model1))
+    else if (sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>* sphere1 = dynamic_cast<sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>*>(model1))
     {
         if (CudaRigidDistanceGridCollisionModel* rigid2 = dynamic_cast<CudaRigidDistanceGridCollisionModel*>(model2))
             return new SphereRigidTest(sphere1, rigid2);
     }
-    else if (CudaPointModel* point1 = dynamic_cast<CudaPointModel*>(model1))
+    else if (CudaPointCollisionModel* point1 = dynamic_cast<CudaPointCollisionModel*>(model1))
     {
         if (CudaRigidDistanceGridCollisionModel* rigid2 = dynamic_cast<CudaRigidDistanceGridCollisionModel*>(model2))
             return new PointRigidTest(point1, rigid2);
@@ -358,7 +358,7 @@ void CudaCollisionDetection::RigidRigidTest::fillContacts(DetectionOutputVector&
 }
 */
 
-CudaCollisionDetection::SphereRigidTest::SphereRigidTest( CudaSphereModel* model1, CudaRigidDistanceGridCollisionModel* model2 )
+CudaCollisionDetection::SphereRigidTest::SphereRigidTest(CudaPointCollisionModel *model1, CudaRigidDistanceGridCollisionModel* model2 )
     : model1(model1), model2(model2)
 {
     std::cout << "CudaCollisionDetection::SphereRigidTest "<<model1->getClassName()<<" - "<<model2->getClassName()<<std::endl;
@@ -467,7 +467,7 @@ void CudaCollisionDetection::SphereRigidTest::fillContacts(DetectionOutputVector
 }
 */
 
-CudaCollisionDetection::PointRigidTest::PointRigidTest( CudaPointModel* model1, CudaRigidDistanceGridCollisionModel* model2 )
+CudaCollisionDetection::PointRigidTest::PointRigidTest( CudaPointCollisionModel* model1, CudaRigidDistanceGridCollisionModel* model2 )
     : model1(model1), model2(model2)
 {
     std::cout << "CudaCollisionDetection::PointRigidTest "<<model1->getClassName()<<" - "<<model2->getClassName()<<std::endl;

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollisionDetection.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollisionDetection.h
@@ -295,7 +295,7 @@ public:
     class SphereRigidTest : public Test
     {
     public:
-        CudaPointCollisionModel* model1;
+        sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>* model1;
         CudaRigidDistanceGridCollisionModel* model2;
         SphereRigidTest(sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types> *model1, CudaRigidDistanceGridCollisionModel* model2);
         bool useGPU() { return true; }

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollisionDetection.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollisionDetection.h
@@ -188,12 +188,12 @@ class TDetectionOutputVector<sofa::gpu::cuda::CudaRigidDistanceGridCollisionMode
 };
 
 template<>
-class TDetectionOutputVector<sofa::gpu::cuda::CudaSphereModel,sofa::gpu::cuda::CudaRigidDistanceGridCollisionModel> : public GPUDetectionOutputVector
+class TDetectionOutputVector<sofa::gpu::cuda::sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>,sofa::gpu::cuda::CudaRigidDistanceGridCollisionModel> : public GPUDetectionOutputVector
 {
 };
 
 template<>
-class TDetectionOutputVector<sofa::gpu::cuda::CudaPointModel,sofa::gpu::cuda::CudaRigidDistanceGridCollisionModel> : public GPUDetectionOutputVector
+class TDetectionOutputVector<sofa::gpu::cuda::CudaPointCollisionModel,sofa::gpu::cuda::CudaRigidDistanceGridCollisionModel> : public GPUDetectionOutputVector
 {
 };
 
@@ -295,9 +295,9 @@ public:
     class SphereRigidTest : public Test
     {
     public:
-        CudaSphereModel* model1;
+        CudaPointCollisionModel* model1;
         CudaRigidDistanceGridCollisionModel* model2;
-        SphereRigidTest(CudaSphereModel* model1, CudaRigidDistanceGridCollisionModel* model2);
+        SphereRigidTest(CudaPointCollisionModel* model1, CudaRigidDistanceGridCollisionModel* model2);
         bool useGPU() { return true; }
         /// Returns how many tests are required
         virtual int init();
@@ -310,9 +310,9 @@ public:
     class PointRigidTest : public Test
     {
     public:
-        CudaPointModel* model1;
+        CudaPointCollisionModel* model1;
         CudaRigidDistanceGridCollisionModel* model2;
-        PointRigidTest(CudaPointModel* model1, CudaRigidDistanceGridCollisionModel* model2);
+        PointRigidTest(CudaPointCollisionModel* model1, CudaRigidDistanceGridCollisionModel* model2);
         bool useGPU() { return true; }
         /// Returns how many tests are required
         virtual int init();

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollisionDetection.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollisionDetection.h
@@ -297,7 +297,7 @@ public:
     public:
         CudaPointCollisionModel* model1;
         CudaRigidDistanceGridCollisionModel* model2;
-        SphereRigidTest(CudaPointCollisionModel* model1, CudaRigidDistanceGridCollisionModel* model2);
+        SphereRigidTest(sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types> *model1, CudaRigidDistanceGridCollisionModel* model2);
         bool useGPU() { return true; }
         /// Returns how many tests are required
         virtual int init();

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollisionDetection.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollisionDetection.h
@@ -188,7 +188,7 @@ class TDetectionOutputVector<sofa::gpu::cuda::CudaRigidDistanceGridCollisionMode
 };
 
 template<>
-class TDetectionOutputVector<sofa::gpu::cuda::sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>,sofa::gpu::cuda::CudaRigidDistanceGridCollisionModel> : public GPUDetectionOutputVector
+class TDetectionOutputVector<sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>,sofa::gpu::cuda::CudaRigidDistanceGridCollisionModel> : public GPUDetectionOutputVector
 {
 };
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollisionDistanceGrid.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollisionDistanceGrid.cpp
@@ -57,7 +57,7 @@ namespace collision
 using namespace sofa::gpu::cuda;
 
 template <>
-void BarycentricPenalityContact<CudaPointModel,CudaRigidDistanceGridCollisionModel,CudaVec3fTypes>::setDetectionOutputs(OutputVector* o)
+void BarycentricPenalityContact<CudaPointCollisionModel,CudaRigidDistanceGridCollisionModel,CudaVec3fTypes>::setDetectionOutputs(OutputVector* o)
 {
     TOutputVector& outputs = *static_cast<TOutputVector*>(o);
     //const bool printLog = this->f_printLog.getValue();
@@ -109,7 +109,7 @@ void BarycentricPenalityContact<CudaPointModel,CudaRigidDistanceGridCollisionMod
 }
 
 template <>
-void BarycentricPenalityContact<CudaSphereModel,CudaRigidDistanceGridCollisionModel,CudaVec3fTypes>::setDetectionOutputs(OutputVector* o)
+void BarycentricPenalityContact<sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>,CudaRigidDistanceGridCollisionModel,CudaVec3fTypes>::setDetectionOutputs(OutputVector* o)
 {
 
     TOutputVector& outputs = *static_cast<TOutputVector*>(o);
@@ -178,8 +178,8 @@ namespace cuda
 using namespace sofa::component::collision;
 
 //sofa::helper::Creator<sofa::core::collision::Contact::Factory, sofa::component::collision::BarycentricPenalityContact<CudaRigidDistanceGridCollisionModel, CudaRigidDistanceGridCollisionModel,CudaVec3fTypes> > CudaDistanceGridCudaDistanceGridContactClass("default", true);
-sofa::helper::Creator<sofa::core::collision::Contact::Factory, sofa::component::collision::BarycentricPenalityContact<CudaPointModel, CudaRigidDistanceGridCollisionModel,CudaVec3fTypes> > CudaPointCudaDistanceGridContactClass("default", true);
-sofa::helper::Creator<sofa::core::collision::Contact::Factory, sofa::component::collision::BarycentricPenalityContact<CudaSphereModel, CudaRigidDistanceGridCollisionModel,CudaVec3fTypes> > CudaSphereCudaDistanceGridContactClass("default", true);
+sofa::helper::Creator<sofa::core::collision::Contact::Factory, sofa::component::collision::BarycentricPenalityContact<CudaPointCollisionModel, CudaRigidDistanceGridCollisionModel,CudaVec3fTypes> > CudaPointCudaDistanceGridContactClass("default", true);
+sofa::helper::Creator<sofa::core::collision::Contact::Factory, sofa::component::collision::BarycentricPenalityContact<sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>, CudaRigidDistanceGridCollisionModel,CudaVec3fTypes> > CudaSphereCudaDistanceGridContactClass("default", true);
 //sofa::helper::Creator<sofa::core::collision::Contact::Factory, sofa::component::collision::BarycentricPenalityContact<CudaRigidDistanceGridCollisionModel, sofa::component::collision::RigidDistanceGridCollisionModel> > CudaDistanceGridDistanceGridContactClass("default", true);
 //sofa::helper::Creator<sofa::core::collision::Contact::Factory, sofa::component::collision::BarycentricPenalityContact<CudaRigidDistanceGridCollisionModel, sofa::component::collision::PointModel> > CudaDistanceGridPointContactClass("default", true);
 //sofa::helper::Creator<sofa::core::collision::Contact::Factory, sofa::component::collision::BarycentricPenalityContact<CudaRigidDistanceGridCollisionModel, sofa::component::collision::SphereModel> > CudaDistanceGridSphereContactClass("default", true);

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaContactMapper.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaContactMapper.h
@@ -133,12 +133,12 @@ public:
 
 /// Mapper for CudaPointDistanceGridCollisionModel
 template <class DataTypes>
-class ContactMapper<sofa::gpu::cuda::CudaPointModel,DataTypes> : public SubsetContactMapper<sofa::gpu::cuda::CudaPointModel,DataTypes>
+class ContactMapper<sofa::gpu::cuda::CudaPointCollisionModel,DataTypes> : public SubsetContactMapper<sofa::gpu::cuda::CudaPointCollisionModel,DataTypes>
 {
 public:
     typedef typename DataTypes::Real Real;
     typedef typename DataTypes::Coord Coord;
-    typedef SubsetContactMapper<sofa::gpu::cuda::CudaPointModel,DataTypes> Inherit;
+    typedef SubsetContactMapper<sofa::gpu::cuda::CudaPointCollisionModel,DataTypes> Inherit;
     typedef typename Inherit::MMechanicalState MMechanicalState;
     typedef typename Inherit::MCollisionModel MCollisionModel;
     typedef typename Inherit::MMapping MMapping;
@@ -165,12 +165,12 @@ public:
 
 
 template <class DataTypes>
-class ContactMapper<sofa::gpu::cuda::CudaSphereModel,DataTypes> : public SubsetContactMapper<sofa::gpu::cuda::CudaSphereModel,DataTypes>
+class ContactMapper<sofa::gpu::cuda::sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>,DataTypes> : public SubsetContactMapper<sofa::gpu::cuda::sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>,DataTypes>
 {
 public:
     typedef typename DataTypes::Real Real;
     typedef typename DataTypes::Coord Coord;
-    typedef SubsetContactMapper<sofa::gpu::cuda::CudaSphereModel,DataTypes> Inherit;
+    typedef SubsetContactMapper<sofa::gpu::cuda::sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>,DataTypes> Inherit;
     typedef typename Inherit::MMechanicalState MMechanicalState;
     typedef typename Inherit::MCollisionModel MCollisionModel;
     typedef typename Inherit::MMapping MMapping;

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaContactMapper.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaContactMapper.h
@@ -165,12 +165,12 @@ public:
 
 
 template <class DataTypes>
-class ContactMapper<sofa::gpu::cuda::sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>,DataTypes> : public SubsetContactMapper<sofa::gpu::cuda::sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>,DataTypes>
+class ContactMapper<sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>,DataTypes> : public SubsetContactMapper<sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>,DataTypes>
 {
 public:
     typedef typename DataTypes::Real Real;
     typedef typename DataTypes::Coord Coord;
-    typedef SubsetContactMapper<sofa::gpu::cuda::sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>,DataTypes> Inherit;
+    typedef SubsetContactMapper<sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>,DataTypes> Inherit;
     typedef typename Inherit::MMechanicalState MMechanicalState;
     typedef typename Inherit::MCollisionModel MCollisionModel;
     typedef typename Inherit::MMapping MMapping;

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSPHFluidForceField.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSPHFluidForceField.inl
@@ -272,6 +272,8 @@ void SPHFluidForceField<gpu::cuda::CudaVec3fTypes>::draw(const core::visual::Vis
     }
     glEnd();
     glPointSize(1);
+#else
+    SOFA_UNUSED(vparams);
 #endif // SOFA_NO_OPENGL
 }
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSphereModel.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSphereModel.h
@@ -35,8 +35,8 @@ namespace gpu
 namespace cuda
 {
 
-typedef sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types> CudaSphereModel;
-typedef sofa::component::collision::TSphere<gpu::cuda::CudaVec3Types> CudaSphere;
+using CudaSphereModel [[deprecated("The CudaSphereModel is now deprecated, please use sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types> instead. Compatibility stops at v20.06")]] = sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>;
+using CudaSphere = sofa::component::collision::TSphere<gpu::cuda::CudaVec3Types>;
 
 
 } // namespace cuda

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticleSource.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticleSource.inl
@@ -221,7 +221,7 @@ void ParticleSource<DataTypes>::animateBegin(double /*dt*/, double time)
         newX.reserve(nbParticlesToCreate * m_numberParticles);
         newV.reserve(nbParticlesToCreate * m_numberParticles);
         const Deriv v0 = d_velocity.getValue();
-        for (int i = 0; i < nbParticlesToCreate; i++)
+        for (size_t i = 0; i < nbParticlesToCreate; i++)
         {
             m_lastTime += d_delay.getValue();
             m_maxdist += d_delay.getValue() * d_velocity.getValue().norm() / d_scale.getValue();
@@ -233,7 +233,7 @@ void ParticleSource<DataTypes>::animateBegin(double /*dt*/, double time)
             {
                 size_t shift = _lastparticles.size() - lp0;
                 Deriv dpos = v0 * d_delay.getValue();
-                for (int s = 0; s < lp0; s++)
+                for (size_t s = 0; s < lp0; s++)
                 {
                     _lastparticles[s] = _lastparticles[s + shift];
                     m_lastpos[s] = m_lastpos[s + shift] + dpos;
@@ -243,7 +243,7 @@ void ParticleSource<DataTypes>::animateBegin(double /*dt*/, double time)
             _lastparticles.resize(lp0);
             m_lastpos.resize(lp0);
 
-            for (int s = 0; s < m_numberParticles; s++)
+            for (size_t s = 0; s < m_numberParticles; s++)
             {
                 Coord p = d_center.getValue()[s] * d_scale.getValue() + d_translation.getValue();
 
@@ -288,7 +288,7 @@ void ParticleSource<DataTypes>::animateBegin(double /*dt*/, double time)
 
         helper::WriteAccessor< Data<VecCoord> > x = *this->mstate->write(core::VecCoordId::position());
         helper::WriteAccessor< Data<VecDeriv> > v = *this->mstate->write(core::VecDerivId::velocity());
-        for (int s = 0; s < nbParticlesToCreate; ++s)
+        for (size_t s = 0; s < nbParticlesToCreate; ++s)
         {
             x[i0 + s] = newX[s];
             v[i0 + s] = newV[s];

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticlesRepulsionForceField.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticlesRepulsionForceField.inl
@@ -81,7 +81,7 @@ void ParticlesRepulsionForceField<DataTypes>::addForce(const core::MechanicalPar
     // Initialization
     f.resize(n);
     particles.resize(n);
-    for (int i=0; i<n; i++)
+    for (size_t i=0; i<n; i++)
     {
         particles[i].neighbors.clear();
     }
@@ -90,10 +90,10 @@ void ParticlesRepulsionForceField<DataTypes>::addForce(const core::MechanicalPar
     // This is an O(n2) step, except if a hash-grid is used to optimize it
     if (grid == nullptr)
     {
-        for (int i=0; i<n; i++)
+        for (size_t i=0; i<n; i++)
         {
             const Coord& ri = x[i];
-            for (int j=i+1; j<n; j++)
+            for (size_t j=i+1; j<n; j++)
             {
                 const Coord& rj = x[j];
                 Real r2 = (rj-ri).norm2();
@@ -109,7 +109,7 @@ void ParticlesRepulsionForceField<DataTypes>::addForce(const core::MechanicalPar
     }
 
     // Compute the forces
-    for (int i=0; i<n; i++)
+    for (size_t i=0; i<n; i++)
     {
         Particle& Pi = particles[i];
 
@@ -155,7 +155,7 @@ void ParticlesRepulsionForceField<DataTypes>::addDForce(const core::MechanicalPa
     df.resize(dx.size());
 
     // Compute the forces
-    for (int i=0; i<n; i++)
+    for (size_t i=0; i<n; i++)
     {
         Particle& Pi = particles[i];
 

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/SPHFluidForceField.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/SPHFluidForceField.inl
@@ -146,7 +146,7 @@ void SPHFluidForceField<DataTypes>::computeNeighbors(const core::MechanicalParam
 
     size_t n = x.size();
     m_particles.resize(n);
-    for (int i=0; i<n; i++) {
+    for (size_t i=0; i<n; i++) {
         m_particles[i].neighbors.clear();
     }
 
@@ -172,10 +172,10 @@ void SPHFluidForceField<DataTypes>::computeNeighbors(const core::MechanicalParam
 
         });
 #else
-        for (int i = 0; i<n; i++)
+        for (size_t i = 0; i<n; i++)
         {
             const Coord& ri = x[i];
-            for (int j = i + 1; j<n; j++)
+            for (size_t j = i + 1; j<n; j++)
             {
                 const Coord& rj = x[j];
                 Real r2 = (rj - ri).norm2();
@@ -197,15 +197,15 @@ void SPHFluidForceField<DataTypes>::computeNeighbors(const core::MechanicalParam
         if (!d_debugGrid.getValue())
             return;
 
-        for (int i = 0; i < n; i++) {
+        for (size_t i = 0; i < n; i++) {
             m_particles[i].neighbors2.clear();
         }
 
         // Check grid info
-        for (int i=0; i<n; i++)
+        for (size_t i=0; i<n; i++)
         {
             const Coord& ri = x[i];
-            for (int j=i+1; j<n; j++)
+            for (size_t j=i+1; j<n; j++)
             {
                 const Coord& rj = x[j];
                 Real r2 = (rj-ri).norm2();
@@ -216,7 +216,7 @@ void SPHFluidForceField<DataTypes>::computeNeighbors(const core::MechanicalParam
                 }
             }
         }
-        for (int i=0; i<n; i++)
+        for (size_t i=0; i<n; i++)
         {
             if (m_particles[i].neighbors.size() != m_particles[i].neighbors2.size())
             {
@@ -278,7 +278,7 @@ void SPHFluidForceField<DataTypes>::computeForce(const core::MechanicalParams* /
     dforces.clear();
     //int n0 = m_particles.size();
     m_particles.resize(n);
-    for (int i=0; i<n; i++)
+    for (size_t i=0; i<n; i++)
     {
         m_particles[i].density = 0;
         m_particles[i].pressure = 0;
@@ -292,7 +292,7 @@ void SPHFluidForceField<DataTypes>::computeForce(const core::MechanicalParams* /
     TKc Kc(h);
 
     // Compute density and pressure
-    for (int i=0; i<n; i++)
+    for (size_t i=0; i<n; i++)
     {
         Particle& Pi = m_particles[i];
         Real density = Pi.density;
@@ -316,7 +316,7 @@ void SPHFluidForceField<DataTypes>::computeForce(const core::MechanicalParams* /
     // Compute surface normal and curvature
     if (surfaceTensionT == 1)
     {
-        for (int i=0; i<n; i++)
+        for (size_t i=0; i<n; i++)
         {
             Particle& Pi = m_particles[i];
             for (typename std::vector< std::pair<int,Real> >::const_iterator it = Pi.neighbors.begin(); it != Pi.neighbors.end(); ++it)
@@ -335,7 +335,7 @@ void SPHFluidForceField<DataTypes>::computeForce(const core::MechanicalParams* /
     }
 
     // Compute the forces
-    for (int i = 0; i < n; i++)
+    for (size_t i = 0; i < n; i++)
     {
         const Particle& Pi = m_particles[i];
         // Gravity

--- a/applications/plugins/image/ImageSampler.h
+++ b/applications/plugins/image/ImageSampler.h
@@ -791,7 +791,6 @@ protected:
         }
         //        for(unsigned int i=0;i<nb;i++) sampler->sout<<"("<<pos[indices[i]]<<") ";  sampler->sout<<sampler->sendl;
         Coord p;
-        typename helper::vector<Coord>::iterator it;
         // add corners
         unsigned int corners[8]= {addPoint(Coord(BB[0][0],BB[0][1],BB[0][2]),pos,indices),addPoint(Coord(BB[1][0],BB[0][1],BB[0][2]),pos,indices),addPoint(Coord(BB[0][0],BB[1][1],BB[0][2]),pos,indices),addPoint(Coord(BB[1][0],BB[1][1],BB[0][2]),pos,indices),addPoint(Coord(BB[0][0],BB[0][1],BB[1][2]),pos,indices),addPoint(Coord(BB[1][0],BB[0][1],BB[1][2]),pos,indices),addPoint(Coord(BB[0][0],BB[1][1],BB[1][2]),pos,indices),addPoint(Coord(BB[1][0],BB[1][1],BB[1][2]),pos,indices)};
         // add cell center


### PR DESCRIPTION
Fix some the last SOFA-related warnings in option:

- fix hidden overload
- remove unused iterator
- Fix size_t int comparison
- add overrides
- fix CUDA collision models
- add override on getTemplateName function 


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
