### PR TITLE
[SofaKernel] Fixes a bug where the camera was not moving with the Qt viewer

### DIFF
--- a/SofaKernel/modules/SofaBaseVisual/BaseCamera.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/BaseCamera.cpp
@@ -655,16 +655,6 @@ void BaseCamera::computeZ()
 {
     if (p_computeZClip.getValue())
     {
-        double zNear = 1e10;
-        double zFar = -1e10;
-
-        const Vec3 & minBBox = p_minBBox.getValue();
-        const Vec3 & maxBBox = p_maxBBox.getValue();
-
-        //get the same zFar and zNear calculations as QGLViewer
-        sceneCenter = (minBBox + maxBBox)*0.5;
-        sceneRadius = 0.5*(maxBBox - minBBox).norm();
-
         //modelview transform
         defaulttype::SolidTypes<SReal>::Transform world_H_cam(p_position.getValue(), this->getOrientation());
 
@@ -674,9 +664,8 @@ void BaseCamera::computeZ()
         double zClippingCoeff = 5;
         double zNearCoeff = 0.01;
 
-
-        zNear = distanceCamToCenter - sceneRadius;
-        zFar = (zNear + 2 * sceneRadius) * 1.1;
+        double zNear = distanceCamToCenter - sceneRadius;
+        double zFar = (zNear + 2 * sceneRadius) * 1.1;
         zNear = zNear * zNearCoeff;
 
         double zMin = zNearCoeff * zClippingCoeff * sceneRadius;

--- a/SofaKernel/modules/SofaBaseVisual/BaseCamera.h
+++ b/SofaKernel/modules/SofaBaseVisual/BaseCamera.h
@@ -183,6 +183,10 @@ public:
     {
         p_minBBox.setValue(min);
         p_maxBBox.setValue(max);
+
+        sceneCenter = (min + max)*0.5;
+        sceneRadius = 0.5*(max - min).norm();
+
         computeZ();
     }
 

--- a/applications/sofa/gui/qt/viewer/qt/QtViewer.cpp
+++ b/applications/sofa/gui/qt/viewer/qt/QtViewer.cpp
@@ -1013,7 +1013,7 @@ void QtViewer::calcProjection(int width, int height)
     if (!currentCamera)
         return;
 
-    if (groot && (!groot->f_bbox.getValue().isValid() || m_bShowAxis))
+    if (groot && (groot->f_bbox.getValue().isValid() || m_bShowAxis))
     {
         vparams->sceneBBox() = groot->f_bbox.getValue();
         currentCamera->setBoundingBox(vparams->sceneBBox().minBBox(), vparams->sceneBBox().maxBBox());

--- a/examples/Demos/caduceus.scn
+++ b/examples/Demos/caduceus.scn
@@ -12,7 +12,7 @@
 
     <DefaultContactManager name="Response" response="FrictionContact" />
 
-    <Camera position="0 30 90" lookAt="0 30 0"/>
+    <InteractiveCamera position="0 30 90" lookAt="0 30 0"/>
     <LightManager />
     <SpotLight name="light1" color="1 1 1" position="0 80 25" direction="0 -1 -0.8" cutoff="30" exponent="1" />
     <SpotLight name="light2" color="1 1 1" position="0 40 100" direction="0 0 -1" cutoff="30" exponent="1" />


### PR DESCRIPTION
The `BaseCamera` is computing the scene center point and scene radius based on the current bounding box. The `InteractiveCamera` is using these information to compute the zoom/translation speed when navigating in the scene with mouse events. 

Since the `BaseCamera` was computing the scene center point and radius only when `BaseCamera::p_computeZClip` was true, when manually giving the z-clip values, the interaction was not working at all (`sceneCenter` and `sceneRadius` were 0, hence the zoom/translation speed were 0).

This was only visible when using the `QtViewer` since the `QglViewer` is using its own internal camera and is ignoring the cameras added to the scene.

This PR also fixes the caduceus scene as it was using a `Camera` instead of `InteractiveCamera`, which isn't listening to mouse events at all, hence navigating with the mouse wasn't possible with the QtViewer. A little bit problematic when it is the default scene of runSofa.
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
