### PR TITLE
[SofaKernel] Filerepository gettemppath

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
@@ -345,6 +345,37 @@ std::string FileRepository::relativeToPath(std::string path, std::string refPath
     return path;
 }
 
+// Zykl.io begin
+std::string FileRepository::getTempPath() const
+{
+    std::string retval;
+
+#ifdef _WIN32
+    TCHAR wbuf [255];
+    GetTempPath (255, wbuf);
+
+    // conversion
+    char buf[255] = {0};
+    if ( !WideCharToMultiByte(CP_UTF8, 0, wbuf, -1, buf, 255, 0, 0) ) {
+        msg_error(this) << "widechar to multibyte encoding failed";
+    }
+    retval = std::string(buf);
+#else
+
+#ifdef __linux__
+    char const *folder = getenv("TMPDIR");
+    if (folder == 0)
+        folder = "/tmp/";
+    retval = std::string(folder);
+
+#else
+    msg_error(this) << "FileRepository::getTempPath() NOT DEFINED ON THIS PLATFORM\n";
+#endif
+
+#endif
+}
+// Zykl.io end
+
 } // namespace system
 
 } // namespace helper

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
@@ -347,6 +347,7 @@ std::string FileRepository::relativeToPath(std::string path, std::string refPath
 
 const std::string FileRepository::getTempPath() const
 {
+    // TODO: replace std::filesystem when all compilers support it. (and not std::experimental::filesystem)
     return boost::filesystem::temp_directory_path().string();
 }
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
@@ -21,6 +21,19 @@
 ******************************************************************************/
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/system/SetDirectory.h>
+#include <sofa/helper/logging/Messaging.h>
+#include <sofa/helper/Utils.h>
+#include <sofa/helper/system/FileSystem.h>
+using sofa::helper::system::FileSystem;
+
+#include <boost/filesystem.hpp>
+
+#include <cstring>
+#include <cstdlib>
+#include <iostream>
+#include <algorithm>
+#include <sstream>
+#include <filesystem>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -30,18 +43,6 @@
 #else
 #include <unistd.h>
 #endif
-
-#include <boost/filesystem.hpp>
-
-#include <cstring>
-#include <cstdlib>
-#include <iostream>
-#include <algorithm>
-#include <sstream>
-#include <sofa/helper/logging/Messaging.h>
-#include <sofa/helper/Utils.h>
-#include <sofa/helper/system/FileSystem.h>
-using sofa::helper::system::FileSystem;
 
 #ifdef WIN32
 #define ON_WIN32 true
@@ -345,36 +346,10 @@ std::string FileRepository::relativeToPath(std::string path, std::string refPath
     return path;
 }
 
-// Zykl.io begin
-std::string FileRepository::getTempPath() const
+const std::string FileRepository::getTempPath() const
 {
-    std::string retval;
-
-#ifdef _WIN32
-    TCHAR wbuf [255];
-    GetTempPath (255, wbuf);
-
-    // conversion
-    char buf[255] = {0};
-    if ( !WideCharToMultiByte(CP_UTF8, 0, wbuf, -1, buf, 255, 0, 0) ) {
-        msg_error("FileRepository") << "widechar to multibyte encoding failed";
-    }
-    retval = std::string(buf);
-#else
-
-#ifdef __linux__
-    char const *folder = getenv("TMPDIR");
-    if (folder == 0)
-        folder = "/tmp/";
-    retval = std::string(folder);
-
-#else
-    msg_error("FileRepository") << "FileRepository::getTempPath() not supported on this platform!";
-#endif
-
-#endif
+    return std::filesystem::temp_directory_path().string();
 }
-// Zykl.io end
 
 } // namespace system
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
@@ -357,7 +357,7 @@ std::string FileRepository::getTempPath() const
     // conversion
     char buf[255] = {0};
     if ( !WideCharToMultiByte(CP_UTF8, 0, wbuf, -1, buf, 255, 0, 0) ) {
-        msg_error(this) << "widechar to multibyte encoding failed";
+        msg_error("FileRepository") << "widechar to multibyte encoding failed";
     }
     retval = std::string(buf);
 #else
@@ -369,7 +369,7 @@ std::string FileRepository::getTempPath() const
     retval = std::string(folder);
 
 #else
-    msg_error(this) << "FileRepository::getTempPath() NOT DEFINED ON THIS PLATFORM\n";
+    msg_error("FileRepository") << "FileRepository::getTempPath() not supported on this platform!";
 #endif
 
 #endif

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
@@ -21,19 +21,6 @@
 ******************************************************************************/
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/system/SetDirectory.h>
-#include <sofa/helper/logging/Messaging.h>
-#include <sofa/helper/Utils.h>
-#include <sofa/helper/system/FileSystem.h>
-using sofa::helper::system::FileSystem;
-
-#include <boost/filesystem.hpp>
-
-#include <cstring>
-#include <cstdlib>
-#include <iostream>
-#include <algorithm>
-#include <sstream>
-#include <filesystem>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -43,6 +30,18 @@ using sofa::helper::system::FileSystem;
 #else
 #include <unistd.h>
 #endif
+
+#include <boost/filesystem.hpp>
+
+#include <cstring>
+#include <cstdlib>
+#include <iostream>
+#include <algorithm>
+#include <sstream>
+#include <sofa/helper/logging/Messaging.h>
+#include <sofa/helper/Utils.h>
+#include <sofa/helper/system/FileSystem.h>
+using sofa::helper::system::FileSystem;
 
 #ifdef WIN32
 #define ON_WIN32 true
@@ -348,7 +347,7 @@ std::string FileRepository::relativeToPath(std::string path, std::string refPath
 
 const std::string FileRepository::getTempPath() const
 {
-    return std::filesystem::temp_directory_path().string();
+    return boost::filesystem::temp_directory_path().string();
 }
 
 } // namespace system

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.h
@@ -143,6 +143,10 @@ public:
 
     void displayPaths() {std::cout<<(*this)<<std::endl;}
 
+    // Zykl.io begin
+    std::string getTempPath() const;
+    // Zykl.io end
+
 protected:
 
     /// A protocol like http: or file: which will bypass the file search if found in the filename of the findFile* functions that directly returns the path as if the function succeeded

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.h
@@ -143,9 +143,7 @@ public:
 
     void displayPaths() {std::cout<<(*this)<<std::endl;}
 
-    // Zykl.io begin
-    std::string getTempPath() const;
-    // Zykl.io end
+    const std::string getTempPath() const;
 
 protected:
 


### PR DESCRIPTION
Adds a helper function to the FileRepository class that returns a platform-specific path to a temporary directory.
Windows and Linux platforms supported. 
______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
