### PR TITLE
[SofaBaseTopology] Proper overload of virtual functions

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.h
@@ -77,7 +77,7 @@ public:
 
     /** Public functions to handle topological engine creation */
     /// To create topological engine link to this Data. Pointer to current topology is needed.
-    virtual void createTopologicalEngine(sofa::core::topology::BaseMeshTopology* _topology, sofa::component::topology::TopologyDataHandler<TopologyElementType,VecT>* _topologyHandler, bool deleteHandler = false);
+    virtual void createTopologicalEngine(sofa::core::topology::BaseMeshTopology* _topology, sofa::core::topology::TopologyHandler* _topologyHandler, bool deleteHandler = false);
 
     /** Public functions to handle topological engine creation */
     /// To create topological engine link to this Data. Pointer to current topology is needed.
@@ -134,7 +134,7 @@ protected:
 
     typename sofa::component::topology::TopologyDataEngine<VecT>::SPtr m_topologicalEngine;
     sofa::core::topology::BaseMeshTopology* m_topology;
-    sofa::component::topology::TopologyDataHandler<TopologyElementType,VecT>* m_topologyHandler;
+    sofa::core::topology::TopologyHandler* m_topologyHandler;
 
     void linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Point*      ) { linkToPointDataArray();       }
     void linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Edge*       ) { linkToEdgeDataArray();        }

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
@@ -34,7 +34,7 @@ namespace sofa::component::topology
 
 
 template <typename TopologyElementType, typename VecT>
-void TopologyData <TopologyElementType, VecT>::createTopologicalEngine(sofa::core::topology::BaseMeshTopology *_topology, sofa::component::topology::TopologyDataHandler<TopologyElementType,VecT>* _topologyHandler, bool deleteHandler)
+void TopologyData <TopologyElementType, VecT>::createTopologicalEngine(sofa::core::topology::BaseMeshTopology *_topology, sofa::core::topology::TopologyHandler* _topologyHandler, bool deleteHandler)
 {
     this->m_topology = _topology;
     if (_topology && dynamic_cast<sofa::core::topology::TopologyContainer*>(_topology))

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologySparseData.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologySparseData.h
@@ -64,11 +64,11 @@ public:
 
     /** Public functions to handle topological engine creation */
     /// To create topological engine link to this Data. Pointer to current topology is needed.
-    virtual void createTopologicalEngine(sofa::core::topology::BaseMeshTopology* _topology, sofa::core::topology::TopologyHandler* _topologyHandler);
+    void createTopologicalEngine(sofa::core::topology::BaseMeshTopology* _topology, sofa::core::topology::TopologyHandler* _topologyHandler, bool deleteHandler = false) override;
 
     /** Public functions to handle topological engine creation */
     /// To create topological engine link to this Data. Pointer to current topology is needed.
-    virtual void createTopologicalEngine(sofa::core::topology::BaseMeshTopology* _topology);
+    void createTopologicalEngine(sofa::core::topology::BaseMeshTopology* _topology) override;
 
 
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologySparseData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologySparseData.inl
@@ -41,7 +41,7 @@ TopologySparseData <TopologyElementType, VecT>::~TopologySparseData()
 
 
 template <typename TopologyElementType, typename VecT>
-void TopologySparseData <TopologyElementType, VecT>::createTopologicalEngine(sofa::core::topology::BaseMeshTopology *_topology, sofa::core::topology::TopologyHandler *_topologyHandler)
+void TopologySparseData <TopologyElementType, VecT>::createTopologicalEngine(sofa::core::topology::BaseMeshTopology *_topology, sofa::core::topology::TopologyHandler *_topologyHandler, bool /*deleteHandler*/)
 {
     this->m_topology = _topology;
     if (_topology && dynamic_cast<sofa::core::topology::TopologyContainer*>(_topology))

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologySubsetData.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologySubsetData.h
@@ -65,11 +65,11 @@ public:
 
     /** Public functions to handle topological engine creation */
     /// To create topological engine link to this Data. Pointer to current topology is needed.
-    virtual void createTopologicalEngine(sofa::core::topology::BaseMeshTopology* _topology, sofa::core::topology::TopologyHandler* _topologyHandler);
+    void createTopologicalEngine(sofa::core::topology::BaseMeshTopology* _topology, sofa::core::topology::TopologyHandler* _topologyHandler, bool deleteHandler = false) override;
 
     /** Public functions to handle topological engine creation */
     /// To create topological engine link to this Data. Pointer to current topology is needed.
-    virtual void createTopologicalEngine(sofa::core::topology::BaseMeshTopology* _topology);
+    void createTopologicalEngine(sofa::core::topology::BaseMeshTopology* _topology) override;
 
 
 protected:

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologySubsetData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologySubsetData.inl
@@ -34,7 +34,7 @@ namespace sofa::component::topology
 
 
 template <typename TopologyElementType, typename VecT>
-void TopologySubsetData <TopologyElementType, VecT>::createTopologicalEngine(sofa::core::topology::BaseMeshTopology *_topology, sofa::core::topology::TopologyHandler *_topologyHandler)
+void TopologySubsetData <TopologyElementType, VecT>::createTopologicalEngine(sofa::core::topology::BaseMeshTopology *_topology, sofa::core::topology::TopologyHandler *_topologyHandler, bool /*deleteHandler*/)
 {
     this->m_topology = _topology;
     if (_topology && dynamic_cast<sofa::core::topology::TopologyContainer*>(_topology))


### PR DESCRIPTION
`TopologySparseData` inherits `TopologyData`
`TopologySubsetData` inherits `TopologyData`
Both `TopologySparseData` and `TopologySubsetData` overload virtual functions defined in `TopologyData`. However, the way they were defined made clang consider this not as an overload, but as a redefinition of a new function hidding the initial virtual function.
Basically, this PR removes a compilation warning.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
