### PR TITLE
[SofaKernel] Add DataTypeInfo for BoundingBox

### DIFF
--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BoundingBox.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BoundingBox.h
@@ -282,7 +282,7 @@ struct BoundingBoxTypeInfo
     };  ///< 1 if copying the data can be done with a memcpy
     enum
     {
-        SimpleLayout = 0
+        SimpleLayout = 1
     };  ///< 1 if the layout in memory is simply N values of the same base type
     enum
     {

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BoundingBox.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BoundingBox.h
@@ -256,6 +256,122 @@ struct DataTypeName<BoundingBox>
   static const char *name() { return "BoundingBox"; }
 };
 
+struct BoundingBoxTypeInfo
+{
+    typedef BoundingBox DataType;
+    typedef Vector3 BaseType;
+    typedef DataTypeInfo<Vec3d> BaseTypeInfo;
+    typedef typename BaseTypeInfo::ValueType ValueType;
+
+    enum
+    {
+        ValidInfo = BaseTypeInfo::ValidInfo
+    };  ///< 1 if this type has valid infos
+    enum
+    {
+        FixedSize = 1
+    };  ///< 1 if this type has a fixed size  -> always 1 single pair of vec3
+    enum
+    {
+        ZeroConstructor = 0
+    };  ///< 1 if the constructor is equivalent to setting memory to 0
+    /// -> I don't think so, bbox are initialized with +inf / -inf usually
+    enum
+    {
+        SimpleCopy = 1
+    };  ///< 1 if copying the data can be done with a memcpy
+    enum
+    {
+        SimpleLayout = 0
+    };  ///< 1 if the layout in memory is simply N values of the same base type
+    enum
+    {
+        Integer = 0
+    };  ///< 1 if this type uses integer values
+    enum
+    {
+        Scalar = 1
+    };  ///< 1 if this type uses scalar values
+    enum
+    {
+        Text = 0
+    };  ///< 1 if this type uses text values
+    enum
+    {
+        CopyOnWrite = 1
+    };  ///< 1 if this type uses copy-on-write -> it seems to be THE important
+    ///< option not to perform too many copies
+    enum
+    {
+        Container = 1
+    };  ///< 1 if this type is a container
+
+    enum
+    {
+        Size = 2
+    };  ///< largest known fixed size for this type, as returned by size()
+
+    static size_t size() { return 3; } // supposed to be the total number of elements. Ends up being the number of elements in the 2nd dimension
+    static size_t byteSize() { return sizeof (ValueType); }  // Size of the smalest single element in the container: BoundingBox uses Vec3d internally, so double
+
+    static size_t size(const DataType & /*data*/) { return 2 * BaseTypeInfo::size(); } // supposed to be the nb of elements in the 1st dimension. Ends up being the total number of elems.
+
+    static bool setSize(DataType & /*data*/, size_t /*size*/) { return false; } // FixedArray -> ignore
+
+    template <typename T>
+    static void getValue(const DataType & data, size_t index,
+                         T & value) /// since TypeInfos abstract all containers as 1D arrays, T here is of ValueType
+    {
+        value = ((ValueType*)&data)[index];
+    }
+
+    template <typename T>
+    static void setValue(DataType & data, size_t index,
+                         const T & value)
+    {
+        ((ValueType*)&data)[index] = value;
+    }
+
+    static double getScalarValue (const void* data, size_t index)
+    {
+        return ((ValueType*)&data)[index];
+    }
+
+    static double setScalarValue (const void* data, size_t index, double value)
+    {
+        ((ValueType*)&data)[index] = value;
+    }
+
+
+    static void getValueString(const DataType &data, size_t index,
+                               std::string &value)
+    {
+        if (index != 0) return;
+        std::ostringstream o;
+        o << data;
+        value = o.str();
+    }
+
+    static void setValueString(DataType &data, size_t index,
+                               const std::string &value)
+    {
+        if (index != 0) return;
+        std::istringstream i(value);
+        i >> data;
+    }
+
+    static const void *getValuePtr(const DataType & bbox) { return (const void*)(&bbox); }
+
+    static void *getValuePtr(DataType &bbox) { return (void*)(&bbox); }
+};
+
+template <>
+struct DataTypeInfo<BoundingBox> : public BoundingBoxTypeInfo
+{
+    static std::string name() { return "BoundingBox"; }
+};
+
+
 }
 }
 

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BoundingBox.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BoundingBox.h
@@ -337,7 +337,7 @@ struct BoundingBoxTypeInfo
         return ((ValueType*)&data)[index];
     }
 
-    static double setScalarValue (const void* data, size_t index, double value)
+    static void setScalarValue (const void* data, size_t index, double value)
     {
         ((ValueType*)&data)[index] = value;
     }


### PR DESCRIPTION
Hey dear reviewers... I'd like you to pay close attention to the `size()` and `size(const DataType & /*data*/)` functions... To me both the documentation in DataTypeInfo.h is incorrect

Depending on your answers correct the doc in DataTypeInfo.h in this PR

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
