### PR TITLE
[SofaOpenCL] Fix compilation

### DIFF
--- a/applications/plugins/SofaOpenCL/OpenCLFixedConstraint.inl
+++ b/applications/plugins/SofaOpenCL/OpenCLFixedConstraint.inl
@@ -248,9 +248,9 @@ void FixedConstraintInternalData<gpu::opencl::OpenCLVec3d1Types>::projectRespons
 	{ data->removeConstraint(this, index); } \
     template<> void FixedConstraint< T >::projectResponse(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataVecDeriv& d_resData) \
     {  \
-        VecDeriv &resData = *d_resData.beginEdit(mparams); \
+        VecDeriv &resData = *d_resData.beginEdit(); \
         data->projectResponse(this, resData);               \
-        d_resData.endEdit(mparams);                        \
+        d_resData.endEdit();                        \
     }
 
 OpenCLFixedConstraint_ImplMethods(gpu::opencl::OpenCLVec3fTypes);


### PR DESCRIPTION
OpenCL's FixedConstraint was still using the deprecated/removed beginEdit()/endEdit() with ExecParams.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
