### PR TITLE
[SofaGeneralSimpleFem] Remove *Containers

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.cpp
@@ -350,10 +350,6 @@ std::map<std::string, ComponentChange> uncreatableComponents = {
     { "BeamFEMForceField", Pluginized("v20.12", "SofaGeneralSimpleFem") },
     { "HexahedralFEMForceField", Pluginized("v20.12", "SofaGeneralSimpleFem") },
     { "HexahedralFEMForceFieldAndMass", Pluginized("v20.12", "SofaGeneralSimpleFem") },
-    { "LengthContainer", Pluginized("v20.12", "SofaGeneralSimpleFem") },
-    { "PoissonContainer", Pluginized("v20.12", "SofaGeneralSimpleFem") },
-    { "RadiusContainer", Pluginized("v20.12", "SofaGeneralSimpleFem") },
-    { "StiffnessContainer", Pluginized("v20.12", "SofaGeneralSimpleFem") },
     { "TetrahedralCorotationalFEMForceField", Pluginized("v20.12", "SofaGeneralSimpleFem") },
     { "TriangularFEMForceFieldOptim", Pluginized("v20.12", "SofaGeneralSimpleFem") },
 

--- a/modules/SofaGeneralSimpleFem/CMakeLists.txt
+++ b/modules/SofaGeneralSimpleFem/CMakeLists.txt
@@ -21,10 +21,6 @@ list(APPEND HEADER_FILES
     ${SOFAGENERALSIMPLEFEM_SRC}/HexahedralFEMForceFieldAndMass.inl
     ${SOFAGENERALSIMPLEFEM_SRC}/HexahedronFEMForceFieldAndMass.h
     ${SOFAGENERALSIMPLEFEM_SRC}/HexahedronFEMForceFieldAndMass.inl
-    ${SOFAGENERALSIMPLEFEM_SRC}/LengthContainer.h
-    ${SOFAGENERALSIMPLEFEM_SRC}/PoissonContainer.h
-    ${SOFAGENERALSIMPLEFEM_SRC}/RadiusContainer.h
-    ${SOFAGENERALSIMPLEFEM_SRC}/StiffnessContainer.h
     ${SOFAGENERALSIMPLEFEM_SRC}/TetrahedralCorotationalFEMForceField.h
     ${SOFAGENERALSIMPLEFEM_SRC}/TetrahedralCorotationalFEMForceField.inl
     ${SOFAGENERALSIMPLEFEM_SRC}/TriangularFEMForceFieldOptim.h

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/BeamFEMForceField.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/BeamFEMForceField.h
@@ -25,14 +25,6 @@
 
 #include <SofaGeneralSimpleFem/config.h>
 
-
-namespace sofa::component::container
-{
-class StiffnessContainer;
-class PoissonContainer;
-
-} // namespace sofa::component::container
-
 namespace  sofa::component::forcefield
 {
 
@@ -181,9 +173,6 @@ public:
     bool m_updateStiffnessMatrix;
     bool m_assembling;
     double m_lastUpdatedStep;
-
-    container::StiffnessContainer* m_stiffnessContainer;
-    container::PoissonContainer* m_poissonContainer;
 
     Quat& beamQuat(int i);
 

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/BeamFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/BeamFEMForceField.inl
@@ -34,8 +34,6 @@
 #include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/defaulttype/RigidTypes.h>
 
-#include "StiffnessContainer.h"
-#include "PoissonContainer.h"
 #include "BeamFEMForceField.h"
 
 
@@ -127,8 +125,6 @@ void BeamFEMForceField<DataTypes>::init()
     }
 
     BaseContext* context = this->getContext();
-    m_stiffnessContainer = context->BaseContext::get<container::StiffnessContainer>();
-    m_poissonContainer = context->BaseContext::get<container::PoissonContainer>();
 
     if(m_topology->getNbEdges()==0)
     {
@@ -183,10 +179,7 @@ void BeamFEMForceField<DataTypes>::reinitBeam(Index i)
     Index b = (*m_indexedElements)[i][1];
 
     const VecCoord& x0 = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
-    if (m_stiffnessContainer)
-        stiffness = m_stiffnessContainer->getStiffness(i) ;
-    else
-        stiffness =  d_youngModulus.getValue() ;
+    stiffness =  d_youngModulus.getValue() ;
 
     length = (x0[a].getCenter()-x0[b].getCenter()).norm() ;
 

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/LengthContainer.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/LengthContainer.h
@@ -20,17 +20,5 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
-#include <SofaGeneralSimpleFem/config.h>
 
-namespace sofa::component::container
-{
-
-class LengthContainer : public virtual sofa::core::objectmodel::BaseObject
-{
-public:
-    SOFA_CLASS(LengthContainer,core::objectmodel::BaseObject);
-
-    virtual double getLength(sofa::Index index) = 0;
-};
-
-} // namespace sofa::component::container
+#error "LengthContainer has been removed (PR21XX)."

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/LengthContainer.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/LengthContainer.h
@@ -21,4 +21,4 @@
 ******************************************************************************/
 #pragma once
 
-#error "LengthContainer has been removed (PR21XX)."
+#error "LengthContainer has been removed (PR2099)."

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/LengthContainer.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/LengthContainer.h
@@ -21,4 +21,4 @@
 ******************************************************************************/
 #pragma once
 
-#error "LengthContainer has been removed (PR2099)."
+#error "LengthContainer has been removed in v21.06 (PR2099)."

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/PoissonContainer.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/PoissonContainer.h
@@ -21,4 +21,4 @@
 ******************************************************************************/
 #pragma once
 
-#error "PoissonContainer has been removed (PR21XX)."
+#error "PoissonContainer has been removed (PR2099)."

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/PoissonContainer.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/PoissonContainer.h
@@ -21,4 +21,4 @@
 ******************************************************************************/
 #pragma once
 
-#error "PoissonContainer has been removed (PR2099)."
+#error "PoissonContainer has been removed in v21.06 (PR2099)."

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/PoissonContainer.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/PoissonContainer.h
@@ -20,17 +20,5 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
-#include <SofaGeneralSimpleFem/config.h>
 
-namespace sofa::component::container
-{
-
-class PoissonContainer : public virtual sofa::core::objectmodel::BaseObject
-{
-public:
-    SOFA_CLASS(PoissonContainer,sofa::core::objectmodel::BaseObject);
-
-    virtual double getPoisson(sofa::Index index) = 0;
-};
-
-} // namespace sofa::component::container
+#error "PoissonContainer has been removed (PR21XX)."

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/RadiusContainer.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/RadiusContainer.h
@@ -22,22 +22,4 @@
 #pragma once
 #include <SofaGeneralSimpleFem/config.h>
 
-#include <sofa/core/objectmodel/BaseObject.h>
-
-namespace sofa::component::container
-{
-
-class RadiusContainer : public virtual sofa::core::objectmodel::BaseObject
-{
-public:
-    SOFA_ABSTRACT_CLASS(RadiusContainer,sofa::core::objectmodel::BaseObject);
-
-    /// Get the radius around a given point
-    virtual double getPointRadius(sofa::Index index) = 0;
-    /// Get the radius around a given edge
-    virtual double getEdgeRadius(sofa::Index index) = 0;
-    /// Deprecated alias for getEdgeRadius
-    double getRadius(sofa::Index index) { return getEdgeRadius(index); }
-};
-
-} // namespace sofa::component::container
+#error "RadiusContainer has been removed (PR21XX)."

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/RadiusContainer.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/RadiusContainer.h
@@ -22,4 +22,4 @@
 #pragma once
 #include <SofaGeneralSimpleFem/config.h>
 
-#error "RadiusContainer has been removed (PR2099)."
+#error "RadiusContainer has been removed in v21.06 (PR2099)."

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/RadiusContainer.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/RadiusContainer.h
@@ -22,4 +22,4 @@
 #pragma once
 #include <SofaGeneralSimpleFem/config.h>
 
-#error "RadiusContainer has been removed (PR21XX)."
+#error "RadiusContainer has been removed (PR2099)."

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/StiffnessContainer.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/StiffnessContainer.h
@@ -21,4 +21,4 @@
 ******************************************************************************/
 #pragma once
 
-#error "StiffnessContainer has been removed (PR21XX)."
+#error "StiffnessContainer has been removed (PR2099)."

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/StiffnessContainer.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/StiffnessContainer.h
@@ -21,4 +21,4 @@
 ******************************************************************************/
 #pragma once
 
-#error "StiffnessContainer has been removed (PR2099)."
+#error "StiffnessContainer has been removed in v21.06 (PR2099)."

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/StiffnessContainer.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/StiffnessContainer.h
@@ -20,17 +20,5 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
-#include <SofaGeneralSimpleFem/config.h>
 
-namespace sofa::component::container
-{
-
-class StiffnessContainer : public virtual sofa::core::objectmodel::BaseObject
-{
-public:
-    SOFA_CLASS(StiffnessContainer,sofa::core::objectmodel::BaseObject);
-
-    virtual double getStiffness(sofa::Index index) = 0;
-};
-
-} // namespace sofa::component::container
+#error "StiffnessContainer has been removed (PR21XX)."

--- a/modules/SofaMiscMapping/src/SofaMiscMapping/TubularMapping.h
+++ b/modules/SofaMiscMapping/src/SofaMiscMapping/TubularMapping.h
@@ -26,7 +26,6 @@
 #include <sofa/core/Mapping.h>
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/defaulttype/RigidTypes.h>
-#include <SofaGeneralSimpleFem/RadiusContainer.h>
 #include <vector>
 
 namespace sofa::component::mapping
@@ -90,7 +89,6 @@ public:
     Data<double> m_radius; ///< radius of the circles around each point of the input object (1 by default)
     Data<int> m_peak; ///< if 1 or 2 creates a peak at the end
 
-    container::RadiusContainer* radiusContainer;
 protected:
 
     TubularMapping ( );

--- a/modules/SofaMiscMapping/src/SofaMiscMapping/TubularMapping.inl
+++ b/modules/SofaMiscMapping/src/SofaMiscMapping/TubularMapping.inl
@@ -33,7 +33,6 @@ TubularMapping<TIn, TOut>::TubularMapping ( )
     , m_nbPointsOnEachCircle( initData(&m_nbPointsOnEachCircle, "nbPointsOnEachCircle", "Discretization of created circles"))
     , m_radius( initData(&m_radius, "radius", "Radius of created circles"))
     , m_peak (initData(&m_peak, 0, "peak", "=0 no peak, =1 peak on the first segment =2 peak on the two first segment, =-1 peak on the last segment"))
-    ,radiusContainer(nullptr)
 {
 }
 template <class TIn, class TOut>
@@ -41,16 +40,12 @@ void TubularMapping<TIn, TOut>::init()
 {
     if (!m_radius.isSet())
     {
-        this->getContext()->get(radiusContainer);
-        msg_info() << "get Radius Container";
-        if (!radiusContainer)
-            msg_error() << "TubularMapping : No Radius defined";
-    }
-    else
-    {
-        msg_info() << "get Radius tout court";
+        msg_error() << "TubularMapping : No Radius defined";
+        d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+        return;
     }
 
+    d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
     Inherit::init();
 
 }
@@ -58,8 +53,10 @@ void TubularMapping<TIn, TOut>::init()
 template <class TIn, class TOut>
 void TubularMapping<TIn, TOut>::apply ( const core::MechanicalParams* /* mparams */, OutDataVecCoord& dOut, const InDataVecCoord& dIn)
 {
-    // Propagation of positions from the input DOFs to the output DOFs
+    if (d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
+        return;
 
+    // Propagation of positions from the input DOFs to the output DOFs
     const InVecCoord& in = dIn.getValue();
     OutVecCoord& out = *dOut.beginEdit();
 
@@ -77,9 +74,6 @@ void TubularMapping<TIn, TOut>::apply ( const core::MechanicalParams* /* mparams
 
     for (unsigned int i=0; i<in.size(); i++)
     {
-        if(radiusContainer)
-            rho = radiusContainer->getPointRadius(i);
-
         // allows for peak at the beginning or at the end of the Tubular Mapping
 
         Real radius_rho = (Real) rho;
@@ -131,6 +125,9 @@ void TubularMapping<TIn, TOut>::apply ( const core::MechanicalParams* /* mparams
 template <class TIn, class TOut>
 void TubularMapping<TIn, TOut>::applyJ( const core::MechanicalParams* /* mparams */, OutDataVecDeriv& dOut, const InDataVecDeriv& dIn )
 {
+    if (d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
+        return;
+
     // Propagation of velocities from the input DOFs to the output DOFs
     const InVecDeriv& in = dIn.getValue();
     OutVecDeriv& out = *dOut.beginEdit();
@@ -163,6 +160,9 @@ void TubularMapping<TIn, TOut>::applyJ( const core::MechanicalParams* /* mparams
 template <class TIn, class TOut>
 void TubularMapping<TIn, TOut>::applyJT( const core::MechanicalParams* /* mparams */, InDataVecDeriv& dOut, const OutDataVecDeriv& dIn )
 {
+    if (d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
+        return;
+
     // useful for a Mechanical Mapping that propagates forces from the output DOFs to the input DOFs
     const OutVecDeriv& in = dIn.getValue();
     InVecDeriv& out = *dOut.beginEdit();
@@ -196,6 +196,9 @@ void TubularMapping<TIn, TOut>::applyJT( const core::MechanicalParams* /* mparam
 template <class TIn, class TOut>
 void TubularMapping<TIn, TOut>::applyJT( const core::ConstraintParams * /*cparams*/, InDataMatrixDeriv& dOut, const OutDataMatrixDeriv& dIn)
 {
+    if (d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
+        return;
+
     // useful for a Mechanical Mapping that propagates forces from the output DOFs to the input DOFs
     const OutMatrixDeriv& in = dIn.getValue();
     InMatrixDeriv& out = *dOut.beginEdit();

--- a/modules/SofaMiscMapping/src/SofaMiscMapping/TubularMapping.inl
+++ b/modules/SofaMiscMapping/src/SofaMiscMapping/TubularMapping.inl
@@ -41,11 +41,11 @@ void TubularMapping<TIn, TOut>::init()
     if (!m_radius.isSet())
     {
         msg_error() << "TubularMapping : No Radius defined";
-        d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+        this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         return;
     }
 
-    d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
+    this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
     Inherit::init();
 
 }
@@ -53,7 +53,7 @@ void TubularMapping<TIn, TOut>::init()
 template <class TIn, class TOut>
 void TubularMapping<TIn, TOut>::apply ( const core::MechanicalParams* /* mparams */, OutDataVecCoord& dOut, const InDataVecCoord& dIn)
 {
-    if (d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
+    if (this->d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
         return;
 
     // Propagation of positions from the input DOFs to the output DOFs
@@ -125,7 +125,7 @@ void TubularMapping<TIn, TOut>::apply ( const core::MechanicalParams* /* mparams
 template <class TIn, class TOut>
 void TubularMapping<TIn, TOut>::applyJ( const core::MechanicalParams* /* mparams */, OutDataVecDeriv& dOut, const InDataVecDeriv& dIn )
 {
-    if (d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
+    if (this->d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
         return;
 
     // Propagation of velocities from the input DOFs to the output DOFs
@@ -160,7 +160,7 @@ void TubularMapping<TIn, TOut>::applyJ( const core::MechanicalParams* /* mparams
 template <class TIn, class TOut>
 void TubularMapping<TIn, TOut>::applyJT( const core::MechanicalParams* /* mparams */, InDataVecDeriv& dOut, const OutDataVecDeriv& dIn )
 {
-    if (d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
+    if (this->d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
         return;
 
     // useful for a Mechanical Mapping that propagates forces from the output DOFs to the input DOFs
@@ -196,7 +196,7 @@ void TubularMapping<TIn, TOut>::applyJT( const core::MechanicalParams* /* mparam
 template <class TIn, class TOut>
 void TubularMapping<TIn, TOut>::applyJT( const core::ConstraintParams * /*cparams*/, InDataMatrixDeriv& dOut, const OutDataMatrixDeriv& dIn)
 {
-    if (d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
+    if (this->d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
         return;
 
     // useful for a Mechanical Mapping that propagates forces from the output DOFs to the input DOFs

--- a/modules/SofaMiscMapping/src/SofaMiscMapping/TubularMapping.inl
+++ b/modules/SofaMiscMapping/src/SofaMiscMapping/TubularMapping.inl
@@ -40,7 +40,7 @@ void TubularMapping<TIn, TOut>::init()
 {
     if (!m_radius.isSet())
     {
-        msg_error() << "TubularMapping : No Radius defined";
+        msg_error() << "No Radius defined";
         this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         return;
     }

--- a/modules/SofaTopologyMapping/CMakeLists.txt
+++ b/modules/SofaTopologyMapping/CMakeLists.txt
@@ -42,11 +42,10 @@ set(SOURCE_FILES
     ${SOFATOPOLOGYMAPPING_SRC}/initSofaTopologyMapping.cpp
 )
 
-sofa_find_package(SofaGeneralSimpleFem REQUIRED)
-sofa_find_package(SofaGeneralTopology REQUIRED)
+sofa_find_package(SofaBaseTopology REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaGeneralTopology SofaGeneralSimpleFem)
+target_link_libraries(${PROJECT_NAME} PUBLIC SofaBaseTopology)
 
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/Edge2QuadTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/Edge2QuadTopologicalMapping.cpp
@@ -267,9 +267,9 @@ void Edge2QuadTopologicalMapping::init()
 
             // Need to fully init the target topology
             to_tstm->init();
-        }
 
-        d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
+            d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
+        }
 
     }
 }

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/Edge2QuadTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/Edge2QuadTopologicalMapping.cpp
@@ -63,24 +63,34 @@ Edge2QuadTopologicalMapping::Edge2QuadTopologicalMapping()
     , d_focalAxis( initData(&d_focalAxis, Vec(0,0,1), "focalAxis", "In case of ellipses"))
     , d_edgeList(initData(&d_edgeList, "edgeList", "list of input edges for the topological mapping: by default, all considered"))
     , d_flipNormals(initData(&d_flipNormals, bool(false), "flipNormals", "Flip Normal ? (Inverse point order when creating quad)"))
-    , m_radiusContainer(nullptr)
 {
 }
 
 void Edge2QuadTopologicalMapping::init()
 {
-    double rho = d_radius.getValue();
-    if (!d_radius.isSet())
-    {
-        this->getContext()->get(m_radiusContainer);
+    d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
 
-        if(!m_radiusContainer)
-            msg_info() << "No radius defined";
+    if (!d_radius.isSet() && !d_radiusFocal.isSet())
+    {
+        msg_error() << "No radius (neither radius nor radiusFocal) defined";
+        return;
     }
+
+    if (d_radius.isSet() && d_radius.getValue() < std::numeric_limits<double>::min())
+    {
+        msg_error() << "Radius is zero or negative";
+        return;
+    }
+    else if (d_radiusFocal.isSet() && d_radiusFocal.getValue() < std::numeric_limits<double>::min())
+    {
+        msg_error() << "Focal Radius is zero or negative";
+        return;
+    }
+    double rho = d_radius.getValue();
 
     bool ellipse = false;
     double rhoFocal;
-    if (d_radiusFocal.isSet() && d_radiusFocal.getValue()>0.)
+    if (d_radiusFocal.isSet())
     {
         ellipse = true;
         rhoFocal = d_radiusFocal.getValue();
@@ -160,8 +170,6 @@ void Edge2QuadTopologicalMapping::init()
 
                     for(unsigned int j=0; j<N; ++j)
                     {
-                        if(m_radiusContainer) rho = m_radiusContainer->getPointRadius(j);
-
                         Vec x;
                         if(ellipse){
                             x = t + Y*cos((Real) (2.0*j*M_PI/N))*((Real) rho) + Z*sin((Real) (2.0*j*M_PI/N))*((Real) rhoFocal);
@@ -261,6 +269,8 @@ void Edge2QuadTopologicalMapping::init()
             to_tstm->init();
         }
 
+        d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
+
     }
 }
 
@@ -272,6 +282,8 @@ Index Edge2QuadTopologicalMapping::getFromIndex(Index ind)
 
 void Edge2QuadTopologicalMapping::updateTopologicalMappingTopDown()
 {
+    if (d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid)
+        return;
 
     unsigned int N = d_nbPointsOnEachCircle.getValue();
 

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/Edge2QuadTopologicalMapping.h
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/Edge2QuadTopologicalMapping.h
@@ -31,9 +31,6 @@
 #include <sofa/core/BaseMapping.h>
 #include <sofa/core/behavior/MechanicalState.h>
 
-#include <SofaGeneralSimpleFem/RadiusContainer.h>
-
-
 namespace sofa::component::topology
 {
 
@@ -105,8 +102,6 @@ protected:
     Data<VecIndex> d_edgeList; ///< list of input edges for the topological mapping: by default, all considered
     Data<bool> d_flipNormals; ///< Flip Normal ? (Inverse point order when creating quad)
 
-    
-    container::RadiusContainer* m_radiusContainer;
 };
 
 } //namespace sofa::component::topology


### PR DESCRIPTION
(not the topological ones 😏)

{Length,Radius,Stiffness,Poisson}Container was created a **long time ago** to provide an "external location" where to set data per element, regardless of the component.
But: 
 - the design was flawed (hard deps, not generic at all)
 - the remaining files are just interfaces (virtual ... =0) and there is no implementation at all in the whole codebase (deleted files in the past? forgotten plugins?), so the code itself at the moment is totally useless. Actually 3 of them was even not including the necessary headers...

So the best course of action to do IMO is to delete them, and maybe find an other design later to provide means to get data per element (opposed to data for the whole set of elements)

A nice side effect is that SofaTopologicalMapping just depends on SofaBaseTopology now.
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
