### PR TITLE
[SofaKernel] Improve error message when a component cannot be created.

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/ObjectFactory.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/ObjectFactory.cpp
@@ -207,13 +207,13 @@ objectmodel::BaseObject::SPtr ObjectFactory::createObject(objectmodel::BaseConte
 
         using sofa::helper::lifecycle::ComponentChange;
         using sofa::helper::lifecycle::uncreatableComponents;
-        if( uncreatableComponents.find(classname) != uncreatableComponents.end() )
-        {
-            arg->logError( uncreatableComponents.at(classname).getMessage() );
-        }
-        else if(it == registry.end())
+        if(it == registry.end())
         {
             arg->logError("The object is not in the factory.");
+            if( uncreatableComponents.find(classname) != uncreatableComponents.end() )
+            {
+                arg->logError( uncreatableComponents.at(classname).getMessage() );
+            }
         }
         else
         {


### PR DESCRIPTION
The problem was that a failure to create a component due to template mismatch on a
pluginized object shows the pluginization message instead of template mismatch one.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
