### PR TITLE
[CMake] Disable CMAKE_INSTALL_DEFAULT_COMPONENT_NAME

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ else()
 endif()
 
 ## Change default install component and prefix
-set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME applications)
+#set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME applications)
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/install CACHE PATH "Install path prefix, prepended onto install directories." FORCE)
 endif()


### PR DESCRIPTION
It looks like this is the reason why SofaPython3 tests are failing.
I still have no idea why for now...

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
