### PR TITLE
[CMake] CLEAN option SOFA_BUILD_WITH_PCH_ENABLED

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,19 +27,17 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # Option for packaging
 option(SOFA_BUILD_RELEASE_PACKAGE "Run package specific configure" OFF)
 
-# Option to accelerate the building
-# https://cmake.org/cmake/help/v3.19/command/target_precompile_headers.html
-option(SOFA_BUILD_WITH_PCH_ENABLED "Compile Sofa using precompiled header (to accelerate the build process)" OFF)
+# Option to accelerate the compilation
+# see https://cmake.org/cmake/help/v3.16/command/target_precompile_headers.html
+# and https://cmake.org/cmake/help/v3.16/prop_tgt/DISABLE_PRECOMPILE_HEADERS.html
+cmake_dependent_option(SOFA_BUILD_WITH_PCH_ENABLED 
+    "Compile SOFA using precompiled header (to accelerate the build process)" OFF
+    "CMAKE_VERSION VERSION_GREATER_EQUAL 3.16" OFF)
 if(SOFA_BUILD_WITH_PCH_ENABLED)
-    if(${CMAKE_VERSION} VERSION_GREATER "3.16.0")
-        message("-- Precompiled headers: Yes (SOFA_BUILD_WITH_PCH_ENABLED variable is ON).")
-    else()
-        message("-- Precompiled headers: No (SOFA_BUILD_WITH_PCH_ENABLED variable is ON but cmake version is <3.16).")
-        set(DISABLE_PRECOMPILE_HEADERS ON)   # https://cmake.org/cmake/help/v3.19/prop_tgt/DISABLE_PRECOMPILE_HEADERS.html
-    endif()
+    message("-- Precompiled headers: enabled (SOFA_BUILD_WITH_PCH_ENABLED is ON).")
 else()
-    message("-- Precompiled headers: No (SOFA_BUILD_WITH_PCH_ENABLED variable is OFF).")
-    set(DISABLE_PRECOMPILE_HEADERS ON)   # https://cmake.org/cmake/help/v3.19/prop_tgt/DISABLE_PRECOMPILE_HEADERS.html
+    message("-- Precompiled headers: disabled (SOFA_BUILD_WITH_PCH_ENABLED is OFF or CMake < 3.16).")
+    set(DISABLE_PRECOMPILE_HEADERS ON)
 endif()
 
 ## Change default install prefix


### PR DESCRIPTION
```
cmake_dependent_option(
    name: SOFA_BUILD_WITH_PCH_ENABLED
    description: "Compile SOFA using precompiled header (to accelerate the build process)"
    default value: OFF
    when to show the option: "CMAKE_VERSION VERSION_GREATER_EQUAL 3.16"
    value forced when hidden: OFF
    )
```





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
