### PR TITLE
[SofaConstraint] fix segfault in GenericConstraintSolver 

### DIFF
--- a/modules/SofaConstraint/src/SofaConstraint/GenericConstraintSolver.cpp
+++ b/modules/SofaConstraint/src/SofaConstraint/GenericConstraintSolver.cpp
@@ -620,11 +620,16 @@ void GenericConstraintProblem::clear(int nbC)
 
 void GenericConstraintProblem::freeConstraintResolutions()
 {
-    for(auto* constraintsResolution : constraintsResolutions)
+    for(unsigned int i=0; i<constraintsResolutions.size(); i++)
     {
-        delete constraintsResolution;
+        if (constraintsResolutions[i] != nullptr)
+        {
+            delete constraintsResolutions[i];
+            constraintsResolutions[i] = nullptr;
+        }
     }
 }
+
 int GenericConstraintProblem::getNumConstraints()
 {
     return dimension;

--- a/modules/SofaConstraint/src/SofaConstraint/GenericConstraintSolver.cpp
+++ b/modules/SofaConstraint/src/SofaConstraint/GenericConstraintSolver.cpp
@@ -620,13 +620,10 @@ void GenericConstraintProblem::clear(int nbC)
 
 void GenericConstraintProblem::freeConstraintResolutions()
 {
-    for(unsigned int i=0; i<constraintsResolutions.size(); i++)
+    for(auto*& constraintsResolution : constraintsResolutions)
     {
-        if (constraintsResolutions[i] != nullptr)
-        {
-            delete constraintsResolutions[i];
-            constraintsResolutions[i] = nullptr;
-        }
+        delete constraintsResolution;
+        constraintsResolution = nullptr;
     }
 }
 


### PR DESCRIPTION
This PR fixes a bug introduced in #2225. It's basically just a revert. 
Half of my scenes were crashing :(   






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
