### PR TITLE
[Sofa.BaseTopology] Remove 1D template for 2D/3D primitives in topology algorithms

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/HexahedronSetGeometryAlgorithms.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/HexahedronSetGeometryAlgorithms.cpp
@@ -31,13 +31,11 @@ using namespace sofa::defaulttype;
 int HexahedronSetGeometryAlgorithmsClass = core::RegisterObject("Hexahedron set geometry algorithms")
         .add< HexahedronSetGeometryAlgorithms<Vec3Types> >(true) // default template
         .add< HexahedronSetGeometryAlgorithms<Vec2Types> >()
-        .add< HexahedronSetGeometryAlgorithms<Vec1Types> >()
 
         ;
 
 template class SOFA_SOFABASETOPOLOGY_API HexahedronSetGeometryAlgorithms<Vec3Types>;
 template class SOFA_SOFABASETOPOLOGY_API HexahedronSetGeometryAlgorithms<Vec2Types>;
-template class SOFA_SOFABASETOPOLOGY_API HexahedronSetGeometryAlgorithms<Vec1Types>;
 
 
 } //namespace sofa::component::topology

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/HexahedronSetGeometryAlgorithms.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/HexahedronSetGeometryAlgorithms.h
@@ -163,11 +163,6 @@ protected:
 #if  !defined(SOFA_COMPONENT_TOPOLOGY_HEXAHEDRONSETGEOMETRYALGORITHMS_CPP)
 extern template class SOFA_SOFABASETOPOLOGY_API HexahedronSetGeometryAlgorithms<defaulttype::Vec3Types>;
 extern template class SOFA_SOFABASETOPOLOGY_API HexahedronSetGeometryAlgorithms<defaulttype::Vec2Types>;
-extern template class SOFA_SOFABASETOPOLOGY_API HexahedronSetGeometryAlgorithms<defaulttype::Vec1Types>;
-//extern template class SOFA_SOFABASETOPOLOGY_API HexahedronSetGeometryAlgorithms<defaulttype::Rigid3Types>;
-//extern template class SOFA_SOFABASETOPOLOGY_API HexahedronSetGeometryAlgorithms<defaulttype::Rigid2Types>;
-
-
 #endif
 
 } //namespace sofa::component::topology

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/QuadSetGeometryAlgorithms.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/QuadSetGeometryAlgorithms.cpp
@@ -32,13 +32,11 @@ using namespace sofa::defaulttype;
 int QuadSetGeometryAlgorithmsClass = core::RegisterObject("Quad set geometry algorithms")
         .add< QuadSetGeometryAlgorithms<Vec3Types> >(true) // default template
         .add< QuadSetGeometryAlgorithms<Vec2Types> >()
-        .add< QuadSetGeometryAlgorithms<Vec1Types> >()
 
         ;
 
 template class SOFA_SOFABASETOPOLOGY_API QuadSetGeometryAlgorithms<Vec3Types>;
 template class SOFA_SOFABASETOPOLOGY_API QuadSetGeometryAlgorithms<Vec2Types>;
-template class SOFA_SOFABASETOPOLOGY_API QuadSetGeometryAlgorithms<Vec1Types>;
 
 
 } //namespace sofa::component::topology

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/QuadSetGeometryAlgorithms.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/QuadSetGeometryAlgorithms.h
@@ -132,7 +132,6 @@ inline Real areaProduct(const type::Vec<1,Real>& , const type::Vec<1,Real>&  );
 #if  !defined(SOFA_COMPONENT_TOPOLOGY_QUADSETGEOMETRYALGORITHMS_CPP)
 extern template class SOFA_SOFABASETOPOLOGY_API QuadSetGeometryAlgorithms<defaulttype::Vec3Types>;
 extern template class SOFA_SOFABASETOPOLOGY_API QuadSetGeometryAlgorithms<defaulttype::Vec2Types>;
-extern template class SOFA_SOFABASETOPOLOGY_API QuadSetGeometryAlgorithms<defaulttype::Vec1Types>;
 
 #endif
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetGeometryAlgorithms.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetGeometryAlgorithms.cpp
@@ -31,13 +31,11 @@ using namespace sofa::defaulttype;
 int TetrahedronSetGeometryAlgorithmsClass = core::RegisterObject("Tetrahedron set geometry algorithms")
         .add< TetrahedronSetGeometryAlgorithms<Vec3dTypes> >(true) // default template
         .add< TetrahedronSetGeometryAlgorithms<Vec2Types> >()
-        .add< TetrahedronSetGeometryAlgorithms<Vec1Types> >()
 
         ;
 
 template class SOFA_SOFABASETOPOLOGY_API TetrahedronSetGeometryAlgorithms<Vec3Types>;
 template class SOFA_SOFABASETOPOLOGY_API TetrahedronSetGeometryAlgorithms<Vec2Types>;
-template class SOFA_SOFABASETOPOLOGY_API TetrahedronSetGeometryAlgorithms<Vec1Types>;
 
 
 } //namespace sofa::component::topology

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetGeometryAlgorithms.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetGeometryAlgorithms.h
@@ -186,7 +186,6 @@ protected:
 #if !defined(SOFA_COMPONENT_TOPOLOGY_TETRAHEDRONSETGEOMETRYALGORITHMS_CPP)
 extern template class SOFA_SOFABASETOPOLOGY_API TetrahedronSetGeometryAlgorithms<defaulttype::Vec3Types>;
 extern template class SOFA_SOFABASETOPOLOGY_API TetrahedronSetGeometryAlgorithms<defaulttype::Vec2Types>;
-extern template class SOFA_SOFABASETOPOLOGY_API TetrahedronSetGeometryAlgorithms<defaulttype::Vec1Types>;
 #endif
 
 } //namespace sofa::component::topology

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetGeometryAlgorithms.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetGeometryAlgorithms.cpp
@@ -32,7 +32,6 @@ using namespace sofa::defaulttype;
 int TriangleSetGeometryAlgorithmsClass = core::RegisterObject("Triangle set geometry algorithms")
         .add< TriangleSetGeometryAlgorithms<Vec3dTypes> >(true) // default template
         .add< TriangleSetGeometryAlgorithms<Vec2Types> >()
-        .add< TriangleSetGeometryAlgorithms<Vec1Types> >()
         ;
 
 
@@ -55,8 +54,6 @@ int TriangleSetGeometryAlgorithms<defaulttype::Vec1Types>::SplitAlongPath(PointI
 
 template class SOFA_SOFABASETOPOLOGY_API TriangleSetGeometryAlgorithms<Vec3Types>;
 template class SOFA_SOFABASETOPOLOGY_API TriangleSetGeometryAlgorithms<Vec2Types>;
-template class SOFA_SOFABASETOPOLOGY_API TriangleSetGeometryAlgorithms<Vec1Types>;
-
 
 
 template<>

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetGeometryAlgorithms.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetGeometryAlgorithms.h
@@ -411,11 +411,6 @@ inline Real areaProduct(const type::Vec<1,Real>& , const type::Vec<1,Real>&  );
 #if  !defined(SOFA_COMPONENT_TOPOLOGY_TRIANGLESETGEOMETRYALGORITHMS_CPP)
 extern template class SOFA_SOFABASETOPOLOGY_API TriangleSetGeometryAlgorithms<defaulttype::Vec3Types>;
 extern template class SOFA_SOFABASETOPOLOGY_API TriangleSetGeometryAlgorithms<defaulttype::Vec2Types>;
-extern template class SOFA_SOFABASETOPOLOGY_API TriangleSetGeometryAlgorithms<defaulttype::Vec1Types>;
-//extern template class SOFA_SOFABASETOPOLOGY_API TriangleSetGeometryAlgorithms<defaulttype::Rigid3Types>;
-//extern template class SOFA_SOFABASETOPOLOGY_API TriangleSetGeometryAlgorithms<defaulttype::Rigid2Types>;
-
-
 #endif
 
 } //namespace sofa::component::topology

--- a/applications/plugins/ManifoldTopologies/ManifoldTriangleSetGeometryAlgorithms.cpp
+++ b/applications/plugins/ManifoldTopologies/ManifoldTriangleSetGeometryAlgorithms.cpp
@@ -37,12 +37,10 @@ using namespace sofa::defaulttype;
 int ManifoldTriangleSetGeometryAlgorithmsClass = core::RegisterObject("ManifoldTriangle set topology algorithms")
         .add< ManifoldTriangleSetGeometryAlgorithms<Vec3Types> >(true) // default template
         .add< ManifoldTriangleSetGeometryAlgorithms<Vec2Types> >()
-        .add< ManifoldTriangleSetGeometryAlgorithms<Vec1Types> >()
         ;
 
 template class SOFA_MANIFOLD_TOPOLOGIES_API ManifoldTriangleSetGeometryAlgorithms<Vec3Types>;
 template class SOFA_MANIFOLD_TOPOLOGIES_API ManifoldTriangleSetGeometryAlgorithms<Vec2Types>;
-template class SOFA_MANIFOLD_TOPOLOGIES_API ManifoldTriangleSetGeometryAlgorithms<Vec1Types>;
 
 } // namespace topology
 

--- a/applications/plugins/ManifoldTopologies/ManifoldTriangleSetGeometryAlgorithms.h
+++ b/applications/plugins/ManifoldTopologies/ManifoldTriangleSetGeometryAlgorithms.h
@@ -134,7 +134,6 @@ private:
 #if  !defined(SOFA_MANIFOLD_TOPOLOGY_TRIANGLESETTOPOLOGYALGORITHMS_CPP)
 extern template class SOFA_MANIFOLD_TOPOLOGIES_API ManifoldTriangleSetGeometryAlgorithms<sofa::defaulttype::Vec3Types>;
 extern template class SOFA_MANIFOLD_TOPOLOGIES_API ManifoldTriangleSetGeometryAlgorithms<sofa::defaulttype::Vec2Types>;
-extern template class SOFA_MANIFOLD_TOPOLOGIES_API ManifoldTriangleSetGeometryAlgorithms<sofa::defaulttype::Vec1Types>;
 #endif
 
 } // namespace topology

--- a/modules/SofaNonUniformFem/src/SofaNonUniformFem/DynamicSparseGridGeometryAlgorithms.cpp
+++ b/modules/SofaNonUniformFem/src/SofaNonUniformFem/DynamicSparseGridGeometryAlgorithms.cpp
@@ -31,7 +31,6 @@ using namespace sofa::defaulttype;
 int DynamicSparseGridGeometryAlgorithmsClass = core::RegisterObject ( "Hexahedron set geometry algorithms" )
         .add< DynamicSparseGridGeometryAlgorithms<Vec3Types> > ( true ) // default template
         .add< DynamicSparseGridGeometryAlgorithms<Vec2Types> >()
-        .add< DynamicSparseGridGeometryAlgorithms<Vec1Types> >()
 
         ;
 
@@ -41,15 +40,8 @@ int DynamicSparseGridGeometryAlgorithms<Vec2Types>::findNearestElementInRestPos(
     return HexahedronSetGeometryAlgorithms<Vec2Types>::findNearestElementInRestPos(pos, baryC, distance);
 }
 
-template <>
-int DynamicSparseGridGeometryAlgorithms<Vec1Types>::findNearestElementInRestPos(const Coord& pos, sofa::type::Vector3& baryC, Real& distance) const
-{
-    return HexahedronSetGeometryAlgorithms<Vec1Types>::findNearestElementInRestPos(pos, baryC, distance);
-}
-
 template class SOFA_SOFANONUNIFORMFEM_API DynamicSparseGridGeometryAlgorithms<Vec3Types>;
 template class SOFA_SOFANONUNIFORMFEM_API DynamicSparseGridGeometryAlgorithms<Vec2Types>;
-template class SOFA_SOFANONUNIFORMFEM_API DynamicSparseGridGeometryAlgorithms<Vec1Types>;
 
 
 } // namespace sofa::component::topology

--- a/modules/SofaNonUniformFem/src/SofaNonUniformFem/DynamicSparseGridGeometryAlgorithms.h
+++ b/modules/SofaNonUniformFem/src/SofaNonUniformFem/DynamicSparseGridGeometryAlgorithms.h
@@ -77,8 +77,6 @@ int SOFA_SOFANONUNIFORMFEM_API DynamicSparseGridGeometryAlgorithms<defaulttype::
 #if  !defined(SOFA_COMPONENT_TOPOLOGY_DYNAMICSPARSEGRIDGEOMETRYALGORITHMS_CPP)
 extern template class SOFA_SOFANONUNIFORMFEM_API DynamicSparseGridGeometryAlgorithms<defaulttype::Vec3Types>;
 extern template class SOFA_SOFANONUNIFORMFEM_API DynamicSparseGridGeometryAlgorithms<defaulttype::Vec2Types>;
-extern template class SOFA_SOFANONUNIFORMFEM_API DynamicSparseGridGeometryAlgorithms<defaulttype::Vec1Types>;
-
 #endif
 
 } // namespace sofa::component::topology


### PR DESCRIPTION
Because it does not make sense to me to use tetra algos in 1D for example 🤥

Maybe should we remove the 2D template for 3D primitives as well ?
I was considering tetra/hexa could be projected in 2D but it seems a bit far streched to me.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
