### PR TITLE
[SofaMiscFem] Remove TopologyHandler in FEM to use TopologyData callbacks (part 4)

### DIFF
--- a/modules/SofaMiscFem/src/SofaMiscFem/FastTetrahedralCorotationalForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/FastTetrahedralCorotationalForceField.h
@@ -109,6 +109,9 @@ protected:
     topology::EdgeData<sofa::type::vector<Mat3x3> > edgeInfo; ///< Internal edge data
     topology::TetrahedronData<sofa::type::vector<TetrahedronRestInformation> > tetrahedronInfo; ///< Internal tetrahedron data
 
+    /** Method to initialize @sa TetrahedronRestInformation when a new Tetrahedron is created.
+    * Will be set as creation callback in the TetrahedronData @sa tetrahedronInfo
+    */
     void createTetrahedronRestInformation(Index, TetrahedronRestInformation& t,
         const core::topology::BaseMeshTopology::Tetrahedron&,
         const sofa::type::vector<Index>&,

--- a/modules/SofaMiscFem/src/SofaMiscFem/FastTetrahedralCorotationalForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/FastTetrahedralCorotationalForceField.h
@@ -105,35 +105,14 @@ protected:
         }
     };
 
-    class FTCFTetrahedronHandler : public topology::TopologyDataHandler<core::topology::BaseMeshTopology::Tetrahedron, sofa::type::vector<TetrahedronRestInformation> >
-    {
-    public:
-        typedef typename FastTetrahedralCorotationalForceField<DataTypes>::TetrahedronRestInformation TetrahedronRestInformation;
-
-        using Index = sofa::Index;
-
-        FTCFTetrahedronHandler(FastTetrahedralCorotationalForceField<DataTypes>* ff,
-                topology::TetrahedronData<sofa::type::vector<TetrahedronRestInformation> >* data )
-            :topology::TopologyDataHandler<core::topology::BaseMeshTopology::Tetrahedron, sofa::type::vector<TetrahedronRestInformation> >(data)
-            ,ff(ff)
-        {
-
-        }
-
-        void applyCreateFunction(Index, TetrahedronRestInformation &t,
-                                 const core::topology::BaseMeshTopology::Tetrahedron&,
-                                 const sofa::type::vector<Index> &,
-                                 const sofa::type::vector<double> &);
-
-    protected:
-        FastTetrahedralCorotationalForceField<DataTypes>* ff;
-
-    };
-
     topology::PointData<sofa::type::vector<Mat3x3> > pointInfo; ///< Internal point data
     topology::EdgeData<sofa::type::vector<Mat3x3> > edgeInfo; ///< Internal edge data
     topology::TetrahedronData<sofa::type::vector<TetrahedronRestInformation> > tetrahedronInfo; ///< Internal tetrahedron data
 
+    void createTetrahedronRestInformation(Index, TetrahedronRestInformation& t,
+        const core::topology::BaseMeshTopology::Tetrahedron&,
+        const sofa::type::vector<Index>&,
+        const sofa::type::vector<double>&);
 
     sofa::core::topology::BaseMeshTopology* m_topology;
     VecCoord  _initialPoints;///< the intial positions of the points
@@ -203,8 +182,6 @@ public:
 
 
 protected :
-    FTCFTetrahedronHandler* tetrahedronHandler;
-
     static void computeQRRotation( Mat3x3 &r, const Coord *dp);
 
     topology::EdgeData<sofa::type::vector<Mat3x3> > &getEdgeInfo() {return edgeInfo;}

--- a/modules/SofaMiscFem/src/SofaMiscFem/FastTetrahedralCorotationalForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/FastTetrahedralCorotationalForceField.inl
@@ -42,14 +42,14 @@ void FastTetrahedralCorotationalForceField<DataTypes>::createTetrahedronRestInfo
         const sofa::type::vector<Index> &,
         const sofa::type::vector<double> &)
 {
-    const std::vector< Tetrahedron > &tetrahedronArray=m_topology->getTetrahedra() ;
+    const std::vector< Tetrahedron > &tetrahedronArray=this->m_topology->getTetrahedra() ;
     //		const std::vector< Edge> &edgeArray=m_topology->getEdges() ;
     unsigned int j,k,l,m,n;
     typename DataTypes::Real lambda=getLambda();
     typename DataTypes::Real mu=getMu();
     typename DataTypes::Real volume,val;
     typename DataTypes::Coord point[4]; //shapeVector[4];
-    const typename DataTypes::VecCoord restPosition=mstate->read(core::ConstVecCoordId::restPosition())->getValue();
+    const typename DataTypes::VecCoord restPosition=this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
 
     ///describe the indices of the 4 tetrahedron vertices
     const Tetrahedron &t= tetrahedronArray[tetrahedronIndex];
@@ -99,7 +99,7 @@ void FastTetrahedralCorotationalForceField<DataTypes>::createTetrahedronRestInfo
     /// compute the edge stiffness of the linear elastic material
     for(j=0; j<6; ++j)
     {
-        core::topology::BaseMeshTopology::Edge e=m_topology->getLocalEdgesInTetrahedron(j);
+        core::topology::BaseMeshTopology::Edge e=this->m_topology->getLocalEdgesInTetrahedron(j);
         k=e[0];
         l=e[1];
 

--- a/modules/SofaMiscFem/src/SofaMiscFem/FastTetrahedralCorotationalForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/FastTetrahedralCorotationalForceField.inl
@@ -36,104 +36,101 @@ namespace sofa::component::forcefield
 using sofa::core::topology::edgesInTetrahedronArray;
 
 template< class DataTypes>
-void FastTetrahedralCorotationalForceField<DataTypes>::FTCFTetrahedronHandler::applyCreateFunction(Index tetrahedronIndex,
+void FastTetrahedralCorotationalForceField<DataTypes>::createTetrahedronRestInformation(Index tetrahedronIndex,
         TetrahedronRestInformation &my_tinfo,
         const core::topology::BaseMeshTopology::Tetrahedron &,
         const sofa::type::vector<Index> &,
         const sofa::type::vector<double> &)
 {
-    if (ff)
+    const std::vector< Tetrahedron > &tetrahedronArray=m_topology->getTetrahedra() ;
+    //		const std::vector< Edge> &edgeArray=m_topology->getEdges() ;
+    unsigned int j,k,l,m,n;
+    typename DataTypes::Real lambda=getLambda();
+    typename DataTypes::Real mu=getMu();
+    typename DataTypes::Real volume,val;
+    typename DataTypes::Coord point[4]; //shapeVector[4];
+    const typename DataTypes::VecCoord restPosition=mstate->read(core::ConstVecCoordId::restPosition())->getValue();
+
+    ///describe the indices of the 4 tetrahedron vertices
+    const Tetrahedron &t= tetrahedronArray[tetrahedronIndex];
+//    BaseMeshTopology::EdgesInTetrahedron te=m_topology->getEdgesInTetrahedron(tetrahedronIndex);
+
+
+    // store the point position
+    for(j=0; j<4; ++j)
+        point[j]=(restPosition)[t[j]];
+    /// compute 6 times the rest volume
+    volume=dot(cross(point[1]-point[0],point[2]-point[0]),point[0]-point[3]);
+    /// store the rest volume
+    my_tinfo.restVolume=volume/6;
+    mu*=fabs(volume)/6;
+    lambda*=fabs(volume)/6;
+
+    // store shape vectors at the rest configuration
+    for(j=0; j<4; ++j)
     {
-        const std::vector< Tetrahedron > &tetrahedronArray=ff->m_topology->getTetrahedra() ;
-        //		const std::vector< Edge> &edgeArray=ff->m_topology->getEdges() ;
-        unsigned int j,k,l,m,n;
-        typename DataTypes::Real lambda=ff->getLambda();
-        typename DataTypes::Real mu=ff->getMu();
-        typename DataTypes::Real volume,val;
-        typename DataTypes::Coord point[4]; //shapeVector[4];
-        const typename DataTypes::VecCoord restPosition=ff->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
+        if ((j%2)==0)
+            my_tinfo.shapeVector[j]=cross(point[(j+2)%4] - point[(j+1)%4],point[(j+3)%4] - point[(j+1)%4])/volume;
+        else
+            my_tinfo.shapeVector[j]= -cross(point[(j+2)%4] - point[(j+1)%4],point[(j+3)%4] - point[(j+1)%4])/volume;
+    }
 
-        ///describe the indices of the 4 tetrahedron vertices
-        const Tetrahedron &t= tetrahedronArray[tetrahedronIndex];
-//    BaseMeshTopology::EdgesInTetrahedron te=ff->m_topology->getEdgesInTetrahedron(tetrahedronIndex);
-
-
-        // store the point position
-        for(j=0; j<4; ++j)
-            point[j]=(restPosition)[t[j]];
-        /// compute 6 times the rest volume
-        volume=dot(cross(point[1]-point[0],point[2]-point[0]),point[0]-point[3]);
-        /// store the rest volume
-        my_tinfo.restVolume=volume/6;
-        mu*=fabs(volume)/6;
-        lambda*=fabs(volume)/6;
-
-        // store shape vectors at the rest configuration
-        for(j=0; j<4; ++j)
+    /// compute the vertex stiffness of the linear elastic material, needed for addKToMatrix
+    for(j=0; j<4; ++j)
+    {
+        // the linear stiffness matrix using shape vectors and Lame coefficients
+        val=mu*dot(my_tinfo.shapeVector[j],my_tinfo.shapeVector[j]);
+        for(m=0; m<3; ++m)
         {
-            if ((j%2)==0)
-                my_tinfo.shapeVector[j]=cross(point[(j+2)%4] - point[(j+1)%4],point[(j+3)%4] - point[(j+1)%4])/volume;
-            else
-                my_tinfo.shapeVector[j]= -cross(point[(j+2)%4] - point[(j+1)%4],point[(j+3)%4] - point[(j+1)%4])/volume;
-        }
-
-        /// compute the vertex stiffness of the linear elastic material, needed for addKToMatrix
-        for(j=0; j<4; ++j)
-        {
-            // the linear stiffness matrix using shape vectors and Lame coefficients
-            val=mu*dot(my_tinfo.shapeVector[j],my_tinfo.shapeVector[j]);
-            for(m=0; m<3; ++m)
+            for(n=m; n<3; ++n)
             {
-                for(n=m; n<3; ++n)
-                {
-                    my_tinfo.linearDfDxDiag[j][m][n]=lambda*my_tinfo.shapeVector[j][n]*my_tinfo.shapeVector[j][m]+
-                            mu*my_tinfo.shapeVector[j][n]*my_tinfo.shapeVector[j][m];
+                my_tinfo.linearDfDxDiag[j][m][n]=lambda*my_tinfo.shapeVector[j][n]*my_tinfo.shapeVector[j][m]+
+                        mu*my_tinfo.shapeVector[j][n]*my_tinfo.shapeVector[j][m];
 
-                    if (m==n)
-                    {
-                        my_tinfo.linearDfDxDiag[j][m][m]+=Real(val);
-                    } else
-                        my_tinfo.linearDfDxDiag[j][n][m]=my_tinfo.linearDfDxDiag[j][m][n];
+                if (m==n)
+                {
+                    my_tinfo.linearDfDxDiag[j][m][m]+=Real(val);
+                } else
+                    my_tinfo.linearDfDxDiag[j][n][m]=my_tinfo.linearDfDxDiag[j][m][n];
+            }
+        }
+    }
+
+    /// compute the edge stiffness of the linear elastic material
+    for(j=0; j<6; ++j)
+    {
+        core::topology::BaseMeshTopology::Edge e=m_topology->getLocalEdgesInTetrahedron(j);
+        k=e[0];
+        l=e[1];
+
+        // store the rest edge vector
+        my_tinfo.restEdgeVector[j]=point[l]-point[k];
+
+        // the linear stiffness matrix using shape vectors and Lame coefficients
+        val=mu*dot(my_tinfo.shapeVector[l],my_tinfo.shapeVector[k]);
+        for(m=0; m<3; ++m)
+        {
+            for(n=0; n<3; ++n)
+            {
+                my_tinfo.linearDfDx[j][m][n]=lambda*my_tinfo.shapeVector[k][n]*my_tinfo.shapeVector[l][m]+
+                        mu*my_tinfo.shapeVector[l][n]*my_tinfo.shapeVector[k][m];
+
+                if (m==n)
+                {
+                    my_tinfo.linearDfDx[j][m][m]+=Real(val);
                 }
             }
         }
-
-        /// compute the edge stiffness of the linear elastic material
-        for(j=0; j<6; ++j)
-        {
-            core::topology::BaseMeshTopology::Edge e=ff->m_topology->getLocalEdgesInTetrahedron(j);
-            k=e[0];
-            l=e[1];
-
-            // store the rest edge vector
-            my_tinfo.restEdgeVector[j]=point[l]-point[k];
-
-            // the linear stiffness matrix using shape vectors and Lame coefficients
-            val=mu*dot(my_tinfo.shapeVector[l],my_tinfo.shapeVector[k]);
-            for(m=0; m<3; ++m)
-            {
-                for(n=0; n<3; ++n)
-                {
-                    my_tinfo.linearDfDx[j][m][n]=lambda*my_tinfo.shapeVector[k][n]*my_tinfo.shapeVector[l][m]+
-                            mu*my_tinfo.shapeVector[l][n]*my_tinfo.shapeVector[k][m];
-
-                    if (m==n)
-                    {
-                        my_tinfo.linearDfDx[j][m][m]+=Real(val);
-                    }
-                }
-            }
-        }
-        if (ff->decompositionMethod==QR_DECOMPOSITION) {
-            // compute the rotation matrix of the initial tetrahedron for the QR decomposition
-            computeQRRotation(my_tinfo.restRotation,my_tinfo.restEdgeVector);
-        } else 	if (ff->decompositionMethod==POLAR_DECOMPOSITION_MODIFIED) {
-            Mat3x3 Transformation;
-            Transformation[0]=point[1]-point[0];
-            Transformation[1]=point[2]-point[0];
-            Transformation[2]=point[3]-point[0];
-            helper::Decompose<Real>::polarDecomposition( Transformation, my_tinfo.restRotation );
-        }
+    }
+    if (decompositionMethod==QR_DECOMPOSITION) {
+        // compute the rotation matrix of the initial tetrahedron for the QR decomposition
+        computeQRRotation(my_tinfo.restRotation,my_tinfo.restEdgeVector);
+    } else 	if (decompositionMethod==POLAR_DECOMPOSITION_MODIFIED) {
+        Mat3x3 Transformation;
+        Transformation[0]=point[1]-point[0];
+        Transformation[1]=point[2]-point[0];
+        Transformation[2]=point[3]-point[0];
+        helper::Decompose<Real>::polarDecomposition( Transformation, my_tinfo.restRotation );
     }
 }
 
@@ -155,14 +152,13 @@ template <class DataTypes> FastTetrahedralCorotationalForceField<DataTypes>::Fas
     , drawColor3(initData(&drawColor3, sofa::type::RGBAColor(0.0f, 1.0f, 1.0f, 1.0f), "drawColor3", " draw color for faces 3"))
     , drawColor4(initData(&drawColor4, sofa::type::RGBAColor(0.5f, 1.0f, 1.0f, 1.0f), "drawColor4", " draw color for faces 4"))
     , l_topology(initLink("topology", "link to the topology container"))
-    , tetrahedronHandler(nullptr)        
 {
-    tetrahedronHandler = new FTCFTetrahedronHandler(this,&tetrahedronInfo);
+
 }
 
 template <class DataTypes> FastTetrahedralCorotationalForceField<DataTypes>::~FastTetrahedralCorotationalForceField()
 {
-    if (tetrahedronHandler) delete tetrahedronHandler;
+
 }
 
 template <class DataTypes> void FastTetrahedralCorotationalForceField<DataTypes>::init()
@@ -234,12 +230,19 @@ template <class DataTypes> void FastTetrahedralCorotationalForceField<DataTypes>
     /// initialize the data structure associated with each tetrahedron
     for (Index i=0; i<m_topology->getNbTetrahedra(); ++i)
     {
-        tetrahedronHandler->applyCreateFunction(i,tetrahedronInf[i],m_topology->getTetrahedron(i),
+        createTetrahedronRestInformation(i,tetrahedronInf[i],m_topology->getTetrahedron(i),
                 (const type::vector< Index > )0,
                 (const type::vector< double >)0);
     }
     /// set the call back function upon creation of a tetrahedron
-    tetrahedronInfo.createTopologyHandler(m_topology,tetrahedronHandler);
+    tetrahedronInfo.createTopologyHandler(m_topology);
+    tetrahedronInfo.setCreationCallback([this](Index tetrahedronIndex, TetrahedronRestInformation& tetraInfo,
+        const core::topology::BaseMeshTopology::Tetrahedron& tetra,
+        const sofa::type::vector< Index >& ancestors,
+        const sofa::type::vector< double >& coefs)
+    {
+        createTetrahedronRestInformation(tetrahedronIndex, tetraInfo, tetra, ancestors, coefs);
+    });
     tetrahedronInfo.endEdit();
 
     updateTopologyInfo=true;

--- a/modules/SofaMiscFem/src/SofaMiscFem/QuadBendingFEMForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/QuadBendingFEMForceField.h
@@ -170,6 +170,9 @@ public:
     topology::PointData<sofa::type::vector<VertexInformation> > vertexInfo; ///< Internal point data
     topology::EdgeData<sofa::type::vector<EdgeInformation> > edgeInfo; ///< Internal edge data
 
+    /** Method to initialize @sa QuadInformation when a new Quad is created.
+    * Will be set as creation callback in the QuadData @sa quadInfo
+    */
     void createQuadInformation(unsigned int quadIndex, QuadInformation&,
         const core::topology::BaseMeshTopology::Quad& t,
         const sofa::type::vector< unsigned int >&,

--- a/modules/SofaMiscFem/src/SofaMiscFem/QuadBendingFEMForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/QuadBendingFEMForceField.h
@@ -170,19 +170,10 @@ public:
     topology::PointData<sofa::type::vector<VertexInformation> > vertexInfo; ///< Internal point data
     topology::EdgeData<sofa::type::vector<EdgeInformation> > edgeInfo; ///< Internal edge data
 
-    class QuadHandler : public topology::TopologyDataHandler<core::topology::BaseMeshTopology::Quad,type::vector<QuadInformation> >
-    {
-    public:
-        QuadHandler(QuadBendingFEMForceField<DataTypes>* _ff, topology::QuadData<sofa::type::vector<QuadInformation> >* _data) : 
-        topology::TopologyDataHandler<core::topology::BaseMeshTopology::Quad, sofa::type::vector<QuadInformation> >(_data), ff(_ff) {}
-
-        void applyCreateFunction(unsigned int quadIndex, QuadInformation& ,
-                const core::topology::BaseMeshTopology::Quad & t,
-                const sofa::type::vector< unsigned int > &,
-                const sofa::type::vector< double > &);
-    protected:
-        QuadBendingFEMForceField<DataTypes>* ff;
-    };
+    void createQuadInformation(unsigned int quadIndex, QuadInformation&,
+        const core::topology::BaseMeshTopology::Quad& t,
+        const sofa::type::vector< unsigned int >&,
+        const sofa::type::vector< double >&);
 
     sofa::core::topology::BaseMeshTopology* m_topology;
     
@@ -229,7 +220,6 @@ public:
     Data<type::vector<Real> > f_poisson; ///< Poisson ratio in Hooke's law (vector)
     Data<type::vector<Real> > f_young; ///< Young modulus in Hooke's law (vector)
     Data<Real> f_thickness;
-    QuadHandler* quadHandler;
 
     /// Link to be set to the topology container in the component graph.
     SingleLink<QuadBendingFEMForceField<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;

--- a/modules/SofaMiscFem/src/SofaMiscFem/QuadBendingFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/QuadBendingFEMForceField.inl
@@ -61,33 +61,6 @@ namespace sofa::component::forcefield
 
 using namespace sofa::core::topology;
 
-// --------------------------------------------------------------------------------------
-// ---  Topology Creation/Destruction functions
-// --------------------------------------------------------------------------------------
-
-template< class DataTypes>
-void QuadBendingFEMForceField<DataTypes>::QuadHandler::applyCreateFunction(unsigned int quadIndex, QuadInformation &, 
-                                                                           const core::topology::BaseMeshTopology::Quad &t, 
-                                                                           const sofa::type::vector<unsigned int> &, 
-                                                                           const sofa::type::vector<double> &)
-{
-    if (ff)
-    {
-        Index idx0 = t[0];
-        Index idx1 = t[1];
-        Index idx2 = t[2];
-        Index idx3 = t[3];
-        switch(ff->method)
-        {
-        case SMALL :
-            ff->initSmall(quadIndex,idx0,idx1,idx2,idx3);
-            ff->computeBendingMaterialStiffness(quadIndex,idx0,idx1,idx2,idx3);
-            ff->computeShearMaterialStiffness(quadIndex,idx0,idx1,idx2,idx3);
-            break;
-
-        }
-    }
-}
 
 // --------------------------------------------------------------------------------------
 // --- constructor
@@ -106,7 +79,7 @@ QuadBendingFEMForceField<DataTypes>::QuadBendingFEMForceField()
   , l_topology(initLink("topology", "link to the topology container"))
 
 {
-    quadHandler = new QuadHandler(this, &quadInfo);
+
 }
                 
 template <class DataTypes>
@@ -114,7 +87,6 @@ QuadBendingFEMForceField<DataTypes>::~QuadBendingFEMForceField()
 {
     f_poisson.setRequired(true);
     f_young.setRequired(true);
-    if(quadHandler) delete quadHandler;
 }
     
 // --------------------------------------------------------------------------------------
@@ -144,7 +116,14 @@ void QuadBendingFEMForceField<DataTypes>::init()
         msg_warning() << "No quads found in linked Topology.";
     }
     // Create specific handler for QuadData
-    quadInfo.createTopologyHandler(m_topology, quadHandler);
+    quadInfo.createTopologyHandler(m_topology);
+    quadInfo.setCreationCallback([this](Index quadIndex, QuadInformation& qInfo,
+        const core::topology::BaseMeshTopology::Quad& q,
+        const sofa::type::vector< Index >& ancestors,
+        const sofa::type::vector< double >& coefs)
+    {
+        createQuadInformation(quadIndex, qInfo, q, ancestors, coefs);
+    });
 
     edgeInfo.createTopologyHandler(m_topology);
 
@@ -203,14 +182,40 @@ void QuadBendingFEMForceField<DataTypes>::reinit()
   
     for (Topology::QuadID i=0; i<m_topology->getNbQuads(); ++i)
     {
-        quadHandler->applyCreateFunction(i, quadInf[i],  m_topology->getQuad(i),  
-                                         (const sofa::type::vector< unsigned int > )0, 
-                                         (const sofa::type::vector< double >)0);
+        createQuadInformation(i, quadInf[i],  m_topology->getQuad(i),
+            (const sofa::type::vector< unsigned int > )0,
+            (const sofa::type::vector< double >)0);
     }
     edgeInfo.endEdit();
     quadInfo.endEdit();
 }
-                
+
+
+// --------------------------------------------------------------------------------------
+// ---  Topology Creation/Destruction functions
+// --------------------------------------------------------------------------------------
+
+template< class DataTypes>
+void QuadBendingFEMForceField<DataTypes>::createQuadInformation(unsigned int quadIndex, QuadInformation&,
+    const core::topology::BaseMeshTopology::Quad& t,
+    const sofa::type::vector<unsigned int>&,
+    const sofa::type::vector<double>&)
+{
+    Index idx0 = t[0];
+    Index idx1 = t[1];
+    Index idx2 = t[2];
+    Index idx3 = t[3];
+    switch (method)
+    {
+    case SMALL:
+        initSmall(quadIndex, idx0, idx1, idx2, idx3);
+        computeBendingMaterialStiffness(quadIndex, idx0, idx1, idx2, idx3);
+        computeShearMaterialStiffness(quadIndex, idx0, idx1, idx2, idx3);
+        break;
+
+    }
+}
+
 // --------------------------------------------------------------------------------------
 // --- Get/Set methods
 // --------------------------------------------------------------------------------------

--- a/modules/SofaMiscFem/src/SofaMiscFem/StandardTetrahedralFEMForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/StandardTetrahedralFEMForceField.h
@@ -191,6 +191,9 @@ public:
 
   //  type::Mat<3,3,double> getPhi( int );
 
+    /** Method to initialize @sa TetrahedronRestInformation when a new Tetrahedron is created.
+    * Will be set as creation callback in the TetrahedronData @sa tetrahedronInfo
+    */
     void createTetrahedronRestInformation(Index, TetrahedronRestInformation& t,
         const core::topology::BaseMeshTopology::Tetrahedron&,
         const sofa::type::vector<Index>&,
@@ -201,9 +204,9 @@ public:
 
 	fem::HyperelasticMaterial<DataTypes> *myMaterial;
 
-        topology::TetrahedronData<tetrahedronRestInfoVector> tetrahedronInfo; ///< Internal tetrahedron data
-        //EdgeData<sofa::type::vector< EdgeInformation> > edgeInfo; ///< Internal edge data
-        topology::EdgeData<edgeInformationVector> edgeInfo; ///< Internal edge data
+    topology::TetrahedronData<tetrahedronRestInfoVector> tetrahedronInfo; ///< Internal tetrahedron data
+    //EdgeData<sofa::type::vector< EdgeInformation> > edgeInfo; ///< Internal edge data
+    topology::EdgeData<edgeInformationVector> edgeInfo; ///< Internal edge data
 
 
         void testDerivatives();

--- a/modules/SofaMiscFem/src/SofaMiscFem/StandardTetrahedralFEMForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/StandardTetrahedralFEMForceField.h
@@ -191,27 +191,10 @@ public:
 
   //  type::Mat<3,3,double> getPhi( int );
 
-    class GHTetrahedronHandler : public topology::TopologyDataHandler<core::topology::BaseMeshTopology::Tetrahedron, tetrahedronRestInfoVector >
-        {
-        public:
-          typedef typename StandardTetrahedralFEMForceField<DataTypes>::TetrahedronRestInformation TetrahedronRestInformation;
-
-          GHTetrahedronHandler(StandardTetrahedralFEMForceField<DataTypes>* ff,
-                               topology::TetrahedronData<tetrahedronRestInfoVector>* data )
-            :topology::TopologyDataHandler<core::topology::BaseMeshTopology::Tetrahedron, tetrahedronRestInfoVector >(data)
-            ,ff(ff)
-          {
-          }
-
-          void applyCreateFunction(Index, TetrahedronRestInformation &t,
-                                   const core::topology::BaseMeshTopology::Tetrahedron&,
-                                   const sofa::type::vector<Index> &,
-                                   const sofa::type::vector<double> &);
-
-         protected:
-          StandardTetrahedralFEMForceField<DataTypes>* ff;
-
-        };
+    void createTetrahedronRestInformation(Index, TetrahedronRestInformation& t,
+        const core::topology::BaseMeshTopology::Tetrahedron&,
+        const sofa::type::vector<Index>&,
+        const sofa::type::vector<double>&);
 	
   protected:
     /// the array that describes the complete material energy and its derivatives
@@ -227,9 +210,6 @@ public:
         void saveMesh( const char *filename );
 	
 	VecCoord myposition;
-
-        GHTetrahedronHandler* tetrahedronHandler;
-    
 };
 
 

--- a/modules/SofaMiscFem/src/SofaMiscFem/StandardTetrahedralFEMForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/StandardTetrahedralFEMForceField.h
@@ -205,7 +205,6 @@ public:
 	fem::HyperelasticMaterial<DataTypes> *myMaterial;
 
     topology::TetrahedronData<tetrahedronRestInfoVector> tetrahedronInfo; ///< Internal tetrahedron data
-    //EdgeData<sofa::type::vector< EdgeInformation> > edgeInfo; ///< Internal edge data
     topology::EdgeData<edgeInformationVector> edgeInfo; ///< Internal edge data
 
 

--- a/modules/SofaMiscFem/src/SofaMiscFem/StandardTetrahedralFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/StandardTetrahedralFEMForceField.inl
@@ -209,7 +209,7 @@ void StandardTetrahedralFEMForceField<DataTypes>::createTetrahedronRestInformati
     /*int l*/;
     typename DataTypes::Real volume;
     typename DataTypes::Coord point[4];
-    const typename DataTypes::VecCoord restPosition = mstate->read(core::ConstVecCoordId::restPosition())->getValue();
+    const typename DataTypes::VecCoord restPosition = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
 
     ///describe the indices of the 4 tetrahedron vertices
     const core::topology::BaseMeshTopology::Tetrahedron& t = tetrahedronArray[tetrahedronIndex];

--- a/modules/SofaMiscFem/src/SofaMiscFem/StandardTetrahedralFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/StandardTetrahedralFEMForceField.inl
@@ -206,7 +206,6 @@ void StandardTetrahedralFEMForceField<DataTypes>::createTetrahedronRestInformati
     const type::vector< core::topology::BaseMeshTopology::Tetrahedron >& tetrahedronArray = m_topology->getTetrahedra();
     const std::vector< core::topology::BaseMeshTopology::Edge>& edgeArray = m_topology->getEdges();
     unsigned int j;
-    /*int l*/;
     typename DataTypes::Real volume;
     typename DataTypes::Coord point[4];
     const typename DataTypes::VecCoord restPosition = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();

--- a/modules/SofaMiscFem/src/SofaMiscFem/TetrahedralTensorMassForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TetrahedralTensorMassForceField.h
@@ -144,30 +144,33 @@ public:
     /// compute lambda and mu based on the Young modulus and Poisson ratio
     void updateLameCoefficients();
 
-    typedef typename topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge, edgeRestInfoVector > TetrahedralTMEdgeHandler;
-
+    /** Method to initialize @sa EdgeRestInformation when a new edge is created.
+    * Will be set as creation callback in the EdgeData @sa edgeInfo
+    */
     void createEdgeRestInformation(Index edgeIndex, EdgeRestInformation& ei,
         const core::topology::BaseMeshTopology::Edge&,
         const sofa::type::vector< Index >&,
         const sofa::type::vector< double >&);
 
+    /** Method to update @sa edgeInfo when a new Tetrahedron is created.
+    * Will be set as callback in the EdgeData @sa edgeInfo when TETRAHEDRAADDED event is fired
+    * to create a new spring in created Tetrahedron.
+    */
     void applyTetrahedronCreation(const sofa::type::vector<Index>& tetrahedronAdded,
         const sofa::type::vector<core::topology::BaseMeshTopology::Tetrahedron>&,
         const sofa::type::vector<sofa::type::vector<Index> >&,
         const sofa::type::vector<sofa::type::vector<double> >&);
 
+    /** Method to update @sa d_edgeSprings when a triangle is removed.
+    * Will be set as callback in the EdgeData @sa edgeInfo when TETRAHEDRAREMOVED event is fired
+    * to remove spring if needed or update adjacent Tetrahedron.
+    */
     void applyTetrahedronDestruction(const sofa::type::vector<Index>& tetrahedronRemoved);
 
+    topology::EdgeData < edgeRestInfoVector >& getEdgeInfo() { return edgeInfo; }
+
 protected:
-
-//    EdgeData < typename VecType < EdgeRestInformation > > edgeInfo; ///< Internal edge data
     topology::EdgeData < edgeRestInfoVector > edgeInfo; ///< Internal edge data
-
-//    EdgeData < typename VecType < EdgeRestInformation > > &getEdgeInfo() {return edgeInfo;}
-    topology::EdgeData < edgeRestInfoVector > &getEdgeInfo() {return edgeInfo;}
-
-
-    TetrahedralTMEdgeHandler* m_edgeHandler;
 
     sofa::core::topology::BaseMeshTopology* m_topology;
 

--- a/modules/SofaMiscFem/src/SofaMiscFem/TetrahedralTensorMassForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TetrahedralTensorMassForceField.h
@@ -144,34 +144,19 @@ public:
     /// compute lambda and mu based on the Young modulus and Poisson ratio
     void updateLameCoefficients();
 
+    typedef typename topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge, edgeRestInfoVector > TetrahedralTMEdgeHandler;
 
-    class TetrahedralTMEdgeHandler : public topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge,edgeRestInfoVector >
-    {
-    public:
-        typedef typename TetrahedralTensorMassForceField<DataTypes>::EdgeRestInformation EdgeRestInformation;
-        TetrahedralTMEdgeHandler(TetrahedralTensorMassForceField<DataTypes>* _ff, topology::EdgeData<edgeRestInfoVector >* _data) : topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge, edgeRestInfoVector >(_data), ff(_ff) {}
+    void createEdgeRestInformation(Index edgeIndex, EdgeRestInformation& ei,
+        const core::topology::BaseMeshTopology::Edge&,
+        const sofa::type::vector< Index >&,
+        const sofa::type::vector< double >&);
 
-        void applyCreateFunction(Index edgeIndex, EdgeRestInformation& ei,
-                const core::topology::BaseMeshTopology::Edge &,
-                const sofa::type::vector< Index > &,
-                const sofa::type::vector< double > &);
+    void applyTetrahedronCreation(const sofa::type::vector<Index>& tetrahedronAdded,
+        const sofa::type::vector<core::topology::BaseMeshTopology::Tetrahedron>&,
+        const sofa::type::vector<sofa::type::vector<Index> >&,
+        const sofa::type::vector<sofa::type::vector<double> >&);
 
-        void applyTetrahedronCreation(const sofa::type::vector<Index> &edgeAdded,
-                const sofa::type::vector<core::topology::BaseMeshTopology::Tetrahedron> &,
-                const sofa::type::vector<sofa::type::vector<Index> > &,
-                const sofa::type::vector<sofa::type::vector<double> > &);
-
-        void applyTetrahedronDestruction(const sofa::type::vector<Index> &edgeRemoved);
-
-        using topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge,edgeRestInfoVector >::ApplyTopologyChange;
-        /// Callback to add tetrahedron elements.
-        void ApplyTopologyChange(const core::topology::TetrahedraAdded* /*event*/);
-        /// Callback to remove tetrahedron elements.
-        void ApplyTopologyChange(const core::topology::TetrahedraRemoved* /*event*/);
-
-    protected:
-        TetrahedralTensorMassForceField<DataTypes>* ff;
-    };
+    void applyTetrahedronDestruction(const sofa::type::vector<Index>& tetrahedronRemoved);
 
 protected:
 
@@ -182,7 +167,7 @@ protected:
     topology::EdgeData < edgeRestInfoVector > &getEdgeInfo() {return edgeInfo;}
 
 
-    TetrahedralTMEdgeHandler* edgeHandler;
+    TetrahedralTMEdgeHandler* m_edgeHandler;
 
     sofa::core::topology::BaseMeshTopology* m_topology;
 

--- a/modules/SofaMiscFem/src/SofaMiscFem/TetrahedralTensorMassForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TetrahedralTensorMassForceField.inl
@@ -235,13 +235,13 @@ TetrahedralTensorMassForceField<DataTypes>::TetrahedralTensorMassForceField()
     , edgeInfo(initData(&edgeInfo, "edgeInfo", "Internal edge data"))
     , m_topology(nullptr)
 {
-    m_edgeHandler = new TetrahedralTMEdgeHandler(&edgeInfo);
+
 }
 
 template <class DataTypes> 
 TetrahedralTensorMassForceField<DataTypes>::~TetrahedralTensorMassForceField()
 {
-    if(m_edgeHandler) delete m_edgeHandler;
+
 }
 
 template <class DataTypes> void 
@@ -265,7 +265,7 @@ TetrahedralTensorMassForceField<DataTypes>::init()
         return;
     }
 
-    edgeInfo.createTopologyHandler(m_topology, m_edgeHandler);
+    edgeInfo.createTopologyHandler(m_topology);
     edgeInfo.linkToTetrahedronDataArray();
 
     if (m_topology->getNbTetrahedra()==0)
@@ -309,13 +309,13 @@ TetrahedralTensorMassForceField<DataTypes>::init()
         createEdgeRestInformation(edgeIndex, ei, edge, ancestors, coefs);
     });
 
-    m_edgeHandler->addCallBack(sofa::core::topology::TopologyChangeType::TETRAHEDRAADDED, [this](const core::topology::TopologyChange* eventTopo) 
+    edgeInfo.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::TETRAHEDRAADDED, [this](const core::topology::TopologyChange* eventTopo)
     {
         const core::topology::TetrahedraAdded* tAdd = static_cast<const core::topology::TetrahedraAdded*>(eventTopo);
         applyTetrahedronCreation(tAdd->getIndexArray(), tAdd->getElementArray(), tAdd->ancestorsList, tAdd->coefs);
     });
 
-    m_edgeHandler->addCallBack(sofa::core::topology::TopologyChangeType::TETRAHEDRAREMOVED, [this](const core::topology::TopologyChange* eventTopo) 
+    edgeInfo.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::TETRAHEDRAREMOVED, [this](const core::topology::TopologyChange* eventTopo)
     {
         const core::topology::TetrahedraRemoved* tRemove = static_cast<const core::topology::TetrahedraRemoved*>(eventTopo);
         applyTetrahedronDestruction(tRemove->getArray());

--- a/modules/SofaMiscFem/src/SofaMiscFem/TetrahedralTensorMassForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TetrahedralTensorMassForceField.inl
@@ -301,6 +301,12 @@ TetrahedralTensorMassForceField<DataTypes>::init()
     for (i=0; i<m_topology->getNbTetrahedra(); ++i)
         tetrahedronAdded.push_back(i);
 
+    applyTetrahedronCreation(tetrahedronAdded,
+        (const sofa::type::vector<Tetrahedron>)0,
+        (const sofa::type::vector<sofa::type::vector<Index> >)0,
+        (const sofa::type::vector<sofa::type::vector<double> >)0);
+
+
     edgeInfo.setCreationCallback([this](Index edgeIndex, EdgeRestInformation& ei,
         const core::topology::BaseMeshTopology::Edge& edge,
         const sofa::type::vector< Index >& ancestors,

--- a/modules/SofaMiscFem/src/SofaMiscFem/TetrahedralTensorMassForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TetrahedralTensorMassForceField.inl
@@ -70,7 +70,7 @@ void TetrahedralTensorMassForceField<DataTypes>::applyTetrahedronCreation(const 
     typename DataTypes::Real lambdastar, mustar;
     typename DataTypes::Coord point[4],shapeVector[4];
 
-    const typename DataTypes::VecCoord restPosition=mstate->read(core::ConstVecCoordId::restPosition())->getValue();
+    const typename DataTypes::VecCoord restPosition=this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
 
     edgeRestInfoVector& edgeData = *(edgeInfo.beginEdit());
 
@@ -152,7 +152,7 @@ void TetrahedralTensorMassForceField<DataTypes>::applyTetrahedronDestruction(con
     typename DataTypes::Real lambdastar, mustar;
     typename DataTypes::Coord point[4],shapeVector[4];
 
-    const typename DataTypes::VecCoord restPosition=mstate->read(core::ConstVecCoordId::restPosition())->getValue();
+    const typename DataTypes::VecCoord restPosition=this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
 
     edgeRestInfoVector& edgeData = *(edgeInfo.beginEdit());
 

--- a/modules/SofaMiscFem/src/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.h
@@ -169,6 +169,9 @@ public:
         d_anisotropySet.setValue(direction);
     }
 
+    /** Method to initialize @sa TetrahedronRestInformation when a new Tetrahedron is created.
+    * Will be set as creation callback in the TetrahedronData @sa m_tetrahedronInfo
+    */
     void createTetrahedronRestInformation(Index, TetrahedronRestInformation& t, const Tetrahedron&,
         const sofa::type::vector<Index>&, const sofa::type::vector<double>&);
 

--- a/modules/SofaMiscFem/src/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.h
@@ -169,24 +169,8 @@ public:
         d_anisotropySet.setValue(direction);
     }
 
-    class SOFA_SOFAMISCFEM_API TetrahedronHandler : public TopologyDataHandler<Tetrahedron,sofa::type::vector<TetrahedronRestInformation> >
-    {
-    public:
-      typedef typename TetrahedronHyperelasticityFEMForceField<DataTypes>::TetrahedronRestInformation TetrahedronRestInformation;
-      TetrahedronHandler(TetrahedronHyperelasticityFEMForceField<DataTypes>* ff,
-                         TetrahedronData<sofa::type::vector<TetrahedronRestInformation> >* data )
-        :TopologyDataHandler<Tetrahedron,sofa::type::vector<TetrahedronRestInformation> >(data)
-        ,ff(ff)
-      {
-
-      }
-
-      void applyCreateFunction(Index, TetrahedronRestInformation &t, const Tetrahedron &,
-                               const sofa::type::vector<Index> &, const sofa::type::vector<double> &);
-
-    protected:
-      TetrahedronHyperelasticityFEMForceField<DataTypes>* ff;
-    };
+    void createTetrahedronRestInformation(Index, TetrahedronRestInformation& t, const Tetrahedron&,
+        const sofa::type::vector<Index>&, const sofa::type::vector<double>&);
 
 protected:
    TetrahedronHyperelasticityFEMForceField();
@@ -215,7 +199,6 @@ public:
     /// the array that describes the complete material energy and its derivatives
 
     fem::HyperelasticMaterial<DataTypes> *m_myMaterial;
-    TetrahedronHandler* m_tetrahedronHandler;
 
     void testDerivatives();
     void saveMesh( const char *filename );

--- a/modules/SofaMiscFem/src/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.inl
@@ -221,7 +221,7 @@ void TetrahedronHyperelasticityFEMForceField<DataTypes>::createTetrahedronRestIn
     //      int k;
     typename DataTypes::Real volume;
     typename DataTypes::Coord point[4];
-    const typename DataTypes::VecCoord restPosition = mstate->read(core::ConstVecCoordId::restPosition())->getValue();
+    const typename DataTypes::VecCoord restPosition = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
 
     ///describe the indices of the 4 tetrahedron vertices
     const Tetrahedron& t = tetrahedronArray[tetrahedronIndex];

--- a/modules/SofaMiscFem/src/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.inl
@@ -53,60 +53,6 @@ using namespace	sofa::component::topology;
 using namespace core::topology;
 
 
-template< class DataTypes >
-void TetrahedronHyperelasticityFEMForceField<DataTypes>::TetrahedronHandler::applyCreateFunction(Index tetrahedronIndex,
-                                                                                              TetrahedronRestInformation &tinfo,
-                                                                                              const Tetrahedron &,
-                                                                                              const sofa::type::vector<Index> &,
-                                                                                              const sofa::type::vector<double> &)
-{
-
-  if (ff) {
-      const type::vector< Tetrahedron > &tetrahedronArray=ff->m_topology->getTetrahedra() ;
-      const std::vector< Edge> &edgeArray=ff->m_topology->getEdges() ;
-      unsigned int j;
-//      int k;
-      typename DataTypes::Real volume;
-      typename DataTypes::Coord point[4];
-      const typename DataTypes::VecCoord restPosition = ff->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
-
-      ///describe the indices of the 4 tetrahedron vertices
-      const Tetrahedron &t= tetrahedronArray[tetrahedronIndex];
-      BaseMeshTopology::EdgesInTetrahedron te=ff->m_topology->getEdgesInTetrahedron(tetrahedronIndex);
-
-      // store the point position
-
-      for(j=0;j<4;++j)
-          point[j]=(restPosition)[t[j]];
-      /// compute 6 times the rest volume
-      volume=dot(cross(point[2]-point[0],point[3]-point[0]),point[1]-point[0]);
-      /// store the rest volume
-      tinfo.m_volScale =(Real)(1.0/volume);
-      tinfo.m_restVolume = fabs(volume/6);
-      // store shape vectors at the rest configuration
-      for(j=0;j<4;++j) {
-          if (!(j%2))
-              tinfo.m_shapeVector[j]=-cross(point[(j+2)%4] - point[(j+1)%4],point[(j+3)%4] - point[(j+1)%4])/ volume;
-          else
-              tinfo.m_shapeVector[j]=cross(point[(j+2)%4] - point[(j+1)%4],point[(j+3)%4] - point[(j+1)%4])/ volume;
-      }
-
-
-      for(j=0;j<6;++j) {
-          Edge e=ff->m_topology->getLocalEdgesInTetrahedron(j);
-          int k=e[0];
-          //int l=e[1];
-          if (edgeArray[te[j]][0]!=t[k]) {
-              k=e[1];
-              //l=e[0];
-          }
-      }
-
-
-  }//end if(ff)
-
-}
-
 template <class DataTypes> TetrahedronHyperelasticityFEMForceField<DataTypes>::TetrahedronHyperelasticityFEMForceField() 
     : m_topology(nullptr)
     , m_initialPoints(0)
@@ -119,14 +65,13 @@ template <class DataTypes> TetrahedronHyperelasticityFEMForceField<DataTypes>::T
     , m_tetrahedronInfo(initData(&m_tetrahedronInfo, "tetrahedronInfo", "Internal tetrahedron data"))
     , m_edgeInfo(initData(&m_edgeInfo, "edgeInfo", "Internal edge data"))
     , l_topology(initLink("topology", "link to the topology container"))
-    , m_tetrahedronHandler(nullptr)
 {
-    m_tetrahedronHandler = new TetrahedronHandler(this,&m_tetrahedronInfo);
+
 }
 
 template <class DataTypes> TetrahedronHyperelasticityFEMForceField<DataTypes>::~TetrahedronHyperelasticityFEMForceField()
 {
-    if(m_tetrahedronHandler) delete m_tetrahedronHandler;
+
 }
 
 template <class DataTypes> void TetrahedronHyperelasticityFEMForceField<DataTypes>::init()
@@ -243,16 +188,72 @@ template <class DataTypes> void TetrahedronHyperelasticityFEMForceField<DataType
     /// initialize the data structure associated with each tetrahedron
     for (Topology::TetrahedronID i=0;i<m_topology->getNbTetrahedra();++i)
     {
-        m_tetrahedronHandler->applyCreateFunction(i, tetrahedronInf[i],
-                                                m_topology->getTetrahedron(i),  (const type::vector< Index > )0,
-                                                (const type::vector< double >)0);
+        createTetrahedronRestInformation(i, tetrahedronInf[i],
+            m_topology->getTetrahedron(i),  (const type::vector< Index > )0,
+            (const type::vector< double >)0);
     }
 
     /// set the call back function upon creation of a tetrahedron
-    m_tetrahedronInfo.createTopologyHandler(m_topology,m_tetrahedronHandler);
+    m_tetrahedronInfo.createTopologyHandler(m_topology);
+    m_tetrahedronInfo.setCreationCallback([this](Index tetrahedronIndex, TetrahedronRestInformation& tetraInfo,
+        const core::topology::BaseMeshTopology::Tetrahedron& tetra,
+        const sofa::type::vector< Index >& ancestors,
+        const sofa::type::vector< double >& coefs)
+    {
+        createTetrahedronRestInformation(tetrahedronIndex, tetraInfo, tetra, ancestors, coefs);
+    });
     m_tetrahedronInfo.endEdit();
     //testDerivatives();
+}
 
+
+template< class DataTypes >
+void TetrahedronHyperelasticityFEMForceField<DataTypes>::createTetrahedronRestInformation(Index tetrahedronIndex,
+    TetrahedronRestInformation& tinfo,
+    const Tetrahedron&,
+    const sofa::type::vector<Index>&,
+    const sofa::type::vector<double>&)
+{
+
+    const type::vector< Tetrahedron >& tetrahedronArray = m_topology->getTetrahedra();
+    const std::vector< Edge>& edgeArray = m_topology->getEdges();
+    unsigned int j;
+    //      int k;
+    typename DataTypes::Real volume;
+    typename DataTypes::Coord point[4];
+    const typename DataTypes::VecCoord restPosition = mstate->read(core::ConstVecCoordId::restPosition())->getValue();
+
+    ///describe the indices of the 4 tetrahedron vertices
+    const Tetrahedron& t = tetrahedronArray[tetrahedronIndex];
+    BaseMeshTopology::EdgesInTetrahedron te = m_topology->getEdgesInTetrahedron(tetrahedronIndex);
+
+    // store the point position
+
+    for (j = 0; j < 4; ++j)
+        point[j] = (restPosition)[t[j]];
+    /// compute 6 times the rest volume
+    volume = dot(cross(point[2] - point[0], point[3] - point[0]), point[1] - point[0]);
+    /// store the rest volume
+    tinfo.m_volScale = (Real)(1.0 / volume);
+    tinfo.m_restVolume = fabs(volume / 6);
+    // store shape vectors at the rest configuration
+    for (j = 0; j < 4; ++j) {
+        if (!(j % 2))
+            tinfo.m_shapeVector[j] = -cross(point[(j + 2) % 4] - point[(j + 1) % 4], point[(j + 3) % 4] - point[(j + 1) % 4]) / volume;
+        else
+            tinfo.m_shapeVector[j] = cross(point[(j + 2) % 4] - point[(j + 1) % 4], point[(j + 3) % 4] - point[(j + 1) % 4]) / volume;;
+    }
+
+
+    for (j = 0; j < 6; ++j) {
+        Edge e = m_topology->getLocalEdgesInTetrahedron(j);
+        int k = e[0];
+        //int l=e[1];
+        if (edgeArray[te[j]][0] != t[k]) {
+            k = e[1];
+            //l=e[0];
+        }
+    }
 }
 
 template <class DataTypes> 

--- a/modules/SofaMiscFem/src/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TetrahedronHyperelasticityFEMForceField.inl
@@ -251,7 +251,6 @@ void TetrahedronHyperelasticityFEMForceField<DataTypes>::createTetrahedronRestIn
         //int l=e[1];
         if (edgeArray[te[j]][0] != t[k]) {
             k = e[1];
-            //l=e[0];
         }
     }
 }

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularAnisotropicFEMForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularAnisotropicFEMForceField.h
@@ -81,37 +81,23 @@ public:
     Data<Real> f_theta; ///< Fiber angle in global reference frame (in degrees)
     Data<VecCoord> f_fiberCenter; ///< Concentric fiber center in global reference frame
     Data<bool> showFiber; ///< Flag activating rendering of fiber directions within each triangle
-
-    topology::TriangleData <type::vector< Deriv> > localFiberDirection; ///< Computed fibers direction within each triangle
+    typedef typename TriangularAnisotropicFEMForceField::Deriv TriangleFiberDirection;
+    topology::TriangleData < sofa::type::vector< TriangleFiberDirection > > localFiberDirection; ///< Computed fibers direction within each triangle
 
     /// Link to be set to the topology container in the component graph.
     using Inherit1::l_topology;
 
-    class TRQSTriangleHandler : public topology::TopologyDataHandler<core::topology::BaseMeshTopology::Triangle,type::vector<Deriv> >
-    {
-    public:
-        typedef typename TriangularAnisotropicFEMForceField::Deriv triangleInfo;
-
-        TRQSTriangleHandler(TriangularAnisotropicFEMForceField<DataTypes>* _ff, topology::TriangleData<type::vector<triangleInfo> >*  _data) : topology::TopologyDataHandler<core::topology::BaseMeshTopology::Triangle, type::vector<triangleInfo> >(_data), ff(_ff) {}
-
-        using topology::TopologyDataHandler<core::topology::BaseMeshTopology::Triangle,type::vector<Deriv> >::applyCreateFunction;
-        void applyCreateFunction(unsigned int triangleIndex,
-                                 type::vector<triangleInfo> & ,
-                                 const core::topology::BaseMeshTopology::Triangle & t,
-                                 const sofa::type::vector< unsigned int > &,
-                                 const sofa::type::vector< double > &);
-
-    protected:
-        TriangularAnisotropicFEMForceField<DataTypes>* ff;
-    };
+    void createTriangleInfo(Index triangleIndex,
+        TriangleFiberDirection&,
+        const core::topology::BaseMeshTopology::Triangle& t,
+        const sofa::type::vector< unsigned int >&,
+        const sofa::type::vector< double >&);
 
     /// Inherited member
     /// Bring inherited member in the current lookup context.
     /// otherwise any access to the Inherit1::member would require "this->".
     /// @see https://gcc.gnu.org/onlinedocs/gcc/Name-lookup.html
     using Inherit1::m_topology;
-
-    TRQSTriangleHandler* triangleHandler;
 };
 
 #if  !defined(SOFA_COMPONENT_FORCEFIELD_TRIANGULARANISOTROPICFEMFORCEFIELD_CPP)

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularAnisotropicFEMForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularAnisotropicFEMForceField.h
@@ -87,6 +87,9 @@ public:
     /// Link to be set to the topology container in the component graph.
     using Inherit1::l_topology;
 
+    /** Method to initialize @sa TriangleFiberDirection when a new Triangle is created.
+    * Will be set as creation callback in the TriangleData @sa localFiberDirection
+    */
     void createTriangleInfo(Index triangleIndex,
         TriangleFiberDirection&,
         const core::topology::BaseMeshTopology::Triangle& t,

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularAnisotropicFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularAnisotropicFEMForceField.inl
@@ -46,7 +46,6 @@ TriangularAnisotropicFEMForceField<DataTypes>::TriangularAnisotropicFEMForceFiel
     , localFiberDirection(initData(&localFiberDirection,"localFiberDirection", "Computed fibers direction within each triangle"))
 {
     this->_anisotropicMaterial = true;
-    triangleHandler = new TRQSTriangleHandler(this, &localFiberDirection);
 
     f_young2.setRequired(true);
 }
@@ -55,30 +54,27 @@ TriangularAnisotropicFEMForceField<DataTypes>::TriangularAnisotropicFEMForceFiel
 template <class DataTypes>
 TriangularAnisotropicFEMForceField<DataTypes>::~TriangularAnisotropicFEMForceField()
 {
-    if(triangleHandler) delete triangleHandler;
+
 }
 
 template< class DataTypes>
-void TriangularAnisotropicFEMForceField<DataTypes>::TRQSTriangleHandler::applyCreateFunction(unsigned int triangleIndex, type::vector<triangleInfo> &, const core::topology::BaseMeshTopology::Triangle &t, const sofa::type::vector<unsigned int> &, const sofa::type::vector<double> &)
+void TriangularAnisotropicFEMForceField<DataTypes>::createTriangleInfo(Index triangleIndex, TriangleFiberDirection&, const core::topology::BaseMeshTopology::Triangle &t, const sofa::type::vector<unsigned int> &, const sofa::type::vector<double> &)
 {
-    if (ff)
-    {
-        //const Triangle &t = ff->m_topology->getTriangle(triangleIndex);
-        Index a = t[0];
-        Index b = t[1];
-        Index c = t[2];
+    //const Triangle &t = m_topology->getTriangle(triangleIndex);
+    Index a = t[0];
+    Index b = t[1];
+    Index c = t[2];
 
-        switch(ff->method)
-        {
-        case TriangularFEMForceField<DataTypes>::SMALL :
-            ff->initSmall(triangleIndex,a,b,c);
-            ff->computeMaterialStiffness(triangleIndex, a, b, c);
-            break;
-        case TriangularFEMForceField<DataTypes>::LARGE :
-            ff->initLarge(triangleIndex,a,b,c);
-            ff->computeMaterialStiffness(triangleIndex, a, b, c);
-            break;
-        }
+    switch(method)
+    {
+    case TriangularFEMForceField<DataTypes>::SMALL :
+        initSmall(triangleIndex,a,b,c);
+        computeMaterialStiffness(triangleIndex, a, b, c);
+        break;
+    case TriangularFEMForceField<DataTypes>::LARGE :
+        initLarge(triangleIndex,a,b,c);
+        computeMaterialStiffness(triangleIndex, a, b, c);
+        break;
     }
 }
 
@@ -102,7 +98,14 @@ void TriangularAnisotropicFEMForceField<DataTypes>::init()
     }
 
     // Create specific handler for TriangleData
-    localFiberDirection.createTopologyHandler(m_topology, triangleHandler);
+    localFiberDirection.createTopologyHandler(m_topology);
+    localFiberDirection.setCreationCallback([this](Index triangleIndex, TriangleFiberDirection& triInfo,
+        const core::topology::BaseMeshTopology::Triangle& t,
+        const sofa::type::vector< Index >& ancestors,
+        const sofa::type::vector< double >& coefs)
+    {
+        createTriangleInfo(triangleIndex, triInfo, t, ancestors, coefs);
+    });
 
     Inherited::init();
     reinit();

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularAnisotropicFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularAnisotropicFEMForceField.inl
@@ -68,11 +68,11 @@ void TriangularAnisotropicFEMForceField<DataTypes>::createTriangleInfo(Index tri
     switch(this->method)
     {
     case TriangularFEMForceField<DataTypes>::SMALL :
-        initSmall(triangleIndex,a,b,c);
+        this->initSmall(triangleIndex,a,b,c);
         computeMaterialStiffness(triangleIndex, a, b, c);
         break;
     case TriangularFEMForceField<DataTypes>::LARGE :
-        initLarge(triangleIndex,a,b,c);
+        this->initLarge(triangleIndex,a,b,c);
         computeMaterialStiffness(triangleIndex, a, b, c);
         break;
     }

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularAnisotropicFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularAnisotropicFEMForceField.inl
@@ -65,7 +65,7 @@ void TriangularAnisotropicFEMForceField<DataTypes>::createTriangleInfo(Index tri
     Index b = t[1];
     Index c = t[2];
 
-    switch(method)
+    switch(this->method)
     {
     case TriangularFEMForceField<DataTypes>::SMALL :
         initSmall(triangleIndex,a,b,c);

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.h
@@ -181,6 +181,9 @@ public:
     topology::TriangleData<sofa::type::vector<TriangleInformation> > triangleInfo;
     topology::PointData<sofa::type::vector<VertexInformation> > vertexInfo; ///< Internal point data
 
+    /** Method to initialize @sa TriangleInformation when a new Triangle is created.
+    * Will be set as creation callback in the TriangleData @sa triangleInfo
+    */
     void createTriangleInformation(Index triangleIndex, TriangleInformation&,
         const core::topology::BaseMeshTopology::Triangle& t,
         const sofa::type::vector< Index >&,


### PR DESCRIPTION
Remove TopologyHandler instances in FEM and set topology callbacks directly using TopologyData thanks to PR #2375
Update FEM:

- FastTetrahedralCorotationalForceField
- QuadBendingFEMForceField
- StandardTetrahedralFEMForceField
- TetrahedralTensorMassForceField
- TetrahedronHyperelasticityFEMForceField
- TriangularAnisotropicFEMForceField




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
