### PR TITLE
[SofaTopologyMapping] Fix Tetra2TriangleTopologicalMapping 

### DIFF
--- a/modules/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.cpp
@@ -443,9 +443,7 @@ void Tetra2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
         case core::topology::EDGESADDED:
         {
             const auto * edgeAdded=static_cast< const EdgesAdded * >( *itBegin );
-            m_outTopoModifier->addEdgesProcess(edgeAdded->edgeArray);
-            m_outTopoModifier->addEdgesWarning(edgeAdded->nEdges, edgeAdded->edgeArray, edgeAdded->edgeIndexArray);
-            m_outTopoModifier->propagateTopologicalChanges();
+            m_outTopoModifier->addEdges(edgeAdded->edgeArray);
             break;
         }
 


### PR DESCRIPTION
Adding Edge case should be done using the proper lower topology addEdge mechanisme.

Should fix the scene test error on AddingTetra2TriangleProcess.scn





______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
