### PR TITLE
[SofaBoundaryCondition] Fix constraints in assembled systems

### DIFF
--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.h
@@ -129,9 +129,8 @@ public:
 
     void projectMatrix( sofa::defaulttype::BaseMatrix* /*M*/, unsigned /*offset*/ ) override;
 
-    using core::behavior::ProjectiveConstraintSet<TDataTypes>::applyConstraint;
-    void applyConstraint(defaulttype::BaseMatrix *mat, unsigned int offset);
-    void applyConstraint(defaulttype::BaseVector *vect, unsigned int offset);
+    void applyConstraint(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
+    void applyConstraint(const core::MechanicalParams* mparams, defaulttype::BaseVector* vector, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialFixedConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialFixedConstraint.h
@@ -81,9 +81,7 @@ public:
     void projectVelocity(const core::MechanicalParams* mparams, DataVecDeriv& vData) override;
     void projectJacobianMatrix(const core::MechanicalParams* mparams, DataMatrixDeriv& cData) override;
 
-    using core::behavior::ProjectiveConstraintSet<DataTypes>::applyConstraint;
-    void applyConstraint(defaulttype::BaseMatrix *mat, unsigned int offset);
-    void applyConstraint(defaulttype::BaseVector *vect, unsigned int offset);
+    void applyConstraint(const core::MechanicalParams* mparams, defaulttype::BaseVector* vector, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
     void applyConstraint(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
 
     void projectMatrix( sofa::defaulttype::BaseMatrix* /*M*/, unsigned /*offset*/ ) override;

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialFixedConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialFixedConstraint.inl
@@ -175,82 +175,42 @@ void PartialFixedConstraint<DataTypes>::projectJacobianMatrix(const core::Mechan
     }
 }
 
-// Matrix Integration interface
 template <class DataTypes>
-void PartialFixedConstraint<DataTypes>::applyConstraint(defaulttype::BaseMatrix *mat, unsigned int offset)
+void PartialFixedConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* mparams, defaulttype::BaseVector* vector, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {
-
-    const unsigned int N = Deriv::size();
-    const VecBool& blockedDirection = d_fixedDirections.getValue();
-
-    if( this->d_fixAll.getValue() )
+    SOFA_UNUSED(mparams);
+    int o = matrix->getGlobalOffset(this->mstate.get());
+    if (o >= 0)
     {
-        unsigned size = this->mstate->getSize();
-        for(unsigned int i=0; i<size; i++)
+        unsigned int offset = (unsigned int)o;
+        const unsigned int N = Deriv::size();
+
+        const VecBool& blockedDirection = d_fixedDirections.getValue();
+
+        if( this->d_fixAll.getValue() )
         {
-            // Reset Fixed Row and Col
-            for (unsigned int c=0; c<N; ++c)
+            for(sofa::Index i=0; i<(sofa::Size) vector->size(); i++ )
             {
-                if( blockedDirection[c] ) mat->clearRowCol(offset + N * i + c);
-            }
-            // Set Fixed Vertex
-            for (unsigned int c=0; c<N; ++c)
-            {
-                if( blockedDirection[c] ) mat->set(offset + N * i + c, offset + N * i + c, 1.0);
-            }
-        }
-    }
-    else
-    {
-        const SetIndexArray & indices = this->d_indices.getValue();
-        for (SetIndexArray::const_iterator it = indices.begin(); it != indices.end(); ++it)
-        {
-            // Reset Fixed Row and Col
-            for (unsigned int c=0; c<N; ++c)
-            {
-                if( blockedDirection[c] ) mat->clearRowCol(offset + N * (*it) + c);
-            }
-            // Set Fixed Vertex
-            for (unsigned int c=0; c<N; ++c)
-            {
-                if( blockedDirection[c] ) mat->set(offset + N * (*it) + c, offset + N * (*it) + c, 1.0);
-            }
-        }
-    }
-}
-
-template <class DataTypes>
-void PartialFixedConstraint<DataTypes>::applyConstraint(defaulttype::BaseVector *vect, unsigned int offset)
-{
-
-
-    const unsigned int N = Deriv::size();
-
-    const VecBool& blockedDirection = d_fixedDirections.getValue();
-
-    if( this->d_fixAll.getValue() )
-    {
-        for(sofa::Index i=0; i<(sofa::Size) vect->size(); i++ )
-        {
-            for (unsigned int c = 0; c < N; ++c)
-            {
-                if (blockedDirection[c])
+                for (unsigned int c = 0; c < N; ++c)
                 {
-                    vect->clear(offset + N * i + c);
+                    if (blockedDirection[c])
+                    {
+                        vector->clear(offset + N * i + c);
+                    }
                 }
             }
         }
-    }
-    else
-    {
-        const SetIndexArray & indices = this->d_indices.getValue();
-        for (unsigned int index : indices)
+        else
         {
-            for (unsigned int c = 0; c < N; ++c)
+            const SetIndexArray & indices = this->d_indices.getValue();
+            for (unsigned int index : indices)
             {
-                if (blockedDirection[c])
+                for (unsigned int c = 0; c < N; ++c)
                 {
-                    vect->clear(offset + N * index + c);
+                    if (blockedDirection[c])
+                    {
+                        vector->clear(offset + N * index + c);
+                    }
                 }
             }
         }

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PointConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PointConstraint.h
@@ -77,9 +77,8 @@ public:
     void projectJacobianMatrix(const core::MechanicalParams* mparams, DataMatrixDeriv& cData) override;
     virtual const sofa::defaulttype::BaseMatrix* getJ(const core::MechanicalParams* );
 
-    using core::behavior::ProjectiveConstraintSet<DataTypes>::applyConstraint;
-    void applyConstraint(defaulttype::BaseMatrix *mat, unsigned int offset);
-    void applyConstraint(defaulttype::BaseVector *vect, unsigned int offset);
+    void applyConstraint(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
+    void applyConstraint(const core::MechanicalParams* mparams, defaulttype::BaseVector* vector, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.h
@@ -109,9 +109,8 @@ public:
     void projectPosition(const core::MechanicalParams* mparams, DataVecCoord& xData) override;
     void projectJacobianMatrix(const core::MechanicalParams* mparams, DataMatrixDeriv& cData) override;
 
-    using core::behavior::ProjectiveConstraintSet<DataTypes>::applyConstraint;
-    void applyConstraint(defaulttype::BaseMatrix *mat, unsigned int offset);
-    void applyConstraint(defaulttype::BaseVector *vect, unsigned int offset);
+    void applyConstraint(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
+    void applyConstraint(const core::MechanicalParams* mparams, defaulttype::BaseVector* vector, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
 
     /// Project the the given matrix (Experimental API, see the spec in sofa::core::behavior::BaseProjectiveConstraintSet).
     void projectMatrix( sofa::defaulttype::BaseMatrix* /*M*/, unsigned /*offset*/ ) override;

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.inl
@@ -225,15 +225,15 @@ void ProjectDirectionConstraint<DataTypes>::projectPosition(const core::Mechanic
 }
 
 template <class DataTypes>
-void ProjectDirectionConstraint<DataTypes>::applyConstraint(defaulttype::BaseMatrix * /*mat*/, unsigned int /*offset*/)
+void ProjectDirectionConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* /*mparams*/, const sofa::core::behavior::MultiMatrixAccessor* /*matrix*/)
 {
-    msg_error() << "applyConstraint is not implemented ";
+    msg_error() << "applyConstraint is not implemented";
 }
 
 template <class DataTypes>
-void ProjectDirectionConstraint<DataTypes>::applyConstraint(defaulttype::BaseVector * /*vect*/, unsigned int /*offset*/)
+void ProjectDirectionConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* /*mparams*/, defaulttype::BaseVector* /*vector*/, const sofa::core::behavior::MultiMatrixAccessor* /*matrix*/)
 {
-    msg_error() << "ProjectDirectionConstraint<DataTypes>::applyConstraint(defaulttype::BaseVector *vect, unsigned int offset) is not implemented ";
+    dmsg_error() << "ProjectDirectionConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* mparams, defaulttype::BaseVector* vector, const sofa::core::behavior::MultiMatrixAccessor* matrix) is not implemented";
 }
 
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.h
@@ -109,9 +109,8 @@ public:
     void projectPosition(const core::MechanicalParams* mparams, DataVecCoord& xData) override;
     void projectJacobianMatrix(const core::MechanicalParams* mparams, DataMatrixDeriv& cData) override;
 
-    using core::behavior::ProjectiveConstraintSet<DataTypes>::applyConstraint;
-    void applyConstraint(defaulttype::BaseMatrix *mat, unsigned int offset);
-    void applyConstraint(defaulttype::BaseVector *vect, unsigned int offset);
+    void applyConstraint(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
+    void applyConstraint(const core::MechanicalParams* mparams, defaulttype::BaseVector* vector, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
 
     /// Project the the given matrix (Experimental API, see the spec in sofa::core::behavior::BaseProjectiveConstraintSet).
     void projectMatrix( sofa::defaulttype::BaseMatrix* /*M*/, unsigned /*offset*/ ) override;

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.inl
@@ -229,15 +229,15 @@ void ProjectToLineConstraint<DataTypes>::projectPosition(const core::MechanicalP
 
 // Matrix Integration interface
 template <class DataTypes>
-void ProjectToLineConstraint<DataTypes>::applyConstraint(defaulttype::BaseMatrix * /*mat*/, unsigned int /*offset*/)
+void ProjectToLineConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* /*mparams*/, const sofa::core::behavior::MultiMatrixAccessor* /*matrix*/)
 {
     msg_error() << "applyConstraint is not implemented ";
 }
 
 template <class DataTypes>
-void ProjectToLineConstraint<DataTypes>::applyConstraint(defaulttype::BaseVector * /*vect*/, unsigned int /*offset*/)
+void ProjectToLineConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* /*mparams*/, defaulttype::BaseVector* /*vector*/, const sofa::core::behavior::MultiMatrixAccessor* /*matrix*/)
 {
-    msg_error() << "ProjectToLineConstraint<DataTypes>::applyConstraint(defaulttype::BaseVector *vect, unsigned int offset) is not implemented ";
+    msg_error() << "ProjectToLineConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* mparams, defaulttype::BaseVector* vector, const sofa::core::behavior::MultiMatrixAccessor* matrix) is not implemented ";
 }
 
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.h
@@ -108,9 +108,8 @@ public:
     void projectPosition(const core::MechanicalParams* mparams, DataVecCoord& xData) override;
     void projectJacobianMatrix(const core::MechanicalParams* mparams, DataMatrixDeriv& cData) override;
 
-    using core::behavior::ProjectiveConstraintSet<DataTypes>::applyConstraint;
-    void applyConstraint(defaulttype::BaseMatrix *mat, unsigned int offset);
-    void applyConstraint(defaulttype::BaseVector *vect, unsigned int offset);
+    void applyConstraint(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
+    void applyConstraint(const core::MechanicalParams* mparams, defaulttype::BaseVector* vector, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
 
     /** Project the the given matrix (Experimental API).
       Replace M with PMP, where P is the projection matrix corresponding to the projectResponse method, shifted by the given offset, i.e. P is the identity matrix with a block on the diagonal replaced by the projection matrix.

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
@@ -226,15 +226,15 @@ void ProjectToPlaneConstraint<DataTypes>::projectPosition(const core::Mechanical
 }
 
 template <class DataTypes>
-void ProjectToPlaneConstraint<DataTypes>::applyConstraint(defaulttype::BaseMatrix * /*mat*/, unsigned int /*offset*/)
+void ProjectToPlaneConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* /*mparams*/, const sofa::core::behavior::MultiMatrixAccessor* /*matrix*/)
 {
     msg_error() << "applyConstraint is not implemented ";
 }
 
 template <class DataTypes>
-void ProjectToPlaneConstraint<DataTypes>::applyConstraint(defaulttype::BaseVector * /*vect*/, unsigned int /*offset*/)
+void ProjectToPlaneConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* /*mparams*/, defaulttype::BaseVector* /*vector*/, const sofa::core::behavior::MultiMatrixAccessor* /*matrix*/)
 {
-    msg_error() << "ProjectToPlaneConstraint<DataTypes>::applyConstraint(defaulttype::BaseVector *vect, unsigned int offset) is not implemented ";
+    msg_error() << "ProjectToPlaneConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* mparams, defaulttype::BaseVector* vector, const sofa::core::behavior::MultiMatrixAccessor* matrix) is not implemented ";
 }
 
 template <class DataTypes>

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.h
@@ -102,9 +102,8 @@ public:
     void projectPosition(const core::MechanicalParams* mparams, DataVecCoord& xData) override;
     void projectJacobianMatrix(const core::MechanicalParams* mparams, DataMatrixDeriv& cData) override;
 
-    using core::behavior::ProjectiveConstraintSet<DataTypes>::applyConstraint;
-    void applyConstraint(defaulttype::BaseMatrix *mat, unsigned int offset);
-    void applyConstraint(defaulttype::BaseVector *vect, unsigned int offset);
+    void applyConstraint(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
+    void applyConstraint(const core::MechanicalParams* mparams, defaulttype::BaseVector* vector, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
 
     /** Project the the given matrix (Experimental API).
       Replace M with PMP, where P is the projection matrix corresponding to the projectResponse method, shifted by the given offset, i.e. P is the identity matrix with a block on the diagonal replaced by the projection matrix.

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.inl
@@ -238,32 +238,43 @@ void ProjectToPointConstraint<DataTypes>::projectPosition(const core::Mechanical
 }
 
 template <class DataTypes>
-void ProjectToPointConstraint<DataTypes>::applyConstraint(defaulttype::BaseMatrix *mat, unsigned int offset)
+void ProjectToPointConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {
-    const unsigned int N = Deriv::size();
-    const SetIndexArray & indices = f_indices.getValue();
-
-    for (SetIndexArray::const_iterator it = indices.begin(); it != indices.end(); ++it)
+    SOFA_UNUSED(mparams);
+    core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate.get());
+    if(r)
     {
-        // Reset Fixed Row and Col
-        for (unsigned int c=0; c<N; ++c)
-            mat->clearRowCol(offset + N * (*it) + c);
-        // Set Fixed Vertex
-        for (unsigned int c=0; c<N; ++c)
-            mat->set(offset + N * (*it) + c, offset + N * (*it) + c, 1.0);
+        const unsigned int N = Deriv::size();
+        const SetIndexArray & indices = f_indices.getValue();
+
+        for (SetIndexArray::const_iterator it = indices.begin(); it != indices.end(); ++it)
+        {
+            // Reset Fixed Row and Col
+            for (unsigned int c=0; c<N; ++c)
+                r.matrix->clearRowCol(r.offset + N * (*it) + c);
+            // Set Fixed Vertex
+            for (unsigned int c=0; c<N; ++c)
+                r.matrix->set(r.offset + N * (*it) + c, r.offset + N * (*it) + c, 1.0);
+        }
     }
 }
 
 template <class DataTypes>
-void ProjectToPointConstraint<DataTypes>::applyConstraint(defaulttype::BaseVector *vect, unsigned int offset)
+void ProjectToPointConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* mparams, defaulttype::BaseVector* vector, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {
-    const unsigned int N = Deriv::size();
-
-    const SetIndexArray & indices = f_indices.getValue();
-    for (SetIndexArray::const_iterator it = indices.begin(); it != indices.end(); ++it)
+    SOFA_UNUSED(mparams);
+    int o = matrix->getGlobalOffset(this->mstate.get());
+    if (o >= 0)
     {
-        for (unsigned int c=0; c<N; ++c)
-            vect->clear(offset + N * (*it) + c);
+        unsigned int offset = (unsigned int)o;
+        const unsigned int N = Deriv::size();
+
+        const SetIndexArray & indices = f_indices.getValue();
+        for (SetIndexArray::const_iterator it = indices.begin(); it != indices.end(); ++it)
+        {
+            for (unsigned int c=0; c<N; ++c)
+                vector->clear(offset + N * (*it) + c);
+        }
     }
 }
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SkeletalMotionConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SkeletalMotionConstraint.h
@@ -79,8 +79,8 @@ public:
     void projectJacobianMatrix(const core::MechanicalParams* mparams, DataMatrixDeriv& cData) override;
 
     using core::behavior::ProjectiveConstraintSet<TDataTypes>::applyConstraint;
-    void applyConstraint(defaulttype::BaseMatrix *mat, unsigned int offset);
-    void applyConstraint(defaulttype::BaseVector *vect, unsigned int offset);
+    void applyConstraint(const core::MechanicalParams* mparams, defaulttype::BaseVector* vector, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
+    void applyConstraint(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
 
     void projectMatrix( sofa::defaulttype::BaseMatrix* M, unsigned offset ) override;
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SkeletalMotionConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SkeletalMotionConstraint.inl
@@ -28,6 +28,7 @@
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/defaulttype/BaseMatrix.h>
 #include <iostream>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
 
 namespace sofa::component::projectiveconstraintset
 {
@@ -304,7 +305,7 @@ void SkeletalMotionConstraint<DataTypes>::addChannel(unsigned int jointIndex , C
 
 // Matrix Integration interface
 template <class DataTypes>
-void SkeletalMotionConstraint<DataTypes>::applyConstraint(defaulttype::BaseMatrix * /*mat*/, unsigned int /*offset*/)
+void SkeletalMotionConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* /*mparams*/, const sofa::core::behavior::MultiMatrixAccessor* /*matrix*/)
 {
     if( !active.getValue() ) return;
 
@@ -323,7 +324,7 @@ void SkeletalMotionConstraint<DataTypes>::applyConstraint(defaulttype::BaseMatri
 }
 
 template <class DataTypes>
-void SkeletalMotionConstraint<DataTypes>::applyConstraint(defaulttype::BaseVector * /*vect*/, unsigned int /*offset*/)
+void SkeletalMotionConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* /*mparams*/, defaulttype::BaseVector* /*vector*/, const sofa::core::behavior::MultiMatrixAccessor* /*matrix*/)
 {
     if( !active.getValue() ) return;
 


### PR DESCRIPTION
`applyConstraint` was not correctly overriden in some constraint component. Instead, they kept an old API which is no longer called.

API changed in https://github.com/sofa-framework/sofa/commit/55121be3494a4fe833904750fc7f043ff045881d.

The list of affected components:

- modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.h
- modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialFixedConstraint.h
- modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PointConstraint.h
- modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.h
- modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.h
- modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.h
- modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.h
- modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.h
- modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SkeletalMotionConstraint.h

Note that some of them don't implement `applyConstraint`. They had the old API, but with a message warning that the method is not implemented.

This problem was not caught before, because the majority of the test scenes uses a matrix-free solver (CGLinearSolver), whereas `applyConstraint` is called only for assembled systems (with SparseLDLSolver for example).



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
