### PR TITLE
[SofaSimpleFem] Add callback on VonMises in TetrahedronFEMForceField

### DIFF
--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.inl
@@ -80,10 +80,10 @@ TetrahedronFEMForceField<DataTypes>::TetrahedronFEMForceField()
     {
         if(_computeVonMisesStress.getValue() == 0 || _computeVonMisesStress.getValue() == 1 || _computeVonMisesStress.getValue() == 2)
         {
-            if (_computeVonMisesStress.getValue() == 1 && method == SMALL)
+            if (_computeVonMisesStress.getValue() == 1 && f_method.getValue() == "small")
             {
                 msg_warning() << "VonMisesStress can only be computed with full Green strain when the method is SMALL.";
-                _computeVonMisesStress.setValue(2);
+                return sofa::core::objectmodel::ComponentState::Invalid;
             }
             else
             {
@@ -92,11 +92,8 @@ TetrahedronFEMForceField<DataTypes>::TetrahedronFEMForceField()
         }
         else
         {
-            msg_warning() << "Value of " << _computeVonMisesStress.getName() << " is invalid (must be 0, 1 or 2). "
-                          << "Set "<<_computeVonMisesStress.getName()<<" to 0, disabling " << _showVonMisesStressPerNode.getName() << " and " << _showVonMisesStressPerElement.getName() << ".";
-            _computeVonMisesStress.setValue(0);
-            _showVonMisesStressPerNode.setValue(false);
-            _showVonMisesStressPerElement.setValue(false);
+            msg_warning() << "Value of " << _computeVonMisesStress.getName() << " is invalid (must be 0, 1 or 2). ";
+            return sofa::core::objectmodel::ComponentState::Invalid;
         }
 
         return sofa::core::objectmodel::ComponentState::Valid;
@@ -1538,8 +1535,8 @@ inline void TetrahedronFEMForceField<DataTypes>::reinit()
 
         if (_computeVonMisesStress.getValue() == 1 && method == SMALL)
         {
-            msg_warning() << "VonMisesStress can only be computed with full Green strain when the method is SMALL.";
-            _computeVonMisesStress.setValue(2);
+            msg_warning() << "(init) VonMisesStress can only be computed with full Green strain when the method is SMALL.";
+            this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         }
     }
 
@@ -1812,11 +1809,13 @@ void TetrahedronFEMForceField<DataTypes>::draw(const core::visual::VisualParams*
         heterogeneous = (fabs(minYoung-maxYoung) > 1e-8);
     }
 
-    // vonMises stress
+
     Real minVM = (Real)1e20, maxVM = (Real)-1e20;
     Real minVMN = (Real)1e20, maxVMN = (Real)-1e20;
     helper::ReadAccessor<Data<type::vector<Real> > > vM =  _vonMisesPerElement;
     helper::ReadAccessor<Data<type::vector<Real> > > vMN =  _vonMisesPerNode;
+
+    // vonMises stress
     if (drawVonMisesStress)
     {
         for (size_t i = 0; i < vM.size(); i++)
@@ -1835,96 +1834,96 @@ void TetrahedronFEMForceField<DataTypes>::draw(const core::visual::VisualParams*
         }
         maxVM *= _showStressAlpha.getValue();
         maxVMN *= _showStressAlpha.getValue();
-    }
 
-    if (drawVonMisesStress && _showVonMisesStressPerNode.getValue())
-    {
-        // Draw nodes (if node option enabled)
-        std::vector<sofa::type::RGBAColor> nodeColors(x.size());
-        std::vector<type::Vector3> pts(x.size());
-        helper::ColorMap::evaluator<Real> evalColor = m_VonMisesColorMap->getEvaluator(minVMN, maxVMN);
-        for (size_t nd = 0; nd < x.size(); nd++) {
-            pts[nd] = x[nd];
-            nodeColors[nd] = evalColor(vMN[nd]);
-        }
-        vparams->drawTool()->drawPoints(pts, 10, nodeColors);
-    }
 
-    if (! (drawVonMisesStress && _showVonMisesStressPerNode.getValue() && !_showVonMisesStressPerElement.getValue()) )
-    {
-        // Draw elements (if not "node only")
-        std::vector< type::Vector3 > points;
-        std::vector< sofa::type::RGBAColor > colorVector;
-        typename VecElement::const_iterator it;
-        int i;
-        for(it = _indexedElements->begin(), i = 0 ; it != _indexedElements->end() ; ++it, ++i)
+        if (_showVonMisesStressPerNode.getValue())
         {
-            Index a = (*it)[0];
-            Index b = (*it)[1];
-            Index c = (*it)[2];
-            Index d = (*it)[3];
-            Coord center = (x[a] + x[b] + x[c] + x[d]) * 0.125;
-
-            Coord pa = x[a];
-            Coord pb = x[b];
-            Coord pc = x[c];
-            Coord pd = x[d];
-
-            if ( ! vparams->displayFlags().getShowWireFrame() )
-            {
-                pa = (pa + center) * Real(0.6667);
-                pb = (pb + center) * Real(0.6667);
-                pc = (pc + center) * Real(0.6667);
-                pd = (pd + center) * Real(0.6667);
+            // Draw nodes (if node option enabled)
+            std::vector<sofa::type::RGBAColor> nodeColors(x.size());
+            std::vector<type::Vector3> pts(x.size());
+            helper::ColorMap::evaluator<Real> evalColor = m_VonMisesColorMap->getEvaluator(minVMN, maxVMN);
+            for (size_t nd = 0; nd < x.size(); nd++) {
+                pts[nd] = x[nd];
+                nodeColors[nd] = evalColor(vMN[nd]);
             }
-
-            // create corresponding colors
-            sofa::type::RGBAColor color[4];
-            if (drawVonMisesStress && _showVonMisesStressPerElement.getValue())
-            {
-                if(heterogeneous)
-                {
-                    float col = (float)((youngModulus[i] - minYoung) / (maxYoung - minYoung));
-                    float fac = col * 0.5f;
-                    color[0] = sofa::type::RGBAColor(col       , 0.0f - fac, 1.0f - col, 1.0f);
-                    color[1] = sofa::type::RGBAColor(col       , 0.5f - fac, 1.0f - col, 1.0f);
-                    color[2] = sofa::type::RGBAColor(col       , 1.0f - fac, 1.0f - col, 1.0f);
-                    color[3] = sofa::type::RGBAColor(col + 0.5f, 1.0f - fac, 1.0f - col, 1.0f);
-                }
-                else
-                {
-                    helper::ColorMap::evaluator<Real> evalColor = m_VonMisesColorMap->getEvaluator(minVM, maxVM);
-                    auto col = sofa::type::RGBAColor::fromVec4(evalColor(vM[i]));
-                    col[3] = 1.0f;
-                    color[0] = col;
-                    color[1] = col;
-                    color[2] = col;
-                    color[3] = col;
-                }
-            }
-            else if (!drawVonMisesStress)
-            {
-                color[0] = sofa::type::RGBAColor(0.0, 0.0, 1.0, 1.0);
-                color[1] = sofa::type::RGBAColor(0.0, 0.5, 1.0, 1.0);
-                color[2] = sofa::type::RGBAColor(0.0, 1.0, 1.0, 1.0);
-                color[3] = sofa::type::RGBAColor(0.5, 1.0, 1.0, 1.0);
-            }
-
-            // create 4 triangles per tetrahedron with corresponding colors
-            points.insert(points.end(), { pa, pb, pc });
-            colorVector.insert(colorVector.end(), { color[0], color[0], color[0] });
-
-            points.insert(points.end(), { pb, pc, pd });
-            colorVector.insert(colorVector.end(), { color[1], color[1], color[1] });
-
-            points.insert(points.end(), { pc, pd, pa });
-            colorVector.insert(colorVector.end(), { color[2], color[2], color[2] });
-
-            points.insert(points.end(), { pd, pa, pb });
-            colorVector.insert(colorVector.end(), { color[3], color[3], color[3] });
+            vparams->drawTool()->drawPoints(pts, 10, nodeColors);
         }
-        vparams->drawTool()->drawTriangles(points, colorVector);
     }
+
+
+    // Draw elements (if not "node only")
+    std::vector< type::Vector3 > points;
+    std::vector< sofa::type::RGBAColor > colorVector;
+    typename VecElement::const_iterator it;
+    int i;
+    for(it = _indexedElements->begin(), i = 0 ; it != _indexedElements->end() ; ++it, ++i)
+    {
+        Index a = (*it)[0];
+        Index b = (*it)[1];
+        Index c = (*it)[2];
+        Index d = (*it)[3];
+        Coord center = (x[a] + x[b] + x[c] + x[d]) * 0.125;
+
+        Coord pa = x[a];
+        Coord pb = x[b];
+        Coord pc = x[c];
+        Coord pd = x[d];
+
+        if ( ! vparams->displayFlags().getShowWireFrame() )
+        {
+            pa = (pa + center) * Real(0.6667);
+            pb = (pb + center) * Real(0.6667);
+            pc = (pc + center) * Real(0.6667);
+            pd = (pd + center) * Real(0.6667);
+        }
+
+        // create corresponding colors
+        sofa::type::RGBAColor color[4];
+        if (drawVonMisesStress && _showVonMisesStressPerElement.getValue())
+        {
+            if(heterogeneous)
+            {
+                float col = (float)((youngModulus[i] - minYoung) / (maxYoung - minYoung));
+                float fac = col * 0.5f;
+                color[0] = sofa::type::RGBAColor(col       , 0.0f - fac, 1.0f - col, 1.0f);
+                color[1] = sofa::type::RGBAColor(col       , 0.5f - fac, 1.0f - col, 1.0f);
+                color[2] = sofa::type::RGBAColor(col       , 1.0f - fac, 1.0f - col, 1.0f);
+                color[3] = sofa::type::RGBAColor(col + 0.5f, 1.0f - fac, 1.0f - col, 1.0f);
+            }
+            else
+            {
+                helper::ColorMap::evaluator<Real> evalColor = m_VonMisesColorMap->getEvaluator(minVM, maxVM);
+                auto col = sofa::type::RGBAColor::fromVec4(evalColor(vM[i]));
+                col[3] = 1.0f;
+                color[0] = col;
+                color[1] = col;
+                color[2] = col;
+                color[3] = col;
+            }
+        }
+        else if (!drawVonMisesStress)
+        {
+            color[0] = sofa::type::RGBAColor(0.0, 0.0, 1.0, 1.0);
+            color[1] = sofa::type::RGBAColor(0.0, 0.5, 1.0, 1.0);
+            color[2] = sofa::type::RGBAColor(0.0, 1.0, 1.0, 1.0);
+            color[3] = sofa::type::RGBAColor(0.5, 1.0, 1.0, 1.0);
+        }
+
+        // create 4 triangles per tetrahedron with corresponding colors
+        points.insert(points.end(), { pa, pb, pc });
+        colorVector.insert(colorVector.end(), { color[0], color[0], color[0] });
+
+        points.insert(points.end(), { pb, pc, pd });
+        colorVector.insert(colorVector.end(), { color[1], color[1], color[1] });
+
+        points.insert(points.end(), { pc, pd, pa });
+        colorVector.insert(colorVector.end(), { color[2], color[2], color[2] });
+
+        points.insert(points.end(), { pd, pa, pb });
+        colorVector.insert(colorVector.end(), { color[3], color[3], color[3] });
+    }
+    vparams->drawTool()->drawTriangles(points, colorVector);
+
 
     ////////////// DRAW ROTATIONS //////////////
     if (vparams->displayFlags().getShowNormals())
@@ -2040,7 +2039,6 @@ void TetrahedronFEMForceField<DataTypes>::handleEvent(core::objectmodel::Event *
             computeVonMisesStress();
         }
     }
-
 }
 
 template<class DataTypes>
@@ -2177,6 +2175,9 @@ void TetrahedronFEMForceField<DataTypes>::setMethod(int val)
 template<class DataTypes>
 void TetrahedronFEMForceField<DataTypes>::computeVonMisesStress()
 {
+    if(this->d_componentState.getValue() == ComponentState::Invalid)
+        return ;
+
     if ( ! isComputeVonMisesStressMethodSet() )
     {
         msg_warning() << "Cannot compute von Mises Stress. "

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.inl
@@ -1797,7 +1797,7 @@ void TetrahedronFEMForceField<DataTypes>::draw(const core::visual::VisualParams*
     const VecReal& youngModulus = _youngModulus.getValue();
 
     bool heterogeneous = false;
-    if (drawHeterogeneousTetra.getValue())
+    if (drawHeterogeneousTetra.getValue() && drawVonMisesStress)
     {
         minYoung=youngModulus[0];
         maxYoung=youngModulus[0];


### PR DESCRIPTION
Now callback handles the check for the draw vonMises value.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
