### PR TITLE
[Sofa.Helper] PluginManager: check if a plugin is already loaded with a different path

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
@@ -444,7 +444,7 @@ bool PluginManager::pluginIsLoaded(const std::string& plugin)
                 // we did find a plugin with the same, but it does not have the same path...
                 msg_warning("PluginManager") << "This plugin " << pluginName << " has been loaded from a different path, it will certainly lead to bugs or crashes... " << msgendl
                                              << "You tried to load: " << pluginPath << msgendl
-                                             << "Already loaded: " << k.first;
+                                             << "Already loaded: " << loadedPath;
                 return true;
             }
         }

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
@@ -437,9 +437,9 @@ bool PluginManager::pluginIsLoaded(const std::string& plugin)
 
         // argument is a path but we need to check if it was not already loaded with a different path
         const auto& pluginName = sofa::helper::system::SetDirectory::GetFileNameWithoutExtension(pluginPath.c_str());
-        for (const auto& k : m_pluginMap)
+        for (const auto& [loadedPath, loadedPlugin] : m_pluginMap)
         {
-            if (pluginName == k.second.getModuleName() && pluginPath != k.first)
+            if (pluginName == loadedPlugin.getModuleName() && pluginPath != loadedPath)
             {
                 // we did find a plugin with the same, but it does not have the same path...
                 msg_warning("PluginManager") << "This plugin " << pluginName << " has been loaded from a different path, it will certainly lead to bugs or crashes... " << msgendl


### PR DESCRIPTION
The case arises mostly because of running runSofa from a build directory but you set SOFA_ROOT. It will then tried to load plugins from the install afterwards, etc..., leading to stuff like:

```
[WARNING] [ObjectFactory] Default template for class DynamicSparseGridGeometryAlgorithms already registered (Vec3d), do not register Vec3d as the default
[WARNING] [ObjectFactory] Class already registered: DynamicSparseGridGeometryAlgorithms<Vec2d>
[WARNING] [ObjectFactory] Class already registered: DynamicSparseGridGeometryAlgorithms<Vec3d>
....
```

or with a cryptic error message if you try to use the PluginManager from the GUI:
```
[INFO]    [PluginManager] Plugin not found in loaded plugins: ..../bin/RelWithDebInfo/SofaNonUniformFem.dll
[ERROR]   [SofaPluginManager] plugin should be loaded: ..../bin/RelWithDebInfo/SofaNonUniformFem.dll
```

Now, if you try to load twice the plugins (from differents paths then), it will print:
(one dll is in `build/bin/Release/` and the other one directly in `build/`
```
[WARNING] [PluginManager] This plugin SofaNonUniformFem has been loaded from a different path, it will certainly lead to bugs or crashes...
You tried to load: ....build/bin/Release/SofaNonUniformFem.dll
Already loaded: ....\build\SofaNonUniformFem.dll
[WARNING] [PluginManager] Plugin SofaNonUniformFem is already loaded from a different path, check you configuration.
```
The "double information" comes from the fact that in the end we consider the plugin as loaded ; the code afterwards will try to load the plugin nevertheless (hence having to detect twice the duplication)
In the GUI code for example: https://github.com/sofa-framework/sofa/blob/71691309251177322967f53bc7a024e89c19bcbc/modules/SofaGuiQt/src/sofa/gui/qt/SofaPluginManager.cpp#L120

Obviously it is really not advised to continue to use Sofa if this case occurs but at least the user will know what is going on.
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
