### PR TITLE
[SofaBoundaryCondition] Avoid ambiguity

### DIFF
--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.inl
@@ -100,7 +100,7 @@ void LinearMovementConstraint<DataTypes>::addIndex(Index index)
 template <class DataTypes>
 void LinearMovementConstraint<DataTypes>::removeIndex(Index index)
 {
-    removeValue(*m_indices.beginEdit(),index);
+    sofa::helper::removeValue(*m_indices.beginEdit(),index);
     m_indices.endEdit();
 }
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
@@ -114,7 +114,7 @@ void PartialLinearMovementConstraint<DataTypes>::addIndex(Index index)
 template <class DataTypes>
 void PartialLinearMovementConstraint<DataTypes>::removeIndex(Index index)
 {
-    removeValue(*m_indices.beginEdit(),index);
+    sofa::helper::removeValue(*m_indices.beginEdit(),index);
     m_indices.endEdit();
 }
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PatchTestMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PatchTestMovementConstraint.inl
@@ -100,7 +100,7 @@ void PatchTestMovementConstraint<DataTypes>::addConstraint(Index index)
 template <class DataTypes>
 void PatchTestMovementConstraint<DataTypes>::removeConstraint(Index index)
 {
-    removeValue(*d_indices.beginEdit(),index);
+    sofa::helper::removeValue(*d_indices.beginEdit(),index);
     d_indices.endEdit();
 }
 

--- a/modules/SofaConstraint/src/SofaConstraint/BilateralConstraintResolution.h
+++ b/modules/SofaConstraint/src/SofaConstraint/BilateralConstraintResolution.h
@@ -86,7 +86,7 @@ public:
         temp[2][1] = w[line+2][line+1];
         temp[2][2] = w[line+2][line+2];
 
-        invertMatrix(invW, temp);
+        sofa::type::invertMatrix(invW, temp);
 
         if(_f)
         {


### PR DESCRIPTION
Avoid ambiguity due to the fact that more than one function have the same name



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
