### PR TITLE
[SofaCUDA] Quick fix for SofaCUDA NVCC flags include not found during CMake setup

### DIFF
--- a/applications/plugins/SofaCUDA/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/CMakeLists.txt
@@ -371,7 +371,7 @@ endif()
 
 ## SofaCUDANvccFlags.cmake
 # Build tree
-configure_file(SofaCUDANvccFlags.cmake ${CMAKE_BINARY_DIR}/cmake/SofaCUDANvccFlags.cmake COPYONLY)
+configure_file(SofaCUDANvccFlags.cmake ${CMAKE_BINARY_DIR}/lib/cmake/SofaCUDANvccFlags.cmake COPYONLY)
 # Install tree
 install(FILES SofaCUDANvccFlags.cmake DESTINATION lib/cmake/SofaCUDA)
 


### PR DESCRIPTION
As introduced in #2021 , a quick fix for a SofaCUDA cmake configuration file not found when requested.





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
