### PR TITLE
[SofaSparseSolver] FIX Metis and CSparse not found in install

### DIFF
--- a/modules/SofaSparseSolver/SofaSparseSolverConfig.cmake.in
+++ b/modules/SofaSparseSolver/SofaSparseSolverConfig.cmake.in
@@ -2,19 +2,12 @@
 
 @PACKAGE_INIT@
 
-set(SOFASPARSESOLVER_HAVE_METIS @SOFASPARSESOLVER_HAVE_METIS@)
-set(SOFASPARSESOLVER_HAVE_CSPARSE @SOFASPARSESOLVER_HAVE_CSPARSE@)
-
 find_package(SofaBase REQUIRED)
 find_package(SofaCommon REQUIRED)
 find_package(SofaGeneral REQUIRED)
 
-if(SOFASPARSESOLVER_HAVE_METIS)
-    find_package(Metis QUIET REQUIRED)
-endif()
-if(SOFASPARSESOLVER_HAVE_CSPARSE)
-    find_package(CSparse QUIET REQUIRED)
-endif()
+find_package(Metis QUIET REQUIRED)
+find_package(CSparse QUIET REQUIRED)
 
 ### Is the target existing ?
 if(NOT TARGET SofaSparseSolver)

--- a/modules/SofaSparseSolver/SofaSparseSolverConfig.cmake.in
+++ b/modules/SofaSparseSolver/SofaSparseSolverConfig.cmake.in
@@ -2,19 +2,12 @@
 
 @PACKAGE_INIT@
 
-# Add parent directory in CMAKE_PREFIX_PATH
-# to expose MetisConfig.cmake and CSparseConfig.cmake
-get_filename_component(parent_dir "${CMAKE_CURRENT_LIST_DIR}" DIRECTORY)
-if(NOT "${parent_dir}" IN_LIST CMAKE_PREFIX_PATH)
-    list(APPEND CMAKE_PREFIX_PATH "${parent_dir}")
-endif()
-
 find_package(SofaBase REQUIRED)
 find_package(SofaCommon REQUIRED)
 find_package(SofaGeneral REQUIRED)
 
-find_package(Metis QUIET REQUIRED)
-find_package(CSparse QUIET REQUIRED)
+find_package(Metis QUIET REQUIRED HINTS "${CMAKE_CURRENT_LIST_DIR}/..")
+find_package(CSparse QUIET REQUIRED HINTS "${CMAKE_CURRENT_LIST_DIR}/..")
 
 ### Is the target existing ?
 if(NOT TARGET SofaSparseSolver)

--- a/modules/SofaSparseSolver/SofaSparseSolverConfig.cmake.in
+++ b/modules/SofaSparseSolver/SofaSparseSolverConfig.cmake.in
@@ -2,6 +2,13 @@
 
 @PACKAGE_INIT@
 
+# Add parent directory in CMAKE_PREFIX_PATH
+# to expose MetisConfig.cmake and CSparseConfig.cmake
+get_filename_component(parent_dir "${CMAKE_CURRENT_LIST_DIR}" DIRECTORY)
+if(NOT "${parent_dir}" IN_LIST CMAKE_PREFIX_PATH)
+    list(APPEND CMAKE_PREFIX_PATH "${parent_dir}")
+endif()
+
 find_package(SofaBase REQUIRED)
 find_package(SofaCommon REQUIRED)
 find_package(SofaGeneral REQUIRED)


### PR DESCRIPTION
Metis and CSparse are always required by SofaSparseSolver, no need have their find_package in if blocks.

Thanks @AlbanOdot for spotting the issue :beers: 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
