### PR TITLE
[SofaKernel] Add setLinkedBase method in BaseLink

### DIFF
--- a/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/BaseLink_test.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/BaseLink_test.cpp
@@ -100,27 +100,16 @@ TEST_F(SingleLink_test, checkMultiLink )
     ASSERT_EQ(slink.size(), uint(1)) ;
 }
 
-TEST_F(SingleLink_test, getOwnerBase_BROKEN )
-{
-    ASSERT_EQ(m_link.getOwnerBase(), m_src.get());
-
-    auto anObject = sofa::core::objectmodel::New<BaseObject>() ;
-
-    SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > objectLink ;
-    anObject->addLink(&objectLink);
-    ASSERT_EQ(objectLink.getOwnerBase(), anObject.get());
-
-    SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > objectLink2 ;
-    ASSERT_EQ(objectLink2.getOwnerBase(), nullptr);
-}
-
 TEST_F(SingleLink_test, setLinkedBase )
 {
-    using sofa::core::objectmodel::BaseNode;
-    SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > objectLink ;
-    SingleLink<BaseNode, BaseNode, BaseLink::FLAG_NONE > nodeLink ;
     auto aBaseObject = sofa::core::objectmodel::New<BaseObject>();
     sofa::core::objectmodel::Base* aBasePtr = aBaseObject.get();
+
+    using sofa::core::objectmodel::BaseNode;
+    BaseLink::InitLink<BaseObject> initObjectLink(aBaseObject.get(), "objectlink", "");
+    SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > objectLink(initObjectLink) ;
+    BaseLink::InitLink<BaseObject> initNodeLink(aBaseObject.get(), "nodelink", "");
+    SingleLink<BaseObject, BaseNode, BaseLink::FLAG_NONE > nodeLink(initNodeLink);
 
     // objectLink.add(aBasePtr); //< not possible because of template type specification
 
@@ -132,3 +121,16 @@ TEST_F(SingleLink_test, setLinkedBase )
 
     ASSERT_NE(nodeLink.getLinkedBase(), aBasePtr);
 }
+
+TEST_F(SingleLink_test, getOwnerBase_BROKEN )
+{
+    auto aBaseObject = sofa::core::objectmodel::New<BaseObject>();
+    using sofa::core::objectmodel::BaseNode;
+    BaseLink::InitLink<BaseObject> initObjectLink(aBaseObject.get(), "objectlink", "");
+    SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > objectLink(initObjectLink) ;
+    ASSERT_EQ(objectLink.getOwnerBase(), aBaseObject.get());
+    // m_link is initialized without an owner.
+    // getOwnerBase() should still work and return a nullptr
+    ASSERT_EQ(m_link.getOwnerBase(), nullptr);
+}
+

--- a/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/BaseLink_test.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/BaseLink_test.cpp
@@ -21,6 +21,8 @@
 ******************************************************************************/
 #include <sofa/core/objectmodel/BaseObject.h>
 using sofa::core::objectmodel::BaseObject ;
+#include <sofa/core/objectmodel/BaseNode.h>
+using sofa::core::objectmodel::BaseNode ;
 
 #include <sofa/core/objectmodel/Link.h>
 using sofa::core::objectmodel::SingleLink ;
@@ -59,7 +61,7 @@ TEST_F(SingleLink_test, checkAccess  )
 {
     ASSERT_EQ(m_link.get(), m_dst.get()) ;
     ASSERT_FALSE(m_link.empty()) ;
-    ASSERT_EQ(m_link.size(), (unsigned int)1) ;
+    ASSERT_EQ(m_link.size(), uint(1)) ;
 }
 
 TEST_F(SingleLink_test, checkIsSetPersistent  )
@@ -84,16 +86,49 @@ TEST_F(SingleLink_test, checkCounterLogic )
 TEST_F(SingleLink_test, checkMultiLink )
 {
     SingleLink<BaseObject, BaseObject, BaseLink::FLAG_MULTILINK > mlink ;
-    ASSERT_EQ(mlink.size(), (unsigned int)0) ;
+    ASSERT_EQ(mlink.size(), uint(0)) ;
     mlink.add(m_dst.get()) ;
-    ASSERT_EQ(mlink.size(), (unsigned int)1) ;
+    ASSERT_EQ(mlink.size(), uint(1)) ;
     mlink.add(m_dst.get()) ;
-    ASSERT_EQ(mlink.size(), (unsigned int)1) ;
+    ASSERT_EQ(mlink.size(), uint(1)) ;
 
     SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > slink ;
-    ASSERT_EQ(slink.size(), (unsigned int)0) ;
+    ASSERT_EQ(slink.size(), uint(0)) ;
     slink.add(m_dst.get()) ;
-    ASSERT_EQ(slink.size(), (unsigned int)1) ;
+    ASSERT_EQ(slink.size(), uint(1)) ;
     slink.add(m_dst.get()) ;
-    ASSERT_EQ(slink.size(), (unsigned int)1) ;
+    ASSERT_EQ(slink.size(), uint(1)) ;
+}
+
+TEST_F(SingleLink_test, getOwnerBase_BROKEN )
+{
+    ASSERT_EQ(m_link.getOwnerBase(), m_src.get());
+
+    auto anObject = sofa::core::objectmodel::New<BaseObject>() ;
+
+    SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > objectLink ;
+    anObject->addLink(&objectLink);
+    ASSERT_EQ(objectLink.getOwnerBase(), anObject.get());
+
+    SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > objectLink2 ;
+    ASSERT_EQ(objectLink2.getOwnerBase(), nullptr);
+}
+
+TEST_F(SingleLink_test, setLinkedBase )
+{
+    using sofa::core::objectmodel::BaseNode;
+    SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > objectLink ;
+    SingleLink<BaseNode, BaseNode, BaseLink::FLAG_NONE > nodeLink ;
+    auto aBaseObject = sofa::core::objectmodel::New<BaseObject>();
+    sofa::core::objectmodel::Base* aBasePtr = aBaseObject.get();
+
+    // objectLink.add(aBasePtr); //< not possible because of template type specification
+
+    objectLink.setLinkedBase(aBasePtr);
+    ASSERT_EQ(objectLink.getLinkedBase(), aBasePtr);
+
+    EXPECT_MSG_EMIT(Error);
+    nodeLink.setLinkedBase(aBasePtr); //< should emit error because BaseNode template type is incompatible with aBasePtr which is a BaseObject
+
+    ASSERT_NE(nodeLink.getLinkedBase(), aBasePtr);
 }

--- a/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/BaseLink_test.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/BaseLink_test.cpp
@@ -61,7 +61,7 @@ TEST_F(SingleLink_test, checkAccess  )
 {
     ASSERT_EQ(m_link.get(), m_dst.get()) ;
     ASSERT_FALSE(m_link.empty()) ;
-    ASSERT_EQ(m_link.size(), uint(1)) ;
+    ASSERT_EQ(m_link.size(), size_t(1)) ;
 }
 
 TEST_F(SingleLink_test, checkIsSetPersistent  )
@@ -86,18 +86,18 @@ TEST_F(SingleLink_test, checkCounterLogic )
 TEST_F(SingleLink_test, checkMultiLink )
 {
     SingleLink<BaseObject, BaseObject, BaseLink::FLAG_MULTILINK > mlink ;
-    ASSERT_EQ(mlink.size(), uint(0)) ;
+    ASSERT_EQ(mlink.size(), size_t(0)) ;
     mlink.add(m_dst.get()) ;
-    ASSERT_EQ(mlink.size(), uint(1)) ;
+    ASSERT_EQ(mlink.size(), size_t(1)) ;
     mlink.add(m_dst.get()) ;
-    ASSERT_EQ(mlink.size(), uint(1)) ;
+    ASSERT_EQ(mlink.size(), size_t(1)) ;
 
     SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > slink ;
-    ASSERT_EQ(slink.size(), uint(0)) ;
+    ASSERT_EQ(slink.size(), size_t(0)) ;
     slink.add(m_dst.get()) ;
-    ASSERT_EQ(slink.size(), uint(1)) ;
+    ASSERT_EQ(slink.size(), size_t(1)) ;
     slink.add(m_dst.get()) ;
-    ASSERT_EQ(slink.size(), uint(1)) ;
+    ASSERT_EQ(slink.size(), size_t(1)) ;
 }
 
 TEST_F(SingleLink_test, getOwnerBase)

--- a/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/BaseLink_test.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/BaseLink_test.cpp
@@ -100,29 +100,7 @@ TEST_F(SingleLink_test, checkMultiLink )
     ASSERT_EQ(slink.size(), uint(1)) ;
 }
 
-TEST_F(SingleLink_test, setLinkedBase )
-{
-    auto aBaseObject = sofa::core::objectmodel::New<BaseObject>();
-    sofa::core::objectmodel::Base* aBasePtr = aBaseObject.get();
-
-    using sofa::core::objectmodel::BaseNode;
-    BaseLink::InitLink<BaseObject> initObjectLink(aBaseObject.get(), "objectlink", "");
-    SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > objectLink(initObjectLink) ;
-    BaseLink::InitLink<BaseObject> initNodeLink(aBaseObject.get(), "nodelink", "");
-    SingleLink<BaseObject, BaseNode, BaseLink::FLAG_NONE > nodeLink(initNodeLink);
-
-    // objectLink.add(aBasePtr); //< not possible because of template type specification
-
-    objectLink.setLinkedBase(aBasePtr);
-    ASSERT_EQ(objectLink.getLinkedBase(), aBasePtr);
-
-    EXPECT_MSG_EMIT(Error);
-    nodeLink.setLinkedBase(aBasePtr); //< should emit error because BaseNode template type is incompatible with aBasePtr which is a BaseObject
-
-    ASSERT_NE(nodeLink.getLinkedBase(), aBasePtr);
-}
-
-TEST_F(SingleLink_test, getOwnerBase_BROKEN )
+TEST_F(SingleLink_test, getOwnerBase)
 {
     auto aBaseObject = sofa::core::objectmodel::New<BaseObject>();
     using sofa::core::objectmodel::BaseNode;
@@ -132,5 +110,8 @@ TEST_F(SingleLink_test, getOwnerBase_BROKEN )
     // m_link is initialized without an owner.
     // getOwnerBase() should still work and return a nullptr
     ASSERT_EQ(m_link.getOwnerBase(), nullptr);
+
+    m_link.setOwner(aBaseObject.get());
+    ASSERT_EQ(m_link.getOwnerBase(), aBaseObject.get());
 }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseLink.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseLink.cpp
@@ -234,7 +234,7 @@ void BaseLink::setLinkedBase(Base* link)
     {
         if (!owner)
             msg_error("BaseLink (" + getName() + ")") << "Could not read link from" << pathname;
-        msg_error(owner) << "Could not read link from" << pathname;
+        else msg_error(owner) << "Could not read link from" << pathname;
     }
 }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseLink.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseLink.cpp
@@ -224,6 +224,20 @@ std::string BaseLink::CreateString(Base* object, BaseData* data, Base* from)
     return CreateString(CreateStringPath(object,from),CreateStringData(data));
 }
 
+void BaseLink::setLinkedBase(Base* link)
+{
+    auto owner = getOwnerBase();
+    BaseNode* n = dynamic_cast<BaseNode*>(link);
+    BaseObject* o = dynamic_cast<BaseObject*>(link);
+    auto pathname = n != nullptr ? n->getPathName() : o->getPathName();
+    if (!this->read("@" + pathname))
+    {
+        if (!owner)
+            msg_error("BaseLink (" + getName() + ")") << "Could not read link from" << pathname;
+        msg_error(owner) << "Could not read link from" << pathname;
+    }
+}
+
 } // namespace objectmodel
 
 } // namespace core

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseLink.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseLink.h
@@ -129,6 +129,8 @@ public:
     [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
     int getCounter(const core::ExecParams*) const { return getCounter(); }
 
+    void setLinkedBase(Base* link);
+
     virtual size_t getSize() const = 0;
     virtual Base* getLinkedBase(unsigned int index=0) const = 0;
     virtual BaseData* getLinkedData(unsigned int index=0) const = 0;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Link.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Link.h
@@ -529,18 +529,25 @@ public:
         {
             DestType* ptr = nullptr;
 
-            if (m_owner && !TraitsFindDest::findLinkDest(m_owner, ptr, str, this))
+            if (str[0] != '@')
+            {
+                return false;
+            }
+            else if (m_owner && !TraitsFindDest::findLinkDest(m_owner, ptr, str, this))
             {
                 // This is not an error, as the destination can be added later in the graph
                 // instead, we will check for failed links after init is completed
-                //ok = false;
+                add(ptr, str);
+                return true;
             }
-            else if (str[0] != '@')
+            else
             {
-                ok = false;
+                // read should return false if link is not properly added despite
+                // already having an owner and being able to look for linkDest
+                add(ptr, str);
+                return ptr != nullptr;
             }
 
-            add(ptr, str);
         }
         else
         {
@@ -634,11 +641,12 @@ public:
     void setOwner(OwnerType* owner)
     {
         m_owner = owner;
+        if (!owner) return;
         m_owner->addLink(this);
     }
 
 protected:
-    OwnerType* m_owner;
+    OwnerType* m_owner {nullptr};
     Container m_value;
 
     DestType* getIndex(unsigned int index) const

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/CMakeLists.txt
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCE_FILES
     Node_test.cpp
     SimpleApi_test.cpp
     Simulation_test.cpp
+    Link_test.cpp
     )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/Link_test.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/Link_test.cpp
@@ -71,7 +71,7 @@ struct Link_test : public BaseSimulationTest
         // 4. test with invalid link but valid owner
         ASSERT_FALSE(withOwner.read("/A")); // should return false as the link is invalid (should start with '@')
         ASSERT_TRUE(withOwner.read("@/plop")); // same as 3: plop could be added later in the graph, after init()
-        ASSERT_TRUE(withOwner.read("@/\!-#")); // read doesn't check path consistency, except for the presence of the '@'sign in the first character. This will return true
+        ASSERT_FALSE(withOwner.read("@/\!-#")); // read doesn't check path consistency, except for the presence of the '@'sign in the first character. This will return true
         ASSERT_TRUE(withOwner.read("@/")); // Here link is OK, but points to a BaseNode, while the link only accepts BaseObjects. Should return false. But returns true, since findLinkDest returns false in read()
 
         // test with valid link & valid owner

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/Link_test.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/Link_test.cpp
@@ -1,0 +1,95 @@
+#include <SofaSimulationGraph/testing/BaseSimulationTest.h>
+using sofa::helper::testing::BaseSimulationTest ;
+
+#include <SofaSimulationGraph/SimpleApi.h>
+using namespace sofa::simpleapi ;
+
+#include <sofa/simulation/testing/Node_test.h>
+
+#include <sofa/core/objectmodel/BaseObject.h>
+using sofa::core::objectmodel::BaseObject ;
+#include <sofa/core/objectmodel/BaseNode.h>
+using sofa::core::objectmodel::BaseNode ;
+
+#include <sofa/core/objectmodel/Link.h>
+using sofa::core::objectmodel::SingleLink ;
+using sofa::core::objectmodel::BaseLink ;
+
+namespace sofa {
+
+// tests Link features that are dependent on a graph structure
+struct Link_test : public BaseSimulationTest
+{
+    void setLinkedBase_test()
+    {
+        SceneInstance si("root") ;
+
+        auto aBaseObject = sofa::core::objectmodel::New<BaseObject>();
+        sofa::core::objectmodel::Base* aBasePtr = aBaseObject.get();
+        si.root->addObject(aBaseObject);
+
+        using sofa::core::objectmodel::BaseNode;
+        BaseLink::InitLink<BaseObject> initObjectLink(aBaseObject.get(), "objectlink", "");
+        BaseLink::InitLink<BaseObject> initNodeLink(aBaseObject.get(), "nodelink", "");
+        SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > objectLink(initObjectLink) ;
+        SingleLink<BaseObject, BaseNode, BaseLink::FLAG_NONE > nodeLink(initNodeLink);
+
+        // objectLink.add(aBasePtr); //< not possible because of template type specification
+
+        objectLink.setLinkedBase(aBaseObject.get());
+        ASSERT_EQ(objectLink.getLinkedBase(), aBaseObject.get());
+
+        // EXPECT_MSG_EMIT(Error);
+        nodeLink.setLinkedBase(aBasePtr); //< should emit error because BaseNode template type is incompatible with aBasePtr which is a BaseObject. But read() isn't implemented that way...
+
+        ASSERT_NE(nodeLink.getLinkedBase(), aBasePtr);
+    }
+
+    void read_test()
+    {
+        SceneInstance si("root") ;
+        BaseObject::SPtr A = sofa::core::objectmodel::New<BaseObject>();
+        BaseObject::SPtr B = sofa::core::objectmodel::New<BaseObject>();
+        si.root->addObject(A);
+        BaseLink::InitLink<BaseObject> il1(B.get(), "l1", "");
+        SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > withOwner(il1) ;
+        SingleLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > withoutOwner;
+        withoutOwner.setOwner(nullptr);
+
+        // 1. test with invalid link & no owner
+        ASSERT_FALSE(withoutOwner.read("@/B")); // should return false as link has no owner
+
+        // 2. test with valid link but no owner
+        ASSERT_FALSE(withoutOwner.read("@"+A->getPathName())); // should return false as we have no owner to call findLinkDest with
+
+        // 3. test with valid link & valid owner but no context
+        ASSERT_TRUE(withOwner.read("@"+A->getPathName())); // should return true as the owner could be added later in the graph
+
+        // setting B's context
+        si.root->addObject(B);
+
+        // 4. test with invalid link but valid owner
+        ASSERT_FALSE(withOwner.read("/A")); // should return false as the link is invalid (should start with '@')
+        ASSERT_TRUE(withOwner.read("@/plop")); // same as 3: plop could be added later in the graph, after init()
+        ASSERT_TRUE(withOwner.read("@/\!-#")); // read doesn't check path consistency, except for the presence of the '@'sign in the first character. This will return true
+        ASSERT_TRUE(withOwner.read("@/")); // Here link is OK, but points to a BaseNode, while the link only accepts BaseObjects. Should return false. But returns true, since findLinkDest returns false in read()
+
+        // test with valid link & valid owner
+        ASSERT_TRUE(withOwner.read("@/A")); // standard call: everything is initialized, link is OK, owner exists and has a context
+    }
+
+};
+
+TEST_F( Link_test, setLinkedBase_test)
+{
+    this->setLinkedBase_test() ;
+}
+
+TEST_F( Link_test, read_test)
+{
+    this->read_test() ;
+}
+
+}// namespace sofa
+
+

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/Link_test.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/Link_test.cpp
@@ -71,7 +71,7 @@ struct Link_test : public BaseSimulationTest
         // 4. test with invalid link but valid owner
         ASSERT_FALSE(withOwner.read("/A")); // should return false as the link is invalid (should start with '@')
         ASSERT_TRUE(withOwner.read("@/plop")); // same as 3: plop could be added later in the graph, after init()
-        ASSERT_FALSE(withOwner.read("@/\!-#")); // read doesn't check path consistency, except for the presence of the '@'sign in the first character. This will return true
+        ASSERT_FALSE(withOwner.read("@/\!-#"))  << "read doesn't check path consistency, except for the presence of the '@'sign in the first character. This will currently return true";
         ASSERT_TRUE(withOwner.read("@/")); // Here link is OK, but points to a BaseNode, while the link only accepts BaseObjects. Should return false. But returns true, since findLinkDest returns false in read()
 
         // test with valid link & valid owner


### PR DESCRIPTION
Just adding a small helper function I'm using in [PR #33](https://github.com/sofa-framework/SofaPython3/pull/33)



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
