### PR TITLE
[SofaKernel] Silence the -Wattribute warning because of its verbosity with g++

### DIFF
--- a/SofaKernel/SofaFramework/src/sofa/config.h.in
+++ b/SofaKernel/SofaFramework/src/sofa/config.h.in
@@ -113,6 +113,11 @@ typedef unsigned __int64	uint64_t;
 #define sofa_do_tostring(a) #a
 #define sofa_tostring(a) sofa_do_tostring(a)
 
+///////////////////// Remove the -Wattribute warning on gcc that is causing lot of troubles
+#if defined(__GNUC__)
+_Pragma("GCC diagnostic error \"-Wattributes\"")
+#endif
+
 ///////////////////// These macros can be used to convert deprecation attributes as error.
 #if defined(_MSC_VER)
 #define SOFA_BEGIN_DEPRECATION_AS_ERROR __pragma("warning( push )") \

--- a/SofaKernel/SofaFramework/src/sofa/config.h.in
+++ b/SofaKernel/SofaFramework/src/sofa/config.h.in
@@ -115,7 +115,7 @@ typedef unsigned __int64	uint64_t;
 
 ///////////////////// Remove the -Wattribute warning on gcc that is causing lot of troubles
 #if defined(__GNUC__)
-_Pragma("GCC diagnostic error \"-Wattributes\"")
+_Pragma("GCC diagnostic ignored \"-Wattributes\"")
 #endif
 
 ///////////////////// These macros can be used to convert deprecation attributes as error.


### PR DESCRIPTION
Silence the -Wattribute warning because of its verbosity g++.
It was supposed to be in pr #1643 but it appears to have been lost somehow... so this PR add it again. 





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
