### PR TITLE
[all] Remove equality operator from Data

### DIFF
--- a/SofaKernel/SofaFramework/src/sofa/config.h.in
+++ b/SofaKernel/SofaFramework/src/sofa/config.h.in
@@ -118,7 +118,7 @@ typedef unsigned __int64	uint64_t;
 #define SOFA_BEGIN_DEPRECATION_AS_ERROR _Pragma("warning( push )") \
                                    _Pragma("warning(error: 4996)")
 #define SOFA_END_DEPRECATION_AS_ERROR _Pragma("warning( pop )")
-#elif defined(__GNU__)
+#elif defined(__GNUC__)
 #define SOFA_BEGIN_DEPRECATION_AS_ERROR _Pragma("GCC push_options") \
                                    _Pragma("GCC diagnostic error \"-Wdeprecated-declarations\"")
 #define SOFA_END_DEPRECATION_AS_ERROR _Pragma("GCC pop_options")

--- a/SofaKernel/SofaFramework/src/sofa/config.h.in
+++ b/SofaKernel/SofaFramework/src/sofa/config.h.in
@@ -113,19 +113,19 @@ typedef unsigned __int64	uint64_t;
 #define sofa_do_tostring(a) #a
 #define sofa_tostring(a) sofa_do_tostring(a)
 
-///////////////////// These two macro can be used to convert deprecation attributes as error.
+///////////////////// These macros can be used to convert deprecation attributes as error.
 #if defined(_MSC_VER)
-#define BEGIN_DEPRECATION_AS_ERROR _Pragma("warning( push )") \
+#define SOFA_BEGIN_DEPRECATION_AS_ERROR _Pragma("warning( push )") \
                                    _Pragma("warning(error: 4996)")
-#define END_DEPRECATION_AS_ERROR _Pragma("warning( pop )")
+#define SOFA_END_DEPRECATION_AS_ERROR _Pragma("warning( pop )")
 #elif defined(__GNU__)
-#define BEGIN_DEPRECATION_AS_ERROR _Pragma("GCC push_options") \
+#define SOFA_BEGIN_DEPRECATION_AS_ERROR _Pragma("GCC push_options") \
                                    _Pragma("GCC diagnostic error \"-Wdeprecated-declarations\"")
-#define END_DEPRECATION_AS_ERROR _Pragma("GCC pop_options")
+#define SOFA_END_DEPRECATION_AS_ERROR _Pragma("GCC pop_options")
 #else /// clang
-#define BEGIN_DEPRECATION_AS_ERROR _Pragma("clang diagnostic push") \
+#define SOFA_BEGIN_DEPRECATION_AS_ERROR _Pragma("clang diagnostic push") \
                                    _Pragma("clang diagnostic error \"-Wdeprecated-declarations\"")
-#define END_DEPRECATION_AS_ERROR _Pragma("clang diagnostic pop")
+#define SOFA_END_DEPRECATION_AS_ERROR _Pragma("clang diagnostic pop")
 #endif
 
 

--- a/SofaKernel/SofaFramework/src/sofa/config.h.in
+++ b/SofaKernel/SofaFramework/src/sofa/config.h.in
@@ -113,6 +113,22 @@ typedef unsigned __int64	uint64_t;
 #define sofa_do_tostring(a) #a
 #define sofa_tostring(a) sofa_do_tostring(a)
 
+///////////////////// These two macro can be used to convert deprecation attributes as error.
+#if defined(_MSC_VER)
+#define BEGIN_DEPRECATION_AS_ERROR _Pragma("warning( push )") \
+                                   _Pragma("warning(error: 4996)")
+#define END_DEPRECATION_AS_ERROR _Pragma("warning( pop )")
+#elif defined(__GNU__)
+#define BEGIN_DEPRECATION_AS_ERROR _Pragma("GCC push_options") \
+                                   _Pragma("GCC diagnostic error \"-Wdeprecated-declarations\"")
+#define END_DEPRECATION_AS_ERROR _Pragma("GCC pop_options")
+#else /// clang
+#define BEGIN_DEPRECATION_AS_ERROR _Pragma("clang diagnostic push") \
+                                   _Pragma("clang diagnostic error \"-Wdeprecated-declarations\"")
+#define END_DEPRECATION_AS_ERROR _Pragma("clang diagnostic pop")
+#endif
+
+
 #ifdef _WIN32
 #  define SOFA_PRAGMA_MESSAGE(text) __pragma(message(__FILE__ "(" sofa_tostring(__LINE__) "): " #text))
 #  define SOFA_PRAGMA_WARNING(text) __pragma(message(__FILE__ "(" sofa_tostring(__LINE__) "): warning: " #text))

--- a/SofaKernel/SofaFramework/src/sofa/config.h.in
+++ b/SofaKernel/SofaFramework/src/sofa/config.h.in
@@ -119,9 +119,9 @@ typedef unsigned __int64	uint64_t;
                                    _Pragma("warning(error: 4996)")
 #define SOFA_END_DEPRECATION_AS_ERROR _Pragma("warning( pop )")
 #elif defined(__GNUC__)
-#define SOFA_BEGIN_DEPRECATION_AS_ERROR _Pragma("GCC push_options") \
+#define SOFA_BEGIN_DEPRECATION_AS_ERROR _Pragma("GCC diagnostic push") \
                                    _Pragma("GCC diagnostic error \"-Wdeprecated-declarations\"")
-#define SOFA_END_DEPRECATION_AS_ERROR _Pragma("GCC pop_options")
+#define SOFA_END_DEPRECATION_AS_ERROR _Pragma("GCC diagnostic pop")
 #else /// clang
 #define SOFA_BEGIN_DEPRECATION_AS_ERROR _Pragma("clang diagnostic push") \
                                    _Pragma("clang diagnostic error \"-Wdeprecated-declarations\"")

--- a/SofaKernel/SofaFramework/src/sofa/config.h.in
+++ b/SofaKernel/SofaFramework/src/sofa/config.h.in
@@ -115,9 +115,9 @@ typedef unsigned __int64	uint64_t;
 
 ///////////////////// These macros can be used to convert deprecation attributes as error.
 #if defined(_MSC_VER)
-#define SOFA_BEGIN_DEPRECATION_AS_ERROR _Pragma("warning( push )") \
-                                   _Pragma("warning(error: 4996)")
-#define SOFA_END_DEPRECATION_AS_ERROR _Pragma("warning( pop )")
+#define SOFA_BEGIN_DEPRECATION_AS_ERROR __pragma("warning( push )") \
+                                        __pragma("warning(error: 4996)")
+#define SOFA_END_DEPRECATION_AS_ERROR __pragma("warning( pop )")
 #elif defined(__GNUC__)
 #define SOFA_BEGIN_DEPRECATION_AS_ERROR _Pragma("GCC diagnostic push") \
                                    _Pragma("GCC diagnostic error \"-Wdeprecated-declarations\"")

--- a/SofaKernel/modules/SofaBaseVisual/BaseCamera.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/BaseCamera.cpp
@@ -576,7 +576,7 @@ void BaseCamera::rotateWorldAroundPoint(Quat &rotation, const Vec3 &point, Quat 
 
 BaseCamera::Vec3 BaseCamera::screenToViewportPoint(const BaseCamera::Vec3& p) const
 {
-    if (p_widthViewport == 0 || p_heightViewport == 0)
+    if (p_widthViewport.getValue() == 0 || p_heightViewport.getValue() == 0)
         return Vec3(0, 0, p.z());
     return Vec3(p.x() / this->p_widthViewport.getValue(),
                 p.y() / this->p_heightViewport.getValue(),

--- a/SofaKernel/modules/SofaCore/src/sofa/core/loader/MeshLoader.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/loader/MeshLoader.cpp
@@ -207,7 +207,7 @@ void MeshLoader::reinit()
 
     if (transformation != Matrix4::s_identity)
     {
-        if (d_scale != Vec3(1.0, 1.0, 1.0) || d_rotation != Vec3(0.0, 0.0, 0.0) || d_translation != Vec3(0.0, 0.0, 0.0))
+        if (d_scale.getValue() != Vec3(1.0, 1.0, 1.0) || d_rotation.getValue() != Vec3(0.0, 0.0, 0.0) || d_translation.getValue() != Vec3(0.0, 0.0, 0.0))
         {
             msg_info() << "Parameters scale, rotation, translation ignored in favor of transformation matrix";
         }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -510,7 +510,7 @@ public:
     /// @{
 
     ComponentState getComponentState() const { return d_componentState.getValue() ; }
-    bool isComponentStateValid() const { return d_componentState == ComponentState::Valid; }
+    bool isComponentStateValid() const { return d_componentState.getValue() == ComponentState::Valid; }
 
     ///@}
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
@@ -330,19 +330,19 @@ public:
         return out;
     }
 
-BEGIN_DEPRECATION_AS_ERROR
-    [[deprecated("Deprecated before definitive removal (see PR#1639). Please update your code by replacing 'myData == aAlue' with 'myData.getValue() == aValue'")]]
+SOFA_BEGIN_DEPRECATION_AS_ERROR
+    [[deprecated("Deprecated before definitive removal (see PR#1639). Please update your code by replacing 'myData == aValue' with 'myData.getValue() == aValue'")]]
     inline bool operator ==( const T& value ) const
     {
             return getValue()==value;
     }
 
-    [[deprecated("Deprecated before definitive removal (see PR#1639). Please update your code by replacing 'myData != aAlue' with 'myData.getValue() != aValue'")]]
+    [[deprecated("Deprecated before definitive removal (see PR#1639). Please update your code by replacing 'myData != aValue' with 'myData.getValue() != aValue'")]]
     inline bool operator !=( const T& value ) const
     {
             return getValue()!=value;
     }
-END_DEPRECATION_AS_ERROR
+SOFA_END_DEPRECATION_AS_ERROR
 
     inline void operator =( const T& value )
     {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
@@ -330,6 +330,20 @@ public:
         return out;
     }
 
+BEGIN_DEPRECATION_AS_ERROR
+    [[deprecated("Deprecated before definitive removal (see PR#1639). Please update your code by replacing 'myData == aAlue' with 'myData.getValue() == aValue'")]]
+    inline bool operator ==( const T& value ) const
+    {
+            return getValue()==value;
+    }
+
+    [[deprecated("Deprecated before definitive removal (see PR#1639). Please update your code by replacing 'myData != aAlue' with 'myData.getValue() != aValue'")]]
+    inline bool operator !=( const T& value ) const
+    {
+            return getValue()!=value;
+    }
+END_DEPRECATION_AS_ERROR
+
     inline void operator =( const T& value )
     {
         this->setValue(value);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
@@ -330,16 +330,6 @@ public:
         return out;
     }
 
-    inline bool operator ==( const T& value ) const
-    {
-        return getValue()==value;
-    }
-
-    inline bool operator !=( const T& value ) const
-    {
-        return getValue()!=value;
-    }
-
     inline void operator =( const T& value )
     {
         this->setValue(value);

--- a/applications/plugins/SensableEmulation/OmniDriverEmu.cpp
+++ b/applications/plugins/SensableEmulation/OmniDriverEmu.cpp
@@ -277,7 +277,7 @@ void *hapticSimuExecute( void *ptr )
             // store actual position of interface for the forcefeedback (as it will be used as soon as new LCP will be computed)
             for (unsigned int i=0; i<omniDrv->data.forceFeedbacks.size(); i++)
             {
-                if (omniDrv->data.forceFeedbacks[i]->d_indice==omniDrv->data.forceFeedbackIndice)
+                if (omniDrv->data.forceFeedbacks[i]->d_indice.getValue()==omniDrv->data.forceFeedbackIndice)
                 {
                     omniDrv->data.forceFeedbacks[i]->computeWrench(world_H_virtualTool,temp1,temp2);
                 }
@@ -490,7 +490,7 @@ void OmniDriverEmu::handleEvent(core::objectmodel::Event *event)
                 // store actual position of interface for the forcefeedback (as it will be used as soon as new LCP will be computed)
                 //data.forceFeedback->setReferencePosition(world_H_virtualTool);
                 for (unsigned int i=0; i<data.forceFeedbacks.size(); i++)
-                    if (data.forceFeedbacks[i]->d_indice==data.forceFeedbackIndice)
+                    if (data.forceFeedbacks[i]->d_indice.getValue()==data.forceFeedbackIndice)
                         data.forceFeedbacks[i]->setReferencePosition(world_H_virtualTool);
 
                 //-----------------------------

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SurfacePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SurfacePressureForceField.inl
@@ -437,7 +437,7 @@ void SurfacePressureForceField<DataTypes>::addQuadSurfacePressure(unsigned int q
 template <class DataTypes>
 bool SurfacePressureForceField<DataTypes>::isInPressuredBox(const Coord &x) const
 {
-    if ( (m_max == Coord()) && (m_min == Coord()) )
+    if ( (m_max.getValue() == Coord()) && (m_min.getValue() == Coord()) )
         return true;
 
     return ( (x[0] >= m_min.getValue()[0])

--- a/modules/SofaGeneralAnimationLoop/src/SofaGeneralAnimationLoop/MechanicalMatrixMapper.inl
+++ b/modules/SofaGeneralAnimationLoop/src/SofaGeneralAnimationLoop/MechanicalMatrixMapper.inl
@@ -131,7 +131,7 @@ void MechanicalMatrixMapper<DataTypes1, DataTypes2>::parseNode(sofa::simulation:
     msg_info() << "parsing node:";
     for(BaseForceField* forcefield : node->forceField)
     {
-        if (forcefield->name != massName)
+        if (forcefield->name.getValue() != massName)
         {
             bool found = true;
             if (!empty)

--- a/modules/SofaValidation/SofaValidation_test/Monitor_test.cpp
+++ b/modules/SofaValidation/SofaValidation_test/Monitor_test.cpp
@@ -31,7 +31,7 @@ struct MonitorTest : public Monitor<Rigid3Types>
         EXPECT_TRUE(i1.size() == i2.size());
         for (size_t i = 0; i < i1.size(); ++i) EXPECT_EQ(i1[i], i2[i]);
 
-        EXPECT_EQ(d_fileName, std::string("./") + getName());
+        EXPECT_EQ(d_fileName.getValue(), std::string("./") + getName());
     }
 
     void testModif(MechanicalObject<Rigid3Types>* mo)


### PR DESCRIPTION
The rational is that we should reduce as much as possible the interface size of an object as long as the same service can be done in our case the two variation are:
myData == value
vs
myData.getValue() == value

The second one has the advantage:
- to make explicit that there is computation/accessor. 
- the object we put in Data<> does not need anymore to have == operators. 
- as the Data interface has less functions so it is easier to learn/discover/read/remember. 

EDIT: I'm not sure it is a good idea to remove the operator== directly without transition period, this is why I'm searching for some template tricks that would print the deprecation warning then stop the compilation but I didn't managed to do so. Any help appreciated.
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
