### PR TITLE
[SofaMiscFem] Quick clean unused parameters in Triangular and TriangleFEMForceField

### DIFF
--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangleFEMForceField.cpp
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangleFEMForceField.cpp
@@ -20,11 +20,10 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #define SOFA_COMPONENT_FORCEFIELD_TRIANGLEFEMFORCEFIELD_CPP
-#include "TriangleFEMForceField.inl"
 
+#include <SofaMiscFem/TriangleFEMForceField.inl>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/defaulttype/VecTypes.h>
-
 
 namespace sofa::component::forcefield
 {
@@ -32,7 +31,7 @@ namespace sofa::component::forcefield
 using namespace sofa::defaulttype;
 
 // Register in the Factory
-int TriangleFEMForceFieldClass = core::RegisterObject("Triangular finite elements")
+int TriangleFEMForceFieldClass = core::RegisterObject("Triangular finite elements for static topology")
         .add< TriangleFEMForceField<Vec3Types> >()
 
         ;

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangleFEMForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangleFEMForceField.h
@@ -23,8 +23,6 @@
 
 #include <SofaMiscFem/config.h>
 
-
-
 #include <sofa/core/behavior/ForceField.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/type/Vec.h>
@@ -200,6 +198,7 @@ protected :
     type::Mat<3, 3, Real> InvalidTransform;
     type::fixed_array <Coord, 3> InvalidCoords;
     StrainDisplacement InvalidStrainDisplacement;
+    /// Pointer to the utils class which store methods common to TriangleFEMForceField
 };
 
 

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangleFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangleFEMForceField.inl
@@ -23,15 +23,9 @@
 
 #include <SofaMiscFem/config.h>
 
-#include "TriangleFEMForceField.h"
+#include <SofaMiscFem/TriangleFEMForceField.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/type/RGBAColor.h>
-#include <sofa/core/ObjectFactory.h>
-#include <sofa/core/topology/BaseMeshTopology.h>
-#include <fstream> // for reading the file
-#include <iostream> //for debugging
-#include <vector>
-#include <sofa/defaulttype/VecTypes.h>
 
 namespace sofa::component::forcefield
 {
@@ -613,13 +607,6 @@ void TriangleFEMForceField<DataTypes>::accumulateForceLarge(VecCoord &f, const V
     }
 
 }
-
-
-//template <class DataTypes>
-//void TriangleFEMForceField<DataTypes>::accumulateDampingLarge(VecCoord &, Index )
-//{
-
-//}
 
 
 template <class DataTypes>

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.cpp
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.cpp
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #define SOFA_COMPONENT_FORCEFIELD_TRIANGULARFEMFORCEFIELD_CPP
 
-#include "TriangularFEMForceField.inl"
+#include <SofaMiscFem/TriangularFEMForceField.inl>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/defaulttype/VecTypes.h>
 
@@ -32,13 +32,12 @@ namespace sofa::component::forcefield
 using namespace sofa::defaulttype;
 
 // Register in the Factory
-int TriangularFEMForceFieldClass = core::RegisterObject("Corotational Triangular finite elements")
+int TriangularFEMForceFieldClass = core::RegisterObject("Corotational Triangular finite elements for dynamic topology")
     .add< TriangularFEMForceField<Vec3Types> >()
 
     ;
 
 template class SOFA_SOFAMISCFEM_API TriangularFEMForceField<Vec3Types>;
-
 
 
 } // namespace sofa::component::forcefield

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.h
@@ -151,27 +151,6 @@ public:
         Real differenceToCriteria;
     };
 
-    /// Class to store FEM information on each edge, for topology modification handling
-    class EdgeInformation
-    {
-    public:
-        EdgeInformation()
-            :fracturable(false) {}
-
-        bool fracturable;
-
-        /// Output stream
-        inline friend std::ostream& operator<< ( std::ostream& os, const EdgeInformation& /*ei*/ )
-        {
-            return os;
-        }
-
-        /// Input stream
-        inline friend std::istream& operator>> ( std::istream& in, EdgeInformation& /*ei*/ )
-        {
-            return in;
-        }
-    };
 
     /// Class to store FEM information on each vertex, for topology modification handling
     class VertexInformation
@@ -201,7 +180,6 @@ public:
     /// Topology Data
     topology::TriangleData<sofa::type::vector<TriangleInformation> > triangleInfo;
     topology::PointData<sofa::type::vector<VertexInformation> > vertexInfo; ///< Internal point data
-    topology::EdgeData<sofa::type::vector<EdgeInformation> > edgeInfo; ///< Internal edge data
 
     void createTriangleInformation(Index triangleIndex, TriangleInformation&,
         const core::topology::BaseMeshTopology::Triangle& t,
@@ -269,7 +247,6 @@ protected :
     void applyStiffnessLarge( VecCoord& f, Real h, const VecCoord& x, const SReal &kFactor );
 
     bool updateMatrix;
-    int lastFracturedEdgeIndex;
 
 public:
 

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.h
@@ -219,10 +219,7 @@ public:
     void setYoung(Real val);
     void setYoungArray(const type::vector<Real>& values);
 
-    Real getDamping() { return f_damping.getValue(); }
-    void setDamping(Real val);
     int  getMethod() { return method; }
-    
     void setMethod(int val);
     void setMethod(const std::string& methodName);
 
@@ -263,16 +260,13 @@ protected :
     ////////////// small displacements method
     void initSmall(int i, Index&a, Index&b, Index&c);
     void accumulateForceSmall( VecCoord& f, const VecCoord & p, Index elementIndex);
-    void accumulateDampingSmall( VecCoord& f, Index elementIndex );
     void applyStiffnessSmall( VecCoord& f, Real h, const VecCoord& x, const SReal &kFactor );
 
     ////////////// large displacements method
     void initLarge(int i, Index&a, Index&b, Index&c);
     void computeRotationLarge( Transformation &r, const VecCoord &p, const Index &a, const Index &b, const Index &c);
     void accumulateForceLarge( VecCoord& f, const VecCoord & p, Index elementIndex);
-    void accumulateDampingLarge( VecCoord& f, Index elementIndex );
     void applyStiffnessLarge( VecCoord& f, Real h, const VecCoord& x, const SReal &kFactor );
-
 
     bool updateMatrix;
     int lastFracturedEdgeIndex;
@@ -284,7 +278,6 @@ public:
     Data<std::string> f_method; ///< large: large displacements, small: small displacements
     Data<type::vector<Real> > f_poisson; ///< Poisson ratio in Hooke's law (vector)
     Data<type::vector<Real> > f_young; ///< Young modulus in Hooke's law (vector)
-    Data<Real> f_damping; ///< Ratio damping/stiffness
 
     /// Initial strain parameters (if FEM is initialised with predefine values)
     Data< sofa::type::vector<type::fixed_array<Coord,3> > > m_rotatedInitialElements;

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.h
@@ -22,16 +22,15 @@
 #pragma once
 
 #include <SofaMiscFem/config.h>
-
-
 #include <sofa/core/behavior/ForceField.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/type/Mat.h>
 #include <SofaBaseTopology/TopologyData.h>
 
+#ifdef PLOT_CURVE
 #include <map>
-#include <sofa/helper/map.h>
+#endif
 
 namespace sofa::helper
 {

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
@@ -1453,7 +1453,7 @@ void TriangularFEMForceField<DataTypes>::draw(const core::visual::VisualParams* 
     if (showStressValue.getValue())
     {
         type::vector<VertexInformation>& vertexInf = *(vertexInfo.beginEdit());
-        double minStress = std::numeric_limits<double>::max();
+        Real minStress = std::numeric_limits<Real>::max();
         double maxStress = 0.0;
         for ( unsigned int i = 0 ; i < vertexInf.size() ; i++)
         {

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
@@ -19,10 +19,9 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-
 #pragma once
 
-#include "TriangularFEMForceField.h"
+#include <SofaMiscFem/TriangularFEMForceField.h>
 
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/ColorMap.h>
@@ -30,13 +29,8 @@
 
 #include <SofaBaseTopology/TopologyData.inl>
 
-#include <sofa/helper/system/thread/debug.h>
 #include <newmat/newmat.h>
 #include <newmat/newmatap.h>
-#include <fstream> // for reading the file
-#include <iostream> //for debugging
-#include <vector>
-#include <algorithm>
 #include <limits>
 
 namespace sofa::component::forcefield
@@ -1520,7 +1514,7 @@ void TriangularFEMForceField<DataTypes>::draw(const core::visual::VisualParams* 
     if (showStressValue.getValue())
     {
         type::vector<VertexInformation>& vertexInf = *(vertexInfo.beginEdit());
-        double minStress = numeric_limits<double>::max();
+        double minStress = std::numeric_limits<double>::max();
         double maxStress = 0.0;
         for ( unsigned int i = 0 ; i < vertexInf.size() ; i++)
         {
@@ -1575,8 +1569,8 @@ void TriangularFEMForceField<DataTypes>::draw(const core::visual::VisualParams* 
         std::vector<sofa::type::Vector3> vertices;
         sofa::type::RGBAColor color;
 
-        Real maxDifference = numeric_limits<Real>::min();
-        Real minDifference = numeric_limits<Real>::max();
+        Real maxDifference = std::numeric_limits<Real>::min();
+        Real minDifference = std::numeric_limits<Real>::max();
         for (Size i = 0 ; i < nbTriangles ; i++)
         {
             if (triangleInf[i].differenceToCriteria > 0)

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
@@ -1454,7 +1454,7 @@ void TriangularFEMForceField<DataTypes>::draw(const core::visual::VisualParams* 
     {
         type::vector<VertexInformation>& vertexInf = *(vertexInfo.beginEdit());
         Real minStress = std::numeric_limits<Real>::max();
-        double maxStress = 0.0;
+        Real maxStress = 0.0;
         for ( unsigned int i = 0 ; i < vertexInf.size() ; i++)
         {
             const core::topology::BaseMeshTopology::TrianglesAroundVertex& triangles = m_topology->getTrianglesAroundVertex(i);


### PR DESCRIPTION
Remove unused Data:
- edgeInfo
- f_damping

Removes API proposing to implement damping inside the same class.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
