### PR TITLE
[SofaConstraint] Set the use of integration factor true by default

### DIFF
--- a/examples/Components/animationloop/MechanicalMatrixMapper.pyscn
+++ b/examples/Components/animationloop/MechanicalMatrixMapper.pyscn
@@ -43,3 +43,4 @@ def createScene(rootNode):
        	FEMNode.createObject("SubsetMultiMapping",name="subsetMapping",template="Vec3d,Vec3d", input="@../beamPart1Mech @../../RigidNode/RigidifiedNode/rigidMecha",output="@./beamMecha", indexPairs="0 0  0 1  0 2  0 3  0 4  0 5  0 6  0 7  0 8  0 9  0 10  0 11  1 0  1 1  1 2  1 3")
 
         return rootNode
+        

--- a/examples/Components/animationloop/MechanicalMatrixMapper.pyscn
+++ b/examples/Components/animationloop/MechanicalMatrixMapper.pyscn
@@ -43,5 +43,3 @@ def createScene(rootNode):
        	FEMNode.createObject("SubsetMultiMapping",name="subsetMapping",template="Vec3d,Vec3d", input="@../beamPart1Mech @../../RigidNode/RigidifiedNode/rigidMecha",output="@./beamMecha", indexPairs="0 0  0 1  0 2  0 3  0 4  0 5  0 6  0 7  0 8  0 9  0 10  0 11  1 0  1 1  1 2  1 3")
 
         return rootNode
-
-

--- a/modules/SofaConstraint/UncoupledConstraintCorrection.inl
+++ b/modules/SofaConstraint/UncoupledConstraintCorrection.inl
@@ -115,7 +115,7 @@ UncoupledConstraintCorrection<DataTypes>::UncoupledConstraintCorrection(sofa::co
     , f_verbose( initData(&f_verbose,false,"verbose","Dump the constraint matrix at each iteration") )
     , d_correctionVelocityFactor(initData(&d_correctionVelocityFactor, (Real)1.0, "correctionVelocityFactor", "Factor applied to the constraint forces when correcting the velocities"))
     , d_correctionPositionFactor(initData(&d_correctionPositionFactor, (Real)1.0, "correctionPositionFactor", "Factor applied to the constraint forces when correcting the positions"))
-    , d_useOdeSolverIntegrationFactors(initData(&d_useOdeSolverIntegrationFactors, false, "useOdeSolverIntegrationFactors", "Use odeSolver integration factors instead of correctionVelocityFactor and correctionPositionFactor"))
+    , d_useOdeSolverIntegrationFactors(initData(&d_useOdeSolverIntegrationFactors, true, "useOdeSolverIntegrationFactors", "Use odeSolver integration factors instead of correctionVelocityFactor and correctionPositionFactor"))
     , l_topology(initLink("topology", "link to the topology container"))
     , m_pOdeSolver(nullptr)
 {


### PR DESCRIPTION
This should avoid confusion in constraint resolution when mixing integration factors.
Let's see how this affect the CI.

This affects the UncoupledConstraintCorrection : the flag _useOdeSolverIntegrationFactors_ is now true by default. This enforces to respect values returned by the ODESolver.

See this [forum topic](https://www.sofa-framework.org/community/forum/topic/bilateralinteractionconstraint-reduces-gravity-by-100x/)

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
