### PR TITLE
[SofaGeneralEngine] Add option in NearestPointROI to use restPosition or position

### DIFF
--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.h
@@ -67,6 +67,8 @@ public:
     SetIndex f_indices1; ///< Indices of the source points on the first model
     SetIndex f_indices2; ///< Indices of the fixed points on the second model
     Data<Real> f_radius; ///< Radius to search corresponding fixed point if no indices are given
+    Data<bool> d_useRestPosition; ///< If true will use rest position only at init. Otherwise will recompute the maps at each update. Default is true.
+    
     SingleLink<NearestPointROI<DataTypes>, MechanicalState<DataTypes>, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> mstate1;
     SingleLink<NearestPointROI<DataTypes>, MechanicalState<DataTypes>, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> mstate2;
 
@@ -77,6 +79,9 @@ public:
     void init() override;
     void reinit() override;
     void doUpdate() override;
+
+protected:
+    void computeNearestPointMaps(const VecCoord& x1, const VecCoord& x2);
 };
 
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
@@ -51,22 +51,47 @@ NearestPointROI<DataTypes>::~NearestPointROI()
 template <class DataTypes>
 void NearestPointROI<DataTypes>::init()
 {
-    if(!mstate1 || !mstate2) {
-        msg_error() << "Cannot Initialize without valid objects";
-        //mstate1->set(static_cast<simulation::Node*>(this->getContext())->getMechanicalState());
+    // Test inputs
+    bool success = true;
+    if (mstate1 && !mstate1.get())
+    {
+        msg_error_when(!mstate1.get()) << "Cannot Initialize, mstate1 link is pointing to invalid object!";
+        success = false;
     }
+    else if (!mstate1)
+    {
+        msg_error_when(!mstate1) << "Cannot Initialize, mstate1 link is invalid!";
+        success = false;
+    }
+
+    if (mstate2 && !mstate2.get())
+    {
+        msg_error_when(!mstate2.get()) << "Cannot Initialize, mstate2 link is pointing to invalid object!";
+        success = false;
+    }
+    else if (!mstate2)
+    {
+        msg_error_when(!mstate2) << "Cannot Initialize, mstate2 link is invalid!";
+        success = false;
+    }
+
+    if(!success) {
+        this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+        return;
+    }
+
+
 
     addInput(this->mstate1->findData("rest_position"));
     addInput(this->mstate2->findData("rest_position"));
     addOutput(&f_indices1);
     addOutput(&f_indices2);
-
-    reinit();
 }
 
 template <class DataTypes>
 void NearestPointROI<DataTypes>::reinit()
 {
+    this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
     if(f_radius.getValue() <= 0){
         msg_error() << "Radius must be a positive real.";
         return;
@@ -75,6 +100,8 @@ void NearestPointROI<DataTypes>::reinit()
         msg_error() << "2 valid mechanicalobjects are required.";
         return;
     }
+
+    this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
     doUpdate();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
@@ -77,7 +77,8 @@ void NearestPointROI<DataTypes>::init()
         success = false;
     }
 
-    if(!success) {
+    if (!success)
+    {
         this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         return;
     }
@@ -118,26 +119,14 @@ void NearestPointROI<DataTypes>::reinit()
 template <class DataTypes>
 void NearestPointROI<DataTypes>::doUpdate()
 {
-    if (d_useRestPosition.getValue())
-    {
-        const VecCoord& x1 = this->mstate1->read(core::ConstVecCoordId::restPosition())->getValue();
-        const VecCoord& x2 = this->mstate2->read(core::ConstVecCoordId::restPosition())->getValue();
+    const auto vecCoordId = d_useRestPosition.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
+    const VecCoord& x1 = this->mstate1->read(vecCoordId)->getValue();
+    const VecCoord& x2 = this->mstate2->read(vecCoordId)->getValue();
 
-        if (x1.size() == 0 || x2.size() == 0)
-            return;
+    if (x1.size() == 0 || x2.size() == 0)
+        return;
 
-        computeNearestPointMaps(x1, x2);
-    }
-    else
-    {
-        const VecCoord& x1 = this->mstate1->read(core::ConstVecCoordId::position())->getValue();
-        const VecCoord& x2 = this->mstate2->read(core::ConstVecCoordId::position())->getValue();
-
-        if (x1.size() == 0 || x2.size() == 0)
-            return;
-
-        computeNearestPointMaps(x1, x2);
-    }
+    computeNearestPointMaps(x1, x2);
 }
 
 
@@ -161,7 +150,8 @@ void NearestPointROI<DataTypes>::computeNearestPointMaps(const VecCoord& x1, con
     {
         pt2 = x2[i2];
         auto el = std::min_element(std::begin(x1), std::end(x1), cmp);
-        if (dist(*el, pt2) < maxR) {
+        if (dist(*el, pt2) < maxR) 
+        {
             indices1->push_back(std::distance(std::begin(x1), el));
             indices2->push_back(i2);
         }


### PR DESCRIPTION
Add option to choose between restPosition and position. Also update the init method to better check the inputs. 

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
