### PR TITLE
[CMake] FIX resources and translations install on Windows

### DIFF
--- a/cmake/Modules/windeployqt.cmake
+++ b/cmake/Modules/windeployqt.cmake
@@ -61,9 +61,36 @@ function(windeployqt target build_dir install_dir)
         )
 
     # copy deployment directory during installation
+    if(CMAKE_CONFIGURATION_TYPES) # Multi-config generator (MSVC)
+        foreach(CONFIG ${CMAKE_CONFIGURATION_TYPES})
+            install(
+                DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/windeployqt/"
+                DESTINATION bin/${CONFIG}
+                OPTIONAL
+                COMPONENT applications
+                PATTERN "resources" EXCLUDE
+                PATTERN "translations" EXCLUDE
+                )
+        endforeach()
+    else()
+        install(
+            DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/windeployqt/"
+            DESTINATION bin
+            COMPONENT applications
+            PATTERN "resources" EXCLUDE
+            PATTERN "translations" EXCLUDE
+            )
+    endif()
     install(
-        DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/windeployqt/"
-        DESTINATION ${install_dir}
+        DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/windeployqt/resources/"
+        DESTINATION resources
+        OPTIONAL
+        COMPONENT applications
+        )
+    install(
+        DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/windeployqt/translations/"
+        DESTINATION translations
+        OPTIONAL
         COMPONENT applications
         )
 
@@ -75,11 +102,22 @@ function(windeployqt target build_dir install_dir)
 
     include(InstallRequiredSystemLibraries)
 
-    install(
-        PROGRAMS ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS}
-        DESTINATION ${install_dir}
-        COMPONENT applications
-    )
+    if(CMAKE_CONFIGURATION_TYPES) # Multi-config generator (MSVC)
+        foreach(CONFIG ${CMAKE_CONFIGURATION_TYPES})
+            install(
+                PROGRAMS ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS}
+                DESTINATION bin/${CONFIG}
+                OPTIONAL
+                COMPONENT applications
+            )
+        endforeach()
+    else()
+        install(
+            PROGRAMS ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS}
+            DESTINATION bin
+            COMPONENT applications
+        )
+    endif()
 
     # foreach(lib ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS})
     #     get_filename_component(filename "${lib}" NAME)


### PR DESCRIPTION
Spotted by https://www.sofa-framework.org/community/forum/topic/error-in-first-launch-of-sofa-after-installation/
`resources` and `translations` folders are not installed where they should.
TODO: backport this in v20.12

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
