### PR TITLE
[SofaGuiQt] Switch name and class name for slaves

### DIFF
--- a/modules/SofaGuiQt/src/sofa/gui/qt/GraphListenerQListView.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/GraphListenerQListView.cpp
@@ -546,19 +546,20 @@ void GraphListenerQListView::onBeginAddSlave(core::objectmodel::BaseObject* mast
             dmsg_error("GraphListenerQListView") << "Unknown master node '"<<master->getName()<<"'";
             return;
         }
-        std::string name = sofa::helper::gettypename(typeid(*slave));
-        std::string::size_type pos = name.find('<');
-        if (pos != std::string::npos)
-            name.erase(pos);
+        std::string className = sofa::helper::gettypename(typeid(*slave));
+        if (const std::string::size_type pos = className.find('<'); pos != std::string::npos)
+            className.erase(pos);
         if (!slave->toConfigurationSetting())
         {
-            item->setText(1, slave->getName().c_str());
+            const auto& name = slave->getName();
+            item->setText(0, name.c_str());
             item->setForeground(1, nameColor);
-            const QString tooltip( ("Name: " + name + "\nClass Name: " + slave->getClassName()).c_str());
+
+            const QString tooltip( ("Name: " + name + "\nClass Name: " + className).c_str());
             item->setToolTip(0, tooltip);
             item->setToolTip(1, tooltip);
         }
-        item->setText(0, name.c_str());
+        item->setText(1, className.c_str());
 
         setMessageIconFrom(item, slave);
 


### PR DESCRIPTION
in the graph display, name and class name were inverted compared to classical objects.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
