### PR TITLE
[SofaKernel] make extern templates of common Vec<> types, remove math.h from header

### DIFF
--- a/SofaKernel/modules/SofaDefaultType/CMakeLists.txt
+++ b/SofaKernel/modules/SofaDefaultType/CMakeLists.txt
@@ -26,6 +26,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/TemplatesAliases.h
     ${SRC_ROOT}/TopologyTypes.h
     ${SRC_ROOT}/Vec.h
+    ${SRC_ROOT}/Vec.inl
     ${SRC_ROOT}/Ray.h
     ${SRC_ROOT}/Vec3Types.h
     ${SRC_ROOT}/VecTypes.h
@@ -39,6 +40,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/BaseMatrix.cpp
     ${SRC_ROOT}/BoundingBox.cpp
     ${SRC_ROOT}/Frame.cpp
+    ${SRC_ROOT}/Vec.cpp
     ${SRC_ROOT}/SolidTypes.cpp
     ${SRC_ROOT}/TemplatesAliases.cpp
     ${SRC_ROOT}/init.cpp

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/Mat.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/Mat.h
@@ -23,6 +23,7 @@
 #define SOFA_DEFAULTTYPE_MAT_H
 
 #include <sofa/defaulttype/Vec.h>
+#include <sofa/helper/rmath.h>
 #include <iostream>
 #include <sofa/helper/logging/Messaging.h>
 

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/Vec.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/Vec.h
@@ -22,10 +22,9 @@
 #ifndef SOFA_DEFAULTTYPE_VEC_H
 #define SOFA_DEFAULTTYPE_VEC_H
 
+#include <sofa/defaulttype/config.h>
 #include <sofa/helper/fixed_array.h>
-#include <sofa/helper/rmath.h>
 #include <sofa/defaulttype/DataTypeInfo.h>
-#include <functional>
 #include <limits>
 
 #define EQUALITY_THRESHOLD 1e-6
@@ -39,13 +38,13 @@ namespace defaulttype
 enum NoInit { NOINIT }; ///< use when calling Vec or Mat constructor to skip initialization of values to 0
 
 template < std::size_t N, typename real=float>
-class Vec : public helper::fixed_array<real,N>
+class SOFA_DEFAULTTYPE_API Vec : public helper::fixed_array<real,N>
 {
 
     static_assert( N > 0, "" );
 
 public:
-    typedef typename helper::fixed_array<real, N>::size_type size_type;
+    typedef std::size_t size_type;
 
     /// Compile-time constant specifying the number of scalars within this vector (equivalent to static_size and size() method)
     enum { total_size = N };
@@ -64,91 +63,91 @@ public:
     }
 
     /// Specific constructor for 1-element vectors.
-    template<size_type NN = N, typename std::enable_if<NN==1,int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<NN==1,int>::type = 0>
     explicit Vec(real r1)
     {
         set( r1 );
     }
 
     /// Specific constructor for 1-element vectors.
-    template<size_type NN = N, typename std::enable_if<NN==1,int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<NN==1,int>::type = 0>
     void operator=(real r1)
     {
         set( r1 );
     }
 
     /// Specific constructor for 2-elements vectors.
-    template<size_type NN = N, typename std::enable_if<NN==2,int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<NN==2,int>::type = 0>
     Vec(real r1, real r2)
     {
         set( r1, r2 );
     }
 
     /// Specific constructor for 3-elements vectors.
-    template<size_type NN = N, typename std::enable_if<NN==3,int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<NN==3,int>::type = 0>
     Vec(real r1, real r2, real r3)
     {
         set( r1, r2, r3 );
     }
 
     /// Specific constructor for 4-elements vectors.
-    template<size_type NN = N, typename std::enable_if<NN==4,int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<NN==4,int>::type = 0>
     Vec(real r1, real r2, real r3, real r4)
     {
         set( r1, r2, r3, r4 );
     }
 
     /// Specific constructor for 5-elements vectors.
-    template<size_type NN = N, typename std::enable_if<NN==5,int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<NN==5,int>::type = 0>
     Vec(real r1, real r2, real r3, real r4, real r5)
     {
         set( r1, r2, r3, r4, r5 );
     }
 
     /// Specific constructor for 6-elements vectors.
-    template<size_type NN = N, typename std::enable_if<NN==6,int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<NN==6,int>::type = 0>
     Vec(real r1, real r2, real r3, real r4, real r5, real r6)
     {
         set( r1, r2, r3, r4, r5, r6 );
     }
 
     /// Specific constructor for 6-elements vectors.
-    template<typename R, typename T, size_type NN=N, typename std::enable_if<NN==6,int>::type = 0 >
+    template<typename R, typename T, std::size_t NN=N, typename std::enable_if<NN==6,int>::type = 0 >
     Vec( const Vec<3,R>& a , const Vec<3,T>& b )
     {
         set( a[0], a[1], a[2], b[0], b[1], b[2] );
     }
 
     /// Specific constructor for 7-elements vectors.
-    template<size_type NN = N, typename std::enable_if<NN==7,int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<NN==7,int>::type = 0>
     Vec(real r1, real r2, real r3, real r4, real r5, real r6, real r7)
     {
         set( r1, r2, r3, r4, r5, r6, r7 );
     }
 
     /// Specific constructor for 8-elements vectors.
-    template<size_type NN = N, typename std::enable_if<NN==8,int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<NN==8,int>::type = 0>
     Vec(real r1, real r2, real r3, real r4, real r5, real r6, real r7, real r8)
     {
         set( r1, r2, r3, r4, r5, r6, r7, r8 );
     }
 
     /// Specific constructor for 9-elements vectors.
-    template<size_type NN = N, typename std::enable_if<NN==9,int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<NN==9,int>::type = 0>
     Vec(real r1, real r2, real r3, real r4, real r5, real r6, real r7, real r8, real r9)
     {
         set( r1, r2, r3, r4, r5, r6, r7, r8, r9 );
     }
 
     /// Specific constructor for 12-elements vectors.
-    template<size_type NN = N, typename std::enable_if<NN==12,int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<NN==12,int>::type = 0>
     Vec(real r1, real r2, real r3, real r4, real r5, real r6, real r7, real r8, real r9, real r10, real r11, real r12)
     {
         set( r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12 );
     }
 
     /// Specific set for 1-element vectors.
-    template<size_type NN = N, typename std::enable_if<NN==1,int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<NN==1,int>::type = 0>
     void set(real r1)
     {
         static_assert(N==1, "");
@@ -156,7 +155,7 @@ public:
     }
 
     /// Specific set for 2-elements vectors.
-    template<size_type NN = N, typename std::enable_if<NN==2,int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<NN==2,int>::type = 0>
     void set(real r1, real r2)
     {
         static_assert(N == 2, "");
@@ -165,7 +164,7 @@ public:
     }
 
     /// Specific set for 3-elements vectors.
-    template<size_type NN = N, typename std::enable_if<NN==3,int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<NN==3,int>::type = 0>
     void set(real r1, real r2, real r3)
     {
         static_assert(N == 3, "");
@@ -175,7 +174,7 @@ public:
     }
 
     /// Specific set for 4-elements vectors.
-    template<size_type NN = N, typename std::enable_if<NN==4,int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<NN==4,int>::type = 0>
     void set(real r1, real r2, real r3, real r4)
     {
         static_assert(N == 4, "");
@@ -186,7 +185,7 @@ public:
     }
 
     /// Specific set for 5-elements vectors.
-    template<size_type NN = N, typename std::enable_if<NN==5,int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<NN==5,int>::type = 0>
     void set(real r1, real r2, real r3, real r4, real r5)
     {
         static_assert(N == 5, "");
@@ -198,7 +197,7 @@ public:
     }
 
     /// Specific set for 6-elements vectors.
-    template<size_type NN = N, typename std::enable_if<NN==6,int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<NN==6,int>::type = 0>
     void set(real r1, real r2, real r3, real r4, real r5, real r6)
     {
         static_assert(N == 6, "");
@@ -211,7 +210,7 @@ public:
     }
 
     /// Specific constructor for 7-elements vectors.
-    template<size_type NN = N, typename std::enable_if<NN==7,int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<NN==7,int>::type = 0>
     void set(real r1, real r2, real r3, real r4, real r5, real r6, real r7)
     {
         static_assert(N == 7, "");
@@ -225,7 +224,7 @@ public:
     }
 
     /// Specific set for 8-elements vectors.
-    template<size_type NN = N, typename std::enable_if<NN==8,int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<NN==8,int>::type = 0>
     void set(real r1, real r2, real r3, real r4, real r5, real r6, real r7, real r8)
     {
         static_assert(N == 8, "");
@@ -240,7 +239,7 @@ public:
     }
 
     /// Specific set for 9-elements vectors.
-    template<size_type NN = N, typename std::enable_if<NN==9,int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<NN==9,int>::type = 0>
     void set(real r1, real r2, real r3, real r4, real r5, real r6, real r7, real r8, real r9)
     {
         static_assert(N == 9, "");
@@ -256,7 +255,7 @@ public:
     }
 
     /// Specific set for 12-elements vectors.
-    template<size_type NN = N, typename std::enable_if<NN==12,int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<NN==12,int>::type = 0>
     void set(real r1, real r2, real r3, real r4, real r5, real r6, real r7, real r8, real r9, real r10, real r11, real r12)
     {
         static_assert(N == 12, "");
@@ -275,19 +274,19 @@ public:
     }
 
     /// Specific set from a different size vector (given default value and ignored outside entries)
-    template<size_type N2, class real2>
+    template<std::size_t N2, class real2>
     void set(const Vec<N2,real2>& v, real defaultvalue=0)
     {
-        size_type maxN = std::min( N, N2 );
-        for(size_type i=0; i<maxN; i++)
+        std::size_t maxN = std::min( N, N2 );
+        for(std::size_t i=0; i<maxN; i++)
             this->elems[i] = (real)v[i];
-        for(size_type i=maxN; i<N ; i++)
+        for(std::size_t i=maxN; i<N ; i++)
             this->elems[i] = defaultvalue;
     }
 
 
     /// Constructor from an N-1 elements vector and an additional value (added at the end).
-    //template<size_type NN = N, typename std::enable_if<(NN>1),int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<(NN>1),int>::type = 0>
     Vec(const Vec<N-1,real>& v, real r1)
     {
         static_assert(N > 1, "");
@@ -296,12 +295,12 @@ public:
 
     Vec(const helper::fixed_array<real, N>& p)
     {
-        for(size_type i=0; i<N; i++)
+        for(std::size_t i=0; i<N; i++)
             this->elems[i] = p[i];
     }
 
     /// Constructor from a different size vector (null default value and ignoring outside entries)
-    template<size_type N2, typename real2>
+    template<std::size_t N2, typename real2>
     explicit Vec(const Vec<N2,real2>& v)
     {
         set( v, 0 );
@@ -311,7 +310,7 @@ public:
     Vec(const Vec<N, real2>& p)
     {
         //std::copy(p.begin(), p.end(), this->begin());
-        for(size_type i=0; i<N; i++)
+        for(std::size_t i=0; i<N; i++)
             this->elems[i] = (real)p(i);
     }
 
@@ -320,33 +319,33 @@ public:
     explicit Vec(const real2* p)
     {
         //std::copy(p, p+N, this->begin());
-        for(size_type i=0; i<N; i++)
+        for(std::size_t i=0; i<N; i++)
             this->elems[i] = (real)p[i];
     }
 
     /// Special access to first element.
-    template<size_type NN = N, typename std::enable_if<(NN>=1),int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<(NN>=1),int>::type = 0>
     real& x()
     {
         static_assert(N >= 1, "");
         return this->elems[0];
     }
     /// Special access to second element.
-    template<size_type NN = N, typename std::enable_if<(NN>=2),int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<(NN>=2),int>::type = 0>
     real& y()
     {
         static_assert(N >= 2, "");
         return this->elems[1];
     }
     /// Special access to third element.
-    template<size_type NN = N, typename std::enable_if<(NN>=3),int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<(NN>=3),int>::type = 0>
     real& z()
     {
         static_assert(N >= 3, "");
         return this->elems[2];
     }
     /// Special access to fourth element.
-    template<size_type NN = N, typename std::enable_if<(NN>=4),int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<(NN>=4),int>::type = 0>
     real& w()
     {
         static_assert(N >= 4, "");
@@ -354,28 +353,28 @@ public:
     }
 
     /// Special const access to first element.
-    template<size_type NN = N, typename std::enable_if<(NN>=1),int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<(NN>=1),int>::type = 0>
     const real& x() const
     {
         static_assert(N >= 1, "");
         return this->elems[0];
     }
     /// Special const access to second element.
-    template<size_type NN = N, typename std::enable_if<(NN>=2),int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<(NN>=2),int>::type = 0>
     const real& y() const
     {
         static_assert(N >= 2, "");
         return this->elems[1];
     }
     /// Special const access to third element.
-    template<size_type NN = N, typename std::enable_if<(NN>=3),int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<(NN>=3),int>::type = 0>
     const real& z() const
     {
         static_assert(N >= 3, "");
         return this->elems[2];
     }
     /// Special const access to fourth element.
-    template<size_type NN = N, typename std::enable_if<(NN>=4),int>::type = 0>
+    template<std::size_t NN = N, typename std::enable_if<(NN>=4),int>::type = 0>
     const real& w() const
     {
         static_assert(N >= 4, "");
@@ -387,16 +386,16 @@ public:
     void operator=(const real2* p)
     {
         //std::copy(p, p+N, this->begin());
-        for(size_type i=0; i<N; i++)
+        for(std::size_t i=0; i<N; i++)
             this->elems[i] = (real)p[i];
     }
 
     /// Assignment from a vector with different dimensions.
-    template<size_type M, typename real2>
+    template<std::size_t M, typename real2>
     void operator=(const Vec<M,real2>& v)
     {
         //std::copy(v.begin(), v.begin()+(N>M?M:N), this->begin());
-        for(size_type i=0; i<(N>M?M:N); i++)
+        for(std::size_t i=0; i<(N>M?M:N); i++)
             this->elems[i] = (real)v(i);
     }
 
@@ -414,7 +413,7 @@ public:
 
     // Access to i-th element.
     // Already in fixed_array
-    //real& operator[](size_type i)
+    //real& operator[](std::size_t i)
     //{
     //    return this->elems[i];
     //}
@@ -422,19 +421,19 @@ public:
     // Access to i-th element.
     // Already in fixed_array
     /// Const access to i-th element.
-    //const real& operator[](size_type i) const
+    //const real& operator[](std::size_t i) const
     //{
     //    return this->elems[i];
     //}
 
     /// Access to i-th element.
-    real& operator()(size_type i)
+    real& operator()(std::size_t i)
     {
         return this->elems[i];
     }
 
     /// Const access to i-th element.
-    const real& operator()(size_type i) const
+    const real& operator()(std::size_t i) const
     {
         return this->elems[i];
     }
@@ -478,7 +477,7 @@ public:
     {
         static_assert(DataTypeInfo<real2>::ValidInfo && DataTypeInfo<real2>::Size==1, "");
         Vec<N,real> r(NOINIT);
-        for (size_type i=0; i<N; i++)
+        for (std::size_t i=0; i<N; i++)
             r[i] = this->elems[i]*(real)f;
         return r;
     }
@@ -497,7 +496,7 @@ public:
     void eqmulscalar(real2 f)
     {
         static_assert(DataTypeInfo<real2>::ValidInfo && DataTypeInfo<real2>::Size==1, "");
-        for (size_type i=0; i<N; i++)
+        for (std::size_t i=0; i<N; i++)
             this->elems[i]*=(real)f;
     }
 
@@ -516,7 +515,7 @@ public:
     {
         static_assert(DataTypeInfo<real2>::ValidInfo && DataTypeInfo<real2>::Size==1, "");
         Vec<N,real> r(NOINIT);
-        for (size_type i=0; i<N; i++)
+        for (std::size_t i=0; i<N; i++)
             r[i] = this->elems[i]/(real)f;
         return r;
     }
@@ -535,7 +534,7 @@ public:
     void eqdivscalar(real2 f)
     {
         static_assert(DataTypeInfo<real2>::ValidInfo && DataTypeInfo<real2>::Size==1, "");
-        for (size_type i=0; i<N; i++)
+        for (std::size_t i=0; i<N; i++)
             this->elems[i]/=(real)f;
     }
 
@@ -553,7 +552,7 @@ public:
     real operator*(const Vec<N,real2>& v) const
     {
         real r = (real)(this->elems[0]*v[0]);
-        for (size_type i=1; i<N; i++)
+        for (std::size_t i=1; i<N; i++)
             r += (real)(this->elems[i]*v[i]);
         return r;
     }
@@ -563,7 +562,7 @@ public:
     Vec<N,real> linearProduct(const Vec<N,real2>& v) const
     {
         Vec<N,real> r(NOINIT);
-        for (size_type i=0; i<N; i++)
+        for (std::size_t i=0; i<N; i++)
             r[i]=this->elems[i]*(real)v[i];
         return r;
     }
@@ -574,7 +573,7 @@ public:
     Vec<N,real> linearDivision(const Vec<N,real2>& v) const
     {
         Vec<N,real> r(NOINIT);
-        for (size_type i=0; i<N; i++)
+        for (std::size_t i=0; i<N; i++)
             r[i]=this->elems[i]/(real)v[i];
         return r;
     }
@@ -584,7 +583,7 @@ public:
     Vec<N,real> operator+(const Vec<N,real2>& v) const
     {
         Vec<N,real> r(NOINIT);
-        for (size_type i=0; i<N; i++)
+        for (std::size_t i=0; i<N; i++)
             r[i]=this->elems[i]+(real)v[i];
         return r;
     }
@@ -593,7 +592,7 @@ public:
     template<class real2>
     void operator+=(const Vec<N,real2>& v)
     {
-        for (size_type i=0; i<N; i++)
+        for (std::size_t i=0; i<N; i++)
             this->elems[i]+=(real)v[i];
     }
 
@@ -602,7 +601,7 @@ public:
     Vec<N,real> operator-(const Vec<N,real2>& v) const
     {
         Vec<N,real> r(NOINIT);
-        for (size_type i=0; i<N; i++)
+        for (std::size_t i=0; i<N; i++)
             r[i]=this->elems[i]-(real)v[i];
         return r;
     }
@@ -611,7 +610,7 @@ public:
     template<class real2>
     void operator-=(const Vec<N,real2>& v)
     {
-        for (size_type i=0; i<N; i++)
+        for (std::size_t i=0; i<N; i++)
             this->elems[i]-=(real)v[i];
     }
 
@@ -619,7 +618,7 @@ public:
     Vec<N,real> operator-() const
     {
         Vec<N,real> r(NOINIT);
-        for (size_type i=0; i<N; i++)
+        for (std::size_t i=0; i<N; i++)
             r[i]=-this->elems[i];
         return r;
     }
@@ -628,58 +627,18 @@ public:
     real norm2() const
     {
         real r = this->elems[0]*this->elems[0];
-        for (size_type i=1; i<N; i++)
+        for (std::size_t i=1; i<N; i++)
             r += this->elems[i]*this->elems[i];
         return r;
     }
 
     /// Euclidean norm.
-    real norm() const
-    {
-        return helper::rsqrt(norm2());
-    }
+    real norm() const;
 
     /// l-norm of the vector
     /// The type of norm is set by parameter l.
     /// Use l<0 for the infinite norm.
-    real lNorm( int l ) const
-    {
-        if( l==2 ) return norm(); // euclidian norm
-        else if( l<0 ) // infinite norm
-        {
-            real n=0;
-            for( size_type i=0; i<N; i++ )
-            {
-                real a = helper::rabs( this->elems[i] );
-                if( a>n ) n=a;
-            }
-            return n;
-        }
-        else if( l==1 ) // Manhattan norm
-        {
-            real n=0;
-            for( size_type i=0; i<N; i++ )
-            {
-                n += helper::rabs( this->elems[i] );
-            }
-            return n;
-        }
-        else if( l==0 ) // counting not null
-        {
-            real n=0;
-            for( size_type i=0; i<N; i++ )
-                if( this->elems[i] ) n+=1;
-            return n;
-        }
-        else // generic implementation
-        {
-            real n = 0;
-            for( size_type i=0; i<N; i++ )
-                n += pow( helper::rabs( this->elems[i] ), l );
-            return pow( n, real(1.0)/(real)l );
-        }
-    }
-
+    real lNorm( int l ) const;
 
     /// Normalize the vector taking advantage of its already computed norm, equivalent to /=norm
     /// returns false iff the norm is too small
@@ -687,7 +646,7 @@ public:
     {
         if (norm>threshold)
         {
-            for (size_type i=0; i<N; i++)
+            for (std::size_t i=0; i<N; i++)
                 this->elems[i]/=norm;
             return true;
         }
@@ -719,9 +678,9 @@ public:
     }
 
     /// return true iff norm()==1
-    bool isNormalized( real threshold=std::numeric_limits<real>::epsilon()*(real)10 ) const { return helper::rabs<real>( norm2()-(real)1 ) <= threshold; }
+    bool isNormalized( real threshold=std::numeric_limits<real>::epsilon()*(real)10 ) const;
 
-    template<typename R,size_type NN = N, typename std::enable_if<(NN==3),int>::type = 0>
+    template<typename R,std::size_t NN = N, typename std::enable_if<(NN==3),int>::type = 0>
     Vec cross( const Vec<3,R>& b ) const
     {
         static_assert(N == 3, "");
@@ -737,7 +696,7 @@ public:
     real sum() const
     {
         real sum = 0.0;
-        for (size_type i=0; i<N; i++)
+        for (std::size_t i=0; i<N; i++)
             sum += this->elems[i];
         return sum;
     }
@@ -748,14 +707,14 @@ public:
 
     bool operator==(const Vec& b) const
     {
-        for (size_type i=0; i<N; i++)
+        for (std::size_t i=0; i<N; i++)
             if ( fabs( (float)(this->elems[i] - b[i]) ) > EQUALITY_THRESHOLD ) return false;
         return true;
     }
 
     bool operator!=(const Vec& b) const
     {
-        for (size_type i=0; i<N; i++)
+        for (std::size_t i=0; i<N; i++)
             if ( fabs( (float)(this->elems[i] - b[i]) ) > EQUALITY_THRESHOLD ) return true;
         return false;
     }
@@ -766,7 +725,7 @@ public:
 
 /// Same as Vec except the values are not initialized by default
 template <std::size_t N, typename real=float>
-class VecNoInit : public Vec<N,real>
+class SOFA_DEFAULTTYPE_API VecNoInit : public Vec<N,real>
 {
 public:
     VecNoInit()
@@ -850,6 +809,33 @@ Vec<N,real> operator*(const float& a, const Vec<N,real>& V)
 {
     return V * a;
 }
+
+#ifndef SOFA_DEFAULTTYPE_VEC_CPP
+extern template class SOFA_DEFAULTTYPE_API Vec<1,float>;
+extern template class SOFA_DEFAULTTYPE_API Vec<1,int>;
+extern template class SOFA_DEFAULTTYPE_API Vec<1,double>;
+extern template class SOFA_DEFAULTTYPE_API Vec<1,unsigned>;
+
+extern template class SOFA_DEFAULTTYPE_API Vec<2,float>;
+extern template class SOFA_DEFAULTTYPE_API Vec<2,int>;
+extern template class SOFA_DEFAULTTYPE_API Vec<2,double>;
+extern template class SOFA_DEFAULTTYPE_API Vec<2,unsigned>;
+
+extern template class SOFA_DEFAULTTYPE_API Vec<3,float>;
+extern template class SOFA_DEFAULTTYPE_API Vec<3,int>;
+extern template class SOFA_DEFAULTTYPE_API Vec<3,double>;
+extern template class SOFA_DEFAULTTYPE_API Vec<3,unsigned>;
+
+extern template class SOFA_DEFAULTTYPE_API Vec<4,float>;
+extern template class SOFA_DEFAULTTYPE_API Vec<4,int>;
+extern template class SOFA_DEFAULTTYPE_API Vec<4,double>;
+extern template class SOFA_DEFAULTTYPE_API Vec<4,unsigned>;
+
+extern template class SOFA_DEFAULTTYPE_API Vec<6,float>;
+extern template class SOFA_DEFAULTTYPE_API Vec<6,int>;
+extern template class SOFA_DEFAULTTYPE_API Vec<6,double>;
+extern template class SOFA_DEFAULTTYPE_API Vec<6,unsigned>;
+#endif
 
 typedef Vec<1,float> Vec1f;
 typedef Vec<1,double> Vec1d;

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/Vec.inl
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/Vec.inl
@@ -19,34 +19,63 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#define SOFA_DEFAULTTYPE_VEC_CPP
+#pragma once
 
-#include <sofa/defaulttype/Vec.inl>
+#include <sofa/defaulttype/Vec.h>
+#include <sofa/helper/rmath.h>
+
+#define EQUALITY_THRESHOLD 1e-6
+
 namespace sofa::defaulttype
 {
-template class Vec<1,float>;
-template class Vec<1,int>;
-template class Vec<1,double>;
-template class Vec<1,unsigned>;
 
-template class Vec<2,float>;
-template class Vec<2,int>;
-template class Vec<2,double>;
-template class Vec<2,unsigned>;
+/// Euclidean norm.
+template<std::size_t N, typename real>
+real Vec<N,real>::norm() const
+{
+    return helper::rsqrt(norm2());
+}
 
-template class Vec<3,float>;
-template class Vec<3,int>;
-template class Vec<3,double>;
-template class Vec<3,unsigned>;
+/// l-norm of the vector
+/// The type of norm is set by parameter l.
+/// Use l<0 for the infinite norm.
+template<std::size_t N, typename real>
+real Vec<N,real>::lNorm( int l ) const
+{
+    if( l==2 ) return norm(); // euclidian norm
+    else if( l<0 ) // infinite norm
+    {
+        real n=0;
+        for( std::size_t i=0; i<N; i++ )
+        {
+            real a = helper::rabs( this->elems[i] );
+            if( a>n ) n=a;
+        }
+        return n;
+    }
+    else if( l==1 ) // Manhattan norm
+    {
+        real n=0;
+        for( std::size_t i=0; i<N; i++ )
+        {
+            n += helper::rabs( this->elems[i] );
+        }
+        return n;
+    }
+    else if( l==0 ) // counting not null
+    {
+        real n=0;
+        for( std::size_t i=0; i<N; i++ )
+            if( this->elems[i] ) n+=1;
+        return n;
+    }
+    else // generic implementation
+    {
+        real n = 0;
+        for( std::size_t i=0; i<N; i++ )
+            n += pow( helper::rabs( this->elems[i] ), l );
+        return pow( n, real(1.0)/(real)l );
+    }
+}
 
-template class Vec<4,float>;
-template class Vec<4,int>;
-template class Vec<4,double>;
-template class Vec<4,unsigned>;
-
-template class Vec<6,float>;
-template class Vec<6,int>;
-template class Vec<6,double>;
-template class Vec<6,unsigned>;
-} // namespace sofa
-
+} /// namespace sofa::defaulttype

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/MarchingCubeUtility.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/MarchingCubeUtility.cpp
@@ -29,6 +29,7 @@
 #include <sofa/helper/MarchingCubeUtility.h>
 #include <sofa/helper/logging/Messaging.h>
 #include <stack>
+#include <sofa/helper/rmath.h>
 
 #define PRECISION 16384.0
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/io/XspLoader.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/io/XspLoader.cpp
@@ -26,6 +26,7 @@
 using sofa::defaulttype::Vector3;
 
 #include <sofa/core/objectmodel/Base.h>
+#include <sofa/helper/rmath.h>
 #include <cstdio>
 #include <iostream>
 #include <fstream>


### PR DESCRIPTION
To move rmath.h from the header I had to moved the code that rely on rmath into Vec.inl so that the include is not spread all around the codebase. Now if you want to instanciate special version of the Vec templates you need to include Vec.inl either. 






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
