### PR TITLE
[SofaBaseTopology] Remove warning when a Data is directly linked to a topoogy Data container

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyContainer.cpp
@@ -268,9 +268,6 @@ void PointSetTopologyContainer::updateDataEngineGraph(sofa::core::objectmodel::B
                 next_enginesLevel.push_back(topoEngine);
                 enginesNames.push_back(topoEngine->getName());
             }
-
-            sofa::core::objectmodel::BaseData* data = dynamic_cast<sofa::core::objectmodel::BaseData*>( (*it) );
-            msg_warning_when(data) << "Data alone linked: " << data->getName();
         }
 
         _outs.clear();


### PR DESCRIPTION
This will remove the warning: "Data alone linked"

Note for myself for this loop:
Possible duplication in update mechanism as Data<m_changeList> is set to dirty when a toplogyChange is added and at the same time PointSetTopologyContainer handle the topologyEngine update manually in this loop.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
