### PR TITLE
[SofaGuiQt] Clean QtGLViewer with key events

### DIFF
--- a/modules/SofaGuiQt/src/sofa/gui/qt/viewer/qgl/QtGLViewer.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/viewer/qgl/QtGLViewer.cpp
@@ -868,7 +868,6 @@ void QtGLViewer::keyPressEvent ( QKeyEvent * e )
         default:
         {
             SofaViewer::keyPressEvent(e);
-            QGLViewer::keyPressEvent(e);
         }
         }
     }


### PR DESCRIPTION
Minor fix of a line causing a double call to the keyPressEvent function



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
