### PR TITLE
[SofaFramework] Put back Sofa.GL in Framework

### DIFF
--- a/SofaKernel/SofaFramework/CMakeLists.txt
+++ b/SofaKernel/SofaFramework/CMakeLists.txt
@@ -14,6 +14,11 @@ foreach(TARGET ${SOFAFRAMEWORK_TARGETS})
     endif()
 endforeach()
 
+if(SOFA_WITH_OPENGL)
+    add_subdirectory(../modules/Sofa.GL ${CMAKE_CURRENT_BINARY_DIR}/Sofa.GL)
+    list(APPEND SOFAFRAMEWORK_TARGETS Sofa.GL)
+endif()
+
 set(SOFAFRAMEWORK_SRC src/SofaFramework)
 set(HEADER_FILES
     ${SOFAFRAMEWORK_SRC}/config.h.in

--- a/SofaKernel/SofaFramework/SofaFrameworkConfig.cmake.in
+++ b/SofaKernel/SofaFramework/SofaFrameworkConfig.cmake.in
@@ -35,4 +35,10 @@ if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 endif()
 
+# This need to be AFTER the inclusion of SofaFrameworkTargets.cmake since Sofa.GL is dependant on SofaHelper and
+# SofaDefaultType targets, which are defined there.
+if(SOFA_WITH_OPENGL)
+    find_package(Sofa.GL CONFIG QUIET REQUIRED)
+endif()
+
 check_required_components(@PROJECT_NAME@)

--- a/SofaKernel/modules/CMakeLists.txt
+++ b/SofaKernel/modules/CMakeLists.txt
@@ -11,7 +11,3 @@ sofa_add_module(SofaEngine SofaEngine ON)
 sofa_add_module(SofaExplicitOdeSolver SofaExplicitOdeSolver ON)
 sofa_add_module(SofaImplicitOdeSolver SofaImplicitOdeSolver ON)
 sofa_add_module(SofaLoader SofaLoader ON)
-
-sofa_add_module(Sofa.GL Sofa.GL ON
-    WHEN_TO_SHOW "SOFA_WITH_OPENGL"
-    VALUE_IF_HIDDEN OFF)


### PR DESCRIPTION
Small revert from #1913 
Sofa.GL is a pure "dll" with no component so cannot be a "sofa module" (aka loadable in a scene file)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
