### PR TITLE
[all] Replace usage of sleep functions for the std one

### DIFF
--- a/SofaKernel/modules/SofaHelper/SofaHelper_test/system/FileMonitor_test.cpp
+++ b/SofaKernel/modules/SofaHelper/SofaHelper_test/system/FileMonitor_test.cpp
@@ -22,6 +22,8 @@
  #include <gtest/gtest.h>
 #include <exception>
 #include <algorithm>
+#include <thread>
+#include <chrono>
 
 #include <vector>
 using std::vector ;
@@ -45,6 +47,7 @@ using sofa::helper::system::FileMonitor ;
 #include <sofa/helper/system/thread/CTime.h>
 using sofa::helper::system::thread::CTime ;
 using sofa::helper::system::thread::ctime_t ;
+
 
 #ifdef WIN32
 #include <windows.h>
@@ -75,7 +78,7 @@ void waitUntilFileExists(const std::string& filename, double timeout)
     ctime_t time = CTime::getTime() ;
     while( !FileSystem::exists(filename)
            && CTime::toSecond(CTime::getTime()-time) < timeout ){
-        CTime::sleep(0.1) ;
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 }
 
@@ -83,13 +86,13 @@ void waitABit()
 {
     // on windows we use file date, which resoution is assumed (by us) to be below this value in ms
 #ifdef WIN32
-    Sleep(100);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
 #endif
 #ifdef __APPLE__
-    // sleep(1);
+    // std::this_thread::sleep_for(1);
 #endif
 #ifdef __linux__
-    //  sleep(1);
+    //  std::this_thread::sleep_for(1);
 #endif
 }
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileMonitor_linux.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileMonitor_linux.cpp
@@ -33,6 +33,8 @@
 //////////////////// C++ Header ///////////////////////////////////////////////
 #include <algorithm>
 #include <iostream>
+#include <chrono>
+#include <thread>
 #include <vector>
 #include <string>
 #include <map>
@@ -232,7 +234,7 @@ int FileMonitor::updates(int timeout)
         // its tasks. The 10000 is a value that work on my system :(
         // Arg non pitié je peux pas laisser ça en l'état c'est trop moche.
         // Promis demain je trouve un meilleur solution (ou pas).
-        usleep(30000);
+        std::this_thread::sleep_for(std::chrono::milliseconds(30));
         int length = 0 ;
         char buffer[BUF_LEN];
         int buffer_i = 0 ;

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileMonitor_macosx.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileMonitor_macosx.cpp
@@ -48,6 +48,8 @@ using namespace std ;
 
 #include <CoreServices/CoreServices.h>
 #include <iostream>
+#include <chrono>
+#include <thread>
 
 namespace sofa
 {
@@ -230,7 +232,8 @@ int FileMonitor::updates(int timeout)
                 keep_going = 0; // we're done
             }
         }
-        if (keep_going) usleep(10000);
+        if (keep_going)
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     while (keep_going);
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileMonitor_windows.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileMonitor_windows.cpp
@@ -34,6 +34,8 @@ using sofa::helper::system::thread::ctime_t ;
 #include <list>
 #include <string>
 #include <map>
+#include <chrono>
+#include <thread>
 
 //////////////////// Windows Header ///////////////////////////////////////////////
 #include <windows.h>
@@ -170,7 +172,7 @@ int FileMonitor::updates(int timeout)
             }
         }
         if(!hadEvent)
-            CTime::sleep(0.05);
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }
 
     return 0;

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PipeProcess.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PipeProcess.cpp
@@ -221,8 +221,6 @@ bool PipeProcess::executeProcess(const std::string &command,  const std::vector<
                     }
                 }
             }
-            if (!busy)
-                Sleep(0);
         }
         CloseHandle(fds[0][0]);
         CloseHandle(fds[1][0]);

--- a/applications/plugins/ARTrack/extlibs/ARTrackLib/mainTracker.cpp
+++ b/applications/plugins/ARTrack/extlibs/ARTrackLib/mainTracker.cpp
@@ -18,6 +18,8 @@
  */
 
 #include <iostream>
+#include <chrono>
+#include <thread>
 
 #ifndef _WIN32
 #define OS_UNIX  // for Unix (Linux, Irix)
@@ -587,13 +589,9 @@ int dtracklib_send(dtracklib_type* handle, unsigned short cmd, int val){
 		return 0;
 	}
 
-	if(cmd == DTRACKLIB_CMD_CAMERAS_AND_CALC_ON){
-#ifdef OS_UNIX
-		sleep(1);     // some delay (actually only necessary for older DTrack versions...)
-#endif
-#ifdef OS_WIN
-		Sleep(1000);  // some delay (actually only necessary for older DTrack versions...)
-#endif
+        if(cmd == DTRACKLIB_CMD_CAMERAS_AND_CALC_ON)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1000));  // some delay (actually only necessary for older DTrack versions...)
 	}
 
 	set_noerror(handle);

--- a/applications/plugins/Geomagic/src/Geomagic/GeomagicDriver.cpp
+++ b/applications/plugins/Geomagic/src/Geomagic/GeomagicDriver.cpp
@@ -29,6 +29,9 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <Geomagic/GeomagicVisualModel.h>
 
+#include <chrono>
+#include <thread>
+
 namespace sofa::component::controller
 {
     
@@ -334,7 +337,7 @@ void GeomagicDriver::initDevice()
     }
     
     // 2.6- Need to wait several ms for the scheduler to be well launched and retrieving correct device information before updating information on the SOFA side.
-    Sleep(42);        
+    std::this_thread::sleep_for(std::chrono::milliseconds(42));
     updatePosition();
 
     sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);

--- a/applications/plugins/Geomagic/src/Geomagic/GeomagicEmulator.cpp
+++ b/applications/plugins/Geomagic/src/Geomagic/GeomagicEmulator.cpp
@@ -33,6 +33,9 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <Geomagic/GeomagicVisualModel.h>
 
+#include <chrono>
+#include <thread>
+
 namespace sofa
 {
 
@@ -106,7 +109,7 @@ GeomagicEmulatorTask::MemoryAlloc GeomagicEmulatorTask::run()
     if (m_driver->m_terminate == false)
     {
         TaskScheduler::getInstance()->addTask(new GeomagicEmulatorTask(m_driver, &m_driver->_simStepStatus));
-        Sleep(100);
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
     return MemoryAlloc::Dynamic;
@@ -133,7 +136,7 @@ void GeomagicEmulator::clearDevice()
     m_terminate = true;
     while (_simStepStatus.isBusy())
     {
-        Sleep(1);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
     _taskScheduler->stop();
 }
@@ -167,7 +170,7 @@ void GeomagicEmulator::initDevice()
     }
 
     // 2.6- Need to wait several ms for the scheduler to be well launched and retrieving correct device information before updating information on the SOFA side.
-    Sleep(42);
+    std::this_thread::sleep_for(std::chrono::milliseconds(42));
     updatePosition();
 }
 

--- a/applications/plugins/LeapMotion/src/LeapMotionDriver.cpp
+++ b/applications/plugins/LeapMotion/src/LeapMotionDriver.cpp
@@ -25,6 +25,8 @@
 #include <sofa/core/objectmodel/KeypressedEvent.h>
 #include <sofa/core/objectmodel/MouseEvent.h>
 
+#include <chrono>
+#include <thread>
 
 namespace sofa
 {
@@ -87,7 +89,7 @@ void LeapMotionDriver::init()
             for (unsigned int n=0; n<15 && !leapConnected; n++)
             {
                 std::cout << ".";
-                sofa::helper::system::thread::CTime::sleep(0.1);
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
                 leapConnected = getLeapController()->isConnected();
             }
             std::cout << "." << std::endl;

--- a/applications/plugins/Sensable/NewOmniDriver.cpp
+++ b/applications/plugins/Sensable/NewOmniDriver.cpp
@@ -38,6 +38,8 @@
 #include <boost/thread.hpp>
 #endif
 
+#include <thread>
+
 //sensable namespace
 
 using std::cout;
@@ -889,7 +891,7 @@ void NewOmniDriver::onAnimateBeginEvent()
 #ifdef SOFA_HAVE_BOOST
 			boost::thread::yield();
 #else
-			sofa::helper::system::thread::CTime::sleep(0);
+                        std::this_thread::sleep_for(0);
 #endif
 		}
 	}

--- a/applications/plugins/Sensable/NewOmniDriver.cpp
+++ b/applications/plugins/Sensable/NewOmniDriver.cpp
@@ -39,7 +39,7 @@
 #endif
 
 #include <thread>
-
+#include <chrono>
 //sensable namespace
 
 using std::cout;
@@ -891,7 +891,7 @@ void NewOmniDriver::onAnimateBeginEvent()
 #ifdef SOFA_HAVE_BOOST
 			boost::thread::yield();
 #else
-                        std::this_thread::sleep_for(0);
+                        std::this_thread::sleep_for(std::chrono::milliseconds(0));
 #endif
 		}
 	}

--- a/applications/plugins/Sensable/OmniDriver.cpp
+++ b/applications/plugins/Sensable/OmniDriver.cpp
@@ -49,6 +49,8 @@
 #include <boost/thread.hpp>
 #endif
 
+#include <thread>
+
 namespace sofa
 {
 
@@ -494,7 +496,7 @@ void OmniDriver::handleEvent(core::objectmodel::Event *event)
 #ifdef SOFA_HAVE_BOOST
             boost::thread::yield();
 #else
-            sofa::helper::system::thread::CTime::sleep(0);
+            std::this_thread::sleep_for(0);
 #endif
         }
 

--- a/applications/plugins/Sensable/OmniDriver.cpp
+++ b/applications/plugins/Sensable/OmniDriver.cpp
@@ -50,6 +50,7 @@
 #endif
 
 #include <thread>
+#include <chrono>
 
 namespace sofa
 {
@@ -496,7 +497,7 @@ void OmniDriver::handleEvent(core::objectmodel::Event *event)
 #ifdef SOFA_HAVE_BOOST
             boost::thread::yield();
 #else
-            std::this_thread::sleep_for(0);
+            std::this_thread::sleep_for(std::chrono::milliseconds(0));
 #endif
         }
 

--- a/applications/plugins/SensableEmulation/NewOmniDriverEmu.cpp
+++ b/applications/plugins/SensableEmulation/NewOmniDriverEmu.cpp
@@ -44,6 +44,7 @@
 #include <sofa/core/objectmodel/MouseEvent.h>
 //sensable namespace
 #include <pthread.h>
+#include <thread>
 
 
 
@@ -240,8 +241,7 @@ void *hapticSimuExecute( void *ptr )
             timeToSleep = int( (requiredTime - totalTime) - timeCorrection); //  [us]
             if (timeToSleep > 0)
             {
-                usleep(timeToSleep);
-                //std::cout << "Frequency OK, computation time: " << totalTime << std::endl;
+                std::this_thread::sleep_for(std::chrono::microseconds(timeToSleep));
             }
             else
             {
@@ -251,11 +251,8 @@ void *hapticSimuExecute( void *ptr )
         }
         else
         {
-            //std::cout << "Running Asynchro without action" << std::endl;
-            usleep(10000);
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
-
-
     }
 }
 

--- a/applications/plugins/SensableEmulation/OmniDriverEmu.cpp
+++ b/applications/plugins/SensableEmulation/OmniDriverEmu.cpp
@@ -44,6 +44,9 @@
 #include <sofa/core/objectmodel/KeypressedEvent.h>
 #include <sofa/core/objectmodel/KeyreleasedEvent.h>
 
+#include <chrono>
+#include <thread>
+
 #ifndef WIN32
 #  include <pthread.h>
 #else
@@ -301,17 +304,11 @@ void *hapticSimuExecute( void *ptr )
 
             endTime = (double)omniDrv->thTimer->getTime();  //[s]
             totalTime = (endTime - startTime);  // [us]
-            timeToSleep = int( (requiredTime - totalTime) - timeCorrection); //  [us]
+            timeToSleep = int( ((requiredTime - totalTime) - timeCorrection) * timeScale); //  [us]
 
             if (timeToSleep > 0)
             {
-#ifndef WIN32
-                // Microseconds sleep
-                usleep(1000000.0 * timeScale * timeToSleep);
-#else
-                // Milliseconds sleep
-                Sleep(static_cast<DWORD>(1000.0 * timeScale * timeToSleep));
-#endif
+                std::this_thread::sleep_for(std::chrono::seconds(timeToSleep));
             }
             else
             {
@@ -325,11 +322,8 @@ void *hapticSimuExecute( void *ptr )
                 msg_info(omniDrv) << "Running Asynchro without action" ;
                 oneTimeMessage = 1;
             }
-#ifndef WIN32
-            usleep(10000);
-#else
-            Sleep(static_cast<DWORD>(10000));
-#endif
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
     }
 }

--- a/applications/projects/SofaGuiGlut/SimpleGUI.cpp
+++ b/applications/projects/SofaGuiGlut/SimpleGUI.cpp
@@ -37,6 +37,7 @@
 #include <sofa/helper/gl/RAII.h>
 
 #include <sofa/helper/system/thread/CTime.h>
+#include <thread>
 
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/defaulttype/BoundingBox.h>
@@ -198,7 +199,7 @@ void SimpleGUI::glut_idle()
         if (instance->getScene() && instance->getScene()->getContext()->getAnimate())
             instance->step();
         else
-            CTime::sleep(0.01);
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
         instance->animate();
     }
 }

--- a/applications/sofa/gui/headlessRecorder/HeadlessRecorder.cpp
+++ b/applications/sofa/gui/headlessRecorder/HeadlessRecorder.cpp
@@ -24,6 +24,7 @@
 #include <sofa/helper/AdvancedTimer.h>
 
 #include <boost/program_options.hpp>
+#include <thread>
 
 namespace sofa
 {
@@ -346,7 +347,7 @@ int HeadlessRecorder::mainLoop()
         }
         else
         {
-            sofa::helper::system::thread::CTime::sleep(10);
+            std::this_thread::sleep_for(10);
         }
     }
     msg_info("HeadlessRecorder") << "Recording time: " << recordTimeInSeconds << " seconds at: " << fps << " fps.";

--- a/applications/sofa/gui/headlessRecorder/HeadlessRecorder.cpp
+++ b/applications/sofa/gui/headlessRecorder/HeadlessRecorder.cpp
@@ -25,6 +25,7 @@
 
 #include <boost/program_options.hpp>
 #include <thread>
+#include <chrono>
 
 namespace sofa
 {
@@ -347,7 +348,7 @@ int HeadlessRecorder::mainLoop()
         }
         else
         {
-            std::this_thread::sleep_for(10);
+            std::this_thread::sleep_for(std::chrono::seconds(10));
         }
     }
     msg_info("HeadlessRecorder") << "Recording time: " << recordTimeInSeconds << " seconds at: " << fps << " fps.";

--- a/modules/SofaConstraint/ConstraintAnimationLoop.cpp
+++ b/modules/SofaConstraint/ConstraintAnimationLoop.cpp
@@ -39,7 +39,6 @@
 #include <sofa/helper/system/thread/CTime.h>
 #include <sofa/helper/LCPcalc.h>
 
-
 #include <sofa/core/ConstraintParams.h>
 #include <sofa/core/ObjectFactory.h>
 
@@ -52,6 +51,8 @@
 #include <string>
 #include <sstream>
 
+#include <chrono>
+#include <thread>
 
 
 /// Change that to true if you want to print extra message on this component.
@@ -611,7 +612,7 @@ void ConstraintAnimationLoop::step ( const core::ExecParams* params, SReal dt )
             msg_info() << "Total time = " << iterationTimeDiff ;
             int toSleep = (int)floor(dt*1000000-compTimeDiff);
             if (toSleep > 0)
-                usleep(toSleep);
+                std::this_thread::sleep_for(std::chrono::microseconds(toSleep));
             else
                 msg_error() << "Cannot achieve frequency for dt = " << dt ;
             compTime = (SReal)timer->getTime();

--- a/modules/SofaGeneralEngine/SofaGeneralEngine_test/RandomPointDistributionInSurface_test.cpp
+++ b/modules/SofaGeneralEngine/SofaGeneralEngine_test/RandomPointDistributionInSurface_test.cpp
@@ -22,6 +22,7 @@
 
 #include <SofaTest/Sofa_test.h>
 #include <sofa/defaulttype/VecTypes.h>
+#include <thread>
 
 #include <SofaGeneralEngine/RandomPointDistributionInSurface.h>
 using sofa::component::engine::RandomPointDistributionInSurface;
@@ -189,7 +190,7 @@ TYPED_TEST(RandomPointDistributionInSurface_test, seeds)
 
     // true random seeds
     this->generate(vertices, triangles, 0.1, 0, nbPoints, outputPoints1);
-    sofa::helper::system::thread::CTime::sleep(1.1); // wait a bit in order to change seed  
+    std::this_thread::sleep_for(std::chrono::milliseconds(1100));; // wait a bit in order to change seed
     this->generate(vertices, triangles, 0.1, 0, nbPoints, outputPoints2);
     ASSERT_EQ(outputPoints1.size(), nbPoints);
     ASSERT_EQ(outputPoints2.size(), nbPoints);


### PR DESCRIPTION
As the title says it.
Regarding @epernod remark about the 1 ms taken to trigger the sleep function ... this should be discussed, but I prepared this PR before !



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
