### PR TITLE
[MultiThreading] Removes useless classid in AnimationLoopParalleleScheduler.cpp

### DIFF
--- a/applications/plugins/MultiThreading/src/MultiThreading/AnimationLoopParallelScheduler.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/AnimationLoopParallelScheduler.cpp
@@ -102,10 +102,6 @@ namespace simulation
             _taskScheduler = TaskScheduler::create(schedulerName.getValue().c_str());
         }        
         _taskScheduler->init( mNbThread );
-
-		sofa::core::objectmodel::classidT<sofa::core::behavior::ConstraintSolver>();
-		sofa::core::objectmodel::classidT<sofa::core::behavior::LinearSolver>();
-		sofa::core::objectmodel::classidT<sofa::core::CollisionModel>();
 	}
 
 


### PR DESCRIPTION
classid is return the ClassInfo associated for a type. 
As there is a static private field in the classid function the first call is used to initialized this static structure. 
The only usage I can see of calling that explicitely is that, because of the multi-threading the initialization was not done properly.
But since c++ 11, initialization of static member is standardize offer thread-safetiness guarantees.
Se we can probably remove that.





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
