### PR TITLE
[All] Remove useless inclusions of MechanicalObject.h

### DIFF
--- a/SofaKernel/modules/SofaBaseCollision/SofaBaseCollision_test/BroadPhase_test.h
+++ b/SofaKernel/modules/SofaBaseCollision/SofaBaseCollision_test/BroadPhase_test.h
@@ -26,6 +26,7 @@
 #include <SofaGeneralMeshCollision/IncrSAP.h>
 #include <SofaBaseCollision/NewProximityIntersection.h>
 #include <SofaSimulationGraph/DAGNode.h>
+#include <SofaBaseMechanics/MechanicalObject.h>
 
 #include <gtest/gtest.h>
 

--- a/SofaKernel/modules/SofaBaseCollision/SofaBaseCollision_test/OBB_test.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/SofaBaseCollision_test/OBB_test.cpp
@@ -25,6 +25,7 @@
 #include <SofaBaseCollision/OBBIntTool.h>
 #include <SofaBaseCollision/CapsuleIntTool.h>
 #include <SofaSimulationGraph/DAGNode.h>
+#include <SofaBaseMechanics/MechanicalObject.h>
 
 using namespace sofa::PrimitiveCreationTest;
 using namespace sofa::defaulttype;

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/LineLocalMinDistanceFilter.cpp
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/LineLocalMinDistanceFilter.cpp
@@ -19,9 +19,9 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-
 #include <SofaMeshCollision/LineLocalMinDistanceFilter.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
+
+#include <sofa/core/behavior/MechanicalState.h>
 #include <SofaBaseTopology/TopologyData.inl>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/core/ObjectFactory.h>
@@ -230,7 +230,7 @@ void LineLocalMinDistanceFilter::PointInfoHandler::applyCreateFunction(Index /*p
     sofa::core::topology::BaseMeshTopology * bmt = lLMDFilter->bmt; //getContext()->getTopology();
     pInfo.setBaseMeshTopology(bmt);
     /////// TODO : template de la classe
-    component::container::MechanicalObject<sofa::defaulttype::Vec3Types>*  mstateVec3d= dynamic_cast<component::container::MechanicalObject<sofa::defaulttype::Vec3Types>*>(lLMDFilter->getContext()->getMechanicalState());
+    auto*  mstateVec3d= dynamic_cast<core::behavior::MechanicalState<sofa::defaulttype::Vec3Types>*>(lLMDFilter->getContext()->getMechanicalState());
     if(mstateVec3d != nullptr)
     {
         pInfo.setPositionFiltering(&mstateVec3d->read(core::ConstVecCoordId::position())->getValue());
@@ -249,7 +249,7 @@ void LineLocalMinDistanceFilter::LineInfoHandler::applyCreateFunction(Index /*ed
 
 
     /////// TODO : template de la classe
-    component::container::MechanicalObject<sofa::defaulttype::Vec3Types>*  mstateVec3d= dynamic_cast<component::container::MechanicalObject<sofa::defaulttype::Vec3Types>*>(lLMDFilter->getContext()->getMechanicalState());
+    auto*  mstateVec3d= dynamic_cast<core::behavior::MechanicalState<sofa::defaulttype::Vec3Types>*>(lLMDFilter->getContext()->getMechanicalState());
     if(mstateVec3d != nullptr)
     {
         lInfo.setPositionFiltering(&mstateVec3d->read(core::ConstVecCoordId::position())->getValue());

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/PointLocalMinDistanceFilter.cpp
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/PointLocalMinDistanceFilter.cpp
@@ -19,9 +19,9 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-
 #include <SofaMeshCollision/PointLocalMinDistanceFilter.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
+
+#include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/visual/VisualParams.h>
 
 #include <SofaMeshCollision/LineModel.h>
@@ -256,7 +256,7 @@ void PointLocalMinDistanceFilter::PointInfoHandler::applyCreateFunction(Index /*
     sofa::core::topology::BaseMeshTopology * bmt = pLMDFilter->bmt; //getContext()->getMeshTopology();
     pInfo.setBaseMeshTopology(bmt);
     /////// TODO : template de la classe
-    component::container::MechanicalObject<sofa::defaulttype::Vec3Types>*  mstateVec3d= dynamic_cast<component::container::MechanicalObject<sofa::defaulttype::Vec3Types>*>(pLMDFilter->getContext()->getMechanicalState());
+    auto*  mstateVec3d= dynamic_cast<core::behavior::MechanicalState<sofa::defaulttype::Vec3Types>*>(pLMDFilter->getContext()->getMechanicalState());
     if(pLMDFilter->isRigid())
     {
         /////// TODO : template de la classe

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/PointModel.h
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/PointModel.h
@@ -23,10 +23,10 @@
 #include <SofaMeshCollision/config.h>
 
 #include <sofa/core/CollisionModel.h>
-#include <SofaMeshCollision/fwd.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
+#include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/defaulttype/VecTypes.h>
+#include <SofaMeshCollision/fwd.h>
 
 namespace sofa::component::collision
 {

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/PointModel.inl
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/PointModel.inl
@@ -25,11 +25,10 @@
 #include <sofa/defaulttype/Mat.h>
 #include <sofa/defaulttype/Vec.h>
 #include <sofa/core/visual/VisualParams.h>
-#include <SofaMeshCollision/PointLocalMinDistanceFilter.h>
-#include <SofaBaseCollision/CubeModel.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/simulation/Node.h>
-#include <vector>
+#include <SofaMeshCollision/PointLocalMinDistanceFilter.h>
+#include <SofaBaseCollision/CubeModel.h>
 
 namespace sofa::component::collision
 {

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/TriangleLocalMinDistanceFilter.cpp
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/TriangleLocalMinDistanceFilter.cpp
@@ -19,9 +19,9 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-
-#include <SofaBaseMechanics/MechanicalObject.h>
 #include <SofaMeshCollision/TriangleLocalMinDistanceFilter.h>
+
+#include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <SofaBaseTopology/TopologyData.inl>
 
@@ -100,7 +100,7 @@ void TriangleLocalMinDistanceFilter::init()
 
     bmt = l_topology.get();
     msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
-    component::container::MechanicalObject<sofa::defaulttype::Vec3Types>*  mstateVec3d= dynamic_cast<component::container::MechanicalObject<Vec3Types>*>(getContext()->getMechanicalState());
+    auto* mstateVec3d= dynamic_cast<core::behavior::MechanicalState<Vec3Types>*>(getContext()->getMechanicalState());
 
 
     if(mstateVec3d == nullptr)
@@ -212,7 +212,7 @@ void TriangleLocalMinDistanceFilter::PointInfoHandler::applyCreateFunction(Index
     sofa::core::topology::BaseMeshTopology * bmt = tLMDFilter->bmt;
     pInfo.setBaseMeshTopology(bmt);
     /////// TODO : template de la classe
-    component::container::MechanicalObject<Vec3Types>*  mstateVec3d= dynamic_cast<component::container::MechanicalObject<Vec3Types>*>(tLMDFilter->getContext()->getMechanicalState());
+    auto*  mstateVec3d= dynamic_cast<core::behavior::MechanicalState<Vec3Types>*>(tLMDFilter->getContext()->getMechanicalState());
     if(tLMDFilter->isRigid())
     {
         /////// TODO : template de la classe
@@ -242,7 +242,7 @@ void TriangleLocalMinDistanceFilter::LineInfoHandler::applyCreateFunction(Index 
     sofa::core::topology::BaseMeshTopology * bmt = tLMDFilter->bmt; // (sofa::core::topology::BaseMeshTopology *)tLMDFilter->getContext()->getTopology();
     lInfo.setBaseMeshTopology(bmt);
     /////// TODO : template de la classe
-    component::container::MechanicalObject<Vec3Types>*  mstateVec3d= dynamic_cast<component::container::MechanicalObject<Vec3Types>*>(tLMDFilter->getContext()->getMechanicalState());
+    auto* mstateVec3d= dynamic_cast<core::behavior::MechanicalState<Vec3Types>*>(tLMDFilter->getContext()->getMechanicalState());
     if(tLMDFilter->isRigid())
     {
         /////// TODO : template de la classe
@@ -271,7 +271,7 @@ void TriangleLocalMinDistanceFilter::TriangleInfoHandler::applyCreateFunction(In
     sofa::core::topology::BaseMeshTopology * bmt = tLMDFilter->bmt; // (sofa::core::topology::BaseMeshTopology *)tLMDFilter->getContext()->getTopology();
     tInfo.setBaseMeshTopology(bmt);
     /////// TODO : template de la classe
-    component::container::MechanicalObject<Vec3Types>*  mstateVec3d= dynamic_cast<component::container::MechanicalObject<Vec3Types>*>(tLMDFilter->getContext()->getMechanicalState());
+    auto*  mstateVec3d= dynamic_cast<core::behavior::MechanicalState<Vec3Types>*>(tLMDFilter->getContext()->getMechanicalState());
     if(tLMDFilter->isRigid())
     {
         /////// TODO : template de la classe

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/TriangleModel.h
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/TriangleModel.h
@@ -21,13 +21,13 @@
 ******************************************************************************/
 #pragma once
 #include <SofaMeshCollision/config.h>
-#include <sofa/core/fwd.h>
 
-#include <sofa/core/CollisionModel.h>
-#include <SofaBaseTopology/TopologyData.h>
-#include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/defaulttype/VecTypes.h>
+#include <sofa/core/fwd.h>
+#include <sofa/core/CollisionModel.h>
 #include <sofa/core/VecId.h>
+#include <sofa/core/topology/BaseMeshTopology.h>
+#include <sofa/core/behavior/MechanicalState.h>
 
 namespace sofa::component::collision
 {

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/TriangleModel.inl
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/TriangleModel.inl
@@ -21,7 +21,6 @@
 ******************************************************************************/
 #pragma once
 #include <SofaMeshCollision/TriangleModel.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <SofaMeshCollision/PointModel.h>
 #include <SofaMeshCollision/TriangleLocalMinDistanceFilter.h>
@@ -89,7 +88,7 @@ void TriangleCollisionModel<DataTypes>::init()
     bool modelsOk = true;
     if (m_mstate == nullptr)
     {
-        msg_error() << "No MechanicalObject found. TriangleCollisionModel<sofa::defaulttype::Vec3Types> requires a Vec3 Mechanical Model in the same Node.";
+        msg_error() << "No MechanicalState found. TriangleCollisionModel<sofa::defaulttype::Vec3Types> requires a Vec3 MechanicalState in the same Node.";
         modelsOk = false;
     }
 

--- a/modules/SofaBoundaryCondition/CMakeLists.txt
+++ b/modules/SofaBoundaryCondition/CMakeLists.txt
@@ -122,13 +122,12 @@ list(APPEND SOURCE_FILES
     ${SOFABOUNDARYCONDITION_SRC}/ProjectToPointConstraint.cpp
     ${SOFABOUNDARYCONDITION_SRC}/ProjectDirectionConstraint.cpp
     )
-
-sofa_find_package(SofaBase REQUIRED) # SofaBaseMechanics  
+    
 sofa_find_package(SofaEigen2Solver REQUIRED)
 sofa_find_package(SofaBaseTopology REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaBaseTopology SofaBaseMechanics)
+target_link_libraries(${PROJECT_NAME} PUBLIC SofaBaseTopology)
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaHelper SofaEigen2Solver)
 
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SkeletalMotionConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SkeletalMotionConstraint.h
@@ -23,7 +23,7 @@
 #include <SofaBoundaryCondition/config.h>
 
 #include <sofa/core/behavior/ProjectiveConstraintSet.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
+#include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/helper/SVector.h>
 #include <type_traits>
 
@@ -45,7 +45,7 @@ public:
     SOFA_CLASS(SOFA_TEMPLATE(SkeletalMotionConstraint,TDataTypes),SOFA_TEMPLATE(sofa::core::behavior::ProjectiveConstraintSet, TDataTypes));
     typedef TDataTypes DataTypes;
     typedef sofa::core::behavior::ProjectiveConstraintSet<TDataTypes> TProjectiveConstraintSet;
-    typedef component::container::MechanicalObject<DataTypes> MechanicalObject;
+    typedef sofa::core::behavior::MechanicalState<DataTypes> MechanicalState;
     typedef typename DataTypes::VecCoord VecCoord;
     typedef typename DataTypes::VecDeriv VecDeriv;
     typedef typename DataTypes::MatrixDeriv MatrixDeriv;

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SkeletalMotionConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SkeletalMotionConstraint.inl
@@ -144,7 +144,7 @@ void SkeletalMotionConstraint<DataTypes>::projectVelocity(const core::Mechanical
     if( !active.getValue() ) return;
 
     helper::WriteAccessor<DataVecDeriv> dx = vData;
-    helper::ReadAccessor<DataVecCoord> x =((MechanicalObject*)this->getContext()->getMechanicalState())->readPositions();
+    helper::ReadAccessor<DataVecCoord> x = ((MechanicalState*)this->getContext()->getMechanicalState())->readPositions();
     Real cT = (Real) this->getContext()->getTime() * animationSpeed.getValue();
     Real dt = (Real) this->getContext()->getDt();
 

--- a/modules/SofaConstraint/src/SofaConstraint/BilateralInteractionConstraint.cpp
+++ b/modules/SofaConstraint/src/SofaConstraint/BilateralInteractionConstraint.cpp
@@ -24,7 +24,6 @@
 #include <SofaConstraint/BilateralInteractionConstraint.inl>
 
 #include <sofa/defaulttype/VecTypes.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
 #include <sofa/core/ObjectFactory.h>
 
 namespace sofa::component::constraintset

--- a/modules/SofaConstraint/src/SofaConstraint/SlidingConstraint.cpp
+++ b/modules/SofaConstraint/src/SofaConstraint/SlidingConstraint.cpp
@@ -24,7 +24,6 @@
 #include <SofaConstraint/SlidingConstraint.inl>
 
 #include <sofa/defaulttype/VecTypes.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
 #include <sofa/core/ObjectFactory.h>
 
 namespace sofa::component::constraintset

--- a/modules/SofaConstraint/src/SofaConstraint/StopperConstraint.cpp
+++ b/modules/SofaConstraint/src/SofaConstraint/StopperConstraint.cpp
@@ -23,7 +23,6 @@
 #include <SofaConstraint/StopperConstraint.inl>
 
 #include <sofa/defaulttype/VecTypes.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
 #include <sofa/core/ObjectFactory.h>
 
 namespace sofa::component::constraintset

--- a/modules/SofaConstraint/src/SofaConstraint/UnilateralInteractionConstraint.cpp
+++ b/modules/SofaConstraint/src/SofaConstraint/UnilateralInteractionConstraint.cpp
@@ -22,7 +22,6 @@
 #define SOFA_COMPONENT_CONSTRAINTSET_UNILATERALINTERACTIONCONSTRAINT_CPP
 #include <SofaConstraint/UnilateralInteractionConstraint.inl>
 #include <sofa/defaulttype/VecTypes.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
 #include <sofa/core/ObjectFactory.h>
 
 namespace sofa::component::constraintset

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/IndexValueMapper.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/IndexValueMapper.h
@@ -25,7 +25,6 @@
 
 
 #include <sofa/core/DataEngine.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
 #include <sofa/helper/vector.h>
 
 namespace sofa::component::engine

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/Indices2ValuesMapper.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/Indices2ValuesMapper.h
@@ -25,7 +25,6 @@
 
 
 #include <sofa/core/DataEngine.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
 #include <sofa/helper/vector.h>
 
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/JoinPoints.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/JoinPoints.h
@@ -25,7 +25,6 @@
 
 
 #include <sofa/core/DataEngine.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
 #include <sofa/helper/vector.h>
 
 namespace sofa::component::engine

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/MergeROIs.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/MergeROIs.h
@@ -25,7 +25,6 @@
 
 
 #include <sofa/core/DataEngine.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
 #include <sofa/helper/vector.h>
 #include <sofa/helper/vectorData.h>
 #include <sofa/helper/SVector.h>

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/ROIValueMapper.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/ROIValueMapper.h
@@ -25,7 +25,6 @@
 
 
 #include <sofa/core/DataEngine.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
 #include <sofa/helper/vector.h>
 #include <sofa/helper/vectorData.h>
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/SelectLabelROI.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/SelectLabelROI.h
@@ -25,7 +25,6 @@
 
 
 #include <sofa/core/DataEngine.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
 #include <sofa/helper/vector.h>
 #include <sofa/helper/SVector.h>
 

--- a/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/TriangleOctree.h
+++ b/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/TriangleOctree.h
@@ -24,7 +24,6 @@
 #include <SofaGeneralMeshCollision/config.h>
 
 #include <sofa/core/CollisionModel.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/defaulttype/VecTypes.h>
 

--- a/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/TriangleOctreeModel.h
+++ b/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/TriangleOctreeModel.h
@@ -24,7 +24,6 @@
 #include <SofaGeneralMeshCollision/config.h>
 
 #include <sofa/core/CollisionModel.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <SofaMeshCollision/TriangleModel.h>

--- a/modules/SofaGeneralRigid/src/SofaGeneralRigid/ArticulatedHierarchyContainer.h
+++ b/modules/SofaGeneralRigid/src/SofaGeneralRigid/ArticulatedHierarchyContainer.h
@@ -26,7 +26,6 @@
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <SofaGeneralRigid/bvh/BVHLoader.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
 #include <sofa/defaulttype/SolidTypes.h>
 #include <sofa/core/objectmodel/DataFileName.h>
 #include <sofa/simulation/fwd.h>

--- a/modules/SofaGeneralRigid/src/SofaGeneralRigid/ArticulatedHierarchyContainer.inl
+++ b/modules/SofaGeneralRigid/src/SofaGeneralRigid/ArticulatedHierarchyContainer.inl
@@ -19,10 +19,12 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-
 #pragma once
+
 #include <SofaGeneralRigid/ArticulatedHierarchyContainer.h>
+
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/simulation/Node.h>
 
@@ -224,11 +226,11 @@ void ArticulatedHierarchyContainer::init ()
 
         buildCenterArticulationsTree(joint, 0, "Root", articulationCenters.get());
 
-        component::container::MechanicalObject<defaulttype::Vec1Types>* mm1 = dynamic_cast<component::container::MechanicalObject<defaulttype::Vec1Types>*>(context->getMechanicalState());
+        auto* mm1 = dynamic_cast<core::behavior::MechanicalState<defaulttype::Vec1Types>*>(context->getMechanicalState());
         mm1->resize(id);
 
         context = (context->child.begin())->get();
-        component::container::MechanicalObject<defaulttype::RigidTypes>* mm2 = dynamic_cast<component::container::MechanicalObject<defaulttype::RigidTypes>*>(context->getMechanicalState());
+        auto* mm2 = dynamic_cast<core::behavior::MechanicalState<defaulttype::RigidTypes>*>(context->getMechanicalState());
         mm2->resize(joint->getNumJoints()+1);
     }
     else

--- a/modules/SofaMiscFem/src/SofaMiscFem/FastTetrahedralCorotationalForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/FastTetrahedralCorotationalForceField.h
@@ -26,7 +26,6 @@
 
 
 #include <sofa/core/behavior/ForceField.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
 #include <sofa/helper/fixed_array.h>
 #include <sofa/helper/vector.h>
 #include <sofa/defaulttype/Vec.h>

--- a/modules/SofaMiscForceField/CMakeLists.txt
+++ b/modules/SofaMiscForceField/CMakeLists.txt
@@ -34,13 +34,14 @@ if(SOFA_WITH_DEPRECATED_COMPONENTS)
 endif()
 
 sofa_find_package(SofaFramework REQUIRED) # SofaHelper
+sofa_find_package(SofaBaseMechanics REQUIRED)
 sofa_find_package(SofaDeformable REQUIRED)
 sofa_find_package(SofaBoundaryCondition REQUIRED)
 sofa_find_package(SofaGeneralTopology REQUIRED) 
 sofa_find_package(SofaMiscTopology REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaHelper SofaDeformable SofaBoundaryCondition SofaMiscTopology SofaGeneralTopology)
+target_link_libraries(${PROJECT_NAME} PUBLIC SofaHelper SofaDeformable SofaBoundaryCondition SofaMiscTopology SofaGeneralTopology SofaBaseMechanics)
 
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Silence attribute warnings (for example, ignored already defined external template)

--- a/modules/SofaSparseSolver/CMakeLists.txt
+++ b/modules/SofaSparseSolver/CMakeLists.txt
@@ -3,8 +3,6 @@ project(SofaSparseSolver LANGUAGES CXX)
 
 # Dependencies
 sofa_find_package(SofaBase REQUIRED)
-sofa_find_package(SofaImplicitOdeSolver REQUIRED) 
-sofa_find_package(SofaSimpleFem REQUIRED)
 sofa_find_package(SofaGeneralLinearSolver REQUIRED)
 
 add_subdirectory(extlibs/csparse)
@@ -41,7 +39,7 @@ set(SOURCE_FILES
     )
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaBaseLinearSolver SofaGeneralLinearSolver SofaImplicitOdeSolver SofaSimpleFem)
+target_link_libraries(${PROJECT_NAME} PUBLIC SofaBaseLinearSolver SofaGeneralLinearSolver)
 target_link_libraries(${PROJECT_NAME} PUBLIC metis csparse)
 
 sofa_create_package_with_targets(

--- a/modules/SofaSparseSolver/src/SofaSparseSolver/PrecomputedLinearSolver.cpp
+++ b/modules/SofaSparseSolver/src/SofaSparseSolver/PrecomputedLinearSolver.cpp
@@ -32,7 +32,6 @@ namespace component
 namespace linearsolver
 {
 
-using namespace sofa::component::odesolver;
 using namespace sofa::component::linearsolver;
 
 int PrecomputedLinearSolverClass = core::RegisterObject("Linear system solver based on a precomputed inverse matrix")

--- a/modules/SofaSparseSolver/src/SofaSparseSolver/PrecomputedLinearSolver.inl
+++ b/modules/SofaSparseSolver/src/SofaSparseSolver/PrecomputedLinearSolver.inl
@@ -32,13 +32,12 @@
 #include <sofa/core/behavior/LinearSolver.h>
 #include <cmath>
 #include <sofa/helper/system/thread/CTime.h>
-#include <SofaSimpleFem/TetrahedronFEMForceField.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <SofaBaseLinearSolver/MatrixLinearSolver.h>
 #include <sofa/helper/system/thread/CTime.h>
 #include <sofa/core/behavior/LinearSolver.h>
 
-#include <SofaImplicitOdeSolver/EulerImplicitSolver.h>
+#include <sofa/core/behavior/ODESolver.h>
 #include <SofaBaseLinearSolver/CGLinearSolver.h>
 
 #if SOFASPARSESOLVER_HAVE_CSPARSE
@@ -92,10 +91,10 @@ void PrecomputedLinearSolver<TMatrix,TVector >::loadMatrix(TMatrix& M)
     internalData.Minv.resize(systemSize,systemSize);
     dt = this->getContext()->getDt();
 
-    odesolver::EulerImplicitSolver* EulerSolver;
-    this->getContext()->get(EulerSolver);
+    sofa::core::behavior::OdeSolver::SPtr odeSolver;
+    this->getContext()->get(odeSolver);
     factInt = 1.0; // christian : it is not a compliance... but an admittance that is computed !
-    if (EulerSolver) factInt = EulerSolver->getPositionIntegrationFactor(); // here, we compute a compliance
+    if (odeSolver) factInt = odeSolver->getPositionIntegrationFactor(); // here, we compute a compliance
 
     std::stringstream ss;
     ss << this->getContext()->getName() << "-" << systemSize << "-" << dt << ".comp";

--- a/modules/SofaSparseSolver/src/SofaSparseSolver/PrecomputedLinearSolver.inl
+++ b/modules/SofaSparseSolver/src/SofaSparseSolver/PrecomputedLinearSolver.inl
@@ -37,7 +37,7 @@
 #include <sofa/helper/system/thread/CTime.h>
 #include <sofa/core/behavior/LinearSolver.h>
 
-#include <sofa/core/behavior/ODESolver.h>
+#include <sofa/core/behavior/OdeSolver.h>
 #include <SofaBaseLinearSolver/CGLinearSolver.h>
 
 #if SOFASPARSESOLVER_HAVE_CSPARSE

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/RayModel.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/RayModel.cpp
@@ -20,10 +20,11 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <SofaUserInteraction/RayModel.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
+
 #include <sofa/core/visual/VisualParams.h>
-#include <SofaBaseCollision/CubeModel.h>
 #include <sofa/core/ObjectFactory.h>
+#include <sofa/core/behavior/MechanicalState.h>
+#include <SofaBaseCollision/CubeModel.h>
 
 namespace sofa::component::collision
 {


### PR DESCRIPTION
Cleaning continues, some files includes MechanicalObject either for no reason at all, or could use MechanicalState (from SofaCore) instead.
▶ No more need for SofaBaseMechanics by SofaBoundaryCondition


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
