### PR TITLE
[Benchmark] Introduce benchmark on matrix assembly

### DIFF
--- a/examples/Benchmark/Performance/MatrixAssembly/MatrixAssembly_assembledCG.scn
+++ b/examples/Benchmark/Performance/MatrixAssembly/MatrixAssembly_assembledCG.scn
@@ -1,0 +1,45 @@
+<!--
+This scene belongs to a collection of similar scenes of a cantilever beam modeled
+with tetrahedra and solved with a backward Euler integration scheme.
+The differences are in the way the global system matrix is built and solved:
+* MatrixAssembly_matrixfreeCG.scn: the linear solver is a Conjugate Gradient and the matrix is not built
+* MatrixAssembly_assembledCG.scn: the linear solver is a Conjugate Gradient and the matrix is explicitly built
+* MatrixAssembly_assembledCG_blocs.scn: the linear solver is a Conjugate Gradient and the bloc-based matrix is explicitly built
+* MatrixAssembly_direct.scn: the linear solver is a LDL solver and the matrix is explicitly built
+* MatrixAssembly_direct_blocs.scn: the linear solver is a LDL solver and the bloc-based matrix is explicitly built
+-->
+
+<Node name="root" gravity="-1.8 0 100" dt="0.001">
+    <RequiredPlugin name="SofaOpenglVisual"/>
+    <RequiredPlugin name="SofaMiscForceField"/>
+    <RequiredPlugin name="SofaImplicitOdeSolver"/>
+    <RequiredPlugin name="SofaLoader"/>
+    <RequiredPlugin name="SofaBoundaryCondition"/>
+    <RequiredPlugin name="SofaSimpleFem"/>
+
+    <Node name="DeformableObject">
+
+        <EulerImplicitSolver name="odeImplicitSolver" />
+
+        <!--
+            Iterative linear solver using the template parameter CompressedRowSparseMatrixd.
+            It means the global system matrix is built explicitly, and solved iteratively.
+         -->
+        <CGLinearSolver iterations="1000" tolerance="1e-9" threshold="1e-9" template="CompressedRowSparseMatrixd"/>
+
+        <MeshGmshLoader name="loader" filename="mesh/truthcylinder1.msh" />
+        <TetrahedronSetTopologyContainer src="@loader" name="topologyContainer"/>
+        <TetrahedronSetGeometryAlgorithms name="geomAlgo"/>
+        <MechanicalObject name="dofs" src="@loader"/>
+        <MeshMatrixMass totalMass="15" topology="@topologyContainer"/>
+
+        <FixedConstraint indices="0 1 2 3 4 5 6 7 8 9 10 &#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;11 12 13 14 15 16 17 18 19 20 &#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 &#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;41 42 43 44 45 46 47 268 269 270 271 343 345" />
+        <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.49" method="large" />
+
+        <Node>
+            <MeshObjLoader name="meshLoader_0" filename="mesh/truthcylinder1.obj" handleSeams="0" />
+            <OglModel name="Visual" src="@meshLoader_0" color="red"/>
+            <BarycentricMapping input="@../dofs" output="@Visual" />
+        </Node>
+    </Node>
+</Node>

--- a/examples/Benchmark/Performance/MatrixAssembly/MatrixAssembly_assembledCG_blocs.scn
+++ b/examples/Benchmark/Performance/MatrixAssembly/MatrixAssembly_assembledCG_blocs.scn
@@ -1,0 +1,45 @@
+<!--
+This scene belongs to a collection of similar scenes of a cantilever beam modeled
+with tetrahedra and solved with a backward Euler integration scheme.
+The differences are in the way the global system matrix is built and solved:
+* MatrixAssembly_matrixfreeCG.scn: the linear solver is a Conjugate Gradient and the matrix is not built
+* MatrixAssembly_assembledCG.scn: the linear solver is a Conjugate Gradient and the matrix is explicitly built
+* MatrixAssembly_assembledCG_blocs.scn: the linear solver is a Conjugate Gradient and the bloc-based matrix is explicitly built
+* MatrixAssembly_direct.scn: the linear solver is a LDL solver and the matrix is explicitly built
+* MatrixAssembly_direct_blocs.scn: the linear solver is a LDL solver and the bloc-based matrix is explicitly built
+-->
+
+<Node name="root" gravity="-1.8 0 100" dt="0.001">
+    <RequiredPlugin name="SofaOpenglVisual"/>
+    <RequiredPlugin name="SofaMiscForceField"/>
+    <RequiredPlugin name="SofaImplicitOdeSolver"/>
+    <RequiredPlugin name="SofaLoader"/>
+    <RequiredPlugin name="SofaBoundaryCondition"/>
+    <RequiredPlugin name="SofaSimpleFem"/>
+
+    <Node name="DeformableObject">
+
+        <EulerImplicitSolver name="odeImplicitSolver" />
+
+        <!--
+            Iterative linear solver using the template parameter CompressedRowSparseMatrixMat3x3d.
+            It means the global system matrix is built explicitly using 3x3 bloc entries, and solved iteratively.
+         -->
+        <CGLinearSolver iterations="1000" tolerance="1e-9" threshold="1e-9" template="CompressedRowSparseMatrixMat3x3d"/>
+
+        <MeshGmshLoader name="loader" filename="mesh/truthcylinder1.msh" />
+        <TetrahedronSetTopologyContainer src="@loader" name="topologyContainer"/>
+        <TetrahedronSetGeometryAlgorithms name="geomAlgo"/>
+        <MechanicalObject name="dofs" src="@loader"/>
+        <MeshMatrixMass totalMass="15" topology="@topologyContainer"/>
+
+        <FixedConstraint indices="0 1 2 3 4 5 6 7 8 9 10 &#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;11 12 13 14 15 16 17 18 19 20 &#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 &#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;41 42 43 44 45 46 47 268 269 270 271 343 345" />
+        <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.49" method="large" />
+
+        <Node>
+            <MeshObjLoader name="meshLoader_0" filename="mesh/truthcylinder1.obj" handleSeams="0" />
+            <OglModel name="Visual" src="@meshLoader_0" color="red"/>
+            <BarycentricMapping input="@../dofs" output="@Visual" />
+        </Node>
+    </Node>
+</Node>

--- a/examples/Benchmark/Performance/MatrixAssembly/MatrixAssembly_direct.scn
+++ b/examples/Benchmark/Performance/MatrixAssembly/MatrixAssembly_direct.scn
@@ -1,0 +1,48 @@
+<!--
+This scene belongs to a collection of similar scenes of a cantilever beam modeled
+with tetrahedra and solved with a backward Euler integration scheme.
+The differences are in the way the global system matrix is built and solved:
+* MatrixAssembly_matrixfreeCG.scn: the linear solver is a Conjugate Gradient and the matrix is not built
+* MatrixAssembly_assembledCG.scn: the linear solver is a Conjugate Gradient and the matrix is explicitly built
+* MatrixAssembly_assembledCG_blocs.scn: the linear solver is a Conjugate Gradient and the bloc-based matrix is explicitly built
+* MatrixAssembly_direct.scn: the linear solver is a LDL solver and the matrix is explicitly built
+* MatrixAssembly_direct_blocs.scn: the linear solver is a LDL solver and the bloc-based matrix is explicitly built
+-->
+
+<Node name="root" gravity="-1.8 0 100" dt="0.001">
+    <RequiredPlugin name="SofaBoundaryCondition"/>
+    <RequiredPlugin name="SofaImplicitOdeSolver"/>
+    <RequiredPlugin name="SofaLoader"/>
+    <RequiredPlugin name="SofaMiscForceField"/>
+    <RequiredPlugin name="SofaOpenglVisual"/>
+    <RequiredPlugin name="SofaSimpleFem"/>
+    <RequiredPlugin name="SofaSparseSolver"/>
+
+    <Node name="DeformableObject">
+
+        <EulerImplicitSolver name="odeImplicitSolver" />
+
+        <!--
+            Direct solver: the system matrix is explicitly built by the ODE solver
+            and provided to the linear solver.
+            The default template (CompressedRowSparseMatrixd) indicates that the matrix
+            is defined using scalar entries.
+         -->
+        <SparseLDLSolver/>
+
+        <MeshGmshLoader name="loader" filename="mesh/truthcylinder1.msh" />
+        <TetrahedronSetTopologyContainer src="@loader" name="topologyContainer"/>
+        <TetrahedronSetGeometryAlgorithms name="geomAlgo"/>
+        <MechanicalObject name="dofs" src="@loader"/>
+        <MeshMatrixMass totalMass="15" topology="@topologyContainer"/>
+
+        <FixedConstraint indices="0 1 2 3 4 5 6 7 8 9 10 &#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;11 12 13 14 15 16 17 18 19 20 &#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 &#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;41 42 43 44 45 46 47 268 269 270 271 343 345" />
+        <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.49" method="large" />
+
+        <Node>
+            <MeshObjLoader name="meshLoader_0" filename="mesh/truthcylinder1.obj" handleSeams="0" />
+            <OglModel name="Visual" src="@meshLoader_0" color="red"/>
+            <BarycentricMapping input="@../dofs" output="@Visual" />
+        </Node>
+    </Node>
+</Node>

--- a/examples/Benchmark/Performance/MatrixAssembly/MatrixAssembly_direct_blocs.scn
+++ b/examples/Benchmark/Performance/MatrixAssembly/MatrixAssembly_direct_blocs.scn
@@ -1,0 +1,47 @@
+<!--
+This scene belongs to a collection of similar scenes of a cantilever beam modeled
+with tetrahedra and solved with a backward Euler integration scheme.
+The differences are in the way the global system matrix is built and solved:
+* MatrixAssembly_matrixfreeCG.scn: the linear solver is a Conjugate Gradient and the matrix is not built
+* MatrixAssembly_assembledCG.scn: the linear solver is a Conjugate Gradient and the matrix is explicitly built
+* MatrixAssembly_assembledCG_blocs.scn: the linear solver is a Conjugate Gradient and the bloc-based matrix is explicitly built
+* MatrixAssembly_direct.scn: the linear solver is a LDL solver and the matrix is explicitly built
+* MatrixAssembly_direct_blocs.scn: the linear solver is a LDL solver and the bloc-based matrix is explicitly built
+-->
+
+<Node name="root" gravity="-1.8 0 100" dt="0.001">
+    <RequiredPlugin name="SofaBoundaryCondition"/>
+    <RequiredPlugin name="SofaImplicitOdeSolver"/>
+    <RequiredPlugin name="SofaLoader"/>
+    <RequiredPlugin name="SofaMiscForceField"/>
+    <RequiredPlugin name="SofaOpenglVisual"/>
+    <RequiredPlugin name="SofaSimpleFem"/>
+    <RequiredPlugin name="SofaSparseSolver"/>
+
+    <Node name="DeformableObject">
+
+        <EulerImplicitSolver name="odeImplicitSolver" />
+
+        <!--
+            Direct solver: the system matrix is explicitly built by the ODE solver
+            and provided to the linear solver.
+            The template CompressedRowSparseMatrixMat3x3d indicates that the matrix is defined by 3x3 blocs.
+         -->
+        <SparseLDLSolver template="CompressedRowSparseMatrixMat3x3d"/>
+
+        <MeshGmshLoader name="loader" filename="mesh/truthcylinder1.msh" />
+        <TetrahedronSetTopologyContainer src="@loader" name="topologyContainer"/>
+        <TetrahedronSetGeometryAlgorithms name="geomAlgo"/>
+        <MechanicalObject name="dofs" src="@loader"/>
+        <MeshMatrixMass totalMass="15" topology="@topologyContainer"/>
+
+        <FixedConstraint indices="0 1 2 3 4 5 6 7 8 9 10 &#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;11 12 13 14 15 16 17 18 19 20 &#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 &#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;41 42 43 44 45 46 47 268 269 270 271 343 345" />
+        <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.49" method="large" />
+
+        <Node>
+            <MeshObjLoader name="meshLoader_0" filename="mesh/truthcylinder1.obj" handleSeams="0" />
+            <OglModel name="Visual" src="@meshLoader_0" color="red"/>
+            <BarycentricMapping input="@../dofs" output="@Visual" />
+        </Node>
+    </Node>
+</Node>

--- a/examples/Benchmark/Performance/MatrixAssembly/MatrixAssembly_matrixfreeCG.scn
+++ b/examples/Benchmark/Performance/MatrixAssembly/MatrixAssembly_matrixfreeCG.scn
@@ -1,0 +1,47 @@
+<!--
+This scene belongs to a collection of similar scenes of a cantilever beam modeled
+with tetrahedra and solved with a backward Euler integration scheme.
+The differences are in the way the global system matrix is built and solved:
+* MatrixAssembly_matrixfreeCG.scn: the linear solver is a Conjugate Gradient and the matrix is not built
+* MatrixAssembly_assembledCG.scn: the linear solver is a Conjugate Gradient and the matrix is explicitly built
+* MatrixAssembly_assembledCG_blocs.scn: the linear solver is a Conjugate Gradient and the bloc-based matrix is explicitly built
+* MatrixAssembly_direct.scn: the linear solver is a LDL solver and the matrix is explicitly built
+* MatrixAssembly_direct_blocs.scn: the linear solver is a LDL solver and the bloc-based matrix is explicitly built
+-->
+
+<Node name="root" gravity="-1.8 0 100" dt="0.001">
+    <RequiredPlugin name="SofaOpenglVisual"/>
+    <RequiredPlugin name="SofaMiscForceField"/>
+    <RequiredPlugin name="SofaImplicitOdeSolver"/>
+    <RequiredPlugin name="SofaLoader"/>
+    <RequiredPlugin name="SofaBoundaryCondition"/>
+    <RequiredPlugin name="SofaSimpleFem"/>
+
+    <Node name="DeformableObject">
+
+        <EulerImplicitSolver name="odeImplicitSolver" />
+
+        <!--
+            Iterative linear solver using the template parameter GraphScattered by default.
+            It means the global matrix system is not built explicitly. Instead, the solver
+            asks the force fields to perform directly the matrix-vector multiplications required
+            by the Conjugate Gradient algorithm.
+         -->
+        <CGLinearSolver iterations="1000" tolerance="1e-9" threshold="1e-9"/>
+
+        <MeshGmshLoader name="loader" filename="mesh/truthcylinder1.msh" />
+        <TetrahedronSetTopologyContainer src="@loader" name="topologyContainer"/>
+        <TetrahedronSetGeometryAlgorithms name="geomAlgo"/>
+        <MechanicalObject name="dofs" src="@loader"/>
+        <MeshMatrixMass totalMass="15" topology="@topologyContainer"/>
+
+        <FixedConstraint indices="0 1 2 3 4 5 6 7 8 9 10 &#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;11 12 13 14 15 16 17 18 19 20 &#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 &#x0A;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;&#x09;41 42 43 44 45 46 47 268 269 270 271 343 345" />
+        <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.49" method="large" />
+
+        <Node>
+            <MeshObjLoader name="meshLoader_0" filename="mesh/truthcylinder1.obj" handleSeams="0" />
+            <OglModel name="Visual" src="@meshLoader_0" color="red"/>
+            <BarycentricMapping input="@../dofs" output="@Visual" />
+        </Node>
+    </Node>
+</Node>

--- a/examples/Benchmark/Performance/MatrixAssembly/run.sh
+++ b/examples/Benchmark/Performance/MatrixAssembly/run.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# This script executes all the simulation files found in this directory
+# It extracts and display simulation times, so they can be compared.
+
+#location of the runSofa executable
+SOFA=bin/runSofa
+
+for filename in *.scn; do
+  echo $filename
+
+  #run the simulation
+  $SOFA -g batch -n 1000 --computationTimeSampling 1000 $filename > "$filename.perf"
+
+  #display the timings
+  grep "iterations done in" "$filename.perf"
+  grep "LEVEL" "$filename.perf"
+  grep "\.\.AnimateVisitor" "$filename.perf"
+  stats=$(grep "\.\.AnimateVisitor" "$filename.perf")
+  milliseconds="$(echo $stats | cut -d' ' -f6)"
+  echo "$milliseconds ms"
+
+  rm "$filename.perf"
+done


### PR DESCRIPTION
Similar scenes are introduced as a benchmark in order to compare their performances.
It's a cantilever beam simulated with 2.5k tetrahedra.
Depending on the scene, it is solved with either a Conjugate Gradient or a LDL solver.
The main difference is how the global system matrix is assembled (or not in case of a matrix free solver). This is defined by the template parameter of the linear solver.

# Results

The results are the average duration in milliseconds of the AnimateVisitor step:

```
MatrixAssembly_assembledCG_blocs.scn  6.54 ms
MatrixAssembly_assembledCG.scn       16.65 ms
MatrixAssembly_direct_blocs.scn      12.85 ms
MatrixAssembly_direct.scn            22.04 ms
MatrixAssembly_matrixfreeCG.scn       7.99 ms
```

* MatrixAssembly_matrixfreeCG.scn: the linear solver is a Conjugate Gradient and the matrix is not built
* MatrixAssembly_assembledCG.scn: the linear solver is a Conjugate Gradient and the matrix is explicitly built
* MatrixAssembly_assembledCG_blocs.scn: the linear solver is a Conjugate Gradient and the bloc-based matrix is explicitly built
* MatrixAssembly_direct.scn: the linear solver is a LDL solver and the matrix is explicitly built
* MatrixAssembly_direct_blocs.scn: the linear solver is a LDL solver and the bloc-based matrix is explicitly built



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
