### PR TITLE
[SofaOpenGLVisual] Use updateCallback to update OglModel's internal buffers

### DIFF
--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglModel.h
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglModel.h
@@ -127,6 +127,7 @@ public:
     bool hasTransparent() override;
     bool hasTexture();
 
+    bool m_isDirty{true};
 public:
     bool isUseEdges()	{ return useEdges; }
     bool isUseTriangles()	{ return useTriangles; }
@@ -151,6 +152,7 @@ public:
     void updateEdgesIndicesBuffer();
     void updateTrianglesIndicesBuffer();
     void updateQuadsIndicesBuffer();
+    void deleteBuffers();
 };
 
 typedef sofa::defaulttype::Vec<3,GLfloat> GLVec3f;


### PR DESCRIPTION
Needs #1408 
OglModel recomputes its internal data on topology change.

There's 2 things I need review for here:
1. which initialization methods should be called to properly update an OglModel? Currently, I'm calling more or less the whole thing: delete buffers, then init / reinit / initVisual & updateBuffers. Not sure all of them are necessary
2. Which datafields should be taken into consideration for a total reinit:
 Ideally I'd like to trigger the full update of the OglModel only when a change in the loader triggers the recomputation: positions can vary during simulation and shouldn't trigger a reload of the component.
Edges / triangles & other topological info change when the loader changes geometry, but could also change during a topological change for instance, and in that 2nd case shouldn't trigger a reload from the loader, whose topology isn't up-to-date anymore.

This component needs heavy restructuring I believe if we want to handle proper data update using callbacks, and might be a good example for other components if we do it right

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
