### PR TITLE
[CMake] CLEAN/FIX deprecated things (MSVC mainly)

### DIFF
--- a/SofaKernel/extlibs/newmat/CMakeLists.txt
+++ b/SofaKernel/extlibs/newmat/CMakeLists.txt
@@ -46,6 +46,11 @@ else()
     target_compile_definitions(${PROJECT_NAME} PUBLIC "USING_DOUBLE")
 endif()
 
+if(WIN32)
+    # remove warnings about deprecation (CRT,etc)
+    target_compile_options(${PROJECT_NAME} PRIVATE "/wd4996")
+endif()
+
 # The code must be relocatable if we want to link a shared library against it
 if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xGNU" OR "x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xClang")
     target_compile_options(${PROJECT_NAME} PRIVATE "-fPIC")

--- a/SofaKernel/modules/Sofa.Config/CMakeLists.txt
+++ b/SofaKernel/modules/Sofa.Config/CMakeLists.txt
@@ -169,7 +169,10 @@ endif()
 ## Windows-specific
 if(WIN32)    
     list(APPEND SOFACONFIG_COMPILE_OPTIONS "-D_USE_MATH_DEFINES")
-    list(APPEND SOFACONFIG_COMPILE_OPTIONS "/MP;/wd4250;/wd4251;/wd4275;/wd4675;/wd4996;/wd4661")
+    list(APPEND SOFACONFIG_COMPILE_OPTIONS "-D_CRT_SECURE_NO_WARNINGS")
+    list(APPEND SOFACONFIG_COMPILE_OPTIONS "-D_CRT_NONSTDC_NO_DEPRECATE")
+
+    list(APPEND SOFACONFIG_COMPILE_OPTIONS "/MP;/wd4250;/wd4251;/wd4275;/wd4675;/wd4661")
     # 4661: no suitable definition provided for explicit template instantiation request
     # it happens because we put explicit instantiation in a separate translation unit
     # it is by design, so this warning is irrelevant in our project

--- a/SofaKernel/modules/SofaCore/src/sofa/core/MultiVecId.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/MultiVecId.h
@@ -194,7 +194,7 @@ protected:
     {
         if (!idMap_ptr)
             idMap_ptr.reset(new IdMap());
-        else if(!idMap_ptr.unique())
+        else if(!(idMap_ptr.use_count() == 1))
             idMap_ptr.reset(new IdMap(*idMap_ptr));
         return *idMap_ptr;
     }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataContentValue.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataContentValue.h
@@ -111,7 +111,7 @@ public:
 
     T* beginEdit()
     {
-        if(!ptr.unique())
+        if(!(ptr.use_count() == 1))
         {
             ptr.reset(new T(*ptr)); // a priori the Data will be modified -> copy
         }

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/thread/CTime.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/thread/CTime.cpp
@@ -69,7 +69,7 @@ ctime_t CTime::getRefTicksPerSec()
 
 void CTime::sleep(double a)
 {
-    _sleep((long)(a*1000.0));
+    Sleep((long)(a*1000.0));
 }
 
 #else /* WIN32 */

--- a/applications/plugins/SofaDistanceGrid/extlibs/miniFlowVR/CMakeLists.txt
+++ b/applications/plugins/SofaDistanceGrid/extlibs/miniFlowVR/CMakeLists.txt
@@ -44,6 +44,11 @@ if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xGNU" OR "x${CMAKE_CXX_COMPILER_ID}" ST
     target_compile_options(${PROJECT_NAME} PRIVATE "-fPIC")
 endif()
 
+if(WIN32)
+    # remove warnings about deprecation (CRT,etc)
+    target_compile_options(${PROJECT_NAME} PRIVATE "/wd4996")
+endif()
+
 include(SofaMacros)
 sofa_create_package_with_targets(
     PACKAGE_NAME MiniFlowVR

--- a/modules/SofaGuiQt/libQGLViewer-2.7.1/QGLViewer/CMakeLists.txt
+++ b/modules/SofaGuiQt/libQGLViewer-2.7.1/QGLViewer/CMakeLists.txt
@@ -99,7 +99,7 @@ target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "$<INSTALL_INTERFACE:in
 
 if(WIN32)
     target_compile_options(${PROJECT_NAME} PRIVATE "-DCREATE_QGLVIEWER_DLL")
-    target_compile_options(${PROJECT_NAME} PRIVATE "/wd4996")
+    target_compile_options(${PROJECT_NAME} PRIVATE "/wd4996") # remove warnings about deprecation (CRT,etc)
 endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES DEBUG_POSTFIX "_d")

--- a/modules/SofaGuiQt/libQGLViewer-2.7.1/QGLViewer/CMakeLists.txt
+++ b/modules/SofaGuiQt/libQGLViewer-2.7.1/QGLViewer/CMakeLists.txt
@@ -99,6 +99,7 @@ target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "$<INSTALL_INTERFACE:in
 
 if(WIN32)
     target_compile_options(${PROJECT_NAME} PRIVATE "-DCREATE_QGLVIEWER_DLL")
+    target_compile_options(${PROJECT_NAME} PRIVATE "/wd4996")
 endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES DEBUG_POSTFIX "_d")

--- a/modules/SofaSparseSolver/extlibs/csparse/CMakeLists.txt
+++ b/modules/SofaSparseSolver/extlibs/csparse/CMakeLists.txt
@@ -19,6 +19,11 @@ add_library(${PROJECT_NAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "$<INSTALL_INTERFACE:include/extlibs/CSparse>")
 
+if(WIN32)
+    # remove warnings about deprecation (CRT,etc)
+    target_compile_options(${PROJECT_NAME} PRIVATE "/wd4996")
+endif()
+
 sofa_create_package_with_targets(
     PACKAGE_NAME CSparse
     PACKAGE_VERSION ${PROJECT_VERSION}

--- a/modules/SofaSparseSolver/extlibs/metis-5.1.0/CMakeLists.txt
+++ b/modules/SofaSparseSolver/extlibs/metis-5.1.0/CMakeLists.txt
@@ -19,6 +19,11 @@ if(UNIX)
     target_link_libraries(${PROJECT_NAME} m)
 endif()
 
+if(WIN32)
+    # remove warnings about deprecation (CRT,etc)
+    target_compile_options(${PROJECT_NAME} PRIVATE "/wd4996")
+endif()
+
 sofa_create_package_with_targets(
     PACKAGE_NAME Metis
     PACKAGE_VERSION 5.1.0


### PR DESCRIPTION
1- MSVC was never throwing deprecation warnings because ... it was disabled with the compiler flags. A bit hard to inform the user that one feature or file is deprecated if he is not warned. 
So this PR re-enables 4996 (deprecation) warnings but still disable some msvc-specific deprecation notices (with some preprocessor defines)

2- A contrario, deprecation warnings in extlibs are quite annoying so they should be disabled IMO.

3- enabling deprecation warnings led to two types of deprecation in the SOFA code base:
 - _sleep() is deprecated (used for WIN32 only)
 - unique() of shared_ptr is deprecated in c++17 : https://en.cppreference.com/w/cpp/memory/shared_ptr/unique 
Replaced with use_count() == 1 but this does not really address the issue of approximation in a multithreaded context.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
