### PR TITLE
[SofaMeshCollision] Fix cmake generated config file

### DIFF
--- a/SofaKernel/modules/SofaMeshCollision/CMakeLists.txt
+++ b/SofaKernel/modules/SofaMeshCollision/CMakeLists.txt
@@ -47,7 +47,9 @@ set(SOURCE_FILES
     ${SOFAMESHCOLLISION_SRC}/TriangleModel.cpp
 )
 
-sofa_find_package(SofaBase REQUIRED) # SofaBaseMechanics SofaBaseCollision SofaBaseTopology
+sofa_find_package(SofaBaseMechanics REQUIRED)
+sofa_find_package(SofaBaseCollision REQUIRED)
+sofa_find_package(SofaBaseTopology REQUIRED)
 sofa_find_package(SofaObjectInteraction REQUIRED)
 sofa_find_package(SofaRigid REQUIRED)
 

--- a/SofaKernel/modules/SofaMeshCollision/SofaMeshCollisionConfig.cmake.in
+++ b/SofaKernel/modules/SofaMeshCollision/SofaMeshCollisionConfig.cmake.in
@@ -5,6 +5,7 @@
 
 find_package(SofaObjectInteraction QUIET REQUIRED)
 find_package(SofaRigid QUIET REQUIRED)
+find_package(SofaBase QUIET REQUIRED)
 
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/SofaKernel/modules/SofaMeshCollision/SofaMeshCollisionConfig.cmake.in
+++ b/SofaKernel/modules/SofaMeshCollision/SofaMeshCollisionConfig.cmake.in
@@ -3,9 +3,11 @@
 @PACKAGE_GUARD@
 @PACKAGE_INIT@
 
+find_package(SofaBaseMechanics QUIET REQUIRED)
+find_package(SofaBaseCollision QUIET REQUIRED)
+find_package(SofaBaseTopology QUIET REQUIRED)
 find_package(SofaObjectInteraction QUIET REQUIRED)
 find_package(SofaRigid QUIET REQUIRED)
-find_package(SofaBase QUIET REQUIRED)
 
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
One package was missing in the SofaMeshCollisionConfig.cmake.in, so out-of-tree projects using sofameshcollision are throwing error while doing the cmake config.

(allows to compile the plugin beamadapter out-of-tree)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
