### PR TITLE
[SofaCore] FIX SingleLink clear/set behavior

### DIFF
--- a/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/SingleLink_test.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/SingleLink_test.cpp
@@ -123,7 +123,7 @@ TEST_F(SingleLink_test, checkClearSetValue  )
     ASSERT_EQ( m_link.size(), 0 ) << "The size of a link container should be zero after clear().";
     m_link.set(nullptr);
     ASSERT_EQ( m_link.size(), 1 ) << "The size of a link container should be one after set(nullptr).";
-    ASSERT_EQ( m_link.getPath(), "@[]" ) << "The path should be empty because of the the previously used set(nullptr).";
+    ASSERT_EQ( m_link.getPath(), "" ) << "The path should be empty because of the the previously used set(nullptr).";
 }
 
 TEST_F(SingleLink_test, checkClearSetPath  )
@@ -139,4 +139,6 @@ TEST_F(SingleLink_test, checkEmptyness  )
 {
     m_link.set(nullptr);
     ASSERT_EQ( m_link.size(), 1 );
+    m_link.clear();
+    ASSERT_EQ( m_link.size(), 0 );
 }

--- a/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/SingleLink_test.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/SingleLink_test.cpp
@@ -42,7 +42,7 @@ public:
 class SingleLink_test: public BaseTest
 {
 public:
-    SingleLink<BaseObject, BaseObject, BaseLink::FLAG_DOUBLELINK|BaseLink::FLAG_STRONGLINK > m_link ;
+    SingleLink<BaseObject, BaseObject, BaseLink::FLAG_DOUBLELINK|BaseLink::FLAG_STRONGLINK|BaseLink::FLAG_STOREPATH > m_link ;
     BaseObject::SPtr m_dst ;
     BaseObject::SPtr m_src ;
 
@@ -115,4 +115,28 @@ TEST_F(SingleLink_test, getOwnerBase)
 
     m_link.setOwner(aBaseObject.get());
     ASSERT_EQ(m_link.getOwnerBase(), aBaseObject.get());
+}
+
+TEST_F(SingleLink_test, checkClearSetValue  )
+{
+    m_link.clear();
+    ASSERT_EQ( m_link.size(), 0 ) << "The size of a link container should be zero after clear().";
+    m_link.set(nullptr);
+    ASSERT_EQ( m_link.size(), 1 ) << "The size of a link container should be one after set(nullptr).";
+    ASSERT_EQ( m_link.getPath(), "@[]" ) << "The path should be empty because of the the previously used set(nullptr).";
+}
+
+TEST_F(SingleLink_test, checkClearSetPath  )
+{
+    m_link.clear();
+    ASSERT_EQ( m_link.size(), 0 )  << "The size of a link container should be zero after clear().";
+    m_link.setPath("@/ThisIsAPath");
+    ASSERT_EQ( m_link.size(), 1 ) << "The size of a link container should be one after setPath().";
+    ASSERT_EQ( m_link.getPath(), "@/ThisIsAPath" ) << "The path should not be empty as it was set previously.";
+}
+
+TEST_F(SingleLink_test, checkEmptyness  )
+{
+    m_link.set(nullptr);
+    ASSERT_EQ( m_link.size(), 1 );
 }

--- a/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/SingleLink_test.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/SingleLink_test.cpp
@@ -123,7 +123,7 @@ TEST_F(SingleLink_test, checkClearSetValue  )
     ASSERT_EQ( m_link.size(), 0 ) << "The size of a link container should be zero after clear().";
     m_link.set(nullptr);
     ASSERT_EQ( m_link.size(), 1 ) << "The size of a link container should be one after set(nullptr).";
-    ASSERT_EQ( m_link.getPath(), "" ) << "The path should be empty because of the the previously used set(nullptr).";
+    ASSERT_EQ( m_link.getLinkedPath(), "" ) << "The path should be empty because of the the previously used set(nullptr).";
 }
 
 TEST_F(SingleLink_test, checkClearSetPath  )
@@ -132,7 +132,7 @@ TEST_F(SingleLink_test, checkClearSetPath  )
     ASSERT_EQ( m_link.size(), 0 )  << "The size of a link container should be zero after clear().";
     m_link.setPath("@/ThisIsAPath");
     ASSERT_EQ( m_link.size(), 1 ) << "The size of a link container should be one after setPath().";
-    ASSERT_EQ( m_link.getPath(), "@/ThisIsAPath" ) << "The path should not be empty as it was set previously.";
+    ASSERT_EQ( m_link.getLinkedPath(), "@/ThisIsAPath" ) << "The path should not be empty as it was set previously.";
 }
 
 TEST_F(SingleLink_test, checkEmptyness  )

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Link.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Link.h
@@ -114,10 +114,11 @@ class LinkTraitsContainer;
 
 
 /// Class to hold 0-or-1 pointer. The interface is similar to std::vector (size/[]/begin/end), plus an automatic convertion to one pointer.
-template < class T, class TPtr = T* >
+template < class T, class TDestPtr, class TPtr = T* >
 class SinglePtr
 {
 protected:
+    bool isEmpty {true};
     TPtr elems[1];
 public:
     typedef T pointed_type;
@@ -135,7 +136,7 @@ public:
     }
     const_iterator end() const
     {
-        return (!elems[0])?elems:elems+1;
+        return (isEmpty)?elems:elems+1;
     }
     const_reverse_iterator rbegin() const
     {
@@ -163,14 +164,22 @@ public:
     }
     std::size_t size() const
     {
-        return (!elems[0])?0:1;
+        return !isEmpty;
+    }
+    void resize(size_t size)
+    {
+        if(size == 1)
+            isEmpty=false;
+        else
+            isEmpty=true;
     }
     bool empty() const
     {
-        return !elems[0];
+        return isEmpty;
     }
     void clear()
     {
+        isEmpty = true;
         elems[0] = TPtr();
     }
     const TPtr& get() const
@@ -180,6 +189,11 @@ public:
     TPtr& get()
     {
         return elems[0];
+    }
+    void add(TDestPtr v)
+    {
+        isEmpty = false;
+        elems[0] = v;
     }
     const TPtr& operator[](std::size_t i) const
     {
@@ -211,14 +225,18 @@ template<class TDestType, class TDestPtr, class TValueType>
 class LinkTraitsContainer<TDestType, TDestPtr, TValueType, false>
 {
 public:
-    typedef SinglePtr<TDestType, TValueType> T;
+    typedef SinglePtr<TDestType, TDestPtr, TValueType> T;
+    static void resize(T& c, size_t newsize)
+    {
+        c.resize(newsize);
+    }
     static void clear(T& c)
     {
         c.clear();
     }
     static std::size_t add(T& c, TDestPtr v)
     {
-        c.get() = v;
+        c.add(v);
         return 0;
     }
     static std::size_t find(const T& c, TDestPtr v)
@@ -352,6 +370,10 @@ public:
         return m_value.crend();
     }
     SOFA_END_DEPRECATION_AS_ERROR
+    void clear()
+    {
+        TraitsContainer::clear(m_value);
+    }
 
     bool add(DestPtr v)
     {
@@ -585,11 +607,6 @@ public:
         return PathResolver::CheckPath(context, GetDestClass(), path);
     }
 
-    void clear()
-    {
-        TraitsContainer::clear(m_value);
-    }
-
 protected:
     OwnerType* m_owner {nullptr};
     Container m_value;
@@ -798,6 +815,7 @@ public:
 
     void set(DestPtr v)
     {
+        TraitsContainer::resize(m_value, 1);
         ValueType& value = m_value.get();
         const DestPtr before = TraitsValueType::get(value);
         if (v == before) return;
@@ -808,6 +826,7 @@ public:
 
     void set(DestPtr v, const std::string& path)
     {
+        TraitsContainer::resize(m_value, 1);
         ValueType& value = m_value.get();
         const DestPtr before = TraitsValueType::get(value);
         if (v != before)
@@ -820,6 +839,7 @@ public:
 
     void setPath(const std::string& path)
     {
+        TraitsContainer::resize(m_value, 1);
         if (path.empty())
         {
             set(nullptr);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Link.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Link.h
@@ -585,6 +585,11 @@ public:
         return PathResolver::CheckPath(context, GetDestClass(), path);
     }
 
+    void clear()
+    {
+        TraitsContainer::clear(m_value);
+    }
+
 protected:
     OwnerType* m_owner {nullptr};
     Container m_value;


### PR DESCRIPTION
When using Single with/without storepath the way a link should behave is "unclear" and inconsitant with multlink. A multilink of size 1 can contains a nullptr while a single link containing a nullptr has size zero (which has side effect on path attributes). Now the size of a SingleLink is either 0 or 1 and a link can contain either nullptr or a path. Said differently, a SingleLink with a path set now report a size of 1.

To fix the bug it was needed to change the SinglePtr signature (which is breaking but as this is an internal feature of SingleLink should be problematic)

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
