### PR TITLE
[SofaGeneralEngine] Fix draw of the sphere in SphereROI

### DIFF
--- a/modules/SofaGeneralEngine/SphereROI.inl
+++ b/modules/SofaGeneralEngine/SphereROI.inl
@@ -475,7 +475,7 @@ void SphereROI<DataTypes>::draw(const core::visual::VisualParams* vparams)
         {
 
             drawcenters.push_back(c[i]);
-            drawradii.push_back((float)(r[i] * 0.5));
+            drawradii.push_back((float)r[i]);
             
             if (edgeAngle.getValue() > 0)
             {

--- a/modules/SofaGeneralEngine/SphereROI.inl
+++ b/modules/SofaGeneralEngine/SphereROI.inl
@@ -475,7 +475,7 @@ void SphereROI<DataTypes>::draw(const core::visual::VisualParams* vparams)
         {
 
             drawcenters.push_back(c[i]);
-            drawradii.push_back((float)r[i]);
+            drawradii.push_back(float(r[i]));
             
             if (edgeAngle.getValue() > 0)
             {


### PR DESCRIPTION
Sphere drawn was actually half the size of the Sphere used..

Thank you @etagliabue for the notice !
 
Problem was:
![](https://i.ibb.co/J5SkJ01/Sphere-ROI-00000001.png)




______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
