### PR TITLE
[SofaExporter] FIX Compilation of SofaExporter_test

### DIFF
--- a/modules/SofaExporter/SofaExporter_test/CMakeLists.txt
+++ b/modules/SofaExporter/SofaExporter_test/CMakeLists.txt
@@ -16,7 +16,7 @@ set(SOURCE_FILES
     )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaGTestMain SofaExporter SofaGeneralImplicitOdeSolver SofaBaseMechanics SofaBaseLinearSolver SofaImplicitOdeSolver)
+target_link_libraries(${PROJECT_NAME} PUBLIC SofaGTestMain SofaExporter SofaGeneralImplicitOdeSolver SofaBaseMechanics SofaBaseLinearSolver SofaImplicitOdeSolver SofaBase SofaCommon SofaGeneral)
 target_compile_definitions(${PROJECT_NAME}
     PRIVATE "SOFAEXPORTER_TESTFILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/files/\""
     PRIVATE "SOFAEXPORTER_BUILD_DIR=\"${CMAKE_BINARY_DIR}/\""


### PR DESCRIPTION
missing libs in target_link_libraries for SofaBase, SofaCommon and SofaGeneral after "modularization"






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
