### PR TITLE
[SofaGraphComponent] Fix a typo in the warning emited by the APIVersion component and add missing allowed versions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@ project(Sofa) # Cannot use VERSION with patch like "00"
 include(CMakeDependentOption)
 
 # Manually define VERSION
-set(Sofa_VERSION_MAJOR 20)
-set(Sofa_VERSION_MINOR 12)
+set(Sofa_VERSION_MAJOR 21)
+set(Sofa_VERSION_MINOR 06)
 set(Sofa_VERSION_PATCH 99)
 set(Sofa_VERSION ${Sofa_VERSION_MAJOR}.${Sofa_VERSION_MINOR}.${Sofa_VERSION_PATCH})
 

--- a/modules/SofaGraphComponent/src/SofaGraphComponent/APIVersion.cpp
+++ b/modules/SofaGraphComponent/src/SofaGraphComponent/APIVersion.cpp
@@ -28,6 +28,7 @@ using sofa::core::RegisterObject ;
 
 #include "APIVersion.h"
 #include <sofa/version.h>
+#include <numeric>
 
 namespace sofa::component::_apiversion_
 {
@@ -56,10 +57,15 @@ void APIVersion::checkInputData()
     if( !d_level.isSet() && name.isSet() ){
         d_level.setValue(getName());
     }
-    std::vector<std::string> allowedVersion = { "17.06", "17.12", "18.06", "18.12", SOFA_VERSION_STR } ;
-    if( std::find( allowedVersion.begin(), allowedVersion.end(), d_level.getValue()) == allowedVersion.end() )
+
+    const auto & API_version = d_level.getValue();
+    static const std::set<std::string> allowedAPIVersions { "17.06", "17.12", "18.06", "18.12", "19.06", "19.12", "20.06", "20.12", SOFA_VERSION_STR } ;
+    if( allowedAPIVersions.find(API_version) == std::cend(allowedAPIVersions) )
     {
-        msg_warning() << "The provided level '"<< d_level.getValue() <<"' is now valid. " ;
+        auto allowedVersionStr = std::accumulate(std::next(allowedAPIVersions.begin()), allowedAPIVersions.end(), *(allowedAPIVersions.begin()), [](const std::string & s, const std::string & v) {
+            return s + ", " + v;
+        });
+        msg_warning() << "The provided level '"<< API_version <<"' is not valid. Allowed versions are [" << allowedVersionStr << "]." ;
     }
 }
 


### PR DESCRIPTION
Using this in your scene:
```xml
<APIVersion level="21.06" />
```
gave (before this PR):
```
[WARNING] [APIVersion(APIVersion)] The provided level '21.06' is now valid.
```
and now gives (with this PR);
```
[WARNING] [APIVersion(APIVersion)] The provided level '21.06' is not valid. Allowed versions are [17.06, 17.12, 18.06, 18.12, 19.06, 19.12, 20.06, 20.12, 20.12.99].
```






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
