### PR TITLE
[all] Fix warnings generated due to change in Aspects

### DIFF
--- a/SofaKernel/modules/SofaBaseCollision/SphereModel.inl
+++ b/SofaKernel/modules/SofaBaseCollision/SphereModel.inl
@@ -275,6 +275,8 @@ typename SphereCollisionModel<DataTypes>::Real SphereCollisionModel<DataTypes>::
 template<class DataTypes>
 void SphereCollisionModel<DataTypes>::computeBBox(const core::ExecParams* params, bool onlyVisible)
 {
+    SOFA_UNUSED(params);
+
     if(m_componentstate!=ComponentState::Valid)
         return ;
 

--- a/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.inl
@@ -1454,6 +1454,7 @@ void MechanicalObject<DataTypes>::endIntegration(const core::ExecParams* /*param
 template <class DataTypes>
 void MechanicalObject<DataTypes>::accumulateForce(const core::ExecParams* params, core::VecDerivId fId)
 {
+    SOFA_UNUSED(params);
 
     {
         helper::ReadAccessor< Data<VecDeriv> > extForces_rA( *this->read(core::ConstVecDerivId::externalForce()) );
@@ -1692,6 +1693,8 @@ void MechanicalObject<DataTypes>::vAvail(const core::ExecParams* /* params */, c
 template <class DataTypes>
 void MechanicalObject<DataTypes>::vAlloc(const core::ExecParams* params, core::VecCoordId v)
 {
+    SOFA_UNUSED(params);
+
     if (v.index >= sofa::core::VecCoordId::V_FIRST_DYNAMIC_INDEX)
     {
         Data<VecCoord>* vec_d = this->write(v);
@@ -1705,7 +1708,7 @@ void MechanicalObject<DataTypes>::vAlloc(const core::ExecParams* params, core::V
 template <class DataTypes>
 void MechanicalObject<DataTypes>::vAlloc(const core::ExecParams* params, core::VecDerivId v)
 {
-
+    SOFA_UNUSED(params);
 
     if (v.index >= sofa::core::VecDerivId::V_FIRST_DYNAMIC_INDEX)
     {
@@ -1720,6 +1723,8 @@ void MechanicalObject<DataTypes>::vAlloc(const core::ExecParams* params, core::V
 template <class DataTypes>
 void MechanicalObject<DataTypes>::vRealloc(const core::ExecParams* params, core::VecCoordId v)
 {
+    SOFA_UNUSED(params);
+
     Data<VecCoord>* vec_d = this->write(v);
 
     if ( !vec_d->isSet() /*&& v.index >= sofa::core::VecCoordId::V_FIRST_DYNAMIC_INDEX*/ )
@@ -1732,6 +1737,8 @@ void MechanicalObject<DataTypes>::vRealloc(const core::ExecParams* params, core:
 template <class DataTypes>
 void MechanicalObject<DataTypes>::vRealloc(const core::ExecParams* params, core::VecDerivId v)
 {
+    SOFA_UNUSED(params);
+
     Data<VecDeriv>* vec_d = this->write(v);
 
     if ( !vec_d->isSet() /*&& v.index >= sofa::core::VecDerivId::V_FIRST_DYNAMIC_INDEX*/ )
@@ -1744,6 +1751,8 @@ void MechanicalObject<DataTypes>::vRealloc(const core::ExecParams* params, core:
 template <class DataTypes>
 void MechanicalObject<DataTypes>::vFree(const core::ExecParams* params, core::VecCoordId vId)
 {
+    SOFA_UNUSED(params);
+
     if (vId.index >= sofa::core::VecCoordId::V_FIRST_DYNAMIC_INDEX)
     {
         Data< VecCoord >* vec_d = this->write(vId);
@@ -1759,6 +1768,8 @@ void MechanicalObject<DataTypes>::vFree(const core::ExecParams* params, core::Ve
 template <class DataTypes>
 void MechanicalObject<DataTypes>::vFree(const core::ExecParams* params, core::VecDerivId vId)
 {
+    SOFA_UNUSED(params);
+
     if (vId.index >= sofa::core::VecDerivId::V_FIRST_DYNAMIC_INDEX)
     {
         Data< VecDeriv >* vec_d = this->write(vId);
@@ -1804,7 +1815,7 @@ void MechanicalObject<DataTypes>::vOp(const core::ExecParams* params, core::VecI
                                       core::ConstVecId a,
                                       core::ConstVecId b, SReal f)
 {
-
+    SOFA_UNUSED(params);
 
     if(v.isNull())
     {
@@ -2341,6 +2352,8 @@ typedef std::size_t nat;
 template <class DataTypes>
 SReal MechanicalObject<DataTypes>::vSum(const core::ExecParams* params, core::ConstVecId a, unsigned l)
 {
+    SOFA_UNUSED(params);
+
     Real r = 0.0;
 
     if (a.type == sofa::core::V_COORD )
@@ -2373,6 +2386,8 @@ SReal MechanicalObject<DataTypes>::vSum(const core::ExecParams* params, core::Co
 template <class DataTypes>
 SReal MechanicalObject<DataTypes>::vMax(const core::ExecParams* params, core::ConstVecId a )
 {
+    SOFA_UNUSED(params);
+
     Real r = 0.0;
 
     if (a.type == sofa::core::V_COORD )
@@ -2406,6 +2421,8 @@ SReal MechanicalObject<DataTypes>::vMax(const core::ExecParams* params, core::Co
 template <class DataTypes>
 size_t MechanicalObject<DataTypes>::vSize(const core::ExecParams* params, core::ConstVecId v)
 {
+    SOFA_UNUSED(params);
+
     if (v.type == sofa::core::V_COORD)
     {
         const VecCoord &vv = this->read(core::ConstVecCoordId(v))->getValue();
@@ -2509,8 +2526,10 @@ unsigned MechanicalObject<DataTypes>::printDOFWithElapsedTime(core::ConstVecId v
 template <class DataTypes>
 void MechanicalObject<DataTypes>::resetForce(const core::ExecParams* params, core::VecDerivId fid)
 {
+    SOFA_UNUSED(params);
+
     {
-        helper::WriteOnlyAccessor< Data<VecDeriv> > f( params, *this->write(fid) );
+        helper::WriteOnlyAccessor< Data<VecDeriv> > f( *this->write(fid) );
         for (unsigned i = 0; i < f.size(); ++i)
 //          if( this->forceMask.getEntry(i) ) // safe getter or not?
                 f[i] = Deriv();
@@ -2520,8 +2539,10 @@ void MechanicalObject<DataTypes>::resetForce(const core::ExecParams* params, cor
 template <class DataTypes>
 void MechanicalObject<DataTypes>::resetAcc(const core::ExecParams* params, core::VecDerivId aId)
 {
+    SOFA_UNUSED(params);
+
     {
-        helper::WriteOnlyAccessor< Data<VecDeriv> > a( params, *this->write(aId) );
+        helper::WriteOnlyAccessor< Data<VecDeriv> > a( *this->write(aId) );
         for (unsigned i = 0; i < a.size(); ++i)
         {
             a[i] = Deriv();
@@ -2533,13 +2554,13 @@ template <class DataTypes>
 void MechanicalObject<DataTypes>::resetConstraint(const core::ConstraintParams* cParams)
 {
     Data<MatrixDeriv>& c_data = *this->write(cParams->j().getId(this));
-    MatrixDeriv *c = c_data.beginEdit(cParams);
+    MatrixDeriv *c = c_data.beginEdit();
     c->clear();
-    c_data.endEdit(cParams);
+    c_data.endEdit();
     Data<MatrixDeriv>& m_data = *this->write(core::MatrixDerivId::mappingJacobian());
-    MatrixDeriv *m = m_data.beginEdit(cParams);
+    MatrixDeriv *m = m_data.beginEdit();
     m->clear();
-    m_data.endEdit(cParams);
+    m_data.endEdit();
 }
 
 template <class DataTypes>

--- a/SofaKernel/modules/SofaBaseVisual/VisualStyle.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/VisualStyle.cpp
@@ -65,7 +65,7 @@ VisualStyle::VisualStyle()
 void VisualStyle::fwdDraw(VisualParams* vparams)
 {
     backupFlags = vparams->displayFlags();
-    vparams->displayFlags() = sofa::core::visual::merge_displayFlags(backupFlags, displayFlags.getValue(vparams));
+    vparams->displayFlags() = sofa::core::visual::merge_displayFlags(backupFlags, displayFlags.getValue());
 }
 
 void VisualStyle::bwdDraw(VisualParams* vparams)

--- a/SofaKernel/modules/SofaEngine/BoxROI.inl
+++ b/SofaKernel/modules/SofaEngine/BoxROI.inl
@@ -1044,6 +1044,8 @@ void BoxROI<DataTypes>::draw(const core::visual::VisualParams* vparams)
 template <class DataTypes>
 void BoxROI<DataTypes>::computeBBox(const ExecParams*  params , bool onlyVisible)
 {
+    SOFA_UNUSED(params);
+
     if( onlyVisible && !d_drawBoxes.getValue() )
         return;
 

--- a/SofaKernel/modules/SofaMeshCollision/LineModel.inl
+++ b/SofaKernel/modules/SofaMeshCollision/LineModel.inl
@@ -594,6 +594,8 @@ void LineCollisionModel<DataTypes>::setFilter(LineLocalMinDistanceFilter *lmdFil
 template<class DataTypes>
 void LineCollisionModel<DataTypes>::computeBBox(const core::ExecParams* params, bool onlyVisible)
 {
+    SOFA_UNUSED(params);
+
     if( !onlyVisible ) return;
 
     static const Real max_real = std::numeric_limits<Real>::max();

--- a/SofaKernel/modules/SofaMeshCollision/PointModel.inl
+++ b/SofaKernel/modules/SofaMeshCollision/PointModel.inl
@@ -393,6 +393,8 @@ void PointCollisionModel<DataTypes>::setFilter(PointLocalMinDistanceFilter *lmdF
 template<class DataTypes>
 void PointCollisionModel<DataTypes>::computeBBox(const core::ExecParams* params, bool onlyVisible)
 {
+    SOFA_UNUSED(params);
+
     if( !onlyVisible ) return;
 
     const int npoints = mstate->getSize();

--- a/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
+++ b/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
@@ -420,6 +420,8 @@ int TriangleCollisionModel<DataTypes>::getTriangleFlags(Topology::TriangleID i)
 template<class DataTypes>
 void TriangleCollisionModel<DataTypes>::computeBBox(const core::ExecParams* params, bool onlyVisible)
 {
+    SOFA_UNUSED(params);
+
     if( !onlyVisible ) return;
 
     // check first that topology didn't changed

--- a/SofaKernel/modules/SofaRigid/JointSpringForceField.inl
+++ b/SofaKernel/modules/SofaRigid/JointSpringForceField.inl
@@ -457,6 +457,8 @@ void JointSpringForceField<DataTypes>::draw(const core::visual::VisualParams* vp
 template <class DataTypes>
 void JointSpringForceField<DataTypes>::computeBBox(const core::ExecParams*  params, bool /* onlyVisible */)
 {
+    SOFA_UNUSED(params);
+
     const Real max_real = std::numeric_limits<Real>::max();
     const Real min_real = std::numeric_limits<Real>::lowest(); //not min() !
     Real maxBBox[3] = { min_real,min_real,min_real };

--- a/SofaKernel/modules/SofaSimpleFem/HexahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/HexahedronFEMForceField.inl
@@ -1171,6 +1171,8 @@ void HexahedronFEMForceField<DataTypes>::addKToMatrix(const core::MechanicalPara
 template<class DataTypes>
 void HexahedronFEMForceField<DataTypes>::computeBBox(const core::ExecParams* params, bool onlyVisible)
 {
+    SOFA_UNUSED(params);
+
     if( !onlyVisible ) return;
 
     helper::ReadAccessor<DataVecCoord> x = this->mstate->read(core::VecCoordId::position());

--- a/applications/plugins/PluginExample/src/PluginExample/MyMappingPendulumInPlane.inl
+++ b/applications/plugins/PluginExample/src/PluginExample/MyMappingPendulumInPlane.inl
@@ -108,8 +108,10 @@ void MyMappingPendulumInPlane<In, Out>::apply(const core::MechanicalParams* mpar
                                              OutDataVecCoord& out,
                                              const InDataVecCoord& in)
 {
-    VecOutCoord& childPos = *out.beginEdit(mparams);
-    const VecInCoord& parentPos = in.getValue(mparams);
+    SOFA_UNUSED(mparams);
+
+    VecOutCoord& childPos = *out.beginEdit();
+    const VecInCoord& parentPos = in.getValue();
 
     ReadAccessor<Data<vector<OutReal> > > distances (f_length);
     for(unsigned i=0; i<childPos.size(); i++)
@@ -120,7 +122,7 @@ void MyMappingPendulumInPlane<In, Out>::apply(const core::MechanicalParams* mpar
         childPos[i][1] = gap[i][1];
     }
 
-    out.endEdit(mparams);
+    out.endEdit();
 }
 
 template <class In, class Out>
@@ -128,8 +130,10 @@ void MyMappingPendulumInPlane<In, Out>::applyJ(const core::MechanicalParams* mpa
                                               OutDataVecDeriv& out,
                                               const InDataVecDeriv& in)
 {
-    VecOutDeriv& childVel = *out.beginEdit(mparams);
-    const VecInDeriv& parentVel = in.getValue(mparams);
+    SOFA_UNUSED(mparams);
+
+    VecOutDeriv& childVel = *out.beginEdit();
+    const VecInDeriv& parentVel = in.getValue();
 
     for(unsigned i=0; i<childVel.size(); i++)
     {
@@ -140,7 +144,7 @@ void MyMappingPendulumInPlane<In, Out>::applyJ(const core::MechanicalParams* mpa
                  (OutReal)0);
     }
 
-    out.endEdit(mparams);
+    out.endEdit();
 }
 
 template <class In, class Out>
@@ -148,8 +152,10 @@ void MyMappingPendulumInPlane<In, Out>::applyJT(const core::MechanicalParams* mp
                                                InDataVecDeriv& out,
                                                const OutDataVecDeriv& in)
 {
-    VecInDeriv& parentForce = *out.beginEdit(mparams);
-    const VecOutDeriv& childForce = in.getValue(mparams);
+    SOFA_UNUSED(mparams);
+
+    VecInDeriv& parentForce = *out.beginEdit();
+    const VecOutDeriv& childForce = in.getValue();
 
     for(unsigned i=0; i<parentForce.size(); i++)
     {
@@ -157,16 +163,18 @@ void MyMappingPendulumInPlane<In, Out>::applyJT(const core::MechanicalParams* mp
         parentForce[i][0] += -gap[i][1] * childForce[i][0] + gap[i][0] * childForce[i][1] ;
     }
 
-    out.endEdit(mparams);
+    out.endEdit();
 }
 
 template <class In, class Out>
-void MyMappingPendulumInPlane<In, Out>::applyJT(const core::ConstraintParams* mparams,
+void MyMappingPendulumInPlane<In, Out>::applyJT(const core::ConstraintParams* cparams,
                                                InDataMatrixDeriv& out,
                                                const OutDataMatrixDeriv& in)
 {
-    MatrixInDeriv& parentJacobians = *out.beginEdit(mparams);
-    const MatrixOutDeriv& childJacobians = in.getValue(mparams);
+    SOFA_UNUSED(cparams);
+
+    MatrixInDeriv& parentJacobians = *out.beginEdit();
+    const MatrixOutDeriv& childJacobians = in.getValue();
 
     for (typename Out::MatrixDeriv::RowConstIterator childJacobian = childJacobians.begin(); childJacobian != childJacobians.end(); ++childJacobian)
     {
@@ -181,7 +189,7 @@ void MyMappingPendulumInPlane<In, Out>::applyJT(const core::ConstraintParams* mp
         }
     }
 
-    out.endEdit(mparams);
+    out.endEdit();
 }
 
 template <class In, class Out>

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaVisualModel.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaVisualModel.inl
@@ -450,6 +450,8 @@ void CudaVisualModel< TDataTypes >::internalDraw(const core::visual::VisualParam
 template<class TDataTypes>
 void CudaVisualModel< TDataTypes >::computeBBox(const core::ExecParams* params, bool)
 {
+    SOFA_UNUSED(params);
+
     const VecCoord& x = state->write(core::VecCoordId::position())->getValue();
 
     SReal minBBox[3] = {std::numeric_limits<Real>::max(),std::numeric_limits<Real>::max(),std::numeric_limits<Real>::max()};
@@ -463,7 +465,7 @@ void CudaVisualModel< TDataTypes >::computeBBox(const core::ExecParams* params, 
             if (p[c] < minBBox[c]) minBBox[c] = p[c];
         }
     }
-    this->f_bbox.setValue(params,sofa::defaulttype::TBoundingBox<SReal>(minBBox,maxBBox));
+    this->f_bbox.setValue(sofa::defaulttype::TBoundingBox<SReal>(minBBox,maxBBox));
 }
 
 

--- a/applications/plugins/SofaEulerianFluid/Fluid2D.cpp
+++ b/applications/plugins/SofaEulerianFluid/Fluid2D.cpp
@@ -413,11 +413,14 @@ void Fluid2D::updateVisual()
         points[i].n.normalize();
 }
 
-void Fluid2D::computeBBox(const core::ExecParams*  params , bool /*onlyVisible*/)
+void Fluid2D::computeBBox(const core::ExecParams*  params , bool onlyVisible)
 {
-    const int& nx = f_nx.getValue(params);
-    const int& ny = f_ny.getValue(params);
-    const real& cellwidth = f_cellwidth.getValue(params);
+    SOFA_UNUSED(params);
+    SOFA_UNUSED(onlyVisible);
+
+    const int& nx = f_nx.getValue();
+    const int& ny = f_ny.getValue();
+    const real& cellwidth = f_cellwidth.getValue();
 
     SReal maxBBox[3];
     SReal size[3] = { (nx-1)*cellwidth, (ny-1)*cellwidth, cellwidth/2 };
@@ -426,7 +429,7 @@ void Fluid2D::computeBBox(const core::ExecParams*  params , bool /*onlyVisible*/
     {
         maxBBox[c] = minBBox[c]+size[c];
     }
-    this->f_bbox.setValue(params,sofa::defaulttype::TBoundingBox<SReal>(minBBox,maxBBox));
+    this->f_bbox.setValue(sofa::defaulttype::TBoundingBox<SReal>(minBBox,maxBBox));
 
 }
 

--- a/applications/plugins/SofaEulerianFluid/Fluid3D.cpp
+++ b/applications/plugins/SofaEulerianFluid/Fluid3D.cpp
@@ -459,18 +459,21 @@ void Fluid3D::updateVisual()
         points[i].n.normalize();
 }
 
-void Fluid3D::computeBBox(const core::ExecParams*  params , bool /*onlyVisible*/)
+void Fluid3D::computeBBox(const core::ExecParams*  params , bool onlyVisible)
 {
-    vec3 center = f_center.getValue(params);
-    const real& cellwidth = f_cellwidth.getValue(params);
-    SReal size[3] = { (f_nx.getValue()-1)*cellwidth, (f_ny.getValue(params)-1)*cellwidth, (f_nz.getValue(params)-1)*cellwidth };
+    SOFA_UNUSED(params);
+    SOFA_UNUSED(onlyVisible);
+
+    vec3 center = f_center.getValue();
+    const real& cellwidth = f_cellwidth.getValue();
+    SReal size[3] = { (f_nx.getValue()-1)*cellwidth, (f_ny.getValue()-1)*cellwidth, (f_nz.getValue()-1)*cellwidth };
     SReal minBBox[3] = { center[0]-size[0]/2, center[1]-size[1]/2, center[2]-size[2]/2 };
     SReal maxBBox[3];
     for (int c=0; c<3; c++)
     {
         maxBBox[c] = minBBox[c]+size[c];
     }
-    this->f_bbox.setValue(params,sofa::defaulttype::TBoundingBox<SReal>(minBBox,maxBBox));
+    this->f_bbox.setValue(sofa::defaulttype::TBoundingBox<SReal>(minBBox,maxBBox));
 }
 
 } // namespace eulerianfluid

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/OglFluidModel.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/OglFluidModel.inl
@@ -745,7 +745,7 @@ void OglFluidModel<DataTypes>::computeBBox(const core::ExecParams* params, bool 
 		}
     }
 
-    this->f_bbox.setValue(params,sofa::defaulttype::TBoundingBox<SReal>(minBBox,maxBBox));
+    this->f_bbox.setValue(sofa::defaulttype::TBoundingBox<SReal>(minBBox,maxBBox));
 
 }
 

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticleSink.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticleSink.inl
@@ -134,25 +134,29 @@ void ParticleSink<DataTypes>::projectResponse(const sofa::core::MechanicalParams
 template<class DataTypes>
 void ParticleSink<DataTypes>::projectVelocity(const sofa::core::MechanicalParams* mparams, DataVecDeriv&  v )
 {
+    SOFA_UNUSED(mparams);
+
     if (!this->mstate) return;
 
-    VecDeriv& vel = *v.beginEdit(mparams);
+    VecDeriv& vel = *v.beginEdit();
     helper::ReadAccessor< Data<SetIndexArray> > _fixed = this->d_fixed;
     Deriv v0 = Deriv();
     for (unsigned int s = 0; s<_fixed.size(); s++)
     {
         vel[_fixed[s]] = v0;
     }    
-    v.endEdit(mparams);
+    v.endEdit();
 }
 
 
 template<class DataTypes>
 void ParticleSink<DataTypes>::projectPosition(const sofa::core::MechanicalParams* mparams, DataVecCoord& xData)
 {
+    SOFA_UNUSED(mparams);
+
     if (!this->mstate) return;
 
-    VecCoord& x = *xData.beginEdit(mparams);
+    VecCoord& x = *xData.beginEdit();
 
     helper::WriteAccessor< Data< SetIndexArray > > _fixed = d_fixed;
 
@@ -167,7 +171,7 @@ void ParticleSink<DataTypes>::projectPosition(const sofa::core::MechanicalParams
         }
     }
 
-    xData.endEdit(mparams);
+    xData.endEdit();
 }
 
 

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticleSource.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticleSource.inl
@@ -111,6 +111,8 @@ void ParticleSource<DataTypes>::reset()
 template<class DataTypes>
 void ParticleSource<DataTypes>::projectResponse(const sofa::core::MechanicalParams* mparams, DataVecDeriv& dxData)
 {
+    SOFA_UNUSED(mparams);
+
     if (!this->mstate || m_lastparticles.getValue().empty()) {
         return;
     }
@@ -120,19 +122,21 @@ void ParticleSource<DataTypes>::projectResponse(const sofa::core::MechanicalPara
         return;
     }
 
-    VecDeriv& dx = *dxData.beginEdit(mparams);
+    VecDeriv& dx = *dxData.beginEdit();
     helper::ReadAccessor<Data<VecIndex> > _lastparticles = this->m_lastparticles;
     for (unsigned int s = 0; s<_lastparticles.size(); s++)
     {
         dx[_lastparticles[s]] = Deriv();
     }    
-    dxData.endEdit(mparams);
+    dxData.endEdit();
 }
 
 
 template<class DataTypes>
 void ParticleSource<DataTypes>::projectPosition(const sofa::core::MechanicalParams* mparams, DataVecCoord& xData)
 {
+    SOFA_UNUSED(mparams);
+
     if (!this->mstate || m_lastparticles.getValue().empty()) {
         return;
     }
@@ -143,7 +147,7 @@ void ParticleSource<DataTypes>::projectPosition(const sofa::core::MechanicalPara
     }
 
     // constraint the most recent particles
-    VecCoord& x = *xData.beginEdit(mparams);       
+    VecCoord& x = *xData.beginEdit();
     Deriv dpos = d_velocity.getValue()*(time - m_lastTime);
     helper::ReadAccessor<Data<VecIndex> > _lastparticles = this->m_lastparticles;    
     msg_info() << "projectPosition: " << _lastparticles;
@@ -152,13 +156,15 @@ void ParticleSource<DataTypes>::projectPosition(const sofa::core::MechanicalPara
         x[_lastparticles[s]] = m_lastpos[s];
         x[_lastparticles[s]] += dpos; // account for particle initial motion
     }
-    xData.endEdit(mparams);
+    xData.endEdit();
 }
 
 
 template<class DataTypes>
 void ParticleSource<DataTypes>::projectVelocity(const sofa::core::MechanicalParams* mparams, DataVecDeriv&  vData)
-{    
+{
+    SOFA_UNUSED(mparams);
+
     if (!this->mstate || m_lastparticles.getValue().empty()) {
         return;
     }
@@ -169,14 +175,14 @@ void ParticleSource<DataTypes>::projectVelocity(const sofa::core::MechanicalPara
     }
     
     // constraint the most recent particles with the initial Velocity
-    VecDeriv& res = *vData.beginEdit(mparams);    
+    VecDeriv& res = *vData.beginEdit();
     Deriv v0 = d_velocity.getValue();
     helper::ReadAccessor<Data<VecIndex> > _lastparticles = this->m_lastparticles;
     for (unsigned int s = 0; s<_lastparticles.size(); s++)
     {
         res[_lastparticles[s]] = v0;
     }
-    vData.endEdit(mparams);
+    vData.endEdit();
 }
 
 

--- a/applications/plugins/image/ImageContainer.h
+++ b/applications/plugins/image/ImageContainer.h
@@ -532,6 +532,8 @@ protected:
 
     void computeBBox(const core::ExecParams*  params, bool onlyVisible=false ) override
     {
+        SOFA_UNUSED(params);
+
         if( onlyVisible && !drawBB.getValue()) return;
 
         defaulttype::Vec<8,defaulttype::Vector3> c;

--- a/applications/plugins/image/ImageViewer.h
+++ b/applications/plugins/image/ImageViewer.h
@@ -423,9 +423,12 @@ public:
         for(unsigned int i=0;i<p.size();i++) c[i]=rtransform->fromImage(p[i]);
     }
 
-    void computeBBox(const core::ExecParams*  params, bool /*onlyVisible=false*/ ) override
+    void computeBBox(const core::ExecParams*  params, bool onlyVisible=false ) override
     {
-        //        if( onlyVisible) return;
+        SOFA_UNUSED(params);
+        SOFA_UNUSED(onlyVisible);
+        //if( onlyVisible) return;
+
         defaulttype::Vec<8,defaulttype::Vector3> c;
         getCorners(c);
 

--- a/modules/SofaBoundaryCondition/FixedConstraint.inl
+++ b/modules/SofaBoundaryCondition/FixedConstraint.inl
@@ -220,6 +220,8 @@ void FixedConstraint<DataTypes>::projectMatrix( sofa::defaulttype::BaseMatrix* M
 template <class DataTypes>
 void FixedConstraint<DataTypes>::projectResponse(const core::MechanicalParams* mparams, DataVecDeriv& resData)
 {
+    SOFA_UNUSED(mparams);
+
     helper::WriteAccessor<DataVecDeriv> res (resData );
     const SetIndexArray & indices = d_indices.getValue();
 
@@ -244,6 +246,8 @@ void FixedConstraint<DataTypes>::projectResponse(const core::MechanicalParams* m
 template <class DataTypes>
 void FixedConstraint<DataTypes>::projectJacobianMatrix(const core::MechanicalParams* mparams, DataMatrixDeriv& cData)
 {
+    SOFA_UNUSED(mparams);
+
     helper::WriteAccessor<DataMatrixDeriv> c (cData );
     const SetIndexArray & indices = d_indices.getValue();
 
@@ -279,6 +283,8 @@ void FixedConstraint<DataTypes>::projectJacobianMatrix(const core::MechanicalPar
 template <class DataTypes>
 void FixedConstraint<DataTypes>::projectVelocity(const core::MechanicalParams* mparams, DataVecDeriv& vData)
 {
+    SOFA_UNUSED(mparams);
+
     if(!d_projectVelocity.getValue()) return;
     const SetIndexArray & indices = this->d_indices.getValue();
     helper::WriteAccessor<DataVecDeriv> res (vData );

--- a/modules/SofaBoundaryCondition/PlaneForceField.inl
+++ b/modules/SofaBoundaryCondition/PlaneForceField.inl
@@ -362,6 +362,8 @@ void PlaneForceField<DataTypes>::drawPlane(const core::visual::VisualParams* vpa
 template <class DataTypes>
 void PlaneForceField<DataTypes>::computeBBox(const core::ExecParams * params, bool onlyVisible)
 {
+    SOFA_UNUSED(params);
+
     if (onlyVisible && !d_drawIsEnabled.getValue())
         return;
 

--- a/modules/SofaBoundaryCondition/PointConstraint.inl
+++ b/modules/SofaBoundaryCondition/PointConstraint.inl
@@ -92,6 +92,8 @@ const sofa::defaulttype::BaseMatrix*  PointConstraint<DataTypes>::getJ(const cor
 template <class DataTypes>
 void PointConstraint<DataTypes>::projectResponse(const core::MechanicalParams* mparams, DataVecDeriv& resData)
 {
+    SOFA_UNUSED(mparams);
+
     helper::WriteAccessor<DataVecDeriv> res ( resData );
     const SetIndexArray & indices = f_indices.getValue();
     for (SetIndexArray::const_iterator it = indices.begin();
@@ -105,6 +107,8 @@ void PointConstraint<DataTypes>::projectResponse(const core::MechanicalParams* m
 template <class DataTypes>
 void PointConstraint<DataTypes>::projectJacobianMatrix(const core::MechanicalParams* mparams, DataMatrixDeriv& cData)
 {
+    SOFA_UNUSED(mparams);
+
     helper::WriteAccessor<DataMatrixDeriv> c (  cData );
     const SetIndexArray & indices = f_indices.getValue();
 

--- a/modules/SofaBoundaryCondition/PositionBasedDynamicsConstraint.cpp
+++ b/modules/SofaBoundaryCondition/PositionBasedDynamicsConstraint.cpp
@@ -65,6 +65,8 @@ template class SOFA_BOUNDARY_CONDITION_API PositionBasedDynamicsConstraint<Rigid
 template <>
 void PositionBasedDynamicsConstraint<Rigid3Types>::projectPosition(const core::MechanicalParams* mparams, DataVecCoord& xData)
 {
+    SOFA_UNUSED(mparams);
+
     helper::WriteAccessor<DataVecCoord> res ( xData );
     helper::ReadAccessor<DataVecCoord> tpos = position ;
     helper::WriteAccessor<DataVecDeriv> vel ( velocity );

--- a/modules/SofaBoundaryCondition/PositionBasedDynamicsConstraint.inl
+++ b/modules/SofaBoundaryCondition/PositionBasedDynamicsConstraint.inl
@@ -90,6 +90,7 @@ void PositionBasedDynamicsConstraint<DataTypes>::reset()
 template <class DataTypes>
 void PositionBasedDynamicsConstraint<DataTypes>::projectJacobianMatrix(const core::MechanicalParams* mparams, DataMatrixDeriv& cData)
 {
+    SOFA_UNUSED(mparams);
     helper::WriteAccessor<DataMatrixDeriv> c ( cData );
 }
 
@@ -98,6 +99,8 @@ void PositionBasedDynamicsConstraint<DataTypes>::projectJacobianMatrix(const cor
 template <class DataTypes>
 void PositionBasedDynamicsConstraint<DataTypes>::projectVelocity(const core::MechanicalParams* mparams, DataVecDeriv& vData)
 {
+    SOFA_UNUSED(mparams);
+
     helper::WriteAccessor<DataVecDeriv> res (vData );
     helper::ReadAccessor<DataVecDeriv> vel ( velocity );
 
@@ -108,6 +111,8 @@ void PositionBasedDynamicsConstraint<DataTypes>::projectVelocity(const core::Mec
 template <class DataTypes>
 void PositionBasedDynamicsConstraint<DataTypes>::projectPosition(const core::MechanicalParams* mparams, DataVecCoord& xData)
 {
+    SOFA_UNUSED(mparams);
+
     helper::WriteAccessor<DataVecCoord> res ( xData );
     helper::WriteAccessor<DataVecDeriv> vel ( velocity );
     helper::WriteAccessor<DataVecCoord> old_pos ( old_position );

--- a/modules/SofaBoundaryCondition/ProjectDirectionConstraint.inl
+++ b/modules/SofaBoundaryCondition/ProjectDirectionConstraint.inl
@@ -222,6 +222,8 @@ void ProjectDirectionConstraint<DataTypes>::projectMatrix( sofa::defaulttype::Ba
 template <class DataTypes>
 void ProjectDirectionConstraint<DataTypes>::projectResponse(const core::MechanicalParams* mparams, DataVecDeriv& resData)
 {
+    SOFA_UNUSED(mparams);
+
     helper::WriteAccessor<DataVecDeriv> res ( resData );
     jacobian.mult(res.wref(),res.ref());
 }

--- a/modules/SofaBoundaryCondition/ProjectToLineConstraint.inl
+++ b/modules/SofaBoundaryCondition/ProjectToLineConstraint.inl
@@ -213,6 +213,8 @@ void ProjectToLineConstraint<DataTypes>::projectMatrix( sofa::defaulttype::BaseM
 template <class DataTypes>
 void ProjectToLineConstraint<DataTypes>::projectResponse(const core::MechanicalParams* mparams, DataVecDeriv& resData)
 {
+    SOFA_UNUSED(mparams);
+
     helper::WriteAccessor<DataVecDeriv> res ( resData );
     jacobian.mult(res.wref(),res.ref());
 }

--- a/modules/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
@@ -223,6 +223,8 @@ void ProjectToPlaneConstraint<DataTypes>::projectMatrix( sofa::defaulttype::Base
 template <class DataTypes>
 void ProjectToPlaneConstraint<DataTypes>::projectResponse(const core::MechanicalParams* mparams, DataVecDeriv& resData)
 {
+    SOFA_UNUSED(mparams);
+
     helper::WriteAccessor<DataVecDeriv> res ( resData );
     jacobian.mult(res.wref(),res.ref());
 }

--- a/modules/SofaBoundaryCondition/ProjectToPointConstraint.inl
+++ b/modules/SofaBoundaryCondition/ProjectToPointConstraint.inl
@@ -180,6 +180,8 @@ void ProjectToPointConstraint<DataTypes>::projectMatrix( sofa::defaulttype::Base
 template <class DataTypes>
 void ProjectToPointConstraint<DataTypes>::projectResponse(const core::MechanicalParams* mparams, DataVecDeriv& resData)
 {
+    SOFA_UNUSED(mparams);
+
     helper::WriteAccessor<DataVecDeriv> res ( resData );
     const SetIndexArray & indices = f_indices.getValue();
     if( f_fixAll.getValue() )
@@ -205,6 +207,8 @@ void ProjectToPointConstraint<DataTypes>::projectResponse(const core::Mechanical
 template <class DataTypes>
 void ProjectToPointConstraint<DataTypes>::projectJacobianMatrix(const core::MechanicalParams* mparams, DataMatrixDeriv& cData)
 {
+    SOFA_UNUSED(mparams);
+
     helper::WriteAccessor<DataMatrixDeriv> c ( cData );
     const SetIndexArray & indices = f_indices.getValue();
 
@@ -244,6 +248,8 @@ void ProjectToPointConstraint<DataTypes>::projectVelocity(const core::Mechanical
 template <class DataTypes>
 void ProjectToPointConstraint<DataTypes>::projectPosition(const core::MechanicalParams* mparams, DataVecCoord& xData)
 {
+    SOFA_UNUSED(mparams);
+
     helper::WriteAccessor<DataVecCoord> res ( xData );
     const SetIndexArray & indices = f_indices.getValue();
     if( f_fixAll.getValue() )

--- a/modules/SofaConstraint/UniformConstraint.inl
+++ b/modules/SofaConstraint/UniformConstraint.inl
@@ -23,6 +23,8 @@ UniformConstraint<DataTypes>::UniformConstraint()
 template< class DataTypes >
 void UniformConstraint<DataTypes>::buildConstraintMatrix(const sofa::core::ConstraintParams* cParams, DataMatrixDeriv & c, unsigned int &cIndex, const DataVecCoord &x)
 {
+    SOFA_UNUSED(cParams);
+
     const std::size_t N = Deriv::size(); // MatrixDeriv is a container of Deriv types.
 
     auto& jacobian = sofa::helper::write(c).wref();
@@ -91,6 +93,7 @@ void UniformConstraint<DataTypes>::getConstraintViolation(const sofa::core::Cons
 template< class DataTypes >
 void UniformConstraint<DataTypes>::getConstraintResolution(const sofa::core::ConstraintParams* cParams, std::vector<sofa::core::behavior::ConstraintResolution*>& crVector, unsigned int& offset)
 {
+    SOFA_UNUSED(cParams);
 
     if (d_iterative.getValue())
     {

--- a/modules/SofaGeneralEngine/SubsetTopology.inl
+++ b/modules/SofaGeneralEngine/SubsetTopology.inl
@@ -880,8 +880,11 @@ void SubsetTopology<DataTypes>::draw(const core::visual::VisualParams* vparams)
 }
 
 template <class DataTypes>
-void SubsetTopology<DataTypes>::computeBBox(const core::ExecParams*  params , bool /*onlyVisible*/)
+void SubsetTopology<DataTypes>::computeBBox(const core::ExecParams*  params , bool onlyVisible)
 {
+    SOFA_UNUSED(params);
+    SOFA_UNUSED(onlyVisible);
+
     const helper::vector<Vec6>& vb=boxes.getValue();
     const Real max_real = std::numeric_limits<Real>::max();
     const Real min_real = std::numeric_limits<Real>::lowest();

--- a/modules/SofaGeneralRigid/LineSetSkinningMapping.inl
+++ b/modules/SofaGeneralRigid/LineSetSkinningMapping.inl
@@ -230,6 +230,8 @@ void LineSetSkinningMapping<TIn, TOut>::draw(const core::visual::VisualParams* v
 template <class TIn, class TOut>
 void LineSetSkinningMapping<TIn, TOut>::apply( const sofa::core::MechanicalParams* mparams, OutDataVecCoord& outData, const InDataVecCoord& inData)
 {
+    SOFA_UNUSED(mparams);
+
     OutVecCoord& out = *outData.beginEdit();
     const InVecCoord& in = inData.getValue();
 
@@ -249,6 +251,8 @@ void LineSetSkinningMapping<TIn, TOut>::apply( const sofa::core::MechanicalParam
 template <class TIn, class TOut>
 void LineSetSkinningMapping<TIn, TOut>::applyJ( const sofa::core::MechanicalParams* mparams, OutDataVecDeriv& outData, const InDataVecDeriv& inData)
 {
+    SOFA_UNUSED(mparams);
+
     const InVecCoord& xfrom = this->fromModel->read(core::ConstVecCoordId::position())->getValue();
     OutVecDeriv& out = *outData.beginEdit();
     const InVecDeriv& in = inData.getValue();
@@ -269,6 +273,8 @@ void LineSetSkinningMapping<TIn, TOut>::applyJ( const sofa::core::MechanicalPara
 template <class TIn, class TOut>
 void LineSetSkinningMapping<TIn, TOut>::applyJT( const sofa::core::MechanicalParams* mparams, InDataVecDeriv& outData, const OutDataVecDeriv& inData)
 {
+    SOFA_UNUSED(mparams);
+
     InVecDeriv& out = *outData.beginEdit();
     const OutVecDeriv& in = inData.getValue();
     const InVecCoord& xfrom = this->fromModel->read(core::ConstVecCoordId::position())->getValue();
@@ -313,6 +319,8 @@ void LineSetSkinningMapping<TIn, TOut>::applyJT( const sofa::core::MechanicalPar
 template <class TIn, class TOut>
 void LineSetSkinningMapping<TIn, TOut>::applyJT( const sofa::core::ConstraintParams* mparams, InDataMatrixDeriv& outData, const OutDataMatrixDeriv& inData)
 {
+    SOFA_UNUSED(mparams);
+
     InMatrixDeriv& out = *outData.beginEdit();
     const OutMatrixDeriv& in = inData.getValue();
     const InVecCoord& xfrom = this->fromModel->read(core::ConstVecCoordId::position())->getValue();

--- a/modules/SofaGeneralRigid/SkinningMapping.inl
+++ b/modules/SofaGeneralRigid/SkinningMapping.inl
@@ -201,6 +201,8 @@ void SkinningMapping<TIn, TOut>::setWeights(const helper::vector<sofa::helper::S
 template <class TIn, class TOut>
 void SkinningMapping<TIn, TOut>::apply( const sofa::core::MechanicalParams* mparams, OutDataVecCoord& outData, const InDataVecCoord& inData)
 {
+    SOFA_UNUSED(mparams);
+
     OutVecCoord& out = *outData.beginEdit();
     const InVecCoord& in = inData.getValue();
 
@@ -244,7 +246,9 @@ void SkinningMapping<TIn, TOut>::apply( const sofa::core::MechanicalParams* mpar
 template <class TIn, class TOut>
 void SkinningMapping<TIn, TOut>::applyJ( const sofa::core::MechanicalParams* mparams, OutDataVecDeriv& outData, const InDataVecDeriv& inData)
 {
-    OutVecDeriv& out = *outData.beginWriteOnly(mparams);
+    SOFA_UNUSED(mparams);
+
+    OutVecDeriv& out = *outData.beginWriteOnly();
     const InVecDeriv& in = inData.getValue();
 
     unsigned int nbref=nbRef.getValue()[0];
@@ -273,6 +277,8 @@ void SkinningMapping<TIn, TOut>::applyJ( const sofa::core::MechanicalParams* mpa
 template <class TIn, class TOut>
 void SkinningMapping<TIn, TOut>::applyJT( const sofa::core::MechanicalParams* mparams, InDataVecDeriv& outData, const OutDataVecDeriv& inData)
 {
+    SOFA_UNUSED(mparams);
+
     InVecDeriv& out = *outData.beginEdit();
     const OutVecDeriv& in = inData.getValue();
 
@@ -307,6 +313,8 @@ void SkinningMapping<TIn, TOut>::applyJT( const sofa::core::MechanicalParams* mp
 template <class TIn, class TOut>
 void SkinningMapping<TIn, TOut>::applyJT ( const sofa::core::ConstraintParams* cparams, InDataMatrixDeriv& outData, const OutDataMatrixDeriv& inData)
 {
+    SOFA_UNUSED(cparams);
+
     InMatrixDeriv& parentJacobians = *outData.beginEdit();
     const OutMatrixDeriv& childJacobians = inData.getValue();
 

--- a/modules/SofaGeneralSimpleFem/BeamFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/BeamFEMForceField.inl
@@ -704,6 +704,8 @@ void BeamFEMForceField<DataTypes>::draw(const core::visual::VisualParams* vparam
 template<class DataTypes>
 void BeamFEMForceField<DataTypes>::computeBBox(const core::ExecParams* params, bool onlyVisible)
 {
+    SOFA_UNUSED(params);
+
     if( !onlyVisible ) return;
 
 

--- a/modules/SofaGeneralSimpleFem/TetrahedralCorotationalFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/TetrahedralCorotationalFEMForceField.inl
@@ -1245,6 +1245,8 @@ void TetrahedralCorotationalFEMForceField<DataTypes>::applyStiffnessPolar( Vecto
 template<class DataTypes>
 void TetrahedralCorotationalFEMForceField<DataTypes>::computeBBox(const core::ExecParams* params, bool onlyVisible)
 {
+    SOFA_UNUSED(params);
+
 	if( !onlyVisible ) return;
 
 	helper::ReadAccessor<DataVecCoord> x = this->mstate->read(core::VecCoordId::position());

--- a/modules/SofaMiscMapping/CenterOfMassMapping.inl
+++ b/modules/SofaMiscMapping/CenterOfMassMapping.inl
@@ -63,6 +63,8 @@ void CenterOfMassMapping<TIn, TOut>::init()
 template <class TIn, class TOut>
 void CenterOfMassMapping<TIn, TOut>::apply( const sofa::core::MechanicalParams* mparams, OutDataVecCoord& outData, const InDataVecCoord& inData)
 {
+    SOFA_UNUSED(mparams);
+
     OutVecCoord& childPositions = *outData.beginEdit();
     const InVecCoord& parentPositions = inData.getValue();
 
@@ -90,6 +92,8 @@ void CenterOfMassMapping<TIn, TOut>::apply( const sofa::core::MechanicalParams* 
 template <class TIn, class TOut>
 void CenterOfMassMapping<TIn, TOut>::applyJ( const sofa::core::MechanicalParams* mparams, OutDataVecDeriv& outData, const InDataVecDeriv& inData)
 {
+    SOFA_UNUSED(mparams);
+
     OutVecDeriv& childForces = *outData.beginEdit();
     const InVecDeriv& parentForces = inData.getValue();
 
@@ -117,6 +121,8 @@ void CenterOfMassMapping<TIn, TOut>::applyJ( const sofa::core::MechanicalParams*
 template <class TIn, class TOut>
 void CenterOfMassMapping<TIn, TOut>::applyJT( const sofa::core::MechanicalParams* mparams, InDataVecDeriv& outData, const OutDataVecDeriv& inData)
 {
+    SOFA_UNUSED(mparams);
+
     InVecDeriv& parentForces = *outData.beginEdit();
     const OutVecDeriv& childForces = inData.getValue();
 

--- a/modules/SofaMiscMapping/CenterOfMassMulti2Mapping.inl
+++ b/modules/SofaMiscMapping/CenterOfMassMulti2Mapping.inl
@@ -95,6 +95,8 @@ void CenterOfMassMulti2Mapping< TIn1, TIn2, TOut >::apply(
         const helper::vector<const In2DataVecCoord*>& dataVecIn2Pos)
 //apply(const vecOutVecCoord& outPos, const vecConstIn1VecCoord& inPos1 , const vecConstIn2VecCoord& inPos2 )
 {
+    SOFA_UNUSED(mparams);
+
     assert( dataVecOutPos.size() == 1); // we are dealing with a many to one mapping.
     typedef typename helper::vector<In1Coord>::iterator iter_coord1;
     typedef typename helper::vector<In2Coord>::iterator iter_coord2;
@@ -158,6 +160,8 @@ void CenterOfMassMulti2Mapping< TIn1, TIn2, TOut >::applyJ(
         const helper::vector<const In2DataVecDeriv*>& dataVecIn2Vel)
 //applyJ(const helper::vector< OutVecDeriv*>& outDeriv, const helper::vector<const In1VecDeriv*>& inDeriv1, const helper::vector<const In2VecDeriv*>& inDeriv2)
 {
+    SOFA_UNUSED(mparams);
+
     assert( dataVecOutVel.size() == 1 );
     typedef typename helper::vector<In1Deriv>::iterator                     iter_deriv1;
     typedef typename helper::vector<In2Deriv>::iterator                     iter_deriv2;
@@ -222,6 +226,8 @@ void CenterOfMassMulti2Mapping< TIn1, TIn2, TOut >::applyJT(
         const helper::vector<const OutDataVecDeriv*>& dataVecInForce)
 //applyJT( const helper::vector<typename In1::VecDeriv*>& outDeriv1 ,const helper::vector<typename In2::VecDeriv*>& outDeriv2 , const helper::vector<const typename Out::VecDeriv*>& inDeriv )
 {
+    SOFA_UNUSED(mparams);
+
     assert( dataVecOut1Force.size() == 1 );
 
     //Not optimized at all...

--- a/modules/SofaMiscMapping/CenterOfMassMultiMapping.inl
+++ b/modules/SofaMiscMapping/CenterOfMassMultiMapping.inl
@@ -92,6 +92,8 @@ public :
 template <class TIn, class TOut>
 void CenterOfMassMultiMapping< TIn, TOut >::apply(const core::MechanicalParams* mparams, const helper::vector<OutDataVecCoord*>& dataVecOutPos, const helper::vector<const InDataVecCoord*>& dataVecInPos)
 {
+    SOFA_UNUSED(mparams);
+
     typedef typename InVecCoord::iterator iter_coord;
 
     //Not optimized at all...
@@ -125,6 +127,8 @@ void CenterOfMassMultiMapping< TIn, TOut >::apply(const core::MechanicalParams* 
 template <class TIn, class TOut>
 void CenterOfMassMultiMapping< TIn, TOut >::applyJ(const core::MechanicalParams* mparams, const helper::vector<OutDataVecDeriv*>& dataVecOutVel, const helper::vector<const InDataVecDeriv*>& dataVecInVel)
 {
+    SOFA_UNUSED(mparams);
+
     typedef typename InVecDeriv::iterator iter_deriv;
 
     //Not optimized at all...
@@ -159,6 +163,8 @@ void CenterOfMassMultiMapping< TIn, TOut >::applyJ(const core::MechanicalParams*
 template < class TIn, class TOut >
 void CenterOfMassMultiMapping< TIn, TOut >::applyJT(const core::MechanicalParams* mparams, const helper::vector<InDataVecDeriv*>& dataVecOutForce, const helper::vector<const OutDataVecDeriv*>& dataVecInForce)
 {
+    SOFA_UNUSED(mparams);
+
     //Not optimized at all...
     helper::vector<InVecDeriv*> outDeriv;
     for(unsigned int i=0; i<dataVecOutForce.size(); i++)

--- a/modules/SofaMiscMapping/DistanceMapping.h
+++ b/modules/SofaMiscMapping/DistanceMapping.h
@@ -210,6 +210,8 @@ public:
 
     void apply(const core::MechanicalParams *mparams, const helper::vector<OutDataVecCoord*>& dataVecOutPos, const helper::vector<const InDataVecCoord*>& dataVecInPos) override
     {
+        SOFA_UNUSED(mparams);
+
         //Not optimized at all...
         helper::vector<OutVecCoord*> vecOutPos;
         for(unsigned int i=0; i<dataVecOutPos.size(); i++)
@@ -229,6 +231,8 @@ public:
 
     void applyJ(const core::MechanicalParams *mparams, const helper::vector<OutDataVecDeriv*>& dataVecOutVel, const helper::vector<const InDataVecDeriv*>& dataVecInVel) override
     {
+        SOFA_UNUSED(mparams);
+
         //Not optimized at all...
         helper::vector<OutVecDeriv*> vecOutVel;
         for(unsigned int i=0; i<dataVecOutVel.size(); i++)
@@ -248,6 +252,8 @@ public:
 
     void applyJT(const core::MechanicalParams *mparams, const helper::vector<InDataVecDeriv*>& dataVecOutForce, const helper::vector<const OutDataVecDeriv*>& dataVecInForce) override
     {
+        SOFA_UNUSED(mparams);
+
         //Not optimized at all...
         helper::vector<InVecDeriv*> vecOutForce;
         for(unsigned int i=0; i<dataVecOutForce.size(); i++)

--- a/modules/SofaMiscMapping/IdentityMultiMapping.inl
+++ b/modules/SofaMiscMapping/IdentityMultiMapping.inl
@@ -103,6 +103,8 @@ IdentityMultiMapping<TIn, TOut>::~IdentityMultiMapping()
 template <class TIn, class TOut>
 void IdentityMultiMapping<TIn, TOut>::apply(const core::MechanicalParams* mparams, const helper::vector<OutDataVecCoord*>& dataVecOutPos, const helper::vector<const InDataVecCoord*>& dataVecInPos)
 {
+    SOFA_UNUSED(mparams);
+
     OutVecCoord& out = *(dataVecOutPos[0]->beginEdit());
 
     unsigned offset = 0;
@@ -123,6 +125,8 @@ void IdentityMultiMapping<TIn, TOut>::apply(const core::MechanicalParams* mparam
 template <class TIn, class TOut>
 void IdentityMultiMapping<TIn, TOut>::applyJ(const core::MechanicalParams* mparams, const helper::vector<OutDataVecDeriv*>& dataVecOutVel, const helper::vector<const InDataVecDeriv*>& dataVecInVel)
 {
+    SOFA_UNUSED(mparams);
+
     OutVecDeriv& out = *(dataVecOutVel[0]->beginEdit());
 
     unsigned offset = 0;
@@ -144,6 +148,8 @@ void IdentityMultiMapping<TIn, TOut>::applyJ(const core::MechanicalParams* mpara
 template <class TIn, class TOut>
 void IdentityMultiMapping<TIn, TOut>::applyJT(const core::MechanicalParams* mparams, const helper::vector<InDataVecDeriv*>& dataVecOutForce, const helper::vector<const OutDataVecDeriv*>& dataVecInForce)
 {
+    SOFA_UNUSED(mparams);
+
     const OutVecDeriv& in = dataVecInForce[0]->getValue();
 
     unsigned offset = 0;

--- a/modules/SofaMiscMapping/SubsetMultiMapping.inl
+++ b/modules/SofaMiscMapping/SubsetMultiMapping.inl
@@ -134,6 +134,8 @@ void SubsetMultiMapping<TIn, TOut>::addPoint( int from, int index)
 template <class TIn, class TOut>
 void SubsetMultiMapping<TIn, TOut>::apply(const core::MechanicalParams* mparams, const helper::vector<OutDataVecCoord*>& dataVecOutPos, const helper::vector<const InDataVecCoord*>& dataVecInPos)
 {
+    SOFA_UNUSED(mparams);
+
     OutVecCoord& out = *(dataVecOutPos[0]->beginEdit());
 
     for(unsigned i=0; i<out.size(); i++)
@@ -151,6 +153,8 @@ void SubsetMultiMapping<TIn, TOut>::apply(const core::MechanicalParams* mparams,
 template <class TIn, class TOut>
 void SubsetMultiMapping<TIn, TOut>::applyJ(const core::MechanicalParams* mparams, const helper::vector<OutDataVecDeriv*>& dataVecOutVel, const helper::vector<const InDataVecDeriv*>& dataVecInVel)
 {
+    SOFA_UNUSED(mparams);
+
     OutVecDeriv& out = *(dataVecOutVel[0]->beginEdit());
 
     for(unsigned i=0; i<out.size(); i++)
@@ -216,6 +220,8 @@ void SubsetMultiMapping<TIn, TOut>::applyJT( const core::ConstraintParams* /*cpa
 template <class TIn, class TOut>
 void SubsetMultiMapping<TIn, TOut>::applyJT(const core::MechanicalParams* mparams, const helper::vector<InDataVecDeriv*>& dataVecOutForce, const helper::vector<const OutDataVecDeriv*>& dataVecInForce)
 {
+    SOFA_UNUSED(mparams);
+
     const OutDataVecDeriv* cderData = dataVecInForce[0];
     const OutVecDeriv& cder = cderData->getValue();
 

--- a/modules/SofaNonUniformFem/HexahedronCompositeFEMMapping.inl
+++ b/modules/SofaNonUniformFem/HexahedronCompositeFEMMapping.inl
@@ -194,6 +194,8 @@ void HexahedronCompositeFEMMapping<BasicMapping>::init()
 template <class BasicMapping>
 void HexahedronCompositeFEMMapping<BasicMapping>::apply( const sofa::core::MechanicalParams* mparams, OutDataVecCoord& outData, const InDataVecCoord& inData)
 {
+    SOFA_UNUSED(mparams);
+
     OutVecCoord& out = *outData.beginEdit();
     const InVecCoord& in = inData.getValue();
 
@@ -271,6 +273,8 @@ void HexahedronCompositeFEMMapping<BasicMapping>::apply( const sofa::core::Mecha
 template <class BasicMapping>
 void HexahedronCompositeFEMMapping<BasicMapping>::applyJ( const sofa::core::MechanicalParams* mparams, OutDataVecDeriv& outData, const InDataVecDeriv& inData)
 {
+    SOFA_UNUSED(mparams);
+
     OutVecDeriv& out = *outData.beginEdit();
     const InVecDeriv& in = inData.getValue();
 
@@ -326,6 +330,8 @@ void HexahedronCompositeFEMMapping<BasicMapping>::applyJ( const sofa::core::Mech
 template <class BasicMapping>
 void HexahedronCompositeFEMMapping<BasicMapping>::applyJT( const sofa::core::MechanicalParams* mparams, InDataVecDeriv& outData, const OutDataVecDeriv& inData)
 {
+    SOFA_UNUSED(mparams);
+
     InVecDeriv& out = *outData.beginEdit();
     const OutVecDeriv& in = inData.getValue();
 


### PR DESCRIPTION
Further to PR #1269 warnings were added in the core of SOFA.
This PR fixes these warnings due to deprecated formats and unused variables.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
