### PR TITLE
[SofaBaseTopology] Remove public access to propagateTopologyChanges

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/EdgeSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/EdgeSetTopologyModifier.cpp
@@ -613,7 +613,7 @@ void EdgeSetTopologyModifier::splitEdgesProcess(sofa::helper::vector<EdgeID> &in
 }
 
 void EdgeSetTopologyModifier::removeEdges(const sofa::helper::vector< EdgeID >& edgeIds,
-        const bool removeIsolatedPoints, const bool resetTopoChange)
+        const bool removeIsolatedPoints)
 {
     sofa::helper::AdvancedTimer::stepBegin("removeEdges");
 
@@ -632,10 +632,8 @@ void EdgeSetTopologyModifier::removeEdges(const sofa::helper::vector< EdgeID >& 
 
     // inform other objects that the edges are going to be removed
     sofa::helper::AdvancedTimer::stepNext ("removeEdgesWarning", "propagateTopologicalChanges");
-    if (resetTopoChange)
-        propagateTopologicalChanges();
-    else
-        propagateTopologicalChangesWithoutReset();
+
+    propagateTopologicalChanges();
 
     // now destroy the old edges.
     sofa::helper::AdvancedTimer::stepNext ("propagateTopologicalChanges", "removeEdgesProcess");

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/EdgeSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/EdgeSetTopologyModifier.h
@@ -122,7 +122,7 @@ public:
     *
     */
     virtual void removeEdges(const sofa::helper::vector<EdgeID> &edgeIds,
-            const bool removeIsolatedPoints = true, const bool resetTopoChange = true);
+            const bool removeIsolatedPoints = true);
 
     /** \brief Generic method to remove a list of items.
     */

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/EdgeSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/EdgeSetTopologyModifier.h
@@ -57,9 +57,6 @@ protected:
 public:
     void init() override;
 
-    /// \brief function to propagate topological change events by parsing the list of topologyEngines linked to this topology.
-    void propagateTopologicalEngineChanges() override;
-
     /** \brief add a set of edges
     @param edges an array of pair of vertex indices describing the edge to be created
     *
@@ -299,6 +296,10 @@ protected:
     void renumberPointsProcess(const sofa::helper::vector<PointID>& index,
         const sofa::helper::vector<PointID>&/*inv_index*/,
         const bool renumberDOF = true) override;
+
+
+    /// \brief function to propagate topological change events by parsing the list of topologyEngines linked to this topology.
+    void propagateTopologicalEngineChanges() override;
 
 private:
     EdgeSetTopologyContainer* 	m_container;

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/HexahedronSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/HexahedronSetTopologyModifier.h
@@ -66,10 +66,6 @@ public:
 
     Data< bool > removeIsolated; ///< Controlled DOF index.
 
-    /// \brief function to propagate topological change events by parsing the list of topologyEngines linked to this topology.
-    void propagateTopologicalEngineChanges() override;
-
-
     /** \brief add a set of hexahedra
     @param hexahedra an array of vertex indices describing the hexahedra to be created
     */
@@ -202,6 +198,10 @@ protected:
     void renumberPointsProcess(const sofa::helper::vector<PointID>& index,
         const sofa::helper::vector<PointID>& inv_index,
         const bool renumberDOF = true) override;
+
+
+    /// \brief function to propagate topological change events by parsing the list of topologyEngines linked to this topology.
+    void propagateTopologicalEngineChanges() override;
 
 private:
     HexahedronSetTopologyContainer* 	m_container;

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyModifier.cpp
@@ -487,6 +487,8 @@ void PointSetTopologyModifier::notifyEndingEvent()
 {
     sofa::core::topology::EndingEvent *e=new sofa::core::topology::EndingEvent();
     m_container->addTopologyChange(e);
+
+    propagateTopologicalChanges();
 }
 
 } //namespace sofa::component::topology

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyModifier.cpp
@@ -445,19 +445,6 @@ void PointSetTopologyModifier::propagateTopologicalChanges()
     m_container->resetTopologyChangeList();
 }
 
-void PointSetTopologyModifier::propagateTopologicalChangesWithoutReset()
-{
-    if (m_container->beginChange() == m_container->endChange()) return; // nothing to do if no event is stored
-    sofa::core::ExecParams* params = sofa::core::execparams::defaultInstance();
-    sofa::simulation::TopologyChangeVisitor a(params, m_container);
-
-    getContext()->executeVisitor(&a);
-
-    //TODO: temporary code to test topology engine pipeline. Commented by default for the moment
-    //this->propagateTopologicalEngineChanges();
-
-}
-
 
 void PointSetTopologyModifier::propagateTopologicalEngineChanges()
 {

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyModifier.h
@@ -113,8 +113,8 @@ public:
     */
     void propagateTopologicalChanges() override;  // DEPRECATED
 
-    /// TODO: doc ??
-    void propagateTopologicalChangesWithoutReset();
+    /// This Method has been removed in PR #1860 as it was never used nor supported
+    void propagateTopologicalChangesWithoutReset() = delete;
 
     /// \brief function to propagate topological change events by parsing the list of topologyEngines linked to this topology.
     /// TODO: temporary duplication of topological events (commented by default)

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyModifier.h
@@ -102,23 +102,8 @@ public:
     virtual void removePoints(sofa::helper::vector< PointID >& indices, const bool removeDOF = true);
 
 
-    /** \brief Called by a topology to warn specific topologies linked to it that TopologyChange objects happened.
-    *
-    * ChangeList should contain all TopologyChange objects corresponding to changes in this topology
-    * that just happened (in the case of creation) or are about to happen (in the case of destruction) since
-    * last call to propagateTopologicalChanges.
-    *
-    * @sa beginChange()
-    * @sa endChange()
-    */
-    void propagateTopologicalChanges() override;  // DEPRECATED
-
     /// This Method has been removed in PR #1860 as it was never used nor supported
     void propagateTopologicalChangesWithoutReset() = delete;
-
-    /// \brief function to propagate topological change events by parsing the list of topologyEngines linked to this topology.
-    /// TODO: temporary duplication of topological events (commented by default)
-    virtual void propagateTopologicalEngineChanges();
 
 
     /** \brief Called by a topology to warn the Mechanical Object component that points have been added or will be removed.
@@ -226,6 +211,21 @@ protected:
         const sofa::helper::vector< PointID >&/*inv_index*/,
         const bool renumberDOF = true);
 
+
+    /** \brief Called by a topology to warn specific topologies linked to it that TopologyChange objects happened.
+    *
+    * ChangeList should contain all TopologyChange objects corresponding to changes in this topology
+    * that just happened (in the case of creation) or are about to happen (in the case of destruction) since
+    * last call to propagateTopologicalChanges.
+    *
+    * @sa beginChange()
+    * @sa endChange()
+    */
+    void propagateTopologicalChanges() override;  // DEPRECATED
+
+    /// \brief function to propagate topological change events by parsing the list of topologyEngines linked to this topology.
+    /// TODO: temporary duplication of topological events (commented by default)
+    virtual void propagateTopologicalEngineChanges();
 
 private:
     PointSetTopologyContainer* 	m_container;

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/QuadSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/QuadSetTopologyModifier.h
@@ -57,9 +57,6 @@ protected:
 public:
     void init() override;
 
-    /// \brief function to propagate topological change events by parsing the list of topologyEngines linked to this topology.
-    void propagateTopologicalEngineChanges() override;
-
     /** \brief add a set of quads
     @param quads an array of vertex indices describing the quads to be created
     */
@@ -183,6 +180,10 @@ protected:
     void renumberPointsProcess(const sofa::helper::vector<PointID>& index,
         const sofa::helper::vector<PointID>& inv_index,
         const bool renumberDOF = true) override;
+
+
+    /// \brief function to propagate topological change events by parsing the list of topologyEngines linked to this topology.
+    void propagateTopologicalEngineChanges() override;
 
 private:
     QuadSetTopologyContainer* 	m_container;

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetTopologyModifier.h
@@ -67,9 +67,6 @@ public:
 
     void reinit() override;
 
-    /// \brief function to propagate topological change events by parsing the list of topologyEngines linked to this topology.
-    void propagateTopologicalEngineChanges() override;
-
     /** \brief add a set of tetrahedra
     @param tetrahedra an array of vertex indices describing the tetrahedra to be created
     */
@@ -209,6 +206,10 @@ protected:
     void renumberPointsProcess(const sofa::helper::vector<PointID>& index,
         const sofa::helper::vector<PointID>&/*inv_index*/,
         const bool renumberDOF = true) override;
+
+
+    /// \brief function to propagate topological change events by parsing the list of topologyEngines linked to this topology.
+    void propagateTopologicalEngineChanges() override;
 
 private:
     TetrahedronSetTopologyContainer* 	m_container;

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyModifier.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyModifier.h
@@ -59,9 +59,6 @@ public:
 
     void reinit() override;
 
-    /// \brief function to propagate topological change events by parsing the list of topologyEngines linked to this topology.
-    void propagateTopologicalEngineChanges() override;
-
     /** \brief add a set of triangles
     @param triangles an array of vertex indices describing the triangles to be created
      * Test precondition and apply:
@@ -251,6 +248,11 @@ protected:
     void renumberPointsProcess(const sofa::helper::vector<PointID>& index,
         const sofa::helper::vector<PointID>& inv_index,
         const bool renumberDOF = true) override;
+
+
+    /// \brief function to propagate topological change events by parsing the list of topologyEngines linked to this topology.
+    void propagateTopologicalEngineChanges() override;
+
 
 
     /** \brief Precondition to fulfill before removing triangles. No preconditions are needed in this class. This function should be inplemented in children classes.

--- a/modules/SofaMiscTopology/src/SofaMiscTopology/TopologicalChangeProcessor.cpp
+++ b/modules/SofaMiscTopology/src/SofaMiscTopology/TopologicalChangeProcessor.cpp
@@ -1303,11 +1303,8 @@ void TopologicalChangeProcessor::inciseWithSavedIndices()
         ind_ta = ind_tb;
         firstCut=false;
 
-        triangleMod->propagateTopologicalChanges();
         // notify the end for the current sequence of topological change events
         triangleMod->notifyEndingEvent();
-
-        triangleMod->propagateTopologicalChanges();
 
         //update the triangle incision information
         updateTriangleIncisionInformation();

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/Edge2QuadTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/Edge2QuadTopologicalMapping.cpp
@@ -301,9 +301,7 @@ void Edge2QuadTopologicalMapping::updateTopologicalMappingTopDown()
 
                 case core::topology::ENDING_EVENT:
                 {
-                    to_tstm->propagateTopologicalChanges();
                     to_tstm->notifyEndingEvent();
-                    to_tstm->propagateTopologicalChanges();
                     break;
                 }
 

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/Edge2QuadTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/Edge2QuadTopologicalMapping.cpp
@@ -548,7 +548,6 @@ void Edge2QuadTopologicalMapping::updateTopologicalMappingTopDown()
                 ++itBegin;
             }
 
-            to_tstm->propagateTopologicalChanges();
             Loc2GlobDataVec.endEdit();
         }
     }

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/Hexa2QuadTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/Hexa2QuadTopologicalMapping.cpp
@@ -176,9 +176,7 @@ void Hexa2QuadTopologicalMapping::updateTopologicalMappingTopDown()
 
         case core::topology::ENDING_EVENT:
         {
-            to_tstm->propagateTopologicalChanges();
             to_tstm->notifyEndingEvent();
-            to_tstm->propagateTopologicalChanges();
             break;
         }
 

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/IdentityTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/IdentityTopologicalMapping.cpp
@@ -206,7 +206,6 @@ void IdentityTopologicalMapping::updateTopologicalMappingTopDown()
 
         ++itBegin;
     }
-    toPointMod->propagateTopologicalChanges();
 
     msg_info() << "End: "
                << "    Nb of points of fromModel : " << fromTriangleCon->getNbPoints() << msgendl

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/IdentityTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/IdentityTopologicalMapping.cpp
@@ -129,9 +129,7 @@ void IdentityTopologicalMapping::updateTopologicalMappingTopDown()
         case core::topology::ENDING_EVENT:
         {
             dmsg_info() << "ENDING_EVENT" ;
-            toPointMod->propagateTopologicalChanges();
             toPointMod->notifyEndingEvent();
-            toPointMod->propagateTopologicalChanges();
             break;
         }
 

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/Mesh2PointTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/Mesh2PointTopologicalMapping.cpp
@@ -596,7 +596,7 @@ void Mesh2PointTopologicalMapping::updateTopologicalMappingTopDown()
 
                 for (unsigned int i=0; i < tab.size(); i++)
                     addInputEdge(tab[i], toPointMod);
-                toPointMod->propagateTopologicalChanges();
+
                 if (copyEdges.getValue())
                 {
                     if (!toEdgeMod) toModel->getContext()->get(toEdgeMod, sofa::core::objectmodel::BaseContext::Local);
@@ -641,7 +641,7 @@ void Mesh2PointTopologicalMapping::updateTopologicalMappingTopDown()
 
                 for (unsigned int i=0; i < tab.size(); i++)
                     addInputTriangle(tab[i], toPointMod);
-                toPointMod->propagateTopologicalChanges();
+
                 if (copyTriangles.getValue())
                 {
                     if (!toTriangleMod) toModel->getContext()->get(toTriangleMod, sofa::core::objectmodel::BaseContext::Local);
@@ -704,7 +704,7 @@ void Mesh2PointTopologicalMapping::updateTopologicalMappingTopDown()
 
                 for (unsigned int i=0; i < tab.size(); i++)
                     addInputTetrahedron(tab[i], toPointMod);
-                toPointMod->propagateTopologicalChanges();
+
                 if (copyTetrahedra.getValue())
                 {
                     if (!toTetrahedronMod) toModel->getContext()->get(toTetrahedronMod, sofa::core::objectmodel::BaseContext::Local);
@@ -779,7 +779,6 @@ void Mesh2PointTopologicalMapping::updateTopologicalMappingTopDown()
                     toPointMod->removePoints(vitems);
 
                     toPointMod->notifyEndingEvent();
-                    toPointMod->propagateTopologicalChanges();
 
                     pointsToRemove.clear();
                 }

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/Quad2TriangleTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/Quad2TriangleTopologicalMapping.cpp
@@ -217,9 +217,7 @@ void Quad2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
 
         case core::topology::ENDING_EVENT:
         {
-            to_tstm->propagateTopologicalChanges();
             to_tstm->notifyEndingEvent();
-            to_tstm->propagateTopologicalChanges();
             break;
         }
 

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/Quad2TriangleTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/Quad2TriangleTopologicalMapping.cpp
@@ -423,7 +423,6 @@ void Quad2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
         sofa::helper::AdvancedTimer::stepEnd(topoChangeType);
         ++itBegin;
     }
-    to_tstm->propagateTopologicalChanges();
     Loc2GlobDataVec.endEdit();
 
     sofa::helper::AdvancedTimer::stepEnd("Update Quad2TriangleTopologicalMapping");

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/SimpleTesselatedTetraTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/SimpleTesselatedTetraTopologicalMapping.cpp
@@ -224,9 +224,7 @@ void SimpleTesselatedTetraTopologicalMapping::updateTopologicalMappingBottomUp()
 
                     tetrahedraToRemove.clear();
 
-                    from_tstm->propagateTopologicalChanges();
                     from_tstm->notifyEndingEvent();
-                    from_tstm->propagateTopologicalChanges();
                 }
 
                 break;

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/SubsetTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/SubsetTopologicalMapping.cpp
@@ -930,7 +930,6 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
         ++count;
         ++itBegin;
     }
-    toPointMod->propagateTopologicalChanges();
 }
 
 } //namespace sofa::component::topology

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/SubsetTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/SubsetTopologicalMapping.cpp
@@ -436,9 +436,7 @@ void SubsetTopologicalMapping::updateTopologicalMappingTopDown()
         case core::topology::ENDING_EVENT:
         {
             msg_info() << "[" << count << "]ENDING_EVENT";
-            toPointMod->propagateTopologicalChanges();
             toPointMod->notifyEndingEvent();
-            toPointMod->propagateTopologicalChanges();
             if (!samePoints.getValue())
             {
                 if (pS2D.size() != (unsigned)fromModel->getNbPoints()) msg_error() << "Invalid pointS2D size : " << pS2D.size() << " != " << fromModel->getNbPoints();

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.cpp
@@ -188,7 +188,6 @@ void Tetra2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
         case core::topology::ENDING_EVENT:
         {
             m_outTopoModifier->notifyEndingEvent();
-            m_outTopoModifier->propagateTopologicalChanges();
             break;
         }
 

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/Triangle2EdgeTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/Triangle2EdgeTopologicalMapping.cpp
@@ -163,7 +163,6 @@ void Triangle2EdgeTopologicalMapping::updateTopologicalMappingTopDown()
         case core::topology::ENDING_EVENT:
         {
             m_outTopoModifier->notifyEndingEvent();
-            m_outTopoModifier->propagateTopologicalChanges();
             break;
         }
         case core::topology::EDGESREMOVED:

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/TopologicalChangeManager.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/TopologicalChangeManager.cpp
@@ -584,9 +584,7 @@ bool TopologicalChangeManager::incisionTriangleModel(TriangleCollisionModel<sofa
             incision.indexPoint = end_points.back();
 
         // -- STEP 8: Propagating topological events.
-        triangleModifier->propagateTopologicalChanges();
         triangleModifier->notifyEndingEvent();
-        triangleModifier->propagateTopologicalChanges(); // needed?
 
         return true;
     }


### PR DESCRIPTION
This PR includes all the work of #1859 and finalized the lock down of the modifier API by removing public access to the propagateTopologyChanges method

- Remove deprecated method: propagateTopologicalChangesWithoutReset
- Turn propagateTopologyChanges  into protected (which will be deleted soon to use only engines)
- Turn propagateTopologicalEnginesChanges into protected




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
