### PR TITLE
[GTest] Fix with GCC11

### DIFF
--- a/SofaKernel/modules/Sofa.Testing/extlibs/gtest/src/gtest-death-test.cc
+++ b/SofaKernel/modules/Sofa.Testing/extlibs/gtest/src/gtest-death-test.cc
@@ -1296,7 +1296,7 @@ static void StackLowerThanAddress(const void* ptr, bool* result) {
 GTEST_ATTRIBUTE_NO_SANITIZE_ADDRESS_
 GTEST_ATTRIBUTE_NO_SANITIZE_HWADDRESS_
 static bool StackGrowsDown() {
-  int dummy;
+  int dummy = 0;
   bool result;
   StackLowerThanAddress(&dummy, &result);
   return result;


### PR DESCRIPTION
Apparently GCC11, by default, treats the "maybe uninitialized" warning as an error. 
This occurs in our version of gtest.
ref: https://github.com/google/googletest/issues/3219

I did not consider updating gtest itself as it could be bothersome.
And I think the "maybe uninitialized" warning as an error itself is good 
(therefore no command line option fix to consider it only as a warning)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
