### PR TITLE
[SofaSimulationCore] Event is propagated also on object's slaves.

### DIFF
--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/PropagateEventVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/PropagateEventVisitor.h
@@ -19,17 +19,13 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_SIMULATION_PROPAGATEEVENTACTION_H
-#define SOFA_SIMULATION_PROPAGATEEVENTACTION_H
+#pragma once
 
+#include <unordered_set>
 #include <sofa/simulation/Visitor.h>
 #include <sofa/core/objectmodel/Event.h>
 
-
-namespace sofa
-{
-
-namespace simulation
+namespace sofa::simulation
 {
 
 /**
@@ -51,12 +47,12 @@ public:
     const char* getClassName() const override { return "PropagateEventVisitor"; }
     virtual std::string getInfos() const override { return std::string(m_event->getClassName());  }
 protected:
-    sofa::core::objectmodel::Event* m_event;
+    sofa::core::objectmodel::Event* m_event { nullptr };
+
+    /// List of BaseObject already processed by this visitor
+    /// This is to avoid processing an object multiple times in case an object appear twice in the graph
+    std::unordered_set<core::objectmodel::BaseObject*> processedObjects;
 };
 
 
-}
-
-}
-
-#endif
+} //namespace sofa::simulation


### PR DESCRIPTION
Events were propagated to objects through a visitor, and applied on the list of objects contained in each Node. However, if an object is a child of another, it is not in the list of the Node. Therefore, the event is not propagated to this object.

The event is also propagated to children in this PR. 
I also added a security in case the object appears multiple times in the graph.
Finally, I make a copy of the list before processing the list, so that the event can modify the graph during the iterations.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
