### PR TITLE
[SofaEigen2Solver] Limit display of deprecation message in CMake

### DIFF
--- a/SofaKernel/modules/SofaEigen2Solver/SofaEigen2SolverConfig.cmake.in
+++ b/SofaKernel/modules/SofaEigen2Solver/SofaEigen2SolverConfig.cmake.in
@@ -6,11 +6,12 @@
 find_package(Sofa.Helper QUIET REQUIRED)
 
 get_property(@PROJECT_NAME@_SENT_DEPRECATION_MESSAGE GLOBAL PROPERTY PROPERTY_@PROJECT_NAME@_SENT_DEPRECATION_MESSAGE SET)
-
 if(NOT @PROJECT_NAME@_SENT_DEPRECATION_MESSAGE)
-    message(WARNING "SofaEigen2Solver has been removed, the package still exists for compatibility but is empty.Eigen classes have moved to Sofa.LinearAlgebra and SVDLinearSolver to SofaDenseSolver.")
+    message(WARNING
+        "SofaEigen2Solver has been removed. The package still exists for compatibility but is empty. "
+        "Eigen classes were moved to Sofa.LinearAlgebra and SVDLinearSolver to SofaDenseSolver."
+        )
 endif()
-
 set_property(GLOBAL PROPERTY PROPERTY_@PROJECT_NAME@_SENT_DEPRECATION_MESSAGE TRUE)
 
 if(NOT TARGET @PROJECT_NAME@)

--- a/SofaKernel/modules/SofaEigen2Solver/SofaEigen2SolverConfig.cmake.in
+++ b/SofaKernel/modules/SofaEigen2Solver/SofaEigen2SolverConfig.cmake.in
@@ -5,8 +5,13 @@
 
 find_package(Sofa.Helper QUIET REQUIRED)
 
-message(WARNING "SofaEigen2Solver has been removed, the package still exists for compatibility but is empty\n.
-    Eigen classes have moved to Sofa.LinearAlgebra and SVDLinearSolver to SofaDenseSolver.")
+get_property(@PROJECT_NAME@_SENT_DEPRECATION_MESSAGE GLOBAL PROPERTY PROPERTY_@PROJECT_NAME@_SENT_DEPRECATION_MESSAGE SET)
+
+if(NOT @PROJECT_NAME@_SENT_DEPRECATION_MESSAGE)
+    message(WARNING "SofaEigen2Solver has been removed, the package still exists for compatibility but is empty.Eigen classes have moved to Sofa.LinearAlgebra and SVDLinearSolver to SofaDenseSolver.")
+endif()
+
+set_property(GLOBAL PROPERTY PROPERTY_@PROJECT_NAME@_SENT_DEPRECATION_MESSAGE TRUE)
 
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
Following #2368 

Some projects (mainly tests) are using find_package(SofaBase) which still uses the project SofaEigen2Solver for compatibility purpose. This leads to a few prints in the cmake output about the SofaEigen2Solver being  deprecated.
Of course this is a bit slightly annoying to read the cmake output.

This PR limits the deprecation display to once a cmake configuration pass.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
