### PR TITLE
[SofaDefaulttype] Remove warnings from typeinfo files

### DIFF
--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_Vector.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_Vector.h
@@ -49,13 +49,13 @@ struct DataTypeInfo< sofa::helper::vector<std::string,Alloc> > : public VectorTy
     static sofa::Size size() { return 1; }
 
     // Total number of elements in the vector
-    static sofa::Size size(const sofa::helper::vector<std::string,Alloc>& data) { return data.size(); }
+    static sofa::Size size(const sofa::helper::vector<std::string,Alloc>& data) { return sofa::Size(data.size()); }
 
     // Resizes the vector
     static bool setSize(sofa::helper::vector<std::string,Alloc>& data, sofa::Size size) { data.resize(size); return true; }
 
     // Sets the value for element at index `index`
-    static void setValueString(sofa::helper::vector<std::string,Alloc>& data, sofa::Size index, const std::string& value)
+    static void setValueString(sofa::helper::vector<std::string,Alloc>& data, sofa::Index index, const std::string& value)
     {
         if (data.size() <= index)
             data.resize(index + 1);
@@ -63,7 +63,7 @@ struct DataTypeInfo< sofa::helper::vector<std::string,Alloc> > : public VectorTy
     }
 
     // Gets the value for element at index `index`
-    static void getValueString(const sofa::helper::vector<std::string,Alloc>& data, sofa::Size index, std::string& value)
+    static void getValueString(const sofa::helper::vector<std::string,Alloc>& data, sofa::Index index, std::string& value)
     {
         if (data.size() <= index)
             msg_error("DataTypeInfo<helper::vector<std::string>") << "Index out of bounds for getValueString";

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/typeinfo/models/SetTypeInfo.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/typeinfo/models/SetTypeInfo.h
@@ -61,7 +61,7 @@ struct SetTypeInfo
     static sofa::Size size(const DataType& data)
     {
         if (BaseTypeInfo::FixedSize)
-            return data.size()*BaseTypeInfo::size();
+            return sofa::Size(data.size()*BaseTypeInfo::size());
         else
         {
             sofa::Size s = 0;

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/typeinfo/models/VectorTypeInfo.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/typeinfo/models/VectorTypeInfo.h
@@ -67,7 +67,7 @@ struct VectorTypeInfo
             return sofa::Size(data.size()*BaseTypeInfo::size());
         else
         {
-            sofa::Size n = data.size();
+            sofa::Size n = sofa::Size(data.size());
             sofa::Size s = 0;
             for (sofa::Size i=0; i<n; ++i)
                 s+= BaseTypeInfo::size(data[i]);


### PR DESCRIPTION
Generating a lot of warnings because those files are pretty much included by everybody



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
