### PR TITLE
[SofaCUDA] Arch auto-detection for nvcc

### DIFF
--- a/applications/plugins/SofaCUDA/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/CMakeLists.txt
@@ -286,10 +286,7 @@ endif()
 
 option(SOFACUDA_PRECISE "Use IEEE 754-compliant floating point operations." OFF)
 
-set(SOFACUDA_ARCH "sm_20" CACHE STRING "GPU architecture, as passed to nvcc with the -arch option.")
-
 include(SofaCUDANvccFlags.cmake)
-
 
 # nvcc uses a "host code compiler" to compile CPU code, specified by CUDA_HOST_COMPILER.
 # With some versions of CMake, CUDA_HOST_COMPILER defaults to CMAKE_C_COMPILER,
@@ -358,7 +355,13 @@ configure_file(SofaCUDANvccFlags.cmake ${CMAKE_BINARY_DIR}/cmake/SofaCUDANvccFla
 install(FILES SofaCUDANvccFlags.cmake DESTINATION lib/cmake/SofaCUDA)
 
 ## Install rules for the library and headers; CMake package configurations files
-sofa_create_package(SofaCUDA ${SOFACUDA_VERSION} SofaCUDA SofaCUDA)
+sofa_generate_package(
+    NAME ${PROJECT_NAME}
+    VERSION ${SOFACUDA_VERSION}
+    TARGETS ${PROJECT_NAME}
+    INCLUDE_INSTALL_DIR "${PROJECT_NAME}"
+    RELOCATABLE "plugins"
+)
 
 ## Install rules for the resources
 install(DIRECTORY examples/ DESTINATION share/sofa/plugins/${PROJECT_NAME})

--- a/applications/plugins/SofaCUDA/SofaCUDANvccFlags.cmake
+++ b/applications/plugins/SofaCUDA/SofaCUDANvccFlags.cmake
@@ -1,10 +1,18 @@
-set(TEMP_CUDA_FLAGS "-arch ${SOFACUDA_ARCH} -Xcompiler")
-if(NOT (${CUDA_NVCC_FLAGS} MATCHES ${TEMP_CUDA_FLAGS}))
-	set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} ${TEMP_CUDA_FLAGS}")
-	if(NOT WIN32)
-	    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -fPIC")
-	endif()
+include(FindCUDA)
+set(CUDA_ARCH_LIST Auto CACHE STRING
+    "List of CUDA architectures (e.g. Pascal, Volta, etc) or \
+compute capability versions (6.1, 7.0, etc) to generate code for. \
+Set to Auto for automatic detection (default)."
+)
+cuda_select_nvcc_arch_flags(CUDA_ARCH_FLAGS ${CUDA_ARCH_LIST})
+
+set(SOFA_ADDITIONAL_CUDA_NVCC_FLAGS "-Xcompiler")
+if(NOT WIN32)
+    set(SOFA_ADDITIONAL_CUDA_NVCC_FLAGS "${SOFA_ADDITIONAL_CUDA_NVCC_FLAGS} -fPIC")
 endif()
+
+list(APPEND CUDA_NVCC_FLAGS ${CUDA_ARCH_FLAGS} ${SOFA_ADDITIONAL_CUDA_NVCC_FLAGS})
+
 
 set(CUDA_NVCC_FLAGS_DEBUG "-g")
 set(CUDA_NVCC_FLAGS_RELEASE "-DNDEBUG")
@@ -13,4 +21,4 @@ if (WIN32)
 	set(CUDA_NVCC_FLAGS_DEBUG "--compiler-options /MDd")
 endif (WIN32)
 
-unset(TEMP_CUDA_FLAGS)
+message(STATUS "SofaCUDA: nvcc flags: ${CUDA_NVCC_FLAGS}")


### PR DESCRIPTION
Replace SOFACUDA_ARCH containing arbitrary value with (CMake's) auto arch detection.
If needed, you can disable auto-detection with the desired arch value.
It should (not tested) also generate cuda code for multiple arch as well.

Remove also warning when configuring with CMake. (about deprecated macro sofa_create_package)

I guess it could break CMake CUDA config for people using the SOFACUDA_ARCH variable.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
