### PR TITLE
[Sofa.LinearAlgebra] Fix assert in CompressedRowSparseMatrix

### DIFF
--- a/SofaKernel/modules/Sofa.LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrix.h
+++ b/SofaKernel/modules/Sofa.LinearAlgebra/src/sofa/linearalgebra/CompressedRowSparseMatrix.h
@@ -1400,9 +1400,9 @@ public:
     template<typename RB, typename RVB, typename RVI, typename MB, typename MVB, typename MVI >
     void mul( CompressedRowSparseMatrix<RB,RVB,RVI>& res, const CompressedRowSparseMatrix<MB,MVB,MVI>& m ) const
     {
-        assert( Bloc::nbCols == MB::nbLines );
-        assert( RB::nbLines == Bloc::nbLines );
-        assert( MB::nbCols == RB::nbCols );
+        static_assert( NC == CompressedRowSparseMatrix<MB,MVB,MVI>::NL );
+        static_assert( CompressedRowSparseMatrix<RB,RVB,RVI>::NL == NL );
+        static_assert( CompressedRowSparseMatrix<MB,MVB,MVI>::NC == CompressedRowSparseMatrix<RB,RVB,RVI>::NC );
 
         assert( colSize() == m.rowSize() );
 
@@ -1462,9 +1462,9 @@ public:
     template<typename RB, typename RVB, typename RVI, typename MB, typename MVB, typename MVI >
     void mulTranspose( CompressedRowSparseMatrix<RB,RVB,RVI>& res, const CompressedRowSparseMatrix<MB,MVB,MVI>& m ) const
     {
-        assert( Bloc::nbLines == MB::nbLines );
-        assert( RB::nbLines == Bloc::nbCols );
-        assert( MB::nbCols == RB::nbCols );
+        static_assert( NL == CompressedRowSparseMatrix<MB,MVB,MVI>::NL );
+        static_assert( CompressedRowSparseMatrix<RB,RVB,RVI>::NL == NC );
+        static_assert( CompressedRowSparseMatrix<MB,MVB,MVI>::NC == CompressedRowSparseMatrix<RB,RVB,RVI>::NC );
 
         assert( rowSize() == m.rowSize() );
 


### PR DESCRIPTION
- Make the assert static so the check is made at compile-time, independently of the compilation mode
- Make the check generic using constants that exist independently of the type of blocks






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
