### PR TITLE
[SofaOpenglVisual] add legend size and shift the color map associated

### DIFF
--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglColorMap.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglColorMap.cpp
@@ -45,18 +45,18 @@ int OglColorMapClass = core::RegisterObject("Provides color palette and support 
         ;
 
 OglColorMap::OglColorMap()
-: f_paletteSize(initData(&f_paletteSize, (unsigned int)256, "paletteSize", "How many colors to use"))
-, f_colorScheme(initData(&f_colorScheme, "colorScheme", "Color scheme to use"))
-, f_showLegend(initData(&f_showLegend, false, "showLegend", "Activate rendering of color scale legend on the side"))
-, f_legendOffset(initData(&f_legendOffset, type::Vec2f(10.0f,5.0f),"legendOffset", "Draw the legend on screen with an x,y offset"))
-, f_legendTitle(initData(&f_legendTitle,"legendTitle", "Add a title to the legend"))
-, f_legendSize(initData(&f_legendSize, 11u, "legendSize", "Add a title to the legend"))
+: d_paletteSize(initData(&d_paletteSize, (unsigned int)256, "paletteSize", "How many colors to use"))
+, d_colorScheme(initData(&d_colorScheme, "colorScheme", "Color scheme to use"))
+, d_showLegend(initData(&d_showLegend, false, "showLegend", "Activate rendering of color scale legend on the side"))
+, d_legendOffset(initData(&d_legendOffset, type::Vec2f(10.0f,5.0f),"legendOffset", "Draw the legend on screen with an x,y offset"))
+, d_legendTitle(initData(&d_legendTitle,"legendTitle", "Font size of the legend (if any)"))
+, d_legendSize(initData(&d_legendSize, 11u, "legendSize", "Add a title to the legend"))
 , d_min(initData(&d_min,0.0f,"min","min value for drawing the legend without the need to actually use the range with getEvaluator method wich sets the min"))
 , d_max(initData(&d_max,0.0f,"max","max value for drawing the legend without the need to actually use the range with getEvaluator method wich sets the max"))
 , d_legendRangeScale(initData(&d_legendRangeScale,1.f,"legendRangeScale","to change the unit of the min/max value of the legend"))
 , texture(0)
 {
-   f_colorScheme.beginEdit()->setNames(19,
+   d_colorScheme.beginEdit()->setNames(19,
         "Red to Blue",  // HSV space
         "Blue to Red",  // HSV space
         "HSV",          // HSV space
@@ -78,8 +78,8 @@ OglColorMap::OglColorMap()
 		"RedInv",// HSV space
         "Custom"// TODO: Custom colors
         );
-    f_colorScheme.beginEdit()->setSelectedItem("HSV");
-    f_colorScheme.endEdit();
+    d_colorScheme.beginEdit()->setSelectedItem("HSV");
+    d_colorScheme.endEdit();
 
 }
 
@@ -99,8 +99,8 @@ void OglColorMap::init()
 
 void OglColorMap::reinit()
 {
-    m_colorMap.setPaletteSize(f_paletteSize.getValue());
-    m_colorMap.setColorScheme(f_colorScheme.getValue().getSelectedItem());
+    m_colorMap.setPaletteSize(d_paletteSize.getValue());
+    m_colorMap.setColorScheme(d_colorScheme.getValue().getSelectedItem());
     m_colorMap.reinit();
     }
 
@@ -119,7 +119,7 @@ void OglColorMap::drawVisual(const core::visual::VisualParams* vparams)
 {
     if( !vparams->displayFlags().getShowVisual() ) return;
 
-    if (!f_showLegend.getValue()) return;
+    if (!d_showLegend.getValue()) return;
 
     // Prepare texture for legend
     // crashes on mac in batch mode (no GL context)
@@ -159,8 +159,8 @@ void OglColorMap::drawVisual(const core::visual::VisualParams* vparams)
     // TODO: move the code to DrawTool
 
 
-    const std::string& legendTitle = f_legendTitle.getValue();
-    int yoffset = legendTitle.empty() ? 0 : (int)(2*f_legendSize.getValue());
+    const std::string& legendTitle = d_legendTitle.getValue();
+    int yoffset = legendTitle.empty() ? 0 : (int)(2*d_legendSize.getValue());
 
 
     GLint viewport[4];
@@ -206,16 +206,16 @@ void OglColorMap::drawVisual(const core::visual::VisualParams* vparams)
     glBegin(GL_QUADS);
 
     glTexCoord1f(1.0);
-    glVertex3f(20.0f+f_legendOffset.getValue().x(), yoffset+20.0f+f_legendOffset.getValue().y(), 0.0f);
+    glVertex3f(20.0f+d_legendOffset.getValue().x(), yoffset+20.0f+d_legendOffset.getValue().y(), 0.0f);
 
     glTexCoord1f(1.0);
-    glVertex3f(10.0f+f_legendOffset.getValue().x(), yoffset+20.0f+f_legendOffset.getValue().y(), 0.0f);
+    glVertex3f(10.0f+d_legendOffset.getValue().x(), yoffset+20.0f+d_legendOffset.getValue().y(), 0.0f);
 
     glTexCoord1f(0.0);
-    glVertex3f(10.0f+f_legendOffset.getValue().x(), yoffset+120.0f+f_legendOffset.getValue().y(), 0.0f);
+    glVertex3f(10.0f+d_legendOffset.getValue().x(), yoffset+120.0f+d_legendOffset.getValue().y(), 0.0f);
 
     glTexCoord1f(0.0);
-    glVertex3f(20.0f+f_legendOffset.getValue().x(), yoffset+120.0f+f_legendOffset.getValue().y(), 0.0f);
+    glVertex3f(20.0f+d_legendOffset.getValue().x(), yoffset+120.0f+d_legendOffset.getValue().y(), 0.0f);
 
     glEnd();
 
@@ -242,9 +242,9 @@ void OglColorMap::drawVisual(const core::visual::VisualParams* vparams)
 
     if( !legendTitle.empty() )
     {
-        vparams->drawTool()->writeOverlayText((int)f_legendOffset.getValue().x(), // x
-                                              (int)f_legendOffset.getValue().y(), // y
-                                              f_legendSize.getValue(),
+        vparams->drawTool()->writeOverlayText((int)d_legendOffset.getValue().x(), // x
+                                              (int)d_legendOffset.getValue().y(), // y
+                                              d_legendSize.getValue(),
                                               textcolor,
                                               legendTitle.c_str());
     }
@@ -258,14 +258,14 @@ void OglColorMap::drawVisual(const core::visual::VisualParams* vparams)
 
 
 
-    vparams->drawTool()->writeOverlayText((int)f_legendOffset.getValue().x(), // x
-                                          yoffset + (int)f_legendOffset.getValue().y(), // y
+    vparams->drawTool()->writeOverlayText((int)d_legendOffset.getValue().x(), // x
+                                          yoffset + (int)d_legendOffset.getValue().y(), // y
                                           12u, // size
                                           textcolor,
                                           smax.str().c_str());
 
-    vparams->drawTool()->writeOverlayText((int)f_legendOffset.getValue().x(), // x
-                                          yoffset + 120 + (int)f_legendOffset.getValue().y(), // y
+    vparams->drawTool()->writeOverlayText((int)d_legendOffset.getValue().x(), // x
+                                          yoffset + 120 + (int)d_legendOffset.getValue().y(), // y
                                           12u, // size
                                           textcolor,
                                           smin.str().c_str());

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglColorMap.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglColorMap.cpp
@@ -50,6 +50,7 @@ OglColorMap::OglColorMap()
 , f_showLegend(initData(&f_showLegend, false, "showLegend", "Activate rendering of color scale legend on the side"))
 , f_legendOffset(initData(&f_legendOffset, type::Vec2f(10.0f,5.0f),"legendOffset", "Draw the legend on screen with an x,y offset"))
 , f_legendTitle(initData(&f_legendTitle,"legendTitle", "Add a title to the legend"))
+, f_legendSize(initData(&f_legendSize, 11u, "legendSize", "Add a title to the legend"))
 , d_min(initData(&d_min,0.0f,"min","min value for drawing the legend without the need to actually use the range with getEvaluator method wich sets the min"))
 , d_max(initData(&d_max,0.0f,"max","max value for drawing the legend without the need to actually use the range with getEvaluator method wich sets the max"))
 , d_legendRangeScale(initData(&d_legendRangeScale,1.f,"legendRangeScale","to change the unit of the min/max value of the legend"))
@@ -159,7 +160,7 @@ void OglColorMap::drawVisual(const core::visual::VisualParams* vparams)
 
 
     const std::string& legendTitle = f_legendTitle.getValue();
-    int yoffset = legendTitle.empty() ? 0 : 25;
+    int yoffset = legendTitle.empty() ? 0 : (int)(2*f_legendSize.getValue());
 
 
     GLint viewport[4];
@@ -243,7 +244,7 @@ void OglColorMap::drawVisual(const core::visual::VisualParams* vparams)
     {
         vparams->drawTool()->writeOverlayText((int)f_legendOffset.getValue().x(), // x
                                               (int)f_legendOffset.getValue().y(), // y
-                                              11u, // size
+                                              f_legendSize.getValue(),
                                               textcolor,
                                               legendTitle.c_str());
     }

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglColorMap.h
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglColorMap.h
@@ -57,13 +57,13 @@ protected:
     ~OglColorMap() override;
 
 public:
-    Data<unsigned int> f_paletteSize; ///< How many colors to use
-    Data<sofa::helper::OptionsGroup> f_colorScheme; ///< Color scheme to use
+    Data<unsigned int> d_paletteSize; ///< How many colors to use
+    Data<sofa::helper::OptionsGroup> d_colorScheme; ///< Color scheme to use
 
-    Data<bool> f_showLegend; ///< Activate rendering of color scale legend on the side
-    Data<type::Vec2f> f_legendOffset; ///< Draw the legend on screen with an x,y offset
-    Data<std::string> f_legendTitle; ///< Add a title to the legend
-    Data<unsigned int> f_legendSize; ///< Fond size of the legend if any
+    Data<bool> d_showLegend; ///< Activate rendering of color scale legend on the side
+    Data<type::Vec2f> d_legendOffset; ///< Draw the legend on screen with an x,y offset
+    Data<std::string> d_legendTitle; ///< Add a title to the legend
+    Data<unsigned int> d_legendSize; ///< Font size of the legend (if any)
     Data<float> d_min; ///< min value for drawing the legend without the need to actually use the range with getEvaluator method wich sets the min
     Data<float> d_max; ///< max value for drawing the legend without the need to actually use the range with getEvaluator method wich sets the max
     Data<float> d_legendRangeScale; ///< to convert unit

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglColorMap.h
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglColorMap.h
@@ -63,6 +63,7 @@ public:
     Data<bool> f_showLegend; ///< Activate rendering of color scale legend on the side
     Data<type::Vec2f> f_legendOffset; ///< Draw the legend on screen with an x,y offset
     Data<std::string> f_legendTitle; ///< Add a title to the legend
+    Data<unsigned int> f_legendSize; ///< Fond size of the legend if any
     Data<float> d_min; ///< min value for drawing the legend without the need to actually use the range with getEvaluator method wich sets the min
     Data<float> d_max; ///< max value for drawing the legend without the need to actually use the range with getEvaluator method wich sets the max
     Data<float> d_legendRangeScale; ///< to convert unit


### PR DESCRIPTION


![thermoelasticity_00000001](https://user-images.githubusercontent.com/17544719/137492922-52ee8c4c-82cf-4f0d-99b2-92f650d4da9d.png)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
