### PR TITLE
[SofaMiscFEM] Fix TriangleFEMForceField and TriangularFEMForceField to have the same behavior

### DIFF
--- a/modules/SofaMiscFem/SofaMiscFem_test/TriangleFEMForceField_test.cpp
+++ b/modules/SofaMiscFem/SofaMiscFem_test/TriangleFEMForceField_test.cpp
@@ -731,12 +731,12 @@ TEST_F(TriangleFEMForceField3_test, checkTriangularFEMForceField_wrongAttributes
     this->checkWrongAttributes(1);
 }
 
-TEST_F(TriangleFEMForceField3_test, DISABLED_checkTriangularFEMForceField_init)
+TEST_F(TriangleFEMForceField3_test, checkTriangularFEMForceField_init)
 {
     this->checkInit(1);
 }
 
-TEST_F(TriangleFEMForceField3_test, DISABLED_checkTriangularFEMForceField_values)
+TEST_F(TriangleFEMForceField3_test, checkTriangularFEMForceField_values)
 {
     this->checkFEMValues(1);
 }

--- a/modules/SofaMiscFem/SofaMiscFem_test/TriangleFEMForceField_test.cpp
+++ b/modules/SofaMiscFem/SofaMiscFem_test/TriangleFEMForceField_test.cpp
@@ -411,7 +411,7 @@ public:
             {
                 typename TriangularFEM::TriangleInformation triangleInfo = triFEM->triangleInfo.getValue()[id];
                 const type::fixed_array <Coord, 3>& rotatedInitPos = triangleInfo.rotatedInitialElements;
-                const Mat33& rotMat = triangleInfo.initialTransformation;
+                const Mat33& rotMat = triangleInfo.rotation;
                 const Mat33& stiffnessMat = triangleInfo.materialMatrix;
                 const Mat63& strainDispl = triangleInfo.strainDisplacementMatrix;
 
@@ -557,7 +557,7 @@ public:
             
             typename TriangularFEM::TriangleInformation triangleInfo = triFEM->triangleInfo.getValue()[idTri];
             const type::fixed_array <Coord, 3>& rotatedInitPos = triangleInfo.rotatedInitialElements;
-            const Mat33& rotMat = triangleInfo.initialTransformation; // rotMat: [1 0 0,0 1 0,0 0 1]
+            const Mat33& rotMat = triangleInfo.rotation;
             const Mat33& stiffnessMat = triangleInfo.materialMatrix;
             const Mat63& strainDispl = triangleInfo.strainDisplacementMatrix;
 

--- a/modules/SofaMiscFem/SofaMiscFem_test/TriangleFEMForceField_test.cpp
+++ b/modules/SofaMiscFem/SofaMiscFem_test/TriangleFEMForceField_test.cpp
@@ -376,8 +376,8 @@ public:
         exp_rotatedInitPos[1] = Mat33(Vec3(0, 0, 0), Vec3(1.4142135, 0, 0), Vec3(0.707107, 1.2247449, 0));
         exp_rotMat[1] = Mat33(Vec3(0, -0.81649661, -0.57735), Vec3(0.707107, 0.40824831, -0.57735), Vec3(0.707107, -0.40824831, 0.57735));
         exp_stiffnessMat[1] = Mat33(Vec3(95.1676, 28.550287, 0), Vec3(28.550287, 95.1676, 0), Vec3(0, 0, 33.30867));
-        exp_strainDispl[1][0] = Vec3(-1, 0, -1); exp_strainDispl[1][1] = Vec3(0, -1, -1); exp_strainDispl[1][2] = Vec3(1, 0, 0);
-        exp_strainDispl[1][3] = Vec3(0, 0, 1); exp_strainDispl[1][4] = Vec3(0, 0, 1); exp_strainDispl[1][5] = Vec3(0, 1, 0);
+        exp_strainDispl[1][0] = Vec3(-0.707107, 0, -0.408248); exp_strainDispl[1][1] = Vec3(0, -0.408248, -0.707107); exp_strainDispl[1][2] = Vec3(0.707107, 0, -0.408248);
+        exp_strainDispl[1][3] = Vec3(0, -0.408248, 0.707107); exp_strainDispl[1][4] = Vec3(0, 0, 0.816497); exp_strainDispl[1][5] = Vec3(0, 0.816497, 0);
 
         if (FEMType == 0)
         {

--- a/modules/SofaMiscFem/SofaMiscFem_test/TriangleFEMForceField_test.cpp
+++ b/modules/SofaMiscFem/SofaMiscFem_test/TriangleFEMForceField_test.cpp
@@ -91,6 +91,9 @@ public:
     {
         m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
 
+        createObject(m_root, "DefaultAnimationLoop");
+        createObject(m_root, "DefaultVisualManagerLoop");
+
         createObject(m_root, "MechanicalObject", {{"template","Vec3d"}, {"position", "0 0 0  1 0 0  0 1 0  1 1 1"} });
         createObject(m_root, "TriangleSetTopologyContainer", { {"triangles","0 1 2  1 3 2"} });
         createObject(m_root, "TriangleSetTopologyModifier");
@@ -123,6 +126,9 @@ public:
         m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
         m_root->setGravity(type::Vec3(0.0, 10.0, 0.0));
         m_root->setDt(0.01);
+
+        createObject(m_root, "DefaultAnimationLoop");
+        createObject(m_root, "DefaultVisualManagerLoop");
 
         createObject(m_root, "RegularGridTopology", { {"name", "grid"}, 
             {"n", str(type::Vec3(nbrGrid, nbrGrid, 1))}, {"min", "0 0 0"}, {"max", "10 10 0"} });
@@ -232,6 +238,9 @@ public:
     void checkNoTopology(int FEMType)
     {
         m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
+        createObject(m_root, "DefaultAnimationLoop");
+        createObject(m_root, "DefaultVisualManagerLoop");
+
         createObject(m_root, "MechanicalObject", { {"template","Vec3d"}, {"position", "0 0 0  1 0 0  0 1 0"} });
         if (FEMType == 0) // TriangleModel
         {
@@ -258,6 +267,9 @@ public:
     void checkEmptyTopology(int FEMType)
     {
         m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
+        createObject(m_root, "DefaultAnimationLoop");
+        createObject(m_root, "DefaultVisualManagerLoop");
+
         createObject(m_root, "MechanicalObject", { {"template","Vec3d"} });
         createObject(m_root, "TriangleSetTopologyContainer");
         if (FEMType == 0) // TriangleModel
@@ -286,6 +298,8 @@ public:
     void checkDefaultAttributes(int FEMType)
     {
         m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
+        createObject(m_root, "DefaultAnimationLoop");
+        createObject(m_root, "DefaultVisualManagerLoop");
 
         createObject(m_root, "MechanicalObject", { {"template","Vec3d"}, {"position", "0 0 0  1 0 0  0 1 0"} });
         createObject(m_root, "TriangleSetTopologyContainer", { {"triangles","0 1 2"} });

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangleFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangleFEMForceField.inl
@@ -521,7 +521,7 @@ void TriangleFEMForceField<DataTypes>::initLarge()
         _rotatedInitialElements[i][2] -= _rotatedInitialElements[i][0];
         _rotatedInitialElements[i][0] = Coord(0,0,0);
 
-        computeStrainDisplacement(_strainDisplacements[i], _initialPoints.getValue()[a], _initialPoints.getValue()[b], _initialPoints.getValue()[c] );
+        computeStrainDisplacement(_strainDisplacements[i], _rotatedInitialElements[i][0], _rotatedInitialElements[i][1], _rotatedInitialElements[i][2]);
     }
 }
 

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
@@ -211,6 +211,7 @@ void TriangularFEMForceField<DataTypes>::initLarge(int i, Index&a, Index&b, Inde
         computeRotationLarge( R_0_1, (initialPoints), a, b, c );
 
         tinfo->initialTransformation.transpose(R_0_1);
+        tinfo->rotation = tinfo->initialTransformation;
 
         if ( a >= (initialPoints).size() || b >= (initialPoints).size() || c >= (initialPoints).size() )
         {

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
@@ -955,7 +955,7 @@ void TriangularFEMForceField<DataTypes>::computeMaterialStiffness(int i, Index &
     tinfo->materialMatrix[2][1] = 0;
     tinfo->materialMatrix[2][2] = (1.0f - p) * 0.5f;//poissonArray[i]);
 
-    tinfo->materialMatrix *= (y / (1.0f - p * p));
+    tinfo->materialMatrix *= (y / (1.0f - p * p)) *tinfo->area;
 
     triangleInfo.endEdit();
 }
@@ -987,7 +987,7 @@ void TriangularFEMForceField<DataTypes>::computeForce(Displacement &F, Index ele
         computeStrainDisplacement(J, elementIndex, Coord(0,0,0), (p[b]-p[a]), (p[c]-p[a]));
         computeStrain(strain, J, D);
         computeStress(stress, triangleInf[elementIndex].materialMatrix, strain);
-        F = J * stress * triangleInf[elementIndex].area;
+        F = J * stress;
 
         // store newly computed values for next time
         triangleInf[elementIndex].strainDisplacementMatrix = J;
@@ -1023,9 +1023,6 @@ void TriangularFEMForceField<DataTypes>::computeForce(Displacement &F, Index ele
         F[3] = /* J[3][0] * KJtD[0] + */ J[3][1] * stress[1] + J[3][2] * stress[2];
         F[4] = /* J[4][0] * KJtD[0] + J[4][1] * KJtD[1] + */ J[4][2] * stress[2];
         F[5] = /* J[5][0] * KJtD[0] + */ J[5][1] * stress[1] /* + J[5][2] * KJtD[2] */ ;
-
-        // Since J has been "normalized" we need to multiply the force F by the area of the triangle to get the correct force
-        F *= triangleInf[elementIndex].area;
 
         // store newly computed values for next time
         R_2_0.transpose(R_0_2);
@@ -1260,7 +1257,6 @@ void TriangularFEMForceField<DataTypes>::applyStiffnessLarge(VecCoord &v, Real h
         F[4] = /* J[4][0] * KJtD[0] + J[4][1] * KJtD[1] + */ J[4][2] * stress[2];
         F[5] = /* J[5][0] * KJtD[0] + */ J[5][1] * stress[1] /* + J[5][2] * KJtD[2] */ ;
 
-        F *= triangleInf[i].area;
 
         v[a] += (triangleInf[i].rotation * Coord(-h*F[0], -h*F[1], 0)) * kFactor;
         v[b] += (triangleInf[i].rotation * Coord(-h*F[2], -h*F[3], 0)) * kFactor;

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
@@ -1187,7 +1187,7 @@ void TriangularFEMForceField<DataTypes>::applyStiffnessSmall(VecCoord &v, Real h
         J = triangleInf[i].strainDisplacementMatrix;
         computeStrain(strain, J, D);
         computeStress(stress, triangleInf[i].materialMatrix, strain);
-        F = J * stress * triangleInf[i].area;
+        F = J * stress;
 
         v[a] += (Coord(-h*F[0], -h*F[1], 0)) * kFactor;
         v[b] += (Coord(-h*F[2], -h*F[3], 0)) * kFactor;

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
@@ -195,7 +195,7 @@ void TriangularFEMForceField<DataTypes>::initLarge(int i, Index&a, Index&b, Inde
     {
         Transformation R_0_1;
         R_0_1 = m_initialTransformation.getValue()[i];
-        tinfo->initialTransformation = R_0_1;
+        tinfo->initialTransformation.transpose(R_0_1);
         tinfo->rotatedInitialElements = m_rotatedInitialElements.getValue()[i];
     }
     else
@@ -210,7 +210,7 @@ void TriangularFEMForceField<DataTypes>::initLarge(int i, Index&a, Index&b, Inde
 
         computeRotationLarge( R_0_1, (initialPoints), a, b, c );
 
-        tinfo->initialTransformation = R_0_1;
+        tinfo->initialTransformation.transpose(R_0_1);
 
         if ( a >= (initialPoints).size() || b >= (initialPoints).size() || c >= (initialPoints).size() )
         {


### PR DESCRIPTION
Several fixes:
- TriangleFEMForcefield : wrong init value for strainDisplacement
- TriangularFEMForceField: strainDisplacement not updated at each timestep and using rest Triangle area like in TriangleFEMForceField
- Enable the 2 tests which same value references for TriangleFEMForcefield and TriangularFEMForceField:
checkTriangularFEMForceField_init
checkTriangularFEMForceField_values

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
