### PR TITLE
[SofaCore] Use references in range loop with non trivial types in BaseObject

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.cpp
@@ -54,7 +54,7 @@ BaseObject::BaseObject()
 BaseObject::~BaseObject()
 {
     assert(l_master.get() == nullptr); // an object that is still a slave should not be able to be deleted, as at least one smart pointer points to it
-    for(auto slave : l_slaves)
+    for(auto& slave : l_slaves)
     {
         if (slave.get())
         {
@@ -69,7 +69,7 @@ void BaseObject::changeContextLink(BaseContext* before, BaseContext*& after)
 {
     if (!after) after = BaseContext::getDefault();
     if (before == after) return;
-    for (auto slave : l_slaves)
+    for (auto& slave : l_slaves)
     {
         if (slave.get())
         {


### PR DESCRIPTION
(because otherwise it is copying the data and generate a compilation warning)






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
