### PR TITLE
[SofaHaptics] Add simple tests on LCPForceFeedback component

### DIFF
--- a/modules/SofaHaptics/CMakeLists.txt
+++ b/modules/SofaHaptics/CMakeLists.txt
@@ -34,6 +34,13 @@ sofa_create_package_with_targets(
     PACKAGE_VERSION ${PROJECT_VERSION}
     TARGETS ${PROJECT_NAME} AUTO_SET_TARGET_PROPERTIES
     INCLUDE_SOURCE_DIR "src"
-    INCLUDE_INSTALL_DIR "SofaHaptics"
+    INCLUDE_INSTALL_DIR "${PROJECT_NAME}"
     RELOCATABLE "plugins"
     )
+    
+# Tests
+cmake_dependent_option(SOFAHAPTICS_BUILD_TESTS "Compile the automatic tests" ON "SOFA_BUILD_TESTS OR NOT DEFINED SOFA_BUILD_TESTS" OFF)
+if(SOFAHAPTICS_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(SofaHaptics_test)
+endif()

--- a/modules/SofaHaptics/SofaHaptics_test/CMakeLists.txt
+++ b/modules/SofaHaptics/SofaHaptics_test/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(SofaHaptics_test)
+
+
+find_package(SofaCommon REQUIRED)
+find_package(SofaGeneral REQUIRED)
+
+set(SOURCE_FILES
+    LCPForceFeedback_test.cpp)
+
+add_definitions("-DSOFAHAPTICS_TEST_SCENES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/scenes\"")
+add_executable(${PROJECT_NAME} ${SOURCE_FILES})
+target_link_libraries(${PROJECT_NAME} SofaGTestMain SofaTest SofaHaptics SofaLoader SofaGeneralLoader )
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/modules/SofaHaptics/SofaHaptics_test/LCPForceFeedback_test.cpp
+++ b/modules/SofaHaptics/SofaHaptics_test/LCPForceFeedback_test.cpp
@@ -1,0 +1,115 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <sofa/helper/testing/BaseTest.h>
+
+#include <SofaSimulationGraph/DAGSimulation.h>
+
+#include <SofaCommon/initSofaCommon.h>
+#include <SofaBase/initSofaBase.h>
+#include <SofaGeneral/initSofaGeneral.h>
+
+#include <SofaBaseMechanics/MechanicalObject.h>
+#include <SofaHaptics/LCPForceFeedback.h>
+
+
+namespace sofa 
+{
+using sofa::simulation::Simulation;
+using sofa::simulation::Node;
+using sofa::core::ExecParams;
+
+
+//template <typename _DataTypes>
+class LCPForceFeedback_test : public sofa::helper::testing::BaseTest
+{
+public:
+    typedef sofa::component::container::MechanicalObject<sofa::defaulttype::Rigid3Types> MecaRig;
+    typedef sofa::component::controller::LCPForceFeedback<sofa::defaulttype::Rigid3Types> LCPRig;
+    typedef typename MecaRig::Coord    Coord;
+    typedef typename MecaRig::VecCoord VecCoord;
+    typedef typename MecaRig::MatrixDeriv MatrixDeriv;
+
+    bool test_InitScene();
+
+protected:
+    void loadTestScene(const std::string& filename);
+
+    Node::SPtr m_root;
+};
+
+
+void LCPForceFeedback_test::loadTestScene(const std::string& filename)
+{
+    sofa::component::initSofaBase();
+    sofa::component::initSofaCommon();
+    sofa::component::initSofaGeneral();
+
+    simulation::Simulation* simu;
+    sofa::simulation::setSimulation(simu = new sofa::simulation::graph::DAGSimulation());
+
+    /// Load the scene
+    std::string sceneFilename = std::string(SOFAHAPTICS_TEST_SCENES_DIR) + "/" + filename;
+    m_root = simu->createNewGraph("root");    
+    m_root = sofa::simulation::getSimulation()->load(sceneFilename.c_str());
+
+    EXPECT_NE(m_root, nullptr);
+
+    sofa::simulation::getSimulation()->init(m_root.get());
+}
+
+bool LCPForceFeedback_test::test_InitScene()
+{
+    loadTestScene("ToolvsFloorCollision_test.scn");
+
+    simulation::Node::SPtr instruNode = m_root->getChild("Instrument");
+    EXPECT_NE(instruNode, nullptr);
+    MecaRig::SPtr meca = instruNode->get<MecaRig>(instruNode->SearchDown);
+    LCPRig::SPtr lcp = instruNode->get<LCPRig>(instruNode->SearchDown);
+
+    // Check components access
+    EXPECT_NE(meca, nullptr);
+    EXPECT_NE(lcp, nullptr);
+
+    // Check meca size and init position
+    EXPECT_EQ(meca->getSize(), 1);
+    if (meca->getSize() > 0)
+    {
+        Coord rigZero;
+        const VecCoord& coords = meca->x.getValue();
+        EXPECT_EQ(coords[0], rigZero);
+    }
+    
+    // check meca constraint, expect no cons in this world
+    const MatrixDeriv& cons = meca->c.getValue();
+    EXPECT_EQ(cons.size(), 0);
+
+    return true;
+}
+
+TEST_F(LCPForceFeedback_test, test_InitScene)
+{
+    ASSERT_TRUE(test_InitScene());
+}
+
+
+} // namespace sofa

--- a/modules/SofaHaptics/SofaHaptics_test/LCPForceFeedback_test.cpp
+++ b/modules/SofaHaptics/SofaHaptics_test/LCPForceFeedback_test.cpp
@@ -221,19 +221,60 @@ bool LCPForceFeedback_test::test_Collision()
     trueForce = sofa::defaulttype::Vec3(0.0, 0.0, 0.0);
     EXPECT_EQ(force, trueForce);
     
+    
     // check position in contact
     lcp->computeForce(coords[0][0], coords[0][1], coords[0][2], 0, 0, 0, 0, force[0], force[1], force[2]);
-    trueForce = sofa::defaulttype::Vec3(-0.0016560039, 0.00276001, -2.5219651e-06);
+
+    // test with groundtruth, do it index by index for better log
+    Coord coordT = Coord(sofa::defaulttype::Vec3d(0.1083095508, -9.45640795, 0.01134330546), sofa::defaulttype::Quatd(0.01623300333, -0.006386979003, -0.408876291, 0.9124230788));
+
+    std::cout << std::setprecision(10) << "coords: " << coords[0] << std::endl;
+    std::cout << std::setprecision(10) << "force: " << force << std::endl;
+    //// position
+    EXPECT_FLOAT_EQ(coords[0][0], coordT[0]);
+    EXPECT_FLOAT_EQ(coords[0][1], coordT[1]);
+    EXPECT_FLOAT_EQ(coords[0][2], coordT[2]);
+
+    //// orientation
+    EXPECT_FLOAT_EQ(coords[0][3], coordT[3]);
+    EXPECT_FLOAT_EQ(coords[0][4], coordT[4]);
+    EXPECT_FLOAT_EQ(coords[0][5], coordT[5]);
+    EXPECT_FLOAT_EQ(coords[0][6], coordT[6]);
+
+    //// force
+    trueForce = sofa::defaulttype::Vec3(-0.00165600391, 0.002760009733, -2.52196513e-06);
     EXPECT_FLOAT_EQ(force[0], trueForce[0]);
     EXPECT_FLOAT_EQ(force[1], trueForce[1]);
     EXPECT_FLOAT_EQ(force[2], trueForce[2]);
 
+    std::cout << std::setprecision(10) << "trueForce: " << trueForce << std::endl;
+
     // check position inside collision
-    lcp->computeForce(coords[0][0], coords[0][1] - 1.0, coords[0][2], 0, 0, 0, 0, force[0], force[1], force[2]);
-    trueForce = sofa::defaulttype::Vec3(-0.1261571, 8.76024, -0.00076634827);
+    Coord inside = Coord(sofa::defaulttype::Vec3d(coords[0][0], coords[0][1] - 1.0, coords[0][2]), sofa::defaulttype::Quatd(0.01623300333, -0.006386979003, -0.408876291, 0.9124230788));
+    lcp->computeForce(inside[0], inside[1], inside[2], 0, 0, 0, 0, force[0], force[1], force[2]);
+
+    // test with groundtruth, do it index by index for better log
+    coordT = Coord(sofa::defaulttype::Vec3d(0.1083095508, -10.45640795, 0.01134330546), sofa::defaulttype::Quatd(0.01623300333, -0.006386979003, -0.408876291, 0.9124230788));
+    std::cout << std::setprecision(10) << "coords 2: " << inside << std::endl;
+    std::cout << std::setprecision(10) << "force 2: " << force << std::endl;
+
+    //// position
+    EXPECT_FLOAT_EQ(inside[0], coordT[0]);
+    EXPECT_FLOAT_EQ(inside[1], coordT[1]);
+    EXPECT_FLOAT_EQ(inside[2], coordT[2]);
+
+    //// orientation
+    EXPECT_FLOAT_EQ(inside[3], coordT[3]);
+    EXPECT_FLOAT_EQ(inside[4], coordT[4]);
+    EXPECT_FLOAT_EQ(inside[5], coordT[5]);
+    EXPECT_FLOAT_EQ(inside[6], coordT[6]);
+
+    //// force
+    trueForce = sofa::defaulttype::Vec3(-0.1261571029, 8.760242635, -0.00076634827);
     EXPECT_FLOAT_EQ(force[0], trueForce[0]);
     EXPECT_FLOAT_EQ(force[1], trueForce[1]);
     EXPECT_FLOAT_EQ(force[2], trueForce[2]);
+    std::cout << std::setprecision(10) << "trueForce 2: " << trueForce << std::endl;
 
     // check rigidTypes computeForce method
     VecDeriv forces;

--- a/modules/SofaHaptics/SofaHaptics_test/LCPForceFeedback_test.cpp
+++ b/modules/SofaHaptics/SofaHaptics_test/LCPForceFeedback_test.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 
 #include <sofa/helper/testing/BaseTest.h>
+#include <sofa/helper/testing/NumericTest.h>
 
 #include <SofaSimulationGraph/DAGSimulation.h>
 
@@ -47,14 +48,19 @@ public:
     typedef sofa::component::controller::LCPForceFeedback<sofa::defaulttype::Rigid3Types> LCPRig;
     typedef typename MecaRig::Coord    Coord;
     typedef typename MecaRig::VecCoord VecCoord;
+    typedef typename MecaRig::Deriv Deriv;
+    typedef typename MecaRig::VecDeriv VecDeriv;
     typedef typename MecaRig::MatrixDeriv MatrixDeriv;
 
     bool test_InitScene();
+
+    bool test_Collision();
 
 protected:
     void loadTestScene(const std::string& filename);
 
     Node::SPtr m_root;
+    SReal epsilonTest = 1e-6;
 };
 
 
@@ -106,9 +112,82 @@ bool LCPForceFeedback_test::test_InitScene()
     return true;
 }
 
+bool LCPForceFeedback_test::test_Collision()
+{
+    loadTestScene("ToolvsFloorCollision_test.scn");
+
+    simulation::Node::SPtr instruNode = m_root->getChild("Instrument");
+    EXPECT_NE(instruNode, nullptr);
+    MecaRig::SPtr meca = instruNode->get<MecaRig>(instruNode->SearchDown);
+    LCPRig::SPtr lcp = instruNode->get<LCPRig>(instruNode->SearchDown);
+
+    // Check components access
+    EXPECT_NE(meca, nullptr);
+    EXPECT_NE(lcp, nullptr);
+
+    // Check meca size and init position
+    EXPECT_EQ(meca->getSize(), 1);
+
+    simulation::Simulation* simu = sofa::simulation::getSimulation();
+    for (int step = 0; step < 100; step++)
+    {
+        simu->animate(m_root.get());
+    }
+
+    const VecCoord& coords = meca->x.getValue();
+    const MatrixDeriv& cons = meca->c.getValue();
+
+    // check position and constraint problem
+    EXPECT_LT(coords[0][1], -9.0);
+    EXPECT_EQ(cons.size(), 84);
+
+    // check LCP computeForce method
+    sofa::defaulttype::Vec3 position;
+    sofa::defaulttype::Vec3 force;
+    sofa::defaulttype::Vec3 trueForce;
+
+    // check out of problem position
+    lcp->computeForce(position[0], position[1], position[2], 0, 0, 0, 0, force[0], force[1], force[2]);
+    trueForce = sofa::defaulttype::Vec3(0.0, 0.0, 0.0);
+    EXPECT_EQ(force, trueForce);
+    
+    // check position in contact
+    lcp->computeForce(coords[0][0], coords[0][1], coords[0][2], 0, 0, 0, 0, force[0], force[1], force[2]);
+    trueForce = sofa::defaulttype::Vec3(-0.0016560039, 0.00276001, -2.5219651e-06);
+    EXPECT_FLOAT_EQ(force[0], trueForce[0]);
+    EXPECT_FLOAT_EQ(force[1], trueForce[1]);
+    EXPECT_FLOAT_EQ(force[2], trueForce[2]);
+
+    // check position inside collision
+    lcp->computeForce(coords[0][0], coords[0][1] - 1.0, coords[0][2], 0, 0, 0, 0, force[0], force[1], force[2]);
+    trueForce = sofa::defaulttype::Vec3(-0.1261571, 8.76024, -0.00076634827);
+    EXPECT_FLOAT_EQ(force[0], trueForce[0]);
+    EXPECT_FLOAT_EQ(force[1], trueForce[1]);
+    EXPECT_FLOAT_EQ(force[2], trueForce[2]);
+
+    // check rigidTypes computeForce method
+    VecDeriv forces;
+    lcp->computeForce(coords, forces);
+    EXPECT_EQ(forces.size(), 1);
+    EXPECT_NEAR(forces[0][0], -0.001656, epsilonTest);
+    EXPECT_NEAR(forces[0][1], 0.00276001, epsilonTest);
+    EXPECT_NEAR(forces[0][2], -2.52199e-06, epsilonTest);
+    EXPECT_NEAR(forces[0][3], 0.000150759, epsilonTest);
+    EXPECT_NEAR(forces[0][4], 8.95514e-05, epsilonTest);
+    EXPECT_NEAR(forces[0][5], -0.000989383, epsilonTest);
+
+    return true;
+}
+
+
 TEST_F(LCPForceFeedback_test, test_InitScene)
 {
     ASSERT_TRUE(test_InitScene());
+}
+
+TEST_F(LCPForceFeedback_test, test_Collision)
+{
+    ASSERT_TRUE(test_Collision());
 }
 
 

--- a/modules/SofaHaptics/SofaHaptics_test/LCPForceFeedback_test.cpp
+++ b/modules/SofaHaptics/SofaHaptics_test/LCPForceFeedback_test.cpp
@@ -172,8 +172,6 @@ bool LCPForceFeedback_test::test_SimpleCollision()
             EXPECT_FLOAT_EQ(coords[0][5], truthC[5]);
             EXPECT_FLOAT_EQ(coords[0][6], truthC[6]);
 
-
-            std::cout << std::setprecision(10) << coords[0][3] << " " << coords[0][4] << " " << coords[0][5] << " " << coords[0][6] << std::endl;
             pctTru++;
         }
     }
@@ -190,6 +188,9 @@ bool LCPForceFeedback_test::test_Collision()
     EXPECT_NE(instruNode, nullptr);
     MecaRig::SPtr meca = instruNode->get<MecaRig>(instruNode->SearchDown);
     LCPRig::SPtr lcp = instruNode->get<LCPRig>(instruNode->SearchDown);
+    
+    // Force only 2 iteration max for ci tests
+    lcp->d_solverMaxIt.setValue(2);
 
     // Check components access
     EXPECT_NE(meca, nullptr);
@@ -227,9 +228,6 @@ bool LCPForceFeedback_test::test_Collision()
 
     // test with groundtruth, do it index by index for better log
     Coord coordT = Coord(sofa::defaulttype::Vec3d(0.1083095508, -9.45640795, 0.01134330546), sofa::defaulttype::Quatd(0.01623300333, -0.006386979003, -0.408876291, 0.9124230788));
-
-    std::cout << std::setprecision(10) << "coords: " << coords[0] << std::endl;
-    std::cout << std::setprecision(10) << "force: " << force << std::endl;
     //// position
     EXPECT_FLOAT_EQ(coords[0][0], coordT[0]);
     EXPECT_FLOAT_EQ(coords[0][1], coordT[1]);
@@ -242,12 +240,10 @@ bool LCPForceFeedback_test::test_Collision()
     EXPECT_FLOAT_EQ(coords[0][6], coordT[6]);
 
     //// force
-    trueForce = sofa::defaulttype::Vec3(-0.00165600391, 0.002760009733, -2.52196513e-06);
+    trueForce = sofa::defaulttype::Vec3(-0.001655988795, 0.002759984308, -2.431849862e-06);
     EXPECT_FLOAT_EQ(force[0], trueForce[0]);
     EXPECT_FLOAT_EQ(force[1], trueForce[1]);
     EXPECT_FLOAT_EQ(force[2], trueForce[2]);
-
-    std::cout << std::setprecision(10) << "trueForce: " << trueForce << std::endl;
 
     // check position inside collision
     Coord inside = Coord(sofa::defaulttype::Vec3d(coords[0][0], coords[0][1] - 1.0, coords[0][2]), sofa::defaulttype::Quatd(0.01623300333, -0.006386979003, -0.408876291, 0.9124230788));
@@ -255,9 +251,6 @@ bool LCPForceFeedback_test::test_Collision()
 
     // test with groundtruth, do it index by index for better log
     coordT = Coord(sofa::defaulttype::Vec3d(0.1083095508, -10.45640795, 0.01134330546), sofa::defaulttype::Quatd(0.01623300333, -0.006386979003, -0.408876291, 0.9124230788));
-    std::cout << std::setprecision(10) << "coords 2: " << inside << std::endl;
-    std::cout << std::setprecision(10) << "force 2: " << force << std::endl;
-
     //// position
     EXPECT_FLOAT_EQ(inside[0], coordT[0]);
     EXPECT_FLOAT_EQ(inside[1], coordT[1]);
@@ -270,22 +263,22 @@ bool LCPForceFeedback_test::test_Collision()
     EXPECT_FLOAT_EQ(inside[6], coordT[6]);
 
     //// force
-    trueForce = sofa::defaulttype::Vec3(-0.1261571029, 8.760242635, -0.00076634827);
+    trueForce = sofa::defaulttype::Vec3(-0.1450155705, 8.930516304, 0.1567013005);
     EXPECT_FLOAT_EQ(force[0], trueForce[0]);
     EXPECT_FLOAT_EQ(force[1], trueForce[1]);
     EXPECT_FLOAT_EQ(force[2], trueForce[2]);
-    std::cout << std::setprecision(10) << "trueForce 2: " << trueForce << std::endl;
 
     // check rigidTypes computeForce method
     VecDeriv forces;
     lcp->computeForce(coords, forces);
+         
     EXPECT_EQ(forces.size(), 1);
-    EXPECT_NEAR(forces[0][0], -0.001656, epsilonTest);
-    EXPECT_NEAR(forces[0][1], 0.00276001, epsilonTest);
-    EXPECT_NEAR(forces[0][2], -2.52199e-06, epsilonTest);
-    EXPECT_NEAR(forces[0][3], 0.000150759, epsilonTest);
-    EXPECT_NEAR(forces[0][4], 8.95514e-05, epsilonTest);
-    EXPECT_NEAR(forces[0][5], -0.000989383, epsilonTest);
+    EXPECT_FLOAT_EQ(forces[0][0], -0.00164953925);
+    EXPECT_FLOAT_EQ(forces[0][1], 0.002749336856);
+    EXPECT_FLOAT_EQ(forces[0][2], -1.032894327e-05);
+    EXPECT_FLOAT_EQ(forces[0][3], 0.0001298280752);
+    EXPECT_FLOAT_EQ(forces[0][4], 7.443984612e-05);
+    EXPECT_FLOAT_EQ(forces[0][5], -0.0009855082698);
 
     return true;
 }

--- a/modules/SofaHaptics/SofaHaptics_test/LCPForceFeedback_test.cpp
+++ b/modules/SofaHaptics/SofaHaptics_test/LCPForceFeedback_test.cpp
@@ -54,6 +54,8 @@ public:
 
     bool test_InitScene();
 
+    bool test_SimpleCollision();
+
     bool test_Collision();
 
 protected:
@@ -111,6 +113,74 @@ bool LCPForceFeedback_test::test_InitScene()
 
     return true;
 }
+
+
+bool LCPForceFeedback_test::test_SimpleCollision()
+{
+    loadTestScene("ToolvsFloorCollision_test.scn");
+    simulation::Node::SPtr instruNode = m_root->getChild("Instrument");
+    EXPECT_NE(instruNode, nullptr);
+    MecaRig::SPtr meca = instruNode->get<MecaRig>(instruNode->SearchDown);
+    LCPRig::SPtr lcp = instruNode->get<LCPRig>(instruNode->SearchDown);
+
+
+    // Check components access
+    EXPECT_NE(meca, nullptr);
+    EXPECT_NE(lcp, nullptr);
+
+    // Check meca size and init position
+    EXPECT_EQ(meca->getSize(), 1);
+
+    simulation::Simulation* simu = sofa::simulation::getSimulation();
+
+    VecCoord truthCoords;
+    truthCoords.push_back(Coord(sofa::defaulttype::Vec3d(0, -0.002498750625, 0), sofa::defaulttype::Quatd(0, 0, 0, 1)));
+    truthCoords.push_back(Coord(sofa::defaulttype::Vec3d(0, -0.1646431247, 0), sofa::defaulttype::Quatd(0, 0, 0, 1)));
+    truthCoords.push_back(Coord(sofa::defaulttype::Vec3d(0, -0.5752928747, 0), sofa::defaulttype::Quatd(0, 0, 0, 1)));
+    truthCoords.push_back(Coord(sofa::defaulttype::Vec3d(0, -1.233208884, 0), sofa::defaulttype::Quatd(0, 0, 0, 1)));
+    truthCoords.push_back(Coord(sofa::defaulttype::Vec3d(0, -2.137158214, 0), sofa::defaulttype::Quatd(0, 0, 0, 1)));
+    truthCoords.push_back(Coord(sofa::defaulttype::Vec3d(0, -3.285914075, 0), sofa::defaulttype::Quatd(0, 0, 0, 1)));
+    truthCoords.push_back(Coord(sofa::defaulttype::Vec3d(0, -4.678255793, 0), sofa::defaulttype::Quatd(0, 0, 0, 1)));
+    truthCoords.push_back(Coord(sofa::defaulttype::Vec3d(0, -6.312968782, 0), sofa::defaulttype::Quatd(0, 0, 0, 1)));
+    truthCoords.push_back(Coord(sofa::defaulttype::Vec3d(0, -8.188844511, 0), sofa::defaulttype::Quatd(0, 0, 0, 1)));
+
+    truthCoords.push_back(Coord(sofa::defaulttype::Vec3d(0.06312707665, -9.252446766, 0.01034522507), sofa::defaulttype::Quatd(0.01791466055, -0.001121278545, -0.1466133921, 0.989031001)));
+    truthCoords.push_back(Coord(sofa::defaulttype::Vec3d(0.1068031131, -9.480637263, 0.01138742455), sofa::defaulttype::Quatd(0.01596551667, -0.006985361948, -0.4382452548, 0.8986864879)));
+    truthCoords.push_back(Coord(sofa::defaulttype::Vec3d(-0.003396912202, -9.692178925, 0.01301318567), sofa::defaulttype::Quatd(0.01059102598, -0.01374254084, -0.7148386272, 0.6990741805)));
+    truthCoords.push_back(Coord(sofa::defaulttype::Vec3d(-0.1668556563, -9.577363026, 0.03455744119), sofa::defaulttype::Quatd(-0.02439727795, -0.04585925265, -0.9016493065, 0.4293369653)));
+    truthCoords.push_back(Coord(sofa::defaulttype::Vec3d(-0.230611987, -9.409244076, 0.05034655108), sofa::defaulttype::Quatd(-0.06676044546, -0.08462859852, -0.9839281746, 0.1423600732)));
+    
+    int pctTru = 0; 
+    for (int step = 0; step < 140; step++)
+    {
+        simu->animate(m_root.get());
+
+        if (step % 10 == 0) 
+        {
+            const VecCoord& coords = meca->x.getValue();
+            const Coord& truthC = truthCoords[pctTru];
+
+            // test with groundtruth, do it index by index for better log
+            // position
+            EXPECT_FLOAT_EQ(coords[0][0], truthC[0]);
+            EXPECT_FLOAT_EQ(coords[0][1], truthC[1]);
+            EXPECT_FLOAT_EQ(coords[0][2], truthC[2]);
+
+            // orientation
+            EXPECT_FLOAT_EQ(coords[0][3], truthC[3]);
+            EXPECT_FLOAT_EQ(coords[0][4], truthC[4]);
+            EXPECT_FLOAT_EQ(coords[0][5], truthC[5]);
+            EXPECT_FLOAT_EQ(coords[0][6], truthC[6]);
+
+
+            std::cout << std::setprecision(10) << coords[0][3] << " " << coords[0][4] << " " << coords[0][5] << " " << coords[0][6] << std::endl;
+            pctTru++;
+        }
+    }
+
+    return true;
+}
+
 
 bool LCPForceFeedback_test::test_Collision()
 {
@@ -184,6 +254,12 @@ TEST_F(LCPForceFeedback_test, test_InitScene)
 {
     ASSERT_TRUE(test_InitScene());
 }
+
+TEST_F(LCPForceFeedback_test, test_SimpleCollision)
+{
+    ASSERT_TRUE(test_SimpleCollision());
+}
+
 
 TEST_F(LCPForceFeedback_test, test_Collision)
 {

--- a/modules/SofaHaptics/SofaHaptics_test/scenes/ToolvsFloorCollision_test.scn
+++ b/modules/SofaHaptics/SofaHaptics_test/scenes/ToolvsFloorCollision_test.scn
@@ -12,42 +12,42 @@
     
     <LCPConstraintSolver tolerance="0.001" maxIt="1000"/>
 
-	<Node name="Floor">
+    <Node name="Floor">
         <MeshObjLoader name="loaderF" filename="mesh/cube.obj" scale3d="20 0.5 20" translation="0 -10 0"/>
         <MeshTopology src="@loaderF" />
         <MechanicalObject src="@loaderF" />
         <TriangleCollisionModel simulated="0" moving="0" bothSide="false" group="1"/>
         <LineCollisionModel simulated="0" moving="0" group="1" />
         <PointCollisionModel simulated="0" moving="0" group="1"/>
-		<Node name="VisuFloor" >
+        <Node name="VisuFloor" >
             <OglModel name="FloorVisualModel"/>
             <IdentityMapping input="@../" output="@FloorVisualModel" />
         </Node>
     </Node>
 
-	<Node name="Instrument" >
+    <Node name="Instrument" >
         <EulerImplicitSolver name="ODE solver" rayleighStiffness="0.01" rayleighMass="0.01" />
         <SparseLDLSolver />
         
-		<MechanicalObject name="instrumentState" template="Rigid3" />
-		<UniformMass name="mass" totalMass="0.5" />
-		
+        <MechanicalObject name="instrumentState" template="Rigid3" />
+        <UniformMass name="mass" totalMass="0.5" />
+        
         <LCPForceFeedback name="LCPFF1" activate="true" forceCoef="1.0"/> 
         <LinearSolverConstraintCorrection />
-		
-		<Node name="VisuTool" >
+        
+        <Node name="VisuTool" >
             <MeshObjLoader name="meshLoader_1" filename="Demos/Dentistry/data/mesh/dental_instrument.obj" handleSeams="1" />
             <OglModel name="InstrumentVisualModel" src="@meshLoader_1" color="1.0 0.2 0.2 1.0" ry="-180" rz="-90" dz="3.5" dx="-0.3"/>
             <RigidMapping name="MM->VM mapping" input="@instrumentState" output="@InstrumentVisualModel" />
         </Node>
-		
+        
         <Node name="CollisionModel" >
             <MeshObjLoader filename="Demos/Dentistry/data/mesh/dental_instrument_centerline.obj"  name="loader"/>
             <MeshTopology src="@loader" name="InstrumentCollisionModel" />
             <MechanicalObject src="@loader" name="instrumentCollisionState"  ry="-180" rz="-90" dz="3.5" dx="-0.3" />
-            <LineCollisionModel contactStiffness="100"/>			
+            <LineCollisionModel contactStiffness="100"/>            
             <PointCollisionModel contactStiffness="100"/>
-            <RigidMapping name="MM->CM mapping" input="@instrumentState" output="@instrumentCollisionState" />		
+            <RigidMapping name="MM->CM mapping" input="@instrumentState" output="@instrumentCollisionState" />        
         </Node>       
     </Node> 
 

--- a/modules/SofaHaptics/SofaHaptics_test/scenes/ToolvsFloorCollision_test.scn
+++ b/modules/SofaHaptics/SofaHaptics_test/scenes/ToolvsFloorCollision_test.scn
@@ -1,0 +1,54 @@
+<?xml version="1.0" ?>
+<Node name="root" dt="0.05" showBoundingTree="0" gravity="0 -1 0">
+    <RequiredPlugin name='SofaOpenglVisual'/>
+    <RequiredPlugin name='SofaHaptics'/>
+    <RequiredPlugin name='SofaSparseSolver'/>
+    
+    <DefaultPipeline name="pipeline" depth="6" verbose="0"/>
+    <BruteForceDetection name="detection" />
+    <DefaultContactManager name="response" response="FrictionContact" />
+    <LocalMinDistance name="proximity" alarmDistance="1.0" contactDistance="0.1" angleCone="0.1" />
+    <FreeMotionAnimationLoop/>
+    
+    <LCPConstraintSolver tolerance="0.001" maxIt="1000"/>
+
+	<Node name="Floor">
+        <MeshObjLoader name="loaderF" filename="mesh/cube.obj" scale3d="20 0.5 20" translation="0 -10 0"/>
+        <MeshTopology src="@loaderF" />
+        <MechanicalObject src="@loaderF" />
+        <TriangleCollisionModel simulated="0" moving="0" bothSide="false" group="1"/>
+        <LineCollisionModel simulated="0" moving="0" group="1" />
+        <PointCollisionModel simulated="0" moving="0" group="1"/>
+		<Node name="VisuFloor" >
+            <OglModel name="FloorVisualModel"/>
+            <IdentityMapping input="@../" output="@FloorVisualModel" />
+        </Node>
+    </Node>
+
+	<Node name="Instrument" >
+        <EulerImplicitSolver name="ODE solver" rayleighStiffness="0.01" rayleighMass="0.01" />
+        <SparseLDLSolver />
+        
+		<MechanicalObject name="instrumentState" template="Rigid3" />
+		<UniformMass name="mass" totalMass="0.5" />
+		
+        <LCPForceFeedback name="LCPFF1" activate="true" forceCoef="0.0001"/> 
+        <LinearSolverConstraintCorrection />
+		
+		<Node name="VisuTool" >
+            <MeshObjLoader name="meshLoader_1" filename="Demos/Dentistry/data/mesh/dental_instrument.obj" handleSeams="1" />
+            <OglModel name="InstrumentVisualModel" src="@meshLoader_1" color="1.0 0.2 0.2 1.0" ry="-180" rz="-90" dz="3.5" dx="-0.3"/>
+            <RigidMapping name="MM->VM mapping" input="@instrumentState" output="@InstrumentVisualModel" />
+        </Node>
+		
+        <Node name="CollisionModel" >
+            <MeshObjLoader filename="Demos/Dentistry/data/mesh/dental_instrument_centerline.obj"  name="loader"/>
+            <MeshTopology src="@loader" name="InstrumentCollisionModel" />
+            <MechanicalObject src="@loader" name="instrumentCollisionState"  ry="-180" rz="-90" dz="3.5" dx="-0.3" />
+            <LineCollisionModel contactStiffness="100"/>			
+            <PointCollisionModel contactStiffness="100"/>
+            <RigidMapping name="MM->CM mapping" input="@instrumentState" output="@instrumentCollisionState" />		
+        </Node>       
+    </Node> 
+
+</Node>

--- a/modules/SofaHaptics/SofaHaptics_test/scenes/ToolvsFloorCollision_test.scn
+++ b/modules/SofaHaptics/SofaHaptics_test/scenes/ToolvsFloorCollision_test.scn
@@ -32,7 +32,7 @@
 		<MechanicalObject name="instrumentState" template="Rigid3" />
 		<UniformMass name="mass" totalMass="0.5" />
 		
-        <LCPForceFeedback name="LCPFF1" activate="true" forceCoef="0.0001"/> 
+        <LCPForceFeedback name="LCPFF1" activate="true" forceCoef="1.0"/> 
         <LinearSolverConstraintCorrection />
 		
 		<Node name="VisuTool" >

--- a/modules/SofaHaptics/src/SofaHaptics/LCPForceFeedback.h
+++ b/modules/SofaHaptics/src/SofaHaptics/LCPForceFeedback.h
@@ -72,6 +72,8 @@ public:
 
     Data< double > solverTimeout; ///< max time to spend solving constraints.
 
+    Data< int > d_solverMaxIt; ///< max iteration to spend solving constraints.
+
     // deriv (or not) the rotations when updating the violations
     Data <bool> d_derivRotations; ///< if true, deriv the rotations when updating the violations
 

--- a/modules/SofaHaptics/src/SofaHaptics/LCPForceFeedback.inl
+++ b/modules/SofaHaptics/src/SofaHaptics/LCPForceFeedback.inl
@@ -130,6 +130,7 @@ template <class DataTypes>
 LCPForceFeedback<DataTypes>::LCPForceFeedback()
     : forceCoef(initData(&forceCoef, 0.03, "forceCoef","multiply haptic force by this coef."))
     , solverTimeout(initData(&solverTimeout, 0.0008, "solverTimeout","max time to spend solving constraints."))
+    , d_solverMaxIt(initData(&d_solverMaxIt, 100, "solverMaxIt", "max iteration to spend solving constraints"))
     , d_derivRotations(initData(&d_derivRotations, false, "derivRotations", "if true, deriv the rotations when updating the violations"))
     , d_localHapticConstraintAllFrames(initData(&d_localHapticConstraintAllFrames, false, "localHapticConstraintAllFrames", "Flag to enable/disable constraint haptic influence from all frames"))
     , mState(nullptr)
@@ -293,7 +294,7 @@ void LCPForceFeedback<DataTypes>::doComputeForce(const VecCoord& state,  VecDeri
         s_mtx.lock();
 
         // Solving constraints
-        cp->solveTimed(cp->tolerance * 0.001, 100, solverTimeout.getValue());	// tol, maxIt, timeout
+        cp->solveTimed(cp->tolerance * 0.001, d_solverMaxIt.getValue(), solverTimeout.getValue());	// tol, maxIt, timeout
 
         s_mtx.unlock();
 


### PR DESCRIPTION
Add a Data<bool> maxIteration in LCPForceFeedBack to set a number max of iteration for the gauss seidel used to solve the constraint problem.

ADD LCPForceFeedback_test using a simple scene of a tool falling on a floor, checking constraint problem and request some force computation from LCPForceFeedback.

Will see in a next PR how to add a test on concurrent threads asking for LCP computeForce 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
