### PR TITLE
[All] Fix debug compilation

### DIFF
--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/RigidTypes.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/RigidTypes.h
@@ -34,6 +34,10 @@
 #include <cstdlib>
 #include <cmath>
 
+#if !defined(NDEBUG)
+#include <sofa/helper/logging/Messaging.h>
+#endif
+
 namespace sofa
 {
 

--- a/applications/plugins/SofaEulerianFluid/Grid2D.h
+++ b/applications/plugins/SofaEulerianFluid/Grid2D.h
@@ -26,8 +26,8 @@
 #include <sofa/type/Vec.h>
 #include <sofa/type/Mat.h>
 #include <sofa/helper/rmath.h>
+#include <sofa/helper/logging/Messaging.h>
 #include <iostream>
-
 
 namespace sofa
 {

--- a/applications/plugins/SofaEulerianFluid/Grid3D.h
+++ b/applications/plugins/SofaEulerianFluid/Grid3D.h
@@ -26,6 +26,7 @@
 #include <sofa/type/Vec.h>
 #include <sofa/type/Mat.h>
 #include <sofa/helper/rmath.h>
+#include <sofa/helper/logging/Messaging.h>
 #include <iostream>
 
 


### PR DESCRIPTION
When trying to compile in Debug mode:
- (GCC/Clang) a header is missing in RigidType
- (MSVC) same header is missing in two files in SofaEulerianFluid


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
