### PR TITLE
[SofaKernel/SofaGuiQt] Qt viewer with intel drivers

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/gl.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/gl.cpp
@@ -31,8 +31,8 @@ SOFA_HELPER_API const char* GetGlExtensionsList()
 
 SOFA_HELPER_API bool CanUseGlExtension(const std::string& ext)
 {
-    std::string Extensions = GetGlExtensionsList();
-    if( Extensions.find( ext ) != std::string::npos )
+    const char * extensions = GetGlExtensionsList();
+    if( extensions && std::string(extensions).find( ext ) != std::string::npos )
         return true;
     return false;
 }

--- a/modules/SofaGuiQt/src/sofa/gui/qt/viewer/qt/QtViewer.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/viewer/qt/QtViewer.cpp
@@ -97,8 +97,8 @@ QSurfaceFormat QtViewer::setupGLFormat(const unsigned int nbMSAASamples)
     //Multisampling
     if(nbMSAASamples > 1)
     {
-        std::cout <<"QtViewer: Set multisampling anti-aliasing (MSSA) with " << nbMSAASamples << " samples." << std::endl;
-        f.setSamples(nbMSAASamples);
+        msg_info("QtViewer") <<"QtViewer: Set multisampling anti-aliasing (MSSA) with " << nbMSAASamples << " samples." ;
+        f.setSamples(static_cast<int>(nbMSAASamples));
     }
 
     if(!SOFAGUIQT_ENABLE_VSYNC)
@@ -109,6 +109,7 @@ QSurfaceFormat QtViewer::setupGLFormat(const unsigned int nbMSAASamples)
     int vmajor = 3, vminor = 2;
     f.setVersion(vmajor,vminor);
     f.setProfile(QSurfaceFormat::CompatibilityProfile);
+    f.setOption(QSurfaceFormat::DeprecatedFunctions, true);
 
     f.setSwapBehavior(QSurfaceFormat::DoubleBuffer);
 
@@ -154,9 +155,6 @@ QtViewer::QtViewer(QWidget* parent, const char* name, const unsigned int nbMSAAS
     : QOpenGLWidget(setupGLFormat(nbMSAASamples), parent)
 #endif // defined(QT_VERSION) && QT_VERSION >= 0x050400
 {
-#ifdef __linux__
-    ::setenv("MESA_GL_VERSION_OVERRIDE", "3.0", 1);
-#endif // __linux
     m_backend.reset(new GLBackend());
     pick = new GLPickHandler();
 
@@ -220,18 +218,16 @@ QtViewer::~QtViewer()
 // -----------------------------------------------------------------
 void QtViewer::initializeGL(void)
 {
-    std::cout << "QtViewer: OpenGL " << glGetString(GL_VERSION)
-              << " context created." << std::endl;
-    if (std::string((const char*)glGetString(GL_VENDOR)).find("Intel") !=
-            std::string::npos)
+    msg_info("QtViewer") << "OpenGL version: " << glGetString(GL_VERSION) << " (" << glGetString(GL_VENDOR) << ")";
+    if (std::string((const char*)glGetString(GL_VENDOR)).find("Intel") != std::string::npos)
     {
         const char* mesaEnv = ::getenv("MESA_GL_VERSION_OVERRIDE");
         if ( !mesaEnv || std::string(mesaEnv) != "3.0")
-            msg_error("runSofa") << "QtViewer is not compatible with Intel drivers on "
-                                    "Linux. To use runSofa, either change the gui to "
-                                    "qglviewer (runSofa -g qglviewer) or set the "
-                                    "environment variable \"MESA_GL_VERSION_OVERRIDE\" "
-                                    "to the value \"3.0\"";
+            msg_warning("QtViewer") << "QtViewer might not be compatible with Intel drivers on "
+                                       "Linux. If you run into rendering issues, try changing "
+                                       "the gui to qglviewer (runSofa -g qglviewer) or set the "
+                                       "environment variable \"MESA_GL_VERSION_OVERRIDE\" "
+                                       "to the value \"3.0\"";
     }
 
     static GLfloat specref[4];


### PR DESCRIPTION
We got this error many times in the past, and I never had the chance to dig into the issue. There was actually two issues:

1. SOFA was unable to find some GL extensions on Intel drivers with the Qt viewer while they were supposed to be there (they were correctly found when using the qglviewer)
2. When no extensions at all were found by Glew, SOFA tried to convert a null pointer to a std::string, which created a segmentation fault

This PR fixes both of these issues. It first make sure that the pointer returned by Glew isn't null before converting it to a std::string. It also asks Qt to enable deprecated functions, which are used by SOFA.

In addition, I've removed the part of the Qt viewer that was forcing the environment variable `MESA_GL_VERSION_OVERRIDE` on Linux. I've also remove the error when this environment variable wasn't set with Intel driver (which was never the case because we were forcing it...) and added a warning instead (Qt viewer works fine on Intel drivers, maybe this was an old bug?).  

Will most probably fix https://github.com/sofa-framework/sofa/issues/1567


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
