### PR TITLE
[SofaGeneralLoader] allow ReadState at init

### DIFF
--- a/modules/SofaGeneralLoader/src/SofaGeneralLoader/ReadState.h
+++ b/modules/SofaGeneralLoader/src/SofaGeneralLoader/ReadState.h
@@ -64,6 +64,8 @@ protected:
 public:
     void init() override;
 
+    void bwdInit() override;
+
     void reset() override;
 
     void setTime(double time);

--- a/modules/SofaGeneralLoader/src/SofaGeneralLoader/ReadState.inl
+++ b/modules/SofaGeneralLoader/src/SofaGeneralLoader/ReadState.inl
@@ -64,6 +64,12 @@ void ReadState::init()
     reset();
 }
 
+void ReadState::bwdInit()
+{
+    processReadState();
+}
+
+
 void ReadState::reset()
 {
     mmodel = this->getContext()->getMechanicalState();


### PR DESCRIPTION
ReadState was only reading the file and making the changes after the first time step (or later). 
This PR allows to load the state at init. 

Edit: I forgot to mention that it shouldn't change the behavior of existing scenes. 
The file loaded by ReadState has time values that define at which time steps of the simulation each different state should be applied. Currently T=0 is not working, this PR simply allows that.  
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
