### PR TITLE
[SofaCore] ADD: DataCallback system in Base

### DIFF
--- a/SofaKernel/modules/SofaCore/SofaCore_test/TrackedData_test.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_test/TrackedData_test.cpp
@@ -103,29 +103,30 @@ protected:
 
 struct DataTracker_test: public ::testing::Test
 {
-    TestObject testObject;
+    TestObject::SPtr testObject;
 
     void SetUp() override
     {
-        testObject.init();
+        testObject = sofa::core::objectmodel::New<TestObject>();
+        testObject->init();
     }
 
     /// to test tracked Data
     void testTrackedData()
     {
         // input did not change, it is not dirtied, so neither its associated DataTracker
-        testObject.updateData();
-        ASSERT_TRUE(testObject.depend_on_input.getValue()==TestObject::NO_CHANGED);
+        testObject->updateData();
+        ASSERT_TRUE(testObject->depend_on_input.getValue()==TestObject::NO_CHANGED);
 
         // modifying input sets it as dirty, so its associated DataTracker too
-        testObject.input.setValue(true);
-        testObject.updateData();
-        ASSERT_TRUE(testObject.depend_on_input.getValue()==TestObject::CHANGED);
+        testObject->input.setValue(true);
+        testObject->updateData();
+        ASSERT_TRUE(testObject->depend_on_input.getValue()==TestObject::CHANGED);
 
-        testObject.input.setValue(false);
-        testObject.input.cleanDirty();
-        testObject.updateData();
-        ASSERT_TRUE(testObject.depend_on_input.getValue()==TestObject::CHANGED);
+        testObject->input.setValue(false);
+        testObject->input.cleanDirty();
+        testObject->updateData();
+        ASSERT_TRUE(testObject->depend_on_input.getValue()==TestObject::CHANGED);
     }
 
 };
@@ -170,10 +171,9 @@ public:
         , depend_on_input(initData(&depend_on_input,"depend_on_input","depend_on_input"))
         , depend_on_input2(initData(&depend_on_input2,"depend_on_input2","depend_on_input2"))
     {
-        m_dataTracker.addInputs({&input,&input2}); // several inputs can be added
-        m_dataTracker.addOutputs({&depend_on_input, &depend_on_input2}); // several output can be added
-        m_dataTracker.addCallback( &TestObject2::myUpdate );
-        m_dataTracker.setDirtyValue();
+        addUpdateCallback("TestObject2Engine", {&input, &input2}
+                          , std::bind(&TestObject2::myUpdate, this)
+                          , {&depend_on_input, &depend_on_input2});
     }
 
     ~TestObject2() override {}
@@ -186,26 +186,13 @@ protected:
     core::DataTrackerEngine m_dataTracker;
 
 
-    static void myUpdate( core::DataTrackerEngine* dataTrackerEngine )
+    sofa::core::objectmodel::ComponentState myUpdate()
     {
         ++s_updateCounter;
 
-        // get the list of inputs for this DDGNode
-        const core::DataTrackerEngine::DDGLinkContainer& inputs = dataTrackerEngine->getInputs();
-        // get the list of outputs for this DDGNode
-        const core::DataTrackerEngine::DDGLinkContainer& outputs = dataTrackerEngine->getOutputs();
-
-        // we known who is who from the order Data were added to the DataTrackerEngine
-        bool input = static_cast<Data< bool >*>( inputs[0] )->getValue();
-        bool input2 = static_cast<Data< bool >*>( inputs[1] )->getValue();
-
-        dataTrackerEngine->cleanDirty();
-
-        Data< bool >* output = static_cast<Data< bool >*>( outputs[0] );
-        Data< bool >* output2 = static_cast<Data< bool >*>( outputs[1] );
-
-        output->setValue( input );
-        output2->setValue( input2 );
+        depend_on_input.setValue(input.getValue());
+        depend_on_input2.setValue(input2.getValue());
+        return sofa::core::objectmodel::ComponentState::Valid;
     }
 
 };
@@ -228,6 +215,7 @@ struct DataTrackerEngine_test: public BaseTest
 {
 
     static unsigned updateCounter;
+    core::DataTrackerEngine dataTracker;
     void SetUp() override
     {
         updateCounter = 0;
@@ -281,39 +269,19 @@ struct DataTrackerEngine_test: public BaseTest
 
     }
 
-
-    static void myUpdate( core::DataTrackerEngine* dataTrackerEngine )
-    {
-        ++updateCounter;
-
-        // get the list of inputs for this DDGNode
-        const core::DataTrackerEngine::DDGLinkContainer& inputs = dataTrackerEngine->getInputs();
-        // get the list of outputs for this DDGNode
-        const core::DataTrackerEngine::DDGLinkContainer& outputs = dataTrackerEngine->getOutputs();
-
-        // we known who is who from the order Data were added to the DataTrackerEngine
-        bool input = static_cast<Data< bool >*>( inputs[0] )->getValue();
-
-        dataTrackerEngine->cleanDirty();
-
-
-        Data< bool >* output = static_cast<Data< bool >*>( outputs[0] );
-
-        output->setValue( input );
-    }
-
-
     /// to test DataTrackerEngine between Data in separated components
     void testBetweenComponents()
     {
-
-
         DummyObject testObject, testObject2;
 
-        core::DataTrackerEngine dataTracker;
         dataTracker.addInput(&testObject.myData); // several inputs can be added
         dataTracker.addOutput(&testObject2.myData); // several output can be added
-        dataTracker.addCallback( &DataTrackerEngine_test::myUpdate );
+        dataTracker.addCallback([&](){
+            ++updateCounter;
+            testObject2.myData.setValue(testObject.myData.getValue());
+            return sofa::core::objectmodel::ComponentState::Valid;
+        });
+
         dataTracker.setDirtyValue();
         unsigned localCounter = 0u;
 

--- a/SofaKernel/modules/SofaCore/SofaCore_test/TrackedData_test.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_test/TrackedData_test.cpp
@@ -172,7 +172,7 @@ public:
         , depend_on_input2(initData(&depend_on_input2,"depend_on_input2","depend_on_input2"))
     {
         addUpdateCallback("TestObject2Engine", {&input, &input2}
-                          , std::bind(&TestObject2::myUpdate, this)
+                          , std::bind(&TestObject2::myUpdate, this, std::placeholders::_1)
                           , {&depend_on_input, &depend_on_input2});
     }
 
@@ -183,11 +183,9 @@ public:
 
 protected:
 
-    core::DataTrackerEngine m_dataTracker;
-
-
-    sofa::core::objectmodel::ComponentState myUpdate()
+    sofa::core::objectmodel::ComponentState myUpdate(const core::DataTracker& tracker)
     {
+        SOFA_UNUSED(tracker);
         ++s_updateCounter;
 
         depend_on_input.setValue(input.getValue());
@@ -215,7 +213,7 @@ struct DataTrackerEngine_test: public BaseTest
 {
 
     static unsigned updateCounter;
-    core::DataTrackerEngine dataTracker;
+    core::DataTrackerCallback dataTracker;
     void SetUp() override
     {
         updateCounter = 0;
@@ -276,7 +274,7 @@ struct DataTrackerEngine_test: public BaseTest
 
         dataTracker.addInput(&testObject.myData); // several inputs can be added
         dataTracker.addOutput(&testObject2.myData); // several output can be added
-        dataTracker.addCallback([&](){
+        dataTracker.setCallback([&](const core::DataTracker&){
             ++updateCounter;
             testObject2.myData.setValue(testObject.myData.getValue());
             return sofa::core::objectmodel::ComponentState::Valid;

--- a/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/DataCallback_test.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/DataCallback_test.cpp
@@ -48,19 +48,19 @@ struct DataCallback_test: public BaseTest
         {
             msg_info("DataCallback_test") << "TestObject : Value of objdata1 changed : "
                                           << this->d_objdata1.getValue();
-            msg_warning("DataCallback_test") << "TestObject : Value of objdata2 did not changed : "
+            msg_warning("DataCallback_test") << "TestObject : Value of objdata2 did not change : "
                                            << this->d_objdata2.getValue();
         }
         void printData2()
         {
             msg_advice("DataCallback_test") << "TestObject : Value of objdata2 changed : "
                                           << this->d_objdata2.getValue();
-            msg_error("DataCallback_test") << "TestObject : Value of objdata1 did not changed : "
+            msg_error("DataCallback_test") << "TestObject : Value of objdata1 did not change : "
                                            << this->d_objdata1.getValue();
         }
         void printDataAll()
         {
-            msg_fatal("DataCallback_test") << "TestObject : Value of objdata1 or objdata2 changed : "
+            msg_fatal("DataCallback_test") << "TestObject : Value of objdata1 or objdata2 change : "
                                           << this->d_objdata1.getValue() << " | "
                                           << this->d_objdata2.getValue();
         }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
@@ -110,8 +110,7 @@ void DataTrackerEngine::update()
         return;
     for(auto& callback : m_callbacks)
     {
-        sofa::core::objectmodel::ComponentState state = callback();
-        m_owner->d_componentstate.setValue(cs);
+        m_owner->d_componentstate.setValue(callback());
     }
     cleanDirty();
 }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
@@ -105,7 +105,10 @@ void DataTrackerCallback::setCallback( std::function<sofa::core::objectmodel::Co
 void DataTrackerCallback::update()
 {
     updateAllInputsIfDirty();
-    m_owner->d_componentstate.setValue(m_callback(m_dataTracker)); // but what if the state of the component was invalid for a reason that doesn't depend on this update?
+
+    auto cs = m_callback(m_dataTracker);
+    if (m_owner)
+        m_owner->d_componentstate.setValue(cs); // but what if the state of the component was invalid for a reason that doesn't depend on this update?
     cleanDirty();
 }
 
@@ -121,12 +124,13 @@ void DataTrackerEngine::addCallback( std::function<sofa::core::objectmodel::Comp
 void DataTrackerEngine::update()
 {
     updateAllInputsIfDirty();
-    if (!m_owner)
-        return;
+    core::objectmodel::ComponentState cs;
+
     for(auto& callback : m_callbacks)
-    {
-        m_owner->d_componentstate.setValue(callback());
-    }
+        cs = callback();
+
+    if (m_owner)
+        m_owner->d_componentstate.setValue(cs);
     cleanDirty();
 }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
@@ -113,6 +113,18 @@ void DataTrackerEngine::update()
     cleanDirty();
 }
 
+void CallbackEngine::setCallback( std::function<sofa::core::objectmodel::ComponentState(void)> f)
+{
+    m_callback = f;
+}
+
+void CallbackEngine::update()
+{
+    updateAllInputsIfDirty();
+    m_owner->d_componentstate.setValue(m_callback()); // but what if the state of the component was invalid for a reason that doesn't depend on this update?
+    cleanDirty();
+}
+
 
 }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
@@ -66,13 +66,15 @@ void DataTracker::clean()
 ////////////////////
 void DataTrackerDDGNode::addInputs(std::initializer_list<sofa::core::objectmodel::BaseData*> datas)
 {
-    for(sofa::core::objectmodel::DDGNode* d : datas)
+    for(sofa::core::objectmodel::BaseData* d : datas) {
+        m_dataTracker.trackData(*d);
         addInput(d);
+    }
 }
 
 void DataTrackerDDGNode::addOutputs(std::initializer_list<sofa::core::objectmodel::BaseData*> datas)
 {
-    for(sofa::core::objectmodel::DDGNode* d : datas)
+    for(sofa::core::objectmodel::BaseData* d : datas)
         addOutput(d);
 }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
@@ -64,13 +64,13 @@ void DataTracker::clean()
 
 
 ////////////////////
-void DataTrackerDDGNode::addInputs(std::initializer_list<sofa::core::objectmodel::DDGNode*> datas)
+void DataTrackerDDGNode::addInputs(std::initializer_list<sofa::core::objectmodel::BaseData*> datas)
 {
     for(sofa::core::objectmodel::DDGNode* d : datas)
         addInput(d);
 }
 
-void DataTrackerDDGNode::addOutputs(std::initializer_list<sofa::core::objectmodel::DDGNode*> datas)
+void DataTrackerDDGNode::addOutputs(std::initializer_list<sofa::core::objectmodel::BaseData*> datas)
 {
     for(sofa::core::objectmodel::DDGNode* d : datas)
         addOutput(d);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
@@ -94,7 +94,22 @@ void DataTrackerDDGNode::updateAllInputsIfDirty()
         static_cast<core::objectmodel::BaseData*>(input)->updateIfDirty();
     }
 }
+
 ///////////////////////
+
+void DataTrackerCallback::setCallback( std::function<sofa::core::objectmodel::ComponentState(const DataTracker&)> f)
+{
+    m_callback = f;
+}
+
+void DataTrackerCallback::update()
+{
+    updateAllInputsIfDirty();
+    m_owner->d_componentstate.setValue(m_callback(m_dataTracker)); // but what if the state of the component was invalid for a reason that doesn't depend on this update?
+    cleanDirty();
+}
+
+
 void DataTrackerEngine::addCallback( std::function<sofa::core::objectmodel::ComponentState(void)> f)
 {
     m_callbacks.push_back(f);
@@ -115,17 +130,6 @@ void DataTrackerEngine::update()
     cleanDirty();
 }
 
-void CallbackEngine::setCallback( std::function<sofa::core::objectmodel::ComponentState(void)> f)
-{
-    m_callback = f;
-}
-
-void CallbackEngine::update()
-{
-    updateAllInputsIfDirty();
-    m_owner->d_componentstate.setValue(m_callback()); // but what if the state of the component was invalid for a reason that doesn't depend on this update?
-    cleanDirty();
-}
 
 
 }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
@@ -100,18 +100,19 @@ void DataTrackerEngine::addCallback( std::function<sofa::core::objectmodel::Comp
     m_callbacks.push_back(f);
 }
 
+/// Each callback in the engine is called, setting its owner's component state to the value returned by the last callback.
+/// Because each callback overwrites the state of the same component, it is important that within a component, all
+/// callbacks perform the same checks to determine the value of the ComponentState.
 void DataTrackerEngine::update()
 {
     updateAllInputsIfDirty();
-    sofa::core::objectmodel::ComponentState cs = sofa::core::objectmodel::ComponentState::Valid;
+    if (!m_owner)
+        return;
     for(auto& callback : m_callbacks)
     {
         sofa::core::objectmodel::ComponentState state = callback();
-        if (state != sofa::core::objectmodel::ComponentState::Valid)
-            cs = state;
-    }
-    if (m_owner)
         m_owner->d_componentstate.setValue(cs);
+    }
     cleanDirty();
 }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #include "DataTracker.h"
 #include "objectmodel/BaseData.h"
+#include "objectmodel/Base.h"
 
 namespace sofa
 {
@@ -63,15 +64,15 @@ void DataTracker::clean()
 
 
 ////////////////////
-void DataTrackerDDGNode::addInputs(std::initializer_list<sofa::core::objectmodel::BaseData*> datas)
+void DataTrackerDDGNode::addInputs(std::initializer_list<sofa::core::objectmodel::DDGNode*> datas)
 {
-    for(sofa::core::objectmodel::BaseData* d : datas)
+    for(sofa::core::objectmodel::DDGNode* d : datas)
         addInput(d);
 }
 
-void DataTrackerDDGNode::addOutputs(std::initializer_list<sofa::core::objectmodel::BaseData*> datas)
+void DataTrackerDDGNode::addOutputs(std::initializer_list<sofa::core::objectmodel::DDGNode*> datas)
 {
-    for(sofa::core::objectmodel::BaseData* d : datas)
+    for(sofa::core::objectmodel::DDGNode* d : datas)
         addOutput(d);
 }
 
@@ -92,17 +93,24 @@ void DataTrackerDDGNode::updateAllInputsIfDirty()
     }
 }
 ///////////////////////
-void DataTrackerEngine::addCallback( std::function<void(DataTrackerEngine*)> f)
+void DataTrackerEngine::addCallback( std::function<sofa::core::objectmodel::ComponentState(void)> f)
 {
     m_callbacks.push_back(f);
 }
 
 void DataTrackerEngine::update()
 {
+    updateAllInputsIfDirty();
+    sofa::core::objectmodel::ComponentState cs = sofa::core::objectmodel::ComponentState::Valid;
     for(auto& callback : m_callbacks)
     {
-        callback(this);
+        sofa::core::objectmodel::ComponentState state = callback();
+        if (state != sofa::core::objectmodel::ComponentState::Valid)
+            cs = state;
     }
+    if (m_owner)
+        m_owner->d_componentstate.setValue(cs);
+    cleanDirty();
 }
 
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.h
@@ -26,6 +26,7 @@
 #include <map>
 #include <vector>
 #include <sofa/core/objectmodel/DDGNode.h>
+#include "objectmodel/ComponentState.h"
 namespace sofa::core::objectmodel
 {
     class Base;
@@ -95,9 +96,9 @@ namespace core
         void operator=(const DataTrackerDDGNode&);
 
     public:
-        /// Create a DataCallback object associated with multiple Data.
-        void addInputs(std::initializer_list<sofa::core::objectmodel::BaseData*> datas);
-        void addOutputs(std::initializer_list<sofa::core::objectmodel::BaseData*> datas);
+        /// Create a DataCallback object associated with multiple Nodes.
+        void addInputs(std::initializer_list<sofa::core::objectmodel::DDGNode*> datas);
+        void addOutputs(std::initializer_list<sofa::core::objectmodel::DDGNode*> datas);
 
         /// Set dirty flag to false
         /// for the DDGNode and for all the tracked Data
@@ -173,13 +174,15 @@ namespace core
     public:
         /// set the update function to call
         /// when asking for an output and any input changed.
-        void addCallback(std::function<void(DataTrackerEngine*)> f);
+        void addCallback(std::function<sofa::core::objectmodel::ComponentState(void)> f);
 
         /// Calls the callback when one of the data has changed.
         void update() override;
 
     protected:
-        std::vector<std::function<void(DataTrackerEngine*)>> m_callbacks;
+        std::vector<std::function<sofa::core::objectmodel::ComponentState(void)>> m_callbacks;
+        std::string m_name {""};
+        sofa::core::objectmodel::Base* m_owner {nullptr};
     };
 
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.h
@@ -96,9 +96,9 @@ namespace core
         void operator=(const DataTrackerDDGNode&);
 
     public:
-        /// Create a DataCallback object associated with multiple Nodes.
-        void addInputs(std::initializer_list<sofa::core::objectmodel::DDGNode*> datas);
-        void addOutputs(std::initializer_list<sofa::core::objectmodel::DDGNode*> datas);
+        /// Create a DataCallback object associated with multiple Data fields.
+        void addInputs(std::initializer_list<sofa::core::objectmodel::BaseData*> datas);
+        void addOutputs(std::initializer_list<sofa::core::objectmodel::BaseData*> datas);
 
         /// Set dirty flag to false
         /// for the DDGNode and for all the tracked Data

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.h
@@ -182,12 +182,12 @@ namespace core
 
 
     ///////////////////////
-#define SOFA_DEPRECATED_CORE_API(str) SOFA_CORE_API [[deprecated(str)]]
 
-    class SOFA_DEPRECATED_CORE_API("2020-06-17: DataTrackerEngine has been deprecated, use DataTrackerCallback instead. DataTrackerCallback only supports 1 callback at a time, but multiple DataTrackerCallbacks can be created within a single component")
-    DataTrackerEngine : public DataTrackerDDGNode
+    class SOFA_CORE_API DataTrackerEngine : public DataTrackerDDGNode
     {
     public:
+        [[deprecated("2020-06-17: DataTrackerEngine has been deprecated, use DataTrackerCallback instead. DataTrackerCallback only supports 1 callback at a time, but multiple DataTrackerCallbacks can be created within a single component")]]
+        DataTrackerEngine() : DataTrackerDDGNode() {}
         /// set the update function to call
         /// when asking for an output and any input changed.
         void addCallback(std::function<sofa::core::objectmodel::ComponentState(void)> f);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.h
@@ -182,8 +182,9 @@ namespace core
 
 
     ///////////////////////
+#define SOFA_DEPRECATED_CORE_API(str) SOFA_CORE_API [[deprecated(str)]]
 
-    class SOFA_CORE_API [[deprecated("2020-06-17: DataTrackerEngine has been deprecated, use DataTrackerCallback instead. DataTrackerCallback only supports 1 callback at a time, but multiple DataTrackerCallbacks can be created within a single component")]]
+    class SOFA_DEPRECATED_CORE_API("2020-06-17: DataTrackerEngine has been deprecated, use DataTrackerCallback instead. DataTrackerCallback only supports 1 callback at a time, but multiple DataTrackerCallbacks can be created within a single component")
     DataTrackerEngine : public DataTrackerDDGNode
     {
     public:

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.h
@@ -183,8 +183,8 @@ namespace core
 
     ///////////////////////
 
-    class [[deprecated("2020-06-17: DataTrackerEngine has been deprecated, use DataTrackerCallback instead. DataTrackerCallback only supports 1 callback at a time, but multiple DataTrackerCallbacks can be created within a single component")]]
-    SOFA_CORE_API DataTrackerEngine : public DataTrackerDDGNode
+    class SOFA_CORE_API [[deprecated("2020-06-17: DataTrackerEngine has been deprecated, use DataTrackerCallback instead. DataTrackerCallback only supports 1 callback at a time, but multiple DataTrackerCallbacks can be created within a single component")]]
+    DataTrackerEngine : public DataTrackerDDGNode
     {
     public:
         /// set the update function to call

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.h
@@ -185,7 +185,22 @@ namespace core
         sofa::core::objectmodel::Base* m_owner {nullptr};
     };
 
+    class SOFA_CORE_API CallbackEngine : public DataTrackerDDGNode
+    {
+    public:
+        /// set the update function to call
+        /// when asking for an output and any input changed.
+        void setCallback(std::function<sofa::core::objectmodel::ComponentState(void)> f);
 
+        /// Calls the callback when one of the data has changed.
+        void update() override;
+
+        inline void setOwner(sofa::core::objectmodel::Base* owner) { m_owner = owner; }
+
+    protected:
+        std::function<sofa::core::objectmodel::ComponentState(void)> m_callback;
+        sofa::core::objectmodel::Base* m_owner {nullptr};
+    };
 /////////////////////////
 
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -72,7 +72,7 @@ Base::Base()
     sendl.setParent(this);
 
     /// name change => component state update
-    addUpdateCallback("name", {&name}, [this](){
+    addUpdateCallback("name", {&name}, [this](const DataTracker&){
         /// Increment the state counter but without changing the state.
         return m_componentstate.getValue();
     }, {&m_componentstate});
@@ -98,7 +98,7 @@ void Base::release()
 
 void Base::addUpdateCallback(const std::string& name,
                              std::initializer_list<BaseData*> inputs,
-                             std::function<sofa::core::objectmodel::ComponentState(void)> func,
+                             std::function<sofa::core::objectmodel::ComponentState(const DataTracker&)> func,
                              std::initializer_list<BaseData*> outputs)
 {
     // But what if 2 callback functions return 2 different states?
@@ -106,8 +106,8 @@ void Base::addUpdateCallback(const std::string& name,
     auto& engine = m_internalEngine[name];
     engine.setOwner(this);
     engine.addInputs(inputs);
-    engine.setCallback([func, name]() {
-        return func();
+    engine.setCallback([func, name](const DataTracker& tracker) {
+        return func(tracker);
     });
     engine.addOutputs(outputs);
 
@@ -119,7 +119,7 @@ void Base::addUpdateCallback(const std::string& name,
     engine.addOutput(&d_componentstate);
 }
 
-void Base::addOutputToCallbackEngine(const std::string& name, BaseData* output)
+void Base::addOutputToCallback(const std::string& name, BaseData* output)
 {
     if (m_internalEngine.find(name) != m_internalEngine.end())
         m_internalEngine[name].addOutputs({output});

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -119,6 +119,13 @@ void Base::addUpdateCallback(const std::string& name,
     engine.addOutput(&d_componentstate);
 }
 
+void Base::addOutputToCallbackEngine(const std::string& name, BaseData* output)
+{
+    if (m_internalEngine.find(name) != m_internalEngine.end())
+        m_internalEngine[name].addOutputs({output});
+}
+
+
 /// Helper method used by initData()
 void Base::initData0( BaseData* field, BaseData::BaseInitData& res, const char* name, const char* help, bool isDisplayed, bool isReadOnly )
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -97,9 +97,9 @@ void Base::release()
 
 
 void Base::addUpdateCallback(const std::string& name,
-                             std::initializer_list<DDGNode*> inputs,
+                             std::initializer_list<BaseData*> inputs,
                              std::function<sofa::core::objectmodel::ComponentState(void)> func,
-                             std::initializer_list<DDGNode*> outputs)
+                             std::initializer_list<BaseData*> outputs)
 {
     auto& engine = m_internalEngine[name];
     engine.addInputs(inputs);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -216,12 +216,6 @@ std::string Base::getNameSpaceName() const
     return getClass()->namespaceName;
 }
 
-
-std::string Base::getPathName() const
-{
-    return "";
-}
-
 void Base::setName(const std::string& na)
 {
     name.setValue(na);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -169,7 +169,7 @@ private:
 
 public:
 
-    std::map<std::string, sofa::core::DataTrackerEngine> m_internalEngine;
+    std::map<std::string, sofa::core::CallbackEngine> m_internalEngine;
 
     void addUpdateCallback(const std::string& name,
                            std::initializer_list<BaseData*> inputs,

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -210,8 +210,6 @@ public:
     /// to override the getNameSpaceName() method.
     virtual std::string getNameSpaceName() const ;
 
-    virtual std::string getPathName() const;
-
     /// Set the source filename (where the component is implemented)
     void setDefinitionSourceFileName(const std::string& sourceFileName);
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -172,9 +172,9 @@ public:
     std::map<std::string, sofa::core::DataTrackerEngine> m_internalEngine;
 
     void addUpdateCallback(const std::string& name,
-                           std::initializer_list<DDGNode*> inputs,
+                           std::initializer_list<BaseData*> inputs,
                            std::function<sofa::core::objectmodel::ComponentState(void)> function,
-                           std::initializer_list<DDGNode*> outputs);
+                           std::initializer_list<BaseData*> outputs);
 
     /// Accessor to the object name
     const std::string& getName() const

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -168,14 +168,14 @@ private:
     }
 
 private:
-    std::map<std::string, sofa::core::CallbackEngine> m_internalEngine;
+    std::map<std::string, sofa::core::DataTrackerCallback> m_internalEngine;
 
 public:
     void addUpdateCallback(const std::string& name,
                            std::initializer_list<BaseData*> inputs,
-                           std::function<sofa::core::objectmodel::ComponentState(void)> function,
+                           std::function<sofa::core::objectmodel::ComponentState(const DataTracker&)> function,
                            std::initializer_list<BaseData*> outputs);
-    void addOutputToCallbackEngine(const std::string& name, BaseData* output);
+    void addOutputToCallback(const std::string& name, BaseData* output);
 
     /// Accessor to the object name
     const std::string& getName() const

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -25,6 +25,7 @@
 #include <sofa/helper/StringUtils.h>
 #include <sofa/defaulttype/BoundingBox.h>
 #include <sofa/core/objectmodel/Data.h>
+#include <sofa/core/DataTracker.h>
 #include <sofa/core/objectmodel/BaseObjectDescription.h>
 #include <sofa/core/objectmodel/Tag.h>
 #include <list>
@@ -33,6 +34,7 @@
 #include <deque>
 
 #include <sofa/core/objectmodel/ComponentState.h>
+#include <sofa/core/DataTracker.h>
 
 // forward declaration of castable classes
 // @author Matthieu Nesme, 2015
@@ -167,6 +169,13 @@ private:
 
 public:
 
+    std::map<std::string, sofa::core::DataTrackerEngine> m_internalEngine;
+
+    void addUpdateCallback(const std::string& name,
+                           std::initializer_list<DDGNode*> inputs,
+                           std::function<sofa::core::objectmodel::ComponentState(void)> function,
+                           std::initializer_list<DDGNode*> outputs);
+
     /// Accessor to the object name
     const std::string& getName() const
     {
@@ -200,6 +209,8 @@ public:
     /// Since #PR 1283, the signature has changed to "final" so it is not possible
     /// to override the getNameSpaceName() method.
     virtual std::string getNameSpaceName() const ;
+
+    virtual std::string getPathName() const;
 
     /// Set the source filename (where the component is implemented)
     void setDefinitionSourceFileName(const std::string& sourceFileName);
@@ -296,6 +307,7 @@ public:
     /// Note that this method should only be called if the Data was not initialized with the initData method
     void addData(BaseData* f, const std::string& name);
 
+
     /// Add a data field.
     /// Note that this method should only be called if the Data was not initialized with the initData method
     void addData(BaseData* f);
@@ -310,16 +322,16 @@ public:
     /// Add a link.
     void addLink(BaseLink* l);
 
-    /// Remove a link.
-    void removeLink(BaseLink* l);
-
     /// Add an alias to a Link
     void addAlias( BaseLink* link, const char* alias);
 
+
     typedef helper::vector<BaseData*> VecData;
     typedef std::multimap<std::string, BaseData*> MapData;
+
     typedef helper::vector<BaseLink*> VecLink;
     typedef std::multimap<std::string, BaseLink*> MapLink;
+
 
     /// Accessor to the vector containing all the fields of this object
     const VecData& getDataFields() const { return m_vecData; }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -167,14 +167,15 @@ private:
         p->release();
     }
 
-public:
-
+private:
     std::map<std::string, sofa::core::CallbackEngine> m_internalEngine;
 
+public:
     void addUpdateCallback(const std::string& name,
                            std::initializer_list<BaseData*> inputs,
                            std::function<sofa::core::objectmodel::ComponentState(void)> function,
                            std::initializer_list<BaseData*> outputs);
+    void addOutputToCallbackEngine(const std::string& name, BaseData* output);
 
     /// Accessor to the object name
     const std::string& getName() const

--- a/modules/SofaExporter/SofaExporter_test/OBJExporter_test.cpp
+++ b/modules/SofaExporter/SofaExporter_test/OBJExporter_test.cpp
@@ -58,7 +58,7 @@ public:
         sofa::simulation::setSimulation(new DAGSimulation());
     }
 
-    void TearDown()
+    void TearDown() override
     {
         for(auto& pathToRemove : dataPath)
         {


### PR DESCRIPTION
This is the callback system we use in our dev branch for runSofa2.
It lets you add a callback function so that outputs can be updated upon changes on their input data.
The callback function returns a component state (Valid / invalid / ...) which guarantees that the component's state is properly maintained.

I kept this PR simple (only tests to show the working principle), but will make another one later on with a few components that we've updated to use this callback mechanism (AddResourceRepository, MeshLoaders (OBJ / VTK / STL ...) 

This mechanism is also used in the "nodephysics" Links POC (https://github.com/SofaDefrost/ComponentData_POC/pull/2)



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
