### PR TITLE
[SofaFramework] 🐛 Homogeneize SOFA_VERSION with APIVersion

### DIFF
--- a/modules/SofaGraphComponent/APIVersion.cpp
+++ b/modules/SofaGraphComponent/APIVersion.cpp
@@ -39,6 +39,7 @@ using sofa::core::ObjectFactory ;
 using sofa::core::RegisterObject ;
 
 #include "APIVersion.h"
+#include <sofa/version.h>
 
 namespace sofa
 {
@@ -50,7 +51,7 @@ namespace _apiversion_
 {
 
 APIVersion::APIVersion() :
-     d_level ( initData(&d_level, std::string("17.06"), "level", "The API Level of the scene ('17.06', '17.12', '18.06', ...)"))
+     d_level ( initData(&d_level, std::string(SOFA_VERSION_STR), "level", "The API Level of the scene ('17.06', '17.12', '18.06', ...)"))
 {
 }
 
@@ -67,13 +68,13 @@ void APIVersion::init()
 void APIVersion::checkInputData()
 {
     if(!d_level.isSet() && !name.isSet() ){
-        msg_warning() << "The level is not set. Using 17.06 as default value. " ;
+        msg_warning() << "The level is not set. Using " << SOFA_VERSION_STR << " as default value. " ;
         return ;
     }
     if( !d_level.isSet() && name.isSet() ){
         d_level.setValue(getName());
     }
-    std::vector<std::string> allowedVersion = { "17.06", "17.12", "18.06", "18.12" } ;
+    std::vector<std::string> allowedVersion = { "17.06", "17.12", "18.06", "18.12", SOFA_VERSION_STR } ;
     if( std::find( allowedVersion.begin(), allowedVersion.end(), d_level.getValue()) == allowedVersion.end() )
     {
         msg_warning() << "The provided level '"<< d_level.getValue() <<"' is now valid. " ;

--- a/modules/SofaGraphComponent/SceneCheckAPIChange.h
+++ b/modules/SofaGraphComponent/SceneCheckAPIChange.h
@@ -22,6 +22,7 @@
 #ifndef SOFA_SIMULATION_SCENECHECKAPICHANGES_H
 #define SOFA_SIMULATION_SCENECHECKAPICHANGES_H
 
+#include <sofa/version.h>
 #include "config.h"
 #include "SceneCheck.h"
 #include <string>
@@ -66,7 +67,7 @@ public:
     void addHookInChangeSet(const std::string& version, ChangeSetHookFunction fct);
 private:
     std::string m_currentApiLevel;
-    std::string m_selectedApiLevel {"20.06"};
+    std::string m_selectedApiLevel {SOFA_VERSION_STR};
 
     std::map<std::string, std::vector<ChangeSetHookFunction>> m_changesets;
 };

--- a/modules/SofaGraphComponent/SceneCheckAPIChange.h
+++ b/modules/SofaGraphComponent/SceneCheckAPIChange.h
@@ -67,7 +67,7 @@ public:
     void addHookInChangeSet(const std::string& version, ChangeSetHookFunction fct);
 private:
     std::string m_currentApiLevel;
-    std::string m_selectedApiLevel {SOFA_VERSION_STR};
+    std::string m_selectedApiLevel {"17.06"};
 
     std::map<std::string, std::vector<ChangeSetHookFunction>> m_changesets;
 };


### PR DESCRIPTION
Hey I hope I got this one right...:

To me the APIVersion component is used to specify the latest version of SOFA we can guarantee compatibility with.

Thus when it is already present in an existing scene, the tag is set explicitely in the scene file.
When creating and saving a scene from a modeler for instance though, an APIVersion should be created, and the level should be the level of  the version of SOFA the user is running.

By default, an APIVersion without a version number was automatically setting the level to 17.12, which to me makes no sense, because we can't guarantee compatibility with 17.12 on a scene that doesn't have an APIVersion set.
Also, somewhere in SceneCheckAPIChange, a 20.06 was hardcoded in a variable `m_selectedApiLevel`

This PR takes the SOFA_VERSION_STR, set by CMake in <sofa/version.h>, and uses this value to replace the default level value in APIVersion, and the selectedAPILevel in SceneCheckAPIChange.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
