### PR TITLE
[SofaKernel] Refactor the FileRepository constructors

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
@@ -76,37 +76,44 @@ std::string cleanPath( const std::string& path )
 
 // Initialize PluginRepository and DataRepository
 #ifdef WIN32
-FileRepository PluginRepository( "SOFA_PLUGIN_PATH", Utils::getExecutableDirectory().c_str() );
+FileRepository PluginRepository(
+        "SOFA_PLUGIN_PATH", {
+            Utils::getExecutableDirectory(),
+            Utils::getSofaPathTo("plugins")
+        }
+);
 #else
-FileRepository PluginRepository( "SOFA_PLUGIN_PATH", Utils::getSofaPathTo("lib").c_str() );
+FileRepository PluginRepository(
+        "SOFA_PLUGIN_PATH", {
+            Utils::getSofaPathTo("lib"),
+            Utils::getSofaPathTo("plugins"),
+        }
+);
 #endif
-FileRepository DataRepository( "SOFA_DATA_PATH", 0, {
+FileRepository DataRepository( "SOFA_DATA_PATH", nullptr, {
                                    { Utils::getSofaPathTo("etc/sofa.ini"), {"SHARE_DIR", "EXAMPLES_DIR"} }
                                });
 
-
-FileRepository::FileRepository(const char* envVar, const char* relativePath, const fileKeysMap& iniFilesAndKeys)
-{
+FileRepository::FileRepository(const char* envVar, const std::vector<std::string> & paths, const fileKeysMap& iniFilesAndKeys) {
     if (envVar != nullptr && envVar[0]!='\0')
     {
         const char* envpath = getenv(envVar);
         if (envpath != nullptr && envpath[0]!='\0')
             addFirstPath(envpath);
     }
-    if (relativePath != nullptr && relativePath[0]!='\0')
-    {
-        std::string path = relativePath;
-        size_t p0 = 0;
-        while ( p0 < path.size() )
-        {
-            size_t p1 = path.find(entrySeparator(),p0);
-            if (p1 == std::string::npos) p1 = path.size();
-            if (p1>p0+1)
-            {
-                std::string p = path.substr(p0,p1-p0);
-                addLastPath(SetDirectory::GetRelativeFromProcess(p.c_str()));
+
+    for (const auto & path : paths) {
+        if (!path.empty()) {
+            size_t p0 = 0;
+            while (p0 < path.size()) {
+                size_t p1 = path.find(entrySeparator(), p0);
+                if (p1 == std::string::npos) p1 = path.size();
+                if (p1 > p0 + 1) {
+                    std::string p = path.substr(p0, p1 - p0);
+                    addLastPath(SetDirectory::GetRelativeFromProcess(p.c_str()));
+                }
+                p0 = p1 + 1;
             }
-            p0 = p1+1;
         }
     }
     if ( !iniFilesAndKeys.empty() )

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.h
@@ -59,8 +59,40 @@ class SOFA_HELPER_API FileRepository
 public:
     typedef std::map< std::string, std::list<std::string> > fileKeysMap;
 
-    /// Initialize the set of paths from an environment variable.
-    FileRepository(const char* envVar = "SOFA_DATA_PATH", const char* relativePath = nullptr, const fileKeysMap& iniFilesAndKeys = {});
+    /**
+     * Initialize the set of paths using the environment variable SOFA_DATA_PATH as default.
+     */
+    FileRepository() : FileRepository("SOFA_DATA_PATH", nullptr, {}) {};
+
+    /**
+     * Initialize the set of paths using the environment variable specified by the parameter envVar.
+     */
+    FileRepository(const char* envVar) : FileRepository(envVar, nullptr, {}) {};
+
+    /**
+     * Initialize the set of paths using the environment variable specified by the parameter envVar and the relative path
+     * specified by the parameter relativePath.
+     */
+    FileRepository(const char* envVar,  const char* relativePath) : FileRepository(envVar, relativePath, {}) {};
+
+    /**
+     * Initialize the set of paths using the environment variable specified by the parameter envVar and the relative paths
+     * specified by the parameter paths.
+     */
+    FileRepository(const char* envVar,  const std::vector<std::string> & paths) : FileRepository(envVar, paths, {}) {};
+
+    /**
+     * Initialize the set of paths using the environment variable specified by the parameter envVar, the relative path
+     * specified by the parameter relativePath and the ini files and respective keys specified by the paramter iniFilesAndKeys.
+     */
+    FileRepository(const char* envVar, const char* relativePath, const fileKeysMap& iniFilesAndKeys)
+    : FileRepository(envVar, {relativePath?std::string(relativePath):""}, iniFilesAndKeys) {}
+
+    /**
+     * Initialize the set of paths using the environment variable specified by the parameter envVar, the relative paths
+     * specified by the parameter paths and the ini files and respective keys specified by the paramter iniFilesAndKeys.
+     */
+    FileRepository(const char* envVar, const std::vector<std::string> & paths, const fileKeysMap& iniFilesAndKeys);
 
     ~FileRepository();
 

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -137,12 +137,6 @@ int main(int argc, char** argv)
         }
     }
 
-    // Add plugins dir to PluginRepository
-    if ( FileSystem::isDirectory(Utils::getSofaPathPrefix()+"/plugins") )
-    {
-        PluginRepository.addFirstPath(Utils::getSofaPathPrefix()+"/plugins");
-    }
-
     sofa::helper::BackTrace::autodump();
 
 #ifdef WIN32


### PR DESCRIPTION
Split the default parameters of the FileRepository constructor into
multiple constructors to avoid ambiguous calls.

Add a new constructor that allows the creation of the repository using
multiple paths.

The plugin file repository is now initialized using both $SOFA_ROOT/lib
and $SOFA_ROOT/plugins.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
