### PR TITLE
[HeadlessRecorder] CLEAN Headless recorder

### DIFF
--- a/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.cpp
+++ b/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.cpp
@@ -33,13 +33,7 @@ using sofa::helper::system::SetDirectory;
 #include <thread>
 #include <chrono>
 
-namespace sofa
-{
-
-namespace gui
-{
-
-namespace hRecorder
+namespace sofa::gui::hRecorder
 {
 
 GLsizei HeadlessRecorder::width = 1920;
@@ -643,10 +637,6 @@ void HeadlessRecorder::record()
         }
     }
 }
-
-} // namespace hRecorder
-
-} // namespace gui
 
 } // namespace sofa
 

--- a/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.cpp
+++ b/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.cpp
@@ -344,7 +344,7 @@ int HeadlessRecorder::mainLoop()
             if(m_nFrames % fps == 0)
             {
                 end = std::chrono::system_clock::now();
-                int elapsed_milliSeconds = std::chrono::duration_cast<std::chrono::milliseconds>(end-start).count();
+                const auto elapsed_milliSeconds = std::chrono::duration_cast<std::chrono::milliseconds>(end-start).count();
                 msg_info("HeadlessRecorder") << "Encoding : " << m_nFrames/fps << " seconds. Encoding time : " << elapsed_milliSeconds << " ms";
                 start = std::chrono::system_clock::now();
             }

--- a/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.cpp
+++ b/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.cpp
@@ -302,11 +302,11 @@ void HeadlessRecorder::initializeGL(void)
     //resetView();
 }
 
-bool HeadlessRecorder::canRecord()
+bool HeadlessRecorder::canRecord() const
 {
     if(recordUntilStopAnimate)
     {
-        return currentSimulation() && currentSimulation()->getContext()->getAnimate();
+        return groot != nullptr && groot->getContext()->getAnimate();
     }
     return static_cast<float>(m_nFrames)/static_cast<float>(fps) <= recordTimeInSeconds;
 }
@@ -368,7 +368,7 @@ int HeadlessRecorder::mainLoop()
     return 0;
 }
 
-bool HeadlessRecorder::keepFrame()
+bool HeadlessRecorder::keepFrame() const
 {
     switch(recordType)
     {

--- a/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.cpp
+++ b/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.cpp
@@ -52,7 +52,6 @@ float HeadlessRecorder::skipTime = 0;
 using namespace sofa::defaulttype;
 using sofa::simulation::getSimulation;
 
-static sofa::core::ObjectFactory::ClassEntry::SPtr classVisualModel;
 typedef GLXContext (*glXCreateContextAttribsARBProc)(Display*, GLXFBConfig, GLXContext, Bool, const int*);
 typedef Bool (*glXMakeContextCurrentARBProc)(Display*, GLXDrawable, GLXDrawable, GLXContext);
 static glXCreateContextAttribsARBProc glXCreateContextAttribsARB = nullptr;

--- a/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.cpp
+++ b/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.cpp
@@ -602,12 +602,15 @@ void HeadlessRecorder::setViewerResolution(int width, int height)
 // -----------------------------------------------------------------
 void HeadlessRecorder::record()
 {
-
     if (saveAsScreenShot)
     {
-        std::string pngFilename = fileName + std::to_string(m_nFrames) + ".png" ;
+        std::stringstream ss;
+        ss << std::setw(8) << std::setfill('0') << m_nFrames;
+
+        std::string pngFilename = fileName + ss.str() + ".png" ;
         m_screencapture.saveScreen(pngFilename, 0);
-    } else if (saveAsVideo)
+    }
+    else if (saveAsVideo)
     {
         if (initVideoRecorder)
         {

--- a/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
+++ b/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
@@ -72,7 +72,7 @@ public:
     void resetView();
     void initializeGL();
     void paintGL();
-    void setScene(sofa::simulation::NodeSPtr scene, const char* filename=NULL, bool temporaryFile=false) override;
+    void setScene(sofa::simulation::NodeSPtr scene, const char* filename=nullptr, bool temporaryFile=false) override;
     void newView();
 
     // Virtual from BaseGUI
@@ -81,7 +81,7 @@ public:
     virtual void setViewerResolution(int width, int height) override;
 
     // Needed for the registration
-    static BaseGUI* CreateGUI(const char* name, sofa::simulation::NodeSPtr groot = NULL, const char* filename = NULL);
+    static BaseGUI* CreateGUI(const char* name, sofa::simulation::NodeSPtr groot = nullptr, const char* filename = nullptr);
     static int RegisterGUIParameters(ArgumentParser* argumentParser);
     static void parseRecordingModeOption();
 

--- a/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
+++ b/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
@@ -124,7 +124,8 @@ private:
     helper::types::RGBAColor m_backgroundColor;
 
 
-    static GLsizei width, height;
+    static GLsizei s_height;
+    static GLsizei s_width;
     static unsigned int fps;
     static std::string fileName;
     static bool saveAsScreenShot, saveAsVideo;

--- a/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
+++ b/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
@@ -110,7 +110,6 @@ private:
     GLuint fbo;
     GLuint rbo_color, rbo_depth;
     double lastProjectionMatrix[16];
-    double lastModelviewMatrix[16];
     bool initTexturesDone;
     bool initVideoRecorder;
     sofa::gl::Capture m_screencapture;

--- a/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
+++ b/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
@@ -50,13 +50,7 @@
 #include <sofa/gl/VideoRecorderFFMPEG.h>
 #include <sofa/gl/Capture.h>
 
-namespace sofa
-{
-
-namespace gui
-{
-
-namespace hRecorder
+namespace sofa::gui::hRecorder
 {
 
 enum class RecordMode { wallclocktime, simulationtime, timeinterval };
@@ -133,10 +127,6 @@ private:
     static RecordMode recordType;
     static float skipTime;
 };
-
-} // namespace hRecorder
-
-} // namespace gui
 
 } // namespace sofa
 

--- a/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
+++ b/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
@@ -107,9 +107,9 @@ private:
     sofa::gl::VideoRecorderFFMPEG m_videorecorder;
     int m_nFrames;
 
-    GLuint fbo;
-    GLuint rbo_color, rbo_depth;
-    double lastProjectionMatrix[16];
+    GLuint fbo{};
+    GLuint rbo_color{}, rbo_depth{};
+    double lastProjectionMatrix[16]{};
     bool initTexturesDone;
     bool initVideoRecorder;
     sofa::gl::Capture m_screencapture;

--- a/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
+++ b/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
@@ -30,7 +30,7 @@
 #include <SofaBaseVisual/InteractiveCamera.h>
 #include <sofa/core/ObjectFactory.h>
 
-#include <signal.h>
+#include <csignal>
 
 #include <iostream>
 #include <chrono>

--- a/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
+++ b/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
@@ -90,8 +90,8 @@ public:
 
 private:
     void record();
-    bool canRecord();
-    bool keepFrame();
+    bool canRecord() const;
+    bool keepFrame() const;
 
     void displayOBJs();
     void drawScene();

--- a/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
+++ b/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
@@ -50,11 +50,6 @@
 #include <sofa/gl/VideoRecorderFFMPEG.h>
 #include <sofa/gl/Capture.h>
 
-namespace sofa::gl
-{
-    class Texture;
-}
-
 namespace sofa::gui::hRecorder
 {
 

--- a/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
+++ b/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
@@ -63,7 +63,7 @@ public:
     typedef sofa::core::visual::DrawToolGL   DrawToolGL;
 
     HeadlessRecorder();
-    ~HeadlessRecorder();
+    ~HeadlessRecorder() override;
 
     int mainLoop() override;
 

--- a/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
+++ b/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
@@ -50,6 +50,11 @@
 #include <sofa/gl/VideoRecorderFFMPEG.h>
 #include <sofa/gl/Capture.h>
 
+namespace sofa::gl
+{
+    class Texture;
+}
+
 namespace sofa::gui::hRecorder
 {
 
@@ -79,6 +84,7 @@ public:
     virtual sofa::simulation::Node* currentSimulation() override;
     virtual int closeGUI() override;
     virtual void setViewerResolution(int width, int height) override;
+    virtual void setBackgroundColor(const sofa::helper::types::RGBAColor& color) override;
 
     // Needed for the registration
     static BaseGUI* CreateGUI(const char* name, sofa::simulation::NodeSPtr groot = nullptr, const char* filename = nullptr);
@@ -97,6 +103,8 @@ private:
     void drawScene();
     void calcProjection();
 
+    void initVideoRecorder();
+
     VisualParams* vparams;
     DrawToolGL   drawTool;
 
@@ -111,8 +119,10 @@ private:
     GLuint rbo_color{}, rbo_depth{};
     double lastProjectionMatrix[16]{};
     bool initTexturesDone;
-    bool initVideoRecorder;
+    bool requestVideoRecorderInit;
     sofa::gl::Capture m_screencapture;
+    helper::types::RGBAColor m_backgroundColor;
+
 
     static GLsizei width, height;
     static unsigned int fps;

--- a/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
+++ b/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
@@ -55,8 +55,6 @@ namespace sofa::gui::hRecorder
 
 enum class RecordMode { wallclocktime, simulationtime, timeinterval };
 
-class VideoRecorderFFmpeg;
-
 class HeadlessRecorder : public sofa::gui::BaseGUI
 {
 

--- a/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
+++ b/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.h
@@ -70,7 +70,6 @@ public:
     void step();
     void redraw() override;
     void resetView();
-    void saveView();
     void initializeGL();
     void paintGL();
     void setScene(sofa::simulation::NodeSPtr scene, const char* filename=NULL, bool temporaryFile=false) override;


### PR DESCRIPTION
Mostly cleaning of the GUI `HeadlessRecorder`, but it also adds support for background color.

In the future, I suggest to move `GLBackend` out of the qt namespace/folder, so it can be used in `HeadlessRecorder`. A lot of code can be shared between both, and `GLBackend` is not dependant on Qt. I'll create an issue.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
