### PR TITLE
[CMake] ADD option to enable/disable compatibility layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,9 +183,13 @@ option(SOFA_ENABLE_SOFT_DEPS_TO_SOFAPYTHON "Enable all soft dependencies to Sofa
 add_subdirectory(extlibs)
 
 ### Main Sofa subdirectories
+option(SOFA_ENABLE_LEGACY_HEADERS "Enable the compatibility layer (headers located in legacy folders)." ON)
+if(SOFA_ENABLE_LEGACY_HEADERS)
+    message("Using legacy headers is enabled.")
+    message("Headers from v20.12 are usable, but it is advised to change your code to use the new headers introduced in v21.06.")
 
-# TODO: add an option once the sofa code has been converted
-add_subdirectory(${SOFA_KERNEL_SOURCE_DIR}/modules/Sofa.Compat)
+    add_subdirectory(${SOFA_KERNEL_SOURCE_DIR}/modules/Sofa.Compat)
+endif()
 
 add_subdirectory(${SOFA_KERNEL_SOURCE_DIR}/SofaFramework)
 add_subdirectory(${SOFA_KERNEL_SOURCE_DIR}/SofaSimulation)

--- a/SofaKernel/modules/Sofa.Type/CMakeLists.txt
+++ b/SofaKernel/modules/Sofa.Type/CMakeLists.txt
@@ -62,7 +62,7 @@ set(SOURCE_FILES
 
 sofa_find_package(Boost REQUIRED)
 sofa_find_package(Sofa.Config REQUIRED)
-sofa_find_package(Sofa.Compat REQUIRED BOTH_SCOPES) #TODO remove REQUIRED once the sofa code has been ported
+sofa_find_package(Sofa.Compat QUIET BOTH_SCOPES)
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 


### PR DESCRIPTION
Use of the compatibility layer becomes optional now. Useful if one needs to check if their code is fully v21.06.
ON is the default value for easy-transitioning (for now)

It would be nice for one build on the CI to set the option to OFF (to detect PRs still using deprecated headers)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
