### PR TITLE
[VolumetricRendering] Fix compilation due to removal of params

### DIFF
--- a/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglTetrahedralModel.inl
+++ b/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglTetrahedralModel.inl
@@ -342,7 +342,7 @@ void OglTetrahedralModel<DataTypes>::computeBBox(const core::ExecParams * params
             }
         }
 
-        this->f_bbox.setValue(params, sofa::defaulttype::TBoundingBox<SReal>(minBBox, maxBBox));
+        this->f_bbox.setValue(sofa::defaulttype::TBoundingBox<SReal>(minBBox, maxBBox));
     }
 }
 

--- a/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglVolumetricModel.cpp
+++ b/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglVolumetricModel.cpp
@@ -489,7 +489,7 @@ void OglVolumetricModel::computeBBox(const core::ExecParams * params, bool /* on
             if (maxBBox[1] < v[1]) maxBBox[1] = v[1];
             if (maxBBox[2] < v[2]) maxBBox[2] = v[2];
         }
-        this->f_bbox.setValue(params, sofa::defaulttype::TBoundingBox<SReal>(minBBox, maxBBox));
+        this->f_bbox.setValue(sofa::defaulttype::TBoundingBox<SReal>(minBBox, maxBBox));
     }
 }
 


### PR DESCRIPTION
Everything in the title : data.setValue(XXX) does not take params as parameter anymore



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
