### PR TITLE
[SofaGeneralAnimationLoop] MechanicalMatrixMapper: adds template

### DIFF
--- a/modules/SofaGeneralAnimationLoop/src/SofaGeneralAnimationLoop/MechanicalMatrixMapper.cpp
+++ b/modules/SofaGeneralAnimationLoop/src/SofaGeneralAnimationLoop/MechanicalMatrixMapper.cpp
@@ -33,11 +33,12 @@ using namespace sofa::defaulttype;
 ////////////////////////////////////////////    FACTORY    //////////////////////////////////////////////
 int MechanicalMatrixMapperClass = core::RegisterObject("This component allows to map the stiffness (and mass) matrix through a mapping.")
 
-        .add< MechanicalMatrixMapper<Rigid3Types, Rigid3Types> >(true)
-        .add< MechanicalMatrixMapper<Vec3Types, Rigid3Types> >(true)
-        .add< MechanicalMatrixMapper<Vec3Types, Vec3Types> >(true)
-        .add< MechanicalMatrixMapper<Vec1Types, Rigid3Types> >(true)
-        .add< MechanicalMatrixMapper<Vec1Types, Vec1Types> >(true)
+        .add< MechanicalMatrixMapper<Rigid3Types, Rigid3Types> >()
+        .add< MechanicalMatrixMapper<Vec3Types, Rigid3Types> >()
+        .add< MechanicalMatrixMapper<Vec3Types, Vec3Types> >()
+        .add< MechanicalMatrixMapper<Vec1Types, Rigid3Types> >()
+        .add< MechanicalMatrixMapper<Vec1Types, Vec3Types> >()
+        .add< MechanicalMatrixMapper<Vec1Types, Vec1Types> >()
         .add< MechanicalMatrixMapper<Rigid3Types, Vec1Types> >(true)
 
         ;
@@ -47,6 +48,7 @@ template class SOFA_SOFAGENERALANIMATIONLOOP_API MechanicalMatrixMapper<Rigid3Ty
 template class SOFA_SOFAGENERALANIMATIONLOOP_API MechanicalMatrixMapper<Vec3Types, Rigid3Types>;
 template class SOFA_SOFAGENERALANIMATIONLOOP_API MechanicalMatrixMapper<Vec3Types, Vec3Types>;
 template class SOFA_SOFAGENERALANIMATIONLOOP_API MechanicalMatrixMapper<Vec1Types, Rigid3Types>;
+template class SOFA_SOFAGENERALANIMATIONLOOP_API MechanicalMatrixMapper<Vec1Types, Vec3Types>;
 template class SOFA_SOFAGENERALANIMATIONLOOP_API MechanicalMatrixMapper<Vec1Types, Vec1Types>;
 template class SOFA_SOFAGENERALANIMATIONLOOP_API MechanicalMatrixMapper<Rigid3Types, Vec1Types> ;
 

--- a/modules/SofaGeneralAnimationLoop/src/SofaGeneralAnimationLoop/MechanicalMatrixMapper.h
+++ b/modules/SofaGeneralAnimationLoop/src/SofaGeneralAnimationLoop/MechanicalMatrixMapper.h
@@ -272,10 +272,13 @@ protected:
 };
 
 #if !defined(SOFA_COMPONENT_ANIMATIONLOOP_MECHANICALMATRIXMAPPER_CPP)
+extern template class SOFA_SOFAGENERALANIMATIONLOOP_API MechanicalMatrixMapper<defaulttype::Rigid3Types, defaulttype::Rigid3Types>;
 extern template class SOFA_SOFAGENERALANIMATIONLOOP_API MechanicalMatrixMapper<defaulttype::Vec3Types, defaulttype::Rigid3Types>;
 extern template class SOFA_SOFAGENERALANIMATIONLOOP_API MechanicalMatrixMapper<defaulttype::Vec3Types, defaulttype::Vec3Types>;
 extern template class SOFA_SOFAGENERALANIMATIONLOOP_API MechanicalMatrixMapper<defaulttype::Vec1Types, defaulttype::Rigid3Types>;
+extern template class SOFA_SOFAGENERALANIMATIONLOOP_API MechanicalMatrixMapper<defaulttype::Vec1Types, defaulttype::Vec3Types>;
 extern template class SOFA_SOFAGENERALANIMATIONLOOP_API MechanicalMatrixMapper<defaulttype::Vec1Types, defaulttype::Vec1Types>;
+extern template class SOFA_SOFAGENERALANIMATIONLOOP_API MechanicalMatrixMapper<defaulttype::Rigid3Types, defaulttype::Vec1Types>;
 #endif
 
 } // namespace sofa::component::interactionforcefield


### PR DESCRIPTION
The PR just adds the template "Vec1,Vec3" to the component MechanicalMatrixMapper.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
