### PR TITLE
[SofaCore] Revert #2047 for deterministic contacts

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/collision/NarrowPhaseDetection.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/collision/NarrowPhaseDetection.h
@@ -41,18 +41,13 @@ class SOFA_CORE_API NarrowPhaseDetection : virtual public Detection
 public:
     SOFA_ABSTRACT_CLASS(NarrowPhaseDetection, Detection);
 
-private:
-
-    struct CollisionModelPairHash
-    {
-        std::size_t operator()(const std::pair< core::CollisionModel*, core::CollisionModel* >& p) const
-        {
-            return (std::hash<CollisionModel*>()(p.first)) ^ (std::hash<CollisionModel*>()(p.second) << 32);
-        }
-    };
-
-public:
-    typedef std::unordered_map< std::pair< core::CollisionModel*, core::CollisionModel* >, DetectionOutputVector*, CollisionModelPairHash> DetectionOutputMap;
+    /// A stable sorted associative container of type key-value, where:
+    /// * KEY: pair of collision models
+    /// * VALUE: collision detection output
+    /// The order of the elements in the container is determined by the order the elements are inserted.
+    /// Contact response processes collision detection output in the order of this map.
+    /// A stable order allows reproducible contact response, therefore a deterministic simulation.
+    typedef sofa::helper::map_ptr_stable_compare< std::pair< core::CollisionModel*, core::CollisionModel* >, DetectionOutputVector*> DetectionOutputMap;
 
 protected:
     /// Destructor


### PR DESCRIPTION
In this PR, `map_ptr_stable_compare` is preferred over `unordered_map`, as it allows reproducible contact response. However, `unordered_map` is still a lot faster.

#2047 leads to a crash in `examples/Components/collision/RayTraceCollision.scn`. I suspect the cause of this crash existed before #2047, and that #2047 revealed the crash by processing the contacts in a non-deterministic order. With the non-deterministic order, I can see that the crash does not happen always at the same current time step. It even happened that there was no crash.

Currently, I am not able to fix the crash. But I will continue investigating. As a workaround I restore the stable map to have deterministic contacts. IMO, it hides the cause of the crash.

In the end, I think the stable map should be proposed to the user (as a parameter?) by default. Let's see if we can accelerate it (perhaps with [Insimo version](https://github.com/InSimo/ISSofa/commits/issofa/framework/sofa/helper/map_ptr_stable_compare.h)).






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
