### PR TITLE
[SofaLoaders] Fix MeshObjLoader material parsing by using the proper locale.

### DIFF
--- a/SofaKernel/modules/SofaLoader/src/SofaLoader/MeshObjLoader.cpp
+++ b/SofaKernel/modules/SofaLoader/src/SofaLoader/MeshObjLoader.cpp
@@ -25,6 +25,7 @@
 #include <sofa/helper/system/SetDirectory.h>
 #include <fstream>
 #include <sofa/helper/accessor.h>
+#include <sofa/helper/system/Locale.h>
 
 namespace sofa::component::loader
 {
@@ -147,6 +148,9 @@ void MeshObjLoader::addGroup (const PrimitiveGroup& g)
 
 bool MeshObjLoader::readOBJ (std::ifstream &file, const char* filename)
 {
+    // Make sure that fscanf() uses a dot '.' as the decimal separator.
+    sofa::helper::system::TemporaryLocale locale(LC_NUMERIC, "C");
+
     const bool handleSeams = d_handleSeams.getValue();
     auto my_positions = getWriteOnlyAccessor(d_positions);
     auto my_texCoords = getWriteOnlyAccessor(d_texCoordsList);


### PR DESCRIPTION
Otherwise the parsing is dependent on the locale in use on the system which
leads to problems with decimals numbers.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
