### PR TITLE
[All] remove method applyTestCreateFunction in TopologyDataHandler 

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyDataHandler.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyDataHandler.h
@@ -139,16 +139,18 @@ public:
         applyCreateFunction(i, t, e, ancestors, coefs);
     }
 
-    virtual bool applyTestCreateFunction(Index /*index*/,
-        const sofa::helper::vector< Index >& /*ancestors*/,
-        const sofa::helper::vector< double >& /*coefs*/) {
-        return false;
-    }
+
 
     // update the default value used during creation
     void setDefaultValue(const value_type& v) {
         m_defaultValue = v;
     }
+
+
+    ////////////////////////////////////// DEPRECATED ///////////////////////////////////////////
+    // TODO change message before PR
+    SOFA_ATTRIBUTE_DISABLED("v21.06 (PR#2171)", "v21.06 (PR#2171)", "This method has been removed as it has never been used and is not needed.")
+    bool applyTestCreateFunction(Index /*index*/, const sofa::helper::vector< Index >& /*ancestors*/, const sofa::helper::vector< double >& /*coefs*/) = delete;
 
 protected:
     t_topologicalData* m_topologyData;

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyDataHandler.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyDataHandler.h
@@ -148,8 +148,7 @@ public:
 
 
     ////////////////////////////////////// DEPRECATED ///////////////////////////////////////////
-    // TODO change message before PR
-    SOFA_ATTRIBUTE_DISABLED("v21.06 (PR#2171)", "v21.06 (PR#2171)", "This method has been removed as it has never been used and is not needed.")
+    SOFA_ATTRIBUTE_DISABLED("v21.06 (PR#2171)", "v21.06 (PR#2171)", "This method has been removed as it has never been used and is not needed. Use applyCreateFunction to add a callback.")
     bool applyTestCreateFunction(Index /*index*/, const sofa::helper::vector< Index >& /*ancestors*/, const sofa::helper::vector< double >& /*coefs*/) = delete;
 
 protected:

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologySubsetData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologySubsetData.inl
@@ -59,11 +59,12 @@ void TopologySubsetData <TopologyElementType, VecT>::add(sofa::Size nbElements,
     // Using default values
     container_type& data = *(this->beginEdit());
 
-    size_t size = data.size();
+    Size size = data.size();
+    data.resize(size + nbElements);
     
     if (this->m_topologyHandler)
     {
-        bool test = false;
+        value_type t;
         for (std::size_t i = 0; i < nbElements; ++i)
         {
             if (ancestors.empty() || coefs.empty())
@@ -71,18 +72,16 @@ void TopologySubsetData <TopologyElementType, VecT>::add(sofa::Size nbElements,
                 const sofa::helper::vector< Index > empty_vecint;
                 const sofa::helper::vector< double > empty_vecdouble;
 
-                test = this->m_topologyHandler->applyTestCreateFunction(Index(size + i), empty_vecint, empty_vecdouble);
+                this->m_topologyHandler->applyCreateFunction(Index(size + i), t, empty_vecint, empty_vecdouble);
             }
             else {
-                test = this->m_topologyHandler->applyTestCreateFunction(Index(size + i), ancestors[i], coefs[i]);
+                this->m_topologyHandler->applyCreateFunction(Index(size + i), t, ancestors[i], coefs[i]);
             }
-
-            if (test)
-                data.push_back((size + i));
         }
     }
    
     this->lastElementIndex += nbElements;
+    this->endEdit();
 }
 
 

--- a/applications/plugins/LMConstraint/src/LMConstraint/DOFBlockerLMConstraint.h
+++ b/applications/plugins/LMConstraint/src/LMConstraint/DOFBlockerLMConstraint.h
@@ -128,9 +128,6 @@ public:
         void applyDestroyFunction(Index /*index*/, value_type& /*T*/);
 
 
-        bool applyTestCreateFunction(Index /*index*/,
-                const sofa::helper::vector< Index > & /*ancestors*/,
-                const sofa::helper::vector< double > & /*coefs*/);
     protected:
         DOFBlockerLMConstraint<DataTypes> *fc;
     };

--- a/applications/plugins/LMConstraint/src/LMConstraint/DOFBlockerLMConstraint.inl
+++ b/applications/plugins/LMConstraint/src/LMConstraint/DOFBlockerLMConstraint.inl
@@ -30,20 +30,6 @@
 namespace sofa::component::constraintset
 {
 
-// Define TestNewPointFunction
-template< class DataTypes>
-bool DOFBlockerLMConstraint<DataTypes>::FCTPointHandler::applyTestCreateFunction(Index /*nbPoints*/, const sofa::helper::vector< Index > &, const sofa::helper::vector< double >& )
-{
-    if (fc)
-    {
-        return true;
-    }
-    else
-    {
-        return false;
-    }
-}
-
 // Define RemovalFunction
 template< class DataTypes>
 void DOFBlockerLMConstraint<DataTypes>::FCTPointHandler::applyDestroyFunction(Index pointIndex, value_type &)

--- a/applications/plugins/LMConstraint/src/LMConstraint/FixedLMConstraint.h
+++ b/applications/plugins/LMConstraint/src/LMConstraint/FixedLMConstraint.h
@@ -112,10 +112,6 @@ public:
 
         void applyDestroyFunction(Index /*index*/, value_type& /*T*/);
 
-
-        bool applyTestCreateFunction(Index /*index*/,
-                const sofa::helper::vector< Index > & /*ancestors*/,
-                const sofa::helper::vector< double > & /*coefs*/);
     protected:
         FixedLMConstraint<DataTypes> *fc;
     };

--- a/applications/plugins/LMConstraint/src/LMConstraint/FixedLMConstraint.inl
+++ b/applications/plugins/LMConstraint/src/LMConstraint/FixedLMConstraint.inl
@@ -30,21 +30,6 @@ namespace sofa::component::constraintset
 {
 
 
-
-// Define TestNewPointFunction
-template< class DataTypes>
-bool FixedLMConstraint<DataTypes>::FCPointHandler::applyTestCreateFunction(Index /*nbPoints*/, const sofa::helper::vector< Index > &, const sofa::helper::vector< double >& )
-{
-    if (fc)
-    {
-        return true;
-    }
-    else
-    {
-        return false;
-    }
-}
-
 // Define RemovalFunction
 template< class DataTypes>
 void FixedLMConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, value_type &)

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticleSource.h
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticleSource.h
@@ -119,10 +119,6 @@ public:
         }
 
 
-        bool applyTestCreateFunction(Index /*index*/,
-                const sofa::helper::vector< Index > & /*ancestors*/,
-                const sofa::helper::vector< double > & /*coefs*/) {return false;}
-
     protected:
         ParticleSource<DataTypes> *ps;
     };

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.h
@@ -151,9 +151,6 @@ public:
         using component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >::applyDestroyFunction;
         void applyDestroyFunction(Index /*index*/, core::objectmodel::Data<value_type>& /*T*/);
 
-        bool applyTestCreateFunction(Index /*index*/,
-                const sofa::helper::vector< Index > & /*ancestors*/,
-                const sofa::helper::vector< double > & /*coefs*/);
     protected:
         AffineMovementConstraint<DataTypes> *fc;
     };

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.inl
@@ -34,14 +34,6 @@
 namespace sofa::component::projectiveconstraintset
 {
 
-// Define TestFunction
-template< class DataTypes>
-bool AffineMovementConstraint<DataTypes>::FCPointHandler::applyTestCreateFunction(Index, const sofa::helper::vector<Index> &, const sofa::helper::vector<double> &)
-{
-    return fc != 0;
-}
-
-
 // Define RemovalFunction
 template< class DataTypes>
 void AffineMovementConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, core::objectmodel::Data<value_type>&)

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.h
@@ -129,10 +129,6 @@ public:
 
         void applyDestroyFunction(Index /*index*/, value_type& /*T*/);
 
-
-        bool applyTestCreateFunction(Index /*index*/,
-                const sofa::helper::vector< Index > & /*ancestors*/,
-                const sofa::helper::vector< double > & /*coefs*/);
     protected:
         FixedConstraint<DataTypes> *fc;
     };

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.inl
@@ -38,20 +38,6 @@ using sofa::core::objectmodel::ComponentState;
 namespace sofa::component::projectiveconstraintset
 {
 
-// Define TestNewPointFunction
-template< class DataTypes>
-bool FixedConstraint<DataTypes>::FCPointHandler::applyTestCreateFunction(Index, const sofa::helper::vector<Index> &, const sofa::helper::vector<double> &)
-{
-    if (fc)
-    {
-        return false;
-    }
-    else
-    {
-        return false;
-    }
-}
-
 // Define RemovalFunction
 template< class DataTypes>
 void FixedConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, value_type &)

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedPlaneConstraint.inl
@@ -53,9 +53,6 @@ public:
 
     void applyDestroyFunction(Index /*index*/, value_type& /*T*/);
 
-    bool applyTestCreateFunction(Index /*index*/,
-                                 const helper::vector< Index > & /*ancestors*/,
-                                 const helper::vector< double > & /*coefs*/);
 protected:
     FixedPlaneConstraint<DataTypes> *fc;
 };
@@ -70,19 +67,6 @@ void FixedPlaneConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index
     }
 }
 
-/// Define TestNewPointFunction
-template< class DataTypes>
-bool FixedPlaneConstraint<DataTypes>::FCPointHandler::applyTestCreateFunction(Index, const helper::vector<Index> &, const helper::vector<double> &)
-{
-    if (fc)
-    {
-        return true;
-    }
-    else
-    {
-        return false;
-    }
-}
 
 /////////////////////////// DEFINITION OF FixedPlaneConstraint /////////////////////////////////////
 template <class DataTypes>

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedTranslationConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedTranslationConstraint.h
@@ -101,10 +101,6 @@ public:
 
         void applyDestroyFunction(Index /*index*/, value_type& /*T*/);
 
-
-        bool applyTestCreateFunction(Index /*index*/,
-                const sofa::helper::vector< Index > & /*ancestors*/,
-                const sofa::helper::vector< double > & /*coefs*/);
     protected:
         FixedTranslationConstraint<DataTypes> *fc;
     };

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedTranslationConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedTranslationConstraint.inl
@@ -31,13 +31,6 @@
 namespace sofa::component::projectiveconstraintset
 {
 
-// Define TestNewPointFunction
-template< class DataTypes>
-bool FixedTranslationConstraint<DataTypes>::FCPointHandler::applyTestCreateFunction(Index, const sofa::helper::vector<Index> &, const sofa::helper::vector<double> &)
-{
-    return fc != 0;
-}
-
 // Define RemovalFunction
 template< class DataTypes>
 void FixedTranslationConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, value_type &)

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.h
@@ -145,9 +145,6 @@ public:
 
         void applyDestroyFunction(Index /*index*/, value_type& /*T*/);
 
-        bool applyTestCreateFunction(Index /*index*/,
-                const sofa::helper::vector< Index > & /*ancestors*/,
-                const sofa::helper::vector< double > & /*coefs*/);
     protected:
         LinearMovementConstraint<DataTypes> *lc;
     };

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.inl
@@ -34,13 +34,6 @@
 namespace sofa::component::projectiveconstraintset
 {
 
-// Define TestNewPointFunction
-template< class DataTypes>
-bool LinearMovementConstraint<DataTypes>::FCPointHandler::applyTestCreateFunction(Index, const sofa::helper::vector<Index> &, const sofa::helper::vector<double> &)
-{
-    return lc != 0;
-}
-
 // Define RemovalFunction
 template< class DataTypes>
 void LinearMovementConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, value_type &)

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearVelocityConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearVelocityConstraint.h
@@ -123,10 +123,6 @@ public:
 
         void applyDestroyFunction(Index /*index*/, value_type& /*T*/);
 
-
-        bool applyTestCreateFunction(Index /*index*/,
-                const sofa::helper::vector< Index > & /*ancestors*/,
-                const sofa::helper::vector< double > & /*coefs*/);
     protected:
         LinearVelocityConstraint<DataTypes> *lc;
     };

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearVelocityConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearVelocityConstraint.inl
@@ -34,14 +34,6 @@
 namespace sofa::component::projectiveconstraintset
 {
 
-
-// Define TestNewPointFunction
-template< class TDataTypes>
-bool LinearVelocityConstraint<TDataTypes>::FCPointHandler::applyTestCreateFunction(Index, const sofa::helper::vector<Index> &, const sofa::helper::vector<double> &)
-{
-    return lc != 0;
-}
-
 // Define RemovalFunction
 template< class TDataTypes>
 void LinearVelocityConstraint<TDataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, value_type &)

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.h
@@ -151,9 +151,6 @@ public:
             : sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >(_data), lc(_lc) {}
 
         void applyDestroyFunction(Index /*index*/, value_type& /*T*/);
-        bool applyTestCreateFunction(Index /*index*/,
-                const sofa::helper::vector< Index > & /*ancestors*/,
-                const sofa::helper::vector< double > & /*coefs*/);
     protected:
         PartialLinearMovementConstraint<DataTypes> *lc;
     };

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
@@ -37,13 +37,6 @@ namespace sofa::component::projectiveconstraintset
 {
 
 
-// Define TestNewPointFunction
-template< class DataTypes>
-bool PartialLinearMovementConstraint<DataTypes>::FCPointHandler::applyTestCreateFunction(Index, const sofa::helper::vector<Index> &, const sofa::helper::vector<double> &)
-{
-    return lc != 0;
-}
-
 // Define RemovalFunction
 template< class DataTypes>
 void PartialLinearMovementConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, value_type &)

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PatchTestMovementConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PatchTestMovementConstraint.h
@@ -146,9 +146,6 @@ public:
 
         void applyDestroyFunction(Index /*index*/, value_type& /*T*/);
 
-        bool applyTestCreateFunction(Index /*index*/,
-                const sofa::helper::vector< Index > & /*ancestors*/,
-                const sofa::helper::vector< double > & /*coefs*/);
     protected:
         PatchTestMovementConstraint<DataTypes> *fc;
     };

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PatchTestMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PatchTestMovementConstraint.inl
@@ -34,14 +34,6 @@
 namespace sofa::component::projectiveconstraintset
 {
 
-// Define TestFunction
-template< class DataTypes>
-bool PatchTestMovementConstraint<DataTypes>::FCPointHandler::applyTestCreateFunction(Index, const sofa::helper::vector<Index> &, const sofa::helper::vector<double> &)
-{
-    return fc != 0;
-}
-
-
 // Define RemovalFunction
 template< class DataTypes>
 void PatchTestMovementConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, value_type &)

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.h
@@ -132,10 +132,6 @@ public:
         using component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, Indices >::applyDestroyFunction;
         void applyDestroyFunction(Index /*index*/, core::objectmodel::Data<value_type>& /*T*/);
 
-
-        bool applyTestCreateFunction(Index /*index*/,
-                const sofa::helper::vector< Index > & /*ancestors*/,
-                const sofa::helper::vector< double > & /*coefs*/);
     protected:
         ProjectDirectionConstraint<DataTypes> *fc;
     };

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.inl
@@ -35,19 +35,6 @@ namespace sofa::component::projectiveconstraintset
 {
 
 template< class DataTypes>
-bool ProjectDirectionConstraint<DataTypes>::FCPointHandler::applyTestCreateFunction(Index, const sofa::helper::vector<Index> &, const sofa::helper::vector<double> &)
-{
-    if (fc)
-    {
-        return false;
-    }
-    else
-    {
-        return false;
-    }
-}
-
-template< class DataTypes>
 void ProjectDirectionConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, core::objectmodel::Data<value_type> &)
 {
     if (fc)

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.h
@@ -132,9 +132,6 @@ public:
         using component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, Indices >::applyDestroyFunction;
         void applyDestroyFunction(Index /*index*/, core::objectmodel::Data<value_type>& /*T*/);
 
-        bool applyTestCreateFunction(Index /*index*/,
-                const sofa::helper::vector< Index > & /*ancestors*/,
-                const sofa::helper::vector< double > & /*coefs*/);
     protected:
         ProjectToLineConstraint<DataTypes> *fc;
     };

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.inl
@@ -34,19 +34,6 @@ namespace sofa::component::projectiveconstraintset
 {
 
 template< class DataTypes>
-bool ProjectToLineConstraint<DataTypes>::FCPointHandler::applyTestCreateFunction(Index, const sofa::helper::vector<Index> &, const sofa::helper::vector<double> &)
-{
-    if (fc)
-    {
-        return false;
-    }
-    else
-    {
-        return false;
-    }
-}
-
-template< class DataTypes>
 void ProjectToLineConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, core::objectmodel::Data<value_type> &)
 {
     if (fc)

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.h
@@ -133,10 +133,6 @@ public:
         using component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, Indices >::applyDestroyFunction;
         void applyDestroyFunction(Index /*index*/, core::objectmodel::Data<value_type>& /*T*/);
 
-
-        bool applyTestCreateFunction(Index /*index*/,
-                const sofa::helper::vector< Index > & /*ancestors*/,
-                const sofa::helper::vector< double > & /*coefs*/);
     protected:
         ProjectToPlaneConstraint<DataTypes> *fc;
     };

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
@@ -35,19 +35,6 @@ namespace sofa::component::projectiveconstraintset
 {
 
 template< class DataTypes>
-bool ProjectToPlaneConstraint<DataTypes>::FCPointHandler::applyTestCreateFunction(Index, const sofa::helper::vector<Index> &, const sofa::helper::vector<double> &)
-{
-    if (fc)
-    {
-        return false;
-    }
-    else
-    {
-        return false;
-    }
-}
-
-template< class DataTypes>
 void ProjectToPlaneConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, core::objectmodel::Data<value_type> &)
 {
     if (fc)

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.h
@@ -128,10 +128,6 @@ public:
         using component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point, SetIndexArray >::applyDestroyFunction;
         void applyDestroyFunction(Index /*index*/, core::objectmodel::Data<value_type>& /*T*/);
 
-
-        bool applyTestCreateFunction(Index /*index*/,
-                const sofa::helper::vector< Index > & /*ancestors*/,
-                const sofa::helper::vector< double > & /*coefs*/);
     protected:
         ProjectToPointConstraint<DataTypes> *fc;
     };

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.inl
@@ -35,19 +35,6 @@ namespace sofa::component::projectiveconstraintset
 {
 
 template< class DataTypes>
-bool ProjectToPointConstraint<DataTypes>::FCPointHandler::applyTestCreateFunction(Index, const sofa::helper::vector<Index> &, const sofa::helper::vector<double> &)
-{
-    if (fc)
-    {
-        return false;
-    }
-    else
-    {
-        return false;
-    }
-}
-
-template< class DataTypes>
 void ProjectToPointConstraint<DataTypes>::FCPointHandler::applyDestroyFunction(Index pointIndex, core::objectmodel::Data<value_type> &)
 {
     if (fc)


### PR DESCRIPTION
This PR will be merged in the topologyChanges_POC branch

this method was never called and is not useful.
Add Disabled message.

This need to be merged before #2114



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
