### PR TITLE
[Sofa.Topology] remove unnecessary pragma

### DIFF
--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Point.cpp
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Point.cpp
@@ -19,7 +19,6 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#pragma once
 
 #include <sofa/topology/config.h>
 


### PR DESCRIPTION
`#pragma once` in a cpp file.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
