### PR TITLE
[SofaImplicitOdeSolver] Add a Euler implicit solver with Newton iterations

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/MechanicalParams.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/MechanicalParams.cpp
@@ -45,6 +45,7 @@ MechanicalParams::MechanicalParams(const sofa::core::ExecParams& p)
     , m_bFactor(0)
     , m_kFactor(0)
     , m_symmetricMatrix(true)
+    , m_linearizeForces(true)
     , m_implicitVelocity(1)
     , m_implicitPosition(1)
 {
@@ -64,6 +65,7 @@ MechanicalParams::MechanicalParams(const MechanicalParams& p)
     , m_bFactor(p.m_bFactor)
     , m_kFactor(p.m_kFactor)
     , m_symmetricMatrix(p.m_symmetricMatrix)
+    , m_linearizeForces(p.m_linearizeForces)
     , m_implicitVelocity(p.m_implicitVelocity)
     , m_implicitPosition(p.m_implicitPosition)
 {
@@ -92,7 +94,18 @@ MechanicalParams* MechanicalParams::operator= ( const MechanicalParams& mparams 
     m_symmetricMatrix = mparams.m_symmetricMatrix;
     m_implicitVelocity = mparams.m_implicitVelocity;
     m_implicitPosition = mparams.m_implicitPosition;
+    m_linearizeForces = mparams.m_linearizeForces;
     return this;
+}
+
+bool MechanicalParams::linearizeForces() const
+{
+    return m_linearizeForces;
+}
+
+void MechanicalParams::setLinearizeForces(bool newLinearizeForces)
+{
+    m_linearizeForces = newLinearizeForces;
 }
 
 const MechanicalParams* MechanicalParams::defaultInstance()

--- a/SofaKernel/modules/SofaCore/src/sofa/core/MechanicalParams.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/MechanicalParams.h
@@ -238,7 +238,8 @@ public:
 
     MechanicalParams* operator= ( const MechanicalParams& mparams );
 
-
+    bool linearizeForces() const;
+    void setLinearizeForces(bool newLinearizeForces);
 protected:
 
     /// Time step
@@ -277,6 +278,9 @@ protected:
     /// True if a symmetric matrix is assumed in the left-hand term of the dynamics equations, for solvers specialized on symmetric matrices
     bool m_symmetricMatrix;
 
+    /// True if the call to addForce must store information for a latter call to addDForce
+    bool m_linearizeForces;
+
     /// @name Experimental compliance API
     /// @{
 protected:
@@ -289,9 +293,6 @@ public:
     void setImplicitPosition( SReal i ) { m_implicitPosition = i; }
     const SReal& implicitPosition() const { return m_implicitPosition; }
     /// @}
-
-
-
 
 };
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/Mass.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/Mass.h
@@ -68,6 +68,7 @@ public:
 
     /// Retrieve the associated MechanicalState
     MechanicalState<DataTypes>* getMState() { return this->mstate.get(); }
+    const MechanicalState<DataTypes>* getMState() { return this->mstate.get(); }
 
 
     /// @name Vector operations

--- a/SofaKernel/modules/SofaImplicitOdeSolver/CMakeLists.txt
+++ b/SofaKernel/modules/SofaImplicitOdeSolver/CMakeLists.txt
@@ -10,12 +10,14 @@ set(HEADER_FILES
     ${SOFAIMPLICITEODESOLVER_SRC}/initSofaImplicitOdeSolver.h
     ${SOFAIMPLICITEODESOLVER_SRC}/EulerImplicitSolver.h
     ${SOFAIMPLICITEODESOLVER_SRC}/StaticSolver.h
+    ${SOFAIMPLICITEODESOLVER_SRC}/NBESolver.h
 )
 
 set(SOURCE_FILES
     ${SOFAIMPLICITEODESOLVER_SRC}/initSofaImplicitOdeSolver.cpp
     ${SOFAIMPLICITEODESOLVER_SRC}/EulerImplicitSolver.cpp
     ${SOFAIMPLICITEODESOLVER_SRC}/StaticSolver.cpp
+    ${SOFAIMPLICITEODESOLVER_SRC}/NBESolver.cpp
 )
 
 sofa_find_package(SofaFramework REQUIRED) # SofaCore SofaSimulationCore

--- a/SofaKernel/modules/SofaImplicitOdeSolver/src/SofaImplicitOdeSolver/NBESolver.cpp
+++ b/SofaKernel/modules/SofaImplicitOdeSolver/src/SofaImplicitOdeSolver/NBESolver.cpp
@@ -1,0 +1,205 @@
+#include "NBESolver.h"
+
+#include <sofa/core/ObjectFactory.h>
+#include <sofa/core/visual/VisualParams.h>
+#include <sofa/helper/AdvancedTimer.h>
+#include <sofa/simulation/MechanicalOperations.h>
+#include <sofa/simulation/VectorOperations.h>
+
+namespace sofa::component::odesolver {
+using sofa::core::VecId;
+using namespace sofa::defaulttype;
+using namespace sofa::core::behavior;
+
+NBESolver::NBESolver()
+    : sofa::core::behavior::OdeSolver(),
+      m_rayleighStiffness(0),
+      m_rayleighMass(0),
+      m_newtonThreshold(1e-5),
+      m_maxNewtonIterations(1),
+      m_lineSearchMaxIterations(1) {}
+
+void NBESolver::init() { sofa::core::behavior::OdeSolver::init(); }
+
+void NBESolver::cleanup() {}
+
+void NBESolver::solve(const sofa::core::ExecParams *params, SReal dt,
+                      sofa::core::MultiVecCoordId xResult,
+                      sofa::core::MultiVecDerivId vResult) {
+  sofa::simulation::common::VectorOperations vop(params, this->getContext());
+  sofa::simulation::common::MechanicalOperations mop(params,
+                                                     this->getContext());
+  MultiVecCoord pos(&vop, sofa::core::VecCoordId::position());
+  MultiVecDeriv vel(&vop, sofa::core::VecDerivId::velocity());
+  MultiVecDeriv f(&vop, sofa::core::VecDerivId::force());
+  MultiVecDeriv b(&vop);
+  MultiVecCoord newPos(&vop, xResult);
+  MultiVecDeriv newVel(&vop, vResult);
+
+  MultiVecCoord pos_i1(&vop);
+  MultiVecDeriv vel_i1(&vop);
+
+  // This two will be used to test the line search current approximation
+  // They will contain the final result of the simulation
+  pos_i1.realloc(&vop, false, true);
+  vel_i1.realloc(&vop, false, true);
+
+  MultiVecCoord pos0(&vop);
+  MultiVecDeriv vel0(&vop);
+  pos0.realloc(&vop, false, true);
+  vel0.realloc(&vop, false, true);
+
+  /// inform the constraint parameters about the position and velocity id
+  mop.cparams.setX(xResult);
+  mop.cparams.setV(vResult);
+
+  // dx is no longer allocated by default (but it will be deleted automatically
+  // by the mechanical objects)
+  MultiVecDeriv dx(&vop, sofa::core::VecDerivId::dx());
+  dx.realloc(&vop, false, true);
+
+  const SReal &h = dt;
+
+  sofa::helper::AdvancedTimer::stepBegin("ComputeForce");
+  mop->setImplicit(true);  // this solver is implicit
+
+  // Here starts my shit
+  // Copy current position and velocity to use it later
+
+  vop.v_eq(pos0, pos);
+  vop.v_eq(vel0, vel);
+
+  // Perform an explicit step
+  vop.v_peq(pos, vel, dt);
+
+  // Propagate explicit step
+  mop.propagateX(pos);
+  mop.propagateV(vel);
+
+  f.eq(vel0);                               // f = v_0
+  f.peq(vel, -(1.0 + h * m_rayleighMass));  // f = v_0 - (1+h*alpha)*v
+  b.clear();                                // b = 0
+  mop.addMdx(b, f, 1.0);                    // b = M * (v_0 - (1+h*alpha)*v)
+  mop.computeForce(f);                      // f = FORCES
+  b.peq(f, h);  // b = h*f + M (v_0 - (1+h*alpha * v_i))
+  mop.addMBKv(b, 0.0, 0.0,
+              h * m_rayleighStiffness);  // b = h * f + M(v_0 - (1+h*alpha)) +
+                                         // h*beta*K*v
+  mop.projectResponse(b);
+
+  SReal error = b.dot(b);
+  int currentNewtonIteration = 0;
+
+  do {
+    sofa::core::behavior::MultiMatrix<
+        sofa::simulation::common::MechanicalOperations>
+        matrix(&mop);
+    matrix = MechanicalMatrix(
+        1.0 + h * m_rayleighMass,         // mass component
+        -h,                               // damping component
+        -h * h - m_rayleighStiffness * h  // stiffness component
+    );
+
+    mop->setDx(dx);
+    matrix.solve(dx, b);  // it says dx, but its a change in the velocities!
+
+    SReal lineSearchStep = 1.0;
+    int lineSearchCurrentIteration = 0;
+    SReal error_i1 = 0.0;
+    bool linearSolveIsSucessful = false;
+
+    // Perform a line search on the direction of dx
+    do {
+      vel_i1.eq(vel);
+      pos_i1.eq(pos0);
+
+      vel_i1.peq(dx, lineSearchStep);  // v_i1 += step * v
+      pos_i1.peq(vel_i1, h);           // pos_i1 += h * v_i1
+
+      // Propagate this temptative position and velocity
+      mop.propagateXAndV(pos_i1, vel_i1);
+
+      // Check if in this situation, we have less error for the original
+      // equation we are solving
+      f.eq(vel0);                               // f = v_0
+      f.peq(vel, -(1.0 + h * m_rayleighMass));  // f = v_0 - (1+h*alpha)*v
+      b.clear();                                // b = 0
+      mop.addMdx(b, f, 1.0);                    // b = M * (v_0 - (1+h*alpha)*v)
+      mop.computeForce(f);                      // f = FORCES
+      b.peq(f, h);  // b = h*f + M (v_0 - (1+h*alpha * v_i))
+      mop.addMBKv(b, 0.0, 0.0,
+                  h * m_rayleighStiffness);  // b = h * f + M(v_0 - (1+h*alpha))
+                                             // + h*beta*K*v
+      mop.projectResponse(b);
+
+      error_i1 = b.dot(b);
+
+      if (error_i1 < error) {
+        pos.eq(pos_i1);
+        vel.eq(vel_i1);
+
+        linearSolveIsSucessful = true;
+
+        break;
+      }
+
+      lineSearchStep *= 0.5;
+      lineSearchCurrentIteration++;
+    } while (lineSearchCurrentIteration < m_lineSearchMaxIterations);
+
+    error = error_i1;
+
+    if (!linearSolveIsSucessful) {
+      // The lineSearch didn't converge. This means the search direction was
+      // really bad and it doesn't improve current result. Return current
+      // result, but the simulation has failed!
+      mop.propagateXAndV(pos0, vel0);
+    }
+    currentNewtonIteration++;
+  } while (error > m_newtonThreshold &&
+           currentNewtonIteration < m_maxNewtonIterations);
+
+  if (error > m_newtonThreshold) {
+    // The newton solver has not reduce the error as much as desired in the
+    // available newton iterations. Return current result, but the simulation
+    // has failed!
+    mop.propagateXAndV(pos0, vel0);
+  }
+
+  newPos.eq(pos);
+  newVel.eq(vel);
+}
+
+SReal NBESolver::rayleighStiffness() const { return m_rayleighStiffness; }
+
+void NBESolver::setRayleighStiffness(SReal newRayleighStiffness) {
+  m_rayleighStiffness = newRayleighStiffness;
+}
+
+SReal NBESolver::rayleighMass() const { return m_rayleighMass; }
+
+void NBESolver::setRayleighMass(SReal newRayleighMass) {
+  m_rayleighMass = newRayleighMass;
+}
+
+SReal NBESolver::newtonThreshold() const { return m_newtonThreshold; }
+
+void NBESolver::setNewtonThreshold(SReal newNewtonThreshold) {
+  m_newtonThreshold = newNewtonThreshold;
+}
+
+int NBESolver::maxNewtonIterations() const { return m_maxNewtonIterations; }
+
+void NBESolver::setMaxNewtonIterations(int newMaxNewtonIterations) {
+  m_maxNewtonIterations = newMaxNewtonIterations;
+}
+
+int NBESolver::lineSearchMaxIterations() const {
+  return m_lineSearchMaxIterations;
+}
+
+void NBESolver::setLineSearchMaxIterations(int newLineSearchMaxIterations) {
+  m_lineSearchMaxIterations = newLineSearchMaxIterations;
+}
+
+}  // namespace sofa::component::odesolver

--- a/SofaKernel/modules/SofaImplicitOdeSolver/src/SofaImplicitOdeSolver/NBESolver.h
+++ b/SofaKernel/modules/SofaImplicitOdeSolver/src/SofaImplicitOdeSolver/NBESolver.h
@@ -1,0 +1,43 @@
+#ifndef VNCS_NBESOLVER_H
+#define VNCS_NBESOLVER_H
+
+#include <sofa/core/behavior/OdeSolver.h>
+
+namespace sofa::component::odesolver {
+class NBESolver : public sofa::core::behavior::OdeSolver {
+ public:
+  SOFA_CLASS(NBESolver, sofa::core::behavior::OdeSolver);
+  NBESolver();
+  void init() override;
+
+  void cleanup() override;
+
+  void solve(const sofa::core::ExecParams *params, SReal dt,
+             sofa::core::MultiVecCoordId xResult,
+             sofa::core::MultiVecDerivId vResult) override;
+
+  SReal rayleighStiffness() const;
+  void setRayleighStiffness(SReal newRayleighStiffness);
+
+  SReal rayleighMass() const;
+  void setRayleighMass(SReal newRayleighMass);
+
+  SReal newtonThreshold() const;
+  void setNewtonThreshold(SReal newNewtonThreshold);
+
+  int maxNewtonIterations() const;
+  void setMaxNewtonIterations(int newMaxNewtonIterations);
+
+  int lineSearchMaxIterations() const;
+  void setLineSearchMaxIterations(int newLineSearchMaxIterations);
+
+ private:
+  SReal m_rayleighStiffness;
+  SReal m_rayleighMass;
+  SReal m_newtonThreshold;
+  int m_maxNewtonIterations;
+  int m_lineSearchMaxIterations;
+};
+}  // namespace sofa::component::odesolver
+
+#endif  // VNCS_NBESOLVER_H


### PR DESCRIPTION
This is a port of the a Newton based Euler implicit solver I had in another project. In that project the solver return a ConvergenceStatus, which in the end allowed me to reduce the dt if the step failed to covnerged. In this case its not possible without modifying the AnimationLoop, but in any case, I am restoring the original position and velocities (or trying to, because it's not actually happening).

