### PR TITLE
[SofaKernel] Windows: Remove "inconsistent dll linkage" warnings

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TetrahedronSetTopologyContainer.h
@@ -286,8 +286,8 @@ public:
     /** \brief Returns the type of the topology */
     sofa::core::topology::TopologyElementType getTopologyType() const override {return sofa::core::topology::TopologyElementType::TETRAHEDRON;}
 
-    SOFA_SOFABASETOPOLOGY_API friend std::ostream& operator<< (std::ostream& out, const TetrahedronSetTopologyContainer& t);
-    SOFA_SOFABASETOPOLOGY_API friend std::istream& operator>>(std::istream& in, TetrahedronSetTopologyContainer& t);
+    friend std::ostream& operator<< (std::ostream& out, const TetrahedronSetTopologyContainer& t);
+    friend std::istream& operator>>(std::istream& in, TetrahedronSetTopologyContainer& t);
 
     /// \brief function to add a TopologyHandler to the current list of engines.
     void addTopologyHandler(sofa::core::topology::TopologyHandler* _TopologyHandler);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/fwd.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/fwd.h
@@ -127,8 +127,8 @@ SOFA_CORE_API std::istream& operator>> ( std::istream& in, const sofa::core::top
 namespace sofa::component::topology
 {
 class TetrahedronSetTopologyContainer;
-SOFA_CORE_API std::ostream& operator<< (std::ostream& out, const TetrahedronSetTopologyContainer& t);
-SOFA_CORE_API std::istream& operator>>(std::istream& in, TetrahedronSetTopologyContainer& t);
+std::ostream& operator<< (std::ostream& out, const TetrahedronSetTopologyContainer& t);
+std::istream& operator>>(std::istream& in, TetrahedronSetTopologyContainer& t);
 }
 
 namespace sofa::core::visual

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.h
@@ -40,7 +40,7 @@ SOFA_HELPER_API std::string gettypename(const std::type_info& t);
 
 /// Log classes registered in the factory
 template<class TKey>
-SOFA_HELPER_API void logFactoryRegister(const std::string& baseclass, const std::string& classname, TKey key, bool multi);
+void logFactoryRegister(const std::string& baseclass, const std::string& classname, TKey key, bool multi);
 
 SOFA_HELPER_API std::string& getFactoryLog();
 


### PR DESCRIPTION
Only relevant to Windows.

TetrahedronSetTopologyContainer's stream operators and especially Factory::logFactoryRegister() were throwing `inconsistent dll linkage` warnings (confusion of dllimport/dllexport).
This PR removes them.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
