### PR TITLE
[SofaCore] Add virtual getPathName function in Base

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -180,6 +180,9 @@ public:
                            std::initializer_list<BaseData*> outputs);
     void addOutputsToCallback(const std::string& name, std::initializer_list<BaseData*> outputs);
 
+
+    virtual std::string getPathName() const { return ""; }
+
     /// Accessor to the object name
     const std::string& getName() const
     {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
@@ -224,7 +224,7 @@ public:
     /// @}
 
     /// If we use the Data as a link and not as value directly
-    std::string getLinkPath() const { return parentBaseData.getPath(); }
+    virtual std::string getLinkPath() const { return parentBaseData.getPath(); }
     /// Return whether this %Data can be used as a linkPath.
     ///
     /// True by default.

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseNode.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseNode.h
@@ -131,7 +131,7 @@ public:
     virtual const BaseContext* getContext() const = 0;
 
     /// Return the full path name of this node
-    virtual std::string getPathName() const;
+    virtual std::string getPathName() const override;
 
     /// Return the path from this node to the root node
     virtual std::string getRootPath() const;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.h
@@ -439,7 +439,7 @@ public:
 
 
     /// Return the full path name of this object
-    virtual std::string getPathName() const;
+    virtual std::string getPathName() const override;
 
     /// @name internalupdate
     ///   Methods related to tracking of data and the internal update


### PR DESCRIPTION
Both BaseObject and BaseNode have a getPathName function, but those can't be called from a Base ptr without dereferencing with toBaseNode / toBaseObject.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
