### PR TITLE
[Sofa.Core] Remove unnecessary functions because they are in base class

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/Mass.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/Mass.h
@@ -66,11 +66,6 @@ protected:
 public:
     void init() override;
 
-    /// Retrieve the associated MechanicalState
-    MechanicalState<DataTypes>* getMState() { return this->mstate.get(); }
-    const MechanicalState<DataTypes>* getMState() const { return this->mstate.get(); }
-
-
     /// @name Vector operations
     /// @{
     ///                         $ f += factor M dx $


### PR DESCRIPTION
The removed code is a copy/paste of its base class. It's useless, and also triggers warning because it hides its base class implementation.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
