### PR TITLE
[CMake] Adding policy to SofaMacros.cmake

### DIFF
--- a/SofaKernel/SofaFramework/SofaMacros.cmake
+++ b/SofaKernel/SofaFramework/SofaMacros.cmake
@@ -772,6 +772,7 @@ macro(sofa_auto_set_target_properties)
         endif()
         get_target_property(target_include_dirs ${target} "INCLUDE_DIRECTORIES")
         
+        cmake_policy(SET CMP0057 NEW)
         if(NOT "\$<BUILD_INTERFACE:${include_source_root}>" IN_LIST target_include_dirs)
             target_include_directories(${target} PUBLIC "$<BUILD_INTERFACE:${include_source_root}>")
         endif()

--- a/SofaKernel/SofaFramework/SofaMacros.cmake
+++ b/SofaKernel/SofaFramework/SofaMacros.cmake
@@ -1,6 +1,7 @@
 include(CMakePackageConfigHelpers)
 include(CMakeParseLibraryList)
 
+cmake_policy(SET CMP0057 NEW)
 
 # - Create an imported target from a library path and an include dir path.
 #   Handle the special case where LIBRARY_PATH is in fact an existing target.
@@ -772,7 +773,6 @@ macro(sofa_auto_set_target_properties)
         endif()
         get_target_property(target_include_dirs ${target} "INCLUDE_DIRECTORIES")
         
-        cmake_policy(SET CMP0057 NEW)
         if(NOT "\$<BUILD_INTERFACE:${include_source_root}>" IN_LIST target_include_dirs)
             target_include_directories(${target} PUBLIC "$<BUILD_INTERFACE:${include_source_root}>")
         endif()


### PR DESCRIPTION
Update SofaMacros.cmake by setting the policy CMP0057 NEW for supporting the IN_LIST operator of if().






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
