### PR TITLE
[All] Update IDE directory for targets

### DIFF
--- a/SofaGui/CMakeLists.txt
+++ b/SofaGui/CMakeLists.txt
@@ -41,6 +41,8 @@ set(SOURCE_FILES
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC ${SOFAGUI_TARGETS})
 
+set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER SofaGui)
+
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}
     PACKAGE_VERSION ${Sofa_VERSION}

--- a/SofaKernel/SofaBase/CMakeLists.txt
+++ b/SofaKernel/SofaBase/CMakeLists.txt
@@ -28,6 +28,8 @@ set(SOURCE_FILES
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC ${SOFABASE_MODULES})
 
+set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER SofaBase)
+
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}
     PACKAGE_VERSION ${Sofa_VERSION}

--- a/SofaKernel/SofaFramework/CMakeLists.txt
+++ b/SofaKernel/SofaFramework/CMakeLists.txt
@@ -47,6 +47,8 @@ set(SOURCE_FILES
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC ${SOFAFRAMEWORK_MODULES})
 
+set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER SofaFramework)
+
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}
     PACKAGE_VERSION ${Sofa_VERSION}

--- a/SofaKernel/SofaSimulation/CMakeLists.txt
+++ b/SofaKernel/SofaSimulation/CMakeLists.txt
@@ -23,6 +23,8 @@ set(SOURCE_FILES
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC ${SOFASIMULATION_MODULES})
 
+set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER SofaSimulation)
+
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}
     PACKAGE_VERSION ${Sofa_VERSION}


### PR DESCRIPTION
Since a few updates of MSVC2019, it is not possible anymore to have at the same time a directory and a target with the same name and in the same level. 
For example, SofaBase (containing all the SofaBase targets) and SofaBase (the target). MSVC complains that it cannot create the SofaBase target and thus, it is not possible de compile it... which is a bit bothersome 🤔

So this PR moves (in an IDE-way) the target into their respective directory (SofaBase in the SofaBase directory, SofaSimulation/SofaFramework/SofaGui same). And it makes more sense to set it like that anyway.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
