### PR TITLE
[Sofa.GL] Remove warnings from deprecated headers

### DIFF
--- a/SofaKernel/modules/Sofa.GL/Sofa.GL_test/src/GLSLShader_test.cpp
+++ b/SofaKernel/modules/Sofa.GL/Sofa.GL_test/src/GLSLShader_test.cpp
@@ -92,11 +92,11 @@ TEST(GLSLShader_test, GLSLShader_SetFiles)
 TEST(GLSLShader_test, GLSLShader_SetStrings)
 {
     gl::GLSLShader glshader;
-    std::string vs = sofa::helper::gl::shader::testvs;
-    std::string fs = sofa::helper::gl::shader::testfs;
-    std::string gs = sofa::helper::gl::shader::testgs;
-    std::string tcs = sofa::helper::gl::shader::testtcs;
-    std::string tes = sofa::helper::gl::shader::testtes;
+    std::string vs = sofa::gl::shader::testvs;
+    std::string fs = sofa::gl::shader::testfs;
+    std::string gs = sofa::gl::shader::testgs;
+    std::string tcs = sofa::gl::shader::testtcs;
+    std::string tes = sofa::gl::shader::testtes;
     glshader.SetVertexShaderFromString(vs);
     glshader.SetFragmentShaderFromString(fs);
 #ifdef GL_GEOMETRY_SHADER_EXT

--- a/SofaKernel/modules/Sofa.GL/Sofa.GL_test/src/test.cppglsl
+++ b/SofaKernel/modules/Sofa.GL/Sofa.GL_test/src/test.cppglsl
@@ -1,9 +1,6 @@
 namespace sofa
 {
 
-namespace helper
-{
-
 namespace gl
 {
 
@@ -54,8 +51,6 @@ void main()
 
 } // shader
 
-} //gl
+} // gl
 
-} //helper
-
-} //sofa
+} // sofa

--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/InteractiveCamera.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/InteractiveCamera.cpp
@@ -251,7 +251,7 @@ void InteractiveCamera::processKeyPressedEvent(core::objectmodel::KeypressedEven
     {
         //glPushMatrix();
         //glLoadIdentity();
-        //helper::gl::Axis(p_position.getValue(), p_orientation.getValue(), 10.0);
+        //sofa::gl::Axis(p_position.getValue(), p_orientation.getValue(), 10.0);
         //glPopMatrix();
         break;
     }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/visual/VisualParams.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/visual/VisualParams.h
@@ -148,10 +148,10 @@ public:
     const helper::visual::Transformation& sceneTransform() const { return m_sceneTransform; }
 
     //[[deprecated("frameBufferObject in DrawTool is removed from VisualParam, use your rendering API instead.")]]
-    //helper::gl::FrameBufferObject*& frameBufferObject() { return m_boundFrameBuffer; }
+    //sofa::gl::FrameBufferObject*& frameBufferObject() { return m_boundFrameBuffer; }
 
     //[[deprecated("frameBufferObject in DrawTool is removed from VisualParam, use your rendering API instead.")]]
-    //helper::gl::FrameBufferObject*& frameBufferObject() const { return m_boundFrameBuffer; }
+    //sofa::gl::FrameBufferObject*& frameBufferObject() const { return m_boundFrameBuffer; }
 
     bool isSupported(unsigned int api) const
     {
@@ -176,7 +176,7 @@ protected:
     Pass                                m_pass;
     DisplayFlags                        m_displayFlags;
     mutable helper::visual::DrawTool*   m_drawTool;
-    //mutable helper::gl::FrameBufferObject*	m_boundFrameBuffer;
+    //mutable sofa::gl::FrameBufferObject*	m_boundFrameBuffer;
     /// Ids of position vector
     ConstMultiVecCoordId m_x;
     /// Ids of velocity vector

--- a/applications/plugins/CGALPlugin/src/CGALPlugin/CuboidMesh.h
+++ b/applications/plugins/CGALPlugin/src/CGALPlugin/CuboidMesh.h
@@ -26,7 +26,7 @@
 #include <sofa/core/DataEngine.h>
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
-#include <sofa/helper/gl/template.h>
+#include <sofa/gl/template.h>
 
 #include <math.h>
 #include   <algorithm>

--- a/applications/plugins/CGALPlugin/src/CGALPlugin/CuboidMesh.inl
+++ b/applications/plugins/CGALPlugin/src/CGALPlugin/CuboidMesh.inl
@@ -445,7 +445,7 @@ void CuboidMesh<DataTypes>::draw()
             //std::cout << "draw vertices" << std::endl;
             glColor3f(1.0, 0.0, 0.0);
             for(unsigned i = 0; i < m_nbVertices; ++i)
-                sofa::helper::gl::glVertexT(points[i]);
+                sofa::gl::glVertexT(points[i]);
         }
         if(debug & (1<<1))//2
         {
@@ -455,7 +455,7 @@ void CuboidMesh<DataTypes>::draw()
             unsigned begin = m_nbVertices;
             unsigned end = m_nbVertices + m_nbCenters;
             for(unsigned i = begin; i < end; ++i)
-                sofa::helper::gl::glVertexT(points[i]);
+                sofa::gl::glVertexT(points[i]);
         }
         if(debug & (1<<2))//4
         {
@@ -465,7 +465,7 @@ void CuboidMesh<DataTypes>::draw()
             unsigned begin = m_nbVertices + m_nbCenters;
             unsigned end = m_nbVertices + m_nbCenters + m_nbBdVertices;
             for(unsigned i = begin; i < end; ++i)
-                sofa::helper::gl::glVertexT(points[i]);
+                sofa::gl::glVertexT(points[i]);
         }
         if(debug & (1<<3))//8
         {
@@ -475,7 +475,7 @@ void CuboidMesh<DataTypes>::draw()
             unsigned begin = m_nbVertices + m_nbCenters + m_nbBdVertices;
             unsigned end = m_nbVertices + m_nbCenters + m_nbBdVertices + m_nbBdCenters;
             for(unsigned i = begin; i < end; ++i)
-                sofa::helper::gl::glVertexT(points[i]);
+                sofa::gl::glVertexT(points[i]);
         }
         glEnd();
         glPointSize(1);
@@ -498,8 +498,8 @@ void CuboidMesh<DataTypes>::draw()
                 {
                     for(int k = j+1; k < 4; ++k)
                     {
-                        sofa::helper::gl::glVertexT(points[tetras[i][j]]);
-                        sofa::helper::gl::glVertexT(points[tetras[i][k]]);
+                        sofa::gl::glVertexT(points[tetras[i][j]]);
+                        sofa::gl::glVertexT(points[tetras[i][k]]);
                     }
                 }
             }
@@ -512,8 +512,8 @@ void CuboidMesh<DataTypes>::draw()
                 {
                     for(int k = j+1; k < 4; ++k)
                     {
-                        sofa::helper::gl::glVertexT(points[tetras[i][j]]);
-                        sofa::helper::gl::glVertexT(points[tetras[i][k]]);
+                        sofa::gl::glVertexT(points[tetras[i][j]]);
+                        sofa::gl::glVertexT(points[tetras[i][k]]);
                     }
                 }
             }
@@ -526,8 +526,8 @@ void CuboidMesh<DataTypes>::draw()
                 {
                     for(int k = j+1; k < 4; ++k)
                     {
-                        sofa::helper::gl::glVertexT(points[tetras[i][j]]);
-                        sofa::helper::gl::glVertexT(points[tetras[i][k]]);
+                        sofa::gl::glVertexT(points[tetras[i][j]]);
+                        sofa::gl::glVertexT(points[tetras[i][k]]);
                     }
                 }
             }

--- a/applications/plugins/CGALPlugin/src/CGALPlugin/CylinderMesh.inl
+++ b/applications/plugins/CGALPlugin/src/CGALPlugin/CylinderMesh.inl
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <CGALPlugin/CylinderMesh.h>
-#include <sofa/helper/gl/template.h>
+#include <sofa/gl/template.h>
 #include <sofa/core/visual/VisualParams.h>
 
 #define MAX(a,b) ( (a)>(b) ? (a):(b))

--- a/applications/plugins/Flexible/deformationMapping/BaseDeformationMapping.inl
+++ b/applications/plugins/Flexible/deformationMapping/BaseDeformationMapping.inl
@@ -26,8 +26,7 @@
 #include "BaseDeformationImpl.inl"
 #include <SofaBaseVisual/VisualModelImpl.h>
 #include <sofa/core/MechanicalParams.h>
-#include <sofa/helper/gl/Color.h>
-#include <sofa/helper/system/glu.h>
+#include <sofa/gl/Color.h>
 #include <sofa/helper/IndexOpenMP.h>
 
 #ifdef _OPENMP
@@ -736,7 +735,7 @@ void BaseDeformationMappingT<JacobianBlockType>::draw(const core::visual::Visual
                 if(w[i][j])
                 {
                     In::get(edge[0][0],edge[0][1],edge[0][2],in[ref[i][j]]);
-                    sofa::helper::gl::Color::getHSVA(&col[0],240.f*(float)w[i][j],1.f,.8f,1.f);
+                    sofa::gl::Color::getHSVA(&col[0],240.f*(float)w[i][j],1.f,.8f,1.f);
                     vparams->drawTool()->drawLines ( edge, 1, col );
                 }
         }

--- a/applications/plugins/Flexible/deformationMapping/BaseDeformationMultiMapping.inl
+++ b/applications/plugins/Flexible/deformationMapping/BaseDeformationMultiMapping.inl
@@ -25,7 +25,7 @@
 #include "BaseDeformationMultiMapping.h"
 #include "BaseDeformationImpl.inl"
 #include "../quadrature/BaseGaussPointSampler.h"
-#include <sofa/helper/gl/Color.h>
+#include <sofa/gl/Color.h>
 #include <sofa/helper/system/glu.h>
 #include <sofa/helper/IndexOpenMP.h>
 
@@ -702,7 +702,7 @@ void BaseDeformationMultiMappingT<JacobianBlockType1,JacobianBlockType2>::draw(c
                 {
                     if(j<size1) In1::get(edge[0][0],edge[0][1],edge[0][2],in1[ref[i][j]]);
                     else In2::get(edge[0][0],edge[0][1],edge[0][2],in2[ref[i][j]-size1]);
-                    sofa::helper::gl::Color::getHSVA(&col[0],240.*w[i][j],1.,.8,1.);
+                    sofa::gl::Color::getHSVA(&col[0],240.*w[i][j],1.,.8,1.);
                     vparams->drawTool()->drawLines ( edge, 1, col );
                 }
         }

--- a/applications/plugins/Flexible/mass/ImageDensityMass.inl
+++ b/applications/plugins/Flexible/mass/ImageDensityMass.inl
@@ -9,7 +9,7 @@
 #include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/defaulttype/DataTypeInfo.h>
-#include <sofa/helper/gl/template.h>
+#include <sofa/gl/template.h>
 
 namespace sofa
 {

--- a/applications/plugins/Flexible/types/ComponentSpecializations.cpp.inl
+++ b/applications/plugins/Flexible/types/ComponentSpecializations.cpp.inl
@@ -186,7 +186,7 @@ template class SOFA_Flexible_API ProjectToPointConstraint<TYPEABSTRACTNAME3dType
 
 
 
-#include <sofa/helper/gl/Axis.h>
+#include <sofa/gl/Axis.h>
 namespace sofa
 {
 namespace component

--- a/applications/plugins/LeapMotion/src/LeapMotionDriver.h
+++ b/applications/plugins/LeapMotion/src/LeapMotionDriver.h
@@ -29,8 +29,8 @@
 #include <sofa/helper/system/thread/CTime.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/helper/system/gl.h>
-#include <sofa/helper/gl/BasicShapes.h>
-#include <sofa/helper/gl/glText.inl>
+#include <sofa/gl/BasicShapes.h>
+#include <sofa/gl/glText.inl>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/simulation/AnimateBeginEvent.h>
 #include <sofa/simulation/AnimateEndEvent.h>

--- a/applications/plugins/PersistentContact/PersistentFrictionContact.inl
+++ b/applications/plugins/PersistentContact/PersistentFrictionContact.inl
@@ -27,7 +27,7 @@
 
 #include <SofaConstraint/FrictionContact.inl>
 
-#include <sofa/helper/gl/template.h>
+#include <sofa/gl/template.h>
 
 
 namespace sofa

--- a/applications/plugins/Registration/ClosestPointRegistrationForceField.inl
+++ b/applications/plugins/Registration/ClosestPointRegistrationForceField.inl
@@ -40,7 +40,7 @@
 #include <limits>
 #include <set>
 #include <iterator>
-#include <sofa/helper/gl/Color.h>
+#include <sofa/gl/Color.h>
 
 using std::cerr;
 using std::endl;
@@ -426,7 +426,7 @@ void ClosestPointRegistrationForceField<DataTypes>::draw(const core::visual::Vis
                 for ( unsigned int j = 0; j < 3; j++)
                 {
                     const unsigned int& indexP = t[i][j];
-                    sofa::helper::gl::Color::setHSVA(dists[indexP]*240./max,1.,.8,1.);
+                    sofa::gl::Color::setHSVA(dists[indexP]*240./max,1.,.8,1.);
                     glVertex3d(x[indexP][0],x[indexP][1],x[indexP][2]);
                 }
             }
@@ -439,7 +439,7 @@ void ClosestPointRegistrationForceField<DataTypes>::draw(const core::visual::Vis
             glBegin( GL_POINTS);
             for (unsigned int i=0; i<dists.size(); i++)
             {
-                sofa::helper::gl::Color::setHSVA(dists[i]*240./max,1.,.8,1.);
+                sofa::gl::Color::setHSVA(dists[i]*240./max,1.,.8,1.);
                 glVertex3d(x[i][0],x[i][1],x[i][2]);
             }
             glEnd();

--- a/applications/plugins/Registration/RegistrationContactForceField.inl
+++ b/applications/plugins/Registration/RegistrationContactForceField.inl
@@ -25,7 +25,7 @@
 #include "RegistrationContactForceField.h"
 //#include <sofa/core/ForceField.inl>
 #include <cassert>
-#include <sofa/helper/gl/template.h>
+#include <sofa/gl/template.h>
 #include <iostream>
 #include <sofa/core/visual/VisualParams.h>
 

--- a/applications/plugins/SixenseHydra/RazerHydraDriver.h
+++ b/applications/plugins/SixenseHydra/RazerHydraDriver.h
@@ -42,8 +42,8 @@
 #include <sofa/core/ObjectFactory.h>
 
 #include <sofa/helper/system/gl.h>
-#include <sofa/helper/gl/BasicShapes.h>
-#include <sofa/helper/gl/glText.inl>
+#include <sofa/gl/BasicShapes.h>
+#include <sofa/gl/glText.inl>
 
 #include <deque>
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaDistanceGridCollisionModel.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaDistanceGridCollisionModel.cpp
@@ -23,7 +23,7 @@
 #include "CudaDistanceGridCollisionModel.h"
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/visual/VisualParams.h>
-#include <sofa/helper/gl/template.h>
+#include <sofa/gl/template.h>
 #include <sofa/helper/rmath.h>
 #include <SofaBaseCollision/CubeModel.h>
 #if SOFACUDA_HAVE_MINIFLOWVR
@@ -686,7 +686,7 @@ void CudaRigidDistanceGridCollisionModel::draw(const core::visual::VisualParams*
         m = elems[index].rotation;
         m.transpose();
         m[3] = Vector4(elems[index].translation,1.0);
-        helper::gl::glMultMatrix(m.ptr());
+        sofa::gl::glMultMatrix(m.ptr());
     }
 
     CudaDistanceGrid* grid = getGrid(index);

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaFixedTranslationConstraint.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaFixedTranslationConstraint.cpp
@@ -27,7 +27,7 @@
 
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/core/ObjectFactory.h>
-#include <sofa/helper/gl/template.h>
+#include <sofa/gl/template.h>
 
 namespace sofa
 {
@@ -62,14 +62,14 @@ void component::projectiveconstraintset::FixedTranslationConstraint<gpu::cuda::C
     {
         for (unsigned i = 0; i < x.size(); i++)
         {
-            helper::gl::glVertexT(defaulttype::Vec<3,float>(x[i][0], x[i][1], x[i][2]));
+            sofa::gl::glVertexT(defaulttype::Vec<3,float>(x[i][0], x[i][1], x[i][2]));
         }
     }
     else
     {
         for (SetIndex::const_iterator it = indices.begin(); it != indices.end(); ++it)
         {
-            helper::gl::glVertexT(defaulttype::Vec<3,float>(x[*it][0], x[*it][1], x[*it][2]));
+            sofa::gl::glVertexT(defaulttype::Vec<3,float>(x[*it][0], x[*it][1], x[*it][2]));
         }
     }
     glEnd();
@@ -92,14 +92,14 @@ void component::projectiveconstraintset::FixedTranslationConstraint<gpu::cuda::C
     {
         for (unsigned i = 0; i < x.size(); i++)
         {
-            helper::gl::glVertexT(defaulttype::Vec<3,float>(x[i][0], x[i][1], x[i][2]));
+            sofa::gl::glVertexT(defaulttype::Vec<3,float>(x[i][0], x[i][1], x[i][2]));
         }
     }
     else
     {
         for (SetIndex::const_iterator it = indices.begin(); it != indices.end(); ++it)
         {
-            helper::gl::glVertexT(defaulttype::Vec<3,float>(x[*it][0], x[*it][1], x[*it][2]));
+            sofa::gl::glVertexT(defaulttype::Vec<3,float>(x[*it][0], x[*it][1], x[*it][2]));
         }
     }
     glEnd();

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPenalityContactForceField.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPenalityContactForceField.inl
@@ -24,7 +24,7 @@
 
 #include "CudaPenalityContactForceField.h"
 #include <SofaObjectInteraction/PenalityContactForceField.inl>
-#include <sofa/helper/gl/template.h>
+#include <sofa/gl/template.h>
 
 namespace sofa
 {
@@ -241,8 +241,8 @@ void PenalityContactForceField<CudaVec3fTypes>::draw(const core::visual::VisualP
             glColor4f(1,0,0,1);
         else
             glColor4f(0,1,0,1);
-        helper::gl::glVertexT(p1[i]); //c.m1]);
-        helper::gl::glVertexT(p2[i]); //c.m2]);
+        sofa::gl::glVertexT(p1[i]); //c.m1]);
+        sofa::gl::glVertexT(p2[i]); //c.m2]);
     }
     glEnd();
 
@@ -255,11 +255,11 @@ void PenalityContactForceField<CudaVec3fTypes>::draw(const core::visual::VisualP
             sofa::defaulttype::Vec4f c = contacts[i];
             Coord norm(c[0],c[1],c[2]); norm.normalize();
             Coord p = p1[i] - norm*0.1;
-            helper::gl::glVertexT(p1[i]);
-            helper::gl::glVertexT(p);
+            sofa::gl::glVertexT(p1[i]);
+            sofa::gl::glVertexT(p);
             p = p2[i] + norm*0.1;
-            helper::gl::glVertexT(p2[i]);
-            helper::gl::glVertexT(p);
+            sofa::gl::glVertexT(p2[i]);
+            sofa::gl::glVertexT(p);
         }
         glEnd();
     }

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSPHFluidForceField.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSPHFluidForceField.inl
@@ -24,7 +24,7 @@
 
 #include "CudaSPHFluidForceField.h"
 #include <SofaSphFluid/SPHFluidForceField.inl>
-#include <sofa/helper/gl/template.h>
+#include <sofa/gl/template.h>
 #include <sofa/core/MechanicalParams.h>
 
 namespace sofa
@@ -262,7 +262,7 @@ void SPHFluidForceField<gpu::cuda::CudaVec3fTypes>::draw(const core::visual::Vis
         {
             glColor3f(f-1,0,2-f);
         }
-        helper::gl::glVertexT(x[i]);
+        sofa::gl::glVertexT(x[i]);
     }
     glEnd();
     glPointSize(1);

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSpatialGridContainer.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSpatialGridContainer.inl
@@ -37,7 +37,7 @@
 #include <sofa/gpu/cuda/CudaSpatialGridContainer.h>
 #include <sofa/gpu/cuda/CudaSort.h>
 #include <SofaSphFluid/SpatialGridContainer.inl>
-#include <sofa/helper/gl/template.h>
+#include <sofa/gl/template.h>
 
 namespace sofa
 {
@@ -327,7 +327,7 @@ void SpatialGrid< SpatialGridTypes < gpu::cuda::CudaVectorTypes<TCoord,TDeriv,TR
         int b = (cell>>4)&3;
         glColor4ub(63+r*64,63+g*64,63+b*64,255);
         //glVertex3fv(sortedPos[i].ptr());
-        helper::gl::glVertexT((*lastX)[p]);
+        sofa::gl::glVertexT((*lastX)[p]);
     }
     glEnd();
     glPointSize(1);

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedralVisualModel.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedralVisualModel.inl
@@ -24,7 +24,7 @@
 
 #include "CudaTetrahedralVisualModel.h"
 
-#include <sofa/helper/gl/GLSLShader.h>
+#include <sofa/gl/GLSLShader.h>
 
 namespace sofa
 {

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaUniformMass.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaUniformMass.inl
@@ -24,7 +24,7 @@
 
 #include "CudaUniformMass.h"
 #include <SofaBaseMechanics/UniformMass.inl>
-#include <sofa/helper/gl/Axis.h>
+#include <sofa/gl/Axis.h>
 
 namespace sofa
 {
@@ -241,7 +241,7 @@ void UniformMass<gpu::cuda::CudaRigid3fTypes, defaulttype::RigidMass<3,float> >:
 
     for (unsigned int i=0; i<x.size(); i++)
     {
-        helper::gl::Axis::draw(x[i].getCenter(), x[i].getOrientation(), len);
+        sofa::gl::Axis::draw(x[i].getCenter(), x[i].getOrientation(), len);
     }
 #endif // SOFACUDA_HAVE_SOFA_GL == 1
 }
@@ -409,7 +409,7 @@ void UniformMass<gpu::cuda::CudaRigid3dTypes, sofa::defaulttype::RigidMass<3,dou
 
     for (unsigned int i=0; i<x.size(); i++)
     {
-        helper::gl::Axis::draw(x[i].getCenter(), x[i].getOrientation(), len);
+        sofa::gl::Axis::draw(x[i].getCenter(), x[i].getOrientation(), len);
     }
 }
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaVisualModel.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaVisualModel.inl
@@ -24,7 +24,7 @@
 
 #include "CudaVisualModel.h"
 #include <sofa/core/visual/VisualParams.h>
-#include <sofa/helper/gl/template.h>
+#include <sofa/gl/template.h>
 
 namespace sofa
 {
@@ -436,9 +436,9 @@ void CudaVisualModel< TDataTypes >::internalDraw(const core::visual::VisualParam
         for (unsigned int i = 0; i < x.size(); i++)
         {
             glBegin(GL_LINES);
-            helper::gl::glVertexT(x[i]);
+            sofa::gl::glVertexT(x[i]);
             Coord p = x[i] + vnormals[i]*0.01;
-            helper::gl::glVertexT(p);
+            sofa::gl::glVertexT(p);
             glEnd();
         }
     }

--- a/applications/plugins/SofaEulerianFluid/Fluid2D.cpp
+++ b/applications/plugins/SofaEulerianFluid/Fluid2D.cpp
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #include <SofaEulerianFluid/Fluid2D.h>
 #include <sofa/core/visual/VisualParams.h>
-#include <sofa/helper/gl/template.h>
+#include <sofa/gl/template.h>
 #include <sofa/core/ObjectFactory.h>
 #include <iostream>
 #include <cstring>

--- a/applications/plugins/SofaEulerianFluid/Fluid3D.cpp
+++ b/applications/plugins/SofaEulerianFluid/Fluid3D.cpp
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #include <SofaEulerianFluid/Fluid3D.h>
 #include <sofa/core/visual/VisualParams.h>
-#include <sofa/helper/gl/template.h>
+#include <sofa/gl/template.h>
 #include <sofa/core/ObjectFactory.h>
 #include <iostream>
 #include <cstring>

--- a/applications/plugins/SofaOpenCL/OpenCLSpatialGridContainer.inl
+++ b/applications/plugins/SofaOpenCL/OpenCLSpatialGridContainer.inl
@@ -36,7 +36,7 @@
 
 #include "OpenCLSpatialGridContainer.h"
 #include <SofaSphFluid/SpatialGridContainer.inl>
-#include <sofa/helper/gl/template.h>
+#include <sofa/gl/template.h>
 
 
 

--- a/applications/plugins/SofaOpenCL/OpenCLUniformMass.inl
+++ b/applications/plugins/SofaOpenCL/OpenCLUniformMass.inl
@@ -24,7 +24,7 @@
 
 #include "OpenCLUniformMass.h"
 #include <SofaBaseMechanics/UniformMass.inl>
-#include <sofa/helper/gl/Axis.h>
+#include <sofa/gl/Axis.h>
 
 namespace sofa
 {

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/OglFluidModel.h
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/OglFluidModel.h
@@ -3,8 +3,8 @@
 #include <SofaSphFluid/config.h>
 
 #include <sofa/core/visual/VisualModel.h>
-#include <sofa/helper/gl/FrameBufferObject.h>
-#include <sofa/helper/gl/GLSLShader.h>
+#include <sofa/gl/FrameBufferObject.h>
+#include <sofa/gl/GLSLShader.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/helper/types/RGBAColor.h>
 
@@ -38,21 +38,21 @@ private:
 	VecCoord m_previousPositions;
 
     GLuint m_posVBO;
-    helper::gl::FrameBufferObject* m_spriteDepthFBO;
-    helper::gl::FrameBufferObject* m_spriteThicknessFBO;
-    helper::gl::FrameBufferObject* m_spriteNormalFBO;
-    helper::gl::FrameBufferObject* m_spriteBlurDepthHFBO;
-    helper::gl::FrameBufferObject* m_spriteBlurDepthVFBO;
-    helper::gl::FrameBufferObject* m_spriteBlurThicknessHFBO;
-    helper::gl::FrameBufferObject* m_spriteBlurThicknessVFBO;
-    helper::gl::FrameBufferObject* m_spriteShadeFBO;
+    sofa::gl::FrameBufferObject* m_spriteDepthFBO;
+    sofa::gl::FrameBufferObject* m_spriteThicknessFBO;
+    sofa::gl::FrameBufferObject* m_spriteNormalFBO;
+    sofa::gl::FrameBufferObject* m_spriteBlurDepthHFBO;
+    sofa::gl::FrameBufferObject* m_spriteBlurDepthVFBO;
+    sofa::gl::FrameBufferObject* m_spriteBlurThicknessHFBO;
+    sofa::gl::FrameBufferObject* m_spriteBlurThicknessVFBO;
+    sofa::gl::FrameBufferObject* m_spriteShadeFBO;
 
-    helper::gl::GLSLShader m_spriteShader;
-    helper::gl::GLSLShader m_spriteNormalShader;
-    helper::gl::GLSLShader m_spriteBlurDepthShader;
-    helper::gl::GLSLShader m_spriteBlurThicknessShader;
-    helper::gl::GLSLShader m_spriteShadeShader;
-    helper::gl::GLSLShader m_spriteFinalPassShader;
+    sofa::gl::GLSLShader m_spriteShader;
+    sofa::gl::GLSLShader m_spriteNormalShader;
+    sofa::gl::GLSLShader m_spriteBlurDepthShader;
+    sofa::gl::GLSLShader m_spriteBlurThicknessShader;
+    sofa::gl::GLSLShader m_spriteShadeShader;
+    sofa::gl::GLSLShader m_spriteFinalPassShader;
 
     void drawSprites(const core::visual::VisualParams* vparams);
     void updateVertexBuffer();

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/OglFluidModel.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/OglFluidModel.inl
@@ -49,14 +49,14 @@ void OglFluidModel<DataTypes>::init()
 template<class DataTypes>
 void OglFluidModel<DataTypes>::initVisual()
 {
-    m_spriteDepthFBO = new helper::gl::FrameBufferObject(true, true, true);
-    m_spriteThicknessFBO = new helper::gl::FrameBufferObject(true, true, true);
-    m_spriteNormalFBO = new helper::gl::FrameBufferObject(true, true, true);
-    m_spriteBlurDepthHFBO = new helper::gl::FrameBufferObject(true, true, true);
-    m_spriteBlurDepthVFBO = new helper::gl::FrameBufferObject(true, true, true);
-    m_spriteBlurThicknessHFBO = new helper::gl::FrameBufferObject(true, true, true);
-    m_spriteBlurThicknessVFBO = new helper::gl::FrameBufferObject(true, true, true);
-    m_spriteShadeFBO = new helper::gl::FrameBufferObject(true, true, true);
+    m_spriteDepthFBO = new sofa::gl::FrameBufferObject(true, true, true);
+    m_spriteThicknessFBO = new sofa::gl::FrameBufferObject(true, true, true);
+    m_spriteNormalFBO = new sofa::gl::FrameBufferObject(true, true, true);
+    m_spriteBlurDepthHFBO = new sofa::gl::FrameBufferObject(true, true, true);
+    m_spriteBlurDepthVFBO = new sofa::gl::FrameBufferObject(true, true, true);
+    m_spriteBlurThicknessHFBO = new sofa::gl::FrameBufferObject(true, true, true);
+    m_spriteBlurThicknessVFBO = new sofa::gl::FrameBufferObject(true, true, true);
+    m_spriteShadeFBO = new sofa::gl::FrameBufferObject(true, true, true);
 
     const VecCoord& vertices = m_positions.getValue();
 
@@ -74,7 +74,7 @@ void OglFluidModel<DataTypes>::initVisual()
     m_spriteBlurThicknessVFBO->init(width, height);
     m_spriteShadeFBO->init(width, height);
 
-    if (!sofa::helper::gl::GLSLShader::InitGLSL())
+    if (!sofa::gl::GLSLShader::InitGLSL())
     {
         msg_error() << "InitGLSL failed, check your GPU setup (driver, etc)";
         return;

--- a/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglTetrahedralModel.inl
+++ b/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglTetrahedralModel.inl
@@ -25,7 +25,7 @@
 #include "OglTetrahedralModel.h"
 
 #include <sstream>
-#include <sofa/helper/gl/GLSLShader.h>
+#include <sofa/gl/GLSLShader.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/defaulttype/BoundingBox.h>
 #include <SofaBaseTopology/TetrahedronSetTopologyContainer.h>

--- a/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglVolumetricModel.cpp
+++ b/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglVolumetricModel.cpp
@@ -27,7 +27,7 @@
 #include <limits>
 
 #include <sofa/core/ObjectFactory.h>
-#include <sofa/helper/gl/GLSLShader.h>
+#include <sofa/gl/GLSLShader.h>
 #include <SofaBaseTopology/TetrahedronSetTopologyContainer.h>
 #include <sofa/defaulttype/BoundingBox.h>
 #include <SofaOpenglVisual/OglAttribute.inl>

--- a/applications/projects/SofaGuiGlut/SimpleGUI.cpp
+++ b/applications/projects/SofaGuiGlut/SimpleGUI.cpp
@@ -33,7 +33,7 @@
 #include <cstring>
 #include <cmath>
 
-#include <sofa/helper/gl/RAII.h>
+#include <sofa/gl/RAII.h>
 
 #include <sofa/helper/system/thread/CTime.h>
 #include <thread>
@@ -65,7 +65,7 @@ namespace glut
 using std::cout;
 using std::endl;
 using namespace sofa::defaulttype;
-using namespace sofa::helper::gl;
+using namespace sofa::gl;
 using sofa::simulation::getSimulation;
 
 SimpleGUI* SimpleGUI::instance = nullptr;
@@ -398,7 +398,7 @@ void SimpleGUI::initializeGL(void)
                 msg_error("SimpleGUI") << "Could not open sofa logo, " << filename ;
                 return;
             }
-            texLogo = new helper::gl::Texture(img);
+            texLogo = new sofa::gl::Texture(img);
             texLogo->init();
         }
 

--- a/applications/projects/SofaGuiGlut/SimpleGUI.h
+++ b/applications/projects/SofaGuiGlut/SimpleGUI.h
@@ -30,8 +30,8 @@
 
 #include <sofa/defaulttype/Vec.h>
 #include <sofa/defaulttype/Quat.h>
-#include <sofa/helper/gl/Texture.h>
-#include <sofa/helper/gl/Capture.h>
+#include <sofa/gl/Texture.h>
+#include <sofa/gl/Capture.h>
 #include <sofa/helper/system/thread/CTime.h>
 #include <sofa/helper/system/gl.h>
 #include <sofa/helper/system/glu.h>
@@ -54,7 +54,7 @@ namespace glut
 {
 
 using namespace sofa::defaulttype;
-using namespace sofa::helper::gl;
+using namespace sofa::gl;
 using namespace sofa::helper::system::thread;
 using namespace sofa::component::collision;
 

--- a/applications/projects/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
+++ b/applications/projects/SofaPhysicsAPI/SofaPhysicsSimulation.cpp
@@ -25,7 +25,7 @@
 #include <sofa/helper/system/gl.h>
 #include <sofa/helper/system/glu.h>
 #include <sofa/helper/io/Image.h>
-#include <sofa/helper/gl/RAII.h>
+#include <sofa/gl/RAII.h>
 
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/system/SetDirectory.h>
@@ -217,7 +217,7 @@ SofaPhysicsDataController** SofaPhysicsAPI::getDataControllers()
 ////////////////////////////////////////
 
 using namespace sofa::defaulttype;
-using namespace sofa::helper::gl;
+using namespace sofa::gl;
 using namespace sofa::core::objectmodel;
 
 static sofa::core::ObjectFactory::ClassEntry::SPtr classVisualModel;
@@ -692,7 +692,7 @@ void SofaPhysicsSimulation::drawGL()
             }
 
             sofa::helper::io::Image* image = sofa::helper::io::Image::FactoryImage::getInstance()->createObject("bmp", sofa::helper::system::DataRepository.getFile(imageFileName));
-            texLogo = new sofa::helper::gl::Texture(image);
+            texLogo = new sofa::gl::Texture(image);
             texLogo->init();
         }
         

--- a/applications/projects/SofaPhysicsAPI/SofaPhysicsSimulation.h
+++ b/applications/projects/SofaPhysicsAPI/SofaPhysicsSimulation.h
@@ -32,7 +32,7 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/visual/DrawToolGL.h>
 #include <SofaBaseVisual/InteractiveCamera.h>
-#include <sofa/helper/gl/Texture.h>
+#include <sofa/gl/Texture.h>
 #include <sofa/simulation/Node.h>
 
 #include <map>
@@ -101,7 +101,7 @@ protected:
     std::vector<SofaDataController*> sofaDataControllers;
     std::vector<SofaPhysicsDataController*> dataControllers;
 
-    sofa::helper::gl::Texture *texLogo;
+    sofa::gl::Texture *texLogo;
     double lastProjectionMatrix[16];
     double lastModelviewMatrix[16];
     GLint lastW, lastH;

--- a/modules/SofaGeneralVisual/src/SofaGeneralVisual/RecordedCamera.h
+++ b/modules/SofaGeneralVisual/src/SofaGeneralVisual/RecordedCamera.h
@@ -23,7 +23,7 @@
 #include <SofaGeneralVisual/config.h>
 
 #include <SofaBaseVisual/BaseCamera.h>
-#include <sofa/helper/gl/Trackball.h>
+#include <sofa/helper/visual/Trackball.h>
 #include <sofa/core/objectmodel/MouseEvent.h>
 
 namespace sofa::component::visualmodel
@@ -58,7 +58,7 @@ private:
     int currentMode;
     bool isMoving;
     int lastMousePosX, lastMousePosY;
-    helper::gl::Trackball currentTrackball;
+    sofa::helper::visual::Trackball currentTrackball;
 
     void moveCamera_rotation();
     void moveCamera_translation();

--- a/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
+++ b/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
@@ -47,8 +47,8 @@
 #include <sofa/helper/io/Image.h>
 #include <sofa/helper/system/SetDirectory.h>
 
-#include <sofa/helper/gl/VideoRecorderFFMPEG.h>
-#include <sofa/helper/gl/Capture.h>
+#include <sofa/gl/VideoRecorderFFMPEG.h>
+#include <sofa/gl/Capture.h>
 
 namespace sofa
 {
@@ -113,7 +113,7 @@ private:
     std::string sceneFileName;
     sofa::component::visualmodel::BaseCamera::SPtr currentCamera;
 
-    sofa::helper::gl::VideoRecorderFFMPEG m_videorecorder;
+    sofa::gl::VideoRecorderFFMPEG m_videorecorder;
     int m_nFrames;
 
     GLuint fbo;
@@ -122,7 +122,7 @@ private:
     double lastModelviewMatrix[16];
     bool initTexturesDone;
     bool initVideoRecorder;
-    sofa::helper::gl::Capture m_screencapture;
+    sofa::gl::Capture m_screencapture;
 
     static GLsizei width, height;
     static unsigned int fps;

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/ClipPlane.h
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/ClipPlane.h
@@ -25,7 +25,7 @@
 
 #include <sofa/core/visual/VisualModel.h>
 #include <sofa/defaulttype/VecTypes.h>
-#include <sofa/helper/gl/template.h>
+#include <sofa/gl/template.h>
 
 namespace sofa
 {

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/DataDisplay.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/DataDisplay.cpp
@@ -303,15 +303,15 @@ void DataDisplay::drawVisual(const core::visual::VisualParams* vparams)
 
                 glNormal3fv(m_normals[t[0]].ptr());
                 glMaterialfv(GL_FRONT,GL_DIFFUSE,color0.data());
-                helper::gl::glVertexNv<3>(x[t[0]].ptr());
+                sofa::gl::glVertexNv<3>(x[t[0]].ptr());
 
                 glNormal3fv(m_normals[t[1]].ptr());
                 glMaterialfv(GL_FRONT,GL_DIFFUSE,color1.data());
-                helper::gl::glVertexNv<3>(x[t[1]].ptr());
+                sofa::gl::glVertexNv<3>(x[t[1]].ptr());
 
                 glNormal3fv(m_normals[t[2]].ptr());
                 glMaterialfv(GL_FRONT,GL_DIFFUSE,color2.data());
-                helper::gl::glVertexNv<3>(x[t[2]].ptr());
+                sofa::gl::glVertexNv<3>(x[t[2]].ptr());
 
             }
             glEnd();
@@ -360,19 +360,19 @@ void DataDisplay::drawVisual(const core::visual::VisualParams* vparams)
 
                 glNormal3fv(m_normals[q[0]].ptr());
                 glMaterialfv(GL_FRONT,GL_DIFFUSE,color0.data());
-                helper::gl::glVertexNv<3>(x[q[0]].ptr());
+                sofa::gl::glVertexNv<3>(x[q[0]].ptr());
 
                 glNormal3fv(m_normals[q[1]].ptr());
                 glMaterialfv(GL_FRONT,GL_DIFFUSE,color1.data());
-                helper::gl::glVertexNv<3>(x[q[1]].ptr());
+                sofa::gl::glVertexNv<3>(x[q[1]].ptr());
 
                 glNormal3fv(m_normals[q[2]].ptr());
                 glMaterialfv(GL_FRONT,GL_DIFFUSE,color2.data());
-                helper::gl::glVertexNv<3>(x[q[2]].ptr());
+                sofa::gl::glVertexNv<3>(x[q[2]].ptr());
 
                 glNormal3fv(m_normals[q[3]].ptr());
                 glMaterialfv(GL_FRONT,GL_DIFFUSE,color3.data());
-                helper::gl::glVertexNv<3>(x[q[3]].ptr());
+                sofa::gl::glVertexNv<3>(x[q[3]].ptr());
 
             }
             glEnd();
@@ -410,15 +410,15 @@ void DataDisplay::drawVisual(const core::visual::VisualParams* vparams)
             }
             glNormal3fv(m_normals[t[0]].ptr());
             glMaterialfv(GL_FRONT,GL_DIFFUSE,color[0].data());
-            helper::gl::glVertexNv<3>(x[t[0]].ptr());
+            sofa::gl::glVertexNv<3>(x[t[0]].ptr());
 
             glNormal3fv(m_normals[t[1]].ptr());
             glMaterialfv(GL_FRONT,GL_DIFFUSE,color[1].data());
-            helper::gl::glVertexNv<3>(x[t[1]].ptr());
+            sofa::gl::glVertexNv<3>(x[t[1]].ptr());
 
             glNormal3fv(m_normals[t[2]].ptr());
             glMaterialfv(GL_FRONT,GL_DIFFUSE,color[2].data());
-            helper::gl::glVertexNv<3>(x[t[2]].ptr());
+            sofa::gl::glVertexNv<3>(x[t[2]].ptr());
 
         }
         glEnd();
@@ -439,19 +439,19 @@ void DataDisplay::drawVisual(const core::visual::VisualParams* vparams)
 
             glNormal3fv(m_normals[q[0]].ptr());
             glMaterialfv(GL_FRONT,GL_DIFFUSE,color[0].data());
-            helper::gl::glVertexNv<3>(x[q[0]].ptr());
+            sofa::gl::glVertexNv<3>(x[q[0]].ptr());
 
             glNormal3fv(m_normals[q[1]].ptr());
             glMaterialfv(GL_FRONT,GL_DIFFUSE,color[1].data());
-            helper::gl::glVertexNv<3>(x[q[1]].ptr());
+            sofa::gl::glVertexNv<3>(x[q[1]].ptr());
 
             glNormal3fv(m_normals[q[2]].ptr());
             glMaterialfv(GL_FRONT,GL_DIFFUSE,color[2].data());
-            helper::gl::glVertexNv<3>(x[q[2]].ptr());
+            sofa::gl::glVertexNv<3>(x[q[2]].ptr());
 
             glNormal3fv(m_normals[q[3]].ptr());
             glMaterialfv(GL_FRONT,GL_DIFFUSE,color[3].data());
-            helper::gl::glVertexNv<3>(x[q[3]].ptr());
+            sofa::gl::glVertexNv<3>(x[q[3]].ptr());
 
         }
         glEnd();

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/Light.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/Light.cpp
@@ -196,12 +196,12 @@ void Light::initVisual()
     computeShadowMapSize();
     //Shadow part
     //Shadow texture init
-    m_shadowFBO = std::unique_ptr<helper::gl::FrameBufferObject>(
-                new helper::gl::FrameBufferObject(true, true, true));
-    m_blurHFBO = std::unique_ptr<helper::gl::FrameBufferObject>(
-                new helper::gl::FrameBufferObject(false,false,true));
-    m_blurVFBO = std::unique_ptr<helper::gl::FrameBufferObject>(
-                new helper::gl::FrameBufferObject(false,false,true));
+    m_shadowFBO = std::unique_ptr<sofa::gl::FrameBufferObject>(
+                new sofa::gl::FrameBufferObject(true, true, true));
+    m_blurHFBO = std::unique_ptr<sofa::gl::FrameBufferObject>(
+                new sofa::gl::FrameBufferObject(false,false,true));
+    m_blurVFBO = std::unique_ptr<sofa::gl::FrameBufferObject>(
+                new sofa::gl::FrameBufferObject(false,false,true));
     m_depthShader = sofa::core::objectmodel::New<OglShader>();
     m_blurShader = sofa::core::objectmodel::New<OglShader>();
 

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/Light.h
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/Light.h
@@ -27,10 +27,10 @@
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/helper/types/RGBAColor.h>
-#include <sofa/helper/gl/template.h>
+#include <sofa/gl/template.h>
 #include <sofa/core/visual/VisualModel.h>
 
-#include <sofa/helper/gl/FrameBufferObject.h>
+#include <sofa/gl/FrameBufferObject.h>
 #include <SofaOpenglVisual/OglShader.h>
 
 namespace sofa
@@ -63,9 +63,9 @@ protected:
     GLint m_lightID;
     GLuint m_shadowTexWidth, m_shadowTexHeight;
 
-    std::unique_ptr<helper::gl::FrameBufferObject> m_shadowFBO;
-    std::unique_ptr<helper::gl::FrameBufferObject> m_blurHFBO;
-    std::unique_ptr<helper::gl::FrameBufferObject> m_blurVFBO;
+    std::unique_ptr<sofa::gl::FrameBufferObject> m_shadowFBO;
+    std::unique_ptr<sofa::gl::FrameBufferObject> m_blurHFBO;
+    std::unique_ptr<sofa::gl::FrameBufferObject> m_blurVFBO;
     static const std::string PATH_TO_GENERATE_DEPTH_TEXTURE_VERTEX_SHADER;
     static const std::string PATH_TO_GENERATE_DEPTH_TEXTURE_FRAGMENT_SHADER;
     static const std::string PATH_TO_BLUR_TEXTURE_VERTEX_SHADER;

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglColorMap.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglColorMap.cpp
@@ -25,7 +25,7 @@
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/visual/VisualParams.h>
 
-#include <sofa/helper/gl/GLSLShader.h>
+#include <sofa/gl/GLSLShader.h>
 
 #include <string>
 #include <iostream>
@@ -215,8 +215,8 @@ void OglColorMap::drawVisual(const core::visual::VisualParams* vparams)
     //glBlendFunc(GL_ONE, GL_ONE);
     glColor3f(1.0f, 1.0f, 1.0f);
 
-    GLhandleARB currentShader = sofa::helper::gl::GLSLShader::GetActiveShaderProgram();
-    sofa::helper::gl::GLSLShader::SetActiveShaderProgram(0);
+    GLhandleARB currentShader = sofa::gl::GLSLShader::GetActiveShaderProgram();
+    sofa::gl::GLSLShader::SetActiveShaderProgram(0);
 
     glBegin(GL_QUADS);
 
@@ -285,7 +285,7 @@ void OglColorMap::drawVisual(const core::visual::VisualParams* vparams)
                                           textcolor,
                                           smin.str().c_str());
 
-    sofa::helper::gl::GLSLShader::SetActiveShaderProgram(currentShader);
+    sofa::gl::GLSLShader::SetActiveShaderProgram(currentShader);
 
     // Restore state
     glPopAttrib();

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglColorMap.h
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglColorMap.h
@@ -29,7 +29,7 @@
 #include <sofa/helper/ColorMap.h>
 #include <sofa/helper/vector.h>
 #include <sofa/helper/rmath.h>
-#include <sofa/helper/gl/template.h>
+#include <sofa/gl/template.h>
 #include <sofa/defaulttype/Vec.h>
 #include <string>
 

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglLabel.h
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglLabel.h
@@ -30,7 +30,7 @@
 #include <sofa/helper/OptionsGroup.h>
 #include <sofa/helper/vector.h>
 #include <sofa/helper/rmath.h>
-#include <sofa/helper/gl/template.h>
+#include <sofa/gl/template.h>
 #include <sofa/defaulttype/Vec.h>
 #include <SofaBaseVisual/BackgroundSetting.h>
 

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglModel.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglModel.cpp
@@ -24,7 +24,7 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/system/gl.h>
-#include <sofa/helper/gl/RAII.h>
+#include <sofa/gl/RAII.h>
 #include <sofa/helper/vector.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
@@ -616,7 +616,7 @@ bool OglModel::loadTexture(const std::string& filename)
     helper::io::Image *img = helper::io::Image::Create(filename);
     if (!img)
         return false;
-    tex = new helper::gl::Texture(img, true, true, false, srgbTexturing.getValue());
+    tex = new sofa::gl::Texture(img, true, true, false, srgbTexturing.getValue());
     return true;
 }
 
@@ -658,7 +658,7 @@ bool OglModel::loadTextures()
             result = false;
             continue;
         }
-        helper::gl::Texture * text = new helper::gl::Texture(img, true, true, false, srgbTexturing.getValue());
+        sofa::gl::Texture * text = new sofa::gl::Texture(img, true, true, false, srgbTexturing.getValue());
         materialTextureIdMap.insert(std::pair<int, int>(*i,textures.size()));
         textures.push_back( text );
     }

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglModel.h
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglModel.h
@@ -25,8 +25,8 @@
 
 #include <vector>
 #include <string>
-#include <sofa/helper/gl/template.h>
-#include <sofa/helper/gl/Texture.h>
+#include <sofa/gl/template.h>
+#include <sofa/gl/Texture.h>
 #include <sofa/helper/OptionsGroup.h>
 #include <sofa/core/visual/VisualModel.h>
 #include <sofa/defaulttype/Vec.h>
@@ -83,7 +83,7 @@ protected:
     Data<sofa::helper::OptionsGroup> destFactor; ///< if alpha blending is enabled this specifies how the red, green, blue, and alpha destination blending factors are computed
     GLenum blendEq, sfactor, dfactor;
 
-    helper::gl::Texture *tex; //this texture is used only if a texture name is specified in the scn
+    sofa::gl::Texture *tex; //this texture is used only if a texture name is specified in the scn
     GLuint vbo, iboEdges, iboTriangles, iboQuads;
     bool VBOGenDone, initDone, useEdges, useTriangles, useQuads, canUsePatches;
     size_t oldVerticesSize, oldNormalsSize, oldTexCoordsSize, oldTangentsSize, oldBitangentsSize, oldEdgesSize, oldTrianglesSize, oldQuadsSize;
@@ -101,7 +101,7 @@ protected:
     virtual void pushTransformMatrix(float* matrix) { glPushMatrix(); glMultMatrixf(matrix); }
     virtual void popTransformMatrix() { glPopMatrix(); }
 
-    std::vector<helper::gl::Texture*> textures;
+    std::vector<sofa::gl::Texture*> textures;
 
     std::map<int, int> materialTextureIdMap; //link between a material and a texture
 
@@ -132,12 +132,12 @@ public:
     bool isUseTriangles()	{ return useTriangles; }
     bool isUseQuads()	{ return useQuads; }
 
-    helper::gl::Texture* getTex() const	{ return tex; }
+    sofa::gl::Texture* getTex() const	{ return tex; }
     GLuint getVbo()	{ return vbo;	}
     GLuint getIboEdges() { return iboEdges; }
     GLuint getIboTriangles() { return iboTriangles; }
     GLuint getIboQuads()    { return iboQuads; }
-    const std::vector<helper::gl::Texture*>& getTextures() const { return textures;	}
+    const std::vector<sofa::gl::Texture*>& getTextures() const { return textures;	}
 
     void createVertexBuffer();
     void createEdgesIndicesBuffer();

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglOITShader.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglOITShader.cpp
@@ -63,7 +63,7 @@ OglOITShader::~OglOITShader()
 
 }
 
-helper::gl::GLSLShader* OglOITShader::accumulationShader()
+sofa::gl::GLSLShader* OglOITShader::accumulationShader()
 {
     if(shaderVector.size() < 1)
         return nullptr;

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglOITShader.h
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglOITShader.h
@@ -43,7 +43,7 @@ protected:
     ~OglOITShader() override;
 
 public:
-    helper::gl::GLSLShader* accumulationShader();
+    sofa::gl::GLSLShader* accumulationShader();
 
 public:
     static const std::string PATH_TO_OIT_ACCUMULATION_VERTEX_SHADERS;

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglShader.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglShader.cpp
@@ -112,7 +112,7 @@ void OglShader::init()
 
     for (unsigned int i=0 ; i<nshaders ; i++)
     {
-        shaderVector[i] = new sofa::helper::gl::GLSLShader();
+        shaderVector[i] = new sofa::gl::GLSLShader();
         if (!vertFilename.getValue().empty())
         {
             shaderVector[i]->SetVertexShaderFileName(vertFilename.getFullPath(std::min(i,(unsigned int)vertFilename.getValue().size()-1)));
@@ -150,7 +150,7 @@ void OglShader::reinit()
 void OglShader::initVisual()
 {
 
-    if (!sofa::helper::gl::GLSLShader::InitGLSL())
+    if (!sofa::gl::GLSLShader::InitGLSL())
     {
         msg_error() << "InitGLSL failed";
         return;

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglShader.h
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglShader.h
@@ -27,8 +27,8 @@
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/core/visual/Shader.h>
 #include <sofa/defaulttype/VecTypes.h>
-#include <sofa/helper/gl/template.h>
-#include <sofa/helper/gl/GLSLShader.h>
+#include <sofa/gl/template.h>
+#include <sofa/gl/GLSLShader.h>
 #include <sofa/core/objectmodel/DataFileName.h>
 
 namespace sofa
@@ -102,7 +102,7 @@ public:
 
 protected:
     ///OpenGL shader
-    std::vector<sofa::helper::gl::GLSLShader*> shaderVector;
+    std::vector<sofa::gl::GLSLShader*> shaderVector;
 
     OglShader();
     ~OglShader() override;

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglTexture.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglTexture.cpp
@@ -218,7 +218,7 @@ void OglTexture::initVisual()
     }
 
     if (texture) delete texture;
-    texture = new helper::gl::Texture(img, repeat.getValue(), linearInterpolation.getValue(),
+    texture = new sofa::gl::Texture(img, repeat.getValue(), linearInterpolation.getValue(),
             generateMipmaps.getValue(), srgbColorspace.getValue(),
             minLod.getValue(), maxLod.getValue());
     texture->init();

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglTexture.h
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglTexture.h
@@ -26,8 +26,8 @@
 #include <sofa/core/visual/VisualModel.h>
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/defaulttype/VecTypes.h>
-#include <sofa/helper/gl/template.h>
-#include <sofa/helper/gl/Texture.h>
+#include <sofa/gl/template.h>
+#include <sofa/gl/Texture.h>
 #include <sofa/core/objectmodel/DataFileName.h>
 #include <SofaOpenglVisual/OglShader.h>
 
@@ -74,7 +74,7 @@ protected:
     sofa::core::objectmodel::DataFileName cubemapFilenameNegY;
     sofa::core::objectmodel::DataFileName cubemapFilenameNegZ;
 
-    helper::gl::Texture* texture;
+    sofa::gl::Texture* texture;
     helper::io::Image* img;
 
 public:

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglTexturePointer.h
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglTexturePointer.h
@@ -26,8 +26,8 @@
 #include <sofa/core/visual/VisualModel.h>
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/defaulttype/VecTypes.h>
-#include <sofa/helper/gl/template.h>
-#include <sofa/helper/gl/Texture.h>
+#include <sofa/gl/template.h>
+#include <sofa/gl/Texture.h>
 #include <sofa/core/objectmodel/DataFileName.h>
 #include <SofaOpenglVisual/OglShader.h>
 #include <SofaOpenglVisual/OglTexture.h>

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglVariable.h
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglVariable.h
@@ -27,7 +27,7 @@
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/defaulttype/Mat.h>
-#include <sofa/helper/gl/template.h>
+#include <sofa/gl/template.h>
 #include <SofaOpenglVisual/OglShader.h>
 
 namespace sofa

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglViewport.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglViewport.cpp
@@ -24,8 +24,8 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/simulation/VisualVisitor.h>
 #include <sofa/core/ObjectFactory.h>
-#include <sofa/helper/gl/Transformation.h>
-#include <sofa/helper/gl/template.h>
+#include <sofa/helper/visual/Transformation.h>
+#include <sofa/gl/template.h>
 #include <sofa/helper/fixed_array.h>
 #include <sofa/helper/system/glu.h>
 #include <SofaBaseVisual/VisualStyle.h>
@@ -87,7 +87,7 @@ void OglViewport::initVisual()
     if (p_useFBO.getValue())
     {
         const Vec<2, unsigned int> screenSize = p_screenSize.getValue();
-        fbo = std::unique_ptr<helper::gl::FrameBufferObject>(new helper::gl::FrameBufferObject());
+        fbo = std::unique_ptr<sofa::gl::FrameBufferObject>(new sofa::gl::FrameBufferObject());
         fbo->init(screenSize[0],screenSize[1]);
     }
 }
@@ -130,7 +130,7 @@ void OglViewport::preDrawScene(core::visual::VisualParams* vp)
         }
 
         cameraOrientation.normalize();
-        helper::gl::Transformation transform;
+        sofa::helper::visual::Transformation transform;
 
         cameraOrientation.buildRotationMatrix(transform.rotation);
         //cameraOrientation.writeOpenGlMatrix((SReal*) transform.rotation);
@@ -191,9 +191,9 @@ void OglViewport::preDrawScene(core::visual::VisualParams* vp)
         glMatrixMode(GL_MODELVIEW);
         glPushMatrix();
         glLoadIdentity();
-        helper::gl::glMultMatrix((SReal *)transform.rotation);
+        sofa::gl::glMultMatrix((SReal *)transform.rotation);
 
-        helper::gl::glTranslate(transform.translation[0], transform.translation[1], transform.translation[2]);
+        sofa::gl::glTranslate(transform.translation[0], transform.translation[1], transform.translation[2]);
     }
 }
 
@@ -264,7 +264,7 @@ void OglViewport::renderToViewport(core::visual::VisualParams* vp)
     }
     else
     {
-        helper::gl::Transformation transform;
+        sofa::helper::visual::Transformation transform;
         double zNear=1e10, zFar=-1e10;
 //        double fovy = 0;
 
@@ -341,9 +341,9 @@ void OglViewport::renderToViewport(core::visual::VisualParams* vp)
         glMatrixMode(GL_MODELVIEW);
         glPushMatrix();
         glLoadIdentity();
-        helper::gl::glMultMatrix((SReal *)transform.rotation);
+        sofa::gl::glMultMatrix((SReal *)transform.rotation);
 
-        helper::gl::glTranslate(transform.translation[0], transform.translation[1], transform.translation[2]);
+        sofa::gl::glTranslate(transform.translation[0], transform.translation[1], transform.translation[2]);
 
         //gluLookAt(cameraPosition[0], cameraPosition[1], cameraPosition[2],0 ,0 ,0, cameraDirection[0], cameraDirection[1], cameraDirection[2]);
     }

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglViewport.h
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglViewport.h
@@ -28,7 +28,7 @@
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/defaulttype/BoundingBox.h>
 
-#include <sofa/helper/gl/FrameBufferObject.h>
+#include <sofa/gl/FrameBufferObject.h>
 #include <sofa/core/visual/VisualParams.h>
 
 namespace sofa
@@ -62,7 +62,7 @@ public:
     Data<bool> p_swapMainView; ///< Swap this viewport with the main view
     Data<bool> p_drawCamera; ///< Draw a frame representing the camera (see it in main viewport)
 
-    std::unique_ptr<helper::gl::FrameBufferObject> fbo;
+    std::unique_ptr<sofa::gl::FrameBufferObject> fbo;
 
 protected:
     OglViewport();

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OrderIndependentTransparencyManager.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OrderIndependentTransparencyManager.cpp
@@ -37,7 +37,7 @@ namespace component
 namespace visualmodel
 {
 
-using namespace helper::gl;
+using namespace sofa::gl;
 using namespace simulation;
 using namespace core::visual;
 

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OrderIndependentTransparencyManager.h
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OrderIndependentTransparencyManager.h
@@ -25,7 +25,7 @@
 #include "config.h"
 
 #include <sofa/core/visual/VisualManager.h>
-#include <sofa/helper/gl/GLSLShader.h>
+#include <sofa/gl/GLSLShader.h>
 #include <SofaOpenglVisual/OglOITShader.h>
 
 namespace sofa
@@ -97,12 +97,12 @@ public:
 
 protected:
     void drawOpaques(core::visual::VisualParams* vp);
-    void drawTransparents(core::visual::VisualParams* vp, helper::gl::GLSLShader* oitShader);
+    void drawTransparents(core::visual::VisualParams* vp, sofa::gl::GLSLShader* oitShader);
 
 private:
     FrameBufferObject            fbo;
-    sofa::helper::gl::GLSLShader accumulationShader;
-    sofa::helper::gl::GLSLShader compositionShader;
+    sofa::gl::GLSLShader accumulationShader;
+    sofa::gl::GLSLShader compositionShader;
 
 };
 

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/PointSplatModel.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/PointSplatModel.cpp
@@ -21,7 +21,7 @@
 ******************************************************************************/
 
 #include <map>
-#include <sofa/helper/gl/template.h>
+#include <sofa/gl/template.h>
 #include <sofa/core/ObjectFactory.h>
 
 #include <sofa/defaulttype/VecTypes.h>

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/PostProcessManager.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/PostProcessManager.cpp
@@ -81,7 +81,7 @@ void PostProcessManager::initVisual()
         GLint windowWidth = viewport[2];
         GLint windowHeight = viewport[3];
 
-        fbo = std::unique_ptr<helper::gl::FrameBufferObject>(new helper::gl::FrameBufferObject());
+        fbo = std::unique_ptr<sofa::gl::FrameBufferObject>(new sofa::gl::FrameBufferObject());
         fbo->init(windowWidth, windowHeight);
 
 

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/PostProcessManager.h
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/PostProcessManager.h
@@ -25,7 +25,7 @@
 
 #include <sofa/core/visual/VisualManager.h>
 #include <sofa/core/visual/VisualParams.h>
-#include <sofa/helper/gl/FrameBufferObject.h>
+#include <sofa/gl/FrameBufferObject.h>
 #include <SofaOpenglVisual/OglShader.h>
 #include <sofa/core/objectmodel/DataFileName.h>
 
@@ -48,7 +48,7 @@ private:
     static const std::string DEPTH_OF_FIELD_FRAGMENT_SHADER;
     Data<double> zNear; ///< Set zNear distance (for Depth Buffer)
     Data<double> zFar; ///< Set zFar distance (for Depth Buffer)
-    std::unique_ptr<helper::gl::FrameBufferObject> fbo;
+    std::unique_ptr<sofa::gl::FrameBufferObject> fbo;
     OglShader* dofShader;
     bool postProcessEnabled;
 

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/SlicedVolumetricModel.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/SlicedVolumetricModel.cpp
@@ -21,7 +21,7 @@
 ******************************************************************************/
 
 #include <map>
-#include <sofa/helper/gl/template.h>
+#include <sofa/gl/template.h>
 #include <sofa/core/ObjectFactory.h>
 
 #include <sofa/defaulttype/VecTypes.h>
@@ -382,12 +382,12 @@ void SlicedVolumetricModel::findAndDrawTriangles()
 
             for( unsigned int i=0; i<tripoints.size()-1; ++i)
             {
-                helper::gl::glTexCoordT(intersections[0].second);
-                helper::gl::glVertexT(intersections[0].first);
-                helper::gl::glTexCoordT(intersections[tripoints[i]].second);
-                helper::gl::glVertexT(intersections[tripoints[i]].first);
-                helper::gl::glTexCoordT(intersections[tripoints[i+1]].second);
-                helper::gl::glVertexT(intersections[tripoints[i+1]].first);
+                sofa::gl::glTexCoordT(intersections[0].second);
+                sofa::gl::glVertexT(intersections[0].first);
+                sofa::gl::glTexCoordT(intersections[tripoints[i]].second);
+                sofa::gl::glVertexT(intersections[tripoints[i]].first);
+                sofa::gl::glTexCoordT(intersections[tripoints[i+1]].second);
+                sofa::gl::glVertexT(intersections[tripoints[i+1]].first);
             }
 
             ++itcell;

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/SlicedVolumetricModel.h
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/SlicedVolumetricModel.h
@@ -28,7 +28,7 @@
 #include <sofa/helper/types/RGBAColor.h>
 #include <SofaBaseTopology/TopologyData.h>
 
-#include <sofa/helper/gl/template.h>
+#include <sofa/gl/template.h>
 
 namespace sofa
 {

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/VisualManagerPass.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/VisualManagerPass.cpp
@@ -33,7 +33,7 @@ namespace component
 namespace visualmodel
 {
 
-using namespace helper::gl;
+using namespace sofa::gl;
 using namespace simulation;
 using namespace core::visual;
 
@@ -92,7 +92,7 @@ void VisualManagerPass::initVisual()
     passWidth = (GLint) ((float)viewport[2]*factor.getValue());
     passHeight = (GLint)((float)viewport[3] * factor.getValue());
 
-    fbo = std::unique_ptr<helper::gl::FrameBufferObject>(
+    fbo = std::unique_ptr<sofa::gl::FrameBufferObject>(
                 new FrameBufferObject(true, true, true, true));
     fbo->init(passWidth, passHeight);
 }

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/VisualManagerPass.h
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/VisualManagerPass.h
@@ -25,7 +25,7 @@
 
 #include <SofaOpenglVisual/CompositingVisualLoop.h>
 #include <sofa/core/visual/VisualManager.h>
-#include <sofa/helper/gl/FrameBufferObject.h>
+#include <sofa/gl/FrameBufferObject.h>
 #include <SofaOpenglVisual/OglShader.h>
 #include <sofa/core/objectmodel/DataFileName.h>
 #include <sofa/core/objectmodel/Event.h>
@@ -56,7 +56,7 @@ protected:
     bool checkMultipass(sofa::core::objectmodel::BaseContext* con);
     bool multiPassEnabled;
 
-    std::unique_ptr<helper::gl::FrameBufferObject> fbo;
+    std::unique_ptr<sofa::gl::FrameBufferObject> fbo;
     bool prerendered;
 
     GLint passWidth;
@@ -82,7 +82,7 @@ public:
 
     virtual bool isPrerendered() {return prerendered;}
 
-    virtual helper::gl::FrameBufferObject& getFBO() {return *fbo;}
+    virtual sofa::gl::FrameBufferObject& getFBO() {return *fbo;}
     bool hasFilledFbo();
     std::string getOutputName();
 };

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/VisualManagerSecondaryPass.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/VisualManagerSecondaryPass.cpp
@@ -32,7 +32,7 @@ namespace component
 namespace visualmodel
 {
 
-using namespace helper::gl;
+using namespace sofa::gl;
 using namespace simulation;
 using namespace core::visual;
 
@@ -95,7 +95,7 @@ void VisualManagerSecondaryPass::initVisual()
     passWidth = (GLint)(viewport[2]*factor.getValue());
     passHeight = (GLint)(viewport[3]*factor.getValue());
 
-    fbo = std::unique_ptr<helper::gl::FrameBufferObject>(
+    fbo = std::unique_ptr<sofa::gl::FrameBufferObject>(
                 new FrameBufferObject(true, true, true, true));
     fbo->init(passWidth, passHeight);
 }

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/VisualManagerSecondaryPass.h
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/VisualManagerSecondaryPass.h
@@ -68,7 +68,7 @@ public:
     void bindInput(core::visual::VisualParams* /*vp*/);
     void unbindInput();
 
-    helper::gl::FrameBufferObject& getFBO() override {return *fbo;}
+    sofa::gl::FrameBufferObject& getFBO() override {return *fbo;}
 
     const sofa::core::objectmodel::TagSet& getOutputTags() {return output_tags.getValue();}
 


### PR DESCRIPTION
Title says all, this PR removes all deprecated headers, occurring since the creation of Sofa.GL.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
