### PR TITLE
[Sofa.Type, Sofa.Topology] Fix testEdgeBuffer with clang (and add constexpr default constructors)

### DIFF
--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Edge.h
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Edge.h
@@ -30,5 +30,5 @@ namespace sofa::topology
 {
     using Edge = sofa::topology::Element<sofa::geometry::Edge>;
 
-    constexpr static Edge InvalidEdge;
+    static constexpr Edge InvalidEdge;
 }

--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Edge.h
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Edge.h
@@ -30,5 +30,5 @@ namespace sofa::topology
 {
     using Edge = sofa::topology::Element<sofa::geometry::Edge>;
 
-    inline static const Edge InvalidEdge;
+    constexpr static Edge InvalidEdge;
 }

--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Element.h
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Element.h
@@ -36,7 +36,12 @@ struct Element : public sofa::type::fixed_array<sofa::Index, GeometryElement::Nu
 {
     constexpr Element() noexcept
     {
-        std::fill(this->begin(), this->end(), sofa::InvalidID);
+        for (auto it = this->begin() ; it != this->end() ; it++)
+        {
+            *it = sofa::InvalidID;
+        }
+        // constexpr std::fill only in c++20
+        // std::fill(this->begin(), this->end(), sofa::InvalidID);
     }
 
     template< typename... ArgsT

--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Hexahedron.h
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Hexahedron.h
@@ -30,5 +30,5 @@ namespace sofa::topology
 {
     using Hexahedron = sofa::topology::Element<sofa::geometry::Hexahedron>;
 
-    inline static const Hexahedron InvalidHexahedron;
+    inline static constexpr Hexahedron InvalidHexahedron;
 }

--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Hexahedron.h
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Hexahedron.h
@@ -30,5 +30,5 @@ namespace sofa::topology
 {
     using Hexahedron = sofa::topology::Element<sofa::geometry::Hexahedron>;
 
-    inline static constexpr Hexahedron InvalidHexahedron;
+    static constexpr Hexahedron InvalidHexahedron;
 }

--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Pentahedron.h
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Pentahedron.h
@@ -30,5 +30,5 @@ namespace sofa::topology
 {
     using Pentahedron = sofa::topology::Element<sofa::geometry::Pentahedron>;
 
-    inline static constexpr Pentahedron InvalidPentahedron;
+    constexpr static Pentahedron InvalidPentahedron;
 }

--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Pentahedron.h
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Pentahedron.h
@@ -30,5 +30,5 @@ namespace sofa::topology
 {
     using Pentahedron = sofa::topology::Element<sofa::geometry::Pentahedron>;
 
-    constexpr static Pentahedron InvalidPentahedron;
+    static constexpr Pentahedron InvalidPentahedron;
 }

--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Pentahedron.h
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Pentahedron.h
@@ -30,5 +30,5 @@ namespace sofa::topology
 {
     using Pentahedron = sofa::topology::Element<sofa::geometry::Pentahedron>;
 
-    inline static const Pentahedron InvalidPentahedron;
+    inline static constexpr Pentahedron InvalidPentahedron;
 }

--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Pyramid.h
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Pyramid.h
@@ -30,5 +30,5 @@ namespace sofa::topology
 {
     using Pyramid = sofa::topology::Element<sofa::geometry::Pyramid>;
 
-    inline static const Pyramid InvalidPyramid;
+    inline static constexpr Pyramid InvalidPyramid;
 }

--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Pyramid.h
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Pyramid.h
@@ -30,5 +30,5 @@ namespace sofa::topology
 {
     using Pyramid = sofa::topology::Element<sofa::geometry::Pyramid>;
 
-    inline static constexpr Pyramid InvalidPyramid;
+    static constexpr Pyramid InvalidPyramid;
 }

--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Quad.h
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Quad.h
@@ -30,5 +30,5 @@ namespace sofa::topology
 {
     using Quad = sofa::topology::Element<sofa::geometry::Quad>;
 
-    inline static const Quad InvalidQuad;
+    inline static constexpr Quad InvalidQuad;
 }

--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Quad.h
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Quad.h
@@ -30,5 +30,5 @@ namespace sofa::topology
 {
     using Quad = sofa::topology::Element<sofa::geometry::Quad>;
 
-    inline static constexpr Quad InvalidQuad;
+    static constexpr Quad InvalidQuad;
 }

--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Tetrahedron.h
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Tetrahedron.h
@@ -30,5 +30,5 @@ namespace sofa::topology
 {
     using Tetrahedron = sofa::topology::Element<sofa::geometry::Tetrahedron>;
 
-    inline static const Tetrahedron InvalidTetrahedron;
+    inline static constexpr Tetrahedron InvalidTetrahedron;
 }

--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Tetrahedron.h
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Tetrahedron.h
@@ -30,5 +30,5 @@ namespace sofa::topology
 {
     using Tetrahedron = sofa::topology::Element<sofa::geometry::Tetrahedron>;
 
-    inline static constexpr Tetrahedron InvalidTetrahedron;
+    static constexpr Tetrahedron InvalidTetrahedron;
 }

--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Triangle.h
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Triangle.h
@@ -30,5 +30,5 @@ namespace sofa::topology
 {
     using Triangle = sofa::topology::Element<sofa::geometry::Triangle>;
 
-    inline static constexpr Triangle InvalidTriangle;
+    static constexpr Triangle InvalidTriangle;
 }

--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Triangle.h
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Triangle.h
@@ -30,5 +30,5 @@ namespace sofa::topology
 {
     using Triangle = sofa::topology::Element<sofa::geometry::Triangle>;
 
-    inline static const Triangle InvalidTriangle;
+    inline static constexpr Triangle InvalidTriangle;
 }

--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/fixed_array.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/fixed_array.h
@@ -79,7 +79,7 @@ public:
     typedef sofa::Size     size_type;
     typedef std::ptrdiff_t difference_type;
 
-    constexpr fixed_array() noexcept = default;
+    constexpr fixed_array() = default;
 
     /// Specific constructor for 1-element vectors.
     template<size_type NN = N, typename std::enable_if<NN == 1, int>::type = 0>

--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/fixed_array.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/fixed_array.h
@@ -65,7 +65,7 @@ template<class T, sofa::Size N>
 class fixed_array
 {
 public:
-    T elems[N];    // fixed-size array of elements of type T
+    T elems[N]{};    // fixed-size array of elements of type T
 
     typedef T Array[N]; ///< name the array type
 
@@ -79,7 +79,7 @@ public:
     typedef sofa::Size     size_type;
     typedef std::ptrdiff_t difference_type;
 
-    fixed_array() = default;
+    constexpr fixed_array() noexcept = default;
 
     /// Specific constructor for 1-element vectors.
     template<size_type NN = N, typename std::enable_if<NN == 1, int>::type = 0>

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/Topology.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/Topology.h
@@ -82,14 +82,14 @@ public:
     SOFA_CORE_TOPOLOGY_ATTRIBUTE_DEPRECATED__ALIASES_INDEX()
     typedef sofa::Index HexaID;
 
-    inline static auto InvalidSet = sofa::topology::InvalidSet;
-    inline static auto InvalidEdge = sofa::topology::InvalidEdge;
-    inline static auto InvalidTriangle = sofa::topology::InvalidTriangle;
-    inline static auto InvalidQuad = sofa::topology::InvalidQuad;
-    inline static auto InvalidTetrahedron = sofa::topology::InvalidTetrahedron;
-    inline static auto InvalidPentahedron = sofa::topology::InvalidPentahedron;
-    inline static auto InvalidHexahedron = sofa::topology::InvalidHexahedron;
-    inline static auto InvalidPyramid = sofa::topology::InvalidPyramid;
+    inline static const auto InvalidSet = sofa::topology::InvalidSet;
+    static constexpr auto InvalidEdge = sofa::topology::InvalidEdge;
+    static constexpr auto InvalidTriangle = sofa::topology::InvalidTriangle;
+    static constexpr auto InvalidQuad = sofa::topology::InvalidQuad;
+    static constexpr auto InvalidTetrahedron = sofa::topology::InvalidTetrahedron;
+    static constexpr auto InvalidPentahedron = sofa::topology::InvalidPentahedron;
+    static constexpr auto InvalidHexahedron = sofa::topology::InvalidHexahedron;
+    static constexpr auto InvalidPyramid = sofa::topology::InvalidPyramid;
 
     using SetIndex = sofa::topology::SetIndex;
     using SetIndices = sofa::topology::SetIndices;


### PR DESCRIPTION
Happening on **clang ONLY** (linux or mac, same) 

Kind of 'mysterious' behavior happened here: https://github.com/sofa-framework/sofa/blob/65a54acb1d47c09acf294333ddfb5a5d57c1d0fe/SofaKernel/modules/SofaCore/src/sofa/core/topology/Topology.h#L86

core::topology::InvalidEdge was getting (0,0) instead of the expected (invalidID, invalidID).

_Assumption (really just guessing)_
the inline static initialization (with clang) is done through a first stage compilation where the default constructor of Edge has not been generated yet, hence calling a (really) default constructor initializing array with a zero-initialization. 
One hint came from the fact that if I switched the inline static init in the h, with a "classical" static declaration in h + initialization in the cpp, it was correctly initializing InvalidEdge with (invalidID, invalidID)...

Instead of just reverting to the classical static init, I have put all those inline static to constexpr members, leading to the fact that fixed_array's default constructor was not constexpr (forgotten 😗)
Anyway, now everything is constexpr and the inline static initialization is correct now....

Bear in mind that it seems that GCC and MSVC are different than CLANG in that regard.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
