### PR TITLE
[SofaHelper] remove stream operator<< in accessor

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
@@ -1210,7 +1210,7 @@ void TetrahedronSetTopologyContainer::updateTopologyEngineGraph()
 std::ostream& operator<< (std::ostream& out, const TetrahedronSetTopologyContainer& t)
 {
     helper::ReadAccessor< Data< sofa::helper::vector<TetrahedronSetTopologyContainer::Tetrahedron> > > m_tetrahedron = t.d_tetrahedron;
-    out  << m_tetrahedron<< " "
+    out  << m_tetrahedron.ref() << " "
             << t.m_edgesInTetrahedron<< " "
             << t.m_trianglesInTetrahedron;
 
@@ -1238,7 +1238,7 @@ std::istream& operator>>(std::istream& in, TetrahedronSetTopologyContainer& t)
     sofa::helper::vector< TetrahedronSetTopologyContainer::TetrahedronID > value;
     helper::WriteAccessor< Data< sofa::helper::vector<TetrahedronSetTopologyContainer::Tetrahedron> > > m_tetrahedron = t.d_tetrahedron;
 
-    in >> m_tetrahedron >> t.m_edgesInTetrahedron >> t.m_trianglesInTetrahedron;
+    in >> m_tetrahedron.wref() >> t.m_edgesInTetrahedron >> t.m_trianglesInTetrahedron;
 
 
     in >> s;

--- a/SofaKernel/modules/SofaDeformable/SofaDeformable_test/StiffSpringForceField_test.cpp
+++ b/SofaKernel/modules/SofaDeformable/SofaDeformable_test/StiffSpringForceField_test.cpp
@@ -190,9 +190,9 @@ struct StiffSpringForceField_test : public ForceField_test<_StiffSpringForceFiel
             std::cout << "                   vp = " << vp << std::endl;
             std::cout << "                   vc = " << vc << std::endl;
             std::cout << "          expected fp = " << fp << std::endl;
-            std::cout << "            actual fp = " << actualfp << std::endl;
+            std::cout << "            actual fp = " << actualfp.ref() << std::endl;
             std::cout << "          expected fc = " << fc << std::endl;
-            std::cout << "            actual fc = " << actualfc << std::endl;
+            std::cout << "            actual fc = " << actualfc.ref() << std::endl;
         }
         ASSERT_TRUE( this->vectorMaxDiff(fp,actualfp)< this->errorMax*this->epsilon() );
         ASSERT_TRUE( this->vectorMaxDiff(fc,actualfc)< this->errorMax*this->epsilon() );

--- a/SofaKernel/modules/SofaDeformable/src/SofaDeformable/PolynomialRestShapeSpringsForceField.inl
+++ b/SofaKernel/modules/SofaDeformable/src/SofaDeformable/PolynomialRestShapeSpringsForceField.inl
@@ -211,9 +211,9 @@ void PolynomialRestShapeSpringsForceField<DataTypes>::addForce(const core::Mecha
     helper::ReadAccessor<DataVecCoord> p1 = x;
     helper::ReadAccessor<DataVecCoord> p0 = *getExtPosition();
 
-    msg_info() << this->getName() << " P1 = " << p1;
-    msg_info() << this->getName() << " P0 = " << p0;
-    msg_info() << this->getName() << " F = " << f1;
+    msg_info() << this->getName() << " P1 = " << p1.ref();
+    msg_info() << this->getName() << " P0 = " << p0.ref();
+    msg_info() << this->getName() << " F = " << f1.ref();
 
     if (this->f_printLog.getValue())
         msg_info() << "[" <<  this->getName() << "]: ";

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/accessor.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/accessor.h
@@ -74,10 +74,14 @@ public:
     const_pointer   operator->() const { return vref; }
     const_reference operator* () const { return  *vref; }
 
+    /// To depreciate...
     template<class U>
-    [[deprecated("Custom operator<< for accessor have been deprecated in #PR1808. Just replace std::cout << myaccessor by std::cout << myccessor.ref()")]]
-    friend std::ostream& operator<<( std::ostream& os, const ReadAccessor<U>& vec ) = delete;
+    friend std::ostream& operator<<( std::ostream& os, const ReadAccessor<U>& vec );
 };
+
+template<class U>
+[[deprecated("Custom operator<< for accessor have been deprecated in #PR1808. Just replace std::cout << myaccessor by std::cout << myccessor.ref()")]]
+std::ostream& operator<<( std::ostream& os, const ReadAccessor<U>& vec ) = delete;
 
 
 /** A WriteAccessor is a proxy class, holding a reference to a given container
@@ -131,15 +135,22 @@ public:
         vref = &v;
     }
 
+    /// To depreciate...
     template<class U>
-    [[deprecated("Custom operator<< for accessor have been deprecated in #PR1808. Just replace std::cout << myaccessor by std::cout << myccessor.ref()")]]
-    friend std::ostream& operator<< ( std::ostream& os, const WriteAccessor<U>& vec ) = delete;
+    friend std::ostream& operator<< ( std::ostream& os, const WriteAccessor<U>& vec );
 
+    /// To depreciate...
     template<class U>
-    [[deprecated("Custom operator<< for accessor have been deprecated in #PR1808. Just replace std::cout << myaccessor by std::cout << myccessor.ref()")]]
-    friend std::istream& operator>> ( std::istream& in, WriteAccessor<U>& vec ) = delete;
+    friend std::istream& operator>> ( std::istream& in, WriteAccessor<U>& vec );
 };
 
+template<class U>
+[[deprecated("Custom operator<< for accessor have been deprecated in #PR1808. Just replace std::cout << myaccessor by std::cout << myccessor.ref()")]]
+std::ostream& operator<< ( std::ostream& os, const WriteAccessor<U>& vec ) = delete;
+
+template<class U>
+[[deprecated("Custom operator<< for accessor have been deprecated in #PR1808. Just replace std::cout << myaccessor by std::cout << myccessor.ref()")]]
+std::istream& operator>> ( std::istream& in, WriteAccessor<U>& vec ) = delete;
 
 /** Identical to WriteAccessor for default implementation, but different for some template specializations such as  core::objectmodel::Data<T>
 */
@@ -189,10 +200,15 @@ public:
     const_iterator begin() const { return vref->begin(); }
     const_iterator end() const { return vref->end(); }
 
+    /// To depreciate.
     template<class U>
-    [[deprecated("Custom operator<< for accessor have been deprecated in #PR1808. Just replace std::cout << myaccessor by std::cout << myccessor.ref()")]]
-    friend std::ostream& operator<< ( std::ostream& os, const ReadAccessorVector<U>& vec ) = delete;
+    friend std::ostream& operator<< ( std::ostream& os, const ReadAccessorVector<U>& vec );
 };
+
+template<class U>
+[[deprecated("Custom operator<< for accessor have been deprecated in #PR1808. Just replace std::cout << myaccessor by std::cout << myccessor.ref()")]]
+std::ostream& operator<< ( std::ostream& os, const ReadAccessorVector<U>& vec ) = delete;
+
 
 /// WriteAccessor implementation class for vector types
 template<class T>

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/accessor.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/accessor.h
@@ -24,6 +24,7 @@
 
 #include <sofa/helper/config.h>
 #include <sofa/helper/vector.h>
+#include <iosfwd>
 
 namespace sofa
 {
@@ -72,6 +73,9 @@ public:
     operator  const_reference () const { return  *vref; }
     const_pointer   operator->() const { return vref; }
     const_reference operator* () const { return  *vref; }
+
+    [[deprecated("Custom operator<< for accessor have been deprecated in #PR1808. Just replace std::cout << myaccessor by std::cout << myccessor.ref()")]]
+    friend std::ostream& operator<< ( std::ostream& os, const ReadAccessor<T>& vec ) = delete;
 };
 
 /** A WriteAccessor is a proxy class, holding a reference to a given container
@@ -124,6 +128,12 @@ public:
     {
         vref = &v;
     }
+
+    [[deprecated("Custom operator<< for accessor have been deprecated in #PR1808. Just replace std::cout << myaccessor by std::cout << myccessor.ref()")]]
+    friend std::ostream& operator<< ( std::ostream& os, const WriteAccessor<T>& vec ) = delete;
+
+    [[deprecated("Custom operator<< for accessor have been deprecated in #PR1808. Just replace std::cout << myaccessor by std::cout << myccessor.ref()")]]
+    friend std::istream& operator>> ( std::istream& in, WriteAccessor<T>& vec ) =delete;
 };
 
 
@@ -174,6 +184,9 @@ public:
 
     const_iterator begin() const { return vref->begin(); }
     const_iterator end() const { return vref->end(); }
+
+    [[deprecated("FUXk")]]
+    friend std::ostream& operator<< ( std::ostream& os, const ReadAccessorVector<T>& vec ) = delete;
 };
 
 /// WriteAccessor implementation class for vector types
@@ -213,6 +226,7 @@ public:
     void resize(Size s, bool /*init*/ = true) { vref->resize(s); }
     void reserve(Size s) { vref->reserve(s); }
     void push_back(const value_type& v) { vref->push_back(v); }
+
 };
 
 // Support for std::vector

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/accessor.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/accessor.h
@@ -24,7 +24,6 @@
 
 #include <sofa/helper/config.h>
 #include <sofa/helper/vector.h>
-#include <iostream>
 
 namespace sofa
 {
@@ -73,11 +72,6 @@ public:
     operator  const_reference () const { return  *vref; }
     const_pointer   operator->() const { return vref; }
     const_reference operator* () const { return  *vref; }
-
-    inline friend std::ostream& operator<< ( std::ostream& os, const ReadAccessor<T>& vec )
-    {
-        return os << *vec.vref;
-    }
 };
 
 /** A WriteAccessor is a proxy class, holding a reference to a given container
@@ -130,16 +124,6 @@ public:
     {
         vref = &v;
     }
-
-    inline friend std::ostream& operator<< ( std::ostream& os, const WriteAccessor<T>& vec )
-    {
-        return os << *vec.vref;
-    }
-
-    inline friend std::istream& operator>> ( std::istream& in, WriteAccessor<T>& vec )
-    {
-        return in >> *vec.vref;
-    }
 };
 
 
@@ -190,12 +174,6 @@ public:
 
     const_iterator begin() const { return vref->begin(); }
     const_iterator end() const { return vref->end(); }
-
-    inline friend std::ostream& operator<< ( std::ostream& os, const ReadAccessorVector<T>& vec )
-    {
-        return os << *vec.vref;
-    }
-
 };
 
 /// WriteAccessor implementation class for vector types
@@ -235,17 +213,6 @@ public:
     void resize(Size s, bool /*init*/ = true) { vref->resize(s); }
     void reserve(Size s) { vref->reserve(s); }
     void push_back(const value_type& v) { vref->push_back(v); }
-
-    inline friend std::ostream& operator<< ( std::ostream& os, const WriteAccessorVector<T>& vec )
-    {
-        return os << *vec.vref;
-    }
-
-    inline friend std::istream& operator>> ( std::istream& in, WriteAccessorVector<T>& vec )
-    {
-        return in >> *vec.vref;
-    }
-
 };
 
 // Support for std::vector

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/accessor.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/accessor.h
@@ -185,7 +185,7 @@ public:
     const_iterator begin() const { return vref->begin(); }
     const_iterator end() const { return vref->end(); }
 
-    [[deprecated("FUXk")]]
+    [[deprecated("Custom operator<< for accessor have been deprecated in #PR1808. Just replace std::cout << myaccessor by std::cout << myccessor.ref()")]]
     friend std::ostream& operator<< ( std::ostream& os, const ReadAccessorVector<T>& vec ) = delete;
 };
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/accessor.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/accessor.h
@@ -74,9 +74,11 @@ public:
     const_pointer   operator->() const { return vref; }
     const_reference operator* () const { return  *vref; }
 
+    template<class U>
     [[deprecated("Custom operator<< for accessor have been deprecated in #PR1808. Just replace std::cout << myaccessor by std::cout << myccessor.ref()")]]
-    friend std::ostream& operator<< ( std::ostream& os, const ReadAccessor<T>& vec ) = delete;
+    friend std::ostream& operator<<( std::ostream& os, const ReadAccessor<U>& vec ) = delete;
 };
+
 
 /** A WriteAccessor is a proxy class, holding a reference to a given container
  *  and providing access to its data, using an unified interface (similar to
@@ -129,11 +131,13 @@ public:
         vref = &v;
     }
 
+    template<class U>
     [[deprecated("Custom operator<< for accessor have been deprecated in #PR1808. Just replace std::cout << myaccessor by std::cout << myccessor.ref()")]]
-    friend std::ostream& operator<< ( std::ostream& os, const WriteAccessor<T>& vec ) = delete;
+    friend std::ostream& operator<< ( std::ostream& os, const WriteAccessor<U>& vec ) = delete;
 
+    template<class U>
     [[deprecated("Custom operator<< for accessor have been deprecated in #PR1808. Just replace std::cout << myaccessor by std::cout << myccessor.ref()")]]
-    friend std::istream& operator>> ( std::istream& in, WriteAccessor<T>& vec ) =delete;
+    friend std::istream& operator>> ( std::istream& in, WriteAccessor<U>& vec ) = delete;
 };
 
 
@@ -185,8 +189,9 @@ public:
     const_iterator begin() const { return vref->begin(); }
     const_iterator end() const { return vref->end(); }
 
+    template<class U>
     [[deprecated("Custom operator<< for accessor have been deprecated in #PR1808. Just replace std::cout << myaccessor by std::cout << myccessor.ref()")]]
-    friend std::ostream& operator<< ( std::ostream& os, const ReadAccessorVector<T>& vec ) = delete;
+    friend std::ostream& operator<< ( std::ostream& os, const ReadAccessorVector<U>& vec ) = delete;
 };
 
 /// WriteAccessor implementation class for vector types

--- a/applications/plugins/PluginExample/PluginExample_test/MyBehaviorModel_test.cpp
+++ b/applications/plugins/PluginExample/PluginExample_test/MyBehaviorModel_test.cpp
@@ -52,7 +52,7 @@ public:
         m_behaviorModel->d_regularUnsignedData.setValue(param);
         auto regularUnsignedDataFromBehaviorModel = sofa::helper::getReadAccessor(m_behaviorModel->d_regularUnsignedData);
 
-        EXPECT_EQ(regularUnsignedDataFromBehaviorModel, param);
+        EXPECT_EQ(regularUnsignedDataFromBehaviorModel.ref(), param);
     }
 
 private:

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticleSource.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticleSource.inl
@@ -150,7 +150,7 @@ void ParticleSource<DataTypes>::projectPosition(const sofa::core::MechanicalPara
     VecCoord& x = *xData.beginEdit();
     Deriv dpos = d_velocity.getValue()*(time - m_lastTime);
     helper::ReadAccessor<Data<VecIndex> > _lastparticles = this->m_lastparticles;    
-    msg_info() << "projectPosition: " << _lastparticles;
+    msg_info() << "projectPosition: " << _lastparticles.ref();
     for (unsigned int s = 0; s < _lastparticles.size(); s++)
     {
         x[_lastparticles[s]] = m_lastpos[s];

--- a/applications/plugins/SofaTest/ForceField_test.h
+++ b/applications/plugins/SofaTest/ForceField_test.h
@@ -180,7 +180,7 @@ struct ForceField_test : public Sofa_test<typename _ForceFieldType::DataTypes::R
             std::cout << "run_test,          x = " << x << std::endl;
             std::cout << "                   v = " << v << std::endl;
             std::cout << "            expected f = " << ef << std::endl;
-            std::cout << "            actual f = " <<  f << std::endl;
+            std::cout << "            actual f = " <<  f.ref() << std::endl;
         }
         ASSERT_TRUE( this->vectorMaxDiff(f,ef)< errorMax*this->epsilon() );
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/ComplementaryROI.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/ComplementaryROI.inl
@@ -126,7 +126,7 @@ void ComplementaryROI<DataTypes>::doUpdate()
     for (unsigned int i=0;i<indices.size();++i)
         pointsInROI.push_back(position[indices[i]]);
 
-    msg_info() << "Created ROI containing " << indices.size() << " points not in " << nbSet << " sets" ;
+    msg_info() << "Created ROI containing " << indices.size() << " points not in " << nbSet.ref() << " sets" ;
 }
 
 } //namespace sofa::component::engine


### PR DESCRIPTION
Because it make no sense to have 50 lines of code+ a dependency to iostream.h to save 4 chars.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
