### PR TITLE
[SofaFramework] Windows/VS: Remove warnings flags from definitions

### DIFF
--- a/SofaKernel/cmake/CompilerOptions.cmake
+++ b/SofaKernel/cmake/CompilerOptions.cmake
@@ -35,8 +35,8 @@ endif()
 
 ## Windows-specific
 if(WIN32)
-    add_definitions("-wd4250 -wd4251 -wd4275 -wd4675 -wd4996 -D_USE_MATH_DEFINES")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+    add_definitions("-D_USE_MATH_DEFINES")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP -wd4250 -wd4251 -wd4275 -wd4675 -wd4996")
     if(MSVC_TOOLSET_VERSION GREATER 140) # > VS 2015
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus")
     endif()


### PR DESCRIPTION
Warnings flags were declared in add_definitions (instead of cxx_flags)

It is messing with projects using the new CUDA language feat.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
