### PR TITLE
[SofaHelper] Fix fixed_array compilation with VS2019

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/fixed_array.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/fixed_array.h
@@ -56,7 +56,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cassert>
-
+#include <iostream>
 
 namespace sofa
 {


### PR DESCRIPTION
For whatever reason, MSVC19 does not compile anymore because of streams in fixed_array (maybe an update in the stl code)
And after further tries, it is not really possible to just deal with iosfwd.h and the implementation in a cpp file (because of templates). 
Anyway, everything is including iostream so it wont hurt more the compilation time.⏳



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
