### PR TITLE
[SofaCore] Remove duplicated explicit instanciation

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.cpp
@@ -23,19 +23,6 @@
 #include <sofa/core/topology/TopologyHandler.h>
 #include <sofa/helper/AdvancedTimer.h>
 
-#ifdef SOFA_CORE_TOPOLOGY_TOPOLOGYHANDLER_DEFINITION
-namespace std
-{
-    template class list<const sofa::core::topology::TopologyChange*>;
-}
-
-namespace sofa::core::objectmodel
-{
-template class Data<std::list<const sofa::core::topology::TopologyChange*>>;
-}
-#endif /// SOFA_CORE_TOPOLOGY_TOPOLOGYHANDLER_DEFINITION
-
-
 namespace sofa::core::topology
 {
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.h
@@ -25,18 +25,6 @@
 #include <sofa/core/topology/TopologyChange.h>
 #include <sofa/core/fwd.h>
 
-#ifndef SOFA_CORE_TOPOLOGY_TOPOLOGYHANDLER_DEFINITION
-namespace std
-{
-    extern template class list<const sofa::core::topology::TopologyChange*>;
-}
-namespace sofa::core::objectmodel
-{
-    extern template class Data<std::list<const sofa::core::topology::TopologyChange*>>;
-}
-
-#endif /// SOFA_CORE_TOPOLOGY_TOPOLOGYHANDLER_DEFINITION
-
 namespace sofa
 {
 


### PR DESCRIPTION
Explicit instanciation of `list<const sofa::core::topology::TopologyChange*>;` was moved to _TopologyChange_ files from _TopologyHandler_ in #1912
But it seems it was (wrongfully) introduced again in _TopologyHandler_ in #1898 (I suppose from a merge)

This PR just remove the duplicated explicit instanciation.

NB: Seems weird to me that the CI does not say anything? (maybe a compiler option avoids this)
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
