### PR TITLE
[SofaCarving] Fix method doCarve should be called at AnimateEndEvent

### DIFF
--- a/applications/plugins/SofaCarving/CarvingManager.cpp
+++ b/applications/plugins/SofaCarving/CarvingManager.cpp
@@ -253,7 +253,7 @@ void CarvingManager::handleEvent(sofa::core::objectmodel::Event* event)
             d_active.setValue(false);
         }
     }
-    else if (simulation::CollisionEndEvent::checkEventType(event))
+    else if (sofa::simulation::AnimateEndEvent::checkEventType(event))
     {
         if (d_active.getValue()) {
             doCarve();


### PR DESCRIPTION
Method doCarve in CarcingManager should be called at AnimateEndEvent and not at CollisionEndEvent to avoid any topology synchronization error during step.



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
