### PR TITLE
[SofaBaseCollision] Fix simulation dependency

### DIFF
--- a/SofaKernel/modules/SofaBaseCollision/CMakeLists.txt
+++ b/SofaKernel/modules/SofaBaseCollision/CMakeLists.txt
@@ -73,7 +73,7 @@ set(SOURCE_FILES
 find_package(SofaFramework REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaCore SofaSimulationCommon)
+target_link_libraries(${PROJECT_NAME} PUBLIC SofaCore SofaSimulationCore)
 
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Silence attribute warnings (for example, ignored already defined external template)

--- a/SofaKernel/modules/SofaBaseCollision/SofaBaseCollisionConfig.cmake.in
+++ b/SofaKernel/modules/SofaBaseCollision/SofaBaseCollisionConfig.cmake.in
@@ -4,7 +4,6 @@
 @PACKAGE_INIT@
 
 find_package(SofaFramework QUIET REQUIRED)
-find_package(SofaSimulationCommon QUIET REQUIRED)
 
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/applications/plugins/MultiThreading/CMakeLists.txt
+++ b/applications/plugins/MultiThreading/CMakeLists.txt
@@ -24,9 +24,10 @@ set(SOURCE_FILES
     )
 
 find_package(SofaMiscMapping REQUIRED)
+find_package(SofaSimulationCommon REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} SofaBaseMechanics SofaMiscMapping SofaConstraint)
+target_link_libraries(${PROJECT_NAME} SofaBaseMechanics SofaMiscMapping SofaConstraint SofaSimulationCommon)
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-DSOFA_MULTITHREADING_PLUGIN")
 
 

--- a/applications/plugins/MultiThreading/MultiThreadingConfig.cmake.in
+++ b/applications/plugins/MultiThreading/MultiThreadingConfig.cmake.in
@@ -2,7 +2,9 @@
 
 @PACKAGE_GUARD@
 @PACKAGE_INIT@
-find_package(SofaMiscMapping REQUIRED)
+find_package(SofaMiscMapping QUIET REQUIRED)
+find_package(SofaSimulationCommon QUIET REQUIRED)
+
 #find_package(Boost QUIET COMPONENTS thread)
 
 if(NOT TARGET MultiThreading)

--- a/modules/SofaGuiCommon/CMakeLists.txt
+++ b/modules/SofaGuiCommon/CMakeLists.txt
@@ -4,6 +4,7 @@ project(SofaGuiCommon)
 find_package(SofaBase REQUIRED)
 find_package(SofaUserInteraction REQUIRED)
 find_package(SofaGraphComponent REQUIRED)
+find_package(SofaSimulationCommon REQUIRED)
 sofa_find_package(Sofa.GL QUIET) # ColourPickingVisitor
 if(Sofa.GL_FOUND)
     message("-- ${PROJECT_NAME}: Sofa.GL dependent features enabled.")
@@ -43,7 +44,7 @@ set(SOURCE_FILES
 )
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaBase SofaGraphComponent SofaUserInteraction)
+target_link_libraries(${PROJECT_NAME} PUBLIC SofaBase SofaGraphComponent SofaUserInteraction SofaSimulationCommon)
 
 # This is required to be able to #include <sofa/gui/BaseGui.h> instead of #include <SofaGuiCommon/sofa/gui/BaseGui.h>
 target_include_directories(${PROJECT_NAME} PUBLIC "$<INSTALL_INTERFACE:include/${PROJECT_NAME}/${PROJECT_NAME}>")

--- a/modules/SofaGuiCommon/SofaGuiCommonConfig.cmake.in
+++ b/modules/SofaGuiCommon/SofaGuiCommonConfig.cmake.in
@@ -8,6 +8,7 @@ set(SOFAGUICOMMON_HAVE_SOFA.GL @SOFAGUICOMMON_HAVE_SOFA.GL@)
 find_package(SofaBase QUIET REQUIRED)
 find_package(SofaUserInteraction QUIET REQUIRED)
 find_package(SofaGraphComponent QUIET REQUIRED)
+find_package(SofaSimulationCommon QUIET REQUIRED)
 
 if(SOFAGUICOMMON_HAVE_SOFA.GL)
     find_package(Sofa.GL QUIET REQUIRED)

--- a/modules/SofaValidation/CMakeLists.txt
+++ b/modules/SofaValidation/CMakeLists.txt
@@ -45,9 +45,10 @@ find_package(SofaBase REQUIRED) # SofaBaseCollision
 find_package(SofaMeshCollision REQUIRED)
 find_package(SofaLoader REQUIRED)
 find_package(SofaGeneralLoader REQUIRED)
+find_package(SofaSimulationCommon REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaBaseCollision SofaLoader SofaMeshCollision SofaGeneralLoader)
+target_link_libraries(${PROJECT_NAME} PUBLIC SofaBaseCollision SofaLoader SofaMeshCollision SofaGeneralLoader SofaSimulationCommon)
 
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}

--- a/modules/SofaValidation/SofaValidationConfig.cmake.in
+++ b/modules/SofaValidation/SofaValidationConfig.cmake.in
@@ -6,6 +6,7 @@ find_package(SofaBase QUIET REQUIRED)
 find_package(SofaMeshCollision QUIET REQUIRED)
 find_package(SofaLoader QUIET REQUIRED)
 find_package(SofaGeneralLoader QUIET REQUIRED)
+find_package(SofaSimulationCommon QUIET REQUIRED)
 
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
Follow-up #1767 

SofaBaseCollision just needs SofaSimulationCore

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
