### PR TITLE
[SofaBoundaryCondition][SofaConstraint] FIX dependency and export symbols

### DIFF
--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.inl
@@ -21,16 +21,12 @@
 ******************************************************************************/
 #pragma once
 
+#include <SofaBoundaryCondition/FixedConstraint.h>
 #include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
-#include <SofaBoundaryCondition/FixedConstraint.h>
-#include <SofaBaseLinearSolver/SparseMatrix.h>
 #include <sofa/core/visual/VisualParams.h>
-#include <sofa/defaulttype/RigidTypes.h>
-#include <iostream>
 #include <sofa/type/vector_algorithm.h>
 
-#include <sofa/core/objectmodel/BaseObject.h>
 using sofa::core::objectmodel::ComponentState;
 
 

--- a/modules/SofaConstraint/src/SofaConstraint/ContactIdentifier.cpp
+++ b/modules/SofaConstraint/src/SofaConstraint/ContactIdentifier.cpp
@@ -24,7 +24,20 @@
 namespace sofa::component::collision
 {
 
-sofa::core::collision::DetectionOutput::ContactId ContactIdentifier::cpt = 0;
-std::list<sofa::core::collision::DetectionOutput::ContactId> ContactIdentifier::availableId;
+ContactIdentifier::ContactIdentifier()
+{
+    if (!availableId.empty())
+    {
+        id = availableId.front();
+        availableId.pop_front();
+    }
+    else
+        id = cpt++;
+}
+
+ContactIdentifier::~ContactIdentifier()
+{
+    availableId.push_back(id);
+}
 
 } //namespace sofa::component::collision

--- a/modules/SofaConstraint/src/SofaConstraint/ContactIdentifier.h
+++ b/modules/SofaConstraint/src/SofaConstraint/ContactIdentifier.h
@@ -32,26 +32,13 @@ namespace sofa::component::collision
 class SOFA_SOFACONSTRAINT_API ContactIdentifier
 {
 public:
-    ContactIdentifier()
-    {
-        if (!availableId.empty())
-        {
-            id = availableId.front();
-            availableId.pop_front();
-        }
-        else
-            id = cpt++;
-    }
-
-    virtual ~ContactIdentifier()
-    {
-        availableId.push_back(id);
-    }
+    ContactIdentifier();
+    virtual ~ContactIdentifier();
 
 protected:
-    static sofa::core::collision::DetectionOutput::ContactId cpt;
+    inline static sofa::core::collision::DetectionOutput::ContactId cpt = 0;
     sofa::core::collision::DetectionOutput::ContactId id;
-    static std::list<sofa::core::collision::DetectionOutput::ContactId> availableId;
+    inline static std::list<sofa::core::collision::DetectionOutput::ContactId> availableId;
 };
 
 inline long cantorPolynomia(sofa::core::collision::DetectionOutput::ContactId x, sofa::core::collision::DetectionOutput::ContactId y)


### PR DESCRIPTION
Small batch from Sofa-NG:
- FixedConstraint 
  - remove useless dep on SparseMatrix (thus on SofaBaseLinearSolver)
  - remove other useless includes
- ContactIdentifier 
  - use C++17 static inline initialization (solve export symbol problem)
  - move ctor/dtor definition into the cpp  



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
