### PR TITLE
[Collision] Build collision tree only if required

### DIFF
--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceBroadPhase.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceBroadPhase.h
@@ -70,6 +70,9 @@ public:
 
     static bool keepCollisionBetween(core::CollisionModel *cm1, core::CollisionModel *cm2);
 
+    /// Bounding tree is not required by this detection algorithm
+    bool needsDeepBoundingTree() const override { return false; }
+
 protected:
 
     /// Return true if the provided CollisionModel can collide with itself

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.h
@@ -36,6 +36,8 @@ class SOFA_SOFABASECOLLISION_API BruteForceDetection :
 public:
     SOFA_CLASS2(BruteForceDetection, BruteForceBroadPhase, BVHNarrowPhase);
 
+    bool needsDeepBoundingTree() const override { return BruteForceBroadPhase::needsDeepBoundingTree() || BVHNarrowPhase::needsDeepBoundingTree(); }
+
 protected:
     BruteForceDetection();
 

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DefaultPipeline.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/DefaultPipeline.cpp
@@ -131,6 +131,11 @@ void DefaultPipeline::doCollisionDetection(const helper::vector<core::CollisionM
         const helper::vector<CollisionModel*>::const_iterator itEnd = collisionModels.end();
         int nActive = 0;
 
+        const int used_depth = (
+                    (broadPhaseDetection && broadPhaseDetection->needsDeepBoundingTree()) ||
+                    (narrowPhaseDetection && narrowPhaseDetection->needsDeepBoundingTree())
+            ) ? d_depth.getValue() : 0;
+
         for (it = collisionModels.begin(); it != itEnd; ++it)
         {
             msg_info_when(d_doPrintInfoMessage.getValue())
@@ -138,14 +143,14 @@ void DefaultPipeline::doCollisionDetection(const helper::vector<core::CollisionM
 
             if (!(*it)->isActive()) continue;
 
-            int used_depth = broadPhaseDetection->needsDeepBoundingTree() ? d_depth.getValue() : 0;
-
-            if (continuous){
-                std::string msg = "Compute Continuous BoundingTree: " + (*it)->getName();
+            if (continuous)
+            {
+                const std::string msg = "Compute Continuous BoundingTree: " + (*it)->getName();
                 ScopedAdvancedTimer bboxtimer(msg.c_str());
                 (*it)->computeContinuousBoundingTree(dt, used_depth);
             }
-            else {
+            else
+            {
                 std::string msg = "Compute BoundingTree: " + (*it)->getName();
                 ScopedAdvancedTimer bboxtimer(msg.c_str());
                 (*it)->computeBoundingTree(used_depth);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/collision/BroadPhaseDetection.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/collision/BroadPhaseDetection.h
@@ -56,8 +56,6 @@ public:
     sofa::helper::vector<CollisionModelPair>& getCollisionModelPairs();
     const sofa::helper::vector<CollisionModelPair>& getCollisionModelPairs() const;
 
-    /// Returns true because it needs a deep bounding tree i.e. a depth that can be superior to 1.
-    inline virtual bool needsDeepBoundingTree()const{return true;}
 protected:
 
     /// Potentially colliding pairs

--- a/SofaKernel/modules/SofaCore/src/sofa/core/collision/Detection.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/collision/Detection.h
@@ -58,6 +58,9 @@ public:
     virtual void setIntersectionMethod(Intersection* v) { intersectionMethod = v;    }
     Intersection* getIntersectionMethod() const         { return intersectionMethod; }
 
+    /// Returns true if the detection algorithm requires a deep bounding tree i.e. a depth that can be superior to 1.
+    inline virtual bool needsDeepBoundingTree() const { return true; }
+
 protected:
     virtual void changeInstanceBP(Instance) {}
     virtual void changeInstanceNP(Instance) {}

--- a/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/DirectSAP.h
+++ b/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/DirectSAP.h
@@ -35,6 +35,8 @@ class SOFA_SOFAGENERALMESHCOLLISION_API DirectSAP :
 {
 public:
     SOFA_CLASS2(DirectSAP, BruteForceBroadPhase, DirectSAPNarrowPhase);
+
+    bool needsDeepBoundingTree() const override { return BruteForceBroadPhase::needsDeepBoundingTree() || DirectSAPNarrowPhase::needsDeepBoundingTree(); }
 };
 
 } // namespace sofa::component::collision

--- a/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/DirectSAPNarrowPhase.h
+++ b/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/DirectSAPNarrowPhase.h
@@ -136,6 +136,9 @@ public:
 
     /// Get the result of the broad phase and check if there are some new collision models that was not yet processed
     void checkNewCollisionModels();
+
+    /// Bounding tree is not required by this detection algorithm
+    bool needsDeepBoundingTree() const override { return false; }
 };
 
 }


### PR DESCRIPTION
The collision tree were built only if the broad phase algorithm requires it. But it is also up to the narrow phase to decide.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
