### PR TITLE
[SofaBaseMechanics] Restore useRestPos Data initialization for BarycentricMapping

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMapping.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMapping.h
@@ -63,7 +63,7 @@ public:
     typedef typename Inherit1::ForceMask ForceMask;
 
 public:
-    Data< bool > useRestPosition; ///< Use the rest position of the input and output models to initialize the mapping    
+    Data< bool > d_useRestPosition; ///< Use the rest position of the input and output models to initialize the mapping    
 
     SingleLink<BarycentricMapping<In,Out>,Mapper,BaseLink::FLAG_STRONGLINK> d_mapper;
     SingleLink<BarycentricMapping<In,Out>,BaseMeshTopology,BaseLink::FLAG_STRONGLINK> d_input_topology;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMapping.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMapping.inl
@@ -86,7 +86,7 @@ static bool is_a(const V * topology) {
 template <class TIn, class TOut>
 BarycentricMapping<TIn, TOut>::BarycentricMapping(core::State<In>* from, core::State<Out>* to, typename Mapper::SPtr mapper)
     : Inherit1 ( from, to )
-    , useRestPosition(core::objectmodel::Base::initData(&useRestPosition, false, "useRestPosition", "Use the rest position of the input and output models to initialize the mapping"))
+    , d_useRestPosition(core::objectmodel::Base::initData(&d_useRestPosition, false, "useRestPosition", "Use the rest position of the input and output models to initialize the mapping"))
     , d_mapper(initLink("mapper","Internal mapper created depending on the type of topology"), mapper)
     , d_input_topology(initLink("input_topology", "Input topology container (usually the surrounding domain)."))
     , d_output_topology(initLink("output_topology", "Output topology container (usually the immersed domain)."))
@@ -101,7 +101,7 @@ BarycentricMapping<TIn, TOut>::BarycentricMapping(core::State<In>* from, core::S
 template <class TIn, class TOut>
 BarycentricMapping<TIn, TOut>::BarycentricMapping (core::State<In>* from, core::State<Out>* to, BaseMeshTopology * input_topology )
     : Inherit1 ( from, to )
-    , useRestPosition(core::objectmodel::Base::initData(&useRestPosition, false, "useRestPosition", "Use the rest position of the input and output models to initialize the mapping"))
+    , d_useRestPosition(core::objectmodel::Base::initData(&d_useRestPosition, false, "useRestPosition", "Use the rest position of the input and output models to initialize the mapping"))
     , d_mapper (initLink("mapper","Internal mapper created depending on the type of topology"))
     , d_input_topology(initLink("input_topology", "Input topology container (usually the surrounding domain)."))
     , d_output_topology(initLink("output_topology", "Output topology container (usually the immersed domain)."))
@@ -296,7 +296,7 @@ void BarycentricMapping<TIn, TOut>::initMapper()
 {
     if (d_mapper != nullptr && this->toModel != nullptr && this->fromModel != nullptr)
     {
-        if (useRestPosition.getValue())
+        if (d_useRestPosition.getValue())
             d_mapper->init (((const core::State<Out> *)this->toModel)->read(core::ConstVecCoordId::restPosition())->getValue(), ((const core::State<In> *)this->fromModel)->read(core::ConstVecCoordId::restPosition())->getValue() );
         else
             d_mapper->init (((const core::State<Out> *)this->toModel)->read(core::ConstVecCoordId::position())->getValue(), ((const core::State<In> *)this->fromModel)->read(core::ConstVecCoordId::position())->getValue() );

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMapping.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMapping.inl
@@ -86,6 +86,7 @@ static bool is_a(const V * topology) {
 template <class TIn, class TOut>
 BarycentricMapping<TIn, TOut>::BarycentricMapping(core::State<In>* from, core::State<Out>* to, typename Mapper::SPtr mapper)
     : Inherit1 ( from, to )
+    , useRestPosition(core::objectmodel::Base::initData(&useRestPosition, false, "useRestPosition", "Use the rest position of the input and output models to initialize the mapping"))
     , d_mapper(initLink("mapper","Internal mapper created depending on the type of topology"), mapper)
     , d_input_topology(initLink("input_topology", "Input topology container (usually the surrounding domain)."))
     , d_output_topology(initLink("output_topology", "Output topology container (usually the immersed domain)."))
@@ -100,6 +101,7 @@ BarycentricMapping<TIn, TOut>::BarycentricMapping(core::State<In>* from, core::S
 template <class TIn, class TOut>
 BarycentricMapping<TIn, TOut>::BarycentricMapping (core::State<In>* from, core::State<Out>* to, BaseMeshTopology * input_topology )
     : Inherit1 ( from, to )
+    , useRestPosition(core::objectmodel::Base::initData(&useRestPosition, false, "useRestPosition", "Use the rest position of the input and output models to initialize the mapping"))
     , d_mapper (initLink("mapper","Internal mapper created depending on the type of topology"))
     , d_input_topology(initLink("input_topology", "Input topology container (usually the surrounding domain)."))
     , d_output_topology(initLink("output_topology", "Output topology container (usually the immersed domain)."))


### PR DESCRIPTION
The initialization of the data disappeared at some point in the past 🤥
This PR restores it.

Credits to:
 - [InSimo](https://github.com/InSimo)(@JeremieA , @fjourdes ) 
 - @remibessard who reported it back to us

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
