### PR TITLE
[SofaSimpleFem] Small Fix

### DIFF
--- a/SofaKernel/modules/SofaSimpleFem/TetrahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/TetrahedronFEMForceField.inl
@@ -1716,6 +1716,7 @@ void TetrahedronFEMForceField<DataTypes>::computeBBox(const core::ExecParams*, b
 {
     if( !onlyVisible ) return;
 
+    if (!this->mstate) return;
     helper::ReadAccessor<DataVecCoord> x = this->mstate->read(core::VecCoordId::position());
 
     static const Real max_real = std::numeric_limits<Real>::max();


### PR DESCRIPTION
Fix crash when calling updateBBox w/o an mstate in TetrahedronFEMForceField






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
