### PR TITLE
[Flexible] FIX deps to pluginized modules

### DIFF
--- a/applications/plugins/Flexible/CMakeLists.txt
+++ b/applications/plugins/Flexible/CMakeLists.txt
@@ -3,6 +3,8 @@ project(Flexible VERSION 0.1)
 
 find_package(SofaMiscMapping REQUIRED)
 find_package(SofaValidation REQUIRED)
+find_package(SofaGeneralEngine REQUIRED)
+find_package(SofaBoundaryCondition REQUIRED)
 sofa_find_package(SofaPython REQUIRED)
 sofa_find_package(image QUIET)
 sofa_find_package(SofaHighOrderTopology QUIET)
@@ -225,7 +227,7 @@ endif()
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${PYTHON_FILES} ${README_FILES})
 
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaMiscMapping SofaValidation SofaBaseVisual)
+target_link_libraries(${PROJECT_NAME} PUBLIC SofaMiscMapping SofaValidation SofaBaseVisual SofaGeneralEngine SofaBoundaryCondition)
 target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/applications/plugins/Flexible/FlexibleConfig.cmake.in
+++ b/applications/plugins/Flexible/FlexibleConfig.cmake.in
@@ -9,6 +9,8 @@ set(FLEXIBLE_HAVE_SOFAHIGHORDERTOPOLOGY @FLEXIBLE_HAVE_SOFAHIGHORDERTOPOLOGY@)
 find_package(SofaMiscMapping REQUIRED)
 find_package(Eigen3 QUIET REQUIRED)
 find_package(SofaValidation REQUIRED)
+find_package(SofaGeneralEngine QUIET REQUIRED)
+find_package(SofaBoundaryCondition QUIET REQUIRED)
 
 if(FLEXIBLE_HAVE_SOFAPYTHON)
     find_package(SofaPython QUIET REQUIRED)


### PR DESCRIPTION
Fix 2 missing deps in Flexible due to pluginization.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
