### PR TITLE
[SofaKernel] Change d_componentState when a message is received.

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -272,11 +272,13 @@ void Base::addMessage(const Message &m) const
         m_messageslog.pop_front();
     }
     m_messageslog.push_back(m) ;
+    d_componentState.setValue(d_componentState.getValue());
 }
 
 void Base::clearLoggedMessages() const
 {
    m_messageslog.clear() ;
+   d_componentState.setValue(d_componentState.getValue());
 }
 
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -494,7 +494,7 @@ public:
 
     Data< sofa::type::BoundingBox > f_bbox; ///< this object bounding box
 
-    Data< sofa::core::objectmodel::ComponentState >  d_componentState; ///< the object state
+    mutable Data< sofa::core::objectmodel::ComponentState >  d_componentState; ///< the object state
 
     SOFA_ATTRIBUTE_DISABLED__COMPONENTSTATE("To fix your code, use d_componentState")
     DeprecatedAndRemoved m_componentstate;


### PR DESCRIPTION

When new messages are received or the message log is clear the componentState is changed. 
This allows the GUI (or other component) to detect that the object has changed (because its message log grew up). 

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
