### PR TITLE
[SofaUserInteraction] Fix Bug of removing topological element when a Hexa2TetraTopologicalMapping is in the scene

### DIFF
--- a/modules/SofaUserInteraction/src/SofaUserInteraction/TopologicalChangeManager.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/TopologicalChangeManager.cpp
@@ -88,7 +88,7 @@ Index TopologicalChangeManager::removeItemsFromTriangleModel(sofa::component::co
     {
         //Quick HACK for Hexa2TetraMapping
         sofa::component::topology::Hexa2TetraTopologicalMapping* badMapping;
-        model->getContext()->get(badMapping, sofa::core::objectmodel::BaseContext::SearchRoot);
+        model->getContext()->get(badMapping, sofa::core::objectmodel::BaseContext::SearchUp);
         if(badMapping) //stop process
         {
             msg_warning("TopologicalChangeManager") << " Removing element is not handle by Hexa2TetraTopologicalMapping. Stopping process." ;

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/TopologicalChangeManager.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/TopologicalChangeManager.cpp
@@ -217,7 +217,7 @@ Index TopologicalChangeManager::removeItemsFromPointModel(sofa::component::colli
     {
         //Quick HACK for Hexa2TetraMapping
         sofa::component::topology::Hexa2TetraTopologicalMapping* badMapping;
-        model->getContext()->get(badMapping, sofa::core::objectmodel::BaseContext::SearchRoot);
+        model->getContext()->get(badMapping, sofa::core::objectmodel::BaseContext::SearchUp);
         if (badMapping) //stop process
         {
             msg_warning("TopologicalChangeManager") << " Removing element is not handle by Hexa2TetraTopologicalMapping. Stopping process.";


### PR DESCRIPTION
Removing element from TriangleModel (using the mouse) when an Hexa2TetraTopologicalmapping is in the scene was not possible because of a searchRoot even if the mapping has nothing to see with the current topology being manipulated. 




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
