### PR TITLE
[SofaBaseLinearSolver] Fix logging info with SPARSEMATRIX_VERBOSE 

### DIFF
--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/CompressedRowSparseMatrix.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/CompressedRowSparseMatrix.h
@@ -35,11 +35,11 @@ namespace sofa::component::linearsolver
 
 /// This pattern is used to force compilation of code fragment that depend on the definition of
 /// the "define". In the following, use if(EMIT_EXTRA_MESSAGE) instead of #ifdef
-#ifdef SPARSEMATRIX_VERBOSE
+#if defined(SPARSEMATRIX_VERBOSE) && (SPARSEMATRIX_VERBOSE == true)
 #define EMIT_EXTRA_MESSAGE true
 #else
 #define EMIT_EXTRA_MESSAGE false
-#endif
+#endif // defined(SPARSEMATRIX_VERBOSE) && (SPARSEMATRIX_VERBOSE == true)
 
 template<typename TBloc, typename TVecBloc = helper::vector<TBloc>, typename TVecIndex = helper::vector<defaulttype::BaseMatrix::Index> >
 class CompressedRowSparseMatrix : public defaulttype::BaseMatrix


### PR DESCRIPTION
CompressedRowSparseMatrix is emitting verbose information even if SPARSEMATRIX_VERBOSE is set to false.
The test is actually done with the definition of the preprocessor define, not its value itself.
This PR fixes it by testing its existence AND its value (true or false)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
