### PR TITLE
[SofaKernel] Set default visibility to SOFA_EXPORT_DYNAMIC_LIBRARY

### DIFF
--- a/SofaKernel/SofaFramework/sharedlibrary_defines.h.in
+++ b/SofaKernel/SofaFramework/sharedlibrary_defines.h.in
@@ -23,7 +23,7 @@
 #define SOFA_CONFIG_SHAREDLIBRARY_DEFINES_H
 
 #ifndef WIN32
-#	define SOFA_EXPORT_DYNAMIC_LIBRARY
+#	define SOFA_EXPORT_DYNAMIC_LIBRARY __attribute__ ((visibility ("default")))
 #   define SOFA_IMPORT_DYNAMIC_LIBRARY
 #else
 #	define SOFA_EXPORT_DYNAMIC_LIBRARY __declspec( dllexport )


### PR DESCRIPTION
On clang/g++ the visibility is not set (left blank). 

This means that a sofa code using SOFA_EXPORT_DYNAMIC_LIBRARY but compiled with a command line setting the unspecified visibility to "hidden" will have linkage problems. 

This fix the issue so now public code...are really public in clang/g++ 

I'm not sure if there is non win32 compiler that does not understand this attribute. If this is the case,it is possible to add extra #ifdef GCC & CLANG & xxx

DM




______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
