### PR TITLE
[SofaGeneralDeformable] Remove TopologyHandler in FEM to use TopologyData callbacks (part 2)

### DIFF
--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/FastTriangularBendingSprings.h
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/FastTriangularBendingSprings.h
@@ -169,43 +169,34 @@ protected:
     /// The list of edge springs, one for each edge between two triangles
     sofa::component::topology::EdgeData<type::vector<EdgeSpring> > d_edgeSprings;
 
-    class TriangularBSEdgeHandler : public topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge, type::vector<EdgeSpring> >
-    {
-    public:
-        typedef typename FastTriangularBendingSprings<DataTypes>::EdgeSpring EdgeSpring;
-        TriangularBSEdgeHandler(FastTriangularBendingSprings<DataTypes>* _ff, sofa::component::topology::EdgeData<sofa::type::vector<EdgeSpring> >* _data)
-            : sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge, sofa::type::vector<EdgeSpring> >(_data), ff(_ff) {}
+    /** Method to initialize @sa EdgeSpring when a new edge is created.
+    * Will be set as creation callback in the EdgeData @sa d_edgeSprings
+    */
+    void applyEdgeCreation(Index edgeIndex,
+        EdgeSpring& ei,
+        const core::topology::BaseMeshTopology::Edge&, const sofa::type::vector< Index >&,
+        const sofa::type::vector< double >&);
 
-        void applyCreateFunction(Index edgeIndex,
-                EdgeSpring &ei,
-                const core::topology::BaseMeshTopology::Edge& ,  const sofa::type::vector< Index > &,
-                const sofa::type::vector< double >&);
+    /** Method to update @sa d_edgeSprings when a new triangle is created.
+    * Will be set as callback in the EdgeData @sa d_edgeSprings when TRIANGLESADDED event is fired
+    * to create a new spring between new created triangles.
+    */
+    void applyTriangleCreation(const sofa::type::vector<Index>& triangleAdded,
+        const sofa::type::vector<core::topology::BaseMeshTopology::Triangle>&,
+        const sofa::type::vector<sofa::type::vector<Index> >&,
+        const sofa::type::vector<sofa::type::vector<double> >&);
 
-        void applyTriangleCreation(const sofa::type::vector<Index> &triangleAdded,
-                const sofa::type::vector<core::topology::BaseMeshTopology::Triangle> & ,
-                const sofa::type::vector<sofa::type::vector<Index> > & ,
-                const sofa::type::vector<sofa::type::vector<double> > &);
+    /** Method to update @sa d_edgeSprings when a triangle is removed.
+    * Will be set as callback in the EdgeData @sa d_edgeSprings when TRIANGLESREMOVED event is fired
+    * to remove spring if needed or update pair of triangles.
+    */
+    void applyTriangleDestruction(const sofa::type::vector<Index>& triangleRemoved);
 
-        void applyTriangleDestruction(const sofa::type::vector<Index> &triangleRemoved);
+    /// Method to update @sa d_edgeSprings when a point is removed. Will be set as callback when POINTSREMOVED event is fired
+    void applyPointDestruction(const sofa::type::vector<Index>& pointIndices);
 
-        void applyPointDestruction(const sofa::type::vector<Index> &pointIndices);
-
-        void applyPointRenumbering(const sofa::type::vector<Index> &pointToRenumber);
-
-        using topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge, type::vector<EdgeSpring> >::ApplyTopologyChange;
-        /// Callback to add triangles elements.
-        void ApplyTopologyChange(const core::topology::TrianglesAdded* /*event*/);
-        /// Callback to remove triangles elements.
-        void ApplyTopologyChange(const core::topology::TrianglesRemoved* /*event*/);
-
-        /// Callback to remove points elements.
-        void ApplyTopologyChange(const core::topology::PointsRemoved* /*event*/);
-        /// Callback to renumbering on points elements.
-        void ApplyTopologyChange(const core::topology::PointsRenumbering* /*event*/);
-
-    protected:
-        FastTriangularBendingSprings<DataTypes>* ff;
-    };
+    /// Method to update @sa d_edgeSprings when points are renumbered. Will be set as callback when POINTSRENUMBERING event is fired
+    void applyPointRenumbering(const sofa::type::vector<Index>& pointToRenumber);
 
     sofa::core::topology::BaseMeshTopology* m_topology;
 
@@ -215,8 +206,6 @@ protected:
     virtual ~FastTriangularBendingSprings();
 
     sofa::component::topology::EdgeData<type::vector<EdgeSpring> > &getEdgeInfo() {return d_edgeSprings;}
-
-    TriangularBSEdgeHandler* d_edgeHandler;
 
     SReal m_potentialEnergy;
 };

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.h
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.h
@@ -97,7 +97,6 @@ public:
     };
 
     sofa::component::topology::EdgeData<type::vector<EdgeInformation> > edgeInfo; ///< Internal Edge data storing @sa EdgeInformation per edge
-    typedef typename topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge, sofa::type::vector<EdgeInformation> > TriangularBSEdgeHandler;
 
 protected:
     TriangularBendingSprings();
@@ -105,7 +104,7 @@ protected:
     virtual ~TriangularBendingSprings();
 
     /** Method to initialize @sa edgeInfo when a new edge is created. (by default everything is set to 0)
-    * Will be used as callback by the TriangularBSEdgeHandler @sa edgeHandler
+    * Will be set as creation callback in the EdgeData @sa edgeInfo
     */
     void applyEdgeCreation(Index edgeIndex,
         EdgeInformation& ei,
@@ -113,7 +112,7 @@ protected:
         const sofa::type::vector< double >&);
 
     /** Method to update @sa edgeInfo when a new triangle is created.
-    * Will be used as callback by the TriangularBSEdgeHandler @sa edgeHandler
+    * Will be set as callback in the EdgeData @sa edgeInfo when TRIANGLESADDED event is fired
     * to create a new spring between new created triangles.
     */
     void applyTriangleCreation(const type::vector<Index>& triangleAdded,
@@ -122,15 +121,15 @@ protected:
         const type::vector<type::vector<double> >&);
 
     /** Method to update @sa edgeInfo when a triangle is removed.
-    * Will be used as callback by the TriangularBSEdgeHandler @sa edgeHandler
+    * Will be set as callback in the EdgeData @sa edgeInfo when TRIANGLESREMOVED event is fired
     * to remove spring if needed or update pair of triangles.
     */
     void applyTriangleDestruction(const type::vector<Index>& triangleRemoved);
 
-    /// Method to update @sa edgeInfo when a point is removed. Will be used as callback by the TriangularBSEdgeHandler @sa edgeHandler
+    /// Method to update @sa edgeInfo when a point is removed. Will be set as callback when POINTSREMOVED event is fired
     void applyPointDestruction(const type::vector<Index>& pointIndices);
 
-    /// Method to update @sa edgeInfo when points are renumbered. Will be used as callback by the TriangularBSEdgeHandler @sa edgeHandler
+    /// Method to update @sa edgeInfo when points are renumbered. Will be set as callback when POINTSRENUMBERING event is fired
     void applyPointRenumbering(const type::vector<Index>& pointToRenumber);
 
 public:
@@ -160,9 +159,6 @@ public:
     sofa::component::topology::EdgeData<type::vector<EdgeInformation> >& getEdgeInfo() { return edgeInfo; }
 
 protected:
-    /// Topology EdgeData handler to manage topological changes on the Topology Data @sa edgeInfo
-    TriangularBSEdgeHandler* edgeHandler;
-    
     /// poential energy accumulate in method @sa addForce
     SReal m_potentialEnergy;
 

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBendingSprings.inl
@@ -289,18 +289,16 @@ TriangularBendingSprings<DataTypes>::TriangularBendingSprings()
     , d_showSprings(initData(&d_showSprings, true, "showSprings", "option to draw springs"))
     , l_topology(initLink("topology", "link to the topology container"))
     , edgeInfo(initData(&edgeInfo, "edgeInfo", "Internal edge data"))
-    , edgeHandler(nullptr)
     , m_potentialEnergy(0.0)
     , m_topology(nullptr)
 {
-    // Create specific handler for EdgeData
-    edgeHandler = new TriangularBSEdgeHandler(&edgeInfo);
+
 }
 
 template<class DataTypes>
 TriangularBendingSprings<DataTypes>::~TriangularBendingSprings()
 {
-    if(edgeHandler) delete edgeHandler;
+
 }
 
 
@@ -335,7 +333,7 @@ void TriangularBendingSprings<DataTypes>::init()
         sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         return;
     }
-    edgeInfo.createTopologyHandler(m_topology,edgeHandler);
+    edgeInfo.createTopologyHandler(m_topology);
     edgeInfo.linkToPointDataArray();
     edgeInfo.linkToTriangleDataArray();
 
@@ -347,23 +345,22 @@ void TriangularBendingSprings<DataTypes>::init()
         applyEdgeCreation(edgeIndex, ei, edge, ancestors, coefs);
     });
 
-
-    edgeHandler->addCallBack(sofa::core::topology::TopologyChangeType::TRIANGLESADDED, [this](const core::topology::TopologyChange* eventTopo) {
+    edgeInfo.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::TRIANGLESADDED, [this](const core::topology::TopologyChange* eventTopo) {
         const core::topology::TrianglesAdded* triAdd = static_cast<const core::topology::TrianglesAdded*>(eventTopo);
         applyTriangleCreation(triAdd->getIndexArray(), triAdd->getElementArray(), triAdd->ancestorsList, triAdd->coefs);
     });
 
-    edgeHandler->addCallBack(sofa::core::topology::TopologyChangeType::TRIANGLESREMOVED, [this](const core::topology::TopologyChange* eventTopo) {
+    edgeInfo.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::TRIANGLESREMOVED, [this](const core::topology::TopologyChange* eventTopo) {
         const core::topology::TrianglesRemoved* triRemove = static_cast<const core::topology::TrianglesRemoved*>(eventTopo);
         applyTriangleDestruction(triRemove->getArray());
     });
 
-    edgeHandler->addCallBack(sofa::core::topology::TopologyChangeType::POINTSREMOVED, [this](const core::topology::TopologyChange* eventTopo) {
+    edgeInfo.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::POINTSREMOVED, [this](const core::topology::TopologyChange* eventTopo) {
         const core::topology::PointsRemoved* pRemove = static_cast<const core::topology::PointsRemoved*>(eventTopo);
         applyPointDestruction(pRemove->getArray());
     });
 
-    edgeHandler->addCallBack(sofa::core::topology::TopologyChangeType::POINTSRENUMBERING, [this](const core::topology::TopologyChange* eventTopo) {
+    edgeInfo.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::POINTSRENUMBERING, [this](const core::topology::TopologyChange* eventTopo) {
         const core::topology::PointsRenumbering* pRenum = static_cast<const core::topology::PointsRenumbering*>(eventTopo);
         applyPointRenumbering(pRenum->getIndexArray());
     });

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularTensorMassForceField.h
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularTensorMassForceField.h
@@ -91,39 +91,28 @@ protected:
 
     sofa::component::topology::EdgeData<sofa::type::vector<EdgeRestInformation> > edgeInfo; ///< Internal edge data
 
-    class TriangularTMEdgeHandler : public topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge,type::vector<EdgeRestInformation> >
-    {
-    public:
-        typedef typename TriangularTensorMassForceField<DataTypes>::EdgeRestInformation EdgeRestInformation;
+    /** Method to initialize @sa EdgeRestInformation when a new edge is created.
+    * Will be set as creation callback in the EdgeData @sa edgeInfo
+    */
+    void applyEdgeCreation(Index edgeIndex, EdgeRestInformation&,
+        const core::topology::BaseMeshTopology::Edge& e,
+        const sofa::type::vector<Index>&,
+        const sofa::type::vector<double>&);
 
-        TriangularTMEdgeHandler(
-            TriangularTensorMassForceField<DataTypes>* ff,
-            sofa::component::topology::EdgeData<sofa::type::vector<EdgeRestInformation> >* data
-        )
-            :sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge,sofa::type::vector<EdgeRestInformation> >(data),ff(ff)
-        {
-        }
+    /** Method to update @sa edgeInfo when a new triangle is created.
+    * Will be set as callback in the EdgeData @sa edgeInfo when TRIANGLESADDED event is fired
+    * to create a new spring between new created triangles.
+    */
+    void applyTriangleCreation(const sofa::type::vector<Index>& triangleAdded,
+        const sofa::type::vector<core::topology::BaseMeshTopology::Triangle>&,
+        const sofa::type::vector<sofa::type::vector<Index> >&,
+        const sofa::type::vector<sofa::type::vector<double> >&);
 
-        void applyCreateFunction(Index edgeIndex, EdgeRestInformation&,
-                const core::topology::BaseMeshTopology::Edge& e,
-                const sofa::type::vector<Index> &,
-                const sofa::type::vector<double> &);
-
-        void applyTriangleCreation(const sofa::type::vector<Index> &triangleAdded,
-                const sofa::type::vector<core::topology::BaseMeshTopology::Triangle> & ,
-                const sofa::type::vector<sofa::type::vector<Index> > & ,
-                const sofa::type::vector<sofa::type::vector<double> > &);
-
-        void applyTriangleDestruction(const sofa::type::vector<Index> &triangleRemoved);
-
-        using topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge,type::vector<EdgeRestInformation> >::ApplyTopologyChange;
-        /// Callback to add triangles elements.
-        void ApplyTopologyChange(const core::topology::TrianglesAdded* /*event*/);
-        /// Callback to remove triangles elements.
-        void ApplyTopologyChange(const core::topology::TrianglesRemoved* /*event*/);
-    protected:
-        TriangularTensorMassForceField<DataTypes>* ff;
-    };
+    /** Method to update @sa edgeInfo when a triangle is removed.
+    * Will be set as callback in the EdgeData @sa edgeInfo when TRIANGLESREMOVED event is fired
+    * to remove spring if needed or update pair of triangles.
+    */
+    void applyTriangleDestruction(const sofa::type::vector<Index>& triangleRemoved);
 
     
     VecCoord  _initialPoints;///< the intial positions of the points
@@ -139,9 +128,6 @@ protected:
 
     Real lambda;  /// first Lame coefficient
     Real mu;    /// second Lame coefficient
-
-    TriangularTMEdgeHandler* edgeHandler;
-
 
     TriangularTensorMassForceField();
 


### PR DESCRIPTION
Remove TopologyHandler instances in FEM and set topology callbacks directly using TopologyData thanks to PR #2375 
Update FEM:
- FastTriangularBendingSprings
- TriangularBendingSprings
- TriangularTensorMassForceField






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
