### PR TITLE
[SofaBaseMechanics] BarycentricMapping: Remove avoidable Sofa.BaseTopology dependencies

### DIFF
--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
@@ -22,15 +22,43 @@
 #pragma once
 
 #include <sofa/geometry/config.h>
+#include <cmath>
+#include <numeric>
 
 namespace sofa::geometry
 {
 
 struct Edge
 {
-    static const sofa::Size NumberOfNodes = 2;
+    static constexpr sofa::Size NumberOfNodes = 2;
 
     Edge() = default;
+
+    template<typename Node,
+        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
+        typename = std::enable_if_t<std::is_scalar_v<T>>>
+    static constexpr auto squaredLength(const Node & n0, const Node & n1)
+    {
+        const auto v = n1 - n0;
+        return std::inner_product(std::begin(v), std::end(v), std::begin(v), 0);
+    }
+
+    template<typename Node,
+        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
+        typename = std::enable_if_t<std::is_scalar_v<T>>>
+    static constexpr auto length(const Node & n0, const Node & n1)
+    {
+        return std::sqrt(computeSquaredLength(n0, n1));
+    }
+
+    template<typename Node,
+        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
+        typename = std::enable_if_t<std::is_scalar_v<T>>>
+    static constexpr auto center(const Node& n0, const Node& n1)
+    {
+        return std::transform(n0.begin(), n0.end(), n1.begin(), n0.begin(),
+            [](T c0, T c1) -> T { return (c0 + c1) / static_cast<T>(NumberOfNodes); });
+    }
 };
 
 } // namespace sofa::geometry

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
@@ -24,6 +24,8 @@
 #include <sofa/geometry/config.h>
 #include <cmath>
 #include <numeric>
+#include <iterator>
+#include <algorithm>
 
 namespace sofa::geometry
 {

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Hexahedron.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Hexahedron.h
@@ -26,6 +26,7 @@
 #include <sofa/type/Mat.h>
 #include <cmath>
 #include <numeric>
+#include <iterator>
 
 namespace sofa::geometry
 {

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Hexahedron.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Hexahedron.h
@@ -27,6 +27,7 @@
 #include <cmath>
 #include <numeric>
 #include <iterator>
+#include <array>
 
 namespace sofa::geometry
 {

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Hexahedron.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Hexahedron.h
@@ -95,7 +95,7 @@ struct Hexahedron
         }
         else
         {
-            Node returnResult{};
+            sofa::type::fixed_array<T, 3> returnResult{};
             std::copy_n(tmpResult.begin(), max_spatial_dimensions, returnResult.begin());
             return returnResult;
         }

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Hexahedron.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Hexahedron.h
@@ -22,15 +22,127 @@
 #pragma once
 
 #include <sofa/geometry/config.h>
+#include <sofa/type/fixed_array.h>
+#include <sofa/type/Mat.h>
+#include <cmath>
+#include <numeric>
 
 namespace sofa::geometry
 {
 
 struct Hexahedron
 {
-    static const sofa::Size NumberOfNodes = 8;
+    static constexpr sofa::Size NumberOfNodes = 8;
 
     Hexahedron() = default;
+
+    template<typename Node,
+        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
+        typename = std::enable_if_t<std::is_scalar_v<T>>
+    >
+        static constexpr auto center(const Node& n0, const Node& n1, const Node& n2, const Node& n3, 
+                                     const Node& n4, const Node& n5, const Node& n6, const Node& n7)
+    {
+        constexpr auto dimensions = sizeof(Node) / sizeof(T);
+        auto centerRes = n0;
+        for (auto i = 0; i < dimensions; i++)
+        {
+            centerRes[i] += n1[i] + n2[i] + n3[i] + n4[i] + n5[i] + n6[i] + n7[i];
+            centerRes[i] /= static_cast<T>(NumberOfNodes);
+        }
+
+        return centerRes;
+    }
+
+    template<typename Node,
+        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
+        typename = std::enable_if_t<std::is_scalar_v<T>>
+    >
+        static constexpr auto barycentricCoefficients(const Node& n0, const Node& n1, const Node& n2, const Node& n3,
+            const Node& n4, const Node& n5, const Node& n6, const Node& n7, const Node& pos)
+    {
+        SOFA_UNUSED(n2);
+        SOFA_UNUSED(n5);
+        SOFA_UNUSED(n6);
+        SOFA_UNUSED(n7);
+        constexpr sofa::Size dimensions = sizeof(Node) / sizeof(T);
+        constexpr auto max_spatial_dimensions = std::min(3u, dimensions);
+
+        sofa::type::Vec<3, T> origin, p1, p3, p4, pnt;
+
+        for (unsigned int w = 0; w < max_spatial_dimensions; ++w)
+        {
+            origin[w] = n0[w];
+            p1[w] = n1[w];
+            p3[w] = n3[w];
+            p4[w] = n4[w];
+            pnt[w] = pos[w];
+        }
+
+        sofa::type::Mat<3,3,T> m, mt, base;
+        m[0] = p1 - origin;
+        m[1] = p3 - origin;
+        m[2] = p4 - origin;
+        mt.transpose(m);
+        const bool canInvert = base.invert(mt);
+        assert(canInvert);
+        SOFA_UNUSED(canInvert);
+        const auto tmpResult = base * (pnt - origin);
+
+        if constexpr (std::is_same_v<decltype(tmpResult), Node>)
+        {
+            return tmpResult;
+        }
+        else
+        {
+            Node returnResult{};
+            std::copy_n(tmpResult.begin(), max_spatial_dimensions, returnResult.begin());
+            return returnResult;
+        }
+    }
+
+    template<typename Node,
+        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
+        typename = std::enable_if_t<std::is_scalar_v<T>>
+    >
+        static constexpr auto distanceTo(const Node& n0, const Node& n1, const Node& n2, const Node& n3,
+            const Node& n4, const Node& n5, const Node& n6, const Node& n7, const Node& pos)
+    {
+        const auto& v = barycentricCoefficients(n0,n1,n2,n3,n4,n5,n6,n7, pos);
+
+        T d = std::max(std::max(-v[0], -v[1]), std::max(std::max(-v[2], v[0] - 1), std::max(v[1] - static_cast<T>(1), v[2] - static_cast<T>(1))));
+
+        if (d > 0)
+            d = (pos - center(n0, n1, n2, n3, n4, n5, n6, n7)).norm2();
+
+        return d;
+    }
+
+    template<typename Node,
+        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
+        typename = std::enable_if_t<std::is_scalar_v<T>>
+    >
+    static constexpr auto getPositionFromBarycentricCoefficients(const Node& n0, const Node& n1, const Node& n2, const Node& n3,
+            const Node& n4, const Node& n5, const Node& n6, const Node& n7, const std::array<SReal, 3>& baryC)
+    {
+        const auto fx = baryC[0];
+        const auto fy = baryC[1];
+        const auto fz = baryC[2];
+
+        const auto pos = n0 * ((1 - fx) * (1 - fy) * (1 - fz))
+            + n1 * ((fx) * (1 - fy) * (1 - fz))
+            + n3 * ((1 - fx) * (fy) * (1 - fz))
+            + n2 * ((fx) * (fy) * (1 - fz))
+            + n4 * ((1 - fx) * (1 - fy) * (fz))
+            + n5 * ((fx) * (1 - fy) * (fz))
+            + n7 * ((1 - fx) * (fy) * (fz))
+            + n6 * ((fx) * (fy) * (fz));
+
+        return pos;
+    }
+
+    
+
 };
 
 } // namespace sofa::geometry

--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Hexahedron.h
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Hexahedron.h
@@ -30,5 +30,38 @@ namespace sofa::topology
 {
     using Hexahedron = sofa::topology::Element<sofa::geometry::Hexahedron>;
 
+    template<typename Coordinates>
+    static constexpr sofa::Index getClosest(const sofa::type::vector<Coordinates>& positions, const sofa::type::vector<Hexahedron>& hexahedra,
+        const Coordinates& pos, Coordinates& baryC, SReal& distance)
+    {
+        sofa::Index index = sofa::InvalidID;
+        distance = std::numeric_limits<SReal>::max();
+
+        for (sofa::Index c = 0; c < hexahedra.size(); ++c)
+        {
+            const auto& h = hexahedra[c];
+            const auto d = sofa::geometry::Hexahedron::distanceTo(positions[h[0]], positions[h[1]], positions[h[2]], positions[h[3]],
+                positions[h[4]], positions[h[5]], positions[h[6]], positions[h[7]],
+                pos);
+
+            if (d < distance)
+            {
+                distance = d;
+                index = c;
+            }
+        }
+
+        if (index != sofa::InvalidID)
+        {
+            const auto& h = hexahedra[index];
+            baryC = sofa::geometry::Hexahedron::barycentricCoefficients(positions[h[0]], positions[h[1]], positions[h[2]], positions[h[3]],
+                positions[h[4]], positions[h[5]], positions[h[6]], positions[h[7]], pos);
+        }
+
+        return index;
+    }
+
     static constexpr Hexahedron InvalidHexahedron;
+
+   
 }

--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Hexahedron.h
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Hexahedron.h
@@ -30,9 +30,9 @@ namespace sofa::topology
 {
     using Hexahedron = sofa::topology::Element<sofa::geometry::Hexahedron>;
 
-    template<typename Coordinates>
-    static constexpr sofa::Index getClosestHexahedronIndex(const sofa::type::vector<Coordinates>& hexahedronPositions, const sofa::type::vector<Hexahedron>& hexahedra,
-        const Coordinates& pos, Coordinates& barycentricCoefficients, SReal& distance)
+    template<typename Coordinates, typename VectorCoordinates>
+    static constexpr sofa::Index getClosestHexahedronIndex(const VectorCoordinates& hexahedronPositions, const sofa::type::vector<Hexahedron>& hexahedra,
+        const Coordinates& pos, sofa::type::fixed_array<SReal,3>& barycentricCoefficients, SReal& distance)
     {
         sofa::Index index = sofa::InvalidID;
         distance = std::numeric_limits<SReal>::max();

--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Hexahedron.h
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Hexahedron.h
@@ -31,8 +31,8 @@ namespace sofa::topology
     using Hexahedron = sofa::topology::Element<sofa::geometry::Hexahedron>;
 
     template<typename Coordinates>
-    static constexpr sofa::Index getClosest(const sofa::type::vector<Coordinates>& positions, const sofa::type::vector<Hexahedron>& hexahedra,
-        const Coordinates& pos, Coordinates& baryC, SReal& distance)
+    static constexpr sofa::Index getClosestHexahedronIndex(const sofa::type::vector<Coordinates>& hexahedronPositions, const sofa::type::vector<Hexahedron>& hexahedra,
+        const Coordinates& pos, Coordinates& barycentricCoefficients, SReal& distance)
     {
         sofa::Index index = sofa::InvalidID;
         distance = std::numeric_limits<SReal>::max();
@@ -40,8 +40,8 @@ namespace sofa::topology
         for (sofa::Index c = 0; c < hexahedra.size(); ++c)
         {
             const auto& h = hexahedra[c];
-            const auto d = sofa::geometry::Hexahedron::distanceTo(positions[h[0]], positions[h[1]], positions[h[2]], positions[h[3]],
-                positions[h[4]], positions[h[5]], positions[h[6]], positions[h[7]],
+            const auto d = sofa::geometry::Hexahedron::distanceTo(hexahedronPositions[h[0]], hexahedronPositions[h[1]], hexahedronPositions[h[2]], hexahedronPositions[h[3]],
+                hexahedronPositions[h[4]], hexahedronPositions[h[5]], hexahedronPositions[h[6]], hexahedronPositions[h[7]],
                 pos);
 
             if (d < distance)
@@ -54,8 +54,8 @@ namespace sofa::topology
         if (index != sofa::InvalidID)
         {
             const auto& h = hexahedra[index];
-            baryC = sofa::geometry::Hexahedron::barycentricCoefficients(positions[h[0]], positions[h[1]], positions[h[2]], positions[h[3]],
-                positions[h[4]], positions[h[5]], positions[h[6]], positions[h[7]], pos);
+            barycentricCoefficients = sofa::geometry::Hexahedron::barycentricCoefficients(hexahedronPositions[h[0]], hexahedronPositions[h[1]], hexahedronPositions[h[2]], hexahedronPositions[h[3]],
+                hexahedronPositions[h[4]], hexahedronPositions[h[5]], hexahedronPositions[h[6]], hexahedronPositions[h[7]], pos);
         }
 
         return index;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperEdgeSetTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperEdgeSetTopology.h
@@ -21,8 +21,6 @@
 ******************************************************************************/
 #pragma once
 #include <SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h>
-#include <SofaBaseTopology/EdgeSetTopologyContainer.h>
-
 
 namespace sofa::component::mapping
 {
@@ -31,7 +29,7 @@ using sofa::type::Mat3x3d;
 using sofa::type::Vector3;
 typedef typename sofa::core::topology::BaseMeshTopology::Edge Edge;
 
-/////// Class allowing barycentric mapping computation on a EdgeSetTopology
+/////// Class allowing barycentric mapping computation on a BaseMeshTopology with edges
 template<class In, class Out>
 class BarycentricMapperEdgeSetTopology : public BarycentricMapperTopologyContainer<In,Out,typename BarycentricMapper<In,Out>::MappingData1D,Edge>
 {
@@ -49,15 +47,15 @@ public:
     {
         SOFA_UNUSED(out);
         SOFA_UNUSED(in);
-        msg_warning() << "BarycentricMapping not implemented for EdgeSetTopologyContainer.";
+        msg_warning() << "BarycentricMapping not implemented for Topologies with edges.";
     }
     Index addPointInLine(const Index edgeIndex, const SReal* baryCoords) override;
     Index createPointInLine(const typename Out::Coord& p, Index edgeIndex, const typename In::VecCoord* points) override;
 
 
 protected:
-    BarycentricMapperEdgeSetTopology(topology::EdgeSetTopologyContainer* fromTopology,
-                                     topology::PointSetTopologyContainer* toTopology);
+    BarycentricMapperEdgeSetTopology(sofa::core::topology::BaseMeshTopology* fromTopology,
+        sofa::core::topology::BaseMeshTopology* toTopology);
 
     ~BarycentricMapperEdgeSetTopology() override {}
 
@@ -68,8 +66,6 @@ protected:
     void computeCenter(Vector3& center, const typename In::VecCoord& in, const Edge& element) override;
     void computeDistance(double& d, const Vector3& v) override;
     void addPointInElement(const Index elementIndex, const SReal* baryCoords) override;
-
-    topology::EdgeSetTopologyContainer*	m_fromContainer;
 
     using Inherit1::d_map;
     using Inherit1::m_fromTopology;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperEdgeSetTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperEdgeSetTopology.h
@@ -54,10 +54,10 @@ public:
 
 
 protected:
-    BarycentricMapperEdgeSetTopology(sofa::core::topology::BaseMeshTopology* fromTopology,
+    BarycentricMapperEdgeSetTopology(sofa::core::topology::TopologyContainer* fromTopology,
         sofa::core::topology::BaseMeshTopology* toTopology);
 
-    ~BarycentricMapperEdgeSetTopology() override {}
+    ~BarycentricMapperEdgeSetTopology() override = default;
 
     virtual type::vector<Edge> getElements() override;
     virtual type::vector<SReal> getBaryCoef(const Real* f) override;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperEdgeSetTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperEdgeSetTopology.h
@@ -21,7 +21,6 @@
 ******************************************************************************/
 #pragma once
 #include <SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h>
-#include <SofaBaseTopology/EdgeSetGeometryAlgorithms.h>
 #include <SofaBaseTopology/EdgeSetTopologyContainer.h>
 
 
@@ -71,7 +70,6 @@ protected:
     void addPointInElement(const Index elementIndex, const SReal* baryCoords) override;
 
     topology::EdgeSetTopologyContainer*	m_fromContainer;
-    topology::EdgeSetGeometryAlgorithms<In>* m_fromGeomAlgo;
 
     using Inherit1::d_map;
     using Inherit1::m_fromTopology;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperEdgeSetTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperEdgeSetTopology.inl
@@ -26,10 +26,9 @@ namespace sofa::component::mapping
 {
 
 template <class In, class Out>
-BarycentricMapperEdgeSetTopology<In,Out>::BarycentricMapperEdgeSetTopology(topology::EdgeSetTopologyContainer* fromTopology,
-                                                                   topology::PointSetTopologyContainer* toTopology)
-    : Inherit1(fromTopology, toTopology),
-      m_fromContainer(fromTopology)
+BarycentricMapperEdgeSetTopology<In,Out>::BarycentricMapperEdgeSetTopology(sofa::core::topology::BaseMeshTopology* fromTopology,
+    sofa::core::topology::BaseMeshTopology* toTopology)
+    : Inherit1(fromTopology, toTopology)
 {}
 
 template <class In, class Out>

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperEdgeSetTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperEdgeSetTopology.inl
@@ -26,7 +26,7 @@ namespace sofa::component::mapping
 {
 
 template <class In, class Out>
-BarycentricMapperEdgeSetTopology<In,Out>::BarycentricMapperEdgeSetTopology(sofa::core::topology::BaseMeshTopology* fromTopology,
+BarycentricMapperEdgeSetTopology<In,Out>::BarycentricMapperEdgeSetTopology(sofa::core::topology::TopologyContainer* fromTopology,
     sofa::core::topology::BaseMeshTopology* toTopology)
     : Inherit1(fromTopology, toTopology)
 {}

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperEdgeSetTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperEdgeSetTopology.inl
@@ -29,8 +29,7 @@ template <class In, class Out>
 BarycentricMapperEdgeSetTopology<In,Out>::BarycentricMapperEdgeSetTopology(topology::EdgeSetTopologyContainer* fromTopology,
                                                                    topology::PointSetTopologyContainer* toTopology)
     : Inherit1(fromTopology, toTopology),
-      m_fromContainer(fromTopology),
-      m_fromGeomAlgo(nullptr)
+      m_fromContainer(fromTopology)
 {}
 
 template <class In, class Out>

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.h
@@ -64,12 +64,11 @@ public:
 
 protected:
     BarycentricMapperHexahedronSetTopology();
-    BarycentricMapperHexahedronSetTopology(topology::HexahedronSetTopologyContainer* fromTopology,
-                                           topology::PointSetTopologyContainer* toTopology);
+    BarycentricMapperHexahedronSetTopology(core::topology::BaseMeshTopology* fromTopology,
+        core::topology::BaseMeshTopology* toTopology);
 
-    void setTopology(topology::HexahedronSetTopologyContainer* topology);
+    void setTopology(core::topology::BaseMeshTopology* topology);
 
-    topology::HexahedronSetTopologyContainer*		m_fromContainer {nullptr};
     std::set<Index> m_invalidIndex;
 
     using Inherit1::d_map;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.h
@@ -22,7 +22,6 @@
 #pragma once
 #include <SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h>
 #include <SofaBaseTopology/HexahedronSetTopologyContainer.h>
-#include <SofaBaseTopology/HexahedronSetGeometryAlgorithms.h>
 
 namespace sofa::component::mapping
 {
@@ -71,7 +70,6 @@ protected:
     void setTopology(topology::HexahedronSetTopologyContainer* topology);
 
     topology::HexahedronSetTopologyContainer*		m_fromContainer {nullptr};
-    topology::HexahedronSetGeometryAlgorithms<In>*	m_fromGeomAlgo  {nullptr};
     std::set<Index> m_invalidIndex;
 
     using Inherit1::d_map;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.h
@@ -47,7 +47,7 @@ public:
 
     typedef typename Inherit1::Real Real;
 
-    ~BarycentricMapperHexahedronSetTopology() override ;
+    ~BarycentricMapperHexahedronSetTopology() override = default;
     virtual type::vector<Hexahedron> getElements() override;
     virtual type::vector<SReal> getBaryCoef(const Real* f) override;
     type::vector<SReal> getBaryCoef(const Real fx, const Real fy, const Real fz);
@@ -63,10 +63,10 @@ public:
 
 protected:
     BarycentricMapperHexahedronSetTopology();
-    BarycentricMapperHexahedronSetTopology(core::topology::BaseMeshTopology* fromTopology,
+    BarycentricMapperHexahedronSetTopology(sofa::core::topology::TopologyContainer* fromTopology,
         core::topology::BaseMeshTopology* toTopology);
 
-    void setTopology(core::topology::BaseMeshTopology* topology);
+    void setTopology(sofa::core::topology::TopologyContainer* topology);
 
     std::set<Index> m_invalidIndex;
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.h
@@ -21,7 +21,6 @@
 ******************************************************************************/
 #pragma once
 #include <SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h>
-#include <SofaBaseTopology/HexahedronSetTopologyContainer.h>
 
 namespace sofa::component::mapping
 {

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.inl
@@ -30,15 +30,13 @@ namespace sofa::component::mapping
 
 template <class In, class Out>
 BarycentricMapperHexahedronSetTopology<In,Out>::BarycentricMapperHexahedronSetTopology()
-    : Inherit1(nullptr, nullptr),
-      m_fromContainer(nullptr)
+    : Inherit1(nullptr, nullptr)
 {}
 
 template <class In, class Out>
-BarycentricMapperHexahedronSetTopology<In,Out>::BarycentricMapperHexahedronSetTopology(topology::HexahedronSetTopologyContainer* fromTopology,
-                                                                                       topology::PointSetTopologyContainer* toTopology)
-    : Inherit1(fromTopology, toTopology),
-      m_fromContainer(fromTopology)
+BarycentricMapperHexahedronSetTopology<In,Out>::BarycentricMapperHexahedronSetTopology(core::topology::BaseMeshTopology* fromTopology,
+    core::topology::BaseMeshTopology* toTopology)
+    : Inherit1(fromTopology, toTopology)
 {}
 
 template <class In, class Out>
@@ -46,10 +44,9 @@ BarycentricMapperHexahedronSetTopology<In,Out>::~BarycentricMapperHexahedronSetT
 {}
 
 template <class In, class Out>
-void BarycentricMapperHexahedronSetTopology<In,Out>::setTopology(topology::HexahedronSetTopologyContainer* topology)
+void BarycentricMapperHexahedronSetTopology<In,Out>::setTopology(core::topology::BaseMeshTopology* topology)
 {
     m_fromTopology  = topology;
-    m_fromContainer = topology;
 }
 
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.inl
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 #include <SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.h>
+#include <sofa/core/behavior/MechanicalState.h>
 
 #include <array>
 
@@ -30,16 +31,14 @@ namespace sofa::component::mapping
 template <class In, class Out>
 BarycentricMapperHexahedronSetTopology<In,Out>::BarycentricMapperHexahedronSetTopology()
     : Inherit1(nullptr, nullptr),
-      m_fromContainer(nullptr),
-      m_fromGeomAlgo(nullptr)
+      m_fromContainer(nullptr)
 {}
 
 template <class In, class Out>
 BarycentricMapperHexahedronSetTopology<In,Out>::BarycentricMapperHexahedronSetTopology(topology::HexahedronSetTopologyContainer* fromTopology,
                                                                                        topology::PointSetTopologyContainer* toTopology)
     : Inherit1(fromTopology, toTopology),
-      m_fromContainer(fromTopology),
-      m_fromGeomAlgo(nullptr)
+      m_fromContainer(fromTopology)
 {}
 
 template <class In, class Out>

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.inl
@@ -213,13 +213,13 @@ void BarycentricMapperHexahedronSetTopology<In,Out>::handleTopologyChange(core::
                             else
                             {
                                 const typename MechanicalStateT::VecCoord& outXto0 = (mState->read(core::ConstVecCoordId::restPosition())->getValue());
-                                index = sofa::topology::getClosest(inRestPos, m_fromTopology->getHexahedra(), Out::getCPos(outXto0[j]), coefs, distance);
+                                index = sofa::topology::getClosestHexahedronIndex(inRestPos, m_fromTopology->getHexahedra(), Out::getCPos(outXto0[j]), coefs, distance);
                             }
                         }
                         else
                         {
 
-                            index = sofa::topology::getClosest(inRestPos, m_fromTopology->getHexahedra(), pos, coefs, distance);
+                            index = sofa::topology::getClosestHexahedronIndex(inRestPos, m_fromTopology->getHexahedra(), pos, coefs, distance);
                         }
 
                         if ( index != sofa::InvalidID )

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.inl
@@ -186,14 +186,14 @@ void BarycentricMapperHexahedronSetTopology<In,Out>::handleTopologyChange(core::
                     const auto j = *iter;
                     if ( mapData[j].in_index == sofa::InvalidID ) // compute new mapping
                     {
-                        Vector3 coefs;
+                        sofa::type::fixed_array<SReal, 3> coefs;
                         typename In::Coord pos;
                         pos[0] = mapData[j].baryCoords[0];
                         pos[1] = mapData[j].baryCoords[1];
                         pos[2] = mapData[j].baryCoords[2];
 
                         // find nearest cell and barycentric coords
-                        Real distance = 1e10;
+                        SReal distance = 1e10;
 
                         Index index = sofa::InvalidID;
                         // When smoothing a mesh, the element has to be found using the rest position of the point. Then, its position is set using this element.
@@ -213,7 +213,8 @@ void BarycentricMapperHexahedronSetTopology<In,Out>::handleTopologyChange(core::
                             else
                             {
                                 const typename MechanicalStateT::VecCoord& outXto0 = (mState->read(core::ConstVecCoordId::restPosition())->getValue());
-                                index = sofa::topology::getClosestHexahedronIndex(inRestPos, m_fromTopology->getHexahedra(), Out::getCPos(outXto0[j]), coefs, distance);
+                                const decltype(inRestPos[0])& outRestPos = Out::getCPos(outXto0[j]); //decltype stuff is to force the same type of coordinates between in and out
+                                index = sofa::topology::getClosestHexahedronIndex(inRestPos, m_fromTopology->getHexahedra(), outRestPos, coefs, distance);
                             }
                         }
                         else

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.inl
@@ -34,17 +34,13 @@ BarycentricMapperHexahedronSetTopology<In,Out>::BarycentricMapperHexahedronSetTo
 {}
 
 template <class In, class Out>
-BarycentricMapperHexahedronSetTopology<In,Out>::BarycentricMapperHexahedronSetTopology(core::topology::BaseMeshTopology* fromTopology,
+BarycentricMapperHexahedronSetTopology<In,Out>::BarycentricMapperHexahedronSetTopology(sofa::core::topology::TopologyContainer* fromTopology,
     core::topology::BaseMeshTopology* toTopology)
     : Inherit1(fromTopology, toTopology)
 {}
 
 template <class In, class Out>
-BarycentricMapperHexahedronSetTopology<In,Out>::~BarycentricMapperHexahedronSetTopology()
-{}
-
-template <class In, class Out>
-void BarycentricMapperHexahedronSetTopology<In,Out>::setTopology(core::topology::BaseMeshTopology* topology)
+void BarycentricMapperHexahedronSetTopology<In,Out>::setTopology(sofa::core::topology::TopologyContainer* topology)
 {
     m_fromTopology  = topology;
 }

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperMeshTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperMeshTopology.h
@@ -89,7 +89,7 @@ public:
 
 protected:
     BarycentricMapperMeshTopology(core::topology::BaseMeshTopology* fromTopology,
-                                  topology::PointSetTopologyContainer* toTopology) ;
+        core::topology::BaseMeshTopology* toTopology) ;
 
     sofa::type::vector< MappingData1D >  m_map1d;
     sofa::type::vector< MappingData2D >  m_map2d;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperMeshTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperMeshTopology.inl
@@ -21,6 +21,8 @@
 ******************************************************************************/
 #pragma once
 #include <SofaBaseMechanics/BarycentricMappers/BarycentricMapperMeshTopology.h>
+
+#include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/State.h>
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperMeshTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperMeshTopology.inl
@@ -50,7 +50,7 @@ typedef typename sofa::core::topology::BaseMeshTopology::SeqHexahedra SeqHexahed
 
 template <class In, class Out>
 BarycentricMapperMeshTopology<In,Out>::BarycentricMapperMeshTopology(core::topology::BaseMeshTopology* fromTopology,
-        topology::PointSetTopologyContainer* toTopology)
+    core::topology::BaseMeshTopology* toTopology)
     : TopologyBarycentricMapper<In,Out>(fromTopology, toTopology),
       m_matrixJ(nullptr), m_updateJ(true)
 {

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperQuadSetTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperQuadSetTopology.h
@@ -21,7 +21,6 @@
 ******************************************************************************/
 #pragma once
 #include <SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h>
-#include <SofaBaseTopology/QuadSetGeometryAlgorithms.h>
 #include <SofaBaseTopology/QuadSetTopologyContainer.h>
 
 namespace sofa::component::mapping
@@ -63,7 +62,6 @@ protected:
     void addPointInElement(const Index elementIndex, const SReal* baryCoords) override;
 
     topology::QuadSetTopologyContainer*			m_fromContainer;
-    topology::QuadSetGeometryAlgorithms<In>*	m_fromGeomAlgo;
 
     using Inherit1::d_map;
     using Inherit1::m_fromTopology;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperQuadSetTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperQuadSetTopology.h
@@ -47,9 +47,9 @@ public:
     Index addPointInQuad(const Index index, const SReal* baryCoords) override;
     Index createPointInQuad(const typename Out::Coord& p, Index index, const typename In::VecCoord* points) override;
 
-    virtual ~BarycentricMapperQuadSetTopology();
+    ~BarycentricMapperQuadSetTopology() override = default;
 protected:
-    BarycentricMapperQuadSetTopology(core::topology::BaseMeshTopology* fromTopology,
+    BarycentricMapperQuadSetTopology(sofa::core::topology::TopologyContainer* fromTopology,
         core::topology::BaseMeshTopology* toTopology);
 
     virtual type::vector<Quad> getElements() override;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperQuadSetTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperQuadSetTopology.h
@@ -21,7 +21,6 @@
 ******************************************************************************/
 #pragma once
 #include <SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h>
-#include <SofaBaseTopology/QuadSetTopologyContainer.h>
 
 namespace sofa::component::mapping
 {
@@ -50,8 +49,8 @@ public:
 
     virtual ~BarycentricMapperQuadSetTopology();
 protected:
-    BarycentricMapperQuadSetTopology(topology::QuadSetTopologyContainer* fromTopology,
-                                     topology::PointSetTopologyContainer* toTopology);
+    BarycentricMapperQuadSetTopology(core::topology::BaseMeshTopology* fromTopology,
+        core::topology::BaseMeshTopology* toTopology);
 
     virtual type::vector<Quad> getElements() override;
     virtual type::vector<SReal> getBaryCoef(const Real* f) override;
@@ -60,8 +59,6 @@ protected:
     void computeCenter(Vector3& center, const typename In::VecCoord& in, const Quad& element) override;
     void computeDistance(double& d, const Vector3& v) override;
     void addPointInElement(const Index elementIndex, const SReal* baryCoords) override;
-
-    topology::QuadSetTopologyContainer*			m_fromContainer;
 
     using Inherit1::d_map;
     using Inherit1::m_fromTopology;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperQuadSetTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperQuadSetTopology.inl
@@ -26,15 +26,10 @@ namespace sofa::component::mapping
 {
 
 template <class In, class Out>
-BarycentricMapperQuadSetTopology<In,Out>::BarycentricMapperQuadSetTopology(core::topology::BaseMeshTopology* fromTopology,
+BarycentricMapperQuadSetTopology<In,Out>::BarycentricMapperQuadSetTopology(sofa::core::topology::TopologyContainer* fromTopology,
     core::topology::BaseMeshTopology* toTopology)
     : Inherit1(fromTopology, toTopology)
 {}
-
-template <class In, class Out>
-BarycentricMapperQuadSetTopology<In,Out>::~BarycentricMapperQuadSetTopology()
-{}
-
 
 template <class In, class Out>
 typename BarycentricMapperQuadSetTopology<In, Out>::Index  

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperQuadSetTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperQuadSetTopology.inl
@@ -26,10 +26,9 @@ namespace sofa::component::mapping
 {
 
 template <class In, class Out>
-BarycentricMapperQuadSetTopology<In,Out>::BarycentricMapperQuadSetTopology(topology::QuadSetTopologyContainer* fromTopology,
-                                                                           topology::PointSetTopologyContainer* toTopology)
-    : Inherit1(fromTopology, toTopology),
-      m_fromContainer(fromTopology)
+BarycentricMapperQuadSetTopology<In,Out>::BarycentricMapperQuadSetTopology(core::topology::BaseMeshTopology* fromTopology,
+    core::topology::BaseMeshTopology* toTopology)
+    : Inherit1(fromTopology, toTopology)
 {}
 
 template <class In, class Out>

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperQuadSetTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperQuadSetTopology.inl
@@ -29,8 +29,7 @@ template <class In, class Out>
 BarycentricMapperQuadSetTopology<In,Out>::BarycentricMapperQuadSetTopology(topology::QuadSetTopologyContainer* fromTopology,
                                                                            topology::PointSetTopologyContainer* toTopology)
     : Inherit1(fromTopology, toTopology),
-      m_fromContainer(fromTopology),
-      m_fromGeomAlgo(nullptr)
+      m_fromContainer(fromTopology)
 {}
 
 template <class In, class Out>

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperRegularGridTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperRegularGridTopology.h
@@ -32,7 +32,6 @@ using sofa::defaulttype::BaseMatrix;
 using sofa::defaulttype::Vec3dTypes;
 using sofa::defaulttype::Vec3fTypes;
 using topology::RegularGridTopology;
-using topology::PointSetTopologyContainer;
 
 /// Class allowing barycentric mapping computation on a RegularGridTopology
 template<class In, class Out>

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperRegularGridTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperRegularGridTopology.h
@@ -78,7 +78,7 @@ public:
 
 protected:
     BarycentricMapperRegularGridTopology(RegularGridTopology* fromTopology,
-                                         PointSetTopologyContainer* toTopology);
+        core::topology::BaseMeshTopology* toTopology);
 
     type::vector<CubeData> m_map;
     RegularGridTopology* m_fromTopology   {nullptr};

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperRegularGridTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperRegularGridTopology.inl
@@ -33,7 +33,7 @@ using sofa::type::Vector3;
 
 template <class In, class Out>
 BarycentricMapperRegularGridTopology<In,Out>::BarycentricMapperRegularGridTopology(RegularGridTopology* fromTopology,
-                                                                                   PointSetTopologyContainer* toTopology)
+    core::topology::BaseMeshTopology* toTopology)
     : Inherit1(fromTopology, toTopology)
     , m_fromTopology(fromTopology)
     , m_matrixJ(nullptr), m_updateJ(true)

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperSparseGridTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperSparseGridTopology.h
@@ -76,7 +76,7 @@ public:
 
 protected:
     BarycentricMapperSparseGridTopology(topology::SparseGridTopology* fromTopology,
-                                        topology::PointSetTopologyContainer* _toTopology);
+        core::topology::BaseMeshTopology* _toTopology);
 
     sofa::type::vector<CubeData> m_map;
     topology::SparseGridTopology* m_fromTopology {nullptr};

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperSparseGridTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperSparseGridTopology.inl
@@ -34,7 +34,7 @@ using sofa::type::Vec;
 
 template<class In, class Out>
 BarycentricMapperSparseGridTopology<In, Out>::BarycentricMapperSparseGridTopology(topology::SparseGridTopology* fromTopology,
-        topology::PointSetTopologyContainer* _toTopology)
+    core::topology::BaseMeshTopology* _toTopology)
     : TopologyBarycentricMapper<In,Out>(fromTopology, _toTopology),
       m_fromTopology(fromTopology),
       m_matrixJ(nullptr), m_updateJ(true)

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h
@@ -22,8 +22,6 @@
 #pragma once
 #include <SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h>
 
-#include <SofaBaseTopology/TetrahedronSetTopologyContainer.h>
-
 namespace sofa::component::mapping
 {
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h
@@ -23,7 +23,6 @@
 #include <SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h>
 
 #include <SofaBaseTopology/TetrahedronSetTopologyContainer.h>
-#include <SofaBaseTopology/TetrahedronSetGeometryAlgorithms.h>
 
 namespace sofa::component::mapping
 {
@@ -68,7 +67,6 @@ protected:
     void processAddPoint(const sofa::type::Vec3d & pos, const typename In::VecCoord& in, MappingData & vectorData);
 
     topology::TetrahedronSetTopologyContainer*      m_fromContainer {nullptr};
-    topology::TetrahedronSetGeometryAlgorithms<In>*	m_fromGeomAlgo  {nullptr};
 
     using Inherit1::d_map;
     using Inherit1::m_fromTopology;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h
@@ -49,8 +49,8 @@ public:
     Index addPointInTetra(const Index index, const SReal* baryCoords) override ;
 
 protected:
-    BarycentricMapperTetrahedronSetTopology(topology::TetrahedronSetTopologyContainer* fromTopology,
-                                            topology::PointSetTopologyContainer* toTopology);
+    BarycentricMapperTetrahedronSetTopology(core::topology::BaseMeshTopology* fromTopology,
+        core::topology::BaseMeshTopology* toTopology);
     ~BarycentricMapperTetrahedronSetTopology() override {}
 
     virtual type::vector<Tetrahedron> getElements() override;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h
@@ -47,9 +47,9 @@ public:
     Index addPointInTetra(const Index index, const SReal* baryCoords) override ;
 
 protected:
-    BarycentricMapperTetrahedronSetTopology(core::topology::BaseMeshTopology* fromTopology,
+    BarycentricMapperTetrahedronSetTopology(sofa::core::topology::TopologyContainer* fromTopology,
         core::topology::BaseMeshTopology* toTopology);
-    ~BarycentricMapperTetrahedronSetTopology() override {}
+    ~BarycentricMapperTetrahedronSetTopology() override = default;
 
     virtual type::vector<Tetrahedron> getElements() override;
     virtual type::vector<SReal> getBaryCoef(const Real* f) override;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.inl
@@ -28,8 +28,7 @@ namespace sofa::component::mapping
 template <class In, class Out>
 BarycentricMapperTetrahedronSetTopology<In,Out>::BarycentricMapperTetrahedronSetTopology(topology::TetrahedronSetTopologyContainer* fromTopology, topology::PointSetTopologyContainer* toTopology)
     : Inherit1(fromTopology, toTopology),
-      m_fromContainer(fromTopology),
-      m_fromGeomAlgo(nullptr)
+      m_fromContainer(fromTopology)
 {}
 
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.inl
@@ -26,7 +26,7 @@ namespace sofa::component::mapping
 {
 
 template <class In, class Out>
-BarycentricMapperTetrahedronSetTopology<In,Out>::BarycentricMapperTetrahedronSetTopology(core::topology::BaseMeshTopology* fromTopology, core::topology::BaseMeshTopology* toTopology)
+BarycentricMapperTetrahedronSetTopology<In,Out>::BarycentricMapperTetrahedronSetTopology(sofa::core::topology::TopologyContainer* fromTopology, core::topology::BaseMeshTopology* toTopology)
     : Inherit1(fromTopology, toTopology)
 {}
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.inl
@@ -26,9 +26,8 @@ namespace sofa::component::mapping
 {
 
 template <class In, class Out>
-BarycentricMapperTetrahedronSetTopology<In,Out>::BarycentricMapperTetrahedronSetTopology(topology::TetrahedronSetTopologyContainer* fromTopology, topology::PointSetTopologyContainer* toTopology)
-    : Inherit1(fromTopology, toTopology),
-      m_fromContainer(fromTopology)
+BarycentricMapperTetrahedronSetTopology<In,Out>::BarycentricMapperTetrahedronSetTopology(core::topology::BaseMeshTopology* fromTopology, core::topology::BaseMeshTopology* toTopology)
+    : Inherit1(fromTopology, toTopology)
 {}
 
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h
@@ -144,7 +144,7 @@ protected:
     std::size_t m_hashTableSize;
 
 
-    BarycentricMapperTopologyContainer(core::topology::BaseMeshTopology* fromTopology, topology::PointSetTopologyContainer* toTopology);
+    BarycentricMapperTopologyContainer(core::topology::BaseMeshTopology* fromTopology, core::topology::BaseMeshTopology* toTopology);
 
     ~BarycentricMapperTopologyContainer() override {}
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h
@@ -144,9 +144,9 @@ protected:
     std::size_t m_hashTableSize;
 
 
-    BarycentricMapperTopologyContainer(core::topology::BaseMeshTopology* fromTopology, core::topology::BaseMeshTopology* toTopology);
+    BarycentricMapperTopologyContainer(sofa::core::topology::TopologyContainer* fromTopology, core::topology::BaseMeshTopology* toTopology);
 
-    ~BarycentricMapperTopologyContainer() override {}
+    ~BarycentricMapperTopologyContainer() override = default;
 
     virtual type::vector<Element> getElements()=0;
     virtual type::vector<SReal> getBaryCoef(const Real* f)=0;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.inl
@@ -33,7 +33,7 @@ typedef typename core::topology::BaseMeshTopology::SeqEdges SeqEdges;
 
 template <class In, class Out, class MappingDataType, class Element>
 BarycentricMapperTopologyContainer<In,Out,MappingDataType,Element>::BarycentricMapperTopologyContainer(core::topology::BaseMeshTopology* fromTopology,
-                                                                                                       topology::PointSetTopologyContainer* toTopology)
+    core::topology::BaseMeshTopology* toTopology)
      : Inherit1(fromTopology, toTopology),
        d_map(initData(&d_map,"map", "mapper data")),
        m_matrixJ(nullptr),

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.inl
@@ -32,7 +32,7 @@ using type::Vec3i;
 typedef typename core::topology::BaseMeshTopology::SeqEdges SeqEdges;
 
 template <class In, class Out, class MappingDataType, class Element>
-BarycentricMapperTopologyContainer<In,Out,MappingDataType,Element>::BarycentricMapperTopologyContainer(core::topology::BaseMeshTopology* fromTopology,
+BarycentricMapperTopologyContainer<In,Out,MappingDataType,Element>::BarycentricMapperTopologyContainer(sofa::core::topology::TopologyContainer* fromTopology,
     core::topology::BaseMeshTopology* toTopology)
      : Inherit1(fromTopology, toTopology),
        d_map(initData(&d_map,"map", "mapper data")),

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTriangleSetTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTriangleSetTopology.h
@@ -44,14 +44,14 @@ public:
                SOFA_TEMPLATE4(BarycentricMapperTopologyContainer,In,Out,MappingData,Triangle));
     typedef typename Inherit1::Real Real;
 
-    ~BarycentricMapperTriangleSetTopology() override {}
+    ~BarycentricMapperTriangleSetTopology() override = default;
 
     Index addPointInTriangle(const Index triangleIndex, const SReal* baryCoords) override;
     Index createPointInTriangle(const typename Out::Coord& p, Index triangleIndex, const typename In::VecCoord* points) override;
 
 protected:
     BarycentricMapperTriangleSetTopology();
-    BarycentricMapperTriangleSetTopology(core::topology::BaseMeshTopology* fromTopology,
+    BarycentricMapperTriangleSetTopology(sofa::core::topology::TopologyContainer* fromTopology,
         core::topology::BaseMeshTopology* toTopology);
 
     virtual type::vector<Triangle> getElements() override;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTriangleSetTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTriangleSetTopology.h
@@ -23,7 +23,6 @@
 #include <SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h>
 
 #include <SofaBaseTopology/TriangleSetTopologyContainer.h>
-#include <SofaBaseTopology/TriangleSetGeometryAlgorithms.h>
 
 namespace sofa::component::mapping
 {
@@ -58,7 +57,6 @@ protected:
                                          topology::PointSetTopologyContainer* toTopology);
 
     topology::TriangleSetTopologyContainer*			m_fromContainer;
-    topology::TriangleSetGeometryAlgorithms<In>*	m_fromGeomAlgo;
 
     virtual type::vector<Triangle> getElements() override;
     virtual type::vector<SReal> getBaryCoef(const Real* f) override;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTriangleSetTopology.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTriangleSetTopology.h
@@ -22,8 +22,6 @@
 #pragma once
 #include <SofaBaseMechanics/BarycentricMappers/BarycentricMapperTopologyContainer.h>
 
-#include <SofaBaseTopology/TriangleSetTopologyContainer.h>
-
 namespace sofa::component::mapping
 {
 
@@ -53,10 +51,8 @@ public:
 
 protected:
     BarycentricMapperTriangleSetTopology();
-    BarycentricMapperTriangleSetTopology(topology::TriangleSetTopologyContainer* fromTopology,
-                                         topology::PointSetTopologyContainer* toTopology);
-
-    topology::TriangleSetTopologyContainer*			m_fromContainer;
+    BarycentricMapperTriangleSetTopology(core::topology::BaseMeshTopology* fromTopology,
+        core::topology::BaseMeshTopology* toTopology);
 
     virtual type::vector<Triangle> getElements() override;
     virtual type::vector<SReal> getBaryCoef(const Real* f) override;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTriangleSetTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTriangleSetTopology.inl
@@ -27,15 +27,13 @@ namespace sofa::component::mapping
 
 template <class In, class Out>
 BarycentricMapperTriangleSetTopology<In,Out>::BarycentricMapperTriangleSetTopology()
-    : Inherit1(nullptr, nullptr),
-      m_fromContainer(nullptr)
+    : Inherit1(nullptr, nullptr)
 {}
 
 template <class In, class Out>
-BarycentricMapperTriangleSetTopology<In,Out>::BarycentricMapperTriangleSetTopology(topology::TriangleSetTopologyContainer* fromTopology,
-                                                                                   topology::PointSetTopologyContainer* toTopology)
-    : Inherit1(fromTopology, toTopology),
-      m_fromContainer(fromTopology)
+BarycentricMapperTriangleSetTopology<In,Out>::BarycentricMapperTriangleSetTopology(core::topology::BaseMeshTopology* fromTopology,
+    core::topology::BaseMeshTopology* toTopology)
+    : Inherit1(fromTopology, toTopology)
 {}
 
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTriangleSetTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTriangleSetTopology.inl
@@ -28,16 +28,14 @@ namespace sofa::component::mapping
 template <class In, class Out>
 BarycentricMapperTriangleSetTopology<In,Out>::BarycentricMapperTriangleSetTopology()
     : Inherit1(nullptr, nullptr),
-      m_fromContainer(nullptr),
-      m_fromGeomAlgo(nullptr)
+      m_fromContainer(nullptr)
 {}
 
 template <class In, class Out>
 BarycentricMapperTriangleSetTopology<In,Out>::BarycentricMapperTriangleSetTopology(topology::TriangleSetTopologyContainer* fromTopology,
                                                                                    topology::PointSetTopologyContainer* toTopology)
     : Inherit1(fromTopology, toTopology),
-      m_fromContainer(fromTopology),
-      m_fromGeomAlgo(nullptr)
+      m_fromContainer(fromTopology)
 {}
 
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTriangleSetTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperTriangleSetTopology.inl
@@ -31,7 +31,7 @@ BarycentricMapperTriangleSetTopology<In,Out>::BarycentricMapperTriangleSetTopolo
 {}
 
 template <class In, class Out>
-BarycentricMapperTriangleSetTopology<In,Out>::BarycentricMapperTriangleSetTopology(core::topology::BaseMeshTopology* fromTopology,
+BarycentricMapperTriangleSetTopology<In,Out>::BarycentricMapperTriangleSetTopology(sofa::core::topology::TopologyContainer* fromTopology,
     core::topology::BaseMeshTopology* toTopology)
     : Inherit1(fromTopology, toTopology)
 {}

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/TopologyBarycentricMapper.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/TopologyBarycentricMapper.h
@@ -62,8 +62,8 @@ public:
     virtual Index setPointInCube(const Index pointIndex, const Index cubeIndex, const SReal* baryCoords);
     virtual Index createPointInCube(const typename Out::Coord& p, Index cubeIndex, const typename In::VecCoord* points);
 
-    virtual void setToTopology( topology::PointSetTopologyContainer* toTopology) {this->m_toTopology = toTopology;}
-    const topology::PointSetTopologyContainer *getToTopology() const {return m_toTopology;}
+    virtual void setToTopology(core::topology::BaseMeshTopology* toTopology) {this->m_toTopology = toTopology;}
+    const core::topology::BaseMeshTopology*getToTopology() const {return m_toTopology;}
 
     virtual void resize( core::State<Out>* toModel ) = 0;
 
@@ -75,7 +75,7 @@ public:
 
 protected:
     TopologyBarycentricMapper(core::topology::BaseMeshTopology* fromTopology,
-                              topology::PointSetTopologyContainer* toTopology = nullptr)
+        core::topology::BaseMeshTopology* toTopology = nullptr)
         : m_fromTopology(fromTopology)
         , m_toTopology(toTopology)
     {}
@@ -83,7 +83,7 @@ protected:
     ~TopologyBarycentricMapper() override {}
 
     core::topology::BaseMeshTopology*    m_fromTopology;
-    topology::PointSetTopologyContainer* m_toTopology;
+    core::topology::BaseMeshTopology*    m_toTopology;
 };
 
 #if !defined(SOFA_COMPONENT_MAPPING_TOPOLOGYBARYCENTRICMAPPER_CPP)

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/TopologyBarycentricMapper.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/TopologyBarycentricMapper.h
@@ -21,7 +21,6 @@
 ******************************************************************************/
 #pragma once
 #include <SofaBaseMechanics/BarycentricMappers/BarycentricMapper.h>
-#include <SofaBaseTopology/PointSetTopologyContainer.h>
 #include <sofa/core/behavior/BaseMechanicalState.h>
 
 namespace sofa::component::mapping::_topologybarycentricmapper_

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMapping.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMapping.inl
@@ -29,11 +29,6 @@
 #include <SofaBaseTopology/QuadSetTopologyContainer.h>
 #include <SofaBaseTopology/TetrahedronSetTopologyContainer.h>
 #include <SofaBaseTopology/HexahedronSetTopologyContainer.h>
-#include <SofaBaseTopology/EdgeSetGeometryAlgorithms.h>
-#include <SofaBaseTopology/TriangleSetGeometryAlgorithms.h>
-#include <SofaBaseTopology/QuadSetGeometryAlgorithms.h>
-#include <SofaBaseTopology/TetrahedronSetGeometryAlgorithms.h>
-#include <SofaBaseTopology/HexahedronSetGeometryAlgorithms.h>
 
 #include<SofaBaseMechanics/BarycentricMappers/BarycentricMapperMeshTopology.h>
 #include<SofaBaseMechanics/BarycentricMappers/BarycentricMapperRegularGridTopology.h>

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMapping.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMapping.inl
@@ -24,11 +24,6 @@
 
 #include <SofaBaseTopology/RegularGridTopology.h>
 #include <SofaBaseTopology/SparseGridTopology.h>
-#include <SofaBaseTopology/EdgeSetTopologyContainer.h>
-#include <SofaBaseTopology/TriangleSetTopologyContainer.h>
-#include <SofaBaseTopology/QuadSetTopologyContainer.h>
-#include <SofaBaseTopology/TetrahedronSetTopologyContainer.h>
-#include <SofaBaseTopology/HexahedronSetTopologyContainer.h>
 
 #include<SofaBaseMechanics/BarycentricMappers/BarycentricMapperMeshTopology.h>
 #include<SofaBaseMechanics/BarycentricMappers/BarycentricMapperRegularGridTopology.h>
@@ -194,42 +189,37 @@ void BarycentricMapping<TIn, TOut>::createMapperFromTopology ()
     }
 
     // Hexahedron Topology
-    if (is_a<HexahedronSetTopologyContainer>(input_topology_container)) {
+    if (input_topology_container->getNbHexahedra() > 0) {
         msg_info() << "Creating HexahedronSetMapper";
-        d_mapper = sofa::core::objectmodel::New<HexahedronSetMapper>(
-            dynamic_cast<HexahedronSetTopologyContainer*>(input_topology_container), output_topology_container);
+        d_mapper = sofa::core::objectmodel::New<HexahedronSetMapper>(input_topology_container, output_topology_container);
         goto end;
     }
 
     // Tetrahedron Topology
-    if (is_a<TetrahedronSetTopologyContainer>(input_topology_container)) {
+    if (input_topology_container->getNbTetrahedra() > 0) {
         msg_info() << "Creating TetrahedronSetMapper";
-        d_mapper = sofa::core::objectmodel::New<TetrahedronSetMapper >(
-            dynamic_cast<TetrahedronSetTopologyContainer*>(input_topology_container), output_topology_container);
+        d_mapper = sofa::core::objectmodel::New<TetrahedronSetMapper >(input_topology_container, output_topology_container);
         goto end;
     }
 
     // Quad Topology
-    if (is_a<QuadSetTopologyContainer>(input_topology_container)) {
+    if (input_topology_container->getNbQuads() > 0) {
         msg_info() << "Creating QuadSetMapper";
-        d_mapper = sofa::core::objectmodel::New<QuadSetMapper >(
-            dynamic_cast<QuadSetTopologyContainer*>(input_topology_container), output_topology_container);
+        d_mapper = sofa::core::objectmodel::New<QuadSetMapper >(input_topology_container, output_topology_container);
         goto end;
     }
 
     // Triangle Topology
-    if (is_a<TriangleSetTopologyContainer>(input_topology_container)) {
+    if (input_topology_container->getNbTriangles() > 0) {
         msg_info() << "Creating TriangleSetMapper";
-        d_mapper = sofa::core::objectmodel::New<TriangleSetMapper >(
-            dynamic_cast<TriangleSetTopologyContainer*>(input_topology_container), output_topology_container);
+        d_mapper = sofa::core::objectmodel::New<TriangleSetMapper >(input_topology_container, output_topology_container);
         goto end;
     }
 
     // Edge Topology
-    if (is_a<EdgeSetTopologyContainer>(input_topology_container)) {
+    if (input_topology_container->getNbEdges() > 0) {
         msg_info() << "Creating EdgeSetMapper";
-        d_mapper = sofa::core::objectmodel::New<EdgeSetMapper >(
-            dynamic_cast<EdgeSetTopologyContainer*>(input_topology_container), output_topology_container);
+        d_mapper = sofa::core::objectmodel::New<EdgeSetMapper >(input_topology_container, output_topology_container);
         goto end;
     }
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMapping.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMapping.inl
@@ -188,39 +188,44 @@ void BarycentricMapping<TIn, TOut>::createMapperFromTopology ()
         goto end;
     }
 
-    // Hexahedron Topology
-    if (is_a<sofa::core::topology::TopologyContainer>(input_topology_container) && input_topology_container->getNbHexahedra() > 0) {
-        msg_info() << "Creating HexahedronSetMapper";
-        d_mapper = sofa::core::objectmodel::New<HexahedronSetMapper>(input_topology_container, output_topology_container);
-        goto end;
-    }
+    //TopologyContainer topologies
+    if(is_a<sofa::core::topology::TopologyContainer>(input_topology_container))
+    {
+        auto topoContainer = dynamic_cast<sofa::core::topology::TopologyContainer*>(input_topology_container);
+        // Hexahedron Topology
+        if (input_topology_container->getNbHexahedra() > 0) {
+            msg_info() << "Creating HexahedronSetMapper";
+            d_mapper = sofa::core::objectmodel::New<HexahedronSetMapper>(topoContainer, output_topology_container);
+            goto end;
+        }
 
-    // Tetrahedron Topology
-    if (is_a<sofa::core::topology::TopologyContainer>(input_topology_container) && input_topology_container->getNbTetrahedra() > 0) {
-        msg_info() << "Creating TetrahedronSetMapper";
-        d_mapper = sofa::core::objectmodel::New<TetrahedronSetMapper >(input_topology_container, output_topology_container);
-        goto end;
-    }
+        // Tetrahedron Topology
+        if (input_topology_container->getNbTetrahedra() > 0) {
+            msg_info() << "Creating TetrahedronSetMapper";
+            d_mapper = sofa::core::objectmodel::New<TetrahedronSetMapper >(topoContainer, output_topology_container);
+            goto end;
+        }
 
-    // Quad Topology
-    if (is_a<sofa::core::topology::TopologyContainer>(input_topology_container) && input_topology_container->getNbQuads() > 0) {
-        msg_info() << "Creating QuadSetMapper";
-        d_mapper = sofa::core::objectmodel::New<QuadSetMapper >(input_topology_container, output_topology_container);
-        goto end;
-    }
+        // Quad Topology
+        if (input_topology_container->getNbQuads() > 0) {
+            msg_info() << "Creating QuadSetMapper";
+            d_mapper = sofa::core::objectmodel::New<QuadSetMapper >(topoContainer, output_topology_container);
+            goto end;
+        }
 
-    // Triangle Topology
-    if (is_a<sofa::core::topology::TopologyContainer>(input_topology_container) && input_topology_container->getNbTriangles() > 0) {
-        msg_info() << "Creating TriangleSetMapper";
-        d_mapper = sofa::core::objectmodel::New<TriangleSetMapper >(input_topology_container, output_topology_container);
-        goto end;
-    }
+        // Triangle Topology
+        if (input_topology_container->getNbTriangles() > 0) {
+            msg_info() << "Creating TriangleSetMapper";
+            d_mapper = sofa::core::objectmodel::New<TriangleSetMapper >(topoContainer, output_topology_container);
+            goto end;
+        }
 
-    // Edge Topology
-    if (is_a<sofa::core::topology::TopologyContainer>(input_topology_container) && input_topology_container->getNbEdges() > 0) {
-        msg_info() << "Creating EdgeSetMapper";
-        d_mapper = sofa::core::objectmodel::New<EdgeSetMapper >(input_topology_container, output_topology_container);
-        goto end;
+        // Edge Topology
+        if (input_topology_container->getNbEdges() > 0) {
+            msg_info() << "Creating EdgeSetMapper";
+            d_mapper = sofa::core::objectmodel::New<EdgeSetMapper >(topoContainer, output_topology_container);
+            goto end;
+        }
     }
 
     // Generic Mesh Topology

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMapping.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMapping.inl
@@ -189,35 +189,35 @@ void BarycentricMapping<TIn, TOut>::createMapperFromTopology ()
     }
 
     // Hexahedron Topology
-    if (input_topology_container->getNbHexahedra() > 0) {
+    if (is_a<sofa::core::topology::TopologyContainer>(input_topology_container) && input_topology_container->getNbHexahedra() > 0) {
         msg_info() << "Creating HexahedronSetMapper";
         d_mapper = sofa::core::objectmodel::New<HexahedronSetMapper>(input_topology_container, output_topology_container);
         goto end;
     }
 
     // Tetrahedron Topology
-    if (input_topology_container->getNbTetrahedra() > 0) {
+    if (is_a<sofa::core::topology::TopologyContainer>(input_topology_container) && input_topology_container->getNbTetrahedra() > 0) {
         msg_info() << "Creating TetrahedronSetMapper";
         d_mapper = sofa::core::objectmodel::New<TetrahedronSetMapper >(input_topology_container, output_topology_container);
         goto end;
     }
 
     // Quad Topology
-    if (input_topology_container->getNbQuads() > 0) {
+    if (is_a<sofa::core::topology::TopologyContainer>(input_topology_container) && input_topology_container->getNbQuads() > 0) {
         msg_info() << "Creating QuadSetMapper";
         d_mapper = sofa::core::objectmodel::New<QuadSetMapper >(input_topology_container, output_topology_container);
         goto end;
     }
 
     // Triangle Topology
-    if (input_topology_container->getNbTriangles() > 0) {
+    if (is_a<sofa::core::topology::TopologyContainer>(input_topology_container) && input_topology_container->getNbTriangles() > 0) {
         msg_info() << "Creating TriangleSetMapper";
         d_mapper = sofa::core::objectmodel::New<TriangleSetMapper >(input_topology_container, output_topology_container);
         goto end;
     }
 
     // Edge Topology
-    if (input_topology_container->getNbEdges() > 0) {
+    if (is_a<sofa::core::topology::TopologyContainer>(input_topology_container) && input_topology_container->getNbEdges() > 0) {
         msg_info() << "Creating EdgeSetMapper";
         d_mapper = sofa::core::objectmodel::New<EdgeSetMapper >(input_topology_container, output_topology_container);
         goto end;

--- a/SofaKernel/modules/SofaMeshCollision/SofaMeshCollision_test/BaryMapper_test.cpp
+++ b/SofaKernel/modules/SofaMeshCollision/SofaMeshCollision_test/BaryMapper_test.cpp
@@ -23,7 +23,7 @@
 #include <SofaSimulationGraph/DAGNode.h>
 #include <SofaMeshCollision/BarycentricContactMapper.h>
 #include <SofaBaseMechanics/BarycentricMappers/BarycentricMapperMeshTopology.h>
-
+#include <SofaBaseTopology/PointSetTopologyContainer.h>
 #include <SofaBaseTopology/MeshTopology.h>
 
 #include <sofa/testing/BaseTest.h>

--- a/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/BarycentricContactMapper.inl
+++ b/SofaKernel/modules/SofaMeshCollision/src/SofaMeshCollision/BarycentricContactMapper.inl
@@ -64,7 +64,7 @@ typename BarycentricContactMapper<TCollisionModel,DataTypes>::MMechanicalState* 
     mstate->setName(GenerateStringID::generate().c_str());
     child->addObject(mstate);
     //mapper = mapping->getMapper();
-    mapper = sofa::core::objectmodel::New<mapping::BarycentricMapperMeshTopology<InDataTypes, typename BarycentricContactMapper::DataTypes> >(model->getCollisionTopology(), (topology::PointSetTopologyContainer*)nullptr);
+    mapper = sofa::core::objectmodel::New<mapping::BarycentricMapperMeshTopology<InDataTypes, typename BarycentricContactMapper::DataTypes> >(model->getCollisionTopology(), nullptr);
     mapper->setName(GenerateStringID::generate().c_str());
     mapping =  sofa::core::objectmodel::New<MMapping>(model->getMechanicalState(), mstate.get(), mapper);
     mapping->setName(GenerateStringID::generate().c_str());

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaBarycentricMapping.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaBarycentricMapping.h
@@ -187,7 +187,7 @@ protected:
     Index getMapIndex(Index outIndex, Index j);
     void calcMapT();
 public:
-    BarycentricMapperMeshTopology(core::topology::BaseMeshTopology* fromTopology, topology::PointSetTopologyContainer* toTopology)
+    BarycentricMapperMeshTopology(core::topology::BaseMeshTopology* fromTopology, core::topology::BaseMeshTopology* toTopology)
         : Inherit(fromTopology, toTopology)
         , maxNIn(0), maxNOut(0), insize(0), size(0), topology(fromTopology)
     {
@@ -249,7 +249,7 @@ public:
     using Index = sofa::Index;
 
 public:
-    BarycentricMapperTetrahedronSetTopology(topology::TetrahedronSetTopologyContainer* fromTopology, topology::PointSetTopologyContainer* _toTopology)
+    BarycentricMapperTetrahedronSetTopology(sofa::core::topology::BaseMeshTopology* fromTopology, sofa::core::topology::BaseMeshTopology* _toTopology)
         : Inherit(fromTopology, _toTopology),
           internalMapper(fromTopology,_toTopology)
     {}

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaBarycentricMappingRigid.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaBarycentricMappingRigid.cpp
@@ -71,6 +71,11 @@ void BarycentricMapperHexahedronSetTopology<CudaVec3Types, defaulttype::Rigid3Ty
     std::list<const core::topology::TopologyChange *>::const_iterator itBegin = this->m_fromTopology->beginChange();
     std::list<const core::topology::TopologyChange *>::const_iterator itEnd = this->m_fromTopology->endChange();
 
+    typedef sofa::core::behavior::MechanicalState<defaulttype::Vec3Types> InMechanicalStateT;
+    InMechanicalStateT* inState;
+    this->m_fromTopology->getContext()->get(inState);
+    const auto& inRestPos = (inState->read(core::ConstVecCoordId::restPosition())->getValue());
+
     for ( std::list<const core::topology::TopologyChange *>::const_iterator changeIt = itBegin;
             changeIt != itEnd; ++changeIt )
     {
@@ -96,9 +101,9 @@ void BarycentricMapperHexahedronSetTopology<CudaVec3Types, defaulttype::Rigid3Ty
                         pos[2] = mapData[j].baryCoords[2];
 
                         // find nearest cell and barycentric coords
-                        Real distance = 1e10;
+                        SReal distance = 1e10;
 
-                        int index = m_fromGeomAlgo->findNearestElementInRestPos ( pos, coefs, distance );
+                        Index index = sofa::topology::getClosestHexahedronIndex(inRestPos, m_fromTopology->getHexahedra(), pos, coefs, distance);
 
                         if ( index != -1 )
                         {
@@ -145,12 +150,14 @@ void BarycentricMapperHexahedronSetTopology<CudaVec3Types, defaulttype::Rigid3Ty
                 {
                     if ( d_map.getValue()[j].in_index == cubeId ) // invalidate mapping
                     {
-                        Vector3 coefs;
+                        std::array<SReal, 3> coefs;
                         coefs[0] = d_map.getValue()[j].baryCoords[0];
                         coefs[1] = d_map.getValue()[j].baryCoords[1];
                         coefs[2] = d_map.getValue()[j].baryCoords[2];
 
-                        defaulttype::Vec3Types::Coord restPos = m_fromGeomAlgo->getRestPointPositionInHexahedron ( cubeId, coefs );
+                        const auto& h = this->m_fromTopology->getHexahedron(cubeId);
+                        const auto restPos = sofa::geometry::Hexahedron::getPositionFromBarycentricCoefficients(inRestPos[h[0]], inRestPos[h[1]], inRestPos[h[2]], inRestPos[h[3]],
+                            inRestPos[h[4]], inRestPos[h[5]], inRestPos[h[6]], inRestPos[h[7]], coefs);
 
                         type::vector<MappingData>& vectorData = *(d_map.beginEdit());
                         vectorData[j].in_index = sofa::InvalidID;

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTypes.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTypes.h
@@ -409,6 +409,11 @@ public:
                 );
     }
 
+    explicit operator sofa::type::Vec<3, Real>()
+    {
+        return { (*this)[0], (*this)[1] , (*this)[2] };
+    }
+
 protected:
     Real dummy;
 };

--- a/modules/SofaMiscMapping/src/SofaMiscMapping/BarycentricMappingRigid.cpp
+++ b/modules/SofaMiscMapping/src/SofaMiscMapping/BarycentricMappingRigid.cpp
@@ -95,7 +95,7 @@ void BarycentricMapperHexahedronSetTopology<defaulttype::Vec3Types, defaulttype:
                         // find nearest cell and barycentric coords
                         Real distance = 1e10;
 
-                        Index index = sofa::topology::getClosest(inRestPos, m_fromTopology->getHexahedra(), pos, coefs, distance);
+                        Index index = sofa::topology::getClosestHexahedronIndex(inRestPos, m_fromTopology->getHexahedra(), pos, coefs, distance);
 
                         if ( index != sofa::InvalidID )
                         {

--- a/modules/SofaMiscMapping/src/SofaMiscMapping/BarycentricMappingRigid.cpp
+++ b/modules/SofaMiscMapping/src/SofaMiscMapping/BarycentricMappingRigid.cpp
@@ -62,6 +62,11 @@ void BarycentricMapperHexahedronSetTopology<defaulttype::Vec3Types, defaulttype:
     std::list<const core::topology::TopologyChange *>::const_iterator itBegin = this->m_fromTopology->beginChange();
     std::list<const core::topology::TopologyChange *>::const_iterator itEnd = this->m_fromTopology->endChange();
 
+    typedef sofa::core::behavior::MechanicalState<defaulttype::Vec3Types> InMechanicalStateT;
+    InMechanicalStateT* inState;
+    this->m_fromTopology->getContext()->get(inState);
+    const auto& inRestPos = (inState->read(core::ConstVecCoordId::restPosition())->getValue());
+
     for ( std::list<const core::topology::TopologyChange *>::const_iterator changeIt = itBegin;
             changeIt != itEnd; ++changeIt )
     {
@@ -90,7 +95,7 @@ void BarycentricMapperHexahedronSetTopology<defaulttype::Vec3Types, defaulttype:
                         // find nearest cell and barycentric coords
                         Real distance = 1e10;
 
-                        Index index = m_fromGeomAlgo->findNearestElementInRestPos ( pos, coefs, distance );
+                        Index index = sofa::topology::getClosest(inRestPos, m_fromTopology->getHexahedra(), pos, coefs, distance);
 
                         if ( index != sofa::InvalidID )
                         {
@@ -138,12 +143,14 @@ void BarycentricMapperHexahedronSetTopology<defaulttype::Vec3Types, defaulttype:
                 {
                     if ( d_map.getValue()[j].in_index == cubeId ) // invalidate mapping
                     {
-                        sofa::type::Vector3 coefs;
+                        std::array<SReal, 3> coefs;
                         coefs[0] = d_map.getValue()[j].baryCoords[0];
                         coefs[1] = d_map.getValue()[j].baryCoords[1];
                         coefs[2] = d_map.getValue()[j].baryCoords[2];
 
-                        defaulttype::Vec3Types::Coord restPos = m_fromGeomAlgo->getRestPointPositionInHexahedron ( cubeId, coefs );
+                        const auto& h = this->m_fromTopology->getHexahedron(cubeId);
+                        const auto restPos = sofa::geometry::Hexahedron::getPositionFromBarycentricCoefficients(inRestPos[h[0]], inRestPos[h[1]], inRestPos[h[2]], inRestPos[h[3]],
+                            inRestPos[h[4]], inRestPos[h[5]], inRestPos[h[6]], inRestPos[h[7]], coefs);
 
                         type::vector<MappingData>& vectorData = *(d_map.beginEdit());
                         vectorData[j].in_index = sofa::InvalidID;

--- a/modules/SofaMiscMapping/src/SofaMiscMapping/BarycentricMappingRigid.h
+++ b/modules/SofaMiscMapping/src/SofaMiscMapping/BarycentricMappingRigid.h
@@ -25,8 +25,6 @@
 
 #include <SofaBaseMechanics/BarycentricMapping.h>
 #include <SofaBaseTopology/TopologyData.h>
-#include <SofaBaseTopology/TetrahedronSetTopologyContainer.h>
-#include <SofaBaseTopology/TetrahedronSetGeometryAlgorithms.h>
 
 #include <SofaBaseMechanics/BarycentricMappers/BarycentricMapperTetrahedronSetTopology.h>
 #include <SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.h>
@@ -74,9 +72,6 @@ protected:
 
     VecCoord actualTetraPosition;
 
-    topology::TetrahedronSetTopologyContainer*			_fromContainer;
-    topology::TetrahedronSetGeometryAlgorithms<In>*	_fromGeomAlgo;
-
     MatrixType* matrixJ;
     bool updateJ;
 
@@ -85,7 +80,7 @@ protected:
     typename Out::VecCoord actualPos;
 
     /// TEMP
-    BarycentricMapperTetrahedronSetTopologyRigid(topology::TetrahedronSetTopologyContainer* fromTopology, topology::PointSetTopologyContainer* _toTopology);
+    BarycentricMapperTetrahedronSetTopologyRigid(core::topology::BaseMeshTopology* fromTopology, core::topology::BaseMeshTopology* _toTopology);
     virtual ~BarycentricMapperTetrahedronSetTopologyRigid() {}
 
 public:
@@ -118,7 +113,7 @@ public:
     SOFA_CLASS(SOFA_TEMPLATE2(BarycentricMapperTetrahedronSetTopology,In,Out),SOFA_TEMPLATE2(BarycentricMapperTetrahedronSetTopologyRigid,In,Out));
     typedef BarycentricMapperTetrahedronSetTopologyRigid<In,Out> Inherit;
 
-    BarycentricMapperTetrahedronSetTopology(topology::TetrahedronSetTopologyContainer* fromTopology, topology::PointSetTopologyContainer* _toTopology)
+    BarycentricMapperTetrahedronSetTopology(core::topology::BaseMeshTopology* fromTopology, core::topology::BaseMeshTopology* _toTopology)
         : Inherit(fromTopology, _toTopology)
     {}
 

--- a/modules/SofaMiscMapping/src/SofaMiscMapping/BarycentricMappingRigid.inl
+++ b/modules/SofaMiscMapping/src/SofaMiscMapping/BarycentricMappingRigid.inl
@@ -30,12 +30,10 @@ namespace sofa::component::mapping
 {
 
 template <class In, class Out>
-BarycentricMapperTetrahedronSetTopologyRigid<In,Out>::BarycentricMapperTetrahedronSetTopologyRigid(topology::TetrahedronSetTopologyContainer* fromTopology, topology::PointSetTopologyContainer* _toTopology)
+BarycentricMapperTetrahedronSetTopologyRigid<In,Out>::BarycentricMapperTetrahedronSetTopologyRigid(core::topology::BaseMeshTopology* fromTopology, core::topology::BaseMeshTopology* _toTopology)
     : TopologyBarycentricMapper<In,Out>(fromTopology, _toTopology),
       map(initData(&map,"map", "mapper data")),
       mapOrient(initData(&mapOrient,"mapOrient", "mapper data for mapped frames")),
-      _fromContainer(fromTopology),
-      _fromGeomAlgo(nullptr),
       matrixJ(nullptr),
       updateJ(true)
 {
@@ -105,10 +103,8 @@ template<class In, class Out>
 void BarycentricMapperTetrahedronSetTopologyRigid<In,Out>::init(const typename Out::VecCoord& out, const typename In::VecCoord& in)
 {
 
-    _fromContainer->getContext()->get ( _fromGeomAlgo );
-
     int outside = 0;
-    const sofa::type::vector<core::topology::BaseMeshTopology::Tetrahedron>& tetrahedra = this->m_fromTopology->getTetrahedra();
+    const auto& tetrahedra = this->m_fromTopology->getTetrahedra();
 
     sofa::type::vector<sofa::type::Matrix3> bases;
     sofa::type::vector<sofa::type::Vector3> centers;


### PR DESCRIPTION
Issue #2402

BarycentricMapping instanciates "mappers" according to the topology it is mapping from.
There are direct dependencies on *SetTopologyContainer, and Grids. Morever, it is using as well a few functions from *SetGeometryAlgorithms.
This PR:
 - replace the direct usage of *SetTopologyContainer, and uses instead the abstraction TopologyContainer (test if a certain kind of element is present) which should be the same effect;
 - move (copy from now) methods from GeometryAlgorithms, into Sofa.Geometry and Sofa.Topology. Those functions are designed to be the most generic possible (but not too much to not have huge/complex template predicates). This "step-by-step" process should be the way to convert *GeometryAlgorithms. (and remove this family of component in the future)

This PR does not address the issue on the RegularGrid/SparseGrid dependency for now 😥


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
