### PR TITLE
[SofaPython3] Fix ExternalProjectConfig.h

### DIFF
--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/BoundingBox.cpp
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/BoundingBox.cpp
@@ -22,6 +22,7 @@
 #include <sofa/type/BoundingBox.h>
 
 #include <limits>
+#include <algorithm>
 
 namespace sofa::type
 {

--- a/applications/plugins/SofaPython3/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/SofaPython3/ExternalProjectConfig.cmake.in
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.11)
 
 include(ExternalProject)
 ExternalProject_Add(SofaPython3
-    GIT_REPOSITORY https://github.com/CRIStAL-PADR/plugin.SofaPython3.git
-    GIT_TAG 204574db917a49ffd3aa87a18601f37e0a729b77
+    GIT_REPOSITORY https://github.com/sofa-framework/SofaPython3
+    GIT_TAG ce76e20fc7cf1fce9cc231952e1d5f74b4ec5bc5
     SOURCE_DIR "${CMAKE_SOURCE_DIR}/applications/plugins/SofaPython3"
     BINARY_DIR ""
     CONFIGURE_COMMAND ""

--- a/applications/plugins/SofaPython3/ExternalProjectConfig.cmake.in
+++ b/applications/plugins/SofaPython3/ExternalProjectConfig.cmake.in
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.11)
 include(ExternalProject)
 ExternalProject_Add(SofaPython3
     GIT_REPOSITORY https://github.com/sofa-framework/SofaPython3
-    GIT_TAG ce76e20fc7cf1fce9cc231952e1d5f74b4ec5bc5
+    GIT_TAG origin/master
     SOURCE_DIR "${CMAKE_SOURCE_DIR}/applications/plugins/SofaPython3"
     BINARY_DIR ""
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
Red alert on the CI ! Fix it now.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
