### PR TITLE
[SofaGuiQt] FIX segfault due to qFatal in GenGraphForm

### DIFF
--- a/modules/SofaGuiQt/src/sofa/gui/qt/GenGraphForm.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/GenGraphForm.cpp
@@ -224,6 +224,8 @@ void GenGraphForm::doExport()
     }
     if (filename->text()==QString("")) return;
 
+    filename->setStyleSheet("");
+
     QString dotfile = filename->text();
 
     QString basefile = removeFileExt(dotfile);
@@ -235,7 +237,10 @@ void GenGraphForm::doExport()
     fdot.open(dotfile.toStdString().c_str(), std::ofstream::out | std::ofstream::trunc);
     if (!fdot.is_open())
     {
-        qFatal("Output to %s failed.\n",dotfile.toStdString().c_str());
+        msg_error("GenGraphForm") << "Output to " << dotfile.toStdString() << " failed.";
+        filename->clear();
+        filename->setFocus();
+        filename->setStyleSheet("border: 1px solid red");
         return;
     }
     {


### PR DESCRIPTION
Spotted by https://www.sofa-framework.org/community/forum/topic/export-graph-button-causes-runsofa-to-segfault-sigsegv-and-crash/



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
