### PR TITLE
[SofaHelper] Adds forward declaration for AdvancedTimer::stepBegin/stepEnd 

### DIFF
--- a/SofaKernel/modules/SofaHelper/CMakeLists.txt
+++ b/SofaKernel/modules/SofaHelper/CMakeLists.txt
@@ -167,6 +167,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/Utils.cpp
     ${SRC_ROOT}/decompose.cpp
     ${SRC_ROOT}/init.cpp
+    ${SRC_ROOT}/fwd.cpp
     ${SRC_ROOT}/io/BaseFileAccess.cpp
     ${SRC_ROOT}/io/FileAccess.cpp
     ${SRC_ROOT}/io/File.cpp

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/fwd.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/fwd.cpp
@@ -21,20 +21,19 @@
 ******************************************************************************/
 #pragma once
 
-#include <sofa/helper/config.h>
-
-namespace sofa::helper
+#include <sofa/helper/fwd.h>
+#include <sofa/helper/AdvancedTimer.h>
+namespace sofa::helper::advancedtimer
 {
-class StateMask;
-
-namespace advancedtimer
+void stepBegin(const char* idStr)
 {
-SOFA_HELPER_API void stepBegin(const char* idStr);
-SOFA_HELPER_API void stepEnd(const char* idStr);
-}
+    AdvancedTimer::stepBegin(idStr);
 }
 
-namespace sofa::helper::visual
+void stepEnd(const char* idStr)
 {
-class DrawTool;
+    AdvancedTimer::stepEnd(idStr);
 }
+
+}
+


### PR DESCRIPTION
As the title suggests.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
