### PR TITLE
[SofaUserInteraction] Deprecate RayTraceDetection

### DIFF
--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.cpp
@@ -61,8 +61,7 @@ void BruteForceDetection::init()
             narrowPhaseComponents[0],
             comma_fold);
 
-    msg_deprecated() << this->getClassName() << " component is deprecated. It will be removed in v21.12." << msgendl
-                     << "  As a replacement, use a BroadPhase component, such as [" << broadPhaseComponentsString
+    msg_deprecated() << "As a replacement, use a BroadPhase component, such as [" << broadPhaseComponentsString
                      << "]," << msgendl
                      << "  AND a NarrowPhase component, such as [" << narrowPhaseComponentsString << "]." << msgendl
                      << "  " << BruteForceBroadPhase::GetClass()->className << " and " << BVHNarrowPhase::GetClass()->className << " have been automatically added to your scene for backward compatibility.";

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.cpp
@@ -32,7 +32,9 @@ namespace lifecycle
 std::map<std::string, Deprecated> deprecatedComponents = {
     // SofaMiscForceField
     {"MatrixMass", Deprecated("v19.06", "v19.12")},
-
+    {"RayTraceDetection", Deprecated("v21.06", "v21.12")},
+    {"BruteForceDetection", Deprecated("v21.06", "v21.12")},
+    {"DirectSAP", Deprecated("v21.06", "v21.12")},
 };
 
 std::map<std::string, ComponentChange> uncreatableComponents = {

--- a/examples/Components/collision/RayTraceCollision.scn
+++ b/examples/Components/collision/RayTraceCollision.scn
@@ -8,7 +8,8 @@
     <RequiredPlugin name="SofaUserInteraction"/>
 
     <DefaultPipeline verbose="0" depth="10" draw="0" />
-    <RayTraceDetection name="N2" />
+    <BruteForceBroadPhase/>
+    <RayTraceNarrowPhase/>
     <NewProximityIntersection name="Proximity" alarmDistance="2" contactDistance="0.7" />
     <DefaultContactManager name="Response" response="default" />
     <DefaultCollisionGroupManager name="Group" />

--- a/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/DirectSAP.cpp
+++ b/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/DirectSAP.cpp
@@ -59,8 +59,7 @@ void DirectSAP::init()
             narrowPhaseComponents[0],
             comma_fold);
 
-    msg_deprecated() << this->getClassName() << " component is deprecated. It will be removed in SOFA v21.12" << msgendl
-                     << "  As a replacement, use a BroadPhase component such as [" << broadPhaseComponentsString << "] " << msgendl
+    msg_deprecated() << "As a replacement, use a BroadPhase component such as [" << broadPhaseComponentsString << "] " << msgendl
                      << "  AND a NarrowPhase component such as [" << narrowPhaseComponentsString << "]." << msgendl
                      << "  " << BruteForceBroadPhase::GetClass()->className << " and " << DirectSAPNarrowPhase::GetClass()->className
                      << " have been automatically added to your scene for backward compatibility.";

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/RayTraceDetection.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/RayTraceDetection.cpp
@@ -21,12 +21,79 @@
 ******************************************************************************/
 
 #include <SofaUserInteraction/RayTraceDetection.h>
+
 #include <sofa/core/ObjectFactory.h>
+#include <numeric>
 
 namespace sofa::component::collision
 {
 
 int RayTraceDetectionClass = core::RegisterObject(
         "Collision detection using TriangleOctreeModel").add<RayTraceDetection>();
+
+
+void RayTraceDetection::init()
+{
+    std::vector<std::string> broadPhaseComponents;
+    std::vector<std::string> narrowPhaseComponents;
+    findAllDetectionComponents(broadPhaseComponents, narrowPhaseComponents);
+
+    if (broadPhaseComponents.empty())
+    {
+        broadPhaseComponents.push_back(BruteForceBroadPhase::GetClass()->className);
+    }
+    if (narrowPhaseComponents.empty())
+    {
+        narrowPhaseComponents.push_back(RayTraceNarrowPhase::GetClass()->className);
+    }
+
+    const auto comma_fold = [](std::string a, std::string b)
+    {
+        return std::move(a) + ", " + std::move(b);
+    };
+
+    const std::string broadPhaseComponentsString = std::accumulate(
+            std::next(broadPhaseComponents.begin()), broadPhaseComponents.end(),
+            broadPhaseComponents[0],
+            comma_fold);
+
+    const std::string narrowPhaseComponentsString = std::accumulate(
+            std::next(narrowPhaseComponents.begin()), narrowPhaseComponents.end(),
+            narrowPhaseComponents[0],
+            comma_fold);
+
+    msg_deprecated() << this->getClassName() << " component is deprecated. It will be removed in v21.12." << msgendl
+                     << "  As a replacement, use a BroadPhase component, such as [" << broadPhaseComponentsString
+                     << "]," << msgendl
+                     << "  AND a NarrowPhase component, such as [" << narrowPhaseComponentsString << "]." << msgendl
+                     << "  " << BruteForceBroadPhase::GetClass()->className << " and " << RayTraceNarrowPhase::GetClass()->className << " have been automatically added to your scene for backward compatibility.";
+}
+
+void RayTraceDetection::findAllDetectionComponents(std::vector<std::string> &broadPhaseComponents,
+                                                     std::vector<std::string> &narrowPhaseComponents)
+{
+    std::vector<sofa::core::ObjectFactory::ClassEntry::SPtr> entries;
+    sofa::core::ObjectFactory::getInstance()->getAllEntries(entries);
+
+    for (const auto &entry : entries)
+    {
+        const auto creatorEntry = entry->creatorMap.begin();
+        if (creatorEntry != entry->creatorMap.end())
+        {
+            const sofa::core::objectmodel::BaseClass *baseClass = creatorEntry->second->getClass();
+            if (baseClass)
+            {
+                if (baseClass->hasParent(sofa::core::collision::BroadPhaseDetection::GetClass()))
+                {
+                    broadPhaseComponents.push_back(baseClass->className);
+                }
+                if (baseClass->hasParent(sofa::core::collision::NarrowPhaseDetection::GetClass()))
+                {
+                    narrowPhaseComponents.push_back(baseClass->className);
+                }
+            }
+        }
+    }
+}
 
 } // namespace sofa::component::collision

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/RayTraceDetection.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/RayTraceDetection.cpp
@@ -62,8 +62,7 @@ void RayTraceDetection::init()
             narrowPhaseComponents[0],
             comma_fold);
 
-    msg_deprecated() << this->getClassName() << " component is deprecated. It will be removed in v21.12." << msgendl
-                     << "  As a replacement, use a BroadPhase component, such as [" << broadPhaseComponentsString
+    msg_deprecated() << "As a replacement, use a BroadPhase component, such as [" << broadPhaseComponentsString
                      << "]," << msgendl
                      << "  AND a NarrowPhase component, such as [" << narrowPhaseComponentsString << "]." << msgendl
                      << "  " << BruteForceBroadPhase::GetClass()->className << " and " << RayTraceNarrowPhase::GetClass()->className << " have been automatically added to your scene for backward compatibility.";

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/RayTraceDetection.h
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/RayTraceDetection.h
@@ -24,10 +24,6 @@
 
 #include <SofaBaseCollision/BruteForceBroadPhase.h>
 #include <SofaGeneralMeshCollision/RayTraceNarrowPhase.h>
-#include <sofa/core/CollisionElement.h>
-#include <sofa/defaulttype/Vec.h>
-#include <set>
-
 
 namespace sofa::component::collision
 {
@@ -39,12 +35,41 @@ namespace sofa::component::collision
  *   up to find a triangle in the other object. Both triangles are tested to evaluate if they are in
  *   colliding state. It must be used with a TriangleOctreeModel,as an octree is used to traverse the object.
  */
-class SOFA_SOFAUSERINTERACTION_API RayTraceDetection :
-    public BruteForceBroadPhase,
-    public RayTraceNarrowPhase
+class SOFA_SOFAUSERINTERACTION_API RayTraceDetection final :
+    public sofa::core::objectmodel::BaseObject
 {
 public:
-    SOFA_CLASS2(RayTraceDetection, BruteForceBroadPhase, RayTraceNarrowPhase);
+    SOFA_CLASS(RayTraceDetection, sofa::core::objectmodel::BaseObject);
+
+    void init() override;
+
+    /// Construction method called by ObjectFactory.
+    template<class T>
+    static typename T::SPtr create(T*, sofa::core::objectmodel::BaseContext* context, sofa::core::objectmodel::BaseObjectDescription* arg)
+    {
+        BruteForceBroadPhase::SPtr broadPhase = sofa::core::objectmodel::New<BruteForceBroadPhase>();
+        broadPhase->setName("bruteForceBroadPhase");
+        if (context) context->addObject(broadPhase);
+
+        RayTraceNarrowPhase::SPtr narrowPhase = sofa::core::objectmodel::New<RayTraceNarrowPhase>();
+        narrowPhase->setName("rayTraceNarrowPhase");
+        if (context) context->addObject(narrowPhase);
+
+        typename T::SPtr obj = sofa::core::objectmodel::New<T>();
+        if (context) context->addObject(obj);
+        if (arg) obj->parse(arg);
+
+        return obj;
+    }
+
+protected:
+    RayTraceDetection() = default;
+    ~RayTraceDetection() override = default;
+
+private:
+
+    void findAllDetectionComponents(std::vector<std::string>& broadPhaseComponents, std::vector<std::string>& narrowPhaseComponents);
+
 };
 
 } // namespace sofa::component::collision


### PR DESCRIPTION
RayTraceDetection is deprecated. Use BruteForceBroadPhase and RayTraceNarrowPhase instead.
A message warns the user and it keeps compatibility with scenes using RayTraceDetection.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
