### PR TITLE
[SofaGuiQt] UX: graph is easier to read

### DIFF
--- a/modules/SofaGuiQt/src/sofa/gui/qt/GraphListenerQListView.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/GraphListenerQListView.cpp
@@ -21,6 +21,8 @@
 ******************************************************************************/
 
 #include "GraphListenerQListView.h"
+
+#include <QApplication>
 #include <sofa/simulation/Colors.h>
 #include <sofa/core/collision/CollisionGroupManager.h>
 #include <sofa/core/collision/ContactManager.h>
@@ -408,6 +410,11 @@ void GraphListenerQListView::onBeginAddChild(Node* parent, Node* child)
         }
 
         item->setText(0, child->getName().c_str());
+        item->setText(1, child->getClassName().c_str());
+        item->setForeground(1, nameColor);
+        QFont font = QApplication::font();
+        font.setBold(true);
+        item->setFont(0, font);
         setMessageIconFrom(item, child);
 
         item->setExpanded(true);
@@ -475,7 +482,12 @@ void GraphListenerQListView::onBeginAddObject(Node* parent, core::objectmodel::B
             name = object->getClassName() ;
         }else
         {
-            name = object->getClassName() + " " + object->getName() ;
+            name = object->getName() ;
+            item->setText(1, object->getClassName().c_str());
+            item->setForeground(1, nameColor);
+            const QString tooltip( ("Name: " + name + "\nClass Name: " + object->getClassName()).c_str());
+            item->setToolTip(0, tooltip);
+            item->setToolTip(1, tooltip);
         }
 
         item->setText(0, name.c_str());
@@ -540,8 +552,11 @@ void GraphListenerQListView::onBeginAddSlave(core::objectmodel::BaseObject* mast
             name.erase(pos);
         if (!slave->toConfigurationSetting())
         {
-            name += "  ";
-            name += slave->getName();
+            item->setText(1, slave->getName().c_str());
+            item->setForeground(1, nameColor);
+            const QString tooltip( ("Name: " + name + "\nClass Name: " + slave->getClassName()).c_str());
+            item->setToolTip(0, tooltip);
+            item->setToolTip(1, tooltip);
         }
         item->setText(0, name.c_str());
 

--- a/modules/SofaGuiQt/src/sofa/gui/qt/GraphListenerQListView.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/GraphListenerQListView.h
@@ -72,6 +72,9 @@ public:
     core::objectmodel::Base* findObject(const QTreeWidgetItem* item);
     core::objectmodel::BaseData* findData(const QTreeWidgetItem* item);
 
+
+    inline static QColor nameColor { 120, 120, 120};
+
 };
 
 } // namespace sofa::gui::qt

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QSofaListView.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QSofaListView.cpp
@@ -80,14 +80,21 @@ QSofaListView::QSofaListView(const SofaListViewAttribute& attribute,
     AddObjectDialog_ = new AddObject ( &list_object, this );
     AddObjectDialog_->hide();
 
+    this->setColumnCount(2);
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-    header()->setResizeMode(header()->count() - 1, QHeaderView::Fixed);
+    header()->setResizeMode(0, QHeaderView::Interactive);
+    header()->setResizeMode(1, QHeaderView::Stretch);
 #else
-    header()->setSectionResizeMode(header()->count() - 1, QHeaderView::Fixed);
+    header()->setSectionResizeMode(0, QHeaderView::Interactive);
+    header()->setSectionResizeMode(1, QHeaderView::Stretch);
 #endif // SOFA_QT5
+    QStringList headerLabels;
+    headerLabels << "Name" << "Class";
+    this->setHeaderLabels(headerLabels);
 
     setRootIsDecorated(true);
-    setIndentation(15);
+    setIndentation(8);
+
     graphListener_ = new GraphListenerQListView(this);
 
     this->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -99,7 +106,6 @@ QSofaListView::QSofaListView(const SofaListViewAttribute& attribute,
 
 QSofaListView::~QSofaListView()
 {
-
     delete graphListener_;
 }
 
@@ -116,7 +122,6 @@ void QSofaListView::Clear(Node* rootNode)
 
     this->setSortingEnabled(false);
 
-    header()->hide();
     rootNode->addListener(graphListener_);
     graphListener_->onBeginAddChild ( nullptr, rootNode );
     graphListener_->freeze ( rootNode );

--- a/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
@@ -1013,6 +1013,7 @@ void RealGUI::setSceneWithoutMonitor (Node::SPtr root, const char* filename, boo
         simulationGraph->Clear(root.get());
         simulationGraph->collapseAll();
         simulationGraph->expandToDepth(0);
+        simulationGraph->resizeColumnToContents(0);
         statWidget->CreateStats(root.get());
 
 #ifndef SOFA_GUI_QT_NO_RECORDER


### PR DESCRIPTION
I found the graph difficult to read in the GUI. In particular, differentiating the name from the class name, and objects from nodes.

Here is what I propose:


# BEFORE

https://user-images.githubusercontent.com/10572752/134344194-8be54612-178a-4c1b-9374-d18e57dcd2e3.mp4

# AFTER

https://user-images.githubusercontent.com/10572752/134344330-122dc953-fa71-494a-a678-e101f34b0e4a.mp4

- Nodes are in bold
- Graph is divided in two columns: 1) the name of the object, 2) its class name. It is inverted compared to the previous display. I think it's more logical with the name first if you think about a path. The path of an object is made from multiple names (nodes + objects), not class names. This way, it is easier to find an object from a path (in a link for example) in the displayed graph.
- The class name is in grey
- Both columns have a header
- Columns can be resized with the mouse using the headers
- There is a tooltip on each object, showing the name and the class name


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
