### PR TITLE
[SofaKernel] Add Data bool d_checkTopology in Topology container to replace the use of CHECK_TOPOLOGY macro

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyContainer.cpp
@@ -231,44 +231,42 @@ int EdgeSetTopologyContainer::getNumberConnectedComponents(sofa::helper::vector<
 
 bool EdgeSetTopologyContainer::checkTopology() const
 {
-	if (CHECK_TOPOLOGY)
+    if (!d_checkTopology.getValue())
+        return true;
+
+	bool ret = true;
+
+    if (hasEdgesAroundVertex())
 	{
-		bool ret = true;
+		helper::ReadAccessor< Data< sofa::helper::vector<Edge> > > m_edge = d_edge;
+		std::set<int> edgeSet;
 
-        if (hasEdgesAroundVertex())
+        // loop on all edges around vertex
+        for (size_t i = 0; i < m_edgesAroundVertex.size(); ++i)
 		{
-			helper::ReadAccessor< Data< sofa::helper::vector<Edge> > > m_edge = d_edge;
-			std::set<int> edgeSet;
-
-            // loop on all edges around vertex
-            for (size_t i = 0; i < m_edgesAroundVertex.size(); ++i)
+			const sofa::helper::vector<EdgeID> &es = m_edgesAroundVertex[i];
+			for (size_t j = 0; j < es.size(); ++j)
 			{
-				const sofa::helper::vector<EdgeID> &es = m_edgesAroundVertex[i];
-				for (size_t j = 0; j < es.size(); ++j)
+                const Edge& edge = m_edge[es[j]];
+                if (!(edge[0] == i || edge[1] == i))
 				{
-                    const Edge& edge = m_edge[es[j]];
-                    if (!(edge[0] == i || edge[1] == i))
-					{
-                        msg_error() << "EdgeSetTopologyContainer::checkTopology() failed: edge " << es[j] << ": [" << edge << "] not around vertex: " << i;
-						ret = false;
-					}
-
-                    // count number of edge
-                    edgeSet.insert(es[j]);
+                    msg_error() << "EdgeSetTopologyContainer::checkTopology() failed: edge " << es[j] << ": [" << edge << "] not around vertex: " << i;
+					ret = false;
 				}
+
+                // count number of edge
+                edgeSet.insert(es[j]);
 			}
+		}
 
-			if (edgeSet.size() != m_edge.size())
-			{
-                msg_error() << "EdgeSetTopologyContainer::checkTopology() failed: found " << edgeSet.size() << " edges in m_edgesAroundVertex out of " << m_edge.size();
-				ret = false;
-            }
+		if (edgeSet.size() != m_edge.size())
+		{
+            msg_error() << "EdgeSetTopologyContainer::checkTopology() failed: found " << edgeSet.size() << " edges in m_edgesAroundVertex out of " << m_edge.size();
+			ret = false;
         }
+    }
 
-		return ret && PointSetTopologyContainer::checkTopology();
-	}
-
-    return true;
+	return ret && PointSetTopologyContainer::checkTopology();
 }
 
 

--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyContainer.cpp
@@ -234,39 +234,39 @@ bool EdgeSetTopologyContainer::checkTopology() const
     if (!d_checkTopology.getValue())
         return true;
 
-	bool ret = true;
+    bool ret = true;
 
     if (hasEdgesAroundVertex())
-	{
-		helper::ReadAccessor< Data< sofa::helper::vector<Edge> > > m_edge = d_edge;
-		std::set<int> edgeSet;
+    {
+        helper::ReadAccessor< Data< sofa::helper::vector<Edge> > > m_edge = d_edge;
+        std::set<int> edgeSet;
 
         // loop on all edges around vertex
         for (size_t i = 0; i < m_edgesAroundVertex.size(); ++i)
-		{
-			const sofa::helper::vector<EdgeID> &es = m_edgesAroundVertex[i];
-			for (size_t j = 0; j < es.size(); ++j)
-			{
+        {
+            const sofa::helper::vector<EdgeID> &es = m_edgesAroundVertex[i];
+            for (size_t j = 0; j < es.size(); ++j)
+            {
                 const Edge& edge = m_edge[es[j]];
                 if (!(edge[0] == i || edge[1] == i))
-				{
+                {
                     msg_error() << "EdgeSetTopologyContainer::checkTopology() failed: edge " << es[j] << ": [" << edge << "] not around vertex: " << i;
-					ret = false;
-				}
+                    ret = false;
+                }
 
                 // count number of edge
                 edgeSet.insert(es[j]);
-			}
-		}
+            }
+        }
 
-		if (edgeSet.size() != m_edge.size())
-		{
+        if (edgeSet.size() != m_edge.size())
+        {
             msg_error() << "EdgeSetTopologyContainer::checkTopology() failed: found " << edgeSet.size() << " edges in m_edgesAroundVertex out of " << m_edge.size();
-			ret = false;
+            ret = false;
         }
     }
 
-	return ret && PointSetTopologyContainer::checkTopology();
+    return ret && PointSetTopologyContainer::checkTopology();
 }
 
 

--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyModifier.cpp
@@ -66,7 +66,7 @@ void EdgeSetTopologyModifier::init()
 
 void EdgeSetTopologyModifier::addEdgeProcess(Edge e)
 {
-	if (CHECK_TOPOLOGY)
+	if (m_container->d_checkTopology.getValue())
 	{
 		// check if the 2 vertices are different
 		if (e[0] == e[1])

--- a/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyContainer.cpp
@@ -840,88 +840,87 @@ HexahedronSetTopologyContainer::HexahedraAroundQuad &HexahedronSetTopologyContai
 
 bool HexahedronSetTopologyContainer::checkTopology() const
 {
-	if (CHECK_TOPOLOGY)
+    if (!d_checkTopology.getValue())
+        return true;
+
+	bool ret = true;
+	helper::ReadAccessor< Data< sofa::helper::vector<Hexahedron> > > m_hexahedron = d_hexahedron;
+	if (hasHexahedraAroundVertex())
 	{
-		bool ret = true;
-		helper::ReadAccessor< Data< sofa::helper::vector<Hexahedron> > > m_hexahedron = d_hexahedron;
-		if (hasHexahedraAroundVertex())
+		for (size_t i = 0; i < m_hexahedraAroundVertex.size(); ++i)
 		{
-			for (size_t i = 0; i < m_hexahedraAroundVertex.size(); ++i)
+			const sofa::helper::vector<HexahedronID> &tvs = m_hexahedraAroundVertex[i];
+			for (size_t j = 0; j < tvs.size(); ++j)
 			{
-				const sofa::helper::vector<HexahedronID> &tvs = m_hexahedraAroundVertex[i];
-				for (size_t j = 0; j < tvs.size(); ++j)
-				{
-					bool check_hexa_vertex_shell = (m_hexahedron[tvs[j]][0] == i)
-						|| (m_hexahedron[tvs[j]][1] == i)
-						|| (m_hexahedron[tvs[j]][2] == i)
-						|| (m_hexahedron[tvs[j]][3] == i)
-						|| (m_hexahedron[tvs[j]][4] == i)
-						|| (m_hexahedron[tvs[j]][5] == i)
-						|| (m_hexahedron[tvs[j]][6] == i)
-						|| (m_hexahedron[tvs[j]][7] == i);
+				bool check_hexa_vertex_shell = (m_hexahedron[tvs[j]][0] == i)
+					|| (m_hexahedron[tvs[j]][1] == i)
+					|| (m_hexahedron[tvs[j]][2] == i)
+					|| (m_hexahedron[tvs[j]][3] == i)
+					|| (m_hexahedron[tvs[j]][4] == i)
+					|| (m_hexahedron[tvs[j]][5] == i)
+					|| (m_hexahedron[tvs[j]][6] == i)
+					|| (m_hexahedron[tvs[j]][7] == i);
 
-					if (!check_hexa_vertex_shell)
-					{
-						msg_error() << "*** CHECK FAILED : check_hexa_vertex_shell, i = " << i << " , j = " << j;
-						ret = false;
-					}
+				if (!check_hexa_vertex_shell)
+				{
+					msg_error() << "*** CHECK FAILED : check_hexa_vertex_shell, i = " << i << " , j = " << j;
+					ret = false;
 				}
 			}
 		}
-
-		if (hasHexahedraAroundEdge())
-		{
-			for (size_t i = 0; i < m_hexahedraAroundEdge.size(); ++i)
-			{
-				const sofa::helper::vector<HexahedronID> &tes = m_hexahedraAroundEdge[i];
-				for (size_t j = 0; j < tes.size(); ++j)
-				{
-					bool check_hexa_edge_shell = (m_edgesInHexahedron[tes[j]][0] == i)
-						|| (m_edgesInHexahedron[tes[j]][1] == i)
-						|| (m_edgesInHexahedron[tes[j]][2] == i)
-						|| (m_edgesInHexahedron[tes[j]][3] == i)
-						|| (m_edgesInHexahedron[tes[j]][4] == i)
-						|| (m_edgesInHexahedron[tes[j]][5] == i)
-						|| (m_edgesInHexahedron[tes[j]][6] == i)
-						|| (m_edgesInHexahedron[tes[j]][7] == i)
-						|| (m_edgesInHexahedron[tes[j]][8] == i)
-						|| (m_edgesInHexahedron[tes[j]][9] == i)
-						|| (m_edgesInHexahedron[tes[j]][10] == i)
-						|| (m_edgesInHexahedron[tes[j]][11] == i);
-					if (!check_hexa_edge_shell)
-					{
-						msg_error() << "*** CHECK FAILED : check_hexa_edge_shell, i = " << i << " , j = " << j;
-						ret = false;
-					}
-				}
-			}
-		}
-
-		if (hasHexahedraAroundQuad())
-		{
-			for (size_t i = 0; i < m_hexahedraAroundQuad.size(); ++i)
-			{
-				const sofa::helper::vector<HexahedronID> &tes = m_hexahedraAroundQuad[i];
-				for (size_t j = 0; j < tes.size(); ++j)
-				{
-					bool check_hexa_quad_shell = (m_quadsInHexahedron[tes[j]][0] == i)
-						|| (m_quadsInHexahedron[tes[j]][1] == i)
-						|| (m_quadsInHexahedron[tes[j]][2] == i)
-						|| (m_quadsInHexahedron[tes[j]][3] == i)
-						|| (m_quadsInHexahedron[tes[j]][4] == i)
-						|| (m_quadsInHexahedron[tes[j]][5] == i);
-					if (!check_hexa_quad_shell)
-					{
-						msg_error() << "*** CHECK FAILED : check_hexa_quad_shell, i = " << i << " , j = " << j;
-						ret = false;
-					}
-				}
-			}
-		}
-
-		return ret && QuadSetTopologyContainer::checkTopology();
 	}
-    return true;
+
+	if (hasHexahedraAroundEdge())
+	{
+		for (size_t i = 0; i < m_hexahedraAroundEdge.size(); ++i)
+		{
+			const sofa::helper::vector<HexahedronID> &tes = m_hexahedraAroundEdge[i];
+			for (size_t j = 0; j < tes.size(); ++j)
+			{
+				bool check_hexa_edge_shell = (m_edgesInHexahedron[tes[j]][0] == i)
+					|| (m_edgesInHexahedron[tes[j]][1] == i)
+					|| (m_edgesInHexahedron[tes[j]][2] == i)
+					|| (m_edgesInHexahedron[tes[j]][3] == i)
+					|| (m_edgesInHexahedron[tes[j]][4] == i)
+					|| (m_edgesInHexahedron[tes[j]][5] == i)
+					|| (m_edgesInHexahedron[tes[j]][6] == i)
+					|| (m_edgesInHexahedron[tes[j]][7] == i)
+					|| (m_edgesInHexahedron[tes[j]][8] == i)
+					|| (m_edgesInHexahedron[tes[j]][9] == i)
+					|| (m_edgesInHexahedron[tes[j]][10] == i)
+					|| (m_edgesInHexahedron[tes[j]][11] == i);
+				if (!check_hexa_edge_shell)
+				{
+					msg_error() << "*** CHECK FAILED : check_hexa_edge_shell, i = " << i << " , j = " << j;
+					ret = false;
+				}
+			}
+		}
+	}
+
+	if (hasHexahedraAroundQuad())
+	{
+		for (size_t i = 0; i < m_hexahedraAroundQuad.size(); ++i)
+		{
+			const sofa::helper::vector<HexahedronID> &tes = m_hexahedraAroundQuad[i];
+			for (size_t j = 0; j < tes.size(); ++j)
+			{
+				bool check_hexa_quad_shell = (m_quadsInHexahedron[tes[j]][0] == i)
+					|| (m_quadsInHexahedron[tes[j]][1] == i)
+					|| (m_quadsInHexahedron[tes[j]][2] == i)
+					|| (m_quadsInHexahedron[tes[j]][3] == i)
+					|| (m_quadsInHexahedron[tes[j]][4] == i)
+					|| (m_quadsInHexahedron[tes[j]][5] == i);
+				if (!check_hexa_quad_shell)
+				{
+					msg_error() << "*** CHECK FAILED : check_hexa_quad_shell, i = " << i << " , j = " << j;
+					ret = false;
+				}
+			}
+		}
+	}
+
+	return ret && QuadSetTopologyContainer::checkTopology();
 }
 
 

--- a/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyModifier.cpp
@@ -98,7 +98,7 @@ void HexahedronSetTopologyModifier::addHexahedra(const sofa::helper::vector<Hexa
 
 void HexahedronSetTopologyModifier::addHexahedronProcess(Hexahedron t)
 {
-	if (CHECK_TOPOLOGY)
+	if (m_container->d_checkTopology.getValue())
 	{
 		// check if the 8 vertices are different
 		assert(t[0] != t[1]); assert(t[0] != t[2]); assert(t[0] != t[3]); assert(t[0] != t[4]); assert(t[0] != t[5]); assert(t[0] != t[6]); assert(t[0] != t[7]);

--- a/SofaKernel/modules/SofaBaseTopology/PointSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/PointSetTopologyContainer.cpp
@@ -63,6 +63,7 @@ int PointSetTopologyContainerClass = core::RegisterObject("Point set topology co
 
 PointSetTopologyContainer::PointSetTopologyContainer(int npoints)
     : d_initPoints (initData(&d_initPoints, "position", "Initial position of points",true,true))
+    , d_checkTopology (initData(&d_checkTopology, false, "checkTopology", "Parameter to activate internal topology checks (might slow down the simulation)"))
     , m_pointTopologyDirty(false)
     , nbPoints (initData(&nbPoints, (unsigned int )npoints, "nbPoints", "Number of points"))
     , points(initData(&points, "points","List of point indices"))

--- a/SofaKernel/modules/SofaBaseTopology/PointSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/PointSetTopologyContainer.h
@@ -172,8 +172,9 @@ protected:
     virtual void displayDataGraph(sofa::core::objectmodel::BaseData& my_Data);
 
 public:
+    Data<InitTypes::VecCoord> d_initPoints; ///< Initial position of points    
 
-    Data<InitTypes::VecCoord> d_initPoints; ///< Initial position of points
+    Data<bool> d_checkTopology; ///< Bool parameter to activate internal topology checks in several methods 
 
 protected:
 

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyContainer.cpp
@@ -460,53 +460,51 @@ QuadSetTopologyContainer::QuadsAroundVertex &QuadSetTopologyContainer::getQuadsA
 
 bool QuadSetTopologyContainer::checkTopology() const
 {
-	if (CHECK_TOPOLOGY)
+    if (!d_checkTopology.getValue())
+        return true;
+
+	bool ret = true;
+	helper::ReadAccessor< Data< sofa::helper::vector<Quad> > > m_quad = d_quad;
+
+	if (hasQuadsAroundVertex())
 	{
-		bool ret = true;
-		helper::ReadAccessor< Data< sofa::helper::vector<Quad> > > m_quad = d_quad;
-
-		if (hasQuadsAroundVertex())
+		for (size_t i = 0; i < m_quadsAroundVertex.size(); ++i)
 		{
-			for (size_t i = 0; i < m_quadsAroundVertex.size(); ++i)
+			const sofa::helper::vector<QuadID> &tvs = m_quadsAroundVertex[i];
+			for (size_t j = 0; j < tvs.size(); ++j)
 			{
-				const sofa::helper::vector<QuadID> &tvs = m_quadsAroundVertex[i];
-				for (size_t j = 0; j < tvs.size(); ++j)
+				if ((m_quad[tvs[j]][0] != i)
+					&& (m_quad[tvs[j]][1] != i)
+					&& (m_quad[tvs[j]][2] != i)
+					&& (m_quad[tvs[j]][3] != i))
 				{
-					if ((m_quad[tvs[j]][0] != i)
-						&& (m_quad[tvs[j]][1] != i)
-						&& (m_quad[tvs[j]][2] != i)
-						&& (m_quad[tvs[j]][3] != i))
-					{
-						ret = false;
-						msg_error() << "*** CHECK FAILED : check_quad_vertex_shell, i = " << i << " , j = " << j;
-					}
+					ret = false;
+					msg_error() << "*** CHECK FAILED : check_quad_vertex_shell, i = " << i << " , j = " << j;
 				}
 			}
 		}
-
-		if (hasQuadsAroundEdge())
-		{
-			for (size_t i = 0; i < m_quadsAroundEdge.size(); ++i)
-			{
-				const sofa::helper::vector<QuadID> &tes = m_quadsAroundEdge[i];
-				for (size_t j = 0; j < tes.size(); ++j)
-				{
-					if ((m_edgesInQuad[tes[j]][0] != i)
-						&& (m_edgesInQuad[tes[j]][1] != i)
-						&& (m_edgesInQuad[tes[j]][2] != i)
-						&& (m_edgesInQuad[tes[j]][3] != i))
-					{
-						ret = false;
-						msg_error() << "*** CHECK FAILED : check_quad_edge_shell, i = " << i << " , j = " << j;
-					}
-				}
-			}
-		}
-
-		return ret && EdgeSetTopologyContainer::checkTopology();
 	}
-	
-	return true;
+
+	if (hasQuadsAroundEdge())
+	{
+		for (size_t i = 0; i < m_quadsAroundEdge.size(); ++i)
+		{
+			const sofa::helper::vector<QuadID> &tes = m_quadsAroundEdge[i];
+			for (size_t j = 0; j < tes.size(); ++j)
+			{
+				if ((m_edgesInQuad[tes[j]][0] != i)
+					&& (m_edgesInQuad[tes[j]][1] != i)
+					&& (m_edgesInQuad[tes[j]][2] != i)
+					&& (m_edgesInQuad[tes[j]][3] != i))
+				{
+					ret = false;
+					msg_error() << "*** CHECK FAILED : check_quad_edge_shell, i = " << i << " , j = " << j;
+				}
+			}
+		}
+	}
+
+	return ret && EdgeSetTopologyContainer::checkTopology();
 }
 
 

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyModifier.cpp
@@ -97,7 +97,7 @@ void QuadSetTopologyModifier::addQuads(const sofa::helper::vector<Quad> &quads,
 
 void QuadSetTopologyModifier::addQuadProcess(Quad t)
 {
-	if (CHECK_TOPOLOGY)
+	if (m_container->d_checkTopology.getValue())
 	{
 		// check if the 4 vertices are different
 		if ((t[0] == t[1]) || (t[0] == t[2]) || (t[0] == t[3])

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
@@ -692,171 +692,169 @@ TetrahedronSetTopologyContainer::TetrahedraAroundTriangle &TetrahedronSetTopolog
 
 bool TetrahedronSetTopologyContainer::checkTopology() const
 {
-    if (CHECK_TOPOLOGY)
+    if (!d_checkTopology.getValue())
+        return true;
+    
+    bool ret = true;
+    helper::ReadAccessor< Data< sofa::helper::vector<Tetrahedron> > > m_tetrahedron = d_tetrahedron;
+
+    if (hasTetrahedraAroundVertex())
     {
-        bool ret = true;
-        helper::ReadAccessor< Data< sofa::helper::vector<Tetrahedron> > > m_tetrahedron = d_tetrahedron;
-
-        if (hasTetrahedraAroundVertex())
+        std::set <int> tetrahedronSet;
+        for (size_t i = 0; i < m_tetrahedraAroundVertex.size(); ++i)
         {
-            std::set <int> tetrahedronSet;
-            for (size_t i = 0; i < m_tetrahedraAroundVertex.size(); ++i)
+            const sofa::helper::vector<TetrahedronID> &tvs = m_tetrahedraAroundVertex[i];
+            for (size_t j = 0; j < tvs.size(); ++j)
             {
-                const sofa::helper::vector<TetrahedronID> &tvs = m_tetrahedraAroundVertex[i];
-                for (size_t j = 0; j < tvs.size(); ++j)
+                const Tetrahedron& tetrahedron = m_tetrahedron[tvs[j]];
+                bool check_tetra_vertex_shell = (tetrahedron[0] == i)
+                    || (tetrahedron[1] == i)
+                    || (tetrahedron[2] == i)
+                    || (tetrahedron[3] == i);
+                if (!check_tetra_vertex_shell)
                 {
-                    const Tetrahedron& tetrahedron = m_tetrahedron[tvs[j]];
-                    bool check_tetra_vertex_shell = (tetrahedron[0] == i)
-                        || (tetrahedron[1] == i)
-                        || (tetrahedron[2] == i)
-                        || (tetrahedron[3] == i);
-                    if (!check_tetra_vertex_shell)
-                    {
-                        msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: tetrahedron " << tvs[j] << ": [" << tetrahedron << "] not around vertex: " << i;
-                        ret = false;
-                    }
-
-                    tetrahedronSet.insert(tvs[j]);
+                    msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: tetrahedron " << tvs[j] << ": [" << tetrahedron << "] not around vertex: " << i;
+                    ret = false;
                 }
-            }
 
-            if (tetrahedronSet.size() != m_tetrahedron.size())
-            {
-                msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: found " << tetrahedronSet.size() << " tetrahedra in m_tetrahedraAroundVertex out of " << m_tetrahedron.size();
-                ret = false;
+                tetrahedronSet.insert(tvs[j]);
             }
         }
 
-
-        if (hasTetrahedraAroundTriangle() && hasTrianglesInTetrahedron())
+        if (tetrahedronSet.size() != m_tetrahedron.size())
         {
-            // check first m_trianglesInTetrahedron
-            helper::ReadAccessor< Data< sofa::helper::vector<Triangle> > > m_triangle = d_triangle;
-
-            if (m_trianglesInTetrahedron.size() != m_tetrahedron.size())
-            {
-                msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: m_trianglesInTetrahedron size: " << m_trianglesInTetrahedron.size() << " not equal to " << m_tetrahedron.size();
-                ret = false;
-            }
-
-            for (size_t i=0; i<m_trianglesInTetrahedron.size(); ++i)
-            {
-                const Tetrahedron& tetrahedron = m_tetrahedron[i];
-                const TrianglesInTetrahedron& triInTetra = m_trianglesInTetrahedron[i];
-
-                for (unsigned int j=0; j<4; j++)
-                {
-                    const Triangle& triangle = m_triangle[triInTetra[j]];
-                    int cptFound = 0;
-                    for (unsigned int k=0; k<4; k++)
-                        if (triangle[0] == tetrahedron[k] || triangle[1] == tetrahedron[k] || triangle[2] == tetrahedron[k])
-                            cptFound++;
-
-                    if (cptFound != 3)
-                    {
-                        msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: triangle: " << triInTetra[j] << ": [" << triangle << "] not found in tetrahedron: " << i << ": " << tetrahedron;
-                        ret = false;
-                    }
-                }
-            }
-
-            // check m_tetrahedraAroundTriangle using checked m_trianglesInTetrahedron
-            std::set <int> tetrahedronSet;
-            for (size_t i = 0; i < m_tetrahedraAroundTriangle.size(); ++i)
-            {
-                const sofa::helper::vector<TetrahedronID> &tes = m_tetrahedraAroundTriangle[i];
-                for (size_t j = 0; j < tes.size(); ++j)
-                {
-                    const TrianglesInTetrahedron& triInTetra = m_trianglesInTetrahedron[tes[j]];
-                    bool check_tetra_triangle_shell = (triInTetra[0] == i)
-                        || (triInTetra[1] == i)
-                        || (triInTetra[2] == i)
-                        || (triInTetra[3] == i);
-                    if (!check_tetra_triangle_shell)
-                    {
-                        msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: tetrahedron: " << tes[j] << " with triangle: [" << triInTetra << "] not found around triangle: " << i;
-                        ret = false;
-                    }
-
-                    tetrahedronSet.insert(tes[j]);
-                }
-            }
-
-            if (tetrahedronSet.size() != m_tetrahedron.size())
-            {
-                msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: found " << tetrahedronSet.size() << " tetrahedra in m_tetrahedraAroundTriangle out of " << m_tetrahedron.size();
-                ret = false;
-            }
+            msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: found " << tetrahedronSet.size() << " tetrahedra in m_tetrahedraAroundVertex out of " << m_tetrahedron.size();
+            ret = false;
         }
-
-
-        if (hasTetrahedraAroundEdge() && hasEdgesInTetrahedron())
-        {
-            // check first m_edgesInTetrahedron
-            helper::ReadAccessor< Data< sofa::helper::vector<Edge> > > m_edge = d_edge;
-
-            if (m_edgesInTetrahedron.size() != m_tetrahedron.size())
-            {
-                msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: m_edgesInTetrahedron size: " << m_edgesInTetrahedron.size() << " not equal to " << m_tetrahedron.size();
-                ret = false;
-            }
-
-            for (size_t i=0; i<m_edgesInTetrahedron.size(); ++i)
-            {
-                const Tetrahedron& tetrahedron = m_tetrahedron[i];
-                const EdgesInTetrahedron& eInTetra = m_edgesInTetrahedron[i];
-
-                for (unsigned int j=0; j<6; j++)
-                {
-                    const Edge& edge = m_edge[eInTetra[j]];
-                    int cptFound = 0;
-                    for (unsigned int k=0; k<4; k++)
-                        if (edge[0] == tetrahedron[k] || edge[1] == tetrahedron[k])
-                            cptFound++;
-
-                    if (cptFound != 2)
-                    {
-                        msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: edge: " << eInTetra[j] << ": [" << edge << "] not found in tetrahedron: " << i << ": " << tetrahedron;
-                        ret = false;
-                    }
-                }
-            }
-
-            // check m_tetrahedraAroundEdge using checked m_edgesInTetrahedron
-            std::set <int> tetrahedronSet;
-            for (size_t i = 0; i < m_tetrahedraAroundEdge.size(); ++i)
-            {
-                const sofa::helper::vector<TetrahedronID> &tes = m_tetrahedraAroundEdge[i];
-                for (size_t j = 0; j < tes.size(); ++j)
-                {
-                    const EdgesInTetrahedron& eInTetra = m_edgesInTetrahedron[tes[j]];
-                    bool check_tetra_edge_shell = (eInTetra[0] == i)
-                        || (eInTetra[1] == i)
-                        || (eInTetra[2] == i)
-                        || (eInTetra[3] == i)
-                        || (eInTetra[4] == i)
-                        || (eInTetra[5] == i);
-                    if (!check_tetra_edge_shell)
-                    {
-                        msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: tetrahedron: " << tes[j] << " with edges: [" << eInTetra << "] not found around edge: " << i;
-                        ret = false;
-                    }
-
-                    tetrahedronSet.insert(tes[j]);
-                }
-            }
-
-            if (tetrahedronSet.size() != m_tetrahedron.size())
-            {
-                msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: found " << tetrahedronSet.size() << " tetrahedra in m_tetrahedraAroundTriangle out of " << m_tetrahedron.size();
-                ret = false;
-            }
-        }
-
-        return ret && TriangleSetTopologyContainer::checkTopology();
     }
 
-    return true;
+
+    if (hasTetrahedraAroundTriangle() && hasTrianglesInTetrahedron())
+    {
+        // check first m_trianglesInTetrahedron
+        helper::ReadAccessor< Data< sofa::helper::vector<Triangle> > > m_triangle = d_triangle;
+
+        if (m_trianglesInTetrahedron.size() != m_tetrahedron.size())
+        {
+            msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: m_trianglesInTetrahedron size: " << m_trianglesInTetrahedron.size() << " not equal to " << m_tetrahedron.size();
+            ret = false;
+        }
+
+        for (size_t i=0; i<m_trianglesInTetrahedron.size(); ++i)
+        {
+            const Tetrahedron& tetrahedron = m_tetrahedron[i];
+            const TrianglesInTetrahedron& triInTetra = m_trianglesInTetrahedron[i];
+
+            for (unsigned int j=0; j<4; j++)
+            {
+                const Triangle& triangle = m_triangle[triInTetra[j]];
+                int cptFound = 0;
+                for (unsigned int k=0; k<4; k++)
+                    if (triangle[0] == tetrahedron[k] || triangle[1] == tetrahedron[k] || triangle[2] == tetrahedron[k])
+                        cptFound++;
+
+                if (cptFound != 3)
+                {
+                    msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: triangle: " << triInTetra[j] << ": [" << triangle << "] not found in tetrahedron: " << i << ": " << tetrahedron;
+                    ret = false;
+                }
+            }
+        }
+
+        // check m_tetrahedraAroundTriangle using checked m_trianglesInTetrahedron
+        std::set <int> tetrahedronSet;
+        for (size_t i = 0; i < m_tetrahedraAroundTriangle.size(); ++i)
+        {
+            const sofa::helper::vector<TetrahedronID> &tes = m_tetrahedraAroundTriangle[i];
+            for (size_t j = 0; j < tes.size(); ++j)
+            {
+                const TrianglesInTetrahedron& triInTetra = m_trianglesInTetrahedron[tes[j]];
+                bool check_tetra_triangle_shell = (triInTetra[0] == i)
+                    || (triInTetra[1] == i)
+                    || (triInTetra[2] == i)
+                    || (triInTetra[3] == i);
+                if (!check_tetra_triangle_shell)
+                {
+                    msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: tetrahedron: " << tes[j] << " with triangle: [" << triInTetra << "] not found around triangle: " << i;
+                    ret = false;
+                }
+
+                tetrahedronSet.insert(tes[j]);
+            }
+        }
+
+        if (tetrahedronSet.size() != m_tetrahedron.size())
+        {
+            msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: found " << tetrahedronSet.size() << " tetrahedra in m_tetrahedraAroundTriangle out of " << m_tetrahedron.size();
+            ret = false;
+        }
+    }
+
+
+    if (hasTetrahedraAroundEdge() && hasEdgesInTetrahedron())
+    {
+        // check first m_edgesInTetrahedron
+        helper::ReadAccessor< Data< sofa::helper::vector<Edge> > > m_edge = d_edge;
+
+        if (m_edgesInTetrahedron.size() != m_tetrahedron.size())
+        {
+            msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: m_edgesInTetrahedron size: " << m_edgesInTetrahedron.size() << " not equal to " << m_tetrahedron.size();
+            ret = false;
+        }
+
+        for (size_t i=0; i<m_edgesInTetrahedron.size(); ++i)
+        {
+            const Tetrahedron& tetrahedron = m_tetrahedron[i];
+            const EdgesInTetrahedron& eInTetra = m_edgesInTetrahedron[i];
+
+            for (unsigned int j=0; j<6; j++)
+            {
+                const Edge& edge = m_edge[eInTetra[j]];
+                int cptFound = 0;
+                for (unsigned int k=0; k<4; k++)
+                    if (edge[0] == tetrahedron[k] || edge[1] == tetrahedron[k])
+                        cptFound++;
+
+                if (cptFound != 2)
+                {
+                    msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: edge: " << eInTetra[j] << ": [" << edge << "] not found in tetrahedron: " << i << ": " << tetrahedron;
+                    ret = false;
+                }
+            }
+        }
+
+        // check m_tetrahedraAroundEdge using checked m_edgesInTetrahedron
+        std::set <int> tetrahedronSet;
+        for (size_t i = 0; i < m_tetrahedraAroundEdge.size(); ++i)
+        {
+            const sofa::helper::vector<TetrahedronID> &tes = m_tetrahedraAroundEdge[i];
+            for (size_t j = 0; j < tes.size(); ++j)
+            {
+                const EdgesInTetrahedron& eInTetra = m_edgesInTetrahedron[tes[j]];
+                bool check_tetra_edge_shell = (eInTetra[0] == i)
+                    || (eInTetra[1] == i)
+                    || (eInTetra[2] == i)
+                    || (eInTetra[3] == i)
+                    || (eInTetra[4] == i)
+                    || (eInTetra[5] == i);
+                if (!check_tetra_edge_shell)
+                {
+                    msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: tetrahedron: " << tes[j] << " with edges: [" << eInTetra << "] not found around edge: " << i;
+                    ret = false;
+                }
+
+                tetrahedronSet.insert(tes[j]);
+            }
+        }
+
+        if (tetrahedronSet.size() != m_tetrahedron.size())
+        {
+            msg_error() << "TetrahedronSetTopologyContainer::checkTopology() failed: found " << tetrahedronSet.size() << " tetrahedra in m_tetrahedraAroundTriangle out of " << m_tetrahedron.size();
+            ret = false;
+        }
+    }
+
+    return ret && TriangleSetTopologyContainer::checkTopology();
 }
 
 

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyModifier.cpp
@@ -104,7 +104,7 @@ void TetrahedronSetTopologyModifier::addTetrahedra(const sofa::helper::vector<Te
 
 void TetrahedronSetTopologyModifier::addTetrahedronProcess(Tetrahedron t)
 {
-	if (CHECK_TOPOLOGY)
+	if (m_container->d_checkTopology.getValue())
 	{
 		// check if the 3 vertices are different
 		assert(t[0] != t[1]);

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyModifier.cpp
@@ -168,7 +168,7 @@ void TriangleSetTopologyModifier::addTrianglesProcess(const sofa::helper::vector
 void TriangleSetTopologyModifier::addTriangleProcess(Triangle t)
 {
 
-	if (CHECK_TOPOLOGY)
+	if (m_container->d_checkTopology.getValue())
 	{
 		// check if the 3 vertices are different
 		if ((t[0] == t[1]) || (t[0] == t[2]) || (t[1] == t[2]))

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseMeshTopology.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseMeshTopology.h
@@ -269,7 +269,11 @@ public:
     /// get information about connexity of the mesh
     /// @{
     /// Checks if the topology has only one connected component. @return Return true if so.
-    virtual bool checkConnexity() {return true;}
+    virtual bool checkConnexity() { return true; }
+
+    /// Checks if the topology is coherent. @return true if so. Should be override by child class.
+    virtual bool checkTopology() const { return true; }
+
     /// Returns the number of connected component.
     virtual size_t getNumberOfConnectedComponent() {return 0;}
     /// Returns the set of element indices connected to an input one (i.e. which can be reached by topological links)


### PR DESCRIPTION
Add Data bool d_checkTopology in PointSetTopologyContainer. By default to false.

- Methods CheckTopology always return true if this option is not activated.
- Update some topology modifiers methods to check this option instead of CHECK_TOPOLOGY  macro



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
