### PR TITLE
[SofaUserInteraction] Refactor PickParticlePerformer

### DIFF
--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
@@ -73,11 +73,11 @@ template class SOFA_GPU_CUDA_API FixParticlePerformer< CudaVec3dTypes >;
 
 ContactMapperCreator< ContactMapper<sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>> > CudaSphereContactMapperClass("default",true);
 
-#ifdef _MSC_VER
+#ifdef WIN32
 template<> SOFA_GPU_CUDA_API
 std::unordered_map<std::type_index, typename FixParticlePerformer<CudaVec3fTypes>::GetFixationPointsOnModelFunction >
 FixParticlePerformer<CudaVec3fTypes>::s_mapSupportedModels;
-#endif // _MSC_VER
+#endif // WIN32
 
 helper::Creator<ComponentMouseInteraction::ComponentMouseInteractionFactory, TComponentMouseInteraction<CudaVec3fTypes> > ComponentMouseInteractionCudaVec3fClass ("MouseSpringCudaVec3f",true);
 helper::Creator<InteractionPerformer::InteractionPerformerFactory, AttachBodyPerformer <CudaVec3fTypes> >  AttachBodyPerformerCudaVec3fClass("AttachBody",true);

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
@@ -83,6 +83,11 @@ helper::Creator<InteractionPerformer::InteractionPerformerFactory, AttachBodyPer
 helper::Creator<InteractionPerformer::InteractionPerformerFactory, FixParticlePerformer<CudaVec3dTypes> >  FixParticlePerformerCudaVec3dClass("FixParticle",true);
 #endif
 
+using FixParticlePerformerCuda3d = FixParticlePerformer<gpu::cuda::CudaVec3Types>;
+
+int triangleFixParticle = FixParticlePerformerCuda3d::RegisterSupportedModel<TriangleCollisionModel<gpu::cuda::Vec3Types>>(&FixParticlePerformerCuda3d::getFixationPointsTriangle<TriangleCollisionModel<gpu::cuda::Vec3Types>>);
+
+
 } //namespace collision
 
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
@@ -73,9 +73,11 @@ template class SOFA_GPU_CUDA_API FixParticlePerformer< CudaVec3dTypes >;
 
 ContactMapperCreator< ContactMapper<sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>> > CudaSphereContactMapperClass("default",true);
 
+#ifdef _MSC_VER
 template<> SOFA_GPU_CUDA_API
 std::unordered_map<std::type_index, typename FixParticlePerformer<CudaVec3fTypes>::GetFixationPointsOnModelFunction >
 FixParticlePerformer<CudaVec3fTypes>::s_mapSupportedModels;
+#endif // _MSC_VER
 
 helper::Creator<ComponentMouseInteraction::ComponentMouseInteractionFactory, TComponentMouseInteraction<CudaVec3fTypes> > ComponentMouseInteractionCudaVec3fClass ("MouseSpringCudaVec3f",true);
 helper::Creator<InteractionPerformer::InteractionPerformerFactory, AttachBodyPerformer <CudaVec3fTypes> >  AttachBodyPerformerCudaVec3fClass("AttachBody",true);

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
@@ -85,6 +85,10 @@ helper::Creator<InteractionPerformer::InteractionPerformerFactory, FixParticlePe
 
 using FixParticlePerformerCuda3d = FixParticlePerformer<gpu::cuda::CudaVec3Types>;
 
+#if defined(_MSC_VER) && _MSC_VER < 1920 // if VS is less than VS2019.0
+SOFA_GPU_CUDA_API std::unordered_map<std::type_index, FixParticlePerformerCuda3d::GetFixationPointsOnModelFunction > FixParticlePerformerCuda3d::s_mapSupportedModels;
+#endif // defined(_MSC_VER) && _MSC_VER < 1920
+
 int triangleFixParticle = FixParticlePerformerCuda3d::RegisterSupportedModel<TriangleCollisionModel<gpu::cuda::Vec3Types>>(&FixParticlePerformerCuda3d::getFixationPointsTriangle<TriangleCollisionModel<gpu::cuda::Vec3Types>>);
 
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
@@ -73,6 +73,10 @@ template class SOFA_GPU_CUDA_API FixParticlePerformer< CudaVec3dTypes >;
 
 ContactMapperCreator< ContactMapper<sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>> > CudaSphereContactMapperClass("default",true);
 
+template<class DataTypes> SOFA_GPU_CUDA_API
+std::unordered_map<std::type_index, typename FixParticlePerformer<DataTypes>::GetFixationPointsOnModelFunction >
+FixParticlePerformer<DataTypes>::s_mapSupportedModels;
+
 helper::Creator<ComponentMouseInteraction::ComponentMouseInteractionFactory, TComponentMouseInteraction<CudaVec3fTypes> > ComponentMouseInteractionCudaVec3fClass ("MouseSpringCudaVec3f",true);
 helper::Creator<InteractionPerformer::InteractionPerformerFactory, AttachBodyPerformer <CudaVec3fTypes> >  AttachBodyPerformerCudaVec3fClass("AttachBody",true);
 helper::Creator<InteractionPerformer::InteractionPerformerFactory, FixParticlePerformer<CudaVec3fTypes> >  FixParticlePerformerCudaVec3fClass("FixParticle",true);

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
@@ -85,10 +85,6 @@ helper::Creator<InteractionPerformer::InteractionPerformerFactory, FixParticlePe
 
 using FixParticlePerformerCuda3d = FixParticlePerformer<gpu::cuda::CudaVec3Types>;
 
-#if defined(_MSC_VER) && _MSC_VER < 1920 // if VS is less than VS2019.0
-SOFA_GPU_CUDA_API std::unordered_map<std::type_index, FixParticlePerformerCuda3d::GetFixationPointsOnModelFunction > FixParticlePerformerCuda3d::s_mapSupportedModels;
-#endif // defined(_MSC_VER) && _MSC_VER < 1920
-
 int triangleFixParticle = FixParticlePerformerCuda3d::RegisterSupportedModel<TriangleCollisionModel<gpu::cuda::Vec3Types>>(&FixParticlePerformerCuda3d::getFixationPointsTriangle<TriangleCollisionModel<gpu::cuda::Vec3Types>>);
 
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
@@ -73,9 +73,9 @@ template class SOFA_GPU_CUDA_API FixParticlePerformer< CudaVec3dTypes >;
 
 ContactMapperCreator< ContactMapper<sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>> > CudaSphereContactMapperClass("default",true);
 
-template<class DataTypes> SOFA_GPU_CUDA_API
-std::unordered_map<std::type_index, typename FixParticlePerformer<DataTypes>::GetFixationPointsOnModelFunction >
-FixParticlePerformer<DataTypes>::s_mapSupportedModels;
+template<> SOFA_GPU_CUDA_API
+std::unordered_map<std::type_index, typename FixParticlePerformer<CudaVec3fTypes>::GetFixationPointsOnModelFunction >
+FixParticlePerformer<CudaVec3fTypes>::s_mapSupportedModels;
 
 helper::Creator<ComponentMouseInteraction::ComponentMouseInteractionFactory, TComponentMouseInteraction<CudaVec3fTypes> > ComponentMouseInteractionCudaVec3fClass ("MouseSpringCudaVec3f",true);
 helper::Creator<InteractionPerformer::InteractionPerformerFactory, AttachBodyPerformer <CudaVec3fTypes> >  AttachBodyPerformerCudaVec3fClass("AttachBody",true);

--- a/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/CapsuleIntersection.cpp
+++ b/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/CapsuleIntersection.cpp
@@ -70,23 +70,20 @@ CapsuleMeshDiscreteIntersection::CapsuleMeshDiscreteIntersection(NewProximityInt
 // add CapsuleModel to the list of supported collision models for FixParticlePerformer
 using FixParticlePerformer3d = sofa::component::collision::FixParticlePerformer<defaulttype::Vec3Types>;
 
-int capsuleFixParticle = FixParticlePerformer3d::RegisterSupportedModel<CapsuleCollisionModel<sofa::defaulttype::Rigid3Types>>(
+int capsuleFixParticle = FixParticlePerformer3d::RegisterSupportedModel<CapsuleCollisionModel<sofa::defaulttype::Vec3Types>>(
     []
 (sofa::core::sptr<sofa::core::CollisionModel> model, const Index idx, helper::vector<Index>& points, FixParticlePerformer3d::Coord& fixPoint)
     {
         std::cout << "obb was registered you know" << std::endl;
 
-        auto* caps = dynamic_cast<CapsuleCollisionModel<sofa::defaulttype::Rigid3Types>*>(model.get());
+        auto* caps = dynamic_cast<CapsuleCollisionModel<sofa::defaulttype::Vec3Types>*>(model.get());
 
         if (!caps)
             return false;
 
-        auto* collisionState = model->getContext()->getMechanicalState();
-        fixPoint[0] = collisionState->getPX(idx);
-        fixPoint[1] = collisionState->getPY(idx);
-        fixPoint[2] = collisionState->getPZ(idx);
-
-        points.push_back(idx);
+        fixPoint = (caps->point1(idx) + caps->point2(idx))/2.0;
+        points.push_back(caps->point1Index(idx));
+        points.push_back(caps->point2Index(idx));
 
         return true;
     }

--- a/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/CapsuleIntersection.cpp
+++ b/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/CapsuleIntersection.cpp
@@ -74,8 +74,6 @@ int capsuleFixParticle = FixParticlePerformer3d::RegisterSupportedModel<CapsuleC
     []
 (sofa::core::sptr<sofa::core::CollisionModel> model, const Index idx, helper::vector<Index>& points, FixParticlePerformer3d::Coord& fixPoint)
     {
-        std::cout << "obb was registered you know" << std::endl;
-
         auto* caps = dynamic_cast<CapsuleCollisionModel<sofa::defaulttype::Vec3Types>*>(model.get());
 
         if (!caps)

--- a/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/CapsuleIntersection.cpp
+++ b/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/CapsuleIntersection.cpp
@@ -29,6 +29,7 @@
 #include <SofaBaseCollision/OBBModel.h>
 #include <SofaBaseCollision/SphereModel.h>
 #include <SofaUserInteraction/RayModel.h>
+#include <SofaUserInteraction/FixParticlePerformer.h>
 
 namespace sofa::component::collision
 {
@@ -65,5 +66,31 @@ CapsuleMeshDiscreteIntersection::CapsuleMeshDiscreteIntersection(NewProximityInt
     intersection->intersectors.add<CapsuleCollisionModel<sofa::defaulttype::Rigid3Types>, TriangleCollisionModel<sofa::defaulttype::Vec3Types>, CapsuleMeshDiscreteIntersection>(this);
     intersection->intersectors.add<CapsuleCollisionModel<sofa::defaulttype::Rigid3Types>, LineCollisionModel<sofa::defaulttype::Vec3Types>, CapsuleMeshDiscreteIntersection>(this);
 }
+
+// add CapsuleModel to the list of supported collision models for FixParticlePerformer
+using FixParticlePerformer3d = sofa::component::collision::FixParticlePerformer<defaulttype::Vec3Types>;
+
+int capsuleFixParticle = FixParticlePerformer3d::RegisterSupportedModel<CapsuleCollisionModel<sofa::defaulttype::Rigid3Types>>(
+    []
+(sofa::core::sptr<sofa::core::CollisionModel> model, const Index idx, helper::vector<Index>& points, FixParticlePerformer3d::Coord& fixPoint)
+    {
+        std::cout << "obb was registered you know" << std::endl;
+
+        auto* caps = dynamic_cast<CapsuleCollisionModel<sofa::defaulttype::Rigid3Types>*>(model.get());
+
+        if (!caps)
+            return false;
+
+        auto* collisionState = model->getContext()->getMechanicalState();
+        fixPoint[0] = collisionState->getPX(idx);
+        fixPoint[1] = collisionState->getPY(idx);
+        fixPoint[2] = collisionState->getPZ(idx);
+
+        points.push_back(idx);
+
+        return true;
+    }
+);
+
 
 } // namespace sofa::component::collision

--- a/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/OBBIntersection.cpp
+++ b/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/OBBIntersection.cpp
@@ -29,6 +29,8 @@
 #include <SofaBaseCollision/CapsuleModel.h>
 #include <SofaUserInteraction/RayModel.h>
 
+#include <SofaUserInteraction/FixParticlePerformer.h>
+
 namespace sofa::component::collision
 {
 
@@ -225,6 +227,29 @@ int  RigidDiscreteIntersection::computeIntersection(Ray& rRay, OBB& rObb, Output
 
 }
 
+// add OBBModel to the list of supported collision models for FixParticlePerformer
+using FixParticlePerformer3d = sofa::component::collision::FixParticlePerformer<defaulttype::Vec3Types>;
 
+int obbFixParticle = FixParticlePerformer3d::RegisterSupportedModel<OBBCollisionModel<sofa::defaulttype::Rigid3Types>>(
+    []
+(sofa::core::sptr<sofa::core::CollisionModel> model, const Index idx, helper::vector<Index>& points, FixParticlePerformer3d::Coord& fixPoint)
+    {
+        std::cout << "obb was registered you know" << std::endl;
+
+        auto* obb = dynamic_cast<OBBCollisionModel<sofa::defaulttype::Rigid3Types>*>(model.get());
+
+        if (!obb)
+            return false;
+
+        auto* collisionState= model->getContext()->getMechanicalState();
+        fixPoint[0] = collisionState->getPX(idx);
+        fixPoint[1] = collisionState->getPY(idx);
+        fixPoint[2] = collisionState->getPZ(idx);
+
+        points.push_back(idx);
+
+        return true;
+    }
+);
 
 } // namespace sofa::component::collision

--- a/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/OBBIntersection.cpp
+++ b/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/OBBIntersection.cpp
@@ -234,8 +234,6 @@ int obbFixParticle = FixParticlePerformer3d::RegisterSupportedModel<OBBCollision
     []
 (sofa::core::sptr<sofa::core::CollisionModel> model, const Index idx, helper::vector<Index>& points, FixParticlePerformer3d::Coord& fixPoint)
     {
-        std::cout << "obb was registered you know" << std::endl;
-
         auto* obb = dynamic_cast<OBBCollisionModel<sofa::defaulttype::Rigid3Types>*>(model.get());
 
         if (!obb)

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
@@ -26,11 +26,11 @@
 namespace sofa::component::collision
 {
 
-#ifdef _MSC_VER
+#ifdef WIN32
 template<> SOFA_SOFAUSERINTERACTION_API
     std::unordered_map<std::type_index, typename FixParticlePerformer<defaulttype::Vec3Types>::GetFixationPointsOnModelFunction >
     FixParticlePerformer<defaulttype::Vec3Types>::s_mapSupportedModels;
-#endif // _MSC_VER
+#endif // WIN32
 using FixParticlePerformer3d = FixParticlePerformer<defaulttype::Vec3Types>;
 
 template class SOFA_SOFAUSERINTERACTION_API FixParticlePerformer<defaulttype::Vec3Types>;

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
@@ -33,62 +33,9 @@ using FixParticlePerformer3d = FixParticlePerformer<defaulttype::Vec3Types>;
 template class SOFA_SOFAUSERINTERACTION_API FixParticlePerformer<defaulttype::Vec3Types>;
 helper::Creator<InteractionPerformer::InteractionPerformerFactory, FixParticlePerformer3d >  FixParticlePerformerVec3dClass("FixParticle",true);
 
-std::unordered_map<std::type_index, FixParticlePerformer3d::PairModelFunction> FixParticlePerformer3d::s_mapSupportedModels;
+int triangleFixParticle = FixParticlePerformer3d::RegisterSupportedModel<TriangleCollisionModel<defaulttype::Vec3Types>>(&FixParticlePerformer3d::getFixationPointsTriangle<TriangleCollisionModel<defaulttype::Vec3Types>>);
+int sphereFixParticle = FixParticlePerformer3d::RegisterSupportedModel<SphereCollisionModel<defaulttype::Vec3Types>>(&FixParticlePerformer3d::getFixationPointsSphere<SphereCollisionModel<defaulttype::Vec3Types>>);
+int rigidSphereFixParticle = FixParticlePerformer3d::RegisterSupportedModel<SphereCollisionModel<defaulttype::Rigid3Types>>(&FixParticlePerformer3d::getFixationPointsSphere<SphereCollisionModel<defaulttype::Rigid3Types>>);
 
-int triangleFixParticle = FixParticlePerformer3d::RegisterSupportedModel<TriangleCollisionModel<defaulttype::Vec3Types>>(
-    []
-    (sofa::core::sptr<sofa::core::CollisionModel> model, const Index idx, helper::vector<Index>& points, FixParticlePerformer3d::Coord& fixPoint)
-    {
-        auto* triangle = dynamic_cast<TriangleCollisionModel<defaulttype::Vec3Types>*>(model.get());
-        
-        if (!triangle)
-            return false;
-
-        Triangle t(triangle, idx);
-        fixPoint = (t.p1() + t.p2() + t.p3()) / 3.0;
-        points.push_back(t.p1Index());
-        points.push_back(t.p2Index());
-        points.push_back(t.p3Index());
-
-        return true;
-    }
-);
-
-int sphereFixParticle = FixParticlePerformer3d::RegisterSupportedModel<SphereCollisionModel<defaulttype::Vec3Types>>(
-    []
-(sofa::core::sptr<sofa::core::CollisionModel> model, const Index idx, helper::vector<Index>& points, FixParticlePerformer3d::Coord& fixPoint)
-    {
-        auto* sphere = dynamic_cast<SphereCollisionModel<defaulttype::Vec3Types>*>(model.get());
-
-        if (!sphere)
-            return false;
-
-        Sphere s(sphere, idx);
-        fixPoint = s.p();
-        points.push_back(s.getIndex());
-
-        return true;
-    }
-);
-
-int rigidSphereFixParticle = FixParticlePerformer3d::RegisterSupportedModel<SphereCollisionModel<defaulttype::Rigid3Types>>(
-    []
-(sofa::core::sptr<sofa::core::CollisionModel> model, const Index idx, helper::vector<Index>& points, FixParticlePerformer3d::Coord& fixPoint)
-    {
-        auto* rigidSphere = dynamic_cast<SphereCollisionModel<defaulttype::Rigid3Types>*>(model.get());
-
-        if (!rigidSphere)
-            return false;
-
-        auto* collisionState = model->getContext()->getMechanicalState();
-        fixPoint[0] = collisionState->getPX(idx);
-        fixPoint[1] = collisionState->getPY(idx);
-        fixPoint[2] = collisionState->getPZ(idx);
-
-        points.push_back(idx);
-
-        return true;
-    }
-);
 
 } // namespace sofa::component::collision

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
@@ -25,6 +25,11 @@
 
 namespace sofa::component::collision
 {
+
+template<class DataTypes> SOFA_SOFAUSERINTERACTION_API
+std::unordered_map<std::type_index, typename FixParticlePerformer<DataTypes>::GetFixationPointsOnModelFunction >
+FixParticlePerformer<DataTypes>::s_mapSupportedModels;
+
 using FixParticlePerformer3d = FixParticlePerformer<defaulttype::Vec3Types>;
 
 template class SOFA_SOFAUSERINTERACTION_API FixParticlePerformer<defaulttype::Vec3Types>;

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
@@ -25,7 +25,51 @@
 
 namespace sofa::component::collision
 {
+using FixParticlePerformer3d = FixParticlePerformer<defaulttype::Vec3Types>;
+
 template class SOFA_SOFAUSERINTERACTION_API FixParticlePerformer<defaulttype::Vec3Types>;
-helper::Creator<InteractionPerformer::InteractionPerformerFactory, FixParticlePerformer<defaulttype::Vec3Types> >  FixParticlePerformerVec3dClass("FixParticle",true);
+helper::Creator<InteractionPerformer::InteractionPerformerFactory, FixParticlePerformer3d >  FixParticlePerformerVec3dClass("FixParticle",true);
+
+std::unordered_map<std::type_index, FixParticlePerformer3d::PairModelFunction> FixParticlePerformer3d::s_mapSupportedModels;
+
+int triangleFixParticle = FixParticlePerformer3d::RegisterSupportedModel<sofa::component::collision::TriangleModel>(
+    []
+    (sofa::core::sptr<sofa::core::CollisionModel> model, const Index idx, helper::vector<Index>& points, FixParticlePerformer3d::Coord& fixPoint)
+    {
+        std::cout << "Triangle was registered you know" << std::endl;
+
+        auto* triangle = dynamic_cast<TriangleModel*>(model.get());
+        
+        if (!triangle)
+            return false;
+
+        Triangle t(triangle, idx);
+        fixPoint = (t.p1() + t.p2() + t.p3()) / 3.0;
+        points.push_back(t.p1Index());
+        points.push_back(t.p2Index());
+        points.push_back(t.p3Index());
+
+        return true;
+    }
+);
+
+int sphereFixParticle = FixParticlePerformer3d::RegisterSupportedModel<sofa::component::collision::SphereModel>(
+    []
+(sofa::core::sptr<sofa::core::CollisionModel> model, const Index idx, helper::vector<Index>& points, FixParticlePerformer3d::Coord& fixPoint)
+    {
+        std::cout << "sphere was registered you know" << std::endl;
+
+        auto* sphere = dynamic_cast<SphereModel*>(model.get());
+
+        if (!sphere)
+            return false;
+
+        Sphere s(sphere, idx);
+        fixPoint = s.p();
+        points.push_back(s.getIndex());
+
+        return true;
+    }
+);
 
 } // namespace sofa::component::collision

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
@@ -26,10 +26,11 @@
 namespace sofa::component::collision
 {
 
+#ifdef _MSC_VER
 template<> SOFA_SOFAUSERINTERACTION_API
     std::unordered_map<std::type_index, typename FixParticlePerformer<defaulttype::Vec3Types>::GetFixationPointsOnModelFunction >
     FixParticlePerformer<defaulttype::Vec3Types>::s_mapSupportedModels;
-
+#endif // _MSC_VER
 using FixParticlePerformer3d = FixParticlePerformer<defaulttype::Vec3Types>;
 
 template class SOFA_SOFAUSERINTERACTION_API FixParticlePerformer<defaulttype::Vec3Types>;

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
@@ -30,6 +30,10 @@ using FixParticlePerformer3d = FixParticlePerformer<defaulttype::Vec3Types>;
 template class SOFA_SOFAUSERINTERACTION_API FixParticlePerformer<defaulttype::Vec3Types>;
 helper::Creator<InteractionPerformer::InteractionPerformerFactory, FixParticlePerformer3d >  FixParticlePerformerVec3dClass("FixParticle",true);
 
+#if defined(_MSC_VER) && _MSC_VER < 1920 // if VS is less than VS2019.0
+SOFA_SOFAUSERINTERACTION_API std::unordered_map<std::type_index, FixParticlePerformer3d::GetFixationPointsOnModelFunction > FixParticlePerformer3d::s_mapSupportedModels;
+#endif // defined(_MSC_VER) && _MSC_VER < 1920
+
 int triangleFixParticle = FixParticlePerformer3d::RegisterSupportedModel<TriangleCollisionModel<defaulttype::Vec3Types>>(&FixParticlePerformer3d::getFixationPointsTriangle<TriangleCollisionModel<defaulttype::Vec3Types>>);
 int sphereFixParticle = FixParticlePerformer3d::RegisterSupportedModel<SphereCollisionModel<defaulttype::Vec3Types>>(&FixParticlePerformer3d::getFixationPointsSphere);
 int rigidSphereFixParticle = FixParticlePerformer3d::RegisterSupportedModel<SphereCollisionModel<defaulttype::Rigid3Types>>(&FixParticlePerformer3d::getFixationPointsSphere);

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
@@ -32,13 +32,11 @@ helper::Creator<InteractionPerformer::InteractionPerformerFactory, FixParticlePe
 
 std::unordered_map<std::type_index, FixParticlePerformer3d::PairModelFunction> FixParticlePerformer3d::s_mapSupportedModels;
 
-int triangleFixParticle = FixParticlePerformer3d::RegisterSupportedModel<sofa::component::collision::TriangleModel>(
+int triangleFixParticle = FixParticlePerformer3d::RegisterSupportedModel<TriangleCollisionModel<defaulttype::Vec3Types>>(
     []
     (sofa::core::sptr<sofa::core::CollisionModel> model, const Index idx, helper::vector<Index>& points, FixParticlePerformer3d::Coord& fixPoint)
     {
-        std::cout << "Triangle was registered you know" << std::endl;
-
-        auto* triangle = dynamic_cast<TriangleModel*>(model.get());
+        auto* triangle = dynamic_cast<TriangleCollisionModel<defaulttype::Vec3Types>*>(model.get());
         
         if (!triangle)
             return false;
@@ -53,13 +51,11 @@ int triangleFixParticle = FixParticlePerformer3d::RegisterSupportedModel<sofa::c
     }
 );
 
-int sphereFixParticle = FixParticlePerformer3d::RegisterSupportedModel<sofa::component::collision::SphereModel>(
+int sphereFixParticle = FixParticlePerformer3d::RegisterSupportedModel<SphereCollisionModel<defaulttype::Vec3Types>>(
     []
 (sofa::core::sptr<sofa::core::CollisionModel> model, const Index idx, helper::vector<Index>& points, FixParticlePerformer3d::Coord& fixPoint)
     {
-        std::cout << "sphere was registered you know" << std::endl;
-
-        auto* sphere = dynamic_cast<SphereModel*>(model.get());
+        auto* sphere = dynamic_cast<SphereCollisionModel<defaulttype::Vec3Types>*>(model.get());
 
         if (!sphere)
             return false;
@@ -67,6 +63,26 @@ int sphereFixParticle = FixParticlePerformer3d::RegisterSupportedModel<sofa::com
         Sphere s(sphere, idx);
         fixPoint = s.p();
         points.push_back(s.getIndex());
+
+        return true;
+    }
+);
+
+int rigidSphereFixParticle = FixParticlePerformer3d::RegisterSupportedModel<SphereCollisionModel<defaulttype::Rigid3Types>>(
+    []
+(sofa::core::sptr<sofa::core::CollisionModel> model, const Index idx, helper::vector<Index>& points, FixParticlePerformer3d::Coord& fixPoint)
+    {
+        auto* rigidSphere = dynamic_cast<SphereCollisionModel<defaulttype::Rigid3Types>*>(model.get());
+
+        if (!rigidSphere)
+            return false;
+
+        auto* collisionState = model->getContext()->getMechanicalState();
+        fixPoint[0] = collisionState->getPX(idx);
+        fixPoint[1] = collisionState->getPY(idx);
+        fixPoint[2] = collisionState->getPZ(idx);
+
+        points.push_back(idx);
 
         return true;
     }

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
@@ -23,6 +23,9 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/helper/Factory.inl>
 
+#include <SofaBaseCollision/SphereModel.h>
+#include <SofaMeshCollision/TriangleModel.h>
+
 namespace sofa::component::collision
 {
 using FixParticlePerformer3d = FixParticlePerformer<defaulttype::Vec3Types>;

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
@@ -23,9 +23,6 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/helper/Factory.inl>
 
-#include <SofaBaseCollision/SphereModel.h>
-#include <SofaMeshCollision/TriangleModel.h>
-
 namespace sofa::component::collision
 {
 using FixParticlePerformer3d = FixParticlePerformer<defaulttype::Vec3Types>;
@@ -34,8 +31,8 @@ template class SOFA_SOFAUSERINTERACTION_API FixParticlePerformer<defaulttype::Ve
 helper::Creator<InteractionPerformer::InteractionPerformerFactory, FixParticlePerformer3d >  FixParticlePerformerVec3dClass("FixParticle",true);
 
 int triangleFixParticle = FixParticlePerformer3d::RegisterSupportedModel<TriangleCollisionModel<defaulttype::Vec3Types>>(&FixParticlePerformer3d::getFixationPointsTriangle<TriangleCollisionModel<defaulttype::Vec3Types>>);
-int sphereFixParticle = FixParticlePerformer3d::RegisterSupportedModel<SphereCollisionModel<defaulttype::Vec3Types>>(&FixParticlePerformer3d::getFixationPointsSphere<SphereCollisionModel<defaulttype::Vec3Types>>);
-int rigidSphereFixParticle = FixParticlePerformer3d::RegisterSupportedModel<SphereCollisionModel<defaulttype::Rigid3Types>>(&FixParticlePerformer3d::getFixationPointsSphere<SphereCollisionModel<defaulttype::Rigid3Types>>);
+int sphereFixParticle = FixParticlePerformer3d::RegisterSupportedModel<SphereCollisionModel<defaulttype::Vec3Types>>(&FixParticlePerformer3d::getFixationPointsSphere);
+int rigidSphereFixParticle = FixParticlePerformer3d::RegisterSupportedModel<SphereCollisionModel<defaulttype::Rigid3Types>>(&FixParticlePerformer3d::getFixationPointsSphere);
 
 
 } // namespace sofa::component::collision

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
@@ -30,10 +30,6 @@ using FixParticlePerformer3d = FixParticlePerformer<defaulttype::Vec3Types>;
 template class SOFA_SOFAUSERINTERACTION_API FixParticlePerformer<defaulttype::Vec3Types>;
 helper::Creator<InteractionPerformer::InteractionPerformerFactory, FixParticlePerformer3d >  FixParticlePerformerVec3dClass("FixParticle",true);
 
-#if defined(_MSC_VER) && _MSC_VER < 1920 // if VS is less than VS2019.0
-SOFA_SOFAUSERINTERACTION_API std::unordered_map<std::type_index, FixParticlePerformer3d::GetFixationPointsOnModelFunction > FixParticlePerformer3d::s_mapSupportedModels;
-#endif // defined(_MSC_VER) && _MSC_VER < 1920
-
 int triangleFixParticle = FixParticlePerformer3d::RegisterSupportedModel<TriangleCollisionModel<defaulttype::Vec3Types>>(&FixParticlePerformer3d::getFixationPointsTriangle<TriangleCollisionModel<defaulttype::Vec3Types>>);
 int sphereFixParticle = FixParticlePerformer3d::RegisterSupportedModel<SphereCollisionModel<defaulttype::Vec3Types>>(&FixParticlePerformer3d::getFixationPointsSphere);
 int rigidSphereFixParticle = FixParticlePerformer3d::RegisterSupportedModel<SphereCollisionModel<defaulttype::Rigid3Types>>(&FixParticlePerformer3d::getFixationPointsSphere);

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
@@ -26,9 +26,9 @@
 namespace sofa::component::collision
 {
 
-template<class DataTypes> SOFA_SOFAUSERINTERACTION_API
-std::unordered_map<std::type_index, typename FixParticlePerformer<DataTypes>::GetFixationPointsOnModelFunction >
-FixParticlePerformer<DataTypes>::s_mapSupportedModels;
+template<> SOFA_SOFAUSERINTERACTION_API
+    std::unordered_map<std::type_index, typename FixParticlePerformer<defaulttype::Vec3Types>::GetFixationPointsOnModelFunction >
+    FixParticlePerformer<defaulttype::Vec3Types>::s_mapSupportedModels;
 
 using FixParticlePerformer3d = FixParticlePerformer<defaulttype::Vec3Types>;
 

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.h
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.h
@@ -27,6 +27,9 @@
 #include <SofaDeformable/StiffSpringForceField.h>
 #include <SofaUserInteraction/MouseInteractor.h>
 
+#include <unordered_map>
+#include <typeindex>
+
 namespace sofa::component::collision
 {
 
@@ -53,10 +56,23 @@ public:
     void execute();
     void draw(const core::visual::VisualParams* vparams);
 
+    using GetFixationPointsOnModelFunction = std::function<bool(sofa::core::sptr<sofa::core::CollisionModel>, const Index, helper::vector<Index>&, Coord&)>;
+    using PairModelFunction = std::pair<sofa::core::sptr<sofa::core::CollisionModel>, GetFixationPointsOnModelFunction>;
+    template<typename TCollisionModel>
+    static int RegisterSupportedModel(GetFixationPointsOnModelFunction func)
+    {
+        std::cout << "RegisterSupportedModel: " << typeid(TCollisionModel).name() << std::endl;
+        s_mapSupportedModels[std::type_index(typeid(TCollisionModel))] = PairModelFunction(sofa::core::objectmodel::New<TCollisionModel>(), func);
+
+        return 1;
+    }
+
 protected:
     MouseContainer* getFixationPoints(const BodyPicked &b, helper::vector<unsigned int> &points, typename DataTypes::Coord &fixPoint);
 
     std::vector< simulation::Node * > fixations;
+
+    static std::unordered_map<std::type_index, PairModelFunction > s_mapSupportedModels;
 };
 
 

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.h
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.h
@@ -95,13 +95,10 @@ protected:
 
     std::vector< simulation::Node * > fixations;
 
-    // inline initialization of templated static members works on VS2019, not on VS2017...
-#if defined(_MSC_VER) && _MSC_VER < 1920 // if VS is less than VS2019.0
+    // inline initialization of templated static members works on VS2019
+    // BUT: not on VS2017 and crash with clang5
+    //inline static std::unordered_map<std::type_index, GetFixationPointsOnModelFunction > s_mapSupportedModels;
     static std::unordered_map<std::type_index, GetFixationPointsOnModelFunction > s_mapSupportedModels;
-#else
-    // lets use C++17 inline initialization for all the other compilers
-    inline static std::unordered_map<std::type_index, GetFixationPointsOnModelFunction > s_mapSupportedModels;
-#endif // defined(_MSC_VER) && _MSC_VER < 1920
 
 };
 

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.h
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.h
@@ -61,7 +61,6 @@ public:
     template<typename TCollisionModel>
     static int RegisterSupportedModel(GetFixationPointsOnModelFunction func)
     {
-        std::cout << "RegisterSupportedModel: " << typeid(TCollisionModel).name() << std::endl;
         s_mapSupportedModels[std::type_index(typeid(TCollisionModel))] = PairModelFunction(sofa::core::objectmodel::New<TCollisionModel>(), func);
 
         return 1;

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.h
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.h
@@ -66,12 +66,48 @@ public:
         return 1;
     }
 
+    template<typename TCollisionModel>
+    static bool getFixationPointsTriangle(sofa::core::sptr<sofa::core::CollisionModel> model, const Index idx, helper::vector<Index>& points, Coord& fixPoint)
+    {
+        auto* triangle = dynamic_cast<TCollisionModel*>(model.get());
+
+        if (!triangle)
+            return false;
+
+        Triangle t(triangle, idx);
+        fixPoint = (t.p1() + t.p2() + t.p3()) / 3.0;
+        points.push_back(t.p1Index());
+        points.push_back(t.p2Index());
+        points.push_back(t.p3Index());
+
+        return true;
+    }
+
+    template<typename TCollisionModel>
+    static bool getFixationPointsSphere(sofa::core::sptr<sofa::core::CollisionModel> model, const Index idx, helper::vector<Index>& points, Coord& fixPoint)
+    {
+        auto* sphere = dynamic_cast<TCollisionModel*>(model.get());
+
+        if (!sphere)
+            return false;
+
+        auto* collisionState = model->getContext()->getMechanicalState();
+        fixPoint[0] = collisionState->getPX(idx);
+        fixPoint[1] = collisionState->getPY(idx);
+        fixPoint[2] = collisionState->getPZ(idx);
+
+        points.push_back(idx);
+
+        return true;
+    }
+
 protected:
     MouseContainer* getFixationPoints(const BodyPicked &b, helper::vector<unsigned int> &points, typename DataTypes::Coord &fixPoint);
 
     std::vector< simulation::Node * > fixations;
 
-    static std::unordered_map<std::type_index, PairModelFunction > s_mapSupportedModels;
+    inline static std::unordered_map<std::type_index, PairModelFunction > s_mapSupportedModels;
+
 };
 
 

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.h
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.h
@@ -102,7 +102,6 @@ protected:
 
 };
 
-
 #if  !defined(SOFA_COMPONENT_COLLISION_FIXPARTICLEPERFORMER_CPP)
 extern template class SOFA_SOFAUSERINTERACTION_API FixParticlePerformer<defaulttype::Vec3Types>;
 

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.h
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.h
@@ -95,8 +95,10 @@ protected:
 
     std::vector< simulation::Node * > fixations;
 
-    // inline initialization of templated static members works on VS2019
-    // BUT: not on VS2017 and crash with clang5
+    // inline initialization of templated static members works on VS2019/gcc/clang (>5?)
+    // but not on VS2017 and crash the compilation itself using clang5.
+    // TODO: once VS2017 and clang5 support is dropped, just uncomment the inline static initialization 
+    // and remove the initialization in the inl file (linux/mac) and cpp (windows)
     //inline static std::unordered_map<std::type_index, GetFixationPointsOnModelFunction > s_mapSupportedModels;
     static std::unordered_map<std::type_index, GetFixationPointsOnModelFunction > s_mapSupportedModels;
 

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.h
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.h
@@ -95,7 +95,13 @@ protected:
 
     std::vector< simulation::Node * > fixations;
 
+    // inline initialization of templated static members works on VS2019, not on VS2017...
+#if defined(_MSC_VER) && _MSC_VER < 1920 // if VS is less than VS2019.0
+    static std::unordered_map<std::type_index, GetFixationPointsOnModelFunction > s_mapSupportedModels;
+#else
+    // lets use C++17 inline initialization for all the other compilers
     inline static std::unordered_map<std::type_index, GetFixationPointsOnModelFunction > s_mapSupportedModels;
+#endif // defined(_MSC_VER) && _MSC_VER < 1920
 
 };
 

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.inl
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.inl
@@ -124,8 +124,10 @@ sofa::component::container::MechanicalObject< DataTypes >* FixParticlePerformer<
         bool foundSupportedModel = false;
         for (auto supportedModel : s_mapSupportedModels)
         {
-            if (foundSupportedModel = supportedModel.second.second(b.body, idx, points, fixPoint))
-                break;
+            std::cout << "Testing: " << typeid(supportedModel).name() << std::endl;
+
+            //if (foundSupportedModel = supportedModel.second.second(b.body, idx, points, fixPoint))
+            //    break;
         }
         if (!foundSupportedModel)
         {
@@ -151,7 +153,7 @@ sofa::component::container::MechanicalObject< DataTypes >* FixParticlePerformer<
             points.push_back(capsule->point1Index(idx));
             points.push_back(capsule->point2Index(idx));
         }
-        else if(dynamic_cast<SphereCollisionModel<sofa::defaulttype::Rigid3Types>*>(b.body)||dynamic_cast<OBBCollisionModel<sofa::defaulttype::Rigid3Types>*>(b.body)){
+        else if(dynamic_cast<SphereCollisionModel<sofa::defaulttype::Rigid3Types>*>(b.body)/*||dynamic_cast<OBBCollisionModel<sofa::defaulttype::Rigid3Types>*>(b.body)*/){
             collisionState = dynamic_cast<MouseContainer*>(b.mstate);
             fixPoint = (collisionState->read(core::ConstVecCoordId::position())->getValue())[idx];
             points.push_back(idx);

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.inl
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.inl
@@ -150,4 +150,10 @@ sofa::component::container::MechanicalObject< DataTypes >* FixParticlePerformer<
     return collisionState;
 }
 
+#ifndef _MSC_VER
+template<typename DataTypes>
+    std::unordered_map<std::type_index, typename FixParticlePerformer<DataTypes>::GetFixationPointsOnModelFunction >
+    FixParticlePerformer<DataTypes>::s_mapSupportedModels;
+#endif // _MSC_VER
+
 } // namespace sofa::component::collision

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.inl
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.inl
@@ -126,18 +126,6 @@ sofa::component::container::MechanicalObject< DataTypes >* FixParticlePerformer<
             msg_warning("FixParticlePerformer") << "Could not find a Collision Model to fix particle on. " 
                                                 << typeid(b.body).name() << " has not been registered.";
         }
-        
-
-        //bool foundSupportedModel = false;
-        //for (auto supportedModel : s_mapSupportedModels)
-        //{
-        //    if (foundSupportedModel = supportedModel.second(b.body, idx, points, fixPoint))
-        //        break;
-        //}
-        //if (!foundSupportedModel)
-        //{
-        //    msg_warning("FixParticlePerformer") << "Could not find a Collision Model to fix particle on.";
-        //}
     }
     else if (b.mstate)
     {
@@ -150,10 +138,10 @@ sofa::component::container::MechanicalObject< DataTypes >* FixParticlePerformer<
     return collisionState;
 }
 
-#ifndef _MSC_VER
+#ifndef WIN32
 template<typename DataTypes>
     std::unordered_map<std::type_index, typename FixParticlePerformer<DataTypes>::GetFixationPointsOnModelFunction >
     FixParticlePerformer<DataTypes>::s_mapSupportedModels;
-#endif // _MSC_VER
+#endif // WIN32
 
 } // namespace sofa::component::collision

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.inl
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.inl
@@ -27,11 +27,6 @@
 #include <sofa/simulation/InitVisitor.h>
 #include <sofa/simulation/DeleteVisitor.h>
 #include <sofa/simulation/Node.h>
-#include <SofaBaseCollision/SphereModel.h>
-#include <SofaMeshCollision/TriangleModel.h>
-#include <SofaBaseCollision/OBBModel.h>
-#include <SofaBaseCollision/CapsuleModel.h>
-
 
 namespace sofa::component::collision
 {
@@ -130,31 +125,6 @@ sofa::component::container::MechanicalObject< DataTypes >* FixParticlePerformer<
         if (!foundSupportedModel)
         {
             msg_warning("FixParticlePerformer") << "Could not find a Collision Model to fix particle on.";
-        }
-
-        //if (SphereCollisionModel<sofa::defaulttype::Vec3Types> *sphere = dynamic_cast<SphereCollisionModel<sofa::defaulttype::Vec3Types>*>(b.body))
-        //{
-        //    Sphere s(sphere, idx);
-        //    fixPoint = s.p();
-        //    points.push_back(s.getIndex());
-        //}
-        //else if(TriangleCollisionModel<sofa::defaulttype::Vec3Types> *triangle = dynamic_cast<TriangleCollisionModel<sofa::defaulttype::Vec3Types>*>(b.body))
-        //{
-        //    Triangle t(triangle, idx);
-        //    fixPoint = (t.p1()+t.p2()+t.p3())/3.0;
-        //    points.push_back(t.p1Index());
-        //    points.push_back(t.p2Index());
-        //    points.push_back(t.p3Index());
-        //}
-        //else if(CapsuleCollisionModel<sofa::defaulttype::Vec3Types> *capsule = dynamic_cast<CapsuleCollisionModel<sofa::defaulttype::Vec3Types>*>(b.body)){
-        //    fixPoint = (capsule->point1(idx) + capsule->point2(idx))/2.0;
-        //    points.push_back(capsule->point1Index(idx));
-        //    points.push_back(capsule->point2Index(idx));
-        //}
-        else if(dynamic_cast<SphereCollisionModel<sofa::defaulttype::Rigid3Types>*>(b.body)){
-            collisionState = dynamic_cast<MouseContainer*>(b.mstate);
-            fixPoint = (collisionState->read(core::ConstVecCoordId::position())->getValue())[idx];
-            points.push_back(idx);
         }
     }
     else if (b.mstate)

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.inl
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.inl
@@ -124,10 +124,8 @@ sofa::component::container::MechanicalObject< DataTypes >* FixParticlePerformer<
         bool foundSupportedModel = false;
         for (auto supportedModel : s_mapSupportedModels)
         {
-            std::cout << "Testing: " << typeid(supportedModel).name() << std::endl;
-
-            //if (foundSupportedModel = supportedModel.second.second(b.body, idx, points, fixPoint))
-            //    break;
+            if (foundSupportedModel = supportedModel.second.second(b.body, idx, points, fixPoint))
+                break;
         }
         if (!foundSupportedModel)
         {
@@ -148,12 +146,12 @@ sofa::component::container::MechanicalObject< DataTypes >* FixParticlePerformer<
         //    points.push_back(t.p2Index());
         //    points.push_back(t.p3Index());
         //}
-        else if(CapsuleCollisionModel<sofa::defaulttype::Vec3Types> *capsule = dynamic_cast<CapsuleCollisionModel<sofa::defaulttype::Vec3Types>*>(b.body)){
-            fixPoint = (capsule->point1(idx) + capsule->point2(idx))/2.0;
-            points.push_back(capsule->point1Index(idx));
-            points.push_back(capsule->point2Index(idx));
-        }
-        else if(dynamic_cast<SphereCollisionModel<sofa::defaulttype::Rigid3Types>*>(b.body)/*||dynamic_cast<OBBCollisionModel<sofa::defaulttype::Rigid3Types>*>(b.body)*/){
+        //else if(CapsuleCollisionModel<sofa::defaulttype::Vec3Types> *capsule = dynamic_cast<CapsuleCollisionModel<sofa::defaulttype::Vec3Types>*>(b.body)){
+        //    fixPoint = (capsule->point1(idx) + capsule->point2(idx))/2.0;
+        //    points.push_back(capsule->point1Index(idx));
+        //    points.push_back(capsule->point2Index(idx));
+        //}
+        else if(dynamic_cast<SphereCollisionModel<sofa::defaulttype::Rigid3Types>*>(b.body)){
             collisionState = dynamic_cast<MouseContainer*>(b.mstate);
             fixPoint = (collisionState->read(core::ConstVecCoordId::position())->getValue())[idx];
             points.push_back(idx);

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.inl
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.inl
@@ -150,4 +150,8 @@ sofa::component::container::MechanicalObject< DataTypes >* FixParticlePerformer<
     return collisionState;
 }
 
+template<class DataTypes>
+std::unordered_map<std::type_index, typename FixParticlePerformer<DataTypes>::GetFixationPointsOnModelFunction >
+FixParticlePerformer<DataTypes>::s_mapSupportedModels;
+
 } // namespace sofa::component::collision

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.inl
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.inl
@@ -150,8 +150,4 @@ sofa::component::container::MechanicalObject< DataTypes >* FixParticlePerformer<
     return collisionState;
 }
 
-template<class DataTypes>
-std::unordered_map<std::type_index, typename FixParticlePerformer<DataTypes>::GetFixationPointsOnModelFunction >
-FixParticlePerformer<DataTypes>::s_mapSupportedModels;
-
 } // namespace sofa::component::collision

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.inl
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.inl
@@ -116,16 +116,28 @@ sofa::component::container::MechanicalObject< DataTypes >* FixParticlePerformer<
     {
         collisionState = dynamic_cast<MouseContainer*>(b.body->getContext()->getMechanicalState());
 
-        bool foundSupportedModel = false;
-        for (auto supportedModel : s_mapSupportedModels)
+        auto funcGetFixationPoints = s_mapSupportedModels.find(std::type_index(typeid(*b.body)));
+        if (funcGetFixationPoints != s_mapSupportedModels.end())
         {
-            if (foundSupportedModel = supportedModel.second.second(b.body, idx, points, fixPoint))
-                break;
+            funcGetFixationPoints->second(b.body, idx, points, fixPoint);
         }
-        if (!foundSupportedModel)
+        else
         {
-            msg_warning("FixParticlePerformer") << "Could not find a Collision Model to fix particle on.";
+            msg_warning("FixParticlePerformer") << "Could not find a Collision Model to fix particle on. " 
+                                                << typeid(b.body).name() << " has not been registered.";
         }
+        
+
+        //bool foundSupportedModel = false;
+        //for (auto supportedModel : s_mapSupportedModels)
+        //{
+        //    if (foundSupportedModel = supportedModel.second(b.body, idx, points, fixPoint))
+        //        break;
+        //}
+        //if (!foundSupportedModel)
+        //{
+        //    msg_warning("FixParticlePerformer") << "Could not find a Collision Model to fix particle on.";
+        //}
     }
     else if (b.mstate)
     {

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/RayContact.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/RayContact.cpp
@@ -24,7 +24,6 @@
 #include <SofaUserInteraction/RayModel.h>
 #include <SofaBaseCollision/SphereModel.h>
 #include <SofaMeshCollision/TriangleModel.h>
-#include <SofaBaseCollision/OBBModel.h>
 
 namespace sofa::component::collision
 {


### PR DESCRIPTION
Follows #2073 and then #2081

PickParticlePerformer has a hard dependency on OBBModel & CapsuleModel to compute where it sets its constraint with the mouse while picking.
So this forces the modules SofaUserInteraction to know those classes before hand.

This design is not that good, as it is not possible for someone creating a new CollisionModel (in a plugin, etc) and use the PickParticlePerformer.

This PR adds a (static) registration system, similar to the ObjectFactory and co., so if anybody wants to add a new collision model to pick on, it just has to register its model, along a callable (lambda, std::function, etc) on how to get the points on this model.
PickParticlePerformer registers by itself the triangle, sphere and rigidsphere models.
SofaMiscCollision (where OBB&Capsule are) registers the obb and capsule model functions.

Fix #1624 
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
