### PR TITLE
[SofaBaseMechanics] Refactor mechanicalobject

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.h
+++ b/SofaKernel/modules/SofaBaseMechanics/MechanicalObject.h
@@ -129,6 +129,7 @@ public:
     Data< VecDeriv > f; ///< force vector of the degrees of freedom
     Data< VecCoord > x0; ///< rest position coordinates of the degrees of freedom
 #endif
+    Data< VecCoord > d_init_x; ///< position coordinates of the degrees of freedom
 
     Data< VecDeriv > externalForces; ///< externalForces vector of the degrees of freedom
     Data< VecDeriv > dx; ///< dx vector of the degrees of freedom
@@ -401,6 +402,7 @@ protected :
 
     //int vsize; ///< Number of elements to allocate in vectors
     Data< int > d_size; ///< Size of the vectors
+    Data< int > d_init_size; ///< Size of the vectors
 
     SingleLink< MechanicalObject<DataTypes>, core::topology::BaseMeshTopology,BaseLink::FLAG_STRONGLINK|BaseLink::FLAG_STOREPATH> l_topology;
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.cpp
@@ -38,14 +38,16 @@ void DataTracker::trackData( const objectmodel::BaseData& data )
     m_dataTrackers[&data] = data.getCounter();
 }
 
-bool DataTracker::hasChanged( const objectmodel::BaseData& data )
+bool DataTracker::hasChanged( const objectmodel::BaseData& data ) const
 {
-    return m_dataTrackers[&data] != data.getCounter();
+    if (m_dataTrackers.find(&data) != m_dataTrackers.end())
+        return m_dataTrackers.at(&data) != data.getCounter();
+    return false;
 }
 
-bool DataTracker::hasChanged()
+bool DataTracker::hasChanged() const
 {
-    for( DataTrackers::iterator it=m_dataTrackers.begin(),itend=m_dataTrackers.end() ; it!=itend ; ++it )
+    for( DataTrackers::const_iterator it=m_dataTrackers.begin(),itend=m_dataTrackers.end() ; it!=itend ; ++it )
         if( it->second != it->first->getCounter() ) return true;
     return false;
 }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.h
@@ -59,10 +59,10 @@ namespace core
 
         /// Did the data change since its last access?
         /// @warning data must be a tracked Data @see trackData
-        bool hasChanged( const objectmodel::BaseData& data );
+        bool hasChanged( const objectmodel::BaseData& data ) const;
 
         /// Did one of the tracked data change since the last call to clean()?
-        bool hasChanged();
+        bool hasChanged() const;
 
         /// comparison point is cleaned for the specified tracked Data
         /// @warning data must be a tracked Data @see trackData


### PR DESCRIPTION
:warning: depends on #1488

This refactoring guarantees size consistency between `position / forces / velocity / external_forces` buffers when resized.

Since those fields are coupled, changing the size of one should change the size of the others. except it's not the case.
plus, there's a "size" datafield that is supposed to determine the size of the buffers.

Thus it is now impossible to edit the size of those buffers directly. any insertion / removal of a line in the buffers must be preceded with a change of size, which in turn will redimension the buffers.

Also: When creating the scene (before executing the simulation) init_size and init_position should be used.
The idea behind that last change is that we should have separate datafields for inputs and outputs, instead of mixing both concepts together.

:warning: **THIS IS BREAKING** because there are probably tons of codes out there that resize position manually and then call` init / reinit / bwdInit` on MOs, hoping for them to update the component (I should know I've been doing it for 6years :D)



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
