### PR TITLE
[SofaMiscFem] Fix add computeBBox method to the hyperelasticFEM

### DIFF
--- a/modules/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.h
+++ b/modules/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.h
@@ -211,6 +211,8 @@ public:
 
     void draw(const core::visual::VisualParams* vparams) override;
 
+    void computeBBox(const core::ExecParams* params, bool onlyVisible) override;
+
     Mat<3,3,double> getPhi( int tetrahedronIndex);
 
 

--- a/modules/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.inl
+++ b/modules/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.inl
@@ -734,6 +734,33 @@ void TetrahedronHyperelasticityFEMForceField<DataTypes>::saveMesh( const char *f
 	fclose( file );
 }
 
+
+
+template<class DataTypes>
+void TetrahedronHyperelasticityFEMForceField<DataTypes>::computeBBox(const core::ExecParams*, bool onlyVisible)
+{
+    if( !onlyVisible ) return;
+
+    helper::ReadAccessor<DataVecCoord> x = this->mstate->read(core::VecCoordId::position());
+
+    static const Real max_real = std::numeric_limits<Real>::max();
+    static const Real min_real = std::numeric_limits<Real>::lowest();
+    Real maxBBox[3] = {min_real,min_real,min_real};
+    Real minBBox[3] = {max_real,max_real,max_real};
+    for (size_t i=0; i<x.size(); i++)
+    {
+        for (int c=0; c<3; c++)
+        {
+            if (x[i][c] > maxBBox[c]) maxBBox[c] = (Real)x[i][c];
+            else if (x[i][c] < minBBox[c]) minBBox[c] = (Real)x[i][c];
+        }
+    }
+
+    this->f_bbox.setValue(sofa::defaulttype::TBoundingBox<Real>(minBBox,maxBBox));
+}
+
+
+
 template<class DataTypes>
 void TetrahedronHyperelasticityFEMForceField<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {

--- a/modules/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.inl
+++ b/modules/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.inl
@@ -741,6 +741,8 @@ void TetrahedronHyperelasticityFEMForceField<DataTypes>::computeBBox(const core:
 {
     if( !onlyVisible ) return;
 
+    if (!this->mstate) return;
+
     helper::ReadAccessor<DataVecCoord> x = this->mstate->read(core::VecCoordId::position());
 
     static const Real max_real = std::numeric_limits<Real>::max();


### PR DESCRIPTION
This is a fix to update a bound box for a hyperelastic force field. Without updating the rotation and translation of a virtual camera works incorrectly. This method is a copy of a bound box computation from TetrahedronFEMForceField.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
