### PR TITLE
[SofaKernel] Improve check for already registered plugins

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
@@ -27,8 +27,10 @@ using sofa::helper::system::FileSystem;
 #include <sofa/helper/Utils.h>
 #include <sofa/helper/logging/Messaging.h>
 
-#include <boost/filesystem.hpp>
 #include <fstream>
+
+#include <filesystem>
+
 
 using sofa::helper::Utils;
 
@@ -316,16 +318,16 @@ std::string PluginManager::findPlugin(const std::string& pluginName, const std::
         {
             const std::string& dir = *i;
 
-            boost::filesystem::recursive_directory_iterator iter(dir);
-            boost::filesystem::recursive_directory_iterator end;
+            std::filesystem::recursive_directory_iterator iter(dir);
+            std::filesystem::recursive_directory_iterator end;
 
             while (iter != end)
             {
-                if ( iter.level() > maxRecursiveDepth )
+                if ( iter.depth() > maxRecursiveDepth )
                 {
-                    iter.no_push(); // skip
+                    iter.disable_recursion_pending(); // skip
                 }
-                else if ( !boost::filesystem::is_directory(iter->path()) )
+                else if ( !std::filesystem::is_directory(iter->path()) )
                 {
                     const std::string path = iter->path().string();
                     const std::string filename = iter->path().filename().string();
@@ -337,12 +339,7 @@ std::string PluginManager::findPlugin(const std::string& pluginName, const std::
                     }
                 }
 
-                boost::system::error_code ec;
-                iter.increment(ec);
-                if (ec)
-                {
-                    msg_error("PluginManager") << "Error while accessing " << iter->path().string() << ": " << ec.message();
-                }
+                iter++;
             }
         }
     }
@@ -351,10 +348,13 @@ std::string PluginManager::findPlugin(const std::string& pluginName, const std::
 
 bool PluginManager::pluginIsLoaded(const std::string& plugin)
 {
+    // check if path valid
     std::string pluginPath = plugin;
-
-    if (!FileSystem::isFile(plugin)) {
-        pluginPath = findPlugin(plugin);
+    std::filesystem::path sysPath(pluginPath);
+    if (!std::filesystem::exists(sysPath))
+    {
+        // Plugin is not a file, try to find the plugin real path
+        pluginPath = findPlugin(pluginPath);
     }
 
     return m_pluginMap.find(pluginPath) != m_pluginMap.end();

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
@@ -242,7 +242,7 @@ Plugin* PluginManager::getPlugin(const std::string& plugin, const std::string& /
     std::string pluginPath = plugin;
 
     if (!FileSystem::isFile(plugin)) {
-        pluginPath = findPlugin(plugin);
+        return getPluginByName(plugin);
     }
 
     if (!pluginPath.empty() && m_pluginMap.find(pluginPath) != m_pluginMap.end())
@@ -254,6 +254,21 @@ Plugin* PluginManager::getPlugin(const std::string& plugin, const std::string& /
         msg_info("PluginManager") << "Plugin not found in loaded plugins: " << plugin << msgendl;
         return nullptr;
     }
+}
+
+Plugin* PluginManager::getPluginByName(const std::string& pluginName)
+{
+    for (PluginMap::iterator itP = m_pluginMap.begin(); itP != m_pluginMap.end(); ++itP)
+    {
+        std::string name(itP->second.getModuleName());
+        if (name.compare(pluginName) == 0)
+        {
+            return &itP->second;
+        }
+    }
+
+    msg_info("PluginManager") << "Plugin not found in loaded plugins: " << pluginName << msgendl;
+    return nullptr;
 }
 
 std::istream& PluginManager::readFromStream(std::istream & in)

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
@@ -171,6 +171,12 @@ bool PluginManager::loadPluginByPath(const std::string& pluginPath, std::ostream
             return false;
         }
         getPluginEntry(p.getModuleName,d);
+
+        if (checkDuplicatedPlugin(p, pluginPath))
+        {
+            return true;
+        }
+
         getPluginEntry(p.getModuleDescription,d);
         getPluginEntry(p.getModuleLicense,d);
         getPluginEntry(p.getModuleComponentList,d);
@@ -358,6 +364,23 @@ bool PluginManager::pluginIsLoaded(const std::string& plugin)
     }
 
     return m_pluginMap.find(pluginPath) != m_pluginMap.end();
+}
+
+
+bool PluginManager::checkDuplicatedPlugin(const Plugin& plugin, const std::string& pluginPath)
+{
+    for (auto itP : m_pluginMap)
+    {
+        std::string name(itP.second.getModuleName());
+        std::string plugName(plugin.getModuleName());
+        if (name.compare(plugName) == 0 && pluginPath.compare(itP.first) != 0)
+        {
+            msg_warning("PluginManager") << "Trying to load plugin (" + name + ", from path: " + pluginPath + ") already registered from path: " + itP.first;
+            return true;
+        }
+    }
+
+    return false;
 }
 
 }

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.h
@@ -170,6 +170,7 @@ public:
 
     std::string findPlugin(const std::string& pluginName, const std::string& suffix = getDefaultSuffix(), bool ignoreCase = true, bool recursive = true, int maxRecursiveDepth = 6);
     bool pluginIsLoaded(const std::string& plugin);
+    bool checkDuplicatedPlugin(const Plugin& plugin, const std::string& pluginPath);
 
     inline friend std::ostream& operator<< ( std::ostream& os, const PluginManager& pluginManager )
     {

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.h
@@ -132,6 +132,7 @@ private:
 class SOFA_HELPER_API PluginManager
 {
 public:
+    /// Map to store the list of plugin registered, key is the plugin path
     typedef std::map<std::string, Plugin > PluginMap;
     typedef PluginMap::iterator PluginIterator;
 
@@ -184,6 +185,7 @@ public:
     PluginMap& getPluginMap()  { return m_pluginMap; }
 
     Plugin* getPlugin(const std::string& plugin, const std::string& = getDefaultSuffix(), bool = true);
+    Plugin* getPluginByName(const std::string& pluginName);
 
     void readFromIniFile(const std::string& path);
     void writeToIniFile(const std::string& path);


### PR DESCRIPTION
Several changes in PluginManager:
- Add check to avoid registering the same plugin from different paths
- Change method getPlugin to look in the map of registered plugin using the plugin name instead of using a reconstructed path.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
