### PR TITLE
[SofaHelper] Factory key type can be other than std::string

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/collision/Contact.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/collision/Contact.h
@@ -83,10 +83,10 @@ public:
     virtual void setKeepAlive(bool /* val */) {}
 
     //Todo adding TPtr parameter
-    class Factory : public helper::Factory< std::string, Contact, std::pair<std::pair<core::CollisionModel*,core::CollisionModel*>,Intersection*>, Contact::SPtr >
+    class SOFA_CORE_API Factory : public helper::Factory< std::string, Contact, std::pair<std::pair<core::CollisionModel*,core::CollisionModel*>,Intersection*>, Contact::SPtr >
     {
     public:
-        static Factory SOFA_CORE_API *getInstance();
+        static Factory *getInstance();
 
         static ObjectPtr CreateObject(Key key, Argument arg)
         {

--- a/SofaKernel/modules/SofaHelper/SofaHelper_test/CMakeLists.txt
+++ b/SofaKernel/modules/SofaHelper/SofaHelper_test/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.12)
 project(SofaHelper_test)
 
 set(SOURCE_FILES
+    Factory_test.cpp
     KdTree_test.cpp
     Utils_test.cpp
     io/MeshOBJ_test.cpp

--- a/SofaKernel/modules/SofaHelper/SofaHelper_test/Factory_test.cpp
+++ b/SofaKernel/modules/SofaHelper/SofaHelper_test/Factory_test.cpp
@@ -1,0 +1,120 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/testing/BaseTest.h>
+using sofa::testing::BaseTest;
+
+#include <sofa/helper/Factory.inl>
+#include <functional>
+
+namespace sofa
+{
+
+/// Enum class used as the key of a factory
+enum class DummyEnum
+{
+    A, B, C, D
+};
+
+/// Factories require this operator in order to have a custom class as a key
+std::ostream& operator << ( std::ostream& out, const DummyEnum& d )
+{
+    switch (d)
+    {
+        case DummyEnum::A: out << "A";
+        case DummyEnum::B: out << "B";
+        case DummyEnum::C: out << "C";
+        case DummyEnum::D: out << "D";
+    }
+    return out;
+}
+
+struct DummyBaseClass
+{
+    virtual std::string getTestValue() const { return "Base";}
+
+    /// Helper function required by the factory to instantiate a new object
+    template<class T>
+    static T* create(T*, sofa::helper::NoArgument /*noarg*/)
+    {
+        return new T();
+    }
+};
+struct DummyClassA : public DummyBaseClass { std::string getTestValue() const override { return "A";}};
+struct DummyClassB : public DummyBaseClass { std::string getTestValue() const override { return "B";}};
+struct DummyClassC : public DummyBaseClass { std::string getTestValue() const override { return "C";}};
+struct DummyClassD : public DummyBaseClass { std::string getTestValue() const override { return "D";}};
+
+/// Definition of the factory
+/// Key is the enum type defined earlier. It requires the less operator and operator <<
+/// Objects created based on the key are of type DummyBaseClass
+using DummyEnumFactory = sofa::helper::Factory<DummyEnum, DummyBaseClass>;
+
+namespace helper
+{
+template class
+sofa::helper::Factory< DummyEnum, DummyBaseClass>;
+}
+
+class Factory_test : public BaseTest
+{
+public:
+    void testEnumKey()
+    {
+        sofa::helper::Creator<DummyEnumFactory, DummyClassA> dummyClassACreator(DummyEnum::A, false);
+        sofa::helper::Creator<DummyEnumFactory, DummyClassB> dummyClassBCreator(DummyEnum::B, false);
+        sofa::helper::Creator<DummyEnumFactory, DummyClassC> dummyClassCCreator(DummyEnum::C, false);
+        sofa::helper::Creator<DummyEnumFactory, DummyClassD> dummyClassDCreator(DummyEnum::D, false);
+
+        auto a = DummyEnumFactory::CreateObject(DummyEnum::A, sofa::helper::NoArgument());
+        EXPECT_TRUE(a);
+        EXPECT_TRUE(dynamic_cast<DummyClassA*>(a));
+        EXPECT_EQ(a->getTestValue(), "A");
+
+        auto b = DummyEnumFactory::CreateObject(DummyEnum::B, sofa::helper::NoArgument());
+        EXPECT_TRUE(b);
+        EXPECT_TRUE(dynamic_cast<DummyClassB*>(b));
+        EXPECT_EQ(b->getTestValue(), "B");
+
+        auto c = DummyEnumFactory::CreateObject(DummyEnum::C, sofa::helper::NoArgument());
+        EXPECT_TRUE(c);
+        EXPECT_TRUE(dynamic_cast<DummyClassC*>(c));
+        EXPECT_EQ(c->getTestValue(), "C");
+
+        auto d = DummyEnumFactory::CreateObject(DummyEnum::D, sofa::helper::NoArgument());
+        EXPECT_TRUE(d);
+        EXPECT_TRUE(dynamic_cast<DummyClassD*>(d));
+        EXPECT_EQ(d->getTestValue(), "D");
+
+        DummyEnumFactory::ResetEntry(DummyEnum::A);
+        DummyEnumFactory::ResetEntry(DummyEnum::B);
+        DummyEnumFactory::ResetEntry(DummyEnum::C);
+        DummyEnumFactory::ResetEntry(DummyEnum::D);
+
+    }
+};
+
+TEST_F(Factory_test, EnumKey)
+{
+    testEnumKey();
+}
+
+} //namespace sofa

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.cpp
@@ -19,6 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#define SOFAHELPER_FACTORY_CPP
 #include <sofa/helper/Factory.inl>
 #include <typeinfo>
 #ifdef __GNUC__
@@ -91,6 +92,8 @@ SOFA_HELPER_API void printFactoryLog(std::ostream& out)
     out << getFactoryLog();
 }
 
+//explicit instantiation for std::string
+template SOFA_HELPER_API void logFactoryRegister<std::string>(const std::string& baseclass, const std::string& classname, std::string key, bool multi);
 
 } // namespace sofa::helper
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.cpp
@@ -30,7 +30,7 @@ namespace sofa::helper
 {
 
 /// Decode the type's name to a more readable form if possible
-std::string SOFA_HELPER_API gettypename(const std::type_info& t)
+SOFA_HELPER_API std::string gettypename(const std::type_info& t)
 {
     std::string name;
 #ifdef __GNUC__
@@ -79,14 +79,14 @@ std::string SOFA_HELPER_API gettypename(const std::type_info& t)
     return name;
 }
 
-std::string& getFactoryLog()
+SOFA_HELPER_API std::string& getFactoryLog()
 {
     static std::string s;
     return s;
 }
 
 /// Print factory log
-void SOFA_HELPER_API printFactoryLog(std::ostream& out)
+SOFA_HELPER_API void printFactoryLog(std::ostream& out)
 {
     out << getFactoryLog();
 }

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.cpp
@@ -26,10 +26,7 @@
 #endif
 #include <cstdlib>
 
-namespace sofa
-{
-
-namespace helper
+namespace sofa::helper
 {
 
 /// Decode the type's name to a more readable form if possible
@@ -95,7 +92,5 @@ void SOFA_HELPER_API printFactoryLog(std::ostream& out)
 }
 
 
-} // namespace helper
-
-} // namespace sofa
+} // namespace sofa::helper
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.cpp
@@ -82,17 +82,10 @@ std::string SOFA_HELPER_API gettypename(const std::type_info& t)
     return name;
 }
 
-static std::string& getFactoryLog()
+std::string& getFactoryLog()
 {
     static std::string s;
     return s;
-}
-
-/// Log classes registered in the factory
-void SOFA_HELPER_API logFactoryRegister(std::string baseclass, std::string classname, std::string key, bool multi)
-{
-    getFactoryLog() += baseclass + (multi?" template class ":" class ")
-            + classname + " registered as " + key + "\n";
 }
 
 /// Print factory log

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.h
@@ -19,8 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_HELPER_FACTORY_H
-#define SOFA_HELPER_FACTORY_H
+#pragma once
 
 #include <map>
 #include <iostream>
@@ -30,10 +29,7 @@
 #include <sofa/helper/config.h>
 #include <sofa/helper/logging/Messaging.h>
 
-namespace sofa
-{
-
-namespace helper
+namespace sofa::helper
 {
 
 /// Allow us to use BaseCreator and Factory without using any Arguments
@@ -44,7 +40,7 @@ std::string SOFA_HELPER_API gettypename(const std::type_info& t);
 
 /// Log classes registered in the factory
 template<class TKey>
-void SOFA_HELPER_API logFactoryRegister(std::string baseclass, std::string classname, TKey key, bool multi);
+void SOFA_HELPER_API logFactoryRegister(const std::string& baseclass, const std::string& classname, TKey key, bool multi);
 
 std::string& getFactoryLog();
 
@@ -69,7 +65,6 @@ public:
     typedef TPtr      ObjectPtr;
     typedef TArgument Argument;
     typedef BaseCreator<Object, Argument, ObjectPtr> Creator;
-    typedef std::multimap<Key, Creator> Registry;
 
 protected:
     std::multimap<Key, Creator*> registry;
@@ -204,11 +199,7 @@ public:
 };
 
 
-} // namespace helper
-
-} // namespace sofa
+} // namespace sofa::helper
 
 // Creator is often used without namespace qualifiers
 using sofa::helper::Creator;
-
-#endif

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.h
@@ -198,6 +198,9 @@ public:
     }
 };
 
+#if !defined(SOFAHELPER_FACTORY_CPP)
+extern template SOFA_HELPER_API void logFactoryRegister(const std::string& baseclass, const std::string& classname, std::string key, bool multi);
+#endif
 
 } // namespace sofa::helper
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.h
@@ -36,16 +36,16 @@ namespace sofa::helper
 class NoArgument {} ;
 
 /// Decode the type's name to a more readable form if possible
-std::string SOFA_HELPER_API gettypename(const std::type_info& t);
+SOFA_HELPER_API std::string gettypename(const std::type_info& t);
 
 /// Log classes registered in the factory
 template<class TKey>
-void SOFA_HELPER_API logFactoryRegister(const std::string& baseclass, const std::string& classname, TKey key, bool multi);
+SOFA_HELPER_API void logFactoryRegister(const std::string& baseclass, const std::string& classname, TKey key, bool multi);
 
-std::string& SOFA_HELPER_API getFactoryLog();
+SOFA_HELPER_API std::string& getFactoryLog();
 
 /// Print factory log
-void SOFA_HELPER_API printFactoryLog(std::ostream& out = std::cout);
+SOFA_HELPER_API void printFactoryLog(std::ostream& out = std::cout);
 
 template <class Object, class Argument = NoArgument, class ObjectPtr = Object*>
 class BaseCreator

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.h
@@ -42,7 +42,7 @@ std::string SOFA_HELPER_API gettypename(const std::type_info& t);
 template<class TKey>
 void SOFA_HELPER_API logFactoryRegister(const std::string& baseclass, const std::string& classname, TKey key, bool multi);
 
-std::string& getFactoryLog();
+std::string& SOFA_HELPER_API getFactoryLog();
 
 /// Print factory log
 void SOFA_HELPER_API printFactoryLog(std::ostream& out = std::cout);

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.h
@@ -43,7 +43,10 @@ class NoArgument {} ;
 std::string SOFA_HELPER_API gettypename(const std::type_info& t);
 
 /// Log classes registered in the factory
-void SOFA_HELPER_API logFactoryRegister(std::string baseclass, std::string classname, std::string key, bool multi);
+template<class TKey>
+void SOFA_HELPER_API logFactoryRegister(std::string baseclass, std::string classname, TKey key, bool multi);
+
+std::string& getFactoryLog();
 
 /// Print factory log
 void SOFA_HELPER_API printFactoryLog(std::ostream& out = std::cout);
@@ -134,7 +137,7 @@ public:
 };
 
 template <class Factory, class RealObject>
-class Creator : public Factory::Creator, public Factory::Key
+class Creator : public Factory::Creator
 {
 public:
     typedef typename Factory::Object    Object;
@@ -142,7 +145,7 @@ public:
     typedef typename Factory::Argument  Argument;
     typedef typename Factory::Key       Key;
     explicit Creator(Key key, bool multi=false)
-        : Key(key)
+        : m_key(key)
     {
         Factory::getInstance()->registerCreator(key, this, multi);
     }
@@ -162,6 +165,14 @@ public:
         msg_info("Creator") << "[SOFA]Registration of class : " << type().name();
     }
 
+    const Key& getKey() const
+    {
+        return m_key;
+    }
+
+private:
+
+    Key m_key;
 };
 
 template <class Factory, class RealObject>

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.inl
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.inl
@@ -36,7 +36,7 @@ namespace helper
 {
 
 template<class TKey>
-void SOFA_HELPER_API logFactoryRegister(std::string baseclass, std::string classname, TKey key, bool multi)
+void logFactoryRegister(std::string baseclass, std::string classname, TKey key, bool multi)
 {
     std::stringstream ss;
     ss << key;

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.inl
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.inl
@@ -35,6 +35,15 @@ namespace sofa
 namespace helper
 {
 
+template<class TKey>
+void SOFA_HELPER_API logFactoryRegister(std::string baseclass, std::string classname, TKey key, bool multi)
+{
+    std::stringstream ss;
+    ss << key;
+    getFactoryLog() += baseclass + (multi?" template class ":" class ")
+        + classname + " registered as " + ss.str() + "\n";
+}
+
 
 template <typename TKey, class TObject, typename TArgument, typename TPtr>
 TPtr Factory<TKey, TObject, TArgument, TPtr>::createObject(Key key, Argument arg)

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.inl
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.inl
@@ -29,14 +29,11 @@
 #include <sofa/type/vector.h>
 #include <sofa/helper/logging/Messaging.h>
 
-namespace sofa
-{
-
-namespace helper
+namespace sofa::helper
 {
 
 template<class TKey>
-void logFactoryRegister(std::string baseclass, std::string classname, TKey key, bool multi)
+void logFactoryRegister(const std::string& baseclass, const std::string& classname, TKey key, bool multi)
 {
     std::stringstream ss;
     ss << key;
@@ -167,8 +164,6 @@ bool Factory<TKey, TObject, TArgument, TPtr>::resetEntry( Key existingKey)
 }
 
 
-} // namespace helper
-
-} // namespace sofa
+} // namespace sofa::helper
 
 #endif

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/BarycentricPenalityContact.cpp
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/BarycentricPenalityContact.cpp
@@ -23,6 +23,7 @@
 #include <SofaMeshCollision/BarycentricPenalityContact.inl>
 #include <SofaMeshCollision/BarycentricContactMapper.h>
 #include <SofaMeshCollision/RigidContactMapper.inl>
+#include <sofa/helper/Factory.inl>
 
 namespace sofa::component::collision
 {

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.inl
@@ -1977,7 +1977,7 @@ void TetrahedronFEMForceField<DataTypes>::addKToMatrix(sofa::defaulttype::BaseMa
     }
     else
     {
-        int i,j,n1, n2, row, column, ROW, COLUMN , IT;
+        int IT;
         StiffnessMatrix JKJt,tmp;
 
         Index noeud1, noeud2;

--- a/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/xml/AttributeElement.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/xml/AttributeElement.cpp
@@ -64,7 +64,7 @@ Creator<BaseElement::NodeFactory, AttributeElement> AttributeNodeClass("Attribut
 
 const char* AttributeElement::getClass() const
 {
-    return AttributeNodeClass.c_str();
+    return AttributeNodeClass.getKey().c_str();
 }
 
 } // namespace sofa::simulation::xml

--- a/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/xml/DataElement.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/xml/DataElement.cpp
@@ -55,7 +55,7 @@ Creator<BaseElement::NodeFactory, DataElement> DataNodeClass("Data");
 
 const char* DataElement::getClass() const
 {
-    return DataNodeClass.c_str();
+    return DataNodeClass.getKey().c_str();
 }
 
 } // namespace sofa::simulation::xml

--- a/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/xml/NodeElement.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/xml/NodeElement.cpp
@@ -85,7 +85,7 @@ helper::Creator<BaseElement::NodeFactory, NodeElement> NodeNodeClass("Node");
 
 const char* NodeElement::getClass() const
 {
-    return NodeNodeClass.c_str();
+    return NodeNodeClass.getKey().c_str();
 }
 
 } // namespace sofa::simulation::xml

--- a/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/xml/ObjectElement.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/xml/ObjectElement.cpp
@@ -113,7 +113,7 @@ Creator<BaseElement::NodeFactory, ObjectElement> ObjectNodeClass("Object");
 
 const char* ObjectElement::getClass() const
 {
-    return ObjectNodeClass.c_str();
+    return ObjectNodeClass.getKey().c_str();
 }
 
 } // namespace sofa::simulation::xml

--- a/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/DAGNodeMultiMappingElement.cpp
+++ b/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/DAGNodeMultiMappingElement.cpp
@@ -55,7 +55,7 @@ helper::Creator<sofa::simulation::xml::BaseElement::NodeFactory, DAGNodeMultiMap
 
 const char* DAGNodeMultiMappingElement::getClass() const
 {
-    return DAGNodeMultiMappingClass.c_str();
+    return DAGNodeMultiMappingClass.getKey().c_str();
 }
 
 

--- a/modules/SofaMiscCollision/src/SofaMiscCollision/TetrahedronRayContact.cpp
+++ b/modules/SofaMiscCollision/src/SofaMiscCollision/TetrahedronRayContact.cpp
@@ -23,6 +23,7 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <SofaUserInteraction/RayModel.h>
 #include <SofaMiscCollision/TetrahedronModel.h>
+#include <sofa/helper/Factory.inl>
 
 namespace sofa
 {

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/AddRecordedCameraPerformer.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/AddRecordedCameraPerformer.cpp
@@ -37,31 +37,33 @@ using namespace sofa::core::objectmodel;
 
 namespace sofa::component::collision
 {
-    helper::Creator<InteractionPerformer::InteractionPerformerFactory, AddRecordedCameraPerformer> AddRecordedCameraPerformerClass("AddRecordedCamera");
 
-    void AddRecordedCameraPerformer::start()
+void AddRecordedCameraPerformer::start()
+{
+    sofa::simulation::Node::SPtr root = down_cast<sofa::simulation::Node>( interactor->getContext()->getRootContext() );
+    if(root)
     {
-        sofa::simulation::Node::SPtr root = down_cast<sofa::simulation::Node>( interactor->getContext()->getRootContext() );
-        if(root)
+        sofa::component::visualmodel::RecordedCamera* currentCamera = root->getNodeObject<sofa::component::visualmodel::RecordedCamera>();
+
+        if(currentCamera)
         {
-            sofa::component::visualmodel::RecordedCamera* currentCamera = root->getNodeObject<sofa::component::visualmodel::RecordedCamera>();
+            // Set the current camera's position in recorded camera for navigation
+            sofa::component::visualmodel::RecordedCamera::Vec3 _pos = currentCamera->p_position.getValue();
+            sofa::type::vector<sofa::component::visualmodel::RecordedCamera::Vec3> posis = currentCamera->m_translationPositions.getValue();
+            posis.push_back(_pos);
+            currentCamera->m_translationPositions.setValue(posis);
 
-            if(currentCamera)
-            {
-                // Set the current camera's position in recorded camera for navigation
-                sofa::component::visualmodel::RecordedCamera::Vec3 _pos = currentCamera->p_position.getValue();
-                sofa::type::vector<sofa::component::visualmodel::RecordedCamera::Vec3> posis = currentCamera->m_translationPositions.getValue();
-                posis.push_back(_pos);
-                currentCamera->m_translationPositions.setValue(posis);
+            // Set the current camera's orientation in recorded camera for navigation
+            sofa::component::visualmodel::RecordedCamera::Quat _ori = currentCamera->p_orientation.getValue();
+            sofa::type::vector<sofa::component::visualmodel::RecordedCamera::Quat>oris = currentCamera->m_translationOrientations.getValue();//push_back(m_vectorOrientations);
+            oris.push_back(_ori);
+            currentCamera->m_translationOrientations.setValue(oris);
 
-                // Set the current camera's orientation in recorded camera for navigation
-                sofa::component::visualmodel::RecordedCamera::Quat _ori = currentCamera->p_orientation.getValue();
-                sofa::type::vector<sofa::component::visualmodel::RecordedCamera::Quat>oris = currentCamera->m_translationOrientations.getValue();//push_back(m_vectorOrientations);
-                oris.push_back(_ori);
-                currentCamera->m_translationOrientations.setValue(oris);
-
-            }
         }
     }
+}
+
+
+helper::Creator<InteractionPerformer::InteractionPerformerFactory, AddRecordedCameraPerformer> AddRecordedCameraPerformerClass("AddRecordedCamera");
 
 }// namespace sofa::component::collision

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/AttachBodyPerformer.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/AttachBodyPerformer.cpp
@@ -39,8 +39,8 @@ template class SOFA_SOFAUSERINTERACTION_API  AttachBodyPerformer<defaulttype::Ve
 template class SOFA_SOFAUSERINTERACTION_API  AttachBodyPerformer<defaulttype::Vec3Types>;
 template class SOFA_SOFAUSERINTERACTION_API  AttachBodyPerformer<defaulttype::Rigid3Types>;
 
-static helper::Creator<InteractionPerformer::InteractionPerformerFactory, AttachBodyPerformer<defaulttype::Vec2Types> >  AttachBodyPerformerVec2dClass("AttachBody",true);
-static helper::Creator<InteractionPerformer::InteractionPerformerFactory, AttachBodyPerformer<defaulttype::Vec3Types> >  AttachBodyPerformerVec3dClass("AttachBody",true);
-static helper::Creator<InteractionPerformer::InteractionPerformerFactory, AttachBodyPerformer<defaulttype::Rigid3Types> >  AttachBodyPerformerRigid3dClass("AttachBody",true);
+helper::Creator<InteractionPerformer::InteractionPerformerFactory, AttachBodyPerformer<defaulttype::Vec2Types> >  AttachBodyPerformerVec2dClass("AttachBody",true);
+helper::Creator<InteractionPerformer::InteractionPerformerFactory, AttachBodyPerformer<defaulttype::Vec3Types> >  AttachBodyPerformerVec3dClass("AttachBody",true);
+helper::Creator<InteractionPerformer::InteractionPerformerFactory, AttachBodyPerformer<defaulttype::Rigid3Types> >  AttachBodyPerformerRigid3dClass("AttachBody",true);
 
 } // namespace sofa::component::collision

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/AttachBodyPerformer.inl
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/AttachBodyPerformer.inl
@@ -25,6 +25,7 @@
 #include <SofaUserInteraction/MouseInteractor.h>
 #include <sofa/core/BaseMapping.h>
 #include <sofa/simulation/Node.h>
+
 namespace sofa::component::collision
 {
 


### PR DESCRIPTION
Factories were used only with `std::string` as a key. That is why it was not noticeable that factories were not compatible with other types than `std::string` as the key.
The limitations come from:

- `logFactoryRegister` assumed `Key` is a string. It is now a template function.
- `Creator` inherits from `Key` and instances was used such as it was a string. Now, `Creator` no longer inherits from `Key` but just stores the key as a class member.

A unit test is added for enum type as a key.


Small downside: `std::string& getFactoryLog()` is now available outside the translation unit.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
