### PR TITLE
[SofaGeneralEngine] Fix BarycentricMapperEngine parse() function

### DIFF
--- a/modules/SofaGeneralEngine/MeshBarycentricMapperEngine.h
+++ b/modules/SofaGeneralEngine/MeshBarycentricMapperEngine.h
@@ -83,7 +83,7 @@ public:
         {
             msg_warning() << "input data 'InputMeshName' changed for 'topology', please update your scene (see PR#1487)";
         }
-        MeshBarycentricMapperEngine::parse(arg);
+        core::DataEngine::parse(arg);
     }
 
 private:


### PR DESCRIPTION
Bug introduced in #1487, with an infinite loop when calling parse()
(Fix timeout with MeshBarycentricMapperEngine.scn on the CI)


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
