### PR TITLE
[SofaKernel] Remove last template parameter in Visitor::for_each/for_each_r

### DIFF
--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVisitor.cpp
@@ -135,28 +135,28 @@ Visitor::Result BaseMechanicalVisitor::processNodeTopDown(simulation::Node* node
 
     if (res != RESULT_PRUNE)
     {
-        res = for_each_r<BaseMechanicalVisitor,VisitorContext,sofa::simulation::Node::Sequence<core::behavior::ConstraintSolver>,core::behavior::ConstraintSolver>(this, ctx, node->constraintSolver, &MechanicalVisitor::fwdConstraintSolver);
+        res = for_each_r(this, ctx, node->constraintSolver, &MechanicalVisitor::fwdConstraintSolver);
     }
 
     if (res != RESULT_PRUNE)
     {
-        res = for_each_r<BaseMechanicalVisitor,VisitorContext,sofa::simulation::Node::Sequence<core::behavior::BaseForceField>,core::behavior::BaseForceField>(this, ctx, node->forceField, &MechanicalVisitor::fwdForceField);
+        res = for_each_r(this, ctx, node->forceField, &MechanicalVisitor::fwdForceField);
     }
 
     if (res != RESULT_PRUNE)
     {
-        res = for_each_r<BaseMechanicalVisitor,VisitorContext,sofa::simulation::Node::Sequence<core::behavior::BaseInteractionForceField>,core::behavior::BaseInteractionForceField>(this, ctx, node->interactionForceField, &MechanicalVisitor::fwdInteractionForceField);
+        res = for_each_r(this, ctx, node->interactionForceField, &MechanicalVisitor::fwdInteractionForceField);
     }
 
 
     if (res != RESULT_PRUNE)
     {
-        res = for_each_r<BaseMechanicalVisitor,VisitorContext,sofa::simulation::Node::Sequence<core::behavior::BaseProjectiveConstraintSet>,core::behavior::BaseProjectiveConstraintSet>(this, ctx, node->projectiveConstraintSet, &MechanicalVisitor::fwdProjectiveConstraintSet);
+        res = for_each_r(this, ctx, node->projectiveConstraintSet, &MechanicalVisitor::fwdProjectiveConstraintSet);
     }
 
     if (res != RESULT_PRUNE)
     {
-        res = for_each_r<BaseMechanicalVisitor,VisitorContext,sofa::simulation::Node::Sequence<core::behavior::BaseConstraintSet>,core::behavior::BaseConstraintSet>(this, ctx, node->constraintSet, &MechanicalVisitor::fwdConstraintSet);
+        res = for_each_r(this, ctx, node->constraintSet, &MechanicalVisitor::fwdConstraintSet);
     }
 
 
@@ -166,9 +166,9 @@ Visitor::Result BaseMechanicalVisitor::processNodeTopDown(simulation::Node* node
 
 void BaseMechanicalVisitor::processNodeBottomUp(simulation::Node* node, VisitorContext* ctx)
 {
-    for_each<BaseMechanicalVisitor,VisitorContext,sofa::simulation::Node::Sequence<core::behavior::BaseProjectiveConstraintSet>,core::behavior::BaseProjectiveConstraintSet>(this, ctx, node->projectiveConstraintSet, &MechanicalVisitor::bwdProjectiveConstraintSet);
-    for_each<BaseMechanicalVisitor,VisitorContext,sofa::simulation::Node::Sequence<core::behavior::BaseConstraintSet>,core::behavior::BaseConstraintSet>(this, ctx, node->constraintSet, &MechanicalVisitor::bwdConstraintSet);
-    for_each<BaseMechanicalVisitor,VisitorContext,sofa::simulation::Node::Sequence<core::behavior::ConstraintSolver>,core::behavior::ConstraintSolver>(this, ctx, node->constraintSolver, &MechanicalVisitor::bwdConstraintSolver);
+    for_each(this, ctx, node->projectiveConstraintSet, &MechanicalVisitor::bwdProjectiveConstraintSet);
+    for_each(this, ctx, node->constraintSet, &MechanicalVisitor::bwdConstraintSet);
+    for_each(this, ctx, node->constraintSolver, &MechanicalVisitor::bwdConstraintSolver);
 
     if (node->mechanicalState != nullptr)
     {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/UpdateMappingVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/UpdateMappingVisitor.cpp
@@ -50,15 +50,6 @@ Visitor::Result UpdateMappingVisitor::processNodeTopDown(simulation::Node* node)
     for_each(this, node, node->mapping, &UpdateMappingVisitor::processMapping);
     for_each(this, node, node->mechanicalMapping, &UpdateMappingVisitor::processMechanicalMapping);
 
-//    {
-//            if (!node->nodeInVisualGraph.empty()) node->nodeInVisualGraph->execute<UpdateMappingVisitor>();
-//            for (simulation::Node::ChildIterator itChild = node->childInVisualGraph.begin(); itChild != node->childInVisualGraph.end(); ++itChild)
-//            {
-//                simulation::Node *child=*itChild;
-//                child->execute<UpdateMappingVisitor>();
-//            }
-//    }
-
     return RESULT_CONTINUE;
 }
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Visitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Visitor.h
@@ -105,8 +105,8 @@ public:
 #endif
 
     /// Helper method to enumerate objects in the given list. The callback gets the pointer to node
-    template < class Visit, class VContext, class Container, class Object >
-    void for_each(Visit* visitor, VContext* ctx, const Container& list, void (Visit::*fn)(VContext*, Object*))
+    template < class Visit, class VContext, class Container >
+    void for_each(Visit* visitor, VContext* ctx, const Container& list, void (Visit::*fn)(VContext*, typename Container::pointed_type*))
     {
         for (typename Container::iterator it=list.begin(); it != list.end(); ++it)
         {
@@ -123,8 +123,8 @@ public:
     }
 
     /// Helper method to enumerate objects in the given list. The callback gets the pointer to node
-    template < class Visit, class VContext, class Container, class Object >
-    Visitor::Result for_each_r(Visit* visitor, VContext* ctx, const Container& list, Visitor::Result (Visit::*fn)(VContext*, Object*))
+    template < class Visit, class VContext, class Container>
+    Visitor::Result for_each_r(Visit* visitor, VContext* ctx, const Container& list, Visitor::Result (Visit::*fn)(VContext*, typename Container::pointed_type*))
     {
         Visitor::Result res = Visitor::RESULT_CONTINUE;
         for (typename Container::iterator it=list.begin(); it != list.end(); ++it)

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Visitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Visitor.h
@@ -105,8 +105,8 @@ public:
 #endif
 
     /// Helper method to enumerate objects in the given list. The callback gets the pointer to node
-    template < class Visit, class VContext, class Container >
-    void for_each(Visit* visitor, VContext* ctx, const Container& list, void (Visit::*fn)(VContext*, typename Container::pointed_type*))
+    template < class Visit, class VContext, class Container, typename PointedType = typename Container::pointed_type >
+    void for_each(Visit* visitor, VContext* ctx, const Container& list, void (Visit::*fn)(VContext*, PointedType*))
     {
         for (typename Container::iterator it=list.begin(); it != list.end(); ++it)
         {
@@ -123,8 +123,8 @@ public:
     }
 
     /// Helper method to enumerate objects in the given list. The callback gets the pointer to node
-    template < class Visit, class VContext, class Container>
-    Visitor::Result for_each_r(Visit* visitor, VContext* ctx, const Container& list, Visitor::Result (Visit::*fn)(VContext*, typename Container::pointed_type*))
+    template < class Visit, class VContext, class Container, typename PointedType = typename Container::pointed_type>
+    Visitor::Result for_each_r(Visit* visitor, VContext* ctx, const Container& list, Visitor::Result (Visit::*fn)(VContext*, PointedType*))
     {
         Visitor::Result res = Visitor::RESULT_CONTINUE;
         for (typename Container::iterator it=list.begin(); it != list.end(); ++it)


### PR DESCRIPTION
This last parameter can be deduced from the container traits so there is no need to specify it. 
This allow to simplifying some calling point as in MechanicalVisitor & UpdateMappingVisitor.h






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
