### PR TITLE
[Sofa.Core] Move eq,peq utilities functions to a standalone file

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/IdentityMapping.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/IdentityMapping.h
@@ -142,9 +142,6 @@ extern template class SOFA_SOFABASEMECHANICS_API IdentityMapping< defaulttype::R
 extern template class SOFA_SOFABASEMECHANICS_API IdentityMapping< defaulttype::Rigid3Types, defaulttype::Vec3dTypes >;
 extern template class SOFA_SOFABASEMECHANICS_API IdentityMapping< defaulttype::Rigid2Types, defaulttype::Vec2Types >;
 
-
-
-
 #endif
 
 } // namespace sofa::component::mapping
@@ -153,131 +150,97 @@ extern template class SOFA_SOFABASEMECHANICS_API IdentityMapping< defaulttype::R
 
 namespace sofa::helper
 {
-    // should certainly be somewhere else
-    // but at least it is accessible to other components
 
+#define SOFA_ATTRIBUTE_DISABLED__HELPER_EQ() \
+    SOFA_ATTRIBUTE_DISABLED( \
+        "v21.06 (PR#21XX)", "v21.06", "You need to include <sofa/core/MappingHelper.h> and use sofa::core::eq(...) instead)")
+
+#define SOFA_ATTRIBUTE_DISABLED__HELPER_PEQ() \
+    SOFA_ATTRIBUTE_DISABLED( \
+        "v21.06 (PR#21XX)", "v21.06", "You need to include <sofa/core/MappingHelper.h> and use sofa::core::peq(...) instead)")
+
+    // Those static functions have been moved in MappingHelper.h
+    template<class T1, class T2>
+    SOFA_ATTRIBUTE_DISABLED__HELPER_EQ()
+    static inline void eq(T1& dest, const T2& src) = delete;
 
     template<class T1, class T2>
-    static inline void eq(T1& dest, const T2& src)
-    {
-        dest = src;
-    }
+    SOFA_ATTRIBUTE_DISABLED__HELPER_PEQ()
+    static inline void peq(T1& dest, const T2& src) = delete;
 
-    template<class T1, class T2>
-    static inline void peq(T1& dest, const T2& src)
-    {
-        dest += src;
-    }
-
-    // float <-> double (to remove warnings)
+    SOFA_ATTRIBUTE_DISABLED__HELPER_EQ()
+    static inline void eq(float& dest, const double& src) = delete;
 
     //template<>
-    static inline void eq(float& dest, const double& src)
-    {
-        dest = (float)src;
-    }
-
-    //template<>
-    static inline void peq(float& dest, const double& src)
-    {
-        dest += (float)src;
-    }
+    SOFA_ATTRIBUTE_DISABLED__HELPER_PEQ()
+    static inline void peq(float& dest, const double& src) = delete;
 
     // Vec <-> Vec
 
     template<Size N1, Size N2, class T1, class T2>
-    static inline void eq(defaulttype::Vec<N1,T1>& dest, const defaulttype::Vec<N2,T2>& src)
-    {
-        dest = src;
-    }
+    SOFA_ATTRIBUTE_DISABLED__HELPER_EQ()
+    static inline void eq(defaulttype::Vec<N1, T1>& dest, const defaulttype::Vec<N2, T2>& src) = delete;
 
     template<Size N1, Size N2, class T1, class T2>
-    static inline void peq(defaulttype::Vec<N1,T1>& dest, const defaulttype::Vec<N2,T2>& src)
-    {
-        for (Size i=0; i<(N1>N2?N2:N1); i++)
-            dest[i] += (T1)src[i];
-    }
+    SOFA_ATTRIBUTE_DISABLED__HELPER_PEQ()
+    static inline void peq(defaulttype::Vec<N1, T1>& dest, const defaulttype::Vec<N2, T2>& src) = delete;
 
     // RigidDeriv <-> RigidDeriv
 
     template<Size N, class T1, class T2>
-    static inline void eq(defaulttype::RigidDeriv<N,T1>& dest, const defaulttype::RigidDeriv<N,T2>& src)
-    {
-        dest.getVCenter() = src.getVCenter();
-        dest.getVOrientation() = (typename defaulttype::RigidDeriv<N,T1>::Rot)src.getVOrientation();
-    }
+    SOFA_ATTRIBUTE_DISABLED__HELPER_EQ()
+    static inline void eq(defaulttype::RigidDeriv<N, T1>& dest, const defaulttype::RigidDeriv<N, T2>& src) = delete;
 
     template<Size N, class T1, class T2>
-    static inline void peq(defaulttype::RigidDeriv<N,T1>& dest, const defaulttype::RigidDeriv<N,T2>& src)
-    {
-        dest.getVCenter() += src.getVCenter();
-        dest.getVOrientation() += (typename defaulttype::RigidDeriv<N,T1>::Rot)src.getVOrientation();
-    }
+    SOFA_ATTRIBUTE_DISABLED__HELPER_PEQ()
+    static inline void peq(defaulttype::RigidDeriv<N, T1>& dest, const defaulttype::RigidDeriv<N, T2>& src) = delete;
 
     // RigidCoord <-> RigidCoord
 
     template<Size N, class T1, class T2>
-    static inline void eq(defaulttype::RigidCoord<N,T1>& dest, const defaulttype::RigidCoord<N,T2>& src)
-    {
-        dest.getCenter() = src.getCenter();
-        dest.getOrientation() = (typename defaulttype::RigidCoord<N,T1>::Rot)src.getOrientation();
-    }
+    SOFA_ATTRIBUTE_DISABLED__HELPER_EQ()
+    static inline void eq(defaulttype::RigidCoord<N, T1>& dest, const defaulttype::RigidCoord<N, T2>& src) = delete;
 
     template<Size N, class T1, class T2>
-    static inline void peq(defaulttype::RigidCoord<N,T1>& dest, const defaulttype::RigidCoord<N,T2>& src)
-    {
-        dest.getCenter() += src.getCenter();
-        dest.getOrientation() += src.getOrientation();
-    }
+    SOFA_ATTRIBUTE_DISABLED__HELPER_PEQ()
+    static inline void peq(defaulttype::RigidCoord<N, T1>& dest, const defaulttype::RigidCoord<N, T2>& src) = delete;
 
     // RigidDeriv <-> Vec
 
     template<Size N, class T1, class T2>
-    static inline void eq(defaulttype::Vec<N,T1>& dest, const defaulttype::RigidDeriv<N,T2>& src)
-    {
-        dest = src.getVCenter();
-    }
+    SOFA_ATTRIBUTE_DISABLED__HELPER_EQ()
+    static inline void eq(defaulttype::Vec<N, T1>& dest, const defaulttype::RigidDeriv<N, T2>& src) = delete;
 
     template<Size N, class T1, class T2>
-    static inline void peq(defaulttype::Vec<N,T1>& dest, const defaulttype::RigidDeriv<N,T2>& src)
-    {
-        dest += src.getVCenter();
-    }
+    SOFA_ATTRIBUTE_DISABLED__HELPER_PEQ()
+    static inline void peq(defaulttype::Vec<N, T1>& dest, const defaulttype::RigidDeriv<N, T2>& src) = delete;
 
     template<Size N, class T1, class T2>
-    static inline void eq(defaulttype::RigidDeriv<N,T1>& dest, const defaulttype::Vec<N,T2>& src)
-    {
-        dest.getVCenter() = src;
-    }
+    SOFA_ATTRIBUTE_DISABLED__HELPER_EQ()
+    static inline void eq(defaulttype::RigidDeriv<N,T1>& dest, const defaulttype::Vec<N,T2>& src) = delete;
 
     template<Size N, class T1, class T2>
-    static inline void peq(defaulttype::RigidDeriv<N,T1>& dest, const defaulttype::Vec<N,T2>& src)
-    {
-        dest.getVCenter() += src;
-    }
+    SOFA_ATTRIBUTE_DISABLED__HELPER_PEQ()
+    static inline void peq(defaulttype::RigidDeriv<N,T1>& dest, const defaulttype::Vec<N,T2>& src) = delete;
 
     // RigidCoord <-> Vec
     template<Size N, class T1, class T2>
-    static inline void eq(defaulttype::Vec<N,T1>& dest, const defaulttype::RigidCoord<N,T2>& src)
-    {
-        dest = src.getCenter();
-    }
+    SOFA_ATTRIBUTE_DISABLED__HELPER_EQ()
+    static inline void eq(defaulttype::Vec<N,T1>& dest, const defaulttype::RigidCoord<N,T2>& src) = delete;
 
     template<Size N, class T1, class T2>
-    static inline void peq(defaulttype::Vec<N,T1>& dest, const defaulttype::RigidCoord<N,T2>& src)
-    {
-        dest += src.getCenter();
-    }
+    SOFA_ATTRIBUTE_DISABLED__HELPER_PEQ()
+    static inline void peq(defaulttype::Vec<N,T1>& dest, const defaulttype::RigidCoord<N,T2>& src) = delete;
 
     template<Size N, class T1, class T2>
-    static inline void eq(defaulttype::RigidCoord<N,T1>& dest, const defaulttype::Vec<N,T2>& src)
-    {
-        dest.getCenter() = src;
-    }
+    SOFA_ATTRIBUTE_DISABLED__HELPER_EQ()
+    static inline void eq(defaulttype::RigidCoord<N,T1>& dest, const defaulttype::Vec<N,T2>& src) = delete;
 
     template<Size N, class T1, class T2>
-    static inline void peq(defaulttype::RigidCoord<N,T1>& dest, const defaulttype::Vec<N,T2>& src)
-    {
-        dest.getCenter() += src;
-    }
+    SOFA_ATTRIBUTE_DISABLED__HELPER_PEQ()
+    static inline void peq(defaulttype::RigidCoord<N, T1>& dest, const defaulttype::Vec<N, T2>& src) = delete;
+
+#undef SOFA_ATTRIBUTE_DISABLED__HELPER_EQ
+#undef SOFA_ATTRIBUTE_DISABLED__HELPER_PEQ
+
 } // namespace sofa::helper

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/IdentityMapping.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/IdentityMapping.h
@@ -153,11 +153,11 @@ namespace sofa::helper
 
 #define SOFA_ATTRIBUTE_DISABLED__HELPER_EQ() \
     SOFA_ATTRIBUTE_DISABLED( \
-        "v21.06 (PR#21XX)", "v21.06", "You need to include <sofa/core/MappingHelper.h> and use sofa::core::eq(...) instead)")
+        "v21.06 (PR#2137)", "v21.06 (PR#2137)", "You need to include <sofa/core/MappingHelper.h> and use sofa::core::eq(...) instead.")
 
 #define SOFA_ATTRIBUTE_DISABLED__HELPER_PEQ() \
     SOFA_ATTRIBUTE_DISABLED( \
-        "v21.06 (PR#21XX)", "v21.06", "You need to include <sofa/core/MappingHelper.h> and use sofa::core::peq(...) instead)")
+        "v21.06 (PR#2137)", "v21.06 (PR#2137)", "You need to include <sofa/core/MappingHelper.h> and use sofa::core::peq(...) instead.")
 
     // Those static functions have been moved in MappingHelper.h
     template<class T1, class T2>

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/IdentityMapping.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/IdentityMapping.inl
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 #include <SofaBaseMechanics/IdentityMapping.h>
+#include <sofa/core/MappingHelper.h>
 
 
 namespace sofa::component::mapping
@@ -67,7 +68,7 @@ void IdentityMapping<TIn, TOut>::apply(const core::MechanicalParams * /*mparams*
 
     for(Size i=0; i<out.size(); i++)
     {
-        helper::eq(out[i], in[i]);
+        core::eq(out[i], in[i]);
     }
 }
 
@@ -79,8 +80,10 @@ void IdentityMapping<TIn, TOut>::applyJ(const core::MechanicalParams * /*mparams
 
     for( size_t i=0 ; i<this->maskTo->size() ; ++i)
     {
-        if( !this->maskTo->isActivated() || this->maskTo->getEntry(i) )
-            helper::eq(out[i], in[i]);
+        if (!this->maskTo->isActivated() || this->maskTo->getEntry(i))
+        {
+            core::eq(out[i], in[i]);
+        }
     }
 }
 
@@ -92,8 +95,10 @@ void IdentityMapping<TIn, TOut>::applyJT(const core::MechanicalParams * /*mparam
 
     for( size_t i=0 ; i<this->maskTo->size() ; ++i)
     {
-        if( this->maskTo->getEntry(i) )
-            helper::peq(out[i], in[i]);
+        if (this->maskTo->getEntry(i))
+        {
+            core::peq(out[i], in[i]);
+        }
     }
 }
 
@@ -113,12 +118,12 @@ void IdentityMapping<TIn, TOut>::applyJT(const core::ConstraintParams * /*cparam
         // Creates a constraints if the input constraint is not empty.
         if (colIt != colItEnd)
         {
-            typename In::MatrixDeriv::RowIterator o = out.writeLine(rowIt.index());
+            auto o = out.writeLine(rowIt.index());
 
             while (colIt != colItEnd)
             {
                 InDeriv data;
-                helper::eq(data, colIt.val());
+                core::eq(data, colIt.val());
 
                 o.addCol(colIt.index(), data);
 

--- a/SofaKernel/modules/SofaCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/CMakeLists.txt
@@ -17,6 +17,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/ExecParams.h
     ${SRC_ROOT}/Mapping.h
     ${SRC_ROOT}/Mapping.inl
+    ${SRC_ROOT}/MappingHelper.h
     ${SRC_ROOT}/MechanicalParams.h
     ${SRC_ROOT}/Multi2Mapping.h
     ${SRC_ROOT}/Multi2Mapping.inl

--- a/SofaKernel/modules/SofaCore/src/sofa/core/MappingHelper.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/MappingHelper.h
@@ -19,6 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#pragma once
 #include <SofaBaseMechanics/config.h>
 
 #include <sofa/type/Vec.h>

--- a/SofaKernel/modules/SofaCore/src/sofa/core/MappingHelper.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/MappingHelper.h
@@ -1,0 +1,154 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <SofaBaseMechanics/config.h>
+
+#include <sofa/type/Vec.h>
+#include <sofa/defaulttype/RigidTypes.h>
+
+namespace sofa::core
+{
+
+    template<class T1, class T2>
+    static inline void eq(T1& dest, const T2& src)
+    {
+        dest = src;
+    }
+
+    template<class T1, class T2>
+    static inline void peq(T1& dest, const T2& src)
+    {
+        dest += src;
+    }
+
+    // float <-> double (to remove warnings)
+
+    //template<>
+    static inline void eq(float& dest, const double& src)
+    {
+        dest = (float)src;
+    }
+
+    //template<>
+    static inline void peq(float& dest, const double& src)
+    {
+        dest += (float)src;
+    }
+
+    // Vec <-> Vec
+
+    template<Size N1, Size N2, class T1, class T2>
+    static inline void eq(defaulttype::Vec<N1,T1>& dest, const defaulttype::Vec<N2,T2>& src)
+    {
+        dest = src;
+    }
+
+    template<Size N1, Size N2, class T1, class T2>
+    static inline void peq(defaulttype::Vec<N1,T1>& dest, const defaulttype::Vec<N2,T2>& src)
+    {
+        for (Size i=0; i<(N1>N2?N2:N1); i++)
+            dest[i] += (T1)src[i];
+    }
+
+    // RigidDeriv <-> RigidDeriv
+
+    template<Size N, class T1, class T2>
+    static inline void eq(defaulttype::RigidDeriv<N,T1>& dest, const defaulttype::RigidDeriv<N,T2>& src)
+    {
+        dest.getVCenter() = src.getVCenter();
+        dest.getVOrientation() = (typename defaulttype::RigidDeriv<N,T1>::Rot)src.getVOrientation();
+    }
+
+    template<Size N, class T1, class T2>
+    static inline void peq(defaulttype::RigidDeriv<N,T1>& dest, const defaulttype::RigidDeriv<N,T2>& src)
+    {
+        dest.getVCenter() += src.getVCenter();
+        dest.getVOrientation() += (typename defaulttype::RigidDeriv<N,T1>::Rot)src.getVOrientation();
+    }
+
+    // RigidCoord <-> RigidCoord
+
+    template<Size N, class T1, class T2>
+    static inline void eq(defaulttype::RigidCoord<N,T1>& dest, const defaulttype::RigidCoord<N,T2>& src)
+    {
+        dest.getCenter() = src.getCenter();
+        dest.getOrientation() = (typename defaulttype::RigidCoord<N,T1>::Rot)src.getOrientation();
+    }
+
+    template<Size N, class T1, class T2>
+    static inline void peq(defaulttype::RigidCoord<N,T1>& dest, const defaulttype::RigidCoord<N,T2>& src)
+    {
+        dest.getCenter() += src.getCenter();
+        dest.getOrientation() += src.getOrientation();
+    }
+
+    // RigidDeriv <-> Vec
+
+    template<Size N, class T1, class T2>
+    static inline void eq(defaulttype::Vec<N,T1>& dest, const defaulttype::RigidDeriv<N,T2>& src)
+    {
+        dest = src.getVCenter();
+    }
+
+    template<Size N, class T1, class T2>
+    static inline void peq(defaulttype::Vec<N,T1>& dest, const defaulttype::RigidDeriv<N,T2>& src)
+    {
+        dest += src.getVCenter();
+    }
+
+    template<Size N, class T1, class T2>
+    static inline void eq(defaulttype::RigidDeriv<N,T1>& dest, const defaulttype::Vec<N,T2>& src)
+    {
+        dest.getVCenter() = src;
+    }
+
+    template<Size N, class T1, class T2>
+    static inline void peq(defaulttype::RigidDeriv<N,T1>& dest, const defaulttype::Vec<N,T2>& src)
+    {
+        dest.getVCenter() += src;
+    }
+
+    // RigidCoord <-> Vec
+    template<Size N, class T1, class T2>
+    static inline void eq(defaulttype::Vec<N,T1>& dest, const defaulttype::RigidCoord<N,T2>& src)
+    {
+        dest = src.getCenter();
+    }
+
+    template<Size N, class T1, class T2>
+    static inline void peq(defaulttype::Vec<N,T1>& dest, const defaulttype::RigidCoord<N,T2>& src)
+    {
+        dest += src.getCenter();
+    }
+
+    template<Size N, class T1, class T2>
+    static inline void eq(defaulttype::RigidCoord<N,T1>& dest, const defaulttype::Vec<N,T2>& src)
+    {
+        dest.getCenter() = src;
+    }
+
+    template<Size N, class T1, class T2>
+    static inline void peq(defaulttype::RigidCoord<N,T1>& dest, const defaulttype::Vec<N,T2>& src)
+    {
+        dest.getCenter() += src;
+    }
+
+} // namespace sofa::component::mapping

--- a/modules/SofaMiscMapping/src/SofaMiscMapping/IdentityMultiMapping.inl
+++ b/modules/SofaMiscMapping/src/SofaMiscMapping/IdentityMultiMapping.inl
@@ -21,10 +21,8 @@
 ******************************************************************************/
 #pragma once
 
-#include <sofa/core/visual/VisualParams.h>
 #include <SofaMiscMapping/IdentityMultiMapping.h>
-#include <SofaBaseMechanics/IdentityMapping.h>
-#include <iostream>
+#include <sofa/core/MappingHelper.h>
 
 namespace sofa::component::mapping
 {
@@ -107,7 +105,7 @@ void IdentityMultiMapping<TIn, TOut>::apply(const core::MechanicalParams* mparam
 
         for(unsigned int j=0; j<inpos.size(); j++)
         {
-            helper::eq( out[offset+j], inpos[j]);
+            core::eq( out[offset+j], inpos[j]);
         }
         offset += inpos.size();
     }
@@ -130,7 +128,7 @@ void IdentityMultiMapping<TIn, TOut>::applyJ(const core::MechanicalParams* mpara
         for(unsigned int j=0; j<in.size(); j++)
         {
             if( !this->maskTo[0]->isActivated() || this->maskTo[0]->getEntry(offset+j) )
-                helper::eq( out[offset+j], in[j]);
+                core::eq( out[offset+j], in[j]);
         }
         offset += in.size();
     }
@@ -153,7 +151,7 @@ void IdentityMultiMapping<TIn, TOut>::applyJT(const core::MechanicalParams* mpar
         for(unsigned int j=0; j<out.size(); j++)
         {
             if( this->maskTo[0]->getEntry(offset+j) )
-                helper::peq( out[j], in[offset+j]);
+                core::peq( out[j], in[offset+j]);
         }
 
         dataVecOutForce[i]->endEdit();

--- a/modules/SofaMiscMapping/src/SofaMiscMapping/SubsetMultiMapping.inl
+++ b/modules/SofaMiscMapping/src/SofaMiscMapping/SubsetMultiMapping.inl
@@ -21,11 +21,10 @@
 ******************************************************************************/
 #pragma once
 
-#include <sofa/core/visual/VisualParams.h>
 #include <SofaMiscMapping/SubsetMultiMapping.h>
+
 #include <SofaEigen2Solver/EigenSparseMatrix.h>
-#include <iostream>
-#include <SofaBaseMechanics/IdentityMapping.h>
+#include <sofa/core/MappingHelper.h>
 
 namespace sofa::component::mapping
 {
@@ -136,7 +135,7 @@ void SubsetMultiMapping<TIn, TOut>::apply(const core::MechanicalParams* mparams,
         const InDataVecCoord* inPosPtr = dataVecInPos[indexPairs.getValue()[i*2]];
         const InVecCoord& inPos = (*inPosPtr).getValue();
 
-        helper::eq( out[i], inPos[indexPairs.getValue()[i*2+1]] );
+        core::eq( out[i], inPos[indexPairs.getValue()[i*2+1]] );
     }
 
     dataVecOutPos[0]->endEdit();
@@ -154,7 +153,7 @@ void SubsetMultiMapping<TIn, TOut>::applyJ(const core::MechanicalParams* mparams
     {
         const InDataVecDeriv* inDerivPtr = dataVecInVel[indexPairs.getValue()[i*2]];
         const InVecDeriv& inDeriv = (*inDerivPtr).getValue();
-        helper::eq( out[i], inDeriv[indexPairs.getValue()[i*2+1]] );
+        core::eq( out[i], inDeriv[indexPairs.getValue()[i*2+1]] );
     }
 
     dataVecOutVel[0]->endEdit();
@@ -198,7 +197,7 @@ void SubsetMultiMapping<TIn, TOut>::applyJT( const core::ConstraintParams* /*cpa
             // for each col of the constraint direction, it adds a col in the corresponding parent's constraint direction
             if(indexPairs.getValue()[colIt.index()*2+1] < (unsigned int)this->fromModels[index_parent]->getSize())
             {
-                InDeriv tmp; helper::eq( tmp, colIt.val() );
+                InDeriv tmp; core::eq( tmp, colIt.val() );
                 o.addCol(indexP[colIt.index()*2+1], tmp);
             }
             ++colIt;
@@ -222,7 +221,7 @@ void SubsetMultiMapping<TIn, TOut>::applyJT(const core::MechanicalParams* mparam
     {
         InDataVecDeriv* inDerivPtr = dataVecOutForce[indexPairs.getValue()[i*2]];
         InVecDeriv& inDeriv = *(*inDerivPtr).beginEdit();
-        helper::peq( inDeriv[indexPairs.getValue()[i*2+1]], cder[i] );
+        core::peq( inDeriv[indexPairs.getValue()[i*2+1]], cder[i] );
         (*inDerivPtr).endEdit();
     }
 }


### PR DESCRIPTION
eq/peq() functions defined in IdentityMapping should be moved elsewhere; no need to know IdentityMapping to use them.

These functions are now located in a file core/MappingHelper.h alongside Mapping.h, as these functions would likely be used only by mappings.

Some points to discuss:
 - header filename ?
 - eq/peq functions name themselves are not very informative... should it be assign() and add() for example ?

Fix #2122 


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
