### PR TITLE
[SofaSimulationCore] Add virtual functions to the base class BaseMech…

### DIFF
--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalComputeEnergyVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalComputeEnergyVisitor.h
@@ -49,9 +49,17 @@ public:
 
     SReal getPotentialEnergy();
 
+    Result processNodeTopDown_fwdMass(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMass_impl(node, ctx);
+    }
     /// Process the BaseMass
     Result fwdMass(simulation::Node* /*node*/, core::behavior::BaseMass* mass) override;
 
+    Result processNodeTopDown_fwdForceField(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdForceField_impl(node, ctx);
+    }
     /// Process the BaseForceField
     Result fwdForceField(simulation::Node* /*node*/, core::behavior::BaseForceField* f) override;
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalGetMomentumVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalGetMomentumVisitor.h
@@ -46,6 +46,10 @@ public:
 
     const defaulttype::Vector6& getMomentum() const { return m_momenta; }
 
+    Result processNodeTopDown_fwdMass(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMass_impl(node, ctx);
+    }
     /// Process the BaseMass
     virtual Result fwdMass(simulation::Node* /*node*/, core::behavior::BaseMass* mass)
     {

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalMatrixVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalMatrixVisitor.h
@@ -63,6 +63,10 @@ public:
         : BaseMechanicalVisitor(params) , nbRow(_nbRow), nbCol(_nbCol), matrix(_matrix)
     {}
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMechanicalState_impl(node, ctx);
+    }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* ms) override
     {
         //ms->contributeToMatrixDimension(nbRow, nbCol);
@@ -73,12 +77,20 @@ public:
         return RESULT_CONTINUE;
     }
 
+    Result processNodeTopDown_fwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMechanicalMapping_impl(node, ctx);
+    }
     Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* mm) override
     {
         if (matrix) matrix->addMechanicalMapping(mm);
         return RESULT_CONTINUE;
     }
 
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMappedMechanicalState_impl(node, ctx);
+    }
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* ms) override
     {
         if (matrix) matrix->addMappedMechanicalState(ms);
@@ -105,6 +117,10 @@ public:
         : BaseMechanicalVisitor(cparams) , cparams(cparams), J(_J), matrix(_matrix), offset(0)
     {}
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMechanicalState_impl(node, ctx);
+    }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* ms) override
     {
         if (matrix) offset = matrix->getGlobalOffset(ms);
@@ -155,6 +171,10 @@ public:
         ,offset(0)
     {}
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMechanicalState_impl(node, ctx);
+    }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* ms) override
     {
         if (matrix) offset = matrix->getGlobalOffset(ms);
@@ -206,12 +226,10 @@ public:
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalAddMBK_ToMatrixVisitor"; }
 
-    Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* /*ms*/) override
+    Result processNodeTopDown_fwdForceField(simulation::Node* node, VisitorContext* ctx) override
     {
-        //ms->setOffset(offsetOnExit);
-        return RESULT_CONTINUE;
+        return processNodeTopDown_fwdForceField_impl(node, ctx);
     }
-
     Result fwdForceField(simulation::Node* /*node*/, core::behavior::BaseForceField* ff) override
     {
         if (matrix != nullptr)
@@ -246,12 +264,20 @@ public:
     /// Only used for debugging / profiling purposes
     const char* getClassName() const override { return "MechanicalAddSubMBK_ToMatrixVisitor"; }
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMechanicalState_impl(node, ctx);
+    }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* /*ms*/) override
     {
         //ms->setOffset(offsetOnExit);
         return RESULT_CONTINUE;
     }
 
+    Result processNodeTopDown_fwdForceField(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdForceField_impl(node, ctx);
+    }
     Result fwdForceField(simulation::Node* /*node*/, core::behavior::BaseForceField* ff) override
     {
         if (matrix != nullptr)
@@ -281,12 +307,20 @@ public:
     /// Only used for debugging / profiling purposes
     virtual const char* getClassName() const override { return "MechanicalApplyProjectiveConstraint_ToMatrixVisitor"; }
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMechanicalState_impl(node, ctx);
+    }
     virtual Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* /*ms*/) override
     {
         //ms->setOffset(offsetOnExit);
         return RESULT_CONTINUE;
     }
-    
+
+    Result processNodeTopDown_fwdProjectiveConstraintSet(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdProjectiveConstraintSet_impl(node, ctx);
+    }
     Result fwdProjectiveConstraintSet(simulation::Node* /*node*/, core::behavior::BaseProjectiveConstraintSet* c) override
     {
         if (matrix != nullptr)
@@ -318,6 +352,10 @@ public:
     {
     }
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMechanicalState_impl(node, ctx);
+    }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override
     {
         if (matrix) offset = matrix->getGlobalOffset(mm);
@@ -351,6 +389,10 @@ public:
     {
     }
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMechanicalState_impl(node, ctx);
+    }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override
     {
         if (matrix) offset = matrix->getGlobalOffset(mm);
@@ -386,6 +428,10 @@ public:
     {
     }
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMechanicalState_impl(node, ctx);
+    }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override
     {
         if (matrix) offset = matrix->getGlobalOffset(mm);

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/MechanicalVisitor.h
@@ -375,6 +375,121 @@ protected:
     sofa::helper::vector< core::ConstMultiVecId > readVector;
     sofa::helper::vector< core::MultiVecId > writeVector;
 #endif
+
+    virtual Result processNodeTopDown_fwdOdeSolvers(simulation::Node* /*node*/, VisitorContext* /*ctx*/)
+    {
+        // return processNodeTopDown_fwdOdeSolvers_impl(node, ctx);
+        return RESULT_CONTINUE;
+    }
+
+    virtual Result processNodeTopDown_fwdMechanicalMapping(simulation::Node* /*node*/, VisitorContext* /*ctx*/)
+    {
+        // return processNodeTopDown_fwdMechanicalMapping_impl(node, ctx);
+        return RESULT_CONTINUE;
+    }
+
+    virtual Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* /*node*/, VisitorContext* /*ctx*/)
+    {
+        // return processNodeTopDown_fwdMappedMechanicalState_impl(node, ctx);
+        return RESULT_CONTINUE;
+    }
+
+    virtual Result processNodeTopDown_fwdMechanicalState(simulation::Node* /*node*/, VisitorContext* /*ctx*/)
+    {
+        // return processNodeTopDown_fwdMechanicalState_impl(node, ctx);
+        return RESULT_CONTINUE;
+    }
+
+    virtual Result processNodeTopDown_fwdMass(simulation::Node* /*node*/, VisitorContext* /*ctx*/)
+    {
+        // return processNodeTopDown_fwdMass_impl(node, ctx);
+        return RESULT_CONTINUE;
+    }
+
+    virtual Result processNodeTopDown_fwdConstraintSolver(simulation::Node* /*node*/, VisitorContext* /*ctx*/)
+    {
+        // return processNodeTopDown_fwdConstraintSolver_impl(node, ctx);
+        return RESULT_CONTINUE;
+    }
+
+    virtual Result processNodeTopDown_fwdForceField(simulation::Node* /*node*/, VisitorContext* /*ctx*/)
+    {
+        // return processNodeTopDown_fwdForceField_impl(node, ctx);
+        return RESULT_CONTINUE;
+    }
+
+    virtual Result processNodeTopDown_fwdInteractionForceField(simulation::Node* /*node*/, VisitorContext* /*ctx*/)
+    {
+        // return processNodeTopDown_fwdInteractionForceField_impl(node, ctx);
+        return RESULT_CONTINUE;
+    }
+
+    virtual Result processNodeTopDown_fwdProjectiveConstraintSet(simulation::Node* /*node*/, VisitorContext* /*ctx*/)
+    {
+        // return processNodeTopDown_fwdProjectiveConstraintSet_impl(node, ctx);
+        return RESULT_CONTINUE;
+    }
+
+    virtual Result processNodeTopDown_fwdConstraintSet(simulation::Node* /*node*/, VisitorContext* /*ctx*/)
+    {
+        // return processNodeTopDown_fwdConstraintSet_impl(node, ctx);
+        return RESULT_CONTINUE;
+    }
+
+    virtual void processNodeBottomUp_bwdProjectiveConstraintSet(simulation::Node* /*node*/, VisitorContext* /*ctx*/)
+    {
+        //processNodeBottomUp_bwdProjectiveConstraintSet_impl(node, ctx);
+    }
+
+    virtual void processNodeBottomUp_bwdConstraintSet(simulation::Node* /*node*/, VisitorContext* /*ctx*/)
+    {
+        //processNodeTopDown_bwdConstraintSet_impl(node, ctx);
+    }
+
+    virtual void processNodeBottomUp_bwdConstraintSolver(simulation::Node* /*node*/, VisitorContext* /*ctx*/)
+    {
+        //processNodeBottomUp_bwdConstraintSolver_impl(node, ctx);
+    }
+
+    virtual void processNodeBottomUp_bwdMappedMechanicalState(simulation::Node* /*node*/, VisitorContext* /*ctx*/)
+    {
+        //processNodeBottomUp_bwdMappedMechanicalState_impl(node, ctx);
+    }
+
+    virtual void processNodeBottomUp_bwdMechanicalMapping(simulation::Node* /*node*/, VisitorContext* /*ctx*/)
+    {
+        //processNodeBottomUp_bwdMechanicalMapping_impl(node, ctx);
+    }
+
+    virtual void processNodeBottomUp_bwdMechanicalState(simulation::Node* /*node*/, VisitorContext* /*ctx*/)
+    {
+        //processNodeBottomUp_bwdMechanicalState_impl(node, ctx);
+    }
+
+    virtual void processNodeBottomUp_bwdOdeSolver(simulation::Node* /*node*/, VisitorContext* /*ctx*/)
+    {
+        //processNodeBottomUp_bwdOdeSolver_impl(node, ctx);
+    }
+
+protected:
+
+    Result processNodeTopDown_fwdOdeSolvers_impl(simulation::Node* node, VisitorContext* ctx);
+    Result processNodeTopDown_fwdMechanicalMapping_impl(simulation::Node* node, VisitorContext* ctx);
+    Result processNodeTopDown_fwdMappedMechanicalState_impl(simulation::Node* node, VisitorContext* ctx);
+    Result processNodeTopDown_fwdMechanicalState_impl(simulation::Node* node, VisitorContext* ctx);
+    Result processNodeTopDown_fwdMass_impl(simulation::Node* node, VisitorContext* ctx);
+    Result processNodeTopDown_fwdConstraintSolver_impl(simulation::Node* node, VisitorContext* ctx);
+    Result processNodeTopDown_fwdForceField_impl(simulation::Node* node, VisitorContext* ctx);
+    Result processNodeTopDown_fwdInteractionForceField_impl(simulation::Node* node, VisitorContext* ctx);
+    Result processNodeTopDown_fwdProjectiveConstraintSet_impl(simulation::Node* node, VisitorContext* ctx);
+    Result processNodeTopDown_fwdConstraintSet_impl(simulation::Node* node, VisitorContext* ctx);
+    void processNodeBottomUp_bwdProjectiveConstraintSet_impl(simulation::Node* node, VisitorContext* ctx);
+    void processNodeBottomUp_bwdConstraintSet_impl(simulation::Node* node, VisitorContext* ctx);
+    void processNodeBottomUp_bwdConstraintSolver_impl(simulation::Node* node, VisitorContext* ctx);
+    void processNodeBottomUp_bwdMappedMechanicalState_impl(simulation::Node* node, VisitorContext* ctx);
+    void processNodeBottomUp_bwdMechanicalMapping_impl(simulation::Node* node, VisitorContext* ctx);
+    void processNodeBottomUp_bwdMechanicalState_impl(simulation::Node* node, VisitorContext* ctx);
+    void processNodeBottomUp_bwdOdeSolver_impl(simulation::Node* node, VisitorContext* ctx);
 };
 
 class SOFA_SIMULATION_CORE_API MechanicalVisitor : public BaseMechanicalVisitor
@@ -404,6 +519,7 @@ public:
         rootData = result;
     }
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
@@ -440,6 +556,8 @@ public:
         setReadWriteVectors();
 #endif
     }
+
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
@@ -497,6 +615,9 @@ public:
         return false;
     }
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
+
     Result fwdMechanicalState(simulation::Node* node, core::behavior::BaseMechanicalState* mm) override;
 
     Result fwdMappedMechanicalState(simulation::Node* node, core::behavior::BaseMechanicalState* mm) override;
@@ -543,6 +664,8 @@ public:
         setReadWriteVectors();
 #endif
     }
+
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
@@ -599,10 +722,13 @@ public:
         return false;
     }
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(simulation::Node* node, core::behavior::BaseMechanicalState* mm) override;
 
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMappedMechanicalState(simulation::Node* node, core::behavior::BaseMechanicalState* mm) override;
 
+    Result processNodeTopDown_fwdInteractionForceField(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdInteractionForceField(simulation::Node* node, core::behavior::BaseInteractionForceField* ff) override;
 
     /// Return a class name for this visitor
@@ -651,8 +777,15 @@ public:
         setReadWriteVectors();
 #endif
     }
+
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMechanicalState_impl(node, ctx);
+    }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+    Result processNodeTopDown_fwdInteractionForceField(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdInteractionForceField(simulation::Node* node, core::behavior::BaseInteractionForceField* ff) override;
 
     /// Return a class name for this visitor
@@ -704,7 +837,9 @@ public:
     MechanicalVOpVisitor& setMapped(bool m = true) { mapped = m; return *this; }
     MechanicalVOpVisitor& setOnlyMapped(bool m = true) { only_mapped = m; return *this; }
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm) override;
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMappedMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm) override;
 
     const char* getClassName() const override { return "MechanicalVOpVisitor";}
@@ -748,6 +883,9 @@ public:
     }
 
     MechanicalVMultiOpVisitor& setMapped(bool m = true) { mapped = m; return *this; }
+
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
 
     Result fwdMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm) override;
     Result fwdMappedMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm) override;
@@ -803,6 +941,7 @@ public:
         rootData = t;
     }
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
@@ -853,6 +992,7 @@ public:
     }
     SReal getResult() const;
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(VisitorContext* ctx, core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
@@ -898,8 +1038,14 @@ public:
         setReadWriteVectors();
 #endif
     }
+
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
+    Result processNodeTopDown_fwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
+
+    void processNodeBottomUp_bwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     void bwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
 
     // This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
@@ -948,6 +1094,12 @@ public:
         setReadWriteVectors();
 #endif
     }
+
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
+    Result processNodeTopDown_fwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override;
+    void processNodeBottomUp_bwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
+
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
     Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
@@ -992,6 +1144,12 @@ public:
         : MechanicalVisitor(mparams) , x(x), f(f), ignoreMask(m)
     {
     }
+
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
+    Result processNodeTopDown_fwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override;
+    void processNodeBottomUp_bwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
+
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
     Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
@@ -1034,7 +1192,11 @@ public:
         setReadWriteVectors();
 #endif
     }
+
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
+    Result processNodeTopDown_fwdMass(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMass(simulation::Node* /*node*/, core::behavior::BaseMass* mass) override;
 
     /// Return a class name for this visitor
@@ -1042,7 +1204,10 @@ public:
     const char* getClassName() const override { return "MechanicalAddMDxVisitor"; }
     virtual std::string getInfos() const override { std::string name="dx["+dx.getName()+"] in res[" + res.getName()+"]"; return name; }
 
+    Result processNodeTopDown_fwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override;
+
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* /*mm*/) override;
 
     /// Specify whether this action can be parallelized.
@@ -1072,7 +1237,11 @@ public:
         setReadWriteVectors();
 #endif
     }
+
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
+    Result processNodeTopDown_fwdMass(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMass(simulation::Node* /*node*/, core::behavior::BaseMass* mass) override;
 
     /// Return a class name for this visitor
@@ -1108,7 +1277,10 @@ public:
 #endif
     }
 
+    Result processNodeTopDown_fwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
+
+    Result processNodeTopDown_fwdProjectiveConstraintSet(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdProjectiveConstraintSet(simulation::Node* /*node*/, core::behavior::BaseProjectiveConstraintSet* c) override;
 
 
@@ -1141,7 +1313,10 @@ public:
 #endif
     }
 
+    Result processNodeTopDown_fwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
+
+    Result processNodeTopDown_fwdProjectiveConstraintSet(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdProjectiveConstraintSet(simulation::Node* /*node*/, core::behavior::BaseProjectiveConstraintSet* c) override;
 
 
@@ -1179,7 +1354,10 @@ public:
 #endif
     }
 
+    Result processNodeTopDown_fwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
+
+    Result processNodeTopDown_fwdProjectiveConstraintSet(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdProjectiveConstraintSet(simulation::Node* /*node*/, core::behavior::BaseProjectiveConstraintSet* c) override;
 
 
@@ -1219,7 +1397,10 @@ public:
 #endif
     }
 
+    Result processNodeTopDown_fwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
+
+    Result processNodeTopDown_fwdProjectiveConstraintSet(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdProjectiveConstraintSet(simulation::Node* /*node*/, core::behavior::BaseProjectiveConstraintSet* c) override;
 
 
@@ -1264,8 +1445,13 @@ public:
     MechanicalPropagateOnlyPositionVisitor( const sofa::core::MechanicalParams* mparams, SReal time=0,
                                         sofa::core::MultiVecCoordId x = sofa::core::VecCoordId::position(), bool m=true);
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
+    Result processNodeTopDown_fwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
+
+    void processNodeBottomUp_bwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     void bwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
 
     // This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
@@ -1318,10 +1504,15 @@ public:
 
     MechanicalPropagateOnlyPositionAndVelocityVisitor(const sofa::core::MechanicalParams* mparams, SReal time=0,
                                                   sofa::core::MultiVecCoordId x = sofa::core::VecId::position(), sofa::core::MultiVecDerivId v = sofa::core::VecId::velocity(),
-            bool m=true );  
+            bool m=true );
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
+    Result processNodeTopDown_fwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
+
+    void processNodeBottomUp_bwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     void bwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
 
     // This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
@@ -1370,9 +1561,15 @@ public:
                                        sofa::core::MultiVecDerivId v = sofa::core::VecId::velocity(),
             bool m=true);
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
+    Result processNodeTopDown_fwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
+
+    void processNodeBottomUp_bwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     void bwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
     // This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
     bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override
     {
@@ -1411,6 +1608,7 @@ public:
                                             sofa::core::MultiVecCoordId x = sofa::core::VecCoordId::position(),
                                             sofa::core::MultiVecDerivId v = sofa::core::VecDerivId::velocity());
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
@@ -1451,7 +1649,11 @@ public:
         setReadWriteVectors();
 #endif
     }
+
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
@@ -1495,10 +1697,20 @@ public:
         setReadWriteVectors();
 #endif
     }
+
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
+    Result processNodeTopDown_fwdForceField(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdForceField(simulation::Node* /*node*/, core::behavior::BaseForceField* ff) override;
+
+    void processNodeBottomUp_bwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override;
     void bwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
+
+    void processNodeBottomUp_bwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     void bwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
 
 
@@ -1549,10 +1761,20 @@ public:
         setReadWriteVectors();
 #endif
     }
+
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
+    Result processNodeTopDown_fwdForceField(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdForceField(simulation::Node* /*node*/, core::behavior::BaseForceField* ff) override;
+
+    void processNodeBottomUp_bwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override;
     void bwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
+
+    void processNodeBottomUp_bwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     void bwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
@@ -1596,6 +1818,8 @@ public:
         setReadWriteVectors();
 #endif
     }
+
+    Result processNodeTopDown_fwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
 
     /// Return a class name for this visitor
@@ -1643,10 +1867,20 @@ public:
         mparamsWithoutStiffness = *mparams;
         mparamsWithoutStiffness.setKFactor(0);
     }
+
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
+    Result processNodeTopDown_fwdForceField(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdForceField(simulation::Node* /*node*/, core::behavior::BaseForceField* ff) override;
+
+    void processNodeBottomUp_bwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override;
     void bwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
+
+    void processNodeBottomUp_bwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     void bwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
@@ -1682,8 +1916,13 @@ public:
 #endif
     }
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
+    Result processNodeTopDown_fwdConstraintSet(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdConstraintSet(simulation::Node* /*node*/, core::behavior::BaseConstraintSet* mm) override;
 
     // This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
@@ -1731,8 +1970,10 @@ public:
 
     const core::ConstraintParams* constraintParams() const { return cparams; }
 
+    Result processNodeTopDown_fwdConstraintSet(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdConstraintSet(simulation::Node* /*node*/, core::behavior::BaseConstraintSet* c) override;
 
+    void processNodeBottomUp_bwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override;
     void bwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
 
     /// This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
@@ -1780,6 +2021,7 @@ public:
 
     const core::ConstraintParams* constraintParams() const { return cparams; }
 
+    Result processNodeTopDown_fwdConstraintSet(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdConstraintSet(simulation::Node* /*node*/, core::behavior::BaseConstraintSet* c) override;
 
     /// This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
@@ -1827,6 +2069,7 @@ public:
 
     const core::ConstraintParams* constraintParams() const { return cparams; }
 
+    void processNodeBottomUp_bwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override;
     void bwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
 
     /// Return true to reverse the order of traversal of child nodes
@@ -1876,8 +2119,14 @@ public:
         setReadWriteVectors();
 #endif
     }
+
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* /*mm*/) override;
+
+    void processNodeBottomUp_bwdProjectiveConstraintSet(simulation::Node* node, VisitorContext* ctx) override;
     void bwdProjectiveConstraintSet(simulation::Node* /*node*/, core::behavior::BaseProjectiveConstraintSet* c) override;
     // This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
     bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override
@@ -1916,7 +2165,11 @@ public:
         setReadWriteVectors();
 #endif
     }
+
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
@@ -1953,7 +2206,11 @@ public:
         setReadWriteVectors();
 #endif
     }
+
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
@@ -1991,11 +2248,12 @@ public:
         setReadWriteVectors();
 #endif
     }
+
+    Result processNodeTopDown_fwdOdeSolvers(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdOdeSolver(simulation::Node* node, core::behavior::OdeSolver* obj) override;
+
+    Result processNodeTopDown_fwdInteractionForceField(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdInteractionForceField(simulation::Node*, core::behavior::BaseInteractionForceField* obj) override;
-    void bwdOdeSolver(simulation::Node* /*node*/, core::behavior::OdeSolver* /*obj*/) override
-    {
-    }
 
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
@@ -2030,8 +2288,14 @@ public:
         setReadWriteVectors();
 #endif
     }
+
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
+    void processNodeBottomUp_bwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override;
     void bwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
 
     /// Return a class name for this visitor
@@ -2067,6 +2331,7 @@ public:
 #endif
     }
 
+    Result processNodeTopDown_fwdMass(simulation::Node* node, VisitorContext* ctx) override;
     /// Process the BaseMass
     Result fwdMass(simulation::Node* /*node*/, core::behavior::BaseMass* mass) override;
 
@@ -2100,8 +2365,13 @@ public:
     {
     }
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
+    Result processNodeTopDown_fwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
+
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor
@@ -2139,8 +2409,13 @@ public:
 	{
 	}
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
 	Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
+
+    Result processNodeTopDown_fwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override;
 	Result fwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override;
+
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
 	Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override;
 
 	/// Return a class name for this visitor
@@ -2180,7 +2455,10 @@ public:
 #endif
     }
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMechanicalState(simulation::Node*, core::behavior::BaseMechanicalState* mm) override;
+
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override;
     Result fwdMappedMechanicalState(simulation::Node*, core::behavior::BaseMechanicalState* mm) override;
 
     /// Return a class name for this visitor

--- a/applications/plugins/Compliant/assembly/AssemblyHelper.h
+++ b/applications/plugins/Compliant/assembly/AssemblyHelper.h
@@ -214,6 +214,11 @@ public:
 #endif
     }
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMechanicalState_impl(node, ctx);
+    }
+
     // reset lambda where there is no compliant FF
     // these reseted lambdas were previously propagated, but were not computed from the last solve
     Result fwdMechanicalState(simulation::Node* node, core::behavior::BaseMechanicalState* mm) override
@@ -235,15 +240,28 @@ public:
         return RESULT_CONTINUE;
     }
 
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMappedMechanicalState_impl(node, ctx);
+    }
     Result fwdMappedMechanicalState(simulation::Node* node, core::behavior::BaseMechanicalState* mm) override
     {
         return fwdMechanicalState( node, mm );
     }
 
+    void processNodeBottomUp_bwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override
+    {
+        processNodeBottomUp_bwdMechanicalMapping_impl(node, ctx);
+    }
     // pop-up lamdas without modifying f
     void bwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override
     {
         map->applyJT( this->mparams, lambdas, lambdas );
+    }
+
+    void processNodeBottomUp_bwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        processNodeBottomUp_bwdMechanicalState_impl(node, ctx);
     }
 
     // for all dofs, f += lambda / dt
@@ -256,6 +274,11 @@ public:
 
             mm->vOp( this->params, resid, resid, lambdasid, invdt ); // f += lambda / dt
         }
+    }
+
+    void processNodeBottomUp_bwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        processNodeBottomUp_bwdMappedMechanicalState_impl(node, ctx);
     }
 
     void bwdMappedMechanicalState(simulation::Node* node, core::behavior::BaseMechanicalState* mm) override
@@ -317,6 +340,10 @@ public:
     }
 
 
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMappedMechanicalState_impl(node, ctx);
+    }
     Result fwdMappedMechanicalState(simulation::Node* node, core::behavior::BaseMechanicalState* state) override
     {
         // lambdas should only be present at compliance location
@@ -330,6 +357,10 @@ public:
         return RESULT_CONTINUE;
     }
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMechanicalState_impl(node, ctx);
+    }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* state) override
     {
         // compliance cannot be present at independent dof level
@@ -338,12 +369,20 @@ public:
         return RESULT_CONTINUE;
     }
 
+    void processNodeBottomUp_bwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override
+    {
+        processNodeBottomUp_bwdMechanicalMapping_impl(node, ctx);
+    }
     void bwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override
     {
         if( propagate )
             map->applyJT(mparams, force, force);
     }
 
+    void processNodeBottomUp_bwdProjectiveConstraintSet(simulation::Node* node, VisitorContext* ctx) override
+    {
+        processNodeBottomUp_bwdProjectiveConstraintSet_impl(node, ctx);
+    }
     void bwdProjectiveConstraintSet(simulation::Node* /*node*/, core::behavior::BaseProjectiveConstraintSet* c) override
     {
         if( propagate )
@@ -369,6 +408,10 @@ public:
     {
     }
 
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMappedMechanicalState_impl(node, ctx);
+    }
     Result fwdMappedMechanicalState(simulation::Node* node, core::behavior::BaseMechanicalState* state) override
     {
         if( node->forceField.empty() || !node->forceField[0]->isCompliance.getValue() )
@@ -381,6 +424,10 @@ public:
         return RESULT_CONTINUE;
     }
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMechanicalState_impl(node, ctx);
+    }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* state) override
     {
         // compliance cannot be present at independent dof level
@@ -390,11 +437,19 @@ public:
         return RESULT_CONTINUE;
     }
 
+    void processNodeBottomUp_bwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override
+    {
+        processNodeBottomUp_bwdMechanicalMapping_impl(node, ctx);
+    }
     void bwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override
     {
         map->applyJT(mparams, lambda, lambda);
     }
 
+    void processNodeBottomUp_bwdProjectiveConstraintSet(simulation::Node* node, VisitorContext* ctx) override
+    {
+        processNodeBottomUp_bwdProjectiveConstraintSet_impl(node, ctx);
+    }
     void bwdProjectiveConstraintSet(simulation::Node* /*node*/, core::behavior::BaseProjectiveConstraintSet* c) override
     {
         c->projectResponse( mparams, lambda );

--- a/applications/plugins/Compliant/odesolver/CompliantNLImplicitSolver.cpp
+++ b/applications/plugins/Compliant/odesolver/CompliantNLImplicitSolver.cpp
@@ -80,6 +80,10 @@ public:
 #endif
     }
 
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMappedMechanicalState_impl(node, ctx);
+    }
     Result fwdMappedMechanicalState(simulation::Node* node, core::behavior::BaseMechanicalState* mm) override
     {
         if( node->forceField.empty() || node->forceField[0]->isCompliance.getValue() )
@@ -87,7 +91,10 @@ public:
         return RESULT_CONTINUE;
     }
 
-
+    void processNodeBottomUp_bwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override
+    {
+        processNodeBottomUp_bwdMechanicalMapping_impl(node, ctx);
+    }
     void bwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override
     {
         //       cerr<<"MechanicalComputeForceVisitor::bwdMechanicalMapping "<<map->getName()<<endl;
@@ -102,7 +109,10 @@ public:
 
     }
 
-
+    void processNodeBottomUp_bwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        processNodeBottomUp_bwdMechanicalState_impl(node, ctx);
+    }
     void bwdMechanicalState(simulation::Node* , core::behavior::BaseMechanicalState* mm) override
     {
         mm->forceMask.activate(false);
@@ -142,11 +152,21 @@ public:
         , invdt( -1.0/dt )
     {
     }
+
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMechanicalState_impl(node, ctx);
+    }
     Result fwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override
     {
         mm->resetForce(this->params, res.getId(mm));
         mm->accumulateForce(this->params, res.getId(mm));
         return RESULT_CONTINUE;
+    }
+
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMappedMechanicalState_impl(node, ctx);
     }
     Result fwdMappedMechanicalState(simulation::Node* node, core::behavior::BaseMechanicalState* mm) override
     {
@@ -181,6 +201,10 @@ public:
 #endif
     }
 
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMappedMechanicalState_impl(node, ctx);
+    }
     // TODO how to propagate lambdas without invalidating forces on mapped dofs?
     Result fwdMappedMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override
     {
@@ -188,7 +212,10 @@ public:
         return RESULT_CONTINUE;
     }
 
-
+    Result processNodeTopDown_fwdForceField(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdForceField_impl(node, ctx);
+    }
     Result fwdForceField(simulation::Node* /*node*/, core::behavior::BaseForceField* ff) override
     {
         if( ff->isCompliance.getValue() )
@@ -201,7 +228,10 @@ public:
         return RESULT_CONTINUE;
     }
 
-
+    void processNodeBottomUp_bwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override
+    {
+        processNodeBottomUp_bwdMechanicalMapping_impl(node, ctx);
+    }
     void bwdMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* map) override
     {
         ForceMaskActivate( map->getMechFrom() );
@@ -210,11 +240,19 @@ public:
         ForceMaskDeactivate( map->getMechTo() );
     }
 
+    void processNodeBottomUp_bwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        processNodeBottomUp_bwdMechanicalState_impl(node, ctx);
+    }
     void bwdMechanicalState(simulation::Node* /*node*/, core::behavior::BaseMechanicalState* mm) override
     {
         mm->forceMask.activate(false);
     }
 
+    void processNodeBottomUp_bwdProjectiveConstraintSet(simulation::Node* node, VisitorContext* ctx) override
+    {
+        processNodeBottomUp_bwdProjectiveConstraintSet_impl(node, ctx);
+    }
     void bwdProjectiveConstraintSet(simulation::Node* /*node*/, core::behavior::BaseProjectiveConstraintSet* c) override
     {
         c->projectResponse( this->mparams, res );

--- a/applications/plugins/Compliant/odesolver/CompliantStaticSolver.cpp
+++ b/applications/plugins/Compliant/odesolver/CompliantStaticSolver.cpp
@@ -303,12 +303,20 @@ public:
 
         return RESULT_CONTINUE;
     }
-    
+
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMappedMechanicalState_impl(node, ctx);
+    }
     Result fwdMappedMechanicalState(simulation::Node* node,
                                             core::behavior::BaseMechanicalState* mm) override {
         return mstate(node, mm);
     }
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMechanicalState_impl(node, ctx);
+    }
     Result fwdMechanicalState(simulation::Node* node,
                                       core::behavior::BaseMechanicalState* mm) override {
         return mstate(node, mm);

--- a/applications/plugins/Compliant/utils/expr.h
+++ b/applications/plugins/Compliant/utils/expr.h
@@ -57,7 +57,11 @@ public:
     }
 
 protected:
-    
+
+    Result processNodeTopDown_fwdMappedMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMappedMechanicalState_impl(node, ctx);
+    }
     virtual Result fwdMappedMechanicalState(sofa::simulation::Node* node,
                                             sofa::core::behavior::BaseMechanicalState* mm) {
         if(mapped) {
@@ -67,6 +71,10 @@ protected:
         
     }
 
+    Result processNodeTopDown_fwdMechanicalState(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdMechanicalState_impl(node, ctx);
+    }
     virtual Result fwdMechanicalState(sofa::simulation::Node* node,
                                       sofa::core::behavior::BaseMechanicalState* mm) {
         _delegate->exec(mparams, mm);

--- a/modules/SofaConstraint/src/SofaConstraint/ConstraintAnimationLoop.h
+++ b/modules/SofaConstraint/src/SofaConstraint/ConstraintAnimationLoop.h
@@ -50,6 +50,10 @@ public:
 #endif
     }
 
+    Result processNodeTopDown_fwdConstraintSet(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdConstraintSet_impl(node, ctx);
+    }
     Result fwdConstraintSet(simulation::Node* node, core::behavior::BaseConstraintSet* cSet) override;
     // This visitor must go through all mechanical mappings, even if isMechanical flag is disabled
     bool stopAtMechanicalMapping(simulation::Node* /*node*/, core::BaseMapping* /*map*/) override;
@@ -80,6 +84,10 @@ public:
 #endif
     }
 
+    Result processNodeTopDown_fwdConstraintSet(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdConstraintSet_impl(node, ctx);
+    }
     Result fwdConstraintSet(simulation::Node* node, core::behavior::BaseConstraintSet* c) override;
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes
@@ -115,6 +123,10 @@ public:
 #endif
     }
 
+    void processNodeBottomUp_bwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override
+    {
+        processNodeBottomUp_bwdMechanicalMapping_impl(node, ctx);
+    }
     void bwdMechanicalMapping(simulation::Node* node, core::BaseMapping* map) override;
     /// Return a class name for this visitor
     /// Only used for debugging / profiling purposes

--- a/modules/SofaConstraint/src/SofaConstraint/ConstraintSolverImpl.h
+++ b/modules/SofaConstraint/src/SofaConstraint/ConstraintSolverImpl.h
@@ -89,6 +89,10 @@ public:
 #endif
     }
 
+    Result processNodeTopDown_fwdConstraintSet(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdConstraintSet_impl(node, ctx);
+    }
     Result fwdConstraintSet(simulation::Node* node, core::behavior::BaseConstraintSet* c) override
     {
         ctime_t t0 = begin(node, c);

--- a/modules/SofaConstraint/src/SofaConstraint/ConstraintStoreLambdaVisitor.h
+++ b/modules/SofaConstraint/src/SofaConstraint/ConstraintStoreLambdaVisitor.h
@@ -34,8 +34,16 @@ class SOFA_SOFACONSTRAINT_API ConstraintStoreLambdaVisitor : public BaseMechanic
 public:
     ConstraintStoreLambdaVisitor(const sofa::core::ConstraintParams* cParams, const sofa::defaulttype::BaseVector* lambda);
 
+    Result processNodeTopDown_fwdConstraintSet(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdConstraintSet_impl(node, ctx);
+    }
     Visitor::Result fwdConstraintSet(simulation::Node* node, core::behavior::BaseConstraintSet* cSet) override;
 
+    void processNodeBottomUp_bwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override
+    {
+        processNodeBottomUp_bwdMechanicalMapping_impl(node, ctx);
+    }
     void bwdMechanicalMapping(simulation::Node* node, core::BaseMapping* map) override;
 
     bool stopAtMechanicalMapping(simulation::Node* node, core::BaseMapping* map) override;

--- a/modules/SofaConstraint/src/SofaConstraint/GenericConstraintSolver.h
+++ b/modules/SofaConstraint/src/SofaConstraint/GenericConstraintSolver.h
@@ -152,6 +152,10 @@ class SOFA_SOFACONSTRAINT_API MechanicalGetConstraintResolutionVisitor : public 
 public:
     MechanicalGetConstraintResolutionVisitor(const core::ConstraintParams* params, std::vector<core::behavior::ConstraintResolution*>& res);
 
+    Result processNodeTopDown_fwdConstraintSet(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdConstraintSet_impl(node, ctx);
+    }
     Result fwdConstraintSet(simulation::Node* node, core::behavior::BaseConstraintSet* cSet) override;
 
     /// Return a class name for this visitor

--- a/modules/SofaConstraint/src/SofaConstraint/LCPConstraintSolver.h
+++ b/modules/SofaConstraint/src/SofaConstraint/LCPConstraintSolver.h
@@ -71,6 +71,10 @@ public:
 #endif
     }
 
+    Result processNodeTopDown_fwdConstraintSet(simulation::Node* node, VisitorContext* ctx) override
+    {
+        return processNodeTopDown_fwdConstraintSet_impl(node, ctx);
+    }
     Result fwdConstraintSet(simulation::Node* node, core::behavior::BaseConstraintSet* cSet) override
     {
         if (core::behavior::BaseConstraint *c=cSet->toBaseConstraint())

--- a/modules/SofaGeneralAnimationLoop/src/SofaGeneralAnimationLoop/MechanicalMatrixMapper.h
+++ b/modules/SofaGeneralAnimationLoop/src/SofaGeneralAnimationLoop/MechanicalMatrixMapper.h
@@ -53,6 +53,10 @@ public:
 
     }
 
+    void processNodeBottomUp_bwdMechanicalMapping(simulation::Node* node, VisitorContext* ctx) override
+    {
+        processNodeBottomUp_bwdMechanicalMapping_impl(node, ctx);
+    }
     void bwdMechanicalMapping(simulation::Node* node, core::BaseMapping* map) override
     {
         ctime_t t0 = begin(node, map);


### PR DESCRIPTION
### Context

All instances of the derived classes of `BaseMechanicalVisitor` execute the same functions `processNodeTopDown` and `processNodeBottomUp`, defined in the base class, and are generally **not** overriden.

In the functions `processNodeTopDown` and `processNodeBottomUp`, a set of other functions are executed. They have a prefix _fwd_ if they are executed in `processNodeTopDown` and _bwd_ if executed in `processNodeBottomUp`. The functions _fwd_* and _bwd_* are generally overriden, but not all of them. By default, they do nothing.

In the functions `processNodeTopDown` and `processNodeBottomUp`, the functions _fwd_* and _bwd_* are surrounded by boilerplate code which is executed even if the functions _fwd_* and _bwd_* are not overriden, i.e. even if they do nothing.

Moreover, all the _fwd_* and _bwd_* functions act on objects or containers, stored in a Node. However, in the context of concurrent tasks, those objects and containers can change. In particular, adding an element to a container invalidates the iterators. It is a problem if a visitor was in the middle of a loop over the container. This problem can occur even if the visitor was not design to work on this specific container through the override of _fwd_* and _bwd_* functions, because of the boilerplate code.

In a nutshell, there are race conditions which can be avoided if the derived class can execute only the code they are designed to execute, and nothing more.

### Proposition

I added two groups of function in `BaseMechanicalVisitor`:
- `processNodeTopDown_fwd*` and `processNodeBottomUp_bwd*`: in the base class they do nothing. In the derived class, they must execute the corresponding `processNodeTopDown_fwd*_impl` or `processNodeBottomUp_bwd*_impl` function.
- `processNodeTopDown_fwd*_impl` and `processNodeBottomUp_bwd*_impl` which have a content and will execute the goal of the visitor. Those functions are not meant to be overriden by the derived classes. They are provided so derived class can call them when they override `processNodeTopDown_fwd*` or `processNodeBottomUp_bwd*`.

### Example

`MechanicalGetDimensionVisitor` inherits from `BaseMechanicalVisitor` and overrides `fwdMechanicalState`. In order for `fwdMechanicalState` to be executed, it must also override `processNodeTopDown_fwdMechanicalState`. In `processNodeTopDown_fwdMechanicalState`, it just have to call `processNodeTopDown_fwdMechanicalState_impl`.

### Pros

- Avoid unnecessary race conditions
- Does not execute unnecessary boilerplate code
- Benefit from inheritance and avoid runtime checks compared to PR #1962 

### Cons

- Breaks all classes derived from `BaseMechanicalVisitor`
- Forces the developers of classes derived from `BaseMechanicalVisitor` to derive more functions

This PR is not to merge yet. It is suggested as an alternative to PR #1962 
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
