### PR TITLE
[SofaMiscTopology] Add a component TopologyBoundingTrasher to remove mesh going outside from scene bounding box

### DIFF
--- a/examples/Components/topology/TopologyBoundingTrasher.scn
+++ b/examples/Components/topology/TopologyBoundingTrasher.scn
@@ -1,0 +1,37 @@
+<!-- Mechanical MassSpring Group Basic Example -->
+<Node name="root" dt="0.01" showBoundingTree="0" gravity="0 -1 0">
+	<RequiredPlugin name="SofaDeformable"/> <!-- Needed to use components [StiffSpringForceField] -->
+	<RequiredPlugin name="SofaGeneralDeformable"/> <!-- Needed to use components [TriangularBendingSprings] -->
+	<RequiredPlugin name="SofaImplicitOdeSolver"/> <!-- Needed to use components [EulerImplicitSolver] -->
+	<RequiredPlugin name="SofaMiscCollision"/> <!-- Needed to use components [DefaultCollisionGroupManager] -->
+	<RequiredPlugin name="SofaMiscFem"/> <!-- Needed to use components [TriangularFEMForceField] -->
+	<RequiredPlugin name="SofaMiscTopology"/> <!-- Needed to use components [TopologyBoundingTrasher] -->
+	<RequiredPlugin name="SofaOpenglVisual"/> <!-- Needed to use components [OglModel] -->
+
+    <VisualStyle displayFlags="showBehaviorModels showVisual" />
+    <DefaultPipeline verbose="0" />
+    <BruteForceBroadPhase/>
+    <BVHNarrowPhase/>
+    <DefaultContactManager response="default" />
+    <MinProximityIntersection name="Proximity" alarmDistance="0.8" contactDistance="0.5" />
+    <DefaultCollisionGroupManager />
+	
+	<Node name="SquareGravity">
+		<CGImplicit iterations="40" tolerance="1e-6" threshold="1e-10" />
+		<MeshGmshLoader name="loader" filename="mesh/square3.msh" createSubelements="true" />
+		<MechanicalObject name="Volume" src="@loader" scale="10" />
+		<TriangleSetTopologyContainer  name="Container" src="@loader" />
+		<TriangleSetTopologyModifier   name="Modifier" />
+		<TriangleSetGeometryAlgorithms name="GeomAlgo" template="Vec3d" />
+		<DiagonalMass massDensity="1" />
+		<StiffSpringForceField name="FF" />
+		<TriangularFEMForceField name="FEM" youngModulus="60" poissonRatio="0.3" method="large" />
+		<TriangularBendingSprings name="FEM-Bend" stiffness="300" damping="1.0" />
+		
+		<TopologyBoundingTrasher box="-10 -10 -10 11 11 11" topology="@Container" drawBox="1" position="@Volume.position"/>
+		<Node >
+			<OglModel name="Visual" color="red" />
+			<IdentityMapping input="@.." output="@Visual" />
+		</Node>
+	</Node>
+</Node>

--- a/modules/SofaMiscTopology/CMakeLists.txt
+++ b/modules/SofaMiscTopology/CMakeLists.txt
@@ -15,10 +15,13 @@ set(SOURCE_FILES
 list(APPEND HEADER_FILES
 	${SOFAMISCTOPOLOGY_SRC}/TopologicalChangeProcessor.h
 	${SOFAMISCTOPOLOGY_SRC}/TopologyChecker.h
+    ${SOFAMISCTOPOLOGY_SRC}/TopologyBoundingTrasher.h
+    ${SOFAMISCTOPOLOGY_SRC}/TopologyBoundingTrasher.inl
 )
 list(APPEND SOURCE_FILES
 	${SOFAMISCTOPOLOGY_SRC}/TopologicalChangeProcessor.cpp
 	${SOFAMISCTOPOLOGY_SRC}/TopologyChecker.cpp
+    ${SOFAMISCTOPOLOGY_SRC}/TopologyBoundingTrasher.cpp
 )
 
 sofa_find_package(SofaBase REQUIRED) # SofaBaseTopology

--- a/modules/SofaMiscTopology/src/SofaMiscTopology/TopologyBoundingTrasher.cpp
+++ b/modules/SofaMiscTopology/src/SofaMiscTopology/TopologyBoundingTrasher.cpp
@@ -1,0 +1,38 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#define SOFA_COMPONENT_MISC_TOPOLOGYBOUNDINGTRASHER_CPP
+#include <SofaMiscTopology/TopologyBoundingTrasher.inl>
+#include <sofa/core/ObjectFactory.h>
+#include <sofa/defaulttype/VecTypes.h>
+
+namespace sofa::component::misc
+{
+
+using namespace sofa::type;
+using namespace sofa::defaulttype;
+
+int TopologyBoundingTrasherClass = core::RegisterObject("A class to remove all elements going outside from the given Bounding Box.")
+        .add< TopologyBoundingTrasher<Vec3Types>  >(true);
+
+template class SOFA_SOFAMISCTOPOLOGY_API TopologyBoundingTrasher<Vec3Types>;
+
+} // namespace sofa::component::misc

--- a/modules/SofaMiscTopology/src/SofaMiscTopology/TopologyBoundingTrasher.h
+++ b/modules/SofaMiscTopology/src/SofaMiscTopology/TopologyBoundingTrasher.h
@@ -51,7 +51,7 @@ namespace sofa::component::misc
  *
 */
 template <class DataTypes>
-class SOFA_SOFAMISCTOPOLOGY_API TopologyBoundingTrasher: public core::objectmodel::BaseObject
+class SOFA_SOFAMISCTOPOLOGY_API TopologyBoundingTrasher: public virtual core::objectmodel::BaseObject
 {
 public:
     SOFA_CLASS(SOFA_TEMPLATE(TopologyBoundingTrasher, DataTypes), core::objectmodel::BaseObject);
@@ -103,6 +103,10 @@ protected:
 
     type::vector<Index> m_indicesToRemove;
 };
+
+#if  !defined(SOFA_COMPONENT_MISC_TOPOLOGYBOUNDINGTRASHER_CPP)
+extern template class SOFA_SOFAMISCTOPOLOGY_API TopologyBoundingTrasher<sofa::defaulttype::Vec3Types>;
+#endif //  !defined(SOFA_COMPONENT_MISC_TOPOLOGYBOUNDINGTRASHER_CPP)
 
 
 } // namespace sofa::component::misc

--- a/modules/SofaMiscTopology/src/SofaMiscTopology/TopologyBoundingTrasher.h
+++ b/modules/SofaMiscTopology/src/SofaMiscTopology/TopologyBoundingTrasher.h
@@ -95,11 +95,11 @@ protected:
     core::topology::BaseMeshTopology::SPtr m_topology;
     sofa::core::topology::TopologyElementType m_topologyType;
 
-    sofa::component::topology::EdgeSetTopologyModifier::SPtr edgeModifier;
-    sofa::component::topology::TriangleSetTopologyModifier::SPtr triangleModifier;
-    sofa::component::topology::QuadSetTopologyModifier::SPtr quadModifier;
-    sofa::component::topology::TetrahedronSetTopologyModifier::SPtr tetraModifier;
-    sofa::component::topology::HexahedronSetTopologyModifier::SPtr hexaModifier;
+    sofa::core::sptr<sofa::component::topology::EdgeSetTopologyModifier> edgeModifier;
+    sofa::core::sptr<sofa::component::topology::TriangleSetTopologyModifier> triangleModifier;
+    sofa::core::sptr<sofa::component::topology::QuadSetTopologyModifier> quadModifier;
+    sofa::core::sptr<sofa::component::topology::TetrahedronSetTopologyModifier> tetraModifier;
+    sofa::core::sptr<sofa::component::topology::HexahedronSetTopologyModifier> hexaModifier;
 
     type::vector<Index> m_indicesToRemove;
 };

--- a/modules/SofaMiscTopology/src/SofaMiscTopology/TopologyBoundingTrasher.h
+++ b/modules/SofaMiscTopology/src/SofaMiscTopology/TopologyBoundingTrasher.h
@@ -1,0 +1,108 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <SofaMiscTopology/config.h>
+#include <sofa/core/DataEngine.h>
+#include <sofa/core/behavior/MechanicalState.h>
+#include <sofa/core/topology/BaseMeshTopology.h>
+
+#include <sofa/simulation/AnimateBeginEvent.h>
+#include <sofa/simulation/AnimateEndEvent.h>
+
+
+namespace sofa::component::topology
+{
+    /// forward declaration to avoid adding includes in .h
+    class EdgeSetTopologyModifier;
+    class TriangleSetTopologyModifier;
+    class TetrahedronSetTopologyModifier;
+    class QuadSetTopologyModifier;
+    class HexahedronSetTopologyModifier;
+}
+
+namespace sofa::component::misc
+{
+
+    using core::topology::BaseMeshTopology;
+    using core::behavior::MechanicalState;
+
+/** Read file containing topological modification. Or apply input modifications
+ * A timestep has to be established for each modification.
+ *
+*/
+template <class DataTypes>
+class SOFA_SOFAMISCTOPOLOGY_API TopologyBoundingTrasher: public core::objectmodel::BaseObject
+{
+public:
+    SOFA_CLASS(SOFA_TEMPLATE(TopologyBoundingTrasher, DataTypes), core::objectmodel::BaseObject);
+    typedef typename DataTypes::VecCoord VecCoord;
+    typedef typename DataTypes::Coord Coord;
+    typedef typename DataTypes::Real Real;
+    typedef type::Vec<3, Real> Vec3;
+    typedef type::Vec<6, Real> Vec6;
+
+    using Index = sofa::Index;
+    using Vector3 = type::Vector3;
+
+protected:
+    TopologyBoundingTrasher();
+
+    ~TopologyBoundingTrasher() override;
+
+    void filterElementsToRemove();
+    void removeElements();
+
+    bool isPointOutside(const Coord& value, const Vec6& bb);
+
+public:
+    void init() override;
+    void reinit() override;
+
+    void handleEvent(sofa::core::objectmodel::Event* event) override;
+
+    void draw(const core::visual::VisualParams* vparams) override;
+
+public:
+    Data<VecCoord> d_positions;
+    Data<Vec6>  d_borders;
+    Data<bool>  m_drawBox; ///< draw bounding box
+
+    /// Link to be set to the topology container in the component graph.
+    SingleLink<TopologyBoundingTrasher, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
+
+
+protected:
+    core::topology::BaseMeshTopology* m_topology;
+    sofa::core::topology::TopologyElementType m_topologyType;
+
+    sofa::component::topology::EdgeSetTopologyModifier* edgeModifier;
+    sofa::component::topology::TriangleSetTopologyModifier* triangleModifier;
+    sofa::component::topology::QuadSetTopologyModifier* quadModifier;
+    sofa::component::topology::TetrahedronSetTopologyModifier* tetraModifier;
+    sofa::component::topology::HexahedronSetTopologyModifier* hexaModifier;
+
+    type::vector<Index> m_indicesToRemove;
+};
+
+
+} // namespace sofa::component::misc

--- a/modules/SofaMiscTopology/src/SofaMiscTopology/TopologyBoundingTrasher.h
+++ b/modules/SofaMiscTopology/src/SofaMiscTopology/TopologyBoundingTrasher.h
@@ -72,7 +72,7 @@ protected:
     void filterElementsToRemove();
     void removeElements();
 
-    bool isPointOutside(const Coord& value, const Vec6& bb);
+    constexpr bool isPointOutside(const Coord& value, const Vec6& bb);
 
 public:
     void init() override;

--- a/modules/SofaMiscTopology/src/SofaMiscTopology/TopologyBoundingTrasher.h
+++ b/modules/SofaMiscTopology/src/SofaMiscTopology/TopologyBoundingTrasher.h
@@ -51,7 +51,7 @@ namespace sofa::component::misc
  *
 */
 template <class DataTypes>
-class SOFA_SOFAMISCTOPOLOGY_API TopologyBoundingTrasher: public virtual core::objectmodel::BaseObject
+class SOFA_SOFAMISCTOPOLOGY_API TopologyBoundingTrasher: public core::objectmodel::BaseObject
 {
 public:
     SOFA_CLASS(SOFA_TEMPLATE(TopologyBoundingTrasher, DataTypes), core::objectmodel::BaseObject);

--- a/modules/SofaMiscTopology/src/SofaMiscTopology/TopologyBoundingTrasher.h
+++ b/modules/SofaMiscTopology/src/SofaMiscTopology/TopologyBoundingTrasher.h
@@ -85,21 +85,21 @@ public:
 public:
     Data<VecCoord> d_positions;
     Data<Vec6>  d_borders;
-    Data<bool>  m_drawBox; ///< draw bounding box
+    Data<bool>  d_drawBox; ///< draw bounding box
 
     /// Link to be set to the topology container in the component graph.
     SingleLink<TopologyBoundingTrasher, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
 
 protected:
-    core::topology::BaseMeshTopology* m_topology;
+    core::topology::BaseMeshTopology::SPtr m_topology;
     sofa::core::topology::TopologyElementType m_topologyType;
 
-    sofa::component::topology::EdgeSetTopologyModifier* edgeModifier;
-    sofa::component::topology::TriangleSetTopologyModifier* triangleModifier;
-    sofa::component::topology::QuadSetTopologyModifier* quadModifier;
-    sofa::component::topology::TetrahedronSetTopologyModifier* tetraModifier;
-    sofa::component::topology::HexahedronSetTopologyModifier* hexaModifier;
+    sofa::component::topology::EdgeSetTopologyModifier::SPtr edgeModifier;
+    sofa::component::topology::TriangleSetTopologyModifier::SPtr triangleModifier;
+    sofa::component::topology::QuadSetTopologyModifier::SPtr quadModifier;
+    sofa::component::topology::TetrahedronSetTopologyModifier::SPtr tetraModifier;
+    sofa::component::topology::HexahedronSetTopologyModifier::SPtr hexaModifier;
 
     type::vector<Index> m_indicesToRemove;
 };

--- a/modules/SofaMiscTopology/src/SofaMiscTopology/TopologyBoundingTrasher.h
+++ b/modules/SofaMiscTopology/src/SofaMiscTopology/TopologyBoundingTrasher.h
@@ -72,7 +72,7 @@ protected:
     void filterElementsToRemove();
     void removeElements();
 
-    constexpr bool isPointOutside(const Coord& value, const Vec6& bb);
+    static constexpr bool isPointOutside(const Coord& value, const Vec6& bb);
 
 public:
     void init() override;

--- a/modules/SofaMiscTopology/src/SofaMiscTopology/TopologyBoundingTrasher.inl
+++ b/modules/SofaMiscTopology/src/SofaMiscTopology/TopologyBoundingTrasher.inl
@@ -269,7 +269,7 @@ void TopologyBoundingTrasher<DataTypes>::removeElements()
 
 
 template <class DataTypes>
-bool TopologyBoundingTrasher<DataTypes>::isPointOutside(const Coord& value, const Vec6& bb)
+constexpr bool TopologyBoundingTrasher<DataTypes>::isPointOutside(const Coord& value, const Vec6& bb)
 {
     if (value[0] < bb[0] || value[0] > bb[3]) // check x
         return true;

--- a/modules/SofaMiscTopology/src/SofaMiscTopology/TopologyBoundingTrasher.inl
+++ b/modules/SofaMiscTopology/src/SofaMiscTopology/TopologyBoundingTrasher.inl
@@ -1,0 +1,339 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <SofaMiscTopology/TopologyBoundingTrasher.h>
+#include <sofa/core/visual/VisualParams.h>
+#include <sofa/simulation/AnimateEndEvent.h>
+#include <sofa/helper/AdvancedTimer.h>
+
+#include <SofaBaseTopology/EdgeSetTopologyModifier.h>
+#include <SofaBaseTopology/TriangleSetTopologyModifier.h>
+#include <SofaBaseTopology/TetrahedronSetTopologyModifier.h>
+#include <SofaBaseTopology/QuadSetTopologyModifier.h>
+#include <SofaBaseTopology/HexahedronSetTopologyModifier.h>
+
+
+namespace sofa::component::misc
+{
+
+using namespace sofa::core::topology;
+
+template <class DataTypes>
+TopologyBoundingTrasher<DataTypes>::TopologyBoundingTrasher()
+    : d_positions(initData(&d_positions, "position", "position coordinates of the topology object to interact with."))
+    , d_borders(initData(&d_borders, Vec6(-1000, -1000, -1000, 1000, 1000, 1000), "box", "List of boxes defined by xmin,ymin,zmin, xmax,ymax,zmax"))
+    , m_drawBox(initData(&m_drawBox, false, "drawBox", "Draw Boxes. (default = false)"))
+    , l_topology(initLink("topology", "link to the topology container"))
+    , m_topology(nullptr)
+    , edgeModifier(nullptr)
+    , triangleModifier(nullptr)
+    , quadModifier(nullptr)
+    , tetraModifier(nullptr)
+    , hexaModifier(nullptr)
+{
+    f_listening.setValue(true);
+}
+
+template <class DataTypes>
+TopologyBoundingTrasher<DataTypes>::~TopologyBoundingTrasher()
+{
+
+}
+
+
+template <class DataTypes>
+void TopologyBoundingTrasher<DataTypes>::init()
+{
+    if (l_topology.empty())
+    {
+        msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
+        l_topology.set(this->getContext()->getMeshTopologyLink());
+    }
+
+    m_topology = l_topology.get();
+    msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
+
+    if (m_topology == nullptr)
+    {
+        msg_error() << "No topology component found at path: " << l_topology.getLinkedPath() << ", nor in current context: " << this->getContext()->name;
+        sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+        return;
+    }
+
+    
+    if (m_topology->getNbHexahedra() > 0)
+    {
+        m_topologyType = TopologyElementType::HEXAHEDRON;
+        this->getContext()->get(hexaModifier);
+        if (!hexaModifier)
+        {
+            msg_error() << "Hexahedron topology but no Modifier found. Add the component HexahedronSetTopologyModifier.";
+            m_topologyType = TopologyElementType::UNKNOWN;
+        }        
+    }
+    else if (m_topology->getNbTetrahedra() > 0)
+    {
+        m_topologyType = TopologyElementType::TETRAHEDRON;
+        this->getContext()->get(tetraModifier);
+        if (!tetraModifier)
+        {
+            msg_error() << "Tetrahedron topology but no modifier found. Add the component TetrahedronSetTopologyModifier.";
+            m_topologyType = TopologyElementType::UNKNOWN;
+        }        
+    }
+    else if (m_topology->getNbQuads() > 0)
+    {
+        m_topologyType = TopologyElementType::QUAD;
+        this->getContext()->get(quadModifier);
+        if (!quadModifier)
+        {
+            msg_error() << "Quad topology but no modifier found. Add the component QuadSetTopologyModifier.";
+            m_topologyType = TopologyElementType::UNKNOWN;
+        }        
+    }
+    else if (m_topology->getNbTriangles() > 0)
+    {
+        m_topologyType = TopologyElementType::TRIANGLE;
+        this->getContext()->get(triangleModifier);
+        if (!triangleModifier)
+        {
+            msg_error() << "Triangle topology but no modifier found. Add the component TriangleSetTopologyModifier.";
+            m_topologyType = TopologyElementType::UNKNOWN;
+        }        
+    }
+    else if (m_topology->getNbEdges() > 0)
+    {
+        m_topologyType = TopologyElementType::EDGE;
+        this->getContext()->get(edgeModifier);
+        if (!edgeModifier)
+        {
+            msg_error() << "Edge topology but no modifier found. Add the component EdgeSetTopologyModifier.";
+            m_topologyType = TopologyElementType::UNKNOWN;
+        }        
+    }
+
+    reinit();
+}
+
+
+template <class DataTypes>
+void TopologyBoundingTrasher<DataTypes>::reinit()
+{
+    const Vec6& border = d_borders.getValue();
+    Real minBBox[3] = { border[0], border[1], border[2] };
+    Real maxBBox[3] = { border[3], border[4], border[5] };
+    this->f_bbox.setValue(type::TBoundingBox<Real>(minBBox, maxBBox));
+}
+
+
+template <class DataTypes>
+void TopologyBoundingTrasher<DataTypes>::filterElementsToRemove()
+{
+    sofa::helper::AdvancedTimer::stepBegin("filterElementsToRemove");
+    const VecCoord& positions = d_positions.getValue();
+    const Vec6& border = d_borders.getValue();
+    m_indicesToRemove.clear();
+    int cpt = 0;
+    if (m_topologyType == TopologyElementType::HEXAHEDRON)
+    {
+        const BaseMeshTopology::SeqHexahedra& hexahedra = m_topology->getHexahedra();
+        for (auto& hexa : hexahedra)
+        {
+            Coord bary;
+            for (unsigned int i = 0; i < 8; i++)
+                bary += positions[hexa[i]];
+
+            bary /= 8;
+            if (isPointOutside(bary, border))
+                m_indicesToRemove.push_back(cpt);
+            
+            cpt++;
+        }
+    }
+    else if (m_topologyType == TopologyElementType::TETRAHEDRON)
+    {
+        const BaseMeshTopology::SeqTetrahedra& tetrahedra = m_topology->getTetrahedra();
+        for (auto& tetra : tetrahedra)
+        {
+            Coord bary;
+            for (unsigned int i = 0; i < 4; i++)
+                bary += positions[tetra[i]];
+
+            bary /= 4;
+            if (isPointOutside(bary, border))
+                m_indicesToRemove.push_back(cpt);
+
+            cpt++;
+        }
+    }
+    else if (m_topologyType == TopologyElementType::QUAD)
+    {
+        const BaseMeshTopology::SeqQuads& quads = m_topology->getQuads();
+        for (auto& quad : quads)
+        {
+            Coord bary;
+            for (unsigned int i = 0; i < 4; i++)
+                bary += positions[quad[i]];
+
+            bary /= 4;
+            if (isPointOutside(bary, border))
+                m_indicesToRemove.push_back(cpt);
+
+            cpt++;
+        }
+    }
+    else if (m_topologyType == TopologyElementType::TRIANGLE)
+    {
+        const BaseMeshTopology::SeqTriangles& triangles = m_topology->getTriangles();
+        for (auto& triangle : triangles)
+        {
+            Coord bary;
+            for (unsigned int i = 0; i < 3; i++)
+                bary += positions[triangle[i]];
+
+            bary /= 3;
+            if (isPointOutside(bary, border))
+                m_indicesToRemove.push_back(cpt);
+
+            cpt++;
+        }
+    }
+    else if (m_topologyType == TopologyElementType::EDGE)
+    {
+        const BaseMeshTopology::SeqEdges& edges = m_topology->getEdges();
+        for (auto& edge : edges)
+        {
+            Coord bary;
+            for (unsigned int i = 0; i < 2; i++)
+                bary += positions[edge[i]];
+
+            bary /= 2;
+            if (isPointOutside(bary, border))
+                m_indicesToRemove.push_back(cpt);
+
+            cpt++;
+        }
+    }
+   
+    if (!m_indicesToRemove.empty())
+        removeElements();
+
+    sofa::helper::AdvancedTimer::stepEnd("filterElementsToRemove");
+}
+
+
+template <class DataTypes>
+void TopologyBoundingTrasher<DataTypes>::removeElements()
+{
+    if (m_topologyType == TopologyElementType::HEXAHEDRON)
+    {
+        hexaModifier->removeHexahedra(m_indicesToRemove);
+    }
+    else if (m_topologyType == TopologyElementType::TETRAHEDRON)
+    {
+        tetraModifier->removeTetrahedra(m_indicesToRemove);
+    }
+    else if (m_topologyType == TopologyElementType::QUAD)
+    {
+        quadModifier->removeQuads(m_indicesToRemove, true, true);
+    }
+    else if (m_topologyType == TopologyElementType::TRIANGLE)
+    {
+        triangleModifier->removeTriangles(m_indicesToRemove, true, true);
+    }
+    else if (m_topologyType == TopologyElementType::EDGE)
+    {
+        edgeModifier->removeEdges(m_indicesToRemove);
+    }
+    m_indicesToRemove.clear();
+}
+
+
+template <class DataTypes>
+bool TopologyBoundingTrasher<DataTypes>::isPointOutside(const Coord& value, const Vec6& bb)
+{
+    if (value[0] < bb[0] || value[0] > bb[3]) // check x
+        return true;
+
+    if (value[1] < bb[1] || value[1] > bb[4]) // check y
+        return true;
+
+    if (value[2] < bb[2] || value[2] > bb[5]) // check z
+        return true;
+
+    return false;
+}
+
+
+template <class DataTypes>
+void TopologyBoundingTrasher<DataTypes>::handleEvent(sofa::core::objectmodel::Event* event)
+{
+    if (simulation::AnimateEndEvent::checkEventType(event))
+    {
+        filterElementsToRemove();
+    }
+}
+
+
+template <class DataTypes>
+void TopologyBoundingTrasher<DataTypes>::draw(const core::visual::VisualParams* vparams)
+{
+    if (m_drawBox.getValue())
+    {
+        const Vec6& border = d_borders.getValue();
+        auto color = sofa::type::RGBAColor(1.0f, 0.4f, 0.4f, 1.0f);
+        std::vector<Vector3> vertices;
+        const Real& Xmin = border[0];
+        const Real& Xmax = border[3];
+        const Real& Ymin = border[1];
+        const Real& Ymax = border[4];
+        const Real& Zmin = border[2];
+        const Real& Zmax = border[5];
+        vertices.push_back(Vector3(Xmin, Ymin, Zmin));
+        vertices.push_back(Vector3(Xmin, Ymin, Zmax));
+        vertices.push_back(Vector3(Xmin, Ymin, Zmin));
+        vertices.push_back(Vector3(Xmax, Ymin, Zmin));
+        vertices.push_back(Vector3(Xmin, Ymin, Zmin));
+        vertices.push_back(Vector3(Xmin, Ymax, Zmin));
+        vertices.push_back(Vector3(Xmin, Ymax, Zmin));
+        vertices.push_back(Vector3(Xmax, Ymax, Zmin));
+        vertices.push_back(Vector3(Xmin, Ymax, Zmin));
+        vertices.push_back(Vector3(Xmin, Ymax, Zmax));
+        vertices.push_back(Vector3(Xmin, Ymax, Zmax));
+        vertices.push_back(Vector3(Xmin, Ymin, Zmax));
+        vertices.push_back(Vector3(Xmin, Ymin, Zmax));
+        vertices.push_back(Vector3(Xmax, Ymin, Zmax));
+        vertices.push_back(Vector3(Xmax, Ymin, Zmax));
+        vertices.push_back(Vector3(Xmax, Ymax, Zmax));
+        vertices.push_back(Vector3(Xmax, Ymin, Zmax));
+        vertices.push_back(Vector3(Xmax, Ymin, Zmin));
+        vertices.push_back(Vector3(Xmin, Ymax, Zmax));
+        vertices.push_back(Vector3(Xmax, Ymax, Zmax));
+        vertices.push_back(Vector3(Xmax, Ymax, Zmin));
+        vertices.push_back(Vector3(Xmax, Ymin, Zmin));
+        vertices.push_back(Vector3(Xmax, Ymax, Zmin));
+        vertices.push_back(Vector3(Xmax, Ymax, Zmax));
+        vparams->drawTool()->drawLines(vertices, 1.0, color);
+    }
+}
+
+} // namespace sofa::component::misc

--- a/modules/SofaMiscTopology/src/SofaMiscTopology/TopologyBoundingTrasher.inl
+++ b/modules/SofaMiscTopology/src/SofaMiscTopology/TopologyBoundingTrasher.inl
@@ -41,7 +41,7 @@ template <class DataTypes>
 TopologyBoundingTrasher<DataTypes>::TopologyBoundingTrasher()
     : d_positions(initData(&d_positions, "position", "position coordinates of the topology object to interact with."))
     , d_borders(initData(&d_borders, Vec6(-1000, -1000, -1000, 1000, 1000, 1000), "box", "List of boxes defined by xmin,ymin,zmin, xmax,ymax,zmax"))
-    , m_drawBox(initData(&m_drawBox, false, "drawBox", "Draw Boxes. (default = false)"))
+    , d_drawBox(initData(&d_drawBox, false, "drawBox", "Draw Boxes. (default = false)"))
     , l_topology(initLink("topology", "link to the topology container"))
     , m_topology(nullptr)
     , edgeModifier(nullptr)
@@ -297,7 +297,7 @@ void TopologyBoundingTrasher<DataTypes>::handleEvent(sofa::core::objectmodel::Ev
 template <class DataTypes>
 void TopologyBoundingTrasher<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
-    if (m_drawBox.getValue())
+    if (d_drawBox.getValue())
     {
         const Vec6& border = d_borders.getValue();
         auto color = sofa::type::RGBAColor(1.0f, 0.4f, 0.4f, 1.0f);


### PR DESCRIPTION
Given a link to the topology, link to the corresponding mechanicalObject and a boundingBox. The component will remove all elements (topology and dofs) going outside from this boundingbox.

**-> Any better name suggestion is welcomed.
-> if this component is not useful in SOFA, abort the PR. otherwise I will add more comments in the header.**

Example of use:
```
        <MechanicalObject src="@../grid_1" name="Volume" />
        <TetrahedronSetTopologyContainer name="Tetra_con" src="@../Beam_generator_01/Container"/>
        <TetrahedronSetTopologyModifier name="Modifier" />
        <TetrahedronSetGeometryAlgorithms name="GeomAlgo" template="Vec3d" drawTetrahedra="1" drawScaleTetrahedra="0.8"/>
     
        <TopologyBoundingTrasher box="-40 -40 -50 50 50 50" topology="@Tetra_con" drawBox="1" position="@Volume.position"/>
```

Video of the result of a tissue falling in 3D:
**Right now in SOFA:**
![ezgif com-gif-maker(1)](https://user-images.githubusercontent.com/21199245/129875985-79e1c469-46ae-459a-a6af-306be7effdf2.gif)


**Using the trasher!**
![ezgif com-gif-maker](https://user-images.githubusercontent.com/21199245/129875812-e2e6af18-bde2-4d76-89ac-3d4369bdc184.gif)




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
