### PR TITLE
[SofaCore] Add PCH support in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,16 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # Option for packaging
 option(SOFA_BUILD_RELEASE_PACKAGE "Run package specific configure" OFF)
 
+# Option to accelerate the building
+# https://cmake.org/cmake/help/v3.19/command/target_precompile_headers.html
+option(SOFA_BUILD_WITH_PCH_ENABLED "Compile Sofa using precompiled header (to accelerate the build process)" OFF)
+if(SOFA_BUILD_WITH_PCH_ENABLED)
+    message("-- Precompiled headers: Yes (SOFA_BUILD_WITH_PCH_ENABLED variable is ON).")
+else()
+    message("-- Precompiled headers: No (SOFA_BUILD_WITH_PCH_ENABLED variable is OFF).")
+    set(DISABLE_PRECOMPILE_HEADERS ON)   # https://cmake.org/cmake/help/v3.19/prop_tgt/DISABLE_PRECOMPILE_HEADERS.html
+endif()
+
 ## Change default install prefix
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/install CACHE PATH "Install path prefix, prepended onto install directories." FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,12 @@ option(SOFA_BUILD_RELEASE_PACKAGE "Run package specific configure" OFF)
 # https://cmake.org/cmake/help/v3.19/command/target_precompile_headers.html
 option(SOFA_BUILD_WITH_PCH_ENABLED "Compile Sofa using precompiled header (to accelerate the build process)" OFF)
 if(SOFA_BUILD_WITH_PCH_ENABLED)
-    message("-- Precompiled headers: Yes (SOFA_BUILD_WITH_PCH_ENABLED variable is ON).")
+    if(${CMAKE_VERSION} VERSION_GREATER "3.16.0")
+        message("-- Precompiled headers: Yes (SOFA_BUILD_WITH_PCH_ENABLED variable is ON).")
+    else()
+        message("-- Precompiled headers: No (SOFA_BUILD_WITH_PCH_ENABLED variable is ON but cmake version is <3.16).")
+        set(DISABLE_PRECOMPILE_HEADERS ON)   # https://cmake.org/cmake/help/v3.19/prop_tgt/DISABLE_PRECOMPILE_HEADERS.html
+    endif()
 else()
     message("-- Precompiled headers: No (SOFA_BUILD_WITH_PCH_ENABLED variable is OFF).")
     set(DISABLE_PRECOMPILE_HEADERS ON)   # https://cmake.org/cmake/help/v3.19/prop_tgt/DISABLE_PRECOMPILE_HEADERS.html

--- a/SofaKernel/SofaFramework/src/sofa/config.h.in
+++ b/SofaKernel/SofaFramework/src/sofa/config.h.in
@@ -73,6 +73,7 @@ typedef double SReal;
 #endif
 
 #ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
 #  include <windows.h>
 #endif
 

--- a/SofaKernel/SofaFramework/src/sofa/config.h.in
+++ b/SofaKernel/SofaFramework/src/sofa/config.h.in
@@ -75,6 +75,7 @@ typedef double SReal;
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #  include <windows.h>
+#undef WIN32_LEAN_AND_MEAN
 #endif
 
 #ifdef BOOST_NO_EXCEPTIONS

--- a/SofaKernel/modules/SofaCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/CMakeLists.txt
@@ -252,7 +252,7 @@ set(SOURCE_FILES
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaHelper SofaDefaultType)
 
-if((NOT DISABLE_PRECOMPILE_HEADERS) AND (${CMAKE_VERSION} VERSION_GREATER "3.16.0"))
+if(SOFA_BUILD_WITH_PCH_ENABLED)
     message("Adding precompiled header for SofaCore")
     target_precompile_headers(${PROJECT_NAME} PUBLIC ${SRC_ROOT}/objectmodel/BaseObject.h ${SRC_ROOT}/objectmodel/Data.h)
 endif()

--- a/SofaKernel/modules/SofaCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/CMakeLists.txt
@@ -252,8 +252,8 @@ set(SOURCE_FILES
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaHelper SofaDefaultType)
 
-if(${CMAKE_VERSION} VERSION_GREATER "3.16.0")
-    message("SofaCore: with precompiled header")
+if((NOT DISABLE_PRECOMPILE_HEADERS) AND (${CMAKE_VERSION} VERSION_GREATER "3.16.0"))
+    message("Adding precompiled header for SofaCore")
     target_precompile_headers(${PROJECT_NAME} PUBLIC ${SRC_ROOT}/objectmodel/BaseObject.h ${SRC_ROOT}/objectmodel/Data.h)
 endif()
 

--- a/SofaKernel/modules/SofaCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/CMakeLists.txt
@@ -251,6 +251,7 @@ set(SOURCE_FILES
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaHelper SofaDefaultType)
+target_precompile_headers(${PROJECT_NAME} PUBLIC ${SRC_ROOT}/objectmodel/BaseObject.h ${SRC_ROOT}/objectmodel/Data.h)
 
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Silence attribute warnings (for example, ignored already defined external template)

--- a/SofaKernel/modules/SofaCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/CMakeLists.txt
@@ -251,7 +251,11 @@ set(SOURCE_FILES
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaHelper SofaDefaultType)
-target_precompile_headers(${PROJECT_NAME} PUBLIC ${SRC_ROOT}/objectmodel/BaseObject.h ${SRC_ROOT}/objectmodel/Data.h)
+
+if(${CMAKE_VERSION} VERSION_GREATER "3.16.0")
+    message("SofaCore: with precompiled header")
+    target_precompile_headers(${PROJECT_NAME} PUBLIC ${SRC_ROOT}/objectmodel/BaseObject.h ${SRC_ROOT}/objectmodel/Data.h)
+endif()
 
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Silence attribute warnings (for example, ignored already defined external template)

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PipeProcess.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PipeProcess.cpp
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <WinNt.h>
 #include <cstdio>
 typedef int ssize_t;
 typedef HANDLE fd_t;

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PipeProcess.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PipeProcess.cpp
@@ -28,6 +28,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <WinNt.h>
+#include <winsock.h>
 #include <cstdio>
 typedef int ssize_t;
 typedef HANDLE fd_t;

--- a/modules/SofaGuiQt/src/sofa/gui/qt/GenGraphForm.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/GenGraphForm.cpp
@@ -23,6 +23,7 @@
 
 #ifdef WIN32
 #include <windows.h>
+#include <shellapi.h>
 #endif
 
 #include <fstream>


### PR DESCRIPTION
Using clang -ftimetrace show that BaseObject/Data/Base are taking a lot of compilation time
because of excessive inclusion and parsing time.
PCH can help to solve this issue and there is support for that in CMake.
Let's se result.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
