### PR TITLE
[SofaOpenglVisual] OglViewport: a fix for compatibility with modern OpenGL

### DIFF
--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglViewport.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglViewport.cpp
@@ -350,6 +350,17 @@ void OglViewport::renderToViewport(core::visual::VisualParams* vp)
 
         //gluLookAt(cameraPosition[0], cameraPosition[1], cameraPosition[2],0 ,0 ,0, cameraDirection[0], cameraDirection[1], cameraDirection[2]);
     }
+
+    GLdouble modelViewMatrix[16];
+    GLdouble lastModelViewMatrix[16];
+    GLdouble projectionMatrix[16];
+    GLdouble lastProjectionMatrix[16];
+    glGetDoublev(GL_PROJECTION_MATRIX, projectionMatrix);
+    glGetDoublev(GL_MODELVIEW_MATRIX, modelViewMatrix);
+    vp->getProjectionMatrix(lastProjectionMatrix);
+    vp->getModelViewMatrix(lastModelViewMatrix);
+    vp->setProjectionMatrix(projectionMatrix);
+    vp->setModelViewMatrix(modelViewMatrix);
     vp->viewport() = Viewport(x0,y0,screenSize[0],screenSize[1]);
     vp->pass() = core::visual::VisualParams::Std;
     simulation::VisualDrawVisitor vdv( vp );
@@ -359,6 +370,8 @@ void OglViewport::renderToViewport(core::visual::VisualParams* vp)
     simulation::VisualDrawVisitor vdvt( vp );
     vdvt.setTags(this->getTags());
     vdvt.execute ( getContext() );
+    vp->setProjectionMatrix(lastProjectionMatrix);
+    vp->setModelViewMatrix(lastModelViewMatrix);
 
     glMatrixMode(GL_PROJECTION);
     glPopMatrix();


### PR DESCRIPTION
I've had a problem combining OglViewport (which is using old openGL) with another component using modern OpenGL.
Here's a fix I did with the help of @fredroy.
We just needed OglViewport to update the visualparams with the new matrices. 


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
