### PR TITLE
[CMake] Macro replace dot with underscore for preprocessor defines

### DIFF
--- a/SofaKernel/SofaFramework/SofaMacrosInstall.cmake
+++ b/SofaKernel/SofaFramework/SofaMacrosInstall.cmake
@@ -217,9 +217,13 @@ macro(sofa_auto_set_target_properties)
             string(REGEX REPLACE "([^A-Z])([A-Z])" "\\1_\\2" sofa_target_oldname "${target}")
             string(REPLACE "Sofa" "" sofa_target_oldname "${sofa_target_oldname}")
             string(TOUPPER "${sofa_target_oldname}" sofa_target_oldname_upper)
-            target_compile_definitions(${target} PRIVATE "-DSOFA_BUILD${sofa_target_oldname_upper}")
+            string(REPLACE "." "_" sofa_oldname_preprocessor "${sofa_target_oldname_upper}")
+            target_compile_definitions(${target} PRIVATE "-DSOFA_BUILD${sofa_oldname_preprocessor}")
         endif()
-        target_compile_definitions(${target} PRIVATE "-DSOFA_BUILD_${sofa_target_name_upper}")
+
+        # C Preprocessor definitions do not handle dot character, so it is replaced with an underscore
+        string(REPLACE "." "_" sofa_name_preprocessor "${sofa_target_name_upper}")
+        target_compile_definitions(${target} PRIVATE "-DSOFA_BUILD_${sofa_name_preprocessor}")
 
         # Set target include directories (if not already set manually)
         set(include_source_root "${CMAKE_CURRENT_SOURCE_DIR}/..") # default but bad practice

--- a/SofaKernel/SofaFramework/SofaMacrosInstall.cmake
+++ b/SofaKernel/SofaFramework/SofaMacrosInstall.cmake
@@ -190,6 +190,8 @@ macro(sofa_auto_set_target_properties)
         endif()
 
         string(TOUPPER "${target}" sofa_target_name_upper)
+        # C Preprocessor definitions do not handle dot character, so it is replaced with an underscore
+        string(REPLACE "." "_" sofa_target_name_upper "${sofa_target_name_upper}")
         set(${sofa_target_name_upper}_TARGET "${sofa_target_name_upper}")
 
         # Set target properties
@@ -217,13 +219,10 @@ macro(sofa_auto_set_target_properties)
             string(REGEX REPLACE "([^A-Z])([A-Z])" "\\1_\\2" sofa_target_oldname "${target}")
             string(REPLACE "Sofa" "" sofa_target_oldname "${sofa_target_oldname}")
             string(TOUPPER "${sofa_target_oldname}" sofa_target_oldname_upper)
-            string(REPLACE "." "_" sofa_oldname_preprocessor "${sofa_target_oldname_upper}")
-            target_compile_definitions(${target} PRIVATE "-DSOFA_BUILD${sofa_oldname_preprocessor}")
+            string(REPLACE "." "_" sofa_target_oldname_upper "${sofa_target_oldname_upper}")
+            target_compile_definitions(${target} PRIVATE "-DSOFA_BUILD${sofa_target_oldname_upper}")
         endif()
-
-        # C Preprocessor definitions do not handle dot character, so it is replaced with an underscore
-        string(REPLACE "." "_" sofa_name_preprocessor "${sofa_target_name_upper}")
-        target_compile_definitions(${target} PRIVATE "-DSOFA_BUILD_${sofa_name_preprocessor}")
+        target_compile_definitions(${target} PRIVATE "-DSOFA_BUILD_${sofa_target_name_upper}")
 
         # Set target include directories (if not already set manually)
         set(include_source_root "${CMAKE_CURRENT_SOURCE_DIR}/..") # default but bad practice

--- a/SofaKernel/modules/Sofa.GL/CMakeLists.txt
+++ b/SofaKernel/modules/Sofa.GL/CMakeLists.txt
@@ -60,8 +60,6 @@ endif()
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaHelper SofaDefaultType)
 
-target_compile_definitions(${PROJECT_NAME} PRIVATE SOFA_BUILD_SOFA_GL) # To remove once sofa_add_targets_to_package remove the dot in the generated definition 
-
 if(TARGET OpenGL::GL AND TARGET OpenGL::GLU) # Imported targets defined since CMake 3.8
     target_link_libraries(${PROJECT_NAME} PUBLIC OpenGL::GL OpenGL::GLU)
 else()


### PR DESCRIPTION
Modules for pluginization contain a dot (Sofa.GL, Sofa.Types, etc),
and custom macro (sofa_create_package_with_targets) generates preprocessor definitions according to the name.
So with the new modules name, the macro creates a preprocessor definition with a dot '.' , but this is not permitted by the C preprocessor.

So this PR replaces a '.' with a '_' for the generated definitions.
Fix #1695 (and seems to remove a warning generated by clang)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
