### PR TITLE
[SofaQtGui] Restore GraphWidget for Momentum and Energy using QtCharts instead of Qwt

### DIFF
--- a/modules/SofaGuiQt/CMakeLists.txt
+++ b/modules/SofaGuiQt/CMakeLists.txt
@@ -228,22 +228,26 @@ endif()
 if(SOFAGUI_ENABLE_QWT)
     list(APPEND MOC_HEADER_FILES
         ${SRC_ROOT}/GraphDataWidget.h
-        ${SRC_ROOT}/QGraphStatWidget.h
-        ${SRC_ROOT}/QEnergyStatWidget.h
-        ${SRC_ROOT}/QMomentumStatWidget.h
         )
     list(APPEND SOURCE_FILES
         ${SRC_ROOT}/GraphDataWidget.cpp
-        ${SRC_ROOT}/QGraphStatWidget.cpp
-        ${SRC_ROOT}/QEnergyStatWidget.cpp
-        ${SRC_ROOT}/QMomentumStatWidget.cpp
         )
 endif()
 
 # QtCharts
 if(Qt5Charts_FOUND)
-    list(APPEND MOC_HEADER_FILES ${SRC_ROOT}/SofaWindowProfiler.h)
-    list(APPEND SOURCE_FILES ${SRC_ROOT}/SofaWindowProfiler.cpp)
+    list(APPEND MOC_HEADER_FILES 
+		${SRC_ROOT}/SofaWindowProfiler.h
+		${SRC_ROOT}/QGraphStatWidget.h
+        ${SRC_ROOT}/QEnergyStatWidget.h
+        ${SRC_ROOT}/QMomentumStatWidget.h
+		)
+    list(APPEND SOURCE_FILES 
+		${SRC_ROOT}/SofaWindowProfiler.cpp
+        ${SRC_ROOT}/QGraphStatWidget.cpp
+        ${SRC_ROOT}/QEnergyStatWidget.cpp
+        ${SRC_ROOT}/QMomentumStatWidget.cpp
+		)
     list(APPEND UI_FILES ${SRC_ROOT}/WindowProfiler.ui)
 else()
     message(STATUS "SofaGuiQt: QtCharts not found, SofaWindowProfiler will not be built.")

--- a/modules/SofaGuiQt/src/sofa/gui/qt/ModifyObject.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/ModifyObject.cpp
@@ -275,7 +275,7 @@ void ModifyObject::createDialog(core::objectmodel::Base* base)
             }
         }
 
-#ifdef SOFAGUIQT_HAVE_QT5_CHARTS
+#if SOFAGUIQT_HAVE_QT5_CHARTS
         //Energy Widget
         if (simulation::Node* real_node = dynamic_cast<simulation::Node*>(node))
         {

--- a/modules/SofaGuiQt/src/sofa/gui/qt/ModifyObject.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/ModifyObject.cpp
@@ -583,15 +583,13 @@ void ModifyObject::updateTables()
 #endif
 #if SOFAGUIQT_HAVE_QWT
     if (energy)
-    {
-        energy->step();
-        if (dialogTab->currentWidget() == energy) energy->updateVisualization();
+    {        
+        if (dialogTab->currentWidget() == energy) energy->step();
     }
 
     if (momentum)
     {
-        momentum->step();
-        if (dialogTab->currentWidget() == momentum) momentum->updateVisualization();
+        if (dialogTab->currentWidget() == momentum) momentum->step();
     }
 #endif
 

--- a/modules/SofaGuiQt/src/sofa/gui/qt/ModifyObject.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/ModifyObject.cpp
@@ -275,6 +275,29 @@ void ModifyObject::createDialog(core::objectmodel::Base* base)
             }
         }
 
+#ifdef SOFAGUIQT_HAVE_QWT
+        //Energy Widget
+        if (simulation::Node* real_node = dynamic_cast<simulation::Node*>(node))
+        {
+            if (dialogFlags_.REINIT_FLAG)
+            {
+                energy = new QEnergyStatWidget(dialogTab, real_node);
+                dialogTab->addTab(energy, QString("Energy Stats"));
+            }
+        }
+
+        //Momentum Widget
+        if (simulation::Node* real_node = dynamic_cast<simulation::Node*>(node))
+        {
+            if (dialogFlags_.REINIT_FLAG)
+            {
+                momentum = new QMomentumStatWidget(dialogTab, real_node);
+                dialogTab->addTab(momentum, QString("Momentum Stats"));
+            }
+        }
+#endif
+
+
         /// Info Widget
         {
             QDataDescriptionWidget* description=new QDataDescriptionWidget(dialogTab, node);

--- a/modules/SofaGuiQt/src/sofa/gui/qt/ModifyObject.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/ModifyObject.cpp
@@ -29,7 +29,7 @@
 #include <QDesktopServices>
 #include <QTimer>
 #include <sofa/gui/qt/QTransformationWidget.h>
-#if SOFAGUIQT_HAVE_QWT
+#if SOFAGUIQT_HAVE_QT5_CHARTS
 #include <sofa/gui/qt/QEnergyStatWidget.h>
 #include <sofa/gui/qt/QMomentumStatWidget.h>
 #endif
@@ -77,7 +77,7 @@ ModifyObject::ModifyObject(void *Id,
       messageTab(nullptr),
       messageEdit(nullptr),
       transformation(nullptr)
-    #if SOFAGUIQT_HAVE_QWT
+    #if SOFAGUIQT_HAVE_QT5_CHARTS
     ,energy(nullptr)
     ,momentum(nullptr)
     #endif
@@ -275,7 +275,7 @@ void ModifyObject::createDialog(core::objectmodel::Base* base)
             }
         }
 
-#ifdef SOFAGUIQT_HAVE_QWT
+#ifdef SOFAGUIQT_HAVE_QT5_CHARTS
         //Energy Widget
         if (simulation::Node* real_node = dynamic_cast<simulation::Node*>(node))
         {
@@ -581,7 +581,7 @@ void ModifyObject::updateTables()
 #ifdef DEBUG_GUI
     std::cout << "GUI<emit updateDataWidgets()" << std::endl;
 #endif
-#if SOFAGUIQT_HAVE_QWT
+#if SOFAGUIQT_HAVE_QT5_CHARTS
     if (energy)
     {        
         if (dialogTab->currentWidget() == energy) energy->step();

--- a/modules/SofaGuiQt/src/sofa/gui/qt/ModifyObject.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/ModifyObject.h
@@ -59,7 +59,7 @@ namespace qt
 {
 
 class QTransformationWidget;
-#if SOFAGUIQT_HAVE_QWT
+#if SOFAGUIQT_HAVE_QT5_CHARTS
 class QEnergyStatWidget;
 class QMomentumStatWidget;
 #endif
@@ -185,7 +185,7 @@ protected:
     //Widget specific to Node:
     //Transformation widget: translation, rotation, scale ( only experimental and deactivated)
     QTransformationWidget* transformation;
-#if SOFAGUIQT_HAVE_QWT
+#if SOFAGUIQT_HAVE_QT5_CHARTS
     //Energy widget: plot the kinetic & potential energy
     QEnergyStatWidget* energy;
     //Momentum widget: plot the linear & angular momentum

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QDisplayPropertyWidget.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QDisplayPropertyWidget.h
@@ -31,7 +31,7 @@
 #include <sofa/helper/fixed_array.h>
 #include <sofa/simulation/Node.h>
 #include <sofa/gui/qt/QTransformationWidget.h>
-#if SOFAGUIQT_HAVE_QWT
+#if SOFAGUIQT_HAVE_QT5_CHARTS
 #include <sofa/gui/qt/QEnergyStatWidget.h>
 #endif
 #include <sofa/gui/qt/WDoubleLineEdit.h>

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QEnergyStatWidget.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QEnergyStatWidget.cpp
@@ -38,7 +38,6 @@ QEnergyStatWidget::QEnergyStatWidget( QWidget* parent, simulation::Node* node )
     setCurve( 2, "Mechanical", Qt::blue );
 
     m_energyVisitor   = new sofa::simulation::MechanicalComputeEnergyVisitor(core::MechanicalParams::defaultInstance());
-    m_yMin = 0;
 }
 
 QEnergyStatWidget::~QEnergyStatWidget()
@@ -64,11 +63,14 @@ void QEnergyStatWidget::stepImpl()
     //Add Mechanical Energy
     m_curves[2]->append(time, kinectic + potential);
 
-    if (potential > m_yMax)
-    {
-        m_yMax = potential;
-        m_axisY->setRange(0, m_yMax*1.1);
-    }
+    // update maxY
+    updateYAxisBounds(kinectic + potential);
+    
+    // update minY
+    if (kinectic < potential)
+        updateYAxisBounds(kinectic);
+    else
+        updateYAxisBounds(potential);
 }
 
 

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QEnergyStatWidget.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QEnergyStatWidget.cpp
@@ -19,8 +19,9 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "QEnergyStatWidget.h"
-
+#include <sofa/gui/qt/QEnergyStatWidget.h>
+#include <QtCharts/QLineSeries>
+#include <QtCharts/QValueAxis>
 
 namespace sofa
 {

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QEnergyStatWidget.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QEnergyStatWidget.h
@@ -46,8 +46,8 @@ public:
     QEnergyStatWidget( QWidget* parent, simulation::Node* node );
 
     ~QEnergyStatWidget();
-
-    void step();
+            
+    void stepImpl() override;
 
 };
 

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QEnergyStatWidget.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QEnergyStatWidget.h
@@ -22,8 +22,7 @@
 #ifndef SOFA_GUI_QT_QENERGYSTATWIDGET_H
 #define SOFA_GUI_QT_QENERGYSTATWIDGET_H
 
-#include "QGraphStatWidget.h"
-
+#include <sofa/gui/qt/QGraphStatWidget.h>
 #include <sofa/simulation/MechanicalComputeEnergyVisitor.h>
 
 namespace sofa

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QGraphStatWidget.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QGraphStatWidget.cpp
@@ -50,6 +50,9 @@ QGraphStatWidget::QGraphStatWidget( QWidget* parent, simulation::Node* node, con
     layout->setObjectName(QString( "tabStats" ) + title);
 
     m_chart = new QChart();
+    QFont font;
+    font.setPixelSize(18);
+    m_chart->setTitleFont(font);
     m_chart->setTitle(title);
 
     m_axisX = new QValueAxis();       
@@ -87,7 +90,7 @@ void QGraphStatWidget::step()
     if (m_cptStep > m_bufferSize) // start swipping the Xaxis
     {
         qreal min = m_axisX->min() + m_node->getDt();
-        m_axisX->setRange(min, time);
+        m_axisX->setRange(min, time);        
 
         // flush series data not anymore display for memory storage
         if ((m_cptStep% m_bufferSize * 2) == 0)
@@ -96,9 +99,22 @@ void QGraphStatWidget::step()
         }
     }
 
+    if ((m_cptStep% m_bufferSize) == 0)
+    {
+        if (m_axisY->max() > m_yMax)
+            m_axisY->setMax(m_yMax*1.01);
+
+        if (m_axisY->min() < m_yMin)
+            m_axisY->setMin(m_yMin*0.99);
+
+        m_yMax = -10000;
+        m_yMin = 10000;
+    }
+
     m_lastTime = time;
     m_cptStep++;
 }
+
 
 void QGraphStatWidget::flushSeries()
 {
@@ -126,6 +142,30 @@ void QGraphStatWidget::setCurve( unsigned index, const QString& name, const QCol
 
     m_curves[index]->attachAxis(m_axisY);
     m_curves[index]->attachAxis(m_axisX);
+}
+
+
+void QGraphStatWidget::updateYAxisBounds(SReal value)
+{
+    if (value > m_axisY->max())
+    {
+        m_axisY->setMax(value*1.01);
+    }
+    if (value < m_axisY->min())
+    {
+        m_axisY->setMin(value*0.99);
+    }
+
+    // for record
+    if (value > m_yMax)
+    {
+        m_yMax = value;
+    }
+
+    if (value < m_yMin)
+    {
+        m_yMin = value;
+    }
 }
 
 

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QGraphStatWidget.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QGraphStatWidget.cpp
@@ -110,14 +110,6 @@ void QGraphStatWidget::flushSeries()
     }
 }
 
-void QGraphStatWidget::updateVisualization()
-{
-    //std::cout << "updateVisualization()" << std::endl;
-   /* for( unsigned i=0 ; i<_numberOfCurves ; ++i )
-        _curves[i]->setRawSamples( &_XHistory[0], &(_YHistory[i][0]), _XHistory.size() );
-    _graph->replot();*/
-}
-
 
 void QGraphStatWidget::setCurve( unsigned index, const QString& name, const QColor& color )
 {

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QGraphStatWidget.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QGraphStatWidget.cpp
@@ -22,7 +22,6 @@
 
 #include "QGraphStatWidget.h"
 
-
 namespace sofa
 {
 namespace gui
@@ -30,56 +29,108 @@ namespace gui
 namespace qt
 {
 
-QGraphStatWidget::QGraphStatWidget( QWidget* parent, simulation::Node* node, const QString& title, unsigned numberOfCurves )
+using namespace QtCharts;
+
+QGraphStatWidget::QGraphStatWidget( QWidget* parent, simulation::Node* node, const QString& title, unsigned numberOfCurves, int bufferSize)
     : QWidget( parent )
-    , _numberOfCurves( numberOfCurves )
-    , _node( node )
+    , m_node( node )
+    , m_bufferSize(bufferSize)
+    , m_yMin(10000)
+    , m_yMax(-10000)
+    , m_lastTime(0.0)
+    , m_cptStep(0)    
 {
-//        QVBoxLayout *layout = new QVBoxLayout( this, 0, 1, QString( "tabStats" ) + title );
     QVBoxLayout *layout = new QVBoxLayout(this);
     layout->setMargin(0);
     layout->setSpacing(1);
     layout->setObjectName(QString( "tabStats" ) + title);
 
-    _graph = new QwtPlot( QwtText( title ), this );
+    m_chart = new QChart();
+    m_chart->setTitle(title);
 
+    m_axisX = new QValueAxis();       
+    m_axisX->setRange(0, m_node->getDt()*m_bufferSize);
+    m_axisX->setTitleText("Time (ms)");
 
-    _graph->setAxisTitle( QwtPlot::xBottom, "Time (s)" );
-    _graph->setTitle( title );
-    _graph->insertLegend( new QwtLegend(), QwtPlot::BottomLegend );
+    m_axisY = new QValueAxis();
+    m_axisY->setTitleText("Value");
+    
+    m_chart->addAxis(m_axisX, Qt::AlignBottom);
+    m_chart->addAxis(m_axisY, Qt::AlignLeft);
+    m_chart->legend()->setAlignment(Qt::AlignBottom);
 
-    layout->addWidget( _graph );
+    m_chartView = new QChartView(m_chart, this);
+    layout->addWidget(m_chartView);
+    
+    m_curves.resize(numberOfCurves);
 
-    _curves.resize( _numberOfCurves );
-    _YHistory.resize( _numberOfCurves );
 }
 
 QGraphStatWidget::~QGraphStatWidget()
 {
-    delete _graph;
+    //delete _graph;
 }
 
 void QGraphStatWidget::step()
 {
-    //Add Time
-    _XHistory.push_back( _node->getTime() );
+    SReal time = m_node->getTime();
+    if (time <= m_lastTime)
+        return;
+
+    stepImpl();
+
+    if (m_cptStep > m_bufferSize) // start swipping
+    {
+        qreal min = m_axisX->min() + m_node->getDt();
+        m_axisX->setRange(min, time);
+
+        if ((m_cptStep% m_bufferSize * 2) == 0)
+        {
+            reduceSeries();
+        }
+    }
+
+    m_lastTime = time;
+    m_cptStep++;
+    
+}
+
+void QGraphStatWidget::reduceSeries()
+{
+    for (auto serie : m_curves)
+    {
+        serie->removePoints(0, m_bufferSize);
+    }
 }
 
 void QGraphStatWidget::updateVisualization()
 {
-    for( unsigned i=0 ; i<_numberOfCurves ; ++i )
+    //std::cout << "updateVisualization()" << std::endl;
+   /* for( unsigned i=0 ; i<_numberOfCurves ; ++i )
         _curves[i]->setRawSamples( &_XHistory[0], &(_YHistory[i][0]), _XHistory.size() );
-    _graph->replot();
+    _graph->replot();*/
 }
 
 
 void QGraphStatWidget::setCurve( unsigned index, const QString& name, const QColor& color )
 {
-    assert( index<_numberOfCurves );
-    _curves[index] = new QwtPlotCurve( name );
-    _curves[index]->attach( _graph );
-    _curves[index]->setPen( QPen( color ) );
+    if (index >= m_curves.size())
+    {
+        m_curves.resize(index+1);
+    }
+
+    m_curves[index] = new QLineSeries();
+    m_curves[index]->setName(name);
+    m_curves[index]->setPen(QPen(color));
+    
+    m_chart->addSeries(m_curves[index]);    
+
+    //for (unsigned int i = 0; i < m_bufferSize; i++)
+    m_curves[index]->attachAxis(m_axisY);
+    m_curves[index]->attachAxis(m_axisX);
+   // m_chart->setAxisY(m_Xaxis, m_curves[index]);
 }
+
 
 } // qt
 } // gui

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QGraphStatWidget.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QGraphStatWidget.h
@@ -31,10 +31,14 @@
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 
-#include <QtCharts/QChartView>
-#include <QtCharts/QChart>
-#include <QtCharts/QLineSeries>
-#include <QtCharts/QValueAxis>
+
+namespace QtCharts
+{
+    class QChartView;
+    class QChart;
+    class QLineSeries;
+    class QValueAxis;
+}
 
 namespace sofa
 {
@@ -65,23 +69,33 @@ protected:
     /// set the index-th curve (index must be < _numberOfCurves)
     void setCurve( unsigned index, const QString& name, const QColor& color );
 
-    void reduceSeries();
+    /// flush data from series not anymore displayed
+    void flushSeries();
 
+    /// pointer to the node monitored
     simulation::Node *m_node;
+
+    /// size of the buffers to stored
+    int m_bufferSize;
 
     /// Pointer to the chart Data
     QtCharts::QChart *m_chart;
-    QtCharts::QChartView* m_chartView;
+
+    /// vector of series to be ploted
     std::vector< QtCharts::QLineSeries *> m_curves;
+
+    /// x axis pointer
     QtCharts::QValueAxis* m_axisX;
+    /// y axis pointer
     QtCharts::QValueAxis* m_axisY;
-
-
+    
+    /// min y axis value stored
     SReal m_yMin;
-    SReal m_yMax;
-    int m_bufferSize;
-
+    /// max y axis value stored
+    SReal m_yMax;    
+    /// last timestep monitored
     SReal m_lastTime;
+    /// step counter monitored
     int m_cptStep;
 };
 

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QGraphStatWidget.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QGraphStatWidget.h
@@ -31,10 +31,10 @@
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 
-#include <qwt_legend.h>
-#include <qwt_plot.h>
-#include <qwt_plot_curve.h>
-
+#include <QtCharts/QChartView>
+#include <QtCharts/QChart>
+#include <QtCharts/QLineSeries>
+#include <QtCharts/QValueAxis>
 
 namespace sofa
 {
@@ -50,29 +50,39 @@ class QGraphStatWidget : public QWidget
     Q_OBJECT
 
 public:
-
-    QGraphStatWidget( QWidget* parent, simulation::Node* node, const QString& title, unsigned numberOfCurves );
+    QGraphStatWidget( QWidget* parent, simulation::Node* node, const QString& title, unsigned numberOfCurves, int bufferSize );
     virtual ~QGraphStatWidget();
+
+    /// Main method called to update the graph
+    virtual void step() final;
+
     /// the only function that should be overloaded
-    virtual void step();
+    virtual void stepImpl() = 0;
 
     void updateVisualization();
 
-
 protected:
-
     /// set the index-th curve (index must be < _numberOfCurves)
     void setCurve( unsigned index, const QString& name, const QColor& color );
-    unsigned _numberOfCurves;
 
-    simulation::Node *_node;
+    void reduceSeries();
 
-    std::vector< double > _XHistory; ///< X-axis values (by default take the node time)
-    std::vector< std::vector< double > > _YHistory; ///< Y-axis values, one for each curve (_numberOfCurves)
+    simulation::Node *m_node;
+
+    /// Pointer to the chart Data
+    QtCharts::QChart *m_chart;
+    QtCharts::QChartView* m_chartView;
+    std::vector< QtCharts::QLineSeries *> m_curves;
+    QtCharts::QValueAxis* m_axisX;
+    QtCharts::QValueAxis* m_axisY;
 
 
-    QwtPlot *_graph;
-    std::vector< QwtPlotCurve* > _curves; ///< resized to _numberOfCurves
+    SReal m_yMin;
+    SReal m_yMax;
+    int m_bufferSize;
+
+    SReal m_lastTime;
+    int m_cptStep;
 };
 
 

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QGraphStatWidget.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QGraphStatWidget.h
@@ -63,8 +63,6 @@ public:
     /// the only function that should be overloaded
     virtual void stepImpl() = 0;
 
-    void updateVisualization();
-
 protected:
     /// set the index-th curve (index must be < _numberOfCurves)
     void setCurve( unsigned index, const QString& name, const QColor& color );

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QGraphStatWidget.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QGraphStatWidget.h
@@ -67,6 +67,9 @@ protected:
     /// set the index-th curve (index must be < _numberOfCurves)
     void setCurve( unsigned index, const QString& name, const QColor& color );
 
+    /// Method to update Y axis scale
+    void updateYAxisBounds(SReal value);
+
     /// flush data from series not anymore displayed
     void flushSeries();
 
@@ -90,7 +93,7 @@ protected:
     /// min y axis value stored
     SReal m_yMin;
     /// max y axis value stored
-    SReal m_yMax;    
+    SReal m_yMax;
     /// last timestep monitored
     SReal m_lastTime;
     /// step counter monitored

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QMomentumStatWidget.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QMomentumStatWidget.cpp
@@ -29,7 +29,7 @@ namespace gui
 namespace qt
 {
 
-QMomentumStatWidget::QMomentumStatWidget( QWidget* parent, simulation::Node* node ) : QGraphStatWidget( parent, node, "Momenta", 6 )
+QMomentumStatWidget::QMomentumStatWidget( QWidget* parent, simulation::Node* node ) : QGraphStatWidget( parent, node, "Momenta", 6, 500 )
 {
     setCurve( 0, "Linear X", Qt::red );
     setCurve( 1, "Linear Y", Qt::green );
@@ -46,16 +46,23 @@ QMomentumStatWidget::~QMomentumStatWidget()
     delete m_momentumVisitor;
 }
 
-void QMomentumStatWidget::step()
+void QMomentumStatWidget::stepImpl()
 {
-    QGraphStatWidget::step(); // time history
+    if (m_curves.size() != 6) {
+        msg_warning("QMomentumStatWidget") << "Wrong number of curves: " << m_curves.size() << ", should be 3.";
+        return;
+    }
 
-    m_momentumVisitor->execute( _node->getContext() );
+    m_momentumVisitor->execute( m_node->getContext() );
 
     const defaulttype::Vector6& momenta = m_momentumVisitor->getMomentum();
 
-    // Add Momentum
-    for( unsigned i=0 ; i<6 ; ++i ) _YHistory[i].push_back( momenta[i] );
+    // Update series
+    SReal time = m_node->getTime();
+    for (unsigned i = 0; i < 6; ++i)
+    {
+        m_curves[i]->append(time, momenta[i]);
+    }
 }
 
 

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QMomentumStatWidget.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QMomentumStatWidget.cpp
@@ -61,10 +61,21 @@ void QMomentumStatWidget::stepImpl()
 
     // Update series
     SReal time = m_node->getTime();
+    SReal min = 100000;
+    SReal max = -100000;
     for (unsigned i = 0; i < 6; ++i)
     {
         m_curves[i]->append(time, momenta[i]);
+        if (momenta[i] < min)
+            min = momenta[i];
+        if (momenta[i] > max)
+            max = momenta[i];
     }
+
+    // update minY
+    updateYAxisBounds(min);
+    // update maxY
+    updateYAxisBounds(max);
 }
 
 

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QMomentumStatWidget.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QMomentumStatWidget.cpp
@@ -20,7 +20,9 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
-#include "QMomentumStatWidget.h"
+#include <sofa/gui/qt/QMomentumStatWidget.h>
+#include <QtCharts/QLineSeries>
+#include <QtCharts/QValueAxis>
 
 namespace sofa
 {

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QMomentumStatWidget.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QMomentumStatWidget.h
@@ -47,7 +47,7 @@ public:
 
     virtual ~QMomentumStatWidget();
 
-    virtual void step();
+    void stepImpl() override;
 };
 
 

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QMomentumStatWidget.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QMomentumStatWidget.h
@@ -22,8 +22,7 @@
 #ifndef SOFA_GUI_QT_QMOMENTUMSTATWIDGET_H
 #define SOFA_GUI_QT_QMOMENTUMSTATWIDGET_H
 
-#include "QGraphStatWidget.h"
-
+#include <sofa/gui/qt/QGraphStatWidget.h>
 #include <sofa/simulation/MechanicalGetMomentumVisitor.h>
 
 namespace sofa


### PR DESCRIPTION
- Restore QGraphStatWidget, QMomentumWidget and QEnergyWidget which have been removed by error in a PR #750 
- Replace use of Qwt by QtCharts

![graph_energy_new](https://user-images.githubusercontent.com/21199245/94669235-43197000-0311-11eb-89ed-4e763d29cf49.JPG)
![graph_momentum_new](https://user-images.githubusercontent.com/21199245/94669247-46acf700-0311-11eb-84e3-5e73650c3c58.JPG)






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [x] builds with SUCCESS for all platforms on the CI.
- [x] does not generate new warnings.
- [x] does not generate new unit test failures.
- [x] does not generate new scene test failures.
- [x] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
