### PR TITLE
[SofaKernel] Clean of Material.h/cpp

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/types/Material.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/types/Material.cpp
@@ -136,7 +136,7 @@ Material & Material::operator= (const Material& mat) {
 
 } // namespace loader
 
-} // namespace coreWhat 
+} // namespace core
 
 } // namespace sofa
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/types/Material.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/types/Material.cpp
@@ -32,10 +32,10 @@ namespace types
 
     void Material::setColor(float r, float g, float b, float a)
     {
-        ambient = defaulttype::RGBAColor(r*0.2f,g*0.2f,b*0.2f,a);
-        diffuse = defaulttype::RGBAColor(r,g,b,a);
-        specular = defaulttype::RGBAColor(r,g,b,a);
-        emissive = defaulttype::RGBAColor(r,g,b,a);
+        ambient = RGBAColor(r*0.2f,g*0.2f,b*0.2f,a);
+        diffuse = RGBAColor(r,g,b,a);
+        specular = RGBAColor(r,g,b,a);
+        emissive = RGBAColor(r,g,b,a);
     }
 
     SOFA_HELPER_API std::ostream&  operator << (std::ostream& out, const Material& m )
@@ -67,10 +67,10 @@ namespace types
 
      Material::Material()
 {
-    ambient =  defaulttype::RGBAColor( 0.2f,0.2f,0.2f,1.0f);
-    diffuse =  defaulttype::RGBAColor( 0.75f,0.75f,0.75f,1.0f);
-    specular =  defaulttype::RGBAColor( 1.0f,1.0f,1.0f,1.0f);
-    emissive =  defaulttype::RGBAColor( 0.0f,0.0f,0.0f,0.0f);
+    ambient =  RGBAColor( 0.2f,0.2f,0.2f,1.0f);
+    diffuse =  RGBAColor( 0.75f,0.75f,0.75f,1.0f);
+    specular =  RGBAColor( 1.0f,1.0f,1.0f,1.0f);
+    emissive =  RGBAColor( 0.0f,0.0f,0.0f,0.0f);
 
     shininess =  45.0f;
     name = "Default";
@@ -136,7 +136,7 @@ Material & Material::operator= (const Material& mat) {
 
 } // namespace loader
 
-} // namespace core
+} // namespace coreWhat 
 
 } // namespace sofa
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/types/Material.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/types/Material.h
@@ -23,9 +23,8 @@
 #ifndef SOFA_HELPER_TYPES_MATERIAL_H_
 #define SOFA_HELPER_TYPES_MATERIAL_H_
 
-#include <sofa/core/core.h>
-#include <sofa/defaulttype/RGBAColor.h>
-#include <sofa/core/objectmodel/DataFileName.h>
+#include <sofa/helper/helper.h>
+#include <sofa/helper/types/RGBAColor.h>
 
 namespace sofa
 {
@@ -40,10 +39,10 @@ class SOFA_HELPER_API Material
 {
 public:
     std::string 	name;		        /* name of material */
-    defaulttype::RGBAColor  diffuse ;	/* diffuse component */
-    defaulttype::RGBAColor  ambient ;	/* ambient component */
-    defaulttype::RGBAColor  specular;	/* specular component */
-    defaulttype::RGBAColor  emissive;	/* emmissive component */
+    RGBAColor  diffuse ;	/* diffuse component */
+    RGBAColor  ambient ;	/* ambient component */
+    RGBAColor  specular;	/* specular component */
+    RGBAColor  emissive;	/* emmissive component */
     float  shininess;	                /* specular exponent */
     bool   useDiffuse;
     bool   useSpecular;


### PR DESCRIPTION
The file was still using the old .h location for RGBAColor. 
Replace to the new ones. 
It was also include DataFilename which was pointless.


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
