### PR TITLE
[Backport] Small fix: removed debug message for Transform *= operator (#1732)

### DIFF
--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/SolidTypes.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/SolidTypes.h
@@ -324,7 +324,6 @@ public:
         template<class Real2>
         Transform& operator*=(Real2 a)
         {
-            dmsg_info("Transform") << "SolidTypes<R>::Transform::operator *=";
             origin_ *= a;
             return *this;
         }


### PR DESCRIPTION
Backport #1732 from v20.12



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
