### PR TITLE
[SofaBaseTopology] Fix TopologySubsetData: call to creation/desctruction callback was missing

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologySubsetData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologySubsetData.inl
@@ -106,18 +106,18 @@ void TopologySubsetData <TopologyElementType, VecT>::add(sofa::Size nbElements,
 
                 this->m_topologyHandler->applyCreateFunction(Index(size + i), t, empty_vecint, empty_vecdouble);
 
-                if (p_onCreationCallback)
+                if (this->p_onCreationCallback)
                 {
-                    p_onCreationCallback(Index(size + i), t, TopologyElementType(), empty_vecint, empty_vecdouble);
+                    this->p_onCreationCallback(Index(size + i), t, TopologyElementType(), empty_vecint, empty_vecdouble);
                 }
 
             }
             else {
                 this->m_topologyHandler->applyCreateFunction(Index(size + i), t, ancestors[i], coefs[i]);
                 
-                if (p_onCreationCallback)
+                if (this->p_onCreationCallback)
                 {
-                    p_onCreationCallback(Index(size + i), t, TopologyElementType(), ancestors[i], coefs[i]);
+                    this->p_onCreationCallback(Index(size + i), t, TopologyElementType(), ancestors[i], coefs[i]);
                 }
             }
         }
@@ -182,9 +182,9 @@ void TopologySubsetData <TopologyElementType, VecT>::remove(const sofa::type::ve
                 this->m_topologyHandler->applyDestroyFunction(idElem, data[idElem]);
             }
 
-            if (p_onDestructionCallback)
+            if (this->p_onDestructionCallback)
             {
-                p_onDestructionCallback(idElem, data[idElem]);
+                this->p_onDestructionCallback(idElem, data[idElem]);
             }
 
             this->swap(idElem, last);

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologySubsetData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologySubsetData.inl
@@ -105,9 +105,20 @@ void TopologySubsetData <TopologyElementType, VecT>::add(sofa::Size nbElements,
                 const sofa::type::vector< double > empty_vecdouble;
 
                 this->m_topologyHandler->applyCreateFunction(Index(size + i), t, empty_vecint, empty_vecdouble);
+
+                if (p_onCreationCallback)
+                {
+                    p_onCreationCallback(Index(size + i), t, TopologyElementType(), empty_vecint, empty_vecdouble);
+                }
+
             }
             else {
                 this->m_topologyHandler->applyCreateFunction(Index(size + i), t, ancestors[i], coefs[i]);
+                
+                if (p_onCreationCallback)
+                {
+                    p_onCreationCallback(Index(size + i), t, TopologyElementType(), ancestors[i], coefs[i]);
+                }
             }
         }
     }
@@ -169,6 +180,11 @@ void TopologySubsetData <TopologyElementType, VecT>::remove(const sofa::type::ve
             if (this->m_topologyHandler)
             {
                 this->m_topologyHandler->applyDestroyFunction(idElem, data[idElem]);
+            }
+
+            if (p_onDestructionCallback)
+            {
+                p_onDestructionCallback(idElem, data[idElem]);
             }
 
             this->swap(idElem, last);


### PR DESCRIPTION
Callback call in TopologySubsetData were missing:
- desctruction callback during Data remove method
- creation callback during Data add method




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
