### PR TITLE
[SofaOpenCL] Fix Cmake configuration

### DIFF
--- a/applications/plugins/SofaOpenCL/CMakeLists.txt
+++ b/applications/plugins/SofaOpenCL/CMakeLists.txt
@@ -4,7 +4,9 @@ project(SofaOpenCL)
 set(SOFAOPENCL_VERSION 0.1)
 
 find_package(OpenCL REQUIRED)
-find_package(SofaGeneral REQUIRED)
+find_package(SofaGeneralObjectInteraction REQUIRED)
+find_package(SofaGeneralDeformable REQUIRED)
+find_package(SofaUserInteraction REQUIRED)
 sofa_find_package(SofaSphFluid QUIET)
 
 set(HEADER_FILES
@@ -103,7 +105,7 @@ add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${OTHER_FILES
 add_definitions("-DSOFA_SRC_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/../../..\"")
 
 add_definitions("-DSOFA_BUILD_GPU_OPENCL")
-target_link_libraries(${PROJECT_NAME} ${OPENCL_LIBRARIES} SofaHelper SofaEngine SofaUserInteraction csparse) # taucs taucs_mt system-taucs)
+target_link_libraries(${PROJECT_NAME} ${OPENCL_LIBRARIES} SofaHelper SofaEngine SofaUserInteraction csparse SofaGeneralObjectInteraction SofaGeneralDeformable) # taucs taucs_mt system-taucs)
 if(SofaSphFluid_FOUND)
     target_link_libraries(${PROJECT_NAME} SofaSphFluid) # taucs taucs_mt system-taucs)
 endif()


### PR DESCRIPTION
Due to SofaGeneral' s modularization.
Stumbled on the issue while doing PR #1646...

[SofaOpenCL is not enabled on the CI]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
