### PR TITLE
[CImgPlugin] Minimize plugin dependencies

### DIFF
--- a/applications/plugins/CImgPlugin/CMakeLists.txt
+++ b/applications/plugins/CImgPlugin/CMakeLists.txt
@@ -17,8 +17,8 @@ set(SOURCE_FILES
 
 add_subdirectory(extlibs/CImg)
 
-sofa_find_package(SofaFramework REQUIRED)
-sofa_find_package(SofaBaseVisual REQUIRED)
+sofa_find_package(Sofa.Helper REQUIRED)
+sofa_find_package(Sofa.DefaultType REQUIRED)
 sofa_find_package(CImg REQUIRED)
 
 # OS X only: if the user installed its own JPEG/PNG lib (typically with homebrew/port),
@@ -71,7 +71,7 @@ add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "$<BUILD_INTERFACE:${CImg_INCLUDE_DIRS}>")
 target_compile_options(${PROJECT_NAME} PUBLIC ${CIMG_CFLAGS})
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaCore SofaBaseVisual)
+target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Helper Sofa.DefaultType)
 target_link_libraries(${PROJECT_NAME} PUBLIC Threads::Threads)
 target_link_libraries(${PROJECT_NAME} PUBLIC ${DEP_TARGETS})
 


### PR DESCRIPTION
Compiled modules before:

- tinyxml
- Sofa.Type
- Sofa.Helper
- Sofa.DefaultType
- Sofa.Core
- Sofa.SimulationCore
- Sofa.BaseTopology
- Sofa.BaseVisual

Compiled modules after:

- Sofa.Type
- Sofa.Helper
- Sofa.DefaultType






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
