### PR TITLE
[SofaDefaultType] FIX missing override warnings

### DIFF
--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/typeinfo/DataTypeInfoDynamicWrapper.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/typeinfo/DataTypeInfoDynamicWrapper.h
@@ -77,8 +77,8 @@ public:
 
     static AbstractTypeInfo* get() { static DataTypeInfoDynamicWrapper<Info> t; return &t; }
 
-    virtual const TypeInfoId& getBaseTypeId() const { return TypeInfoId::GetTypeId<typename Info::BaseType>(); }
-    virtual const TypeInfoId& getValueTypeId() const { return TypeInfoId::GetTypeId<typename Info::ValueType>(); }
+    const TypeInfoId& getBaseTypeId() const override { return TypeInfoId::GetTypeId<typename Info::BaseType>(); }
+    const TypeInfoId& getValueTypeId() const override { return TypeInfoId::GetTypeId<typename Info::ValueType>(); }
 
     std::string name() const override { return Info::name(); }
     std::string getTypeName() const override {return Info::name();}

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/typeinfo/NameOnlyTypeInfo.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/typeinfo/NameOnlyTypeInfo.h
@@ -124,8 +124,8 @@ public:
     virtual const std::type_info* type_info() const {return &typeid(this); }
 
 protected:
-    virtual const TypeInfoId& getBaseTypeId() const { return TypeInfoId::GetTypeId<NoTypeInfo>(); }
-    virtual const TypeInfoId& getValueTypeId() const  { return TypeInfoId::GetTypeId<NoTypeInfo>(); }
+    const TypeInfoId& getBaseTypeId() const override { return TypeInfoId::GetTypeId<NoTypeInfo>(); }
+    const TypeInfoId& getValueTypeId() const override { return TypeInfoId::GetTypeId<NoTypeInfo>(); }
 
 private:
     std::string m_name;

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/typeinfo/NoTypeInfo.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/typeinfo/NoTypeInfo.h
@@ -120,8 +120,8 @@ public:
     virtual const std::type_info* type_info() const {return &typeid(this); }
 
 protected:
-    virtual const TypeInfoId& getBaseTypeId() const { return TypeInfoId::GetTypeId<NoTypeInfo>(); }
-    virtual const TypeInfoId& getValueTypeId() const  { return TypeInfoId::GetTypeId<NoTypeInfo>(); }
+    const TypeInfoId& getBaseTypeId() const override { return TypeInfoId::GetTypeId<NoTypeInfo>(); }
+    const TypeInfoId& getValueTypeId() const override { return TypeInfoId::GetTypeId<NoTypeInfo>(); }
 
 };
 


### PR DESCRIPTION
6572 warnings about these missing `override` on MacOS are making the build logs explode :sweat_smile: 
This PR fixes that.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
