### PR TITLE
[CImgPlugin] Add Threads dependency in Cmake

### DIFF
--- a/applications/plugins/CImgPlugin/CMakeLists.txt
+++ b/applications/plugins/CImgPlugin/CMakeLists.txt
@@ -22,6 +22,7 @@ sofa_find_package(CImg REQUIRED)
 # it will allow to use those instead of those present in XCode's frameworks
 set(CMAKE_FIND_FRAMEWORK LAST)
 
+sofa_find_package(Threads REQUIRED)
 sofa_find_package(TIFF QUIET)
 sofa_find_package(JPEG QUIET)
 sofa_find_package(PNG QUIET)
@@ -68,6 +69,7 @@ add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "$<BUILD_INTERFACE:${CImg_INCLUDE_DIRS}>")
 target_compile_options(${PROJECT_NAME} PUBLIC ${CIMG_CFLAGS})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaCore)
+target_link_libraries(${PROJECT_NAME} PUBLIC Threads::Threads)
 target_link_libraries(${PROJECT_NAME} PUBLIC ${DEP_TARGETS})
 
 if(SOFA_BUILD_RELEASE_PACKAGE OR CMAKE_SYSTEM_NAME STREQUAL Windows)


### PR DESCRIPTION
Got a missing linker reference to pthread with my configuration.
I suppose this does not appear on the CI because of some differences in the cmake config (packages?)

Related to the removal of boost::thread which was doing the job for everybody before.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
