### PR TITLE
[SofaSimpleFem] Fix nasty bug in HexaFEMForceField' s draw()

### DIFF
--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/HexahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/HexahedronFEMForceField.inl
@@ -1195,7 +1195,6 @@ void HexahedronFEMForceField<DataTypes>::draw(const core::visual::VisualParams* 
 
     typename VecElement::const_iterator it;
     sofa::Index i;
-    std::vector< defaulttype::Vector3 > points[6];
     for(it = this->getIndexedElements()->begin(), i = 0 ; it != this->getIndexedElements()->end() ; ++it, ++i)
     {
         Index a = (*it)[0];
@@ -1223,47 +1222,15 @@ void HexahedronFEMForceField<DataTypes>::draw(const core::visual::VisualParams* 
             vparams->drawTool()->enableBlending();
         }
 
-        points[0].push_back(pa);
-        points[0].push_back(pb);
-        points[0].push_back(pc);
-        points[0].push_back(pa);
-        points[0].push_back(pc);
-        points[0].push_back(pd);
-
-        points[1].push_back(pe);
-        points[1].push_back(pf);
-        points[1].push_back(pg);
-        points[1].push_back(pe);
-        points[1].push_back(pg);
-        points[1].push_back(ph);
-
-        points[2].push_back(pc);
-        points[2].push_back(pd);
-        points[2].push_back(ph);
-        points[2].push_back(pc);
-        points[2].push_back(ph);
-        points[2].push_back(pg);
-
-        points[3].push_back(pa);
-        points[3].push_back(pb);
-        points[3].push_back(pf);
-        points[3].push_back(pa);
-        points[3].push_back(pf);
-        points[3].push_back(pe);
-
-        points[4].push_back(pa);
-        points[4].push_back(pd);
-        points[4].push_back(ph);
-        points[4].push_back(pa);
-        points[4].push_back(ph);
-        points[4].push_back(pe);
-
-        points[5].push_back(pb);
-        points[5].push_back(pc);
-        points[5].push_back(pg);
-        points[5].push_back(pb);
-        points[5].push_back(pg);
-        points[5].push_back(pf);
+        std::vector< defaulttype::Vector3 > points[6] =
+        {
+            { pa, pb, pc, pa, pc, pd },
+            { pe, pf, pg, pe, pg, ph },
+            { pc, pd, ph, pc, ph, pg },
+            { pa, pb, pf, pa, pf, pe },
+            { pa, pd, ph, pa, ph, pe },
+            { pb, pc, pg, pb, pg, pf },
+        };
 
         vparams->drawTool()->setLightingEnabled(false);
         vparams->drawTool()->drawTriangles(points[0], sofa::helper::types::RGBAColor(0.7f,0.7f,0.1f,(_sparseGrid?_sparseGrid->getStiffnessCoef(i):1.0f)));


### PR DESCRIPTION
Fix SofaPython3 advanced_timer.py test when launched from runSofa (and a gui)

The draw() function was pushing_back() new points, making the loop slower and slower (and the memory exploding...)
Rewrote in a  cleaner and more readable way.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
