### PR TITLE
[SofaHelper] Quater does not depend on Vec and Mat from defaulttype anymore

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/loader/MeshLoader.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/loader/MeshLoader.h
@@ -23,6 +23,7 @@
 #define SOFA_CORE_LOADER_MESHLOADER_H
 
 #include <sofa/defaulttype/Quat.h>
+#include <sofa/defaulttype/Mat.h>
 #include <sofa/core/loader/BaseLoader.h>
 #include <sofa/core/loader/PrimitiveGroup.h>
 #include <sofa/core/topology/Topology.h>

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/HapticDeviceEvent.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/HapticDeviceEvent.h
@@ -24,6 +24,8 @@
 
 #include <sofa/core/objectmodel/Event.h>
 #include <sofa/defaulttype/Quat.h>
+#include <sofa/defaulttype/Mat.h>
+
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/visual/DrawTool.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/visual/DrawTool.h
@@ -25,7 +25,7 @@
 #include <sofa/core/config.h>
 #include <sofa/defaulttype/Quat.h>
 #include <sofa/helper/types/RGBAColor.h>
-
+#include <sofa/defaulttype/Vec.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaHelper/SofaHelper_test/Quater_test.cpp
+++ b/SofaKernel/modules/SofaHelper/SofaHelper_test/Quater_test.cpp
@@ -24,6 +24,9 @@
 #include <cstdlib>
 #include <ctime>
 
+#include <sofa/defaulttype/Vec.h>
+#include <sofa/defaulttype/Mat.h>
+
 using sofa::helper::Quater;
 
 double errorThreshold = 1e-6;

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/Quater.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/Quater.h
@@ -22,12 +22,14 @@
 #ifndef SOFA_HELPER_QUATER_H
 #define SOFA_HELPER_QUATER_H
 
+#include <sofa/helper/config.h>
+
 #include <sofa/defaulttype/Vec.h>
 #include <sofa/defaulttype/Mat.h>
 #include <cmath>
 #include <cassert>
 #include <iostream>
-#include <sofa/helper/config.h>
+#include <array>
 
 namespace sofa
 {
@@ -39,12 +41,12 @@ template<class Real>
 class SOFA_HELPER_API Quater
 {
 private:
-    Real _q[4];
+    std::array<Real, 4> _q;
 
 public:
-
     typedef Real value_type;
     typedef std::size_t size_type;
+    using Vector3 = std::array<Real, 3>;
 
     Quater();
     ~Quater();
@@ -53,12 +55,12 @@ public:
     Quater(const Real2 q[]) { for (int i=0; i<4; i++) _q[i] = Real(q[i]); }
     template<class Real2>
     Quater(const Quater<Real2>& q) { for (int i=0; i<4; i++) _q[i] = Real(q[i]); }
-    Quater( const defaulttype::Vec<3,Real>& axis, Real angle );
+    Quater( const Vector3& axis, Real angle );
 
     /** Sets this quaternion to the rotation required to rotate direction vector vFrom to direction vector vTo.        
         vFrom and vTo are assumed to be normalized.
     */
-    Quater(const defaulttype::Vec<3, Real>& vFrom, const defaulttype::Vec<3, Real>& vTo);
+    Quater(const Vector3& vFrom, const Vector3& vTo);
 
     static Quater identity()
     {
@@ -78,13 +80,13 @@ public:
     /// Cast into a standard C array of elements.
     const Real* ptr() const
     {
-        return this->_q;
+        return this->_q.data();
     }
 
     /// Cast into a standard C array of elements.
     Real* ptr()
     {
-        return this->_q;
+        return this->_q.data();
     }
 
     /// Returns true if norm of Quaternion is one, false otherwise.
@@ -101,7 +103,7 @@ public:
         _q[3]=1.0;
     }
 
-    void fromFrame(defaulttype::Vec<3,Real>& x, defaulttype::Vec<3,Real>&y, defaulttype::Vec<3,Real>&z);
+    void fromFrame(Vector3& x, Vector3&y, Vector3&z);
 
 
     void fromMatrix(const defaulttype::Matrix3 &m);
@@ -160,9 +162,9 @@ public:
 
     /// Given two Quaters, multiply them together to get a third quaternion.
 
-    Quater quatVectMult(const defaulttype::Vec<3,Real>& vect);
+    Quater quatVectMult(const Vector3& vect);
 
-    Quater vectQuatMult(const defaulttype::Vec<3,Real>& vect);
+    Quater vectQuatMult(const Vector3& vect);
 
     Real& operator[](size_type index)
     {
@@ -179,9 +181,9 @@ public:
     Quater inverse() const;
 
 
-    defaulttype::Vec<3,Real> quatToRotationVector() const;
+    auto quatToRotationVector() const;
 
-    defaulttype::Vec<3,Real> toEulerVector() const;
+    auto toEulerVector() const;
 
 
     /*! Returns the slerp interpolation of Quaternions \p a and \p b, at time \p t.
@@ -203,11 +205,11 @@ public:
     // This function computes a quaternion based on an axis (defined by
     // the given vector) and an angle about which to rotate.  The angle is
     // expressed in radians.
-    Quater axisToQuat(defaulttype::Vec<3,Real> a, Real phi);
-    void quatToAxis(defaulttype::Vec<3,Real> & a, Real &phi) const;
+    Quater axisToQuat(Vector3 a, Real phi);
+    void quatToAxis(Vector3 & a, Real &phi) const;
 
 
-    static Quater createQuaterFromFrame(const defaulttype::Vec<3, Real> &lox, const defaulttype::Vec<3, Real> &loy,const defaulttype::Vec<3, Real> &loz);
+    static Quater createQuaterFromFrame(const Vector3 &lox, const Vector3&loy,const Vector3&loz);
 
     /// Create using rotation vector (axis*angle) given in parent coordinates
     template<class V>
@@ -231,17 +233,17 @@ public:
         XYZ, YXZ, ZXY, ZYX, YZX, XZY, NONE
     };
 
-    static Quater createQuaterFromEuler( defaulttype::Vec<3,Real> v, EulerOrder order = EulerOrder::ZYX)
+    static Quater createQuaterFromEuler( Vector3 v, EulerOrder order = EulerOrder::ZYX)
     {
         Real quat[4];
 
-        Real c1 = cos( v.elems[0] / 2 );
-        Real c2 = cos( v.elems[1] / 2 );
-        Real c3 = cos( v.elems[2] / 2 );
+        Real c1 = cos( v[0] / 2 );
+        Real c2 = cos( v[1] / 2 );
+        Real c3 = cos( v[2] / 2 );
 
-        Real s1 = sin( v.elems[0] / 2 );
-        Real s2 = sin( v.elems[1] / 2 );
-        Real s3 = sin( v.elems[2] / 2 );
+        Real s1 = sin( v[0] / 2 );
+        Real s2 = sin( v[1] / 2 );
+        Real s3 = sin( v[2] / 2 );
 
         switch(order)
         {
@@ -336,7 +338,7 @@ public:
     }
 
     /// Return the eulerian vector resulting of the movement between 2 quaternions
-    defaulttype::Vec<3,Real> angularDisplacement( Quater a, const Quater& b)
+    Vector3 angularDisplacement( Quater a, const Quater& b)
     {
         return quatDiff(a,b).quatToRotationVector();    // Use of quatToRotationVector instead of toEulerVector:
                                                         // this is done to keep the old behavior (before the
@@ -344,7 +346,7 @@ public:
     }
 
     /// Sets this quaternion to the rotation required to rotate direction vector vFrom to direction vector vTo. vFrom and vTo are assumed to be normalized.
-    void setFromUnitVectors(const defaulttype::Vec<3, Real>& vFrom, const defaulttype::Vec<3, Real>& vTo);
+    void setFromUnitVectors(const Vector3& vFrom, const Vector3& vTo);
 
 
     // Print the quaternion (C style)

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/Quater.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/Quater.h
@@ -24,7 +24,6 @@
 #include <sofa/helper/config.h>
 
 #include <sofa/helper/fixed_array.h>
-#include <sofa/helper/logging/Messaging.h>
 
 #include <cmath>
 #include <cassert>
@@ -58,32 +57,15 @@ public:
     */
     Quater(const Vector3& vFrom, const Vector3& vTo);
 
-    static Quater identity()
-    {
-        return Quater(0,0,0,1);
-    }
+    static Quater identity();
 
-
-    void set(Real x, Real y, Real z, Real w)
-    {
-        _q[0] = x;
-        _q[1] = y;
-        _q[2] = z;
-        _q[3] = w;
-    }
-
+    void set(Real x, Real y, Real z, Real w);
 
     /// Cast into a standard C array of elements.
-    const Real* ptr() const
-    {
-        return this->_q.data();
-    }
+    const Real* ptr() const;
 
     /// Cast into a standard C array of elements.
-    Real* ptr()
-    {
-        return &(this->_q[0]);
-    }
+    Real* ptr();
 
     /// Returns true if norm of Quaternion is one, false otherwise.
     bool isNormalized();
@@ -91,13 +73,7 @@ public:
     /// Normalize a quaternion
     void normalize();
 
-    void clear()
-    {
-        _q[0]=0.0;
-        _q[1]=0.0;
-        _q[2]=0.0;
-        _q[3]=1.0;
-    }
+    void clear();
 
     void fromFrame(Vector3& x, Vector3&y, Vector3&z);
 
@@ -220,20 +196,10 @@ public:
 
     Quater vectQuatMult(const Vector3& vect);
 
-    Real& operator[](size_type index)
-    {
-        assert(index >= 0 && index < 4);
-        return _q[index];
-    }
-
-    const Real& operator[](size_type index) const
-    {
-        assert(index >= 0 && index < 4);
-        return _q[index];
-    }
+    Real& operator[](size_type index);
+    const Real& operator[](size_type index) const;
 
     Quater inverse() const;
-
 
     Vector3 quatToRotationVector() const;
 
@@ -262,20 +228,7 @@ public:
     Quater axisToQuat(Vector3 a, Real phi);
     void quatToAxis(Vector3 & a, Real &phi) const;
 
-    static Quater createQuaterFromFrame(const Vector3& lox, const Vector3& loy, const Vector3& loz)
-    {
-        Quater<Real> q;
-        Real m[3][3];
-
-        for (unsigned int i = 0; i < 3; i++)
-        {
-            m[i][0] = lox[i];
-            m[i][1] = loy[i];
-            m[i][2] = loz[i];
-        }
-        q.fromMatrix(m);
-        return q;
-    }
+    static Quater createQuaterFromFrame(const Vector3& lox, const Vector3& loy, const Vector3& loz);
 
     /// Create using rotation vector (axis*angle) given in parent coordinates
     template<class V>
@@ -299,71 +252,10 @@ public:
         XYZ, YXZ, ZXY, ZYX, YZX, XZY, NONE
     };
 
-    static Quater createQuaterFromEuler( Vector3 v, EulerOrder order = EulerOrder::ZYX)
-    {
-        Real quat[4];
-
-        Real c1 = cos( v[0] / 2 );
-        Real c2 = cos( v[1] / 2 );
-        Real c3 = cos( v[2] / 2 );
-
-        Real s1 = sin( v[0] / 2 );
-        Real s2 = sin( v[1] / 2 );
-        Real s3 = sin( v[2] / 2 );
-
-        switch(order)
-        {
-        case EulerOrder::XYZ:
-            quat[0] = s1 * c2 * c3 + c1 * s2 * s3;
-            quat[1] = c1 * s2 * c3 - s1 * c2 * s3;
-            quat[2] = c1 * c2 * s3 + s1 * s2 * c3;
-            quat[3] = c1 * c2 * c3 - s1 * s2 * s3;
-            break;
-        case EulerOrder::YXZ:
-            quat[0] = s1 * c2 * c3 + c1 * s2 * s3;
-            quat[1] = c1 * s2 * c3 - s1 * c2 * s3;
-            quat[2] = c1 * c2 * s3 - s1 * s2 * c3;
-            quat[3] = c1 * c2 * c3 + s1 * s2 * s3;
-            break;
-        case EulerOrder::ZXY:
-            quat[0] = s1 * c2 * c3 - c1 * s2 * s3;
-            quat[1] = c1 * s2 * c3 + s1 * c2 * s3;
-            quat[2] = c1 * c2 * s3 + s1 * s2 * c3;
-            quat[3] = c1 * c2 * c3 - s1 * s2 * s3;
-            break;
-        case EulerOrder::ZYX:
-            quat[0] = s1 * c2 * c3 - c1 * s2 * s3;
-            quat[1] = c1 * s2 * c3 + s1 * c2 * s3;
-            quat[2] = c1 * c2 * s3 - s1 * s2 * c3;
-            quat[3] = c1 * c2 * c3 + s1 * s2 * s3;
-            break;
-        case EulerOrder::YZX:
-            quat[0] = s1 * c2 * c3 + c1 * s2 * s3;
-            quat[1] = c1 * s2 * c3 + s1 * c2 * s3;
-            quat[2] = c1 * c2 * s3 - s1 * s2 * c3;
-            quat[3] = c1 * c2 * c3 - s1 * s2 * s3;
-            break;
-        case EulerOrder::XZY:
-            quat[0] = s1 * c2 * c3 - c1 * s2 * s3;
-            quat[1] = c1 * s2 * c3 - s1 * c2 * s3;
-            quat[2] = c1 * c2 * s3 + s1 * s2 * c3;
-            quat[3] = c1 * c2 * c3 + s1 * s2 * s3;
-            break;
-        case EulerOrder::NONE:
-        default:
-            msg_error("Quaternion") << "FromEuler: given order is not a valid order to create a Quaternion";
-            return Quater();
-        }
-
-        Quater quatResult{ quat[0], quat[1], quat[2], quat[3] };
-        return quatResult;
-    }
-
+    static Quater createQuaterFromEuler(const Vector3& v, EulerOrder order = EulerOrder::ZYX);
 
     /// Create a quaternion from Euler angles
-    static Quater fromEuler( Real alpha, Real beta, Real gamma, EulerOrder order = EulerOrder::ZYX ){
-        return createQuaterFromEuler( {alpha, beta, gamma }, order );
-    }
+    static Quater fromEuler(Real alpha, Real beta, Real gamma, EulerOrder order = EulerOrder::ZYX);
 
     /// Create using the entries of a rotation vector (axis*angle) given in parent coordinates
     template<class T>
@@ -388,28 +280,10 @@ public:
     static Quater set(T a0, T a1, T a2) { return createFromRotationVector(a0,a1,a2); }
 
     /// Return the quaternion resulting of the movement between 2 quaternions
-    Quater quatDiff( Quater a, const Quater& b)
-    {
-        // If the axes are not oriented in the same direction, flip the axis and angle of a to get the same convention than b
-        if (a[0]*b[0]+a[1]*b[1]+a[2]*b[2]+a[3]*b[3]<0)
-        {
-            a[0] = -a[0];
-            a[1] = -a[1];
-            a[2] = -a[2];
-            a[3] = -a[3];
-        }
-
-        Quater q = b.inverse() * a;
-        return q;
-    }
+    Quater quatDiff(Quater a, const Quater& b);
 
     /// Return the eulerian vector resulting of the movement between 2 quaternions
-    Vector3 angularDisplacement( Quater a, const Quater& b)
-    {
-        return quatDiff(a,b).quatToRotationVector();    // Use of quatToRotationVector instead of toEulerVector:
-                                                        // this is done to keep the old behavior (before the
-                                                        // correction of the toEulerVector function).
-    }
+    Vector3 angularDisplacement(Quater a, const Quater& b);
 
     /// Sets this quaternion to the rotation required to rotate direction vector vFrom to direction vector vTo. vFrom and vTo are assumed to be normalized.
     void setFromUnitVectors(const Vector3& vFrom, const Vector3& vTo);
@@ -423,41 +297,31 @@ public:
     void operator+=(const Quater& q2);
     void operator*=(const Quater& q2);
 
-    bool operator==(const Quater& q) const
-    {
-        for (int i=0; i<4; i++)
-            if ( std::abs( _q[i] - q._q[i] ) > std::numeric_limits<SReal>::epsilon() ) return false;
-        return true;
-    }
+    bool operator==(const Quater& q) const;
 
-    bool operator!=(const Quater& q) const
-    {
-        for (int i=0; i<4; i++)
-            if ( std::abs( _q[i] - q._q[i] ) > std::numeric_limits<SReal>::epsilon() ) return true;
-        return false;
-    }
+    bool operator!=(const Quater& q) const;
 
     /// write to an output stream
-    inline friend std::ostream& operator << ( std::ostream& out, const Quater& v )
+    inline friend std::ostream& operator << (std::ostream& out, const Quater& v)
     {
-        out<<v._q[0]<<" "<<v._q[1]<<" "<<v._q[2]<<" "<<v._q[3];
+        out << v._q[0] << " " << v._q[1] << " " << v._q[2] << " " << v._q[3];
         return out;
     }
 
     /// read from an input stream
-    inline friend std::istream& operator >> ( std::istream& in, Quater& v )
+    inline friend std::istream& operator >> (std::istream& in, Quater& v)
     {
-        in>>v._q[0]>>v._q[1]>>v._q[2]>>v._q[3];
+        in >> v._q[0] >> v._q[1] >> v._q[2] >> v._q[3];
         return in;
     }
 
-    enum { static_size = 4 };
+    static constexpr unsigned int static_size = 4;
     static unsigned int size() {return 4;}
 
     /// Compile-time constant specifying the number of scalars within this vector (equivalent to the size() method)
-    enum { total_size = 4 };
+    static constexpr unsigned int total_size = 4;
     /// Compile-time constant specifying the number of dimensions of space (NOT equivalent to total_size for quaternions)
-    enum { spatial_dimensions = 3 };
+    static constexpr unsigned int spatial_dimensions = 3;
 };
 
 #if  !defined(SOFA_HELPER_QUATER_CPP)

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/Quater.inl
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/Quater.inl
@@ -286,90 +286,20 @@ void Quater<Real>::normalize()
 template<class Real>
 void Quater<Real>::fromFrame(Vector3& x, Vector3&y, Vector3&z)
 {
+    std::array<Vector3, 3> matrix;
 
-    defaulttype::Matrix3 R(x,y,z);
-    R.transpose();
-    this->fromMatrix(R);
+    matrix[0][0] = x[0];
+    matrix[1][0] = x[1];
+    matrix[2][0] = x[2];
+    matrix[0][1] = y[0];
+    matrix[1][1] = y[1];
+    matrix[2][1] = y[2];
+    matrix[0][2] = z[0];
+    matrix[1][2] = z[1];
+    matrix[2][2] = z[2];
 
-
+    this->fromMatrix(matrix);
 }
-
-template<class Real>
-void Quater<Real>::fromMatrix(const defaulttype::Matrix3 &m)
-{
-    Real tr, s;
-
-    tr = (Real)(m.x().x() + m.y().y() + m.z().z());
-
-    // check the diagonal
-    if (tr > 0)
-    {
-        s = (float)sqrt (tr + 1);
-        _q[3] = s * 0.5f; // w OK
-        s = 0.5f / s;
-        _q[0] = (Real)((m.z().y() - m.y().z()) * s); // x OK
-        _q[1] = (Real)((m.x().z() - m.z().x()) * s); // y OK
-        _q[2] = (Real)((m.y().x() - m.x().y()) * s); // z OK
-    }
-    else
-    {
-        if (m.y().y() > m.x().x() && m.z().z() <= m.y().y())
-        {
-            s = (Real)sqrt ((m.y().y() - (m.z().z() + m.x().x())) + 1.0f);
-
-            _q[1] = s * 0.5f; // y OK
-
-            if (s != 0.0f)
-                s = 0.5f / s;
-
-            _q[2] = (Real)((m.y().z() + m.z().y()) * s); // z OK
-            _q[0] = (Real)((m.x().y() + m.y().x()) * s); // x OK
-            _q[3] = (Real)((m.x().z() - m.z().x()) * s); // w OK
-        }
-        else if ((m.y().y() <= m.x().x()  &&  m.z().z() > m.x().x())  ||  (m.z().z() > m.y().y()))
-        {
-            s = (Real)sqrt ((m.z().z() - (m.x().x() + m.y().y())) + 1.0f);
-
-            _q[2] = s * 0.5f; // z OK
-
-            if (s != 0.0f)
-                s = 0.5f / s;
-
-            _q[0] = (Real)((m.z().x() + m.x().z()) * s); // x OK
-            _q[1] = (Real)((m.y().z() + m.z().y()) * s); // y OK
-            _q[3] = (Real)((m.y().x() - m.x().y()) * s); // w OK
-        }
-        else
-        {
-            s = (Real)sqrt ((m.x().x() - (m.y().y() + m.z().z())) + 1.0f);
-
-            _q[0] = s * 0.5f; // x OK
-
-            if (s != 0.0f)
-                s = 0.5f / s;
-
-            _q[1] = (Real)((m.x().y() + m.y().x()) * s); // y OK
-            _q[2] = (Real)((m.z().x() + m.x().z()) * s); // z OK
-            _q[3] = (Real)((m.z().y() - m.y().z()) * s); // w OK
-        }
-    }
-}
-
-// template<class Real> template<class Mat33>
-//     void Quater<Real>::toMatrix(Mat33 &m) const
-// {
-// 	m[0][0] = (1.0 - 2.0 * (_q[1] * _q[1] + _q[2] * _q[2]));
-// 	m[0][1] = (2.0 * (_q[0] * _q[1] - _q[2] * _q[3]));
-// 	m[0][2] = (2.0 * (_q[2] * _q[0] + _q[1] * _q[3]));
-//
-// 	m[1][0] = (2.0 * (_q[0] * _q[1] + _q[2] * _q[3]));
-// 	m[1][1] = (1.0 - 2.0 * (_q[2] * _q[2] + _q[0] * _q[0]));
-// 	m[1][2] = (float) (2.0 * (_q[1] * _q[2] - _q[0] * _q[3]));
-//
-// 	m[2][0] = (float) (2.0 * (_q[2] * _q[0] - _q[1] * _q[3]));
-// 	m[2][1] = (float) (2.0 * (_q[1] * _q[2] + _q[0] * _q[3]));
-// 	m[2][2] = (float) (1.0 - 2.0 * (_q[1] * _q[1] + _q[0] * _q[0]));
-// }
 
 /// Build a rotation matrix, given a quaternion rotation.
 template<class Real>
@@ -484,9 +414,9 @@ Quater<Real> Quater<Real>::axisToQuat(Vector3 a, Real phi)
         return Quater();
     }
 
-    _q[0] = a[0] / anorm;;
-    _q[1] = a[1] / anorm;;
-    _q[2] = a[2] / anorm;;
+    _q[0] = Real(a[0] / anorm);
+    _q[1] = Real(a[1] / anorm);
+    _q[2] = Real(a[2] / anorm);
 
     _q[0] = _q[0] * (Real)sin(phi / 2.0);
     _q[1] = _q[1] * (Real)sin(phi / 2.0);
@@ -529,7 +459,7 @@ void Quater<Real>::quatToAxis(Vector3 & axis, Real &angle) const
 
 /// Given a quaternion, compute rotation vector (axis times angle)
 template<class Real>
-auto Quater<Real>::quatToRotationVector() const
+typename Quater<Real>::Vector3 Quater<Real>::quatToRotationVector() const
 {
 
     Quater<Real> q = *this;
@@ -571,7 +501,7 @@ auto Quater<Real>::quatToRotationVector() const
 /// Pitch: rotation about the Y-axis
 /// Yaw: rotation about the Z-axis
 template<class Real>
-auto Quater<Real>::toEulerVector() const
+typename Quater<Real>::Vector3 Quater<Real>::toEulerVector() const
 {
     Quater<Real> q = *this;
     q.normalize();
@@ -698,28 +628,12 @@ Quater<Real> Quater<Real>::slerp2(Quater<Real> &q1, Real t)
 }
 
 template<class Real>
-Quater<Real> Quater<Real>::createQuaterFromFrame(const Vector3 &lox, const Vector3 &loy,const Vector3 &loz)
-{
-    Quater<Real> q;
-    sofa::defaulttype::Mat<3,3, Real> m;
-
-    for (unsigned int i=0 ; i<3 ; i++)
-    {
-        m[i][0] = lox[i];
-        m[i][1] = loy[i];
-        m[i][2] = loz[i];
-    }
-    q.fromMatrix(m);
-    return q;
-}
-
-template<class Real>
 inline void Quater<Real>::setFromUnitVectors(const Vector3& vFrom, const Vector3& vTo)
 {
     Vector3 v1;
     Real epsilon = std::numeric_limits<Real>::epsilon();
     
-    Real res_dot = sofa::helper::dot(vFrom, vTo) + 1;
+    Real res_dot = Real(sofa::helper::dot(vFrom, vTo) + 1);
     if (res_dot < epsilon)
     {
         res_dot = 0;

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/fixed_array.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/fixed_array.h
@@ -278,7 +278,7 @@ public:
     }
 
     // size is constant
-    static size_type size()
+    static constexpr size_type size()
     {
         return N;
     }

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/gl/Trackball.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/gl/Trackball.h
@@ -73,6 +73,7 @@
 #define SOFA_HELPER_GL_TRACKBALL_H
 
 #include <sofa/defaulttype/Quat.h>
+#include <sofa/defaulttype/Vec.h>
 
 #include <sofa/helper/config.h>
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/testing/NumericTest.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/testing/NumericTest.h
@@ -255,7 +255,7 @@ struct setRotWrapper<DataTypes, N, true>
 
 template<class DataTypes>
 struct setRotWrapper<DataTypes, 2, false>
-{ static void setRot(typename DataTypes::Coord& coord, const sofa::helper::Quater<SReal>& rot)	{ coord.getOrientation() = rot.quatToRotationVector().z(); } };
+{ static void setRot(typename DataTypes::Coord& coord, const sofa::helper::Quater<SReal>& rot)	{ coord.getOrientation() = rot.quatToRotationVector()[3]; } };
 // Use of quatToRotationVector instead of toEulerVector:
 // this is done to keep the old behavior (before the
 // correction of the toEulerVector  function). If the

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_algebra.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_algebra.h
@@ -23,6 +23,7 @@
 #define SOFA_HELPER_VECTOR_ALGEBRA_H
 
 #include <sofa/helper/vector.h>
+#include <array>
 
 namespace sofa
 {
@@ -67,6 +68,21 @@ void axpy( V1& result, Scalar a, const V2& x, const V3& y )
     for(std::size_t i=0; i<n; i++)
         result[i] = x[i]*a + y[i];
 }
+
+/// Norm of a vector
+template<typename V>
+auto cross(const V vector1, const V vector2)
+{
+    //static_assert( std::size(vector1) == 3); // nope ?
+    static_assert(vector1.size() == 3);
+
+    return V{
+        vector1[1] * vector2[2] - vector1[2] * vector2[1],
+        vector1[2] * vector2[0] - vector1[0] * vector2[2],
+        vector1[0] * vector2[1] - vector1[1] * vector2[0]
+    };
+}
+
 
 } // namespace helper
 

--- a/applications/plugins/CMakeLists.txt
+++ b/applications/plugins/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.12)
 find_package(SofaFramework)
 
 sofa_add_subdirectory_external(SofaHighOrder SofaHighOrder)
-#sofa_add_subdirectory_external(SofaPython3 SofaPython3)
+sofa_add_subdirectory_external(SofaPython3 SofaPython3)
 
 sofa_add_plugin(CImgPlugin CImgPlugin ON) # ON by default and first as it is used by other plugins.
 sofa_add_plugin(SofaEulerianFluid SofaEulerianFluid)

--- a/applications/plugins/CMakeLists.txt
+++ b/applications/plugins/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.12)
 find_package(SofaFramework)
 
 sofa_add_subdirectory_external(SofaHighOrder SofaHighOrder)
-sofa_add_subdirectory_external(SofaPython3 SofaPython3)
+#sofa_add_subdirectory_external(SofaPython3 SofaPython3)
 
 sofa_add_plugin(CImgPlugin CImgPlugin ON) # ON by default and first as it is used by other plugins.
 sofa_add_plugin(SofaEulerianFluid SofaEulerianFluid)

--- a/applications/plugins/Flexible/quadrature/BaseGaussPointSampler.h
+++ b/applications/plugins/Flexible/quadrature/BaseGaussPointSampler.h
@@ -29,6 +29,7 @@
 #include <sofa/helper/vector.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/OptionsGroup.h>
+#include <sofa/defaulttype/Mat.h>
 
 #define GAUSSLEGENDRE 0
 #define NEWTONCOTES 1

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/OglFluidModel.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/OglFluidModel.inl
@@ -3,8 +3,11 @@
 #include <SofaSphFluid/OglFluidModel.h>
 
 #include <sstream>
-#include <sofa/core/visual/VisualParams.h>
 #include <limits>
+
+#include <sofa/core/visual/VisualParams.h>
+
+#include <sofa/defaulttype/Mat.h>
 
 #include <SofaSphFluid/shaders/pointToSprite.cppglsl>
 #include <SofaSphFluid/shaders/spriteToSpriteNormal.cppglsl>

--- a/applications/plugins/image/ImageContainer.h
+++ b/applications/plugins/image/ImageContainer.h
@@ -125,8 +125,8 @@ struct ImageContainerSpecialization< defaulttype::Image<T> >
 
                 defaulttype::Mat<3,3,Real> R;
                 R = container->RotVec3DToRotMat3D(rotation);
-                helper::Quater< float > q; q.fromMatrix(R);
-                wtransform->getRotation()=q.toEulerVector() * (Real)180.0 / (Real)M_PI ;
+                helper::Quater< Real > q; q.fromMatrix(R);
+                wtransform->getRotation()= defaulttype::Vec<3, Real> (q.toEulerVector() ) * (Real)180.0 / (Real)M_PI ;
             }
             //			Real t0 = wtransform->getRotation()[0];
             //			Real t1 = wtransform->getRotation()[1];
@@ -149,7 +149,7 @@ struct ImageContainerSpecialization< defaulttype::Image<T> >
                     for(unsigned int i=0;i<3;i++) wtransform->getTranslation()[i]=(Real)translation[i];
                     defaulttype::Mat<3,3,Real> R; for(unsigned int i=0;i<3;i++) for(unsigned int j=0;j<3;j++) R[i][j]=(Real)affine[3*i+j];
                     helper::Quater< Real > q; q.fromMatrix(R);
-                    wtransform->getRotation()=q.toEulerVector() * (Real)180.0 / (Real)M_PI ;
+                    wtransform->getRotation()= defaulttype::Vec<3, Real> (q.toEulerVector()) * (Real)180.0 / (Real)M_PI ;
                     wtransform->getOffsetT()=(Real)offsetT;
                     wtransform->getScaleT()=(Real)scaleT;
                     wtransform->isPerspective()=isPerspective;
@@ -291,7 +291,7 @@ struct ImageContainerSpecialization< defaulttype::Image<T> >
 
             if (!container->transformIsSet)
             {
-                wtransform->getRotation()=q.toEulerVector() * (Real)180.0 / (Real)M_PI ;
+                wtransform->getRotation()= defaulttype::Vec<3, Real> (q.toEulerVector()) * (Real)180.0 / (Real)M_PI ;
             }
         }
 

--- a/applications/plugins/image/ImageTransformEngine.h
+++ b/applications/plugins/image/ImageTransformEngine.h
@@ -118,7 +118,7 @@ protected:
         outT->getTranslation() = r.rotate(inT->getTranslation())*s + t;
 
         helper::Quater<Real> q = r*inT->qrotation;
-        outT->getRotation()=q.toEulerVector() * (Real)180.0 / (Real)M_PI ;
+        outT->getRotation()= defaulttype::Vec<3, Real> (q.toEulerVector()) * (Real)180.0 / (Real)M_PI ;
 
         outT->update(); // update internal data
     }

--- a/applications/plugins/image/MeshToImageEngine.h
+++ b/applications/plugins/image/MeshToImageEngine.h
@@ -334,7 +334,7 @@ protected:
 
             // get orientation from eigen vectors
             helper::Quater< Real > q; q.fromMatrix(M);
-            tr->getRotation()=q.toEulerVector()* (Real)180.0 / (Real)M_PI;
+            tr->getRotation()= defaulttype::Vec<3, Real> (q.toEulerVector())* (Real)180.0 / (Real)M_PI;
 
             // get bb
             Coord P;

--- a/modules/SofaGeneralDeformable/FrameSpringForceField.inl
+++ b/modules/SofaGeneralDeformable/FrameSpringForceField.inl
@@ -84,7 +84,7 @@ void FrameSpringForceField<DataTypes>::addSpringForce ( SReal& /*potentialEnergy
     springRef[a] = p1[a];
 
     VecN fT = kst.linearProduct( ( p2[b].getCenter() + Mr02 * ( spring.vec2)) - ( p1[a].getCenter() + Mr01 * ( spring.vec1))) + damping.linearProduct ( getVCenter(Vp1p2));
-    VecN fR = ksr.linearProduct( ( p1[a].getOrientation().inverse() * p2[b].getOrientation()).quatToRotationVector());  // Use of quatToRotationVector instead of toEulerVector:
+    VecN fR = ksr.linearProduct(VecN{ (p1[a].getOrientation().inverse() * p2[b].getOrientation()).quatToRotationVector() });  // Use of quatToRotationVector instead of toEulerVector:
                                                                                                                         // this is done to keep the old behavior (before the
                                                                                                                         // correction of the toEulerVector  function). If the
                                                                                                                         // purpose was to obtain the Eulerian vector and not the


### PR DESCRIPTION
+ some cleaning and hard coded epsilon removals.

Should not be breaking, EXCEPT: 
 - for code using Vec/Mat without including them (👎)
 - rare code depending on Vec3 as parameters 🧨

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
