### PR TITLE
[SofaHelper] Add SOFA/bin to SOFA_PLUGIN_PATH

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
@@ -79,6 +79,7 @@ std::string cleanPath( const std::string& path )
 FileRepository PluginRepository(
         "SOFA_PLUGIN_PATH", {
             Utils::getExecutableDirectory(),
+            Utils::getSofaPathTo("bin"),
             Utils::getSofaPathTo("plugins")
         }
 );


### PR DESCRIPTION
It is needed to resolve dependencies when using binaries for dev on Windows.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
