### PR TITLE
[SofaConstraint] Remove dependency on TetrahedronFEMForcefield

### DIFF
--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.h
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.h
@@ -28,6 +28,7 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/type/Mat.h>
 #include <sofa/core/behavior/BaseRotationFinder.h>
+#include <sofa/core/behavior/RotationFinder.h>
 #include <sofa/helper/OptionsGroup.h>
 
 #include <sofa/helper/ColorMap.h>
@@ -78,10 +79,10 @@ public:
 *   Corotational methods are based on a rotation from world-space to material-space.
 */
 template<class DataTypes>
-class TetrahedronFEMForceField : public core::behavior::ForceField<DataTypes>, public sofa::core::behavior::BaseRotationFinder
+class TetrahedronFEMForceField : public core::behavior::ForceField<DataTypes>, public sofa::core::behavior::RotationFinder<DataTypes>
 {
 public:
-    SOFA_CLASS2(SOFA_TEMPLATE(TetrahedronFEMForceField, DataTypes), SOFA_TEMPLATE(core::behavior::ForceField, DataTypes), core::behavior::BaseRotationFinder);
+    SOFA_CLASS2(SOFA_TEMPLATE(TetrahedronFEMForceField, DataTypes), SOFA_TEMPLATE(core::behavior::ForceField, DataTypes), SOFA_TEMPLATE(core::behavior::RotationFinder, DataTypes));
 
     typedef typename core::behavior::ForceField<DataTypes> InheritForceField;
     typedef typename DataTypes::VecCoord VecCoord;
@@ -174,9 +175,15 @@ public:
     Real getRestVolume() {return m_restVolume;}
 
     //For a faster contact handling with simplified compliance
-    void getRotation(Transformation& R, Index nodeIdx);
+    void getRotation(Mat33& R, Index nodeIdx);
     void getRotations(VecReal& vecR) ;
-    void getRotations(defaulttype::BaseMatrix * rotations,int offset = 0) override ;
+    
+    // BaseRotationFinder API
+    void getRotations(defaulttype::BaseMatrix * rotations,int offset = 0) override;
+    // RotationFinder<T> API
+    type::vector< Mat33 > m_rotations;
+    const type::vector<Mat33>& getRotations() override;
+
     Data< VecCoord > _initialPoints; ///< the initial positions of the points
     int method;
     Data<std::string> f_method; ///< the computation method of the displacements

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.h
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.h
@@ -27,7 +27,6 @@
 #include <sofa/type/vector.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/type/Mat.h>
-#include <sofa/core/behavior/BaseRotationFinder.h>
 #include <sofa/core/behavior/RotationFinder.h>
 #include <sofa/helper/OptionsGroup.h>
 

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.inl
@@ -844,7 +844,7 @@ inline void TetrahedronFEMForceField<DataTypes>::computeRotationLarge( Transform
 
 //HACK get rotation for fast contact handling with simplified compliance
 template<class DataTypes>
-inline void TetrahedronFEMForceField<DataTypes>::getRotation(Transformation& R, unsigned int nodeIdx)
+inline void TetrahedronFEMForceField<DataTypes>::getRotation(Mat33& R, unsigned int nodeIdx)
 { 
     if(method == SMALL)
     {
@@ -852,7 +852,7 @@ inline void TetrahedronFEMForceField<DataTypes>::getRotation(Transformation& R, 
         R[0][1] = 0.0 ; R[0][2] = 0.0 ;
         R[1][0] = 0.0 ; R[1][2] = 0.0 ;
         R[2][0] = 0.0 ; R[2][1] = 0.0 ;
-        msg_warning() << "getRotation called but no rotation comptued because case== SMALL";
+        msg_warning() << "getRotation called but no rotation computed because case== SMALL";
         return;
     }
 
@@ -2314,6 +2314,22 @@ void TetrahedronFEMForceField<DataTypes>::getRotations(defaulttype::BaseMatrix *
             rotations->set(e+2,e+0,t[2][0]); rotations->set(e+2,e+1,t[2][1]); rotations->set(e+2,e+2,t[2][2]);
         }
     }
+}
+
+
+template<class DataTypes>
+const type::vector< typename TetrahedronFEMForceField<DataTypes>::Mat33 >& TetrahedronFEMForceField<DataTypes>::getRotations()
+{
+    const auto nbDOFs = this->mstate->getSize();
+
+    m_rotations.resize(nbDOFs);
+
+    for (auto i = 0; i < nbDOFs; ++i)
+    {
+        getRotation(m_rotations[i], i);
+    }
+
+    return m_rotations;
 }
 
 template<class DataTypes>

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.inl
@@ -1320,7 +1320,7 @@ TetrahedronFEMForceField<DataTypes>::~TetrahedronFEMForceField()
 template <class DataTypes>
 void TetrahedronFEMForceField<DataTypes>::init()
 {
-    d_componentState.setValue(ComponentState::Invalid) ;
+    this->d_componentState.setValue(ComponentState::Invalid) ;
 
     const VecReal& youngModulus = _youngModulus.getValue();
     minYoung=youngModulus[0];
@@ -1442,7 +1442,7 @@ void TetrahedronFEMForceField<DataTypes>::init()
        _indexedElements = tetrahedra;
     }
 
-    d_componentState.setValue(ComponentState::Valid) ;
+    this->d_componentState.setValue(ComponentState::Valid) ;
 
     reinit(); // compute per-element stiffness matrices and other precomputed values
 
@@ -1463,7 +1463,7 @@ void TetrahedronFEMForceField<DataTypes>::reset()
 template <class DataTypes>
 inline void TetrahedronFEMForceField<DataTypes>::reinit()
 {
-    if(d_componentState.getValue() == ComponentState::Invalid)
+    if(this->d_componentState.getValue() == ComponentState::Invalid)
         return ;
 
     if (!this->mstate || !m_topology){
@@ -1747,7 +1747,7 @@ void TetrahedronFEMForceField<DataTypes>::computeBBox(const core::ExecParams*, b
 template<class DataTypes>
 void TetrahedronFEMForceField<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
-    if(d_componentState.getValue() == ComponentState::Invalid)
+    if(this->d_componentState.getValue() == ComponentState::Invalid)
         return ;
 
     if (!vparams->displayFlags().getShowForceFields()) return;

--- a/modules/SofaConstraint/CMakeLists.txt
+++ b/modules/SofaConstraint/CMakeLists.txt
@@ -80,11 +80,10 @@ list(APPEND SOURCE_FILES
 sofa_find_package(SofaBase REQUIRED) # SofaBaseLinearSolver
 sofa_find_package(SofaImplicitOdeSolver REQUIRED)  
 sofa_find_package(SofaMeshCollision REQUIRED)
-sofa_find_package(SofaSimpleFem REQUIRED)
 sofa_find_package(SofaUserInteraction REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaMeshCollision SofaSimpleFem SofaImplicitOdeSolver SofaUserInteraction SofaBaseLinearSolver)
+target_link_libraries(${PROJECT_NAME} PUBLIC SofaMeshCollision SofaImplicitOdeSolver SofaUserInteraction SofaBaseLinearSolver)
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaEigen2Solver)
 
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/modules/SofaConstraint/src/SofaConstraint/PrecomputedConstraintCorrection.inl
+++ b/modules/SofaConstraint/src/SofaConstraint/PrecomputedConstraintCorrection.inl
@@ -32,8 +32,6 @@
 #include <SofaBaseLinearSolver/SparseMatrix.h>
 #include <SofaBaseLinearSolver/CGLinearSolver.h>
 
-#include <SofaSimpleFem/TetrahedronFEMForceField.inl>
-
 #include <sofa/core/behavior/RotationFinder.h>
 
 #include <sofa/helper/system/FileRepository.h>
@@ -798,50 +796,34 @@ void PrecomputedConstraintCorrection< DataTypes >::draw(const core::visual::Visu
 
     vparams->drawTool()->saveLastState();
 
-    using sofa::component::forcefield::TetrahedronFEMForceField;
     using sofa::core::behavior::RotationFinder;
 
     // we draw the rotations associated to each node //
 
     simulation::Node *node = dynamic_cast< simulation::Node* >(this->getContext());
 
-    TetrahedronFEMForceField< DataTypes >* forceField = nullptr;
     RotationFinder< DataTypes > * rotationFinder = nullptr;
 
     if (node != nullptr)
     {
-        forceField = node->get< TetrahedronFEMForceField< DataTypes > > ();
-        if (forceField == nullptr)
+        rotationFinder = node->get< RotationFinder< DataTypes > > ();
+        if (rotationFinder == nullptr)
         {
-            rotationFinder = node->get< RotationFinder< DataTypes > > ();
-            if (rotationFinder == nullptr)
-            {
-                msg_warning() << "No rotation defined : only defined for TetrahedronFEMForceField and RotationFinder!";
-                return;
-            }
+            return;
         }
     }
 
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
+    const auto& rotations = rotationFinder->getRotations();
     for (unsigned int i=0; i< x.size(); i++)
     {
-        Transformation Ri;
-        if (forceField != nullptr)
-        {
-            forceField->getRotation(Ri, i);
-        }
-        else // rotationFinder has been defined
-        {
-            Ri = rotationFinder->getRotations()[i];
-        }
-
         sofa::type::Matrix3 RotMat;
 
         for (unsigned int a=0; a<3; a++)
         {
             for (unsigned int b=0; b<3; b++)
             {
-                RotMat[a][b] = Ri(a,b);
+                RotMat[a][b] = rotations[i](a,b);
             }
         }
 
@@ -858,7 +840,6 @@ void PrecomputedConstraintCorrection< DataTypes >::draw(const core::visual::Visu
 template< class DataTypes >
 void PrecomputedConstraintCorrection< DataTypes >::rotateConstraints(bool back)
 {
-    using sofa::component::forcefield::TetrahedronFEMForceField;
     using sofa::core::behavior::RotationFinder;
 
     helper::WriteAccessor<Data<MatrixDeriv> > cData = *this->mstate->write(core::MatrixDerivId::constraintJacobian());
@@ -866,20 +847,15 @@ void PrecomputedConstraintCorrection< DataTypes >::rotateConstraints(bool back)
 
     simulation::Node *node = dynamic_cast< simulation::Node * >(this->getContext());
 
-    TetrahedronFEMForceField< DataTypes >* forceField = nullptr;
     RotationFinder< DataTypes >* rotationFinder = nullptr;
 
     if (node != nullptr)
     {
-        forceField = node->get< TetrahedronFEMForceField< DataTypes > > ();
-        if (forceField == nullptr)
+        rotationFinder = node->get< RotationFinder< DataTypes > > ();
+        if (rotationFinder == nullptr)
         {
-            rotationFinder = node->get< RotationFinder< DataTypes > > ();
-            if (rotationFinder == nullptr)
-            {
-                msg_warning() << "No rotation defined : only defined for TetrahedronFEMForceField and RotationFinder!";
-                return;
-            }
+            msg_warning() << "No rotation defined : only applicable for components implementing RotationFinder!";
+            return;
         }
     }
     else
@@ -891,6 +867,8 @@ void PrecomputedConstraintCorrection< DataTypes >::rotateConstraints(bool back)
     // on fait tourner les normales (en les ramenant dans le "pseudo" repere initial) //
     MatrixDerivRowIterator rowItEnd = c.end();
 
+    Transformation Ri;
+    auto rotations = rotationFinder->getRotations();
     for (MatrixDerivRowIterator rowIt = c.begin(); rowIt != rowItEnd; ++rowIt)
     {
         MatrixDerivColIterator colItEnd = rowIt.end();
@@ -899,22 +877,15 @@ void PrecomputedConstraintCorrection< DataTypes >::rotateConstraints(bool back)
         {
             Deriv& n = colIt.val();
             const int localRowNodeIdx = colIt.index();
-            Transformation Ri;
 
-            if (forceField != nullptr)
-            {
-                forceField->getRotation(Ri, localRowNodeIdx);
-            }
-            else // rotationFinder has been defined
-            {
-                Ri = rotationFinder->getRotations()[localRowNodeIdx];
-            }
+            // rotationFinder has been defined
+            Ri = rotations[localRowNodeIdx];
 
             if(!back)
                 Ri.transpose();
 
             // on passe les normales du repere global au repere local
-            Deriv n_i = Ri * n;
+            const Deriv n_i = Ri * n;
             n.x() =  n_i.x();
             n.y() =  n_i.y();
             n.z() =  n_i.z();
@@ -930,20 +901,15 @@ void PrecomputedConstraintCorrection<DataTypes>::rotateResponse()
 
     using sofa::core::behavior::RotationFinder;
 
-    sofa::component::forcefield::TetrahedronFEMForceField<DataTypes>* forceField = nullptr;
     RotationFinder< DataTypes >* rotationFinder = nullptr;
 
     if (node != nullptr)
     {
-        forceField = node->get<component::forcefield::TetrahedronFEMForceField<DataTypes> > ();
-        if (forceField == nullptr)
+        rotationFinder = node->get< RotationFinder< DataTypes > > ();
+        if (rotationFinder == nullptr)
         {
-            rotationFinder = node->get< RotationFinder< DataTypes > > ();
-            if (rotationFinder == nullptr)
-            {
-                msg_warning() << "No rotation defined : only defined for TetrahedronFEMForceField and RotationFinder!";
-                return;
-            }
+            msg_warning() << "No rotation defined : only applicable for components implementing RotationFinder!";
+            return;
         }
     }
     else
@@ -954,19 +920,12 @@ void PrecomputedConstraintCorrection<DataTypes>::rotateResponse()
 
     helper::WriteAccessor<Data<VecDeriv> > dxData = *this->mstate->write(core::VecDerivId::dx());
     VecDeriv& dx = dxData.wref();
+    const auto& rotations = rotationFinder->getRotations();
+
     for(unsigned int j = 0; j < dx.size(); j++)
     {
-        Transformation Rj;
-        if (forceField != nullptr)
-        {
-            forceField->getRotation(Rj, j);
-        }
-        else // rotationFinder has been defined
-        {
-            Rj = rotationFinder->getRotations()[j];
-        }
         // on passe les deplacements du repere local au repere global
-        Deriv temp = Rj * dx[j];
+        Deriv temp = rotations[j] * dx[j];
         dx[j] = temp;
     }
 }

--- a/modules/SofaConstraint/src/SofaConstraint/PrecomputedConstraintCorrection.inl
+++ b/modules/SofaConstraint/src/SofaConstraint/PrecomputedConstraintCorrection.inl
@@ -868,7 +868,7 @@ void PrecomputedConstraintCorrection< DataTypes >::rotateConstraints(bool back)
     MatrixDerivRowIterator rowItEnd = c.end();
 
     Transformation Ri;
-    auto rotations = rotationFinder->getRotations();
+    const auto& rotations = rotationFinder->getRotations();
     for (MatrixDerivRowIterator rowIt = c.begin(); rowIt != rowItEnd; ++rowIt)
     {
         MatrixDerivColIterator colItEnd = rowIt.end();
@@ -925,8 +925,7 @@ void PrecomputedConstraintCorrection<DataTypes>::rotateResponse()
     for(unsigned int j = 0; j < dx.size(); j++)
     {
         // on passe les deplacements du repere local au repere global
-        Deriv temp = rotations[j] * dx[j];
-        dx[j] = temp;
+        dx[j] = rotations[j] * dx[j];
     }
 }
 

--- a/modules/SofaPreconditioner/CMakeLists.txt
+++ b/modules/SofaPreconditioner/CMakeLists.txt
@@ -37,12 +37,11 @@ list(APPEND SOURCE_FILES
 
 # Dependencies
 sofa_find_package(SofaImplicitOdeSolver REQUIRED)
-sofa_find_package(SofaSimpleFem REQUIRED)
 sofa_find_package(SofaGeneralLinearSolver REQUIRED)
 sofa_find_package(SofaSparseSolver QUIET) # Soft dependency of PrecomputedWarpPreconditioner
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaImplicitOdeSolver SofaGeneralLinearSolver SofaSimpleFem)
+target_link_libraries(${PROJECT_NAME} PUBLIC SofaImplicitOdeSolver SofaGeneralLinearSolver)
 if(SofaSparseSolver_FOUND)
     target_link_libraries(${PROJECT_NAME} PUBLIC SofaSparseSolver)
 endif()

--- a/modules/SofaPreconditioner/src/SofaPreconditioner/PrecomputedWarpPreconditioner.inl
+++ b/modules/SofaPreconditioner/src/SofaPreconditioner/PrecomputedWarpPreconditioner.inl
@@ -33,7 +33,6 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <cmath>
 #include <sofa/helper/system/thread/CTime.h>
-#include <SofaSimpleFem/TetrahedronFEMForceField.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <SofaBaseLinearSolver/MatrixLinearSolver.h>
 #include <sofa/helper/system/thread/CTime.h>
@@ -473,39 +472,16 @@ void PrecomputedWarpPreconditioner<TDataTypes>::rotateConstraints()
     if (! use_rotations.getValue()) return;
 
     simulation::Node *node = dynamic_cast<simulation::Node *>(this->getContext());
-    sofa::component::forcefield::TetrahedronFEMForceField<TDataTypes>* forceField = nullptr;
     sofa::core::behavior::RotationFinder<TDataTypes>* rotationFinder = nullptr;
 
     if (node != nullptr)
     {
-        forceField = node->get<component::forcefield::TetrahedronFEMForceField<TDataTypes> > ();
-        if (forceField == nullptr)
-        {
-            rotationFinder = node->get< sofa::core::behavior::RotationFinder<TDataTypes> > ();
-
-            msg_info_when(rotationFinder == nullptr) << "No rotation defined : only defined for TetrahedronFEMForceField and RotationFinder!";
-        }
+        rotationFinder = node->get< sofa::core::behavior::RotationFinder<TDataTypes> > ();
+        msg_info_when(rotationFinder == nullptr) << "No rotation defined : only applicable for components implementing RotationFinder!";
     }
 
     Transformation Rotation;
-    if (forceField != nullptr)
-    {
-        for(unsigned int k = 0; k < nb_dofs; k++)
-        {
-            int pid;
-            pid = k;
-
-            forceField->getRotation(Rotation, pid);
-            for (int j=0; j<3; j++)
-            {
-                for (int i=0; i<3; i++)
-                {
-                    R[k*9+j*3+i] = (Real)Rotation[j][i];
-                }
-            }
-        }
-    }
-    else if (rotationFinder != nullptr)
+    if (rotationFinder != nullptr)
     {
         const type::vector<type::Mat<3,3,Real> > & rotations = rotationFinder->getRotations();
         for(unsigned int k = 0; k < nb_dofs; k++)

--- a/modules/SofaPreconditioner/src/SofaPreconditioner/WarpPreconditioner.h
+++ b/modules/SofaPreconditioner/src/SofaPreconditioner/WarpPreconditioner.h
@@ -26,7 +26,6 @@
 #include <sofa/simulation/MechanicalVisitor.h>
 #include <sofa/core/behavior/LinearSolver.h>
 #include <sofa/core/behavior/MechanicalState.h>
-#include <SofaSimpleFem/TetrahedronFEMForceField.h>
 #include <sofa/type/Mat.h>
 #include <SofaBaseLinearSolver/FullVector.h>
 #include <cmath>


### PR DESCRIPTION
TL;DR (dev): Remove direct dependency in SofaConstraint&SofaPrecond on SofaSimpleFEM by implementing a function in TetraFEM.
TL;DR (user): Using PrecomputedConstraintCorrection with `rotations="true"` now **requires** to have a RotationFinder.


PrecomputedConstraintCorrection has a hard dependency on TetrahedronFEMForceField, to get rotations.
(hence calling a a function of TetraFEM)
It can also get rotations if it detects a component implemented RotationFinder<T>.
But TetrahedronFEMForceField is already implementing BaseRotationFinder taking a BaseMatrix*.
RotationFinder<T> inherits BaseRotationFinder, so I made TetrahedronFEMForceField implementing RotationFinder<T> instead. (which adds an other method to implement)
Finally, PrecomputedConstraintCorrection only needs RotationFinder<T> now.

IMO, 
- BaseRotationFinder implemented in TetrahedronFEM & HexahedronFEM only and used in WarpPreconditioner;
- RotationFinder<T> (implemented by nobody in the sofacode base but apparently by one external plugin @pedroperrusi) and used by PrecomputedConstraintCorrection, WarpPreconditioner and PrecomputedWarpPreconditioner;

would really need a refactoring or some re-working.
Those two were defined more or less in the same time, in 2006 (!) in the early days of SOFA.

Some cleaning in PrecomputedConstraintCorrection as well
and this PR made me wonder the never-defined preprocessor definition NEW_METHOD_UNBUILT in PrecomputedConstraintCorrection  (@ChristianDuriez ?)

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
