### PR TITLE
[SofaCUDA] Renaming cudaMatrix methods to use rowSize and colSize 

### DIFF
--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMatrix.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMatrix.h
@@ -198,6 +198,12 @@ public:
         return sizeY;
     }
 
+    [[deprecated("2021-02-17: Method has been depreciate in PR #1788. Please use rowSize instead")]]
+    Size getSizeY() const {return  rowSize();}
+
+    [[deprecated("2021-02-17: Method has been depreciate in PR #1788. Please use colSize instead")]]
+    Size getSizeX() const {return  colSize();}
+
     Size getPitchDevice() const {
         return pitch_device;
     }

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMatrix.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMatrix.h
@@ -455,10 +455,10 @@ public:
     friend std::ostream& operator<< ( std::ostream& os, const Matrix & mat ) {
         mat.hostRead();
         os << "[\n";
-        for (unsigned j=0; j<mat.getSizeY(); j++)
+        for (unsigned j=0; j<mat.rowSize(); j++)
         {
             os << "[ ";
-            for (unsigned i=0; i<mat.getSizeX(); i++)
+            for (unsigned i=0; i<mat.colSize(); i++)
             {
                 os << " " << mat[j][i];
             }

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMatrix.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMatrix.h
@@ -190,11 +190,11 @@ public:
         if (devicePointer!=NULL) mycudaFree(devicePointer);
     }
 
-    Size getSizeX() const {
+    Size colSize() const {
         return sizeX;
     }
 
-    Size getSizeY() const {
+    Size rowSize() const {
         return sizeY;
     }
 


### PR DESCRIPTION

Change Naming in cudaMatrix with rowSize and colSize which are the standard names in sofa. 
This change enables to use CudaMatrix as template


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
