### PR TITLE
[SofaBaseTopology][SofaExporter] Fix failing tests due to changes in topology

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/GridTopology.h
+++ b/SofaKernel/modules/SofaBaseTopology/GridTopology.h
@@ -184,8 +184,9 @@ public:
     /// Get Cube index, similar to \sa hexa method
     int cube(int x, int y, int z) const { return hexa(x,y,z); }
 
-	/// Get the actual dimension of this grid using Enum @sa Grid_dimension
-	Grid_dimension getDimensions() const;
+    /// Get the actual dimension of this grid using Enum @sa Grid_dimension
+    Grid_dimension getDimensions() const;
+
 public:
     /// Data storing the size of the grid in the 3 directions
     Data<Vec3i> d_n;

--- a/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/RegularGridTopology_test.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/RegularGridTopology_test.cpp
@@ -158,12 +158,12 @@ bool RegularGridTopology_test::regularGridFindPoint()
                 );
     grid->init();
 
-    EXPECT_EQ(grid->findPoint(Coordinates{ .4, .4, .4 }),
-        -1); // No margin set means anything position rounded to a valid
+    EXPECT_EQ(grid->findPoint(Coordinates{ .4, .4, .4 }), -1);
+    // No margin set means anything position rounded to a valid
     // node will be returned
     EXPECT_EQ(grid->findPoint(Coordinates{ .51, .51, .51 }), 0);
-    EXPECT_EQ(grid->findPoint(Coordinates{ .51, .51, .51 }, Epsilon(0.01)),
-        -1); // Margin set means anything within a radius of 0.01*cell_size
+    EXPECT_EQ(grid->findPoint(Coordinates{ .51, .51, .51 }, Epsilon(0.01)), -1);
+    // Margin set means anything within a radius of 0.01*cell_size
     // will be returned
     EXPECT_EQ(grid->findPoint(Coordinates{ 1., 1., 1. }), 0); // First node of the grid
     EXPECT_EQ(grid->findPoint(Coordinates{ 4., 4., 4. }), 63); // Last node of the grid
@@ -236,10 +236,8 @@ TEST_P(RegularGridTopology_test, regularGridSizeComputeEdgeFromTriangle)
     /// We check if this test should returns a warning.
     if (GetParam()[3] == 1)
     {
-        {
-            EXPECT_MSG_EMIT(Warning);
-            ASSERT_TRUE(regularGridSize(GetParam(), true));
-        }
+        EXPECT_MSG_EMIT(Warning);
+        ASSERT_TRUE(regularGridSize(GetParam(), true));
     }
     else
     {

--- a/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/RegularGridTopology_test.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/RegularGridTopology_test.cpp
@@ -3,15 +3,13 @@ using sofa::Sofa_test;
 
 #include <SofaBaseTopology/RegularGridTopology.h>
 
-using sofa::core::objectmodel::New ;
-using sofa::defaulttype::Vector3 ;
+using sofa::core::objectmodel::New;
+using sofa::defaulttype::Vector3;
 using namespace sofa::component::topology;
 using namespace sofa::helper::testing;
 
-
-struct RegularGridTopology_test :
-        public BaseTest,
-        public ::testing::WithParamInterface<std::vector<int>>
+struct RegularGridTopology_test : public BaseTest,
+                                  public ::testing::WithParamInterface<std::vector<int>>
 {
     bool regularGridCreation();
     bool regularGridPosition();
@@ -20,25 +18,24 @@ struct RegularGridTopology_test :
     bool regularGridSize(const std::vector<int>& p, bool fromTriangleList);
 };
 
-
 bool RegularGridTopology_test::regularGridCreation()
 {
     // Creating a good Grid in 3D
-    RegularGridTopology::SPtr regGrid3 =New<RegularGridTopology>(5, 5, 5);
+    RegularGridTopology::SPtr regGrid3 = New<RegularGridTopology>(5, 5, 5);
     EXPECT_NE(regGrid3, nullptr);
-    EXPECT_EQ(regGrid3->d_p0.getValue(), Vector3(0.0f,0.0f,0.0f));
+    EXPECT_EQ(regGrid3->d_p0.getValue(), Vector3(0.0f, 0.0f, 0.0f));
     EXPECT_EQ(regGrid3->d_cellWidth.getValue(), 0.0);
 
     // Creating a good Grid in 2D
-    RegularGridTopology::SPtr regGrid2 =New<RegularGridTopology>(5, 5, 1);
+    RegularGridTopology::SPtr regGrid2 = New<RegularGridTopology>(5, 5, 1);
     EXPECT_NE(regGrid2, nullptr);
-    EXPECT_EQ(regGrid2->d_p0.getValue(), Vector3(0.0f,0.0f,0.0f));
+    EXPECT_EQ(regGrid2->d_p0.getValue(), Vector3(0.0f, 0.0f, 0.0f));
     EXPECT_EQ(regGrid2->d_cellWidth.getValue(), 0.0);
 
     // Creating a good Grid in 3D
-    RegularGridTopology::SPtr regGrid1 =New<RegularGridTopology>(5, 1, 1);
+    RegularGridTopology::SPtr regGrid1 = New<RegularGridTopology>(5, 1, 1);
     EXPECT_NE(regGrid1, nullptr);
-    EXPECT_EQ(regGrid1->d_p0.getValue(), Vector3(0.0f,0.0f,0.0f));
+    EXPECT_EQ(regGrid1->d_p0.getValue(), Vector3(0.0f, 0.0f, 0.0f));
     EXPECT_EQ(regGrid1->d_cellWidth.getValue(), 0.0);
 
     return true;
@@ -46,61 +43,63 @@ bool RegularGridTopology_test::regularGridCreation()
 
 bool RegularGridTopology_test::regularGridSize(const std::vector<int>& p, bool fromTriangleList)
 {
-    int nx=p[0];
-    int ny=p[1];
-    int nz=p[2];
+    int nx = p[0];
+    int ny = p[1];
+    int nz = p[2];
 
     /// Creating a good Grid in 3D
-    RegularGridTopology::SPtr regGrid =New<RegularGridTopology>(nx, ny, nz);
+    RegularGridTopology::SPtr regGrid = New<RegularGridTopology>(nx, ny, nz);
     regGrid->d_computeTriangleList.setValue(fromTriangleList);
     regGrid->init();
 
     /// The input was not valid...the default data should be used.
-    if(p[4]==1){
+    if (p[4] == 1)
+    {
         nx = 2;
         ny = 2;
         nz = 2;
     }
 
     /// check topology
-    int nbHexa = (nx-1)*(ny-1)*(nz-1);
-    int nbQuads = (nx-1)*(ny-1)*nz+(nx-1)*ny*(nz-1)+nx*(ny-1)*(nz-1);
+    int nbHexa = (nx - 1) * (ny - 1) * (nz - 1);
+    int nbQuads = (nx - 1) * (ny - 1) * nz + (nx - 1) * ny * (nz - 1) + nx * (ny - 1) * (nz - 1);
 
     /// Dimmension invariant assumption
-    EXPECT_EQ(regGrid->getNbPoints(), nx*ny*nz);
-    if(fromTriangleList)
+    EXPECT_EQ(regGrid->getNbPoints(), nx * ny * nz);
+    if (fromTriangleList)
     {
-        int nbEgdes = (nx-1)*ny*nz + nx*(ny-1)*nz + nx*ny*(nz-1) + nbQuads;
+        int nbEgdes = (nx - 1) * ny * nz + nx * (ny - 1) * nz + nx * ny * (nz - 1) + nbQuads;
         EXPECT_EQ(regGrid->getNbEdges(), nbEgdes);
     }
     else
     {
-        int nbEgdes = (nx-1)*ny*nz+nx*(ny-1)*nz+nx*ny*(nz-1);
+        int nbEgdes = (nx - 1) * ny * nz + nx * (ny - 1) * nz + nx * ny * (nz - 1);
         EXPECT_EQ(regGrid->getNbEdges(), nbEgdes);
     }
 
     /// Compute the dimmension.
-    int d=(p[0]==1)+(p[1]==1)+(p[2]==1) ; /// Check if there is reduced dimmension
-    int e=(p[0]<=0)+(p[1]<=0)+(p[2]<=0) ; /// Check if there is an error
-    if(e==0){
-        if(d==0)
+    int d = (p[0] == 1) + (p[1] == 1) + (p[2] == 1); /// Check if there is reduced dimmension
+    int e = (p[0] <= 0) + (p[1] <= 0) + (p[2] <= 0); /// Check if there is an error
+    if (e == 0)
+    {
+        if (d == 0)
         {
-            EXPECT_EQ(regGrid->getDimensions(), Grid_dimension::GRID_3D) ;
+            EXPECT_EQ(regGrid->getDimensions(), Grid_dimension::GRID_3D);
         }
-        else if(d==1)
+        else if (d == 1)
         {
-            EXPECT_EQ(regGrid->getDimensions(), Grid_dimension::GRID_2D) ;
+            EXPECT_EQ(regGrid->getDimensions(), Grid_dimension::GRID_2D);
             nbHexa = 0;
         }
-        else if(d==2)
+        else if (d == 2)
         {
-            EXPECT_EQ(regGrid->getDimensions(), Grid_dimension::GRID_1D) ;
+            EXPECT_EQ(regGrid->getDimensions(), Grid_dimension::GRID_1D);
             nbHexa = 0;
             nbQuads = 0;
         }
         else
         {
-            EXPECT_EQ(regGrid->getDimensions(), Grid_dimension::GRID_nullptr) ;
+            EXPECT_EQ(regGrid->getDimensions(), Grid_dimension::GRID_nullptr);
         }
     }
     EXPECT_EQ(regGrid->getNbHexahedra(), nbHexa);
@@ -113,12 +112,12 @@ bool RegularGridTopology_test::regularGridPosition()
     int nx = 8;
     int ny = 8;
     int nz = 5;
-    RegularGridTopology::SPtr regGrid =New<RegularGridTopology>(nx, ny, nz);
+    RegularGridTopology::SPtr regGrid = New<RegularGridTopology>(nx, ny, nz);
     regGrid->init();
 
     // Check first circle with
     sofa::defaulttype::Vector3 p0 = regGrid->getPoint(0);
-    sofa::defaulttype::Vector3 p1 = regGrid->getPoint(nx-1);
+    sofa::defaulttype::Vector3 p1 = regGrid->getPoint(nx - 1);
     // Check first point
     EXPECT_LE(p0[0], 0.0001);
     EXPECT_EQ(p0[0], p0[1]);
@@ -131,13 +130,13 @@ bool RegularGridTopology_test::regularGridPosition()
     EXPECT_EQ(p0[2], 0);
 
     // check last point of first level
-    sofa::defaulttype::Vector3 p1Last = regGrid->getPoint(nx*ny -1);
+    sofa::defaulttype::Vector3 p1Last = regGrid->getPoint(nx * ny - 1);
     EXPECT_LE(p1Last[0], 0.0001);
     EXPECT_EQ(p1[0], p1Last[0]);
     EXPECT_EQ(p1[1], -p1Last[1]);
 
     // Check first point of last level of the regular
-    sofa::defaulttype::Vector3 p0Last = regGrid->getPoint(nx*ny*(nz-1));
+    sofa::defaulttype::Vector3 p0Last = regGrid->getPoint(nx * ny * (nz - 1));
     EXPECT_EQ(p0Last[0], p0[0]);
     EXPECT_EQ(p0Last[1], p0[1]);
 
@@ -146,45 +145,61 @@ bool RegularGridTopology_test::regularGridPosition()
 
 bool RegularGridTopology_test::regularGridFindPoint()
 {
-    using Dimension   = RegularGridTopology::Vec3i;
+    using Dimension = RegularGridTopology::Vec3i;
     using BoundingBox = RegularGridTopology::BoundingBox;
-    using Coordinates  = sofa::defaulttype::Vector3;
+    using Coordinates = sofa::defaulttype::Vector3;
     using Epsilon = float;
 
-    // 3D grid with 3x3x3=27 cells, each of dimension 1x1x1,  starting at {1,1,1} and ending at {4,4,4}
-    auto grid = New<RegularGridTopology>(Dimension {4, 4, 4}, BoundingBox (Coordinates {1., 1., 1.} /*min*/, Coordinates {4, 4, 4} /*max*/));
+    // 3D grid with 3x3x3=27 cells, each of dimension 1x1x1,  starting at {1,1,1}
+    // and ending at {4,4,4}
+    auto grid = New<RegularGridTopology>(
+                    Dimension{ 4, 4, 4 },
+                    BoundingBox( Coordinates{ 1., 1., 1. } /*min*/, Coordinates{ 4, 4, 4 } /*max*/ )
+                );
     grid->init();
 
-    EXPECT_EQ(grid->findPoint(Coordinates { .4,  .4,  .4}), -1); // No margin set means anything position rounded to a valid node will be returned
-    EXPECT_EQ(grid->findPoint(Coordinates { .51,  .51,  .51}), 0);
-    EXPECT_EQ(grid->findPoint(Coordinates { .51,  .51,  .51}, Epsilon (0.01)), -1); // Margin set means anything within a radius of 0.01*cell_size will be returned
-    EXPECT_EQ(grid->findPoint(Coordinates {1., 1., 1.}), 0); // First node of the grid
-    EXPECT_EQ(grid->findPoint(Coordinates {4., 4., 4.}), 63); // Last node of the grid
-    EXPECT_EQ(grid->findPoint(Coordinates {4.49, 4.49, 4.49}), 63);
-    EXPECT_EQ(grid->findPoint(Coordinates {4.51, 4, 4}), -1);
-    EXPECT_EQ(grid->findPoint(Coordinates {4., 4.51, 4}), -1);
-    EXPECT_EQ(grid->findPoint(Coordinates {4., 4, 4.51}), -1);
+    EXPECT_EQ(grid->findPoint(Coordinates{ .4, .4, .4 }),
+        -1); // No margin set means anything position rounded to a valid
+    // node will be returned
+    EXPECT_EQ(grid->findPoint(Coordinates{ .51, .51, .51 }), 0);
+    EXPECT_EQ(grid->findPoint(Coordinates{ .51, .51, .51 }, Epsilon(0.01)),
+        -1); // Margin set means anything within a radius of 0.01*cell_size
+    // will be returned
+    EXPECT_EQ(grid->findPoint(Coordinates{ 1., 1., 1. }), 0); // First node of the grid
+    EXPECT_EQ(grid->findPoint(Coordinates{ 4., 4., 4. }), 63); // Last node of the grid
+    EXPECT_EQ(grid->findPoint(Coordinates{ 4.49, 4.49, 4.49 }), 63);
+    EXPECT_EQ(grid->findPoint(Coordinates{ 4.51, 4, 4 }), -1);
+    EXPECT_EQ(grid->findPoint(Coordinates{ 4., 4.51, 4 }), -1);
+    EXPECT_EQ(grid->findPoint(Coordinates{ 4., 4, 4.51 }), -1);
     return true;
 }
 
-
-TEST_F(RegularGridTopology_test, regularGridCreation ) { ASSERT_TRUE( regularGridCreation()); }
-TEST_F(RegularGridTopology_test, regularGridPosition ) { ASSERT_TRUE( regularGridPosition()); }
-TEST_F(RegularGridTopology_test, regularGridFindPoint ) { ASSERT_TRUE( regularGridFindPoint()); }
-
+TEST_F(RegularGridTopology_test, regularGridCreation)
+{
+    ASSERT_TRUE(regularGridCreation());
+}
+TEST_F(RegularGridTopology_test, regularGridPosition)
+{
+    ASSERT_TRUE(regularGridPosition());
+}
+TEST_F(RegularGridTopology_test, regularGridFindPoint)
+{
+    ASSERT_TRUE(regularGridFindPoint());
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 ///
 /// Test on various dimmensions
 ///
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-std::vector<std::vector<int>> dimvalues={
+std::vector<std::vector<int>> dimvalues = {
     /// The first three values are for the dimmension of the grid.
     /// The fourth is to encode if we need to catch a Warning message
-    /// The fith is to indicate that the component should be initialized with the default values of
+    /// The fith is to indicate that the component should be initialized with
+    /// the default values of
     /// 2-2-2
     {5,5,5, 0, 0},
-	{2,2,2, 0, 0},
+    {2,2,2, 0, 0},
     {5,5,1, 0, 0},
     {5,1,5, 0, 0},
     {1,5,5, 0, 0},
@@ -216,34 +231,36 @@ std::vector<std::vector<int>> dimvalues={
     {-2,1,1, 1, 1},
 };
 
-TEST_P(RegularGridTopology_test, regularGridSizeComputeEdgeFromTriangle )
+TEST_P(RegularGridTopology_test, regularGridSizeComputeEdgeFromTriangle)
 {
     /// We check if this test should returns a warning.
-    if(GetParam()[3]==1){
+    if (GetParam()[3] == 1)
+    {
         {
-            EXPECT_MSG_EMIT(Warning) ;
-            ASSERT_TRUE( regularGridSize(GetParam(), true) );
+            EXPECT_MSG_EMIT(Warning);
+            ASSERT_TRUE(regularGridSize(GetParam(), true));
         }
-    }else{
-        ASSERT_TRUE( regularGridSize(GetParam(), true) );
+    }
+    else
+    {
+        ASSERT_TRUE(regularGridSize(GetParam(), true));
     }
 }
 
-TEST_P(RegularGridTopology_test, regularGridSize )
+TEST_P(RegularGridTopology_test, regularGridSize)
 {
     /// We check if this test should returns a warning.
-    if(GetParam()[3]==1){
-        {
-            EXPECT_MSG_EMIT(Warning) ;
-            ASSERT_TRUE( regularGridSize(GetParam(), false) );
-        }
-    }else{
-        ASSERT_TRUE( regularGridSize(GetParam(), false) );
+    if (GetParam()[3] == 1)
+    {
+        EXPECT_MSG_EMIT(Warning);
+        ASSERT_TRUE(regularGridSize(GetParam(), false));
+    }
+    else
+    {
+        ASSERT_TRUE(regularGridSize(GetParam(), false));
     }
 }
 
 INSTANTIATE_TEST_CASE_P(regularGridSize3D,
                         RegularGridTopology_test,
                         ::testing::ValuesIn(dimvalues));
-
-

--- a/modules/SofaExporter/SofaExporter_test/MeshExporter_test.cpp
+++ b/modules/SofaExporter/SofaExporter_test/MeshExporter_test.cpp
@@ -80,7 +80,7 @@ public:
                 "<Node 	name='Root' gravity='0 0 0' time='0' animate='0'   >       \n"
                 "   <DefaultAnimationLoop/>                                        \n"
                 "   <MechanicalObject position='0 1 2 3 4 5 6 7 8 9'/>             \n"
-                "   <RegularGridTopology name='grid' n='6 6 6' min='-10 -10 -10' max='10 10 10' p0='-30 -10 -10' computeHexaList='0'/> \n"
+                "   <RegularGridTopology name='grid' n='6 6 6' min='-10 -10 -10' max='10 10 10' p0='-30 -10 -10' computeHexaList='1'/> \n"
                 "   <MeshExporter name='exporter1' format='"<< format <<"' printLog='true' filename='"<< filename << "' exportAtBegin='true' /> \n"
                 "</Node>                                                           \n" ;
 
@@ -112,7 +112,7 @@ public:
                 "<Node 	name='Root' gravity='0 0 0' time='0' animate='0'   >       \n"
                 "   <DefaultAnimationLoop/>                                        \n"
                 "   <MechanicalObject position='0 1 2 3 4 5 6 7 8 9'/>             \n"
-                "   <RegularGridTopology name='grid' n='6 6 6' min='-10 -10 -10' max='10 10 10' p0='-30 -10 -10' computeHexaList='0'/> \n"
+                "   <RegularGridTopology name='grid' n='6 6 6' min='-10 -10 -10' max='10 10 10' p0='-30 -10 -10' computeHexaList='1'/> \n"
                 "   <MeshExporter name='exporterA' format='"<< format <<"' printLog='true' filename='"<< filename << "' exportEveryNumberOfSteps='5' /> \n"
                 "</Node>                                                           \n" ;
 


### PR DESCRIPTION
Fix tests further to #1323 

- SofaExporter_test was expecting to export Hexa while option computeHexa was false in RGrid
- RegularGridTopology_test was expecting the wrong number of edges since the computation is now under the condition whether the triangles are used or not to compute the edges



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
