### PR TITLE
[SofaFramework] Fix deprecated_as_error macro for MSVC

### DIFF
--- a/SofaKernel/SofaFramework/src/sofa/config.h.in
+++ b/SofaKernel/SofaFramework/src/sofa/config.h.in
@@ -115,9 +115,9 @@ typedef unsigned __int64	uint64_t;
 
 ///////////////////// These macros can be used to convert deprecation attributes as error.
 #if defined(_MSC_VER)
-#define SOFA_BEGIN_DEPRECATION_AS_ERROR __pragma("warning( push )") \
-                                        __pragma("warning(error: 4996)")
-#define SOFA_END_DEPRECATION_AS_ERROR __pragma("warning( pop )")
+#define SOFA_BEGIN_DEPRECATION_AS_ERROR __pragma(warning( push )) \
+                                        __pragma(warning(error: 4996))
+#define SOFA_END_DEPRECATION_AS_ERROR __pragma(warning( pop ))
 #elif defined(__GNUC__)
 #define SOFA_BEGIN_DEPRECATION_AS_ERROR _Pragma("GCC diagnostic push") \
                                    _Pragma("GCC diagnostic error \"-Wdeprecated-declarations\"")


### PR DESCRIPTION
"Fix" #1643 

The newly introduced macros are actually doing nothing on MSVC, just generating tons of warnings.
▶ __pragma (MSVC only) does not take a string but directly the instruction itself.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
