### PR TITLE
[OmniDriverEmul] Fix thread behavior and replace boost/pthread by std::thread

### DIFF
--- a/applications/plugins/SensableEmulation/OmniDriverEmu.cpp
+++ b/applications/plugins/SensableEmulation/OmniDriverEmu.cpp
@@ -304,11 +304,11 @@ void *hapticSimuExecute( void *ptr )
 
             endTime = (double)omniDrv->thTimer->getTime();  //[s]
             totalTime = (endTime - startTime);  // [us]
-            timeToSleep = int( ((requiredTime - totalTime) - timeCorrection) * timeScale); //  [us]
+            timeToSleep = int( ((requiredTime - totalTime) - timeCorrection) ); //  [us]
 
             if (timeToSleep > 0)
             {
-                std::this_thread::sleep_for(std::chrono::seconds(timeToSleep));
+                std::this_thread::sleep_for(std::chrono::seconds(int(timeToSleep * timeScale)));
             }
             else
             {
@@ -394,13 +394,6 @@ void OmniDriverEmu::setDataValue()
     data.endOmni_H_virtualTool.set(positionTool.getValue(), q);
     data.permanent_feedback = permanent.getValue();
 }
-
-void OmniDriverEmu::reset()
-{
-    msg_info()<<"OmniDriverEmu::reset() is called.";
-    this->reinit();
-}
-
 
 void OmniDriverEmu::reinit()
 {

--- a/applications/plugins/SensableEmulation/OmniDriverEmu.h
+++ b/applications/plugins/SensableEmulation/OmniDriverEmu.h
@@ -31,11 +31,7 @@
 #include <sofa/defaulttype/SolidTypes.h>
 
 #include <sofa/helper/system/thread/CTime.h>
-
-#ifndef WIN32
-#  include <pthread.h>
-#endif
-
+#include <thread>
 #include <SensableEmulation/config.h>
 
 
@@ -139,9 +135,11 @@ public:
     //need for "omni simulation"
     helper::system::thread::CTime *thTimer;
 
-#ifndef WIN32
-    pthread_t hapSimuThread;
-#endif
+    /// Thread object
+    std::thread hapSimuThread;
+
+    /// Bool to notify thread to stop work
+    std::atomic<bool> m_terminate;
 
     double lastStep;
     bool executeAsynchro;

--- a/applications/plugins/SensableEmulation/OmniDriverEmu.h
+++ b/applications/plugins/SensableEmulation/OmniDriverEmu.h
@@ -122,7 +122,6 @@ public:
 
     void init() override;
     void bwdInit() override;
-    void reset() override;
     void reinit() override;
     void cleanup() override;
     void draw(const core::visual::VisualParams*) override;

--- a/applications/plugins/SensableEmulation/examples/testOmniDriverEmu.scn
+++ b/applications/plugins/SensableEmulation/examples/testOmniDriverEmu.scn
@@ -1,5 +1,9 @@
 <Node name="root" dt="0.01" gravity="0 0 0" >
     <RequiredPlugin name="SensableEmulation" pluginName="SensableEmulation" />
+    <RequiredPlugin name='SofaConstraint'/>
+    <RequiredPlugin name='SofaGraphComponent'/>
+    <RequiredPlugin name='SofaUserInteraction'/>
+
 	<Gravity name="G" gravity="10 0 0" />
 	<DefaultPipeline name="pipeline" depth="6" verbose="0"/>
 	<BruteForceDetection name="detection" />


### PR DESCRIPTION
- Replace the use of phtread (on windows) or boost thread (on linux) by std::thread. Use an atomic bool to be able to stop the 'emulator/haptic' thread from the main thread before closing it. 
This shouldl fix possible segmention fault or lock/time out at scene test exit (cf dashboard)
- Also fix the timeToSleep test inside the thread which was always failing due to bad conversion.








______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
