### PR TITLE
[SofaHelper] Remove SofaSimulationCore dependency from AdvancedTimer

### DIFF
--- a/SofaKernel/modules/SofaHelper/CMakeLists.txt
+++ b/SofaKernel/modules/SofaHelper/CMakeLists.txt
@@ -374,17 +374,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen)
 
 # Json (header only) needed by AdvancedTimer
 if(JSON_FOUND)
-    install(DIRECTORY "${JSON_INCLUDE_DIR}/"
-        COMPONENT headers
-        DESTINATION "include/extlibs/json"
-        PATTERN "*.in" EXCLUDE
-        PATTERN "*.txt" EXCLUDE
-        PATTERN "*.cpp" EXCLUDE
-        )
-    target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
-        "$<BUILD_INTERFACE:${JSON_INCLUDE_DIR}>"
-        "$<INSTALL_INTERFACE:include/extlibs/json>"
-        )
+    target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "$<BUILD_INTERFACE:${JSON_INCLUDE_DIR}>")
 endif()
 
 sofa_add_targets_to_package(

--- a/SofaKernel/modules/SofaHelper/SofaHelper_simutest/AdvancedTimer_test.cpp
+++ b/SofaKernel/modules/SofaHelper/SofaHelper_simutest/AdvancedTimer_test.cpp
@@ -99,8 +99,8 @@ TEST_F(AdvancedTimerTest, End)
 	using namespace sofa::helper;
 	initScene();
 
-	ASSERT_TRUE(AdvancedTimer::end("validId", root.get()) == std::string(""));
-	ASSERT_TRUE(AdvancedTimer::end("", root.get())  == std::string(""));
+	ASSERT_TRUE(AdvancedTimer::end("validId", root->getTime(), root->getDt()) == std::string(""));
+	ASSERT_TRUE(AdvancedTimer::end("", root->getTime(), root->getDt())  == std::string(""));
 	EXPECT_NO_FATAL_FAILURE(AdvancedTimer::end("validId", nullptr));
 }
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.cpp
@@ -20,13 +20,10 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #define SOFA_HELPER_ADVANCEDTIMER_CPP
-#include <sofa/helper/AdvancedTimer.h>
-#include <sofa/simulation/Node.h>
-#include <sofa/helper/vector.h>
-#include <sofa/helper/map.h>
-#include <iomanip>
-#include "../../extlibs/json/json.h"
 
+#include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/vector.h>
+#include <json.h>
 
 #include <iomanip>
 #include <cmath>
@@ -34,6 +31,7 @@
 #include <stack>
 #include <algorithm>
 #include <cctype>
+#include <iostream>
 
 #define DEFAULT_INTERVAL 100
 
@@ -330,7 +328,7 @@ void AdvancedTimer::end(IdTimer id)
     }
 }
 
-std::string AdvancedTimer::end(IdTimer id, simulation::Node* node)
+std::string AdvancedTimer::end(IdTimer id, double time, double dt)
 {
     TimerData& data = timers[id];
     if(!data.id)
@@ -340,8 +338,8 @@ std::string AdvancedTimer::end(IdTimer id, simulation::Node* node)
 
     switch(data.timerOutputType)
     {
-        case JSON   : return getTimeAnalysis(id, node);
-        case LJSON  : return getTimeAnalysis(id, node);
+        case JSON   : return getTimeAnalysis(id, time, dt);
+        case LJSON  : return getTimeAnalysis(id, time, dt);
         case GUI    : return std::string("");
         case STDOUT : end(id);
                       return std::string("");
@@ -1442,11 +1440,9 @@ void AdvancedTimer::clearData(IdTimer id)
     data.clear();
 }
 
-std::string AdvancedTimer::getTimeAnalysis(IdTimer id, simulation::Node* node)
+std::string AdvancedTimer::getTimeAnalysis(IdTimer id, double time, double deltaTime)
 {
     // Get simulation context and find the actual simulation step
-    double time = node->getContext()->getTime();
-    double deltaTime = node->getContext()->getDt();
     std::stringstream tempStepNumber;
     std::string stepNumber;
     json outputJson;

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.h
@@ -25,7 +25,8 @@
 #include <sofa/helper/system/thread/CTime.h>
 #include <sofa/helper/vector.h>
 
-#include <iostream>
+#include <ostream>
+#include <istream>
 #include <string>
 #include <map>
 
@@ -328,10 +329,11 @@ public:
     /**
      * @brief getTimeAnalysis Return the result of the AdvancedTimer
      * @param id IdTimer, id of the timer
-     * @param node Node*, pointeur on a node to get the scene simulation context
+     * @param time double, current time (from the context)
+     * @param time dt, current delta time or dt (from the context)
      * @return The timer value in JSON
      */
-    static std::string getTimeAnalysis(IdTimer id, simulation::Node* node);
+    static std::string getTimeAnalysis(IdTimer id, double time, double dt);
 
     /**
      * @brief getSteps Return the vector of IDStep of the AdvancedTimer given execution
@@ -371,10 +373,26 @@ public:
     /**
      * @brief end Ovveride fo the end method in which you can use JSON or old format
      * @param id IdTimer, the id of the used timer
-     * @param node Node*, node used to get the scene cotext
+     * @param time double, current time (from the context)
+     * @param time dt, current delta time or dt (from the context)
      * @return std::string, the output if JSON format is set
      */
-    static std::string end(IdTimer id, simulation::Node* node);
+    static std::string end(IdTimer id, double time, double dt);
+
+    /**
+     * @brief end Deprecated version with a node Pointer ; does not do anything.
+     * @param id IdTimer, the id of the used timer
+     * @param node simulation::Node* 
+     * @return std::string, the output if JSON format is set
+     */
+    [[deprecated("This function has been deprecated in #PR XXXX because of simulation::Node dependency." \
+        "This function does not take into account the node argument, and will be removed in the v21.06 release." \
+        "Use end(id, node->getTime(), node->getDt()) instead.")]]
+    static std::string end(IdTimer id, simulation::Node* node)
+    {
+        end(id);
+        return std::string("");
+    }
 
     static bool isActive();
 

--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -480,7 +480,7 @@ int main(int argc, char** argv)
     sofa::simulation::getSimulation()->init(groot.get());
     if( computationTimeAtBegin )
     {
-        msg_info("") << sofa::helper::AdvancedTimer::end("Init", groot.get());
+        msg_info("") << sofa::helper::AdvancedTimer::end("Init", groot->getTime(), groot->getDt());
     }
 
     //=======================================

--- a/modules/SofaGuiCommon/src/sofa/gui/BatchGUI.cpp
+++ b/modules/SofaGuiCommon/src/sofa/gui/BatchGUI.cpp
@@ -61,7 +61,7 @@ int BatchGUI::mainLoop()
 
         sofa::helper::AdvancedTimer::begin("Animate");
         sofa::simulation::getSimulation()->animate(groot.get());
-        msg_info("BatchGUI") << "Processing." << sofa::helper::AdvancedTimer::end("Animate", groot.get()) << msgendl;
+        msg_info("BatchGUI") << "Processing." << sofa::helper::AdvancedTimer::end("Animate", groot->getTime(), groot->getDt()) << msgendl;
         sofa::simulation::Visitor::ctime_t rtfreq = sofa::helper::system::thread::CTime::getRefTicksPerSec();
         sofa::simulation::Visitor::ctime_t tfreq = sofa::helper::system::thread::CTime::getTicksPerSec();
         sofa::simulation::Visitor::ctime_t rt = sofa::helper::system::thread::CTime::getRefTime();


### PR DESCRIPTION
AdvancedTimer has a function end(), which wants a Node just to get a time and a dt...
And add an ugly (implicit) dependency on SofaSimulationCore (header-wise)

Consequently, this PR :
 - adds a fonction end() which takes a time and a dt instead of a Node*
 - deprecates the original function end(... , Node* node) but change its behavior (calling the standard end())

Maybe it would even better to just delete the end() taking a Node*, as only BatchGUI, runSofa and its own test are using it. (in the SOFA code base at least)

And as a side commit, clean the includes (json double-quoted include 🥱 )


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
