### PR TITLE
[All] Remove several TopologyDataHandler and headers inclusion in components

### DIFF
--- a/SofaKernel/modules/SofaDeformable/src/SofaDeformable/MeshSpringForceField.inl
+++ b/SofaKernel/modules/SofaDeformable/src/SofaDeformable/MeshSpringForceField.inl
@@ -24,7 +24,6 @@
 
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
-#include <SofaBaseTopology/TopologySubsetData.h>
 #include <sofa/type/RGBAColor.h>
 #include <iostream>
 

--- a/applications/plugins/LMConstraint/src/LMConstraint/DOFBlockerLMConstraint.h
+++ b/applications/plugins/LMConstraint/src/LMConstraint/DOFBlockerLMConstraint.h
@@ -77,15 +77,13 @@ protected:
         , f_indices(core::objectmodel::Base::initData(&f_indices, "indices", "List of the index of particles to be fixed"))
         , showSizeAxis(core::objectmodel::Base::initData(&showSizeAxis, 1.0f, "showSizeAxis", "size of the vector used to display the constrained axis"))
         , l_topology(initLink("topology", "link to the topology container"))
-        , m_pointHandler(nullptr)
     {
         
     }
 
     ~DOFBlockerLMConstraint()
     {
-        if (m_pointHandler)
-            delete m_pointHandler;
+
     }
 
 public:
@@ -117,25 +115,8 @@ public:
     /// Link to be set to the topology container in the component graph.
     SingleLink<DOFBlockerLMConstraint<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
-    class FCTPointHandler : public sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, type::vector<Index> >
-    {
-    public:
-        FCTPointHandler(DOFBlockerLMConstraint<DataTypes>* _fc, SetIndex* _data)
-            : sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, sofa::type::vector<Index> >(_data), fc(_fc) {}
-
-
-
-        void applyDestroyFunction(Index /*index*/, value_type& /*T*/);
-
-
-    protected:
-        DOFBlockerLMConstraint<DataTypes> *fc;
-    };
-
 protected :
     sofa::type::vector<SetIndexArray> idxEquations;
-    
-    FCTPointHandler* m_pointHandler;
 };
 
 #if  !defined(SOFA_COMPONENT_CONSTRAINTSET_DOFBLOCKERLMCONSTRAINT_CPP)

--- a/applications/plugins/LMConstraint/src/LMConstraint/DOFBlockerLMConstraint.inl
+++ b/applications/plugins/LMConstraint/src/LMConstraint/DOFBlockerLMConstraint.inl
@@ -29,17 +29,6 @@
 namespace sofa::component::constraintset
 {
 
-// Define RemovalFunction
-template< class DataTypes>
-void DOFBlockerLMConstraint<DataTypes>::FCTPointHandler::applyDestroyFunction(Index pointIndex, value_type &)
-{
-    if (fc)
-    {
-        fc->removeConstraint((Index) pointIndex);
-    }
-    return;
-}
-
 template <class DataTypes>
 void DOFBlockerLMConstraint<DataTypes>::clearConstraints()
 {
@@ -80,9 +69,8 @@ void DOFBlockerLMConstraint<DataTypes>::init()
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
         
-        // Initialize functions and parameters
-        m_pointHandler = new FCTPointHandler(this, &f_indices);
-        f_indices.createTopologyHandler(_topology, m_pointHandler);
+        // Initialize topological change handling
+        f_indices.createTopologyHandler(_topology);
     }
     else
     {

--- a/applications/plugins/LMConstraint/src/LMConstraint/FixedLMConstraint.h
+++ b/applications/plugins/LMConstraint/src/LMConstraint/FixedLMConstraint.h
@@ -70,8 +70,7 @@ protected:
 
     ~FixedLMConstraint()
     {
-        if (m_pointHandler)
-            delete m_pointHandler;
+
     }
 
 public:
@@ -101,30 +100,11 @@ public:
     /// Link to be set to the topology container in the component graph.
     SingleLink<FixedLMConstraint<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
-    class FCPointHandler : public sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >
-    {
-    public:
-        typedef typename FixedLMConstraint<DataTypes>::SetIndexArray SetIndexArray;
-        FCPointHandler(FixedLMConstraint<DataTypes>* _fc, SetIndex* _data)
-            : sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >(_data), fc(_fc) {}
-
-
-
-        void applyDestroyFunction(Index /*index*/, value_type& /*T*/);
-
-    protected:
-        FixedLMConstraint<DataTypes> *fc;
-    };
-
 protected :
 
     Deriv X,Y,Z;
     SetIndexArray idxX, idxY, idxZ;
     std::map< Index, Coord> restPosition;
-
-
-    FCPointHandler* m_pointHandler;
-
 };
 
 

--- a/applications/plugins/LMConstraint/src/LMConstraint/FixedLMConstraint.inl
+++ b/applications/plugins/LMConstraint/src/LMConstraint/FixedLMConstraint.inl
@@ -28,25 +28,12 @@
 namespace sofa::component::constraintset
 {
 
-
-// Define RemovalFunction
-template< class DataTypes>
-void FixedLMConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, value_type &)
-{
-    if (fc)
-    {
-        fc->removeConstraint((Index) pointIndex);
-    }
-    return;
-}
-
 template <class DataTypes>
 FixedLMConstraint<DataTypes>::FixedLMConstraint(MechanicalState *dof)
     : core::behavior::LMConstraint<DataTypes,DataTypes>(dof,dof)
     , f_indices(core::objectmodel::Base::initData(&f_indices, "indices", "List of the index of particles to be fixed"))
     , _drawSize(core::objectmodel::Base::initData(&_drawSize,0.0,"drawSize","0 -> point based rendering, >0 -> radius of spheres") )
     , l_topology(initLink("topology", "link to the topology container"))
-    , m_pointHandler(nullptr)
 {
     
 }
@@ -103,9 +90,8 @@ void FixedLMConstraint<DataTypes>::init()
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 
-        // Initialize functions and parameters
-        m_pointHandler = new FCPointHandler(this, &f_indices);
-        f_indices.createTopologyHandler(_topology, m_pointHandler);
+        // Initialize topological change handling
+        f_indices.createTopologyHandler(_topology);
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.h
@@ -140,30 +140,12 @@ public:
     /// Draw the constrained points (= border mesh points)
      void draw(const core::visual::VisualParams* vparams) override;
 
-     class FCPointHandler : public component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >
-    {
-    public:
-        typedef typename AffineMovementConstraint<DataTypes>::SetIndexArray SetIndexArray;
-
-        FCPointHandler(AffineMovementConstraint<DataTypes>* _fc, SetIndex* _data)
-            : sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >(_data), fc(_fc) {}
-
-        using component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >::applyDestroyFunction;
-        void applyDestroyFunction(Index /*index*/, core::objectmodel::Data<value_type>& /*T*/);
-
-    protected:
-        AffineMovementConstraint<DataTypes> *fc;
-    };
-
 protected:
     
     template <class DataDeriv>
     void projectResponseT(const core::MechanicalParams* mparams, DataDeriv& dx);
 
 private:
-
-    /// Handler for subset Data
-    FCPointHandler* m_pointHandler;
 
     /// Initialize initial positions
     void initializeInitialPositions (const SetIndexArray & indices, DataVecCoord& xData, VecCoord& x0);

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.inl
@@ -33,17 +33,6 @@
 namespace sofa::component::projectiveconstraintset
 {
 
-// Define RemovalFunction
-template< class DataTypes>
-void AffineMovementConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, core::objectmodel::Data<value_type>&)
-{
-    if (fc)
-    {
-        fc->removeConstraint(pointIndex);
-    }
-}
-
-
 template <class DataTypes>
 AffineMovementConstraint<DataTypes>::AffineMovementConstraint()
     : core::behavior::ProjectiveConstraintSet<DataTypes>(nullptr)
@@ -57,7 +46,6 @@ AffineMovementConstraint<DataTypes>::AffineMovementConstraint()
     , m_translation(  initData(&m_translation,"translation","translation applied to border points") )
     , m_drawConstrainedPoints(  initData(&m_drawConstrainedPoints,"drawConstrainedPoints","draw constrained points") )
     , l_topology(initLink("topology", "link to the topology container"))
-    , m_pointHandler(nullptr)
 {
     if(!m_beginConstraintTime.isSet())
         m_beginConstraintTime = 0;
@@ -70,8 +58,7 @@ AffineMovementConstraint<DataTypes>::AffineMovementConstraint()
 template <class DataTypes>
 AffineMovementConstraint<DataTypes>::~AffineMovementConstraint()
 {
-    if (m_pointHandler)
-        delete m_pointHandler;
+
 }
 
 template <class DataTypes>
@@ -115,9 +102,8 @@ void AffineMovementConstraint<DataTypes>::init()
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";        
 
-        // Initialize functions and parameters
-        m_pointHandler = new FCPointHandler(this, &m_indices);
-        m_indices.createTopologyHandler(_topology, m_pointHandler);
+        // Initialize topological changes support
+        m_indices.createTopologyHandler(_topology);
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.h
@@ -118,27 +118,9 @@ public:
 
     bool fixAllDOFs() const { return d_fixAll.getValue(); }
 
-    class FCPointHandler : public sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >
-    {
-    public:
-        typedef typename FixedConstraint<DataTypes>::SetIndexArray SetIndexArray;
-
-        FCPointHandler(FixedConstraint<DataTypes>* _fc, SetIndex* _data)
-            : sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >(_data), fc(_fc) {}
-
-
-        void applyDestroyFunction(Index /*index*/, value_type& /*T*/);
-
-    protected:
-        FixedConstraint<DataTypes> *fc;
-    };
-
 protected :
     /// Function check values of given indices
     void checkIndices();
-    
-    /// Handler for subset Data
-    FCPointHandler* m_pointHandler;
 
 };
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.inl
@@ -37,16 +37,6 @@ using sofa::core::objectmodel::ComponentState;
 namespace sofa::component::projectiveconstraintset
 {
 
-// Define RemovalFunction
-template< class DataTypes>
-void FixedConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, value_type &)
-{
-    if (fc)
-    {
-        fc->removeConstraint((Index) pointIndex);
-    }
-}
-
 template <class DataTypes>
 FixedConstraint<DataTypes>::FixedConstraint()
     : core::behavior::ProjectiveConstraintSet<DataTypes>(nullptr)
@@ -57,7 +47,6 @@ FixedConstraint<DataTypes>::FixedConstraint()
     , d_projectVelocity( initData(&d_projectVelocity,false,"activate_projectVelocity","activate project velocity to set velocity") )
     , l_topology(initLink("topology", "link to the topology container"))
     , data(new FixedConstraintInternalData<DataTypes>())
-    , m_pointHandler(nullptr)
 {
     // default to indice 0
     d_indices.beginEdit()->push_back(0);
@@ -75,9 +64,6 @@ FixedConstraint<DataTypes>::FixedConstraint()
 template <class DataTypes>
 FixedConstraint<DataTypes>::~FixedConstraint()
 {
-    if (m_pointHandler)
-        delete m_pointHandler;
-
     delete data;
 }
 
@@ -129,9 +115,8 @@ void FixedConstraint<DataTypes>::init()
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 
-        // Initialize topological functions
-        m_pointHandler = new FCPointHandler(this, &d_indices);
-        d_indices.createTopologyHandler(_topology, m_pointHandler);
+        // Initialize topological changes support
+        d_indices.createTopologyHandler(_topology);
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedPlaneConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedPlaneConstraint.h
@@ -110,12 +110,6 @@ protected:
     FixedPlaneConstraintInternalData<DataTypes> data;
     friend class FixedPlaneConstraintInternalData<DataTypes>;
 
-    /// Forward class declaration, definition is in the .inl
-    class FCPointHandler;
-
-    /// Handler for subset Data
-    FCPointHandler* m_pointHandler {nullptr};
-
     /// whether vertices should be selected from 2 parallel planes
     bool m_selectVerticesFromPlanes {false};
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedPlaneConstraint.inl
@@ -35,36 +35,6 @@ namespace sofa::component::projectiveconstraintset
 
 using sofa::helper::WriteAccessor;
 using sofa::type::Vec;
-using sofa::component::topology::TopologyDataHandler;
-
-
-/////////////////////////// DEFINITION OF FCPointHandler (INNER CLASS) /////////////////////////////
-template <class DataTypes>
-class FixedPlaneConstraint<DataTypes>::FCPointHandler :
-        public TopologyDataHandler<BaseMeshTopology::Point, SetIndexArray >
-{
-public:
-    typedef typename FixedPlaneConstraint<DataTypes>::SetIndexArray SetIndexArray;
-
-    FCPointHandler(FixedPlaneConstraint<DataTypes>* _fc, SetIndex* _data)
-        : TopologyDataHandler<BaseMeshTopology::Point, SetIndexArray >(_data), fc(_fc) {}
-
-    void applyDestroyFunction(Index /*index*/, value_type& /*T*/);
-
-protected:
-    FixedPlaneConstraint<DataTypes> *fc;
-};
-
-/// Define RemovalFunction
-template< class DataTypes>
-void FixedPlaneConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, value_type &)
-{
-    if (fc)
-    {
-        fc->removeConstraint((Index) pointIndex);
-    }
-}
-
 
 /////////////////////////// DEFINITION OF FixedPlaneConstraint /////////////////////////////////////
 template <class DataTypes>
@@ -74,7 +44,6 @@ FixedPlaneConstraint<DataTypes>::FixedPlaneConstraint()
     , d_dmax( initData(&d_dmax,(Real)0,"dmax","Maximum plane distance from the origin") )
     , d_indices( initData(&d_indices,"indices","Indices of the fixed points"))
     , l_topology(initLink("topology", "link to the topology container"))
-    , m_pointHandler(nullptr)
 {
     m_selectVerticesFromPlanes=false;   
 }
@@ -82,8 +51,7 @@ FixedPlaneConstraint<DataTypes>::FixedPlaneConstraint()
 template <class DataTypes>
 FixedPlaneConstraint<DataTypes>::~FixedPlaneConstraint()
 {
-    if (m_pointHandler)
-        delete m_pointHandler;
+
 }
 
 /// Matrix Integration interface
@@ -236,9 +204,8 @@ void FixedPlaneConstraint<DataTypes>::init()
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
         
-        /// Initialize functions and parameters
-        m_pointHandler = new FCPointHandler(this, &d_indices);
-        d_indices.createTopologyHandler(_topology, m_pointHandler);
+        // Initialize topological changes support
+        d_indices.createTopologyHandler(_topology);
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedTranslationConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedTranslationConstraint.h
@@ -89,28 +89,9 @@ public:
 
     void draw(const core::visual::VisualParams* vparams) override;
 
-    class FCPointHandler : public sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >
-    {
-    public:
-        typedef typename FixedTranslationConstraint<DataTypes>::SetIndexArray SetIndexArray;
-        typedef sofa::core::topology::Point Point;
-        FCPointHandler(FixedTranslationConstraint<DataTypes>* _fc, SetIndex* _data)
-            : sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >(_data), fc(_fc) {}
-
-
-
-        void applyDestroyFunction(Index /*index*/, value_type& /*T*/);
-
-    protected:
-        FixedTranslationConstraint<DataTypes> *fc;
-    };
-
 protected:
     template <class DataDeriv>
     void projectResponseT(const core::MechanicalParams* mparams, DataDeriv& dx);
-
-    /// Handler for subset Data
-    FCPointHandler* m_pointHandler;
 
 };
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedTranslationConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedTranslationConstraint.inl
@@ -30,16 +30,6 @@
 namespace sofa::component::projectiveconstraintset
 {
 
-// Define RemovalFunction
-template< class DataTypes>
-void FixedTranslationConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, value_type &)
-{
-    if (fc)
-    {
-        fc->removeIndex((Index) pointIndex);
-    }
-}
-
 template< class DataTypes>
 FixedTranslationConstraint<DataTypes>::FixedTranslationConstraint()
     : core::behavior::ProjectiveConstraintSet<DataTypes>(nullptr)
@@ -48,7 +38,6 @@ FixedTranslationConstraint<DataTypes>::FixedTranslationConstraint()
     , _drawSize( initData(&_drawSize,(SReal)0.0,"drawSize","0 -> point based rendering, >0 -> radius of spheres") )
     , f_coordinates( initData(&f_coordinates,"coordinates","Coordinates of the fixed points") )
     , l_topology(initLink("topology", "link to the topology container"))
-    , m_pointHandler(nullptr)
 {
     // default to indice 0
     f_indices.beginEdit()->push_back(0);
@@ -59,8 +48,7 @@ FixedTranslationConstraint<DataTypes>::FixedTranslationConstraint()
 template <class DataTypes>
 FixedTranslationConstraint<DataTypes>::~FixedTranslationConstraint()
 {
-    if (m_pointHandler)
-        delete m_pointHandler;
+
 }
 
 template <class DataTypes>
@@ -102,9 +90,8 @@ void FixedTranslationConstraint<DataTypes>::init()
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 
-        // Initialize functions and parameters
-        m_pointHandler = new FCPointHandler(this, &f_indices);
-        f_indices.createTopologyHandler(_topology, m_pointHandler);
+        // Initialize topological changes support
+        f_indices.createTopologyHandler(_topology);
         f_coordinates.createTopologyHandler(_topology);
     }
     else

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.h
@@ -135,20 +135,6 @@ public:
 
     void draw(const core::visual::VisualParams* vparams) override;
 
-    class FCPointHandler : public sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >
-    {
-    public:
-        typedef typename LinearMovementConstraint<DataTypes>::SetIndexArray SetIndexArray;
-
-        FCPointHandler(LinearMovementConstraint<DataTypes>* _lc, SetIndex* _data)
-            : sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >(_data), lc(_lc) {}
-
-        void applyDestroyFunction(Index /*index*/, value_type& /*T*/);
-
-    protected:
-        LinearMovementConstraint<DataTypes> *lc;
-    };
-
 protected:
     template <class DataDeriv>
     void projectResponseT(const core::MechanicalParams* mparams, DataDeriv& dx);
@@ -167,9 +153,6 @@ private:
 
     /// find previous and next time keys
     void findKeyTimes();
-
-    /// Handler for subset Data
-    FCPointHandler* m_pointHandler;
 };
 
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.inl
@@ -33,16 +33,6 @@
 namespace sofa::component::projectiveconstraintset
 {
 
-// Define RemovalFunction
-template< class DataTypes>
-void LinearMovementConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, value_type &)
-{
-    if (lc)
-    {
-        lc->removeIndex(pointIndex);
-    }
-}
-
 template <class DataTypes>
 LinearMovementConstraint<DataTypes>::LinearMovementConstraint()
     : core::behavior::ProjectiveConstraintSet<DataTypes>(nullptr)
@@ -53,7 +43,6 @@ LinearMovementConstraint<DataTypes>::LinearMovementConstraint()
     , d_relativeMovements( initData(&d_relativeMovements, bool(true), "relativeMovements", "If true, movements are relative to first position, absolute otherwise") )
     , showMovement( initData(&showMovement, bool(false), "showMovement", "Visualization of the movement to be applied to constrained dofs."))
     , l_topology(initLink("topology", "link to the topology container"))
-    , m_pointHandler(nullptr)
 {
     // default to indice 0
     m_indices.beginEdit()->push_back(0);
@@ -71,8 +60,7 @@ LinearMovementConstraint<DataTypes>::LinearMovementConstraint()
 template <class DataTypes>
 LinearMovementConstraint<DataTypes>::~LinearMovementConstraint()
 {
-    if (m_pointHandler)
-        delete m_pointHandler;
+
 }
 
 template <class DataTypes>
@@ -132,9 +120,8 @@ void LinearMovementConstraint<DataTypes>::init()
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 
-        // Initialize functions and parameters
-        m_pointHandler = new FCPointHandler(this, &m_indices);
-        m_indices.createTopologyHandler(_topology, m_pointHandler);
+        // Initialize topological changes support
+        m_indices.createTopologyHandler(_topology);
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearVelocityConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearVelocityConstraint.h
@@ -111,22 +111,6 @@ public:
 
     void draw(const core::visual::VisualParams* vparams) override;
 
-    class FCPointHandler : public sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >
-    {
-    public:
-        typedef typename LinearVelocityConstraint<DataTypes>::SetIndexArray SetIndexArray;
-
-        FCPointHandler(LinearVelocityConstraint<DataTypes>* _lc, SetIndex* _data)
-            : sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >(_data), lc(_lc) {}
-
-
-
-        void applyDestroyFunction(Index /*index*/, value_type& /*T*/);
-
-    protected:
-        LinearVelocityConstraint<DataTypes> *lc;
-    };
-
 private:
 
     /// to keep the time corresponding to the key times
@@ -137,9 +121,6 @@ private:
 
     /// find previous and next time keys
     void findKeyTimes();
-
-    /// Handler for subset Data
-    FCPointHandler* m_pointHandler;
 };
 
 #if  !defined(SOFA_COMPONENT_PROJECTIVECONSTRAINTSET_LINEARVELOCITYCONSTRAINT_CPP)

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearVelocityConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearVelocityConstraint.inl
@@ -33,16 +33,6 @@
 namespace sofa::component::projectiveconstraintset
 {
 
-// Define RemovalFunction
-template< class TDataTypes>
-void LinearVelocityConstraint<TDataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, value_type &)
-{
-    if (lc)
-    {
-        lc->removeIndex((Index) pointIndex);
-    }
-}
-
 template <class TDataTypes>
 LinearVelocityConstraint<TDataTypes>::LinearVelocityConstraint()
     : core::behavior::ProjectiveConstraintSet<TDataTypes>(nullptr)
@@ -51,7 +41,6 @@ LinearVelocityConstraint<TDataTypes>::LinearVelocityConstraint()
     , d_keyVelocities(  initData(&d_keyVelocities,"velocities","velocities corresponding to the key times") )
     , d_coordinates( initData(&d_coordinates, "coordinates", "coordinates on which to apply velocities") )
     , l_topology(initLink("topology", "link to the topology container"))
-    , m_pointHandler(nullptr)
 {
     d_indices.beginEdit()->push_back(0);
     d_indices.endEdit();
@@ -66,8 +55,7 @@ LinearVelocityConstraint<TDataTypes>::LinearVelocityConstraint()
 template <class TDataTypes>
 LinearVelocityConstraint<TDataTypes>::~LinearVelocityConstraint()
 {
-    if (m_pointHandler)
-        delete m_pointHandler;
+
 }
 
 template <class TDataTypes>
@@ -129,9 +117,8 @@ void LinearVelocityConstraint<TDataTypes>::init()
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 
-        // Initialize functions and parameters
-        m_pointHandler = new FCPointHandler(this, &d_indices);
-        d_indices.createTopologyHandler(_topology, m_pointHandler);
+        // Initialize topological changes support
+        d_indices.createTopologyHandler(_topology);
         d_coordinates.createTopologyHandler(_topology);
     }
     else

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.h
@@ -142,19 +142,6 @@ public:
 
     void draw(const core::visual::VisualParams*) override;
 
-    class FCPointHandler : public sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >
-    {
-    public:
-        typedef typename PartialLinearMovementConstraint<DataTypes>::SetIndexArray SetIndexArray;
-
-        FCPointHandler(PartialLinearMovementConstraint<DataTypes>* _lc, SetIndex* _data)
-            : sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >(_data), lc(_lc) {}
-
-        void applyDestroyFunction(Index /*index*/, value_type& /*T*/);
-    protected:
-        PartialLinearMovementConstraint<DataTypes> *lc;
-    };
-
 protected:
     template <class DataDeriv>
     void projectResponseT(const core::MechanicalParams* mparams, DataDeriv& dx);
@@ -174,9 +161,6 @@ private:
 
     /// find previous and next time keys
     void findKeyTimes();
-
-    /// Handler for subset Data
-    FCPointHandler* m_pointHandler;
 };
 
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
@@ -35,17 +35,6 @@
 namespace sofa::component::projectiveconstraintset
 {
 
-
-// Define RemovalFunction
-template< class DataTypes>
-void PartialLinearMovementConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, value_type &)
-{
-    if (lc)
-    {
-        lc->removeIndex((Index) pointIndex);
-    }
-}
-
 template <class DataTypes>
 PartialLinearMovementConstraint<DataTypes>::PartialLinearMovementConstraint()
     : core::behavior::ProjectiveConstraintSet<DataTypes>(nullptr)
@@ -64,7 +53,6 @@ PartialLinearMovementConstraint<DataTypes>::PartialLinearMovementConstraint()
     , Z0 ( initData ( &Z0, Real(0.0),"Z0","Size of specimen in Z-direction" ) )
     , movedDirections( initData(&movedDirections,"movedDirections","for each direction, 1 if moved, 0 if free") )
     , l_topology(initLink("topology", "link to the topology container"))
-    , m_pointHandler(nullptr)
 {
     // default to indice 0
     m_indices.beginEdit()->push_back(0);
@@ -85,8 +73,7 @@ PartialLinearMovementConstraint<DataTypes>::PartialLinearMovementConstraint()
 template <class DataTypes>
 PartialLinearMovementConstraint<DataTypes>::~PartialLinearMovementConstraint()
 {
-    if (m_pointHandler)
-        delete m_pointHandler;
+
 }
 
 template <class DataTypes>
@@ -148,9 +135,8 @@ void PartialLinearMovementConstraint<DataTypes>::init()
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 
-        // Initialize functions and parameters
-        m_pointHandler = new FCPointHandler(this, &m_indices);
-        m_indices.createTopologyHandler(_topology, m_pointHandler);
+        // Initialize topological changes support
+        m_indices.createTopologyHandler(_topology);
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PatchTestMovementConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PatchTestMovementConstraint.h
@@ -136,29 +136,12 @@ public:
     /// Draw the constrained points (= border mesh points)
      void draw(const core::visual::VisualParams* vparams) override;
 
-    class FCPointHandler : public sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >
-    {
-    public:
-        typedef typename PatchTestMovementConstraint<DataTypes>::SetIndexArray SetIndexArray;
-
-        FCPointHandler(PatchTestMovementConstraint<DataTypes>* _fc, SetIndex* _data)
-            : sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >(_data), fc(_fc) {}
-
-        void applyDestroyFunction(Index /*index*/, value_type& /*T*/);
-
-    protected:
-        PatchTestMovementConstraint<DataTypes> *fc;
-    };
-
 protected:
     
     template <class DataDeriv>
     void projectResponseT(const core::MechanicalParams* mparams, DataDeriv& dx);
 
 private:
-
-    /// Handler for subset Data
-    FCPointHandler* m_pointHandler;
 
     /// Find the corners of the grid mesh
     void findCornerPoints();

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PatchTestMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PatchTestMovementConstraint.inl
@@ -33,17 +33,6 @@
 namespace sofa::component::projectiveconstraintset
 {
 
-// Define RemovalFunction
-template< class DataTypes>
-void PatchTestMovementConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, value_type &)
-{
-    if (fc)
-    {
-        fc->removeConstraint((Index) pointIndex);
-    }
-}
-
-
 template <class DataTypes>
 PatchTestMovementConstraint<DataTypes>::PatchTestMovementConstraint()
     : core::behavior::ProjectiveConstraintSet<DataTypes>(nullptr)
@@ -57,7 +46,6 @@ PatchTestMovementConstraint<DataTypes>::PatchTestMovementConstraint()
     , d_cornerPoints(  initData(&d_cornerPoints,"cornerPoints","corner points for computing constraint") )
     , d_drawConstrainedPoints(  initData(&d_drawConstrainedPoints,"drawConstrainedPoints","draw constrained points") )
     , l_topology(initLink("topology", "link to the topology container"))
-    , m_pointHandler(nullptr)
 {
     if(!d_beginConstraintTime.isSet())
      d_beginConstraintTime = 0;
@@ -70,8 +58,7 @@ PatchTestMovementConstraint<DataTypes>::PatchTestMovementConstraint()
 template <class DataTypes>
 PatchTestMovementConstraint<DataTypes>::~PatchTestMovementConstraint()
 {
-    if (m_pointHandler)
-        delete m_pointHandler;
+
 }
 
 template <class DataTypes>
@@ -115,9 +102,8 @@ void PatchTestMovementConstraint<DataTypes>::init()
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 
-        // Initialize functions and parameters
-        m_pointHandler = new FCPointHandler(this, &d_indices);
-        d_indices.createTopologyHandler(_topology, m_pointHandler);
+        // Initialize topological changes support
+        d_indices.createTopologyHandler(_topology);
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PositionBasedDynamicsConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PositionBasedDynamicsConstraint.h
@@ -31,7 +31,6 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/type/vector.h>
-#include <SofaBaseTopology/TopologySubsetData.h>
 #include <set>
 
 namespace sofa::component::projectiveconstraintset

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.h
@@ -119,26 +119,7 @@ public:
 
     void draw(const core::visual::VisualParams* vparams) override;
 
-
-    class FCPointHandler : public component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, Indices >
-    {
-    public:
-        typedef typename ProjectDirectionConstraint<DataTypes>::Indices Indices;
-        typedef sofa::core::topology::Point Point;
-        FCPointHandler(ProjectDirectionConstraint<DataTypes>* _fc, IndexSubsetData* _data)
-            : sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, Indices >(_data), fc(_fc) {}
-
-
-        using component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, Indices >::applyDestroyFunction;
-        void applyDestroyFunction(Index /*index*/, core::objectmodel::Data<value_type>& /*T*/);
-
-    protected:
-        ProjectDirectionConstraint<DataTypes> *fc;
-    };
-
 protected :
-    /// Handler for subset Data
-    FCPointHandler* m_pointHandler;
 
     SparseMatrix jacobian; ///< projection matrix in local state
     SparseMatrix J;        ///< auxiliary variable

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.inl
@@ -33,15 +33,6 @@
 namespace sofa::component::projectiveconstraintset
 {
 
-template< class DataTypes>
-void ProjectDirectionConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, core::objectmodel::Data<value_type> &)
-{
-    if (fc)
-    {
-        fc->removeConstraint((Index) pointIndex);
-    }
-}
-
 template <class DataTypes>
 ProjectDirectionConstraint<DataTypes>::ProjectDirectionConstraint()
     : core::behavior::ProjectiveConstraintSet<DataTypes>(nullptr)
@@ -50,7 +41,6 @@ ProjectDirectionConstraint<DataTypes>::ProjectDirectionConstraint()
     , f_direction( initData(&f_direction,CPos(),"direction","Direction of the line"))
     , l_topology(initLink("topology", "link to the topology container"))
     , data(new ProjectDirectionConstraintInternalData<DataTypes>())    
-    , m_pointHandler(nullptr)
 {
     f_indices.beginEdit()->push_back(0);
     f_indices.endEdit();
@@ -60,9 +50,6 @@ ProjectDirectionConstraint<DataTypes>::ProjectDirectionConstraint()
 template <class DataTypes>
 ProjectDirectionConstraint<DataTypes>::~ProjectDirectionConstraint()
 {
-    if (m_pointHandler)
-        delete m_pointHandler;
-
     delete data;
 }
 
@@ -108,9 +95,8 @@ void ProjectDirectionConstraint<DataTypes>::init()
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
         
-        // Initialize functions and parameters
-        m_pointHandler = new FCPointHandler(this, &f_indices);
-        f_indices.createTopologyHandler(_topology, m_pointHandler);
+        // Initialize topological changes support
+        f_indices.createTopologyHandler(_topology);
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.h
@@ -119,26 +119,7 @@ public:
 
     void draw(const core::visual::VisualParams* vparams) override;
 
-
-    class FCPointHandler : public component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, Indices >
-    {
-    public:
-        typedef typename ProjectToLineConstraint<DataTypes>::Indices Indices;
-        typedef sofa::core::topology::Point Point;
-        FCPointHandler(ProjectToLineConstraint<DataTypes>* _fc, IndexSubsetData* _data)
-            : sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, Indices >(_data), fc(_fc) {}
-
-
-        using component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, Indices >::applyDestroyFunction;
-        void applyDestroyFunction(Index /*index*/, core::objectmodel::Data<value_type>& /*T*/);
-
-    protected:
-        ProjectToLineConstraint<DataTypes> *fc;
-    };
-
 protected :
-    /// Handler for subset Data
-    FCPointHandler* m_pointHandler;
 
     SparseMatrix jacobian; ///< projection matrix in local state
     SparseMatrix J;        ///< auxiliary variable

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.inl
@@ -32,15 +32,6 @@
 namespace sofa::component::projectiveconstraintset
 {
 
-template< class DataTypes>
-void ProjectToLineConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, core::objectmodel::Data<value_type> &)
-{
-    if (fc)
-    {
-        fc->removeConstraint((Index) pointIndex);
-    }
-}
-
 template <class DataTypes>
 ProjectToLineConstraint<DataTypes>::ProjectToLineConstraint()
     : core::behavior::ProjectiveConstraintSet<DataTypes>(nullptr)
@@ -50,7 +41,6 @@ ProjectToLineConstraint<DataTypes>::ProjectToLineConstraint()
     , f_direction( initData(&f_direction,CPos(),"direction","Direction of the line"))
     , l_topology(initLink("topology", "link to the topology container"))
     , data(new ProjectToLineConstraintInternalData<DataTypes>())    
-    , m_pointHandler(nullptr)
 {
     f_indices.beginEdit()->push_back(0);
     f_indices.endEdit();
@@ -60,9 +50,6 @@ ProjectToLineConstraint<DataTypes>::ProjectToLineConstraint()
 template <class DataTypes>
 ProjectToLineConstraint<DataTypes>::~ProjectToLineConstraint()
 {
-    if (m_pointHandler)
-        delete m_pointHandler;
-
     delete data;
 }
 
@@ -107,9 +94,8 @@ void ProjectToLineConstraint<DataTypes>::init()
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
         
-        // Initialize functions and parameters
-        m_pointHandler = new FCPointHandler(this, &f_indices);
-        f_indices.createTopologyHandler(_topology, m_pointHandler);
+        // Initialize topological changes support
+        f_indices.createTopologyHandler(_topology);
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.h
@@ -120,26 +120,7 @@ public:
 
     void draw(const core::visual::VisualParams* vparams) override;
 
-
-    class FCPointHandler : public component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, Indices >
-    {
-    public:
-        typedef typename ProjectToPlaneConstraint<DataTypes>::Indices Indices;
-        typedef typename sofa::core::topology::Point Point;
-        FCPointHandler(ProjectToPlaneConstraint<DataTypes>* _fc, IndexSubsetData* _data)
-            : sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, Indices >(_data), fc(_fc) {}
-
-
-        using component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, Indices >::applyDestroyFunction;
-        void applyDestroyFunction(Index /*index*/, core::objectmodel::Data<value_type>& /*T*/);
-
-    protected:
-        ProjectToPlaneConstraint<DataTypes> *fc;
-    };
-
 protected :
-    /// Handler for subset Data
-    FCPointHandler* m_pointHandler;
 
     SparseMatrix jacobian; ///< projection matrix in local state
     SparseMatrix J;        ///< auxiliary variable

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
@@ -32,15 +32,6 @@
 namespace sofa::component::projectiveconstraintset
 {
 
-template< class DataTypes>
-void ProjectToPlaneConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, core::objectmodel::Data<value_type> &)
-{
-    if (fc)
-    {
-        fc->removeConstraint((Index) pointIndex);
-    }
-}
-
 template <class DataTypes>
 ProjectToPlaneConstraint<DataTypes>::ProjectToPlaneConstraint()
     : core::behavior::ProjectiveConstraintSet<DataTypes>(nullptr)
@@ -50,7 +41,6 @@ ProjectToPlaneConstraint<DataTypes>::ProjectToPlaneConstraint()
     , f_drawSize( initData(&f_drawSize,(SReal)0.0,"drawSize","0 -> point based rendering, >0 -> radius of spheres") )
     , l_topology(initLink("topology", "link to the topology container"))
     , data(new ProjectToPlaneConstraintInternalData<DataTypes>())    
-    , m_pointHandler(nullptr)
 {
     f_indices.beginEdit()->push_back(0);
     f_indices.endEdit();
@@ -60,9 +50,6 @@ ProjectToPlaneConstraint<DataTypes>::ProjectToPlaneConstraint()
 template <class DataTypes>
 ProjectToPlaneConstraint<DataTypes>::~ProjectToPlaneConstraint()
 {
-    if (m_pointHandler)
-        delete m_pointHandler;
-
     delete data;
 }
 
@@ -107,9 +94,8 @@ void ProjectToPlaneConstraint<DataTypes>::init()
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 
-        // Initialize functions and parameters
-        m_pointHandler = new FCPointHandler(this, &f_indices);
-        f_indices.createTopologyHandler(_topology, m_pointHandler);
+        // Initialize topological changes support
+        f_indices.createTopologyHandler(_topology);
     }
     else
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.h
@@ -116,25 +116,7 @@ public:
 
     bool fixAllDOFs() const { return f_fixAll.getValue(); }
 
-    class FCPointHandler : public component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >
-    {
-    public:
-        typedef typename ProjectToPointConstraint<DataTypes>::SetIndexArray SetIndexArray;
-        typedef sofa::core::topology::Point Point;
-        FCPointHandler(ProjectToPointConstraint<DataTypes>* _fc, SetIndex* _data)
-            : component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >(_data), fc(_fc) {}
-
-
-        using component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >::applyDestroyFunction;
-        void applyDestroyFunction(Index /*index*/, core::objectmodel::Data<value_type>& /*T*/);
-
-    protected:
-        ProjectToPointConstraint<DataTypes> *fc;
-    };
-
 protected :
-    /// Handler for subset Data
-    FCPointHandler* m_pointHandler;
 
     /// Matrix used in getJ
 //    linearsolver::EigenBaseSparseMatrix<SReal> jacobian;

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.inl
@@ -33,15 +33,6 @@
 namespace sofa::component::projectiveconstraintset
 {
 
-template< class DataTypes>
-void ProjectToPointConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, core::objectmodel::Data<value_type> &)
-{
-    if (fc)
-    {
-        fc->removeConstraint((Index) pointIndex);
-    }
-}
-
 template <class DataTypes>
 ProjectToPointConstraint<DataTypes>::ProjectToPointConstraint()
     : core::behavior::ProjectiveConstraintSet<DataTypes>(nullptr)
@@ -51,7 +42,6 @@ ProjectToPointConstraint<DataTypes>::ProjectToPointConstraint()
     , f_drawSize( initData(&f_drawSize,(SReal)0.0,"drawSize","0 -> point based rendering, >0 -> radius of spheres") )
     , l_topology(initLink("topology", "link to the topology container"))
     , data(new ProjectToPointConstraintInternalData<DataTypes>())    
-    , m_pointHandler(nullptr)
 {
     f_indices.beginEdit()->push_back(0);
     f_indices.endEdit();
@@ -61,9 +51,6 @@ ProjectToPointConstraint<DataTypes>::ProjectToPointConstraint()
 template <class DataTypes>
 ProjectToPointConstraint<DataTypes>::~ProjectToPointConstraint()
 {
-    if (m_pointHandler)
-        delete m_pointHandler;
-
     delete data;
 }
 
@@ -108,9 +95,8 @@ void ProjectToPointConstraint<DataTypes>::init()
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 
-        // Initialize functions and parameters
-        m_pointHandler = new FCPointHandler(this, &f_indices);
-        f_indices.createTopologyHandler(_topology, m_pointHandler);
+        // Initialize topological changes support
+        f_indices.createTopologyHandler(_topology);
     }
     else
     {

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.h
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.h
@@ -33,6 +33,11 @@
 #include <unordered_map>
 #include <typeindex>
 
+namespace sofa::simulation
+{
+    class Node;
+}
+
 namespace sofa::component::collision
 {
 


### PR DESCRIPTION
This PR integrate PR #2114 and will be merged inside branch inf_topologyChanges_POC

Remove several header includes not needed. Also remove all TopologyDataHandler in constraints as they were only redefining a Data resize operation. This is already done directly inside the TopologyData. 
The destroyFunction should be only overridden if a complex behavior is needed.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
