### PR TITLE
[SofaBaseTopology] Remove definition of real

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/polygon_cube_intersection/fast_polygon_cube_intersection.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/polygon_cube_intersection/fast_polygon_cube_intersection.cpp
@@ -70,7 +70,7 @@ namespace polygon_cube_intersection
 
 #define TEST_AGAINST_PARALLEL_PLANES(posbit, negbit, value, limit)	\
 	if (mask & (posbit|negbit)) {					\
-        /*register*/ real temp = value;				\
+        /*register*/ float temp = value;				\
 		if ((mask & posbit) && temp > limit)			\
 			outcode |= posbit;				\
 		else if ((mask & negbit) && temp < -limit)		\
@@ -84,7 +84,7 @@ namespace polygon_cube_intersection
  */
 
 static inline  unsigned long
-face_plane(const real p[3], unsigned long mask)
+face_plane(const float p[3], unsigned long mask)
 {
     /*register*/ unsigned long outcode = 0L;
 
@@ -103,7 +103,7 @@ face_plane(const real p[3], unsigned long mask)
  */
 
 static inline unsigned long
-bevel_2d(const real p[3], unsigned long mask)
+bevel_2d(const float p[3], unsigned long mask)
 {
     /*register*/ unsigned long outcode = 0L;
 
@@ -125,7 +125,7 @@ bevel_2d(const real p[3], unsigned long mask)
  */
 
 static inline unsigned long
-bevel_3d(const real p[3], unsigned long mask)
+bevel_3d(const float p[3], unsigned long mask)
 {
     /*register*/ unsigned long outcode = 0L;
 
@@ -146,7 +146,7 @@ bevel_3d(const real p[3], unsigned long mask)
  */
 
 extern int
-trivial_vertex_tests(int nverts, const real verts[][3],
+trivial_vertex_tests(int nverts, const float verts[][3],
         int already_know_verts_are_outside_cube)
 {
     /*register*/ unsigned long cum_and;  /* cumulative logical ANDs */
@@ -223,8 +223,8 @@ trivial_vertex_tests(int nverts, const real verts[][3],
  * polygon_intersects_cube().
  */
 extern int
-fast_polygon_intersects_cube(int nverts, const real verts[][3],
-        const real polynormal[3],
+fast_polygon_intersects_cube(int nverts, const float verts[][3],
+        const float polynormal[3],
         int already_know_verts_are_outside_cube,
         int already_know_edges_are_outside_cube)
 {

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/polygon_cube_intersection/polygon_cube_intersection.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/polygon_cube_intersection/polygon_cube_intersection.h
@@ -75,11 +75,6 @@ namespace polygon_cube_intersection
  *                                                                           *
 \* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-
-#ifndef real
-#define real float
-#endif
-
 /*
  *                   POLYGON INTERSECTS CUBE
  *
@@ -114,8 +109,8 @@ namespace polygon_cube_intersection
  * utility instead which combines both of these tests.
  */
 extern SOFA_SOFABASETOPOLOGY_API int
-polygon_intersects_cube(int nverts, const real verts[/* nverts */][3],
-        const real polynormal[3],
+polygon_intersects_cube(int nverts, const float verts[/* nverts */][3],
+        const float polynormal[3],
         int already_know_verts_are_outside_cube,
         int already_know_edges_are_outside_cube);
 
@@ -130,8 +125,8 @@ polygon_intersects_cube(int nverts, const real verts[/* nverts */][3],
  * already_know_verts_are_outside_cube argument.
  */
 extern SOFA_SOFABASETOPOLOGY_API int
-fast_polygon_intersects_cube(int nverts, const real verts[/* nverts */][3],
-        const real polynormal[3],
+fast_polygon_intersects_cube(int nverts, const float verts[/* nverts */][3],
+        const float polynormal[3],
         int already_know_verts_are_outside_cube,
         int already_know_edges_are_outside_cube);
 
@@ -144,7 +139,7 @@ fast_polygon_intersects_cube(int nverts, const real verts[/* nverts */][3],
  * of any testing plane (trivial reject), -1 otherwise (couldn't help).
  */
 extern SOFA_SOFABASETOPOLOGY_API int
-trivial_vertex_tests(int nverts, const real verts[/* nverts */][3],
+trivial_vertex_tests(int nverts, const float verts[/* nverts */][3],
         int already_know_verts_are_outside_cube);
 
 
@@ -155,7 +150,7 @@ trivial_vertex_tests(int nverts, const real verts[/* nverts */][3],
  * centered at the origin, 0 otherwise.
  */
 extern SOFA_SOFABASETOPOLOGY_API int
-segment_intersects_cube(const real v0[3], const real v1[3]);
+segment_intersects_cube(const float v0[3], const float v1[3]);
 
 
 /*
@@ -169,9 +164,9 @@ segment_intersects_cube(const real v0[3], const real v1[3]);
  * it's CCW).
  */
 extern SOFA_SOFABASETOPOLOGY_API int
-polygon_contains_point_3d(int nverts, const real verts[/* nverts */][3],
-        const real polynormal[3],
-        real point[3]);
+polygon_contains_point_3d(int nverts, const float verts[/* nverts */][3],
+        const float polynormal[3],
+        float point[3]);
 
 /*
  *  Calculate a vector perpendicular to a planar polygon.
@@ -184,9 +179,9 @@ polygon_contains_point_3d(int nverts, const real verts[/* nverts */][3],
  *  (see Graphics Gems III) but is slightly more efficient than Newell's
  *  for triangles and quads (slightly less efficient for higher polygons).
  */
-SOFA_SOFABASETOPOLOGY_API real *
-get_polygon_normal(real normal[3],
-        int nverts, const real verts[/* nverts */][3]);
+SOFA_SOFABASETOPOLOGY_API float *
+get_polygon_normal(float normal[3],
+        int nverts, const float verts[/* nverts */][3]);
 
 }
 }


### PR DESCRIPTION
"real" is replaced with its only possible type: float. float is assumed
by SparseGridTopology.cpp. Removing "real" avoids issues when some
templated functions have a template parameter named "real".






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
