### PR TITLE
[SofaKernel] Remove parentBaseData in  BaseData.h

### DIFF
--- a/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/DataLink_test.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/DataLink_test.cpp
@@ -25,6 +25,9 @@ using sofa::core::objectmodel::Data;
 #include <sofa/helper/testing/BaseTest.h>
 using sofa::helper::testing::BaseTest ;
 
+#include <sofa/defaulttype/Vec.h>
+using sofa::defaulttype::Vec3d;
+using sofa::defaulttype::Vec3f;
 
 /**  Test suite for data link.
 Create two datas and a link between them.
@@ -34,6 +37,8 @@ struct DataLink_test: public BaseTest
 {
     Data<int> data1;
     Data<int> data2;
+    Data<Vec3f> dataVec3f;
+    Data<Vec3d> dataVec3d;
 
     /// This method is defined in gtest framework to setting the test up.
     void SetUp() override
@@ -41,6 +46,9 @@ struct DataLink_test: public BaseTest
         /// Setup the data and create a link between the two datas
         data1.setName("data1");
         data2.setName("data2");
+
+        data1.setName("dataVec3f");
+        data2.setName("dataVec3d");
     }
 
     void TearDown() override
@@ -58,6 +66,17 @@ TEST_F(DataLink_test, UnsetByValue)
     ASSERT_NE(data2.getParent(), nullptr);
     data2.setValue(0);
     ASSERT_NE(data2.getParent(), nullptr);
+}
+
+/// We should be able to set a parent of different type and rely on type conversion at runtime
+TEST_F(DataLink_test, SetParentOfDifferentType)
+{
+    ASSERT_TRUE(dataVec3f.setParent(&dataVec3d));
+    ASSERT_NE(dataVec3f.getParent(), nullptr);
+    dataVec3d.setValue(Vec3d(1.0,2.0,3.0));
+    ASSERT_FLOAT_EQ(dataVec3f.getValue().x(), 1.0f);
+    ASSERT_FLOAT_EQ(dataVec3f.getValue().y(), 2.0f);
+    ASSERT_FLOAT_EQ(dataVec3f.getValue().z(), 3.0f);
 }
 
 /// This test check that the setting/unsetting mechanisme is working

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
@@ -224,7 +224,7 @@ public:
     /// @}
 
     /// If we use the Data as a link and not as value directly
-    virtual std::string getLinkPath() const { return parentBaseData.getPath(); }
+    virtual std::string getLinkPath() const { return parentData.getPath(); }
     /// Return whether this %Data can be used as a linkPath.
     ///
     /// True by default.
@@ -285,7 +285,7 @@ public:
     /// Check if a given Data can be linked as a parent of this data
     virtual bool validParent(BaseData* parent);
 
-    BaseData* getParent() const { return parentBaseData.get(); }
+    BaseData* getParent() const { return parentData.get(); }
 
     /// Update the value of this %Data
     void update() override;
@@ -324,8 +324,7 @@ protected:
 
     /// @}
 
-    virtual void doSetParent(BaseData* parent);
-
+    /// Delegates from DDGNode.
     void doDelInput(DDGNode* n) override;
 
     /// Update this %Data from the value of its parent
@@ -351,7 +350,7 @@ protected:
     std::string m_name;
 
     /// Parent Data
-    SingleLink<BaseData,BaseData,BaseLink::FLAG_STOREPATH|BaseLink::FLAG_DATALINK|BaseLink::FLAG_DUPLICATE> parentBaseData;
+    SingleLink<BaseData,BaseData,BaseLink::FLAG_STOREPATH|BaseLink::FLAG_DATALINK|BaseLink::FLAG_DUPLICATE> parentData;
 
     /// Helper method to decode the type name to a more readable form if possible
     static std::string decodeTypeName(const std::type_info& t);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
@@ -42,18 +42,6 @@ class TData : public BaseData
 public:
     typedef T value_type;
 
-    /// @name Class reflection system
-    /// @{
-    typedef TClass<TData<T>,BaseData> MyClass;
-    static const sofa::core::objectmodel::BaseClass* GetClass() { return MyClass::get(); }
-    const BaseClass* getClass() const { return GetClass(); }
-    static std::string templateName(const TData<T>* = nullptr)
-    {
-        T* ptr = nullptr;
-        return BaseData::typeName(ptr);
-    }
-    /// @}
-
     explicit TData(const BaseInitData& init) : BaseData(init)
     {
     }
@@ -289,20 +277,6 @@ public:
     using TData<T>::setDirtyOutputs;
     using TData<T>::updateIfDirty;
     using TData<T>::notifyEndEdit;
-
-    /// @name Class reflection system
-    /// @{
-    typedef TClass<Data<T>, TData<T> > MyClass;
-    static const sofa::core::objectmodel::BaseClass* GetClass() { return MyClass::get(); }
-    virtual const BaseClass* getClass() const
-    { return GetClass(); }
-
-    static std::string templateName(const Data<T>* = nullptr)
-    {
-        T* ptr = nullptr;
-        return BaseData::typeName(ptr);
-    }
-    /// @}
 
     /// @name Construction / destruction
     /// @{

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
@@ -54,8 +54,7 @@ public:
     }
     /// @}
 
-    explicit TData(const BaseInitData& init)
-        : BaseData(init), parentData(initLink("parentSameType", "Linked Data in case it stores exactly the same type of Data, and efficient copies can be made (by value or by sharing pointers with Copy-on-Write)"))
+    explicit TData(const BaseInitData& init) : BaseData(init)
     {
     }
 
@@ -65,7 +64,7 @@ public:
         TData( sofa::helper::safeCharToString(helpMsg), isDisplayed, isReadOnly) {}
 
     TData( const std::string& helpMsg, bool isDisplayed=true, bool isReadOnly=false)
-        : BaseData(helpMsg, isDisplayed, isReadOnly), parentData(initLink("parentSameType", "Linked Data in case it stores exactly the same type of Data, and efficient copies can be made (by value or by sharing pointers with Copy-on-Write)"))
+        : BaseData(helpMsg, isDisplayed, isReadOnly)
     {
     }
 
@@ -124,11 +123,7 @@ protected:
 
     BaseLink::InitLink<TData<T> > initLink(const char* name, const char* help);
 
-    void doSetParent(BaseData* parent) override;
-
     bool updateFromParentValue(const BaseData* parent) override;
-
-    SingleLink<TData<T>,TData<T>, BaseLink::FLAG_DATALINK|BaseLink::FLAG_DUPLICATE> parentData;
 };
 
 
@@ -591,18 +586,12 @@ BaseLink::InitLink<TData<T> > TData<T>::initLink(const char* name, const char* h
 }
 
 template <class T>
-void TData<T>::doSetParent(BaseData* parent)
-{
-    parentData.set(dynamic_cast<TData<T>*>(parent));
-    BaseData::doSetParent(parent);
-}
-
-template <class T>
 bool TData<T>::updateFromParentValue(const BaseData* parent)
 {
-    if (parent == parentData.get())
+    auto typedParent = dynamic_cast<const TData<T>*>(parent);
+    if (typedParent)
     {
-        virtualSetLink(*parentData.get());
+        virtualSetLink(*parent);
         return true;
     }
     else

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
@@ -278,6 +278,12 @@ public:
     using TData<T>::updateIfDirty;
     using TData<T>::notifyEndEdit;
 
+    static std::string templateName(const TData<T>* = nullptr)
+    {
+        T* ptr = nullptr;
+        return BaseData::typeName(ptr);
+    }
+
     /// @name Construction / destruction
     /// @{
 

--- a/SofaKernel/modules/SofaDeformable/MeshSpringForceField.h
+++ b/SofaKernel/modules/SofaDeformable/MeshSpringForceField.h
@@ -24,6 +24,7 @@
 #include "config.h"
 
 #include <SofaDeformable/StiffSpringForceField.h>
+#include <SofaBaseTopology/TopologySubsetData.inl>
 #include <set>
 
 namespace sofa

--- a/SofaKernel/modules/SofaDeformable/StiffSpringForceField.h
+++ b/SofaKernel/modules/SofaDeformable/StiffSpringForceField.h
@@ -27,6 +27,7 @@
 #include <sofa/defaulttype/Mat.h>
 #include <sofa/core/MechanicalParams.h>
 #include <SofaBaseTopology/TopologySubsetData.h>
+#include <SofaBaseTopology/TopologySubsetData.inl> 
 
 namespace sofa
 {

--- a/modules/SofaGeneralDeformable/MeshSpringForceField.inl
+++ b/modules/SofaGeneralDeformable/MeshSpringForceField.inl
@@ -25,6 +25,7 @@
 #include <SofaDeformable/MeshSpringForceField.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
+#include <SofaBaseTopology/TopologySubsetData.h>
 #include <iostream>
 
 

--- a/modules/SofaGeneralDeformable/MeshSpringForceField.inl
+++ b/modules/SofaGeneralDeformable/MeshSpringForceField.inl
@@ -25,7 +25,7 @@
 #include <SofaDeformable/MeshSpringForceField.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
-#include <SofaBaseTopology/TopologySubsetData.h>
+#include <SofaBaseTopology/TopologySubsetData.inl>
 #include <iostream>
 
 

--- a/modules/SofaGeneralDeformable/RegularGridSpringForceField.h
+++ b/modules/SofaGeneralDeformable/RegularGridSpringForceField.h
@@ -25,6 +25,7 @@
 
 #include <SofaDeformable/StiffSpringForceField.h>
 #include <SofaBaseTopology/RegularGridTopology.h>
+#include <SofaBaseTopology/TopologySubsetData.inl>
 #include <sofa/core/MechanicalParams.h>
 
 


### PR DESCRIPTION
The actual implementation to store parentData is weird because it stores two times the same object.

One is in the base class (parentBaseData) and one in its child class
(parentData). 

The rational behind the current implementation is that we wanted to access the data without abstraction cost, ie. accessing the object with its true type (eg: Data<T>) instead of its parent type (BaseData) and at the same time having an abstraction to manipulate BaseData. 

Duplicating the same obect/point is in general a code smell indicating that something is wrong in the implementation. In general duplication complexify the implementation and error prone (because you have to garantee that the different copies are kept synchronized and interact together in a seamlessness way. 

So, in this PR I addresse this duplication problem by removing the lowest type and relying on a dynamic_cast when it is needed. There is an abstraction cost...but it is on a on a very rarerly used method (actually only used for fast copy of data field...and in that context...the cost of the dynamic cast against one of copying millions of Dofs is totally neglectible). 

A different pattern was initially used with a child-delegation to expose the abstraction to its parent but it appears it would have made the PR breaking. The difference is that the selected pattern allows one data to be parented to a data of different type while the pattern with child-delegation restrict the parenting to be of exactly the same time. 

I personally prefer to have parent only on same type (so that data conversion must be added manually and becomes explicit) but this was not done previously in Sofa and thus breaks some scenes (somes of them are actually really funny....and probably work only by side effect). 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [x] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
