### PR TITLE
[SofaCore] Fix RotationFinder return type for child classes

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/RotationFinder.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/RotationFinder.h
@@ -47,7 +47,7 @@ public:
     typedef type::Mat< 3, 3, Real > Mat3x3;
 
     using BaseRotationFinder::getRotations;
-    virtual const type::vector< type::Mat3x3 >& getRotations() = 0;
+    virtual const type::vector< Mat3x3 >& getRotations() = 0;
 };
 
 } // namespace behavior


### PR DESCRIPTION
Return type of `getRotations()` should use the `typedef` type to respect the floating point precision of the template `DataTypes`

As it is now, it causes compilation errors when  using template `defaulttype::Vec3fTypes`






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
