### PR TITLE
[all] Quick test for unity-build 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,19 @@ else()
     set(DISABLE_PRECOMPILE_HEADERS ON)
 endif()
 
+# Option to accelerate the compilation
+# see https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html
+cmake_dependent_option(SOFA_BUILD_WITH_UNITY_BUILD_ENABLED
+    "Compile SOFA using unity build (to accelerate the build process)" OFF
+    "CMAKE_VERSION VERSION_GREATER_EQUAL 3.16" OFF)
+if(SOFA_BUILD_WITH_UNITY_BUILD_ENABLED)
+    message("-- Unity build: enabled (SOFA_BUILD_WITH_UNITY_BUILD_ENABLED is ON).")
+    set(SOFA_UNITY_BUILD_BATCH_SIZE 8)
+else()
+    message("-- Unity build: disabled (SOFA_BUILD_WITH_UNITY_BUILD_ENABLED is OFF or CMake < 3.16).")
+endif()
+
+
 ## Change default install prefix
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/install CACHE PATH "Install path prefix, prepended onto install directories." FORCE)

--- a/SofaKernel/modules/Sofa.Config/cmake/SofaMacrosConfigure.cmake
+++ b/SofaKernel/modules/Sofa.Config/cmake/SofaMacrosConfigure.cmake
@@ -175,6 +175,23 @@ macro(sofa_add_application directory app_name)
     sofa_add_generic( ${directory} ${app_name} "Application" DEFAULT_VALUE "${ARGV2}" ${ARGN})
 endmacro()
 
+function(sofa_configure_unity_build)
+    set(optionArgs)
+    set(oneValueArgs TARGET ACTIVATED BATCHSIZE)
+    set(multiValueArgs)
+    cmake_parse_arguments("ARG" "${optionArgs}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(${ARG_ACTIVATED})
+        message("-- ${ARG_TARGET}: Unity build activated, batch size ${ARG_BATCHSIZE}.")
+        set_target_properties(${PROJECT_NAME} PROPERTIES
+                              UNITY_BUILD true
+                              UNITY_BUILD_MODE BATCH
+                              UNITY_BUILD_BATCH_SIZE "${ARG_BATCHSIZE}"
+                              )
+    else()
+        message("-- ${ARG_TARGET}: Unity build de-activated.")
+    endif()
+endfunction()
 
 ### External projects management
 # Thanks to http://crascit.com/2015/07/25/cmake-gtest/

--- a/SofaKernel/modules/SofaBaseCollision/CMakeLists.txt
+++ b/SofaKernel/modules/SofaBaseCollision/CMakeLists.txt
@@ -76,6 +76,10 @@ sofa_find_package(SofaFramework REQUIRED)
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaCore SofaSimulationCore)
 
+sofa_configure_unity_build(TARGET ${PROJECT_NAME}
+                           ACTIVATED "${SOFA_BUILD_WITH_UNITY_BUILD_ENABLED}"
+                           BATCHSIZE "${SOFA_UNITY_BUILD_BATCH_SIZE}")
+
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Silence attribute warnings (for example, ignored already defined external template)
     target_compile_options(${PROJECT_NAME} PRIVATE -Wno-attributes)

--- a/SofaKernel/modules/SofaDeformable/CMakeLists.txt
+++ b/SofaKernel/modules/SofaDeformable/CMakeLists.txt
@@ -43,6 +43,10 @@ if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     target_compile_options(${PROJECT_NAME} PRIVATE -Wno-attributes)
 endif()
 
+sofa_configure_unity_build(TARGET ${PROJECT_NAME}
+                           ACTIVATED "${SOFA_BUILD_WITH_UNITY_BUILD_ENABLED}"
+                           BATCHSIZE "${SOFA_UNITY_BUILD_BATCH_SIZE}")
+
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}
     PACKAGE_VERSION ${Sofa_VERSION}

--- a/SofaKernel/modules/SofaHelper/CMakeLists.txt
+++ b/SofaKernel/modules/SofaHelper/CMakeLists.txt
@@ -272,6 +272,10 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../SofaDefaultType/compat>")
 source_group("compat" FILES ${COMPAT_HEADER_FILES})
 
+sofa_configure_unity_build(TARGET ${PROJECT_NAME}
+                           ACTIVATED "${SOFA_BUILD_WITH_UNITY_BUILD_ENABLED}"
+                           BATCHSIZE "${SOFA_UNITY_BUILD_BATCH_SIZE}")
+
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
     target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "$<INSTALL_INTERFACE:include/extlibs/WinDepPack>")
 endif()

--- a/SofaKernel/modules/SofaMeshCollision/CMakeLists.txt
+++ b/SofaKernel/modules/SofaMeshCollision/CMakeLists.txt
@@ -72,6 +72,9 @@ sofa_find_package(SofaRigid REQUIRED)
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaObjectInteraction SofaRigid SofaBaseCollision SofaBaseMechanics SofaBaseTopology)
 
+sofa_configure_unity_build(TARGET ${PROJECT_NAME}
+                           ACTIVATED "${SOFA_BUILD_WITH_UNITY_BUILD_ENABLED}"
+                           BATCHSIZE "${SOFA_UNITY_BUILD_BATCH_SIZE}")
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Silence attribute warnings (for example, ignored already defined external template)
     target_compile_options(${PROJECT_NAME} PRIVATE -Wno-attributes)

--- a/modules/SofaGeneralMeshCollision/CMakeLists.txt
+++ b/modules/SofaGeneralMeshCollision/CMakeLists.txt
@@ -47,6 +47,10 @@ sofa_find_package(SofaRigid REQUIRED)
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaObjectInteraction SofaRigid SofaBaseCollision SofaMeshCollision)
 
+sofa_configure_unity_build(TARGET ${PROJECT_NAME}
+                           ACTIVATED "${SOFA_BUILD_WITH_UNITY_BUILD_ENABLED}"
+                           BATCHSIZE "${SOFA_UNITY_BUILD_BATCH_SIZE}")
+
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}
     PACKAGE_VERSION ${Sofa_VERSION}

--- a/modules/SofaGeneralRigid/CMakeLists.txt
+++ b/modules/SofaGeneralRigid/CMakeLists.txt
@@ -42,6 +42,10 @@ sofa_find_package(SofaBase REQUIRED)
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaBaseMechanics)
 
+sofa_configure_unity_build(TARGET ${PROJECT_NAME}
+                           ACTIVATED "${SOFA_BUILD_WITH_UNITY_BUILD_ENABLED}"
+                           BATCHSIZE "${SOFA_UNITY_BUILD_BATCH_SIZE}")
+
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}
     PACKAGE_VERSION ${Sofa_VERSION}

--- a/modules/SofaGeneralSimpleFem/CMakeLists.txt
+++ b/modules/SofaGeneralSimpleFem/CMakeLists.txt
@@ -48,6 +48,10 @@ sofa_find_package(SofaBaseLinearSolver REQUIRED)
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaBaseTopology SofaSimpleFem SofaBaseLinearSolver SofaBaseMechanics)
 
+sofa_configure_unity_build(TARGET ${PROJECT_NAME}
+                           ACTIVATED "${SOFA_BUILD_WITH_UNITY_BUILD_ENABLED}"
+                           BATCHSIZE "${SOFA_UNITY_BUILD_BATCH_SIZE}")
+
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}
     PACKAGE_VERSION ${Sofa_VERSION}

--- a/modules/SofaGeneralTopology/CMakeLists.txt
+++ b/modules/SofaGeneralTopology/CMakeLists.txt
@@ -30,6 +30,10 @@ sofa_find_package(SofaBase REQUIRED) # SofaBaseTopology
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaBaseTopology)
 
+sofa_configure_unity_build(TARGET ${PROJECT_NAME}
+                           ACTIVATED "${SOFA_BUILD_WITH_UNITY_BUILD_ENABLED}"
+                           BATCHSIZE "${SOFA_UNITY_BUILD_BATCH_SIZE}")
+
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}
     PACKAGE_VERSION ${Sofa_VERSION}

--- a/modules/SofaGraphComponent/CMakeLists.txt
+++ b/modules/SofaGraphComponent/CMakeLists.txt
@@ -60,6 +60,10 @@ list(APPEND SOURCE_FILES
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaHelper SofaSimulationCore SofaBaseUtils)
 
+sofa_configure_unity_build(TARGET ${PROJECT_NAME}
+                           ACTIVATED "${SOFA_BUILD_WITH_UNITY_BUILD_ENABLED}"
+                           BATCHSIZE "${SOFA_UNITY_BUILD_BATCH_SIZE}")
+
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}
     PACKAGE_VERSION ${Sofa_VERSION}

--- a/modules/SofaGuiCommon/CMakeLists.txt
+++ b/modules/SofaGuiCommon/CMakeLists.txt
@@ -57,6 +57,10 @@ add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${COMPAT_HEAD
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaBase SofaGraphComponent SofaUserInteraction SofaSimulationCommon)
 target_link_libraries(${PROJECT_NAME} PUBLIC Boost::program_options)
 
+sofa_configure_unity_build(TARGET ${PROJECT_NAME}
+                           ACTIVATED "${SOFA_BUILD_WITH_UNITY_BUILD_ENABLED}"
+                           BATCHSIZE "${SOFA_UNITY_BUILD_BATCH_SIZE}")
+
 if (SOFA_BUILD_RELEASE_PACKAGE OR CMAKE_SYSTEM_NAME STREQUAL Windows)
     sofa_install_libraries(PATHS ${Boost_LIBRARIES}) # Boost_LIBRARIES covers Boost internal dependencies
 endif()

--- a/modules/SofaGuiQt/CMakeLists.txt
+++ b/modules/SofaGuiQt/CMakeLists.txt
@@ -340,6 +340,9 @@ if(SOFAGUIQT_ENABLE_NODEGRAPH)
     endif()
 endif()
 
+sofa_configure_unity_build(TARGET ${PROJECT_NAME}
+                           ACTIVATED "${SOFA_BUILD_WITH_UNITY_BUILD_ENABLED}"
+                           BATCHSIZE "${SOFA_UNITY_BUILD_BATCH_SIZE}")
 
 # FFMPEG
 if(FFMPEG_EXEC_FOUND)

--- a/modules/SofaMiscFem/CMakeLists.txt
+++ b/modules/SofaMiscFem/CMakeLists.txt
@@ -81,6 +81,11 @@ sofa_create_package_with_targets(
     RELOCATABLE "plugins"
     )
 
+
+sofa_configure_unity_build(TARGET ${PROJECT_NAME}
+                           ACTIVATED "${SOFA_BUILD_WITH_UNITY_BUILD_ENABLED}"
+                           BATCHSIZE "${SOFA_UNITY_BUILD_BATCH_SIZE}")
+
 # Tests
 # If SOFA_BUILD_TESTS exists and is OFF, then these tests will be auto-disabled
 cmake_dependent_option(SOFAMISCFEM_BUILD_TESTS "Compile the automatic tests" ON "SOFA_BUILD_TESTS OR NOT DEFINED SOFA_BUILD_TESTS" OFF)

--- a/modules/SofaMiscForceField/CMakeLists.txt
+++ b/modules/SofaMiscForceField/CMakeLists.txt
@@ -42,6 +42,10 @@ sofa_find_package(SofaMiscTopology REQUIRED)
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaHelper SofaDeformable SofaBoundaryCondition SofaMiscTopology SofaGeneralTopology)
 
+sofa_configure_unity_build(TARGET ${PROJECT_NAME}
+                           ACTIVATED "${SOFA_BUILD_WITH_UNITY_BUILD_ENABLED}"
+                           BATCHSIZE "${SOFA_UNITY_BUILD_BATCH_SIZE}")
+
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Silence attribute warnings (for example, ignored already defined external template)
     target_compile_options(${PROJECT_NAME} PRIVATE -Wno-attributes)

--- a/modules/SofaMiscSolver/CMakeLists.txt
+++ b/modules/SofaMiscSolver/CMakeLists.txt
@@ -21,6 +21,10 @@ set(SOURCE_FILES
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaCore SofaSimulationCore)
 
+sofa_configure_unity_build(TARGET ${PROJECT_NAME}
+                           ACTIVATED "${SOFA_BUILD_WITH_UNITY_BUILD_ENABLED}"
+                           BATCHSIZE "${SOFA_UNITY_BUILD_BATCH_SIZE}")
+
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}
     PACKAGE_VERSION ${Sofa_VERSION}

--- a/modules/SofaNonUniformFem/CMakeLists.txt
+++ b/modules/SofaNonUniformFem/CMakeLists.txt
@@ -66,6 +66,10 @@ if(SofaDenseSolver_FOUND)
     target_link_libraries(${PROJECT_NAME} PUBLIC SofaDenseSolver)
 endif()
 
+sofa_configure_unity_build(TARGET ${PROJECT_NAME}
+                           ACTIVATED "${SOFA_BUILD_WITH_UNITY_BUILD_ENABLED}"
+                           BATCHSIZE "${SOFA_UNITY_BUILD_BATCH_SIZE}")
+
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Silence attribute warnings (for example, ignored already defined external template)
     target_compile_options(${PROJECT_NAME} PRIVATE -Wno-attributes)

--- a/modules/SofaOpenglVisual/CMakeLists.txt
+++ b/modules/SofaOpenglVisual/CMakeLists.txt
@@ -80,8 +80,11 @@ set(EXTRA_FILES
     )
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${EXTRA_FILES})
-
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaBaseVisual SofaSimulationCore Sofa.GL)
+
+sofa_configure_unity_build(TARGET ${PROJECT_NAME}
+                           ACTIVATED "${SOFA_BUILD_WITH_UNITY_BUILD_ENABLED}"
+                           BATCHSIZE "${SOFA_UNITY_BUILD_BATCH_SIZE}")
 
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}

--- a/modules/SofaPreconditioner/CMakeLists.txt
+++ b/modules/SofaPreconditioner/CMakeLists.txt
@@ -43,6 +43,11 @@ sofa_find_package(SofaSparseSolver QUIET) # Soft dependency of PrecomputedWarpPr
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaImplicitOdeSolver SofaGeneralLinearSolver SofaSimpleFem)
+
+sofa_configure_unity_build(TARGET ${PROJECT_NAME}
+                           ACTIVATED "${SOFA_BUILD_WITH_UNITY_BUILD_ENABLED}"
+                           BATCHSIZE "${SOFA_UNITY_BUILD_BATCH_SIZE}")
+
 if(SofaSparseSolver_FOUND)
     target_link_libraries(${PROJECT_NAME} PUBLIC SofaSparseSolver)
 endif()

--- a/modules/SofaTopologyMapping/CMakeLists.txt
+++ b/modules/SofaTopologyMapping/CMakeLists.txt
@@ -48,6 +48,10 @@ sofa_find_package(SofaGeneralTopology REQUIRED)
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaGeneralTopology SofaGeneralSimpleFem)
 
+sofa_configure_unity_build(TARGET ${PROJECT_NAME}
+                           ACTIVATED "${SOFA_BUILD_WITH_UNITY_BUILD_ENABLED}"
+                           BATCHSIZE "${SOFA_UNITY_BUILD_BATCH_SIZE}")
+
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}
     PACKAGE_VERSION ${Sofa_VERSION}

--- a/modules/SofaUserInteraction/CMakeLists.txt
+++ b/modules/SofaUserInteraction/CMakeLists.txt
@@ -79,6 +79,10 @@ sofa_find_package(SofaGraphComponent REQUIRED)
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaMeshCollision SofaGeneralMeshCollision SofaGeneralVisual SofaTopologyMapping SofaDeformable SofaBoundaryCondition SofaGraphComponent)
 
+sofa_configure_unity_build(TARGET ${PROJECT_NAME}
+                           ACTIVATED "${SOFA_BUILD_WITH_UNITY_BUILD_ENABLED}"
+                           BATCHSIZE "${SOFA_UNITY_BUILD_BATCH_SIZE}")
+
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Silence attribute warnings (for example, ignored already defined external template)
     target_compile_options(${PROJECT_NAME} PRIVATE -Wno-attributes)


### PR DESCRIPTION
Quick test to check the behavior of unity-build on the CI (eg: ram limit)

It would be nice to gather some statistics on pch/unity build (poke @alxbilger, @fredroy, @guparan) because the performance can increase/decrease with unity build for low memory system. Having insight on wether or not we activate them (in the CI for example)

Damien's latop: 8 core, 32GB Ram, linux 
```console
- clang/debug: 03:37 min
- clang/debug/pch: 03:05 min
- clang/debug/unity: 03:01 min
- clang/debug/pch+unity: 02:32 min
 
- clang/release: 05:58 min
- clang/release/pch: 05:06 min
- clang/release/unity: 05:43 min
- clang/release/pch+unity: 05:01 min
```
PROs: pch and unity build are a good way to detect duplicated code and can reduce compilation time.
CONs: pch and unity build can be problematic as they hides possibly missing includes,  can increase compilation time (memory limit. Not very c++20 module friendly ?

NB 1: unity build is only partially deployed until the PRs, fusing duplicated code, made by @alxbilger are not merged. 

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
