### PR TITLE
[SofaSphFluid] FIX .scene-tests

### DIFF
--- a/applications/plugins/SofaSphFluid/examples/.scene-tests
+++ b/applications/plugins/SofaSphFluid/examples/.scene-tests
@@ -1,5 +1,4 @@
 # those scenes use shader (e.g. due to OglFluidModel), can't run on CI VM.
 ignore "OglFluidModel_SPH.scn"
 ignore "OglFluidModel_SPHParticles.scn"
-ignore "OglFluidModel_SPHParticles.scn"
 ignore "SPHParticleSink_obstacle.scn"


### PR DESCRIPTION
SPHParticleSink_obstacle.scn should be ignored.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
