### PR TITLE
[SofaCore] Base::findLinkDest returns Base* instead of void*

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/PathResolver.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/PathResolver.cpp
@@ -78,7 +78,7 @@ bool PathResolver::FindDataLinkDest(Base* context, BaseData*& ptr, const std::st
     return context->findDataLinkDest(ptr, path, link);
 }
 
-void* PathResolver::FindLinkDestClass(Base* context, const BaseClass* destType, const std::string& path, const BaseLink* link)
+Base* PathResolver::FindLinkDestClass(Base* context, const BaseClass* destType, const std::string& path, const BaseLink* link)
 {
     if(context==nullptr)
         return nullptr;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/PathResolver.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/PathResolver.h
@@ -65,7 +65,7 @@ public:
         return result != nullptr;
     }
 
-    static void* FindLinkDestClass(Base* context, const BaseClass* destType, const std::string& path, const BaseLink* link);
+    static Base* FindLinkDestClass(Base* context, const BaseClass* destType, const std::string& path, const BaseLink* link);
 
     template<class T>
     static bool CheckPath(Base* context, const std::string& path)
@@ -78,8 +78,8 @@ public:
     template<class T>
     static bool FindLinkDest(Base* base, T*& ptr, const std::string& path, const BaseLink* link)
     {
-        void* result = FindLinkDestClass(base, T::GetClass(), path, link);
-        ptr = reinterpret_cast<T*>(result);
+        Base* result = FindLinkDestClass(base, T::GetClass(), path, link);
+        ptr=dynamic_cast<T*>(result);
         return (result != nullptr);
     }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -422,7 +422,7 @@ bool Base::findDataLinkDest(BaseData*& ptr, const std::string& path, const BaseL
     return (ptr != nullptr);
 }
 
-void* Base::findLinkDestClass(const BaseClass* /*destType*/, const std::string& /*path*/, const BaseLink* /*link*/)
+Base* Base::findLinkDestClass(const BaseClass* /*destType*/, const std::string& /*path*/, const BaseLink* /*link*/)
 {
     msg_error() << "Base: calling unimplemented findLinkDest method" ;
     return nullptr;
@@ -505,9 +505,7 @@ bool Base::parseField( const std::string& attribute, const std::string& value)
             std::stringstream tmp;
             tmp << "  " << linkVec[l]->getLinkedPath(i) << " = ";
             Base* b = linkVec[l]->getLinkedBase(i);
-            BaseData* d = linkVec[l]->getLinkedData(i);
             if (b) tmp << b->getTypeName() << " " << b->getName();
-            if (d) tmp << " . " << d->getValueTypeString() << " " << d->getName();
             msg_info() << tmp.str();
         }
     }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -350,7 +350,7 @@ public:
     const MapLink& getLinkAliases() const { return m_aliasLink; }
 
     virtual bool findDataLinkDest(BaseData*& ptr, const std::string& path, const BaseLink* link);
-    virtual void* findLinkDestClass(const BaseClass* destType, const std::string& path, const BaseLink* link);
+    virtual Base* findLinkDestClass(const BaseClass* destType, const std::string& path, const BaseLink* link);
     template<class T>
     bool findLinkDest(T*& ptr, const std::string& path, const BaseLink* link)
     {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -135,12 +135,6 @@ public:
     static const BaseClass* GetClass() { return MyClass::get(); }
     virtual const BaseClass* getClass() const { return GetClass(); }
 
-    template<class T>
-    static void dynamicCast(T*& ptr, Base* b)
-    {
-        ptr = dynamic_cast<T*>(b);
-    }
-
 protected:
     /// Constructor cannot be called directly
     /// Use the New() method instead

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -348,8 +348,8 @@ public:
     template<class T>
     bool findLinkDest(T*& ptr, const std::string& path, const BaseLink* link)
     {
-        void* result = findLinkDestClass(T::GetClass(), path, link);
-        ptr = reinterpret_cast<T*>(result);
+        Base* result = findLinkDestClass(T::GetClass(), path, link);
+        ptr = dynamic_cast<T*>(result);
         return (result != nullptr);
     }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseClass.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseClass.h
@@ -390,9 +390,7 @@ protected:
 
     Base* dynamicCast(Base* obj) const override
     {
-        T* ptr = nullptr;
-        T::dynamicCast(ptr, obj);
-        return ptr;
+        return dynamic_cast<T*>(obj);
     }
 
     bool isInstance(Base* obj) const override

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseClass.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseClass.h
@@ -96,7 +96,7 @@ public:
         return !((*this)==c);
     }
 
-    virtual void* dynamicCast(Base* obj) const = 0;
+    virtual Base* dynamicCast(Base* obj) const = 0;
     virtual bool isInstance(Base* obj) const = 0;
 
     ///////////////////////////////// DEPRECATED //////////////////////////////////////////////////
@@ -143,7 +143,7 @@ class SOFA_CORE_API DeprecatedBaseClass : public BaseClass
 public:
     DeprecatedBaseClass();
 
-    void* dynamicCast(Base*) const override { return nullptr; }
+    Base* dynamicCast(Base*) const override { return nullptr; }
     bool isInstance(Base*) const override { return false; }
 
     static BaseClass* GetSingleton();
@@ -388,7 +388,7 @@ protected:
     }
     ~TClass() override {}
 
-    void* dynamicCast(Base* obj) const override
+    Base* dynamicCast(Base* obj) const override
     {
         T* ptr = nullptr;
         T::dynamicCast(ptr, obj);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseNode.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseNode.h
@@ -136,7 +136,7 @@ public:
     /// Return the path from this node to the root node
     virtual std::string getRootPath() const;
 
-    void* findLinkDestClass(const BaseClass* destType, const std::string& path, const BaseLink* link) override = 0;
+    Base* findLinkDestClass(const BaseClass* destType, const std::string& path, const BaseLink* link) override = 0;
 
     /// @}
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.cpp
@@ -185,7 +185,7 @@ void BaseObject::setSrc(const std::string &valueString, const BaseObject *loader
     }
 }
 
-void* BaseObject::findLinkDestClass(const BaseClass* destType, const std::string& path, const BaseLink* link)
+Base* BaseObject::findLinkDestClass(const BaseClass* destType, const std::string& path, const BaseLink* link)
 {
     if (this->getContext() == BaseContext::getDefault())
         return nullptr;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.h
@@ -434,7 +434,7 @@ public:
     /// Use it before scene graph insertion
     void setSrc(const std::string &v, const BaseObject *loader, std::vector< std::string > *attributeList=nullptr);
 
-    void* findLinkDestClass(const BaseClass* destType, const std::string& path, const BaseLink* link) override;
+    Base* findLinkDestClass(const BaseClass* destType, const std::string& path, const BaseLink* link) override;
 
 
     /// Return the full path name of this object

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.cpp
@@ -94,6 +94,7 @@ Node::Node(const std::string& name)
 {
     _context = this;
     setName(name);
+    f_printLog.setValue(DEBUG_LINK);
 }
 
 
@@ -358,7 +359,7 @@ core::objectmodel::BaseObject* Node::getObject(const std::string& name) const
     return nullptr;
 }
 
-void* Node::findLinkDestClass(const core::objectmodel::BaseClass* destType, const std::string& path, const core::objectmodel::BaseLink* link)
+sofa::core::objectmodel::Base* Node::findLinkDestClass(const core::objectmodel::BaseClass* destType, const std::string& path, const core::objectmodel::BaseLink* link)
 {
     std::string pathStr;
     if (link)
@@ -524,7 +525,7 @@ void* Node::findLinkDestClass(const core::objectmodel::BaseClass* destType, cons
     }
     else
     {
-        void* r = destType->dynamicCast(node);
+        Base* r = destType->dynamicCast(node);
         if (r)
         {
             if(DEBUG_LINK)
@@ -534,7 +535,7 @@ void* Node::findLinkDestClass(const core::objectmodel::BaseClass* destType, cons
         for (ObjectIterator it = node->object.begin(), itend = node->object.end(); it != itend; ++it)
         {
             BaseObject* obj = it->get();
-            void *o = destType->dynamicCast(obj);
+            Base *o = destType->dynamicCast(obj);
             if (!o) continue;
             if(DEBUG_LINK)
                 dmsg_info()  << "  found " << obj->getTypeName() << " " << obj->getName() << "." ;

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.h
@@ -327,8 +327,7 @@ public:
     /// Find an object given its name
     sofa::core::objectmodel::BaseObject* getObject(const std::string& name) const;
 
-    void* findLinkDestClass(const sofa::core::objectmodel::BaseClass* destType, const std::string& path, const sofa::core::objectmodel::BaseLink* link) override;
-
+    Base* findLinkDestClass(const sofa::core::objectmodel::BaseClass* destType, const std::string& path, const sofa::core::objectmodel::BaseLink* link) override;
 
     /// Generic object access, given a set of required tags, possibly searching up or down from the current context
     ///

--- a/applications/plugins/Compliant/misc/FailNode.cpp
+++ b/applications/plugins/Compliant/misc/FailNode.cpp
@@ -88,7 +88,7 @@ std::string FailNode::getPathName() const {fail(); return 0; }
 /// Return the path from this node to the root node
 std::string FailNode::getRootPath() const {fail(); return 0; }
 
-void* FailNode::findLinkDestClass(const BaseClass* /*destType*/, const std::string& /*path*/, const BaseLink* /*link*/){ fail(); return nullptr;}
+Base* FailNode::findLinkDestClass(const BaseClass* /*destType*/, const std::string& /*path*/, const BaseLink* /*link*/){ fail(); return nullptr;}
 
 
 

--- a/applications/plugins/Compliant/misc/FailNode.h
+++ b/applications/plugins/Compliant/misc/FailNode.h
@@ -81,7 +81,7 @@ public:
     /// Return the path from this node to the root node
     virtual std::string getRootPath() const override;
 
-    virtual void* findLinkDestClass(const core::objectmodel::BaseClass* destType, 
+    virtual Base* findLinkDestClass(const core::objectmodel::BaseClass* destType,
 									const std::string& path, 
                                     const BaseLink* link) override;
 


### PR DESCRIPTION
Given that BaseClass is to describe Base* object and that Link can only hold Base* either it make sense to returns Base* from dynamicCast as well as from findLinkDest. 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
