### PR TITLE
[SofaBaseTopology] Add security in TopologyData to check input Topology pointer

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
@@ -43,6 +43,11 @@ TopologyData <TopologyElementType, VecT>::TopologyData(const typename sofa::core
 template <typename TopologyElementType, typename VecT>
 void TopologyData <TopologyElementType, VecT>::createTopologyHandler(sofa::core::topology::BaseMeshTopology* _topology)
 {
+    if (_topology == nullptr)
+    {
+        msg_error(this->getOwner()) << "Topology used to register this TopologyData: " << this->getName() << " is invalid. TopologyData won't be registered.";
+        return;
+    }
     this->m_topology = _topology;
 
     // Create Topology engine
@@ -66,6 +71,12 @@ void TopologyData <TopologyElementType, VecT>::createTopologyHandler(sofa::core:
 template <typename TopologyElementType, typename VecT>
 void TopologyData <TopologyElementType, VecT>::createTopologyHandler(sofa::core::topology::BaseMeshTopology* _topology, sofa::component::topology::TopologyDataHandler< TopologyElementType, VecT>* topoEngine)
 {
+    if (_topology == nullptr)
+    {
+        msg_error(this->getOwner()) << "Topology used to register this TopologyData: " << this->getName() << " is invalid. TopologyData won't be registered.";
+        return;
+    }
+
     this->m_topology = _topology;
 
     // Set Topology engine


### PR DESCRIPTION
Following issue identified in PR #2026. Check that the topology pointer given is not null before registering it. 


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
