### PR TITLE
[SofaHelper] Link necessary Boost macro with SofaHelper (for Windows)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,9 +130,6 @@ endif()
 
 ### Windows config
 if(MSVC)
-    #define BOOST_ALL_DYN_LINK needed for dynamic linking with boost libraries
-    add_definitions(-DBOOST_ALL_DYN_LINK)
-
     # WinDepPack
     set(SOFA_DEPENDENCY_PACK_DIR "${CMAKE_SOURCE_DIR}" CACHE PATH "Directory containing Windows Dependency Pack")
     if(NOT EXISTS ${SOFA_DEPENDENCY_PACK_DIR})

--- a/SofaKernel/modules/SofaHelper/CMakeLists.txt
+++ b/SofaKernel/modules/SofaHelper/CMakeLists.txt
@@ -402,6 +402,11 @@ if(Boost_FOUND)
     if (SOFA_BUILD_RELEASE_PACKAGE OR CMAKE_SYSTEM_NAME STREQUAL Windows)
         sofa_install_libraries(PATHS ${Boost_LIBRARIES}) # Boost_LIBRARIES covers Boost internal dependencies
     endif()
+
+    if(MSVC)
+        #define BOOST_ALL_DYN_LINK needed for dynamic linking with boost libraries
+        target_compile_definitions(${PROJECT_NAME} PUBLIC BOOST_ALL_DYN_LINK)
+    endif()
 endif()
 
 # GTest


### PR DESCRIPTION
BOOST_ALL_DYN_LINK is necessary when using/compiling boost on Windows (weird boost linking stuff 😵)
It was defined in the root CMakeLists of SOFA, therefore this macro was not propagated to other projects needing Boost (SofaPython3 👀)
It is now linked with the target SofaHelper and is propagated to all projects using it.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
