### PR TITLE
[Geomagic] Fix Geomagic plugin compilation 

### DIFF
--- a/applications/plugins/Geomagic/src/Geomagic/GeomagicDriver.cpp
+++ b/applications/plugins/Geomagic/src/Geomagic/GeomagicDriver.cpp
@@ -496,7 +496,7 @@ void GeomagicDriver::computeBBox(const core::ExecParams*  params, bool  )
     maxBBox[1] = d_posDevice.getValue().getCenter()[1]+d_positionBase.getValue()[1]*d_scale.getValue();
     maxBBox[2] = d_posDevice.getValue().getCenter()[2]+d_positionBase.getValue()[2]*d_scale.getValue();
 
-    this->f_bbox.setValue(params,sofa::defaulttype::TBoundingBox<SReal>(minBBox,maxBBox));
+    this->f_bbox.setValue(sofa::defaulttype::TBoundingBox<SReal>(minBBox,maxBBox));
 }
 
 


### PR DESCRIPTION
remove call to setValue using execParams which has been depreciate






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
