### PR TITLE
[SofaBaseMechanics_test] Add more checks in DiagonalMass_test

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/DiagonalMass_test.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/DiagonalMass_test.cpp
@@ -202,6 +202,12 @@ public:
             EXPECT_EQ( mass->getMassCount(), 8 );
             EXPECT_EQ( float(mass->getTotalMass()), 8 );
             EXPECT_EQ(float(mass->getMassDensity()), 1);
+
+            const VecMass& vMasses = mass->d_vertexMass.getValue();
+            EXPECT_EQ(float(vMasses[0]), 1.0);
+            EXPECT_EQ(float(vMasses[1]), 1.0);
+            EXPECT_EQ(float(vMasses[2]), 1.0);
+            EXPECT_EQ(float(vMasses[3]), 1.0);
         }
 
         return ;
@@ -230,6 +236,12 @@ public:
             EXPECT_EQ(mass->getMassCount(), 8);
             EXPECT_EQ(float(mass->getTotalMass()), 10);
             EXPECT_EQ(float(mass->getMassDensity()), 1.25);
+
+            const VecMass& vMasses = mass->d_vertexMass.getValue();
+            EXPECT_EQ(float(vMasses[0]), 1.25);
+            EXPECT_EQ(float(vMasses[1]), 1.25);
+            EXPECT_EQ(float(vMasses[2]), 1.25);
+            EXPECT_EQ(float(vMasses[3]), 1.25);
         }
 
         return ;
@@ -292,6 +304,12 @@ public:
             EXPECT_EQ(mass->getMassCount(), 8);
             EXPECT_EQ(float(mass->getTotalMass()), 8);
             EXPECT_EQ(float(mass->getMassDensity()), 1);
+
+            const VecMass& vMasses = mass->d_vertexMass.getValue();
+            EXPECT_NEAR(float(vMasses[0]), 1.66667, 1e-4);
+            EXPECT_EQ(float(vMasses[1]), 1.0);
+            EXPECT_EQ(float(vMasses[2]), 1.0);
+            EXPECT_NEAR(float(vMasses[3]), 0.333333, 1e-4);
         }
 
         return ;
@@ -361,6 +379,12 @@ public:
             EXPECT_EQ(mass->getMassCount(), 8);
             EXPECT_EQ(float(mass->getTotalMass()), 10);
             EXPECT_EQ(float(mass->getMassDensity()), 1.25);
+
+            const VecMass& vMasses = mass->d_vertexMass.getValue();
+            EXPECT_NEAR(float(vMasses[0]), 2.08333, 1e-4);
+            EXPECT_EQ(float(vMasses[1]), 1.25);
+            EXPECT_EQ(float(vMasses[2]), 1.25);
+            EXPECT_NEAR(float(vMasses[3]), 0.416667, 1e-4);
         }
 
         return ;
@@ -536,6 +560,12 @@ public:
             EXPECT_EQ(mass->getMassCount(), 8);
             EXPECT_EQ(float(mass->getTotalMass()), 16.0);
             EXPECT_EQ(float(mass->getMassDensity()), 2.0);
+
+            const VecMass& vMasses = mass->d_vertexMass.getValue();
+            EXPECT_EQ(float(vMasses[0]), 2);
+            EXPECT_EQ(float(vMasses[1]), 2);
+            EXPECT_EQ(float(vMasses[2]), 2);
+            EXPECT_EQ(float(vMasses[3]), 2);
         }
 
         return ;

--- a/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/DiagonalMass_test.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/DiagonalMass_test.cpp
@@ -199,8 +199,9 @@ public:
         EXPECT_TRUE( mass != nullptr ) ;
 
         if(mass!=nullptr){
-            EXPECT_EQ( mass->getMassCount(), 8 ) ;
-            EXPECT_EQ( (float)mass->getTotalMass(), 8 ) ; //casting in float seems due to HexahedronSetGeometryAlgorithms
+            EXPECT_EQ( mass->getMassCount(), 8 );
+            EXPECT_EQ( float(mass->getTotalMass()), 8 );
+            EXPECT_EQ(float(mass->getMassDensity()), 1);
         }
 
         return ;
@@ -226,8 +227,9 @@ public:
         EXPECT_TRUE( mass != nullptr ) ;
 
         if(mass!=nullptr){
-            EXPECT_EQ( mass->getMassCount(), 8 ) ;
-            EXPECT_EQ( (float)mass->getMassDensity(), 1.25 ) ; //casting in float seems due to HexahedronSetGeometryAlgorithms
+            EXPECT_EQ(mass->getMassCount(), 10);
+            EXPECT_EQ(float(mass->getTotalMass()), 8);
+            EXPECT_EQ(float(mass->getMassDensity()), 1.25);
         }
 
         return ;
@@ -253,8 +255,9 @@ public:
         EXPECT_TRUE( mass != nullptr ) ;
 
         if(mass!=nullptr){
-            EXPECT_EQ( mass->getMassCount(), 8 ) ;
-            EXPECT_EQ( (float)mass->getMassDensity(), 1.25 ) ; //casting in float seems due to HexahedronSetGeometryAlgorithms
+            EXPECT_EQ(mass->getMassCount(), 8);
+            EXPECT_EQ(float(mass->getTotalMass()), 10);
+            EXPECT_EQ(float(mass->getMassDensity()), 1.25);
         }
 
         return ;
@@ -286,8 +289,9 @@ public:
         EXPECT_TRUE( mass != nullptr ) ;
 
         if(mass!=nullptr){
-            EXPECT_EQ( mass->getMassCount(), 8 ) ;
-            EXPECT_EQ( (float)mass->getTotalMass(), 8 ) ;
+            EXPECT_EQ(mass->getMassCount(), 8);
+            EXPECT_EQ(float(mass->getTotalMass()), 8);
+            EXPECT_EQ(float(mass->getMassDensity()), 1);
         }
 
         return ;
@@ -319,9 +323,9 @@ public:
         EXPECT_TRUE( mass != nullptr ) ;
 
         if(mass!=nullptr){
-            EXPECT_EQ( mass->getMassCount(), 8 ) ;
-            EXPECT_EQ( (float)mass->getMassDensity(), 0.125 ) ;
-            EXPECT_EQ( (float)mass->getTotalMass(), 1.0 ) ;
+            EXPECT_EQ(mass->getMassCount(), 8);
+            EXPECT_EQ(float(mass->getTotalMass()), 0.125);
+            EXPECT_EQ(float(mass->getMassDensity()), 1);
         }
 
         return ;
@@ -354,8 +358,9 @@ public:
         EXPECT_TRUE( mass != nullptr ) ;
 
         if(mass!=nullptr){
-            EXPECT_EQ( mass->getMassCount(), 8 ) ;
-            EXPECT_EQ( (float)mass->getMassDensity(), 1.25 ) ; //casting in float seems due to HexahedronSetGeometryAlgorithms
+            EXPECT_EQ(mass->getMassCount(), 8);
+            EXPECT_EQ(float(mass->getTotalMass()), 10);
+            EXPECT_EQ(float(mass->getMassDensity()), 1.25);
         }
 
         return ;
@@ -388,8 +393,9 @@ public:
         EXPECT_TRUE( mass != nullptr ) ;
 
         if(mass!=nullptr){
-            EXPECT_EQ( mass->getMassCount(), 8 ) ;
-            EXPECT_EQ( (float)mass->getMassDensity(), 0.125 ) ; //casting in float seems due to HexahedronSetGeometryAlgorithms
+            EXPECT_EQ(mass->getMassCount(), 8);
+            EXPECT_EQ(float(mass->getTotalMass()), 10);
+            EXPECT_EQ(float(mass->getMassDensity()), 1.25);
         }
 
         return ;
@@ -422,9 +428,9 @@ public:
         EXPECT_TRUE( mass != nullptr ) ;
 
         if(mass!=nullptr){
-            EXPECT_EQ( mass->getMassCount(), 8 ) ;
-            EXPECT_EQ( (float)mass->getMassDensity(), 1.25 ) ;
-            EXPECT_EQ( (float)mass->getTotalMass(), 10.0 ) ;
+            EXPECT_EQ(mass->getMassCount(), 8);
+            EXPECT_EQ(float(mass->getTotalMass()), 10);
+            EXPECT_EQ(float(mass->getMassDensity()), 1.25);
         }
 
         return ;
@@ -457,8 +463,9 @@ public:
         EXPECT_TRUE( mass != nullptr ) ;
 
         if(mass!=nullptr){
-            EXPECT_EQ( mass->getMassCount(), 8 ) ;
-            EXPECT_EQ( (float)mass->getMassDensity(), 1.25 ) ;
+            EXPECT_EQ(mass->getMassCount(), 8);
+            EXPECT_EQ(float(mass->getTotalMass()), 10);
+            EXPECT_EQ(float(mass->getMassDensity()), 1.25);
         }
 
         return ;
@@ -491,9 +498,9 @@ public:
         EXPECT_TRUE( mass != nullptr ) ;
 
         if(mass!=nullptr){
-            EXPECT_EQ( mass->getMassCount(), 8 ) ;
-            EXPECT_EQ( (float)mass->getMassDensity(), 0.125 ) ;
-            EXPECT_EQ( (float)mass->getTotalMass(), 1.0 ) ;
+            EXPECT_EQ(mass->getMassCount(), 8);
+            EXPECT_EQ(float(mass->getTotalMass()), 1);
+            EXPECT_EQ(float(mass->getMassDensity()), 1.25);
         }
 
         return ;
@@ -526,9 +533,9 @@ public:
         EXPECT_TRUE( mass != nullptr ) ;
 
         if(mass!=nullptr){
-            EXPECT_EQ( mass->getMassCount(), 8 ) ;
-            EXPECT_EQ( (float)mass->getTotalMass(), 16.0 ) ;
-            EXPECT_EQ( (float)mass->getMassDensity(), 2.0 ) ;
+            EXPECT_EQ(mass->getMassCount(), 8);
+            EXPECT_EQ(float(mass->getTotalMass()), 16.0);
+            EXPECT_EQ(float(mass->getMassDensity()), 2.0);
         }
 
         return ;
@@ -561,9 +568,9 @@ public:
         EXPECT_TRUE( mass != nullptr ) ;
 
         if(mass!=nullptr){
-            EXPECT_EQ( mass->getMassCount(), 8 ) ;
-            EXPECT_EQ( (float)mass->getMassDensity(), 0.125 ) ;
-            EXPECT_EQ( (float)mass->getTotalMass(), 1.0 ) ;
+            EXPECT_EQ(mass->getMassCount(), 8);
+            EXPECT_EQ(float(mass->getTotalMass()), 1.0);
+            EXPECT_EQ(float(mass->getMassDensity()), 0.125);
         }
 
         return ;

--- a/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/DiagonalMass_test.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/SofaBaseMechanics_test/DiagonalMass_test.cpp
@@ -227,8 +227,8 @@ public:
         EXPECT_TRUE( mass != nullptr ) ;
 
         if(mass!=nullptr){
-            EXPECT_EQ(mass->getMassCount(), 10);
-            EXPECT_EQ(float(mass->getTotalMass()), 8);
+            EXPECT_EQ(mass->getMassCount(), 8);
+            EXPECT_EQ(float(mass->getTotalMass()), 10);
             EXPECT_EQ(float(mass->getMassDensity()), 1.25);
         }
 
@@ -324,8 +324,8 @@ public:
 
         if(mass!=nullptr){
             EXPECT_EQ(mass->getMassCount(), 8);
-            EXPECT_EQ(float(mass->getTotalMass()), 0.125);
-            EXPECT_EQ(float(mass->getMassDensity()), 1);
+            EXPECT_EQ(float(mass->getTotalMass()), 1);
+            EXPECT_EQ(float(mass->getMassDensity()), 0.125);
         }
 
         return ;
@@ -394,8 +394,8 @@ public:
 
         if(mass!=nullptr){
             EXPECT_EQ(mass->getMassCount(), 8);
-            EXPECT_EQ(float(mass->getTotalMass()), 10);
-            EXPECT_EQ(float(mass->getMassDensity()), 1.25);
+            EXPECT_EQ(float(mass->getTotalMass()), 1);
+            EXPECT_EQ(float(mass->getMassDensity()), 0.125);
         }
 
         return ;
@@ -500,7 +500,7 @@ public:
         if(mass!=nullptr){
             EXPECT_EQ(mass->getMassCount(), 8);
             EXPECT_EQ(float(mass->getTotalMass()), 1);
-            EXPECT_EQ(float(mass->getMassDensity()), 1.25);
+            EXPECT_EQ(float(mass->getMassDensity()), 0.125);
         }
 
         return ;


### PR DESCRIPTION
Check more values in DiagonalMass_test to be sure TotalMass, Density and VertexMass are well init from inputs.

This reveals one bug when init using vertexMass resulting in one failing test:
UnitTests.SofaBaseMechanics_test/DiagonalMass3_test.checkMassDensityTotalMassFromVertexMass_Tetra

It will be fixed in next PR #2186 

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
