### PR TITLE
[Sofa.Type] add operator* for RGBAColor

### DIFF
--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/RGBAColor.cpp
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/RGBAColor.cpp
@@ -283,9 +283,14 @@ SOFA_TYPE_API std::ostream& operator << ( std::ostream& out, const RGBAColor& v 
 /// @brief enlight a color by a given factor.
 RGBAColor RGBAColor::lighten(const RGBAColor& in, const SReal factor)
 {
-    RGBAColor c = in + ((RGBAColor::white() - clamp(in, 0.0f, 1.0f)) * rclamp(float(factor), 0.0f, 1.0f));
+    RGBAColor c = in + ( (RGBAColor::white() - clamp(in, 0.0f, 1.0f)) * rclamp(float(factor), 0.0f, 1.0f));
     c.a()=1.0;
     return c ;
+}
+
+RGBAColor RGBAColor::operator*(float f) const
+{
+    return RGBAColor(r() * f, g() * f, b() * f, a() * f);
 }
 
 

--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/RGBAColor.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/RGBAColor.h
@@ -97,6 +97,8 @@ public:
         return false;
     }
 
+    RGBAColor operator*(float f) const;
+
     friend SOFA_TYPE_API std::ostream& operator<<(std::ostream& i, const RGBAColor& t) ;
     friend SOFA_TYPE_API std::istream& operator>>(std::istream& i, RGBAColor& t) ;
 


### PR DESCRIPTION
This operator is not defined for RGBAColor. However, the compilator
somehow found a suitable operator in Vec.h, probably through implicit
conversion (?). This commit does not fix the compilation, but makes
things clearer. It also help the IDE to find the path to the operator
(it could not before).






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
