### PR TITLE
[CMake] CLEAN and reenable old macro for git infos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,6 +296,8 @@ endif()
 file(WRITE "${CMAKE_BINARY_DIR}/plugins/README.txt" "This folder will be automatically scanned by the Plugin Manager.")
 install(DIRECTORY ${CMAKE_BINARY_DIR}/plugins/ DESTINATION plugins COMPONENT resources)
 
+sofa_install_git_infos(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR})
+
 # Post-install scripts (must be the last add_subdirectory)
 add_subdirectory(tools/postinstall-fixup)
 

--- a/SofaKernel/modules/Sofa.Config/cmake/SofaMacrosInstall.cmake
+++ b/SofaKernel/modules/Sofa.Config/cmake/SofaMacrosInstall.cmake
@@ -207,6 +207,8 @@ macro(sofa_create_package)
     if(ARG_RELOCATABLE)
         sofa_set_project_install_relocatable(${package_install_dir} ${CMAKE_CURRENT_BINARY_DIR} ${ARG_RELOCATABLE})
     endif()
+
+    sofa_install_git_infos(${ARG_PACKAGE_NAME} ${CMAKE_CURRENT_SOURCE_DIR})
 endmacro()
 
 
@@ -935,40 +937,42 @@ endfunction()
 ## to store which sources have been used for installed binaries
 ## these should be internal files and not delivered, but this is definitively useful
 ## when storing backups / demos across several repositories (e.g. sofa + plugins)
-macro( sofa_install_git_version name sourcedir )
-INSTALL( CODE
-"
-    find_package(Git REQUIRED)
-
-    # the current commit hash should be enough
-    # except if the git history changes...
-    # so adding more stuff to be sure
-
-    # get the current working branch
-    execute_process(
-      COMMAND \${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
-      WORKING_DIRECTORY ${sourcedir}
-      OUTPUT_VARIABLE SOFA_GIT_BRANCH
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-
-    # get the current commit info (hash, author, date, comment)
-    execute_process(
-      COMMAND \${GIT_EXECUTABLE} log --format=medium -n 1
-      WORKING_DIRECTORY ${sourcedir}
-      OUTPUT_VARIABLE SOFA_GIT_INFO
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-
-    string( TOLOWER \"${name}\" name_lower )
-    if( name_lower STREQUAL \"sofa\" )
-        file(WRITE  \"${CMAKE_INSTALL_PREFIX}/git.version\" \"######## ${name} ########\nBranch: \${SOFA_GIT_BRANCH}\n\${SOFA_GIT_INFO}\n############\n\n\" )
-    else()
-        file(APPEND \"${CMAKE_INSTALL_PREFIX}/git.version\" \"######## ${name} ########\nBranch: \${SOFA_GIT_BRANCH}\n\${SOFA_GIT_INFO}\n############\n\n\" )
+function(sofa_install_git_infos name sourcedir)
+    if(NOT EXISTS "${sourcedir}/.git")
+        return()
     endif()
-"
-)
-endmacro()
+    install(CODE "
+        find_package(Git REQUIRED)
+        # get the current working branch
+        execute_process(
+            COMMAND \${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+            WORKING_DIRECTORY \"${sourcedir}\"
+            OUTPUT_VARIABLE CURRENT_GIT_BRANCH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        # get the current commit info (hash, author, date, comment)
+        execute_process(
+            COMMAND \${GIT_EXECUTABLE} log --pretty -n 1
+            WORKING_DIRECTORY \"${sourcedir}\"
+            OUTPUT_VARIABLE CURRENT_GIT_INFO
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        # write all infos in git-infos.txt
+        file(WRITE \"\${CMAKE_INSTALL_PREFIX}/git-infos.txt\"
+            \"------ Git infos for ${name} ------\"    \\n
+                                                       \\n
+            \"---- Branch ----\"                       \\n
+            \"\${CURRENT_GIT_BRANCH}\"                 \\n
+                                                       \\n
+            \"---- Latest commit ----\"                \\n
+            \"\${CURRENT_GIT_INFO}\"                   \\n
+                                                       \\n
+            \"-----------------------------------\"    \\n
+            )
+        "
+        COMPONENT resources
+        )
+endfunction()
 
 
 


### PR DESCRIPTION
Macro sofa_install_git_infos will install a file `git-infos.txt` in all modules that contain a `.git` in their sources.
This will help to keep track of versions within SOFA binaries.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
