### PR TITLE
[CMake] FIX SofaFramework aliases

### DIFF
--- a/SofaKernel/SofaFramework/CMakeLists.txt
+++ b/SofaKernel/SofaFramework/CMakeLists.txt
@@ -54,10 +54,3 @@ sofa_create_package_with_targets(
     INCLUDE_SOURCE_DIR "src"
     INCLUDE_INSTALL_DIR "${PROJECT_NAME}"
     )
-
-# Create aliases to support compatibility, starting from v21.06
-# These aliases will be deleted in v21.12
-add_library(SofaHelper ALIAS Sofa.Helper)
-add_library(SofaDefaultType ALIAS Sofa.DefaultType)
-add_library(SofaCore ALIAS Sofa.Core)
-add_library(SofaSimulationCore ALIAS Sofa.SimulationCore)

--- a/SofaKernel/SofaFramework/SofaFrameworkConfig.cmake.in
+++ b/SofaKernel/SofaFramework/SofaFrameworkConfig.cmake.in
@@ -7,18 +7,11 @@ cmake_minimum_required(VERSION 3.12)
 set(SOFAFRAMEWORK_MODULES @SOFAFRAMEWORK_MODULES@)
 
 foreach(module ${SOFAFRAMEWORK_MODULES})
-	find_package(${module} QUIET REQUIRED)
+    find_package(${module} QUIET REQUIRED)
 endforeach()
 
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 endif()
-
-# Create aliases to support compatibility, starting from v21.06
-# These aliases will be deleted in v21.12
-add_library(SofaHelper ALIAS Sofa.Helper)
-add_library(SofaDefaultType ALIAS Sofa.DefaultType)
-add_library(SofaCore ALIAS Sofa.Core)
-add_library(SofaSimulationCore ALIAS Sofa.SimulationCore)
 
 check_required_components(@PROJECT_NAME@)

--- a/SofaKernel/modules/SofaCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/CMakeLists.txt
@@ -263,6 +263,10 @@ sofa_find_package(Sofa.Helper REQUIRED)
 sofa_find_package(Sofa.DefaultType REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
+# Create alias to support compatibility, starting from v21.06
+# This alias will be deleted in v21.12
+add_library(SofaCore ALIAS Sofa.Core)
+
 target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Helper Sofa.Topology Sofa.DefaultType)
 
 if(SOFA_BUILD_WITH_PCH_ENABLED)

--- a/SofaKernel/modules/SofaCore/Sofa.CoreConfig.cmake.in
+++ b/SofaKernel/modules/SofaCore/Sofa.CoreConfig.cmake.in
@@ -11,4 +11,12 @@ if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 endif()
 
+# Create alias to support compatibility, starting from v21.06
+# This alias will be deleted in v21.12
+get_target_property(Sofa.Core_IMPORTED Sofa.Core IMPORTED)
+if(Sofa.Core_IMPORTED)
+    set_target_properties(Sofa.Core PROPERTIES IMPORTED_GLOBAL TRUE)
+endif()
+add_library(SofaCore ALIAS Sofa.Core)
+
 check_required_components(@PROJECT_NAME@)

--- a/SofaKernel/modules/SofaDefaultType/CMakeLists.txt
+++ b/SofaKernel/modules/SofaDefaultType/CMakeLists.txt
@@ -86,6 +86,10 @@ sofa_find_package(Sofa.Helper REQUIRED)
 sofa_find_package(Eigen3 REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${COMPAT_HEADER_FILES})
+# Create alias to support compatibility, starting from v21.06
+# This alias will be deleted in v21.12
+add_library(SofaDefaultType ALIAS Sofa.DefaultType)
+
 target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Helper Sofa.Type)
 target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen)
 target_compile_definitions(${PROJECT_NAME} PRIVATE "-DSOFA_BUILD_DEFAULTTYPE")

--- a/SofaKernel/modules/SofaDefaultType/Sofa.DefaultTypeConfig.cmake.in
+++ b/SofaKernel/modules/SofaDefaultType/Sofa.DefaultTypeConfig.cmake.in
@@ -10,4 +10,12 @@ if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 endif()
 
+# Create alias to support compatibility, starting from v21.06
+# This alias will be deleted in v21.12
+get_target_property(Sofa.DefaultType_IMPORTED Sofa.DefaultType IMPORTED)
+if(Sofa.DefaultType_IMPORTED)
+    set_target_properties(Sofa.DefaultType PROPERTIES IMPORTED_GLOBAL TRUE)
+endif()
+add_library(SofaDefaultType ALIAS Sofa.DefaultType)
+
 check_required_components(@PROJECT_NAME@)

--- a/SofaKernel/modules/SofaHelper/CMakeLists.txt
+++ b/SofaKernel/modules/SofaHelper/CMakeLists.txt
@@ -218,6 +218,9 @@ sofa_find_package(Sofa.Topology REQUIRED)
 
 # LIBRARY
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
+# Create alias to support compatibility, starting from v21.06
+# This alias will be deleted in v21.12
+add_library(SofaHelper ALIAS Sofa.Helper)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
     target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "$<INSTALL_INTERFACE:include/extlibs/WinDepPack>")

--- a/SofaKernel/modules/SofaHelper/Sofa.HelperConfig.cmake.in
+++ b/SofaKernel/modules/SofaHelper/Sofa.HelperConfig.cmake.in
@@ -22,4 +22,12 @@ if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 endif()
 
+# Create alias to support compatibility, starting from v21.06
+# This alias will be deleted in v21.12
+get_target_property(Sofa.Helper_IMPORTED Sofa.Helper IMPORTED)
+if(Sofa.Helper_IMPORTED)
+    set_target_properties(Sofa.Helper PROPERTIES IMPORTED_GLOBAL TRUE)
+endif()
+add_library(SofaHelper ALIAS Sofa.Helper)
+
 check_required_components(@PROJECT_NAME@)

--- a/SofaKernel/modules/SofaSimulationCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaSimulationCore/CMakeLists.txt
@@ -256,6 +256,10 @@ set(SOURCE_FILES
 sofa_find_package(Sofa.Core REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
+# Create alias to support compatibility, starting from v21.06
+# This alias will be deleted in v21.12
+add_library(SofaSimulationCore ALIAS Sofa.SimulationCore)
+
 target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Core)
 
 # is this a compiler/linker version specific problem?

--- a/SofaKernel/modules/SofaSimulationCore/Sofa.SimulationCoreConfig.cmake.in
+++ b/SofaKernel/modules/SofaSimulationCore/Sofa.SimulationCoreConfig.cmake.in
@@ -9,4 +9,12 @@ if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 endif()
 
+# Create alias to support compatibility, starting from v21.06
+# This alias will be deleted in v21.12
+get_target_property(Sofa.SimulationCore_IMPORTED Sofa.SimulationCore IMPORTED)
+if(Sofa.SimulationCore_IMPORTED)
+    set_target_properties(Sofa.SimulationCore PROPERTIES IMPORTED_GLOBAL TRUE)
+endif()
+add_library(SofaSimulationCore ALIAS Sofa.SimulationCore)
+
 check_required_components(@PROJECT_NAME@)

--- a/modules/SofaGeneralAnimationLoop/SofaGeneralAnimationLoopConfig.cmake.in
+++ b/modules/SofaGeneralAnimationLoop/SofaGeneralAnimationLoopConfig.cmake.in
@@ -4,6 +4,7 @@
 @PACKAGE_INIT@
 
 find_package(SofaBase QUIET REQUIRED)
+find_package(SofaSimulationCommon QUIET REQUIRED)
 
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
Imported targets can be aliased only if they are global.

Otherwise, this error is raised:
```
CMake Error at /data/Softwares/sofa/build/build-master/install/lib/cmake/SofaFramework/SofaFrameworkConfig.cmake:45 (add_library):
  add_library cannot create ALIAS target "SofaHelper" because target
  "Sofa.Helper" is imported but not globally visible.
Call Stack (most recent call first):
  CMakeLists.txt:5 (find_package)
```

Thus, this PR adds the GLOBAL property to the imported targets we want to alias.
It also move all the alias definitions in their respective projects (not in SofaFramework anymore).

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
