### PR TITLE
[SofaCore_simutest] Fix getobjects and testcomponentstate unit tests

### DIFF
--- a/SofaKernel/modules/SofaCore/SofaCore_simutest/objectmodel/BaseContext_test.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_simutest/objectmodel/BaseContext_test.cpp
@@ -36,22 +36,25 @@ public:
     {
         EXPECT_MSG_NOEMIT(Error, Warning) ;
         importPlugin("SofaComponentAll") ;
-        std::stringstream scene ;
-        scene << "<?xml version='1.0'?>"
-                 "<Node name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
-                 "   <InfoComponent/>                                                             \n"
-                 "   <Node name='child1'>                                                    \n"
-                 "      <InfoComponent/>                                                          \n"
-                 "      <InfoComponent/>                                                          \n"
-                 "      <MechanicalObject />                                                 \n"
-                 "      <Node name='child2'>                                                 \n"
-                 "          <InfoComponent/>                                                      \n"
-                 "          <InfoComponent/>                                                      \n"
-                 "      </Node>                                                              \n"
-                 "   </Node>                                                                 \n"
-                 "</Node>                                                                    \n" ;
+        const std::string scene = R"(
+            <?xml version='1.0'?>
+            <Node name='Root' gravity='0 -9.81 0' time='0' animate='0' >
+               <DefaultAnimationLoop />
+               <DefaultVisualManagerLoop />
+               <InfoComponent/>
+               <Node name='child1'>
+                  <InfoComponent/>
+                  <InfoComponent/>
+                  <MechanicalObject />
+                  <Node name='child2'>
+                      <InfoComponent/>
+                      <InfoComponent/>
+                  </Node>
+               </Node>
+            </Node>
+        )";
 
-        SceneInstance c("xml", scene.str()) ;
+        SceneInstance c("xml", scene) ;
         c.initScene() ;
 
         Node* root = c.root.get() ;
@@ -68,9 +71,12 @@ public:
         ASSERT_EQ( context->getObjects(results2).size(), 3 ) ;
 
         /// Query a specific model with a compact syntax, this returns std::vector<BaseObject*>
-        /// So there is 4 base object in the scene.
+        /// getObjects()'s default search direction is SearchUp
+        /// so it will get the current objects in the context + the ones upper
+        /// (here 3 in child1 + 3 in root itself)
+        /// So it will find 6 base objects in the scene.
         for(auto& m : context->getObjects() ) { SOFA_UNUSED(m); }
-        ASSERT_EQ( context->getObjects().size(), 4 ) ;
+        ASSERT_EQ( context->getObjects().size(), 6 ) ;
 
         /// Query a specific model with a compact syntax, this returns std::vector<BaseObject*>
         for(auto& m : context->getObjects(BaseContext::SearchDirection::SearchDown) ) { SOFA_UNUSED(m); }

--- a/SofaKernel/modules/SofaCore/SofaCore_simutest/objectmodel/Base_test.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_simutest/objectmodel/Base_test.cpp
@@ -63,17 +63,20 @@ public:
     {
         EXPECT_MSG_NOEMIT(Error, Warning) ;
         importPlugin("SofaComponentAll") ;
-        std::stringstream scene ;
-        scene << "<?xml version='1.0'?>"
-                 "<Node name='Root' gravity='0 -9.81 0' time='0' animate='0' >               \n"
-                 "   <Node name='child1'>                                                    \n"
-                 "      <MechanicalObject />                                                 \n"
-                 "      <Node name='child2'>                                                 \n"
-                 "      </Node>                                                              \n"
-                 "   </Node>                                                                 \n"
-                 "</Node>                                                                    \n" ;
+        const std::string scene = R"(
+            <?xml version='1.0'?>
+            <Node name='Root' gravity='0 -9.81 0' time='0' animate='0' >
+               <DefaultAnimationLoop />
+               <DefaultVisualManagerLoop />
+               <Node name='child1'>
+                  <MechanicalObject />
+                  <Node name='child2'>
+                  </Node>
+               </Node>
+            </Node>
+        )";
 
-        SceneInstance c("xml", scene.str()) ;
+        SceneInstance c("xml", scene) ;
         c.initScene() ;
 
         Node* root = c.root.get() ;


### PR DESCRIPTION
They were failing since the introduction of 2 warning messages if one was not explicitly defining an AnimationLoop and a VisualLoop.

I've also adding some comment on a test and using a string litteral instead of the ugly stringstream when describing the scene in xml.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
