### PR TITLE
[SofaHelper] Fix AdvandedTimer test with end()

### DIFF
--- a/SofaKernel/modules/SofaHelper/SofaHelper_simutest/AdvancedTimer_test.cpp
+++ b/SofaKernel/modules/SofaHelper/SofaHelper_simutest/AdvancedTimer_test.cpp
@@ -54,9 +54,9 @@ protected:
 				 "<Node 	name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
 				 "</Node>                                                                        \n" ;
 
-		//root = SceneLoaderXML::loadFromMemory ("testscene",
-		//									scene.str().c_str(),
-		//									scene.str().size()) ;
+		root = SceneLoaderXML::loadFromMemory ("testscene",
+											scene.str().c_str(),
+											scene.str().size()) ;
 	}
 
 public:
@@ -98,9 +98,10 @@ TEST_F(AdvancedTimerTest, End)
 {
 	using namespace sofa::helper;
 	initScene();
-
+	AdvancedTimer::begin("validId");
 	ASSERT_TRUE(AdvancedTimer::end("validId", root->getTime(), root->getDt()) == std::string(""));
 	ASSERT_TRUE(AdvancedTimer::end("", root->getTime(), root->getDt())  == std::string(""));
+	AdvancedTimer::begin("validId");
 	EXPECT_NO_FATAL_FAILURE(AdvancedTimer::end("validId"));
 }
 


### PR DESCRIPTION
I don't know why this was not detected while doing the previous #1770 🤨
Or maybe it was not noticed... 😮



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
