### PR TITLE
[SofaBaseTopology] Add method to register callbacks directly using the topologyData

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.h
@@ -59,7 +59,8 @@ public:
     typedef core::topology::TopologyElementInfo<TopologyElementType> ElementInfo;
     typedef core::topology::TopologyChangeElementInfo<TopologyElementType> ChangeElementInfo;
     typedef typename ChangeElementInfo::AncestorElem    AncestorElem;
-
+    typedef typename sofa::component::topology::TopologyDataHandler< TopologyElementType, VecT>  TopologyDataElementHandler;
+    typedef typename TopologyDataElementHandler::TopologyChangeCallback TopologyChangeCallback;
 
     /// Constructor
     TopologyData(const typename sofa::core::topology::BaseTopologyData< VecT >::InitData& data);
@@ -126,6 +127,9 @@ public:
     */
     void setCreationCallback(std::function<void(Index, value_type&, const TopologyElementType&, const sofa::type::vector< Index >&, const sofa::type::vector< double >&)> func) { p_onCreationCallback = func; }
 
+    /// Method to add a Callback method to be registered in the TopologyHandler. This callback will be used when TopologyChangeType @sa type is fired.
+    void addTopologyEventCallBack(core::topology::TopologyChangeType type, TopologyChangeCallback callback);
+
     std::function<void(Index, value_type&)> p_onDestructionCallback;
     std::function<void(Index, value_type&, const TopologyElementType&, const sofa::type::vector< Index >&, const sofa::type::vector< double >&)> p_onCreationCallback;
 
@@ -143,7 +147,7 @@ public:
     void registerTopologicalData() = delete;
     
 protected:
-    sofa::component::topology::TopologyDataHandler< TopologyElementType, VecT>* m_topologyHandler;
+    TopologyDataElementHandler* m_topologyHandler;
 
     bool m_isTopologyDynamic;
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.h
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.h
@@ -66,13 +66,12 @@ public:
     TopologyData(const typename sofa::core::topology::BaseTopologyData< VecT >::InitData& data);
 
 
-    /** Public functions to handle topological engine creation */
-    /// To create topological engine link to this Data. Pointer to current topology is needed.
+    /// Function to create topology handler to manage this Data. @param Pointer to dynamic topology is needed.
     virtual void createTopologyHandler(sofa::core::topology::BaseMeshTopology* _topology);
-
-    /** Public functions to handle topological engine creation */
-    /// To create topological engine link to this Data. Pointer to current topology is needed.
-    virtual void createTopologyHandler(sofa::core::topology::BaseMeshTopology* _topology, sofa::component::topology::TopologyDataHandler< TopologyElementType, VecT>* topoEngine);
+    
+    /// Function to register an existing topology handler to manage this Data. @param Pointer to dynamic topology is needed.
+    /// @param Pointer to dynamic topology is needed.
+    virtual void createTopologyHandler(sofa::core::topology::BaseMeshTopology* _topology, sofa::component::topology::TopologyDataHandler< TopologyElementType, VecT>* topoHandler);
 
     /// Link Data to topology arrays
     void linkToPointDataArray();

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
@@ -49,26 +49,23 @@ void TopologyData <TopologyElementType, VecT>::createTopologyHandler(sofa::core:
     }
     this->m_topology = _topology;
 
-    // Create Topology engine
+    // Create TopologyHandler
     this->m_topologyHandler = new TopologyDataHandler< TopologyElementType, VecT>(this, _topology);
-    this->m_topologyHandler->setNamePrefix(std::string(sofa::core::topology::TopologyElementInfo<TopologyElementType>::name()) + std::string("Engine_"));
+    this->m_topologyHandler->setNamePrefix("TopologyDataHandler( " + this->getOwner()->getName() + " )");
     this->m_topologyHandler->init();
 
-    // Register the engine
+    // Register the TopologyHandler
     m_isTopologyDynamic = this->m_topologyHandler->registerTopology(_topology);
     if (m_isTopologyDynamic)
     {
         this->linkToElementDataArray((TopologyElementType*)nullptr);
         msg_info(this->getOwner()) << "TopologyData: " << this->getName() << " initialized with dynamic " << _topology->getClassName() << "Topology.";
     }
-
-    //if (this->getOwner() && dynamic_cast<sofa::core::objectmodel::BaseObject*>(this->getOwner()))
-    //    dynamic_cast<sofa::core::objectmodel::BaseObject*>(this->getOwner())->addSlave(this->m_topologyHandler);
 }
 
 
 template <typename TopologyElementType, typename VecT>
-void TopologyData <TopologyElementType, VecT>::createTopologyHandler(sofa::core::topology::BaseMeshTopology* _topology, sofa::component::topology::TopologyDataHandler< TopologyElementType, VecT>* topoEngine)
+void TopologyData <TopologyElementType, VecT>::createTopologyHandler(sofa::core::topology::BaseMeshTopology* _topology, sofa::component::topology::TopologyDataHandler< TopologyElementType, VecT>* topoHandler)
 {
     if (_topology == nullptr)
     {
@@ -78,12 +75,12 @@ void TopologyData <TopologyElementType, VecT>::createTopologyHandler(sofa::core:
 
     this->m_topology = _topology;
 
-    // Set Topology engine
-    this->m_topologyHandler = topoEngine;
-    this->m_topologyHandler->setNamePrefix(std::string(sofa::core::topology::TopologyElementInfo<TopologyElementType>::name()) + std::string("Engine_"));
+    // Set Topology TopologyHandler
+    this->m_topologyHandler = topoHandler;
+    this->m_topologyHandler->setNamePrefix("TopologyDataHandler( " + this->getOwner()->getName() + " )");
     this->m_topologyHandler->init();
 
-    // Register the engine
+    // Register the TopologyHandler
     m_isTopologyDynamic = this->m_topologyHandler->registerTopology(_topology);
     if (m_isTopologyDynamic)
     {
@@ -91,14 +88,12 @@ void TopologyData <TopologyElementType, VecT>::createTopologyHandler(sofa::core:
         msg_info(this->getOwner()) << "TopologyData: " << this->getName() << " initialized with dynamic " << this->m_topology->getClassName() << "Topology.";
     }
     else
-        msg_info(this->getOwner()) << "TopologyData: " << this->getName() << " has no engine. Topological changes will be disabled. Use createTopologicalEngine method before registerTopologicalData to allow topological changes.";
-    
-    //if (this->getOwner() && dynamic_cast<sofa::core::objectmodel::BaseObject*>(this->getOwner())) 
-    //    dynamic_cast<sofa::core::objectmodel::BaseObject*>(this->getOwner())->addSlave(this->m_topologyHandler);   
+        msg_info(this->getOwner()) << "TopologyData: " << this->getName() << " has no TopologyHandler. Topological changes will be disabled. Use createTopologyHandler method before registerTopologicalData to allow topological changes.";
+   
 }
 
 
-/// Method used to link Data to point Data array, using the engine's method
+/// Method used to link Data to point Data array, using the TopologyHandler's method
 template <typename TopologyElementType, typename VecT>
 void TopologyData <TopologyElementType, VecT>::linkToPointDataArray()
 {
@@ -111,7 +106,7 @@ void TopologyData <TopologyElementType, VecT>::linkToPointDataArray()
         msg_info(this->getOwner()) << "TopologyData: " << this->getName() << " won't be linkToPointDataArray as toplogy is not dynamic";
 }
 
-/// Method used to link Data to edge Data array, using the engine's method
+/// Method used to link Data to edge Data array, using the TopologyHandler's method
 template <typename TopologyElementType, typename VecT>
 void TopologyData <TopologyElementType, VecT>::linkToEdgeDataArray()
 {
@@ -124,7 +119,7 @@ void TopologyData <TopologyElementType, VecT>::linkToEdgeDataArray()
         msg_info(this->getOwner()) << "TopologyData: " << this->getName() << " won't be linkToEdgeDataArray as toplogy is not dynamic";
 }
 
-/// Method used to link Data to triangle Data array, using the engine's method
+/// Method used to link Data to triangle Data array, using the TopologyHandler's method
 template <typename TopologyElementType, typename VecT>
 void TopologyData <TopologyElementType, VecT>::linkToTriangleDataArray()
 {
@@ -137,7 +132,7 @@ void TopologyData <TopologyElementType, VecT>::linkToTriangleDataArray()
         msg_info(this->getOwner()) << "TopologyData: " << this->getName() << " won't be linkToTriangleDataArray as toplogy is not dynamic";
 }
 
-/// Method used to link Data to quad Data array, using the engine's method
+/// Method used to link Data to quad Data array, using the TopologyHandler's method
 template <typename TopologyElementType, typename VecT>
 void TopologyData <TopologyElementType, VecT>::linkToQuadDataArray()
 {
@@ -150,7 +145,7 @@ void TopologyData <TopologyElementType, VecT>::linkToQuadDataArray()
         msg_info(this->getOwner()) << "TopologyData: " << this->getName() << " won't be linkToQuadDataArray as toplogy is not dynamic";
 }
 
-/// Method used to link Data to tetrahedron Data array, using the engine's method
+/// Method used to link Data to tetrahedron Data array, using the TopologyHandler's method
 template <typename TopologyElementType, typename VecT>
 void TopologyData <TopologyElementType, VecT>::linkToTetrahedronDataArray()
 {
@@ -163,7 +158,7 @@ void TopologyData <TopologyElementType, VecT>::linkToTetrahedronDataArray()
         msg_info(this->getOwner()) << "TopologyData: " << this->getName() << " won't be linkToTetrahedronDataArray as toplogy is not dynamic";
 }
 
-/// Method used to link Data to hexahedron Data array, using the engine's method
+/// Method used to link Data to hexahedron Data array, using the TopologyHandler's method
 template <typename TopologyElementType, typename VecT>
 void TopologyData <TopologyElementType, VecT>::linkToHexahedronDataArray()
 {

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
@@ -392,4 +392,20 @@ void TopologyData <TopologyElementType, VecT>::removeOnMovedPosition(const sofa:
 }
 
 
+template <typename TopologyElementType, typename VecT>
+void TopologyData <TopologyElementType, VecT>::addTopologyEventCallBack(core::topology::TopologyChangeType type, TopologyChangeCallback callback)
+{
+    if (m_topologyHandler != nullptr)
+    {
+        m_topologyHandler->addCallBack(type, callback);
+    }
+    else
+    {
+        msg_warning(this->getOwner()) << "No TopologyHandler has been creating to manage this TopologyData: " << this->getName() 
+            << ". Callback for event: '" << parseTopologyChangeTypeToString(type) << "' won't be registered.";
+    }
+
+}
+
+
 } //namespace sofa::component::topology

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyData.inl
@@ -396,7 +396,7 @@ void TopologyData <TopologyElementType, VecT>::addTopologyEventCallBack(core::to
     }
     else
     {
-        msg_warning(this->getOwner()) << "No TopologyHandler has been creating to manage this TopologyData: " << this->getName() 
+        msg_warning(this->getOwner()) << "No TopologyHandler has been created to manage this TopologyData: " << this->getName() 
             << ". Callback for event: '" << parseTopologyChangeTypeToString(type) << "' won't be registered.";
     }
 

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyDataHandler.inl
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TopologyDataHandler.inl
@@ -58,18 +58,10 @@ TopologyDataHandler< TopologyElementType, VecT>::TopologyDataHandler(t_topologic
 template <typename TopologyElementType, typename VecT>
 void TopologyDataHandler<TopologyElementType,  VecT>::init()
 {
-    // A pointData is by default child of positionSet Data
-    //this->linkToPointDataArray();  // already done while creating engine
-
     // Name creation
-    if (m_prefix.empty()) m_prefix = "TopologyHandler_";
+    if (m_prefix.empty()) m_prefix = "TopologyDataHandler( " + this->m_topologyData->getOwner()->getName() + " )";
     m_data_name = this->m_topologyData->getName();
     this->addOutput(this->m_topologyData);
-
-    // Register Engine in containter list
-    //if (m_topology)
-    //   m_topology->addTopologyHandler(this);
-    //this->registerTopology(m_topology);
 }
 
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.cpp
@@ -56,8 +56,9 @@ void TopologyHandler::ApplyTopologyChanges(const std::list<const core::topology:
     for (changeIt = _changeList.begin(); changeIt != _changeList.end(); ++changeIt)
     {
         core::topology::TopologyChangeType changeType = (*changeIt)->getChangeType();
-        std::string topoChangeType = "DefaultTopologyHandler: " + parseTopologyChangeTypeToString(changeType);
+        std::string topoChangeType = m_prefix + ": " + m_data_name + " - " + parseTopologyChangeTypeToString(changeType);
         sofa::helper::AdvancedTimer::stepBegin(topoChangeType);
+        dmsg_info("TopologyHandler") << topoChangeType;
 
 
         // New version using map of callback


### PR DESCRIPTION
- Add method ```addTopologyEventCallBack``` in TopologyData to be able to register callback to the TopologyHandler without having to manually create and manipulate this handler class.
```addTopologyEventCallBack``` redirect the registration to ```TopologyHandler->addCallBack```
- Various minor cleaning in code comments

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
