### PR TITLE
[SofaBaseVisual] Fix VisualModelImpl to use topologyData and callback to handle topological changes

### DIFF
--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
@@ -1003,6 +1003,25 @@ void VisualModelImpl::initFromTopology()
                 }
             }
         });
+        if (m_vtexcoords.isSet()) // Data set from loader as not part of the topology
+        {
+            m_vtexcoords.updateIfDirty();
+            m_vtexcoords.setParent(nullptr); // manually break the data link to follow topological changes
+            m_vtexcoords.createTopologyHandler(m_topology);
+            m_vtexcoords.setCreationCallback([this](Index pointIndex, TexCoord& tCoord,
+                const core::topology::BaseMeshTopology::Point& point,
+                const sofa::type::vector< Index >& ancestors,
+                const sofa::type::vector< double >& coefs)
+            {
+                const VecTexCoord& texcoords = m_vtexcoords.getValue();
+                tCoord = TexCoord(0, 0);
+                for (Index i = 0; i < ancestors.size(); i++)
+                {
+                    const TexCoord& tAnces = texcoords[ancestors[i]];
+                    tCoord += tAnces * coefs[i];
+                }
+            });
+        }
     }
 
 }

--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
@@ -920,6 +920,49 @@ void VisualModelImpl::initFromTopology()
     {
         m_handleDynamicTopology.setValue(false);
     }
+    // add the functions to handle topology changes.
+    if (m_handleDynamicTopology.getValue())
+    {
+        if (!m_triangles.getValue().empty())
+        {
+            m_triangles.createTopologyHandler(m_topology);
+            m_triangles.setCreationCallback([this](Index elemID, VisualTriangle& visuTri,
+                const core::topology::BaseMeshTopology::Triangle& topoTri,
+                const sofa::type::vector< Index >& ancestors,
+                const sofa::type::vector< double >& coefs)
+            {
+                SOFA_UNUSED(elemID);
+                visuTri = topoTri; // simple copy from topology Data
+            });
+        }
+
+        if (!m_edges.getValue().empty())
+        {
+            m_edges.createTopologyHandler(m_topology);
+            m_edges.setCreationCallback([this](Index elemID, VisualEdge& visuEdge,
+                const core::topology::BaseMeshTopology::Edge& topoEdge,
+                const sofa::type::vector< Index >& ancestors,
+                const sofa::type::vector< double >& coefs)
+            {
+                SOFA_UNUSED(elemID);
+                visuEdge = topoEdge; // simple copy from topology Data
+            });
+        }
+
+        if (!m_quads.getValue().empty())
+        {
+            m_quads.createTopologyHandler(m_topology);
+            m_quads.setCreationCallback([this](Index elemID, VisualQuad& visuQuad,
+                const core::topology::BaseMeshTopology::Quad& topoQuad,
+                const sofa::type::vector< Index >& ancestors,
+                const sofa::type::vector< double >& coefs)
+            {
+                SOFA_UNUSED(elemID);
+                visuQuad = topoQuad; // simple copy from topology Data
+            });
+        }
+    }
+
 }
 
 
@@ -946,31 +989,33 @@ void VisualModelImpl::computeNormals()
 
         for (std::size_t i = 0; i < triangles.size(); i++)
         {
-            const Coord& v1 = vertices[triangles[i][0]];
-            const Coord& v2 = vertices[triangles[i][1]];
-            const Coord& v3 = vertices[triangles[i][2]];
+            const VisualTriangle& triangle = triangles[i];
+            const Coord& v1 = vertices[ triangle[0] ];
+            const Coord& v2 = vertices[ triangle[1] ];
+            const Coord& v3 = vertices[ triangle[2] ];
             Coord n = cross(v2-v1, v3-v1);
 
-            normals[triangles[i][0]] += n;
-            normals[triangles[i][1]] += n;
-            normals[triangles[i][2]] += n;
+            normals[ triangle[0] ] += n;
+            normals[ triangle[1] ] += n;
+            normals[ triangle[2] ] += n;
         }
 
         for (std::size_t i = 0; i < quads.size(); i++)
         {
-            const Coord & v1 = vertices[quads[i][0]];
-            const Coord & v2 = vertices[quads[i][1]];
-            const Coord & v3 = vertices[quads[i][2]];
-            const Coord & v4 = vertices[quads[i][3]];
+            const VisualQuad& quad = quads[i];
+            const Coord & v1 = vertices[ quad[0] ];
+            const Coord & v2 = vertices[ quad[1] ];
+            const Coord & v3 = vertices[ quad[2] ];
+            const Coord & v4 = vertices[ quad[3] ];
             Coord n1 = cross(v2-v1, v4-v1);
             Coord n2 = cross(v3-v2, v1-v2);
             Coord n3 = cross(v4-v3, v2-v3);
             Coord n4 = cross(v1-v4, v3-v4);
 
-            normals[quads[i][0]] += n1;
-            normals[quads[i][1]] += n2;
-            normals[quads[i][2]] += n3;
-            normals[quads[i][3]] += n4;
+            normals[ quad[0] ] += n1;
+            normals[ quad[1] ] += n2;
+            normals[ quad[2] ] += n3;
+            normals[ quad[3] ] += n4;
         }
 
         for (std::size_t i = 0; i < normals.size(); i++)
@@ -994,31 +1039,33 @@ void VisualModelImpl::computeNormals()
 
         for (std::size_t i = 0; i < triangles.size() ; i++)
         {
-            const Coord & v1 = vertices[triangles[i][0]];
-            const Coord & v2 = vertices[triangles[i][1]];
-            const Coord & v3 = vertices[triangles[i][2]];
+            const VisualTriangle& triangle = triangles[i];
+            const Coord & v1 = vertices[ triangle[0] ];
+            const Coord & v2 = vertices[ triangle[1] ];
+            const Coord & v3 = vertices[ triangle[2] ];
             Coord n = cross(v2-v1, v3-v1);
 
-            normals[vertNormIdx[triangles[i][0]]] += n;
-            normals[vertNormIdx[triangles[i][1]]] += n;
-            normals[vertNormIdx[triangles[i][2]]] += n;
+            normals[vertNormIdx[ triangle[0] ]] += n;
+            normals[vertNormIdx[ triangle[1] ]] += n;
+            normals[vertNormIdx[ triangle[2] ]] += n;
         }
 
         for (std::size_t i = 0; i < quads.size() ; i++)
         {
-            const Coord & v1 = vertices[quads[i][0]];
-            const Coord & v2 = vertices[quads[i][1]];
-            const Coord & v3 = vertices[quads[i][2]];
-            const Coord & v4 = vertices[quads[i][3]];
+            const VisualQuad& quad = quads[i];
+            const Coord & v1 = vertices[ quad[0] ];
+            const Coord & v2 = vertices[ quad[1] ];
+            const Coord & v3 = vertices[ quad[2] ];
+            const Coord & v4 = vertices[ quad[3] ];
             Coord n1 = cross(v2-v1, v4-v1);
             Coord n2 = cross(v3-v2, v1-v2);
             Coord n3 = cross(v4-v3, v2-v3);
             Coord n4 = cross(v1-v4, v3-v4);
 
-            normals[vertNormIdx[quads[i][0]]] += n1;
-            normals[vertNormIdx[quads[i][1]]] += n2;
-            normals[vertNormIdx[quads[i][2]]] += n3;
-            normals[vertNormIdx[quads[i][3]]] += n4;
+            normals[vertNormIdx[ quad[0] ]] += n1;
+            normals[vertNormIdx[ quad[1] ]] += n2;
+            normals[vertNormIdx[ quad[2] ]] += n3;
+            normals[vertNormIdx[ quad[3] ]] += n4;
         }
 
         for (std::size_t i = 0; i < normals.size(); i++)
@@ -1450,142 +1497,6 @@ void VisualModelImpl::handleTopologyChange()
             break;
         }
 
-        case core::topology::TRIANGLESADDED:
-        {
-            if (!groups.getValue().empty())
-            {
-                groups.beginEdit()->clear();
-                groups.endEdit();
-            }
-
-            const sofa::core::topology::TrianglesAdded *ta = static_cast< const sofa::core::topology::TrianglesAdded * >( *itBegin );
-
-            VisualTriangle t;
-            const std::size_t nbAddedTriangles = ta->getNbAddedTriangles();
-            const std::size_t nbTririangles = triangles.size();
-
-            triangles.resize(nbTririangles + nbAddedTriangles);
-
-            for (std::size_t i = 0; i < nbAddedTriangles; ++i)
-            {
-                t[0] = visual_index_type(ta->triangleArray[i][0]);
-                t[1] = visual_index_type(ta->triangleArray[i][1]);
-                t[2] = visual_index_type(ta->triangleArray[i][2]);
-                triangles[nbTririangles + i] = t;
-            }
-
-            break;
-        }
-
-        case core::topology::QUADSADDED:
-        {
-            if (!groups.getValue().empty())
-            {
-                groups.beginEdit()->clear();
-                groups.endEdit();
-            }
-
-            const sofa::core::topology::QuadsAdded *qa = static_cast< const sofa::core::topology::QuadsAdded * >( *itBegin );
-
-            const std::size_t nbAddedQuads = qa->getNbAddedQuads();
-            const std::size_t nbQuaduads = quads.size();
-
-            quads.resize(nbQuaduads + nbAddedQuads);
-
-            for (std::size_t i = 0; i < nbAddedQuads; ++i)
-            {
-                const auto& rQuad = qa->getQuad(Size(i));
-
-                quads[nbQuaduads + i][0] = visual_index_type(rQuad[0]);
-                quads[nbQuaduads + i][1] = visual_index_type(rQuad[1]);
-                quads[nbQuaduads + i][2] = visual_index_type(rQuad[2]);
-                quads[nbQuaduads + i][3] = visual_index_type(rQuad[3]);
-            }
-
-            break;
-        }
-
-        case core::topology::TRIANGLESREMOVED:
-        {
-            if (!groups.getValue().empty())
-            {
-                groups.beginEdit()->clear();
-                groups.endEdit();
-            }
-
-            std::size_t last;
-
-            last = m_topology->getNbTriangles() - 1;
-
-            const auto &tab = ( static_cast< const sofa::core::topology::TrianglesRemoved *>( *itBegin ) )->getArray();
-
-            VisualTriangle tmp;
-
-            for (std::size_t i = 0; i <tab.size(); ++i)
-            {
-                visual_index_type ind_k = visual_index_type(tab[i]);
-
-                tmp = triangles[ind_k];
-                triangles[ind_k] = triangles[last];
-                triangles[last] = tmp;
-
-                std::size_t ind_last = triangles.size() - 1;
-
-                if(last != ind_last)
-                {
-                    tmp = triangles[last];
-                    triangles[last] = triangles[ind_last];
-                    triangles[ind_last] = tmp;
-                }
-
-                triangles.resize( triangles.size() - 1 );
-
-                --last;
-            }
-
-            break;
-        }
-
-        case core::topology::QUADSREMOVED:
-        {
-            if (!groups.getValue().empty())
-            {
-                groups.beginEdit()->clear();
-                groups.endEdit();
-            }
-
-            std::size_t last;
-
-            last = m_topology->getNbQuads() - 1;
-
-            const auto &tab = ( static_cast< const sofa::core::topology::QuadsRemoved *>( *itBegin ) )->getArray();
-
-            VisualQuad tmp;
-
-            for (std::size_t i = 0; i <tab.size(); ++i)
-            {
-                visual_index_type ind_k = visual_index_type(tab[i]);
-
-                tmp = quads[ind_k];
-                quads[ind_k] = quads[last];
-                quads[last] = tmp;
-
-                std::size_t ind_last = quads.size() - 1;
-
-                if(last != ind_last)
-                {
-                    tmp = quads[last];
-                    quads[last] = quads[ind_last];
-                    quads[ind_last] = tmp;
-                }
-
-                quads.resize( quads.size() - 1 );
-
-                --last;
-            }
-
-            break;
-        }
 
         case core::topology::POINTSREMOVED:
         {

--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.h
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.h
@@ -419,6 +419,14 @@ public:
 
     bool insertInNode( core::objectmodel::BaseNode* node ) override { Inherit1::insertInNode(node); Inherit2::insertInNode(node); return true; }
     bool removeInNode( core::objectmodel::BaseNode* node ) override { Inherit1::removeInNode(node); Inherit2::removeInNode(node); return true; }
+
+protected:
+    /// Internal buffer to be filled by topology Data @sa m_triangles callback when points are removed. Those dirty triangles will be updated at next updateVisual 
+    /// This avoid to update the whole mesh.
+    std::set< sofa::core::topology::BaseMeshTopology::TriangleID> m_dirtyTriangles;
+
+    /// Internal buffer similar to @sa m_dirtyTriangles but to be used by topolgy Data @sa m_quads callback when points are removed.
+    std::set< sofa::core::topology::BaseMeshTopology::QuadID> m_dirtyQuads;
 };
 
 

--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.h
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.h
@@ -30,7 +30,7 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/helper/io/Mesh.h>
-#include <SofaBaseTopology/TopologyData.h>
+#include <SofaBaseTopology/TopologyData.inl>
 #include <string>
 
 namespace sofa::component::visualmodel
@@ -384,9 +384,6 @@ public:
     virtual void deleteTextures() {}
 
     void updateVisual() override;
-
-    /// Handle topological changes
-    void handleTopologyChange() override;
 
     void init() override;
     void initFromTopology();

--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.h
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.h
@@ -30,7 +30,7 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/helper/io/Mesh.h>
-#include <SofaBaseTopology/TopologyData.inl>
+#include <SofaBaseTopology/TopologyData.h>
 #include <string>
 
 namespace sofa::component::visualmodel
@@ -118,9 +118,9 @@ public:
     topology::PointData< VecTexCoord > m_vtexcoords; ///< coordinates of the texture
     topology::PointData< VecCoord > m_vtangents; ///< tangents for normal mapping
     topology::PointData< VecCoord > m_vbitangents; ///< tangents for normal mapping
-    Data< VecVisualEdge > m_edges; ///< edges of the model
-    Data< VecVisualTriangle > m_triangles; ///< triangles of the model
-    Data< VecVisualQuad > m_quads; ///< quads of the model
+    topology::EdgeData< VecVisualEdge > m_edges; ///< edges of the model
+    topology::TriangleData< VecVisualTriangle > m_triangles; ///< triangles of the model
+    topology::QuadData< VecVisualQuad > m_quads; ///< quads of the model
 
     bool m_textureChanged {false};
 

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglModel.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglModel.cpp
@@ -993,7 +993,7 @@ void OglModel::updateBuffers()
 
             //Indices
             //Edges
-            if(useEdges)
+            if(useEdges && !edges.empty())
                 if(oldEdgesSize != edges.size())
                     initEdgesIndicesBuffer();
                 else
@@ -1002,7 +1002,7 @@ void OglModel::updateBuffers()
                 createEdgesIndicesBuffer();
 
             //Triangles
-            if(useTriangles)
+            if(useTriangles && !triangles.empty())
                 if(oldTrianglesSize != triangles.size())
                     initTrianglesIndicesBuffer();
                 else
@@ -1011,7 +1011,7 @@ void OglModel::updateBuffers()
                 createTrianglesIndicesBuffer();
 
             //Quads
-            if (useQuads)
+            if (useQuads && !quads.empty())
                 if(oldQuadsSize != quads.size())
                     initQuadsIndicesBuffer();
                 else


### PR DESCRIPTION
This PR depends on PR #2299 (should be rebased)

1. Use callback to update the list of triangles/quads and vertices when topological changes happened.
2. Add also callback on texcoord to update texture coordinate when mesh changed.



- Update of texture coordinates was buggy when removing points
<img src="https://user-images.githubusercontent.com/21199245/129899818-50ef6454-ca73-49fa-9a1a-f3284eb4915b.png" width="70%" />

- Adding new points where created with texCoord(0, 0)
<img src="https://user-images.githubusercontent.com/21199245/129899836-1a9ad38b-5359-447a-9d68-b11bb68f7813.png" width="70%" />


-> Using the callback on texcoords, use ancestors and coefficient of added point to apply the good texCoords
<img src="https://user-images.githubusercontent.com/21199245/129899846-178564ea-044d-4db8-a5fb-b4e318f0467e.png" width="70%" />

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
