### PR TITLE
[SofaGuiQt] Fix compilation

### DIFF
--- a/modules/SofaGuiQt/CMakeLists.txt
+++ b/modules/SofaGuiQt/CMakeLists.txt
@@ -14,11 +14,11 @@ if(${CMAKE_VERSION} VERSION_GREATER "3.16.0")
 endif()
 find_package(Qt5 COMPONENTS Core QUIET)
 
-if (Qt5_FOUND)
+if (Qt5Core_FOUND)
     message("SofaGuiQt: will use Qt5")
     sofa_find_package(Qt5 COMPONENTS Core Gui OpenGL REQUIRED)
     set(QT_TARGETS ${QT_TARGETS} Qt5::Core Qt5::Gui Qt5::OpenGL)
-elseif (Qt6_FOUND)
+elseif (Qt6Core_FOUND)
     message("SofaGuiQt: will use Qt6 (beta)")
     sofa_find_package(Qt6 COMPONENTS Widgets OpenGLWidgets REQUIRED)
     set(QT_TARGETS ${QT_TARGETS} Qt::Core Qt::Gui Qt::Widgets Qt::OpenGLWidgets )
@@ -26,7 +26,7 @@ else()
     message(SEND_ERROR "SofaGuiQt: Could not find either Qt5 or Qt6.")
 endif()
 
-if (Qt5_FOUND)
+if (Qt5Core_FOUND)
     # Profiling
     sofa_find_package(Qt5 COMPONENTS Charts QUIET BOTH_SCOPES)
     if(Qt5Charts_FOUND)
@@ -42,10 +42,7 @@ if (Qt5_FOUND)
         sofa_find_package(Qt5 COMPONENTS WebEngine WebEngineWidgets REQUIRED BOTH_SCOPES)
         set(QT_TARGETS ${QT_TARGETS} Qt5::WebEngine Qt5::WebEngineWidgets)
     endif()
-
-    # Previous optional Qt5 find_package() can reset the variable Qt5_FOUND
-    set(Qt5_FOUND 1)
-elseif (Qt6_FOUND)
+elseif (Qt6Core_FOUND)
     # https://doc-snapshots.qt.io/qt6-dev/whatsnew60.html
     # Charts and WebEngine have been removed from Qt6 and may be reintroduced later
 
@@ -304,10 +301,10 @@ if (SOFAGUIQT_ENABLE_NODEGRAPH)
         )
 endif()
 
-if (Qt5_FOUND)
+if (Qt5Core_FOUND)
     qt5_wrap_cpp(MOC_FILES ${MOC_HEADER_FILES})
     qt5_wrap_ui(FORM_FILES ${UI_FILES})
-elseif (Qt6_FOUND)
+elseif (Qt6Core_FOUND)
     qt6_wrap_cpp(MOC_FILES ${MOC_HEADER_FILES})
     qt6_wrap_ui(FORM_FILES ${UI_FILES})
 endif()

--- a/modules/SofaGuiQt/CMakeLists.txt
+++ b/modules/SofaGuiQt/CMakeLists.txt
@@ -42,6 +42,9 @@ if (Qt5_FOUND)
         sofa_find_package(Qt5 COMPONENTS WebEngine WebEngineWidgets REQUIRED BOTH_SCOPES)
         set(QT_TARGETS ${QT_TARGETS} Qt5::WebEngine Qt5::WebEngineWidgets)
     endif()
+
+    # Previous optional Qt5 find_package() can reset the variable Qt5_FOUND
+    set(Qt5_FOUND 1)
 elseif (Qt6_FOUND)
     # https://doc-snapshots.qt.io/qt6-dev/whatsnew60.html
     # Charts and WebEngine have been removed from Qt6 and may be reintroduced later

--- a/modules/SofaGuiQt/libQGLViewer-2.7.1/QGLViewer/CMakeLists.txt
+++ b/modules/SofaGuiQt/libQGLViewer-2.7.1/QGLViewer/CMakeLists.txt
@@ -74,10 +74,10 @@ set(UI_FILES
     VRenderInterface.ui
     )
 
-if (Qt5_FOUND)
+if (Qt5Core_FOUND)
     qt5_wrap_cpp(MOC_FILES ${MOC_HEADER_FILES})
     qt5_wrap_ui(FORM_FILES ${UI_FILES})
-elseif (Qt6_FOUND)
+elseif (Qt6Core_FOUND)
     qt6_wrap_cpp(MOC_FILES ${MOC_HEADER_FILES})
     qt6_wrap_ui(FORM_FILES ${UI_FILES})
 endif()


### PR DESCRIPTION
Recent PR #1756 is testing wheter Qt5_FOUND is true or not.
The optional search for QWebEngine, QtCharts, can set back this value to FALSE (even if Qt5 itself is there)

This PR fixes this (thus fixes the further generation of ui_ headers) by using instead Qt5Core_FOUND (thanks to @guparan )

(This was not detected on the CI or my Windows System as the optional Qt5 components was present, thus Qt5_FOUND was always true)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
