### PR TITLE
[SofaBaseMechanics] 🐛 FIX draw function in UniformMass

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/UniformMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/UniformMass.inl
@@ -662,6 +662,9 @@ void UniformMass<DataTypes, MassType>::draw(const VisualParams* vparams)
     if ( !vparams->displayFlags().getShowBehaviorModels() )
         return;
 
+    if (!mstate.get())
+        return;
+
     ReadAccessor<VecCoord> x = mstate->read(ConstVecCoordId::position())->getValue();
     ReadAccessor<Data<vector<int> > > indices = d_indices;
 


### PR DESCRIPTION
(when no mstate is provided)






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
