### PR TITLE
[SofaHelper] Remove Datatypeinfo dependency in vector(_device).h

### DIFF
--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_Vector.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/typeinfo/TypeInfo_Vector.h
@@ -27,35 +27,35 @@
 namespace sofa::defaulttype
 {
 
-template<class T, class Alloc>
-struct DataTypeInfo< sofa::helper::vector<T,Alloc> > : public VectorTypeInfo<sofa::helper::vector<T,Alloc> >
+template<class T, class Alloc, class TypeInfoManager>
+struct DataTypeInfo< sofa::helper::vector<T,Alloc, TypeInfoManager> > : public VectorTypeInfo<sofa::helper::vector<T,Alloc, TypeInfoManager> >
 {
 };
 
 // vector<bool> is a bitset, cannot get a pointer to the values
-template<class Alloc>
-struct DataTypeInfo< sofa::helper::vector<bool,Alloc> > : public VectorTypeInfo<sofa::helper::vector<bool,Alloc> >
+template<class Alloc, class TypeInfoManager>
+struct DataTypeInfo< sofa::helper::vector<bool,Alloc, TypeInfoManager> > : public VectorTypeInfo<sofa::helper::vector<bool,Alloc, TypeInfoManager> >
 {
     enum { SimpleLayout = 0 };
-    static const void* getValuePtr(const sofa::helper::vector<bool,Alloc>& /*data*/) { return nullptr; }
-    static void* getValuePtr(sofa::helper::vector<bool,Alloc>& /*data*/) { return nullptr; }
+    static const void* getValuePtr(const sofa::helper::vector<bool,Alloc, TypeInfoManager>& /*data*/) { return nullptr; }
+    static void* getValuePtr(sofa::helper::vector<bool,Alloc, TypeInfoManager>& /*data*/) { return nullptr; }
 };
 
 // Cannot use default impl of VectorTypeInfo for non-fixed size BaseTypes
-template<class Alloc>
-struct DataTypeInfo< sofa::helper::vector<std::string,Alloc> > : public VectorTypeInfo<sofa::helper::vector<std::string,Alloc> >
+template<class Alloc, class TypeInfoManager>
+struct DataTypeInfo< sofa::helper::vector<std::string,Alloc, TypeInfoManager> > : public VectorTypeInfo<sofa::helper::vector<std::string,Alloc, TypeInfoManager> >
 {
     // BaseType size is not fixed. Returning 1
     static sofa::Size size() { return 1; }
 
     // Total number of elements in the vector
-    static sofa::Size size(const sofa::helper::vector<std::string,Alloc>& data) { return sofa::Size(data.size()); }
+    static sofa::Size size(const sofa::helper::vector<std::string,Alloc, TypeInfoManager>& data) { return sofa::Size(data.size()); }
 
     // Resizes the vector
-    static bool setSize(sofa::helper::vector<std::string,Alloc>& data, sofa::Size size) { data.resize(size); return true; }
+    static bool setSize(sofa::helper::vector<std::string,Alloc, TypeInfoManager>& data, sofa::Size size) { data.resize(size); return true; }
 
     // Sets the value for element at index `index`
-    static void setValueString(sofa::helper::vector<std::string,Alloc>& data, sofa::Index index, const std::string& value)
+    static void setValueString(sofa::helper::vector<std::string,Alloc, TypeInfoManager>& data, sofa::Index index, const std::string& value)
     {
         if (data.size() <= index)
             data.resize(index + 1);
@@ -63,7 +63,7 @@ struct DataTypeInfo< sofa::helper::vector<std::string,Alloc> > : public VectorTy
     }
 
     // Gets the value for element at index `index`
-    static void getValueString(const sofa::helper::vector<std::string,Alloc>& data, sofa::Index index, std::string& value)
+    static void getValueString(const sofa::helper::vector<std::string,Alloc, TypeInfoManager>& data, sofa::Index index, std::string& value)
     {
         if (data.size() <= index)
             msg_error("DataTypeInfo<helper::vector<std::string>") << "Index out of bounds for getValueString";

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/typeinfo/models/VectorTypeInfo.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/typeinfo/models/VectorTypeInfo.h
@@ -24,6 +24,7 @@
 #include <sstream>
 
 #include <sofa/defaulttype/typeinfo/DataTypeInfo.h>
+#include <sofa/helper/vector.h>
 
 namespace sofa::defaulttype
 {

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.cpp
@@ -32,6 +32,7 @@
 #include <algorithm>
 #include <cctype>
 #include <iostream>
+#include <atomic>
 
 #define DEFAULT_INTERVAL 100
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/SVector.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/SVector.h
@@ -37,53 +37,54 @@ namespace helper
 template<
 class T
 >
-class SVector: public helper::vector<T, helper::CPUMemoryManager<T> >
+class SVector: public helper::vector<T, helper::CPUMemoryManager<T>, helper::TypeInfoManager<T> >
 {
 public:
+    using Inherit = helper::vector<T, helper::CPUMemoryManager<T>, helper::TypeInfoManager<T> >;
     typedef helper::CPUMemoryManager<T>  Alloc;
     /// Size
-    typedef typename helper::vector<T,Alloc>::Size Size;
+    typedef typename Inherit::Size Size;
     /// reference to a value (read-write)
-    //typedef typename helper::vector<T,Alloc>::reference reference;
+    //typedef typename Inherit::reference reference;
     /// const reference to a value (read only)
-    //typedef typename helper::vector<T,Alloc>::const_reference const_reference;
+    //typedef typename Inherit::const_reference const_reference;
 
     /// Basic onstructor
-    SVector() : helper::vector<T,Alloc>() {}
+    SVector() : Inherit() {}
     /// Constructor
-    SVector(Size n, const T& value): helper::vector<T,Alloc>(n,value) {}
+    SVector(Size n, const T& value): Inherit(n,value) {}
     /// Constructor
-    SVector(int n, const T& value): helper::vector<T,Alloc>(n,value) {}
+    SVector(int n, const T& value): Inherit(n,value) {}
     /// Constructor
-    SVector(long n, const T& value): helper::vector<T,Alloc>(n,value) {}
+    SVector(long n, const T& value): Inherit(n,value) {}
     /// Constructor
-    explicit SVector(Size n): helper::vector<T,Alloc>(n) {}
+    explicit SVector(Size n): Inherit(n) {}
     /// Constructor
-    SVector(const helper::vector<T, Alloc>& x): helper::vector<T,Alloc>(x) {}
+    SVector(const Inherit& x): Inherit(x) {}
     /// Move constructor
-    SVector(helper::vector<T,Alloc>&& v): helper::vector<T,Alloc>(std::move(v)) {}
+    SVector(Inherit&& v): Inherit(std::move(v)) {}
 
 
     /// Copy operator
-    SVector<T>& operator=(const helper::vector<T, Alloc>& x)
+    SVector<T>& operator=(const Inherit& x)
     {
-        helper::vector<T,Alloc>::operator=(x);
+        Inherit::operator=(x);
         return *this;
     }
     /// Move assignment operator
-    SVector<T>& operator=(helper::vector<T,Alloc>&& v)
+    SVector<T>& operator=(Inherit&& v)
     {
-        helper::vector<T,Alloc>::operator=(std::move(v));
+        Inherit::operator=(std::move(v));
         return *this;
     }
 
 #ifdef __STL_MEMBER_TEMPLATES
     /// Constructor
     template <class InputIterator>
-    SVector(InputIterator first, InputIterator last): helper::vector<T,Alloc>(first,last) {}
+    SVector(InputIterator first, InputIterator last): Inherit(first,last) {}
 #else /* __STL_MEMBER_TEMPLATES */
     /// Constructor
-    SVector(typename SVector<T>::const_iterator first, typename SVector<T>::const_iterator last): helper::vector<T,Alloc>(first,last) {}
+    SVector(typename SVector<T>::const_iterator first, typename SVector<T>::const_iterator last): Inherit(first,last) {}
 #endif /* __STL_MEMBER_TEMPLATES */
 
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/accessor.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/accessor.h
@@ -268,20 +268,20 @@ public:
     WriteAccessor(container_type& c) : Inherit(c) {}
 };
 
-template<class T, class Alloc>
-class ReadAccessor< helper::vector<T,Alloc> > : public ReadAccessorVector< helper::vector<T,Alloc> >
+template<class T, class Alloc, class DataTypeInfo>
+class ReadAccessor< helper::vector<T,Alloc, DataTypeInfo> > : public ReadAccessorVector< helper::vector<T,Alloc, DataTypeInfo> >
 {
 public:
-    typedef ReadAccessorVector< helper::vector<T,Alloc> > Inherit;
+    typedef ReadAccessorVector< helper::vector<T,Alloc, DataTypeInfo> > Inherit;
     typedef typename Inherit::container_type container_type;
     ReadAccessor(const container_type& c) : Inherit(c) {}
 };
 
-template<class T, class Alloc>
-class WriteAccessor< helper::vector<T,Alloc> > : public WriteAccessorVector< helper::vector<T,Alloc> >
+template<class T, class Alloc, class DataTypeInfo>
+class WriteAccessor< helper::vector<T,Alloc, DataTypeInfo> > : public WriteAccessorVector< helper::vector<T,Alloc, DataTypeInfo> >
 {
 public:
-    typedef WriteAccessorVector< helper::vector<T,Alloc> > Inherit;
+    typedef WriteAccessorVector< helper::vector<T,Alloc, DataTypeInfo> > Inherit;
     typedef typename Inherit::container_type container_type;
     WriteAccessor(container_type& c) : Inherit(c) {}
 };

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/vector.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/vector.h
@@ -57,8 +57,18 @@ int SOFA_HELPER_API getInteger(const std::string& s, std::stringstream& msg, uns
 /// is incremented.
 unsigned int SOFA_HELPER_API getUnsignedInteger(const std::string& s, std::stringstream& msg, unsigned int& numErrors) ;
 
+template <typename T>
+struct TypeInfoManager
+{
+    // Not used here, just for reference
+    enum class DataTypeInfo
+    {
+        SimpleCopy = 1,
+        ZeroConstructor = 1
+    };
+};
 
-template <class T, class MemoryManager = CPUMemoryManager<T> >
+template <class T, class MemoryManager = CPUMemoryManager<T>, class DataTypeInfoManager = TypeInfoManager<T> >
 class vector;
 
 /// Regular vector
@@ -66,10 +76,12 @@ class vector;
 ///  - string serialization (making it usable in Data)
 ///  - operator[] is checking if the index is within the bounds in debug
 template <class T>
-class SOFA_HELPER_API vector<T, CPUMemoryManager<T> > : public std::vector<T, std::allocator<T> >
+class SOFA_HELPER_API vector<T, CPUMemoryManager<T>, TypeInfoManager<T> > : public std::vector<T, std::allocator<T> >
 {
 public:
     typedef CPUMemoryManager<T> memory_manager;
+    typedef TypeInfoManager<T> typeinfo;
+
     typedef std::allocator<T> Alloc;
     /// Size
     typedef typename std::vector<T,Alloc>::size_type Size;
@@ -80,7 +92,7 @@ public:
 
     template<class T2> struct rebind
     {
-        typedef vector< T2,CPUMemoryManager<T2> > other;
+        typedef vector< T2,CPUMemoryManager<T2>, TypeInfoManager<T> > other;
     };
 
     /// Basic constructor

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/vector.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/vector.h
@@ -92,7 +92,7 @@ public:
 
     template<class T2> struct rebind
     {
-        typedef vector< T2,CPUMemoryManager<T2>, TypeInfoManager<T> > other;
+        typedef vector< T2,CPUMemoryManager<T2>, TypeInfoManager<T2> > other;
     };
 
     /// Basic constructor
@@ -112,13 +112,13 @@ public:
     /// Move constructor
     vector(std::vector<T,Alloc>&& v): std::vector<T,Alloc>(std::move(v)) {}
     /// Copy operator
-    vector<T, Alloc>& operator=(const std::vector<T, Alloc>& x)
+    vector<T, Alloc, typeinfo>& operator=(const std::vector<T, Alloc>& x)
     {
         std::vector<T,Alloc>::operator=(x);
         return *this;
     }
     /// Move assignment operator
-    vector<T, Alloc>& operator=(std::vector<T,Alloc>&& v)
+    vector<T, Alloc, typeinfo>& operator=(std::vector<T,Alloc>&& v)
     {
         std::vector<T,Alloc>::operator=(std::move(v));
         return *this;

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTypes.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTypes.h
@@ -54,7 +54,7 @@ struct DataTypeInfoManager
     using DataTypeInfo = sofa::defaulttype::DataTypeInfo<T>;
     template<class T2> struct rebind
     {
-        typedef DataTypeInfoRebound<T2> other;
+        typedef DataTypeInfoManager<T2> other;
     };
 
 };

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTypes.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTypes.h
@@ -48,17 +48,29 @@ namespace gpu
 namespace cuda
 {
 
+template<typename T>
+struct DataTypeInfoManager
+{
+    using DataTypeInfo = sofa::defaulttype::DataTypeInfo<T>;
+    template<class T2> struct rebind
+    {
+        typedef DataTypeInfoRebound<T2> other;
+    };
+
+};
+
 template<class T>
-class CudaVector : public helper::vector<T,CudaMemoryManager<T> >
+class CudaVector : public helper::vector<T,CudaMemoryManager<T>, DataTypeInfoManager<T> >
 {
 public :
+    using Inherit = helper::vector<T, CudaMemoryManager<T>, DataTypeInfoManager<T> >;
     typedef size_t Size;
 
-    CudaVector() : helper::vector<T,CudaMemoryManager<T> >() {}
+    CudaVector() : Inherit() {}
 
-    CudaVector(Size n) : helper::vector<T,CudaMemoryManager<T> >(n) {}
+    CudaVector(Size n) : Inherit(n) {}
 
-    CudaVector(const helper::vector<T,CudaMemoryManager< T > >& v) : helper::vector<T,CudaMemoryManager<T> >(v) {}
+    CudaVector(const Inherit& v) : Inherit(v) {}
 
 };
 

--- a/applications/plugins/SofaOpenCL/OpenCLFixedConstraint.inl
+++ b/applications/plugins/SofaOpenCL/OpenCLFixedConstraint.inl
@@ -248,9 +248,9 @@ void FixedConstraintInternalData<gpu::opencl::OpenCLVec3d1Types>::projectRespons
 	{ data->removeConstraint(this, index); } \
     template<> void FixedConstraint< T >::projectResponse(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataVecDeriv& d_resData) \
     {  \
-        VecDeriv &resData = *d_resData.beginEdit(mparams); \
+        VecDeriv &resData = *d_resData.beginEdit(); \
         data->projectResponse(this, resData);               \
-        d_resData.endEdit(mparams);                        \
+        d_resData.endEdit();                        \
     }
 
 OpenCLFixedConstraint_ImplMethods(gpu::opencl::OpenCLVec3fTypes);

--- a/applications/plugins/SofaOpenCL/OpenCLTypes.h
+++ b/applications/plugins/SofaOpenCL/OpenCLTypes.h
@@ -41,17 +41,29 @@ namespace gpu
 namespace opencl
 {
 
+template<typename T>
+struct DataTypeInfoManager
+{
+    using DataTypeInfo = sofa::defaulttype::DataTypeInfo<T>;
+    template<class T2> struct rebind
+    {
+        typedef DataTypeInfoRebound<T2> other;
+    };
+
+};
+
 template<class T>
-class OpenCLVector : public helper::vector<T,OpenCLMemoryManager<T> >
+class OpenCLVector : public helper::vector<T,OpenCLMemoryManager<T>, DataTypeInfoManager<T> >
 {
 public :
+    using Inherit = helper::vector<T, OpenCLMemoryManager<T>, DataTypeInfoManager<T> >;
     typedef size_t size_type;
 
-    OpenCLVector() : helper::vector<T,OpenCLMemoryManager<T> >() {}
+    OpenCLVector() : Inherit() {}
 
-    OpenCLVector(size_type n) : helper::vector<T,OpenCLMemoryManager<T> >(n) {}
+    OpenCLVector(size_type n) : Inherit(n) {}
 
-    OpenCLVector(const helper::vector<T,OpenCLMemoryManager< T > >& v) : helper::vector<T,OpenCLMemoryManager<T> >(v) {}
+    OpenCLVector(const Inherit& v) : Inherit(v) {}
 
 };
 

--- a/applications/plugins/SofaOpenCL/OpenCLTypes.h
+++ b/applications/plugins/SofaOpenCL/OpenCLTypes.h
@@ -47,7 +47,7 @@ struct DataTypeInfoManager
     using DataTypeInfo = sofa::defaulttype::DataTypeInfo<T>;
     template<class T2> struct rebind
     {
-        typedef DataTypeInfoRebound<T2> other;
+        typedef DataTypeInfoManager<T2> other;
     };
 
 };


### PR DESCRIPTION
Prelude to moving vector & co to Sofa.Type.

helper::vector is a bit complicated (defined in vector_device.h but standard,main code is in vector.h with some trick on templates).
But vector_device, the "main" implementation of vector has a dependency on defaulttype/dataypeinfo.h (needs some flags from it).

Some ways to remove it:
 - change the whole mess of vector, vector_device (used only for SofaCUDA and SofaOpenCL) -> **breaking** -> _Nope_
 - remove the use of those dataypeinfo flags -> **change in behavior** -> _Nope_
 - move the dependency of datatypeinfo using the template mechanism. Purpose of the PR.
It adds a new template parameter to vector (but is set to an empty, unused class so hamrless) and is compatible with standard code.
And SofaCUDA and SofaOpenCL can pass dataypeinfo (along their own MemoryManager actually) so they can use the flags.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
