### PR TITLE
[SofaSPHFluid] Fix compilation with std::execution

### DIFF
--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/SPHFluidForceField.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/SPHFluidForceField.inl
@@ -29,7 +29,7 @@
 #include <iostream>
 #include <sofa/helper/AdvancedTimer.h>
 
-#if __has_include(<execution>)
+#if __has_include(<execution>) && !defined(__APPLE__)
 #include <execution>
 #endif
 
@@ -152,7 +152,7 @@ void SPHFluidForceField<DataTypes>::computeNeighbors(const core::MechanicalParam
     // This is an O(n2) step, except if a hash-grid is used to optimize it
     if (m_grid == nullptr)
     {
-#if __has_include(<execution>)
+#if __has_include(<execution>) && !defined(__APPLE__)
         std::for_each(std::execution::par, x.begin(), x.end(), [&](const auto& ri)
         {
             auto i = &ri - &x[0]; // only possible with vector, etc.


### PR DESCRIPTION
Clang still does not implement parallel execution (https://en.cppreference.com/w/cpp/compiler_support)
It was guarded before with has_include<execution> (could be used with GCC and MSVC)

BUT the new XCode seems to introduce the header without implementation 🤔.
(has_include<execution> is true, and the execution header exists)



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
