### PR TITLE
[All] Removes search & searchAll from BaseObject

### DIFF
--- a/SofaKernel/modules/Sofa.Config/src/sofa/config.h.in
+++ b/SofaKernel/modules/Sofa.Config/src/sofa/config.h.in
@@ -196,6 +196,11 @@ typedef unsigned __int64	uint64_t;
         "ExecParams are not needed anymore. " \
         "Remove the ExecParams argument from your call. ")
 
+#define SOFA_ATTRIBUTE_DISABLED__BASEOBJECT_SEARCH(msg) \
+    SOFA_ATTRIBUTE_DISABLED( \
+        "v20.06 (PR#1842)", "v21.06 (PR#1842)", \
+        "This function was removed as it duplicates a function that can be done using getContext()." msg)
+
 /**********************************************/
 
 #define SOFA_DECL_CLASS(name) // extern "C" { int sofa_concat(class_,name) = 0; }

--- a/SofaKernel/modules/Sofa.Config/src/sofa/config.h.in
+++ b/SofaKernel/modules/Sofa.Config/src/sofa/config.h.in
@@ -198,8 +198,8 @@ typedef unsigned __int64	uint64_t;
 
 #define SOFA_ATTRIBUTE_DISABLED__BASEOBJECT_SEARCH(msg) \
     SOFA_ATTRIBUTE_DISABLED( \
-        "v20.06 (PR#1842)", "v21.06 (PR#1842)", \
-        "This function was removed as it duplicates a function that can be done using getContext()." msg)
+        "v21.06 (PR#1842)", "v21.06 (PR#1842)", \
+        "This function was removed as it duplicates a function that can be done using getContext(). " msg)
 
 /**********************************************/
 
@@ -234,5 +234,4 @@ using Size = uint32_t;
 constexpr Index InvalidID = (std::numeric_limits<Index>::max)(); 
 
 }
-
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.h
@@ -135,250 +135,131 @@ public:
     virtual void removeSlave(BaseObject::SPtr s);
     /// @}
 
+
     /// @name Component accessors
     /// @{
 
-    /// Local search of an object of the given type
+    /// This function was removed as it duplicates the behavior that is already available by
+    /// using getContext()->get<T>(BaseContext::Local)
     template<class T>
-    typename T::SPtr searchLocal() const { const BaseContext* context = getContext(); return typename T::SPtr(context->get<T>(BaseContext::Local)); }
-    /// Upward search of an object of the given type, starting from the local context
-    template<class T>
-    typename T::SPtr searchUp() const { const BaseContext* context = getContext(); return typename T::SPtr(context->get<T>(BaseContext::SearchUp)); }
-    /// Downward search of an object of the given type, starting from the local context
-    template<class T>
-    typename T::SPtr searchDown() const { const BaseContext* context = getContext(); return typename T::SPtr(context->get<T>(BaseContext::SearchDown)); }
-    /// Search of an object of the given type, starting from the root
-    /// @todo or only in the root ?
-    template<class T>
-    typename T::SPtr searchFromRoot() const { const BaseContext* context = getContext(); return typename T::SPtr(context->get<T>(BaseContext::SearchRoot)); }
-    /// Search of an object of the given type, in the parents of the local context
-    /// @todo is this an upward search starting from each parent, or only a local search in each parent ?
-    template<class T>
-    typename T::SPtr searchInParents() const { const BaseContext* context = getContext(); return typename T::SPtr(context->get<T>(BaseContext::SearchParents)); }
+    SOFA_ATTRIBUTE_DISABLED__BASEOBJECT_SEARCH("Use getContext()->get<T>(BaseContext::Local) to update.")
+    typename T::SPtr searchLocal() const = delete;
 
-    /// Local search of all objects of the given type
+    /// This function was removed as it duplicates the behavior that is already available by
+    /// using getContext()->get<T>(BaseContext::SearchUp)
     template<class T>
-    helper::vector<typename T::SPtr> searchAllLocal() const
-    {
-        helper::vector<T*> v;
-        const BaseContext* context = getContext();
-        context->get<T>(&v,BaseContext::Local);
-        helper::vector<typename T::SPtr> vp;
-        for( unsigned i=0; i<v.size(); i++ )
-        {
-            vp.push_back(typename T::SPtr(v[i]));
-        }
-        return vp;
-    }
-    /// Upward search of all objects of the given type, starting from the local context
-    template<class T>
-    helper::vector<typename T::SPtr> searchAllUp() const
-    {
-        helper::vector<T*> v;
-        const BaseContext* context = getContext();
-        context->get<T>(&v,BaseContext::SearchUp);
-        helper::vector<typename T::SPtr> vp;
-        for( unsigned i=0; i<v.size(); i++ )
-        {
-            vp.push_back(typename T::SPtr(v[i]));
-        }
-        return vp;
-    }
-    /// Downward search of all objects of the given type, starting from the local context
-    template<class T>
-    helper::vector<typename T::SPtr> searchAllDown() const
-    {
-        helper::vector<T*> v;
-        const BaseContext* context = getContext();
-        context->get<T>(&v,BaseContext::SearchDown);
-        helper::vector<typename T::SPtr> vp;
-        for( unsigned i=0; i<v.size(); i++ )
-        {
-            vp.push_back(typename T::SPtr(v[i]));
-        }
-        return vp;
-    }
-    /// Search of all objects of the given type, starting from the root
-    template<class T>
-    helper::vector<typename T::SPtr> searchAllFromRoot() const
-    {
-        helper::vector<T*> v;
-        const BaseContext* context = getContext();
-        context->get<T>(&v,BaseContext::SearchRoot);
-        helper::vector<typename T::SPtr> vp;
-        for( unsigned i=0; i<v.size(); i++ )
-        {
-            vp.push_back(typename T::SPtr(v[i]));
-        }
-        return vp;
-    }
-    /// Search of all objects of the given type, in the parents of the local context
-    /// @todo is this an upward search starting from each parent, or only a local search in each parent ?
-    template<class T>
-    helper::vector<typename T::SPtr> searchAllInParents() const
-    {
-        helper::vector<T*> v;
-        const BaseContext* context = getContext();
-        context->get<T>(&v,BaseContext::SearchParents);
-        helper::vector<typename T::SPtr> vp;
-        for( unsigned i=0; i<v.size(); i++ )
-        {
-            vp.push_back(typename T::SPtr(v[i]));
-        }
-        return vp;
-    }
+    SOFA_ATTRIBUTE_DISABLED__BASEOBJECT_SEARCH("Use getContext()->get<T>(BaseContext::SearchUp) to update.")
+    typename T::SPtr searchUp() const = delete;
 
+    /// This function was removed as it duplicates the behavior that is already available by
+    /// using getContext()->get<T>(BaseContext::SearchDown)
+    template<class T>
+    SOFA_ATTRIBUTE_DISABLED__BASEOBJECT_SEARCH("Use getContext()->get<T>(BaseContext::SearchDown) to update.")
+    typename T::SPtr searchDown() const = delete;
 
+    /// This function was removed as it duplicates the behavior that is already available by
+    /// using getContext()->get<T>(BaseContext::SearchRoot)
+    template<class T>
+    SOFA_ATTRIBUTE_DISABLED__BASEOBJECT_SEARCH("Use getContext()->get<T>(BaseContext::SearchFromRoot) to update.")
+    typename T::SPtr searchFromRoot() const = delete;
 
-    /// Local search of all objects of the given type with a given Tag
+    /// This function was removed as it duplicates the behavior that is already available by
+    /// using getContext()->get<T>(BaseContext::SearchParents)
     template<class T>
-    helper::vector<typename T::SPtr> searchAllLocal(const Tag& t) const
-    {
-        helper::vector<T*> v;
-        const BaseContext* context = getContext();
-        context->get<T>(&v,t,BaseContext::Local);
-        helper::vector<typename T::SPtr> vp;
-        for( unsigned i=0; i<v.size(); i++ )
-        {
-            vp.push_back(typename T::SPtr(v[i]));
-        }
-        return vp;
-    }
-    /// Upward search of all objects of the given type with a given Tag, starting from the local context
-    template<class T>
-    helper::vector<typename T::SPtr> searchAllUp(const Tag& t) const
-    {
-        helper::vector<T*> v;
-        const BaseContext* context = getContext();
-        context->get<T>(&v,t,BaseContext::SearchUp);
-        helper::vector<typename T::SPtr> vp;
-        for( unsigned i=0; i<v.size(); i++ )
-        {
-            vp.push_back(typename T::SPtr(v[i]));
-        }
-        return vp;
-    }
-    /// Downward search of all objects of the given typee with a given Tag, starting from the local context
-    template<class T>
-    helper::vector<typename T::SPtr> searchAllDown(const Tag& t) const
-    {
-        helper::vector<T*> v;
-        const BaseContext* context = getContext();
-        context->get<T>(&v,t,BaseContext::SearchDown);
-        helper::vector<typename T::SPtr> vp;
-        for( unsigned i=0; i<v.size(); i++ )
-        {
-            vp.push_back(typename T::SPtr(v[i]));
-        }
-        return vp;
-    }
-    /// Search of all objects of the given typee with a given Tag, starting from the root
-    template<class T>
-    helper::vector<typename T::SPtr> searchAllFromRoot(const Tag& t) const
-    {
-        helper::vector<T*> v;
-        const BaseContext* context = getContext();
-        context->get<T>(&v,t,BaseContext::SearchRoot);
-        helper::vector<typename T::SPtr> vp;
-        for( unsigned i=0; i<v.size(); i++ )
-        {
-            vp.push_back(typename T::SPtr(v[i]));
-        }
-        return vp;
-    }
-    /// Search of all objects of the given typee with a given Tag, in the parents of the local context
-    /// @todo is this an upward search starting from each parent, or only a local search in each parent ?
-    template<class T>
-    helper::vector<typename T::SPtr> searchAllInParents(const Tag& t) const
-    {
-        helper::vector<T*> v;
-        const BaseContext* context = getContext();
-        context->get<T>(&v,t,BaseContext::SearchParents);
-        helper::vector<typename T::SPtr> vp;
-        for( unsigned i=0; i<v.size(); i++ )
-        {
-            vp.push_back(typename T::SPtr(v[i]));
-        }
-        return vp;
-    }
+    SOFA_ATTRIBUTE_DISABLED__BASEOBJECT_SEARCH("Use getContext()->get<T>(BaseContext::SearchParents) to update.")
+    typename T::SPtr searchInParents() const = delete;
 
+    /// This function was removed as it duplicates the behavior that is already available by
+    /// using getContext()->getObjects<T>(BaseContext::Local)
+    template<class T>
+    SOFA_ATTRIBUTE_DISABLED__BASEOBJECT_SEARCH("Use getContext()->get<T>(BaseContext::SearchLocal) to update.")
+    helper::vector<typename T::SPtr> searchAllLocal() const = delete;
 
+    /// This function was removed as it duplicates the behavior that is already available by
+    /// using getContext()->getObjects<T>(BaseContext::SearchUp)
+    template<class T>
+    SOFA_ATTRIBUTE_DISABLED__BASEOBJECT_SEARCH("Use getContext()->get<T>(BaseContext::SearchUp) to update.")
+    helper::vector<typename T::SPtr> searchAllUp() const = delete;
 
+    /// This function was removed as it duplicates the behavior that is already available by
+    /// using getContext()->getObjects<T>(BaseContext::SearchDown)
+    template<class T>
+    SOFA_ATTRIBUTE_DISABLED__BASEOBJECT_SEARCH("Use getContext()->get<T>(BaseContext::SearchDown) to update.")
+    helper::vector<typename T::SPtr> searchAllDown() const = delete;
 
-    /// Local search of all objects of the given type with a given TagSet
+    /// This function was removed as it duplicates the behavior that is already available by
+    /// using getContext()->getObjects<T>(BaseContext::SearchRoot)
     template<class T>
-    helper::vector<typename T::SPtr> searchAllLocal(const TagSet& t) const
-    {
-        helper::vector<T*> v;
-        const BaseContext* context = getContext();
-        context->get<T>(&v,t,BaseContext::Local);
-        helper::vector<typename T::SPtr> vp;
-        for( unsigned i=0; i<v.size(); i++ )
-        {
-            vp.push_back(typename T::SPtr(v[i]));
-        }
-        return vp;
-    }
-    /// Upward search of all objects of the given type with a given TagSet, starting from the local context
+    SOFA_ATTRIBUTE_DISABLED__BASEOBJECT_SEARCH("Use getContext()->get<T>(BaseContext::SearchRoot) to update.")
+    helper::vector<typename T::SPtr> searchAllFromRoot() const = delete;
+
+    /// This function was removed as it duplicates the behavior that is already available by
+    /// using getContext()->getObjects<T>(BaseContext::SearchParents)
     template<class T>
-    helper::vector<typename T::SPtr> searchAllUp(const TagSet& t) const
-    {
-        helper::vector<T*> v;
-        const BaseContext* context = getContext();
-        context->get<T>(&v,t,BaseContext::SearchUp);
-        helper::vector<typename T::SPtr> vp;
-        for( unsigned i=0; i<v.size(); i++ )
-        {
-            vp.push_back(typename T::SPtr(v[i]));
-        }
-        return vp;
-    }
-    /// Downward search of all objects of the given typee with a given TagSet, starting from the local context
+    SOFA_ATTRIBUTE_DISABLED__BASEOBJECT_SEARCH("Use getContext()->get<T>(BaseContext::SearchParents) to update.")
+    helper::vector<typename T::SPtr> searchAllInParents() const = delete;
+
+    /// This function was removed as it duplicates the behavior that is already available by
+    /// using getContext()->getObjects<T>(BaseContext::Local)
     template<class T>
-    helper::vector<typename T::SPtr> searchAllDown(const TagSet& t) const
-    {
-        helper::vector<T*> v;
-        const BaseContext* context = getContext();
-        context->get<T>(&v,t,BaseContext::SearchDown);
-        helper::vector<typename T::SPtr> vp;
-        for( unsigned i=0; i<v.size(); i++ )
-        {
-            vp.push_back(typename T::SPtr(v[i]));
-        }
-        return vp;
-    }
-    /// Search of all objects of the given typee with a given TagSet, starting from the root
+    SOFA_ATTRIBUTE_DISABLED__BASEOBJECT_SEARCH("Use getContext()->get<T>(BaseContext::SearchLocal) to update.")
+    helper::vector<typename T::SPtr> searchAllLocal(const Tag& t) const = delete;
+
+    /// This function was removed as it duplicates the behavior that is already available by
+    /// using getContext()->getObjects<T>(BaseContext::SearchUp)
     template<class T>
-    helper::vector<typename T::SPtr> searchAllFromRoot(const TagSet& t) const
-    {
-        helper::vector<T*> v;
-        const BaseContext* context = getContext();
-        context->get<T>(&v,t,BaseContext::SearchRoot);
-        helper::vector<typename T::SPtr> vp;
-        for( unsigned i=0; i<v.size(); i++ )
-        {
-            vp.push_back(typename T::SPtr(v[i]));
-        }
-        return vp;
-    }
-    /// Search of all objects of the given typee with a given TagSet, in the parents of the local context
-    /// @todo is this an upward search starting from each parent, or only a local search in each parent ?
+    SOFA_ATTRIBUTE_DISABLED__BASEOBJECT_SEARCH("Use getContext()->get<T>(BaseContext::SearchUp) to update.")
+    helper::vector<typename T::SPtr> searchAllUp(const Tag& t) const = delete;
+
+    /// This function was removed as it duplicates the behavior that is already available by
+    /// using getContext()->getObjects<T>(BaseContext::SearchDown)
     template<class T>
-    helper::vector<typename T::SPtr> searchAllInParents(const TagSet& t) const
-    {
-        helper::vector<T*> v;
-        const BaseContext* context = getContext();
-        context->get<T>(&v,t,BaseContext::SearchParents);
-        helper::vector<typename T::SPtr> vp;
-        for( unsigned i=0; i<v.size(); i++ )
-        {
-            vp.push_back(typename T::SPtr(v[i]));
-        }
-        return vp;
-    }
+    SOFA_ATTRIBUTE_DISABLED__BASEOBJECT_SEARCH("Use getContext()->get<T>(BaseContext::SearchDown) to update.")
+    helper::vector<typename T::SPtr> searchAllDown(const Tag& t) const = delete;
+
+    /// This function was removed as it duplicates the behavior that is already available by
+    /// using getContext()->getObjects<T>(BaseContext::SearchRoot)
+    template<class T>
+    SOFA_ATTRIBUTE_DISABLED__BASEOBJECT_SEARCH("Use getContext()->get<T>(BaseContext::SearchRoot) to update.")
+    helper::vector<typename T::SPtr> searchAllFromRoot(const Tag& t) const = delete;
+
+    /// This function was removed as it duplicates the behavior that is already available by
+    /// using getContext()->getObjects<T>(BaseContext::SearchParents)
+    template<class T>
+    SOFA_ATTRIBUTE_DISABLED__BASEOBJECT_SEARCH("Use getContext()->get<T>(BaseContext::SearchParents) to update.")
+    helper::vector<typename T::SPtr> searchAllInParents(const Tag& t) const = delete;
+
+    /// This function was removed as it duplicates the behavior that is already available by
+    /// using getContext()->getObjects<T>(BaseContext::Local)
+    template<class T>
+    SOFA_ATTRIBUTE_DISABLED__BASEOBJECT_SEARCH("Use getContext()->get<T>(BaseContext::Local) to update.")
+    helper::vector<typename T::SPtr> searchAllLocal(const TagSet& t) const = delete;
+
+    /// This function was removed as it duplicates the behavior that is already available by
+    /// using getContext()->getObjects<T>(BaseContext::SearchUp)
+    template<class T>
+    SOFA_ATTRIBUTE_DISABLED__BASEOBJECT_SEARCH("Use getContext()->get<T>(BaseContext::SearchUp) to update.")
+    helper::vector<typename T::SPtr> searchAllUp(const TagSet& t) const = delete;
+
+    /// This function was removed as it duplicates the behavior that is already available by
+    /// using getContext()->getObjects<T>(BaseContext::SearchDown)
+    template<class T>
+    SOFA_ATTRIBUTE_DISABLED__BASEOBJECT_SEARCH("Use getContext()->get<T>(BaseContext::SearchDown) to update.")
+    helper::vector<typename T::SPtr> searchAllDown(const TagSet& t) const = delete;
+
+    /// This function was removed as it duplicates the behavior that is already available by
+    /// using getContext()->getObjects<T>(BaseContext::SearchRoot)
+    template<class T>
+    SOFA_ATTRIBUTE_DISABLED__BASEOBJECT_SEARCH("Use getContext()->get<T>(BaseContext::SearchRoot) to update.")
+    helper::vector<typename T::SPtr> searchAllFromRoot(const TagSet& t) const = delete;
+
+    /// This function was removed as it duplicates the behavior that is already available by
+    /// using getContext()->getObjects<T>(BaseContext::SearchParents)
+    template<class T>
+    SOFA_ATTRIBUTE_DISABLED__BASEOBJECT_SEARCH("Use getContext()->get<T>(BaseContext::SearchParents) to update.")
+    helper::vector<typename T::SPtr> searchAllInParents(const TagSet& t) const = delete;
 
     /// @}
-
 
     /// @name data access
     ///   Access to external data

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Context.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Context.h
@@ -22,10 +22,8 @@
 #ifndef SOFA_CORE_OBJECTMODEL_CONTEXT_H
 #define SOFA_CORE_OBJECTMODEL_CONTEXT_H
 
-#include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/core/objectmodel/BaseContext.h>
-
-
+#include <sofa/core/objectmodel/BaseObject.h>
 
 namespace sofa
 {

--- a/applications/plugins/Compliant/Compliant_gui/CompliantAttachPerformer.inl
+++ b/applications/plugins/Compliant/Compliant_gui/CompliantAttachPerformer.inl
@@ -196,28 +196,18 @@ void CompliantAttachPerformer<DataTypes>::start()
         pickedParticleIndex = 0;
 
     //-------- Mouse manipulator
-    mouseMapping = this->interactor->core::objectmodel::BaseObject::template searchUp<sofa::core::BaseMapping>();
+    mouseMapping = this->interactor->getContext()->template get<sofa::core::BaseMapping>();
     this->mouseState = down_cast<Point3dState>(this->interactor->getMouseContainer());
-//    typename Point3dState::ReadVecCoord xmouse = mouseState->readPositions();
-//    typename Point3dState::Coord pointOnRay = mouseState->readPositions()[0];
-
-
 
     // set target point to closest point on the ray
     SReal distanceFromMouse=picked.rayLength;
     Ray ray = this->interactor->getMouseRayModel()->getRay(0);
     defaulttype::Vector3 pointOnRay = ray.origin() + ray.direction()*distanceFromMouse;
-//    ray.setOrigin(pointOnRay);
     this->interactor->setMouseAttached(true);
     this->interactor->setDistanceFromMouse(distanceFromMouse);
 
 
     initialMousePos = DataTypes::getCPos(mouseState->readPositions()[0]);
-
-//    cerr<<"CompliantAttachPerformer<DataTypes>::start() "<<mouseState->readPositions()[0]<<" "<<pointOnRay<< endl;
-
-//    mouseState->writePositions()[0] = pointOnRay;
-
     //---------- Set up the interaction
 
     // look for existing interactions

--- a/applications/plugins/Flexible/deformationMapping/TriangleStrainAverageMapping.inl
+++ b/applications/plugins/Flexible/deformationMapping/TriangleStrainAverageMapping.inl
@@ -61,7 +61,7 @@ TriangleStrainAverageMapping<TIn, TOut>::~TriangleStrainAverageMapping()
 template <class TIn, class TOut>
 void TriangleStrainAverageMapping<TIn, TOut>::init()
 {
-    triangleContainer = this->template searchUp<sofa::component::topology::TriangleSetTopologyContainer>();
+    triangleContainer = this->getContext()->template get<sofa::component::topology::TriangleSetTopologyContainer>();
 
     if( !triangleContainer )
         serr<<"No TriangleSetTopologyContainer found ! "<<sendl;

--- a/applications/plugins/image/ImageTypes.h
+++ b/applications/plugins/image/ImageTypes.h
@@ -291,7 +291,7 @@ public:
 
         for(unsigned int m=0; m<visualModels.size(); m++)
         {
-            sofa::component::visualmodel::VisualStyle::SPtr ptr = visualModels[m]->template searchUp<sofa::component::visualmodel::VisualStyle>();
+            sofa::component::visualmodel::VisualStyle::SPtr ptr = visualModels[m]->getContext()->template get<sofa::component::visualmodel::VisualStyle>();
             if (ptr && !ptr->displayFlags.getValue().getShowVisualModels()) continue;
 
             const sofa::helper::vector<VisualModelTypes::Coord>& verts= visualModels[m]->getVertices();

--- a/modules/SofaExporter/src/SofaExporter/BlenderExporter.inl
+++ b/modules/SofaExporter/src/SofaExporter/BlenderExporter.inl
@@ -49,7 +49,7 @@ namespace sofa
             template<class T>
             void BlenderExporter<T>::init()
             {
-                mmodel = Inherit::searchLocal<DataType>();
+                mmodel = getContext()->template get<DataType>(sofa::core::objectmodel::BaseContext::SearchDirection::Local);
                 if(mmodel == nullptr)
                     msg_error()<<"Initialization failed!";
                 Inherit::init();


### PR DESCRIPTION
These function allows to retrive other base object from the context and are actually duplicating a service that is already provided by BaseContext.

To refactor that there was two options.
(1) keep search & searchAll and remove the getContext() (to follow Demeter's rules)
(2) remove the search & searchAll and keep getContext() 

Given that accessing the context seems an important feature (used for much more) , decided to do solution (2). 

NB: There was more line of code in the implementation that the line of of code this functions saves. 
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
