### PR TITLE
[SofaCore] Add const version of getMSState to Mass

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/Mass.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/Mass.h
@@ -68,7 +68,7 @@ public:
 
     /// Retrieve the associated MechanicalState
     MechanicalState<DataTypes>* getMState() { return this->mstate.get(); }
-    const MechanicalState<DataTypes>* getMState() { return this->mstate.get(); }
+    const MechanicalState<DataTypes>* getMState() const { return this->mstate.get(); }
 
 
     /// @name Vector operations

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/Mass.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/Mass.h
@@ -68,6 +68,7 @@ public:
 
     /// Retrieve the associated MechanicalState
     MechanicalState<DataTypes>* getMState() { return this->mstate.get(); }
+    const MechanicalState<DataTypes>* getMState() { return this->mstate.get(); }
 
 
     /// @name Vector operations


### PR DESCRIPTION
Without this patch, its not possible to call getMSState from the getPotentialEnergy in Mass (well, at least its not possible without casting to a ForceField). This makes it easier