### PR TITLE
[SofaCUDA] change the setTopology method signature

### DIFF
--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaBarycentricMapping.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaBarycentricMapping.h
@@ -131,7 +131,7 @@ public:
     Index addPointInCube(const Index cubeIndex, const SReal* baryCoords);
 
     bool isEmpty() { return map.size() == 0; }
-    void setTopology(topology::RegularGridTopology* _topology) { topology = _topology; }
+    void setTopology(topology::SparseGridTopology* _topology) { topology = _topology; }
 
     void init(const typename Out::VecCoord& out, const typename In::VecCoord& in);
     void apply( typename Out::VecCoord& out, const typename In::VecCoord& in );


### PR DESCRIPTION
I don't understand how such a function could have worked given that
SparseGrid & MeshGrid are not equivalent.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
