### PR TITLE
[SofaBaseTopology] Fix GridTopology edge computation

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/GridTopology.h
+++ b/SofaKernel/modules/SofaBaseTopology/GridTopology.h
@@ -80,7 +80,7 @@ private:
         void updateTriangles();
         void updateHexas();
     private:
-        GridTopology* topology;
+        GridTopology* m_topology;
     };
 
 protected:
@@ -193,6 +193,7 @@ public:
     /// Data bool to set option to compute topological elements
     Data<bool> d_computeHexaList;
     Data<bool> d_computeQuadList; ///< put true if the list of Quad is needed during init (default=true)
+    Data<bool> d_computeTriangleList; ///< put true if the list of Triangles is needed during init (default=true)
     Data<bool> d_computeEdgeList; ///< put true if the list of Lines is needed during init (default=true)
     Data<bool> d_computePointList; ///< put true if the list of Points is needed during init (default=true)
     /// Data bool to set option to compute texcoords

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.cpp
@@ -291,6 +291,7 @@ void TriangleSetTopologyContainer::createEdgesInTriangleArray()
                         << " [" << t[(j + 1) % 3] << ", " << t[(j + 2) % 3] << "]"
                         << " in triangle " << i;
                     m_edgesInTriangle.clear();
+                    this->d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Invalid);
                     return;
                 }
             }

--- a/examples/Components/topology/RegularGridTopology_TrianglesMesh.scn
+++ b/examples/Components/topology/RegularGridTopology_TrianglesMesh.scn
@@ -1,0 +1,38 @@
+<?xml version="1.0" ?>
+<Node name="root" dt="0.05" showBoundingTree="0" gravity="0 -9 5">
+    <RequiredPlugin name="SofaOpenglVisual"/>
+    <VisualStyle displayFlags="showBehaviorModels showVisual" />
+    <DefaultPipeline />
+    <BruteForceDetection name="N2" />
+    <DefaultContactManager response="default" />
+    <MinProximityIntersection name="Proximity" alarmDistance="0.8" contactDistance="0.5" />
+
+    <Node name="SquareGravity">
+        <EulerImplicitSolver name="cg_odesolver"/>
+        <CGImplicit iterations="40" tolerance="1e-6" threshold="1e-10" />
+               
+        <RegularGridTopology name="grid" nx="10" ny="10" nz="1" xmin="-5" xmax="5" ymin="-5" ymax="5" zmin="0" zmax="0"/>
+        
+        <MechanicalObject src="@grid" scale="10" />
+        
+        <TriangleSetTopologyContainer  name="Container" src="@grid"/>
+        <TriangleSetTopologyModifier   name="Modifier" />
+        <TriangleSetTopologyAlgorithms name="TopoAlgo" />
+        <TriangleSetGeometryAlgorithms name="GeomAlgo" drawEdges="1"/>
+        
+        <DiagonalMass massDensity="0.15" />
+        <FixedConstraint indices="0 1 8 9 10 19" />
+       
+       
+        <TriangularFEMForceField name="FEM" youngModulus="60" poissonRatio="0.3" method="large" />
+        <TriangularBendingSprings name="FEM-Bend" stiffness="300" damping="1.0" />
+        
+        <TriangleCollisionModel />
+        
+        <Node >
+          <OglModel name="Visual" color="red" />
+          <IdentityMapping input="@.." output="@Visual" />
+        </Node>
+
+    </Node>
+</Node>

--- a/modules/SofaGeneralDeformable/TriangularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/TriangularBendingSprings.inl
@@ -494,7 +494,7 @@ void TriangularBendingSprings<DataTypes>::init()
         return;
     }
 
-    if (m_topology->getNbTriangles()==0)
+    if (m_topology->d_componentstate.getValue() == sofa::core::objectmodel::ComponentState::Invalid || m_topology->getNbTriangles()==0)
     {
         msg_error() << " object must have a Triangular Set Topology.";
         sofa::core::objectmodel::BaseObject::d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Invalid);


### PR DESCRIPTION
- Fix edges computation in GridTopology: It is now based either on triangles or on the quad grid, depending on what is asked. Option ```computeTriangleList``` has been added to GridTopology. True by default. If false, only quads will be computed and the corresponding list of edges
- Set TriangleSetTopologyContainer to invalid if EdgeInTriangle buffer creation failed. Check validity of the topology in TriangularBendingSprings. This will avoid the crash.

fix #1243

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
