### PR TITLE
[Doc] Remove Inria Foundation mention from CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Welcome to the SOFA Community! Here is a brief summary of how it is structured:
 - SOFA Developpers: people programming into SOFA, modifying the API, writing plugins.
 - SOFA Contributors: (awesome) people proposing their changes in SOFA code via pull-requests.
 - SOFA Reviewers: people reviewing and merging the pull-requests. This group is validated by the Scientific and Technical Committee (STC).
-- SOFA Consortium: research centers and companies willing to share the cost of development and maintenance of SOFA, hosted by the Inria Foundation.
+- SOFA Consortium: research centers and companies willing to share the cost of development and maintenance of SOFA, hosted by Inria.
 - SOFA Consortium Staff: administrators of SOFA and its ecosystem. This group is directed by the Executive Committee (EC).
 
 All SOFA Developpers are gladly invited to the SOFA-dev meetings.  


### PR DESCRIPTION
as the consortium is hosted by Inria since 2019.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
