### PR TITLE
[SofaBaseLinearSolver] Introduce GlobalSystemMatrixExporter

### DIFF
--- a/SofaKernel/modules/SofaBaseLinearSolver/CMakeLists.txt
+++ b/SofaKernel/modules/SofaBaseLinearSolver/CMakeLists.txt
@@ -18,6 +18,7 @@ set(HEADER_FILES
     ${SOFABASELINEARSOLVER_SRC}/FullMatrix.inl
     ${SOFABASELINEARSOLVER_SRC}/FullVector.h
     ${SOFABASELINEARSOLVER_SRC}/FullVector.inl
+    ${SOFABASELINEARSOLVER_SRC}/GlobalSystemMatrixExporter.h
     ${SOFABASELINEARSOLVER_SRC}/GraphScatteredTypes.h
     ${SOFABASELINEARSOLVER_SRC}/MatrixExpr.h
     ${SOFABASELINEARSOLVER_SRC}/MatrixLinearSolver.h
@@ -35,6 +36,7 @@ set(SOURCE_FILES
     ${SOFABASELINEARSOLVER_SRC}/DefaultMultiMatrixAccessor.cpp
     ${SOFABASELINEARSOLVER_SRC}/FullMatrix.cpp
     ${SOFABASELINEARSOLVER_SRC}/FullVector.cpp
+    ${SOFABASELINEARSOLVER_SRC}/GlobalSystemMatrixExporter.cpp
     ${SOFABASELINEARSOLVER_SRC}/GraphScatteredTypes.cpp
     ${SOFABASELINEARSOLVER_SRC}/MatrixLinearSolver.cpp
     ${SOFABASELINEARSOLVER_SRC}/SingleMatrixAccessor.cpp

--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/GlobalSystemMatrixExporter.cpp
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/GlobalSystemMatrixExporter.cpp
@@ -68,10 +68,8 @@ bool GlobalSystemMatrixExporter::write()
             {
                 const std::string filename = basename + "." + exporter->first;
                 msg_info() << "Writing global system matrix from linear solver '" << l_linearSolver->getName() << "' in " << filename;
-                exporter->second(filename, l_linearSolver->getSystemBaseMatrix());
+                return exporter->second(filename, l_linearSolver->getSystemBaseMatrix());
             }
-
-            return true;
         }
         else
         {

--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/GlobalSystemMatrixExporter.cpp
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/GlobalSystemMatrixExporter.cpp
@@ -1,0 +1,81 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <SofaBaseLinearSolver/GlobalSystemMatrixExporter.h>
+#include <sofa/core/ObjectFactory.h>
+#include <fstream>
+
+namespace sofa::component::linearsolver
+{
+
+int GlobalSystemMatrixExporterClass = core::RegisterObject("Export the global system matrix from a linear solver.")
+        .add<GlobalSystemMatrixExporter>();
+
+GlobalSystemMatrixExporter::GlobalSystemMatrixExporter()
+: Inherit1()
+, l_linearSolver(initLink("linearSolver", "Linear solver used to export its matrix"))
+{
+    d_exportAtBegin.setReadOnly(true);
+    d_exportAtEnd.setReadOnly(true);
+
+    d_exportAtBegin.setDisplayed(false);
+    d_exportAtEnd.setDisplayed(false);
+}
+
+void GlobalSystemMatrixExporter::doInit()
+{
+    l_linearSolver.set(this->getContext()->template get<sofa::core::behavior::LinearSolver>());
+
+    if (!l_linearSolver)
+    {
+        msg_error() << "A linear solver has not been found in the current context, whereas it is required. This component exports the matrix from a linear solver.";
+        this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+    }
+}
+
+bool GlobalSystemMatrixExporter::write()
+{
+    if (l_linearSolver)
+    {
+        if (l_linearSolver->getSystemBaseMatrix())
+        {
+            const std::string basename = getOrCreateTargetPath(d_filename.getValue(),
+                                                               d_exportEveryNbSteps.getValue());
+            const std::string filename = basename + ".mat";
+
+            msg_info() << "Writing global system matrix from linear solver '" << l_linearSolver->getName() << "' in " << filename;
+
+            std::ofstream file(filename);
+            file << *l_linearSolver->getSystemBaseMatrix();
+            file.close();
+
+            return true;
+        }
+        else
+        {
+            msg_warning() << "Matrix cannot be exported, probably because the linear solver '"
+                          << l_linearSolver->getName() << "' does not assemble explicitly the system matrix.";
+        }
+    }
+    return false;
+}
+
+}

--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/GlobalSystemMatrixExporter.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/GlobalSystemMatrixExporter.h
@@ -29,7 +29,10 @@ namespace sofa::component::linearsolver
 {
 
 /**
- * @brief Exports the global system matrix of the current context into a text file. The matrix is printed in its dense format.
+ * @brief Exports the global system matrix of the current context into a file. The exporter allows to write the file
+ * under several formats.
+ *
+ * The class is designed so more file format can be supported. For example, image export is added in the CImg plugin.
  */
 class SOFA_SOFABASELINEARSOLVER_API GlobalSystemMatrixExporter : public sofa::simulation::BaseSimulationExporter
 {

--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/GlobalSystemMatrixExporter.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/GlobalSystemMatrixExporter.h
@@ -1,0 +1,46 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <SofaBaseLinearSolver/config.h>
+#include <sofa/simulation/BaseSimulationExporter.h>
+#include <sofa/core/behavior/LinearSolver.h>
+
+namespace sofa::component::linearsolver
+{
+
+/**
+ * @brief Exports the global system matrix of the current context into a text file. The matrix is printed in its dense format.
+ */
+class SOFA_SOFABASELINEARSOLVER_API GlobalSystemMatrixExporter : public sofa::simulation::BaseSimulationExporter
+{
+public:
+    SOFA_CLASS(GlobalSystemMatrixExporter, sofa::simulation::BaseSimulationExporter);
+
+    bool write() override;
+    void doInit() override;
+
+protected:
+    GlobalSystemMatrixExporter();
+
+    SingleLink<GlobalSystemMatrixExporter, sofa::core::behavior::LinearSolver, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_linearSolver;
+};
+}

--- a/SofaKernel/modules/SofaDefaultType/CMakeLists.txt
+++ b/SofaKernel/modules/SofaDefaultType/CMakeLists.txt
@@ -10,6 +10,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/DataTypeInfo.h
     ${SRC_ROOT}/MapMapSparseMatrix.h
     ${SRC_ROOT}/MapMapSparseMatrixEigenUtils.h
+    ${SRC_ROOT}/MatrixExporter.h
     ${SRC_ROOT}/RigidTypes.h
     ${SRC_ROOT}/RigidVec6Types.h
     ${SRC_ROOT}/SolidTypes.h
@@ -58,6 +59,7 @@ set(SOURCE_FILES
     ${SRC_ROOT}/AbstractTypeInfo.cpp
     ${SRC_ROOT}/BaseMatrix.cpp
     ${SRC_ROOT}/BaseVector.cpp
+    ${SRC_ROOT}/MatrixExporter.cpp
     ${SRC_ROOT}/SolidTypes.cpp
     ${SRC_ROOT}/TemplatesAliases.cpp
     ${SRC_ROOT}/TypeInfoID.cpp

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/MatrixExporter.cpp
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/MatrixExporter.cpp
@@ -19,31 +19,53 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#pragma once
-#include <SofaBaseLinearSolver/config.h>
-#include <sofa/simulation/BaseSimulationExporter.h>
-#include <sofa/core/behavior/LinearSolver.h>
-#include <sofa/helper/OptionsGroup.h>
+#include <sofa/defaulttype/MatrixExporter.h>
+#include <sofa/defaulttype/BaseMatrix.h>
 
-namespace sofa::component::linearsolver
+#include <fstream>
+
+namespace sofa::defaulttype
 {
 
-/**
- * @brief Exports the global system matrix of the current context into a text file. The matrix is printed in its dense format.
- */
-class SOFA_SOFABASELINEARSOLVER_API GlobalSystemMatrixExporter : public sofa::simulation::BaseSimulationExporter
+bool writeMatrixTxt(const std::string& filename, sofa::defaulttype::BaseMatrix* matrix)
 {
-public:
-    SOFA_CLASS(GlobalSystemMatrixExporter, sofa::simulation::BaseSimulationExporter);
+    if (matrix)
+    {
+        std::ofstream file(filename);
+        file << *matrix;
+        file.close();
 
-    bool write() override;
-    void doInit() override;
+        return true;
+    }
+    return false;
+}
 
-protected:
-    Data<sofa::helper::OptionsGroup> d_fileFormat;
+bool writeMatrixCsv(const std::string& filename, sofa::defaulttype::BaseMatrix* matrix)
+{
+    if (matrix)
+    {
+        std::ofstream file(filename);
 
-    GlobalSystemMatrixExporter();
+        const auto nx = matrix->colSize();
+        const auto ny = matrix->rowSize();
 
-    SingleLink<GlobalSystemMatrixExporter, sofa::core::behavior::LinearSolver, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_linearSolver;
-};
+        if (nx > 0)
+        {
+            for (sofa::SignedIndex y = 0; y<ny; ++y)
+            {
+                for (sofa::SignedIndex x = 0; x < nx - 1; ++x)
+                {
+                    file << matrix->element(y, x) << ",";
+                }
+                file << matrix->element(y, nx - 1) << "\n";
+            }
+        }
+
+        file.close();
+
+        return true;
+    }
+    return false;
+}
+
 }

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/MatrixExporter.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/MatrixExporter.h
@@ -30,8 +30,8 @@
 namespace sofa::defaulttype
 {
 
-bool writeMatrixTxt(const std::string& filename, sofa::defaulttype::BaseMatrix* matrix);
-bool writeMatrixCsv(const std::string& filename, sofa::defaulttype::BaseMatrix* matrix);
+bool SOFA_DEFAULTTYPE_API writeMatrixTxt(const std::string& filename, sofa::defaulttype::BaseMatrix* matrix);
+bool SOFA_DEFAULTTYPE_API writeMatrixCsv(const std::string& filename, sofa::defaulttype::BaseMatrix* matrix);
 
 inline std::unordered_map<std::string, std::function<bool(const std::string&, sofa::defaulttype::BaseMatrix*)> > matrixExporterMap =
 {

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/MatrixExporter.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/MatrixExporter.h
@@ -20,30 +20,25 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
-#include <SofaBaseLinearSolver/config.h>
-#include <sofa/simulation/BaseSimulationExporter.h>
-#include <sofa/core/behavior/LinearSolver.h>
+
+#include <sofa/defaulttype/fwd.h>
+#include <string>
+#include <unordered_map>
+#include <functional>
 #include <sofa/helper/OptionsGroup.h>
 
-namespace sofa::component::linearsolver
+namespace sofa::defaulttype
 {
 
-/**
- * @brief Exports the global system matrix of the current context into a text file. The matrix is printed in its dense format.
- */
-class SOFA_SOFABASELINEARSOLVER_API GlobalSystemMatrixExporter : public sofa::simulation::BaseSimulationExporter
+bool writeMatrixTxt(const std::string& filename, sofa::defaulttype::BaseMatrix* matrix);
+bool writeMatrixCsv(const std::string& filename, sofa::defaulttype::BaseMatrix* matrix);
+
+inline std::unordered_map<std::string, std::function<bool(const std::string&, sofa::defaulttype::BaseMatrix*)> > matrixExporterMap =
 {
-public:
-    SOFA_CLASS(GlobalSystemMatrixExporter, sofa::simulation::BaseSimulationExporter);
-
-    bool write() override;
-    void doInit() override;
-
-protected:
-    Data<sofa::helper::OptionsGroup> d_fileFormat;
-
-    GlobalSystemMatrixExporter();
-
-    SingleLink<GlobalSystemMatrixExporter, sofa::core::behavior::LinearSolver, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_linearSolver;
+    {"txt", writeMatrixTxt},
+    {"csv", writeMatrixCsv},
 };
+
+inline sofa::helper::OptionsGroup matrixExporterOptionsGroup(2, "txt", "csv");
+
 }

--- a/applications/plugins/CImgPlugin/CMakeLists.txt
+++ b/applications/plugins/CImgPlugin/CMakeLists.txt
@@ -6,16 +6,19 @@ set(HEADER_FILES
     src/CImgPlugin/CImgPlugin.h.in
     src/CImgPlugin/SOFACImg.h
     src/CImgPlugin/CImgData.h
+    src/CImgPlugin/MatrixImageExporter.h
     )
 
 set(SOURCE_FILES
     src/CImgPlugin/ImageCImg.cpp
     src/CImgPlugin/initCImgPlugin.cpp
+    src/CImgPlugin/MatrixImageExporter.cpp
     )
 
 add_subdirectory(extlibs/CImg)
 
 sofa_find_package(SofaFramework REQUIRED)
+sofa_find_package(SofaBaseVisual REQUIRED)
 sofa_find_package(CImg REQUIRED)
 
 # OS X only: if the user installed its own JPEG/PNG lib (typically with homebrew/port),
@@ -67,7 +70,7 @@ add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "$<BUILD_INTERFACE:${CImg_INCLUDE_DIRS}>")
 target_compile_options(${PROJECT_NAME} PUBLIC ${CIMG_CFLAGS})
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaCore)
+target_link_libraries(${PROJECT_NAME} PUBLIC SofaCore SofaBaseVisual)
 target_link_libraries(${PROJECT_NAME} PUBLIC ${DEP_TARGETS})
 
 if(SOFA_BUILD_RELEASE_PACKAGE OR CMAKE_SYSTEM_NAME STREQUAL Windows)

--- a/applications/plugins/CImgPlugin/src/CImgPlugin/MatrixImageExporter.cpp
+++ b/applications/plugins/CImgPlugin/src/CImgPlugin/MatrixImageExporter.cpp
@@ -1,0 +1,85 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <CImgPlugin/MatrixImageExporter.h>
+#include <sofa/defaulttype/MatrixExporter.h>
+#include <sofa/defaulttype/BaseMatrix.h>
+#include <CImgPlugin/ImageCImg.h>
+
+namespace sofa::defaulttype
+{
+bool writeMatrixImage(const std::string& filename, sofa::defaulttype::BaseMatrix* matrix)
+{
+    if (matrix)
+    {
+        const auto nx = matrix->colSize();
+        const auto ny = matrix->rowSize();
+
+        sofa::helper::io::ImageCImg image;
+        image.init(nx, ny, 1, 1, sofa::helper::io::Image::DataType::UNORM8, sofa::helper::io::Image::ChannelFormat::L);
+
+        unsigned char* pixels = image.getPixels();
+        for (sofa::SignedIndex y = 0; y < ny; ++y)
+        {
+            for (sofa::SignedIndex x = 0; x < nx; ++x)
+            {
+                pixels[y * nx + x] = !static_cast<bool>(matrix->element(nx - y - 1, x)) * std::numeric_limits<unsigned char>::max();
+            }
+        }
+        return image.save(filename);
+    }
+    return false;
+}
+} //namespace sofa::defaulttype
+
+namespace sofa::component
+{
+
+void initializeMatrixExporterComponents()
+{
+    static bool first = true;
+    if (first)
+    {
+        const auto addMatrixExporter = [](const std::string& format, std::function<bool(const std::string&, sofa::defaulttype::BaseMatrix*)> exporter)
+        {
+            //Add an exporter which writes a matrix as an image
+            sofa::defaulttype::matrixExporterMap.insert({format, exporter});
+
+            //The added exporter is made available in the options group
+            sofa::defaulttype::matrixExporterOptionsGroup.setNbItems(sofa::defaulttype::matrixExporterOptionsGroup.size() + 1);
+            sofa::defaulttype::matrixExporterOptionsGroup.setItemName(sofa::defaulttype::matrixExporterOptionsGroup.size() - 1, format);
+        };
+
+#if CIMGPLUGIN_HAVE_JPEG
+        addMatrixExporter("jpg", sofa::defaulttype::writeMatrixImage);
+#endif // CIMGPLUGIN_HAVE_JPEG
+
+#if CIMGPLUGIN_HAVE_PNG
+        addMatrixExporter("png", sofa::defaulttype::writeMatrixImage);
+#endif // CIMGPLUGIN_HAVE_PNG
+
+        addMatrixExporter("bmp", sofa::defaulttype::writeMatrixImage);
+
+        first = false;
+    }
+}
+
+} //namespace sofa::component

--- a/applications/plugins/CImgPlugin/src/CImgPlugin/MatrixImageExporter.h
+++ b/applications/plugins/CImgPlugin/src/CImgPlugin/MatrixImageExporter.h
@@ -21,15 +21,16 @@
 ******************************************************************************/
 #pragma once
 
+#include <CImgPlugin/CImgPlugin.h>
 #include <sofa/defaulttype/fwd.h>
 #include <string>
 
 namespace sofa::defaulttype
 {
-bool writeMatrixImage(const std::string& filename, sofa::defaulttype::BaseMatrix* matrix);
+bool SOFA_CIMGPLUGIN_API writeMatrixImage(const std::string& filename, sofa::defaulttype::BaseMatrix* matrix);
 } //namespace sofa::defaulttype
 
 namespace sofa::component
 {
-void initializeMatrixExporterComponents();
+void SOFA_CIMGPLUGIN_API initializeMatrixExporterComponents();
 } //namespace sofa::component

--- a/applications/plugins/CImgPlugin/src/CImgPlugin/MatrixImageExporter.h
+++ b/applications/plugins/CImgPlugin/src/CImgPlugin/MatrixImageExporter.h
@@ -20,30 +20,16 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
-#include <SofaBaseLinearSolver/config.h>
-#include <sofa/simulation/BaseSimulationExporter.h>
-#include <sofa/core/behavior/LinearSolver.h>
-#include <sofa/helper/OptionsGroup.h>
 
-namespace sofa::component::linearsolver
+#include <sofa/defaulttype/fwd.h>
+#include <string>
+
+namespace sofa::defaulttype
 {
+bool writeMatrixImage(const std::string& filename, sofa::defaulttype::BaseMatrix* matrix);
+} //namespace sofa::defaulttype
 
-/**
- * @brief Exports the global system matrix of the current context into a text file. The matrix is printed in its dense format.
- */
-class SOFA_SOFABASELINEARSOLVER_API GlobalSystemMatrixExporter : public sofa::simulation::BaseSimulationExporter
+namespace sofa::component
 {
-public:
-    SOFA_CLASS(GlobalSystemMatrixExporter, sofa::simulation::BaseSimulationExporter);
-
-    bool write() override;
-    void doInit() override;
-
-protected:
-    Data<sofa::helper::OptionsGroup> d_fileFormat;
-
-    GlobalSystemMatrixExporter();
-
-    SingleLink<GlobalSystemMatrixExporter, sofa::core::behavior::LinearSolver, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_linearSolver;
-};
-}
+void initializeMatrixExporterComponents();
+} //namespace sofa::component

--- a/applications/plugins/CImgPlugin/src/CImgPlugin/initCImgPlugin.cpp
+++ b/applications/plugins/CImgPlugin/src/CImgPlugin/initCImgPlugin.cpp
@@ -8,6 +8,8 @@
 #include <iostream>
 #include <vector>
 
+#include <CImgPlugin/MatrixImageExporter.h>
+
 #include "SOFACImg.h"
 
 /// CImg is a header only library. The consequence is that if compiled in multiple libraries
@@ -52,6 +54,8 @@ void initExternalModule()
         first = false;
 
         sofa::helper::io::ImageCImg::setCimgCreators();
+
+        sofa::component::initializeMatrixExporterComponents();
     }
 }
 

--- a/examples/Components/linearsolver/GlobalSystemMatrixExporter.scn
+++ b/examples/Components/linearsolver/GlobalSystemMatrixExporter.scn
@@ -1,0 +1,32 @@
+<Node name="root" dt="0.02" gravity="0 -10 0">
+    <RequiredPlugin name="SofaBoundaryCondition"/>
+    <RequiredPlugin name="SofaImplicitOdeSolver"/>
+    <RequiredPlugin name="SofaMiscCollision"/>
+    <RequiredPlugin name="SofaSimpleFem"/>
+    <RequiredPlugin name="SofaSparseSolver"/>
+
+    <VisualStyle displayFlags="showBehaviorModels showForceFields" />
+
+    <Node name="M1">
+        <EulerImplicitSolver name="odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <SparseLDLSolver printLog="false" template="CompressedRowSparseMatrixMat3x3d"/>
+        <GlobalSystemMatrixExporter exportEveryNumberOfSteps="1" filename="global_matrix_ldl" printLog="true"/>
+        <MechanicalObject />
+        <UniformMass vertexMass="1"/>
+        <RegularGridTopology nx="4" ny="4" nz="20" xmin="-9" xmax="-6" ymin="0" ymax="3" zmin="0" zmax="19" />
+        <FixedConstraint indices="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15" />
+        <HexahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" method="large" />
+    </Node>
+
+    <Node name="M2">
+        <EulerImplicitSolver name="odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver printLog="false" template="GraphScattered"/>
+        <!-- The following exporter will warn that the matrix cannot be exported because the matrix is not assembled -->
+        <GlobalSystemMatrixExporter exportEveryNumberOfSteps="1" filename="global_matrix_cg" printLog="true"/>
+        <MechanicalObject />
+        <UniformMass vertexMass="1"/>
+        <RegularGridTopology nx="4" ny="4" nz="20" xmin="-6" xmax="-3" ymin="0" ymax="3" zmin="0" zmax="19" />
+        <FixedConstraint indices="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15" />
+        <HexahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" method="large" />
+    </Node>
+</Node>

--- a/examples/Components/linearsolver/GlobalSystemMatrixExporter.scn
+++ b/examples/Components/linearsolver/GlobalSystemMatrixExporter.scn
@@ -10,10 +10,10 @@
     <Node name="M1">
         <EulerImplicitSolver name="odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
         <SparseLDLSolver printLog="false" template="CompressedRowSparseMatrixMat3x3d"/>
-        <GlobalSystemMatrixExporter exportEveryNumberOfSteps="1" filename="global_matrix_ldl" printLog="true"/>
+        <GlobalSystemMatrixExporter exportEveryNumberOfSteps="1" filename="global_matrix_ldl" printLog="true" format="txt"/>
         <MechanicalObject />
         <UniformMass vertexMass="1"/>
-        <RegularGridTopology nx="4" ny="4" nz="20" xmin="-9" xmax="-6" ymin="0" ymax="3" zmin="0" zmax="19" />
+        <RegularGridTopology nx="4" ny="4" nz="10" xmin="-9" xmax="-6" ymin="0" ymax="3" zmin="0" zmax="9" />
         <FixedConstraint indices="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15" />
         <HexahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" method="large" />
     </Node>
@@ -25,8 +25,30 @@
         <GlobalSystemMatrixExporter exportEveryNumberOfSteps="1" filename="global_matrix_cg" printLog="true"/>
         <MechanicalObject />
         <UniformMass vertexMass="1"/>
-        <RegularGridTopology nx="4" ny="4" nz="20" xmin="-6" xmax="-3" ymin="0" ymax="3" zmin="0" zmax="19" />
+        <RegularGridTopology nx="4" ny="4" nz="10" xmin="-6" xmax="-3" ymin="0" ymax="3" zmin="0" zmax="9" />
         <FixedConstraint indices="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15" />
         <HexahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" method="large" />
+    </Node>
+
+    <!-- Node containing 2 objects under a single linear solver -->
+    <Node name="M3">
+        <EulerImplicitSolver name="odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <SparseLDLSolver printLog="false" template="CompressedRowSparseMatrixMat3x3d"/>
+        <GlobalSystemMatrixExporter exportEveryNumberOfSteps="1" filename="global_matrix_ldl_2objects" printLog="true" format="jpg"/> <!-- Plugin CImg is required for image export -->
+
+        <Node name="N1">
+            <MechanicalObject />
+            <UniformMass vertexMass="1"/>
+            <RegularGridTopology nx="4" ny="4" nz="10" xmin="-3" xmax="0" ymin="0" ymax="3" zmin="0" zmax="9" />
+            <FixedConstraint indices="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15" />
+            <HexahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" method="large" />
+        </Node>
+        <Node name="N2">
+            <MechanicalObject />
+            <UniformMass vertexMass="1"/>
+            <RegularGridTopology nx="4" ny="4" nz="10" xmin="0" xmax="3" ymin="0" ymax="3" zmin="0" zmax="9" />
+            <FixedConstraint indices="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15" />
+            <HexahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" method="large" />
+        </Node>
     </Node>
 </Node>


### PR DESCRIPTION
Introduce a new component:
It exports the global system matrix of the current context into a file. The exporter allows to write the file under several formats. The class is designed so more file format can be supported. For example, image export is added in the CImg plugin.

An example is provided.

Example:

![image](https://user-images.githubusercontent.com/10572752/130434673-82d50165-2cc6-49f5-9298-241be36490ad.png)

![image](https://user-images.githubusercontent.com/10572752/130598924-8a805845-bb95-407a-972f-d68e56c18fb2.png)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
