### PR TITLE
[SofaBaseTopology] Add missing export symbol keyword for TopologySubsetData

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologySubsetData.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologySubsetData.cpp
@@ -26,6 +26,6 @@
 namespace sofa::component::topology
 {
 
-template class TopologySubsetData<Index, sofa::type::vector<Index>>;
+template class SOFA_SOFABASETOPOLOGY_API TopologySubsetData<Index, sofa::type::vector<Index>>;
 
 } // namespace sofa::component::topology


### PR DESCRIPTION
Title says all.
I am still wondering why we did not encounter the problem before 🤔 (happening while doing sofang)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
