### PR TITLE
[SofaMiscFem] Remove unnecessary copy/pasted code

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ForceField.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ForceField.h
@@ -165,20 +165,20 @@ public:
     template<class IndexArray, class ElementMat>
     void addToMatrix(sofa::defaulttype::BaseMatrix* bm, unsigned offset, const IndexArray& nodeIndex, const ElementMat& em, SReal scale )
     {
-        const unsigned S = DataTypes::deriv_total_size; // size of node blocks
+        constexpr auto S = DataTypes::deriv_total_size; // size of node blocks
         for (unsigned n1=0; n1<nodeIndex.size(); n1++)
         {
             for(unsigned i=0; i<S; i++)
             {
-                unsigned ROW = offset + S*nodeIndex[n1] + i;  // i-th row associated with node n1 in BaseMatrix
-                unsigned row = S*n1+i;                        // i-th row associated with node n1 in the element matrix
+                const unsigned ROW = offset + S*nodeIndex[n1] + i;  // i-th row associated with node n1 in BaseMatrix
+                const unsigned row = S*n1+i;                        // i-th row associated with node n1 in the element matrix
 
                 for (unsigned n2=0; n2<nodeIndex.size(); n2++)
                 {
                     for (unsigned j=0; j<S; j++)
                     {
-                        unsigned COLUMN = offset + S*nodeIndex[n2] +j; // j-th column associated with node n2 in BaseMatrix
-                        unsigned column = S*n2+j;                      // j-th column associated with node n2 in the element matrix
+                        const unsigned COLUMN = offset + S*nodeIndex[n2] +j; // j-th column associated with node n2 in BaseMatrix
+                        const unsigned column = S*n2+j;                      // j-th column associated with node n2 in the element matrix
                         bm->add( ROW,COLUMN, em[row][column]* scale );
                     }
                 }

--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangleFEMForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangleFEMForceField.h
@@ -164,37 +164,6 @@ protected :
     void computeElementStiffnessMatrix( StiffnessMatrix& S, StiffnessMatrix& SR, const MaterialStiffness &K, const StrainDisplacement &J, const Transformation& Rot );
     void addKToMatrix(sofa::defaulttype::BaseMatrix *mat, SReal k, unsigned int &offset) override; // compute and add all the element stiffnesses to the global stiffness matrix
 
-    /** Accumulate an element matrix to a global assembly matrix. This is a helper for addKToMatrix, to accumulate each (square) element matrix in the (square) assembled matrix.
-      \param bm the global assembly matrix
-      \param offset start index of the local DOFs within the global matrix
-      \param nodeIndex indices of the nodes of the element within the local nodes, as stored in the topology
-      \param em element matrix, typically a stiffness, damping, mass, or weighted sum thereof
-      \param scale weight applied to the matrix, typically ±params->kfactor() for a stiffness matrix
-      */
-    template<class IndexArray, class ElementMat>
-    void addToMatrix(sofa::defaulttype::BaseMatrix* bm, unsigned offset, const IndexArray& nodeIndex, const ElementMat& em, SReal scale )
-    {
-        const unsigned  S = DataTypes::deriv_total_size; // size of node blocks
-        for (unsigned n1=0; n1<nodeIndex.size(); n1++)
-        {
-            for(unsigned i=0; i<S; i++)
-            {
-                unsigned ROW = offset + S*nodeIndex[n1] + i;  // i-th row associated with node n1 in BaseMatrix
-                unsigned row = S*n1+i;                        // i-th row associated with node n1 in the element matrix
-
-                for (unsigned n2=0; n2<nodeIndex.size(); n2++)
-                {
-                    for (unsigned j=0; j<S; j++)
-                    {
-                        unsigned COLUMN = offset + S*nodeIndex[n2] +j; // j-th column associated with node n2 in BaseMatrix
-                        unsigned column = 3*n2+j;                      // j-th column associated with node n2 in the element matrix
-                        bm->add( ROW,COLUMN, em[row][column]* scale );
-                    }
-                }
-            }
-        }
-    }
-
     type::Mat<3, 3, Real> InvalidTransform;
     type::fixed_array <Coord, 3> InvalidCoords;
     StrainDisplacement InvalidStrainDisplacement;


### PR DESCRIPTION
`TriangleFEMForceField::addToMatrix` was a copy/paste of `ForceField::addToMatrix`, which is a base class: it is unnecessary.
Note it is used in `TriangleFEMForceField::addKToMatrix`.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
