### PR TITLE
[SofaFramework] Restore IDE folder

### DIFF
--- a/SofaKernel/SofaFramework/CMakeLists.txt
+++ b/SofaKernel/SofaFramework/CMakeLists.txt
@@ -30,6 +30,11 @@ foreach(module ${SOFAFRAMEWORK_LEGACYMODULES})
     add_subdirectory(../modules/${module} ${CMAKE_CURRENT_BINARY_DIR}/${module})
 endforeach()
 
+# add subprojects into a IDE folder called SofaFramework
+foreach(module ${SOFAFRAMEWORK_MODULES})
+    set_target_properties(${module} PROPERTIES FOLDER SofaFramework) # IDE folder
+endforeach()
+
 set(SOFAFRAMEWORK_SRC src/SofaFramework)
 set(HEADER_FILES
     ${SOFAFRAMEWORK_SRC}/config.h.in


### PR DESCRIPTION
Just a PR to restore the SofaFramework folder for its modules (it was spread at the root of the project before)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
