### PR TITLE
[SofaCore] Link: case where Data parent is invalid

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -484,7 +484,7 @@ bool Base::parseField( const std::string& attribute, const std::string& value)
                 }
                 else
                 {
-                    msg_warning() << "Link Data '" << attribute << "' to invalid Data '" << value << '\'';
+                    msg_error() << "Link Data '" << attribute << "' to invalid Data '" << value << '\'';
                     ok = false;
                     continue;
                 }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -477,10 +477,11 @@ bool Base::parseField( const std::string& attribute, const std::string& value)
             {
                 if (BaseData* parentData = dataVec[d]->getParent())
                 {
-                    msg_info() << "Link from parent Data " << value
-                                                         << " (" << parentData->getValueTypeInfo()->name()
-                                                         << ") to Data " << attribute
-                                                         << " (" << dataVec[d]->getValueTypeInfo()->name() << ") OK";
+                    msg_info() << "Link from parent Data "
+                                    << value << " (" << parentData->getValueTypeInfo()->name() << ") "
+                                    << "to Data "
+                                    << attribute << " (" << dataVec[d]->getValueTypeInfo()->name() << ") "
+                                    << "OK";
                 }
             }
             /* children Data cannot be modified changing the parent Data value */

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -475,8 +475,19 @@ bool Base::parseField( const std::string& attribute, const std::string& value)
             }
             else
             {
-                BaseData* parentData = dataVec[d]->getParent();
-                msg_info() << "Link from parent Data " << value << " (" << parentData->getValueTypeInfo()->name() << ") to Data " << attribute << "(" << dataVec[d]->getValueTypeInfo()->name() << ") OK";
+                if (BaseData* parentData = dataVec[d]->getParent())
+                {
+                    msg_info() << "Link from parent Data " << value
+                                                         << " (" << parentData->getValueTypeInfo()->name()
+                                                         << ") to Data " << attribute
+                                                         << " (" << dataVec[d]->getValueTypeInfo()->name() << ") OK";
+                }
+                else
+                {
+                    msg_warning() << "Link Data '" << attribute << "' to invalid Data '" << value << '\'';
+                    ok = false;
+                    continue;
+                }
             }
             /* children Data cannot be modified changing the parent Data value */
             dataVec[d]->setReadOnly(true);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -482,12 +482,6 @@ bool Base::parseField( const std::string& attribute, const std::string& value)
                                                          << ") to Data " << attribute
                                                          << " (" << dataVec[d]->getValueTypeInfo()->name() << ") OK";
                 }
-                else
-                {
-                    msg_error() << "Link Data '" << attribute << "' to invalid Data '" << value << '\'';
-                    ok = false;
-                    continue;
-                }
             }
             /* children Data cannot be modified changing the parent Data value */
             dataVec[d]->setReadOnly(true);


### PR DESCRIPTION
`parentData == nullptr` leads to a crash. I think it happens when the linked object could not be created for some reasons.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
