### PR TITLE
[SofaBaseTopology] Ensure to add a topology EndingEvent before propagating to all topologyData

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyModifier.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/PointSetTopologyModifier.cpp
@@ -434,6 +434,8 @@ void PointSetTopologyModifier::propagateTopologicalChanges()
 {
     if (m_container->beginChange() == m_container->endChange()) return; // nothing to do if no event is stored
 
+    sofa::core::topology::EndingEvent* e = new sofa::core::topology::EndingEvent();
+    m_container->addTopologyChange(e);
     this->propagateTopologicalEngineChanges();
     
     sofa::core::ExecParams* params = sofa::core::execparams::defaultInstance();


### PR DESCRIPTION
Add topology EndingEvent  to the queue of event each time before propagating. This event can be catch by callback if needed.
See next PR with uniformMass





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
