### PR TITLE
[SofaKernel] Fix SimpleApi forward declaration of BaseObject and relocatable of Sofa.GL

### DIFF
--- a/SofaKernel/modules/Sofa.GL/CMakeLists.txt
+++ b/SofaKernel/modules/Sofa.GL/CMakeLists.txt
@@ -90,7 +90,7 @@ sofa_create_package_with_targets(
     TARGETS ${PROJECT_NAME} AUTO_SET_TARGET_PROPERTIES
     INCLUDE_SOURCE_DIR "src"
     INCLUDE_INSTALL_DIR "${PROJECT_NAME}"
-    RELOCATABLE "SofaFramework"
+    RELOCATABLE "plugins"
 )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER SofaFramework)

--- a/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/SimpleApi.h
+++ b/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/SimpleApi.h
@@ -49,11 +49,11 @@ NodeSPtr SOFA_SOFASIMULATIONGRAPH_API createRootNode( Simulation::SPtr, const st
 ///@brief Create a sofa object in the provided node.
 ///The parameter "params" is for passing specific data argument to the created object including the
 ///object's type.
-BaseObject::SPtr SOFA_SOFASIMULATIONGRAPH_API createObject(NodeSPtr node, BaseObjectDescription& params);
+sofa::core::sptr<BaseObject> SOFA_SOFASIMULATIONGRAPH_API createObject(NodeSPtr node, BaseObjectDescription& params);
 
 ///@brief create a sofa object in the provided node of the given type.
 ///The parameter "params" is for passing specific data argument to the created object.
-BaseObject::SPtr SOFA_SOFASIMULATIONGRAPH_API createObject( NodeSPtr node, const std::string& type,
+sofa::core::sptr<BaseObject> SOFA_SOFASIMULATIONGRAPH_API createObject( NodeSPtr node, const std::string& type,
     const std::map<std::string, std::string>& params = std::map<std::string, std::string>{} );
 
 ///@brief create a child to the provided nodeof given name.


### PR DESCRIPTION
Needed for the good compilation of SofaPython3.





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
