### PR TITLE
[SofaGuiQt] Fix RealGUI: QDesktopWidget header missing for Qt < 5.11

### DIFF
--- a/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
@@ -103,7 +103,10 @@ using sofa::simulation::SceneLoaderFactory;
 #include <QMimeData>
 #include <QCompleter>
 #include <QDesktopServices>
-#include <QDesktopWidget>
+
+#if (QT_VERSION < QT_VERSION_CHECK(5, 11, 0))
+    #include <QDesktopWidget>
+#endif
 
 #   ifdef SOFA_GUI_INTERACTION
 #    include <QCursor>

--- a/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
@@ -103,6 +103,7 @@ using sofa::simulation::SceneLoaderFactory;
 #include <QMimeData>
 #include <QCompleter>
 #include <QDesktopServices>
+#include <QDesktopWidget>
 
 #   ifdef SOFA_GUI_INTERACTION
 #    include <QCursor>


### PR DESCRIPTION
Fix compilation for Qt version< 5.11 or we decide to remove that and I update my computer:
```if (QT_VERSION < QT_VERSION_CHECK(5, 11, 0))```

```18>C:\projects\sofa-src\modules\SofaGuiQt\src\sofa\gui\qt\RealGUI.cpp(456,49): error C2027: use of undefined type 'QDesktopWidget'
18>C:\Qt\5.10.1\msvc2017_64\include\QtWidgets\qapplication.h(57): message : see declaration of 'QDesktopWidget'```

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
