### PR TITLE
[SofaBaseVisual] Fix VisualModelImpl updateTextures callback to not call init method

### DIFF
--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
@@ -235,7 +235,14 @@ VisualModelImpl::VisualModelImpl() //const std::string &name, std::string filena
 
     // add one identity matrix
     xforms.resize(1);
-
+        
+    addUpdateCallback("updateTextures", { &texturename },
+        [&](const core::DataTracker& tracker) -> sofa::core::objectmodel::ComponentState
+    {
+        SOFA_UNUSED(tracker);
+        m_textureChanged = true;
+        return sofa::core::objectmodel::ComponentState::Loading;
+    }, { &d_componentState });    
 }
 
 VisualModelImpl::~VisualModelImpl()
@@ -854,14 +861,6 @@ void VisualModelImpl::init()
 
     m_topology = l_topology.get();
     msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
-
-    addUpdateCallback("updateTextures", { &texturename },
-        [&](const core::DataTracker& tracker) -> sofa::core::objectmodel::ComponentState
-    {
-        SOFA_UNUSED(tracker);
-        m_textureChanged = true;
-        return sofa::core::objectmodel::ComponentState::Loading;
-    }, { &d_componentState });
 
     if (m_vertPosIdx.getValue().size() > 0 && m_vertices2.getValue().empty())
     { // handle case where vertPosIdx was initialized through a loader

--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
@@ -236,13 +236,6 @@ VisualModelImpl::VisualModelImpl() //const std::string &name, std::string filena
     // add one identity matrix
     xforms.resize(1);
 
-    addUpdateCallback("updateTextures", { &texturename },
-        [&](const core::DataTracker& tracker) -> sofa::core::objectmodel::ComponentState
-    {
-        SOFA_UNUSED(tracker);
-        m_textureChanged = true;
-        return sofa::core::objectmodel::ComponentState::Loading;
-    }, { &d_componentState });
 }
 
 VisualModelImpl::~VisualModelImpl()
@@ -294,13 +287,14 @@ void VisualModelImpl::drawVisual(const core::visual::VisualParams* vparams)
         if (m_textureChanged)
         {
             deleteTextures();
+            loadTexture(texturename.getFullPath());
             m_textureChanged = false;
         }
-        init();
         initVisual();
         updateBuffers();
         d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
     }
+
     //Update external buffers (like VBO) if the mesh change AFTER doing the updateVisual() process
     if(m_vertices2.isDirty())
     {
@@ -861,6 +855,13 @@ void VisualModelImpl::init()
     m_topology = l_topology.get();
     msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 
+    addUpdateCallback("updateTextures", { &texturename },
+        [&](const core::DataTracker& tracker) -> sofa::core::objectmodel::ComponentState
+    {
+        SOFA_UNUSED(tracker);
+        m_textureChanged = true;
+        return sofa::core::objectmodel::ComponentState::Loading;
+    }, { &d_componentState });
 
     if (m_vertPosIdx.getValue().size() > 0 && m_vertices2.getValue().empty())
     { // handle case where vertPosIdx was initialized through a loader


### PR DESCRIPTION
The callback on '''Data<string> texturename ''' was calling init() method. This can produce bugs as the init() method should be called only once to setup callbacks or init mesh.

Move this callback creation in init method and use loadTextures(...) instead of init() method.







______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
