### PR TITLE
[SofaHelper] Clarify with global namespace

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PipeProcess.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PipeProcess.cpp
@@ -312,7 +312,7 @@ bool PipeProcess::executeProcess(const std::string &command,  const std::vector<
                 {
                     int n = BUFSIZE-nfill[i];
                     if (n> STEPSIZE) n = STEPSIZE;
-                    n = read(fds[i][0], buf[i]+nfill[i], n);
+                    n = ::read(fds[i][0], buf[i]+nfill[i], n);
 
                     if (n == 0)
                     {


### PR DESCRIPTION
It could be confused with sofa::helper::read()






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
