### PR TITLE
[SofaHelper] Throw a compilation error if using AdvancedTimer end(Node*)

### DIFF
--- a/SofaKernel/modules/SofaHelper/SofaHelper_simutest/AdvancedTimer_test.cpp
+++ b/SofaKernel/modules/SofaHelper/SofaHelper_simutest/AdvancedTimer_test.cpp
@@ -101,7 +101,7 @@ TEST_F(AdvancedTimerTest, End)
 
 	ASSERT_TRUE(AdvancedTimer::end("validId", root->getTime(), root->getDt()) == std::string(""));
 	ASSERT_TRUE(AdvancedTimer::end("", root->getTime(), root->getDt())  == std::string(""));
-	EXPECT_NO_FATAL_FAILURE(AdvancedTimer::end("validId", nullptr));
+	EXPECT_NO_FATAL_FAILURE(AdvancedTimer::end("validId"));
 }
 
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.h
@@ -380,19 +380,14 @@ public:
     static std::string end(IdTimer id, double time, double dt);
 
     /**
-     * @brief end Deprecated version with a node Pointer ; does not do anything.
+     * @brief end Deleted version with a node Pointer ; will throw an error at compile-time if called.
      * @param id IdTimer, the id of the used timer
      * @param node simulation::Node* 
      * @return std::string, the output if JSON format is set
      */
-    [[deprecated("This function has been deprecated in #PR XXXX because of simulation::Node dependency." \
-        "This function does not take into account the node argument, and will be removed in the v21.06 release." \
+    [[deprecated("This function has been deleted in #PR 1770 because of simulation::Node dependency." \
         "Use end(id, node->getTime(), node->getDt()) instead.")]]
-    static std::string end(IdTimer id, simulation::Node* node)
-    {
-        end(id);
-        return std::string("");
-    }
+    static std::string end(IdTimer id, simulation::Node* node) = delete;
 
     static bool isActive();
 

--- a/applications/plugins/SofaPython/Binding_SofaModule.cpp
+++ b/applications/plugins/SofaPython/Binding_SofaModule.cpp
@@ -878,7 +878,7 @@ static PyObject * Sofa_timerEnd(PyObject* /*self*/, PyObject *args)
 
     node = down_cast<Node>(((PySPtr<Base>*)tempNode)->object->toBaseNode());
 
-    result = AdvancedTimer::end(id, node);
+    result = AdvancedTimer::end(id, node->getTime(), node->getDt());
 
     if(std::string("null").compare(result) == 0)
         Py_RETURN_NONE;


### PR DESCRIPTION
Follow-up of #1770 where it was decided to throw an error if calling the erroneous function but was merged before I could do it 😬
Using the =delete keyword is an elegant way to do this.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
