### PR TITLE
[SofaKernel] Removes the method BaseData::getOwnerClass() 

### DIFF
--- a/SofaKernel/modules/Sofa.Config/src/sofa/config.h.in
+++ b/SofaKernel/modules/Sofa.Config/src/sofa/config.h.in
@@ -158,6 +158,10 @@ typedef unsigned __int64	uint64_t;
         "Link<> cannot hold BaseData anymore. " \
         "To make a link between Datas use DataLink instead. ")
 
+#define SOFA_ATTRIBUTE_REMOVAL_OF_BASEDATA_GETOWNERCLASS(msg) \
+    SOFA_ATTRIBUTE_DEPRECATED( \
+        "v21.06 (PR#18)", "v21.12", \
+        "BaseData API has changed. " msg)
 
 #define SOFA_ATTRIBUTE_DISABLED__DATA_OPERATOR(msg) \
     SOFA_ATTRIBUTE_DISABLED( \

--- a/SofaKernel/modules/Sofa.Config/src/sofa/config.h.in
+++ b/SofaKernel/modules/Sofa.Config/src/sofa/config.h.in
@@ -158,7 +158,7 @@ typedef unsigned __int64	uint64_t;
         "Link<> cannot hold BaseData anymore. " \
         "To make a link between Datas use DataLink instead. ")
 
-#define SOFA_ATTRIBUTE_REMOVAL_OF_BASEDATA_GETOWNERCLASS(msg) \
+#define SOFA_ATTRIBUTE_REMOVAL_OF_BASEDATA_OWNERCLASS_ACCESSOR(msg) \
     SOFA_ATTRIBUTE_DEPRECATED( \
         "v21.06 (PR#1890)", "v21.12", \
         "BaseData API has changed. " msg)

--- a/SofaKernel/modules/Sofa.Config/src/sofa/config.h.in
+++ b/SofaKernel/modules/Sofa.Config/src/sofa/config.h.in
@@ -160,7 +160,7 @@ typedef unsigned __int64	uint64_t;
 
 #define SOFA_ATTRIBUTE_REMOVAL_OF_BASEDATA_GETOWNERCLASS(msg) \
     SOFA_ATTRIBUTE_DEPRECATED( \
-        "v21.06 (PR#18)", "v21.12", \
+        "v21.06 (PR#1890)", "v21.12", \
         "BaseData API has changed. " msg)
 
 #define SOFA_ATTRIBUTE_DISABLED__DATA_OPERATOR(msg) \

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
@@ -153,9 +153,11 @@ public:
     void setHelp(const std::string& val) { help = val; }
 
     /// Get owner class
+    SOFA_ATTRIBUTE_REMOVAL_OF_BASEDATA_OWNERCLASS_ACCESSOR("Replace getOwnerClass() by getOwner()->className")
     const std::string& getOwnerClass() const { return ownerClass; }
 
     /// Set owner class
+    SOFA_ATTRIBUTE_REMOVAL_OF_BASEDATA_OWNERCLASS_ACCESSOR("The function will be totally removed. The owner's class name being using getOwner()->className")
     void setOwnerClass(const char* val) { ownerClass = val; }
 
     /// Get group


### PR DESCRIPTION
In this PR we deprecate for removal the set/getOwnerClass() method from BaseData because this methods duplicates what can be accessed through BaseData::getOwner()



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
