### PR TITLE
[SofaHelper] Optimize use of map_ptr_stable_compare

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/collision/NarrowPhaseDetection.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/collision/NarrowPhaseDetection.cpp
@@ -78,16 +78,8 @@ auto NarrowPhaseDetection::getDetectionOutputs() const -> const DetectionOutputM
 DetectionOutputVector*& NarrowPhaseDetection::getDetectionOutputs(CollisionModel *cm1, CollisionModel *cm2)
 {
     std::pair< CollisionModel*, CollisionModel* > cm_pair = std::make_pair(cm1, cm2);
-
-    DetectionOutputMap::iterator it = m_outputsMap.find(cm_pair);
-
-    if (it == m_outputsMap.end())
-    {
-        // new contact
-        it = m_outputsMap.insert( std::make_pair(cm_pair, static_cast< DetectionOutputVector * >(0)) ).first;
-    }
-
-    return it->second;
+    const auto res = m_outputsMap.insert(m_outputsMap.end(), {cm_pair, nullptr});
+    return res->second;
 }
 
 void NarrowPhaseDetection::changeInstanceNP(Instance inst)

--- a/SofaKernel/modules/SofaCore/src/sofa/core/collision/NarrowPhaseDetection.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/collision/NarrowPhaseDetection.cpp
@@ -46,25 +46,23 @@ void NarrowPhaseDetection::addCollisionPairs(const sofa::helper::vector< std::pa
 
 void NarrowPhaseDetection::endNarrowPhase()
 {
-    DetectionOutputMap::iterator it = m_outputsMap.begin();
-
-    while (it != m_outputsMap.end())
+    for (auto it = m_outputsMap.begin(); it != m_outputsMap.end();)
     {
         DetectionOutputVector *do_vec = (it->second);
-
         if (!do_vec || do_vec->empty())
         {
-            /// @todo Optimization
-            DetectionOutputMap::iterator iterase = it;
-            ++it;
-            m_outputsMap.erase(iterase);
-            if (do_vec) do_vec->release();
+            if (do_vec)
+            {
+                do_vec->release();
+            }
+            m_outputsMap.erase(it++);
         }
         else
         {
             ++it;
         }
     }
+
 }
 
 size_t NarrowPhaseDetection::getPrimitiveTestCount() const
@@ -80,16 +78,8 @@ auto NarrowPhaseDetection::getDetectionOutputs() const -> const DetectionOutputM
 DetectionOutputVector*& NarrowPhaseDetection::getDetectionOutputs(CollisionModel *cm1, CollisionModel *cm2)
 {
     std::pair< CollisionModel*, CollisionModel* > cm_pair = std::make_pair(cm1, cm2);
-
-    DetectionOutputMap::iterator it = m_outputsMap.find(cm_pair);
-
-    if (it == m_outputsMap.end())
-    {
-        // new contact
-        it = m_outputsMap.insert( std::make_pair(cm_pair, static_cast< DetectionOutputVector * >(0)) ).first;
-    }
-
-    return it->second;
+    const auto res = m_outputsMap.insert(m_outputsMap.end(), {cm_pair, nullptr});
+    return res->second;
 }
 
 void NarrowPhaseDetection::changeInstanceNP(Instance inst)

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/map_ptr_stable_compare.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/map_ptr_stable_compare.h
@@ -26,10 +26,7 @@
 #include <map>
 #include <memory>
 
-namespace sofa
-{
-
-namespace helper
+namespace sofa::helper
 {
 
 /// An object transforming pointers to stable ids, i.e. whose value depend on the order the pointers
@@ -44,18 +41,14 @@ public:
 
     unsigned int operator()(T* p)
     {
-        unsigned int id = 0;
-        typename std::map<T*,unsigned int>::iterator it = idMap->find(p);
+        const auto it = idMap->find(p);
         if (it != idMap->end())
         {
-            id = it->second;
+            return it->second;
         }
-        else
-        {
-            id = ++(*counter);
-            idMap->insert(std::make_pair(p, id));
-        }
-        return id;
+
+        idMap->insert({p, *counter});
+        return (*counter)++;
     }
 
     inline unsigned int id(T* p)
@@ -188,8 +181,6 @@ private:
     std::unique_ptr<stable_id_map_type> m_stable_id_map;
 };
 
-} // namespace helper
-
-} // namespace sofa
+} // namespace sofa::helper
 
 #endif

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/map_ptr_stable_compare.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/map_ptr_stable_compare.h
@@ -95,11 +95,8 @@ public:
 
     bool operator()(const std::pair<T*,T*>& a, const std::pair<T*,T*>& b) const
     {
-        if (a.first != b.first)
-        {
-            return m_ids->id(a.first) < m_ids->id(b.first);
-        }
-        return m_ids->id(a.second) < m_ids->id(b.second);
+        return std::make_pair(m_ids->id(b.first), m_ids->id(b.second)) >
+               std::make_pair(m_ids->id(a.first), m_ids->id(a.second));
     }
 
     explicit ptr_stable_compare( ptr_stable_id<T>* ids):m_ids(ids)

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/map_ptr_stable_compare.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/map_ptr_stable_compare.h
@@ -38,25 +38,25 @@ template <typename T>
 class ptr_stable_id
 {
 public:
-	ptr_stable_id() 
-		: counter(new unsigned int(0))
-		, idMap(new std::map<T*, unsigned int>) {}
+    ptr_stable_id()
+        : counter(new unsigned int(0))
+        , idMap(new std::map<T*, unsigned int>) {}
 
-	unsigned int operator()(T* p)
-	{
-		unsigned int id = 0;
+    unsigned int operator()(T* p)
+    {
+        unsigned int id = 0;
         typename std::map<T*,unsigned int>::iterator it = idMap->find(p);
-		if (it != idMap->end())
-		{
-			id = it->second;
-		}
-		else
-		{
-			id = ++(*counter);
-			idMap->insert(std::make_pair(p, id));
-		}
-		return id;
-	}
+        if (it != idMap->end())
+        {
+            id = it->second;
+        }
+        else
+        {
+            id = ++(*counter);
+            idMap->insert(std::make_pair(p, id));
+        }
+        return id;
+    }
 
     inline unsigned int id(T* p)
     {
@@ -78,12 +78,11 @@ class ptr_stable_compare<T*>
 public:
     // wrap the ptr_stable_id<T> into an opaque type
     typedef ptr_stable_id<T> stable_map_type;
-	// This operator must be declared const in order to be used within const methods
-	// such as std::map::find()
-	bool operator()(T* a, T* b) const
-	{
-		return (m_ids->id(a) < m_ids->id(b));
-	}
+
+    bool operator()(T* a, T* b) const
+    {
+        return m_ids->id(a) < m_ids->id(b);
+    }
 
     explicit ptr_stable_compare( const ptr_stable_id<T>* ids ):m_ids(ids)
     {
@@ -91,7 +90,7 @@ public:
 
 protected:
     /// memory is owned by the map_ptr_stable_compare instance
-	mutable ptr_stable_id<T>* m_ids;
+    mutable ptr_stable_id<T>* m_ids;
 };
 
 template <typename T>
@@ -100,12 +99,15 @@ class ptr_stable_compare< std::pair<T*,T*> >
 public:
     // wrap the ptr_stable_id<T> into an opaque type
     typedef ptr_stable_id<T> stable_id_map_type;
-	// This operator must be declared const in order to be used within const methods
-	// such as std::map::find()
-	bool operator()(const std::pair<T*,T*>& a, const std::pair<T*,T*>& b) const
-	{
-		return (std::make_pair(m_ids->id(a.first), m_ids->id(a.second)) < std::make_pair(m_ids->id(b.first), m_ids->id(b.second)) );
-	}
+
+    bool operator()(const std::pair<T*,T*>& a, const std::pair<T*,T*>& b) const
+    {
+        if (a.first != b.first)
+        {
+            return m_ids->id(a.first) < m_ids->id(b.first);
+        }
+        return m_ids->id(a.second) < m_ids->id(b.second);
+    }
 
     explicit ptr_stable_compare( ptr_stable_id<T>* ids):m_ids(ids)
     {
@@ -118,7 +120,7 @@ public:
 
 protected:
     /// memory is owned by the map_ptr_stable_compare instance
-	mutable ptr_stable_id<T>* m_ids;
+    mutable ptr_stable_id<T>* m_ids;
 
 private:
     ptr_stable_compare():m_ids(nullptr){}
@@ -129,13 +131,13 @@ template< typename Key, typename Tp >
 class map_ptr_stable_compare : public std::map<Key, Tp, ptr_stable_compare<Key> >
 {
 public:
-	typedef std::map<Key, Tp, ptr_stable_compare<Key> > Inherit;
+    typedef std::map<Key, Tp, ptr_stable_compare<Key> > Inherit;
     /// Key
-	typedef typename Inherit::key_type               key_type;
+    typedef typename Inherit::key_type               key_type;
     /// Tp
-	typedef typename Inherit::mapped_type            mapped_type;
+    typedef typename Inherit::mapped_type            mapped_type;
     /// pair<Key,Tp>
-	typedef typename Inherit::value_type             value_type;
+    typedef typename Inherit::value_type             value_type;
     /// reference to a value (read-write)
     typedef typename Inherit::reference              reference;
     /// const reference to a value (read only)

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/map_ptr_stable_compare.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/map_ptr_stable_compare.h
@@ -36,19 +36,19 @@ class ptr_stable_id
 {
 public:
     ptr_stable_id()
-        : counter(new unsigned int(0))
-        , idMap(new std::map<T*, unsigned int>) {}
+        : counter(0)
+        , idMap() {}
 
     unsigned int operator()(T* p)
     {
-        const auto it = idMap->find(p);
-        if (it != idMap->end())
+        const typename std::map<T*,unsigned int>::const_iterator it = idMap.find(p);
+        if (it != idMap.cend())
         {
             return it->second;
         }
 
-        idMap->insert({p, *counter});
-        return (*counter)++;
+        idMap.insert({p, counter});
+        return counter++;
     }
 
     inline unsigned int id(T* p)
@@ -57,8 +57,8 @@ public:
     }
 
 protected:
-    mutable std::shared_ptr<unsigned int> counter;
-    mutable std::shared_ptr< std::map<T*,unsigned int> > idMap;
+    mutable unsigned int counter;
+    mutable std::map<T*,unsigned int> idMap;
 };
 
 /// A comparison object that order pointers in a stable way, i.e. in the order pointers are presented

--- a/modules/SofaHaptics/SofaHaptics_test/LCPForceFeedback_test.cpp
+++ b/modules/SofaHaptics/SofaHaptics_test/LCPForceFeedback_test.cpp
@@ -227,15 +227,15 @@ bool LCPForceFeedback_test::test_SimpleCollision()
 
             // test with groundtruth, do it index by index for better log
             // position
-            EXPECT_FLOAT_EQ(coords[0][0], truthC[0]);
-            EXPECT_FLOAT_EQ(coords[0][1], truthC[1]);
-            EXPECT_FLOAT_EQ(coords[0][2], truthC[2]);
+            EXPECT_FLOAT_EQ(coords[0][0], truthC[0]) << "Iteration " << step;
+            EXPECT_FLOAT_EQ(coords[0][1], truthC[1]) << "Iteration " << step;
+            EXPECT_FLOAT_EQ(coords[0][2], truthC[2]) << "Iteration " << step;
 
             // orientation
-            EXPECT_FLOAT_EQ(coords[0][3], truthC[3]);
-            EXPECT_FLOAT_EQ(coords[0][4], truthC[4]);
-            EXPECT_FLOAT_EQ(coords[0][5], truthC[5]);
-            EXPECT_FLOAT_EQ(coords[0][6], truthC[6]);
+            EXPECT_FLOAT_EQ(coords[0][3], truthC[3]) << "Iteration " << step;
+            EXPECT_FLOAT_EQ(coords[0][4], truthC[4]) << "Iteration " << step;
+            EXPECT_FLOAT_EQ(coords[0][5], truthC[5]) << "Iteration " << step;
+            EXPECT_FLOAT_EQ(coords[0][6], truthC[6]) << "Iteration " << step;
 
             pctTru++;
         }

--- a/modules/SofaHaptics/SofaHaptics_test/scenes/ToolvsFloorCollision_test.scn
+++ b/modules/SofaHaptics/SofaHaptics_test/scenes/ToolvsFloorCollision_test.scn
@@ -1,11 +1,13 @@
 <?xml version="1.0" ?>
 <Node name="root" dt="0.05" showBoundingTree="0" gravity="0 -1 0">
-    <RequiredPlugin name='SofaOpenglVisual'/>
-    <RequiredPlugin name='SofaHaptics'/>
-    <RequiredPlugin name='SofaSparseSolver'/>
-    <RequiredPlugin name='SofaConstraint'/>
-    <RequiredPlugin name='SofaImplicitOdeSolver'/>
-    <RequiredPlugin name='SofaLoader'/>
+    <RequiredPlugin name="SofaOpenglVisual"/>
+    <RequiredPlugin name="SofaHaptics"/>
+    <RequiredPlugin name="SofaSparseSolver"/>
+    <RequiredPlugin name="SofaConstraint"/>
+    <RequiredPlugin name="SofaImplicitOdeSolver"/>
+    <RequiredPlugin name="SofaLoader"/>
+    <RequiredPlugin name="SofaMeshCollision"/>
+    <RequiredPlugin name="SofaRigid"/>
     
     <DefaultPipeline name="pipeline" depth="6" verbose="0"/>
     <BruteForceDetection name="detection" />


### PR DESCRIPTION
`map_ptr_stable_compare` is used in the `NarrowPhase` components. In this PR:

- The use of `map_ptr_stable_compare` is optimized in `NarrowPhase` components
- `map_ptr_stable_compare` itself is a bit optimized

The benchmark results show great performances improvements at the level of the container manipulation.
However, at the level of a simulation the performances improvements are negligible.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
