### PR TITLE
[SofaGeneralSimpleFem] Update BeamFEMForceField topologyHander and add tests

### DIFF
--- a/modules/SofaGeneralSimpleFem/CMakeLists.txt
+++ b/modules/SofaGeneralSimpleFem/CMakeLists.txt
@@ -52,3 +52,12 @@ sofa_create_package_with_targets(
     INCLUDE_INSTALL_DIR "${PROJECT_NAME}"
     RELOCATABLE "plugins"
 )
+
+# Tests
+# If SOFA_BUILD_TESTS exists and is OFF, then these tests will be auto-disabled
+cmake_dependent_option(SOFAGENERALSIMPLEFEM_BUILD_TESTS "Compile the automatic tests" ON "SOFA_BUILD_TESTS OR NOT DEFINED SOFA_BUILD_TESTS" OFF)
+if(SOFAGENERALSIMPLEFEM_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(${PROJECT_NAME}_test)
+endif()
+

--- a/modules/SofaGeneralSimpleFem/SofaGeneralSimpleFem_test/BeamFEMForceField_test.cpp
+++ b/modules/SofaGeneralSimpleFem/SofaGeneralSimpleFem_test/BeamFEMForceField_test.cpp
@@ -1,0 +1,307 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/defaulttype/VecTypes.h>
+#include <SofaBaseMechanics/MechanicalObject.h>
+#include <SofaGeneralSimpleFem/BeamFEMForceField.h>
+#include <SofaBaseTopology/EdgeSetTopologyModifier.h>
+#include <SofaBaseTopology/TopologyData.inl>
+
+#include <SofaSimulationGraph/SimpleApi.h>
+#include <SofaSimulationGraph/DAGSimulation.h>
+#include <sofa/simulation/Simulation.h>
+#include <sofa/simulation/Node.h>
+using sofa::simulation::Node;
+
+#include <sofa/testing/BaseTest.h>
+using sofa::testing::BaseTest;
+
+#include <string>
+using std::string;
+
+
+namespace sofa
+{
+using namespace sofa::defaulttype;
+using namespace sofa::simpleapi;
+using sofa::component::container::MechanicalObject;
+
+template <class DataTypes>
+class BeamFEMForceField_test : public BaseTest
+{
+public:
+    typedef typename DataTypes::Real Real;
+    typedef typename DataTypes::Coord Coord;
+    typedef typename DataTypes::VecCoord VecCoord;
+    typedef MechanicalObject<DataTypes> MState;
+    using BeamFEM = sofa::component::forcefield::BeamFEMForceField<DataTypes>;
+    using EdgeModifier = sofa::component::topology::EdgeSetTopologyModifier;
+    typedef typename BeamFEM::BeamInfo BeamInfo;
+    typedef typename type::vector<BeamInfo> VecBeamInfo;
+
+protected:
+    simulation::Simulation* m_simulation = nullptr;
+    simulation::Node::SPtr m_root;
+    
+public:
+
+    void SetUp() override
+    {
+        sofa::simpleapi::importPlugin("SofaComponentAll");
+        simulation::setSimulation(m_simulation = new simulation::graph::DAGSimulation());
+    }
+
+    void TearDown() override
+    {
+        if (m_root != nullptr)
+            simulation::getSimulation()->unload(m_root);
+    }
+
+    void createSimpleBeam(Real radius, Real youngModulus, Real poissonRatio)
+    {
+        m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
+        m_root->setGravity(type::Vec3(0.0, -1.0, 0.0));
+        m_root->setDt(0.01);
+
+        createObject(m_root, "DefaultAnimationLoop");
+        createObject(m_root, "DefaultVisualManagerLoop");
+
+        createObject(m_root, "EulerImplicitSolver");
+        createObject(m_root, "CGLinearSolver", { { "iterations", "20" }, { "threshold", "1e-8" } });
+        createObject(m_root, "MechanicalObject", {{"template","Rigid3d"}, {"position", "0 0 1 0 0 0 1   1 0 1 0 0 0 1   2 0 1 0 0 0 1   3 0 1 0 0 0 1"} });
+        createObject(m_root, "EdgeSetTopologyContainer", { {"edges","0 1  1 2  2 3"} });
+        createObject(m_root, "EdgeSetTopologyModifier");
+        createObject(m_root, "EdgeSetGeometryAlgorithms", { {"template","Rigid3d"} });
+
+        createObject(m_root, "BeamFEMForceField", { {"Name","Beam"}, {"template", "Rigid3d"}, {"radius", str(radius)}, {"youngModulus", str(youngModulus)}, {"poissonRatio", str(poissonRatio)} });
+        createObject(m_root, "UniformMass", { {"name","mass"}, {"totalMass","1.0"} });
+        createObject(m_root, "FixedConstraint", { {"name","fix"}, {"indices","0"} });
+
+        /// Init simulation
+        sofa::simulation::getSimulation()->init(m_root.get());
+    }
+
+
+    void checkCreation()
+    {
+        createSimpleBeam(0.05, 20000000, 0.49);
+
+        typename MState::SPtr dofs = m_root->getTreeObject<MState>();
+        ASSERT_TRUE(dofs.get() != nullptr);
+        ASSERT_EQ(dofs->getSize(), 4);
+
+        typename BeamFEM::SPtr bFEM = m_root->getTreeObject<BeamFEM>();
+        ASSERT_TRUE(bFEM.get() != nullptr);
+        ASSERT_FLOAT_EQ(bFEM->d_radius.getValue(), 0.05);
+        ASSERT_FLOAT_EQ(bFEM->d_youngModulus.getValue(), 20000000);
+        ASSERT_FLOAT_EQ(bFEM->d_poissonRatio.getValue(), 0.49);
+    }
+
+
+    void checkNoMechanicalObject()
+    {
+        EXPECT_MSG_EMIT(Error);
+        
+        m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
+        createObject(m_root, "BeamFEMForceField", { {"Name","Beam"}, {"template", "Rigid3d"}, {"radius", "0.05"} });
+        
+        sofa::simulation::getSimulation()->init(m_root.get());
+    }
+
+
+    void checkNoTopology()
+    {
+        EXPECT_MSG_EMIT(Error);
+
+        m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
+        createObject(m_root, "MechanicalObject", { {"template","Rigid3d"}, {"position", "0 0 1 0 0 0 1   1 0 1 0 0 0 1   2 0 1 0 0 0 1   3 0 1 0 0 0 1"} });
+        createObject(m_root, "BeamFEMForceField", { {"Name","Beam"}, {"template", "Rigid3d"} });
+
+        sofa::simulation::getSimulation()->init(m_root.get());
+    }
+
+
+    void checkEmptyTopology()
+    {
+        m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
+        createObject(m_root, "MechanicalObject", { {"template","Rigid3d"}, {"position", "0 0 1 0 0 0 1   1 0 1 0 0 0 1   2 0 1 0 0 0 1   3 0 1 0 0 0 1"} });
+        createObject(m_root, "EdgeSetTopologyContainer");
+        createObject(m_root, "BeamFEMForceField", { {"Name","Beam"}, {"template", "Rigid3d"} });
+
+        EXPECT_MSG_EMIT(Error);
+
+        /// Init simulation
+        sofa::simulation::getSimulation()->init(m_root.get());
+    }
+
+
+    void checkDefaultAttributes()
+    {
+        m_root = sofa::simpleapi::createRootNode(m_simulation, "root");
+
+        createObject(m_root, "MechanicalObject", { {"template","Rigid3d"}, {"position", "0 0 1 0 0 0 1   1 0 1 0 0 0 1   2 0 1 0 0 0 1   3 0 1 0 0 0 1"} });
+        createObject(m_root, "EdgeSetTopologyContainer", { {"edges","0 1  1 2  2 3"} });
+        createObject(m_root, "BeamFEMForceField", { {"Name","Beam"}, {"template", "Rigid3d"} });
+
+        typename BeamFEM::SPtr bFEM = m_root->getTreeObject<BeamFEM>();
+        ASSERT_TRUE(bFEM.get() != nullptr);
+        ASSERT_FLOAT_EQ(bFEM->d_radius.getValue(), 0.1);
+        ASSERT_FLOAT_EQ(bFEM->d_youngModulus.getValue(), 5000);
+        ASSERT_FLOAT_EQ(bFEM->d_poissonRatio.getValue(), 0.49);
+    }
+
+
+    void checkInit()
+    {
+        Real radius = 0.05;
+        Real young = 20000000;
+        Real poisson = 0.49;
+        createSimpleBeam(radius, young, poisson);
+
+        typename BeamFEM::SPtr bFEM = m_root->getTreeObject<BeamFEM>();
+        ASSERT_TRUE(bFEM.get() != nullptr);
+
+        const VecBeamInfo& EdgeInfos = bFEM->m_beamsData.getValue();
+        ASSERT_EQ(EdgeInfos.size(), 3);
+
+        // check edgeInfo
+        const BeamInfo& bI = EdgeInfos[0];
+        ASSERT_EQ(bI._E, young);
+        ASSERT_EQ(bI._nu, poisson);
+        ASSERT_EQ(bI._r, radius);
+        ASSERT_EQ(bI._L, 1.0);
+        ASSERT_FLOAT_EQ(bI._G, young/(2.0*(1.0+poisson)));
+    }
+
+
+    void checkFEMValues()
+    {
+        Real radius = 0.05;
+        Real young = 20000000;
+        Real poisson = 0.49;
+        createSimpleBeam(radius, young, poisson);
+
+        if (m_root.get() == nullptr)
+            return;
+
+        // Access mstate
+        typename MState::SPtr dofs = m_root->getTreeObject<MState>();
+        ASSERT_TRUE(dofs.get() != nullptr);
+     
+        // Access dofs
+        const VecCoord& positions = dofs->x.getValue();
+        ASSERT_EQ(positions.size(), 4);
+
+        // check positions at init
+        EXPECT_NEAR(positions[3][0], 3, 1e-4);
+        EXPECT_NEAR(positions[3][1], 0, 1e-4);
+        EXPECT_NEAR(positions[3][2], 1, 1e-4);
+
+        // access beam info
+        typename BeamFEM::SPtr bFEM = m_root->getTreeObject<BeamFEM>();
+        const VecBeamInfo& EdgeInfos = bFEM->m_beamsData.getValue();
+        const BeamInfo& bI = EdgeInfos[2];
+
+        // simulate
+        for (int i = 0; i < 10; i++)
+        {
+            m_simulation->animate(m_root.get(), 0.01);
+        }
+
+        // check positions after simulation
+        EXPECT_NEAR(positions[3][0], 3, 1e-4);
+        EXPECT_NEAR(positions[3][1], -0.004936, 1e-4);
+        EXPECT_NEAR(positions[3][2], 1, 1e-4);
+
+        // check edgeInfo
+        ASSERT_EQ(bI._E, young);
+        ASSERT_EQ(bI._nu, poisson);
+        ASSERT_EQ(bI._r, radius);
+        ASSERT_EQ(bI._L, 1.0);
+    }
+
+
+    void checkTopologyChanges()
+    {
+        createSimpleBeam(0.05, 20000000, 0.49);
+
+        typename EdgeModifier::SPtr edgeModif = m_root->getTreeObject<EdgeModifier>();
+        ASSERT_TRUE(edgeModif.get() != nullptr);
+
+        typename BeamFEM::SPtr bFEM = m_root->getTreeObject<BeamFEM>();
+        const VecBeamInfo& EdgeInfos = bFEM->m_beamsData.getValue();
+
+        ASSERT_EQ(EdgeInfos.size(), 3);
+        
+        sofa::topology::SetIndex indices = { 0 };
+        edgeModif->removeEdges(indices, true);
+
+        m_simulation->animate(m_root.get(), 0.01);
+        ASSERT_EQ(EdgeInfos.size(), 2);
+    }
+};
+
+
+typedef BeamFEMForceField_test<Rigid3Types> BeamFEMForceField_Rig3_test;
+
+TEST_F(BeamFEMForceField_Rig3_test, checkForceField_Creation)
+{
+    this->checkCreation();
+}
+
+TEST_F(BeamFEMForceField_Rig3_test, checkForceField_noMechanicalObject)
+{
+    this->checkNoMechanicalObject();
+}
+
+TEST_F(BeamFEMForceField_Rig3_test, checkForceField_noTopology)
+{
+    this->checkNoTopology();
+}
+
+TEST_F(BeamFEMForceField_Rig3_test, checkForceField_emptyTopology)
+{
+    this->checkEmptyTopology();
+}
+
+TEST_F(BeamFEMForceField_Rig3_test, checkForceField_defaultAttributes)
+{
+    this->checkDefaultAttributes();
+}
+
+// checkWrongAttributes is missing
+
+TEST_F(BeamFEMForceField_Rig3_test, checkForceField_init)
+{
+    this->checkInit();
+}
+
+TEST_F(BeamFEMForceField_Rig3_test, checkForceField_values)
+{
+    this->checkFEMValues();
+}
+
+TEST_F(BeamFEMForceField_Rig3_test, checkForceField_TopologyChanges)
+{
+    this->checkTopologyChanges();
+}
+
+} // namespace sofa

--- a/modules/SofaGeneralSimpleFem/SofaGeneralSimpleFem_test/BeamFEMForceField_test.cpp
+++ b/modules/SofaGeneralSimpleFem/SofaGeneralSimpleFem_test/BeamFEMForceField_test.cpp
@@ -92,7 +92,7 @@ public:
         createObject(m_root, "EdgeSetGeometryAlgorithms", { {"template","Rigid3d"} });
 
         createObject(m_root, "BeamFEMForceField", { {"Name","Beam"}, {"template", "Rigid3d"}, {"radius", str(radius)}, {"youngModulus", str(youngModulus)}, {"poissonRatio", str(poissonRatio)} });
-        createObject(m_root, "UniformMass", { {"name","mass"}, {"totalMass","1.0"} });
+        createObject(m_root, "UniformMass", { {"name","mass"}, {"totalMass","1.0"}, {"handleTopologicalChanges", "1" } });
         createObject(m_root, "FixedConstraint", { {"name","fix"}, {"indices","0"} });
 
         /// Init simulation

--- a/modules/SofaGeneralSimpleFem/SofaGeneralSimpleFem_test/CMakeLists.txt
+++ b/modules/SofaGeneralSimpleFem/SofaGeneralSimpleFem_test/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(SofaGeneralSimpleFem_test)
+
+sofa_find_package(SofaGeneralSimpleFem REQUIRED)
+sofa_find_package(SofaBaseMechanics REQUIRED)
+
+set(SOURCE_FILES
+    BeamFEMForceField_test.cpp
+    )
+
+add_executable(${PROJECT_NAME} ${SOURCE_FILES})
+target_link_libraries(${PROJECT_NAME} Sofa.Testing SofaGeneralSimpleFem SofaBaseMechanics)
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/BeamFEMForceField.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/BeamFEMForceField.h
@@ -30,8 +30,6 @@ namespace  sofa::component::forcefield
 
 namespace _beamfemforcefield_
 {
-
-using topology::TopologyDataHandler;
 using core::MechanicalParams;
 using core::behavior::MultiMatrixAccessor;
 using core::behavior::ForceField;
@@ -65,8 +63,6 @@ public:
     typedef BaseMeshTopology::Edge Element;
     typedef type::vector<BaseMeshTopology::Edge> VecElement;
     typedef Vec<3, Real> Vec3;
-
-protected:
 
     typedef Vec<12, Real> Displacement;     ///< the displacement vector
     typedef Mat<3, 3, Real> Transformation; ///< matrix for rigid transformations like rotations
@@ -134,26 +130,13 @@ protected:
         }
     };
 
-    class BeamFFEdgeHandler : public TopologyDataHandler<BaseMeshTopology::Edge, type::vector<BeamInfo> >
-    {
-    public:
-        typedef typename BeamFEMForceField<DataTypes>::BeamInfo BeamInfo;
-        BeamFFEdgeHandler(BeamFEMForceField<DataTypes>* ff, EdgeData<type::vector<BeamInfo> >* data)
-            :TopologyDataHandler<BaseMeshTopology::Edge, type::vector<BeamInfo> >(data),ff(ff) {}
-
-        void applyCreateFunction(Index edgeIndex, BeamInfo&,
-                                 const BaseMeshTopology::Edge& e,
-                                 const type::vector<Index> &,
-                                 const type::vector< double > &);
-
-    protected:
-        BeamFEMForceField<DataTypes>* ff;
-
-    };
-
-    //just for draw forces
-    VecDeriv m_forces;
     EdgeData<type::vector<BeamInfo> > m_beamsData; ///< Internal element data
+
+protected:
+    void createBeamInfo(Index edgeIndex, BeamInfo&,
+        const BaseMeshTopology::Edge& e,
+        const type::vector<Index> &,
+        const type::vector< double > &);
 
     const VecElement *m_indexedElements;
 
@@ -169,6 +152,9 @@ public:
     SingleLink<BeamFEMForceField<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
  protected:
+    //just for draw forces
+    VecDeriv m_forces;
+
     bool m_partialListSegment;
     bool m_updateStiffnessMatrix;
     bool m_assembling;
@@ -177,7 +163,6 @@ public:
     Quat<SReal>& beamQuat(int i);
 
     BaseMeshTopology* m_topology;
-    BeamFFEdgeHandler* m_edgeHandler;
 
     BeamFEMForceField();
     BeamFEMForceField(Real poissonRatio, Real youngModulus, Real radius, Real radiusInner);


### PR DESCRIPTION
In ```BeamFEMForceField```:
- Remove TopologyHandler to directly use TopologyData creation callback.

Activate ```SofaGeneralSimpleFem_test``` by adding 8 tests in ```BeamFEMForceField_test.cpp``` to test:
- Component creation with given values or default values
- Error catching when creating without MechanicalObject
- Error catching when creating without topology or with empty topology
- value after init and after several simulation steps
- Check update of the FEM while removing edges

This last test on topological change is failing because of the bug in UniformMass fixed in PR #2377 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
