### PR TITLE
[SofaHelper][SofaBoundaryCondition] Fix export keywords

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.h
@@ -161,7 +161,7 @@ public:
     {
     public:
         /** Internal class used to generate IDs. */
-        class SOFA_HELPER_API IdFactory : public Base
+        class IdFactory : public Base
         {
         protected:
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TrianglePressureForceField.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TrianglePressureForceField.h
@@ -138,7 +138,7 @@ protected :
     bool isPointInPlane(Coord p);
 };
 
-#if  !defined(SOFA_COMPONENT_FORCEFIELD_TrianglePressureForceField_CPP)
+#if !defined(SOFA_COMPONENT_FORCEFIELD_TRIANGLEPRESSUREFORCEFIELD_CPP)
 
 extern template class SOFA_SOFABOUNDARYCONDITION_API TrianglePressureForceField<sofa::defaulttype::Vec3Types>;
 


### PR DESCRIPTION
I was trying to compile with CLang on Windows to see if it could increase the perfomance (spoiler: it does not).
Clang is really strict with the export/import symbol system so I got some errors I cannot get with MSVC.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
