### PR TITLE
[SofaGeneralExplicitOdeSolver] Fix typo in CentralDifferenceSolver description

### DIFF
--- a/modules/SofaGeneralExplicitOdeSolver/src/SofaGeneralExplicitOdeSolver/CentralDifferenceSolver.cpp
+++ b/modules/SofaGeneralExplicitOdeSolver/src/SofaGeneralExplicitOdeSolver/CentralDifferenceSolver.cpp
@@ -160,7 +160,7 @@ void CentralDifferenceSolver::solve(const core::ExecParams* params, SReal dt, so
 
 }
 
-int CentralDifferenceSolverClass = core::RegisterObject("Explicit time integrator using central difference (also known as Verlet of Leap-frop)")
+int CentralDifferenceSolverClass = core::RegisterObject("Explicit time integrator using central difference (also known as Verlet of Leap-frog)")
         .add< CentralDifferenceSolver >()
         .addAlias("CentralDifference");
 ;


### PR DESCRIPTION
fixed typo error, from leap-frop to leap-frog



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
