### PR TITLE
[SofaKernel] Set read-only all data defined by the file loaded

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/loader/MeshLoader.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/loader/MeshLoader.cpp
@@ -112,6 +112,23 @@ MeshLoader::MeshLoader() : BaseLoader()
     d_pentahedraGroups.setGroup("Groups");
     d_tetrahedraGroups.setGroup("Groups");
 
+    d_positions.setReadOnly(true);
+    d_polylines.setReadOnly(true);
+    d_edges.setReadOnly(true);
+    d_triangles.setReadOnly(true);
+    d_quads.setReadOnly(true);
+    d_polygons.setReadOnly(true);
+    d_highOrderEdgePositions.setReadOnly(true);
+    d_highOrderTrianglePositions.setReadOnly(true);
+    d_highOrderQuadPositions.setReadOnly(true);
+    d_tetrahedra.setReadOnly(true);
+    d_hexahedra.setReadOnly(true);
+    d_pentahedra.setReadOnly(true);
+    d_highOrderTetrahedronPositions.setReadOnly(true);
+    d_highOrderHexahedronPositions.setReadOnly(true);
+    d_pyramids.setReadOnly(true);
+    d_normals.setReadOnly(true);
+
     /// name filename => component state update + change of all data field...but not visible ?
     addUpdateCallback("filename", {&m_filename}, [this](const core::DataTracker& t)
     {


### PR DESCRIPTION
Just set all data defined by the loader as read-only since it makes no sense any user modifies them directly



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
