### PR TITLE
[Sofa.Type] Structured binding declaration for fixed_array 

### DIFF
--- a/SofaKernel/modules/Sofa.Type/Sofa.Type_test/Color_test.cpp
+++ b/SofaKernel/modules/Sofa.Type/Sofa.Type_test/Color_test.cpp
@@ -145,20 +145,53 @@ void Color_Test::checkConstructors()
 
 void Color_Test::checkGetSet()
 {
-    RGBAColor a;
-    a.r(1);
-    EXPECT_EQ(a.r(), 1.0) ;
+    RGBAColor color;
+    color.r(1);
+    EXPECT_EQ(color.r(), 1.0) ;
 
-    a.g(2);
-    EXPECT_EQ(a.g(), 2.0) ;
+    color.g(2);
+    EXPECT_EQ(color.g(), 2.0) ;
 
-    a.b(3);
-    EXPECT_EQ(a.b(), 3.0) ;
+    color.b(3);
+    EXPECT_EQ(color.b(), 3.0) ;
 
-    a.a(4);
-    EXPECT_EQ(a.a(), 4.0) ;
+    color.a(4);
+    EXPECT_EQ(color.a(), 4.0) ;
 
-    EXPECT_EQ(a, RGBAColor(1.0,2.0,3.0,4.0)) ;
+    EXPECT_EQ(color, RGBAColor(1.0, 2.0, 3.0, 4.0)) ;
+
+    {
+        const auto [r, g, b, a] = color;
+        EXPECT_EQ(r, color.r());
+        EXPECT_EQ(g, color.g());
+        EXPECT_EQ(b, color.b());
+        EXPECT_EQ(a, color.a());
+    }
+
+    {
+        auto& [r, g, b, a] = color;
+        r = 10.f;
+        g = 11.f;
+        b = 12.f;
+        a = 13.f;
+        EXPECT_EQ(color, RGBAColor(10.f, 11.f, 12.f, 13.f)) ;
+    }
+
+    {
+        sofa::type::vector< sofa::type::RGBAColor > colors {
+            RGBAColor(1.f, 2.f, 3.f, 4.f),
+            RGBAColor(5.f, 6.f, 7.f, 8.f),
+            RGBAColor(9.f, 10.f, 11.f, 12.f)
+        };
+        float i = 0.f;
+        for (const auto& [r, g, b, a] : colors)
+        {
+            EXPECT_FLOAT_EQ(r, i += 1.f);
+            EXPECT_FLOAT_EQ(g, i += 1.f);
+            EXPECT_FLOAT_EQ(b, i += 1.f);
+            EXPECT_FLOAT_EQ(a, i += 1.f);
+        }
+    }
 }
 
 void Color_Test::checkStreamingOperator(const std::vector<std::string>& p)
@@ -257,6 +290,11 @@ TEST_F(Color_Test, checkCreateFromDouble)
 TEST_F(Color_Test, checkEquality)
 {
     this->checkEquality() ;
+}
+
+TEST_F(Color_Test, checkGetSet)
+{
+    this->checkGetSet() ;
 }
 
 TEST_F(Color_Test, checkEnlight)

--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/RGBAColor.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/RGBAColor.h
@@ -110,3 +110,17 @@ public:
 };
 
 } // namespace sofa::type
+
+namespace std
+{
+template<>
+struct tuple_size<::sofa::type::RGBAColor >
+{
+    static constexpr size_t value = 4;
+};
+template<::size_t Index>
+struct tuple_element<Index, ::sofa::type::RGBAColor >
+{
+    using type = float;
+};
+}

--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/Vec.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/Vec.h
@@ -859,4 +859,15 @@ struct less< sofa::type::Vec<N,T> >
     }
 };
 
+template<sofa::Size N, class T>
+struct tuple_size<::sofa::type::Vec<N, T> >
+{
+    static constexpr size_t value = N;
+};
+template<::size_t Index, sofa::Size N, class T>
+struct tuple_element<Index, ::sofa::type::Vec<N, T> >
+{
+    using type = T;
+};
+
 } // namespace std

--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/fixed_array.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/fixed_array.h
@@ -56,6 +56,7 @@
 #include <iostream>
 #include <type_traits>
 #include <algorithm>
+#include <utility>
 
 
 namespace sofa::type
@@ -143,6 +144,18 @@ public:
     {
         rangecheck(i);
         return elems[i];
+    }
+
+    template<std::size_t Index>
+    std::tuple_element_t<Index, fixed_array<T, N> >& get()
+    {
+        return at(Index);
+    }
+
+    template<std::size_t Index>
+    const std::tuple_element_t<Index, fixed_array<T, N> >& get() const
+    {
+        return at(Index);
     }
 
     // front() and back()
@@ -285,3 +298,17 @@ extern template class SOFA_TYPE_API fixed_array<double, 7>;
 #endif //FIXED_ARRAY_CPP
 
 } // namespace sofa::type
+
+namespace std
+{
+template<class T, sofa::Size N>
+struct tuple_size<::sofa::type::fixed_array<T, N> >
+{
+    static constexpr size_t value = N;
+};
+template<::size_t Index, class T, sofa::Size N>
+struct tuple_element<Index, ::sofa::type::fixed_array<T, N> >
+{
+    using type = T;
+};
+}


### PR DESCRIPTION
and some derived types.

This allows to write such code:

```cpp
const auto [r, g, b, a] = color;
```

```cpp
auto& [r, g, b, a] = color;
```
```cpp
for (const auto& [r, g, b, a] : colors)
{
}
```
See the unit test Color_test




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
