### PR TITLE
[Demo] Use exception for matrix inversion

### DIFF
--- a/SofaKernel/modules/Sofa.Type/Sofa.TypeConfig.cmake.in
+++ b/SofaKernel/modules/Sofa.Type/Sofa.TypeConfig.cmake.in
@@ -3,6 +3,8 @@
 @PACKAGE_GUARD@
 @PACKAGE_INIT@
 
+find_package(Sofa.Config QUIET REQUIRED)
+
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 endif()

--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/Mat.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/Mat.h
@@ -29,6 +29,7 @@
 
 #include <iostream>
 #include <stdexcept>
+#include <string>
 
 namespace // anonymous
 {

--- a/SofaKernel/modules/SofaDefaultType/SofaDefaultType_test/MatTypes_test.cpp
+++ b/SofaKernel/modules/SofaDefaultType/SofaDefaultType_test/MatTypes_test.cpp
@@ -35,7 +35,7 @@ using namespace sofa::defaulttype;
 void test_transformInverse(Matrix4 const& M)
 {
     Matrix4 M_inv;
-    M_inv.transformInvert(M);
+    EXPECT_NO_THROW(M_inv.transformInvert(M));
     Matrix4 res = M*M_inv;
     Matrix4 I;I.identity();
     EXPECT_MAT_NEAR(I, res, (SReal)1e-12);
@@ -43,10 +43,10 @@ void test_transformInverse(Matrix4 const& M)
 
 TEST(MatTypesTest, transformInverse)
 {
-    test_transformInverse(Matrix4::s_identity);
-    test_transformInverse(Matrix4::transformTranslation(Vector3(1.,2.,3.)));
-    test_transformInverse(Matrix4::transformScale(Vector3(1.,2.,3.)));
-    test_transformInverse(Matrix4::transformRotation(Quat::fromEuler(M_PI_4,M_PI_2,M_PI/3.)));
+    EXPECT_NO_THROW(test_transformInverse(Matrix4::s_identity));
+    EXPECT_NO_THROW(test_transformInverse(Matrix4::transformTranslation(Vector3(1.,2.,3.))));
+    EXPECT_NO_THROW(test_transformInverse(Matrix4::transformScale(Vector3(1.,2.,3.))));
+    EXPECT_NO_THROW(test_transformInverse(Matrix4::transformRotation(Quat::fromEuler(M_PI_4,M_PI_2,M_PI/3.))));
 }
 
 TEST(MatTypesTest, setsub_vec)
@@ -117,14 +117,19 @@ TEST(MatTypesTest, invert)
     Matrix2 Mtest(Matrix2::Line(0.6,-0.7),
                   Matrix2::Line(-0.2,0.4));
 
-    defaulttype::invertMatrix(Minv, M);
+    EXPECT_NO_THROW(defaulttype::invertMatrix(Minv, M));
     EXPECT_EQ(Minv, Mtest);
 
     EXPECT_EQ(M.inverted(), Mtest);
 
-    Minv.invert(M);
+    EXPECT_NO_THROW(Minv.invert(M));
     EXPECT_EQ(Minv, Mtest);
 
-    M.invert(M);
+    EXPECT_NO_THROW(M.invert(M));
     EXPECT_EQ(M, Mtest);
+
+    // non invertibility test
+    Matrix2 M2noninv(Matrix2::Line(0, 0), Matrix2::Line(0,0));
+    EXPECT_ANY_THROW(sofa::type::invertMatrix(Minv, M2noninv)); // expect any exception
+    EXPECT_THROW(sofa::type::invertMatrix(Minv, M2noninv), std::logic_error); // expect this exact exception type
 }

--- a/SofaKernel/modules/SofaDefaultType/compat/sofa/defaulttype/Mat.h
+++ b/SofaKernel/modules/SofaDefaultType/compat/sofa/defaulttype/Mat.h
@@ -115,40 +115,61 @@ inline Vec<N, real> diagonal(const Mat<N, N, real>& m)
 template<sofa::Size S, class real>
 bool invertMatrix(Mat<S, S, real>& dest, const Mat<S, S, real>& from)
 {
-    auto res = type::invertMatrix(dest, from);
-    if(!res)
+    try
     {
-        msg_error("Mat") << "invertMatrix (general case) finds too small determinant for matrix = " << from;
+        type::invertMatrix(dest, from);
     }
-    return res;
+    catch(std::logic_error e)
+    {
+        msg_error("Mat") << e.what() << "(matrix was " << from << ")";
+        return false;
+    }
+    return true;
 }
 
 template<class real>
 bool invertMatrix(Mat<3, 3, real>& dest, const Mat<3, 3, real>& from)
 {
-    auto res = type::invertMatrix(dest, from);
-    if (!res)
+    try
     {
-        msg_error("Mat") << "invertMatrix (special case 3x3) finds too small determinant for matrix = " << from;
+        type::invertMatrix(dest, from);
     }
-    return res;
+    catch (std::logic_error e)
+    {
+        msg_error("Mat") << e.what() << "(3x3 matrix was " << from << ")";
+        return false;
+    }
+    return true;
 }
 
 template<class real>
 bool invertMatrix(Mat<2, 2, real>& dest, const Mat<2, 2, real>& from)
 {
-    auto res = type::invertMatrix(dest, from);
-    if (!res)
+    try
     {
-        msg_error("Mat") << "invertMatrix (general case) finds too small determinant for matrix = " << from;
+        type::invertMatrix(dest, from);
     }
-    return res;
+    catch (std::logic_error e)
+    {
+        msg_error("Mat") << e.what() << "(2x2 matrix was " << from << ")";
+        return false;
+    }
+    return true;
 }
 
 template<sofa::Size S, class real>
 bool transformInvertMatrix(Mat<S, S, real>& dest, const Mat<S, S, real>& from)
 {
-    return type::transformInvertMatrix(dest, from);
+    try
+    {
+        type::transformInvertMatrix(dest, from);
+    }
+    catch (std::logic_error e)
+    {
+        msg_error("Mat") << e.what() << "(matrix was " << from << ")";
+        return false;
+    }
+    return true;
 }
 
 template <sofa::Size L, sofa::Size C, typename real>

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.inl
@@ -1593,7 +1593,15 @@ inline void TetrahedronFEMForceField<DataTypes>::reinit()
                     matVert[k][l] = X0[ix][l-1];
             }
 
-            defaulttype::invertMatrix(elemShapeFun[i], matVert);
+            try 
+            {
+                defaulttype::invertMatrix(elemShapeFun[i], matVert);
+            }
+            catch (std::logic_error e)
+            {
+                msg_error() << "Cannot compute vonMisses for  element " << (*it) << " because "
+                            << e.what();
+            }
         }
         computeVonMisesStress();
     }

--- a/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/MeshDiscreteIntersection.cpp
+++ b/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/MeshDiscreteIntersection.cpp
@@ -75,8 +75,17 @@ int MeshDiscreteIntersection::computeIntersection(Triangle& e1, Line& e2, Output
         M[i][2] = -PQ[i];
         right[i] = P[i]-A[i];
     }
-    if (!Minv.invert(M))
+
+    try
+    {
+        Minv.invert(M);
+    }
+    catch (std::logic_error e)
+    {
+        msg_error("MeshDiscreteIntersection") << e.what() << " ; aborting computeIntersection";
         return 0;
+    }
+
     Vector3 baryCoords = Minv * right;
     if (baryCoords[0] < 0 || baryCoords[1] < 0 || baryCoords[0]+baryCoords[1] > 1)
         return 0; // out of the triangle

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/RayDiscreteIntersection.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/RayDiscreteIntersection.cpp
@@ -82,8 +82,15 @@ int RayDiscreteIntersection::computeIntersection(Ray& e1, Triangle& e2, OutputVe
         M[i][2] = -PQ[i];
         right[i] = P[i]-A[i];
     }
-    if (!Minv.invert(M))
+    try
+    {
+        Minv.invert(M);
+    }
+    catch (std::logic_error e)
+    {
+        msg_error("RayDiscreteIntersection") << e.what() << " ; aborting computeIntersection";
         return 0;
+    }
     Vector3 baryCoords = Minv * right;
     if (baryCoords[0] < 0 || baryCoords[1] < 0 || baryCoords[0]+baryCoords[1] > 1)
         return 0; // out of the triangle


### PR DESCRIPTION
Showcase, not supposed to be merged as it is.
(prone to discussion at sofameetings)

This PR is a prototype on how exception would be used with the example of the matrix functions invert()

(Issue #1924 )

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
