### PR TITLE
[All] Remove deprecated calls and warnings

### DIFF
--- a/SofaKernel/modules/Sofa.Config/src/sofa/config.h.in
+++ b/SofaKernel/modules/Sofa.Config/src/sofa/config.h.in
@@ -135,31 +135,57 @@ typedef unsigned __int64	uint64_t;
 // Empty class to be used to highlight deprecated objects at compilation time.
 class DeprecatedAndRemoved {};
 
-#define SOFA_DEPRECATED_HEADER(deprecateDate, disableDate, newHeader) \
-    SOFA_PRAGMA_WARNING( \
-        "This header has been DEPRECATED since " deprecateDate ". " \
-        "You have until " disableDate " to fix your code. " \
-        "To fix this warning you must include " newHeader " instead." )
+#if defined(_WIN32) || defined(__clang__)
+    #define SOFA_DEPRECATED_HEADER(deprecateDate, disableDate, newHeader) \
+        SOFA_PRAGMA_WARNING( \
+            "This header has been DEPRECATED since " deprecateDate ". " \
+            "You have until " disableDate " to fix your code. " \
+            "To fix this warning you must include " newHeader " instead." )
 
-#define SOFA_DISABLED_HEADER(deprecateDate, disableDate, newHeader) \
-    SOFA_PRAGMA_ERROR( \
-        "This header has been DISABLED since " disableDate " " \
-        "after being deprecated on " deprecateDate ". " \
-        "To fix this error you must include " newHeader " instead. " )
+    #define SOFA_DISABLED_HEADER(deprecateDate, disableDate, newHeader) \
+        SOFA_PRAGMA_ERROR( \
+            "This header has been DISABLED since " disableDate " " \
+            "after being deprecated on " deprecateDate ". " \
+            "To fix this error you must include " newHeader " instead. " )
 
+    #define SOFA_DEPRECATED_HEADER_NOT_REPLACED(deprecateDate, disableDate) \
+        SOFA_PRAGMA_WARNING( \
+            "This header has been DEPRECATED since " deprecateDate ". " \
+            "You have until " disableDate " to fix your code. " \
+            "It will not replaced by another one. " )
 
-#define SOFA_DEPRECATED_HEADER_NOT_REPLACED(deprecateDate, disableDate) \
-    SOFA_PRAGMA_WARNING( \
-        "This header has been DEPRECATED since " deprecateDate ". " \
-        "You have until " disableDate " to fix your code. " \
-        "It will not replaced by another one. " )
+    #define SOFA_DISABLED_HEADER_NOT_REPLACED(deprecateDate, disableDate) \
+        SOFA_PRAGMA_ERROR( \
+            "This header has been DISABLED since " disableDate " " \
+            "after being deprecated on " deprecateDate ". "\
+            "It is not replaced by another one. " \
+            "Contact the SOFA Consortium for more information. " )
+#else
+	#define SOFA_DEPRECATED_HEADER(deprecateDate, disableDate, newHeader) \
+        SOFA_PRAGMA_WARNING( \
+            This header has been DEPRECATED since deprecateDate. \
+            You have until disableDate to fix your code. \
+            To fix this warning you must include newHeader instead. )
 
-#define SOFA_DISABLED_HEADER_NOT_REPLACED(deprecateDate, disableDate) \
-    SOFA_PRAGMA_ERROR( \
-        "This header has been DISABLED since " disableDate " " \
-        "after being deprecated on " deprecateDate ". "\
-        "It is not replaced by another one. " \
-        "Contact the SOFA Consortium for more information. " )
+	#define SOFA_DISABLED_HEADER(deprecateDate, disableDate, newHeader) \
+        SOFA_PRAGMA_ERROR( \
+            This header has been DISABLED since disableDate \
+            after being deprecated on deprecateDate. \
+            To fix this error you must include newHeader instead. )
+
+    #define SOFA_DEPRECATED_HEADER_NOT_REPLACED(deprecateDate, disableDate) \
+        SOFA_PRAGMA_WARNING( \
+            This header has been DEPRECATED since deprecateDate. \
+            You have until disableDate to fix your code. \
+            It will not replaced by another one. )
+
+    #define SOFA_DISABLED_HEADER_NOT_REPLACED(deprecateDate, disableDate) \
+        SOFA_PRAGMA_ERROR( \
+            This header has been DISABLED since disableDate \
+            after being deprecated on deprecateDate. \
+            It is not replaced by another one. \
+            Contact the SOFA Consortium for more information. )
+#endif
 
 
 #define SOFA_ATTRIBUTE_DEPRECATED(deprecateDate, removeDate, toFixMsg) \

--- a/SofaKernel/modules/Sofa.Config/src/sofa/config.h.in
+++ b/SofaKernel/modules/Sofa.Config/src/sofa/config.h.in
@@ -202,7 +202,7 @@ class DeprecatedAndRemoved {};
         "Link<> cannot hold BaseData anymore. " \
         "To make a link between Datas use DataLink instead. ")
 
-#define SOFA_ATTRIBUTE_REMOVAL_OF_BASEDATA_OWNERCLASS_ACCESSOR(msg) \
+#define SOFA_ATTRIBUTE_DEPRECATED__BASEDATA_OWNERCLASS_ACCESSOR(msg) \
     SOFA_ATTRIBUTE_DEPRECATED( \
         "v21.06 (PR#1890)", "v21.12", \
         "BaseData API has changed. " msg)

--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/Mat.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/Mat.h
@@ -683,10 +683,21 @@ public:
     template<class Quat>
     static Mat<L,C,real> transformRotation(const Quat& q)
     {
+        static_assert(L == C && (L ==4 || L == 3), "transformRotation can only be called with 3x3 or 4x4 matrices.");
+
         Mat<L,C,real> m;
         m.identity();
-        q.toMatrix(m);
-        return m;
+
+        if constexpr(L == 4 && C == 4)
+        {
+            q.toHomogeneousMatrix(m);
+            return m;
+        }
+        else // if constexpr(L == 3 && C == 3)
+        {
+            q.toMatrix(m);
+            return m;
+        }
     }
 
     /// @return True if and only if the Matrix is a transformation matrix

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/MinProximityIntersection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/MinProximityIntersection.cpp
@@ -77,6 +77,7 @@ bool MinProximityIntersection::testIntersection(Cube& cube1, Cube& cube2)
 
 int MinProximityIntersection::computeIntersection(Cube& cube1, Cube& cube2, OutputVector* contacts)
 {
+    SOFA_UNUSED(contacts);
     return BaseProximityIntersection::testIntersection(cube1, cube2);
 }
 

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/NewProximityIntersection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/NewProximityIntersection.cpp
@@ -66,6 +66,7 @@ bool NewProximityIntersection::testIntersection(Cube& cube1, Cube& cube2)
 
 int NewProximityIntersection::computeIntersection(Cube& cube1, Cube& cube2, OutputVector* contacts) 
 { 
+    SOFA_UNUSED(contacts);
     return BaseProximityIntersection::testIntersection(cube1, cube2); 
 }
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetGeometryAlgorithms.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetGeometryAlgorithms.inl
@@ -1661,7 +1661,6 @@ bool TriangleSetGeometryAlgorithms< DataTypes >::computeIntersectionsLineTriangl
     vecBaryCoef.clear();
 
     bool is_validated = false;
-    bool is_intersected = false;
 
     const Triangle& t = this->m_topology->getTriangle(ind_t);
     const typename DataTypes::VecCoord& vect_c = (this->object->read(core::ConstVecCoordId::position())->getValue());
@@ -1709,7 +1708,6 @@ bool TriangleSetGeometryAlgorithms< DataTypes >::computeIntersectionsLineTriangl
             Real coord_t = 0.0;
             Real coord_k = 0.0;
 
-            bool is_initialized = false;
             coord_kmin = 0.0;
 
             Real coord_test1;

--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
@@ -1488,7 +1488,6 @@ void VisualModelImpl::handleTopologyChange()
 
             const sofa::core::topology::QuadsAdded *qa = static_cast< const sofa::core::topology::QuadsAdded * >( *itBegin );
 
-            VisualQuad q;
             const std::size_t nbAddedQuads = qa->getNbAddedQuads();
             const std::size_t nbQuaduads = quads.size();
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/MultiMapping.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/MultiMapping.h
@@ -227,7 +227,7 @@ public:
             arg->logError("The 'output' data attribute is empty. It should contain a valid path "
                           "to one or more mechanical states. of type '" + std::string(TOut::Name()) + "'.");
             return false;
-        } else if (!PathResolver::CheckPaths(context, LinkToModels::DestType::GetClass(), input)) {
+        } else if (!PathResolver::CheckPaths(context, LinkToModels::DestType::GetClass(), output)) {
             arg->logError("The 'output' data attribute does not contain a valid path to one or more mechanical "
                           "states of type '" + std::string(TOut::Name()) + "'.");
             return false;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/MultiMapping.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/MultiMapping.h
@@ -215,7 +215,8 @@ public:
             arg->logError("The 'input' data attribute is empty. It should contain a valid path "
                           "to one or more mechanical states of type '" + std::string(TIn::Name()) + "'.");
             return false;
-        } else if (!LinkFromModels::CheckPaths(input, context)) {
+
+        } else if (!PathResolver::CheckPaths(context, LinkFromModels::DestType::GetClass(), input)) {
             arg->logError("The 'input' data attribute does not contain a valid path to one or more mechanical "
                           "states of type '" + std::string(TIn::Name()) + "'.");
             return false;
@@ -226,7 +227,7 @@ public:
             arg->logError("The 'output' data attribute is empty. It should contain a valid path "
                           "to one or more mechanical states. of type '" + std::string(TOut::Name()) + "'.");
             return false;
-        } else if (!LinkToModels::CheckPaths(output, context)) {
+        } else if (!PathResolver::CheckPaths(context, LinkToModels::DestType::GetClass(), input)) {
             arg->logError("The 'output' data attribute does not contain a valid path to one or more mechanical "
                           "states of type '" + std::string(TOut::Name()) + "'.");
             return false;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -53,16 +53,11 @@ Base::Base()
     , f_bbox(initData( &f_bbox, "bbox", "this object bounding box"))
     , d_componentState(initData(&d_componentState, ComponentState::Undefined, "componentState", "The state of the component among (Dirty, Valid, Undefined, Loading, Invalid)."))
 {
-    name.setOwnerClass("Base");
     name.setAutoLink(false);
     d_componentState.setAutoLink(false);
     d_componentState.setReadOnly(true);
-    d_componentState.setOwnerClass("Base");
-    f_printLog.setOwnerClass("Base");
     f_printLog.setAutoLink(false);
-    f_tags.setOwnerClass("Base");
     f_tags.setAutoLink(false);
-    f_bbox.setOwnerClass("Base");
     f_bbox.setReadOnly(true);
     f_bbox.setDisplayed(false);
     f_bbox.setAutoLink(false);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
@@ -153,11 +153,11 @@ public:
     void setHelp(const std::string& val) { help = val; }
 
     /// Get owner class
-    SOFA_ATTRIBUTE_REMOVAL_OF_BASEDATA_OWNERCLASS_ACCESSOR("Replace getOwnerClass() by getOwner()->className")
+    SOFA_ATTRIBUTE_DEPRECATED__BASEDATA_OWNERCLASS_ACCESSOR("Replace getOwnerClass() by getOwner()->getClassName().")
     const std::string& getOwnerClass() const { return ownerClass; }
 
     /// Set owner class
-    SOFA_ATTRIBUTE_REMOVAL_OF_BASEDATA_OWNERCLASS_ACCESSOR("The function will be totally removed. The owner's class name being using getOwner()->className")
+    SOFA_ATTRIBUTE_DEPRECATED__BASEDATA_OWNERCLASS_ACCESSOR("This feature will be totally removed. You are not supposed to change Owner's type name.")
     void setOwnerClass(const char* val) { ownerClass = val; }
 
     /// Get group

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/RigidTypes.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/RigidTypes.h
@@ -565,6 +565,15 @@ public:
         m[2][3] = (typename Mat::Real)center[2];
     }
 
+    void toHomogeneousMatrix( HomogeneousMat& m) const
+    {
+        m.identity();
+        orientation.toHomogeneousMatrix(m);
+        m[0][3] = center[0];
+        m[1][3] = center[1];
+        m[2][3] = center[2];
+    }
+
     /// create a homogeneous vector from a 3d vector
     template <typename V>
     static HomogeneousVec toHomogeneous( V v, real r=1. ){

--- a/SofaKernel/modules/SofaExplicitOdeSolver/src/SofaExplicitOdeSolver/EulerSolver.cpp
+++ b/SofaKernel/modules/SofaExplicitOdeSolver/src/SofaExplicitOdeSolver/EulerSolver.cpp
@@ -308,7 +308,7 @@ void EulerExplicitSolver::assembleSystemMatrix(core::behavior::MultiMatrix<simul
     //       is called on every BaseProjectiveConstraintSet objects. An example of such constraint set is the
     //       FixedConstraint. In this case, it will set to 0 every column (_, i) and row (i, _) of the assembled
     //       matrix for the ith degree of freedom.
-    *matrix = MechanicalMatrix::M;
+    (*matrix).setSystemMBKMatrix(MechanicalMatrix::M);
 }
 
 void EulerExplicitSolver::solveSystem(core::behavior::MultiMatrix<simulation::common::MechanicalOperations>* matrix,

--- a/SofaKernel/modules/SofaImplicitOdeSolver/src/SofaImplicitOdeSolver/EulerImplicitSolver.cpp
+++ b/SofaKernel/modules/SofaImplicitOdeSolver/src/SofaImplicitOdeSolver/EulerImplicitSolver.cpp
@@ -148,9 +148,9 @@ void EulerImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa::
     core::behavior::MultiMatrix<simulation::common::MechanicalOperations> matrix(&mop);
 
     if (firstOrder)
-        matrix = MechanicalMatrix(1,0,-h*tr); //MechanicalMatrix::K * (-h*tr) + MechanicalMatrix::M;
+        matrix.setSystemMBKMatrix(MechanicalMatrix(1,0,-h*tr)); //MechanicalMatrix::K * (-h*tr) + MechanicalMatrix::M;
     else
-        matrix = MechanicalMatrix(1+tr*h*f_rayleighMass.getValue(),-tr*h,-tr*h*(h+f_rayleighStiffness.getValue())); // MechanicalMatrix::K * (-tr*h*(h+f_rayleighStiffness.getValue())) + MechanicalMatrix::B * (-tr*h) + MechanicalMatrix::M * (1+tr*h*f_rayleighMass.getValue());
+        matrix.setSystemMBKMatrix(MechanicalMatrix(1+tr*h*f_rayleighMass.getValue(),-tr*h,-tr*h*(h+f_rayleighStiffness.getValue()))); // MechanicalMatrix::K * (-tr*h*(h+f_rayleighStiffness.getValue())) + MechanicalMatrix::B * (-tr*h) + MechanicalMatrix::M * (1+tr*h*f_rayleighMass.getValue());
 
     msg_info() << "EulerImplicitSolver, matrix = " << (MechanicalMatrix::K * (-h * (h + f_rayleighStiffness.getValue())) + MechanicalMatrix::M * (1 + h * f_rayleighMass.getValue())) << " = " << matrix;
     msg_info() << "EulerImplicitSolver, Matrix K = " << MechanicalMatrix::K;

--- a/SofaKernel/modules/SofaImplicitOdeSolver/src/SofaImplicitOdeSolver/StaticSolver.cpp
+++ b/SofaKernel/modules/SofaImplicitOdeSolver/src/SofaImplicitOdeSolver/StaticSolver.cpp
@@ -275,7 +275,7 @@ void StaticSolver::solve(const sofa::core::ExecParams* params, double dt, sofa::
             //       is called on every BaseProjectiveConstraintSet objects. An example of such constraint set is the
             //       FixedConstraint. In this case, it will set to 0 every column (_, i) and row (i, _) of the assembled
             //       matrix for the ith degree of freedom.
-            matrix = MechanicalMatrix::K * -1.0;
+            matrix.setSystemMBKMatrix(MechanicalMatrix::K * -1.0);
         }
 
         // Part II. Solve the unknown increment.

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/MeshNewProximityIntersection.cpp
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/MeshNewProximityIntersection.cpp
@@ -56,37 +56,43 @@ MeshNewProximityIntersection::MeshNewProximityIntersection(NewProximityIntersect
 
 bool MeshNewProximityIntersection::testIntersection(Point& pt1, Point& pt2)
 {
-
+    SOFA_UNUSED(pt1);
+    SOFA_UNUSED(pt2);
     return false;
 }
 
 bool MeshNewProximityIntersection::testIntersection(Line& line, Point& pt)
 {
-
+    SOFA_UNUSED(line);
+    SOFA_UNUSED(pt);
     return false;
 }
 
 bool MeshNewProximityIntersection::testIntersection(Line& line1, Line& line2)
 {
-
+    SOFA_UNUSED(line1);
+    SOFA_UNUSED(line2);
     return false;
 }
 
 bool MeshNewProximityIntersection::testIntersection(Triangle& tri, Point& pt)
 {
-
+    SOFA_UNUSED(tri);
+    SOFA_UNUSED(pt);
     return false;
 }
 
 bool MeshNewProximityIntersection::testIntersection(Triangle& tri, Line& line)
 {
-
+    SOFA_UNUSED(tri);
+    SOFA_UNUSED(line);
     return false;
 }
 
 bool MeshNewProximityIntersection::testIntersection(Triangle& tri1, Triangle& tri2)
 {
-
+    SOFA_UNUSED(tri1);
+    SOFA_UNUSED(tri2);
     return false;
 }
 

--- a/modules/SofaConstraint/src/SofaConstraint/UncoupledConstraintCorrection.inl
+++ b/modules/SofaConstraint/src/SofaConstraint/UncoupledConstraintCorrection.inl
@@ -410,6 +410,8 @@ void UncoupledConstraintCorrection<DataTypes>::computeDx(const Data< VecDeriv > 
 template<class DataTypes>
 void UncoupledConstraintCorrection<DataTypes>::computeMotionCorrection(const core::ConstraintParams* cparams, core::MultiVecDerivId dx, core::MultiVecDerivId f)
 {
+    SOFA_UNUSED(cparams);
+
     auto writeDx = sofa::helper::getWriteAccessor( *dx[this->getMState()].write() );
     const Data<VecDeriv>& f_d = *f[this->getMState()].read();
     computeDx(f_d, writeDx.wref());

--- a/modules/SofaGeneralImplicitOdeSolver/src/SofaGeneralImplicitOdeSolver/VariationalSymplecticSolver.cpp
+++ b/modules/SofaGeneralImplicitOdeSolver/src/SofaGeneralImplicitOdeSolver/VariationalSymplecticSolver.cpp
@@ -205,7 +205,7 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
 			mop.projectResponse(b);
 			// add left term : matrix=-K+4/h^(2)M, but with dampings rK and rM
             core::behavior::MultiMatrix<simulation::common::MechanicalOperations> matrix(&mop);
-			matrix = MechanicalMatrix::K * (-1.0-4*rK/h) +  MechanicalMatrix::M * (4.0/(h*h)+4*rM/h);
+            matrix.setSystemMBKMatrix(MechanicalMatrix::K * (-1.0-4*rK/h) +  MechanicalMatrix::M * (4.0/(h*h)+4*rM/h));
 
 			sofa::helper::AdvancedTimer::stepNext ("MBKBuild", "MBKSolve");
 
@@ -290,7 +290,7 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
             b.clear();
             core::behavior::MultiMatrix<simulation::common::MechanicalOperations> matrix(&mop);
             // Mass matrix
-            matrix = MechanicalMatrix::M;
+            matrix.setSystemMBKMatrix(MechanicalMatrix::M);
 
             // resolution of matrix*b=newp
             matrix.solve(b,newp); // b = inv(matrix)*newp = Minv*newp

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QDisplayDataWidget.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QDisplayDataWidget.cpp
@@ -30,6 +30,7 @@
 #include <QLabel>
 #include <QValidator>
 #include <sofa/core/objectmodel/DataFileName.h>
+#include <sofa/core/objectmodel/Base.h>
 
 #define TEXTSIZE_THRESHOLD 45
 
@@ -60,7 +61,7 @@ QDisplayDataWidget::QDisplayDataWidget(QWidget* parent,
 
     const std::string& help = data_->getHelp().c_str();
     const std::string valuetype = data_->getValueTypeString();
-    const std::string& ownerClass = data_->getOwnerClass();
+    const std::string& ownerClass = data_->getOwner()->getClassName();
     std::stringstream s;
 
     s << (!help.empty() ? help : "< No help found >")

--- a/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.cpp
+++ b/modules/SofaHeadlessRecorder/src/SofaHeadlessRecorder/HeadlessRecorder.cpp
@@ -476,7 +476,11 @@ void HeadlessRecorder::calcProjection()
     else
     {
         float ratio = static_cast<float>( vparams->zFar() / (vparams->zNear() * 20) );
-        Vector3 tcenter = vparams->sceneTransform() * center;
+        Mat4x4d projMat;
+        vparams->getProjectionMatrix(projMat.ptr());
+        Mat4x4d modelMat;
+        vparams->getModelViewMatrix(modelMat.ptr());
+        Vector3 tcenter = (projMat * modelMat).transform(center);
         if (tcenter[2] < 0.0)
         {
             ratio = static_cast<float>( -300 * (tcenter.norm2()) / tcenter[2] );

--- a/modules/SofaMiscEngine/src/SofaMiscEngine/DisplacementMatrixEngine.cpp
+++ b/modules/SofaMiscEngine/src/SofaMiscEngine/DisplacementMatrixEngine.cpp
@@ -54,13 +54,13 @@ void DisplacementTransformEngine<Rigid3Types,Rigid3Types::Coord>::mult( Rigid3Ty
 template <>
 void DisplacementTransformEngine<Rigid3Types,Mat4x4>::setInverse( Mat4x4& inv, const Coord& x0 )
 {
-    Rigid3Types::inverse(x0).toMatrix(inv);
+    Rigid3Types::inverse(x0).toHomogeneousMatrix(inv);
 }
 
 template <>
 void DisplacementTransformEngine<Rigid3Types,Mat4x4>::mult( Mat4x4& out, const Mat4x4& inv, const Coord& x )
 {
-    x.toMatrix(out);
+    x.toHomogeneousMatrix(out);
     out = out * inv;
 }
 

--- a/modules/SofaMiscEngine/src/SofaMiscEngine/DisplacementMatrixEngine.inl
+++ b/modules/SofaMiscEngine/src/SofaMiscEngine/DisplacementMatrixEngine.inl
@@ -174,7 +174,7 @@ void DisplacementMatrixEngine< DataTypes >::doUpdate()
     displacements.resize(size);
     for( unsigned int i = 0; i < size; ++i )
     {
-        x[i].toMatrix(displacements[i]);
+        x[i].toHomogeneousMatrix(displacements[i]);
         displacements[i] = displacements[i] * this->SxInverses[i];
     }
     this->d_displacements.endEdit();

--- a/modules/SofaMiscSolver/src/SofaMiscSolver/NewmarkImplicitSolver.cpp
+++ b/modules/SofaMiscSolver/src/SofaMiscSolver/NewmarkImplicitSolver.cpp
@@ -123,7 +123,7 @@ void NewmarkImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa
 
     core::behavior::MultiMatrix<simulation::common::MechanicalOperations> matrix(&mop);
 
-    matrix = MechanicalMatrix::K * (-h*h*beta - h*rK*gamma) + MechanicalMatrix::B*(-h)*gamma + MechanicalMatrix::M * (1 + h*gamma*rM);
+    matrix.setSystemMBKMatrix(MechanicalMatrix::K * (-h*h*beta - h*rK*gamma) + MechanicalMatrix::B*(-h)*gamma + MechanicalMatrix::M * (1 + h*gamma*rM));
 
     msg_info()<<"matrix = "<< MechanicalMatrix::K *(-h*h*beta + -h*rK*gamma) + MechanicalMatrix::M * (1 + h*gamma*rM) << " = " << matrix<<sendl;
     matrix.solve(aResult, b);


### PR DESCRIPTION
Cleaning PR for the v21.06 release.

1. remove warnings about unused variables/parameters
2. transformRotation of Mat enforces if the given Mat is 3x3 or 4x4 (does not make sense otherwise, or could even crash)
3. add a function toHomogeneousMatrix() for Mat4x4 for RigidTypes (which will use the toHomogenous of Quat)
4. remove uses of operator= with MultiMatrix in ODESolvers
5. HeadlessRecorder was using a deprecated feature of VisualParameters (sceneTransform)
6. Use PathResolver in MultiMapping
7. Rename Deprecation Macro in BaseData.h, correct the fix message and remove use of setOwnerClass.

Note for 7.: the GUI was displaying either "Base" for owner (when hovering on the Data name) or "no owner found". I dont really know what was supposed to be displayed.
Now with the correction, all the Data will display their owner's name, which seems a bit useless to me.

Before:
![prclean_2106_beforename](https://user-images.githubusercontent.com/11028016/123656430-35593280-d830-11eb-8f3a-bfd4283ac64f.png) ![prclean_2106_beforeflags](https://user-images.githubusercontent.com/11028016/123656436-368a5f80-d830-11eb-8a41-d772aa2f679a.png)

After:
![prclean_2106_aftername](https://user-images.githubusercontent.com/11028016/123656520-4ace5c80-d830-11eb-86ba-9a761911530b.png) ![prclean_2106_afterflags](https://user-images.githubusercontent.com/11028016/123656532-4d30b680-d830-11eb-8a6a-af7ec55843f4.png)

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
