### PR TITLE
[CMake] FIX header include tree

### DIFF
--- a/SofaKernel/SofaFramework/SofaFrameworkConfig.cmake.in
+++ b/SofaKernel/SofaFramework/SofaFrameworkConfig.cmake.in
@@ -30,6 +30,8 @@ if(SOFAHELPER_HAVE_GTEST)
     find_package(GTest CONFIG QUIET REQUIRED)
 endif()
 
+find_package(Sofa.Config QUIET REQUIRED)
+
 # Eigen3 is required by SofaDefaultType and SofaHelper
 find_package(Eigen3 QUIET REQUIRED)
 

--- a/SofaKernel/modules/Sofa.Config/CMakeLists.txt
+++ b/SofaKernel/modules/Sofa.Config/CMakeLists.txt
@@ -276,15 +276,16 @@ configure_file(cmake/CMakeParseLibraryList.cmake ${CMAKE_BINARY_DIR}/cmake/CMake
 install(FILES cmake/CMakeParseLibraryList.cmake DESTINATION lib/cmake/${PROJECT_NAME} COMPONENT headers)
 
 # SofaMacros*.cmake
-file(GLOB macro_files RELATIVE ${CMAKE_CURRENT_LIST_DIR}/cmake LIST_DIRECTORIES FALSE "SofaMacros*.cmake")
+set(macro_files SofaMacros.cmake SofaMacrosConfigure.cmake SofaMacrosInstall.cmake SofaMacrosPython.cmake SofaMacrosUtils.cmake)
 foreach(macro_file ${macro_files})
-    configure_file(${macro_file} ${CMAKE_BINARY_DIR}/cmake/${macro_file} COPYONLY)
-    install(FILES ${macro_file} DESTINATION lib/cmake/${PROJECT_NAME} COMPONENT headers)
+    configure_file(cmake/${macro_file} ${CMAKE_BINARY_DIR}/cmake/${macro_file} COPYONLY)
+    install(FILES cmake/${macro_file} DESTINATION lib/cmake/${PROJECT_NAME} COMPONENT headers)
 endforeach()
 
 # own include dir, the macro does not handle "independent" package for SofaFramework-style include 
 # i.e NOT the name of package first (sofa/ is wanted, instead of Sofa.Config/sofa)
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/${PROJECT_NAME}>")
+target_include_directories(${PROJECT_NAME} PUBLIC "$<INSTALL_INTERFACE:include/${PROJECT_NAME}/${PROJECT_NAME}>")
 
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}

--- a/SofaKernel/modules/Sofa.Config/CMakeLists.txt
+++ b/SofaKernel/modules/Sofa.Config/CMakeLists.txt
@@ -282,11 +282,6 @@ foreach(macro_file ${macro_files})
     install(FILES cmake/${macro_file} DESTINATION lib/cmake/${PROJECT_NAME} COMPONENT headers)
 endforeach()
 
-# own include dir, the macro does not handle "independent" package for SofaFramework-style include 
-# i.e NOT the name of package first (sofa/ is wanted, instead of Sofa.Config/sofa)
-target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/${PROJECT_NAME}>")
-target_include_directories(${PROJECT_NAME} PUBLIC "$<INSTALL_INTERFACE:include/${PROJECT_NAME}/${PROJECT_NAME}>")
-
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}
     PACKAGE_VERSION ${Sofa_VERSION}

--- a/SofaKernel/modules/Sofa.Config/cmake/SofaMacrosInstall.cmake
+++ b/SofaKernel/modules/Sofa.Config/cmake/SofaMacrosInstall.cmake
@@ -602,7 +602,8 @@ macro(sofa_install_targets_in_package)
                     if("${header_relative_dir_for_build}" STREQUAL "") # Headers are not in a subdirectory
                         set(header_relative_dir_for_build "${target}")
                     endif()
-                    if(NOT "${target}" STREQUAL "SofaFramework" AND
+                    if(NOT "${header_relative_dir_for_build}" MATCHES "^sofa$" AND
+                       NOT "${header_relative_dir_for_build}" MATCHES "^sofa/" AND
                        NOT "${ARG_INCLUDE_INSTALL_DIR}/${header_relative_dir_for_build}" MATCHES "${target}/${target}")
                         # Force include/PackageName/PackageName/... layout for package headers in build directory
                         set(header_relative_dir_for_build "${target}/${header_relative_dir_for_build}")

--- a/SofaKernel/modules/Sofa.Config/cmake/SofaMacrosInstall.cmake
+++ b/SofaKernel/modules/Sofa.Config/cmake/SofaMacrosInstall.cmake
@@ -202,7 +202,7 @@ macro(sofa_create_package)
         "${CMAKE_BINARY_DIR}/lib/cmake/${ARG_PACKAGE_NAME}Config.cmake"
         INSTALL_DESTINATION "lib/cmake/${package_install_dir}"
         )
-    install(FILES "${CMAKE_BINARY_DIR}/cmake/${ARG_PACKAGE_NAME}Config.cmake" DESTINATION "lib/cmake/${package_install_dir}" COMPONENT headers)
+    install(FILES "${CMAKE_BINARY_DIR}/lib/cmake/${ARG_PACKAGE_NAME}Config.cmake" DESTINATION "lib/cmake/${package_install_dir}" COMPONENT headers)
 
     if(ARG_RELOCATABLE)
         sofa_set_project_install_relocatable(${package_install_dir} ${CMAKE_CURRENT_BINARY_DIR} ${ARG_RELOCATABLE})

--- a/SofaKernel/modules/Sofa.GL/CMakeLists.txt
+++ b/SofaKernel/modules/Sofa.GL/CMakeLists.txt
@@ -80,11 +80,6 @@ else()
     message("OpenGL advanced functions (e.g shaders, FBO) are disabled.")
 endif()
 
-# own include dir, the macro does not handle "independent" package for SofaFramework-style include 
-# i.e NOT the name of package first (sofa/gl is wanted, instead of Sofa.GL/)
-target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/${PROJECT_NAME}>")
-target_include_directories(${PROJECT_NAME} PUBLIC "$<INSTALL_INTERFACE:include/${PROJECT_NAME}/${PROJECT_NAME}>")
-
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}
     PACKAGE_VERSION ${Sofa_VERSION}

--- a/SofaKernel/modules/Sofa.GL/CMakeLists.txt
+++ b/SofaKernel/modules/Sofa.GL/CMakeLists.txt
@@ -83,6 +83,7 @@ endif()
 # own include dir, the macro does not handle "independent" package for SofaFramework-style include 
 # i.e NOT the name of package first (sofa/gl is wanted, instead of Sofa.GL/)
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/${PROJECT_NAME}>")
+target_include_directories(${PROJECT_NAME} PUBLIC "$<INSTALL_INTERFACE:include/${PROJECT_NAME}/${PROJECT_NAME}>")
 
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}
@@ -90,7 +91,6 @@ sofa_create_package_with_targets(
     TARGETS ${PROJECT_NAME} AUTO_SET_TARGET_PROPERTIES
     INCLUDE_SOURCE_DIR "src"
     INCLUDE_INSTALL_DIR "${PROJECT_NAME}"
-    RELOCATABLE "plugins"
 )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER SofaFramework)

--- a/modules/SofaGuiCommon/CMakeLists.txt
+++ b/modules/SofaGuiCommon/CMakeLists.txt
@@ -46,9 +46,6 @@ set(SOURCE_FILES
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaBase SofaGraphComponent SofaUserInteraction SofaSimulationCommon)
 
-# This is required to be able to #include <sofa/gui/BaseGui.h> instead of #include <SofaGuiCommon/sofa/gui/BaseGui.h>
-target_include_directories(${PROJECT_NAME} PUBLIC "$<INSTALL_INTERFACE:include/${PROJECT_NAME}/${PROJECT_NAME}>")
-
 if(Sofa.GL_FOUND)
     target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.GL)
 endif()
@@ -65,7 +62,3 @@ sofa_create_package_with_targets(
     INCLUDE_SOURCE_DIR "src"
     INCLUDE_INSTALL_DIR ${PROJECT_NAME}
     )
-
-# sofa_create_package_with_targets add automatically PROJECT_NAME as include_dir
-# but SofaGui's code is like sofa/gui... so we need to forcefully add src/SofaGuiCommon
-target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/${PROJECT_NAME}>")


### PR DESCRIPTION
Multiple errors with the out-of-tree process for SOFA, especially after the Sofa.Config merge.
This PR should fix this, plus some issues with Sofa.GL being a relocatable "plugin" 🤔

Tested with SofaPython3 out-of-tree. (no CI test for that yet)

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
