### PR TITLE
[SofaHelper] Replace boost::shared_ptr for std::shared_ptr

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/logging/ComponentInfo.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/logging/ComponentInfo.h
@@ -32,14 +32,9 @@
 #include <sofa/helper/config.h>
 #include <sstream>
 #include <set>
+#include <memory>
 
-#include <boost/shared_ptr.hpp>
-
-namespace sofa
-{
-namespace helper
-{
-namespace logging
+namespace sofa::helper::logging
 {
 
 /// The base class to keep track of informations associated with a message.
@@ -63,7 +58,7 @@ public:
     friend std::ostream& operator<<(std::ostream& out, const ComponentInfo& nfo) ;
     friend std::ostream& operator<<(std::ostream& out, const ComponentInfo* nfo) ;
 
-    typedef boost::shared_ptr<ComponentInfo> SPtr;
+    typedef std::shared_ptr<ComponentInfo> SPtr;
 protected:
     std::string m_sender ;
 };
@@ -85,9 +80,7 @@ inline bool notMuted(const ComponentInfo::SPtr&){ return true; }
 /// This function is used in the msg_* macro to handle string based on string.
 inline bool notMuted(const std::string&){ return true; }
 
-} // logging
-} // helper
-} // sofa
+} // namespace sofa::helper::logging
 
 
 #endif // COMPONENTINFO_H

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/logging/FileInfo.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/logging/FileInfo.h
@@ -32,16 +32,10 @@
 #include <sofa/helper/config.h>
 #include <sstream>
 #include <set>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 
-namespace sofa
-{
-
-namespace helper
-{
-
-namespace logging
+namespace sofa::helper::logging
 {
 
 static const char * s_unknownFile = "unknown-file";
@@ -52,7 +46,7 @@ static const char * s_unknownFile = "unknown-file";
 /// instead.
 struct FileInfo
 {
-    typedef boost::shared_ptr<FileInfo> SPtr;
+    typedef std::shared_ptr<FileInfo> SPtr;
 
     const char *filename {nullptr};
     int line             {0};
@@ -90,9 +84,7 @@ static FileInfo::SPtr EmptyFileInfo(new FileInfo(s_unknownFile, 0)) ;
 #define SOFA_FILE_INFO sofa::helper::logging::FileInfo::SPtr(new sofa::helper::logging::FileInfo(__FILE__, __LINE__))
 #define SOFA_FILE_INFO_COPIED_FROM(file,line) sofa::helper::logging::FileInfo::SPtr(new sofa::helper::logging::FileInfoOwningFilename(file,line))
 
-} // logging
-} // helper
-} // sofa
+} // sofa::helper::logging
 
 
 #endif // MESSAGE_H


### PR DESCRIPTION
Maybe breaking, if someone, somewhere, somehow stored `ComponentInfo::SPtr` or `FileInfo::SPtr` in its components using directly `boost::shared_ptr<T>`.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
