### PR TITLE
[all] Remove method registerTopologicalData() from TopologyData

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
@@ -717,7 +717,6 @@ void DiagonalMass<DataTypes, MassType>::initTopologyHandlers()
         d_vertexMass.linkToTetrahedronDataArray();
     if (hexaGeo)
         d_vertexMass.linkToHexahedronDataArray();
-    d_vertexMass.registerTopologicalData();
 }
 
 template <class DataTypes, class MassType>

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/SubsetMapping.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/SubsetMapping.inl
@@ -161,7 +161,6 @@ void SubsetMapping<TIn, TOut>::init()
         {
             // Initialize functions and parameters for topological changes
             f_indices.createTopologyHandler(topology);
-            f_indices.registerTopologicalData();
         }
         else
         {

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.h
@@ -73,11 +73,6 @@ public:
     /// To create topological engine link to this Data. Pointer to current topology is needed.
     void createTopologyHandler(sofa::core::topology::BaseMeshTopology* _topology, sofa::component::topology::TopologyDataHandler< TopologyElementType, VecT>* topoEngine);
 
-    /// Function to link the topological Data with the engine and the current topology. And init everything.
-    /// This function should be used at the end of the all declaration link to this Data while using it in a component.
-    void registerTopologicalData();
-
-
     /// Link Data to topology arrays
     void linkToPointDataArray();
     void linkToEdgeDataArray();
@@ -127,6 +122,8 @@ public:
     SOFA_ATTRIBUTE_DISABLED("v21.06 (PR#2082)", "v21.06 (PR#2082)", "This method was deleted because it presented risks. Use Write/Read Accessor instead.")
     value_type& operator[](int i) = delete;
 
+    SOFA_ATTRIBUTE_DISABLED("v21.06 (PR#2086)", "v21.06 (PR#2086)", "This method has been removed as it's mechanism is now automatically done in TopologyHandler.")
+    void registerTopologicalData() = delete;
 
 protected:
     sofa::component::topology::TopologyDataHandler< TopologyElementType, VecT>* m_topologyHandler;

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
@@ -91,20 +91,13 @@ void TopologyData <TopologyElementType, VecT>::createTopologyHandler(sofa::core:
         this->linkToElementDataArray((TopologyElementType*)nullptr);
         msg_info(this->getOwner()) << "TopologyData: " << this->getName() << " initialized with dynamic " << this->m_topology->getClassName() << "Topology.";
     }
+    else
+        msg_info(this->getOwner()) << "TopologyData: " << this->getName() << " has no engine. Topological changes will be disabled. Use createTopologicalEngine method before registerTopologicalData to allow topological changes.";
     
     //if (this->getOwner() && dynamic_cast<sofa::core::objectmodel::BaseObject*>(this->getOwner())) 
     //    dynamic_cast<sofa::core::objectmodel::BaseObject*>(this->getOwner())->addSlave(this->m_topologyHandler);   
 }
 
-
-template <typename TopologyElementType, typename VecT>
-void TopologyData <TopologyElementType, VecT>::registerTopologicalData()
-{
-    if (this->m_topologyHandler)
-        this->m_topologyHandler->registerTopology(this->m_topology);
-    else if (!this->m_topology)
-        msg_info(this->getOwner()) << "TopologyData: " << this->getName() << " has no engine. Topological changes will be disabled. Use createTopologyHandler method before registerTopologicalData to allow topological changes." ;
-}
 
 /// Method used to link Data to point Data array, using the engine's method
 template <typename TopologyElementType, typename VecT>

--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
@@ -827,7 +827,6 @@ template<class VecType>
 void VisualModelImpl::addTopoHandler(topology::PointData<VecType>* data, int algo)
 {
     data->createTopologyHandler(m_topology, new VisualModelPointHandler<VecType>(this, data, algo));
-    data->registerTopologicalData();
 }
 
 void VisualModelImpl::init()

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/LineLocalMinDistanceFilter.cpp
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/LineLocalMinDistanceFilter.cpp
@@ -208,7 +208,6 @@ void LineLocalMinDistanceFilter::init()
 
         pointInfoHandler = new PointInfoHandler(this,&m_pointInfo);
         m_pointInfo.createTopologyHandler(bmt, pointInfoHandler);
-        m_pointInfo.registerTopologicalData();
 
         helper::vector< LineInfo >& lInfo = *(m_lineInfo.beginEdit());
         lInfo.resize(bmt->getNbEdges());
@@ -216,7 +215,6 @@ void LineLocalMinDistanceFilter::init()
 
         lineInfoHandler = new LineInfoHandler(this,&m_lineInfo);
         m_lineInfo.createTopologyHandler(bmt, lineInfoHandler);
-        m_lineInfo.registerTopologicalData();
     }
 }
 

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/PointLocalMinDistanceFilter.cpp
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/PointLocalMinDistanceFilter.cpp
@@ -219,7 +219,6 @@ void PointLocalMinDistanceFilter::init()
 
         pointInfoHandler = new PointInfoHandler(this,&m_pointInfo);
         m_pointInfo.createTopologyHandler(bmt, pointInfoHandler);
-        m_pointInfo.registerTopologicalData();
     }
     if(this->isRigid())
     {

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/TriangleLocalMinDistanceFilter.cpp
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/TriangleLocalMinDistanceFilter.cpp
@@ -115,7 +115,6 @@ void TriangleLocalMinDistanceFilter::init()
 
         pointInfoHandler = new PointInfoHandler(this,&m_pointInfo);
         m_pointInfo.createTopologyHandler(bmt, pointInfoHandler);
-        m_pointInfo.registerTopologicalData();
         m_pointInfo.createTopologyHandler(bmt);
 
         helper::vector< PointInfo >& pInfo = *(m_pointInfo.beginEdit());
@@ -130,7 +129,6 @@ void TriangleLocalMinDistanceFilter::init()
 
         lineInfoHandler = new LineInfoHandler(this,&m_lineInfo);
         m_lineInfo.createTopologyHandler(bmt, lineInfoHandler);
-        m_lineInfo.registerTopologicalData();
 
         helper::vector< LineInfo >& lInfo = *(m_lineInfo.beginEdit());
         lInfo.resize(bmt->getNbEdges());
@@ -144,7 +142,6 @@ void TriangleLocalMinDistanceFilter::init()
 
         triangleInfoHandler = new TriangleInfoHandler(this,&m_triangleInfo);
         m_triangleInfo.createTopologyHandler(bmt, triangleInfoHandler);
-        m_triangleInfo.registerTopologicalData();
 
         helper::vector< TriangleInfo >& tInfo = *(m_triangleInfo.beginEdit());
         tInfo.resize(bmt->getNbTriangles());

--- a/applications/plugins/LMConstraint/src/LMConstraint/DOFBlockerLMConstraint.inl
+++ b/applications/plugins/LMConstraint/src/LMConstraint/DOFBlockerLMConstraint.inl
@@ -98,7 +98,6 @@ void DOFBlockerLMConstraint<DataTypes>::init()
         // Initialize functions and parameters
         m_pointHandler = new FCTPointHandler(this, &f_indices);
         f_indices.createTopologyHandler(_topology, m_pointHandler);
-        f_indices.registerTopologicalData();        
     }
     else
     {

--- a/applications/plugins/LMConstraint/src/LMConstraint/FixedLMConstraint.inl
+++ b/applications/plugins/LMConstraint/src/LMConstraint/FixedLMConstraint.inl
@@ -122,7 +122,6 @@ void FixedLMConstraint<DataTypes>::init()
         // Initialize functions and parameters
         m_pointHandler = new FCPointHandler(this, &f_indices);
         f_indices.createTopologyHandler(_topology, m_pointHandler);
-        f_indices.registerTopologicalData();
     }
     else
     {

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticleSink.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticleSink.inl
@@ -85,7 +85,6 @@ void ParticleSink<DataTypes>::init()
 
         // Initialize functions and parameters for topology data and handler
         d_fixed.createTopologyHandler(_topology);
-        d_fixed.registerTopologicalData();
     }
 
     msg_info() << "Normal=" << d_planeNormal.getValue() << " d0=" << d_planeD0.getValue() << " d1=" << d_planeD1.getValue();

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticleSource.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticleSource.inl
@@ -84,7 +84,6 @@ void ParticleSource<DataTypes>::init()
     {
         m_pointHandler = new PSPointHandler(this, &m_lastparticles);
         m_lastparticles.createTopologyHandler(_topology, m_pointHandler);
-        m_lastparticles.registerTopologicalData();
     }
 
     msg_info() << "ParticleSource: center = " << d_center.getValue();

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.inl
@@ -127,7 +127,6 @@ void AffineMovementConstraint<DataTypes>::init()
         // Initialize functions and parameters
         m_pointHandler = new FCPointHandler(this, &m_indices);
         m_indices.createTopologyHandler(_topology, m_pointHandler);
-        m_indices.registerTopologicalData();
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ConstantForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ConstantForceField.inl
@@ -98,7 +98,6 @@ void ConstantForceField<DataTypes>::init()
         
         // Initialize functions and parameters for topology data and handler
         d_indices.createTopologyHandler(_topology);
-        d_indices.registerTopologicalData();
 
         m_systemSize = _topology->getNbPoints();
     }

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/EdgePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/EdgePressureForceField.inl
@@ -97,7 +97,6 @@ void EdgePressureForceField<DataTypes>::init()
 
     // init edgesubsetData engine
     edgePressureMap.createTopologyHandler(m_topology);
-    edgePressureMap.registerTopologicalData();
 
     if (dmin.getValue()!=dmax.getValue())
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.inl
@@ -147,7 +147,6 @@ void FixedConstraint<DataTypes>::init()
         // Initialize topological functions
         m_pointHandler = new FCPointHandler(this, &d_indices);
         d_indices.createTopologyHandler(_topology, m_pointHandler);
-        d_indices.registerTopologicalData();
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedPlaneConstraint.inl
@@ -257,7 +257,6 @@ void FixedPlaneConstraint<DataTypes>::init()
         /// Initialize functions and parameters
         m_pointHandler = new FCPointHandler(this, &d_indices);
         d_indices.createTopologyHandler(_topology, m_pointHandler);
-        d_indices.registerTopologicalData();
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedTranslationConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedTranslationConstraint.inl
@@ -113,10 +113,7 @@ void FixedTranslationConstraint<DataTypes>::init()
         // Initialize functions and parameters
         m_pointHandler = new FCPointHandler(this, &f_indices);
         f_indices.createTopologyHandler(_topology, m_pointHandler);
-        f_indices.registerTopologicalData();
-
         f_coordinates.createTopologyHandler(_topology);
-        f_coordinates.registerTopologicalData();
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/HermiteSplineConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/HermiteSplineConstraint.inl
@@ -84,7 +84,6 @@ void HermiteSplineConstraint<DataTypes>::init()
 
         // Initialize functions and parameters for topology data and handler
         m_indices.createTopologyHandler(_topology);
-        m_indices.registerTopologicalData();
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearForceField.inl
@@ -63,7 +63,6 @@ void LinearForceField<DataTypes>::init()
         
         // Initialize functions and parameters for topology data and handler
         points.createTopologyHandler(_topology);
-        points.registerTopologicalData();
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.inl
@@ -143,7 +143,6 @@ void LinearMovementConstraint<DataTypes>::init()
         // Initialize functions and parameters
         m_pointHandler = new FCPointHandler(this, &m_indices);
         m_indices.createTopologyHandler(_topology, m_pointHandler);
-        m_indices.registerTopologicalData();        
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearVelocityConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearVelocityConstraint.inl
@@ -141,10 +141,7 @@ void LinearVelocityConstraint<TDataTypes>::init()
         // Initialize functions and parameters
         m_pointHandler = new FCPointHandler(this, &d_indices);
         d_indices.createTopologyHandler(_topology, m_pointHandler);
-        d_indices.registerTopologicalData();
-
         d_coordinates.createTopologyHandler(_topology);
-        d_coordinates.registerTopologicalData();
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/OscillatingTorsionPressureForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/OscillatingTorsionPressureForceField.inl
@@ -96,7 +96,6 @@ void OscillatingTorsionPressureForceField<DataTypes>::init()
     origCenter.resize( numPts );
 
     trianglePressureMap.createTopologyHandler(m_topology);
-    trianglePressureMap.registerTopologicalData();
 
     initTriangleInformation();
 }

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ParabolicConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ParabolicConstraint.inl
@@ -74,7 +74,6 @@ void ParabolicConstraint<DataTypes>::init()
 
         // Initialize functions and parameters for topology data and handler
         m_indices.createTopologyHandler(_topology);
-        m_indices.registerTopologicalData();
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
@@ -159,7 +159,6 @@ void PartialLinearMovementConstraint<DataTypes>::init()
         // Initialize functions and parameters
         m_pointHandler = new FCPointHandler(this, &m_indices);
         m_indices.createTopologyHandler(_topology, m_pointHandler);
-        m_indices.registerTopologicalData();
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PatchTestMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PatchTestMovementConstraint.inl
@@ -127,7 +127,6 @@ void PatchTestMovementConstraint<DataTypes>::init()
         // Initialize functions and parameters
         m_pointHandler = new FCPointHandler(this, &d_indices);
         d_indices.createTopologyHandler(_topology, m_pointHandler);
-        d_indices.registerTopologicalData();
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.inl
@@ -125,7 +125,6 @@ void ProjectDirectionConstraint<DataTypes>::init()
         // Initialize functions and parameters
         m_pointHandler = new FCPointHandler(this, &f_indices);
         f_indices.createTopologyHandler(_topology, m_pointHandler);
-        f_indices.registerTopologicalData();
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.inl
@@ -124,7 +124,6 @@ void ProjectToLineConstraint<DataTypes>::init()
         // Initialize functions and parameters
         m_pointHandler = new FCPointHandler(this, &f_indices);
         f_indices.createTopologyHandler(_topology, m_pointHandler);
-        f_indices.registerTopologicalData();        
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
@@ -125,7 +125,6 @@ void ProjectToPlaneConstraint<DataTypes>::init()
         // Initialize functions and parameters
         m_pointHandler = new FCPointHandler(this, &f_indices);
         f_indices.createTopologyHandler(_topology, m_pointHandler);
-        f_indices.registerTopologicalData();
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.inl
@@ -125,7 +125,6 @@ void ProjectToPointConstraint<DataTypes>::init()
         // Initialize functions and parameters
         m_pointHandler = new FCPointHandler(this, &f_indices);
         f_indices.createTopologyHandler(_topology, m_pointHandler);
-        f_indices.registerTopologicalData();
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/QuadPressureForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/QuadPressureForceField.inl
@@ -82,7 +82,6 @@ void QuadPressureForceField<DataTypes>::init()
     }
 
     quadPressureMap.createTopologyHandler(m_topology);
-    quadPressureMap.registerTopologicalData();
 
     initQuadInformation();
 }

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TrianglePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TrianglePressureForceField.inl
@@ -84,7 +84,6 @@ template <class DataTypes> void TrianglePressureForceField<DataTypes>::init()
     }
 
     trianglePressureMap.createTopologyHandler(m_topology);
-    trianglePressureMap.registerTopologicalData();
 	
     initTriangleInformation();
 		

--- a/modules/SofaConstraint/src/SofaConstraint/UncoupledConstraintCorrection.inl
+++ b/modules/SofaConstraint/src/SofaConstraint/UncoupledConstraintCorrection.inl
@@ -164,7 +164,6 @@ void UncoupledConstraintCorrection<DataTypes>::init()
             if (_topology != nullptr)
             {
                 compliance.createTopologyHandler(_topology);
-                compliance.registerTopologicalData();
             }
         }
     }

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/FastTriangularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/FastTriangularBendingSprings.inl
@@ -379,8 +379,7 @@ void FastTriangularBendingSprings<DataTypes>::init()
     d_edgeSprings.createTopologyHandler(m_topology,d_edgeHandler);
     d_edgeSprings.linkToPointDataArray();
     d_edgeSprings.linkToTriangleDataArray();
-    d_edgeSprings.registerTopologicalData();
-
+    
     this->reinit();
 }
 

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/QuadularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/QuadularBendingSprings.inl
@@ -521,7 +521,6 @@ void QuadularBendingSprings<DataTypes>::init()
     edgeInfo.createTopologyHandler(m_topology,edgeHandler);
     edgeInfo.linkToPointDataArray();
     edgeInfo.linkToQuadDataArray();
-    edgeInfo.registerTopologicalData();
 
     /// prepare to store info in the edge array
     helper::vector<EdgeInformation>& edgeInf = *(edgeInfo.beginEdit());

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.inl
@@ -487,7 +487,6 @@ void TriangularBendingSprings<DataTypes>::init()
     edgeInfo.createTopologyHandler(m_topology,edgeHandler);
     edgeInfo.linkToPointDataArray();
     edgeInfo.linkToTriangleDataArray();
-    edgeInfo.registerTopologicalData();
 
     this->reinit();
 }

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.inl
@@ -232,12 +232,10 @@ template <class DataTypes> void TriangularBiquadraticSpringsForceField<DataTypes
 
     // Edge info
     edgeInfo.createTopologyHandler(m_topology,edgeHandler);
-    edgeInfo.registerTopologicalData();
     edgeInfo.endEdit();
 
     // Triangle info
     triangleInfo.createTopologyHandler(m_topology,triangleHandler);
-    triangleInfo.registerTopologicalData();
     triangleInfo.endEdit();
 }
 

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.inl
@@ -171,10 +171,7 @@ template <class DataTypes> void TriangularQuadraticSpringsForceField<DataTypes>:
     }
 
     triangleInfo.createTopologyHandler(m_topology,triangleHandler);
-    triangleInfo.registerTopologicalData();
-
     edgeInfo.createTopologyHandler(m_topology,edgeHandler);
-    edgeInfo.registerTopologicalData();
 
     if (m_topology->getNbTriangles()==0)
     {

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularTensorMassForceField.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularTensorMassForceField.inl
@@ -338,7 +338,6 @@ template <class DataTypes> void TriangularTensorMassForceField<DataTypes>::init(
 
     edgeInfo.createTopologyHandler(m_topology,edgeHandler);
     edgeInfo.linkToTriangleDataArray();
-    edgeInfo.registerTopologicalData();
     edgeInfo.endEdit();
 }
 

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/VectorSpringForceField.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/VectorSpringForceField.inl
@@ -183,7 +183,6 @@ void VectorSpringForceField<DataTypes>::init()
         {
             edgeHandler = new EdgeDataHandler(this,&springArray);
             springArray.createTopologyHandler(m_topology,edgeHandler);
-            springArray.registerTopologicalData();
         }
     }
     this->getContext()->get(edgeGeo);

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/BeamFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/BeamFEMForceField.inl
@@ -158,7 +158,6 @@ void BeamFEMForceField<DataTypes>::init()
     }
 
     m_beamsData.createTopologyHandler(m_topology,m_edgeHandler);
-    m_beamsData.registerTopologicalData();
 
     reinit();
 }

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/HexahedralFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/HexahedralFEMForceField.inl
@@ -142,7 +142,6 @@ void HexahedralFEMForceField<DataTypes>::reinit()
                 (const std::vector< double >)0);
     }
     hexahedronInfo.createTopologyHandler(_topology,hexahedronHandler);
-    hexahedronInfo.registerTopologicalData();
     hexahedronInfo.endEdit();
 }
 

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TetrahedralCorotationalFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TetrahedralCorotationalFEMForceField.inl
@@ -149,8 +149,6 @@ void TetrahedralCorotationalFEMForceField<DataTypes>::reinit()
     }
 
     tetrahedronInfo.createTopologyHandler(m_topology,tetrahedronHandler);
-    tetrahedronInfo.registerTopologicalData();
-
     tetrahedronInfo.endEdit();
 }
 

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.inl
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.inl
@@ -119,16 +119,9 @@ void TriangularFEMForceFieldOptim<DataTypes>::init()
 
     // Create specific handler for TriangleData
     d_triangleInfo.createTopologyHandler(m_topology, triangleInfoHandler);
-    d_triangleInfo.registerTopologicalData();
-
     d_triangleState.createTopologyHandler(m_topology, triangleStateHandler);
-    d_triangleState.registerTopologicalData();
-
     d_edgeInfo.createTopologyHandler(m_topology);
-    d_edgeInfo.registerTopologicalData();
-
     d_vertexInfo.createTopologyHandler(m_topology);
-    d_vertexInfo.registerTopologicalData();
 
     if (m_topology->getNbTriangles()==0 && m_topology->getNbQuads()!=0 )
     {

--- a/modules/SofaMiscFem/src/SofaMiscFem/FastTetrahedralCorotationalForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/FastTetrahedralCorotationalForceField.inl
@@ -215,14 +215,12 @@ template <class DataTypes> void FastTetrahedralCorotationalForceField<DataTypes>
     /// prepare to store info in the edge array
     edgeInf.resize(m_topology->getNbEdges());
     edgeInfo.createTopologyHandler(m_topology);
-    edgeInfo.registerTopologicalData();
     edgeInfo.endEdit();
 
     helper::vector<Mat3x3>& pointInf = *(pointInfo.beginEdit());
     /// prepare to store info in the point array
     pointInf.resize(m_topology->getNbPoints());
     pointInfo.createTopologyHandler(m_topology);
-    pointInfo.registerTopologicalData();
     pointInfo.endEdit();
 
     if (_initialPoints.size() == 0)
@@ -242,7 +240,6 @@ template <class DataTypes> void FastTetrahedralCorotationalForceField<DataTypes>
     }
     /// set the call back function upon creation of a tetrahedron
     tetrahedronInfo.createTopologyHandler(m_topology,tetrahedronHandler);
-    tetrahedronInfo.registerTopologicalData();
     tetrahedronInfo.endEdit();
 
     updateTopologyInfo=true;

--- a/modules/SofaMiscFem/src/SofaMiscFem/QuadBendingFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/QuadBendingFEMForceField.inl
@@ -141,13 +141,10 @@ void QuadBendingFEMForceField<DataTypes>::init()
     }
     // Create specific handler for QuadData
     quadInfo.createTopologyHandler(m_topology, quadHandler);
-    quadInfo.registerTopologicalData();
 
     edgeInfo.createTopologyHandler(m_topology);
-    edgeInfo.registerTopologicalData();
 
     vertexInfo.createTopologyHandler(m_topology);
-    vertexInfo.registerTopologicalData(); 
 
     reinit();
 }

--- a/modules/SofaMiscFem/src/SofaMiscFem/StandardTetrahedralFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/StandardTetrahedralFEMForceField.inl
@@ -158,10 +158,7 @@ template <class DataTypes> void StandardTetrahedralFEMForceField<DataTypes>::ini
     }
 
     tetrahedronInfo.createTopologyHandler(m_topology,tetrahedronHandler);
-    tetrahedronInfo.registerTopologicalData();
-
     edgeInfo.createTopologyHandler(m_topology);
-    edgeInfo.registerTopologicalData();
 
     /** parse the parameter set */
     SetParameterArray paramSet=f_parameterSet.getValue();

--- a/modules/SofaMiscFem/src/SofaMiscFem/TetrahedralTensorMassForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TetrahedralTensorMassForceField.inl
@@ -296,8 +296,6 @@ template <class DataTypes> void TetrahedralTensorMassForceField<DataTypes>::init
 
     edgeInfo.createTopologyHandler(m_topology,edgeHandler);
     edgeInfo.linkToTetrahedronDataArray();
-    edgeInfo.registerTopologicalData();
-
 
     if (m_topology->getNbTetrahedra()==0)
     {

--- a/modules/SofaMiscFem/src/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.inl
@@ -240,8 +240,6 @@ template <class DataTypes> void TetrahedronHyperelasticityFEMForceField<DataType
     edgeInf.resize(m_topology->getNbEdges());
     m_edgeInfo.createTopologyHandler(m_topology);
 
-    m_edgeInfo.registerTopologicalData();
-
     m_edgeInfo.endEdit();
 
     // get restPosition
@@ -261,8 +259,6 @@ template <class DataTypes> void TetrahedronHyperelasticityFEMForceField<DataType
 
     /// set the call back function upon creation of a tetrahedron
     m_tetrahedronInfo.createTopologyHandler(m_topology,m_tetrahedronHandler);
-    m_tetrahedronInfo.registerTopologicalData();
-
     m_tetrahedronInfo.endEdit();
     //testDerivatives();
 

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularAnisotropicFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularAnisotropicFEMForceField.inl
@@ -103,7 +103,6 @@ void TriangularAnisotropicFEMForceField<DataTypes>::init()
 
     // Create specific handler for TriangleData
     localFiberDirection.createTopologyHandler(m_topology, triangleHandler);
-    localFiberDirection.registerTopologicalData();
 
     Inherited::init();
     reinit();

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
@@ -173,13 +173,8 @@ void TriangularFEMForceField<DataTypes>::init()
 
     // Create specific Engine for TriangleData
     triangleInfo.createTopologyHandler(m_topology, triangleEngine);
-    triangleInfo.registerTopologicalData();
-
     edgeInfo.createTopologyHandler(m_topology);
-    edgeInfo.registerTopologicalData();
-
     vertexInfo.createTopologyHandler(m_topology);
-    vertexInfo.registerTopologicalData();
 
 
     if (f_method.getValue() == "small")

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -1079,10 +1079,6 @@ void MeshMatrixMass<DataTypes, MassType>::initTopologyHandlers(sofa::core::topol
 
     // PointData need to be linked to Edge container in any topology. d_edgeMassInfo as EdgeData is automatically register to Edge container
     d_vertexMassInfo.linkToEdgeDataArray();
-    
-    // Register topological Data
-    d_vertexMassInfo.registerTopologicalData();
-    d_edgeMassInfo.registerTopologicalData();
 }
 
 
@@ -1309,9 +1305,6 @@ void MeshMatrixMass<DataTypes, MassType>::computeMass()
         m_edgeMassHandler->applyTriangleCreation(trianglesAdded, m_topology->getTriangles(), emptyAncestors, emptyCoefficients);
         m_massLumpingCoeff = 2.0;
     }
-
-    d_vertexMassInfo.registerTopologicalData();
-    d_edgeMassInfo.registerTopologicalData();
 
     d_vertexMassInfo.endEdit();
     d_edgeMassInfo.endEdit();

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglAttribute.inl
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglAttribute.inl
@@ -74,7 +74,6 @@ void OglAttribute< size, type, DataTypes>::init()
     if (_topology!= nullptr && handleDynamicTopology.getValue())
     {
         value.createTopologyHandler(_topology);
-        value.registerTopologicalData();
     }
 }
 


### PR DESCRIPTION
This PR includes PR #2085 and #2082
will be merge in TopologyChange Poc branch

This method is not needed anymore in the TopologyHandler mechanism.

Remove this call from all components

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
