### PR TITLE
[SofaCore] Clearer message when template parameter is not compatible with current context

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/ObjectFactory.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/ObjectFactory.cpp
@@ -281,22 +281,23 @@ objectmodel::BaseObject::SPtr ObjectFactory::createObject(objectmodel::BaseConte
         for(unsigned int i = 0; i < templateList.size(); ++i)
         {
             ss << templateList[i];
-            isUserTemplateNameInTemplateList |= templateList[i] == usertemplatename || templateList[i] == userresolved;
+            isUserTemplateNameInTemplateList |= (templateList[i] == usertemplatename || templateList[i] == userresolved);
             if (i != templateList.size() - 1)
                 ss << ", ";
         }
         if (isUserTemplateNameInTemplateList)
         {
-            msg_warning(object.get()) << "Requested template '" << usertemplatename << "' is not compatible with the"
-                                         " current context. Falling back to the first compatible template: '"
-                                      << object->getTemplateName() << "'";
+            msg_warning(object.get()) << "Requested template '" << usertemplatename << "' "
+                                      << "is not compatible with the current context. "
+                                      << "Falling back to the first compatible template: '"
+                                      << object->getTemplateName() << "'.";
         }
         else
         {
-            const std::string w = "Requested template '" + usertemplatename + "' cannot be found in the list of available templates ["
-                + ss.str() + "].\n\t"
-                + "Falling back to default template '" + object->getTemplateName() + "'.";
-            msg_warning(object.get()) << w;
+            msg_warning(object.get()) << "Requested template '" << usertemplatename << "' "
+                                      << "cannot be found in the list of available templates [" << ss.str() << "]. "
+                                      << "Falling back to default template: '"
+                                      << object->getTemplateName() << "'.";
         }
     }
     else if (creators.size() > 1)

--- a/SofaKernel/modules/SofaCore/src/sofa/core/ObjectFactory.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/ObjectFactory.cpp
@@ -277,19 +277,30 @@ objectmodel::BaseObject::SPtr ObjectFactory::createObject(objectmodel::BaseConte
             for (const auto& cr : entry->creatorMap)
                 templateList.push_back(cr.first);
         std::stringstream ss;
+        bool isUserTemplateNameInTemplateList = false;
         for(unsigned int i = 0; i < templateList.size(); ++i)
         {
             ss << templateList[i];
+            isUserTemplateNameInTemplateList |= templateList[i] == usertemplatename || templateList[i] == userresolved;
             if (i != templateList.size() - 1)
                 ss << ", ";
         }
-        const std::string w = "Template '" + usertemplatename + "' cannot be found in the list of available templates ["
-                              + ss.str() + "].\n\t"
-                              + "Falling back to default template '" + object->getTemplateName() + "'.";
-        msg_warning(object.get()) << w;
+        if (isUserTemplateNameInTemplateList)
+        {
+            msg_warning(object.get()) << "Requested template '" << usertemplatename << "' is not compatible with the"
+                                         " current context. Falling back to the first compatible template: '"
+                                      << object->getTemplateName() << "'";
+        }
+        else
+        {
+            const std::string w = "Requested template '" + usertemplatename + "' cannot be found in the list of available templates ["
+                + ss.str() + "].\n\t"
+                + "Falling back to default template '" + object->getTemplateName() + "'.";
+            msg_warning(object.get()) << w;
+        }
     }
     else if (creators.size() > 1)
-    {	// There was multiple possibilities, we used the first one (not necessarily the default, as it can be incompatible)
+    {	// There were multiple possibilities, we used the first one (not necessarily the default, as it can be incompatible)
         std::string w = "Template '" + templatename + std::string("' incorrect, used ") + object->getTemplateName() + std::string(" in the list:");
         for(unsigned int i = 0; i < creators.size(); ++i)
             w += std::string("\n\t* ") + creators[i].first;


### PR DESCRIPTION
In the case the template parameter is in the list of possible template, but is not compatible with the current context, the message said the template is not in the list.
A new message is introduced for this special case.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
