### PR TITLE
[SofaKernel] Refactor DDGNode

### DIFF
--- a/SofaKernel/modules/SofaCore/SofaCore_simutest/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/SofaCore_simutest/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.1)
 project(SofaCore_simutest)
 
 find_package(SofaBase REQUIRED)
+find_package(SofaComponentAll REQUIRED)
 
 set(SOURCE_FILES
     objectmodel/Base_test.cpp

--- a/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/DDGNode_test.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/DDGNode_test.cpp
@@ -39,9 +39,6 @@ public:
     {
         m_cptNotify++;
     }
-    const std::string& getName() const override {return "";}
-    sofa::core::objectmodel::Base* getOwner() const override {return nullptr;}
-    sofa::core::objectmodel::BaseData* getData() const override{return nullptr;}
 };
 
 class DDGNode_test: public BaseTest

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataEngine.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataEngine.cpp
@@ -30,8 +30,6 @@ namespace core
 
 DataEngine::DataEngine()
 {
-    addLink(&(this->core::objectmodel::DDGNode::inputs));
-    addLink(&(this->core::objectmodel::DDGNode::outputs));
 }
 
 DataEngine::~DataEngine()

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataEngine.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataEngine.h
@@ -59,7 +59,7 @@ namespace core
 class SOFA_CORE_API DataEngine : public core::DataTrackerDDGNode, public virtual core::objectmodel::BaseObject
 {
 public:
-    SOFA_ABSTRACT_CLASS2(DataEngine, core::objectmodel::BaseObject, core::DataTrackerDDGNode);
+    SOFA_ABSTRACT_CLASS(DataEngine, core::objectmodel::BaseObject);
     SOFA_BASE_CAST_IMPLEMENTATION(DataEngine)
 protected:
     /// Constructor
@@ -94,96 +94,6 @@ public:
 
     /// Add a new output to this engine
     void addOutput(objectmodel::BaseData* n);
-
-    // The methods below must be redefined because of the
-    // double inheritance from Base and DDGNode
-
-    /// @name Class reflection system
-    /// @{
-
-    template<class T>
-    static std::string typeName(const T* ptr= nullptr)
-    {
-        return core::objectmodel::BaseObject::typeName(ptr);
-    }
-
-    /// Helper method to get the class name of a type derived from this class
-    ///
-    /// This method should be used as follow :
-    /// \code  T* ptr = nullptr; std::string type = T::className(ptr); \endcode
-    /// This way derived classes can redefine the className method
-    template<class T>
-    static std::string className(const T* ptr= nullptr)
-    {
-        SOFA_UNUSED(ptr);
-        return sofa::helper::NameDecoder::getClassName<T>();
-    }
-
-    /// Helper method to get the namespace name of a type derived from this class
-    ///
-    /// This method should be used as follow :
-    /// \code  T* ptr = nullptr; std::string type = T::namespaceName(ptr); \endcode
-    /// This way derived classes can redefine the namespaceName method
-    template<class T>
-    static std::string namespaceName(const T* ptr= nullptr)
-    {
-        return core::objectmodel::BaseObject::namespaceName(ptr);
-    }
-
-    /// Helper method to get the template name of a type derived from this class
-    ///
-    /// This method should be used as follow :
-    /// \code  T* ptr = nullptr; std::string type = T::templateName(ptr); \endcode
-    /// This way derived classes can redefine the templateName method
-    template<class T>
-    static std::string templateName(const T* ptr= nullptr)
-    {
-        return core::objectmodel::BaseObject::templateName(ptr);
-    }
-
-    /// Helper method to get the shortname of a type derived from this class.
-    /// The default implementation return the class name.
-    ///
-    /// This method should be used as follow :
-    /// \code  T* ptr = nullptr; std::string type = T::shortName(ptr); \endcode
-    /// This way derived classes can redefine the shortName method
-    template< class T>
-    static std::string shortName( const T* ptr = nullptr, core::objectmodel::BaseObjectDescription* desc = nullptr )
-    {
-        return core::objectmodel::BaseObject::shortName(ptr,desc);
-    }
-
-    template<class T>
-    static void dynamicCast(T*& ptr, Base* b)
-    {
-        core::objectmodel::BaseObject::dynamicCast(ptr, b);
-    }
-
-    /// @}
-
-    /// This method is needed by DDGNode
-    const std::string& getName() const override
-    {
-        return objectmodel::BaseObject::getName();
-    }
-
-    /// This method is needed by DDGNode
-    objectmodel::Base* getOwner() const override
-    {
-        return const_cast<DataEngine*>(this);
-    }
-
-    /// This method is needed by DDGNode
-    objectmodel::BaseData* getData() const override
-    {
-        return nullptr;
-    }
-
-    /// Add a link.
-    void addLink(objectmodel::BaseLink* l)
-    {
-        objectmodel::BaseObject::addLink(l);
-    }
 };
 
 } // namespace core

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
@@ -86,9 +86,9 @@ void DataTrackerDDGNode::cleanDirty(const core::ExecParams*)
 void DataTrackerDDGNode::updateAllInputsIfDirty()
 {
     const DDGLinkContainer& inputs = DDGNode::getInputs();
-    for(size_t i=0, iend=inputs.size() ; i<iend ; ++i )
+    for(auto input : inputs)
     {
-        static_cast<core::objectmodel::BaseData*>(inputs[i])->updateIfDirty();
+        static_cast<core::objectmodel::BaseData*>(input)->updateIfDirty();
     }
 }
 ///////////////////////

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.h
@@ -22,7 +22,15 @@
 #ifndef SOFA_CORE_DATATRACKER_H
 #define SOFA_CORE_DATATRACKER_H
 
+#include <functional>
+#include <map>
+#include <vector>
 #include <sofa/core/objectmodel/DDGNode.h>
+namespace sofa::core::objectmodel
+{
+    class Base;
+    class BaseData;
+}
 
 namespace sofa
 {
@@ -170,17 +178,6 @@ namespace core
         /// Calls the callback when one of the data has changed.
         void update() override;
 
-        /// This method is needed by DDGNode
-        const std::string& getName() const override
-        {
-            static const std::string emptyName ="";
-            return emptyName;
-        }
-        /// This method is needed by DDGNode
-        objectmodel::Base* getOwner() const override { return nullptr; }
-        /// This method is needed by DDGNode
-        objectmodel::BaseData* getData() const override { return nullptr; }
-
     protected:
         std::vector<std::function<void(DataTrackerEngine*)>> m_callbacks;
     };
@@ -216,16 +213,6 @@ namespace core
 
         /// This method is needed by DDGNode
         void update() override{}
-        /// This method is needed by DDGNode
-        const std::string& getName() const override
-        {
-            static const std::string emptyName ="";
-            return emptyName;
-        }
-        /// This method is needed by DDGNode
-        objectmodel::Base* getOwner() const override { return nullptr; }
-        /// This method is needed by DDGNode
-        objectmodel::BaseData* getData() const override { return nullptr; }
 
     private:
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseContext.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseContext.h
@@ -62,13 +62,6 @@ public:
     SOFA_CLASS(BaseContext, Base);
     SOFA_BASE_CAST_IMPLEMENTATION(BaseContext)
 
-    /// @name Types defined for local coordinate system handling
-    /// @{
-
-//    typedef SolidTypes::Rot Quat;
-//    typedef SolidTypes::Mat Mat33;
-    /// @}
-
     typedef defaulttype::Vector3 Vec3;
 
 protected:

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.cpp
@@ -46,8 +46,6 @@ BaseData::BaseData(const std::string& h, DataFlags dataflags)
     , m_owner(nullptr), m_name("")
     , parentBaseData(initLink("parent", "Linked Data, from which values are automatically copied"))
 {
-    addLink(&inputs);
-    addLink(&outputs);
     m_counter = 0;
     m_isSet = false;
     setFlag(FLAG_PERSISTENT, false);
@@ -63,8 +61,6 @@ BaseData::BaseData( const std::string& h, bool isDisplayed, bool isReadOnly)
     , m_counter(), m_isSet(), m_dataFlags(FLAG_DEFAULT), m_owner(nullptr), m_name("")
     , parentBaseData(initLink("parent", "Linked Data, from which values are automatically copied"))
 {
-    addLink(&inputs);
-    addLink(&outputs);
     m_counter = 0;
     m_isSet = false;
     setFlag(FLAG_DISPLAYED,isDisplayed);
@@ -78,8 +74,6 @@ BaseData::BaseData( const BaseInitData& init)
     , m_owner(init.owner), m_name(init.name)
     , parentBaseData(initLink("parent", "Linked Data, from which values are automatically copied"))
 {
-    addLink(&inputs);
-    addLink(&outputs);
     m_counter = 0;
     m_isSet = false;
 
@@ -303,11 +297,6 @@ bool BaseData::copyValue(const BaseData* parent)
     if (updateFromParentValue(parent))
         return true;
     return false;
-}
-
-bool BaseData::findDataLinkDest(DDGNode*& ptr, const std::string& path, const BaseLink* link)
-{
-    return DDGNode::findDataLinkDest(ptr, path, link);
 }
 
 bool BaseData::findDataLinkDest(BaseData*& ptr, const std::string& path, const BaseLink* link)

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
@@ -24,6 +24,8 @@
 
 #include <sofa/core/core.h>
 #include <sofa/core/objectmodel/DDGNode.h>
+#include <sofa/core/objectmodel/BaseClass.h>
+#include <sofa/core/objectmodel/Link.h>
 
 namespace sofa
 {
@@ -66,11 +68,15 @@ public:
 
     /// @name Class reflection system
     /// @{
-    typedef TClass<BaseData,DDGNode> MyClass;
+    typedef TClass<BaseData> MyClass;
     static const sofa::core::objectmodel::BaseClass* GetClass() { return MyClass::get(); }
-    const BaseClass* getClass() const override
-    { return GetClass(); }
-    /// @}
+    const BaseClass* getClass() const
+    { return GetClass(); }    
+    template<class T>
+    static void dynamicCast(T*& ptr, Base* /*b*/)
+    {
+        ptr = nullptr; // BaseData does not derive from Base
+    }/// @}
 
     /// This internal class is used by the initData() methods to store initialization parameters of a Data
     class BaseInitData
@@ -226,18 +232,18 @@ public:
     virtual bool canBeLinked() const { return true; }
 
     /// Return the Base component owning this %Data.
-    Base* getOwner() const override { return m_owner; }
+    Base* getOwner() const { return m_owner; }
     /// Set the owner of this %Data.
     void setOwner(Base* o) { m_owner=o; }
 
     /// This method is needed by DDGNode
-    BaseData* getData() const override
+    BaseData* getData() const
     {
         return const_cast<BaseData*>(this);
     }
 
     /// Return the name of this %Data within the Base component
-    const std::string& getName() const override { return m_name; }
+    const std::string& getName() const { return m_name; }
     /// Set the name of this %Data.
     ///
     /// This method should not be called directly, the %Data registration methods in Base should be used instead.
@@ -290,8 +296,6 @@ public:
     typedef std::vector<BaseLink*> VecLink;
     /// Accessor to the vector containing all the fields of this object
     const VecLink& getLinks() const { return m_vecLink; }
-
-    virtual bool findDataLinkDest(DDGNode*& ptr, const std::string& path, const BaseLink* link) override;
 
     virtual bool findDataLinkDest(BaseData*& ptr, const std::string& path, const BaseLink* link);
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseLink.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseLink.h
@@ -126,8 +126,7 @@ public:
 
     /// Return the number of changes since creation
     /// This can be used to efficiently detect changes
-        [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
-
+    [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
     int getCounter(const core::ExecParams*) const { return getCounter(); }
 
     virtual size_t getSize() const = 0;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGNode.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGNode.cpp
@@ -19,44 +19,29 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <algorithm>
+#include <iostream>
+#include <cassert>
 #include <sofa/core/objectmodel/DDGNode.h>
-#include <sofa/core/objectmodel/BaseData.h>
-#include <sofa/core/objectmodel/Base.h>
-#include <sofa/core/DataEngine.h>
-
-//#define SOFA_DDG_TRACE
-
-namespace sofa
-{
-
-namespace core
-{
-
-namespace objectmodel
+#include <sofa/helper/BackTrace.h>
+namespace sofa::core::objectmodel
 {
 
 /// Constructor
 DDGNode::DDGNode()
-    : inputs(initLink("inputs", "Links to inputs Data"))
-    , outputs(initLink("outputs", "Links to outputs Data"))
 {
 }
 
 DDGNode::~DDGNode()
 {
-    for(DDGLinkIterator it=inputs.begin(); it!=inputs.end(); ++it)
-        (*it)->doDelOutput(this);
-    for(DDGLinkIterator it=outputs.begin(); it!=outputs.end(); ++it)
-        (*it)->doDelInput(this);
-}
-
-template<>
-TClass<DDGNode,void>::TClass()
-{
-    namespaceName = sofa::helper::NameDecoder::getNamespaceName<DDGNode>();
-    className = sofa::helper::NameDecoder::getClassName<DDGNode>();
-    templateName = sofa::helper::NameDecoder::getTemplateName<DDGNode>();
-    shortName = sofa::helper::NameDecoder::getShortName<DDGNode>();
+    for(auto it : inputs)
+    {
+        it->doDelOutput(this);
+    }
+    for(auto it : outputs)
+    {
+        it->doDelInput(this);
+    }
 }
 
 void DDGNode::setDirtyValue()
@@ -94,18 +79,23 @@ void DDGNode::cleanDirty()
 
 void DDGNode::notifyEndEdit()
 {
-    for(DDGLinkIterator it=outputs.begin(), itend=outputs.end(); it != itend; ++it)
-        (*it)->notifyEndEdit();
+    for(auto it : outputs)
+        it->notifyEndEdit();
 }
 
 void DDGNode::cleanDirtyOutputsOfInputs()
 {
-    for(DDGLinkIterator it=inputs.begin(), itend=inputs.end(); it != itend; ++it)
-        (*it)->dirtyFlags.dirtyOutputs = false;
+    for(auto it : inputs)
+        it->dirtyFlags.dirtyOutputs = false;
 }
 
 void DDGNode::addInput(DDGNode* n)
 {
+    if(std::find(inputs.begin(), inputs.end(), n) != inputs.end())
+    {
+        assert(false && "trying to add a DDGNode that is already in the input set.");
+        return;
+    }
     doAddInput(n);
     n->doAddOutput(this);
     setDirtyValue();
@@ -113,12 +103,21 @@ void DDGNode::addInput(DDGNode* n)
 
 void DDGNode::delInput(DDGNode* n)
 {
+    /// It is not allowed to remove an entry that is not in the set.
+    assert(std::find(inputs.begin(), inputs.end(), n) != inputs.end());
+
     doDelInput(n);
     n->doDelOutput(this);
 }
 
 void DDGNode::addOutput(DDGNode* n)
 {
+    if(std::find(outputs.begin(), outputs.end(), n) != outputs.end())
+    {
+        assert(false && "trying to add a DDGNode that is already in the output set.");
+        return;
+    }
+
     doAddOutput(n);
     n->doAddInput(this);
     n->setDirtyValue();
@@ -126,97 +125,50 @@ void DDGNode::addOutput(DDGNode* n)
 
 void DDGNode::delOutput(DDGNode* n)
 {
+    /// It is not allowed to remove an entry that is not in the set.
+    assert(std::find(outputs.begin(), outputs.end(), n) != outputs.end());
+
     doDelOutput(n);
     n->doDelInput(this);
 }
 
 const DDGNode::DDGLinkContainer& DDGNode::getInputs()
 {
-    return inputs.getValue();
+    return inputs;
 }
 
 const DDGNode::DDGLinkContainer& DDGNode::getOutputs()
 {
-    return outputs.getValue();
+    return outputs;
 }
 
-sofa::core::objectmodel::Base* LinkTraitsPtrCasts<DDGNode>::getBase(sofa::core::objectmodel::DDGNode* n)
+void DDGNode::updateIfDirty() const
 {
-    if (!n) return nullptr;
-    return n->getOwner();
-    //sofa::core::objectmodel::BaseData* d = dynamic_cast<sofa::core::objectmodel::BaseData*>(n);
-    //if (d) return d->getOwner();
-    //return dynamic_cast<sofa::core::objectmodel::Base*>(n);
+    if (isDirty())
+    {
+        const_cast <DDGNode*> (this)->update();
+    }
 }
 
-sofa::core::objectmodel::BaseData* LinkTraitsPtrCasts<DDGNode>::getData(sofa::core::objectmodel::DDGNode* n)
+void DDGNode::doAddInput(DDGNode* n)
 {
-    if (!n) return nullptr;
-    return n->getData();
-    //return dynamic_cast<sofa::core::objectmodel::BaseData*>(n);
+    inputs.push_back(n);
 }
 
-bool DDGNode::findDataLinkDest(DDGNode*& ptr, const std::string& path, const BaseLink* link)
+void DDGNode::doDelInput(DDGNode* n)
 {
-    std::string pathStr, dataStr(" "); // non-empty data to specify that a data name is optionnal for DDGNode (as it can be a DataEngine)
-    if (link)
-    {
-        if (!link->parseString(path, &pathStr, &dataStr))
-            return false;
-    }
-    else
-    {
-        if (!BaseLink::ParseString(path, &pathStr, &dataStr, this->getOwner()))
-            return false;
-    }
-    bool self = (pathStr.empty() || pathStr == "[]");
-    if (dataStr == "") // no Data -> we look for a DataEngine
-    {
-        if (self)
-        {
-            ptr = this;
-            return true;
-        }
-        else
-        {
-            Base* owner = this->getOwner();
-            DataEngine* obj = nullptr;
-            if (!owner)
-                return false;
-            if (!owner->findLinkDest(obj, path, link))
-                return false;
-            ptr = obj;
-            return true;
-        }
-    }
-    Base* owner = this->getOwner();
-    if (!owner)
-        return false;
-    if (self)
-    {
-        ptr = owner->findData(dataStr);
-        return (ptr != nullptr);
-    }
-    else
-    {
-        Base* obj = nullptr;
-        if (!owner->findLinkDest(obj, BaseLink::CreateString(pathStr), link))
-            return false;
-        if (!obj)
-            return false;
-        ptr = obj->findData(dataStr);
-        return (ptr != nullptr);
-    }
+    inputs.erase(std::remove(inputs.begin(), inputs.end(), n));
 }
 
-void DDGNode::addLink(BaseLink* /*l*/)
+void DDGNode::doAddOutput(DDGNode* n)
 {
-    // the inputs and outputs links in DDGNode is manually added
-    // once the link vectors are constructed in Base or BaseData
+    outputs.push_back(n);
 }
 
-} // namespace objectmodel
+void DDGNode::doDelOutput(DDGNode* n)
+{
+    outputs.erase(std::remove(outputs.begin(), outputs.end(), n));
+}
 
-} // namespace core
 
-} // namespace sofa
+} /// namespace sofa::core::objectmodel

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGNode.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGNode.h
@@ -19,114 +19,38 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_CORE_OBJECTMODEL_DDGNODE_H
-#define SOFA_CORE_OBJECTMODEL_DDGNODE_H
+#pragma once
 
+#include <sofa/helper/stable_vector.h>
 #include <sofa/core/core.h>
-#include <sofa/core/objectmodel/Link.h>
-#include <sofa/core/objectmodel/BaseClass.h>
-#include <sofa/helper/NameDecoder.h>
-#include <list>
 
-namespace sofa
+namespace sofa::core
+{
+    class ExecParams;
+}
+
+namespace sofa::core::objectmodel
 {
 
-namespace core
-{
-
-namespace objectmodel
-{
-
-class Base;
-class BaseData;
 class DDGNode;
-class BaseObjectDescription;
-
-template<>
-class LinkTraitsPtrCasts<DDGNode>
-{
-public:
-    static sofa::core::objectmodel::Base* getBase(sofa::core::objectmodel::DDGNode* n);
-    static sofa::core::objectmodel::BaseData* getData(sofa::core::objectmodel::DDGNode* n);
-};
 
 /**
- *  \brief Abstract base to manage data dependencies. BaseData and DataEngine inherites from this class
- *
+ *  \brief A DDGNode is a vertex in the data dependencies graph.
+ * The data dependency graph is used to update the data when
+ * some of other changes and it is at the root of the implementation
+ * of the data update mecanisme as well as DataEngines.
  */
 class SOFA_CORE_API DDGNode
 {
 public:
-
-    typedef MultiLink<DDGNode, DDGNode, BaseLink::FLAG_DOUBLELINK|BaseLink::FLAG_DATALINK> DDGLink;
-    typedef DDGLink::Container DDGLinkContainer;
-    typedef DDGLink::const_iterator DDGLinkIterator;
+    typedef sofa::helper::stable_vector<DDGNode*> DDGLinkContainer;
+    typedef DDGLinkContainer::const_iterator DDGLinkIterator;
 
     /// Constructor
     DDGNode();
 
     /// Destructor. Automatically remove remaining links
     virtual ~DDGNode();
-
-    /// @name Class reflection system
-    /// @{
-    typedef TClass<DDGNode> MyClass;
-    static const sofa::core::objectmodel::BaseClass* GetClass() { return MyClass::get(); }
-    virtual const BaseClass* getClass() const
-    { return GetClass(); }
-
-    template<class T>
-    static void dynamicCast(T*& ptr, Base* /*b*/)
-    {
-        ptr = nullptr; // DDGNode does not derive from Base
-    }
-
-    /// Helper method to get the type name of a type derived from this class
-    ///
-    /// This method should be used as follow :
-    /// \code  T* ptr = nullptr; std::string type = T::typeName(ptr); \endcode
-    /// This way derived classes can redefine the typeName method
-    template<class T>
-    static std::string typeName(const T* ptr= nullptr)
-    {
-        return BaseClass::defaultTypeName(ptr);
-    }
-
-    /// Helper method to get the class name of a type derived from this class
-    ///
-    /// This method should be used as follow :
-    /// \code  T* ptr = nullptr; std::string type = T::className(ptr); \endcode
-    /// This way derived classes can redefine the className method
-    template<class T>
-    static std::string className(const T* ptr= nullptr)
-    {
-        SOFA_UNUSED(ptr);
-        return sofa::helper::NameDecoder::getClassName<T>();
-    }
-
-    /// Helper method to get the namespace name of a type derived from this class
-    ///
-    /// This method should be used as follow :
-    /// \code  T* ptr = nullptr; std::string type = T::namespaceName(ptr); \endcode
-    /// This way derived classes can redefine the namespaceName method
-    template<class T>
-    static std::string namespaceName(const T* ptr= nullptr)
-    {
-        SOFA_UNUSED(ptr);
-        return sofa::helper::NameDecoder::getNamespaceName<T>();
-    }
-
-    /// Helper method to get the template name of a type derived from this class
-    ///
-    /// This method should be used as follow :
-    /// \code  T* ptr = nullptr; std::string type = T::templateName(ptr); \endcode
-    /// This way derived classes can redefine the templateName method
-    template<class T>
-    static std::string templateName(const T* ptr= nullptr)
-    {
-        SOFA_UNUSED(ptr);
-        return sofa::helper::NameDecoder::getTemplateName<T>();
-    }
 
     /// Add a new input to this node
     void addInput(DDGNode* n);
@@ -150,6 +74,7 @@ public:
     virtual void update() = 0;
 
     /// Returns true if the DDGNode needs to be updated
+    [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
     bool isDirty(const core::ExecParams*) const { return isDirty(); }
     bool isDirty() const { return dirtyFlags.dirtyValue; }
 
@@ -176,56 +101,19 @@ public:
     /// Utility method to call update if necessary. This method should be called before reading of writing the value of this node.
     [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
     void updateIfDirty(const core::ExecParams*) const { updateIfDirty(); }
-    void updateIfDirty() const
-    {
-        if (isDirty())
-        {
-            const_cast <DDGNode*> (this)->update();
-        }
-    }
-
-    virtual const std::string& getName() const = 0;
-
-    virtual Base* getOwner() const = 0;
-
-    virtual BaseData* getData() const = 0;
-
-    virtual bool findDataLinkDest(DDGNode*& ptr, const std::string& path, const BaseLink* link);
-
-    void addLink(BaseLink* l);
+    void updateIfDirty() const;
 
 protected:
+    DDGLinkContainer inputs;
+    DDGLinkContainer outputs;
 
-    BaseLink::InitLink<DDGNode>
-    initLink(const char* name, const char* help)
-    {
-        return BaseLink::InitLink<DDGNode>(this, name, help);
-    }
-
-    DDGLink inputs;
-    DDGLink outputs;
-
-    virtual void doAddInput(DDGNode* n)
-    {
-        inputs.add(n);
-    }
-
-    virtual void doDelInput(DDGNode* n)
-    {
-        inputs.remove(n);
-    }
-
-    virtual void doAddOutput(DDGNode* n)
-    {
-        outputs.add(n);
-    }
-
-    virtual void doDelOutput(DDGNode* n)
-    {
-        outputs.remove(n);
-    }
+    virtual void doAddInput(DDGNode* n);
+    virtual void doDelInput(DDGNode* n);
+    virtual void doAddOutput(DDGNode* n);
+    virtual void doDelOutput(DDGNode* n);
 
     /// the dirtyOutputs flags of all the inputs will be set to false
+    [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
     void cleanDirtyOutputsOfInputs(const core::ExecParams*) { cleanDirtyOutputsOfInputs(); }
     void cleanDirtyOutputsOfInputs();
 
@@ -233,18 +121,11 @@ private:
 
     struct DirtyFlags
     {
-        DirtyFlags() : dirtyValue(false), dirtyOutputs(false) {}
-
-        bool dirtyValue;
-        bool dirtyOutputs;
+        bool dirtyValue {false};
+        bool dirtyOutputs {false};
     };
     DirtyFlags dirtyFlags;
 };
 
-} // namespace objectmodel
+} // namespace sofa::core::objectmodel
 
-} // namespace core
-
-} // namespace sofa
-
-#endif

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
@@ -46,9 +46,7 @@ public:
     /// @{
     typedef TClass<TData<T>,BaseData> MyClass;
     static const sofa::core::objectmodel::BaseClass* GetClass() { return MyClass::get(); }
-    const BaseClass* getClass() const override
-    { return GetClass(); }
-
+    const BaseClass* getClass() const { return GetClass(); }
     static std::string templateName(const TData<T>* = nullptr)
     {
         T* ptr = nullptr;
@@ -415,35 +413,30 @@ public:
     }
 
     [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
-
     inline void endEdit(const core::ExecParams*)
     {
         endEdit();
     }
 
     [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
-
     inline T* beginWriteOnly(const core::ExecParams*)
     {
         return beginWriteOnly();
     }
 
     [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
-
     inline T* beginEdit(const core::ExecParams*)
     {
         return beginEdit();
     }
 
     [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
-
     inline void setValue(const core::ExecParams*, const T& value)
     {
         setValue(value);
     }
 
     [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
-
     inline const T& getValue(const core::ExecParams*) const
     {
         return getValue();

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataCallback.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataCallback.cpp
@@ -60,22 +60,6 @@ void DataCallback::notifyEndEdit()
     }
 }
 
-const std::string& DataCallback::getName() const
-{
-    static std::string s="";
-    return s;
-}
-
-sofa::core::objectmodel::Base* DataCallback::getOwner() const
-{
-    return nullptr;
-}
-
-sofa::core::objectmodel::BaseData* DataCallback::getData() const
-{
-    return nullptr;
-}
-
 void DataCallback::update()
 {
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataCallback.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataCallback.h
@@ -79,9 +79,6 @@ public:
     void notifyEndEdit() override ;
 
     void update() override;
-    const std::string& getName() const override ;
-    Base* getOwner() const override ;
-    BaseData* getData() const override ;
 
 private:
     bool m_updating {false};


### PR DESCRIPTION
This is the the third step of my LockOut refactoring effort for Sofa. In PR#1283 we have refactored the reflection system. We can now clean the DDGNode to cut the un-needed dependencies. 
DDGNode needed to be part of reflection system because it was storing its inputs and ouputs with Links. It is unclear what the link data structure was needed for and storing the input and output with a more classical data structure (a stable_vector) remove the needs to have DDNode be part of the reflection system...so remove a lot of un-needed code. 

Exemple of needed but in face un-needed code that are now removed:
```cpp
        /// This method is needed by DDGNode
        const std::string& getName() const override
        {
            static const std::string emptyName ="";
            return emptyName;
        }
        /// This method is needed by DDGNode
        objectmodel::Base* getOwner() const override { return nullptr; }
        /// This method is needed by DDGNode
        objectmodel::BaseData* getData() const override { return nullptr; }
```
 
Some code was added in BaseData. This is because these code was in-herited from DDGNode and are now not provided anymore. The code cannot be removed because BaseData is still  used in Links and thus, still required to implement the reflection system...removing that is for an incoming PR. 




______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
