### PR TITLE
[SofaKernel] Add whole program optimization (aka link-time optimization) for msvc

### DIFF
--- a/SofaKernel/cmake/CompilerOptions.cmake
+++ b/SofaKernel/cmake/CompilerOptions.cmake
@@ -45,6 +45,18 @@ if(WIN32)
     if(MSVC_TOOLSET_VERSION GREATER 140) # > VS 2015
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus")
     endif()
+
+    # Focus on max speed in Release Mode with link-time optimization
+    option(SOFA_ENABLE_LINK_TIME_OPTIMIZATION "Enable LTCG IN release mode (MSVC only for now) [Warning, use a lot of disk space!]" OFF)
+
+    if(SOFA_ENABLE_LINK_TIME_OPTIMIZATION)
+        add_compile_options(
+            "$<$<CONFIG:Release>:/GL>" # Whole Program Optimization
+        )
+        add_link_options(
+            "$<$<CONFIG:Release>:/LTCG>" # Link time code Optimization
+        )
+    endif()
 endif()
 
 # Mac specific


### PR DESCRIPTION
⚠-For MSVC only
⚠-in Release mode only
⚠-with CMake flag SOFA_ENABLE_LINK_TIME_OPTIMIZATION

Enable Link-time optimization to whole SOFA project.
(with caduceus.scn : w/o: 170fps, w/: 190fps)

WARNING: typical SOFA compilation takes 20GB!🥴


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
