### PR TITLE
[SofaOpenCL] Remove use of deleted functions

### DIFF
--- a/applications/plugins/SofaOpenCL/OpenCLIdentityMapping.inl
+++ b/applications/plugins/SofaOpenCL/OpenCLIdentityMapping.inl
@@ -57,30 +57,27 @@ using namespace gpu::opencl;
 template <>
 void IdentityMapping<gpu::opencl::OpenCLVec3fTypes, gpu::opencl::OpenCLVec3fTypes>::apply( const core::MechanicalParams* mparams /* PARAMS FIRST */, OutDataVecCoord& dOut, const InDataVecCoord& dIn )
 {
-    OutVecCoord& out = *dOut.beginEdit(mparams);
-    const InVecCoord& in = dIn.getValue(mparams);
+    auto out = sofa::helper::getWriteOnlyAccessor(dOut).wref();
+    const InVecCoord& in = dIn.getValue();
     out.fastResize(in.size());
     gpu::opencl::MechanicalObjectOpenCLVec3f_vAssign(out.size(), out.deviceWrite(), in.deviceRead());
-    dOut.endEdit(mparams);
 }
 
 template <>
 void IdentityMapping<gpu::opencl::OpenCLVec3fTypes, gpu::opencl::OpenCLVec3fTypes>::applyJ( const core::MechanicalParams* mparams /* PARAMS FIRST */, OutDataVecDeriv& dOut, const InDataVecDeriv& dIn )
 {
-    OutVecDeriv& out = *dOut.beginEdit(mparams);
-    const InVecDeriv& in = dIn.getValue(mparams);
+    auto out = sofa::helper::getWriteOnlyAccessor(dOut).wref();
+    const InVecDeriv& in = dIn.getValue();
     out.fastResize(in.size());
     gpu::opencl::MechanicalObjectOpenCLVec3f_vAssign(out.size(), out.deviceWrite(), in.deviceRead());
-    dOut.endEdit(mparams);
 }
 
 template <>
 void IdentityMapping<gpu::opencl::OpenCLVec3fTypes, gpu::opencl::OpenCLVec3fTypes>::applyJT( const core::MechanicalParams* mparams /* PARAMS FIRST */, InDataVecDeriv& dOut, const OutDataVecDeriv& dIn )
 {
-    InVecDeriv& out = *dOut.beginEdit(mparams);
-    const OutVecDeriv& in = dIn.getValue(mparams);
+    auto out = sofa::helper::getWriteOnlyAccessor(dOut).wref();
+    const OutVecDeriv& in = dIn.getValue();
     gpu::opencl::MechanicalObjectOpenCLVec3f_vPEq(out.size(), out.deviceWrite(), in.deviceRead());
-    dOut.endEdit(mparams);
 }
 
 
@@ -89,30 +86,27 @@ void IdentityMapping<gpu::opencl::OpenCLVec3fTypes, gpu::opencl::OpenCLVec3fType
 template <>
 void IdentityMapping<gpu::opencl::OpenCLVec3f1Types, gpu::opencl::OpenCLVec3f1Types>::apply( const core::MechanicalParams* mparams /* PARAMS FIRST */, OutDataVecCoord& dOut, const InDataVecCoord& dIn )
 {
-    OutVecCoord& out = *dOut.beginEdit(mparams);
-    const InVecCoord& in = dIn.getValue(mparams);
+    auto out = sofa::helper::getWriteOnlyAccessor(dOut).wref();
+    const InVecCoord& in = dIn.getValue();
     out.fastResize(in.size());
     gpu::opencl::MechanicalObjectOpenCLVec3f1_vAssign(out.size(), out.deviceWrite(), in.deviceRead());
-    dOut.endEdit(mparams);
 }
 
 template <>
 void IdentityMapping<gpu::opencl::OpenCLVec3f1Types, gpu::opencl::OpenCLVec3f1Types>::applyJ( const core::MechanicalParams* mparams /* PARAMS FIRST */, OutDataVecDeriv& dOut, const InDataVecDeriv& dIn )
 {
-    OutVecDeriv& out = *dOut.beginEdit(mparams);
-    const InVecDeriv& in = dIn.getValue(mparams);
+    auto out = sofa::helper::getWriteOnlyAccessor(dOut).wref();
+    const InVecDeriv& in = dIn.getValue();
     out.fastResize(in.size());
     gpu::opencl::MechanicalObjectOpenCLVec3f1_vAssign(out.size(), out.deviceWrite(), in.deviceRead());
-    dOut.endEdit(mparams);
 }
 
 template <>
 void IdentityMapping<gpu::opencl::OpenCLVec3f1Types, gpu::opencl::OpenCLVec3f1Types>::applyJT( const core::MechanicalParams* mparams /* PARAMS FIRST */, InDataVecDeriv& dOut, const OutDataVecDeriv& dIn )
 {
-    InVecDeriv& out = *dOut.beginEdit(mparams);
-    const OutVecDeriv& in = dIn.getValue(mparams);
+    auto out = sofa::helper::getWriteOnlyAccessor(dOut).wref();
+    const OutVecDeriv& in = dIn.getValue();
     gpu::opencl::MechanicalObjectOpenCLVec3f1_vPEq(out.size(), out.deviceWrite(), in.deviceRead());
-    dOut.endEdit(mparams);
 }
 
 } // namespace mapping

--- a/applications/plugins/SofaOpenCL/OpenCLTypes.h
+++ b/applications/plugins/SofaOpenCL/OpenCLTypes.h
@@ -22,7 +22,7 @@
 #ifndef SOFAOPENCL_OPENCLTYPES_H
 #define SOFAOPENCL_OPENCLTYPES_H
 
-#include <sofa/helper/system/gl.h>
+#include <sofa/gl/gl.h>
 #include <sofa/defaulttype/Vec.h>
 #include <sofa/helper/vector.h>
 #include <sofa/helper/accessor.h>


### PR DESCRIPTION
This PR follows latest changes from master and using accessor instead of begin/endEdit()

SofaOpenCL is not activated by default (either in Sofa or the CI). so compilation and tests are not relevant here.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
