### PR TITLE
[SofaGeneralDeformable] Add option to enable/disable spring display in TriangularBendingSprings

### DIFF
--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.h
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.h
@@ -68,6 +68,7 @@ public:
 
     Data<double> f_ks; ///< uniform stiffness for the all springs
     Data<double> f_kd; ///< uniform damping for the all springs
+    Data<bool> d_showSprings; ///< Option to enable/disable the spring display when showForceField is on. True by default
 
     /// Link to be set to the topology container in the component graph.
     SingleLink<TriangularBendingSprings<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.inl
@@ -384,6 +384,7 @@ template<class DataTypes>
 TriangularBendingSprings<DataTypes>::TriangularBendingSprings(/*double _ks, double _kd*/)
     : f_ks(initData(&f_ks,(double) 100000.0,"stiffness","uniform stiffness for the all springs")) //(Real)0.3 ??
     , f_kd(initData(&f_kd,(double) 1.0,"damping","uniform damping for the all springs")) // (Real)1000. ??
+    , d_showSprings(initData(&d_showSprings, true, "showSprings", "option to draw springs"))
     , l_topology(initLink("topology", "link to the topology container"))
     , edgeInfo(initData(&edgeInfo, "edgeInfo", "Internal edge data"))
     , updateMatrix(true)
@@ -675,6 +676,7 @@ template<class DataTypes>
 void TriangularBendingSprings<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
     unsigned int i;
+    if (!d_showSprings.getValue()) { return; }
     if (!vparams->displayFlags().getShowForceFields()) {return;}
     if (!this->mstate) {return;}
 

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.inl
@@ -675,7 +675,6 @@ void TriangularBendingSprings<DataTypes>::addDForce(const core::MechanicalParams
 template<class DataTypes>
 void TriangularBendingSprings<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
-    unsigned int i;
     if (!d_showSprings.getValue()) { return; }
     if (!vparams->displayFlags().getShowForceFields()) {return;}
     if (!this->mstate) {return;}
@@ -691,16 +690,16 @@ void TriangularBendingSprings<DataTypes>::draw(const core::visual::VisualParams*
     std::vector<sofa::type::RGBAColor> colors;
 
     vparams->drawTool()->disableLighting();
-    const type::vector<EdgeInformation>& edgeInf = edgeInfo.getValue();
-    for(i=0; i<edgeInf.size(); ++i)
+    const type::vector<EdgeInformation>& edgeInfos = edgeInfo.getValue();
+    for(auto& edgeInfo : edgeInfos)
     {
-        if(edgeInf[i].is_activated)
+        if(edgeInfo.is_activated)
         {
             bool external=true;
-            Real d = (x[edgeInf[i].m2]-x[edgeInf[i].m1]).norm();
+            Real d = (x[edgeInfo.m2]-x[edgeInfo.m1]).norm();
             if (external)
             {
-                if (d<edgeInf[i].restlength*0.9999)
+                if (d<edgeInfo.restlength*0.9999)
                 {
                     colors.push_back(sofa::type::RGBAColor::red());
                 }
@@ -711,7 +710,7 @@ void TriangularBendingSprings<DataTypes>::draw(const core::visual::VisualParams*
             }
             else
             {
-                if (d<edgeInf[i].restlength*0.9999)
+                if (d<edgeInfo.restlength*0.9999)
                 {
                     colors.push_back(sofa::type::RGBAColor(1,0.5, 0,1));
                 }
@@ -721,8 +720,8 @@ void TriangularBendingSprings<DataTypes>::draw(const core::visual::VisualParams*
                 }
             }
 
-            vertices.push_back( x[edgeInf[i].m1] );
-            vertices.push_back( x[edgeInf[i].m2] );
+            vertices.push_back( x[edgeInfo.m1] );
+            vertices.push_back( x[edgeInfo.m2] );
         }
     }
     vparams->drawTool()->drawLines(vertices, 1, colors);


### PR DESCRIPTION
- Option is set to true by default to not change the current behavior in SOFA
- also improve the EdgeInformation access in for loop in draw method.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
