### PR TITLE
[LMConstraint] Fix collision model

### DIFF
--- a/applications/plugins/LMConstraint/CMakeLists.txt
+++ b/applications/plugins/LMConstraint/CMakeLists.txt
@@ -5,13 +5,16 @@ sofa_find_package(SofaFramework REQUIRED)
 sofa_find_package(SofaBase REQUIRED)
 sofa_find_package(SofaImplicitOdeSolver REQUIRED) 
 sofa_find_package(SofaConstraint REQUIRED) 
-sofa_find_package(SofaDistanceGrid QUIET) 
+sofa_find_package(SofaMiscCollision REQUIRED)
+sofa_find_package(SofaDistanceGrid QUIET)
 
 # List all files
 set(LMCONSTRAINT_SRC_DIR src/LMConstraint)
 set(HEADER_FILES
     ${LMCONSTRAINT_SRC_DIR}/config.h.in
     ${LMCONSTRAINT_SRC_DIR}/BaseLMConstraint.h
+    ${LMCONSTRAINT_SRC_DIR}/BarycentricDistanceLMConstraintContact.h
+    ${LMCONSTRAINT_SRC_DIR}/BarycentricDistanceLMConstraintContact.inl
     ${LMCONSTRAINT_SRC_DIR}/LMConstraint.h
     ${LMCONSTRAINT_SRC_DIR}/LMConstraint.inl
     ${LMCONSTRAINT_SRC_DIR}/ContactDescription.h
@@ -28,11 +31,13 @@ set(HEADER_FILES
     ${LMCONSTRAINT_SRC_DIR}/MechanicalWriteLMConstraint.h
     ${LMCONSTRAINT_SRC_DIR}/PrecomputedLMConstraintCorrection.h
     ${LMCONSTRAINT_SRC_DIR}/PrecomputedLMConstraintCorrection.inl
+
     )
 
 set(SOURCE_FILES
     ${LMCONSTRAINT_SRC_DIR}/initLMConstraint.cpp
     ${LMCONSTRAINT_SRC_DIR}/BaseLMConstraint.cpp
+    ${LMCONSTRAINT_SRC_DIR}/BarycentricDistanceLMConstraintContact.cpp
     ${LMCONSTRAINT_SRC_DIR}/LMConstraint.cpp
     ${LMCONSTRAINT_SRC_DIR}/DOFBlockerLMConstraint.cpp
     ${LMCONSTRAINT_SRC_DIR}/FixedLMConstraint.cpp
@@ -42,21 +47,12 @@ set(SOURCE_FILES
     ${LMCONSTRAINT_SRC_DIR}/LMConstraintDirectSolver.cpp
     ${LMCONSTRAINT_SRC_DIR}/MechanicalWriteLMConstraint.cpp
     ${LMCONSTRAINT_SRC_DIR}/PrecomputedLMConstraintCorrection.cpp
+    ${LMCONSTRAINT_SRC_DIR}/TetrahedronBarycentricDistanceLMConstraintContact.cpp
     )
-
 
 if(SofaDistanceGrid_FOUND)
-    list(APPEND HEADER_FILES
-
-        ${LMCONSTRAINT_SRC_DIR}/BarycentricDistanceLMConstraintContact.h
-        ${LMCONSTRAINT_SRC_DIR}/BarycentricDistanceLMConstraintContact.inl
-    )
     list(APPEND SOURCE_FILES
-
-        ${LMCONSTRAINT_SRC_DIR}/BarycentricDistanceLMConstraintContact_DistanceGrid.cpp
-        ${LMCONSTRAINT_SRC_DIR}/BarycentricDistanceLMConstraintContact.cpp
-        ${LMCONSTRAINT_SRC_DIR}/TetrahedronBarycentricDistanceLMConstraintContact.cpp
-
+        ${LMCONSTRAINT_SRC_DIR}/BarycentricDistanceLMConstraintContact_DistanceGrid.cpp     
     )
 else()
     message(STATUS "SofaDistanceGrid not found: DistanceLM codes will not be compiled")
@@ -65,7 +61,7 @@ endif()
 
 # Create the plugin library
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} )
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaCore SofaBaseLinearSolver SofaImplicitOdeSolver SofaHelper SofaDefaultType SofaConstraint)
+target_link_libraries(${PROJECT_NAME} PUBLIC SofaCore SofaBaseLinearSolver SofaImplicitOdeSolver SofaHelper SofaDefaultType SofaConstraint SofaMiscCollision)
 
 if(SofaDistanceGrid_FOUND)
     target_link_libraries(${PROJECT_NAME} PUBLIC SofaDistanceGrid)

--- a/applications/plugins/LMConstraint/src/LMConstraint/BaseLMConstraint.h
+++ b/applications/plugins/LMConstraint/src/LMConstraint/BaseLMConstraint.h
@@ -166,7 +166,11 @@ public:
     virtual const helper::vector< ConstraintGroup* > &getConstraintsOrder(ConstraintParams::ConstOrder Order) const
     {
         constraintOrder_t::const_iterator c = constraintOrder.find( Order );
-        assert( c != constraintOrder.end());
+        if( c == constraintOrder.end());
+        {
+            static helper::vector<ConstraintGroup*> emptyVector;
+            return emptyVector;
+        }
         return c->second;
     }
 


### PR DESCRIPTION
The collision model used in LMConstraint are only compiled if the SofaDistanceGrid plugin is loaded while they shouldn't.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
