### PR TITLE
[SofaKernel] Remove ambiguous constructors from type::vector

### DIFF
--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/vector_T.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/vector_T.h
@@ -73,10 +73,6 @@ public:
     /// Constructor
     vector(Size n, const T& value): std::vector<T,Alloc>(n,value) {}
     /// Constructor
-    vector(int n, const T& value): std::vector<T,Alloc>(n,value) {}
-    /// Constructor
-    vector(long n, const T& value): std::vector<T,Alloc>(n,value) {}
-    /// Constructor
     explicit vector(Size n): std::vector<T,Alloc>(n) {}
     /// Constructor
     vector(const std::vector<T, Alloc>& x): std::vector<T,Alloc>(x) {}


### PR DESCRIPTION
The `sofa::type::vector<T>` class has three ambiguous constructors:

```c++
vector(Size n, const T& value): std::vector<T,Alloc>(n,value) {}
vector(int n, const T& value): std::vector<T,Alloc>(n,value) {}
vector(long n, const T& value): std::vector<T,Alloc>(n,value) {}
```
effectively making the constructor taking a `sofa::Size` useless: using it will result in an ambiguous call since it can be implicitly converted to both `int` and `long`.

This PR remove two of them and keep only the `vector(Size n, const T& value)` one.

Steps to reproduce
1. **main.cpp**
```c++
#include <sofa/type/vector.h>
#include <iostream>

int main() {
    using namespace sofa::type;
    vector<double> d_v (sofa::Size(5), 0);
    std::cout << d_v << std::endl;
    return 0;
}
```
2. **Compile**
```sh
$ gcc -isystem $SOFA_ROOT/include/Sofa.Type -isystem $SOFA_ROOT/include/Sofa.Config -o main.o -c main.cpp
```
```sh
main.cpp: In function ‘int main()’:
main.cpp:6:41: error: call of overloaded ‘vector(sofa::Size, int)’ is ambiguous
    6 |     vector<double> d_v (sofa::Size(5), 0);
      |                                         ^
In file included from /sofa/include/Sofa.Type/sofa/type/vector.h:24,
                 from main.cpp:1:
/sofa/include/Sofa.Type/sofa/type/vector_T.h:78:5: note: candidate: ‘sofa::type::vector<T, MemoryManager>::vector(long int, const T&) [with T = double; MemoryManager = sofa::type::CPUMemoryManager<double>]’
   78 |     vector(long n, const T& value): std::vector<T,Alloc>(n,value) {}
      |     ^~~~~~
/sofa/include/Sofa.Type/sofa/type/vector_T.h:76:5: note: candidate: ‘sofa::type::vector<T, MemoryManager>::vector(int, const T&) [with T = double; MemoryManager = sofa::type::CPUMemoryManager<double>]’
   76 |     vector(int n, const T& value): std::vector<T,Alloc>(n,value) {}
      |     ^~~~~~
/sofa/include/Sofa.Type/sofa/type/vector_T.h:74:5: note: candidate: ‘sofa::type::vector<T, MemoryManager>::vector(sofa::type::vector<T, MemoryManager>::Size, const T&) [with T = double; MemoryManager = sofa::type::CPUMemoryManager<double>; sofa::type::vector<T, MemoryManager>::Size = long unsigned int]’
   74 |     vector(Size n, const T& value): std::vector<T,Alloc>(n,value) {}
      |     ^~~~~~
```

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
