### PR TITLE
[SofaCore] Remove unwanted logs in TopologyHandler.

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyHandler.cpp
@@ -58,8 +58,6 @@ void TopologyHandler::ApplyTopologyChanges(const std::list<const core::topology:
         core::topology::TopologyChangeType changeType = (*changeIt)->getChangeType();
         std::string topoChangeType = m_prefix + ": " + m_data_name + " - " + parseTopologyChangeTypeToString(changeType);
         sofa::helper::AdvancedTimer::stepBegin(topoChangeType);
-        dmsg_info("TopologyHandler") << topoChangeType;
-
 
         // New version using map of callback
         std::map < core::topology::TopologyChangeType, TopologyChangeCallback>::iterator itM;


### PR DESCRIPTION
I thought dmsg_info was only display in debug but this line is trolling the whole CI.
Remove this debugging info from normal execution. 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
