### PR TITLE
[runSofa] CLEAN unused dep to SofaGeneralLoader

### DIFF
--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -51,7 +51,6 @@ using sofa::simulation::scenechecking::SceneCheckerListener;
 #include <SofaCommon/initSofaCommon.h>
 #include <SofaBase/initSofaBase.h>
 
-#include <SofaGeneralLoader/ReadState.h>
 #include <sofa/helper/Factory.h>
 #include <sofa/helper/cast.h>
 #include <sofa/helper/BackTrace.h>
@@ -72,7 +71,6 @@ using sofa::core::ExecParams ;
 #include <sofa/helper/system/console.h>
 using sofa::helper::Utils;
 
-using sofa::component::misc::ReadStateActivator;
 using sofa::simulation::tree::TreeSimulation;
 using sofa::simulation::graph::DAGSimulation;
 using sofa::helper::system::SetDirectory;


### PR DESCRIPTION
Fixing build error on sofa-custom: https://ci.inria.fr/sofa-ci-dev/job/sofa-custom/683/CI_CONFIG=ubuntu_gcc-7,CI_TYPE=release/console

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
