### PR TITLE
[SofaGuiQt] Change gui dimension so the full graph view is visible at startup.

### DIFF
--- a/modules/SofaGuiQt/src/sofa/gui/qt/GUI.ui
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/GUI.ui
@@ -7,8 +7,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
-    <height>600</height>
+    <width>1280</width>
+    <height>900</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -20,7 +20,7 @@
   <property name="minimumSize">
    <size>
     <width>210</width>
-    <height>481</height>
+    <height>700</height>
    </size>
   </property>
   <property name="acceptDrops">
@@ -71,8 +71,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>800</width>
-     <height>20</height>
+     <width>1280</width>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="fileMenu">
@@ -130,8 +130,8 @@
    </property>
    <property name="minimumSize">
     <size>
-     <width>200</width>
-     <height>551</height>
+     <width>400</width>
+     <height>600</height>
     </size>
    </property>
    <attribute name="dockWidgetArea">
@@ -146,7 +146,7 @@
     </property>
     <property name="minimumSize">
      <size>
-      <width>200</width>
+      <width>400</width>
       <height>0</height>
      </size>
     </property>
@@ -338,7 +338,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>200</width>
+            <width>400</width>
             <height>0</height>
            </size>
           </property>


### PR DESCRIPTION
runSofa is now using a two column view to separate type and name in the graph view. 
by default the size is to short to visualize the types. 
In this PR i increase it. 





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
