### PR TITLE
[SofaPython] Small fixes to import plugin and remove scene warnings

### DIFF
--- a/applications/plugins/SofaPython/PythonEnvironment.cpp
+++ b/applications/plugins/SofaPython/PythonEnvironment.cpp
@@ -169,14 +169,20 @@ void PythonEnvironment::Init()
 
     // Add the paths to the plugins' python modules to sys.path.  Those paths
     // are read from all the files in 'etc/sofa/python.d'
-    std::string confDir = Utils::getSofaPathPrefix() + "/etc/sofa/python.d";
-    if (FileSystem::exists(confDir))
+    std::vector< std::string > paths = sofa::helper::system::DataRepository.getPaths();
+    paths.push_back(Utils::getSofaPathPrefix());
+    for (auto path : paths)
     {
-        std::vector<std::string> files;
-        FileSystem::listDirectory(confDir, files);
-        for (size_t i=0; i<files.size(); i++)
+        std::string confDir = path + "/etc/sofa/python.d";
+        if (FileSystem::exists(confDir))
         {
-            addPythonModulePathsFromConfigFile(confDir + "/" + files[i]);
+            std::vector<std::string> files;
+            FileSystem::listDirectory(confDir, files);
+
+            for (size_t i = 0; i < files.size(); i++)
+            {
+                addPythonModulePathsFromConfigFile(confDir + "/" + files[i]);
+            }
         }
     }
 

--- a/applications/plugins/SofaPython/examples/fountain.py
+++ b/applications/plugins/SofaPython/examples/fountain.py
@@ -30,11 +30,11 @@ class Fountain(Sofa.PythonScriptController):
     def createCube(self,parentNode,name,vx,vy,vz,color):
         node = parentNode.createChild(name)
 
-        node.createObject('EulerImplicit')
+        node.createObject('EulerImplicitSolver')
         node.createObject('CGLinearSolver',iterations=25,tolerance=1.0e-9,threshold=1.0e-9)
-        object = node.createObject('MechanicalObject',name='MecaObject',template='Rigid')
+        object = node.createObject('MechanicalObject',name='MecaObject',template='Rigid3d')
         node.createObject('UniformMass',totalMass='1')
-        node.createObject('SphereModel',radius='0.5', group='1')
+        node.createObject('SphereCollisionModel',radius='0.5', group='1')
 
         # VisualNode
         VisuNode = node.createChild('Visu')

--- a/applications/plugins/SofaPython/examples/fountain.scn
+++ b/applications/plugins/SofaPython/examples/fountain.scn
@@ -1,6 +1,7 @@
 
 <Node name="root" dt="0.02">
-    <RequiredPlugin name="SofaOpenglVisual"/>
+  <RequiredPlugin name="SofaOpenglVisual"/>
+  <RequiredPlugin pluginName='SofaMiscCollision'/>
   <RequiredPlugin name="SofaPython" pluginName="SofaPython" />
   <VisualStyle displayFlags="hideBehaviorModels hideCollisionModels hideMappings hideForceFields" />
   <DefaultPipeline verbose="0" depth="10" draw="0" />
@@ -13,9 +14,9 @@
     <MeshObjLoader name="loader" filename="mesh/floor2b.obj" />
     <MeshTopology src="@loader" />
     <MechanicalObject src="@loader" dy="-10.25" scale="0.5" />
-    <TriangleCollisionModel name="Floor" simulated="0" moving="0"  group='2'/>
-    <LineCollisionModel name="Floor" simulated="0" moving="0" group='2'/>
-    <PointCollisionModel name="Floor" simulated="0" moving="0" group='2'/>
+    <TriangleCollisionModel name="FloorT" simulated="0" moving="0"  group='2'/>
+    <LineCollisionModel name="FloorL" simulated="0" moving="0" group='2'/>
+    <PointCollisionModel name="FloorP" simulated="0" moving="0" group='2'/>
     <OglModel name="FloorV" src="@loader" scale="0.5" texturename="textures/floor.bmp" dy="-10" />
   </Node>
 

--- a/applications/plugins/SofaPython/examples/keyboardControl.scn
+++ b/applications/plugins/SofaPython/examples/keyboardControl.scn
@@ -6,6 +6,7 @@
 
 <Node name="root" dt="0.005" >
     <RequiredPlugin name="SofaOpenglVisual"/>
+    <RequiredPlugin pluginName='SofaHaptics'/>
 	<VisualStyle displayFlags="hideBehaviorModels hideCollisionModels hideMappings hideForceFields" />
 	<RequiredPlugin name="SofaPython" pluginName="SofaPython" />
 	<Gravity name="G" gravity="10 0 0" />
@@ -36,9 +37,9 @@
 			<MeshObjLoader filename="mesh/raptor_8kp.obj"  name="loader"/>
 			<MeshTopology src="@loader" name="raptorVisualModel"  />
 			<MechanicalObject src="@loader" name="raptorState"/>		
-			<TriangleCollisionModel name="raptor" contactStiffness="100"/>
-			<LineCollisionModel name="raptor" contactStiffness="100"/>	
-			<PointCollisionModel name="raptor" contactStiffness="100"/>	
+			<TriangleCollisionModel contactStiffness="100"/>
+			<LineCollisionModel contactStiffness="100"/>	
+			<PointCollisionModel contactStiffness="100"/>	
 			<BarycentricMapping name="tongueMapping" input="@../mecaRaptor" output="@raptorState" mapForces="false"/>
 		</Node>
 	</Node>
@@ -76,8 +77,8 @@
 			<MeshObjLoader filename="dental_instrument_centerline.obj"  name="loader"/>
 			<MeshTopology src="@loader" name="InstrumentCollisionModel" />
 			<MechanicalObject src="@loader" name="instrumentCollisionState"  ry="-180" rz="-90" dz="3.5" dx="-0.3" />
-			<LineCollisionModel name="instrument" contactStiffness="10" />
-			<PointCollisionModel name="instrument" contactStiffness="10" /> 
+			<LineCollisionModel contactStiffness="10" />
+			<PointCollisionModel contactStiffness="10" /> 
 			<RigidMapping name="MM->CM mapping" input="@instrumentState" output="@instrumentCollisionState" />
 		</Node>
 		<VectorSpringForceField  object1="@Input/RefModel/instrumentCollisionState" object2="@Instrument/CollisionModel/instrumentCollisionState" stiffness="10" viscosity="0" />

--- a/applications/plugins/SofaPython/initSofaPython.cpp
+++ b/applications/plugins/SofaPython/initSofaPython.cpp
@@ -28,11 +28,11 @@ extern "C" {
 
 SOFA_SOFAPYTHON_API void initExternalModule()
 {
-    static bool first = true;
-    if (first)
+    static bool firstPythonInit = true;
+    if (firstPythonInit)
     {
         sofa::simulation::PythonEnvironment::Init();
-        first = false;
+        firstPythonInit = false;
     }
 }
 


### PR DESCRIPTION
2 small fixes to allow usage of SofaPython by a third-party software. 
1. Tests all known data path from SOFA to look for /etc/sofa/python.d (not only SOFA_ROOT or current exec dir)
2. Give a more specific name to the static bool at plugin init. It was messing up with another variable. 

+ Clean some example scenes warnings.


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
