### PR TITLE
[Sofa.Helper] Add new MOVED status to ComponentChange

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.cpp
@@ -646,8 +646,10 @@ std::map<std::string, ComponentChange> uncreatableComponents = {
     {"InterpolationController", Removed("v17.12", "v18.12")},
     {"MechanicalStateControllerOmni", Removed("v17.12", "v18.12")},
     {"NodeToggleController", Removed("v17.12", "v18.12")},
-};
 
+    /***********************/
+    // MOVED SINCE v21.06
+};
 
 } // namespace lifecycle
 } // namespace helper

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.h
@@ -102,8 +102,8 @@ class SOFA_HELPER_API Moved : public ComponentChange
 public:
     Moved(std::string  sinceVersion, std::string fromPlugin, std::string toPlugin) {
         std::stringstream output;
-        output << "This component has moved from " << fromPlugin << " to " << toPlugin << " since SOFA " << sinceVersion << "."
-               <<  "To continue using this component you may need to update you scene "
+        output << "This component has been moved from " << fromPlugin << " to " << toPlugin << " since SOFA " << sinceVersion << "."
+               <<  "To continue using this component you need to update your scene "
                <<  "by adding <RequiredPlugin name='" << toPlugin << "'/>";
         m_message = output.str();
         m_changeVersion = sinceVersion;

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.h
@@ -97,6 +97,19 @@ public:
     }
 };
 
+class SOFA_HELPER_API Moved : public ComponentChange
+{
+public:
+    Moved(std::string  sinceVersion, std::string fromPlugin, std::string toPlugin) {
+        std::stringstream output;
+        output << "This component has moved from " << fromPlugin << " to " << toPlugin << " since SOFA " << sinceVersion << "."
+               <<  "To continue using this component you may need to update you scene "
+               <<  "by adding <RequiredPlugin name='" << toPlugin << "'/>";
+        m_message = output.str();
+        m_changeVersion = sinceVersion;
+    }
+};
+
 extern SOFA_HELPER_API std::map< std::string, Deprecated > deprecatedComponents;
 extern SOFA_HELPER_API std::map< std::string, ComponentChange > uncreatableComponents;
 


### PR DESCRIPTION
This PR adds a "MOVED" status to ComponentChange, as it was only handling deprecated, removed and pluginized status.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
