### PR TITLE
[SofaMiscFEM] Small optimizations on TriangularFEMForceField (speedup ~x1.6)

### DIFF
--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.h
@@ -251,7 +251,7 @@ protected :
     void computeStrainDisplacement(StrainDisplacement &J, Index elementIndex, Coord a, Coord b, Coord c );
     void computeStiffness(StrainDisplacement &J, Stiffness &K, MaterialStiffness &D);
     void computeStrain(type::Vec<3,Real> &strain, const StrainDisplacement &J, const Displacement &D);
-    void computeStress(type::Vec<3,Real> &stress, MaterialStiffness &K, type::Vec<3,Real> &strain);
+    void computeStress(type::Vec<3,Real> &stress, const MaterialStiffness &K, const type::Vec<3,Real> &strain);
     void computeForce(Displacement &F, Index elementIndex, const VecCoord &p);
     void computePrincipalStrain(Index elementIndex, type::Vec<3,Real> &strain);
     void computePrincipalStress(Index elementIndex, type::Vec<3,Real> &stress);

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
@@ -196,7 +196,7 @@ void TriangularFEMForceField<DataTypes>::initSmall(int i, Index&a, Index&b, Inde
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::initLarge(int i, Index&a, Index&b, Index&c)
 {
-    type::vector<TriangleInformation>& triangleInf = *(triangleInfo.beginEdit());
+    type::vector<TriangleInformation>& triangleInf = *(triangleInfo.beginWriteOnly());
 
     msg_error_when((unsigned int)i >= triangleInf.size())
             << "Try to access an element which indices bigger than the size of the vector: i=" << i << " and size=" << triangleInf.size() ;
@@ -261,9 +261,9 @@ void TriangularFEMForceField<DataTypes>::reinit()
     else if (f_method.getValue() == "large")
         method = LARGE;
 
-    type::vector<EdgeInformation>& edgeInf = *(edgeInfo.beginEdit());
+    type::vector<EdgeInformation>& edgeInf = *(edgeInfo.beginWriteOnly());
 
-    type::vector<TriangleInformation>& triangleInf = *(triangleInfo.beginEdit());
+    type::vector<TriangleInformation>& triangleInf = *(triangleInfo.beginWriteOnly());
 
     /// prepare to store info in the triangle array
     triangleInf.resize(m_topology->getNbTriangles());
@@ -273,7 +273,7 @@ void TriangularFEMForceField<DataTypes>::reinit()
 
 
     unsigned int nbPoints = m_topology->getNbPoints();
-    type::vector<VertexInformation>& vi = *(vertexInfo.beginEdit());
+    type::vector<VertexInformation>& vi = *(vertexInfo.beginWriteOnly());
     vi.resize(nbPoints);
     vertexInfo.endEdit();
 
@@ -679,15 +679,13 @@ void TriangularFEMForceField<DataTypes>::computeDisplacementSmall(Displacement &
     Coord deforme_b = p[b]-p[a];
     Coord deforme_c = p[c]-p[a];
 
-    type::vector<TriangleInformation>& triangleInf = *(triangleInfo.beginEdit());
-
+    const type::vector<TriangleInformation>& triangleInf = triangleInfo.getValue();
     D[0] = 0;
     D[1] = 0;
     D[2] = triangleInf[elementIndex].rotatedInitialElements[1][0] - deforme_b[0];
     D[3] = triangleInf[elementIndex].rotatedInitialElements[1][1] - deforme_b[1];
     D[4] = triangleInf[elementIndex].rotatedInitialElements[2][0] - deforme_c[0];
     D[5] = triangleInf[elementIndex].rotatedInitialElements[2][1] - deforme_c[1];
-    triangleInfo.endEdit();
 }
 
 // -------------------------------------------------------------------------------------------------------------
@@ -705,7 +703,7 @@ void TriangularFEMForceField<DataTypes>::computeDisplacementLarge(Displacement &
     Coord deforme_b = R_0_2 * (p[b]-p[a]);
     Coord deforme_c = R_0_2 * (p[c]-p[a]);
 
-    type::vector<TriangleInformation>& triangleInf = *(triangleInfo.beginEdit());
+    const type::vector<TriangleInformation>& triangleInf = triangleInfo.getValue();
 
     // displacements
     D[0] = 0;
@@ -721,8 +719,6 @@ void TriangularFEMForceField<DataTypes>::computeDisplacementLarge(Displacement &
                    << "computeDisplacementLarge :: deforme_c = " <<  deforme_c << msgendl
                    << "computeDisplacementLarge :: R_0_2 = " <<  R_0_2 << msgendl;
     }
-
-    triangleInfo.endEdit();
 }
 
 // ------------------------------------------------------------------------------------------------------------
@@ -732,7 +728,7 @@ template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::computeStrainDisplacement(StrainDisplacement &J, Index elementIndex, Coord a, Coord b, Coord c )
 {
     Real determinant;
-    type::vector<TriangleInformation>& triangleInf = *(triangleInfo.beginEdit());
+    type::vector<TriangleInformation>& triangleInf = *(triangleInfo.beginWriteOnly());
 
     if (method == SMALL)
     {
@@ -887,7 +883,7 @@ void TriangularFEMForceField<DataTypes>::computePrincipalStrain(Index elementInd
     Coord v((Real)V(1,1), (Real)V(2,1), 0.0);
     v.normalize();
 
-    type::vector<TriangleInformation>& triangleInf = *(triangleInfo.beginEdit());
+    type::vector<TriangleInformation>& triangleInf = *(triangleInfo.beginWriteOnly());
 
     triangleInf[elementIndex].maxStrain = (Real)D(1,1);
 
@@ -1028,7 +1024,7 @@ void TriangularFEMForceField<DataTypes>::computeForce(Displacement &F, Index ele
     Index b = tri[1];
     Index c = tri[2];
 
-    type::vector<TriangleInformation>& triangleInf = *(triangleInfo.beginEdit());
+    type::vector<TriangleInformation>& triangleInf = *(triangleInfo.beginWriteOnly());
 
     if (method == SMALL)
     {
@@ -1270,7 +1266,7 @@ void TriangularFEMForceField<DataTypes>::applyStiffnessLarge(VecCoord &v, Real h
     Coord x_2;
     unsigned int nbTriangles = m_topology->getNbTriangles();
 
-    type::vector<TriangleInformation>& triangleInf = *(triangleInfo.beginEdit());
+    type::vector<TriangleInformation>& triangleInf = *(triangleInfo.beginWriteOnly());
 
     for(unsigned int i=0; i<nbTriangles; i++)
     {

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
@@ -842,7 +842,7 @@ void TriangularFEMForceField<DataTypes>::computeStrain(type::Vec<3,Real> &strain
 // --- Stress = K * Strain = KJtD = KBd
 // --------------------------------------------------------------------------------------------------------
 template <class DataTypes>
-void TriangularFEMForceField<DataTypes>::computeStress(type::Vec<3,Real> &stress, MaterialStiffness &K, type::Vec<3,Real> &strain)
+void TriangularFEMForceField<DataTypes>::computeStress(type::Vec<3,Real> &stress, const MaterialStiffness &K, const type::Vec<3,Real> &strain)
 {
     if (_anisotropicMaterial || method == SMALL)
     {

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
@@ -1023,9 +1023,10 @@ void TriangularFEMForceField<DataTypes>::computeForce(Displacement &F, Index ele
     type::Vec<3,Real> stress;
     Transformation R_0_2, R_2_0;
 
-    Index a = m_topology->getTriangle(elementIndex)[0];
-    Index b = m_topology->getTriangle(elementIndex)[1];
-    Index c = m_topology->getTriangle(elementIndex)[2];
+    const Triangle& tri = m_topology->getTriangle(elementIndex);
+    Index a = tri[0];
+    Index b = tri[1];
+    Index c = tri[2];
 
     type::vector<TriangleInformation>& triangleInf = *(triangleInfo.beginEdit());
 
@@ -1273,29 +1274,23 @@ void TriangularFEMForceField<DataTypes>::applyStiffnessLarge(VecCoord &v, Real h
 
     for(unsigned int i=0; i<nbTriangles; i++)
     {
-        Index a = m_topology->getTriangle(i)[0];
-        Index b = m_topology->getTriangle(i)[1];
-        Index c = m_topology->getTriangle(i)[2];
+        const Element& tri = m_topology->getTriangle(i);
+        Index a = tri[0];
+        Index b = tri[1];
+        Index c = tri[2];
 
         Transformation R_0_2;
         R_0_2.transpose(triangleInf[i].rotation);
 
-        VecCoord disp;
-        disp.resize(3);
-
         x_2 = R_0_2 * x[a];
-        disp[0] = x_2;
-
         D[0] = x_2[0];
         D[1] = x_2[1];
 
         x_2 = R_0_2 * x[b];
-        disp[1] = x_2;
         D[2] = x_2[0];
         D[3] = x_2[1];
 
         x_2 = R_0_2 * x[c];
-        disp[2] = x_2;
         D[4] = x_2[0];
         D[5] = x_2[1];
 
@@ -1362,10 +1357,10 @@ template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::accumulateForceLarge(VecCoord &f, const VecCoord &p, Index elementIndex )
 {
     Displacement F;
-
-    Index a = m_topology->getTriangle(elementIndex)[0];
-    Index b = m_topology->getTriangle(elementIndex)[1];
-    Index c = m_topology->getTriangle(elementIndex)[2];
+    const Triangle& tri = m_topology->getTriangle(elementIndex);
+    Index a = tri[0];
+    Index b = tri[1];
+    Index c = tri[2];
 
     // compute force on element (in the co-rotational space)
     computeForce( F, elementIndex, p);

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
@@ -1365,14 +1365,13 @@ void TriangularFEMForceField<DataTypes>::accumulateForceLarge(VecCoord &f, const
     // compute force on element (in the co-rotational space)
     computeForce( F, elementIndex, p);
 
-    type::vector<TriangleInformation>& triangleInf = *(triangleInfo.beginEdit());
-
+    const type::vector<TriangleInformation>& triangleInf = triangleInfo.getValue();
+    const Transformation& rot = triangleInf[elementIndex].rotation;
     // transform force back into global ref. frame
-    f[a] += triangleInf[elementIndex].rotation * Coord(F[0], F[1], 0);
-    f[b] += triangleInf[elementIndex].rotation * Coord(F[2], F[3], 0);
-    f[c] += triangleInf[elementIndex].rotation * Coord(F[4], F[5], 0);
+    f[a] += rot * Coord(F[0], F[1], 0);
+    f[b] += rot * Coord(F[2], F[3], 0);
+    f[c] += rot * Coord(F[4], F[5], 0);
 
-    triangleInfo.endEdit();
 }
 
 // --------------------------------------------------------------------------------------

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
@@ -541,9 +541,9 @@ void TriangularFEMForceField<DataTypes>::getRotations()
         r01=tinfo->initialTransformation;
         r21=tinfo->rotation*r01;
 
-        for(int j=0; j<3; j++)
+        const Triangle& tri = m_topology->getTriangle(i);
+        for(auto idx : tri)
         {
-            int idx=m_topology->getTriangle(i)[j];
             VertexInformation *vinfo= &vertexInf[idx];
             vinfo->rotation+=r21;
         }
@@ -671,9 +671,10 @@ void TriangularFEMForceField<DataTypes>::computeRotationLarge( Transformation &r
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::computeDisplacementSmall(Displacement &D, Index elementIndex, const VecCoord &p)
 {
-    Index a = m_topology->getTriangle(elementIndex)[0];
-    Index b = m_topology->getTriangle(elementIndex)[1];
-    Index c = m_topology->getTriangle(elementIndex)[2];
+    const Triangle& tri = m_topology->getTriangle(elementIndex);
+    Index a = tri[0];
+    Index b = tri[1];
+    Index c = tri[2];
 
     //Coord deforme_a = Coord(0,0,0);
     Coord deforme_b = p[b]-p[a];
@@ -695,9 +696,10 @@ void TriangularFEMForceField<DataTypes>::computeDisplacementSmall(Displacement &
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::computeDisplacementLarge(Displacement &D, Index elementIndex, const Transformation &R_0_2, const VecCoord &p)
 {
-    Index a = m_topology->getTriangle(elementIndex)[0];
-    Index b = m_topology->getTriangle(elementIndex)[1];
-    Index c = m_topology->getTriangle(elementIndex)[2];
+    const Triangle& tri = m_topology->getTriangle(elementIndex);
+    Index a = tri[0];
+    Index b = tri[1];
+    Index c = tri[2];
 
     // positions of the deformed and displaced triangle in its frame
     Coord deforme_b = R_0_2 * (p[b]-p[a]);
@@ -1097,9 +1099,10 @@ void TriangularFEMForceField<DataTypes>::computeStress(type::Vec<3,Real> &stress
     type::Vec<3,Real> strain;
     Transformation R_0_2, R_2_0;
     const VecCoord& p = this->mstate->read(core::ConstVecCoordId::position())->getValue();
-    Index a = m_topology->getTriangle(elementIndex)[0];
-    Index b = m_topology->getTriangle(elementIndex)[1];
-    Index c = m_topology->getTriangle(elementIndex)[2];
+    const Triangle& tri = m_topology->getTriangle(elementIndex);
+    Index a = tri[0];
+    Index b = tri[1];
+    Index c = tri[2];
 
     type::vector<TriangleInformation>& triangleInf = *(triangleInfo.beginEdit());
 
@@ -1170,9 +1173,10 @@ void TriangularFEMForceField<DataTypes>::computeStressAlongDirection(Real &stres
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::computeStressAcrossDirection(Real &stress_across_dir, Index elementIndex, const Coord &dir, const type::Vec<3,Real> &stress)
 {
-    Index a = m_topology->getTriangle(elementIndex)[0];
-    Index b = m_topology->getTriangle(elementIndex)[1];
-    Index c = m_topology->getTriangle(elementIndex)[2];
+    const Triangle& tri = m_topology->getTriangle(elementIndex);
+    Index a = tri[0];
+    Index b = tri[1];
+    Index c = tri[2];
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
     Coord n = cross(x[b]-x[a],x[c]-x[a]);
     Coord dir_t = cross(dir,n);
@@ -1182,9 +1186,10 @@ void TriangularFEMForceField<DataTypes>::computeStressAcrossDirection(Real &stre
 template <class DataTypes>
 void TriangularFEMForceField<DataTypes>::computeStressAcrossDirection(Real &stress_across_dir, Index elementIndex, const Coord &dir)
 {
-    Index a = m_topology->getTriangle(elementIndex)[0];
-    Index b = m_topology->getTriangle(elementIndex)[1];
-    Index c = m_topology->getTriangle(elementIndex)[2];
+    const Triangle& tri = m_topology->getTriangle(elementIndex);
+    Index a = tri[0];
+    Index b = tri[1];
+    Index c = tri[2];
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
     Coord n = cross(x[b]-x[a],x[c]-x[a]);
     Coord dir_t = cross(dir,n);
@@ -1218,9 +1223,10 @@ void TriangularFEMForceField<DataTypes>::applyStiffnessSmall(VecCoord &v, Real h
 
     for(unsigned int i=0; i<nbTriangles; i++)
     {
-        Index a = m_topology->getTriangle(i)[0];
-        Index b = m_topology->getTriangle(i)[1];
-        Index c = m_topology->getTriangle(i)[2];
+        const Triangle& tri = m_topology->getTriangle(i);
+        Index a = tri[0];
+        Index b = tri[1];
+        Index c = tri[2];
 
         D[0] = x[a][0];
         D[1] = x[a][1];
@@ -1333,9 +1339,10 @@ void TriangularFEMForceField<DataTypes>::accumulateForceSmall( VecCoord &f, cons
 {
     Displacement F;
 
-    Index a = m_topology->getTriangle(elementIndex)[0];
-    Index b = m_topology->getTriangle(elementIndex)[1];
-    Index c = m_topology->getTriangle(elementIndex)[2];
+    const Element& tri = m_topology->getTriangle(elementIndex);
+    Index a = tri[0];
+    Index b = tri[1];
+    Index c = tri[2];
 
     // compute force on element
     computeForce(F, elementIndex, p);
@@ -1498,7 +1505,7 @@ void TriangularFEMForceField<DataTypes>::draw(const core::visual::VisualParams* 
         std::vector<sofa::type::Vector3> vertices;
         for(Size i=0; i< nbTriangles; ++i)
         {
-            Triangle tri = m_topology->getTriangle(i);
+            const Triangle& tri = m_topology->getTriangle(i);
             Index a = tri[0];
             Index b = tri[1];
             Index c = tri[2];
@@ -1544,9 +1551,10 @@ void TriangularFEMForceField<DataTypes>::draw(const core::visual::VisualParams* 
         helper::ColorMap::evaluator<double> evalColor = p_drawColorMap->getEvaluator(minStress, maxStress);
         for(Size i=0; i<nbTriangles; ++i)
         {
-            Index a = m_topology->getTriangle(i)[0];
-            Index b = m_topology->getTriangle(i)[1];
-            Index c = m_topology->getTriangle(i)[2];
+            const Triangle& tri = m_topology->getTriangle(i);
+            Index a = tri[0];
+            Index b = tri[1];
+            Index c = tri[2];
 
             colorVector.push_back(evalColor(vertexInf[a].stress));
             vertices.push_back(sofa::type::Vector3(x[a]));
@@ -1586,10 +1594,10 @@ void TriangularFEMForceField<DataTypes>::draw(const core::visual::VisualParams* 
             if (triangleInf[i].differenceToCriteria > 0)
             {
                 color = sofa::type::RGBAColor( float(0.4 + 0.4 * (triangleInf[i].differenceToCriteria - minDifference ) /  (maxDifference - minDifference)) , 0.0f , 0.0f, 0.5f);
-
-                Index a = m_topology->getTriangle(i)[0];
-                Index b = m_topology->getTriangle(i)[1];
-                Index c = m_topology->getTriangle(i)[2];
+                const Triangle& tri = m_topology->getTriangle(i);
+                Index a = tri[0];
+                Index b = tri[1];
+                Index c = tri[2];
 
                 colorVector.push_back(color);
                 vertices.push_back(sofa::type::Vector3(x[a]));


### PR DESCRIPTION
Small optimizations monitored using tests: ```TriangleFEMForceField3_test, DISABLED_testTriangularFEMPerformance``` which is performing 10 successive simulations of  1000 steps of a grid of 40x40x2= 3200 triangles.

Current logs (per simulation of 1000 steps):
```
timeMean: 3.69814
timeMin : 3.62193
timeMax : 3.84991
```

First quick optimisation on accessing triangle in for loop:
```
+ const Triangle& tri = m_topology->getTriangle(elementIndex);
+ Index a = tri[0];
+ Index b = tri[1];
+ Index c = tri[2];
- Index a = m_topology->getTriangle(elementIndex)[0];
- Index b = m_topology->getTriangle(elementIndex)[1];
- Index c = m_topology->getTriangle(elementIndex)[2];
```
Gives:
```
timeMean : 2.40153
timeMin : 2.38573
timeMax : 2.42425
```

Additionnal small optimization using BeginWriteOnly accessors and const ref in methods give final record:

```
timeMean : 2.26662
timeMin : 2.23438
timeMax : 2.2895
```
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
