### PR TITLE
[extlibs/gtest] Fix the broken sofa_create_package_with_targets in gtest

### DIFF
--- a/extlibs/gtest/CMakeLists.txt
+++ b/extlibs/gtest/CMakeLists.txt
@@ -81,7 +81,7 @@ include(${SOFA_KERNEL_SOURCE_DIR}/SofaFramework/SofaMacros.cmake)
 sofa_create_package_with_targets(
     PACKAGE_NAME GTest
     PACKAGE_VERSION ${PROJECT_VERSION}
-    TARGETS ${PROJECT_NAME}
+    TARGETS ${PROJECT_NAME} AUTO_SET_TARGET_PROPERTIES
     INCLUDE_SOURCE_DIR "include"
     INCLUDE_INSTALL_DIR "extlibs/GTest"
     )


### PR DESCRIPTION
It is not exporting the target properties and thus the include path.






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
