### PR TITLE
[All] Change index_type from size_t to uint

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/PointSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/PointSetTopologyModifier.cpp
@@ -52,7 +52,7 @@ void PointSetTopologyModifier::init()
 }
 
 
-void PointSetTopologyModifier::swapPoints(const int i1, const int i2)
+void PointSetTopologyModifier::swapPoints(const index_type i1, const index_type i2)
 {
     PointsIndicesSwap *e2 = new PointsIndicesSwap( i1, i2 );
     addStateChange(e2);

--- a/SofaKernel/modules/SofaBaseTopology/PointSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/PointSetTopologyModifier.h
@@ -61,7 +61,7 @@ public:
     /** \brief Swap points i1 and i2.
     *
     */
-    virtual void swapPoints(const int i1,const int i2);
+    virtual void swapPoints(const index_type i1,const index_type i2);
 
     /** \brief Sends a message to warn that some points were added in this topology.
     *

--- a/SofaKernel/modules/SofaBaseTopology/TopologySubsetDataHandler.h
+++ b/SofaKernel/modules/SofaBaseTopology/TopologySubsetDataHandler.h
@@ -97,12 +97,12 @@ protected:
     using core::topology::TopologyElementHandler< TopologyElementType >::add;
 
     /// Add some values. Values are added at the end of the vector.
-    virtual void add( index_type nbElements,
+    virtual void add(std::size_t nbElements,
             const sofa::helper::vector< TopologyElementType >& ,
             const sofa::helper::vector< sofa::helper::vector< index_type > > &ancestors,
             const sofa::helper::vector< sofa::helper::vector< double > >& coefs);
 
-    virtual void add( index_type nbElements,
+    virtual void add(std::size_t nbElements,
             const sofa::helper::vector< sofa::helper::vector< index_type > > &ancestors,
             const sofa::helper::vector< sofa::helper::vector< double > >& coefs);
 

--- a/SofaKernel/modules/SofaBaseTopology/TopologySubsetDataHandler.inl
+++ b/SofaKernel/modules/SofaBaseTopology/TopologySubsetDataHandler.inl
@@ -75,7 +75,7 @@ void TopologySubsetDataHandler <TopologyElementType, VecT>::add(std::size_t nbEl
 
 
 template <typename TopologyElementType, typename VecT>
-void TopologySubsetDataHandler <TopologyElementType, VecT>::add(index_type nbElements,
+void TopologySubsetDataHandler <TopologyElementType, VecT>::add(std::size_t nbElements,
         const sofa::helper::vector< TopologyElementType >& ,
         const sofa::helper::vector<sofa::helper::vector<index_type> > &ancestors,
         const sofa::helper::vector<sofa::helper::vector<double> > &coefs)

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseMechanicalState.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseMechanicalState.h
@@ -74,7 +74,9 @@ class SOFA_CORE_API BaseMechanicalState : public virtual BaseState
 {
 public:
     SOFA_ABSTRACT_CLASS(BaseMechanicalState, BaseState);
-    SOFA_BASE_CAST_IMPLEMENTATION(BaseMechanicalState)
+    SOFA_BASE_CAST_IMPLEMENTATION(BaseMechanicalState);
+
+    using index_type = sofa::defaulttype::index_type;
 protected:
     BaseMechanicalState();
 
@@ -86,9 +88,9 @@ private:
 public:
     /// @name Methods allowing to have access to the geometry without a template class (generic but not efficient)
     /// @{
-    virtual SReal getPX(size_t /*i*/) const { return 0.0; }
-    virtual SReal getPY(size_t /*i*/) const { return 0.0; }
-    virtual SReal getPZ(size_t /*i*/) const { return 0.0; }
+    virtual SReal getPX(index_type /*i*/) const { return 0.0; }
+    virtual SReal getPY(index_type /*i*/) const { return 0.0; }
+    virtual SReal getPZ(index_type /*i*/) const { return 0.0; }
 
     /// @}
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/MechanicalState.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/MechanicalState.h
@@ -77,7 +77,7 @@ public:
     /// Sparse matrix containing derivative values (constraints)
     typedef typename DataTypes::MatrixDeriv MatrixDeriv;
 
-    using index_type = std::size_t;
+    using index_type = sofa::defaulttype::index_type;
 
 protected:
     ~MechanicalState() override {}

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopology.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopology.h
@@ -121,7 +121,7 @@ public:
 class SOFA_CORE_API TopologyModifier : public sofa::core::topology::BaseTopologyObject
 {
 public:
-    typedef std::size_t index_type;
+    typedef sofa::defaulttype::index_type index_type;
 
     SOFA_CLASS(TopologyModifier, BaseTopologyObject);
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/Topology.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/Topology.h
@@ -58,7 +58,7 @@ class SOFA_CORE_API Topology : public virtual core::objectmodel::BaseObject
 public:
     /// Topology global typedefs
     //typedef int index_type;
-    typedef std::size_t index_type;
+    typedef sofa::defaulttype::index_type index_type;
     //enum { InvalidID = sofa::defaulttype::InvalidID };
     static constexpr index_type InvalidID = sofa::defaulttype::InvalidID;
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.h
@@ -48,6 +48,8 @@ typedef Topology::Hexahedron       Hexahedron;
 class SOFA_CORE_API TopologyHandler
 {
 public:
+    using index_type = sofa::defaulttype::index_type;
+
     TopologyHandler() : lastElementIndex(0) {}
 
     virtual ~TopologyHandler() {}
@@ -151,17 +153,17 @@ public:
     virtual bool isTopologyDataRegistered() {return false;}
 
     /// Swaps values at indices i1 and i2.
-    virtual void swap(std::size_t /*i1*/, std::size_t /*i2*/ ) {}
+    virtual void swap(index_type /*i1*/, index_type /*i2*/ ) {}
 
     /// Reorder the values.
-    virtual void renumber( const sofa::helper::vector<std::size_t> &/*index*/ ) {}
+    virtual void renumber( const sofa::helper::vector<index_type> &/*index*/ ) {}
 
 protected:
     /// to handle PointSubsetData
-    void setDataSetArraySize(const std::size_t s) { lastElementIndex = s-1; }
+    void setDataSetArraySize(const index_type s) { lastElementIndex = s-1; }
 
     /// to handle properly the removal of items, the container must know the index of the last element
-    std::size_t lastElementIndex;
+    index_type lastElementIndex;
 };
 
 

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/TopologyTypes.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/TopologyTypes.h
@@ -29,7 +29,7 @@ namespace sofa
 namespace defaulttype
 {
 
-typedef std::size_t index_type;
+using index_type = unsigned int;
 constexpr index_type InvalidID = UINT_MAX;
 
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/MarchingCubeUtility.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/MarchingCubeUtility.cpp
@@ -746,7 +746,7 @@ void MarchingCubeUtility::run ( unsigned char *data, const float isolevel,
     //Do the Marching Cube
     run ( data, isolevel, triangles, vertices );
 
-    const size_t numTriangles = triangles.size() /3;
+    const auto numTriangles = triangles.size() /3;
     facets.resize ( numTriangles, vector< vector < PointID > > ( 3, vector<PointID> ( 3, 0 ) ) );
     for ( size_t i=0; i<triangles.size(); /*i+=3*/ )
     {

--- a/SofaKernel/modules/SofaMeshCollision/BarycentricContactMapper.h
+++ b/SofaKernel/modules/SofaMeshCollision/BarycentricContactMapper.h
@@ -84,7 +84,7 @@ public:
 
     MMechanicalState* createMapping(const char* name="contactPoints");
 
-    void resize(index_type size)
+    void resize(std::size_t size)
     {
         if (mapping != nullptr)
         {

--- a/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
+++ b/SofaKernel/modules/SofaMeshCollision/TriangleModel.inl
@@ -460,7 +460,7 @@ void TriangleCollisionModel<DataTypes>::computeBBox(const core::ExecParams* para
 
 
 template<class DataTypes>
-void TriangleCollisionModel<DataTypes>::draw(const core::visual::VisualParams* vparams , std::size_t index)
+void TriangleCollisionModel<DataTypes>::draw(const core::visual::VisualParams* vparams , index_type index)
 {
     Element t(this,index);
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaBarycentricMapping.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaBarycentricMapping.inl
@@ -344,7 +344,7 @@ void BarycentricMapperSparseGridTopology<gpu::cuda::CudaVectorTypes<VecIn,VecIn,
 
 
 template <typename VecIn, typename VecOut>
-void BarycentricMapperMeshTopology<gpu::cuda::CudaVectorTypes<VecIn,VecIn,float>, gpu::cuda::CudaVectorTypes<VecOut,VecOut,float> >::resizeMap(index_type size2, index_type maxNIn2)
+void BarycentricMapperMeshTopology<gpu::cuda::CudaVectorTypes<VecIn,VecIn,float>, gpu::cuda::CudaVectorTypes<VecOut,VecOut,float> >::resizeMap(std::size_t size2, std::size_t maxNIn2)
 {
     if (maxNIn2 < maxNIn) maxNIn2 = maxNIn;
     map.resize(((size2+BSIZE-1)/BSIZE)*maxNIn2);


### PR DESCRIPTION
#1453 was about to make uniform the type representing indices. But this "universal" index_type was a std::size_t which is a bit too much for our simulations (and breaks a lot of memory-dependent code such as CUDA things)
This PR change this type to unsigned int;  and fixes some forgotten index_type mistakes by the way.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
