### PR TITLE
[SofaBaseVisual] Better Fix in VisualModelImpl for texcoord update during topological changes

### DIFF
--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
@@ -990,21 +990,20 @@ void VisualModelImpl::initFromTopology()
 
         if (m_vtexcoords.isSet()) // Data set from loader as not part of the topology
         {
-            m_vtexcoords.updateIfDirty();
-            m_vtexcoords.setParent(nullptr); // manually break the data link to follow topological changes
             m_vtexcoords.createTopologyHandler(m_topology);
             m_vtexcoords.setCreationCallback([this](Index pointIndex, TexCoord& tCoord,
                 const core::topology::BaseMeshTopology::Point& point,
                 const sofa::type::vector< Index >& ancestors,
                 const sofa::type::vector< double >& coefs)
             {
-                const VecTexCoord& texcoords = m_vtexcoords.getValue();
+                helper::WriteOnlyAccessor<Data< type::vector<TexCoord> > > texcoords = m_vtexcoords;
                 tCoord = TexCoord(0, 0);
                 for (Index i = 0; i < ancestors.size(); i++)
                 {
                     const TexCoord& tAnces = texcoords[ancestors[i]];
                     tCoord += tAnces * coefs[i];
                 }
+                m_vtexcoords.cleanDirty();
             });
         }
     }

--- a/examples/Components/forcefield/TetrahedronDiffusionFEMForceField.scn
+++ b/examples/Components/forcefield/TetrahedronDiffusionFEMForceField.scn
@@ -34,7 +34,7 @@
 
         <Node name="Visu">
             <TextureInterpolation template="Vec1d" name="EngineInterpolation"  input_states="@../gridTemperature.position"  input_coordinates="@../../raptorDOFs.position"  min_value="0.0"  max_value="1.0"  manual_scale="1"  drawPotentiels="0"  showIndicesScale="5e-05" />
-            <OglModel template="Vec3d" name="oglPotentiel"  texcoords="@EngineInterpolation.output_coordinates" texturename="textures/heatColor.bmp" scale3d="1000 1000 1000"  material="Default Diffuse 1 1 1 1 0.5 Ambient 1 1 1 1 0.3 Specular 0 0.5 0.5 0.5 1 Emissive 0 0.5 0.5 0.5 1 Shininess 0 45 No texture linked to the material No bump texture linked to the material "/>
+            <OglModel template="Vec3d" name="oglPotentiel"  handleDynamicTopology="0" texcoords="@EngineInterpolation.output_coordinates" texturename="textures/heatColor.bmp" material="Default Diffuse 1 1 1 1 0.5 Ambient 1 1 1 1 0.3 Specular 0 0.5 0.5 0.5 1 Emissive 0 0.5 0.5 0.5 1 Shininess 0 45 No texture linked to the material No bump texture linked to the material "/>
             <IdentityMapping input="@../../raptorDOFs" output="@oglPotentiel" />
         </Node>
     </Node>


### PR DESCRIPTION
Better fix to handle texture coordinate update during topological changes. 
The problem was coming from updating the data from parent Data (from Loader/engine) during the changes. 
Instead of breaking the "parentship", the topology callback has been changed to avoid calling updateIfDirty during the changes.

This PR combine with the #2414 will
fix #2392 
Add safeguard in the scene to avoid topologicalChanges which are not handled by TextureInterpolation
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
