### PR TITLE
[SofaCore] ADD directory DataFileNames

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataFileName.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataFileName.cpp
@@ -76,7 +76,7 @@ void DataFileName::updatePath()
         if (!fullpath.empty())
             DataRepository.findFile(fullpath,"",(this->m_owner ? &(this->m_owner->serr.ostringstream()) : &std::cerr));
 
-        if (isDirectory() != fs::FileSystem::isDirectory(fullpath))
+        if (isDirectory() != fs::FileSystem::isDirectory(fullpath) && fs::FileSystem::exists(fullpath))
         {
             msg_error(this->getName()) << "This DataFileName only accepts " << (isDirectory() ? "directories" : "files");
         }
@@ -130,7 +130,7 @@ void DataFileNameVector::updatePath()
             else
             {
                 helper::system::DataRepository.findFile(m_fullpath[i],"",(this->m_owner ? &(this->m_owner->serr.ostringstream()) : &std::cerr));
-                if (isDirectory() != fs::FileSystem::isDirectory(m_fullpath[i]))
+                if (isDirectory() != fs::FileSystem::isDirectory(m_fullpath[i]) && fs::FileSystem::exists(m_fullpath[i]))
                 {
                     msg_error(this->getName()) << "This DataFileName only accepts " << (isDirectory() ? "directories" : "files");
                     m_fullpath[i] = "";

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataFileName.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataFileName.cpp
@@ -58,9 +58,9 @@ void DataFileName::updatePath()
     if (parentDataFileName)
     {
         std::string fullpath = parentDataFileName->getFullPath();
-        if (isDirectory() != parentDataFileName->isDirectory())
+        if (getPathType() != BOTH && getPathType() != parentDataFileName->getPathType())
         {
-            msg_error(this->getName()) << "This DataFileName only accepts " << (isDirectory() ? "directories" : "files");
+            msg_error(this->getName()) << "This DataFileName only accepts " << (getPathType() == FILE ? "directories" : "files");
         }
         else
         {
@@ -76,9 +76,9 @@ void DataFileName::updatePath()
         if (!fullpath.empty())
             DataRepository.findFile(fullpath,"",(this->m_owner ? &(this->m_owner->serr.ostringstream()) : &std::cerr));
 
-        if (fs::FileSystem::exists(fullpath) && isDirectory() != fs::FileSystem::isDirectory(fullpath))
+        if (getPathType() != BOTH && (fs::FileSystem::exists(fullpath) && getPathType() != fs::FileSystem::isDirectory(fullpath)))
         {
-            msg_error(this->getName()) << "This DataFileName only accepts " << (isDirectory() ? "directories" : "files");
+            msg_error(this->getName()) << "This DataFileName only accepts " << (getPathType() == FILE ? "directories" : "files");
         }
         else
         {
@@ -112,9 +112,9 @@ void DataFileNameVector::updatePath()
     if (parentData)
     {
         parentDataFileNameVector = dynamic_cast<DataFileNameVector*>(parentData.get());
-        if (isDirectory() != parentDataFileNameVector->isDirectory())
+        if (getPathType() != BOTH && getPathType() != parentDataFileNameVector->getPathType())
         {
-            msg_error(this->getName()) << "Cannot retrieve DataFileNames from Parent value: this DataFileName only accepts " << (isDirectory() ? "directories" : "files");
+            msg_error(this->getName()) << "Cannot retrieve DataFileNames from Parent value: this DataFileName only accepts " << (getPathType() ? "directories" : "files");
             return;
         }
     }
@@ -130,9 +130,9 @@ void DataFileNameVector::updatePath()
             else
             {
                 helper::system::DataRepository.findFile(m_fullpath[i],"",(this->m_owner ? &(this->m_owner->serr.ostringstream()) : &std::cerr));
-                if (fs::FileSystem::exists(m_fullpath[i]) && isDirectory() != fs::FileSystem::isDirectory(m_fullpath[i]))
+                if (getPathType() != BOTH && (fs::FileSystem::exists(m_fullpath[i]) && getPathType() != fs::FileSystem::isDirectory(m_fullpath[i])))
                 {
-                    msg_error(this->getName()) << "This DataFileName only accepts " << (isDirectory() ? "directories" : "files");
+                    msg_error(this->getName()) << "This DataFileName only accepts " << (getPathType() ? "directories" : "files");
                     m_fullpath[i] = "";
                 }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataFileName.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataFileName.cpp
@@ -76,7 +76,7 @@ void DataFileName::updatePath()
         if (!fullpath.empty())
             DataRepository.findFile(fullpath,"",(this->m_owner ? &(this->m_owner->serr.ostringstream()) : &std::cerr));
 
-        if (isDirectory() != fs::FileSystem::isDirectory(fullpath) && fs::FileSystem::exists(fullpath))
+        if (fs::FileSystem::exists(fullpath) && isDirectory() != fs::FileSystem::isDirectory(fullpath))
         {
             msg_error(this->getName()) << "This DataFileName only accepts " << (isDirectory() ? "directories" : "files");
         }
@@ -130,7 +130,7 @@ void DataFileNameVector::updatePath()
             else
             {
                 helper::system::DataRepository.findFile(m_fullpath[i],"",(this->m_owner ? &(this->m_owner->serr.ostringstream()) : &std::cerr));
-                if (isDirectory() != fs::FileSystem::isDirectory(m_fullpath[i]) && fs::FileSystem::exists(m_fullpath[i]))
+                if (fs::FileSystem::exists(m_fullpath[i]) && isDirectory() != fs::FileSystem::isDirectory(m_fullpath[i]))
                 {
                     msg_error(this->getName()) << "This DataFileName only accepts " << (isDirectory() ? "directories" : "files");
                     m_fullpath[i] = "";

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataFileName.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataFileName.h
@@ -228,7 +228,7 @@ public:
     virtual bool read(const std::string& s )
     {
         bool ret = Inherit::read(s);
-        if (ret || fullpath.empty()) updatePath();
+        if (ret || m_fullpath.empty()) updatePath();
         return ret;
     }
 
@@ -236,12 +236,12 @@ public:
     virtual const std::string& getFullPath(unsigned int i) const
     {
         this->updateIfDirty();
-        return fullpath[i];
+        return m_fullpath[i];
     }
     virtual const std::string& getAbsolutePath(unsigned int i) const
     {
         this->updateIfDirty();
-        return fullpath[i];
+        return m_fullpath[i];
     }
 
     virtual void update()
@@ -250,10 +250,21 @@ public:
         this->updatePath();
     }
 
+    void setIsDirectory(bool isDir)
+    {
+        m_isDir = isDir;
+    }
+
+    bool isDirectory()
+    {
+        return m_isDir;
+    }
+
 protected:
     void updatePath();
 
-    sofa::helper::vector<std::string> fullpath;
+    sofa::helper::vector<std::string> m_fullpath;
+    bool m_isDir; //< used to determine how file dialogs should be opened
 
 private:
     DataFileNameVector(const Inherit& d);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataFileName.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataFileName.h
@@ -34,6 +34,12 @@ namespace core
 namespace objectmodel
 {
 
+enum PathType {
+    FILE,
+    DIRECTORY,
+    BOTH
+};
+
 /**
  *  \brief Data specialized to store filenames, potentially relative to the current directory at the time it was specified.
  *
@@ -41,17 +47,19 @@ namespace objectmodel
 class SOFA_CORE_API DataFileName : public sofa::core::objectmodel::Data<std::string>
 {
 public:
+
+
     typedef sofa::core::objectmodel::Data<std::string> Inherit;
 
     DataFileName( const std::string& helpMsg="", bool isDisplayed=true, bool isReadOnly=false )
         : Inherit(helpMsg, isDisplayed, isReadOnly),
-          m_isDir(false)
+          m_pathType(FILE)
     {
     }
 
     DataFileName( const std::string& value, const std::string& helpMsg="", bool isDisplayed=true, bool isReadOnly=false )
         : Inherit(value, helpMsg, isDisplayed, isReadOnly),
-        m_isDir(false)
+        m_pathType(FILE)
     {
         updatePath();
     }
@@ -61,7 +69,7 @@ public:
      */
     explicit DataFileName(const BaseData::BaseInitData& init)
         : Inherit(init),
-          m_isDir(false)
+          m_pathType(FILE)
     {
     }
 
@@ -70,7 +78,7 @@ public:
      */
     explicit DataFileName(const Inherit::InitData& init)
         : Inherit(init),
-          m_isDir(false)
+          m_pathType(FILE)
     {
         updatePath();
     }
@@ -97,14 +105,14 @@ public:
         endEdit();
     }
 
-    void setIsDirectory(bool isDir)
+    void setPathType(PathType pathType)
     {
-        m_isDir = isDir;
+        m_pathType = pathType;
     }
 
-    bool isDirectory()
+    PathType getPathType()
     {
-        return m_isDir;
+        return m_pathType;
     }
 
     virtual void virtualEndEdit() { endEdit(); }
@@ -140,12 +148,13 @@ public:
     }
 
 protected:
+
     void updatePath();
 
     std::string m_fullpath;
     std::string m_relativepath;
     std::string m_extension;
-    bool        m_isDir; //< used to determine how file dialogs should be opened
+    PathType    m_pathType; //< used to determine how file dialogs should be opened
 
 private:
     DataFileName(const Inherit& d);
@@ -159,13 +168,15 @@ class SOFA_CORE_API DataFileNameVector : public sofa::core::objectmodel::Data< s
 public:
     typedef sofa::core::objectmodel::Data<sofa::helper::SVector<std::string> > Inherit;
 
-    DataFileNameVector( const char* helpMsg=nullptr, bool isDisplayed=true, bool isReadOnly=false )
-        : Inherit(helpMsg, isDisplayed, isReadOnly)
+    DataFileNameVector( const char* helpMsg=nullptr, bool isDisplayed=true, bool isReadOnly=false)
+        : Inherit(helpMsg, isDisplayed, isReadOnly),
+          m_pathType(DIRECTORY)
     {
     }
 
     DataFileNameVector( const sofa::helper::vector<std::string>& value, const char* helpMsg=nullptr, bool isDisplayed=true, bool isReadOnly=false )
-        : Inherit(value, helpMsg, isDisplayed, isReadOnly)
+        : Inherit(value, helpMsg, isDisplayed, isReadOnly),
+          m_pathType(DIRECTORY)
     {
         updatePath();
     }
@@ -174,7 +185,8 @@ public:
         this constructor should be used through the initData() methods
      */
     explicit DataFileNameVector(const BaseData::BaseInitData& init)
-        : Inherit(init)
+        : Inherit(init),
+          m_pathType(DIRECTORY)
     {
     }
 
@@ -182,7 +194,8 @@ public:
         this constructor should be used through the initData() methods
      */
     explicit DataFileNameVector(const Inherit::InitData& init)
-        : Inherit(init)
+        : Inherit(init),
+          m_pathType(DIRECTORY)
     {
         updatePath();
     }
@@ -250,21 +263,21 @@ public:
         this->updatePath();
     }
 
-    void setIsDirectory(bool isDir)
+    void setPathType(PathType pathType)
     {
-        m_isDir = isDir;
+        m_pathType = pathType;
     }
 
-    bool isDirectory()
+    PathType getPathType()
     {
-        return m_isDir;
+        return m_pathType;
     }
 
 protected:
     void updatePath();
 
     sofa::helper::vector<std::string> m_fullpath;
-    bool m_isDir; //< used to determine how file dialogs should be opened
+    PathType m_pathType; //< used to determine how file dialogs should be opened
 
 private:
     DataFileNameVector(const Inherit& d);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataFileName.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataFileName.h
@@ -170,13 +170,13 @@ public:
 
     DataFileNameVector( const char* helpMsg=nullptr, bool isDisplayed=true, bool isReadOnly=false)
         : Inherit(helpMsg, isDisplayed, isReadOnly),
-          m_pathType(DIRECTORY)
+          m_pathType(FILE)
     {
     }
 
     DataFileNameVector( const sofa::helper::vector<std::string>& value, const char* helpMsg=nullptr, bool isDisplayed=true, bool isReadOnly=false )
         : Inherit(value, helpMsg, isDisplayed, isReadOnly),
-          m_pathType(DIRECTORY)
+          m_pathType(FILE)
     {
         updatePath();
     }
@@ -186,7 +186,7 @@ public:
      */
     explicit DataFileNameVector(const BaseData::BaseInitData& init)
         : Inherit(init),
-          m_pathType(DIRECTORY)
+          m_pathType(FILE)
     {
     }
 
@@ -195,7 +195,7 @@ public:
      */
     explicit DataFileNameVector(const Inherit::InitData& init)
         : Inherit(init),
-          m_pathType(DIRECTORY)
+          m_pathType(FILE)
     {
         updatePath();
     }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataFileName.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataFileName.h
@@ -44,12 +44,14 @@ public:
     typedef sofa::core::objectmodel::Data<std::string> Inherit;
 
     DataFileName( const std::string& helpMsg="", bool isDisplayed=true, bool isReadOnly=false )
-        : Inherit(helpMsg, isDisplayed, isReadOnly)
+        : Inherit(helpMsg, isDisplayed, isReadOnly),
+          m_isDir(false)
     {
     }
 
     DataFileName( const std::string& value, const std::string& helpMsg="", bool isDisplayed=true, bool isReadOnly=false )
-        : Inherit(value, helpMsg, isDisplayed, isReadOnly)
+        : Inherit(value, helpMsg, isDisplayed, isReadOnly),
+        m_isDir(false)
     {
         updatePath();
     }
@@ -58,7 +60,8 @@ public:
         this constructor should be used through the initData() methods
      */
     explicit DataFileName(const BaseData::BaseInitData& init)
-        : Inherit(init)
+        : Inherit(init),
+          m_isDir(false)
     {
     }
 
@@ -66,7 +69,8 @@ public:
         this constructor should be used through the initData() methods
      */
     explicit DataFileName(const Inherit::InitData& init)
-        : Inherit(init)
+        : Inherit(init),
+          m_isDir(false)
     {
         updatePath();
     }
@@ -92,6 +96,17 @@ public:
         *beginEdit()=v;
         endEdit();
     }
+
+    void setIsDirectory(bool isDir)
+    {
+        m_isDir = isDir;
+    }
+
+    bool isDirectory()
+    {
+        return m_isDir;
+    }
+
     virtual void virtualEndEdit() { endEdit(); }
     virtual void virtualSetValue(const std::string& v) { setValue(v); }
     virtual bool read(const std::string& s );
@@ -130,6 +145,7 @@ protected:
     std::string m_fullpath;
     std::string m_relativepath;
     std::string m_extension;
+    bool        m_isDir; //< used to determine how file dialogs should be opened
 
 private:
     DataFileName(const Inherit& d);

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/BaseSimulationExporter.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/BaseSimulationExporter.cpp
@@ -49,6 +49,7 @@ BaseSimulationExporter::BaseSimulationExporter() :
   , d_isEnabled( initData(&d_isEnabled, true, "enable", "Enable or disable the component. (default=true)"))
 {
     f_listening.setValue(false) ;
+    d_filename.setPathType(core::objectmodel::PathType::BOTH);
 }
 
 


### PR DESCRIPTION
This PR adds an attribute pathType (m_pathType) in DataFileName and DataFileNameVector to be able to easily identify whether a component holding a DataFileName accepts files, directories or both. This is useful to provide custom fileDialogs in user interfaces such as runSofa2, give more information about the type of values a dataFileName takes, and  provide better error messages.

To use it: in the ctor of the component, on a DataFileName datafield, call setPathType(<PathType>) (<PathType> being an enum value of either FILE, DIRECTORY or BOTH. Default value is FILE)

The PathType of a DataFileName can be queried by calling getPathType().

In addition, checks are made within the updatePath() method of DataFileName, called when the value changes, to guarantee that the value set is consistent with the defined path type.

Since the default pathtype is set to FILE, there are only few components that are directly affected by the pull request (AddResourceRepository is one of them (takes only directories), MeshExporters have a DataFileNameVector which can accept both directories and files. Those 2 components had to be modified to behave properly, and I've been able to identify them thanks to the existing unit tests & scene tests that we compile on the CI. There's no guarantee that there isn't any untested component that should be updated too, but the fix is easy (setPathType(WHATEVER) in the ctor of the component). Same goes for pluginized components of course.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
