### PR TITLE
[SofaMiscMapping] Factorize code to remove duplicated struct

### DIFF
--- a/modules/SofaMiscMapping/CMakeLists.txt
+++ b/modules/SofaMiscMapping/CMakeLists.txt
@@ -19,6 +19,7 @@ list(APPEND HEADER_FILES
     ${SOFAMISCMAPPING_SRC}/BeamLinearMapping.inl
     ${SOFAMISCMAPPING_SRC}/CenterOfMassMapping.h
     ${SOFAMISCMAPPING_SRC}/CenterOfMassMapping.inl
+    ${SOFAMISCMAPPING_SRC}/CenterOfMassMappingOperation.h
     ${SOFAMISCMAPPING_SRC}/CenterOfMassMulti2Mapping.h
     ${SOFAMISCMAPPING_SRC}/CenterOfMassMulti2Mapping.inl
     ${SOFAMISCMAPPING_SRC}/CenterOfMassMultiMapping.h

--- a/modules/SofaMiscMapping/src/SofaMiscMapping/CenterOfMassMappingOperation.h
+++ b/modules/SofaMiscMapping/src/SofaMiscMapping/CenterOfMassMappingOperation.h
@@ -1,0 +1,72 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+namespace sofa::component::mapping {
+
+template<typename Model>
+struct CenterOfMassMappingOperation
+{
+    typedef typename Model::VecCoord VecCoord;
+    typedef typename Model::Coord Coord;
+    typedef typename Model::Deriv Deriv;
+    typedef typename Model::VecDeriv VecDeriv;
+
+public :
+    static inline const VecCoord *getVecCoord(const Model *m, const sofa::core::VecId id) {
+        return m->getVecCoord(id.index);
+    }
+
+    static inline VecDeriv *getVecDeriv(Model *m, const sofa::core::VecId id) { return m->getVecDeriv(id.index); }
+
+    static inline const sofa::core::behavior::BaseMass *fetchMass(const Model *m) {
+        sofa::core::behavior::BaseMass *mass = m->getContext()->getMass();
+        return mass;
+    }
+
+    static inline double computeTotalMass(const Model *model, const sofa::core::behavior::BaseMass *mass) {
+        double result = 0.0;
+        const unsigned int modelSize = static_cast<unsigned int>(model->getSize());
+        for (unsigned int i = 0; i < modelSize; i++) {
+            result += mass->getElementMass(i);
+        }
+        return result;
+    }
+
+    static inline Coord WeightedCoord(const VecCoord *v, const sofa::core::behavior::BaseMass *m) {
+        Coord c;
+        for (unsigned int i = 0; i < v->size(); i++) {
+            c += (*v)[i] * m->getElementMass(i);
+        }
+        return c;
+    }
+
+    static inline Deriv WeightedDeriv(const VecDeriv *v, const sofa::core::behavior::BaseMass *m) {
+        Deriv d;
+        for (unsigned int i = 0; i < v->size(); i++) {
+            d += (*v)[i] * m->getElementMass(i);
+        }
+        return d;
+    }
+};
+
+}

--- a/modules/SofaMiscMapping/src/SofaMiscMapping/CenterOfMassMultiMapping.inl
+++ b/modules/SofaMiscMapping/src/SofaMiscMapping/CenterOfMassMultiMapping.inl
@@ -22,6 +22,8 @@
 #pragma once
 
 #include <SofaMiscMapping/CenterOfMassMultiMapping.h>
+#include <SofaMiscMapping/CenterOfMassMappingOperation.h>
+
 #include <sofa/core/visual/VisualParams.h>
 
 #include <algorithm>
@@ -29,56 +31,6 @@
 
 namespace sofa::component::mapping
 {
-
-template < typename Model >
-struct Operation
-{
-    typedef typename Model::VecCoord VecCoord;
-    typedef typename Model::Coord    Coord;
-    typedef typename Model::Deriv    Deriv;
-    typedef typename Model::VecDeriv VecDeriv;
-
-public :
-    static inline const VecCoord* getVecCoord( const Model* m, const sofa::core::VecId id) { return m->getVecCoord(id.index); }
-    static inline VecDeriv* getVecDeriv( Model* m, const sofa::core::VecId id) { return m->getVecDeriv(id.index);}
-
-    static inline const sofa::core::behavior::BaseMass* fetchMass  ( const Model* m)
-    {
-        sofa::core::behavior::BaseMass* mass = m->getContext()->getMass();
-        return mass;
-    }
-    static inline double computeTotalMass( const Model* model, const sofa::core::behavior::BaseMass* mass )
-    {
-        double result = 0.0;
-        const unsigned int modelSize = static_cast<unsigned int>(model->getSize());
-        for (unsigned int i = 0; i < modelSize; i++)
-        {
-            result += mass->getElementMass(i);
-        }
-        return result;
-    }
-
-    static inline Coord WeightedCoord( const VecCoord* v, const sofa::core::behavior::BaseMass* m)
-    {
-        Coord c;
-        for (unsigned int i=0 ; i< v->size() ; i++)
-        {
-            c += (*v)[i] * m->getElementMass(i);
-        }
-        return c;
-    }
-
-    static inline Deriv WeightedDeriv( const VecDeriv* v, const sofa::core::behavior::BaseMass* m)
-    {
-        Deriv d;
-        for (unsigned int i=0 ; i< v->size() ; i++)
-        {
-            d += (*v)[i] * m->getElementMass(i);
-        }
-        return d;
-    }
-};
-
 
 template <class TIn, class TOut>
 void CenterOfMassMultiMapping< TIn, TOut >::apply(const core::MechanicalParams* mparams, const helper::vector<OutDataVecCoord*>& dataVecOutPos, const helper::vector<const InDataVecCoord*>& dataVecInPos)
@@ -98,7 +50,7 @@ void CenterOfMassMultiMapping< TIn, TOut >::apply(const core::MechanicalParams* 
 
     assert( outPos.size() == 1); // we are dealing with a many to one mapping.
     InCoord COM;
-    std::transform(inPos.begin(), inPos.end(), inputBaseMass.begin(), inputWeightedCOM.begin(), Operation< core::State<In> >::WeightedCoord );
+    std::transform(inPos.begin(), inPos.end(), inputBaseMass.begin(), inputWeightedCOM.begin(), CenterOfMassMappingOperation< core::State<In> >::WeightedCoord );
 
     for( iter_coord iter = inputWeightedCOM.begin() ; iter != inputWeightedCOM.end(); ++iter ) COM += *iter;
     COM *= invTotalMass;
@@ -134,7 +86,7 @@ void CenterOfMassMultiMapping< TIn, TOut >::applyJ(const core::MechanicalParams*
     assert( outDeriv.size() == 1 );
 
     InDeriv Velocity;
-    std::transform(inDeriv.begin(), inDeriv.end(), inputBaseMass.begin(), inputWeightedForce.begin(), Operation<In>::WeightedDeriv );
+    std::transform(inDeriv.begin(), inDeriv.end(), inputBaseMass.begin(), inputWeightedForce.begin(), CenterOfMassMappingOperation<In>::WeightedDeriv );
 
     for ( iter_deriv iter = inputWeightedForce.begin() ; iter != inputWeightedForce.end() ; ++iter ) Velocity += *iter;
     Velocity *= invTotalMass;
@@ -208,9 +160,9 @@ void CenterOfMassMultiMapping< TIn, TOut>::init()
     inputWeightedCOM.resize( this->getFromModels().size() );
     inputWeightedForce.resize( this->getFromModels().size() );
 
-    std::transform(this->getFromModels().begin(), this->getFromModels().end(), inputBaseMass.begin(), Operation< core::State<In> >::fetchMass );
+    std::transform(this->getFromModels().begin(), this->getFromModels().end(), inputBaseMass.begin(), CenterOfMassMappingOperation< core::State<In> >::fetchMass );
 
-    std::transform(this->getFromModels().begin(), this->getFromModels().end(), inputBaseMass.begin(), inputTotalMass.begin(), Operation< core::State<In> >::computeTotalMass );
+    std::transform(this->getFromModels().begin(), this->getFromModels().end(), inputBaseMass.begin(), inputTotalMass.begin(), CenterOfMassMappingOperation< core::State<In> >::computeTotalMass );
 
     invTotalMass = 0.0;
     for ( iter_double iter = inputTotalMass.begin() ; iter != inputTotalMass.end() ; ++ iter )


### PR DESCRIPTION
The struct Operation was defined twice in two different files while
having the same implementation. It can be factorized into a single
implementation. The name Operation has been changed to
CenterOfMassMappingOperation for more clarity.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
