### PR TITLE
[SofaSimulationGraph] Remove dead-end experiment in SimpleApi.h

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/fake_TopologyScene.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/SofaBaseTopology_test/fake_TopologyScene.cpp
@@ -26,7 +26,6 @@
 #include "fake_TopologyScene.h"
 
 using namespace sofa::simpleapi;
-using namespace sofa::simpleapi::components;
 using namespace sofa::core::topology;
 
 fake_TopologyScene::fake_TopologyScene(const std::string& filename, TopologyElementType topoType, bool staticTopo)

--- a/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/SimpleApi_test.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/SofaSimulationGraph_test/SimpleApi_test.cpp
@@ -4,7 +4,6 @@ using sofa::helper::testing::BaseSimulationTest ;
 #include <SofaSimulationGraph/SimpleApi.h>
 using namespace sofa ;
 using namespace sofa::simpleapi ;
-using namespace sofa::simpleapi::components ;
 
 class SimpleApi_test : public BaseSimulationTest
 {
@@ -18,15 +17,15 @@ bool SimpleApi_test::testParamAPI()
     Simulation::SPtr simu = createSimulation("DAG") ;
     Node::SPtr root = createRootNode(simu, "root") ;
 
-    auto meca1 = createObject(root, MechanicalObject::objectname, {
-                     {MechanicalObject::data::name, "aMechanicalObject1"},
-                     {MechanicalObject::data::position, "1 2 3"}
+    auto meca1 = createObject(root, "MechanicalObject", {
+                     {"name", "aMechanicalObject1"},
+                     {"position", "1 2 3"}
                  });
 
 
-    auto meca2 = createObject(root, MechanicalObject::objectname, {
-                     {MechanicalObject::data::name, "aMechanicalObject2"},
-                     {MechanicalObject::data::position, "1 2 3"}
+    auto meca2 = createObject(root, "MechanicalObject", {
+                     {"name", "aMechanicalObject2"},
+                     {"position", "1 2 3"}
                  });
 
     EXPECT_EQ( (meca1->getName()), std::string("aMechanicalObject1") ) ;

--- a/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/SimpleApi.h
+++ b/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/SimpleApi.h
@@ -75,39 +75,3 @@ std::string str(const T& t)
     return s.str() ;
 }
 } // namespace sofa::simpleapi
-
-
-namespace sofa::simpleapi::components 
-{
-
-namespace BaseObject
-{
-    static const std::string aobjectname {"BaseObject"} ;
-    namespace data{
-        static const std::string name {"name"} ;
-    }
-}
-
-namespace MechanicalObject
-{
-    static const std::string objectname {"MechanicalObject"} ;
-    namespace data{
-        using namespace BaseObject::data ;
-        static const std::string position {"position"} ;
-    }
-}
-
-namespace VisualModel
-{
-    static const std::string objectname {"VisualModel"} ;
-
-    namespace data {
-        using namespace BaseObject::data ;
-        static const std::string filename {"filename"} ;
-    }
-}
-
-} // namespace sofa::simpleapi::components
-
-namespace sofa::meca   { using namespace sofa::simpleapi::components::MechanicalObject ; }
-namespace sofa::visual { using namespace sofa::simpleapi::components::VisualModel ; }

--- a/applications/plugins/SofaCarving/SofaCarving_test/SofaCarving_test.cpp
+++ b/applications/plugins/SofaCarving/SofaCarving_test/SofaCarving_test.cpp
@@ -31,8 +31,6 @@
 using namespace sofa::helper::testing;
 using namespace sofa::component::collision;
 using namespace sofa::simpleapi;
-using namespace sofa::simpleapi::components;
-
 
 class SofaCarving_test : public BaseSimulationTest
 {


### PR DESCRIPTION
The code removed in simpleapi was an experiment to avoid having to type "string" that shouldn't be merged. Given that no one use such a thin and how hard it would be to generalize the idea to the whole code base it is far better to remove it.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
