### PR TITLE
[SofaCore] Move function definition in cpp files

### DIFF
--- a/SofaKernel/modules/SofaCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/CMakeLists.txt
@@ -198,8 +198,10 @@ set(SOURCE_FILES
     ${SRC_ROOT}/behavior/PairInteractionProjectiveConstraintSet.cpp
     ${SRC_ROOT}/behavior/ProjectiveConstraintSet.cpp
     ${SRC_ROOT}/behavior/fwd.cpp
+    ${SRC_ROOT}/collision/BroadPhaseDetection.cpp
     ${SRC_ROOT}/collision/Contact.cpp
     ${SRC_ROOT}/collision/Intersection.cpp
+    ${SRC_ROOT}/collision/NarrowPhaseDetection.cpp
     ${SRC_ROOT}/collision/Pipeline.cpp
     ${SRC_ROOT}/init.cpp    
     ${SRC_ROOT}/fwd.cpp

--- a/SofaKernel/modules/SofaCore/src/sofa/core/collision/BroadPhaseDetection.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/collision/BroadPhaseDetection.cpp
@@ -56,4 +56,5 @@ void BroadPhaseDetection::changeInstanceBP(Instance inst)
     storedCmPairs[instance].swap(cmPairs);
     cmPairs.swap(storedCmPairs[inst]);
 }
-}
+
+} // namespace sofa::core::collision

--- a/SofaKernel/modules/SofaCore/src/sofa/core/collision/BroadPhaseDetection.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/collision/BroadPhaseDetection.cpp
@@ -1,0 +1,59 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/core/collision/BroadPhaseDetection.h>
+
+namespace sofa::core::collision
+{
+
+void BroadPhaseDetection::beginBroadPhase()
+{
+    cmPairs.clear();
+}
+
+void BroadPhaseDetection::addCollisionModels(const sofa::helper::vector<core::CollisionModel *>& v)
+{
+    for (auto* collisionModel : v)
+    {
+        addCollisionModel(collisionModel);
+    }
+}
+
+void BroadPhaseDetection::endBroadPhase()
+{
+}
+
+auto BroadPhaseDetection::getCollisionModelPairs() -> sofa::helper::vector<CollisionModelPair>&
+{
+    return cmPairs;
+}
+
+auto BroadPhaseDetection::getCollisionModelPairs() const -> const sofa::helper::vector<CollisionModelPair>&
+{
+    return cmPairs;
+}
+
+void BroadPhaseDetection::changeInstanceBP(Instance inst)
+{
+    storedCmPairs[instance].swap(cmPairs);
+    cmPairs.swap(storedCmPairs[inst]);
+}
+}

--- a/SofaKernel/modules/SofaCore/src/sofa/core/collision/BroadPhaseDetection.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/collision/BroadPhaseDetection.h
@@ -19,8 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_CORE_COLLISION_BROADPHASEDETECTION_H
-#define SOFA_CORE_COLLISION_BROADPHASEDETECTION_H
+#pragma once
 
 #include <sofa/core/collision/Detection.h>
 #include <sofa/helper/vector.h>
@@ -69,4 +68,3 @@ protected:
 };
 
 }
-#endif

--- a/SofaKernel/modules/SofaCore/src/sofa/core/collision/BroadPhaseDetection.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/collision/BroadPhaseDetection.h
@@ -25,18 +25,13 @@
 #include <sofa/core/collision/Detection.h>
 #include <sofa/helper/vector.h>
 
-namespace sofa
+namespace sofa::core::collision
 {
 
-namespace core
-{
-
-namespace collision
-{
 /**
  * @brief given a set of root collision models, computes potentially colliding pairs.
  */
-class BroadPhaseDetection : virtual public Detection
+class SOFA_CORE_API BroadPhaseDetection : virtual public Detection
 {
 public:
     SOFA_ABSTRACT_CLASS(BroadPhaseDetection, Detection);
@@ -47,31 +42,20 @@ protected:
     ~BroadPhaseDetection() override = default;
 public:
     /// Clear all the potentially colliding pairs detected in the previous simulation step
-    virtual void beginBroadPhase()
-    {
-        cmPairs.clear();
-    }
+    virtual void beginBroadPhase();
 
     /// Add a new collision model to the set of root collision models managed by this class
     virtual void addCollisionModel(core::CollisionModel *cm) = 0;
 
     /// Add a list of collision models to the set of root collision models managed by this class
-    virtual void addCollisionModels(const sofa::helper::vector<core::CollisionModel *>& v)
-    {
-        for (auto* collisionModel : v)
-        {
-            addCollisionModel(collisionModel);
-        }
-    }
+    virtual void addCollisionModels(const sofa::helper::vector<core::CollisionModel *>& v);
 
     /// Actions to accomplish when the broadPhase is finished. By default do nothing.
-    virtual void endBroadPhase()
-    {
-    }
+    virtual void endBroadPhase();
 
     /// Get the potentially colliding pairs detected
-    sofa::helper::vector<CollisionModelPair>& getCollisionModelPairs() { return cmPairs; }
-    const sofa::helper::vector<CollisionModelPair>& getCollisionModelPairs() const { return cmPairs; }
+    sofa::helper::vector<CollisionModelPair>& getCollisionModelPairs();
+    const sofa::helper::vector<CollisionModelPair>& getCollisionModelPairs() const;
 
     /// Returns true because it needs a deep bounding tree i.e. a depth that can be superior to 1.
     inline virtual bool needsDeepBoundingTree()const{return true;}
@@ -81,17 +65,8 @@ protected:
     sofa::helper::vector< CollisionModelPair > cmPairs;
     std::map<Instance,sofa::helper::vector< CollisionModelPair > > storedCmPairs;
 
-    void changeInstanceBP(Instance inst) override
-    {
-        storedCmPairs[instance].swap(cmPairs);
-        cmPairs.swap(storedCmPairs[inst]);
-    }
+    void changeInstanceBP(Instance inst) override;
 };
 
-} // namespace collision
-
-} // namespace core
-
-} // namespace sofa
-
+}
 #endif

--- a/SofaKernel/modules/SofaCore/src/sofa/core/collision/BroadPhaseDetection.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/collision/BroadPhaseDetection.h
@@ -67,4 +67,4 @@ protected:
     void changeInstanceBP(Instance inst) override;
 };
 
-}
+} // namespace sofa::core::collision

--- a/SofaKernel/modules/SofaCore/src/sofa/core/collision/NarrowPhaseDetection.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/collision/NarrowPhaseDetection.cpp
@@ -1,0 +1,101 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/core/collision/NarrowPhaseDetection.h>
+
+namespace sofa::core::collision
+{
+
+void NarrowPhaseDetection::beginNarrowPhase()
+{
+    for (DetectionOutputMap::iterator it = m_outputsMap.begin(); it != m_outputsMap.end(); it++)
+    {
+        DetectionOutputVector *do_vec = (it->second);
+
+        if (do_vec != nullptr)
+            do_vec->clear();
+    }
+}
+
+void NarrowPhaseDetection::addCollisionPairs(const sofa::helper::vector< std::pair<core::CollisionModel*, core::CollisionModel*> >& v)
+{
+    for (sofa::helper::vector< std::pair<core::CollisionModel*, core::CollisionModel*> >::const_iterator it = v.begin(); it!=v.end(); it++)
+        addCollisionPair(*it);
+
+    // m_outputsMap should just be filled in addCollisionPair function
+    m_primitiveTestCount = m_outputsMap.size();
+}
+
+void NarrowPhaseDetection::endNarrowPhase()
+{
+    DetectionOutputMap::iterator it = m_outputsMap.begin();
+
+    while (it != m_outputsMap.end())
+    {
+        DetectionOutputVector *do_vec = (it->second);
+
+        if (!do_vec || do_vec->empty())
+        {
+            /// @todo Optimization
+            DetectionOutputMap::iterator iterase = it;
+            ++it;
+            m_outputsMap.erase(iterase);
+            if (do_vec) do_vec->release();
+        }
+        else
+        {
+            ++it;
+        }
+    }
+}
+
+size_t NarrowPhaseDetection::getPrimitiveTestCount() const
+{
+    return m_primitiveTestCount;
+}
+
+auto NarrowPhaseDetection::getDetectionOutputs() const -> const DetectionOutputMap&
+{
+    return m_outputsMap;
+}
+
+DetectionOutputVector*& NarrowPhaseDetection::getDetectionOutputs(CollisionModel *cm1, CollisionModel *cm2)
+{
+    std::pair< CollisionModel*, CollisionModel* > cm_pair = std::make_pair(cm1, cm2);
+
+    DetectionOutputMap::iterator it = m_outputsMap.find(cm_pair);
+
+    if (it == m_outputsMap.end())
+    {
+        // new contact
+        it = m_outputsMap.insert( std::make_pair(cm_pair, static_cast< DetectionOutputVector * >(0)) ).first;
+    }
+
+    return it->second;
+}
+
+void NarrowPhaseDetection::changeInstanceNP(Instance inst)
+{
+    m_storedOutputsMap[instance].swap(m_outputsMap);
+    m_outputsMap.swap(m_storedOutputsMap[inst]);
+}
+
+}

--- a/SofaKernel/modules/SofaCore/src/sofa/core/collision/NarrowPhaseDetection.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/collision/NarrowPhaseDetection.cpp
@@ -98,4 +98,4 @@ void NarrowPhaseDetection::changeInstanceNP(Instance inst)
     m_outputsMap.swap(m_storedOutputsMap[inst]);
 }
 
-}
+} // namespace sofa::core::collision

--- a/SofaKernel/modules/SofaCore/src/sofa/core/collision/NarrowPhaseDetection.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/collision/NarrowPhaseDetection.h
@@ -19,8 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_COMPONENT_COLLISION_NARROWPHASEDETECTION_H
-#define SOFA_COMPONENT_COLLISION_NARROWPHASEDETECTION_H
+#pragma once
 
 #include <sofa/core/collision/Detection.h>
 #include <sofa/core/collision/DetectionOutput.h>
@@ -82,5 +81,3 @@ protected:
 };
 
 } // namespace sofa
-
-#endif

--- a/SofaKernel/modules/SofaCore/src/sofa/core/collision/NarrowPhaseDetection.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/collision/NarrowPhaseDetection.h
@@ -80,4 +80,4 @@ protected:
     size_t m_primitiveTestCount; // used only for statistics purpose
 };
 
-} // namespace sofa
+} // namespace sofa::core::collision

--- a/SofaKernel/modules/SofaCore/src/sofa/core/collision/NarrowPhaseDetection.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/collision/NarrowPhaseDetection.h
@@ -28,20 +28,13 @@
 #include <vector>
 #include <map>
 
-namespace sofa
-{
-
-namespace core
-{
-
-namespace collision
+namespace sofa::core::collision
 {
 
 /**
-* @brief Given a set of potentially colliding pairs of models, compute set of contact points
-*/
-
-class NarrowPhaseDetection : virtual public Detection
+ * @brief Given a set of potentially colliding pairs of models, compute set of contact points
+ */
+class SOFA_CORE_API NarrowPhaseDetection : virtual public Detection
 {
 public:
     SOFA_ABSTRACT_CLASS(NarrowPhaseDetection, Detection);
@@ -53,76 +46,21 @@ protected:
     ~NarrowPhaseDetection() override { }
 public:
     /// Clear all the potentially colliding pairs detected in the previous simulation step
-    virtual void beginNarrowPhase()
-    {
-        for (DetectionOutputMap::iterator it = m_outputsMap.begin(); it != m_outputsMap.end(); it++)
-        {
-            DetectionOutputVector *do_vec = (it->second);
-
-            if (do_vec != nullptr)
-                do_vec->clear();
-        }
-    }
+    virtual void beginNarrowPhase();
 
     /// Add a new potentially colliding pairs of models
     virtual void addCollisionPair (const std::pair<core::CollisionModel*, core::CollisionModel*>& cmPair) = 0;
 
     /// Add a new list of potentially colliding pairs of models
-    virtual void addCollisionPairs(const sofa::helper::vector< std::pair<core::CollisionModel*, core::CollisionModel*> >& v)
-    {
-        for (sofa::helper::vector< std::pair<core::CollisionModel*, core::CollisionModel*> >::const_iterator it = v.begin(); it!=v.end(); it++)
-            addCollisionPair(*it);
+    virtual void addCollisionPairs(const sofa::helper::vector< std::pair<core::CollisionModel*, core::CollisionModel*> >& v);
 
-        // m_outputsMap should just be filled in addCollisionPair function
-        m_primitiveTestCount = m_outputsMap.size();
-    }
+    virtual void endNarrowPhase();
 
-    virtual void endNarrowPhase()
-    {
-        DetectionOutputMap::iterator it = m_outputsMap.begin();
-        
-        while (it != m_outputsMap.end())
-        {
-            DetectionOutputVector *do_vec = (it->second);
+    size_t getPrimitiveTestCount() const;
 
-            if (!do_vec || do_vec->empty())
-            {
-                /// @todo Optimization
-                DetectionOutputMap::iterator iterase = it;
-				++it;
-				m_outputsMap.erase(iterase);
-                if (do_vec) do_vec->release();
-            }
-            else
-            {
-                ++it;
-            }
-        }
-    }
+    const DetectionOutputMap& getDetectionOutputs() const;
 
-    //sofa::helper::vector<std::pair<core::CollisionElementIterator, core::CollisionElementIterator> >& getCollisionElementPairs() { return elemPairs; }
-
-    size_t getPrimitiveTestCount() const { return m_primitiveTestCount; }
-
-    const DetectionOutputMap& getDetectionOutputs() const
-    {
-        return m_outputsMap;
-    }
-
-    DetectionOutputVector*& getDetectionOutputs(CollisionModel *cm1, CollisionModel *cm2)
-    {
-        std::pair< CollisionModel*, CollisionModel* > cm_pair = std::make_pair(cm1, cm2);
-
-        DetectionOutputMap::iterator it = m_outputsMap.find(cm_pair);
-
-        if (it == m_outputsMap.end())
-        {
-            // new contact
-            it = m_outputsMap.insert( std::make_pair(cm_pair, static_cast< DetectionOutputVector * >(0)) ).first;
-        }
-
-        return it->second;
-    }
+    DetectionOutputVector*& getDetectionOutputs(CollisionModel *cm1, CollisionModel *cm2);
 
     //Returns true if the last narrow phase detected no collision, to use after endNarrowPhase.
     inline bool zeroCollision()const{
@@ -132,11 +70,7 @@ public:
 protected:
     bool _zeroCollision;//true if the last narrow phase detected no collision, to use after endNarrowPhase
 
-    void changeInstanceNP(Instance inst) override
-    {
-        m_storedOutputsMap[instance].swap(m_outputsMap);
-        m_outputsMap.swap(m_storedOutputsMap[inst]);
-    }
+    void changeInstanceNP(Instance inst) override;
 
 protected:
     std::map<Instance, DetectionOutputMap> m_storedOutputsMap;
@@ -146,10 +80,6 @@ protected:
 
     size_t m_primitiveTestCount; // used only for statistics purpose
 };
-
-} // namespace collision
-
-} // namespace core
 
 } // namespace sofa
 


### PR DESCRIPTION
`BroadPhaseDetection` and `NarrowPhaseDetection` classes did not have any source files. The class member functions were defined in the header file.
I created the associated cpp files and moved the definitions into them.
I also added the symbol exports.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
