### PR TITLE
[SofaHelper] Fix CMake config with SOFA_NO_OPENGL and dependency package (Windows)

### DIFF
--- a/SofaKernel/modules/SofaHelper/CMakeLists.txt
+++ b/SofaKernel/modules/SofaHelper/CMakeLists.txt
@@ -332,6 +332,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CUR
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../SofaDefaultType/src>")
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../SofaCore/src>")
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+    target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>")
     target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "$<INSTALL_INTERFACE:include/extlibs/WinDepPack>")
 endif()
 # The default binary suffix for libraries/plugins is "_d" when using a debug build.


### PR DESCRIPTION
Stumbled on it with #1649 

DiffusionSolver was unable to find "png.h" when SOFA_NO_OPENGL is activated.

It appears that if SOFA_NO_OPENGL is not activated, adding glew somewhat adds the dependency package directory (<sofaroot>/include) to the include_directories of SofaHelper (and the subsequent modules needing it).

But if SOFA_NO_OPENGL is not activated, this directory is not added.
DiffusionSolver needs Cimg, which adds only for himself the include directory (i.e no target_include_directories).
So CImg compiles well but the modules needing it do not. That's why DiffusionSolver cannot find "png.h"

My fix does add this include_directory to the target, but I don't know if it is the best way.

Joy of CMake 🥴


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
