### PR TITLE
[all] Refactor vector & vector_device

### DIFF
--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/FullVector.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/FullVector.h
@@ -22,6 +22,7 @@
 #pragma once
 #include <SofaBaseLinearSolver/config.h>
 
+#include <sofa/helper/logging/Messaging.h>
 #include <sofa/defaulttype/BaseVector.h>
 
 namespace sofa::component::linearsolver

--- a/SofaKernel/modules/SofaHelper/CMakeLists.txt
+++ b/SofaKernel/modules/SofaHelper/CMakeLists.txt
@@ -116,7 +116,13 @@ set(HEADER_FILES
     ${SRC_ROOT}/system/FileMonitor.h
     ${SRC_ROOT}/system/FileRepository.h
     ${SRC_ROOT}/vector.h
+    ${SRC_ROOT}/vector_T.h
+    ${SRC_ROOT}/vector_T.inl
+    ${SRC_ROOT}/vector_Real.h
+    ${SRC_ROOT}/vector_Integral.h
+    ${SRC_ROOT}/vector_String.h
     ${SRC_ROOT}/vector_algebra.h
+    ${SRC_ROOT}/vector_algorithm.h
     ${SRC_ROOT}/vector_device.h
     ${SRC_ROOT}/types/RGBAColor.h
     ${SRC_ROOT}/types/RGBAColor_fwd.h
@@ -195,6 +201,9 @@ set(SOURCE_FILES
     ${SRC_ROOT}/system/thread/debug.cpp
     ${SRC_ROOT}/system/FileRepository.cpp
     ${SRC_ROOT}/vector.cpp
+    ${SRC_ROOT}/vector_Real.cpp
+    ${SRC_ROOT}/vector_Integral.cpp
+    ${SRC_ROOT}/vector_String.cpp
     ${SRC_ROOT}/types/RGBAColor.cpp
     ${SRC_ROOT}/types/Material.cpp
     ${SRC_ROOT}/types/PrimitiveGroup.cpp

--- a/SofaKernel/modules/SofaHelper/SofaHelper_test/testing/TestMessageHandler_test.cpp
+++ b/SofaKernel/modules/SofaHelper/SofaHelper_test/testing/TestMessageHandler_test.cpp
@@ -1,5 +1,5 @@
 #include <gtest/gtest-spi.h>
-
+#include <sofa/helper/logging/Messaging.h>
 #include <sofa/helper/testing/BaseTest.h>
 using sofa::helper::testing::BaseTest ;
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #define SOFA_HELPER_ADVANCEDTIMER_CPP
 
+#include <sofa/helper/logging/Messaging.h>
 #include <sofa/helper/AdvancedTimer.h>
 #include <sofa/helper/vector.h>
 #include <json.h>

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/ColorMap.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/ColorMap.cpp
@@ -21,7 +21,7 @@
 ******************************************************************************/
 
 #include <sofa/helper/ColorMap.h>
-
+#include <sofa/helper/logging/Messaging.h>
 #include <string>
 #include <iostream>
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/logging/MessageDispatcher.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/logging/MessageDispatcher.cpp
@@ -59,12 +59,7 @@ namespace helper
 namespace logging
 {
 
-#if(SOFA_WITH_THREADING==1)
-   #define MUTEX_IF_THREADING lock_guard<mutex> guard(getMainInstance()->getMutex()) ;
-#else
-   #define MUTEX_IF_THREADING
-#endif
-
+#define PUBLIC_API_ENTRY_POINT_MUTEX lock_guard<mutex> guard(getMainInstance()->getMutex()) ;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 /// Threading issues...
@@ -126,39 +121,34 @@ public:
     }
 };
 
-
-MessageDispatcherImpl* s_messagedispatcher = nullptr ;
-
 MessageDispatcherImpl* getMainInstance(){
-    if(s_messagedispatcher==nullptr){
-        s_messagedispatcher = new MessageDispatcherImpl();
-    }
-    return s_messagedispatcher;
+    static MessageDispatcherImpl s_messagedispatcher;
+    return &s_messagedispatcher;
 }
 
 std::vector<MessageHandler*>& MessageDispatcher::getHandlers()
 {
-    MUTEX_IF_THREADING ;
+    PUBLIC_API_ENTRY_POINT_MUTEX ;
     return getMainInstance()->getHandlers();
 }
 
 int MessageDispatcher::addHandler(MessageHandler* o){
-    MUTEX_IF_THREADING ;
+    PUBLIC_API_ENTRY_POINT_MUTEX ;
     return getMainInstance()->addHandler(o);
 }
 
 int MessageDispatcher::rmHandler(MessageHandler* o){
-    MUTEX_IF_THREADING ;
+    PUBLIC_API_ENTRY_POINT_MUTEX ;
     return getMainInstance()->rmHandler(o);
 }
 
 void MessageDispatcher::clearHandlers(){
-    MUTEX_IF_THREADING ;
+    PUBLIC_API_ENTRY_POINT_MUTEX ;
     getMainInstance()->clearHandlers();
 }
 
 void MessageDispatcher::process(sofa::helper::logging::Message& m){
-    MUTEX_IF_THREADING ;
+    PUBLIC_API_ENTRY_POINT_MUTEX ;
     getMainInstance()->process(m);
 }
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/testing/BaseTest.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/testing/BaseTest.cpp
@@ -40,6 +40,7 @@ using sofa::helper::BackTrace;
 #include <sofa/helper/system/console.h>
 
 #include <sofa/helper/testing/TestMessageHandler.h>
+#include <sofa/helper/logging/Messaging.h>
 using sofa::helper::logging::MessageDispatcher ;
 using sofa::helper::logging::MainGtestMessageHandler ;
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/vector.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/vector.cpp
@@ -19,10 +19,10 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#define SOFA_HELPER_VECTOR_CPP
+#define SOFA_HELPER_VECTOR_DEFINITION
 #include <sofa/helper/vector.h>
-#include <sofa/helper/vector_device.h>
 #include <sofa/helper/Factory.h>
+#include <sofa/helper/integer_id.h>
 #include <sofa/helper/BackTrace.h>
 #include <cassert>
 #include <iostream>

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/vector.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/vector.h
@@ -25,5 +25,5 @@
 #include "vector_T.inl"            ///< Definition of the default vector      (the default implementation)
 #include "vector_Integral.h"       ///< Extern declaration for integral types (the specialization)
 #include "vector_String.h"         ///< Extern declaration for string types   (the specialization)
-#include "vector_Real.h"           ///< Extern declaration for real types   (the specialization)
+#include "vector_Real.h"           ///< Extern declaration for real types     (the specialization)
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_Integral.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_Integral.cpp
@@ -1,0 +1,224 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#define SOFA_HELPER_VECTOR_INTEGRAL_DEFINITION
+
+#include <sofa/helper/vector_Integral.h>
+#include <sofa/helper/vector_T.inl>
+#include <sofa/helper/logging/Messaging.h>
+
+namespace sofa::helper
+{
+
+/// Input stream
+/// Specialization for reading vectors of int and unsigned int using "A-B" notation for all integers between A and B, optionnally specifying a step using "A-B-step" notation.
+template<>
+SOFA_HELPER_API std::istream& vector<int>::read( std::istream& in )
+{
+    int t;
+    this->clear();
+    std::string s;
+    std::stringstream msg;
+    unsigned int numErrors=0;
+
+    /// Cut the input stream in words using the standard's '<space>' token eparator.
+    while(in>>s)
+    {
+        /// Check if there is the sign '-' in the string s.
+        std::string::size_type hyphen = s.find_first_of('-',1);
+
+        /// If there is no '-' in s
+        if (hyphen == std::string::npos)
+        {
+            /// Convert the word into an integer number.
+            /// Use strtol because it reports error in case of parsing problem.
+            t = getInteger(s, msg, numErrors) ;
+            this->push_back(t);
+        }
+
+        /// If there is at least one '-'
+        else
+        {
+            int t1,t2,tinc;
+            std::string s1(s,0,hyphen);
+            t1 = getInteger(s1, msg, numErrors) ;
+            std::string::size_type hyphen2 = s.find_first_of('-',hyphen+2);
+            if (hyphen2 == std::string::npos)
+            {
+                std::string s2(s,hyphen+1);
+                t2 = getInteger(s2, msg, numErrors) ;
+                tinc = (t1<t2) ? 1 : -1;
+            }
+            else
+            {
+                std::string s2(s,hyphen+1,hyphen2-hyphen-1);
+                std::string s3(s,hyphen2+1);
+                t2 =  getInteger(s2, msg, numErrors) ;
+                tinc =  getInteger(s3, msg, numErrors) ;
+                if (tinc == 0)
+                {
+                    tinc = (t1<t2) ? 1 : -1;
+                    msg << "- Increment 0 is replaced by "<< tinc << msgendl;
+                }
+                if ((t2-t1)*tinc < 0)
+                {
+                    // increment not of the same sign as t2-t1 : swap t1<->t2
+                    t = t1;
+                    t1 = t2;
+                    t2 = t;
+                }
+            }
+
+            /// Go in backward order.
+            if (tinc < 0)
+                for (t=t1; t>=t2; t+=tinc)
+                    this->push_back(t);
+            /// Go in Forward order
+            else
+                for (t=t1; t<=t2; t+=tinc)
+                    this->push_back(t);
+        }
+    }
+    if( in.rdstate() & std::ios_base::eofbit ) { in.clear(); }
+    if(numErrors!=0)
+    {
+        msg_warning("vector<int>") << "Unable to parse vector values:" << msgendl
+                                   << msg.str() ;
+    }
+    return in;
+}
+
+
+/// Input stream
+/// Specialization for reading vectors of int and unsigned int using "A-B" notation for all integers between A and B
+template<>
+SOFA_HELPER_API std::istream& vector<unsigned int>::read( std::istream& in )
+{
+    std::stringstream errmsg ;
+    unsigned int errcnt = 0 ;
+    unsigned int t = 0 ;
+
+    this->clear();
+    std::string s;
+
+    while(in>>s)
+    {
+        std::string::size_type hyphen = s.find_first_of('-',1);
+        if (hyphen == std::string::npos)
+        {
+            t = getUnsignedInteger(s, errmsg, errcnt) ;
+            this->push_back(t);
+        }
+        else
+        {
+            unsigned int t1,t2;
+            int tinc;
+            std::string s1(s,0,hyphen);
+            t1 = getUnsignedInteger(s1, errmsg, errcnt) ;
+            std::string::size_type hyphen2 = s.find_first_of('-',hyphen+2);
+            if (hyphen2 == std::string::npos)
+            {
+                std::string s2(s,hyphen+1);
+                t2 = getUnsignedInteger(s2, errmsg, errcnt);
+                tinc = (t1<=t2) ? 1 : -1;
+            }
+            else
+            {
+                std::string s2(s,hyphen+1,hyphen2-hyphen-1);
+                std::string s3(s,hyphen2+1);
+                t2 = getUnsignedInteger(s2, errmsg, errcnt);
+                tinc = getInteger(s3, errmsg, errcnt);
+                if (tinc == 0)
+                {
+                    tinc = (t1<=t2) ? 1 : -1;
+                    errmsg << "- problem while parsing '"<<s<<"': increment is 0. Use " << tinc << " instead." ;
+                }
+                if (((int)(t2-t1))*tinc < 0)
+                {
+                    /// increment not of the same sign as t2-t1 : swap t1<->t2
+                    t = t1;
+                    t1 = t2;
+                    t2 = t;
+                }
+            }
+            if (tinc < 0){
+                for (t=t1; t>t2; t=t+tinc)
+                    this->push_back(t);
+                this->push_back(t2);
+            } else {
+                for (t=t1; t<=t2; t=t+tinc)
+                    this->push_back(t);
+            }
+        }
+    }
+    if( in.rdstate() & std::ios_base::eofbit ) { in.clear(); }
+    if(errcnt!=0)
+    {
+        msg_warning("vector<unsigned int>") << "Unable to parse values" << msgendl
+                                            << errmsg.str() ;
+    }
+
+    return in;
+}
+
+/// Output stream
+/// Specialization for writing vectors of unsigned char
+template<>
+SOFA_HELPER_API std::ostream& vector<unsigned char>::write(std::ostream& os) const
+{
+    if( this->size()>0 )
+    {
+        for( Size i=0; i<this->size()-1; ++i )
+            os<<(int)(*this)[i]<<" ";
+        os<<(int)(*this)[this->size()-1];
+    }
+    return os;
+}
+
+
+
+/// Input stream
+/// Specialization for reading vectors of unsigned char
+template<>
+SOFA_HELPER_API std::istream& vector<unsigned char>::read(std::istream& in)
+{
+    int t;
+    this->clear();
+    while(in>>t)
+    {
+        this->push_back((unsigned char)t);
+    }
+    if( in.rdstate() & std::ios_base::eofbit ) { in.clear(); }
+    return in;
+}
+
+} /// namespace sofa::helper
+
+
+template class SOFA_HELPER_API sofa::helper::vector<bool>;
+template class SOFA_HELPER_API sofa::helper::vector<char>;
+template class SOFA_HELPER_API sofa::helper::vector<unsigned char>;
+template class SOFA_HELPER_API sofa::helper::vector<int>;
+template class SOFA_HELPER_API sofa::helper::vector<unsigned int>;
+template class SOFA_HELPER_API sofa::helper::vector<long>;
+template class SOFA_HELPER_API sofa::helper::vector<unsigned long>;
+template class SOFA_HELPER_API sofa::helper::vector<long long>;
+template class SOFA_HELPER_API sofa::helper::vector<unsigned long long>;

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_Integral.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_Integral.h
@@ -30,14 +30,3 @@ template<> SOFA_HELPER_API std::istream& sofa::helper::vector<unsigned int>::rea
 template<> SOFA_HELPER_API std::ostream& sofa::helper::vector<unsigned char>::write(std::ostream& os) const;
 template<> SOFA_HELPER_API std::istream& sofa::helper::vector<unsigned char>::read(std::istream& in);
 
-//#ifndef SOFA_HELPER_VECTOR_INTEGRAL_DEFINITION
-//extern template class SOFA_HELPER_API sofa::helper::vector<bool>;
-//extern template class SOFA_HELPER_API sofa::helper::vector<char>;
-//extern template class SOFA_HELPER_API sofa::helper::vector<unsigned char>;
-//extern template class SOFA_HELPER_API sofa::helper::vector<int>;
-//extern template class SOFA_HELPER_API sofa::helper::vector<unsigned int>;
-//extern template class SOFA_HELPER_API sofa::helper::vector<long>;
-//extern template class SOFA_HELPER_API sofa::helper::vector<unsigned long>;
-//extern template class SOFA_HELPER_API sofa::helper::vector<long long>;
-//extern template class SOFA_HELPER_API sofa::helper::vector<unsigned long long>;
-//#endif // SOFA_HELPER_VECTOR_INTEGRAL_DEFINITION

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_Integral.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_Integral.h
@@ -20,10 +20,24 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
+#include <sofa/helper/vector_T.h>
 
-#include "vector_T.h"              ///< Declaration of the class vector       (the interface)
-#include "vector_T.inl"            ///< Definition of the default vector      (the default implementation)
-#include "vector_Integral.h"       ///< Extern declaration for integral types (the specialization)
-#include "vector_String.h"         ///< Extern declaration for string types   (the specialization)
-#include "vector_Real.h"           ///< Extern declaration for real types   (the specialization)
+/// Specialization for reading vectors of int and unsigned int using "A-B" notation for all integers between A and B
+template<> SOFA_HELPER_API std::istream& sofa::helper::vector<int>::read( std::istream& in );
+template<> SOFA_HELPER_API std::istream& sofa::helper::vector<unsigned int>::read( std::istream& in );
 
+/// Specialization for writing vectors of unsigned char
+template<> SOFA_HELPER_API std::ostream& sofa::helper::vector<unsigned char>::write(std::ostream& os) const;
+template<> SOFA_HELPER_API std::istream& sofa::helper::vector<unsigned char>::read(std::istream& in);
+
+//#ifndef SOFA_HELPER_VECTOR_INTEGRAL_DEFINITION
+//extern template class SOFA_HELPER_API sofa::helper::vector<bool>;
+//extern template class SOFA_HELPER_API sofa::helper::vector<char>;
+//extern template class SOFA_HELPER_API sofa::helper::vector<unsigned char>;
+//extern template class SOFA_HELPER_API sofa::helper::vector<int>;
+//extern template class SOFA_HELPER_API sofa::helper::vector<unsigned int>;
+//extern template class SOFA_HELPER_API sofa::helper::vector<long>;
+//extern template class SOFA_HELPER_API sofa::helper::vector<unsigned long>;
+//extern template class SOFA_HELPER_API sofa::helper::vector<long long>;
+//extern template class SOFA_HELPER_API sofa::helper::vector<unsigned long long>;
+//#endif // SOFA_HELPER_VECTOR_INTEGRAL_DEFINITION

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_Real.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_Real.cpp
@@ -19,11 +19,10 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#pragma once
+#define SOFA_HELPER_VECTOR_REAL_DEFINITION
+#include <sofa/helper/vector_Real.h>
+#include <sofa/helper/vector_T.inl>
 
-#include "vector_T.h"              ///< Declaration of the class vector       (the interface)
-#include "vector_T.inl"            ///< Definition of the default vector      (the default implementation)
-#include "vector_Integral.h"       ///< Extern declaration for integral types (the specialization)
-#include "vector_String.h"         ///< Extern declaration for string types   (the specialization)
-#include "vector_Real.h"           ///< Extern declaration for real types   (the specialization)
+template class SOFA_HELPER_API sofa::helper::vector<float>;
+template class SOFA_HELPER_API sofa::helper::vector<double>;
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_Real.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_Real.h
@@ -22,7 +22,3 @@
 #pragma once
 #include <sofa/helper/vector_T.h>
 
-//#ifndef SOFA_HELPER_VECTOR_REAL_DEFINITION
-//extern template class sofa::helper::vector<float>;
-//extern template class sofa::helper::vector<double>;
-//#endif // #ifndef SOFA_HELPER_VECTOR_REAL_DEFINITION

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_Real.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_Real.h
@@ -20,10 +20,9 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
+#include <sofa/helper/vector_T.h>
 
-#include "vector_T.h"              ///< Declaration of the class vector       (the interface)
-#include "vector_T.inl"            ///< Definition of the default vector      (the default implementation)
-#include "vector_Integral.h"       ///< Extern declaration for integral types (the specialization)
-#include "vector_String.h"         ///< Extern declaration for string types   (the specialization)
-#include "vector_Real.h"           ///< Extern declaration for real types   (the specialization)
-
+//#ifndef SOFA_HELPER_VECTOR_REAL_DEFINITION
+//extern template class sofa::helper::vector<float>;
+//extern template class sofa::helper::vector<double>;
+//#endif // #ifndef SOFA_HELPER_VECTOR_REAL_DEFINITION

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_String.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_String.cpp
@@ -19,11 +19,34 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#pragma once
+#define SOFA_HELPER_VECTOR_STRING_DEFINITION
+#include <sofa/helper/vector_String.h>
+#include <sofa/helper/vector_T.inl>
 
-#include "vector_T.h"              ///< Declaration of the class vector       (the interface)
-#include "vector_T.inl"            ///< Definition of the default vector      (the default implementation)
-#include "vector_Integral.h"       ///< Extern declaration for integral types (the specialization)
-#include "vector_String.h"         ///< Extern declaration for string types   (the specialization)
-#include "vector_Real.h"           ///< Extern declaration for real types   (the specialization)
+#include <iostream>
+#include <sstream>
 
+
+/// All integral types are considered as extern templates.
+namespace sofa::helper
+{
+
+/// Output stream
+/// Specialization for writing vectors of unsigned char
+template<>
+SOFA_HELPER_API std::ostream& vector<std::string>::write(std::ostream& os) const
+{
+    std::string separator = "";
+    os << "[";
+    for(auto& v : (*this))
+    {
+        os << separator << '"' << v << '"';
+        separator = ", ";
+    }
+    os << "]";
+    return os;
+}
+
+} // namespace sofa::helper
+
+template class SOFA_HELPER_API sofa::helper::vector<std::string>;

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_String.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_String.h
@@ -20,10 +20,10 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
+#include <sofa/helper/vector_T.h>
 
-#include "vector_T.h"              ///< Declaration of the class vector       (the interface)
-#include "vector_T.inl"            ///< Definition of the default vector      (the default implementation)
-#include "vector_Integral.h"       ///< Extern declaration for integral types (the specialization)
-#include "vector_String.h"         ///< Extern declaration for string types   (the specialization)
-#include "vector_Real.h"           ///< Extern declaration for real types   (the specialization)
+template<> SOFA_HELPER_API std::ostream& sofa::helper::vector<std::string>::write(std::ostream& os) const;
 
+//#ifndef SOFA_HELPER_VECTOR_STRING_DEFINITION
+//extern template class sofa::helper::vector<std::string>;
+//#endif /// SOFA_HELPER_VECTOR_STRING_DEFINITION

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_String.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_String.h
@@ -24,6 +24,3 @@
 
 template<> SOFA_HELPER_API std::ostream& sofa::helper::vector<std::string>::write(std::ostream& os) const;
 
-//#ifndef SOFA_HELPER_VECTOR_STRING_DEFINITION
-//extern template class sofa::helper::vector<std::string>;
-//#endif /// SOFA_HELPER_VECTOR_STRING_DEFINITION

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_T.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_T.h
@@ -120,7 +120,7 @@ public:
             if (n >= this->size())
                 vector_access_failure(this, this->size(), n, typeid(T));
         }
-        return *(this->begin() + n);
+        return std::vector<T>::operator[](n);
     }
 
     /// Read-only random access
@@ -131,7 +131,7 @@ public:
             if (n >= this->size())
                 vector_access_failure(this, this->size(), n, typeid(T));
         }
-        return *(this->begin() + n);
+        return std::vector<T>::operator[](n);
     }
 
     std::ostream& write(std::ostream& os) const

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_T.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_T.h
@@ -1,0 +1,181 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <vector>
+#include <string>
+#include <typeinfo>
+#include <istream>
+#include <ostream>
+
+#include <sofa/helper/config.h>
+#include <sofa/helper/MemoryManager.h>
+
+#if !defined(NDEBUG) && !defined(SOFA_NO_VECTOR_ACCESS_FAILURE)
+#define SOFA_VECTOR_CHECK_ACCESS true
+#else
+#define SOFA_VECTOR_CHECK_ACCESS false
+#endif
+
+namespace sofa::helper
+{
+
+void SOFA_HELPER_API vector_access_failure(const void* vec, unsigned size, unsigned i, const std::type_info& type);
+
+/// Convert the string 's' into an unsigned int. The error are reported in msg & numErrors
+/// is incremented.
+int SOFA_HELPER_API getInteger(const std::string& s, std::stringstream& msg, unsigned int& numErrors) ;
+
+/// Convert the string 's' into an unsigned int. The error are reported in msg & numErrors
+/// is incremented.
+unsigned int SOFA_HELPER_API getUnsignedInteger(const std::string& s, std::stringstream& msg, unsigned int& numErrors) ;
+
+static constexpr bool isEnabledVectorAccessChecking {SOFA_VECTOR_CHECK_ACCESS};
+
+/// Regular vector
+/// Using CPUMemoryManager, it has the same behavior as std::helper with extra conveniences:
+///  - string serialization (making it usable in Data)
+///  - operator[] is checking if the index is within the bounds in debug
+template <class T, class MemoryManager = CPUMemoryManager<T>>
+class vector : public std::vector<T, std::allocator<T> >
+{
+public:
+    typedef CPUMemoryManager<T> memory_manager;
+    typedef std::allocator<T> Alloc;
+    /// Size
+    typedef typename std::vector<T,Alloc>::size_type Size;
+    /// reference to a value (read-write)
+    typedef typename std::vector<T,Alloc>::reference reference;
+    /// const reference to a value (read only)
+    typedef typename std::vector<T,Alloc>::const_reference const_reference;
+
+    template<class T2> struct rebind
+    {
+        typedef vector< T2,CPUMemoryManager<T2> > other;
+    };
+
+    /// Basic constructor
+    vector() : std::vector<T,Alloc>() {}
+    /// Constructor
+    vector(Size n, const T& value): std::vector<T,Alloc>(n,value) {}
+    /// Constructor
+    vector(int n, const T& value): std::vector<T,Alloc>(n,value) {}
+    /// Constructor
+    vector(long n, const T& value): std::vector<T,Alloc>(n,value) {}
+    /// Constructor
+    explicit vector(Size n): std::vector<T,Alloc>(n) {}
+    /// Constructor
+    vector(const std::vector<T, Alloc>& x): std::vector<T,Alloc>(x) {}
+    /// Brace initalizer constructor
+    vector(const std::initializer_list<T>& t) : std::vector<T,Alloc>(t) {}
+    /// Move constructor
+    vector(std::vector<T,Alloc>&& v): std::vector<T,Alloc>(std::move(v)) {}
+
+    /// Copy operator
+    vector& operator=(const std::vector<T, Alloc>& x)
+    {
+        std::vector<T,Alloc>::operator=(x);
+        return *this;
+    }
+    /// Move assignment operator
+    vector& operator=(std::vector<T,Alloc>&& v)
+    {
+        std::vector<T,Alloc>::operator=(std::move(v));
+        return *this;
+    }
+
+#ifdef __STL_MEMBER_TEMPLATES
+    /// Constructor
+    template <class InputIterator>
+    vector(InputIterator first, InputIterator last): std::vector<T,Alloc>(first,last) {}
+#else /* __STL_MEMBER_TEMPLATES */
+    /// Constructor
+    vector(typename vector<T>::const_iterator first, typename vector<T>::const_iterator last): std::vector<T>(first,last) {}
+#endif /* __STL_MEMBER_TEMPLATES */
+
+    /// Read/write random access
+    reference operator[](Size n)
+    {
+        if constexpr (sofa::helper::isEnabledVectorAccessChecking)
+        {
+            if (n >= this->size())
+                vector_access_failure(this, this->size(), n, typeid(T));
+        }
+        return *(this->begin() + n);
+    }
+
+    /// Read-only random access
+    const_reference operator[](Size n) const
+    {
+        if constexpr (sofa::helper::isEnabledVectorAccessChecking)
+        {
+            if (n >= this->size())
+                vector_access_failure(this, this->size(), n, typeid(T));
+        }
+        return *(this->begin() + n);
+    }
+
+    std::ostream& write(std::ostream& os) const
+    {
+        if( this->size()>0 )
+        {
+            for( Size i=0; i<this->size()-1; ++i )
+                os<<(*this)[i]<<" ";
+            os<<(*this)[this->size()-1];
+        }
+        return os;
+    }
+
+    std::istream& read(std::istream& in)
+    {
+        T t=T();
+        this->clear();
+        while(in>>t)
+        {
+            this->push_back(t);
+        }
+        if( in.rdstate() & std::ios_base::eofbit ) { in.clear(); }
+        return in;
+    }
+
+
+    /// Output stream
+    friend std::ostream& operator<< ( std::ostream& os, const vector& vec ) { return vec.write(os); }
+
+    /// Input stream
+    friend std::istream& operator>> ( std::istream& in, vector& vec ){ return vec.read(in); }
+
+    /// Sets every element to 'value'
+    void fill( const T& value )
+    {
+        std::fill(this->begin(), this->end(), value);
+    }
+
+    /// this function is usefull for vector_device because it resize the vector without device operation (if device is not valid).
+    /// Therefore the function is used in asynchronous code to safly resize a vector which is either cuda of helper::vector
+    void fastResize(Size n)
+    {
+        this->resize(n);
+    }
+};
+
+} /// namespace sofa::helper

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_T.inl
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_T.inl
@@ -20,10 +20,6 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
-
-#include "vector_T.h"              ///< Declaration of the class vector       (the interface)
-#include "vector_T.inl"            ///< Definition of the default vector      (the default implementation)
-#include "vector_Integral.h"       ///< Extern declaration for integral types (the specialization)
-#include "vector_String.h"         ///< Extern declaration for string types   (the specialization)
-#include "vector_Real.h"           ///< Extern declaration for real types   (the specialization)
-
+#include <cassert>
+#include <iostream>
+#include <sofa/helper/vector_T.h>

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_algorithm.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_algorithm.h
@@ -21,9 +21,56 @@
 ******************************************************************************/
 #pragma once
 
-#include "vector_T.h"              ///< Declaration of the class vector       (the interface)
-#include "vector_T.inl"            ///< Definition of the default vector      (the default implementation)
-#include "vector_Integral.h"       ///< Extern declaration for integral types (the specialization)
-#include "vector_String.h"         ///< Extern declaration for string types   (the specialization)
-#include "vector_Real.h"           ///< Extern declaration for real types   (the specialization)
+#include <algorithm>
+#include <sofa/helper/vector_T.h>
 
+namespace sofa::helper
+{
+/** Remove the first occurence of a given value.
+    The remaining values are shifted.
+*/
+template<class T1, class T2>
+void remove( T1& v, const T2& elem )
+{
+    typename T1::iterator e = std::find( v.begin(), v.end(), elem );
+    if( e != v.end() )
+    {
+        typename T1::iterator next = e;
+        next++;
+        for( ; next != v.end(); ++e, ++next )
+            *e = *next;
+    }
+    v.pop_back();
+}
+
+/** Remove the first occurence of a given value.
+
+The last value is moved to where the value was found, and the other values are not shifted.
+*/
+template<class T1, class T2>
+void removeValue( T1& v, const T2& elem )
+{
+    typename T1::iterator e = std::find( v.begin(), v.end(), elem );
+    if( e != v.end() )
+    {
+        if (e != v.end()-1)
+            *e = v.back();
+        v.pop_back();
+    }
+}
+
+/// Remove value at given index, replace it by the value at the last index, other values are not changed
+template<class T, class TT>
+void removeIndex( std::vector<T,TT>& v, size_t index )
+{
+    if constexpr(sofa::helper::isEnabledVectorAccessChecking)
+    {
+        if (index>=v.size())
+            vector_access_failure(&v, v.size(), index, typeid(T));
+    }
+    if (index != v.size()-1)
+        v[index] = v.back();
+    v.pop_back();
+}
+
+}

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_device.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/vector_device.h
@@ -22,8 +22,8 @@
 #ifndef SOFA_HELPER_VECTOR_DEVICE_H
 #define SOFA_HELPER_VECTOR_DEVICE_H
 
-#include <sofa/helper/vector.h>
 #include <sofa/defaulttype/DataTypeInfo.h>
+#include <sofa/helper/vector.h>
 
 // maximum number of bytes we allow to increase the size when of a vector in a single step when we reserve on the host or device
 #define SOFA_VECTOR_HOST_STEP_SIZE 32768
@@ -54,7 +54,7 @@ namespace helper
 DEBUG_OUT_V(extern SOFA_HELPER_API int cptid;)
 
 template <class T, class MemoryManager>
-class vector
+class vector_device
 {
 public:
     typedef T      value_type;
@@ -69,7 +69,7 @@ public:
     typedef MemoryManager memory_manager;
     template<class T2> struct rebind
     {
-        typedef vector<T2, typename memory_manager::template rebind<T2>::other > other;
+        typedef vector_device<T2, typename memory_manager::template rebind<T2>::other > other;
     };
 
 protected:
@@ -95,7 +95,7 @@ protected:
 
 public:
 
-    vector()
+    vector_device()
         : vectorSize ( 0 ), allocSize ( 0 ), hostPointer ( nullptr ), deviceIsValid ( ALL_DEVICE_VALID ), hostIsValid ( true ), bufferIsRegistered(false)
         , bufferObject(0)
     {
@@ -113,7 +113,7 @@ public:
 #endif
         clearSize = 0;
     }
-    vector ( Size n )
+    vector_device ( Size n )
         : vectorSize ( 0 ), allocSize ( 0 ), hostPointer ( nullptr ), deviceIsValid ( ALL_DEVICE_VALID ), hostIsValid ( true ), bufferIsRegistered(false)
         , bufferObject(0)
     {
@@ -132,7 +132,7 @@ public:
         clearSize = 0;
         resize ( n );
     }
-    vector ( const vector<T,MemoryManager >& v )
+    vector_device ( const vector_device<T,MemoryManager >& v )
         : vectorSize ( 0 ), allocSize ( 0 ), hostPointer ( nullptr ), deviceIsValid ( ALL_DEVICE_VALID ), hostIsValid ( true ), bufferIsRegistered(false)
         , bufferObject(0)
     {
@@ -173,7 +173,7 @@ public:
         DEBUG_OUT_V(SPACEM << "clear vector " << std::endl);
     }
 
-    void operator= ( const vector<T,MemoryManager >& v )
+    void operator= ( const vector_device<T,MemoryManager >& v )
     {
         if (&v == this)
         {
@@ -231,7 +231,7 @@ public:
         DEBUG_OUT_V(SPACEM << "operator= " << std::endl);
     }
 
-    ~vector()
+    ~vector_device()
     {
         if ( hostPointer!=nullptr ) MemoryManager::hostFree ( hostPointer );
 
@@ -477,7 +477,7 @@ public:
         DEBUG_OUT_V(SPACEM << "resize " << std::endl);
     }
 
-    void swap ( vector<T,MemoryManager>& v )
+    void swap ( vector_device<T,MemoryManager>& v )
     {
         DEBUG_OUT_V(SPACEP << "swap " << std::endl);
 #define VSWAP(type, var) { type t = var; var = v.var; v.var = t; }
@@ -675,7 +675,7 @@ public:
     }
 
     /// Output stream
-    inline friend std::ostream& operator<< ( std::ostream& os, const vector<T,MemoryManager>& vec )
+    inline friend std::ostream& operator<< ( std::ostream& os, const vector_device<T,MemoryManager>& vec )
     {
         if ( vec.size() >0 )
         {
@@ -686,7 +686,7 @@ public:
     }
 
     /// Input stream
-    inline friend std::istream& operator>> ( std::istream& in, vector<T,MemoryManager>& vec )
+    inline friend std::istream& operator>> ( std::istream& in, vector_device<T,MemoryManager>& vec )
     {
         T t;
         vec.clear();

--- a/applications/plugins/LMConstraint/src/LMConstraint/DOFBlockerLMConstraint.inl
+++ b/applications/plugins/LMConstraint/src/LMConstraint/DOFBlockerLMConstraint.inl
@@ -24,6 +24,7 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <SofaBaseTopology/TopologySubsetData.inl>
 #include <sofa/helper/types/RGBAColor.h>
+#include <sofa/helper/vector_algorithm.h>
 
 
 namespace sofa::component::constraintset

--- a/applications/plugins/LMConstraint/src/LMConstraint/FixedLMConstraint.inl
+++ b/applications/plugins/LMConstraint/src/LMConstraint/FixedLMConstraint.inl
@@ -23,6 +23,7 @@
 #include <LMConstraint/FixedLMConstraint.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <SofaBaseTopology/TopologySubsetData.inl>
+#include <sofa/helper/vector_algorithm.h>
 
 
 namespace sofa::component::constraintset

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTypes.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTypes.h
@@ -46,16 +46,16 @@ namespace cuda
 {
 
 template<class T>
-class CudaVector : public helper::vector<T,CudaMemoryManager<T> >
+class CudaVector : public helper::vector_device<T,CudaMemoryManager<T> >
 {
 public :
     typedef size_t Size;
 
-    CudaVector() : helper::vector<T,CudaMemoryManager<T> >() {}
+    CudaVector() : helper::vector_device<T,CudaMemoryManager<T> >() {}
 
-    CudaVector(Size n) : helper::vector<T,CudaMemoryManager<T> >(n) {}
+    CudaVector(Size n) : helper::vector_device<T,CudaMemoryManager<T> >(n) {}
 
-    CudaVector(const helper::vector<T,CudaMemoryManager< T > >& v) : helper::vector<T,CudaMemoryManager<T> >(v) {}
+    CudaVector(const helper::vector_device<T,CudaMemoryManager< T > >& v) : helper::vector_device<T,CudaMemoryManager<T> >(v) {}
 
 };
 

--- a/applications/plugins/SofaOpenCL/OpenCLTypes.h
+++ b/applications/plugins/SofaOpenCL/OpenCLTypes.h
@@ -42,16 +42,16 @@ namespace opencl
 {
 
 template<class T>
-class OpenCLVector : public helper::vector<T,OpenCLMemoryManager<T> >
+class OpenCLVector : public helper::vector_device<T,OpenCLMemoryManager<T> >
 {
 public :
     typedef size_t size_type;
 
-    OpenCLVector() : helper::vector<T,OpenCLMemoryManager<T> >() {}
+    OpenCLVector() : helper::vector_device<T,OpenCLMemoryManager<T> >() {}
 
-    OpenCLVector(size_type n) : helper::vector<T,OpenCLMemoryManager<T> >(n) {}
+    OpenCLVector(size_type n) : helper::vector_device<T,OpenCLMemoryManager<T> >(n) {}
 
-    OpenCLVector(const helper::vector<T,OpenCLMemoryManager< T > >& v) : helper::vector<T,OpenCLMemoryManager<T> >(v) {}
+    OpenCLVector(const helper::vector_device<T,OpenCLMemoryManager< T > >& v) : helper::vector_device<T,OpenCLMemoryManager<T> >(v) {}
 
 };
 

--- a/applications/projects/Regression/ExternalProjectConfig.cmake.in
+++ b/applications/projects/Regression/ExternalProjectConfig.cmake.in
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.8.2)
 include(ExternalProject)
 ExternalProject_Add(Regression
     GIT_REPOSITORY https://github.com/sofa-framework/regression
-    GIT_TAG 041929c1ea5afc696f59a97120d60244e22ad290
+    GIT_TAG db26140ba6523645627a98c90ed751df4f78cd1c
     SOURCE_DIR "${CMAKE_SOURCE_DIR}/applications/projects/Regression"
     BINARY_DIR ""
     CONFIGURE_COMMAND ""

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.inl
@@ -27,6 +27,7 @@
 #include <SofaBaseTopology/TopologySubsetData.inl>
 #include <iostream>
 #include <sofa/helper/cast.h>
+#include <sofa/helper/vector_algorithm.h>
 
 #include <SofaBoundaryCondition/AffineMovementConstraint.h>
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.inl
@@ -29,6 +29,7 @@
 #include <sofa/defaulttype/RigidTypes.h>
 #include <iostream>
 #include <SofaBaseTopology/TopologySubsetData.inl>
+#include <sofa/helper/vector_algorithm.h>
 
 #include <sofa/core/objectmodel/BaseObject.h>
 using sofa::core::objectmodel::ComponentState;

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedPlaneConstraint.inl
@@ -28,7 +28,7 @@
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/defaulttype/VecTypes.h>
-
+#include <sofa/helper/vector_algorithm.h>
 #include <SofaBaseTopology/TopologySubsetData.inl>
 
 namespace sofa::component::projectiveconstraintset

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedTranslationConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedTranslationConstraint.inl
@@ -26,6 +26,7 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/types/RGBAColor.h>
 #include <SofaBaseTopology/TopologySubsetData.inl>
+#include <sofa/helper/vector_algorithm.h>
 
 namespace sofa::component::projectiveconstraintset
 {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.inl
@@ -28,6 +28,7 @@
 #include <sofa/helper/types/RGBAColor.h>
 #include <iostream>
 #include <SofaBaseTopology/TopologySubsetData.inl>
+#include <sofa/helper/vector_algorithm.h>
 
 
 namespace sofa::component::projectiveconstraintset

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearVelocityConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearVelocityConstraint.inl
@@ -28,6 +28,7 @@
 #include <sofa/defaulttype/RigidTypes.h>
 #include <iostream>
 #include <SofaBaseTopology/TopologySubsetData.inl>
+#include <sofa/helper/vector_algorithm.h>
 
 
 namespace sofa::component::projectiveconstraintset

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
@@ -30,6 +30,7 @@
 #include <sofa/helper/types/RGBAColor.h>
 #include <iostream>
 #include <SofaBaseTopology/TopologySubsetData.inl>
+#include <sofa/helper/vector_algorithm.h>
 
 
 namespace sofa::component::projectiveconstraintset

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PatchTestMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PatchTestMovementConstraint.inl
@@ -28,6 +28,7 @@
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/simulation/Simulation.h>
 #include <iostream>
+#include <sofa/helper/vector_algorithm.h>
 #include <sofa/helper/cast.h>
 
 namespace sofa::component::projectiveconstraintset

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.inl
@@ -28,6 +28,7 @@
 #include <sofa/simulation/Simulation.h>
 #include <iostream>
 #include <SofaBaseTopology/TopologySubsetData.inl>
+#include <sofa/helper/vector_algorithm.h>
 
 
 namespace sofa::component::projectiveconstraintset

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.inl
@@ -28,6 +28,7 @@
 #include <sofa/simulation/Simulation.h>
 #include <iostream>
 #include <SofaBaseTopology/TopologySubsetData.inl>
+#include <sofa/helper/vector_algorithm.h>
 
 namespace sofa::component::projectiveconstraintset
 {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
@@ -27,6 +27,7 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/simulation/Simulation.h>
 #include <iostream>
+#include <sofa/helper/vector_algorithm.h>
 
 #include <SofaBaseTopology/TopologySubsetData.inl>
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.inl
@@ -28,6 +28,7 @@
 #include <sofa/simulation/Simulation.h>
 #include <iostream>
 #include <SofaBaseTopology/TopologySubsetData.inl>
+#include <sofa/helper/vector_algorithm.h>
 
 
 namespace sofa::component::projectiveconstraintset

--- a/modules/SofaGuiQt/src/sofa/gui/qt/SofaWindowProfiler.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/SofaWindowProfiler.cpp
@@ -25,7 +25,7 @@
 #include <QHeaderView>
 #include <QMenu>
 #include <QMessageBox>
-
+#include <sofa/helper/logging/Messaging.h>
 #include <QGridLayout>
 #include <QDebug>
 


### PR DESCRIPTION
Follow up of https://github.com/sofa-framework/sofa/pull/1663
For comparison with #1797

In this PR we cut the coupling between vector and vector_device to make them really independant class. 
We then split the vector.h class in multiple separated parts for the differents specializations. 

Because of unclear problems with windows explicit specialization  interger, real and strings (extern template) have been removed. 


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
