### PR TITLE
[SofaHelper] Add a method getTrace() to BackTrace class.

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/BackTrace.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/BackTrace.h
@@ -23,6 +23,8 @@
 #define SOFA_HELPER_BACKTRACE_H
 
 #include <sofa/helper/config.h>
+#include <vector>
+#include <string>
 
 namespace sofa
 {
@@ -41,6 +43,9 @@ public:
     /// Useful to have information about crashes without starting a debugger (as it is not always easy to do, i.e. for parallel/distributed applications).
     /// Currently only works on Linux. NOOP on other architectures
     static void autodump();
+
+    typedef std::vector<std::string> StackTrace;
+    static StackTrace getTrace(size_t maxEntries=std::numeric_limits<unsigned int>().max());
 
 protected:
 


### PR DESCRIPTION
Currently the StackTraces are printed in std::cerr directly from the dump method().

Instead of doing that a new method is added to return the StackTrace as a vector
of strings allowing anyone to retrieve a StackTrace at any point
(including associating one with thrown exception).





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
