### PR TITLE
[SofaGeneralEngine] Remove dep on IdentityMapping (because of helper::eq)

### DIFF
--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/GenerateGrid.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/GenerateGrid.inl
@@ -88,7 +88,7 @@ void GenerateGrid<DataTypes>::doUpdate()
         height = size[2]/freqH;
     Coord origin;
 
-    const auto minCorder = d_minCorner.getValue();
+    const auto& minCorder = d_minCorner.getValue();
     for (auto i = 0; i < Coord::spatial_dimensions; i++)
     {
         origin[i] = minCorder[i];
@@ -105,7 +105,7 @@ void GenerateGrid<DataTypes>::doUpdate()
         for(j=0;j<=freqW;++j) {
             for(i=0;i<=freqL;i++) {
                 // handle Vec2D case
-                auto t = Vec3(i * length, j * width, k * height);
+                const Vec3 t { i * length, j * width, k * height };
                 for (auto c = 0; c < Coord::spatial_dimensions; c++)
                 {
                     pos[c] = t[c];

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/GenerateGrid.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/GenerateGrid.inl
@@ -21,7 +21,6 @@
 ******************************************************************************/
 #pragma once
 #include "GenerateGrid.h"
-#include <SofaBaseMechanics/IdentityMapping.h>
 
 namespace sofa::component::engine
 {
@@ -88,9 +87,12 @@ void GenerateGrid<DataTypes>::doUpdate()
     else
         height = size[2]/freqH;
     Coord origin;
-    helper::eq(origin,Vec3(d_minCorner.getValue()));
 
-
+    const auto minCorder = d_minCorner.getValue();
+    for (auto i = 0; i < Coord::spatial_dimensions; i++)
+    {
+        origin[i] = minCorder[i];
+    }
 
 
     size_t  nbVertices= (freqL+1)*(freqH+1)*(freqW+1);
@@ -103,7 +105,12 @@ void GenerateGrid<DataTypes>::doUpdate()
         for(j=0;j<=freqW;++j) {
             for(i=0;i<=freqL;i++) {
                 // handle Vec2D case
-                helper::eq(pos,Vec3(i*length,j*width,k*height));
+                auto t = Vec3(i * length, j * width, k * height);
+                for (auto c = 0; c < Coord::spatial_dimensions; c++)
+                {
+                    pos[c] = t[c];
+                }
+
                 pos+=origin;
                 out[index++]=pos;
             }


### PR DESCRIPTION
IdentityMapping.h possesses some helper functions (eq & peq on float <-> double, and Coord <->OtherCoord)
This should be moved in a later PR.

This PR just removes the need of those utility functions in GenerateGrid (which has nothing to do with IdentityMapping obviously), thus removing the header inclusion.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
