### PR TITLE
[QSofaListModel] replace the use of c-cast with explicit c++_cast. 

### DIFF
--- a/modules/SofaGuiQt/src/sofa/gui/qt/QSofaListView.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QSofaListView.cpp
@@ -771,13 +771,18 @@ void QSofaListView::Export()
     Node* root = down_cast<Node>( graphListener_->findObject(this->topLevelItem(0))->toBaseNode() );
     GenGraphForm* form = new sofa::gui::qt::GenGraphForm(this);
     form->setScene ( root );
-    std::string gname(((RealGUI*) (QApplication::topLevelWidgets()[0]))->windowFilePath().toStdString());
-    std::size_t gpath = gname.find_last_of("/\\");
-    std::size_t gext = gname.rfind('.');
-    if (gext != std::string::npos && (gpath == std::string::npos || gext > gpath))
-        gname = gname.substr(0,gext);
-    form->filename->setText(gname.c_str());
-    form->show();
+    auto gui = dynamic_cast<RealGUI*>(QApplication::topLevelWidgets()[0]);
+    if(gui)
+    {
+        std::string gname = gui->windowFilePath().toStdString();
+        std::size_t gpath = gname.find_last_of("/\\");
+        std::size_t gext = gname.rfind('.');
+        if (gext != std::string::npos && (gpath == std::string::npos || gext > gpath))
+            gname = gname.substr(0,gext);
+        form->filename->setText(gname.c_str());
+        form->show();
+    }
+    msg_error("runSofa") << "Missing RealGUI, cannot export";
 }
 
 


### PR DESCRIPTION
Downcasting from a base class to a child would be much better handled with an explicit dynamic_cast or a static_cast (or a q_cast as pointed by @untereiner) than with an implicit C-cast.
____________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
