### PR TITLE
[SofaGeneralEngine] fixes ExtrudeQuadsAndGenerateHexas

### DIFF
--- a/examples/Components/engine/ExtrudeQuadAndGenerateHexa.py
+++ b/examples/Components/engine/ExtrudeQuadAndGenerateHexa.py
@@ -1,0 +1,43 @@
+import Sofa
+
+def createScene(rootNode):
+
+    rootNode.createObject('VisualStyle', displayFlags='showVisualModels showForceFields showBehavior')
+    rootNode.createObject('RequiredPlugin', pluginName='SofaBoundaryCondition SofaGeneralEngine SofaTopologyMapping SofaPython SofaOpenglVisual SofaMiscMapping')
+
+    rootNode.gravity = [0,-9810,0]
+    rootNode.createObject('EulerImplicitSolver')
+    rootNode.createObject('CGLinearSolver')
+
+    positions = [[0,0,0],[15,0,0],[30,0,0],[45,0,0]]
+    edgetopo = rootNode.createChild('Edge')
+    edgetopo.createObject('EdgeSetTopologyContainer', position=positions, edges=[[k,k+1] for k in range(3)])
+    edgetopo.createObject('EdgeSetTopologyModifier')
+    edgetopo.createObject('MechanicalObject', template='Rigid3', position=[positions[k]+[0,0,0,1] for k in range(4)], showObject=True, showObjectScale=2)
+
+    quadtopo = edgetopo.createChild('Quad')
+    quadtopo.createObject('QuadSetTopologyContainer')
+    quadtopo.createObject('QuadSetTopologyModifier')
+    quadtopo.createObject('MechanicalObject')
+    quadtopo.createObject('Edge2QuadTopologicalMapping',
+                          input=edgetopo.EdgeSetTopologyContainer.getLinkPath(),
+                          output=quadtopo.QuadSetTopologyContainer.getLinkPath(),
+                          flipNormals=True, nbPointsOnEachCircle=8, radius=10)
+    quadtopo.createObject('OglModel', color=[1,1,1,1])
+
+    hexatopo = quadtopo.createChild('Hexa')
+    hexatopo.createObject('ExtrudeQuadsAndGenerateHexas', name='extruder',
+                            surfaceVertices=quadtopo.MechanicalObject.findData('position').getLinkPath(),
+                            surfaceQuads=quadtopo.QuadSetTopologyContainer.findData('quads').getLinkPath(),
+                            thicknessIn=5, thicknessOut=5, numberOfSlices=2)
+
+    hexatopo.createObject('HexahedronSetTopologyContainer',
+                            points=hexatopo.extruder.findData('extrudedVertices').getLinkPath(),
+                            hexahedra=hexatopo.extruder.findData('extrudedHexas').getLinkPath())
+    hexatopo.createObject('HexahedronSetTopologyModifier')
+    hexatopo.createObject('MechanicalObject')
+    hexatopo.createObject('UniformMass', totalMass=0.5)
+    hexatopo.createObject('HexahedronFEMForceField', poissonRatio=0.3, youngModulus=650)
+    hexatopo.createObject('FixedConstraint', indices=range(24))
+
+    return

--- a/examples/Components/engine/ExtrudeQuadAndGenerateHexa.py
+++ b/examples/Components/engine/ExtrudeQuadAndGenerateHexa.py
@@ -6,8 +6,6 @@ def createScene(rootNode):
     rootNode.createObject('RequiredPlugin', pluginName='SofaBoundaryCondition SofaGeneralEngine SofaTopologyMapping SofaPython SofaOpenglVisual SofaMiscMapping')
 
     rootNode.gravity = [0,-9810,0]
-    rootNode.createObject('EulerImplicitSolver')
-    rootNode.createObject('CGLinearSolver')
 
     positions = [[0,0,0],[15,0,0],[30,0,0],[45,0,0]]
     edgetopo = rootNode.createChild('Edge')
@@ -26,10 +24,12 @@ def createScene(rootNode):
     quadtopo.createObject('OglModel', color=[1,1,1,1])
 
     hexatopo = quadtopo.createChild('Hexa')
+    hexatopo.createObject('EulerImplicitSolver')
+    hexatopo.createObject('CGLinearSolver')
     hexatopo.createObject('ExtrudeQuadsAndGenerateHexas', name='extruder',
                             surfaceVertices=quadtopo.MechanicalObject.findData('position').getLinkPath(),
                             surfaceQuads=quadtopo.QuadSetTopologyContainer.findData('quads').getLinkPath(),
-                            thicknessIn=5, thicknessOut=5, numberOfSlices=2)
+                            thicknessIn=5, thicknessOut=5, numberOfSlices=2, flipNormals=True)
 
     hexatopo.createObject('HexahedronSetTopologyContainer',
                             points=hexatopo.extruder.findData('extrudedVertices').getLinkPath(),

--- a/examples/Components/topology/Edge2QuadTopologyMapping.py
+++ b/examples/Components/topology/Edge2QuadTopologyMapping.py
@@ -1,0 +1,24 @@
+import Sofa
+
+def createScene(rootNode):
+
+    rootNode.createObject('VisualStyle', displayFlags='showVisualModels showWireframe')
+    rootNode.createObject('RequiredPlugin', pluginName='SofaGeneralEngine SofaTopologyMapping SofaPython SofaOpenglVisual SofaMiscMapping')
+
+    positions = [[0,0,0],[10,0,0],[20,0,0],[30,0,0]]
+    edgetopo = rootNode.createChild('Edge')
+    edgetopo.createObject('EdgeSetTopologyContainer', position=positions, edges=[[k,k+1] for k in range(3)])
+    edgetopo.createObject('EdgeSetTopologyModifier')
+    edgetopo.createObject('MechanicalObject', template='Rigid3', position=[positions[k]+[0,0,0,1] for k in range(4)], showObject=True, showObjectScale=2)
+
+    quadtopo = edgetopo.createChild('Quad')
+    quadtopo.createObject('QuadSetTopologyContainer')
+    quadtopo.createObject('QuadSetTopologyModifier')
+    quadtopo.createObject('MechanicalObject')
+    quadtopo.createObject('Edge2QuadTopologicalMapping',
+                          input=edgetopo.EdgeSetTopologyContainer.getLinkPath(),
+                          output=quadtopo.QuadSetTopologyContainer.getLinkPath(),
+                          flipNormals=True, nbPointsOnEachCircle=8, radius=10)
+    quadtopo.createObject('OglModel', color=[1,1,1,1])
+
+    return

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/ExtrudeQuadsAndGenerateHexas.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/ExtrudeQuadsAndGenerateHexas.h
@@ -69,6 +69,7 @@ public:
     Data<Real>                                       f_thicknessIn; ///< Thickness of the extruded volume in the opposite direction of the normals
     Data<Real>                                       f_thicknessOut; ///< Thickness of the extruded volume in the direction of the normals
     Data<int>                                        f_numberOfSlices; ///< Number of slices / steps in the extrusion
+    Data<bool>                                       f_flipNormals;
     Data<VecCoord>                                   f_surfaceVertices; ///< Position coordinates of the surface
     Data< helper::vector<sofa::core::topology::BaseMeshTopology::Quad> >   f_surfaceQuads; ///< Indices of the quads of the surface to extrude
     Data<VecCoord>                                   f_extrudedVertices; ///< Coordinates of the extruded vertices

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/ExtrudeQuadsAndGenerateHexas.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/ExtrudeQuadsAndGenerateHexas.inl
@@ -34,6 +34,7 @@ ExtrudeQuadsAndGenerateHexas<DataTypes>::ExtrudeQuadsAndGenerateHexas()
     , f_thicknessIn( initData (&f_thicknessIn, Real (0.0), "thicknessIn", "Thickness of the extruded volume in the opposite direction of the normals") )
     , f_thicknessOut( initData (&f_thicknessOut, Real (1.0), "thicknessOut", "Thickness of the extruded volume in the direction of the normals") )
     , f_numberOfSlices( initData (&f_numberOfSlices, int (1), "numberOfSlices", "Number of slices / steps in the extrusion") )
+    , f_flipNormals(initData(&f_flipNormals, bool(false), "flipNormals", "If true, will inverse point order when creating hexa"))
     , f_surfaceVertices( initData (&f_surfaceVertices, "surfaceVertices", "Position coordinates of the surface") )
     , f_surfaceQuads( initData (&f_surfaceQuads, "surfaceQuads", "Indices of the quads of the surface to extrude") )
     , f_extrudedVertices( initData (&f_extrudedVertices, "extrudedVertices", "Coordinates of the extruded vertices") )
@@ -170,9 +171,16 @@ void ExtrudeQuadsAndGenerateHexas<DataTypes>::doUpdate()
     {
         for (int n=0; n<nSlices; n++)
         {
-            BaseMeshTopology::Hexa hexa = BaseMeshTopology::Hexa(surfaceQuads[q][0]*(nSlices+1)+n,   surfaceQuads[q][1]*(nSlices+1)+n,   surfaceQuads[q][2]*(nSlices+1)+n,   surfaceQuads[q][3]*(nSlices+1)+n,
-                    surfaceQuads[q][0]*(nSlices+1)+n+1, surfaceQuads[q][1]*(nSlices+1)+n+1, surfaceQuads[q][2]*(nSlices+1)+n+1, surfaceQuads[q][3]*(nSlices+1)+n+1);
-            extrudedHexas->push_back(hexa);
+            if (f_flipNormals.getValue())
+            {
+                BaseMeshTopology::Hexa hexa = BaseMeshTopology::Hexa(surfaceQuads[q][0]*(nSlices+1)+n,   surfaceQuads[q][1]*(nSlices+1)+n,   surfaceQuads[q][2]*(nSlices+1)+n,   surfaceQuads[q][3]*(nSlices+1)+n,
+                        surfaceQuads[q][0]*(nSlices+1)+n+1, surfaceQuads[q][1]*(nSlices+1)+n+1, surfaceQuads[q][2]*(nSlices+1)+n+1, surfaceQuads[q][3]*(nSlices+1)+n+1);
+                extrudedHexas->push_back(hexa);
+            } else {
+                BaseMeshTopology::Hexa hexa = BaseMeshTopology::Hexa(surfaceQuads[q][3]*(nSlices+1)+n,   surfaceQuads[q][2]*(nSlices+1)+n,   surfaceQuads[q][1]*(nSlices+1)+n,   surfaceQuads[q][0]*(nSlices+1)+n,
+                        surfaceQuads[q][3]*(nSlices+1)+n+1, surfaceQuads[q][2]*(nSlices+1)+n+1, surfaceQuads[q][1]*(nSlices+1)+n+1, surfaceQuads[q][0]*(nSlices+1)+n+1);
+                extrudedHexas->push_back(hexa);
+            }
         }
     }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/ExtrudeQuadsAndGenerateHexas.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/ExtrudeQuadsAndGenerateHexas.inl
@@ -169,14 +169,14 @@ void ExtrudeQuadsAndGenerateHexas<DataTypes>::doUpdate()
     // compute indices of newly created hexas
     for (unsigned int q=0; q<surfaceQuads.size(); q++)
     {
-        for (int n=0; n<nSlices; n++)
-        {
-            if (f_flipNormals.getValue())
-            {
+        if (f_flipNormals.getValue()) {
+            for (int n=0; n<nSlices; n++) {
                 BaseMeshTopology::Hexa hexa = BaseMeshTopology::Hexa(surfaceQuads[q][0]*(nSlices+1)+n,   surfaceQuads[q][1]*(nSlices+1)+n,   surfaceQuads[q][2]*(nSlices+1)+n,   surfaceQuads[q][3]*(nSlices+1)+n,
                         surfaceQuads[q][0]*(nSlices+1)+n+1, surfaceQuads[q][1]*(nSlices+1)+n+1, surfaceQuads[q][2]*(nSlices+1)+n+1, surfaceQuads[q][3]*(nSlices+1)+n+1);
                 extrudedHexas->push_back(hexa);
-            } else {
+            }
+        } else {
+            for (int n=0; n<nSlices; n++) {
                 BaseMeshTopology::Hexa hexa = BaseMeshTopology::Hexa(surfaceQuads[q][3]*(nSlices+1)+n,   surfaceQuads[q][2]*(nSlices+1)+n,   surfaceQuads[q][1]*(nSlices+1)+n,   surfaceQuads[q][0]*(nSlices+1)+n,
                         surfaceQuads[q][3]*(nSlices+1)+n+1, surfaceQuads[q][2]*(nSlices+1)+n+1, surfaceQuads[q][1]*(nSlices+1)+n+1, surfaceQuads[q][0]*(nSlices+1)+n+1);
                 extrudedHexas->push_back(hexa);

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/ExtrudeQuadsAndGenerateHexas.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/ExtrudeQuadsAndGenerateHexas.inl
@@ -170,8 +170,8 @@ void ExtrudeQuadsAndGenerateHexas<DataTypes>::doUpdate()
     {
         for (int n=0; n<nSlices; n++)
         {
-            BaseMeshTopology::Hexa hexa = BaseMeshTopology::Hexa(surfaceQuads[q][3]*(nSlices+1)+n,   surfaceQuads[q][2]*(nSlices+1)+n,   surfaceQuads[q][1]*(nSlices+1)+n,   surfaceQuads[q][0]*(nSlices+1)+n,
-                    surfaceQuads[q][3]*(nSlices+1)+n+1, surfaceQuads[q][2]*(nSlices+1)+n+1, surfaceQuads[q][1]*(nSlices+1)+n+1, surfaceQuads[q][0]*(nSlices+1)+n+1);
+            BaseMeshTopology::Hexa hexa = BaseMeshTopology::Hexa(surfaceQuads[q][0]*(nSlices+1)+n,   surfaceQuads[q][1]*(nSlices+1)+n,   surfaceQuads[q][2]*(nSlices+1)+n,   surfaceQuads[q][3]*(nSlices+1)+n,
+                    surfaceQuads[q][0]*(nSlices+1)+n+1, surfaceQuads[q][1]*(nSlices+1)+n+1, surfaceQuads[q][2]*(nSlices+1)+n+1, surfaceQuads[q][3]*(nSlices+1)+n+1);
             extrudedHexas->push_back(hexa);
         }
     }


### PR DESCRIPTION
ExtrudeQuadsAndGenerateHexas does exactly what the name says.  
The point order used when generating the hexas was causing different issues:
- mapping fallure 
- inverted forces (e.g. gravity and mouse spring)

This PR allows to change the point order and fixes the issues.
The PR also adds two examples, one for Edge2QuadTopologyMapping, and one for ExtrudeQuadsAndGenerateHexas.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
