### PR TITLE
[SofaGraphComponent] Restore check of deprecated components 

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.h
@@ -62,7 +62,7 @@ public:
                   "and will be removed in SOFA " << untilVersion << ". "
                   "Please consider updating your scene as using "
                   "deprecated component may result in poor performance and undefined behavior. "
-                  "If this component is crucial to you please report that to sofa-dev@ so we can  "
+                  "If this component is crucial to you please report that to sofa-dev@ so we can "
                   "reconsider this component for future re-integration.";
         m_message = output.str();
         m_changeVersion = untilVersion;

--- a/modules/SofaGraphComponent/CMakeLists.txt
+++ b/modules/SofaGraphComponent/CMakeLists.txt
@@ -28,6 +28,7 @@ list(APPEND HEADER_FILES
     ${SOFAGRAPHCOMPONENT_SRC}/StatsSetting.h
     ${SOFAGRAPHCOMPONENT_SRC}/ViewerSetting.h
     ${SOFAGRAPHCOMPONENT_SRC}/SceneCheck.h
+    ${SOFAGRAPHCOMPONENT_SRC}/SceneCheckDeprecatedComponents.h
     ${SOFAGRAPHCOMPONENT_SRC}/SceneCheckDuplicatedName.h
     ${SOFAGRAPHCOMPONENT_SRC}/SceneCheckMissingRequiredPlugin.h
     ${SOFAGRAPHCOMPONENT_SRC}/SceneCheckAPIChange.h
@@ -48,6 +49,7 @@ list(APPEND SOURCE_FILES
     ${SOFAGRAPHCOMPONENT_SRC}/SofaDefaultPathSetting.cpp
     ${SOFAGRAPHCOMPONENT_SRC}/StatsSetting.cpp
     ${SOFAGRAPHCOMPONENT_SRC}/ViewerSetting.cpp
+    ${SOFAGRAPHCOMPONENT_SRC}/SceneCheckDeprecatedComponents.cpp
     ${SOFAGRAPHCOMPONENT_SRC}/SceneCheckDuplicatedName.cpp
     ${SOFAGRAPHCOMPONENT_SRC}/SceneCheckMissingRequiredPlugin.cpp
     ${SOFAGRAPHCOMPONENT_SRC}/SceneCheckAPIChange.cpp

--- a/modules/SofaGraphComponent/src/SofaGraphComponent/SceneCheckAPIChange.cpp
+++ b/modules/SofaGraphComponent/src/SofaGraphComponent/SceneCheckAPIChange.cpp
@@ -30,10 +30,6 @@ using sofa::core::objectmodel::Base;
 #include <sofa/simulation/Node.h>
 using sofa::simulation::Node;
 
-#include <sofa/helper/ComponentChange.h>
-using sofa::helper::lifecycle::ComponentChange;
-using sofa::helper::lifecycle::deprecatedComponents;
-
 #include "APIVersion.h"
 using sofa::component::APIVersion;
 
@@ -94,12 +90,6 @@ void SceneCheckAPIChange::doCheckOn(Node* node)
     {
         Base* o = object.get();
 
-        if( deprecatedComponents.find( o->getClassName() ) != deprecatedComponents.end() )
-        {
-            msg_deprecated(o) << this->getName() << ": "
-                              << deprecatedComponents.at(o->getClassName()).getMessage();
-        }
-
         if(m_selectedApiLevel != m_currentApiLevel && m_changesets.find(m_selectedApiLevel) != m_changesets.end())
         {
             for(auto& hook : m_changesets[m_selectedApiLevel])
@@ -109,7 +99,6 @@ void SceneCheckAPIChange::doCheckOn(Node* node)
         }
     }
 }
-
 
 void SceneCheckAPIChange::installDefaultChangeSets()
 {

--- a/modules/SofaGraphComponent/src/SofaGraphComponent/SceneCheckAPIChange.h
+++ b/modules/SofaGraphComponent/src/SofaGraphComponent/SceneCheckAPIChange.h
@@ -44,7 +44,7 @@ namespace sofa::core::objectmodel
 namespace sofa::simulation::_scenechecking_
 {
 
-typedef std::function<void(sofa::core::objectmodel::Base*)> ChangeSetHookFunction;
+typedef std::function<void(sofa::core::objectmodel::Base*)>     ChangeSetHookFunction;
 
 class SOFA_SOFAGRAPHCOMPONENT_API SceneCheckAPIChange : public SceneCheck
 {

--- a/modules/SofaGraphComponent/src/SofaGraphComponent/SceneCheckDeprecatedComponents.cpp
+++ b/modules/SofaGraphComponent/src/SofaGraphComponent/SceneCheckDeprecatedComponents.cpp
@@ -19,36 +19,51 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "SceneCheckerListener.h"
+#include <SofaGraphComponent/SceneCheckDeprecatedComponents.h>
 
 #include <sofa/simulation/Node.h>
-#include <SofaGraphComponent/SceneCheckMissingRequiredPlugin.h>
-#include <SofaGraphComponent/SceneCheckDuplicatedName.h>
-#include <SofaGraphComponent/SceneCheckUsingAlias.h>
-#include <SofaGraphComponent/SceneCheckDeprecatedComponents.h>
+using sofa::simulation::Node;
+
+#include <sofa/helper/ComponentChange.h>
+using sofa::helper::lifecycle::deprecatedComponents;
 
 namespace sofa::simulation::_scenechecking_
 {
 
-SceneCheckerListener::SceneCheckerListener()
+
+const std::string SceneCheckDeprecatedComponents::getName()
 {
-    m_sceneChecker.addCheck(SceneCheckDuplicatedName::newSPtr());
-    m_sceneChecker.addCheck(SceneCheckMissingRequiredPlugin::newSPtr());
-    m_sceneChecker.addCheck(SceneCheckUsingAlias::newSPtr());
-    m_sceneChecker.addCheck(SceneCheckDeprecatedComponents::newSPtr());
+    return "SceneCheckDeprecatedComponents";
 }
 
-SceneCheckerListener* SceneCheckerListener::getInstance()
+const std::string SceneCheckDeprecatedComponents::getDesc()
 {
-    static SceneCheckerListener sceneLoaderListener;
-    return &sceneLoaderListener;
+    return "Check there is not deprecated components in the scenegraph";
 }
 
-void SceneCheckerListener::rightAfterLoadingScene(sofa::simulation::Node::SPtr node)
+void SceneCheckDeprecatedComponents::doInit(Node* node)
 {
-    if(node.get())
-        m_sceneChecker.validate(node.get());
+    SOFA_UNUSED(node);
 }
 
+void SceneCheckDeprecatedComponents::doCheckOn(Node* node)
+{
+    if(node==nullptr)
+        return;
 
-} // nnamespace sofa::simulation::_scenechecking_
+    for (auto& object : node->object )
+    {
+        core::Base* o = object.get();
+
+        if( deprecatedComponents.find( o->getClassName() ) != deprecatedComponents.end() )
+        {
+            msg_deprecated(o) << this->getName() << ": "
+                << deprecatedComponents.at(o->getClassName()).getMessage();
+        }
+    }
+}
+
+void SceneCheckDeprecatedComponents::doPrintSummary()
+{}
+
+} //namespace sofa::simulation::_scenechecking_

--- a/modules/SofaGraphComponent/src/SofaGraphComponent/SceneCheckDeprecatedComponents.cpp
+++ b/modules/SofaGraphComponent/src/SofaGraphComponent/SceneCheckDeprecatedComponents.cpp
@@ -30,7 +30,6 @@ using sofa::helper::lifecycle::deprecatedComponents;
 namespace sofa::simulation::_scenechecking_
 {
 
-
 const std::string SceneCheckDeprecatedComponents::getName()
 {
     return "SceneCheckDeprecatedComponents";
@@ -48,22 +47,28 @@ void SceneCheckDeprecatedComponents::doInit(Node* node)
 
 void SceneCheckDeprecatedComponents::doCheckOn(Node* node)
 {
-    if(node==nullptr)
+    if (node == nullptr)
         return;
 
     for (auto& object : node->object )
     {
-        core::Base* o = object.get();
-
-        if( deprecatedComponents.find( o->getClassName() ) != deprecatedComponents.end() )
+        if (core::Base* o = object.get())
         {
-            msg_deprecated(o) << this->getName() << ": "
-                << deprecatedComponents.at(o->getClassName()).getMessage();
+            if( deprecatedComponents.find( o->getClassName() ) != deprecatedComponents.end() )
+            {
+                msg_deprecated(o) << this->getName() << ": "
+                    << deprecatedComponents.at(o->getClassName()).getMessage();
+            }
         }
     }
 }
 
 void SceneCheckDeprecatedComponents::doPrintSummary()
 {}
+
+std::shared_ptr<SceneCheckDeprecatedComponents> SceneCheckDeprecatedComponents::newSPtr()
+{
+    return std::shared_ptr<SceneCheckDeprecatedComponents>(new SceneCheckDeprecatedComponents());
+}
 
 } //namespace sofa::simulation::_scenechecking_

--- a/modules/SofaGraphComponent/src/SofaGraphComponent/SceneCheckDeprecatedComponents.h
+++ b/modules/SofaGraphComponent/src/SofaGraphComponent/SceneCheckDeprecatedComponents.h
@@ -19,36 +19,28 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "SceneCheckerListener.h"
+#pragma once
 
-#include <sofa/simulation/Node.h>
-#include <SofaGraphComponent/SceneCheckMissingRequiredPlugin.h>
-#include <SofaGraphComponent/SceneCheckDuplicatedName.h>
-#include <SofaGraphComponent/SceneCheckUsingAlias.h>
-#include <SofaGraphComponent/SceneCheckDeprecatedComponents.h>
+#include <SofaGraphComponent/config.h>
+#include <SofaGraphComponent/SceneCheck.h>
 
 namespace sofa::simulation::_scenechecking_
 {
 
-SceneCheckerListener::SceneCheckerListener()
+class SOFA_SOFAGRAPHCOMPONENT_API SceneCheckDeprecatedComponents : public SceneCheck
 {
-    m_sceneChecker.addCheck(SceneCheckDuplicatedName::newSPtr());
-    m_sceneChecker.addCheck(SceneCheckMissingRequiredPlugin::newSPtr());
-    m_sceneChecker.addCheck(SceneCheckUsingAlias::newSPtr());
-    m_sceneChecker.addCheck(SceneCheckDeprecatedComponents::newSPtr());
-}
+public:
+    virtual ~SceneCheckDeprecatedComponents() {}
+    static std::shared_ptr<SceneCheckDeprecatedComponents> newSPtr()
+    {
+        return std::shared_ptr<SceneCheckDeprecatedComponents>(new SceneCheckDeprecatedComponents());
+    }
 
-SceneCheckerListener* SceneCheckerListener::getInstance()
-{
-    static SceneCheckerListener sceneLoaderListener;
-    return &sceneLoaderListener;
-}
+    const std::string getName() override;
+    const std::string getDesc() override;
+    void doInit(Node* node) override;
+    void doCheckOn(Node* node) override;
+    void doPrintSummary() override;
+};
 
-void SceneCheckerListener::rightAfterLoadingScene(sofa::simulation::Node::SPtr node)
-{
-    if(node.get())
-        m_sceneChecker.validate(node.get());
-}
-
-
-} // nnamespace sofa::simulation::_scenechecking_
+} //namespace sofa::simulation::_scenechecking_

--- a/modules/SofaGraphComponent/src/SofaGraphComponent/SceneCheckDeprecatedComponents.h
+++ b/modules/SofaGraphComponent/src/SofaGraphComponent/SceneCheckDeprecatedComponents.h
@@ -31,10 +31,7 @@ class SOFA_SOFAGRAPHCOMPONENT_API SceneCheckDeprecatedComponents : public SceneC
 {
 public:
     virtual ~SceneCheckDeprecatedComponents() {}
-    static std::shared_ptr<SceneCheckDeprecatedComponents> newSPtr()
-    {
-        return std::shared_ptr<SceneCheckDeprecatedComponents>(new SceneCheckDeprecatedComponents());
-    }
+    static std::shared_ptr<SceneCheckDeprecatedComponents> newSPtr();
 
     const std::string getName() override;
     const std::string getDesc() override;


### PR DESCRIPTION
Introduction of a scene checker SceneCheckDeprecatedComponents. Its job is to check for deprecated components in the scene, which was done previously by SceneCheckAPIChange. But SceneCheckAPIChange is no longer enabled.

Note that SceneCheckAPIChange requires an APIVersion component in the scene, but does not use it to check for deprecated components. That is why I decided to move this check elsewhere.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
