### PR TITLE
[SofaBoundaryCondition] Fix ProjectToLineConstraint_RemovingMeshTest.scn

### DIFF
--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.h
@@ -145,6 +145,10 @@ protected :
 
     SparseMatrix jacobian; ///< projection matrix in local state
     SparseMatrix J;        ///< auxiliary variable
+
+    /// Resize/update Jacobian matrix according to the linked mechanical state and the direction
+    void updateJacobian();
+
 };
 
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.inl
@@ -144,11 +144,17 @@ void ProjectToLineConstraint<DataTypes>::init()
         }
     }
 
-    reinit();
+    updateJacobian();
 }
 
 template <class DataTypes>
 void  ProjectToLineConstraint<DataTypes>::reinit()
+{
+    updateJacobian();
+}
+
+template <class DataTypes>
+void  ProjectToLineConstraint<DataTypes>::updateJacobian()
 {
     // normalize the normal vector
     CPos n = f_direction.getValue();
@@ -208,8 +214,13 @@ template <class DataTypes>
 void ProjectToLineConstraint<DataTypes>::projectResponse(const core::MechanicalParams* mparams, DataVecDeriv& resData)
 {
     SOFA_UNUSED(mparams);
+    
+    helper::WriteAccessor<DataVecDeriv> res(resData);
+    if( (jacobian.colSize() / DataTypes::deriv_total_size) != res.size())
+    {
+        updateJacobian();
+    }
 
-    helper::WriteAccessor<DataVecDeriv> res ( resData );
     jacobian.mult(res.wref(),res.ref());
 }
 


### PR DESCRIPTION
Detected by the CI sporadically.
The crash is triggered "correctly" when executing in Debug mode.

The problem comes from the fact that the stored Jacobian matrix is not updated when the model (i.e mechanicalObject) is modified topologically.
There are some problems still with topological changes (#2242 ) so I opted for a check every time projectResponse() is called.
Not ideal so would need to be changed once topological changes mechanism is finished.

Also create a updateJacobian() method (instead of reinit())



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
