### PR TITLE
[SofaHelper] Fix compilation in kdtree

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/kdTree.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/kdTree.h
@@ -24,6 +24,7 @@
 #include <set>
 #include <list>
 
+#include <sofa/helper/config.h>
 #include <sofa/type/Vec.h>
 #include <sofa/helper/vector.h>
 


### PR DESCRIPTION
.. due to a missing header (defining SOFA_HELPER_API)
I suppose this came from various merge before merging #1915 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
