### PR TITLE
[SofaBaseCollision] Remove dependencies on BaseIntTool

### DIFF
--- a/SofaKernel/modules/SofaBaseCollision/SofaBaseCollision_test/BroadPhase_test.h
+++ b/SofaKernel/modules/SofaBaseCollision/SofaBaseCollision_test/BroadPhase_test.h
@@ -28,6 +28,8 @@
 #include <SofaSimulationGraph/DAGNode.h>
 #include <SofaBaseMechanics/MechanicalObject.h>
 
+#include <SofaBaseCollision/OBBModel.h>
+
 #include <gtest/gtest.h>
 
 using sofa::core::objectmodel::New;

--- a/SofaKernel/modules/SofaBaseCollision/SofaBaseCollision_test/Sphere_test.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/SofaBaseCollision_test/Sphere_test.cpp
@@ -52,7 +52,10 @@ using sofa::component::collision::Sphere;
 using sofa::component::collision::SphereCollisionModel ;
 using sofa::component::collision::TriangleCollisionModel;
 using sofa::component::collision::RigidSphere;
+
+#include <SofaBaseCollision/BaseIntTool.h>
 using sofa::component::collision::BaseIntTool;
+
 using sofa::core::collision::DetectionOutput;
 using sofa::defaulttype::Vec3d;
 

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BaseProximityIntersection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BaseProximityIntersection.cpp
@@ -31,4 +31,33 @@ BaseProximityIntersection::BaseProximityIntersection()
 	contactDistance.setRequired(true);
 }
 
+
+bool BaseProximityIntersection::testIntersection(Cube& cube1, Cube& cube2)
+{
+    const auto& minVect1 = cube1.minVect();
+    const auto& minVect2 = cube2.minVect();
+    const auto& maxVect1 = cube1.maxVect();
+    const auto& maxVect2 = cube2.maxVect();
+
+    const auto alarmDist = getAlarmDistance() + cube1.getProximity() + cube2.getProximity();
+
+    for (int i = 0; i < 3; i++)
+    {
+        if (minVect1[i] > maxVect2[i] + alarmDist || minVect2[i] > maxVect1[i] + alarmDist)
+            return false;
+    }
+
+    return true;
+}
+
+int BaseProximityIntersection::computeIntersection(Cube& cube1, Cube& cube2, OutputVector* contacts)
+{
+    SOFA_UNUSED(cube1);
+    SOFA_UNUSED(cube2);
+    SOFA_UNUSED(contacts);
+
+    return 0;
+}
+
+
 } // namespace sofa::component::collision

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BaseProximityIntersection.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BaseProximityIntersection.h
@@ -51,6 +51,10 @@ public:
 
     /// Sets the contact distance (if useProximity() is false, the contact distance is equal to 0)
     void setContactDistance(SReal v) override { contactDistance.setValue(v); }
+
+    // Intersectors
+    bool testIntersection(Cube& cube1, Cube& cube2);
+    int computeIntersection(Cube& cube1, Cube& cube2, OutputVector* contacts);
 };
 
 } // namespace sofa::component::collision

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BaseProximityIntersection.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BaseProximityIntersection.h
@@ -55,6 +55,7 @@ public:
     // Intersectors
     bool testIntersection(Cube& cube1, Cube& cube2);
     int computeIntersection(Cube& cube1, Cube& cube2, OutputVector* contacts);
+
 };
 
 } // namespace sofa::component::collision

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DiscreteIntersection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DiscreteIntersection.cpp
@@ -98,42 +98,6 @@ int DiscreteIntersection::computeIntersection(Cube& cube1, Cube& cube2, OutputVe
     return 0;
 }
 
-namespace // anonymous
-{
-    template<class SphereType1, class SphereType2>
-    bool testIntersectionSphere(SphereType1& sph1, SphereType2& sph2, const SReal alarmDist)
-    {
-        const auto r = sph1.r() + sph2.r() + alarmDist;
-        return (sph1.center() - sph2.center()).norm2() <= r * r;
-    }
-
-    template<class SphereType1, class SphereType2>
-    int computeIntersectionSphere(SphereType1& sph1, SphereType2& sph2, DiscreteIntersection::OutputVector* contacts, const SReal alarmDist, const SReal contactDist)
-    {    
-        SReal r = sph1.r() + sph2.r();
-        SReal myAlarmDist = alarmDist + r;
-        defaulttype::Vector3 dist = sph2.center() - sph1.center();
-        SReal norm2 = dist.norm2();
-
-        if (norm2 > myAlarmDist * myAlarmDist)
-            return 0;
-
-        contacts->resize(contacts->size() + 1);
-        DetectionOutput* detection = &*(contacts->end() - 1);
-        SReal distSph1Sph2 = helper::rsqrt(norm2);
-        detection->normal = dist / distSph1Sph2;
-        detection->point[0] = sph1.getContactPointByNormal(-detection->normal);
-        detection->point[1] = sph2.getContactPointByNormal(detection->normal);
-
-        detection->value = distSph1Sph2 - r - contactDist;
-        detection->elem.first = sph1;
-        detection->elem.second = sph2;
-        detection->id = (sph1.getCollisionModel()->getSize() > sph2.getCollisionModel()->getSize()) ? sph1.getIndex() : sph2.getIndex();
-
-        return 1;
-    }
-} // anonymous
-
 template <> 
 bool DiscreteIntersection::testIntersection<Sphere, Sphere>(Sphere& sph1, Sphere& sph2)
 {
@@ -169,18 +133,5 @@ int DiscreteIntersection::computeIntersection<Sphere, RigidSphere>(Sphere& sph1,
 {
     return computeIntersectionSphere(sph1, sph2, contacts, this->getAlarmDistance(), this->getContactDistance());
 }
-
-template <> 
-bool DiscreteIntersection::testIntersection<RigidSphere, Sphere>(RigidSphere& sph1, Sphere& sph2)
-{
-    return testIntersectionSphere(sph1, sph2, this->getAlarmDistance());
-}
-
-template <> 
-int DiscreteIntersection::computeIntersection<RigidSphere, Sphere>(RigidSphere& sph1, Sphere& sph2, OutputVector* contacts)
-{
-    return computeIntersectionSphere(sph1, sph2, contacts, this->getAlarmDistance(), this->getContactDistance());
-}
-
 
 } // namespace sofa::component::collision

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DiscreteIntersection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DiscreteIntersection.cpp
@@ -25,9 +25,6 @@
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/collision/Intersection.inl>
 
-#include <SofaBaseCollision/SphereModel.h>
-#include <SofaBaseCollision/BaseIntTool.h>
-
 namespace sofa::core::collision
 {
     template class SOFA_SOFABASECOLLISION_API IntersectorFactory<component::collision::DiscreteIntersection>;
@@ -46,9 +43,7 @@ int DiscreteIntersectionClass = core::RegisterObject("TODO-DiscreteIntersectionC
 DiscreteIntersection::DiscreteIntersection()
 {
     intersectors.add<CubeCollisionModel,       CubeCollisionModel,         DiscreteIntersection> (this);
-
     intersectors.add<SphereCollisionModel<sofa::defaulttype::Vec3Types>,     SphereCollisionModel<sofa::defaulttype::Vec3Types>,       DiscreteIntersection> (this);
-
     intersectors.add<RigidSphereModel,RigidSphereModel,DiscreteIntersection>(this);
     intersectors.add<SphereCollisionModel<sofa::defaulttype::Vec3Types>,RigidSphereModel, DiscreteIntersection> (this);
 
@@ -61,7 +56,6 @@ ElementIntersector* DiscreteIntersection::findIntersector(core::CollisionModel* 
     return intersectors.get(object1, object2, swapModels);
 }
 
-template<>
 bool DiscreteIntersection::testIntersection(Cube& cube1, Cube& cube2)
 {
     const SReal alarmDist = this->getAlarmDistance();
@@ -88,7 +82,6 @@ bool DiscreteIntersection::testIntersection(Cube& cube1, Cube& cube2)
     return true;
 }
 
-template<>
 int DiscreteIntersection::computeIntersection(Cube& cube1, Cube& cube2, OutputVector* contacts)
 {
     SOFA_UNUSED(cube1);
@@ -98,38 +91,32 @@ int DiscreteIntersection::computeIntersection(Cube& cube1, Cube& cube2, OutputVe
     return 0;
 }
 
-template <> 
-bool DiscreteIntersection::testIntersection<Sphere, Sphere>(Sphere& sph1, Sphere& sph2)
+bool DiscreteIntersection::testIntersection(Sphere& sph1, Sphere& sph2)
 {
     return testIntersectionSphere(sph1, sph2, this->getAlarmDistance());
 }
 
-template <> 
-int DiscreteIntersection::computeIntersection<Sphere, Sphere>(Sphere& sph1, Sphere& sph2, OutputVector* contacts)
+int DiscreteIntersection::computeIntersection(Sphere& sph1, Sphere& sph2, OutputVector* contacts)
 {
     return computeIntersectionSphere(sph1, sph2, contacts, this->getAlarmDistance(), this->getContactDistance());
 }
 
-template <> 
-bool DiscreteIntersection::testIntersection<RigidSphere, RigidSphere>(RigidSphere& sph1, RigidSphere& sph2)
+bool DiscreteIntersection::testIntersection(RigidSphere& sph1, RigidSphere& sph2)
 {
     return testIntersectionSphere(sph1, sph2, this->getAlarmDistance());
 }
 
-template <> 
-int DiscreteIntersection::computeIntersection<RigidSphere, RigidSphere>(RigidSphere& sph1, RigidSphere& sph2, OutputVector* contacts)
+int DiscreteIntersection::computeIntersection(RigidSphere& sph1, RigidSphere& sph2, OutputVector* contacts)
 {
     return computeIntersectionSphere(sph1, sph2, contacts, this->getAlarmDistance(), this->getContactDistance());
 }
 
-template <> 
-bool DiscreteIntersection::testIntersection<Sphere, RigidSphere>(Sphere& sph1, RigidSphere& sph2)
+bool DiscreteIntersection::testIntersection(Sphere& sph1, RigidSphere& sph2)
 {
     return testIntersectionSphere(sph1, sph2, this->getAlarmDistance());
 }
 
-template <> 
-int DiscreteIntersection::computeIntersection<Sphere, RigidSphere>(Sphere& sph1, RigidSphere& sph2, OutputVector* contacts)
+int DiscreteIntersection::computeIntersection(Sphere& sph1, RigidSphere& sph2, OutputVector* contacts)
 {
     return computeIntersectionSphere(sph1, sph2, contacts, this->getAlarmDistance(), this->getContactDistance());
 }

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DiscreteIntersection.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DiscreteIntersection.h
@@ -57,6 +57,41 @@ public:
     {
         return BaseIntTool::computeIntersection(e1, e2, e1.getProximity() + e2.getProximity() + getAlarmDistance(), e1.getProximity() + e2.getProximity() + getContactDistance(), contacts);
     }
+
+protected:
+
+    template<class SphereType1, class SphereType2>
+    bool testIntersectionSphere(SphereType1& sph1, SphereType2& sph2, const SReal alarmDist)
+    {
+        const auto r = sph1.r() + sph2.r() + alarmDist;
+        return (sph1.center() - sph2.center()).norm2() <= r * r;
+    }
+
+    template<class SphereType1, class SphereType2>
+    int computeIntersectionSphere(SphereType1& sph1, SphereType2& sph2, DiscreteIntersection::OutputVector* contacts, const SReal alarmDist, const SReal contactDist)
+    {
+        SReal r = sph1.r() + sph2.r();
+        SReal myAlarmDist = alarmDist + r;
+        defaulttype::Vector3 dist = sph2.center() - sph1.center();
+        SReal norm2 = dist.norm2();
+
+        if (norm2 > myAlarmDist * myAlarmDist)
+            return 0;
+
+        contacts->resize(contacts->size() + 1);
+        DetectionOutput* detection = &*(contacts->end() - 1);
+        SReal distSph1Sph2 = helper::rsqrt(norm2);
+        detection->normal = dist / distSph1Sph2;
+        detection->point[0] = sph1.getContactPointByNormal(-detection->normal);
+        detection->point[1] = sph2.getContactPointByNormal(detection->normal);
+
+        detection->value = distSph1Sph2 - r - contactDist;
+        detection->elem.first = sph1;
+        detection->elem.second = sph2;
+        detection->id = (sph1.getCollisionModel()->getSize() > sph2.getCollisionModel()->getSize()) ? sph1.getIndex() : sph2.getIndex();
+
+        return 1;
+    }
 };
 
 
@@ -72,8 +107,6 @@ template <> bool DiscreteIntersection::testIntersection<RigidSphere, RigidSphere
 template <> int DiscreteIntersection::computeIntersection<RigidSphere, RigidSphere>(RigidSphere& sph1, RigidSphere& sph2, OutputVector* contacts);
 template <> bool DiscreteIntersection::testIntersection<Sphere, RigidSphere>(Sphere& sph1, RigidSphere& sph2);
 template <> int DiscreteIntersection::computeIntersection<Sphere, RigidSphere>(Sphere& sph1, RigidSphere& sph2, OutputVector* contacts);
-template <> bool DiscreteIntersection::testIntersection<RigidSphere, Sphere>(RigidSphere& sph1, Sphere& sph2);
-template <> int DiscreteIntersection::computeIntersection<RigidSphere, Sphere>(RigidSphere& sph1, Sphere& sph2, OutputVector* contacts);
 
 } // namespace sofa::component::collision
 

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DiscreteIntersection.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DiscreteIntersection.h
@@ -24,7 +24,8 @@
 
 #include <sofa/core/collision/Intersection.h>
 #include <sofa/core/collision/IntersectorFactory.h>
-#include <SofaBaseCollision/BaseIntTool.h>
+#include <SofaBaseCollision/SphereModel.h>
+#include <SofaBaseCollision/CubeModel.h>
 
 namespace sofa::component::collision
 {
@@ -45,18 +46,17 @@ public:
     typedef core::collision::IntersectorFactory<DiscreteIntersection> IntersectorFactory;
 
     //Intersectors
-    //Generic case
-    template <class Elem1, class Elem2>
-    bool testIntersection(Elem1& e1, Elem2& e2)
-    {
-        return BaseIntTool::testIntersection(e1, e2, this->getAlarmDistance());
-    }
+    // // Cube
+    bool testIntersection(Cube& cube1, Cube& cube2);
+    int computeIntersection(Cube& cube1, Cube& cube2, OutputVector* contacts);
 
-    template <class Elem1, class Elem2>
-    int computeIntersection(Elem1& e1, Elem2& e2, OutputVector* contacts)
-    {
-        return BaseIntTool::computeIntersection(e1, e2, e1.getProximity() + e2.getProximity() + getAlarmDistance(), e1.getProximity() + e2.getProximity() + getContactDistance(), contacts);
-    }
+    //Sphere
+    bool testIntersection(Sphere& sph1, Sphere& sph2);
+    int computeIntersection(Sphere& sph1, Sphere& sph2, OutputVector* contacts);
+    bool testIntersection(RigidSphere& sph1, RigidSphere& sph2);
+    int computeIntersection(RigidSphere& sph1, RigidSphere& sph2, OutputVector* contacts);
+    bool testIntersection(Sphere& sph1, RigidSphere& sph2);
+    int computeIntersection(Sphere& sph1, RigidSphere& sph2, OutputVector* contacts);
 
 protected:
 
@@ -93,20 +93,6 @@ protected:
         return 1;
     }
 };
-
-
-// specializations
-// Cube
-template <> bool DiscreteIntersection::testIntersection<Cube,Cube>(Cube& cube1, Cube& cube2);
-template <> int DiscreteIntersection::computeIntersection<Cube, Cube>(Cube& cube1, Cube& cube2, OutputVector* contacts);
-
-//Sphere
-template <> bool DiscreteIntersection::testIntersection<Sphere, Sphere>(Sphere& sph1, Sphere& sph2);
-template <> int DiscreteIntersection::computeIntersection<Sphere, Sphere>(Sphere& sph1, Sphere& sph2, OutputVector* contacts);
-template <> bool DiscreteIntersection::testIntersection<RigidSphere, RigidSphere>(RigidSphere& sph1, RigidSphere& sph2);
-template <> int DiscreteIntersection::computeIntersection<RigidSphere, RigidSphere>(RigidSphere& sph1, RigidSphere& sph2, OutputVector* contacts);
-template <> bool DiscreteIntersection::testIntersection<Sphere, RigidSphere>(Sphere& sph1, RigidSphere& sph2);
-template <> int DiscreteIntersection::computeIntersection<Sphere, RigidSphere>(Sphere& sph1, RigidSphere& sph2, OutputVector* contacts);
 
 } // namespace sofa::component::collision
 

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DiscreteIntersection.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DiscreteIntersection.h
@@ -44,16 +44,35 @@ public:
     core::collision::IntersectorMap intersectors;
     typedef core::collision::IntersectorFactory<DiscreteIntersection> IntersectorFactory;
 
-    template <class Elem1,class Elem2>
-    int computeIntersection(Elem1 & e1,Elem2 & e2,OutputVector* contacts){
-        return BaseIntTool::computeIntersection(e1,e2,e1.getProximity() + e2.getProximity() + getAlarmDistance(),e1.getProximity() + e2.getProximity() + getContactDistance(),contacts);
+    //Generic case
+    template <class Elem1, class Elem2>
+    bool testIntersection(Elem1& e1, Elem2& e2)
+    {
+        return BaseIntTool::testIntersection(e1, e2, this->getAlarmDistance());
     }
 
-    template <class Elem1,class Elem2>
-    bool testIntersection(Elem1& e1,Elem2& e2){
-        return BaseIntTool::testIntersection(e1,e2,this->getAlarmDistance());
+    template <class Elem1, class Elem2>
+    int computeIntersection(Elem1& e1, Elem2& e2, OutputVector* contacts)
+    {
+        return BaseIntTool::computeIntersection(e1, e2, e1.getProximity() + e2.getProximity() + getAlarmDistance(), e1.getProximity() + e2.getProximity() + getContactDistance(), contacts);
     }
 };
+
+
+// specializations
+// Cube
+template <> bool DiscreteIntersection::testIntersection<Cube,Cube>(Cube& sph1, Cube& sph2);
+template <> int DiscreteIntersection::computeIntersection<Cube, Cube>(Cube& sph1, Cube& sph2, OutputVector* contacts);
+
+//Sphere
+template <> bool DiscreteIntersection::testIntersection<Sphere, Sphere>(Sphere& sph1, Sphere& sph2);
+template <> int DiscreteIntersection::computeIntersection<Sphere, Sphere>(Sphere& sph1, Sphere& sph2, OutputVector* contacts);
+template <> bool DiscreteIntersection::testIntersection<RigidSphere, RigidSphere>(RigidSphere& sph1, RigidSphere& sph2);
+template <> int DiscreteIntersection::computeIntersection<RigidSphere, RigidSphere>(RigidSphere& sph1, RigidSphere& sph2, OutputVector* contacts);
+template <> bool DiscreteIntersection::testIntersection<Sphere, RigidSphere>(Sphere& sph1, RigidSphere& sph2);
+template <> int DiscreteIntersection::computeIntersection<Sphere, RigidSphere>(Sphere& sph1, RigidSphere& sph2, OutputVector* contacts);
+template <> bool DiscreteIntersection::testIntersection<RigidSphere, Sphere>(RigidSphere& sph1, Sphere& sph2);
+template <> int DiscreteIntersection::computeIntersection<RigidSphere, Sphere>(RigidSphere& sph1, Sphere& sph2, OutputVector* contacts);
 
 } // namespace sofa::component::collision
 

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DiscreteIntersection.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DiscreteIntersection.h
@@ -79,7 +79,7 @@ protected:
             return 0;
 
         contacts->resize(contacts->size() + 1);
-        DetectionOutput* detection = &*(contacts->end() - 1);
+        core::collision::DetectionOutput* detection = &*(contacts->end() - 1);
         SReal distSph1Sph2 = helper::rsqrt(norm2);
         detection->normal = dist / distSph1Sph2;
         detection->point[0] = sph1.getContactPointByNormal(-detection->normal);

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DiscreteIntersection.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DiscreteIntersection.h
@@ -44,6 +44,7 @@ public:
     core::collision::IntersectorMap intersectors;
     typedef core::collision::IntersectorFactory<DiscreteIntersection> IntersectorFactory;
 
+    //Intersectors
     //Generic case
     template <class Elem1, class Elem2>
     bool testIntersection(Elem1& e1, Elem2& e2)
@@ -61,8 +62,8 @@ public:
 
 // specializations
 // Cube
-template <> bool DiscreteIntersection::testIntersection<Cube,Cube>(Cube& sph1, Cube& sph2);
-template <> int DiscreteIntersection::computeIntersection<Cube, Cube>(Cube& sph1, Cube& sph2, OutputVector* contacts);
+template <> bool DiscreteIntersection::testIntersection<Cube,Cube>(Cube& cube1, Cube& cube2);
+template <> int DiscreteIntersection::computeIntersection<Cube, Cube>(Cube& cube1, Cube& cube2, OutputVector* contacts);
 
 //Sphere
 template <> bool DiscreteIntersection::testIntersection<Sphere, Sphere>(Sphere& sph1, Sphere& sph2);

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/MinProximityIntersection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/MinProximityIntersection.cpp
@@ -29,7 +29,6 @@
 #include <sofa/core/collision/Intersection.inl>
 #include <iostream>
 #include <algorithm>
-#include <SofaBaseCollision/BaseIntTool.h>
 
 #define DYNAMIC_CONE_ANGLE_COMPUTATION
 
@@ -63,6 +62,7 @@ void MinProximityIntersection::init()
 {
     intersectors.add<CubeCollisionModel, CubeCollisionModel, MinProximityIntersection>(this);
     intersectors.add<SphereCollisionModel<sofa::defaulttype::Vec3Types>, SphereCollisionModel<sofa::defaulttype::Vec3Types>, MinProximityIntersection>(this);
+
 
     IntersectorFactory::getInstance()->addIntersectors(this);
 

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/MinProximityIntersection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/MinProximityIntersection.cpp
@@ -62,13 +62,23 @@ void MinProximityIntersection::init()
 {
     intersectors.add<CubeCollisionModel, CubeCollisionModel, MinProximityIntersection>(this);
     intersectors.add<SphereCollisionModel<sofa::defaulttype::Vec3Types>, SphereCollisionModel<sofa::defaulttype::Vec3Types>, MinProximityIntersection>(this);
-
+    intersectors.add<RigidSphereModel,RigidSphereModel, MinProximityIntersection> (this);
+    intersectors.add<SphereCollisionModel<sofa::defaulttype::Vec3Types>, RigidSphereModel, MinProximityIntersection>(this);
 
     IntersectorFactory::getInstance()->addIntersectors(this);
 
 	BaseProximityIntersection::init();
 }
 
+bool MinProximityIntersection::testIntersection(Cube& cube1, Cube& cube2)
+{
+    return BaseProximityIntersection::testIntersection(cube1, cube2);
+}
+
+int MinProximityIntersection::computeIntersection(Cube& cube1, Cube& cube2, OutputVector* contacts)
+{
+    return BaseProximityIntersection::testIntersection(cube1, cube2);
+}
 
 bool MinProximityIntersection::getUseSurfaceNormals(){
     return useSurfaceNormals.getValue();
@@ -78,6 +88,45 @@ void MinProximityIntersection::draw(const core::visual::VisualParams* vparams)
 {
     if (!vparams->displayFlags().getShowCollisionModels())
         return;
+}
+
+bool MinProximityIntersection::testIntersection(Sphere& sph1, Sphere& sph2)
+{
+    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
+    return DiscreteIntersection::testIntersectionSphere(sph1, sph2, alarmDist);
+}
+
+int MinProximityIntersection::computeIntersection(Sphere& sph1, Sphere& sph2, OutputVector* contacts)
+{
+    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
+    const auto contactDist = this->getContactDistance() + sph1.getProximity() + sph2.getProximity();
+    return DiscreteIntersection::computeIntersectionSphere(sph1, sph2, contacts, alarmDist, contactDist);
+}
+
+bool MinProximityIntersection::testIntersection(Sphere& sph1, RigidSphere& sph2)
+{
+    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
+    return DiscreteIntersection::testIntersectionSphere(sph1, sph2, alarmDist);
+}
+
+int MinProximityIntersection::computeIntersection(Sphere& sph1, RigidSphere& sph2, OutputVector* contacts)
+{
+    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
+    const auto contactDist = this->getContactDistance() + sph1.getProximity() + sph2.getProximity();
+    return DiscreteIntersection::computeIntersectionSphere(sph1, sph2, contacts, alarmDist, contactDist);
+}
+
+bool MinProximityIntersection::testIntersection(RigidSphere& sph1, RigidSphere& sph2)
+{
+    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
+    return DiscreteIntersection::testIntersectionSphere(sph1, sph2, alarmDist);
+}
+
+int MinProximityIntersection::computeIntersection(RigidSphere& sph1, RigidSphere& sph2, OutputVector* contacts)
+{
+    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
+    const auto contactDist = this->getContactDistance() + sph1.getProximity() + sph2.getProximity();
+    return DiscreteIntersection::computeIntersectionSphere(sph1, sph2, contacts, alarmDist, contactDist);
 }
 
 } // namespace sofa::component::collision

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/MinProximityIntersection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/MinProximityIntersection.cpp
@@ -90,43 +90,4 @@ void MinProximityIntersection::draw(const core::visual::VisualParams* vparams)
         return;
 }
 
-bool MinProximityIntersection::testIntersection(Sphere& sph1, Sphere& sph2)
-{
-    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
-    return DiscreteIntersection::testIntersectionSphere(sph1, sph2, alarmDist);
-}
-
-int MinProximityIntersection::computeIntersection(Sphere& sph1, Sphere& sph2, OutputVector* contacts)
-{
-    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
-    const auto contactDist = this->getContactDistance() + sph1.getProximity() + sph2.getProximity();
-    return DiscreteIntersection::computeIntersectionSphere(sph1, sph2, contacts, alarmDist, contactDist);
-}
-
-bool MinProximityIntersection::testIntersection(Sphere& sph1, RigidSphere& sph2)
-{
-    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
-    return DiscreteIntersection::testIntersectionSphere(sph1, sph2, alarmDist);
-}
-
-int MinProximityIntersection::computeIntersection(Sphere& sph1, RigidSphere& sph2, OutputVector* contacts)
-{
-    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
-    const auto contactDist = this->getContactDistance() + sph1.getProximity() + sph2.getProximity();
-    return DiscreteIntersection::computeIntersectionSphere(sph1, sph2, contacts, alarmDist, contactDist);
-}
-
-bool MinProximityIntersection::testIntersection(RigidSphere& sph1, RigidSphere& sph2)
-{
-    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
-    return DiscreteIntersection::testIntersectionSphere(sph1, sph2, alarmDist);
-}
-
-int MinProximityIntersection::computeIntersection(RigidSphere& sph1, RigidSphere& sph2, OutputVector* contacts)
-{
-    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
-    const auto contactDist = this->getContactDistance() + sph1.getProximity() + sph2.getProximity();
-    return DiscreteIntersection::computeIntersectionSphere(sph1, sph2, contacts, alarmDist, contactDist);
-}
-
 } // namespace sofa::component::collision

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/MinProximityIntersection.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/MinProximityIntersection.h
@@ -52,12 +52,19 @@ public:
     bool testIntersection(Cube& cube1, Cube& cube2);
     int computeIntersection(Cube& cube1, Cube& cube2, OutputVector* contacts);
 
-    bool testIntersection(Sphere& sph1, Sphere& sph2);
-    int computeIntersection(Sphere& sph1, Sphere& sph2, OutputVector* contacts);
-    bool testIntersection(Sphere& sph1, RigidSphere& sph2);
-    int computeIntersection(Sphere& sph1, RigidSphere& sph2, OutputVector* contacts);
-    bool testIntersection(RigidSphere& sph1, RigidSphere& sph2);
-    int computeIntersection(RigidSphere& sph1, RigidSphere& sph2, OutputVector* contacts);
+    template<typename SphereType1, typename SphereType2>
+    bool testIntersection(SphereType1& sph1, SphereType2& sph2)
+    {
+        const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
+        return DiscreteIntersection::testIntersectionSphere(sph1, sph2, alarmDist);
+    }
+    template<typename SphereType1, typename SphereType2>
+    int computeIntersection(SphereType1& sph1, SphereType2& sph2, OutputVector* contacts)
+    {
+        const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
+        const auto contactDist = this->getContactDistance() + sph1.getProximity() + sph2.getProximity();
+        return DiscreteIntersection::computeIntersectionSphere(sph1, sph2, contacts, alarmDist, contactDist);
+    }
 
 private:
     SReal mainAlarmDistance;

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/MinProximityIntersection.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/MinProximityIntersection.h
@@ -49,6 +49,16 @@ public:
 
     void draw(const core::visual::VisualParams* vparams) override;
 
+    bool testIntersection(Cube& cube1, Cube& cube2);
+    int computeIntersection(Cube& cube1, Cube& cube2, OutputVector* contacts);
+
+    bool testIntersection(Sphere& sph1, Sphere& sph2);
+    int computeIntersection(Sphere& sph1, Sphere& sph2, OutputVector* contacts);
+    bool testIntersection(Sphere& sph1, RigidSphere& sph2);
+    int computeIntersection(Sphere& sph1, RigidSphere& sph2, OutputVector* contacts);
+    bool testIntersection(RigidSphere& sph1, RigidSphere& sph2);
+    int computeIntersection(RigidSphere& sph1, RigidSphere& sph2, OutputVector* contacts);
+
 private:
     SReal mainAlarmDistance;
     SReal mainContactDistance;

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/NewProximityIntersection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/NewProximityIntersection.cpp
@@ -51,10 +51,61 @@ void NewProximityIntersection::init()
 {
     intersectors.add<CubeCollisionModel, CubeCollisionModel, NewProximityIntersection>(this);
     intersectors.add<SphereCollisionModel<sofa::defaulttype::Vec3Types>, SphereCollisionModel<sofa::defaulttype::Vec3Types>, NewProximityIntersection>(this);
+    intersectors.add<RigidSphereModel, RigidSphereModel, NewProximityIntersection>(this);
+    intersectors.add<SphereCollisionModel<sofa::defaulttype::Vec3Types>, RigidSphereModel, NewProximityIntersection>(this);
 
     IntersectorFactory::getInstance()->addIntersectors(this);
 
 	BaseProximityIntersection::init();
+}
+
+bool NewProximityIntersection::testIntersection(Cube& cube1, Cube& cube2)
+{
+    return BaseProximityIntersection::testIntersection(cube1, cube2);
+}
+
+int NewProximityIntersection::computeIntersection(Cube& cube1, Cube& cube2, OutputVector* contacts) 
+{ 
+    return BaseProximityIntersection::testIntersection(cube1, cube2); 
+}
+
+bool NewProximityIntersection::testIntersection(Sphere& sph1, Sphere& sph2)
+{
+    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
+    return testIntersectionSphere(sph1, sph2, alarmDist);
+}
+
+int NewProximityIntersection::computeIntersection(Sphere& sph1, Sphere& sph2, OutputVector* contacts)
+{
+    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
+    const auto contactDist = this->getContactDistance() + sph1.getProximity() + sph2.getProximity();
+    return computeIntersectionSphere(sph1, sph2, contacts, alarmDist, contactDist);
+}
+
+bool NewProximityIntersection::testIntersection(Sphere& sph1, RigidSphere& sph2)
+{
+    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
+    return testIntersectionSphere(sph1, sph2, alarmDist);
+}
+
+int NewProximityIntersection::computeIntersection(Sphere& sph1, RigidSphere& sph2, OutputVector* contacts)
+{
+    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
+    const auto contactDist = this->getContactDistance() + sph1.getProximity() + sph2.getProximity();
+    return computeIntersectionSphere(sph1, sph2, contacts, alarmDist, contactDist);
+}
+
+bool NewProximityIntersection::testIntersection(RigidSphere& sph1, RigidSphere& sph2)
+{
+    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
+    return testIntersectionSphere(sph1, sph2, alarmDist);
+}
+
+int NewProximityIntersection::computeIntersection(RigidSphere& sph1, RigidSphere& sph2, OutputVector* contacts)
+{
+    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
+    const auto contactDist = this->getContactDistance() + sph1.getProximity() + sph2.getProximity();
+    return computeIntersectionSphere(sph1, sph2, contacts, alarmDist, contactDist);
 }
 
 } // namespace sofa::component::collision

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/NewProximityIntersection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/NewProximityIntersection.cpp
@@ -69,43 +69,5 @@ int NewProximityIntersection::computeIntersection(Cube& cube1, Cube& cube2, Outp
     return BaseProximityIntersection::testIntersection(cube1, cube2); 
 }
 
-bool NewProximityIntersection::testIntersection(Sphere& sph1, Sphere& sph2)
-{
-    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
-    return testIntersectionSphere(sph1, sph2, alarmDist);
-}
-
-int NewProximityIntersection::computeIntersection(Sphere& sph1, Sphere& sph2, OutputVector* contacts)
-{
-    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
-    const auto contactDist = this->getContactDistance() + sph1.getProximity() + sph2.getProximity();
-    return computeIntersectionSphere(sph1, sph2, contacts, alarmDist, contactDist);
-}
-
-bool NewProximityIntersection::testIntersection(Sphere& sph1, RigidSphere& sph2)
-{
-    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
-    return testIntersectionSphere(sph1, sph2, alarmDist);
-}
-
-int NewProximityIntersection::computeIntersection(Sphere& sph1, RigidSphere& sph2, OutputVector* contacts)
-{
-    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
-    const auto contactDist = this->getContactDistance() + sph1.getProximity() + sph2.getProximity();
-    return computeIntersectionSphere(sph1, sph2, contacts, alarmDist, contactDist);
-}
-
-bool NewProximityIntersection::testIntersection(RigidSphere& sph1, RigidSphere& sph2)
-{
-    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
-    return testIntersectionSphere(sph1, sph2, alarmDist);
-}
-
-int NewProximityIntersection::computeIntersection(RigidSphere& sph1, RigidSphere& sph2, OutputVector* contacts)
-{
-    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
-    const auto contactDist = this->getContactDistance() + sph1.getProximity() + sph2.getProximity();
-    return computeIntersectionSphere(sph1, sph2, contacts, alarmDist, contactDist);
-}
 
 } // namespace sofa::component::collision

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/NewProximityIntersection.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/NewProximityIntersection.h
@@ -44,41 +44,13 @@ public:
     bool testIntersection(Cube& cube1, Cube& cube2);
     int computeIntersection(Cube& cube1, Cube& cube2, OutputVector* contacts);
 
-    bool testIntersection(Sphere& sph1, Sphere& sph2);
-    int computeIntersection(Sphere& sph1, Sphere& sph2, OutputVector* contacts);
-    bool testIntersection(Sphere& sph1, RigidSphere& sph2);
-    int computeIntersection(Sphere& sph1, RigidSphere& sph2, OutputVector* contacts);
-    bool testIntersection(RigidSphere& sph1, RigidSphere& sph2);
-    int computeIntersection(RigidSphere& sph1, RigidSphere& sph2, OutputVector* contacts);
+    template<typename SphereType1, typename SphereType2>
+    bool testIntersection(SphereType1& sph1, SphereType2& sph2);
+    template<typename SphereType1, typename SphereType2>
+    int computeIntersection(SphereType1& sph1, SphereType2& sph2, OutputVector* contacts);
 
 protected:
     NewProximityIntersection();
-
-    template<class SphereType1, class SphereType2>
-    bool testIntersectionSphere(SphereType1& sph1, SphereType2& sph2, const SReal alarmDist)
-    {
-        OutputVector contacts;
-        const double alarmDist2 = alarmDist + sph1.r() + sph2.r();
-        int n = doIntersectionPointPoint(alarmDist2 * alarmDist2, sph1.center(), sph2.center(), &contacts, -1);
-        return n > 0;
-    }
-
-    template<class SphereType1, class SphereType2>
-    int computeIntersectionSphere(SphereType1& sph1, SphereType2& sph2, DiscreteIntersection::OutputVector* contacts, const SReal alarmDist, const SReal contactDist)
-    {
-        const double alarmDist2 = alarmDist + sph1.r() + sph2.r();
-        int n = doIntersectionPointPoint(alarmDist2 * alarmDist2, sph1.center(), sph2.center(), contacts, (sph1.getCollisionModel()->getSize() > sph2.getCollisionModel()->getSize()) ? sph1.getIndex() : sph2.getIndex());
-        if (n > 0)
-        {
-            const double contactDist2 = contactDist + sph1.r() + sph2.r();
-            for (OutputVector::iterator detection = contacts->end() - n; detection != contacts->end(); ++detection)
-            {
-                detection->elem = std::pair<core::CollisionElementIterator, core::CollisionElementIterator>(sph1, sph2);
-                detection->value -= contactDist2;
-            }
-        }
-        return n;
-    }
 
 };
 

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/NewProximityIntersection.inl
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/NewProximityIntersection.inl
@@ -50,5 +50,36 @@ inline int NewProximityIntersection::doIntersectionPointPoint(SReal dist2, const
     return 1;
 }
 
+template<typename SphereType1, typename SphereType2>
+bool NewProximityIntersection::testIntersection(SphereType1& sph1, SphereType2& sph2)
+{
+    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
+
+    OutputVector contacts;
+    const double alarmDist2 = alarmDist + sph1.r() + sph2.r();
+    int n = doIntersectionPointPoint(alarmDist2 * alarmDist2, sph1.center(), sph2.center(), &contacts, -1);
+    return n > 0;
+}
+
+template<typename SphereType1, typename SphereType2>
+int NewProximityIntersection::computeIntersection(SphereType1& sph1, SphereType2& sph2, OutputVector* contacts)
+{
+    const auto alarmDist = this->getAlarmDistance() + sph1.getProximity() + sph2.getProximity();
+    const auto contactDist = this->getContactDistance() + sph1.getProximity() + sph2.getProximity();
+
+    const double alarmDist2 = alarmDist + sph1.r() + sph2.r();
+    int n = doIntersectionPointPoint(alarmDist2 * alarmDist2, sph1.center(), sph2.center(), contacts, (sph1.getCollisionModel()->getSize() > sph2.getCollisionModel()->getSize()) ? sph1.getIndex() : sph2.getIndex());
+    if (n > 0)
+    {
+        const double contactDist2 = contactDist + sph1.r() + sph2.r();
+        for (OutputVector::iterator detection = contacts->end() - n; detection != contacts->end(); ++detection)
+        {
+            detection->elem = std::pair<core::CollisionElementIterator, core::CollisionElementIterator>(sph1, sph2);
+            detection->value -= contactDist2;
+        }
+    }
+    return n;
+}
+
 
 } // namespace sofa::component::collision

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/MeshNewProximityIntersection.cpp
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/MeshNewProximityIntersection.cpp
@@ -38,19 +38,56 @@ MeshNewProximityIntersection::MeshNewProximityIntersection(NewProximityIntersect
     if (addSelf)
     {
         intersection->intersectors.add<PointCollisionModel<sofa::defaulttype::Vec3Types>, PointCollisionModel<sofa::defaulttype::Vec3Types>, MeshNewProximityIntersection>(this);
-        intersection->intersectors.add<SphereCollisionModel<sofa::defaulttype::Vec3Types>, PointCollisionModel<sofa::defaulttype::Vec3Types>, MeshNewProximityIntersection>(this);
         intersection->intersectors.add<LineCollisionModel<sofa::defaulttype::Vec3Types>, PointCollisionModel<sofa::defaulttype::Vec3Types>, MeshNewProximityIntersection>(this);
-        intersection->intersectors.add<LineCollisionModel<sofa::defaulttype::Vec3Types>, SphereCollisionModel<sofa::defaulttype::Vec3Types>, MeshNewProximityIntersection>(this);
         intersection->intersectors.add<LineCollisionModel<sofa::defaulttype::Vec3Types>, LineCollisionModel<sofa::defaulttype::Vec3Types>, MeshNewProximityIntersection>(this);
         intersection->intersectors.add<TriangleCollisionModel<sofa::defaulttype::Vec3Types>, PointCollisionModel<sofa::defaulttype::Vec3Types>, MeshNewProximityIntersection>(this);
-        intersection->intersectors.add<TriangleCollisionModel<sofa::defaulttype::Vec3Types>, SphereCollisionModel<sofa::defaulttype::Vec3Types>, MeshNewProximityIntersection>(this);
         intersection->intersectors.add<TriangleCollisionModel<sofa::defaulttype::Vec3Types>, LineCollisionModel<sofa::defaulttype::Vec3Types>, MeshNewProximityIntersection>(this);
         intersection->intersectors.add<TriangleCollisionModel<sofa::defaulttype::Vec3Types>, TriangleCollisionModel<sofa::defaulttype::Vec3Types>, MeshNewProximityIntersection>(this);
-        
+
+        intersection->intersectors.add<SphereCollisionModel<sofa::defaulttype::Vec3Types>, PointCollisionModel<sofa::defaulttype::Vec3Types>, MeshNewProximityIntersection>(this);
         intersection->intersectors.add<RigidSphereModel, PointCollisionModel<sofa::defaulttype::Vec3Types>, MeshNewProximityIntersection>(this);
         intersection->intersectors.add<LineCollisionModel<sofa::defaulttype::Vec3Types>, RigidSphereModel, MeshNewProximityIntersection>(this);
+        intersection->intersectors.add<LineCollisionModel<sofa::defaulttype::Vec3Types>, SphereCollisionModel<sofa::defaulttype::Vec3Types>, MeshNewProximityIntersection>(this);
         intersection->intersectors.add<TriangleCollisionModel<sofa::defaulttype::Vec3Types>, RigidSphereModel, MeshNewProximityIntersection>(this);
+        intersection->intersectors.add<TriangleCollisionModel<sofa::defaulttype::Vec3Types>, SphereCollisionModel<sofa::defaulttype::Vec3Types>, MeshNewProximityIntersection>(this);
+
     }
+}
+
+bool MeshNewProximityIntersection::testIntersection(Point& pt1, Point& pt2)
+{
+
+    return false;
+}
+
+bool MeshNewProximityIntersection::testIntersection(Line& line, Point& pt)
+{
+
+    return false;
+}
+
+bool MeshNewProximityIntersection::testIntersection(Line& line1, Line& line2)
+{
+
+    return false;
+}
+
+bool MeshNewProximityIntersection::testIntersection(Triangle& tri, Point& pt)
+{
+
+    return false;
+}
+
+bool MeshNewProximityIntersection::testIntersection(Triangle& tri, Line& line)
+{
+
+    return false;
+}
+
+bool MeshNewProximityIntersection::testIntersection(Triangle& tri1, Triangle& tri2)
+{
+
+    return false;
 }
 
 int MeshNewProximityIntersection::computeIntersection(Point& e1, Point& e2, OutputVector* contacts)

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/MeshNewProximityIntersection.h
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/MeshNewProximityIntersection.h
@@ -39,36 +39,35 @@ class SOFA_SOFAMESHCOLLISION_API MeshNewProximityIntersection : public core::col
 public:
     MeshNewProximityIntersection(NewProximityIntersection* object, bool addSelf=true);
 
-
-    template <class T1,class T2>
-    bool testIntersection(T1 & e1,T2 & e2){
-        return BaseIntTool::testIntersection(e1,e2,intersection->getAlarmDistance());
-    }
-
-
+    bool testIntersection(Point&, Point&);
     int computeIntersection(Point&, Point&, OutputVector*);
-    template <class T> int computeIntersection(TSphere<T>&, Point&, OutputVector*);
+    bool testIntersection(Line&, Point&);
     int computeIntersection(Line&, Point&, OutputVector*);
-    template <class T> int computeIntersection(Line&, TSphere<T>&, OutputVector*);
+    bool testIntersection(Line&, Line&);
     int computeIntersection(Line&, Line&, OutputVector*);
+    bool testIntersection(Triangle&, Point&);
     int computeIntersection(Triangle&, Point&, OutputVector*);
-
-    template <class T> int computeIntersection(Triangle&, TSphere<T>&, OutputVector*);
+    bool testIntersection(Triangle&, Line&);
     int computeIntersection(Triangle&, Line&, OutputVector*);
-
+    bool testIntersection(Triangle&, Triangle&);
     int computeIntersection(Triangle&, Triangle&, OutputVector*);
 
-    template <class T1,class T2>
-    int computeIntersection(T1 & e1,T2 & e2,OutputVector* contacts){
-        return MeshIntTool::computeIntersection(e1,e2,e1.getProximity() + e2.getProximity() + intersection->getAlarmDistance(),e1.getProximity() + e2.getProximity() + intersection->getContactDistance(),contacts);
-    }
+    template <class T>
+    bool testIntersection(TSphere<T>& sph, Point& pt);
+    template <class T> 
+    int computeIntersection(TSphere<T>& sph, Point& pt, OutputVector*);
+    template <class T>
+    bool testIntersection(Line&, TSphere<T>&);
+    template <class T> 
+    int computeIntersection(Line& line, TSphere<T>& sph, OutputVector*);
+    template <class T>
+    bool testIntersection(Triangle&, TSphere<T>&);
+    template <class T> 
+    int computeIntersection(Triangle& tri, TSphere<T>& sph, OutputVector*);
 
     static inline int doIntersectionLineLine(SReal dist2, const defaulttype::Vector3& p1, const defaulttype::Vector3& p2, const defaulttype::Vector3& q1, const defaulttype::Vector3& q2, OutputVector* contacts, int id, const defaulttype::Vector3& n=defaulttype::Vector3(), bool useNormal=false);
-
     static inline int doIntersectionLinePoint(SReal dist2, const defaulttype::Vector3& p1, const defaulttype::Vector3& p2, const defaulttype::Vector3& q, OutputVector* contacts, int id, bool swapElems = false);
-
     static inline int doIntersectionTrianglePoint(SReal dist2, int flags, const defaulttype::Vector3& p1, const defaulttype::Vector3& p2, const defaulttype::Vector3& p3, const defaulttype::Vector3& n, const defaulttype::Vector3& q, OutputVector* contacts, int id, bool swapElems = false, bool useNormal=false);
-
     static inline int doIntersectionTrianglePoint2(SReal dist2, int flags, const defaulttype::Vector3& p1, const defaulttype::Vector3& p2, const defaulttype::Vector3& p3, const defaulttype::Vector3& n, const defaulttype::Vector3& q, OutputVector* contacts, int id, bool swapElems = false);
 
 protected:

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/MeshNewProximityIntersection.h
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/MeshNewProximityIntersection.h
@@ -25,9 +25,7 @@
 #include <SofaBaseCollision/NewProximityIntersection.h>
 #include <SofaMeshCollision/TriangleModel.h>
 #include <SofaMeshCollision/LineModel.h>
-#include <SofaMeshCollision/MeshIntTool.h>
-#include <SofaBaseCollision/IntrUtility3.h>
-#include <SofaBaseCollision/BaseIntTool.h>
+#include <SofaMeshCollision/PointModel.h>
 
 namespace sofa::component::collision
 {

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/MeshNewProximityIntersection.inl
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/MeshNewProximityIntersection.inl
@@ -27,6 +27,8 @@
 #include <sofa/defaulttype/Vec.h>
 #include <sofa/core/collision/Intersection.inl>
 
+#include <SofaBaseCollision/IntrUtility3.inl>
+
 namespace sofa::component::collision
 {
 

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/MeshNewProximityIntersection.inl
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/MeshNewProximityIntersection.inl
@@ -290,6 +290,15 @@ inline int MeshNewProximityIntersection::doIntersectionTrianglePoint(SReal dist2
     return 1;
 }
 
+template <class T>
+bool MeshNewProximityIntersection::testIntersection(TSphere<T>& e1, Point& e2)
+{
+    OutputVector contacts;
+    const double alarmDist = intersection->getAlarmDistance() + e1.getProximity() + e2.getProximity() + e1.r();
+    int n = intersection->doIntersectionPointPoint(alarmDist * alarmDist, e1.center(), e2.p(), &contacts, -1);
+    return n > 0;
+}
+
 template<class T>
 int MeshNewProximityIntersection::computeIntersection(TSphere<T>& e1, Point& e2, OutputVector* contacts)
 {
@@ -307,6 +316,16 @@ int MeshNewProximityIntersection::computeIntersection(TSphere<T>& e1, Point& e2,
     return n;
 }
 
+template <class T>
+bool MeshNewProximityIntersection::testIntersection(Line& e1, TSphere<T>& e2)
+{
+    SOFA_UNUSED(e1);
+    SOFA_UNUSED(e2);
+
+    msg_warning(intersection) << "Unnecessary call to NewProximityIntersection::testIntersection(Line,Sphere).";
+    return true;
+}
+
 template<class T>
 int MeshNewProximityIntersection::computeIntersection(Line& e1, TSphere<T>& e2, OutputVector* contacts)
 {
@@ -322,6 +341,16 @@ int MeshNewProximityIntersection::computeIntersection(Line& e1, TSphere<T>& e2, 
         }
     }
     return n;
+}
+
+template <class T>
+bool MeshNewProximityIntersection::testIntersection(Triangle& e1, TSphere<T>& e2)
+{
+    SOFA_UNUSED(e1);
+    SOFA_UNUSED(e2);
+
+    msg_warning(intersection) << "Unnecessary call to NewProximityIntersection::testIntersection(Triangle,Sphere).";
+    return true;
 }
 
 template<class T>

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
@@ -116,7 +116,7 @@ public:
         using CudaSphereCollisionModel = sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>;
 
         sofa::component::collision::NewProximityIntersection::init();
-        intersectors.add<CudaSphereCollisionModel, CudaSphereCollisionModel,   DiscreteIntersection>(this);
+        intersectors.add<CudaSphereCollisionModel, CudaSphereCollisionModel, NewProximityIntersection>(this);
         RayDiscreteIntersection* rayIntersector = new RayDiscreteIntersection(this, false);
         intersectors.add<RayCollisionModel,        CudaSphereCollisionModel,   RayDiscreteIntersection>(rayIntersector);
         MeshNewProximityIntersection* meshIntersector = new MeshNewProximityIntersection(this, false);

--- a/applications/plugins/SofaMiscCollision/CMakeLists.txt
+++ b/applications/plugins/SofaMiscCollision/CMakeLists.txt
@@ -39,18 +39,18 @@ list(APPEND HEADER_FILES
     ${SRC_ROOT}/TetrahedronDiscreteIntersection.h
     ${SRC_ROOT}/TetrahedronModel.h
     ${SRC_ROOT}/TriangleModelInRegularGrid.h
+    ${SRC_ROOT}/CapsuleContactMapper.h
+    ${SRC_ROOT}/OBBContactMapper.h
     )
 
 list(APPEND SOURCE_FILES
     ${SRC_ROOT}/BarycentricStickContact.cpp
     ${SRC_ROOT}/CapsuleIntersection.cpp
     ${SRC_ROOT}/CapsuleContact.cpp
-    ${SRC_ROOT}/CapsuleContactMapper.h
     ${SRC_ROOT}/CapsuleContactMapper.cpp
     ${SRC_ROOT}/DefaultCollisionGroupManager.cpp
     ${SRC_ROOT}/OBBIntersection.cpp
     ${SRC_ROOT}/OBBContact.cpp
-    ${SRC_ROOT}/OBBContactMapper.h
     ${SRC_ROOT}/OBBContactMapper.cpp
     ${SRC_ROOT}/RayTriangleVisitor.cpp
     ${SRC_ROOT}/RuleBasedContactManager.cpp

--- a/applications/plugins/SofaMiscCollision/CMakeLists.txt
+++ b/applications/plugins/SofaMiscCollision/CMakeLists.txt
@@ -47,10 +47,12 @@ list(APPEND SOURCE_FILES
     ${SRC_ROOT}/BarycentricStickContact.cpp
     ${SRC_ROOT}/CapsuleIntersection.cpp
     ${SRC_ROOT}/CapsuleContact.cpp
+    ${SRC_ROOT}/CapsuleContactMapper.h
     ${SRC_ROOT}/CapsuleContactMapper.cpp
     ${SRC_ROOT}/DefaultCollisionGroupManager.cpp
     ${SRC_ROOT}/OBBIntersection.cpp
     ${SRC_ROOT}/OBBContact.cpp
+    ${SRC_ROOT}/OBBContactMapper.h
     ${SRC_ROOT}/OBBContactMapper.cpp
     ${SRC_ROOT}/RayTriangleVisitor.cpp
     ${SRC_ROOT}/RuleBasedContactManager.cpp

--- a/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/CapsuleContact.cpp
+++ b/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/CapsuleContact.cpp
@@ -19,14 +19,13 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-
+#include <SofaBaseCollision/CapsuleModel.h>
+#include <SofaBaseCollision/RigidCapsuleModel.h>
 #include <SofaBaseCollision/OBBModel.h>
 #include <SofaMiscCollision/OBBContactMapper.h>
 #include <SofaMiscCollision/CapsuleContactMapper.h>
 #include <SofaMeshCollision/BarycentricPenalityContact.inl>
 #include <SofaConstraint/FrictionContact.inl>
-#include <SofaBaseCollision/CapsuleModel.h>
-#include <SofaBaseCollision/RigidCapsuleModel.h>
 
 using namespace sofa::core::collision;
 

--- a/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/CapsuleContact.cpp
+++ b/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/CapsuleContact.cpp
@@ -19,13 +19,14 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <SofaBaseCollision/CapsuleModel.h>
-#include <SofaBaseCollision/RigidCapsuleModel.h>
+
 #include <SofaBaseCollision/OBBModel.h>
 #include <SofaMiscCollision/OBBContactMapper.h>
 #include <SofaMiscCollision/CapsuleContactMapper.h>
 #include <SofaMeshCollision/BarycentricPenalityContact.inl>
 #include <SofaConstraint/FrictionContact.inl>
+#include <SofaBaseCollision/CapsuleModel.h>
+#include <SofaBaseCollision/RigidCapsuleModel.h>
 
 using namespace sofa::core::collision;
 

--- a/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/CapsuleContactMapper.cpp
+++ b/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/CapsuleContactMapper.cpp
@@ -26,7 +26,6 @@
 #include <SofaMeshCollision/RigidContactMapper.inl>
 #include <SofaBaseCollision/CapsuleModel.h>
 #include <SofaBaseCollision/RigidCapsuleModel.h>
-#include <SofaConstraint/FrictionContact.inl>
 
 using namespace sofa::core::collision;
 

--- a/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/CapsuleContactMapper.cpp
+++ b/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/CapsuleContactMapper.cpp
@@ -26,12 +26,12 @@
 #include <SofaMeshCollision/RigidContactMapper.inl>
 #include <SofaBaseCollision/CapsuleModel.h>
 #include <SofaBaseCollision/RigidCapsuleModel.h>
+#include <SofaConstraint/FrictionContact.inl>
 
 using namespace sofa::core::collision;
 
 namespace sofa::component::collision
 {
-
 
 ContactMapperCreator< ContactMapper<CapsuleCollisionModel<sofa::defaulttype::Vec3Types>> > CapsuleContactMapperClass("default", true);
 ContactMapperCreator< ContactMapper<CapsuleCollisionModel<sofa::defaulttype::Rigid3Types>, sofa::defaulttype::Vec3Types> > RigidCapsuleContactMapperClass("default", true);

--- a/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/CapsuleIntersection.cpp
+++ b/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/CapsuleIntersection.cpp
@@ -26,6 +26,7 @@
 
 #include <SofaBaseCollision/CapsuleModel.h>
 #include <SofaBaseCollision/RigidCapsuleModel.h>
+#include <SofaBaseCollision/OBBModel.h>
 #include <SofaBaseCollision/SphereModel.h>
 #include <SofaUserInteraction/RayModel.h>
 

--- a/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/CapsuleIntersection.h
+++ b/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/CapsuleIntersection.h
@@ -27,6 +27,9 @@
 #include <SofaBaseCollision/DiscreteIntersection.h>
 #include <SofaBaseCollision/MinProximityIntersection.h>
 #include <SofaBaseCollision/NewProximityIntersection.h>
+#include <SofaBaseCollision/CapsuleModel.h>
+#include <SofaBaseCollision/BaseIntTool.h>
+#include <SofaMeshCollision/MeshIntTool.h>
 #include <SofaMeshCollision/MeshNewProximityIntersection.h>
 
 namespace sofa::component::collision

--- a/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/CapsuleIntersection.h
+++ b/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/CapsuleIntersection.h
@@ -83,7 +83,6 @@ public:
     bool testIntersection(Capsule&, Triangle&) { return true; }
     bool testIntersection(Capsule&, Line&) { return true; }
 
-protected:
     NewProximityIntersection* intersection;
 
 };

--- a/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/CapsuleIntersection.h
+++ b/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/CapsuleIntersection.h
@@ -83,6 +83,7 @@ public:
     bool testIntersection(Capsule&, Triangle&) { return true; }
     bool testIntersection(Capsule&, Line&) { return true; }
 
+protected:
     NewProximityIntersection* intersection;
 
 };

--- a/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/OBBContact.cpp
+++ b/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/OBBContact.cpp
@@ -46,4 +46,5 @@ Creator<Contact::Factory, FrictionContact<TriangleCollisionModel<sofa::defaultty
 Creator<Contact::Factory, FrictionContact<RigidSphereModel, OBBCollisionModel<sofa::defaulttype::Rigid3Types>> > RigidSphereOBBFrictionContactClass("FrictionContact", true);
 
 Creator<Contact::Factory, RayContact<OBBCollisionModel<sofa::defaulttype::Rigid3Types>> > RayRigidBoxContactClass("ray", true); //cast not wroking
+
 } // namespace sofa::component::collision

--- a/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/OBBContact.cpp
+++ b/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/OBBContact.cpp
@@ -47,4 +47,5 @@ Creator<Contact::Factory, FrictionContact<RigidSphereModel, OBBCollisionModel<so
 
 Creator<Contact::Factory, RayContact<OBBCollisionModel<sofa::defaulttype::Rigid3Types>> > RayRigidBoxContactClass("ray", true); //cast not wroking
 
+
 } // namespace sofa::component::collision

--- a/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/OBBContact.cpp
+++ b/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/OBBContact.cpp
@@ -47,5 +47,4 @@ Creator<Contact::Factory, FrictionContact<RigidSphereModel, OBBCollisionModel<so
 
 Creator<Contact::Factory, RayContact<OBBCollisionModel<sofa::defaulttype::Rigid3Types>> > RayRigidBoxContactClass("ray", true); //cast not wroking
 
-
 } // namespace sofa::component::collision

--- a/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/OBBContactMapper.cpp
+++ b/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/OBBContactMapper.cpp
@@ -24,7 +24,6 @@
 
 #include <SofaMeshCollision/BarycentricContactMapper.inl>
 #include <SofaMeshCollision/RigidContactMapper.inl>
-#include <SofaConstraint/FrictionContact.inl>
 #include <SofaBaseCollision/OBBModel.h>
 
 using namespace sofa::core::collision;

--- a/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/OBBContactMapper.cpp
+++ b/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/OBBContactMapper.cpp
@@ -24,6 +24,7 @@
 
 #include <SofaMeshCollision/BarycentricContactMapper.inl>
 #include <SofaMeshCollision/RigidContactMapper.inl>
+#include <SofaConstraint/FrictionContact.inl>
 #include <SofaBaseCollision/OBBModel.h>
 
 using namespace sofa::core::collision;

--- a/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/OBBIntersection.h
+++ b/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/OBBIntersection.h
@@ -25,10 +25,11 @@
 #include <sofa/core/collision/Intersection.h>
 
 #include <SofaBaseCollision/DiscreteIntersection.h>
-#include <SofaMeshCollision/MeshNewProximityIntersection.h>
-
-#include <SofaUserInteraction/RayModel.h>
 #include <SofaBaseCollision/OBBModel.h>
+#include <SofaBaseCollision/BaseIntTool.h>
+#include <SofaMeshCollision/MeshIntTool.h>
+#include <SofaMeshCollision/MeshNewProximityIntersection.h>
+#include <SofaUserInteraction/RayModel.h>
 
 namespace sofa::component::collision
 {

--- a/applications/plugins/SofaTest/BroadPhase_test.h
+++ b/applications/plugins/SofaTest/BroadPhase_test.h
@@ -5,7 +5,7 @@
 #include <SofaBaseCollision/NewProximityIntersection.h>
 #include <sofa/simulation/Node.h>
 #include <SofaSimulationGraph/DAGNode.h>
-
+#include <SofaBaseCollision/OBBModel.h>
 #include <gtest/gtest.h>
 
 typedef sofa::component::container::MechanicalObject<sofa::defaulttype::Vec3Types> MechanicalObject3;

--- a/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/MeshDiscreteIntersection.cpp
+++ b/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/MeshDiscreteIntersection.cpp
@@ -22,9 +22,6 @@
 #include <SofaGeneralMeshCollision/MeshDiscreteIntersection.inl>
 
 #include <sofa/core/collision/Intersection.inl>
-#include <sofa/helper/proximity.h>
-#include <iostream>
-#include <algorithm>
 #include <sofa/core/collision/IntersectorFactory.h>
 
 namespace sofa::component::collision

--- a/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/MeshDiscreteIntersection.h
+++ b/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/MeshDiscreteIntersection.h
@@ -25,21 +25,18 @@
 
 #include <sofa/core/collision/Intersection.h>
 
-#include <SofaBaseCollision/SphereModel.h>
-#include <SofaMeshCollision/PointModel.h>
 #include <SofaMeshCollision/LineModel.h>
 #include <SofaMeshCollision/TriangleModel.h>
-#include <SofaBaseCollision/CubeModel.h>
-#include <SofaBaseCollision/DiscreteIntersection.h>
-#include <SofaMeshCollision/MeshIntTool.h>
+#include <SofaBaseCollision/SphereModel.h>
 
 namespace sofa::component::collision
 {
 
+class DiscreteIntersection;
+
 class SOFA_SOFAGENERALMESHCOLLISION_API MeshDiscreteIntersection : public core::collision::BaseIntersector
 {
-
-    typedef DiscreteIntersection::OutputVector OutputVector;
+    typedef core::collision::BaseIntersector::OutputVector OutputVector;
 
 public:
     MeshDiscreteIntersection(DiscreteIntersection* object, bool addSelf=true);
@@ -51,7 +48,6 @@ public:
     template<class T> int computeIntersection(TSphere<T>&, Triangle&, OutputVector*);
 
 protected:
-
     DiscreteIntersection* intersection;
 
 };

--- a/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/MeshDiscreteIntersection.inl
+++ b/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/MeshDiscreteIntersection.inl
@@ -22,12 +22,7 @@
 #pragma once
 
 #include <SofaGeneralMeshCollision/MeshDiscreteIntersection.h>
-#include <sofa/core/visual/VisualParams.h>
-#include <sofa/core/ObjectFactory.h>
-#include <sofa/helper/proximity.h>
-#include <iostream>
-#include <algorithm>
-
+#include <SofaBaseCollision/DiscreteIntersection.h>
 
 namespace sofa::component::collision
 {

--- a/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/MeshMinProximityIntersection.cpp
+++ b/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/MeshMinProximityIntersection.cpp
@@ -23,9 +23,6 @@
 
 #include <SofaBaseCollision/DiscreteIntersection.h>
 #include <sofa/core/collision/Intersection.inl>
-#include <sofa/helper/proximity.h>
-#include <iostream>
-#include <algorithm>
 #include <sofa/core/collision/IntersectorFactory.h>
 
 

--- a/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/MeshMinProximityIntersection.h
+++ b/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/MeshMinProximityIntersection.h
@@ -24,13 +24,11 @@
 #include <SofaGeneralMeshCollision/config.h>
 
 #include <SofaBaseCollision/MinProximityIntersection.h>
-#include <SofaMeshCollision/MeshIntTool.h>
 #include <SofaBaseCollision/SphereModel.h>
 #include <SofaMeshCollision/TriangleModel.h>
 #include <SofaMeshCollision/LineModel.h>
 #include <SofaMeshCollision/PointModel.h>
 #include <SofaBaseCollision/CubeModel.h>
-#include <SofaBaseCollision/IntrUtility3.h>
 
 namespace sofa::component::collision
 {


### PR DESCRIPTION
This follows #2073 

BaseIntTool/MeshIntTool (and their friends IntrUtility stuff) was mostly created to handle OBB/Capsule.
Their design is quite weird (at least to me) and it is [based on a code copied from GeometricTools](https://github.com/sofa-framework/sofa/blob/44001a4da752dc91078b8e10ca035e07845ecb66/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/IntrUtility3.h#L22) (so the copyright/licensing is nebulous in the best case).

This PR makes SofaBaseCollision to not rely at all on those code, mainly to revert back the code from a long time ago.
It fixes also the fact that DiscreteIntersection was using proximities for the  various computeIntersection() [1st error], but not using proximities in the various testIntersection in the proximities-based Intersections [2nd error]



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
