### PR TITLE
[SofaSimulationCore] Add boolean variables to the base class BaseMech…

### DIFF
--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalComputeEnergyVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalComputeEnergyVisitor.cpp
@@ -33,6 +33,8 @@ MechanicalComputeEnergyVisitor::MechanicalComputeEnergyVisitor(const core::Mecha
     , m_kineticEnergy(0.)
     , m_potentialEnergy(0.)
 {
+    applyFwdMass = true;
+    applyFwdForceField = true;
 }
 
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalGetMomentumVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalGetMomentumVisitor.h
@@ -42,7 +42,9 @@ class MechanicalGetMomentumVisitor : public sofa::simulation::MechanicalVisitor
 public:
     MechanicalGetMomentumVisitor(const core::MechanicalParams* mparams)
         : sofa::simulation::MechanicalVisitor(mparams)
-    {}
+    {
+        applyFwdMass = true;
+    }
 
     const defaulttype::Vector6& getMomentum() const { return m_momenta; }
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalMatrixVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalMatrixVisitor.h
@@ -61,7 +61,11 @@ public:
         const core::ExecParams* params, sofa::Size* const _nbRow, sofa::Size* const _nbCol,
         sofa::core::behavior::MultiMatrixAccessor* _matrix = nullptr )
         : BaseMechanicalVisitor(params) , nbRow(_nbRow), nbCol(_nbCol), matrix(_matrix)
-    {}
+    {
+        applyFwdMechanicalState = true;
+        applyFwdMechanicalMapping = true;
+        applyFwdMappedMechanicalState = true;
+    }
 
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* ms) override
     {
@@ -103,7 +107,9 @@ public:
     MechanicalGetConstraintJacobianVisitor(
         const core::ConstraintParams* cparams, defaulttype::BaseMatrix * _J, const sofa::core::behavior::MultiMatrixAccessor* _matrix = nullptr)
         : BaseMechanicalVisitor(cparams) , cparams(cparams), J(_J), matrix(_matrix), offset(0)
-    {}
+    {
+        applyFwdMechanicalState = true;
+    }
 
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* ms) override
     {
@@ -153,7 +159,9 @@ public:
         ,vId(v)
         ,matrix(_matrix)
         ,offset(0)
-    {}
+    {
+        applyFwdMechanicalState = true;
+    }
 
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* ms) override
     {
@@ -200,6 +208,8 @@ public:
     MechanicalAddMBK_ToMatrixVisitor(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* _matrix )
         : MechanicalVisitor(mparams) ,  matrix(_matrix) //,m(_m),b(_b),k(_k)
     {
+        applyFwdMechanicalState = true;
+        applyFwdForceField = true;
     }
 
     /// Return a class name for this visitor
@@ -240,6 +250,8 @@ public:
     MechanicalAddSubMBK_ToMatrixVisitor(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* _matrix, const helper::vector<unsigned> & Id)
         : MechanicalVisitor(mparams) ,  matrix(_matrix), subMatrixIndex(Id) //,m(_m),b(_b),k(_k)
     {
+        applyFwdMechanicalState = true;
+        applyFwdForceField = true;
     }
 
     /// Return a class name for this visitor
@@ -275,6 +287,8 @@ public:
     MechanicalApplyProjectiveConstraint_ToMatrixVisitor(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* _matrix )
         : MechanicalVisitor(mparams) ,  matrix(_matrix) //,m(_m),b(_b),k(_k)
     {
+        applyFwdMechanicalState = true;
+        applyFwdProjectiveConstraintSet = true;
     }
 
     /// Return a class name for this visitor
@@ -286,7 +300,7 @@ public:
         //ms->setOffset(offsetOnExit);
         return RESULT_CONTINUE;
     }
-    
+
     Result fwdProjectiveConstraintSet(simulation::Node* /*node*/, core::behavior::BaseProjectiveConstraintSet* c) override
     {
         if (matrix != nullptr)
@@ -316,6 +330,7 @@ public:
         const sofa::core::behavior::MultiMatrixAccessor* _matrix = nullptr )
         : BaseMechanicalVisitor(params) , src(_src), vect(_vect), matrix(_matrix), offset(0)
     {
+        applyFwdMechanicalState = true;
     }
 
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override
@@ -349,6 +364,7 @@ public:
         const sofa::core::behavior::MultiMatrixAccessor* _matrix = nullptr )
         : BaseMechanicalVisitor(params) , src(_src), dest(_dest), matrix(_matrix), offset(0)
     {
+        applyFwdMechanicalState = true;
     }
 
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override
@@ -384,6 +400,7 @@ public:
         const sofa::core::behavior::MultiMatrixAccessor* _matrix = nullptr )
         : BaseMechanicalVisitor(params) , src(_src), dest(_dest), matrix(_matrix), offset(0)
     {
+        applyFwdMechanicalState = true;
     }
 
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVisitor.h
@@ -49,12 +49,14 @@ namespace simulation
 /** Base class for easily creating new actions for mechanical simulation.
 
 During the first traversal (top-down), method processNodeTopDown(simulation::Node*) is applied to each simulation::Node.
-Each component attached to this node is processed using the appropriate method, prefixed by fwd.
+Each component attached to this node is processed using the appropriate method, prefixed by fwd, only if the
+corresponding applyFwd* boolean is true.
 During the second traversal (bottom-up), method processNodeBottomUp(simulation::Node*) is applied to each simulation::Node.
-Each component attached to this node is processed using the appropriate method, prefixed by bwd.
+Each component attached to this node is processed using the appropriate method, prefixed by bwd, only if the
+corresponding applyBwd* boolean is true.
 The default behavior of the fwd* and bwd* is to do nothing.
 Derived actions typically overload these methods to implement the desired processing.
-
+If a derived class overloads these methods, it must usually also set the corresponding applyFwd* and applyBwd* variables to true
 */
 class SOFA_SIMULATION_CORE_API BaseMechanicalVisitor : public Visitor
 {
@@ -141,6 +143,8 @@ public:
         return fwdOdeSolver(ctx->node, solver);
     }
 
+    bool applyFwdOdeSolver { false };
+
     /// Process the ConstraintSolver
     virtual Result fwdConstraintSolver(simulation::Node* /*node*/, core::behavior::ConstraintSolver* /*solver*/)
     {
@@ -152,6 +156,8 @@ public:
     {
         return fwdConstraintSolver(ctx->node, solver);
     }
+
+    bool applyFwdConstraintSolver { false };
 
     /// Process the BaseMechanicalMapping
     virtual Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/)
@@ -165,6 +171,8 @@ public:
         return fwdMechanicalMapping(ctx->node, map);
     }
 
+    bool applyFwdMechanicalMapping { false };
+
     /// Process the BaseMechanicalState if it is mapped from the parent level
     virtual Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* /*mm*/)
     {
@@ -176,6 +184,8 @@ public:
     {
         return fwdMappedMechanicalState(ctx->node, mm);
     }
+
+    bool applyFwdMappedMechanicalState { false };
 
     /// Process the BaseMechanicalState if it is not mapped from the parent level
     virtual Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* /*mm*/)
@@ -189,6 +199,8 @@ public:
         return fwdMechanicalState(ctx->node, mm);
     }
 
+    bool applyFwdMechanicalState { false };
+
     /// Process the BaseMass
     virtual Result fwdMass(simulation::Node* /*node*/, core::behavior::BaseMass* /*mass*/)
     {
@@ -201,18 +213,21 @@ public:
         return fwdMass(ctx->node, mass);
     }
 
+    bool applyFwdMass { false };
+
     /// Process all the BaseForceField
     virtual Result fwdForceField(simulation::Node* /*node*/, core::behavior::BaseForceField* /*ff*/)
     {
         return RESULT_CONTINUE;
     }
 
-
     /// Process all the BaseForceField
     virtual Result fwdForceField(VisitorContext* ctx, core::behavior::BaseForceField* ff)
     {
         return fwdForceField(ctx->node, ff);
     }
+
+    bool applyFwdForceField { false };
 
     /// Process all the InteractionForceField
     virtual Result fwdInteractionForceField(simulation::Node* node, core::behavior::BaseInteractionForceField* ff)
@@ -226,17 +241,23 @@ public:
         return fwdInteractionForceField(ctx->node, ff);
     }
 
+    bool applyFwdInteractionForceField { false };
+
     /// Process all the BaseProjectiveConstraintSet
     virtual Result fwdProjectiveConstraintSet(simulation::Node* /*node*/, core::behavior::BaseProjectiveConstraintSet* /*c*/)
     {
         return RESULT_CONTINUE;
     }
 
+    bool applyFwdProjectiveConstraintSet { false };
+
     /// Process all the BaseConstraintSet
     virtual Result fwdConstraintSet(simulation::Node* /*node*/, core::behavior::BaseConstraintSet* /*c*/)
     {
         return RESULT_CONTINUE;
     }
+
+    bool applyFwdConstraintSet { false };
 
     /// Process all the BaseProjectiveConstraintSet
     virtual Result fwdProjectiveConstraintSet(VisitorContext* ctx, core::behavior::BaseProjectiveConstraintSet* c)
@@ -256,11 +277,15 @@ public:
         return RESULT_CONTINUE;
     }
 
+    bool applyFwdInteractionProjectiveConstraintSet { false };
+
     /// Process all the InteractionConstraint
     virtual Result fwdInteractionConstraint(simulation::Node* /*node*/, core::behavior::BaseInteractionConstraint* /*c*/)
     {
         return RESULT_CONTINUE;
     }
+
+    bool applyFwdInteractionConstraint { false };
 
     /// Process all the InteractionConstraint
     virtual Result fwdInteractionProjectiveConstraintSet(VisitorContext* ctx, core::behavior::BaseInteractionProjectiveConstraintSet* c);
@@ -294,6 +319,8 @@ public:
     virtual void bwdMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm)
     { bwdMechanicalState(ctx->node, mm); }
 
+    bool applyBwdMechanicalState { false };
+
     /// Process the BaseMechanicalState when it is mapped from parent level
     virtual void bwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* /*mm*/)
     {}
@@ -301,6 +328,8 @@ public:
     /// Process the BaseMechanicalState when it is mapped from parent level
     virtual void bwdMappedMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm)
     { bwdMappedMechanicalState(ctx->node, mm); }
+
+    bool applyBwdMappedMechanicalState { false };
 
     /// Process the BaseMechanicalMapping
     virtual void bwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/)
@@ -310,6 +339,8 @@ public:
     virtual void bwdMechanicalMapping(VisitorContext* ctx, core::BaseMapping* map)
     { bwdMechanicalMapping(ctx->node, map); }
 
+    bool applyBwdMechanicalMapping { false };
+
     /// Process the OdeSolver
     virtual void bwdOdeSolver(simulation::Node* /*node*/, core::behavior::OdeSolver* /*solver*/)
     {}
@@ -317,6 +348,8 @@ public:
     /// Process the OdeSolver
     virtual void bwdOdeSolver(VisitorContext* ctx, core::behavior::OdeSolver* solver)
     { bwdOdeSolver(ctx->node, solver); }
+
+    bool applyBwdOdeSolver { false };
 
     /// Process the ConstraintSolver
     virtual void bwdConstraintSolver(simulation::Node* /*node*/, core::behavior::ConstraintSolver* /*solver*/)
@@ -326,13 +359,19 @@ public:
     virtual void bwdConstraintSolver(VisitorContext* ctx, core::behavior::ConstraintSolver* solver)
     { bwdConstraintSolver(ctx->node, solver); }
 
+    bool applyBwdConstraintSolver { false };
+
     /// Process all the BaseProjectiveConstraintSet
     virtual void bwdProjectiveConstraintSet(simulation::Node* /*node*/, core::behavior::BaseProjectiveConstraintSet* /*c*/)
     {}
 
+    bool applyBwdProjectiveConstraintSet { false };
+
     /// Process all the BaseConstraintSet
     virtual void bwdConstraintSet(simulation::Node* /*node*/, core::behavior::BaseConstraintSet* /*c*/)
     {}
+
+    bool applyBwdConstraintSet { false };
 
     /// Process all the BaseProjectiveConstraintSet
     virtual void bwdProjectiveConstraintSet(VisitorContext* ctx, core::behavior::BaseProjectiveConstraintSet* c)
@@ -402,6 +441,7 @@ public:
         setReadWriteVectors();
 #endif
         rootData = result;
+        applyFwdMechanicalState = true;
     }
 
     Result fwdMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm) override;
@@ -439,6 +479,7 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
     }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
 
@@ -490,6 +531,8 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
+        applyFwdMappedMechanicalState = true;
     }
 
     bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override
@@ -542,6 +585,7 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
     }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
 
@@ -592,6 +636,9 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
+        applyFwdMappedMechanicalState = true;
+        applyFwdInteractionForceField = true;
     }
 
     bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override
@@ -650,6 +697,9 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
+        applyFwdMappedMechanicalState = true;
+        applyFwdInteractionForceField = true;
     }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
@@ -690,6 +740,8 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
+        applyFwdMappedMechanicalState = true;
     }
 
     // If mapped or only_mapped is ste, this visitor must go through all mechanical mappings, even if isMechanical flag is disabled
@@ -745,6 +797,8 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
+        applyFwdMappedMechanicalState = true;
     }
 
     MechanicalVMultiOpVisitor& setMapped(bool m = true) { mapped = m; return *this; }
@@ -801,6 +855,7 @@ public:
         setReadWriteVectors();
 #endif
         rootData = t;
+        applyFwdMechanicalState = true;
     }
 
     Result fwdMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm) override;
@@ -850,6 +905,7 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
     }
     SReal getResult() const;
 
@@ -897,6 +953,9 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
+        applyFwdMechanicalMapping = true;
+        applyBwdMechanicalState = true;
     }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
     Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
@@ -947,6 +1006,10 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
+        applyFwdMappedMechanicalState = true;
+        applyFwdMechanicalMapping = true;
+        applyBwdMechanicalState = true;
     }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
@@ -991,6 +1054,10 @@ public:
                                                     sofa::core::MultiVecCoordId x, sofa::core::MultiVecDerivId f, bool m)
         : MechanicalVisitor(mparams) , x(x), f(f), ignoreMask(m)
     {
+        applyFwdMechanicalState = true;
+        applyFwdMappedMechanicalState = true;
+        applyFwdMechanicalMapping = true;
+        applyBwdMechanicalState = true;
     }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
@@ -1033,6 +1100,10 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
+        applyFwdMass = true;
+        applyFwdMechanicalMapping = true;
+        applyFwdMappedMechanicalState = true;
     }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
     Result fwdMass(simulation::Node* /*node*/, core::behavior::BaseMass* mass) override;
@@ -1071,6 +1142,8 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
+        applyFwdMass = true;
     }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
     Result fwdMass(simulation::Node* /*node*/, core::behavior::BaseMass* mass) override;
@@ -1106,6 +1179,8 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalMapping = true;
+        applyFwdProjectiveConstraintSet = true;
     }
 
     Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
@@ -1139,6 +1214,8 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalMapping = true;
+        applyFwdProjectiveConstraintSet = true;
     }
 
     Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
@@ -1177,6 +1254,8 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalMapping = true;
+        applyFwdProjectiveConstraintSet = true;
     }
 
     Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
@@ -1217,6 +1296,8 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalMapping = true;
+        applyFwdProjectiveConstraintSet = true;
     }
 
     Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
@@ -1318,7 +1399,7 @@ public:
 
     MechanicalPropagateOnlyPositionAndVelocityVisitor(const sofa::core::MechanicalParams* mparams, SReal time=0,
                                                   sofa::core::MultiVecCoordId x = sofa::core::VecId::position(), sofa::core::MultiVecDerivId v = sofa::core::VecId::velocity(),
-            bool m=true );  
+            bool m=true );
 
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
     Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
@@ -1364,8 +1445,8 @@ class SOFA_SIMULATION_CORE_API MechanicalPropagateOnlyVelocityVisitor : public M
 public:
     SReal currentTime;
     sofa::core::MultiVecDerivId v;
-    bool ignoreMask;    
-    
+    bool ignoreMask;
+
     MechanicalPropagateOnlyVelocityVisitor(const sofa::core::MechanicalParams* mparams, SReal time=0,
                                        sofa::core::MultiVecDerivId v = sofa::core::VecId::velocity(),
             bool m=true);
@@ -1450,6 +1531,8 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
+        applyFwdMappedMechanicalState = true;
     }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
@@ -1494,6 +1577,11 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
+        applyFwdMappedMechanicalState = true;
+        applyFwdForceField = true;
+        applyBwdMechanicalMapping = true;
+        applyBwdMechanicalState = true;
     }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
@@ -1541,6 +1629,11 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
+        applyFwdMappedMechanicalState = true;
+        applyFwdForceField = true;
+        applyBwdMechanicalMapping = true;
+        applyBwdMechanicalState = true;
     }
     MechanicalComputeDfVisitor(const sofa::core::MechanicalParams* mparams, sofa::core::MultiVecDerivId res, bool accumulate)
         : MechanicalVisitor(mparams) , res(res), accumulate(accumulate)
@@ -1548,6 +1641,11 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
+        applyFwdMappedMechanicalState = true;
+        applyFwdForceField = true;
+        applyBwdMechanicalMapping = true;
+        applyBwdMechanicalState = true;
     }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
@@ -1595,6 +1693,7 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalMapping = true;
     }
     Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
 
@@ -1642,6 +1741,12 @@ public:
 #endif
         mparamsWithoutStiffness = *mparams;
         mparamsWithoutStiffness.setKFactor(0);
+
+        applyFwdMechanicalState = true;
+        applyFwdMappedMechanicalState = true;
+        applyFwdForceField = true;
+        applyBwdMechanicalMapping = true;
+        applyBwdMechanicalState = true;
     }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
@@ -1680,6 +1785,9 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
+        applyFwdMappedMechanicalState = true;
+        applyFwdConstraintSet = true;
     }
 
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
@@ -1727,6 +1835,8 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdConstraintSet = true;
+        applyBwdMechanicalMapping = true;
     }
 
     const core::ConstraintParams* constraintParams() const { return cparams; }
@@ -1776,6 +1886,7 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdConstraintSet = true;
     }
 
     const core::ConstraintParams* constraintParams() const { return cparams; }
@@ -1823,6 +1934,7 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyBwdMechanicalMapping = true;
     }
 
     const core::ConstraintParams* constraintParams() const { return cparams; }
@@ -1875,6 +1987,9 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
+        applyFwdMappedMechanicalState = true;
+        applyBwdProjectiveConstraintSet = true;
     }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* /*mm*/) override;
@@ -1915,6 +2030,8 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
+        applyFwdMappedMechanicalState = true;
     }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
@@ -1952,6 +2069,8 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
+        applyFwdMappedMechanicalState = true;
     }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
@@ -1990,6 +2109,9 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdOdeSolver = true;
+        applyFwdInteractionForceField = true;
+        applyBwdOdeSolver = true;
     }
     Result fwdOdeSolver(simulation::Node* node, core::behavior::OdeSolver* obj) override;
     Result fwdInteractionForceField(simulation::Node*, core::behavior::BaseInteractionForceField* obj) override;
@@ -2029,6 +2151,9 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
+        applyFwdMappedMechanicalState = true;
+        applyBwdMechanicalMapping = true;
     }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
@@ -2065,6 +2190,7 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMass = true;
     }
 
     /// Process the BaseMass
@@ -2098,6 +2224,9 @@ public:
     MechanicalPickParticlesVisitor(const sofa::core::ExecParams* mparams, const defaulttype::Vec3d& origin, const defaulttype::Vec3d& direction, double r0=0.001, double dr=0.0, sofa::core::objectmodel::Tag tag = sofa::core::objectmodel::Tag("NoPicking") )
         : BaseMechanicalVisitor(mparams) , rayOrigin(origin), rayDirection(direction), radius0(r0), dRadius(dr), tagNoPicking(tag)
     {
+        applyFwdMechanicalState = true;
+        applyFwdMechanicalMapping = true;
+        applyFwdMappedMechanicalState = true;
     }
 
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
@@ -2137,6 +2266,9 @@ public:
 	MechanicalPickParticlesWithTagsVisitor(const sofa::core::ExecParams* mparams, const defaulttype::Vec3d& origin, const defaulttype::Vec3d& direction, double r0=0.001, double dr=0.0, std::list<sofa::core::objectmodel::Tag> _tags = std::list<sofa::core::objectmodel::Tag>(), bool _mustContainAllTags = false)
 		: BaseMechanicalVisitor(mparams) , rayOrigin(origin), rayDirection(direction), radius0(r0), dRadius(dr), tags(_tags), mustContainAllTags(_mustContainAllTags)
 	{
+        applyFwdMechanicalState = true;
+        applyFwdMechanicalMapping = true;
+        applyFwdMappedMechanicalState = true;
 	}
 
 	Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
@@ -2178,6 +2310,8 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
+        applyFwdMappedMechanicalState = true;
     }
 
     Result fwdMechanicalState(simulation::Node*, core::behavior::BaseMechanicalState* mm) override;

--- a/applications/plugins/Compliant/assembly/AssemblyHelper.h
+++ b/applications/plugins/Compliant/assembly/AssemblyHelper.h
@@ -212,6 +212,11 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMechanicalState = true;
+        applyFwdMappedMechanicalState = true;
+        applyBwdMechanicalMapping = true;
+        applyBwdMechanicalState = true;
+        applyBwdMappedMechanicalState = true;
     }
 
     // reset lambda where there is no compliant FF
@@ -314,6 +319,11 @@ public:
         , propagate(propagate)
     {
         assert(!propagate || clear ); // existing forces must be cleared if propagating
+
+        applyFwdMappedMechanicalState = true;
+        applyFwdMechanicalState = true;
+        applyBwdMechanicalMapping = true;
+        applyBwdProjectiveConstraintSet = true;
     }
 
 
@@ -367,6 +377,10 @@ public:
         : simulation::MechanicalVisitor(mparams)
         , lambda( lambda )
     {
+        applyFwdMappedMechanicalState = true;
+        applyFwdMechanicalState = true;
+        applyBwdMechanicalMapping = true;
+        applyBwdProjectiveConstraintSet = true;
     }
 
     Result fwdMappedMechanicalState(simulation::Node* node, core::behavior::BaseMechanicalState* state) override

--- a/applications/plugins/Compliant/odesolver/CompliantNLImplicitSolver.cpp
+++ b/applications/plugins/Compliant/odesolver/CompliantNLImplicitSolver.cpp
@@ -78,6 +78,9 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMappedMechanicalState = true;
+        applyBwdMechanicalMapping = true;
+        applyBwdMechanicalState = true;
     }
 
     Result fwdMappedMechanicalState(simulation::Node* node, core::behavior::BaseMechanicalState* mm) override
@@ -141,6 +144,8 @@ public:
         , lambdas( lambdas )
         , invdt( -1.0/dt )
     {
+        applyFwdMechanicalState = true;
+        applyFwdMappedMechanicalState = true;
     }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override
     {
@@ -179,6 +184,11 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdMappedMechanicalState = true;
+        applyFwdForceField = true;
+        applyBwdMechanicalMapping = true;
+        applyBwdMechanicalState = true;
+        applyBwdProjectiveConstraintSet = true;
     }
 
     // TODO how to propagate lambdas without invalidating forces on mapped dofs?

--- a/applications/plugins/Compliant/odesolver/CompliantStaticSolver.cpp
+++ b/applications/plugins/Compliant/odesolver/CompliantStaticSolver.cpp
@@ -284,10 +284,14 @@ public:
     AugmentedLagrangianVisitor(const sofa::core::MechanicalParams* mparams,
                                core::MultiVecId id)
         : MechanicalVisitor(mparams),
-          id(id) { }
+          id(id)
+    {
+        applyFwdMechanicalState = true;
+        applyFwdMappedMechanicalState = true;
+    }
 
     core::MultiVecId id;
-    
+
     Result mstate(simulation::Node* node,
                   core::behavior::BaseMechanicalState* mm) {
 
@@ -296,14 +300,14 @@ public:
 
         if( c ) {
             // TODO project ?
-            
+
             // add force to external force
-            mm->vOp(params, id.getId(mm), core::ConstVecId::force() );            
+            mm->vOp(params, id.getId(mm), core::ConstVecId::force() );
         }
 
         return RESULT_CONTINUE;
     }
-    
+
     Result fwdMappedMechanicalState(simulation::Node* node,
                                             core::behavior::BaseMechanicalState* mm) override {
         return mstate(node, mm);
@@ -317,13 +321,17 @@ public:
 };
 
 
-// somehow setting external force directly does not work 
+// somehow setting external force directly does not work
 class WriteExternalForceVisitor : public simulation::MechanicalVisitor {
 public:
     WriteExternalForceVisitor(const sofa::core::MechanicalParams* mparams,
                               core::MultiVecId id)
         : MechanicalVisitor(mparams),
-          id(id) { }
+          id(id)
+    {
+        applyFwdMappedMechanicalState = true;
+        applyFwdMechanicalState = true;
+    }
 
 
     core::MultiVecId id;

--- a/applications/plugins/Compliant/utils/expr.h
+++ b/applications/plugins/Compliant/utils/expr.h
@@ -31,7 +31,10 @@ public:
 
         mapped = true;
         precomp = true;
-        
+
+        applyFwdMechanicalState = true;
+        applyFwdMappedMechanicalState = true;
+
         // TODO more
     }
 

--- a/applications/plugins/LMConstraint/src/LMConstraint/MechanicalWriteLMConstraint.h
+++ b/applications/plugins/LMConstraint/src/LMConstraint/MechanicalWriteLMConstraint.h
@@ -41,6 +41,7 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdConstraintSet = true;
     }
 
     Result fwdConstraintSet(simulation::Node* /*node*/, core::behavior::BaseConstraintSet* c) override;

--- a/modules/SofaConstraint/src/SofaConstraint/ConstraintAnimationLoop.h
+++ b/modules/SofaConstraint/src/SofaConstraint/ConstraintAnimationLoop.h
@@ -48,6 +48,7 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdConstraintSet = true;
     }
 
     Result fwdConstraintSet(simulation::Node* node, core::behavior::BaseConstraintSet* cSet) override;
@@ -78,6 +79,7 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdConstraintSet = true;
     }
 
     Result fwdConstraintSet(simulation::Node* node, core::behavior::BaseConstraintSet* c) override;
@@ -113,6 +115,7 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyBwdMechanicalMapping = true;
     }
 
     void bwdMechanicalMapping(simulation::Node* node, core::BaseMapping* map) override;

--- a/modules/SofaConstraint/src/SofaConstraint/ConstraintSolverImpl.h
+++ b/modules/SofaConstraint/src/SofaConstraint/ConstraintSolverImpl.h
@@ -87,6 +87,7 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdConstraintSet = true;
     }
 
     Result fwdConstraintSet(simulation::Node* node, core::behavior::BaseConstraintSet* c) override

--- a/modules/SofaConstraint/src/SofaConstraint/ConstraintStoreLambdaVisitor.cpp
+++ b/modules/SofaConstraint/src/SofaConstraint/ConstraintStoreLambdaVisitor.cpp
@@ -30,6 +30,8 @@ ConstraintStoreLambdaVisitor::ConstraintStoreLambdaVisitor(const sofa::core::Con
 ,m_cParams(cParams)
 ,m_lambda(lambda)
 {
+    applyFwdConstraintSet = true;
+    applyBwdMechanicalMapping = true;
 }
 
 Visitor::Result ConstraintStoreLambdaVisitor::fwdConstraintSet(simulation::Node* node, core::behavior::BaseConstraintSet* cSet)

--- a/modules/SofaConstraint/src/SofaConstraint/GenericConstraintSolver.cpp
+++ b/modules/SofaConstraint/src/SofaConstraint/GenericConstraintSolver.cpp
@@ -1109,6 +1109,7 @@ MechanicalGetConstraintResolutionVisitor::MechanicalGetConstraintResolutionVisit
 #ifdef SOFA_DUMP_VISITOR_INFO
   setReadWriteVectors();
 #endif
+    applyFwdConstraintSet = true;
 }
 
 MechanicalGetConstraintResolutionVisitor::Result MechanicalGetConstraintResolutionVisitor::fwdConstraintSet(simulation::Node* node, core::behavior::BaseConstraintSet* cSet)

--- a/modules/SofaConstraint/src/SofaConstraint/LCPConstraintSolver.h
+++ b/modules/SofaConstraint/src/SofaConstraint/LCPConstraintSolver.h
@@ -69,6 +69,7 @@ public:
 #ifdef SOFA_DUMP_VISITOR_INFO
         setReadWriteVectors();
 #endif
+        applyFwdConstraintSet = true;
     }
 
     Result fwdConstraintSet(simulation::Node* node, core::behavior::BaseConstraintSet* cSet) override

--- a/modules/SofaGeneralAnimationLoop/src/SofaGeneralAnimationLoop/MechanicalMatrixMapper.h
+++ b/modules/SofaGeneralAnimationLoop/src/SofaGeneralAnimationLoop/MechanicalMatrixMapper.h
@@ -50,7 +50,7 @@ public:
         , res(_res)
         , cparams(_cparams)
     {
-
+        applyBwdMechanicalMapping = true;
     }
 
     void bwdMechanicalMapping(simulation::Node* node, core::BaseMapping* map) override


### PR DESCRIPTION
### Context

All instances of the derived classes of `BaseMechanicalVisitor` execute the same functions `processNodeTopDown` and `processNodeBottomUp`, defined in the base class, and are generally **not** overriden.

In the functions `processNodeTopDown` and `processNodeBottomUp`, a set of other functions are executed. They have a prefix _fwd_ if they are executed in `processNodeTopDown` and _bwd_ if executed in `processNodeBottomUp`. The functions _fwd_* and _bwd_* are generally overriden, but not all of them. By default, they do nothing.

In the functions `processNodeTopDown` and `processNodeBottomUp`, the functions _fwd_* and _bwd_* are surrounded by boilerplate code which is executed even if the functions _fwd_* and _bwd_* are not overriden, i.e. even if they do nothing.

Moreover, all the _fwd_* and _bwd_* functions act on objects or containers, stored in a Node. However, in the context of concurrent tasks, those objects and containers can change. In particular, adding an element to a container invalidates the iterators. It is a problem if a visitor was in the middle of a loop over the container. This problem can occur even if the visitor was not design to work on this specific container through the override of _fwd_* and _bwd_* functions, because of the boilerplate code.

In a nutshell, there are race conditions which can be avoided if the derived class can execute only the code they are designed to execute, and nothing more.

### Proposition

I added boolean variables named `applyFwd*` and `applyBwd*`, each corresponding to the `fwd*` and `bwd*` functions. They are all set to false by default.
For example, if `applyFwdMechanicalState` is true, then the code related to `fwdMechanicalState` is executed. Remember that previously, the boilerplate code related to `fwdMechanicalState` was executed even if `fwdMechanicalState` does nothing. To change that, the derived class must set the right variables to true, so the right code is executed. For example, if a derived class wants to execute `fwdMechanicalState`, it must set `applyFwdMechanicalState` first, usually in its constructor.

### Pros

- Avoid unnecessary race conditions
- Does not execute unnecessary boilerplate code
- Simple to understand

### Cons

- Breaks all classes derived from `BaseMechanicalVisitor`
- Forces the developers of classes derived from `BaseMechanicalVisitor` to tune booleans according the goal of the visitor.
- Runtime check of the variables

This PR is not to merge yet. IIt is suggested as an alternative to PR #1963


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
