### PR TITLE
[SofaKernel] Improve the object factory message for duplicated entries

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/ObjectFactory.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/ObjectFactory.cpp
@@ -572,22 +572,25 @@ RegisterObject::operator int()
                 reg.defaultTemplate = entry.defaultTemplate;
             }
         }
-        for (ObjectFactory::CreatorMap::iterator itc = entry.creatorMap.begin(), itcend = entry.creatorMap.end(); itc != itcend; ++itc)
+        for (auto & creator_entry : entry.creatorMap)
         {
-            if (reg.creatorMap.find(itc->first) != reg.creatorMap.end())
-            {
-                msg_warning("ObjectFactory") << "Class already registered: " << itc->first;
-            }
-            else
-            {
-                reg.creatorMap.insert(*itc);
+            const std::string & template_name = creator_entry.first;
+            if (reg.creatorMap.find(template_name) != reg.creatorMap.end()) {
+                if (template_name.empty()) {
+                    msg_warning("ObjectFactory") << "Class already registered: " << entry.className;
+                } else {
+                    msg_warning("ObjectFactory") << "Class already registered: " << entry.className << "<" << template_name << ">";
+                }
+            } else {
+                reg.creatorMap.insert(creator_entry);
             }
         }
-        for (std::set<std::string>::iterator it = entry.aliases.begin(), itend = entry.aliases.end(); it != itend; ++it)
+
+        for (const auto & alias : entry.aliases)
         {
-            if (reg.aliases.find(*it) == reg.aliases.end())
+            if (reg.aliases.find(alias) == reg.aliases.end())
             {
-                ObjectFactory::getInstance()->addAlias(*it,entry.className);
+                ObjectFactory::getInstance()->addAlias(alias,entry.className);
             }
         }
         return 1;


### PR DESCRIPTION
I recently had a small problem when a plugin was implicitly loading SofaConstraint from the SOFA's installation because its compilation was depending on it, but runSofa was launched from the build directory, hence loading SofaConstraint two times (one from the build directory, and one from the installation directory). This resulted in these output from the object manager:

```
[WARNING] [ObjectFactory] Class already registered: Rigid3d
[WARNING] [ObjectFactory] Class already registered: Vec3d
[WARNING] [ObjectFactory] Class already registered: 
[WARNING] [ObjectFactory] Class already registered: 
[WARNING] [ObjectFactory] Class already registered: 
[WARNING] [ObjectFactory] Class already registered: 
[WARNING] [ObjectFactory] Class already registered: 
[WARNING] [ObjectFactory] Class already registered: 
[WARNING] [ObjectFactory] Class already registered: Rigid3d
[WARNING] [ObjectFactory] Class already registered: Vec1d
[WARNING] [ObjectFactory] Class already registered: Vec2d
[WARNING] [ObjectFactory] Class already registered: Vec3d
[WARNING] [ObjectFactory] Class already registered: 
[WARNING] [ObjectFactory] Class already registered: Rigid3d
[WARNING] [ObjectFactory] Class already registered: Vec3d
[WARNING] [ObjectFactory] Class already registered: Rigid3d
[WARNING] [ObjectFactory] Class already registered: Vec1d
[WARNING] [ObjectFactory] Class already registered: Vec3d
[WARNING] [ObjectFactory] Default template for class SlidingConstraint already registered (Vec3d), do not register Vec3d as the default
[WARNING] [ObjectFactory] Class already registered: Vec3d
[WARNING] [ObjectFactory] Class already registered: Vec1d
[WARNING] [ObjectFactory] Class already registered: Rigid3d
[WARNING] [ObjectFactory] Class already registered: Vec1d
[WARNING] [ObjectFactory] Class already registered: Vec2d
[WARNING] [ObjectFactory] Class already registered: Vec3d
[WARNING] [ObjectFactory] Class already registered: Vec1d
[WARNING] [ObjectFactory] Class already registered: Vec3d
[WARNING] [ObjectFactory] Class already registered: Rigid3d
[WARNING] [ObjectFactory] Class already registered: Vec3d
[WARNING] [ObjectFactory] Class already registered: Rigid3d
[WARNING] [ObjectFactory] Class already registered: Vec3d
[WARNING] [ObjectFactory] Class already registered: Vec3d
[WARNING] [ObjectFactory] Class already registered: Rigid3d
[WARNING] [ObjectFactory] Class already registered: Vec3d
[WARNING] [ObjectFactory] Class already registered: 
[WARNING] [ObjectFactory] Class already registered: 
[INFO]    [PluginManager] Loaded plugin: /home/jnbrunet/sources/sofa/build/lib/libSofaConstraint.so
```

Which doesn't give us a lot of information, on the contrary...

This PR improve the diagnostic message from the object factory. This is the resulted output:

```
[WARNING] [ObjectFactory] Class already registered: BilateralInteractionConstraint<Rigid3d>
[WARNING] [ObjectFactory] Class already registered: BilateralInteractionConstraint<Vec3d>
[WARNING] [ObjectFactory] Class already registered: ConstraintAnimationLoop
[WARNING] [ObjectFactory] Class already registered: FreeMotionAnimationLoop
[WARNING] [ObjectFactory] Class already registered: GenericConstraintCorrection
[WARNING] [ObjectFactory] Class already registered: GenericConstraintSolver
[WARNING] [ObjectFactory] Class already registered: LCPConstraintSolver
[WARNING] [ObjectFactory] Class already registered: LMDNewProximityIntersection
[WARNING] [ObjectFactory] Class already registered: LinearSolverConstraintCorrection<Rigid3d>
[WARNING] [ObjectFactory] Class already registered: LinearSolverConstraintCorrection<Vec1d>
[WARNING] [ObjectFactory] Class already registered: LinearSolverConstraintCorrection<Vec2d>
[WARNING] [ObjectFactory] Class already registered: LinearSolverConstraintCorrection<Vec3d>
[WARNING] [ObjectFactory] Class already registered: LocalMinDistance
[WARNING] [ObjectFactory] Class already registered: MappingGeometricStiffnessForceField<Rigid3d>
[WARNING] [ObjectFactory] Class already registered: MappingGeometricStiffnessForceField<Vec3d>
[WARNING] [ObjectFactory] Class already registered: PrecomputedConstraintCorrection<Rigid3d>
[WARNING] [ObjectFactory] Class already registered: PrecomputedConstraintCorrection<Vec1d>
[WARNING] [ObjectFactory] Class already registered: PrecomputedConstraintCorrection<Vec3d>
[WARNING] [ObjectFactory] Default template for class SlidingConstraint already registered (Vec3d), do not register Vec3d as the default
[WARNING] [ObjectFactory] Class already registered: SlidingConstraint<Vec3d>
[WARNING] [ObjectFactory] Class already registered: StopperConstraint<Vec1d>
[WARNING] [ObjectFactory] Class already registered: UncoupledConstraintCorrection<Rigid3d>
[WARNING] [ObjectFactory] Class already registered: UncoupledConstraintCorrection<Vec1d>
[WARNING] [ObjectFactory] Class already registered: UncoupledConstraintCorrection<Vec2d>
[WARNING] [ObjectFactory] Class already registered: UncoupledConstraintCorrection<Vec3d>
[WARNING] [ObjectFactory] Class already registered: UniformConstraint<Vec1d>
[WARNING] [ObjectFactory] Class already registered: UnilateralInteractionConstraint<Vec3d>
[WARNING] [ObjectFactory] Class already registered: DOFBlockerLMConstraint<Rigid3d>
[WARNING] [ObjectFactory] Class already registered: DOFBlockerLMConstraint<Vec3d>
[WARNING] [ObjectFactory] Class already registered: FixedLMConstraint<Rigid3d>
[WARNING] [ObjectFactory] Class already registered: FixedLMConstraint<Vec3d>
[WARNING] [ObjectFactory] Class already registered: DistanceLMContactConstraint<Vec3d>
[WARNING] [ObjectFactory] Class already registered: DistanceLMConstraint<Rigid3d>
[WARNING] [ObjectFactory] Class already registered: DistanceLMConstraint<Vec3d>
[WARNING] [ObjectFactory] Class already registered: LMConstraintSolver
[WARNING] [ObjectFactory] Class already registered: LMConstraintDirectSolver
[INFO]    [PluginManager] Loaded plugin: /home/jnbrunet/sources/sofa/build/lib/libSofaConstraint.so
```


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
