### PR TITLE
[Demo] Use 'expected' idiom for matrix inversion

### DIFF
--- a/SofaKernel/modules/Sofa.Type/CMakeLists.txt
+++ b/SofaKernel/modules/Sofa.Type/CMakeLists.txt
@@ -44,11 +44,13 @@ set(SOURCE_FILES
     ${SOFATYPESRC_ROOT}/stdtype/fixed_array.cpp
 )
 
+sofa_find_package(Boost REQUIRED)
+
 sofa_find_package(Sofa.Config REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 
-target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Config)
+target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Config Boost::boost)
 
 sofa_add_targets_to_package(
     PACKAGE_NAME SofaFramework

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.inl
@@ -1601,7 +1601,15 @@ inline void TetrahedronFEMForceField<DataTypes>::reinit()
                     matVert[k][l] = X0[ix][l-1];
             }
 
-            defaulttype::invertMatrix(elemShapeFun[i], matVert);
+            if (auto res = type::invertMatrix(matVert))
+            {
+                elemShapeFun[i] = res.value();
+            }
+            else
+            {
+                msg_error() << "Cannot compute vonMises for  element " << (*it) << " because "
+                    << res.error().what();
+            }
         }
         computeVonMisesStress();
     }

--- a/modules/SofaConstraint/src/SofaConstraint/BilateralConstraintResolution.h
+++ b/modules/SofaConstraint/src/SofaConstraint/BilateralConstraintResolution.h
@@ -71,6 +71,7 @@ public:
     BilateralConstraintResolution3Dof(sofa::defaulttype::Vec3d* vec = nullptr)
         : ConstraintResolution(3)
         , _f(vec)
+        , m_bValid(true)
     {
     }
     void init(int line, double** w, double *force) override
@@ -86,7 +87,15 @@ public:
         temp[2][1] = w[line+2][line+1];
         temp[2][2] = w[line+2][line+2];
 
-        invertMatrix(invW, temp);
+        if (auto res = type::invertMatrix(temp))
+        {
+            invW = res.value();
+        }
+        else
+        {
+            msg_error("BilateralConstraintResolution3Dof") << res.error().what();
+            m_bValid = false;
+        }
 
         if(_f)
         {
@@ -97,7 +106,7 @@ public:
 
     void initForce(int line, double* force) override
     {
-        if(_f)
+        if(m_bValid && _f)
         {
             for(int i=0; i<3; i++)
                 force[line+i] = (*_f)[i];
@@ -106,6 +115,9 @@ public:
 
     void resolution(int line, double** /*w*/, double* d, double* force, double * dFree) override
     {
+        if (!m_bValid)
+            return;
+
         SOFA_UNUSED(dFree);
         for(int i=0; i<3; i++)
         {
@@ -116,7 +128,7 @@ public:
 
     void store(int line, double* force, bool /*convergence*/) override
     {
-        if(_f)
+        if (m_bValid && _f)
         {
             for(int i=0; i<3; i++)
                 (*_f)[i] = force[line+i];
@@ -126,6 +138,7 @@ public:
 protected:
     sofa::defaulttype::Mat<3,3,double> invW;
     sofa::defaulttype::Vec3d* _f;
+    bool m_bValid;
 };
 
 class BilateralConstraintResolutionNDof : public ConstraintResolution


### PR DESCRIPTION
An other method for better error handling. (the other one to be exception mechanism #1882 )

'Expected' idiom : 
 - [theory by Andrei Alexandrescu](https://channel9.msdn.com/Shows/Going+Deep/C-and-Beyond-2012-Andrei-Alexandrescu-Systematic-Error-Handling-in-C)
 - clear explanation and comparison with exception: https://bell0bytes.eu/expected/

I am using boost::outcome because we have already boost in SOFA, but this is just to show the concept (I dont want to introduce more boost in SOFA..): https://ned14.github.io/outcome/

(Issue #1924 )
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
