### PR TITLE
[SofaTopologyMapping] Fix Edge2Quad condition

### DIFF
--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/Edge2QuadTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/Edge2QuadTopologicalMapping.cpp
@@ -81,16 +81,16 @@ void Edge2QuadTopologicalMapping::init()
         msg_error() << "Radius is zero or negative";
         return;
     }
-    else if (d_radiusFocal.isSet() && d_radiusFocal.getValue() < std::numeric_limits<double>::min())
+    if (d_radiusFocal.isSet() && d_radiusFocal.getValue() < std::numeric_limits<double>::min())
     {
-        msg_error() << "Focal Radius is zero or negative";
-        return;
+        msg_warning() << "Focal Radius is zero or negative";
     }
+
     double rho = d_radius.getValue();
 
     bool ellipse = false;
     double rhoFocal;
-    if (d_radiusFocal.isSet())
+    if (d_radiusFocal.isSet() && d_radiusFocal.getValue() >= std::numeric_limits<double>::min())
     {
         ellipse = true;
         rhoFocal = d_radiusFocal.getValue();


### PR DESCRIPTION
Fix failing test because the user is giving a focal radius of zero.
This became an error in #2099 .

But it could happen that a user gives both a radius (non zero) and a focal radius (with zero).
This should not be really a fatal error (acting like the focal radius has not be given), 
but more a "warning" (a "focal" radius at 0 is still wrong after all)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
