### PR TITLE
[Sofa.GL] static variable belongs to the class

### DIFF
--- a/SofaKernel/modules/Sofa.GL/src/sofa/gl/Axis.cpp
+++ b/SofaKernel/modules/Sofa.GL/src/sofa/gl/Axis.cpp
@@ -31,7 +31,8 @@
 namespace sofa::gl
 {
 
-static const int quadricDiscretisation = 16;
+const int Axis::quadricDiscretisation = 16;
+
 //GLuint Axis::displayList;
 //GLUquadricObj *Axis::quadratic = nullptr;
 std::map < std::pair<std::pair<float,float>,float>, Axis* > Axis::axisMap; // great idea but no more valid when creating a new opengl context when switching sofa viewer

--- a/SofaKernel/modules/Sofa.GL/src/sofa/gl/Axis.h
+++ b/SofaKernel/modules/Sofa.GL/src/sofa/gl/Axis.h
@@ -83,6 +83,8 @@ private:
 public:
     static void clear() { axisMap.clear(); } // need to be called when display list has been created in another opengl context
 
+private:
+    static const int quadricDiscretisation;
 };
 
 } // namespace sofa::gl

--- a/SofaKernel/modules/Sofa.GL/src/sofa/gl/Cylinder.cpp
+++ b/SofaKernel/modules/Sofa.GL/src/sofa/gl/Cylinder.cpp
@@ -29,7 +29,8 @@
 namespace sofa::gl
 {
 
-static const int quadricDiscretisation = 16;
+const int Cylinder::quadricDiscretisation = 16;
+
 //GLuint Cylinder::displayList;
 //GLUquadricObj *Cylinder::quadratic = nullptr;
 std::map < std::pair<std::pair<float,float>,float>, Cylinder* > Cylinder::CylinderMap;

--- a/SofaKernel/modules/Sofa.GL/src/sofa/gl/Cylinder.h
+++ b/SofaKernel/modules/Sofa.GL/src/sofa/gl/Cylinder.h
@@ -76,6 +76,9 @@ private:
     static Cylinder* get(const Vector3& len);
 public:
     static void clear() { CylinderMap.clear(); } // need to be called when display list has been created in another opengl context
+
+private:
+    static const int quadricDiscretisation;
 };
 
 } // namespace sofa::gl


### PR DESCRIPTION
Two variables with internal linkage were defined with the same symbol, and the same value. Instead, I propose to associate these variable to the classes where they are used. I did not made them global variables because we could imagine having two different values for both classes.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
