### PR TITLE
[SofaGeneralDeformable] Clean class TriangularBendingSpring and add tests

### DIFF
--- a/modules/SofaGeneralDeformable/CMakeLists.txt
+++ b/modules/SofaGeneralDeformable/CMakeLists.txt
@@ -69,9 +69,9 @@ sofa_create_package_with_targets(
 
 # Tests
 # If SOFA_BUILD_TESTS exists and is OFF, then these tests will be auto-disabled
-# cmake_dependent_option(SOFAGENERALDEFORMABLE_BUILD_TESTS "Compile the automatic tests" ON "SOFA_BUILD_TESTS OR NOT DEFINED SOFA_BUILD_TESTS" OFF)
-# if(SOFAGENERALDEFORMABLE_BUILD_TESTS)
-#     enable_testing()
-#     add_subdirectory(${PROJECT_NAME}_test)
-# endif()
+cmake_dependent_option(SOFAGENERALDEFORMABLE_BUILD_TESTS "Compile the automatic tests" ON "SOFA_BUILD_TESTS OR NOT DEFINED SOFA_BUILD_TESTS" OFF)
+if(SOFAGENERALDEFORMABLE_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(${PROJECT_NAME}_test)
+endif()
 

--- a/modules/SofaGeneralDeformable/SofaGeneralDeformable_test/CMakeLists.txt
+++ b/modules/SofaGeneralDeformable/SofaGeneralDeformable_test/CMakeLists.txt
@@ -2,12 +2,16 @@ cmake_minimum_required(VERSION 3.12)
 
 project(SofaGeneralDeformable_test)
 
+sofa_find_package(SofaGeneralDeformable REQUIRED)
+sofa_find_package(SofaBaseMechanics REQUIRED)
+
 set(SOURCE_FILES
+    TriangularBendingSprings_test.cpp
     )
 
 find_package(SofaGeneralDeformable REQUIRED)
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} SofaGeneralDeformable)
+target_link_libraries(${PROJECT_NAME} Sofa.Testing SofaGeneralDeformable SofaBaseMechanics)
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/modules/SofaGeneralDeformable/SofaGeneralDeformable_test/TriangularBendingSprings_test.cpp
+++ b/modules/SofaGeneralDeformable/SofaGeneralDeformable_test/TriangularBendingSprings_test.cpp
@@ -1,0 +1,315 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/defaulttype/VecTypes.h>
+#include <SofaBaseMechanics/MechanicalObject.h>
+#include <SofaBaseTopology/TriangleSetTopologyContainer.h>
+#include <SofaGeneralDeformable/TriangularBendingSprings.h>
+#include <SofaBaseTopology/TopologyData.inl>
+
+#include <SofaSimulationGraph/SimpleApi.h>
+#include <SofaSimulationGraph/DAGSimulation.h>
+#include <sofa/simulation/Simulation.h>
+#include <sofa/simulation/Node.h>
+using sofa::simulation::Node;
+
+#include <sofa/testing/BaseTest.h>
+using sofa::testing::BaseTest;
+
+#include <string>
+using std::string;
+
+
+namespace sofa
+{
+using namespace sofa::defaulttype;
+using namespace sofa::simpleapi;
+using sofa::component::container::MechanicalObject;
+
+template <class DataTypes>
+class TriangularBendingSprings_test : public BaseTest
+{
+public:
+    typedef typename DataTypes::Real Real;
+    typedef typename DataTypes::Coord Coord;
+    typedef typename DataTypes::VecCoord VecCoord;
+    typedef MechanicalObject<DataTypes> MState;
+    using TriangleBS = sofa::component::forcefield::TriangularBendingSprings<DataTypes>;
+    typedef typename TriangleBS::EdgeInformation EdgeInfo;
+    typedef typename type::vector<EdgeInfo> VecEdgeInfo;
+    using Vec3 = type::Vec<3, Real>;
+    using Mat33 = type::Mat<3, 3, Real>;
+    using Mat63 = type::Mat<6, 3, Real>;
+
+protected:
+    simulation::Simulation* m_simulation = nullptr;
+    simulation::Node::SPtr m_root;
+    
+public:
+
+    void SetUp() override
+    {
+        sofa::simpleapi::importPlugin("SofaComponentAll");
+        simulation::setSimulation(m_simulation = new simulation::graph::DAGSimulation());
+    }
+
+    void TearDown() override
+    {
+        if (m_root != nullptr)
+            simulation::getSimulation()->unload(m_root);
+    }
+
+    void createSimpleTrianglePairScene(Real ks, Real kd)
+    {
+        m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
+
+        createObject(m_root, "DefaultAnimationLoop");
+        createObject(m_root, "DefaultVisualManagerLoop");        
+        createObject(m_root, "MechanicalObject", {{"template","Vec3d"}, {"position", "0 0 0  1 0 0  0 1 0  1 1 1"} });
+        createObject(m_root, "TriangleSetTopologyContainer", { {"triangles","0 1 2  1 3 2"} });
+        createObject(m_root, "TriangleSetTopologyModifier");
+        createObject(m_root, "TriangleSetGeometryAlgorithms", { {"template","Vec3d"} });
+
+        createObject(m_root, "TriangularBendingSprings", { {"Name","TBS"}, {"stiffness", str(ks)}, {"damping", str(kd)} });
+
+        /// Init simulation
+        sofa::simulation::getSimulation()->init(m_root.get());
+    }
+
+
+    void createGridScene(int nbrGrid, Real ks, Real kd)
+    {
+        m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
+        m_root->setGravity(type::Vec3(0.0, -1.0, 0.0));
+        m_root->setDt(0.01);
+
+        createObject(m_root, "DefaultAnimationLoop");
+        createObject(m_root, "DefaultVisualManagerLoop");
+        createObject(m_root, "RegularGridTopology", { {"name", "grid"}, 
+            {"n", str(type::Vec3(nbrGrid, nbrGrid, 1))}, {"min", "0 0 0"}, {"max", "10 10 0"} });
+        
+        Node::SPtr FNode = sofa::simpleapi::createChild(m_root, "SpringNode");
+        createObject(FNode, "EulerImplicitSolver");
+        createObject(FNode, "CGLinearSolver", { { "iterations", "20" }, { "threshold", "1e-6" } });
+        createObject(FNode, "MechanicalObject", {
+            {"name","dof"}, {"template","Vec3d"}, {"position", "@../grid.position"} });
+        createObject(FNode, "TriangleSetTopologyContainer", {
+            {"name","topo"}, {"src","@../grid"} });
+        createObject(FNode, "TriangleSetTopologyModifier", {
+            {"name","Modifier"} });
+        createObject(FNode, "TriangleSetGeometryAlgorithms", {
+            {"name","GeomAlgo"}, {"template","Vec3d"} });
+        
+        createObject(FNode, "TriangularBendingSprings", { {"Name","TBS"}, {"stiffness", str(ks)}, {"damping", str(kd)} });
+        createObject(FNode, "DiagonalMass", { {"name","mass"}, {"massDensity","0.1"} });
+
+        ASSERT_NE(m_root.get(), nullptr);
+
+        /// Init simulation
+        sofa::simulation::getSimulation()->init(m_root.get());
+    }
+
+
+    void checkCreation()
+    {
+        createSimpleTrianglePairScene(100, 0.1);
+
+        typename MState::SPtr dofs = m_root->getTreeObject<MState>();
+        ASSERT_TRUE(dofs.get() != nullptr);
+        ASSERT_EQ(dofs->getSize(), 4);
+
+        typename TriangleBS::SPtr triBS = m_root->getTreeObject<TriangleBS>();
+        ASSERT_TRUE(triBS.get() != nullptr);
+        ASSERT_FLOAT_EQ(triBS->getKs(), 100);
+        ASSERT_FLOAT_EQ(triBS->getKd(), 0.1);
+    }
+
+
+    void checkNoTopology()
+    {
+        m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
+        createObject(m_root, "MechanicalObject", { {"template","Vec3d"}, {"position", "0 0 0  1 0 0  0 1 0  1 1 1"} });
+        createObject(m_root, "TriangularBendingSprings");
+
+        EXPECT_MSG_EMIT(Error);
+
+        /// Init simulation
+        sofa::simulation::getSimulation()->init(m_root.get());
+    }
+
+
+    void checkEmptyTopology()
+    {
+        m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
+        createObject(m_root, "MechanicalObject", { {"template","Vec3d"}, {"position", "0 0 0  1 0 0  0 1 0  1 1 1"} });
+        createObject(m_root, "TriangleSetTopologyContainer");
+        createObject(m_root, "TriangularBendingSprings");
+
+        EXPECT_MSG_EMIT(Error);
+
+        /// Init simulation
+        sofa::simulation::getSimulation()->init(m_root.get());
+    }
+
+
+    void checkDefaultAttributes()
+    {
+        m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
+
+        createObject(m_root, "MechanicalObject", { {"template","Vec3d"}, {"position", "0 0 0  1 0 0  0 1 0  1 1 1"} });
+        createObject(m_root, "TriangleSetTopologyContainer", { {"triangles","0 1 2  1 3 2"} });
+        createObject(m_root, "TriangleSetTopologyModifier");
+        createObject(m_root, "TriangleSetGeometryAlgorithms", { {"template","Vec3d"} });
+        createObject(m_root, "TriangularBendingSprings");
+
+        typename TriangleBS::SPtr triBS = m_root->getTreeObject<TriangleBS>();
+        ASSERT_TRUE(triBS.get() != nullptr);
+        ASSERT_FLOAT_EQ(triBS->getKs(), 100000);
+        ASSERT_FLOAT_EQ(triBS->getKd(), 1);
+    }
+
+
+    void checkWrongAttributes()
+    {
+        EXPECT_MSG_EMIT(Warning);
+        createSimpleTrianglePairScene(-100, -0.1);
+    }
+
+
+    void checkInit()
+    {
+        createSimpleTrianglePairScene(300, 0.5);
+
+        typename TriangleBS::SPtr triBS = m_root->getTreeObject<TriangleBS>();
+        ASSERT_TRUE(triBS.get() != nullptr);
+        
+        const VecEdgeInfo& EdgeInfos = triBS->edgeInfo.getValue();
+        ASSERT_EQ(EdgeInfos.size(), 5);
+
+        // only one commun edge == only one spring between [0; 3] with restLength = ||(1,1,1)||
+        int cptActivated = 0;
+        float restLength = sqrtf(3);
+        for (auto& ei : EdgeInfos)
+        {
+            ASSERT_TRUE(ei.is_initialized == true);
+            if (ei.is_activated)
+            {
+                cptActivated++;
+                ASSERT_EQ(ei.m1, 3);
+                ASSERT_EQ(ei.m2, 0);
+                ASSERT_FLOAT_EQ(ei.ks, 300);
+                ASSERT_FLOAT_EQ(ei.kd, 0.5);
+                ASSERT_FLOAT_EQ(ei.restlength, restLength);
+            }
+        }
+
+        ASSERT_EQ(cptActivated, 1);
+    }
+
+
+    void checkFEMValues()
+    {
+        // load Triangular FEM
+        int nbrGrid = 20;
+        int nbrStep = 10;
+        createGridScene(nbrGrid, 300, 0.5);
+
+        if (m_root.get() == nullptr)
+            return;
+
+        // Access mstate
+        typename MState::SPtr dofs = m_root->getTreeObject<MState>();
+        ASSERT_TRUE(dofs.get() != nullptr);
+        
+        // Access dofs
+        const VecCoord& positions = dofs->x.getValue();
+        ASSERT_EQ(positions.size(), nbrGrid * nbrGrid);
+
+        typename TriangleBS::SPtr triBS = m_root->getTreeObject<TriangleBS>();
+        ASSERT_TRUE(triBS.get() != nullptr);
+        ASSERT_FLOAT_EQ(triBS->getAccumulatedPotentialEnergy(), 0.0);
+
+        const VecEdgeInfo& EdgeInfos = triBS->edgeInfo.getValue();
+        
+        ASSERT_EQ(EdgeInfos.size(), 1121);
+        ASSERT_EQ(EdgeInfos[0].is_activated, true);
+        ASSERT_EQ(EdgeInfos[1].is_activated, true);
+        ASSERT_EQ(EdgeInfos[2].is_activated, false);
+        ASSERT_FLOAT_EQ(EdgeInfos[0].restlength, 1.1768779);
+        
+        EXPECT_NEAR(positions[nbrGrid][0], 0, 1e-4);
+        EXPECT_NEAR(positions[nbrGrid][1], 0.5263, 1e-4);
+        EXPECT_NEAR(positions[nbrGrid][2], 0, 1e-4);
+
+        for (int i = 0; i < nbrStep; i++)
+        {
+            m_simulation->animate(m_root.get(), 0.01);
+        }
+
+        EXPECT_NEAR(positions[nbrGrid][0], -0.00031, 1e-4);
+        EXPECT_NEAR(positions[nbrGrid][1], 0.5216297, 1e-4);
+        EXPECT_NEAR(positions[nbrGrid][2], 0, 1e-4);
+
+        ASSERT_FLOAT_EQ(triBS->getAccumulatedPotentialEnergy(), 6.5779859e-05);
+        ASSERT_FLOAT_EQ(EdgeInfos[0].restlength, 1.1768779);
+    }
+
+};
+
+
+typedef TriangularBendingSprings_test<Vec3Types> TriangularBendingSprings3_test;
+
+TEST_F(TriangularBendingSprings3_test, checkForceField_Creation)
+{
+    this->checkCreation();
+}
+
+TEST_F(TriangularBendingSprings3_test, checkForceField_noTopology)
+{
+    this->checkNoTopology();
+}
+
+TEST_F(TriangularBendingSprings3_test, checkForceField_emptyTopology)
+{
+    this->checkEmptyTopology();
+}
+
+TEST_F(TriangularBendingSprings3_test, checkForceField_defaultAttributes)
+{
+    this->checkDefaultAttributes();
+}
+
+TEST_F(TriangularBendingSprings3_test, checkFEMForceField_wrongAttributess)
+{
+    this->checkWrongAttributes();
+}
+
+TEST_F(TriangularBendingSprings3_test, checkForceField_init)
+{
+    this->checkInit();
+}
+
+TEST_F(TriangularBendingSprings3_test, checkForceField_values)
+{
+    this->checkFEMValues();
+}
+
+} // namespace sofa

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.h
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.h
@@ -57,8 +57,8 @@ public:
     typedef type::Mat<N,N,Real> Mat;
     using Index = sofa::Index;
 
-    Data<double> f_ks; ///< uniform stiffness for the all springs
-    Data<double> f_kd; ///< uniform damping for the all springs
+    Data<Real> f_ks; ///< uniform stiffness for the all springs
+    Data<Real> f_kd; ///< uniform damping for the all springs
     Data<bool> d_showSprings; ///< Option to enable/disable the spring display when showForceField is on. True by default
 
     /// Link to be set to the topology container in the component graph.
@@ -68,20 +68,16 @@ public:
     {
     public:
         Mat DfDx; /// the edge stiffness matrix
-
-        int     m1, m2;  /// the two extremities of the spring: masses m1 and m2
-
-        double  ks;      /// spring stiffness (initialized to the default value)
-        double  kd;      /// damping factor (initialized to the default value)
-
-        double  restlength; /// rest length of the spring
+        int   m1, m2;  /// the two extremities of the spring: masses m1 and m2
+        Real  ks;      /// spring stiffness (initialized to the default value)
+        Real  kd;      /// damping factor (initialized to the default value)
+        Real  restlength; /// rest length of the spring
 
         bool is_activated;
-
         bool is_initialized;
 
         EdgeInformation(int m1=0, int m2=0, double restlength=0.0, bool is_activated=false, bool is_initialized=false)
-            : m1(m1), m2(m2), restlength(restlength), is_activated(is_activated), is_initialized(is_initialized)
+            : m1(m1), m2(m2), ks(Real(100000.0)), kd(Real(1.0)), restlength(restlength), is_activated(is_activated), is_initialized(is_initialized)
         {
         }
         /// Output stream
@@ -120,6 +116,7 @@ protected:
     void applyPointDestruction(const type::vector<Index>& pointIndices);
 
     void applyPointRenumbering(const type::vector<Index>& pointToRenumber);
+
 public:
     /// Searches triangle topology and creates the bending springs
     void init() override;
@@ -130,16 +127,16 @@ public:
     void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;
     SReal getPotentialEnergy(const core::MechanicalParams* mparams, const DataVecCoord& d_x) const override;
 
-    virtual double getKs() const { return f_ks.getValue();}
-    virtual double getKd() const { return f_kd.getValue();}
+    virtual Real getKs() const { return f_ks.getValue();}
+    virtual Real getKd() const { return f_kd.getValue();}
 
     void setKs(const double ks)
     {
-        f_ks.setValue((double)ks);
+        f_ks.setValue(Real(ks));
     }
     void setKd(const double kd)
     {
-        f_kd.setValue((double)kd);
+        f_kd.setValue(Real(kd));
     }
 
     void draw(const core::visual::VisualParams* vparams) override;
@@ -157,7 +154,6 @@ protected:
 
 #if  !defined(SOFA_COMPONENT_FORCEFIELD_TRIANGULARBENDINGSPRINGS_CPP)
 extern template class SOFA_SOFAGENERALDEFORMABLE_API TriangularBendingSprings<defaulttype::Vec3Types>;
-
 #endif // !defined(SOFA_COMPONENT_FORCEFIELD_TRIANGULARBENDINGSPRINGS_CPP)
 
 

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.h
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.h
@@ -60,8 +60,8 @@ public:
     typedef type::Mat<N,N,Real> Mat;
     using Index = sofa::Index;
 
-    Data<Real> f_ks; ///< uniform stiffness for the all springs
-    Data<Real> f_kd; ///< uniform damping for the all springs
+    Data<Real> d_ks; ///< uniform stiffness for the all springs
+    Data<Real> d_kd; ///< uniform damping for the all springs
     Data<bool> d_showSprings; ///< Option to enable/disable the spring display when showForceField is on. True by default
 
     /// Link to be set to the topology container in the component graph.
@@ -144,12 +144,12 @@ public:
     void draw(const core::visual::VisualParams* vparams) override;
 
     /// Getter/setter on the mesh spring stiffness
-    virtual Real getKs() const { return f_ks.getValue();}
-    void setKs(const Real ks) { f_ks.setValue(ks); }
+    virtual Real getKs() const { return d_ks.getValue();}
+    void setKs(const Real ks);
 
     /// Getter/setter on the mesh spring damping
-    virtual Real getKd() const { return f_kd.getValue();}
-    void setKd(const Real kd) { f_kd.setValue(kd); }
+    virtual Real getKd() const { return d_kd.getValue();}
+    void setKd(const Real kd);
 
     /// Getter to global potential energy accumulated
     SReal getAccumulatedPotentialEnergy() const {return m_potentialEnergy;}

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.h
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.h
@@ -22,14 +22,9 @@
 #pragma once
 
 #include <SofaGeneralDeformable/config.h>
-
-#include <map>
-
 #include <sofa/core/behavior/ForceField.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/type/Vec.h>
-#include <sofa/type/Mat.h>
-
 #include <sofa/type/Mat.h>
 #include <SofaBaseTopology/TopologyData.h>
 
@@ -40,7 +35,6 @@ namespace sofa::component::forcefield
 Bending springs added between vertices of triangles sharing a common edge.
 The springs connect the vertices not belonging to the common edge. It compresses when the surface bends along the common edge.
 
-
 	@author The SOFA team </www.sofa-framework.org>
 */
 template<class DataTypes>
@@ -50,20 +44,17 @@ public:
     SOFA_CLASS(SOFA_TEMPLATE(TriangularBendingSprings, DataTypes), SOFA_TEMPLATE(core::behavior::ForceField, DataTypes));
 
     typedef core::behavior::ForceField<DataTypes> Inherited;
-    //typedef typename DataTypes::Real Real;
     typedef typename DataTypes::VecCoord VecCoord;
     typedef typename DataTypes::VecDeriv VecDeriv;
     typedef typename DataTypes::Coord Coord;
     typedef typename DataTypes::Deriv Deriv;
     typedef typename DataTypes::Real Real;
-    //typedef core::behavior::MechanicalState<DataTypes> MechanicalState;
 
     typedef core::objectmodel::Data<VecCoord> DataVecCoord;
     typedef core::objectmodel::Data<VecDeriv> DataVecDeriv;
 
     enum { N=DataTypes::spatial_dimensions };
     typedef type::Mat<N,N,Real> Mat;
-
     using Index = sofa::Index;
 
     Data<double> f_ks; ///< uniform stiffness for the all springs
@@ -72,11 +63,6 @@ public:
 
     /// Link to be set to the topology container in the component graph.
     SingleLink<TriangularBendingSprings<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
-
-protected:
-
-    //Data<double> ks;
-    //Data<double> kd;
 
     class EdgeInformation
     {
@@ -94,8 +80,8 @@ protected:
 
         bool is_initialized;
 
-        EdgeInformation(int m1=0, int m2=0, /* double ks=getKs(), double kd=getKd(), */ double restlength=0.0, bool is_activated=false, bool is_initialized=false)
-            : m1(m1), m2(m2), /* ks(ks), kd(kd), */ restlength(restlength), is_activated(is_activated), is_initialized(is_initialized)
+        EdgeInformation(int m1=0, int m2=0, double restlength=0.0, bool is_activated=false, bool is_initialized=false)
+            : m1(m1), m2(m2), restlength(restlength), is_activated(is_activated), is_initialized(is_initialized)
         {
         }
         /// Output stream
@@ -114,9 +100,8 @@ protected:
     sofa::component::topology::EdgeData<type::vector<EdgeInformation> > edgeInfo; ///< Internal edge data
     typedef typename topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge, sofa::type::vector<EdgeInformation> > TriangularBSEdgeHandler;
 
-    bool updateMatrix;
-    TriangularBendingSprings(/*double _ks, double _kd*/);
-    //TriangularBendingSprings(); //MechanicalState<DataTypes> *mm1 = nullptr, MechanicalState<DataTypes> *mm2 = nullptr);
+protected:
+    TriangularBendingSprings();
 
     virtual ~TriangularBendingSprings();
 
@@ -168,11 +153,6 @@ protected:
     SReal m_potentialEnergy;
 
     sofa::core::topology::BaseMeshTopology* m_topology;
-
-    //public:
-    //Data<double> ks;
-    //Data<double> kd;
-
 };
 
 #if  !defined(SOFA_COMPONENT_FORCEFIELD_TRIANGULARBENDINGSPRINGS_CPP)

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.h
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.h
@@ -151,6 +151,9 @@ public:
     virtual Real getKd() const { return f_kd.getValue();}
     void setKd(const Real kd) { f_kd.setValue(kd); }
 
+    /// Getter to global potential energy accumulated
+    SReal getAccumulatedPotentialEnergy() const {return m_potentialEnergy;}
+
     /// Getter on the potential energy.
     SReal getPotentialEnergy(const core::MechanicalParams* mparams, const DataVecCoord& d_x) const override;
 

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.h
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.h
@@ -70,11 +70,11 @@ public:
     class EdgeInformation
     {
     public:
-        Mat DfDx; /// the edge stiffness matrix
-        int   m1, m2;  /// the two extremities of the spring: masses m1 and m2
-        Real  ks;      /// spring stiffness (initialized to the default value)
-        Real  kd;      /// damping factor (initialized to the default value)
-        Real  restlength; /// rest length of the spring
+        Mat DfDx; ///< the edge stiffness matrix
+        int   m1, m2;  ///< the two extremities of the spring: masses m1 and m2
+        Real  ks;      ///< spring stiffness (initialized to the default value)
+        Real  kd;      ///< damping factor (initialized to the default value)
+        Real  restlength; ///< rest length of the spring
 
         bool is_activated;
         bool is_initialized;

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.inl
@@ -290,6 +290,7 @@ TriangularBendingSprings<DataTypes>::TriangularBendingSprings()
     , l_topology(initLink("topology", "link to the topology container"))
     , edgeInfo(initData(&edgeInfo, "edgeInfo", "Internal edge data"))
     , edgeHandler(nullptr)
+    , m_potentialEnergy(0.0)
     , m_topology(nullptr)
 {
     // Create specific handler for EdgeData

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.inl
@@ -284,8 +284,8 @@ void TriangularBendingSprings<DataTypes>::applyPointRenumbering(const sofa::type
 
 template<class DataTypes>
 TriangularBendingSprings<DataTypes>::TriangularBendingSprings()
-    : f_ks(initData(&f_ks, Real(100000.0),"stiffness","uniform stiffness for the all springs"))
-    , f_kd(initData(&f_kd, Real(1.0),"damping","uniform damping for the all springs"))
+    : d_ks(initData(&d_ks, Real(100000.0),"stiffness","uniform stiffness for the all springs"))
+    , d_kd(initData(&d_kd, Real(1.0),"damping","uniform damping for the all springs"))
     , d_showSprings(initData(&d_showSprings, true, "showSprings", "option to draw springs"))
     , l_topology(initLink("topology", "link to the topology container"))
     , edgeInfo(initData(&edgeInfo, "edgeInfo", "Internal edge data"))
@@ -308,6 +308,10 @@ template<class DataTypes>
 void TriangularBendingSprings<DataTypes>::init()
 {
     this->Inherited::init();
+
+    // checking inputs using setter
+    setKs(d_ks.getValue());
+    setKd(d_kd.getValue());
 
     if (l_topology.empty())
     {
@@ -401,6 +405,34 @@ SReal TriangularBendingSprings<DataTypes>::getPotentialEnergy(const core::Mechan
 {
     msg_error()<<"TriangularBendingSprings::getPotentialEnergy-not-implemented !!!";
     return 0;
+}
+
+
+template<class DataTypes>
+void TriangularBendingSprings<DataTypes>::setKs(const Real ks)
+{ 
+    if (ks < 0)
+    {
+        msg_warning() << "Input Bending Stiffness is not possible: " << ks << ", setting default value: 100000.0";
+    }
+    else if (ks != d_ks.getValue())
+    {
+        d_ks.setValue(ks);
+    }
+}
+
+
+template<class DataTypes>
+void TriangularBendingSprings<DataTypes>::setKd(const Real kd) 
+{ 
+    if (kd < 0)
+    {
+        msg_warning() << "Input Bending damping is not possible: " << kd << ", setting default value: 1.0";
+    }
+    else if (kd != d_kd.getValue())
+    {
+        d_kd.setValue(kd);
+    }
 }
 
 

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.inl
@@ -24,9 +24,6 @@
 #include <SofaGeneralDeformable/TriangularBendingSprings.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/type/RGBAColor.h>
-#include <fstream> // for reading the file
-#include <iostream> //for debugging
-
 #include <SofaBaseTopology/TopologyData.inl>
 
 namespace sofa::component::forcefield
@@ -38,20 +35,18 @@ template< class DataTypes>
 void TriangularBendingSprings<DataTypes>::applyEdgeCreation(Index , EdgeInformation &ei, const core::topology::Edge &,
     const sofa::type::vector<Index> &, const sofa::type::vector<double> &)
 {
-        unsigned int u,v;
-        /// set to zero the edge stiffness matrix
-        for (u=0; u<N; ++u)
+    /// set to zero the edge stiffness matrix
+    for (auto u=0; u<N; ++u)
+    {
+        for (auto v=0; v<N; ++v)
         {
-            for (v=0; v<N; ++v)
-            {
-                ei.DfDx[u][v]=0;
-            }
+            ei.DfDx[u][v] = Real(0);
         }
+    }
 
-        ei.is_activated=false;
-        ei.is_initialized=false;
+    ei.is_activated=false;
+    ei.is_initialized=false;
 }
-
 
 
 template< class DataTypes>
@@ -59,99 +54,76 @@ void TriangularBendingSprings<DataTypes>::applyTriangleCreation(const sofa::type
     const sofa::type::vector<sofa::type::vector<Index> > &, const sofa::type::vector<sofa::type::vector<double> > &)
 {
     using namespace core::topology;
-        double m_ks=getKs();
-        double m_kd=getKd();
+    Real m_ks=getKs();
+    Real m_kd=getKd();
 
-        unsigned int u,v;
+    const typename DataTypes::VecCoord& restPosition = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
+    sofa::helper::WriteOnlyAccessor< core::objectmodel::Data< type::vector<EdgeInformation> > > edgeData = edgeInfo;
 
-        unsigned int nb_activated = 0;
+    for (unsigned int i=0; i<triangleAdded.size(); ++i)
+    {
+        /// describe the jth edge index of triangle no i
+        EdgesInTriangle te2 = m_topology->getEdgesInTriangle(triangleAdded[i]);
+        /// describe the jth vertex index of triangle no i
+        Triangle t2 = m_topology->getTriangle(triangleAdded[i]);
 
-        const typename DataTypes::VecCoord& restPosition = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
-
-        type::vector<EdgeInformation>& edgeData = *(edgeInfo.beginEdit());
-
-        for (unsigned int i=0; i<triangleAdded.size(); ++i)
+        for(unsigned int j=0; j<3; ++j) // for each edge in triangle
         {
-
-            /// describe the jth edge index of triangle no i
-            EdgesInTriangle te2 = m_topology->getEdgesInTriangle(triangleAdded[i]);
-            /// describe the jth vertex index of triangle no i
-            Triangle t2 = m_topology->getTriangle(triangleAdded[i]);
-
-            for(unsigned int j=0; j<3; ++j)
+            EdgeInformation &ei = edgeData[te2[j]]; // edgeInfo
+            if(!(ei.is_initialized))
             {
+                ei.is_initialized = true;
+                unsigned int edgeIndex = te2[j];
+                const auto& shell = m_topology->getTrianglesAroundEdge(edgeIndex);
 
-                EdgeInformation &ei = edgeData[te2[j]]; // edgeInfo
-                if(!(ei.is_initialized))
+                if (shell.size() != 2) // Only Manifold triangulation is handled
                 {
-
-                    unsigned int edgeIndex = te2[j];
-                    ei.is_activated=true;
-
-                    /// set to zero the edge stiffness matrix
-                    for (u=0; u<N; ++u)
-                    {
-                        for (v=0; v<N; ++v)
-                        {
-                            ei.DfDx[u][v]=0;
-                        }
-                    }
-
-                    const auto& shell = m_topology->getTrianglesAroundEdge(edgeIndex);
-                    if (shell.size()==2)
-                    {
-
-                        nb_activated+=1;
-
-                        EdgesInTriangle te1;
-                        Triangle t1;
-
-                        if(shell[0] == triangleAdded[i])
-                        {
-
-                            te1 = m_topology->getEdgesInTriangle(shell[1]);
-                            t1 = m_topology->getTriangle(shell[1]);
-
-                        }
-                        else   // shell[1] == triangleAdded[i]
-                        {
-
-                            te1 = m_topology->getEdgesInTriangle(shell[0]);
-                            t1 = m_topology->getTriangle(shell[0]);
-                        }
-
-                        int i1 = m_topology->getEdgeIndexInTriangle(te1, edgeIndex); //edgeIndex //te1[j]
-                        int i2 = m_topology->getEdgeIndexInTriangle(te2, edgeIndex); // edgeIndex //te2[j]
-
-                        ei.m1 = t1[i1];
-                        ei.m2 = t2[i2];
-
-                        //TriangularBendingSprings<DataTypes> *fftest= (TriangularBendingSprings<DataTypes> *)param;
-                        ei.ks=m_ks; //(fftest->ks).getValue();
-                        ei.kd=m_kd; //(fftest->kd).getValue();
-
-                        Coord u = (restPosition)[ei.m1] - (restPosition)[ei.m2];
-
-                        Real d = u.norm();
-
-                        ei.restlength=(double) d;
-
-                        ei.is_activated=true;
-
-                    }
-                    else
-                    {
-
-                        ei.is_activated=false;
-
-                    }
-
-                    ei.is_initialized = true;
+                    ei.is_activated = false;
+                    continue;
                 }
-            }
 
+
+                /// set to zero the edge stiffness matrix
+                for (auto u=0; u<N; ++u)
+                {
+                    for (auto v=0; v<N; ++v)
+                    {
+                        ei.DfDx[u][v] = Real(0);
+                    }
+                }
+
+                EdgesInTriangle te1;
+                Triangle t1;
+
+                // search for the opposite triangle in shell
+                if(shell[0] == triangleAdded[i])
+                {
+                    te1 = m_topology->getEdgesInTriangle(shell[1]);
+                    t1 = m_topology->getTriangle(shell[1]);
+                }
+                else   // shell[1] == triangleAdded[i]
+                {
+                    te1 = m_topology->getEdgesInTriangle(shell[0]);
+                    t1 = m_topology->getTriangle(shell[0]);
+                }
+
+                // get localIndices of the edge in triangle, same index as opposite vertex in triangle
+                int i1 = m_topology->getEdgeIndexInTriangle(te1, edgeIndex);
+                int i2 = m_topology->getEdgeIndexInTriangle(te2, edgeIndex);
+
+                // store vertex indices of the spring extremities, as well as global spring stiffness and damping
+                ei.m1 = t1[i1];
+                ei.m2 = t2[i2];
+                ei.ks = m_ks;
+                ei.kd = m_kd;
+
+                Coord u = (restPosition)[ei.m1] - (restPosition)[ei.m2];
+                Real d = u.norm();
+                ei.restlength = d;
+                ei.is_activated = true;
+            }
         }
-        edgeInfo.endEdit();    
+    }
 }
 
 
@@ -160,110 +132,81 @@ void TriangularBendingSprings<DataTypes>::applyTriangleDestruction(const sofa::t
 {
     using namespace core::topology;
 
-        double m_ks=getKs(); // typename DataTypes::
-        double m_kd=getKd(); // typename DataTypes::
+    Real m_ks=getKs();
+    Real m_kd=getKd();
 
-        //unsigned int u,v;
+    const typename DataTypes::VecCoord& restPosition = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
+    sofa::helper::WriteOnlyAccessor< core::objectmodel::Data< type::vector<EdgeInformation> > > edgeData = edgeInfo;
 
-        const typename DataTypes::VecCoord& restPosition = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
-        type::vector<EdgeInformation>& edgeData = *(edgeInfo.beginEdit());
+    for (unsigned int i=0; i<triangleRemoved.size(); ++i)
+    {
+        /// describe the jth edge index of triangle no i
+        EdgesInTriangle te = m_topology->getEdgesInTriangle(triangleRemoved[i]);
 
-        for (unsigned int i=0; i<triangleRemoved.size(); ++i)
+        for(unsigned int j=0; j<3; ++j) // for each edge of the triangle
         {
-            /// describe the jth edge index of triangle no i
-            EdgesInTriangle te = m_topology->getEdgesInTriangle(triangleRemoved[i]);
-            /// describe the jth vertex index of triangle no i
-            //Triangle t = m_topology->getTriangle(triangleRemoved[i]);
-
-
-            for(unsigned int j=0; j<3; ++j)
+            EdgeInformation &ei = edgeData[te[j]]; // edgeInfo
+            if (!ei.is_initialized) // not init == no spring, nothing to do
             {
-
-                EdgeInformation &ei = edgeData[te[j]]; // edgeInfo
-                if(ei.is_initialized)
-                {
-
-                    unsigned int edgeIndex = te[j];
-
-                    const auto& shell = m_topology->getTrianglesAroundEdge(edgeIndex);
-                    if (shell.size()==3)
-                    {
-
-                        EdgesInTriangle te1;
-                        Triangle t1;
-                        EdgesInTriangle te2;
-                        Triangle t2;
-
-                        if(shell[0] == triangleRemoved[i])
-                        {
-                            te1 = m_topology->getEdgesInTriangle(shell[1]);
-                            t1 = m_topology->getTriangle(shell[1]);
-                            te2 = m_topology->getEdgesInTriangle(shell[2]);
-                            t2 = m_topology->getTriangle(shell[2]);
-
-                        }
-                        else
-                        {
-
-                            if(shell[1] == triangleRemoved[i])
-                            {
-
-                                te1 = m_topology->getEdgesInTriangle(shell[2]);
-                                t1 = m_topology->getTriangle(shell[2]);
-                                te2 = m_topology->getEdgesInTriangle(shell[0]);
-                                t2 = m_topology->getTriangle(shell[0]);
-
-                            }
-                            else   // shell[2] == triangleRemoved[i]
-                            {
-
-                                te1 = m_topology->getEdgesInTriangle(shell[0]);
-                                t1 = m_topology->getTriangle(shell[0]);
-                                te2 = m_topology->getEdgesInTriangle(shell[1]);
-                                t2 = m_topology->getTriangle(shell[1]);
-
-                            }
-                        }
-
-                        int i1 = m_topology->getEdgeIndexInTriangle(te1, edgeIndex);
-                        int i2 = m_topology->getEdgeIndexInTriangle(te2, edgeIndex);
-
-                        ei.m1 = t1[i1];
-                        ei.m2 = t2[i2];
-
-                        //TriangularBendingSprings<DataTypes> *fftest= (TriangularBendingSprings<DataTypes> *)param;
-                        ei.ks=m_ks; //(fftest->ks).getValue();
-                        ei.kd=m_kd; //(fftest->kd).getValue();
-
-                        Coord u = (restPosition)[ei.m1] - (restPosition)[ei.m2];
-                        Real d = u.norm();
-
-                        ei.restlength=(double) d;
-
-                        ei.is_activated=true;
-
-                    }
-                    else
-                    {
-
-                        ei.is_activated=false;
-                        ei.is_initialized = false;
-
-                    }
-
-                }
-                else
-                {
-
-                    ei.is_activated=false;
-                    ei.is_initialized = false;
-
-                }
+                ei.is_activated = false;
+                ei.is_initialized = false;
+                continue;
             }
 
-        }
+            unsigned int edgeIndex = te[j];
 
-        edgeInfo.endEdit();
+            const auto& shell = m_topology->getTrianglesAroundEdge(edgeIndex);
+            if (shell.size()==3) // This case is possible during remeshing phase (adding/removing triangles)
+            {
+                // search for the 2 opposites triangles in shell To keep only this spring
+                EdgesInTriangle te1;
+                Triangle t1;
+                EdgesInTriangle te2;
+                Triangle t2;
+
+                if(shell[0] == triangleRemoved[i])
+                {
+                    te1 = m_topology->getEdgesInTriangle(shell[1]);
+                    t1 = m_topology->getTriangle(shell[1]);
+                    te2 = m_topology->getEdgesInTriangle(shell[2]);
+                    t2 = m_topology->getTriangle(shell[2]);
+                }
+                else if (shell[1] == triangleRemoved[i])
+                {
+                    te1 = m_topology->getEdgesInTriangle(shell[2]);
+                    t1 = m_topology->getTriangle(shell[2]);
+                    te2 = m_topology->getEdgesInTriangle(shell[0]);
+                    t2 = m_topology->getTriangle(shell[0]);
+                }
+                else   // shell[2] == triangleRemoved[i]
+                {
+                    te1 = m_topology->getEdgesInTriangle(shell[0]);
+                    t1 = m_topology->getTriangle(shell[0]);
+                    te2 = m_topology->getEdgesInTriangle(shell[1]);
+                    t2 = m_topology->getTriangle(shell[1]);
+                }
+
+                int i1 = m_topology->getEdgeIndexInTriangle(te1, edgeIndex);
+                int i2 = m_topology->getEdgeIndexInTriangle(te2, edgeIndex);
+
+                ei.m1 = t1[i1];
+                ei.m2 = t2[i2];
+                ei.ks = m_ks;
+                ei.kd = m_kd;
+
+                Coord u = (restPosition)[ei.m1] - (restPosition)[ei.m2];
+                Real d = u.norm();
+
+                ei.restlength = d;
+                ei.is_activated = true;
+            }
+            else
+            {
+                ei.is_activated = false;
+                ei.is_initialized = false;
+            }
+        }
+    }
 }
 
 
@@ -271,118 +214,78 @@ template<class DataTypes>
 void TriangularBendingSprings<DataTypes>::applyPointDestruction(const sofa::type::vector<Index> &tab)
 {
     using namespace core::topology;
-        bool debug_mode = false;
 
-        unsigned int last = m_topology->getNbPoints() -1;
-        unsigned int i,j;
+    sofa::Index last = m_topology->getNbPoints() -1;
+    unsigned int i,j;
 
-        type::vector<EdgeInformation>& edgeInf = *(edgeInfo.beginEdit());
+    sofa::helper::WriteOnlyAccessor< core::objectmodel::Data< type::vector<EdgeInformation> > > edgeInf = edgeInfo;
 
-        sofa::type::vector<unsigned int> lastIndexVec;
-        for(unsigned int i_init = 0; i_init < tab.size(); ++i_init)
+    sofa::type::vector<unsigned int> lastIndexVec;
+    for(unsigned int i_init = 0; i_init < tab.size(); ++i_init)
+    {
+        lastIndexVec.push_back(last - i_init);
+    }
+
+    for ( i = 0; i < tab.size(); ++i)
+    {
+        unsigned int i_next = i;
+        bool is_reached = false;
+        while( (!is_reached) && (i_next < lastIndexVec.size() - 1))
         {
-
-            lastIndexVec.push_back(last - i_init);
+            i_next += 1 ;
+            is_reached = is_reached || (lastIndexVec[i_next] == tab[i]);
         }
 
-        for ( i = 0; i < tab.size(); ++i)
+        if(is_reached)
         {
-
-            unsigned int i_next = i;
-            bool is_reached = false;
-            while( (!is_reached) && (i_next < lastIndexVec.size() - 1))
-            {
-
-                i_next += 1 ;
-                is_reached = is_reached || (lastIndexVec[i_next] == tab[i]);
-            }
-
-            if(is_reached)
-            {
-
-                lastIndexVec[i_next] = lastIndexVec[i];
-
-            }
-
-            const auto &shell= m_topology->getTrianglesAroundVertex(lastIndexVec[i]);
-            for (j=0; j<shell.size(); ++j)
-            {
-
-                Triangle tj = m_topology->getTriangle(shell[j]);
-
-                int vertexIndex = m_topology->getVertexIndexInTriangle(tj, lastIndexVec[i]);
-
-                EdgesInTriangle tej = m_topology->getEdgesInTriangle(shell[j]);
-
-                unsigned int ind_j = tej[vertexIndex];
-
-                if (edgeInf[ind_j].m1 == (int) last)
-                {
-                    edgeInf[ind_j].m1=(int) tab[i];
-                }
-                else
-                {
-                    if (edgeInf[ind_j].m2 == (int) last)
-                    {
-                        edgeInf[ind_j].m2=(int) tab[i];
-                    }
-                }
-            }
-
-            if(debug_mode)
-            {
-
-                for (unsigned int j_loc=0; j_loc<edgeInf.size(); ++j_loc)
-                {
-
-                    //bool is_forgotten = false;
-                    if (edgeInf[j_loc].m1 == (int) last)
-                    {
-                        edgeInf[j_loc].m1 =(int) tab[i];
-                        //is_forgotten=true;
-
-                    }
-                    else
-                    {
-                        if (edgeInf[j_loc].m2 ==(int) last)
-                        {
-                            edgeInf[j_loc].m2 =(int) tab[i];
-                            //is_forgotten=true;
-
-                        }
-
-                    }
-
-                }
-            }
-
-            --last;
+            lastIndexVec[i_next] = lastIndexVec[i];
         }
 
-        edgeInfo.endEdit();
+        const auto &shell= m_topology->getTrianglesAroundVertex(lastIndexVec[i]);
+        int iLast = int(last);
+        int iTab = int(tab[i]);
+        for (j=0; j<shell.size(); ++j)
+        {
+            Triangle tj = m_topology->getTriangle(shell[j]);
+            int vertexIndex = m_topology->getVertexIndexInTriangle(tj, lastIndexVec[i]);
+
+            EdgesInTriangle tej = m_topology->getEdgesInTriangle(shell[j]);
+            unsigned int ind_j = tej[vertexIndex];
+
+            if (edgeInf[ind_j].m1 == iLast)
+            {
+                edgeInf[ind_j].m1 = iTab;
+            }
+            else if (edgeInf[ind_j].m2 == iLast)
+            {
+                edgeInf[ind_j].m2 = iTab;
+            }
+        }
+
+        --last;
+    }
 }
 
 
 template<class DataTypes>
 void TriangularBendingSprings<DataTypes>::applyPointRenumbering(const sofa::type::vector<Index> &tab)
 {
-        type::vector<EdgeInformation>& edgeInf = *(edgeInfo.beginEdit());
-        for (unsigned int i = 0; i < m_topology->getNbEdges(); ++i)
+    sofa::helper::WriteOnlyAccessor< core::objectmodel::Data< type::vector<EdgeInformation> > > edgeInf = edgeInfo;
+    for (unsigned int i = 0; i < m_topology->getNbEdges(); ++i)
+    {
+        if(edgeInf[i].is_activated)
         {
-            if(edgeInf[i].is_activated)
-            {
-                edgeInf[i].m1  = tab[edgeInf[i].m1];
-                edgeInf[i].m2  = tab[edgeInf[i].m2];
-            }
+            edgeInf[i].m1  = tab[edgeInf[i].m1];
+            edgeInf[i].m2  = tab[edgeInf[i].m2];
         }
-        edgeInfo.endEdit();
+    }
 }
 
 
 template<class DataTypes>
-TriangularBendingSprings<DataTypes>::TriangularBendingSprings(/*double _ks, double _kd*/)
-    : f_ks(initData(&f_ks,(double) 100000.0,"stiffness","uniform stiffness for the all springs")) //(Real)0.3 ??
-    , f_kd(initData(&f_kd,(double) 1.0,"damping","uniform damping for the all springs")) // (Real)1000. ??
+TriangularBendingSprings<DataTypes>::TriangularBendingSprings()
+    : f_ks(initData(&f_ks, Real(100000.0),"stiffness","uniform stiffness for the all springs"))
+    , f_kd(initData(&f_kd, Real(1.0),"damping","uniform damping for the all springs"))
     , d_showSprings(initData(&d_showSprings, true, "showSprings", "option to draw springs"))
     , l_topology(initLink("topology", "link to the topology container"))
     , edgeInfo(initData(&edgeInfo, "edgeInfo", "Internal edge data"))
@@ -469,7 +372,7 @@ void TriangularBendingSprings<DataTypes>::reinit()
 {
     using namespace core::topology;
     /// prepare to store info in the edge array
-    type::vector<EdgeInformation>& edgeInf = *(edgeInfo.beginEdit());
+    sofa::helper::WriteOnlyAccessor< core::objectmodel::Data< type::vector<EdgeInformation> > > edgeInf = edgeInfo;
     edgeInf.resize(m_topology->getNbEdges());
     Index i;
     // set edge tensor to 0
@@ -481,7 +384,6 @@ void TriangularBendingSprings<DataTypes>::reinit()
             (const sofa::type::vector< double >)0);
     }
 
-
     // create edge tensor by calling the triangle creation function
     sofa::type::vector<Index> triangleAdded;
     for (i=0; i<m_topology->getNbTriangles(); ++i)
@@ -491,8 +393,6 @@ void TriangularBendingSprings<DataTypes>::reinit()
         (const sofa::type::vector<Triangle>)0,
         (const sofa::type::vector<sofa::type::vector<Index> >)0,
         (const sofa::type::vector<sofa::type::vector<double> >)0);
-
-    edgeInfo.endEdit();
 }
 
 template <class DataTypes>
@@ -574,7 +474,6 @@ void TriangularBendingSprings<DataTypes>::addDForce(const core::MechanicalParams
     VecDeriv& df = *d_df.beginEdit();
     const VecDeriv& dx = d_dx.getValue();
     Real kFactor = (Real)sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue());
-
 
     size_t nbEdges=m_topology->getNbEdges();
     const type::vector<EdgeInformation>& edgeInf = edgeInfo.getValue();
@@ -658,6 +557,5 @@ void TriangularBendingSprings<DataTypes>::draw(const core::visual::VisualParams*
 
     vparams->drawTool()->restoreLastState();
 }
-
 
 } // namespace sofa::component::forcefield


### PR DESCRIPTION
In ```TriangularBendingSpring```:
- Remove all unused code
- Clean loops logic to exit/continue when possible. No major changes.
- Rename damping and stiffness Data to use prefix `d_`
- Add tests on Data setter to avoid negative values
- Document Header

Activate ```SofaGeneralDeformable_test``` by adding 8 tests in ```TriangularBendingSpring_test.cpp``` to test:
- Component creation with given values or default values
- Error catching if wrong Data values
- Error catching when creating without topology or with empty topology
- Init value on a single pair of triangles
- Simulated values on a grid scene
- Check update of the FEM while removing triangles

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
