### PR TITLE
[SofaKernel] FIX PluginManager::pluginIsLoaded

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
@@ -370,25 +370,25 @@ std::string PluginManager::findPlugin(const std::string& pluginName, const std::
     return std::string();
 }
 
-bool PluginManager::pluginIsLoaded(const std::string& pluginName)
+bool PluginManager::pluginIsLoaded(const std::string& plugin)
 {
-    std::string pluginPath = pluginName;
+    std::string pluginPath = plugin;
 
     /// If we are not providing a filename then we have either to iterate in the plugin
     /// map to check no plugin has the same name or check in there is no accessible path
     /// in the plugin repository matching the pluginName
-    if (!FileSystem::isFile(pluginName))
+    if (!FileSystem::isFile(plugin))
     {
         /// Here is the iteration in the loaded plugin map
         for(auto k : m_pluginMap)
         {
-            if(pluginName == k.second.getModuleName())
+            if(plugin == k.second.getModuleName())
                 return true;
         }
 
         /// At this point we have not found a loaded plugin, we try to
         /// explore if the filesystem can help.
-        pluginPath = findPlugin(pluginName);
+        pluginPath = findPlugin(plugin);
     }
 
     /// Check that the path (either provided by user or through the call to findPlugin()

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
@@ -370,17 +370,31 @@ std::string PluginManager::findPlugin(const std::string& pluginName, const std::
     return std::string();
 }
 
-bool PluginManager::pluginIsLoaded(const std::string& plugin)
+bool PluginManager::pluginIsLoaded(const std::string& pluginName)
 {
-    std::string pluginPath = plugin;
+    std::string pluginPath = pluginName;
 
-    if (!FileSystem::isFile(plugin)) {
-        pluginPath = findPlugin(plugin);
+    /// If we are not providing a filename then we have either to iterate in the plugin
+    /// map to check no plugin has the same name or check in there is no accessible path
+    /// in the plugin repository matching the pluginName
+    if (!FileSystem::isFile(pluginName))
+    {
+        /// Here is the iteration in the loaded plugin map
+        for(auto k : m_pluginMap)
+        {
+            if(pluginName == k.second.getModuleName())
+                return true;
+        }
+
+        /// At this point we have not found a loaded plugin, we try to
+        /// explore if the filesystem can help.
+        pluginPath = findPlugin(pluginName);
     }
 
+    /// Check that the path (either provided by user or through the call to findPlugin()
+    /// leads to a loaded plugin.
     return m_pluginMap.find(pluginPath) != m_pluginMap.end();
 }
-
 
 bool PluginManager::checkDuplicatedPlugin(const Plugin& plugin, const std::string& pluginPath)
 {


### PR DESCRIPTION
The function pluginIsLoaded is not behaving as it name suggest and does not detect plugin that have not been loaded using an absolute file path. 

See: 
https://github.com/SofaDefrost/plugin.SofaPython3.deprecated/issues/137





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
