### PR TITLE
[Sofa.Helper] PluginManager: Add optional way to check if a plugin is init at the load stage

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
@@ -192,7 +192,7 @@ bool PluginManager::loadPluginByPath(const std::string& pluginPath, std::ostream
     {
         if (!p.moduleIsInitialized())
         {
-            const std::string msg = pluginPath + " reported an error while trying to initialize. " + "This plugin will not be loaded.";
+            const std::string msg = pluginPath + " reported an error while trying to initialize. This plugin will not be loaded.";
             msg_error("PluginManager") << msg;
             if (errlog) (*errlog) << msg << std::endl;
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.cpp
@@ -66,6 +66,7 @@ const char* Plugin::GetModuleDescription::symbol      = "getModuleDescription";
 const char* Plugin::GetModuleLicense::symbol          = "getModuleLicense";
 const char* Plugin::GetModuleName::symbol             = "getModuleName";
 const char* Plugin::GetModuleVersion::symbol          = "getModuleVersion";
+const char* Plugin::ModuleIsInitialized::symbol       = "moduleIsInitialized";
 
 std::string PluginManager::s_gui_postfix = "gui";
 
@@ -185,6 +186,20 @@ bool PluginManager::loadPluginByPath(const std::string& pluginPath, std::ostream
     p.dynamicLibrary = d;
     m_pluginMap[pluginPath] = p;
     p.initExternalModule();
+
+    // check if the plugin is initialized (if it can report this information)
+    if (getPluginEntry(p.moduleIsInitialized, d))
+    {
+        if (!p.moduleIsInitialized())
+        {
+            const std::string msg = pluginPath + " reported an error while trying to initialize. " + "This plugin will not be loaded.";
+            msg_error("PluginManager") << msg;
+            if (errlog) (*errlog) << msg << std::endl;
+
+            unloadPlugin(pluginPath);
+            return false;
+        }
+    }
 
     msg_info("PluginManager") << "Loaded plugin: " << pluginPath;
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/system/PluginManager.h
@@ -119,12 +119,25 @@ public:
         GetModuleVersion():func(nullptr) {}
     } GetModuleVersion;
 
+    struct ModuleIsInitialized
+    {
+        static const char* symbol;
+        typedef bool (*FuncPtr) ();
+        FuncPtr func;
+        bool operator() () const
+        {
+            return (func) ? func() : false;
+        }
+        ModuleIsInitialized() :func(nullptr) {}
+    };
+
     InitExternalModule     initExternalModule;
     GetModuleName          getModuleName;
     GetModuleDescription   getModuleDescription;
     GetModuleLicense       getModuleLicense;
     GetModuleComponentList getModuleComponentList;
     GetModuleVersion       getModuleVersion;
+    ModuleIsInitialized    moduleIsInitialized;
 private:
     DynamicLibrary::Handle dynamicLibrary;
 


### PR DESCRIPTION
No information is given when the initExternalModule entry point is called.
For 99.999% of the plugins, there is nothing special in it but some (SofaPython3, I am looking at you) is doing a lot of "failable" things when it is called.
This PR is a potential solution to this problem, by adding a (optional) entry point to check if the plugin reports by itself that it was loaded successfully.

This allows SOFA to not crash if a problem arises in SofaPython3 when calling PythonEnvironment::Init() 

It is not really necessary for the "ci depends on" as the two PR can compile without needing the other one; but it makes sense to merge them in the same time I think.

[ci-depends-on https://github.com/sofa-framework/SofaPython3/pull/210]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
