### PR TITLE
[SofaMiscCollision] Contact response order

### DIFF
--- a/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/DefaultCollisionGroupManager.h
+++ b/applications/plugins/SofaMiscCollision/src/SofaMiscCollision/DefaultCollisionGroupManager.h
@@ -68,7 +68,7 @@ protected:
     void createGroup(core::collision::Contact* contact,
                      int& groupIndex,
                      MergeGroupsMap& mergedGroups,
-                     std::map<core::collision::Contact*, simulation::Node::SPtr>& contactGroup,
+                     sofa::helper::vector< std::pair<core::collision::Contact*, simulation::Node::SPtr> >& contactGroup,
                      sofa::helper::vector< simulation::Node::SPtr >& removedGroup,
                      sofa::helper::vector< core::collision::Contact* >& stationaryContacts);
 


### PR DESCRIPTION
In #2076, a `vector` was replaced in favour of a `map`. It has a consequence on the order of traversal, therefore on the contact response creation. With a `map`, the order is based on the contact pointer address, which can be random. The vector is ordered by insertion.
This PR restores the `vector` for reproducible simulations. It should fix #2128.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
