### PR TITLE
[Sofa.Type] Add missing header in fixed_array

### DIFF
--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/fixed_array.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/fixed_array.h
@@ -55,6 +55,7 @@
 #include <cassert>
 #include <iostream>
 #include <type_traits>
+#include <algorithm>
 
 
 namespace sofa::type


### PR DESCRIPTION
Master is failing on a missing header for std::swap_ranges (which is in `<algorithm>` )



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
