### PR TITLE
[LMConstraint] Add the requiredplugin lines in examples

### DIFF
--- a/applications/plugins/LMConstraint/examples/DOFBlockerLMConstraint.scn
+++ b/applications/plugins/LMConstraint/examples/DOFBlockerLMConstraint.scn
@@ -1,5 +1,7 @@
 <Node name="Root" gravity="0 0 0" dt="0.001">
     <RequiredPlugin name="SofaOpenglVisual"/>
+    <RequiredPlugin name="LMConstraint"/>
+    
     <VisualStyle displayFlags="showForceFields showBoundingCollisionModels" />
     <EulerImplicitSolver name="default26" printLog="0"  rayleighStiffness="0.1" rayleighMass="0.1" />
     <LMConstraintSolver name="ConstraintSolver" constraintVel="1" constraintPos="1" numIterations="27" maxError="1e-7"/>

--- a/applications/plugins/LMConstraint/examples/DistanceLMConstraint.scn
+++ b/applications/plugins/LMConstraint/examples/DistanceLMConstraint.scn
@@ -1,4 +1,6 @@
 <Node name="root" dt="0.02">
+    <RequiredPlugin name="LMConstraint"/>
+    
     <VisualStyle displayFlags="showBehaviorModels showForceFields" />
     <EulerImplicitSolver  rayleighStiffness="0.1" rayleighMass="0.1" />
     <CGLinearSolver iterations="25" tolerance="1e-5" threshold="1e-5"/>

--- a/applications/plugins/LMConstraint/examples/DistanceLMContactConstraint.scn
+++ b/applications/plugins/LMConstraint/examples/DistanceLMContactConstraint.scn
@@ -1,12 +1,15 @@
 <Node name="root" gravity="0 -9.81 0" dt="0.02">
     <RequiredPlugin name="SofaOpenglVisual"/>
+    <RequiredPlugin name="LMConstraint"/>
+    <RequiredPlugin name="SofaDistanceGrid"/>
+
     <VisualStyle displayFlags="showVisual showBehaviorModels showForceFields" />
     <DefaultPipeline name="default0" verbose="0" draw="0" />
     <BruteForceDetection name="N2" />
     <MinProximityIntersection name="Proximity" alarmDistance="0.8" contactDistance="0.7" />
     <DefaultContactManager name="Response" response="distanceLMConstraint" />
     <Node name="cubeFEM" gravity="0 -9.81 0">
-        <EulerImplicitSolver name="cg_odesolver" printLog="0"  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <EulerImplicitSolver name="cg_odesolver" printLog="0"  rayleighStiffness="0.1" rayleighMass="0.1"  solveConstraint="true"  />
         <CGLinearSolver template="GraphScattered" name="linear solver" iterations="25" tolerance="1e-09" threshold="1e-09" />
         <LMConstraintSolver name="default0" listening="1" constraintVel="1" constraintPos="1" numIterations="27" maxError="1e-7"/>
         <MechanicalObject template="Vec3d" name="dof"  translation="0 2 0" rotation="30 20 15" restScale="1" />

--- a/applications/plugins/LMConstraint/examples/DistanceLMContactConstraint_DirectSolver.scn
+++ b/applications/plugins/LMConstraint/examples/DistanceLMContactConstraint_DirectSolver.scn
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
 <Node name="root" gravity="0 -9.81 0" dt="0.02">
+    <RequiredPlugin name="LMConstraint"/>
+    <RequiredPlugin name="SofaDistanceGrid"/>
+    
     <RequiredPlugin name="SofaOpenglVisual"/>
     <VisualStyle displayFlags="showBehaviorModels showForceFields" />
     <DefaultPipeline name="default0" verbose="0" draw="0" />

--- a/applications/plugins/LMConstraint/examples/FixedLMConstraint.scn
+++ b/applications/plugins/LMConstraint/examples/FixedLMConstraint.scn
@@ -3,6 +3,8 @@
 The outcome of this scene is a still object. The MechanicalObject is comprised by two Rigids connected with a jointspring. The first end is Fixed through the FixedLMConstraint on rigid. The second end is fixed as well, but because all the dofs that are mapped to this end are fixed as well. -->   
 
 <Node 	name="Root" dt="0.02"  >
+    <RequiredPlugin name="LMConstraint"/>
+
   <VisualStyle displayFlags="showCollisionModels showBehaviorModels" />
 	<EulerImplicitSolver   rayleighStiffness="0.1" rayleighMass="0.1" />
 	<CGLinearSolver iterations="25" tolerance="1e-5" threshold="1e-5" />

--- a/applications/plugins/LMConstraint/examples/LMConstraintCollisionResponse.scn
+++ b/applications/plugins/LMConstraint/examples/LMConstraintCollisionResponse.scn
@@ -4,6 +4,9 @@ This scene involves collision between rigid and deformable ojects with different
 and stiffness coefficients for the collision models. 
 -->
 <Node >
+    <RequiredPlugin name="LMConstraint"/>
+    <RequiredPlugin name="SofaDistanceGrid"/>
+    
     <VisualStyle displayFlags="showBehaviorModels showCollisionModels" />
     <DefaultPipeline />
     <BruteForceDetection />


### PR DESCRIPTION
Some scenes in LMConstraint were crashing on the CI due to the facts that those scenes were expecting the plugin to be compiled with SofaDistanceGrid (necessary for the response defined as "distanceLMConstraint").
As the CI is not compiling the SofaDistanceGrid plugin and the scenes were not telling that they needed it, the scenes are crashing once there is a contact.

This PR adds the required plugins lines where it should be needed.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
