### PR TITLE
[SofaCore] FIX BaseData::getLinkPath()

### DIFF
--- a/SofaKernel/modules/SofaCore/SofaCore_test/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/SofaCore_test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCE_FILES
     loader/MeshLoader_test.cpp
     objectmodel/AspectPool_test.cpp
     objectmodel/BaseClass_test.cpp
+    objectmodel/BaseData_test.cpp
     objectmodel/BaseLink_test.cpp
     objectmodel/BaseObjectDescription_test.cpp
     objectmodel/Data_test.cpp

--- a/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/BaseData_test.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/BaseData_test.cpp
@@ -32,22 +32,21 @@ class MyData : public BaseData
 {
 public:
     MyData() : BaseData(BaseInitData()) {}
-    virtual bool read(const std::string&)override {return true;}
-    virtual void printValue(std::ostream&) const override {return;}
-    virtual std::string getValueString() const override  {return "";}
-    virtual std::string getValueTypeString() const override {return "";}
-    virtual const sofa::defaulttype::AbstractTypeInfo* getValueTypeInfo() const override {return nullptr;}
-    virtual const void* getValueVoidPtr() const {return nullptr;}
-    virtual void* beginEditVoidPtr(){return nullptr;}
-    virtual void* beginWriteOnlyVoidPtr(){return nullptr;}
-    virtual void endEditVoidPtr(){}
+    bool read(const std::string&)override {return true;}
+    void printValue(std::ostream&) const override {return;}
+    std::string getValueString() const override  {return "";}
+    std::string getValueTypeString() const override {return "";}
+    const sofa::defaulttype::AbstractTypeInfo* getValueTypeInfo() const override {return nullptr;}
+    const void* getValueVoidPtr() const {return nullptr;}
+    void* beginEditVoidPtr(){return nullptr;}
+    void* beginWriteOnlyVoidPtr(){return nullptr;}
+    void endEditVoidPtr(){}
     bool doIsExactSameDataType(const BaseData* ) override{ return false; }
     bool doCopyValueFrom(const BaseData* ) override{ return false; }
     bool doSetValueFromLink(const BaseData* ) override{ return false; }
-    virtual const void* doGetValueVoidPtr() const override { return nullptr; }
-    virtual void* doBeginEditVoidPtr() override { return nullptr; }
-    virtual void doEndEditVoidPtr() override { }
-
+    const void* doGetValueVoidPtr() const override { return nullptr; }
+    void* doBeginEditVoidPtr() override { return nullptr; }
+    void doEndEditVoidPtr() override { }
 };
 
 class MyObject : public BaseObject

--- a/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/BaseData_test.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_test/objectmodel/BaseData_test.cpp
@@ -32,15 +32,22 @@ class MyData : public BaseData
 {
 public:
     MyData() : BaseData(BaseInitData()) {}
-    virtual bool read(const std::string&){return true;}
-    virtual void printValue(std::ostream&) const {return;}
-    virtual std::string getValueString() const {return "";}
-    virtual std::string getValueTypeString() const {return "";}
-    virtual const sofa::defaulttype::AbstractTypeInfo* getValueTypeInfo() const {return nullptr;}
+    virtual bool read(const std::string&)override {return true;}
+    virtual void printValue(std::ostream&) const override {return;}
+    virtual std::string getValueString() const override  {return "";}
+    virtual std::string getValueTypeString() const override {return "";}
+    virtual const sofa::defaulttype::AbstractTypeInfo* getValueTypeInfo() const override {return nullptr;}
     virtual const void* getValueVoidPtr() const {return nullptr;}
     virtual void* beginEditVoidPtr(){return nullptr;}
     virtual void* beginWriteOnlyVoidPtr(){return nullptr;}
     virtual void endEditVoidPtr(){}
+    bool doIsExactSameDataType(const BaseData* ) override{ return false; }
+    bool doCopyValueFrom(const BaseData* ) override{ return false; }
+    bool doSetValueFromLink(const BaseData* ) override{ return false; }
+    virtual const void* doGetValueVoidPtr() const override { return nullptr; }
+    virtual void* doBeginEditVoidPtr() override { return nullptr; }
+    virtual void doEndEditVoidPtr() override { }
+
 };
 
 class MyObject : public BaseObject
@@ -49,7 +56,12 @@ public:
     SOFA_CLASS(MyObject, BaseObject);
     MyData myData;
     MyObject() :
-        myData() {}
+        myData()
+    {
+        myData.setName("myData");
+        setName("node1");
+        myData.setOwner(this);
+    }
 };
 
 class BaseData_test: public BaseTest
@@ -62,4 +74,9 @@ TEST_F(BaseData_test, setGetName)
 {
     m_object.myData.setName("data1");
     ASSERT_EQ(m_object.myData.getName(), "data1");
+}
+
+TEST_F(BaseData_test, getLinkName)
+{
+    ASSERT_EQ(m_object.myData.getLinkPath(), "@node1.myData");
 }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.cpp
@@ -143,6 +143,13 @@ bool BaseData::setParent(BaseData* parent, const std::string& path)
     return true;
 }
 
+std::string BaseData::getLinkPath() const
+{
+    if(m_owner)
+        return "@"+m_owner->getPathName()+"."+getName();
+    return "";
+}
+
 bool BaseData::setParent(const std::string& path)
 {
     parentData.setPath(path);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
@@ -209,7 +209,7 @@ public:
     /// @}
 
     /// If we use the Data as a link and not as value directly
-    virtual std::string getLinkPath() const { return parentData.getPath(); }
+    virtual std::string getLinkPath() const;
 
     /// Return whether this %Data can be used as a linkPath.
     ///

--- a/modules/SofaGuiQt/src/sofa/gui/qt/DataWidget.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/DataWidget.cpp
@@ -212,14 +212,15 @@ QDisplayDataInfoWidget::QDisplayDataInfoWidget(QWidget* parent, const std::strin
             helper_button->setToolTip( ("Data from "+ownerClass).c_str());
             //QToolTip::add(helper_button, ("Data from "+ownerClass).c_str());
     }
-    if(modifiable || !data->getLinkPath().empty())
+    if(modifiable || data->getParent())
     {
+        std::string linkvalue = data->getParent()->getLinkPath();
         linkpath_edit = new QLineEdit(this);
         linkpath_edit->setContentsMargins(2, 0, 0, 0);
-        linkpath_edit->setText(QString(data->getLinkPath().c_str()));
+        linkpath_edit->setText(QString(linkvalue.c_str()));
         linkpath_edit->setReadOnly(!modifiable);
         layout->addWidget(linkpath_edit);
-        linkpath_edit->setVisible(!data->getLinkPath().empty());
+        linkpath_edit->setVisible(!linkvalue.empty());
         if(modifyObjectFlags.PROPERTY_WIDGET_FLAG)
             connect(linkpath_edit, SIGNAL( textChanged(const QString&)), this, SIGNAL( WidgetDirty()));
         else


### PR DESCRIPTION
The implementation was not correct.
BaseData::getLinkPath() should return a string pointing to the current data not the link value
of a parented data.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
