### PR TITLE
[all] Move ScopedAdvancedTimer in its own files (.h & .cpp)

### DIFF
--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.cpp
@@ -24,7 +24,7 @@
 #include <SofaBaseCollision/CubeModel.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/visual/VisualParams.h>
-#include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 #include <queue>
 #include <stack>
 

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DefaultPipeline.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DefaultPipeline.cpp
@@ -34,8 +34,7 @@
 #include <sofa/simulation/Visitor.h>
 #endif
 
-#include <sofa/helper/AdvancedTimer.h>
-using sofa::helper::AdvancedTimer ;
+#include <sofa/helper/ScopedAdvancedTimer.h>
 using sofa::helper::ScopedAdvancedTimer ;
 
 

--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/CGLinearSolver.inl
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/CGLinearSolver.inl
@@ -22,8 +22,10 @@
 #pragma once
 #include <SofaBaseLinearSolver/CGLinearSolver.h>
 #include <sofa/simulation/MechanicalVisitor.h>
-#include <sofa/helper/AdvancedTimer.h>
 
+#include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
+using sofa::helper::ScopedAdvancedTimer ;
 
 namespace sofa::component::linearsolver
 {

--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
@@ -41,6 +41,8 @@
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/types/Material.h>
 
+#include <sofa/helper/ScopedAdvancedTimer.h>
+
 #include <sstream>
 #include <map>
 #include <memory>

--- a/SofaKernel/modules/SofaHelper/CMakeLists.txt
+++ b/SofaKernel/modules/SofaHelper/CMakeLists.txt
@@ -64,6 +64,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/RandomGenerator.h
     ${SRC_ROOT}/SVector.h
     ${SRC_ROOT}/SimpleTimer.h
+    ${SRC_ROOT}/ScopedAdvancedTimer.h
     ${SRC_ROOT}/SortedPermutation.h
     ${SRC_ROOT}/StringUtils.h
     ${SRC_ROOT}/TagFactory.h
@@ -164,6 +165,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/MarchingCubeUtility.cpp
     ${SRC_ROOT}/NameDecoder.cpp
     ${SRC_ROOT}/OptionsGroup.cpp
+    ${SRC_ROOT}/ScopedAdvancedTimer.cpp
     ${SRC_ROOT}/StateMask.cpp
     ${SRC_ROOT}/SVector.cpp
     ${SRC_ROOT}/Polynomial_LD.cpp

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.h
@@ -24,6 +24,7 @@
 #include <sofa/helper/system/thread/thread_specific_ptr.h>
 #include <sofa/helper/system/thread/CTime.h>
 #include <sofa/helper/vector.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 
 #include <ostream>
 #include <istream>
@@ -523,30 +524,6 @@ extern template class SOFA_HELPER_API AdvancedTimer::Id<AdvancedTimer::Step>;
 extern template class SOFA_HELPER_API AdvancedTimer::Id<AdvancedTimer::Obj>;
 extern template class SOFA_HELPER_API AdvancedTimer::Id<AdvancedTimer::Val>;
 #endif
-
-
-/// Scoped (RAII) AdvancedTimer to simplify a basic usage
-struct ScopedAdvancedTimer {
-
-    const char* message;
-
-    ScopedAdvancedTimer(const std::string& message)
-        : ScopedAdvancedTimer(message.c_str())
-    {
-
-    }
-
-    ScopedAdvancedTimer( const char* message )
-    : message( message )
-    {
-        AdvancedTimer::stepBegin( message );
-    }
-
-    ~ScopedAdvancedTimer()
-    {
-        AdvancedTimer::stepEnd( message );
-    }
-};
 
 }
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/ScopedAdvancedTimer.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/ScopedAdvancedTimer.cpp
@@ -1,0 +1,44 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/helper/ScopedAdvancedTimer.h>
+#include <sofa/helper/AdvancedTimer.h>
+
+namespace sofa::helper
+{
+
+ScopedAdvancedTimer::ScopedAdvancedTimer(const std::string& message)
+    : ScopedAdvancedTimer(message.c_str())
+{
+}
+
+ScopedAdvancedTimer::ScopedAdvancedTimer( const char* message )
+    : message( message )
+{
+    AdvancedTimer::stepBegin( message );
+}
+
+ScopedAdvancedTimer::~ScopedAdvancedTimer()
+{
+    AdvancedTimer::stepEnd( message );
+}
+
+} /// sofa::helper

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/ScopedAdvancedTimer.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/ScopedAdvancedTimer.h
@@ -21,13 +21,21 @@
 ******************************************************************************/
 #pragma once
 
+#include <sofa/helper/config.h>
 #include<string>
 
 namespace sofa::helper
 {
 
 /// Scoped (RAII) AdvancedTimer to simplify a basic usage
-struct ScopedAdvancedTimer
+/// Example of use
+/// {   ///< open a scope to start measuring
+///     ScopedAdvancedTimer t("myMeasurement")
+///     ...
+///     ...
+/// }   ///< close the scope... the timer t is destructed and the
+///     measurement recorded.
+struct SOFA_HELPER_API ScopedAdvancedTimer
 {
     const char* message;
     ScopedAdvancedTimer(const std::string& message);

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/ScopedAdvancedTimer.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/ScopedAdvancedTimer.h
@@ -1,0 +1,39 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include<string>
+
+namespace sofa::helper
+{
+
+/// Scoped (RAII) AdvancedTimer to simplify a basic usage
+struct ScopedAdvancedTimer
+{
+    const char* message;
+    ScopedAdvancedTimer(const std::string& message);
+    ScopedAdvancedTimer( const char* message );
+    ~ScopedAdvancedTimer();
+};
+
+} /// sofa::helper
+

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/CollisionAnimationLoop.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/CollisionAnimationLoop.cpp
@@ -36,7 +36,7 @@
 #include <sofa/simulation/UpdateBoundingBoxVisitor.h>
 #include <sofa/simulation/UpdateContextVisitor.h>
 #include <sofa/simulation/BehaviorUpdatePositionVisitor.h>
-#include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 
 #include <cstdlib>
 #include <cmath>

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DefaultAnimationLoop.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DefaultAnimationLoop.cpp
@@ -35,6 +35,7 @@
 #include <sofa/simulation/UpdateBoundingBoxVisitor.h>
 
 #include <sofa/helper/system/SetDirectory.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 #include <sofa/helper/AdvancedTimer.h>
 
 #include <sofa/core/visual/VisualParams.h>

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/UpdateBoundingBoxVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/UpdateBoundingBoxVisitor.cpp
@@ -23,7 +23,7 @@
 #include <sofa/helper/vector.h>
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/simulation/Node.h>
-#include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 
 namespace sofa
 {
@@ -49,7 +49,7 @@ Visitor::Result UpdateBoundingBoxVisitor::processNodeTopDown(Node* node)
         nodeBBox->invalidate();
     for ( object = objectList.begin(); object != objectList.end(); ++object)
     {
-        sofa::helper::AdvancedTimer::stepBegin("ComputeBBox: " + (*object)->getName());
+        sofa::helper::ScopedAdvancedTimer("ComputeBBox: " + (*object)->getName());
         // warning the second parameter should NOT be false
         // otherwise every object will participate to the bounding box
         // when it makes no sense for some of them
@@ -60,8 +60,6 @@ Visitor::Result UpdateBoundingBoxVisitor::processNodeTopDown(Node* node)
         (*object)->computeBBox(params, true);
 
         nodeBBox->include((*object)->f_bbox.getValue());
-
-        sofa::helper::AdvancedTimer::stepEnd("ComputeBBox: " + (*object)->getName());
     }
     node->f_bbox.endEdit();
     return RESULT_CONTINUE;

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/UpdateMappingVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/UpdateMappingVisitor.cpp
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #include <sofa/simulation/UpdateMappingVisitor.h>
 #include <sofa/core/VecId.h>
-#include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 #include <sofa/simulation/Node.h>
 
 namespace sofa

--- a/applications/plugins/Compliant/assembly/AssemblyHelper.h
+++ b/applications/plugins/Compliant/assembly/AssemblyHelper.h
@@ -1,5 +1,5 @@
 #include <SofaEigen2Solver/EigenSparseMatrix.h>
-#include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 #include <sofa/simulation/MechanicalVisitor.h>
 #include <sofa/simulation/Node.h>
 #include "../utils/sparse.h"

--- a/applications/plugins/Compliant/assembly/AssemblyVisitor.cpp
+++ b/applications/plugins/Compliant/assembly/AssemblyVisitor.cpp
@@ -1,5 +1,6 @@
 #include "AssemblyVisitor.h"
 
+#include <sofa/helper/ScopedAdvancedTimer.h>
 
 #include <SofaBaseLinearSolver/SingleMatrixAccessor.h>
 #include <SofaBaseLinearSolver/DefaultMultiMatrixAccessor.h>

--- a/applications/plugins/Compliant/misc/SimpleAnimationLoop.cpp
+++ b/applications/plugins/Compliant/misc/SimpleAnimationLoop.cpp
@@ -2,7 +2,7 @@
 
 
 #include <sofa/simulation/AnimateVisitor.h>
-#include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/simulation/PropagateEventVisitor.h>
 #include <sofa/simulation/AnimateBeginEvent.h>

--- a/applications/plugins/SofaCarving/CarvingManager.cpp
+++ b/applications/plugins/SofaCarving/CarvingManager.cpp
@@ -32,7 +32,7 @@
 
 #include <sofa/core/topology/TopologicalMapping.h>
 #include <SofaUserInteraction/TopologicalChangeManager.h>
-#include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 
 namespace sofa
 {

--- a/applications/plugins/SofaPython/PythonMainScriptController.cpp
+++ b/applications/plugins/SofaPython/PythonMainScriptController.cpp
@@ -24,7 +24,7 @@
 #include <sofa/core/ObjectFactory.h>
 using sofa::core::RegisterObject;
 
-#include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 using sofa::helper::ScopedAdvancedTimer;
 
 using sofa::core::visual::VisualParams;

--- a/modules/SofaConstraint/src/SofaConstraint/FreeMotionAnimationLoop.cpp
+++ b/modules/SofaConstraint/src/SofaConstraint/FreeMotionAnimationLoop.cpp
@@ -27,7 +27,7 @@
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/VecId.h>
 
-#include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 #include <sofa/simulation/UpdateInternalDataVisitor.h>
 #include <sofa/simulation/BehaviorUpdatePositionVisitor.h>
 #include <sofa/simulation/MechanicalOperations.h>


### PR DESCRIPTION
Currently it is still included in AdvancedTimer so this does not breaks too much external code. 




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
