### PR TITLE
[Sofa.Core] Deprecate officially the usage of SofaOStream (sout, serr, sendl in Base)

### DIFF
--- a/SofaKernel/modules/Sofa.Config/src/sofa/config.h.in
+++ b/SofaKernel/modules/Sofa.Config/src/sofa/config.h.in
@@ -315,6 +315,11 @@ class DeprecatedAndRemoved {};
         "v21.06 (PR#1808)", "v21.12", \
         "replace std::cout << myaccessor by std::cout << myaccessor.ref() ")
 
+#define SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM() \
+    SOFA_ATTRIBUTE_DEPRECATED( \
+        "v21.12 (PR#XXXX)", "v22.06", \
+        "Use the Messaging API instead of using SofaOStream and sout/serr/sendl.")
+
 /**********************************************/
 
 #define SOFA_DECL_CLASS(name) // extern "C" { int sofa_concat(class_,name) = 0; }

--- a/SofaKernel/modules/Sofa.Config/src/sofa/config.h.in
+++ b/SofaKernel/modules/Sofa.Config/src/sofa/config.h.in
@@ -317,7 +317,7 @@ class DeprecatedAndRemoved {};
 
 #define SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM() \
     SOFA_ATTRIBUTE_DEPRECATED( \
-        "v21.12 (PR#XXXX)", "v22.06", \
+        "v21.12 (PR#2292)", "v22.06", \
         "Use the Messaging API instead of using SofaOStream and sout/serr/sendl.")
 
 /**********************************************/

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BVHNarrowPhase.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BVHNarrowPhase.cpp
@@ -151,7 +151,7 @@ void BVHNarrowPhase::processExternalCell(const TestPair &externalCell,
 
         if (coarseIntersector == nullptr)
         {
-            msg_error() << "Error finding coarseIntersector " << intersectionMethod->getName() << " for "<<cm1->getClassName()<<" - "<<cm2->getClassName()<<sendl;
+            msg_error() << "Error finding coarseIntersector " << intersectionMethod->getName() << " for "<<cm1->getClassName()<<" - "<<cm2->getClassName();
         }
 
         if (swapModels)

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BVHNarrowPhase.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BVHNarrowPhase.cpp
@@ -151,7 +151,7 @@ void BVHNarrowPhase::processExternalCell(const TestPair &externalCell,
 
         if (coarseIntersector == nullptr)
         {
-            msg_error() << "Error finding coarseIntersector " << intersectionMethod->getName() << " for "<<cm1->getClassName()<<" - "<<cm2->getClassName();
+            msg_error() << "Unable to find coarseIntersector " << intersectionMethod->getName() << " for "<<cm1->getClassName()<<" - "<<cm2->getClassName();
         }
 
         if (swapModels)

--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
@@ -2002,7 +2002,7 @@ void VisualModelImpl::exportOBJ(std::string name, std::ostream* out, std::ostrea
         }
         *out << '\n';
     }
-    *out << sendl;
+    *out << '\n';
     vindex+=nbv;
     nindex+=nbn;
     tindex+=nbt;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -370,13 +370,13 @@ private:
 public:
     /// write into component buffer + Message processedby message handlers
     /// default message type = Warning
-    /*SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()*/ helper::system::SofaOStream<helper::logging::Message::Warning> serr;
+    /*SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()*/ mutable helper::system::SofaOStream<helper::logging::Message::Warning> serr;
     /// write into component buffer.
     /// Message is processed by message handlers only if printLog==true
     /// /// default message type = Info
-    /*SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()*/ helper::system::SofaOStream<helper::logging::Message::Info> sout;
+    /*SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()*/ mutable helper::system::SofaOStream<helper::logging::Message::Info> sout;
     /// runs the stream processing
-    /*SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()*/ helper::system::SofaEndl<Base> sendl;
+    /*SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()*/ mutable helper::system::SofaEndl<Base> sendl;
 
     void processStream(std::ostream& out);
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -37,6 +37,8 @@
 #include <sofa/core/objectmodel/ComponentState.h>
 #include <sofa/core/DataTracker.h>
 
+#include <sofa/helper/system/SofaOStream.h>
+
 // forward declaration of castable classes
 // @author Matthieu Nesme, 2015
 // it is not super elegant, but it is way more efficient than dynamic_cast
@@ -368,13 +370,13 @@ private:
 public:
     /// write into component buffer + Message processedby message handlers
     /// default message type = Warning
-    mutable helper::system::SofaOStream<helper::logging::Message::Warning> serr;
+    /*SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()*/ helper::system::SofaOStream<helper::logging::Message::Warning> serr;
     /// write into component buffer.
     /// Message is processed by message handlers only if printLog==true
     /// /// default message type = Info
-    mutable helper::system::SofaOStream<helper::logging::Message::Info> sout;
+    /*SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()*/ helper::system::SofaOStream<helper::logging::Message::Info> sout;
     /// runs the stream processing
-    mutable helper::system::SofaEndl<Base> sendl;
+    /*SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()*/ helper::system::SofaEndl<Base> sendl;
 
     void processStream(std::ostream& out);
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataFileName.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataFileName.cpp
@@ -71,7 +71,10 @@ void DataFileName::updatePath()
         // Update the fullpath.
         std::string fullpath = m_value.getValue();
         if (!fullpath.empty())
-            DataRepository.findFile(fullpath,"", &std::cerr);
+        {
+            std::ostringstream tempOss;
+            DataRepository.findFile(fullpath, "", &tempOss);
+        }
 
         if (getPathType() != PathType::BOTH && (fs::FileSystem::exists(fullpath) && ((getPathType() == PathType::DIRECTORY) != fs::FileSystem::isDirectory(fullpath))))
         {
@@ -124,7 +127,8 @@ void DataFileNameVector::updatePath()
             }
             else
             {
-                DataRepository.findFile(m_fullpath[i],"",&std::cerr);
+                std::ostringstream tempOss;
+                DataRepository.findFile(m_fullpath[i], "", &tempOss);
                 if (getPathType() != PathType::BOTH && (fs::FileSystem::exists(m_fullpath[i]) && ((getPathType() == PathType::DIRECTORY) != fs::FileSystem::isDirectory(m_fullpath[i]))))
                 {
                     msg_error(this->getName()) << "This DataFileName only accepts " << (getPathType() == PathType::DIRECTORY ? "directories" : "files");

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataFileName.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DataFileName.cpp
@@ -71,7 +71,7 @@ void DataFileName::updatePath()
         // Update the fullpath.
         std::string fullpath = m_value.getValue();
         if (!fullpath.empty())
-            DataRepository.findFile(fullpath,"",(this->m_owner ? &(this->m_owner->serr.ostringstream()) : &std::cerr));
+            DataRepository.findFile(fullpath,"", &std::cerr);
 
         if (getPathType() != PathType::BOTH && (fs::FileSystem::exists(fullpath) && ((getPathType() == PathType::DIRECTORY) != fs::FileSystem::isDirectory(fullpath))))
         {
@@ -124,7 +124,7 @@ void DataFileNameVector::updatePath()
             }
             else
             {
-                helper::system::DataRepository.findFile(m_fullpath[i],"",(this->m_owner ? &(this->m_owner->serr.ostringstream()) : &std::cerr));
+                DataRepository.findFile(m_fullpath[i],"",&std::cerr);
                 if (getPathType() != PathType::BOTH && (fs::FileSystem::exists(m_fullpath[i]) && ((getPathType() == PathType::DIRECTORY) != fs::FileSystem::isDirectory(m_fullpath[i]))))
                 {
                     msg_error(this->getName()) << "This DataFileName only accepts " << (getPathType() == PathType::DIRECTORY ? "directories" : "files");

--- a/SofaKernel/modules/SofaDeformable/src/SofaDeformable/PolynomialRestShapeSpringsForceField.h
+++ b/SofaKernel/modules/SofaDeformable/src/SofaDeformable/PolynomialRestShapeSpringsForceField.h
@@ -132,7 +132,7 @@ public:
 
     virtual SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord& /* x */) const override
     {
-        serr << "Get potentialEnergy not implemented" << sendl;
+        msg_error() << "Get potentialEnergy not implemented";
         return 0.0;
     }
 

--- a/SofaKernel/modules/SofaEigen2Solver/src/SofaEigen2Solver/SVDLinearSolver.cpp
+++ b/SofaKernel/modules/SofaEigen2Solver/src/SofaEigen2Solver/SVDLinearSolver.cpp
@@ -77,13 +77,13 @@ void SVDLinearSolver<TMatrix,TVector>::solve(Matrix& M, Vector& x, Vector& b)
 
     if(verbose)
     {
-        msg_info() << "solve, the singular values are:" << sendl << svd.singularValues()  << msgendl
+        msg_info() << "solve, the singular values are:" << msgendl << svd.singularValues()  << msgendl
                    << "Its left singular vectors are the columns of the thin U matrix: " << msgendl
                    << svd.matrixU() << msgendl
                    << "Its right singular vectors are the columns of the thin V matrix:" msgendl
                    << svd.matrixV() ;
     }else{
-        msg_info() << "solve, the singular values are:" << sendl << svd.singularValues()  << msgendl;
+        msg_info() << "solve, the singular values are:" << msgendl << svd.singularValues()  << msgendl;
     }
 
     /// Solve the equation system and copy the solution to the SOFA vector

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/SofaOStream.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/SofaOStream.h
@@ -26,7 +26,7 @@
 #include <sstream>
 #include <sofa/helper/logging/Message.h>
 
-// SOFA_DEPRECATED_HEADER_NOT_REPLACED("v21.12 (PR#XXXX)", "v22.06")
+// SOFA_DEPRECATED_HEADER_NOT_REPLACED("v21.12 (PR#2292)", "v22.06")
 
 // The methods in SofaOStream have been deprecated, but we still want it to work.
 // Its usage in Base.h would generate warnings.
@@ -38,10 +38,10 @@
 // (and does not choke when using the msvc keyword __declspec(deprecated("xxx"))
 
 #ifndef SOFA_BUILD_SOFA_CORE
-#if defined(_MSC_VER) && (_MSC_VER < 1920) // if less than VS 2017
+#if defined(_MSC_VER) && (_MSC_VER < 1920) // if less than VS 2019
 #define SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM() \
     __declspec(deprecated(\
-        "It is still usable but has been DEPRECATED since v21.12 (PR#XXXX). " \
+        "It is still usable but has been DEPRECATED since v21.12 (PR#2292). " \
         "You have until v22.06 to fix your code. " \
         "Use the Messaging API instead of using SofaOStream and sout/serr/sendl."))
 #else // _MSC_VER

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/SofaOStream.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/SofaOStream.h
@@ -26,6 +26,8 @@
 #include <sstream>
 #include <sofa/helper/logging/Message.h>
 
+// SOFA_DEPRECATED_HEADER_NOT_REPLACED("v21.12 (PR#XXXX)", "v22.06")
+
 namespace sofa
 {
 
@@ -47,6 +49,7 @@ protected:
 
 public:
 
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     friend inline std::ostream &operator << (std::ostream& out, const SofaEndl<Container> & s)
     {
         if (s.parent)
@@ -60,6 +63,7 @@ public:
     {
     }
 
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     void setParent(Container* p)
     {
         parent = p;
@@ -79,21 +83,22 @@ public:
     SofaOStream(std::ostringstream& os) : m_ostream(os), m_messageType((logging::Message::Type)DefaultMessageType) {}
 
     bool operator==(const std::ostream& os) { return &os == &m_ostream; }
-
-    // operator std::ostream&() const { return m_ostream; }
-
+    
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     friend inline SofaOStream& operator<<( SofaOStream& out, const logging::FileInfo::SPtr& fi )
     {
         out.m_fileInfo = fi;
         return out;
     }
 
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     friend inline SofaOStream& operator<<( SofaOStream& out, const logging::Message::Type& mt )
     {
         out.m_messageType = mt;
         return out;
     }
 
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     friend inline SofaOStream& operator<<( SofaOStream& out, const logging::Message::Class& mc )
     {
         out.m_messageClass = mc;
@@ -101,6 +106,7 @@ public:
     }
 
     template<class T>
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     friend inline std::ostringstream& operator<<( SofaOStream& out, const T& t )
     {
         out.m_ostream << t;
@@ -108,17 +114,32 @@ public:
     }
 
     // a few useful functions on ostringstream, for a complete API, convert this in a ostringstream
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     std::string str() const { return m_ostream.str(); }
+
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     void str(const std::string& s) { m_ostream.str(s); }
+
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     std::streamsize precision() const { return m_ostream.precision(); }
+
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     std::streamsize precision( std::streamsize p ) { return m_ostream.precision(p); }
 
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     std::ostringstream& ostringstream() const { return m_ostream; }
+
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     const logging::FileInfo::SPtr& fileInfo() const { return m_fileInfo; }
+
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     const logging::Message::Type& messageType() const { return m_messageType; }
+
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     const logging::Message::Class& messageClass() const { return m_messageClass; }
 
     /// clearing the SofaOStream (set empty string, empty FileInfo, default Message type)
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     void clear()
     {
         str("");

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/SofaOStream.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/SofaOStream.h
@@ -28,6 +28,11 @@
 
 // SOFA_DEPRECATED_HEADER_NOT_REPLACED("v21.12 (PR#XXXX)", "v22.06")
 
+// The methods in SofaOStream have been deprecated, but we still want it to work.
+// Its usage in Base.h would generate warnings.
+// That is why the deprecation is set between SOFA_BUILD_SOFA_CORE macro, to disable the warnings only when building Sofa.Core.
+// Warning messages will appear when used outside of Sofa.Core (logically in the components)
+
 namespace sofa
 {
 
@@ -49,7 +54,9 @@ protected:
 
 public:
 
+#ifndef SOFA_BUILD_SOFA_CORE
     SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+#endif // SOFA_BUILD_SOFA_CORE
     friend inline std::ostream &operator << (std::ostream& out, const SofaEndl<Container> & s)
     {
         if (s.parent)
@@ -63,7 +70,9 @@ public:
     {
     }
 
+#ifndef SOFA_BUILD_SOFA_CORE
     SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+#endif // SOFA_BUILD_SOFA_CORE
     void setParent(Container* p)
     {
         parent = p;
@@ -84,21 +93,27 @@ public:
 
     bool operator==(const std::ostream& os) { return &os == &m_ostream; }
     
+#ifndef SOFA_BUILD_SOFA_CORE
     SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+#endif // SOFA_BUILD_SOFA_CORE
     friend inline SofaOStream& operator<<( SofaOStream& out, const logging::FileInfo::SPtr& fi )
     {
         out.m_fileInfo = fi;
         return out;
     }
 
+#ifndef SOFA_BUILD_SOFA_CORE
     SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+#endif // SOFA_BUILD_SOFA_CORE
     friend inline SofaOStream& operator<<( SofaOStream& out, const logging::Message::Type& mt )
     {
         out.m_messageType = mt;
         return out;
     }
 
+#ifndef SOFA_BUILD_SOFA_CORE
     SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+#endif // SOFA_BUILD_SOFA_CORE
     friend inline SofaOStream& operator<<( SofaOStream& out, const logging::Message::Class& mc )
     {
         out.m_messageClass = mc;
@@ -106,7 +121,9 @@ public:
     }
 
     template<class T>
+#ifndef SOFA_BUILD_SOFA_CORE
     SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+#endif // SOFA_BUILD_SOFA_CORE
     friend inline std::ostringstream& operator<<( SofaOStream& out, const T& t )
     {
         out.m_ostream << t;
@@ -114,32 +131,50 @@ public:
     }
 
     // a few useful functions on ostringstream, for a complete API, convert this in a ostringstream
+#ifndef SOFA_BUILD_SOFA_CORE
     SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+#endif // SOFA_BUILD_SOFA_CORE
     std::string str() const { return m_ostream.str(); }
 
+#ifndef SOFA_BUILD_SOFA_CORE
     SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+#endif // SOFA_BUILD_SOFA_CORE
     void str(const std::string& s) { m_ostream.str(s); }
 
+#ifndef SOFA_BUILD_SOFA_CORE
     SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+#endif // SOFA_BUILD_SOFA_CORE
     std::streamsize precision() const { return m_ostream.precision(); }
 
+#ifndef SOFA_BUILD_SOFA_CORE
     SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+#endif // SOFA_BUILD_SOFA_CORE
     std::streamsize precision( std::streamsize p ) { return m_ostream.precision(p); }
 
+#ifndef SOFA_BUILD_SOFA_CORE
     SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+#endif // SOFA_BUILD_SOFA_CORE
     std::ostringstream& ostringstream() const { return m_ostream; }
 
+#ifndef SOFA_BUILD_SOFA_CORE
     SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+#endif // SOFA_BUILD_SOFA_CORE
     const logging::FileInfo::SPtr& fileInfo() const { return m_fileInfo; }
 
+#ifndef SOFA_BUILD_SOFA_CORE
     SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+#endif // SOFA_BUILD_SOFA_CORE
     const logging::Message::Type& messageType() const { return m_messageType; }
 
+#ifndef SOFA_BUILD_SOFA_CORE
     SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+#endif // SOFA_BUILD_SOFA_CORE
     const logging::Message::Class& messageClass() const { return m_messageClass; }
 
     /// clearing the SofaOStream (set empty string, empty FileInfo, default Message type)
+#ifndef SOFA_BUILD_SOFA_CORE
     SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+#endif // SOFA_BUILD_SOFA_CORE
     void clear()
     {
         str("");

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/SofaOStream.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/SofaOStream.h
@@ -39,17 +39,17 @@
 
 #ifndef SOFA_BUILD_SOFA_CORE
 #if defined(_MSC_VER) && (_MSC_VER < 1920) // if less than VS 2019
-#define SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM() \
+#define SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM__OVERRIDE() \
     __declspec(deprecated(\
         "It is still usable but has been DEPRECATED since v21.12 (PR#2292). " \
         "You have until v22.06 to fix your code. " \
         "Use the Messaging API instead of using SofaOStream and sout/serr/sendl."))
 #else // _MSC_VER
-#define SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM() \
+#define SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM__OVERRIDE() \
         SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
 #endif // _MSC_VER
 #else // SOFA_BUILD_SOFA_CORE
-#define SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM() // dont do anything if we are building Sofa.Core
+#define SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM__OVERRIDE() // dont do anything if we are building Sofa.Core
 #endif // SOFA_BUILD_SOFA_CORE
         
 namespace sofa
@@ -73,7 +73,7 @@ protected:
 
 public:
 
-    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM__OVERRIDE()
     friend inline
     std::ostream &operator << (std::ostream& out, const SofaEndl<Container> & s)
     {
@@ -88,7 +88,7 @@ public:
     {
     }
 
-    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM__OVERRIDE()
     void setParent(Container* p)
     {
         parent = p;
@@ -109,21 +109,21 @@ public:
 
     bool operator==(const std::ostream& os) { return &os == &m_ostream; }
     
-    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM__OVERRIDE()
     friend inline SofaOStream& operator<<( SofaOStream& out, const logging::FileInfo::SPtr& fi )
     {
         out.m_fileInfo = fi;
         return out;
     }
 
-    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM__OVERRIDE()
     friend inline SofaOStream& operator<<( SofaOStream& out, const logging::Message::Type& mt )
     {
         out.m_messageType = mt;
         return out;
     }
 
-    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM__OVERRIDE()
     friend inline SofaOStream& operator<<( SofaOStream& out, const logging::Message::Class& mc )
     {
         out.m_messageClass = mc;
@@ -131,7 +131,7 @@ public:
     }
 
     template<class T>
-    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM__OVERRIDE()
     friend inline std::ostringstream& operator<<( SofaOStream& out, const T& t )
     {
         out.m_ostream << t;
@@ -139,32 +139,32 @@ public:
     }
 
     // a few useful functions on ostringstream, for a complete API, convert this in a ostringstream
-    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM__OVERRIDE()
     std::string str() const { return m_ostream.str(); }
 
-    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM__OVERRIDE()
     void str(const std::string& s) { m_ostream.str(s); }
 
-    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM__OVERRIDE()
     std::streamsize precision() const { return m_ostream.precision(); }
 
-    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM__OVERRIDE()
     std::streamsize precision( std::streamsize p ) { return m_ostream.precision(p); }
 
-    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM__OVERRIDE()
     std::ostringstream& ostringstream() const { return m_ostream; }
 
-    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM__OVERRIDE()
     const logging::FileInfo::SPtr& fileInfo() const { return m_fileInfo; }
 
-    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM__OVERRIDE()
     const logging::Message::Type& messageType() const { return m_messageType; }
 
-    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM__OVERRIDE()
     const logging::Message::Class& messageClass() const { return m_messageClass; }
 
     /// clearing the SofaOStream (set empty string, empty FileInfo, default Message type)
-    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM__OVERRIDE()
     void clear()
     {
         str("");

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/SofaOStream.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/SofaOStream.h
@@ -33,6 +33,25 @@
 // That is why the deprecation is set between SOFA_BUILD_SOFA_CORE macro, to disable the warnings only when building Sofa.Core.
 // Warning messages will appear when used outside of Sofa.Core (logically in the components)
 
+// There is also a check on the version of MSVC2017
+// as there is a bug when applying [[deprecated]] on a friend method.
+// (and does not choke when using the msvc keyword __declspec(deprecated("xxx"))
+
+#ifndef SOFA_BUILD_SOFA_CORE
+#if defined(_MSC_VER) && (_MSC_VER < 1920) // if less than VS 2017
+#define SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM() \
+    __declspec(deprecated(\
+        "It is still usable but has been DEPRECATED since v21.12 (PR#XXXX). " \
+        "You have until v22.06 to fix your code. " \
+        "Use the Messaging API instead of using SofaOStream and sout/serr/sendl."))
+#else // _MSC_VER
+#define SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM() \
+        SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+#endif // _MSC_VER
+#else // SOFA_BUILD_SOFA_CORE
+#define SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM() // dont do anything if we are building Sofa.Core
+#endif // SOFA_BUILD_SOFA_CORE
+        
 namespace sofa
 {
 
@@ -54,10 +73,9 @@ protected:
 
 public:
 
-#ifndef SOFA_BUILD_SOFA_CORE
-    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
-#endif // SOFA_BUILD_SOFA_CORE
-    friend inline std::ostream &operator << (std::ostream& out, const SofaEndl<Container> & s)
+    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
+    friend inline
+    std::ostream &operator << (std::ostream& out, const SofaEndl<Container> & s)
     {
         if (s.parent)
             s.parent->processStream(out);
@@ -70,9 +88,7 @@ public:
     {
     }
 
-#ifndef SOFA_BUILD_SOFA_CORE
-    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
-#endif // SOFA_BUILD_SOFA_CORE
+    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     void setParent(Container* p)
     {
         parent = p;
@@ -93,27 +109,21 @@ public:
 
     bool operator==(const std::ostream& os) { return &os == &m_ostream; }
     
-#ifndef SOFA_BUILD_SOFA_CORE
-    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
-#endif // SOFA_BUILD_SOFA_CORE
+    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     friend inline SofaOStream& operator<<( SofaOStream& out, const logging::FileInfo::SPtr& fi )
     {
         out.m_fileInfo = fi;
         return out;
     }
 
-#ifndef SOFA_BUILD_SOFA_CORE
-    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
-#endif // SOFA_BUILD_SOFA_CORE
+    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     friend inline SofaOStream& operator<<( SofaOStream& out, const logging::Message::Type& mt )
     {
         out.m_messageType = mt;
         return out;
     }
 
-#ifndef SOFA_BUILD_SOFA_CORE
-    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
-#endif // SOFA_BUILD_SOFA_CORE
+    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     friend inline SofaOStream& operator<<( SofaOStream& out, const logging::Message::Class& mc )
     {
         out.m_messageClass = mc;
@@ -121,9 +131,7 @@ public:
     }
 
     template<class T>
-#ifndef SOFA_BUILD_SOFA_CORE
-    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
-#endif // SOFA_BUILD_SOFA_CORE
+    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     friend inline std::ostringstream& operator<<( SofaOStream& out, const T& t )
     {
         out.m_ostream << t;
@@ -131,50 +139,32 @@ public:
     }
 
     // a few useful functions on ostringstream, for a complete API, convert this in a ostringstream
-#ifndef SOFA_BUILD_SOFA_CORE
-    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
-#endif // SOFA_BUILD_SOFA_CORE
+    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     std::string str() const { return m_ostream.str(); }
 
-#ifndef SOFA_BUILD_SOFA_CORE
-    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
-#endif // SOFA_BUILD_SOFA_CORE
+    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     void str(const std::string& s) { m_ostream.str(s); }
 
-#ifndef SOFA_BUILD_SOFA_CORE
-    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
-#endif // SOFA_BUILD_SOFA_CORE
+    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     std::streamsize precision() const { return m_ostream.precision(); }
 
-#ifndef SOFA_BUILD_SOFA_CORE
-    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
-#endif // SOFA_BUILD_SOFA_CORE
+    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     std::streamsize precision( std::streamsize p ) { return m_ostream.precision(p); }
 
-#ifndef SOFA_BUILD_SOFA_CORE
-    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
-#endif // SOFA_BUILD_SOFA_CORE
+    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     std::ostringstream& ostringstream() const { return m_ostream; }
 
-#ifndef SOFA_BUILD_SOFA_CORE
-    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
-#endif // SOFA_BUILD_SOFA_CORE
+    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     const logging::FileInfo::SPtr& fileInfo() const { return m_fileInfo; }
 
-#ifndef SOFA_BUILD_SOFA_CORE
-    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
-#endif // SOFA_BUILD_SOFA_CORE
+    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     const logging::Message::Type& messageType() const { return m_messageType; }
 
-#ifndef SOFA_BUILD_SOFA_CORE
-    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
-#endif // SOFA_BUILD_SOFA_CORE
+    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     const logging::Message::Class& messageClass() const { return m_messageClass; }
 
     /// clearing the SofaOStream (set empty string, empty FileInfo, default Message type)
-#ifndef SOFA_BUILD_SOFA_CORE
-    SOFA_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
-#endif // SOFA_BUILD_SOFA_CORE
+    SOFA_OVERRIDE_ATTRIBUTE_DEPRECATED__SOFAOSTREAM()
     void clear()
     {
         str("");

--- a/SofaKernel/modules/SofaLoader/src/SofaLoader/MeshVTKLoader.cpp
+++ b/SofaKernel/modules/SofaLoader/src/SofaLoader/MeshVTKLoader.cpp
@@ -39,7 +39,7 @@ using sofa::component::loader::BaseVTKReader ;
 //XML VTK Loader
 #define checkError(A) if (!A) { return false; }
 #define checkErrorPtr(A) if (!A) { return nullptr; }
-#define checkErrorMsg(A, B) if (!A) { msg_error("MeshVTKLoader") << B << "\n" ; return false; }
+#define checkErrorMsg(A, B) if (!A) { msg_error() << B << "\n" ; return false; }
 
 namespace sofa::component::loader
 {
@@ -471,7 +471,7 @@ bool MeshVTKLoader::setInputsMesh()
                 break;
                 // more types are defined in vtkCellType.h in libvtk
             default:
-                msg_error() << "ERROR: unsupported cell type " << t;
+                msg_error() << "Unsupported cell type " << t;
             }
 
             if (!offsets)
@@ -573,7 +573,7 @@ bool LegacyVTKReader::readFile(const char* filename)
     std::getline(inVTKFile, line);
     if (string(line, 0, 23) != "# vtk DataFile Version ")
     {
-        msg_error() << "Error: Unrecognized header in file '" << filename << "'." ;
+        msg_error() << "Unrecognized header in file '" << filename << "'." ;
         return false;
     }
     string version(line, 23);
@@ -596,7 +596,7 @@ bool LegacyVTKReader::readFile(const char* filename)
     }
     else
     {
-        msg_error() << "Error: Unrecognized format in file '" << filename << "'." ;
+        msg_error() << "Unrecognized format in file '" << filename << "'." ;
         return false;
     }
 
@@ -615,7 +615,7 @@ bool LegacyVTKReader::readFile(const char* filename)
     if (line != "DATASET POLYDATA" && line != "DATASET UNSTRUCTURED_GRID"
             && line != "DATASET POLYDATA\r" && line != "DATASET UNSTRUCTURED_GRID\r" )
     {
-        msg_error() << "Error: Unsupported data type in file '" << filename << "'.";
+        msg_error() << "Unsupported data type in file '" << filename << "'.";
         return false;
     }
 
@@ -1030,7 +1030,7 @@ bool XMLVTKReader::readFile(const char* filename)
         checkErrorMsg(false, "Dataset format not implemented");
         break;
     }
-    checkErrorMsg(stateLoading, "Error while parsing XML");
+    checkErrorMsg(stateLoading, "Unable to parse XML");
 
     return true;
 }

--- a/SofaKernel/modules/SofaLoader/src/SofaLoader/MeshVTKLoader.cpp
+++ b/SofaKernel/modules/SofaLoader/src/SofaLoader/MeshVTKLoader.cpp
@@ -471,7 +471,7 @@ bool MeshVTKLoader::setInputsMesh()
                 break;
                 // more types are defined in vtkCellType.h in libvtk
             default:
-                msg_error() << "ERROR: unsupported cell type " << t << sendl;
+                msg_error() << "ERROR: unsupported cell type " << t;
             }
 
             if (!offsets)
@@ -615,7 +615,7 @@ bool LegacyVTKReader::readFile(const char* filename)
     if (line != "DATASET POLYDATA" && line != "DATASET UNSTRUCTURED_GRID"
             && line != "DATASET POLYDATA\r" && line != "DATASET UNSTRUCTURED_GRID\r" )
     {
-        msg_error() << "Error: Unsupported data type in file '" << filename << "'." << sendl;
+        msg_error() << "Error: Unsupported data type in file '" << filename << "'.";
         return false;
     }
 
@@ -641,7 +641,7 @@ bool LegacyVTKReader::readFile(const char* filename)
             int n;
             string typestr;
             ln >> n >> typestr;
-            msg_info() << "Found " << n << " " << typestr << " points" << sendl;
+            msg_info() << "Found " << n << " " << typestr << " points";
             inputPoints = newVTKDataIO(typestr);
             if (inputPoints == nullptr)
             {

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/HexahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/HexahedronFEMForceField.inl
@@ -535,7 +535,7 @@ void HexahedronFEMForceField<DataTypes>::computeElementStiffness( ElementStiffne
                 }
                 tmp<<" |  "<<std::endl;
             }
-            tmp<<"  "<<sendl;
+            tmp<<"  "<< std::endl;
         }
         tmp<<"===============================================================" << msgendl;
         msg_info() << tmp.str() ;

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Simulation.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Simulation.cpp
@@ -164,10 +164,9 @@ void Simulation::init ( Node* root )
 
     if (!root->getAnimationLoop())
     {
-        root->getContext()->sout
-                <<"Default Animation Manager Loop will be used. Add DefaultAnimationLoop to the root node of scene file to remove this warning"
-                        <<root->getContext()->sendl;
-
+        msg_warning("Simulation") <<
+            "Default Animation Manager Loop will be used. Add DefaultAnimationLoop to the root node of scene file to remove this warning";
+        
         DefaultAnimationLoop::SPtr aloop = sofa::core::objectmodel::New<DefaultAnimationLoop>(root);
         aloop->setName(sofa::helper::NameDecoder::shortName(aloop->getClassName()));
         root->addObject(aloop);
@@ -175,9 +174,8 @@ void Simulation::init ( Node* root )
 
     if(!root->getVisualLoop())
     {
-        root->getContext()->sout
-                <<"Default Visual Manager Loop will be used. Add DefaultVisualManagerLoop to the root node of scene file to remove this warning"
-                        <<root->getContext()->sendl;
+        msg_warning("Simulation") <<
+            "Default Visual Manager Loop will be used. Add DefaultVisualManagerLoop to the root node of scene file to remove this warning";
 
         DefaultVisualManagerLoop::SPtr vloop = sofa::core::objectmodel::New<DefaultVisualManagerLoop>(root);
         vloop->setName(sofa::helper::NameDecoder::shortName(vloop->getClassName()));

--- a/applications/plugins/LMConstraint/src/LMConstraint/PrecomputedLMConstraintCorrection.inl
+++ b/applications/plugins/LMConstraint/src/LMConstraint/PrecomputedLMConstraintCorrection.inl
@@ -151,10 +151,8 @@ void PrecomputedLMConstraintCorrection<DataTypes>::bwdInit()
         std::stringstream tmpStr;
         for (unsigned int f = 0; f < this->nbNodes; f++)
         {
-            std::streamsize prevPrecision = sout.precision();
             tmpStr.precision(2);
             tmpStr << "Precomputing constraint correction : " << std::fixed << (float)f / (float)this->nbNodes * 100.0f << " %   " << '\xd';
-            sout.precision(prevPrecision);
 
             for (unsigned int i = 0; i < this->dof_on_node; i++)
             {

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaHexahedronTLEDForceField.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaHexahedronTLEDForceField.cpp
@@ -98,7 +98,7 @@ void CudaHexahedronTLEDForceField::reinit()
     sofa::core::topology::BaseMeshTopology* topology = this->getContext()->getMeshTopology();
     if (topology==NULL || topology->getNbHexahedra()==0)
     {
-        serr << "ERROR(CudaHexahedronTLEDForceField): no elements found.\n";
+        msg_error() << "no elements found.\n";
         return;
     }
     VecElement inputElems = topology->getHexahedra();
@@ -313,7 +313,7 @@ void CudaHexahedronTLEDForceField::reinit()
     }
 
 
-    sout << "CudaHexahedronTLEDForceField::reinit() DONE." << sendl;
+    msg_info() << "reinit() DONE.";
 }
 
 // --------------------------------------------------------------------------------------

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearForceField.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearForceField.inl
@@ -162,7 +162,7 @@ void LinearForceField<sofa::gpu::cuda::CudaRigid3fTypes>::addForce(const core::M
 template<>
 SReal LinearForceField<sofa::gpu::cuda::CudaRigid3fTypes>::getPotentialEnergy(const core::MechanicalParams*, const DataVecCoord&) const
 {
-    this->serr<<"["<<this->getName()<<"] getPotentialEnergy not implemented !"<<this->sendl;
+    msg_error() <<"["<<this->getName()<<"] getPotentialEnergy not implemented !";
     return 0;
 }
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearForceField.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearForceField.inl
@@ -162,7 +162,7 @@ void LinearForceField<sofa::gpu::cuda::CudaRigid3fTypes>::addForce(const core::M
 template<>
 SReal LinearForceField<sofa::gpu::cuda::CudaRigid3fTypes>::getPotentialEnergy(const core::MechanicalParams*, const DataVecCoord&) const
 {
-    msg_error() <<"["<<this->getName()<<"] getPotentialEnergy not implemented !";
+    msg_error() <<"GetPotentialEnergy not implemented !";
     return 0;
 }
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPenalityContactForceField.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPenalityContactForceField.inl
@@ -210,7 +210,7 @@ void PenalityContactForceField<CudaVec3fTypes>::addDForce(const core::Mechanical
 //template<>
 SReal PenalityContactForceField<CudaVec3fTypes>::getPotentialEnergy(const core::MechanicalParams*, const DataVecCoord&, const DataVecCoord& ) const
 {
-    serr<<"PenalityContactForceField::getPotentialEnergy-not-implemented !!!"<<sendl;
+    msg_error()<<"PenalityContactForceField::getPotentialEnergy-not-implemented !!!";
     return 0;
 }
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPointModel.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPointModel.cpp
@@ -59,7 +59,7 @@ void CudaPointCollisionModel::init()
 
     if (mstate==NULL)
     {
-        serr << "ERROR: CudaPointCollisionModel requires a CudaVec3f Mechanical Model.\n";
+        msg_error() << "CudaPointCollisionModel requires a CudaVec3f Mechanical Model.\n";
         return;
     }
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.cpp
@@ -98,7 +98,7 @@ void CudaTetrahedronTLEDForceField::reinit()
 
     if (topology==NULL)
     {
-        serr << "ERROR(CudaTetrahedronTLEDForceField): no topology found." << sendl;
+        msg_error() << "no topology found.";
         return;
     }
     VecElement inputElems = topology->getTetrahedra();
@@ -108,7 +108,7 @@ void CudaTetrahedronTLEDForceField::reinit()
     {
         if (topology->getNbHexahedra() == 0)
         {
-            serr << "ERROR(CudaTetrahedronTLEDForceField): this forcefield requires a tetrahedral or hexahedral topology." << sendl;
+            msg_error() << "this forcefield requires a tetrahedral or hexahedral topology.";
             return;
         }
         int nbcubes = topology->getNbHexahedra();
@@ -353,7 +353,7 @@ void CudaTetrahedronTLEDForceField::reinit()
     // Computes Lame coefficients
     updateLameCoefficients();
 
-    sout << "CudaTetrahedronTLEDForceField::reinit() DONE." << sendl;
+    msg_info() << "reinit() DONE.";
 }
 
 // --------------------------------------------------------------------------------------

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.cpp
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.cpp
@@ -106,16 +106,17 @@ void RigidDistanceGridCollisionModel::init()
     DistanceGrid* grid = NULL;
     if (fileRigidDistanceGrid.getValue().empty())
     {
-        if (elems.size()==0 || elems[0].grid==NULL)
-            serr << "ERROR: RigidDistanceGridCollisionModel requires an input filename." << sendl;
+        if (elems.size() == 0 || elems[0].grid == NULL)
+            msg_error() << "RigidDistanceGridCollisionModel requires an input filename.";
         // else the grid has already been set
         return;
     }
-    sout << "RigidDistanceGridCollisionModel: creating "<<nx.getValue()<<"x"<<ny.getValue()<<"x"<<nz.getValue()<<" DistanceGrid from file "<<fileRigidDistanceGrid.getValue();
-    if (scale.getValue()!=1.0) sout<<" scale="<<scale.getValue();
-    if (sampling.getValue()!=0.0) sout<<" sampling="<<sampling.getValue();
-    if (box.getValue()[0][0]<box.getValue()[1][0]) sout<<" bbox=<"<<box.getValue()[0]<<">-<"<<box.getValue()[0]<<">";
-    sout << sendl;
+    msg_info() << "RigidDistanceGridCollisionModel: creating "<<nx.getValue()<<"x"<<ny.getValue()<<"x"<<nz.getValue()<<" DistanceGrid from file "<<fileRigidDistanceGrid.getValue();
+
+    if (scale.getValue()!=1.0) msg_info()<<" scale="<<scale.getValue();
+    if (sampling.getValue()!=0.0) msg_info()<<" sampling="<<sampling.getValue();
+    if (box.getValue()[0][0]<box.getValue()[1][0]) msg_info()<<" bbox=<"<<box.getValue()[0]<<">-<"<<box.getValue()[0]<<">";
+
     grid = DistanceGrid::loadShared(fileRigidDistanceGrid.getFullPath(), scale.getValue(), sampling.getValue(), nx.getValue(),ny.getValue(),nz.getValue(),box.getValue()[0],box.getValue()[1]);
     if (grid->getNx() != this->nx.getValue())
         this->nx.setValue(grid->getNx());
@@ -127,11 +128,11 @@ void RigidDistanceGridCollisionModel::init()
     elems[0].grid = grid;
     if (grid && !dumpfilename.getValue().empty())
     {
-        sout << "RigidDistanceGridCollisionModel: dump grid to "<<dumpfilename.getValue()<<sendl;
+        msg_info() << "RigidDistanceGridCollisionModel: dump grid to "<<dumpfilename.getValue();
         grid->save(dumpfilename.getFullPath());
     }
     updateState();
-    sout << "< RigidDistanceGridCollisionModel::init()"<<sendl;
+    msg_info() << "< RigidDistanceGridCollisionModel::init()";
 }
 
 void RigidDistanceGridCollisionModel::resize(Size s)
@@ -474,31 +475,31 @@ void FFDDistanceGridCollisionModel::init()
     ffdSGrid = dynamic_cast< topology::SparseGridTopology* > (ffdMesh);
     if (!ffd || (!ffdRGrid && !ffdSGrid))
     {
-        serr <<"FFDDistanceGridCollisionModel requires a Vec3-based deformable model with associated RegularGridTopology or SparseGridTopology" << sendl;
+        msg_error() << "FFDDistanceGridCollisionModel requires a Vec3-based deformable model with associated RegularGridTopology or SparseGridTopology";
         return;
     }
 
     DistanceGrid* grid = NULL;
     if (fileFFDDistanceGrid.getValue().empty())
     {
-        serr<<"ERROR: FFDDistanceGridCollisionModel requires an input filename" << sendl;
+        msg_error() << "ERROR: FFDDistanceGridCollisionModel requires an input filename";
         return;
     }
-    sout << "FFDDistanceGridCollisionModel: creating "<<nx.getValue()<<"x"<<ny.getValue()<<"x"<<nz.getValue()<<" DistanceGrid from file "<<fileFFDDistanceGrid.getValue();
-    if (scale.getValue()!=1.0) sout<<" scale="<<scale.getValue();
-    if (sampling.getValue()!=0.0) sout<<" sampling="<<sampling.getValue();
-    if (box.getValue()[0][0]<box.getValue()[1][0]) sout<<" bbox=<"<<box.getValue()[0]<<">-<"<<box.getValue()[0]<<">";
-    sout << sendl;
+    msg_info() << "FFDDistanceGridCollisionModel: creating "<<nx.getValue()<<"x"<<ny.getValue()<<"x"<<nz.getValue()<<" DistanceGrid from file "<<fileFFDDistanceGrid.getValue();
+    if (scale.getValue()!=1.0) msg_info()<<" scale="<<scale.getValue();
+    if (sampling.getValue()!=0.0) msg_info()<<" sampling="<<sampling.getValue();
+    if (box.getValue()[0][0]<box.getValue()[1][0]) msg_info()<<" bbox=<"<<box.getValue()[0]<<">-<"<<box.getValue()[0]<<">";
+
     grid = DistanceGrid::loadShared(fileFFDDistanceGrid.getFullPath(), scale.getValue(), sampling.getValue(), nx.getValue(),ny.getValue(),nz.getValue(),box.getValue()[0],box.getValue()[1]);
     if (!dumpfilename.getValue().empty())
     {
-        sout << "FFDDistanceGridCollisionModel: dump grid to "<<dumpfilename.getValue()<<sendl;
+        msg_info() << "FFDDistanceGridCollisionModel: dump grid to "<<dumpfilename.getValue();
         grid->save(dumpfilename.getFullPath());
     }
     /// place points in ffd elements
     int nbp = grid->meshPts.size();
     elems.resize(ffdMesh->getNbHexahedra());
-    sout << "FFDDistanceGridCollisionModel: placing "<<nbp<<" points in "<<ffdMesh->getNbHexahedra()<<" cubes."<<sendl;
+    msg_info() << "FFDDistanceGridCollisionModel: placing "<<nbp<<" points in "<<ffdMesh->getNbHexahedra()<<" cubes.";
 
     for (int i=0; i<nbp; i++)
     {
@@ -508,7 +509,7 @@ void FFDDistanceGridCollisionModel::init()
         if (elem == sofa::InvalidID) continue;
         if (elem >= elems.size())
         {
-            serr << "ERROR (FFDDistanceGridCollisionModel): point "<<i<<" "<<p0<<" in invalid cube "<<elem<<sendl;
+            msg_error() << "point "<<i<<" "<<p0<<" in invalid cube "<<elem;
         }
         else
         {
@@ -523,7 +524,7 @@ void FFDDistanceGridCollisionModel::init()
     }
     /// fill other data and remove inactive elements
 
-    sout << "FFDDistanceGridCollisionModel: initializing "<<ffdMesh->getNbHexahedra()<<" cubes."<<sendl;
+    msg_info() << "FFDDistanceGridCollisionModel: initializing "<<ffdMesh->getNbHexahedra()<<" cubes.";
     Size c=0;
     for (Size e=0; e<ffdMesh->getNbHexahedra(); e++)
     {
@@ -571,7 +572,7 @@ void FFDDistanceGridCollisionModel::init()
         elems[i].neighbors.erase(i);
     }
 
-    sout << "FFDDistanceGridCollisionModel: "<<c<<" active cubes."<<sendl;
+    msg_info() << "FFDDistanceGridCollisionModel: "<<c<<" active cubes.";
 }
 
 void FFDDistanceGridCollisionModel::resize(Size s)

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.cpp
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.cpp
@@ -107,11 +107,11 @@ void RigidDistanceGridCollisionModel::init()
     if (fileRigidDistanceGrid.getValue().empty())
     {
         if (elems.size() == 0 || elems[0].grid == NULL)
-            msg_error() << "RigidDistanceGridCollisionModel requires an input filename.";
+            msg_error() << "An input filename is required.";
         // else the grid has already been set
         return;
     }
-    msg_info() << "RigidDistanceGridCollisionModel: creating "<<nx.getValue()<<"x"<<ny.getValue()<<"x"<<nz.getValue()<<" DistanceGrid from file "<<fileRigidDistanceGrid.getValue();
+    msg_info() << "Creating "<<nx.getValue()<<"x"<<ny.getValue()<<"x"<<nz.getValue()<<" DistanceGrid from file "<<fileRigidDistanceGrid.getValue();
 
     if (scale.getValue()!=1.0) msg_info()<<" scale="<<scale.getValue();
     if (sampling.getValue()!=0.0) msg_info()<<" sampling="<<sampling.getValue();
@@ -128,11 +128,11 @@ void RigidDistanceGridCollisionModel::init()
     elems[0].grid = grid;
     if (grid && !dumpfilename.getValue().empty())
     {
-        msg_info() << "RigidDistanceGridCollisionModel: dump grid to "<<dumpfilename.getValue();
+        msg_info() << "Dump grid to "<<dumpfilename.getValue();
         grid->save(dumpfilename.getFullPath());
     }
     updateState();
-    msg_info() << "< RigidDistanceGridCollisionModel::init()";
+    msg_info() << "Initialisation done.";
 }
 
 void RigidDistanceGridCollisionModel::resize(Size s)
@@ -180,7 +180,6 @@ void RigidDistanceGridCollisionModel::updateState()
 
     for (Size i=0; i<size; i++)
     {
-        //static_cast<DistanceGridCollisionElement*>(elems[i])->recalcBBox();
         Vector3 emin, emax;
         if (rigid)
         {
@@ -223,7 +222,6 @@ void RigidDistanceGridCollisionModel::computeBoundingTree(int maxDepth)
     cubeModel->resize(size);
     for (Size i=0; i<size; i++)
     {
-        //static_cast<DistanceGridCollisionElement*>(elems[i])->recalcBBox();
         Vector3 emin, emax;
         if (elems[i].isTransformed)
         {
@@ -290,9 +288,6 @@ void RigidDistanceGridCollisionModel::draw(const core::visual::VisualParams* ,In
     if (elems[index].isTransformed)
     {
         glPushMatrix();
-        // float m[16];
-        // (*rigid->read(sofa::core::ConstVecCoordId::position())->getValue())[index].writeOpenGlMatrix( m );
-        // glMultMatrixf(m);
         Matrix4 m;
         m.identity();
         m = elems[index].rotation;
@@ -306,8 +301,6 @@ void RigidDistanceGridCollisionModel::draw(const core::visual::VisualParams* ,In
     DistanceGrid::Coord corners[8];
     for(unsigned int i=0; i<8; i++)
         corners[i] = grid->getCorner(i);
-    //glEnable(GL_BLEND);
-    //glDepthMask(0);
     if (!isSimulated())
         glColor4f(0.25f, 0.25f, 0.25f, 0.1f);
     else
@@ -332,8 +325,6 @@ void RigidDistanceGridCollisionModel::draw(const core::visual::VisualParams* ,In
     glDepthMask(1);
     for(unsigned int i=0; i<8; i++)
         corners[i] = grid->getBBCorner(i);
-    //glEnable(GL_BLEND);
-    //glDepthMask(0);
 
     if (!isSimulated())
         glColor4f(0.5f, 0.5f, 0.5f, 1.0f);
@@ -470,22 +461,22 @@ void FFDDistanceGridCollisionModel::init()
 {
     this->core::CollisionModel::init();
     ffd = dynamic_cast< core::behavior::MechanicalState<Vec3Types>* > (getContext()->getMechanicalState());
-    ffdMesh = /*dynamic_cast< topology::RegularGridTopology* >*/ (getContext()->getMeshTopology());
+    ffdMesh = getContext()->getMeshTopology();
     ffdRGrid = dynamic_cast< topology::RegularGridTopology* > (ffdMesh);
     ffdSGrid = dynamic_cast< topology::SparseGridTopology* > (ffdMesh);
     if (!ffd || (!ffdRGrid && !ffdSGrid))
     {
-        msg_error() << "FFDDistanceGridCollisionModel requires a Vec3-based deformable model with associated RegularGridTopology or SparseGridTopology";
+        msg_error() << "Requires a Vec3-based deformable model with associated RegularGridTopology or SparseGridTopology";
         return;
     }
 
     DistanceGrid* grid = NULL;
     if (fileFFDDistanceGrid.getValue().empty())
     {
-        msg_error() << "ERROR: FFDDistanceGridCollisionModel requires an input filename";
+        msg_error() << "Requires an input filename";
         return;
     }
-    msg_info() << "FFDDistanceGridCollisionModel: creating "<<nx.getValue()<<"x"<<ny.getValue()<<"x"<<nz.getValue()<<" DistanceGrid from file "<<fileFFDDistanceGrid.getValue();
+    msg_info() << "Creating "<<nx.getValue()<<"x"<<ny.getValue()<<"x"<<nz.getValue()<<" DistanceGrid from file "<<fileFFDDistanceGrid.getValue();
     if (scale.getValue()!=1.0) msg_info()<<" scale="<<scale.getValue();
     if (sampling.getValue()!=0.0) msg_info()<<" sampling="<<sampling.getValue();
     if (box.getValue()[0][0]<box.getValue()[1][0]) msg_info()<<" bbox=<"<<box.getValue()[0]<<">-<"<<box.getValue()[0]<<">";
@@ -493,13 +484,13 @@ void FFDDistanceGridCollisionModel::init()
     grid = DistanceGrid::loadShared(fileFFDDistanceGrid.getFullPath(), scale.getValue(), sampling.getValue(), nx.getValue(),ny.getValue(),nz.getValue(),box.getValue()[0],box.getValue()[1]);
     if (!dumpfilename.getValue().empty())
     {
-        msg_info() << "FFDDistanceGridCollisionModel: dump grid to "<<dumpfilename.getValue();
+        msg_info() << "Dump grid to "<<dumpfilename.getValue();
         grid->save(dumpfilename.getFullPath());
     }
     /// place points in ffd elements
     int nbp = grid->meshPts.size();
     elems.resize(ffdMesh->getNbHexahedra());
-    msg_info() << "FFDDistanceGridCollisionModel: placing "<<nbp<<" points in "<<ffdMesh->getNbHexahedra()<<" cubes.";
+    msg_info() << "Placing "<<nbp<<" points in "<<ffdMesh->getNbHexahedra()<<" cubes.";
 
     for (int i=0; i<nbp; i++)
     {
@@ -524,7 +515,7 @@ void FFDDistanceGridCollisionModel::init()
     }
     /// fill other data and remove inactive elements
 
-    msg_info() << "FFDDistanceGridCollisionModel: initializing "<<ffdMesh->getNbHexahedra()<<" cubes.";
+    msg_info() << "Initializing "<<ffdMesh->getNbHexahedra()<<" cubes.";
     Size c=0;
     for (Size e=0; e<ffdMesh->getNbHexahedra(); e++)
     {
@@ -572,7 +563,7 @@ void FFDDistanceGridCollisionModel::init()
         elems[i].neighbors.erase(i);
     }
 
-    msg_info() << "FFDDistanceGridCollisionModel: "<<c<<" active cubes.";
+    msg_info() << c <<" active cubes.";
 }
 
 void FFDDistanceGridCollisionModel::resize(Size s)
@@ -735,10 +726,7 @@ void FFDDistanceGridCollisionModel::draw(const core::visual::VisualParams* vpara
 void FFDDistanceGridCollisionModel::draw(const core::visual::VisualParams* vparams, Index index)
 {
 #if SOFADISTANCEGRID_HAVE_SOFA_GL == 1
-    //DistanceGrid* grid = getGrid(index);
     DeformedCube& cube = getDeformCube( index );
-    //glEnable(GL_BLEND);
-    //glDepthMask(0);
     float cscale;
     if (!isSimulated())
         cscale = 0.5f;
@@ -771,22 +759,6 @@ void FFDDistanceGridCollisionModel::draw(const core::visual::VisualParams* vpara
     glLineWidth(2);
     glPointSize(5);
     {
-        /*
-            for (int j=0; j<3; j++)
-            {
-                glBegin(GL_LINE_STRIP);
-                for (int r=0;r<=16;r++)
-                {
-                    SReal c = cube.radius*(SReal)cos(r*M_PI/8);
-                    SReal s = cube.radius*(SReal)sin(r*M_PI/8);
-                    sofa::type::Vec<3, SReal> p = cube.center;
-                    p[j] += c;
-                    p[(j+1)%3] += s;
-                    sofa::gl::glVertexT(p);
-                }
-                glEnd();
-            }
-        */
         glBegin(GL_POINTS);
         {
             sofa::gl::glVertexT(cube.center);
@@ -817,28 +789,6 @@ void FFDDistanceGridCollisionModel::draw(const core::visual::VisualParams* vpara
     glPointSize(1);
 #endif // SOFADISTANCEGRID_HAVE_SOFA_GL == 1
 }
-
-//template <class DataTypes>
-//typename ContactMapper<RigidDistanceGridCollisionModel,DataTypes>::MMechanicalState* ContactMapper<RigidDistanceGridCollisionModel,DataTypes>::createMapping(const char* name)
-//{
-//	using sofa::component::mapping::IdentityMapping;
-//
-//    MMechanicalState* outmodel = Inherit::createMapping(name);
-//    if (this->child!=NULL && this->mapping==NULL)
-//    {
-//        // add velocity visualization
-///*        sofa::component::visualmodel::DrawV* visu = new sofa::component::visualmodel::DrawV;
-//        this->child->addObject(visu);
-//        visu->useAlpha.setValue(true);
-//        visu->vscale.setValue(this->model->getContext()->getDt());
-//        IdentityMapping< DataTypes, StdVectorTypes< Vec<3,GLfloat>, Vec<3,GLfloat> > > * map = new IdentityMapping< DataTypes, StdVectorTypes< Vec<3,GLfloat>, Vec<3,GLfloat> > >( outmodel, visu );
-//        this->child->addObject(map);
-//        visu->init();
-//        map->init(); */
-//    }
-//    return outmodel;
-//}
-
 
 ContactMapperCreator< ContactMapper<FFDDistanceGridCollisionModel> > FFDDistanceGridContactMapperClass("default", true);
 

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/FFDDistanceGridDiscreteIntersection.cpp
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/FFDDistanceGridDiscreteIntersection.cpp
@@ -108,7 +108,7 @@ int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridColl
                 if (!grid2->inBBox( p2, margin )) continue;
                 if (!grid2->inGrid( p2 ))
                 {
-                    msg_error(intersection) << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e2.getCollisionModel()->getName();
+                    msg_error(intersection) << "Margin less than "<<margin<<" in DistanceGrid "<<e2.getCollisionModel()->getName();
                     continue;
                 }
 

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/FFDDistanceGridDiscreteIntersection.cpp
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/FFDDistanceGridDiscreteIntersection.cpp
@@ -108,7 +108,7 @@ int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridColl
                 if (!grid2->inBBox( p2, margin )) continue;
                 if (!grid2->inGrid( p2 ))
                 {
-                    intersection->serr << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e2.getCollisionModel()->getName()<<intersection->sendl;
+                    msg_error(intersection) << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e2.getCollisionModel()->getName();
                     continue;
                 }
 
@@ -170,7 +170,7 @@ int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridColl
                         || b[2] < -berr || b[2] > 1+berr)
                         break; // far from the cube
                     if (iter>3)
-                        intersection->sout << "Iter"<<iter<<": "<<err1<<" -> "<<err<<" b = "<<b<<" diff = "<<diff<<" d = "<<grid1->interp(c1.initpos(b))<<""<<intersection->sendl;
+                        msg_info(intersection) << "Iter"<<iter<<": "<<err1<<" -> "<<err<<" b = "<<b<<" diff = "<<diff<<" d = "<<grid1->interp(c1.initpos(b))<<"";
                     if (err < 0.005f)
                     {
                         // we found the corresponding point, but is is only valid if inside the current cube
@@ -221,7 +221,7 @@ int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridColl
                     if (b[0] > 0.001f && b[0] < 0.999f
                         && b[1] > 0.001f && b[1] < 0.999f
                         && b[2] > 0.001f && b[2] < 0.999f)
-                        intersection->serr << "ERROR: FFD-Rigid collision failed to converge to undeformed point: p1 = "<<p1<<" b = "<<b<<" c000 = "<<c1.corners[0]<<" c100 = "<<c1.corners[1]<<" c010 = "<<c1.corners[2]<<" c110 = "<<c1.corners[3]<<" c001 = "<<c1.corners[4]<<" c101 = "<<c1.corners[5]<<" c011 = "<<c1.corners[6]<<" c111 = "<<c1.corners[7]<<" pinit = "<<c1.initpos(b)<<" pdeform = "<<c1.deform(b)<<" err = "<<err1<<intersection->sendl;
+                        msg_error(intersection) << "FFD-Rigid collision failed to converge to undeformed point: p1 = "<<p1<<" b = "<<b<<" c000 = "<<c1.corners[0]<<" c100 = "<<c1.corners[1]<<" c010 = "<<c1.corners[2]<<" c110 = "<<c1.corners[3]<<" c001 = "<<c1.corners[4]<<" c101 = "<<c1.corners[5]<<" c011 = "<<c1.corners[6]<<" c111 = "<<c1.corners[7]<<" pinit = "<<c1.initpos(b)<<" pdeform = "<<c1.deform(b)<<" err = "<<err1;
                 }
             }
         }
@@ -285,7 +285,7 @@ int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridColl
                     || b[2] < -berr || b[2] > 1+berr)
                     break; // far from the cube
                 if (iter>3)
-                    intersection->sout << "Iter"<<iter<<": "<<err1<<" -> "<<err<<" b = "<<b<<" diff = "<<diff<<" d = "<<grid2->interp(c2.initpos(b))<<""<<intersection->sendl;
+                    msg_info(intersection) << "Iter"<<iter<<": "<<err1<<" -> "<<err<<" b = "<<b<<" diff = "<<diff<<" d = "<<grid2->interp(c2.initpos(b));
                 if (err < 0.005f)
                 {
                     // we found the corresponding point, but is is only valid if inside the current cube
@@ -336,7 +336,7 @@ int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridColl
                 if (b[0] > 0.001f && b[0] < 0.999f
                     && b[1] > 0.001f && b[1] < 0.999f
                     && b[2] > 0.001f && b[2] < 0.999f)
-                    intersection->serr << "ERROR: FFD-FFD collision failed to converge to undeformed point: p2 = "<<p2<<" b = "<<b<<" c000 = "<<c2.corners[0]<<" c100 = "<<c2.corners[1]<<" c010 = "<<c2.corners[2]<<" c110 = "<<c2.corners[3]<<" c001 = "<<c2.corners[4]<<" c101 = "<<c2.corners[5]<<" c011 = "<<c2.corners[6]<<" c111 = "<<c2.corners[7]<<" pinit = "<<c2.initpos(b)<<" pdeform = "<<c2.deform(b)<<" err = "<<err1<<intersection->sendl;
+                    msg_error(intersection) << "FFD-FFD collision failed to converge to undeformed point: p2 = "<<p2<<" b = "<<b<<" c000 = "<<c2.corners[0]<<" c100 = "<<c2.corners[1]<<" c010 = "<<c2.corners[2]<<" c110 = "<<c2.corners[3]<<" c001 = "<<c2.corners[4]<<" c101 = "<<c2.corners[5]<<" c011 = "<<c2.corners[6]<<" c111 = "<<c2.corners[7]<<" pinit = "<<c2.initpos(b)<<" pdeform = "<<c2.deform(b)<<" err = "<<err1;
             }
         }
     }
@@ -364,7 +364,7 @@ int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridColl
                 DistanceGrid::Coord diff = p1-pdeform;
                 SReal err = diff.norm();
                 if (iter>3)
-                    intersection->sout << "Iter"<<iter<<": "<<err1<<" -> "<<err<<" b = "<<b<<" diff = "<<diff<<" d = "<<grid1->interp(c1.initpos(b))<<""<<intersection->sendl;
+                    msg_info(intersection) << "Iter"<<iter<<": "<<err1<<" -> "<<err<<" b = "<<b<<" diff = "<<diff<<" d = "<<grid1->interp(c1.initpos(b));
                 SReal berr = err*cubesize; if (berr>0.5f) berr=0.5f;
                 if (b[0] < -berr || b[0] > 1+berr
                     || b[1] < -berr || b[1] > 1+berr
@@ -420,7 +420,7 @@ int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridColl
                 if (b[0] > 0.001f && b[0] < 0.999f
                     && b[1] > 0.001f && b[1] < 0.999f
                     && b[2] > 0.001f && b[2] < 0.999f)
-                    intersection->serr << "ERROR: FFD-FFD collision failed to converge to undeformed point: p1 = "<<p1<<" b = "<<b<<" c000 = "<<c1.corners[0]<<" c100 = "<<c1.corners[1]<<" c010 = "<<c1.corners[2]<<" c110 = "<<c1.corners[3]<<" c001 = "<<c1.corners[4]<<" c101 = "<<c1.corners[5]<<" c011 = "<<c1.corners[6]<<" c111 = "<<c1.corners[7]<<" pinit = "<<c1.initpos(b)<<" pdeform = "<<c1.deform(b)<<" err = "<<err1<<intersection->sendl;
+                    msg_error(intersection) << "FFD-FFD collision failed to converge to undeformed point: p1 = "<<p1<<" b = "<<b<<" c000 = "<<c1.corners[0]<<" c100 = "<<c1.corners[1]<<" c010 = "<<c1.corners[2]<<" c110 = "<<c1.corners[3]<<" c001 = "<<c1.corners[4]<<" c101 = "<<c1.corners[5]<<" c011 = "<<c1.corners[6]<<" c111 = "<<c1.corners[7]<<" pinit = "<<c1.initpos(b)<<" pdeform = "<<c1.deform(b)<<" err = "<<err1;
             }
         }
     }
@@ -460,7 +460,7 @@ int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridColl
         DistanceGrid::Coord diff = p1-pdeform;
         SReal err = diff.norm();
         if (iter>3)
-            intersection->sout << "Iter"<<iter<<": "<<err1<<" -> "<<err<<" b = "<<b<<" diff = "<<diff<<" d = "<<grid1->interp(c1.initpos(b))<<""<<intersection->sendl;
+            msg_info(intersection) << "Iter"<<iter<<": "<<err1<<" -> "<<err<<" b = "<<b<<" diff = "<<diff<<" d = "<<grid1->interp(c1.initpos(b));
         SReal berr = err*cubesize; if (berr>0.5f) berr=0.5f;
         if (b[0] < -berr || b[0] > 1+berr
             || b[1] < -berr || b[1] > 1+berr
@@ -510,7 +510,7 @@ int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridColl
         if (b[0] > 0.001f && b[0] < 0.999f
             && b[1] > 0.001f && b[1] < 0.999f
             && b[2] > 0.001f && b[2] < 0.999f)
-            intersection->serr << "ERROR: FFD-FFD collision failed to converge to undeformed point: p1 = "<<p1<<" b = "<<b<<" c000 = "<<c1.corners[0]<<" c100 = "<<c1.corners[1]<<" c010 = "<<c1.corners[2]<<" c110 = "<<c1.corners[3]<<" c001 = "<<c1.corners[4]<<" c101 = "<<c1.corners[5]<<" c011 = "<<c1.corners[6]<<" c111 = "<<c1.corners[7]<<" pinit = "<<c1.initpos(b)<<" pdeform = "<<c1.deform(b)<<" err = "<<err1<<intersection->sendl;
+            msg_error(intersection) << "FFD-FFD collision failed to converge to undeformed point: p1 = "<<p1<<" b = "<<b<<" c000 = "<<c1.corners[0]<<" c100 = "<<c1.corners[1]<<" c010 = "<<c1.corners[2]<<" c110 = "<<c1.corners[3]<<" c001 = "<<c1.corners[4]<<" c101 = "<<c1.corners[5]<<" c011 = "<<c1.corners[6]<<" c111 = "<<c1.corners[7]<<" pinit = "<<c1.initpos(b)<<" pdeform = "<<c1.deform(b)<<" err = "<<err1;
     }
 
     return nc;
@@ -553,7 +553,7 @@ int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridColl
             DistanceGrid::Coord diff = p1-pdeform;
             SReal err = diff.norm();
             if (iter>3)
-                intersection->sout << "Iter"<<iter<<": "<<err1<<" -> "<<err<<" b = "<<b<<" diff = "<<diff<<" d = "<<grid1->interp(c1.initpos(b))<<""<<intersection->sendl;
+                msg_info(intersection) << "Iter"<<iter<<": "<<err1<<" -> "<<err<<" b = "<<b<<" diff = "<<diff<<" d = "<<grid1->interp(c1.initpos(b));
             SReal berr = err*cubesize; if (berr>0.5f) berr=0.5f;
             if (b[0] < -berr || b[0] > 1+berr
                 || b[1] < -berr || b[1] > 1+berr
@@ -604,7 +604,7 @@ int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridColl
             if (b[0] > 0.001f && b[0] < 0.999f
                 && b[1] > 0.001f && b[1] < 0.999f
                 && b[2] > 0.001f && b[2] < 0.999f)
-                intersection->serr << "ERROR: FFD-FFD collision failed to converge to undeformed point: p1 = "<<p1<<" b = "<<b<<" c000 = "<<c1.corners[0]<<" c100 = "<<c1.corners[1]<<" c010 = "<<c1.corners[2]<<" c110 = "<<c1.corners[3]<<" c001 = "<<c1.corners[4]<<" c101 = "<<c1.corners[5]<<" c011 = "<<c1.corners[6]<<" c111 = "<<c1.corners[7]<<" pinit = "<<c1.initpos(b)<<" pdeform = "<<c1.deform(b)<<" err = "<<err1<<intersection->sendl;
+                msg_error(intersection) << "FFD-FFD collision failed to converge to undeformed point: p1 = "<<p1<<" b = "<<b<<" c000 = "<<c1.corners[0]<<" c100 = "<<c1.corners[1]<<" c010 = "<<c1.corners[2]<<" c110 = "<<c1.corners[3]<<" c001 = "<<c1.corners[4]<<" c101 = "<<c1.corners[5]<<" c011 = "<<c1.corners[6]<<" c111 = "<<c1.corners[7]<<" pinit = "<<c1.initpos(b)<<" pdeform = "<<c1.deform(b)<<" err = "<<err1;
         }
     }
     return nc;

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/FFDDistanceGridDiscreteIntersection.inl
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/FFDDistanceGridDiscreteIntersection.inl
@@ -125,7 +125,7 @@ int FFDDistanceGridDiscreteIntersection::computeIntersection(FFDDistanceGridColl
         if (b[0] > 0.001f && b[0] < 0.999f
             && b[1] > 0.001f && b[1] < 0.999f
             && b[2] > 0.001f && b[2] < 0.999f)
-            intersection->serr << "ERROR: FFD-FFD collision failed to converge to undeformed point: p1 = "<<p1<<" b = "<<b<<" c000 = "<<c1.corners[0]<<" c100 = "<<c1.corners[1]<<" c010 = "<<c1.corners[2]<<" c110 = "<<c1.corners[3]<<" c001 = "<<c1.corners[4]<<" c101 = "<<c1.corners[5]<<" c011 = "<<c1.corners[6]<<" c111 = "<<c1.corners[7]<<" pinit = "<<c1.initpos(b)<<" pdeform = "<<c1.deform(b)<<" err = "<<err1<<intersection->sendl;
+            msg_error(intersection) << "FFD-FFD collision failed to converge to undeformed point: p1 = "<<p1<<" b = "<<b<<" c000 = "<<c1.corners[0]<<" c100 = "<<c1.corners[1]<<" c010 = "<<c1.corners[2]<<" c110 = "<<c1.corners[3]<<" c001 = "<<c1.corners[4]<<" c101 = "<<c1.corners[5]<<" c011 = "<<c1.corners[6]<<" c111 = "<<c1.corners[7]<<" pinit = "<<c1.initpos(b)<<" pdeform = "<<c1.deform(b)<<" err = "<<err1;
     }
 
     return 0;

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/RigidDistanceGridDiscreteIntersection.cpp
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/RigidDistanceGridDiscreteIntersection.cpp
@@ -275,7 +275,7 @@ int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGrid
                 if (!grid2->inBBox( p2 /*, margin*/ )) continue;
                 if (!grid2->inGrid( p2 ))
                 {
-                    intersection->serr << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e2.getCollisionModel()->getName()<<intersection->sendl;
+                    msg_error(intersection) << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e2.getCollisionModel()->getName();
                     continue;
                 }
 
@@ -519,7 +519,7 @@ int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGrid
                 if (!grid1->inBBox( p1 /*, margin*/ )) continue;
                 if (!grid1->inGrid( p1 ))
                 {
-                    intersection->serr << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName()<<intersection->sendl;
+                    msg_error(intersection) << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName();
                     continue;
                 }
 
@@ -583,7 +583,7 @@ int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGrid
         if (!grid1->inBBox( p1, margin )) return 0;
         if (!grid1->inGrid( p1 ))
         {
-            intersection->serr << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName()<<intersection->sendl;
+            msg_error(intersection) << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName();
             return 0;
         }
     }
@@ -645,7 +645,7 @@ int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGrid
         {
             if (!grid1->inGrid( p1 ))
             {
-                intersection->serr << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName()<<intersection->sendl;
+                msg_error(intersection) << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName();
             }
             else
             {
@@ -690,7 +690,7 @@ int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGrid
         {
             if (!grid1->inGrid( p1 ))
             {
-                intersection->serr << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName()<<intersection->sendl;
+                msg_error(intersection) << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName();
             }
             else
             {
@@ -754,7 +754,7 @@ int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGrid
         {
             if (!grid1->inGrid( p1 ))
             {
-                intersection->serr << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName()<<intersection->sendl;
+                msg_error(intersection) << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName();
             }
             else
             {
@@ -883,7 +883,6 @@ int RigidDistanceGridDiscreteIntersection::computeIntersection(Ray& e2, RigidDis
             l0 += dist;
             p = rayOrigin + rayDirection*l0;
             dist = grid1->interp(p);
-            //sout << "p="<<p<<" dist="<<dist<<" l0="<<l0<<" l1="<<l1<<" epsilon="<<epsilon<<sendl;
         }
         if (dist < epsilon)
         {

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/RigidDistanceGridDiscreteIntersection.cpp
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/RigidDistanceGridDiscreteIntersection.cpp
@@ -275,7 +275,7 @@ int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGrid
                 if (!grid2->inBBox( p2 /*, margin*/ )) continue;
                 if (!grid2->inGrid( p2 ))
                 {
-                    msg_error(intersection) << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e2.getCollisionModel()->getName();
+                    msg_error(intersection) << "Margin less than "<<margin<<" in DistanceGrid "<<e2.getCollisionModel()->getName();
                     continue;
                 }
 
@@ -519,7 +519,7 @@ int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGrid
                 if (!grid1->inBBox( p1 /*, margin*/ )) continue;
                 if (!grid1->inGrid( p1 ))
                 {
-                    msg_error(intersection) << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName();
+                    msg_error(intersection) << "Mmargin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName();
                     continue;
                 }
 
@@ -583,7 +583,7 @@ int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGrid
         if (!grid1->inBBox( p1, margin )) return 0;
         if (!grid1->inGrid( p1 ))
         {
-            msg_error(intersection) << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName();
+            msg_error(intersection) << "Margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName();
             return 0;
         }
     }
@@ -645,7 +645,7 @@ int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGrid
         {
             if (!grid1->inGrid( p1 ))
             {
-                msg_error(intersection) << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName();
+                msg_error(intersection) << "Margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName();
             }
             else
             {
@@ -690,7 +690,7 @@ int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGrid
         {
             if (!grid1->inGrid( p1 ))
             {
-                msg_error(intersection) << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName();
+                msg_error(intersection) << "Margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName();
             }
             else
             {
@@ -754,7 +754,7 @@ int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGrid
         {
             if (!grid1->inGrid( p1 ))
             {
-                msg_error(intersection) << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName();
+                msg_error(intersection) << "Margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName();
             }
             else
             {

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/RigidDistanceGridDiscreteIntersection.inl
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/RigidDistanceGridDiscreteIntersection.inl
@@ -69,7 +69,7 @@ int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGrid
     if (!grid1->inBBox( p1, margin )) return 0;
     if (!grid1->inGrid( p1 ))
     {
-        msg_error(intersection) << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName();
+        msg_error(intersection) << "Margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName();
         return 0;
     }
 

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/RigidDistanceGridDiscreteIntersection.inl
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/RigidDistanceGridDiscreteIntersection.inl
@@ -69,7 +69,7 @@ int RigidDistanceGridDiscreteIntersection::computeIntersection(RigidDistanceGrid
     if (!grid1->inBBox( p1, margin )) return 0;
     if (!grid1->inGrid( p1 ))
     {
-        intersection->serr << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName()<<intersection->sendl;
+        msg_error(intersection) << "WARNING: margin less than "<<margin<<" in DistanceGrid "<<e1.getCollisionModel()->getName();
         return 0;
     }
 

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/forcefield/DistanceGridForceField.h
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/forcefield/DistanceGridForceField.h
@@ -216,7 +216,7 @@ public:
     void addKToMatrix(const sofa::core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override
     {
-        msg_warning() << "Get potentialEnergy not implemented" << sendl;
+        msg_warning() << "Get potentialEnergy not implemented";
         return 0.0;
     }
     void draw(const core::visual::VisualParams* vparams) override;

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/forcefield/DistanceGridForceField.inl
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/forcefield/DistanceGridForceField.inl
@@ -96,7 +96,7 @@ void DistanceGridForceField<DataTypes>::init()
         }
         else
         {
-            serr << "No triangles found in topology" << sendl;
+            msg_error() << "No triangles found in topology";
         }
     }
 
@@ -121,7 +121,7 @@ void DistanceGridForceField<DataTypes>::init()
         }
         else
         {
-            serr << "No tetrahedra found in topology" << sendl;
+            msg_error() << "No tetrahedra found in topology";
         }
     }
 

--- a/applications/plugins/SofaEulerianFluid/Fluid2D.h
+++ b/applications/plugins/SofaEulerianFluid/Fluid2D.h
@@ -139,7 +139,7 @@ protected:
         }
         else
         {
-            serr << "ERROR: Invalid face "<<p1<<" "<<p2<<" "<<p3<<sendl;
+            msg_error() << "Invalid face "<<p1<<" "<<p2<<" "<<p3;
             return -1;
         }
     }

--- a/applications/plugins/SofaEulerianFluid/Fluid3D.h
+++ b/applications/plugins/SofaEulerianFluid/Fluid3D.h
@@ -134,8 +134,8 @@ protected:
     {
         int nbp = points.size();
         if ((unsigned)p1<(unsigned)nbp &&
-            (unsigned)p2<(unsigned)nbp &&
-            (unsigned)p3<(unsigned)nbp)
+                (unsigned)p2<(unsigned)nbp &&
+                (unsigned)p3<(unsigned)nbp)
         {
             int f = facets.size();
             facets.resize(f+1);
@@ -146,7 +146,7 @@ protected:
         }
         else
         {
-           msg_error() << "ERROR: Invalid face "<<p1<<" "<<p2<<" "<<p3;
+            msg_error() << "Invalid face indices: "<<p1<<" "<<p2<<" "<<p3;
             return -1;
         }
     }

--- a/applications/plugins/SofaEulerianFluid/Fluid3D.h
+++ b/applications/plugins/SofaEulerianFluid/Fluid3D.h
@@ -146,7 +146,7 @@ protected:
         }
         else
         {
-            serr << "ERROR: Invalid face "<<p1<<" "<<p2<<" "<<p3<<sendl;
+           msg_error() << "ERROR: Invalid face "<<p1<<" "<<p2<<" "<<p3;
             return -1;
         }
     }

--- a/applications/plugins/SofaImplicitField/components/mapping/ImplicitSurfaceMapping.h
+++ b/applications/plugins/SofaImplicitField/components/mapping/ImplicitSurfaceMapping.h
@@ -174,7 +174,7 @@ protected:
         }
         else
         {
-            msg_error() << "ERROR: Invalid face "<<p1<<" "<<p2<<" "<<p3;
+            msg_error() << "Invalid face "<<p1<<" "<<p2<<" "<<p3;
             return -1;
         }
     }

--- a/applications/plugins/SofaImplicitField/components/mapping/ImplicitSurfaceMapping.h
+++ b/applications/plugins/SofaImplicitField/components/mapping/ImplicitSurfaceMapping.h
@@ -106,12 +106,12 @@ public:
     void applyJ(const core::MechanicalParams *mparams, Data<OutVecDeriv>& out, const Data<InVecDeriv>& in) override;
     void applyJT( const sofa::core::MechanicalParams* /*mparams*/, InDataVecDeriv& /*out*/, const OutDataVecDeriv& /*in*/) override
     {
-        serr << "applyJT(dx) is not implemented" << sendl;
+        msg_error() << "applyJT(dx) is not implemented";
     }
 
     void applyJT( const sofa::core::ConstraintParams* /*cparams*/, InDataMatrixDeriv& /*out*/, const OutDataMatrixDeriv& /*in*/) override
     {
-        serr << "applyJT(constraint) is not implemented" << sendl;
+        msg_error() << "applyJT(constraint) is not implemented";
     }
 
 protected:
@@ -174,7 +174,7 @@ protected:
         }
         else
         {
-            serr << "ERROR: Invalid face "<<p1<<" "<<p2<<" "<<p3<<sendl;
+            msg_error() << "ERROR: Invalid face "<<p1<<" "<<p2<<" "<<p3;
             return -1;
         }
     }

--- a/applications/plugins/SofaImplicitField/components/mapping/ImplicitSurfaceMapping.inl
+++ b/applications/plugins/SofaImplicitField/components/mapping/ImplicitSurfaceMapping.inl
@@ -237,9 +237,8 @@ void ImplicitSurfaceMapping<In,Out>::apply(const core::MechanicalParams * /*mpar
                             (b+edgecube[tri[1]])->p[edgepts[tri[1]]],
                             (b+edgecube[tri[2]])->p[edgepts[tri[2]]], out.size())<0)
                     {
-                        serr << "  mk=0x"<<std::hex<<mk<<std::dec<<" p1="<<tri[0]<<" p2="<<tri[1]<<" p3="<<tri[2]<<sendl;
-                        for (int e=0; e<12; e++) serr << "  e"<<e<<"="<<(b+edgecube[e])->p[edgepts[e]];
-                        serr<<sendl;
+                        msg_error() << "  mk=0x"<<std::hex<<mk<<std::dec<<" p1="<<tri[0]<<" p2="<<tri[1]<<" p3="<<tri[2]<<msgendl;
+                        for (int e=0; e<12; e++) msg_error() << "  e"<<e<<"="<<(b+edgecube[e])->p[edgepts[e]];
                     }
                     tri+=3;
                 }

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticleSource.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticleSource.inl
@@ -51,7 +51,7 @@ ParticleSource<DataTypes>::ParticleSource()
     , m_pointHandler(nullptr)
 {
     this->f_listening.setValue(true);
-    d_center.beginEdit()->push_back(Coord()); d_center.endEdit();    
+    d_center.beginEdit()->push_back(Coord()); d_center.endEdit();
 }
 
 
@@ -84,12 +84,12 @@ void ParticleSource<DataTypes>::init()
     if (_topology != nullptr)
     {
         m_pointHandler = new PSPointHandler(this, &m_lastparticles);
-       // m_lastparticles.createTopologyHandler(_topology, m_pointHandler);
+        // m_lastparticles.createTopologyHandler(_topology, m_pointHandler);
     }
 
-    msg_info() << "ParticleSource: center = " << d_center.getValue();
-    msg_info() << " radius = " << d_radius.getValue() << " m_numberParticles = " << m_numberParticles;
-    msg_info() << " start = " << d_start.getValue() << " stop = " << d_stop.getValue() << " delay = " << d_delay.getValue();
+    msg_info() << " center = " << d_center.getValue() << msgendl
+               << " radius = " << d_radius.getValue() << " m_numberParticles = " << m_numberParticles << msgendl
+               << " start = " << d_start.getValue() << " stop = " << d_stop.getValue() << " delay = " << d_delay.getValue();
 }
 
 
@@ -128,7 +128,7 @@ void ParticleSource<DataTypes>::projectResponse(const sofa::core::MechanicalPara
     for (unsigned int s = 0; s<_lastparticles.size(); s++)
     {
         dx[_lastparticles[s]] = Deriv();
-    }    
+    }
     dxData.endEdit();
 }
 
@@ -208,14 +208,14 @@ void ParticleSource<DataTypes>::animateBegin(double /*dt*/, double time)
         i0 = 0;
         sofa::component::topology::PointSetTopologyContainer* pointCon;
         this->getContext()->get(pointCon);
-        if (pointCon != nullptr) 
+        if (pointCon != nullptr)
         {
             // TODO: epernod.... why why why.... still a diff between meca->getSize and topo->GetNbrPoints...
             pointCon->setNbPoints(1);
         }
     }
 
-    size_t nbParticlesToCreate = (int)((time - m_lastTime) / d_delay.getValue());    
+    size_t nbParticlesToCreate = (int)((time - m_lastTime) / d_delay.getValue());
     if (nbParticlesToCreate > 0)
     {
         msg_info() << "ParticleSource: animate begin time= " << time << " | size: " << i0;
@@ -255,7 +255,7 @@ void ParticleSource<DataTypes>::animateBegin(double /*dt*/, double time)
 
                 for (unsigned int c = 0; c < p.size(); c++)
                     p[c] += d_radius.getValue()[c] * rrand();
-               
+
                 m_lastpos.push_back(p);
                 _lastparticles.push_back((Index)(i0 + newX.size()));
                 newX.push_back(p + v0 * (time - m_lastTime)); // account for particle initial motion
@@ -284,7 +284,7 @@ void ParticleSource<DataTypes>::animateBegin(double /*dt*/, double time)
             else
             {
                 n -= this->mstate->getSize();
-            }            
+            }
             pointMod->addPoints(n);
         }
         else
@@ -326,7 +326,7 @@ void ParticleSource<DataTypes>::draw(const core::visual::VisualParams* vparams)
         return;
 
     double time = this->getContext()->getTime();
-    if (time < d_start.getValue() || time > d_stop.getValue()) 
+    if (time < d_start.getValue() || time > d_stop.getValue())
         return;
 
     Deriv dpos = d_velocity.getValue()*(time - m_lastTime);

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticleSource.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticleSource.inl
@@ -218,7 +218,7 @@ void ParticleSource<DataTypes>::animateBegin(double /*dt*/, double time)
     size_t nbParticlesToCreate = (int)((time - m_lastTime) / d_delay.getValue());    
     if (nbParticlesToCreate > 0)
     {
-        msg_info() << "ParticleSource: animate begin time= " << time << " | size: " << i0 << sendl;
+        msg_info() << "ParticleSource: animate begin time= " << time << " | size: " << i0;
         msg_info() << "nbParticlesToCreate: " << nbParticlesToCreate << " m_maxdist: " << m_maxdist;
         SetIndexArray& _lastparticles = *m_lastparticles.beginEdit(); ///< lastparticles indices
 

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticlesRepulsionForceField.h
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticlesRepulsionForceField.h
@@ -96,7 +96,7 @@ public:
 
     SReal getPotentialEnergy(const sofa::core::MechanicalParams* /*mparams*/, const DataVecCoord& /* x */) const override
     {
-        serr << "getPotentialEnergy not implemented" << sendl;
+        msg_error() << "getPotentialEnergy not implemented";
 
         return 0.0;
     }

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticlesRepulsionForceField.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/ParticlesRepulsionForceField.inl
@@ -55,13 +55,7 @@ void ParticlesRepulsionForceField<DataTypes>::init()
     this->Inherit::init();
     this->getContext()->get(grid); //new Grid(distance.getValue());
     if (grid==nullptr)
-        serr<<"SpatialGridContainer not found by ParticlesRepulsionForceField, slow O(n2) method will be used !!!" << sendl;
-    //int n = (this->mstate->read(core::ConstVecCoordId::position())->getValue()).size();
-    //particles.resize(n);
-    //for (int i=0;i<n;i++)
-    //{
-    //	particles[i].neighbors.clear();
-    //}
+        msg_error()<<"SpatialGridContainer not found by ParticlesRepulsionForceField, slow O(n2) method will be used !!!";
 }
 
 template<class DataTypes>

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/SPHFluidForceField.inl
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/SPHFluidForceField.inl
@@ -61,14 +61,48 @@ void SPHFluidForceField<DataTypes>::init()
 {
     this->Inherit::init();
 
-    SPHKernel<SPH_KERNEL_CUBIC,Deriv> Kcubic(4);
-    if (!Kcubic.CheckAll(2, sout.ostringstream(), serr.ostringstream())) serr << sendl;
+    SPHKernel<SPH_KERNEL_CUBIC, Deriv> Kcubic(4);
+    {
+        std::ostringstream ossInfo;
+        std::ostringstream ossError;
+        if (!Kcubic.CheckAll(2, ossInfo, ossError))
+        {
+            msg_info_when(ossInfo.str().empty(), this) << ossInfo.str();
+            msg_error_when(ossError.str().empty(), this) << ossError.str();
+        }
+    }
     SPHKernel<SPH_KERNEL_DEFAULT_DENSITY,Deriv> Kd(4);
-    if (!Kd.CheckAll(2, sout.ostringstream(), serr.ostringstream())) serr << sendl;
+    {
+        std::ostringstream ossInfo;
+        std::ostringstream ossError;
+        if (!Kd.CheckAll(2, ossInfo, ossError))
+        {
+            msg_info_when(ossInfo.str().empty(), this) << ossInfo.str();
+            msg_error_when(ossError.str().empty(), this) << ossError.str();
+        }
+    }
+
     SPHKernel<SPH_KERNEL_DEFAULT_PRESSURE,Deriv> Kp(4);
-    if (!Kp.CheckAll(1, sout.ostringstream(), serr.ostringstream())) serr << sendl;
+    {
+        std::ostringstream ossInfo;
+        std::ostringstream ossError;
+        if (!Kp.CheckAll(1, ossInfo, ossError))
+        {
+            msg_info_when(ossInfo.str().empty(), this) << ossInfo.str();
+            msg_error_when(ossError.str().empty(), this) << ossError.str();
+        }
+    }
+
     SPHKernel<SPH_KERNEL_DEFAULT_VISCOSITY,Deriv> Kv(4);
-    if (!Kv.CheckAll(2, sout.ostringstream(), serr.ostringstream())) serr << sendl;
+    {
+        std::ostringstream ossInfo;
+        std::ostringstream ossError;
+        if (!Kv.CheckAll(2, ossInfo, ossError))
+        {
+            msg_info_when(ossInfo.str().empty(), this) << ossInfo.str();
+            msg_error_when(ossError.str().empty(), this) << ossError.str();
+        }
+    }
 
     this->getContext()->get(m_grid); //new Grid(d_particleRadius.getValue());
     if (m_grid==nullptr)

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/SpatialGridPointModel.cpp
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/SpatialGridPointModel.cpp
@@ -51,7 +51,7 @@ void SpatialGridPointModel::init()
 
     if (grid==NULL)
     {
-        serr <<"SpatialGridPointModel requires a Vec3 SpatialGridContainer" << sendl;
+        msg_error() <<"SpatialGridPointModel requires a Vec3 SpatialGridContainer";
         return;
     }
 }
@@ -163,7 +163,7 @@ void SpatialGridPointModel::computeBoundingTree(int maxDepth)
     }
     if (!sorted)
     {
-        serr << "ERROR(SpatialGridPointModel): points are not sorted in spatial grid."<<sendl;
+        msg_error() << "ERROR(SpatialGridPointModel): points are not sorted in spatial grid.";
     }
     //sout << sendl;
     cubeModel->resize(cells.size());
@@ -192,7 +192,7 @@ void SpatialGridPointModel::computeBoundingTree(int maxDepth)
     int depth = 0;
     while (depth < maxDepth && cells.size() > 8)
     {
-        msg_info() << "SpatialGridPointModel: cube depth "<<depth<<": "<<cells.size()<<" cells ("<<(size*100/cells.size())*0.01<<" points/cell)."<<sendl;
+        msg_info() << "SpatialGridPointModel: cube depth "<<depth<<": "<<cells.size()<<" cells ("<<(size*100/cells.size())*0.01<<" points/cell).";
         // compact cells inplace
         int parent = -1;
         for (unsigned int i=0; i<cells.size(); ++i)

--- a/applications/plugins/SofaSphFluid/src/SofaSphFluid/SpatialGridPointModel.cpp
+++ b/applications/plugins/SofaSphFluid/src/SofaSphFluid/SpatialGridPointModel.cpp
@@ -51,7 +51,7 @@ void SpatialGridPointModel::init()
 
     if (grid==NULL)
     {
-        msg_error() <<"SpatialGridPointModel requires a Vec3 SpatialGridContainer";
+        msg_error() <<"Requires a Vec3 SpatialGridContainer";
         return;
     }
 }
@@ -163,7 +163,7 @@ void SpatialGridPointModel::computeBoundingTree(int maxDepth)
     }
     if (!sorted)
     {
-        msg_error() << "ERROR(SpatialGridPointModel): points are not sorted in spatial grid.";
+        msg_error() << "Points are not sorted in spatial grid.";
     }
     //sout << sendl;
     cubeModel->resize(cells.size());

--- a/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglVolumetricModel.cpp
+++ b/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglVolumetricModel.cpp
@@ -66,7 +66,7 @@ void OglVolumetricModel::init()
     context->get(m_shader);
     if (!m_shader)
     {
-        serr << "Need an OglShader to work !" << sendl;
+        msg_error() << "Need an OglShader to work !";
         return;
     }
 
@@ -95,7 +95,7 @@ void OglVolumetricModel::init()
 
     if (!m_mappingTableValues)
     {
-        sout << "No MappingTable found, instanciating one" << sendl;
+        msg_info() << "No MappingTable found, instanciating one";
         m_mappingTableValues = sofa::core::objectmodel::New<sofa::component::visualmodel::OglFloatVector4Variable>();
         m_mappingTableValues->setName("MappingTable");
         m_mappingTableValues->setID("MappingTable");
@@ -116,7 +116,7 @@ void OglVolumetricModel::init()
     }
     if (!m_runSelectTableValues)
     {
-        sout << "No RunSelectTable found, instanciating one" << sendl;
+        msg_info() << "No RunSelectTable found, instanciating one";
 
         m_runSelectTableValues = sofa::core::objectmodel::New<sofa::component::visualmodel::OglFloatVector4Variable>();
         m_runSelectTableValues->setName("RunSelectTable");
@@ -141,7 +141,7 @@ void OglVolumetricModel::init()
 
     if (!m_topology)
     {
-        sout << "No BaseMeshTopology found." << sendl;
+        msg_info() << "No BaseMeshTopology found.";
         b_useTopology = false;
         b_modified = false;
     }
@@ -200,7 +200,7 @@ void OglVolumetricModel::initVisual()
     }
     if (!m_vertexColors)
     {
-        serr << "No attributes called a_vertexColor found, instanciating one with a default color" << sendl;
+        msg_error() << "No attributes called a_vertexColor found, instanciating one with a default color";
         m_vertexColors = sofa::core::objectmodel::New<sofa::component::visualmodel::OglFloat4Attribute>();
         m_vertexColors->setName("a_vertexColor");
         m_vertexColors->setID("a_vertexColor");
@@ -255,7 +255,7 @@ void OglVolumetricModel::computeMeshFromTopology()
     // update m_positions
     if (m_topology->hasPos())
     {
-        sout << "OglVolumetricModel: copying " << m_topology->getNbPoints() << "points from topology." << sendl;
+        msg_info() << "OglVolumetricModel: copying " << m_topology->getNbPoints() << "points from topology.";
         helper::WriteAccessor<  Data<type::vector<Coord> > > position = m_positions;
         position.resize(m_topology->getNbPoints());
         for (unsigned int i = 0; i<position.size(); i++) 
@@ -269,7 +269,7 @@ void OglVolumetricModel::computeMeshFromTopology()
         
     if (BaseMechanicalState* mstate = dynamic_cast< BaseMechanicalState* >(m_topology->getContext()->getMechanicalState()))
     {
-        sout << "OglVolumetricModel: copying " << mstate->getSize() << " points from mechanical state." << sendl;
+        msg_info() << "OglVolumetricModel: copying " << mstate->getSize() << " points from mechanical state.";
         helper::WriteAccessor< Data<type::vector<Coord> > > position = m_positions;
         position.resize(mstate->getSize());
         for (unsigned int i = 0; i<position.size(); i++)
@@ -281,12 +281,12 @@ void OglVolumetricModel::computeMeshFromTopology()
     }
     else
     {
-        serr << "OglVolumetricModel: can not update positions!" << sendl;
+        msg_error() << "OglVolumetricModel: can not update positions!";
     }
 
     // update Tetrahedrons
     const SeqTetrahedra& inputTetrahedra = m_topology->getTetrahedra();
-    sout << "OglVolumetricModel: copying " << inputTetrahedra.size() << " tetrahedra from topology." << sendl;
+    msg_info() << "OglVolumetricModel: copying " << inputTetrahedra.size() << " tetrahedra from topology.";
     helper::WriteAccessor< Data< type::vector<Tetrahedron> > > tetrahedra = d_tetrahedra;
     tetrahedra.clear();
     tetrahedra.resize(inputTetrahedra.size());
@@ -296,7 +296,7 @@ void OglVolumetricModel::computeMeshFromTopology()
         
     // update Hexahedrons
     const SeqHexahedra& inputHexahedra = m_topology->getHexahedra();
-    sout << "OglVolumetricModel: copying " << inputHexahedra.size() << " hexahedra from topology." << sendl;
+    msg_info() << "OglVolumetricModel: copying " << inputHexahedra.size() << " hexahedra from topology.";
     helper::WriteAccessor< Data< type::vector<Hexahedron> > > hexahedra = d_hexahedra;
     hexahedra.clear();
     hexahedra.resize(inputHexahedra.size());
@@ -452,7 +452,7 @@ void OglVolumetricModel::drawTransparent(const core::visual::VisualParams* vpara
     //glDisable(GL_CLIP_DISTANCE0);
 
 #else
-    serr << "Your OpenGL driver does not support GL_LINES_ADJACENCY_EXT" << sendl;
+    msg_error() << "Your OpenGL driver does not support GL_LINES_ADJACENCY_EXT";
 #endif // GL_LINES_ADJACENCY_EXT
 
     if (vparams->displayFlags().getShowWireFrame())

--- a/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglVolumetricModel.cpp
+++ b/applications/plugins/VolumetricRendering/src/VolumetricRendering/OglVolumetricModel.cpp
@@ -255,7 +255,7 @@ void OglVolumetricModel::computeMeshFromTopology()
     // update m_positions
     if (m_topology->hasPos())
     {
-        msg_info() << "OglVolumetricModel: copying " << m_topology->getNbPoints() << "points from topology.";
+        msg_info() << "Copying " << m_topology->getNbPoints() << "points from topology.";
         helper::WriteAccessor<  Data<type::vector<Coord> > > position = m_positions;
         position.resize(m_topology->getNbPoints());
         for (unsigned int i = 0; i<position.size(); i++) 
@@ -269,7 +269,7 @@ void OglVolumetricModel::computeMeshFromTopology()
         
     if (BaseMechanicalState* mstate = dynamic_cast< BaseMechanicalState* >(m_topology->getContext()->getMechanicalState()))
     {
-        msg_info() << "OglVolumetricModel: copying " << mstate->getSize() << " points from mechanical state.";
+        msg_info() << "Copying " << mstate->getSize() << " points from mechanical state.";
         helper::WriteAccessor< Data<type::vector<Coord> > > position = m_positions;
         position.resize(mstate->getSize());
         for (unsigned int i = 0; i<position.size(); i++)
@@ -286,7 +286,7 @@ void OglVolumetricModel::computeMeshFromTopology()
 
     // update Tetrahedrons
     const SeqTetrahedra& inputTetrahedra = m_topology->getTetrahedra();
-    msg_info() << "OglVolumetricModel: copying " << inputTetrahedra.size() << " tetrahedra from topology.";
+    msg_info() << "Copying " << inputTetrahedra.size() << " tetrahedra from topology.";
     helper::WriteAccessor< Data< type::vector<Tetrahedron> > > tetrahedra = d_tetrahedra;
     tetrahedra.clear();
     tetrahedra.resize(inputTetrahedra.size());
@@ -296,7 +296,7 @@ void OglVolumetricModel::computeMeshFromTopology()
         
     // update Hexahedrons
     const SeqHexahedra& inputHexahedra = m_topology->getHexahedra();
-    msg_info() << "OglVolumetricModel: copying " << inputHexahedra.size() << " hexahedra from topology.";
+    msg_info() << "Copying " << inputHexahedra.size() << " hexahedra from topology.";
     helper::WriteAccessor< Data< type::vector<Hexahedron> > > hexahedra = d_hexahedra;
     hexahedra.clear();
     hexahedra.resize(inputHexahedra.size());

--- a/applications/plugins/image/ImageContainer.h
+++ b/applications/plugins/image/ImageContainer.h
@@ -602,8 +602,8 @@ protected:
 
         if(lastUnderscorePosition == std::string::npos)
         {
-            msg_error() << filenameError << currentFname;
-            msg_error() << filenameDescription;
+            msg_error() << filenameError << currentFname << msgendl
+                        << filenameDescription;
             return "";
         }
 
@@ -613,8 +613,8 @@ protected:
 
         if(nextDotPosition == std::string::npos)
         {
-            msg_error() << filenameError << currentFname;
-            msg_error() << filenameDescription;
+            msg_error() << filenameError << currentFname << msgendl
+                           filenameDescription;
             return "";
         }
 

--- a/applications/plugins/image/ImageContainer.h
+++ b/applications/plugins/image/ImageContainer.h
@@ -614,7 +614,7 @@ protected:
         if(nextDotPosition == std::string::npos)
         {
             msg_error() << filenameError << currentFname << msgendl
-                           filenameDescription;
+                        << filenameDescription;
             return "";
         }
 

--- a/applications/plugins/image/ImageContainer.h
+++ b/applications/plugins/image/ImageContainer.h
@@ -95,7 +95,7 @@ struct ImageContainerSpecialization< defaulttype::Image<T> >
                 if( !container->loadCamera() )
                 {
                     wimage->getCImgList().push_back(cimg_library::CImg<T>());
-                    container->serr << "no input image" << container->sendl;
+                    msg_error(container) << "no input image" ;
                 }
     }
 
@@ -160,7 +160,7 @@ struct ImageContainerSpecialization< defaulttype::Image<T> >
                 // nfo files are used for compatibility with gridmaterial of frame and voxelize rplugins
 
                 std::ifstream fileStream (fname.c_str(), std::ifstream::in);
-                if (!fileStream.is_open()) { container->serr << "Cannot open " << fname << container->sendl; return false; }
+                if (!fileStream.is_open()) { msg_error(container) << "Cannot open " << fname ; return false; }
                 std::string str;
                 fileStream >> str;	char vtype[32]; fileStream.getline(vtype,32);
                 type::Vec<3,unsigned int> dim;  fileStream >> str; fileStream >> dim;
@@ -463,7 +463,7 @@ protected:
         std::string fname(this->m_filename.getFullPath());
         if (!sofa::helper::system::DataRepository.findFile(fname))
         {
-            serr << "ImageContainer: cannot find "<<fname<<sendl;
+            msg_error() << "ImageContainer: cannot find "<<fname;
             return false;
         }
         fname=sofa::helper::system::DataRepository.getFile(fname);
@@ -570,7 +570,7 @@ protected:
 
         if (!sofa::helper::system::DataRepository.findFile(nextFname))
         {
-            serr << "ImageContainer: cannot find "<<fname<<sendl;
+            msg_error() << "ImageContainer: cannot find "<<fname;
             return false;
         }
 
@@ -602,8 +602,8 @@ protected:
 
         if(lastUnderscorePosition == std::string::npos)
         {
-            serr << filenameError << currentFname << sendl;
-            serr << filenameDescription << sendl;
+            msg_error() << filenameError << currentFname;
+            msg_error() << filenameDescription;
             return "";
         }
 
@@ -613,8 +613,8 @@ protected:
 
         if(nextDotPosition == std::string::npos)
         {
-            serr << filenameError << currentFname << sendl;
-            serr << filenameDescription << sendl;
+            msg_error() << filenameError << currentFname;
+            msg_error() << filenameDescription;
             return "";
         }
 

--- a/applications/plugins/image/ImageCoordValuesFromPositions.h
+++ b/applications/plugins/image/ImageCoordValuesFromPositions.h
@@ -81,7 +81,7 @@ struct ImageCoordValuesFromPositionsSpecialization<defaulttype::Image<T>>
 
         if(img.spectrum()!=3)
         {
-            This.serr<<"input image must have 3 channels"<<This.sendl;
+            msg_error(&This) <<"input image must have 3 channels";
             return;
         }
 

--- a/applications/plugins/image/ImageExporter.h
+++ b/applications/plugins/image/ImageExporter.h
@@ -78,12 +78,12 @@ struct ImageExporterSpecialization<defaulttype::Image<T>>
     {
         typedef typename ImageExporterT::Real Real;
 
-        if (!exporter.m_filename.isSet()) { exporter.serr << "ImageExporter: file not set"<<exporter.name<<exporter.sendl; return false; }
+        if (!exporter.m_filename.isSet()) { msg_error(&exporter) << "ImageExporter: file not set"<<exporter.name; return false; }
         std::string fname(exporter.m_filename.getFullPath());
 
         typename ImageExporterT::raImage rimage(exporter.image);
         typename ImageExporterT::raTransform rtransform(exporter.transform);
-        if (rimage->isEmpty()) { exporter.serr << "ImageExporter: no image "<<exporter.name<<exporter.sendl; return false; }
+        if (rimage->isEmpty()) { msg_error(&exporter) << "ImageExporter: no image "<<exporter.name; return false; }
 
         if(fname.find(".mhd")!=std::string::npos || fname.find(".MHD")!=std::string::npos || fname.find(".Mhd")!=std::string::npos
            || fname.find(".raw")!=std::string::npos || fname.find(".RAW")!=std::string::npos || fname.find(".Raw")!=std::string::npos)
@@ -105,7 +105,7 @@ struct ImageExporterSpecialization<defaulttype::Image<T>>
         {
             // nfo files are used for compatibility with gridmaterial of frame and voxelizer plugins
             std::ofstream fileStream (fname.c_str(), std::ofstream::out);
-            if (!fileStream.is_open()) { exporter.serr << "GridMaterial, Can not open " << fname << exporter.sendl; return false; }
+            if (!fileStream.is_open()) { msg_error(&exporter) << "GridMaterial, Can not open " << fname ; return false; }
             fileStream << "voxelType: " << cimg_library::CImg<T>::pixel_type() << std::endl;
             fileStream << "dimensions: " << rimage->getDimensions()[0] << " " << rimage->getDimensions()[1]<< " " << rimage->getDimensions()[2]  << std::endl;
             fileStream << "origin: " << rtransform->getTranslation()[0] << " " << rtransform->getTranslation()[1]<< " " << rtransform->getTranslation()[2]<< std::endl;

--- a/applications/plugins/image/ImageExporter.h
+++ b/applications/plugins/image/ImageExporter.h
@@ -78,12 +78,12 @@ struct ImageExporterSpecialization<defaulttype::Image<T>>
     {
         typedef typename ImageExporterT::Real Real;
 
-        if (!exporter.m_filename.isSet()) { msg_error(&exporter) << "ImageExporter: file not set"<<exporter.name; return false; }
+        if (!exporter.m_filename.isSet()) { msg_error(&exporter) << "File not set"<<exporter.name; return false; }
         std::string fname(exporter.m_filename.getFullPath());
 
         typename ImageExporterT::raImage rimage(exporter.image);
         typename ImageExporterT::raTransform rtransform(exporter.transform);
-        if (rimage->isEmpty()) { msg_error(&exporter) << "ImageExporter: no image "<<exporter.name; return false; }
+        if (rimage->isEmpty()) { msg_error(&exporter) << "No image "<<exporter.name; return false; }
 
         if(fname.find(".mhd")!=std::string::npos || fname.find(".MHD")!=std::string::npos || fname.find(".Mhd")!=std::string::npos
            || fname.find(".raw")!=std::string::npos || fname.find(".RAW")!=std::string::npos || fname.find(".Raw")!=std::string::npos)

--- a/applications/plugins/image/ImageSampler.h
+++ b/applications/plugins/image/ImageSampler.h
@@ -205,7 +205,7 @@ struct ImageSamplerSpecialization<defaulttype::Image<T>>
             case FASTMARCHING : fastMarching<Real,T>(trial,dist, voronoi, sampler->transform.getValue().getScale(),biasFactor ); break;
             case DIJKSTRA : dijkstra<Real,T>(trial,dist, voronoi, sampler->transform.getValue().getScale(), biasFactor); break;
             case PARALLELMARCHING : parallelMarching<Real,T>(dist, voronoi, sampler->transform.getValue().getScale(), pmmIter, pmmTol, biasFactor); break;
-            default : sampler->serr << "Unknown Distance Field Computation Method" << sampler->sendl; break;
+            default : msg_error(sampler) << "Unknown Distance Field Computation Method" ; break;
             };
         }
 
@@ -226,7 +226,7 @@ struct ImageSamplerSpecialization<defaulttype::Image<T>>
                 case FASTMARCHING : fastMarching<Real,T>(trial,dist, voronoi, sampler->transform.getValue().getScale(),biasFactor ); break;
                 case DIJKSTRA : dijkstra<Real,T>(trial,dist, voronoi, sampler->transform.getValue().getScale(), biasFactor); break;
                 case PARALLELMARCHING : parallelMarching<Real,T>(dist, voronoi, sampler->transform.getValue().getScale(), pmmIter, pmmTol, biasFactor); break;
-                default : sampler->serr << "Unknown Distance Field Computation Method" << sampler->sendl; break;
+                default : msg_error(sampler) << "Unknown Distance Field Computation Method" ; break;
                 };
             }
             else break;
@@ -250,7 +250,7 @@ struct ImageSamplerSpecialization<defaulttype::Image<T>>
                 case FASTMARCHING : fastMarching<Real,T>(trial,dist, voronoi, sampler->transform.getValue().getScale(),biasFactor ); break;
                 case DIJKSTRA : dijkstra<Real,T>(trial,dist, voronoi, sampler->transform.getValue().getScale(), biasFactor); break;
                 case PARALLELMARCHING : parallelMarching<Real,T>(dist, voronoi, sampler->transform.getValue().getScale(), pmmIter, pmmTol, biasFactor); break;
-                default : sampler->serr << "Unknown Distance Field Computation Method" << sampler->sendl; break;
+                default : msg_error(sampler) << "Unknown Distance Field Computation Method" ; break;
                 };
                 it++; if(it>=lloydIt) converged=true;
             }
@@ -320,7 +320,7 @@ struct ImageSamplerSpecialization<defaulttype::Image<T>>
             case FASTMARCHING : fastMarching<Real,T>(trial,dist, voronoi, sampler->transform.getValue().getScale(),biasFactor ); break;
             case DIJKSTRA : dijkstra<Real,T>(trial,dist, voronoi, sampler->transform.getValue().getScale(), biasFactor); break;
             case PARALLELMARCHING : parallelMarching<Real,T>(dist, voronoi, sampler->transform.getValue().getScale(), pmmIter, pmmTol, biasFactor); break;
-            default : sampler->serr << "Unknown Distance Field Computation Method" << sampler->sendl; break;
+            default : msg_error(sampler) << "Unknown Distance Field Computation Method" ; break;
             };
         }
 
@@ -350,7 +350,7 @@ struct ImageSamplerSpecialization<defaulttype::Image<T>>
                 case FASTMARCHING : fastMarching<Real,T>(trial,dist, voronoi, sampler->transform.getValue().getScale(),biasFactor ); break;
                 case DIJKSTRA : dijkstra<Real,T>(trial,dist, voronoi, sampler->transform.getValue().getScale(), biasFactor); break;
                 case PARALLELMARCHING : parallelMarching<Real,T>(dist, voronoi, sampler->transform.getValue().getScale(), pmmIter, pmmTol, biasFactor); break;
-                default : sampler->serr << "Unknown Distance Field Computation Method" << sampler->sendl; break;
+                default : msg_error(sampler) << "Unknown Distance Field Computation Method" ; break;
                 };
             }
 
@@ -372,7 +372,7 @@ struct ImageSamplerSpecialization<defaulttype::Image<T>>
                     case FASTMARCHING : fastMarching<Real,T>(trial,dist, voronoi, sampler->transform.getValue().getScale(),biasFactor ); break;
                     case DIJKSTRA : dijkstra<Real,T>(trial,dist, voronoi, sampler->transform.getValue().getScale(), biasFactor); break;
                     case PARALLELMARCHING : parallelMarching<Real,T>(dist, voronoi, sampler->transform.getValue().getScale(), pmmIter, pmmTol, biasFactor); break;
-                    default : sampler->serr << "Unknown Distance Field Computation Method" << sampler->sendl; break;
+                    default : msg_error(sampler) << "Unknown Distance Field Computation Method" ; break;
                     };
                     it++; if(it>=lloydIt) converged=true;
                 }

--- a/applications/plugins/image/ImageTransform.h
+++ b/applications/plugins/image/ImageTransform.h
@@ -88,7 +88,7 @@ public:
     {
         container = this->getContext()->template get<ImageContainer>(core::objectmodel::BaseContext::SearchUp);
         if (!container)
-            serr << "No ImageContainer found" << sendl;
+            msg_error() << "No ImageContainer found";
 
         reinit();
     }

--- a/applications/plugins/image/MeshToImageEngine.h
+++ b/applications/plugins/image/MeshToImageEngine.h
@@ -178,7 +178,7 @@ public:
                 if(meshId>=this->vf_FillInside.size() || this->vf_FillInside[meshId]->getValue())
                 {
                     this->vf_InsideValues[meshId]->setValue(this->vf_values[meshId]->getValue()[0]);
-                    serr<<"InsideValue["<<meshId<<"] is not set -> used Value["<<meshId<<"]="<<this->vf_values[meshId]->getValue()[0]<<" instead"<<sendl;
+                    msg_error()<<"InsideValue["<<meshId<<"] is not set -> used Value["<<meshId<<"]="<<this->vf_values[meshId]->getValue()[0]<<" instead";
                 }
 
 

--- a/applications/plugins/image/MeshToImageEngine.h
+++ b/applications/plugins/image/MeshToImageEngine.h
@@ -178,7 +178,7 @@ public:
                 if(meshId>=this->vf_FillInside.size() || this->vf_FillInside[meshId]->getValue())
                 {
                     this->vf_InsideValues[meshId]->setValue(this->vf_values[meshId]->getValue()[0]);
-                    msg_error()<<"InsideValue["<<meshId<<"] is not set -> used Value["<<meshId<<"]="<<this->vf_values[meshId]->getValue()[0]<<" instead";
+                    msg_warning()<<"InsideValue["<<meshId<<"] is not set -> used Value["<<meshId<<"]="<<this->vf_values[meshId]->getValue()[0]<<" instead";
                 }
 
 

--- a/applications/plugins/image/imagetoolbox/contour/contourimagetoolbox.h
+++ b/applications/plugins/image/imagetoolbox/contour/contourimagetoolbox.h
@@ -121,7 +121,7 @@ public:
         addInput(&d_transform);
         addOutput(&d_imageOut);
 
-        raImage im(this->d_image);    if( ! im->getCImgList().size() ) {serr<<"no input image"<<sendl; return;}
+        raImage im(this->d_image);    if( ! im->getCImgList().size() ) { msg_error() <<"no input image"; return;}
 
         color.setValue(im->getCImg().min());
 

--- a/modules/SofaConstraint/src/SofaConstraint/ConstraintAnimationLoop.cpp
+++ b/modules/SofaConstraint/src/SofaConstraint/ConstraintAnimationLoop.cpp
@@ -333,7 +333,7 @@ void ConstraintAnimationLoop::init()
 void ConstraintAnimationLoop::launchCollisionDetection(const core::ExecParams* params)
 {
     dmsg_info_when(EMIT_EXTRA_DEBUG_MESSAGE)
-            <<"computeCollision is called"<<sendl;
+            <<"computeCollision is called";
 
     ////////////////// COLLISION DETECTION///////////////////////////////////////////////////////////////////////////////////////////
     sofa::helper::AdvancedTimer::stepBegin("Collision");

--- a/modules/SofaConstraint/src/SofaConstraint/PrecomputedConstraintCorrection.inl
+++ b/modules/SofaConstraint/src/SofaConstraint/PrecomputedConstraintCorrection.inl
@@ -295,10 +295,8 @@ void PrecomputedConstraintCorrection<DataTypes>::bwdInit()
         std::stringstream tmpStr;
         for (unsigned int f = 0; f < nbNodes; f++)
         {
-            std::streamsize prevPrecision = sout.precision();
             tmpStr.precision(2);
             tmpStr << "Precomputing constraint correction : " << std::fixed << (float)f / (float)nbNodes * 100.0f << " %   " << '\xd';
-            sout.precision(prevPrecision);
 
             for (unsigned int i = 0; i < dof_on_node; i++)
             {

--- a/modules/SofaExporter/src/SofaExporter/MeshExporter.cpp
+++ b/modules/SofaExporter/src/SofaExporter/MeshExporter.cpp
@@ -75,7 +75,7 @@ void MeshExporter::doReInit()
 
     if (!m_inputtopology)
     {
-        msg_error() << "Error, no topology." << sendl;
+        msg_error() << "Error, no topology.";
         d_componentState.setValue(ComponentState::Invalid) ;
         return;
     }

--- a/modules/SofaExporter/src/SofaExporter/VTKExporter.cpp
+++ b/modules/SofaExporter/src/SofaExporter/VTKExporter.cpp
@@ -855,7 +855,7 @@ void VTKExporter::writeParallelFile()
                 if (!obj)
                     msg_error() << "VTKExporter : error while fetching data field '"
                          << cellsDataField[i] << "' of object '" << cellsDataObject[i]
-                            << "', check object name" << sendl;
+                            << "', check object name" << msgendl;
                 else if (!field)
                     msg_error() << "VTKExporter : error while fetching data field '" << msgendl
                                 << cellsDataField[i] << "' of object '" << cellsDataObject[i] << msgendl

--- a/modules/SofaGeneralAnimationLoop/src/SofaGeneralAnimationLoop/MechanicalMatrixMapper.inl
+++ b/modules/SofaGeneralAnimationLoop/src/SofaGeneralAnimationLoop/MechanicalMatrixMapper.inl
@@ -70,7 +70,7 @@ void MechanicalMatrixMapper<DataTypes1, DataTypes2>::init()
 
     if(l_nodeToParse.get() == nullptr)
     {
-        msg_error() << " failed to initialized -> missing/wrong link " << l_nodeToParse.getName() << " : " << l_nodeToParse.getLinkedPath() << sendl;
+        msg_error() << " failed to initialized -> missing/wrong link " << l_nodeToParse.getName() << " : " << l_nodeToParse.getLinkedPath();
         this->d_componentState.setValue(ComponentState::Invalid) ;
         return;
     }
@@ -79,7 +79,7 @@ void MechanicalMatrixMapper<DataTypes1, DataTypes2>::init()
 
     if (mstate1.get() == nullptr || mstate2.get() == nullptr)
     {
-        msg_error() << " failed to initialized -> missing/wrong link " << mstate1.getName() << " or " << mstate2.getName() << sendl;
+        msg_error() << " failed to initialized -> missing/wrong link " << mstate1.getName() << " or " << mstate2.getName();
         this->d_componentState.setValue(ComponentState::Invalid) ;
         return;
     }

--- a/modules/SofaGeneralAnimationLoop/src/SofaGeneralAnimationLoop/MultiTagAnimationLoop.cpp
+++ b/modules/SofaGeneralAnimationLoop/src/SofaGeneralAnimationLoop/MultiTagAnimationLoop.cpp
@@ -106,7 +106,7 @@ void MultiTagAnimationLoop::step(const sofa::core::ExecParams* params, SReal dt)
         dmsg_info() << "step, end collision" ;
         dmsg_info() << "step, begin integration  for tag: "<< *it ;
         integrate(params, dt);
-        dmsg_info() << "end integration" << sendl;
+        dmsg_info() << "end integration" << msgendl;
 
         this->removeTag (*it);
     }

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/TransformPosition.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/TransformPosition.inl
@@ -225,7 +225,7 @@ void TransformPosition<DataTypes>::getTransfoFromTfm()
     }
     else
     {
-        msg_error() << "Could not open file " << fname << sendl << "Matrix set to identity";
+        msg_error() << "Could not open file " << fname << msgendl << "Matrix set to identity";
     }
 }
 
@@ -303,7 +303,7 @@ void TransformPosition<DataTypes>::getTransfoFromTrm()
     }
     else
     {
-        msg_error() << "Could not open file " << fname << sendl << "Matrix set to identity";
+        msg_error() << "Could not open file " << fname << msgendl << "Matrix set to identity";
     }
 
 }
@@ -366,7 +366,7 @@ void TransformPosition<DataTypes>::getTransfoFromTxt()
     }
     else
     {
-        msg_error() << "Could not open file " << fname << sendl << "Matrix set to identity";
+        msg_error() << "Could not open file " << fname << msgendl << "Matrix set to identity";
     }
 }
 

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.inl
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.inl
@@ -137,7 +137,7 @@ void TriangularFEMForceFieldOptim<DataTypes>::parse( sofa::core::objectmodel::Ba
     const char* method = arg->getAttribute("method");
     if (method && *method && std::string(method) != std::string("large"))
     {
-        msg_warning() << "Attribute method was specified as \""<<method<<"\" while this version only implements the \"large\" method. Ignoring..." << sendl;
+        msg_warning() << "Attribute method was specified as \""<<method<<"\" while this version only implements the \"large\" method. Ignoring...";
     }
     Inherited::parse(arg);
 }
@@ -591,7 +591,7 @@ void TriangularFEMForceFieldOptim<DataTypes>::draw(const core::visual::VisualPar
         else
         {
             drawPrevMaxStress = maxStress;
-            msg_info() << "max stress = " << maxStress << sendl;
+            msg_info() << "max stress = " << maxStress;
         }
         if (d_showStressMaxValue.isSet())
         {

--- a/modules/SofaMiscExtra/src/SofaMiscExtra/MeshTetraStuffing.cpp
+++ b/modules/SofaMiscExtra/src/SofaMiscExtra/MeshTetraStuffing.cpp
@@ -253,13 +253,13 @@ void MeshTetraStuffing::init()
                         {
                             eBDist[p1][e] = results[i].t - d;
                             if (eBDist[p1][e] < 0.00001)
-                                msg_info() << "WARNING: point " << p1 << " is too close to the surface on edge " << e << " : alpha = " << eBDist[p1][e]<<sendl;
+                                msg_info() << "WARNING: point " << p1 << " is too close to the surface on edge " << e << " : alpha = " << eBDist[p1][e];
                         }
                         if (i > 0)
                         {
                             eBDist[p1][e+1] = d - results[i-1].t;
                             if (eBDist[p1][e+1] < 0.00001)
-                                msg_info() << "WARNING: point " << p1 << " is too close to the surface on edge " << e+1 << " : alpha = " << eBDist[p1][e+1]<<sendl;
+                                msg_info() << "WARNING: point " << p1 << " is too close to the surface on edge " << e+1 << " : alpha = " << eBDist[p1][e+1];
                         }
 
                         p1 = getEdgePoint2(p1,e);

--- a/modules/SofaMiscExtra/src/SofaMiscExtra/MeshTetraStuffing.cpp
+++ b/modules/SofaMiscExtra/src/SofaMiscExtra/MeshTetraStuffing.cpp
@@ -148,8 +148,8 @@ void MeshTetraStuffing::init()
 
     outP.resize(gsize[0]*gsize[1]*gsize[2] + hsize[0]*hsize[1]*hsize[2]);
 
-    msg_info() << "Grid 1 size " << gsize[0] << "x" << gsize[1] << "x" << gsize[2] << ", total " << gsize[0]*gsize[1]*gsize[2];
-    msg_info() << "Grid 2 size " << hsize[0] << "x" << hsize[1] << "x" << hsize[2] << ", total " << hsize[0]*hsize[1]*hsize[2];
+    msg_info() << "Grid 1 size " << gsize[0] << "x" << gsize[1] << "x" << gsize[2] << ", total " << gsize[0]*gsize[1]*gsize[2] << msgendl
+               << "Grid 2 size " << hsize[0] << "x" << hsize[1] << "x" << hsize[2] << ", total " << hsize[0]*hsize[1]*hsize[2];
 
     ph0 = gsize[0]*gsize[1]*gsize[2];
     int p = 0;
@@ -253,13 +253,13 @@ void MeshTetraStuffing::init()
                         {
                             eBDist[p1][e] = results[i].t - d;
                             if (eBDist[p1][e] < 0.00001)
-                                msg_info() << "WARNING: point " << p1 << " is too close to the surface on edge " << e << " : alpha = " << eBDist[p1][e];
+                                msg_info() << "Point " << p1 << " is too close to the surface on edge " << e << " : alpha = " << eBDist[p1][e];
                         }
                         if (i > 0)
                         {
                             eBDist[p1][e+1] = d - results[i-1].t;
                             if (eBDist[p1][e+1] < 0.00001)
-                                msg_info() << "WARNING: point " << p1 << " is too close to the surface on edge " << e+1 << " : alpha = " << eBDist[p1][e+1];
+                                msg_info() << "Point " << p1 << " is too close to the surface on edge " << e+1 << " : alpha = " << eBDist[p1][e+1];
                         }
 
                         p1 = getEdgePoint2(p1,e);
@@ -627,7 +627,7 @@ void MeshTetraStuffing::addTetra(SeqTetrahedra& outT, SeqPoints& outP, int p1, i
         Real vol6 = a*(b.cross(c));
         if (vol6 < 0)
         {
-            msg_info() << "MeshTetraStuffing("<<line<<"): WARNING: grid tetra " << p1 << " " << p2 << " " << p3 << " " << p4 << " is inverted.";
+            msg_info() << "line("<<line<<"): grid tetra " << p1 << " " << p2 << " " << p3 << " " << p4 << " is inverted.";
             int tmp = p3; p3 = p4; p4 = tmp;
         }
     }

--- a/modules/SofaMiscSolver/src/SofaMiscSolver/NewmarkImplicitSolver.cpp
+++ b/modules/SofaMiscSolver/src/SofaMiscSolver/NewmarkImplicitSolver.cpp
@@ -125,7 +125,7 @@ void NewmarkImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa
 
     matrix.setSystemMBKMatrix(MechanicalMatrix::K * (-h*h*beta - h*rK*gamma) + MechanicalMatrix::B*(-h)*gamma + MechanicalMatrix::M * (1 + h*gamma*rM));
 
-    msg_info()<<"matrix = "<< MechanicalMatrix::K *(-h*h*beta + -h*rK*gamma) + MechanicalMatrix::M * (1 + h*gamma*rM) << " = " << matrix<<sendl;
+    msg_info()<<"matrix = "<< MechanicalMatrix::K *(-h*h*beta + -h*rK*gamma) + MechanicalMatrix::M * (1 + h*gamma*rM) << " = " << matrix;
     matrix.solve(aResult, b);
     msg_info() << "a1 = " << aResult;
 

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglCylinderModel.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglCylinderModel.cpp
@@ -171,7 +171,7 @@ void OglCylinderModel::exportOBJ(std::string name, std::ostream* out, std::ostre
     for( size_t i = 0 ; i < edges.size() ; i++ )
         *out << "f " << edges[i][0]+vindex+1 << " " << edges[i][1]+vindex+1 << '\n';
 
-    *out << sendl;
+    *out << std::endl;
 
     vindex += nbv;
 }

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglShader.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglShader.cpp
@@ -587,7 +587,7 @@ void OglShaderElement::init()
 
     if (shaders.empty())
     {
-        msg_error() << this->getTypeName() <<" \"" << this->getName() << "\": no relevant shader found. please check tags validity"<< sendl;
+        msg_error() << this->getTypeName() <<" \"" << this->getName() << "\": no relevant shader found. please check tags validity";
         return;
     }
 }

--- a/modules/SofaPreconditioner/src/SofaPreconditioner/PrecomputedWarpPreconditioner.inl
+++ b/modules/SofaPreconditioner/src/SofaPreconditioner/PrecomputedWarpPreconditioner.inl
@@ -237,7 +237,7 @@ void PrecomputedWarpPreconditioner<TDataTypes>::loadMatrixWithCSparse(TMatrix& M
         {
             tmpStr.precision(2);
             tmpStr << "Precomputing constraint correction : " << std::fixed << (float)(j*dof_on_node+d)*100.0f/(float)(nb_dofs*dof_on_node) << " %   " << '\xd'
-                   << sendl;
+                   << "\n";
 
             b.set(pid_j*dof_on_node+d,1.0);
             solver.solve(M,r,b);


### PR DESCRIPTION
sout/serr (and sendl) were wrappers for std::cout & std::cerr to get access to the streams for the GUIs initially.

After the introduction of the Messaging system, it was deemed deprecated (there is even a compat layer, redirecting sout/serr to msg_info(), msg_warning(), etc), but never enforced and never publicized actually.

This PR officially deprecates it by still being able to use it but will warn at compilation time if anybody uses the stream operators with serr/sendl. (you can see that on the CI log for the soon-to-be-dropped plugin like Flexible or Compliant)

This PR also (should) remove all those serr/sout/sendl in SOFA itself and the supported plugins.

EDIT: Adding "breaking" label because serr was throwing "WARNING" before (yeah makes sense), so it cannot be replaced 1-on-1 with msg_error( could be msg_warning as well)

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
