### PR TITLE
[CMake] Create an IDE folder for all relocatable_install targets

### DIFF
--- a/SofaKernel/SofaFramework/SofaMacros.cmake
+++ b/SofaKernel/SofaFramework/SofaMacros.cmake
@@ -705,6 +705,7 @@ function(sofa_set_install_relocatable target install_dir)
                 || true
             )
     endif()
+    set_target_properties(${target}_relocatable_install PROPERTIES FOLDER "relocatable_install")
 endfunction()
 
 


### PR DESCRIPTION
In an IDE (Visual Studio at least), tidy cozily all *_relocatable_install projects into a folder.
Before:
![Capture1](https://user-images.githubusercontent.com/11028016/83787044-787bbd00-a693-11ea-8949-55a86b91b779.PNG)
After:
![Capture2](https://user-images.githubusercontent.com/11028016/83787136-a103b700-a693-11ea-9a7f-d2652e039bbd.PNG)



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
