### PR TITLE
[SofaMeshCollision] Fix compilation without Compatiblity layer

### DIFF
--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/RayTriangleIntersection.cpp
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/RayTriangleIntersection.cpp
@@ -22,8 +22,8 @@
 #include <SofaMeshCollision/RayTriangleIntersection.h>
 
 #include <SofaMeshCollision/TriangleModel.h>
-#include <sofa/helper/LCPSolver.inl>
 #include <sofa/core/VecId.h>
+
 namespace sofa::component::collision
 {
 


### PR DESCRIPTION
... by removing a useless (and from the compatibility layer) in SofaMeshCollsion



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
