### PR TITLE
[SofaSimpleFem] Simplify bloc-based optimization

### DIFF
--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/fixed_array.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/fixed_array.h
@@ -164,7 +164,7 @@ public:
     }
 
     // size is constant
-    static size_type size() noexcept
+    static constexpr size_type size() noexcept
     {
         return N;
     }
@@ -172,7 +172,7 @@ public:
     {
         return false;
     }
-    static size_type max_size() noexcept
+    static constexpr size_type max_size() noexcept
     {
         return N;
     }

--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/CompressedRowSparseMatrix.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/CompressedRowSparseMatrix.h
@@ -748,6 +748,16 @@ public:
         traits::v(*wbloc(i,j,true), bi, bj) += (Real)v;
     }
 
+    void add(Index row, Index col, const type::Mat3x3d & _M) override
+    {
+        BaseMatrix::add(row, col, _M);
+    }
+
+    void add(Index row, Index col, const type::Mat3x3f & _M) override
+    {
+        BaseMatrix::add(row, col, _M);
+    }
+
     void clear(Index i, Index j) override
     {
         dmsg_info_when(EMIT_EXTRA_MESSAGE)

--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/CompressedRowSparseMatrix.inl
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/CompressedRowSparseMatrix.inl
@@ -25,6 +25,48 @@
 namespace sofa::component::linearsolver
 {
 
+template <class TMatrix, class TBlocMatrix>
+void addBloc(TMatrix& self, Index row, Index col, const TBlocMatrix & _M)
+{
+    if (row % TBlocMatrix::nbLines == 0 && col % TBlocMatrix::nbCols == 0)
+    {
+        if (EMIT_EXTRA_MESSAGE)
+        {
+            dmsg_info(&self) << "(" << self.rowSize() << "," << self.colSize() << "): element(" << row << "," << col << ") += " << _M;
+        }
+
+        *self.wbloc(row / TBlocMatrix::nbLines, col / TBlocMatrix::nbCols, true) += _M;
+    }
+    else
+    {
+        self.BaseMatrix::add(row, col, _M);
+    }
+}
+
+template <>
+void CompressedRowSparseMatrix<type::Mat<3,3,double> >::add(Index row, Index col, const type::Mat3x3d & _M)
+{
+    addBloc(*this, row, col, _M);
+}
+
+template <>
+void CompressedRowSparseMatrix<type::Mat<3,3,double> >::add(Index row, Index col, const type::Mat3x3f & _M)
+{
+    addBloc(*this, row, col, _M);
+}
+
+template <>
+void CompressedRowSparseMatrix<type::Mat<3,3,float> >::add(Index row, Index col, const type::Mat3x3d & _M)
+{
+    addBloc(*this, row, col, _M);
+}
+
+template <>
+void CompressedRowSparseMatrix<type::Mat<3,3,float> >::add(Index row, Index col, const type::Mat3x3f & _M)
+{
+    addBloc(*this, row, col, _M);
+}
+
 template <> template <>
 inline void CompressedRowSparseMatrix<double>::filterValues(CompressedRowSparseMatrix<type::Mat<3,3,double> >& M, filter_fn* filter, const Bloc& ref)
 {

--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/CompressedRowSparseMatrix.inl
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/CompressedRowSparseMatrix.inl
@@ -39,7 +39,7 @@ void addBloc(TMatrix& self, Index row, Index col, const TBlocMatrix & _M)
     }
     else
     {
-        self.BaseMatrix::add(row, col, _M);
+        self.defaulttype::BaseMatrix::add(row, col, _M);
     }
 }
 

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BaseMatrix.cpp
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BaseMatrix.cpp
@@ -111,31 +111,31 @@ struct BaseMatrixLinearOpMV_BlockDiagonal
 };
 
 ///Adding values from a 3x3d matrix this function may be overload to obtain better performances
-void BaseMatrix::add(Index _i, Index _j, const type::Mat3x3d & _M) {
+void BaseMatrix::add(Index row, Index col, const type::Mat3x3d & _M) {
     for (unsigned i=0;i<3;i++)
         for (unsigned j=0;j<3;j++)
-            add(_i+i,_j+j,_M[i][j]);
+            add(row + i, col + j, _M[i][j]);
 }
 
 ///Adding values from a 3x3f matrix this function may be overload to obtain better performances
-void BaseMatrix::add(Index _i, Index _j, const type::Mat3x3f & _M) {
+void BaseMatrix::add(Index row, Index col, const type::Mat3x3f & _M) {
     for (unsigned i=0;i<3;i++)
         for (unsigned j=0;j<3;j++)
-            add(_i+i,_j+j,_M[i][j]);
+            add(row + i, col + j, _M[i][j]);
 }
 
 ///Adding values from a 2x2d matrix this function may be overload to obtain better performances
-void BaseMatrix::add(Index _i, Index _j, const type::Mat2x2d & _M) {
+void BaseMatrix::add(Index row, Index col, const type::Mat2x2d & _M) {
     for (unsigned i=0;i<2;i++)
         for (unsigned j=0;j<2;j++)
-            add(_i+i,_j+j,_M[i][j]);
+            add(row + i, col + j, _M[i][j]);
 }
 
 ///Adding values from a 2x2f matrix this function may be overload to obtain better performances
-void BaseMatrix::add(Index _i, Index _j, const type::Mat2x2f & _M) {
+void BaseMatrix::add(Index row, Index col, const type::Mat2x2f & _M) {
     for (unsigned i=0;i<2;i++)
         for (unsigned j=0;j<2;j++)
-            add(_i+i,_j+j,_M[i][j]);
+            add(row + i, col + j, _M[i][j]);
 }
 
 

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BaseMatrix.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/BaseMatrix.h
@@ -66,19 +66,19 @@ public:
     /// Write the value of the element at row i, column j (using 0-based indices)
     virtual void set(Index i, Index j, double v) = 0;
     /// Add v to the existing value of the element at row i, column j (using 0-based indices)
-    virtual void add(Index i, Index j, double v) = 0;
+    virtual void add(Index row, Index col, double v) = 0;
 
-    ///Adding values from a 3x3d matrix this function may be overload to obtain better performances
-    virtual void add(Index _i, Index _j, const type::Mat3x3d & _M);
+    ///Adding values from a 3x3d matrix. This function may be overload to obtain better performances
+    virtual void add(Index row, Index col, const type::Mat3x3d & _M);
 
-    ///Adding values from a 3x3f matrix this function may be overload to obtain better performances
-    virtual void add(Index _i, Index _j, const type::Mat3x3f & _M);
+    ///Adding values from a 3x3f matrix. This function may be overload to obtain better performances
+    virtual void add(Index row, Index col, const type::Mat3x3f & _M);
 
-    ///Adding values from a 2x2d matrix this function may be overload to obtain better performances
-    virtual void add(Index _i, Index _j, const type::Mat2x2d & _M);
+    ///Adding values from a 2x2d matrix. This function may be overload to obtain better performances
+    virtual void add(Index row, Index col, const type::Mat2x2d & _M);
 
-    ///Adding values from a 2x2f matrix this function may be overload to obtain better performances
-    virtual void add(Index _i, Index _j, const type::Mat2x2f & _M);
+    ///Adding values from a 2x2f matrix. This function may be overload to obtain better performances
+    virtual void add(Index row, Index col, const type::Mat2x2f & _M);
 
     /*    /// Write the value of the element at row i, column j (using 0-based indices)
         virtual void set(Index i, Index j, float v) { set(i,j,(double)v); }

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/HexahedronFEMForceField.h
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/HexahedronFEMForceField.h
@@ -153,12 +153,6 @@ public:
 
     void addKToMatrix(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
 
-    /// Specialized addKToMatrix implementation for CRS 3x3 bloc matrices
-    template<class BlocReal>
-    void addKToBlocMatrix(
-            sofa::component::linearsolver::CompressedRowSparseMatrix<type::Mat<3,3,BlocReal>,  type::vector<type::Mat<3,3,BlocReal> >, type::vector<sofa::Index> > *crsmat,
-            SReal k, unsigned int &offset);
-
     void computeBBox(const core::ExecParams* params, bool onlyVisible) override;
 
     void draw(const core::visual::VisualParams* vparams) override;

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/HexahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/HexahedronFEMForceField.inl
@@ -1124,80 +1124,32 @@ void HexahedronFEMForceField<DataTypes>::addKToMatrix(const core::MechanicalPara
     sofa::core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate);
     const Real kFactor = (Real)sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue());
 
-    if (auto* crsmat_d = dynamic_cast<sofa::component::linearsolver::CompressedRowSparseMatrix<type::Mat<3,3,double> > * >(r.matrix))
+    sofa::Index e { 0 }; //index of the element in the topology
+
+    const auto& stiffnesses = _elementStiffnesses.getValue();
+    const auto* indexedElements = this->getIndexedElements();
+
+    for (const auto& element : *indexedElements)
     {
-        addKToBlocMatrix<double>(crsmat_d, kFactor, r.offset);
-    }
-    else if (auto* crsmat_f = dynamic_cast<sofa::component::linearsolver::CompressedRowSparseMatrix<type::Mat<3,3,float> > * >(r.matrix))
-    {
-        addKToBlocMatrix<float>(crsmat_f, kFactor, r.offset);
-    }
-    else
-    {
-        int e; //index of the element in the topology
-
-        typename VecElement::const_iterator it;
-        typename Element::size_type n1, n2;
-
-        Index node1, node2;
-
-        for(it = this->getIndexedElements()->begin(), e=0 ; it != this->getIndexedElements()->end() ; ++it,++e)
-        {
-            const ElementStiffness &Ke = _elementStiffnesses.getValue()[e];
-            const Transformation Rot = getElementRotation(e);
-
-            // find index of node 1
-            for (n1 = 0; n1 < Element::size(); n1++)
-            {
-                node1 = (*it)[n1];
-                // find index of node 2
-                for (n2 = 0; n2 < Element::size(); n2++)
-                {
-                    node2 = (*it)[n2];
-
-                    const Mat33 tmp = Rot.multTranspose( Mat33(
-                            Coord(Ke[3*n1+0][3*n2+0],Ke[3*n1+0][3*n2+1],Ke[3*n1+0][3*n2+2]),
-                            Coord(Ke[3*n1+1][3*n2+0],Ke[3*n1+1][3*n2+1],Ke[3*n1+1][3*n2+2]),
-                            Coord(Ke[3*n1+2][3*n2+0],Ke[3*n1+2][3*n2+1],Ke[3*n1+2][3*n2+2])) ) * Rot;
-                    r.matrix->add(r.offset + 3 * node1, r.offset + 3 * node2, tmp * (-kFactor));
-                }
-            }
-        }
-    }
-}
-
-template<class DataTypes>
-template<class BlocReal>
-void HexahedronFEMForceField<DataTypes>::addKToBlocMatrix(
-        sofa::component::linearsolver::CompressedRowSparseMatrix<type::Mat<3, 3, BlocReal>, type::vector<type::Mat<3, 3, BlocReal> >, type::vector<sofa::Index> >* crsmat,
-        SReal k, unsigned int& offset)
-{
-    int e; //index of the element in the topology
-
-    typename VecElement::const_iterator it;
-    typename Element::size_type n1, n2;
-
-    Index node1, node2;
-
-    for(it = this->getIndexedElements()->begin(), e=0 ; it != this->getIndexedElements()->end() ; ++it,++e)
-    {
-        const ElementStiffness &Ke = _elementStiffnesses.getValue()[e];
+        const ElementStiffness &Ke = stiffnesses[e];
         const Transformation Rot = getElementRotation(e);
+        e++;
 
         // find index of node 1
-        for (n1 = 0; n1 < Element::size(); n1++)
+        for (Element::size_type n1 = 0; n1 < Element::size(); n1++)
         {
-            node1 = (*it)[n1];
+            const auto node1 = element[n1];
             // find index of node 2
-            for (n2 = 0; n2 < Element::size(); n2++)
+            for (Element::size_type n2 = 0; n2 < Element::size(); n2++)
             {
-                node2 = (*it)[n2];
+                const auto node2 = element[n2];
 
                 const Mat33 tmp = Rot.multTranspose( Mat33(
                         Coord(Ke[3*n1+0][3*n2+0],Ke[3*n1+0][3*n2+1],Ke[3*n1+0][3*n2+2]),
                         Coord(Ke[3*n1+1][3*n2+0],Ke[3*n1+1][3*n2+1],Ke[3*n1+1][3*n2+2]),
                         Coord(Ke[3*n1+2][3*n2+0],Ke[3*n1+2][3*n2+1],Ke[3*n1+2][3*n2+2])) ) * Rot;
-                *crsmat->wbloc(offset / 3 + node1, offset / 3 + node2, true) += tmp * (-k);
+
+                r.matrix->add( r.offset + 3 * node1, r.offset + 3 * node2, tmp * (-kFactor));
             }
         }
     }

--- a/modules/SofaSparseSolver/examples/FEM_SparseLDLSolver.scn
+++ b/modules/SofaSparseSolver/examples/FEM_SparseLDLSolver.scn
@@ -9,7 +9,8 @@
 
     <Node name="M1">
         <EulerImplicitSolver name="odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
-        <SparseLDLSolver printLog="false"/>
+        <SparseLDLSolver printLog="false" template="CompressedRowSparseMatrixMat3x3d"/>
+<!--        <SparseLDLSolver printLog="false" template="CompressedRowSparseMatrixd"/>-->
         <MechanicalObject />
         <UniformMass vertexMass="1" />
         <RegularGridTopology nx="4" ny="4" nz="20" xmin="-9" xmax="-6" ymin="0" ymax="3" zmin="0" zmax="19" />

--- a/modules/SofaSparseSolver/examples/FEM_SparseLDLSolver.scn
+++ b/modules/SofaSparseSolver/examples/FEM_SparseLDLSolver.scn
@@ -10,7 +10,9 @@
     <Node name="M1">
         <EulerImplicitSolver name="odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
         <SparseLDLSolver printLog="false" template="CompressedRowSparseMatrixMat3x3d"/>
-<!--        <SparseLDLSolver printLog="false" template="CompressedRowSparseMatrixd"/>-->
+        <!-- You can assemble the matrix using scalar instead of blocks by changing the SparseLDLSolver template as follows:
+            <SparseLDLSolver printLog="false" template="CompressedRowSparseMatrixd"/>
+        -->
         <MechanicalObject />
         <UniformMass vertexMass="1" />
         <RegularGridTopology nx="4" ny="4" nz="20" xmin="-9" xmax="-6" ymin="0" ymax="3" zmin="0" zmax="19" />


### PR DESCRIPTION
PR based on #2280.
Template specialization for `void CompressedRowSparseMatrix<type::Mat<3,3,double> >::add(Index row, Index col, const type::Mat3x3d & _M)` in order to accelerate insertion.
This allows to avoid branching in force fields, based on the type of the system matrix (`dynamic_cast`). I removed it in `HexahedronFEMForceField`, but it could be removed in other places. It allows also to automatically optimize bloc insertion in force fields that did not have the branches.

# Benchmarks

## List of benchmarks

- `BM_CRS_Fixture<double>/Add3x3Bloc_CRSdouble`: insertion of 1000 3x3 blocs into a CRS made of double
- `BM_CRS_Fixture<sofa::type::Mat<3,3,double>>/Add3x3Bloc_CRS3x3d`: insertion of 1000 3x3 blocs into a CRS made of 3x3 blocs
- `BM_CRS_Fixture<sofa::type::Mat<3,3,double>>/Add3x3BlocShortcut_CRS3x3d`: insertion of 1000 3x3 blocs into a CRS made of 3x3 blocs, but insertion uses the fast function specialized for 3x3 CRS matrices. This is the fastest possible bloc insertion. It is actually used in the specialized function introduced by this PR, among other checks. Therefore, this speed is the goal to achieve for the specialized function.
- `BM_CRS_Fixture<double>/Add3x3BlocScalar_double`: insertion of 1000 3x3 blocs into a CRS made of double using 9 individual scalar insertion
- `BM_CRS_Fixture<sofa::type::Mat<3,3,double>>/Add3x3BlocScalar_CRS3x3d `: insertion of 1000 3x3 blocs into a CRS made of 3x3 blocs, using 9 individual scalar insertion. This is equivalent to what happens in BaseMatrix' bloc insertion, therefore it corresponds to the previous behavior of bloc insertion (before this PR).

## Before

```
-----------------------------------------------------------------------------------------------------------------
Benchmark                                                                       Time             CPU   Iterations
-----------------------------------------------------------------------------------------------------------------
BM_CRS_Fixture<double>/Add3x3Bloc_CRSdouble                                 75568 ns        75550 ns         9185
BM_CRS_Fixture<sofa::type::Mat<3,3,double>>/Add3x3Bloc_CRS3x3d              55533 ns        54699 ns        12798
BM_CRS_Fixture<sofa::type::Mat<3,3,double>>/Add3x3BlocShortcut_CRS3x3d      12930 ns        12785 ns        49662
BM_CRS_Fixture<double>/Add3x3BlocScalar_double                              67780 ns        66811 ns        10488
BM_CRS_Fixture<sofa::type::Mat<3,3,double>>/Add3x3BlocScalar_CRS3x3d        51334 ns        50603 ns        13884
```

## After

```
-----------------------------------------------------------------------------------------------------------------
Benchmark                                                                       Time             CPU   Iterations
-----------------------------------------------------------------------------------------------------------------
BM_CRS_Fixture<double>/Add3x3Bloc_CRSdouble                                 76223 ns        76266 ns         9132
BM_CRS_Fixture<sofa::type::Mat<3,3,double>>/Add3x3Bloc_CRS3x3d              13781 ns        13808 ns        51026
BM_CRS_Fixture<sofa::type::Mat<3,3,double>>/Add3x3BlocShortcut_CRS3x3d      12434 ns        12458 ns        56014
BM_CRS_Fixture<double>/Add3x3BlocScalar_double                              66579 ns        66637 ns        10530
BM_CRS_Fixture<sofa::type::Mat<3,3,double>>/Add3x3BlocScalar_CRS3x3d        49684 ns        49713 ns        14274
```

# Conclusion

The benchmarks show that insertion of 3x3 blocs is faster in 3x3 bloc-based CRS matrices than before (the test `Add3x3Bloc_CRS3x3d`). It goes almost at the same speed than the bloc insertion specialized for 3x3 CRS matrices (benchmark BM_CRS_Fixture<sofa::type::Mat<3,3,double>>/Add3x3BlocShortcut_CRS3x3d).
The speed remains the same for CRS made doubles, which is expected.

TODO: explain the benchmarks and push them


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
