### PR TITLE
[SofaDeformable] Fix test in StiffSpringForceField doUpdateInternal

### DIFF
--- a/SofaKernel/modules/SofaDeformable/src/SofaDeformable/StiffSpringForceField.h
+++ b/SofaKernel/modules/SofaDeformable/src/SofaDeformable/StiffSpringForceField.h
@@ -77,8 +77,6 @@ protected:
     StiffSpringForceField(double ks=100.0, double kd=5.0);
     StiffSpringForceField(MechanicalState* object1, MechanicalState* object2, double ks=100.0, double kd=5.0);
 
-    void doUpdateInternal() override;
-
     /// Will create the set of springs using \sa d_indices1 and \sa d_indices2 with \sa d_length
     void createSpringsFromInputs();
 

--- a/SofaKernel/modules/SofaDeformable/src/SofaDeformable/StiffSpringForceField.inl
+++ b/SofaKernel/modules/SofaDeformable/src/SofaDeformable/StiffSpringForceField.inl
@@ -55,8 +55,6 @@ void StiffSpringForceField<DataTypes>::init()
     {        
         this->trackInternalData(d_indices1);
         this->trackInternalData(d_indices2);
-
-        createSpringsFromInputs();
     }
 
     this->SpringForceField<DataTypes>::init();
@@ -65,10 +63,11 @@ void StiffSpringForceField<DataTypes>::init()
 template<class DataTypes>
 void StiffSpringForceField<DataTypes>::doUpdateInternal()
 {
-    if (!d_indices1.isSet() && !d_indices2.isSet()) // nothing to do in this case
-        return;
-
-    createSpringsFromInputs();
+    
+    if (this->hasDataChanged(d_indices1) || this->hasDataChanged(d_indices2))
+    {
+        createSpringsFromInputs();
+    }
 }
 
 

--- a/SofaKernel/modules/SofaDeformable/src/SofaDeformable/StiffSpringForceField.inl
+++ b/SofaKernel/modules/SofaDeformable/src/SofaDeformable/StiffSpringForceField.inl
@@ -36,6 +36,12 @@ template<class DataTypes>
 StiffSpringForceField<DataTypes>::StiffSpringForceField(double ks, double kd)
     : StiffSpringForceField<DataTypes>(nullptr, nullptr, ks, kd)
 {
+    this->addUpdateCallback("updateSprings-ks-kd", { &d_indices1, &d_indices2, &d_length, &this->ks, &this->kd}, [this](const core::DataTracker& t)
+    {
+        SOFA_UNUSED(t);
+        createSpringsFromInputs();
+        return sofa::core::objectmodel::ComponentState::Valid;
+    }, {&this->springs});
 }
 
 template<class DataTypes>
@@ -45,29 +51,27 @@ StiffSpringForceField<DataTypes>::StiffSpringForceField(MechanicalState* object1
     , d_indices2(initData(&d_indices2, "indices2", "Indices of the fixed points on the second model"))
     , d_length(initData(&d_length, 0.0, "length", "uniform length of all springs"))
 {
+    this->addUpdateCallback("updateSprings-m1-m2-ks-kd", { &d_indices1, &d_indices2, &d_length, &this->ks, &this->kd}, [this](const core::DataTracker& t)
+    {
+        SOFA_UNUSED(t);
+        createSpringsFromInputs();
+        return sofa::core::objectmodel::ComponentState::Valid;
+    }, {&this->springs});
 }
 
 
 template<class DataTypes>
 void StiffSpringForceField<DataTypes>::init()
 {
+    this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+
     if (d_indices1.isSet() && d_indices2.isSet())
-    {        
-        this->trackInternalData(d_indices1);
-        this->trackInternalData(d_indices2);
-    }
-
-    this->SpringForceField<DataTypes>::init();
-}
-
-template<class DataTypes>
-void StiffSpringForceField<DataTypes>::doUpdateInternal()
-{
-    
-    if (this->hasDataChanged(d_indices1) || this->hasDataChanged(d_indices2))
     {
         createSpringsFromInputs();
     }
+    this->SpringForceField<DataTypes>::init();
+
+    this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
 }
 
 
@@ -76,19 +80,20 @@ void StiffSpringForceField<DataTypes>::createSpringsFromInputs()
 {
     if (d_indices1.getValue().size() != d_indices2.getValue().size())
     {
-        msg_error() << "Inputs indices sets sizes are different: d_indices1: " << d_indices1.getValue().size() 
+        msg_error() << "Inputs indices sets sizes are different: d_indices1: " << d_indices1.getValue().size()
             << " | d_indices2 " << d_indices2.getValue().size()
             << " . No springs will be created";
         return;
     }
 
-    msg_info() << "Inputs have changed, recompute  Springs From Data Inputs";    
+    msg_info() << "Inputs have changed, recompute  Springs From Data Inputs";
+
     helper::vector<Spring>& _springs = *this->springs.beginEdit();
     _springs.clear();
 
     const SetIndexArray & indices1 = d_indices1.getValue();
     const SetIndexArray & indices2 = d_indices2.getValue();
-    
+
     const SReal& _ks = this->ks.getValue();
     const SReal& _kd = this->kd.getValue();
     const SReal& _length = d_length.getValue();

--- a/SofaKernel/modules/SofaDeformable/src/SofaDeformable/StiffSpringForceField.inl
+++ b/SofaKernel/modules/SofaDeformable/src/SofaDeformable/StiffSpringForceField.inl
@@ -36,12 +36,6 @@ template<class DataTypes>
 StiffSpringForceField<DataTypes>::StiffSpringForceField(double ks, double kd)
     : StiffSpringForceField<DataTypes>(nullptr, nullptr, ks, kd)
 {
-    this->addUpdateCallback("updateSprings-ks-kd", { &d_indices1, &d_indices2, &d_length, &this->ks, &this->kd}, [this](const core::DataTracker& t)
-    {
-        SOFA_UNUSED(t);
-        createSpringsFromInputs();
-        return sofa::core::objectmodel::ComponentState::Valid;
-    }, {&this->springs});
 }
 
 template<class DataTypes>
@@ -51,7 +45,7 @@ StiffSpringForceField<DataTypes>::StiffSpringForceField(MechanicalState* object1
     , d_indices2(initData(&d_indices2, "indices2", "Indices of the fixed points on the second model"))
     , d_length(initData(&d_length, 0.0, "length", "uniform length of all springs"))
 {
-    this->addUpdateCallback("updateSprings-m1-m2-ks-kd", { &d_indices1, &d_indices2, &d_length, &this->ks, &this->kd}, [this](const core::DataTracker& t)
+    this->addUpdateCallback("updateSprings", { &d_indices1, &d_indices2, &d_length, &this->ks, &this->kd}, [this](const core::DataTracker& t)
     {
         SOFA_UNUSED(t);
         createSpringsFromInputs();


### PR DESCRIPTION
Also avoid to call the method at ```init``` as input indices might probably not be updated yet. 





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
