### PR TITLE
[SofaHelper] ADD: singleton for ConsoleMessageHandler

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/logging/ConsoleMessageHandler.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/logging/ConsoleMessageHandler.cpp
@@ -51,6 +51,12 @@ void ConsoleMessageHandler::setMessageFormatter(MessageFormatter* formatter)
     m_formatter = formatter;
 }
 
+ConsoleMessageHandler& MainConsoleMessageHandler::getInstance()
+{
+    static ConsoleMessageHandler s_instance;
+    return s_instance;
+}
+
 } // logging
 } // helper
 } // sofa

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/logging/ConsoleMessageHandler.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/logging/ConsoleMessageHandler.h
@@ -57,6 +57,18 @@ private:
 
 };
 
+///
+/// \brief The MainConsoleMessageHandler class contains a singleton to ConsoleMessageHandler
+/// and offer static version of ConsoleMessageHandler API
+///
+/// \see ConsoleMessageHandler
+///
+class SOFA_HELPER_API MainConsoleMessageHandler
+{
+public:
+    static ConsoleMessageHandler& getInstance() ;
+};
+
 
 } // logging
 } // helper


### PR DESCRIPTION
Static access to the ConsoleMessageHandler (use case in SP3 ([PR #18](https://github.com/sofa-framework/SofaPython3/pull/18))





______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
