### PR TITLE
[SofaMiscForceField] Fix massDensity vector update when adding new elements in MeshMatrixMass

### DIFF
--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.h
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.h
@@ -177,6 +177,10 @@ public:
     virtual void setMassDensity(sofa::type::vector< Real > massDensity);
     virtual void setMassDensity(Real massDensityValue);
     virtual void setTotalMass(Real totalMass);
+
+    virtual void addMassDensity(const sofa::type::vector< Index >& indices,        
+        const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+        const sofa::type::vector< sofa::type::vector< double > >& coefs);
     /// @}
 
 
@@ -253,73 +257,73 @@ protected:
 
         /// Mass coefficient Creation/Destruction functions for Triangular Mesh:
         /// Vertex coefficient of mass matrix creation function to handle creation of new triangles
-        void applyTriangleCreation(const sofa::type::vector< Index >& /*indices*/,
-                const sofa::type::vector< core::topology::BaseMeshTopology::Triangle >& /*elems*/,
-                const sofa::type::vector< sofa::type::vector< Index > >& /*ancestors*/,
-                const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
+        void applyTriangleCreation(const sofa::type::vector< Index >& triangleAdded,
+                const sofa::type::vector< core::topology::BaseMeshTopology::Triangle >& elems,
+                const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+                const sofa::type::vector< sofa::type::vector< double > >& coefs);
 
         /// Vertex coefficient of mass matrix destruction function to handle creation of new triangles
-        void applyTriangleDestruction(const sofa::type::vector<Index> & /*indices*/);
+        void applyTriangleDestruction(const sofa::type::vector<Index> & triangleRemoved);
 
         using topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point,MassVector>::ApplyTopologyChange;
         /// Callback to add triangles elements.
-        void ApplyTopologyChange(const core::topology::TrianglesAdded* /*event*/);
+        void ApplyTopologyChange(const core::topology::TrianglesAdded* topoEvent);
         /// Callback to remove triangles elements.
-        void ApplyTopologyChange(const core::topology::TrianglesRemoved* /*event*/);
+        void ApplyTopologyChange(const core::topology::TrianglesRemoved* topoEvent);
 
 
         ///////////////////////// Functions on Quads //////////////////////////////////////
 
         /// Mass coefficient Creation/Destruction functions for Quad Mesh:
         /// Vertex coefficient of mass matrix creation function to handle creation of new quads
-        void applyQuadCreation(const sofa::type::vector< Index >& /*indices*/,
-                const sofa::type::vector< core::topology::BaseMeshTopology::Quad >& /*elems*/,
-                const sofa::type::vector< sofa::type::vector< Index > >& /*ancestors*/,
-                const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
+        void applyQuadCreation(const sofa::type::vector< Index >& quadAdded,
+                const sofa::type::vector< core::topology::BaseMeshTopology::Quad >& elems,
+                const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+                const sofa::type::vector< sofa::type::vector< double > >& coefs);
 
         /// Vertex coefficient of mass matrix destruction function to handle creation of new quads
-        void applyQuadDestruction(const sofa::type::vector<Index> & /*indices*/);
+        void applyQuadDestruction(const sofa::type::vector<Index> & quadRemoved);
 
         /// Callback to add quads elements.
-        void ApplyTopologyChange(const core::topology::QuadsAdded* /*event*/);
+        void ApplyTopologyChange(const core::topology::QuadsAdded* topoEvent);
         /// Callback to remove quads elements.
-        void ApplyTopologyChange(const core::topology::QuadsRemoved* /*event*/);
+        void ApplyTopologyChange(const core::topology::QuadsRemoved* topoEvent);
 
 
         ///////////////////////// Functions on Tetrahedron //////////////////////////////////////
 
         /// Mass coefficient Creation/Destruction functions for Tetrahedral Mesh:
         /// Vertex coefficient of mass matrix creation function to handle creation of new tetrahedra
-        void applyTetrahedronCreation(const sofa::type::vector< Index >& /*indices*/,
-                const sofa::type::vector< core::topology::BaseMeshTopology::Tetrahedron >& /*elems*/,
-                const sofa::type::vector< sofa::type::vector< Index > >& /*ancestors*/,
-                const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
+        void applyTetrahedronCreation(const sofa::type::vector< Index >& tetrahedronAdded,
+                const sofa::type::vector< core::topology::BaseMeshTopology::Tetrahedron >& elems,
+                const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+                const sofa::type::vector< sofa::type::vector< double > >& coefs);
 
         /// Vertex coefficient of mass matrix destruction function to handle creation of new tetrahedra
-        void applyTetrahedronDestruction(const sofa::type::vector<Index> & /*indices*/);
+        void applyTetrahedronDestruction(const sofa::type::vector<Index> & tetrahedronRemoved);
 
         /// Callback to add tetrahedron elements.
-        void ApplyTopologyChange(const core::topology::TetrahedraAdded* /*event*/);
+        void ApplyTopologyChange(const core::topology::TetrahedraAdded* topoEvent);
         /// Callback to remove tetrahedron elements.
-        void ApplyTopologyChange(const core::topology::TetrahedraRemoved* /*event*/);
+        void ApplyTopologyChange(const core::topology::TetrahedraRemoved* topoEvent);
 
 
         ///////////////////////// Functions on Hexahedron //////////////////////////////////////
 
         /// Mass coefficient Creation/Destruction functions for Hexahedral Mesh:
         /// Vertex coefficient of mass matrix creation function to handle creation of new hexahedra
-        void applyHexahedronCreation(const sofa::type::vector< Index >& /*indices*/,
-                const sofa::type::vector< core::topology::BaseMeshTopology::Hexahedron >& /*elems*/,
-                const sofa::type::vector< sofa::type::vector< Index > >& /*ancestors*/,
-                const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
+        void applyHexahedronCreation(const sofa::type::vector< Index >& hexahedronAdded,
+                const sofa::type::vector< core::topology::BaseMeshTopology::Hexahedron >& elems,
+                const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+                const sofa::type::vector< sofa::type::vector< double > >& coefs);
 
         /// Vertex coefficient of mass matrix destruction function to handle creation of new hexahedra
-        void applyHexahedronDestruction(const sofa::type::vector<Index> & /*indices*/);
+        void applyHexahedronDestruction(const sofa::type::vector<Index> & hexahedronRemoved);
 
         /// Callback to add hexahedron elements.
-        virtual void ApplyTopologyChange(const core::topology::HexahedraAdded* /*event*/);
+        virtual void ApplyTopologyChange(const core::topology::HexahedraAdded* topoEvent);
          /// Callback to remove hexahedron elements.
-        virtual void ApplyTopologyChange(const core::topology::HexahedraRemoved* /*event*/);
+        virtual void ApplyTopologyChange(const core::topology::HexahedraRemoved* topoEvent);
 
     protected:
         MeshMatrixMass<DataTypes,TMassType>* m;
@@ -345,69 +349,69 @@ protected:
         ///////////////////////// Functions on Triangles //////////////////////////////////////
 
         /// Edge coefficient of mass matrix creation function to handle creation of new triangles
-        void applyTriangleCreation(const sofa::type::vector< Index >& /*indices*/,
-                const sofa::type::vector< core::topology::BaseMeshTopology::Triangle >& /*elems*/,
-                const sofa::type::vector< sofa::type::vector< Index > >& /*ancestors*/,
-                const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
+        void applyTriangleCreation(const sofa::type::vector< Index >& triangleAdded,
+                const sofa::type::vector< core::topology::BaseMeshTopology::Triangle >& elems,
+                const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+                const sofa::type::vector< sofa::type::vector< double > >& coefs);
 
         /// Edge coefficient of mass matrix destruction function to handle creation of new triangles
-        void applyTriangleDestruction(const sofa::type::vector<Index> & /*indices*/);
+        void applyTriangleDestruction(const sofa::type::vector<Index> & triangleRemoved);
 
         /// Callback to add triangles elements.
-        void ApplyTopologyChange(const core::topology::TrianglesAdded* /*event*/);
+        void ApplyTopologyChange(const core::topology::TrianglesAdded* topoEvent);
         /// Callback to remove triangles elements.
-        void ApplyTopologyChange(const core::topology::TrianglesRemoved* /*event*/);
+        void ApplyTopologyChange(const core::topology::TrianglesRemoved* topoEvent);
 
 
         ///////////////////////// Functions on Quads //////////////////////////////////////
 
         /// Edge coefficient of mass matrix creation function to handle creation of new quads
-        void applyQuadCreation(const sofa::type::vector< Index >& /*indices*/,
-                const sofa::type::vector< core::topology::BaseMeshTopology::Quad >& /*elems*/,
-                const sofa::type::vector< sofa::type::vector< Index > >& /*ancestors*/,
-                const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
+        void applyQuadCreation(const sofa::type::vector< Index >& quadAdded,
+                const sofa::type::vector< core::topology::BaseMeshTopology::Quad >& elems,
+                const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+                const sofa::type::vector< sofa::type::vector< double > >& coefs);
 
         /// Edge coefficient of mass matrix destruction function to handle creation of new quads
-        void applyQuadDestruction(const sofa::type::vector<Index> & /*indices*/);
+        void applyQuadDestruction(const sofa::type::vector<Index> & quadRemoved);
 
         /// Callback to add quads elements.
-        void ApplyTopologyChange(const core::topology::QuadsAdded* /*event*/);
+        void ApplyTopologyChange(const core::topology::QuadsAdded* topoEvent);
         /// Callback to remove quads elements.
-        void ApplyTopologyChange(const core::topology::QuadsRemoved* /*event*/);
+        void ApplyTopologyChange(const core::topology::QuadsRemoved* topoEvent);
 
 
         ///////////////////////// Functions on Tetrahedron //////////////////////////////////////
 
         /// Edge coefficient of mass matrix creation function to handle creation of new tetrahedra
-        void applyTetrahedronCreation(const sofa::type::vector< Index >& /*indices*/,
-                const sofa::type::vector< core::topology::BaseMeshTopology::Tetrahedron >& /*elems*/,
-                const sofa::type::vector< sofa::type::vector< Index > >& /*ancestors*/,
-                const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
+        void applyTetrahedronCreation(const sofa::type::vector< Index >& tetrahedronAdded,
+                const sofa::type::vector< core::topology::BaseMeshTopology::Tetrahedron >& elems,
+                const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+                const sofa::type::vector< sofa::type::vector< double > >& coefs);
 
         /// Edge coefficient of mass matrix destruction function to handle creation of new tetrahedra
-        void applyTetrahedronDestruction(const sofa::type::vector<Index> & /*indices*/);
+        void applyTetrahedronDestruction(const sofa::type::vector<Index> & tetrahedronRemoved);
 
         /// Callback to add tetrahedron elements.
-        void ApplyTopologyChange(const core::topology::TetrahedraAdded* /*event*/);
+        void ApplyTopologyChange(const core::topology::TetrahedraAdded* topoEvent);
         /// Callback to remove tetrahedron elements.
-        void ApplyTopologyChange(const core::topology::TetrahedraRemoved* /*event*/);
+        void ApplyTopologyChange(const core::topology::TetrahedraRemoved* topoEvent);
 
 
         ///////////////////////// Functions on Hexahedron //////////////////////////////////////
 
         /// Edge coefficient of mass matrix creation function to handle creation of new hexahedra
-        void applyHexahedronCreation(const sofa::type::vector< Index >& /*indices*/,
-                const sofa::type::vector< core::topology::BaseMeshTopology::Hexahedron >& /*elems*/,
-                const sofa::type::vector< sofa::type::vector< Index > >& /*ancestors*/,
-                const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
+        void applyHexahedronCreation(const sofa::type::vector< Index >& hexahedronAdded,
+                const sofa::type::vector< core::topology::BaseMeshTopology::Hexahedron >& elems,
+                const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+                const sofa::type::vector< sofa::type::vector< double > >& coefs);
 
         /// Edge coefficient of mass matrix destruction function to handle creation of new hexahedra
         void applyHexahedronDestruction(const sofa::type::vector<Index> & /*indices*/);
 
         /// Callback to add hexahedron elements.
-        void ApplyTopologyChange(const core::topology::HexahedraAdded* /*event*/);
+        void ApplyTopologyChange(const core::topology::HexahedraAdded* topoEvent);
          /// Callback to remove hexahedron elements.
-        void ApplyTopologyChange(const core::topology::HexahedraRemoved* /*event*/);
+        void ApplyTopologyChange(const core::topology::HexahedraRemoved* topoEvent);
 
     protected:
         MeshMatrixMass<DataTypes,TMassType>* m;

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -121,16 +121,23 @@ void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::applyDestroyFunction(
 /// Creation fonction for mass stored on vertices
 template< class DataTypes, class MassType>
 void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyTriangleCreation(const sofa::type::vector< Index >& triangleAdded,
-        const sofa::type::vector< core::topology::BaseMeshTopology::Triangle >& /*elems*/,
-        const sofa::type::vector< sofa::type::vector< Index > >& /*ancestors*/,
-        const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/)
+        const sofa::type::vector< core::topology::BaseMeshTopology::Triangle >& elems,
+        const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+        const sofa::type::vector< sofa::type::vector< double > >& coefs)
 {
+    SOFA_UNUSED(elems);
     MeshMatrixMass<DataTypes, MassType> *MMM = this->m;
 
     if (MMM && MMM->getMassTopologyType() == TopologyElementType::TRIANGLE)
     {
         helper::WriteAccessor< Data< type::vector<MassType> > > VertexMasses ( MMM->d_vertexMass );
-        helper::WriteAccessor<Data<Real> > totalMass(MMM->d_totalMass);
+        helper::WriteAccessor<Data<Real> > totalMass(MMM->d_totalMass);        
+
+        // update mass density vector
+        sofa::Size nbMass = MMM->getMassDensity().size();
+        sofa::Size nbTri = MMM->m_topology->getNbTriangles();
+        if (nbMass < nbTri)
+            MMM->addMassDensity(triangleAdded, ancestors, coefs);
 
         // Initialisation
         const type::vector<Real> densityM = MMM->getMassDensity();
@@ -167,16 +174,23 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyTriangleCreati
 /// Creation fonction for mass stored on edges
 template< class DataTypes, class MassType>
 void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::applyTriangleCreation(const sofa::type::vector< Index >& triangleAdded,
-        const sofa::type::vector< core::topology::BaseMeshTopology::Triangle >& /*elems*/,
-        const sofa::type::vector< sofa::type::vector< Index > >& /*ancestors*/,
-        const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/)
+        const sofa::type::vector< core::topology::BaseMeshTopology::Triangle >& elems,
+        const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+        const sofa::type::vector< sofa::type::vector< double > >& coefs)
 {
+    SOFA_UNUSED(elems);
     MeshMatrixMass<DataTypes, MassType> *MMM = this->m;
 
     if (MMM && MMM->getMassTopologyType() == TopologyElementType::TRIANGLE)
     {
         helper::WriteAccessor< Data< type::vector<MassType> > > EdgeMasses ( MMM->d_edgeMass );
         helper::WriteAccessor<Data<Real> > totalMass(MMM->d_totalMass);
+
+        // update mass density vector
+        sofa::Size nbMass = MMM->getMassDensity().size();
+        sofa::Size nbTri = MMM->m_topology->getNbTriangles();
+        if (nbMass < nbTri)
+            MMM->addMassDensity(triangleAdded, ancestors, coefs);
 
         // Initialisation
         const type::vector<Real> densityM = MMM->getMassDensity();
@@ -295,12 +309,12 @@ void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::applyTriangleDestruct
 }
 
 template< class DataTypes, class MassType>
-void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::ApplyTopologyChange(const core::topology::TrianglesAdded* e)
+void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::ApplyTopologyChange(const core::topology::TrianglesAdded* topoEvent)
 {
-    const auto &triangleAdded = e->getIndexArray();
-    const sofa::type::vector<core::topology::BaseMeshTopology::Triangle> &elems = e->getElementArray();
-    const auto & ancestors = e->ancestorsList;
-    const sofa::type::vector<sofa::type::vector<double> > & coefs = e->coefs;
+    const auto &triangleAdded = topoEvent->getIndexArray();
+    const sofa::type::vector<core::topology::BaseMeshTopology::Triangle> &elems = topoEvent->getElementArray();
+    const auto & ancestors = topoEvent->ancestorsList;
+    const sofa::type::vector<sofa::type::vector<double> > & coefs = topoEvent->coefs;
 
     applyTriangleCreation(triangleAdded, elems, ancestors, coefs);
 }
@@ -314,12 +328,12 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::ApplyTopologyChange
 }
 
 template< class DataTypes, class MassType>
-void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(const core::topology::TrianglesAdded* e)
+void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(const core::topology::TrianglesAdded* topoEvent)
 {
-    const auto &triangleAdded = e->getIndexArray();
-    const sofa::type::vector<core::topology::BaseMeshTopology::Triangle> &elems = e->getElementArray();
-    const auto & ancestors = e->ancestorsList;
-    const sofa::type::vector<sofa::type::vector<double> > & coefs = e->coefs;
+    const auto &triangleAdded = topoEvent->getIndexArray();
+    const sofa::type::vector<core::topology::BaseMeshTopology::Triangle> &elems = topoEvent->getElementArray();
+    const auto & ancestors = topoEvent->ancestorsList;
+    const sofa::type::vector<sofa::type::vector<double> > & coefs = topoEvent->coefs;
 
     applyTriangleCreation(triangleAdded, elems, ancestors, coefs);
 }
@@ -342,16 +356,23 @@ void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(c
 /// Creation fonction for mass stored on vertices
 template< class DataTypes, class MassType>
 void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyQuadCreation(const sofa::type::vector< Index >& quadAdded,
-        const sofa::type::vector< core::topology::BaseMeshTopology::Quad >& /*elems*/,
-        const sofa::type::vector< sofa::type::vector< Index > >& /*ancestors*/,
-        const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/)
+        const sofa::type::vector< core::topology::BaseMeshTopology::Quad >& elems,
+        const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+        const sofa::type::vector< sofa::type::vector< double > >& coefs)
 {
+    SOFA_UNUSED(elems);
     MeshMatrixMass<DataTypes, MassType> *MMM = this->m;
 
     if (MMM && MMM->getMassTopologyType() == TopologyElementType::QUAD)
     {
         helper::WriteAccessor< Data< type::vector<MassType> > > VertexMasses ( MMM->d_vertexMass );
         helper::WriteAccessor<Data<Real> > totalMass(MMM->d_totalMass);
+
+        // update mass density vector
+        sofa::Size nbMass = MMM->getMassDensity().size();
+        sofa::Size nbQ = MMM->m_topology->getNbQuads();
+        if (nbMass < nbQ)
+            MMM->addMassDensity(quadAdded, ancestors, coefs);
 
         // Initialisation
         const type::vector<Real> densityM = MMM->getMassDensity();
@@ -388,16 +409,23 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyQuadCreation(c
 /// Creation fonction for mass stored on edges
 template< class DataTypes, class MassType>
 void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::applyQuadCreation(const sofa::type::vector< Index >& quadAdded,
-        const sofa::type::vector< core::topology::BaseMeshTopology::Quad >& /*elems*/,
-        const sofa::type::vector< sofa::type::vector< Index > >& /*ancestors*/,
-        const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/)
+        const sofa::type::vector< core::topology::BaseMeshTopology::Quad >& elems,
+        const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+        const sofa::type::vector< sofa::type::vector< double > >& coefs)
 {
+    SOFA_UNUSED(elems);
     MeshMatrixMass<DataTypes, MassType> *MMM = this->m;
 
     if (MMM && MMM->getMassTopologyType() == TopologyElementType::QUAD)
     {
         helper::WriteAccessor< Data< type::vector<MassType> > > EdgeMasses ( MMM->d_edgeMass );
         helper::WriteAccessor<Data<Real> > totalMass(MMM->d_totalMass);
+        
+        // update mass density vector
+        sofa::Size nbMass = MMM->getMassDensity().size();
+        sofa::Size nbQ = MMM->m_topology->getNbQuads();
+        if (nbMass < nbQ)
+            MMM->addMassDensity(quadAdded, ancestors, coefs);
 
         // Initialisation
         const type::vector<Real> densityM = MMM->getMassDensity();
@@ -516,39 +544,39 @@ void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::applyQuadDestruction(
 }
 
 template< class DataTypes, class MassType>
-void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::ApplyTopologyChange(const core::topology::QuadsAdded* e)
+void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::ApplyTopologyChange(const core::topology::QuadsAdded* topoEvent)
 {
-    const auto &quadAdded = e->getIndexArray();
-    const sofa::type::vector<core::topology::BaseMeshTopology::Quad> &elems = e->getElementArray();
-    const auto & ancestors = e->ancestorsList;
-    const sofa::type::vector<sofa::type::vector<double> > & coefs = e->coefs;
+    const auto &quadAdded = topoEvent->getIndexArray();
+    const sofa::type::vector<core::topology::BaseMeshTopology::Quad> &elems = topoEvent->getElementArray();
+    const auto & ancestors = topoEvent->ancestorsList;
+    const sofa::type::vector<sofa::type::vector<double> > & coefs = topoEvent->coefs;
 
     applyQuadCreation(quadAdded, elems, ancestors, coefs);
 }
 
 template< class DataTypes, class MassType>
-void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::ApplyTopologyChange(const core::topology::QuadsRemoved* e)
+void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::ApplyTopologyChange(const core::topology::QuadsRemoved* topoEvent)
 {
-    const auto &quadRemoved = e->getArray();
+    const auto &quadRemoved = topoEvent->getArray();
 
     applyQuadDestruction(quadRemoved);
 }
 
 template< class DataTypes, class MassType>
-void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(const core::topology::QuadsAdded* e)
+void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(const core::topology::QuadsAdded* topoEvent)
 {
-    const auto &quadAdded = e->getIndexArray();
-    const sofa::type::vector<core::topology::BaseMeshTopology::Quad> &elems = e->getElementArray();
-    const auto& ancestors = e->ancestorsList;
-    const sofa::type::vector<sofa::type::vector<double> > & coefs = e->coefs;
+    const auto &quadAdded = topoEvent->getIndexArray();
+    const sofa::type::vector<core::topology::BaseMeshTopology::Quad> &elems = topoEvent->getElementArray();
+    const auto& ancestors = topoEvent->ancestorsList;
+    const sofa::type::vector<sofa::type::vector<double> > & coefs = topoEvent->coefs;
 
     applyQuadCreation(quadAdded, elems, ancestors, coefs);
 }
 
 template< class DataTypes, class MassType>
-void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(const core::topology::QuadsRemoved* e)
+void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(const core::topology::QuadsRemoved* topoEvent)
 {
-    const auto &quadRemoved = e->getArray();
+    const auto &quadRemoved = topoEvent->getArray();
 
     applyQuadDestruction(quadRemoved);
 }
@@ -565,16 +593,23 @@ void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(c
 /// Creation fonction for mass stored on vertices
 template< class DataTypes, class MassType>
 void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyTetrahedronCreation(const sofa::type::vector< Index >& tetrahedronAdded,
-        const sofa::type::vector< core::topology::BaseMeshTopology::Tetrahedron >& /*elems*/,
-        const sofa::type::vector< sofa::type::vector< Index > >& /*ancestors*/,
-        const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/)
+        const sofa::type::vector< core::topology::BaseMeshTopology::Tetrahedron >& elems,
+        const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+        const sofa::type::vector< sofa::type::vector< double > >& coefs)
 {
+    SOFA_UNUSED(elems);
     MeshMatrixMass<DataTypes, MassType> *MMM = this->m;
 
     if (MMM && MMM->getMassTopologyType() == TopologyElementType::TETRAHEDRON)
     {
         helper::WriteAccessor< Data< type::vector<MassType> > > VertexMasses ( MMM->d_vertexMass );
         helper::WriteAccessor<Data<Real> > totalMass(MMM->d_totalMass);
+
+        // update mass density vector
+        sofa::Size nbMass = MMM->getMassDensity().size();
+        sofa::Size nbT = MMM->m_topology->getNbTetrahedra();
+        if (nbMass < nbT)
+            MMM->addMassDensity(tetrahedronAdded, ancestors, coefs);
 
         // Initialisation
         const type::vector<Real> densityM = MMM->getMassDensity();
@@ -611,16 +646,23 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyTetrahedronCre
 /// Creation fonction for mass stored on edges
 template< class DataTypes, class MassType>
 void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::applyTetrahedronCreation(const sofa::type::vector< Index >& tetrahedronAdded,
-        const sofa::type::vector< core::topology::BaseMeshTopology::Tetrahedron >& /*elems*/,
-        const sofa::type::vector< sofa::type::vector< Index > >& /*ancestors*/,
-        const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/)
+        const sofa::type::vector< core::topology::BaseMeshTopology::Tetrahedron >& elems,
+        const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+        const sofa::type::vector< sofa::type::vector< double > >& coefs)
 {
+    SOFA_UNUSED(elems);
     MeshMatrixMass<DataTypes, MassType> *MMM = this->m;
 
     if (MMM && MMM->getMassTopologyType() == TopologyElementType::TETRAHEDRON)
     {
         helper::WriteAccessor< Data< type::vector<MassType> > > EdgeMasses ( MMM->d_edgeMass );
         helper::WriteAccessor<Data<Real> > totalMass(MMM->d_totalMass);
+        
+        // update mass density vector
+        sofa::Size nbMass = MMM->getMassDensity().size();
+        sofa::Size nbT = MMM->m_topology->getNbTetrahedra();
+        if (nbMass < nbT)
+            MMM->addMassDensity(tetrahedronAdded, ancestors, coefs);
 
         // Initialisation
         const type::vector<Real> densityM = MMM->getMassDensity();
@@ -739,39 +781,39 @@ void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::applyTetrahedronDestr
 }
 
 template< class DataTypes, class MassType>
-void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::ApplyTopologyChange(const core::topology::TetrahedraAdded* e)
+void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::ApplyTopologyChange(const core::topology::TetrahedraAdded* topoEvent)
 {
-    const auto &tetraAdded = e->getIndexArray();
-    const sofa::type::vector<core::topology::BaseMeshTopology::Tetrahedron> &elems = e->getElementArray();
-    const auto & ancestors = e->ancestorsList;
-    const sofa::type::vector<sofa::type::vector<double> > & coefs = e->coefs;
+    const auto &tetraAdded = topoEvent->getIndexArray();
+    const sofa::type::vector<core::topology::BaseMeshTopology::Tetrahedron> &elems = topoEvent->getElementArray();
+    const auto & ancestors = topoEvent->ancestorsList;
+    const sofa::type::vector<sofa::type::vector<double> > & coefs = topoEvent->coefs;
 
     applyTetrahedronCreation(tetraAdded, elems, ancestors, coefs);
 }
 
 template< class DataTypes, class MassType>
-void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::ApplyTopologyChange(const core::topology::TetrahedraRemoved* e)
+void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::ApplyTopologyChange(const core::topology::TetrahedraRemoved* topoEvent)
 {
-    const auto &tetraRemoved = e->getArray();
+    const auto &tetraRemoved = topoEvent->getArray();
 
     applyTetrahedronDestruction(tetraRemoved);
 }
 
 template< class DataTypes, class MassType>
-void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(const core::topology::TetrahedraAdded* e)
+void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(const core::topology::TetrahedraAdded* topoEvent)
 {
-    const auto &tetraAdded = e->getIndexArray();
-    const sofa::type::vector<core::topology::BaseMeshTopology::Tetrahedron> &elems = e->getElementArray();
-    const auto& ancestors = e->ancestorsList;
-    const sofa::type::vector<sofa::type::vector<double> > & coefs = e->coefs;
+    const auto &tetraAdded = topoEvent->getIndexArray();
+    const sofa::type::vector<core::topology::BaseMeshTopology::Tetrahedron> &elems = topoEvent->getElementArray();
+    const auto& ancestors = topoEvent->ancestorsList;
+    const sofa::type::vector<sofa::type::vector<double> > & coefs = topoEvent->coefs;
 
     applyTetrahedronCreation(tetraAdded, elems, ancestors, coefs);
 }
 
 template< class DataTypes, class MassType>
-void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(const core::topology::TetrahedraRemoved* e)
+void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(const core::topology::TetrahedraRemoved* topoEvent)
 {
-    const auto& tetraRemoved = e->getArray();
+    const auto& tetraRemoved = topoEvent->getArray();
 
     applyTetrahedronDestruction(tetraRemoved);
 }
@@ -787,16 +829,23 @@ void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(c
 /// Creation fonction for mass stored on vertices
 template< class DataTypes, class MassType>
 void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyHexahedronCreation(const sofa::type::vector< Index >& hexahedronAdded,
-        const sofa::type::vector< core::topology::BaseMeshTopology::Hexahedron >& /*elems*/,
-        const sofa::type::vector< sofa::type::vector< Index > >& /*ancestors*/,
-        const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/)
+        const sofa::type::vector< core::topology::BaseMeshTopology::Hexahedron >& elems,
+        const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+        const sofa::type::vector< sofa::type::vector< double > >& coefs)
 {
+    SOFA_UNUSED(elems);
     MeshMatrixMass<DataTypes, MassType> *MMM = this->m;
 
     if (MMM && MMM->getMassTopologyType() == TopologyElementType::HEXAHEDRON)
     {
         helper::WriteAccessor< Data< type::vector<MassType> > > VertexMasses ( MMM->d_vertexMass );
         helper::WriteAccessor<Data<Real> > totalMass(MMM->d_totalMass);
+        
+        // update mass density vector
+        sofa::Size nbMass = MMM->getMassDensity().size();
+        sofa::Size nbT = MMM->m_topology->getNbHexahedra();
+        if (nbMass < nbT)
+            MMM->addMassDensity(hexahedronAdded, ancestors, coefs);
 
         // Initialisation
         const type::vector<Real> densityM = MMM->getMassDensity();
@@ -833,16 +882,23 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyHexahedronCrea
 /// Creation fonction for mass stored on edges
 template< class DataTypes, class MassType>
 void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::applyHexahedronCreation(const sofa::type::vector< Index >& hexahedronAdded,
-        const sofa::type::vector< core::topology::BaseMeshTopology::Hexahedron >& /*elems*/,
-        const sofa::type::vector< sofa::type::vector< Index > >& /*ancestors*/,
-        const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/)
+        const sofa::type::vector< core::topology::BaseMeshTopology::Hexahedron >& elems,
+        const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+        const sofa::type::vector< sofa::type::vector< double > >& coefs)
 {
+    SOFA_UNUSED(elems);
     MeshMatrixMass<DataTypes, MassType> *MMM = this->m;
 
     if (MMM && MMM->getMassTopologyType() == TopologyElementType::HEXAHEDRON)
     {
         helper::WriteAccessor< Data< type::vector<MassType> > > EdgeMasses ( MMM->d_edgeMass );
         helper::WriteAccessor<Data<Real> > totalMass(MMM->d_totalMass);
+
+        // update mass density vector
+        sofa::Size nbMass = MMM->getMassDensity().size();
+        sofa::Size nbT = MMM->m_topology->getNbHexahedra();
+        if (nbMass < nbT)
+            MMM->addMassDensity(hexahedronAdded, ancestors, coefs);
 
         // Initialisation
         const type::vector<Real> densityM = MMM->getMassDensity();
@@ -961,39 +1017,39 @@ void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::applyHexahedronDestru
 }
 
 template< class DataTypes, class MassType>
-void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::ApplyTopologyChange(const core::topology::HexahedraAdded* e)
+void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::ApplyTopologyChange(const core::topology::HexahedraAdded* topoEvent)
 {
-    const auto &hexaAdded = e->getIndexArray();
-    const sofa::type::vector<core::topology::BaseMeshTopology::Hexahedron> &elems = e->getElementArray();
-    const auto & ancestors = e->ancestorsList;
-    const sofa::type::vector<sofa::type::vector<double> > & coefs = e->coefs;
+    const auto &hexaAdded = topoEvent->getIndexArray();
+    const sofa::type::vector<core::topology::BaseMeshTopology::Hexahedron> &elems = topoEvent->getElementArray();
+    const auto & ancestors = topoEvent->ancestorsList;
+    const sofa::type::vector<sofa::type::vector<double> > & coefs = topoEvent->coefs;
 
     applyHexahedronCreation(hexaAdded, elems, ancestors, coefs);
 }
 
 template< class DataTypes, class MassType>
-void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::ApplyTopologyChange(const core::topology::HexahedraRemoved* e)
+void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::ApplyTopologyChange(const core::topology::HexahedraRemoved* topoEvent)
 {
-    const auto &hexaRemoved = e->getArray();
+    const auto &hexaRemoved = topoEvent->getArray();
 
     applyHexahedronDestruction(hexaRemoved);
 }
 
 template< class DataTypes, class MassType>
-void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(const core::topology::HexahedraAdded* e)
+void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(const core::topology::HexahedraAdded* topoEvent)
 {
-    const auto &hexaAdded = e->getIndexArray();
-    const sofa::type::vector<core::topology::BaseMeshTopology::Hexahedron> &elems = e->getElementArray();
-    const auto & ancestors = e->ancestorsList;
-    const sofa::type::vector<sofa::type::vector<double> > & coefs = e->coefs;
+    const auto &hexaAdded = topoEvent->getIndexArray();
+    const sofa::type::vector<core::topology::BaseMeshTopology::Hexahedron> &elems = topoEvent->getElementArray();
+    const auto & ancestors = topoEvent->ancestorsList;
+    const sofa::type::vector<sofa::type::vector<double> > & coefs = topoEvent->coefs;
 
     applyHexahedronCreation(hexaAdded, elems, ancestors, coefs);
 }
 
 template< class DataTypes, class MassType>
-void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(const core::topology::HexahedraRemoved* e)
+void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(const core::topology::HexahedraRemoved* topoEvent)
 {
-    const auto &hexaRemoved = e->getArray();
+    const auto &hexaRemoved = topoEvent->getArray();
 
     applyHexahedronDestruction(hexaRemoved);
 }
@@ -1864,6 +1920,32 @@ void MeshMatrixMass<DataTypes, MassType>::setMassDensity(Real massDensityValue)
     }
 }
 
+template <class DataTypes, class MassType>
+void MeshMatrixMass<DataTypes, MassType>::addMassDensity(const sofa::type::vector< Index >& indices, 
+    const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+    const sofa::type::vector< sofa::type::vector< double > >& coefs)
+{
+    helper::WriteOnlyAccessor<Data<sofa::type::vector< Real > > > massDensity = d_massDensity;
+    for (unsigned int id = 0; id < indices.size(); ++id)
+    {
+        // if no ancestor apply the first density of the vector
+        if (ancestors[id].empty())
+        {
+            massDensity.push_back(massDensity[0]);
+            continue;
+        }
+
+        // Accumulate mass of their neighbours
+        Real massD = 0.0;
+        for (unsigned int j = 0; j < ancestors[id].size(); ++j)
+        {
+            Index ancId = ancestors[id][j];
+            double coef = coefs[id][j];
+            massD += massDensity[ancId] * coef;
+        }
+        massDensity.push_back(massD);
+    }
+}
 
 template <class DataTypes, class MassType>
 void MeshMatrixMass<DataTypes, MassType>::setTotalMass(Real totalMass)
@@ -2115,7 +2197,7 @@ void MeshMatrixMass<DataTypes, MassType>::addMToMatrix(const core::MechanicalPar
     const MassVector &edgeMass= d_edgeMass.getValue();
 
     size_t nbEdges=m_topology->getNbEdges();
-    size_t v0,v1;
+    sofa::Index v0,v1;
 
     const int N = defaulttype::DataTypeInfo<Deriv>::size();
     AddMToMatrixFunctor<Deriv,MassType> calc;


### PR DESCRIPTION
Add method to compute the good element density using ancestors and coefs values.
Update all toplogy addElement to take into account ancestors indices and coefficients.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
