### PR TITLE
[SofaHighOrder] Update URL of external repository

### DIFF
--- a/applications/plugins/SofaHighOrder/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/SofaHighOrder/ExternalProjectConfig.cmake.in
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.2)
 
 include(ExternalProject)
 ExternalProject_Add(SofaHighOrder
-    GIT_REPOSITORY https://github.com/sofa-framework/plugin.HighOrder
+    GIT_REPOSITORY https://github.com/sofa-framework/SofaHighOrder
     GIT_TAG origin/master
     SOURCE_DIR "${CMAKE_SOURCE_DIR}/applications/plugins/SofaHighOrder"
     BINARY_DIR ""


### PR DESCRIPTION
Name / link change : 
- from https://github.com/sofa-framework/plugin.HighOrder
- to https://github.com/sofa-framework/SofaHighOrder

More info: https://github.com/sofa-framework/plugin.HighOrder/issues/5

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
