### PR TITLE
[tools] More default plugins in binaries

### DIFF
--- a/tools/postinstall-fixup/linux-postinstall-fixup.sh
+++ b/tools/postinstall-fixup/linux-postinstall-fixup.sh
@@ -16,20 +16,28 @@ fi
 
 # Keep plugin_list as short as possible
 echo "" > "$INSTALL_DIR/lib/plugin_list.conf"
+disabled_plugins='plugins_ignored_by_default'
 for plugin in \
-        SofaExporter       \
-        SofaSparseSolver   \
-        SofaPreconditioner \
-        SofaValidation     \
-        SofaDenseSolver    \
-        SofaNonUniformFem  \
-        SofaOpenglVisual   \
-        SofaSphFluid       \
-        CImgPlugin         \
-        SofaMiscCollision  \
+        SofaEulerianFluid     \
+        SofaDistanceGrid      \
+        SofaImplicitField     \
+        MultiThreading        \
+        DiffusionSolver       \
+        image                 \
+        Compliant             \
+        SofaPython            \
+        Flexible              \
+        Registration          \
+        ExternalBehaviorModel \
+        ManifoldTopologies    \
+        ManualMapping         \
+        THMPGSpatialHashing   \
+        SofaCarving           \
+        RigidScale            \
     ; do
-    grep "$plugin" "$INSTALL_DIR/lib/plugin_list.conf.default" >> "$INSTALL_DIR/lib/plugin_list.conf"
+    disabled_plugins=$disabled_plugins'\|'$plugin
 done
+grep -v $disabled_plugins "$INSTALL_DIR/lib/plugin_list.conf.default" >> "$INSTALL_DIR/lib/plugin_list.conf"
 
 echo "Fixing up libs..."
 

--- a/tools/postinstall-fixup/macos-postinstall-fixup.sh
+++ b/tools/postinstall-fixup/macos-postinstall-fixup.sh
@@ -25,20 +25,28 @@ echo "MACDEPLOYQT_EXE = $MACDEPLOYQT_EXE"
 
 # Keep plugin_list as short as possible
 echo "" > "$INSTALL_DIR/lib/plugin_list.conf"
+disabled_plugins='plugins_ignored_by_default'
 for plugin in \
-        SofaExporter       \
-        SofaSparseSolver   \
-        SofaPreconditioner \
-        SofaValidation     \
-        SofaDenseSolver    \
-        SofaNonUniformFem  \
-        SofaOpenglVisual   \
-        SofaSphFluid       \
-        CImgPlugin         \
-        SofaMiscCollision  \
+        SofaEulerianFluid     \
+        SofaDistanceGrid      \
+        SofaImplicitField     \
+        MultiThreading        \
+        DiffusionSolver       \
+        image                 \
+        Compliant             \
+        SofaPython            \
+        Flexible              \
+        Registration          \
+        ExternalBehaviorModel \
+        ManifoldTopologies    \
+        ManualMapping         \
+        THMPGSpatialHashing   \
+        SofaCarving           \
+        RigidScale            \
     ; do
-    grep "$plugin" "$INSTALL_DIR/lib/plugin_list.conf.default" >> "$INSTALL_DIR/lib/plugin_list.conf"
+    disabled_plugins=$disabled_plugins'\|'$plugin
 done
+grep -v $disabled_plugins "$INSTALL_DIR/lib/plugin_list.conf.default" >> "$INSTALL_DIR/lib/plugin_list.conf"
 
 # Make sure the bin folder exists and contains runSofa
 if [ ! -d "$INSTALL_DIR/bin" ]; then

--- a/tools/postinstall-fixup/windows-postinstall-fixup.sh
+++ b/tools/postinstall-fixup/windows-postinstall-fixup.sh
@@ -13,20 +13,28 @@ fi
 
 # Keep plugin_list as short as possible
 echo "" > "$INSTALL_DIR/bin/plugin_list.conf"
+disabled_plugins='plugins_ignored_by_default'
 for plugin in \
-        SofaExporter       \
-        SofaSparseSolver   \
-        SofaPreconditioner \
-        SofaValidation     \
-        SofaDenseSolver    \
-        SofaNonUniformFem  \
-        SofaOpenglVisual   \
-        SofaSphFluid       \
-        CImgPlugin         \
-        SofaMiscCollision  \
+        SofaEulerianFluid     \
+        SofaDistanceGrid      \
+        SofaImplicitField     \
+        MultiThreading        \
+        DiffusionSolver       \
+        image                 \
+        Compliant             \
+        SofaPython            \
+        Flexible              \
+        Registration          \
+        ExternalBehaviorModel \
+        ManifoldTopologies    \
+        ManualMapping         \
+        THMPGSpatialHashing   \
+        SofaCarving           \
+        RigidScale            \
     ; do
-    grep "$plugin" "$INSTALL_DIR/bin/plugin_list.conf.default" >> "$INSTALL_DIR/bin/plugin_list.conf"
+    disabled_plugins=$disabled_plugins'\|'$plugin
 done
+grep -v $disabled_plugins "$INSTALL_DIR/bin/plugin_list.conf.default" >> "$INSTALL_DIR/bin/plugin_list.conf"
 
 # Link all plugin libs in install/bin to make them easily findable
 cd "$INSTALL_DIR" && find "plugins" -name "*.dll" | while read lib; do


### PR DESCRIPTION
All pluginized modules were ignored in binaries due to postinstall-fixup scripts.

:warning:  **Do not hesitate to suggest other plugins/modules that should be DISABLED by default.**

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
