### PR TITLE
[SofaGuiQt] Introduce expand/collapse buttons in profiler

### DIFF
--- a/modules/SofaGuiQt/src/sofa/gui/qt/SofaWindowProfiler.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/SofaWindowProfiler.cpp
@@ -357,6 +357,16 @@ SofaWindowProfiler::SofaWindowProfiler(QWidget *parent)
 
     connect(step_scroller, SIGNAL(valueChanged(int)), m_chartView, SLOT(updateSelection(int)));
     connect(m_chartView, SIGNAL(pointSelected(int)), this, SLOT(updateFromSelectedStep(int)));
+
+    ExpandAllButton->setIcon(QIcon(":/RealGUI/expandAll"));
+    CollapseAllButton->setIcon(QIcon(":/RealGUI/collapseAll"));
+    for (auto* button : {ExpandAllButton, CollapseAllButton})
+    {
+        button->setFixedWidth(button->height());
+    }
+
+    connect ( ExpandAllButton, SIGNAL ( clicked() ), tree_steps, SLOT ( expandAll() ) );
+    connect ( CollapseAllButton, SIGNAL ( clicked() ), this, SLOT ( expandRootNodeOnly() ) );
 }
 
 
@@ -596,5 +606,8 @@ void SofaWindowProfiler::onStepSelected(QTreeWidgetItem *item, int /*column*/)
     }
 }
 
-
+void SofaWindowProfiler::expandRootNodeOnly() const
+{
+    tree_steps->expandToDepth(0);
+}
 } //namespace sofa::gui::qt

--- a/modules/SofaGuiQt/src/sofa/gui/qt/SofaWindowProfiler.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/SofaWindowProfiler.h
@@ -185,7 +185,7 @@ protected:
     void addTreeItem(AnimationSubStepData* subStep, QTreeWidgetItem* parent);
 
 public slots:
-    void closeEvent( QCloseEvent* )
+    void closeEvent( QCloseEvent* ) override
     {
         emit(closeWindow(false));
     }
@@ -199,6 +199,8 @@ public slots:
     void updateTree(int step);
     /// Method called when a QTreeWidgetItem is selected in the Tree view.
     void onStepSelected(QTreeWidgetItem *item, int column);
+
+    void expandRootNodeOnly() const;
 
 signals:
     void closeWindow(bool);

--- a/modules/SofaGuiQt/src/sofa/gui/qt/WindowProfiler.ui
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/WindowProfiler.ui
@@ -117,17 +117,41 @@
        <item>
         <layout class="QVBoxLayout" name="Layout_tree">
          <item>
-          <spacer name="horizontalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QPushButton" name="CollapseAllButton">
+             <property name="toolTip">
+              <string>Collapse all</string>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="ExpandAllButton">
+             <property name="toolTip">
+              <string>Expand all</string>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
          <item>
           <widget class="QTreeWidget" name="tree_steps">


### PR DESCRIPTION
Similar to #2322, but in the profiler. Buttons collapse or expand the displayed tree of timers.
![image](https://user-images.githubusercontent.com/10572752/134161374-9985c29b-d864-4900-a9ac-a5e27a59c964.png)

Note that those two buttons add extra space on top of the tree widget, but not so much because there was already an empty spacer here.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
