### PR TITLE
[All] Remove un-needed includes (step2)

### DIFF
--- a/SofaKernel/modules/SofaBaseCollision/SofaBaseCollision_test/BroadPhase_test.h
+++ b/SofaKernel/modules/SofaBaseCollision/SofaBaseCollision_test/BroadPhase_test.h
@@ -140,7 +140,7 @@ void getMyBoxes(sofa::core::CollisionModel * cm,std::vector<MyBox> & my_boxes){
         my_boxes.push_back(MyBox(sofa::component::collision::Cube(cbm,i)));
 }
 
-sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr makeOBBModel(const std::vector<Vector3> & p,sofa::simulation::Node::SPtr &father,double default_extent);
+sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr makeOBBModel(const std::vector<Vector3> & p,sofa::core::sptr<sofa::simulation::Node> &father,double default_extent);
 
 void randMoving(sofa::core::CollisionModel* cm,const Vector3 & min_vect,const Vector3 & max_vect){
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types> * obbm = dynamic_cast<sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>*>(cm->getLast());
@@ -383,10 +383,10 @@ bool GENTest(sofa::core::CollisionModel * cm1,sofa::core::CollisionModel * cm2,D
 }
 
 
-sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr makeOBBModel(const std::vector<Vector3> & p,sofa::simulation::Node::SPtr &father,double default_extent){
+sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr makeOBBModel(const std::vector<Vector3> & p,sofa::core::sptr<sofa::simulation::Node> &father,double default_extent){
     int n = p.size();
     //creating node containing OBBModel
-    sofa::simulation::Node::SPtr obb = father->createChild("obb");
+    sofa::core::sptr<sofa::simulation::Node> obb = father->createChild("obb");
 
     //creating a mechanical object which will be attached to the OBBModel
     MechanicalObjectRigid3::SPtr obbDOF = New<MechanicalObjectRigid3>();
@@ -458,7 +458,7 @@ bool BroadPhaseTest<BroadPhase>::randTest(int seed,int nb1,int nb2,const Vector3
     for(int i = 0 ; i < nb2 ; ++i)
         secondCollision.push_back(randVect(min,max));
 
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbm1,obbm2;
     obbm1 = makeOBBModel(firstCollision,scn,getExtent());
     obbm2 = makeOBBModel(secondCollision,scn,getExtent());

--- a/SofaKernel/modules/SofaBaseCollision/SofaBaseCollision_test/DefaultPipeline_test.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/SofaBaseCollision_test/DefaultPipeline_test.cpp
@@ -37,6 +37,8 @@ using sofa::component::collision::DefaultPipeline ;
 #include <SofaSimulationGraph/DAGSimulation.h>
 using sofa::simulation::graph::DAGSimulation ;
 using sofa::simulation::Simulation ;
+
+#include <sofa/simulation/Node.h>
 using sofa::simulation::Node ;
 
 #include <SofaSimulationCommon/SceneLoaderXML.h>

--- a/SofaKernel/modules/SofaBaseCollision/SofaBaseCollision_test/OBB_test.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/SofaBaseCollision_test/OBB_test.cpp
@@ -53,7 +53,7 @@ struct TestCapOBB  : public ::testing::Test{
 
 struct TestSphereOBB : public ::testing::Test{
     sofa::component::collision::SphereCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr makeMyRSphere(const Vec3 & center,double radius,const Vec3 & v,
-                                                                       sofa::simulation::Node::SPtr & father);
+                                                                       sofa::core::sptr<sofa::simulation::Node> & father);
 
     bool vertex();
     bool edge();
@@ -80,9 +80,9 @@ typedef sofa::component::container::MechanicalObject<sofa::defaulttype::StdRigid
 typedef MechanicalObjectRigid3d MechanicalObjectRigid3;
 
 sofa::component::collision::SphereCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr TestSphereOBB::makeMyRSphere(const Vec3 & center,double radius,const Vec3 & v,
-                                                                   sofa::simulation::Node::SPtr & father){
+                                                                   sofa::core::sptr<sofa::simulation::Node> & father){
     //creating node containing SphereModel
-    sofa::simulation::Node::SPtr sph = father->createChild("cap");
+    sofa::core::sptr<sofa::simulation::Node> sph = father->createChild("cap");
 
     //creating a mechanical object which will be attached to the SphereModel
     MechanicalObjectRigid3::SPtr sphDOF = New<MechanicalObjectRigid3>();
@@ -136,7 +136,7 @@ bool TestOBB::faceVertex(){
     //first, we create the transformation to make the first OBB (which is axes aligned)
     double angles[3] = {0,0,0};
     int order[3] = {0,1,2};
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel0 = makeOBB(Vec3(0,0,-1),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);//this OBB is not moving and the contact face will be z = 0 since
                                         //the center of this OBB is (0,0,-1) and its extent is 1
 
@@ -207,7 +207,7 @@ bool TestOBB::vertexVertex(){
     angles[1] = acos(1/sqrt(3.0));
     angles[2] = M_PI_4;
 
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel0 = makeOBB(Vec3(0,0,-sqrt(3.0)),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel1 = makeOBB(Vec3(0,0,sqrt(3.0) + 0.01),angles,order,Vec3(0,0,-10),Vec3(1,1,1),scn);
 
@@ -246,7 +246,7 @@ bool TestOBB::vertexVertex(){
 bool TestOBB::faceFace(){
     double angles[3] = {0,0,0};
     int order[3] = {0,1,2};
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel0 = makeOBB(Vec3(0,0,-1),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel1 = makeOBB(Vec3(0,1,1.01),angles,order,Vec3(0,0,-10),Vec3(1,1,1),scn);
 
@@ -293,7 +293,7 @@ bool TestOBB::faceFace(){
 bool TestOBB::faceEdge(){
     double angles[3] = {0,0,0};
     int order[3] = {0,1,2};
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel0 = makeOBB(Vec3(0,0,-1),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);
 
     order[0] = 2;
@@ -354,7 +354,7 @@ bool TestOBB::edgeEdge(){
     angles[1] = M_PI_2;
     angles[2] = M_PI_4;
 
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel0 = makeOBB(Vec3(0,0,-sqrt(2.0)),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel1 = makeOBB(Vec3(0,0,sqrt(2.0) + 0.01),angles,order,Vec3(0,0,-10),Vec3(1,1,1),scn);
 
@@ -386,7 +386,7 @@ bool TestOBB::edgeVertex(){
     angles[1] = M_PI_2;
     angles[2] = M_PI_4;
 
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel0 = makeOBB(Vec3(0,0,-sqrt(2.0)),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);
 
     order[0] = 2;
@@ -418,7 +418,7 @@ bool TestCapOBB::faceVertex(){
     //first, we create the transformation to make the first OBB (which is axes aligned)
     double angles[3] = {0,0,0};
     int order[3] = {0,1,2};
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel =
             makeOBB(Vec3(0,0,-1),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);//this OBB is not moving and the contact face will be z = 0 since
                                         //the center of this OBB is (0,0,-1) and its extent is 1
@@ -458,7 +458,7 @@ bool TestCapOBB::faceEdge(){
     //first, we create the transformation to make the first OBB (which is axes aligned)
     double angles[3] = {0,0,0};
     int order[3] = {0,1,2};
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel =
             makeOBB(Vec3(0,0,-1),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);//this OBB is not moving and the contact face will be z = 0 since
                                         //the center of this OBB is (0,0,-1) and its extent is 1
@@ -506,7 +506,7 @@ bool TestCapOBB::edgeVertex(){
     angles[1] = M_PI_2;
     angles[2] = M_PI_4;
 
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel =
             makeOBB(Vec3(0,0,-sqrt(2.0)),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);//this OBB is not moving and the contact face will be z = 0 since
                                         //the center of this OBB is (0,0,-1) and its extent is 1
@@ -554,7 +554,7 @@ bool TestCapOBB::edgeEdge(){
     angles[1] = M_PI_2;
     angles[2] = M_PI_4;
 
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel =
             makeOBB(Vec3(0,0,-sqrt(2.0)),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);//this OBB is not moving and the contact face will be z = 0 since
                                         //the center of this OBB is (0,0,-1) and its extent is 1
@@ -603,7 +603,7 @@ bool TestCapOBB::vertexEdge(){
     angles[1] = acos(1/sqrt(3.0));
     angles[2] = M_PI_4;
 
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel = makeOBB(Vec3(0,0,-sqrt(3.0)),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);//this OBB is not moving and the contact face will be z = 0 since
                                         //the center of this OBB is (0,0,-1) and its extent is 1
 
@@ -651,7 +651,7 @@ bool TestCapOBB::vertexVertex(){
     angles[1] = acos(1/sqrt(3.0));
     angles[2] = M_PI_4;
 
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel = makeOBB(Vec3(0,0,-sqrt(3.0)),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);//this OBB is not moving and the contact face will be z = 0 since
                                         //the center of this OBB is (0,0,-1) and its extent is 1
 
@@ -697,7 +697,7 @@ bool TestSphereOBB::vertex(){
     angles[1] = acos(1/sqrt(3.0));
     angles[2] = M_PI_4;
 
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel = makeOBB(Vec3(0,0,-sqrt(3.0)),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);//this OBB is not moving and the contact face will be z = 0 since
                                         //the center of this OBB is (0,0,-1) and its extent is 1
 
@@ -747,7 +747,7 @@ bool TestSphereOBB::edge(){
     angles[1] = M_PI_2;
     angles[2] = M_PI_4;
 
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel = makeOBB(Vec3(0,0,-sqrt(2.0)),angles,order,Vec3(0,0,-10),Vec3(1,1,1),scn);//this OBB is not moving and the contact face will be z = 0 since
                                         //the center of this OBB is (0,0,-1) and its extent is 1
 
@@ -788,7 +788,7 @@ bool TestSphereOBB::face(){
     double angles[3] = {0,0,0};
     int order[3] = {0,1,2};
 
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel = makeOBB(Vec3(0,0,-1),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);//this OBB is not moving and the contact face will be z = 0 since
                                         //the center of this OBB is (0,0,-1) and its extent is 1
 
@@ -826,7 +826,7 @@ bool TestSphereOBB::face(){
 bool TestTriOBB::faceFace(){
     double angles[3] = {0,0,0};
     int order[3] = {0,1,2};
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel = makeOBB(Vec3(0,0,-1),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);
 
     int tri_flg = sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_POINTS | sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_EDGES;
@@ -856,7 +856,7 @@ bool TestTriOBB::faceFace(){
 bool TestTriOBB::faceVertex_out(){
     double angles[3] = {0,0,0};
     int order[3] = {0,1,2};
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel = makeOBB(Vec3(-1.01,0,1.01),angles,order,Vec3(0,0,-10),Vec3(1,1,1),scn);
 
     int tri_flg = sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_POINTS | sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_EDGES;
@@ -891,7 +891,7 @@ bool TestTriOBB::faceVertex_out(){
 bool TestTriOBB::faceVertex_out2(){
     double angles[3] = {0,0,0};
     int order[3] = {0,1,2};
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel = makeOBB(Vec3(-1.01,0,-1.01),angles,order,Vec3(0,0,10),Vec3(1,1,1),scn);
 
     int tri_flg = sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_POINTS | sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_EDGES;
@@ -926,7 +926,7 @@ bool TestTriOBB::faceVertex_out2(){
 bool TestTriOBB::faceEdge(){
     double angles[3] = {0,0,0};
     int order[3] = {0,1,2};
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel = makeOBB(Vec3(0,0,-1),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);
 
     int tri_flg = sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_POINTS | sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_EDGES;
@@ -956,7 +956,7 @@ bool TestTriOBB::faceEdge(){
 bool TestTriOBB::faceVertex(){
     double angles[3] = {0,0,0};
     int order[3] = {0,1,2};
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel = makeOBB(Vec3(0,0,-1),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);
 
     int tri_flg = sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_POINTS | sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_EDGES;
@@ -993,7 +993,7 @@ bool TestTriOBB::edgeFace(){
     angles[1] = M_PI_2;
     angles[2] = M_PI_4;
 
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel = makeOBB(Vec3(0,0,-sqrt(2.0)),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);
 
     int tri_flg = sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_POINTS | sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_EDGES;
@@ -1030,7 +1030,7 @@ bool TestTriOBB::edgeEdge(){
     angles[1] = M_PI_2;
     angles[2] = M_PI_4;
 
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel = makeOBB(Vec3(0,0,-sqrt(2.0)),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);
 
     int tri_flg = sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_POINTS | sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_EDGES;
@@ -1067,7 +1067,7 @@ bool TestTriOBB::edgeEdge2(){
     angles[1] = M_PI_2;
     angles[2] = M_PI_4;
 
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel = makeOBB(Vec3(0,0,-sqrt(2.0)),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);
 
     int tri_flg = sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_POINTS | sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_EDGES;
@@ -1103,7 +1103,7 @@ bool TestTriOBB::edgeVertex(){
     angles[1] = M_PI_2;
     angles[2] = M_PI_4;
 
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel = makeOBB(Vec3(0,0,-sqrt(2.0)),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);
 
     int tri_flg = sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_POINTS | sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_EDGES;
@@ -1140,7 +1140,7 @@ bool TestTriOBB::vertexFace(){
     angles[1] = acos(1/sqrt(3.0));
     angles[2] = M_PI_4;
 
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel = makeOBB(Vec3(0,0,-sqrt(3.0)),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);
 
     int tri_flg = sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_POINTS | sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_EDGES;
@@ -1177,7 +1177,7 @@ bool TestTriOBB::vertexEdge(){
     angles[1] = acos(1/sqrt(3.0));
     angles[2] = M_PI_4;
 
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel = makeOBB(Vec3(0,0,-sqrt(3.0)),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);
 
     int tri_flg = sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_POINTS | sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_EDGES;
@@ -1214,7 +1214,7 @@ bool TestTriOBB::vertexVertex(){
     angles[1] = acos(1/sqrt(3.0));
     angles[2] = M_PI_4;
 
-    sofa::simulation::Node::SPtr scn = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbmodel = makeOBB(Vec3(0,0,-sqrt(3.0)),angles,order,Vec3(0,0,0),Vec3(1,1,1),scn);
 
     int tri_flg = sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_POINTS | sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::FLAG_EDGES;

--- a/SofaKernel/modules/SofaBaseLinearSolver/BlocMatrixWriter.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/BlocMatrixWriter.h
@@ -43,7 +43,7 @@ class BlocMatrixWriter
 {
 public:
     typedef TBloc Bloc;
-    typedef matrix_bloc_traits<Bloc, defaulttype::BaseMatrix::Index> traits;
+    typedef matrix_bloc_traits<Bloc, defaulttype::BaseMatrixIndex> traits;
     typedef typename traits::Real Real;
     enum { NL = traits::NL };
     enum { NC = traits::NC };

--- a/SofaKernel/modules/SofaBaseLinearSolver/CompressedRowSparseMatrix.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/CompressedRowSparseMatrix.h
@@ -49,7 +49,7 @@ namespace linearsolver
 #define EMIT_EXTRA_MESSAGE false
 #endif
 
-template<typename TBloc, typename TVecBloc = helper::vector<TBloc>, typename TVecIndex = helper::vector<defaulttype::BaseMatrix::Index> >
+template<typename TBloc, typename TVecBloc = helper::vector<TBloc>, typename TVecIndex = helper::vector<defaulttype::BaseMatrixIndex> >
 class CompressedRowSparseMatrix : public defaulttype::BaseMatrix
 {
 public:

--- a/SofaKernel/modules/SofaBaseLinearSolver/FullMatrix.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/FullMatrix.h
@@ -47,7 +47,7 @@ class FullMatrix : public defaulttype::BaseMatrix
 {
 public:
     typedef T Real;
-    typedef typename defaulttype::BaseMatrix::Index Index;
+    typedef typename defaulttype::BaseMatrixIndex Index;
     typedef FullVector<Real> Line;
 
     class LineConstIterator

--- a/SofaKernel/modules/SofaBaseLinearSolver/FullVector.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/FullVector.h
@@ -44,7 +44,7 @@ class FullVector : public defaulttype::BaseVector
 {
 public:
     typedef T Real;
-    typedef defaulttype::BaseVector::Index Index;
+    typedef sofa::defaulttype::BaseVectorIndex Index;
     typedef T* Iterator;
     typedef const T* ConstIterator;
 

--- a/SofaKernel/modules/SofaBaseLinearSolver/MatrixLinearSolver.inl
+++ b/SofaKernel/modules/SofaBaseLinearSolver/MatrixLinearSolver.inl
@@ -23,7 +23,7 @@
 #define SOFA_COMPONENT_LINEARSOLVER_MATRIXLINEARSOLVER_INL
 
 #include <SofaBaseLinearSolver/MatrixLinearSolver.h>
-
+#include <sofa/simulation/Node.h>
 #include <sofa/helper/BackTrace.h>
 
 namespace sofa {

--- a/SofaKernel/modules/SofaBaseMechanics/AddMToMatrixFunctor.h
+++ b/SofaKernel/modules/SofaBaseMechanics/AddMToMatrixFunctor.h
@@ -25,6 +25,7 @@
 
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/defaulttype/DataTypeInfo.h>
+#include <sofa/defaulttype/BaseMatrix.h>
 #include <iostream>
 
 namespace sofa

--- a/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/DiagonalMass.inl
@@ -688,7 +688,7 @@ SReal DiagonalMass<DataTypes, MassType>::getElementMass(sofa::defaulttype::index
 template <class DataTypes, class MassType>
 void DiagonalMass<DataTypes, MassType>::getElementMass(sofa::defaulttype::index_type index, defaulttype::BaseMatrix *m) const
 {
-    static const defaulttype::BaseMatrix::Index dimension = defaulttype::BaseMatrix::Index(defaulttype::DataTypeInfo<Deriv>::size());
+    static const defaulttype::BaseMatrixIndex dimension = defaulttype::BaseMatrixIndex(defaulttype::DataTypeInfo<Deriv>::size());
     if (m->rowSize() != dimension || m->colSize() != dimension) m->resize(dimension,dimension);
 
     m->clear();

--- a/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/BarycentricMapping_test.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/BarycentricMapping_test.cpp
@@ -31,6 +31,8 @@ using sofa::component::topology::TriangleSetTopologyContainer;
 using sofa::component::topology::TetrahedronSetTopologyContainer;
 using sofa::core::topology::BaseMeshTopology;
 
+#include <sofa/simulation/Node.h>
+
 #include <gtest/gtest.h>
 using testing::Test;
 

--- a/SofaKernel/modules/SofaBaseMechanics/UniformMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/UniformMass.inl
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 
+#include <sofa/defaulttype/BaseMatrix.h>
 #include <SofaBaseMechanics/UniformMass.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/topology/Topology.h>
@@ -646,8 +647,7 @@ void UniformMass<DataTypes, MassType>::getElementMass (sofa::defaulttype::index_
                                                         BaseMatrix *m ) const
 {
     SOFA_UNUSED(index);
-
-    static const BaseMatrix::Index dimension = BaseMatrix::Index(DataTypeInfo<Deriv>::size());
+    static const sofa::defaulttype::BaseMatrixIndex dimension = DataTypeInfo<Deriv>::size() ;
     if ( m->rowSize() != dimension || m->colSize() != dimension )
         m->resize ( dimension, dimension );
 

--- a/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/fake_TopologyScene.h
+++ b/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/fake_TopologyScene.h
@@ -24,6 +24,7 @@
 
 #include <sofa/core/topology/Topology.h>
 #include <SofaSimulationGraph/SimpleApi.h>
+#include <sofa/simulation/Node.h>
 
 class fake_TopologyScene
 {
@@ -37,13 +38,13 @@ public:
     bool loadMeshFile();
 
     /// Method to get acces to node containing the meshLoader and the toplogy container.
-    sofa::simulation::Node::SPtr getNode() { return m_root; }
+    sofa::core::sptr<sofa::simulation::Node> getNode() { return m_root; }
 
 protected:
     /// Simulation object
     sofa::simulation::Simulation::SPtr m_simu;
     /// Node containing the topology
-    sofa::simulation::Node::SPtr m_root;
+    sofa::core::sptr<sofa::simulation::Node> m_root;
 
     /// Type of topology asked
     sofa::core::topology::TopologyObjectType m_topoType;

--- a/SofaKernel/modules/SofaBaseUtils/SofaBaseUtils_test/AddResourceRepository_test.cpp
+++ b/SofaKernel/modules/SofaBaseUtils/SofaBaseUtils_test/AddResourceRepository_test.cpp
@@ -36,7 +36,7 @@ const std::string& END_STR("</Node>");
 
 struct AddResourceRepository_test : public Sofa_test<>
 {
-    sofa::simulation::Node::SPtr m_root;
+    sofa::core::sptr<sofa::simulation::Node> m_root;
     std::string m_testRepoDir;
 
     void SetUp()

--- a/SofaKernel/modules/SofaBaseUtils/SofaBaseUtils_test/AddResourceRepository_test.cpp
+++ b/SofaKernel/modules/SofaBaseUtils/SofaBaseUtils_test/AddResourceRepository_test.cpp
@@ -27,6 +27,7 @@
 #include <SofaSimulationCommon/SceneLoaderXML.h>
 
 #include <SofaBaseUtils/AddResourceRepository.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaBaseVisual/VisualStyle.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/VisualStyle.cpp
@@ -24,6 +24,7 @@
 #include <sofa/core/objectmodel/Context.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/simulation/UpdateContextVisitor.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaBaseVisual/VisualStyle.h
+++ b/SofaKernel/modules/SofaBaseVisual/VisualStyle.h
@@ -25,7 +25,9 @@
 
 #include <sofa/core/visual/VisualModel.h>
 #include <sofa/core/visual/DisplayFlags.h>
-#include <sofa/simulation/Node.h>
+
+#include <sofa/core/sptr.h>
+namespace sofa::simulation { class Node; }
 
 namespace sofa
 {
@@ -78,7 +80,7 @@ protected:
     DisplayFlags backupFlags;
 };
 
-SOFA_BASE_VISUAL_API helper::WriteAccessor<sofa::core::visual::DisplayFlags> addVisualStyle( simulation::Node::SPtr node );
+SOFA_BASE_VISUAL_API helper::WriteAccessor<sofa::core::visual::DisplayFlags> addVisualStyle( sofa::core::sptr<sofa::simulation::Node> node );
 
 
 } // visual

--- a/SofaKernel/modules/SofaCore/SofaCore_simutest/objectmodel/BaseContext_test.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_simutest/objectmodel/BaseContext_test.cpp
@@ -26,6 +26,8 @@ using sofa::core::objectmodel::BaseContext ;
 using sofa::helper::testing::BaseSimulationTest ;
 using sofa::simulation::Node ;
 
+#include <sofa/simulation/Node.h>
+
 #include <SofaBaseUtils/InfoComponent.h>
 using sofa::component::InfoComponent;
 

--- a/SofaKernel/modules/SofaCore/SofaCore_simutest/objectmodel/Base_test.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_simutest/objectmodel/Base_test.cpp
@@ -30,8 +30,13 @@ using sofa::simulation::Node ;
 #include <sofa/core/objectmodel/BaseObject.h>
 using sofa::core::objectmodel::BaseObject;
 
+#include <sofa/defaulttype/RigidTypes.h>
 using sofa::defaulttype::Rigid3Types;
+
+#include <sofa/defaulttype/Vec3Types.h>
 using sofa::defaulttype::Vec3Types;
+
+#include <sofa/simulation/Node.h>
 
 namespace customns
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseMechanicalState.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseMechanicalState.h
@@ -25,11 +25,10 @@
 
 #include <sofa/core/BaseState.h>
 #include <sofa/core/MultiVecId.h>
-#include <sofa/defaulttype/BaseMatrix.h>
+#include <sofa/defaulttype/DefaultTypeFwd.h>
 #include <sofa/defaulttype/Vec.h>
 #include <sofa/defaulttype/Quat.h>
 #include <sofa/helper/StateMask.h>
-
 
 
 namespace sofa

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ForceField.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ForceField.h
@@ -24,6 +24,7 @@
 
 #include <sofa/core/config.h>
 #include <sofa/core/behavior/BaseForceField.h>
+#include <sofa/defaulttype/BaseMatrix.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/LinearSolver.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/LinearSolver.h
@@ -25,7 +25,7 @@
 #include <sofa/core/objectmodel/BaseObject.h>
 
 #include <sofa/core/MechanicalParams.h>
-#include <sofa/defaulttype/BaseMatrix.h>
+#include <sofa/defaulttype/DefaultTypeFwd.h>
 
 #include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/core/ConstraintParams.h>
@@ -108,7 +108,7 @@ public:
     virtual void init_partial_solve() { msg_warning() << "partial_solve is not implemented yet."; }
 
     ///
-    virtual void partial_solve(std::list<defaulttype::BaseMatrix::Index>& /*I_last_Disp*/, std::list<defaulttype::BaseMatrix::Index>& /*I_last_Dforce*/, bool /*NewIn*/) { msg_warning() << "partial_solve is not implemented yet"; }
+    virtual void partial_solve(std::list<defaulttype::BaseMatrixIndex>& /*I_last_Disp*/, std::list<defaulttype::BaseMatrixIndex>& /*I_last_Dforce*/, bool /*NewIn*/) { msg_warning() << "partial_solve is not implemented yet"; }
 
     /// Invert the system, this method is optional because it's called when solveSystem() is called for the first time
     virtual void invertSystem() {}

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/Mass.inl
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/Mass.inl
@@ -24,6 +24,7 @@
 
 #include <sofa/core/behavior/Mass.h>
 #include <sofa/core/behavior/BaseConstraint.h>
+#include <sofa/defaulttype/BaseMatrix.h>
 #include <sofa/defaulttype/DataTypeInfo.h>
 #include <fstream>
 
@@ -249,7 +250,7 @@ SReal Mass<DataTypes>::getElementMass(sofa::defaulttype::index_type ) const
 template <class DataTypes>
 void Mass<DataTypes>::getElementMass(sofa::defaulttype::index_type, defaulttype::BaseMatrix *m) const
 {
-    static const defaulttype::BaseMatrix::Index dimension = (defaulttype::BaseMatrix::Index) defaulttype::DataTypeInfo<Coord>::size();
+    static const defaulttype::BaseMatrixIndex dimension = (defaulttype::BaseMatrixIndex) defaulttype::DataTypeInfo<Coord>::size();
     if (m->rowSize() != dimension || m->colSize() != dimension) m->resize(dimension,dimension);
 
     m->clear();

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/MultiMatrixAccessor.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/MultiMatrixAccessor.h
@@ -41,7 +41,7 @@ namespace behavior
 class SOFA_CORE_API MultiMatrixAccessor
 {
 public:
-    using Index = defaulttype::BaseMatrix::Index;
+    using Index = defaulttype::BaseMatrixIndex;
 
     virtual ~MultiMatrixAccessor();
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -22,7 +22,6 @@
 #ifndef SOFA_CORE_OBJECTMODEL_BASE_H
 #define SOFA_CORE_OBJECTMODEL_BASE_H
 
-#include <sofa/helper/StringUtils.h>
 #include <sofa/defaulttype/BoundingBox.h>
 #include <sofa/core/objectmodel/Data.h>
 #include <sofa/core/DataTracker.h>

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/ScriptEvent.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/ScriptEvent.cpp
@@ -33,7 +33,7 @@ namespace objectmodel
 
 SOFA_EVENT_CPP( ScriptEvent )
 
-ScriptEvent::ScriptEvent(sofa::simulation::Node::SPtr sender, const char* eventName)
+ScriptEvent::ScriptEvent(sofa::core::sptr<sofa::simulation::Node> sender, const char* eventName)
     : sofa::core::objectmodel::Event()
     , m_sender(sender)
     , m_eventName(eventName)

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/ScriptEvent.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/ScriptEvent.h
@@ -36,6 +36,8 @@ namespace core
 namespace objectmodel
 {
 
+using sofa::simulation::Node;
+
 /**
 * @brief Generic Event class to send a message through the simulation graph.
 */
@@ -48,7 +50,7 @@ public:
     /**
      * @brief Constructor.
      */
-    ScriptEvent(sofa::simulation::Node::SPtr sender, const char* eventName);
+    ScriptEvent(sofa::core::sptr<sofa::simulation::Node> sender, const char* eventName);
 
     /**
      * @brief Destructor.
@@ -58,7 +60,7 @@ public:
     /**
      * @brief Get the sender name
      */
-    const sofa::simulation::Node::SPtr getSender(void) const {return m_sender;}
+    const sofa::core::sptr<sofa::simulation::Node> getSender(void) const {return m_sender;}
 
     /**
      * @brief Get the event name
@@ -68,7 +70,7 @@ public:
     inline static const char* GetClassName() { return "ScriptEvent"; }
 private:
 
-    sofa::simulation::Node::SPtr m_sender;
+    sofa::core::sptr<sofa::simulation::Node> m_sender;
     std::string m_eventName;
 
 };

--- a/SofaKernel/modules/SofaDefaultType/CMakeLists.txt
+++ b/SofaKernel/modules/SofaDefaultType/CMakeLists.txt
@@ -8,6 +8,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/BaseVector.h
     ${SRC_ROOT}/BoundingBox.h
     ${SRC_ROOT}/DataTypeInfo.h
+    ${SRC_ROOT}/DefaultTypeFwd.h
     ${SRC_ROOT}/Frame.h
     ${SRC_ROOT}/MapMapSparseMatrix.h
     ${SRC_ROOT}/MapMapSparseMatrixEigenUtils.h

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BaseMatrix.cpp
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BaseMatrix.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/defaulttype/BaseMatrix.h>
+#include <sofa/defaulttype/DefaultTypeFwd.h>
 #include <sofa/defaulttype/Mat.h>
 #include <sofa/defaulttype/Vec.h>
 #include <sofa/helper/logging/Messaging.h>
@@ -202,7 +203,7 @@ template<bool add, bool transpose>
 class BaseMatrixLinearOpMV
 {
 public:
-    typedef typename BaseMatrix::Index Index;
+    typedef BaseMatrixIndex Index;
     template <class M, class V1, class V2>
     static inline void opFull(const M* mat, V1& result, const V2& v)
     {
@@ -575,7 +576,7 @@ template< bool transpose>
 class BaseMatrixLinearOpAM
 {
 public:
-    typedef typename BaseMatrix::Index Index;
+    typedef BaseMatrixIndex Index;
     template <class M1, class M2 >
     static inline void opFull(const M1 * m1, M2 * m2, double fact)
     {

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BaseMatrix.cpp
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BaseMatrix.cpp
@@ -19,8 +19,9 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <sofa/defaulttype/BaseMatrix.h>
 #include <sofa/defaulttype/DefaultTypeFwd.h>
+#include <sofa/defaulttype/BaseMatrix.h>
+#include <sofa/defaulttype/BaseVector.h>
 #include <sofa/defaulttype/Mat.h>
 #include <sofa/defaulttype/Vec.h>
 #include <sofa/helper/logging/Messaging.h>
@@ -38,19 +39,19 @@ BaseMatrix::~BaseMatrix()
 
 void BaseMatrix::compress() {}
 
-static inline void opVresize(BaseVector& vec, BaseVector::Index n) { vec.resize(n); }
-template<class Real2> static inline void opVresize(Real2* vec, BaseVector::Index n) { for (const Real2* end=vec+n; vec != end; ++vec) *vec = (Real2)0; }
-static inline SReal opVget(const BaseVector& vec, BaseVector::Index i) { return (SReal)vec.element(i); }
-template<class Real2> static inline SReal opVget(const Real2* vec, BaseVector::Index i) { return (SReal)vec[i]; }
+static inline void opVresize(BaseVector& vec, sofa::defaulttype::BaseVectorIndex n) { vec.resize(n); }
+template<class Real2> static inline void opVresize(Real2* vec, sofa::defaulttype::BaseVectorIndex n) { for (const Real2* end=vec+n; vec != end; ++vec) *vec = (Real2)0; }
+static inline SReal opVget(const BaseVector& vec, sofa::defaulttype::BaseVectorIndex i) { return (SReal)vec.element(i); }
+template<class Real2> static inline SReal opVget(const Real2* vec, sofa::defaulttype::BaseVectorIndex i) { return (SReal)vec[i]; }
 
 //this line was remove to supress a warning.
-//static inline void opVset(BaseVector& vec, BaseVector::Index i, SReal v) { vec.set(i, v); }
+//static inline void opVset(BaseVector& vec, sofa::defaulttype::BaseVectorIndex i, SReal v) { vec.set(i, v); }
 
-template<class Real2> static inline void opVset(Real2* vec, BaseVector::Index i, SReal v) { vec[i] = (Real2)v; }
-static inline void opVadd(BaseVector& vec, BaseVector::Index i, double v) { vec.add(i, (SReal)v); }
-static inline void opVadd(BaseVector& vec, BaseVector::Index i, float v) { vec.add(i, (SReal)v); }
-template<class Real2> static inline void opVadd(Real2* vec, BaseVector::Index i, double v) { vec[i] += (Real2)v; }
-template<class Real2> static inline void opVadd(Real2* vec, BaseVector::Index i, float v) { vec[i] += (Real2)v; }
+template<class Real2> static inline void opVset(Real2* vec, sofa::defaulttype::BaseVectorIndex i, SReal v) { vec[i] = (Real2)v; }
+static inline void opVadd(BaseVector& vec, sofa::defaulttype::BaseVectorIndex i, double v) { vec.add(i, (SReal)v); }
+static inline void opVadd(BaseVector& vec, sofa::defaulttype::BaseVectorIndex i, float v) { vec.add(i, (SReal)v); }
+template<class Real2> static inline void opVadd(Real2* vec, sofa::defaulttype::BaseVectorIndex i, double v) { vec[i] += (Real2)v; }
+template<class Real2> static inline void opVadd(Real2* vec, sofa::defaulttype::BaseVectorIndex i, float v) { vec[i] += (Real2)v; }
 
 template <class Real, int NL, int NC, bool add, bool transpose, class M, class V1, class V2>
 struct BaseMatrixLinearOpMV_BlockDiagonal

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BaseMatrix.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BaseMatrix.h
@@ -23,6 +23,7 @@
 #define SOFA_DEFAULTTYPE_BASEMATRIX_H
 
 #include <sofa/defaulttype/config.h>
+#include <sofa/defaulttype/DefaultTypeFwd.h>
 #include <sofa/defaulttype/BaseVector.h>
 #include <sofa/defaulttype/Mat.h>
 #include <sofa/helper/logging/Messaging.h>
@@ -32,6 +33,7 @@
 #include <vector>
 #include <cassert>
 #include <climits>
+
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BaseMatrix.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BaseMatrix.h
@@ -24,7 +24,6 @@
 
 #include <sofa/defaulttype/config.h>
 #include <sofa/defaulttype/DefaultTypeFwd.h>
-#include <sofa/defaulttype/BaseVector.h>
 #include <sofa/defaulttype/Mat.h>
 #include <sofa/helper/logging/Messaging.h>
 #include <utility> // for std::pair
@@ -49,7 +48,7 @@ namespace defaulttype
 class SOFA_DEFAULTTYPE_API BaseMatrix
 {
 public:
-    typedef BaseVector::Index Index;
+    typedef sofa::defaulttype::BaseVectorIndex Index;
 
     BaseMatrix();
     virtual ~BaseMatrix();

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BaseVector.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BaseVector.h
@@ -24,6 +24,7 @@
 
 #include <sofa/defaulttype/config.h>
 #include <iostream>
+#include <sofa/defaulttype/DefaultTypeFwd.h>
 #include <sofa/defaulttype/TopologyTypes.h>
 
 namespace sofa

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/DefaultTypeFwd.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/DefaultTypeFwd.h
@@ -19,54 +19,14 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_CORE_BEHAVIOR_SingleMatrixAccessor_H
-#define SOFA_CORE_BEHAVIOR_SingleMatrixAccessor_H
-#include "config.h"
+#pragma once
 
-#include <sofa/core/behavior/MultiMatrixAccessor.h>
-#include <sofa/defaulttype/BaseMatrix.h>
-
-namespace sofa
+#include <sofa/defaulttype/config.h>
+namespace sofa::defaulttype
 {
+    class BaseMatrix;
+    class BaseVector;
 
-namespace component
-{
-
-namespace linearsolver
-{
-
-/** Special case to access a single square matrix.
-*/
-class SOFA_BASE_LINEAR_SOLVER_API SingleMatrixAccessor : public core::behavior::MultiMatrixAccessor
-{
-public:
-    typedef defaulttype::BaseMatrix BaseMatrix;
-
-    SingleMatrixAccessor( BaseMatrix* m=nullptr ) { setMatrix(m); }
-    ~SingleMatrixAccessor() override;
-
-    void setMatrix( BaseMatrix* m );
-    BaseMatrix* getMatrix() { return matrix; }
-    const BaseMatrix* getMatrix() const { return matrix; }
-
-
-    sofa::defaulttype::BaseMatrixIndex getGlobalDimension() const override { return matrix->rowSize(); }
-    int getGlobalOffset(const core::behavior::BaseMechanicalState*) const override { return 0; }
-    MatrixRef getMatrix(const core::behavior::BaseMechanicalState*) const override;
-
-
-    InteractionMatrixRef getMatrix(const core::behavior::BaseMechanicalState* mstate1, const core::behavior::BaseMechanicalState* mstate2) const override;
-
-protected:
-    BaseMatrix* matrix;   ///< The single matrix
-    MatrixRef matRef; ///< The accessor to the single matrix
-
-};
-
-} // namespace behavior
-
-} // namespace core
-
-} // namespace sofa
-
-#endif
+    typedef int BaseMatrixIndex;
+    typedef int BaseVectorIndex;
+}

--- a/SofaKernel/modules/SofaDeformable/PolynomialRestShapeSpringsForceField.inl
+++ b/SofaKernel/modules/SofaDeformable/PolynomialRestShapeSpringsForceField.inl
@@ -28,7 +28,7 @@
 #include <SofaDeformable/PolynomialRestShapeSpringsForceField.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/AdvancedTimer.h>
-
+#include <sofa/defaulttype/BaseMatrix.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaDeformable/PolynomialSpringsForceField.inl
+++ b/SofaKernel/modules/SofaDeformable/PolynomialSpringsForceField.inl
@@ -28,7 +28,7 @@
 #include <sofa/core/behavior/ForceField.inl>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/AdvancedTimer.h>
-
+#include <sofa/defaulttype/BaseMatrix.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaDeformable/StiffSpringForceField.inl
+++ b/SofaKernel/modules/SofaDeformable/StiffSpringForceField.inl
@@ -24,7 +24,7 @@
 
 #include <SofaDeformable/StiffSpringForceField.h>
 #include <sofa/helper/AdvancedTimer.h>
-
+#include <sofa/defaulttype/BaseMatrix.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <SofaBaseTopology/TopologySubsetData.inl>
 namespace sofa

--- a/SofaKernel/modules/SofaEigen2Solver/EigenSparseMatrix.h
+++ b/SofaKernel/modules/SofaEigen2Solver/EigenSparseMatrix.h
@@ -72,7 +72,7 @@ public:
     enum { Nin=InDataTypes::deriv_total_size, Nout=OutDataTypes::deriv_total_size };
     typedef defaulttype::Mat<Nout,Nin, OutReal> Block;  ///< block relating an OutDeriv to an InDeriv. This is used for input only, not for internal storage.
 
-    using Index = defaulttype::BaseMatrix::Index;
+    using Index = defaulttype::BaseMatrixIndex;
 protected:
     typedef std::map<Index,Block> BlockRowMap;        ///< Map which represents one block-view row of the matrix. The index represents the block-view column index of an entry.
     typedef std::map<Index,BlockRowMap> BlockMatMap;  ///< Map which represents a block-view matrix. The index represents the block-view index of a block-view row.

--- a/SofaKernel/modules/SofaEngine/SofaEngine_test/BoxROI_test.cpp
+++ b/SofaKernel/modules/SofaEngine/SofaEngine_test/BoxROI_test.cpp
@@ -44,6 +44,8 @@ using sofa::component::initBaseMechanics;
 #include <SofaSimulationGraph/DAGSimulation.h>
 using sofa::simulation::Simulation;
 using sofa::simulation::graph::DAGSimulation;
+
+#include <sofa/simulation/Node.h>
 using sofa::simulation::Node;
 using sofa::simulation::setSimulation;
 using sofa::core::objectmodel::BaseObject;

--- a/SofaKernel/modules/SofaHelper/SofaHelper_simutest/AdvancedTimer_test.cpp
+++ b/SofaKernel/modules/SofaHelper/SofaHelper_simutest/AdvancedTimer_test.cpp
@@ -22,7 +22,9 @@
 #include <sofa/helper/AdvancedTimer.h>
 
 #include <SofaSimulationCommon/SceneLoaderXML.h>
-using sofa::simulation::SceneLoaderXML ;
+using sofa::simulation::SceneLoaderXML;
+
+#include <sofa/simulation/Node.h>
 using sofa::simulation::Node ;
 using sofa::core::ExecParams;
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.cpp
@@ -27,6 +27,8 @@
 #include <sofa/helper/map.h>
 #include "../../extlibs/json/json.h"
 
+//TODO(dmarchal 2020-09-30): it make no sense to have a dependency from sofa::simulation into sofa::helper. Please refactor to cut that.
+#include <sofa/simulation/Node.h>
 
 #include <cmath>
 #include <cstdlib>

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.h
@@ -21,13 +21,18 @@
 ******************************************************************************/
 #ifndef SOFA_HELPER_ADVANCEDTIMER_H
 #define SOFA_HELPER_ADVANCEDTIMER_H
+#include <map>
 #include <sofa/helper/config.h>
-#include <sofa/simulation/Simulation.h>
+#include <sofa/helper/vector.h>
+#include <sofa/helper/system/thread/CTime.h>
 #include <sofa/helper/system/thread/thread_specific_ptr.h>
 
 #include <iostream>
 #include <string>
 #include <vector>
+
+/// Forward declaration
+namespace sofa::simulation { class Node; }
 
 
 namespace sofa

--- a/SofaKernel/modules/SofaMeshCollision/PointModel.inl
+++ b/SofaKernel/modules/SofaMeshCollision/PointModel.inl
@@ -39,6 +39,7 @@
 #include <sofa/core/topology/BaseMeshTopology.h>
 
 #include <sofa/simulation/Simulation.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaMeshCollision/SofaMeshCollision_test/BaryMapper_test.cpp
+++ b/SofaKernel/modules/SofaMeshCollision/SofaMeshCollision_test/BaryMapper_test.cpp
@@ -30,7 +30,7 @@ using defaulttype::Vector3;
 using core::objectmodel::New;
 
 typedef sofa::component::topology::MeshTopology MeshTopology;
-typedef sofa::simulation::Node::SPtr NodePtr;
+typedef sofa::core::sptr<sofa::simulation::Node> NodePtr;
 typedef sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types> TriangleModel;
 typedef sofa::defaulttype::Vec3Types DataTypes;
 typedef DataTypes::VecCoord VecCoord;
@@ -91,7 +91,7 @@ MeshTopology* BaryMapperTest::initMesh(NodePtr &father){
 
 bool BaryMapperTest::test_inside(SReal alpha,SReal beta){
     initTriPts();
-    sofa::simulation::Node::SPtr father = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> father = New<sofa::simulation::tree::GNode>();
     MeshTopology * topo = initMesh(father);
     //makeTri()
     component::mapping::BarycentricMapperMeshTopology<DataTypes, DataTypes>::SPtr mapper = sofa::core::objectmodel::New<component::mapping::BarycentricMapperMeshTopology<DataTypes, DataTypes> >(topo,(component::topology::PointSetTopologyContainer*)0x0/*model->getMeshTopology(), (topology::PointSetTopologyContainer*)nullptr, &model->getMechanicalState()->forceMask, &mstate->forceMask*/);
@@ -116,7 +116,7 @@ bool BaryMapperTest::test_inside(SReal alpha,SReal beta){
 
 bool BaryMapperTest::test_outside(int index){
     initTriPts();
-    sofa::simulation::Node::SPtr father = New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> father = New<sofa::simulation::tree::GNode>();
     MeshTopology * topo = initMesh(father);
     //makeTri()
     component::mapping::BarycentricMapperMeshTopology<DataTypes, DataTypes>::SPtr mapper = sofa::core::objectmodel::New<component::mapping::BarycentricMapperMeshTopology<DataTypes, DataTypes> >(topo,(component::topology::PointSetTopologyContainer*)0x0/*model->getMeshTopology(), (topology::PointSetTopologyContainer*)nullptr, &model->getMechanicalState()->forceMask, &mstate->forceMask*/);

--- a/SofaKernel/modules/SofaSimpleFem/TetrahedronDiffusionFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/TetrahedronDiffusionFEMForceField.inl
@@ -28,6 +28,7 @@
 #include <iostream> //for debugging
 #include <sofa/core/visual/VisualParams.h>
 
+#include <sofa/defaulttype/BaseMatrix.h>
 #include <SofaBaseTopology/TopologyData.inl>
 #include <SofaBaseTopology/TopologySubsetData.inl>
 

--- a/SofaKernel/modules/SofaSimulationCommon/SceneLoaderPHP.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/SceneLoaderPHP.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #include "SceneLoaderPHP.h"
 
+#include <sofa/simulation/Node.h>
 #include <SofaSimulationCommon/SceneLoaderXML.h>
 #include <sofa/helper/system/PipeProcess.h>
 #include <SofaSimulationCommon/xml/NodeElement.h>
@@ -60,10 +61,10 @@ void SceneLoaderPHP::getExtensionList(ExtensionList* list)
 }
 
 
-sofa::simulation::Node::SPtr SceneLoaderPHP::doLoad(const std::string& filename, const std::vector<std::string>& sceneArgs)
+sofa::core::sptr<sofa::simulation::Node> SceneLoaderPHP::doLoad(const std::string& filename, const std::vector<std::string>& sceneArgs)
 {
     SOFA_UNUSED(sceneArgs);
-    sofa::simulation::Node::SPtr root;
+    sofa::core::sptr<sofa::simulation::Node> root;
 
     if (!canLoadFileName(filename.c_str()))
         return 0;

--- a/SofaKernel/modules/SofaSimulationCommon/SceneLoaderPHP.h
+++ b/SofaKernel/modules/SofaSimulationCommon/SceneLoaderPHP.h
@@ -38,7 +38,7 @@ public:
     bool canLoadFileExtension(const char *extension) override;
 
     /// load the file
-    virtual sofa::simulation::Node::SPtr doLoad(const std::string& filename, const std::vector<std::string>& sceneArgs) override;
+    virtual sofa::core::sptr<sofa::simulation::Node> doLoad(const std::string& filename, const std::vector<std::string>& sceneArgs) override;
 
     /// get the file type description
     virtual std::string getFileTypeDesc() override;

--- a/SofaKernel/modules/SofaSimulationCommon/SceneLoaderXML.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/SceneLoaderXML.cpp
@@ -66,10 +66,10 @@ void SceneLoaderXML::getExtensionList(ExtensionList* list)
     list->push_back("scn");
 }
 
-sofa::simulation::Node::SPtr SceneLoaderXML::doLoad(const std::string& filename, const std::vector<std::string>& sceneArgs)
+sofa::core::sptr<sofa::simulation::Node> SceneLoaderXML::doLoad(const std::string& filename, const std::vector<std::string>& sceneArgs)
 {
     SOFA_UNUSED(sceneArgs);
-    sofa::simulation::Node::SPtr root;
+    sofa::core::sptr<sofa::simulation::Node> root;
 
     if (!canLoadFileName(filename.c_str()))
         return 0;

--- a/SofaKernel/modules/SofaSimulationCommon/SceneLoaderXML.h
+++ b/SofaKernel/modules/SofaSimulationCommon/SceneLoaderXML.h
@@ -42,16 +42,16 @@ public:
     bool canWriteFileExtension(const char *extension) override;
 
     /// load the file
-    virtual sofa::simulation::Node::SPtr doLoad(const std::string& filename, const std::vector<std::string>& sceneArgs) override;
+    virtual sofa::core::sptr<sofa::simulation::Node> doLoad(const std::string& filename, const std::vector<std::string>& sceneArgs) override;
 
     /// write the file
     void write(sofa::simulation::Node* node, const char *filename) override;
 
     /// generic function to process xml tree (after loading the xml structure)
-    static Node::SPtr processXML(xml::BaseElement* xml, const char *filename);
+    static sofa::core::sptr<sofa::simulation::Node> processXML(xml::BaseElement* xml, const char *filename);
 
     /// load a scene from memory (typically : an xml into a string)
-    static Node::SPtr loadFromMemory ( const char *filename, const char *data, unsigned int size );
+    static sofa::core::sptr<sofa::simulation::Node> loadFromMemory ( const char *filename, const char *data, unsigned int size );
 
     /// get the file type description
     virtual std::string getFileTypeDesc() override;

--- a/SofaKernel/modules/SofaSimulationCommon/TransformationVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/TransformationVisitor.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <SofaSimulationCommon/TransformationVisitor.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaSimulationCommon/xml/BaseMultiMappingElement.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/xml/BaseMultiMappingElement.cpp
@@ -26,6 +26,7 @@
 #include <sofa/core/objectmodel/BaseNode.h>
 #include <SofaSimulationCommon/xml/NodeElement.h>
 #include <SofaSimulationCommon/xml/Element.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DeactivatedNodeVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DeactivatedNodeVisitor.cpp
@@ -20,7 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/simulation/DeactivatedNodeVisitor.h>
-
+#include <sofa/simulation/Node.h>
 namespace sofa
 {
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/InitVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/InitVisitor.cpp
@@ -25,6 +25,7 @@
 #include <sofa/core/BaseMapping.h>
 #include <sofa/core/visual/VisualModel.h>
 #include <sofa/defaulttype/BoundingBox.h>
+#include <sofa/simulation/Node.h>
 
 //#include "MechanicalIntegration.h"
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalOperations.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalOperations.cpp
@@ -478,10 +478,10 @@ void MechanicalOperations::m_print( std::ostream& out )
     auto ny = m->rowSize();
     auto nx = m->colSize();
     out << "[";
-    for (defaulttype::BaseMatrix::Index y=0; y<ny; ++y)
+    for (defaulttype::BaseMatrixIndex y=0; y<ny; ++y)
     {
         out << "[";
-        for (defaulttype::BaseMatrix::Index x=0; x<nx; x++)
+        for (defaulttype::BaseMatrixIndex x=0; x<nx; x++)
             out << ' ' << m->element(x,y);
         out << "]";
     }

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalOperations.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalOperations.cpp
@@ -28,6 +28,7 @@
 #include <sofa/core/ConstraintParams.h>
 #include <sofa/core/behavior/LinearSolver.h>
 #include <sofa/defaulttype/BaseMatrix.h>
+#include <sofa/core/behavior/ConstraintSolver.h>
 
 using namespace sofa::core;
 namespace sofa

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.cpp
@@ -29,6 +29,7 @@
 #include <sofa/simulation/MechanicalVisitor.h>
 #include <sofa/simulation/VisualVisitor.h>
 #include <sofa/simulation/UpdateMappingVisitor.h>
+#include <sofa/core/behavior/BaseConstraintSet.h>
 
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/helper/Factory.inl>

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.h
@@ -42,7 +42,6 @@
 #include <sofa/core/behavior/BaseInteractionForceField.h>
 #include <sofa/core/behavior/Mass.h>
 #include <sofa/core/behavior/BaseProjectiveConstraintSet.h>
-#include <sofa/core/behavior/BaseConstraintSet.h>
 #include <sofa/core/topology/Topology.h>
 #include <sofa/core/topology/BaseTopologyObject.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
@@ -59,12 +58,14 @@
 
 #include <type_traits>
 
-namespace sofa
+namespace sofa::simulation
 {
-namespace simulation
-{
-class Visitor;
+    class Visitor;
 }
+
+namespace sofa::core::behavior
+{
+    class BaseConstraintSet;
 }
 
 #include <sofa/helper/system/thread/CTime.h>

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/PropagateEventVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/PropagateEventVisitor.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/simulation/PropagateEventVisitor.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/SceneLoaderFactory.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/SceneLoaderFactory.cpp
@@ -21,9 +21,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include "SceneLoaderFactory.h"
-
-
-
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {
@@ -118,6 +116,23 @@ SceneLoader* SceneLoaderFactory::addEntry(SceneLoader *loader)
     return loader;
 }
 
+/// load the file
+sofa::core::sptr<sofa::simulation::Node> SceneLoader::load(const std::string& filename, bool reload, const std::vector<std::string>& sceneArgs)
+{
+    if(reload)
+        notifyReloadingSceneBefore();
+    else
+        notifyLoadingSceneBefore();
+
+    sofa::core::sptr<sofa::simulation::Node> root = doLoad(filename, sceneArgs);
+
+    if(reload)
+        notifyReloadingSceneAfter(root);
+    else
+        notifyLoadingSceneAfter(root);
+
+    return root;
+}
 
 
 } // namespace simulation

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/SceneLoaderFactory.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/SceneLoaderFactory.h
@@ -23,15 +23,17 @@
 #define SOFA_SIMULATION_SCENELOADERFACTORY_H
 
 #include <sofa/simulation/config.h>
-#include <sofa/simulation/Node.h>
 #include <sofa/helper/system/SetDirectory.h>
-
+#include <sofa/core/sptr.h>
+#include <vector>
+#include <set>
 
 namespace sofa
 {
 
 namespace simulation
 {
+    class Node;
 
 /**
  *  \brief Main class used to register scene file loaders
@@ -66,23 +68,9 @@ public:
     virtual bool canWriteFileExtension(const char * /*extension*/) { return false; }
 
     /// load the file
-    sofa::simulation::Node::SPtr load(const std::string& filename, bool reload = false, const std::vector<std::string>& sceneArgs = std::vector<std::string>(0))
-    {
-        if(reload)
-            notifyReloadingSceneBefore();
-        else
-            notifyLoadingSceneBefore();
+    sofa::core::sptr<sofa::simulation::Node> load(const std::string& filename, bool reload = false, const std::vector<std::string>& sceneArgs = std::vector<std::string>(0));
 
-        sofa::simulation::Node::SPtr root = doLoad(filename, sceneArgs);
-
-        if(reload)
-            notifyReloadingSceneAfter(root);
-        else
-            notifyLoadingSceneAfter(root);
-
-        return root;
-    }
-    virtual sofa::simulation::Node::SPtr doLoad(const std::string& filename, const std::vector<std::string>& sceneArgs) = 0;
+    virtual sofa::core::sptr<sofa::simulation::Node> doLoad(const std::string& filename, const std::vector<std::string>& sceneArgs) = 0;
 
     /// write scene graph in the file
     virtual void write(sofa::simulation::Node* /*node*/, const char * /*filename*/) {}
@@ -99,10 +87,10 @@ public:
     struct Listener
     {
         virtual void rightBeforeLoadingScene() {} ///< callback called just before loading the scene file
-        virtual void rightAfterLoadingScene(sofa::simulation::Node::SPtr) {} ///< callback called just after loading the scene file
+        virtual void rightAfterLoadingScene(sofa::core::sptr<sofa::simulation::Node>&) {} ///< callback called just after loading the scene file
 
         virtual void rightBeforeReloadingScene() { this->rightBeforeLoadingScene(); } ///< callback called just before reloading the scene file
-        virtual void rightAfterReloadingScene(sofa::simulation::Node::SPtr root) { this->rightAfterLoadingScene(root); } ///< callback called just after reloading the scene file
+        virtual void rightAfterReloadingScene(sofa::core::sptr<sofa::simulation::Node>& root) { this->rightAfterLoadingScene(root); } ///< callback called just after reloading the scene file
     };
 
     /// adding a listener
@@ -118,8 +106,8 @@ protected:
     static Listeners s_listeners;
     static void notifyLoadingSceneBefore() { for( auto* l : s_listeners ) l->rightBeforeLoadingScene(); }
     static void notifyReloadingSceneBefore() { for( auto* l : s_listeners ) l->rightBeforeReloadingScene(); }
-    static void notifyLoadingSceneAfter(sofa::simulation::Node::SPtr node) { for( auto* l : s_listeners ) l->rightAfterLoadingScene(node); }
-    static void notifyReloadingSceneAfter(sofa::simulation::Node::SPtr node) { for( auto* l : s_listeners ) l->rightAfterReloadingScene(node); }
+    static void notifyLoadingSceneAfter(sofa::core::sptr<sofa::simulation::Node>& node) { for( auto* l : s_listeners ) l->rightAfterLoadingScene(node); }
+    static void notifyReloadingSceneAfter(sofa::core::sptr<sofa::simulation::Node>& node) { for( auto* l : s_listeners ) l->rightAfterReloadingScene(node); }
 
 };
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Simulation.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Simulation.cpp
@@ -60,6 +60,7 @@
 #include <sofa/simulation/events/SimulationInitStartEvent.h>
 #include <sofa/simulation/events/SimulationInitDoneEvent.h>
 
+#include <sofa/simulation/Node.h>
 
 #include <fstream>
 #include <cstring>

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Simulation.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Simulation.h
@@ -22,10 +22,20 @@
 #ifndef SOFA_SIMULATION_CORE_SIMULATION_H
 #define SOFA_SIMULATION_CORE_SIMULATION_H
 
-#include <sofa/simulation/Node.h>
-#include <sofa/core/objectmodel/DataFileName.h>
-#include <sofa/core/visual/DisplayFlags.h>
+#include <sofa/simulation/config.h>
+#include <sofa/core/sptr.h>
+#include <sofa/core/objectmodel/Base.h>
 #include <memory>
+
+namespace sofa::simulation
+{
+    class Node;
+}
+
+namespace sofa::core::visual
+{
+    class VisualParams;
+}
 
 namespace sofa
 {
@@ -42,7 +52,6 @@ class SOFA_SIMULATION_CORE_API Simulation: public virtual sofa::core::objectmode
 public:
     SOFA_CLASS(Simulation, sofa::core::objectmodel::Base);
 
-    typedef sofa::core::visual::DisplayFlags DisplayFlags;
     Simulation();
     ~Simulation() override;
 	
@@ -109,16 +118,16 @@ public:
     virtual void dumpState( Node* root, std::ofstream& out );
 
     /// Load a scene from a file
-    virtual Node::SPtr load(const std::string& /* filename */, bool reload = false, const std::vector<std::string>& sceneArgs = std::vector<std::string>(0));
+    virtual sofa::core::sptr<Node> load(const std::string& /* filename */, bool reload = false, const std::vector<std::string>& sceneArgs = std::vector<std::string>(0));
 
     /// Unload a scene from a Node.
-    virtual void unload(Node::SPtr root);
+    virtual void unload(sofa::core::sptr<Node> root);
 
     /// create a new graph(or tree) and return its root node.
-    virtual Node::SPtr createNewGraph(const std::string& name)=0;//Todo replace newNode method
+    virtual sofa::core::sptr<Node> createNewGraph(const std::string& name)=0;//Todo replace newNode method
 
     /// creates and returns a new node.
-    virtual Node::SPtr createNewNode(const std::string& name)=0;
+    virtual sofa::core::sptr<Node> createNewNode(const std::string& name)=0;
 
     /// @warning this singleton has one limitation: it is easy to create several types of
     /// simulations at the same time (e.g. DAGSimulation + TreeSimulation)

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Simulation.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Simulation.h
@@ -118,16 +118,16 @@ public:
     virtual void dumpState( Node* root, std::ofstream& out );
 
     /// Load a scene from a file
-    virtual sofa::core::sptr<Node> load(const std::string& /* filename */, bool reload = false, const std::vector<std::string>& sceneArgs = std::vector<std::string>(0));
+    virtual sofa::core::sptr<sofa::simulation::Node> load(const std::string& /* filename */, bool reload = false, const std::vector<std::string>& sceneArgs = std::vector<std::string>(0));
 
     /// Unload a scene from a Node.
-    virtual void unload(sofa::core::sptr<Node> root);
+    virtual void unload(sofa::core::sptr<sofa::simulation::Node> root);
 
     /// create a new graph(or tree) and return its root node.
-    virtual sofa::core::sptr<Node> createNewGraph(const std::string& name)=0;//Todo replace newNode method
+    virtual sofa::core::sptr<sofa::simulation::Node> createNewGraph(const std::string& name)=0;//Todo replace newNode method
 
     /// creates and returns a new node.
-    virtual sofa::core::sptr<Node> createNewNode(const std::string& name)=0;
+    virtual sofa::core::sptr<sofa::simulation::Node> createNewNode(const std::string& name)=0;
 
     /// @warning this singleton has one limitation: it is easy to create several types of
     /// simulations at the same time (e.g. DAGSimulation + TreeSimulation)

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/SolveVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/SolveVisitor.cpp
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #include <sofa/simulation/SolveVisitor.h>
 #include <sofa/core/behavior/BaseMechanicalState.h>
-
+#include <sofa/simulation/Node.h>
 #include <sofa/helper/AdvancedTimer.h>
 
 namespace sofa

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/UpdateMappingVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/UpdateMappingVisitor.cpp
@@ -22,6 +22,7 @@
 #include <sofa/simulation/UpdateMappingVisitor.h>
 #include <sofa/core/VecId.h>
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/VelocityThresholdVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/VelocityThresholdVisitor.cpp
@@ -20,10 +20,9 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
-
-
 #include <sofa/simulation/VelocityThresholdVisitor.h>
 #include <sofa/core/behavior/BaseMechanicalState.h>
+#include <sofa/simulation/Node.h>
 #include <iostream>
 
 namespace sofa

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Visitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Visitor.cpp
@@ -23,6 +23,7 @@
 #include <sofa/simulation/VisualVisitor.h>
 #include <sofa/simulation/MechanicalVisitor.h>
 #include <sofa/simulation/Simulation.h>
+#include <sofa/simulation/Node.h>
 
 
 namespace sofa

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Visitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Visitor.h
@@ -23,16 +23,19 @@
 #define SOFA_SIMULATION_VISITOR_H
 
 #include <sofa/simulation/config.h>
-#include <sofa/simulation/Node.h>
 #include <sofa/simulation/LocalStorage.h>
 
 #include <sofa/core/behavior/BaseMechanicalState.h>
 #include <sofa/core/ExecParams.h>
 
+#include <sofa/helper/system/thread/CTime.h>
 #include <sofa/helper/set.h>
 #include <iostream>
 
+namespace sofa::simulation { class Node; }
+
 #ifdef SOFA_DUMP_VISITOR_INFO
+#include <sofa/simulation/Node.h>
 #include <sofa/helper/system/thread/CTime.h>
 #endif
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/WriteStateVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/WriteStateVisitor.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #include <sofa/simulation/WriteStateVisitor.h>
 #include <sofa/defaulttype/Vec.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaSimulationGraph/DAGSimulation.h
+++ b/SofaKernel/modules/SofaSimulationGraph/DAGSimulation.h
@@ -50,10 +50,10 @@ public:
     ~DAGSimulation() override; // this is a terminal class
 
     /// create a new graph(or tree) and return its root node.
-    virtual sofa::core::sptr<Node> createNewGraph(const std::string& name) override;
+    virtual sofa::core::sptr<sofa::simulation::Node> createNewGraph(const std::string& name) override;
 
     /// creates and returns a new node.
-    virtual sofa::core::sptr<Node> createNewNode(const std::string& name) override;
+    virtual sofa::core::sptr<sofa::simulation::Node> createNewNode(const std::string& name) override;
 
     /// Can the simulation handle a directed acyclic graph?
     bool isDirectedAcyclicGraph() override { return true; }

--- a/SofaKernel/modules/SofaSimulationGraph/DAGSimulation.h
+++ b/SofaKernel/modules/SofaSimulationGraph/DAGSimulation.h
@@ -50,10 +50,10 @@ public:
     ~DAGSimulation() override; // this is a terminal class
 
     /// create a new graph(or tree) and return its root node.
-    virtual Node::SPtr createNewGraph(const std::string& name) override;
+    virtual sofa::core::sptr<Node> createNewGraph(const std::string& name) override;
 
     /// creates and returns a new node.
-    virtual Node::SPtr createNewNode(const std::string& name) override;
+    virtual sofa::core::sptr<Node> createNewNode(const std::string& name) override;
 
     /// Can the simulation handle a directed acyclic graph?
     bool isDirectedAcyclicGraph() override { return true; }

--- a/SofaKernel/modules/SofaSimulationGraph/testing/BaseSimulationTest.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/testing/BaseSimulationTest.cpp
@@ -35,6 +35,8 @@ using sofa::simulation::SceneLoaderXML ;
 #include <sofa/helper/system/PluginManager.h>
 using sofa::helper::system::PluginManager ;
 
+#include <sofa/simulation/Node.h>
+
 namespace sofa
 {
 namespace helper

--- a/SofaKernel/modules/SofaSimulationGraph/testing/BaseSimulationTest.h
+++ b/SofaKernel/modules/SofaSimulationGraph/testing/BaseSimulationTest.h
@@ -24,8 +24,13 @@
 
 #include <SofaSimulationGraph/config.h>
 #include <sofa/helper/testing/BaseTest.h>
-#include <sofa/simulation/Node.h>
-#include <sofa/simulation/Simulation.h>
+#include <sofa/core/sptr.h>
+
+namespace sofa::simulation
+{
+    class Node;
+    class Simulation;
+}
 
 namespace sofa
 {
@@ -53,7 +58,7 @@ public:
         /// Create a new scene instance from the content of the filename using the factory.
         static SceneInstance LoadFromFile(const std::string& filename) ;
 
-        Node::SPtr root ;
+        sofa::core::sptr<Node> root ;
         Simulation* simulation {nullptr} ;
 
         void initScene() ;

--- a/SofaKernel/modules/SofaSimulationGraph/testing/BaseSimulationTest.h
+++ b/SofaKernel/modules/SofaSimulationGraph/testing/BaseSimulationTest.h
@@ -58,7 +58,7 @@ public:
         /// Create a new scene instance from the content of the filename using the factory.
         static SceneInstance LoadFromFile(const std::string& filename) ;
 
-        sofa::core::sptr<Node> root ;
+        sofa::core::sptr<sofa::simulation::Node> root ;
         Simulation* simulation {nullptr} ;
 
         void initScene() ;

--- a/SofaKernel/modules/SofaSimulationGraph/testing/BaseSimulationTest.h
+++ b/SofaKernel/modules/SofaSimulationGraph/testing/BaseSimulationTest.h
@@ -24,7 +24,7 @@
 
 #include <SofaSimulationGraph/config.h>
 #include <sofa/helper/testing/BaseTest.h>
-#include <sofa/core/sptr.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa::simulation
 {

--- a/SofaKernel/modules/SofaSimulationTree/TreeSimulation.h
+++ b/SofaKernel/modules/SofaSimulationTree/TreeSimulation.h
@@ -50,10 +50,10 @@ public:
     ~TreeSimulation() override; // this is a terminal class
 
     /// create a new graph(or tree) and return its root node.
-    virtual Node::SPtr createNewGraph(const std::string& name) override;
+    virtual sofa::core::sptr<Node> createNewGraph(const std::string& name) override;
 
     /// creates and returns a new node.
-    virtual Node::SPtr createNewNode(const std::string& name) override;
+    virtual sofa::core::sptr<Node> createNewNode(const std::string& name) override;
 
     /// Can the simulation handle a directed acyclic graph?
     bool isDirectedAcyclicGraph() override { return false; }

--- a/SofaKernel/modules/SofaSimulationTree/TreeSimulation.h
+++ b/SofaKernel/modules/SofaSimulationTree/TreeSimulation.h
@@ -50,10 +50,10 @@ public:
     ~TreeSimulation() override; // this is a terminal class
 
     /// create a new graph(or tree) and return its root node.
-    virtual sofa::core::sptr<Node> createNewGraph(const std::string& name) override;
+    virtual sofa::core::sptr<sofa::simulation::Node> createNewGraph(const std::string& name) override;
 
     /// creates and returns a new node.
-    virtual sofa::core::sptr<Node> createNewNode(const std::string& name) override;
+    virtual sofa::core::sptr<sofa::simulation::Node> createNewNode(const std::string& name) override;
 
     /// Can the simulation handle a directed acyclic graph?
     bool isDirectedAcyclicGraph() override { return false; }

--- a/applications/plugins/Compliant/assembly/AssemblyHelper.h
+++ b/applications/plugins/Compliant/assembly/AssemblyHelper.h
@@ -8,7 +8,7 @@
 
 #include <sofa/helper/logging/Messaging.h>
 #include <sofa/helper/OwnershipSPtr.h>
-
+#include <sofa/simulation/Node.h>
 
 namespace sofa {
 

--- a/applications/plugins/Compliant/assembly/AssemblyVisitor.cpp
+++ b/applications/plugins/Compliant/assembly/AssemblyVisitor.cpp
@@ -3,7 +3,7 @@
 
 #include <SofaBaseLinearSolver/SingleMatrixAccessor.h>
 #include <SofaBaseLinearSolver/DefaultMultiMatrixAccessor.h>
-
+#include <sofa/simulation/Node.h>
 #include <sofa/helper/cast.h>
 #include "../utils/scoped.h"
 #include "../utils/sparse.h"

--- a/applications/plugins/Compliant/compliance/UniformCompliance.inl
+++ b/applications/plugins/Compliant/compliance/UniformCompliance.inl
@@ -135,7 +135,7 @@ SReal UniformCompliance<DataTypes>::getPotentialEnergy( const core::MechanicalPa
 template<class DataTypes>
 const sofa::defaulttype::BaseMatrix* UniformCompliance<DataTypes>::getComplianceMatrix(const core::MechanicalParams*)
 {
-    if( resizable.getValue() && (defaulttype::BaseMatrix::Index)this->mstate->getSize() != matC.rows() ) reinit();
+    if( resizable.getValue() && (defaulttype::BaseMatrixIndex)this->mstate->getSize() != matC.rows() ) reinit();
 
     return &matC;
 }
@@ -159,7 +159,7 @@ void UniformCompliance<DataTypes>::addBToMatrix( sofa::defaulttype::BaseMatrix *
 template<class DataTypes>
 void UniformCompliance<DataTypes>::addForce(const core::MechanicalParams *, DataVecDeriv& f, const DataVecCoord& x, const DataVecDeriv& /*v*/)
 {
-    if( resizable.getValue() &&  (defaulttype::BaseMatrix::Index)x.getValue().size() != matK.compressedMatrix.rows() ) reinit();
+    if( resizable.getValue() &&  (defaulttype::BaseMatrixIndex)x.getValue().size() != matK.compressedMatrix.rows() ) reinit();
 
 //    if( matK.compressedMatrix.nonZeros() )
         matK.addMult( f, x  );

--- a/applications/plugins/Compliant/controller/CompliantSleepController.cpp
+++ b/applications/plugins/Compliant/controller/CompliantSleepController.cpp
@@ -4,6 +4,7 @@
 #include "../compliance/DiagonalCompliance.h"
 #include "../compliance/UniformCompliance.h"
 #include <sofa/helper/cast.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/applications/plugins/Compliant/forcefield/UniformStiffness.inl
+++ b/applications/plugins/Compliant/forcefield/UniformStiffness.inl
@@ -101,7 +101,7 @@ SReal UniformStiffness<DataTypes>::getPotentialEnergy( const core::MechanicalPar
 template<class DataTypes>
 const sofa::defaulttype::BaseMatrix* UniformStiffness<DataTypes>::getStiffnessMatrix(const core::MechanicalParams*)
 {
-    if( resizable.getValue() && (defaulttype::BaseMatrix::Index)this->mstate->getSize() != matC.rows() ) reinit();
+    if( resizable.getValue() && (defaulttype::BaseMatrixIndex)this->mstate->getSize() != matC.rows() ) reinit();
 
     return &matC;
 }
@@ -122,7 +122,7 @@ void UniformStiffness<DataTypes>::addBToMatrix( sofa::defaulttype::BaseMatrix * 
 template<class DataTypes>
 void UniformStiffness<DataTypes>::addForce(const core::MechanicalParams *, DataVecDeriv& f, const DataVecCoord& x, const DataVecDeriv& /*v*/)
 {
-    if( resizable.getValue() &&  (defaulttype::BaseMatrix::Index)x.getValue().size() != matK.compressedMatrix.rows() ) reinit();
+    if( resizable.getValue() &&  (defaulttype::BaseMatrixIndex)x.getValue().size() != matK.compressedMatrix.rows() ) reinit();
     matK.addMult( f, x  );
 }
 

--- a/applications/plugins/Compliant/odesolver/CompliantStaticSolver.cpp
+++ b/applications/plugins/Compliant/odesolver/CompliantStaticSolver.cpp
@@ -1,5 +1,6 @@
 #include "CompliantStaticSolver.h"
 
+#include <sofa/simulation/Node.h>
 #include <sofa/core/ObjectFactory.h>
 
 #include <boost/math/tools/minima.hpp>

--- a/applications/plugins/ExternalBehaviorModel/FEMGridBehaviorModel.h
+++ b/applications/plugins/ExternalBehaviorModel/FEMGridBehaviorModel.h
@@ -134,7 +134,7 @@ protected:
     component::topology::RegularGridTopology::SPtr m_internalTopology;
     typename component::forcefield::HexahedronFEMForceField<DataTypes>::SPtr m_internalForceField;
     typename component::mass::UniformMass<DataTypes,Real>::SPtr m_internalMass;
-    sofa::simulation::Node::SPtr m_internalNode;
+    sofa::core::sptr<sofa::simulation::Node> m_internalNode;
 
     int mapExposedInternalIndices[8]; ///< identity mapping between exposed SOFA dofs and internal model dofs
     /// @}

--- a/applications/plugins/Flexible/mass/ImageDensityMass.inl
+++ b/applications/plugins/Flexible/mass/ImageDensityMass.inl
@@ -433,7 +433,7 @@ void ImageDensityMass< DataTypes, ShapeFunctionTypes, MassType >::getElementMass
 
     //    std::cerr<<"ImageDensityMass::getElementMass "<<std::endl;
 
-    static const BaseMatrix::Index dimension = (BaseMatrix::Index) DataTypes::deriv_total_size;
+    static const BaseMatrixIndex dimension = (BaseMatrixIndex) DataTypes::deriv_total_size;
 
     if( m->rowSize() != dimension || m->colSize() != dimension ) m->resize( dimension, dimension );
 
@@ -442,11 +442,11 @@ void ImageDensityMass< DataTypes, ShapeFunctionTypes, MassType >::getElementMass
     //    for( unsigned i=0 ; i<dimension; ++i )
     //        m->set( i,i,1);
 
-    BaseMatrix::Index i = index;
-    BaseMatrix::Index bi = 0;
+    BaseMatrixIndex i = index;
+    BaseMatrixIndex bi = 0;
     m_massMatrix.split_row_index( i, bi );
 
-    BaseMatrix::Index rowId = i * m_massMatrix.getRowIndex().size() / m_massMatrix.rowBSize();
+    BaseMatrixIndex rowId = i * m_massMatrix.getRowIndex().size() / m_massMatrix.rowBSize();
     if( m_massMatrix.sortedFind( m_massMatrix.getRowIndex(), i, rowId ) )
     {
         typename MassMatrix::Range rowRange( m_massMatrix.getRowBegin()[rowId], m_massMatrix.getRowBegin()[rowId+1] );

--- a/applications/plugins/Geomagic/src/Geomagic/GeomagicVisualModel.h
+++ b/applications/plugins/Geomagic/src/Geomagic/GeomagicVisualModel.h
@@ -70,7 +70,7 @@ public:
 	virtual ~GeomagicVisualModel();
 
     /// Main Method to init the visual component tree of OGLModels. Called by Geomagic InitDevice() if drawVisual is on.
-    void initDisplay(sofa::simulation::Node::SPtr node, const std::string& _deviceName, double _scale);
+    void initDisplay(sofa::core::sptr<sofa::simulation::Node> node, const std::string& _deviceName, double _scale);
 
     /// Method to update the visualNode using the current device position and the angles of the different node of the device. Updated by Geomagic UpdatePosition()
     void updateDisplay(const GeomagicDriver::Coord& posDevice, HDdouble angle1[3], HDdouble angle2[3]);

--- a/applications/plugins/SceneCreator/SceneCreator_test/SceneCreator_test.cpp
+++ b/applications/plugins/SceneCreator/SceneCreator_test/SceneCreator_test.cpp
@@ -263,7 +263,7 @@ bool SceneCreator_test::createRigidCylinderSuccess()
 bool SceneCreator_test::createSphereFailed()
 {
     // Null parent for Sphere case
-    sofa::simulation::Node::SPtr cyl = sofa::modeling::addSphere(nullptr, "SphereFEM_1", sofa::defaulttype::Vec3Types::Deriv(5, 5, 5),
+    sofa::core::sptr<sofa::simulation::Node> cyl = sofa::modeling::addSphere(nullptr, "SphereFEM_1", sofa::defaulttype::Vec3Types::Deriv(5, 5, 5),
                                                                    sofa::defaulttype::Vec3Types::Deriv(0, 1, 0), 1.0,
                                                                    10, 1000, 0.45,
                                                                    sofa::defaulttype::Vec3Types::Deriv(0, 5, 0));
@@ -277,7 +277,7 @@ bool SceneCreator_test::createSphereFailed()
     EXPECT_EQ(cyl, nullptr);
 
     // Sphere with bad grid size
-    sofa::simulation::Node::SPtr root = sofa::modeling::createRootWithCollisionPipeline();
+    sofa::core::sptr<sofa::simulation::Node> root = sofa::modeling::createRootWithCollisionPipeline();
     cyl = sofa::modeling::addRigidSphere(root, "SphereFIX_3", sofa::defaulttype::Vec3Types::Deriv(0, 5, 5),
                                             sofa::defaulttype::Vec3Types::Deriv(1, 0, 0), 0.5,
                                             sofa::defaulttype::Vec3Types::Deriv(0, 5, 0));
@@ -292,8 +292,8 @@ bool SceneCreator_test::createSphereSuccess()
 {
     // Create Sphere
     SReal poissonRatio = 0.45;
-    sofa::simulation::Node::SPtr root = sofa::modeling::createRootWithCollisionPipeline();
-    sofa::simulation::Node::SPtr node = sofa::modeling::addSphere(root, "SphereFEM_1", sofa::defaulttype::Vec3Types::Deriv(5, 5, 5),
+    sofa::core::sptr<sofa::simulation::Node> root = sofa::modeling::createRootWithCollisionPipeline();
+    sofa::core::sptr<sofa::simulation::Node> node = sofa::modeling::addSphere(root, "SphereFEM_1", sofa::defaulttype::Vec3Types::Deriv(5, 5, 5),
                                                                     sofa::defaulttype::Vec3Types::Deriv(0, 1, 0), 1.0,
                                                                     10, 1000, 0.45,
                                                                     sofa::defaulttype::Vec3Types::Deriv(0, 5, 0));
@@ -329,8 +329,8 @@ bool SceneCreator_test::createSphereSuccess()
 
 bool SceneCreator_test::createRigidSphereSuccess()
 {
-    sofa::simulation::Node::SPtr root = sofa::modeling::createRootWithCollisionPipeline();
-    sofa::simulation::Node::SPtr node = sofa::modeling::addRigidSphere(root, "SphereFIX_3", sofa::defaulttype::Vec3Types::Deriv(5, 5, 5),
+    sofa::core::sptr<sofa::simulation::Node> root = sofa::modeling::createRootWithCollisionPipeline();
+    sofa::core::sptr<sofa::simulation::Node> node = sofa::modeling::addRigidSphere(root, "SphereFIX_3", sofa::defaulttype::Vec3Types::Deriv(5, 5, 5),
                                                                          sofa::defaulttype::Vec3Types::Deriv(1, 0, 0), 0.5,
                                                                          sofa::defaulttype::Vec3Types::Deriv(0, 5, 0));
 

--- a/applications/plugins/SceneCreator/sceneCreatorExamples/SceneCreatorBenchmarks.cpp
+++ b/applications/plugins/SceneCreator/sceneCreatorExamples/SceneCreatorBenchmarks.cpp
@@ -35,7 +35,7 @@
 #include <boost/program_options.hpp>
 
 
-void fallingCubeExample(sofa::simulation::Node::SPtr root)
+void fallingCubeExample(sofa::core::sptr<sofa::simulation::Node> root)
 {
     //Add objects
     for (unsigned int i=0; i<10; ++i)
@@ -48,7 +48,7 @@ void fallingCubeExample(sofa::simulation::Node::SPtr root)
                                   sofa::defaulttype::Vec3Types::Deriv(0, 0, 0), sofa::defaulttype::Vec3Types::Deriv(0, 0, 0), sofa::defaulttype::Vec3Types::Deriv(40, 0, 40));
 }
 
-void fallingCylinderExample(sofa::simulation::Node::SPtr root)
+void fallingCylinderExample(sofa::core::sptr<sofa::simulation::Node> root)
 {
     //Add objects
     for (unsigned int i=0; i<10; ++i)
@@ -62,7 +62,7 @@ void fallingCylinderExample(sofa::simulation::Node::SPtr root)
                                   sofa::defaulttype::Vec3Types::Deriv(0, 0, 0), sofa::defaulttype::Vec3Types::Deriv(0, 0, 0), sofa::defaulttype::Vec3Types::Deriv(40, 0, 40));
 }
 
-void fallingSphereExample(sofa::simulation::Node::SPtr root)
+void fallingSphereExample(sofa::core::sptr<sofa::simulation::Node> root)
 {
     //Add objects
     for (unsigned int i=0; i<10; ++i)
@@ -77,7 +77,7 @@ void fallingSphereExample(sofa::simulation::Node::SPtr root)
 }
 
 
-void fallingDrapExample(sofa::simulation::Node::SPtr root)
+void fallingDrapExample(sofa::core::sptr<sofa::simulation::Node> root)
 {
     //Add objects
     for (unsigned int i=0; i<6; ++i){
@@ -145,7 +145,7 @@ int main(int argc, char** argv)
 
 
     // Create the graph root node with collision
-    sofa::simulation::Node::SPtr root = sofa::modeling::createRootWithCollisionPipeline();
+    sofa::core::sptr<sofa::simulation::Node> root = sofa::modeling::createRootWithCollisionPipeline();
     root->setGravity( sofa::defaulttype::Vec3Types::Deriv(0,-10.0,0) );
 
 

--- a/applications/plugins/SceneCreator/src/SceneCreator/GetAssembledSizeVisitor.cpp
+++ b/applications/plugins/SceneCreator/src/SceneCreator/GetAssembledSizeVisitor.cpp
@@ -31,6 +31,7 @@
 //
 #include "GetAssembledSizeVisitor.h"
 #include <sofa/defaulttype/Vec.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/applications/plugins/SceneCreator/src/SceneCreator/GetAssembledSizeVisitor.h
+++ b/applications/plugins/SceneCreator/src/SceneCreator/GetAssembledSizeVisitor.h
@@ -39,7 +39,7 @@
 #include <sofa/simulation/Visitor.h>
 #include <sofa/core/MultiVecId.h>
 #include <sofa/defaulttype/BaseVector.h>
-
+#include <sofa/core/MechanicalParams.h>
 
 namespace sofa
 {

--- a/applications/plugins/SceneCreator/src/SceneCreator/GetVectorVisitor.cpp
+++ b/applications/plugins/SceneCreator/src/SceneCreator/GetVectorVisitor.cpp
@@ -31,6 +31,7 @@
 //
 #include "GetVectorVisitor.h"
 #include <sofa/defaulttype/Vec.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/applications/plugins/SceneCreator/src/SceneCreator/SceneCreator.cpp
+++ b/applications/plugins/SceneCreator/src/SceneCreator/SceneCreator.cpp
@@ -59,7 +59,7 @@ using sofa::core::objectmodel::New ;
 
 using sofa::helper::system::DataRepository ;
 
-static sofa::simulation::Node::SPtr root = nullptr;
+static sofa::core::sptr<sofa::simulation::Node> root = nullptr;
 
 using sofa::core::objectmodel::BaseObject ;
 
@@ -397,7 +397,7 @@ simulation::Node::SPtr addCube(simulation::Node::SPtr parent, const std::string&
         isRigid = true;
 
     // Add Cube Node
-    sofa::simulation::Node::SPtr cube;
+    sofa::core::sptr<sofa::simulation::Node> cube;
     if (isRigid)
         cube = parent->createChild(objectName + "_node");
     else
@@ -470,7 +470,7 @@ simulation::Node::SPtr addCylinder(simulation::Node::SPtr parent, const std::str
         isRigid = true;
 
     // Add Cylinder Node
-    sofa::simulation::Node::SPtr cylinder;
+    sofa::core::sptr<sofa::simulation::Node> cylinder;
     if (isRigid)
         cylinder = parent->createChild(objectName + "_node");
     else
@@ -534,7 +534,7 @@ simulation::Node::SPtr addSphere(simulation::Node::SPtr parent, const std::strin
         isRigid = true;
 
     // Add Sphere Node
-    sofa::simulation::Node::SPtr sphere;
+    sofa::core::sptr<sofa::simulation::Node> sphere;
     if (isRigid)
         sphere = parent->createChild(objectName + "_node");
     else
@@ -594,7 +594,7 @@ simulation::Node::SPtr addPlane(simulation::Node::SPtr parent, const std::string
         isRigid = true;
 
     // Add plane node
-    sofa::simulation::Node::SPtr plane;
+    sofa::core::sptr<sofa::simulation::Node> plane;
     if (isRigid)
         plane = parent->createChild(objectName + "_node");
     else

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaBaseVector.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaBaseVector.h
@@ -101,7 +101,7 @@ template<class T>
 class CudaBaseVectorType : public BaseVector {
 public :
     typedef T Real;
-    typedef typename BaseVector::Index Index;
+    typedef typename sofa::defaulttype::BaseVectorIndex Index;
 
     virtual void resize(Index nbRow) = 0;
     virtual Index size() const = 0;

--- a/applications/plugins/SofaDistanceGrid/components/forcefield/DistanceGridForceField.h
+++ b/applications/plugins/SofaDistanceGrid/components/forcefield/DistanceGridForceField.h
@@ -27,6 +27,7 @@
 #include <sofa/core/behavior/ForceField.h>
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/objectmodel/Data.h>
+#include <sofa/core/objectmodel/DataFileName.h>
 #include <sofa/defaulttype/VecTypes.h>
 
 namespace sofa

--- a/applications/plugins/SofaDistanceGrid/components/forcefield/DistanceGridForceField.inl
+++ b/applications/plugins/SofaDistanceGrid/components/forcefield/DistanceGridForceField.inl
@@ -24,6 +24,7 @@
 
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/simulation/Simulation.h>
+#include <sofa/core/topology/BaseMeshTopology.h>
 #include "DistanceGridForceField.h"
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/helper/gl/template.h>

--- a/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/RayTriangleVisitor.cpp
+++ b/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/RayTriangleVisitor.cpp
@@ -24,6 +24,7 @@
 #include <SofaMeshCollision/TriangleModel.h>
 #include <SofaBaseMechanics/MechanicalObject.h>
 #include <sofa/defaulttype/VecTypes.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/applications/plugins/SofaPython/Binding_Base.cpp
+++ b/applications/plugins/SofaPython/Binding_Base.cpp
@@ -32,6 +32,7 @@
 
 #include "PythonFactory.h"
 #include "PythonToSofa.inl"
+#include <sofa/simulation/Node.h>
 
 #include "PythonEnvironment.h"
 using sofa::simulation::PythonEnvironment ;

--- a/applications/plugins/SofaPython/Binding_BaseLoader.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseLoader.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
+#include <sofa/simulation/Node.h>
 #include "Binding_BaseLoader.h"
 #include "Binding_BaseObject.h"
 #include "PythonToSofa.inl"

--- a/applications/plugins/SofaPython/Binding_BaseMapping.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseMapping.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
+#include <sofa/defaulttype/BaseMatrix.h>
 #include "Binding_BaseMapping.h"
 #include "Binding_BaseObject.h"
 #include "PythonFactory.h"

--- a/applications/plugins/SofaPython/Binding_BaseMechanicalState.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseMechanicalState.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
+#include <sofa/simulation/Node.h>
 #include "Binding_BaseMechanicalState.h"
 #include "Binding_BaseState.h"
 #include "PythonToSofa.inl"

--- a/applications/plugins/SofaPython/Binding_BaseMeshTopology.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseMeshTopology.cpp
@@ -20,6 +20,8 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
+
+#include <sofa/simulation/Node.h>
 #include "Binding_BaseMeshTopology.h"
 #include "Binding_Topology.h"
 #include "PythonToSofa.inl"

--- a/applications/plugins/SofaPython/Binding_BaseObject.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseObject.cpp
@@ -35,6 +35,8 @@ using sofa::core::ObjectCreator ;
 #include "PythonFactory.h"
 #include "PythonToSofa.inl"
 
+#include <sofa/simulation/Node.h>
+
 using sofa::core::objectmodel::BaseObject;
 
 static BaseObject* get_baseobject(PyObject* self) {

--- a/applications/plugins/SofaPython/Binding_BaseState.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseState.cpp
@@ -20,6 +20,8 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
+
+#include <sofa/simulation/Node.h>
 #include "Binding_BaseState.h"
 #include "Binding_BaseObject.h"
 #include "PythonToSofa.inl"

--- a/applications/plugins/SofaPython/Binding_BaseTopologyObject.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseTopologyObject.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
+#include <sofa/simulation/Node.h>
 #include "Binding_BaseTopologyObject.h"
 #include "Binding_BaseObject.h"
 

--- a/applications/plugins/SofaPython/Binding_Context.cpp
+++ b/applications/plugins/SofaPython/Binding_Context.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
+#include <sofa/simulation/Node.h>
 #include "Binding_Context.h"
 #include "Binding_BaseContext.h"
 

--- a/applications/plugins/SofaPython/PythonScriptControllerHelper.h
+++ b/applications/plugins/SofaPython/PythonScriptControllerHelper.h
@@ -30,6 +30,7 @@
 #include <SofaPython/config.h>
 
 #include <sofa/simulation/Simulation.h>
+#include <sofa/simulation/Node.h>
 
 #include "PythonScriptController.h"
 #include "PythonScriptFunction.h"
@@ -81,7 +82,7 @@ PyObject* PythonScript_parametersToTuple(ParametersType... parameters)
  * If the controller functions returns \c None, or if you are not interested by the returned value, call it with \c nullptr as first parameter.
  */
 template<typename ResultType, typename... ParametersType>
-void PythonScriptController_call(ResultType * result, sofa::simulation::Node::SPtr root, std::string const& pythonScriptControllerName, std::string const& funcName, ParametersType... parameters)
+void PythonScriptController_call(ResultType * result, sofa::core::sptr<sofa::simulation::Node> root, std::string const& pythonScriptControllerName, std::string const& funcName, ParametersType... parameters)
 {
     sofa::component::controller::PythonScriptController* controller = nullptr;
     controller = dynamic_cast<sofa::component::controller::PythonScriptController*>(root->getObject(pythonScriptControllerName.c_str()));
@@ -104,7 +105,7 @@ void PythonScriptController_call(ResultType * result, sofa::simulation::Node::SP
 }
 
 template<typename... ParametersType>
-void PythonScriptController_call(std::nullptr_t /*result*/, sofa::simulation::Node::SPtr root, std::string const& pythonScriptControllerName, std::string const& funcName, ParametersType... parameters)
+void PythonScriptController_call(std::nullptr_t /*result*/, sofa::core::sptr<sofa::simulation::Node> root, std::string const& pythonScriptControllerName, std::string const& funcName, ParametersType... parameters)
 {
     int* none=nullptr;
     PythonScriptController_call(none, root, pythonScriptControllerName, funcName, parameters...);

--- a/applications/plugins/SofaPython/PythonScriptEvent.cpp
+++ b/applications/plugins/SofaPython/PythonScriptEvent.cpp
@@ -34,7 +34,7 @@ namespace objectmodel
 
 SOFA_EVENT_CPP( PythonScriptEvent )
 
-PythonScriptEvent::PythonScriptEvent(sofa::simulation::Node::SPtr sender, const char* eventName, PyObject* userData)
+PythonScriptEvent::PythonScriptEvent(sofa::core::sptr<sofa::simulation::Node> sender, const char* eventName, PyObject* userData)
     : sofa::core::objectmodel::ScriptEvent(sender,eventName)
     , m_userData(userData)
 {

--- a/applications/plugins/SofaPython/PythonScriptEvent.h
+++ b/applications/plugins/SofaPython/PythonScriptEvent.h
@@ -49,7 +49,7 @@ public:
     /**
      * @brief Constructor.
      */
-    PythonScriptEvent(sofa::simulation::Node::SPtr sender, const char* eventName, PyObject* userData);
+    PythonScriptEvent(sofa::core::sptr<sofa::simulation::Node> sender, const char* eventName, PyObject* userData);
 
     /**
      * @brief Destructor.

--- a/applications/plugins/SofaPython/PythonVisitor.cpp
+++ b/applications/plugins/SofaPython/PythonVisitor.cpp
@@ -2,6 +2,7 @@
 #include "PythonVisitor.h"
 #include "PythonFactory.h"
 
+#include <sofa/simulation/Node.h>
 
 
 namespace sofa

--- a/applications/plugins/SofaPython/SceneLoaderPY.cpp
+++ b/applications/plugins/SofaPython/SceneLoaderPY.cpp
@@ -83,9 +83,9 @@ void SceneLoaderPY::getExtensionList(ExtensionList* list)
 }
 
 
-sofa::simulation::Node::SPtr SceneLoaderPY::doLoad(const std::string& filename, const std::vector<std::string>& sceneArgs)
+sofa::core::sptr<sofa::simulation::Node> SceneLoaderPY::doLoad(const std::string& filename, const std::vector<std::string>& sceneArgs)
 {
-    sofa::simulation::Node::SPtr root;
+    sofa::core::sptr<sofa::simulation::Node> root;
     doLoadSceneWithArguments(filename, sceneArgs, &root);
     return root;
 }

--- a/applications/plugins/SofaPython/SceneLoaderPY.h
+++ b/applications/plugins/SofaPython/SceneLoaderPY.h
@@ -25,6 +25,7 @@
 #include <SofaPython/config.h>
 #include <sofa/simulation/SceneLoaderFactory.h>
 
+#include <sofa/simulation/Node.h>
 
 #include <sofa/simulation/Visitor.h>
 #include <string>

--- a/applications/plugins/SofaPython/SofaPython_test/PythonScriptControllerHelper_test.cpp
+++ b/applications/plugins/SofaPython/SofaPython_test/PythonScriptControllerHelper_test.cpp
@@ -13,7 +13,7 @@ struct PythonScriptControllerHelper_test : public ::testing::Test
 {
 protected:
 
-    sofa::simulation::Node::SPtr root;
+    sofa::core::sptr<sofa::simulation::Node> root;
 
     void SetUp() override
     {

--- a/applications/plugins/SofaTest/BroadPhase_test.h
+++ b/applications/plugins/SofaTest/BroadPhase_test.h
@@ -113,7 +113,7 @@ void getMyBoxes(sofa::core::CollisionModel * cm,std::vector<MyBox> & my_boxes){
         my_boxes.push_back(MyBox(sofa::component::collision::Cube(cbm,i)));
 }
 
-sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr makeOBBModel(const std::vector<sofa::defaulttype::Vector3> & p,sofa::simulation::Node::SPtr &father,double default_extent);
+sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr makeOBBModel(const std::vector<sofa::defaulttype::Vector3> & p,sofa::core::sptr<sofa::simulation::Node> &father,double default_extent);
 
 void randMoving(sofa::core::CollisionModel* cm,const sofa::defaulttype::Vector3 & min_vect,const sofa::defaulttype::Vector3 & max_vect){
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types> * obbm = dynamic_cast<sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>*>(cm->getLast());
@@ -356,10 +356,10 @@ bool GENTest(sofa::core::CollisionModel * cm1,sofa::core::CollisionModel * cm2,D
 }
 
 
-sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr makeOBBModel(const std::vector<sofa::defaulttype::Vector3> & p,sofa::simulation::Node::SPtr &father,double default_extent){
+sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr makeOBBModel(const std::vector<sofa::defaulttype::Vector3> & p,sofa::core::sptr<sofa::simulation::Node> &father,double default_extent){
     int n = p.size();
     //creating node containing OBBModel
-    sofa::simulation::Node::SPtr obb = father->createChild("obb");
+    sofa::core::sptr<sofa::simulation::Node> obb = father->createChild("obb");
 
     //creating a mechanical object which will be attached to the OBBModel
     MechanicalObjectRigid3::SPtr obbDOF = sofa::core::objectmodel::New<MechanicalObjectRigid3>();
@@ -429,7 +429,7 @@ bool BroadPhaseTest<BroadPhase>::randTest(int /*seed*/, int nb1, int nb2, const 
     for(int i = 0 ; i < nb2 ; ++i)
         secondCollision.push_back(randVect(min,max));
 
-    sofa::simulation::Node::SPtr scn = sofa::core::objectmodel::New<sofa::simulation::tree::GNode>();
+    sofa::core::sptr<sofa::simulation::Node> scn = sofa::core::objectmodel::New<sofa::simulation::tree::GNode>();
     sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr obbm1,obbm2;
     obbm1 = makeOBBModel(firstCollision,scn,getExtent());
     obbm2 = makeOBBModel(secondCollision,scn,getExtent());

--- a/applications/plugins/SofaTest/PrimitiveCreation.cpp
+++ b/applications/plugins/SofaTest/PrimitiveCreation.cpp
@@ -38,9 +38,9 @@ void rotz(double angle,Vec3 & x,Vec3 & y,Vec3 & z){
 }
 
 
-sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr makeOBB(const Vec3 & p,const double *angles,const int *order,const Vec3 &v,const Vec3 &extents, sofa::simulation::Node::SPtr &father){
+sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr makeOBB(const Vec3 & p,const double *angles,const int *order,const Vec3 &v,const Vec3 &extents, sofa::core::sptr<sofa::simulation::Node> &father){
     //creating node containing OBBModel
-    sofa::simulation::Node::SPtr obb = father->createChild("obb");
+    sofa::core::sptr<sofa::simulation::Node> obb = father->createChild("obb");
 
     //creating a mechanical object which will be attached to the OBBModel
     MechanicalObjectRigid3::SPtr obbDOF = New<MechanicalObjectRigid3>();
@@ -99,9 +99,9 @@ sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::S
 }
 
 
-sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::SPtr makeTri(const Vec3 & p0,const Vec3 & p1,const Vec3 & p2,const Vec3 & v, sofa::simulation::Node::SPtr &father){
+sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::SPtr makeTri(const Vec3 & p0,const Vec3 & p1,const Vec3 & p2,const Vec3 & v, sofa::core::sptr<sofa::simulation::Node> &father){
     //creating node containing TriangleModel
-    sofa::simulation::Node::SPtr tri = father->createChild("tri");
+    sofa::core::sptr<sofa::simulation::Node> tri = father->createChild("tri");
 
     //creating a mechanical object which will be attached to the OBBModel
     MechanicalObject3::SPtr triDOF = New<MechanicalObject3>();
@@ -151,9 +151,9 @@ sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>
 
 
 sofa::component::collision::CapsuleCollisionModel<sofa::defaulttype::Vec3Types>::SPtr makeCap(const Vec3 & p0,const Vec3 & p1,double radius,const Vec3 & v,
-                                                                   sofa::simulation::Node::SPtr & father){
+                                                                   sofa::core::sptr<sofa::simulation::Node> & father){
     //creating node containing OBBModel
-    sofa::simulation::Node::SPtr cap = father->createChild("cap");
+    sofa::core::sptr<sofa::simulation::Node> cap = father->createChild("cap");
 
     //creating a mechanical object which will be attached to the OBBModel
     MechanicalObject3::SPtr capDOF = New<MechanicalObject3>();
@@ -203,9 +203,9 @@ sofa::component::collision::CapsuleCollisionModel<sofa::defaulttype::Vec3Types>:
 
 
 sofa::component::collision::SphereCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr makeRigidSphere(const Vec3 & p,SReal radius,const Vec3 &v,const double *angles,const int *order,
-                                                                            sofa::simulation::Node::SPtr & father){
+                                                                            sofa::core::sptr<sofa::simulation::Node> & father){
     //creating node containing OBBModel
-    sofa::simulation::Node::SPtr sphere = father->createChild("sphere");
+    sofa::core::sptr<sofa::simulation::Node> sphere = father->createChild("sphere");
 
     //creating a mechanical object which will be attached to the OBBModel
     MechanicalObjectRigid3::SPtr sphereDOF = New<MechanicalObjectRigid3>();
@@ -263,9 +263,9 @@ sofa::component::collision::SphereCollisionModel<sofa::defaulttype::Rigid3Types>
 }
 
 
-sofa::component::collision::SphereCollisionModel<sofa::defaulttype::Vec3Types>::SPtr makeSphere(const Vec3 & p,SReal radius,const Vec3 & v,sofa::simulation::Node::SPtr & father){
+sofa::component::collision::SphereCollisionModel<sofa::defaulttype::Vec3Types>::SPtr makeSphere(const Vec3 & p,SReal radius,const Vec3 & v,sofa::core::sptr<sofa::simulation::Node> & father){
     //creating node containing OBBModel
-    sofa::simulation::Node::SPtr sphere = father->createChild("sphere");
+    sofa::core::sptr<sofa::simulation::Node> sphere = father->createChild("sphere");
 
     //creating a mechanical object which will be attached to the OBBModel
     MechanicalObject3::SPtr sphereDOF = New<MechanicalObject3>();

--- a/applications/plugins/SofaTest/PrimitiveCreation.h
+++ b/applications/plugins/SofaTest/PrimitiveCreation.h
@@ -22,17 +22,17 @@ using sofa::defaulttype::Vec3;
   *\param extents it contains half-extents of the OBB
   *\param father it is a node that will contain the returned OBBModel
   */
-SOFA_SOFATEST_API sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr makeOBB(const Vec3 & p,const double *angles,const int *order,const Vec3 &v,const Vec3 &extents, sofa::simulation::Node::SPtr &father);
+SOFA_SOFATEST_API sofa::component::collision::OBBCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr makeOBB(const Vec3 & p,const double *angles,const int *order,const Vec3 &v,const Vec3 &extents, sofa::core::sptr<sofa::simulation::Node> &father);
 
-SOFA_SOFATEST_API sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::SPtr makeTri(const Vec3 & p0,const Vec3 & p1,const Vec3 & p2,const Vec3 & v, sofa::simulation::Node::SPtr &father);
+SOFA_SOFATEST_API sofa::component::collision::TriangleCollisionModel<sofa::defaulttype::Vec3Types>::SPtr makeTri(const Vec3 & p0,const Vec3 & p1,const Vec3 & p2,const Vec3 & v, sofa::core::sptr<sofa::simulation::Node> &father);
 
 SOFA_SOFATEST_API sofa::component::collision::CapsuleCollisionModel<sofa::defaulttype::Vec3Types>::SPtr makeCap(const Vec3 & p0,const Vec3 & p1,double radius,const Vec3 & v,
-                                                                   sofa::simulation::Node::SPtr & father);
+                                                                   sofa::core::sptr<sofa::simulation::Node> & father);
 
 SOFA_SOFATEST_API sofa::component::collision::SphereCollisionModel<sofa::defaulttype::Rigid3Types>::SPtr makeRigidSphere(const Vec3 & p,SReal radius,const Vec3 &v,const double *angles,const int *order,
-                                                                            sofa::simulation::Node::SPtr & father);
+                                                                            sofa::core::sptr<sofa::simulation::Node> & father);
 
-SOFA_SOFATEST_API sofa::component::collision::SphereCollisionModel<sofa::defaulttype::Vec3Types>::SPtr makeSphere(const Vec3 & p,SReal radius,const Vec3 & v,sofa::simulation::Node::SPtr & father);
+SOFA_SOFATEST_API sofa::component::collision::SphereCollisionModel<sofa::defaulttype::Vec3Types>::SPtr makeSphere(const Vec3 & p,SReal radius,const Vec3 & v,sofa::core::sptr<sofa::simulation::Node> & father);
 
 void rotx(double ax,Vec3 & x,Vec3 & y,Vec3 & z);
 

--- a/applications/plugins/SofaTest/Sofa_test.h
+++ b/applications/plugins/SofaTest/Sofa_test.h
@@ -28,6 +28,7 @@
 #include <sofa/helper/testing/BaseTest.h>
 #include <sofa/helper/testing/NumericTest.h>
 #include <SofaSimulationGraph/testing/BaseSimulationTest.h>
+#include <sofa/simulation/Node.h>
 
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/defaulttype/VecTypes.h>

--- a/applications/projects/SofaGuiGlut/SimpleGUI.h
+++ b/applications/projects/SofaGuiGlut/SimpleGUI.h
@@ -84,7 +84,7 @@ public:
     /// @name registration of each GUI
     /// @{
 
-    static BaseGUI* CreateGUI(const char* name, sofa::simulation::Node::SPtr groot = NULL, const char* filename = nullptr);
+    static BaseGUI* CreateGUI(const char* name, sofa::core::sptr<sofa::simulation::Node> groot = NULL, const char* filename = nullptr);
     void setViewerResolution(int width , int height) override;
     /// @}
 
@@ -127,7 +127,7 @@ private:
     enum { MINMOVE = 10 };
 
 
-    sofa::simulation::Node::SPtr groot;
+    sofa::core::sptr<sofa::simulation::Node> groot;
     std::string sceneFileName;
     sofa::component::visualmodel::BaseCamera::SPtr currentCamera;
 
@@ -201,7 +201,7 @@ protected:
     void calcProjection();
 
 public:
-    void setScene(sofa::simulation::Node::SPtr scene, const char* filename=nullptr, bool temporaryFile=false);
+    void setScene(sofa::core::sptr<sofa::simulation::Node> scene, const char* filename=nullptr, bool temporaryFile=false);
     sofa::simulation::Node* getScene()
     {
         return groot.get();
@@ -237,7 +237,7 @@ public:
     int _mouseInteractorSavedPosY;
 
     static int     InitGUI(const char* /*name*/, const std::vector<std::string>& /*options*/);
-    static sofa::gui::BaseGUI* CreateGUI(const char* /*name*/, const std::vector<std::string>& /*options*/, sofa::simulation::Node::SPtr groot, const char* filename);
+    static sofa::gui::BaseGUI* CreateGUI(const char* /*name*/, const std::vector<std::string>& /*options*/, sofa::core::sptr<sofa::simulation::Node> groot, const char* filename);
 private:
 
     void	InitGFX();

--- a/applications/projects/SofaPhysicsAPI/SofaPhysicsSimulation.h
+++ b/applications/projects/SofaPhysicsAPI/SofaPhysicsSimulation.h
@@ -83,7 +83,7 @@ public:
 protected:
 
     sofa::simulation::Simulation* m_Simulation;
-    sofa::simulation::Node::SPtr m_RootNode;
+    sofa::core::sptr<sofa::simulation::Node> m_RootNode;
     std::string sceneFileName;
     sofa::component::visualmodel::BaseCamera::SPtr currentCamera;
 
@@ -140,7 +140,7 @@ public:
         return m_RootNode.get();
     }
 
-    sofa::simulation::Node::SPtr getRootNode() const
+    sofa::core::sptr<sofa::simulation::Node> getRootNode() const
     {
         return m_RootNode;
     }

--- a/applications/projects/SofaPhysicsAPI/SofaPhysicsSimulation.h
+++ b/applications/projects/SofaPhysicsAPI/SofaPhysicsSimulation.h
@@ -28,6 +28,7 @@
 #include "SofaPhysicsDataController_impl.h"
 
 #include <sofa/simulation/Simulation.h>
+#include <sofa/simulation/Node.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/visual/DrawToolGL.h>
 #include <SofaBaseVisual/InteractiveCamera.h>

--- a/applications/projects/SofaPhysicsAPI/fakegui.h
+++ b/applications/projects/SofaPhysicsAPI/fakegui.h
@@ -37,7 +37,7 @@ public:
     int mainLoop() override {return 0;}
     void redraw() override {}
     int closeGUI() override {return 0;}
-    virtual void setScene(sofa::simulation::Node::SPtr /*groot*/, const char* /*filename*/=nullptr, bool /*temporaryFile*/=false) override {}
+    virtual void setScene(sofa::core::sptr<sofa::simulation::Node> /*groot*/, const char* /*filename*/=nullptr, bool /*temporaryFile*/=false) override {}
     sofa::simulation::Node* currentSimulation() override {return nullptr;}
     /// @}
 

--- a/modules/SofaBoundaryCondition/AffineMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/AffineMovementConstraint.inl
@@ -28,6 +28,7 @@
 #include <sofa/simulation/Simulation.h>
 #include <iostream>
 #include <sofa/helper/cast.h>
+#include <sofa/simulation/Node.h>
 
 #include <SofaBoundaryCondition/AffineMovementConstraint.h>
 
@@ -186,7 +187,7 @@ void AffineMovementConstraint<DataTypes>::projectVelocity(const core::Mechanical
 template <class DataTypes>
 void AffineMovementConstraint<DataTypes>::projectPosition(const core::MechanicalParams* /*mparams*/, DataVecCoord& xData)
 {
-    sofa::simulation::Node::SPtr root = down_cast<sofa::simulation::Node>( this->getContext()->getRootContext() );
+    sofa::core::sptr<sofa::simulation::Node> root = down_cast<sofa::simulation::Node>( this->getContext()->getRootContext() );
     helper::WriteAccessor<DataVecCoord> x = xData;
     const SetIndexArray & indices = m_indices.getValue();
 

--- a/modules/SofaBoundaryCondition/FixedPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/FixedPlaneConstraint.inl
@@ -27,6 +27,7 @@
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/defaulttype/VecTypes.h>
+#include <sofa/defaulttype/BaseMatrix.h>
 
 #include <SofaBaseTopology/TopologySubsetData.inl>
 

--- a/modules/SofaBoundaryCondition/PatchTestMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/PatchTestMovementConstraint.inl
@@ -277,7 +277,7 @@ void PatchTestMovementConstraint<DataTypes>::projectVelocity(const core::Mechani
 template <class DataTypes>
 void PatchTestMovementConstraint<DataTypes>::projectPosition(const core::MechanicalParams* /*mparams*/, DataVecCoord& xData)
 {
-    sofa::simulation::Node::SPtr root = down_cast<sofa::simulation::Node>( this->getContext()->getRootContext() );
+    sofa::core::sptr<sofa::simulation::Node> root = down_cast<sofa::simulation::Node>( this->getContext()->getRootContext() );
     helper::WriteAccessor<DataVecCoord> x = xData;
     const SetIndexArray & indices = d_indices.getValue();
 

--- a/modules/SofaBoundaryCondition/PatchTestMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/PatchTestMovementConstraint.inl
@@ -29,6 +29,7 @@
 #include <sofa/simulation/Simulation.h>
 #include <iostream>
 #include <sofa/helper/cast.h>
+#include <sofa/simulation/Node.h>
 
 
 namespace sofa

--- a/modules/SofaBoundaryCondition/SkeletalMotionConstraint.inl
+++ b/modules/SofaBoundaryCondition/SkeletalMotionConstraint.inl
@@ -22,6 +22,7 @@
 #ifndef SOFA_COMPONENT_PROJECTIVECONSTRAINTSET_SKELETALMOTIONCONSTRAINT_INL
 #define SOFA_COMPONENT_PROJECTIVECONSTRAINTSET_SKELETALMOTIONCONSTRAINT_INL
 
+#include <sofa/defaulttype/BaseMatrix.h>
 #include <SofaBoundaryCondition/SkeletalMotionConstraint.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/topology/BaseMeshTopology.h>

--- a/modules/SofaBoundaryCondition/SofaBoundaryCondition_test/ProjectDirectionConstraint_test.cpp
+++ b/modules/SofaBoundaryCondition/SofaBoundaryCondition_test/ProjectDirectionConstraint_test.cpp
@@ -29,7 +29,7 @@
 #include <sofa/defaulttype/VecTypes.h>
 
 #include <SofaTest/TestMessageHandler.h>
-
+#include <sofa/simulation/Node.h>
 
 namespace sofa {
 

--- a/modules/SofaBoundaryCondition/SofaBoundaryCondition_test/ProjectToLineConstraint_test.cpp
+++ b/modules/SofaBoundaryCondition/SofaBoundaryCondition_test/ProjectToLineConstraint_test.cpp
@@ -30,6 +30,8 @@
 
 #include <SofaTest/TestMessageHandler.h>
 
+#include <sofa/simulation/Node.h>
+
 
 namespace sofa {
 using namespace component;

--- a/modules/SofaBoundaryCondition/SofaBoundaryCondition_test/ProjectToPlaneConstraint_test.cpp
+++ b/modules/SofaBoundaryCondition/SofaBoundaryCondition_test/ProjectToPlaneConstraint_test.cpp
@@ -29,6 +29,7 @@
 #include <sofa/defaulttype/VecTypes.h>
 
 #include <SofaTest/TestMessageHandler.h>
+#include <sofa/simulation/Node.h>
 
 
 namespace sofa {

--- a/modules/SofaBoundaryCondition/SofaBoundaryCondition_test/ProjectToPointConstraint_test.cpp
+++ b/modules/SofaBoundaryCondition/SofaBoundaryCondition_test/ProjectToPointConstraint_test.cpp
@@ -31,7 +31,7 @@
 #include <sofa/defaulttype/VecTypes.h>
 
 #include <SofaTest/TestMessageHandler.h>
-
+#include <sofa/simulation/Node.h>
 
 namespace sofa {
 namespace {

--- a/modules/SofaBoundaryCondition/SofaBoundaryCondition_test/SkeletalMotionConstraint_test.cpp
+++ b/modules/SofaBoundaryCondition/SofaBoundaryCondition_test/SkeletalMotionConstraint_test.cpp
@@ -29,7 +29,7 @@
 #include <sofa/defaulttype/VecTypes.h>
 
 #include <SofaTest/TestMessageHandler.h>
-
+#include <sofa/simulation/Node.h>
 
 namespace sofa {
 

--- a/modules/SofaBoundaryCondition/SphereForceField.inl
+++ b/modules/SofaBoundaryCondition/SphereForceField.inl
@@ -24,6 +24,7 @@
 
 #include "SphereForceField.h"
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/defaulttype/BaseMatrix.h>
 #include <sofa/helper/rmath.h>
 #include <cassert>
 #include <iostream>

--- a/modules/SofaBoundaryCondition/SurfacePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/SurfacePressureForceField.inl
@@ -25,6 +25,7 @@
 #include <SofaBoundaryCondition/SurfacePressureForceField.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
+#include <sofa/defaulttype/BaseMatrix.h>
 #include <sofa/helper/types/RGBAColor.h>
 #include <vector>
 #include <set>

--- a/modules/SofaBoundaryCondition/UniformVelocityDampingForceField.inl
+++ b/modules/SofaBoundaryCondition/UniformVelocityDampingForceField.inl
@@ -23,7 +23,7 @@
 #define SOFA_COMPONENT_FORCEFIELD_UNIFORMVELOCITYDAMPINGFORCEFIELD_INL
 
 #include "UniformVelocityDampingForceField.h"
-
+#include <sofa/defaulttype/BaseMatrix.h>
 namespace sofa
 {
 

--- a/modules/SofaConstraint/GenericConstraintSolver.cpp
+++ b/modules/SofaConstraint/GenericConstraintSolver.cpp
@@ -26,6 +26,8 @@
 #include <sofa/helper/AdvancedTimer.h>
 #include <sofa/core/ObjectFactory.h>
 #include "ConstraintStoreLambdaVisitor.h"
+#include <sofa/simulation/Node.h>
+
 #include <algorithm>
 
 namespace sofa

--- a/modules/SofaConstraint/LMConstraintSolver.cpp
+++ b/modules/SofaConstraint/LMConstraintSolver.cpp
@@ -35,6 +35,9 @@
 #include <Eigen/LU>
 #include <Eigen/QR>
 
+#include <sofa/simulation/Node.h>
+
+
 namespace sofa
 {
 

--- a/modules/SofaConstraint/LMConstraintSolver.h
+++ b/modules/SofaConstraint/LMConstraintSolver.h
@@ -51,7 +51,7 @@ protected:
 
     typedef Eigen::Matrix<SReal, Eigen::Dynamic, Eigen::Dynamic> MatrixEigen;
     typedef linearsolver::VectorEigen          VectorEigen;
-    typedef defaulttype::BaseVector::Index     Index;
+    typedef sofa::defaulttype::BaseVectorIndex     Index;
     typedef linearsolver::SparseMatrixEigen    SparseMatrixEigen;
     typedef linearsolver::SparseVectorEigen    SparseVectorEigen;
 

--- a/modules/SofaConstraint/LinearSolverConstraintCorrection.h
+++ b/modules/SofaConstraint/LinearSolverConstraintCorrection.h
@@ -64,7 +64,7 @@ public:
     typedef typename DataTypes::Coord Coord;
     typedef typename DataTypes::Deriv Deriv;
 
-    typedef std::list<defaulttype::BaseMatrix::Index> ListIndex;
+    typedef std::list<defaulttype::BaseMatrixIndex> ListIndex;
     typedef sofa::core::behavior::ConstraintCorrection< TDataTypes > Inherit;
 protected:
     LinearSolverConstraintCorrection(sofa::core::behavior::MechanicalState<DataTypes> *mm = nullptr);

--- a/modules/SofaConstraint/LinearSolverConstraintCorrection.inl
+++ b/modules/SofaConstraint/LinearSolverConstraintCorrection.inl
@@ -209,7 +209,7 @@ void LinearSolverConstraintCorrection<DataTypes>::getComplianceMatrix(defaulttyp
     const unsigned int N = Deriv::size();
     const unsigned int numDOFReals = numDOFs*N;
     static linearsolver::SparseMatrix<SReal> J; //local J
-    if (J.rowSize() != (defaulttype::BaseMatrix::Index)numDOFReals)
+    if (J.rowSize() != (defaulttype::BaseMatrixIndex)numDOFReals)
     {
         J.resize(numDOFReals,numDOFReals);
         for (unsigned int i=0; i<numDOFReals; ++i)

--- a/modules/SofaConstraint/MappingGeometricStiffnessForceField.inl
+++ b/modules/SofaConstraint/MappingGeometricStiffnessForceField.inl
@@ -52,9 +52,9 @@ void MappingGeometricStiffnessForceField<DataTypes>::addKToMatrix(const sofa::co
 
     const sofa::defaulttype::BaseMatrix* mappingK = l_mapping->getK();
 
-    for (sofa::defaulttype::BaseMatrix::Index i = 0; i < mappingK->rowSize(); ++i)
+    for (sofa::defaulttype::BaseMatrixIndex i = 0; i < mappingK->rowSize(); ++i)
     {
-        for (sofa::defaulttype::BaseMatrix::Index j = 0; j < mappingK->colSize(); ++j)
+        for (sofa::defaulttype::BaseMatrixIndex j = 0; j < mappingK->colSize(); ++j)
         {
             mat->add(offset + i, offset + j, mappingK->element(i, j)*kFact);
         }

--- a/modules/SofaExporter/SofaExporter_test/MeshExporter_test.cpp
+++ b/modules/SofaExporter/SofaExporter_test/MeshExporter_test.cpp
@@ -34,6 +34,8 @@ using sofa::core::objectmodel::BaseObject ;
 #include <SofaSimulationGraph/DAGSimulation.h>
 using sofa::simulation::Simulation ;
 using sofa::simulation::graph::DAGSimulation ;
+
+#include <sofa/simulation/Node.h>
 using sofa::simulation::Node ;
 
 #include <SofaSimulationCommon/SceneLoaderXML.h>

--- a/modules/SofaExporter/SofaExporter_test/OBJExporter_test.cpp
+++ b/modules/SofaExporter/SofaExporter_test/OBJExporter_test.cpp
@@ -34,6 +34,8 @@ using sofa::core::objectmodel::BaseObject ;
 #include <SofaSimulationGraph/DAGSimulation.h>
 using sofa::simulation::Simulation ;
 using sofa::simulation::graph::DAGSimulation ;
+
+#include <sofa/simulation/Node.h>
 using sofa::simulation::Node ;
 
 #include <SofaSimulationCommon/SceneLoaderXML.h>

--- a/modules/SofaExporter/SofaExporter_test/WriteState_test.cpp
+++ b/modules/SofaExporter/SofaExporter_test/WriteState_test.cpp
@@ -29,6 +29,8 @@ using sofa::helper::testing::BaseTest;
 
 #include <SofaSimulationGraph/DAGSimulation.h>
 
+#include <sofa/simulation/Node.h>
+
 #include <SofaImplicitOdeSolver/EulerImplicitSolver.h>
 #include <SofaGeneralImplicitOdeSolver/VariationalSymplecticSolver.h>
 #include <SofaBaseLinearSolver/CGLinearSolver.h>

--- a/modules/SofaExporter/src/SofaExporter/BlenderExporter.inl
+++ b/modules/SofaExporter/src/SofaExporter/BlenderExporter.inl
@@ -180,7 +180,7 @@ namespace sofa
                                 pos[2] = (float)x[2];
 
                                 Deriv v;
-                                if((mmodel->read(core::ConstVecDerivId::velocity())) && ( (defaulttype::BaseVector::Index)mmodel->readVelocities().size()>i))
+                                if((mmodel->read(core::ConstVecDerivId::velocity())) && ( (sofa::defaulttype::BaseVectorIndex)mmodel->readVelocities().size()>i))
                                 {
                                     v =mmodel->readVelocities()[i];
                                     vel[0] = (float)v[0]; 
@@ -189,7 +189,7 @@ namespace sofa
                                 }
 
                                 Coord x0;
-                                if((mmodel->read(core::ConstVecCoordId::restPosition())) && ( (defaulttype::BaseVector::Index)mmodel->readRestPositions().size()>i))
+                                if((mmodel->read(core::ConstVecCoordId::restPosition())) && ( (sofa::defaulttype::BaseVectorIndex)mmodel->readRestPositions().size()>i))
                                 {
                                     x0 =mmodel->readRestPositions()[i];
                                     rest[0] = (float)x0[0]; 

--- a/modules/SofaExporter/src/SofaExporter/WriteState.h
+++ b/modules/SofaExporter/src/SofaExporter/WriteState.h
@@ -31,7 +31,7 @@
 #include <sofa/simulation/AnimateEndEvent.h>
 #include <sofa/defaulttype/DataTypeInfo.h>
 #include <sofa/simulation/Visitor.h>
-
+#include <sofa/core/objectmodel/DataFileName.h>
 #if SOFAEXPORTER_HAVE_ZLIB
 #include <zlib.h>
 #endif

--- a/modules/SofaGeneralAnimationLoop/MechanicalMatrixMapper.inl
+++ b/modules/SofaGeneralAnimationLoop/MechanicalMatrixMapper.inl
@@ -39,6 +39,9 @@
 //  Eigen Sparse Matrix
 #include <Eigen/Sparse>
 
+#include <sofa/simulation/Node.h>
+
+
 namespace sofa
 {
 

--- a/modules/SofaGeneralAnimationLoop/MechanicalMatrixMapper.inl
+++ b/modules/SofaGeneralAnimationLoop/MechanicalMatrixMapper.inl
@@ -202,7 +202,7 @@ void copyKToEigenFormat(CompressedRowSparseMatrix< T >* K, Eigen::SparseMatrix<d
     {
         row = K->rowIndex[it_rows_k] ;
         typename CompressedRowSparseMatrix<T>::Range rowRange( K->rowBegin[it_rows_k], K->rowBegin[it_rows_k+1] );
-        for(sofa::defaulttype::BaseVector::Index xj = rowRange.begin() ; xj < rowRange.end() ; xj++ )  // for each non-null block
+        for(sofa::defaulttype::BaseVectorIndex xj = rowRange.begin() ; xj < rowRange.end() ; xj++ )  // for each non-null block
         {
             int col = K->colsIndex[xj];     // block column
             const T& k = K->colsValue[xj]; // non-null element of the matrix

--- a/modules/SofaGeneralEngine/SofaGeneralEngine_test/AverageCoord_test.cpp
+++ b/modules/SofaGeneralEngine/SofaGeneralEngine_test/AverageCoord_test.cpp
@@ -38,6 +38,8 @@ using sofa::simulation::graph::DAGSimulation;
 #include <SofaGeneralEngine/AverageCoord.h>
 using sofa::component::engine::AverageCoord ;
 
+#include <sofa/simulation/Node.h>
+
 using sofa::helper::vector;
 
 

--- a/modules/SofaGeneralEngine/SofaGeneralEngine_test/ClusteringEngine_test.cpp
+++ b/modules/SofaGeneralEngine/SofaGeneralEngine_test/ClusteringEngine_test.cpp
@@ -38,6 +38,7 @@ using sofa::core::visual::VisualParams;
 #include <SofaGeneralEngine/ClusteringEngine.h>
 using sofa::component::engine::ClusteringEngine ;
 
+#include <sofa/simulation/Node.h>
 using sofa::helper::vector;
 
 namespace sofa

--- a/modules/SofaGeneralEngine/SofaGeneralEngine_test/ComplementaryROI_test.cpp
+++ b/modules/SofaGeneralEngine/SofaGeneralEngine_test/ComplementaryROI_test.cpp
@@ -22,7 +22,6 @@
 #include <SofaTest/Sofa_test.h>
 #include <SofaTest/TestMessageHandler.h>
 
-
 #include <sofa/helper/BackTrace.h>
 
 #include <SofaSimulationGraph/DAGSimulation.h>
@@ -38,6 +37,8 @@ using sofa::core::visual::VisualParams;
 
 #include <SofaGeneralEngine/ComplementaryROI.h>
 using sofa::component::engine::ComplementaryROI ;
+
+#include <sofa/simulation/Node.h>
 
 using sofa::helper::vector;
 

--- a/modules/SofaGeneralEngine/SofaGeneralEngine_test/DifferenceEngine_test.cpp
+++ b/modules/SofaGeneralEngine/SofaGeneralEngine_test/DifferenceEngine_test.cpp
@@ -39,6 +39,7 @@ using sofa::core::visual::VisualParams;
 #include <SofaGeneralEngine/DifferenceEngine.h>
 using sofa::component::engine::DifferenceEngine ;
 
+#include <sofa/simulation/Node.h>
 using sofa::helper::vector;
 
 namespace sofa

--- a/modules/SofaGeneralEngine/SofaGeneralEngine_test/DilateEngine_test.cpp
+++ b/modules/SofaGeneralEngine/SofaGeneralEngine_test/DilateEngine_test.cpp
@@ -22,7 +22,7 @@
 #include <SofaTest/Sofa_test.h>
 #include <SofaTest/TestMessageHandler.h>
 
-
+#include <sofa/simulation/Node.h>
 #include <sofa/helper/BackTrace.h>
 
 #include <SofaSimulationGraph/DAGSimulation.h>

--- a/modules/SofaGeneralEngine/SofaGeneralEngine_test/ExtrudeEdgesAndGenerateQuads_test.cpp
+++ b/modules/SofaGeneralEngine/SofaGeneralEngine_test/ExtrudeEdgesAndGenerateQuads_test.cpp
@@ -22,7 +22,7 @@
 #include <SofaTest/Sofa_test.h>
 #include <SofaTest/TestMessageHandler.h>
 
-
+#include <sofa/simulation/Node.h>
 #include <sofa/helper/BackTrace.h>
 
 #include <SofaSimulationGraph/DAGSimulation.h>

--- a/modules/SofaGeneralEngine/SofaGeneralEngine_test/SmoothMeshEngine_test.cpp
+++ b/modules/SofaGeneralEngine/SofaGeneralEngine_test/SmoothMeshEngine_test.cpp
@@ -1,6 +1,8 @@
 #include <SofaTest/Sofa_test.h>
 #include <sofa/helper/BackTrace.h>
 
+#include <sofa/simulation/Node.h>
+
 #include <SofaSimulationGraph/DAGSimulation.h>
 using sofa::simulation::Simulation ;
 using sofa::simulation::Node ;

--- a/modules/SofaGeneralLinearSolver/BTDLinearSolver.h
+++ b/modules/SofaGeneralLinearSolver/BTDLinearSolver.h
@@ -276,7 +276,7 @@ class BTDMatrix : public defaulttype::BaseMatrix
 public:
     enum { BSIZE = N };
     typedef T Real;
-    typedef typename defaulttype::BaseMatrix::Index Index;
+    typedef typename defaulttype::BaseMatrixIndex Index;
 
     class TransposedBloc
     {

--- a/modules/SofaGeneralLoader/ReadState.cpp
+++ b/modules/SofaGeneralLoader/ReadState.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #include <SofaGeneralLoader/ReadState.inl>
 #include <sofa/core/ObjectFactory.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/modules/SofaGeneralLoader/ReadState.h
+++ b/modules/SofaGeneralLoader/ReadState.h
@@ -26,6 +26,7 @@
 #include <sofa/simulation/AnimateBeginEvent.h>
 #include <sofa/simulation/AnimateEndEvent.h>
 #include <sofa/simulation/Visitor.h>
+#include <sofa/core/objectmodel/DataFileName.h>
 
 #if SOFAGENERALLOADER_HAVE_ZLIB
 #include <zlib.h>

--- a/modules/SofaGeneralLoader/ReadTopology.cpp
+++ b/modules/SofaGeneralLoader/ReadTopology.cpp
@@ -21,7 +21,8 @@
 ******************************************************************************/
 #include <SofaGeneralLoader/ReadTopology.inl>
 #include <sofa/core/ObjectFactory.h>
-
+#include <sofa/simulation/Node.h>
+#include <sofa/core/MechanicalParams.h>
 namespace sofa
 {
 

--- a/modules/SofaGeneralLoader/ReadTopology.h
+++ b/modules/SofaGeneralLoader/ReadTopology.h
@@ -23,6 +23,7 @@
 #define SOFA_COMPONENT_MISC_READTOPOLOGY_H
 #include <SofaGeneralLoader/config.h>
 
+#include <sofa/core/objectmodel/DataFileName.h>
 #include <sofa/simulation/AnimateBeginEvent.h>
 #include <sofa/simulation/AnimateEndEvent.h>
 #include <sofa/simulation/Visitor.h>

--- a/modules/SofaGeneralLoader/ReadTopology.inl
+++ b/modules/SofaGeneralLoader/ReadTopology.inl
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #ifndef SOFA_COMPONENT_MISC_READTOPOLOGY_INL
 #define SOFA_COMPONENT_MISC_READTOPOLOGY_INL
-
+#include <sofa/core/topology/BaseMeshTopology.h>
 #include <SofaGeneralLoader/ReadTopology.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/simulation/MechanicalVisitor.h>

--- a/modules/SofaGraphComponent/PauseAnimation.cpp
+++ b/modules/SofaGraphComponent/PauseAnimation.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #include <SofaGraphComponent/PauseAnimation.h>
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/modules/SofaGraphComponent/SceneCheckMissingRequiredPlugin.cpp
+++ b/modules/SofaGraphComponent/SceneCheckMissingRequiredPlugin.cpp
@@ -25,6 +25,7 @@
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/simulation/Visitor.h>
 #include <sofa/helper/system/PluginManager.h>
+#include <sofa/simulation/Node.h>
 
 #include <SofaBaseUtils/RequiredPlugin.h>
 

--- a/modules/SofaGraphComponent/SceneCheckerListener.cpp
+++ b/modules/SofaGraphComponent/SceneCheckerListener.cpp
@@ -51,7 +51,7 @@ SceneCheckerListener* SceneCheckerListener::getInstance()
     return &sceneLoaderListener;
 }
 
-void SceneCheckerListener::rightAfterLoadingScene(sofa::simulation::Node::SPtr node)
+void SceneCheckerListener::rightAfterLoadingScene(sofa::core::sptr<sofa::simulation::Node>& node)
 {
     if(node.get())
         m_sceneChecker.validate(node.get());

--- a/modules/SofaGraphComponent/SceneCheckerListener.h
+++ b/modules/SofaGraphComponent/SceneCheckerListener.h
@@ -45,11 +45,11 @@ public:
     static SceneCheckerListener* getInstance();
     virtual ~SceneCheckerListener() {}
 
-    virtual void rightAfterLoadingScene(Node::SPtr node) override;
+    virtual void rightAfterLoadingScene(Node::SPtr& node) override;
 
     // Do nothing on reload
     virtual void rightBeforeReloadingScene() override {}
-    virtual void rightAfterReloadingScene(Node::SPtr node) override
+    virtual void rightAfterReloadingScene(Node::SPtr& node) override
     {
         SOFA_UNUSED(node);
     }

--- a/modules/SofaGraphComponent/SceneCheckerListener.h
+++ b/modules/SofaGraphComponent/SceneCheckerListener.h
@@ -23,6 +23,7 @@
 #define SOFA_SIMULATION_SCENECHECKERLISTENER_H
 
 #include "config.h"
+#include <sofa/simulation/Node.h>
 
 #include <sofa/simulation/SceneLoaderFactory.h>
 #include <sofa/simulation/Visitor.h>

--- a/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
+++ b/modules/SofaGraphComponent/SceneCheckerVisitor.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include "SceneCheckerVisitor.h"
+#include <sofa/simulation/Node.h>
 
 #include <algorithm>
 #include <sofa/version.h>

--- a/modules/SofaGuiCommon/src/sofa/gui/BaseGUI.cpp
+++ b/modules/SofaGuiCommon/src/sofa/gui/BaseGUI.cpp
@@ -63,7 +63,7 @@ BaseGUI::~BaseGUI()
 
 }
 
-void BaseGUI::configureGUI(sofa::simulation::Node::SPtr groot)
+void BaseGUI::configureGUI(sofa::core::sptr<sofa::simulation::Node> groot)
 {
 
     sofa::component::configurationsetting::SofaDefaultPathSetting *defaultPath;

--- a/modules/SofaGuiCommon/src/sofa/gui/BaseGUI.h
+++ b/modules/SofaGuiCommon/src/sofa/gui/BaseGUI.h
@@ -55,13 +55,13 @@ public:
     /// Close the GUI
     virtual int closeGUI()=0;
     /// Register the scene in our GUI
-    virtual void setScene(sofa::simulation::Node::SPtr groot, const char* filename=nullptr, bool temporaryFile=false)=0;
+    virtual void setScene(sofa::core::sptr<sofa::simulation::Node> groot, const char* filename=nullptr, bool temporaryFile=false)=0;
     /// Get the rootNode of the sofa scene
     virtual sofa::simulation::Node* currentSimulation() = 0;
     /// @}
 
     /// Use a component setting to configure our GUI
-    virtual void configureGUI(sofa::simulation::Node::SPtr groot);
+    virtual void configureGUI(sofa::core::sptr<sofa::simulation::Node> groot);
 
     /// @name methods to configure the GUI
     /// @{

--- a/modules/SofaGuiCommon/src/sofa/gui/BaseViewer.cpp
+++ b/modules/SofaGuiCommon/src/sofa/gui/BaseViewer.cpp
@@ -65,7 +65,7 @@ void BaseViewer::setSceneFileName(const std::string &f)
     sceneFileName = f;
 }
 
-void BaseViewer::setScene(sofa::simulation::Node::SPtr scene, const char* filename /* = nullptr */, bool /* = false */)
+void BaseViewer::setScene(sofa::core::sptr<sofa::simulation::Node> scene, const char* filename /* = nullptr */, bool /* = false */)
 {
     std::string prefix = "";
     if (filename)

--- a/modules/SofaGuiCommon/src/sofa/gui/BaseViewer.h
+++ b/modules/SofaGuiCommon/src/sofa/gui/BaseViewer.h
@@ -55,7 +55,7 @@
 #include <SofaBaseVisual/InteractiveCamera.h>
 
 #include <sofa/helper/io/Image.h>
-
+#include <sofa/simulation/Node.h>
 #include <string>
 
 namespace sofa
@@ -83,7 +83,7 @@ public:
     virtual sofa::simulation::Node* getScene();
     virtual const std::string& getSceneFileName();
     virtual void setSceneFileName(const std::string &f);
-    virtual void setScene(sofa::simulation::Node::SPtr scene, const char* filename = nullptr, bool /*keepParams*/= false);
+    virtual void setScene(sofa::core::sptr<sofa::simulation::Node> scene, const char* filename = nullptr, bool /*keepParams*/= false);
     virtual void setCameraMode(core::visual::VisualParams::CameraType);
 
     /// true when the viewer keep the hand on the render
@@ -145,7 +145,7 @@ protected:
     virtual void redraw() = 0;
 
     /// the sofa root note of the current scene
-    sofa::simulation::Node::SPtr groot;
+    sofa::core::sptr<sofa::simulation::Node> groot;
 
     sofa::component::visualmodel::BaseCamera::SPtr currentCamera;
 

--- a/modules/SofaGuiCommon/src/sofa/gui/BatchGUI.cpp
+++ b/modules/SofaGuiCommon/src/sofa/gui/BatchGUI.cpp
@@ -110,7 +110,7 @@ int BatchGUI::closeGUI()
     return 0;
 }
 
-void BatchGUI::setScene(sofa::simulation::Node::SPtr groot, const char* filename, bool )
+void BatchGUI::setScene(sofa::core::sptr<sofa::simulation::Node> groot, const char* filename, bool )
 {
     this->groot = groot;
     this->filename = (filename?filename:"");
@@ -158,7 +158,7 @@ sofa::simulation::Node* BatchGUI::currentSimulation()
     return groot.get();
 }
 
-BaseGUI* BatchGUI::CreateGUI(const char* name, sofa::simulation::Node::SPtr groot, const char* filename)
+BaseGUI* BatchGUI::CreateGUI(const char* name, sofa::core::sptr<sofa::simulation::Node> groot, const char* filename)
 {
     BatchGUI::mGuiName = name;
     BatchGUI* gui = new BatchGUI();

--- a/modules/SofaGuiCommon/src/sofa/gui/BatchGUI.h
+++ b/modules/SofaGuiCommon/src/sofa/gui/BatchGUI.h
@@ -45,7 +45,7 @@ public:
 
     BatchGUI();
 
-    void setScene(sofa::simulation::Node::SPtr groot, const char* filename="", bool temporaryFile=false) override;
+    void setScene(sofa::core::sptr<sofa::simulation::Node> groot, const char* filename="", bool temporaryFile=false) override;
 
     void resetScene();
 
@@ -78,7 +78,7 @@ public:
     /// @name registration of each GUI
     /// @{
 
-    static BaseGUI* CreateGUI(const char* name, sofa::simulation::Node::SPtr groot = nullptr, const char* filename = nullptr);
+    static BaseGUI* CreateGUI(const char* name, sofa::core::sptr<sofa::simulation::Node> groot = nullptr, const char* filename = nullptr);
     static int RegisterGUIParameters(ArgumentParser* argumentParser);
 
 
@@ -94,7 +94,7 @@ protected:
 
     std::ostringstream m_dumpVisitorStream;
 
-    sofa::simulation::Node::SPtr groot;
+    sofa::core::sptr<sofa::simulation::Node> groot;
     std::string filename;
     static signed int nbIter;
     static std::string nbIterInp;

--- a/modules/SofaGuiCommon/src/sofa/gui/GUIManager.cpp
+++ b/modules/SofaGuiCommon/src/sofa/gui/GUIManager.cpp
@@ -228,7 +228,7 @@ int GUIManager::Init(const char* argv0, const char* name)
 }
 
 
-int GUIManager::createGUI(sofa::simulation::Node::SPtr groot, const char* filename)
+int GUIManager::createGUI(sofa::core::sptr<sofa::simulation::Node> groot, const char* filename)
 {
     if (!currentGUI)
     {
@@ -270,7 +270,7 @@ sofa::simulation::Node* GUIManager::CurrentSimulation()
         return nullptr;
 }
 
-void GUIManager::SetScene(sofa::simulation::Node::SPtr groot, const char* filename /*=nullptr*/, bool temporaryFile /*=false*/ )
+void GUIManager::SetScene(sofa::core::sptr<sofa::simulation::Node> groot, const char* filename /*=nullptr*/, bool temporaryFile /*=false*/ )
 {
     if (currentGUI)
     {
@@ -280,7 +280,7 @@ void GUIManager::SetScene(sofa::simulation::Node::SPtr groot, const char* filena
 
 }
 
-int GUIManager::MainLoop(sofa::simulation::Node::SPtr groot, const char* filename)
+int GUIManager::MainLoop(sofa::core::sptr<sofa::simulation::Node> groot, const char* filename)
 {
     int ret = 0;
     if (!currentGUI)

--- a/modules/SofaGuiCommon/src/sofa/gui/GUIManager.h
+++ b/modules/SofaGuiCommon/src/sofa/gui/GUIManager.h
@@ -37,12 +37,12 @@ namespace sofa
 namespace gui
 {
 class BaseGUI;
-
+using sofa::simulation::Node;
 
 class SOFA_SOFAGUICOMMON_API GUIManager
 {
 public:
-    typedef BaseGUI* CreateGUIFn(const char* name, sofa::simulation::Node::SPtr groot, const char* filename);
+    typedef BaseGUI* CreateGUIFn(const char* name, sofa::core::sptr<sofa::simulation::Node> groot, const char* filename);
     typedef int RegisterGUIParameters(ArgumentParser* argumentParser);
 
     struct GUICreator
@@ -69,18 +69,18 @@ public:
     static std::vector<std::string> ListSupportedGUI();
     static std::string ListSupportedGUI(char separator);
     static void RegisterParameters(ArgumentParser* parser);
-    static int createGUI(sofa::simulation::Node::SPtr groot = nullptr, const char* filename = nullptr);
+    static int createGUI(sofa::core::sptr<sofa::simulation::Node> groot = nullptr, const char* filename = nullptr);
     static void closeGUI();
 
     /// @name Static methods for direct access to GUI
     /// @{
-    static int MainLoop(sofa::simulation::Node::SPtr groot = nullptr, const char* filename = nullptr);
+    static int MainLoop(sofa::core::sptr<sofa::simulation::Node> groot = nullptr, const char* filename = nullptr);
 
     static void Redraw();
 
     static sofa::simulation::Node* CurrentSimulation();
 
-    static void SetScene(sofa::simulation::Node::SPtr groot, const char* filename=nullptr, bool temporaryFile=false);
+    static void SetScene(sofa::core::sptr<sofa::simulation::Node> groot, const char* filename=nullptr, bool temporaryFile=false);
     static void SetDimension(int  width , int  height );
     static void SetFullScreen();
     static void SaveScreenshot(const char* filename);

--- a/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
@@ -227,7 +227,7 @@ public:
 
 //======================= STATIC METHODS ========================= {
 
-BaseGUI* RealGUI::CreateGUI ( const char* name, sofa::simulation::Node::SPtr root, const char* filename )
+BaseGUI* RealGUI::CreateGUI ( const char* name, sofa::core::sptr<sofa::simulation::Node> root, const char* filename )
 {
 
     CreateApplication();

--- a/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.h
@@ -118,7 +118,7 @@ class SOFA_SOFAGUIQT_API RealGUI : public QMainWindow, public Ui::GUI, public so
 
 //-----------------STATIC METHODS------------------------{
 public:
-    static BaseGUI* CreateGUI(const char* name, sofa::simulation::Node::SPtr groot = nullptr, const char* filename = nullptr);
+    static BaseGUI* CreateGUI(const char* name, sofa::core::sptr<sofa::simulation::Node> groot = nullptr, const char* filename = nullptr);
 
     static void SetPixmap(std::string pixmap_filename, QPushButton* b);
 
@@ -334,7 +334,7 @@ protected:
         while (goal > clock()/(float)CLOCKS_PER_SEC) t++;
     }
 
-    sofa::simulation::Node::SPtr mSimulation;
+    sofa::core::sptr<sofa::simulation::Node> mSimulation;
 
     sofa::helper::system::FileEventListener* m_filelistener {nullptr};
 private:

--- a/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
+++ b/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
@@ -81,7 +81,7 @@ public:
     void saveView();
     void initializeGL();
     void paintGL();
-    void setScene(sofa::simulation::Node::SPtr scene, const char* filename=NULL, bool temporaryFile=false) override;
+    void setScene(sofa::core::sptr<sofa::simulation::Node> scene, const char* filename=NULL, bool temporaryFile=false) override;
     void newView();
 
     // Virtual from BaseGUI
@@ -90,7 +90,7 @@ public:
     virtual void setViewerResolution(int width, int height) override;
 
     // Needed for the registration
-    static BaseGUI* CreateGUI(const char* name, sofa::simulation::Node::SPtr groot = NULL, const char* filename = NULL);
+    static BaseGUI* CreateGUI(const char* name, sofa::core::sptr<sofa::simulation::Node> groot = NULL, const char* filename = NULL);
     static int RegisterGUIParameters(ArgumentParser* argumentParser);
     static void parseRecordingModeOption();
 
@@ -109,7 +109,7 @@ private:
     VisualParams* vparams;
     DrawToolGL   drawTool;
 
-    sofa::simulation::Node::SPtr groot;
+    sofa::core::sptr<sofa::simulation::Node> groot;
     std::string sceneFileName;
     sofa::component::visualmodel::BaseCamera::SPtr currentCamera;
 

--- a/modules/SofaMiscFem/SofaMiscFem_test/TetrahedronHyperelasticityFEMForceField_params_test.cpp
+++ b/modules/SofaMiscFem/SofaMiscFem_test/TetrahedronHyperelasticityFEMForceField_params_test.cpp
@@ -26,6 +26,8 @@
 #include <SofaTest/Sofa_test.h>
 #include <SofaTest/TestMessageHandler.h>
 
+#include <sofa/simulation/Node.h>
+
 #include <SofaBaseMechanics/MechanicalObject.h>
 #include <SofaMiscFem/TetrahedronHyperelasticityFEMForceField.h>
 

--- a/modules/SofaMiscFem/SofaMiscFem_test/TetrahedronHyperelasticityFEMForceField_scene_test.cpp
+++ b/modules/SofaMiscFem/SofaMiscFem_test/TetrahedronHyperelasticityFEMForceField_scene_test.cpp
@@ -26,6 +26,8 @@
 #include <SofaTest/Sofa_test.h>
 #include <SofaTest/TestMessageHandler.h>
 
+#include <sofa/simulation/Node.h>
+
 #include <SofaBaseMechanics/MechanicalObject.h>
 #include <SofaMiscFem/TetrahedronHyperelasticityFEMForceField.h>
 

--- a/modules/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/MeshMatrixMass.inl
@@ -2075,7 +2075,7 @@ SReal MeshMatrixMass<DataTypes, MassType>::getElementMass(index_type index) cons
 template <class DataTypes, class MassType>
 void MeshMatrixMass<DataTypes, MassType>::getElementMass(index_type index, defaulttype::BaseMatrix *m) const
 {
-    static const defaulttype::BaseMatrix::Index dimension = defaulttype::BaseMatrix::Index(defaulttype::DataTypeInfo<Deriv>::size());
+    static const defaulttype::BaseMatrixIndex dimension = defaulttype::BaseMatrixIndex(defaulttype::DataTypeInfo<Deriv>::size());
     if (m->rowSize() != dimension || m->colSize() != dimension) m->resize(dimension,dimension);
 
     m->clear();

--- a/modules/SofaPreconditioner/src/SofaPreconditioner/PrecomputedWarpPreconditioner.inl
+++ b/modules/SofaPreconditioner/src/SofaPreconditioner/PrecomputedWarpPreconditioner.inl
@@ -41,6 +41,7 @@
 #include <sofa/core/behavior/LinearSolver.h>
 
 #include <sofa/helper/Quater.h>
+#include <sofa/simulation/Node.h>
 
 #include <SofaImplicitOdeSolver/EulerImplicitSolver.h>
 #include <SofaBaseLinearSolver/CGLinearSolver.h>

--- a/modules/SofaPreconditioner/src/SofaPreconditioner/PrecomputedWarpPreconditioner.inl
+++ b/modules/SofaPreconditioner/src/SofaPreconditioner/PrecomputedWarpPreconditioner.inl
@@ -160,7 +160,7 @@ void PrecomputedWarpPreconditioner<TDataTypes>::loadMatrix(TMatrix& M)
 
     if (share_matrix.getValue()) internalData.setMinv(internalData.getSharedMatrix(fname));
 
-    if (share_matrix.getValue() && internalData.MinvPtr->rowSize() == (defaulttype::BaseMatrix::Index)systemSize)
+    if (share_matrix.getValue() && internalData.MinvPtr->rowSize() == (defaulttype::BaseMatrixIndex)systemSize)
     {
         msg_info("PrecomputedWarpPreconditioner") << "shared matrix : " << fname << " is already built." ;
     }

--- a/modules/SofaUserInteraction/AddRecordedCameraPerformer.cpp
+++ b/modules/SofaUserInteraction/AddRecordedCameraPerformer.cpp
@@ -46,7 +46,7 @@ namespace sofa
 
             void AddRecordedCameraPerformer::start()
             {
-                sofa::simulation::Node::SPtr root = down_cast<sofa::simulation::Node>( interactor->getContext()->getRootContext() );
+                sofa::core::sptr<sofa::simulation::Node> root = down_cast<sofa::simulation::Node>( interactor->getContext()->getRootContext() );
                 if(root)
                 {
                     sofa::component::visualmodel::RecordedCamera* currentCamera = root->getNodeObject<sofa::component::visualmodel::RecordedCamera>();

--- a/modules/SofaUserInteraction/SleepController.cpp
+++ b/modules/SofaUserInteraction/SleepController.cpp
@@ -24,6 +24,7 @@
 #include <sofa/core/collision/Contact.h>
 #include <sofa/core/collision/ContactManager.h>
 #include <sofa/core/ObjectFactory.h>
+#include <sofa/simulation/Node.h>
 
 #include <sofa/simulation/AnimateBeginEvent.h>
 #include <sofa/simulation/AnimateEndEvent.h>

--- a/modules/SofaUserInteraction/StartNavigationPerformer.cpp
+++ b/modules/SofaUserInteraction/StartNavigationPerformer.cpp
@@ -46,7 +46,7 @@ namespace sofa
 
             void StartNavigationPerformer::start()
             {
-                sofa::simulation::Node::SPtr root = down_cast<sofa::simulation::Node>( interactor->getContext()->getRootContext() );
+                sofa::core::sptr<sofa::simulation::Node> root = down_cast<sofa::simulation::Node>( interactor->getContext()->getRootContext() );
                 if(root)
                 {
                     sofa::component::visualmodel::RecordedCamera* currentCamera = root->getNodeObject<sofa::component::visualmodel::RecordedCamera>();

--- a/modules/SofaValidation/SofaValidation_test/Monitor_test.cpp
+++ b/modules/SofaValidation/SofaValidation_test/Monitor_test.cpp
@@ -14,6 +14,8 @@ using sofa::simulation::Node;
 using sofa::simulation::SceneLoaderXML;
 using sofa::core::ExecParams;
 
+#include <sofa/simulation/Node.h>
+
 #include <fstream>
 #include <streambuf>
 #include <string>
@@ -55,7 +57,7 @@ struct MonitorTest : public Monitor<Rigid3Types>
 
 struct Monitor_test : public sofa::Sofa_test<>
 {
-    sofa::simulation::Node::SPtr root;
+    sofa::core::sptr<sofa::simulation::Node> root;
     sofa::simulation::SceneLoaderXML loader;
     MonitorTest* monitor;
     MechanicalObject<Rigid3Types>::SPtr mo;

--- a/modules/SofaValidation/src/SofaValidation/CompareState.cpp
+++ b/modules/SofaValidation/src/SofaValidation/CompareState.cpp
@@ -28,6 +28,7 @@
 #include <SofaSimulationCommon/xml/XML.h>
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/system/SetDirectory.h>
+#include <sofa/simulation/Node.h>
 
 #include <sstream>
 #include <algorithm>

--- a/modules/SofaValidation/src/SofaValidation/CompareTopology.cpp
+++ b/modules/SofaValidation/src/SofaValidation/CompareTopology.cpp
@@ -19,10 +19,12 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <sofa/core/topology/BaseMeshTopology.h>
 #include <SofaValidation/CompareTopology.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/simulation/MechanicalVisitor.h>
 #include <sofa/simulation/UpdateMappingVisitor.h>
+#include <sofa/simulation/Node.h>
 
 #include <sstream>
 #include <sofa/core/ObjectFactory.h>


### PR DESCRIPTION
To move forward in order to be ready for c++20 modules we need to clean the dependency graph of SOFA. This PR is going in this direction by removing most of the dependency to BaseVector.h, BaseMatrix.h and StringUtils.h. 

In SOFA we often use this pattern
```cpp
class MyClass
{
public:
          typedef int Index;  
};
``` 

Which impose a dependency to the full MyClass definition to manipulate indices. 
I design pattern avoiding this problem is used in the PR. This PR work as the following: 
```cpp
/// Forward declaration
class MyClass;
typedef int MyClassIndex;

/// Definition 
class MyClass
{
public:
          typedef MyClassIndex Index;  
};
``` 

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
