### PR TITLE
[SofaMiscCollision] Fix config.in cmake file for export

### DIFF
--- a/applications/plugins/SofaMiscCollision/CMakeLists.txt
+++ b/applications/plugins/SofaMiscCollision/CMakeLists.txt
@@ -1,6 +1,14 @@
 cmake_minimum_required(VERSION 3.12)
 project(SofaMiscCollision VERSION 1.0)
 
+sofa_find_package(SofaBaseCollision REQUIRED)
+sofa_find_package(SofaBaseTopology REQUIRED)
+sofa_find_package(SofaGeneralMeshCollision REQUIRED)
+sofa_find_package(SofaGeneralDeformable REQUIRED)
+sofa_find_package(SofaConstraint REQUIRED)
+sofa_find_package(SofaExplicitOdeSolver REQUIRED)
+sofa_find_package(SofaGeneralExplicitOdeSolver REQUIRED)
+sofa_find_package(SofaImplicitOdeSolver REQUIRED)
 sofa_find_package(SofaSphFluid QUIET)
 sofa_find_package(SofaDistanceGrid QUIET)
 

--- a/applications/plugins/SofaMiscCollision/SofaMiscCollisionConfig.cmake.in
+++ b/applications/plugins/SofaMiscCollision/SofaMiscCollisionConfig.cmake.in
@@ -3,6 +3,15 @@
 @PACKAGE_GUARD@
 @PACKAGE_INIT@
 
+find_package(SofaBaseCollision QUIET REQUIRED)
+find_package(SofaBaseTopology QUIET REQUIRED)
+find_package(SofaGeneralMeshCollision QUIET REQUIRED)
+find_package(SofaGeneralDeformable QUIET REQUIRED)
+find_package(SofaConstraint QUIET REQUIRED)
+find_package(SofaExplicitOdeSolver QUIET REQUIRED)
+find_package(SofaGeneralExplicitOdeSolver QUIET REQUIRED)
+find_package(SofaImplicitOdeSolver QUIET REQUIRED)
+
 set(SOFAMISCCOLLISION_HAVE_SOFASPHFLUID @SOFAMISCCOLLISION_HAVE_SOFASPHFLUID@)
 set(SOFAMISCCOLLISION_HAVE_SOFADISTANCEGRID @SOFAMISCCOLLISION_HAVE_SOFADISTANCEGRID@)
 


### PR DESCRIPTION
SofaMiscCollisionConfig.cmake.in was ill-formed, so projects using it in out-of-tree builds are stuck in the cmake configuration process.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
