### PR TITLE
[SofaCore_test] Update the two failling tests so they match the new convention for TypeInfo

### DIFF
--- a/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/Data_test.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/Data_test.cpp
@@ -44,8 +44,8 @@ public:
 
 TEST_F(Data_test, getValueTypeString)
 {
-    EXPECT_EQ(dataInt.getValueTypeString(), "int");
-    EXPECT_EQ(dataFloat.getValueTypeString(), "float");
+    EXPECT_EQ(dataInt.getValueTypeString(), "i");
+    EXPECT_EQ(dataFloat.getValueTypeString(), "f");
     EXPECT_EQ(dataBool.getValueTypeString(), "bool");
     EXPECT_EQ(dataVec3.getValueTypeString(), "Vec3d");
     EXPECT_EQ(dataVectorVec3.getValueTypeString(), "vector<Vec3d>");
@@ -54,8 +54,8 @@ TEST_F(Data_test, getValueTypeString)
 
 TEST_F(Data_test, getNameWithValueTypeInfo)
 {
-    EXPECT_EQ(dataInt.getValueTypeInfo()->name(), "int");
-    EXPECT_EQ(dataFloat.getValueTypeInfo()->name(), "float");
+    EXPECT_EQ(dataInt.getValueTypeInfo()->name(), "i");
+    EXPECT_EQ(dataFloat.getValueTypeInfo()->name(), "f");
     EXPECT_EQ(dataBool.getValueTypeInfo()->name(), "bool");
     EXPECT_EQ(dataVec3.getValueTypeInfo()->name(), "Vec3d");
     EXPECT_EQ(dataVectorVec3.getValueTypeInfo()->name(), "vector<Vec3d>");


### PR DESCRIPTION
Given that the 20.12 release is on its way we can probably update the tests to the new value.

Reminder of the convention:
TypeInfo::GetTypeName() => is a string representing the type as seen from c++, eg: vector<Vec<double, 3>>
TypeInfo::name() => is a string representing the type with as much as short cut, eg: vector<Vec3d>






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
