### PR TITLE
[all] Adds forward declaration and opaque api for the base types (the one used in Node.h)

### DIFF
--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DefaultContactManager.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DefaultContactManager.cpp
@@ -25,6 +25,7 @@
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/objectmodel/Tag.h>
 #include <sofa/simulation/Node.h>
+#include <sofa/core/collision/Pipeline.h>
 
 namespace sofa::component::collision
 {

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
@@ -25,7 +25,6 @@
 
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/core/behavior/Mass.h>
-#include <sofa/core/objectmodel/Event.h>
 #include <SofaBaseTopology/TopologyData.h>
 #include <sofa/helper/vector.h>
 #include <sofa/defaulttype/VecTypes.h>

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/MechanicalObject.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/MechanicalObject.h
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #pragma once
 #include <SofaBaseMechanics/config.h>
-
+#include <sofa/core/fwd.h>
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/MechanicalObject.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/MechanicalObject.inl
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 #include <SofaBaseMechanics/MechanicalObject.h>
+#include <sofa/core/ConstraintParams.h>
 #include <sofa/core/behavior/MechanicalState.inl>
 #include <SofaBaseLinearSolver/SparseMatrix.h>
 #include <sofa/core/visual/VisualParams.h>
@@ -29,6 +30,7 @@
 #include <sofa/defaulttype/DataTypeInfo.h>
 #include <sofa/helper/accessor.h>
 #include <sofa/simulation/Node.h>
+
 #ifdef SOFA_DUMP_VISITOR_INFO
 #include <sofa/simulation/Visitor.h>
 #endif

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/EdgeSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/EdgeSetTopologyContainer.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <SofaBaseTopology/EdgeSetTopologyContainer.h>
+#include <sofa/core/topology/BaseTopologyEngine.h>
 
 #include <sofa/core/ObjectFactory.h>
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/EdgeSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/EdgeSetTopologyModifier.cpp
@@ -25,6 +25,7 @@
 #include <sofa/core/topology/TopologyChange.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/core/topology/BaseTopologyEngine.h>
 
 #include <algorithm>
 #include <utility>

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/HexahedronSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/HexahedronSetTopologyContainer.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <SofaBaseTopology/HexahedronSetTopologyContainer.h>
+#include <sofa/core/topology/BaseTopologyEngine.h>
 
 #include <sofa/core/ObjectFactory.h>
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/HexahedronSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/HexahedronSetTopologyModifier.cpp
@@ -24,6 +24,7 @@
 #include <sofa/core/topology/TopologyChange.h>
 #include <SofaBaseTopology/HexahedronSetTopologyContainer.h>
 #include <sofa/core/ObjectFactory.h>
+#include <sofa/core/topology/BaseTopologyEngine.h>
 
 #include <algorithm>
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/MeshTopology.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/MeshTopology.h
@@ -24,6 +24,7 @@
 
 #include <sofa/core/topology/Topology.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
+#include <sofa/core/DataEngine.h>
 #include <sofa/helper/vector.h>
 
 namespace sofa::component::topology

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyContainer.cpp
@@ -23,6 +23,7 @@
 
 #include <sofa/core/objectmodel/DDGNode.h>
 #include <sofa/core/ObjectFactory.h>
+#include <sofa/core/topology/BaseTopologyEngine.h>
 
 #include <algorithm>
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyModifier.cpp
@@ -27,6 +27,7 @@
 #include <SofaBaseTopology/PointSetTopologyContainer.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/core/topology/BaseTopologyEngine.h>
 
 namespace sofa::component::topology
 {

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/QuadSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/QuadSetTopologyContainer.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <SofaBaseTopology/QuadSetTopologyContainer.h>
+#include <sofa/core/topology/BaseTopologyEngine.h>
 
 #include <sofa/core/ObjectFactory.h>
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/QuadSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/QuadSetTopologyModifier.cpp
@@ -24,6 +24,7 @@
 #include <SofaBaseTopology/QuadSetTopologyContainer.h>
 #include <sofa/core/topology/TopologyChange.h>
 #include <sofa/core/ObjectFactory.h>
+#include <sofa/core/topology/BaseTopologyEngine.h>
 
 #include <algorithm>
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <SofaBaseTopology/TetrahedronSetTopologyContainer.h>
+#include <sofa/core/topology/BaseTopologyEngine.h>
 
 #include <sofa/core/ObjectFactory.h>
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetTopologyModifier.cpp
@@ -25,6 +25,7 @@
 #include <sofa/core/topology/TopologyChange.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/core/topology/BaseTopologyEngine.h>
 
 #include <algorithm>
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyContainer.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <SofaBaseTopology/TriangleSetTopologyContainer.h>
+#include <sofa/core/topology/BaseTopologyEngine.h>
 
 #include <sofa/core/ObjectFactory.h>
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyModifier.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <SofaBaseTopology/TriangleSetTopologyModifier.h>
+#include <sofa/core/topology/BaseTopologyEngine.h>
 
 #include <SofaBaseTopology/TriangleSetTopologyContainer.h>
 #include <sofa/core/topology/TopologyChange.h>

--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
@@ -40,8 +40,7 @@
 #include <sofa/helper/accessor.h>
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/types/Material.h>
-
-#include <sofa/helper/ScopedAdvancedTimer.h>
+#include <sofa/helper/AdvancedTimer.h>
 
 #include <sstream>
 #include <map>

--- a/SofaKernel/modules/SofaCore/SofaCore_simutest/objectmodel/BaseLink_simutest.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_simutest/objectmodel/BaseLink_simutest.cpp
@@ -23,6 +23,8 @@
 using sofa::core::objectmodel::Base ;
 using sofa::core::objectmodel::ComponentState;
 
+#include <sofa/core/behavior/BaseMechanicalState.h>
+
 #include <SofaSimulationGraph/testing/BaseSimulationTest.h>
 using sofa::helper::testing::BaseSimulationTest ;
 using sofa::simulation::Node ;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/DataTracker.h
@@ -25,8 +25,10 @@
 #include <functional>
 #include <map>
 #include <vector>
+#include <string>
 #include <sofa/core/objectmodel/DDGNode.h>
-#include "objectmodel/ComponentState.h"
+#include <sofa/core/objectmodel/ComponentState.h>
+
 namespace sofa::core::objectmodel
 {
     class Base;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/PathResolver.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/PathResolver.h
@@ -60,7 +60,7 @@ public:
     template<class T>
     static bool FindLinkDest(Base* base, T*& ptr, const std::string& path, const BaseLink* link)
     {
-        Base* result = FindLinkDestClass(base,  sofa::core::base::GetClass<T>(), path, link);
+        Base* result = FindLinkDestClass(base,  sofa::core::objectmodel::base::GetClass<T>(), path, link);
         ptr=castBaseTo<T*>(result);
         return (result != nullptr);
     }
@@ -71,7 +71,7 @@ public:
     template<class T>
     static bool CheckPath(Base* base, T*&, const std::string& path, const BaseLink* link)
     {
-        void* result = FindLinkDestClass(base, sofa::core::base::GetClass<T>(), path, link);
+        void* result = FindLinkDestClass(base, sofa::core::objectmodel::base::GetClass<T>(), path, link);
         return result != nullptr;
     }
 
@@ -80,7 +80,7 @@ public:
     {
         if (path.empty())
             return false;
-        return CheckPath(context, sofa::core::base::GetClass<T>(), path);
+        return CheckPath(context, sofa::core::objectmodel::base::GetClass<T>(), path);
     }
 
     /// Check that a given path is valid and that the pointed object exists regardless of its type.

--- a/SofaKernel/modules/SofaCore/src/sofa/core/PathResolver.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/PathResolver.h
@@ -23,24 +23,20 @@
 
 #include <string>
 #include <sofa/core/config.h>
-
-namespace sofa::core::objectmodel
-{
-    class Base;
-    class BaseData;
-    class BaseLink;
-    class AbstractDataLink;
-    class BaseClass;
-}
+#include <sofa/core/fwd.h>
 
 namespace sofa::core
 {
 
+/// Private (anonymous) namespace to make things more readable.
+namespace {
 using objectmodel::Base;
 using objectmodel::BaseData;
 using objectmodel::BaseLink;
 using objectmodel::BaseClass;
 using objectmodel::AbstractDataLink;
+using sofa::core::castBaseTo;
+}
 
 ///////////////////////////////////////////////////////////////////////////////////////
 /// @brief This class expose an API to query a context to find Base* or a BaseData*.
@@ -64,8 +60,8 @@ public:
     template<class T>
     static bool FindLinkDest(Base* base, T*& ptr, const std::string& path, const BaseLink* link)
     {
-        Base* result = FindLinkDestClass(base, T::GetClass(), path, link);
-        ptr=dynamic_cast<T*>(result);
+        Base* result = FindLinkDestClass(base,  sofa::core::base::GetClass<T>(), path, link);
+        ptr=castBaseTo<T*>(result);
         return (result != nullptr);
     }
 
@@ -75,7 +71,7 @@ public:
     template<class T>
     static bool CheckPath(Base* base, T*&, const std::string& path, const BaseLink* link)
     {
-        void* result = FindLinkDestClass(base, T::GetClass(), path, link);
+        void* result = FindLinkDestClass(base, sofa::core::base::GetClass<T>(), path, link);
         return result != nullptr;
     }
 
@@ -84,7 +80,7 @@ public:
     {
         if (path.empty())
             return false;
-        return CheckPath(context, T::GetClass(), path);
+        return CheckPath(context, sofa::core::base::GetClass<T>(), path);
     }
 
     /// Check that a given path is valid and that the pointed object exists regardless of its type.

--- a/SofaKernel/modules/SofaCore/src/sofa/core/PathResolver.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/PathResolver.h
@@ -35,7 +35,7 @@ using objectmodel::BaseData;
 using objectmodel::BaseLink;
 using objectmodel::BaseClass;
 using objectmodel::AbstractDataLink;
-using sofa::core::castBaseTo;
+using sofa::core::dynamicCastBaseTo;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////
@@ -61,7 +61,7 @@ public:
     static bool FindLinkDest(Base* base, T*& ptr, const std::string& path, const BaseLink* link)
     {
         Base* result = FindLinkDestClass(base,  sofa::core::objectmodel::base::GetClass<T>(), path, link);
-        ptr=castBaseTo<T*>(result);
+        ptr=dynamicCastBaseTo<T*>(result);
         return (result != nullptr);
     }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/State.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/State.cpp
@@ -21,6 +21,8 @@
 ******************************************************************************/
 #define SOFA_CORE_STATE_CPP
 #include <sofa/core/State.inl>
+#include <sofa/defaulttype/RigidTypes.h>
+#include <sofa/defaulttype/VecTypes.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/State.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/State.h
@@ -24,8 +24,7 @@
 
 #include <sofa/core/config.h>
 #include <sofa/core/BaseState.h>
-#include <sofa/defaulttype/RigidTypes.h>
-#include <sofa/defaulttype/VecTypes.h>
+#include <sofa/defaulttype/fwd.h>
 namespace sofa
 {
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseMechanicalState.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseMechanicalState.h
@@ -22,7 +22,7 @@
 #ifndef SOFA_CORE_BEHAVIOR_BASEMECHANICALSTATE_H
 #define SOFA_CORE_BEHAVIOR_BASEMECHANICALSTATE_H
 
-
+#include <sofa/core/fwd.h>
 #include <sofa/core/BaseState.h>
 #include <sofa/core/MultiVecId.h>
 #include <sofa/defaulttype/Vec.h>
@@ -35,8 +35,6 @@ namespace sofa
 
 namespace core
 {
-
-class ConstraintParams;
 
 namespace behavior
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/fwd.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/fwd.cpp
@@ -3,9 +3,6 @@
 #include <sofa/core/BaseState.h>
 #include <sofa/core/BaseMapping.h>
 #include <sofa/core/CollisionModel.h>
-#include <sofa/core/objectmodel/BaseObject.h>
-#include <sofa/core/objectmodel/ConfigurationSetting.h>
-#include <sofa/core/objectmodel/ContextObject.h>
 
 #include <sofa/core/behavior/BaseMass.h>
 #include <sofa/core/BehaviorModel.h>
@@ -22,19 +19,20 @@
 #include <sofa/core/behavior/BaseProjectiveConstraintSet.h>
 #include <sofa/core/behavior/BaseConstraint.h>
 
+#include <sofa/core/collision/Pipeline.h>
+
+#include <sofa/core/objectmodel/BaseObject.h>
+#include <sofa/core/objectmodel/ConfigurationSetting.h>
+#include <sofa/core/objectmodel/ContextObject.h>
+
 #include <sofa/core/topology/Topology.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/core/topology/BaseTopology.h>
-
-#include <sofa/core/collision/Pipeline.h>
 
 #include <sofa/core/visual/VisualLoop.h>
 #include <sofa/core/visual/VisualModel.h>
 #include <sofa/core/visual/VisualManager.h>
 #include <sofa/core/visual/Shader.h>
-
-#include <sofa/core/collision/Pipeline.h>
-#include <sofa/core/collision/Pipeline.h>
 
 namespace sofa::core::topology
 {
@@ -69,44 +67,35 @@ std::istream& operator>> ( std::istream& in, const TopologyChange*& )
 namespace sofa::core
 {
 
-#define DEFINE_OPAQUE_FUNCTION_FOR(TYPENAME) \
-    template<> \
-    TYPENAME* castBaseTo(sofa::core::objectmodel::Base* base) \
-    { return dynamic_cast<TYPENAME*>(base); } \
-    sofa::core::objectmodel::Base* baseFrom(TYPENAME* b) \
-    { return dynamic_cast<sofa::core::objectmodel::Base*>(b); } \
-    namespace objectmodel::base { template<> const sofa::core::objectmodel::BaseClass* GetClass<TYPENAME>() \
-    { return TYPENAME::GetClass(); } }
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::BaseState);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::BaseMapping);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::BehaviorModel);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::CollisionModel);
 
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::BaseState);
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::BaseMapping);
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::BehaviorModel);
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::CollisionModel);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::objectmodel::BaseObject);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::objectmodel::ContextObject);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::objectmodel::ConfigurationSetting);
 
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::objectmodel::BaseObject);
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::objectmodel::ContextObject);
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::objectmodel::ConfigurationSetting);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::behavior::BaseAnimationLoop);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::behavior::BaseMass);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::behavior::OdeSolver);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::behavior::ConstraintSolver);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::behavior::BaseLinearSolver);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::behavior::BaseMechanicalState);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::behavior::BaseForceField);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::behavior::BaseInteractionForceField);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::behavior::BaseProjectiveConstraintSet);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::behavior::BaseConstraintSet);
 
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseAnimationLoop);
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseMass);
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::OdeSolver);
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::ConstraintSolver);
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseLinearSolver);
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseMechanicalState);
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseForceField);
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseInteractionForceField);
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseProjectiveConstraintSet);
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseConstraintSet);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::topology::Topology);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::topology::BaseMeshTopology);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::topology::BaseTopologyObject);
 
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::topology::Topology);
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::topology::BaseMeshTopology);
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::topology::BaseTopologyObject);
-
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::collision::Pipeline);
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::visual::VisualLoop);
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::visual::Shader);
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::visual::VisualModel);
-DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::visual::VisualManager);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::collision::Pipeline);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::visual::VisualLoop);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::visual::Shader);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::visual::VisualModel);
+SOFA_DEFINE_OPAQUE_FUNCTIONS_BETWEEN_BASE_AND(sofa::core::visual::VisualManager);
 
 }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/fwd.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/fwd.cpp
@@ -75,7 +75,7 @@ namespace sofa::core
     { return dynamic_cast<TYPENAME*>(base); } \
     sofa::core::objectmodel::Base* baseFrom(TYPENAME* b) \
     { return dynamic_cast<sofa::core::objectmodel::Base*>(b); } \
-    namespace base { template<> const sofa::core::objectmodel::BaseClass* GetClass<TYPENAME>() \
+    namespace objectmodel::base { template<> const sofa::core::objectmodel::BaseClass* GetClass<TYPENAME>() \
     { return TYPENAME::GetClass(); } }
 
 DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::BaseState);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/fwd.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/fwd.cpp
@@ -1,5 +1,40 @@
 #include <sofa/core/fwd.h>
 #include <sofa/core/topology/TopologyChange.h>
+#include <sofa/core/BaseState.h>
+#include <sofa/core/BaseMapping.h>
+#include <sofa/core/CollisionModel.h>
+#include <sofa/core/objectmodel/BaseObject.h>
+#include <sofa/core/objectmodel/ConfigurationSetting.h>
+#include <sofa/core/objectmodel/ContextObject.h>
+
+#include <sofa/core/behavior/BaseMass.h>
+#include <sofa/core/BehaviorModel.h>
+#include <sofa/core/behavior/BaseAnimationLoop.h>
+#include <sofa/core/behavior/BaseMass.h>
+#include <sofa/core/behavior/OdeSolver.h>
+#include <sofa/core/behavior/ConstraintSolver.h>
+#include <sofa/core/behavior/BaseMechanicalState.h>
+#include <sofa/core/behavior/BaseForceField.h>
+#include <sofa/core/behavior/LinearSolver.h>
+#include <sofa/core/behavior/BaseConstraintSet.h>
+#include <sofa/core/behavior/BaseInteractionForceField.h>
+#include <sofa/core/behavior/BaseInteractionConstraint.h>
+#include <sofa/core/behavior/BaseProjectiveConstraintSet.h>
+#include <sofa/core/behavior/BaseConstraint.h>
+
+#include <sofa/core/topology/Topology.h>
+#include <sofa/core/topology/BaseMeshTopology.h>
+#include <sofa/core/topology/BaseTopology.h>
+
+#include <sofa/core/collision/Pipeline.h>
+
+#include <sofa/core/visual/VisualLoop.h>
+#include <sofa/core/visual/VisualModel.h>
+#include <sofa/core/visual/VisualManager.h>
+#include <sofa/core/visual/Shader.h>
+
+#include <sofa/core/collision/Pipeline.h>
+#include <sofa/core/collision/Pipeline.h>
 
 namespace sofa::core::topology
 {
@@ -28,6 +63,50 @@ std::istream& operator>> ( std::istream& in, const TopologyChange*& )
 {
     return in;
 }
+
+}
+
+namespace sofa::core
+{
+
+#define DEFINE_OPAQUE_FUNCTION_FOR(TYPENAME) \
+    template<> \
+    TYPENAME* castBaseTo(sofa::core::objectmodel::Base* base) \
+    { return dynamic_cast<TYPENAME*>(base); } \
+    sofa::core::objectmodel::Base* baseFrom(TYPENAME* b) \
+    { return dynamic_cast<sofa::core::objectmodel::Base*>(b); } \
+    namespace base { template<> const sofa::core::objectmodel::BaseClass* GetClass<TYPENAME>() \
+    { return TYPENAME::GetClass(); } }
+
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::BaseState);
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::BaseMapping);
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::BehaviorModel);
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::CollisionModel);
+
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::objectmodel::BaseObject);
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::objectmodel::ContextObject);
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::objectmodel::ConfigurationSetting);
+
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseAnimationLoop);
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseMass);
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::OdeSolver);
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::ConstraintSolver);
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseLinearSolver);
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseMechanicalState);
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseForceField);
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseInteractionForceField);
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseProjectiveConstraintSet);
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseConstraintSet);
+
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::topology::Topology);
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::topology::BaseMeshTopology);
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::topology::BaseTopologyObject);
+
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::collision::Pipeline);
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::visual::VisualLoop);
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::visual::Shader);
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::visual::VisualModel);
+DEFINE_OPAQUE_FUNCTION_FOR(sofa::core::visual::VisualManager);
 
 }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/fwd.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/fwd.h
@@ -4,13 +4,14 @@
 
 namespace sofa::core
 {
+class BaseState;
 class ExecParams;
 class ConstraintParams;
 class BaseMapping;
 class CollisionModel;
 class CollisionElementIterator;
 class ConstraintParams;
-class ExecParams;
+class BehaviorModel;
 }
 
 namespace sofa::core::objectmodel
@@ -21,23 +22,35 @@ class BaseNode;
 class BaseContext;
 class BaseData;
 class BaseLink;
-class BaseNode;
+class BaseClass;
+class AbstractDataLink;
 class Event;
+class BaseClass;
+class AbstractDataLink;
+class ContextObject;
+class ConfigurationSetting;
+
 
 class Tag;
 SOFA_CORE_API std::ostream& operator<<(std::ostream& o, const Tag& t);
 SOFA_CORE_API std::istream& operator>>(std::istream& i, Tag& t);
 }
 
+
 namespace sofa::core::behavior
 {
 class BaseForceField;
 class BaseMass;
 class BaseMechanicalState;
+class BaseAnimationLoop;
 class BaseConstraint;
 class BaseConstraintSet;
 class ConstraintSolver;
 class ConstraintResolution;
+class OdeSolver;
+class BaseLinearSolver;
+class BaseInteractionForceField;
+class BaseProjectiveConstraintSet;
 
 template<class T>
 class MechanicalState;
@@ -45,17 +58,23 @@ class MechanicalState;
 
 namespace sofa::core::topology
 {
+class BaseMeshTopology;
+class BaseTopologyObject;
+class Topology;
+class TopologyEngine;
 class TopologyChange;
 SOFA_CORE_API std::ostream& operator<< ( std::ostream& out, const sofa::core::topology::TopologyChange* t );
 SOFA_CORE_API std::istream& operator>> ( std::istream& in, sofa::core::topology::TopologyChange*& t );
 SOFA_CORE_API std::istream& operator>> ( std::istream& in, const sofa::core::topology::TopologyChange*& );
-
-class Topology;
 }
 
 namespace sofa::core::visual
 {
 class VisualParams;
+class VisualLoop;
+class VisualModel;
+class VisualManager;
+class Shader;
 
 class FlagTreeItem;
 SOFA_CORE_API std::ostream& operator<< ( std::ostream& os, const FlagTreeItem& root );
@@ -66,11 +85,86 @@ SOFA_CORE_API std::ostream& operator<< ( std::ostream& os, const DisplayFlags& f
 SOFA_CORE_API std::istream& operator>> ( std::istream& in, DisplayFlags& flags );
 }
 
-namespace sofa::component::topology
+namespace sofa::core::collision
 {
-class TetrahedronSetTopologyContainer;
-SOFA_CORE_API std::ostream& operator<< (std::ostream& out, const TetrahedronSetTopologyContainer& t);
-SOFA_CORE_API std::istream& operator>>(std::istream& in, TetrahedronSetTopologyContainer& t);
+class Pipeline;
+}
+
+namespace sofa::core
+{
+/////////////////////////////// CORE::OPAQUE FUNCTION /////////////////////////////////////////////////
+///
+/// CORE::OPAQUE function are a groupe of function that make "opaque" some of the common sofa behaviors.
+///
+/// Core::Opaque functions are:
+///     - Base* sofa::core::baseFrom(T*) replace dynamic_cast<Base*>(T*);
+///     - T* sofa::core::castBaseTo(Base*) replace dynamic_cast<T*>(Base*);
+///     - sofa:core::base::GetClass<T>() replace T::GetClass();
+///
+/// These functions are called "opaque" as they work with only forward declaration of the involved
+/// types in comparison to class methods the requires the full class declaration to be used.
+///
+/// It is highly recommanded to use as much as possible opaque function in header files as this
+/// allow to reduce the dependency tree.
+///
+/// Opaque function may be slower at runtime (by one function call) but this is true only if LTO isn't
+/// able to optimize them properly. If you have experience/feedback with LTO please join the discussion
+/// in https://github.com/sofa-framework/sofa/discussions/1822
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+template<class B>
+sofa::core::objectmodel::Base* baseFrom(B*b){ return dynamic_cast<sofa::core::objectmodel::Base*>(b);}
+
+template<class Dest>
+Dest castBaseTo(sofa::core::objectmodel::Base* base){ return dynamic_cast<Dest>(base); }
+
+/// getClass is in the namespace base as it is an opaque function for Base::GetClass
+namespace base
+{
+template<class B>
+const sofa::core::objectmodel::BaseClass* GetClass(){return B::GetClass(); }
+}
+
+/// Macro use to simplify the declaration of the core opaque function.
+#define DECLARE_OPAQUE_FUNCTION_FOR(TYPENAME) \
+    template<> SOFA_CORE_API TYPENAME* castBaseTo(sofa::core::objectmodel::Base* base); \
+    SOFA_CORE_API sofa::core::objectmodel::Base* baseFrom(TYPENAME* b); \
+    namespace base { template<> SOFA_CORE_API const sofa::core::objectmodel::BaseClass* GetClass<TYPENAME>(); }
+
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::BaseState);
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::BaseMapping);
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::BehaviorModel);
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::CollisionModel);
+
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::objectmodel::BaseObject);
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::objectmodel::ContextObject);
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::objectmodel::ConfigurationSetting);
+
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseAnimationLoop);
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseMass);
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::OdeSolver);
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::ConstraintSolver);
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseLinearSolver);
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseMechanicalState);
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseForceField);
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseInteractionForceField);
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseProjectiveConstraintSet);
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::behavior::BaseConstraintSet);
+
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::topology::Topology);
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::topology::BaseMeshTopology);
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::topology::BaseTopologyObject);
+
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::collision::Pipeline);
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::visual::VisualLoop);
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::visual::Shader);
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::visual::VisualModel);
+DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::visual::VisualManager);
+}
+
+namespace sofa::core::objectmodel::basecontext
+{
+SOFA_CORE_API SReal getDt(sofa::core::objectmodel::BaseContext* context);
+SOFA_CORE_API SReal getTime(sofa::core::objectmodel::BaseContext* context);
 }
 
 namespace sofa::core::objectmodel::basecontext

--- a/SofaKernel/modules/SofaCore/src/sofa/core/fwd.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/fwd.h
@@ -99,7 +99,7 @@ namespace sofa::core
 /// Core::Opaque functions are:
 ///     - Base* sofa::core::baseFrom(T*) replace dynamic_cast<Base*>(T*);
 ///     - T* sofa::core::castBaseTo(Base*) replace dynamic_cast<T*>(Base*);
-///     - sofa:core::base::GetClass<T>() replace T::GetClass();
+///     - sofa:core::objectmodel::base::GetClass<T>() replace T::GetClass();
 ///
 /// These functions are called "opaque" as they work with only forward declaration of the involved
 /// types in comparison to class methods the requires the full class declaration to be used.
@@ -118,7 +118,7 @@ template<class Dest>
 Dest castBaseTo(sofa::core::objectmodel::Base* base){ return dynamic_cast<Dest>(base); }
 
 /// getClass is in the namespace base as it is an opaque function for Base::GetClass
-namespace base
+namespace objectmodel::base
 {
 template<class B>
 const sofa::core::objectmodel::BaseClass* GetClass(){return B::GetClass(); }
@@ -128,7 +128,7 @@ const sofa::core::objectmodel::BaseClass* GetClass(){return B::GetClass(); }
 #define DECLARE_OPAQUE_FUNCTION_FOR(TYPENAME) \
     template<> SOFA_CORE_API TYPENAME* castBaseTo(sofa::core::objectmodel::Base* base); \
     SOFA_CORE_API sofa::core::objectmodel::Base* baseFrom(TYPENAME* b); \
-    namespace base { template<> SOFA_CORE_API const sofa::core::objectmodel::BaseClass* GetClass<TYPENAME>(); }
+    namespace objectmodel::base { template<> SOFA_CORE_API const sofa::core::objectmodel::BaseClass* GetClass<TYPENAME>(); }
 
 DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::BaseState);
 DECLARE_OPAQUE_FUNCTION_FOR(sofa::core::BaseMapping);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -22,11 +22,11 @@
 #ifndef SOFA_CORE_OBJECTMODEL_BASE_H
 #define SOFA_CORE_OBJECTMODEL_BASE_H
 
-#include <sofa/defaulttype/BoundingBox.h>                    //NOTE-FOR-SELF: Remove
+#include <sofa/defaulttype/BoundingBox.h>
 #include <sofa/core/objectmodel/Data.h>
-#include <sofa/core/objectmodel/Link.h>                      //NOTE-FOR-SELF: Remove
+#include <sofa/core/objectmodel/Link.h>
 #include <sofa/core/objectmodel/BaseClass.h>
-#include <sofa/core/objectmodel/BaseObjectDescription.h>     //NOTE-FOR-SELF: Remove
+#include <sofa/core/objectmodel/BaseObjectDescription.h>
 #include <sofa/core/objectmodel/Tag.h>
 #include <list>
 #include <sofa/core/sptr.h>

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseNode.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseNode.h
@@ -30,21 +30,6 @@ namespace sofa
 namespace core
 {
 
-// forward declaration of classes accessible from the node
-namespace behavior
-{
-class BaseAnimationLoop;
-class OdeSolver;
-}
-namespace collision
-{
-class Pipeline;
-}
-namespace visual
-{
-class VisualLoop;
-}
-
 namespace objectmodel
 {
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/ComponentState.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/ComponentState.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <sofa/core/config.h>
-#include <iostream>
+#include <iosfwd>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Link.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Link.h
@@ -503,7 +503,7 @@ protected:
 
         /// Downcast the pointer to a compatible type and
         /// If the types are not compatible with the Link we returns false
-        auto destptr = castBaseTo<DestType*>(baseptr);
+        auto destptr = dynamicCastBaseTo<DestType*>(baseptr);
         if(baseptr && !destptr)
         {
             return false;
@@ -517,7 +517,7 @@ protected:
     bool _doSet_(Base* baseptr, const size_t index) override
     {
         assert(index < m_value.size());
-        auto destptr = castBaseTo<DestType*>(baseptr);
+        auto destptr = dynamicCastBaseTo<DestType*>(baseptr);
 
         if(!destptr)
             return false;
@@ -528,7 +528,7 @@ protected:
 
     Base* _doGet_(const size_t index=0) const override
     {
-        return sofa::core::baseFrom(getIndex(index));
+        return sofa::core::dynamicCastBaseFrom(getIndex(index));
     }
 
     std::string _doGetLinkedPath_(const std::size_t index=0) const override
@@ -541,7 +541,7 @@ protected:
         {
             DestType* ptr = TraitsDestPtr::get(TraitsValueType::get(value));
             if (ptr)
-                path = BaseLink::CreateString(sofa::core::baseFrom(ptr), m_owner);
+                path = BaseLink::CreateString(sofa::core::dynamicCastBaseFrom(ptr), m_owner);
         }
         return path;
     }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Link.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Link.h
@@ -24,8 +24,10 @@
 
 #include <sofa/core/objectmodel/BaseLink.h>
 #include <sofa/helper/stable_vector.h>
-
 #include <sofa/core/PathResolver.h>
+#include <sofa/core/sptr.h>
+#include <sofa/core/fwd.h>
+
 namespace sofa
 {
 
@@ -53,7 +55,7 @@ template<class TDestType>
 class LinkTraitsDestPtr<TDestType, true>
 {
 public:
-    typedef typename TDestType::SPtr T;
+    typedef typename sofa::core::sptr<TDestType> T;
     static TDestType* get(const T& p) { return p.get(); }
 };
 
@@ -436,12 +438,12 @@ public:
 
     const BaseClass* getDestClass() const override
     {
-        return DestType::GetClass();
+        return sofa::core::base::GetClass<DestType>();
     }
 
     const BaseClass* getOwnerClass() const override
     {
-        return OwnerType::GetClass();
+        return sofa::core::base::GetClass<OwnerType>();
     }
 
     size_t getSize() const override
@@ -501,7 +503,7 @@ protected:
 
         /// Downcast the pointer to a compatible type and
         /// If the types are not compatible with the Link we returns false
-        auto destptr = dynamic_cast<DestType*>(baseptr);
+        auto destptr = castBaseTo<DestType*>(baseptr);
         if(baseptr && !destptr)
         {
             return false;
@@ -515,7 +517,7 @@ protected:
     bool _doSet_(Base* baseptr, const size_t index) override
     {
         assert(index < m_value.size());
-        auto destptr = dynamic_cast<DestType*>(baseptr);
+        auto destptr = castBaseTo<DestType*>(baseptr);
 
         if(!destptr)
             return false;
@@ -526,7 +528,7 @@ protected:
 
     Base* _doGet_(const size_t index=0) const override
     {
-        return getIndex(index);
+        return sofa::core::baseFrom(getIndex(index));
     }
 
     std::string _doGetLinkedPath_(const std::size_t index=0) const override
@@ -539,7 +541,7 @@ protected:
         {
             DestType* ptr = TraitsDestPtr::get(TraitsValueType::get(value));
             if (ptr)
-                path = BaseLink::CreateString(ptr, nullptr, m_owner);
+                path = BaseLink::CreateString(sofa::core::baseFrom(ptr), m_owner);
         }
         return path;
     }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Link.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Link.h
@@ -438,12 +438,12 @@ public:
 
     const BaseClass* getDestClass() const override
     {
-        return sofa::core::base::GetClass<DestType>();
+        return sofa::core::objectmodel::base::GetClass<DestType>();
     }
 
     const BaseClass* getOwnerClass() const override
     {
-        return sofa::core::base::GetClass<OwnerType>();
+        return sofa::core::objectmodel::base::GetClass<OwnerType>();
     }
 
     size_t getSize() const override
@@ -471,7 +471,7 @@ public:
     [[deprecated("2021-01-01: CheckPath as been deprecated for complete removal in PR. You can update your code by using PathResolver::CheckPath(Base*, BaseClass*, string).")]]
     static bool CheckPath(const std::string& path, Base* context)
     {
-        return PathResolver::CheckPath(context, DestType::GetClass(), path);
+        return PathResolver::CheckPath(context, sofa::core::objectmodel::base::GetClass<DestType>(), path);
     }
 
 protected:

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseMeshTopology.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseMeshTopology.h
@@ -22,8 +22,8 @@
 #ifndef SOFA_CORE_TOPOLOGY_BASEMESHTOPOLOGY_H
 #define SOFA_CORE_TOPOLOGY_BASEMESHTOPOLOGY_H
 
+#include <sofa/core/fwd.h>
 #include <sofa/core/topology/Topology.h>
-#include <sofa/core/topology/BaseTopologyEngine.h>
 #include <sofa/core/objectmodel/DataFileName.h>
 
 namespace sofa

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopology.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopology.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <sofa/core/topology/BaseTopology.h>
+#include <sofa/core/topology/BaseTopologyEngine.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/testing/BaseTest.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/testing/BaseTest.cpp
@@ -39,6 +39,7 @@ using sofa::helper::BackTrace;
 
 #include <sofa/helper/system/console.h>
 
+#include <sofa/helper/logging/Messaging.h>
 #include <sofa/helper/testing/TestMessageHandler.h>
 #include <sofa/helper/logging/Messaging.h>
 using sofa::helper::logging::MessageDispatcher ;

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/visual/DrawTool.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/visual/DrawTool.h
@@ -24,6 +24,7 @@
 #include <sofa/helper/config.h>
 #include <sofa/helper/types/RGBAColor.h>
 #include <sofa/defaulttype/Vec.h>
+#include <sofa/defaulttype/fwd.h>
 #include <sofa/defaulttype/Quat.h>
 #include <vector>
 

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/RayTriangleIntersection.cpp
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/RayTriangleIntersection.cpp
@@ -23,7 +23,7 @@
 
 #include <SofaMeshCollision/TriangleModel.h>
 #include <sofa/helper/LCPSolver.inl>
-
+#include <sofa/core/VecId.h>
 namespace sofa::component::collision
 {
 

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/TriangleModel.h
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/TriangleModel.h
@@ -27,6 +27,7 @@
 #include <SofaBaseTopology/TopologyData.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/defaulttype/VecTypes.h>
+#include <sofa/core/VecId.h>
 
 namespace sofa::component::collision
 {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/CollisionVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/CollisionVisitor.cpp
@@ -22,6 +22,7 @@
 #include <sofa/simulation/CollisionVisitor.h>
 #include <sofa/simulation/Node.h>
 #include <sofa/core/collision/NarrowPhaseDetection.h>
+#include <sofa/core/behavior/BaseConstraintSet.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DefaultVisualManagerLoop.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DefaultVisualManagerLoop.cpp
@@ -22,7 +22,7 @@
 #include <sofa/simulation/DefaultVisualManagerLoop.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/visual/VisualParams.h>
-
+#include <sofa/core/visual/VisualManager.h>
 #include <sofa/simulation/VisualVisitor.h>
 #include <sofa/simulation/UpdateContextVisitor.h>
 #include <sofa/simulation/UpdateMappingVisitor.h>

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/ExportDotVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/ExportDotVisitor.cpp
@@ -24,9 +24,14 @@
 #include <sofa/simulation/Node.h>
 #include <sofa/simulation/Colors.h>
 #include <sofa/simulation/ExportDotVisitor.h>
-
+#include <sofa/core/collision/Pipeline.h>
 #include <sofa/core/collision/CollisionGroupManager.h>
 #include <sofa/core/collision/ContactManager.h>
+#include <sofa/core/behavior/BaseAnimationLoop.h>
+#include <sofa/core/behavior/OdeSolver.h>
+#include <sofa/core/behavior/LinearSolver.h>
+#include <sofa/core/behavior/BaseInteractionForceField.h>
+#include <sofa/core/BaseMapping.h>
 
 namespace sofa::simulation::graph
 {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/ExportGnuplotVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/ExportGnuplotVisitor.cpp
@@ -22,6 +22,8 @@
 #include <sofa/simulation/ExportGnuplotVisitor.h>
 #include <sofa/simulation/Node.h>
 #include <sofa/core/behavior/BaseMechanicalState.h>
+#include <sofa/core/behavior/BaseInteractionForceField.h>
+#include <sofa/core/behavior/Mass.h>
 #include <iostream>
 
 namespace sofa

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/ExportOBJVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/ExportOBJVisitor.cpp
@@ -23,6 +23,8 @@
 #include <sofa/helper/Factory.h>
 #include <sofa/simulation/Node.h>
 #include <sofa/core/objectmodel/BaseContext.h>
+#include <sofa/core/visual/VisualModel.h>
+
 namespace sofa
 {
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVPrintVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVPrintVisitor.cpp
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #include <sofa/simulation/MechanicalVPrintVisitor.h>
 #include <sofa/simulation/Node.h>
-
+#include <sofa/core/behavior/BaseMechanicalState.h>
 using namespace sofa::core;
 namespace sofa
 {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVisitor.cpp
@@ -23,7 +23,11 @@
 #include <sofa/simulation/MechanicalVisitor.h>
 #include <sofa/simulation/Node.h>
 #include <sofa/simulation/LocalStorage.h>
+#include <sofa/core/behavior/BaseMass.h>
+#include <sofa/core/behavior/ConstraintSolver.h>
 #include <sofa/core/behavior/BaseInteractionConstraint.h>
+#include <sofa/core/behavior/OdeSolver.h>
+#include <sofa/core/CollisionModel.h>
 #include <iostream>
 
 namespace sofa

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.inl
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Node.inl
@@ -31,7 +31,6 @@ namespace simulation
 template <class RealObject>
 Node::SPtr Node::create( RealObject*, sofa::core::objectmodel::BaseObjectDescription* arg)
 {
-//    Node::SPtr obj=getSimulation()->createNewGraph(arg->getName());
     Node::SPtr obj=getSimulation()->createNewNode(arg->getName());
     obj->parse(arg);
     return obj;

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/PrintVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/PrintVisitor.cpp
@@ -22,6 +22,19 @@
 #include <sofa/simulation/PrintVisitor.h>
 #include <sofa/helper/Factory.h>
 #include <sofa/simulation/Node.h>
+#include <sofa/core/topology/Topology.h>
+#include <sofa/core/collision/Pipeline.h>
+#include <sofa/core/CollisionModel.h>
+#include <sofa/core/BehaviorModel.h>
+#include <sofa/core/behavior/OdeSolver.h>
+#include <sofa/core/behavior/LinearSolver.h>
+#include <sofa/core/behavior/BaseInteractionForceField.h>
+#include <sofa/core/behavior/BaseProjectiveConstraintSet.h>
+#include <sofa/core/behavior/BaseConstraintSet.h>
+#include <sofa/core/behavior/BaseMass.h>
+#include <sofa/core/objectmodel/ContextObject.h>
+#include <sofa/core/visual/VisualModel.h>
+#include <sofa/core/BaseMapping.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/StateChangeVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/StateChangeVisitor.cpp
@@ -24,6 +24,7 @@
 #include <sofa/simulation/Node.h>
 #include <sofa/core/topology/TopologicalMapping.h>
 #include <sofa/core/BaseMapping.h>
+#include <sofa/core/behavior/BaseMechanicalState.h>
 
 namespace sofa
 {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/VisualVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/VisualVisitor.cpp
@@ -22,7 +22,10 @@
 #include <sofa/simulation/VisualVisitor.h>
 #include <sofa/simulation/Node.h>
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/core/visual/Shader.h>
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/core/BehaviorModel.h>
+#include <sofa/core/behavior/BaseMechanicalState.h>
 
 #ifdef DEBUG_DRAW
 #define DO_DEBUG_DRAW true

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/WriteStateVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/WriteStateVisitor.cpp
@@ -22,7 +22,7 @@
 #include <sofa/simulation/WriteStateVisitor.h>
 #include <sofa/defaulttype/Vec.h>
 #include <sofa/simulation/Node.h>
-
+#include <sofa/core/behavior/BaseMechanicalState.h>
 namespace sofa
 {
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/XMLPrintVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/XMLPrintVisitor.cpp
@@ -25,6 +25,7 @@
 #include <sofa/core/behavior/BaseInteractionForceField.h>
 #include <sofa/core/behavior/BaseInteractionProjectiveConstraintSet.h>
 #include <sofa/core/behavior/BaseInteractionConstraint.h>
+#include <sofa/core/BaseMapping.h>
 
 namespace sofa
 {

--- a/applications/plugins/Compliant/controller/CompliantSleepController.cpp
+++ b/applications/plugins/Compliant/controller/CompliantSleepController.cpp
@@ -1,5 +1,6 @@
 #include "CompliantSleepController.h"
 #include <sofa/simulation/Node.h>
+#include <sofa/core/BaseMapping.h>
 #include <sofa/core/ObjectFactory.h>
 #include "../compliance/DiagonalCompliance.h"
 #include "../compliance/UniformCompliance.h"

--- a/applications/plugins/LMConstraint/src/LMConstraint/LMConstraintSolver.cpp
+++ b/applications/plugins/LMConstraint/src/LMConstraint/LMConstraintSolver.cpp
@@ -23,6 +23,7 @@
 #include <LMConstraint/LMConstraintSolver.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/behavior/LinearSolver.h>
+#include <sofa/core/behavior/BaseMass.h>
 #include <SofaBaseLinearSolver/FullMatrix.h>
 #include <SofaBaseLinearSolver/FullVector.h>
 #include <sofa/simulation/AnimateBeginEvent.h>

--- a/applications/plugins/SceneCreator/src/SceneCreator/GetAssembledSizeVisitor.cpp
+++ b/applications/plugins/SceneCreator/src/SceneCreator/GetAssembledSizeVisitor.cpp
@@ -32,6 +32,7 @@
 #include "GetAssembledSizeVisitor.h"
 #include <sofa/defaulttype/Vec.h>
 #include <sofa/simulation/Node.h>
+#include <sofa/core/behavior/BaseMechanicalState.h>
 
 namespace sofa
 {

--- a/applications/plugins/SceneCreator/src/SceneCreator/GetVectorVisitor.cpp
+++ b/applications/plugins/SceneCreator/src/SceneCreator/GetVectorVisitor.cpp
@@ -32,7 +32,7 @@
 #include "GetVectorVisitor.h"
 #include <sofa/defaulttype/Vec.h>
 #include <sofa/simulation/Node.h>
-
+#include <sofa/core/behavior/BaseMechanicalState.h>
 namespace sofa
 {
 

--- a/applications/plugins/SceneCreator/src/SceneCreator/SceneUtils.cpp
+++ b/applications/plugins/SceneCreator/src/SceneCreator/SceneUtils.cpp
@@ -29,7 +29,7 @@
 #include <sofa/defaulttype/VecTypes.h>
 using sofa::defaulttype::Vec3Types ;
 
-#include <SofaBaseMechanics/MechanicalObject.h>
+#include <SofaBaseMechanics/MechanicalObject.inl>
 typedef sofa::component::container::MechanicalObject<Vec3Types> MechanicalObject3;
 
 #include <sofa/helper/system/FileRepository.h>

--- a/applications/plugins/SceneCreator/src/SceneCreator/SceneUtils.h
+++ b/applications/plugins/SceneCreator/src/SceneCreator/SceneUtils.h
@@ -25,7 +25,7 @@
 #include <SceneCreator/config.h>
 #include <Eigen/Core>
 #include <SofaEigen2Solver/EigenSparseMatrix.h>
-
+#include <sofa/core/VecId.h>
 namespace sofa
 {
 namespace modeling

--- a/applications/plugins/SofaCarving/SofaCarving_test/SofaCarving_test.cpp
+++ b/applications/plugins/SofaCarving/SofaCarving_test/SofaCarving_test.cpp
@@ -22,6 +22,7 @@
 #include <sofa/helper/system/FileRepository.h>
 #include <SofaCarving/CarvingManager.h>
 #include <SofaSimulationGraph/SimpleApi.h>
+#include <sofa/core/topology/BaseMeshTopology.h>
 #include <SofaSimulationGraph/testing/BaseSimulationTest.h>
 #include <SofaBaseUtils/initSofaBaseUtils.h>
 #include <SofaBaseLinearSolver/initSofaBaseLinearSolver.h>

--- a/applications/plugins/SofaPython/Binding_BaseMapping.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseMapping.cpp
@@ -24,6 +24,7 @@
 #include "Binding_BaseObject.h"
 #include "PythonFactory.h"
 #include "PythonToSofa.inl"
+#include <sofa/defaulttype/BaseMatrix.h>
 
 using namespace sofa;
 using namespace sofa::core;

--- a/applications/plugins/SofaPython/Binding_BaseObject.cpp
+++ b/applications/plugins/SofaPython/Binding_BaseObject.cpp
@@ -24,8 +24,24 @@
 using sofa::core::ObjectFactory ;
 using sofa::core::ObjectCreator ;
 
+#include <sofa/core/objectmodel/Context.h>
+#include <sofa/core/objectmodel/ContextObject.h>
+#include <sofa/core/BehaviorModel.h>
+#include <sofa/core/behavior/BaseAnimationLoop.h>
 #include <sofa/core/behavior/BaseController.h>
 #include <sofa/core/behavior/BaseConstraintCorrection.h>
+#include <sofa/core/behavior/BaseConstraintSet.h>
+#include <sofa/core/behavior/BaseForceField.h>
+#include <sofa/core/behavior/BaseInteractionForceField.h>
+#include <sofa/core/behavior/BaseMass.h>
+#include <sofa/core/behavior/BaseProjectiveConstraintSet.h>
+#include <sofa/core/behavior/OdeSolver.h>
+#include <sofa/core/behavior/ConstraintSolver.h>
+#include <sofa/core/visual/VisualLoop.h>
+#include <sofa/core/behavior/LinearSolver.h>
+#include <sofa/core/collision/Pipeline.h>
+#include <sofa/core/visual/VisualLoop.h>
+#include <sofa/core/objectmodel/ConfigurationSetting.h>
 #include <sofa/core/collision/CollisionAlgorithm.h>
 #include <sofa/core/topology/TopologicalMapping.h>
 #include <sofa/core/collision/Intersection.h>

--- a/applications/plugins/SofaPython/Binding_Node.cpp
+++ b/applications/plugins/SofaPython/Binding_Node.cpp
@@ -23,6 +23,8 @@
 #include <sofa/simulation/Simulation.h>
 #include <sofa/core/objectmodel/KeypressedEvent.h>
 #include <sofa/core/objectmodel/KeyreleasedEvent.h>
+#include <sofa/core/visual/VisualLoop.h>
+#include <sofa/core/behavior/BaseMass.h>
 #include <sofa/simulation/MechanicalVisitor.h>
 #include <sofa/simulation/UpdateMappingVisitor.h>
 #include <sofa/simulation/VisualVisitor.h>

--- a/applications/plugins/SofaSimpleGUI/SofaGL.cpp
+++ b/applications/plugins/SofaSimpleGUI/SofaGL.cpp
@@ -2,6 +2,7 @@
 #include "SofaGL.h"
 #include "VisualPickVisitor.h"
 #include <sofa/core/objectmodel/Tag.h>
+#include <sofa/core/visual/VisualLoop.h>
 #include <sofa/simulation/MechanicalVisitor.h>
 
 using std::cout;

--- a/applications/plugins/SofaSimpleGUI/VisualPickVisitor.cpp
+++ b/applications/plugins/SofaSimpleGUI/VisualPickVisitor.cpp
@@ -6,6 +6,7 @@ using std::endl;
 
 #include <sofa/helper/system/gl.h>
 #include <sofa/simulation/Node.h>
+#include <sofa/core/visual/Shader.h>
 namespace sofa
 {
 

--- a/applications/plugins/SofaTest/Mapping_test.h
+++ b/applications/plugins/SofaTest/Mapping_test.h
@@ -37,6 +37,7 @@
 #include <SofaBaseMechanics/MechanicalObject.h>
 #include <SofaSimulationGraph/DAGSimulation.h>
 #include <SceneCreator/SceneCreator.h>
+#include <sofa/core/Mapping.h>
 
 #include <sofa/helper/logging/Messaging.h>
 

--- a/applications/projects/SofaPhysicsAPI/SofaPhysicsSimulation.h
+++ b/applications/projects/SofaPhysicsAPI/SofaPhysicsSimulation.h
@@ -27,6 +27,7 @@
 #include "SofaPhysicsDataMonitor_impl.h"
 #include "SofaPhysicsDataController_impl.h"
 
+#include <sofa/helper/system/thread/CTime.h>
 #include <sofa/simulation/Simulation.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/visual/DrawToolGL.h>

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.h
@@ -25,7 +25,6 @@
 #include <sofa/core/behavior/ProjectiveConstraintSet.h>
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
-#include <sofa/core/objectmodel/Event.h>
 #include <sofa/defaulttype/Mat.h>
 #include <sofa/helper/vector.h>
 #include <sofa/helper/Quater.h>

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.h
@@ -25,7 +25,6 @@
 #include <sofa/core/behavior/ProjectiveConstraintSet.h>
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
-#include <sofa/core/objectmodel/Event.h>
 #include <sofa/defaulttype/BaseMatrix.h>
 #include <sofa/defaulttype/BaseVector.h>
 #include <sofa/defaulttype/VecTypes.h>

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PlaneForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PlaneForceField.inl
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/simulation/Simulation.h>
 #include <SofaBoundaryCondition/PlaneForceField.h>
 #include <sofa/helper/accessor.h>

--- a/modules/SofaConstraint/src/SofaConstraint/BilateralInteractionConstraint.h
+++ b/modules/SofaConstraint/src/SofaConstraint/BilateralInteractionConstraint.h
@@ -30,12 +30,6 @@
 #include <sofa/defaulttype/Vec.h>
 #include <sofa/defaulttype/VecTypes.h>
 
-#include <sofa/core/objectmodel/Event.h>
-#include <sofa/simulation/AnimateBeginEvent.h>
-#include <sofa/simulation/AnimateEndEvent.h>
-#include <sofa/core/objectmodel/KeypressedEvent.h>
-#include <sofa/core/objectmodel/KeyreleasedEvent.h>
-
 #include <deque>
 
 #include <SofaConstraint/BilateralConstraintResolution.h>

--- a/modules/SofaConstraint/src/SofaConstraint/BilateralInteractionConstraint.inl
+++ b/modules/SofaConstraint/src/SofaConstraint/BilateralInteractionConstraint.inl
@@ -21,6 +21,11 @@
 ******************************************************************************/
 #pragma once
 #include <SofaConstraint/BilateralInteractionConstraint.h>
+#include <sofa/simulation/AnimateBeginEvent.h>
+#include <sofa/simulation/AnimateEndEvent.h>
+#include <sofa/core/objectmodel/KeypressedEvent.h>
+#include <sofa/core/objectmodel/KeyreleasedEvent.h>
+
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/types/RGBAColor.h>
 #include <sofa/defaulttype/Vec.h>

--- a/modules/SofaExporter/src/SofaExporter/WriteState.cpp
+++ b/modules/SofaExporter/src/SofaExporter/WriteState.cpp
@@ -21,6 +21,9 @@
 ******************************************************************************/
 #include <SofaExporter/WriteState.inl>
 #include <sofa/core/ObjectFactory.h>
+#include <sofa/core/behavior/OdeSolver.h>
+#include <sofa/core/behavior/BaseMass.h>
+#include <sofa/core/BaseMapping.h>
 
 namespace sofa
 {

--- a/modules/SofaExporter/src/SofaExporter/WriteState.inl
+++ b/modules/SofaExporter/src/SofaExporter/WriteState.inl
@@ -26,7 +26,7 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/simulation/Node.h>
 #include <sofa/core/objectmodel/DataFileName.h>
-
+#include <sofa/core/behavior/BaseMass.h>
 #include <fstream>
 #include <sstream>
 

--- a/modules/SofaExporter/src/SofaExporter/WriteTopology.cpp
+++ b/modules/SofaExporter/src/SofaExporter/WriteTopology.cpp
@@ -21,6 +21,8 @@
 ******************************************************************************/
 #include <SofaExporter/WriteTopology.inl>
 #include <sofa/core/ObjectFactory.h>
+#include <sofa/core/behavior/BaseMass.h>
+#include <sofa/core/BaseMapping.h>
 
 namespace sofa
 {

--- a/modules/SofaGeneralAnimationLoop/src/SofaGeneralAnimationLoop/MechanicalMatrixMapper.inl
+++ b/modules/SofaGeneralAnimationLoop/src/SofaGeneralAnimationLoop/MechanicalMatrixMapper.inl
@@ -29,6 +29,7 @@
 #include <sofa/core/ExecParams.h>
 #include <sofa/core/objectmodel/BaseContext.h>
 #include <sofa/core/behavior/MechanicalState.h>
+#include <sofa/core/behavior/BaseMass.h>
 #include <sofa/defaulttype/MapMapSparseMatrix.h>
 
 // verify timing

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/SelectConnectedLabelsROI.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/SelectConnectedLabelsROI.h
@@ -23,11 +23,9 @@
 #include <SofaGeneralEngine/config.h>
 
 #include <sofa/core/DataEngine.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
 #include <sofa/helper/vector.h>
 #include <sofa/helper/SVector.h>
 #include <sofa/helper/vectorData.h>
-
 
 namespace sofa::component::engine
 {
@@ -147,5 +145,11 @@ protected:
 
 };
 
+#ifndef SelectConnectedLabelsROI_CPP_
+extern template class SOFA_SOFAGENERALENGINE_API SelectConnectedLabelsROI<unsigned int>;
+extern template class SOFA_SOFAGENERALENGINE_API SelectConnectedLabelsROI<unsigned char>;
+extern template class SOFA_SOFAGENERALENGINE_API SelectConnectedLabelsROI<unsigned short>;
+extern template class SOFA_SOFAGENERALENGINE_API SelectConnectedLabelsROI<int>;
+#endif ///
 
 } //namespace sofa::component::engine

--- a/modules/SofaGeneralLoader/src/SofaGeneralLoader/ReadState.cpp
+++ b/modules/SofaGeneralLoader/src/SofaGeneralLoader/ReadState.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #include <SofaGeneralLoader/ReadState.inl>
 #include <sofa/core/ObjectFactory.h>
+#include <sofa/core/behavior/OdeSolver.h>
 #include <sofa/simulation/Node.h>
 
 namespace sofa::component::misc

--- a/modules/SofaGeneralObjectInteraction/src/SofaGeneralObjectInteraction/AttachConstraint.inl
+++ b/modules/SofaGeneralObjectInteraction/src/SofaGeneralObjectInteraction/AttachConstraint.inl
@@ -22,6 +22,7 @@
 #pragma once
 #include <SofaGeneralObjectInteraction/AttachConstraint.h>
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/defaulttype/RigidTypes.h>
 #include <SofaBaseTopology/TopologySubsetData.inl>
 #include <sofa/simulation/Node.h>

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/BeamFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/BeamFEMForceField.inl
@@ -29,6 +29,7 @@
 #include <iostream>
 #include <set>
 #include <sofa/core/behavior/MechanicalState.h>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/defaulttype/RigidTypes.h>

--- a/modules/SofaGuiCommon/src/sofa/gui/ColourPickingVisitor.h
+++ b/modules/SofaGuiCommon/src/sofa/gui/ColourPickingVisitor.h
@@ -22,6 +22,7 @@
 #pragma once
 #include <sofa/gui/config.h>
 #include <sofa/simulation/Visitor.h>
+#include <sofa/core/visual/VisualParams.h>
 #include <SofaMeshCollision/fwd.h>
 #include <SofaBaseCollision/fwd.h>
 #include <SofaUserInteraction/MouseInteractor.h>

--- a/modules/SofaGuiCommon/src/sofa/gui/PickHandler.cpp
+++ b/modules/SofaGuiCommon/src/sofa/gui/PickHandler.cpp
@@ -28,6 +28,7 @@
 #include <sofa/simulation/DeleteVisitor.h>
 #include <sofa/simulation/MechanicalVisitor.h>
 #include <sofa/simulation/Node.h>
+#include <sofa/core/collision/Pipeline.h>
 
 #include <SofaMeshCollision/TriangleModel.h>
 #include <SofaBaseCollision/SphereModel.h>

--- a/modules/SofaGuiQt/src/sofa/gui/qt/SofaWindowProfiler.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/SofaWindowProfiler.cpp
@@ -29,6 +29,7 @@
 #include <QGridLayout>
 #include <QDebug>
 
+#include <sofa/helper/logging/Messaging.h>
 namespace sofa::gui::qt
 {
 using namespace sofa::helper;

--- a/modules/SofaMiscMapping/src/SofaMiscMapping/DistanceMapping.inl
+++ b/modules/SofaMiscMapping/src/SofaMiscMapping/DistanceMapping.inl
@@ -23,10 +23,12 @@
 
 #include "DistanceMapping.h"
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/core/ConstraintParams.h>
 #include <iostream>
 #include <sofa/simulation/Node.h>
 #include <sofa/defaulttype/MapMapSparseMatrixEigenUtils.h>
-
+#include <sofa/core/behavior/BaseForceField.h>
+#include <sofa/core/behavior/MechanicalState.h>
 namespace sofa::component::mapping
 {
 

--- a/modules/SofaMiscMapping/src/SofaMiscMapping/SquareDistanceMapping.inl
+++ b/modules/SofaMiscMapping/src/SofaMiscMapping/SquareDistanceMapping.inl
@@ -25,6 +25,8 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <iostream>
 #include <sofa/simulation/Node.h>
+#include <sofa/core/behavior/BaseForceField.h>
+#include <sofa/core/behavior/MechanicalState.inl>
 
 namespace sofa::component::mapping
 {

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/LightManager.h
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/LightManager.h
@@ -26,7 +26,6 @@
 #include <sofa/defaulttype/SolidTypes.h>
 #include <SofaOpenglVisual/Light.h>
 #include <sofa/core/visual/VisualManager.h>
-#include <sofa/core/objectmodel/Event.h>
 #include <sofa/defaulttype/Mat.h>
 #include <sofa/helper/types/RGBAColor.h>
 

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/InteractionPerformer.h
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/InteractionPerformer.h
@@ -24,8 +24,6 @@
 
 #include <SofaGraphComponent/MouseButtonSetting.h>
 #include <sofa/helper/Factory.h>
-#include <sofa/core/objectmodel/Event.h>
-#include <sofa/core/visual/VisualParams.h>
 
 namespace sofa::component::collision
 {

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/RemovePrimitivePerformer.inl
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/RemovePrimitivePerformer.inl
@@ -23,6 +23,7 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/topology/TopologicalMapping.h>
 #include <sofa/simulation/Node.h>
+#include <sofa/core/topology/BaseTopology.h>
 namespace sofa::component::collision
 {
 

--- a/modules/SofaValidation/src/SofaValidation/CompareState.cpp
+++ b/modules/SofaValidation/src/SofaValidation/CompareState.cpp
@@ -21,14 +21,16 @@
 ******************************************************************************/
 
 #include <SofaValidation/CompareState.h>
+#include <sofa/core/ObjectFactory.h>
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/core/behavior/OdeSolver.h>
 #include <sofa/simulation/MechanicalVisitor.h>
 #include <sofa/simulation/UpdateMappingVisitor.h>
-#include <sofa/core/ObjectFactory.h>
 #include <SofaSimulationCommon/xml/XML.h>
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/system/SetDirectory.h>
 #include <sofa/simulation/Node.h>
+
 
 #include <sstream>
 #include <algorithm>


### PR DESCRIPTION
This is the second step of removal of Base* inclusion in Node.h 
This is made possible by all the PR that layed out the fwd stuff and Link refactoring. 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
