### PR TITLE
[plugins] Add SofaPython3 as external project in SOFA

### DIFF
--- a/applications/plugins/CMakeLists.txt
+++ b/applications/plugins/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.12)
 find_package(SofaFramework)
 
 sofa_add_subdirectory_external(SofaHighOrder SofaHighOrder)
+sofa_add_subdirectory_external(SofaPython3 SofaPython3)
 
 sofa_add_plugin(CImgPlugin CImgPlugin ON) # ON by default and first as it is used by other plugins.
 sofa_add_plugin(SofaEulerianFluid SofaEulerianFluid)

--- a/applications/plugins/SofaPython3/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/SofaPython3/ExternalProjectConfig.cmake.in
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.11)
 
 include(ExternalProject)
 ExternalProject_Add(SofaPython3
-    GIT_REPOSITORY https://github.com/SofaDefrost/plugin.SofaPython3
+    GIT_REPOSITORY https://github.com/sofa-framework/SofaPython3
     GIT_TAG origin/master
     SOURCE_DIR "${CMAKE_SOURCE_DIR}/applications/plugins/SofaPython3"
     BINARY_DIR ""

--- a/applications/plugins/SofaPython3/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/SofaPython3/ExternalProjectConfig.cmake.in
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.11)
+
+include(ExternalProject)
+ExternalProject_Add(SofaPython3
+    GIT_REPOSITORY https://github.com/SofaDefrost/plugin.SofaPython3
+    GIT_TAG origin/master
+    SOURCE_DIR "${CMAKE_SOURCE_DIR}/applications/plugins/SofaPython3"
+    BINARY_DIR ""
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    TEST_COMMAND ""
+)


### PR DESCRIPTION
Everything is in the name.
I checked compilation on Linux.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
