### PR TITLE
[SofaUserInteraction] Minor cleaning of RayTraceDetection

### DIFF
--- a/modules/SofaUserInteraction/src/SofaUserInteraction/RayTraceDetection.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/RayTraceDetection.cpp
@@ -62,6 +62,11 @@ RayTraceDetection ():bDraw (initData
 {
 }
 
+void RayTraceDetection::beginBroadPhase()
+{
+    core::collision::BroadPhaseDetection::beginBroadPhase();
+    collisionModels.clear();
+}
 
 void RayTraceDetection::findPairsVolume (CubeCollisionModel * cm1, CubeCollisionModel * cm2)
 {
@@ -240,10 +245,8 @@ void RayTraceDetection::addCollisionModel (core::CollisionModel * cm)
 {
     if (cm->empty ())
         return;
-    for (sofa::helper::vector < core::CollisionModel * >::iterator it =
-            collisionModels.begin (); it != collisionModels.end (); ++it)
+    for (auto* cm2 : collisionModels)
     {
-        core::CollisionModel * cm2 = *it;
         if (!cm->isSimulated() && !cm2->isSimulated())
             continue;
         if (!cm->canCollideWith (cm2))
@@ -257,11 +260,9 @@ void RayTraceDetection::addCollisionModel (core::CollisionModel * cm)
         core::CollisionModel* cm1 = (swapModels?cm2:cm);
         cm2 = (swapModels?cm:cm2);
 
-
         // Here we assume a single root element is present in both models
         if (intersector->canIntersect (cm1->begin (), cm2->begin ()))
         {
-
             cmPairs.push_back (std::make_pair (cm1, cm2));
         }
     }
@@ -314,8 +315,8 @@ void RayTraceDetection::draw (const core::visual::VisualParams* vparams)
                 TriangleOctreeModel >::iterator it2 = (outputs)->begin ();
                 it2 != outputs->end (); ++it2)
         {
-            vertices.push_back(sofa::defaulttype::Vector3(it2->point[0][0], it2->point[0][1],it2->point[0][2]));
-            vertices.push_back(sofa::defaulttype::Vector3(it2->point[1][0], it2->point[1][1],it2->point[1][2]));
+            vertices.push_back(it2->point[0]);
+            vertices.push_back(it2->point[1]);
 
             msg_error() << it2->point[0] << " " << it2->point[0];
 

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/RayTraceDetection.h
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/RayTraceDetection.h
@@ -51,28 +51,35 @@ private:
 
 public:
     typedef sofa::helper::vector<sofa::core::collision::DetectionOutput>    OutputVector;
+
 protected:
     RayTraceDetection ();
+
 public:
+
+    /////////////////////////////
+    /// BROAD PHASE interface ///
+    /////////////////////////////
+
+    void beginBroadPhase() override;
+
+    void addCollisionModel (core::CollisionModel * cm) override;
+
+    //////////////////////////////
+    /// NARROW PHASE interface ///
+    //////////////////////////////
+
+    void addCollisionPair (const std::pair < core::CollisionModel *,
+            core::CollisionModel * >&cmPair) override;
+
+public:
+    void findPairsVolume (CubeCollisionModel * cm1, CubeCollisionModel * cm2);
+
+    void draw (const core::visual::VisualParams* vparams) override;
     void setDraw (bool val)
     {
         bDraw.setValue (val);
     }
-    void selfCollision (TriangleOctreeModel * cm1);
-    void addCollisionModel (core::CollisionModel * cm) override;
-    void addCollisionPair (const std::pair < core::CollisionModel *,
-            core::CollisionModel * >&cmPair) override;
-
-    void findPairsVolume (CubeCollisionModel * cm1,
-            CubeCollisionModel * cm2);
-
-    void beginBroadPhase() override
-    {
-        core::collision::BroadPhaseDetection::beginBroadPhase();
-        collisionModels.clear();
-    }
-
-    void draw (const core::visual::VisualParams* vparams) override;
 };
 
 } // namespace sofa::component::collision


### PR DESCRIPTION
Initially, I wanted to differentiate the functions from the broad phase, from the functions from the narrow phase, in the header file.
`void selfCollision (TriangleOctreeModel * cm1);` has been removed since it is not implemented. Other modifications are minor.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
