### PR TITLE
[SofaKernel] change data content copy on write condition

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
@@ -253,10 +253,10 @@ public:
     bool copyValueFrom(const BaseData* data){ return doCopyValueFrom(data); }
     bool copyValueFrom(const Data<T>* data);
 
-    bool isCopyOnWrite(){ return sofa::defaulttype::DataTypeInfo<T>::CopyOnWrite; }
+    static constexpr bool isCopyOnWrite(){ return !std::is_scalar_v<T>; }
 
 protected:
-    typedef DataContentValue<T, sofa::defaulttype::DataTypeInfo<T>::CopyOnWrite> ValueType;
+    typedef DataContentValue<T,  !std::is_scalar_v<T>> ValueType;
 
     /// Value
     ValueType m_value;


### PR DESCRIPTION
The Data's hold their actual content within a dedicated  container called DataContentValue.
Two versions of this containers exists, on holding the data using a copy-on-write mechanism while an other is using a systematic copy. 

Currently the selection is based on the content of DataTypeInfo, I found it more explicit and clear to rely on type_traits to select the proper DataContentValue version. 

```console
Caduceuse, 10 000 iterations:
  - master: 24.15 s
  - copy on write to true: 24.2 s
  - copy on write to false: 23.78 s
  - copy on write to is_scalar: 25.0 s
  - copy on write to !is_scalar: 23.0 s

collisionMultiple.scn, 1 000 iterations:
  - master: 15.9 s
  - copy on write to true: 15.9 s
  - copy on write to false: 14.7 s
  - copy on write to is_scalar: 16.3 s
  - copy on write to !is_scalar: 14.5 s
  
 beam16x16x76-hexafem-rk4-CPU.scn: 2000 iterations
  - master: 1 m 30
  - copy on write to true: 1 m 32
  - copy on write to false: 1 m 30 
  - copy on write to is_scalar:  1 m 26
  - copy on write to !is_scalar: 1 m 18
  
  TorusFall: 4000 iterations
  - master: 41.5 s
  - copy on write to true: 43.9 s
  - copy on write to false: 41.2 s 
  - copy on write to is_scalar: 43.3 s  
  - copy on write to !is_scalar: 42.5 s
```
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
