### PR TITLE
[SofaKernel] Data file repository now looks into the SOFA install directory

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
@@ -90,9 +90,19 @@ FileRepository PluginRepository(
         }
 );
 #endif
-FileRepository DataRepository( "SOFA_DATA_PATH", nullptr, {
-                                   { Utils::getSofaPathTo("etc/sofa.ini"), {"SHARE_DIR", "EXAMPLES_DIR"} }
-                               });
+FileRepository DataRepository(
+        "SOFA_DATA_PATH",
+        {
+                Utils::getSofaPathTo("share/sofa"),
+                Utils::getSofaPathTo("share/sofa/examples")
+        },
+        {
+            {
+                Utils::getSofaPathTo("etc/sofa.ini"),
+                {"SHARE_DIR", "EXAMPLES_DIR"}
+            }
+        }
+);
 
 FileRepository::FileRepository(const char* envVar, const std::vector<std::string> & paths, const fileKeysMap& iniFilesAndKeys) {
     if (envVar != nullptr && envVar[0]!='\0')
@@ -136,7 +146,7 @@ FileRepository::FileRepository(const char* envVar, const std::vector<std::string
                 }
 
                 const std::string& absoluteDir = SetDirectory::GetRelativeFromProcess(lineDir.c_str());
-                if ( FileSystem::isDirectory(absoluteDir) )
+                if ( FileSystem::exists(absoluteDir) && FileSystem::isDirectory(absoluteDir) )
                 {
                     addFirstPath(absoluteDir);
                 }


### PR DESCRIPTION
Also, the repository won't generate anymore the following error when it is created from another library/executable that is not placed directly in the SOFA installation directory:

```
Error:    [FileSystem::isDirectory()] /home/runner/work/my_program/share/sofa/examples: No such file or directory
Error:    [FileSystem::isDirectory()] /home/runner/work/my_program/share/sofa: No such file or directory
``` 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
