### PR TITLE
[SofaKernel] Remove un-needed StringUtil.h in Base.h

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -22,7 +22,6 @@
 #ifndef SOFA_CORE_OBJECTMODEL_BASE_H
 #define SOFA_CORE_OBJECTMODEL_BASE_H
 
-#include <sofa/helper/StringUtils.h>
 #include <sofa/defaulttype/BoundingBox.h>
 #include <sofa/core/objectmodel/Data.h>
 #include <sofa/core/objectmodel/Link.h>


### PR DESCRIPTION
My most important PR so-far.

______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
