### PR TITLE
[SofaHelper] FIX "name vs path" issue in PluginManager + FIX PluginManager_test

### DIFF
--- a/SofaKernel/modules/SofaHelper/SofaHelper_test/system/PluginManager_test.cpp
+++ b/SofaKernel/modules/SofaHelper/SofaHelper_test/system/PluginManager_test.cpp
@@ -58,7 +58,21 @@ struct PluginManager_test: public BaseTest
 
     void SetUp() override
     {
-        pluginDir = sofa::helper::system::PluginRepository.getFirstPath();
+        // Set pluginDir by searching pluginFileName in the PluginRepository
+        for ( std::string path : sofa::helper::system::PluginRepository.getPaths() )
+        {
+            if ( FileSystem::exists(path + separator + pluginFileName + dotExt) )
+            {
+                pluginDir = path;
+                break;
+            }
+        }
+
+        ASSERT_FALSE( pluginDir.empty() );
+
+        std::cout << "PluginManager_test.loadTestPluginByPath: "
+                  << "pluginDir = " << pluginDir
+                  << std::endl;
     }
 
     void TearDown() override
@@ -83,15 +97,20 @@ TEST_F(PluginManager_test, loadTestPluginByPath)
 {
     PluginManager&pm = PluginManager::getInstance();
 
-    std::string pluginPath = pluginDir + separator + prefix + pluginFileName + dotExt;
-    std::string nonpluginPath = pluginDir + separator + prefix + nonpluginName + dotExt;
+    std::string pluginPath = FileSystem::cleanPath(pluginDir + separator + prefix + pluginFileName + dotExt);
+    std::string nonpluginPath = FileSystem::cleanPath(pluginDir + separator + prefix + nonpluginName + dotExt);
 
     /// Check that existing plugins are correctly handled and returns no
     /// error/warning message.
     {
         EXPECT_MSG_NOEMIT(Warning, Error) ;
 
-        std::cout << pm.getPluginMap().size() << std::endl;
+        std::cout << "PluginManager_test.loadTestPluginByPath: "
+                  << "pm.getPluginMap().size() = " << pm.getPluginMap().size()
+                  << std::endl;
+        std::cout << "PluginManager_test.loadTestPluginByPath: "
+                  << "pluginPath = " << pluginPath
+                  << std::endl;
         ASSERT_TRUE(pm.loadPluginByPath(pluginPath));
         ASSERT_GT(pm.findPlugin(pluginName).size(), 0u);
     }
@@ -102,10 +121,14 @@ TEST_F(PluginManager_test, loadTestPluginByPath)
         EXPECT_MSG_NOEMIT(Warning) ;
         EXPECT_MSG_EMIT(Error) ;
 
-        std::cout << pm.getPluginMap().size() << std::endl;
+        std::cout << "PluginManager_test.loadTestPluginByPath: "
+                  << "pm.getPluginMap().size() = " << pm.getPluginMap().size()
+                  << std::endl;
         ASSERT_FALSE(pm.loadPluginByPath(nonpluginPath));
         ASSERT_EQ(pm.findPlugin(nonpluginName).size(), 0u);
-        std::cout << pm.getPluginMap().size() << std::endl;
+        std::cout << "PluginManager_test.loadTestPluginByPath: "
+                  << "pm.getPluginMap().size() = " << pm.getPluginMap().size()
+                  << std::endl;
     }
 }
 

--- a/SofaKernel/modules/SofaHelper/SofaHelper_test/system/PluginManager_test.cpp
+++ b/SofaKernel/modules/SofaHelper/SofaHelper_test/system/PluginManager_test.cpp
@@ -97,8 +97,12 @@ TEST_F(PluginManager_test, loadTestPluginByPath)
 {
     PluginManager&pm = PluginManager::getInstance();
 
-    std::string pluginPath = FileSystem::cleanPath(pluginDir + separator + prefix + pluginFileName + dotExt);
-    std::string nonpluginPath = FileSystem::cleanPath(pluginDir + separator + prefix + nonpluginName + dotExt);
+    std::string pluginPath = pluginDir + separator + prefix + pluginFileName + dotExt;
+    std::string nonpluginPath = pluginDir + separator + prefix + nonpluginName + dotExt;
+
+    std::cout << "PluginManager_test.loadTestPluginByPath: "
+              << "pluginPath = " << pluginPath
+              << std::endl;
 
     /// Check that existing plugins are correctly handled and returns no
     /// error/warning message.
@@ -107,9 +111,6 @@ TEST_F(PluginManager_test, loadTestPluginByPath)
 
         std::cout << "PluginManager_test.loadTestPluginByPath: "
                   << "pm.getPluginMap().size() = " << pm.getPluginMap().size()
-                  << std::endl;
-        std::cout << "PluginManager_test.loadTestPluginByPath: "
-                  << "pluginPath = " << pluginPath
                   << std::endl;
         ASSERT_TRUE(pm.loadPluginByPath(pluginPath));
         ASSERT_GT(pm.findPlugin(pluginName).size(), 0u);

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
@@ -395,18 +395,35 @@ std::string PluginManager::findPlugin(const std::string& pluginName, const std::
 
 bool PluginManager::pluginIsLoaded(const std::string& plugin)
 {
-    std::string pluginPath = plugin;
+    if (plugin.empty()) return false;
+
+    std::string pluginPath;
 
     /// If we are not providing a filename then we have either to iterate in the plugin
     /// map to check no plugin has the same name or check in there is no accessible path
     /// in the plugin repository matching the pluginName
-    if (!FileSystem::isFile(plugin))
+    if (FileSystem::cleanPath(plugin, FileSystem::SLASH).find('/') != std::string::npos)
     {
+        // plugin argument is a path
+        if (!FileSystem::isFile(plugin))
+        {
+            // path is invalid
+            msg_error("PluginManager") << "File not found: " << plugin;
+            return false;
+        }
+
+        pluginPath = plugin;
+    }
+    else
+    {
+        // plugin argument is a name
         /// Here is the iteration in the loaded plugin map
         for(auto k : m_pluginMap)
         {
             if(plugin == k.second.getModuleName())
+            {
                 return true;
+            }
         }
 
         /// At this point we have not found a loaded plugin, we try to


### PR DESCRIPTION
PluginManager.cpp:403 `if (!FileSystem::isFile(plugin))` can mean 2 things:
- plugin is a path but is invalid (file does not exist or path is badly formed)
- plugin is not a path (it's a name)

The problem was that we assumed that `!FileSystem::isFile(plugin)` implied that plugin was a name.

PluginManager::pluginIsLoaded should now correctly handle paths and names.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
