### PR TITLE
[SofaBaseMechanics] Clean DiagonalMass init 

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
@@ -244,6 +244,9 @@ protected:
     void initTopologyHandlers();
     void massInitialization();
 
+    /// Will compute the vertexMass using input denstiy and return the corresponding full mass.
+    Real computeVertexMass(const Real& density);
+
 public:
 
     SReal getTotalMass() const { return d_totalMass.getValue(); }
@@ -253,6 +256,7 @@ public:
     void printMass();
 
     /// Compute the mass from input values
+    SOFA_ATTRIBUTE_DEPRECATED("v21.06", "v21.12", "ComputeMass should not be call from outside. Changing one of the Data: density, totalMass or vertexMass will recompute the mass.")
     void computeMass();
 
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
@@ -244,8 +244,8 @@ protected:
     void initTopologyHandlers();
     void massInitialization();
 
-    /// Will compute the vertexMass using input denstiy and return the corresponding full mass.
-    Real computeVertexMass(const Real& density);
+    /// Compute the vertexMass using input density and return the corresponding full mass.
+    Real computeVertexMass(Real density);
 
 public:
 
@@ -256,7 +256,7 @@ public:
     void printMass();
 
     /// Compute the mass from input values
-    SOFA_ATTRIBUTE_DEPRECATED("v21.06", "v21.12", "ComputeMass should not be call from outside. Changing one of the Data: density, totalMass or vertexMass will recompute the mass.")
+    SOFA_ATTRIBUTE_DEPRECATED("v21.06", "v21.12", "ComputeMass should not be called from outside. Changing one of the Data: density, totalMass or vertexMass will recompute the mass.")
     void computeMass();
 
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
@@ -1172,9 +1172,9 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
             if (hexaGeo)
             {
                 if (d_computeMassOnRest.getValue())
-                    mass = (md * hexaGeo->computeRestHexahedronVolume(i)) / (Real(8.0));
+                    mass = (density * hexaGeo->computeRestHexahedronVolume(i)) / (Real(8.0));
                 else
-                    mass = (md * hexaGeo->computeHexahedronVolume(i)) / (Real(8.0));
+                    mass = (density * hexaGeo->computeHexahedronVolume(i)) / (Real(8.0));
 
                 for (unsigned int j = 0; j < h.size(); j++)
                 {
@@ -1194,9 +1194,9 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
             if (tetraGeo)
             {
                 if (d_computeMassOnRest.getValue())
-                    mass = (md * tetraGeo->computeRestTetrahedronVolume(i)) / (Real(4.0));
+                    mass = (density * tetraGeo->computeRestTetrahedronVolume(i)) / (Real(4.0));
                 else
-                    mass = (md * tetraGeo->computeTetrahedronVolume(i)) / (Real(4.0));
+                    mass = (density * tetraGeo->computeTetrahedronVolume(i)) / (Real(4.0));
             }
             for (unsigned int j = 0; j < t.size(); j++)
             {
@@ -1215,9 +1215,9 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
             if (quadGeo)
             {
                 if (d_computeMassOnRest.getValue())
-                    mass = (md * quadGeo->computeRestQuadArea(i)) / (Real(4.0));
+                    mass = (density * quadGeo->computeRestQuadArea(i)) / (Real(4.0));
                 else
-                    mass = (md * quadGeo->computeQuadArea(i)) / (Real(4.0));
+                    mass = (density * quadGeo->computeQuadArea(i)) / (Real(4.0));
             }
             for (unsigned int j = 0; j < t.size(); j++)
             {
@@ -1236,9 +1236,9 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
             if (triangleGeo)
             {
                 if (d_computeMassOnRest.getValue())
-                    mass = (md * triangleGeo->computeRestTriangleArea(i)) / (Real(3.0));
+                    mass = (density * triangleGeo->computeRestTriangleArea(i)) / (Real(3.0));
                 else
-                    mass = (md * triangleGeo->computeTriangleArea(i)) / (Real(3.0));
+                    mass = (density * triangleGeo->computeTriangleArea(i)) / (Real(3.0));
             }
             for (unsigned int j = 0; j < t.size(); j++)
             {
@@ -1257,9 +1257,9 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
             if (edgeGeo)
             {
                 if (d_computeMassOnRest.getValue())
-                    mass = (md * edgeGeo->computeRestEdgeLength(i)) / (Real(2.0));
+                    mass = (density * edgeGeo->computeRestEdgeLength(i)) / (Real(2.0));
                 else
-                    mass = (md * edgeGeo->computeEdgeLength(i)) / (Real(2.0));
+                    mass = (density * edgeGeo->computeEdgeLength(i)) / (Real(2.0));
             }
             for (unsigned int j = 0; j < e.size(); j++)
             {
@@ -1337,9 +1337,9 @@ void DiagonalMass<DataTypes, MassType>::initFromVertexMass()
     // save a copy of input vertexMass vector
     MassVector vertexMass = d_vertexMass.getValue();
     Real totalMassSave = 0.0;
-    for(size_t i=0; i<vertexMass.size(); i++)
+    for (auto vm : vertexMass)
     {
-        totalMassSave += vertexMass[i];
+        totalMassSave += vm;
     }
 
     // set total mass
@@ -1406,14 +1406,17 @@ void DiagonalMass<DataTypes, MassType>::initFromTotalMass()
     const Real sumMass = computeVertexMass(1.0);
 
     // Set real density from sumMass found
-    setMassDensity(Real(totalMass / sumMass));
+    if (sumMass < std::numeric_limits<typename DataTypes::Real>::epsilon())
+        setMassDensity(1.0);
+    else
+        setMassDensity(Real(totalMass / sumMass));
     
     // Update vertex mass using real density
     helper::WriteAccessor<Data<MassVector> > vertexMass = d_vertexMass;
-    const Real& md = d_massDensity.getValue();
-    for (size_t i = 0; i < vertexMass.size(); i++)
+    const Real& density = d_massDensity.getValue();
+    for (auto vm : vertexMass)
     {
-        vertexMass[i] *= md;
+        vm *= density;
     }
 }
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
@@ -29,6 +29,7 @@
 #include <SofaBaseTopology/TopologyData.inl>
 #include <SofaBaseMechanics/AddMToMatrixFunctor.h>
 #include <sofa/core/behavior/MultiMatrixAccessor.h>
+#include <numeric>
 
 namespace sofa::component::mass
 {
@@ -1330,11 +1331,7 @@ void DiagonalMass<DataTypes, MassType>::initFromVertexMass()
 
     // save a copy of input vertexMass vector
     const MassVector& vertexMass = d_vertexMass.getValue();
-    Real totalMassSave = 0.0;
-    for (auto vm : vertexMass)
-    {
-        totalMassSave += vm;
-    }
+    const Real totalMassSave = std::accumulate(vertexMass.begin(), vertexMass.end(), Real(0));
 
     // set total mass
     d_totalMass.setValue(totalMassSave);

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
@@ -1169,18 +1169,16 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
         for (Topology::HexahedronID i = 0; i < m_topology->getNbHexahedra(); ++i)
         {
             const Hexahedron& h = m_topology->getHexahedron(i);
-            if (hexaGeo)
-            {
-                if (d_computeMassOnRest.getValue())
-                    mass = (density * hexaGeo->computeRestHexahedronVolume(i)) / (Real(8.0));
-                else
-                    mass = (density * hexaGeo->computeHexahedronVolume(i)) / (Real(8.0));
 
-                for (unsigned int j = 0; j < h.size(); j++)
-                {
-                    masses[h[j]] += mass;
-                    total_mass += mass;
-                }
+            if (d_computeMassOnRest.getValue())
+                mass = (density * hexaGeo->computeRestHexahedronVolume(i)) / (Real(8.0));
+            else
+                mass = (density * hexaGeo->computeHexahedronVolume(i)) / (Real(8.0));
+
+            for (unsigned int j = 0; j < h.size(); j++)
+            {
+                masses[h[j]] += mass;
+                total_mass += mass;
             }
         }
     }
@@ -1191,13 +1189,12 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
         for (Topology::TetrahedronID i = 0; i < m_topology->getNbTetrahedra(); ++i)
         {
             const Tetrahedron& t = m_topology->getTetrahedron(i);
-            if (tetraGeo)
-            {
-                if (d_computeMassOnRest.getValue())
-                    mass = (density * tetraGeo->computeRestTetrahedronVolume(i)) / (Real(4.0));
-                else
-                    mass = (density * tetraGeo->computeTetrahedronVolume(i)) / (Real(4.0));
-            }
+
+            if (d_computeMassOnRest.getValue())
+                mass = (density * tetraGeo->computeRestTetrahedronVolume(i)) / (Real(4.0));
+            else
+                mass = (density * tetraGeo->computeTetrahedronVolume(i)) / (Real(4.0));
+
             for (unsigned int j = 0; j < t.size(); j++)
             {
                 masses[t[j]] += mass;
@@ -1212,13 +1209,12 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
         for (Topology::QuadID i = 0; i < m_topology->getNbQuads(); ++i)
         {
             const Quad& t = m_topology->getQuad(i);
-            if (quadGeo)
-            {
-                if (d_computeMassOnRest.getValue())
-                    mass = (density * quadGeo->computeRestQuadArea(i)) / (Real(4.0));
-                else
-                    mass = (density * quadGeo->computeQuadArea(i)) / (Real(4.0));
-            }
+
+            if (d_computeMassOnRest.getValue())
+                mass = (density * quadGeo->computeRestQuadArea(i)) / (Real(4.0));
+            else
+                mass = (density * quadGeo->computeQuadArea(i)) / (Real(4.0));
+
             for (unsigned int j = 0; j < t.size(); j++)
             {
                 masses[t[j]] += mass;
@@ -1233,13 +1229,12 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
         for (Topology::TriangleID i = 0; i < m_topology->getNbTriangles(); ++i)
         {
             const Triangle& t = m_topology->getTriangle(i);
-            if (triangleGeo)
-            {
-                if (d_computeMassOnRest.getValue())
-                    mass = (density * triangleGeo->computeRestTriangleArea(i)) / (Real(3.0));
-                else
-                    mass = (density * triangleGeo->computeTriangleArea(i)) / (Real(3.0));
-            }
+
+            if (d_computeMassOnRest.getValue())
+                mass = (density * triangleGeo->computeRestTriangleArea(i)) / (Real(3.0));
+            else
+                mass = (density * triangleGeo->computeTriangleArea(i)) / (Real(3.0));
+
             for (unsigned int j = 0; j < t.size(); j++)
             {
                 masses[t[j]] += mass;
@@ -1254,13 +1249,12 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
         for (Topology::EdgeID i = 0; i < m_topology->getNbEdges(); ++i)
         {
             const Edge& e = m_topology->getEdge(i);
-            if (edgeGeo)
-            {
-                if (d_computeMassOnRest.getValue())
-                    mass = (density * edgeGeo->computeRestEdgeLength(i)) / (Real(2.0));
-                else
-                    mass = (density * edgeGeo->computeEdgeLength(i)) / (Real(2.0));
-            }
+
+            if (d_computeMassOnRest.getValue())
+                mass = (density * edgeGeo->computeRestEdgeLength(i)) / (Real(2.0));
+            else
+                mass = (density * edgeGeo->computeEdgeLength(i)) / (Real(2.0));
+
             for (unsigned int j = 0; j < e.size(); j++)
             {
                 masses[e[j]] += mass;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
@@ -1329,8 +1329,8 @@ void DiagonalMass<DataTypes, MassType>::initFromVertexMass()
 {
     msg_info() << "vertexMass information is used";
 
-    // save a copy of input vertexMass vector
-    const MassVector& vertexMass = d_vertexMass.getValue();
+    // saving a copy of vertexMass vector to recover the input values after init methods which are overwritten those values.
+    const MassVector vertexMass = d_vertexMass.getValue();
     const Real totalMassSave = std::accumulate(vertexMass.begin(), vertexMass.end(), Real(0));
 
     // set total mass

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
@@ -1329,8 +1329,12 @@ void DiagonalMass<DataTypes, MassType>::initFromVertexMass()
     msg_info() << "vertexMass information is used";
 
     // save a copy of input vertexMass vector
-    helper::ReadAccessor< MassVector > vertexMass = d_vertexMass;
-    const Real totalMassSave = std::accumulate(vertexMass.begin(), vertexMass.end(), (Real)0, std::plus<Real>());
+    const MassVector& vertexMass = d_vertexMass.getValue();
+    Real totalMassSave = 0.0;
+    for (auto vm : vertexMass)
+    {
+        totalMassSave += vm;
+    }
 
     // set total mass
     d_totalMass.setValue(totalMassSave);

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
@@ -1329,12 +1329,8 @@ void DiagonalMass<DataTypes, MassType>::initFromVertexMass()
     msg_info() << "vertexMass information is used";
 
     // save a copy of input vertexMass vector
-    MassVector vertexMass = d_vertexMass.getValue();
-    Real totalMassSave = 0.0;
-    for (auto vm : vertexMass)
-    {
-        totalMassSave += vm;
-    }
+    helper::ReadAccessor< MassVector > vertexMass = d_vertexMass;
+    const Real totalMassSave = std::accumulate(vertexMass.begin(), vertexMass.end(), (Real)0, std::plus<Real>());
 
     // set total mass
     d_totalMass.setValue(totalMassSave);
@@ -1408,7 +1404,7 @@ void DiagonalMass<DataTypes, MassType>::initFromTotalMass()
     // Update vertex mass using real density
     helper::WriteAccessor<Data<MassVector> > vertexMass = d_vertexMass;
     const Real& density = d_massDensity.getValue();
-    for (auto vm : vertexMass)
+    for (auto& vm : vertexMass)
     {
         vm *= density;
     }

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
@@ -1146,7 +1146,7 @@ void DiagonalMass<DataTypes, MassType>::computeMass()
 
 
 template <class DataTypes, class MassType>
-typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassType>::computeVertexMass(const Real& md)
+typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassType>::computeVertexMass(Real density)
 {
     Real total_mass = Real(0);
 
@@ -1160,11 +1160,7 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
     helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
     // resize array
     masses.clear();
-    masses.resize(this->mstate->getSize());
-    
-    // set to 0
-    for (unsigned int i = 0; i < masses.size(); ++i)
-        masses[i] = Real(0);
+    masses.resize(this->mstate->getSize(), Real(0));
 
     if (m_topology->getNbHexahedra() > 0 && hexaGeo)
     {
@@ -1350,7 +1346,7 @@ void DiagonalMass<DataTypes, MassType>::initFromVertexMass()
     d_totalMass.setValue(totalMassSave);
 
     // compute vertexMass vector with density == 1
-    Real sumMass = computeVertexMass(1.0);
+    const Real sumMass = computeVertexMass(1.0);
 
     // Set real density from sumMass found
     if (sumMass < std::numeric_limits<typename DataTypes::Real>::epsilon())
@@ -1392,7 +1388,7 @@ void DiagonalMass<DataTypes, MassType>::initFromMassDensity()
 
     // Compute Mass per vertex using mesh topology
     const Real& md = d_massDensity.getValue();
-    Real sumMass = computeVertexMass(md);
+    const Real sumMass = computeVertexMass(md);
 
     // sum of mass per vertex give total mass
     d_totalMass.setValue(sumMass);
@@ -1407,7 +1403,7 @@ void DiagonalMass<DataTypes, MassType>::initFromTotalMass()
     const Real totalMass = d_totalMass.getValue();
     
     // compute vertexMass vector with density == 1
-    Real sumMass = computeVertexMass(1.0);
+    const Real sumMass = computeVertexMass(1.0);
 
     // Set real density from sumMass found
     setMassDensity(Real(totalMass / sumMass));

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
@@ -542,25 +542,22 @@ void DiagonalMass<DataTypes,MassType>::DMassPointEngine::ApplyTopologyChange(con
 template <class DataTypes, class MassType>
 void DiagonalMass<DataTypes, MassType>::clear()
 {
-    MassVector& masses = *d_vertexMass.beginEdit();
+    helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
     masses.clear();
-    d_vertexMass.endEdit();
 }
 
 template <class DataTypes, class MassType>
 void DiagonalMass<DataTypes, MassType>::addMass(const MassType& m)
 {
-    MassVector& masses = *d_vertexMass.beginEdit();
+    helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
     masses.push_back(m);
-    d_vertexMass.endEdit();
 }
 
 template <class DataTypes, class MassType>
 void DiagonalMass<DataTypes, MassType>::resize(int vsize)
 {
-    MassVector& masses = *d_vertexMass.beginEdit();
+    helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
     masses.resize(vsize);
-    d_vertexMass.endEdit();
 }
 
 // -- Mass interface
@@ -858,13 +855,12 @@ void DiagonalMass<DataTypes, MassType>::init()
         // TODO(dmarchal 2018-11-10): this code is duplicated with the one in RigidImpl we should factor it (remove in 1 year if not done or update the dates)
         if (this->mstate && d_vertexMass.getValue().size() > 0 && d_vertexMass.getValue().size() < unsigned(this->mstate->getSize()))
         {
-            MassVector &masses= *d_vertexMass.beginEdit();
+            helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
             size_t i = masses.size()-1;
             size_t n = size_t(this->mstate->getSize());
             masses.reserve(n);
             while (masses.size() < n)
                 masses.push_back(masses[i]);
-            d_vertexMass.endEdit();
         }
 
         massInitialization();
@@ -979,8 +975,7 @@ void DiagonalMass<DataTypes, MassType>::computeMass()
     {
         if (m_topology->getNbHexahedra()>0 && hexaGeo)
         {
-
-            MassVector& masses = *d_vertexMass.beginEdit();
+            helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
             m_massTopologyType = TopologyElementType::HEXAHEDRON;
 
             masses.resize(this->mstate->getSize());
@@ -1010,13 +1005,10 @@ void DiagonalMass<DataTypes, MassType>::computeMass()
             }
 
             d_totalMass.setValue(total_mass);
-            d_vertexMass.endEdit();
-
         }
         else if (m_topology->getNbTetrahedra()>0 && tetraGeo)
         {
-
-            MassVector& masses = *d_vertexMass.beginEdit();
+            helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
             m_massTopologyType = TopologyElementType::TETRAHEDRON;
 
             // resize array
@@ -1047,10 +1039,9 @@ void DiagonalMass<DataTypes, MassType>::computeMass()
                 }
             }
             d_totalMass.setValue(total_mass);
-            d_vertexMass.endEdit();
         }
         else if (m_topology->getNbQuads()>0 && quadGeo) {
-            MassVector& masses = *d_vertexMass.beginEdit();
+            helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
             m_massTopologyType = TopologyElementType::QUAD;
 
             // resize array
@@ -1081,11 +1072,10 @@ void DiagonalMass<DataTypes, MassType>::computeMass()
                 }
             }
             d_totalMass.setValue(total_mass);
-            d_vertexMass.endEdit();
         }
         else if (m_topology->getNbTriangles()>0 && triangleGeo)
         {
-            MassVector& masses = *d_vertexMass.beginEdit();
+            helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
             m_massTopologyType = TopologyElementType::TRIANGLE;
 
             // resize array
@@ -1116,12 +1106,10 @@ void DiagonalMass<DataTypes, MassType>::computeMass()
                 }
             }
             d_totalMass.setValue(total_mass);
-            d_vertexMass.endEdit();
         }
         else if (m_topology->getNbEdges()>0 && edgeGeo)
         {
-
-            MassVector& masses = *d_vertexMass.beginEdit();
+            helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
             m_massTopologyType = TopologyElementType::EDGE;
 
             // resize array
@@ -1152,7 +1140,6 @@ void DiagonalMass<DataTypes, MassType>::computeMass()
                 }
             }
             d_totalMass.setValue(total_mass);
-            d_vertexMass.endEdit();
         }
     }
 }
@@ -1170,7 +1157,7 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
     }
     
     Real mass = Real(0);
-    MassVector& masses = *d_vertexMass.beginEdit();
+    helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
     // resize array
     masses.clear();
     masses.resize(this->mstate->getSize());
@@ -1286,8 +1273,6 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
         }
     }
 
-    d_vertexMass.endEdit();
-
     return total_mass;
 }
 
@@ -1368,7 +1353,10 @@ void DiagonalMass<DataTypes, MassType>::initFromVertexMass()
     Real sumMass = computeVertexMass(1.0);
 
     // Set real density from sumMass found
-    setMassDensity(Real(totalMassSave / sumMass));
+    if (sumMass < std::numeric_limits<typename DataTypes::Real>::epsilon())
+        setMassDensity(1.0);
+    else
+        setMassDensity(Real(totalMassSave / sumMass));
 
     // restore input vertexMass vector
     helper::WriteAccessor<Data<MassVector> > vertexMassWrite = d_vertexMass;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
@@ -1157,6 +1157,140 @@ void DiagonalMass<DataTypes, MassType>::computeMass()
     }
 }
 
+
+template <class DataTypes, class MassType>
+typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassType>::computeVertexMass(const Real& md)
+{
+    Real total_mass = Real(0);
+
+    if (m_topology == nullptr)
+    {
+        msg_warning() << "No topology set. DiagonalMass can't computeMass.";
+        return total_mass;
+    }
+    
+    Real mass = Real(0);
+    MassVector& masses = *d_vertexMass.beginEdit();
+    // resize array
+    masses.clear();
+    masses.resize(this->mstate->getSize());
+    
+    // set to 0
+    for (unsigned int i = 0; i < masses.size(); ++i)
+        masses[i] = Real(0);
+
+    if (m_topology->getNbHexahedra() > 0 && hexaGeo)
+    {
+        m_massTopologyType = TopologyElementType::HEXAHEDRON;
+
+        for (Topology::HexahedronID i = 0; i < m_topology->getNbHexahedra(); ++i)
+        {
+            const Hexahedron& h = m_topology->getHexahedron(i);
+            if (hexaGeo)
+            {
+                if (d_computeMassOnRest.getValue())
+                    mass = (md * hexaGeo->computeRestHexahedronVolume(i)) / (Real(8.0));
+                else
+                    mass = (md * hexaGeo->computeHexahedronVolume(i)) / (Real(8.0));
+
+                for (unsigned int j = 0; j < h.size(); j++)
+                {
+                    masses[h[j]] += mass;
+                    total_mass += mass;
+                }
+            }
+        }
+    }
+    else if (m_topology->getNbTetrahedra() > 0 && tetraGeo)
+    {
+        m_massTopologyType = TopologyElementType::TETRAHEDRON;
+
+        for (Topology::TetrahedronID i = 0; i < m_topology->getNbTetrahedra(); ++i)
+        {
+            const Tetrahedron& t = m_topology->getTetrahedron(i);
+            if (tetraGeo)
+            {
+                if (d_computeMassOnRest.getValue())
+                    mass = (md * tetraGeo->computeRestTetrahedronVolume(i)) / (Real(4.0));
+                else
+                    mass = (md * tetraGeo->computeTetrahedronVolume(i)) / (Real(4.0));
+            }
+            for (unsigned int j = 0; j < t.size(); j++)
+            {
+                masses[t[j]] += mass;
+                total_mass += mass;
+            }
+        }
+    }
+    else if (m_topology->getNbQuads() > 0 && quadGeo) 
+    {
+        m_massTopologyType = TopologyElementType::QUAD;
+
+        for (Topology::QuadID i = 0; i < m_topology->getNbQuads(); ++i)
+        {
+            const Quad& t = m_topology->getQuad(i);
+            if (quadGeo)
+            {
+                if (d_computeMassOnRest.getValue())
+                    mass = (md * quadGeo->computeRestQuadArea(i)) / (Real(4.0));
+                else
+                    mass = (md * quadGeo->computeQuadArea(i)) / (Real(4.0));
+            }
+            for (unsigned int j = 0; j < t.size(); j++)
+            {
+                masses[t[j]] += mass;
+                total_mass += mass;
+            }
+        }
+    }
+    else if (m_topology->getNbTriangles() > 0 && triangleGeo)
+    {
+        m_massTopologyType = TopologyElementType::TRIANGLE;
+
+        for (Topology::TriangleID i = 0; i < m_topology->getNbTriangles(); ++i)
+        {
+            const Triangle& t = m_topology->getTriangle(i);
+            if (triangleGeo)
+            {
+                if (d_computeMassOnRest.getValue())
+                    mass = (md * triangleGeo->computeRestTriangleArea(i)) / (Real(3.0));
+                else
+                    mass = (md * triangleGeo->computeTriangleArea(i)) / (Real(3.0));
+            }
+            for (unsigned int j = 0; j < t.size(); j++)
+            {
+                masses[t[j]] += mass;
+                total_mass += mass;
+            }
+        }
+    }
+    else if (m_topology->getNbEdges() > 0 && edgeGeo)
+    {
+        m_massTopologyType = TopologyElementType::EDGE;
+
+        for (Topology::EdgeID i = 0; i < m_topology->getNbEdges(); ++i)
+        {
+            const Edge& e = m_topology->getEdge(i);
+            if (edgeGeo)
+            {
+                if (d_computeMassOnRest.getValue())
+                    mass = (md * edgeGeo->computeRestEdgeLength(i)) / (Real(2.0));
+                else
+                    mass = (md * edgeGeo->computeEdgeLength(i)) / (Real(2.0));
+            }
+            for (unsigned int j = 0; j < e.size(); j++)
+            {
+                masses[e[j]] += mass;
+                total_mass += mass;
+            }
+        }
+    }
+
+    d_vertexMass.endEdit();
+
+    return total_mass;
+}
+
 template <class DataTypes, class MassType>
 bool DiagonalMass<DataTypes, MassType>::checkTotalMass()
 {
@@ -1219,15 +1353,24 @@ void DiagonalMass<DataTypes, MassType>::initFromVertexMass()
 {
     msg_info() << "vertexMass information is used";
 
-    const MassVector& vertexMass = d_vertexMass.getValue();
+    // save a copy of input vertexMass vector
+    MassVector vertexMass = d_vertexMass.getValue();
     Real totalMassSave = 0.0;
     for(size_t i=0; i<vertexMass.size(); i++)
     {
         totalMassSave += vertexMass[i];
     }
 
+    // set total mass
     d_totalMass.setValue(totalMassSave);
-    initFromTotalMass();
+
+    // compute vertexMass vector with density == 1
+    Real sumMass = computeVertexMass(1.0);
+
+    // Set real density from sumMass found
+    setMassDensity(Real(totalMassSave / sumMass));
+
+    // restore input vertexMass vector
     helper::WriteAccessor<Data<MassVector> > vertexMassWrite = d_vertexMass;
     for(size_t i=0; i<vertexMassWrite.size(); i++)
     {
@@ -1260,14 +1403,10 @@ void DiagonalMass<DataTypes, MassType>::initFromMassDensity()
     msg_info() << "massDensity information is used";
 
     // Compute Mass per vertex using mesh topology
-    computeMass();
+    const Real& md = d_massDensity.getValue();
+    Real sumMass = computeVertexMass(md);
 
-    // Sum the mass per vertex to obtain total mass
-    const MassVector &vertexMass = d_vertexMass.getValue();    
-    Real sumMass = 0.0;
-    for (auto vMass : vertexMass)
-        sumMass += vMass;
-
+    // sum of mass per vertex give total mass
     d_totalMass.setValue(sumMass);
 }
 
@@ -1277,22 +1416,21 @@ void DiagonalMass<DataTypes, MassType>::initFromTotalMass()
 {
     msg_info() << "totalMass information is used";
 
-    const Real totalMassTemp = d_totalMass.getValue();
+    const Real totalMass = d_totalMass.getValue();
+    
+    // compute vertexMass vector with density == 1
+    Real sumMass = computeVertexMass(1.0);
 
-    Real sumMass = 0.0;
-    setMassDensity(1.0);
-
-    // Compute Mass per vertex using mesh topology
-    computeMass();
-
-    // Sum the mass per vertex to obtain total mass
-    const MassVector &vertexMass = d_vertexMass.getValue();
-    for (auto vMass : vertexMass)
-        sumMass += vMass;
-
-    setMassDensity(Real(totalMassTemp/sumMass));
-
-    computeMass();
+    // Set real density from sumMass found
+    setMassDensity(Real(totalMass / sumMass));
+    
+    // Update vertex mass using real density
+    helper::WriteAccessor<Data<MassVector> > vertexMass = d_vertexMass;
+    const Real& md = d_massDensity.getValue();
+    for (size_t i = 0; i < vertexMass.size(); i++)
+    {
+        vertexMass[i] *= md;
+    }
 }
 
 


### PR DESCRIPTION
Add a new method to compute vertexMass using an input density and rework the different init to avoid calling several time the method computeMass which should not be used outside from the class.

Fix test UnitTests.SofaBaseMechanics_test/DiagonalMass3_test.checkMassDensityTotalMassFromVertexMass_Tetra
which is failling since PR #2183 




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
