### PR TITLE
[SofaCore] FIX simu unload crash caused by missing checks on slaves ptrs

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.cpp
@@ -54,11 +54,11 @@ BaseObject::BaseObject()
 BaseObject::~BaseObject()
 {
     assert(l_master.get() == nullptr); // an object that is still a slave should not be able to be deleted, as at least one smart pointer points to it
-    for(VecSlaves::const_iterator iSlaves = l_slaves.begin(); iSlaves != l_slaves.end(); ++iSlaves)
+    for(auto slave : l_slaves)
     {
-        if (iSlaves->get())
+        if (slave.get())
         {
-            (*iSlaves)->l_master.reset();
+            slave->l_master.reset();
         }
     }
 }
@@ -69,11 +69,11 @@ void BaseObject::changeContextLink(BaseContext* before, BaseContext*& after)
 {
     if (!after) after = BaseContext::getDefault();
     if (before == after) return;
-    for (unsigned int i = 0; i < l_slaves.size(); ++i)
+    for (auto slave : l_slaves)
     {
-        if (l_slaves.get(i))
+        if (slave.get())
         {
-            l_slaves.get(i)->l_context.set(after);
+            slave->l_context.set(after);
         }
     }
     if (after != BaseContext::getDefault())
@@ -221,10 +221,10 @@ const BaseObject::VecSlaves& BaseObject::getSlaves() const
 
 BaseObject* BaseObject::getSlave(const std::string& name) const
 {
-    for(VecSlaves::const_iterator iSlaves = l_slaves.begin(); iSlaves != l_slaves.end(); ++iSlaves)
+  for (auto slave : l_slaves)
     {
-        if ((*iSlaves)->getName() == name)
-            return iSlaves->get();
+      if (slave.get() && slave->getName() == name)
+	return slave.get();
     }
     return nullptr;
 }
@@ -252,11 +252,11 @@ void BaseObject::removeSlave(BaseObject::SPtr s)
 
 void BaseObject::init()
 {
-    for(VecData::const_iterator iData = this->m_vecData.begin(); iData != this->m_vecData.end(); ++iData)
+  for(auto data: this->m_vecData)
     {
-        if ((*iData)->isRequired() && !(*iData)->isSet())
+        if (data->isRequired() && !data->isSet())
         {
-        msg_warning() << "Required data \"" << (*iData)->getName() << "\" has not been set. (Current value is " << (*iData)->getValueString() << ")" ;
+            msg_warning() << "Required data \"" << data->getName() << "\" has not been set. (Current value is " << data->getValueString() << ")" ;
         }
     }
 }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.cpp
@@ -57,7 +57,9 @@ BaseObject::~BaseObject()
     for(VecSlaves::const_iterator iSlaves = l_slaves.begin(); iSlaves != l_slaves.end(); ++iSlaves)
     {
         if (iSlaves->get())
+        {
             (*iSlaves)->l_master.reset();
+        }
     }
 }
 
@@ -67,7 +69,13 @@ void BaseObject::changeContextLink(BaseContext* before, BaseContext*& after)
 {
     if (!after) after = BaseContext::getDefault();
     if (before == after) return;
-    for (unsigned int i = 0; i < l_slaves.size(); ++i) if (l_slaves.get(i)) l_slaves.get(i)->l_context.set(after);
+    for (unsigned int i = 0; i < l_slaves.size(); ++i)
+    {
+        if (l_slaves.get(i))
+        {
+            l_slaves.get(i)->l_context.set(after);
+        }
+    }
     if (after != BaseContext::getDefault())
     {
         // update links
@@ -244,13 +252,13 @@ void BaseObject::removeSlave(BaseObject::SPtr s)
 
 void BaseObject::init()
 {
-	for(VecData::const_iterator iData = this->m_vecData.begin(); iData != this->m_vecData.end(); ++iData)
-	{
-		if ((*iData)->isRequired() && !(*iData)->isSet())
-		{
+    for(VecData::const_iterator iData = this->m_vecData.begin(); iData != this->m_vecData.end(); ++iData)
+    {
+        if ((*iData)->isRequired() && !(*iData)->isSet())
+        {
         msg_warning() << "Required data \"" << (*iData)->getName() << "\" has not been set. (Current value is " << (*iData)->getValueString() << ")" ;
-		}
-	}
+        }
+    }
 }
 
 void BaseObject::bwdInit()

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.cpp
@@ -221,10 +221,10 @@ const BaseObject::VecSlaves& BaseObject::getSlaves() const
 
 BaseObject* BaseObject::getSlave(const std::string& name) const
 {
-  for (auto slave : l_slaves)
+    for (auto slave : l_slaves)
     {
-      if (slave.get() && slave->getName() == name)
-	return slave.get();
+        if (slave.get() && slave->getName() == name)
+            return slave.get();
     }
     return nullptr;
 }
@@ -252,7 +252,7 @@ void BaseObject::removeSlave(BaseObject::SPtr s)
 
 void BaseObject::init()
 {
-  for(auto data: this->m_vecData)
+    for(auto data: this->m_vecData)
     {
         if (data->isRequired() && !data->isSet())
         {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.cpp
@@ -56,7 +56,8 @@ BaseObject::~BaseObject()
     assert(l_master.get() == nullptr); // an object that is still a slave should not be able to be deleted, as at least one smart pointer points to it
     for(VecSlaves::const_iterator iSlaves = l_slaves.begin(); iSlaves != l_slaves.end(); ++iSlaves)
     {
-        (*iSlaves)->l_master.reset();
+        if (iSlaves->get())
+            (*iSlaves)->l_master.reset();
     }
 }
 
@@ -66,7 +67,7 @@ void BaseObject::changeContextLink(BaseContext* before, BaseContext*& after)
 {
     if (!after) after = BaseContext::getDefault();
     if (before == after) return;
-    for (unsigned int i = 0; i < l_slaves.size(); ++i) l_slaves.get(i)->l_context.set(after);
+    for (unsigned int i = 0; i < l_slaves.size(); ++i) if (l_slaves.get(i)) l_slaves.get(i)->l_context.set(after);
     if (after != BaseContext::getDefault())
     {
         // update links


### PR DESCRIPTION
Got some crashes on some simulations, when trying to unload them.
Here's the fix



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
