### PR TITLE
[Sofa.GL] Set glew as mandatory

### DIFF
--- a/SofaKernel/modules/Sofa.GL/CMakeLists.txt
+++ b/SofaKernel/modules/Sofa.GL/CMakeLists.txt
@@ -4,7 +4,7 @@ project(Sofa.GL LANGUAGES CXX)
 set(SOFAGLSRC_ROOT "src/sofa/gl")
 
 sofa_find_package(OpenGL REQUIRED BOTH_SCOPES)
-sofa_find_package(GLEW BOTH_SCOPES)
+sofa_find_package(GLEW BOTH_SCOPES REQUIRED)
 
 set(HEADER_FILES
     ${SOFAGLSRC_ROOT}/config.h.in
@@ -71,13 +71,9 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux AND SOFA_BUILD_RELEASE_PACKAGE AND OPENGL_GL
     sofa_install_libraries(PATHS ${OPENGL_glu_LIBRARY})
 endif()
 
-if(GLEW_FOUND)
-    target_link_libraries(${PROJECT_NAME} PUBLIC GLEW::GLEW)
-    if (SOFA_BUILD_RELEASE_PACKAGE OR CMAKE_SYSTEM_NAME STREQUAL Windows)
-        sofa_install_libraries(TARGETS GLEW::GLEW)
-    endif()
-else()
-    message("OpenGL advanced functions (e.g shaders, FBO) are disabled.")
+target_link_libraries(${PROJECT_NAME} PUBLIC GLEW::GLEW)
+if (SOFA_BUILD_RELEASE_PACKAGE OR CMAKE_SYSTEM_NAME STREQUAL Windows)
+    sofa_install_libraries(TARGETS GLEW::GLEW)
 endif()
 
 sofa_create_package_with_targets(

--- a/SofaKernel/modules/Sofa.GL/Sofa.GLConfig.cmake.in
+++ b/SofaKernel/modules/Sofa.GL/Sofa.GLConfig.cmake.in
@@ -7,10 +7,7 @@ set(SOFA_GL_HAVE_GLEW @SOFA_GL_HAVE_GLEW@)
 
 find_package(SofaFramework QUIET REQUIRED) # SofaHelper SofaDefaulttype
 find_package(OpenGL QUIET REQUIRED)
-
-if(SOFA_GL_HAVE_GLEW)
-	find_package(GLEW QUIET REQUIRED)
-endif()
+find_package(GLEW QUIET REQUIRED)
 
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
Forgot to install libglew-dev on a new system, cmake is OK but when compiling, an error on the fact that gl/glew.h could not be found.

Some time ago, it had been decided that the gl subsystem will always need glew (it was optional before)
But the cmake did not reflect this choice.

Now cmake will complain if glew is not found (if SOFA_WITH_OPENGL is enabled of course!)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
