### PR TITLE
[SofaSimulationCore] Launch a new event when textures have been initialized.

### DIFF
--- a/SofaKernel/modules/SofaSimulationCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaSimulationCore/CMakeLists.txt
@@ -75,6 +75,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/VisitorAsync.h
     ${SRC_ROOT}/events/SimulationInitDoneEvent.h
     ${SRC_ROOT}/events/SimulationInitStartEvent.h
+    ${SRC_ROOT}/events/SimulationInitTexturesDoneEvent.h
     ${SRC_ROOT}/events/SimulationStartEvent.h
     ${SRC_ROOT}/events/SimulationStopEvent.h
 )
@@ -141,6 +142,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/InitTasks.cpp
     ${SRC_ROOT}/events/SimulationInitDoneEvent.cpp
     ${SRC_ROOT}/events/SimulationInitStartEvent.cpp
+    ${SRC_ROOT}/events/SimulationInitTexturesDoneEvent.cpp
     ${SRC_ROOT}/events/SimulationStartEvent.cpp
     ${SRC_ROOT}/events/SimulationStopEvent.cpp
 )

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Simulation.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Simulation.cpp
@@ -59,6 +59,7 @@
 
 #include <sofa/simulation/events/SimulationInitStartEvent.h>
 #include <sofa/simulation/events/SimulationInitDoneEvent.h>
+#include <sofa/simulation/events/SimulationInitTexturesDoneEvent.h>
 
 
 #include <fstream>
@@ -306,6 +307,10 @@ void Simulation::initTextures ( Node* root )
         msg_error() << "Simulation::initTextures() : VisualLoop expected at the root node";
         return;
     }
+
+    SimulationInitTexturesDoneEvent endInit;
+    PropagateEventVisitor pe {params, &endInit};
+    root->execute(pe);
 }
 
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/events/SimulationInitTexturesDoneEvent.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/events/SimulationInitTexturesDoneEvent.cpp
@@ -1,0 +1,29 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/simulation/events/SimulationInitTexturesDoneEvent.h>
+
+namespace sofa::simulation
+{
+
+SOFA_EVENT_CPP( SimulationInitTexturesDoneEvent )
+
+} // namespace sofa::simulation

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/events/SimulationInitTexturesDoneEvent.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/events/SimulationInitTexturesDoneEvent.h
@@ -1,0 +1,47 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/core/objectmodel/Event.h>
+#include <sofa/simulation/config.h>
+
+namespace sofa::simulation
+{
+
+/**
+  Event fired when sofa::simulation::Simulation::initTextures has been called.
+*/
+class SOFA_SIMULATION_CORE_API SimulationInitTexturesDoneEvent : public sofa::core::objectmodel::Event
+{
+public:
+
+    SOFA_EVENT_H( SimulationInitTexturesDoneEvent )
+
+    SimulationInitTexturesDoneEvent() = default;
+    ~SimulationInitTexturesDoneEvent() override = default;
+
+    inline static const char* GetClassName() { return "SimulationInitTexturesDoneEvent"; }
+
+};
+
+} // namespace sofa::simulation
+


### PR DESCRIPTION
This PR adds a new event type, `SimulationInitTexturesDoneEvent`, that will be launch as soon as textures have been initialized. This is needed to make sure all OpenGL buffers have been created, and that we can render a first frame even if there have been no simulation steps done.

This was needed for the [SofaOffscreenCamera](https://github.com/jnbrunet/SofaOffscreenCamera) to be able to render the visual before any simulation steps.





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
