### PR TITLE
[SofaBaseCollision] REFACTOR BruteForceDetection

### DIFF
--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.cpp
@@ -319,26 +319,20 @@ void BruteForceDetection::processInternalCell(const TestPair& root,
 {
     //first collision model
     core::CollisionElementIterator begin1 = root.first.first;
-    core::CollisionElementIterator end1 = root.first.second;
 
     //second collision model
     core::CollisionElementIterator begin2 = root.second.first;
-    core::CollisionElementIterator end2 = root.second.second;
 
     if (begin1.getCollisionModel() == finalcm1 && begin2.getCollisionModel() == finalcm2)
     {
         // Final collision pairs
-        for (core::CollisionElementIterator it1 = begin1; it1 != end1; ++it1)
-        {
-            for (core::CollisionElementIterator it2 = begin2; it2 != end2; ++it2)
-            {
-                if (!selfCollision || it1.canCollideWith(it2))
-                    intersector->intersect(it1,it2,outputs);
-            }
-        }
+        finalCollisionPairs(root, selfCollision, intersector, outputs);
     }
     else
     {
+        core::CollisionElementIterator end1 = root.first.second;
+        core::CollisionElementIterator end2 = root.second.second;
+
         for (core::CollisionElementIterator it1 = begin1; it1 != end1; ++it1)
         {
             for (core::CollisionElementIterator it2 = begin2; it2 != end2; ++it2)
@@ -388,23 +382,12 @@ void BruteForceDetection::processInternalCell(const TestPair& root,
                                 {
                                     if (newExternalTests.first.first.getCollisionModel() == finalcm1 && newExternalTests.second.first.getCollisionModel() == finalcm2)
                                     {
-                                        core::CollisionElementIterator extBegin1 = newExternalTests.first.first;
-                                        core::CollisionElementIterator extEnd1 = newExternalTests.first.second;
-                                        core::CollisionElementIterator extBegin2 = newExternalTests.second.first;
-                                        core::CollisionElementIterator extEnd2 = newExternalTests.second.second;
-                                        for (core::CollisionElementIterator extIt1 = extBegin1; extIt1 != extEnd1; ++extIt1)
-                                        {
-                                            for (core::CollisionElementIterator extIt2 = extBegin2; extIt2 != extEnd2; ++extIt2)
-                                            {
-                                                //if (!extIt1->canCollideWith(extIt2)) continue;
-                                                // Final collision pair
-                                                if (!selfCollision || extIt1.canCollideWith(extIt2))
-                                                    finalintersector->intersect(extIt1,extIt2,outputs);
-                                            }
-                                        }
+                                        finalCollisionPairs(newExternalTests, selfCollision, finalintersector, outputs);
                                     }
                                     else
+                                    {
                                         externalCells.push(newExternalTests);
+                                    }
                                 }
                                 else
                                 {
@@ -435,6 +418,28 @@ void BruteForceDetection::processInternalCell(const TestPair& root,
                     }
                 }
             }
+        }
+    }
+}
+
+void BruteForceDetection::finalCollisionPairs(const TestPair& pair,
+                                              bool selfCollision,
+                                              core::collision::ElementIntersector* intersector,
+                                              sofa::core::collision::DetectionOutputVector*& outputs)
+{
+    core::CollisionElementIterator begin1 = pair.first.first;
+    core::CollisionElementIterator end1 = pair.first.second;
+    core::CollisionElementIterator begin2 = pair.second.first;
+    core::CollisionElementIterator end2 = pair.second.second;
+
+    for (core::CollisionElementIterator it1 = begin1; it1 != end1; ++it1)
+    {
+        for (core::CollisionElementIterator it2 = begin2; it2 != end2; ++it2)
+        {
+            //if (!extIt1->canCollideWith(extIt2)) continue;
+            // Final collision pair
+            if (!selfCollision || it1.canCollideWith(it2))
+                intersector->intersect(it1, it2, outputs);
         }
     }
 }

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.cpp
@@ -353,18 +353,18 @@ void BruteForceDetection::processInternalCell(const TestPair& root,
                                 {
                                     if (newExternalTests.first.first.getCollisionModel() == finalcm1 && newExternalTests.second.first.getCollisionModel() == finalcm2)
                                     {
-                                        core::CollisionElementIterator begin1 = newExternalTests.first.first;
-                                        core::CollisionElementIterator end1 = newExternalTests.first.second;
-                                        core::CollisionElementIterator begin2 = newExternalTests.second.first;
-                                        core::CollisionElementIterator end2 = newExternalTests.second.second;
-                                        for (core::CollisionElementIterator it1 = begin1; it1 != end1; ++it1)
+                                        core::CollisionElementIterator extBegin1 = newExternalTests.first.first;
+                                        core::CollisionElementIterator extEnd1 = newExternalTests.first.second;
+                                        core::CollisionElementIterator extBegin2 = newExternalTests.second.first;
+                                        core::CollisionElementIterator extEnd2 = newExternalTests.second.second;
+                                        for (core::CollisionElementIterator extIt1 = extBegin1; extIt1 != extEnd1; ++extIt1)
                                         {
-                                            for (core::CollisionElementIterator it2 = begin2; it2 != end2; ++it2)
+                                            for (core::CollisionElementIterator extIt2 = extBegin2; extIt2 != extEnd2; ++extIt2)
                                             {
-                                                //if (!it1->canCollideWith(it2)) continue;
+                                                //if (!extIt1->canCollideWith(extIt2)) continue;
                                                 // Final collision pair
-                                                if (!selfCollision || it1.canCollideWith(it2))
-                                                    finalintersector->intersect(it1,it2,outputs);
+                                                if (!selfCollision || extIt1.canCollideWith(extIt2))
+                                                    finalintersector->intersect(extIt1,extIt2,outputs);
                                             }
                                         }
                                     }

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.cpp
@@ -393,9 +393,7 @@ void BruteForceDetection::processInternalCell(const TestPair& root,
                                 {
                                     // only first element has external children
                                     // test them against the second element
-                                    newExternalTests.second.first = it2;
-                                    newExternalTests.second.second = it2;
-                                    ++newExternalTests.second.second;
+                                    newExternalTests.second= {it2, it2 + 1};
                                     externalCells.emplace(newExternalTests.first, newInternalTests.second);
                                 }
                             }
@@ -403,9 +401,7 @@ void BruteForceDetection::processInternalCell(const TestPair& root,
                             {
                                 // only first element has external children
                                 // test them against the first element
-                                newExternalTests.first.first = it1;
-                                newExternalTests.first.second = it1;
-                                ++newExternalTests.first.second;
+                                newExternalTests.first = {it1, it1 + 1};
                                 externalCells.emplace(newExternalTests.first, newExternalTests.second);
                             }
                             else

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.cpp
@@ -190,7 +190,10 @@ void BruteForceDetection::addCollisionPair(const std::pair<core::CollisionModel*
         TestPair root = externalCells.front();
         externalCells.pop();
 
-        processExternalCell(root, finalcm1, finalcm2, intersector, finalintersector, &mirror, externalCells, selfCollision, outputs);
+        processExternalCell(root,
+                            cm1, cm2,
+                            finalcm1, finalcm2,
+                            intersector, finalintersector, &mirror, externalCells, selfCollision, outputs);
     }
 }
 
@@ -227,6 +230,8 @@ void BruteForceDetection::initializeExternalCells(
 }
 
 void BruteForceDetection::processExternalCell(const TestPair& root,
+                                              core::CollisionModel *& cm1,
+                                              core::CollisionModel *& cm2,
                                               core::CollisionModel *finalcm1,
                                               core::CollisionModel *finalcm2,
                                               core::collision::ElementIntersector* intersector,
@@ -236,9 +241,6 @@ void BruteForceDetection::processExternalCell(const TestPair& root,
                                               bool selfCollision,
                                               sofa::core::collision::DetectionOutputVector*& outputs)
 {
-    core::CollisionModel *cm1 {nullptr};
-    core::CollisionModel *cm2 {nullptr};
-
     const auto& range1 = root.first;
     const auto& range2 = root.second;
 
@@ -262,8 +264,10 @@ void BruteForceDetection::processExternalCell(const TestPair& root,
             intersector = mirror;
         }
     }
+
     if (intersector == nullptr)
         return;
+
     std::stack< TestPair > internalCells;
     internalCells.push(root);
 

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.cpp
@@ -237,16 +237,11 @@ void BruteForceDetection::initializeExternalCells(
     const CollisionIteratorRange externalChildren1 = cm1->begin().getExternalChildren();
     const CollisionIteratorRange externalChildren2 = cm2->begin().getExternalChildren();
 
-    const auto isChildrenRangeEmpty = [](const CollisionIteratorRange& children)
-    {
-        return children.first == children.second;
-    };
-
-    const auto addToExternalCells = [&isChildrenRangeEmpty, &externalCells](
+    const auto addToExternalCells = [&externalCells](
             const CollisionIteratorRange& children1,
             const CollisionIteratorRange& children2)
     {
-        if (!isChildrenRangeEmpty(children1) && !isChildrenRangeEmpty(children2))
+        if (!isRangeEmpty(children1) && !isRangeEmpty(children2))
         {
             externalCells.emplace(children1,children2);
         }
@@ -359,9 +354,9 @@ void BruteForceDetection::processInternalCell(const TestPair& root,
 
                     TestPair newInternalTests(it1.getInternalChildren(),it2.getInternalChildren());
                     TestPair newExternalTests(it1.getExternalChildren(),it2.getExternalChildren());
-                    if (newInternalTests.first.first != newInternalTests.first.second)
+                    if (!isRangeEmpty(newInternalTests.first))
                     {
-                        if (newInternalTests.second.first != newInternalTests.second.second)
+                        if (!isRangeEmpty(newInternalTests.second))
                         {
                             internalCells.push(newInternalTests);
                         }
@@ -375,7 +370,7 @@ void BruteForceDetection::processInternalCell(const TestPair& root,
                     }
                     else
                     {
-                        if (newInternalTests.second.first != newInternalTests.second.second)
+                        if (!isRangeEmpty(newInternalTests.second))
                         {
                             newInternalTests.first.first = it1;
                             newInternalTests.first.second = it1;
@@ -386,9 +381,9 @@ void BruteForceDetection::processInternalCell(const TestPair& root,
                         {
                             // end of both internal tree of elements.
                             // need to test external children
-                            if (newExternalTests.first.first != newExternalTests.first.second)
+                            if (!isRangeEmpty(newExternalTests.first))
                             {
-                                if (newExternalTests.second.first != newExternalTests.second.second)
+                                if (!isRangeEmpty(newExternalTests.second))
                                 {
                                     if (newExternalTests.first.first.getCollisionModel() == finalcm1 && newExternalTests.second.first.getCollisionModel() == finalcm2)
                                     {
@@ -420,7 +415,7 @@ void BruteForceDetection::processInternalCell(const TestPair& root,
                                     externalCells.emplace(newExternalTests.first, newInternalTests.second);
                                 }
                             }
-                            else if (newExternalTests.second.first != newExternalTests.second.second)
+                            else if (!isRangeEmpty(newExternalTests.second))
                             {
                                 // only first element has external children
                                 // test them against the first element
@@ -441,6 +436,11 @@ void BruteForceDetection::processInternalCell(const TestPair& root,
             }
         }
     }
+}
+
+bool BruteForceDetection::isRangeEmpty(const CollisionIteratorRange& range)
+{
+    return range.first == range.second;
 }
 
 } // namespace sofa::component::collision

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.cpp
@@ -346,25 +346,26 @@ void BruteForceDetection::processInternalCell(const TestPair& root,
                 //if (self && !it1.canCollideWith(it2)) continue;
                 //if (!it1->canCollideWith(it2)) continue;
 
-                bool b = intersector->canIntersect(it1,it2);
-                if (b)
+                if (intersector->canIntersect(it1,it2))
                 {
                     // Need to test recursively
                     // Note that an element cannot have both internal and external children
 
-                    TestPair newInternalTests(it1.getInternalChildren(),it2.getInternalChildren());
-                    TestPair newExternalTests(it1.getExternalChildren(),it2.getExternalChildren());
+                    TestPair newInternalTests(it1.getInternalChildren(), it2.getInternalChildren());
+                    TestPair newExternalTests(it1.getExternalChildren(), it2.getExternalChildren());
+
                     if (!isRangeEmpty(newInternalTests.first))
                     {
                         if (!isRangeEmpty(newInternalTests.second))
                         {
+                            //both collision elements have internal children. They are added to the list
                             internalCells.push(newInternalTests);
                         }
                         else
                         {
-                            newInternalTests.second.first = it2;
-                            newInternalTests.second.second = it2;
-                            ++newInternalTests.second.second;
+                            //only the first collision element has internal children. The second collision element
+                            //is kept as it is
+                            newInternalTests.second = {it2, it2 + 1};
                             internalCells.push(newInternalTests);
                         }
                     }
@@ -372,9 +373,9 @@ void BruteForceDetection::processInternalCell(const TestPair& root,
                     {
                         if (!isRangeEmpty(newInternalTests.second))
                         {
-                            newInternalTests.first.first = it1;
-                            newInternalTests.first.second = it1;
-                            ++newInternalTests.first.second;
+                            //only the second collision element has internal children. The first collision element
+                            //is kept as it is
+                            newInternalTests.first = {it1, it1 + 1};
                             internalCells.push(newInternalTests);
                         }
                         else

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.h
@@ -93,6 +93,8 @@ protected:
 
     void processExternalCell(
             const TestPair& root,
+            core::CollisionModel *& cm1,
+            core::CollisionModel *& cm2,
             core::CollisionModel *finalcm1,
             core::CollisionModel *finalcm2,
             core::collision::ElementIntersector* intersector,

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.h
@@ -126,6 +126,10 @@ protected:
             std::stack<TestPair>& internalCells,
             bool selfCollision,
             sofa::core::collision::DetectionOutputVector*& outputs);
+
+private:
+
+    static bool isRangeEmpty(const CollisionIteratorRange& range);
 };
 
 } // namespace sofa::component::collision

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.h
@@ -133,8 +133,8 @@ protected:
             core::CollisionModel *cm2,
             std::queue<TestPair>& externalCells);
 
-    /// Store data related to two finnest CollisionModel's
-    struct FinnestCollision
+    /// Store data related to two finest CollisionModel's
+    struct FinestCollision
     {
         core::CollisionModel* cm1 { nullptr };
         core::CollisionModel* cm2 { nullptr };
@@ -150,7 +150,7 @@ protected:
                              core::CollisionModel *&cm1,
                              core::CollisionModel *&cm2,
                              core::collision::ElementIntersector *coarseIntersector,
-                             const FinnestCollision &finnest,
+                             const FinestCollision &finest,
                              MirrorIntersector *mirror,
                              std::queue<TestPair> &externalCells,
                              sofa::core::collision::DetectionOutputVector *&outputs) const;
@@ -158,14 +158,14 @@ protected:
     static void
     processInternalCell(const TestPair &internalCell,
                         core::collision::ElementIntersector *coarseIntersector,
-                        const FinnestCollision &finnest,
+                        const FinestCollision &finest,
                         std::queue<TestPair> &externalCells,
                         std::stack<TestPair> &internalCells,
                         sofa::core::collision::DetectionOutputVector *&outputs);
 
     static void visitCollisionElements(const TestPair &root,
                                        core::collision::ElementIntersector *coarseIntersector,
-                                       const FinnestCollision &finnest,
+                                       const FinestCollision &finest,
                                        std::queue<TestPair> &externalCells,
                                        std::stack<TestPair> &internalCells,
                                        sofa::core::collision::DetectionOutputVector *&outputs);
@@ -173,7 +173,7 @@ protected:
     static void
     visitExternalChildren(const core::CollisionElementIterator &it1, const core::CollisionElementIterator &it2,
                           core::collision::ElementIntersector *coarseIntersector,
-                          const FinnestCollision &finnest,
+                          const FinestCollision &finest,
                           std::queue<TestPair> &externalCells,
                           sofa::core::collision::DetectionOutputVector *&outputs);
 

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.h
@@ -27,16 +27,26 @@
 #include <SofaBaseCollision/CubeModel.h>
 #include <sofa/helper/vector.h>
 
+#include <queue>
+#include <stack>
+
+namespace sofa::core::collision
+{
+    class ElementIntersector;
+}
 
 namespace sofa::component::collision
 {
 
-class CubeCollisionModel;
+class MirrorIntersector;
 
 class SOFA_SOFABASECOLLISION_API BruteForceDetection :
     public core::collision::BroadPhaseDetection,
     public core::collision::NarrowPhaseDetection
 {
+    using CollisionIteratorRange = std::pair<core::CollisionElementIterator,core::CollisionElementIterator>;
+    using TestPair = std::pair< CollisionIteratorRange, CollisionIteratorRange >;
+
 public:
     SOFA_CLASS2(BruteForceDetection, core::collision::BroadPhaseDetection, core::collision::NarrowPhaseDetection);
 
@@ -73,6 +83,34 @@ public:
     void draw(const core::visual::VisualParams* /* vparams */) override { }
 
     inline bool needsDeepBoundingTree()const override {return true;}
+
+protected:
+
+    static void initializeExternalCells(
+            core::CollisionModel *cm1,
+            core::CollisionModel *cm2,
+            std::queue<TestPair>& externalCells);
+
+    void processExternalCell(
+            const TestPair& root,
+            core::CollisionModel *finalcm1,
+            core::CollisionModel *finalcm2,
+            core::collision::ElementIntersector* intersector,
+            core::collision::ElementIntersector* finalintersector,
+            MirrorIntersector* mirror,
+            std::queue<TestPair>& externalCells,
+            bool selfCollision,
+            sofa::core::collision::DetectionOutputVector*& outputs);
+    void processInternalCell(
+            const TestPair& current,
+            core::CollisionModel *finalcm1,
+            core::CollisionModel *finalcm2,
+            core::collision::ElementIntersector* intersector,
+            core::collision::ElementIntersector* finalintersector,
+            std::queue<TestPair>& externalCells,
+            std::stack<TestPair>& internalCells,
+            bool selfCollision,
+            sofa::core::collision::DetectionOutputVector*& outputs);
 };
 
 } // namespace sofa::component::collision

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.h
@@ -127,6 +127,28 @@ protected:
             bool selfCollision,
             sofa::core::collision::DetectionOutputVector*& outputs);
 
+    void visitCollisionElements(const TestPair& root,
+                                core::CollisionModel *finalcm1,
+                                core::CollisionModel *finalcm2,
+                                core::collision::ElementIntersector* intersector,
+                                core::collision::ElementIntersector* finalintersector,
+                                std::queue<TestPair>& externalCells,
+                                std::stack<TestPair>& internalCells,
+                                bool selfCollision,
+                                sofa::core::collision::DetectionOutputVector*& outputs);
+
+    void visitExternalChildren(const TestPair& externalChildren,
+                               const TestPair& internalChildren,
+                               const core::CollisionElementIterator& it1,
+                               const core::CollisionElementIterator& it2,
+                               core::CollisionModel *finalcm1,
+                               core::CollisionModel *finalcm2,
+                               core::collision::ElementIntersector* intersector,
+                               core::collision::ElementIntersector* finalintersector,
+                               std::queue<TestPair>& externalCells,
+                               bool selfCollision,
+                               sofa::core::collision::DetectionOutputVector*& outputs);
+
     void finalCollisionPairs(const TestPair& pair,
                              bool selfCollision,
                              core::collision::ElementIntersector* intersector,

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.h
@@ -127,6 +127,11 @@ protected:
             bool selfCollision,
             sofa::core::collision::DetectionOutputVector*& outputs);
 
+    void finalCollisionPairs(const TestPair& pair,
+                             bool selfCollision,
+                             core::collision::ElementIntersector* intersector,
+                             sofa::core::collision::DetectionOutputVector*& outputs);
+
 private:
 
     static bool isRangeEmpty(const CollisionIteratorRange& range);

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.h
@@ -71,20 +71,33 @@ public:
     void init() override;
     void reinit() override;
 
+    /** \brief In the broad phase, ignores collision with the provided collision model if possible and add pairs of
+     * collision models if in intersection.
+     *
+     * Ignore the collision with the provided collision model if it does not intersect with the box defined in
+     * the Data box when it is defined.
+     * Add the provided collision model to be investigated in the narrow phase in case of self collision.
+     * Check intersection with already added collision models. If it can intersect another collision model, the pair
+     * is added to be further investigated in the narrow phase.
+     */
     void addCollisionModel (core::CollisionModel *cm) override;
+
+    /** \brief In the narrow phase, examine a potential collision between a pair of collision models, which has
+     * been detected in the broad phase.
+     */
     void addCollisionPair (const std::pair<core::CollisionModel*, core::CollisionModel*>& cmPair) override;
 
-    void beginBroadPhase() override
-    {
-        core::collision::BroadPhaseDetection::beginBroadPhase();
-        collisionModels.clear();
-    }
+    void beginBroadPhase() override;
+    void endBroadPhase() override;
 
     void draw(const core::visual::VisualParams* /* vparams */) override { }
 
     inline bool needsDeepBoundingTree()const override {return true;}
 
 protected:
+
+    bool intersectWithBoxModel(core::CollisionModel *cm) const;
+    bool doesSelfCollide(core::CollisionModel *cm) const;
 
     static void initializeExternalCells(
             core::CollisionModel *cm1,

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.h
@@ -44,7 +44,13 @@ class SOFA_SOFABASECOLLISION_API BruteForceDetection :
     public core::collision::BroadPhaseDetection,
     public core::collision::NarrowPhaseDetection
 {
-    using CollisionIteratorRange = std::pair<core::CollisionElementIterator,core::CollisionElementIterator>;
+    /// Range defined by two iterators in a container of CollisionElement
+    using CollisionIteratorRange = std::pair<core::CollisionElementIterator, core::CollisionElementIterator>;
+
+    /// A pair of CollisionIteratorRange where the first range contains elements from a first collision model
+    /// and the second range contains collision elements from a second collision model
+    /// This type is used when testing collision between two collision models
+    /// Note that the second collision model can be the same than the first in case of self collision
     using TestPair = std::pair< CollisionIteratorRange, CollisionIteratorRange >;
 
 public:
@@ -52,6 +58,9 @@ public:
 
 private:
 
+    /// vector of accumulated CollisionModel's when the collision pipeline asks
+    /// to add a CollisionModel in BruteForceDetection::addCollisionModel
+    /// This vector is emptied at each time step in BruteForceDetection::beginBroadPhase
     sofa::helper::vector<core::CollisionModel*> collisionModels;
 
     Data< helper::fixed_array<sofa::defaulttype::Vector3,2> > box; ///< if not empty, objects that do not intersect this bounding-box will be ignored
@@ -71,6 +80,10 @@ public:
     void init() override;
     void reinit() override;
 
+    //////////////////////////////
+    /// BROAD PHASE interface ///
+    //////////////////////////////
+
     /** \brief In the broad phase, ignores collision with the provided collision model if possible and add pairs of
      * collision models if in intersection.
      *
@@ -80,81 +93,102 @@ public:
      * Check intersection with already added collision models. If it can intersect another collision model, the pair
      * is added to be further investigated in the narrow phase.
      */
-    void addCollisionModel (core::CollisionModel *cm) override;
-
-    /** \brief In the narrow phase, examine a potential collision between a pair of collision models, which has
-     * been detected in the broad phase.
-     */
-    void addCollisionPair (const std::pair<core::CollisionModel*, core::CollisionModel*>& cmPair) override;
+    void addCollisionModel(core::CollisionModel *cm) override;
 
     void beginBroadPhase() override;
     void endBroadPhase() override;
 
+    //////////////////////////////
+    /// NARROW PHASE interface ///
+    //////////////////////////////
+
+    /** \brief In the narrow phase, examine a potential collision between a pair of collision models, which has
+     * been detected in the broad phase.
+     *
+     * The function traverses the hierarchy of CollisionElement's contained in each CollisionModel to avoid
+     * unnecessary pair intersections.
+     * An iterative form of the hierarchy traversal is adopted instead of a recursive form.
+     */
+    void addCollisionPair(const std::pair<core::CollisionModel*, core::CollisionModel*>& cmPair) override;
+
+
     void draw(const core::visual::VisualParams* /* vparams */) override { }
 
-    inline bool needsDeepBoundingTree()const override {return true;}
+    inline bool needsDeepBoundingTree() const override { return true; }
 
 protected:
 
+    /// Return true if the provided CollisionModel intersect boxModel, false otherwise
     bool intersectWithBoxModel(core::CollisionModel *cm) const;
+
+    /// Return true if the provided CollisionModel can collide with itself
     bool doesSelfCollide(core::CollisionModel *cm) const;
 
+    /// Return true if both collision models belong to the same object, false otherwise
+    static bool isSelfCollision(core::CollisionModel* cm1, core::CollisionModel* cm2);
+
+    /// Build a list of TestPair's from internal and external children of two CollisionModel's
     static void initializeExternalCells(
             core::CollisionModel *cm1,
             core::CollisionModel *cm2,
             std::queue<TestPair>& externalCells);
 
-    void processExternalCell(
-            const TestPair& root,
-            core::CollisionModel *& cm1,
-            core::CollisionModel *& cm2,
-            core::CollisionModel *finalcm1,
-            core::CollisionModel *finalcm2,
-            core::collision::ElementIntersector* intersector,
-            core::collision::ElementIntersector* finalintersector,
-            MirrorIntersector* mirror,
-            std::queue<TestPair>& externalCells,
-            bool selfCollision,
-            sofa::core::collision::DetectionOutputVector*& outputs);
-    void processInternalCell(
-            const TestPair& current,
-            core::CollisionModel *finalcm1,
-            core::CollisionModel *finalcm2,
-            core::collision::ElementIntersector* intersector,
-            core::collision::ElementIntersector* finalintersector,
-            std::queue<TestPair>& externalCells,
-            std::stack<TestPair>& internalCells,
-            bool selfCollision,
-            sofa::core::collision::DetectionOutputVector*& outputs);
+    /// Store data related to two finnest CollisionModel's
+    struct FinnestCollision
+    {
+        core::CollisionModel* cm1 { nullptr };
+        core::CollisionModel* cm2 { nullptr };
 
-    void visitCollisionElements(const TestPair& root,
-                                core::CollisionModel *finalcm1,
-                                core::CollisionModel *finalcm2,
-                                core::collision::ElementIntersector* intersector,
-                                core::collision::ElementIntersector* finalintersector,
-                                std::queue<TestPair>& externalCells,
-                                std::stack<TestPair>& internalCells,
-                                bool selfCollision,
-                                sofa::core::collision::DetectionOutputVector*& outputs);
+        /// ElementIntersector corresponding to cm1 and cm2
+        core::collision::ElementIntersector* intersector { nullptr };
 
-    void visitExternalChildren(const TestPair& externalChildren,
-                               const TestPair& internalChildren,
-                               const core::CollisionElementIterator& it1,
-                               const core::CollisionElementIterator& it2,
-                               core::CollisionModel *finalcm1,
-                               core::CollisionModel *finalcm2,
-                               core::collision::ElementIntersector* intersector,
-                               core::collision::ElementIntersector* finalintersector,
-                               std::queue<TestPair>& externalCells,
-                               bool selfCollision,
-                               sofa::core::collision::DetectionOutputVector*& outputs);
+        // True in case cm1 and cm2 belong to the same object, false otherwise
+        bool selfCollision { false };
+    };
 
-    void finalCollisionPairs(const TestPair& pair,
+    void processExternalCell(const TestPair &externalCell,
+                             core::CollisionModel *&cm1,
+                             core::CollisionModel *&cm2,
+                             core::collision::ElementIntersector *coarseIntersector,
+                             const FinnestCollision &finnest,
+                             MirrorIntersector *mirror,
+                             std::queue<TestPair> &externalCells,
+                             sofa::core::collision::DetectionOutputVector *&outputs) const;
+
+    static void
+    processInternalCell(const TestPair &internalCell,
+                        core::collision::ElementIntersector *coarseIntersector,
+                        const FinnestCollision &finnest,
+                        std::queue<TestPair> &externalCells,
+                        std::stack<TestPair> &internalCells,
+                        sofa::core::collision::DetectionOutputVector *&outputs);
+
+    static void visitCollisionElements(const TestPair &root,
+                                       core::collision::ElementIntersector *coarseIntersector,
+                                       const FinnestCollision &finnest,
+                                       std::queue<TestPair> &externalCells,
+                                       std::stack<TestPair> &internalCells,
+                                       sofa::core::collision::DetectionOutputVector *&outputs);
+
+    static void
+    visitExternalChildren(const core::CollisionElementIterator &it1, const core::CollisionElementIterator &it2,
+                          core::collision::ElementIntersector *coarseIntersector,
+                          const FinnestCollision &finnest,
+                          std::queue<TestPair> &externalCells,
+                          sofa::core::collision::DetectionOutputVector *&outputs);
+
+    /// Test intersection between two ranges of CollisionElement's
+    /// The provided TestPair contains ranges of external CollisionElement's, which means that
+    /// they can be tested against each other for intersection
+    static void finalCollisionPairs(const TestPair& pair,
                              bool selfCollision,
                              core::collision::ElementIntersector* intersector,
                              sofa::core::collision::DetectionOutputVector*& outputs);
 
 private:
+
+    /// Get both collision models corresponding to the provided TestPair
+    static std::pair<core::CollisionModel*, core::CollisionModel*> getCollisionModelsFromTestPair(const TestPair& pair);
 
     static bool isRangeEmpty(const CollisionIteratorRange& range);
 };

--- a/SofaKernel/modules/SofaCore/src/sofa/core/CollisionElement.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/CollisionElement.h
@@ -258,7 +258,7 @@ public:
     /// Test if this element can collide with another element.
     ///
     /// @see CollisionModel::canCollideWithElement
-    bool canCollideWith(TCollisionElementIterator<Model>& elem)
+    bool canCollideWith(const TCollisionElementIterator<Model>& elem) const
     {
         return ((model != elem.model) || (index < elem.index)) && model->canCollideWithElement(index, elem.model, elem.index);
     }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/CollisionElement.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/CollisionElement.h
@@ -82,16 +82,38 @@ public:
         }
     }
 
-    /// Increment this iterator to reference the next element.
-    void operator++()
+    /// Prefix increment this iterator to reference the next element.
+    BaseCollisionElementIterator& operator++()
     {
         next();
+        return *this;
     }
 
-    /// Increment this iterator to reference the next element.
-    void operator++(int)
+    /// Postfix increment this iterator to reference the next element.
+    BaseCollisionElementIterator operator++(int)
     {
+        auto tmp = *this;
         next();
+        return tmp;
+    }
+
+    // Increment this iterator by n elements. Negative numbers are not supported
+    BaseCollisionElementIterator& operator+=(int n)
+    {
+        if (n > 0)
+        {
+            while(n--)
+            {
+                next();
+            }
+        }
+        return *this;
+    }
+
+    BaseCollisionElementIterator operator+(int n) const
+    {
+        auto tmp = *this;
+        return tmp += n;
     }
 
     /// Return the index of the referenced element inside the CollisionModel.
@@ -182,6 +204,19 @@ public:
     bool operator!=(const TCollisionElementIterator<Model2>& i) const
     {
         return this->model != i.getCollisionModel() || this->index != i.getIndex();
+    }
+
+    // Increment this iterator by n elements. Negative numbers are not supported
+    TCollisionElementIterator& operator+=(int n)
+    {
+        BaseCollisionElementIterator::operator+=(n);
+        return *this;
+    }
+
+    TCollisionElementIterator operator+(int n) const
+    {
+        auto tmp = *this;
+        return tmp += n;
     }
 
     /// Test if this iterator is initialized with a valid CollisionModel.

--- a/SofaKernel/modules/SofaCore/src/sofa/core/collision/BroadPhaseDetection.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/collision/BroadPhaseDetection.h
@@ -71,6 +71,7 @@ public:
 
     /// Get the potentially colliding pairs detected
     sofa::helper::vector<CollisionModelPair>& getCollisionModelPairs() { return cmPairs; }
+    const sofa::helper::vector<CollisionModelPair>& getCollisionModelPairs() const { return cmPairs; }
 
     /// Returns true because it needs a deep bounding tree i.e. a depth that can be superior to 1.
     inline virtual bool needsDeepBoundingTree()const{return true;}


### PR DESCRIPTION
I propose a more readable code for the component BruteForceDetection. It is a crucial component, used in many Sofa scenes, and yet it is hard to understand what it does.
Among the changes I propose:
- Split giant functions into multiple smaller functions
- Give meaningful names to functions, variables and types
- Merge simple operations which was hard to read into simple expressions
- Add a lot of comments

The algorithm stays the same.

Note the number of lines is larger than before. It is the price for readability. It is mainly due to the several functions I added

I did not notice any performances drop.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
