### PR TITLE
[Sofa] Fix CMake files due to SofaBase ongoing packaging

### DIFF
--- a/SofaGui/SofaGuiConfig.cmake.in
+++ b/SofaGui/SofaGuiConfig.cmake.in
@@ -19,6 +19,7 @@ find_package(SofaFramework QUIET REQUIRED)
 find_package(SofaUserInteraction QUIET REQUIRED)
 find_package(SofaGraphComponent QUIET REQUIRED)
 find_package(SofaMiscForceField QUIET REQUIRED) # SofaGuiQt
+find_package(SofaLoader QUIET REQUIRED)
 
 if(SOFAGUI_HAVE_SOFAGUIQT)
     if(SOFAGUIQT_HAVE_QTVIEWER)

--- a/SofaKernel/SofaBase/SofaBaseConfig.cmake.in
+++ b/SofaKernel/SofaBase/SofaBaseConfig.cmake.in
@@ -4,18 +4,18 @@
 @PACKAGE_INIT@
 
 set(SOFABASE_TARGETS @SOFABASE_TARGETS@)
-set(SOFAEIGEN2SOLVER_HAVE_OPENMP @SOFAEIGEN2SOLVER_HAVE_OPENMP@)
 
 find_package(SofaFramework QUIET REQUIRED)
 find_package(SofaSimulation QUIET REQUIRED)
 
-# Eigen3 is required by SofaBaseTopology and SofaEigen2Solver
-find_package(Eigen3 QUIET REQUIRED)
+# Temporary list while doing packaging
+set(SOFABASE_MODULES SofaBaseLinearSolver SofaEigen2Solver SofaBaseCollision SofaBaseUtils)
 
-# OpenMP might be required by SofaEigen2Solver
-if (SOFAEIGEN2SOLVER_HAVE_OPENMP AND NOT TARGET OpenMP::OpenMP_CXX)
-    find_package(OpenMP QUIET REQUIRED)
-endif()
+foreach(module ${SOFABASE_MODULES})
+    find_package(${module} QUIET REQUIRED)
+endforeach()
+
+set(SOFABASE_TARGETS SofaBaseTopology SofaBaseVisual SofaBaseMechanics)
 
 foreach(target ${SOFABASE_TARGETS})
     if(NOT TARGET ${target})
@@ -23,6 +23,7 @@ foreach(target ${SOFABASE_TARGETS})
         break()
     endif()
 endforeach()
+
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 endif()

--- a/SofaKernel/modules/SofaObjectInteraction/CMakeLists.txt
+++ b/SofaKernel/modules/SofaObjectInteraction/CMakeLists.txt
@@ -15,7 +15,7 @@ set(SOURCE_FILES
     ${SOFAOBJECTINTERACTION_SRC}/PenalityContactForceField.cpp
 )
 
-
+find_package(SofaDeformable REQUIRED)
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaDeformable)
 

--- a/SofaKernel/modules/SofaObjectInteraction/SofaObjectInteractionConfig.cmake.in
+++ b/SofaKernel/modules/SofaObjectInteraction/SofaObjectInteractionConfig.cmake.in
@@ -3,7 +3,7 @@
 @PACKAGE_GUARD@
 @PACKAGE_INIT@
 
-find_package(SofaBase QUIET REQUIRED)
+find_package(SofaDeformable QUIET REQUIRED)
 
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
Relevant for those compiling out-of-tree (e.g SofaPython3 😙)
Some dependencies were missing in the *cmake.in.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
