### PR TITLE
[SofaKernel] Remove some dependencies from SofaHelper to SofaCore

### DIFF
--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
@@ -39,6 +39,7 @@
 #include <sofa/helper/rmath.h>
 #include <sofa/helper/accessor.h>
 #include <sofa/helper/system/FileRepository.h>
+#include <sofa/helper/types/Material.h>
 
 #include <sstream>
 #include <map>
@@ -47,9 +48,10 @@
 namespace sofa::component::visualmodel
 {
 using sofa::helper::types::RGBAColor;
+using sofa::helper::types::Material;
+using sofa::helper::types::PrimitiveGroup;
 using namespace sofa::defaulttype;
 using namespace sofa::core::topology;
-using namespace sofa::core::loader;
 using helper::vector;
 
 Vec3State::Vec3State()

--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.h
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.h
@@ -185,7 +185,7 @@ public:
     /// @}
 
     sofa::defaulttype::Vec3f bbox[2];
-    Data< sofa::core::loader::Material > material;
+    Data< sofa::helper::types::Material > material;
     Data< bool > putOnlyTexCoords;
     Data< bool > srgbTexturing;
 
@@ -221,7 +221,7 @@ public:
         }
     };
 
-    Data< helper::vector<sofa::core::loader::Material> > materials;
+    Data< helper::vector<sofa::helper::types::Material> > materials;
     Data< helper::vector<FaceGroup> > groups;
 
     /// Link to be set to the topology container in the component graph.

--- a/SofaKernel/modules/SofaCore/src/sofa/core/loader/Material.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/loader/Material.h
@@ -19,32 +19,9 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_CORE_LOADER_MATERIAL_H_
-#define SOFA_CORE_LOADER_MATERIAL_H_
-
-#include <sofa/helper/types/Material.h>
-
-namespace sofa
-{
-
-namespace core
-{
-
-namespace loader
-{
-
 ///The Material object that was previously in this sofa::core::loader is now in sofa::helper:types::Material.
 ///The following lines is there to provide backward compatibility with existing code base.
-///This is just there for a transitional period of time and will be removed after 2018-01-07
-using sofa::helper::types::Material ;
-
-//TODO(dmarchal 2017-06-13): Delete that around 2018-01-07
+///This is just there for a transitional period of time and has be removed at sofa release 21.06
+#error Material is now located in sofa/helper/types/Material.h
 
 
-} // namespace loader
-
-} // namespace core
-
-} // namespace sofa
-
-#endif /* SOFA_CORE_LOADER_MATERIAL_H_ */

--- a/SofaKernel/modules/SofaCore/src/sofa/core/loader/PrimitiveGroup.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/loader/PrimitiveGroup.h
@@ -19,52 +19,17 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#pragma once
+#include <sofa/helper/types/PrimitiveGroup.h>
 
-#ifndef SOFA_CORE_LOADER_PRIMITIVEGROUP_H_
-#define SOFA_CORE_LOADER_PRIMITIVEGROUP_H_
-
-#include <string>
-
-namespace sofa
+namespace sofa::core::loader
 {
 
-namespace core
-{
-
-namespace loader
-{
-
-class PrimitiveGroup
-{
-public:
-    int p0, nbp;
-    std::string materialName;
-    std::string groupName;
-    int materialId;
-    inline friend std::ostream& operator << (std::ostream& out, const PrimitiveGroup &g)
-    {
-        out << g.groupName << " " << g.materialName << " " << g.materialId << " " << g.p0 << " " << g.nbp;
-        return out;
-    }
-    inline friend std::istream& operator >> (std::istream& in, PrimitiveGroup &g)
-    {
-        in >> g.groupName >> g.materialName >> g.materialId >> g.p0 >> g.nbp;
-        return in;
-    }
-
-    bool operator <(const PrimitiveGroup& p) const
-    {
-        return p0 < p.p0;
-    }
-
-    PrimitiveGroup() : p0(0), nbp(0), materialId(-1) {}
-    PrimitiveGroup(int p0, int nbp, std::string materialName, std::string groupName, int materialId) : p0(p0), nbp(nbp), materialName(materialName), groupName(groupName), materialId(materialId) {}
-};
-
-} // namespace loader
-
-} // namespace core
+///The PrimitiveGroup object that was previously in this sofa::core::loader is now in sofa::helper:types::Material.
+///The following lines is there to provide backward compatibility with existing code base.
+///This is just there for a transitional period of time and will be removed after 2018-01-07
+//TODO(dmarchal 2020-12-29): Delete that around 2021-05-01
+using sofa::helper::types::PrimitiveGroup;
 
 } // namespace sofa
 
-#endif /* SOFA_CORE_LOADER_PRIMITIVEGROUP_H_ */

--- a/SofaKernel/modules/SofaDefaultType/CMakeLists.txt
+++ b/SofaKernel/modules/SofaDefaultType/CMakeLists.txt
@@ -32,7 +32,6 @@ set(HEADER_FILES
     ${SRC_ROOT}/TopologyTypes.h
     ${SRC_ROOT}/Vec.h
     ${SRC_ROOT}/Ray.h
-    ${SRC_ROOT}/Vec3Types.h
     ${SRC_ROOT}/VecTypes.h
     ${SRC_ROOT}/defaulttype.h
     ${SRC_ROOT}/config.h.in
@@ -79,7 +78,6 @@ set(SOURCE_FILES
     ${SRC_ROOT}/TypeInfoRegistry.cpp
     ${SRC_ROOT}/TypeInfoRegistryTools.cpp
     ${SRC_ROOT}/init.cpp
-
     ${SRC_ROOT}/typeinfo/TypeInfo_Bool.cpp
     ${SRC_ROOT}/typeinfo/TypeInfo_BoundingBox.cpp
     ${SRC_ROOT}/typeinfo/TypeInfo_FixedArray.cpp

--- a/SofaKernel/modules/SofaHelper/CMakeLists.txt
+++ b/SofaKernel/modules/SofaHelper/CMakeLists.txt
@@ -137,6 +137,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/types/RGBAColor.h
     ${SRC_ROOT}/types/RGBAColor_fwd.h
     ${SRC_ROOT}/types/Material.h
+    ${SRC_ROOT}/types/PrimitiveGroup.h
     ${SRC_ROOT}/logging/Messaging.h
     ${SRC_ROOT}/logging/Message.h
     ${SRC_ROOT}/logging/ComponentInfo.h
@@ -216,6 +217,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/types/fixed_array.cpp
     ${SRC_ROOT}/types/RGBAColor.cpp
     ${SRC_ROOT}/types/Material.cpp
+    ${SRC_ROOT}/types/PrimitiveGroup.cpp
     ${SRC_ROOT}/logging/Message.cpp
     ${SRC_ROOT}/logging/MessageDispatcher.cpp
     ${SRC_ROOT}/logging/MessageFormatter.cpp

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.cpp
@@ -25,6 +25,7 @@
 #include <sofa/helper/system/thread/CTime.h>
 #include <sofa/helper/vector.h>
 #include <sofa/helper/map.h>
+#include <iomanip>
 #include "../../extlibs/json/json.h"
 
 
@@ -36,7 +37,6 @@
 
 #define DEFAULT_INTERVAL 100
 
-using namespace sofa::core::objectmodel;
 using json = sofa::helper::json;
 
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/io/Mesh.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/io/Mesh.h
@@ -25,8 +25,8 @@
 #include <sofa/helper/vector.h>
 #include <sofa/defaulttype/Vec.h>
 #include <sofa/helper/Factory.h>
-#include <sofa/core/loader/PrimitiveGroup.h>
-#include <sofa/core/loader/Material.h>
+#include <sofa/helper/types/Material.h>
+#include <sofa/helper/types/PrimitiveGroup.h>
 #include <sofa/core/topology/Topology.h>
 
 namespace sofa
@@ -47,8 +47,8 @@ public:
     
 public:
     typedef sofa::defaulttype::Vector3 Vector3;
-    typedef sofa::core::loader::PrimitiveGroup PrimitiveGroup;
-    typedef sofa::core::loader::Material Material;
+    typedef sofa::helper::types::PrimitiveGroup PrimitiveGroup;
+    typedef sofa::helper::types::Material Material;
     typedef Topology::PointID PointID;
 
     /* specify for each control point lying on an edge : the control point index, the index of the  edge,
@@ -149,14 +149,13 @@ protected:
     helper::vector< PrimitiveGroup > m_polygonsGroups; ///< Groups of Polygons
     helper::vector< PrimitiveGroup > m_tetrahedraGroups; ///< Groups of Tetrahedra
     helper::vector< PrimitiveGroup > m_hexahedraGroups; ///< Groups of Hexahedra
-    helper::vector< PrimitiveGroup > m_pentahedraGroups; ///< Groups of Pentahedra
+    helper::vector< PrimitiveGroup >     m_pentahedraGroups; ///< Groups of Pentahedra
     helper::vector< PrimitiveGroup > m_pyramidsGroups; ///< Groups of Pyramids
 
 
     sofa::helper::vector<Vector3> texCoords; // for the moment, we suppose that texCoords is order 2 (2 texCoords for a vertex)
     sofa::helper::vector<Vector3> normals;
     sofa::helper::vector< sofa::helper::vector < sofa::helper::vector <PointID> > > facets;
-    //sofa::core::objectmodel::Data< Material > material;
     Material material;
 
     std::vector<Material> materials;

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/io/Mesh.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/io/Mesh.h
@@ -149,7 +149,7 @@ protected:
     helper::vector< PrimitiveGroup > m_polygonsGroups; ///< Groups of Polygons
     helper::vector< PrimitiveGroup > m_tetrahedraGroups; ///< Groups of Tetrahedra
     helper::vector< PrimitiveGroup > m_hexahedraGroups; ///< Groups of Hexahedra
-    helper::vector< PrimitiveGroup >     m_pentahedraGroups; ///< Groups of Pentahedra
+    helper::vector< PrimitiveGroup > m_pentahedraGroups; ///< Groups of Pentahedra
     helper::vector< PrimitiveGroup > m_pyramidsGroups; ///< Groups of Pyramids
 
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/io/MeshGmsh.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/io/MeshGmsh.cpp
@@ -93,7 +93,7 @@ void MeshGmsh::init (std::string filename)
 }
 
 
-void MeshGmsh::addInGroup(helper::vector< sofa::core::loader::PrimitiveGroup>& group, int tag, std::size_t /*eid*/)
+void MeshGmsh::addInGroup(helper::vector< sofa::helper::types::PrimitiveGroup>& group, int tag, std::size_t /*eid*/)
 {
     for (std::size_t i = 0; i<group.size(); i++) {
         if (tag == group[i].p0) {
@@ -106,10 +106,10 @@ void MeshGmsh::addInGroup(helper::vector< sofa::core::loader::PrimitiveGroup>& g
     std::string s;
     ss << tag;
 
-    group.push_back(sofa::core::loader::PrimitiveGroup(tag, 1, s, s, -1));
+    group.push_back(sofa::helper::types::PrimitiveGroup(tag, 1, s, s, -1));
 }
 
-void MeshGmsh::normalizeGroup(helper::vector< sofa::core::loader::PrimitiveGroup>& group) 
+void MeshGmsh::normalizeGroup(helper::vector< sofa::helper::types::PrimitiveGroup>& group)
 {
     int start = 0;
     for (unsigned i = 0; i<group.size(); i++) {

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/io/MeshGmsh.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/io/MeshGmsh.h
@@ -49,9 +49,9 @@ protected:
 
     bool readGmsh(std::ifstream &file, const unsigned int gmshFormat);
 
-    void addInGroup(helper::vector< sofa::core::loader::PrimitiveGroup>& group, int tag, std::size_t eid);
+    void addInGroup(helper::vector< sofa::helper::types::PrimitiveGroup>& group, int tag, std::size_t eid);
 
-    void normalizeGroup(helper::vector< sofa::core::loader::PrimitiveGroup>& group);
+    void normalizeGroup(helper::vector< sofa::helper::types::PrimitiveGroup>& group);
 };
 
 } // namespace io

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/types/Material.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/types/Material.cpp
@@ -30,42 +30,42 @@ namespace helper
 namespace types
 {
 
-    void Material::setColor(float r, float g, float b, float a)
-    {
-        ambient = RGBAColor(r*0.2f,g*0.2f,b*0.2f,a);
-        diffuse = RGBAColor(r,g,b,a);
-        specular = RGBAColor(r,g,b,a);
-        emissive = RGBAColor(r,g,b,a);
-    }
+void Material::setColor(float r, float g, float b, float a)
+{
+    ambient = RGBAColor(r*0.2f,g*0.2f,b*0.2f,a);
+    diffuse = RGBAColor(r,g,b,a);
+    specular = RGBAColor(r,g,b,a);
+    emissive = RGBAColor(r,g,b,a);
+}
 
-    SOFA_HELPER_API std::ostream&  operator << (std::ostream& out, const Material& m )
-    {
-        out   << m.name         << " ";
-        out  << "Diffuse"       << " " <<  m.useDiffuse   << " " <<  m.diffuse      << " ";
-        out  << "Ambient"       << " " <<  m.useAmbient   << " " <<  m.ambient      << " ";
-        out  << "Specular"      << " " <<  m.useSpecular  << " " <<  m.specular     << " ";
-        out  << "Emissive"      << " " <<  m.useEmissive  << " " <<  m.emissive     << " ";
-        out  << "Shininess"     << " " <<  m.useShininess << " " <<  m.shininess   << " ";
-        return out;
-    }
+std::ostream&  operator << (std::ostream& out, const Material& m )
+{
+    out   << m.name         << " ";
+    out  << "Diffuse"       << " " <<  m.useDiffuse   << " " <<  m.diffuse      << " ";
+    out  << "Ambient"       << " " <<  m.useAmbient   << " " <<  m.ambient      << " ";
+    out  << "Specular"      << " " <<  m.useSpecular  << " " <<  m.specular     << " ";
+    out  << "Emissive"      << " " <<  m.useEmissive  << " " <<  m.emissive     << " ";
+    out  << "Shininess"     << " " <<  m.useShininess << " " <<  m.shininess   << " ";
+    return out;
+}
 
-    SOFA_HELPER_API std::istream&  operator >> (std::istream& in, Material &m )
+std::istream&  operator >> (std::istream& in, Material &m )
+{
+    std::string element;
+    in  >>  m.name ;
+    for (unsigned int i=0; i<5; ++i)
     {
-        std::string element;
-        in  >>  m.name ;
-        for (unsigned int i=0; i<5; ++i)
-        {
-            in  >>  element;
-            if      (element == std::string("Diffuse")   || element == std::string("diffuse")   ) { in  >>  m.useDiffuse   ; in >> m.diffuse;   }
-            else if (element == std::string("Ambient")   || element == std::string("ambient")   ) { in  >>  m.useAmbient   ; in >> m.ambient;   }
-            else if (element == std::string("Specular")  || element == std::string("specular")  ) { in  >>  m.useSpecular  ; in >> m.specular;  }
-            else if (element == std::string("Emissive")  || element == std::string("emissive")  ) { in  >>  m.useEmissive  ; in >> m.emissive;  }
-            else if (element == std::string("Shininess") || element == std::string("shininess") ) { in  >>  m.useShininess ; in >> m.shininess; }
-        }
-        return in;
+        in  >>  element;
+        if      (element == std::string("Diffuse")   || element == std::string("diffuse")   ) { in  >>  m.useDiffuse   ; in >> m.diffuse;   }
+        else if (element == std::string("Ambient")   || element == std::string("ambient")   ) { in  >>  m.useAmbient   ; in >> m.ambient;   }
+        else if (element == std::string("Specular")  || element == std::string("specular")  ) { in  >>  m.useSpecular  ; in >> m.specular;  }
+        else if (element == std::string("Emissive")  || element == std::string("emissive")  ) { in  >>  m.useEmissive  ; in >> m.emissive;  }
+        else if (element == std::string("Shininess") || element == std::string("shininess") ) { in  >>  m.useShininess ; in >> m.shininess; }
     }
+    return in;
+}
 
-     Material::Material()
+Material::Material()
 {
     ambient =  RGBAColor( 0.2f,0.2f,0.2f,1.0f);
     diffuse =  RGBAColor( 0.75f,0.75f,0.75f,1.0f);

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/types/Material.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/types/Material.h
@@ -19,20 +19,12 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-
-#ifndef SOFA_HELPER_TYPES_MATERIAL_H_
-#define SOFA_HELPER_TYPES_MATERIAL_H_
+#pragma once
 
 #include <sofa/helper/config.h>
 #include <sofa/helper/types/RGBAColor.h>
 
-namespace sofa
-{
-
-namespace helper
-{
-
-namespace types
+namespace sofa::helper::types
 {
 
 class SOFA_HELPER_API Material
@@ -55,19 +47,15 @@ public:
     std::string   textureFilename; // path to the texture linked to the material
     std::string   bumpTextureFilename; // path to the bump texture linked to the material
 
-    void setColor(float r, float g, float b, float a) ;
-
     friend SOFA_HELPER_API std::ostream& operator << (std::ostream& out, const Material& m ) ;
     friend SOFA_HELPER_API std::istream& operator >> (std::istream& in, Material &m ) ;
+
+    void setColor(float r, float g, float b, float a) ;
+
     Material() ;
     Material(const Material& mat) ;
     Material & operator= (const Material& other);
 };
 
-} // namespace types
+} /// namespace sofa::helper::types
 
-} // namespace helper
-
-} // namespace sofa
-
-#endif /* SOFA_HELPER_TYPES_MATERIAL_H_ */

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/types/PrimitiveGroup.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/types/PrimitiveGroup.cpp
@@ -1,0 +1,27 @@
+#include <sofa/helper/types/PrimitiveGroup.h>
+
+namespace sofa::helper::types
+{
+
+std::ostream& operator << (std::ostream& out, const PrimitiveGroup &g)
+{
+    out << g.groupName << " " << g.materialName << " " << g.materialId << " " << g.p0 << " " << g.nbp;
+    return out;
+}
+
+std::istream& operator >> (std::istream& in, PrimitiveGroup &g)
+{
+    in >> g.groupName >> g.materialName >> g.materialId >> g.p0 >> g.nbp;
+    return in;
+}
+
+bool PrimitiveGroup::operator <(const PrimitiveGroup& p) const
+{
+    return p0 < p.p0;
+}
+
+PrimitiveGroup::PrimitiveGroup() : p0(0), nbp(0), materialId(-1) {}
+
+PrimitiveGroup::PrimitiveGroup(int p0, int nbp, std::string materialName, std::string groupName, int materialId) : p0(p0), nbp(nbp), materialName(materialName), groupName(groupName), materialId(materialId) {}
+
+} /// namespace sofa::helper::types

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/types/PrimitiveGroup.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/types/PrimitiveGroup.cpp
@@ -1,3 +1,25 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <iostream>
 #include <sofa/helper/types/PrimitiveGroup.h>
 
 namespace sofa::helper::types

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/types/PrimitiveGroup.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/types/PrimitiveGroup.h
@@ -20,12 +20,13 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
+#include <sofa/helper/config.h>
 #include <string>
 
 namespace sofa::helper::types
 {
 
-class PrimitiveGroup
+class SOFA_HELPER_API PrimitiveGroup
 {
 public:
     int p0, nbp;
@@ -33,12 +34,14 @@ public:
     std::string groupName;
     int materialId;
 
-    friend std::ostream& operator << (std::ostream& out, const PrimitiveGroup &g);
-    friend std::istream& operator >> (std::istream& in, PrimitiveGroup &g);
-    bool operator <(const PrimitiveGroup& p) const;
+    friend SOFA_HELPER_API std::ostream& operator<<(std::ostream& out, const PrimitiveGroup &g);
+    friend SOFA_HELPER_API std::istream& operator>>(std::istream& in, PrimitiveGroup &g);
+
+    bool operator<(const PrimitiveGroup& p) const;
 
     PrimitiveGroup();
     PrimitiveGroup(int p0, int nbp, std::string materialName, std::string groupName, int materialId);
 };
+
 
 } // namespace sofa

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/types/PrimitiveGroup.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/types/PrimitiveGroup.h
@@ -19,4 +19,26 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#error This file will be removed after sofa 21.06 release. Update your code by replacing #include<sofa/defaulttype/Vec3Types.h> with #include<sofa/defaulttype/VecTypes.h>
+#pragma once
+#include <string>
+
+namespace sofa::helper::types
+{
+
+class PrimitiveGroup
+{
+public:
+    int p0, nbp;
+    std::string materialName;
+    std::string groupName;
+    int materialId;
+
+    friend std::ostream& operator << (std::ostream& out, const PrimitiveGroup &g);
+    friend std::istream& operator >> (std::istream& in, PrimitiveGroup &g);
+    bool operator <(const PrimitiveGroup& p) const;
+
+    PrimitiveGroup();
+    PrimitiveGroup(int p0, int nbp, std::string materialName, std::string groupName, int materialId);
+};
+
+} // namespace sofa

--- a/applications/plugins/image/ImageTypes.h
+++ b/applications/plugins/image/ImageTypes.h
@@ -302,7 +302,7 @@ public:
             {
                 tposition[i]=transform->toImage(Coord((Real)verts[i][0],(Real)verts[i][1],(Real)verts[i][2]));
             }
-            helper::ReadAccessor<Data< core::loader::Material > > mat(visualModels[m]->material);
+            helper::ReadAccessor<Data< sofa::helper::types::Material > > mat(visualModels[m]->material);
             const unsigned char color[3]= {(unsigned char)helper::round(mat->diffuse[0]*255.),(unsigned char)helper::round(mat->diffuse[1]*255.),(unsigned char)helper::round(mat->diffuse[2]*255.)};
 
             cimg_library::CImg<bool> tmp = this->img->get_slicedModels(index,axis,roi,tposition,visualModels[m]->getTriangles(),visualModels[m]->getQuads());

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.h
@@ -28,7 +28,6 @@
 #include <sofa/core/objectmodel/Event.h>
 #include <sofa/defaulttype/BaseMatrix.h>
 #include <sofa/defaulttype/BaseVector.h>
-#include <sofa/defaulttype/Vec3Types.h>
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/helper/vector.h>
 #include <SofaBaseTopology/TopologySubsetData.h>

--- a/modules/SofaGuiQt/src/sofa/gui/qt/MaterialDataWidget.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/MaterialDataWidget.h
@@ -22,7 +22,7 @@
 #ifndef MATERIAL_DATAWIDGET_H
 #define MATERIAL_DATAWIDGET_H
 #include "DataWidget.h"
-#include <sofa/core/loader/Material.h>
+#include <sofa/helper/types/Material.h>
 #include <sofa/defaulttype/Vec.h>
 
 #include <QColorDialog>
@@ -52,7 +52,7 @@ namespace qt
 namespace materialdatawidget_h
 {
 using sofa::gui::qt::QRGBAColorPicker ;
-using sofa::core::loader::Material ;
+using sofa::helper::types::Material ;
 using sofa::core::objectmodel::Data ;
 
 class MaterialDataWidget : public TDataWidget<Material>

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QRGBAColorPicker.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QRGBAColorPicker.h
@@ -22,7 +22,7 @@
 #ifndef QRGBACOLORPICKER_H
 #define QRGBACOLORPICKER_H
 #include "DataWidget.h"
-#include <sofa/core/loader/Material.h>
+#include <sofa/helper/types/Material.h>
 #include <sofa/defaulttype/Vec.h>
 
 #include <QColorDialog>

--- a/modules/SofaGuiQt/src/sofa/gui/qt/StructDataWidget.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/StructDataWidget.h
@@ -504,29 +504,29 @@ class data_widget_container < CLASS > : public struct_data_widget_container < CL
 
 
 ////////////////////////////////////////////////////////////////
-/// sofa::core::loader::Material support
+/// sofa::helper::types::Material support
 ////////////////////////////////////////////////////////////////
 
 template<>
-class struct_data_trait < sofa::core::loader::Material >
+class struct_data_trait < sofa::helper::types::Material >
 {
 public:
-    typedef sofa::core::loader::Material data_type;
+    typedef sofa::helper::types::Material data_type;
     enum { NVAR = 6 };
     static void set( data_type& /*d*/)
     {
     }
 };
 
-template<> STRUCT_DATA_VAR(sofa::core::loader::Material, 0, "Name", "Name", std::string, name);
-template<> STRUCT_DATA_VAR_CHECK(sofa::core::loader::Material, 1, "Ambient", "Amb", sofa::helper::types::RGBAColor, ambient, useAmbient);
-template<> STRUCT_DATA_VAR_CHECK(sofa::core::loader::Material, 2, "Diffuse", "Diff", sofa::helper::types::RGBAColor, diffuse, useDiffuse);
-template<> STRUCT_DATA_VAR_CHECK(sofa::core::loader::Material, 3, "Specular", "Spec", sofa::helper::types::RGBAColor, specular, useSpecular);
-template<> STRUCT_DATA_VAR_CHECK(sofa::core::loader::Material, 4, "Emissive", "Emm", sofa::helper::types::RGBAColor, emissive, useEmissive);
-template<> STRUCT_DATA_VAR_CHECK(sofa::core::loader::Material, 5, "Shininess", "Shin", float, shininess, useShininess);
+template<> STRUCT_DATA_VAR(sofa::helper::types::Material, 0, "Name", "Name", std::string, name);
+template<> STRUCT_DATA_VAR_CHECK(sofa::helper::types::Material, 1, "Ambient", "Amb", sofa::helper::types::RGBAColor, ambient, useAmbient);
+template<> STRUCT_DATA_VAR_CHECK(sofa::helper::types::Material, 2, "Diffuse", "Diff", sofa::helper::types::RGBAColor, diffuse, useDiffuse);
+template<> STRUCT_DATA_VAR_CHECK(sofa::helper::types::Material, 3, "Specular", "Spec", sofa::helper::types::RGBAColor, specular, useSpecular);
+template<> STRUCT_DATA_VAR_CHECK(sofa::helper::types::Material, 4, "Emissive", "Emm", sofa::helper::types::RGBAColor, emissive, useEmissive);
+template<> STRUCT_DATA_VAR_CHECK(sofa::helper::types::Material, 5, "Shininess", "Shin", float, shininess, useShininess);
 
 template<>
-class data_widget_container < sofa::core::loader::Material > : public struct_data_widget_container < sofa::core::loader::Material >
+class data_widget_container < sofa::helper::types::Material > : public struct_data_widget_container < sofa::helper::types::Material >
 {};
 
 } // namespace qt

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglModel.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglModel.cpp
@@ -42,8 +42,8 @@ namespace visualmodel
 {
 
 using sofa::helper::types::RGBAColor;
+using sofa::helper::types::Material;
 using namespace sofa::defaulttype;
-using namespace sofa::core::loader;
 
 int OglModelClass = core::RegisterObject("Generic visual model for OpenGL display")
     .add< sofa::component::visualmodel::OglModel >();


### PR DESCRIPTION
Move Material.h and PrimitiveGroup from SofaCore to SofaHelper. 
This move was needed as it was causing a backward dependency (ie. SofaHelper depending on SofaCore) 
I also removed the SofaDefaultType/Vector3Types... which was flagged for deprecation after 2018 :)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
