### PR TITLE
[SofaExporter] Removed duplicated header guard

### DIFF
--- a/modules/SofaExporter/src/SofaExporter/BlenderExporter.h
+++ b/modules/SofaExporter/src/SofaExporter/BlenderExporter.h
@@ -19,8 +19,9 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_COMPONENT_MISC_WRITESTATE_H
-#define SOFA_COMPONENT_MISC_WRITESTATE_H
+
+#pragma once
+
 #include <SofaExporter/config.h>
 
 #include <sofa/core/State.h>
@@ -123,5 +124,3 @@ namespace sofa
     } // namespace component
 
 } // namespace sofa
-
-#endif


### PR DESCRIPTION
SOFA_COMPONENT_MISC_WRITESTATE_H was already used in WriteState.h






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
