### PR TITLE
[Sofa.Helper] Fix and micro-optimize AdvancedTimer

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ConstraintSolver.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ConstraintSolver.cpp
@@ -23,6 +23,7 @@
 #include <sofa/helper/AdvancedTimer.h>
 #include <sofa/core/objectmodel/BaseNode.h>
 #include <sofa/core/ConstraintParams.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 
 namespace sofa::core::behavior
 {

--- a/SofaKernel/modules/SofaExplicitOdeSolver/src/SofaExplicitOdeSolver/EulerSolver.cpp
+++ b/SofaKernel/modules/SofaExplicitOdeSolver/src/SofaExplicitOdeSolver/EulerSolver.cpp
@@ -26,6 +26,7 @@
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/behavior/MultiMatrix.h>
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 
 #include <sofa/simulation/mechanicalvisitor/MechanicalGetNonDiagonalMassesCountVisitor.h>
 using sofa::simulation::mechanicalvisitor::MechanicalGetNonDiagonalMassesCountVisitor;

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/AdvancedTimer.h
@@ -24,10 +24,8 @@
 #include <sofa/helper/system/thread/thread_specific_ptr.h>
 #include <sofa/helper/system/thread/CTime.h>
 #include <sofa/type/vector.h>
-#include <sofa/helper/ScopedAdvancedTimer.h>
 
 #include <ostream>
-#include <istream>
 #include <string>
 #include <map>
 
@@ -167,10 +165,12 @@ public:
 
             /// the list of the id names. the Ids are the indices in the vector
             std::vector<std::string> idsList;
+            std::map<std::string, unsigned int> idsMap;
 
             IdFactory()
             {
-                idsList.push_back(std::string("0")); // ID 0 == "0" or empty string
+                idsMap.insert({"0", 0});
+                idsList.push_back("0");
             }
             
         public:
@@ -184,22 +184,17 @@ public:
                 if (name.empty())
                     return 0;
                 IdFactory& idfac = getInstance();
-                std::vector<std::string>::iterator it = idfac.idsList.begin();
-                unsigned int i = 0;
 
-                while (it != idfac.idsList.end() && (*it) != name)
+                const auto it = idfac.idsMap.find(name);
+                if (it == idfac.idsMap.end())
                 {
-                    ++it;
-                    i++;
-                }
-
-                if (it!=idfac.idsList.end())
-                    return i;
-                else
-                {
+                    const auto idsMapSize = idfac.idsMap.size();
+                    idfac.idsMap.insert({name, idsMapSize});
                     idfac.idsList.push_back(name);
-                    return i;
+                    return idsMapSize;
                 }
+
+                return it->second;
             }
 
             static std::size_t getLastID()

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/ScopedAdvancedTimer.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/ScopedAdvancedTimer.cpp
@@ -26,19 +26,20 @@ namespace sofa::helper
 {
 
 ScopedAdvancedTimer::ScopedAdvancedTimer(const std::string& message)
-    : ScopedAdvancedTimer(message.c_str())
+    : m_id( message )
 {
+    AdvancedTimer::stepBegin( m_id );
 }
 
 ScopedAdvancedTimer::ScopedAdvancedTimer( const char* message )
-    : message( message )
+    : m_id( message )
 {
-    AdvancedTimer::stepBegin( message );
+    AdvancedTimer::stepBegin( m_id );
 }
 
 ScopedAdvancedTimer::~ScopedAdvancedTimer()
 {
-    AdvancedTimer::stepEnd( message );
+    AdvancedTimer::stepEnd( m_id );
 }
 
 } /// sofa::helper

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/ScopedAdvancedTimer.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/ScopedAdvancedTimer.h
@@ -24,6 +24,8 @@
 #include <sofa/helper/config.h>
 #include<string>
 
+#include <sofa/helper/AdvancedTimer.h>
+
 namespace sofa::helper
 {
 
@@ -37,9 +39,10 @@ namespace sofa::helper
 ///     measurement recorded.
 struct SOFA_HELPER_API ScopedAdvancedTimer
 {
-    const char* message;
-    ScopedAdvancedTimer(const std::string& message);
-    ScopedAdvancedTimer( const char* message );
+    AdvancedTimer::IdStep m_id;
+
+    explicit ScopedAdvancedTimer(const std::string& message);
+    explicit ScopedAdvancedTimer( const char* message );
     ~ScopedAdvancedTimer();
 };
 

--- a/SofaKernel/modules/SofaImplicitOdeSolver/src/SofaImplicitOdeSolver/StaticSolver.cpp
+++ b/SofaKernel/modules/SofaImplicitOdeSolver/src/SofaImplicitOdeSolver/StaticSolver.cpp
@@ -22,7 +22,7 @@
 #include <SofaImplicitOdeSolver/StaticSolver.h>
 
 #include <sofa/core/ObjectFactory.h>
-#include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 #include <sofa/simulation/MechanicalOperations.h>
 #include <sofa/simulation/VectorOperations.h>
 #include <sofa/core/behavior/MultiMatrix.h>

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/SolveVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/SolveVisitor.cpp
@@ -24,6 +24,7 @@
 #include <sofa/simulation/Node.h>
 #include <sofa/core/behavior/OdeSolver.h>
 #include <sofa/simulation/TaskScheduler.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 
 namespace sofa::simulation
 {

--- a/modules/SofaConstraint/src/SofaConstraint/ConstraintAnimationLoop.cpp
+++ b/modules/SofaConstraint/src/SofaConstraint/ConstraintAnimationLoop.cpp
@@ -38,6 +38,7 @@
 #include <sofa/simulation/UpdateBoundingBoxVisitor.h>
 #include <sofa/helper/system/thread/CTime.h>
 #include <sofa/helper/LCPcalc.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 
 
 #include <sofa/core/ObjectFactory.h>

--- a/modules/SofaGeneralAnimationLoop/src/SofaGeneralAnimationLoop/MultiStepAnimationLoop.cpp
+++ b/modules/SofaGeneralAnimationLoop/src/SofaGeneralAnimationLoop/MultiStepAnimationLoop.cpp
@@ -32,6 +32,7 @@
 #include <sofa/simulation/UpdateInternalDataVisitor.h>
 #include <sofa/simulation/UpdateContextVisitor.h>
 #include <sofa/simulation/UpdateMappingVisitor.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 #include <cmath>
 #include <iostream>
 

--- a/modules/SofaGeneralAnimationLoop/src/SofaGeneralAnimationLoop/MultiTagAnimationLoop.cpp
+++ b/modules/SofaGeneralAnimationLoop/src/SofaGeneralAnimationLoop/MultiTagAnimationLoop.cpp
@@ -32,6 +32,7 @@
 #include <sofa/simulation/UpdateMappingVisitor.h>
 #include <sofa/simulation/UpdateMappingEndEvent.h>
 #include <sofa/simulation/UpdateBoundingBoxVisitor.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 #include <cmath>
 #include <iostream>
 

--- a/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/DirectSAPNarrowPhase.cpp
+++ b/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/DirectSAPNarrowPhase.cpp
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #include <SofaGeneralMeshCollision/DirectSAPNarrowPhase.h>
 #include <sofa/core/collision/Intersection.h>
-#include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/ObjectFactory.h>
 #include <unordered_map>


### PR DESCRIPTION
- In `ScopedAdvancedTimer`, store the timer id as a real id rather than the `std::string` used to find the real id. This fixes a strange bug occurring with `ScopedAdvancedTimer` (which I am not able to explain).
- In `AdvancedTimer`, use a map for constant complexity when searching an id, instead of a `std::vector`

[ci-depends-on https://github.com/sofa-framework/Compliant/pull/2]


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
