### PR TITLE
[SofaKernel] 🐛 Break link when passing a nullptr to setLinkedBase

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseLink.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseLink.cpp
@@ -229,6 +229,11 @@ void BaseLink::setLinkedBase(Base* link)
     auto owner = getOwnerBase();
     BaseNode* n = dynamic_cast<BaseNode*>(link);
     BaseObject* o = dynamic_cast<BaseObject*>(link);
+    if (!n && !o)
+    {
+        read("@");
+        return;
+    }
     auto pathname = n != nullptr ? n->getPathName() : o->getPathName();
     if (!this->read("@" + pathname))
     {


### PR DESCRIPTION
Currently, passing a nullptr to setLinkedBase just does nothing.
With this PR it breaks the link, (as, IMHO, it should)



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
