### PR TITLE
[SofaMacros] Shorter name for relocatable targets

### DIFF
--- a/SofaKernel/SofaFramework/SofaMacrosInstall.cmake
+++ b/SofaKernel/SofaFramework/SofaMacrosInstall.cmake
@@ -704,8 +704,11 @@ function(sofa_set_project_install_relocatable project_name binary_dir install_di
     # Remove cmakepatch file at each configure
     file(REMOVE "${binary_dir}/cmake_install.cmakepatch")
 
+    set(custom_target ${project_name}_relocatable_install)
     get_filename_component(binary_dirname "${binary_dir}" NAME_WE)
-    set(custom_target ${project_name}_${binary_dirname}_relocatable_install)
+    if(binary_dirname AND NOT "${binary_dirname}" STREQUAL "${project_name}")
+        set(custom_target ${project_name}_${binary_dirname}_relocatable_install)
+    endif()
 
     # Hack to make installed plugin independant and keep the add_subdirectory mechanism
     # Does not fail if cmakepatch file already exists thanks to "|| true"


### PR DESCRIPTION
This should fix most path size issues on Windows

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
