### PR TITLE
[SofaHelper] Add two search paths for every prefixes of the plugin manager

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
@@ -29,6 +29,7 @@ using sofa::helper::system::FileSystem;
 
 #include <boost/filesystem.hpp>
 #include <fstream>
+#include <array>
 
 using sofa::helper::Utils;
 
@@ -321,12 +322,20 @@ std::string PluginManager::findPlugin(const std::string& pluginName, const std::
     const std::string libName = DynamicLibrary::prefix + name + "." + DynamicLibrary::extension;
 
     // First try: case sensitive
-    for (std::vector<std::string>::iterator i = searchPaths.begin(); i!=searchPaths.end(); i++)
-    {
-        const std::string path = *i + "/" + libName;
-        if (FileSystem::isFile(path))
-            return path;
+    for (const auto & prefix : searchPaths) {
+        const std::array<std::string, 4> paths = {
+                prefix + "/" + libName,
+                prefix + "/" + pluginName + "/" + libName,
+                prefix + "/" + pluginName + "/bin/" + libName,
+                prefix + "/" + pluginName + "/lib/" + libName
+        };
+        for (const auto & path : paths) {
+            if (FileSystem::isFile(path)) {
+                return path;
+            }
+        }
     }
+
     // Second try: case insensitive and recursive
     if (ignoreCase)
     {

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.h
@@ -169,7 +169,7 @@ public:
     void init();
     void init(const std::string& pluginPath);
 
-    std::string findPlugin(const std::string& pluginName, const std::string& suffix = getDefaultSuffix(), bool ignoreCase = true, bool recursive = true, int maxRecursiveDepth = 6);
+    std::string findPlugin(const std::string& pluginName, const std::string& suffix = getDefaultSuffix(), bool ignoreCase = true, bool recursive = true, int maxRecursiveDepth = 3);
     bool pluginIsLoaded(const std::string& plugin);
     bool checkDuplicatedPlugin(const Plugin& plugin, const std::string& pluginPath);
 


### PR DESCRIPTION
When the plugin manager searches for a plugin, it will loop through the prefixes defined inside the PluginRepository, and append it the plugin name. If this file exists, it will be directly returned. Else, it will go recursively through each prefixes trying to find the file, which is inefficient and does not follow symbolic links. Especially since the prefixes contain large directories such as "/usr/lib".

This PR adds two hard coded path to each prefixes which will help the plugin manager find common plugins usually located in _"$SOFA_ROOT/plugins/PLUGIN_NAME/lib/libPLUGIN_NAME.so"_ **just before** doing the recursive search.

This should improve the speed for locating common plugins, and moreover allow some symbolic links to external plugins since the recursive search do not follow these links.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
