### PR TITLE
[all] Remove un-needed includes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,16 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # Option for packaging
 option(SOFA_BUILD_RELEASE_PACKAGE "Run package specific configure" OFF)
 
+# Option to accelerate the building
+# https://cmake.org/cmake/help/v3.19/command/target_precompile_headers.html
+option(SOFA_BUILD_WITH_PCH_ENABLED "Compile Sofa using precompiled header (to accelerate the build process)" OFF)
+if(SOFA_BUILD_WITH_PCH_ENABLED)
+    message("-- Precompiled headers: Yes (SOFA_BUILD_WITH_PCH_ENABLED variable is ON).")
+else()
+    message("-- Precompiled headers: No (SOFA_BUILD_WITH_PCH_ENABLED variable is OFF).")
+    set(DISABLE_PRECOMPILE_HEADERS ON)   # https://cmake.org/cmake/help/v3.19/prop_tgt/DISABLE_PRECOMPILE_HEADERS.html
+endif()
+
 ## Change default install prefix
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/install CACHE PATH "Install path prefix, prepended onto install directories." FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,12 @@ option(SOFA_BUILD_RELEASE_PACKAGE "Run package specific configure" OFF)
 # https://cmake.org/cmake/help/v3.19/command/target_precompile_headers.html
 option(SOFA_BUILD_WITH_PCH_ENABLED "Compile Sofa using precompiled header (to accelerate the build process)" OFF)
 if(SOFA_BUILD_WITH_PCH_ENABLED)
-    message("-- Precompiled headers: Yes (SOFA_BUILD_WITH_PCH_ENABLED variable is ON).")
+    if(${CMAKE_VERSION} VERSION_GREATER "3.16.0")
+        message("-- Precompiled headers: Yes (SOFA_BUILD_WITH_PCH_ENABLED variable is ON).")
+    else()
+        message("-- Precompiled headers: No (SOFA_BUILD_WITH_PCH_ENABLED variable is ON but cmake version is <3.16).")
+        set(DISABLE_PRECOMPILE_HEADERS ON)   # https://cmake.org/cmake/help/v3.19/prop_tgt/DISABLE_PRECOMPILE_HEADERS.html
+    endif()
 else()
     message("-- Precompiled headers: No (SOFA_BUILD_WITH_PCH_ENABLED variable is OFF).")
     set(DISABLE_PRECOMPILE_HEADERS ON)   # https://cmake.org/cmake/help/v3.19/prop_tgt/DISABLE_PRECOMPILE_HEADERS.html

--- a/SofaKernel/SofaFramework/src/sofa/config.h.in
+++ b/SofaKernel/SofaFramework/src/sofa/config.h.in
@@ -73,6 +73,7 @@ typedef double SReal;
 #endif
 
 #ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
 #  include <windows.h>
 #endif
 

--- a/SofaKernel/SofaFramework/src/sofa/config.h.in
+++ b/SofaKernel/SofaFramework/src/sofa/config.h.in
@@ -75,6 +75,7 @@ typedef double SReal;
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #  include <windows.h>
+#undef WIN32_LEAN_AND_MEAN
 #endif
 
 #ifdef BOOST_NO_EXCEPTIONS

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/CapsuleModel.inl
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/CapsuleModel.inl
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #include <SofaBaseCollision/CapsuleModel.h>
 
+#include <sofa/helper/visual/DrawTool.h>
 #include <sofa/defaulttype/Vec.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <SofaBaseCollision/CubeModel.h>

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/CubeModel.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/CubeModel.cpp
@@ -22,6 +22,7 @@
 #include <SofaBaseCollision/CubeModel.h>
 
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/helper/visual/DrawTool.h>
 #include <sofa/core/ObjectFactory.h>
 #include <algorithm>
 

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DefaultContactManager.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DefaultContactManager.cpp
@@ -24,7 +24,7 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/objectmodel/Tag.h>
-
+#include <sofa/simulation/Node.h>
 
 namespace sofa::component::collision
 {
@@ -48,9 +48,12 @@ DefaultContactManager::~DefaultContactManager()
     //clear();
 }
 
-sofa::helper::OptionsGroup DefaultContactManager::initializeResponseOptions(core::collision::Pipeline *pipeline)
+sofa::helper::OptionsGroup DefaultContactManager::initializeResponseOptions(sofa::core::objectmodel::BaseContext *context)
 {
     std::set<std::string> listResponse;
+
+    sofa::simulation::Node* node = sofa::simulation::getNodeFromContext(context);
+    sofa::core::collision::Pipeline* pipeline = node->collisionPipeline;
     if (pipeline) listResponse=pipeline->getResponseList();
     else
     {
@@ -70,8 +73,7 @@ void DefaultContactManager::init()
 {
     if (response.getValue().size() == 0)
     {
-        core::collision::Pipeline *pipeline=static_cast<simulation::Node*>(getContext())->collisionPipeline;
-        response.setValue(initializeResponseOptions(pipeline));
+        response.setValue(initializeResponseOptions(getContext()));
     }
 }
 

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DefaultContactManager.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DefaultContactManager.h
@@ -23,7 +23,7 @@
 #include <SofaBaseCollision/config.h>
 
 #include <sofa/core/collision/ContactManager.h>
-#include <sofa/simulation/Node.h>
+#include <sofa/simulation/fwd.h>
 #include <sofa/helper/OptionsGroup.h>
 #include <sofa/helper/map_ptr_stable_compare.h>
 
@@ -49,12 +49,10 @@ public :
     static typename T::SPtr create(T*, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg)
     {
         typename T::SPtr obj = sofa::core::objectmodel::New<T>();
-
         if (context)
         {
             context->addObject(obj);
-            core::collision::Pipeline *pipeline = static_cast<simulation::Node*>(context)->collisionPipeline;
-            sofa::helper::OptionsGroup options = initializeResponseOptions(pipeline);
+            sofa::helper::OptionsGroup options = initializeResponseOptions(context);
             obj->response.setValue(options);
         }
 
@@ -95,7 +93,7 @@ protected:
 
     void changeInstance(Instance inst) override ;
 
-    static sofa::helper::OptionsGroup initializeResponseOptions(core::collision::Pipeline *pipeline);
+    static sofa::helper::OptionsGroup initializeResponseOptions(sofa::core::objectmodel::BaseContext *pipeline);
 
     // count failure messages, so we don't continuously repeat them
     std::map<std::pair<std::string,std::pair<std::string,std::string> >, int> errorMsgCount;

--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/BlocMatrixWriter.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/BlocMatrixWriter.h
@@ -23,6 +23,8 @@
 #include <SofaBaseLinearSolver/config.h>
 
 #include <SofaBaseLinearSolver/CompressedRowSparseMatrix.h>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
+
 
 namespace sofa::component::linearsolver
 {

--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/MatrixLinearSolver.inl
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/MatrixLinearSolver.inl
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 #include <SofaBaseLinearSolver/MatrixLinearSolver.h>
+#include <sofa/simulation/Node.h>
 
 
 namespace sofa::component::linearsolver {

--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/MatrixLinearSolver.inl
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/MatrixLinearSolver.inl
@@ -21,8 +21,6 @@
 ******************************************************************************/
 #pragma once
 #include <SofaBaseLinearSolver/MatrixLinearSolver.h>
-#include <sofa/simulation/Node.h>
-
 
 namespace sofa::component::linearsolver {
 
@@ -108,9 +106,8 @@ void MatrixLinearSolver<Matrix,Vector>::setSystemMBKMatrix(const core::Mechanica
 
     if (!this->frozen)
     {
-        simulation::Node* root = dynamic_cast<simulation::Node*>(this->getContext());
         SReal dim = 0;
-        simulation::MechanicalGetDimensionVisitor(mparams, &dim).execute(root);
+        simulation::MechanicalGetDimensionVisitor(mparams, &dim).execute(this->getContext());
         currentGroup->systemSize = Size(dim);
         currentGroup->matrixAccessor.setDoPrintInfo( this->f_printLog.getValue() ) ;
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/AddMToMatrixFunctor.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/AddMToMatrixFunctor.h
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #pragma once
 #include <SofaBaseMechanics/config.h>
-
+#include <sofa/defaulttype/BaseMatrix.h>
 #include <sofa/defaulttype/RigidTypes.h>
 
 namespace sofa::component::mass

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.inl
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #pragma once
 #include <SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h>
-
+#include <sofa/core/State.h>
 #include <sofa/core/visual/VisualParams.h>
 
 namespace sofa::component::mapping::_barycentricmappertopologycontainer_

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
@@ -27,6 +27,7 @@
 #include <sofa/defaulttype/DataTypeInfo.h>
 #include <SofaBaseTopology/TopologyData.inl>
 #include <SofaBaseMechanics/AddMToMatrixFunctor.h>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 
 namespace sofa::component::mass
 {

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/UniformMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/UniformMass.inl
@@ -28,6 +28,7 @@
 #include <sofa/helper/accessor.h>
 #include <sofa/defaulttype/DataTypeInfo.h>
 #include <SofaBaseMechanics/AddMToMatrixFunctor.h>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 
 
 namespace sofa::component::mass

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/UniformMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/UniformMass.inl
@@ -29,7 +29,7 @@
 #include <sofa/defaulttype/DataTypeInfo.h>
 #include <SofaBaseMechanics/AddMToMatrixFunctor.h>
 #include <sofa/core/behavior/MultiMatrixAccessor.h>
-
+#include <sofa/core/topology/TopologyChange.h>
 
 namespace sofa::component::mass
 {

--- a/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/fake_TopologyScene.h
+++ b/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/fake_TopologyScene.h
@@ -24,6 +24,7 @@
 
 #include <sofa/core/topology/Topology.h>
 #include <SofaSimulationGraph/SimpleApi.h>
+#include <sofa/simulation/Node.h>
 
 class fake_TopologyScene
 {

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/MeshTopology.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/MeshTopology.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #include <SofaBaseTopology/MeshTopology.h>
 
+#include <sofa/helper/visual/DrawTool.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/ObjectFactory.h>
 #include <algorithm>

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.h
@@ -68,7 +68,11 @@ public:
           m_topologyHandler(nullptr)
     {}
 
-    virtual ~TopologyDataImpl();
+    virtual ~TopologyDataImpl(){
+        if (this->m_topologyHandler)
+            delete m_topologyHandler;
+
+    }
 
 
     /** Public functions to handle topological engine creation */

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
@@ -31,12 +31,6 @@ namespace sofa::component::topology
 /////////////////////////////   Generic Topology Data Implementation   /////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-template <typename TopologyElementType, typename VecT>
-TopologyDataImpl <TopologyElementType, VecT>::~TopologyDataImpl()
-{
-    if (this->m_topologyHandler)
-        delete m_topologyHandler;
-}
 
 
 template <typename TopologyElementType, typename VecT>

--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/BaseCamera.h
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/BaseCamera.h
@@ -29,7 +29,7 @@
 #include <sofa/defaulttype/Mat.h>
 #include <sofa/helper/Quater.h>
 
-#include <sofa/core/visual/VisualParams.h>
+#include <sofa/core/fwd.h>
 #include <sofa/helper/OptionsGroup.h>
 
 
@@ -41,7 +41,6 @@ class SOFA_SOFABASEVISUAL_API BaseCamera : public core::objectmodel::BaseObject
 public:
     SOFA_CLASS(BaseCamera, core::objectmodel::BaseObject);
 
-    typedef sofa::core::visual::VisualParams::CameraType CameraType;
     typedef defaulttype::Ray Ray;
     typedef defaulttype::Vector4 Vec4;
     typedef defaulttype::Vector3 Vec3;

--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.h
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.h
@@ -30,8 +30,7 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/helper/io/Mesh.h>
-#include <SofaBaseTopology/TopologyData.inl>
-
+#include <SofaBaseTopology/TopologyData.h>
 #include <string>
 
 namespace sofa::component::visualmodel

--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.h
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.h
@@ -30,7 +30,7 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/helper/io/Mesh.h>
-#include <SofaBaseTopology/TopologyData.h>
+#include <SofaBaseTopology/TopologyData.inl>
 #include <string>
 
 namespace sofa::component::visualmodel

--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualStyle.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualStyle.cpp
@@ -24,7 +24,7 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/objectmodel/Context.h>
 #include <sofa/core/ObjectFactory.h>
-
+#include <sofa/simulation/Node.h>
 namespace sofa::component::visualmodel
 {
 

--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualStyle.h
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualStyle.h
@@ -24,7 +24,7 @@
 
 #include <sofa/core/visual/VisualModel.h>
 #include <sofa/core/visual/DisplayFlags.h>
-#include <sofa/simulation/Node.h>
+#include <sofa/simulation/fwd.h>
 
 namespace sofa::component::visualmodel
 {
@@ -73,7 +73,7 @@ protected:
     DisplayFlags backupFlags;
 };
 
-SOFA_SOFABASEVISUAL_API helper::WriteAccessor<sofa::core::visual::DisplayFlags> addVisualStyle( simulation::Node::SPtr node );
+SOFA_SOFABASEVISUAL_API helper::WriteAccessor<sofa::core::visual::DisplayFlags> addVisualStyle( simulation::NodeSPtr node );
 
 
 } // namespace sofa::component::visualmodel

--- a/SofaKernel/modules/SofaCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/CMakeLists.txt
@@ -72,6 +72,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/behavior/ProjectiveConstraintSet.h
     ${SRC_ROOT}/behavior/ProjectiveConstraintSet.inl
     ${SRC_ROOT}/behavior/RotationMatrix.h
+    ${SRC_ROOT}/behavior/fwd.h
     ${SRC_ROOT}/collision/BroadPhaseDetection.h
     ${SRC_ROOT}/collision/CollisionAlgorithm.h
     ${SRC_ROOT}/collision/CollisionGroupManager.h
@@ -192,6 +193,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/behavior/PairInteractionForceField.cpp
     ${SRC_ROOT}/behavior/PairInteractionProjectiveConstraintSet.cpp
     ${SRC_ROOT}/behavior/ProjectiveConstraintSet.cpp
+    ${SRC_ROOT}/behavior/fwd.cpp
     ${SRC_ROOT}/collision/Contact.cpp
     ${SRC_ROOT}/collision/Intersection.cpp
     ${SRC_ROOT}/collision/Pipeline.cpp
@@ -251,6 +253,7 @@ set(SOURCE_FILES
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaHelper SofaDefaultType)
+target_precompile_headers(${PROJECT_NAME} PUBLIC ${SRC_ROOT}/objectmodel/BaseObject.h ${SRC_ROOT}/objectmodel/BaseContext.h)
 
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Silence attribute warnings (for example, ignored already defined external template)

--- a/SofaKernel/modules/SofaCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/CMakeLists.txt
@@ -198,7 +198,8 @@ set(SOURCE_FILES
     ${SRC_ROOT}/collision/Contact.cpp
     ${SRC_ROOT}/collision/Intersection.cpp
     ${SRC_ROOT}/collision/Pipeline.cpp
-    ${SRC_ROOT}/init.cpp
+    ${SRC_ROOT}/init.cpp    
+    ${SRC_ROOT}/fwd.cpp
     ${SRC_ROOT}/loader/BaseLoader.cpp
     ${SRC_ROOT}/loader/MeshLoader.cpp
     ${SRC_ROOT}/loader/SceneLoader.cpp
@@ -238,6 +239,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/topology/BaseMeshTopology.cpp
     ${SRC_ROOT}/topology/BaseTopology.cpp
     ${SRC_ROOT}/topology/BaseTopologyObject.cpp
+    ${SRC_ROOT}/topology/BaseTopologyEngine.cpp
     ${SRC_ROOT}/topology/Topology.cpp
     ${SRC_ROOT}/topology/TopologyChange.cpp
     ${SRC_ROOT}/topology/TopologyElementHandler.cpp

--- a/SofaKernel/modules/SofaCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/CMakeLists.txt
@@ -253,7 +253,7 @@ set(SOURCE_FILES
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaHelper SofaDefaultType)
-target_precompile_headers(${PROJECT_NAME} PUBLIC ${SRC_ROOT}/objectmodel/BaseObject.h ${SRC_ROOT}/objectmodel/BaseContext.h)
+#target_precompile_headers(${PROJECT_NAME} PUBLIC ${SRC_ROOT}/objectmodel/BaseObject.h ${SRC_ROOT}/objectmodel/BaseContext.h)
 
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Silence attribute warnings (for example, ignored already defined external template)

--- a/SofaKernel/modules/SofaCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/CMakeLists.txt
@@ -252,7 +252,7 @@ set(SOURCE_FILES
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaHelper SofaDefaultType)
 
-if((NOT DISABLE_PRECOMPILE_HEADERS) AND (${CMAKE_VERSION} VERSION_GREATER "3.16.0"))
+if(SOFA_BUILD_WITH_PCH_ENABLED)
     message("Adding precompiled header for SofaCore")
     target_precompile_headers(${PROJECT_NAME} PUBLIC ${SRC_ROOT}/objectmodel/BaseObject.h ${SRC_ROOT}/objectmodel/Data.h)
 endif()

--- a/SofaKernel/modules/SofaCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/CMakeLists.txt
@@ -252,8 +252,8 @@ set(SOURCE_FILES
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaHelper SofaDefaultType)
 
-if(${CMAKE_VERSION} VERSION_GREATER "3.16.0")
-    message("SofaCore: with precompiled header")
+if((NOT DISABLE_PRECOMPILE_HEADERS) AND (${CMAKE_VERSION} VERSION_GREATER "3.16.0"))
+    message("Adding precompiled header for SofaCore")
     target_precompile_headers(${PROJECT_NAME} PUBLIC ${SRC_ROOT}/objectmodel/BaseObject.h ${SRC_ROOT}/objectmodel/Data.h)
 endif()
 

--- a/SofaKernel/modules/SofaCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/CMakeLists.txt
@@ -251,6 +251,7 @@ set(SOURCE_FILES
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaHelper SofaDefaultType)
+target_precompile_headers(${PROJECT_NAME} PUBLIC ${SRC_ROOT}/objectmodel/BaseObject.h ${SRC_ROOT}/objectmodel/Data.h)
 
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Silence attribute warnings (for example, ignored already defined external template)

--- a/SofaKernel/modules/SofaCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/CMakeLists.txt
@@ -251,7 +251,11 @@ set(SOURCE_FILES
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaHelper SofaDefaultType)
-target_precompile_headers(${PROJECT_NAME} PUBLIC ${SRC_ROOT}/objectmodel/BaseObject.h ${SRC_ROOT}/objectmodel/Data.h)
+
+if(${CMAKE_VERSION} VERSION_GREATER "3.16.0")
+    message("SofaCore: with precompiled header")
+    target_precompile_headers(${PROJECT_NAME} PUBLIC ${SRC_ROOT}/objectmodel/BaseObject.h ${SRC_ROOT}/objectmodel/Data.h)
+endif()
 
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Silence attribute warnings (for example, ignored already defined external template)

--- a/SofaKernel/modules/SofaCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/CMakeLists.txt
@@ -88,6 +88,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/config.h.in
     ${SRC_ROOT}/core.h
     ${SRC_ROOT}/init.h
+    ${SRC_ROOT}/fwd.h
     ${SRC_ROOT}/loader/BaseLoader.h
     ${SRC_ROOT}/loader/ImageLoader.h
     ${SRC_ROOT}/loader/Material.h

--- a/SofaKernel/modules/SofaCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/CMakeLists.txt
@@ -253,7 +253,7 @@ set(SOURCE_FILES
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaHelper SofaDefaultType)
-#target_precompile_headers(${PROJECT_NAME} PUBLIC ${SRC_ROOT}/objectmodel/BaseObject.h ${SRC_ROOT}/objectmodel/BaseContext.h)
+target_precompile_headers(${PROJECT_NAME} PUBLIC ${SRC_ROOT}/objectmodel/BaseObject.h ${SRC_ROOT}/objectmodel/BaseContext.h)
 
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Silence attribute warnings (for example, ignored already defined external template)

--- a/SofaKernel/modules/SofaCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/CMakeLists.txt
@@ -256,7 +256,7 @@ set(SOURCE_FILES
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaHelper SofaDefaultType)
-target_precompile_headers(${PROJECT_NAME} PUBLIC ${SRC_ROOT}/objectmodel/BaseObject.h ${SRC_ROOT}/objectmodel/BaseContext.h)
+#target_precompile_headers(${PROJECT_NAME} PUBLIC ${SRC_ROOT}/objectmodel/BaseObject.h ${SRC_ROOT}/objectmodel/BaseContext.h)
 
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Silence attribute warnings (for example, ignored already defined external template)

--- a/SofaKernel/modules/SofaCore/src/sofa/core/BaseMapping.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/BaseMapping.h
@@ -22,7 +22,6 @@
 #ifndef SOFA_CORE_BASEMAPPING_H
 #define SOFA_CORE_BASEMAPPING_H
 
-
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/ConstraintParams.h>
 #include <sofa/core/MechanicalParams.h>

--- a/SofaKernel/modules/SofaCore/src/sofa/core/ConstraintParams.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/ConstraintParams.h
@@ -25,7 +25,6 @@
 #include <sofa/core/ExecParams.h>
 #include <sofa/core/MultiVecId.h>
 
-
 namespace sofa
 {
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/ConstraintParams.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/ConstraintParams.h
@@ -24,6 +24,8 @@
 
 #include <sofa/core/ExecParams.h>
 #include <sofa/core/MultiVecId.h>
+#include <sofa/core/objectmodel/Data.h>
+#include <sofa/core/objectmodel/Link.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/MechanicalParams.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/MechanicalParams.h
@@ -24,7 +24,7 @@
 
 #include <sofa/core/ExecParams.h>
 #include <sofa/core/MultiVecId.h>
-
+#include <sofa/core/objectmodel/Data.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/MechanicalParams.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/MechanicalParams.h
@@ -25,6 +25,7 @@
 #include <sofa/core/ExecParams.h>
 #include <sofa/core/MultiVecId.h>
 #include <sofa/core/objectmodel/Data.h>
+#include <sofa/core/objectmodel/Link.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/MultiVecId.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/MultiVecId.h
@@ -23,7 +23,7 @@
 #define SOFA_CORE_MULTIVECID_H
 
 #include <sofa/core/VecId.h>
-
+#include <sofa/core/objectmodel/Data.h>
 namespace sofa
 {
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/VecId.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/VecId.h
@@ -24,6 +24,7 @@
 
 #include <string>
 #include <sstream>
+#include <cassert>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/VecId.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/VecId.h
@@ -23,6 +23,7 @@
 #define SOFA_CORE_VECID_H
 
 #include <string>
+#include <sstream>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/VecId.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/VecId.h
@@ -22,6 +22,8 @@
 #ifndef SOFA_CORE_VECID_H
 #define SOFA_CORE_VECID_H
 
+#include <string>
+
 namespace sofa
 {
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/VecId.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/VecId.h
@@ -149,10 +149,9 @@ public:
 
     static MyVecId constraintJacobian()    { return MyVecId(1);} // jacobian matrix of constraints
     static MyVecId mappingJacobian() { return MyVecId(2);}         // accumulated matrix of the mappings
-    static MyVecId holonomicC()    { return MyVecId(1);
-                                     dmsg_deprecated("") << "holonomicC is deprecated."
-                                                           "See VecId.h to remove this message and replace by constraintJacobian"
-                                                           "Update your code ! It will be removed after May 2018"; }
+
+    [[deprecated("HolonomicC has be deprecated.")]]
+    static MyVecId holonomicC()    { return MyVecId(1); }
     enum { V_FIRST_DYNAMIC_INDEX = 3 }; ///< This is the first index used for dynamically allocated vectors
 
     static std::string getName(const MyVecId& v)

--- a/SofaKernel/modules/SofaCore/src/sofa/core/VecId.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/VecId.h
@@ -22,9 +22,6 @@
 #ifndef SOFA_CORE_VECID_H
 #define SOFA_CORE_VECID_H
 
-#include <sofa/core/objectmodel/BaseObject.h>
-
-
 namespace sofa
 {
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseConstraintSet.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseConstraintSet.h
@@ -25,7 +25,7 @@
 #include <sofa/core/ConstraintParams.h>
 #include <sofa/core/config.h>
 #include <sofa/defaulttype/BaseVector.h>
-
+#include <sofa/core/objectmodel/BaseObject.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseForceField.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseForceField.h
@@ -24,8 +24,10 @@
 
 #include <sofa/core/config.h>
 #include <sofa/core/objectmodel/BaseObject.h>
-#include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/core/MechanicalParams.h>
+
+namespace sofa::defaulttype { class BaseMatrix; }
+namespace sofa::core::behavior { class MultiMatrixAccessor; }
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseForceField.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseForceField.h
@@ -25,6 +25,7 @@
 #include <sofa/core/config.h>
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/core/behavior/MultiMatrixAccessor.h>
+#include <sofa/core/MechanicalParams.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseInteractionProjectiveConstraintSet.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseInteractionProjectiveConstraintSet.h
@@ -23,6 +23,7 @@
 #define SOFA_CORE_BEHAVIOR_BASEINTERACTIONPROJECTIVECONSTRAINTSET_H
 
 #include <sofa/core/behavior/BaseProjectiveConstraintSet.h>
+#include <sofa/core/behavior/BaseMechanicalState.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseMass.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseMass.h
@@ -25,8 +25,10 @@
 #include <sofa/core/config.h>
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/core/MechanicalParams.h>
-#include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/defaulttype/TopologyTypes.h>
+
+namespace sofa::defaulttype { class BaseMatrix; }
+namespace sofa::core::behavior { class MultiMatrixAccessor; }
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseMass.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseMass.h
@@ -24,6 +24,7 @@
 
 #include <sofa/core/config.h>
 #include <sofa/core/objectmodel/BaseObject.h>
+#include <sofa/core/MechanicalParams.h>
 #include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/defaulttype/TopologyTypes.h>
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseMechanicalState.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseMechanicalState.h
@@ -25,12 +25,10 @@
 
 #include <sofa/core/BaseState.h>
 #include <sofa/core/MultiVecId.h>
-#include <sofa/defaulttype/BaseMatrix.h>
 #include <sofa/defaulttype/Vec.h>
 #include <sofa/defaulttype/Quat.h>
 #include <sofa/helper/StateMask.h>
-
-
+#include <sofa/defaulttype/fwd.h> /// For BaseMatrix
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseProjectiveConstraintSet.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseProjectiveConstraintSet.h
@@ -23,7 +23,12 @@
 #define SOFA_CORE_BEHAVIOR_BASEPROJECTIVECONSTRAINTSET_H
 
 #include <sofa/core/objectmodel/BaseObject.h>
-#include <sofa/core/behavior/MultiMatrixAccessor.h>
+#include <sofa/core/MultiVecId.h>
+
+namespace sofa::defaulttype { class BaseMatrix; }
+namespace sofa::core { class MechanicalParams; }
+namespace sofa::core::behavior { class MultiMatrixAccessor; }
+
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ForceField.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ForceField.h
@@ -24,6 +24,7 @@
 
 #include <sofa/core/config.h>
 #include <sofa/core/behavior/BaseForceField.h>
+#include <sofa/core/behavior/MechanicalState.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ForceField.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ForceField.h
@@ -25,7 +25,7 @@
 #include <sofa/core/config.h>
 #include <sofa/core/behavior/BaseForceField.h>
 #include <sofa/core/behavior/MechanicalState.h>
-
+#include <sofa/defaulttype/fwd.h>
 namespace sofa
 {
 
@@ -163,39 +163,6 @@ public:
 
     /// addBToMatrix only on the subMatrixIndex
     virtual void addSubBToMatrix(sofa::defaulttype::BaseMatrix * matrix, const helper::vector<unsigned> & subMatrixIndex, SReal bFact, unsigned int &offset);
-
-
-    /** Accumulate an element matrix to a global assembly matrix. This is a helper for addKToMatrix, to accumulate each (square) element matrix in the (square) assembled matrix.
-      \param bm the global assembly matrix
-      \param offset start index of the local DOFs within the global matrix
-      \param nodeIndex indices of the nodes of the element within the local nodes, as stored in the topology
-      \param em element matrix, typically a stiffness, damping, mass, or weighted sum thereof
-      \param scale weight applied to the matrix, typically ±params->kfactor() for a stiffness matrix
-      */
-    template<class IndexArray, class ElementMat>
-    void addToMatrix(sofa::defaulttype::BaseMatrix* bm, unsigned offset, const IndexArray& nodeIndex, const ElementMat& em, SReal scale )
-    {
-        const unsigned  S = DataTypes::deriv_total_size; // size of node blocks
-        for (unsigned n1=0; n1<nodeIndex.size(); n1++)
-        {
-            for(unsigned i=0; i<S; i++)
-            {
-                unsigned ROW = offset + S*nodeIndex[n1] + i;  // i-th row associated with node n1 in BaseMatrix
-                unsigned row = S*n1+i;                        // i-th row associated with node n1 in the element matrix
-
-                for (unsigned n2=0; n2<nodeIndex.size(); n2++)
-                {
-                    for (unsigned j=0; j<S; j++)
-                    {
-                        unsigned COLUMN = offset + S*nodeIndex[n2] +j; // j-th column associated with node n2 in BaseMatrix
-                        unsigned column = 3*n2+j;                      // j-th column associated with node n2 in the element matrix
-                        bm->add( ROW,COLUMN, em[row][column]* scale );
-                    }
-                }
-            }
-        }
-    }
-
 
     /// Pre-construction check method called by ObjectFactory.
     /// Check that DataTypes matches the MechanicalState.

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ForceField.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ForceField.h
@@ -26,6 +26,7 @@
 #include <sofa/core/behavior/BaseForceField.h>
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/defaulttype/fwd.h>
+#include <sofa/defaulttype/BaseMatrix.h>
 namespace sofa
 {
 
@@ -152,12 +153,41 @@ public:
     /// addToMatrix only on the subMatrixIndex
     virtual void addSubKToMatrix(sofa::defaulttype::BaseMatrix * matrix, const helper::vector<unsigned> & subMatrixIndex, SReal kFact, unsigned int &offset);
 
-
-
     void addBToMatrix(const MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
 
     /// addBToMatrix only on the subMatrixIndex
     void addSubBToMatrix(const MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix, const helper::vector<unsigned> & subMatrixIndex ) override;
+
+    /** Accumulate an element matrix to a global assembly matrix. This is a helper for addKToMatrix, to accumulate each (square) element matrix in the (square) assembled matrix.
+    \param bm the global assembly matrix
+    \param offset start index of the local DOFs within the global matrix
+    \param nodeIndex indices of the nodes of the element within the local nodes, as stored in the topology
+    \param em element matrix, typically a stiffness, damping, mass, or weighted sum thereof
+    \param scale weight applied to the matrix, typically ±params->kfactor() for a stiffness matrix
+    */
+    template<class IndexArray, class ElementMat>
+    void addToMatrix(sofa::defaulttype::BaseMatrix* bm, unsigned offset, const IndexArray& nodeIndex, const ElementMat& em, SReal scale )
+    {
+        const unsigned  S = DataTypes::deriv_total_size; // size of node blocks
+        for (unsigned n1=0; n1<nodeIndex.size(); n1++)
+        {
+            for(unsigned i=0; i<S; i++)
+            {
+                unsigned ROW = offset + S*nodeIndex[n1] + i;  // i-th row associated with node n1 in BaseMatrix
+                unsigned row = S*n1+i;                        // i-th row associated with node n1 in the element matrix
+
+                for (unsigned n2=0; n2<nodeIndex.size(); n2++)
+                {
+                    for (unsigned j=0; j<S; j++)
+                    {
+                        unsigned COLUMN = offset + S*nodeIndex[n2] +j; // j-th column associated with node n2 in BaseMatrix
+                        unsigned column = 3*n2+j;                      // j-th column associated with node n2 in the element matrix
+                        bm->add( ROW,COLUMN, em[row][column]* scale );
+                    }
+                }
+            }
+        }
+    }
 
     virtual void addBToMatrix(sofa::defaulttype::BaseMatrix * matrix, SReal bFact, unsigned int &offset);
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ForceField.inl
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ForceField.inl
@@ -23,6 +23,7 @@
 #define SOFA_CORE_BEHAVIOR_FORCEFIELD_INL
 
 #include <sofa/core/behavior/ForceField.h>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <iostream>
 
 namespace sofa

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/Mass.inl
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/Mass.inl
@@ -24,9 +24,9 @@
 
 #include <sofa/core/behavior/Mass.h>
 #include <sofa/core/behavior/BaseConstraint.h>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/defaulttype/DataTypeInfo.h>
 #include <fstream>
-
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/MixedInteractionForceField.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/MixedInteractionForceField.h
@@ -24,6 +24,8 @@
 
 #include <sofa/core/config.h>
 #include <sofa/core/behavior/BaseInteractionForceField.h>
+#include <sofa/core/behavior/MechanicalState.h>
+
 namespace sofa
 {
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/MultiMatrixAccessor.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/MultiMatrixAccessor.h
@@ -22,8 +22,9 @@
 #ifndef SOFA_CORE_BEHAVIOR_MULTIMATRIXACCESSOR_H
 #define SOFA_CORE_BEHAVIOR_MULTIMATRIXACCESSOR_H
 
-#include <sofa/core/behavior/BaseMechanicalState.h>
-#include <sofa/core/BaseMapping.h>
+#include <sofa/defaulttype/BaseMatrix.h>
+
+namespace sofa::core::behavior { class BaseMechanicalState; }
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/MultiMatrixAccessor.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/MultiMatrixAccessor.h
@@ -22,7 +22,9 @@
 #ifndef SOFA_CORE_BEHAVIOR_MULTIMATRIXACCESSOR_H
 #define SOFA_CORE_BEHAVIOR_MULTIMATRIXACCESSOR_H
 
+#include <sofa/core/config.h>
 #include <sofa/defaulttype/BaseMatrix.h>
+#include <sofa/core/fwd.h>
 
 namespace sofa::core::behavior { class BaseMechanicalState; }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/PairInteractionForceField.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/PairInteractionForceField.h
@@ -24,7 +24,7 @@
 
 #include <sofa/core/config.h>
 #include <sofa/core/behavior/BaseInteractionForceField.h>
-
+#include <sofa/core/behavior/MechanicalState.h>
 
 
 namespace sofa

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/PairInteractionProjectiveConstraintSet.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/PairInteractionProjectiveConstraintSet.h
@@ -24,7 +24,7 @@
 
 #include <sofa/core/config.h>
 #include <sofa/core/behavior/BaseInteractionProjectiveConstraintSet.h>
-
+#include <sofa/core/behavior/MechanicalState.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ProjectiveConstraintSet.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ProjectiveConstraintSet.h
@@ -24,8 +24,7 @@
 
 #include <sofa/core/config.h>
 #include <sofa/core/behavior/BaseProjectiveConstraintSet.h>
-
-
+#include <sofa/core/behavior/MechanicalState.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/fwd.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/fwd.cpp
@@ -1,0 +1,24 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/core/behavior/fwd.h>
+
+/// put here conversion function to/from the fwd declared object.S

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/fwd.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/fwd.h
@@ -1,0 +1,37 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+namespace sofa::core::behavior
+{
+    class BaseAnimationLoop;
+    class BaseConstraint;
+    class BaseConstraintCorrection;
+    class BaseController;
+    class BaseForceField;
+    class BaseInteractionConstraint;
+    class BaseInteractionForceField;
+    class BaseInteractionProjectiveConstraintSet;
+    class BaseMass;
+    class BaseMechanicalState;
+    class MultiMatrixAccessor;
+}

--- a/SofaKernel/modules/SofaCore/src/sofa/core/fwd.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/fwd.cpp
@@ -1,0 +1,33 @@
+#include <sofa/core/fwd.h>
+#include <sofa/core/topology/TopologyChange.h>
+
+namespace sofa::core::topology
+{
+
+std::ostream& operator<< ( std::ostream& out, const TopologyChange* t )
+{
+    if (t)
+    {
+        t->write(out);
+    }
+    return out;
+}
+
+/// Input (empty) stream
+std::istream& operator>> ( std::istream& in, TopologyChange*& t )
+{
+    if (t)
+    {
+        t->read(in);
+    }
+    return in;
+}
+
+/// Input (empty) stream
+std::istream& operator>> ( std::istream& in, const TopologyChange*& )
+{
+    return in;
+}
+
+}
+

--- a/SofaKernel/modules/SofaCore/src/sofa/core/fwd.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/fwd.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <sofa/core/config.h>
+namespace sofa::core::objectmodel
+{
+    class Base;
+    class BaseObject;
+    class BaseNode;
+    class BaseContext;
+    class BaseData;
+    class BaseLink;
+}
+
+namespace sofa::core::topology
+{
+    class TopologyChange;
+}

--- a/SofaKernel/modules/SofaCore/src/sofa/core/fwd.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/fwd.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <sofa/core/config.h>
+#include <iosfwd>
 namespace sofa::core::objectmodel
 {
     class Base;
@@ -13,4 +14,14 @@ namespace sofa::core::objectmodel
 namespace sofa::core::topology
 {
     class TopologyChange;
+
+    /// Output  stream
+    std::ostream& operator<< ( std::ostream& out, const sofa::core::topology::TopologyChange* t );
+
+    /// Input (empty) stream
+    std::istream& operator>> ( std::istream& in, sofa::core::topology::TopologyChange*& t );
+
+    /// Input (empty) stream
+    std::istream& operator>> ( std::istream& in, const sofa::core::topology::TopologyChange*& );
+
 }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/fwd.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/fwd.h
@@ -1,6 +1,12 @@
 #pragma once
 #include <sofa/core/config.h>
 #include <iosfwd>
+
+namespace sofa::core
+{
+    class BaseMapping;
+}
+
 namespace sofa::core::objectmodel
 {
     class Base;
@@ -9,6 +15,13 @@ namespace sofa::core::objectmodel
     class BaseContext;
     class BaseData;
     class BaseLink;
+}
+
+namespace sofa::core::behavior
+{
+    class BaseForceField;
+    class BaseMass;
+    class BaseMechanicalState;
 }
 
 namespace sofa::core::topology
@@ -23,4 +36,9 @@ namespace sofa::core::topology
 
     /// Input (empty) stream
     SOFA_CORE_API std::istream& operator>> ( std::istream& in, const sofa::core::topology::TopologyChange*& );
+}
+
+namespace sofa::core::visual
+{
+    class VisualParams;
 }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/fwd.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/fwd.h
@@ -16,12 +16,11 @@ namespace sofa::core::topology
     class TopologyChange;
 
     /// Output  stream
-    std::ostream& operator<< ( std::ostream& out, const sofa::core::topology::TopologyChange* t );
+    SOFA_CORE_API std::ostream& operator<< ( std::ostream& out, const sofa::core::topology::TopologyChange* t );
 
     /// Input (empty) stream
-    std::istream& operator>> ( std::istream& in, sofa::core::topology::TopologyChange*& t );
+    SOFA_CORE_API std::istream& operator>> ( std::istream& in, sofa::core::topology::TopologyChange*& t );
 
     /// Input (empty) stream
-    std::istream& operator>> ( std::istream& in, const sofa::core::topology::TopologyChange*& );
-
+    SOFA_CORE_API std::istream& operator>> ( std::istream& in, const sofa::core::topology::TopologyChange*& );
 }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.h
@@ -486,7 +486,6 @@ public:
     /// so the Node does not have to test its type against every known types.
     /// \returns true iff the component was removed
     virtual bool removeInNode( BaseNode* /*node*/ ) { return false; }
-
 };
 
 } // namespace objectmodel

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
@@ -26,6 +26,7 @@
 #include <sofa/core/objectmodel/BaseData.h>
 #include <sofa/helper/StringUtils.h>
 #include <sofa/helper/accessor.h>
+#include <istream>
 #include <sofa/core/objectmodel/DataContentValue.h>
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/ScriptEvent.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/ScriptEvent.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 
 #include <sofa/core/objectmodel/ScriptEvent.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/ScriptEvent.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/ScriptEvent.cpp
@@ -42,6 +42,11 @@ ScriptEvent::ScriptEvent(sofa::simulation::Node::SPtr sender, const char* eventN
 
 }
 
+const sofa::simulation::NodeSPtr ScriptEvent::getSender(void) const
+{
+    return m_sender;
+}
+
 ScriptEvent::~ScriptEvent()
 {
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/ScriptEvent.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/ScriptEvent.h
@@ -24,8 +24,7 @@
 
 #include <sofa/core/objectmodel/Event.h>
 #include <string>
-#include <sofa/simulation/Node.h>
-
+#include <sofa/simulation/fwd.h>
 
 namespace sofa
 {
@@ -48,7 +47,7 @@ public:
     /**
      * @brief Constructor.
      */
-    ScriptEvent(sofa::simulation::Node::SPtr sender, const char* eventName);
+    ScriptEvent(sofa::simulation::NodeSPtr sender, const char* eventName);
 
     /**
      * @brief Destructor.
@@ -58,7 +57,7 @@ public:
     /**
      * @brief Get the sender name
      */
-    const sofa::simulation::Node::SPtr getSender(void) const {return m_sender;}
+    const sofa::simulation::NodeSPtr getSender(void) const {return m_sender;}
 
     /**
      * @brief Get the event name
@@ -68,7 +67,7 @@ public:
     inline static const char* GetClassName() { return "ScriptEvent"; }
 private:
 
-    sofa::simulation::Node::SPtr m_sender;
+    sofa::simulation::NodeSPtr m_sender;
     std::string m_eventName;
 
 };

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/ScriptEvent.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/ScriptEvent.h
@@ -57,7 +57,7 @@ public:
     /**
      * @brief Get the sender name
      */
-    const sofa::simulation::NodeSPtr getSender(void) const {return m_sender;}
+    const sofa::simulation::NodeSPtr getSender(void) const;
 
     /**
      * @brief Get the event name

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseMeshTopology.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseMeshTopology.cpp
@@ -23,7 +23,6 @@
 #include <sofa/helper/io/MeshTopologyLoader.h>
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/core/objectmodel/BaseNode.h>
-
 namespace sofa
 {
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopology.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopology.h
@@ -22,6 +22,7 @@
 #ifndef SOFA_CORE_TOPOLOGY_BASETOPOLOGY_H
 #define SOFA_CORE_TOPOLOGY_BASETOPOLOGY_H
 
+#include <sofa/core/topology/TopologyChange.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/core/topology/BaseTopologyObject.h>
 #include <sofa/core/VecId.h>

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopologyEngine.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopologyEngine.cpp
@@ -19,74 +19,47 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_COMPONENT_TOPOLOGY_BASETOPOLOGYENGINE_H
-#define SOFA_COMPONENT_TOPOLOGY_BASETOPOLOGYENGINE_H
+#define SOFA_CORE_TOPOLOGY_BASETOPOLOGYENGINE_DEFINITION true
+#include <sofa/core/topology/BaseTopologyEngine.h>
+#include <sofa/core/topology/TopologyChange.h>
 
-#include <sofa/core/DataEngine.h>
-#include <sofa/core/fwd.h>
-
-#ifndef SOFA_CORE_TOPOLOGY_BASETOPOLOGYENGINE_DEFINITION
+#ifdef SOFA_CORE_TOPOLOGY_BASETOPOLOGYENGINE_DEFINITION
 namespace std
 {
-    extern template class list<const sofa::core::topology::TopologyChange*>;
+    template class list<const sofa::core::topology::TopologyChange*>;
 }
+
 namespace sofa::core::objectmodel
 {
-    extern template class Data<std::list<const sofa::core::topology::TopologyChange*>>;
+template class Data<std::list<const sofa::core::topology::TopologyChange*>>;
 }
-
 #endif /// SOFA_CORE_TOPOLOGY_BASETOPOLOGYENGINE_DEFINITION
 
-namespace sofa
+
+namespace sofa::core::topology
 {
 
-namespace core
+void TopologyEngine::init()
 {
+    sofa::core::DataEngine::init();
+    this->createEngineName();
+}
 
-namespace topology
+size_t TopologyEngine::getNumberOfTopologicalChanges()
 {
+    return (m_changeList.getValue()).size();
+}
 
-/** A class that will interact on a topological Data */
-class TopologyEngine : public sofa::core::DataEngine
+void TopologyEngine::createEngineName()
 {
-public:
-    SOFA_ABSTRACT_CLASS(TopologyEngine, DataEngine);
+    if (m_data_name.empty())
+        setName( m_prefix + "no_name" );
+    else
+        setName( m_prefix + m_data_name );
 
-protected:
-    TopologyEngine() {}
-    ~TopologyEngine() override {}
+    return;
+}
 
-public:
-    void init() override ;
-    void handleTopologyChange() override {}
-
-public:
-    // really need to be a Data??
-    Data <std::list<const TopologyChange *> >m_changeList;
-
-    size_t getNumberOfTopologicalChanges();
-
-    virtual void createEngineName();
-    virtual void linkToPointDataArray() {}
-    virtual void linkToEdgeDataArray() {}
-    virtual void linkToTriangleDataArray() {}
-    virtual void linkToQuadDataArray() {}
-    virtual void linkToTetrahedronDataArray() {}
-    virtual void linkToHexahedronDataArray() {}
-
-    void setNamePrefix(const std::string& s) { m_prefix = s; }
-
-protected:
-    /// use to define engine name.
-    std::string m_prefix;
-    /// use to define data handled name.
-    std::string m_data_name;
-};
-
-} // namespace topology
-
-} // namespace component
 
 } // namespace sofa
 
-#endif // SOFA_COMPONENT_TOPOLOGY_BASETOPOLOGYENGINE_H

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopologyEngine.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopologyEngine.h
@@ -47,7 +47,7 @@ namespace topology
 {
 
 /** A class that will interact on a topological Data */
-class TopologyEngine : public sofa::core::DataEngine
+class SOFA_CORE_API TopologyEngine : public sofa::core::DataEngine
 {
 public:
     SOFA_ABSTRACT_CLASS(TopologyEngine, DataEngine);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyChange.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyChange.h
@@ -345,30 +345,13 @@ public:
     virtual bool read(std::istream& in);
 
     /// Output  stream
-    friend std::ostream& operator<< ( std::ostream& out, const TopologyChange* t )
-    {
-        if (t)
-        {
-            t->write(out);
-        }
-        return out;
-    }
+    friend std::ostream& operator<< ( std::ostream& out, const TopologyChange* t );
 
     /// Input (empty) stream
-    friend std::istream& operator>> ( std::istream& in, TopologyChange*& t )
-    {
-        if (t)
-        {
-            t->read(in);
-        }
-        return in;
-    }
-    
+    friend std::istream& operator>> ( std::istream& in, TopologyChange*& t );
+
     /// Input (empty) stream
-    friend std::istream& operator>> ( std::istream& in, const TopologyChange*& )
-    {
-        return in;
-    }
+    friend std::istream& operator>> ( std::istream& in, const TopologyChange*& );
 
 protected:
     TopologyChange( TopologyChangeType changeType = BASE )

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyChange.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyChange.h
@@ -345,13 +345,13 @@ public:
     virtual bool read(std::istream& in);
 
     /// Output  stream
-    friend std::ostream& operator<< ( std::ostream& out, const TopologyChange* t );
+    SOFA_CORE_API friend std::ostream& operator<< ( std::ostream& out, const TopologyChange* t );
 
     /// Input (empty) stream
-    friend std::istream& operator>> ( std::istream& in, TopologyChange*& t );
+    SOFA_CORE_API friend std::istream& operator>> ( std::istream& in, TopologyChange*& t );
 
     /// Input (empty) stream
-    friend std::istream& operator>> ( std::istream& in, const TopologyChange*& );
+    SOFA_CORE_API friend std::istream& operator>> ( std::istream& in, const TopologyChange*& );
 
 protected:
     TopologyChange( TopologyChangeType changeType = BASE )

--- a/SofaKernel/modules/SofaCore/src/sofa/core/visual/VisualParams.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/visual/VisualParams.h
@@ -27,6 +27,7 @@
 #include <sofa/helper/visual/DrawTool.h>
 #include <sofa/helper/visual/Transformation.h>
 #include <sofa/core/visual/DisplayFlags.h>
+#include <sofa/core/ExecParams.h>
 
 namespace sofa::core::visual
 {

--- a/SofaKernel/modules/SofaDefaultType/CMakeLists.txt
+++ b/SofaKernel/modules/SofaDefaultType/CMakeLists.txt
@@ -36,8 +36,8 @@ set(HEADER_FILES
     ${SRC_ROOT}/defaulttype.h
     ${SRC_ROOT}/config.h.in
     ${SRC_ROOT}/init.h
+    ${SRC_ROOT}/fwd.h
     ${SRC_ROOT}/Color.h
-
     ${SRC_ROOT}/typeinfo/DataTypeInfoDynamicWrapper.h
     ${SRC_ROOT}/typeinfo/DataTypeInfo.h
     ${SRC_ROOT}/typeinfo/NoTypeInfo.h

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BaseMatrix.cpp
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BaseMatrix.cpp
@@ -734,6 +734,83 @@ void BaseMatrix::opAddMT(defaulttype::BaseMatrix* result,double fact) const
 }
 
 
+std::ostream& operator<<(std::ostream& out, const  sofa::defaulttype::BaseMatrix& m )
+{
+    Index nx = m.colSize();
+    Index ny = m.rowSize();
+    out << "[";
+    for (Index y=0; y<ny; ++y)
+    {
+        out << "\n[";
+        for (Index x=0; x<nx; ++x)
+        {
+            out << " " << m.element(y,x);
+        }
+        out << " ]";
+    }
+    out << " ]";
+    return out;
+}
+
+std::istream& operator>>( std::istream& in, sofa::defaulttype::BaseMatrix& m )
+{
+    // The reading could be way simplier with an other format,
+    // but I did not want to change the existing output.
+    // Anyway, I guess there are better ways to perform the reading
+    // but at least this one is working...
+
+    std::vector<SReal> line;
+    std::vector< std::vector<SReal> > lines;
+
+//    unsigned l=0, c;
+
+    in.ignore(INT_MAX, '['); // ignores all characters until it passes a [, start of the matrix
+
+    while(true)
+    {
+        in.ignore(INT_MAX, '['); // ignores all characters until it passes a [, start of the line
+//        c=0;
+
+        SReal r;
+        char car; in >> car;
+        while( car!=']') // end of the line
+        {
+            in.seekg( -1, std::istream::cur ); // unread car
+            in >> r;
+            line.push_back(r);
+//            ++c;
+            in >> car;
+        }
+
+//        ++l;
+
+        lines.push_back(line);
+        line.clear();
+
+        in >> car;
+        if( car==']' ) break; // end of the matrix
+        else in.seekg( -1, std::istream::cur ); // unread car
+
+    }
+
+    m.resize( (Index)lines.size(), (Index)lines[0].size() );
+
+    for( size_t i=0; i<lines.size();++i)
+    {
+        assert( lines[i].size() == lines[0].size() ); // all line should have the same number of columns
+        for( size_t j=0; j<lines[i].size();++j)
+        {
+            m.add( (Index)i, (Index)j, lines[i][j] );
+        }
+    }
+
+    m.compress();
+
+
+    if( in.rdstate() & std::ios_base::eofbit ) { in.clear(); }
+    return in;
+}
+
 
 } // nampespace defaulttype
 

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BaseMatrix.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BaseMatrix.h
@@ -30,7 +30,6 @@
 #include <cstddef> // for nullptr and std::size_t
 #include <iostream>
 #include <vector>
-#include <cassert>
 #include <climits>
 
 namespace sofa
@@ -1200,85 +1199,17 @@ public:
 
     /// @}
 
-    friend std::ostream& operator<<(std::ostream& out, const  sofa::defaulttype::BaseMatrix& m )
-    {
-        Index nx = m.colSize();
-        Index ny = m.rowSize();
-        out << "[";
-        for (Index y=0; y<ny; ++y)
-        {
-            out << "\n[";
-            for (Index x=0; x<nx; ++x)
-            {
-                out << " " << m.element(y,x);
-            }
-            out << " ]";
-        }
-        out << " ]";
-        return out;
-    }
-
-    friend std::istream& operator>>( std::istream& in, sofa::defaulttype::BaseMatrix& m )
-    {
-        // The reading could be way simplier with an other format,
-        // but I did not want to change the existing output.
-        // Anyway, I guess there are better ways to perform the reading
-        // but at least this one is working...
-
-        std::vector<SReal> line;
-        std::vector< std::vector<SReal> > lines;
-
-    //    unsigned l=0, c;
-
-        in.ignore(INT_MAX, '['); // ignores all characters until it passes a [, start of the matrix
-
-        while(true)
-        {
-            in.ignore(INT_MAX, '['); // ignores all characters until it passes a [, start of the line
-    //        c=0;
-
-            SReal r;
-            char car; in >> car;
-            while( car!=']') // end of the line
-            {
-                in.seekg( -1, std::istream::cur ); // unread car
-                in >> r;
-                line.push_back(r);
-    //            ++c;
-                in >> car;
-            }
-
-    //        ++l;
-
-            lines.push_back(line);
-            line.clear();
-
-            in >> car;
-            if( car==']' ) break; // end of the matrix
-            else in.seekg( -1, std::istream::cur ); // unread car
-
-        }
-
-        m.resize( (Index)lines.size(), (Index)lines[0].size() );
-
-        for( size_t i=0; i<lines.size();++i)
-        {
-            assert( lines[i].size() == lines[0].size() ); // all line should have the same number of columns
-            for( size_t j=0; j<lines[i].size();++j)
-            {
-                m.add( (Index)i, (Index)j, lines[i][j] );
-            }
-        }
-
-        m.compress();
-
-
-        if( in.rdstate() & std::ios_base::eofbit ) { in.clear(); }
-        return in;
-    }
-
+    /// Declare that the operator << is friend so they can use private data.
+    friend std::ostream& operator<<(std::ostream& out, const  sofa::defaulttype::BaseMatrix& m );
+    /// Declare that the operator >> is friend so they can use private data.
+    friend std::istream& operator>>( std::istream& in, sofa::defaulttype::BaseMatrix& m );
 };
 
+/// Declare that the operator >> exists but is defined in a BaseMatrix.cpp
+SOFA_DEFAULTTYPE_API std::ostream& operator<<(std::ostream& out, const  sofa::defaulttype::BaseMatrix& m );
+
+/// Declare that the operator >> exists but is defined in a BaseMatrix.cpp
+SOFA_DEFAULTTYPE_API std::istream& operator>>( std::istream& in, sofa::defaulttype::BaseMatrix& m );
 
 } // nampespace defaulttype
 

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BaseMatrix.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BaseMatrix.h
@@ -28,8 +28,7 @@
 #include <sofa/helper/logging/Messaging.h>
 #include <utility> // for std::pair
 #include <cstddef> // for nullptr and std::size_t
-#include <iostream>
-#include <vector>
+#include <iosfwd>
 #include <climits>
 
 namespace sofa
@@ -1200,9 +1199,9 @@ public:
     /// @}
 
     /// Declare that the operator << is friend so they can use private data.
-    friend std::ostream& operator<<(std::ostream& out, const  sofa::defaulttype::BaseMatrix& m );
+    friend SOFA_DEFAULTTYPE_API std::ostream& operator<<(std::ostream& out, const  sofa::defaulttype::BaseMatrix& m );
     /// Declare that the operator >> is friend so they can use private data.
-    friend std::istream& operator>>( std::istream& in, sofa::defaulttype::BaseMatrix& m );
+    friend SOFA_DEFAULTTYPE_API std::istream& operator>>( std::istream& in, sofa::defaulttype::BaseMatrix& m );
 };
 
 /// Declare that the operator >> exists but is defined in a BaseMatrix.cpp

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/fwd.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/fwd.h
@@ -21,7 +21,19 @@
 ******************************************************************************/
 #pragma once
 
+#include <sofa/defaulttype/config.h>
+namespace sofa::helper
+{
+    template<class T>
+    class Quater;
+}
+
 namespace sofa::defaulttype
 {
     class BaseMatrix;
+
+    typedef sofa::helper::Quater<float> Quatf;
+    typedef sofa::helper::Quater<double> Quatd;
+    typedef sofa::helper::Quater<SReal> Quat;
+    typedef Quat Quaternion;
 }

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/fwd.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/fwd.h
@@ -19,22 +19,9 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#define SOFA_COMPONENT_PROJECTIVECONSTRAINTSET_SKELETALMOTIONCONSTRAINT_CPP
-#include <SofaBoundaryCondition/SkeletalMotionConstraint.inl>
-#include <sofa/core/ObjectFactory.h>
-#include <sofa/defaulttype/RigidTypes.h>
-#include <sofa/defaulttype/BaseMatrix.h>
-#include <sofa/simulation/Node.h>
+#pragma once
 
-namespace sofa::component::projectiveconstraintset
+namespace sofa::defaulttype
 {
-
-//declaration of the class, for the factory
-int SkeletalMotionConstraintClass = core::RegisterObject("animate a skeleton")
-        .add< SkeletalMotionConstraint<defaulttype::Rigid3Types> >()
-
-        ;
-
-template class SOFA_SOFABOUNDARYCONDITION_API SkeletalMotionConstraint<defaulttype::Rigid3Types>;
-
-} // namespace sofa::component::projectiveconstraintset
+    class BaseMatrix;
+}

--- a/SofaKernel/modules/SofaDeformable/src/SofaDeformable/StiffSpringForceField.inl
+++ b/SofaKernel/modules/SofaDeformable/src/SofaDeformable/StiffSpringForceField.inl
@@ -21,6 +21,8 @@
 ******************************************************************************/
 #pragma once
 #include <SofaDeformable/StiffSpringForceField.h>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
+
 #include <sofa/helper/AdvancedTimer.h>
 
 #include <sofa/core/visual/VisualParams.h>

--- a/SofaKernel/modules/SofaEigen2Solver/src/SofaEigen2Solver/EigenBaseSparseMatrix.h
+++ b/SofaKernel/modules/SofaEigen2Solver/src/SofaEigen2Solver/EigenBaseSparseMatrix.h
@@ -22,6 +22,8 @@
 #pragma once
 #include <SofaEigen2Solver/config.h>
 
+#include <sofa/core/objectmodel/Data.h>
+#include <sofa/defaulttype/DataTypeInfo.h>
 #include <sofa/defaulttype/BaseMatrix.h>
 #include <sofa/helper/vector.h>
 #include <sofa/core/behavior/MultiMatrixAccessor.h>

--- a/SofaKernel/modules/SofaEigen2Solver/src/SofaEigen2Solver/EigenSparseMatrix.h
+++ b/SofaKernel/modules/SofaEigen2Solver/src/SofaEigen2Solver/EigenSparseMatrix.h
@@ -23,6 +23,7 @@
 #include <SofaEigen2Solver/config.h>
 
 #include <SofaEigen2Solver/EigenBaseSparseMatrix.h>
+#include <sofa/defaulttype/DataTypeInfo.h>
 #include <sofa/defaulttype/Mat.h>
 #include <SofaBaseLinearSolver/CompressedRowSparseMatrix.h>
 #include <sofa/helper/SortedPermutation.h>

--- a/SofaKernel/modules/SofaHelper/CMakeLists.txt
+++ b/SofaKernel/modules/SofaHelper/CMakeLists.txt
@@ -101,6 +101,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/random.h
     ${SRC_ROOT}/rmath.h
     ${SRC_ROOT}/set.h
+    ${SRC_ROOT}/fwd.h
     ${SRC_ROOT}/stable_vector.h
     ${SRC_ROOT}/system/DynamicLibrary.h
     ${SRC_ROOT}/system/FileSystem.h

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.cpp
@@ -21,8 +21,7 @@
 ******************************************************************************/
 #define SOFA_HELPER_ADVANCEDTIMER_CPP
 #include <sofa/helper/AdvancedTimer.h>
-
-#include <sofa/helper/system/thread/CTime.h>
+#include <sofa/simulation/Node.h>
 #include <sofa/helper/vector.h>
 #include <sofa/helper/map.h>
 #include <iomanip>

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.h
@@ -19,21 +19,22 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_HELPER_ADVANCEDTIMER_H
-#define SOFA_HELPER_ADVANCEDTIMER_H
+#pragma once
 #include <sofa/helper/config.h>
-#include <sofa/simulation/Simulation.h>
 #include <sofa/helper/system/thread/thread_specific_ptr.h>
+#include <sofa/helper/system/thread/CTime.h>
+#include <sofa/helper/vector.h>
 
 #include <iostream>
 #include <string>
-#include <vector>
+#include <map>
 
-
-namespace sofa
+namespace sofa::simulation
 {
+    class Node;
+}
 
-namespace helper
+namespace sofa::helper
 {
 
 /**
@@ -534,9 +535,5 @@ struct ScopedAdvancedTimer {
     }
 };
 
-
 }
 
-}
-
-#endif

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/fwd.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/fwd.h
@@ -1,0 +1,29 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/helper/config.h>
+
+namespace sofa::helper::visual
+{
+    class DrawTool;
+}

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PipeProcess.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PipeProcess.cpp
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <WinNt.h>
 #include <cstdio>
 typedef int ssize_t;
 typedef HANDLE fd_t;

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PipeProcess.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PipeProcess.cpp
@@ -28,6 +28,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <WinNt.h>
+#include <winsock.h>
 #include <cstdio>
 typedef int ssize_t;
 typedef HANDLE fd_t;

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/visual/DrawTool.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/visual/DrawTool.h
@@ -22,9 +22,9 @@
 #pragma once
 
 #include <sofa/core/config.h>
-#include <sofa/defaulttype/Quat.h>
 #include <sofa/helper/types/RGBAColor.h>
-
+#include <sofa/defaulttype/Vec.h>
+#include <sofa/defaulttype/fwd.h>
 
 namespace sofa::helper::visual
 {
@@ -35,7 +35,7 @@ namespace sofa::helper::visual
  *  Class which contains a set of methods to perform minimal debug drawing regardless of the graphics API used.
  *  Components receive a pointer to the DrawTool through the VisualParams parameter of their draw method.
  *  Sofa provides a default concrete implementation of this class for the OpenGL API with the DrawToolGL class.
- *
+ *k
  */
 
 class DrawTool

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/BarycentricContactMapper.h
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/BarycentricContactMapper.h
@@ -24,7 +24,6 @@
 
 #include <SofaBaseMechanics/BarycentricMapping.h>
 #include <SofaBaseMechanics/MechanicalObject.h>
-#include <sofa/simulation/Node.h>
 #include <SofaBaseCollision/BaseContactMapper.h>
 #include <SofaBaseCollision/CapsuleModel.h>
 #include <SofaMeshCollision/TriangleModel.h>

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/IdentityContactMapper.h
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/IdentityContactMapper.h
@@ -25,7 +25,6 @@
 #include <sofa/helper/Factory.h>
 #include <SofaBaseMechanics/IdentityMapping.h>
 #include <SofaBaseMechanics/MechanicalObject.h>
-#include <sofa/simulation/Node.h>
 #include <SofaBaseCollision/BaseContactMapper.h>
 #include <SofaBaseCollision/SphereModel.h>
 #include <SofaMeshCollision/PointModel.h>

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/RigidContactMapper.h
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/RigidContactMapper.h
@@ -25,13 +25,12 @@
 #include <sofa/helper/Factory.h>
 #include <SofaRigid/RigidMapping.h>
 #include <SofaBaseMechanics/MechanicalObject.h>
-#include <sofa/simulation/Node.h>
 #include <SofaBaseCollision/BaseContactMapper.h>
 #include <SofaBaseCollision/SphereModel.h>
 #include <SofaBaseCollision/OBBModel.h>
 #include <SofaBaseCollision/RigidCapsuleModel.h>
 #include <SofaBaseCollision/CylinderModel.h>
-
+#include <sofa/simulation/fwd.h>
 namespace sofa::component::collision
 {
 
@@ -54,7 +53,7 @@ public:
     using Index = sofa::Index;
 
     MCollisionModel* model;
-    simulation::Node::SPtr child;
+    simulation::NodeSPtr child;
     typename MMapping::SPtr mapping;
     typename MMechanicalState::SPtr outmodel;
     Size nbp;

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/HexahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/HexahedronFEMForceField.inl
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #pragma once
 #include <SofaSimpleFem/HexahedronFEMForceField.h>
-
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/core/behavior/RotationMatrix.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/decompose.h>

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.inl
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #pragma once
 #include <SofaSimpleFem/TetrahedronFEMForceField.h>
-
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/core/behavior/RotationMatrix.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <SofaBaseTopology/GridTopology.h>

--- a/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/TransformationVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/TransformationVisitor.cpp
@@ -20,6 +20,8 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <SofaSimulationCommon/TransformationVisitor.h>
+#include <sofa/core/behavior/BaseMechanicalState.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa::simulation
 {

--- a/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/xml/BaseMultiMappingElement.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/xml/BaseMultiMappingElement.cpp
@@ -24,6 +24,7 @@
 #include <sofa/core/BaseState.h>
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/core/objectmodel/BaseNode.h>
+#include <sofa/simulation/Node.h>
 #include <SofaSimulationCommon/xml/NodeElement.h>
 #include <SofaSimulationCommon/xml/Element.h>
 

--- a/SofaKernel/modules/SofaSimulationCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaSimulationCore/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SRC_ROOT "src/sofa/simulation")
 
 set(HEADER_FILES
     ${SRC_ROOT}/config.h.in
+    ${SRC_ROOT}/fwd.h
     ${SRC_ROOT}/simulationcore.h
     ${SRC_ROOT}/AnimateBeginEvent.h
     ${SRC_ROOT}/AnimateEndEvent.h
@@ -131,6 +132,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/WriteStateVisitor.cpp
     ${SRC_ROOT}/XMLPrintVisitor.cpp
     ${SRC_ROOT}/init.cpp
+    ${SRC_ROOT}/fwd.cpp
     ${SRC_ROOT}/MechanicalComputeEnergyVisitor.cpp
     ${SRC_ROOT}/BaseSimulationExporter.cpp
     ${SRC_ROOT}/TaskScheduler.cpp

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/AnimateVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/AnimateVisitor.cpp
@@ -29,11 +29,9 @@
 #include <sofa/simulation/IntegrateBeginEvent.h>
 #include <sofa/simulation/IntegrateEndEvent.h>
 #include <sofa/simulation/PropagateEventVisitor.h>
-
+#include <sofa/simulation/Node.h>
 
 #include <sofa/helper/AdvancedTimer.h>
-
-//#include "MechanicalIntegration.h"
 
 using namespace sofa::core;
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/AnimateVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/AnimateVisitor.h
@@ -23,9 +23,9 @@
 #define SOFA_SIMULATION_ANIMATEACTION_H
 
 #include <sofa/simulation/config.h>
+#include <sofa/simulation/fwd.h>
 #include <sofa/simulation/Visitor.h>
-#include <sofa/simulation/Node.h>
-#include <sofa/core/VecId.h>
+#include <sofa/core/behavior/fwd.h>
 #include <sofa/core/MultiVecId.h>
 #include <sofa/core/ExecParams.h>
 #include <sofa/core/MechanicalParams.h>

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/BehaviorUpdatePositionVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/BehaviorUpdatePositionVisitor.cpp
@@ -20,7 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/simulation/BehaviorUpdatePositionVisitor.h>
-
+#include <sofa/simulation/Node.h>
 namespace sofa
 {
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/BehaviorUpdatePositionVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/BehaviorUpdatePositionVisitor.h
@@ -24,8 +24,8 @@
 
 #include <sofa/core/ExecParams.h>
 #include <sofa/simulation/Visitor.h>
-#include <sofa/simulation/Node.h>
 #include <sofa/core/BehaviorModel.h>
+#include <sofa/simulation/fwd.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DeactivatedNodeVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DeactivatedNodeVisitor.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/simulation/DeactivatedNodeVisitor.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DefaultAnimationLoop.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DefaultAnimationLoop.cpp
@@ -22,6 +22,7 @@
 #include <sofa/simulation/DefaultAnimationLoop.h>
 #include <sofa/core/ObjectFactory.h>
 
+#include <sofa/simulation/Node.h>
 #include <sofa/simulation/AnimateVisitor.h>
 #include <sofa/simulation/UpdateContextVisitor.h>
 #include <sofa/simulation/UpdateMappingVisitor.h>

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DefaultAnimationLoop.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DefaultAnimationLoop.h
@@ -25,8 +25,7 @@
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/core/behavior/BaseAnimationLoop.h>
 #include <sofa/core/ExecParams.h>
-#include <sofa/simulation/config.h>
-#include <sofa/simulation/Node.h>
+#include <sofa/simulation/fwd.h>
 
 namespace sofa {
 namespace core {
@@ -73,7 +72,7 @@ public:
     template<class T>
     static typename T::SPtr create(T*, BaseContext* context, BaseObjectDescription* arg)
     {
-        simulation::Node* gnode = dynamic_cast<simulation::Node*>(context);
+        simulation::Node* gnode = getNodeFromContext(context);
         typename T::SPtr obj = sofa::core::objectmodel::New<T>(gnode);
         if (context) context->addObject(obj);
         if (arg) obj->parse(arg);

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DefaultVisualManagerLoop.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DefaultVisualManagerLoop.cpp
@@ -160,6 +160,10 @@ void DefaultVisualManagerLoop::computeBBoxStep(sofa::core::visual::VisualParams*
     }
 }
 
+simulation::Node* DefaultVisualManagerLoop::getNodeFromContext(BaseContext* context)
+{
+    return dynamic_cast<simulation::Node*>(context);
+}
 
 
 } // namespace simulation

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DefaultVisualManagerLoop.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DefaultVisualManagerLoop.cpp
@@ -28,7 +28,7 @@
 #include <sofa/simulation/UpdateMappingVisitor.h>
 #include <sofa/simulation/UpdateMappingEndEvent.h>
 #include <sofa/simulation/PropagateEventVisitor.h>
-
+#include <sofa/simulation/Node.h>
 
 #include <sofa/helper/AdvancedTimer.h>
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DefaultVisualManagerLoop.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DefaultVisualManagerLoop.h
@@ -25,7 +25,7 @@
 #include <sofa/core/visual/VisualLoop.h>
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/simulation/config.h>
-#include <sofa/simulation/Node.h>
+#include <sofa/simulation/fwd.h>
 
 namespace sofa {
 namespace core {
@@ -80,7 +80,7 @@ public:
     template<class T>
     static typename T::SPtr create(T*, BaseContext* context, BaseObjectDescription* arg)
     {
-        simulation::Node* gnode = dynamic_cast<simulation::Node*>(context);
+        simulation::Node* gnode = getNodeFromContext(context);
         typename T::SPtr obj = sofa::core::objectmodel::New<T>(gnode);
         if (context) context->addObject(obj);
         if (arg) obj->parse(arg);
@@ -88,7 +88,7 @@ public:
     }
 
 protected:
-
+    static simulation::Node* getNodeFromContext(BaseContext*);
     simulation::Node* gRoot;
 };
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/InitTasks.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/InitTasks.cpp
@@ -7,7 +7,6 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/AdvancedTimer.h>
 
-
 namespace sofa
 {
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/InitVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/InitVisitor.cpp
@@ -25,8 +25,7 @@
 #include <sofa/core/BaseMapping.h>
 #include <sofa/core/visual/VisualModel.h>
 #include <sofa/defaulttype/BoundingBox.h>
-
-//#include "MechanicalIntegration.h"
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalComputeEnergyVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalComputeEnergyVisitor.cpp
@@ -20,7 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/simulation/MechanicalComputeEnergyVisitor.h>
-
+#include <sofa/core/behavior/BaseMass.h>
 namespace sofa
 {
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalGetMomentumVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalGetMomentumVisitor.h
@@ -25,7 +25,7 @@
 #include <sofa/simulation/MechanicalVisitor.h>
 #include <sofa/defaulttype/Vec.h>
 #include <sofa/core/MechanicalParams.h>
-
+#include <sofa/core/behavior/BaseMass.h>
 namespace sofa
 {
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalMatrixVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalMatrixVisitor.h
@@ -35,6 +35,7 @@
 #include <sofa/core/behavior/BaseConstraintSet.h>
 #include <sofa/defaulttype/BaseMatrix.h>
 #include <sofa/defaulttype/BaseVector.h>
+#include <sofa/core/BaseMapping.h>
 #include <iostream>
 
 #include <sofa/core/ExecParams.h>

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalOperations.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalOperations.cpp
@@ -28,6 +28,7 @@
 #include <sofa/core/ConstraintParams.h>
 #include <sofa/core/behavior/LinearSolver.h>
 #include <sofa/defaulttype/BaseMatrix.h>
+#include <sofa/core/behavior/ConstraintSolver.h>
 
 using namespace sofa::core;
 namespace sofa

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVisitor.cpp
@@ -23,6 +23,7 @@
 #include <sofa/simulation/MechanicalVisitor.h>
 #include <sofa/simulation/Node.h>
 #include <sofa/simulation/LocalStorage.h>
+#include <sofa/core/behavior/BaseInteractionConstraint.h>
 #include <iostream>
 
 namespace sofa
@@ -239,6 +240,18 @@ void BaseMechanicalVisitor::processNodeBottomUp(simulation::Node* node)
     ctx.node = node;
     ctx.nodeData = rootData;
     processNodeBottomUp(node, &ctx);
+}
+
+/// Process all the InteractionConstraint
+Visitor::Result BaseMechanicalVisitor::fwdInteractionProjectiveConstraintSet(VisitorContext* ctx, core::behavior::BaseInteractionProjectiveConstraintSet* c)
+{
+    return fwdProjectiveConstraintSet(ctx->node, c);
+}
+
+/// Process all the InteractionConstraint
+Visitor::Result BaseMechanicalVisitor::fwdInteractionConstraint(VisitorContext* ctx, core::behavior::BaseInteractionConstraint* c)
+{
+    return fwdConstraintSet(ctx->node, c);
 }
 
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVisitor.cpp
@@ -22,6 +22,7 @@
 #define SOFA_SIMULATION_MECHANICALVISITOR_CPP
 #include <sofa/simulation/MechanicalVisitor.h>
 #include <sofa/simulation/Node.h>
+#include <sofa/simulation/LocalStorage.h>
 #include <iostream>
 
 namespace sofa

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVisitor.h
@@ -28,7 +28,6 @@
 #include <sofa/core/ConstraintParams.h>
 #include <sofa/core/MechanicalParams.h>
 #include <sofa/core/behavior/BaseMechanicalState.h>
-#include <sofa/core/behavior/Mass.h>
 #include <sofa/core/behavior/ForceField.h>
 #include <sofa/core/BaseMapping.h>
 #include <sofa/core/behavior/MultiMatrixAccessor.h>

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVisitor.h
@@ -32,7 +32,6 @@
 #include <sofa/core/BaseMapping.h>
 #include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/core/behavior/BaseInteractionForceField.h>
-#include <sofa/core/behavior/BaseInteractionConstraint.h>
 #include <sofa/core/behavior/BaseProjectiveConstraintSet.h>
 #include <sofa/core/behavior/BaseInteractionProjectiveConstraintSet.h>
 #include <sofa/core/behavior/BaseConstraintSet.h>
@@ -265,16 +264,10 @@ public:
     }
 
     /// Process all the InteractionConstraint
-    virtual Result fwdInteractionProjectiveConstraintSet(VisitorContext* ctx, core::behavior::BaseInteractionProjectiveConstraintSet* c)
-    {
-        return fwdProjectiveConstraintSet(ctx->node, c);
-    }
+    virtual Result fwdInteractionProjectiveConstraintSet(VisitorContext* ctx, core::behavior::BaseInteractionProjectiveConstraintSet* c);
 
     /// Process all the InteractionConstraint
-    virtual Result fwdInteractionConstraint(VisitorContext* ctx, core::behavior::BaseInteractionConstraint* c)
-    {
-        return fwdConstraintSet(ctx->node, c);
-    }
+    virtual Result fwdInteractionConstraint(VisitorContext* ctx, core::behavior::BaseInteractionConstraint* c);
 
     ///@}
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVisitor.h
@@ -30,6 +30,8 @@
 #include <sofa/core/behavior/BaseMechanicalState.h>
 #include <sofa/core/behavior/Mass.h>
 #include <sofa/core/behavior/ForceField.h>
+#include <sofa/core/BaseMapping.h>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/core/behavior/BaseInteractionForceField.h>
 #include <sofa/core/behavior/BaseInteractionConstraint.h>
 #include <sofa/core/behavior/BaseProjectiveConstraintSet.h>

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MutationListener.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MutationListener.h
@@ -22,8 +22,9 @@
 #ifndef SOFA_SIMULATION_CORE_MUTATIONLISTENER_H
 #define SOFA_SIMULATION_CORE_MUTATIONLISTENER_H
 
-#include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/simulation/config.h>
+#include <sofa/simulation/fwd.h>
+#include <sofa/core/fwd.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.cpp
@@ -30,6 +30,7 @@
 #include <sofa/simulation/VisualVisitor.h>
 #include <sofa/simulation/UpdateMappingVisitor.h>
 
+#include <sofa/simulation/MutationListener.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/helper/Factory.inl>
 #include <sofa/helper/cast.h>

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.h
@@ -67,7 +67,6 @@ class Visitor;
 }
 }
 
-#include <sofa/helper/system/thread/CTime.h>
 #include <string>
 #include <stack>
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.h
@@ -54,7 +54,6 @@
 #include <sofa/core/collision/Pipeline.h>
 #include <sofa/core/loader/BaseLoader.h>
 #include <sofa/core/objectmodel/Event.h>
-#include <sofa/simulation/MutationListener.h>
 #include <sofa/simulation/VisitorScheduler.h>
 
 #include <sofa/simulation/fwd.h>

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.h
@@ -57,6 +57,7 @@
 #include <sofa/simulation/MutationListener.h>
 #include <sofa/simulation/VisitorScheduler.h>
 
+#include <sofa/simulation/fwd.h>
 #include <type_traits>
 
 namespace sofa

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/PropagateEventVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/PropagateEventVisitor.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/simulation/PropagateEventVisitor.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Simulation.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Simulation.h
@@ -23,9 +23,6 @@
 #define SOFA_SIMULATION_CORE_SIMULATION_H
 
 #include <sofa/simulation/config.h>
-#include <sofa/core/objectmodel/DataFileName.h>
-#include <sofa/core/visual/DisplayFlags.h>
-#include <memory>
 
 namespace sofa::simulation {
     class Node;
@@ -47,7 +44,9 @@ class SOFA_SIMULATION_CORE_API Simulation: public virtual sofa::core::objectmode
 public:
     SOFA_CLASS(Simulation, sofa::core::objectmodel::Base);
 
-    typedef sofa::core::visual::DisplayFlags DisplayFlags;
+    [[deprecated("Simulation::DisplayFlags is deprecated use sofa::core::visual::DisplayFlags instead.")]]
+    typedef int DisplayFlags;
+
     Simulation();
     ~Simulation() override;
 	

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Simulation.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Simulation.h
@@ -23,8 +23,11 @@
 #define SOFA_SIMULATION_CORE_SIMULATION_H
 
 #include <sofa/simulation/config.h>
+#include <sofa/core/objectmodel/Base.h>
+#include <sofa/core/fwd.h>
 
-namespace sofa::simulation {
+namespace sofa::simulation
+{
     class Node;
     typedef sofa::core::sptr<Node> NodeSPtr;
 }

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Simulation.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Simulation.h
@@ -22,10 +22,15 @@
 #ifndef SOFA_SIMULATION_CORE_SIMULATION_H
 #define SOFA_SIMULATION_CORE_SIMULATION_H
 
-#include <sofa/simulation/Node.h>
+#include <sofa/simulation/config.h>
 #include <sofa/core/objectmodel/DataFileName.h>
 #include <sofa/core/visual/DisplayFlags.h>
 #include <memory>
+
+namespace sofa::simulation {
+    class Node;
+    typedef sofa::core::sptr<Node> NodeSPtr;
+}
 
 namespace sofa
 {
@@ -109,16 +114,16 @@ public:
     virtual void dumpState( Node* root, std::ofstream& out );
 
     /// Load a scene from a file
-    virtual Node::SPtr load(const std::string& /* filename */, bool reload = false, const std::vector<std::string>& sceneArgs = std::vector<std::string>(0));
+    virtual NodeSPtr load(const std::string& /* filename */, bool reload = false, const std::vector<std::string>& sceneArgs = std::vector<std::string>(0));
 
     /// Unload a scene from a Node.
-    virtual void unload(Node::SPtr root);
+    virtual void unload(NodeSPtr root);
 
     /// create a new graph(or tree) and return its root node.
-    virtual Node::SPtr createNewGraph(const std::string& name)=0;//Todo replace newNode method
+    virtual NodeSPtr createNewGraph(const std::string& name)=0;//Todo replace newNode method
 
     /// creates and returns a new node.
-    virtual Node::SPtr createNewNode(const std::string& name)=0;
+    virtual NodeSPtr createNewNode(const std::string& name)=0;
 
     /// @warning this singleton has one limitation: it is easy to create several types of
     /// simulations at the same time (e.g. DAGSimulation + TreeSimulation)

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/SolveVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/SolveVisitor.cpp
@@ -21,8 +21,8 @@
 ******************************************************************************/
 #include <sofa/simulation/SolveVisitor.h>
 #include <sofa/core/behavior/BaseMechanicalState.h>
-
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/UpdateInternalDataVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/UpdateInternalDataVisitor.cpp
@@ -20,7 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/simulation/UpdateInternalDataVisitor.h>
-
+#include <sofa/simulation/Node.h>
 namespace sofa
 {
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/UpdateInternalDataVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/UpdateInternalDataVisitor.h
@@ -24,7 +24,7 @@
 
 #include <sofa/core/ExecParams.h>
 #include <sofa/simulation/Visitor.h>
-#include <sofa/simulation/Node.h>
+#include <sofa/simulation/fwd.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/UpdateMappingVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/UpdateMappingVisitor.cpp
@@ -22,6 +22,7 @@
 #include <sofa/simulation/UpdateMappingVisitor.h>
 #include <sofa/core/VecId.h>
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/VelocityThresholdVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/VelocityThresholdVisitor.cpp
@@ -24,6 +24,7 @@
 
 #include <sofa/simulation/VelocityThresholdVisitor.h>
 #include <sofa/core/behavior/BaseMechanicalState.h>
+#include <sofa/simulation/Node.h>
 #include <iostream>
 
 namespace sofa

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Visitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Visitor.h
@@ -23,18 +23,14 @@
 #define SOFA_SIMULATION_VISITOR_H
 
 #include <sofa/simulation/config.h>
-#include <sofa/simulation/Node.h>
-#include <sofa/simulation/LocalStorage.h>
-
-#include <sofa/core/behavior/BaseMechanicalState.h>
-#include <sofa/core/ExecParams.h>
-
-#include <sofa/helper/set.h>
-#include <iostream>
-
+#include <sofa/helper/system/thread/CTime.h>
 #ifdef SOFA_DUMP_VISITOR_INFO
 #include <sofa/helper/system/thread/CTime.h>
 #endif
+
+namespace sofa::simulation { class Node; }
+namespace sofa::core { class ExecParams; }
+namespace sofa::core::behavior { class BaseMechanicalState; }
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Visitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Visitor.h
@@ -22,6 +22,8 @@
 #ifndef SOFA_SIMULATION_VISITOR_H
 #define SOFA_SIMULATION_VISITOR_H
 
+#include <string>
+#include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/simulation/config.h>
 #include <sofa/helper/system/thread/CTime.h>
 #ifdef SOFA_DUMP_VISITOR_INFO

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/VisitorScheduler.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/VisitorScheduler.h
@@ -22,9 +22,9 @@
 #ifndef SOFA_SIMULATION_VISITORSCHEDULER_H
 #define SOFA_SIMULATION_VISITORSCHEDULER_H
 
-#include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/simulation/config.h>
-#include "ClassSystem.h"
+#include <sofa/core/objectmodel/BaseObject.h>
+#include <sofa/simulation/fwd.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/VisualVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/VisualVisitor.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/simulation/VisualVisitor.h>
+#include <sofa/simulation/Node.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/AdvancedTimer.h>
 
@@ -34,6 +35,13 @@ namespace sofa
 
 namespace simulation
 {
+
+Visitor::Result VisualVisitor::processNodeTopDown(simulation::Node* node)
+{
+    for_each(this, node, node->object, &VisualVisitor::processObject);
+    for_each(this, node, node->visualModel, &VisualVisitor::processVisualModel);
+    return RESULT_CONTINUE;
+}
 
 
 Visitor::Result VisualDrawVisitor::processNodeTopDown(simulation::Node* node)
@@ -160,6 +168,16 @@ VisualComputeBBoxVisitor::VisualComputeBBoxVisitor(const core::ExecParams* param
     minBBox[0] = minBBox[1] = minBBox[2] = 1e10;
     maxBBox[0] = maxBBox[1] = maxBBox[2] = -1e10;
 }
+
+Visitor::Result VisualComputeBBoxVisitor::processNodeTopDown(simulation::Node* node)
+{
+    for_each(this, node, node->behaviorModel,  &VisualComputeBBoxVisitor::processBehaviorModel);
+    for_each(this, node, node->mechanicalState, &VisualComputeBBoxVisitor::processMechanicalState);
+    for_each(this, node, node->visualModel,     &VisualComputeBBoxVisitor::processVisualModel);
+
+    return RESULT_CONTINUE;
+}
+
 
 void VisualComputeBBoxVisitor::processMechanicalState(simulation::Node*, core::behavior::BaseMechanicalState* vm)
 {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/VisualVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/VisualVisitor.h
@@ -24,7 +24,6 @@
 
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/ExecParams.h>
-#include <sofa/simulation/Node.h>
 #include <sofa/simulation/Visitor.h>
 #include <sofa/core/visual/VisualModel.h>
 #include <iostream>
@@ -58,12 +57,7 @@ public:
     virtual void processVisualModel(simulation::Node* node, core::visual::VisualModel* vm) = 0;
     virtual void processObject(simulation::Node* /*node*/, core::objectmodel::BaseObject* /*o*/) {}
 
-    Result processNodeTopDown(simulation::Node* node) override
-    {
-        for_each(this, node, node->object, &VisualVisitor::processObject);
-        for_each(this, node, node->visualModel, &VisualVisitor::processVisualModel);
-        return RESULT_CONTINUE;
-    }
+    Result processNodeTopDown(simulation::Node* node) override;
 
     /// Return a category name for this action.
     /// Only used for debugging / profiling purposes
@@ -131,14 +125,7 @@ public:
     virtual void processMechanicalState(simulation::Node*, core::behavior::BaseMechanicalState* vm);
     virtual void processVisualModel(simulation::Node*, core::visual::VisualModel* vm);
 
-    Result processNodeTopDown(simulation::Node* node) override
-    {
-        for_each(this, node, node->behaviorModel,  &VisualComputeBBoxVisitor::processBehaviorModel);
-        for_each(this, node, node->mechanicalState, &VisualComputeBBoxVisitor::processMechanicalState);
-        for_each(this, node, node->visualModel,     &VisualComputeBBoxVisitor::processVisualModel);
-
-        return RESULT_CONTINUE;
-    }
+    Result processNodeTopDown(simulation::Node* node) override;
     const char* getClassName() const override { return "VisualComputeBBoxVisitor"; }
 };
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/WriteStateVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/WriteStateVisitor.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #include <sofa/simulation/WriteStateVisitor.h>
 #include <sofa/defaulttype/Vec.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/fwd.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/fwd.cpp
@@ -1,0 +1,32 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/simulation/fwd.h>
+#include <sofa/simulation/Node.h>
+#include <sofa/core/objectmodel/BaseContext.h>
+
+namespace sofa::simulation
+{
+    sofa::simulation::Node* getNodeFromContext(sofa::core::objectmodel::BaseContext* context)
+    {
+        return dynamic_cast<sofa::simulation::Node*>(context);
+    }
+}

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/fwd.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/fwd.cpp
@@ -29,4 +29,9 @@ namespace sofa::simulation
     {
         return dynamic_cast<sofa::simulation::Node*>(context);
     }
+
+    sofa::core::objectmodel::BaseContext* getContextFromNode(sofa::simulation::Node* node)
+    {
+        return static_cast<sofa::simulation::Node*>(node);
+    }
 }

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/fwd.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/fwd.h
@@ -39,4 +39,5 @@ namespace sofa::simulation
     class Visitor;
 
     SOFA_SIMULATION_CORE_API Node* getNodeFromContext(sofa::core::objectmodel::BaseContext*);
+    SOFA_SIMULATION_CORE_API sofa::core::objectmodel::BaseContext* getContextFromNode(Node*);
 }

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/fwd.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/fwd.h
@@ -38,5 +38,5 @@ namespace sofa::simulation
     class MutationListener;
     class Visitor;
 
-    Node* SOFA_SIMULATION_CORE_API getNodeFromContext(sofa::core::objectmodel::BaseContext*);
+    SOFA_SIMULATION_CORE_API Node* getNodeFromContext(sofa::core::objectmodel::BaseContext*);
 }

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/fwd.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/fwd.h
@@ -21,7 +21,9 @@
 ******************************************************************************/
 #pragma once
 
+#include <sofa/simulation/config.h>
 #include <sofa/core/sptr.h>
+
 namespace sofa::core::objectmodel { class BaseContext; }
 
 namespace sofa::simulation
@@ -36,5 +38,5 @@ namespace sofa::simulation
     class MutationListener;
     class Visitor;
 
-    Node* getNodeFromContext(sofa::core::objectmodel::BaseContext*);
+    Node* SOFA_SIMULATION_CORE_API getNodeFromContext(sofa::core::objectmodel::BaseContext*);
 }

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/fwd.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/fwd.h
@@ -1,0 +1,40 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/core/sptr.h>
+namespace sofa::core::objectmodel { class BaseContext; }
+
+namespace sofa::simulation
+{
+    class Node;
+    typedef sofa::core::sptr<Node> NodeSPtr;
+
+    class Simulation;
+    typedef sofa::core::sptr<Simulation> SimulationSPtr;
+
+    class LocalStorage;
+    class MutationListener;
+    class Visitor;
+
+    Node* getNodeFromContext(sofa::core::objectmodel::BaseContext*);
+}

--- a/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/DAGSimulation.h
+++ b/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/DAGSimulation.h
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 #include <sofa/simulation/Simulation.h>
+#include <sofa/simulation/Node.h>
 #include <SofaSimulationGraph/config.h>
 #include <memory>
 

--- a/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/DAGSimulation.h
+++ b/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/DAGSimulation.h
@@ -21,8 +21,8 @@
 ******************************************************************************/
 #pragma once
 #include <sofa/simulation/Simulation.h>
-#include <sofa/simulation/Node.h>
 #include <SofaSimulationGraph/config.h>
+#include <sofa/simulation/fwd.h>
 #include <memory>
 
 
@@ -43,10 +43,10 @@ public:
     ~DAGSimulation() override; // this is a terminal class
 
     /// create a new graph(or tree) and return its root node.
-    virtual Node::SPtr createNewGraph(const std::string& name) override;
+    virtual NodeSPtr createNewGraph(const std::string& name) override;
 
     /// creates and returns a new node.
-    virtual Node::SPtr createNewNode(const std::string& name) override;
+    virtual NodeSPtr createNewNode(const std::string& name) override;
 
     /// Can the simulation handle a directed acyclic graph?
     bool isDirectedAcyclicGraph() override { return true; }

--- a/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/SimpleApi.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/SimpleApi.cpp
@@ -19,6 +19,8 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <sofa/simulation/Node.h>
+
 #include <sofa/core/ObjectFactory.h>
 using sofa::core::ObjectFactory ;
 

--- a/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/SimpleApi.h
+++ b/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/SimpleApi.h
@@ -26,8 +26,8 @@
 #include <sstream>
 #include <map>
 
-#include <sofa/simulation/Node.h>
 #include <sofa/simulation/Simulation.h>
+#include <sofa/simulation/fwd.h>
 
 namespace sofa::simpleapi
 {
@@ -37,34 +37,35 @@ using sofa::core::objectmodel::BaseObjectDescription;
 
 using sofa::simulation::Simulation ;
 using sofa::simulation::Node ;
+using sofa::simulation::NodeSPtr ;
 
 bool SOFA_SOFASIMULATIONGRAPH_API importPlugin(const std::string& name) ;
 
 Simulation::SPtr SOFA_SOFASIMULATIONGRAPH_API createSimulation(const std::string& type="DAG") ;
 
-Node::SPtr SOFA_SOFASIMULATIONGRAPH_API createRootNode( Simulation::SPtr, const std::string& name,
+NodeSPtr SOFA_SOFASIMULATIONGRAPH_API createRootNode( Simulation::SPtr, const std::string& name,
     const std::map<std::string, std::string>& params = std::map<std::string, std::string>{} );
 
 ///@brief Create a sofa object in the provided node.
 ///The parameter "params" is for passing specific data argument to the created object including the
 ///object's type.
-BaseObject::SPtr SOFA_SOFASIMULATIONGRAPH_API createObject(Node::SPtr node, BaseObjectDescription& params);
+BaseObject::SPtr SOFA_SOFASIMULATIONGRAPH_API createObject(NodeSPtr node, BaseObjectDescription& params);
 
 ///@brief create a sofa object in the provided node of the given type.
 ///The parameter "params" is for passing specific data argument to the created object.
-BaseObject::SPtr SOFA_SOFASIMULATIONGRAPH_API createObject( Node::SPtr node, const std::string& type,
+BaseObject::SPtr SOFA_SOFASIMULATIONGRAPH_API createObject( NodeSPtr node, const std::string& type,
     const std::map<std::string, std::string>& params = std::map<std::string, std::string>{} );
 
 ///@brief create a child to the provided nodeof given name.
 ///The parameter "params" is for passing specific data argument to the created object.
-Node::SPtr SOFA_SOFASIMULATIONGRAPH_API createChild( Node::SPtr& node, const std::string& name,
+NodeSPtr SOFA_SOFASIMULATIONGRAPH_API createChild( NodeSPtr& node, const std::string& name,
     const std::map<std::string, std::string>& params = std::map<std::string, std::string>{} );
 
 ///@brief create a child to the provided node.
 ///The parameter "params" is for passing specific data argument to the created object (including the node name).
-Node::SPtr SOFA_SOFASIMULATIONGRAPH_API createChild(Node::SPtr node, BaseObjectDescription& desc);
+NodeSPtr SOFA_SOFASIMULATIONGRAPH_API createChild(NodeSPtr node, BaseObjectDescription& desc);
 
-void SOFA_SOFASIMULATIONGRAPH_API dumpScene(Node::SPtr root) ;
+void SOFA_SOFASIMULATIONGRAPH_API dumpScene(NodeSPtr root) ;
 
 template<class T>
 std::string str(const T& t)

--- a/applications/plugins/Compliant/assembly/AssemblyHelper.h
+++ b/applications/plugins/Compliant/assembly/AssemblyHelper.h
@@ -1,11 +1,10 @@
 #include <SofaEigen2Solver/EigenSparseMatrix.h>
 #include <sofa/helper/AdvancedTimer.h>
 #include <sofa/simulation/MechanicalVisitor.h>
-
+#include <sofa/simulation/Node.h>
 #include "../utils/sparse.h"
 
 #include <Compliant/config.h>
-
 #include <sofa/helper/logging/Messaging.h>
 #include <sofa/helper/OwnershipSPtr.h>
 

--- a/applications/plugins/Compliant/assembly/AssemblyVisitor.cpp
+++ b/applications/plugins/Compliant/assembly/AssemblyVisitor.cpp
@@ -3,6 +3,7 @@
 
 #include <SofaBaseLinearSolver/SingleMatrixAccessor.h>
 #include <SofaBaseLinearSolver/DefaultMultiMatrixAccessor.h>
+#include <sofa/simulation/Node.h>
 
 #include <sofa/helper/cast.h>
 #include "../utils/scoped.h"

--- a/applications/plugins/Compliant/contact/BaseContact.h
+++ b/applications/plugins/Compliant/contact/BaseContact.h
@@ -7,13 +7,11 @@
 #include <SofaBaseCollision/BaseContactMapper.h>
 
 #include <Compliant/config.h>
-
+#include <sofa/simulation/Node.h>
 #include "../mapping/DifferenceMapping.h"
 
 #include "../constraint/Restitution.h"
 #include "../constraint/HolonomicConstraintValue.h"
-
-//#include <sofa/simulation/DeactivatedNodeVisitor.h>
 
 #include <sofa/helper/cast.h>
 
@@ -257,7 +255,7 @@ protected:
 
     // the node that will hold all the stuff
     typedef sofa::simulation::Node node_type;
-    node_type::SPtr delta_node;
+    sofa::core::sptr<node_type> delta_node;
 
     // TODO correct real type
     typedef container::MechanicalObject<ResponseDataTypes> delta_dofs_type;

--- a/applications/plugins/Compliant/controller/CompliantSleepController.cpp
+++ b/applications/plugins/Compliant/controller/CompliantSleepController.cpp
@@ -1,5 +1,5 @@
 #include "CompliantSleepController.h"
-
+#include <sofa/simulation/Node.h>
 #include <sofa/core/ObjectFactory.h>
 #include "../compliance/DiagonalCompliance.h"
 #include "../compliance/UniformCompliance.h"

--- a/applications/plugins/Compliant/misc/RigidMass.h
+++ b/applications/plugins/Compliant/misc/RigidMass.h
@@ -3,7 +3,7 @@
 
 #include <sofa/core/behavior/Mass.h>
 #include <sofa/core/behavior/MechanicalState.h>
-
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include "../utils/se3.h"
 #include "../utils/map.h"
 

--- a/applications/plugins/Compliant/odesolver/CompliantStaticSolver.cpp
+++ b/applications/plugins/Compliant/odesolver/CompliantStaticSolver.cpp
@@ -1,5 +1,5 @@
 #include "CompliantStaticSolver.h"
-
+#include <sofa/simulation/Node.h>
 #include <sofa/core/ObjectFactory.h>
 
 #include <boost/math/tools/minima.hpp>

--- a/applications/plugins/Flexible/deformationMapping/BaseDeformationMapping.h
+++ b/applications/plugins/Flexible/deformationMapping/BaseDeformationMapping.h
@@ -32,7 +32,6 @@
 
 #include "../shapeFunction/BaseShapeFunction.h"
 #include "../quadrature/BaseGaussPointSampler.h"
-#include <SofaBaseTopology/TopologyData.inl>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <SofaBaseMechanics/MechanicalObject.h>
 #include <sofa/core/visual/VisualParams.h>

--- a/applications/plugins/Flexible/mass/ImageDensityMass.inl
+++ b/applications/plugins/Flexible/mass/ImageDensityMass.inl
@@ -6,6 +6,7 @@
 
 #include "../shapeFunction/BaseShapeFunction.h"
 
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/defaulttype/DataTypeInfo.h>
 #include <sofa/helper/gl/template.h>

--- a/applications/plugins/LMConstraint/src/LMConstraint/LMConstraintSolver.cpp
+++ b/applications/plugins/LMConstraint/src/LMConstraint/LMConstraintSolver.cpp
@@ -26,6 +26,7 @@
 #include <SofaBaseLinearSolver/FullMatrix.h>
 #include <SofaBaseLinearSolver/FullVector.h>
 #include <sofa/simulation/AnimateBeginEvent.h>
+#include <sofa/simulation/Node.h>
 
 #include <sofa/defaulttype/Quat.h>
 

--- a/applications/plugins/Registration/ClosestPointRegistrationForceField.inl
+++ b/applications/plugins/Registration/ClosestPointRegistrationForceField.inl
@@ -28,6 +28,7 @@
 #include <sofa/core/objectmodel/BaseContext.h>
 #include <sofa/simulation/Simulation.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <iostream>
 #include <map>
 

--- a/applications/plugins/Registration/IntensityProfileRegistrationForceField.inl
+++ b/applications/plugins/Registration/IntensityProfileRegistrationForceField.inl
@@ -26,6 +26,7 @@
 #include "IntensityProfileRegistrationForceField.h"
 #include <sofa/core/objectmodel/BaseContext.h>
 #include <sofa/simulation/Simulation.h>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <iostream>
 #include <cfloat>

--- a/applications/plugins/SceneCreator/src/SceneCreator/GetAssembledSizeVisitor.cpp
+++ b/applications/plugins/SceneCreator/src/SceneCreator/GetAssembledSizeVisitor.cpp
@@ -31,6 +31,7 @@
 //
 #include "GetAssembledSizeVisitor.h"
 #include <sofa/defaulttype/Vec.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/applications/plugins/SceneCreator/src/SceneCreator/GetAssembledSizeVisitor.h
+++ b/applications/plugins/SceneCreator/src/SceneCreator/GetAssembledSizeVisitor.h
@@ -39,7 +39,7 @@
 #include <sofa/simulation/Visitor.h>
 #include <sofa/core/MultiVecId.h>
 #include <sofa/defaulttype/BaseVector.h>
-
+#include <sofa/core/MechanicalParams.h>
 
 namespace sofa
 {

--- a/applications/plugins/SceneCreator/src/SceneCreator/GetVectorVisitor.cpp
+++ b/applications/plugins/SceneCreator/src/SceneCreator/GetVectorVisitor.cpp
@@ -31,6 +31,7 @@
 //
 #include "GetVectorVisitor.h"
 #include <sofa/defaulttype/Vec.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaVisualModel.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaVisualModel.h
@@ -25,6 +25,7 @@
 #include <sofa/core/visual/VisualModel.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/core/State.h>
+#include <sofa/core/topology/TopologyChange.h>
 #include "CudaTypes.h"
 
 namespace sofa

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/forcefield/DistanceGridForceField.h
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/forcefield/DistanceGridForceField.h
@@ -23,7 +23,7 @@
 #define SOFA_COMPONENT_INTERACTIONFORCEFIELD_DISTANCEGRIDFORCEFIELD_H
 #include <SofaDistanceGrid/config.h>
 #include <SofaDistanceGrid/DistanceGrid.h>
-
+#include <sofa/core/objectmodel/DataFileName.h>
 #include <sofa/core/behavior/ForceField.h>
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/objectmodel/Data.h>

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/forcefield/DistanceGridForceField.inl
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/forcefield/DistanceGridForceField.inl
@@ -26,6 +26,7 @@
 #include <sofa/simulation/Simulation.h>
 #include "DistanceGridForceField.h"
 #include <sofa/defaulttype/VecTypes.h>
+#include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/gl/template.h>
 #include <cassert>
 #include <iostream>

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/forcefield/DistanceGridForceField.inl
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/forcefield/DistanceGridForceField.inl
@@ -31,6 +31,7 @@
 #include <cassert>
 #include <iostream>
 
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 
 
 namespace sofa

--- a/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/RayTriangleVisitor.cpp
+++ b/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/RayTriangleVisitor.cpp
@@ -24,6 +24,7 @@
 #include <SofaMeshCollision/TriangleModel.h>
 #include <SofaBaseMechanics/MechanicalObject.h>
 #include <sofa/defaulttype/VecTypes.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/applications/plugins/SofaPython/PythonScriptEvent.h
+++ b/applications/plugins/SofaPython/PythonScriptEvent.h
@@ -26,7 +26,7 @@
 
 #include <SofaPython/config.h>
 #include <sofa/core/objectmodel/ScriptEvent.h>
-
+#include <sofa/simulation/Node.h>
 
 namespace sofa
 {

--- a/applications/plugins/SofaSimpleGUI/VisualPickVisitor.cpp
+++ b/applications/plugins/SofaSimpleGUI/VisualPickVisitor.cpp
@@ -5,7 +5,7 @@ using std::cerr;
 using std::endl;
 
 #include <sofa/helper/system/gl.h>
-
+#include <sofa/simulation/Node.h>
 namespace sofa
 {
 

--- a/applications/projects/SofaPhysicsAPI/SofaPhysicsSimulation.h
+++ b/applications/projects/SofaPhysicsAPI/SofaPhysicsSimulation.h
@@ -32,6 +32,7 @@
 #include <sofa/core/visual/DrawToolGL.h>
 #include <SofaBaseVisual/InteractiveCamera.h>
 #include <sofa/helper/gl/Texture.h>
+#include <sofa/simulation/Node.h>
 
 #include <map>
 

--- a/applications/projects/SofaPhysicsAPI/fakegui.h
+++ b/applications/projects/SofaPhysicsAPI/fakegui.h
@@ -23,6 +23,7 @@
 #define FAKEGUI_H
 
 #include <sofa/gui/BaseGUI.h>
+#include <sofa/simulation/Node.h>
 
 /// this fake GUI is only meant to manage "sendMessage" from python scripts
 class FakeGUI : public sofa::gui::BaseGUI

--- a/applications/tutorials/oneTetrahedron/oneTetrahedron.cpp
+++ b/applications/tutorials/oneTetrahedron/oneTetrahedron.cpp
@@ -32,6 +32,7 @@ using VecCoord3 = sofa::helper::vector<Coord3>;
 #include <sofa/gui/Main.h>
 #include <sofa/helper/ArgumentParser.h>
 #include <sofa/helper/system/FileRepository.h>
+#include <sofa/simulation/Node.h>
 
 #include <SofaBase/initSofaBase.h>
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.inl
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #pragma once
 
-
+#include <sofa/simulation/Node.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <SofaBaseTopology/TopologySubsetData.inl>
 #include <sofa/simulation/Simulation.h>

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.inl
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <SofaBoundaryCondition/FixedConstraint.h>
 #include <SofaBaseLinearSolver/SparseMatrix.h>

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedPlaneConstraint.inl
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <SofaBoundaryCondition/FixedPlaneConstraint.h>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/defaulttype/RigidTypes.h>

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialFixedConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialFixedConstraint.inl
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <sofa/core/topology/BaseMeshTopology.h>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <SofaBoundaryCondition/PartialFixedConstraint.h>
 #include <sofa/simulation/Simulation.h>
 #include <sofa/defaulttype/RigidTypes.h>

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <SofaBoundaryCondition/PartialLinearMovementConstraint.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/core/visual/VisualParams.h>

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PatchTestMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PatchTestMovementConstraint.inl
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 
+#include <sofa/simulation/Node.h>
 #include "PatchTestMovementConstraint.h"
 #include <sofa/core/visual/VisualParams.h>
 #include <SofaBaseTopology/TopologySubsetData.inl>

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PlaneForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PlaneForceField.inl
@@ -30,6 +30,7 @@
 #include <iostream>
 #include <sofa/defaulttype/BoundingBox.h>
 #include <limits>
+#include <sofa/simulation/Node.h>
 
 namespace sofa::component::forcefield
 {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SkeletalMotionConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SkeletalMotionConstraint.inl
@@ -27,7 +27,7 @@
 #include <sofa/simulation/Simulation.h>
 #include <sofa/defaulttype/RigidTypes.h>
 #include <SofaBaseTopology/TopologySubsetData.inl>
-
+#include <sofa/defaulttype/BaseMatrix.h>
 #include <iostream>
 
 namespace sofa::component::projectiveconstraintset

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SphereForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SphereForceField.inl
@@ -26,6 +26,7 @@
 #include <sofa/helper/rmath.h>
 #include <cassert>
 #include <iostream>
+#include <sofa/defaulttype/BaseMatrix.h>
 
 namespace sofa::component::forcefield
 {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SurfacePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SurfacePressureForceField.inl
@@ -21,8 +21,10 @@
 ******************************************************************************/
 #pragma once
 
+
 #include <SofaBoundaryCondition/SurfacePressureForceField.h>
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/helper/types/RGBAColor.h>
 #include <vector>

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/UniformVelocityDampingForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/UniformVelocityDampingForceField.inl
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "UniformVelocityDampingForceField.h"
+#include <sofa/defaulttype/BaseMatrix.h>
 
 namespace sofa::component::forcefield
 {

--- a/modules/SofaConstraint/src/SofaConstraint/ConstraintAnimationLoop.h
+++ b/modules/SofaConstraint/src/SofaConstraint/ConstraintAnimationLoop.h
@@ -27,7 +27,7 @@
 #include <sofa/core/VecId.h>
 #include <sofa/core/behavior/BaseConstraintCorrection.h>
 #include <sofa/core/behavior/OdeSolver.h>
-
+#include <sofa/core/behavior/BaseConstraint.h>
 #include <SofaBaseLinearSolver/FullMatrix.h>
 
 #include <sofa/simulation/CollisionAnimationLoop.h>

--- a/modules/SofaConstraint/src/SofaConstraint/ConstraintAttachBodyPerformer.inl
+++ b/modules/SofaConstraint/src/SofaConstraint/ConstraintAttachBodyPerformer.inl
@@ -23,7 +23,8 @@
 #include <SofaConstraint/ConstraintAttachBodyPerformer.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <SofaUserInteraction/MouseInteractor.h>
-
+#include <sofa/core/BaseMapping.h>
+#include <sofa/simulation/Node.h>
 namespace sofa::component::collision
 {
 

--- a/modules/SofaConstraint/src/SofaConstraint/ConstraintStoreLambdaVisitor.cpp
+++ b/modules/SofaConstraint/src/SofaConstraint/ConstraintStoreLambdaVisitor.cpp
@@ -19,6 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <sofa/core/behavior/BaseConstraint.h>
 #include <SofaConstraint/ConstraintStoreLambdaVisitor.h>
 
 namespace sofa::simulation

--- a/modules/SofaConstraint/src/SofaConstraint/GenericConstraintSolver.cpp
+++ b/modules/SofaConstraint/src/SofaConstraint/GenericConstraintSolver.cpp
@@ -25,8 +25,11 @@
 #include <sofa/simulation/VectorOperations.h>
 #include <sofa/helper/AdvancedTimer.h>
 #include <sofa/core/ObjectFactory.h>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <SofaConstraint/ConstraintStoreLambdaVisitor.h>
 #include <algorithm>
+#include <sofa/core/behavior/MultiVec.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa::component::constraintset
 {

--- a/modules/SofaConstraint/src/SofaConstraint/GenericConstraintSolver.h
+++ b/modules/SofaConstraint/src/SofaConstraint/GenericConstraintSolver.h
@@ -24,6 +24,7 @@
 
 #include <SofaConstraint/ConstraintSolverImpl.h>
 #include <sofa/core/behavior/BaseConstraintCorrection.h>
+#include <sofa/core/behavior/BaseConstraint.h>
 #include <SofaBaseLinearSolver/SparseMatrix.h>
 
 namespace sofa::component::constraintset

--- a/modules/SofaConstraint/src/SofaConstraint/LCPConstraintSolver.cpp
+++ b/modules/SofaConstraint/src/SofaConstraint/LCPConstraintSolver.cpp
@@ -285,7 +285,7 @@ void LCPConstraintSolver::init()
     for (unsigned int i = 0; i < constraintCorrections.size(); i++)
         constraintCorrections[i]->addConstraintSolver(this);
 
-    context = (simulation::Node*) getContext();
+    context = getContext();
 }
 
 void LCPConstraintSolver::cleanup()

--- a/modules/SofaConstraint/src/SofaConstraint/LCPConstraintSolver.h
+++ b/modules/SofaConstraint/src/SofaConstraint/LCPConstraintSolver.h
@@ -24,6 +24,7 @@
 
 #include <SofaConstraint/ConstraintSolverImpl.h>
 #include <sofa/core/behavior/BaseConstraintCorrection.h>
+#include <sofa/core/behavior/BaseConstraint.h>
 
 #include <sofa/simulation/Node.h>
 #include <sofa/simulation/MechanicalVisitor.h>

--- a/modules/SofaConstraint/src/SofaConstraint/LCPConstraintSolver.h
+++ b/modules/SofaConstraint/src/SofaConstraint/LCPConstraintSolver.h
@@ -26,8 +26,8 @@
 #include <sofa/core/behavior/BaseConstraintCorrection.h>
 #include <sofa/core/behavior/BaseConstraint.h>
 
-#include <sofa/simulation/Node.h>
 #include <sofa/simulation/MechanicalVisitor.h>
+#include <sofa/simulation/fwd.h>
 
 #include <SofaBaseLinearSolver/FullMatrix.h>
 #include <SofaBaseLinearSolver/SparseMatrix.h>
@@ -197,7 +197,7 @@ public:
 
 
     /// common built-unbuilt
-    simulation::Node *context;
+    sofa::core::objectmodel::BaseContext *context;
     sofa::component::linearsolver::FullVector<double> *_dFree, *_result;
     ///
     sofa::helper::system::thread::CTime timer;

--- a/modules/SofaConstraint/src/SofaConstraint/PrecomputedConstraintCorrection.inl
+++ b/modules/SofaConstraint/src/SofaConstraint/PrecomputedConstraintCorrection.inl
@@ -39,7 +39,7 @@
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/Quater.h>
 
-#include <sofa/simulation/Node.h>
+#include <sofa/simulation/fwd.h>
 
 #include <fstream>
 #include <sstream>

--- a/modules/SofaExporter/SofaExporter_test/WriteState_test.cpp
+++ b/modules/SofaExporter/SofaExporter_test/WriteState_test.cpp
@@ -35,7 +35,7 @@ using sofa::helper::testing::BaseTest;
 #include <SofaBaseMechanics/MechanicalObject.h>
 #include <SofaBaseMechanics/UniformMass.h>
 #include <SofaExporter/WriteState.h>
-
+#include <sofa/simulation/Node.h>
 #include <SofaBase/initSofaBase.h>
 
 namespace sofa {

--- a/modules/SofaExporter/src/SofaExporter/WriteState.h
+++ b/modules/SofaExporter/src/SofaExporter/WriteState.h
@@ -31,6 +31,7 @@
 #include <sofa/simulation/AnimateEndEvent.h>
 #include <sofa/defaulttype/DataTypeInfo.h>
 #include <sofa/simulation/Visitor.h>
+#include <sofa/core/objectmodel/DataFileName.h>
 
 #if SOFAEXPORTER_HAVE_ZLIB
 #include <zlib.h>

--- a/modules/SofaGeneralAnimationLoop/src/SofaGeneralAnimationLoop/MechanicalMatrixMapper.inl
+++ b/modules/SofaGeneralAnimationLoop/src/SofaGeneralAnimationLoop/MechanicalMatrixMapper.inl
@@ -37,6 +37,9 @@
 //  Eigen Sparse Matrix
 #include <Eigen/Sparse>
 
+#include <sofa/simulation/Node.h>
+
+
 namespace sofa::component::interactionforcefield
 {
 

--- a/modules/SofaGeneralLoader/src/SofaGeneralLoader/ReadState.cpp
+++ b/modules/SofaGeneralLoader/src/SofaGeneralLoader/ReadState.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #include <SofaGeneralLoader/ReadState.inl>
 #include <sofa/core/ObjectFactory.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa::component::misc
 {

--- a/modules/SofaGeneralLoader/src/SofaGeneralLoader/ReadState.h
+++ b/modules/SofaGeneralLoader/src/SofaGeneralLoader/ReadState.h
@@ -25,6 +25,7 @@
 #include <sofa/simulation/AnimateBeginEvent.h>
 #include <sofa/simulation/AnimateEndEvent.h>
 #include <sofa/simulation/Visitor.h>
+#include <sofa/core/objectmodel/DataFileName.h>
 
 #if SOFAGENERALLOADER_HAVE_ZLIB
 #include <zlib.h>

--- a/modules/SofaGeneralLoader/src/SofaGeneralLoader/ReadTopology.cpp
+++ b/modules/SofaGeneralLoader/src/SofaGeneralLoader/ReadTopology.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #include <SofaGeneralLoader/ReadTopology.inl>
 #include <sofa/core/ObjectFactory.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa::component::misc
 {

--- a/modules/SofaGeneralLoader/src/SofaGeneralLoader/ReadTopology.h
+++ b/modules/SofaGeneralLoader/src/SofaGeneralLoader/ReadTopology.h
@@ -30,6 +30,8 @@
 #include <zlib.h>
 #endif
 
+#include <sofa/core/topology/BaseMeshTopology.h>
+#include <sofa/core/objectmodel/DataFileName.h>
 #include <fstream>
 
 namespace sofa::component::misc

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/HexahedralFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/HexahedralFEMForceField.inl
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 #include "HexahedralFEMForceField.h"
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/types/RGBAColor.h>
 #include <sofa/helper/decompose.h>

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/HexahedralFEMForceFieldAndMass.inl
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/HexahedralFEMForceFieldAndMass.inl
@@ -22,6 +22,7 @@
 #pragma once
 #include "HexahedralFEMForceFieldAndMass.h"
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 
 #include <SofaBaseTopology/TopologyData.inl>
 

--- a/modules/SofaGraphComponent/src/SofaGraphComponent/PauseAnimation.cpp
+++ b/modules/SofaGraphComponent/src/SofaGraphComponent/PauseAnimation.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #include <SofaGraphComponent/PauseAnimation.h>
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa::component::misc
 {

--- a/modules/SofaGraphComponent/src/SofaGraphComponent/SceneCheckMissingRequiredPlugin.cpp
+++ b/modules/SofaGraphComponent/src/SofaGraphComponent/SceneCheckMissingRequiredPlugin.cpp
@@ -27,6 +27,7 @@
 #include <sofa/helper/system/PluginManager.h>
 
 #include <SofaBaseUtils/RequiredPlugin.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa::simulation::_scenechecking_
 {

--- a/modules/SofaGraphComponent/src/SofaGraphComponent/SceneCheckerVisitor.cpp
+++ b/modules/SofaGraphComponent/src/SofaGraphComponent/SceneCheckerVisitor.cpp
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <sofa/version.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa::simulation::_scenechecking_
 {

--- a/modules/SofaGuiCommon/src/sofa/gui/BaseGUI.h
+++ b/modules/SofaGuiCommon/src/sofa/gui/BaseGUI.h
@@ -23,11 +23,11 @@
 #define SOFA_GUI_BASEGUI_H
 
 #include <sofa/gui/config.h>
-#include <sofa/simulation/Node.h>
 #include <sofa/defaulttype/Vec.h>
 #include <SofaGraphComponent/ViewerSetting.h>
 #include <SofaGraphComponent/MouseButtonSetting.h>
 #include <sofa/helper/ArgumentParser.h>
+#include <sofa/simulation/fwd.h>
 using sofa::helper::ArgumentParser;
 
 #include <list>
@@ -55,13 +55,13 @@ public:
     /// Close the GUI
     virtual int closeGUI()=0;
     /// Register the scene in our GUI
-    virtual void setScene(sofa::simulation::Node::SPtr groot, const char* filename=nullptr, bool temporaryFile=false)=0;
+    virtual void setScene(sofa::simulation::NodeSPtr groot, const char* filename=nullptr, bool temporaryFile=false)=0;
     /// Get the rootNode of the sofa scene
     virtual sofa::simulation::Node* currentSimulation() = 0;
     /// @}
 
     /// Use a component setting to configure our GUI
-    virtual void configureGUI(sofa::simulation::Node::SPtr groot);
+    virtual void configureGUI(sofa::simulation::NodeSPtr groot);
 
     /// @name methods to configure the GUI
     /// @{

--- a/modules/SofaGuiCommon/src/sofa/gui/BaseViewer.h
+++ b/modules/SofaGuiCommon/src/sofa/gui/BaseViewer.h
@@ -32,18 +32,12 @@
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/CollisionModel.h>
 
-
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/system/SetDirectory.h>
-
-//#include <sofa/helper/gl/Capture.h>
-//#include <sofa/helper/gl/Texture.h>
 
 #include <sofa/core/objectmodel/KeypressedEvent.h>
 #include <sofa/core/objectmodel/KeyreleasedEvent.h>
 #include <sofa/core/objectmodel/MouseEvent.h>
-#include <sofa/core/collision/Pipeline.h>
-
 #include <SofaGraphComponent/ViewerSetting.h>
 
 //instruments handling

--- a/modules/SofaGuiCommon/src/sofa/gui/ColourPickingVisitor.cpp
+++ b/modules/SofaGuiCommon/src/sofa/gui/ColourPickingVisitor.cpp
@@ -23,6 +23,7 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/core/objectmodel/BaseContext.h>
 #include <sofa/simulation/Simulation.h>
+#include <sofa/simulation/Node.h>
 #if SOFAGUICOMMON_HAVE_SOFA_GL
 #include <sofa/gl/gl.h>
 #include <sofa/gl/BasicShapes.h>

--- a/modules/SofaGuiCommon/src/sofa/gui/ColourPickingVisitor.h
+++ b/modules/SofaGuiCommon/src/sofa/gui/ColourPickingVisitor.h
@@ -23,7 +23,6 @@
 #define SOFA_GUI_COLOURPICKING_VISITOR
 
 #include <sofa/gui/config.h>
-#include <sofa/simulation/Node.h>
 #include <sofa/simulation/Visitor.h>
 #include <sofa/core/CollisionModel.h>
 #include <sofa/core/ExecParams.h>

--- a/modules/SofaGuiCommon/src/sofa/gui/GUIManager.cpp
+++ b/modules/SofaGuiCommon/src/sofa/gui/GUIManager.cpp
@@ -29,6 +29,7 @@
 #include <sofa/helper/Utils.h>
 #include <sofa/helper/logging/Messaging.h>
 #include <sofa/helper/system/FileRepository.h>
+#include <sofa/simulation/Node.h>
 
 using sofa::helper::system::FileSystem;
 using sofa::helper::Utils;

--- a/modules/SofaGuiCommon/src/sofa/gui/GUIManager.h
+++ b/modules/SofaGuiCommon/src/sofa/gui/GUIManager.h
@@ -23,7 +23,7 @@
 #define SOFA_GUI_GUIMANAGER_H
 
 #include <sofa/helper/ArgumentParser.h>
-#include <sofa/simulation/Node.h>
+#include <sofa/simulation/fwd.h>
 #include <sofa/gui/config.h>
 #include <vector>
 #include <string>
@@ -42,7 +42,7 @@ class BaseGUI;
 class SOFA_SOFAGUICOMMON_API GUIManager
 {
 public:
-    typedef BaseGUI* CreateGUIFn(const char* name, sofa::simulation::Node::SPtr groot, const char* filename);
+    typedef BaseGUI* CreateGUIFn(const char* name, sofa::simulation::NodeSPtr groot, const char* filename);
     typedef int RegisterGUIParameters(ArgumentParser* argumentParser);
 
     struct GUICreator
@@ -69,18 +69,18 @@ public:
     static std::vector<std::string> ListSupportedGUI();
     static std::string ListSupportedGUI(char separator);
     static void RegisterParameters(ArgumentParser* parser);
-    static int createGUI(sofa::simulation::Node::SPtr groot = nullptr, const char* filename = nullptr);
+    static int createGUI(sofa::simulation::NodeSPtr groot = nullptr, const char* filename = nullptr);
     static void closeGUI();
 
     /// @name Static methods for direct access to GUI
     /// @{
-    static int MainLoop(sofa::simulation::Node::SPtr groot = nullptr, const char* filename = nullptr);
+    static int MainLoop(sofa::simulation::NodeSPtr groot = nullptr, const char* filename = nullptr);
 
     static void Redraw();
 
     static sofa::simulation::Node* CurrentSimulation();
 
-    static void SetScene(sofa::simulation::Node::SPtr groot, const char* filename=nullptr, bool temporaryFile=false);
+    static void SetScene(sofa::simulation::NodeSPtr groot, const char* filename=nullptr, bool temporaryFile=false);
     static void SetDimension(int  width , int  height );
     static void SetFullScreen();
     static void SaveScreenshot(const char* filename);

--- a/modules/SofaGuiCommon/src/sofa/gui/PickHandler.h
+++ b/modules/SofaGuiCommon/src/sofa/gui/PickHandler.h
@@ -25,6 +25,7 @@
 #include <sofa/gui/config.h>
 #include "OperationFactory.h"
 
+#include <sofa/simulation/fwd.h>
 #include <sofa/gui/ColourPickingVisitor.h>
 #include <SofaBaseMechanics/MechanicalObject.h>
 
@@ -126,7 +127,7 @@ protected:
     MOUSE_BUTTON mouseButton;
 
 
-    Node::SPtr                mouseNode;
+    sofa::simulation::NodeSPtr     mouseNode;
     MouseContainer::SPtr      mouseContainer;
     MouseCollisionModel::SPtr mouseCollision;
 

--- a/modules/SofaGuiQt/src/sofa/gui/qt/DataWidget.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/DataWidget.cpp
@@ -25,6 +25,9 @@
 #include "ModifyObject.h"
 #include <sofa/helper/Factory.inl>
 #include <sofa/helper/logging/Messaging.h>
+#include <sofa/core/objectmodel/Base.h>
+#include <sofa/core/objectmodel/BaseNode.h>
+#include <sofa/core/objectmodel/BaseObject.h>
 
 #include <QToolTip>
 

--- a/modules/SofaGuiQt/src/sofa/gui/qt/DataWidget.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/DataWidget.h
@@ -26,10 +26,7 @@
 
 #include <sofa/gui/qt/config.h>
 #include "ModifyObject.h"
-#include <sofa/core/objectmodel/BaseData.h>
-#include <sofa/core/objectmodel/Base.h>
-#include <sofa/core/objectmodel/BaseNode.h>
-#include <sofa/core/objectmodel/BaseObject.h>
+#include <sofa/core/objectmodel/Data.h>
 #include <sofa/helper/Factory.h>
 #include <sofa/helper/system/FileRepository.h>
 

--- a/modules/SofaGuiQt/src/sofa/gui/qt/GenGraphForm.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/GenGraphForm.cpp
@@ -23,6 +23,7 @@
 
 #ifdef WIN32
 #include <windows.h>
+#include <shellapi.h>
 #endif
 
 #include <fstream>

--- a/modules/SofaGuiQt/src/sofa/gui/qt/GraphListenerQListView.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/GraphListenerQListView.cpp
@@ -26,6 +26,10 @@
 #include <sofa/core/collision/ContactManager.h>
 #include <sofa/core/objectmodel/ConfigurationSetting.h>
 #include <SofaBaseUtils/InfoComponent.h>
+#include <sofa/core/behavior/BaseInteractionForceField.h>
+#include <sofa/core/objectmodel/BaseNode.h>
+#include <sofa/simulation/Node.h>
+
 using sofa::component::InfoComponent ;
 
 #include "resources/icons/iconmultinode.xpm"

--- a/modules/SofaGuiQt/src/sofa/gui/qt/GraphListenerQListView.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/GraphListenerQListView.h
@@ -30,12 +30,8 @@
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
 
-
-#include <sofa/simulation/Node.h>
-#include <sofa/simulation/Simulation.h>
+#include <sofa/simulation/fwd.h>
 #include <sofa/simulation/MutationListener.h>
-
-
 
 namespace sofa
 {

--- a/modules/SofaGuiQt/src/sofa/gui/qt/ModifyObject.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/ModifyObject.cpp
@@ -668,6 +668,9 @@ QString ModifyObject::parseDataModified()
     return cat;
 }
 
+bool ModifyObject::hideData(core::objectmodel::BaseData* data) { return (!data->isDisplayed()) && dialogFlags_.HIDE_FLAG;}
+
+
 } // namespace qt
 
 } // namespace gui

--- a/modules/SofaGuiQt/src/sofa/gui/qt/ModifyObject.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/ModifyObject.h
@@ -23,8 +23,7 @@
 #define SOFA_GUI_QT_MODIFYOBJECT_H
 
 #include <sofa/gui/qt/config.h>
-#include <sofa/core/objectmodel/BaseObject.h>
-
+#include <sofa/core/fwd.h>
 #include <sofa/defaulttype/Vec.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/helper/fixed_array.h>
@@ -135,7 +134,7 @@ public:
 
     void createDialog(core::objectmodel::Base* node);
     void createDialog(core::objectmodel::BaseData* data);
-    bool hideData(core::objectmodel::BaseData* data) { return (!data->isDisplayed()) && dialogFlags_.HIDE_FLAG;}
+    bool hideData(core::objectmodel::BaseData* data);
     void readOnlyData(QTableWidget *widget, core::objectmodel::BaseData* data);
     void readOnlyData(QWidget *widget, core::objectmodel::BaseData* data);
 

--- a/modules/SofaGuiQt/src/sofa/gui/qt/ModifyObject.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/ModifyObject.h
@@ -28,7 +28,6 @@
 #include <sofa/defaulttype/Vec.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/helper/fixed_array.h>
-#include <sofa/simulation/Node.h>
 #include <sofa/gui/qt/WDoubleLineEdit.h>
 
 #include <QDialog>
@@ -48,6 +47,7 @@
 #include <QVBoxLayout>
 #include <QTextBrowser>
 
+#include <sofa/simulation/fwd.h>
 
 namespace sofa
 {

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QDisplayDataWidget.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QDisplayDataWidget.cpp
@@ -29,6 +29,7 @@
 #include <QGroupBox>
 #include <QLabel>
 #include <QValidator>
+#include <sofa/core/objectmodel/DataFileName.h>
 
 #define TEXTSIZE_THRESHOLD 45
 

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QEnergyStatWidget.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QEnergyStatWidget.cpp
@@ -22,7 +22,7 @@
 #include <sofa/gui/qt/QEnergyStatWidget.h>
 #include <QtCharts/QLineSeries>
 #include <QtCharts/QValueAxis>
-
+#include <sofa/simulation/Node.h>
 namespace sofa
 {
 namespace gui

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QGraphStatWidget.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QGraphStatWidget.cpp
@@ -25,7 +25,7 @@
 #include <QtCharts/QChart>
 #include <QtCharts/QLineSeries>
 #include <QtCharts/QValueAxis>
-
+#include <sofa/simulation/Node.h>
 namespace sofa
 {
 namespace gui

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QGraphStatWidget.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QGraphStatWidget.h
@@ -22,7 +22,7 @@
 #ifndef SOFA_GUI_QT_QGRAPHSTATWIDGET_H
 #define SOFA_GUI_QT_QGRAPHSTATWIDGET_H
 
-#include <sofa/simulation/Node.h>
+#include <sofa/simulation/fwd.h>
 
 #include <QWidget>
 #include <QTextEdit>

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QMomentumStatWidget.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QMomentumStatWidget.cpp
@@ -23,7 +23,7 @@
 #include <sofa/gui/qt/QMomentumStatWidget.h>
 #include <QtCharts/QLineSeries>
 #include <QtCharts/QValueAxis>
-
+#include <sofa/simulation/Node.h>
 namespace sofa
 {
 namespace gui

--- a/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.cpp
+++ b/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.cpp
@@ -26,6 +26,8 @@ using sofa::helper::Utils;
 #include <sofa/helper/system/SetDirectory.h>
 using sofa::helper::system::SetDirectory;
 
+#include <sofa/simulation/Node.h>
+
 #include <boost/program_options.hpp>
 #include <thread>
 #include <chrono>

--- a/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
+++ b/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
@@ -25,6 +25,7 @@
 #include <sofa/gui/BaseGUI.h>
 
 #include <sofa/simulation/Simulation.h>
+#include <sofa/simulation/fwd.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/visual/DrawToolGL.h>
 #include <SofaBaseVisual/InteractiveCamera.h>
@@ -81,7 +82,7 @@ public:
     void saveView();
     void initializeGL();
     void paintGL();
-    void setScene(sofa::simulation::Node::SPtr scene, const char* filename=NULL, bool temporaryFile=false) override;
+    void setScene(sofa::simulation::NodeSPtr scene, const char* filename=NULL, bool temporaryFile=false) override;
     void newView();
 
     // Virtual from BaseGUI
@@ -90,7 +91,7 @@ public:
     virtual void setViewerResolution(int width, int height) override;
 
     // Needed for the registration
-    static BaseGUI* CreateGUI(const char* name, sofa::simulation::Node::SPtr groot = NULL, const char* filename = NULL);
+    static BaseGUI* CreateGUI(const char* name, sofa::simulation::NodeSPtr groot = NULL, const char* filename = NULL);
     static int RegisterGUIParameters(ArgumentParser* argumentParser);
     static void parseRecordingModeOption();
 
@@ -109,7 +110,7 @@ private:
     VisualParams* vparams;
     DrawToolGL   drawTool;
 
-    sofa::simulation::Node::SPtr groot;
+    sofa::simulation::NodeSPtr groot;
     std::string sceneFileName;
     sofa::component::visualmodel::BaseCamera::SPtr currentCamera;
 

--- a/modules/SofaMiscFem/src/SofaMiscFem/FastTetrahedralCorotationalForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/FastTetrahedralCorotationalForceField.inl
@@ -27,6 +27,7 @@
 #include <iostream> //for debugging
 #include <SofaBaseTopology/TopologyData.inl>
 #include <sofa/helper/decompose.h>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 
 namespace sofa::component::forcefield
 {

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangleFEMForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangleFEMForceField.h
@@ -162,6 +162,36 @@ protected :
     void computeElementStiffnessMatrix( StiffnessMatrix& S, StiffnessMatrix& SR, const MaterialStiffness &K, const StrainDisplacement &J, const Transformation& Rot );
     void addKToMatrix(sofa::defaulttype::BaseMatrix *mat, SReal k, unsigned int &offset) override; // compute and add all the element stiffnesses to the global stiffness matrix
 
+    /** Accumulate an element matrix to a global assembly matrix. This is a helper for addKToMatrix, to accumulate each (square) element matrix in the (square) assembled matrix.
+      \param bm the global assembly matrix
+      \param offset start index of the local DOFs within the global matrix
+      \param nodeIndex indices of the nodes of the element within the local nodes, as stored in the topology
+      \param em element matrix, typically a stiffness, damping, mass, or weighted sum thereof
+      \param scale weight applied to the matrix, typically ±params->kfactor() for a stiffness matrix
+      */
+    template<class IndexArray, class ElementMat>
+    void addToMatrix(sofa::defaulttype::BaseMatrix* bm, unsigned offset, const IndexArray& nodeIndex, const ElementMat& em, SReal scale )
+    {
+        const unsigned  S = DataTypes::deriv_total_size; // size of node blocks
+        for (unsigned n1=0; n1<nodeIndex.size(); n1++)
+        {
+            for(unsigned i=0; i<S; i++)
+            {
+                unsigned ROW = offset + S*nodeIndex[n1] + i;  // i-th row associated with node n1 in BaseMatrix
+                unsigned row = S*n1+i;                        // i-th row associated with node n1 in the element matrix
+
+                for (unsigned n2=0; n2<nodeIndex.size(); n2++)
+                {
+                    for (unsigned j=0; j<S; j++)
+                    {
+                        unsigned COLUMN = offset + S*nodeIndex[n2] +j; // j-th column associated with node n2 in BaseMatrix
+                        unsigned column = 3*n2+j;                      // j-th column associated with node n2 in the element matrix
+                        bm->add( ROW,COLUMN, em[row][column]* scale );
+                    }
+                }
+            }
+        }
+    }
 };
 
 

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -37,7 +37,7 @@
 #include <SofaBaseTopology/QuadSetGeometryAlgorithms.h>
 #include <SofaBaseTopology/HexahedronSetGeometryAlgorithms.h>
 #include <sofa/simulation/AnimateEndEvent.h>
-
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 
 namespace sofa::component::mass
 {

--- a/modules/SofaMiscMapping/src/SofaMiscMapping/CenterOfMassMapping.inl
+++ b/modules/SofaMiscMapping/src/SofaMiscMapping/CenterOfMassMapping.inl
@@ -28,6 +28,7 @@
 
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/defaulttype/RigidTypes.h>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 
 #include <string>
 #include <iostream>

--- a/modules/SofaMiscMapping/src/SofaMiscMapping/DeformableOnRigidFrameMapping.inl
+++ b/modules/SofaMiscMapping/src/SofaMiscMapping/DeformableOnRigidFrameMapping.inl
@@ -24,6 +24,7 @@
 #include <SofaMiscMapping/DeformableOnRigidFrameMapping.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
+#include <sofa/core/topology/TopologyHandler.h>
 
 namespace sofa::component::mapping
 {

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/CompositingVisualLoop.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/CompositingVisualLoop.cpp
@@ -24,7 +24,7 @@
 #include <SofaBaseVisual/VisualStyle.h>
 #include <sofa/core/visual/DisplayFlags.h>
 #include <sofa/simulation/VisualVisitor.h>
-
+#include <sofa/simulation/Node.h>
 
 #include <sofa/helper/AdvancedTimer.h>
 

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OrderIndependentTransparencyManager.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OrderIndependentTransparencyManager.cpp
@@ -25,6 +25,7 @@
 #include <sofa/simulation/VisualVisitor.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/helper/system/FileRepository.h>
+#include <sofa/simulation/Node.h>
 
 
 namespace sofa

--- a/modules/SofaPreconditioner/src/SofaPreconditioner/PrecomputedWarpPreconditioner.inl
+++ b/modules/SofaPreconditioner/src/SofaPreconditioner/PrecomputedWarpPreconditioner.inl
@@ -52,6 +52,8 @@
 #include <SofaGeneralLinearSolver/CholeskySolver.h>
 #endif
 
+#include <sofa/simulation/Node.h>
+
 
 namespace sofa
 {

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/AddRecordedCameraPerformer.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/AddRecordedCameraPerformer.cpp
@@ -30,6 +30,7 @@
 #include <SofaDeformable/SpringForceField.inl>
 #include <SofaDeformable/StiffSpringForceField.inl>
 #include <sofa/helper/cast.h>
+#include <sofa/simulation/Node.h>
 
 using namespace sofa::component::interactionforcefield;
 using namespace sofa::core::objectmodel;

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/AttachBodyPerformer.inl
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/AttachBodyPerformer.inl
@@ -23,9 +23,8 @@
 #include <SofaUserInteraction/AttachBodyPerformer.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <SofaUserInteraction/MouseInteractor.h>
-
-
-
+#include <sofa/core/BaseMapping.h>
+#include <sofa/simulation/Node.h>
 namespace sofa::component::collision
 {
 

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/ComponentMouseInteraction.h
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/ComponentMouseInteraction.h
@@ -27,6 +27,7 @@
 #include <SofaUserInteraction/MouseInteractor.h>
 #include <SofaBaseMechanics/IdentityMapping.h>
 #include <sofa/core/Mapping.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa::component::collision
 {

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.inl
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.inl
@@ -28,7 +28,7 @@
 
 #include <sofa/simulation/InitVisitor.h>
 #include <sofa/simulation/DeleteVisitor.h>
-
+#include <sofa/simulation/Node.h>
 #include <SofaBaseCollision/SphereModel.h>
 #include <SofaMeshCollision/TriangleModel.h>
 #include <SofaBaseCollision/OBBModel.h>

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/MouseInteractor.h
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/MouseInteractor.h
@@ -25,9 +25,7 @@
 #include <SofaUserInteraction/InteractionPerformer.h>
 #include <SofaUserInteraction/RayModel.h>
 #include <sofa/core/collision/DetectionOutput.h>
-#include <sofa/simulation/Node.h>
-
-
+#include <sofa/core/BehaviorModel.h>
 namespace sofa::component::collision
 {
 

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/RemovePrimitivePerformer.inl
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/RemovePrimitivePerformer.inl
@@ -23,7 +23,7 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/topology/TopologicalMapping.h>
 #include <sofa/simulation/Simulation.h>
-
+#include <sofa/simulation/Node.h>
 namespace sofa::component::collision
 {
 

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/SleepController.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/SleepController.cpp
@@ -29,6 +29,8 @@
 #include <sofa/simulation/AnimateEndEvent.h>
 #include <sofa/simulation/CollisionEndEvent.h>
 
+#include <sofa/simulation/Node.h>
+
 namespace sofa::component::controller
 {
 

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/StartNavigationPerformer.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/StartNavigationPerformer.cpp
@@ -30,6 +30,7 @@
 #include <SofaDeformable/SpringForceField.inl>
 #include <SofaDeformable/StiffSpringForceField.inl>
 #include <sofa/helper/cast.h>
+#include <sofa/simulation/Node.h>
 
 using namespace sofa::component::interactionforcefield;
 using namespace sofa::core::objectmodel;

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/TopologicalChangeManager.h
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/TopologicalChangeManager.h
@@ -34,8 +34,6 @@
 #include <sofa/defaulttype/VecTypes.h>
 
 #include <SofaBaseMechanics/MechanicalObject.h>
-#include <sofa/simulation/Node.h>
-
 
 namespace sofa::component::collision
 {

--- a/modules/SofaValidation/src/SofaValidation/CompareState.cpp
+++ b/modules/SofaValidation/src/SofaValidation/CompareState.cpp
@@ -28,6 +28,7 @@
 #include <SofaSimulationCommon/xml/XML.h>
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/system/SetDirectory.h>
+#include <sofa/simulation/Node.h>
 
 #include <sstream>
 #include <algorithm>

--- a/modules/SofaValidation/src/SofaValidation/CompareTopology.cpp
+++ b/modules/SofaValidation/src/SofaValidation/CompareTopology.cpp
@@ -23,6 +23,7 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/simulation/MechanicalVisitor.h>
 #include <sofa/simulation/UpdateMappingVisitor.h>
+#include <sofa/simulation/Node.h>
 
 #include <sstream>
 #include <sofa/core/ObjectFactory.h>


### PR DESCRIPTION
Clean the inclusion graph using the combination of three technique.

1) do not rely on properties within class as this imply to have the full class definition to compile the code. 
Eg: `Node::SPtr` is strictly equivalent to `sofa::core::sptr<Node>` but the latter does not always requires the full class definition. 
2) replacement of `dynamiac_cast<>()` with an opaque function that does not need the complete inheritance graph to be visible. 
3) move definition of fonction from the .h to the .cpp 

By applygin these refactoring step there is more opportunity to use forward declaration. 

To handle the forward declaration it was decided during the reviewing of PR #1688 to use a dedicated file for that: 
Eg:
```console
- sofa/core/fwd.h
- sofa/defaulttype/fwd.h
- sofa/helper/fwd.h 
```
I also put in these files dynamic_cast replacement eg:
```cpp
Node* getNodeFromBase(Base*);
```

And there is also there is the definition of NodeSPtr as context free replacement for Node::SPtr. 


The PR also contains: #1727 
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
