### PR TITLE
[SofaBaseTopology] Add callback mechanism in TopologyHandler to handle TopologyChanges

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.h
@@ -110,7 +110,24 @@ public:
     /// Remove Element after a displacement of vertices, ie. add element based on previous position topology revision.
     virtual void removeOnMovedPosition(const sofa::helper::vector<Index>& indices);
 
+    /** Method to add a callback when a element is deleted from this container. It will be called by @sa remove method for example.
+    * This is only to specify a specific behevior/computation when removing an element from this container. Otherwise normal deletion is applyed.
+    * Parameters are @param Index of the element which is detroyed and @value_type value hold by this container.
+    */
+    void applyDestroyFunction(std::function<void(Index, value_type&)> func) { m_DestroyFunction = func; }
+    
+    /** Method to add a callback when a element is created in this container. It will be called by @sa add method for example.
+    * This is only to specify a specific behevior/computation when adding an element in this container. Otherwise default constructor of the element is used.
+    * @param Index of the element which is created.
+    * @param value_type value hold by this container.
+    * @param TopologyElementType type of topologyElement created.
+    * @param List of ancestor indices.
+    * @param List of coefficient respect to the ancestor indices.
+    */
+    void applyCreateFunction(std::function<void(Index, value_type&, const TopologyElementType&, const sofa::helper::vector< Index >&, const sofa::helper::vector< double >&)> func) { m_CreateFunction = func; }
 
+    std::function<void(Index, value_type&)> m_DestroyFunction;
+    std::function<void(Index, value_type&, const TopologyElementType&, const sofa::helper::vector< Index >&, const sofa::helper::vector< double >&)> m_CreateFunction;
 
     ////////////////////////////////////// DEPRECATED ///////////////////////////////////////////
     SOFA_ATTRIBUTE_DISABLED("v21.06 (PR#2082)", "v21.06 (PR#2082)", "This method has been removed as it is not part of the new topology change design.")
@@ -124,13 +141,7 @@ public:
 
     SOFA_ATTRIBUTE_DISABLED("v21.06 (PR#2086)", "v21.06 (PR#2086)", "This method has been removed as it's mechanism is now automatically done in TopologyHandler.")
     void registerTopologicalData() = delete;
-
-    void applyDestroyFunction(std::function<void(Index, value_type&)> func) { myDestroyFunction = func; }
-    void applyCreateFunction(std::function<void(Index, value_type&, const TopologyElementType&, const sofa::helper::vector< Index >&, const sofa::helper::vector< double >&)> func) { myCreateFunction = func; }
-
-    std::function<void(Index, value_type&)> myDestroyFunction;
-    std::function<void(Index, value_type&, const TopologyElementType&, const sofa::helper::vector< Index >&, const sofa::helper::vector< double >&)> myCreateFunction;
-
+    
 protected:
     sofa::component::topology::TopologyDataHandler< TopologyElementType, VecT>* m_topologyHandler;
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.h
@@ -125,6 +125,12 @@ public:
     SOFA_ATTRIBUTE_DISABLED("v21.06 (PR#2086)", "v21.06 (PR#2086)", "This method has been removed as it's mechanism is now automatically done in TopologyHandler.")
     void registerTopologicalData() = delete;
 
+    void applyDestroyFunction(std::function<void(Index, value_type&)> func) { myDestroyFunction = func; }
+    void applyCreateFunction(std::function<void(Index, value_type&, const TopologyElementType&, const sofa::helper::vector< Index >&, const sofa::helper::vector< double >&)> func) { myCreateFunction = func; }
+
+    std::function<void(Index, value_type&)> myDestroyFunction;
+    std::function<void(Index, value_type&, const TopologyElementType&, const sofa::helper::vector< Index >&, const sofa::helper::vector< double >&)> myCreateFunction;
+
 protected:
     sofa::component::topology::TopologyDataHandler< TopologyElementType, VecT>* m_topologyHandler;
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.h
@@ -114,7 +114,7 @@ public:
     * This is only to specify a specific behevior/computation when removing an element from this container. Otherwise normal deletion is applyed.
     * Parameters are @param Index of the element which is detroyed and @value_type value hold by this container.
     */
-    void applyDestroyFunction(std::function<void(Index, value_type&)> func) { m_DestroyFunction = func; }
+    void setDestructionCallback(std::function<void(Index, value_type&)> func) { p_onDestructionCallback = func; }
     
     /** Method to add a callback when a element is created in this container. It will be called by @sa add method for example.
     * This is only to specify a specific behevior/computation when adding an element in this container. Otherwise default constructor of the element is used.
@@ -124,10 +124,10 @@ public:
     * @param List of ancestor indices.
     * @param List of coefficient respect to the ancestor indices.
     */
-    void applyCreateFunction(std::function<void(Index, value_type&, const TopologyElementType&, const sofa::helper::vector< Index >&, const sofa::helper::vector< double >&)> func) { m_CreateFunction = func; }
+    void setCreationCallback(std::function<void(Index, value_type&, const TopologyElementType&, const sofa::helper::vector< Index >&, const sofa::helper::vector< double >&)> func) { p_onCreationCallback = func; }
 
-    std::function<void(Index, value_type&)> m_DestroyFunction;
-    std::function<void(Index, value_type&, const TopologyElementType&, const sofa::helper::vector< Index >&, const sofa::helper::vector< double >&)> m_CreateFunction;
+    std::function<void(Index, value_type&)> p_onDestructionCallback;
+    std::function<void(Index, value_type&, const TopologyElementType&, const sofa::helper::vector< Index >&, const sofa::helper::vector< double >&)> p_onCreationCallback;
 
     ////////////////////////////////////// DEPRECATED ///////////////////////////////////////////
     SOFA_ATTRIBUTE_DISABLED("v21.06 (PR#2082)", "v21.06 (PR#2082)", "This method has been removed as it is not part of the new topology change design.")

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
@@ -206,9 +206,9 @@ void TopologyData <TopologyElementType, VecT>::remove(const sofa::helper::vector
                 this->m_topologyHandler->applyDestroyFunction(index[i], data[index[i]]);
             }
 
-            if (myDestroyFunction)
+            if (m_DestroyFunction)
             {
-                myDestroyFunction(index[i], data[index[i]]);
+                m_DestroyFunction(index[i], data[index[i]]);
             }
 
             this->swap(index[i], last);
@@ -258,9 +258,9 @@ void TopologyData <TopologyElementType, VecT>::add(const sofa::helper::vector<In
                     (ancestors.empty() || coefs.empty()) ? empty_vecdouble : coefs[i],
                     (ancestorElems.empty()) ? nullptr : &ancestorElems[i]);
             
-            if (myCreateFunction)
+            if (m_CreateFunction)
             {
-                myCreateFunction(Index(i0 + i), t, elems[i],
+                m_CreateFunction(Index(i0 + i), t, elems[i],
                     (ancestors.empty() || coefs.empty()) ? empty_vecint : ancestors[i],
                     (ancestors.empty() || coefs.empty()) ? empty_vecdouble : coefs[i]);
             }

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
@@ -205,6 +205,13 @@ void TopologyData <TopologyElementType, VecT>::remove(const sofa::helper::vector
             if (this->m_topologyHandler) {
                 this->m_topologyHandler->applyDestroyFunction(index[i], data[index[i]]);
             }
+
+            if (myDestroyFunction)
+            {
+                std::cout << "apply myDestroyFunction" << std::endl;
+                myDestroyFunction(index[i], data[index[i]]);
+            }
+
             this->swap(index[i], last);
             --last;
         }
@@ -251,7 +258,14 @@ void TopologyData <TopologyElementType, VecT>::add(const sofa::helper::vector<In
                     (ancestors.empty() || coefs.empty()) ? empty_vecint : ancestors[i],
                     (ancestors.empty() || coefs.empty()) ? empty_vecdouble : coefs[i],
                     (ancestorElems.empty()) ? nullptr : &ancestorElems[i]);
-        
+            
+            if (myCreateFunction)
+            {
+                std::cout << "apply myCreateFunction" << std::endl;
+                myCreateFunction(Index(i0 + i), t, elems[i],
+                    (ancestors.empty() || coefs.empty()) ? empty_vecint : ancestors[i],
+                    (ancestors.empty() || coefs.empty()) ? empty_vecdouble : coefs[i]);
+            }
         }
     }
     this->endEdit();

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
@@ -208,7 +208,6 @@ void TopologyData <TopologyElementType, VecT>::remove(const sofa::helper::vector
 
             if (myDestroyFunction)
             {
-                std::cout << "apply myDestroyFunction" << std::endl;
                 myDestroyFunction(index[i], data[index[i]]);
             }
 
@@ -261,7 +260,6 @@ void TopologyData <TopologyElementType, VecT>::add(const sofa::helper::vector<In
             
             if (myCreateFunction)
             {
-                std::cout << "apply myCreateFunction" << std::endl;
                 myCreateFunction(Index(i0 + i), t, elems[i],
                     (ancestors.empty() || coefs.empty()) ? empty_vecint : ancestors[i],
                     (ancestors.empty() || coefs.empty()) ? empty_vecdouble : coefs[i]);

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
@@ -206,9 +206,9 @@ void TopologyData <TopologyElementType, VecT>::remove(const sofa::helper::vector
                 this->m_topologyHandler->applyDestroyFunction(index[i], data[index[i]]);
             }
 
-            if (m_DestroyFunction)
+            if (p_onDestructionCallback)
             {
-                m_DestroyFunction(index[i], data[index[i]]);
+                p_onDestructionCallback(index[i], data[index[i]]);
             }
 
             this->swap(index[i], last);
@@ -258,9 +258,9 @@ void TopologyData <TopologyElementType, VecT>::add(const sofa::helper::vector<In
                     (ancestors.empty() || coefs.empty()) ? empty_vecdouble : coefs[i],
                     (ancestorElems.empty()) ? nullptr : &ancestorElems[i]);
             
-            if (m_CreateFunction)
+            if (p_onCreationCallback)
             {
-                m_CreateFunction(Index(i0 + i), t, elems[i],
+                p_onCreationCallback(Index(i0 + i), t, elems[i],
                     (ancestors.empty() || coefs.empty()) ? empty_vecint : ancestors[i],
                     (ancestors.empty() || coefs.empty()) ? empty_vecdouble : coefs[i]);
             }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.cpp
@@ -63,12 +63,11 @@ void TopologyHandler::ApplyTopologyChanges(const std::list<const core::topology:
 
 
         // New version using map of callback
-        std::map < core::topology::TopologyChangeType, TopoChange_callback>::iterator itM;
+        std::map < core::topology::TopologyChangeType, TopologyChangeCallback>::iterator itM;
         itM = m_callbackMap.find(changeType);
 
         if (itM != m_callbackMap.end())
         {
-            std::cout << "m_callbackMap found" << std::endl;
             (*itM).second(*changeIt);
         }
 
@@ -198,7 +197,7 @@ void TopologyHandler::update()
     sofa::helper::AdvancedTimer::stepEnd(msg.c_str());
 }
 
-void TopologyHandler::addCallBack(core::topology::TopologyChangeType type, TopoChange_callback callback)
+void TopologyHandler::addCallBack(core::topology::TopologyChangeType type, TopologyChangeCallback callback)
 {
     // need to warn duplicate callback
     m_callbackMap[type] = callback;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.cpp
@@ -41,6 +41,11 @@ TopologyHandler::TopologyHandler()
 {
     
 }
+#define SOFA_CALLBACK_CASE(name, type) \
+    case core::topology::name: \
+        (*itM).second(static_cast< const type* >( *changeIt )); \
+        break;
+
 
 void TopologyHandler::ApplyTopologyChanges(const std::list<const core::topology::TopologyChange*>& _topologyChangeEvents, const Size _dataSize)
 {
@@ -56,6 +61,71 @@ void TopologyHandler::ApplyTopologyChanges(const std::list<const core::topology:
         std::string topoChangeType = "DefaultTopologyHandler: " + parseTopologyChangeTypeToString(changeType);
         sofa::helper::AdvancedTimer::stepBegin(topoChangeType);
 
+
+        // New version using map of callback
+        std::map < core::topology::TopologyChangeType, TopoChange_callback>::iterator itM;
+        itM = m_callbackMap.find(changeType);
+
+        if (itM != m_callbackMap.end())
+        {
+            std::cout << "m_callbackMap found" << std::endl;
+            (*itM).second(*changeIt);
+        }
+
+        /*
+        if (itM != m_callbackMap.end())
+        {
+            std::cout << "m_callbackMap found" << std::endl;
+            switch (changeType)
+            {
+                SOFA_CALLBACK_CASE(ENDING_EVENT, EndingEvent);
+
+                SOFA_CALLBACK_CASE(POINTSINDICESSWAP, PointsIndicesSwap);
+                SOFA_CALLBACK_CASE(POINTSADDED, PointsAdded);
+                SOFA_CALLBACK_CASE(POINTSREMOVED, PointsRemoved);
+                SOFA_CALLBACK_CASE(POINTSMOVED, PointsMoved);
+                SOFA_CALLBACK_CASE(POINTSRENUMBERING, PointsRenumbering);
+
+                SOFA_CALLBACK_CASE(EDGESINDICESSWAP, EdgesIndicesSwap);
+                SOFA_CALLBACK_CASE(EDGESADDED, EdgesAdded);
+                SOFA_CALLBACK_CASE(EDGESREMOVED, EdgesRemoved);
+                SOFA_CALLBACK_CASE(EDGESMOVED_REMOVING, EdgesMoved_Removing);
+                SOFA_CALLBACK_CASE(EDGESMOVED_ADDING, EdgesMoved_Adding);
+                SOFA_CALLBACK_CASE(EDGESRENUMBERING, EdgesRenumbering);
+
+                SOFA_CALLBACK_CASE(TRIANGLESINDICESSWAP, TrianglesIndicesSwap);
+                SOFA_CALLBACK_CASE(TRIANGLESADDED, TrianglesAdded);
+                SOFA_CALLBACK_CASE(TRIANGLESREMOVED, TrianglesRemoved);
+                SOFA_CALLBACK_CASE(TRIANGLESMOVED_REMOVING, TrianglesMoved_Removing);
+                SOFA_CALLBACK_CASE(TRIANGLESMOVED_ADDING, TrianglesMoved_Adding);
+                SOFA_CALLBACK_CASE(TRIANGLESRENUMBERING, TrianglesRenumbering);
+
+                SOFA_CALLBACK_CASE(TETRAHEDRAINDICESSWAP, TetrahedraIndicesSwap);
+                SOFA_CALLBACK_CASE(TETRAHEDRAADDED, TetrahedraAdded);
+                SOFA_CALLBACK_CASE(TETRAHEDRAREMOVED, TetrahedraRemoved);
+                SOFA_CALLBACK_CASE(TETRAHEDRAMOVED_REMOVING, TetrahedraMoved_Removing);
+                SOFA_CALLBACK_CASE(TETRAHEDRAMOVED_ADDING, TetrahedraMoved_Adding);
+                SOFA_CALLBACK_CASE(TETRAHEDRARENUMBERING, TetrahedraRenumbering);
+
+                SOFA_CALLBACK_CASE(QUADSINDICESSWAP, QuadsIndicesSwap);
+                SOFA_CALLBACK_CASE(QUADSADDED, QuadsAdded);
+                SOFA_CALLBACK_CASE(QUADSREMOVED, QuadsRemoved);
+                SOFA_CALLBACK_CASE(QUADSMOVED_REMOVING, QuadsMoved_Removing);
+                SOFA_CALLBACK_CASE(QUADSMOVED_ADDING, QuadsMoved_Adding);
+                SOFA_CALLBACK_CASE(QUADSRENUMBERING, QuadsRenumbering);
+
+                SOFA_CALLBACK_CASE(HEXAHEDRAINDICESSWAP, HexahedraIndicesSwap);
+                SOFA_CALLBACK_CASE(HEXAHEDRAADDED, HexahedraAdded);
+                SOFA_CALLBACK_CASE(HEXAHEDRAREMOVED, HexahedraRemoved);
+                SOFA_CALLBACK_CASE(HEXAHEDRAMOVED_REMOVING, HexahedraMoved_Removing);
+                SOFA_CALLBACK_CASE(HEXAHEDRAMOVED_ADDING, HexahedraMoved_Adding);
+                SOFA_CALLBACK_CASE(HEXAHEDRARENUMBERING, HexahedraRenumbering);
+            default:
+                break;
+            };
+        }*/
+
+        // old version to be removed.
         switch (changeType)
         {
 #define SOFA_CASE_EVENT(name,type) \
@@ -114,7 +184,7 @@ void TopologyHandler::ApplyTopologyChanges(const std::list<const core::topology:
         //++changeIt;
     }
 }
-
+#undef SOFA_CALLBACK_CASE
 
 void TopologyHandler::update()
 {
@@ -126,6 +196,12 @@ void TopologyHandler::update()
     sofa::helper::AdvancedTimer::stepBegin(msg.c_str());
     this->handleTopologyChange();
     sofa::helper::AdvancedTimer::stepEnd(msg.c_str());
+}
+
+void TopologyHandler::addCallBack(core::topology::TopologyChangeType type, TopoChange_callback callback)
+{
+    // need to warn duplicate callback
+    m_callbackMap[type] = callback;
 }
 
 bool TopologyHandler::registerTopology(sofa::core::topology::BaseMeshTopology* _topology)

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.cpp
@@ -41,10 +41,6 @@ TopologyHandler::TopologyHandler()
 {
     
 }
-#define SOFA_CALLBACK_CASE(name, type) \
-    case core::topology::name: \
-        (*itM).second(static_cast< const type* >( *changeIt )); \
-        break;
 
 
 void TopologyHandler::ApplyTopologyChanges(const std::list<const core::topology::TopologyChange*>& _topologyChangeEvents, const Size _dataSize)
@@ -71,58 +67,6 @@ void TopologyHandler::ApplyTopologyChanges(const std::list<const core::topology:
             (*itM).second(*changeIt);
         }
 
-        /*
-        if (itM != m_callbackMap.end())
-        {
-            std::cout << "m_callbackMap found" << std::endl;
-            switch (changeType)
-            {
-                SOFA_CALLBACK_CASE(ENDING_EVENT, EndingEvent);
-
-                SOFA_CALLBACK_CASE(POINTSINDICESSWAP, PointsIndicesSwap);
-                SOFA_CALLBACK_CASE(POINTSADDED, PointsAdded);
-                SOFA_CALLBACK_CASE(POINTSREMOVED, PointsRemoved);
-                SOFA_CALLBACK_CASE(POINTSMOVED, PointsMoved);
-                SOFA_CALLBACK_CASE(POINTSRENUMBERING, PointsRenumbering);
-
-                SOFA_CALLBACK_CASE(EDGESINDICESSWAP, EdgesIndicesSwap);
-                SOFA_CALLBACK_CASE(EDGESADDED, EdgesAdded);
-                SOFA_CALLBACK_CASE(EDGESREMOVED, EdgesRemoved);
-                SOFA_CALLBACK_CASE(EDGESMOVED_REMOVING, EdgesMoved_Removing);
-                SOFA_CALLBACK_CASE(EDGESMOVED_ADDING, EdgesMoved_Adding);
-                SOFA_CALLBACK_CASE(EDGESRENUMBERING, EdgesRenumbering);
-
-                SOFA_CALLBACK_CASE(TRIANGLESINDICESSWAP, TrianglesIndicesSwap);
-                SOFA_CALLBACK_CASE(TRIANGLESADDED, TrianglesAdded);
-                SOFA_CALLBACK_CASE(TRIANGLESREMOVED, TrianglesRemoved);
-                SOFA_CALLBACK_CASE(TRIANGLESMOVED_REMOVING, TrianglesMoved_Removing);
-                SOFA_CALLBACK_CASE(TRIANGLESMOVED_ADDING, TrianglesMoved_Adding);
-                SOFA_CALLBACK_CASE(TRIANGLESRENUMBERING, TrianglesRenumbering);
-
-                SOFA_CALLBACK_CASE(TETRAHEDRAINDICESSWAP, TetrahedraIndicesSwap);
-                SOFA_CALLBACK_CASE(TETRAHEDRAADDED, TetrahedraAdded);
-                SOFA_CALLBACK_CASE(TETRAHEDRAREMOVED, TetrahedraRemoved);
-                SOFA_CALLBACK_CASE(TETRAHEDRAMOVED_REMOVING, TetrahedraMoved_Removing);
-                SOFA_CALLBACK_CASE(TETRAHEDRAMOVED_ADDING, TetrahedraMoved_Adding);
-                SOFA_CALLBACK_CASE(TETRAHEDRARENUMBERING, TetrahedraRenumbering);
-
-                SOFA_CALLBACK_CASE(QUADSINDICESSWAP, QuadsIndicesSwap);
-                SOFA_CALLBACK_CASE(QUADSADDED, QuadsAdded);
-                SOFA_CALLBACK_CASE(QUADSREMOVED, QuadsRemoved);
-                SOFA_CALLBACK_CASE(QUADSMOVED_REMOVING, QuadsMoved_Removing);
-                SOFA_CALLBACK_CASE(QUADSMOVED_ADDING, QuadsMoved_Adding);
-                SOFA_CALLBACK_CASE(QUADSRENUMBERING, QuadsRenumbering);
-
-                SOFA_CALLBACK_CASE(HEXAHEDRAINDICESSWAP, HexahedraIndicesSwap);
-                SOFA_CALLBACK_CASE(HEXAHEDRAADDED, HexahedraAdded);
-                SOFA_CALLBACK_CASE(HEXAHEDRAREMOVED, HexahedraRemoved);
-                SOFA_CALLBACK_CASE(HEXAHEDRAMOVED_REMOVING, HexahedraMoved_Removing);
-                SOFA_CALLBACK_CASE(HEXAHEDRAMOVED_ADDING, HexahedraMoved_Adding);
-                SOFA_CALLBACK_CASE(HEXAHEDRARENUMBERING, HexahedraRenumbering);
-            default:
-                break;
-            };
-        }*/
 
         // old version to be removed.
         switch (changeType)
@@ -183,7 +127,6 @@ void TopologyHandler::ApplyTopologyChanges(const std::list<const core::topology:
         //++changeIt;
     }
 }
-#undef SOFA_CALLBACK_CASE
 
 void TopologyHandler::update()
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.h
@@ -47,6 +47,7 @@ public:
     void update() override;
 
 public:
+    typedef std::function<void(const core::topology::TopologyChange*)> TopoChange_callback;
 
     virtual void ApplyTopologyChanges(const std::list< const core::topology::TopologyChange*>& _topologyChangeEvents, const Size _dataSize);
 
@@ -165,6 +166,8 @@ public:
     */
     virtual bool registerTopology(sofa::core::topology::BaseMeshTopology* _topology);
 
+    void addCallBack(core::topology::TopologyChangeType type, TopoChange_callback callback);
+
 
     ////////////////////////////////////// DEPRECATED ///////////////////////////////////////////
     SOFA_ATTRIBUTE_DISABLED("v21.06 (PR#2085)", "v21.06 (PR#2085)", "This method has been removed as it is not part of the new topology change design.")
@@ -177,6 +180,7 @@ protected:
     std::string m_data_name;
 
     sofa::core::topology::TopologyContainer* m_topology;
+    std::map < core::topology::TopologyChangeType, TopoChange_callback> m_callbackMap;
 };
 
 } // namespace topology

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.h
@@ -47,7 +47,7 @@ public:
     void update() override;
 
 public:
-    typedef std::function<void(const core::topology::TopologyChange*)> TopoChange_callback;
+    typedef std::function<void(const core::topology::TopologyChange*)> TopologyChangeCallback;
 
     virtual void ApplyTopologyChanges(const std::list< const core::topology::TopologyChange*>& _topologyChangeEvents, const Size _dataSize);
 
@@ -166,7 +166,9 @@ public:
     */
     virtual bool registerTopology(sofa::core::topology::BaseMeshTopology* _topology);
 
-    void addCallBack(core::topology::TopologyChangeType type, TopoChange_callback callback);
+    /// Method to add a CallBack method to be used when a @sa core::topology::TopologyChangeType event is fired. The call back should use the @TopologyChangeCallback 
+    /// signature and pass the corresponding core::topology::TopologyChange* structure.
+    void addCallBack(core::topology::TopologyChangeType type, TopologyChangeCallback callback);
 
 
     ////////////////////////////////////// DEPRECATED ///////////////////////////////////////////
@@ -180,7 +182,7 @@ protected:
     std::string m_data_name;
 
     sofa::core::topology::TopologyContainer* m_topology;
-    std::map < core::topology::TopologyChangeType, TopoChange_callback> m_callbackMap;
+    std::map < core::topology::TopologyChangeType, TopologyChangeCallback> m_callbackMap;
 };
 
 } // namespace topology

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.h
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.h
@@ -60,7 +60,6 @@ public:
 
     typedef core::objectmodel::Data<VecCoord> DataVecCoord;
     typedef core::objectmodel::Data<VecDeriv> DataVecDeriv;
-    typedef typename topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge, sofa::helper::vector<EdgeInformation> > TriangularBSEdgeHandler;
 
     enum { N=DataTypes::spatial_dimensions };
     typedef defaulttype::Mat<N,N,Real> Mat;
@@ -111,6 +110,7 @@ protected:
         }
     };
 
+    typedef typename topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge, sofa::helper::vector<EdgeInformation> > TriangularBSEdgeHandler;
     sofa::component::topology::EdgeData<helper::vector<EdgeInformation> > edgeInfo; ///< Internal edge data
 
     bool updateMatrix;

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.h
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.h
@@ -60,6 +60,7 @@ public:
 
     typedef core::objectmodel::Data<VecCoord> DataVecCoord;
     typedef core::objectmodel::Data<VecDeriv> DataVecDeriv;
+    typedef typename topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge, sofa::helper::vector<EdgeInformation> > TriangularBSEdgeHandler;
 
     enum { N=DataTypes::spatial_dimensions };
     typedef defaulttype::Mat<N,N,Real> Mat;
@@ -112,49 +113,27 @@ protected:
 
     sofa::component::topology::EdgeData<helper::vector<EdgeInformation> > edgeInfo; ///< Internal edge data
 
-    class TriangularBSEdgeHandler : public topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge, helper::vector<EdgeInformation> >
-    {
-    public:
-        typedef typename TriangularBendingSprings<DataTypes>::EdgeInformation EdgeInformation;
-        TriangularBSEdgeHandler(TriangularBendingSprings<DataTypes>* _ff, topology::EdgeData<helper::vector<EdgeInformation> >* _data)
-            : topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge, sofa::helper::vector<EdgeInformation> >(_data), ff(_ff) {}
-
-        void applyCreateFunction(Index edgeIndex,
-                EdgeInformation &ei,
-                const core::topology::BaseMeshTopology::Edge& ,  const sofa::helper::vector< Index > &,
-                const sofa::helper::vector< double >&);
-
-        void applyTriangleCreation(const helper::vector<Index> &triangleAdded,
-                const helper::vector<core::topology::BaseMeshTopology::Triangle> & ,
-                const helper::vector<helper::vector<Index> > & ,
-                const helper::vector<helper::vector<double> > &);
-
-        void applyTriangleDestruction(const helper::vector<Index> &triangleRemoved);
-
-        void applyPointDestruction(const helper::vector<Index> &pointIndices);
-
-        void applyPointRenumbering(const helper::vector<Index> &pointToRenumber);
-
-        using topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge, helper::vector<EdgeInformation> >::ApplyTopologyChange;
-        /// Callback to add triangles elements.
-        void ApplyTopologyChange(const core::topology::TrianglesAdded* /*event*/);
-        /// Callback to remove triangles elements.
-        void ApplyTopologyChange(const core::topology::TrianglesRemoved* /*event*/);
-
-        /// Callback to remove points elements.
-        void ApplyTopologyChange(const core::topology::PointsRemoved* /*event*/);
-        /// Callback to renumbering on points elements.
-        void ApplyTopologyChange(const core::topology::PointsRenumbering* /*event*/);
-
-    protected:
-        TriangularBendingSprings<DataTypes>* ff;
-    };    
-
     bool updateMatrix;
     TriangularBendingSprings(/*double _ks, double _kd*/);
     //TriangularBendingSprings(); //MechanicalState<DataTypes> *mm1 = nullptr, MechanicalState<DataTypes> *mm2 = nullptr);
 
     virtual ~TriangularBendingSprings();
+
+    void applyEdgeCreation(Index edgeIndex,
+        EdgeInformation& ei,
+        const core::topology::BaseMeshTopology::Edge&, const sofa::helper::vector< Index >&,
+        const sofa::helper::vector< double >&);
+
+    void applyTriangleCreation(const helper::vector<Index>& triangleAdded,
+        const helper::vector<core::topology::BaseMeshTopology::Triangle>&,
+        const helper::vector<helper::vector<Index> >&,
+        const helper::vector<helper::vector<double> >&);
+
+    void applyTriangleDestruction(const helper::vector<Index>& triangleRemoved);
+
+    void applyPointDestruction(const helper::vector<Index>& pointIndices);
+
+    void applyPointRenumbering(const helper::vector<Index>& pointToRenumber);
 public:
     /// Searches triangle topology and creates the bending springs
     void init() override;

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.inl
@@ -36,11 +36,9 @@ namespace sofa::component::forcefield
 typedef core::topology::BaseMeshTopology::EdgesInTriangle EdgesInTriangle;
 
 template< class DataTypes>
-void TriangularBendingSprings<DataTypes>::TriangularBSEdgeHandler::applyCreateFunction(Index , EdgeInformation &ei, const core::topology::Edge &, 
+void TriangularBendingSprings<DataTypes>::applyEdgeCreation(Index , EdgeInformation &ei, const core::topology::Edge &,
     const sofa::helper::vector<Index> &, const sofa::helper::vector<double> &)
 {
-    if (ff)
-    {
         unsigned int u,v;
         /// set to zero the edge stiffness matrix
         for (u=0; u<N; ++u)
@@ -53,43 +51,38 @@ void TriangularBendingSprings<DataTypes>::TriangularBSEdgeHandler::applyCreateFu
 
         ei.is_activated=false;
         ei.is_initialized=false;
-
-    }
 }
 
 
 
 template< class DataTypes>
-void TriangularBendingSprings<DataTypes>::TriangularBSEdgeHandler::applyTriangleCreation(const sofa::helper::vector<Index> &triangleAdded, const sofa::helper::vector<core::topology::Triangle> &, 
+void TriangularBendingSprings<DataTypes>::applyTriangleCreation(const sofa::helper::vector<Index> &triangleAdded, const sofa::helper::vector<core::topology::Triangle> &, 
     const sofa::helper::vector<sofa::helper::vector<Index> > &, const sofa::helper::vector<sofa::helper::vector<double> > &)
 {
     using namespace core::topology;
-    if (ff)
-    {
-
-        double m_ks=ff->getKs();
-        double m_kd=ff->getKd();
+        double m_ks=getKs();
+        double m_kd=getKd();
 
         unsigned int u,v;
 
         unsigned int nb_activated = 0;
 
-        const typename DataTypes::VecCoord& restPosition=ff->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
+        const typename DataTypes::VecCoord& restPosition=mstate->read(core::ConstVecCoordId::restPosition())->getValue();
 
-        helper::vector<EdgeInformation>& edgeData = *(ff->edgeInfo.beginEdit());
+        helper::vector<EdgeInformation>& edgeData = *(edgeInfo.beginEdit());
 
         for (unsigned int i=0; i<triangleAdded.size(); ++i)
         {
 
             /// describe the jth edge index of triangle no i
-            EdgesInTriangle te2 = ff->m_topology->getEdgesInTriangle(triangleAdded[i]);
+            EdgesInTriangle te2 = m_topology->getEdgesInTriangle(triangleAdded[i]);
             /// describe the jth vertex index of triangle no i
-            Triangle t2 = ff->m_topology->getTriangle(triangleAdded[i]);
+            Triangle t2 = m_topology->getTriangle(triangleAdded[i]);
 
             for(unsigned int j=0; j<3; ++j)
             {
 
-                EdgeInformation &ei = edgeData[te2[j]]; // ff->edgeInfo
+                EdgeInformation &ei = edgeData[te2[j]]; // edgeInfo
                 if(!(ei.is_initialized))
                 {
 
@@ -105,7 +98,7 @@ void TriangularBendingSprings<DataTypes>::TriangularBSEdgeHandler::applyTriangle
                         }
                     }
 
-                    const auto& shell = ff->m_topology->getTrianglesAroundEdge(edgeIndex);
+                    const auto& shell = m_topology->getTrianglesAroundEdge(edgeIndex);
                     if (shell.size()==2)
                     {
 
@@ -117,19 +110,19 @@ void TriangularBendingSprings<DataTypes>::TriangularBSEdgeHandler::applyTriangle
                         if(shell[0] == triangleAdded[i])
                         {
 
-                            te1 = ff->m_topology->getEdgesInTriangle(shell[1]);
-                            t1 = ff->m_topology->getTriangle(shell[1]);
+                            te1 = m_topology->getEdgesInTriangle(shell[1]);
+                            t1 = m_topology->getTriangle(shell[1]);
 
                         }
                         else   // shell[1] == triangleAdded[i]
                         {
 
-                            te1 = ff->m_topology->getEdgesInTriangle(shell[0]);
-                            t1 = ff->m_topology->getTriangle(shell[0]);
+                            te1 = m_topology->getEdgesInTriangle(shell[0]);
+                            t1 = m_topology->getTriangle(shell[0]);
                         }
 
-                        int i1 = ff->m_topology->getEdgeIndexInTriangle(te1, edgeIndex); //edgeIndex //te1[j]
-                        int i2 = ff->m_topology->getEdgeIndexInTriangle(te2, edgeIndex); // edgeIndex //te2[j]
+                        int i1 = m_topology->getEdgeIndexInTriangle(te1, edgeIndex); //edgeIndex //te1[j]
+                        int i2 = m_topology->getEdgeIndexInTriangle(te2, edgeIndex); // edgeIndex //te2[j]
 
                         ei.m1 = t1[i1];
                         ei.m2 = t2[i2];
@@ -159,46 +152,41 @@ void TriangularBendingSprings<DataTypes>::TriangularBSEdgeHandler::applyTriangle
             }
 
         }
-
-        ff->edgeInfo.endEdit();
-    }
-
+        edgeInfo.endEdit();    
 }
 
 
 template< class DataTypes>
-void TriangularBendingSprings<DataTypes>::TriangularBSEdgeHandler::applyTriangleDestruction(const sofa::helper::vector<Index> &triangleRemoved)
+void TriangularBendingSprings<DataTypes>::applyTriangleDestruction(const sofa::helper::vector<Index> &triangleRemoved)
 {
     using namespace core::topology;
-    if (ff)
-    {
 
-        double m_ks=ff->getKs(); // typename DataTypes::
-        double m_kd=ff->getKd(); // typename DataTypes::
+        double m_ks=getKs(); // typename DataTypes::
+        double m_kd=getKd(); // typename DataTypes::
 
         //unsigned int u,v;
 
-        const typename DataTypes::VecCoord& restPosition=ff->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
-        helper::vector<EdgeInformation>& edgeData = *(ff->edgeInfo.beginEdit());
+        const typename DataTypes::VecCoord& restPosition=mstate->read(core::ConstVecCoordId::restPosition())->getValue();
+        helper::vector<EdgeInformation>& edgeData = *(edgeInfo.beginEdit());
 
         for (unsigned int i=0; i<triangleRemoved.size(); ++i)
         {
             /// describe the jth edge index of triangle no i
-            EdgesInTriangle te = ff->m_topology->getEdgesInTriangle(triangleRemoved[i]);
+            EdgesInTriangle te = m_topology->getEdgesInTriangle(triangleRemoved[i]);
             /// describe the jth vertex index of triangle no i
-            //Triangle t = ff->m_topology->getTriangle(triangleRemoved[i]);
+            //Triangle t = m_topology->getTriangle(triangleRemoved[i]);
 
 
             for(unsigned int j=0; j<3; ++j)
             {
 
-                EdgeInformation &ei = edgeData[te[j]]; // ff->edgeInfo
+                EdgeInformation &ei = edgeData[te[j]]; // edgeInfo
                 if(ei.is_initialized)
                 {
 
                     unsigned int edgeIndex = te[j];
 
-                    const auto& shell = ff->m_topology->getTrianglesAroundEdge(edgeIndex);
+                    const auto& shell = m_topology->getTrianglesAroundEdge(edgeIndex);
                     if (shell.size()==3)
                     {
 
@@ -209,10 +197,10 @@ void TriangularBendingSprings<DataTypes>::TriangularBSEdgeHandler::applyTriangle
 
                         if(shell[0] == triangleRemoved[i])
                         {
-                            te1 = ff->m_topology->getEdgesInTriangle(shell[1]);
-                            t1 = ff->m_topology->getTriangle(shell[1]);
-                            te2 = ff->m_topology->getEdgesInTriangle(shell[2]);
-                            t2 = ff->m_topology->getTriangle(shell[2]);
+                            te1 = m_topology->getEdgesInTriangle(shell[1]);
+                            t1 = m_topology->getTriangle(shell[1]);
+                            te2 = m_topology->getEdgesInTriangle(shell[2]);
+                            t2 = m_topology->getTriangle(shell[2]);
 
                         }
                         else
@@ -221,25 +209,25 @@ void TriangularBendingSprings<DataTypes>::TriangularBSEdgeHandler::applyTriangle
                             if(shell[1] == triangleRemoved[i])
                             {
 
-                                te1 = ff->m_topology->getEdgesInTriangle(shell[2]);
-                                t1 = ff->m_topology->getTriangle(shell[2]);
-                                te2 = ff->m_topology->getEdgesInTriangle(shell[0]);
-                                t2 = ff->m_topology->getTriangle(shell[0]);
+                                te1 = m_topology->getEdgesInTriangle(shell[2]);
+                                t1 = m_topology->getTriangle(shell[2]);
+                                te2 = m_topology->getEdgesInTriangle(shell[0]);
+                                t2 = m_topology->getTriangle(shell[0]);
 
                             }
                             else   // shell[2] == triangleRemoved[i]
                             {
 
-                                te1 = ff->m_topology->getEdgesInTriangle(shell[0]);
-                                t1 = ff->m_topology->getTriangle(shell[0]);
-                                te2 = ff->m_topology->getEdgesInTriangle(shell[1]);
-                                t2 = ff->m_topology->getTriangle(shell[1]);
+                                te1 = m_topology->getEdgesInTriangle(shell[0]);
+                                t1 = m_topology->getTriangle(shell[0]);
+                                te2 = m_topology->getEdgesInTriangle(shell[1]);
+                                t2 = m_topology->getTriangle(shell[1]);
 
                             }
                         }
 
-                        int i1 = ff->m_topology->getEdgeIndexInTriangle(te1, edgeIndex);
-                        int i2 = ff->m_topology->getEdgeIndexInTriangle(te2, edgeIndex);
+                        int i1 = m_topology->getEdgeIndexInTriangle(te1, edgeIndex);
+                        int i2 = m_topology->getEdgeIndexInTriangle(te2, edgeIndex);
 
                         ei.m1 = t1[i1];
                         ei.m2 = t2[i2];
@@ -276,44 +264,20 @@ void TriangularBendingSprings<DataTypes>::TriangularBSEdgeHandler::applyTriangle
 
         }
 
-        ff->edgeInfo.endEdit();
-    }
-
+        edgeInfo.endEdit();
 }
 
+
 template<class DataTypes>
-void TriangularBendingSprings<DataTypes>::TriangularBSEdgeHandler::ApplyTopologyChange(const core::topology::TrianglesAdded* e)
+void TriangularBendingSprings<DataTypes>::applyPointDestruction(const sofa::helper::vector<Index> &tab)
 {
     using namespace core::topology;
-    const auto &triangleAdded = e->getIndexArray();
-    const sofa::helper::vector<Triangle> &elems = e->getElementArray();
-    const auto & ancestors = e->ancestorsList;
-    const sofa::helper::vector<sofa::helper::vector<double> > & coefs = e->coefs;
-
-    applyTriangleCreation(triangleAdded, elems, ancestors, coefs);
-}
-
-template<class DataTypes>
-void TriangularBendingSprings<DataTypes>::TriangularBSEdgeHandler::ApplyTopologyChange(const core::topology::TrianglesRemoved* e)
-{
-    const auto &triangleRemoved = e->getArray();
-
-    applyTriangleDestruction(triangleRemoved);
-}
-
-
-template<class DataTypes>
-void TriangularBendingSprings<DataTypes>::TriangularBSEdgeHandler::applyPointDestruction(const sofa::helper::vector<Index> &tab)
-{
-    using namespace core::topology;
-    if(ff)
-    {
         bool debug_mode = false;
 
-        unsigned int last = ff->m_topology->getNbPoints() -1;
+        unsigned int last = m_topology->getNbPoints() -1;
         unsigned int i,j;
 
-        helper::vector<EdgeInformation>& edgeInf = *(ff->edgeInfo.beginEdit());
+        helper::vector<EdgeInformation>& edgeInf = *(edgeInfo.beginEdit());
 
         sofa::helper::vector<unsigned int> lastIndexVec;
         for(unsigned int i_init = 0; i_init < tab.size(); ++i_init)
@@ -341,15 +305,15 @@ void TriangularBendingSprings<DataTypes>::TriangularBSEdgeHandler::applyPointDes
 
             }
 
-            const auto &shell= ff->m_topology->getTrianglesAroundVertex(lastIndexVec[i]);
+            const auto &shell= m_topology->getTrianglesAroundVertex(lastIndexVec[i]);
             for (j=0; j<shell.size(); ++j)
             {
 
-                Triangle tj = ff->m_topology->getTriangle(shell[j]);
+                Triangle tj = m_topology->getTriangle(shell[j]);
 
-                int vertexIndex = ff->m_topology->getVertexIndexInTriangle(tj, lastIndexVec[i]);
+                int vertexIndex = m_topology->getVertexIndexInTriangle(tj, lastIndexVec[i]);
 
-                EdgesInTriangle tej = ff->m_topology->getEdgesInTriangle(shell[j]);
+                EdgesInTriangle tej = m_topology->getEdgesInTriangle(shell[j]);
 
                 unsigned int ind_j = tej[vertexIndex];
 
@@ -396,18 +360,15 @@ void TriangularBendingSprings<DataTypes>::TriangularBSEdgeHandler::applyPointDes
             --last;
         }
 
-        ff->edgeInfo.endEdit();
-    }
+        edgeInfo.endEdit();
 }
 
 
 template<class DataTypes>
-void TriangularBendingSprings<DataTypes>::TriangularBSEdgeHandler::applyPointRenumbering(const sofa::helper::vector<Index> &tab)
+void TriangularBendingSprings<DataTypes>::applyPointRenumbering(const sofa::helper::vector<Index> &tab)
 {
-    if(ff)
-    {
-        helper::vector<EdgeInformation>& edgeInf = *(ff->edgeInfo.beginEdit());
-        for (unsigned int i = 0; i < ff->m_topology->getNbEdges(); ++i)
+        helper::vector<EdgeInformation>& edgeInf = *(edgeInfo.beginEdit());
+        for (unsigned int i = 0; i < m_topology->getNbEdges(); ++i)
         {
             if(edgeInf[i].is_activated)
             {
@@ -415,22 +376,7 @@ void TriangularBendingSprings<DataTypes>::TriangularBSEdgeHandler::applyPointRen
                 edgeInf[i].m2  = tab[edgeInf[i].m2];
             }
         }
-        ff->edgeInfo.endEdit();
-    }
-}
-
-template<class DataTypes>
-void TriangularBendingSprings<DataTypes>::TriangularBSEdgeHandler::ApplyTopologyChange(const core::topology::PointsRemoved* e)
-{
-    const auto & tab = e->getArray();
-    applyPointDestruction(tab);
-}
-
-template<class DataTypes>
-void TriangularBendingSprings<DataTypes>::TriangularBSEdgeHandler::ApplyTopologyChange(const core::topology::PointsRenumbering* e)
-{
-    const auto &newIndices = e->getIndexArray();
-    applyPointRenumbering(newIndices);
+        edgeInfo.endEdit();
 }
 
 
@@ -445,7 +391,7 @@ TriangularBendingSprings<DataTypes>::TriangularBendingSprings(/*double _ks, doub
     , m_topology(nullptr)
 {
     // Create specific handler for EdgeData
-    edgeHandler = new TriangularBSEdgeHandler(this, &edgeInfo);
+    edgeHandler = new TriangularBSEdgeHandler(&edgeInfo);
     //msg_error()<<"TriangularBendingSprings<DataTypes>::TriangularBendingSprings";
 }
 
@@ -488,6 +434,35 @@ void TriangularBendingSprings<DataTypes>::init()
     edgeInfo.linkToPointDataArray();
     edgeInfo.linkToTriangleDataArray();
 
+    edgeInfo.applyCreateFunction([this](Index edgeIndex, EdgeInformation& ei,
+        const core::topology::BaseMeshTopology::Edge& edge,
+        const sofa::helper::vector< Index >& ancestors,
+        const sofa::helper::vector< double >& coefs)
+    {
+        applyEdgeCreation(edgeIndex, ei, edge, ancestors, coefs);
+    });
+
+
+    edgeHandler->addCallBack(sofa::core::topology::TopologyChangeType::TRIANGLESADDED, [this](const core::topology::TopologyChange* eventTopo) {
+        const core::topology::TrianglesAdded* triAdd = static_cast<const core::topology::TrianglesAdded*>(eventTopo);
+        applyTriangleCreation(triAdd->getIndexArray(), triAdd->getElementArray(), triAdd->ancestorsList, triAdd->coefs);
+    });
+
+    edgeHandler->addCallBack(sofa::core::topology::TopologyChangeType::TRIANGLESREMOVED, [this](const core::topology::TopologyChange* eventTopo) {
+        const core::topology::TrianglesRemoved* triRemove = static_cast<const core::topology::TrianglesRemoved*>(eventTopo);
+        applyTriangleDestruction(triRemove->getArray());
+    });
+
+    edgeHandler->addCallBack(sofa::core::topology::TopologyChangeType::POINTSREMOVED, [this](const core::topology::TopologyChange* eventTopo) {
+        const core::topology::PointsRemoved* pRemove = static_cast<const core::topology::PointsRemoved*>(eventTopo);
+        applyPointDestruction(pRemove->getArray());
+    });
+
+    edgeHandler->addCallBack(sofa::core::topology::TopologyChangeType::POINTSRENUMBERING, [this](const core::topology::TopologyChange* eventTopo) {
+        const core::topology::PointsRenumbering* pRenum = static_cast<const core::topology::PointsRenumbering*>(eventTopo);
+        applyPointRenumbering(pRenum->getIndexArray());
+    });
+
     this->reinit();
 }
 
@@ -504,9 +479,9 @@ void TriangularBendingSprings<DataTypes>::reinit()
     for (i=0; i<m_topology->getNbEdges(); ++i)
     {
 
-        edgeHandler->applyCreateFunction(i, edgeInf[i],
-                m_topology->getEdge(i),  (const sofa::helper::vector< Index > )0,
-                (const sofa::helper::vector< double >)0);
+        applyEdgeCreation(i, edgeInf[i],
+            m_topology->getEdge(i),  (const sofa::helper::vector< Index > )0,
+            (const sofa::helper::vector< double >)0);
     }
 
     // create edge tensor by calling the triangle creation function
@@ -514,10 +489,10 @@ void TriangularBendingSprings<DataTypes>::reinit()
     for (i=0; i<m_topology->getNbTriangles(); ++i)
         triangleAdded.push_back(i);
 
-    edgeHandler->applyTriangleCreation(triangleAdded,
-            (const sofa::helper::vector<Triangle>)0,
-            (const sofa::helper::vector<sofa::helper::vector<Index> >)0,
-            (const sofa::helper::vector<sofa::helper::vector<double> >)0);
+    applyTriangleCreation(triangleAdded,
+        (const sofa::helper::vector<Triangle>)0,
+        (const sofa::helper::vector<sofa::helper::vector<Index> >)0,
+        (const sofa::helper::vector<sofa::helper::vector<double> >)0);
 
     edgeInfo.endEdit();
 }

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.inl
@@ -67,7 +67,7 @@ void TriangularBendingSprings<DataTypes>::applyTriangleCreation(const sofa::help
 
         unsigned int nb_activated = 0;
 
-        const typename DataTypes::VecCoord& restPosition=mstate->read(core::ConstVecCoordId::restPosition())->getValue();
+        const typename DataTypes::VecCoord& restPosition = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
 
         helper::vector<EdgeInformation>& edgeData = *(edgeInfo.beginEdit());
 
@@ -166,7 +166,7 @@ void TriangularBendingSprings<DataTypes>::applyTriangleDestruction(const sofa::h
 
         //unsigned int u,v;
 
-        const typename DataTypes::VecCoord& restPosition=mstate->read(core::ConstVecCoordId::restPosition())->getValue();
+        const typename DataTypes::VecCoord& restPosition = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
         helper::vector<EdgeInformation>& edgeData = *(edgeInfo.beginEdit());
 
         for (unsigned int i=0; i<triangleRemoved.size(); ++i)

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.inl
@@ -434,7 +434,7 @@ void TriangularBendingSprings<DataTypes>::init()
     edgeInfo.linkToPointDataArray();
     edgeInfo.linkToTriangleDataArray();
 
-    edgeInfo.applyCreateFunction([this](Index edgeIndex, EdgeInformation& ei,
+    edgeInfo.setCreationCallback([this](Index edgeIndex, EdgeInformation& ei,
         const core::topology::BaseMeshTopology::Edge& edge,
         const sofa::helper::vector< Index >& ancestors,
         const sofa::helper::vector< double >& coefs)

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.h
@@ -204,21 +204,10 @@ public:
     topology::PointData<sofa::helper::vector<VertexInformation> > vertexInfo; ///< Internal point data
     topology::EdgeData<sofa::helper::vector<EdgeInformation> > edgeInfo; ///< Internal edge data
 
-
-    class TRQSTriangleEngine : public topology::TopologyDataHandler<core::topology::BaseMeshTopology::Triangle,helper::vector<TriangleInformation> >
-    {
-    public:
-        TRQSTriangleEngine(TriangularFEMForceField<DataTypes>* _ff, topology::TriangleData<sofa::helper::vector<TriangleInformation> >* _data) : topology::TopologyDataHandler<core::topology::BaseMeshTopology::Triangle, sofa::helper::vector<TriangleInformation> >(_data), ff(_ff) {}
-
-        void applyCreateFunction(Index triangleIndex, TriangleInformation& ,
-                const core::topology::BaseMeshTopology::Triangle & t,
-                const sofa::helper::vector< Index > &,
-                const sofa::helper::vector< double > &);
-
-    protected:
-        TriangularFEMForceField<DataTypes>* ff;
-    };
-
+    void createTriangleInformation(Index triangleIndex, TriangleInformation&,
+        const core::topology::BaseMeshTopology::Triangle& t,
+        const sofa::helper::vector< Index >&,
+        const sofa::helper::vector< double >&);
 
     sofa::core::topology::BaseMeshTopology* m_topology;
 
@@ -315,8 +304,6 @@ public:
     Data<bool> showFracturableTriangles; ///< Flag activating rendering of triangles to fracture
 
     Data<bool> f_computePrincipalStress; ///< Compute principal stress for each triangle
-
-    TRQSTriangleEngine* triangleEngine;
 
     /// Link to be set to the topology container in the component graph.
     SingleLink<TriangularFEMForceField<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
@@ -144,7 +144,7 @@ void TriangularFEMForceField<DataTypes>::init()
     edgeInfo.createTopologyHandler(m_topology);
     vertexInfo.createTopologyHandler(m_topology);
 
-    triangleInfo.applyCreateFunction([this](Index triangleIndex, TriangleInformation& triInfo,
+    triangleInfo.setCreationCallback([this](Index triangleIndex, TriangleInformation& triInfo,
         const core::topology::BaseMeshTopology::Triangle& triangle,
         const sofa::helper::vector< Index >& ancestors,
         const sofa::helper::vector< double >& coefs) 

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
@@ -45,36 +45,6 @@ namespace sofa::component::forcefield
 using namespace sofa::core::topology;
 
 // --------------------------------------------------------------------------------------
-// ---  Topology Creation/Destruction functions
-// --------------------------------------------------------------------------------------
-
-template< class DataTypes>
-void TriangularFEMForceField<DataTypes>::TRQSTriangleEngine::applyCreateFunction(Index triangleIndex, TriangleInformation &, const core::topology::BaseMeshTopology::Triangle &t, const sofa::helper::vector<Index> &, const sofa::helper::vector<double> &)
-{
-    if (ff)
-    {
-
-        Index a = t[0];
-        Index b = t[1];
-        Index c = t[2];
-
-        switch(ff->method)
-        {
-        case SMALL :
-            ff->initSmall(triangleIndex,a,b,c);
-            ff->computeMaterialStiffness(triangleIndex,a,b,c);
-            break;
-
-        case LARGE :
-            ff->initLarge(triangleIndex,a,b,c);
-            ff->computeMaterialStiffness(triangleIndex,a,b,c);
-            break;
-        }
-    }
-}
-
-
-// --------------------------------------------------------------------------------------
 // --- constructor
 // --------------------------------------------------------------------------------------
 template <class DataTypes>
@@ -108,7 +78,6 @@ TriangularFEMForceField<DataTypes>::TriangularFEMForceField()
     , p_computeDrawInfo(false)
 {
     _anisotropicMaterial = false;
-    triangleEngine = new TRQSTriangleEngine(this, &triangleInfo);
 #ifdef PLOT_CURVE
     f_graphStress.setWidget("graph");
     f_graphCriteria.setWidget("graph");
@@ -124,7 +93,6 @@ TriangularFEMForceField<DataTypes>::TriangularFEMForceField()
 template <class DataTypes>
 TriangularFEMForceField<DataTypes>::~TriangularFEMForceField()
 {
-    if(triangleEngine) delete triangleEngine;
     if (p_drawColorMap) delete p_drawColorMap;
 }
 
@@ -172,11 +140,19 @@ void TriangularFEMForceField<DataTypes>::init()
     }
 
     // Create specific Engine for TriangleData
-    triangleInfo.createTopologyHandler(m_topology, triangleEngine);
+    triangleInfo.createTopologyHandler(m_topology);
     edgeInfo.createTopologyHandler(m_topology);
     vertexInfo.createTopologyHandler(m_topology);
 
-
+    triangleInfo.applyCreateFunction([this](Index triangleIndex, TriangleInformation& triInfo,
+        const core::topology::BaseMeshTopology::Triangle& triangle,
+        const sofa::helper::vector< Index >& ancestors,
+        const sofa::helper::vector< double >& coefs) 
+    {
+        createTriangleInformation(triangleIndex, triInfo, triangle, ancestors, coefs);
+    });
+       
+    
     if (f_method.getValue() == "small")
         method = SMALL;
     else if (f_method.getValue() == "large")
@@ -306,7 +282,7 @@ void TriangularFEMForceField<DataTypes>::reinit()
 
     for (Topology::TriangleID i=0; i<m_topology->getNbTriangles(); ++i)
     {
-        triangleEngine->applyCreateFunction(i, triangleInf[i],  m_topology->getTriangle(i),  (const sofa::helper::vector< Index > )0, (const sofa::helper::vector< double >)0);
+        createTriangleInformation(i, triangleInf[i],  m_topology->getTriangle(i),  (const sofa::helper::vector< Index > )0, (const sofa::helper::vector< double >)0);
     }
 
     edgeInfo.endEdit();
@@ -333,8 +309,35 @@ void TriangularFEMForceField<DataTypes>::reinit()
 #endif
 }
 
+// --------------------------------------------------------------------------------------
+// ---  Topology Creation/Destruction functions
+// --------------------------------------------------------------------------------------
 
+template <class DataTypes>
+void TriangularFEMForceField<DataTypes>::createTriangleInformation(Index triangleIndex, TriangleInformation&,
+    const core::topology::BaseMeshTopology::Triangle& t,
+    const sofa::helper::vector< Index >&,
+    const sofa::helper::vector< double >&)
+{
+    std::cout << "Calling TriangularFEMForceField<DataTypes>::createTriangleInfo: " << triangleIndex << std::endl;
 
+    Index a = t[0];
+    Index b = t[1];
+    Index c = t[2];
+
+    switch (method)
+    {
+    case SMALL:
+        initSmall(triangleIndex, a, b, c);
+        computeMaterialStiffness(triangleIndex, a, b, c);
+        break;
+
+    case LARGE:
+        initLarge(triangleIndex, a, b, c);
+        computeMaterialStiffness(triangleIndex, a, b, c);
+        break;
+    }
+}
 
 
 // --------------------------------------------------------------------------------------

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
@@ -319,8 +319,6 @@ void TriangularFEMForceField<DataTypes>::createTriangleInformation(Index triangl
     const sofa::helper::vector< Index >&,
     const sofa::helper::vector< double >&)
 {
-    std::cout << "Calling TriangularFEMForceField<DataTypes>::createTriangleInfo: " << triangleIndex << std::endl;
-
     Index a = t[0];
     Index b = t[1];
     Index c = t[2];


### PR DESCRIPTION
PR #2036 rebased and to be merge inside topologyChanges PoC branch.

Add mechanism of callbacks inside ```TopologyHandler``` instead of inheriting from it and override methods.

- Callback have been added inside ```TopologyDat``` a to define specific method when creating/destroying element (call by remove/add). See ```TriangularFEMForceField``` for an example
- Map of Callback has been added inside TopologyHandler to set specific callback depending on the topology event. See ```TriangularBendingSprings``` as an example which handle Edge but also Triangle removing/adding.

To discuss if this is better than inheriting from ```TopologyHandler```.

![image](https://user-images.githubusercontent.com/21199245/121326580-fa3f9f80-c912-11eb-9d89-0966330bbded.png)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
