### PR TITLE
[CImgPlugin/image] Move file and clean headers

### DIFF
--- a/applications/plugins/CImgPlugin/CMakeLists.txt
+++ b/applications/plugins/CImgPlugin/CMakeLists.txt
@@ -5,7 +5,6 @@ set(HEADER_FILES
     src/CImgPlugin/ImageCImg.h
     src/CImgPlugin/CImgPlugin.h.in
     src/CImgPlugin/SOFACImg.h
-    src/CImgPlugin/CImgData.h
     )
 
 set(SOURCE_FILES

--- a/applications/plugins/CImgPlugin/src/CImgPlugin/CImgData.h
+++ b/applications/plugins/CImgPlugin/src/CImgPlugin/CImgData.h
@@ -3,19 +3,21 @@
 #include <CImgPlugin/SOFACImg.h>
 
 // datatypes
+#include <sofa/type/fixed_array.h>
 #include <sofa/type/Vec.h>
 #include <sofa/type/Mat.h>
 #include <sofa/type/Quat.h>
 
-// visual dependencies
-#include <SofaBaseVisual/VisualModelImpl.h>
-#include <SofaBaseVisual/VisualStyle.h>
+// topology
+#include <sofa/topology/Triangle.h>
+#include <sofa/topology/Quad.h>
 
 // helpers
 #include <sofa/helper/rmath.h>
 #include <sofa/helper/accessor.h>
-#include <sofa/type/fixed_array.h>
 #include <sofa/helper/rmath.h>
+
+#include <sofa/defaulttype/DataTypeInfo.h>
 
 
 namespace sofa
@@ -246,7 +248,7 @@ public:
     // returns a binary image cutting through 3D input meshes, corresponding to a plane indexed by "coord" along "axis" and inside a bounding box
     // positions are in image coordinates
     template<typename Real>
-    cimg_library::CImg<bool> get_slicedModels(const unsigned int coord,const unsigned int axis,const type::Mat<2,3,unsigned int>& ROI,const type::vector<type::Vec<3,Real> >& position, const type::vector< component::visualmodel::VisualModelImpl::VisualTriangle >& triangle, const type::vector< component::visualmodel::VisualModelImpl::VisualQuad >& quad) const
+    cimg_library::CImg<bool> get_slicedModels(const unsigned int coord,const unsigned int axis,const type::Mat<2,3,unsigned int>& ROI,const type::vector<type::Vec<3,Real> >& position, const type::vector< sofa::topology::Triangle >& triangles, const type::vector< sofa::topology::Quad >& quads) const
     {
         const unsigned int dim[3]= {ROI[1][0]-ROI[0][0]+1,ROI[1][1]-ROI[0][1]+1,ROI[1][2]-ROI[0][2]+1};
         cimg_library::CImg<bool> ret;
@@ -255,7 +257,7 @@ public:
         else ret=cimg_library::CImg<bool>(dim[0],dim[1]);
         ret.fill(false);
 
-        if(triangle.size()==0 && quad.size()==0) //pt visu
+        if(triangles.size()==0 && quads.size()==0) //pt visu
         {
             for (unsigned int i = 0; i < position.size() ; i++)
             {
@@ -277,9 +279,9 @@ public:
             type::Vec<3,int> pt[4];
             bool tru=true;
 
-            for (unsigned int i = 0; i < triangle.size() ; i++)  // box/ triangle intersection -> polygon with a maximum of 5 edges, to draw
+            for (unsigned int i = 0; i < triangles.size() ; i++)  // box/ triangle intersection -> polygon with a maximum of 5 edges, to draw
             {
-                for (unsigned int j = 0; j < 3 ; j++) { v[j] = position[triangle[i][j]]; pt[j]= type::Vec<3,int>((int)helper::round(v[j][0]),(int)helper::round(v[j][1]),(int)helper::round(v[j][2])); }
+                for (unsigned int j = 0; j < 3 ; j++) { v[j] = position[triangles[i][j]]; pt[j]= type::Vec<3,int>((int)helper::round(v[j][0]),(int)helper::round(v[j][1]),(int)helper::round(v[j][2])); }
 
                 type::vector<type::Vec<3,int> > pts;
                 for (unsigned int j = 0; j < 3 ; j++)
@@ -308,9 +310,9 @@ public:
                 }
 
             }
-            for (unsigned int i = 0; i < quad.size() ; i++)
+            for (unsigned int i = 0; i < quads.size() ; i++)
             {
-                for (unsigned int j = 0; j < 4 ; j++) { v[j] = position[quad[i][j]]; pt[j]= type::Vec<3,int>((int)helper::round(v[j][0]),(int)helper::round(v[j][1]),(int)helper::round(v[j][2])); }
+                for (unsigned int j = 0; j < 4 ; j++) { v[j] = position[quads[i][j]]; pt[j]= type::Vec<3,int>((int)helper::round(v[j][0]),(int)helper::round(v[j][1]),(int)helper::round(v[j][2])); }
 
                 type::vector<type::Vec<3,int> > pts;
                 for (unsigned int j = 0; j < 4 ; j++)

--- a/applications/plugins/image/CImgData.h
+++ b/applications/plugins/image/CImgData.h
@@ -8,16 +8,13 @@
 #include <sofa/type/Mat.h>
 #include <sofa/type/Quat.h>
 
-// topology
-#include <sofa/topology/Triangle.h>
-#include <sofa/topology/Quad.h>
-
 // helpers
 #include <sofa/helper/rmath.h>
 #include <sofa/helper/accessor.h>
 #include <sofa/helper/rmath.h>
 
 #include <sofa/defaulttype/DataTypeInfo.h>
+#include <SofaBaseVisual/VisualModelImpl.h>
 
 
 namespace sofa
@@ -248,7 +245,7 @@ public:
     // returns a binary image cutting through 3D input meshes, corresponding to a plane indexed by "coord" along "axis" and inside a bounding box
     // positions are in image coordinates
     template<typename Real>
-    cimg_library::CImg<bool> get_slicedModels(const unsigned int coord,const unsigned int axis,const type::Mat<2,3,unsigned int>& ROI,const type::vector<type::Vec<3,Real> >& position, const type::vector< sofa::topology::Triangle >& triangles, const type::vector< sofa::topology::Quad >& quads) const
+    cimg_library::CImg<bool> get_slicedModels(const unsigned int coord,const unsigned int axis,const type::Mat<2,3,unsigned int>& ROI,const type::vector<type::Vec<3,Real> >& position, const type::vector< sofa::component::visualmodel::VisualModelImpl::VisualTriangle >& triangles, const type::vector< sofa::component::visualmodel::VisualModelImpl::VisualQuad >& quads) const
     {
         const unsigned int dim[3]= {ROI[1][0]-ROI[0][0]+1,ROI[1][1]-ROI[0][1]+1,ROI[1][2]-ROI[0][2]+1};
         cimg_library::CImg<bool> ret;

--- a/applications/plugins/image/CMakeLists.txt
+++ b/applications/plugins/image/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SOURCE_FILES
     )
 set(HEADER_FILES
     config.h.in
+    CImgData.h
     CollisionToCarvingEngine.h
     Containers.h
     ImageAccumulator.h

--- a/applications/plugins/image/ImageCoordValuesFromPositions.h
+++ b/applications/plugins/image/ImageCoordValuesFromPositions.h
@@ -28,6 +28,7 @@
 #include <sofa/simulation/AnimateEndEvent.h>
 #include <sofa/helper/OptionsGroup.h>
 #include <sofa/type/Vec.h>
+#include <sofa/core/DataEngine.h>
 
 #define INTERPOLATION_NEAREST 0
 #define INTERPOLATION_LINEAR 1

--- a/applications/plugins/image/ImageToRigidMassEngine.h
+++ b/applications/plugins/image/ImageToRigidMassEngine.h
@@ -30,6 +30,7 @@
 #include <sofa/type/Vec.h>
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/helper/decompose.h>
+#include <sofa/core/DataEngine.h>
 
 namespace sofa
 {

--- a/applications/plugins/image/ImageTypes.h
+++ b/applications/plugins/image/ImageTypes.h
@@ -37,7 +37,7 @@
 #include "VectorVis.h"
 
 //(imports + Image data structure + others) are in here
-#include <CImgPlugin/CImgData.h>
+#include <image/CImgData.h>
 
 #include <SofaBaseVisual/VisualModelImpl.h>
 #include <SofaBaseVisual/VisualStyle.h>

--- a/applications/plugins/image/ImageTypes.h
+++ b/applications/plugins/image/ImageTypes.h
@@ -39,6 +39,9 @@
 //(imports + Image data structure + others) are in here
 #include <CImgPlugin/CImgData.h>
 
+#include <SofaBaseVisual/VisualModelImpl.h>
+#include <SofaBaseVisual/VisualStyle.h>
+
 namespace sofa
 {
 

--- a/applications/plugins/image/ImageValuesFromPositions.h
+++ b/applications/plugins/image/ImageValuesFromPositions.h
@@ -28,6 +28,7 @@
 #include <sofa/simulation/AnimateEndEvent.h>
 #include <sofa/helper/OptionsGroup.h>
 #include <sofa/type/Vec.h>
+#include <sofa/core/DataEngine.h>
 
 #define INTERPOLATION_NEAREST 0
 #define INTERPOLATION_LINEAR 1

--- a/applications/plugins/image/ImageViewer.h
+++ b/applications/plugins/image/ImageViewer.h
@@ -141,7 +141,7 @@ public:
     Data <int> scroll; ///< 0 if no scrolling, 1 for up, 2 for down, 3 left, and 4 for right
     Data <bool> display; ///< Boolean to activate/desactivate the display of the image
 
-    typedef component::visualmodel::VisualModelImpl VisuModelType;
+    typedef sofa::component::visualmodel::VisualModelImpl VisuModelType;
 
     ImageViewer() : Inherited()
       , image(initData(&image,ImageTypes(),"image","input image"))


### PR DESCRIPTION
CImgData.h only contains classes and things related to the image plugin.
Thats why it seems more consistent to move this file directly into the image plugin.

Moreover, it had a non-met (soft) dependency on SofaBaseVisual (as there is no cpp, and it is only used by the image plugin, this was not an issue before).

IMO, CImgPlugin should be only a plugin:
 - introducing the cimg library
 - using cimg, allowing loading various picture file format (jpg/png, etc)

I added some includes here and there as well.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
