### PR TITLE
[SofaSimpleFem] Fix TetrahedronFEMForceField Von Mises stress drawing

### DIFF
--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.h
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.h
@@ -163,6 +163,7 @@ protected:
     friend class TetrahedronFEMForceFieldInternalData<DataTypes>;
 
     Real m_restVolume;
+    sofa::helper::ColorMap* m_VonMisesColorMap;
 
 public:
     // get the volume of the mesh
@@ -212,7 +213,6 @@ public:
     Data<helper::vector<Real> > _vonMisesPerNode; ///< von Mises Stress per node
     Data<helper::vector<defaulttype::Vec4f> > _vonMisesStressColors; ///< Vector of colors describing the VonMises stress
     
-    helper::ColorMap m_VonMisesColorMap;
     Data<std::string> _showStressColorMap; ///< Color map used to show stress values
     Data<float> _showStressAlpha; ///< Alpha for vonMises visualisation
     Data<bool> _showVonMisesStressPerNode; ///< draw points  showing vonMises stress interpolated in nodes

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.h
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.h
@@ -195,7 +195,6 @@ public:
     Data< sofa::helper::OptionsGroup > _gatherPt; ///< use in GPU version
     Data< sofa::helper::OptionsGroup > _gatherBsize; ///< use in GPU version
     Data< bool > drawHeterogeneousTetra; ///< Draw Heterogeneous Tetra in different color
-    Data< bool > drawAsEdges; ///< Draw as edges instead of tetrahedra
 
     Real minYoung, maxYoung;
 

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.inl
@@ -1841,23 +1841,7 @@ void TetrahedronFEMForceField<DataTypes>::draw(const core::visual::VisualParams*
                 pd = (pd + center) * Real(0.6667);
             }
 
-            // create 4 triangles per tetrahedron
-            points.push_back(pa);
-            points.push_back(pb);
-            points.push_back(pc);
-
-            points.push_back(pb);
-            points.push_back(pc);
-            points.push_back(pd);
-
-            points.push_back(pc);
-            points.push_back(pd);
-            points.push_back(pa);
-
-            points.push_back(pd);
-            points.push_back(pa);
-            points.push_back(pb);
-            
+           
             // create corresponding colors
             sofa::helper::types::RGBAColor color[4];
             if(heterogeneous)
@@ -1890,15 +1874,18 @@ void TetrahedronFEMForceField<DataTypes>::draw(const core::visual::VisualParams*
                 }
             }
 
-            for (int tri = 0; tri < 4; ++tri)
-            { 
-                for (int vert = 0; vert < 3; ++vert)
-                {
-                    colorVector.push_back(color[tri]);
-                }
-            }
+            // create 4 triangles per tetrahedron with corresponding colors
+            points.insert(points.end(), { pa, pb, pc });
+            colorVector.insert(colorVector.end(), { color[0], color[0], color[0] });
 
-            
+            points.insert(points.end(), { pb, pc, pd });
+            colorVector.insert(colorVector.end(), { color[1], color[1], color[1] });
+
+            points.insert(points.end(), { pc, pd, pa });
+            colorVector.insert(colorVector.end(), { color[2], color[2], color[2] });
+
+            points.insert(points.end(), { pd, pa, pb });
+            colorVector.insert(colorVector.end(), { color[3], color[3], color[3] });
         }
 
         vparams->drawTool()->drawTriangles(points, colorVector);


### PR DESCRIPTION
- Fix the Von Mises stress drawing and use ColorMap Blue to Red by default.
- Factorize code for plain and wireframe drawing
- Fix crash when trying to display Von Mises stress per point without computing it. 

Fix #1852 

![Tetra2TriangleTopologicalMapping_00000004](https://user-images.githubusercontent.com/21199245/108897384-5574ad00-7616-11eb-979a-55e90c60a768.png)
![Tetra2TriangleTopologicalMapping_00000005](https://user-images.githubusercontent.com/21199245/108897396-573e7080-7616-11eb-8b3f-f40f559b186c.png)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
