### PR TITLE
[SofaRigid] fixes applyJT of RigidMapping

### DIFF
--- a/SofaKernel/modules/SofaRigid/src/SofaRigid/RigidMapping.inl
+++ b/SofaKernel/modules/SofaRigid/src/SofaRigid/RigidMapping.inl
@@ -425,29 +425,22 @@ void RigidMapping<TIn, TOut>::applyJT(const core::ConstraintParams * /*cparams*/
 
     for (typename Out::MatrixDeriv::RowConstIterator rowIt = in.begin(); rowIt != rowItEnd; ++rowIt)
     {
-        typename Out::MatrixDeriv::ColConstIterator colIt = rowIt.begin();
-        typename Out::MatrixDeriv::ColConstIterator colItEnd = rowIt.end();
-
         for (unsigned int ito = 0; ito < numDofs; ito++)
         {
             DPos v;
             DRot omega = DRot();
             bool needToInsert = false;
 
-            for (unsigned int cpt = 0; cpt < points.getValue().size() && colIt != colItEnd; cpt++)
+            for (typename Out::MatrixDeriv::ColConstIterator colIt = rowIt.begin(); colIt != rowIt.end(); ++colIt)
             {
-                unsigned int rigidIndex = getRigidIndex( cpt );
-                if( rigidIndex != ito )
-                    continue;
-                if (colIt.index() != cpt)
+                unsigned int rigidIndex = getRigidIndex( colIt.index() );
+                if(rigidIndex != ito)
                     continue;
 
                 needToInsert = true;
                 const Deriv f = colIt.val();
                 v += f;
-                omega += (DRot) cross(rotatedPoints[cpt], f);
-
-                ++colIt;
+                omega += (DRot) cross(rotatedPoints[colIt.index()], f);
             }
 
             if (needToInsert)
@@ -459,7 +452,6 @@ void RigidMapping<TIn, TOut>::applyJT(const core::ConstraintParams * /*cparams*/
             }
         }
     }
-
 
     dmsg_info() << "new J on input  DOFs = " << out ;
 


### PR DESCRIPTION
This PR fixes applyJT (constraints) of RigidMapping. 

When using `rigidIndexPerPoint`, it would only work with indices in ascending order.  
For example: `rigidIndexPerPoint=[8,10,10,6,6,8]` would only map the three first constraints.

This PR fixes this issue and should not change the behavior when using `index` or `indexFromEnd`.

@ChristianDuriez: This was the problem with Etienne's scene. If you could have a look.. 
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
