### PR TITLE
[SofaSimulation/Tests] Fix init/cleanup in SofaSimulation modules

### DIFF
--- a/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/init.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/init.cpp
@@ -23,7 +23,7 @@
 
 #include <sofa/core/init.h>
 #include <sofa/helper/init.h>
-
+#include <sofa/simulation/init.h>
 #include <sofa/helper/Factory.h>
 #include <sofa/simulation/Node.inl>
 #include <SofaSimulationCommon/xml/NodeElement.h>
@@ -41,7 +41,7 @@ SOFA_SOFASIMULATIONCOMMON_API void init()
 {
     if (!s_initialized)
     {
-        sofa::core::init();
+        sofa::simulation::core::init();
         s_initialized = true;
     }
 }
@@ -55,7 +55,7 @@ SOFA_SOFASIMULATIONCOMMON_API void cleanup()
 {
     if (!s_cleanedUp)
     {
-        sofa::core::cleanup();
+        sofa::simulation::core::cleanup();
         s_cleanedUp = true;
     }
 }

--- a/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/init.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/init.cpp
@@ -20,7 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <SofaSimulationGraph/config.h>
-#include <sofa/simulation/init.h>
+#include <sofaSimulationCommon/init.h>
 #include <sofa/helper/init.h>
 
 namespace sofa::simulation::graph
@@ -33,7 +33,7 @@ SOFA_SOFASIMULATIONGRAPH_API void init()
 {
     if (!s_initialized)
     {
-        sofa::simulation::core::init();
+        sofa::simulation::common::init();
         s_initialized = true;
     }
 }
@@ -47,7 +47,7 @@ SOFA_SOFASIMULATIONGRAPH_API void cleanup()
 {
     if (!s_cleanedUp)
     {
-        sofa::simulation::core::cleanup();
+        sofa::simulation::common::cleanup();
         s_cleanedUp = true;
     }
 }

--- a/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/init.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/init.cpp
@@ -20,7 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <SofaSimulationGraph/config.h>
-#include <sofaSimulationCommon/init.h>
+#include <SofaSimulationCommon/init.h>
 #include <sofa/helper/init.h>
 
 namespace sofa::simulation::graph


### PR DESCRIPTION
... And fix various crashes of unit tests when they quit.

Some unit tests are crashing when quitting (maybe random) since #1883 , with a call to an invalid MessageDispatcher (GtestMessageDispatcher) .
After some investigations, it appears that some init()/cleanup() in simulation do not respect the chain of dependency : 
 - SofaSimulationGraph was calling the ones fromSofaSimulationCore instead of the one of SofaSimulationCommon; 
 - SofaSimulationCommon was init/cleanup of SofaCore instead of SofaSimulationCore.

I suppose #1883 exposed the problem by removing **seemingly** useless init().
But it seems they were patching the issue raised in this PR.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
