### PR TITLE
[Sofa.Type] Remove MIN_DETERMINANT preprocessor value

### DIFF
--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/Mat.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/Mat.h
@@ -32,12 +32,18 @@
 namespace // anonymous
 {
     template<typename real>
-    real rabs(const real r)
+    constexpr real rabs(const real r)
     {
         if constexpr (std::is_signed<real>())
             return std::abs(r);
         else
             return r;
+    }
+
+    template<typename real>
+    constexpr real equalsZero(const real r, const real epsilon = std::numeric_limits<real>::epsilon())
+    {
+        return rabs(r) <= epsilon;
     }
 
 } // anonymous namespace
@@ -837,8 +843,6 @@ inline Vec<N,real> diagonal(const Mat<N,N,real>& m)
     return v;
 }
 
-#define MIN_DETERMINANT  1.0e-100
-
 /// Matrix inversion (general case).
 template<sofa::Size S, class real>
 [[nodiscard]] bool invertMatrix(Mat<S,S,real>& dest, const Mat<S,S,real>& from)
@@ -872,7 +876,7 @@ template<sofa::Size S, class real>
             }
         }
 
-        if (pivot <= (real) MIN_DETERMINANT)
+        if (equalsZero(pivot))
         {
             return false;
         }
@@ -913,7 +917,7 @@ template<class real>
 {
     real det=determinant(from);
 
-    if ( -(real) MIN_DETERMINANT<=det && det<=(real) MIN_DETERMINANT)
+    if (equalsZero(det))
     {
         return false;
     }
@@ -937,7 +941,7 @@ bool invertMatrix(Mat<2,2,real>& dest, const Mat<2,2,real>& from)
 {
     real det=determinant(from);
 
-    if ( -(real) MIN_DETERMINANT<=det && det<=(real) MIN_DETERMINANT)
+    if (equalsZero(det))
     {
         return false;
     }
@@ -949,7 +953,6 @@ bool invertMatrix(Mat<2,2,real>& dest, const Mat<2,2,real>& from)
 
     return true;
 }
-#undef MIN_DETERMINANT
 
 /// Inverse Matrix considering the matrix as a transformation.
 template<sofa::Size S, class real>


### PR DESCRIPTION
Fix #1931

Still a question about the value to compare float/double against. numeric_limits<real>::epsilon()? min() or a fixed value like 1e-100 (previous value of MIN_DETERMINANT) ?

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
