### PR TITLE
[Tests] Update SceneCreator_test to inherit from BaseSimulationTest and remove some warnings

### DIFF
--- a/applications/plugins/SceneCreator/CMakeLists.txt
+++ b/applications/plugins/SceneCreator/CMakeLists.txt
@@ -21,7 +21,7 @@ set(SOURCE_FILES
     )
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaSimulationGraph SofaBaseMechanics)
+target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Testing SofaSimulationGraph SofaBaseMechanics)
 target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen)
 target_compile_definitions(${PROJECT_NAME} PRIVATE "-DSOFA_BUILD_SCENECREATOR")
 

--- a/applications/plugins/SceneCreator/CMakeLists.txt
+++ b/applications/plugins/SceneCreator/CMakeLists.txt
@@ -21,7 +21,7 @@ set(SOURCE_FILES
     )
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Testing SofaSimulationGraph SofaBaseMechanics)
+target_link_libraries(${PROJECT_NAME} PUBLIC SofaSimulationGraph SofaBaseMechanics)
 target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen)
 target_compile_definitions(${PROJECT_NAME} PRIVATE "-DSOFA_BUILD_SCENECREATOR")
 

--- a/applications/plugins/SceneCreator/SceneCreator_test/SceneCreator_test.cpp
+++ b/applications/plugins/SceneCreator/SceneCreator_test/SceneCreator_test.cpp
@@ -1,4 +1,10 @@
-#include <SofaTest/Sofa_test.h>
+#include <sofa/testing/BaseSimulationTest.h>
+using namespace sofa::testing;
+
+#include <sofa/defaulttype/RigidTypes.h>
+#include <sofa/defaulttype/VecTypes.h>
+using sofa::defaulttype::Vec3Types;
+
 #include <SceneCreator/SceneCreator.h>
 
 #include <SofaSimpleFem/TetrahedronFEMForceField.h>
@@ -21,26 +27,16 @@ using sofa::component::topology::CylinderGridTopology;
 using sofa::component::topology::SphereGridTopology;
 
 using sofa::core::objectmodel::BaseContext;
-using sofa::defaulttype::Vec3Types;
-
 
 #include <sofa/simulation/Simulation.h>
 using sofa::simulation::Node;
 
-typedef MechanicalObject<sofa::defaulttype::Vec3Types>      MechanicalObject3;
-typedef TetrahedronFEMForceField<Vec3Types>                 TetrahedronFEMForceField3;
-typedef TriangularFEMForceField<Vec3Types>                  TriangularFEMForceField3;
-
-#include <sofa/helper/system/PluginManager.h>
-using sofa::helper::system::PluginManager ;
-
-class SceneCreator_test : public sofa::Sofa_test<>
+class SceneCreator_test : public BaseSimulationTest
 {
 public:
     void SetUp() override
     {
-        importPlugin("SofaOpenglVisual");
-        importPlugin("SofaGeneralTopology");
+        importPlugin("SofaComponentAll");
     }
 
     bool createCubeFailed();

--- a/applications/plugins/SceneCreator/src/SceneCreator/SceneCreator.cpp
+++ b/applications/plugins/SceneCreator/src/SceneCreator/SceneCreator.cpp
@@ -434,8 +434,6 @@ simulation::Node::SPtr addCube(simulation::Node::SPtr parent, const std::string&
     //Node VISUAL
     createVisualNodeVec3(cube, dofFEM, "", "red", Deriv3(), Deriv3(), MT_Identity);
 
-    simpleapi::dumpScene(parent) ;
-
     return cube;
 }
 

--- a/applications/plugins/SofaCarving/SofaCarving_test/SofaCarving_test.cpp
+++ b/applications/plugins/SofaCarving/SofaCarving_test/SofaCarving_test.cpp
@@ -23,11 +23,11 @@
 #include <SofaCarving/CarvingManager.h>
 #include <SofaSimulationGraph/SimpleApi.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
-#include <SofaSimulationGraph/testing/BaseSimulationTest.h>
+#include <sofa/testing/BaseSimulationTest.h>
 #include <SofaBaseUtils/initSofaBaseUtils.h>
 #include <SofaBaseLinearSolver/initSofaBaseLinearSolver.h>
 
-using namespace sofa::helper::testing;
+using namespace sofa::testing;
 using namespace sofa::component::collision;
 using namespace sofa::simpleapi;
 


### PR DESCRIPTION
Remove logs/warnings in SceneCreator_test by:
- inheriting from BaseSimulationTest  instead of old api: sofa_test
- Remove sceneDump in AddCube method

Also update SofaCarving_test to use the correct header path. 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
