### PR TITLE
[examples] Limit GlobalSystemMatrixExporter.scn to 1 iteration

### DIFF
--- a/examples/.scene-tests
+++ b/examples/.scene-tests
@@ -46,3 +46,5 @@ ignore "Components/controller/MechanicalStateController.scn"
 ignore "Benchmark/TopologicalChanges/ProjectToPlaneConstraint_RemovingMeshTest.scn"
 ignore "Benchmark/TopologicalChanges/FixedPlaneConstraint_RemovingMeshTest.scn"
 
+# No need for more than 1 iteration to test an export
+iterations "examples/Components/linearsolver/GlobalSystemMatrixExporter.scn" "1"

--- a/examples/.scene-tests
+++ b/examples/.scene-tests
@@ -47,4 +47,4 @@ ignore "Benchmark/TopologicalChanges/ProjectToPlaneConstraint_RemovingMeshTest.s
 ignore "Benchmark/TopologicalChanges/FixedPlaneConstraint_RemovingMeshTest.scn"
 
 # No need for more than 1 iteration to test an export
-iterations "examples/Components/linearsolver/GlobalSystemMatrixExporter.scn" "1"
+iterations "Components/linearsolver/GlobalSystemMatrixExporter.scn" "1"


### PR DESCRIPTION
No need for more than 1 iteration to test an export






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
