### PR TITLE
[SofaCore] Remove warning in ExecParam

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/ExecParams.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/ExecParams.h
@@ -138,7 +138,7 @@ public:
 
     /// Specify the aspect index of the current thread
     [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. If the feature was important to you contact sofa-dev. ")]]
-    ExecParams& setAspectID(int v){ return *this; }
+    ExecParams& setAspectID(int /* v */){ return *this; }
 
     [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. If the feature was important to you contact sofa-dev. ")]]
     static int currentAspect(){ return 0; }


### PR DESCRIPTION
Remove a really annoying "unused variable" warning



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
