### PR TITLE
[SofaKernel] Totally remove the macro CHECK_TOPOLOGY from BaseMeshTopology

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/EdgeSetTopologyContainer.cpp
@@ -154,8 +154,7 @@ void EdgeSetTopologyContainer::reinit()
 
 void EdgeSetTopologyContainer::createEdgeSetArray()
 {
-	if(CHECK_TOPOLOGY)
-        msg_error() << "createEdgeSetArray method must be implemented by an higher level topology.";
+    msg_error() << "createEdgeSetArray method must be implemented by an higher level topology.";
 }
 
 

--- a/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/HexahedronSetTopologyContainer.cpp
@@ -105,8 +105,7 @@ void HexahedronSetTopologyContainer::initTopology()
 
 void HexahedronSetTopologyContainer::createHexahedronSetArray()
 {
-	if (CHECK_TOPOLOGY)
-        msg_error() << "createHexahedronSetArray method must be implemented by a child topology.";
+    msg_error() << "createHexahedronSetArray method must be implemented by a child topology.";
 }
 
 void HexahedronSetTopologyContainer::createEdgeSetArray()

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyContainer.cpp
@@ -92,9 +92,7 @@ void QuadSetTopologyContainer::initTopology()
 
 void QuadSetTopologyContainer::createQuadSetArray()
 {
-	if (CHECK_TOPOLOGY)
-        msg_error() << "createQuadSetArray method must be implemented by a child topology.";
-
+    msg_error() << "createQuadSetArray method must be implemented by a child topology.";
 }
 
 void QuadSetTopologyContainer::createQuadsAroundVertexArray()

--- a/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/QuadSetTopologyModifier.cpp
@@ -358,11 +358,6 @@ void QuadSetTopologyModifier::addPointsProcess(const size_t nPoints)
 
 void QuadSetTopologyModifier::addEdgesProcess(const sofa::helper::vector< Edge > &edges)
 {
-    if(!m_container->hasEdges())
-    {
-        m_container->createEdgeSetArray();
-    }
-
     // start by calling the parent's method.
     EdgeSetTopologyModifier::addEdgesProcess( edges );
 

--- a/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
@@ -101,8 +101,7 @@ void TetrahedronSetTopologyContainer::initTopology()
 
 void TetrahedronSetTopologyContainer::createTetrahedronSetArray()
 {
-	if (CHECK_TOPOLOGY)
-      msg_error() << "createTetrahedronSetArray method must be implemented by a child topology.";
+    msg_error() << "createTetrahedronSetArray method must be implemented by a child topology.";
 }
 
 void TetrahedronSetTopologyContainer::createEdgeSetArray()

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyContainer.cpp
@@ -99,8 +99,7 @@ void TriangleSetTopologyContainer::reinit()
 
 void TriangleSetTopologyContainer::createTriangleSetArray()
 {
-    if (CHECK_TOPOLOGY)
-        msg_error() << "createTriangleSetArray method must be implemented by a child topology.";
+    msg_error() << "createTriangleSetArray method must be implemented by a child topology.";
 }
 
 void TriangleSetTopologyContainer::createTrianglesAroundVertexArray()

--- a/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/TriangleSetTopologyModifier.cpp
@@ -294,11 +294,6 @@ void TriangleSetTopologyModifier::addPointsProcess(const size_t nPoints)
 
 void TriangleSetTopologyModifier::addEdgesProcess(const sofa::helper::vector< Edge > &edges)
 {
-    if(!m_container->hasEdges())
-    {
-        m_container->createEdgeSetArray();
-    }
-
     // start by calling the parent's method.
     EdgeSetTopologyModifier::addEdgesProcess( edges );
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseMeshTopology.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseMeshTopology.h
@@ -26,12 +26,6 @@
 #include <sofa/core/topology/BaseTopologyEngine.h>
 #include <sofa/core/objectmodel/DataFileName.h>
 
-#ifndef NDEBUG
-#define CHECK_TOPOLOGY true
-#else
-#define CHECK_TOPOLOGY false
-#endif
-
 namespace sofa
 {
 

--- a/applications/plugins/ManifoldTopologies/ManifoldEdgeSetTopologyContainer.cpp
+++ b/applications/plugins/ManifoldTopologies/ManifoldEdgeSetTopologyContainer.cpp
@@ -54,23 +54,22 @@ void ManifoldEdgeSetTopologyContainer::init()
     // load edges
     EdgeSetTopologyContainer::init();
 
-    // the edgesAroundVertex is needed to recognize if the edgeSet is manifold
-    createEdgesAroundVertexArray();
-
-    computeConnectedComponent();
-    checkTopology();
+    helper::ReadAccessor< Data< sofa::helper::vector<Edge> > > m_edge = d_edge;
+    if (!m_edge.empty())
+    {
+        computeConnectedComponent();
+        checkTopology();
+    }
 }
 
 void ManifoldEdgeSetTopologyContainer::createEdgesAroundVertexArray()
 {
+    // first clear potential previous buffer
+    clearEdgesAroundVertex();
+
     if(!hasEdges())	//  this method should only be called when edges exist
     {
         createEdgeSetArray();
-    }
-
-    if(hasEdgesAroundVertex())
-    {
-        clearEdgesAroundVertex();
     }
 
     m_edgesAroundVertex.resize( getNbPoints() );


### PR DESCRIPTION
The use of the macro CHECK_TOPOLOGY  has been removed from the code through several PR. This one totally remove it.

Remove duplicate call to createEdgeSetArray from Modifier when adding an edge to the topology. As all topology buffers are init at start, if hasEdges return 0, it means the topology is really empty not that the topology is not init.
This behavior has been set in the PR #967


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
