### PR TITLE
[SofaGeneralDeformable] Remove TopologyHandler in FEM to use TopologyData callbacks (part 3)

### DIFF
--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/QuadularBendingSprings.h
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/QuadularBendingSprings.h
@@ -138,49 +138,35 @@ public:
 
     sofa::component::topology::EdgeData<sofa::type::vector<EdgeInformation> > &getEdgeInfo() {return edgeInfo;}
 
+    /** Method to initialize @sa EdgeInformation when a new edge is created.
+    * Will be set as creation callback in the EdgeData @sa edgeInfo
+    */
+    void applyEdgeCreation(Index edgeIndex, EdgeInformation& ei,
+        const core::topology::BaseMeshTopology::Edge&,
+        const sofa::type::vector< Index >&,
+        const sofa::type::vector< double >&);
 
-    class EdgeBSHandler : public topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge, type::vector<EdgeInformation> >
-    {
-    public:
-        typedef typename QuadularBendingSprings<DataTypes>::EdgeInformation EdgeInformation;
+    /** Method to update @sa edgeInfo when a new quad is created.
+    * Will be set as callback in the EdgeData @sa edgeInfo when QUADSADDED event is fired
+    * to create a new spring between new created triangles.
+    */
+    void applyQuadCreation(const sofa::type::vector<Index>& quadAdded,
+        const sofa::type::vector<core::topology::BaseMeshTopology::Quad>&,
+        const sofa::type::vector<sofa::type::vector<Index> >&,
+        const sofa::type::vector<sofa::type::vector<double> >&);
 
-        EdgeBSHandler(QuadularBendingSprings<DataTypes>* ff, topology::EdgeData<sofa::type::vector<EdgeInformation> >* data )
-            :topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge, sofa::type::vector<EdgeInformation> >(data)
-            ,ff(ff)
-        {
-        }
+    /** Method to update @sa edgeInfo when a quad is removed.
+    * Will be set as callback in the EdgeData @sa edgeInfo when QUADSREMOVED event is fired
+    * to remove spring if needed or update pair of quad.
+    */
+    void applyQuadDestruction(const sofa::type::vector<Index>& quadRemoved);
 
-        void applyCreateFunction(Index edgeIndex, EdgeInformation& ei,
-                const core::topology::BaseMeshTopology::Edge &,
-                const sofa::type::vector< Index > &,
-                const sofa::type::vector< double > &);
+    /// Method to update @sa edgeInfo when a point is removed. Will be set as callback when POINTSREMOVED event is fired
+    void applyPointDestruction(const sofa::type::vector<Index>& pointIndices);
 
-        void applyQuadCreation(const sofa::type::vector<Index> & quadAdded,
-                const sofa::type::vector<core::topology::BaseMeshTopology::Quad> &,
-                const sofa::type::vector<sofa::type::vector<Index> > &,
-                const sofa::type::vector<sofa::type::vector<double> > &);
+    /// Method to update @sa edgeInfo when points are renumbered. Will be set as callback when POINTSRENUMBERING event is fired
+    void applyPointRenumbering(const sofa::type::vector<Index>& pointToRenumber);
 
-        void applyQuadDestruction(const sofa::type::vector<Index> & quadRemoved);
-
-        using topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge, type::vector<EdgeInformation> >::ApplyTopologyChange;
-
-        /// Callback to add quads elements.
-        void ApplyTopologyChange(const core::topology::QuadsAdded* /*event*/);
-        /// Callback to remove quads elements.
-        void ApplyTopologyChange(const core::topology::QuadsRemoved* /*event*/);
-
-        void applyPointDestruction(const sofa::type::vector<Index> &pointIndices);
-
-        void applyPointRenumbering(const sofa::type::vector<Index> &pointToRenumber);
-
-        /// Callback to remove points elements.
-        void ApplyTopologyChange(const core::topology::PointsRemoved* /*event*/);
-        /// Callback to renumbering on points elements.
-        void ApplyTopologyChange(const core::topology::PointsRenumbering* /*event*/);
-
-    protected:
-        QuadularBendingSprings<DataTypes>* ff;
-    };
 
     Data<double> f_ks; ///< uniform stiffness for the all springs
     Data<double> f_kd; ///< uniform damping for the all springs
@@ -193,9 +179,6 @@ protected:
 
     /// Pointer to the current topology
     sofa::core::topology::BaseMeshTopology* m_topology;
-
-    /// Handler for subset Data
-    EdgeBSHandler* edgeHandler;
 
     bool updateMatrix;
     SReal m_potentialEnergy;

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.h
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.h
@@ -177,59 +177,36 @@ public:
     /// compute lambda and mu based on the Young modulus and Poisson ratio
     void updateLameCoefficients();
 
-    class TRBSEdgeHandler : public sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge, sofa::type::vector<EdgeRestInformation> >
-    {
-    public:
-        typedef typename TriangularBiquadraticSpringsForceField<DataTypes>::EdgeRestInformation EdgeRestInformation;
+    /** Method to initialize @sa EdgeRestInformation when a new edge is created.
+    * Will be set as creation callback in the EdgeData @sa edgeInfo
+    */
+    void applyEdgeCreation(Index edgeIndex,
+        EdgeRestInformation& ei,
+        const core::topology::BaseMeshTopology::Edge& edge, 
+        const sofa::type::vector< Index >& ancestors,
+        const sofa::type::vector< double >& coefs);
 
-        TRBSEdgeHandler(TriangularBiquadraticSpringsForceField<DataTypes>* ff,
-                sofa::component::topology::EdgeData<sofa::type::vector<EdgeRestInformation> >* data)
-            :sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge, sofa::type::vector<EdgeRestInformation> >(data)
-            ,ff(ff)
-        {
-        }
-        void applyCreateFunction(Index, EdgeRestInformation &t, const core::topology::BaseMeshTopology::Edge &,
-                const sofa::type::vector<Index> &, const sofa::type::vector<double> &);
+    /** Method to initialize @sa TriangleRestInformation when a new triangle is created.
+    * Will be set as creation callback in the TriangleData @sa triangleInfo
+    */
+    void applyTriangleCreation(Index triangleIndex, TriangleRestInformation& tinfo,
+        const core::topology::BaseMeshTopology::Triangle& triangle,
+        const sofa::type::vector<Index>& ancestors,
+        const sofa::type::vector<double>& coefs);
 
-    protected:
-        TriangularBiquadraticSpringsForceField<DataTypes>* ff;
-    };
-
-    class TRBSTriangleHandler : public sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Triangle,sofa::type::vector<TriangleRestInformation> >
-    {
-    public:
-        typedef typename TriangularBiquadraticSpringsForceField<DataTypes>::TriangleRestInformation TriangleRestInformation;
-
-        TRBSTriangleHandler(TriangularBiquadraticSpringsForceField<DataTypes>* ff,
-                sofa::component::topology::TriangleData<sofa::type::vector<TriangleRestInformation> >* data)
-            :sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Triangle,sofa::type::vector<TriangleRestInformation> >(data)
-            ,ff(ff)
-        {
-        }
-
-        void applyCreateFunction(Index, TriangleRestInformation &t,
-                const core::topology::BaseMeshTopology::Triangle &,
-                const sofa::type::vector<Index> &,
-                const sofa::type::vector<double> &);
-        void applyDestroyFunction(Index, TriangleRestInformation &);
-
-
-    protected:
-        TriangularBiquadraticSpringsForceField<DataTypes>* ff;
-    };
+    /** Method to update @sa triangleInfo when a triangle is removed.
+    * Will be set as destruction callback in the TriangleData @sa triangleInfo
+    */
+    void applyTriangleDestruction(Index triangleIndex, TriangleRestInformation& tinfo);
 
     /// Link to be set to the topology container in the component graph.
     SingleLink<TriangularBiquadraticSpringsForceField<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
 protected :
-    TRBSEdgeHandler* edgeHandler;
-    TRBSTriangleHandler* triangleHandler;
-
     /// Pointer to the current topology
     sofa::core::topology::BaseMeshTopology* m_topology;
 
     sofa::component::topology::EdgeData<type::vector<EdgeRestInformation> > &getEdgeInfo() {return edgeInfo;}
-
 };
 
 

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.h
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.h
@@ -168,48 +168,33 @@ public:
     /// compute lambda and mu based on the Young modulus and Poisson ratio
     void updateLameCoefficients();
 
+    /** Method to initialize @sa EdgeRestInformation when a new edge is created.
+    * Will be set as creation callback in the EdgeData @sa edgeInfo
+    */
+    void applyEdgeCreation(Index edgeIndex,
+        EdgeRestInformation& ei,
+        const core::topology::BaseMeshTopology::Edge& edge,
+        const sofa::type::vector< Index >& ancestors,
+        const sofa::type::vector< double >& coefs);
 
-    class TRQSTriangleHandler : public sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Triangle,type::vector<TriangleRestInformation> >
-    {
-    public:
-        typedef typename TriangularQuadraticSpringsForceField<DataTypes>::TriangleRestInformation TriangleRestInformation;
-        TRQSTriangleHandler(TriangularQuadraticSpringsForceField<DataTypes>* _ff, sofa::component::topology::TriangleData<sofa::type::vector<TriangleRestInformation> >* _data) : sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Triangle, sofa::type::vector<TriangleRestInformation> >(_data), ff(_ff) {}
+    /** Method to initialize @sa TriangleRestInformation when a new triangle is created.
+    * Will be set as creation callback in the TriangleData @sa triangleInfo
+    */
+    void applyTriangleCreation(Index triangleIndex, TriangleRestInformation& tinfo,
+        const core::topology::BaseMeshTopology::Triangle& triangle,
+        const sofa::type::vector<Index>& ancestors,
+        const sofa::type::vector<double>& coefs);
 
-        void applyCreateFunction(Index triangleIndex, TriangleRestInformation& ,
-                const core::topology::BaseMeshTopology::Triangle & t,
-                const sofa::type::vector< Index > &,
-                const sofa::type::vector< double > &);
-
-        void applyDestroyFunction(Index, TriangleRestInformation &);
-
-    protected:
-        TriangularQuadraticSpringsForceField<DataTypes>* ff;
-    };
-
-    class TRQSEdgeHandler : public sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge,type::vector<EdgeRestInformation> >
-    {
-    public:
-        typedef typename TriangularQuadraticSpringsForceField<DataTypes>::EdgeRestInformation EdgeRestInformation;
-        TRQSEdgeHandler(TriangularQuadraticSpringsForceField<DataTypes>* _ff, sofa::component::topology::EdgeData<sofa::type::vector<EdgeRestInformation> >* _data) : sofa::component::topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge, sofa::type::vector<EdgeRestInformation> >(_data), ff(_ff) {}
-
-        void applyCreateFunction(Index edgeIndex, EdgeRestInformation& ,
-                const core::topology::BaseMeshTopology::Edge & t,
-                const sofa::type::vector< Index > &,
-                const sofa::type::vector< double > &);
-
-    protected:
-        TriangularQuadraticSpringsForceField<DataTypes>* ff;
-    };
-
+    /** Method to update @sa triangleInfo when a triangle is removed.
+    * Will be set as destruction callback in the TriangleData @sa triangleInfo
+    */
+    void applyTriangleDestruction(Index triangleIndex, TriangleRestInformation& tinfo);
 
 protected :
     sofa::component::topology::TriangleData<sofa::type::vector<TriangleRestInformation> > triangleInfo; ///< Internal triangle data
     sofa::component::topology::EdgeData<sofa::type::vector<EdgeRestInformation> > edgeInfo; ///< Internal edge data
 
     sofa::component::topology::EdgeData<sofa::type::vector<EdgeRestInformation> > &getEdgeInfo() {return edgeInfo;}
-
-    TRQSTriangleHandler* triangleHandler;
-    TRQSEdgeHandler* edgeHandler;
 
     /// Pointer to the current topology
     sofa::core::topology::BaseMeshTopology* m_topology;

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/VectorSpringForceField.h
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/VectorSpringForceField.h
@@ -100,24 +100,6 @@ public:
     /// where the springs information are stored
     sofa::component::topology::EdgeData<sofa::type::vector<Spring> > springArray;
 
-    class EdgeDataHandler : public sofa::component::topology::TopologyDataHandler< core::topology::BaseMeshTopology::Edge, sofa::type::vector<Spring> >
-    {
-    public:
-        typedef typename VectorSpringForceField<DataTypes>::Spring Spring;
-        EdgeDataHandler(VectorSpringForceField<DataTypes>* ff, topology::EdgeData<sofa::type::vector<Spring> >* data)
-            :topology::TopologyDataHandler< core::topology::BaseMeshTopology::Edge,sofa::type::vector<Spring> >(data)
-            ,ff(ff)
-        {
-
-        }
-
-        void applyCreateFunction(Index, Spring &t,
-                const core::topology::BaseMeshTopology::Edge &,
-                const sofa::type::vector<Index> &, const sofa::type::vector<double> &);
-    protected:
-        VectorSpringForceField<DataTypes>* ff;
-
-    };
     /// the filename where to load the spring information
     sofa::core::objectmodel::DataFileName m_filename;
     /// By default, assume that all edges have the same stiffness
@@ -143,7 +125,13 @@ protected:
     VectorSpringForceField(MechanicalState* _object1, MechanicalState* _object2);
     virtual ~VectorSpringForceField() override;
 
-    EdgeDataHandler* edgeHandler;
+    /** Method to initialize @sa Spring when a new edge is created.
+    * Will be set as creation callback in the EdgeData @sa springArray
+    */
+    void createEdgeInformation(Index, Spring& t,
+        const core::topology::BaseMeshTopology::Edge& e,
+        const sofa::type::vector<Index>& ancestors,
+        const sofa::type::vector<double>& coefs);
 
 public:
     bool load(const char *filename);


### PR DESCRIPTION
Remove TopologyHandler instances in FEM and set topology callbacks directly using TopologyData thanks to PR #2375
Update FEM:

- QuadularBendingSprings
- TriangularBiquadraticSpringsForceField
- TriangularQuadraticSpringsForceField
- VectorSpringForceField



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
