### PR TITLE
[SofaHelper] Fix the use of Read/WriteAccessorVector that is too permisive (in accessor.h)

### DIFF
--- a/SofaKernel/modules/Sofa.Type/CMakeLists.txt
+++ b/SofaKernel/modules/Sofa.Type/CMakeLists.txt
@@ -13,6 +13,7 @@ set(HEADER_FILES
     ${SOFATYPESRC_ROOT}/Mat_solve_LU.h
     ${SOFATYPESRC_ROOT}/Mat_solve_SVD.h
     ${SOFATYPESRC_ROOT}/trait/is_container.h
+    ${SOFATYPESRC_ROOT}/trait/is_vector.h
     ${SOFATYPESRC_ROOT}/fwd.h
     ${SOFATYPESRC_ROOT}/Quat.h
     ${SOFATYPESRC_ROOT}/Quat.inl

--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/trait/is_container.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/trait/is_container.h
@@ -45,13 +45,10 @@ struct is_container
 
         typedef typename A::iterator iterator;
         typedef typename A::const_iterator const_iterator;
-        //typedef typename A::value_type value_type;
         return  std::is_same<decltype(pt->begin()),iterator>::value &&
                 std::is_same<decltype(pt->end()),iterator>::value &&
                 std::is_same<decltype(cpt->begin()),const_iterator>::value &&
-                std::is_same<decltype(cpt->end()),const_iterator>::value /*&&
-                std::is_same<decltype(**pi),value_type &>::value &&
-                std::is_same<decltype(*pci),value_type const &>::value;*/;
+                std::is_same<decltype(cpt->end()),const_iterator>::value;
     }
 
     template<typename A>

--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/trait/is_vector.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/trait/is_vector.h
@@ -1,0 +1,63 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <type_traits>
+
+namespace sofa::type::trait
+{
+
+/// Detect if a type T has iterator/const iterator function and operator[](size_t)
+template<typename T>
+struct is_vector
+{
+    typedef typename std::remove_const<T>::type test_type;
+
+    template<typename A>
+    static constexpr bool test(
+        A * pt,
+        A const * cpt = nullptr,
+        decltype(pt->begin()) * = nullptr,
+        decltype(pt->end()) * = nullptr,
+        decltype(cpt->begin()) * = nullptr,
+        decltype(cpt->end()) * = nullptr,
+        typename std::decay<decltype((*pt)[0])>::type * = nullptr,   ///< Is there an operator[] ?
+        typename A::iterator * = nullptr,
+        typename A::const_iterator * = nullptr,
+        typename A::value_type * = nullptr) {
+
+        typedef typename A::iterator iterator;
+        typedef typename A::const_iterator const_iterator;
+        return  std::is_same<decltype(pt->begin()),iterator>::value
+                && std::is_same<decltype(pt->end()),iterator>::value
+                && std::is_same<decltype(cpt->begin()),const_iterator>::value
+                && std::is_same<decltype(cpt->end()),const_iterator>::value;
+    }
+
+    template<typename A>
+    static constexpr bool test(...) {
+        return false;
+    }
+
+    static const bool value = test<test_type>(nullptr);
+};
+
+}

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/accessor.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/accessor.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <sofa/helper/config.h>
-#include <sofa/type/trait/is_container.h>
+#include <sofa/type/trait/is_vector.h>
 
 #include <iosfwd>        ///< Needed to declare the operator<< and >> as deleted.
                          /// Remove it when the operator are completely removed
@@ -251,7 +251,7 @@ public:
 /// Support for std::vector
 template<class VectorLikeType>
 class ReadAccessor<VectorLikeType,
-        typename std::enable_if<sofa::type::trait::is_container<VectorLikeType>::value>::type> : public ReadAccessorVector< VectorLikeType >
+        typename std::enable_if<sofa::type::trait::is_vector<VectorLikeType>::value>::type> : public ReadAccessorVector< VectorLikeType >
 {
 public:
     typedef ReadAccessorVector< VectorLikeType > Inherit;
@@ -261,7 +261,7 @@ public:
 
 template<class VectorLikeType>
 class WriteAccessor<VectorLikeType,
-        typename std::enable_if<sofa::type::trait::is_container<VectorLikeType>::value>::type> : public WriteAccessorVector< VectorLikeType >
+        typename std::enable_if<sofa::type::trait::is_vector<VectorLikeType>::value>::type> : public WriteAccessorVector< VectorLikeType >
 {
 public:
     typedef WriteAccessorVector< VectorLikeType > Inherit;
@@ -271,7 +271,7 @@ public:
 
 template<class VectorLikeType>
 class WriteOnlyAccessor<VectorLikeType,
-        typename std::enable_if<sofa::type::trait::is_container<VectorLikeType>::value>::type> : public WriteAccessorVector< VectorLikeType >
+        typename std::enable_if<sofa::type::trait::is_vector<VectorLikeType>::value>::type> : public WriteAccessorVector< VectorLikeType >
 {
 public:
     typedef WriteAccessorVector< VectorLikeType > Inherit;


### PR DESCRIPTION
In the current implementation of accessor.h we are using a type_trait to select between default accessor implementation or vector's one. 

The traits we are using, called is_container, as its name suggest is returning true if the type parameter is a container.This means that std::set or map are also switching to the vector version of accessors. 

This PR
- adds an is_vector type trait which check there is a operator[] in the type parameter 
- use the is_vector into accessor.h to fix the compilation problem. 

@fredroy I hope you appreciate the "quasi c++20 concepts", when they will be available we will be ready
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
