### PR TITLE
[SofaHelper] Fix FileRepository::relativeToPath.

### DIFF
--- a/SofaKernel/modules/SofaHelper/SofaHelper_test/system/FileRepository_test.cpp
+++ b/SofaKernel/modules/SofaHelper/SofaHelper_test/system/FileRepository_test.cpp
@@ -39,7 +39,13 @@ struct FileRepository_test: public ::testing::Test
     }
 };
 
-
+TEST_F(FileRepository_test, relativeTo )
+{
+    ASSERT_EQ( fileRepository.relativeToPath("/test/file/sofa/scene.xml", "/test/file/"), "sofa/scene.xml" );
+    ASSERT_EQ( fileRepository.relativeToPath("/test/file/sofa/scene.xml", "/test/file"), "/sofa/scene.xml" );
+    ASSERT_EQ( fileRepository.relativeToPath("/test/file/sofa/", "/test/file/sofa"), "/" );
+    ASSERT_EQ( fileRepository.relativeToPath("/test/file/sofa", "/test/file/sofa"), "" );
+}
 
 TEST_F(FileRepository_test, findFile )
 {

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
@@ -337,7 +337,7 @@ std::string FileRepository::relativeToPath(std::string path, std::string refPath
         /// Case sensitive OS.
         std::string::size_type loc = path.find( refPath, 0 );
         if (loc==0)
-            path = path.substr(refPath.size()+1);
+            path = path.substr(refPath.size());
 
         return path;
     }
@@ -355,7 +355,7 @@ std::string FileRepository::relativeToPath(std::string path, std::string refPath
 
     std::string::size_type loc = tmppath.find( refPath, 0 );
     if (loc==0)
-        path = path.substr(refPath.size()+1);
+        path = path.substr(refPath.size());
 
     return path;
 }

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/FileRepository.cpp
@@ -38,6 +38,7 @@
 #include <iostream>
 #include <algorithm>
 #include <sstream>
+#include <filesystem>
 #include <sofa/helper/logging/Messaging.h>
 #include <sofa/helper/Utils.h>
 #include <sofa/helper/system/FileSystem.h>
@@ -169,6 +170,14 @@ void FileRepository::addFirstPath(const std::string& p)
 {
     // replacing every occurences of "//" by "/"
     std::string path = FileSystem::cleanPath(p);
+
+    if(path.back() != '/')
+        path.push_back('/');
+
+    if(!std::filesystem::exists(path))
+    {
+        msg_error("FileRepository") << "Not a path";
+    }
 
     std::vector<std::string> entries;
     size_t p0 = 0;


### PR DESCRIPTION
The function is not working at all and was not tested.

In this PR:
- add tests for relativePathTo, following the existing function documentation.
- fix the function

Signed-off-by: Damien Marchal <damien.marchal@univ-lille1.fr>






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
