### PR TITLE
[SofaMeshCollision] Fix: windows debug linkage of class EmptyFilter

### DIFF
--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/EmptyFilter.h
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/EmptyFilter.h
@@ -30,7 +30,7 @@ namespace sofa::component::collision
 /**
  * @brief
  */
-class SOFA_SOFAMESHCOLLISION_API EmptyFilter
+class EmptyFilter
 {
 public:
     /**


### PR DESCRIPTION







______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
