### PR TITLE
[SofaBaseVisual] Split VisualModelImpl init method in several methods for more clarity

### DIFF
--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.h
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.h
@@ -389,6 +389,9 @@ public:
     void handleTopologyChange() override;
 
     void init() override;
+    void initFromTopology();
+    void initPositionFromVertices();
+    void initFromFileMesh();
 
     void initVisual() override;
 

--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.h
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.h
@@ -136,9 +136,6 @@ public:
     /// Rendering method.
     virtual void internalDraw(const core::visual::VisualParams* /*vparams*/, bool /*transparent*/) {}
 
-    template<class VecType>
-    void addTopoHandler(topology::PointData<VecType>* data, int algo = 0);
-
 public:
 
     sofa::core::objectmodel::DataFileName fileMesh;


### PR DESCRIPTION
- Split init method in 3 depending if mesh, data or topology is used. also Avoid recomputing topology at updateVisual
- also remove not working topologyHandler



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
