### PR TITLE
[SofaMacros] FIX plugins RPATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,6 @@ if(UNIX)
 
     # see https://cmake.org/Wiki/CMake_RPATH_handling for $ORIGIN doc
     set(CMAKE_INSTALL_RPATH
-        "../lib"
         "$ORIGIN/../lib"
         "$$ORIGIN/../lib"
         )

--- a/SofaKernel/SofaFramework/CMakeLists.txt
+++ b/SofaKernel/SofaFramework/CMakeLists.txt
@@ -12,6 +12,14 @@ set(SOFA_VERSION "${Sofa_VERSION_MAJOR}${Sofa_VERSION_MINOR}${Sofa_VERSION_PATCH
 set_property(GLOBAL PROPERTY __GlobalTargetList__ "")
 set_property(GLOBAL PROPERTY __GlobalTargetNameList__ "")
 
+# Help RELOCATABLE plugins to resolve their dependencies.
+# See SofaMacrosInstall.cmake for usage of this property.
+define_property(TARGET
+    PROPERTY "RELOCATABLE_INSTALL_DIR"
+    BRIEF_DOCS "Install directory of RELOCATABLE target"
+    FULL_DOCS "Install directory of RELOCATABLE target"
+    )
+
 # Options
 option(SOFA_DETECTIONOUTPUT_FREEMOTION "Compile Sofa with the DETECTIONOUTPUT_FREEMOTION macro defined." OFF)
 option(SOFA_NO_OPENGL "Compile Sofa with no OpenGL support. (This will define the SOFA_NO_OPENGL macro.)" OFF)

--- a/SofaKernel/SofaFramework/SofaFrameworkConfig.cmake.in
+++ b/SofaKernel/SofaFramework/SofaFrameworkConfig.cmake.in
@@ -21,6 +21,14 @@ endif()
 list(APPEND CMAKE_INCLUDE_PATH "${SOFA_ROOT}/include/extlibs/WinDepPack")
 list(APPEND CMAKE_MODULE_PATH "${SOFA_ROOT}/lib/cmake/Modules")
 
+# Help RELOCATABLE plugins to resolve their dependencies.
+# See SofaMacrosInstall.cmake for usage of this property.
+define_property(TARGET
+    PROPERTY "RELOCATABLE_INSTALL_DIR"
+    BRIEF_DOCS "Install directory of RELOCATABLE target"
+    FULL_DOCS "Install directory of RELOCATABLE target"
+    )
+
 include(SofaMacros)
 
 set(SOFAFRAMEWORK_TARGETS @SOFAFRAMEWORK_TARGETS@)

--- a/tools/postinstall-fixup/windows-postinstall-fixup.sh
+++ b/tools/postinstall-fixup/windows-postinstall-fixup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!bash
 
 usage() {
     echo "Usage: windows-postinstall-fixup.sh <build-dir> <install-dir>"
@@ -26,4 +26,10 @@ for plugin in \
         SofaMiscCollision  \
     ; do
     grep "$plugin" "$INSTALL_DIR/bin/plugin_list.conf.default" >> "$INSTALL_DIR/bin/plugin_list.conf"
+done
+
+# Link all plugin libs in install/bin to make them easily findable
+cd "$INSTALL_DIR" && find "plugins" -name "*.dll" | while read lib; do
+    libname="$(basename $lib)"
+    ln -s "../$lib" "bin/$libname"
 done


### PR DESCRIPTION
This PR adds custom RPATH to handle dependencies to relocatable targets that will be installed in the "plugins" directory.

3 cases are handled:
- A non-relocatable library depends on a relocatable library
- A relocatable library depends on a relocatable library
- A relocatable library depends on a non-relocatable library

WARNING: note that this is a hacky fix based on the hacky RELOCATABLE "feature". 
TODO: rework the CMake files to replace the relocatable mechanism by something more standard.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
