### PR TITLE
[SofaSparseSolver] Clean useless dependencies

### DIFF
--- a/modules/SofaSparseSolver/CMakeLists.txt
+++ b/modules/SofaSparseSolver/CMakeLists.txt
@@ -3,8 +3,6 @@ project(SofaSparseSolver LANGUAGES CXX)
 
 # Dependencies
 sofa_find_package(SofaBase REQUIRED)
-sofa_find_package(SofaImplicitOdeSolver REQUIRED) 
-sofa_find_package(SofaSimpleFem REQUIRED)
 sofa_find_package(SofaGeneralLinearSolver REQUIRED)
 
 add_subdirectory(extlibs/csparse)
@@ -41,7 +39,7 @@ set(SOURCE_FILES
     )
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaBaseLinearSolver SofaGeneralLinearSolver SofaImplicitOdeSolver SofaSimpleFem)
+target_link_libraries(${PROJECT_NAME} PUBLIC SofaBaseLinearSolver SofaGeneralLinearSolver)
 target_link_libraries(${PROJECT_NAME} PUBLIC metis csparse)
 
 sofa_create_package_with_targets(

--- a/modules/SofaSparseSolver/src/SofaSparseSolver/PrecomputedLinearSolver.cpp
+++ b/modules/SofaSparseSolver/src/SofaSparseSolver/PrecomputedLinearSolver.cpp
@@ -32,7 +32,6 @@ namespace component
 namespace linearsolver
 {
 
-using namespace sofa::component::odesolver;
 using namespace sofa::component::linearsolver;
 
 int PrecomputedLinearSolverClass = core::RegisterObject("Linear system solver based on a precomputed inverse matrix")

--- a/modules/SofaSparseSolver/src/SofaSparseSolver/PrecomputedLinearSolver.inl
+++ b/modules/SofaSparseSolver/src/SofaSparseSolver/PrecomputedLinearSolver.inl
@@ -32,13 +32,12 @@
 #include <sofa/core/behavior/LinearSolver.h>
 #include <cmath>
 #include <sofa/helper/system/thread/CTime.h>
-#include <SofaSimpleFem/TetrahedronFEMForceField.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <SofaBaseLinearSolver/MatrixLinearSolver.h>
 #include <sofa/helper/system/thread/CTime.h>
 #include <sofa/core/behavior/LinearSolver.h>
 
-#include <SofaImplicitOdeSolver/EulerImplicitSolver.h>
+#include <sofa/core/behavior/ODESolver.h>
 #include <SofaBaseLinearSolver/CGLinearSolver.h>
 
 #if SOFASPARSESOLVER_HAVE_CSPARSE
@@ -92,10 +91,10 @@ void PrecomputedLinearSolver<TMatrix,TVector >::loadMatrix(TMatrix& M)
     internalData.Minv.resize(systemSize,systemSize);
     dt = this->getContext()->getDt();
 
-    odesolver::EulerImplicitSolver* EulerSolver;
-    this->getContext()->get(EulerSolver);
+    sofa::core::behavior::OdeSolver::SPtr odeSolver;
+    this->getContext()->get(odeSolver);
     factInt = 1.0; // christian : it is not a compliance... but an admittance that is computed !
-    if (EulerSolver) factInt = EulerSolver->getPositionIntegrationFactor(); // here, we compute a compliance
+    if (odeSolver) factInt = odeSolver->getPositionIntegrationFactor(); // here, we compute a compliance
 
     std::stringstream ss;
     ss << this->getContext()->getName() << "-" << systemSize << "-" << dt << ".comp";

--- a/modules/SofaSparseSolver/src/SofaSparseSolver/PrecomputedLinearSolver.inl
+++ b/modules/SofaSparseSolver/src/SofaSparseSolver/PrecomputedLinearSolver.inl
@@ -37,7 +37,7 @@
 #include <sofa/helper/system/thread/CTime.h>
 #include <sofa/core/behavior/LinearSolver.h>
 
-#include <sofa/core/behavior/ODESolver.h>
+#include <sofa/core/behavior/OdeSolver.h>
 #include <SofaBaseLinearSolver/CGLinearSolver.h>
 
 #if SOFASPARSESOLVER_HAVE_CSPARSE


### PR DESCRIPTION
- PrecomputedLinearSolver needed the ODESolver EulerImplicitSolver from SofaImplicitOdeSolver, for an information available in a higher level (OdeSolver directly)
- useless inclusion of TetraFEM from SofaSimpleFEM
▶ No dependencies on SofaImplicitOdeSolver and SofaSimpleFEM anymore




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
