### PR TITLE
[Sofa.Helper_test] "fix" wstring unittest

### DIFF
--- a/SofaKernel/modules/SofaHelper/SofaHelper_test/Utils_test.cpp
+++ b/SofaKernel/modules/SofaHelper/SofaHelper_test/Utils_test.cpp
@@ -25,6 +25,7 @@
 #include <gtest/gtest.h>
 
 #include <sofa/helper/system/FileSystem.h>
+#include <sofa/helper/system/Locale.h>
 
 using sofa::helper::Utils;
 using sofa::helper::system::FileSystem;
@@ -35,6 +36,16 @@ TEST(UtilsTest, string_to_widestring_to_string)
     for (char c = 32 ; c <= 126 ; c++)
         ascii_chars.push_back(c);
     EXPECT_EQ(ascii_chars, Utils::narrowString(Utils::widenString(ascii_chars)));
+
+    // This test will pass if the executable has been executed with a unicode-compliant locale
+    // Windows and MacOS are unicode by default
+    // But it seems some linux distrib are not (?)
+#ifdef __linux
+    if(std::locale("").name().find("UTF-8") == std::string::npos)
+    {
+        return;
+    }
+#endif
 
     const std::string s("chaîne de test avec des caractères accentués");
     EXPECT_EQ(s, Utils::narrowString(Utils::widenString(s)));


### PR DESCRIPTION
"Fix" the dreaded test UtilsTest.string_to_widestring_to_string
which pass only if the test has been launched with a UTF-8 locale.

I tried setting TemporaryLocale to UTF-8 but it was still not working. 
(same with `setlocale(LC_ALL, "en_US.UTF-8");` coming directly from an example of cppreference)

Last try was to simply avoid running the test if we detect the system is not UTF-8.

Related to #2290

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
