### PR TITLE
[SofaLoader] FIX Circular dependency in the update of MeshObjLoader

### DIFF
--- a/SofaKernel/modules/SofaLoader/src/SofaLoader/MeshObjLoader.cpp
+++ b/SofaKernel/modules/SofaLoader/src/SofaLoader/MeshObjLoader.cpp
@@ -34,7 +34,6 @@ using namespace sofa::defaulttype;
 using namespace sofa::core::loader;
 using namespace sofa::helper::types;
 using sofa::helper::getWriteOnlyAccessor;
-using sofa::helper::getWriteAccessor;
 
 int MeshObjLoaderClass = core::RegisterObject("Specific mesh loader for Obj file format.")
         .add< MeshObjLoader >();
@@ -115,7 +114,7 @@ void MeshObjLoader::doClearBuffers()
     getWriteOnlyAccessor(d_texCoordsList).clear();
     getWriteOnlyAccessor(d_normalsList).clear();
 
-    getWriteAccessor(d_material)->activated = false;
+    getWriteOnlyAccessor(d_material)->activated = false;
     getWriteOnlyAccessor(d_materials).clear();
     getWriteOnlyAccessor(d_faceList)->clear();
     getWriteOnlyAccessor(d_normalsIndexList)->clear();
@@ -186,7 +185,7 @@ bool MeshObjLoader::readOBJ (std::ifstream &file, const char* filename)
 
     int vtn[3];
     Vector3 result;
-    helper::WriteAccessor<Data<helper::vector< PrimitiveGroup> > > my_faceGroups[NBFACETYPE] =
+    helper::WriteOnlyAccessor<Data<helper::vector< PrimitiveGroup> > > my_faceGroups[NBFACETYPE] =
     {
         d_edgesGroups,
         d_trianglesGroups,
@@ -462,8 +461,8 @@ bool MeshObjLoader::readOBJ (std::ifstream &file, const char* filename)
 
         // Then we can create the final arrays
         helper::vector<sofa::defaulttype::Vector3> vertices2;
-        auto vnormals = getWriteAccessor(d_normals);
-        auto vtexcoords = getWriteAccessor(d_texCoords);
+        auto vnormals = getWriteOnlyAccessor(d_normals);
+        auto vtexcoords = getWriteOnlyAccessor(d_texCoords);
         auto vertPosIdx = getWriteOnlyAccessor(d_vertPosIdx);
         auto vertNormIdx = getWriteOnlyAccessor(d_vertNormIdx);
 

--- a/SofaKernel/modules/SofaLoader/src/SofaLoader/MeshObjLoader.cpp
+++ b/SofaKernel/modules/SofaLoader/src/SofaLoader/MeshObjLoader.cpp
@@ -25,6 +25,7 @@
 #include <sofa/helper/system/SetDirectory.h>
 #include <fstream>
 #include <sofa/helper/accessor.h>
+#include <sofa/helper/system/Locale.h>
 
 namespace sofa::component::loader
 {
@@ -147,6 +148,9 @@ void MeshObjLoader::addGroup (const PrimitiveGroup& g)
 
 bool MeshObjLoader::readOBJ (std::ifstream &file, const char* filename)
 {
+    // Make sure that fscanf() uses a dot '.' as the decimal separator.
+    sofa::helper::system::TemporaryLocale locale(LC_NUMERIC, "C");
+
     const bool handleSeams = d_handleSeams.getValue();
     auto my_positions = getWriteOnlyAccessor(d_positions);
     auto my_texCoords = getWriteOnlyAccessor(d_texCoordsList);


### PR DESCRIPTION
This PR fix a bug due to circular dependency in the DDG. 

To reproduce the bug:
In caduceus scene, activate the informations message with printLog="1". 
Run the scene... you should see for the visual_snale_body:
```console
[INFO]    [MeshObjLoader(visual_snake_body)] Loading OBJ file: mesh/snake_body.obj
[INFO]    [MeshObjLoader(visual_snake_body)] Loading OBJ file: mesh/snake_body.obj
[INFO]    [MeshObjLoader(visual_snake_body)] Loading OBJ file: mesh/snake_body.obj
[INFO]    [MeshObjLoader(visual_snake_body)] Loading OBJ file: mesh/snake_body.obj
[INFO]    [MeshObjLoader(visual_snake_body)] 3730 input positions, 3966 final vertices.
[INFO]    [MeshObjLoader(visual_snake_body)] Loading OBJ file: mesh/snake_body.obj
[INFO]    [MeshObjLoader(visual_snake_body)] 3730 input positions, 3966 final vertices.
[INFO]    [MeshObjLoader(visual_snake_body)] 7696 input positions, 3966 final vertices.
[INFO]    [MeshObjLoader(visual_snake_body)] 7696 input positions, 3966 final vertices.
[INFO]    [MeshObjLoader(visual_snake_body)] 7696 input positions, 3966 final vertices.
[INFO]    [MeshObjLoader(visual_snake_body)] Loading OBJ file: mesh/snake_body.obj
[INFO]    [MeshObjLoader(visual_snake_body)] 3730 input positions, 3966 final vertices.
```
Which indicates tthat the same loader is loading the file multiple times.

With the PR it now gives:
```
INFO]    [MeshObjLoader(visual_snake_body)] Loading OBJ file: mesh/snake_body.obj
[INFO]    [MeshObjLoader(visual_snake_body)] 3730 input positions, 3966 final vertices.
```

Depends on PR #2200 
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
