### PR TITLE
[SofaSphFluid] Remove std::execution usage

### DIFF
--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/SPHFluidForceField.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/SPHFluidForceField.inl
@@ -29,10 +29,6 @@
 #include <iostream>
 #include <sofa/helper/AdvancedTimer.h>
 
-#if __has_include(<execution>) && !defined(__APPLE__)
-#include <execution>
-#endif
-
 namespace sofa
 {
 
@@ -152,24 +148,6 @@ void SPHFluidForceField<DataTypes>::computeNeighbors(const core::MechanicalParam
     // This is an O(n2) step, except if a hash-grid is used to optimize it
     if (m_grid == nullptr)
     {
-#if __has_include(<execution>) && !defined(__APPLE__)
-        std::for_each(std::execution::par, x.begin(), x.end(), [&](const auto& ri)
-        {
-            auto i = &ri - &x[0]; // only possible with vector, etc.
-
-            for (size_t j = i + 1; j<n; j++)
-            {
-                const Coord& rj = x[j];
-                Real r2 = (rj - ri).norm2();
-                if (r2 < h2)
-                {
-                    Real r_h = (Real)sqrt(r2 / h2);
-                    m_particles[i].neighbors.push_back(std::make_pair(j, r_h));
-                }
-            }
-
-        });
-#else
         for (size_t i = 0; i<n; i++)
         {
             const Coord& ri = x[i];
@@ -185,7 +163,6 @@ void SPHFluidForceField<DataTypes>::computeNeighbors(const core::MechanicalParam
                 }
             }
         }
-#endif
     }
     else
     {


### PR DESCRIPTION
SofaSphFluid was computing normals using an experimental parallel loop (brought by std::execution)
Requires external Intel' s TBB library and does not really bring an significant speed-up.
So it is better to remove it to remove conditional code (as it was not compiled for Apple as well)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
