### PR TITLE
[SofaBaseTopology] Clean RenumberPoints methods

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/EdgeSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/EdgeSetTopologyModifier.cpp
@@ -650,19 +650,6 @@ void EdgeSetTopologyModifier::removeItems(const sofa::helper::vector< EdgeID >& 
     removeEdges(items);
 }
 
-void EdgeSetTopologyModifier::renumberPoints( const sofa::helper::vector<EdgeID> &index,
-        const sofa::helper::vector<EdgeID> &inv_index, const bool renumberDOF)
-{
-    /// add the topological changes in the queue
-    renumberPointsWarning(index, inv_index, renumberDOF);
-    // inform other objects that the triangles are going to be removed
-    propagateTopologicalChanges();
-    // now renumber the points
-    renumberPointsProcess(index, inv_index, renumberDOF);
-
-    m_container->checkTopology();
-}
-
 void EdgeSetTopologyModifier::addEdges(const sofa::helper::vector< Edge >& edges)
 {
     sofa::helper::AdvancedTimer::stepBegin("addEdges");

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/EdgeSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/EdgeSetTopologyModifier.cpp
@@ -651,14 +651,14 @@ void EdgeSetTopologyModifier::removeItems(const sofa::helper::vector< EdgeID >& 
 }
 
 void EdgeSetTopologyModifier::renumberPoints( const sofa::helper::vector<EdgeID> &index,
-        const sofa::helper::vector<EdgeID> &inv_index)
+        const sofa::helper::vector<EdgeID> &inv_index, const bool renumberDOF)
 {
     /// add the topological changes in the queue
-    renumberPointsWarning(index, inv_index);
+    renumberPointsWarning(index, inv_index, renumberDOF);
     // inform other objects that the triangles are going to be removed
     propagateTopologicalChanges();
     // now renumber the points
-    renumberPointsProcess(index, inv_index);
+    renumberPointsProcess(index, inv_index, renumberDOF);
 
     m_container->checkTopology();
 }

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/EdgeSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/EdgeSetTopologyModifier.h
@@ -217,7 +217,7 @@ public:
     /** \brief Generic method for points renumbering
     */
     void renumberPoints( const sofa::helper::vector<PointID> & index,
-            const sofa::helper::vector<PointID> & inv_index) override;
+            const sofa::helper::vector<PointID> & inv_index, const bool renumberDOF = true) override;
 
     /** \brief Swap a list of pair edges, replacing each edge pair ((p11, p12), (p21, p22)) by the edge pair ((p11, p21), (p12, p22))
     *

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/EdgeSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/EdgeSetTopologyModifier.h
@@ -194,14 +194,6 @@ public:
     void removePointsProcess(const sofa::helper::vector<PointID> &indices,
             const bool removeDOF = true) override;
 
-    /** \brief Reorder this topology.
-    *
-    * Important : the points are actually renumbered in the mechanical object's state vectors iff (renumberDOF == true)
-    * \see MechanicalObject::renumberValues
-    */
-    void renumberPointsProcess( const sofa::helper::vector<PointID> &index,
-            const sofa::helper::vector<PointID> &/*inv_index*/,
-            const bool renumberDOF = true) override;
 
     /** \brief Remove a set of edges
     @param edges an array of edge indices to be removed (note that the array is not const since it needs to be sorted)
@@ -214,10 +206,6 @@ public:
     */
     void removeItems(const sofa::helper::vector<EdgeID> &items) override;
 
-    /** \brief Generic method for points renumbering
-    */
-    void renumberPoints( const sofa::helper::vector<PointID> & index,
-            const sofa::helper::vector<PointID> & inv_index, const bool renumberDOF = true) override;
 
     /** \brief Swap a list of pair edges, replacing each edge pair ((p11, p12), (p21, p22)) by the edge pair ((p11, p21), (p12, p22))
     *
@@ -295,6 +283,16 @@ public:
     * @return false if something goes wrong during the process.
     */
     virtual bool removeIsolatedElements(sofa::Size scaleElem);
+
+protected:
+    /** \brief Reorder this topology.
+    *
+    * Important : the points are actually renumbered in the mechanical object's state vectors iff (renumberDOF == true)
+    * \see MechanicalObject::renumberValues
+    */
+    void renumberPointsProcess(const sofa::helper::vector<PointID>& index,
+        const sofa::helper::vector<PointID>&/*inv_index*/,
+        const bool renumberDOF = true) override;
 
 private:
     EdgeSetTopologyContainer* 	m_container;

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/HexahedronSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/HexahedronSetTopologyModifier.cpp
@@ -608,19 +608,6 @@ void HexahedronSetTopologyModifier::removeItems(const sofa::helper::vector< Hexa
     removeHexahedra(items);
 }
 
-void HexahedronSetTopologyModifier::renumberPoints(const sofa::helper::vector<PointID> &index,
-        const sofa::helper::vector<PointID> &inv_index, const bool renumberDOF)
-{
-    /// add the topological changes in the queue
-    renumberPointsWarning(index, inv_index, renumberDOF);
-    // inform other objects that the triangles are going to be removed
-    propagateTopologicalChanges();
-    // now renumber the points
-    renumberPointsProcess(index, inv_index, renumberDOF);
-
-    m_container->checkTopology();
-}
-
 void HexahedronSetTopologyModifier::propagateTopologicalEngineChanges()
 {
     if (m_container->beginChange() == m_container->endChange()) return; // nothing to do if no event is stored

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/HexahedronSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/HexahedronSetTopologyModifier.cpp
@@ -609,14 +609,14 @@ void HexahedronSetTopologyModifier::removeItems(const sofa::helper::vector< Hexa
 }
 
 void HexahedronSetTopologyModifier::renumberPoints(const sofa::helper::vector<PointID> &index,
-        const sofa::helper::vector<PointID> &inv_index)
+        const sofa::helper::vector<PointID> &inv_index, const bool renumberDOF)
 {
     /// add the topological changes in the queue
-    renumberPointsWarning(index, inv_index);
+    renumberPointsWarning(index, inv_index, renumberDOF);
     // inform other objects that the triangles are going to be removed
     propagateTopologicalChanges();
     // now renumber the points
-    renumberPointsProcess(index, inv_index);
+    renumberPointsProcess(index, inv_index, renumberDOF);
 
     m_container->checkTopology();
 }

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/HexahedronSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/HexahedronSetTopologyModifier.h
@@ -177,15 +177,6 @@ public:
     */
     void removePointsProcess(const sofa::helper::vector<PointID> &indices, const bool removeDOF = true) override;
 
-    /** \brief Reorder this topology.
-    *
-    * Important : the points are actually renumbered in the mechanical object's state vectors iff (renumberDOF == true)
-    * \see MechanicalObject::renumberValues
-    */
-    void renumberPointsProcess( const sofa::helper::vector<PointID> &index,
-            const sofa::helper::vector<PointID>& inv_index,
-            const bool renumberDOF = true) override;
-
     /** \brief Remove a set  of hexahedra
     @param hexahedra an array of hexahedron indices to be removed (note that the array is not const since it needs to be sorted)
     *
@@ -196,11 +187,15 @@ public:
     */
     void removeItems(const sofa::helper::vector<HexahedronID> &items) override;
 
-    /** \brief Generic method for points renumbering
+protected:
+    /** \brief Reorder this topology.
+    *
+    * Important : the points are actually renumbered in the mechanical object's state vectors iff (renumberDOF == true)
+    * \see MechanicalObject::renumberValues
     */
-    void renumberPoints( const sofa::helper::vector<PointID>& index,
-            const sofa::helper::vector<PointID>& inv_index, const bool renumberDOF = true) override;
-
+    void renumberPointsProcess(const sofa::helper::vector<PointID>& index,
+        const sofa::helper::vector<PointID>& inv_index,
+        const bool renumberDOF = true) override;
 
 private:
     HexahedronSetTopologyContainer* 	m_container;

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/HexahedronSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/HexahedronSetTopologyModifier.h
@@ -199,7 +199,7 @@ public:
     /** \brief Generic method for points renumbering
     */
     void renumberPoints( const sofa::helper::vector<PointID>& index,
-            const sofa::helper::vector<PointID>& inv_index) override;
+            const sofa::helper::vector<PointID>& inv_index, const bool renumberDOF = true) override;
 
 
 private:

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyModifier.cpp
@@ -326,6 +326,27 @@ void PointSetTopologyModifier::movePointsProcess (const sofa::helper::vector <Po
 
 
 
+void PointSetTopologyModifier::renumberPoints(const sofa::helper::vector< PointID >& index,
+    const sofa::helper::vector< PointID >& inv_index,
+    const bool renumberDOF)
+{
+    sofa::helper::AdvancedTimer::stepBegin("Renumber Points");
+
+    sofa::helper::AdvancedTimer::stepBegin("renumberPointsWarning");
+    renumberPointsWarning(index, inv_index, renumberDOF);
+
+    sofa::helper::AdvancedTimer::stepNext("renumberPointsWarning", "propagateTopologicalChanges");
+    propagateTopologicalChanges();
+
+    sofa::helper::AdvancedTimer::stepNext("propagateTopologicalChanges", "renumberPointsProcess");
+    renumberPointsProcess(index, inv_index, renumberDOF);
+
+    sofa::helper::AdvancedTimer::stepEnd("renumberPointsProcess");
+
+    sofa::helper::AdvancedTimer::stepEnd("Renumber Points");
+}
+
+
 void PointSetTopologyModifier::removePointsWarning(sofa::helper::vector<PointID> &indices,
         const bool removeDOF)
 {

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyModifier.h
@@ -56,6 +56,12 @@ public:
     */
     virtual void swapPoints(const Index i1,const Index i2);
 
+    /** \brief Generic method for points renumbering
+    */
+    virtual void renumberPoints(const sofa::helper::vector< PointID >& index,
+        const sofa::helper::vector< PointID >& inv_index,
+        const bool renumberDOF = true);
+
     /** \brief Sends a message to warn that some points were added in this topology.
     *
     * \sa addPointsProcess
@@ -199,12 +205,6 @@ public:
     /** \brief Generic method to remove a list of items.
     */
     void removeItems(const sofa::helper::vector<  PointID  >& /*items*/) override
-    { }
-
-    /** \brief Generic method for points renumbering
-    */
-    virtual void renumberPoints( const sofa::helper::vector< PointID > &/*index*/,
-            const sofa::helper::vector< PointID > &/*inv_index*/)
     { }
 
 private:

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyModifier.h
@@ -57,6 +57,9 @@ public:
     virtual void swapPoints(const Index i1,const Index i2);
 
     /** \brief Generic method for points renumbering
+    *
+    * Important : the points are actually renumbered in the mechanical object's state vectors iff (renumberDOF == true)
+    * \see MechanicalObject::renumberValues
     */
     virtual void renumberPoints(const sofa::helper::vector< PointID >& index,
         const sofa::helper::vector< PointID >& inv_index,
@@ -150,22 +153,7 @@ public:
             const sofa::helper::vector< sofa::helper::vector< SReal > >& coefs,
             const bool moveDOF = true);
 
-    /** \brief Sends a message to warn that points are about to be reordered.
-    *
-    * \sa renumberPointsProcess
-    */
-    void renumberPointsWarning( const sofa::helper::vector< PointID > &index,
-            const sofa::helper::vector< PointID > &inv_index,
-            const bool renumberDOF = true);
 
-    /** \brief Reorder this topology.
-    *
-    * Important : the points are actually renumbered in the mechanical object's state vectors iff (renumberDOF == true)
-    * \see MechanicalObject::renumberValues
-    */
-    virtual void renumberPointsProcess( const sofa::helper::vector< PointID > &index,
-            const sofa::helper::vector< PointID > &/*inv_index*/,
-            const bool renumberDOF = true);
 
     /** \brief Called by a topology to warn specific topologies linked to it that TopologyChange objects happened.
     *
@@ -206,6 +194,25 @@ public:
     */
     void removeItems(const sofa::helper::vector<  PointID  >& /*items*/) override
     { }
+
+protected:
+    /** \brief Sends a message to warn that points are about to be reordered.
+    *
+    * \sa renumberPointsProcess
+    */
+    void renumberPointsWarning(const sofa::helper::vector< PointID >& index,
+        const sofa::helper::vector< PointID >& inv_index,
+        const bool renumberDOF = true);
+
+    /** \brief Reorder this topology.
+    *
+    * Important : the points are actually renumbered in the mechanical object's state vectors iff (renumberDOF == true)
+    * \see MechanicalObject::renumberValues
+    */
+    virtual void renumberPointsProcess(const sofa::helper::vector< PointID >& index,
+        const sofa::helper::vector< PointID >&/*inv_index*/,
+        const bool renumberDOF = true);
+
 
 private:
     PointSetTopologyContainer* 	m_container;

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/QuadSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/QuadSetTopologyModifier.cpp
@@ -491,14 +491,14 @@ void QuadSetTopologyModifier::removeItems(const sofa::helper::vector<QuadID> &it
 }
 
 void QuadSetTopologyModifier::renumberPoints( const sofa::helper::vector<PointID> &index,
-        const sofa::helper::vector<PointID> &inv_index)
+        const sofa::helper::vector<PointID> &inv_index, const bool renumberDOF)
 {
     /// add the topological changes in the queue
-    renumberPointsWarning(index, inv_index);
+    renumberPointsWarning(index, inv_index, renumberDOF);
     // inform other objects that the triangles are going to be removed
     propagateTopologicalChanges();
     // now renumber the points
-    renumberPointsProcess(index, inv_index);
+    renumberPointsProcess(index, inv_index, renumberDOF);
 
     m_container->checkTopology();
 }

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/QuadSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/QuadSetTopologyModifier.cpp
@@ -490,19 +490,6 @@ void QuadSetTopologyModifier::removeItems(const sofa::helper::vector<QuadID> &it
     removeQuads(items, true, true);
 }
 
-void QuadSetTopologyModifier::renumberPoints( const sofa::helper::vector<PointID> &index,
-        const sofa::helper::vector<PointID> &inv_index, const bool renumberDOF)
-{
-    /// add the topological changes in the queue
-    renumberPointsWarning(index, inv_index, renumberDOF);
-    // inform other objects that the triangles are going to be removed
-    propagateTopologicalChanges();
-    // now renumber the points
-    renumberPointsProcess(index, inv_index, renumberDOF);
-
-    m_container->checkTopology();
-}
-
 
 void QuadSetTopologyModifier::propagateTopologicalEngineChanges()
 {

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/QuadSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/QuadSetTopologyModifier.h
@@ -153,15 +153,6 @@ public:
     void removePointsProcess(const sofa::helper::vector<PointID> &indices,
             const bool removeDOF = true) override;
 
-    /** \brief Reorder this topology.
-    *
-    * Important : the points are actually renumbered in the mechanical object's state vectors iff (renumberDOF == true)
-    * \see MechanicalObject::renumberValues
-    */
-    void renumberPointsProcess( const sofa::helper::vector<PointID>& index,
-            const sofa::helper::vector<PointID>& inv_index,
-            const bool renumberDOF = true) override;
-
     /** \brief Remove a set  of quads
     @param quads an array of quad indices to be removed (note that the array is not const since it needs to be sorted)
     *
@@ -177,11 +168,15 @@ public:
     */
     void removeItems(const sofa::helper::vector< QuadID >& items) override;
 
-    /** \brief Generic method for points renumbering
+protected:
+    /** \brief Reorder this topology.
+    *
+    * Important : the points are actually renumbered in the mechanical object's state vectors iff (renumberDOF == true)
+    * \see MechanicalObject::renumberValues
     */
-    void renumberPoints( const sofa::helper::vector<PointID>& index,
-            const sofa::helper::vector<PointID>& inv_index, const bool renumberDOF = true) override;
-
+    void renumberPointsProcess(const sofa::helper::vector<PointID>& index,
+        const sofa::helper::vector<PointID>& inv_index,
+        const bool renumberDOF = true) override;
 
 private:
     QuadSetTopologyContainer* 	m_container;

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/QuadSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/QuadSetTopologyModifier.h
@@ -180,7 +180,7 @@ public:
     /** \brief Generic method for points renumbering
     */
     void renumberPoints( const sofa::helper::vector<PointID>& index,
-            const sofa::helper::vector<PointID>& inv_index) override;
+            const sofa::helper::vector<PointID>& inv_index, const bool renumberDOF = true) override;
 
 
 private:

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetTopologyModifier.cpp
@@ -630,20 +630,6 @@ void TetrahedronSetTopologyModifier::removeItems(const sofa::helper::vector< Tet
     removeTetrahedra(items);
 }
 
-void TetrahedronSetTopologyModifier::renumberPoints( const sofa::helper::vector<PointID> &index,
-        const sofa::helper::vector<PointID> &inv_index, const bool renumberDOF)
-{
-    /// add the topological changes in the queue
-    renumberPointsWarning(index, inv_index, renumberDOF);
-    // inform other objects that the triangles are going to be removed
-    propagateTopologicalChanges();
-    // now renumber the points
-    renumberPointsProcess(index, inv_index, renumberDOF);
-
-    m_container->checkTopology();
-}
-
-
 void TetrahedronSetTopologyModifier::propagateTopologicalEngineChanges()
 {
     if (m_container->beginChange() == m_container->endChange()) return; // nothing to do if no event is stored

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetTopologyModifier.cpp
@@ -631,14 +631,14 @@ void TetrahedronSetTopologyModifier::removeItems(const sofa::helper::vector< Tet
 }
 
 void TetrahedronSetTopologyModifier::renumberPoints( const sofa::helper::vector<PointID> &index,
-        const sofa::helper::vector<PointID> &inv_index)
+        const sofa::helper::vector<PointID> &inv_index, const bool renumberDOF)
 {
     /// add the topological changes in the queue
-    renumberPointsWarning(index, inv_index);
+    renumberPointsWarning(index, inv_index, renumberDOF);
     // inform other objects that the triangles are going to be removed
     propagateTopologicalChanges();
     // now renumber the points
-    renumberPointsProcess(index, inv_index);
+    renumberPointsProcess(index, inv_index, renumberDOF);
 
     m_container->checkTopology();
 }

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetTopologyModifier.h
@@ -179,15 +179,6 @@ public:
     */
     void removePointsProcess(const sofa::helper::vector<PointID> &indices, const bool removeDOF = true) override;
 
-    /** \brief Reorder this topology.
-    *
-    * Important : the points are actually renumbered in the mechanical object's state vectors iff (renumberDOF == true)
-    * \see MechanicalObject::renumberValues
-    */
-    void renumberPointsProcess( const sofa::helper::vector<PointID> &index,
-            const sofa::helper::vector<PointID> &/*inv_index*/,
-            const bool renumberDOF = true) override;
-
     /** \brief Remove a set  of tetrahedra
     @param tetrahedra an array of tetrahedron indices to be removed (note that the array is not const since it needs to be sorted)
     *
@@ -202,11 +193,15 @@ public:
     */
     void RemoveTetraBall(TetrahedronID ind_ta, TetrahedronID ind_tb);
 
-    /** \brief Generic method for points renumbering
+protected:
+    /** \brief Reorder this topology.
+    *
+    * Important : the points are actually renumbered in the mechanical object's state vectors iff (renumberDOF == true)
+    * \see MechanicalObject::renumberValues
     */
-    void renumberPoints( const sofa::helper::vector<PointID> &index,
-            const sofa::helper::vector<PointID> &inv_index, const bool renumberDOF = true) override;
-
+    void renumberPointsProcess(const sofa::helper::vector<PointID>& index,
+        const sofa::helper::vector<PointID>&/*inv_index*/,
+        const bool renumberDOF = true) override;
 
 private:
     TetrahedronSetTopologyContainer* 	m_container;

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetTopologyModifier.h
@@ -204,8 +204,8 @@ public:
 
     /** \brief Generic method for points renumbering
     */
-    void renumberPoints( const sofa::helper::vector<PointID> &/*index*/,
-            const sofa::helper::vector<PointID> &/*inv_index*/) override;
+    void renumberPoints( const sofa::helper::vector<PointID> &index,
+            const sofa::helper::vector<PointID> &inv_index, const bool renumberDOF = true) override;
 
 
 private:

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyModifier.cpp
@@ -590,15 +590,15 @@ void TriangleSetTopologyModifier::renumberPointsProcess( const sofa::helper::vec
 
 
 void TriangleSetTopologyModifier::renumberPoints( const sofa::helper::vector<PointID> &index,
-        const sofa::helper::vector<PointID> &inv_index)
+        const sofa::helper::vector<PointID> &inv_index, const bool renumberDOF)
 {
 
     /// add the topological changes in the queue
-    renumberPointsWarning(index, inv_index);
+    renumberPointsWarning(index, inv_index, renumberDOF);
     // inform other objects that the triangles are going to be removed
     propagateTopologicalChanges();
     // now renumber the points
-    renumberPointsProcess(index, inv_index);
+    renumberPointsProcess(index, inv_index, renumberDOF);
 
     m_container->checkTopology();
 }

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyModifier.cpp
@@ -587,24 +587,6 @@ void TriangleSetTopologyModifier::renumberPointsProcess( const sofa::helper::vec
 }
 
 
-
-
-void TriangleSetTopologyModifier::renumberPoints( const sofa::helper::vector<PointID> &index,
-        const sofa::helper::vector<PointID> &inv_index, const bool renumberDOF)
-{
-
-    /// add the topological changes in the queue
-    renumberPointsWarning(index, inv_index, renumberDOF);
-    // inform other objects that the triangles are going to be removed
-    propagateTopologicalChanges();
-    // now renumber the points
-    renumberPointsProcess(index, inv_index, renumberDOF);
-
-    m_container->checkTopology();
-}
-
-
-
 void TriangleSetTopologyModifier::addRemoveTriangles( const sofa::Size nTri2Add,
         const sofa::helper::vector< Triangle >& triangles2Add,
         const sofa::helper::vector< TriangleID >& trianglesIndex2Add,

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyModifier.h
@@ -238,7 +238,7 @@ public:
     /** \brief Generic method for points renumbering
      */
     void renumberPoints( const sofa::helper::vector<PointID> &index,
-            const sofa::helper::vector<PointID> &inv_index) override;
+            const sofa::helper::vector<PointID> &inv_index, const bool renumberDOF = true) override;
 
 
     /** \brief Move input points indices to input new coords.

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyModifier.h
@@ -225,22 +225,6 @@ public:
             const bool removeDOF = true) override;
 
 
-    /** \brief Reorder this topology.
-     *
-     * Important : the points are actually renumbered in the mechanical object's state vectors iff (renumberDOF == true)
-     * \see MechanicalObject::renumberValues
-     */
-    void renumberPointsProcess( const sofa::helper::vector<PointID> &index,
-            const sofa::helper::vector<PointID> &inv_index,
-            const bool renumberDOF = true) override;
-
-
-    /** \brief Generic method for points renumbering
-     */
-    void renumberPoints( const sofa::helper::vector<PointID> &index,
-            const sofa::helper::vector<PointID> &inv_index, const bool renumberDOF = true) override;
-
-
     /** \brief Move input points indices to input new coords.
      * Also propagate event and update edgesAroundVertex and trianglesAroundVertex for data handling.
      *
@@ -261,6 +245,14 @@ public:
     virtual int InciseAlongEdge(EdgeID edge, int* createdPoints = nullptr);
 
 protected:
+    /** \brief Reorder this topology.
+    *
+    * Important : the points are actually renumbered in the mechanical object's state vectors iff (renumberDOF == true)
+    * \see MechanicalObject::renumberValues
+    */
+    void renumberPointsProcess(const sofa::helper::vector<PointID>& index,
+        const sofa::helper::vector<PointID>& inv_index,
+        const bool renumberDOF = true) override;
 
     /** \brief Precondition to fulfill before removing triangles. No preconditions are needed in this class. This function should be inplemented in children classes.
      *

--- a/applications/plugins/ManifoldTopologies/ManifoldEdgeSetTopologyModifier.cpp
+++ b/applications/plugins/ManifoldTopologies/ManifoldEdgeSetTopologyModifier.cpp
@@ -86,19 +86,6 @@ void ManifoldEdgeSetTopologyModifier::removeItems(sofa::helper::vector< EdgeID >
     removeEdges(items);
 }
 
-void ManifoldEdgeSetTopologyModifier::renumberPoints( const sofa::helper::vector<Index> &index,
-        const sofa::helper::vector<Index> &inv_index)
-{
-    /// add the topological changes in the queue
-    renumberPointsWarning(index, inv_index);
-    // inform other objects that the triangles are going to be removed
-    propagateTopologicalChanges();
-    // now renumber the points
-    renumberPointsProcess(index, inv_index);
-
-    m_container->checkTopology();
-}
-
 void ManifoldEdgeSetTopologyModifier::addEdges(const sofa::helper::vector< Edge >& edges)
 {
     const size_t nEdges = m_container->getNumberOfEdges();

--- a/applications/plugins/ManifoldTopologies/ManifoldEdgeSetTopologyModifier.h
+++ b/applications/plugins/ManifoldTopologies/ManifoldEdgeSetTopologyModifier.h
@@ -94,11 +94,6 @@ public:
      */
     virtual void removeItems(/*const*/ sofa::helper::vector< EdgeID >& items);
 
-    /** \brief Generic method for points renumbering
-    */
-    virtual void renumberPoints( const sofa::helper::vector<Index> & index,
-            const sofa::helper::vector<Index> & inv_index) override;
-
     /** \brief add a set  of edges
     @param edges an array of pair of vertex indices describing the edge to be created
     *

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/Edge2QuadTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/Edge2QuadTopologicalMapping.cpp
@@ -493,10 +493,7 @@ void Edge2QuadTopologicalMapping::updateTopologicalMappingTopDown()
                     sofa::helper::vector<Index>& tab_indices = indices;
                     sofa::helper::vector<Index>& inv_tab_indices = inv_indices;
 
-                    to_tstm->renumberPointsWarning(tab_indices, inv_tab_indices, true);
-                    to_tstm->propagateTopologicalChanges();
-                    to_tstm->renumberPointsProcess(tab_indices, inv_tab_indices, true);
-
+                    to_tstm->renumberPoints(tab_indices, inv_tab_indices, true);
                     break;
                 }
 

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/Hexa2QuadTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/Hexa2QuadTopologicalMapping.cpp
@@ -393,9 +393,7 @@ void Hexa2QuadTopologicalMapping::updateTopologicalMappingTopDown()
             Topology::SetIndices & tab_indices = indices;
             Topology::SetIndices & inv_tab_indices = inv_indices;
 
-            to_tstm->renumberPointsWarning(tab_indices, inv_tab_indices, false);
-            to_tstm->propagateTopologicalChanges();
-            to_tstm->renumberPointsProcess(tab_indices, inv_tab_indices, false);
+            to_tstm->renumberPoints(tab_indices, inv_tab_indices, false);
 
             break;
         }

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/IdentityTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/IdentityTopologicalMapping.cpp
@@ -160,9 +160,7 @@ void IdentityTopologicalMapping::updateTopologicalMappingTopDown()
             const auto &tab = pRenumber->getIndexArray();
             const auto &inv_tab = pRenumber->getinv_IndexArray();
             dmsg_info() << "POINTSRENUMBERING : " << tab.size() ;
-            toPointMod->renumberPointsWarning(tab, inv_tab, true);
-            toPointMod->propagateTopologicalChanges();
-            toPointMod->renumberPointsProcess(tab, inv_tab, true);
+            toPointMod->renumberPoints(tab, inv_tab, true);
             break;
         }
 

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/Quad2TriangleTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/Quad2TriangleTopologicalMapping.cpp
@@ -411,10 +411,7 @@ void Quad2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
             Topology::SetIndices& tab_indices = indices;
             Topology::SetIndices& inv_tab_indices = inv_indices;
 
-            to_tstm->renumberPointsWarning(tab_indices, inv_tab_indices, false);
-            to_tstm->propagateTopologicalChanges();
-            to_tstm->renumberPointsProcess(tab_indices, inv_tab_indices, false);
-
+            to_tstm->renumberPoints(tab_indices, inv_tab_indices, false);
             break;
         }
 

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/SubsetTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/SubsetTopologicalMapping.cpp
@@ -621,9 +621,7 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
             if (samePoints.getValue())
             {
                 msg_info() << "[" << count << "]POINTSRENUMBERING : " << tab.size() << " : " << tab;
-                toPointMod->renumberPointsWarning(tab, inv_tab, true);
-                toPointMod->propagateTopologicalChanges();
-                toPointMod->renumberPointsProcess(tab, inv_tab, true);
+                toPointMod->renumberPoints(tab, inv_tab, true);
             }
             else
             {
@@ -641,9 +639,7 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
                     inv_tab2[pd2] = pd;
                 }
                 msg_info() << "[" << count << "]POINTSRENUMBERING : " << tab.size() << " -> " << tab2.size() << " : " << tab << " -> " << tab2;
-                toPointMod->renumberPointsWarning(tab2, inv_tab2, true);
-                toPointMod->propagateTopologicalChanges();
-                toPointMod->renumberPointsProcess(tab2, inv_tab2, true);
+                toPointMod->renumberPoints(tab2, inv_tab2, true);
                 SetIndex pS2D0 = pS2D.ref();
                 for (Index ps = 0; ps < pS2D.size(); ++ps)
                 {

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.cpp
@@ -489,10 +489,7 @@ void Tetra2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
             Topology::SetIndices & tab_indices = indices;
             Topology::SetIndices & inv_tab_indices = inv_indices;
 
-            m_outTopoModifier->renumberPointsWarning(tab_indices, inv_tab_indices, false);
-            m_outTopoModifier->propagateTopologicalChanges();
-            m_outTopoModifier->renumberPointsProcess(tab_indices, inv_tab_indices, false);
-
+            m_outTopoModifier->renumberPoints(tab_indices, inv_tab_indices, false);
             break;
         }
         default:

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/Triangle2EdgeTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/Triangle2EdgeTopologicalMapping.cpp
@@ -354,9 +354,7 @@ void Triangle2EdgeTopologicalMapping::updateTopologicalMappingTopDown()
             auto& tab_indices = indices;
             auto& inv_tab_indices = inv_indices;
 
-            m_outTopoModifier->renumberPointsWarning(tab_indices, inv_tab_indices, false);
-            m_outTopoModifier->propagateTopologicalChanges();
-            m_outTopoModifier->renumberPointsProcess(tab_indices, inv_tab_indices, false);
+            m_outTopoModifier->renumberPoints(tab_indices, inv_tab_indices, false);
             break;
         }
         /**


### PR DESCRIPTION
Only the method ```PointSetTopologyContainer::RenumberPoints``` should be used from outside.
This method makes sure to use the good mechanism of Warning, topology event propagation and process. 
Therefore, ```RenumberPointProcess``` and ```RenumberPointWarning``` **have been set to protected** and can only be overridden by child topology class.

Remove redundant RenumberPoints in other topology classes



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
