### PR TITLE
[SofaHelper] Moves operator>> specialisation for int from set.h to set.cpp

### DIFF
--- a/SofaKernel/modules/SofaCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/CMakeLists.txt
@@ -269,7 +269,6 @@ set (COMPAT_HEADER_FILES
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${COMPAT_HEADER_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaHelper SofaDefaultType)
-#target_precompile_headers(${PROJECT_NAME} PUBLIC ${SRC_ROOT}/objectmodel/BaseObject.h ${SRC_ROOT}/objectmodel/BaseContext.h)
 
 if(SOFA_BUILD_WITH_PCH_ENABLED)
     message("Adding precompiled header for SofaCore")

--- a/SofaKernel/modules/SofaHelper/CMakeLists.txt
+++ b/SofaKernel/modules/SofaHelper/CMakeLists.txt
@@ -194,6 +194,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/system/thread/CircularQueue.cpp
     ${SRC_ROOT}/system/thread/debug.cpp
     ${SRC_ROOT}/system/FileRepository.cpp
+    ${SRC_ROOT}/set.cpp
     ${SRC_ROOT}/vector.cpp
     ${SRC_ROOT}/vector_Real.cpp
     ${SRC_ROOT}/vector_Integral.cpp

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/set.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/set.cpp
@@ -1,0 +1,157 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/helper/config.h>
+
+#include <string>
+#include <iostream>
+
+#include <sofa/helper/set.h>
+#include <sofa/helper/logging/Messaging.h>
+
+/// adding string serialization to std::set to make it compatible with Data
+/// \todo: refactoring of the containers required
+/// More info PR #113: https://github.com/sofa-framework/sofa/pull/113
+
+namespace std
+{
+
+/// Input stream
+/// Specialization for reading sets of int and unsigned int using "A-B" notation for all integers between A and B, optionnally specifying a step using "A-B-step" notation.
+template<>
+std::istream& operator>> ( std::istream& in, std::set<int>& _set )
+{
+    int t;
+    _set.clear();
+    std::string s;
+    while(in>>s)
+    {
+        std::string::size_type hyphen = s.find_first_of('-',1);
+        if (hyphen == std::string::npos)
+        {
+            t = atoi(s.c_str());
+            _set.insert(t);
+        }
+        else
+        {
+            int t1,t2,tinc;
+            std::string s1(s,0,hyphen);
+            t1 = atoi(s1.c_str());
+            std::string::size_type hyphen2 = s.find_first_of('-',hyphen+2);
+            if (hyphen2 == std::string::npos)
+            {
+                std::string s2(s,hyphen+1);
+                t2 = atoi(s2.c_str());
+                tinc = (t1<t2) ? 1 : -1;
+            }
+            else
+            {
+                std::string s2(s,hyphen+1,hyphen2);
+                std::string s3(s,hyphen2+1);
+                t2 = atoi(s2.c_str());
+                tinc = atoi(s3.c_str());
+                if (tinc == 0)
+                {
+                    msg_error("set") << "parsing \""<<s<<"\": increment is 0";
+                    tinc = (t1<t2) ? 1 : -1;
+                }
+                if ((t2-t1)*tinc < 0)
+                {
+                    // increment not of the same sign as t2-t1 : swap t1<->t2
+                    t = t1;
+                    t1 = t2;
+                    t2 = t;
+                }
+            }
+            if (tinc < 0)
+                for (t=t1; t>=t2; t+=tinc)
+                    _set.insert(t);
+            else
+                for (t=t1; t<=t2; t+=tinc)
+                    _set.insert(t);
+        }
+    }
+    if( in.rdstate() & std::ios_base::eofbit ) { in.clear(); }
+    return in;
+}
+
+/// Input stream
+/// Specialization for reading sets of int and unsigned int using "A-B" notation for all integers between A and B
+template<>
+std::istream& operator>> ( std::istream& in, std::set<unsigned int>& _set )
+{
+    unsigned int t;
+    _set.clear();
+    std::string s;
+    while(in>>s)
+    {
+        std::string::size_type hyphen = s.find_first_of('-',1);
+        if (hyphen == std::string::npos)
+        {
+            t = atoi(s.c_str());
+            _set.insert(t);
+        }
+        else
+        {
+            unsigned int t1,t2;
+            int tinc;
+            std::string s1(s,0,hyphen);
+            t1 = (unsigned int)atoi(s1.c_str());
+            std::string::size_type hyphen2 = s.find_first_of('-',hyphen+2);
+            if (hyphen2 == std::string::npos)
+            {
+                std::string s2(s,hyphen+1);
+                t2 = (unsigned int)atoi(s2.c_str());
+                tinc = (t1<t2) ? 1 : -1;
+            }
+            else
+            {
+                std::string s2(s,hyphen+1,hyphen2);
+                std::string s3(s,hyphen2+1);
+                t2 = (unsigned int)atoi(s2.c_str());
+                tinc = atoi(s3.c_str());
+                if (tinc == 0)
+                {
+                    msg_error("set") << "parsing \""<<s<<"\": increment is 0";
+                    tinc = (t1<t2) ? 1 : -1;
+                }
+                if (((int)(t2-t1))*tinc < 0)
+                {
+                    // increment not of the same sign as t2-t1 : swap t1<->t2
+                    t = t1;
+                    t1 = t2;
+                    t2 = t;
+                }
+            }
+            if (tinc < 0)
+                for (t=t1; t>=t2; t=(unsigned int)((int)t+tinc))
+                    _set.insert(t);
+            else
+                for (t=t1; t<=t2; t=(unsigned int)((int)t+tinc))
+                    _set.insert(t);
+        }
+    }
+    if( in.rdstate() & std::ios_base::eofbit ) { in.clear(); }
+    return in;
+}
+
+} // namespace std
+

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/set.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/set.h
@@ -23,19 +23,12 @@
 #define SOFA_HELPER_SET_H
 
 #include <sofa/helper/config.h>
-
 #include <set>
-#include <string>
 #include <iostream>
-
-#include <sofa/helper/logging/Messaging.h>
-
 
 /// adding string serialization to std::set to make it compatible with Data
 /// \todo: refactoring of the containers required
 /// More info PR #113: https://github.com/sofa-framework/sofa/pull/113
-
-
 namespace std
 {
 
@@ -66,127 +59,13 @@ std::istream& operator>> ( std::istream& i, std::set<K>& s )
     return i;
 }
 
-
-
-
 /// Input stream
 /// Specialization for reading sets of int and unsigned int using "A-B" notation for all integers between A and B, optionnally specifying a step using "A-B-step" notation.
-template<>
-inline std::istream& operator>> ( std::istream& in, std::set<int>& _set )
-{
-    int t;
-    _set.clear();
-    std::string s;
-    while(in>>s)
-    {
-        std::string::size_type hyphen = s.find_first_of('-',1);
-        if (hyphen == std::string::npos)
-        {
-            t = atoi(s.c_str());
-            _set.insert(t);
-        }
-        else
-        {
-            int t1,t2,tinc;
-            std::string s1(s,0,hyphen);
-            t1 = atoi(s1.c_str());
-            std::string::size_type hyphen2 = s.find_first_of('-',hyphen+2);
-            if (hyphen2 == std::string::npos)
-            {
-                std::string s2(s,hyphen+1);
-                t2 = atoi(s2.c_str());
-                tinc = (t1<t2) ? 1 : -1;
-            }
-            else
-            {
-                std::string s2(s,hyphen+1,hyphen2);
-                std::string s3(s,hyphen2+1);
-                t2 = atoi(s2.c_str());
-                tinc = atoi(s3.c_str());
-                if (tinc == 0)
-                {
-                    msg_error("set") << "parsing \""<<s<<"\": increment is 0";
-                    tinc = (t1<t2) ? 1 : -1;
-                }
-                if ((t2-t1)*tinc < 0)
-                {
-                    // increment not of the same sign as t2-t1 : swap t1<->t2
-                    t = t1;
-                    t1 = t2;
-                    t2 = t;
-                }
-            }
-            if (tinc < 0)
-                for (t=t1; t>=t2; t+=tinc)
-                    _set.insert(t);
-            else
-                for (t=t1; t<=t2; t+=tinc)
-                    _set.insert(t);
-        }
-    }
-    if( in.rdstate() & std::ios_base::eofbit ) { in.clear(); }
-    return in;
-}
+template<> SOFA_HELPER_API std::istream& operator>> ( std::istream& in, std::set<int>& _set );
 
 /// Input stream
 /// Specialization for reading sets of int and unsigned int using "A-B" notation for all integers between A and B
-template<>
-inline std::istream& operator>> ( std::istream& in, std::set<unsigned int>& _set )
-{
-    unsigned int t;
-    _set.clear();
-    std::string s;
-    while(in>>s)
-    {
-        std::string::size_type hyphen = s.find_first_of('-',1);
-        if (hyphen == std::string::npos)
-        {
-            t = atoi(s.c_str());
-            _set.insert(t);
-        }
-        else
-        {
-            unsigned int t1,t2;
-            int tinc;
-            std::string s1(s,0,hyphen);
-            t1 = (unsigned int)atoi(s1.c_str());
-            std::string::size_type hyphen2 = s.find_first_of('-',hyphen+2);
-            if (hyphen2 == std::string::npos)
-            {
-                std::string s2(s,hyphen+1);
-                t2 = (unsigned int)atoi(s2.c_str());
-                tinc = (t1<t2) ? 1 : -1;
-            }
-            else
-            {
-                std::string s2(s,hyphen+1,hyphen2);
-                std::string s3(s,hyphen2+1);
-                t2 = (unsigned int)atoi(s2.c_str());
-                tinc = atoi(s3.c_str());
-                if (tinc == 0)
-                {
-                    msg_error("set") << "parsing \""<<s<<"\": increment is 0";
-                    tinc = (t1<t2) ? 1 : -1;
-                }
-                if (((int)(t2-t1))*tinc < 0)
-                {
-                    // increment not of the same sign as t2-t1 : swap t1<->t2
-                    t = t1;
-                    t1 = t2;
-                    t2 = t;
-                }
-            }
-            if (tinc < 0)
-                for (t=t1; t>=t2; t=(unsigned int)((int)t+tinc))
-                    _set.insert(t);
-            else
-                for (t=t1; t<=t2; t=(unsigned int)((int)t+tinc))
-                    _set.insert(t);
-        }
-    }
-    if( in.rdstate() & std::ios_base::eofbit ) { in.clear(); }
-    return in;
-}
+template<> SOFA_HELPER_API std::istream& operator>> ( std::istream& in, std::set<unsigned int>& _set );
 
 
 } // namespace std


### PR DESCRIPTION
Because I have so much branch with this change duplicated that it is worth having it in a PR and forget about that. 

Of course, a real refactoring of the reading code would be better but until done let's just have this kind of  cleaning .

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
