### PR TITLE
[SofaGeneralLoader] Allow flip normals in Gmsh and STL loaders

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/loader/MeshLoader.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/loader/MeshLoader.cpp
@@ -733,7 +733,6 @@ void MeshLoader::addTriangle(helper::vector<Triangle >* pTriangles, const Triang
     {
         Triangle revertP;
         std::reverse_copy(p.begin(), p.end(), revertP.begin());
-
         pTriangles->push_back(revertP);
     }
     else
@@ -832,30 +831,42 @@ void MeshLoader::copyMeshToData(sofa::helper::io::Mesh* _mesh)
 {
     // copy vertices
     helper::vector<sofa::defaulttype::Vec3>& my_positions = *(d_positions.beginEdit());
-    my_positions = _mesh->getVertices();
+    helper::vector<sofa::defaulttype::Vec3> allVertices = _mesh->getVertices();
+    for(size_t i=0; i<allVertices.size(); i++)
+        this->addPosition(&my_positions, allVertices[i]);
     d_positions.endEdit();
 
     // copy 2D topoogy
     helper::vector<Edge>& my_edges = *(d_edges.beginEdit());
-    my_edges = _mesh->getEdges();
+    helper::vector<Edge> allEdges = _mesh->getEdges();
+    for(size_t i=0; i<allEdges.size(); i++)
+        this->addEdge(&my_edges, allEdges[i]);
     d_edges.endEdit();
 
     helper::vector<Triangle>& my_triangles = *(d_triangles.beginEdit());
-    my_triangles = _mesh->getTriangles();
+    helper::vector<Triangle> allTriangles = _mesh->getTriangles();
+    for(size_t i=0; i<allTriangles.size(); i++)
+        this->addTriangle(&my_triangles, allTriangles[i]);
     d_triangles.endEdit();
 
     helper::vector<Quad>& my_quads = *(d_quads.beginEdit());
-    my_quads = _mesh->getQuads();
+    helper::vector<Quad> allQuads = _mesh->getQuads();
+    for(size_t i=0; i<allQuads.size(); i++)
+        this->addQuad(&my_quads, allQuads[i]);
     d_quads.endEdit();
 
 
     // copy 3D elements
     helper::vector<Tetrahedron>& my_tetrahedra = *(d_tetrahedra.beginEdit());
-    my_tetrahedra = _mesh->getTetrahedra();
+    helper::vector<Tetrahedron> allTets = _mesh->getTetrahedra();
+    for(size_t i=0; i<allTets.size(); i++)
+        this->addTetrahedron(&my_tetrahedra, allTets[i]);
     d_tetrahedra.endEdit();
 
     helper::vector<Hexahedron>& my_hexahedra = *(d_hexahedra.beginEdit());
-    my_hexahedra = _mesh->getHexahedra();
+    helper::vector<Hexahedron> allHexs = _mesh->getHexahedra();
+    for(size_t i=0; i<allHexs.size(); i++)
+        this->addHexahedron(&my_hexahedra, allHexs[i]);
     d_hexahedra.endEdit();
 
     // copy groups

--- a/SofaKernel/modules/SofaCore/src/sofa/core/loader/MeshLoader.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/loader/MeshLoader.cpp
@@ -831,26 +831,26 @@ void MeshLoader::copyMeshToData(sofa::helper::io::Mesh* _mesh)
 {
     // copy vertices
     helper::vector<sofa::defaulttype::Vec3>& my_positions = *(d_positions.beginEdit());
-    helper::vector<sofa::defaulttype::Vec3> allVertices = _mesh->getVertices();
+    const helper::vector<sofa::defaulttype::Vec3>& allVertices = _mesh->getVertices();
     for(size_t i=0; i<allVertices.size(); i++)
         this->addPosition(&my_positions, allVertices[i]);
     d_positions.endEdit();
 
     // copy 2D topoogy
     helper::vector<Edge>& my_edges = *(d_edges.beginEdit());
-    helper::vector<Edge> allEdges = _mesh->getEdges();
+    const helper::vector<Edge>& allEdges = _mesh->getEdges();
     for(size_t i=0; i<allEdges.size(); i++)
         this->addEdge(&my_edges, allEdges[i]);
     d_edges.endEdit();
 
     helper::vector<Triangle>& my_triangles = *(d_triangles.beginEdit());
-    helper::vector<Triangle> allTriangles = _mesh->getTriangles();
+    const helper::vector<Triangle>& allTriangles = _mesh->getTriangles();
     for(size_t i=0; i<allTriangles.size(); i++)
         this->addTriangle(&my_triangles, allTriangles[i]);
     d_triangles.endEdit();
 
     helper::vector<Quad>& my_quads = *(d_quads.beginEdit());
-    helper::vector<Quad> allQuads = _mesh->getQuads();
+    const helper::vector<Quad>& allQuads = _mesh->getQuads();
     for(size_t i=0; i<allQuads.size(); i++)
         this->addQuad(&my_quads, allQuads[i]);
     d_quads.endEdit();
@@ -858,13 +858,13 @@ void MeshLoader::copyMeshToData(sofa::helper::io::Mesh* _mesh)
 
     // copy 3D elements
     helper::vector<Tetrahedron>& my_tetrahedra = *(d_tetrahedra.beginEdit());
-    helper::vector<Tetrahedron> allTets = _mesh->getTetrahedra();
+    const helper::vector<Tetrahedron>& allTets = _mesh->getTetrahedra();
     for(size_t i=0; i<allTets.size(); i++)
         this->addTetrahedron(&my_tetrahedra, allTets[i]);
     d_tetrahedra.endEdit();
 
     helper::vector<Hexahedron>& my_hexahedra = *(d_hexahedra.beginEdit());
-    helper::vector<Hexahedron> allHexs = _mesh->getHexahedra();
+    const helper::vector<Hexahedron>& allHexs = _mesh->getHexahedra();
     for(size_t i=0; i<allHexs.size(); i++)
         this->addHexahedron(&my_hexahedra, allHexs[i]);
     d_hexahedra.endEdit();

--- a/examples/Components/loader/MeshGmshLoader.scn
+++ b/examples/Components/loader/MeshGmshLoader.scn
@@ -2,16 +2,17 @@
 <!-- For more details see: https://wiki.sofa-framework.org/tdev/wiki/Notes/NewLoaderArchitecture -->
 <Node name="Root" gravity="0 -9.81 0" dt="0.05">
     <RequiredPlugin name="SofaOpenglVisual"/>
+    <RequiredPlugin pluginName='SofaMiscCollision'/>
     <VisualStyle displayFlags="showVisual showBehaviorModels showForceFields showCollision showMapping" />
     <DefaultPipeline name="DefaultCollisionPipeline" verbose="0" draw="0" depth="6" />
     <BruteForceDetection name="Detection" />
     <MinProximityIntersection name="Proximity" alarmDistance="0.3" contactDistance="0.2" />
     <DefaultContactManager name="Response" response="default" />
-    <TreeCollisionGroupManager name="Group" />
+    <DefaultCollisionGroupManager name="Group" />
     <Node name="gmsh file">
         <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-        <MeshGmshLoader name="GmshLoader" filename="mesh/square3.msh" createSubelements="true" />
+        <MeshGmshLoader name="GmshLoader" filename="mesh/square3.msh" createSubelements="true" flipNormals="0" />
         <MechanicalObject name="dofs" scale="10" src="@GmshLoader" />
         <TriangleSetTopologyContainer name="topo" src="@GmshLoader" />
         <TriangleSetTopologyModifier name="modif" />

--- a/examples/Components/loader/MeshSTLLoader.scn
+++ b/examples/Components/loader/MeshSTLLoader.scn
@@ -3,6 +3,6 @@
     <RequiredPlugin name="SofaOpenglVisual"/>
     <VisualStyle displayFlags="showVisual" />
 
-    <MeshSTLLoader name="STLLoader" filename="mesh/circle_knot_ascii.stl" printLog="true" />
+    <MeshSTLLoader name="STLLoader" filename="mesh/circle_knot_ascii.stl" printLog="true" flipNormals="0" />
     <OglModel src="@STLLoader" name="VisualModel" color="red" />
 </Node>

--- a/examples/Components/loader/MeshVTKLoader.scn
+++ b/examples/Components/loader/MeshVTKLoader.scn
@@ -10,7 +10,7 @@
     <Node name="vtk file">
         <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-        <MeshVTKLoader name="VtkLoader" filename="mesh/liver.vtk" />
+        <MeshVTKLoader name="VtkLoader" filename="mesh/liver.vtk" flipNormals="0"/>
         <!--	  <MeshGmshLoader name="loader" filename="mesh/square3.msh" /> -->
         <MechanicalObject name="dofs" scale="1" src="@VtkLoader" />
         <TriangleSetTopologyContainer name="topo" src="@VtkLoader" />

--- a/modules/SofaGeneralLoader/MeshGmshLoader.cpp
+++ b/modules/SofaGeneralLoader/MeshGmshLoader.cpp
@@ -265,8 +265,9 @@ bool MeshGmshLoader::readGmsh(std::ifstream &file, const unsigned int gmshFormat
                 nnodes = 0;
             }
         }
-        //store real index of node and not line index
 
+
+        //store real index of node and not line index
         helper::vector <unsigned int> nodes;
         nodes.resize (nnodes);
         const unsigned int edgesInQuadraticTriangle[3][2] = {{0,1}, {1,2}, {2,0}};

--- a/modules/SofaGeneralLoader/MeshSTLLoader.cpp
+++ b/modules/SofaGeneralLoader/MeshSTLLoader.cpp
@@ -199,7 +199,7 @@ bool MeshSTLLoader::readBinarySTL(const char *filename)
     if(my_triangles.size() != (size_t)nbrFacet)
     {
         msg_error() << "Size mismatch between triangle vector and facetSize";
-        m_componentstate = sofa::core::objectmodel::ComponentState::Invalid;
+        return false;
     }
 
     this->d_positions.endEdit();

--- a/modules/SofaGeneralLoader/MeshSTLLoader.cpp
+++ b/modules/SofaGeneralLoader/MeshSTLLoader.cpp
@@ -134,8 +134,8 @@ bool MeshSTLLoader::readBinarySTL(const char *filename)
     // temporaries
     sofa::defaulttype::Vec3f vertex, normal;
 
-    // clear before filling it
-    my_triangles.clear();
+    // reserve vector before filling it
+    my_triangles.reserve( nbrFacet );
 
     // Parsing facets
     for (uint32_t i = 0; i<nbrFacet; ++i)
@@ -194,15 +194,13 @@ bool MeshSTLLoader::readBinarySTL(const char *filename)
         // Attribute byte count
         uint16_t count;
         dataFile.read((char*)&count, 2);
-
-        // Security: // checked once before reading in debug mode
-//        position = dataFile.tellg();
-//        if (position == length)
-//            break;
     }
 
     if(my_triangles.size() != (size_t)nbrFacet)
+    {
         msg_error() << "Size mismatch between triangle vector and facetSize";
+        m_componentstate = sofa::core::objectmodel::ComponentState::Invalid;
+    }
 
     this->d_positions.endEdit();
     this->d_triangles.endEdit();


### PR DESCRIPTION
Allow all loaders (namely Gmsh and STL) to flipNormals (actually reorder the indices of vertices in a triangle).
Update associated scenes.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
