### PR TITLE
[All] Add doInit in Forcefield and make init as final

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.cpp
@@ -166,7 +166,7 @@ void DiagonalMass<RigidTypes, RigidMass>::initRigidImpl()
 
     if (!d_fileMass.getValue().empty())
         load(d_fileMass.getFullPath().c_str());
-    Inherited::init();
+
     initTopologyHandlers();
 
     // Initialize the f_mass vector. The f_mass vector is enlarged to contains
@@ -269,13 +269,13 @@ void DiagonalMass<Rigid2Types, Rigid2Mass>::reinit()
 }
 
 template <>
-void DiagonalMass<Rigid3Types, Rigid3Mass>::init()
+void DiagonalMass<Rigid3Types, Rigid3Mass>::doInit()
 {
     initRigidImpl<Rigid3Types>() ;
 }
 
 template <>
-void DiagonalMass<Rigid2Types, Rigid2Mass>::init()
+void DiagonalMass<Rigid2Types, Rigid2Mass>::doInit()
 {
     initRigidImpl<Rigid2Types>() ;
 }

--- a/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.h
+++ b/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.h
@@ -236,7 +236,7 @@ public:
     void clear();
 
     void reinit() override;
-    void init() override;
+    void doInit() override;
     void handleEvent(sofa::core::objectmodel::Event* ) override;
 
     void doUpdateInternal() override;
@@ -371,9 +371,9 @@ void DiagonalMass<defaulttype::Rigid3Types, defaulttype::Rigid3Mass>::reinit();
 template <>
 void DiagonalMass<defaulttype::Rigid2Types, defaulttype::Rigid2Mass>::reinit();
 template <>
-void DiagonalMass<defaulttype::Rigid3Types, defaulttype::Rigid3Mass>::init();
+void DiagonalMass<defaulttype::Rigid3Types, defaulttype::Rigid3Mass>::doInit();
 template <>
-void DiagonalMass<defaulttype::Rigid2Types, defaulttype::Rigid2Mass>::init();
+void DiagonalMass<defaulttype::Rigid2Types, defaulttype::Rigid2Mass>::doInit();
 template <>
 void DiagonalMass<defaulttype::Rigid2Types, defaulttype::Rigid2Mass>::draw(const core::visual::VisualParams* vparams);
 template <>

--- a/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.inl
@@ -848,7 +848,7 @@ bool DiagonalMass<DataTypes, MassType>::checkTopology()
 }
 
 template <class DataTypes, class MassType>
-void DiagonalMass<DataTypes, MassType>::init()
+void DiagonalMass<DataTypes, MassType>::doInit()
 {
     this->d_componentState.setValue(ComponentState::Valid);
 
@@ -861,7 +861,6 @@ void DiagonalMass<DataTypes, MassType>::init()
         msg_warning() << "File given as input for DiagonalMass, in this a case:" << msgendl
                       << "the topology won't be used to compute the mass" << msgendl
                       << "the update, the coherency and the tracking of mass information data are disable (listening = false)";
-        Inherited::init();
     }
     else
     {
@@ -870,7 +869,6 @@ void DiagonalMass<DataTypes, MassType>::init()
             this->d_componentState.setValue(ComponentState::Invalid);
             return;
         }
-        Inherited::init();
         initTopologyHandlers();
 
         // TODO(dmarchal 2018-11-10): this code is duplicated with the one in RigidImpl we should factor it (remove in 1 year if not done or update the dates)

--- a/SofaKernel/modules/SofaBaseMechanics/UniformMass.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/UniformMass.cpp
@@ -426,7 +426,7 @@ void UniformMass<Rigid3Types, Rigid3Mass>::constructor_message()
 }
 
 template<> SOFA_BASE_MECHANICS_API
-void UniformMass<Rigid3Types, Rigid3Mass>::init()
+void UniformMass<Rigid3Types, Rigid3Mass>::doInit()
 {
     initDefaultImpl() ;
 

--- a/SofaKernel/modules/SofaBaseMechanics/UniformMass.h
+++ b/SofaKernel/modules/SofaBaseMechanics/UniformMass.h
@@ -109,7 +109,7 @@ public:
     void loadRigidMass(const std::string& filename);
 
     void reinit() override;
-    void init() override;
+    void doInit() override;
     void initDefaultImpl() ;
     void doUpdateInternal() override;
     void handleEvent(sofa::core::objectmodel::Event *event) override;
@@ -202,7 +202,7 @@ private:
 
 //Specialization for rigids
 template <>
-void UniformMass<defaulttype::Rigid3Types, defaulttype::Rigid3Mass>::init();
+void UniformMass<defaulttype::Rigid3Types, defaulttype::Rigid3Mass>::doInit();
 template <>
 void UniformMass<defaulttype::Rigid3Types, defaulttype::Rigid3Mass>::loadRigidMass ( const std::string&  );
 template <>

--- a/SofaKernel/modules/SofaBaseMechanics/UniformMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/UniformMass.inl
@@ -125,7 +125,7 @@ void UniformMass<DataTypes, MassType>::setTotalMass ( SReal m )
 
 
 template <class DataTypes, class MassType>
-void UniformMass<DataTypes, MassType>::init()
+void UniformMass<DataTypes, MassType>::doInit()
 {
     initDefaultImpl();
 }
@@ -135,8 +135,6 @@ template <class DataTypes, class MassType>
 void UniformMass<DataTypes, MassType>::initDefaultImpl()
 {
     this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
-
-    Mass<DataTypes>::init();
 
     WriteAccessor<Data<vector<int> > > indices = d_indices;
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ForceField.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ForceField.h
@@ -64,7 +64,9 @@ protected:
 
     ~ForceField() override;
 public:
-    void init() override;
+    void init() final;
+
+    virtual void doInit() {};
 
     /// Retrieve the associated MechanicalState
     MechanicalState<DataTypes>* getMState() { return mstate.get(); }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ForceField.inl
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ForceField.inl
@@ -54,6 +54,8 @@ void ForceField<DataTypes>::init()
 
     if (!mstate.get())
         mstate.set(dynamic_cast< MechanicalState<DataTypes>* >(getContext()->getMechanicalState()));
+
+    doInit();
 }
 
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/Mass.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/Mass.h
@@ -64,8 +64,6 @@ protected:
 
     ~Mass() override;
 public:
-    void init() override;
-
     /// Retrieve the associated MechanicalState
     MechanicalState<DataTypes>* getMState() { return this->mstate.get(); }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/Mass.inl
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/Mass.inl
@@ -50,13 +50,6 @@ Mass<DataTypes>::~Mass()
 }
 
 template<class DataTypes>
-void Mass<DataTypes>::init()
-{
-    ForceField<DataTypes>::init();
-}
-
-
-template<class DataTypes>
 void Mass<DataTypes>::addMDx(const MechanicalParams* mparams, MultiVecDerivId fid, SReal factor)
 {
     if (mparams)

--- a/SofaKernel/modules/SofaSimpleFem/HexahedronFEMForceField.h
+++ b/SofaKernel/modules/SofaSimpleFem/HexahedronFEMForceField.h
@@ -142,7 +142,7 @@ public:
     void setUpdateStiffnessMatrix(bool val) { this->f_updateStiffnessMatrix.setValue(val); }
     void setComputeGlobalMatrix(bool val) { this->f_assembling.setValue(val); }
 
-    void init() override;
+    void doInit() override;
     void reinit() override;
     void addForce (const core::MechanicalParams* mparams, DataVecDeriv& f,
                            const DataVecCoord& x, const DataVecDeriv& v) override;

--- a/SofaKernel/modules/SofaSimpleFem/HexahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/HexahedronFEMForceField.inl
@@ -113,12 +113,10 @@ HexahedronFEMForceField<DataTypes>::HexahedronFEMForceField()
 
 
 template <class DataTypes>
-void HexahedronFEMForceField<DataTypes>::init()
+void HexahedronFEMForceField<DataTypes>::doInit()
 {
     if(_alreadyInit)return;
     else _alreadyInit=true;
-
-    this->core::behavior::ForceField<DataTypes>::init();
 
     if (l_topology.empty())
     {

--- a/SofaKernel/modules/SofaSimpleFem/TetrahedronDiffusionFEMForceField.h
+++ b/SofaKernel/modules/SofaSimpleFem/TetrahedronDiffusionFEMForceField.h
@@ -101,7 +101,7 @@ public:
 
       //@{
       /** Other usual SOFA functions */
-      void init() override;
+      void doInit() override;
       void reinit() override;
       void draw(const core::visual::VisualParams*) override;
       //@}

--- a/SofaKernel/modules/SofaSimpleFem/TetrahedronDiffusionFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/TetrahedronDiffusionFEMForceField.inl
@@ -167,10 +167,8 @@ TetrahedronDiffusionFEMForceField<DataTypes>::~TetrahedronDiffusionFEMForceField
 // --- Initialization stage
 // --------------------------------------------------------------------------------------
 template <class DataTypes>
-void TetrahedronDiffusionFEMForceField<DataTypes>::init()
+void TetrahedronDiffusionFEMForceField<DataTypes>::doInit()
 {
-    this->Inherited::init();
-
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";

--- a/SofaKernel/modules/SofaSimpleFem/TetrahedronFEMForceField.h
+++ b/SofaKernel/modules/SofaSimpleFem/TetrahedronFEMForceField.h
@@ -256,7 +256,7 @@ public:
     void setUpdateStiffnessMatrix(bool val) { this->_updateStiffnessMatrix.setValue(val); }
 
     void reset() override;
-    void init() override;
+    void doInit() override;
     void reinit() override;
 
     void addForce(const core::MechanicalParams* mparams, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v) override;

--- a/SofaKernel/modules/SofaSimpleFem/TetrahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/TetrahedronFEMForceField.inl
@@ -1324,7 +1324,7 @@ TetrahedronFEMForceField<DataTypes>::~TetrahedronFEMForceField()
 
 
 template <class DataTypes>
-void TetrahedronFEMForceField<DataTypes>::init()
+void TetrahedronFEMForceField<DataTypes>::doInit()
 {
     d_componentState.setValue(ComponentState::Invalid) ;
 
@@ -1343,8 +1343,6 @@ void TetrahedronFEMForceField<DataTypes>::init()
     // ParallelDataThrd is used to build the matrix asynchronusly (when listening = true)
     // This feature is activated when callin handleEvent with ParallelizeBuildEvent
     // At init parallelDataSimu == parallelDataThrd (and it's the case since handleEvent is called)
-
-    this->core::behavior::ForceField<DataTypes>::init();
 
     /// Take the user provide topology.
     if (l_topology.empty())

--- a/applications/plugins/Compliant/compliance/DiagonalCompliance.h
+++ b/applications/plugins/Compliant/compliance/DiagonalCompliance.h
@@ -40,7 +40,7 @@ public:
 
     Data< helper::vector<SReal> > damping; ///< diagonal damping
 
-    virtual void init() override;
+    virtual void doInit() override;
 
     /// Compute the compliance matrix
     virtual void reinit() override;

--- a/applications/plugins/Compliant/compliance/DiagonalCompliance.inl
+++ b/applications/plugins/Compliant/compliance/DiagonalCompliance.inl
@@ -29,9 +29,8 @@ DiagonalCompliance<DataTypes>::DiagonalCompliance( core::behavior::MechanicalSta
 }
 
 template<class DataTypes>
-void DiagonalCompliance<DataTypes>::init()
+void DiagonalCompliance<DataTypes>::doInit()
 {
-    Inherit::init();
     if( this->getMState()==NULL ) serr<<"init(), no mstate !" << sendl;
     reinit();
 }

--- a/applications/plugins/Compliant/compliance/FullCompliance.h
+++ b/applications/plugins/Compliant/compliance/FullCompliance.h
@@ -41,7 +41,7 @@ public:
 
     Data< helper::vector<SReal> > damping; ///< Full damping
 
-    virtual void init() override;
+    virtual void doInit() override;
 
     /// Compute the compliance matrix
     virtual void reinit() override;

--- a/applications/plugins/Compliant/compliance/FullCompliance.inl
+++ b/applications/plugins/Compliant/compliance/FullCompliance.inl
@@ -28,9 +28,8 @@ FullCompliance<DataTypes>::FullCompliance( core::behavior::MechanicalState<DataT
 }
 
 template<class DataTypes>
-void FullCompliance<DataTypes>::init()
+void FullCompliance<DataTypes>::doInit()
 {
-    Inherit::init();
     if( this->getMState()==NULL ) serr<<"init(), no mstate !" << sendl;
     reinit();
 }

--- a/applications/plugins/Compliant/compliance/LinearDiagonalCompliance.h
+++ b/applications/plugins/Compliant/compliance/LinearDiagonalCompliance.h
@@ -35,7 +35,7 @@ public:
     Data< Real > d_complianceMin; ///< Minimum compliance
     Data< Real > d_errorMin; ///< complianceMin is reached for this error value
 
-    virtual void init() override;
+    virtual void doInit() override;
 
 //    virtual SReal getPotentialEnergy( const core::MechanicalParams* mparams, const typename Inherit::DataVecCoord& x ) const;
     virtual const sofa::defaulttype::BaseMatrix* getComplianceMatrix(const core::MechanicalParams*) override;

--- a/applications/plugins/Compliant/compliance/LinearDiagonalCompliance.inl
+++ b/applications/plugins/Compliant/compliance/LinearDiagonalCompliance.inl
@@ -16,7 +16,7 @@ LinearDiagonalCompliance<DataTypes>::LinearDiagonalCompliance( core::behavior::M
 {}
 
 template<class DataTypes>
-void LinearDiagonalCompliance<DataTypes>::init()
+void LinearDiagonalCompliance<DataTypes>::doInit()
 {
     Real complianceMin = d_complianceMin.getValue();
     {
@@ -25,7 +25,6 @@ void LinearDiagonalCompliance<DataTypes>::init()
         for (std::size_t i=0; i<diag.size(); ++i)
             diag[i].fill(complianceMin);
     }
-    Inherit::init();
 }
 
 

--- a/applications/plugins/Compliant/compliance/UniformCompliance.h
+++ b/applications/plugins/Compliant/compliance/UniformCompliance.h
@@ -40,7 +40,7 @@ public:
     Data< bool > resizable; ///< can the associated dofs can be resized? (in which case the matrices must be updated)
 
 
-    virtual void init() override;
+    virtual void doInit() override;
 
     /// Compute the compliance matrix
     virtual void reinit() override;

--- a/applications/plugins/Compliant/compliance/UniformCompliance.inl
+++ b/applications/plugins/Compliant/compliance/UniformCompliance.inl
@@ -28,9 +28,8 @@ UniformCompliance<DataTypes>::UniformCompliance( core::behavior::MechanicalState
 }
 
 template<class DataTypes>
-void UniformCompliance<DataTypes>::init()
+void UniformCompliance<DataTypes>::doInit()
 {
-    Inherit::init();
     if( this->getMState()==NULL ) serr<<"UniformCompliance<DataTypes>::init(), no mstate !" << sendl;
     reinit();
 }

--- a/applications/plugins/Compliant/forcefield/DiagonalStiffness.h
+++ b/applications/plugins/Compliant/forcefield/DiagonalStiffness.h
@@ -41,7 +41,7 @@ public:
 
     Data< helper::vector<SReal> > damping; ///< diagonal damping
 
-    virtual void init() override;
+    virtual void doInit() override;
 
     /// Compute the Stiffness matrix
     virtual void reinit() override;

--- a/applications/plugins/Compliant/forcefield/DiagonalStiffness.inl
+++ b/applications/plugins/Compliant/forcefield/DiagonalStiffness.inl
@@ -25,9 +25,8 @@ DiagonalStiffness<DataTypes>::DiagonalStiffness( core::behavior::MechanicalState
 }
 
 template<class DataTypes>
-void DiagonalStiffness<DataTypes>::init()
+void DiagonalStiffness<DataTypes>::doInit()
 {
-    Inherit::init();
     if( this->getMState()==NULL ) serr<<"init(), no mstate !" << sendl;
     reinit();
 }

--- a/applications/plugins/Compliant/forcefield/UniformStiffness.h
+++ b/applications/plugins/Compliant/forcefield/UniformStiffness.h
@@ -47,7 +47,7 @@ public:
     Data< bool > resizable; ///< can the associated dofs can be resized? (in which case the matrices must be updated)
 
 
-    virtual void init() override;
+    virtual void doInit() override;
 
     /// Compute the Stiffness matrix
     virtual void reinit() override;

--- a/applications/plugins/Compliant/forcefield/UniformStiffness.inl
+++ b/applications/plugins/Compliant/forcefield/UniformStiffness.inl
@@ -22,9 +22,8 @@ UniformStiffness<DataTypes>::UniformStiffness( core::behavior::MechanicalState<D
 }
 
 template<class DataTypes>
-void UniformStiffness<DataTypes>::init()
+void UniformStiffness<DataTypes>::doInit()
 {
-    Inherit::init();
     if( this->getMState()==NULL ) serr<<"UniformStiffness<DataTypes>::init(), no mstate !" << sendl;
     reinit();
 }

--- a/applications/plugins/Compliant/misc/RigidMass.h
+++ b/applications/plugins/Compliant/misc/RigidMass.h
@@ -77,9 +77,7 @@ protected:
     
 public:
 
-    void init() override {
-		this->core::behavior::Mass<DataTypes>::init();
-
+    void doInit() override {
         typedef std::runtime_error error;
 
         try{ 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaHexahedronTLEDForceField.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaHexahedronTLEDForceField.cpp
@@ -83,9 +83,8 @@ CudaHexahedronTLEDForceField::~CudaHexahedronTLEDForceField()
     }
 }
 
-void CudaHexahedronTLEDForceField::init()
+void CudaHexahedronTLEDForceField::doInit()
 {
-    core::behavior::ForceField<CudaVec3fTypes>::init();
     reinit();
 }
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaHexahedronTLEDForceField.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaHexahedronTLEDForceField.h
@@ -104,7 +104,7 @@ public:
 
     CudaHexahedronTLEDForceField();
     virtual ~CudaHexahedronTLEDForceField();
-    void init() override;
+    void doInit() override;
     void reinit() override;
 //    void addForce (VecDeriv& f, const VecCoord& x, const VecDeriv& /*v*/);
     virtual void addForce(const sofa::core::MechanicalParams* /*mparams*/, DataVecDeriv& dataF, const DataVecCoord& dataX, const DataVecDeriv& /*dataV*/ ) override;

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearForceField.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearForceField.h
@@ -76,7 +76,7 @@ public:
 
 
 template<>
-void LinearForceField< gpu::cuda::CudaRigid3fTypes >::init();
+void LinearForceField< gpu::cuda::CudaRigid3fTypes >::doInit();
 
 template<>
 void LinearForceField< gpu::cuda::CudaRigid3fTypes >::addForce(const core::MechanicalParams* mparams, DataVecDeriv& f, const DataVecCoord& x, const DataVecDeriv& v);

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearForceField.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearForceField.inl
@@ -145,10 +145,9 @@ void LinearForceFieldInternalData< gpu::cuda::CudaRigidTypes<N, real> >::addForc
 }// LinearForceFieldInternalData::addForce
 
 template<>
-void LinearForceField<sofa::gpu::cuda::CudaRigid3fTypes>::init()
+void LinearForceField<sofa::gpu::cuda::CudaRigid3fTypes>::doInit()
 {
     data->init(this);
-	Inherit::init();
 }// LinearForceFieldInternalData::init
 
 template<>

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.cpp
@@ -82,9 +82,8 @@ CudaTetrahedronTLEDForceField::~CudaTetrahedronTLEDForceField()
     }
 }
 
-void CudaTetrahedronTLEDForceField::init()
+void CudaTetrahedronTLEDForceField::doInit()
 {
-    core::behavior::ForceField<CudaVec3fTypes>::init();
     reinit();
 }
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.h
@@ -105,7 +105,7 @@ public:
 
     CudaTetrahedronTLEDForceField();
     virtual ~CudaTetrahedronTLEDForceField();
-    void init() override;
+    void doInit() override;
     void reinit() override;
 //    void addForce (VecDeriv& f, const VecCoord& x, const VecDeriv& /*v*/);
     virtual void addForce(const sofa::core::MechanicalParams* /*mparams*/, DataVecDeriv& dataF, const DataVecCoord& dataX, const DataVecDeriv& /*dataV*/ ) override;

--- a/applications/plugins/SofaDistanceGrid/components/forcefield/DistanceGridForceField.h
+++ b/applications/plugins/SofaDistanceGrid/components/forcefield/DistanceGridForceField.h
@@ -196,7 +196,7 @@ protected:
         this->addAlias(&fileDistanceGrid,"fileDistanceGrid");
     }
 public:
-    void init() override;
+    void doInit() override;
 
     void setMState(  core::behavior::MechanicalState<DataTypes>* mstate ) { this->mstate = mstate; }
 

--- a/applications/plugins/SofaDistanceGrid/components/forcefield/DistanceGridForceField.inl
+++ b/applications/plugins/SofaDistanceGrid/components/forcefield/DistanceGridForceField.inl
@@ -43,11 +43,8 @@ namespace forcefield
 
 
 template<class DataTypes>
-void DistanceGridForceField<DataTypes>::init()
+void DistanceGridForceField<DataTypes>::doInit()
 {
-    Inherit::init();
-
-
     if (fileDistanceGrid.getValue().empty())
     {
         if (grid==NULL)

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticlesRepulsionForceField.h
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticlesRepulsionForceField.h
@@ -87,7 +87,7 @@ public:
 protected:
     ParticlesRepulsionForceField();
 public:
-    void init() override;
+    void doInit() override;
 
     void addForce(const core::MechanicalParams* mparams, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v) override;
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticlesRepulsionForceField.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticlesRepulsionForceField.inl
@@ -50,9 +50,8 @@ ParticlesRepulsionForceField<DataTypes>::ParticlesRepulsionForceField()
 }
 
 template<class DataTypes>
-void ParticlesRepulsionForceField<DataTypes>::init()
+void ParticlesRepulsionForceField<DataTypes>::doInit()
 {
-    this->Inherit::init();
     this->getContext()->get(grid); //new Grid(distance.getValue());
     if (grid==nullptr)
         serr<<"SpatialGridContainer not found by ParticlesRepulsionForceField, slow O(n2) method will be used !!!" << sendl;

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/SPHFluidForceField.h
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/SPHFluidForceField.h
@@ -176,7 +176,7 @@ public:
         return constWc(h)*d_particleMass.getValue();
     }
 
-    void init() override;
+    void doInit() override;
 
     void addForce(const core::MechanicalParams* mparams, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v) override;
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/SPHFluidForceField.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/SPHFluidForceField.inl
@@ -61,10 +61,8 @@ SPHFluidForceField<DataTypes>::SPHFluidForceField()
 }
 
 template<class DataTypes>
-void SPHFluidForceField<DataTypes>::init()
+void SPHFluidForceField<DataTypes>::doInit()
 {
-    this->Inherit::init();
-
     SPHKernel<SPH_KERNEL_CUBIC,Deriv> Kcubic(4);
     if (!Kcubic.CheckAll(2, sout.ostringstream(), serr.ostringstream())) serr << sendl;
     SPHKernel<SPH_KERNEL_DEFAULT_DENSITY,Deriv> Kd(4);

--- a/modules/SofaBoundaryCondition/ConstantForceField.h
+++ b/modules/SofaBoundaryCondition/ConstantForceField.h
@@ -78,7 +78,7 @@ public:
     SingleLink<ConstantForceField<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
     /// Init function
-    void init() override;
+    void doInit() override;
 
     /// Re-init function
     void reinit() override;

--- a/modules/SofaBoundaryCondition/ConstantForceField.inl
+++ b/modules/SofaBoundaryCondition/ConstantForceField.inl
@@ -79,7 +79,7 @@ void ConstantForceField<DataTypes>::parse(BaseObjectDescription* arg)
 
 
 template<class DataTypes>
-void ConstantForceField<DataTypes>::init()
+void ConstantForceField<DataTypes>::doInit()
 {
     this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
        
@@ -188,9 +188,6 @@ void ConstantForceField<DataTypes>::init()
         }
         msg_info() << "Input totalForce is used for initialization";
     }
-
-    // init from ForceField
-    Inherit::init();
 
     // add to tracker
     this->trackInternalData(d_indices);

--- a/modules/SofaBoundaryCondition/EdgePressureForceField.h
+++ b/modules/SofaBoundaryCondition/EdgePressureForceField.h
@@ -106,7 +106,7 @@ protected:
     /// Pointer to the current topology
     sofa::core::topology::BaseMeshTopology* m_topology;
 public:
-    void init() override;
+    void doInit() override;
 
     void addForce(const sofa::core::MechanicalParams* /*mparams*/, DataVecDeriv &  dataF, const DataVecCoord &  dataX , const DataVecDeriv & dataV ) override;
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& /* d_df */, const DataVecDeriv& /* d_dx */) override;

--- a/modules/SofaBoundaryCondition/EdgePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/EdgePressureForceField.inl
@@ -62,10 +62,8 @@ template <class DataTypes> EdgePressureForceField<DataTypes>::~EdgePressureForce
 }
 
 template <class DataTypes>
-void EdgePressureForceField<DataTypes>::init()
+void EdgePressureForceField<DataTypes>::doInit()
 {
-    this->core::behavior::ForceField<DataTypes>::init();
-
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";

--- a/modules/SofaBoundaryCondition/LinearForceField.cpp
+++ b/modules/SofaBoundaryCondition/LinearForceField.cpp
@@ -53,9 +53,9 @@ template class SOFA_BOUNDARY_CONDITION_API LinearForceField<Rigid3Types>;
 
 
 template <>
-void LinearForceField<Rigid3Types>::init()
+void LinearForceField<Rigid3Types>::doInit()
 {
-    Inherit::init();
+
 }
 
 template <>

--- a/modules/SofaBoundaryCondition/LinearForceField.h
+++ b/modules/SofaBoundaryCondition/LinearForceField.h
@@ -106,7 +106,7 @@ public:
     void addKeyForce(Real time, Deriv force);
     void clearKeyForces();
 
-    void init() override;
+    void doInit() override;
 
     // ForceField methods
     /// Add the forces
@@ -133,7 +133,7 @@ private :
 
 
 template <>
-void SOFA_BOUNDARY_CONDITION_API LinearForceField<defaulttype::Rigid3Types>::init();
+void SOFA_BOUNDARY_CONDITION_API LinearForceField<defaulttype::Rigid3Types>::doInit();
 
 template <>
 SReal SOFA_BOUNDARY_CONDITION_API LinearForceField<defaulttype::Rigid3Types>::getPotentialEnergy(const core::MechanicalParams*, const DataVecCoord& ) const;

--- a/modules/SofaBoundaryCondition/LinearForceField.inl
+++ b/modules/SofaBoundaryCondition/LinearForceField.inl
@@ -52,10 +52,8 @@ LinearForceField<DataTypes>::LinearForceField()
 
 
 template<class DataTypes>
-void LinearForceField<DataTypes>::init()
+void LinearForceField<DataTypes>::doInit()
 {
-    Inherit::init();
-
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";

--- a/modules/SofaBoundaryCondition/OscillatingTorsionPressureForceField.h
+++ b/modules/SofaBoundaryCondition/OscillatingTorsionPressureForceField.h
@@ -100,7 +100,7 @@ public:
     /// Link to be set to the topology container in the component graph.
     SingleLink<OscillatingTorsionPressureForceField<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
-    void init() override;
+    void doInit() override;
     void addForce(const core::MechanicalParams* mparams, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v) override;
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& /* d_df */, const DataVecDeriv& /* d_dx */) override;
 

--- a/modules/SofaBoundaryCondition/OscillatingTorsionPressureForceField.inl
+++ b/modules/SofaBoundaryCondition/OscillatingTorsionPressureForceField.inl
@@ -62,9 +62,8 @@ OscillatingTorsionPressureForceField<DataTypes>::~OscillatingTorsionPressureForc
 
 
 template <class DataTypes>
-void OscillatingTorsionPressureForceField<DataTypes>::init()
+void OscillatingTorsionPressureForceField<DataTypes>::doInit()
 {
-    this->core::behavior::ForceField<DataTypes>::init();
     axis.setValue( axis.getValue() / axis.getValue().norm() );
 
     if (l_topology.empty())

--- a/modules/SofaBoundaryCondition/PlaneForceField.h
+++ b/modules/SofaBoundaryCondition/PlaneForceField.h
@@ -110,7 +110,7 @@ public:
     void rotate( Deriv axe, Real angle ); // around the origin (0,0,0)
 
     /// Inherited from ForceField.
-    void init() override;
+    void doInit() override;
     void addForce(const core::MechanicalParams* mparams,
                           DataVecDeriv& f, const DataVecCoord& x, const DataVecDeriv& v) override;
     void addDForce(const core::MechanicalParams* mparams,

--- a/modules/SofaBoundaryCondition/PlaneForceField.inl
+++ b/modules/SofaBoundaryCondition/PlaneForceField.inl
@@ -64,12 +64,11 @@ PlaneForceField<DataTypes>::PlaneForceField() :
 }
 
 template<class DataTypes>
-void PlaneForceField<DataTypes>::init(){
+void PlaneForceField<DataTypes>::doInit(){
     if(this->d_componentState.getValue() == ComponentState::Valid){
         msg_warning(this) << "Calling an already fully initialized component.  You should use reinit instead." ;
     }
 
-    Inherit::init() ;
     if( this->mstate == nullptr ){
         msg_error(this) << "Missing mechanical object.  This component will be considered as not valid and will do nothing.  "
                         << "To remove this error message you need to set a <MechanicalObject> in the context of this component."  ;

--- a/modules/SofaBoundaryCondition/QuadPressureForceField.h
+++ b/modules/SofaBoundaryCondition/QuadPressureForceField.h
@@ -110,7 +110,7 @@ protected:
 
     virtual ~QuadPressureForceField();
 public:
-    void init() override;
+    void doInit() override;
 
     void addForce(const core::MechanicalParams* mparams, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v) override;
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;

--- a/modules/SofaBoundaryCondition/QuadPressureForceField.inl
+++ b/modules/SofaBoundaryCondition/QuadPressureForceField.inl
@@ -60,10 +60,8 @@ QuadPressureForceField<DataTypes>::QuadPressureForceField()
 }
 
 template <class DataTypes>
-void QuadPressureForceField<DataTypes>::init()
+void QuadPressureForceField<DataTypes>::doInit()
 {
-    this->core::behavior::ForceField<DataTypes>::init();
-
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";

--- a/modules/SofaBoundaryCondition/SurfacePressureForceField.h
+++ b/modules/SofaBoundaryCondition/SurfacePressureForceField.h
@@ -98,7 +98,7 @@ protected:
     SurfacePressureForceField();
     virtual ~SurfacePressureForceField();
 public:
-    void init() override;
+    void doInit() override;
 
     void addForce(const core::MechanicalParams* mparams, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v) override;
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& /* d_df */, const DataVecDeriv& /* d_dx */) override;

--- a/modules/SofaBoundaryCondition/SurfacePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/SurfacePressureForceField.inl
@@ -71,10 +71,8 @@ SurfacePressureForceField<DataTypes>::~SurfacePressureForceField()
 
 
 template <class DataTypes>
-void SurfacePressureForceField<DataTypes>::init()
+void SurfacePressureForceField<DataTypes>::doInit()
 {
-    this->core::behavior::ForceField<DataTypes>::init();
-   
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";

--- a/modules/SofaBoundaryCondition/TaitSurfacePressureForceField.h
+++ b/modules/SofaBoundaryCondition/TaitSurfacePressureForceField.h
@@ -105,7 +105,7 @@ public:
     /// Link to be set to the topology container in the component graph.
     SingleLink<TaitSurfacePressureForceField<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
-    void init() override;
+    void doInit() override;
     void storeResetState() override;
     void reset() override;
     void handleEvent(core::objectmodel::Event *event) override;

--- a/modules/SofaBoundaryCondition/TaitSurfacePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/TaitSurfacePressureForceField.inl
@@ -104,10 +104,8 @@ TaitSurfacePressureForceField<DataTypes>::~TaitSurfacePressureForceField()
 }
 
 template <class DataTypes>
-void TaitSurfacePressureForceField<DataTypes>::init()
+void TaitSurfacePressureForceField<DataTypes>::doInit()
 {
-    Inherit1::init();
-
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";

--- a/modules/SofaBoundaryCondition/TrianglePressureForceField.h
+++ b/modules/SofaBoundaryCondition/TrianglePressureForceField.h
@@ -111,7 +111,7 @@ protected:
 
     ~TrianglePressureForceField() override;
 public:
-    void init() override;
+    void doInit() override;
 
     void addForce(const core::MechanicalParams* mparams, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v) override;
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;

--- a/modules/SofaBoundaryCondition/TrianglePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/TrianglePressureForceField.inl
@@ -59,11 +59,8 @@ template <class DataTypes>  TrianglePressureForceField<DataTypes>::TrianglePress
     {
     }
 
-template <class DataTypes> void TrianglePressureForceField<DataTypes>::init()
+template <class DataTypes> void TrianglePressureForceField<DataTypes>::doInit()
 {
-
-    this->core::behavior::ForceField<DataTypes>::init();
-	
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";

--- a/modules/SofaGeneralDeformable/FastTriangularBendingSprings.h
+++ b/modules/SofaGeneralDeformable/FastTriangularBendingSprings.h
@@ -85,7 +85,7 @@ public:
     SingleLink<FastTriangularBendingSprings<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
     /// Searches triangle topology and creates the bending springs
-    void init() override;
+    void doInit() override;
 
     void reinit() override;
 

--- a/modules/SofaGeneralDeformable/FastTriangularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/FastTriangularBendingSprings.inl
@@ -357,10 +357,8 @@ FastTriangularBendingSprings<DataTypes>::~FastTriangularBendingSprings()
 
 
 template<class DataTypes>
-void FastTriangularBendingSprings<DataTypes>::init()
+void FastTriangularBendingSprings<DataTypes>::doInit()
 {
-    this->Inherited::init();
-
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";

--- a/modules/SofaGeneralDeformable/QuadularBendingSprings.h
+++ b/modules/SofaGeneralDeformable/QuadularBendingSprings.h
@@ -118,7 +118,7 @@ protected:
 
 public:
     /// Searches quad topology and creates the bending springs
-    void init() override;
+    void doInit() override;
 
     void addForce(const core::MechanicalParams* mparams, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v) override;
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;

--- a/modules/SofaGeneralDeformable/QuadularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/QuadularBendingSprings.inl
@@ -500,10 +500,8 @@ QuadularBendingSprings<DataTypes>::~QuadularBendingSprings()
 
 
 template<class DataTypes>
-void QuadularBendingSprings<DataTypes>::init()
+void QuadularBendingSprings<DataTypes>::doInit()
 {
-    this->Inherited::init();
-
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";

--- a/modules/SofaGeneralDeformable/TriangularBendingSprings.h
+++ b/modules/SofaGeneralDeformable/TriangularBendingSprings.h
@@ -165,7 +165,7 @@ protected:
     virtual ~TriangularBendingSprings();
 public:
     /// Searches triangle topology and creates the bending springs
-    void init() override;
+    void doInit() override;
 
     void reinit() override;
 

--- a/modules/SofaGeneralDeformable/TriangularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/TriangularBendingSprings.inl
@@ -464,11 +464,8 @@ TriangularBendingSprings<DataTypes>::~TriangularBendingSprings()
 
 
 template<class DataTypes>
-void TriangularBendingSprings<DataTypes>::init()
+void TriangularBendingSprings<DataTypes>::doInit()
 {
-    //msg_error() << "initializing TriangularBendingSprings" ;
-    this->Inherited::init();
-
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";

--- a/modules/SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.h
+++ b/modules/SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.h
@@ -160,7 +160,7 @@ protected:
 
     virtual ~TriangularBiquadraticSpringsForceField();
 public:
-    void init() override;
+    void doInit() override;
 
     void addForce(const core::MechanicalParams* mparams, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v) override;
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;

--- a/modules/SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.inl
+++ b/modules/SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.inl
@@ -183,10 +183,8 @@ template <class DataTypes> TriangularBiquadraticSpringsForceField<DataTypes>::~T
 
 }
 
-template <class DataTypes> void TriangularBiquadraticSpringsForceField<DataTypes>::init()
+template <class DataTypes> void TriangularBiquadraticSpringsForceField<DataTypes>::doInit()
 {
-    this->Inherited::init();
-    
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";

--- a/modules/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.h
+++ b/modules/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.h
@@ -146,7 +146,7 @@ protected:
 
     virtual ~TriangularQuadraticSpringsForceField();
 public:
-    void init() override;
+    void doInit() override;
 
     void addForce(const core::MechanicalParams* mparams, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v) override;
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;

--- a/modules/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.inl
+++ b/modules/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.inl
@@ -156,11 +156,8 @@ template <class DataTypes> TriangularQuadraticSpringsForceField<DataTypes>::~Tri
     if(edgeHandler) delete edgeHandler;
 }
 
-template <class DataTypes> void TriangularQuadraticSpringsForceField<DataTypes>::init()
+template <class DataTypes> void TriangularQuadraticSpringsForceField<DataTypes>::doInit()
 {
-    msg_info() << "initializing TriangularQuadraticSpringsForceField";
-    this->Inherited::init();
-
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";

--- a/modules/SofaGeneralDeformable/TriangularTensorMassForceField.h
+++ b/modules/SofaGeneralDeformable/TriangularTensorMassForceField.h
@@ -157,7 +157,7 @@ protected:
 
     virtual ~TriangularTensorMassForceField();
 public:
-    void init() override;
+    void doInit() override;
 
     void addForce(const core::MechanicalParams* mparams, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v) override;
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;

--- a/modules/SofaGeneralDeformable/TriangularTensorMassForceField.inl
+++ b/modules/SofaGeneralDeformable/TriangularTensorMassForceField.inl
@@ -282,11 +282,8 @@ template <class DataTypes> TriangularTensorMassForceField<DataTypes>::~Triangula
     if(edgeHandler) delete edgeHandler;
 }
 
-template <class DataTypes> void TriangularTensorMassForceField<DataTypes>::init()
+template <class DataTypes> void TriangularTensorMassForceField<DataTypes>::doInit()
 {
-    msg_info() << "initializing TriangularTensorMassForceField";
-    this->Inherited::init();
-
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";

--- a/modules/SofaGeneralSimpleFem/BeamFEMForceField.h
+++ b/modules/SofaGeneralSimpleFem/BeamFEMForceField.h
@@ -206,7 +206,7 @@ public:
 
 public:
 
-    void init() override;
+    void doInit() override;
     void bwdInit() override;
     void reinit() override;
     virtual void reinitBeam(index_type i);

--- a/modules/SofaGeneralSimpleFem/BeamFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/BeamFEMForceField.inl
@@ -118,10 +118,8 @@ void BeamFEMForceField<DataTypes>::bwdInit()
 
 
 template <class DataTypes>
-void BeamFEMForceField<DataTypes>::init()
+void BeamFEMForceField<DataTypes>::doInit()
 {
-    Inherit1::init();
-    
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";

--- a/modules/SofaGeneralSimpleFem/HexahedralFEMForceField.h
+++ b/modules/SofaGeneralSimpleFem/HexahedralFEMForceField.h
@@ -152,7 +152,7 @@ public:
 
     void setMethod(int val) { method = val; }
 
-    void init() override;
+    void doInit() override;
     void reinit() override;
 
     void addForce (const core::MechanicalParams* mparams, DataVecDeriv& f, const DataVecCoord& x, const DataVecDeriv& v) override;

--- a/modules/SofaGeneralSimpleFem/HexahedralFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/HexahedralFEMForceField.inl
@@ -111,10 +111,8 @@ HexahedralFEMForceField<DataTypes>::~HexahedralFEMForceField()
 
 
 template <class DataTypes>
-void HexahedralFEMForceField<DataTypes>::init()
+void HexahedralFEMForceField<DataTypes>::doInit()
 {
-    this->core::behavior::ForceField<DataTypes>::init();
-
     this->getContext()->get(_topology);
 
     if (_topology==nullptr)

--- a/modules/SofaGeneralSimpleFem/HexahedralFEMForceFieldAndMass.h
+++ b/modules/SofaGeneralSimpleFem/HexahedralFEMForceFieldAndMass.h
@@ -71,7 +71,7 @@ public:
 protected:
     HexahedralFEMForceFieldAndMass();
 public:
-    void init( ) override;
+    void doInit( ) override;
     void reinit( ) override;
 
     // -- Mass interface

--- a/modules/SofaGeneralSimpleFem/HexahedralFEMForceFieldAndMass.inl
+++ b/modules/SofaGeneralSimpleFem/HexahedralFEMForceFieldAndMass.inl
@@ -52,10 +52,8 @@ HexahedralFEMForceFieldAndMass<DataTypes>::HexahedralFEMForceFieldAndMass()
 
 
 template<class DataTypes>
-void HexahedralFEMForceFieldAndMass<DataTypes>::init( )
+void HexahedralFEMForceFieldAndMass<DataTypes>::doInit( )
 {
-    this->core::behavior::ForceField<DataTypes>::init();
-
     this->getContext()->get(this->_topology);
 
     if(this->_topology == nullptr)

--- a/modules/SofaGeneralSimpleFem/HexahedronFEMForceFieldAndMass.h
+++ b/modules/SofaGeneralSimpleFem/HexahedronFEMForceFieldAndMass.h
@@ -70,7 +70,7 @@ protected:
     HexahedronFEMForceFieldAndMass();
 public:
 
-    void init( ) override;
+    void doInit( ) override;
     void reinit( ) override;
 
     virtual void computeElementMasses( ); ///< compute the mass matrices

--- a/modules/SofaGeneralSimpleFem/HexahedronFEMForceFieldAndMass.inl
+++ b/modules/SofaGeneralSimpleFem/HexahedronFEMForceFieldAndMass.inl
@@ -50,11 +50,10 @@ HexahedronFEMForceFieldAndMass<DataTypes>::HexahedronFEMForceFieldAndMass()
 
 
 template<class DataTypes>
-void HexahedronFEMForceFieldAndMass<DataTypes>::init( )
+void HexahedronFEMForceFieldAndMass<DataTypes>::doInit( )
 {
     if(this->_alreadyInit)return;
-    HexahedronFEMForceFieldT::init();
-    MassT::init();
+    HexahedronFEMForceFieldT::doInit();
 
     _particleMasses.resize( this->_initialPoints.getValue().size() );
 

--- a/modules/SofaGeneralSimpleFem/TetrahedralCorotationalFEMForceField.h
+++ b/modules/SofaGeneralSimpleFem/TetrahedralCorotationalFEMForceField.h
@@ -204,7 +204,7 @@ public:
 
     void setComputeGlobalMatrix(bool val) { this->_assembling.setValue(val); }
 
-    void init() override;
+    void doInit() override;
     void reinit() override;
 
     void addForce(const core::MechanicalParams* mparams, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v) override;

--- a/modules/SofaGeneralSimpleFem/TetrahedralCorotationalFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/TetrahedralCorotationalFEMForceField.inl
@@ -107,10 +107,8 @@ TetrahedralCorotationalFEMForceField<DataTypes>::TetrahedralCorotationalFEMForce
 }
 
 template <class DataTypes>
-void TetrahedralCorotationalFEMForceField<DataTypes>::init()
+void TetrahedralCorotationalFEMForceField<DataTypes>::doInit()
 {
-    this->core::behavior::ForceField<DataTypes>::init();
-
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";

--- a/modules/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.h
+++ b/modules/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.h
@@ -109,7 +109,7 @@ protected:
 
     virtual ~TriangularFEMForceFieldOptim();
 public:
-    void init() override;
+    void doInit() override;
     void reinit() override;
     void addForce(const core::MechanicalParams* mparams, DataVecDeriv& f, const DataVecCoord& x, const DataVecDeriv& v) override;
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& df, const DataVecDeriv& dx) override;

--- a/modules/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.inl
+++ b/modules/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.inl
@@ -105,10 +105,8 @@ TriangularFEMForceFieldOptim<DataTypes>::~TriangularFEMForceFieldOptim()
 // --- Initialization stage
 // --------------------------------------------------------------------------------------
 template <class DataTypes>
-void TriangularFEMForceFieldOptim<DataTypes>::init()
+void TriangularFEMForceFieldOptim<DataTypes>::doInit()
 {
-    this->Inherited::init();
-
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";

--- a/modules/SofaMiscFem/FastTetrahedralCorotationalForceField.h
+++ b/modules/SofaMiscFem/FastTetrahedralCorotationalForceField.h
@@ -172,7 +172,7 @@ protected:
 
 public:
 
-    void init() override;
+    void doInit() override;
 
 
     void addForce(const sofa::core::MechanicalParams* /*mparams*/, DataVecDeriv &  dataF, const DataVecCoord &  dataX , const DataVecDeriv & dataV ) override;

--- a/modules/SofaMiscFem/FastTetrahedralCorotationalForceField.inl
+++ b/modules/SofaMiscFem/FastTetrahedralCorotationalForceField.inl
@@ -171,10 +171,8 @@ template <class DataTypes> FastTetrahedralCorotationalForceField<DataTypes>::~Fa
     if (tetrahedronHandler) delete tetrahedronHandler;
 }
 
-template <class DataTypes> void FastTetrahedralCorotationalForceField<DataTypes>::init()
+template <class DataTypes> void FastTetrahedralCorotationalForceField<DataTypes>::doInit()
 {
-    this->Inherited::init();
-
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";

--- a/modules/SofaMiscFem/StandardTetrahedralFEMForceField.h
+++ b/modules/SofaMiscFem/StandardTetrahedralFEMForceField.h
@@ -180,7 +180,7 @@ public:
 
   //  virtual void parse(core::objectmodel::BaseObjectDescription* arg);
 
-    void init() override;
+    void doInit() override;
     //Used for CUDA implementation
     void initNeighbourhoodPoints();
     void initNeighbourhoodEdges();

--- a/modules/SofaMiscFem/StandardTetrahedralFEMForceField.inl
+++ b/modules/SofaMiscFem/StandardTetrahedralFEMForceField.inl
@@ -141,9 +141,8 @@ template <class DataTypes> StandardTetrahedralFEMForceField<DataTypes>::~Standar
     if (tetrahedronHandler) delete tetrahedronHandler;
 }
 
-template <class DataTypes> void StandardTetrahedralFEMForceField<DataTypes>::init()
+template <class DataTypes> void StandardTetrahedralFEMForceField<DataTypes>::doInit()
 {
-    this->Inherited::init();
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";

--- a/modules/SofaMiscFem/TetrahedralTensorMassForceField.h
+++ b/modules/SofaMiscFem/TetrahedralTensorMassForceField.h
@@ -124,7 +124,7 @@ protected:
 
 public:
 
-    void init() override;
+    void doInit() override;
     void initNeighbourhoodPoints();
 
     void addForce(const core::MechanicalParams* mparams, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v) override;

--- a/modules/SofaMiscFem/TetrahedralTensorMassForceField.inl
+++ b/modules/SofaMiscFem/TetrahedralTensorMassForceField.inl
@@ -281,10 +281,8 @@ template <class DataTypes> TetrahedralTensorMassForceField<DataTypes>::~Tetrahed
     if(edgeHandler) delete edgeHandler;
 }
 
-template <class DataTypes> void TetrahedralTensorMassForceField<DataTypes>::init()
+template <class DataTypes> void TetrahedralTensorMassForceField<DataTypes>::doInit()
 {
-    this->Inherited::init();
-
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";

--- a/modules/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.h
+++ b/modules/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.h
@@ -202,7 +202,7 @@ public:
 
   //  virtual void parse(core::objectmodel::BaseObjectDescription* arg);
 
-    void init() override;
+    void doInit() override;
     
     void addForce(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v) override;
     void addDForce(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;

--- a/modules/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.inl
+++ b/modules/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.inl
@@ -129,12 +129,10 @@ template <class DataTypes> TetrahedronHyperelasticityFEMForceField<DataTypes>::~
     if(m_tetrahedronHandler) delete m_tetrahedronHandler;
 }
 
-template <class DataTypes> void TetrahedronHyperelasticityFEMForceField<DataTypes>::init()
+template <class DataTypes> void TetrahedronHyperelasticityFEMForceField<DataTypes>::doInit()
 {
     if (this->f_printLog.getValue())
         msg_info() << "initializing TetrahedronHyperelasticityFEMForceField";
-
-    this->Inherited::init();
 
     /** parse the parameter set */
     SetParameterArray paramSet=d_parameterSet.getValue();

--- a/modules/SofaMiscFem/TriangleFEMForceField.h
+++ b/modules/SofaMiscFem/TriangleFEMForceField.h
@@ -110,7 +110,7 @@ protected:
 
 public:
 
-    void init() override;
+    void doInit() override;
     void reinit() override;
     void addForce(const core::MechanicalParams* mparams, DataVecDeriv& f, const DataVecCoord& x, const DataVecDeriv& v) override;
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& df, const DataVecDeriv& dx) override;

--- a/modules/SofaMiscFem/TriangleFEMForceField.inl
+++ b/modules/SofaMiscFem/TriangleFEMForceField.inl
@@ -69,9 +69,8 @@ TriangleFEMForceField<DataTypes>::~TriangleFEMForceField()
 
 
 template <class DataTypes>
-void TriangleFEMForceField<DataTypes>::init()
+void TriangleFEMForceField<DataTypes>::doInit()
 {
-    this->Inherited::init();
     if (f_method.getValue() == "small")
         method = SMALL;
     else if (f_method.getValue() == "large")

--- a/modules/SofaMiscFem/TriangularAnisotropicFEMForceField.h
+++ b/modules/SofaMiscFem/TriangularAnisotropicFEMForceField.h
@@ -68,7 +68,7 @@ public:
     typedef sofa::core::topology::BaseMeshTopology::Triangle Element;
     typedef sofa::core::topology::BaseMeshTopology::SeqTriangles VecElement;
 
-    void init() override;
+    void doInit() override;
     void reinit() override;
     void draw(const core::visual::VisualParams* vparams) override;
 protected:

--- a/modules/SofaMiscFem/TriangularAnisotropicFEMForceField.inl
+++ b/modules/SofaMiscFem/TriangularAnisotropicFEMForceField.inl
@@ -90,7 +90,7 @@ void TriangularAnisotropicFEMForceField<DataTypes>::TRQSTriangleHandler::applyCr
 }
 
 template< class DataTypes>
-void TriangularAnisotropicFEMForceField<DataTypes>::init()
+void TriangularAnisotropicFEMForceField<DataTypes>::doInit()
 {
     if (l_topology.empty())
     {
@@ -112,7 +112,6 @@ void TriangularAnisotropicFEMForceField<DataTypes>::init()
     localFiberDirection.createTopologicalEngine(m_topology, triangleHandler);
     localFiberDirection.registerTopologicalData();
 
-    Inherited::init();
     reinit();
 }
 

--- a/modules/SofaMiscFem/TriangularFEMForceField.h
+++ b/modules/SofaMiscFem/TriangularFEMForceField.h
@@ -105,7 +105,7 @@ protected:
 
     ~TriangularFEMForceField() override;
 public:
-    void init() override;
+    void doInit() override;
     void reinit() override;
     void addForce(const core::MechanicalParams* mparams, DataVecDeriv& f, const DataVecCoord& x, const DataVecDeriv& v) override;
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& df, const DataVecDeriv& dx) override;

--- a/modules/SofaMiscFem/TriangularFEMForceField.inl
+++ b/modules/SofaMiscFem/TriangularFEMForceField.inl
@@ -138,10 +138,8 @@ TriangularFEMForceField<DataTypes>::~TriangularFEMForceField()
 // --- Initialization stage
 // --------------------------------------------------------------------------------------
 template <class DataTypes>
-void TriangularFEMForceField<DataTypes>::init()
+void TriangularFEMForceField<DataTypes>::doInit()
 {
-    this->Inherited::init();
-
 #ifdef PLOT_CURVE
     allGraphStress.clear();
     allGraphCriteria.clear();

--- a/modules/SofaMiscForceField/LennardJonesForceField.h
+++ b/modules/SofaMiscForceField/LennardJonesForceField.h
@@ -85,7 +85,7 @@ public:
     void setDamping(Real v) { damping.setValue(v); }
 
 
-    void init() override;
+    void doInit() override;
 
     void addForce(const core::MechanicalParams* mparams, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v) override;
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;

--- a/modules/SofaMiscForceField/LennardJonesForceField.inl
+++ b/modules/SofaMiscForceField/LennardJonesForceField.inl
@@ -56,10 +56,8 @@ LennardJonesForceField<DataTypes>::LennardJonesForceField()
 }
 
 template<class DataTypes>
-void LennardJonesForceField<DataTypes>::init()
+void LennardJonesForceField<DataTypes>::doInit()
 {
-    this->Inherit::init();
-
     assert( this->mstate );
 
     if(aInit.getValue()!=0)

--- a/modules/SofaMiscForceField/MeshMatrixMass.h
+++ b/modules/SofaMiscForceField/MeshMatrixMass.h
@@ -158,7 +158,7 @@ public:
     virtual void clear();
 
     void reinit() override;
-    void init() override;
+    void doInit() override;
     void handleEvent(sofa::core::objectmodel::Event *event) override;
     void doUpdateInternal() override;
 

--- a/modules/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/MeshMatrixMass.inl
@@ -907,7 +907,7 @@ void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(c
 using sofa::core::topology::TopologyObjectType;
 
 template <class DataTypes, class MassType>
-void MeshMatrixMass<DataTypes, MassType>::init()
+void MeshMatrixMass<DataTypes, MassType>::doInit()
 {
     m_massLumpingCoeff = 0.0;
 
@@ -917,7 +917,6 @@ void MeshMatrixMass<DataTypes, MassType>::init()
         sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         return;
     }
-    Inherited::init();
     initTopologyHandlers(topoType);
 
     massInitialization();

--- a/modules/SofaNonUniformFem/src/SofaNonUniformFem/HexahedronCompositeFEMForceFieldAndMass.h
+++ b/modules/SofaNonUniformFem/src/SofaNonUniformFem/HexahedronCompositeFEMForceFieldAndMass.h
@@ -89,7 +89,7 @@ protected:
 
 public:
 
-    void init() override;
+    void doInit() override;
     void reinit() override;
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/modules/SofaNonUniformFem/src/SofaNonUniformFem/HexahedronCompositeFEMForceFieldAndMass.inl
+++ b/modules/SofaNonUniformFem/src/SofaNonUniformFem/HexahedronCompositeFEMForceFieldAndMass.inl
@@ -429,11 +429,10 @@ const float HexahedronCompositeFEMForceFieldAndMass<DataTypes>::RIGID_STIFFNESS[
 };
 
 template <class DataTypes>
-void HexahedronCompositeFEMForceFieldAndMass<DataTypes>::init()
+void HexahedronCompositeFEMForceFieldAndMass<DataTypes>::doInit()
 {
-
     // init topology, virtual levels, calls computeMechanicalMatricesByCondensation, handles masses
-    NonUniformHexahedronFEMForceFieldAndMassT::init();
+    NonUniformHexahedronFEMForceFieldAndMassT::doInit();
 
 
     if(d_drawSize.getValue()==-1)

--- a/modules/SofaNonUniformFem/src/SofaNonUniformFem/NonUniformHexahedralFEMForceFieldAndMass.h
+++ b/modules/SofaNonUniformFem/src/SofaNonUniformFem/NonUniformHexahedralFEMForceFieldAndMass.h
@@ -94,7 +94,7 @@ public:
 protected:
     NonUniformHexahedralFEMForceFieldAndMass();
 public:
-    void init() override;
+    void doInit() override;
     void reinit() override;
 
     // handle topological changes

--- a/modules/SofaNonUniformFem/src/SofaNonUniformFem/NonUniformHexahedralFEMForceFieldAndMass.inl
+++ b/modules/SofaNonUniformFem/src/SofaNonUniformFem/NonUniformHexahedralFEMForceFieldAndMass.inl
@@ -39,10 +39,8 @@ NonUniformHexahedralFEMForceFieldAndMass<DataTypes>::NonUniformHexahedralFEMForc
 {}
 
 template <class DataTypes>
-void NonUniformHexahedralFEMForceFieldAndMass<DataTypes>::init()
+void NonUniformHexahedralFEMForceFieldAndMass<DataTypes>::doInit()
 {
-    this->core::behavior::ForceField<DataTypes>::init();
-
     this->getContext()->get(this->_topology);
 
     if(this->_topology == nullptr)

--- a/modules/SofaNonUniformFem/src/SofaNonUniformFem/NonUniformHexahedronFEMForceFieldAndMass.h
+++ b/modules/SofaNonUniformFem/src/SofaNonUniformFem/NonUniformHexahedronFEMForceFieldAndMass.h
@@ -85,7 +85,7 @@ protected:
 
 public:
 
-    void init() override;
+    void doInit() override;
     void reinit()  override { msg_warning() << "Non-uniform mechanical properties can't be updated, changes on mechanical properties (young, poisson, density) are not taken into account."; }
 
     void addMDx(const core::MechanicalParams* mparams, DataVecDeriv& f, const DataVecDeriv& dx, SReal factor) override;

--- a/modules/SofaNonUniformFem/src/SofaNonUniformFem/NonUniformHexahedronFEMForceFieldAndMass.inl
+++ b/modules/SofaNonUniformFem/src/SofaNonUniformFem/NonUniformHexahedronFEMForceFieldAndMass.inl
@@ -39,13 +39,10 @@ NonUniformHexahedronFEMForceFieldAndMass<DataTypes>::NonUniformHexahedronFEMForc
 }
 
 template <class DataTypes>
-void NonUniformHexahedronFEMForceFieldAndMass<DataTypes>::init()
+void NonUniformHexahedronFEMForceFieldAndMass<DataTypes>::doInit()
 {
     if(this->_alreadyInit)return;
     else this->_alreadyInit=true;
-
-
-    this->core::behavior::ForceField<DataTypes>::init();
 
     if (l_topology.empty())
     {


### PR DESCRIPTION
Turn ForceField init method as final and internally call a delegate fonction doInit which can be overide. This is to avoid adding a call super in each forcefield as ForceField::init has to be called in the current api




______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
