### PR TITLE
[SofaSimulationCore] Revert changes in #1927

### DIFF
--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DefaultTaskScheduler.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DefaultTaskScheduler.cpp
@@ -55,6 +55,7 @@ namespace sofa
             m_isClosing = false;
             
             // init global static thread local var
+            if (_threads.find(std::this_thread::get_id()) == _threads.end())
             {
                 workerThreadIndex = new WorkerThread(this, 0, "Main  ");
                 _threads[std::this_thread::get_id()] = workerThreadIndex;// new WorkerThread(this, 0, "Main  ");

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DefaultTaskScheduler.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DefaultTaskScheduler.cpp
@@ -55,7 +55,6 @@ namespace sofa
             m_isClosing = false;
             
             // init global static thread local var
-            if (_threads.find(std::this_thread::get_id()) == _threads.end())
             {
                 workerThreadIndex = new WorkerThread(this, 0, "Main  ");
                 _threads[std::this_thread::get_id()] = workerThreadIndex;// new WorkerThread(this, 0, "Main  ");

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/TaskScheduler.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/TaskScheduler.cpp
@@ -16,7 +16,7 @@ namespace sofa
         // the TaskScheduler::_schedulers must be initialized before any call to TaskScheduler::registerScheduler
         std::map<std::string, std::function<TaskScheduler*()> > TaskScheduler::_schedulers;
         std::string TaskScheduler::_currentSchedulerName;
-        std::unique_ptr<TaskScheduler> TaskScheduler::_currentScheduler = nullptr;
+        TaskScheduler* TaskScheduler::_currentScheduler = nullptr;
         
         // register default task scheduler
         const bool DefaultTaskScheduler::isRegistered = TaskScheduler::registerScheduler(DefaultTaskScheduler::name(), &DefaultTaskScheduler::create);
@@ -27,7 +27,7 @@ namespace sofa
             // is already the current scheduler
             std::string nameStr(name);
             if (!nameStr.empty() && _currentSchedulerName == name)
-                return _currentScheduler.get();
+                return _currentScheduler;
             
             auto iter = _schedulers.find(name);
             if (iter == _schedulers.end())
@@ -40,17 +40,17 @@ namespace sofa
             
             if (_currentScheduler != nullptr)
             {
-                _currentScheduler.reset();
+                delete _currentScheduler;
             }
             
             TaskSchedulerCreatorFunction& creatorFunc = iter->second;
-            _currentScheduler = std::unique_ptr<TaskScheduler>(creatorFunc());
+            _currentScheduler = creatorFunc();
             
             _currentSchedulerName = iter->first;
             
             Task::setAllocator(_currentScheduler->getTaskAllocator());
             
-            return _currentScheduler.get();
+            return _currentScheduler;
         }
         
         
@@ -68,7 +68,7 @@ namespace sofa
                 _currentScheduler->init();
             }
             
-            return _currentScheduler.get();
+            return _currentScheduler;
         }
         
         

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/TaskScheduler.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/TaskScheduler.h
@@ -111,7 +111,7 @@ namespace sofa
             
             // current instantiated scheduler
             static std::string _currentSchedulerName;
-            static std::unique_ptr<TaskScheduler> _currentScheduler;
+            static TaskScheduler* _currentScheduler;
             
             friend class Task;
         };


### PR DESCRIPTION
#1927 is suspected to causes crashes in multi-threaded scenes on Jenkins






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
