### PR TITLE
[Sofa.Compat] Fix Matrixexpr alias

### DIFF
--- a/SofaKernel/modules/Sofa.Compat/src/SofaBaseLinearSolver/MatrixExpr.h
+++ b/SofaKernel/modules/Sofa.Compat/src/SofaBaseLinearSolver/MatrixExpr.h
@@ -43,7 +43,7 @@ namespace sofa::component::linearsolver
     template<class M1>
     using MatrixNegative = sofa::linearalgebra::MatrixNegative<M1>;
 
-    template<class M1, class R2>
+    template<class M1, class M2>
     using MatrixScale = sofa::linearalgebra::MatrixScale<M1, M2>;
 
     template<class T>


### PR DESCRIPTION
The error was not detected on CI as nobody was using this `MatrixScale` thing.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
