### PR TITLE
[Sofa.Helper] Remove usage of boost::filesystem

### DIFF
--- a/SofaKernel/modules/SofaHelper/CMakeLists.txt
+++ b/SofaKernel/modules/SofaHelper/CMakeLists.txt
@@ -4,9 +4,6 @@ project(Sofa.Helper)
 # DEPENDENCIES
 # sofa_find_package(Sofa.Type REQUIRED)
 
-# Boost
-sofa_find_package(Boost REQUIRED COMPONENTS filesystem BOTH_SCOPES)
-
 # Eigen (header only)
 sofa_find_package(Eigen3 REQUIRED)
 # Json (header only) needed by AdvancedTimer
@@ -188,10 +185,6 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 elseif(CMAKE_SYSTEM_NAME STREQUAL Windows)
     list(APPEND SOURCE_FILES  ${SRC_ROOT}/system/FileMonitor_windows.cpp)
 endif()
-if(Boost_FILESYSTEM_FOUND)
-    list(APPEND HEADER_FILES ${SRC_ROOT}/system/FileRepository.h)
-    list(APPEND SOURCE_FILES ${SRC_ROOT}/system/FileRepository.cpp)
-endif()
 
 sofa_find_package(Sofa.Config REQUIRED)
 sofa_find_package(Sofa.Type REQUIRED)
@@ -228,20 +221,6 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 elseif(CMAKE_SYSTEM_NAME STREQUAL Windows)
     # Windows library, used in system::FileSystem
     target_link_libraries(${PROJECT_NAME} PRIVATE Shlwapi)
-endif()
-
-# Boost
-if(Boost_FOUND)
-    target_link_libraries(${PROJECT_NAME} PUBLIC Boost::boost Boost::filesystem)
-
-    if (SOFA_BUILD_RELEASE_PACKAGE OR CMAKE_SYSTEM_NAME STREQUAL Windows)
-        sofa_install_libraries(PATHS ${Boost_LIBRARIES}) # Boost_LIBRARIES covers Boost internal dependencies
-    endif()
-
-    if(MSVC)
-        #define BOOST_ALL_DYN_LINK needed for dynamic linking with boost libraries
-        target_compile_definitions(${PROJECT_NAME} PUBLIC BOOST_ALL_DYN_LINK)
-    endif()
 endif()
 
 # Eigen (header only)

--- a/SofaKernel/modules/SofaHelper/Sofa.HelperConfig.cmake.in
+++ b/SofaKernel/modules/SofaHelper/Sofa.HelperConfig.cmake.in
@@ -7,11 +7,6 @@ find_package(Sofa.Config QUIET REQUIRED)
 find_package(Sofa.Type QUIET REQUIRED)
 find_package(Sofa.Topology QUIET REQUIRED)
 
-set(SOFA_HELPER_HAVE_BOOST "@SOFA_HELPER_HAVE_BOOST@")
-set(SOFA_HELPER_HAVE_BOOST_FILESYSTEM "@SOFA_HELPER_HAVE_BOOST_FILESYSTEM@")
-
-find_package(Boost QUIET REQUIRED filesystem)
-
 find_package(Eigen3 QUIET REQUIRED)
 
 if(NOT TARGET @PROJECT_NAME@)

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileMonitor_linux.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileMonitor_linux.cpp
@@ -38,16 +38,15 @@
 #include <vector>
 #include <string>
 #include <map>
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/operations.hpp>
-using namespace boost::filesystem;
+
 
 #include "FileSystem.h"
 using sofa::helper::system::FileSystem ;
 
 #include "FileMonitor.h"
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
+using namespace std::filesystem;
 
 using namespace std ;
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
@@ -31,7 +31,7 @@
 #include <unistd.h>
 #endif
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include <cstring>
 #include <cstdlib>
@@ -243,18 +243,9 @@ bool FileRepository::findFileIn(std::string& filename, const std::string& path)
 {
     if (filename.empty()) return false; // no filename
     std::string newfname = SetDirectory::GetRelativeFromDir(filename.c_str(), path.c_str());
-    std::locale locale;
-    try
-    {
-        locale = std::locale("en_US.UTF-8");
-    }
-    catch (const std::exception & /*e*/)
-    {
-        locale = std::locale("");
-    }
-    boost::filesystem::path::imbue(locale);
-    boost::filesystem::path p(newfname);
-    if (boost::filesystem::exists(p))
+
+    std::filesystem::path p = std::filesystem::u8path(newfname);
+    if (std::filesystem::exists(p))
     {
         // File found
         filename = newfname;
@@ -362,8 +353,7 @@ std::string FileRepository::relativeToPath(std::string path, std::string refPath
 
 const std::string FileRepository::getTempPath() const
 {
-    // TODO: replace std::filesystem when all compilers support it. (and not std::experimental::filesystem)
-    return boost::filesystem::temp_directory_path().string();
+    return std::filesystem::temp_directory_path().string();
 }
 
 } // namespace system

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
@@ -32,6 +32,7 @@
 #endif
 
 #include <filesystem>
+#include <iterator>
 
 #include <cstring>
 #include <cstdlib>

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileSystem.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileSystem.cpp
@@ -23,7 +23,7 @@
 #include <sofa/helper/logging/Messaging.h>
 #include <sofa/helper/Utils.h>
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include <fstream>
 #include <iostream>
@@ -318,9 +318,9 @@ std::string FileSystem::convertSlashesToBackSlashes(const std::string& path)
 bool FileSystem::removeAll(const std::string& path){
     try
     {
-        boost::filesystem::remove_all(path);
+        std::filesystem::remove_all(path);
     }
-    catch(boost::filesystem::filesystem_error const & /*e*/)
+    catch(std::filesystem::filesystem_error const & /*e*/)
     {
         return false ;
     }

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
@@ -27,7 +27,7 @@ using sofa::helper::system::FileSystem;
 #include <sofa/helper/Utils.h>
 #include <sofa/helper/logging/Messaging.h>
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <fstream>
 #include <array>
 
@@ -369,16 +369,16 @@ std::string PluginManager::findPlugin(const std::string& pluginName, const std::
         {
             const std::string& dir = *i;
 
-            boost::filesystem::recursive_directory_iterator iter(dir);
-            boost::filesystem::recursive_directory_iterator end;
+            std::filesystem::recursive_directory_iterator iter(dir);
+            std::filesystem::recursive_directory_iterator end;
 
             while (iter != end)
             {
-                if ( iter.level() > maxRecursiveDepth )
+                if ( iter.depth() > maxRecursiveDepth )
                 {
-                    iter.no_push(); // skip
+                    iter.disable_recursion_pending(); // skip
                 }
-                else if ( !boost::filesystem::is_directory(iter->path()) )
+                else if ( !std::filesystem::is_directory(iter->path()) )
                 {
                     const std::string path = iter->path().string();
                     const std::string filename = iter->path().filename().string();
@@ -390,7 +390,7 @@ std::string PluginManager::findPlugin(const std::string& pluginName, const std::
                     }
                 }
 
-                boost::system::error_code ec;
+                std::error_code ec;
                 iter.increment(ec);
                 if (ec)
                 {

--- a/applications/plugins/OptiTrackNatNet/CMakeLists.txt
+++ b/applications/plugins/OptiTrackNatNet/CMakeLists.txt
@@ -21,6 +21,12 @@ sofa_find_package(Boost QUIET COMPONENTS system regex date_time REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-DSOFA_BUILD_OPTITRACKNATNET")
+
+if(MSVC)
+    #define BOOST_ALL_DYN_LINK needed for dynamic linking with boost libraries
+    target_compile_definitions(${PROJECT_NAME} PUBLIC BOOST_ALL_DYN_LINK)
+endif()
+
 target_link_libraries(${PROJECT_NAME} SofaCore SofaSimulationCommon SofaUserInteraction Sofa.GL)
 target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES})
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/..")

--- a/modules/SofaExporter/SofaExporter_test/MeshExporter_test.cpp
+++ b/modules/SofaExporter/SofaExporter_test/MeshExporter_test.cpp
@@ -47,9 +47,9 @@ using sofa::helper::system::FileSystem ;
 
 using ::testing::Types;
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 namespace {
-std::string tempdir = boost::filesystem::temp_directory_path().string() ;
+std::string tempdir = std::filesystem::temp_directory_path().string() ;
 
 class MeshExporter_test : public BaseTest,
                           public ::testing::WithParamInterface<vector<string>>

--- a/modules/SofaExporter/SofaExporter_test/OBJExporter_test.cpp
+++ b/modules/SofaExporter/SofaExporter_test/OBJExporter_test.cpp
@@ -45,9 +45,9 @@ using sofa::core::execparams::defaultInstance;
 #include <sofa/helper/system/FileSystem.h>
 using sofa::helper::system::FileSystem ;
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 namespace{
-std::string tempdir = boost::filesystem::temp_directory_path().string() ;
+std::string tempdir = std::filesystem::temp_directory_path().string() ;
 
 
 class OBJExporter_test : public BaseTest {

--- a/modules/SofaExporter/SofaExporter_test/STLExporter_test.cpp
+++ b/modules/SofaExporter/SofaExporter_test/STLExporter_test.cpp
@@ -49,9 +49,9 @@ using sofa::helper::system::FileSystem ;
 
 #include <SofaBaseUtils/initSofaBaseUtils.h>
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 namespace {
-std::string tempdir = boost::filesystem::temp_directory_path().string() ;
+std::string tempdir = std::filesystem::temp_directory_path().string() ;
 
 
 class STLExporter_test : public BaseTest {


### PR DESCRIPTION
boost::filesystem is the last dependency on a (compiled) boost library.
However, SOFA is still dependent on header-only boost libraries (for graph, stable_vector and intrusive_ptr especially)
(config of the target Boost::boost is in Sofa.Type)

The change is really easy. just replace boost::filesystem with std::filesystem.
The only non trivial 1-1 replacement was for managing unicode path (not sure on the change actually)

This is finally possible because minimum requirement is ubuntu 20.04 (with an updated version of gcc supporting std::filesystem instead of std::experimental::filesystem) and macOS 10.15 (same with its clang version/mac SDK)

[ci-depends-on https://github.com/sofa-framework/SofaPython3/pull/177]
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
