### PR TITLE
[SofaKernel] Remove support for BaseData in Link.h

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/PathResolver.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/PathResolver.cpp
@@ -19,8 +19,6 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#pragma once
-
 #include <regex>
 #include "PathResolver.h"
 #include <sofa/core/objectmodel/DataLink.h>
@@ -85,6 +83,13 @@ void* PathResolver::FindLinkDestClass(Base* context, const BaseClass* destType, 
     if(context==nullptr)
         return nullptr;
     return context->findLinkDestClass(destType, path, link);
+}
+
+
+bool PathResolver::CheckPath(sofa::core::objectmodel::Base* context, const sofa::core::objectmodel::BaseClass* classType, const std::string& path)
+{
+    void* tmp = PathResolver::FindLinkDestClass(context, classType, path, nullptr);
+    return tmp != nullptr;
 }
 
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/PathResolver.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/PathResolver.h
@@ -59,7 +59,7 @@ public:
     static bool FindDataLinkDest(Base* base, BaseData*& ptr, const std::string& path, const BaseLink* link);
 
     template<class T>
-    static bool CheckPath(Base* base, T*& ptr, const std::string& path, const BaseLink* link)
+    static bool CheckPath(Base* base, T*&, const std::string& path, const BaseLink* link)
     {
         void* result = FindLinkDestClass(base, T::GetClass(), path, link);
         return result != nullptr;
@@ -72,7 +72,7 @@ public:
     {
         if (path.empty())
             return false;
-        return CheckPath(path, T::GetClass(), context);
+        return CheckPath(context, T::GetClass(), path);
     }
 
     template<class T>
@@ -87,6 +87,9 @@ public:
 
     /// Check that a given path is valid, that the pointed object exists and is of the right type
     static bool CheckPath(sofa::core::objectmodel::Base* context, const std::string& path);
+
+    /// Check that a given path is valid, that the pointed object exists and is of the right type
+    static bool CheckPath(sofa::core::objectmodel::Base* context, const BaseClass* classType, const std::string& path);
 };
 
 }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
@@ -337,16 +337,6 @@ public:
     }
 };
 
-template<class Type>
-class LinkTraitsPtrCasts
-{
-public:
-    static sofa::core::objectmodel::Base* getBase(sofa::core::objectmodel::Base* b) { return b; }
-    static sofa::core::objectmodel::Base* getBase(sofa::core::objectmodel::BaseData* d) { return d->getOwner(); }
-    static sofa::core::objectmodel::BaseData* getData(sofa::core::objectmodel::Base* /*b*/) { return nullptr; }
-    static sofa::core::objectmodel::BaseData* getData(sofa::core::objectmodel::BaseData* d) { return d; }
-};
-
 /** A WriteAccessWithRawPtr is a RAII class, holding a reference to a given container
  *  and providing access to its data through a non-const void* ptr taking care of the
  * beginEdit/endEdit pairs.

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseLink.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseLink.h
@@ -53,7 +53,6 @@ public:
         FLAG_MULTILINK  = 1 << 0, ///< True if link is an array
         FLAG_STRONGLINK = 1 << 1, ///< True if link has ownership of linked object(s)
         FLAG_DOUBLELINK = 1 << 2, ///< True if link has a reciprocal link in linked object(s)
-        FLAG_DATALINK   = 1 << 3, ///< True if link points to a Data
         FLAG_DUPLICATE  = 1 << 4, ///< True if link duplicates another one (possibly with a different/specialized DestType)
         FLAG_STOREPATH  = 1 << 5, ///< True if link requires a path string in order to be created
     };
@@ -91,7 +90,10 @@ public:
     void setHelp(const std::string& val) { m_help = val; }
 
     virtual Base* getOwnerBase() const = 0;
-    virtual BaseData* getOwnerData() const = 0;
+
+    [[deprecated("2020-10-03: Deprecated since PR #1503. BaseLink cannot hold Data anymore. Use DataLink instead. Please update your code. ")]]
+    virtual sofa::core::objectmodel::BaseData* getOwnerData() const = 0;
+
 
     /// Set one of the flags.
     void setFlag(LinkFlagsEnum flag, bool b)
@@ -104,7 +106,9 @@ public:
     bool getFlag(LinkFlagsEnum flag) const { return (m_flags&LinkFlags(flag))!=0; }
 
     bool isMultiLink() const { return getFlag(FLAG_MULTILINK); }
-    bool isDataLink() const { return getFlag(FLAG_DATALINK); }
+
+    [[deprecated("2020-10-03: Deprecated since PR #1503. BaseLink cannot hold Data anymore. Use DataLink instead. Please update your code. ")]]
+    bool isDataLink() const { return false; }
     bool isStrongLink() const { return getFlag(FLAG_STRONGLINK); }
     bool isDoubleLink() const { return getFlag(FLAG_DOUBLELINK); }
     bool isDuplicate() const { return getFlag(FLAG_DUPLICATE); }
@@ -133,7 +137,10 @@ public:
 
     virtual size_t getSize() const = 0;
     virtual Base* getLinkedBase(std::size_t index=0) const = 0;
+
+    [[deprecated("2020-10-03: Deprecated since PR #1503. BaseLink cannot hold Data anymore. Use DataLink instead. Please update your code. ")]]
     virtual BaseData* getLinkedData(std::size_t index=0) const = 0;
+
     virtual std::string getLinkedPath(std::size_t index=0) const = 0;
 
     /// @name Serialization API

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
@@ -27,7 +27,6 @@
 #include <sofa/helper/StringUtils.h>
 #include <sofa/helper/accessor.h>
 #include <sofa/core/objectmodel/DataContentValue.h>
-
 namespace sofa
 {
 
@@ -49,7 +48,7 @@ public:
     {
     }
 
-    //TODO(dmarchal:08/10/2019)Uncomment the deprecated when VS2015 support will be dropped. 
+    //TODO(dmarchal:08/10/2019)Uncomment the deprecated when VS2015 support will be dropped.
     //[[deprecated("Replaced with one with std::string instead of char* version")]]
     TData( const char* helpMsg=nullptr, bool isDisplayed=true, bool isReadOnly=false) :
         TData( sofa::helper::safeCharToString(helpMsg), isDisplayed, isReadOnly) {}
@@ -175,12 +174,10 @@ public:
         T value;
     };
 
-
     static std::string templateName()
     {
         return sofa::core::objectmodel::BaseData::typeName<Data<T>>();
     }
-
 
     // It's used for getting a new instance from an existing instance. This function is used by the communication plugin
     virtual BaseData* getNewInstance() { return new Data();}
@@ -350,7 +347,7 @@ public:
 
 protected:
 
-    typedef DataValue<T, sofa::defaulttype::DataTypeInfo<T>::CopyOnWrite> ValueType;
+    typedef DataContentValue<T, sofa::defaulttype::DataTypeInfo<T>::CopyOnWrite> ValueType;
 
     /// Value
     ValueType m_value;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataContentValue.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataContentValue.h
@@ -31,30 +31,30 @@ namespace sofa::core::objectmodel
 /// - CopyOnWrite==false: an independent copy (duplicated memory)
 /// - CopyOnWrite==true: shared memory while the Data is not modified (in that case the memory is duplicated to get an independent copy)
 template <class T, bool CopyOnWrite>
-class DataValue;
+class DataContentValue;
 
 template <class T>
-class DataValue<T, false>
+class DataContentValue<T, false>
 {
     T data;
 public:
 
-    DataValue()
+    DataContentValue()
         : data(T())// BUGFIX (Jeremie A.): Force initialization of basic types to 0 (bool, int, float, etc).
     {
     }
 
-    explicit DataValue(const T &value)
+    explicit DataContentValue(const T &value)
         : data(value)
     {
     }
 
-    DataValue(const DataValue& dc)
+    DataContentValue(const DataContentValue& dc)
         : data(dc.getValue())
     {
     }
 
-    DataValue& operator=(const DataValue& dc )
+    DataContentValue& operator=(const DataContentValue& dc )
     {
         data = dc.getValue(); // copy
         return *this;
@@ -74,31 +74,31 @@ public:
 
 
 template <class T>
-class DataValue<T, true>
+class DataContentValue<T, true>
 {
     std::shared_ptr<T> ptr;
 public:
 
-    DataValue()
+    DataContentValue()
         : ptr(new T(T())) // BUGFIX (Jeremie A.): Force initialization of basic types to 0 (bool, int, float, etc).
     {
     }
 
-    explicit DataValue(const T& value)
+    explicit DataContentValue(const T& value)
         : ptr(new T(value))
     {
     }
 
-    DataValue(const DataValue& dc)
+    DataContentValue(const DataContentValue& dc)
         : ptr(dc.ptr) // start with shared memory
     {
     }
 
-    ~DataValue()
+    ~DataContentValue()
     {
     }
 
-    DataValue& operator=(const DataValue& dc )
+    DataContentValue& operator=(const DataContentValue& dc )
     {
         //avoid self reference
         if(&dc != this)

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Link.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Link.h
@@ -25,15 +25,16 @@
 #include <sofa/core/objectmodel/BaseLink.h>
 #include <sofa/helper/stable_vector.h>
 
+#include <sofa/core/PathResolver.h>
 #include <sstream>
 #include <utility>
 #include <vector>
-
 namespace sofa
 {
 
 namespace core
 {
+
 
 namespace objectmodel
 {
@@ -211,7 +212,6 @@ class LinkTraitsContainer<TDestType, TDestPtr, TValueType, false>
 {
 public:
     typedef SinglePtr<TDestType, TValueType> T;
-    //typedef helper::fixed_array<TValueType,1> T;
     static void clear(T& c)
     {
         c.clear();
@@ -265,44 +265,6 @@ public:
     }
 };
 
-template<class OwnerType, class DestType, bool data>
-class LinkTraitsFindDest;
-
-template<class OwnerType, class DestType>
-class LinkTraitsFindDest<OwnerType, DestType, false>
-{
-public:
-    static bool findLinkDest(OwnerType* owner, DestType*& ptr, const std::string& path, const BaseLink* link)
-    {
-        return owner->findLinkDest(ptr, path, link);
-    }
-    template<class TContext>
-    static bool checkPath(const std::string& path, TContext* context)
-    {
-        DestType* ptr = nullptr;
-        return context->findLinkDest(ptr, path, nullptr);
-    }
-};
-
-template<class OwnerType, class DestType>
-class LinkTraitsFindDest<OwnerType, DestType, true>
-{
-public:
-    static bool findLinkDest(OwnerType* owner, DestType*& ptr, const std::string& path, const BaseLink* link)
-    {
-        return owner->findDataLinkDest(ptr, path, link);
-    }
-    template<class TContext>
-    static bool checkPath(const std::string& path, TContext* context)
-    {
-        DestType* ptr = nullptr;
-        return context->findDataLinkDest(ptr, path, nullptr);
-    }
-};
-
-template<class Type>
-class LinkTraitsPtrCasts;
-
 /**
  *  \brief Container of all links in the scenegraph, from a given type of object (Owner) to another (Dest)
  *
@@ -323,9 +285,6 @@ public:
     typedef typename TraitsContainer::T Container;
     typedef typename Container::const_iterator const_iterator;
     typedef typename Container::const_reverse_iterator const_reverse_iterator;
-    typedef LinkTraitsFindDest<OwnerType, DestType, ACTIVEFLAG(FLAG_DATALINK)> TraitsFindDest;
-    typedef LinkTraitsPtrCasts<TOwnerType> TraitsOwnerCasts;
-    typedef LinkTraitsPtrCasts<TDestType> TraitsDestCasts;
 #undef ACTIVEFLAG
 
     TLink()
@@ -343,56 +302,49 @@ public:
     {
     }
 
-        [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
-
+    [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
     size_t size(const core::ExecParams*) const { return size(); }
     size_t size() const
     {
         return static_cast<size_t>(m_value.size());
     }
 
-        [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
-
+    [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
     bool empty(const core::ExecParams* param) const ;
     bool empty() const
     {
         return m_value.empty();
     }
 
-        [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
-
+    [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
     const Container& getValue(const core::ExecParams*) const { return getValue(); }
     const Container& getValue() const
     {
         return m_value;
     }
 
-        [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
-
+    [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
     const_iterator begin(const core::ExecParams*) const { return begin(); }
     const_iterator begin() const
     {
         return m_value.cbegin();
     }
 
-        [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
-
+    [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
     const_iterator end(const core::ExecParams*) const { return end(); }
     const_iterator end() const
     {
         return m_value.cend();
     }
 
-        [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
-
+    [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
     const_reverse_iterator rbegin(const core::ExecParams*) const { return rbegin(); }
     const_reverse_iterator rbegin() const
     {
         return m_value.crbegin();
     }
 
-        [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
-
+    [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
     const_reverse_iterator rend(const core::ExecParams*) const { return rend(); }
     const_reverse_iterator rend() const
     {
@@ -423,7 +375,7 @@ public:
         if (path.empty()) return false;
         DestType* ptr = nullptr;
         if (m_owner)
-            TraitsFindDest::findLinkDest(m_owner, ptr, path, this);
+            PathResolver::FindLinkDest(m_owner, ptr, path, this);
         return add(ptr, path);
     }
 
@@ -494,20 +446,22 @@ public:
         {
             DestType* ptr = TraitsDestPtr::get(TraitsValueType::get(value));
             if (ptr)
-                path = BaseLink::CreateString(TraitsDestCasts::getBase(ptr), TraitsDestCasts::getData(ptr),
-                        TraitsOwnerCasts::getBase(m_owner));
+                path = BaseLink::CreateString(ptr, nullptr, m_owner);
         }
         return path;
     }
 
     Base* getLinkedBase(std::size_t index=0) const override
     {
-        return TraitsDestCasts::getBase(getIndex(index));
+        return getIndex(index);
     }
-    BaseData* getLinkedData(std::size_t index=0) const override
+
+    [[deprecated("This function has been deprecated in PR#1503 and will be removed soon. Link<> cannot hold BaseData anymore. To make link between Data use DataLink instead.")]]
+    BaseData* getLinkedData(std::size_t =0) const override
     {
-        return TraitsDestCasts::getData(getIndex(index));
+        return nullptr;
     }
+
     std::string getLinkedPath(std::size_t index=0) const override
     {
         return getPath(index);
@@ -533,7 +487,7 @@ public:
             {
                 return false;
             }
-            else if (m_owner && !TraitsFindDest::findLinkDest(m_owner, ptr, str, this))
+            else if (m_owner && !PathResolver::FindLinkDest(m_owner, ptr, str, this))
             {
                 // This is not an error, as the destination can be added later in the graph
                 // instead, we will check for failed links after init is completed
@@ -562,7 +516,7 @@ public:
             while (istr >> path)
             {
                 DestType *ptr = nullptr;
-                if (m_owner && !TraitsFindDest::findLinkDest(m_owner, ptr, path, this))
+                if (m_owner && !PathResolver::FindLinkDest(m_owner, ptr, path, this))
                 {
                     // This is not an error, as the destination can be added later in the graph
                     // instead, we will check for failed links after init is completed
@@ -619,23 +573,24 @@ public:
         if (!context)
         {
             std::string p,d;
-            return BaseLink::ParseString( path, &p, (ActiveFlags & FLAG_DATALINK) ? &d : nullptr, nullptr);
+            return BaseLink::ParseString(path, &p, nullptr, context);
         }
-        else
-        {
-            return TraitsFindDest::checkPath(path, context);
-        }
+
+        DestType* ptr = nullptr;
+        return context->findLinkDest(ptr, path, nullptr);
     }
 
     /// @}
 
     sofa::core::objectmodel::Base* getOwnerBase() const override
     {
-        return TraitsOwnerCasts::getBase(m_owner);
+        return m_owner;
     }
+
+    [[deprecated("This function has been deprecated in PR#1503 and will be removed soon. Link<> cannot hold BaseData anymore. To make link between Data use DataLink instead.")]]
     sofa::core::objectmodel::BaseData* getOwnerData() const override
     {
-        return TraitsOwnerCasts::getData(m_owner);
+        return nullptr;
     }
 
     void setOwner(OwnerType* owner)
@@ -678,9 +633,6 @@ public:
     typedef typename Inherit::ValueType ValueType;
     typedef typename Inherit::TraitsContainer TraitsContainer;
     typedef typename Inherit::Container Container;
-    typedef typename Inherit::TraitsOwnerCasts TraitsOwnerCasts;
-    typedef typename Inherit::TraitsDestCasts TraitsDestCasts;
-    typedef typename Inherit::TraitsFindDest TraitsFindDest;
 
     typedef void (OwnerType::*ValidatorFn)(DestPtr v, std::size_t index, bool add);
 
@@ -736,7 +688,7 @@ public:
                 DestType* ptr = TraitsDestPtr::get(TraitsValueType::get(value));
                 if (!ptr)
                 {
-                    TraitsFindDest::findLinkDest(this->m_owner, ptr, path, this);
+                    PathResolver::FindLinkDest(this->m_owner, ptr, path, this);
                     if (ptr)
                     {
                         DestPtr v = ptr;
@@ -754,7 +706,7 @@ public:
         return ok;
     }
 
-        [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
+    [[deprecated("2020-03-25: Aspect have been deprecated for complete removal in PR #1269. You can probably update your code by removing aspect related calls. If the feature was important to you contact sofa-dev. ")]]
 
     DestType* get(std::size_t index, const core::ExecParams*) const { return get(index); }
     DestType* get(std::size_t index) const
@@ -803,9 +755,6 @@ public:
     typedef typename Inherit::ValueType ValueType;
     typedef typename Inherit::TraitsContainer TraitsContainer;
     typedef typename Inherit::Container Container;
-    typedef typename Inherit::TraitsOwnerCasts TraitsOwnerCasts;
-    typedef typename Inherit::TraitsDestCasts TraitsDestCasts;
-    typedef typename Inherit::TraitsFindDest TraitsFindDest;
     using Inherit::updateCounter;
     using Inherit::m_value;
     using Inherit::m_owner;
@@ -885,7 +834,7 @@ public:
         if (path.empty()) { reset(); return; }
         DestType* ptr = nullptr;
         if (m_owner)
-            TraitsFindDest::findLinkDest(m_owner, ptr, path, this);
+            PathResolver::FindLinkDest(m_owner, ptr, path, this);
         set(ptr, path);
     }
 
@@ -902,7 +851,7 @@ public:
             DestType* ptr = TraitsDestPtr::get(TraitsValueType::get(value));
             if (!ptr)
             {
-                TraitsFindDest::findLinkDest(m_owner, ptr, path, this);
+                PathResolver::FindLinkDest(m_owner, ptr, path, this);
                 if (ptr)
                 {
                     set(ptr, path);

--- a/SofaKernel/modules/SofaDeformable/MeshSpringForceField.inl
+++ b/SofaKernel/modules/SofaDeformable/MeshSpringForceField.inl
@@ -25,6 +25,7 @@
 #include <SofaDeformable/MeshSpringForceField.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
+#include <SofaBaseTopology/TopologySubsetData.h>
 #include <iostream>
 
 namespace sofa

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVisitor.h
@@ -2100,7 +2100,7 @@ public:
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
-    const char* getClassName() const override { std::string name= "MechanicalComputeContactForceVisitor["+res.getName()+"]"; return name.c_str(); }
+    const char* getClassName() const override { static std::string name= "MechanicalComputeContactForceVisitor["+res.getName()+"]"; return name.c_str(); }
 
     /// Specify whether this action can be parallelized.
     bool isThreadSafe() const override

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/Link_test.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/Link_test.cpp
@@ -45,6 +45,28 @@ struct Link_test : public BaseSimulationTest
         ASSERT_NE(nodeLink.getLinkedBase(), aBasePtr);
     }
 
+    void read_multilink_test()
+    {
+        SceneInstance si("root") ;
+        BaseObject::SPtr A = sofa::core::objectmodel::New<BaseObject>();
+        BaseObject::SPtr B = sofa::core::objectmodel::New<BaseObject>();
+        BaseObject::SPtr C = sofa::core::objectmodel::New<BaseObject>();
+        si.root->addObject(A);
+        si.root->addObject(B);
+
+        BaseLink::InitLink<BaseObject> il1(B.get(), "l1", "");
+        MultiLink<BaseObject, BaseObject, BaseLink::FLAG_NONE > withOwner(il1) ;
+
+        // 1. test with valid link & owner
+        ASSERT_TRUE(withOwner.read("@/B"));
+
+        // 2. setting C's context
+        si.root->addObject(B);
+
+        ASSERT_TRUE(withOwner.read("@/C"));
+        ASSERT_TRUE(withOwner.read("@/B @/C"));
+    }
+
     void read_test()
     {
         SceneInstance si("root") ;
@@ -88,6 +110,11 @@ TEST_F( Link_test, setLinkedBase_test)
 TEST_F( Link_test, read_test)
 {
     this->read_test() ;
+}
+
+TEST_F( Link_test, read_multilink_test)
+{
+    this->read_multilink_test();
 }
 
 }// namespace sofa


### PR DESCRIPTION
In past PR we have removed the use of a Link to store link between two data and we use DataLink instead. 
As Link cannot store anymore a link between Data the type traits code can be removed from Link.h and BaseLink.h.  

This is what this PR does (removing the un-needed). 

The next step will consist in refactoring the whole Link to separate SingleLink & MultiLink. 


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
