### PR TITLE
[SofaGeneralRigid] Check null pointer in ArticulatedSystemMapping applyJT function

### DIFF
--- a/modules/SofaGeneralRigid/ArticulatedSystemMapping.h
+++ b/modules/SofaGeneralRigid/ArticulatedSystemMapping.h
@@ -107,6 +107,9 @@ public:
     {
         if(dataVecOutPos.empty() || dataVecInPos.empty())
             return;
+            
+        if(dataVecOutPos[0] == nullptr || dataVecInPos[0] == nullptr)
+			return;      
 
         const InRootVecCoord* inroot = nullptr;
 
@@ -131,6 +134,9 @@ public:
     {
         if(dataVecOutVel.empty() || dataVecInVel.empty())
             return;
+            
+        if(dataVecOutVel[0] == nullptr || dataVecInVel[0] == nullptr)
+			return;        
 
         const InRootVecDeriv* inroot = nullptr;
 
@@ -155,6 +161,9 @@ public:
     {
         if(dataVecOutForce.empty() || dataVecInForce.empty())
             return;
+            
+        if(dataVecOutForce[0] == nullptr || dataVecInForce[0] == nullptr)
+			return;    
 
         InRootVecDeriv* outroot = nullptr;
 
@@ -188,6 +197,9 @@ public:
     {
         if(dataMatOutConst.empty() || dataMatInConst.empty())
             return;
+            
+        if(dataMatOutConst[0] == nullptr || dataMatInConst[0] == nullptr)
+			return;      
 
         InRootMatrixDeriv* outroot = nullptr;
 


### PR DESCRIPTION
In my program, when running the scene, "dataVecInForce[0] is nullptr" appears in the function applyJT. Is it possible that the pointer is empty?






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
