### PR TITLE
[SofaBoundaryCondition] Deprecate PointConstraint

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.cpp
@@ -35,6 +35,7 @@ std::map<std::string, Deprecated> deprecatedComponents = {
     {"RayTraceDetection", Deprecated("v21.06", "v21.12")},
     {"BruteForceDetection", Deprecated("v21.06", "v21.12")},
     {"DirectSAP", Deprecated("v21.06", "v21.12")},
+    {"PointConstraint", Deprecated("v21.12", "v22.06")},
 };
 
 std::map<std::string, ComponentChange> uncreatableComponents = {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialFixedConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialFixedConstraint.inl
@@ -264,7 +264,55 @@ void PartialFixedConstraint<DataTypes>::applyConstraint(const core::MechanicalPa
     core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate.get());
     if(r)
     {
-        applyConstraint(r.matrix, r.offset);
+        const unsigned int N = Deriv::size();
+        const VecBool& blockedDirection = d_fixedDirections.getValue();
+        const SetIndexArray & indices = this->d_indices.getValue();
+
+        if( this->d_fixAll.getValue() )
+        {
+            unsigned size = this->mstate->getSize();
+            for(unsigned int i=0; i<size; i++)
+            {
+                // Reset Fixed Row and Col
+                for (unsigned int c=0; c<N; ++c)
+                {
+                    if (blockedDirection[c])
+                    {
+                        r.matrix->clearRowCol(r.offset + N * i + c);
+                    }
+                }
+                // Set Fixed Vertex
+                for (unsigned int c=0; c<N; ++c)
+                {
+                    if (blockedDirection[c])
+                    {
+                        r.matrix->set(r.offset + N * i + c, r.offset + N * i + c, 1.0);
+                    }
+                }
+            }
+        }
+        else
+        {
+            for (SetIndexArray::const_iterator it = indices.begin(); it != indices.end(); ++it)
+            {
+                // Reset Fixed Row and Col
+                for (unsigned int c=0; c<N; ++c)
+                {
+                    if (blockedDirection[c])
+                    {
+                        r.matrix->clearRowCol(r.offset + N * (*it) + c);
+                    }
+                }
+                // Set Fixed Vertex
+                for (unsigned int c=0; c<N; ++c)
+                {
+                    if (blockedDirection[c])
+                    {
+                        r.matrix->set(r.offset + N * (*it) + c, r.offset + N * (*it) + c, 1.0);
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialFixedConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialFixedConstraint.inl
@@ -264,55 +264,7 @@ void PartialFixedConstraint<DataTypes>::applyConstraint(const core::MechanicalPa
     core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate.get());
     if(r)
     {
-        const unsigned int N = Deriv::size();
-        const VecBool& blockedDirection = d_fixedDirections.getValue();
-        const SetIndexArray & indices = this->d_indices.getValue();
-
-        if( this->d_fixAll.getValue() )
-        {
-            unsigned size = this->mstate->getSize();
-            for(unsigned int i=0; i<size; i++)
-            {
-                // Reset Fixed Row and Col
-                for (unsigned int c=0; c<N; ++c)
-                {
-                    if (blockedDirection[c])
-                    {
-                        r.matrix->clearRowCol(r.offset + N * i + c);
-                    }
-                }
-                // Set Fixed Vertex
-                for (unsigned int c=0; c<N; ++c)
-                {
-                    if (blockedDirection[c])
-                    {
-                        r.matrix->set(r.offset + N * i + c, r.offset + N * i + c, 1.0);
-                    }
-                }
-            }
-        }
-        else
-        {
-            for (SetIndexArray::const_iterator it = indices.begin(); it != indices.end(); ++it)
-            {
-                // Reset Fixed Row and Col
-                for (unsigned int c=0; c<N; ++c)
-                {
-                    if (blockedDirection[c])
-                    {
-                        r.matrix->clearRowCol(r.offset + N * (*it) + c);
-                    }
-                }
-                // Set Fixed Vertex
-                for (unsigned int c=0; c<N; ++c)
-                {
-                    if (blockedDirection[c])
-                    {
-                        r.matrix->set(r.offset + N * (*it) + c, r.offset + N * (*it) + c, 1.0);
-                    }
-                }
-            }
-        }
+        applyConstraint(r.matrix, r.offset);
     }
 }
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PointConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PointConstraint.h
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 #include <SofaBoundaryCondition/config.h>
+#include <sofa/config.h>
 
 #include <sofa/core/behavior/ProjectiveConstraintSet.h>
 #include <sofa/core/behavior/MechanicalState.h>
@@ -40,7 +41,8 @@ namespace sofa::component::projectiveconstraintset
 /** Attach given particles to their initial positions. This is a temporary class, somehow redundant with FixedConstraint, simplified to avoid the memory leak issue. @todo Remove one of the two classes
 */
 template <class DataTypes>
-class PointConstraint : public core::behavior::ProjectiveConstraintSet<DataTypes>
+class SOFA_ATTRIBUTE_DEPRECATED("v21.12", "v22.06", "As an alternative, use FixedConstraint.")
+PointConstraint : public core::behavior::ProjectiveConstraintSet<DataTypes>
 {
 public:
     SOFA_CLASS(SOFA_TEMPLATE(PointConstraint,DataTypes),SOFA_TEMPLATE(sofa::core::behavior::ProjectiveConstraintSet, DataTypes));


### PR DESCRIPTION
PointConstraint was introduced in https://github.com/sofa-framework/sofa/commit/a30c68b77e3686fce3c4409b21600a3bc565f51e as a temporary component to be removed later.
It is redundant with FixedConstraint.
A problem with "memory leak issue" is mentioned. I don't know if it has been fixed.
Note that I did not find any use of this component in scene files.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
