### PR TITLE
[Geomagic] Fix compilation of code with openHaptics due to sofa::type namespace missing.

### DIFF
--- a/applications/plugins/Geomagic/src/Geomagic/GeomagicDriver.cpp
+++ b/applications/plugins/Geomagic/src/Geomagic/GeomagicDriver.cpp
@@ -35,6 +35,7 @@ namespace sofa::component::controller
 {
     
 using namespace sofa::defaulttype;
+using namespace sofa::type;
 
 #if GEOMAGIC_HAVE_OPENHAPTICS
 // Method to get the first error on the deck and if logError is not set to false will pop up full error message before returning the error code.


### PR DESCRIPTION
Lines 97, 100 and 101 not compiling: https://github.com/sofa-framework/sofa/blob/cfda6846a2b3135ac88d6f7a0f363641a556cbf0/applications/plugins/Geomagic/src/Geomagic/GeomagicDriver.cpp#L97-L101

Errors not detected on the CI because inside #if GEOMAGIC_HAVE_OPENHAPTICS



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
