### PR TITLE
[Geomagic] Fix GeomagicVisualModel compilation

### DIFF
--- a/applications/plugins/Geomagic/src/Geomagic/GeomagicVisualModel.h
+++ b/applications/plugins/Geomagic/src/Geomagic/GeomagicVisualModel.h
@@ -24,6 +24,7 @@
 
 //Geomagic include
 #include <Geomagic/config.h>
+#include <Geomagic/GeomagicDriver.h>
 #include <SofaOpenglVisual/OglModel.h>
 #include <SofaLoader/MeshObjLoader.h>
 
@@ -34,8 +35,7 @@
 //Visualization
 #include <SofaRigid/RigidMapping.h>
 #include <SofaBaseMechanics/MechanicalObject.h>
-
-#include <Geomagic/GeomagicDriver.h>
+#include <sofa/simulation/Node.h>
 
 namespace sofa 
 {


### PR DESCRIPTION
Include to Node.h was missing.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
