### PR TITLE
[SofaEigen2Solver] Fix cmake test on the version of Eigen

### DIFF
--- a/SofaKernel/modules/SofaEigen2Solver/CMakeLists.txt
+++ b/SofaKernel/modules/SofaEigen2Solver/CMakeLists.txt
@@ -21,7 +21,7 @@ set(SOURCE_FILES
 
 find_package(Eigen3 REQUIRED)
 
-if (SOFA_OPENMP AND "${Eigen3_VERSION}" VERSION_LESS 3.2.9)
+if (SOFA_OPENMP AND "${EIGEN3_VERSION}" VERSION_LESS 3.2.9)
     sofa_find_package(OpenMP BOTH_SCOPES) # will set/update SOFAEIGEN2SOLVER_HAVE_OPENMP
 endif()
 


### PR DESCRIPTION
`FindEigen3.cmake` is defining the cmake variable **EIGEN3_VERSION**, whereas `SofaEigen2Solver` was using **Eigen3_VERSION** to get the version of Eigen (which was
empty). Hence, **SOFAEIGEN2SOLVER_HAVE_OPENMP** was always true (given **SOFA_OPENMP**=ON), which was making the compilation fail when using Eigen > 3.2.9.

Fixes #1412 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
