### PR TITLE
[All] FIX build without SofaPython soft dependencies

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/CMakeLists.txt
+++ b/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.12)
 
 project(SofaBaseMechanics_test)
 
+find_package(SofaTest REQUIRED)
+
 set(SOURCE_FILES
     UniformMass_test.cpp
     DiagonalMass_test.cpp
@@ -10,20 +12,12 @@ set(SOURCE_FILES
     BarycentricMapping_test.cpp
     )
 
-
-
-find_package(SofaPython QUIET)
-if(SofaPython_FOUND AND SOFA_ENABLE_SOFT_DEPS_TO_SOFAPYTHON)
+if(SOFATEST_HAVE_SOFAPYTHON)
     add_definitions("-DSOFABASEMECHANICS_TEST_PYTHON_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/python\"")
     list(APPEND SOURCE_FILES python_test_list.cpp)
 endif()
 
-
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} SofaTest SofaGTestMain)
-
-if(SofaPython_FOUND AND SOFA_ENABLE_SOFT_DEPS_TO_SOFAPYTHON)
-    target_link_libraries(${PROJECT_NAME} SofaPython)
-endif()
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/applications/plugins/Flexible/Flexible_test/CMakeLists.txt
+++ b/applications/plugins/Flexible/Flexible_test/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.12)
 
 project(Flexible_test)
 
+find_package(SofaTest REQUIRED)
+
 set(HEADER_FILES
     StrainMapping_test.h
 )
@@ -36,9 +38,7 @@ if(WIN32)
     list(APPEND SOURCE_FILES "stdafx.cpp")
 endif()
 
-find_package(SofaPython QUIET)
-
-if(SofaPython_FOUND)
+if(SOFATEST_HAVE_SOFAPYTHON)
     list(APPEND SOURCE_FILES python_test_list.cpp)
     add_definitions("-DFLEXIBLE_TEST_PYTHON_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/scenes/python\"")
 endif()

--- a/applications/plugins/Flexible/Flexible_test/CMakeLists.txt
+++ b/applications/plugins/Flexible/Flexible_test/CMakeLists.txt
@@ -61,6 +61,7 @@ target_link_libraries(${PROJECT_NAME} Flexible SofaTest SofaGTestMain CImgPlugin
 
 if(image_FOUND)
     target_link_libraries(${PROJECT_NAME} image)
+    target_compile_definitions(${PROJECT_NAME} "FLEXIBLE_TEST_WITH_IMAGE")
 endif()
 
 

--- a/applications/plugins/Flexible/Flexible_test/CMakeLists.txt
+++ b/applications/plugins/Flexible/Flexible_test/CMakeLists.txt
@@ -61,7 +61,7 @@ target_link_libraries(${PROJECT_NAME} Flexible SofaTest SofaGTestMain CImgPlugin
 
 if(image_FOUND)
     target_link_libraries(${PROJECT_NAME} image)
-    target_compile_definitions(${PROJECT_NAME} "FLEXIBLE_TEST_WITH_IMAGE")
+    target_compile_definitions(${PROJECT_NAME} PUBLIC "FLEXIBLE_TEST_WITH_IMAGE")
 endif()
 
 

--- a/applications/plugins/Flexible/Flexible_test/stdafx.h
+++ b/applications/plugins/Flexible/Flexible_test/stdafx.h
@@ -28,9 +28,11 @@
 #include <SofaBoundaryCondition/TrianglePressureForceField.h>
 #include <SofaBoundaryCondition/PatchTestMovementConstraint.h>
 
-
+#ifdef FLEXIBLE_TEST_WITH_IMAGE
 #include <image/ImageTypes.h>
 #include <image/ImageContainer.h>
+#endif
+
 #include <Flexible/types/DeformationGradientTypes.h>
 #include <Flexible/types/StrainTypes.h>
 #include <Flexible/material/HookeForceField.h>
@@ -42,11 +44,13 @@
 #include <Flexible/strainMapping/CauchyStrainMapping.h>
 #include <Flexible/strainMapping/InvariantMapping.h>
 #include <Flexible/strainMapping/PrincipalStretchesMapping.h>
-#include <Flexible/shapeFunction/VoronoiShapeFunction.h>
 #include <Flexible/shapeFunction/ShepardShapeFunction.h>
 #include <Flexible/shapeFunction/HatShapeFunction.h>
+#ifdef FLEXIBLE_TEST_WITH_IMAGE
+#include <Flexible/shapeFunction/VoronoiShapeFunction.h>
 #include <Flexible/shapeFunction/ShapeFunctionDiscretizer.h>
 #include <Flexible/shapeFunction/DiffusionShapeFunction.h>
+#endif
 
 
 

--- a/applications/plugins/SofaImplicitField/CMakeLists.txt
+++ b/applications/plugins/SofaImplicitField/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.12)
 project(SofaImplicitField VERSION 1.0)
 
 sofa_find_package(SofaDistanceGrid REQUIRED)
-sofa_find_package(SofaPython QUIET)
 
 set(HEADER_FILES
     config.h.in

--- a/applications/plugins/SofaTest/CMakeLists.txt
+++ b/applications/plugins/SofaTest/CMakeLists.txt
@@ -49,7 +49,7 @@ find_package(SofaMiscMapping REQUIRED)
 find_package(SofaMiscFem REQUIRED)
 find_package(SceneCreator REQUIRED)
 
-find_package(SofaPython QUIET)
+sofa_find_package(SofaPython QUIET)
 if(SofaPython_FOUND)
     list(APPEND HEADER_FILES "Python_test.h")
     list(APPEND SOURCE_FILES "Python_test.cpp")

--- a/applications/plugins/SofaTest/SofaTestConfig.cmake.in
+++ b/applications/plugins/SofaTest/SofaTestConfig.cmake.in
@@ -8,7 +8,7 @@ find_package(SofaMiscForceField REQUIRED)
 find_package(SofaMiscMapping REQUIRED)
 find_package(SceneCreator REQUIRED)
 
-set(SOFATEST_HAVE_SOFAPYTHON @SofaPython_FOUND@)
+set(SOFATEST_HAVE_SOFAPYTHON @SOFATEST_HAVE_SOFAPYTHON@)
 
 if(SOFATEST_HAVE_SOFAPYTHON)
     find_package(SofaPython REQUIRED)


### PR DESCRIPTION
Here are a few fixes needed for SofaPython2 -> SofaPython3 transition on CI :+1:

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
