### PR TITLE
[CMake] Fix Cmake configure step with SOFA_WITH_DEPRECATED_COMPONENTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,12 @@ if(${SOFA_FLOATING_POINT_TYPE} STREQUAL both)
     set(SOFA_WITH_DOUBLE 1)
 endif()
 
+### Deprecated components
+option(SOFA_WITH_DEPRECATED_COMPONENTS "Compile SOFA with all deprecated components" ON)
+if(SOFA_WITH_DEPRECATED_COMPONENTS)
+    message(DEPRECATION "Deprecated components are activated (SOFA_WITH_DEPRECATED_COMPONENTS variable is ON)")
+endif()
+
 ### Extlibs
 add_subdirectory(extlibs)
 
@@ -320,12 +326,6 @@ if(NOT "${SOFA_EXTERNAL_DIRECTORIES}" STREQUAL "")
         message("Adding external directory: ${name} (${dir})")
         add_subdirectory(${dir} "${CMAKE_CURRENT_BINARY_DIR}/external_directories/${name}")
     endforeach()
-endif()
-
-### Deprecated components
-option(SOFA_WITH_DEPRECATED_COMPONENTS "Compile SOFA with all deprecated components" ON)
-if(SOFA_WITH_DEPRECATED_COMPONENTS)
-    message(DEPRECATION "Deprecated components are activated (SOFA_WITH_DEPRECATED_COMPONENTS variable is ON)")
 endif()
 
 ## Custom


### PR DESCRIPTION
SOFA_WITH_DEPRECATED_COMPONENTS  option was declared after it was supposed to be used in SofaFramework's own CMakeLists. Therefore CMake was throwing an error at the first step  [here](https://github.com/sofa-framework/sofa/blob/d3aee470bc79a017e4f3e04b608c49d16d5874a6/SofaKernel/SofaFramework/CMakeLists.txt#L26)



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
