### PR TITLE
[Backport] Exposing Data in ContactListener

### DIFF
--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/ContactListener.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/ContactListener.h
@@ -20,7 +20,9 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
+#include "sofa/config.h"
 #include <SofaBaseCollision/config.h>
+#include <sofa/defaulttype/Vec.h>
 
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/core/collision/DetectionOutput.h>
@@ -56,6 +58,27 @@ public:
     virtual void endContact(void*) {}
 
     void handleEvent( core::objectmodel::Event* event ) override;
+
+    // Returns the number of stored contacts.
+    sofa::Size getNumberOfContacts() const;
+
+    // Returns the distances between the stored contacts as a vector.
+    helper::vector<double> getDistances() const;
+
+    // Returns the full ContactsVector
+    helper::vector<const helper::vector<DetectionOutput>* > getContactsVector() const;
+
+    // Returns the contact points in the form of a vector of tuples containing two positive integers and two Vector3.
+    // The Vector3 store the X, Y, Z coordinates of the points in contact
+    // The integers specify to which collision models the points belong. (e.g. (collModel2, (3., 5., 7.), collModel1, (3.1, 5., 6.9)))
+    // TODO: replace the tuple with a struct to avoid forgetting which element refers to what.
+    std::vector<std::tuple<unsigned int, sofa::defaulttype::Vector3, unsigned int, sofa::defaulttype::Vector3>> getContactPoints() const; // model, position, model, position
+
+    // Returns the collision elements in the form of a vector of tuples containing four positive integers.
+    // The second and fourth integer represent the id of the collision element in the collision models (from a topology)
+    // The first and third integer specify to which collision models the ids belong. (e.g. (collModel2, 58, collModel1, 67))
+    // TODO: replace the tuple with a struct to avoid forgetting which element refers to what.
+    std::vector<std::tuple<unsigned int, unsigned int, unsigned int, unsigned int>> getContactElements() const; // model, id, model, id
 
     template<class T>
     static bool canCreate(T*& obj, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
@@ -139,6 +162,7 @@ protected:
 
 private:
     helper::vector<const helper::vector<DetectionOutput>* > m_ContactsVector;
+    helper::vector<const helper::vector<DetectionOutput>* > m_ContactsVectorBuffer;
     core::collision::NarrowPhaseDetection* m_NarrowPhase;
 };
 


### PR DESCRIPTION
* Added getter for ContactsVector. Added a buffer variable that is overwritten before ContactsVector is cleared. Added functions to retrieve the number of contacts and their respective distance values in the buffer.

* added a check before trying to access contact information. Added a function to also retrieve a list of collision point pairs

* Simplified code a bit, by moving the check up in the hierarchy.

* Added a getter function to retrieve the element ids of the collision models. This can be used to lookup the ids in a MechanicalObject that are affected by a contact from a topology (get elements -> lookup MO ids in topology -> lookup points in MO). Also added some Docstrings

* Exchanged push_back with emplace_back and sped up code by reserving memory for vectors.

* Replaced Vector3 from helper with Vector3 from defaulttypes.

* Changed unsigned int to sofa::Size and placed curly brackets on new line.

#1678 




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
