### PR TITLE
[SofaMacros] FIX missing lib copy on Windows

### DIFF
--- a/SofaKernel/SofaFramework/SofaMacrosInstall.cmake
+++ b/SofaKernel/SofaFramework/SofaMacrosInstall.cmake
@@ -778,7 +778,11 @@ function(sofa_install_libraries)
 
         if(parseOk AND NOT CMAKE_CONFIGURATION_TYPES) # Single-config generator
             string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_UPPER)
-            set(lib_paths ${LIBRARIES_${CMAKE_BUILD_TYPE_UPPER}})
+            if(CMAKE_BUILD_TYPE_UPPER STREQUAL "DEBUG")
+                set(lib_paths ${LIBRARIES_DEBUG})
+            else()
+                set(lib_paths ${LIBRARIES_RELEASE})
+            endif()
         endif()
     else()
         message(WARNING "sofa_install_libraries: no lib found with ${ARGV}")


### PR DESCRIPTION
Boost libs were not copied correctly in MinSizeRel and RelWithDebInfo configurations on Windows.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
