### PR TITLE
[SofaConstraint] Better includes

### DIFF
--- a/modules/SofaConstraint/src/SofaConstraint/GenericConstraintSolver.h
+++ b/modules/SofaConstraint/src/SofaConstraint/GenericConstraintSolver.h
@@ -28,8 +28,7 @@
 #include <SofaBaseLinearSolver/SparseMatrix.h>
 #include <sofa/helper/map.h>
 
-#include <sofa/simulation/TaskScheduler.h>
-#include <sofa/simulation/InitTasks.h>
+#include <sofa/simulation/CpuTask.h>
 
 namespace sofa::component::constraintset
 {


### PR DESCRIPTION
- `InitTasks.h` was useful only because it includes `CpuTask.h`
- `TaskScheduler.h` is not necessary in the header file



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
