### PR TITLE
[SofaSimulationGraph] Add a getCustomClassName to name DAGNode  as Node in the GUI.

### DIFF
--- a/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/DAGNode.h
+++ b/SofaKernel/modules/SofaSimulationGraph/src/SofaSimulationGraph/DAGNode.h
@@ -53,6 +53,8 @@ protected:
     virtual ~DAGNode() override;
 
 public:
+    static const std::string GetCustomClassName(){ return "Node"; }
+
     /// Pure Virtual method from Node
     virtual Node::SPtr createChild(const std::string& nodeName) override;
 


### PR DESCRIPTION
There is only one "Node" implemenation in Sofa so there is no need to expose internal details (saying it is "DAG") to the UI layer.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
