### PR TITLE
[SofaBaseTopology] Register TopologyHandler directly in each TopologyContainer

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/EdgeSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/EdgeSetTopologyContainer.cpp
@@ -575,6 +575,12 @@ void EdgeSetTopologyContainer::updateTopologyHandlerGraph()
 
     // will concatenate with points one:
     PointSetTopologyContainer::updateTopologyHandlerGraph();
+
+}
+
+void EdgeSetTopologyContainer::addTopologyHandler(sofa::core::topology::TopologyHandler* _TopologyHandler)
+{
+    this->m_enginesList.push_back(_TopologyHandler);
 }
 
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/EdgeSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/EdgeSetTopologyContainer.h
@@ -174,6 +174,8 @@ public:
     /** \brief Returns the type of the topology */
     sofa::core::topology::TopologyElementType getTopologyType() const override {return sofa::core::topology::TopologyElementType::EDGE;}
     
+    /// \brief function to add a TopologyHandler to the current list of engines.
+    void addTopologyHandler(sofa::core::topology::TopologyHandler* _TopologyHandler);
 
 protected:
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/HexahedronSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/HexahedronSetTopologyContainer.cpp
@@ -1227,4 +1227,9 @@ void HexahedronSetTopologyContainer::updateTopologyHandlerGraph()
     QuadSetTopologyContainer::updateTopologyHandlerGraph();
 }
 
+void HexahedronSetTopologyContainer::addTopologyHandler(sofa::core::topology::TopologyHandler* _TopologyHandler)
+{
+    this->m_enginesList.push_back(_TopologyHandler);
+}
+
 } //namespace sofa::component::topology

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/HexahedronSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/HexahedronSetTopologyContainer.h
@@ -312,6 +312,8 @@ public:
     /** \brief Returns the type of the topology */
 	sofa::core::topology::TopologyElementType getTopologyType() const override {return core::topology::TopologyElementType::HEXAHEDRON;}
 
+    /// \brief function to add a TopologyHandler to the current list of engines.
+    void addTopologyHandler(sofa::core::topology::TopologyHandler* _TopologyHandler);
 
 protected:
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyContainer.cpp
@@ -190,9 +190,9 @@ void PointSetTopologyContainer::updateTopologyHandlerGraph()
 }
 
 
-void PointSetTopologyContainer::addEngineToList(sofa::core::topology::TopologyHandler *_engine)
+void PointSetTopologyContainer::addTopologyHandler(sofa::core::topology::TopologyHandler * _TopologyHandler)
 {
-    this->m_enginesList.push_back(_engine);
+    this->m_enginesList.push_back(_TopologyHandler);
 }
 
 const sofa::helper::vector< PointSetTopologyContainer::PointID >& PointSetTopologyContainer::getPoints() const

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyContainer.h
@@ -138,6 +138,9 @@ public:
 
     const sofa::helper::vector<PointID>& getPoints() const;
 
+    /// \brief function to add a TopologyHandler to the current list of engines.
+    void addTopologyHandler(sofa::core::topology::TopologyHandler* _TopologyHandler);
+
 protected:
     /// \brief Function creating the data graph linked to d_point
     void updateTopologyHandlerGraph() override;
@@ -151,9 +154,6 @@ protected:
     void setPointTopologyToDirty();
     void cleanPointTopologyFromDirty();
     const bool& isPointTopologyDirty() {return m_pointTopologyDirty;}
-
-    /// \brief function to add a TopologyHandler to the current list of engines.
-    void addEngineToList(sofa::core::topology::TopologyHandler * _engine);
 
     /// \brief functions to display the graph of Data/DataEngines linked to the different Data array, using member variable.
     virtual void displayDataGraph(sofa::core::objectmodel::BaseData& my_Data);

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/QuadSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/QuadSetTopologyContainer.cpp
@@ -777,4 +777,9 @@ void QuadSetTopologyContainer::updateTopologyHandlerGraph()
     EdgeSetTopologyContainer::updateTopologyHandlerGraph();
 }
 
+void QuadSetTopologyContainer::addTopologyHandler(sofa::core::topology::TopologyHandler* _TopologyHandler)
+{
+    this->m_enginesList.push_back(_TopologyHandler);
+}
+
 } //namespace sofa::component::topology

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/QuadSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/QuadSetTopologyContainer.h
@@ -220,6 +220,9 @@ public:
     /** \brief Returns the type of the topology */
     sofa::core::topology::TopologyElementType getTopologyType() const override {return sofa::core::topology::TopologyElementType::QUAD;}
 
+    /// \brief function to add a TopologyHandler to the current list of engines.
+    void addTopologyHandler(sofa::core::topology::TopologyHandler* _TopologyHandler);
+
 protected:
 
     /** \brief Creates the QuadSet array.

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetTopologyContainer.cpp
@@ -1208,6 +1208,11 @@ void TetrahedronSetTopologyContainer::updateTopologyHandlerGraph()
     TriangleSetTopologyContainer::updateTopologyHandlerGraph();
 }
 
+void TetrahedronSetTopologyContainer::addTopologyHandler(sofa::core::topology::TopologyHandler* _TopologyHandler)
+{
+    this->m_enginesList.push_back(_TopologyHandler);
+}
+
 std::ostream& operator<< (std::ostream& out, const TetrahedronSetTopologyContainer& t)
 {
     helper::ReadAccessor< Data< sofa::helper::vector<TetrahedronSetTopologyContainer::Tetrahedron> > > m_tetrahedron = t.d_tetrahedron;

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetTopologyContainer.h
@@ -289,6 +289,9 @@ public:
     SOFA_SOFABASETOPOLOGY_API friend std::ostream& operator<< (std::ostream& out, const TetrahedronSetTopologyContainer& t);
     SOFA_SOFABASETOPOLOGY_API friend std::istream& operator>>(std::istream& in, TetrahedronSetTopologyContainer& t);
 
+    /// \brief function to add a TopologyHandler to the current list of engines.
+    void addTopologyHandler(sofa::core::topology::TopologyHandler* _TopologyHandler);
+
 protected:
     /** \brief Creates the EdgeSet array.
      *

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.h
@@ -118,13 +118,13 @@ public:
 
 
     ////////////////////////////////////// DEPRECATED ///////////////////////////////////////////
-    SOFA_ATTRIBUTE_DISABLED("v21.06", "PR#2082", "This method has been removed as it is not part of the new topology change design.")
+    SOFA_ATTRIBUTE_DISABLED("v21.06 (PR#2082)", "v21.06 (PR#2082)", "This method has been removed as it is not part of the new topology change design.")
     void addInputData(sofa::core::objectmodel::BaseData* _data) = delete;
 
-    SOFA_ATTRIBUTE_DISABLED("v21.06", "PR#2082", "This method was deleted because it presented risks. Use Write/Read Accessor instead.")
+    SOFA_ATTRIBUTE_DISABLED("v21.06 (PR#2082)", "v21.06 (PR#2082)", "This method was deleted because it presented risks. Use Write/Read Accessor instead.")
     const value_type& operator[](int i) const = delete;
 
-    SOFA_ATTRIBUTE_DISABLED("v21.06", "PR#2082", "This method was deleted because it presented risks. Use Write/Read Accessor instead.")
+    SOFA_ATTRIBUTE_DISABLED("v21.06 (PR#2082)", "v21.06 (PR#2082)", "This method was deleted because it presented risks. Use Write/Read Accessor instead.")
     value_type& operator[](int i) = delete;
 
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
@@ -56,7 +56,7 @@ void TopologyData <TopologyElementType, VecT>::createTopologyHandler(sofa::core:
     this->m_topologyHandler->init();
 
     // Register the engine
-    m_isTopologyDynamic = this->m_topologyHandler->registerTopology();
+    m_isTopologyDynamic = this->m_topologyHandler->registerTopology(_topology);
     if (m_isTopologyDynamic)
     {
         this->linkToElementDataArray((TopologyElementType*)nullptr);

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyDataHandler.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyDataHandler.h
@@ -80,10 +80,6 @@ public:
 
     void handleTopologyChange() override;
 
-    bool registerTopology(sofa::core::topology::BaseMeshTopology* _topology) override;
-
-    bool registerTopology() override;
-
     void registerTopologicalData(t_topologicalData *topologicalData) {m_topologyData = topologicalData;}
 
 
@@ -156,7 +152,6 @@ public:
 
 protected:
     t_topologicalData* m_topologyData;
-    sofa::core::topology::TopologyContainer* m_topology;
     value_type m_defaultValue; // default value when adding an element (by set as value_type() by default)
 
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyDataHandler.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyDataHandler.inl
@@ -34,13 +34,11 @@ TopologyDataHandler< TopologyElementType, VecT>::TopologyDataHandler(t_topologic
         sofa::core::topology::BaseMeshTopology *_topology, value_type defaultValue)
     : TopologyHandler()
     , m_topologyData(_topologicalData)
-    , m_topology(nullptr)
     , m_pointsLinked(false), m_edgesLinked(false), m_trianglesLinked(false)
     , m_quadsLinked(false), m_tetrahedraLinked(false), m_hexahedraLinked(false)
 {
     SOFA_UNUSED(defaultValue);
-    m_topology =  dynamic_cast<sofa::core::topology::TopologyContainer*>(_topology);
-
+    m_topology = dynamic_cast<sofa::core::topology::TopologyContainer*>(_topology);
 }
 
 
@@ -49,7 +47,6 @@ TopologyDataHandler< TopologyElementType, VecT>::TopologyDataHandler(t_topologic
     value_type defaultValue)
     : TopologyHandler()
     , m_topologyData(_topologicalData)
-    , m_topology(nullptr)
     , m_defaultValue(defaultValue)
     , m_pointsLinked(false), m_edgesLinked(false), m_trianglesLinked(false)
     , m_quadsLinked(false), m_tetrahedraLinked(false), m_hexahedraLinked(false)
@@ -73,38 +70,6 @@ void TopologyDataHandler<TopologyElementType,  VecT>::init()
     //if (m_topology)
     //   m_topology->addTopologyHandler(this);
     //this->registerTopology(m_topology);
-}
-
-
-template <typename TopologyElementType, typename VecT>
-bool TopologyDataHandler<TopologyElementType,  VecT>::registerTopology(sofa::core::topology::BaseMeshTopology *_topology)
-{
-    m_topology =  dynamic_cast<sofa::core::topology::TopologyContainer*>(_topology);
-
-    if (m_topology == nullptr)
-    {
-        msg_info("TopologyDataHandler") <<"Topology: " << _topology->getName() << " is not dynamic, topology engine on Data '" << m_data_name << "' won't be registered.";
-        return false;
-    }
-    else
-        m_topology->addTopologyHandler(this);
-
-    return true;
-}
-
-
-template <typename TopologyElementType, typename VecT>
-bool TopologyDataHandler<TopologyElementType,  VecT>::registerTopology()
-{
-    if (m_topology == nullptr)
-    {
-        msg_info("TopologyDataHandler") << "Current topology is not dynamic, topology engine on Data '" << m_data_name << "' won't be registered.";
-        return false;
-    }
-    else
-        m_topology->addTopologyHandler(this);
-
-    return true;
 }
 
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyDataHandler.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyDataHandler.inl
@@ -106,6 +106,7 @@ void TopologyDataHandler<TopologyElementType,  VecT>::linkToPointDataArray()
     }
 
     _container->d_initPoints.addOutput(this);
+    _container->addTopologyHandler(this);
     m_pointsLinked = true;
 }
 
@@ -130,6 +131,7 @@ void TopologyDataHandler<TopologyElementType,  VecT>::linkToEdgeDataArray()
     }
 
     _container->d_edge.addOutput(this);
+    _container->addTopologyHandler(this);
     m_edgesLinked = true;
 }
 
@@ -154,6 +156,7 @@ void TopologyDataHandler<TopologyElementType,  VecT>::linkToTriangleDataArray()
     }
 
     _container->d_triangle.addOutput(this);
+    _container->addTopologyHandler(this);
     m_trianglesLinked = true;
 }
 
@@ -178,6 +181,7 @@ void TopologyDataHandler<TopologyElementType,  VecT>::linkToQuadDataArray()
     }
 
     _container->d_quad.addOutput(this);
+    _container->addTopologyHandler(this);
     m_quadsLinked = true;
 }
 
@@ -202,6 +206,7 @@ void TopologyDataHandler<TopologyElementType,  VecT>::linkToTetrahedronDataArray
     }
 
     _container->d_tetrahedron.addOutput(this);
+    _container->addTopologyHandler(this);
     m_tetrahedraLinked = true;
 }
 
@@ -226,6 +231,7 @@ void TopologyDataHandler<TopologyElementType,  VecT>::linkToHexahedronDataArray(
     }
 
     _container->d_hexahedron.addOutput(this);
+    _container->addTopologyHandler(this);
     m_hexahedraLinked = true;
 }
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyDataHandler.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyDataHandler.inl
@@ -81,7 +81,7 @@ void TopologyDataHandler<TopologyElementType,  VecT>::handleTopologyChange()
 
     m_topologyData->setDataSetArraySize(m_topology->getNbPoints());
 
-    sofa::core::topology::TopologyHandler::ApplyTopologyChanges(m_changeList.getValue(), m_topology->getNbPoints());
+    sofa::core::topology::TopologyHandler::ApplyTopologyChanges(m_topology->m_changeList.getValue(), m_topology->getNbPoints());
 }
 
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyContainer.cpp
@@ -1049,5 +1049,10 @@ void TriangleSetTopologyContainer::updateTopologyHandlerGraph()
 }
 
 
+void TriangleSetTopologyContainer::addTopologyHandler(sofa::core::topology::TopologyHandler* _TopologyHandler)
+{
+    this->m_enginesList.push_back(_TopologyHandler);
+}
+
 
 } //namespace sofa::component::topology

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyContainer.h
@@ -257,6 +257,9 @@ public:
     /** \brief Returns the type of the topology */
     sofa::core::topology::TopologyElementType getTopologyType() const override { return sofa::core::topology::TopologyElementType::TRIANGLE; }
 
+    /// \brief function to add a TopologyHandler to the current list of engines.
+    void addTopologyHandler(sofa::core::topology::TopologyHandler* _TopologyHandler);
+
 protected:
 
     /** \brief Creates the TriangleSet array.

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseMeshTopology.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseMeshTopology.cpp
@@ -372,13 +372,6 @@ std::list<const TopologyChange *>::const_iterator BaseMeshTopology::endStateChan
 }
 
 
-
-void BaseMeshTopology::addTopologyHandler(TopologyHandler* _TopologyHandler)
-{
-    msg_error() << "addTopologyHandler() not supported.";
-    (void)_TopologyHandler;
-}
-
 Topology::EdgeID BaseMeshTopology::getEdgeIndex(PointID, PointID)
 {
     msg_error() << "getEdgeIndex() not supported.";

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseMeshTopology.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseMeshTopology.cpp
@@ -372,20 +372,6 @@ std::list<const TopologyChange *>::const_iterator BaseMeshTopology::endStateChan
 }
 
 
-std::list<TopologyHandler *>::const_iterator BaseMeshTopology::beginTopologyHandler() const
-{
-    msg_error() << "beginTopologyHandler() not supported.";
-    std::list<TopologyHandler *>::const_iterator l;
-    return l;
-}
-
-
-std::list<TopologyHandler *>::const_iterator BaseMeshTopology::endTopologyHandler() const
-{
-    msg_error() << "endTopologyHandler() not supported.";
-    std::list<TopologyHandler *>::const_iterator l;
-    return l;
-}
 
 void BaseMeshTopology::addTopologyHandler(TopologyHandler* _TopologyHandler)
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseMeshTopology.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseMeshTopology.h
@@ -306,14 +306,6 @@ public:
     /** \brief Adds a TopologyHandler to the list.
     */
     virtual void addTopologyHandler(TopologyHandler* _TopologyHandler);
-
-    /** \brief Provides an iterator on the first element in the list of TopologyHandler objects.
-    */
-    virtual std::list<TopologyHandler *>::const_iterator beginTopologyHandler() const;
-
-    /** \brief Provides an iterator on the last element in the list of TopologyHandler objects.
-    */
-    virtual std::list<TopologyHandler *>::const_iterator endTopologyHandler() const;
     /// @}
 
     // functions returning border elements. To be moved in a mapping.

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseMeshTopology.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseMeshTopology.h
@@ -314,15 +314,14 @@ public:
 
 
     ////////////////////////////////////// DEPRECATED ///////////////////////////////////////////
-    SOFA_ATTRIBUTE_DISABLED("v21.06", "PR#2085", "This method has been removed as it is not part of the new topology change design.")
+    SOFA_ATTRIBUTE_DISABLED("v21.06 (PR#2085)", "v21.06 (PR#2085)", "This method has been removed as it is not part of the new topology change design.")
     std::list<TopologyHandler*>::const_iterator beginTopologyHandler() const = delete;
 
-    SOFA_ATTRIBUTE_DISABLED("v21.06", "PR#2085", "This method has been removed as it is not part of the new topology change design.")
+    SOFA_ATTRIBUTE_DISABLED("v21.06 (PR#2085)", "v21.06 (PR#2085)", "This method has been removed as it is not part of the new topology change design.")
     std::list<TopologyHandler*>::const_iterator endTopologyHandler() const = delete;
 
-    SOFA_ATTRIBUTE_DISABLED("v21.06", "PR#2085", "This method has been removed from this Base class as it is common to static topology and is now in TopologyContainer.")
+    SOFA_ATTRIBUTE_DISABLED("v21.06 (PR#2085)", "v21.06 (PR#2085)", "This method has been removed from this Base class as it is common to static topology and is now in TopologyContainer.")
     void addTopologyHandler(TopologyHandler* _TopologyHandler) = delete;
-
 protected:
 
     sofa::core::objectmodel::DataFileName fileTopology;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseMeshTopology.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseMeshTopology.h
@@ -312,6 +312,17 @@ public:
 
     virtual const sofa::helper::vector <PointID>& getPointsOnBorder();
 
+
+    ////////////////////////////////////// DEPRECATED ///////////////////////////////////////////
+    SOFA_ATTRIBUTE_DISABLED("v21.06", "PR#2085", "This method has been removed as it is not part of the new topology change design.")
+    std::list<TopologyHandler*>::const_iterator beginTopologyHandler() const = delete;
+
+    SOFA_ATTRIBUTE_DISABLED("v21.06", "PR#2085", "This method has been removed as it is not part of the new topology change design.")
+    std::list<TopologyHandler*>::const_iterator endTopologyHandler() const = delete;
+
+    SOFA_ATTRIBUTE_DISABLED("v21.06", "PR#2085", "This method has been removed from this Base class as it is common to static topology and is now in TopologyContainer.")
+    void addTopologyHandler(TopologyHandler* _TopologyHandler) = delete;
+
 protected:
 
     sofa::core::objectmodel::DataFileName fileTopology;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseMeshTopology.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseMeshTopology.h
@@ -303,9 +303,6 @@ public:
     */
     virtual std::list<const TopologyChange *>::const_iterator endStateChange() const;
 
-    /** \brief Adds a TopologyHandler to the list.
-    */
-    virtual void addTopologyHandler(TopologyHandler* _TopologyHandler);
     /// @}
 
     // functions returning border elements. To be moved in a mapping.

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopology.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopology.cpp
@@ -122,16 +122,6 @@ std::list<const TopologyChange *>::const_iterator TopologyContainer::beginStateC
     return (m_stateChangeList.getValue()).begin();
 }
 
-std::list<TopologyHandler *>::const_iterator TopologyContainer::endTopologyHandler() const
-{
-    return m_TopologyHandlerList.end();
-}
-
-std::list<TopologyHandler *>::const_iterator TopologyContainer::beginTopologyHandler() const
-{
-    return m_TopologyHandlerList.begin();
-}
-
 void TopologyContainer::resetTopologyChangeList()
 {
     std::list<const TopologyChange *>& my_changeList = *(m_changeList.beginEdit());

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopology.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopology.cpp
@@ -97,7 +97,6 @@ void TopologyContainer::addStateChange(const TopologyChange *topologyChange)
 void TopologyContainer::addTopologyHandler(TopologyHandler *_TopologyHandler)
 {
     m_TopologyHandlerList.push_back(_TopologyHandler);
-    m_TopologyHandlerList.back()->m_changeList.setParent(&this->m_changeList);
     this->updateTopologyHandlerGraph();
 }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopology.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopology.h
@@ -250,7 +250,7 @@ public:
 
     /** \brief Adds a TopologyHandler to the list.
     */
-    void addTopologyHandler(TopologyHandler* _TopologyHandler) override;
+    void addTopologyHandler(TopologyHandler* _TopologyHandler);
 
 
     /** \brief Free each Topology changes in the list and remove them from the list

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopology.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopology.h
@@ -253,14 +253,6 @@ public:
     void addTopologyHandler(TopologyHandler* _TopologyHandler) override;
 
 
-    /** \brief Provides an iterator on the first element in the list of TopologyHandler objects.
-     */
-    std::list<TopologyHandler *>::const_iterator beginTopologyHandler() const override;
-
-    /** \brief Provides an iterator on the last element in the list of TopologyHandler objects.
-     */
-    std::list<TopologyHandler *>::const_iterator endTopologyHandler() const override;
-
     /** \brief Free each Topology changes in the list and remove them from the list
     *
     */
@@ -269,8 +261,7 @@ public:
     ///@}
 
 
-protected:
-
+public:
     virtual void updateTopologyHandlerGraph() {}
 
     /// Array of topology modifications that have already occured (addition) or will occur next (deletion).

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.cpp
@@ -36,6 +36,12 @@ size_t TopologyHandler::getNumberOfTopologicalChanges()
 //////////////////////////////   Generic Handling of Topology Event    /////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+TopologyHandler::TopologyHandler()
+    : m_topology(nullptr)
+{
+    
+}
+
 void TopologyHandler::ApplyTopologyChanges(const std::list<const core::topology::TopologyChange*>& _topologyChangeEvents, const Size _dataSize)
 {
     if (!this->isTopologyDataRegistered())
@@ -122,15 +128,17 @@ void TopologyHandler::update()
     sofa::helper::AdvancedTimer::stepEnd(msg.c_str());
 }
 
-bool TopologyHandler::registerTopology()
-{
-    return false;
-}
-
 bool TopologyHandler::registerTopology(sofa::core::topology::BaseMeshTopology* _topology)
 {
-    SOFA_UNUSED(_topology);
-    return false;
+    m_topology = dynamic_cast<sofa::core::topology::TopologyContainer*>(_topology);
+
+    if (m_topology == nullptr)
+    {
+        msg_info("TopologyHandler") << "Topology: " << _topology->getName() << " is not dynamic, topology engine on Data '" << m_data_name << "' won't be registered.";
+        return false;
+    }
+
+    return true;
 }
 
 } // namespace sofa

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.cpp
@@ -28,7 +28,7 @@ namespace sofa::core::topology
 
 size_t TopologyHandler::getNumberOfTopologicalChanges()
 {
-    return (m_changeList.getValue()).size();
+    return (m_topology->m_changeList.getValue()).size();
 }
 
 
@@ -122,7 +122,7 @@ void TopologyHandler::update()
     if (!this->isTopologyDataRegistered())
         return;
 
-    std::string msg = this->getName() + " - doUpdate: Nbr changes: " + std::to_string(m_changeList.getValue().size());
+    std::string msg = this->getName() + " - doUpdate: Nbr changes: " + std::to_string(m_topology->m_changeList.getValue().size());
     sofa::helper::AdvancedTimer::stepBegin(msg.c_str());
     this->handleTopologyChange();
     sofa::helper::AdvancedTimer::stepEnd(msg.c_str());

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <sofa/core/DataEngine.h>
+#include <sofa/core/topology/BaseTopology.h>
 #include <sofa/core/topology/TopologyChange.h>
 #include <sofa/core/fwd.h>
 
@@ -38,7 +39,7 @@ namespace topology
 class SOFA_CORE_API TopologyHandler : public sofa::core::objectmodel::DDGNode
 {
 protected:
-    TopologyHandler() {}
+    TopologyHandler();
 
 public:
     virtual void handleTopologyChange() {}
@@ -162,13 +163,17 @@ public:
     void setNamePrefix(const std::string& s) { m_prefix = s; }
     std::string getName() { return m_prefix + m_data_name; }
 
-    virtual bool registerTopology();
+    /** Function to link the topological Data with the engine and the current topology. And init everything.
+    * This function should be used at the end of the all declaration link to this Data while using it in a component.
+    */
     virtual bool registerTopology(sofa::core::topology::BaseMeshTopology* _topology);
 protected:
     /// use to define engine name.
     std::string m_prefix;
     /// use to define data handled name.
     std::string m_data_name;
+
+    sofa::core::topology::TopologyContainer* m_topology;
 };
 
 } // namespace topology

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.h
@@ -167,7 +167,7 @@ public:
 
 
     ////////////////////////////////////// DEPRECATED ///////////////////////////////////////////
-    SOFA_ATTRIBUTE_DISABLED("v21.06", "PR#2085", "This method has been removed as it is not part of the new topology change design.")
+    SOFA_ATTRIBUTE_DISABLED("v21.06 (PR#2085)", "v21.06 (PR#2085)", "This method has been removed as it is not part of the new topology change design.")
     bool registerTopology() = delete;
 
 protected:

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.h
@@ -164,6 +164,12 @@ public:
     * This function should be used at the end of the all declaration link to this Data while using it in a component.
     */
     virtual bool registerTopology(sofa::core::topology::BaseMeshTopology* _topology);
+
+
+    ////////////////////////////////////// DEPRECATED ///////////////////////////////////////////
+    SOFA_ATTRIBUTE_DISABLED("v21.06", "PR#2085", "This method has been removed as it is not part of the new topology change design.")
+    bool registerTopology() = delete;
+
 protected:
     /// use to define engine name.
     std::string m_prefix;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.h
@@ -47,9 +47,6 @@ public:
     void update() override;
 
 public:
-    // really need to be a Data??
-    Data <std::list<const TopologyChange *> >m_changeList;
-
 
     virtual void ApplyTopologyChanges(const std::list< const core::topology::TopologyChange*>& _topologyChangeEvents, const Size _dataSize);
 


### PR DESCRIPTION
This PR includes PR #2082 

- move topology pointer in mother class TopologyHandler instead of TopologyDataHandler
- Register TopologyHandler directly in each TopologyContainer level instead of inside a global list.
- Remove Data list of TopologyChange from each TopologyHandler and use directly the one from the TopologyContainer

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
