### PR TITLE
[runSofa] FIX UI problem related to messages.

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -272,11 +272,13 @@ void Base::addMessage(const Message &m) const
         m_messageslog.pop_front();
     }
     m_messageslog.push_back(m) ;
+    d_componentState.setValue(d_componentState.getValue());
 }
 
 void Base::clearLoggedMessages() const
 {
    m_messageslog.clear() ;
+   d_componentState.setValue(d_componentState.getValue());
 }
 
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -494,7 +494,7 @@ public:
 
     Data< sofa::type::BoundingBox > f_bbox; ///< this object bounding box
 
-    Data< sofa::core::objectmodel::ComponentState >  d_componentState; ///< the object state
+    mutable Data< sofa::core::objectmodel::ComponentState >  d_componentState; ///< the object state
 
     SOFA_ATTRIBUTE_DISABLED__COMPONENTSTATE("To fix your code, use d_componentState")
     DeprecatedAndRemoved m_componentstate;

--- a/modules/SofaGuiQt/src/sofa/gui/qt/GraphListenerQListView.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/GraphListenerQListView.h
@@ -39,12 +39,15 @@ using sofa::simulation::MutationListener;
 
 QPixmap* getPixmap(core::objectmodel::Base* obj, bool, bool,bool);
 
+class ObjectStateListener;
+
 class SOFA_SOFAGUIQT_API GraphListenerQListView : public MutationListener
 {
 public:
     //Q3ListView* widget;
     QTreeWidget* widget;
     bool frozen;
+    std::map<core::objectmodel::Base*, ObjectStateListener* > listeners;
     std::map<core::objectmodel::Base*, QTreeWidgetItem* > items;
     std::map<core::objectmodel::BaseData*, QTreeWidgetItem* > datas;
     std::multimap<QTreeWidgetItem *, QTreeWidgetItem*> nodeWithMultipleParents;
@@ -54,6 +57,7 @@ public:
     {
     }
 
+    ~GraphListenerQListView() override;
 
     /*****************************************************************************************************************/
     QTreeWidgetItem* createItem(QTreeWidgetItem* parent);
@@ -69,9 +73,9 @@ public:
     virtual void removeDatas(core::objectmodel::BaseObject* parent);
     virtual void freeze(Node* groot);
     virtual void unfreeze(Node* groot);
+
     core::objectmodel::Base* findObject(const QTreeWidgetItem* item);
     core::objectmodel::BaseData* findData(const QTreeWidgetItem* item);
-
 
     inline static QColor nameColor { 120, 120, 120};
 


### PR DESCRIPTION
This PR fix UI problem:
- the icon now display the correct icon (green for info message, yellow for warning and red for error) instead of a red sign all the time
- the icon was displayed at scene loading but not updated. This happens when using controllers that emits messages at simulation time. The result was that the treeview was out-of-date misleading the users. Using the feature introduced in #2397,  the state is now tracked to correctly report the message status with it is changed.  



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
