### PR TITLE
[SofaGuiCommon] Write json file

### DIFF
--- a/modules/SofaGuiCommon/src/sofa/gui/BatchGUI.cpp
+++ b/modules/SofaGuiCommon/src/sofa/gui/BatchGUI.cpp
@@ -25,9 +25,9 @@
 #include <sofa/simulation/UpdateContextVisitor.h>
 #include <sofa/simulation/Node.h>
 #include <sofa/helper/system/thread/CTime.h>
-#include <iostream>
-#include <sstream>
+#include <fstream>
 #include <string>
+#include <sofa/helper/system/SetDirectory.h>
 
 #include <boost/program_options.hpp>
 
@@ -74,8 +74,18 @@ int BatchGUI::mainLoop()
             if (i != nbIter)
             {
                 sofa::helper::AdvancedTimer::begin("Animate");
+
                 sofa::simulation::getSimulation()->animate(groot.get());
-                sofa::helper::AdvancedTimer::end("Animate");
+
+                const auto timerOutputStr = sofa::helper::AdvancedTimer::end("Animate", groot->getTime(), groot->getDt());
+                if (!timerOutputStr.empty() && timerOutputStr.compare("null") != 0)
+                {
+                    std::string jsonFilename = sofa::helper::system::SetDirectory::GetFileNameWithoutExtension(filename.c_str()) + "_" + std::to_string(i) + ".json";
+                    msg_info("BatchGUI") << "Writing " << jsonFilename;
+                    std::ofstream out(jsonFilename);
+                    out << timerOutputStr;
+                    out.close();
+                }
             }
 
             if ( i == nbIter || (nbIter == -1 && i%1000 == 0) )

--- a/modules/SofaGuiCommon/src/sofa/gui/BatchGUI.h
+++ b/modules/SofaGuiCommon/src/sofa/gui/BatchGUI.h
@@ -94,6 +94,12 @@ protected:
     std::string filename;
     static signed int nbIter;
     static std::string nbIterInp;
+
+    /// Return true if the timer output string has a json string and the timer is setup to output json
+    static bool canExportJson(const std::string& timerOutputStr, const std::string& timerId);
+
+    /// Export a text file (with json extension) containing the timer output string
+    void exportJson(const std::string& timerOutputStr, int iterationNumber) const;
 };
 
 } // namespace sofa::gui


### PR DESCRIPTION
According to the help in runSofa, the option `--computationTimeOutputType` gives the choice to output computation time stats as a json file. I was not able to export any json file, so I tried to fix it. This is my proposition. It works only for `BatchGUI`.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
