### PR TITLE
[SofaConstraint] Fix symbol export of BilateralInteractionConstraint on RigidTypes

### DIFF
--- a/modules/SofaConstraint/src/SofaConstraint/BilateralInteractionConstraint.cpp
+++ b/modules/SofaConstraint/src/SofaConstraint/BilateralInteractionConstraint.cpp
@@ -257,17 +257,17 @@ public:
 };
 
 
-template<>
+template<> SOFA_SOFACONSTRAINT_API
 void BilateralInteractionConstraint<Rigid3Types>::init(){
     unspecializedInit() ;
 }
 
-template<>
+template<> SOFA_SOFACONSTRAINT_API
 void BilateralInteractionConstraint<Rigid3Types>::bwdInit() {
     BilateralInteractionConstraintSpecialization<RigidImpl>::bwdInit(*this);
 }
 
-template<>
+template<> SOFA_SOFACONSTRAINT_API
 void BilateralInteractionConstraint<Rigid3Types>::getConstraintResolution(const ConstraintParams* cParams,
                                                                            std::vector<ConstraintResolution*>& resTab,
                                                                            unsigned int& offset)
@@ -277,7 +277,7 @@ void BilateralInteractionConstraint<Rigid3Types>::getConstraintResolution(const 
                                                                                      d_numericalTolerance.getValue()) ;
 }
 
-template <>
+template <> SOFA_SOFACONSTRAINT_API
 void BilateralInteractionConstraint<Rigid3Types>::buildConstraintMatrix(const ConstraintParams* cParams,
                                                                          DataMatrixDeriv &c1_d,
                                                                          DataMatrixDeriv &c2_d,
@@ -290,7 +290,7 @@ void BilateralInteractionConstraint<Rigid3Types>::buildConstraintMatrix(const Co
 }
 
 
-template <>
+template <> SOFA_SOFACONSTRAINT_API
 void BilateralInteractionConstraint<Rigid3Types>::getConstraintViolation(const ConstraintParams* cParams,
                                                                           BaseVector *v,
                                                                           const DataVecCoord &d_x1, const DataVecCoord &d_x2,
@@ -302,7 +302,7 @@ void BilateralInteractionConstraint<Rigid3Types>::getConstraintViolation(const C
 }
 
 
-template <>
+template <> SOFA_SOFACONSTRAINT_API
 void BilateralInteractionConstraint<Rigid3Types>::getVelocityViolation(BaseVector * /*v*/,
                                                                         const DataVecCoord &/*x1*/,
                                                                         const DataVecCoord &/*x2*/,
@@ -312,7 +312,7 @@ void BilateralInteractionConstraint<Rigid3Types>::getVelocityViolation(BaseVecto
 
 }
 
-template<>
+template<> SOFA_SOFACONSTRAINT_API
 void BilateralInteractionConstraint<defaulttype::Rigid3Types>::addContact(Deriv norm,
                                                                            Coord P, Coord Q, Real contactDistance,
                                                                            int m1, int m2,

--- a/modules/SofaConstraint/src/SofaConstraint/BilateralInteractionConstraint.h
+++ b/modules/SofaConstraint/src/SofaConstraint/BilateralInteractionConstraint.h
@@ -164,24 +164,6 @@ private:
     void unspecializedInit() ;
 };
 
-template<>
-void BilateralInteractionConstraint<Rigid3Types>::buildConstraintMatrix(const ConstraintParams *cParams,
-                                                                        DataMatrixDeriv &c1_d, DataMatrixDeriv &c2_d,
-                                                                        unsigned int &cIndex
-                                                                        , const DataVecCoord &x1, const DataVecCoord &x2);
-
-template<>
-void BilateralInteractionConstraint<Rigid3Types>::getConstraintViolation(const ConstraintParams *cParams,
-                                                                         BaseVector *v, const DataVecCoord &x1_d, const DataVecCoord &x2_d
-                                                                         , const DataVecDeriv &v1_d, const DataVecDeriv &v2_d);
-
-template<>
-void BilateralInteractionConstraint<Rigid3Types>::addContact(Deriv /*norm*/,
-                                                             Coord P, Coord Q, Real /*contactDistance*/,
-                                                             int m1, int m2, Coord /*Pfree*/,
-                                                             Coord /*Qfree*/, long /*id*/, PersistentID /*localid*/);
-
-
 
 #if !defined(SOFA_COMPONENT_CONSTRAINTSET_BILATERALINTERACTIONCONSTRAINT_CPP)
 extern template class SOFA_SOFACONSTRAINT_API BilateralInteractionConstraint< Vec3Types >;


### PR DESCRIPTION
(For Windows)
- Specialized functions of BilateralInteractionConstraint on Rigids were declared in the header file (useless)
- the definition of these specialized functions did not have the _API keyword (exporting these symbols in the dll)

There is currently no problem because components using BilateralInteractionConstraint are all in the same module...



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
