### PR TITLE
[SofaBaseTopology] Fix Last element index update in TopologyData

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.h
@@ -147,12 +147,12 @@ protected:
 
     bool m_isTopologyDynamic;
 
-    void linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Point*      ) { linkToPointDataArray();       }
-    void linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Edge*       ) { linkToEdgeDataArray();        }
-    void linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Triangle*   ) { linkToTriangleDataArray();    }
-    void linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Quad*       ) { linkToQuadDataArray();        }
-    void linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Tetrahedron*) { linkToTetrahedronDataArray(); }
-    void linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Hexahedron* ) { linkToHexahedronDataArray();  }
+    void linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Point*);
+    void linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Edge*);
+    void linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Triangle*);
+    void linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Quad*);
+    void linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Tetrahedron*);
+    void linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Hexahedron*);
 };
 
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
@@ -36,7 +36,6 @@ TopologyData <TopologyElementType, VecT>::TopologyData(const typename sofa::core
     , m_topologyHandler(nullptr)
     , m_isTopologyDynamic(false)
 {
-    this->m_lastElementIndex = 0;
 }
 
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
@@ -36,7 +36,7 @@ TopologyData <TopologyElementType, VecT>::TopologyData(const typename sofa::core
     , m_topologyHandler(nullptr)
     , m_isTopologyDynamic(false)
 {
-    this->lastElementIndex = 0;
+    this->m_lastElementIndex = 0;
 }
 
 
@@ -198,8 +198,6 @@ void TopologyData <TopologyElementType, VecT>::remove(const sofa::type::vector<I
     container_type& data = *(this->beginEdit());
     if (data.size() > 0)
     {
-        Index last = Index(data.size() - 1);
-
         for (std::size_t i = 0; i < index.size(); ++i)
         {
             if (this->m_topologyHandler) {
@@ -211,8 +209,8 @@ void TopologyData <TopologyElementType, VecT>::remove(const sofa::type::vector<I
                 p_onDestructionCallback(index[i], data[index[i]]);
             }
 
-            this->swap(index[i], last);
-            --last;
+            this->swap(index[i], this->m_lastElementIndex);
+            --this->m_lastElementIndex;
         }
 
         data.resize(data.size() - index.size());
@@ -243,6 +241,7 @@ void TopologyData <TopologyElementType, VecT>::add(const sofa::type::vector<Inde
         i0 = index[0];
     }
     data.resize(i0 + nbElements);
+    this->m_lastElementIndex += nbElements;
 
     const sofa::type::vector< Index > empty_vecint;
     const sofa::type::vector< double > empty_vecdouble;
@@ -324,6 +323,7 @@ void TopologyData <TopologyElementType, VecT>::addOnMovedPosition(const sofa::ty
             this->m_topologyHandler->applyCreateFunction(indexList[i], data[indexList[i]], elems[i], ancestors, coefs);
         }
     }
+    this->m_lastElementIndex += indexList.size();
     this->endEdit();
 }
 
@@ -340,6 +340,7 @@ void TopologyData <TopologyElementType, VecT>::removeOnMovedPosition(const sofa:
         }
     }
 
+    this->m_lastElementIndex -= indices.size();
     this->endEdit();
 
     // TODO check why this call.

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
@@ -178,6 +178,51 @@ void TopologyData <TopologyElementType, VecT>::linkToHexahedronDataArray()
 }
 
 
+/////////////////////// Protected functions on TopologyData init ///////////////////////////////
+
+template <typename TopologyElementType, typename VecT>
+void TopologyData <TopologyElementType, VecT>::linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Point*) 
+{ 
+    setDataSetArraySize(m_topology->getNbPoints());
+    linkToPointDataArray(); 
+}
+
+template <typename TopologyElementType, typename VecT>
+void TopologyData <TopologyElementType, VecT>::linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Edge*) 
+{ 
+    setDataSetArraySize(m_topology->getNbEdges());
+    linkToEdgeDataArray(); 
+}
+
+template <typename TopologyElementType, typename VecT>
+void TopologyData <TopologyElementType, VecT>::linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Triangle*) 
+{ 
+    setDataSetArraySize(m_topology->getNbTriangles());
+    linkToTriangleDataArray(); 
+}
+
+template <typename TopologyElementType, typename VecT>
+void TopologyData <TopologyElementType, VecT>::linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Quad*) 
+{ 
+    setDataSetArraySize(m_topology->getNbQuads());
+    linkToQuadDataArray(); 
+}
+
+template <typename TopologyElementType, typename VecT>
+void TopologyData <TopologyElementType, VecT>::linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Tetrahedron*) 
+{ 
+    setDataSetArraySize(m_topology->getNbTetrahedra());
+    linkToTetrahedronDataArray(); 
+}
+
+template <typename TopologyElementType, typename VecT>
+void TopologyData <TopologyElementType, VecT>::linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Hexahedron*) 
+{ 
+    setDataSetArraySize(m_topology->getNbHexahedra());
+    linkToHexahedronDataArray(); 
+}
+
+
 ///////////////////// Protected functions on TopologyData changes /////////////////////////////
 
 template <typename TopologyElementType, typename VecT>

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
@@ -183,42 +183,42 @@ void TopologyData <TopologyElementType, VecT>::linkToHexahedronDataArray()
 template <typename TopologyElementType, typename VecT>
 void TopologyData <TopologyElementType, VecT>::linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Point*) 
 { 
-    setDataSetArraySize(m_topology->getNbPoints());
+    this->setDataSetArraySize(this->m_topology->getNbPoints());
     linkToPointDataArray(); 
 }
 
 template <typename TopologyElementType, typename VecT>
 void TopologyData <TopologyElementType, VecT>::linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Edge*) 
 { 
-    setDataSetArraySize(m_topology->getNbEdges());
+    this->setDataSetArraySize(this->m_topology->getNbEdges());
     linkToEdgeDataArray(); 
 }
 
 template <typename TopologyElementType, typename VecT>
 void TopologyData <TopologyElementType, VecT>::linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Triangle*) 
 { 
-    setDataSetArraySize(m_topology->getNbTriangles());
+    this->setDataSetArraySize(this->m_topology->getNbTriangles());
     linkToTriangleDataArray(); 
 }
 
 template <typename TopologyElementType, typename VecT>
 void TopologyData <TopologyElementType, VecT>::linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Quad*) 
 { 
-    setDataSetArraySize(m_topology->getNbQuads());
+    this->setDataSetArraySize(this->m_topology->getNbQuads());
     linkToQuadDataArray(); 
 }
 
 template <typename TopologyElementType, typename VecT>
 void TopologyData <TopologyElementType, VecT>::linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Tetrahedron*) 
 { 
-    setDataSetArraySize(m_topology->getNbTetrahedra());
+    this->setDataSetArraySize(this->m_topology->getNbTetrahedra());
     linkToTetrahedronDataArray(); 
 }
 
 template <typename TopologyElementType, typename VecT>
 void TopologyData <TopologyElementType, VecT>::linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Hexahedron*) 
 { 
-    setDataSetArraySize(m_topology->getNbHexahedra());
+    this->setDataSetArraySize(this->m_topology->getNbHexahedra());
     linkToHexahedronDataArray(); 
 }
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
@@ -286,7 +286,7 @@ void TopologyData <TopologyElementType, VecT>::add(const sofa::type::vector<Inde
         i0 = index[0];
     }
     data.resize(i0 + nbElements);
-    this->m_lastElementIndex += nbElements;
+    this->m_lastElementIndex += sofa::Index(nbElements);
 
     const sofa::type::vector< Index > empty_vecint;
     const sofa::type::vector< double > empty_vecdouble;
@@ -368,7 +368,7 @@ void TopologyData <TopologyElementType, VecT>::addOnMovedPosition(const sofa::ty
             this->m_topologyHandler->applyCreateFunction(indexList[i], data[indexList[i]], elems[i], ancestors, coefs);
         }
     }
-    this->m_lastElementIndex += indexList.size();
+    this->m_lastElementIndex += sofa::Index(indexList.size());
     this->endEdit();
 }
 
@@ -385,7 +385,7 @@ void TopologyData <TopologyElementType, VecT>::removeOnMovedPosition(const sofa:
         }
     }
 
-    this->m_lastElementIndex -= indices.size();
+    this->m_lastElementIndex -= sofa::Index(indices.size());
     this->endEdit();
 
     // TODO check why this call.

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyDataHandler.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyDataHandler.inl
@@ -105,7 +105,6 @@ void TopologyDataHandler<TopologyElementType,  VecT>::linkToPointDataArray()
 
     _container->d_initPoints.addOutput(this);
     _container->addTopologyHandler(this);
-    m_topologyData->setDataSetArraySize(_container->getNbPoints());
     m_pointsLinked = true;
 }
 
@@ -131,7 +130,6 @@ void TopologyDataHandler<TopologyElementType,  VecT>::linkToEdgeDataArray()
 
     _container->d_edge.addOutput(this);
     _container->addTopologyHandler(this);
-    m_topologyData->setDataSetArraySize(_container->d_edge.getValue().size());
     m_edgesLinked = true;
 }
 
@@ -157,7 +155,6 @@ void TopologyDataHandler<TopologyElementType,  VecT>::linkToTriangleDataArray()
 
     _container->d_triangle.addOutput(this);
     _container->addTopologyHandler(this);
-    m_topologyData->setDataSetArraySize(_container->d_triangle.getValue().size());
     m_trianglesLinked = true;
 }
 
@@ -183,7 +180,6 @@ void TopologyDataHandler<TopologyElementType,  VecT>::linkToQuadDataArray()
 
     _container->d_quad.addOutput(this);
     _container->addTopologyHandler(this);
-    m_topologyData->setDataSetArraySize(_container->d_quad.getValue().size());
     m_quadsLinked = true;
 }
 
@@ -209,7 +205,6 @@ void TopologyDataHandler<TopologyElementType,  VecT>::linkToTetrahedronDataArray
 
     _container->d_tetrahedron.addOutput(this);
     _container->addTopologyHandler(this);
-    m_topologyData->setDataSetArraySize(_container->d_tetrahedron.getValue().size());
     m_tetrahedraLinked = true;
 }
 
@@ -235,7 +230,6 @@ void TopologyDataHandler<TopologyElementType,  VecT>::linkToHexahedronDataArray(
 
     _container->d_hexahedron.addOutput(this);
     _container->addTopologyHandler(this);
-    m_topologyData->setDataSetArraySize(_container->d_hexahedron.getValue().size());
     m_hexahedraLinked = true;
 }
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologySubsetData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologySubsetData.inl
@@ -83,7 +83,7 @@ void TopologySubsetData <TopologyElementType, VecT>::add(sofa::Size nbElements,
     const sofa::type::vector<sofa::type::vector<double> >& coefs)
 {
     if (!this->getSparseDataStatus()) {
-        this->lastElementIndex += nbElements;
+        this->m_lastElementIndex += nbElements;
         return;
     }
 
@@ -180,12 +180,12 @@ void TopologySubsetData <TopologyElementType, VecT>::remove(const sofa::type::ve
         }
 
         // need to check if lastIndex in the map        
-        idElem = this->indexOfElement(this->lastElementIndex);
+        idElem = this->indexOfElement(this->m_lastElementIndex);
         if (idElem != sofa::InvalidID)
         {
             updateLastIndex(idElem, idRemove);
         }
-        this->lastElementIndex--;
+        this->m_lastElementIndex--;
     }
 
     if (cptDone != 0)
@@ -243,8 +243,8 @@ void TopologySubsetData <TopologyElementType, VecT>::addPostProcess(sofa::Size n
 {
     for (unsigned int i = 0; i < nbElements; ++i)
     {
-        this->lastElementIndex++;
-        m_map2Elements.push_back(this->lastElementIndex);
+        this->m_lastElementIndex++;
+        m_map2Elements.push_back(this->m_lastElementIndex);
     }
 }
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologySubsetIndices.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologySubsetIndices.cpp
@@ -74,7 +74,7 @@ void TopologySubsetIndices::removePostProcess(sofa::Size nbElements)
 
 void TopologySubsetIndices::addPostProcess(sofa::Size nbElements)
 {
-    this->lastElementIndex += nbElements;
+    this->m_lastElementIndex += nbElements;
 }
 
 void TopologySubsetIndices::updateLastIndex(Index posLastIndex, Index newGlobalId)

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopologyData.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopologyData.h
@@ -120,13 +120,20 @@ public:
     }
 
     /// to handle PointSubsetData
-    void setDataSetArraySize(const Index s) { lastElementIndex = s - 1; }
+    void setDataSetArraySize(const Index s) { m_lastElementIndex = s - 1; }
+
+    /// Return the last element index of the topolgy buffer this Data is linked to. @sa m_lastElementIndex
+    Index getLastElementIndex() { return m_lastElementIndex; }
 
 protected:
+    /// Pointer to the Topology this TopologyData is depending on
     sofa::core::topology::BaseMeshTopology* m_topology = nullptr;
 
-    /// to handle properly the removal of items, the container must know the index of the last element
-    Index lastElementIndex = 0;
+    /** to handle properly the removal of items, the container must keep the last element index and update it during operations (add/remove).
+    * Note that this index is mandatory and can't be retrieve directly form the topology in the case when several topology events are queued.
+    * i.e: If 2 removalElements events are queued, the second event still point to a topology not yet updated by the first event. 
+    */
+    Index m_lastElementIndex = 0;
 };
 
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopologyData.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopologyData.h
@@ -123,14 +123,14 @@ public:
     void setDataSetArraySize(const Index s) { m_lastElementIndex = s - 1; }
 
     /// Return the last element index of the topolgy buffer this Data is linked to. @sa m_lastElementIndex
-    Index getLastElementIndex() { return m_lastElementIndex; }
+    Index getLastElementIndex() const { return m_lastElementIndex; }
 
 protected:
     /// Pointer to the Topology this TopologyData is depending on
     sofa::core::topology::BaseMeshTopology* m_topology = nullptr;
 
     /** to handle properly the removal of items, the container must keep the last element index and update it during operations (add/remove).
-    * Note that this index is mandatory and can't be retrieve directly form the topology in the case when several topology events are queued.
+    * Note that this index is mandatory and can't be retrieved directly from the topology in the case when several topology events are queued.
     * i.e: If 2 removalElements events are queued, the second event still point to a topology not yet updated by the first event. 
     */
     Index m_lastElementIndex = 0;


### PR DESCRIPTION
- Rename variable ```lastElementIndex``` into ```m_lastElementIndex```
- Add accessor
- Update this counter during add/remove operation. This counter is mandatory when multiple remove events are queued. 
- Init the counter during topologyData connection with its topology buffer

api is converging but this PR might have some side effects...




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
