### PR TITLE
[SofaGuiCommon] fix BackgroundSetting

### DIFF
--- a/modules/SofaGuiCommon/src/sofa/gui/BaseViewer.cpp
+++ b/modules/SofaGuiCommon/src/sofa/gui/BaseViewer.cpp
@@ -176,7 +176,7 @@ void BaseViewer::resetView()
 
 void BaseViewer::setBackgroundColour(float r, float g, float b)
 {
-    _background = 2;
+    _background = 3;
     backgroundColour[0] = r;
     backgroundColour[1] = g;
     backgroundColour[2] = b;


### PR DESCRIPTION
Setting the background color with the component BackgroundSetting wasn't working anymore, because in PR #1758 the test changed from:

```cpp
else if (_background==2)
        glClearColor(backgroundColour[0],backgroundColour[1],backgroundColour[2], 1.0f);	    
```
to: 

```cpp
else if (_background==3)
        glClearColor(backgroundColour[0],backgroundColour[1],backgroundColour[2], 1.0f);	
```



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
