### PR TITLE
[SofaSimpleFem] Fix row/col indices in hexa fem for bloc-based matrices

### DIFF
--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/HexahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/HexahedronFEMForceField.inl
@@ -1197,7 +1197,7 @@ void HexahedronFEMForceField<DataTypes>::addKToBlocMatrix(
                         Coord(Ke[3*n1+0][3*n2+0],Ke[3*n1+0][3*n2+1],Ke[3*n1+0][3*n2+2]),
                         Coord(Ke[3*n1+1][3*n2+0],Ke[3*n1+1][3*n2+1],Ke[3*n1+1][3*n2+2]),
                         Coord(Ke[3*n1+2][3*n2+0],Ke[3*n1+2][3*n2+1],Ke[3*n1+2][3*n2+2])) ) * Rot;
-                *crsmat->wbloc(offset + node1, offset + node2, true) += tmp * (-k);
+                *crsmat->wbloc(offset / 3 + node1, offset / 3 + node2, true) += tmp * (-k);
             }
         }
     }


### PR DESCRIPTION
Indices were wrong in case of multiple objects under the same linear solver which uses an assembled 3x3 bloc-based matrix.
Bug introduced in https://github.com/sofa-framework/sofa/pull/2240


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
