### PR TITLE
[SofaBaseMechanics] Fix bug when deleting point. Mass vector was not well recomputed.

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
@@ -77,33 +77,26 @@ void DiagonalMass<DataTypes,MassType>::DMassPointEngine::applyPointDestruction(c
     helper::WriteAccessor<Data<MassVector> > masses(dm->d_vertexMass);
     helper::WriteAccessor<Data<Real> > totalMass(dm->d_totalMass);
 
-    size_t numberPointsRemoved = pointsRemoved.size();
-    size_t newSize = masses.size()-numberPointsRemoved;
-    size_t counter = 0;
-
-    // Remove the mass of the removed points from totalMass
-    for(size_t i=0; i<numberPointsRemoved; i++)
+    Index last = masses.size() - 1;
+    for (std::size_t i = 0; i < pointsRemoved.size(); ++i)
     {
-        totalMass -= masses[pointsRemoved[i]];
-    }
+        Index id = pointsRemoved[i];
 
-    // Resize the vertexMass vector and remove removed indices
-    bool removedPointFound;
-    for(size_t i=0; i<newSize; i++)
-    {
-        removedPointFound = false;
-        for(size_t j=0; j<numberPointsRemoved; j++)
+        if (id >= masses.size())
         {
-            if(i == pointsRemoved[j])
-                removedPointFound = true;
+            msg_error("DMassPointEngine") << "Point to remove is out of bounds from mass vector: " << id << " out of size: " << masses.size();
+            continue;
         }
-        if(removedPointFound)
-            counter++;
-        else
-            masses[i-counter] = masses[i];
+        
+        // Remove the mass of the removed points from totalMass
+        totalMass -= masses[id];
+
+        // swap value before resize
+        masses[id] = masses[last];
+        --last;
     }
 
-    masses.resize(newSize);
+    masses.resize(last + 1);
 }
 
 template <class DataTypes, class MassType>


### PR DESCRIPTION
When removing point, mass vector was not following the vertex buffer. Which is using swap + pop_back.
This bug could create negative mass during further element deletion.

The bug is easy to see with a high mass density:
![ezgif com-gif-maker(5)](https://user-images.githubusercontent.com/21199245/121010323-917ee880-c795-11eb-9a1e-270c925d845f.gif)


After fix:
![ezgif com-gif-maker(4)](https://user-images.githubusercontent.com/21199245/121010119-4bc22000-c795-11eb-97ca-405644d13cd0.gif)






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
