### PR TITLE
[SofaBaseLinearSolver] Brings all add functions into the scope

### DIFF
--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/DiagonalMatrix.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/DiagonalMatrix.h
@@ -103,7 +103,6 @@ public:
     }
 
     using defaulttype::BaseMatrix::add;
-
     void add(Index i, Index j, double v) override
     {
         if (i==j) data[i] += (Real)v;
@@ -429,6 +428,7 @@ public:
             setB(i, b);
     }
 
+    using defaulttype::BaseMatrix::add;
     void add(Index i, Index j, double v) override
     {
         Index bi=0, bj=0; traits::split_row_index(i, bi); traits::split_col_index(j, bj);

--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/DiagonalMatrix.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/DiagonalMatrix.h
@@ -102,6 +102,8 @@ public:
         if (i==j) data[i] = (Real)v;
     }
 
+    using defaulttype::BaseMatrix::add;
+
     void add(Index i, Index j, double v) override
     {
         if (i==j) data[i] += (Real)v;

--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/DiagonalMatrix.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/DiagonalMatrix.h
@@ -161,7 +161,6 @@ public:
         data[i] = (Real)v;
     }
 
-    using BaseMatrix::add;
     void add(Index i, double v)
     {
         data[i] += (Real)v;

--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/FullMatrix.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/FullMatrix.h
@@ -95,6 +95,7 @@ public:
 
     SReal element(Index i, Index j) const override;
     void set(Index i, Index j, double v) override;
+    using defaulttype::BaseMatrix::add;
     void add(Index i, Index j, double v) override;
     void clear(Index i, Index j) override;
 

--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/RotationMatrix.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/RotationMatrix.h
@@ -53,6 +53,8 @@ public:
     /// Write the value of the element at row i, column j (using 0-based indices)
     void set(sofa::SignedIndex i, sofa::SignedIndex j, double v) override;
 
+    using defaulttype::BaseMatrix::add;
+
     /// Add v to the existing value of the element at row i, column j (using 0-based indices)
     void add(sofa::SignedIndex i, sofa::SignedIndex j, double v) override;
 

--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/SparseMatrix.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/SparseMatrix.h
@@ -158,6 +158,7 @@ public:
         data[i][j] = (Real)v;
     }
 
+    using defaulttype::BaseMatrix::add;
     void add(Index i, Index j, double v) override
     {
         if(SPARSEMATRIX_VERBOSE){


### PR DESCRIPTION
Some overloads of the function `add` from `BaseMatrix` were hidden in derived classes (SparseMatrix, RotationMatrix, FullMatrix and DiagonalMatrix). The using-declaration asks to bring all the overloads into the scope. 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
