### PR TITLE
[SofaHelper][SofaPython] ADD PluginManager callback and use it in SofaPython

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
@@ -77,32 +77,31 @@ std::string cleanPath( const std::string& path )
 // Initialize PluginRepository and DataRepository
 #ifdef WIN32
 FileRepository PluginRepository(
-        "SOFA_PLUGIN_PATH", {
-            Utils::getExecutableDirectory(),
-            Utils::getSofaPathTo("bin"),
-            Utils::getSofaPathTo("plugins")
-        }
+    "SOFA_PLUGIN_PATH",
+    {
+        Utils::getSofaPathTo("plugins"),
+        Utils::getSofaPathTo("bin"),
+        Utils::getExecutableDirectory(),
+    }
 );
 #else
 FileRepository PluginRepository(
-        "SOFA_PLUGIN_PATH", {
-            Utils::getSofaPathTo("lib"),
-            Utils::getSofaPathTo("plugins"),
-        }
+    "SOFA_PLUGIN_PATH",
+    {
+        Utils::getSofaPathTo("plugins"),
+        Utils::getSofaPathTo("lib"),
+    }
 );
 #endif
 FileRepository DataRepository(
-        "SOFA_DATA_PATH",
-        {
-                Utils::getSofaPathTo("share/sofa"),
-                Utils::getSofaPathTo("share/sofa/examples")
-        },
-        {
-            {
-                Utils::getSofaPathTo("etc/sofa.ini"),
-                {"SHARE_DIR", "EXAMPLES_DIR"}
-            }
-        }
+    "SOFA_DATA_PATH",
+    {
+        Utils::getSofaPathTo("share/sofa"),
+        Utils::getSofaPathTo("share/sofa/examples")
+    },
+    {
+        { Utils::getSofaPathTo("etc/sofa.ini"), {"SHARE_DIR", "EXAMPLES_DIR"} }
+    }
 );
 
 FileRepository::FileRepository(const char* envVar, const std::vector<std::string> & paths, const fileKeysMap& iniFilesAndKeys) {

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
@@ -186,7 +186,29 @@ bool PluginManager::loadPluginByPath(const std::string& pluginPath, std::ostream
     p.initExternalModule();
 
     msg_info("PluginManager") << "Loaded plugin: " << pluginPath;
+
+    for (const auto& [key, callback] : m_onPluginLoadedCallbacks)
+    {
+        if(callback)
+        {
+            callback(pluginPath, p);
+        }
+    }
+
     return true;
+}
+
+void PluginManager::addOnPluginLoadedCallback(const std::string& key, std::function<void(const std::string&, const Plugin&)> callback)
+{
+    if(m_onPluginLoadedCallbacks.find(key) == m_onPluginLoadedCallbacks.end())
+    {
+        m_onPluginLoadedCallbacks[key] = callback;
+    }
+}
+
+void PluginManager::removeOnPluginLoadedCallback(const std::string& key)
+{
+    m_onPluginLoadedCallbacks.erase(key);
 }
 
 bool PluginManager::loadPluginByName(const std::string& pluginName, const std::string& suffix, bool ignoreCase, bool recursive, std::ostream* errlog)
@@ -231,6 +253,7 @@ bool PluginManager::unloadPlugin(const std::string &pluginPath, std::ostream* er
     else
     {
         m_pluginMap.erase(m_pluginMap.find(pluginPath));
+        removeOnPluginLoadedCallback(pluginPath);
         return true;
     }
 }

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.h
@@ -27,6 +27,7 @@
 #include <vector>
 #include <map>
 #include <memory>
+#include <functional>
 
 namespace sofa
 {
@@ -192,6 +193,9 @@ public:
 
     static std::string s_gui_postfix; ///< the postfix to gui plugin, default="gui" (e.g. myplugin_gui.so)
 
+    void addOnPluginLoadedCallback(const std::string& key, std::function<void(const std::string&, const Plugin&)> callback);
+    void removeOnPluginLoadedCallback(const std::string& key);
+
 private:
     PluginManager();
     ~PluginManager();
@@ -200,6 +204,7 @@ private:
     std::istream& readFromStream( std::istream& );
 private:
     PluginMap m_pluginMap;
+    std::map<std::string, std::function<void(const std::string&, const Plugin&)>> m_onPluginLoadedCallbacks;
 };
 
 

--- a/applications/plugins/SofaPython/PythonEnvironment.cpp
+++ b/applications/plugins/SofaPython/PythonEnvironment.cpp
@@ -338,19 +338,15 @@ void PythonEnvironment::addPluginManagerCallback()
 {
     PluginManager::getInstance().addOnPluginLoadedCallback(pluginLibraryPath,
         [](const std::string& pluginLibraryPath, const Plugin& plugin) {
-            // WARNING:
-            // Loaded plugin must be organized like plugin_name/lib/plugin_name.so
-
-            // pluginRoot must be 2 levels above the library
-            std::string pluginRoot = FileSystem::getParentDirectory(
-                                         FileSystem::getParentDirectory(
-                                            pluginLibraryPath
-                                     ));
-            // pluginRoot basename must be pluginName
-            std::string pluginName = plugin.getModuleName();
-            if(FileSystem::stripDirectory(pluginRoot) == pluginName)
+            // WARNING: loaded plugin must be organized like plugin_name/lib/plugin_name.so
+            for ( auto path : sofa::helper::system::PluginRepository.getPaths() )
             {
-                PythonEnvironment::addPythonModulePathsForPlugins(pluginRoot);
+                std::string pluginRoot = FileSystem::cleanPath( path + "/" + plugin.getModuleName() );
+                if ( FileSystem::isDirectory(pluginRoot) )
+                {
+                    PythonEnvironment::addPythonModulePathsForPlugins(pluginRoot);
+                    return;
+                }
             }
         }
     );

--- a/applications/plugins/SofaPython/PythonEnvironment.cpp
+++ b/applications/plugins/SofaPython/PythonEnvironment.cpp
@@ -344,7 +344,7 @@ void PythonEnvironment::addPluginManagerCallback()
                 std::string pluginRoot = FileSystem::cleanPath( path + "/" + plugin.getModuleName() );
                 if ( FileSystem::isDirectory(pluginRoot) )
                 {
-                    PythonEnvironment::addPythonModulePathsForPlugins(pluginRoot);
+                    addPythonModulePathsForPlugins(pluginRoot);
                     return;
                 }
             }

--- a/applications/plugins/SofaPython/PythonEnvironment.cpp
+++ b/applications/plugins/SofaPython/PythonEnvironment.cpp
@@ -342,7 +342,7 @@ void PythonEnvironment::addPluginManagerCallback()
             for ( auto path : sofa::helper::system::PluginRepository.getPaths() )
             {
                 std::string pluginRoot = FileSystem::cleanPath( path + "/" + plugin.getModuleName() );
-                if ( FileSystem::isDirectory(pluginRoot) )
+                if ( FileSystem::exists(pluginRoot) && FileSystem::isDirectory(pluginRoot) )
                 {
                     addPythonModulePathsForPlugins(pluginRoot);
                     return;

--- a/applications/plugins/SofaPython/PythonEnvironment.cpp
+++ b/applications/plugins/SofaPython/PythonEnvironment.cpp
@@ -311,7 +311,7 @@ void PythonEnvironment::addPythonModulePathsForPlugins(const std::string& plugin
 
     if(!added)
     {
-        msg_warning("PythonEnvironment") << "No python dir found in " << pluginsDirectory;
+        msg_info("PythonEnvironment") << "No python dir found in " << pluginsDirectory;
     }
 }
 
@@ -331,7 +331,7 @@ void PythonEnvironment::addPythonModulePathsForPluginsByName(const std::string& 
             return;
         }
     }
-    msg_warning("PythonEnvironment") << pluginName << " not found in PluginManager's map.";
+    msg_info("PythonEnvironment") << pluginName << " not found in PluginManager's map.";
 }
 
 void PythonEnvironment::addPluginManagerCallback()

--- a/applications/plugins/SofaPython/PythonEnvironment.h
+++ b/applications/plugins/SofaPython/PythonEnvironment.h
@@ -46,6 +46,11 @@ public:
     static void Init();
     static void Release();
 
+    /// Add a new callback in PluginManager to auto-add future
+    /// loaded plugins to sys.path
+    static void addPluginManagerCallback();
+    static void removePluginManagerCallback();
+
     /// Add a path to sys.path, the list of search path for Python modules.
     static void addPythonModulePath(const std::string& path);
 
@@ -117,6 +122,7 @@ public:
 
 private:
     static PythonEnvironmentData* getStaticData() ;
+    static std::string PythonEnvironment::pluginLibraryPath;
 };
 
 

--- a/applications/plugins/SofaPython/PythonEnvironment.h
+++ b/applications/plugins/SofaPython/PythonEnvironment.h
@@ -122,7 +122,7 @@ public:
 
 private:
     static PythonEnvironmentData* getStaticData() ;
-    static std::string PythonEnvironment::pluginLibraryPath;
+    static std::string pluginLibraryPath;
 };
 
 

--- a/applications/plugins/SofaPython/initSofaPython.cpp
+++ b/applications/plugins/SofaPython/initSofaPython.cpp
@@ -34,6 +34,10 @@ SOFA_SOFAPYTHON_API void initExternalModule()
         sofa::simulation::PythonEnvironment::Init();
         firstPythonInit = false;
     }
+
+    // Add a callback in PluginManager
+    // to auto-add future loaded plugins to sys.path
+    sofa::simulation::PythonEnvironment::addPluginManagerCallback();
 }
 
 SOFA_SOFAPYTHON_API const char* getModuleName()


### PR DESCRIPTION
The idea is to trigger a callback after every plugin loading to permit SofaPython and SofaPython3 to check if any site-packages directory can be added to sys.path

No more manual PYTHONPATH setting should be needed with this change.

To be backported in v20.12 to ease SofaPython3 usage.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
