### PR TITLE
[SofaSimulationGraph] No reason to have moveChild in private

### DIFF
--- a/SofaKernel/modules/SofaSimulationGraph/DAGNode.h
+++ b/SofaKernel/modules/SofaSimulationGraph/DAGNode.h
@@ -139,6 +139,8 @@ public:
     /// compute the traversal order from this Node
     void precomputeTraversalOrder( const core::ExecParams* params ) override;
 
+    virtual void moveChild(BaseNode::SPtr node) override;
+
 protected:
 
     /// bottom-up traversal, returning the first node which have a descendancy containing both node1 & node2
@@ -147,7 +149,6 @@ protected:
 
     LinkParents l_parents;
 
-    virtual void moveChild(BaseNode::SPtr node) override;
 
     virtual void doAddChild(BaseNode::SPtr node) override;
     virtual void doRemoveChild(BaseNode::SPtr node) override;


### PR DESCRIPTION
When addChild, removeChild, addObject, removeObject etc. are public






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
