### PR TITLE
[SofaSparseSolver] FIX Metis and CSparse not found in install (redo)

### DIFF
--- a/modules/SofaSparseSolver/CMakeLists.txt
+++ b/modules/SofaSparseSolver/CMakeLists.txt
@@ -7,11 +7,14 @@ find_package(SofaCommon REQUIRED) # SofaImplicitOdeSolver SofaSimpleFem
 find_package(SofaGeneral REQUIRED) # SofaGeneralLinearSolver
 
 add_subdirectory(extlibs/csparse)
+sofa_set_01(SOFASPARSESOLVER_HAVE_CSPARSE TRUE)
+
 find_package(metis QUIET) # Unix users can have an installed version of metis
 if(NOT metis_FOUND)
-    message(STATUS "SofaSparseSolver: metis library not found, will use built-in metis library.")
+    message(STATUS "SofaSparseSolver: using built-in metis library")
     add_subdirectory(extlibs/metis-5.1.0)
 endif()
+sofa_set_01(SOFASPARSESOLVER_HAVE_METIS TRUE)
 
 set(SRC_ROOT src/SofaSparseSolver)
 

--- a/modules/SofaSparseSolver/SofaSparseSolverConfig.cmake.in
+++ b/modules/SofaSparseSolver/SofaSparseSolverConfig.cmake.in
@@ -2,12 +2,19 @@
 
 @PACKAGE_INIT@
 
+set(SOFASPARSESOLVER_HAVE_METIS @SOFASPARSESOLVER_HAVE_METIS@)
+set(SOFASPARSESOLVER_HAVE_CSPARSE @SOFASPARSESOLVER_HAVE_CSPARSE@)
+
 find_package(SofaBase REQUIRED)
 find_package(SofaCommon REQUIRED)
 find_package(SofaGeneral REQUIRED)
 
-find_package(Metis QUIET REQUIRED HINTS "${CMAKE_CURRENT_LIST_DIR}/..")
-find_package(CSparse QUIET REQUIRED HINTS "${CMAKE_CURRENT_LIST_DIR}/..")
+if(SOFASPARSESOLVER_HAVE_METIS)
+    find_package(Metis QUIET REQUIRED)
+endif()
+if(SOFASPARSESOLVER_HAVE_CSPARSE)
+    find_package(CSparse QUIET REQUIRED)
+endif()
 
 ### Is the target existing ?
 if(NOT TARGET SofaSparseSolver)

--- a/modules/SofaSparseSolver/SofaSparseSolverConfig.cmake.in
+++ b/modules/SofaSparseSolver/SofaSparseSolverConfig.cmake.in
@@ -10,10 +10,10 @@ find_package(SofaCommon REQUIRED)
 find_package(SofaGeneral REQUIRED)
 
 if(SOFASPARSESOLVER_HAVE_METIS)
-    find_package(Metis QUIET REQUIRED)
+    find_package(Metis QUIET REQUIRED HINTS "${CMAKE_CURRENT_LIST_DIR}/..")
 endif()
 if(SOFASPARSESOLVER_HAVE_CSPARSE)
-    find_package(CSparse QUIET REQUIRED)
+    find_package(CSparse QUIET REQUIRED HINTS "${CMAKE_CURRENT_LIST_DIR}/..")
 endif()
 
 ### Is the target existing ?


### PR DESCRIPTION
This is a quick redo of #1437 
I did not see that SOFASPARSESOLVER_HAVE_METIS and SOFASPARSESOLVER_HAVE_CSPARSE are actually used in SofaSparseSolver sources :fearful: 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
