### PR TITLE
[SofaKernel] Remove the getXXXAccessor in accessor.h to keep the one in Data.h

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
@@ -480,7 +480,10 @@ public:
     WriteOnlyAccessor(const core::ExecParams*, data_container_type* d) : Inherit( d->beginWriteOnly(), *d ) {}
 };
 
-/// Easy syntax for getting read/write access to a Data using operator ->. Example: write(someFlagData)->setFlagValue(true);
+
+/// Returns a write only accessor from the provided Data<>
+/// Example of use:
+///   auto points = getWriteOnlyAccessor(d_points)
 template<class T>
 WriteAccessor<core::objectmodel::Data<T> > getWriteAccessor(core::objectmodel::Data<T>& data)
 { 
@@ -498,6 +501,11 @@ template<class T>
 SOFA_ATTRIBUTE_DISABLED__ASPECT("You can probably update your code by removing aspect related calls.")
 WriteAccessor<core::objectmodel::Data<T> > write(core::objectmodel::Data<T>& data, const core::ExecParams*) = delete;
 
+
+
+/// Returns a read accessor from the provided Data<>
+/// Example of use:
+///   auto points = getReadAccessor(d_points)
 template<class T>
 ReadAccessor<core::objectmodel::Data<T> > getReadAccessor(const core::objectmodel::Data<T>& data)
 {
@@ -515,13 +523,17 @@ template<class T>
 SOFA_ATTRIBUTE_DISABLED__ASPECT("You can probably update your code by removing aspect related calls.")
 ReadAccessor<core::objectmodel::Data<T> > read(const core::objectmodel::Data<T>& data, const core::ExecParams*) = delete;
 
-/// Easy syntax for getting write only access to a Data using operator ->. Example: writeOnly(someFlagData)->setFlagValue(true);
+/// Returns a write only accessor from the provided Data<>
+/// WriteOnly accessors are faster than WriteAccessor because
+/// as the data is only read this means there is no need to pull
+/// the data from the parents
+/// Example of use:
+///   auto points = getWriteOnlyAccessor(d_points)
 template<class T>
 WriteOnlyAccessor<core::objectmodel::Data<T> > getWriteOnlyAccessor(core::objectmodel::Data<T>& data)
 {
     return WriteOnlyAccessor<core::objectmodel::Data<T> >(data);
 }
-
 
 } // namespace helper
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/accessor.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/accessor.h
@@ -279,35 +279,5 @@ public:
     WriteOnlyAccessor(container_type& c) : Inherit(c) {}
 };
 
-/// Returns a read accessor from the provided Data<>
-/// Example of use:
-///   auto points = getReadAccessor(d_points)
-template<class D>
-sofa::helper::ReadAccessor<D> getReadAccessor(D& c)
-{
-    return sofa::helper::ReadAccessor<D>{ c };
-}
-
-/// Returns a write only accessor from the provided Data<>
-/// Example of use:
-///   auto points = getWriteOnlyAccessor(d_points)
-template<class D>
-sofa::helper::WriteAccessor<D> getWriteAccessor(D& c)
-{
-    return sofa::helper::WriteAccessor<D>{ c };
-}
-
-/// Returns a write only accessor from the provided Data<>
-/// WriteOnly accessors are faster than WriteAccessor because
-/// as the data is only read this means there is no need to pull
-/// the data from the parents
-/// Example of use:
-///   auto points = getWriteOnlyAccessor(d_points)
-template<class D>
-sofa::helper::WriteOnlyAccessor<D> getWriteOnlyAccessor(D& c)
-{
-    return sofa::helper::WriteOnlyAccessor<D>{ c };
-}
-
 } /// namespace sofa::core
 


### PR DESCRIPTION
The implementation in accessor.h were deprecated with the one in Data.h

In addition, when trying to get an accessor from a data containnig an object overloading Data<>, this implemention
(the one in accessor.h) confuses the system wich mis-select to find the proper accessor implementation and fallback to the one
that is not offering the vectorized API.

Removing the getReadAccess, getWriteAccess, getWriteOnlyAccess fix that.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
