### PR TITLE
[Sofa.Type] Add forgotten function declaration, used in Debug

### DIFF
--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/stdtype/vector_T.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/stdtype/vector_T.h
@@ -40,6 +40,8 @@ namespace sofa::type::stdtype
 
 static constexpr bool isEnabledVectorAccessChecking {SOFA_VECTOR_CHECK_ACCESS};
 
+extern void SOFA_TYPE_API vector_access_failure(const void* vec, unsigned size, unsigned i, const std::type_info& type);
+
 // standard vector dont use the CPUMemoryManager given as template
 template <typename T>
 class CPUMemoryManager;

--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/FullVector.inl
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/FullVector.inl
@@ -36,7 +36,7 @@ void FullVector<Real>::checkIndex(Index n) const
     {
         msg_error("FullVector") << "in vector<" << sofa::helper::gettypename(typeid(*this)) << "> " << std::hex << (long)this << std::dec << " size " << cursize << " : invalid index " << (int)n;
         sofa::helper::BackTrace::dump();
-        assert(i < size);
+        assert(n < cursize);
     }
 }
 


### PR DESCRIPTION
Debug compilation was failing due to the fact that the header is not supposed to know `vector_access_failure` , defined in the cpp file.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
