### PR TITLE
[SofaCore] Deprecate operator=

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/MultiMatrix.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/MultiMatrix.h
@@ -65,7 +65,7 @@ public:
         parent->m_resetSystem();
     }
 
-    [[deprecated("Use setSystemMBKMatrix instead.")]]
+    SOFA_ATTRIBUTE_DEPRECATED("v21.06 (PR#2167)", "v21.12", "Use setSystemMBKMatrix instead.")
     void operator=(const MechanicalMatrix& m)
     {
         setSystemMBKMatrix(m);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/MultiMatrix.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/MultiMatrix.h
@@ -65,8 +65,13 @@ public:
         parent->m_resetSystem();
     }
 
-    /// m = m*M+b*B+k*K
+    [[deprecated("Use setSystemMBKMatrix instead.")]]
     void operator=(const MechanicalMatrix& m)
+    {
+        setSystemMBKMatrix(m);
+    }
+
+    void setSystemMBKMatrix(const MechanicalMatrix& m)
     {
         parent->m_setSystemMBKMatrix(m.getMFact(), m.getBFact(), m.getKFact());
     }


### PR DESCRIPTION
Operator= is deprecated because it hides operations. Readers might think that = is simply an assignment, but it is more than that. As a replacement, the method `setSystemMBKMatrix` is provided.

Removing calls to operator= will be done in another PR, once this one is validated.





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
