### PR TITLE
[SofaMiscForceField] Fix addForce function in MeshMatrixMass

### DIFF
--- a/examples/Components/mass/DiagonalMass.scn
+++ b/examples/Components/mass/DiagonalMass.scn
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<Node name="root" dt="0.02">
+<Node name="root" dt="0.005">
     <RequiredPlugin name="SofaOpenglVisual"/>
     <RequiredPlugin pluginName='SofaBoundaryCondition'/>
     <RequiredPlugin pluginName='SofaGeneralLoader'/>
@@ -17,25 +17,25 @@
     <MeshObjLoader name="meshLoader_0" filename="mesh/liver-smooth.obj" handleSeams="1" />
 
     <Node name="Liver" depend="topo dofs">
-        <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
-        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-        <MechanicalObject src="@../loader" name="dofs" />
+        <EulerImplicitSolver name="integration scheme" />
+        <CGLinearSolver name="linear solver" iterations="1000" tolerance="1e-9" threshold="1e-9"/>
+        <MechanicalObject name="dofs" src="@../loader" />
         <!-- Container for the tetrahedra-->
-        <TetrahedronSetTopologyContainer src="@../loader" name="topo" />
+        <TetrahedronSetTopologyContainer name="TetraTopo" src="@../loader" />
         <TetrahedronSetGeometryAlgorithms name="GeomAlgo" />
         <DiagonalMass totalMass="60" name="diagonalMass" />
-        <TetrahedralCorotationalFEMForceField name="FEM" youngModulus="3000" poissonRatio="0.3" computeGlobalMatrix="false" method="large" />
+        <TetrahedralCorotationalFEMForceField template="Vec3d" name="FEM" method="large" poissonRatio="0.45" youngModulus="5000" />
         <FixedConstraint name="FixedConstraint" indices="3 39 64" />
         
         <Node name="Visu">
             <OglModel name="VisualModel" src="@../../meshLoader_0" color="red" />
-            <BarycentricMapping input="@.." output="@VisualModel" name="visual mapping" />
+            <BarycentricMapping name="VisualMapping" input="@../dofs" output="@VisualModel" />
         </Node>
         <Node name="Surf">
     	    <SphereLoader filename="mesh/liver.sph" />
-            <MechanicalObject position="@[-1].position" />
+            <MechanicalObject name="spheres" position="@[-1].position" />
             <SphereCollisionModel name="CollisionModel" listRadius="@[-2].listRadius" />
-            <BarycentricMapping name="sphere mapping" />
+            <BarycentricMapping name="CollisionMapping" input="@../dofs" output="@spheres" />
         </Node>
     </Node>
 </Node>

--- a/examples/Components/mass/DiagonalMass.scn
+++ b/examples/Components/mass/DiagonalMass.scn
@@ -1,3 +1,4 @@
+<?xml version="1.0" ?>
 <Node name="root" dt="0.02">
     <RequiredPlugin name="SofaOpenglVisual"/>
     <RequiredPlugin pluginName='SofaBoundaryCondition'/>
@@ -11,26 +12,27 @@
     <BVHNarrowPhase/>
     <DefaultContactManager response="default" name="collision response" />
     <DiscreteIntersection />
+
+    <MeshGmshLoader name="loader" filename="mesh/liver.msh" />
+    <MeshObjLoader name="meshLoader_0" filename="mesh/liver-smooth.obj" handleSeams="1" />
+
     <Node name="Liver" depend="topo dofs">
-        <!--<CGImplicit iterations="25"/>-->
         <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-        <MeshGmshLoader name="loader" filename="mesh/liver.msh" />
-        <MechanicalObject src="@loader" name="dofs" />
+        <MechanicalObject src="@../loader" name="dofs" />
         <!-- Container for the tetrahedra-->
-        <TetrahedronSetTopologyContainer src="@loader" name="topo" />
-        <!-- Algorithms: used in DiagonalMass to compute the mass -->
+        <TetrahedronSetTopologyContainer src="@../loader" name="topo" />
         <TetrahedronSetGeometryAlgorithms name="GeomAlgo" />
-        <DiagonalMass massDensity="1" name="diagonalMass" />
+        <DiagonalMass totalMass="60" name="diagonalMass" />
         <TetrahedralCorotationalFEMForceField name="FEM" youngModulus="3000" poissonRatio="0.3" computeGlobalMatrix="false" method="large" />
         <FixedConstraint name="FixedConstraint" indices="3 39 64" />
+        
         <Node name="Visu">
-            <MeshObjLoader name="meshLoader_0" filename="mesh/liver-smooth.obj" handleSeams="1" />
-            <OglModel name="VisualModel" src="@meshLoader_0" color="red" />
+            <OglModel name="VisualModel" src="@../../meshLoader_0" color="red" />
             <BarycentricMapping input="@.." output="@VisualModel" name="visual mapping" />
         </Node>
         <Node name="Surf">
-	    <SphereLoader filename="mesh/liver.sph" />
+    	    <SphereLoader filename="mesh/liver.sph" />
             <MechanicalObject position="@[-1].position" />
             <SphereCollisionModel name="CollisionModel" listRadius="@[-2].listRadius" />
             <BarycentricMapping name="sphere mapping" />

--- a/examples/Components/mass/MeshMatrixMass.scn
+++ b/examples/Components/mass/MeshMatrixMass.scn
@@ -11,28 +11,28 @@
 
     <VisualStyle displayFlags="showBehaviorModels showForceFields" />
 
-    <DefaultPipeline verbose="0" />
+    <DefaultPipeline verbose="0" name="CollisionPipeline" />
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
-    <DefaultContactManager name="Response" response="default" />
+    <DefaultContactManager response="default" name="collision response" />
     <DiscreteIntersection />
 
     <MeshGmshLoader name="MeshLoader" filename="mesh/liver.msh" />
     <MeshObjLoader name="LiverSurface" filename="mesh/liver-smooth.obj" />
 
     <Node name="Liver">
-        <EulerImplicitSolver />
-        <CGLinearSolver iterations="1000" tolerance="1e-5" threshold="1e-5"/>
+        <EulerImplicitSolver name="integration scheme" />
+        <CGLinearSolver name="linear solver" iterations="1000" tolerance="1e-9" threshold="1e-9"/>
         <MechanicalObject name="dofs" src="@../MeshLoader"/>
         <!-- Container for the tetrahedra-->
         <TetrahedronSetTopologyContainer name="TetraTopo" src="@../MeshLoader"/>
-        <TetrahedronSetGeometryAlgorithms />
+        <TetrahedronSetGeometryAlgorithms name="GeomAlgo" />
         <MeshMatrixMass totalMass="60" name="SparseMass" topology="@TetraTopo" />
         <TetrahedralCorotationalFEMForceField template="Vec3d" name="FEM" method="large" poissonRatio="0.45" youngModulus="5000" />
         <FixedConstraint name="FixedConstraint" indices="3 39 64" />
 
         <Node name="Visu" >
-            <OglModel  name="VisualModel" src="@../../LiverSurface" color="0 1 1"/>
+            <OglModel  name="VisualModel" src="@../../LiverSurface" color="cyan"/>
             <BarycentricMapping name="VisualMapping" input="@../dofs" output="@VisualModel" />
         </Node>
         <Node name="Surf" >

--- a/examples/Components/mass/MeshMatrixMass.scn
+++ b/examples/Components/mass/MeshMatrixMass.scn
@@ -1,3 +1,4 @@
+<?xml version="1.0" ?>
 <Node name="root" dt="0.005">
     <RequiredPlugin pluginName="SofaOpenglVisual"/>
     <RequiredPlugin pluginName='SofaMiscCollision'/>
@@ -9,11 +10,11 @@
     <RequiredPlugin pluginName='SofaMiscForceField'/> 
 
     <VisualStyle displayFlags="showBehaviorModels showForceFields" />
+
     <DefaultPipeline verbose="0" />
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
     <DefaultContactManager name="Response" response="default" />
-    <DefaultCollisionGroupManager name="Group" />
     <DiscreteIntersection />
 
     <MeshGmshLoader name="MeshLoader" filename="mesh/liver.msh" />
@@ -23,15 +24,12 @@
         <EulerImplicitSolver />
         <CGLinearSolver iterations="1000" tolerance="1e-5" threshold="1e-5"/>
         <MechanicalObject name="dofs" src="@../MeshLoader"/>
-
+        <!-- Container for the tetrahedra-->
         <TetrahedronSetTopologyContainer name="TetraTopo" src="@../MeshLoader"/>
         <TetrahedronSetGeometryAlgorithms />
-
-        <MeshMatrixMass massDensity="1.5" topology="@TetraTopo" />
+        <MeshMatrixMass totalMass="60" name="SparseMass" topology="@TetraTopo" />
         <TetrahedralCorotationalFEMForceField template="Vec3d" name="FEM" method="large" poissonRatio="0.45" youngModulus="5000" />
-        
-        <FixedConstraint  name="FixedConstraint" indices="3" />
-        <PartialFixedConstraint  name="PartialFixedConstraint" indices="39 64" fixedDirections="1 1 0" />
+        <FixedConstraint name="FixedConstraint" indices="3 39 64" />
 
         <Node name="Visu" >
             <OglModel  name="VisualModel" src="@../../LiverSurface" color="0 1 1"/>

--- a/examples/Components/mass/UniformMass.scn
+++ b/examples/Components/mass/UniformMass.scn
@@ -12,29 +12,29 @@
     <BVHNarrowPhase/>
     <DefaultContactManager response="default" name="collision response" />
     <DiscreteIntersection />
-    <!--<DefaultCollisionGroupManager />-->
+
+    <MeshGmshLoader name="loader" filename="mesh/liver.msh" />
+    <MeshObjLoader name="meshLoader_0" filename="mesh/liver-smooth.obj" handleSeams="1" />
+
     <Node name="Liver" depend="topo dofs">
-        <!--<CGImplicit iterations="25"/>-->
         <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-        <MeshGmshLoader name="loader" filename="mesh/liver.msh" />
-        <MechanicalObject src="@loader" name="dofs" />
+        <MechanicalObject src="@../loader" name="dofs" />
         <!-- Container for the tetrahedra-->
-        <TetrahedronSetTopologyContainer src="@loader" name="topo" />
-        <!-- Algorithms: used in DiagonalMass to compute the mass -->
+        <TetrahedronSetTopologyContainer src="@../loader" name="topo" />
         <TetrahedronSetGeometryAlgorithms name="GeomAlgo" />
-        <UniformMass vertexMass="0.05" />
+        <UniformMass totalMass="60"  name="uniformlyConstantMass" />
         <TetrahedralCorotationalFEMForceField name="FEM" youngModulus="3000" poissonRatio="0.3" computeGlobalMatrix="false" method="large" />
         <FixedConstraint name="FixedConstraint" indices="3 39 64" />
+        
         <Node name="Visu">
-            <MeshObjLoader name="meshLoader_0" filename="mesh/liver-smooth.obj" handleSeams="1" />
-            <OglModel name="VisualModel" src="@meshLoader_0" color="red" />
+            <OglModel name="VisualModel" src="@../../meshLoader_0" color="red" />
             <BarycentricMapping input="@.." output="@VisualModel" name="visual mapping" />
         </Node>
         <Node name="Surf">
-	    <SphereLoader filename="mesh/liver.sph" />
+    	    <SphereLoader filename="mesh/liver.sph" />
             <MechanicalObject position="@[-1].position" />
-            <SphereCollisionModel listRadius="@[-2].listRadius" />
+            <SphereCollisionModel name="CollisionModel" listRadius="@[-2].listRadius" />
             <BarycentricMapping name="sphere mapping" />
         </Node>
     </Node>

--- a/examples/Components/mass/UniformMass.scn
+++ b/examples/Components/mass/UniformMass.scn
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<Node name="root" dt="0.02">
+<Node name="root" dt="0.005">
     <RequiredPlugin name="SofaOpenglVisual"/>
     <RequiredPlugin pluginName='SofaBoundaryCondition'/>
     <RequiredPlugin pluginName='SofaGeneralLoader'/>
@@ -17,25 +17,25 @@
     <MeshObjLoader name="meshLoader_0" filename="mesh/liver-smooth.obj" handleSeams="1" />
 
     <Node name="Liver" depend="topo dofs">
-        <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
-        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-        <MechanicalObject src="@../loader" name="dofs" />
+        <EulerImplicitSolver name="integration scheme" />
+        <CGLinearSolver name="linear solver" iterations="1000" tolerance="1e-9" threshold="1e-9"/>
+        <MechanicalObject name="dofs" src="@../loader" />
         <!-- Container for the tetrahedra-->
-        <TetrahedronSetTopologyContainer src="@../loader" name="topo" />
+        <TetrahedronSetTopologyContainer name="TetraTopo" src="@../loader" />
         <TetrahedronSetGeometryAlgorithms name="GeomAlgo" />
         <UniformMass totalMass="60"  name="uniformlyConstantMass" />
-        <TetrahedralCorotationalFEMForceField name="FEM" youngModulus="3000" poissonRatio="0.3" computeGlobalMatrix="false" method="large" />
+        <TetrahedralCorotationalFEMForceField template="Vec3d" name="FEM" method="large" poissonRatio="0.45" youngModulus="5000" />
         <FixedConstraint name="FixedConstraint" indices="3 39 64" />
         
         <Node name="Visu">
-            <OglModel name="VisualModel" src="@../../meshLoader_0" color="red" />
-            <BarycentricMapping input="@.." output="@VisualModel" name="visual mapping" />
+            <OglModel name="VisualModel" src="@../../meshLoader_0" color="yellow" />
+            <BarycentricMapping name="VisualMapping" input="@../dofs" output="@VisualModel" />
         </Node>
         <Node name="Surf">
     	    <SphereLoader filename="mesh/liver.sph" />
-            <MechanicalObject position="@[-1].position" />
+            <MechanicalObject name="spheres" position="@[-1].position" />
             <SphereCollisionModel name="CollisionModel" listRadius="@[-2].listRadius" />
-            <BarycentricMapping name="sphere mapping" />
+            <BarycentricMapping name="CollisionMapping" input="@../dofs" output="@spheres" />
         </Node>
     </Node>
 </Node>

--- a/examples/RegressionStateScenes.regression-tests
+++ b/examples/RegressionStateScenes.regression-tests
@@ -32,6 +32,10 @@ Components/solver/EulerImplicitSolver.scn 3000 1e-4 0 1
 Components/topology/Mesh2PointTopologicalMapping.scn 100 1e-4 0 1
 Components/topology/SparseGridTopology.scn 100 1e-4 0 1
 Components/topology/SparseGridRamificationTopology.scn 100 1e-4 0 1
+Components/mass/UniformMass.scn 100 1e-4 0 1
+Components/mass/DiagonalMass.scn 100 1e-4 0 1
+Components/mass/MeshMatrixMass.scn 100 1e-4 0 1
+
 
 ### Benchmark scenes ###
 Benchmark/Performance/MatrixAssembly/MatrixAssembly_assembledCG.scn 300 1e-4 0 1

--- a/modules/SofaMiscForceField/SofaMiscForceField_test/MeshMatrixMass_test.cpp
+++ b/modules/SofaMiscForceField/SofaMiscForceField_test/MeshMatrixMass_test.cpp
@@ -1270,7 +1270,7 @@ public:
                     "            <HexahedronSetTopologyContainer name='Container' src='@../grid' />                     "
                     "            <HexahedronSetTopologyModifier name='Modifier' />                                      "
                     "            <HexahedronSetGeometryAlgorithms template='Vec3d' name='GeomAlgo' />                   "
-                    "            <MeshMatrixMass name='m_mass' massDensity='1.0' lumping='true'                         "
+                    "            <MeshMatrixMass name='m_mass' massDensity='1.0' lumping='true'/>                       "
                     "    </Node>                                                                                        "
                     "</Node>                                                                                            ";
         }
@@ -1306,9 +1306,17 @@ public:
         // check vertex mass
         EXPECT_FLOAT_EQ(vMasses[0], refValueV);
         EXPECT_FLOAT_EQ(vMasses[1], refValueV * 2);
-        // check edge mass
-        EXPECT_FLOAT_EQ(eMasses[0], refValueE * 2);
-        EXPECT_FLOAT_EQ(eMasses[2], refValueE); // eMasses[1] == 0 because not taken into account from grid to hexahedron Topology
+        // check edge mass (only if not lumped else eMass is not computed)
+        if(!lumped)
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], refValueE * 2);
+            EXPECT_FLOAT_EQ(eMasses[2], refValueE); // eMasses[1] == 0 because not taken into account from grid to hexahedron Topology
+        }
+        else
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], 0.);
+            EXPECT_FLOAT_EQ(eMasses[2], 0.);
+        }
         
         // -- remove hexahedron id: 0 -- 
         sofa::type::vector<sofa::Index> hexaIds = { 0 };
@@ -1320,10 +1328,17 @@ public:
         // check vertex mass
         EXPECT_FLOAT_EQ(vMasses[0], refValueV); // check update of Mass when removing tetra
         EXPECT_FLOAT_EQ(vMasses[1], refValueV);
-        // check edge mass
-        EXPECT_FLOAT_EQ(eMasses[0], refValueE);
-        EXPECT_FLOAT_EQ(eMasses[3], refValueE);
-
+        // check edge mass (only if not lumped else eMass is not computed)
+        if(!lumped)
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], refValueE);
+            EXPECT_FLOAT_EQ(eMasses[3], refValueE);
+        }
+        else
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], 0.);
+            EXPECT_FLOAT_EQ(eMasses[3], 0.);
+        }
 
         // -- remove hexahedron id: 0 --
         modifier->removeHexahedra(hexaIds);
@@ -1334,10 +1349,17 @@ public:
         // check vertex mass
         EXPECT_FLOAT_EQ(vMasses[0], refValueV); // check update of Mass when removing tetra
         EXPECT_FLOAT_EQ(vMasses[1], refValueV);
-        // check edge mass
-        EXPECT_FLOAT_EQ(eMasses[0], refValueE);
-        EXPECT_FLOAT_EQ(eMasses[3], refValueE);
-        
+        // check edge mass (only if not lumped else eMass is not computed)
+        if(!lumped)
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], refValueE);
+            EXPECT_FLOAT_EQ(eMasses[3], refValueE);
+        }
+        else
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], 0.);
+            EXPECT_FLOAT_EQ(eMasses[3], 0.);
+        }
         
         // -- remove hexahedron id: 0, 1 --
         hexaIds.push_back(1);
@@ -1349,9 +1371,17 @@ public:
         // check vertex mass
         EXPECT_FLOAT_EQ(vMasses[0], refValueV);
         EXPECT_FLOAT_EQ(vMasses[1], refValueV * 2);
-        // check edge mass
-        EXPECT_FLOAT_EQ(eMasses[3], refValueE);
-        EXPECT_FLOAT_EQ(eMasses[20], refValueE);
+        // check edge mass (only if not lumped else eMass is not computed)
+        if(!lumped)
+        {
+            EXPECT_FLOAT_EQ(eMasses[3], refValueE);
+            EXPECT_FLOAT_EQ(eMasses[20], refValueE);
+        }
+        else
+        {
+            EXPECT_FLOAT_EQ(eMasses[3], 0.);
+            EXPECT_FLOAT_EQ(eMasses[20], 0.);
+        }
 
         // -- remove hexahedron id: 0, 1, 2, 3 --
         hexaIds.push_back(2);
@@ -1434,9 +1464,17 @@ public:
         // check vertex mass
         EXPECT_FLOAT_EQ(vMasses[0], refValueV * 5);
         EXPECT_FLOAT_EQ(vMasses[1], refValueV * 3);
-        // check edge mass
-        EXPECT_FLOAT_EQ(eMasses[0], refValueE * 3);
-        EXPECT_FLOAT_EQ(eMasses[1], refValueE * 2);
+        // check edge mass (only if not lumped else eMass is not computed)
+        if(!lumped)
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], refValueE * 3);
+            EXPECT_FLOAT_EQ(eMasses[1], refValueE * 2);
+        }
+        else
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], 0.);
+            EXPECT_FLOAT_EQ(eMasses[1], 0.);
+        }
 
         // -- remove tetrahedron id: 0 -- 
         sofa::type::vector<sofa::Index> elemIds = { 0 };
@@ -1448,9 +1486,17 @@ public:
         // check vertex mass
         EXPECT_FLOAT_EQ(vMasses[0], refValueV * 4); // check update of Mass when removing tetra
         EXPECT_FLOAT_EQ(vMasses[1], refValueV * 2);
-        // check edge mass
-        EXPECT_FLOAT_EQ(eMasses[0], refValueE * 2);
-        EXPECT_FLOAT_EQ(eMasses[1], refValueE);
+        // check edge mass (only if not lumped else eMass is not computed)
+        if(!lumped)
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], refValueE * 2);
+            EXPECT_FLOAT_EQ(eMasses[1], refValueE);
+        }
+        else
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], 0.);
+            EXPECT_FLOAT_EQ(eMasses[1], 0.);
+        }
 
 
         // -- remove tetrahedron id: 0 --
@@ -1462,9 +1508,17 @@ public:
         // check vertex mass
         EXPECT_FLOAT_EQ(vMasses[0], refValueV * 3); // check update of Mass when removing tetra
         EXPECT_FLOAT_EQ(vMasses[1], refValueV * 2);
-        // check edge mass
-        EXPECT_FLOAT_EQ(eMasses[0], refValueE);
-        EXPECT_FLOAT_EQ(eMasses[1], refValueE);
+        // check edge mass (only if not lumped else eMass is not computed)
+        if(!lumped)
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], refValueE);
+            EXPECT_FLOAT_EQ(eMasses[1], refValueE);
+        }
+        else
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], 0.);
+            EXPECT_FLOAT_EQ(eMasses[1], 0.);
+        }
 
 
         // -- remove tetrahedron id: 0, 1 --
@@ -1477,9 +1531,17 @@ public:
         // check vertex mass
         EXPECT_FLOAT_EQ(vMasses[0], refValueV);
         EXPECT_FLOAT_EQ(vMasses[1], refValueV);
-        // check edge mass
-        EXPECT_FLOAT_EQ(eMasses[0], refValueE);
-        EXPECT_FLOAT_EQ(eMasses[1], refValueE);
+        // check edge mass (only if not lumped else eMass is not computed)
+        if(!lumped)
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], refValueE);
+            EXPECT_FLOAT_EQ(eMasses[1], refValueE);
+        }
+        else
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], 0.);
+            EXPECT_FLOAT_EQ(eMasses[1], 0.);
+        }
 
         // -- remove tetrahedron id: 0, 1 --
         modifier->removeTetrahedra(elemIds);
@@ -1555,9 +1617,17 @@ public:
         // check vertex mass
         EXPECT_FLOAT_EQ(vMasses[0], refValueV);
         EXPECT_FLOAT_EQ(vMasses[1], refValueV * 2);
-        // check edge mass
-        EXPECT_FLOAT_EQ(eMasses[0], refValueE * 2);
-        EXPECT_FLOAT_EQ(eMasses[2], refValueE); // eMasses[1] == 0 because not taken into account from grid to quad Topology
+        // check edge mass (only if not lumped else eMass is not computed)
+        if(!lumped)
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], refValueE * 2);
+            EXPECT_FLOAT_EQ(eMasses[2], refValueE); // eMasses[1] == 0 because not taken into account from grid to quad Topology
+        }
+        else
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], 0.);
+            EXPECT_FLOAT_EQ(eMasses[2], 0.);
+        }
 
         // -- remove quad id: 0 -- 
         sofa::type::vector<sofa::Index> elemIds = { 0 };
@@ -1569,9 +1639,17 @@ public:
         // check vertex mass
         EXPECT_FLOAT_EQ(vMasses[0], refValueV); // check update of Mass when removing tetra
         EXPECT_FLOAT_EQ(vMasses[1], refValueV);
-        // check edge mass
-        EXPECT_FLOAT_EQ(eMasses[0], refValueE);
-        EXPECT_FLOAT_EQ(eMasses[3], refValueE);
+        // check edge mass (only if not lumped else eMass is not computed)
+        if(!lumped)
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], refValueE);
+            EXPECT_FLOAT_EQ(eMasses[3], refValueE);
+        }
+        else
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], 0.);
+            EXPECT_FLOAT_EQ(eMasses[3], 0.);
+        }
 
         // -- remove quad id: 0 --
         modifier->removeQuads(elemIds, true, true);
@@ -1582,9 +1660,17 @@ public:
         // check vertex mass
         EXPECT_FLOAT_EQ(vMasses[0], refValueV);
         EXPECT_FLOAT_EQ(vMasses[1], refValueV);
-        // check edge mass
-        EXPECT_FLOAT_EQ(eMasses[0], refValueE);
-        EXPECT_FLOAT_EQ(eMasses[3], refValueE);
+        // check edge mass (only if not lumped else eMass is not computed)
+        if(!lumped)
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], refValueE);
+            EXPECT_FLOAT_EQ(eMasses[3], refValueE);
+        }
+        else
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], 0.);
+            EXPECT_FLOAT_EQ(eMasses[3], 0.);
+        }
 
         // -- remove quad id: 0, 1 --
         elemIds.push_back(1);
@@ -1662,9 +1748,18 @@ public:
         // check vertex mass
         EXPECT_FLOAT_EQ(vMasses[0], refValueV * 2);
         EXPECT_FLOAT_EQ(vMasses[1], refValueV * 3);
-        // check edge mass
-        EXPECT_FLOAT_EQ(eMasses[0], refValueE * 2);
-        EXPECT_FLOAT_EQ(eMasses[1], refValueE * 2);
+        // check edge mass (only if not lumped else eMass is not computed)
+        if(!lumped)
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], refValueE * 2);
+            EXPECT_FLOAT_EQ(eMasses[1], refValueE * 2);
+        }
+        else
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], 0.);
+            EXPECT_FLOAT_EQ(eMasses[1], 0.);
+        }
+
 
         // -- remove triangle id: 0 -- 
         sofa::type::vector<sofa::Index> elemIds = { 0 };
@@ -1676,9 +1771,17 @@ public:
         // check vertex mass
         EXPECT_FLOAT_EQ(vMasses[0], refValueV); // check update of Mass when removing tetra
         EXPECT_FLOAT_EQ(vMasses[1], refValueV * 2);
-        // check edge mass
-        EXPECT_FLOAT_EQ(eMasses[0], refValueE);
-        EXPECT_FLOAT_EQ(eMasses[3], refValueE * 2);
+        // check edge mass (only if not lumped else eMass is not computed)
+        if(!lumped)
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], refValueE);
+            EXPECT_FLOAT_EQ(eMasses[3], refValueE * 2);
+        }
+        else
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], 0.);
+            EXPECT_FLOAT_EQ(eMasses[3], 0.);
+        }
 
         // -- remove triangle id: 0 --
         modifier->removeTriangles(elemIds, true, true);
@@ -1689,9 +1792,17 @@ public:
         // check vertex mass
         EXPECT_FLOAT_EQ(vMasses[0], refValueV);
         EXPECT_FLOAT_EQ(vMasses[1], refValueV * 2);
-        // check edge mass
-        EXPECT_FLOAT_EQ(eMasses[0], refValueE);
-        EXPECT_FLOAT_EQ(eMasses[3], refValueE * 2);
+        // check edge mass (only if not lumped else eMass is not computed)
+        if(!lumped)
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], refValueE);
+            EXPECT_FLOAT_EQ(eMasses[3], refValueE * 2);
+        }
+        else
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], 0.);
+            EXPECT_FLOAT_EQ(eMasses[3], 0.);
+        }
 
         // -- remove triangle id: 0, 1 --
         elemIds.push_back(1);
@@ -1703,9 +1814,17 @@ public:
         // check vertex mass
         EXPECT_FLOAT_EQ(vMasses[0], refValueV * 2);
         EXPECT_FLOAT_EQ(vMasses[1], refValueV * 2);
-        // check edge mass
-        EXPECT_FLOAT_EQ(eMasses[0], refValueE);
-        EXPECT_FLOAT_EQ(eMasses[3], refValueE);
+        // check edge mass (only if not lumped else eMass is not computed)
+        if(!lumped)
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], refValueE);
+            EXPECT_FLOAT_EQ(eMasses[3], refValueE);
+        }
+        else
+        {
+            EXPECT_FLOAT_EQ(eMasses[0], 0.);
+            EXPECT_FLOAT_EQ(eMasses[3], 0.);
+        }
 
         // -- remove triangle id: 0, 1, 2, 3 --
         elemIds.push_back(2);

--- a/modules/SofaMiscForceField/SofaMiscForceField_test/MeshMatrixMass_test.cpp
+++ b/modules/SofaMiscForceField/SofaMiscForceField_test/MeshMatrixMass_test.cpp
@@ -1747,12 +1747,12 @@ TEST_F(MeshMatrixMass3_test, singleTriangle)
     TriangleSetGeometryAlgorithms<Vec3Types>::SPtr geometryAlgorithms
         = New<TriangleSetGeometryAlgorithms<Vec3Types> >();
 
-    static const MassType volume = 0.5;
+    static const MassType surface = 0.5;
     static const MassType expectedTotalMass = 1.0f;
-    static const MassType density = expectedTotalMass / volume;
+    static const MassType density = expectedTotalMass / surface;
 
-    static const VecMass expectedVMass(3, (MassType)(density * volume * 1 / 6));
-    static const VecMass expectedEMass(3, (MassType)(density * volume * 1 / 12));
+    static const VecMass expectedVMass(3, (MassType)(density * surface * 1 / 6));
+    static const VecMass expectedEMass(3, (MassType)(density * surface * 1 / 12));
 
     runTest(positions, topologyContainer, geometryAlgorithms, expectedTotalMass, density, expectedVMass, expectedEMass);
 }
@@ -1771,11 +1771,11 @@ TEST_F(MeshMatrixMass3_test, singleQuad)
     QuadSetGeometryAlgorithms<Vec3Types>::SPtr geometryAlgorithms
         = New<QuadSetGeometryAlgorithms<Vec3Types> >();
 
-    static const MassType volume = 1.0;
+    static const MassType surface = 1.0;
     static const MassType expectedTotalMass = 1.0f;
-    static const MassType density = expectedTotalMass / volume;
-    static const VecMass expectedVMass(4, (MassType)(density * volume * 1 / 8));
-    static const VecMass expectedEMass(4, (MassType)(density * volume * 1 / 16));
+    static const MassType density = expectedTotalMass / surface;
+    static const VecMass expectedVMass(4, (MassType)(density * surface * 1 / 8));
+    static const VecMass expectedEMass(4, (MassType)(density * surface * 1 / 16));
 
     runTest(positions, topologyContainer, geometryAlgorithms, expectedTotalMass, density, expectedVMass, expectedEMass);
 }

--- a/modules/SofaMiscForceField/SofaMiscForceField_test/MeshMatrixMass_test.cpp
+++ b/modules/SofaMiscForceField/SofaMiscForceField_test/MeshMatrixMass_test.cpp
@@ -1241,21 +1241,39 @@ public:
     }
 
 
-    void checkTopologicalChanges_Hexa()
+    void checkTopologicalChanges_Hexa(bool lumped)
     {
-        static const string scene =
-            "<?xml version='1.0'?>                                                                              "
-            "<Node  name='Root' gravity='0 0 0' time='0' animate='0'   >                                        "
-            "    <RegularGridTopology name='grid' n='3 3 3' min='0 0 0' max='2 2 2' p0='0 0 0' />               "
-            "    <Node name='Hexa' >                                                                            "
-            "            <MechanicalObject position = '@../grid.position' />                                    "
-            "            <HexahedronSetTopologyContainer name='Container' src='@../grid' />                     "
-            "            <HexahedronSetTopologyModifier name='Modifier' />                                      "
-            "            <HexahedronSetGeometryAlgorithms template='Vec3d' name='GeomAlgo' />                   "
-            "            <MeshMatrixMass name='m_mass' massDensity='1.0'/>                                        "
-            "    </Node>                                                                                        "
-            "</Node>                                                                                            ";
-
+        string scene;
+        if(!lumped)
+        {
+            scene =
+                    "<?xml version='1.0'?>                                                                              "
+                    "<Node  name='Root' gravity='0 0 0' time='0' animate='0'   >                                        "
+                    "    <RegularGridTopology name='grid' n='3 3 3' min='0 0 0' max='2 2 2' p0='0 0 0' />               "
+                    "    <Node name='Hexa' >                                                                            "
+                    "            <MechanicalObject position = '@../grid.position' />                                    "
+                    "            <HexahedronSetTopologyContainer name='Container' src='@../grid' />                     "
+                    "            <HexahedronSetTopologyModifier name='Modifier' />                                      "
+                    "            <HexahedronSetGeometryAlgorithms template='Vec3d' name='GeomAlgo' />                   "
+                    "            <MeshMatrixMass name='m_mass' massDensity='1.0'/>                                      "
+                    "    </Node>                                                                                        "
+                    "</Node>                                                                                            ";
+        }
+        else
+        {
+            scene =
+                    "<?xml version='1.0'?>                                                                              "
+                    "<Node  name='Root' gravity='0 0 0' time='0' animate='0'   >                                        "
+                    "    <RegularGridTopology name='grid' n='3 3 3' min='0 0 0' max='2 2 2' p0='0 0 0' />               "
+                    "    <Node name='Hexa' >                                                                            "
+                    "            <MechanicalObject position = '@../grid.position' />                                    "
+                    "            <HexahedronSetTopologyContainer name='Container' src='@../grid' />                     "
+                    "            <HexahedronSetTopologyModifier name='Modifier' />                                      "
+                    "            <HexahedronSetGeometryAlgorithms template='Vec3d' name='GeomAlgo' />                   "
+                    "            <MeshMatrixMass name='m_mass' massDensity='1.0' lumping='true'                         "
+                    "    </Node>                                                                                        "
+                    "</Node>                                                                                            ";
+        }
         Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam",
             scene.c_str(),
             sofa::Size(scene.size()));
@@ -1345,22 +1363,43 @@ public:
     }
 
 
-    void checkTopologicalChanges_Tetra()
+    void checkTopologicalChanges_Tetra(bool lumped)
     {
-        static const string scene =
-            "<?xml version='1.0'?>                                                                              "
-            "<Node  name='Root' gravity='0 0 0' time='0' animate='0'   >                                        "
-            "    <RequiredPlugin name='SofaTopologyMapping'/>                                                   "
-            "    <RegularGridTopology name='grid' n='2 2 2' min='0 0 0' max='2 2 2' p0='0 0 0' />               "
-            "    <Node name='Tetra' >                                                                           "
-            "            <MechanicalObject position='@../grid.position' />                                      "
-            "            <TetrahedronSetTopologyContainer name='Container' />                                   "
-            "            <TetrahedronSetTopologyModifier name='Modifier' />                                     "
-            "            <TetrahedronSetGeometryAlgorithms template='Vec3d' name='GeomAlgo' />                  "
-            "            <Hexa2TetraTopologicalMapping input='@../grid' output='@Container' />                  "
-            "            <MeshMatrixMass name='m_mass' massDensity='1.0'/>                                        "
-            "    </Node>                                                                                        "
-            "</Node>                                                                                            ";
+        string scene;
+        if(!lumped)
+        {
+             scene =
+                    "<?xml version='1.0'?>                                                                              "
+                    "<Node  name='Root' gravity='0 0 0' time='0' animate='0'   >                                        "
+                    "    <RequiredPlugin name='SofaTopologyMapping'/>                                                   "
+                    "    <RegularGridTopology name='grid' n='2 2 2' min='0 0 0' max='2 2 2' p0='0 0 0' />               "
+                    "    <Node name='Tetra' >                                                                           "
+                    "            <MechanicalObject position='@../grid.position' />                                      "
+                    "            <TetrahedronSetTopologyContainer name='Container' />                                   "
+                    "            <TetrahedronSetTopologyModifier name='Modifier' />                                     "
+                    "            <TetrahedronSetGeometryAlgorithms template='Vec3d' name='GeomAlgo' />                  "
+                    "            <Hexa2TetraTopologicalMapping input='@../grid' output='@Container' />                  "
+                    "            <MeshMatrixMass name='m_mass' massDensity='1.0'/>                                      "
+                    "    </Node>                                                                                        "
+                    "</Node>                                                                                            ";
+        }
+        else
+        {
+            scene =
+                "<?xml version='1.0'?>                                                                              "
+                "<Node  name='Root' gravity='0 0 0' time='0' animate='0'   >                                        "
+                "    <RequiredPlugin name='SofaTopologyMapping'/>                                                   "
+                "    <RegularGridTopology name='grid' n='2 2 2' min='0 0 0' max='2 2 2' p0='0 0 0' />               "
+                "    <Node name='Tetra' >                                                                           "
+                "            <MechanicalObject position='@../grid.position' />                                      "
+                "            <TetrahedronSetTopologyContainer name='Container' />                                   "
+                "            <TetrahedronSetTopologyModifier name='Modifier' />                                     "
+                "            <TetrahedronSetGeometryAlgorithms template='Vec3d' name='GeomAlgo' />                  "
+                "            <Hexa2TetraTopologicalMapping input='@../grid' output='@Container' />                  "
+                "            <MeshMatrixMass name='m_mass' massDensity='1.0' lumping='true'/>                       "
+                "    </Node>                                                                                        "
+                "</Node>                                                                                            ";
+        }
 
         Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam",
             scene.c_str(),
@@ -1449,20 +1488,39 @@ public:
         EXPECT_NEAR(mass->getTotalMass(), 0, 1e-4);
     }
 
-    void checkTopologicalChanges_Quad()
+    void checkTopologicalChanges_Quad(bool lumped)
     {
-        static const string scene =
-            "<?xml version='1.0'?>                                                                              "
-            "<Node  name='Root' gravity='0 0 0' time='0' animate='0'   >                                        "
-            "    <RegularGridTopology name='grid' n='3 3 1' min='0 0 0' max='2 2 2' p0='0 0 0' />               "
-            "    <Node name='Quad' >                                                                            "
-            "            <MechanicalObject position = '@../grid.position' />                                    "
-            "            <QuadSetTopologyContainer name='Container' src='@../grid' />                     "
-            "            <QuadSetTopologyModifier name='Modifier' />                                      "
-            "            <QuadSetGeometryAlgorithms template='Vec3d' name='GeomAlgo' />                   "
-            "            <MeshMatrixMass name='m_mass' massDensity='1.0'/>                                        "
-            "    </Node>                                                                                        "
-            "</Node>                                                                                            ";
+        string scene;
+        if(!lumped)
+        {
+            scene =
+                    "<?xml version='1.0'?>                                                                              "
+                    "<Node  name='Root' gravity='0 0 0' time='0' animate='0'   >                                        "
+                    "    <RegularGridTopology name='grid' n='3 3 1' min='0 0 0' max='2 2 2' p0='0 0 0' />               "
+                    "    <Node name='Quad' >                                                                            "
+                    "            <MechanicalObject position = '@../grid.position' />                                    "
+                    "            <QuadSetTopologyContainer name='Container' src='@../grid' />                           "
+                    "            <QuadSetTopologyModifier name='Modifier' />                                            "
+                    "            <QuadSetGeometryAlgorithms template='Vec3d' name='GeomAlgo' />                         "
+                    "            <MeshMatrixMass name='m_mass' massDensity='1.0'/>                                      "
+                    "    </Node>                                                                                        "
+                    "</Node>                                                                                            ";
+        }
+        else
+        {
+            scene =
+                    "<?xml version='1.0'?>                                                                              "
+                    "<Node  name='Root' gravity='0 0 0' time='0' animate='0'   >                                        "
+                    "    <RegularGridTopology name='grid' n='3 3 1' min='0 0 0' max='2 2 2' p0='0 0 0' />               "
+                    "    <Node name='Quad' >                                                                            "
+                    "            <MechanicalObject position = '@../grid.position' />                                    "
+                    "            <QuadSetTopologyContainer name='Container' src='@../grid' />                           "
+                    "            <QuadSetTopologyModifier name='Modifier' />                                            "
+                    "            <QuadSetGeometryAlgorithms template='Vec3d' name='GeomAlgo' />                         "
+                    "            <MeshMatrixMass name='m_mass' massDensity='1.0' lumping='true'/>                       "
+                    "    </Node>                                                                                        "
+                    "</Node>                                                                                            ";
+        }
 
         Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam",
             scene.c_str(),
@@ -1537,20 +1595,39 @@ public:
     }
 
 
-    void checkTopologicalChanges_Triangle()
+    void checkTopologicalChanges_Triangle(bool lumped)
     {
-        static const string scene =
-            "<?xml version='1.0'?>                                                                              "
-            "<Node  name='Root' gravity='0 0 0' time='0' animate='0'   >                                        "
-            "    <RegularGridTopology name='grid' n='3 3 1' min='0 0 0' max='2 2 2' p0='0 0 0' />               "
-            "    <Node name='Triangle' >                                                                            "
-            "            <MechanicalObject position = '@../grid.position' />                                    "
-            "            <TriangleSetTopologyContainer name='Container' src='@../grid' />                     "
-            "            <TriangleSetTopologyModifier name='Modifier' />                                      "
-            "            <TriangleSetGeometryAlgorithms template='Vec3d' name='GeomAlgo' />                   "
-            "            <MeshMatrixMass name='m_mass' massDensity='1.0'/>                                        "
-            "    </Node>                                                                                        "
-            "</Node>                                                                                            ";
+        string scene;
+        if(!lumped)
+        {
+            scene =
+                    "<?xml version='1.0'?>                                                                              "
+                    "<Node  name='Root' gravity='0 0 0' time='0' animate='0'   >                                        "
+                    "    <RegularGridTopology name='grid' n='3 3 1' min='0 0 0' max='2 2 2' p0='0 0 0' />               "
+                    "    <Node name='Triangle' >                                                                        "
+                    "            <MechanicalObject position = '@../grid.position' />                                    "
+                    "            <TriangleSetTopologyContainer name='Container' src='@../grid' />                       "
+                    "            <TriangleSetTopologyModifier name='Modifier' />                                        "
+                    "            <TriangleSetGeometryAlgorithms template='Vec3d' name='GeomAlgo' />                     "
+                    "            <MeshMatrixMass name='m_mass' massDensity='1.0'/>                                      "
+                    "    </Node>                                                                                        "
+                    "</Node>                                                                                            ";
+        }
+        else
+        {
+            scene =
+                    "<?xml version='1.0'?>                                                                              "
+                    "<Node  name='Root' gravity='0 0 0' time='0' animate='0'   >                                        "
+                    "    <RegularGridTopology name='grid' n='3 3 1' min='0 0 0' max='2 2 2' p0='0 0 0' />               "
+                    "    <Node name='Triangle' >                                                                        "
+                    "            <MechanicalObject position = '@../grid.position' />                                    "
+                    "            <TriangleSetTopologyContainer name='Container' src='@../grid' />                       "
+                    "            <TriangleSetTopologyModifier name='Modifier' />                                        "
+                    "            <TriangleSetGeometryAlgorithms template='Vec3d' name='GeomAlgo' />                     "
+                    "            <MeshMatrixMass name='m_mass' massDensity='1.0' lumping='true'/>                       "
+                    "    </Node>                                                                                        "
+                    "</Node>                                                                                            ";
+        }
 
         Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam",
             scene.c_str(),
@@ -1639,20 +1716,39 @@ public:
         EXPECT_NEAR(mass->getTotalMass(), 0, 1e-4);
     }
 
-    void checkTopologicalChanges_Edge()
+    void checkTopologicalChanges_Edge(bool lumped)
     {
-        static const string scene =
-            "<?xml version='1.0'?>                                                                              "
-            "<Node  name='Root' gravity='0 0 0' time='0' animate='0'   >                                        "
-            "    <RegularGridTopology name='grid' n='4 1 1' min='0 0 0' max='2 2 2' p0='0 0 0' />               "
-            "    <Node name='Edge' >                                                                            "
-            "            <MechanicalObject position = '@../grid.position' />                                    "
-            "            <EdgeSetTopologyContainer name='Container' src='@../grid' />                     "
-            "            <EdgeSetTopologyModifier name='Modifier' />                                      "
-            "            <EdgeSetGeometryAlgorithms template='Vec3d' name='GeomAlgo' />                   "
-            "            <MeshMatrixMass name='m_mass' massDensity='1.0'/>                                        "
-            "    </Node>                                                                                        "
-            "</Node>                                                                                            ";
+        string scene;
+        if(!lumped)
+        {
+            scene =
+                    "<?xml version='1.0'?>                                                                              "
+                    "<Node  name='Root' gravity='0 0 0' time='0' animate='0'   >                                        "
+                    "    <RegularGridTopology name='grid' n='4 1 1' min='0 0 0' max='2 2 2' p0='0 0 0' />               "
+                    "    <Node name='Edge' >                                                                            "
+                    "            <MechanicalObject position = '@../grid.position' />                                    "
+                    "            <EdgeSetTopologyContainer name='Container' src='@../grid' />                           "
+                    "            <EdgeSetTopologyModifier name='Modifier' />                                            "
+                    "            <EdgeSetGeometryAlgorithms template='Vec3d' name='GeomAlgo' />                         "
+                    "            <MeshMatrixMass name='m_mass' massDensity='1.0'/>                                      "
+                    "    </Node>                                                                                        "
+                    "</Node>                                                                                            ";
+        }
+        else
+        {
+            scene =
+                "<?xml version='1.0'?>                                                                              "
+                "<Node  name='Root' gravity='0 0 0' time='0' animate='0'   >                                        "
+                "    <RegularGridTopology name='grid' n='4 1 1' min='0 0 0' max='2 2 2' p0='0 0 0' />               "
+                "    <Node name='Edge' >                                                                            "
+                "            <MechanicalObject position = '@../grid.position' />                                    "
+                "            <EdgeSetTopologyContainer name='Container' src='@../grid' />                           "
+                "            <EdgeSetTopologyModifier name='Modifier' />                                            "
+                "            <EdgeSetGeometryAlgorithms template='Vec3d' name='GeomAlgo' />                         "
+                "            <MeshMatrixMass name='m_mass' massDensity='1.0' lumping='true'/>                       "
+                "    </Node>                                                                                        "
+                "</Node>                                                                                            ";
+        }
 
         Node::SPtr root = SceneLoaderXML::loadFromMemory("loadWithNoParam",
             scene.c_str(),
@@ -1969,29 +2065,54 @@ TEST_F(MeshMatrixMass3_test, check_DoubleDeclaration_TotalMassAndMassDensity_Wro
 }
 
 
-TEST_F(MeshMatrixMass3_test, checkTopologicalChanges_Hexa) {
+TEST_F(MeshMatrixMass3_test, checkTopologicalChanges_Hexa_sparse) {
     EXPECT_MSG_NOEMIT(Error);
-    checkTopologicalChanges_Hexa();
+    checkTopologicalChanges_Hexa(false);
 }
 
-TEST_F(MeshMatrixMass3_test, checkTopologicalChanges_Tetra) {
+TEST_F(MeshMatrixMass3_test, checkTopologicalChanges_Tetra_sparse) {
     EXPECT_MSG_NOEMIT(Error);
-    checkTopologicalChanges_Tetra();
+    checkTopologicalChanges_Tetra(false);
 }
 
-TEST_F(MeshMatrixMass3_test, checkTopologicalChanges_Quad) {
+TEST_F(MeshMatrixMass3_test, checkTopologicalChanges_Quad_sparse) {
     EXPECT_MSG_NOEMIT(Error);
-    checkTopologicalChanges_Quad();
+    checkTopologicalChanges_Quad(false);
 }
 
-TEST_F(MeshMatrixMass3_test, checkTopologicalChanges_Triangle) {
+TEST_F(MeshMatrixMass3_test, checkTopologicalChanges_Triangle_sparse) {
     EXPECT_MSG_NOEMIT(Error);
-    checkTopologicalChanges_Triangle();
+    checkTopologicalChanges_Triangle(false);
 }
 
-TEST_F(MeshMatrixMass3_test, checkTopologicalChanges_Edge) {
+TEST_F(MeshMatrixMass3_test, checkTopologicalChanges_Edge_sparse) {
     EXPECT_MSG_NOEMIT(Error);
-    checkTopologicalChanges_Edge();
+    checkTopologicalChanges_Edge(false);
+}
+
+TEST_F(MeshMatrixMass3_test, checkTopologicalChanges_Hexa_lumped) {
+    EXPECT_MSG_NOEMIT(Error);
+    checkTopologicalChanges_Hexa(true);
+}
+
+TEST_F(MeshMatrixMass3_test, checkTopologicalChanges_Tetra_lumped) {
+    EXPECT_MSG_NOEMIT(Error);
+    checkTopologicalChanges_Tetra(true);
+}
+
+TEST_F(MeshMatrixMass3_test, checkTopologicalChanges_Quad_lumped) {
+    EXPECT_MSG_NOEMIT(Error);
+    checkTopologicalChanges_Quad(true);
+}
+
+TEST_F(MeshMatrixMass3_test, checkTopologicalChanges_Triangle_lumped) {
+    EXPECT_MSG_NOEMIT(Error);
+    checkTopologicalChanges_Triangle(true);
+}
+
+TEST_F(MeshMatrixMass3_test, checkTopologicalChanges_Edge_lumped) {
+    EXPECT_MSG_NOEMIT(Error);
+    checkTopologicalChanges_Edge(true);
 }
 
 

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -353,20 +353,26 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::ApplyTopologyChange
 template< class DataTypes, class MassType>
 void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(const core::topology::TrianglesAdded* topoEvent)
 {
-    const auto &triangleAdded = topoEvent->getIndexArray();
-    const sofa::type::vector<core::topology::BaseMeshTopology::Triangle> &elems = topoEvent->getElementArray();
-    const auto & ancestors = topoEvent->ancestorsList;
-    const sofa::type::vector<sofa::type::vector<double> > & coefs = topoEvent->coefs;
+    if(!this->m->isLumped())
+    {
+        const auto &triangleAdded = topoEvent->getIndexArray();
+        const sofa::type::vector<core::topology::BaseMeshTopology::Triangle> &elems = topoEvent->getElementArray();
+        const auto & ancestors = topoEvent->ancestorsList;
+        const sofa::type::vector<sofa::type::vector<double> > & coefs = topoEvent->coefs;
 
-    applyTriangleCreation(triangleAdded, elems, ancestors, coefs);
+        applyTriangleCreation(triangleAdded, elems, ancestors, coefs);
+    }
 }
 
 template< class DataTypes, class MassType>
 void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(const core::topology::TrianglesRemoved* e)
 {
-    const auto &triangleRemoved = e->getArray();
+    if(!this->m->isLumped())
+    {
+        const auto &triangleRemoved = e->getArray();
 
-    applyTriangleDestruction(triangleRemoved);
+        applyTriangleDestruction(triangleRemoved);
+    }
 }
 
 // }
@@ -608,20 +614,26 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::ApplyTopologyChange
 template< class DataTypes, class MassType>
 void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(const core::topology::QuadsAdded* topoEvent)
 {
-    const auto &quadAdded = topoEvent->getIndexArray();
-    const sofa::type::vector<core::topology::BaseMeshTopology::Quad> &elems = topoEvent->getElementArray();
-    const auto& ancestors = topoEvent->ancestorsList;
-    const sofa::type::vector<sofa::type::vector<double> > & coefs = topoEvent->coefs;
+    if(!this->m->isLumped())
+    {
+        const auto &quadAdded = topoEvent->getIndexArray();
+        const sofa::type::vector<core::topology::BaseMeshTopology::Quad> &elems = topoEvent->getElementArray();
+        const auto& ancestors = topoEvent->ancestorsList;
+        const sofa::type::vector<sofa::type::vector<double> > & coefs = topoEvent->coefs;
 
-    applyQuadCreation(quadAdded, elems, ancestors, coefs);
+        applyQuadCreation(quadAdded, elems, ancestors, coefs);
+    }
 }
 
 template< class DataTypes, class MassType>
 void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(const core::topology::QuadsRemoved* topoEvent)
 {
-    const auto &quadRemoved = topoEvent->getArray();
+    if(!this->m->isLumped())
+    {
+        const auto &quadRemoved = topoEvent->getArray();
 
-    applyQuadDestruction(quadRemoved);
+        applyQuadDestruction(quadRemoved);
+    }
 }
 
 // }
@@ -865,20 +877,26 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::ApplyTopologyChange
 template< class DataTypes, class MassType>
 void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(const core::topology::TetrahedraAdded* topoEvent)
 {
-    const auto &tetraAdded = topoEvent->getIndexArray();
-    const sofa::type::vector<core::topology::BaseMeshTopology::Tetrahedron> &elems = topoEvent->getElementArray();
-    const auto& ancestors = topoEvent->ancestorsList;
-    const sofa::type::vector<sofa::type::vector<double> > & coefs = topoEvent->coefs;
+    if(!this->m->isLumped())
+    {
+        const auto &tetraAdded = topoEvent->getIndexArray();
+        const sofa::type::vector<core::topology::BaseMeshTopology::Tetrahedron> &elems = topoEvent->getElementArray();
+        const auto& ancestors = topoEvent->ancestorsList;
+        const sofa::type::vector<sofa::type::vector<double> > & coefs = topoEvent->coefs;
 
-    applyTetrahedronCreation(tetraAdded, elems, ancestors, coefs);
+        applyTetrahedronCreation(tetraAdded, elems, ancestors, coefs);
+    }
 }
 
 template< class DataTypes, class MassType>
 void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(const core::topology::TetrahedraRemoved* topoEvent)
 {
-    const auto& tetraRemoved = topoEvent->getArray();
+    if(!this->m->isLumped())
+    {
+        const auto& tetraRemoved = topoEvent->getArray();
 
-    applyTetrahedronDestruction(tetraRemoved);
+        applyTetrahedronDestruction(tetraRemoved);
+    }
 }
 
 // }
@@ -1121,20 +1139,26 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::ApplyTopologyChange
 template< class DataTypes, class MassType>
 void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(const core::topology::HexahedraAdded* topoEvent)
 {
-    const auto &hexaAdded = topoEvent->getIndexArray();
-    const sofa::type::vector<core::topology::BaseMeshTopology::Hexahedron> &elems = topoEvent->getElementArray();
-    const auto & ancestors = topoEvent->ancestorsList;
-    const sofa::type::vector<sofa::type::vector<double> > & coefs = topoEvent->coefs;
+    if(!this->m->isLumped())
+    {
+        const auto &hexaAdded = topoEvent->getIndexArray();
+        const sofa::type::vector<core::topology::BaseMeshTopology::Hexahedron> &elems = topoEvent->getElementArray();
+        const auto & ancestors = topoEvent->ancestorsList;
+        const sofa::type::vector<sofa::type::vector<double> > & coefs = topoEvent->coefs;
 
-    applyHexahedronCreation(hexaAdded, elems, ancestors, coefs);
+        applyHexahedronCreation(hexaAdded, elems, ancestors, coefs);
+    }
 }
 
 template< class DataTypes, class MassType>
 void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::ApplyTopologyChange(const core::topology::HexahedraRemoved* topoEvent)
 {
-    const auto &hexaRemoved = topoEvent->getArray();
+    if(!this->m->isLumped())
+    {
+        const auto &hexaRemoved = topoEvent->getArray();
 
-    applyHexahedronDestruction(hexaRemoved);
+        applyHexahedronDestruction(hexaRemoved);
+    }
 }
 
 // }

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -107,8 +107,13 @@ template< class DataTypes, class MassType>
 void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::applyDestroyFunction(Index id, MassType& EdgeMass)
 {
     SOFA_UNUSED(id);
-    helper::WriteAccessor<Data<Real> > totalMass(this->m->d_totalMass);
-    totalMass -= EdgeMass;
+    if(!this->m->isLumped())
+    {
+        helper::WriteAccessor<Data<Real> > totalMass(this->m->d_totalMass);
+        totalMass -= EdgeMass;
+    }
+    else
+        SOFA_UNUSED(EdgeMass);
 }
 
 
@@ -166,7 +171,12 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyTriangleCreati
                 VertexMasses[ t[j] ] += mass;
 
             // update total mass: 
-            totalMass += 3.0 * mass * MMM->m_massLumpingCoeff;
+            if(!this->m->isLumped())
+            {
+                totalMass += 3.0 * mass;
+            }
+            else
+                totalMass += 3.0 * mass * MMM->m_massLumpingCoeff;
         }
     }
 }
@@ -218,8 +228,11 @@ void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::applyTriangleCreation
             for (unsigned int j=0; j<3; ++j)
                 EdgeMasses[ te[j] ] += mass;
 
-            // update total mass: *2 because added to 2 vertices
-            totalMass += 3.0 * 2.0 * mass;
+            // update total mass
+            if(!this->m->isLumped())
+            {
+                totalMass += 3.0 * mass * 2.0; // x 2 because mass is actually splitted over half-edges
+            }
         }
     }
 }
@@ -261,7 +274,12 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyTriangleDestru
                 VertexMasses[ t[j] ] -= mass;
 
             // update total mass
-            totalMass -= 3.0 * mass * MMM->m_massLumpingCoeff;
+            if(!this->m->isLumped())
+            {
+                totalMass -= 3.0 * mass;
+            }
+            else
+                totalMass -= 3.0 * mass * MMM->m_massLumpingCoeff;
         }
     }
 }
@@ -302,8 +320,11 @@ void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::applyTriangleDestruct
             for (unsigned int j=0; j<3; ++j)
                 EdgeMasses[ te[j] ] -= mass;
 
-            // update total mass: *2 because added to 2 vertices
-            totalMass -= 3.0 * 2.0 * mass;
+            // update total mass
+            if(!this->m->isLumped())
+            {
+                totalMass -= 3.0 * mass * 2.0; // x 2 because mass is actually splitted over half-edges
+            }
         }
     }
 }
@@ -401,7 +422,12 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyQuadCreation(c
                 VertexMasses[ q[j] ] += mass;
 
             // update total mass
-            totalMass += 4.0 * mass * MMM->m_massLumpingCoeff;
+            if(!this->m->isLumped())
+            {
+                totalMass += 4.0 * mass;
+            }
+            else
+                totalMass += 4.0 * mass * MMM->m_massLumpingCoeff;
         }
     }
 }
@@ -453,8 +479,11 @@ void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::applyQuadCreation(con
             for (unsigned int j=0; j<4; ++j)
                 EdgeMasses[ qe[j] ] += mass;
 
-            // update total mass: *2 because added to 2 vertices
-            totalMass += 4.0 * mass * 2.0;
+            // update total mass
+            if(!this->m->isLumped())
+            {
+                totalMass += 4.0 * mass * 2.0; // x 2 because mass is actually splitted over half-edges
+            }
         }
     }
 }
@@ -496,7 +525,12 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyQuadDestructio
                 VertexMasses[ q[j] ] -= mass;
 
             // update total mass
-            totalMass -= 4.0 * mass * MMM->m_massLumpingCoeff;
+            if(!this->m->isLumped())
+            {
+                totalMass -= 4.0 * mass;
+            }
+            else
+                totalMass -= 4.0 * mass * MMM->m_massLumpingCoeff;
         }
     }
 }
@@ -537,8 +571,11 @@ void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::applyQuadDestruction(
             for (unsigned int j=0; j<4; ++j)
                 EdgeMasses[ qe[j] ] -= mass;
 
-            // update total mass: *2 because added to 2 vertices
-            totalMass -= 4.0 * mass * 2.0;
+            // update total mass
+            if(!this->m->isLumped())
+            {
+                totalMass -= 4.0 * mass * 2.0; // x 2 because mass is actually splitted over half-edges
+            }
         }
     }
 }
@@ -638,7 +675,12 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyTetrahedronCre
                 VertexMasses[ t[j] ] += mass;
 
             // update total mass
-            totalMass += 4.0 * mass * MMM->m_massLumpingCoeff;
+            if(!this->m->isLumped())
+            {
+                totalMass += 4.0 * mass;
+            }
+            else
+                totalMass += 4.0 * mass * MMM->m_massLumpingCoeff;
         }
     }
 }
@@ -691,7 +733,10 @@ void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::applyTetrahedronCreat
                 EdgeMasses[ te[j] ] += mass;
 
             // update total mass
-            totalMass += 6.0 * mass * 2.0;
+            if(!this->m->isLumped())
+            {
+                totalMass += 6.0 * mass * 2.0; // x 2 because mass is actually splitted over half-edges
+            }
         }
     }
 }
@@ -733,7 +778,12 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyTetrahedronDes
                 VertexMasses[ t[j] ] -= mass;
 
             // update total mass
-            totalMass -= 4.0 * mass * MMM->m_massLumpingCoeff;
+            if(!this->m->isLumped())
+            {
+                totalMass -= 4.0 * mass;
+            }
+            else
+                totalMass -= 4.0 * mass * MMM->m_massLumpingCoeff;
         }
     }
 }
@@ -775,7 +825,10 @@ void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::applyTetrahedronDestr
                 EdgeMasses[ te[j] ] -= mass;
 
             // update total mass
-            totalMass -= 6.0 * mass * 2.0;
+            if(!this->m->isLumped())
+            {
+                totalMass -= 6.0 * mass * 2.0; // x 2 because mass is actually splitted over half-edges
+            }
         }
     }
 }
@@ -874,7 +927,12 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyHexahedronCrea
                 VertexMasses[ h[j] ] += mass;
 
             // update total mass
-            totalMass += 8.0 * mass * MMM->m_massLumpingCoeff;
+            if(!this->m->isLumped())
+            {
+                totalMass += 8.0 * mass;
+            }
+            else
+                totalMass += 8.0 * mass * MMM->m_massLumpingCoeff;
         }
     }
 }
@@ -927,7 +985,10 @@ void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::applyHexahedronCreati
                 EdgeMasses[ he[j] ] += mass;
 
             // update total mass
-            totalMass += 12.0 * mass * 2.0;
+            if(!this->m->isLumped())
+            {
+                totalMass += 12.0 * mass * 2.0; // x 2 because mass is actually splitted over half-edges
+            }
         }
     }
 }
@@ -969,7 +1030,12 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyHexahedronDest
                 VertexMasses[ h[j] ] -= mass;
 
             // update total mass
-            totalMass -= 8.0 * mass * MMM->m_massLumpingCoeff;
+            if(!this->m->isLumped())
+            {
+                totalMass -= 8.0 * mass;
+            }
+            else
+                totalMass -= 8.0 * mass * MMM->m_massLumpingCoeff;
         }
     }
 }
@@ -1011,7 +1077,10 @@ void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::applyHexahedronDestru
                 EdgeMasses[ he[j] ] -= mass;
 
             // update total mass
-            totalMass -= 12.0 * mass * 2.0;
+            if(!this->m->isLumped())
+            {
+                totalMass -= 12.0 * mass * 2.0; // x 2 because mass is actually splitted over half-edges
+            }
         }
     }
 }
@@ -1283,7 +1352,7 @@ void MeshMatrixMass<DataTypes, MassType>::massInitialization()
                     initFromVertexAndEdgeMass();
                 }
             }
-            else if(d_lumping.getValue() && !d_edgeMass.isSet())
+            else if(isLumped() && !d_edgeMass.isSet())
             {
                 if(!checkVertexMass())
                 {
@@ -1412,7 +1481,6 @@ void MeshMatrixMass<DataTypes, MassType>::computeMass()
         if (!isLumped())
         {
             m_edgeMassHandler->applyHexahedronCreation(hexahedraAdded, m_topology->getHexahedra(), emptyAncestors, emptyCoefficients);
-            m_massLumpingCoeff = 1.0;
         }
         
         m_vertexMassHandler->applyHexahedronCreation(hexahedraAdded, m_topology->getHexahedra(), emptyAncestors, emptyCoefficients);
@@ -1431,7 +1499,6 @@ void MeshMatrixMass<DataTypes, MassType>::computeMass()
         if (!isLumped())
         {
             m_edgeMassHandler->applyTetrahedronCreation(tetrahedraAdded, m_topology->getTetrahedra(), emptyAncestors, emptyCoefficients);
-            m_massLumpingCoeff = 1.0;
         }
 
         m_vertexMassHandler->applyTetrahedronCreation(tetrahedraAdded, m_topology->getTetrahedra(), emptyAncestors, emptyCoefficients);
@@ -1450,7 +1517,6 @@ void MeshMatrixMass<DataTypes, MassType>::computeMass()
         if (!isLumped())
         {
             m_edgeMassHandler->applyQuadCreation(quadsAdded, m_topology->getQuads(), emptyAncestors, emptyCoefficients);
-            m_massLumpingCoeff = 1.0;
         }
 
         m_vertexMassHandler->applyQuadCreation(quadsAdded, m_topology->getQuads(), emptyAncestors, emptyCoefficients);
@@ -1469,7 +1535,6 @@ void MeshMatrixMass<DataTypes, MassType>::computeMass()
         if (!isLumped())
         {
             m_edgeMassHandler->applyTriangleCreation(trianglesAdded, m_topology->getTriangles(), emptyAncestors, emptyCoefficients);
-            m_massLumpingCoeff = 1.0;
         }
 
         m_vertexMassHandler->applyTriangleCreation(trianglesAdded, m_topology->getTriangles(), emptyAncestors, emptyCoefficients);
@@ -1515,42 +1580,6 @@ void MeshMatrixMass<DataTypes, MassType>::doUpdateInternal()
             this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         }
     }
-
-    /*else if(this->hasDataChanged(d_vertexMass))
-    {
-        if(this->hasDataChanged(d_edgeMass))
-        {
-            if(checkVertexMass() && checkEdgeMass() )
-            {
-                initFromVertexAndEdgeMass();
-                this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
-            }
-            else
-            {
-                msg_error() << "doUpdateInternal: incorrect update from vertex and edgeMass";
-                this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
-            }
-        }
-        else if(d_lumping.getValue() && (!this->hasDataChanged(d_edgeMass)))
-        {
-            if(checkVertexMass())
-            {
-                initFromVertexMass();
-                this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
-            }
-            else
-            {
-                msg_error() << "doUpdateInternal: incorrect update from vertexMass (lumping)";
-                this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
-            }
-        }
-        else
-        {
-            this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
-            msg_error() << "Initialization using vertexMass requires the lumping option or the edgeMass information";
-        }
-    }*/
-
 
     //Info post-init
     msg_info() << "mass information updated";
@@ -1630,14 +1659,14 @@ void MeshMatrixMass<DataTypes, MassType>::initFromVertexMass()
     computeMass();
 
     helper::WriteAccessor<Data<MassVector> > vertexMassInfo = d_vertexMass;
-    //Compute volume = mass since massDensity = 1.0
+    //Compute mass (which is equal to the volume since massDensity = 1.0)
     Real volume = 0.0;
     for(size_t i=0; i<vertexMassInfo.size(); i++)
     {
         volume += vertexMassInfo[i]*m_massLumpingCoeff;
         vertexMassInfo[i] = vertexMass[i];
     }
-    m_massLumpingCoeff = 1.0;
+
     //Update all computed values
     setMassDensity(Real(totalMassSave/volume));
     d_totalMass.setValue(totalMassSave);
@@ -1812,13 +1841,17 @@ void MeshMatrixMass<DataTypes, MassType>::initFromMassDensity()
     const MassVector &vertexMassInfo = d_vertexMass.getValue();
     
     // Sum the mass per vertices and apply massLumping coef
-    Real sumMass = std::accumulate(vertexMassInfo.begin(), vertexMassInfo.end(), Real(0)) * m_massLumpingCoeff;
+    Real sumMass = std::accumulate(vertexMassInfo.begin(), vertexMassInfo.end(), Real(0));
 
-    if (!d_lumping.getValue())
+    if (!isLumped())
     {
         // Add mass per edges if not lumped, *2 as it is added to both edge vertices
         helper::WriteAccessor<Data<MassVector> > edgeMass = d_edgeMass;
-        sumMass += std::accumulate(edgeMass.begin(), edgeMass.end(), Real(0)) * 2;
+        sumMass += std::accumulate(edgeMass.begin(), edgeMass.end(), Real(0)) * 2.0;
+    }
+    else
+    {
+        sumMass *= m_massLumpingCoeff;
     }
 
     d_totalMass.setValue(sumMass);
@@ -2009,7 +2042,7 @@ void MeshMatrixMass<DataTypes, MassType>::addMDx(const core::MechanicalParams*, 
     SReal massTotal = 0.0;
 
     //using a lumped matrix (default)-----
-    if(d_lumping.getValue())
+    if(isLumped())
     {
         for (size_t i=0; i<dx.size(); i++)
         {
@@ -2066,7 +2099,7 @@ template <class DataTypes, class MassType>
 void MeshMatrixMass<DataTypes, MassType>::accFromF(const core::MechanicalParams* mparams, DataVecDeriv& a, const DataVecDeriv& f)
 {
     SOFA_UNUSED(mparams);
-    if( !d_lumping.getValue() )
+    if( !isLumped() )
     {
         msg_error() << "the method 'accFromF' can't be used with MeshMatrixMass as this SPARSE mass matrix can't be inversed easily. "
                     << "Please proceed to mass lumping or use a DiagonalMass (both are equivalent).";
@@ -2213,7 +2246,7 @@ void MeshMatrixMass<DataTypes, MassType>::addMToMatrix(const core::MechanicalPar
 
     SReal massTotal=0.0;
 
-    if(d_lumping.getValue())
+    if(isLumped())
     {
         for (size_t i=0; i<vertexMass.size(); i++)
         {

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -112,8 +112,6 @@ void MeshMatrixMass<DataTypes, MassType>::EdgeMassHandler::applyDestroyFunction(
         helper::WriteAccessor<Data<Real> > totalMass(this->m->d_totalMass);
         totalMass -= EdgeMass;
     }
-    else
-        SOFA_UNUSED(EdgeMass);
 }
 
 
@@ -176,7 +174,9 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyTriangleCreati
                 totalMass += 3.0 * mass;
             }
             else
+            {
                 totalMass += 3.0 * mass * MMM->m_massLumpingCoeff;
+            }
         }
     }
 }
@@ -279,7 +279,9 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyTriangleDestru
                 totalMass -= 3.0 * mass;
             }
             else
+            {
                 totalMass -= 3.0 * mass * MMM->m_massLumpingCoeff;
+            }
         }
     }
 }
@@ -427,7 +429,9 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyQuadCreation(c
                 totalMass += 4.0 * mass;
             }
             else
+            {
                 totalMass += 4.0 * mass * MMM->m_massLumpingCoeff;
+            }
         }
     }
 }
@@ -530,7 +534,9 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyQuadDestructio
                 totalMass -= 4.0 * mass;
             }
             else
+            {
                 totalMass -= 4.0 * mass * MMM->m_massLumpingCoeff;
+            }
         }
     }
 }
@@ -680,7 +686,9 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyTetrahedronCre
                 totalMass += 4.0 * mass;
             }
             else
+            {
                 totalMass += 4.0 * mass * MMM->m_massLumpingCoeff;
+            }
         }
     }
 }
@@ -783,7 +791,9 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyTetrahedronDes
                 totalMass -= 4.0 * mass;
             }
             else
+            {
                 totalMass -= 4.0 * mass * MMM->m_massLumpingCoeff;
+            }
         }
     }
 }
@@ -932,7 +942,9 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyHexahedronCrea
                 totalMass += 8.0 * mass;
             }
             else
+            {
                 totalMass += 8.0 * mass * MMM->m_massLumpingCoeff;
+            }
         }
     }
 }
@@ -1035,7 +1047,9 @@ void MeshMatrixMass<DataTypes, MassType>::VertexMassHandler::applyHexahedronDest
                 totalMass -= 8.0 * mass;
             }
             else
+            {
                 totalMass -= 8.0 * mass * MMM->m_massLumpingCoeff;
+            }
         }
     }
 }


### PR DESCRIPTION
Fix bug introduced in #2193 and reported by @jnbunet in the Caribou CI! Thanks again @jnbrunet and @epernod for the discussions !

- Homogeneize the use of the massLumpingCoeff
- In the test, only cosmetic change
- homogeneize and add scenes in the regression

Fixes #2301

[ci-depends-on https://github.com/sofa-framework/Regression/pull/18]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
