### PR TITLE
[SofaRigid] Clean JointSpring

### DIFF
--- a/SofaKernel/modules/SofaRigid/src/SofaRigid/JointSpringForceField.h
+++ b/SofaKernel/modules/SofaRigid/src/SofaRigid/JointSpringForceField.h
@@ -23,9 +23,7 @@
 #include <SofaRigid/config.h>
 
 #include <sofa/core/objectmodel/DataFileName.h>
-
 #include <sofa/core/behavior/PairInteractionForceField.h>
-#include <SofaRigid/JointSpring.h>
 
 namespace sofa::component::interactionforcefield
 {
@@ -40,8 +38,6 @@ public:
 template<typename DataTypes>
 class JointSpring;
 
-template<typename DataTypes>
-class JointSpring;
 
 /** JointSpringForceField simulates 6D springs between Rigid DOFS
   Use kst vector to specify the directionnal stiffnesses (on each local axe)
@@ -165,9 +161,8 @@ public:
 
 };
 
-#if  !defined(SOFA_COMPONENT_FORCEFIELD_JOINTSPRINGFORCEFIELD_CPP)
-extern template class SOFA_SOFARIGID_API JointSpring<defaulttype::Rigid3Types>;
+#if !defined(SOFA_COMPONENT_FORCEFIELD_JOINTSPRINGFORCEFIELD_CPP)
 extern template class SOFA_SOFARIGID_API JointSpringForceField<defaulttype::Rigid3Types>;
-
 #endif
+
 } // namespace sofa::component::interactionforcefield

--- a/SofaKernel/modules/SofaRigid/src/SofaRigid/JointSpringForceField.inl
+++ b/SofaKernel/modules/SofaRigid/src/SofaRigid/JointSpringForceField.inl
@@ -23,6 +23,7 @@
 #include <SofaRigid/JointSpringForceField.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/MechanicalParams.h>
+#include <SofaRigid/JointSpring.h>
 #include <fstream>
 
 namespace sofa::component::interactionforcefield

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QModelViewTableDataContainer.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QModelViewTableDataContainer.h
@@ -36,6 +36,7 @@
 #include <QStandardItemModel>
 
 #include <sofa/helper/deque.h>
+#include <SofaRigid/JointSpring.h>
 
 namespace sofa::gui::qt
 {

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QModelViewTableDataContainer.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QModelViewTableDataContainer.h
@@ -36,7 +36,6 @@
 #include <QStandardItemModel>
 
 #include <sofa/helper/deque.h>
-#include <SofaRigid/JointSpring.h>
 
 namespace sofa::gui::qt
 {

--- a/modules/SofaGuiQt/src/sofa/gui/qt/StructDataWidget.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/StructDataWidget.h
@@ -23,6 +23,7 @@
 #include "SimpleDataWidget.h"
 #include <sofa/defaulttype/RigidTypes.h>
 #include <SofaDeformable/SpringForceField.h>
+#include <SofaRigid/JointSpring.h>
 #include <SofaRigid/JointSpringForceField.h>
 #include <SofaMiscForceField/GearSpringForceField.h>
 /* #include <../../../projects/vulcain/lib/DiscreteElementModel.h> */


### PR DESCRIPTION
- useless external instanciation of JointSpring in JointSpringFF (because already defined in JointSpring,h)
- remove duplicate forward declaration
- use actual forward declaration and move JointSpring header



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
