### PR TITLE
[all] Fix warnings due to visibility attribute

### DIFF
--- a/SofaKernel/modules/SofaBaseCollision/IntrUtility3.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/IntrUtility3.cpp
@@ -44,7 +44,7 @@ template class SOFA_BASE_COLLISION_API FindContactSet<TOBB<Rigid3Types> >;
 template SOFA_BASE_COLLISION_API void ClipConvexPolygonAgainstPlane<double> (const Vec<3,double>&, double,int&, Vec<3,double>*);
 template SOFA_BASE_COLLISION_API Vec<3,double> GetPointFromIndex<double> (int, const MyBox<double>&);
 template SOFA_BASE_COLLISION_API Vec<3,Rigid3Types::Real> getPointFromIndex<Rigid3Types> (int index, const TOBB<Rigid3Types>& box);
-template SOFA_BASE_COLLISION_API class CapIntrConfiguration<double>;
+template class SOFA_BASE_COLLISION_API CapIntrConfiguration<double>;
 
 //----------------------------------------------------------------------------
 

--- a/SofaKernel/modules/SofaBaseCollision/IntrUtility3.h
+++ b/SofaKernel/modules/SofaBaseCollision/IntrUtility3.h
@@ -335,7 +335,7 @@ extern template struct SOFA_BASE_COLLISION_API IntrConfigManager<TOBB<defaulttyp
 extern template SOFA_BASE_COLLISION_API void ClipConvexPolygonAgainstPlane(const defaulttype::Vec<3,SReal>&, SReal, int&,defaulttype::Vec<3,SReal>*);
 extern template SOFA_BASE_COLLISION_API defaulttype::Vec<3,SReal> GetPointFromIndex (int, const MyBox<SReal>& );
 extern template SOFA_BASE_COLLISION_API defaulttype::Vec<3,defaulttype::Rigid3Types::Real> getPointFromIndex (int, const TOBB<defaulttype::Rigid3Types>& );
-extern template SOFA_BASE_COLLISION_API class CapIntrConfiguration<SReal>;
+extern template class SOFA_BASE_COLLISION_API CapIntrConfiguration<SReal>;
 
 #endif
 

--- a/SofaKernel/modules/SofaBaseLinearSolver/FullVector.cpp
+++ b/SofaKernel/modules/SofaBaseLinearSolver/FullVector.cpp
@@ -63,7 +63,7 @@ template<> double FullVector<bool>::norm() const
     return helper::rsqrt(r);
 }
 
-template SOFA_BASE_LINEAR_SOLVER_API class FullVector<bool>;
+template class SOFA_BASE_LINEAR_SOLVER_API FullVector<bool>;
 
 } // namespace linearsolver
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/LCPcalc.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/LCPcalc.h
@@ -108,7 +108,7 @@ SOFA_HELPER_API void afficheLCP(double *q, double **M, int dim);
 SOFA_HELPER_API void afficheLCP(double *q, double **M, double *f, int dim);
 SOFA_HELPER_API void resultToString(std::ostream& s, double *f, int dim);
 
-typedef SOFA_HELPER_API double FemClipsReal;
+typedef double FemClipsReal;
 SOFA_HELPER_API void gaussSeidelLCP1(int dim, FemClipsReal * q, FemClipsReal ** M, FemClipsReal * res, double tol, int numItMax, double minW=0.0, double maxF=0.0, std::vector<double>* residuals = nullptr);
 
 

--- a/applications/plugins/PluginExample/src/PluginExample/MyVisualModel.h
+++ b/applications/plugins/PluginExample/src/PluginExample/MyVisualModel.h
@@ -47,7 +47,7 @@ public:
     void init() override;
     void reinit() override;
 
-    void updateBuffers() {}
+    void updateBuffers() override {}
 
 protected:
 };

--- a/applications/sofa/gui/qt/viewer/OglModelPolicy.h
+++ b/applications/sofa/gui/qt/viewer/OglModelPolicy.h
@@ -58,7 +58,7 @@ public:
 protected:
 };
 
-typedef SOFA_SOFAGUIQT_API CustomPolicySofaViewer< OglModelPolicy > OglModelSofaViewer;
+typedef CustomPolicySofaViewer< OglModelPolicy > OglModelSofaViewer;
 
 } // namespace viewer
 } // namespace qt


### PR DESCRIPTION
Just not 100% sure for LCPcalc.h  and OglModelPolicy.h 
Else we should get back to original warning number.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
