### PR TITLE
[SofaExporter] Remove SofaBaseVisual dependency

### DIFF
--- a/modules/SofaExporter/CMakeLists.txt
+++ b/modules/SofaExporter/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 project(SofaExporter LANGUAGES CXX)
 
-sofa_find_package(SofaBaseVisual REQUIRED)
+sofa_find_package(SofaFramework REQUIRED)
 sofa_find_package(ZLIB REQUIRED)
 
 set(SRC_ROOT src/SofaExporter)
@@ -46,7 +46,7 @@ list(APPEND SOURCE_FILES
     )
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${EXTRA_FILES})
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaBaseVisual)
+target_link_libraries(${PROJECT_NAME} PUBLIC SofaSimulationCore)
 target_link_libraries(${PROJECT_NAME} PUBLIC ZLIB::ZLIB)
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
     sofa_install_libraries(TARGETS ZLIB::ZLIB)

--- a/modules/SofaExporter/src/SofaExporter/STLExporter.cpp
+++ b/modules/SofaExporter/src/SofaExporter/STLExporter.cpp
@@ -25,13 +25,10 @@
 #include <fstream>
 
 #include <sofa/core/ObjectFactory.h>
-
-
 #include <sofa/core/behavior/BaseMechanicalState.h>
-
 #include <sofa/core/objectmodel/KeypressedEvent.h>
 #include <sofa/core/objectmodel/GUIEvent.h>
-#include <SofaBaseVisual/VisualModelImpl.h>
+#include <sofa/core/visual/VisualModel.h>
 
 using sofa::core::objectmodel::KeypressedEvent ;
 using sofa::core::objectmodel::GUIEvent ;


### PR DESCRIPTION
STLExporter had a useless dependency on VisualModelImpl.
Removing it removes the need on SofaBaseVisual for SofaExporter.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
