### PR TITLE
[SofaSimulation*] Fix confusion between namespaces

### DIFF
--- a/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/xml/BaseElement.h
+++ b/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/xml/BaseElement.h
@@ -41,7 +41,7 @@ enum IncludeNodeType
     INCLUDE_NODE_MERGE, ///< indicating a node that should be merged with its parent, and any child node with the same name as an existing child should be recursively merged
 };
 
-class SOFA_SOFASIMULATIONCOMMON_API BaseElement : public core::objectmodel::BaseObjectDescription
+class SOFA_SOFASIMULATIONCOMMON_API BaseElement : public sofa::core::objectmodel::BaseObjectDescription
 {
 private:
     std::string basefile;
@@ -63,7 +63,7 @@ public:
     virtual const char* getClass() const = 0;
 
     /// Get the associated object
-    core::objectmodel::Base* getObject() override = 0;
+    sofa::core::objectmodel::Base* getObject() override = 0;
 
     /// Get the node instance name
     std::string getName() override

--- a/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/xml/Element.h
+++ b/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/xml/Element.h
@@ -42,7 +42,7 @@ public:
     virtual void setObject(typename Object::SPtr newObject);
 
     /// Get the associated object
-    core::objectmodel::Base* getObject() override;
+    sofa::core::objectmodel::Base* getObject() override;
 
     typedef helper::Factory< std::string, Object, Element<Object>*, typename Object::SPtr > Factory;
 };

--- a/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/xml/Element.inl
+++ b/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/xml/Element.inl
@@ -51,7 +51,7 @@ void Element<Object>::setObject(typename Object::SPtr newObject)
 
 /// Get the associated object
 template<class Object>
-core::objectmodel::Base* Element<Object>::getObject()
+sofa::core::objectmodel::Base* Element<Object>::getObject()
 {
     return object.get();
 }

--- a/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/xml/NodeElement.h
+++ b/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/xml/NodeElement.h
@@ -28,7 +28,7 @@
 namespace sofa::simulation::xml
 {
 
-class SOFA_SOFASIMULATIONCOMMON_API NodeElement : public Element<core::objectmodel::BaseNode>
+class SOFA_SOFASIMULATIONCOMMON_API NodeElement : public Element<sofa::core::objectmodel::BaseNode>
 {
 public:
     NodeElement(const std::string& name, const std::string& type, BaseElement* parent=nullptr);
@@ -43,7 +43,7 @@ public:
 
     virtual const char* getClass() const;
 
-    typedef Element<core::objectmodel::BaseNode>::Factory Factory;
+    typedef Element<sofa::core::objectmodel::BaseNode>::Factory Factory;
 };
 
 } // namespace sofa::simulation::xml

--- a/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/xml/ObjectElement.h
+++ b/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/xml/ObjectElement.h
@@ -26,7 +26,7 @@
 namespace sofa::simulation::xml
 {
 
-class SOFA_SOFASIMULATIONCOMMON_API ObjectElement : public Element<core::objectmodel::BaseObject>
+class SOFA_SOFASIMULATIONCOMMON_API ObjectElement : public Element<sofa::core::objectmodel::BaseObject>
 {
 public:
     ObjectElement(const std::string& name, const std::string& type, BaseElement* parent=nullptr);

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/BaseSimulationExporter.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/BaseSimulationExporter.cpp
@@ -49,7 +49,7 @@ BaseSimulationExporter::BaseSimulationExporter() :
   , d_isEnabled( initData(&d_isEnabled, true, "enable", "Enable or disable the component. (default=true)"))
 {
     f_listening.setValue(false) ;
-    d_filename.setPathType(core::objectmodel::PathType::BOTH);
+    d_filename.setPathType(sofa::core::objectmodel::PathType::BOTH);
 }
 
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/InitTasks.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/InitTasks.cpp
@@ -25,13 +25,13 @@ namespace sofa
         Task::MemoryAlloc InitPerThreadDataTask::run()
         {
             
-            core::execparams::defaultInstance();
-            
-            core::constraintparams::defaultInstance();
-            
-            core::mechanicalparams::defaultInstance();
-            
-            core::visual::visualparams::defaultInstance();
+            sofa::core::execparams::defaultInstance();
+
+            sofa::core::constraintparams::defaultInstance();
+
+            sofa::core::mechanicalparams::defaultInstance();
+
+            sofa::core::visual::visualparams::defaultInstance();
             
             {
                 // to solve IdFactory<Base>::getID() problem in AdvancedTimer functions

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalComputeEnergyVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalComputeEnergyVisitor.cpp
@@ -28,7 +28,7 @@ namespace simulation
 {
 
 
-MechanicalComputeEnergyVisitor::MechanicalComputeEnergyVisitor(const core::MechanicalParams* mparams)
+MechanicalComputeEnergyVisitor::MechanicalComputeEnergyVisitor(const sofa::core::MechanicalParams* mparams)
     : sofa::simulation::MechanicalVisitor(mparams)
     , m_kineticEnergy(0.)
     , m_potentialEnergy(0.)
@@ -52,13 +52,13 @@ SReal MechanicalComputeEnergyVisitor::getPotentialEnergy()
 
 
 /// Process the BaseMass
-Visitor::Result MechanicalComputeEnergyVisitor::fwdMass(simulation::Node* /*node*/, core::behavior::BaseMass* mass)
+Visitor::Result MechanicalComputeEnergyVisitor::fwdMass(simulation::Node* /*node*/, sofa::core::behavior::BaseMass* mass)
 {
     m_kineticEnergy += (SReal)mass->getKineticEnergy();
     return RESULT_CONTINUE;
 }
 /// Process the BaseForceField
-Visitor::Result MechanicalComputeEnergyVisitor::fwdForceField(simulation::Node* /*node*/, core::behavior::BaseForceField* f)
+Visitor::Result MechanicalComputeEnergyVisitor::fwdForceField(simulation::Node* /*node*/, sofa::core::behavior::BaseForceField* f)
 {
     m_potentialEnergy += (SReal)f->getPotentialEnergy();
     return RESULT_CONTINUE;

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalComputeEnergyVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalComputeEnergyVisitor.h
@@ -41,7 +41,7 @@ class SOFA_SIMULATION_CORE_API MechanicalComputeEnergyVisitor : public sofa::sim
     SReal m_potentialEnergy;
 
 public:
-    MechanicalComputeEnergyVisitor(const core::MechanicalParams* mparams);
+    MechanicalComputeEnergyVisitor(const sofa::core::MechanicalParams* mparams);
 
     ~MechanicalComputeEnergyVisitor() override;
 
@@ -50,10 +50,10 @@ public:
     SReal getPotentialEnergy();
 
     /// Process the BaseMass
-    Result fwdMass(simulation::Node* /*node*/, core::behavior::BaseMass* mass) override;
+    Result fwdMass(simulation::Node* /*node*/, sofa::core::behavior::BaseMass* mass) override;
 
     /// Process the BaseForceField
-    Result fwdForceField(simulation::Node* /*node*/, core::behavior::BaseForceField* f) override;
+    Result fwdForceField(simulation::Node* /*node*/, sofa::core::behavior::BaseForceField* f) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVisitor.h
@@ -68,7 +68,7 @@ protected:
 
 public:
 
-    BaseMechanicalVisitor(const core::ExecParams* params)
+    BaseMechanicalVisitor(const sofa::core::ExecParams* params)
         : Visitor(params)
 		, root(nullptr), rootData(nullptr)
     {
@@ -95,16 +95,16 @@ public:
             *parentData += *nodeData;
     }
 
-    static inline void ForceMaskActivate( const helper::vector<core::behavior::BaseMechanicalState*>& v )
+    static inline void ForceMaskActivate( const helper::vector<sofa::core::behavior::BaseMechanicalState*>& v )
     {
-        std::for_each( v.begin(), v.end(), [](core::behavior::BaseMechanicalState* m) {
+        std::for_each( v.begin(), v.end(), [](sofa::core::behavior::BaseMechanicalState* m) {
             m->forceMask.activate(true);
         });
     }
 
-    static inline void ForceMaskDeactivate( const helper::vector<core::behavior::BaseMechanicalState*>& v)
+    static inline void ForceMaskDeactivate( const helper::vector<sofa::core::behavior::BaseMechanicalState*>& v)
     {
-        std::for_each( v.begin(), v.end(), [](core::behavior::BaseMechanicalState* m) {
+        std::for_each( v.begin(), v.end(), [](sofa::core::behavior::BaseMechanicalState* m) {
             m->forceMask.activate(false);
         });
     }
@@ -130,143 +130,143 @@ public:
     Result processNodeTopDown(simulation::Node* node, LocalStorage* stack) override;
 
     /// Process the OdeSolver
-    virtual Result fwdOdeSolver(simulation::Node* /*node*/, core::behavior::OdeSolver* /*solver*/)
+    virtual Result fwdOdeSolver(simulation::Node* /*node*/, sofa::core::behavior::OdeSolver* /*solver*/)
     {
         return RESULT_CONTINUE;
     }
 
     /// Process the OdeSolver
-    virtual Result fwdOdeSolver(VisitorContext* ctx, core::behavior::OdeSolver* solver)
+    virtual Result fwdOdeSolver(VisitorContext* ctx, sofa::core::behavior::OdeSolver* solver)
     {
         return fwdOdeSolver(ctx->node, solver);
     }
 
     /// Process the ConstraintSolver
-    virtual Result fwdConstraintSolver(simulation::Node* /*node*/, core::behavior::ConstraintSolver* /*solver*/)
+    virtual Result fwdConstraintSolver(simulation::Node* /*node*/, sofa::core::behavior::ConstraintSolver* /*solver*/)
     {
         return RESULT_CONTINUE;
     }
 
     /// Process the ConstraintSolver
-    virtual Result fwdConstraintSolver(VisitorContext* ctx, core::behavior::ConstraintSolver* solver)
+    virtual Result fwdConstraintSolver(VisitorContext* ctx, sofa::core::behavior::ConstraintSolver* solver)
     {
         return fwdConstraintSolver(ctx->node, solver);
     }
 
     /// Process the BaseMechanicalMapping
-    virtual Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/)
+    virtual Result fwdMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* /*map*/)
     {
         return RESULT_CONTINUE;
     }
 
     /// Process the BaseMechanicalMapping
-    virtual Result fwdMechanicalMapping(VisitorContext* ctx, core::BaseMapping* map)
+    virtual Result fwdMechanicalMapping(VisitorContext* ctx, sofa::core::BaseMapping* map)
     {
         return fwdMechanicalMapping(ctx->node, map);
     }
 
     /// Process the BaseMechanicalState if it is mapped from the parent level
-    virtual Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* /*mm*/)
+    virtual Result fwdMappedMechanicalState(simulation::Node* /*node*/, sofa::core::behavior::BaseMechanicalState* /*mm*/)
     {
         return RESULT_CONTINUE;
     }
 
     /// Process the BaseMechanicalState if it is mapped from the parent level
-    virtual Result fwdMappedMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm)
+    virtual Result fwdMappedMechanicalState(VisitorContext* ctx, sofa::core::behavior::BaseMechanicalState* mm)
     {
         return fwdMappedMechanicalState(ctx->node, mm);
     }
 
     /// Process the BaseMechanicalState if it is not mapped from the parent level
-    virtual Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* /*mm*/)
+    virtual Result fwdMechanicalState(simulation::Node* /*node*/, sofa::core::behavior::BaseMechanicalState* /*mm*/)
     {
         return RESULT_CONTINUE;
     }
 
     /// Process the BaseMechanicalState if it is not mapped from the parent level
-    virtual Result fwdMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm)
+    virtual Result fwdMechanicalState(VisitorContext* ctx, sofa::core::behavior::BaseMechanicalState* mm)
     {
         return fwdMechanicalState(ctx->node, mm);
     }
 
     /// Process the BaseMass
-    virtual Result fwdMass(simulation::Node* /*node*/, core::behavior::BaseMass* /*mass*/)
+    virtual Result fwdMass(simulation::Node* /*node*/, sofa::core::behavior::BaseMass* /*mass*/)
     {
         return RESULT_CONTINUE;
     }
 
     /// Process the BaseMass
-    virtual Result fwdMass(VisitorContext* ctx, core::behavior::BaseMass* mass)
+    virtual Result fwdMass(VisitorContext* ctx, sofa::core::behavior::BaseMass* mass)
     {
         return fwdMass(ctx->node, mass);
     }
 
     /// Process all the BaseForceField
-    virtual Result fwdForceField(simulation::Node* /*node*/, core::behavior::BaseForceField* /*ff*/)
+    virtual Result fwdForceField(simulation::Node* /*node*/, sofa::core::behavior::BaseForceField* /*ff*/)
     {
         return RESULT_CONTINUE;
     }
 
 
     /// Process all the BaseForceField
-    virtual Result fwdForceField(VisitorContext* ctx, core::behavior::BaseForceField* ff)
+    virtual Result fwdForceField(VisitorContext* ctx, sofa::core::behavior::BaseForceField* ff)
     {
         return fwdForceField(ctx->node, ff);
     }
 
     /// Process all the InteractionForceField
-    virtual Result fwdInteractionForceField(simulation::Node* node, core::behavior::BaseInteractionForceField* ff)
+    virtual Result fwdInteractionForceField(simulation::Node* node, sofa::core::behavior::BaseInteractionForceField* ff)
     {
         return fwdForceField(node, ff);
     }
 
     /// Process all the InteractionForceField
-    virtual Result fwdInteractionForceField(VisitorContext* ctx, core::behavior::BaseInteractionForceField* ff)
+    virtual Result fwdInteractionForceField(VisitorContext* ctx, sofa::core::behavior::BaseInteractionForceField* ff)
     {
         return fwdInteractionForceField(ctx->node, ff);
     }
 
     /// Process all the BaseProjectiveConstraintSet
-    virtual Result fwdProjectiveConstraintSet(simulation::Node* /*node*/, core::behavior::BaseProjectiveConstraintSet* /*c*/)
+    virtual Result fwdProjectiveConstraintSet(simulation::Node* /*node*/, sofa::core::behavior::BaseProjectiveConstraintSet* /*c*/)
     {
         return RESULT_CONTINUE;
     }
 
     /// Process all the BaseConstraintSet
-    virtual Result fwdConstraintSet(simulation::Node* /*node*/, core::behavior::BaseConstraintSet* /*c*/)
+    virtual Result fwdConstraintSet(simulation::Node* /*node*/,sofa::core::behavior::BaseConstraintSet* /*c*/)
     {
         return RESULT_CONTINUE;
     }
 
     /// Process all the BaseProjectiveConstraintSet
-    virtual Result fwdProjectiveConstraintSet(VisitorContext* ctx, core::behavior::BaseProjectiveConstraintSet* c)
+    virtual Result fwdProjectiveConstraintSet(VisitorContext* ctx,sofa::core::behavior::BaseProjectiveConstraintSet* c)
     {
         return fwdProjectiveConstraintSet(ctx->node, c);
     }
 
     /// Process all the BaseConstraintSet
-    virtual Result fwdConstraintSet(VisitorContext* ctx, core::behavior::BaseConstraintSet* c)
+    virtual Result fwdConstraintSet(VisitorContext* ctx,sofa::core::behavior::BaseConstraintSet* c)
     {
         return fwdConstraintSet(ctx->node, c);
     }
 
     /// Process all the InteractionConstraint
-    virtual Result fwdInteractionProjectiveConstraintSet(simulation::Node* /*node*/, core::behavior::BaseInteractionProjectiveConstraintSet* /*c*/)
+    virtual Result fwdInteractionProjectiveConstraintSet(simulation::Node* /*node*/,sofa::core::behavior::BaseInteractionProjectiveConstraintSet* /*c*/)
     {
         return RESULT_CONTINUE;
     }
 
     /// Process all the InteractionConstraint
-    virtual Result fwdInteractionConstraint(simulation::Node* /*node*/, core::behavior::BaseInteractionConstraint* /*c*/)
+    virtual Result fwdInteractionConstraint(simulation::Node* /*node*/,sofa::core::behavior::BaseInteractionConstraint* /*c*/)
     {
         return RESULT_CONTINUE;
     }
 
     /// Process all the InteractionConstraint
-    virtual Result fwdInteractionProjectiveConstraintSet(VisitorContext* ctx, core::behavior::BaseInteractionProjectiveConstraintSet* c);
+    virtual Result fwdInteractionProjectiveConstraintSet(VisitorContext* ctx,sofa::core::behavior::BaseInteractionProjectiveConstraintSet* c);
 
     /// Process all the InteractionConstraint
-    virtual Result fwdInteractionConstraint(VisitorContext* ctx, core::behavior::BaseInteractionConstraint* c);
+    virtual Result fwdInteractionConstraint(VisitorContext* ctx,sofa::core::behavior::BaseInteractionConstraint* c);
 
     ///@}
 
@@ -287,59 +287,59 @@ public:
     void processNodeBottomUp(simulation::Node* /*node*/, LocalStorage* stack) override;
 
     /// Process the BaseMechanicalState when it is not mapped from parent level
-    virtual void bwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* /*mm*/)
+    virtual void bwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* /*mm*/)
     {}
 
     /// Process the BaseMechanicalState when it is not mapped from parent level
-    virtual void bwdMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm)
+    virtual void bwdMechanicalState(VisitorContext* ctx,sofa::core::behavior::BaseMechanicalState* mm)
     { bwdMechanicalState(ctx->node, mm); }
 
     /// Process the BaseMechanicalState when it is mapped from parent level
-    virtual void bwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* /*mm*/)
+    virtual void bwdMappedMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* /*mm*/)
     {}
 
     /// Process the BaseMechanicalState when it is mapped from parent level
-    virtual void bwdMappedMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm)
+    virtual void bwdMappedMechanicalState(VisitorContext* ctx,sofa::core::behavior::BaseMechanicalState* mm)
     { bwdMappedMechanicalState(ctx->node, mm); }
 
     /// Process the BaseMechanicalMapping
-    virtual void bwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/)
+    virtual void bwdMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* /*map*/)
     {}
 
     /// Process the BaseMechanicalMapping
-    virtual void bwdMechanicalMapping(VisitorContext* ctx, core::BaseMapping* map)
+    virtual void bwdMechanicalMapping(VisitorContext* ctx, sofa::core::BaseMapping* map)
     { bwdMechanicalMapping(ctx->node, map); }
 
     /// Process the OdeSolver
-    virtual void bwdOdeSolver(simulation::Node* /*node*/, core::behavior::OdeSolver* /*solver*/)
+    virtual void bwdOdeSolver(simulation::Node* /*node*/,sofa::core::behavior::OdeSolver* /*solver*/)
     {}
 
     /// Process the OdeSolver
-    virtual void bwdOdeSolver(VisitorContext* ctx, core::behavior::OdeSolver* solver)
+    virtual void bwdOdeSolver(VisitorContext* ctx,sofa::core::behavior::OdeSolver* solver)
     { bwdOdeSolver(ctx->node, solver); }
 
     /// Process the ConstraintSolver
-    virtual void bwdConstraintSolver(simulation::Node* /*node*/, core::behavior::ConstraintSolver* /*solver*/)
+    virtual void bwdConstraintSolver(simulation::Node* /*node*/,sofa::core::behavior::ConstraintSolver* /*solver*/)
     {}
 
     /// Process the ConstraintSolver
-    virtual void bwdConstraintSolver(VisitorContext* ctx, core::behavior::ConstraintSolver* solver)
+    virtual void bwdConstraintSolver(VisitorContext* ctx,sofa::core::behavior::ConstraintSolver* solver)
     { bwdConstraintSolver(ctx->node, solver); }
 
     /// Process all the BaseProjectiveConstraintSet
-    virtual void bwdProjectiveConstraintSet(simulation::Node* /*node*/, core::behavior::BaseProjectiveConstraintSet* /*c*/)
+    virtual void bwdProjectiveConstraintSet(simulation::Node* /*node*/,sofa::core::behavior::BaseProjectiveConstraintSet* /*c*/)
     {}
 
     /// Process all the BaseConstraintSet
-    virtual void bwdConstraintSet(simulation::Node* /*node*/, core::behavior::BaseConstraintSet* /*c*/)
+    virtual void bwdConstraintSet(simulation::Node* /*node*/,sofa::core::behavior::BaseConstraintSet* /*c*/)
     {}
 
     /// Process all the BaseProjectiveConstraintSet
-    virtual void bwdProjectiveConstraintSet(VisitorContext* ctx, core::behavior::BaseProjectiveConstraintSet* c)
+    virtual void bwdProjectiveConstraintSet(VisitorContext* ctx,sofa::core::behavior::BaseProjectiveConstraintSet* c)
     { bwdProjectiveConstraintSet(ctx->node, c); }
 
     /// Process all the BaseConstraintSet
-    virtual void bwdConstraintSet(VisitorContext* ctx, core::behavior::BaseConstraintSet* c)
+    virtual void bwdConstraintSet(VisitorContext* ctx,sofa::core::behavior::BaseConstraintSet* c)
     { bwdConstraintSet(ctx->node, c); }
 
     ///@}
@@ -352,14 +352,14 @@ public:
         return "animate";
     }
 
-    virtual bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map)
+    virtual bool stopAtMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* map)
     {
         return !map->areForcesMapped();
     }
 
 #ifdef SOFA_DUMP_VISITOR_INFO
-    ctime_t begin(simulation::Node* node, core::objectmodel::BaseObject* obj, const std::string &info=std::string("type")) override;
-    void end(simulation::Node* node, core::objectmodel::BaseObject* obj, ctime_t t0) override;
+    ctime_t begin(simulation::Node* node, sofa::core::objectmodel::BaseObject* obj, const std::string &info=std::string("type")) override;
+    void end(simulation::Node* node, sofa::core::objectmodel::BaseObject* obj, ctime_t t0) override;
 #endif
 
 #ifdef SOFA_DUMP_VISITOR_INFO
@@ -368,12 +368,12 @@ public:
     virtual void addWriteVector(core::MultiVecId id) {  writeVector.push_back(id);  }
     virtual void addReadWriteVector(core::MultiVecId id) {  readVector.push_back(core::ConstMultiVecId(id)); writeVector.push_back(id);  }
     void printReadVectors(core::behavior::BaseMechanicalState* mm);
-    void printReadVectors(simulation::Node* node, core::objectmodel::BaseObject* obj);
+    void printReadVectors(simulation::Node* node, sofa::core::objectmodel::BaseObject* obj);
     void printWriteVectors(core::behavior::BaseMechanicalState* mm);
-    void printWriteVectors(simulation::Node* node, core::objectmodel::BaseObject* obj);
+    void printWriteVectors(simulation::Node* node, sofa::core::objectmodel::BaseObject* obj);
 protected:
-    sofa::helper::vector< core::ConstMultiVecId > readVector;
-    sofa::helper::vector< core::MultiVecId > writeVector;
+    sofa::helper::vector< sofa::core::ConstMultiVecId > readVector;
+    sofa::helper::vector< sofa::core::MultiVecId > writeVector;
 #endif
 };
 
@@ -381,11 +381,11 @@ class SOFA_SIMULATION_CORE_API MechanicalVisitor : public BaseMechanicalVisitor
 {
 
 protected:
-    const core::MechanicalParams* mparams;
+    const sofa::core::MechanicalParams* mparams;
 
 public:
 
-    MechanicalVisitor(const core::MechanicalParams* m_mparams)
+    MechanicalVisitor(const sofa::core::MechanicalParams* m_mparams)
         : BaseMechanicalVisitor(sofa::core::mechanicalparams::castToExecParams(m_mparams))
         , mparams(m_mparams)
     {}
@@ -395,7 +395,7 @@ public:
 class SOFA_SIMULATION_CORE_API MechanicalGetDimensionVisitor : public MechanicalVisitor
 {
 public:
-    MechanicalGetDimensionVisitor(const core::MechanicalParams* mparams, SReal* result)
+    MechanicalGetDimensionVisitor(const sofa::core::MechanicalParams* mparams, SReal* result)
         : MechanicalVisitor(mparams)
     {
 #ifdef SOFA_DUMP_VISITOR_INFO
@@ -404,7 +404,7 @@ public:
         rootData = result;
     }
 
-    Result fwdMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(VisitorContext* ctx, sofa::core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
@@ -433,14 +433,14 @@ public:
     typedef std::set<sofa::core::BaseState*> StateSet;
     MyVecId& v;
     StateSet states;
-    MechanicalVAvailVisitor( const core::ExecParams* params, MyVecId& v)
+    MechanicalVAvailVisitor( const sofa::core::ExecParams* params, MyVecId& v)
         : BaseMechanicalVisitor(params), v(v)
     {
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
     }
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
@@ -481,7 +481,7 @@ public:
     /// \param _vDest output vector
     /// \param _vSrc input vector
     /// \param propagate sets to true propagates vector initialization to mapped mechanical states
-    MechanicalVInitVisitor(const core::ExecParams* params, DestMultiVecId _vDest, SrcMultiVecId _vSrc = SrcMultiVecId::null(), bool propagate=false)
+    MechanicalVInitVisitor(const sofa::core::ExecParams* params, DestMultiVecId _vDest, SrcMultiVecId _vSrc = SrcMultiVecId::null(), bool propagate=false)
         : BaseMechanicalVisitor(params)
         , vDest(_vDest)
         , vSrc(_vSrc)
@@ -492,14 +492,14 @@ public:
 #endif
     }
 
-    bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override
+    bool stopAtMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* /*map*/) override
     {
         return false;
     }
 
-    Result fwdMechanicalState(simulation::Node* node, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(simulation::Node* node,sofa::core::behavior::BaseMechanicalState* mm) override;
 
-    Result fwdMappedMechanicalState(simulation::Node* node, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMappedMechanicalState(simulation::Node* node,sofa::core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
@@ -536,14 +536,14 @@ class SOFA_SIMULATION_CORE_API MechanicalVAllocVisitor : public BaseMechanicalVi
 public:
     typedef sofa::core::TMultiVecId<vtype, sofa::core::V_WRITE> MyMultiVecId;
     MyMultiVecId v;
-    MechanicalVAllocVisitor( const core::ExecParams* params, MyMultiVecId v )
+    MechanicalVAllocVisitor( const sofa::core::ExecParams* params, MyMultiVecId v )
         : BaseMechanicalVisitor(params) , v(v)
     {
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
     }
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
@@ -583,7 +583,7 @@ public:
     /// \param _vDest output vector
     /// \param propagate sets to true propagates vector initialization to mapped mechanical states
     /// \param interactionForceField sets to true also initializes external mechanical states linked by an interaction force field
-    MechanicalVReallocVisitor(const core::ExecParams* params, DestMultiVecId *v, bool interactionForceField=false, bool propagate=false)
+    MechanicalVReallocVisitor(const sofa::core::ExecParams* params, DestMultiVecId *v, bool interactionForceField=false, bool propagate=false)
         : BaseMechanicalVisitor(params)
         , v(v)
         , m_propagate(propagate)
@@ -594,16 +594,16 @@ public:
 #endif
     }
 
-    bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override
+    bool stopAtMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* /*map*/) override
     {
         return false;
     }
 
-    Result fwdMechanicalState(simulation::Node* node, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(simulation::Node* node,sofa::core::behavior::BaseMechanicalState* mm) override;
 
-    Result fwdMappedMechanicalState(simulation::Node* node, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMappedMechanicalState(simulation::Node* node,sofa::core::behavior::BaseMechanicalState* mm) override;
 
-    Result fwdInteractionForceField(simulation::Node* node, core::behavior::BaseInteractionForceField* ff) override;
+    Result fwdInteractionForceField(simulation::Node* node,sofa::core::behavior::BaseInteractionForceField* ff) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
@@ -629,7 +629,7 @@ public:
 protected:
 
 
-    MyVecId getId( core::behavior::BaseMechanicalState* mm );
+    MyVecId getId(sofa::core::behavior::BaseMechanicalState* mm );
 };
 
 
@@ -651,9 +651,9 @@ public:
         setReadWriteVectors();
 #endif
     }
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdInteractionForceField(simulation::Node* node, core::behavior::BaseInteractionForceField* ff) override;
+    Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMappedMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdInteractionForceField(simulation::Node* node,sofa::core::behavior::BaseInteractionForceField* ff) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
@@ -693,7 +693,7 @@ public:
     }
 
     // If mapped or only_mapped is ste, this visitor must go through all mechanical mappings, even if isMechanical flag is disabled
-    bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override
+    bool stopAtMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* map) override
     {
         if (mapped || only_mapped)
             return false;
@@ -704,8 +704,8 @@ public:
     MechanicalVOpVisitor& setMapped(bool m = true) { mapped = m; return *this; }
     MechanicalVOpVisitor& setOnlyMapped(bool m = true) { only_mapped = m; return *this; }
 
-    Result fwdMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMappedMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(VisitorContext* ctx,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMappedMechanicalState(VisitorContext* ctx,sofa::core::behavior::BaseMechanicalState* mm) override;
 
     const char* getClassName() const override { return "MechanicalVOpVisitor";}
     virtual std::string getInfos() const override;
@@ -737,7 +737,7 @@ public:
 class SOFA_SIMULATION_CORE_API MechanicalVMultiOpVisitor : public BaseMechanicalVisitor
 {
 public:
-    typedef core::behavior::BaseMechanicalState::VMultiOp VMultiOp;
+    typedef sofa::core::behavior::BaseMechanicalState::VMultiOp VMultiOp;
     bool mapped;
     MechanicalVMultiOpVisitor(const sofa::core::ExecParams* params, const VMultiOp& o)
         : BaseMechanicalVisitor(params), mapped(false), ops(o)
@@ -749,8 +749,8 @@ public:
 
     MechanicalVMultiOpVisitor& setMapped(bool m = true) { mapped = m; return *this; }
 
-    Result fwdMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMappedMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(VisitorContext* ctx,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMappedMechanicalState(VisitorContext* ctx,sofa::core::behavior::BaseMechanicalState* mm) override;
 
     const char* getClassName() const override { return "MechanicalVMultiOpVisitor"; }
     virtual std::string getInfos() const override;
@@ -803,7 +803,7 @@ public:
         rootData = t;
     }
 
-    Result fwdMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(VisitorContext* ctx,sofa::core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
@@ -853,7 +853,7 @@ public:
     }
     SReal getResult() const;
 
-    Result fwdMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(VisitorContext* ctx,sofa::core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
@@ -898,12 +898,12 @@ public:
         setReadWriteVectors();
 #endif
     }
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
-    void bwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* map) override;
+    void bwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
 
     // This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
-    bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override
+    bool stopAtMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* map) override
     {
         if (ignoreFlag)
             return false;
@@ -948,10 +948,10 @@ public:
         setReadWriteVectors();
 #endif
     }
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
-    void bwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMappedMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* map) override;
+    void bwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
@@ -992,10 +992,10 @@ public:
         : MechanicalVisitor(mparams) , x(x), f(f), ignoreMask(m)
     {
     }
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
-    void bwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMappedMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* map) override;
+    void bwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
@@ -1034,16 +1034,16 @@ public:
         setReadWriteVectors();
 #endif
     }
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMass(simulation::Node* /*node*/, core::behavior::BaseMass* mass) override;
+    Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMass(simulation::Node* /*node*/,sofa::core::behavior::BaseMass* mass) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalAddMDxVisitor"; }
     virtual std::string getInfos() const override { std::string name="dx["+dx.getName()+"] in res[" + res.getName()+"]"; return name; }
 
-    Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override;
-    Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* /*mm*/) override;
+    Result fwdMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* /*map*/) override;
+    Result fwdMappedMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* /*mm*/) override;
 
     /// Specify whether this action can be parallelized.
     bool isThreadSafe() const override
@@ -1072,8 +1072,8 @@ public:
         setReadWriteVectors();
 #endif
     }
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMass(simulation::Node* /*node*/, core::behavior::BaseMass* mass) override;
+    Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMass(simulation::Node* /*node*/,sofa::core::behavior::BaseMass* mass) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
@@ -1108,8 +1108,8 @@ public:
 #endif
     }
 
-    Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
-    Result fwdProjectiveConstraintSet(simulation::Node* /*node*/, core::behavior::BaseProjectiveConstraintSet* c) override;
+    Result fwdMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* map) override;
+    Result fwdProjectiveConstraintSet(simulation::Node* /*node*/,sofa::core::behavior::BaseProjectiveConstraintSet* c) override;
 
 
     /// Return a class name for this visitor
@@ -1141,8 +1141,8 @@ public:
 #endif
     }
 
-    Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
-    Result fwdProjectiveConstraintSet(simulation::Node* /*node*/, core::behavior::BaseProjectiveConstraintSet* c) override;
+    Result fwdMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* map) override;
+    Result fwdProjectiveConstraintSet(simulation::Node* /*node*/,sofa::core::behavior::BaseProjectiveConstraintSet* c) override;
 
 
     /// Return a class name for this visitor
@@ -1179,8 +1179,8 @@ public:
 #endif
     }
 
-    Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
-    Result fwdProjectiveConstraintSet(simulation::Node* /*node*/, core::behavior::BaseProjectiveConstraintSet* c) override;
+    Result fwdMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* map) override;
+    Result fwdProjectiveConstraintSet(simulation::Node* /*node*/,sofa::core::behavior::BaseProjectiveConstraintSet* c) override;
 
 
     /// Return a class name for this visitor
@@ -1219,8 +1219,8 @@ public:
 #endif
     }
 
-    Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
-    Result fwdProjectiveConstraintSet(simulation::Node* /*node*/, core::behavior::BaseProjectiveConstraintSet* c) override;
+    Result fwdMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* map) override;
+    Result fwdProjectiveConstraintSet(simulation::Node* /*node*/,sofa::core::behavior::BaseProjectiveConstraintSet* c) override;
 
 
     /// Return a class name for this visitor
@@ -1264,12 +1264,12 @@ public:
     MechanicalPropagateOnlyPositionVisitor( const sofa::core::MechanicalParams* mparams, SReal time=0,
                                         sofa::core::MultiVecCoordId x = sofa::core::VecCoordId::position(), bool m=true);
 
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
-    void bwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* map) override;
+    void bwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
 
     // This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
-    bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override
+    bool stopAtMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* /*map*/) override
     {
         return false; // !map->isMechanical();
     }
@@ -1320,12 +1320,12 @@ public:
                                                   sofa::core::MultiVecCoordId x = sofa::core::VecId::position(), sofa::core::MultiVecDerivId v = sofa::core::VecId::velocity(),
             bool m=true );  
 
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
-    void bwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* map) override;
+    void bwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
 
     // This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
-    bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override
+    bool stopAtMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* /*map*/) override
     {
         return false;
     }
@@ -1370,11 +1370,11 @@ public:
                                        sofa::core::MultiVecDerivId v = sofa::core::VecId::velocity(),
             bool m=true);
 
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
-    void bwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* map) override;
+    void bwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
     // This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
-    bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override
+    bool stopAtMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* /*map*/) override
     {
         return false; // !map->isMechanical();
     }
@@ -1411,7 +1411,7 @@ public:
                                             sofa::core::MultiVecCoordId x = sofa::core::VecCoordId::position(),
                                             sofa::core::MultiVecDerivId v = sofa::core::VecDerivId::velocity());
 
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
@@ -1451,8 +1451,8 @@ public:
         setReadWriteVectors();
 #endif
     }
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMappedMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
@@ -1495,11 +1495,11 @@ public:
         setReadWriteVectors();
 #endif
     }
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdForceField(simulation::Node* /*node*/, core::behavior::BaseForceField* ff) override;
-    void bwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
-    void bwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMappedMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdForceField(simulation::Node* /*node*/,sofa::core::behavior::BaseForceField* ff) override;
+    void bwdMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* map) override;
+    void bwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
 
 
     /// Return a class name for this visitor
@@ -1549,11 +1549,11 @@ public:
         setReadWriteVectors();
 #endif
     }
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdForceField(simulation::Node* /*node*/, core::behavior::BaseForceField* ff) override;
-    void bwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
-    void bwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMappedMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdForceField(simulation::Node* /*node*/,sofa::core::behavior::BaseForceField* ff) override;
+    void bwdMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* map) override;
+    void bwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
@@ -1596,7 +1596,7 @@ public:
         setReadWriteVectors();
 #endif
     }
-    Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
+    Result fwdMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* map) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
@@ -1643,11 +1643,11 @@ public:
         mparamsWithoutStiffness = *mparams;
         mparamsWithoutStiffness.setKFactor(0);
     }
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdForceField(simulation::Node* /*node*/, core::behavior::BaseForceField* ff) override;
-    void bwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
-    void bwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMappedMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdForceField(simulation::Node* /*node*/,sofa::core::behavior::BaseForceField* ff) override;
+    void bwdMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* map) override;
+    void bwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
@@ -1682,12 +1682,12 @@ public:
 #endif
     }
 
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdConstraintSet(simulation::Node* /*node*/, core::behavior::BaseConstraintSet* mm) override;
+    Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMappedMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdConstraintSet(simulation::Node* /*node*/,sofa::core::behavior::BaseConstraintSet* mm) override;
 
     // This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
-    bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override
+    bool stopAtMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* /*map*/) override
     {
         return false; // !map->isMechanical();
     }
@@ -1729,14 +1729,14 @@ public:
 #endif
     }
 
-    const core::ConstraintParams* constraintParams() const { return cparams; }
+    const sofa::core::ConstraintParams* constraintParams() const { return cparams; }
 
-    Result fwdConstraintSet(simulation::Node* /*node*/, core::behavior::BaseConstraintSet* c) override;
+    Result fwdConstraintSet(simulation::Node* /*node*/,sofa::core::behavior::BaseConstraintSet* c) override;
 
-    void bwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
+    void bwdMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* map) override;
 
     /// This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
-    bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override
+    bool stopAtMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* /*map*/) override
     {
         return false; // !map->isMechanical();
     }
@@ -1778,12 +1778,12 @@ public:
 #endif
     }
 
-    const core::ConstraintParams* constraintParams() const { return cparams; }
+    const sofa::core::ConstraintParams* constraintParams() const { return cparams; }
 
-    Result fwdConstraintSet(simulation::Node* /*node*/, core::behavior::BaseConstraintSet* c) override;
+    Result fwdConstraintSet(simulation::Node* /*node*/,sofa::core::behavior::BaseConstraintSet* c) override;
 
     /// This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
-    bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override
+    bool stopAtMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* /*map*/) override
     {
         return false; // !map->isMechanical();
     }
@@ -1825,15 +1825,15 @@ public:
 #endif
     }
 
-    const core::ConstraintParams* constraintParams() const { return cparams; }
+    const sofa::core::ConstraintParams* constraintParams() const { return cparams; }
 
-    void bwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
+    void bwdMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* map) override;
 
     /// Return true to reverse the order of traversal of child nodes
     bool childOrderReversed(simulation::Node* /*node*/) override { return reverseOrder; }
 
     /// This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
-    bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override
+    bool stopAtMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* /*map*/) override
     {
         return false; // !map->isMechanical();
     }
@@ -1876,11 +1876,11 @@ public:
         setReadWriteVectors();
 #endif
     }
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* /*mm*/) override;
-    void bwdProjectiveConstraintSet(simulation::Node* /*node*/, core::behavior::BaseProjectiveConstraintSet* c) override;
+    Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMappedMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* /*mm*/) override;
+    void bwdProjectiveConstraintSet(simulation::Node* /*node*/,sofa::core::behavior::BaseProjectiveConstraintSet* c) override;
     // This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
-    bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override
+    bool stopAtMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* /*map*/) override
     {
         return false;
     }
@@ -1916,14 +1916,14 @@ public:
         setReadWriteVectors();
 #endif
     }
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMappedMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalBeginIntegrationVisitor"; }
 
     // This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
-    bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override
+    bool stopAtMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* /*map*/) override
     {
         return false;
     }
@@ -1953,15 +1953,15 @@ public:
         setReadWriteVectors();
 #endif
     }
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMappedMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalEndIntegrationVisitor"; }
 
     // This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
-    bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override
+    bool stopAtMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* /*map*/) override
     {
         return false;
     }
@@ -1991,9 +1991,9 @@ public:
         setReadWriteVectors();
 #endif
     }
-    Result fwdOdeSolver(simulation::Node* node, core::behavior::OdeSolver* obj) override;
-    Result fwdInteractionForceField(simulation::Node*, core::behavior::BaseInteractionForceField* obj) override;
-    void bwdOdeSolver(simulation::Node* /*node*/, core::behavior::OdeSolver* /*obj*/) override
+    Result fwdOdeSolver(simulation::Node* node,sofa::core::behavior::OdeSolver* obj) override;
+    Result fwdInteractionForceField(simulation::Node*,sofa::core::behavior::BaseInteractionForceField* obj) override;
+    void bwdOdeSolver(simulation::Node* /*node*/,sofa::core::behavior::OdeSolver* /*obj*/) override
     {
     }
 
@@ -2030,9 +2030,9 @@ public:
         setReadWriteVectors();
 #endif
     }
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    void bwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
+    Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMappedMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    void bwdMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* map) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
@@ -2068,7 +2068,7 @@ public:
     }
 
     /// Process the BaseMass
-    Result fwdMass(simulation::Node* /*node*/, core::behavior::BaseMass* mass) override;
+    Result fwdMass(simulation::Node* /*node*/,sofa::core::behavior::BaseMass* mass) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
@@ -2100,9 +2100,9 @@ public:
     {
     }
 
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
-    Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* map) override;
+    Result fwdMappedMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
@@ -2115,7 +2115,7 @@ public:
 #endif
 
     /// get the closest pickable particle
-    void getClosestParticle( core::behavior::BaseMechanicalState*& mstate, sofa::Index& indexCollisionElement, defaulttype::Vector3& point, SReal& rayLength );
+    void getClosestParticle(sofa::core::behavior::BaseMechanicalState*& mstate, sofa::Index& indexCollisionElement, defaulttype::Vector3& point, SReal& rayLength );
 
 
 };
@@ -2139,9 +2139,9 @@ public:
 	{
 	}
 
-	Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
-	Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
-	Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+	Result fwdMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
+	Result fwdMechanicalMapping(simulation::Node* /*node*/, sofa::core::BaseMapping* map) override;
+	Result fwdMappedMechanicalState(simulation::Node* /*node*/,sofa::core::behavior::BaseMechanicalState* mm) override;
 
 	/// Return a class name for this visitor
 	/// Only used for debugging / profiling purposes
@@ -2154,12 +2154,12 @@ public:
 #endif
 
 	/// get the closest pickable particle
-	void getClosestParticle( core::behavior::BaseMechanicalState*& mstate, unsigned int& indexCollisionElement, defaulttype::Vector3& point, SReal& rayLength );
+	void getClosestParticle(sofa::core::behavior::BaseMechanicalState*& mstate, unsigned int& indexCollisionElement, defaulttype::Vector3& point, SReal& rayLength );
 
 private:
 
     // this function checks if the component must be included in the pick process according to its tags
-    bool isComponentTagIncluded(const core::behavior::BaseMechanicalState* mm);
+    bool isComponentTagIncluded(const sofa::core::behavior::BaseMechanicalState* mm);
 
 };
 
@@ -2180,8 +2180,8 @@ public:
 #endif
     }
 
-    Result fwdMechanicalState(simulation::Node*, core::behavior::BaseMechanicalState* mm) override;
-    Result fwdMappedMechanicalState(simulation::Node*, core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMechanicalState(simulation::Node*,sofa::core::behavior::BaseMechanicalState* mm) override;
+    Result fwdMappedMechanicalState(simulation::Node*,sofa::core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/SolveVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/SolveVisitor.cpp
@@ -30,7 +30,7 @@ namespace sofa
 namespace simulation
 {
 
-void SolveVisitor::processSolver(simulation::Node* node, core::behavior::OdeSolver* s)
+void SolveVisitor::processSolver(simulation::Node* node, sofa::core::behavior::OdeSolver* s)
 {
     sofa::helper::AdvancedTimer::stepBegin("Mechanical",node);
     s->solve(params, dt, x, v);

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/SolveVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/SolveVisitor.h
@@ -39,24 +39,26 @@ namespace simulation
 class SOFA_SIMULATION_CORE_API SolveVisitor : public Visitor
 {
 public:
-    SolveVisitor(const sofa::core::ExecParams* params, SReal _dt) : Visitor(params), dt(_dt), x(core::VecCoordId::position()),
-        v(core::VecDerivId::velocity()) {}
+    SolveVisitor(const sofa::core::ExecParams* params, SReal _dt) : Visitor(params), dt(_dt), x(sofa::core::VecCoordId::position()),
+        v(sofa::core::VecDerivId::velocity()) {}
 
     SolveVisitor(const sofa::core::ExecParams* params, SReal _dt, bool free) : Visitor(params), dt(_dt){
-        if(free){
-            x = core::VecCoordId::freePosition();
-            v = core::VecDerivId::freeVelocity();
+        if(free)
+        {
+            x = sofa::core::VecCoordId::freePosition();
+            v = sofa::core::VecDerivId::freeVelocity();
         }
-        else{
-            x = core::VecCoordId::position();
-            v = core::VecDerivId::velocity();
+        else
+        {
+            x = sofa::core::VecCoordId::position();
+            v = sofa::core::VecDerivId::velocity();
         }
     }
 
     SolveVisitor(const sofa::core::ExecParams* params, SReal _dt, sofa::core::MultiVecCoordId X,sofa::core::MultiVecDerivId V) : Visitor(params), dt(_dt),
         x(X),v(V){}
 
-    virtual void processSolver(simulation::Node* node, core::behavior::OdeSolver* b);
+    virtual void processSolver(simulation::Node* node, sofa::core::behavior::OdeSolver* b);
     Result processNodeTopDown(simulation::Node* node) override;
 
     /// Specify whether this action can be parallelized.

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/StateChangeVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/StateChangeVisitor.cpp
@@ -32,12 +32,12 @@ namespace sofa
 namespace simulation
 {
 
-StateChangeVisitor::StateChangeVisitor(const sofa::core::ExecParams* params, core::topology::Topology* source)
+StateChangeVisitor::StateChangeVisitor(const sofa::core::ExecParams* params, sofa::core::topology::Topology* source)
     : Visitor(params), root(true), m_source(source)
 {
 }
 
-void StateChangeVisitor::processStateChange(core::behavior::BaseMechanicalState* obj)
+void StateChangeVisitor::processStateChange(sofa::core::behavior::BaseMechanicalState* obj)
 {
     obj->handleStateChange(m_source);
 }

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/StateChangeVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/StateChangeVisitor.h
@@ -35,9 +35,9 @@ class SOFA_SIMULATION_CORE_API StateChangeVisitor : public Visitor
 {
 
 public:
-    StateChangeVisitor(const sofa::core::ExecParams* params, core::topology::Topology* source);
+    StateChangeVisitor(const sofa::core::ExecParams* params, sofa::core::topology::Topology* source);
 
-    virtual void processStateChange(core::behavior::BaseMechanicalState* obj);
+    virtual void processStateChange(sofa::core::behavior::BaseMechanicalState* obj);
 
     Result processNodeTopDown(simulation::Node* node) override;
 
@@ -51,7 +51,7 @@ public:
 
 protected:
     bool root;
-    core::topology::Topology* m_source;
+    sofa::core::topology::Topology* m_source;
 };
 
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/TopologyChangeVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/TopologyChangeVisitor.cpp
@@ -40,7 +40,7 @@ using namespace sofa::core::topology;
 using namespace sofa::core;
 
 
-TopologyChangeVisitor::TopologyChangeVisitor(const sofa::core::ExecParams* params, core::topology::Topology* source)
+TopologyChangeVisitor::TopologyChangeVisitor(const sofa::core::ExecParams* params, sofa::core::topology::Topology* source)
     : Visitor(params)
     , m_source(source)
 {
@@ -52,7 +52,7 @@ std::string TopologyChangeVisitor::getInfos() const
     return "Topology:" + m_source->getName();
 }
 
-void TopologyChangeVisitor::processTopologyChange(simulation::Node *node, core::objectmodel::BaseObject* obj)
+void TopologyChangeVisitor::processTopologyChange(simulation::Node *node, sofa::core::objectmodel::BaseObject* obj)
 {
 #ifdef SOFA_DUMP_VISITOR_INFO
     simulation::Visitor::printComment("processTopologyChange");

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/TopologyChangeVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/TopologyChangeVisitor.h
@@ -34,11 +34,11 @@ class SOFA_SIMULATION_CORE_API TopologyChangeVisitor : public Visitor
 {
 
 public:
-    TopologyChangeVisitor(const sofa::core::ExecParams* params, core::topology::Topology* source);
+    TopologyChangeVisitor(const sofa::core::ExecParams* params, sofa::core::topology::Topology* source);
 
     ~TopologyChangeVisitor() override {}
 
-    virtual void processTopologyChange(simulation::Node* node, core::objectmodel::BaseObject* obj);
+    virtual void processTopologyChange(simulation::Node* node, sofa::core::objectmodel::BaseObject* obj);
 
     Result processNodeTopDown(simulation::Node* node) override;
     void processNodeBottomUp(simulation::Node* node) override;
@@ -52,7 +52,7 @@ public:
     const char* getClassName() const override { return "TopologyChangeVisitor"; }
     std::string getInfos() const override;
 protected:
-    core::topology::Topology* m_source;
+    sofa::core::topology::Topology* m_source;
 };
 
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Visitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Visitor.h
@@ -62,7 +62,7 @@ public:
     Visitor(const sofa::core::ExecParams* params);
     virtual ~Visitor();
 
-    const core::ExecParams* execParams() const { return params; }
+    const sofa::core::ExecParams* execParams() const { return params; }
 
     enum Result { RESULT_CONTINUE, RESULT_PRUNE };
 
@@ -95,11 +95,11 @@ public:
     virtual std::string getInfos() const { return ""; }
 
 #ifdef SOFA_VERBOSE_TRAVERSAL
-    void debug_write_state_before( core::objectmodel::BaseObject* obj ) ;
-    void debug_write_state_after( core::objectmodel::BaseObject* obj ) ;
+    void debug_write_state_before( sofa::core::objectmodel::BaseObject* obj ) ;
+    void debug_write_state_after( sofa::core::objectmodel::BaseObject* obj ) ;
 #else
-    inline void debug_write_state_before( core::objectmodel::BaseObject*  ) {}
-    inline void debug_write_state_after( core::objectmodel::BaseObject*  ) {}
+    inline void debug_write_state_before( sofa::core::objectmodel::BaseObject*  ) {}
+    inline void debug_write_state_after( sofa::core::objectmodel::BaseObject*  ) {}
 #endif
 
     /// Helper method to enumerate objects in the given list. The callback gets the pointer to node
@@ -145,20 +145,20 @@ public:
     //method to compare the tags of the objet with the ones of the visitor
     // return true if the object has all the tags of the visitor
     // or if no tag is set to the visitor
-    bool testTags(core::objectmodel::BaseObject* obj);
+    bool testTags(sofa::core::objectmodel::BaseObject* obj);
 
     /// Alias for context->executeVisitor(this)
-    virtual void execute(core::objectmodel::BaseContext* node, bool precomputedOrder=false);
+    virtual void execute(sofa::core::objectmodel::BaseContext* node, bool precomputedOrder=false);
 
-    virtual ctime_t begin(simulation::Node* node, core::objectmodel::BaseObject* obj
+    virtual ctime_t begin(simulation::Node* node, sofa::core::objectmodel::BaseObject* obj
             , const std::string &typeInfo=std::string("type")
                          );
 
-    virtual void end(simulation::Node* node, core::objectmodel::BaseObject* obj, ctime_t t0);
-    ctime_t begin(simulation::Visitor::VisitorContext* node, core::objectmodel::BaseObject* obj
+    virtual void end(simulation::Node* node, sofa::core::objectmodel::BaseObject* obj, ctime_t t0);
+    ctime_t begin(simulation::Visitor::VisitorContext* node, sofa::core::objectmodel::BaseObject* obj
             , const std::string &typeInfo=std::string("type")
                  );
-    void end(simulation::Visitor::VisitorContext* node, core::objectmodel::BaseObject* obj, ctime_t t0);
+    void end(simulation::Visitor::VisitorContext* node, sofa::core::objectmodel::BaseObject* obj, ctime_t t0);
 
     /// Specify whether this visitor can be parallelized.
     virtual bool isThreadSafe() const { return false; }
@@ -185,7 +185,7 @@ public:
 	bool canAccessSleepingNode;
 
 protected:
-    const core::ExecParams* params;
+    const sofa::core::ExecParams* params;
 
 
 #ifdef SOFA_DUMP_VISITOR_INFO

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/XMLPrintVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/XMLPrintVisitor.h
@@ -49,7 +49,7 @@ public:
     template<class Seq>
     void processObjects(Seq& list);
 
-    void processBaseObject(core::objectmodel::BaseObject* obj);
+    void processBaseObject(sofa::core::objectmodel::BaseObject* obj);
 
     Result processNodeTopDown(simulation::Node* node) override;
     void processNodeBottomUp(simulation::Node* node) override;

--- a/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/DAGNode.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/DAGNode.cpp
@@ -58,7 +58,7 @@ protected:
 GetDownObjectsVisitor::GetDownObjectsVisitor(const sofa::core::objectmodel::ClassInfo& class_info,
                                              DAGNode::GetObjectsCallBack& container,
                                              const sofa::core::objectmodel::TagSet& tags)
-    : Visitor( core::execparams::defaultInstance() )
+    : Visitor( sofa::core::execparams::defaultInstance() )
     , _class_info(class_info)
     , _container(container)
     , _tags(tags)
@@ -110,7 +110,7 @@ GetUpObjectsVisitor::GetUpObjectsVisitor(DAGNode* searchNode,
                                          const sofa::core::objectmodel::ClassInfo& class_info,
                                          DAGNode::GetObjectsCallBack& container,
                                          const sofa::core::objectmodel::TagSet& tags)
-    : Visitor( core::execparams::defaultInstance() )
+    : Visitor( sofa::core::execparams::defaultInstance() )
     , _searchNode( searchNode )
     , _class_info(class_info)
     , _container(container)
@@ -240,7 +240,7 @@ void* DAGNode::getObject(const sofa::core::objectmodel::ClassInfo& class_info, c
     if (dir != SearchParents)
         for (ObjectIterator it = this->object.begin(); it != this->object.end(); ++it)
         {
-            core::objectmodel::BaseObject* obj = it->get();
+            sofa::core::objectmodel::BaseObject* obj = it->get();
             if (tags.empty() || (obj)->getTags().includes(tags))
             {
 
@@ -345,7 +345,7 @@ void* DAGNode::getObject(const sofa::core::objectmodel::ClassInfo& class_info, c
         }
         else
         {
-            core::objectmodel::BaseObject* obj = simulation::Node::getObject(name);
+            sofa::core::objectmodel::BaseObject* obj = simulation::Node::getObject(name);
             if (obj == nullptr)
             {
                 return nullptr;
@@ -415,7 +415,7 @@ void DAGNode::getObjects(const sofa::core::objectmodel::ClassInfo& class_info, G
 }
 
 /// Get a list of parent node
-core::objectmodel::BaseNode::Parents DAGNode::getParents() const
+sofa::core::objectmodel::BaseNode::Parents DAGNode::getParents() const
 {
     Parents p;
 
@@ -434,7 +434,7 @@ size_t DAGNode::getNbParents() const
 }
 
 /// return the first parent (returns nullptr if no parent)
-core::objectmodel::BaseNode* DAGNode::getFirstParent() const
+sofa::core::objectmodel::BaseNode* DAGNode::getFirstParent() const
 {
     const LinkParents::Container& parents = l_parents.getValue();
     if( parents.empty() ) return nullptr;
@@ -482,7 +482,7 @@ bool DAGNode::hasAncestor(const BaseContext* context) const
 
 /// Mesh Topology that is relevant for this context
 /// (within it or its parents until a mapping is reached that does not preserve topologies).
-core::topology::BaseMeshTopology* DAGNode::getMeshTopologyLink(SearchDirection dir) const
+sofa::core::topology::BaseMeshTopology* DAGNode::getMeshTopologyLink(SearchDirection dir) const
 {
     if (this->meshTopology)
         return this->meshTopology;
@@ -497,7 +497,7 @@ core::topology::BaseMeshTopology* DAGNode::getMeshTopologyLink(SearchDirection d
     {
         return nullptr;
     }
-    for ( Sequence<core::BaseMapping>::iterator i=this->mapping.begin(), iend=this->mapping.end(); i!=iend; ++i )
+    for ( Sequence<sofa::core::BaseMapping>::iterator i=this->mapping.begin(), iend=this->mapping.end(); i!=iend; ++i )
     {
         if (!(*i)->sameTopology())
         {
@@ -511,7 +511,7 @@ core::topology::BaseMeshTopology* DAGNode::getMeshTopologyLink(SearchDirection d
         // if the visitor is run from a sub-graph containing a multinode linked with a node outside of the subgraph, do not consider the outside node by looking on the sub-graph descendancy
         if ( parents[i] )
         {
-            core::topology::BaseMeshTopology* res = parents[i]->getMeshTopologyLink(Local);
+            sofa::core::topology::BaseMeshTopology* res = parents[i]->getMeshTopologyLink(Local);
             if (res)
                 return res;
         }
@@ -520,14 +520,14 @@ core::topology::BaseMeshTopology* DAGNode::getMeshTopologyLink(SearchDirection d
 }
 
 
-void DAGNode::precomputeTraversalOrder( const core::ExecParams* params )
+void DAGNode::precomputeTraversalOrder( const sofa::core::ExecParams* params )
 {
     // acumulating traversed Nodes
     class TraversalOrderVisitor : public Visitor
     {
         NodeList& _orderList;
     public:
-        TraversalOrderVisitor(const core::ExecParams* params, NodeList& orderList )
+        TraversalOrderVisitor(const sofa::core::ExecParams* params, NodeList& orderList )
             : Visitor(params)
             , _orderList( orderList )
         {
@@ -792,7 +792,7 @@ void DAGNode::initVisualContext()
 
 void DAGNode::updateContext()
 {
-    core::objectmodel::BaseNode* firstParent = getFirstParent();
+    sofa::core::objectmodel::BaseNode* firstParent = getFirstParent();
 
     if ( firstParent )
     {
@@ -809,7 +809,7 @@ void DAGNode::updateContext()
 
 void DAGNode::updateSimulationContext()
 {
-    core::objectmodel::BaseNode* firstParent = getFirstParent();
+    sofa::core::objectmodel::BaseNode* firstParent = getFirstParent();
 
     if ( firstParent )
     {
@@ -854,7 +854,7 @@ void DAGNode::getLocalObjects( const sofa::core::objectmodel::ClassInfo& class_i
 {
     for (DAGNode::ObjectIterator it = this->object.begin(); it != this->object.end(); ++it)
     {
-        core::objectmodel::BaseObject* obj = it->get();
+        sofa::core::objectmodel::BaseObject* obj = it->get();
         void* result = class_info.dynamicCast(obj);
         if (result != nullptr && (tags.empty() || (obj)->getTags().includes(tags)))
             container(result);

--- a/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/DAGNode.h
+++ b/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/DAGNode.h
@@ -104,7 +104,7 @@ public:
 
     /// Mesh Topology that is relevant for this context
     /// (within it or its parents until a mapping is reached that does not preserve topologies).
-    core::topology::BaseMeshTopology* getMeshTopologyLink(SearchDirection dir = SearchUp) const override;
+    sofa::core::topology::BaseMeshTopology* getMeshTopologyLink(SearchDirection dir = SearchUp) const override;
 
 
     /// Called during initialization to corectly propagate the visual context to the children
@@ -116,7 +116,7 @@ public:
     /// Update the simulation context values(gravity, time...), based on parent and local ContextObjects
     void updateSimulationContext() override;
 
-    static DAGNode::SPtr create(DAGNode*, core::objectmodel::BaseObjectDescription* arg)
+    static DAGNode::SPtr create(DAGNode*, sofa::core::objectmodel::BaseObjectDescription* arg)
     {
         DAGNode::SPtr obj = DAGNode::SPtr();
         obj->parse(arg);
@@ -130,7 +130,7 @@ public:
     Node* findCommonParent( Node* node2 ) override;
 
     /// compute the traversal order from this Node
-    void precomputeTraversalOrder( const core::ExecParams* params ) override;
+    void precomputeTraversalOrder( const sofa::core::ExecParams* params ) override;
 
     virtual void moveChild(BaseNode::SPtr node) override;
 


### PR DESCRIPTION
sofa::core can be confused with sofa::simulation::core, so I added sofa:: in front of core namespace

This confusion arose when compiling using a jumbo build.




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
