### PR TITLE
[SofaGeneralSimpleFem] Remove TopologyHandler in FEM to use TopologyData callbacks (part 1)

### DIFF
--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/HexahedralFEMForceField.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/HexahedralFEMForceField.h
@@ -189,6 +189,9 @@ public:
     /// container that stotes all requires information for each hexahedron
     topology::HexahedronData<sofa::type::vector<HexahedronInformation> > hexahedronInfo;
 
+    /** Method to create @sa HexahedronInformation when a new hexahedron is created.
+    * Will be set as creation callback in the HexahedronData @sa hexahedronInfo
+    */
     void createHexahedronInformation(Index, HexahedronInformation& t, const core::topology::BaseMeshTopology::Hexahedron&,
         const sofa::type::vector<Index>&, const sofa::type::vector<double>&);
 

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/HexahedralFEMForceField.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/HexahedralFEMForceField.h
@@ -189,28 +189,10 @@ public:
     /// container that stotes all requires information for each hexahedron
     topology::HexahedronData<sofa::type::vector<HexahedronInformation> > hexahedronInfo;
 
-    class HFFHexahedronHandler : public topology::TopologyDataHandler<core::topology::BaseMeshTopology::Hexahedron,sofa::type::vector<HexahedronInformation> >
-    {
-    public:
-        typedef typename HexahedralFEMForceField<DataTypes>::HexahedronInformation HexahedronInformation;
-
-        HFFHexahedronHandler(HexahedralFEMForceField<DataTypes>* ff, topology::HexahedronData<sofa::type::vector<HexahedronInformation> >* data )
-            :topology::TopologyDataHandler<core::topology::BaseMeshTopology::Hexahedron,sofa::type::vector<HexahedronInformation> >(data)
-            ,ff(ff)
-        {
-        }
-
-        void applyCreateFunction(Index, HexahedronInformation &t, const core::topology::BaseMeshTopology::Hexahedron &,
-                const sofa::type::vector<Index> &, const sofa::type::vector<double> &);
-    protected:
-        HexahedralFEMForceField<DataTypes>* ff;
-    };
-
-
+    void createHexahedronInformation(Index, HexahedronInformation& t, const core::topology::BaseMeshTopology::Hexahedron&,
+        const sofa::type::vector<Index>&, const sofa::type::vector<double>&);
 
 protected:
-    HFFHexahedronHandler* hexahedronHandler;
-
     topology::HexahedronSetTopologyContainer* _topology;
 
     type::Mat<8,3,int> _coef; ///< coef of each vertices to compute the strain stress matrix

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TetrahedralCorotationalFEMForceField.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TetrahedralCorotationalFEMForceField.h
@@ -137,28 +137,7 @@ public:
     SReal m_potentialEnergy;
 
     sofa::core::topology::BaseMeshTopology* _topology;
-public:
-    class SOFA_SOFAGENERALSIMPLEFEM_API TetrahedronHandler : public topology::TopologyDataHandler<core::topology::BaseMeshTopology::Tetrahedron, sofa::type::vector<TetrahedronInformation> >
-    {
-    public :
-        typedef typename TetrahedralCorotationalFEMForceField<DataTypes>::TetrahedronInformation TetrahedronInformation;
-        using Index = sofa::Index;
-        TetrahedronHandler(TetrahedralCorotationalFEMForceField<DataTypes>* ff,
-                           topology::TetrahedronData<sofa::type::vector<TetrahedronInformation> >* data)
-            :topology::TopologyDataHandler<core::topology::BaseMeshTopology::Tetrahedron, sofa::type::vector<TetrahedronInformation> >(data)
-            ,ff(ff)
-        {
 
-        }
-
-        void applyCreateFunction(Index, TetrahedronInformation &t, const core::topology::BaseMeshTopology::Tetrahedron &,
-                const sofa::type::vector<Index> &,
-                const sofa::type::vector<double> &);
-
-    protected:
-        TetrahedralCorotationalFEMForceField<DataTypes>* ff;
-
-    };
 public:
     int method;
     Data<std::string> f_method; ///< the computation method of the displacements
@@ -179,7 +158,6 @@ public:
     SingleLink<TetrahedralCorotationalFEMForceField<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 protected:
     TetrahedralCorotationalFEMForceField();
-    TetrahedronHandler* tetrahedronHandler;
 
     /// Pointer to the topology container. Will be set by link @sa l_topology
     sofa::core::topology::BaseMeshTopology* m_topology;
@@ -224,6 +202,13 @@ public:
 
 
 protected:
+    /** Method to create @sa TetrahedronInformation when a new tetrahedron is created.
+    * Will be set as creation callback in the TetrahedronData @sa tetrahedronInfo
+    */
+    void createTetrahedronInformation(Index tetrahedronIndex, TetrahedronInformation& tInfo,
+        const core::topology::BaseMeshTopology::Tetrahedron& tetra,
+        const sofa::type::vector<Index>& ancestors,
+        const sofa::type::vector<double>& coefs);
 
     void computeStrainDisplacement( StrainDisplacementTransposed &J, Coord a, Coord b, Coord c, Coord d );
     Real peudo_determinant_for_coef ( const type::Mat<2, 3, Real>&  M );

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TetrahedralCorotationalFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TetrahedralCorotationalFEMForceField.inl
@@ -35,40 +35,33 @@ namespace sofa::component::forcefield
 {
 
 template< class DataTypes>
-void TetrahedralCorotationalFEMForceField<DataTypes>::TetrahedronHandler::applyCreateFunction(Index tetrahedronIndex,
-        TetrahedronInformation &,
-        const core::topology::BaseMeshTopology::Tetrahedron &,
-        const sofa::type::vector<Index> &,
-        const sofa::type::vector<double> &)
+void TetrahedralCorotationalFEMForceField<DataTypes>::createTetrahedronInformation(Index tetrahedronIndex, TetrahedronInformation& tInfo,
+        const core::topology::BaseMeshTopology::Tetrahedron& tetra,
+        const sofa::type::vector<Index>& ancestors,
+        const sofa::type::vector<double>& coefs)
 {
+    const core::topology::BaseMeshTopology::Tetrahedron t=this->m_topology->getTetrahedron(tetrahedronIndex);
+    Index a = t[0];
+    Index b = t[1];
+    Index c = t[2];
+    Index d = t[3];
 
-    if (ff)
+    switch(method)
     {
+    case SMALL :
+        computeMaterialStiffness(tetrahedronIndex,a,b,c,d);
+        initSmall(tetrahedronIndex,a,b,c,d);
+        break;
+    case LARGE :
+        computeMaterialStiffness(tetrahedronIndex,a,b,c,d);
+        initLarge(tetrahedronIndex,a,b,c,d);
 
-        const core::topology::BaseMeshTopology::Tetrahedron t=ff->m_topology->getTetrahedron(tetrahedronIndex);
-        Index a = t[0];
-        Index b = t[1];
-        Index c = t[2];
-        Index d = t[3];
-
-        switch(ff->method)
-        {
-        case SMALL :
-            ff->computeMaterialStiffness(tetrahedronIndex,a,b,c,d);
-            ff->initSmall(tetrahedronIndex,a,b,c,d);
-            break;
-        case LARGE :
-            ff->computeMaterialStiffness(tetrahedronIndex,a,b,c,d);
-            ff->initLarge(tetrahedronIndex,a,b,c,d);
-
-            break;
-        case POLAR :
-            ff->computeMaterialStiffness(tetrahedronIndex,a,b,c,d);
-            ff->initPolar(tetrahedronIndex,a,b,c,d);
-            break;
-        }
+        break;
+    case POLAR :
+        computeMaterialStiffness(tetrahedronIndex,a,b,c,d);
+        initPolar(tetrahedronIndex,a,b,c,d);
+        break;
     }
-
 }
 
 template< class DataTypes>
@@ -86,11 +79,9 @@ TetrahedralCorotationalFEMForceField<DataTypes>::TetrahedralCorotationalFEMForce
     , drawColor3(initData(&drawColor3,sofa::type::RGBAColor(0.0f,1.0f,1.0f,1.0f),"drawColor3"," draw color for faces 3"))
     , drawColor4(initData(&drawColor4,sofa::type::RGBAColor(0.5f,1.0f,1.0f,1.0f),"drawColor4"," draw color for faces 4"))
     , l_topology(initLink("topology", "link to the topology container"))
-    , tetrahedronHandler(nullptr)
 {
     this->addAlias(&_assembling, "assembling");
     _poissonRatio.setWidget("poissonRatio");
-    tetrahedronHandler = new TetrahedronHandler(this,&tetrahedronInfo);
 
     _poissonRatio.setRequired(true);
     _youngModulus.setRequired(true);
@@ -143,12 +134,20 @@ void TetrahedralCorotationalFEMForceField<DataTypes>::reinit()
 
     for (std::size_t i=0; i<m_topology->getNbTetrahedra(); ++i)
     {
-        tetrahedronHandler->applyCreateFunction(i, tetrahedronInf[i],
+        createTetrahedronInformation(i, tetrahedronInf[i],
                 m_topology->getTetrahedron(i),  (const std::vector< Index > )0,
                 (const std::vector< double >)0);
     }
 
-    tetrahedronInfo.createTopologyHandler(m_topology,tetrahedronHandler);
+    tetrahedronInfo.createTopologyHandler(m_topology);
+    tetrahedronInfo.setCreationCallback([this](Index tetrahedronIndex, TetrahedronInformation& tInfo,
+        const core::topology::BaseMeshTopology::Tetrahedron& tetra,
+        const sofa::type::vector<Index>& ancestors,
+        const sofa::type::vector<double>& coefs)
+    {
+        createTetrahedronInformation(tetrahedronIndex, tInfo, tetra, ancestors, coefs);
+    });
+
     tetrahedronInfo.endEdit();
 }
 

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.h
@@ -229,11 +229,17 @@ public:
     topology::PointData<VecVertexInfo> d_vertexInfo; ///< Internal point data
     topology::EdgeData<VecEdgeInfo> d_edgeInfo; ///< Internal edge data
 
+    /** Method to create @sa TriangleInfo when a new triangle is created.
+    * Will be set as creation callback in the TriangleData @sa d_triangleInfo
+    */
     void createTriangleInfo(Index triangleIndex, TriangleInfo&, 
         const Triangle& t,
         const sofa::type::vector< Index >&,
         const sofa::type::vector< double >&);
 
+    /** Method to create @sa TriangleState when a new triangle is created.
+    * Will be set as creation callback in the TriangleData @sa d_triangleState
+    */
     void createTriangleState(Index triangleIndex, TriangleState&, 
         const Triangle& t,
         const sofa::type::vector< Index > &,

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.h
@@ -229,20 +229,16 @@ public:
     topology::PointData<VecVertexInfo> d_vertexInfo; ///< Internal point data
     topology::EdgeData<VecEdgeInfo> d_edgeInfo; ///< Internal edge data
 
+    void createTriangleInfo(Index triangleIndex, TriangleInfo&, 
+        const Triangle& t,
+        const sofa::type::vector< Index >&,
+        const sofa::type::vector< double >&);
 
-    class TFEMFFOTriangleInfoHandler : public topology::TopologyDataHandler<Triangle,VecTriangleInfo >
-    {
-    public:
-        TFEMFFOTriangleInfoHandler(TriangularFEMForceFieldOptim<DataTypes>* _ff, topology::TriangleData<VecTriangleInfo >* _data) : topology::TopologyDataHandler<Triangle, VecTriangleInfo >(_data), ff(_ff) {}
+    void createTriangleState(Index triangleIndex, TriangleState&, 
+        const Triangle& t,
+        const sofa::type::vector< Index > &,
+        const sofa::type::vector< double > &);
 
-        void applyCreateFunction(Index triangleIndex, TriangleInfo& ,
-                const Triangle & t,
-                const sofa::type::vector< Index > &,
-                const sofa::type::vector< double > &);
-
-    protected:
-        TriangularFEMForceFieldOptim<DataTypes>* ff;
-    };
     void initTriangleInfo(Index triangleIndex, TriangleInfo& ti, const Triangle t, const VecCoord& x0);
     void initTriangleState(Index triangleIndex, TriangleState& ti, const Triangle t, const VecCoord& x);
 
@@ -255,20 +251,6 @@ public:
     {
         computeTriangleRotation(result,x0[t[0]], x0[t[1]], x0[t[2]]);
     }
-
-    class TFEMFFOTriangleStateHandler : public topology::TopologyDataHandler<Triangle,VecTriangleState >
-    {
-    public:
-        TFEMFFOTriangleStateHandler(TriangularFEMForceFieldOptim<DataTypes>* _ff, topology::TriangleData<VecTriangleState >* _data) : topology::TopologyDataHandler<Triangle, VecTriangleState >(_data), ff(_ff) {}
-
-        void applyCreateFunction(Index triangleIndex, TriangleState& ,
-                const Triangle & t,
-                const sofa::type::vector< Index > &,
-                const sofa::type::vector< double > &);
-
-    protected:
-        TriangularFEMForceFieldOptim<DataTypes>* ff;
-    };
 
     template<class MatrixWriter>
     void addKToMatrixT(const core::MechanicalParams* mparams, MatrixWriter m);
@@ -288,10 +270,6 @@ public:
     Data<bool> d_showStressValue;
     Data<bool> d_showStressVector; ///< Flag activating rendering of stress directions within each triangle
     Data<Real> d_showStressMaxValue; ///< Max value for rendering of stress values
-
-
-    TFEMFFOTriangleInfoHandler* triangleInfoHandler;
-    TFEMFFOTriangleStateHandler* triangleStateHandler;
 
     /// Link to be set to the topology container in the component graph. 
     SingleLink<TriangularFEMForceFieldOptim<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.inl
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.inl
@@ -196,13 +196,13 @@ void TriangularFEMForceFieldOptim<DataTypes>::initTriangleState(Index i, Triangl
 template< class DataTypes>
 void TriangularFEMForceFieldOptim<DataTypes>::createTriangleInfo(Index triangleIndex, TriangleInfo& ti, const Triangle& t, const sofa::type::vector<Index>&, const sofa::type::vector<double>&)
 {
-    initTriangleInfo(triangleIndex, ti, t, mstate->read(core::ConstVecCoordId::restPosition())->getValue());
+    initTriangleInfo(triangleIndex, ti, t, this->mstate->read(core::ConstVecCoordId::restPosition())->getValue());
 }
 
 template< class DataTypes>
 void TriangularFEMForceFieldOptim<DataTypes>::createTriangleState(Index triangleIndex, TriangleState& ti, const Triangle& t, const sofa::type::vector<Index>&, const sofa::type::vector<double>&)
 {
-    initTriangleState(triangleIndex, ti, t, mstate->read(core::ConstVecCoordId::position())->getValue());
+    initTriangleState(triangleIndex, ti, t, this->mstate->read(core::ConstVecCoordId::position())->getValue());
 }
 
 // --------------------------------------------------------------------------------------


### PR DESCRIPTION
Remove TopologyHandler instances in FEM and set topology callbacks directly using TopologyData thanks to PR #2375
Update FEM:

- HexahedralFEMForceField
- TetrahedralCorotationalFEMForceField
- TriangularFEMForceFieldOptim


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
