### PR TITLE
[SofaBaseMechanics] Remove TopologyHandler in masses to use TopologyData callbacks (part 5)

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
@@ -179,7 +179,7 @@ protected:
     /** Method to update @sa d_vertexMass when a Point is removed.
     * Will be set as destruction callback in the PointData @sa d_vertexMass
     */
-    void applyPointDestruction(const sofa::type::vector<PointID>& /*indices*/);
+    void applyPointDestruction(Index id, MassType& VertexMass);
 
 
     /** Method to update @sa d_vertexMass when a new Edge is created.
@@ -190,7 +190,7 @@ protected:
         const sofa::type::vector< sofa::type::vector< EdgeID > >& /*ancestors*/,
         const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
 
-    /** Method to update @sa d_vertexMass when a new Edge is removed.
+    /** Method to update @sa d_vertexMass when a Edge is removed.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when EDGESREMOVED event is fired.
     */
     void applyEdgeDestruction(const sofa::type::vector<EdgeID>& /*indices*/);
@@ -204,7 +204,7 @@ protected:
         const sofa::type::vector< sofa::type::vector< TriangleID > >& /*ancestors*/,
         const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
 
-    /** Method to update @sa d_vertexMass when a new Triangle is removed.
+    /** Method to update @sa d_vertexMass when a Triangle is removed.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when TRIANGLESREMOVED event is fired.
     */
     void applyTriangleDestruction(const sofa::type::vector<TriangleID>& /*indices*/);
@@ -218,7 +218,7 @@ protected:
         const sofa::type::vector< sofa::type::vector< QuadID > >& /*ancestors*/,
         const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
 
-    /** Method to update @sa d_vertexMass when a new Quad is removed.
+    /** Method to update @sa d_vertexMass when a Quad is removed.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when QUADSREMOVED event is fired.
     */
     void applyQuadDestruction(const sofa::type::vector<QuadID>& /*indices*/);
@@ -232,7 +232,7 @@ protected:
         const sofa::type::vector< sofa::type::vector< TetrahedronID > >& /*ancestors*/,
         const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
 
-    /** Method to update @sa d_vertexMass when a new Tetrahedron is removed.
+    /** Method to update @sa d_vertexMass when a Tetrahedron is removed.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when TETRAHEDRAREMOVED event is fired.
     */
     void applyTetrahedronDestruction(const sofa::type::vector<TetrahedronID>& /*indices*/);
@@ -246,7 +246,7 @@ protected:
         const sofa::type::vector< sofa::type::vector< HexahedronID > >& /*ancestors*/,
         const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
     
-    /** Method to update @sa d_vertexMass when a new Edge is removed.
+    /** Method to update @sa d_vertexMass when a Hexahedron is removed.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when HEXAHEDRAREMOVED event is fired.
     */
     void applyHexahedronDestruction(const sofa::type::vector<HexahedronID>& /*indices*/);

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
@@ -82,6 +82,7 @@ public:
     typedef core::topology::BaseMeshTopology::Edge Edge;
     typedef core::topology::BaseMeshTopology::EdgeID EdgeID;
     typedef core::topology::BaseMeshTopology::Quad Quad;
+    typedef core::topology::BaseMeshTopology::QuadID QuadID;
     typedef core::topology::BaseMeshTopology::Triangle Triangle;
     typedef core::topology::BaseMeshTopology::TriangleID TriangleID;
     typedef core::topology::BaseMeshTopology::Tetrahedron Tetrahedron;
@@ -89,83 +90,6 @@ public:
     typedef core::topology::BaseMeshTopology::Hexahedron Hexahedron;
     typedef core::topology::BaseMeshTopology::HexahedronID HexahedronID;
 
-    class DMassPointEngine : public topology::TopologyDataHandler<Point,MassVector>
-    {
-    public:
-        typedef typename DiagonalMass<DataTypes,TMassType>::MassVector MassVector;
-        DMassPointEngine(DiagonalMass<DataTypes,TMassType>* _dm, sofa::component::topology::PointData<MassVector>* _data)
-            : topology::TopologyDataHandler<Point,MassVector>(_data), dm(_dm)
-        {}
-
-        void applyCreateFunction(PointID pointIndex, TMassType& m, const Point&, const sofa::type::vector< PointID > &,
-                                 const sofa::type::vector< double > &);
-
-        using topology::TopologyDataHandler<Point,MassVector>::ApplyTopologyChange;
-
-        ///////////////////////// Functions on Points //////////////////////////////////////
-        /// Apply removing points.
-        void applyPointDestruction(const sofa::type::vector<PointID> & /*indices*/);
-        /// Callback to remove points.
-        virtual void ApplyTopologyChange(const core::topology::PointsRemoved* /*event*/);
-
-        ///////////////////////// Functions on Edges //////////////////////////////////////
-        /// Apply adding edges elements.
-        void applyEdgeCreation(const sofa::type::vector< EdgeID >& /*indices*/,
-                               const sofa::type::vector< Edge >& /*elems*/,
-                               const sofa::type::vector< sofa::type::vector< EdgeID > >& /*ancestors*/,
-                               const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
-        /// Apply removing edges elements.
-        void applyEdgeDestruction(const sofa::type::vector<EdgeID> & /*indices*/);
-
-        /// Callback to add edges elements.
-        virtual void ApplyTopologyChange(const core::topology::EdgesAdded* /*event*/);
-        /// Callback to remove edges elements.
-        virtual void ApplyTopologyChange(const core::topology::EdgesRemoved* /*event*/);
-
-        ///////////////////////// Functions on Triangles //////////////////////////////////////
-        /// Apply adding triangles elements.
-        void applyTriangleCreation(const sofa::type::vector< TriangleID >& /*indices*/,
-                                   const sofa::type::vector< Triangle >& /*elems*/,
-                                   const sofa::type::vector< sofa::type::vector< TriangleID > >& /*ancestors*/,
-                                   const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
-        /// Apply removing triangles elements.
-        void applyTriangleDestruction(const sofa::type::vector<TriangleID> & /*indices*/);
-
-        /// Callback to add triangles elements.
-        virtual void ApplyTopologyChange(const core::topology::TrianglesAdded* /*event*/);
-        /// Callback to remove triangles elements.
-        virtual void ApplyTopologyChange(const core::topology::TrianglesRemoved* /*event*/);
-
-        ///////////////////////// Functions on Tetrahedron //////////////////////////////////////
-        /// Apply adding tetrahedron elements.
-        void applyTetrahedronCreation(const sofa::type::vector< TetrahedronID >& /*indices*/,
-                                      const sofa::type::vector< Tetrahedron >& /*elems*/,
-                                      const sofa::type::vector< sofa::type::vector< TetrahedronID > >& /*ancestors*/,
-                                      const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
-        /// Apply removing tetrahedron elements.
-        void applyTetrahedronDestruction(const sofa::type::vector<TetrahedronID> & /*indices*/);
-
-        /// Callback to add tetrahedron elements.
-        virtual void ApplyTopologyChange(const core::topology::TetrahedraAdded* /*event*/);
-        /// Callback to remove tetrahedron elements.
-        virtual void ApplyTopologyChange(const core::topology::TetrahedraRemoved* /*event*/);
-
-        ///////////////////////// Functions on Hexahedron //////////////////////////////////////
-        /// Apply adding hexahedron elements.
-        void applyHexahedronCreation(const sofa::type::vector< HexahedronID >& /*indices*/,
-                                     const sofa::type::vector< Hexahedron >& /*elems*/,
-                                     const sofa::type::vector< sofa::type::vector< HexahedronID > >& /*ancestors*/,
-                                     const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
-        /// Apply removing hexahedron elements.
-        void applyHexahedronDestruction(const sofa::type::vector<HexahedronID> & /*indices*/);
-        /// Callback to add hexahedron elements.
-        virtual void ApplyTopologyChange(const core::topology::HexahedraAdded* /*event*/);
-        /// Callback to remove hexahedron elements.
-        virtual void ApplyTopologyChange(const core::topology::HexahedraRemoved* /*event*/);
-
-    protected:
-        DiagonalMass<DataTypes,TMassType>* dm;
-    };
     /// the mass density used to compute the mass from a mesh topology and geometry
     Data< Real > d_massDensity;
 
@@ -180,8 +104,6 @@ public:
 
     Data< float > d_showAxisSize; ///< factor length of the axis displayed (only used for rigids)
     core::objectmodel::DataFileName d_fileMass; ///< an Xsp3.0 file to specify the mass parameters
-
-    DMassPointEngine* m_pointEngine;
 
     /// value defining the initialization process of the mass (0 : totalMass, 1 : massDensity, 2 : vertexMass)
     int m_initializationProcess;
@@ -246,6 +168,88 @@ protected:
 
     /// Compute the vertexMass using input density and return the corresponding full mass.
     Real computeVertexMass(Real density);
+
+    /** Method to initialize @sa MassVector when a new Point is created.
+    * Will be set as creation callback in the PointData @sa d_vertexMass
+    */
+    void applyPointCreation(PointID pointIndex, MassType& m, const Point&,
+        const sofa::type::vector< PointID >&,
+        const sofa::type::vector< double >&);
+
+    /** Method to update @sa d_vertexMass when a Point is removed.
+    * Will be set as destruction callback in the PointData @sa d_vertexMass
+    */
+    void applyPointDestruction(const sofa::type::vector<PointID>& /*indices*/);
+
+
+    /** Method to update @sa d_vertexMass when a new Edge is created.
+    * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when EDGESADDED event is fired.    
+    */
+    void applyEdgeCreation(const sofa::type::vector< EdgeID >& /*indices*/,
+        const sofa::type::vector< Edge >& /*elems*/,
+        const sofa::type::vector< sofa::type::vector< EdgeID > >& /*ancestors*/,
+        const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
+
+    /** Method to update @sa d_vertexMass when a new Edge is removed.
+    * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when EDGESREMOVED event is fired.
+    */
+    void applyEdgeDestruction(const sofa::type::vector<EdgeID>& /*indices*/);
+
+
+    /** Method to update @sa d_vertexMass when a new Triangle is created.
+    * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when TRIANGLESADDED event is fired.
+    */
+    void applyTriangleCreation(const sofa::type::vector< TriangleID >& /*indices*/,
+        const sofa::type::vector< Triangle >& /*elems*/,
+        const sofa::type::vector< sofa::type::vector< TriangleID > >& /*ancestors*/,
+        const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
+
+    /** Method to update @sa d_vertexMass when a new Triangle is removed.
+    * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when TRIANGLESREMOVED event is fired.
+    */
+    void applyTriangleDestruction(const sofa::type::vector<TriangleID>& /*indices*/);
+
+
+    /** Method to update @sa d_vertexMass when a new Quad is created.
+    * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when QUADSADDED event is fired.
+    */
+    void applyQuadCreation(const sofa::type::vector< QuadID >& /*indices*/,
+        const sofa::type::vector< Quad >& /*elems*/,
+        const sofa::type::vector< sofa::type::vector< QuadID > >& /*ancestors*/,
+        const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
+
+    /** Method to update @sa d_vertexMass when a new Quad is removed.
+    * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when QUADSREMOVED event is fired.
+    */
+    void applyQuadDestruction(const sofa::type::vector<QuadID>& /*indices*/);
+    
+
+    /** Method to update @sa d_vertexMass when a new Tetrahedron is created.
+    * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when TETRAHEDRAADDED event is fired.
+    */
+    void applyTetrahedronCreation(const sofa::type::vector< TetrahedronID >& /*indices*/,
+        const sofa::type::vector< Tetrahedron >& /*elems*/,
+        const sofa::type::vector< sofa::type::vector< TetrahedronID > >& /*ancestors*/,
+        const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
+
+    /** Method to update @sa d_vertexMass when a new Tetrahedron is removed.
+    * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when TETRAHEDRAREMOVED event is fired.
+    */
+    void applyTetrahedronDestruction(const sofa::type::vector<TetrahedronID>& /*indices*/);
+
+
+    /** Method to update @sa d_vertexMass when a new Hexahedron is created.
+    * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when HEXAHEDRAADDED event is fired.
+    */
+    void applyHexahedronCreation(const sofa::type::vector< HexahedronID >& /*indices*/,
+        const sofa::type::vector< Hexahedron >& /*elems*/,
+        const sofa::type::vector< sofa::type::vector< HexahedronID > >& /*ancestors*/,
+        const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
+    
+    /** Method to update @sa d_vertexMass when a new Edge is removed.
+    * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when HEXAHEDRAREMOVED event is fired.
+    */
+    void applyHexahedronDestruction(const sofa::type::vector<HexahedronID>& /*indices*/);
 
 public:
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
@@ -110,7 +110,7 @@ void DiagonalMass<DataTypes,MassType>::applyEdgeCreation(const sofa::type::vecto
             totalMass += 2.0*mass;
         }
 
-        cleanTracker();
+        this->cleanTracker();
         printMass();
     }
 }
@@ -143,7 +143,7 @@ void DiagonalMass<DataTypes,MassType>::applyEdgeDestruction(const sofa::type::ve
             totalMass -= 2.0*mass;
         }
 
-        cleanTracker();
+        this->cleanTracker();
         printMass();
     }
 }
@@ -181,7 +181,7 @@ void DiagonalMass<DataTypes,MassType>::applyTriangleCreation(const sofa::type::v
             totalMass+= 3.0*mass;
         }
 
-        cleanTracker();
+        this->cleanTracker();
         printMass();
     }
 }
@@ -217,7 +217,7 @@ void DiagonalMass<DataTypes,MassType>::applyTriangleDestruction(const sofa::type
             totalMass -= 3.0 * mass;
         }
 
-        cleanTracker();
+        this->cleanTracker();
         printMass();
     }
 }
@@ -256,7 +256,7 @@ void DiagonalMass<DataTypes, MassType>::applyQuadCreation(const sofa::type::vect
             totalMass += 4.0 * mass;
         }
 
-        cleanTracker();
+        this->cleanTracker();
         printMass();
     }
 }
@@ -293,7 +293,7 @@ void DiagonalMass<DataTypes, MassType>::applyQuadDestruction(const sofa::type::v
             totalMass -= 4.0 * mass;
         }
 
-        cleanTracker();
+        this->cleanTracker();
         printMass();
     }
 }
@@ -334,7 +334,7 @@ void DiagonalMass<DataTypes,MassType>::applyTetrahedronCreation(const sofa::type
             totalMass += 4.0*mass;
         }
 
-        cleanTracker();
+        this->cleanTracker();
         printMass();
     }
 }
@@ -369,7 +369,7 @@ void DiagonalMass<DataTypes,MassType>::applyTetrahedronDestruction(const sofa::t
             totalMass -= 4.0*mass;
         }
 
-        cleanTracker();
+        this->cleanTracker();
         printMass();
     }
 }
@@ -406,7 +406,7 @@ void DiagonalMass<DataTypes,MassType>::applyHexahedronCreation(const sofa::type:
             totalMass += 8.0*mass;
         }
 
-        cleanTracker();
+        this->cleanTracker();
         printMass();
     }
 }
@@ -439,7 +439,7 @@ void DiagonalMass<DataTypes,MassType>::applyHexahedronDestruction(const sofa::ty
             totalMass -= 8.0*mass;
         }
 
-        cleanTracker();
+        this->cleanTracker();
         printMass();
     }
 }

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
@@ -76,6 +76,7 @@ void DiagonalMass<DataTypes,MassType>::applyPointDestruction(Index id, MassType&
     SOFA_UNUSED(id);
     helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
     totalMass -= VertexMass;
+    this->cleanTracker();
 }
 
 
@@ -1236,7 +1237,7 @@ template <class DataTypes, class MassType>
 bool DiagonalMass<DataTypes, MassType>::checkTotalMass()
 {
     //Check for negative or null value, if wrongly set use the default value totalMass = 1.0
-    if(d_totalMass.getValue() <= 0.0)
+    if(d_totalMass.getValue() < 0.0)
     {
         msg_warning() << "totalMass data can not have a negative value.\n"
                       << "To remove this warning, you need to set a strictly positive value to the totalMass data";
@@ -1278,7 +1279,7 @@ bool DiagonalMass<DataTypes, MassType>::checkVertexMass()
         //Check that the vertexMass vector has only strictly positive values
         for(size_t i=0; i<vertexMass.size(); i++)
         {
-            if(vertexMass[i]<=0)
+            if(vertexMass[i]<0)
             {
                 msg_warning() << "Negative value of vertexMass vector: vertexMass[" << i << "] = " << vertexMass[i];
                 return false;
@@ -1325,7 +1326,7 @@ bool DiagonalMass<DataTypes, MassType>::checkMassDensity()
     const Real &massDensity = d_massDensity.getValue();
 
     //Check that the massDensity is strictly positive
-    if(massDensity <= 0.0)
+    if(massDensity < 0.0)
     {
         msg_warning() << "Negative value of massDensity: massDensity = " << massDensity;
         return false;

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.h
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.h
@@ -237,187 +237,146 @@ public:
 
 
 protected:
+    /** Method to initialize @sa MassType when a new Point is created to compute mass coefficient matrix.
+    * Will be set as creation callback in the PointData @sa d_vertexMass
+    */
+    void applyVertexMassCreation(Index pointIndex, MassType& VertexMass,
+        const core::topology::BaseMeshTopology::Point& point,
+        const sofa::type::vector< Index >&,
+        const sofa::type::vector< double >&);
 
-    class VertexMassHandler : public topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point,MassVector>
-    {
-    public:
-        VertexMassHandler(MeshMatrixMass<DataTypes,TMassType>* _m, topology::PointData<type::vector<TMassType> >* _data) : topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point,type::vector<TMassType> >(_data), m(_m) {}
-
-        /// Mass initialization Creation Functions:
-        /// Vertex mass coefficient matrix creation function
-        void applyCreateFunction(Index pointIndex, TMassType & VertexMass,
-                const sofa::type::vector< Index > &,
-                const sofa::type::vector< double >&);
-
-        /// Apply removing 
-        void applyDestroyFunction(Index, TMassType&);
+    /** Method to update @sa d_vertexMass when a Point is removed.
+    * Will be set as destruction callback in the PointData @sa d_vertexMass
+    */
+    void applyVertexMassDestruction(Index, MassType&);
 
 
-        ///////////////////////// Functions on Triangles //////////////////////////////////////
+    /** Method to update @sa d_vertexMass using mass matrix coefficient when a new Triangle is created.
+    * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when TRIANGLESADDED event is fired.
+    */
+    void applyVertexMassTriangleCreation(const sofa::type::vector< Index >& triangleAdded,
+        const sofa::type::vector< core::topology::BaseMeshTopology::Triangle >& elems,
+        const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+        const sofa::type::vector< sofa::type::vector< double > >& coefs);
 
-        /// Mass coefficient Creation/Destruction functions for Triangular Mesh:
-        /// Vertex coefficient of mass matrix creation function to handle creation of new triangles
-        void applyTriangleCreation(const sofa::type::vector< Index >& triangleAdded,
-                const sofa::type::vector< core::topology::BaseMeshTopology::Triangle >& elems,
-                const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
-                const sofa::type::vector< sofa::type::vector< double > >& coefs);
-
-        /// Vertex coefficient of mass matrix destruction function to handle creation of new triangles
-        void applyTriangleDestruction(const sofa::type::vector<Index> & triangleRemoved);
-
-        using topology::TopologyDataHandler<core::topology::BaseMeshTopology::Point,MassVector>::ApplyTopologyChange;
-        /// Callback to add triangles elements.
-        void ApplyTopologyChange(const core::topology::TrianglesAdded* topoEvent);
-        /// Callback to remove triangles elements.
-        void ApplyTopologyChange(const core::topology::TrianglesRemoved* topoEvent);
+    /** Method to update @sa d_vertexMass using mass matrix coefficient when a Triangle is removed.
+    * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when TRIANGLESREMOVED event is fired.
+    */
+    void applyVertexMassTriangleDestruction(const sofa::type::vector<Index>& triangleRemoved);
 
 
-        ///////////////////////// Functions on Quads //////////////////////////////////////
+    /** Method to update @sa d_vertexMass using mass matrix coefficient when a new Quad is created.
+    * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when QUADSADDED event is fired.
+    */
+    void applyVertexMassQuadCreation(const sofa::type::vector< Index >& quadAdded,
+        const sofa::type::vector< core::topology::BaseMeshTopology::Quad >& elems,
+        const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+        const sofa::type::vector< sofa::type::vector< double > >& coefs);
 
-        /// Mass coefficient Creation/Destruction functions for Quad Mesh:
-        /// Vertex coefficient of mass matrix creation function to handle creation of new quads
-        void applyQuadCreation(const sofa::type::vector< Index >& quadAdded,
-                const sofa::type::vector< core::topology::BaseMeshTopology::Quad >& elems,
-                const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
-                const sofa::type::vector< sofa::type::vector< double > >& coefs);
-
-        /// Vertex coefficient of mass matrix destruction function to handle creation of new quads
-        void applyQuadDestruction(const sofa::type::vector<Index> & quadRemoved);
-
-        /// Callback to add quads elements.
-        void ApplyTopologyChange(const core::topology::QuadsAdded* topoEvent);
-        /// Callback to remove quads elements.
-        void ApplyTopologyChange(const core::topology::QuadsRemoved* topoEvent);
+    /** Method to update @sa d_vertexMass using mass matrix coefficient when a Quad is removed.
+    * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when QUADSREMOVED event is fired.
+    */
+    void applyVertexMassQuadDestruction(const sofa::type::vector<Index>& quadRemoved);
 
 
-        ///////////////////////// Functions on Tetrahedron //////////////////////////////////////
+    /** Method to update @sa d_vertexMass using mass matrix coefficient when a new Tetrahedron is created.
+    * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when TETRAHEDRAADDED event is fired.
+    */
+    void applyVertexMassTetrahedronCreation(const sofa::type::vector< Index >& tetrahedronAdded,
+        const sofa::type::vector< core::topology::BaseMeshTopology::Tetrahedron >& elems,
+        const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+        const sofa::type::vector< sofa::type::vector< double > >& coefs);
 
-        /// Mass coefficient Creation/Destruction functions for Tetrahedral Mesh:
-        /// Vertex coefficient of mass matrix creation function to handle creation of new tetrahedra
-        void applyTetrahedronCreation(const sofa::type::vector< Index >& tetrahedronAdded,
-                const sofa::type::vector< core::topology::BaseMeshTopology::Tetrahedron >& elems,
-                const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
-                const sofa::type::vector< sofa::type::vector< double > >& coefs);
+    /** Method to update @sa d_vertexMass using mass matrix coefficient when a Tetrahedron is removed.
+    * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when TETRAHEDRAREMOVED event is fired.
+    */
+    void applyVertexMassTetrahedronDestruction(const sofa::type::vector<Index>& tetrahedronRemoved);
 
-        /// Vertex coefficient of mass matrix destruction function to handle creation of new tetrahedra
-        void applyTetrahedronDestruction(const sofa::type::vector<Index> & tetrahedronRemoved);
+    
+    /** Method to update @sa d_vertexMass using mass matrix coefficient when a new Hexahedron is created.
+    * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when HEXAHEDRAADDED event is fired.
+    */
+    void applyVertexMassHexahedronCreation(const sofa::type::vector< Index >& hexahedronAdded,
+        const sofa::type::vector< core::topology::BaseMeshTopology::Hexahedron >& elems,
+        const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+        const sofa::type::vector< sofa::type::vector< double > >& coefs);
 
-        /// Callback to add tetrahedron elements.
-        void ApplyTopologyChange(const core::topology::TetrahedraAdded* topoEvent);
-        /// Callback to remove tetrahedron elements.
-        void ApplyTopologyChange(const core::topology::TetrahedraRemoved* topoEvent);
-
-
-        ///////////////////////// Functions on Hexahedron //////////////////////////////////////
-
-        /// Mass coefficient Creation/Destruction functions for Hexahedral Mesh:
-        /// Vertex coefficient of mass matrix creation function to handle creation of new hexahedra
-        void applyHexahedronCreation(const sofa::type::vector< Index >& hexahedronAdded,
-                const sofa::type::vector< core::topology::BaseMeshTopology::Hexahedron >& elems,
-                const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
-                const sofa::type::vector< sofa::type::vector< double > >& coefs);
-
-        /// Vertex coefficient of mass matrix destruction function to handle creation of new hexahedra
-        void applyHexahedronDestruction(const sofa::type::vector<Index> & hexahedronRemoved);
-
-        /// Callback to add hexahedron elements.
-        virtual void ApplyTopologyChange(const core::topology::HexahedraAdded* topoEvent);
-         /// Callback to remove hexahedron elements.
-        virtual void ApplyTopologyChange(const core::topology::HexahedraRemoved* topoEvent);
-
-    protected:
-        MeshMatrixMass<DataTypes,TMassType>* m;
-    };
-    VertexMassHandler* m_vertexMassHandler;
-
-    class EdgeMassHandler : public topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge,MassVector>
-    {
-    public:
-        EdgeMassHandler(MeshMatrixMass<DataTypes,TMassType>* _m, topology::EdgeData<type::vector<TMassType> >* _data) : topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge,type::vector<TMassType> >(_data), m(_m) {}
-
-        /// Edge mass coefficient matrix creation function
-        void applyCreateFunction(Index edgeIndex, MassType & EdgeMass,
-                const core::topology::BaseMeshTopology::Edge&,
-                const sofa::type::vector< Index > &,
-                const sofa::type::vector< double >&);
-
-        /// Apply removing 
-        void applyDestroyFunction(Index, MassType&);
-
-        using topology::TopologyDataHandler<core::topology::BaseMeshTopology::Edge,MassVector>::ApplyTopologyChange;
-
-        ///////////////////////// Functions on Triangles //////////////////////////////////////
-
-        /// Edge coefficient of mass matrix creation function to handle creation of new triangles
-        void applyTriangleCreation(const sofa::type::vector< Index >& triangleAdded,
-                const sofa::type::vector< core::topology::BaseMeshTopology::Triangle >& elems,
-                const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
-                const sofa::type::vector< sofa::type::vector< double > >& coefs);
-
-        /// Edge coefficient of mass matrix destruction function to handle creation of new triangles
-        void applyTriangleDestruction(const sofa::type::vector<Index> & triangleRemoved);
-
-        /// Callback to add triangles elements.
-        void ApplyTopologyChange(const core::topology::TrianglesAdded* topoEvent);
-        /// Callback to remove triangles elements.
-        void ApplyTopologyChange(const core::topology::TrianglesRemoved* topoEvent);
+    /** Method to update @sa d_vertexMass using mass matrix coefficient when a Hexahedron is removed.
+    * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when HEXAHEDRAREMOVED event is fired.
+    */
+    void applyVertexMassHexahedronDestruction(const sofa::type::vector<Index>& hexahedronRemoved);
+   
 
 
-        ///////////////////////// Functions on Quads //////////////////////////////////////
+    /** Method to initialize @sa MassType when a new Edge is created to compute mass coefficient matrix.
+    * Will be set as creation callback in the EdgeData @sa d_edgeMass
+    */
+    void applyEdgeMassCreation(Index edgeIndex, MassType& EdgeMass,
+        const core::topology::BaseMeshTopology::Edge&,
+        const sofa::type::vector< Index >&,
+        const sofa::type::vector< double >&);
 
-        /// Edge coefficient of mass matrix creation function to handle creation of new quads
-        void applyQuadCreation(const sofa::type::vector< Index >& quadAdded,
-                const sofa::type::vector< core::topology::BaseMeshTopology::Quad >& elems,
-                const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
-                const sofa::type::vector< sofa::type::vector< double > >& coefs);
+    /** Method to update @sa d_edgeMass when a Edge is removed.
+    * Will be set as destruction callback in the EdgeData @sa d_edgeMass
+    */
+    void applyEdgeMassDestruction(Index, MassType&);
 
-        /// Edge coefficient of mass matrix destruction function to handle creation of new quads
-        void applyQuadDestruction(const sofa::type::vector<Index> & quadRemoved);
+    
+    /** Method to update @sa d_edgeMass using mass matrix coefficient when a new Triangle is created.
+    * Will be set as callback in the EdgeData @sa d_edgeMass to update the mass vector when TRIANGLESADDED event is fired.
+    */
+    void applyEdgeMassTriangleCreation(const sofa::type::vector< Index >& triangleAdded,
+        const sofa::type::vector< core::topology::BaseMeshTopology::Triangle >& elems,
+        const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+        const sofa::type::vector< sofa::type::vector< double > >& coefs);
 
-        /// Callback to add quads elements.
-        void ApplyTopologyChange(const core::topology::QuadsAdded* topoEvent);
-        /// Callback to remove quads elements.
-        void ApplyTopologyChange(const core::topology::QuadsRemoved* topoEvent);
-
-
-        ///////////////////////// Functions on Tetrahedron //////////////////////////////////////
-
-        /// Edge coefficient of mass matrix creation function to handle creation of new tetrahedra
-        void applyTetrahedronCreation(const sofa::type::vector< Index >& tetrahedronAdded,
-                const sofa::type::vector< core::topology::BaseMeshTopology::Tetrahedron >& elems,
-                const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
-                const sofa::type::vector< sofa::type::vector< double > >& coefs);
-
-        /// Edge coefficient of mass matrix destruction function to handle creation of new tetrahedra
-        void applyTetrahedronDestruction(const sofa::type::vector<Index> & tetrahedronRemoved);
-
-        /// Callback to add tetrahedron elements.
-        void ApplyTopologyChange(const core::topology::TetrahedraAdded* topoEvent);
-        /// Callback to remove tetrahedron elements.
-        void ApplyTopologyChange(const core::topology::TetrahedraRemoved* topoEvent);
+    /** Method to update @sa d_edgeMass using mass matrix coefficient when a Triangle is removed.
+    * Will be set as callback in the EdgeData @sa d_edgeMass to update the mass vector when TRIANGLESREMOVED event is fired.
+    */
+    void applyEdgeMassTriangleDestruction(const sofa::type::vector<Index>& triangleRemoved);
 
 
-        ///////////////////////// Functions on Hexahedron //////////////////////////////////////
+    /** Method to update @sa d_edgeMass using mass matrix coefficient when a new Quad is created.
+    * Will be set as callback in the EdgeData @sa d_edgeMass to update the mass vector when QUADSADDED event is fired.
+    */
+    void applyEdgeMassQuadCreation(const sofa::type::vector< Index >& quadAdded,
+        const sofa::type::vector< core::topology::BaseMeshTopology::Quad >& elems,
+        const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+        const sofa::type::vector< sofa::type::vector< double > >& coefs);
 
-        /// Edge coefficient of mass matrix creation function to handle creation of new hexahedra
-        void applyHexahedronCreation(const sofa::type::vector< Index >& hexahedronAdded,
-                const sofa::type::vector< core::topology::BaseMeshTopology::Hexahedron >& elems,
-                const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
-                const sofa::type::vector< sofa::type::vector< double > >& coefs);
+    /** Method to update @sa d_edgeMass using mass matrix coefficient when a Quad is removed.
+    * Will be set as callback in the EdgeData @sa d_edgeMass to update the mass vector when QUADSREMOVED event is fired.
+    */
+    void applyEdgeMassQuadDestruction(const sofa::type::vector<Index>& quadRemoved);
 
-        /// Edge coefficient of mass matrix destruction function to handle creation of new hexahedra
-        void applyHexahedronDestruction(const sofa::type::vector<Index> & /*indices*/);
 
-        /// Callback to add hexahedron elements.
-        void ApplyTopologyChange(const core::topology::HexahedraAdded* topoEvent);
-         /// Callback to remove hexahedron elements.
-        void ApplyTopologyChange(const core::topology::HexahedraRemoved* topoEvent);
+    /** Method to update @sa d_edgeMass using mass matrix coefficient when a new Tetrahedron is created.
+    * Will be set as callback in the EdgeData @sa d_edgeMass to update the mass vector when TETRAHEDRAADDED event is fired.
+    */
+    void applyEdgeMassTetrahedronCreation(const sofa::type::vector< Index >& tetrahedronAdded,
+        const sofa::type::vector< core::topology::BaseMeshTopology::Tetrahedron >& elems,
+        const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+        const sofa::type::vector< sofa::type::vector< double > >& coefs);
 
-    protected:
-        MeshMatrixMass<DataTypes,TMassType>* m;
-    };
+    /** Method to update @sa d_edgeMass using mass matrix coefficient when a Tetrahedron is removed.
+    * Will be set as callback in the EdgeData @sa d_edgeMass to update the mass vector when TETRAHEDRAREMOVED event is fired.
+    */
+    void applyEdgeMassTetrahedronDestruction(const sofa::type::vector<Index>& tetrahedronRemoved);
 
-    EdgeMassHandler* m_edgeMassHandler;
+
+    /** Method to update @sa d_edgeMass using mass matrix coefficient when a new Hexahedron is created.
+    * Will be set as callback in the EdgeData @sa d_edgeMass to update the mass vector when HEXAHEDRAADDED event is fired.
+    */
+    void applyEdgeMassHexahedronCreation(const sofa::type::vector< Index >& hexahedronAdded,
+        const sofa::type::vector< core::topology::BaseMeshTopology::Hexahedron >& elems,
+        const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
+        const sofa::type::vector< sofa::type::vector< double > >& coefs);
+
+    /** Method to update @sa d_vertexMass using mass matrix coefficient when a Hexahedron is removed.
+    * Will be set as callback in the EdgeData @sa d_edgeMass to update the mass vector when HEXAHEDRAREMOVED event is fired.
+    */
+    void applyEdgeMassHexahedronDestruction(const sofa::type::vector<Index>& /*indices*/);
+
 
     sofa::core::topology::BaseMeshTopology* m_topology;
 };

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -1140,15 +1140,18 @@ void MeshMatrixMass<DataTypes, MassType>::initTopologyHandlers(sofa::core::topol
             applyVertexMassHexahedronDestruction(hRemove->getArray());
         });
 
-        d_edgeMass.linkToHexahedronDataArray();
-        d_edgeMass.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::HEXAHEDRAADDED, [this](const core::topology::TopologyChange* eventTopo) {
-            const core::topology::HexahedraAdded* hAdd = static_cast<const core::topology::HexahedraAdded*>(eventTopo);
-            applyEdgeMassHexahedronCreation(hAdd->getIndexArray(), hAdd->getElementArray(), hAdd->ancestorsList, hAdd->coefs);
-        });
-        d_edgeMass.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::HEXAHEDRAREMOVED, [this](const core::topology::TopologyChange* eventTopo) {
-            const core::topology::HexahedraRemoved* hRemove = static_cast<const core::topology::HexahedraRemoved*>(eventTopo);
-            applyEdgeMassHexahedronDestruction(hRemove->getArray());
-        });
+        if (!this->isLumped())
+        {
+            d_edgeMass.linkToHexahedronDataArray();
+            d_edgeMass.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::HEXAHEDRAADDED, [this](const core::topology::TopologyChange* eventTopo) {
+                const core::topology::HexahedraAdded* hAdd = static_cast<const core::topology::HexahedraAdded*>(eventTopo);
+                applyEdgeMassHexahedronCreation(hAdd->getIndexArray(), hAdd->getElementArray(), hAdd->ancestorsList, hAdd->coefs);
+            });
+            d_edgeMass.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::HEXAHEDRAREMOVED, [this](const core::topology::TopologyChange* eventTopo) {
+                const core::topology::HexahedraRemoved* hRemove = static_cast<const core::topology::HexahedraRemoved*>(eventTopo);
+                applyEdgeMassHexahedronDestruction(hRemove->getArray());
+            });
+        }
 
         hasQuads = true; // hexahedron imply quads
     }
@@ -1164,15 +1167,18 @@ void MeshMatrixMass<DataTypes, MassType>::initTopologyHandlers(sofa::core::topol
             applyVertexMassTetrahedronDestruction(tRemove->getArray());
         });
 
-        d_edgeMass.linkToTetrahedronDataArray();
-        d_edgeMass.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::TETRAHEDRAADDED, [this](const core::topology::TopologyChange* eventTopo) {
-            const core::topology::TetrahedraAdded* tAdd = static_cast<const core::topology::TetrahedraAdded*>(eventTopo);
-            applyEdgeMassTetrahedronCreation(tAdd->getIndexArray(), tAdd->getElementArray(), tAdd->ancestorsList, tAdd->coefs);
-        });
-        d_edgeMass.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::TETRAHEDRAREMOVED, [this](const core::topology::TopologyChange* eventTopo) {
-            const core::topology::TetrahedraRemoved* tRemove = static_cast<const core::topology::TetrahedraRemoved*>(eventTopo);
-            applyEdgeMassTetrahedronDestruction(tRemove->getArray());
-        });
+        if (!this->isLumped())
+        {
+            d_edgeMass.linkToTetrahedronDataArray();
+            d_edgeMass.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::TETRAHEDRAADDED, [this](const core::topology::TopologyChange* eventTopo) {
+                const core::topology::TetrahedraAdded* tAdd = static_cast<const core::topology::TetrahedraAdded*>(eventTopo);
+                applyEdgeMassTetrahedronCreation(tAdd->getIndexArray(), tAdd->getElementArray(), tAdd->ancestorsList, tAdd->coefs);
+            });
+            d_edgeMass.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::TETRAHEDRAREMOVED, [this](const core::topology::TopologyChange* eventTopo) {
+                const core::topology::TetrahedraRemoved* tRemove = static_cast<const core::topology::TetrahedraRemoved*>(eventTopo);
+                applyEdgeMassTetrahedronDestruction(tRemove->getArray());
+            });
+        }
 
         hasTriangles = true; // Tetrahedron imply triangles
     }
@@ -1189,15 +1195,18 @@ void MeshMatrixMass<DataTypes, MassType>::initTopologyHandlers(sofa::core::topol
             applyVertexMassQuadDestruction(qRemove->getArray());
         });
 
-        d_edgeMass.linkToQuadDataArray();
-        d_edgeMass.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::QUADSADDED, [this](const core::topology::TopologyChange* eventTopo) {
-            const core::topology::QuadsAdded* qAdd = static_cast<const core::topology::QuadsAdded*>(eventTopo);
-            applyEdgeMassQuadCreation(qAdd->getIndexArray(), qAdd->getElementArray(), qAdd->ancestorsList, qAdd->coefs);
-        });
-        d_edgeMass.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::QUADSREMOVED, [this](const core::topology::TopologyChange* eventTopo) {
-            const core::topology::QuadsRemoved* qRemove = static_cast<const core::topology::QuadsRemoved*>(eventTopo);
-            applyEdgeMassQuadDestruction(qRemove->getArray());
-        });
+        if (!this->isLumped())
+        {
+            d_edgeMass.linkToQuadDataArray();
+            d_edgeMass.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::QUADSADDED, [this](const core::topology::TopologyChange* eventTopo) {
+                const core::topology::QuadsAdded* qAdd = static_cast<const core::topology::QuadsAdded*>(eventTopo);
+                applyEdgeMassQuadCreation(qAdd->getIndexArray(), qAdd->getElementArray(), qAdd->ancestorsList, qAdd->coefs);
+            });
+            d_edgeMass.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::QUADSREMOVED, [this](const core::topology::TopologyChange* eventTopo) {
+                const core::topology::QuadsRemoved* qRemove = static_cast<const core::topology::QuadsRemoved*>(eventTopo);
+                applyEdgeMassQuadDestruction(qRemove->getArray());
+            });
+        }
     }
 
     if (topologyType == TopologyElementType::TRIANGLE || hasTriangles)
@@ -1212,15 +1221,18 @@ void MeshMatrixMass<DataTypes, MassType>::initTopologyHandlers(sofa::core::topol
             applyVertexMassTriangleDestruction(tRemove->getArray());
         });
 
-        d_edgeMass.linkToTriangleDataArray();
-        d_edgeMass.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::TRIANGLESADDED, [this](const core::topology::TopologyChange* eventTopo) {
-            const core::topology::TrianglesAdded* tAdd = static_cast<const core::topology::TrianglesAdded*>(eventTopo);
-            applyEdgeMassTriangleCreation(tAdd->getIndexArray(), tAdd->getElementArray(), tAdd->ancestorsList, tAdd->coefs);
-        });
-        d_edgeMass.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::TRIANGLESREMOVED, [this](const core::topology::TopologyChange* eventTopo) {
-            const core::topology::TrianglesRemoved* tRemove = static_cast<const core::topology::TrianglesRemoved*>(eventTopo);
-            applyEdgeMassTriangleDestruction(tRemove->getArray());
-        });
+        if (!this->isLumped())
+        {
+            d_edgeMass.linkToTriangleDataArray();
+            d_edgeMass.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::TRIANGLESADDED, [this](const core::topology::TopologyChange* eventTopo) {
+                const core::topology::TrianglesAdded* tAdd = static_cast<const core::topology::TrianglesAdded*>(eventTopo);
+                applyEdgeMassTriangleCreation(tAdd->getIndexArray(), tAdd->getElementArray(), tAdd->ancestorsList, tAdd->coefs);
+            });
+            d_edgeMass.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::TRIANGLESREMOVED, [this](const core::topology::TopologyChange* eventTopo) {
+                const core::topology::TrianglesRemoved* tRemove = static_cast<const core::topology::TrianglesRemoved*>(eventTopo);
+                applyEdgeMassTriangleDestruction(tRemove->getArray());
+            });
+        }
     }
 }
 

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -1514,7 +1514,7 @@ template <class DataTypes, class MassType>
 bool MeshMatrixMass<DataTypes, MassType>::checkTotalMass()
 {
     //Check for negative or null value, if wrongly set use the default value totalMass = 1.0
-    if(d_totalMass.getValue() <= 0.0)
+    if(d_totalMass.getValue() < 0.0)
     {
         msg_warning(this) << "totalMass data can not have a negative value.\n"
                           << "To remove this warning, you need to set a strictly positive value to the totalMass data";
@@ -1554,7 +1554,7 @@ bool MeshMatrixMass<DataTypes, MassType>::checkVertexMass()
         //Check that the vertexMass vector has only strictly positive values
         for(size_t i=0; i<vertexMass.size(); i++)
         {
-            if(vertexMass[i]<=0)
+            if(vertexMass[i]<0)
             {
                 msg_warning() << "Negative value of vertexMass vector: vertexMass[" << i << "] = " << vertexMass[i];
                 return false;
@@ -1611,7 +1611,7 @@ bool MeshMatrixMass<DataTypes, MassType>::checkEdgeMass()
         //Check that the vertexMass vector has only strictly positive values
         for(size_t i=0; i<edgeMass.size(); i++)
         {
-            if(edgeMass[i]<=0)
+            if(edgeMass[i]<0)
             {
                 msg_warning() << "Negative value of edgeMass vector: edgeMass[" << i << "] = " << edgeMass[i];
                 return false;
@@ -1718,7 +1718,7 @@ bool MeshMatrixMass<DataTypes, MassType>::checkMassDensity()
     if(massDensity.size() == 1)
     {
         //Check that the massDensity is strictly positive
-        if(density <= 0.0)
+        if(density < 0.0)
         {
             msg_warning() << "Negative value of massDensity: massDensity = " << density;
             return false;
@@ -1742,7 +1742,7 @@ bool MeshMatrixMass<DataTypes, MassType>::checkMassDensity()
         //Check that the massDensity has only strictly positive values
         for(size_t i=0; i<massDensity.size(); i++)
         {
-            if(massDensity[i]<=0)
+            if(massDensity[i]<0)
             {
                 msg_warning() << "Negative value of massDensity vector: massDensity[" << i << "] = " << massDensity[i];
                 return false;


### PR DESCRIPTION
Remove TopologyHandler instances in FEM and set topology callbacks directly using TopologyData thanks to PR #2375
Updated components:
- DiagonalMass
- MeshMatrixMass

Also fix DiagonalMass topological changes for Quad topology and update test which was wrong.




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
