### PR TITLE
[Sofa.Geometry][Sofa.Topology] Add some functions + create unittests

### DIFF
--- a/SofaKernel/modules/Sofa.Geometry/CMakeLists.txt
+++ b/SofaKernel/modules/Sofa.Geometry/CMakeLists.txt
@@ -37,3 +37,11 @@ sofa_create_package_with_targets(
     INCLUDE_SOURCE_DIR "src"
     INCLUDE_INSTALL_DIR "${PROJECT_NAME}"
 )
+
+# Tests
+# If SOFA_BUILD_TESTS exists and is OFF, then these tests will be auto-disabled
+cmake_dependent_option(SOFAGEOMETRY_BUILD_TESTS "Compile the automatic tests" ON "SOFA_BUILD_TESTS OR NOT DEFINED SOFA_BUILD_TESTS" OFF)
+if(SOFAGEOMETRY_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(${PROJECT_NAME}_test)
+endif()

--- a/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/CMakeLists.txt
+++ b/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/CMakeLists.txt
@@ -5,7 +5,9 @@ project(Sofa.Geometry_test)
 set(SOURCE_FILES
     Edge_test.cpp
     Triangle_test.cpp
+    Quad_test.cpp
     Tetrahedron_test.cpp
+    Hexahedron_test.cpp
 )
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})

--- a/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/CMakeLists.txt
+++ b/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(Sofa.Geometry_test)
+
+set(SOURCE_FILES
+    Edge_test.cpp
+    Triangle_test.cpp
+    Tetrahedron_test.cpp
+)
+
+add_executable(${PROJECT_NAME} ${SOURCE_FILES})
+
+target_link_libraries(${PROJECT_NAME} Sofa.Testing Sofa.Geometry)
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Edge_test.cpp
+++ b/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Edge_test.cpp
@@ -1,0 +1,102 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <sofa/geometry/Edge.h>
+
+#include <sofa/type/fixed_array.h>
+#include <array>
+#include <sofa/type/Vec.h>
+
+#include <gtest/gtest.h>
+
+
+namespace sofa
+{
+
+TEST(GeometryEdge_test, squaredLength1f)
+{
+    const std::array<float, 1> a1{ 1.f };
+    const std::array<float, 1> b1{ 10.f };
+
+    const sofa::type::fixed_array<float, 1> a2{ 1.f };
+    const sofa::type::fixed_array<float, 1> b2{ 10.f };
+
+    const sofa::type::Vec1f a3{ 1.f };
+    const sofa::type::Vec1f b3{ 10.f };
+
+    const float expectedResult = 81.f;
+
+    EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength(a1, b1));
+    EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength(a2, b2));
+    EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength(a3, b3));
+}
+
+TEST(GeometryEdge_test, squaredLength2f_stdarray)
+{
+    const std::array<float, 2> a1{ 1.f, 1.f };
+    const std::array<float, 2> b1{ 10.f, 10.f };
+    const sofa::type::fixed_array<float, 2> a2{ 1.f, 1.f };
+    const sofa::type::fixed_array<float, 2> b2{ 10.f, 10.f };
+    const sofa::type::Vec2f a3{ 1.f, 1.f };
+    const sofa::type::Vec2f b3{ 10.f, 10.f };
+
+    const float expectedResult = 162.f;
+
+    EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength(a1, b1));
+    EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength(a2, b2));
+    EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength(a3, b3));
+}
+
+TEST(GeometryEdge_test, squaredLength3f_stdarray)
+{
+    const std::array<float, 3> a1{ 3.f, 2.f, 7.f };
+    const std::array<float, 3> b1{ 8.f, 1.f, 9.f };
+    const sofa::type::fixed_array<float, 3> a2{ 3.f, 2.f, 7.f };
+    const sofa::type::fixed_array<float, 3> b2{ 8.f, 1.f, 9.f };
+    const sofa::type::Vec3f a3{ 3.f, 2.f, 7.f };
+    const sofa::type::Vec3f b3{ 8.f, 1.f, 9.f };
+
+    const float expectedResult = 30.f;
+
+    EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength(a1, b1));
+    EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength(a2, b2));
+    EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength(a3, b3));
+}
+
+TEST(GeometryEdge_test, length3f_stdarray)
+{
+    const std::array<float, 3> a1{ 2.f, 1.f, 1.f };
+    const std::array<float, 3> b1{ 5.f, 2.f, -1.f };
+    const sofa::type::fixed_array<float, 3> a2{ 2.f, 1.f, 1.f };
+    const sofa::type::fixed_array<float, 3> b2{ 5.f, 2.f, -1.f };
+    const sofa::type::Vec3f a3{ 2.f, 1.f, 1.f };
+    const sofa::type::Vec3f b3{ 5.f, 2.f, -1.f };
+
+    const float expectedResult = 3.74165739f;
+
+    EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::length(a1, b1));
+    EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::length(a2, b2));
+    EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::length(a3, b3));
+}
+
+
+}// namespace sofa

--- a/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Edge_test.cpp
+++ b/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Edge_test.cpp
@@ -50,7 +50,7 @@ TEST(GeometryEdge_test, squaredLength1f)
     EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength(a3, b3));
 }
 
-TEST(GeometryEdge_test, squaredLength2f_stdarray)
+TEST(GeometryEdge_test, squaredLength2f)
 {
     const std::array<float, 2> a1{ 1.f, 1.f };
     const std::array<float, 2> b1{ 10.f, 10.f };
@@ -66,7 +66,7 @@ TEST(GeometryEdge_test, squaredLength2f_stdarray)
     EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength(a3, b3));
 }
 
-TEST(GeometryEdge_test, squaredLength3f_stdarray)
+TEST(GeometryEdge_test, squaredLength3f)
 {
     const std::array<float, 3> a1{ 3.f, 2.f, 7.f };
     const std::array<float, 3> b1{ 8.f, 1.f, 9.f };
@@ -82,7 +82,7 @@ TEST(GeometryEdge_test, squaredLength3f_stdarray)
     EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength(a3, b3));
 }
 
-TEST(GeometryEdge_test, length3f_stdarray)
+TEST(GeometryEdge_test, length3f)
 {
     const std::array<float, 3> a1{ 2.f, 1.f, 1.f };
     const std::array<float, 3> b1{ 5.f, 2.f, -1.f };
@@ -97,6 +97,5 @@ TEST(GeometryEdge_test, length3f_stdarray)
     EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::length(a2, b2));
     EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::length(a3, b3));
 }
-
 
 }// namespace sofa

--- a/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Edge_test.cpp
+++ b/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Edge_test.cpp
@@ -48,6 +48,10 @@ TEST(GeometryEdge_test, squaredLength1f)
     EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength(a1, b1));
     EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength(a2, b2));
     EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength(a3, b3));
+
+    //special cases
+    EXPECT_FLOAT_EQ(0.f, sofa::geometry::Edge::squaredLength(a1, a1));
+    EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength((a3 * -1.f), (b3 * -1.f)));
 }
 
 TEST(GeometryEdge_test, squaredLength2f)
@@ -64,6 +68,10 @@ TEST(GeometryEdge_test, squaredLength2f)
     EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength(a1, b1));
     EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength(a2, b2));
     EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength(a3, b3));
+
+    //special cases
+    EXPECT_FLOAT_EQ(0.f, sofa::geometry::Edge::squaredLength(a1, a1));
+    EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength((a3 * -1.f), (b3 * -1.f)));
 }
 
 TEST(GeometryEdge_test, squaredLength3f)
@@ -80,6 +88,10 @@ TEST(GeometryEdge_test, squaredLength3f)
     EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength(a1, b1));
     EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength(a2, b2));
     EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength(a3, b3));
+
+    //special cases
+    EXPECT_FLOAT_EQ(0.f, sofa::geometry::Edge::squaredLength(a1, a1));
+    EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::squaredLength( (a3 * -1.f), (b3 * -1.f)));
 }
 
 TEST(GeometryEdge_test, length3f)
@@ -96,6 +108,10 @@ TEST(GeometryEdge_test, length3f)
     EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::length(a1, b1));
     EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::length(a2, b2));
     EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::length(a3, b3));
+
+    //special cases
+    EXPECT_FLOAT_EQ(0.f, sofa::geometry::Edge::length(a1, a1));
+    EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::length((a3 * -1.f), (b3 * -1.f)));
 }
 
 }// namespace sofa

--- a/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Hexahedron_test.cpp
+++ b/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Hexahedron_test.cpp
@@ -140,38 +140,49 @@ TEST(GeometryHexahedron_test, getPositionFromBarycentricCoefficients_vec3f)
     EXPECT_TRUE(testPosition[0] == expectedPosition[0] && testPosition[1] == expectedPosition[1] && testPosition[2] == expectedPosition[2]);
 }
 
-TEST(GeometryHexahedron_test, volume_vec3f)
+TEST(GeometryHexahedron_test, cube_volume_vec3f)
 {
-    {
-        const sofa::type::Vec3f a{ 0.f, 0.f, 0.f };
-        const sofa::type::Vec3f b{ 8.f, 0.f, 0.f };
-        const sofa::type::Vec3f c{ 8.f, 8.f, 0.f };
-        const sofa::type::Vec3f d{ 0.f, 8.f, 0.f };
-        const sofa::type::Vec3f e{ 0.f, 0.f, 8.f };
-        const sofa::type::Vec3f f{ 8.f, 0.f, 8.f };
-        const sofa::type::Vec3f g{ 8.f, 8.f, 8.f };
-        const sofa::type::Vec3f h{ 0.f, 8.f, 8.f };
+    
+    const sofa::type::Vec3f a{ 0.f, 0.f, 0.f };
+    const sofa::type::Vec3f b{ 8.f, 0.f, 0.f };
+    const sofa::type::Vec3f c{ 8.f, 8.f, 0.f };
+    const sofa::type::Vec3f d{ 0.f, 8.f, 0.f };
+    const sofa::type::Vec3f e{ 0.f, 0.f, 8.f };
+    const sofa::type::Vec3f f{ 8.f, 0.f, 8.f };
+    const sofa::type::Vec3f g{ 8.f, 8.f, 8.f };
+    const sofa::type::Vec3f h{ 0.f, 8.f, 8.f };
 
-        auto testVolume = sofa::geometry::Hexahedron::volume(a, b, c, d, e, f, g, h);
-        auto expectedVolume = 8.f * 8.f * 8.f;
+    auto testVolume = sofa::geometry::Hexahedron::volume(a, b, c, d, e, f, g, h);
+    auto expectedVolume = 8.f * 8.f * 8.f;
 
-        EXPECT_FLOAT_EQ(testVolume, expectedVolume);
-    }
-    {
-        const sofa::type::Vec3f a{ 0.f, 0.f, 0.f };
-        const sofa::type::Vec3f b{ 7.f, 0.f, 1.f };
-        const sofa::type::Vec3f c{ 8.f, 8.f, 1.f };
-        const sofa::type::Vec3f d{ 0.f, 9.f, 0.f };
-        const sofa::type::Vec3f e{ 0.f, 0.f, 7.f };
-        const sofa::type::Vec3f f{ 8.f, 0.f, 7.f };
-        const sofa::type::Vec3f g{ 9.f, 8.f, 9.f };
-        const sofa::type::Vec3f h{ 0.f, 7.f, 8.f };
+    EXPECT_FLOAT_EQ(testVolume, expectedVolume);
+}
+TEST(GeometryHexahedron_test, rand_volume_vec3f)
+{
+    const sofa::type::Vec3f a{ 0.f, 0.f, 0.f };
+    const sofa::type::Vec3f b{ 7.f, 0.f, 1.f };
+    const sofa::type::Vec3f c{ 8.f, 8.f, 1.f };
+    const sofa::type::Vec3f d{ 0.f, 9.f, 0.f };
+    const sofa::type::Vec3f e{ 0.f, 0.f, 7.f };
+    const sofa::type::Vec3f f{ 8.f, 0.f, 7.f };
+    const sofa::type::Vec3f g{ 9.f, 8.f, 9.f };
+    const sofa::type::Vec3f h{ 0.f, 7.f, 8.f };
 
-        auto testVolume = sofa::geometry::Hexahedron::volume(a, b, c, d, e, f, g, h);
-        auto expectedVolume = 469.16667f;
+    auto testVolume = sofa::geometry::Hexahedron::volume(a, b, c, d, e, f, g, h);
+    auto expectedVolume = 469.16667f;
 
-        EXPECT_FLOAT_EQ(testVolume, expectedVolume);
-    }
+    EXPECT_FLOAT_EQ(testVolume, expectedVolume);
+}
+TEST(GeometryHexahedron_test, null_volume_vec3f)
+{
+    // special case
+    const sofa::type::Vec3f a{ 0.f, 0.f, 0.f };
+
+    auto testVolume = sofa::geometry::Hexahedron::volume(a, a, a, a, a, a, a, a);
+    auto expectedVolume = 0.f;
+
+    EXPECT_FLOAT_EQ(testVolume, expectedVolume);
+    
 }
 
 }// namespace sofa

--- a/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Hexahedron_test.cpp
+++ b/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Hexahedron_test.cpp
@@ -1,0 +1,177 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <sofa/geometry/Hexahedron.h>
+
+#include <sofa/type/fixed_array.h>
+#include <array>
+
+#include <gtest/gtest.h>
+
+namespace sofa
+{
+
+TEST(GeometryHexahedron_test, center_vec3f)
+{
+    const sofa::type::Vec3f a{ 0.f, 0.f, 0.f };
+    const sofa::type::Vec3f b{ 10.f, 0.f, 0.f };
+    const sofa::type::Vec3f c{ 0.f, 10.f, 0.f };
+    const sofa::type::Vec3f d{ 10.f, 10.f, 0.f };
+    const sofa::type::Vec3f e{ 0.f, 0.f, 10.f };
+    const sofa::type::Vec3f f{ 10.f, 0.f, 10.f };
+    const sofa::type::Vec3f g{ 0.f, 10.f, 10.f };
+    const sofa::type::Vec3f h{ 10.f, 10.f, 10.f };
+
+    const sofa::type::Vec3f expectedCenter{ 5.f, 5.f, 5.f };
+    const auto testCenter = sofa::geometry::Hexahedron::center(a, b, c, d, e, f ,g, h);
+    EXPECT_EQ(testCenter, expectedCenter);
+    EXPECT_EQ(testCenter, (h-a) * 0.5f);
+}
+
+TEST(GeometryHexahedron_test, barycentricCoefficients_vec3f)
+{
+    const sofa::type::Vec3f a{ 0.f, 0.f, 0.f };
+    const sofa::type::Vec3f b{ 8.f, 0.f, 0.f };
+    const sofa::type::Vec3f c{ 8.f, 8.f, 0.f };
+    const sofa::type::Vec3f d{ 0.f, 8.f, 0.f };
+    const sofa::type::Vec3f e{ 0.f, 0.f, 8.f };
+    const sofa::type::Vec3f f{ 8.f, 0.f, 8.f };
+    const sofa::type::Vec3f g{ 8.f, 8.f, 8.f };
+    const sofa::type::Vec3f h{ 0.f, 8.f, 8.f };
+
+    const sofa::type::Vec3f pos0{ 4.f, 4.f, 4.f };
+    auto testCoeffs = sofa::geometry::Hexahedron::barycentricCoefficients(a, b, c, d, e, f, g, h, pos0);
+
+    sofa::type::fixed_array<float,3> expectedCoeffs{ .5f, .5f, .5f };
+    // no operator == for sofa::fixed_array
+    EXPECT_TRUE(testCoeffs[0] == expectedCoeffs[0] && testCoeffs[1] == expectedCoeffs[1] && testCoeffs[2] == expectedCoeffs[2]);
+
+    const sofa::type::Vec3f pos1{ 0.f, 8.f, 0.f };
+    testCoeffs = sofa::geometry::Hexahedron::barycentricCoefficients(a, b, c, d, e, f, g, h, pos1);
+    expectedCoeffs = sofa::type::fixed_array<float, 3>{ 0.f, 1.f, 0.f };
+    EXPECT_TRUE(testCoeffs[0] == expectedCoeffs[0] && testCoeffs[1] == expectedCoeffs[1] && testCoeffs[2] == expectedCoeffs[2]);
+
+    const sofa::type::Vec3f pos2{ 6.f, 0.f, 2.0f };
+    testCoeffs = sofa::geometry::Hexahedron::barycentricCoefficients(a, b, c, d, e, f, g, h, pos2);
+    expectedCoeffs = sofa::type::fixed_array<float, 3>{ 0.75f, 0.f, 0.25f };
+    EXPECT_TRUE(testCoeffs[0] == expectedCoeffs[0] && testCoeffs[1] == expectedCoeffs[1] && testCoeffs[2] == expectedCoeffs[2]);
+}
+
+TEST(GeometryHexahedron_test, squaredDistanceTo_vec3f)
+{
+    const sofa::type::Vec3f a{ 0.f, 0.f, 0.f };
+    const sofa::type::Vec3f b{ 10.f, 0.f, 0.f };
+    const sofa::type::Vec3f c{ 10.f, 10.f, 0.f };
+    const sofa::type::Vec3f d{ 0.f, 10.f, 0.f };
+    const sofa::type::Vec3f e{ 0.f, 0.f, 10.f };
+    const sofa::type::Vec3f f{ 10.f, 0.f, 10.f };
+    const sofa::type::Vec3f g{ 10.f, 10.f, 10.f };
+    const sofa::type::Vec3f h{ 0.f, 10.f, 10.f };
+
+    const sofa::type::Vec3f pos0{ 5.f, 5.f, 5.f };
+    auto testSqDistance = sofa::geometry::Hexahedron::squaredDistanceTo(a, b, c, d, e, f, g, h, pos0);
+
+    float expectedDistance = 0.f; // inside
+    EXPECT_FLOAT_EQ(testSqDistance, expectedDistance * expectedDistance);
+
+    const sofa::type::Vec3f pos1{ 15.f, 5.f, 5.f };
+    testSqDistance = sofa::geometry::Hexahedron::squaredDistanceTo(a, b, c, d, e, f, g, h, pos1);
+    expectedDistance = 10.f;
+    EXPECT_FLOAT_EQ(testSqDistance, expectedDistance * expectedDistance);
+
+    const sofa::type::Vec3f pos2{ -15.f, -15.f, -15.f };
+    testSqDistance = sofa::geometry::Hexahedron::squaredDistanceTo(a, b, c, d, e, f, g, h, pos2);
+    expectedDistance = 34.641016f;
+    EXPECT_FLOAT_EQ(testSqDistance, expectedDistance * expectedDistance);
+}
+
+TEST(GeometryHexahedron_test, getPositionFromBarycentricCoefficients_vec3f)
+{
+    const sofa::type::Vec3f a{ 0.f, 0.f, 0.f };
+    const sofa::type::Vec3f b{ 8.f, 0.f, 0.f };
+    const sofa::type::Vec3f c{ 8.f, 8.f, 0.f };
+    const sofa::type::Vec3f d{ 0.f, 8.f, 0.f };
+    const sofa::type::Vec3f e{ 0.f, 0.f, 8.f };
+    const sofa::type::Vec3f f{ 8.f, 0.f, 8.f };
+    const sofa::type::Vec3f g{ 8.f, 8.f, 8.f };
+    const sofa::type::Vec3f h{ 0.f, 8.f, 8.f };
+
+    const sofa::type::fixed_array<SReal, 3> coeffs0{ 0.5f, 0.5f, 0.5f };
+    auto testPosition = sofa::geometry::Hexahedron::getPositionFromBarycentricCoefficients(a, b, c, d, e, f, g, h, coeffs0);
+    sofa::type::Vec3f expectedPosition{ 4.f, 4.f, 4.f };
+    // no operator == for sofa::fixed_array
+    EXPECT_TRUE(testPosition[0] == expectedPosition[0] && testPosition[1] == expectedPosition[1] && testPosition[2] == expectedPosition[2]);
+
+    const sofa::type::fixed_array<SReal, 3> coeffs1{ 1.0f, 1.0f, 1.0f };
+    testPosition = sofa::geometry::Hexahedron::getPositionFromBarycentricCoefficients(a, b, c, d, e, f, g, h, coeffs1);
+    expectedPosition = sofa::type::Vec3f{ 8.f, 8.f, 8.f };
+    // no operator == for sofa::fixed_array
+    EXPECT_TRUE(testPosition[0] == expectedPosition[0] && testPosition[1] == expectedPosition[1] && testPosition[2] == expectedPosition[2]);
+
+    const sofa::type::fixed_array<SReal, 3> coeffs2{ 0.0f, 0.0f, 0.0f };
+    testPosition = sofa::geometry::Hexahedron::getPositionFromBarycentricCoefficients(a, b, c, d, e, f, g, h, coeffs2);
+    expectedPosition = sofa::type::Vec3f{ 0.f, 0.f, 0.f };
+    // no operator == for sofa::fixed_array
+    EXPECT_TRUE(testPosition[0] == expectedPosition[0] && testPosition[1] == expectedPosition[1] && testPosition[2] == expectedPosition[2]);
+
+    const sofa::type::fixed_array<SReal, 3> coeffs3{ 0.1f, 0.6f, 0.3f };
+    testPosition = sofa::geometry::Hexahedron::getPositionFromBarycentricCoefficients(a, b, c, d, e, f, g, h, coeffs3);
+    expectedPosition = sofa::type::Vec3f{ 0.8f, 4.8f, 2.4f };
+    // no operator == for sofa::fixed_array
+    EXPECT_TRUE(testPosition[0] == expectedPosition[0] && testPosition[1] == expectedPosition[1] && testPosition[2] == expectedPosition[2]);
+}
+
+TEST(GeometryHexahedron_test, volume_vec3f)
+{
+    {
+        const sofa::type::Vec3f a{ 0.f, 0.f, 0.f };
+        const sofa::type::Vec3f b{ 8.f, 0.f, 0.f };
+        const sofa::type::Vec3f c{ 8.f, 8.f, 0.f };
+        const sofa::type::Vec3f d{ 0.f, 8.f, 0.f };
+        const sofa::type::Vec3f e{ 0.f, 0.f, 8.f };
+        const sofa::type::Vec3f f{ 8.f, 0.f, 8.f };
+        const sofa::type::Vec3f g{ 8.f, 8.f, 8.f };
+        const sofa::type::Vec3f h{ 0.f, 8.f, 8.f };
+
+        auto testVolume = sofa::geometry::Hexahedron::volume(a, b, c, d, e, f, g, h);
+        auto expectedVolume = 8.f * 8.f * 8.f;
+
+        EXPECT_FLOAT_EQ(testVolume, expectedVolume);
+    }
+    {
+        const sofa::type::Vec3f a{ 0.f, 0.f, 0.f };
+        const sofa::type::Vec3f b{ 7.f, 0.f, 1.f };
+        const sofa::type::Vec3f c{ 8.f, 8.f, 1.f };
+        const sofa::type::Vec3f d{ 0.f, 9.f, 0.f };
+        const sofa::type::Vec3f e{ 0.f, 0.f, 7.f };
+        const sofa::type::Vec3f f{ 8.f, 0.f, 7.f };
+        const sofa::type::Vec3f g{ 9.f, 8.f, 9.f };
+        const sofa::type::Vec3f h{ 0.f, 7.f, 8.f };
+
+        auto testVolume = sofa::geometry::Hexahedron::volume(a, b, c, d, e, f, g, h);
+        auto expectedVolume = 469.16667f;
+
+        EXPECT_FLOAT_EQ(testVolume, expectedVolume);
+    }
+}
+
+}// namespace sofa

--- a/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Quad_test.cpp
+++ b/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Quad_test.cpp
@@ -1,0 +1,57 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <sofa/geometry/Quad.h>
+
+#include <sofa/type/fixed_array.h>
+#include <array>
+
+#include <gtest/gtest.h>
+
+namespace sofa
+{
+
+TEST(GeometryQuad_test, square_area3f_stdarray)
+{
+    const std::array<float, 3> a{ -2.f, -2.f, 1.f };
+    const std::array<float, 3> b{ 6.f, -2.f, 1.f };
+    const std::array<float, 3> c{ 6.f, 6.f, 1.f };
+    const std::array<float, 3> d{ -2.f, 6.f, 1.f };
+
+    const auto testArea = sofa::geometry::Quad::area(a, b, c, d);
+    const auto expectedArea = 8.f * 8.f;
+    EXPECT_FLOAT_EQ(testArea, expectedArea);
+}
+
+TEST(GeometryQuad_test, quad_area3f_stdarray)
+{
+    const std::array<float, 3> a{ 5.f, 0.f, 0.f };
+    const std::array<float, 3> b{ 0.f, 0.f, 2.f };
+    const std::array<float, 3> c{ 0.f, 4.f, 0.f };
+    const std::array<float, 3> d{ 5.f, 6.f, -3.f };
+
+    const auto testArea = sofa::geometry::Quad::area(a, b, c, d);
+    const auto expectedArea = 29.685856f;
+    EXPECT_FLOAT_EQ(testArea, expectedArea);
+}
+
+}// namespace sofa

--- a/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Tetrahedron_test.cpp
+++ b/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Tetrahedron_test.cpp
@@ -19,40 +19,25 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#pragma once
 
-#include <sofa/geometry/config.h>
-#include <cmath>
-#include <numeric>
-#include <iterator>
-#include <algorithm>
+#include <sofa/geometry/Tetrahedron.h>
 
-namespace sofa::geometry
+#include <sofa/type/Vec.h>
+
+#include <gtest/gtest.h>
+
+namespace sofa
 {
 
-struct Edge
+TEST(GeometryTetrahedron_test, volume2_vec3f)
 {
-    static constexpr sofa::Size NumberOfNodes = 2;
+    const sofa::type::Vec3f a{ -1.f, 2.f, 0.f };
+    const sofa::type::Vec3f b{ 2.f, 1.f, -3.f };
+    const sofa::type::Vec3f c{ 1.f, 0.f, 1.f };
+    const sofa::type::Vec3f d{ 3.f, -2.f, 3.f };
 
-    Edge() = default;
+    const auto testVolume = sofa::geometry::Tetrahedron::volume(a, b, c, d);
+    EXPECT_NEAR(testVolume, 2.f/3.f, 1e-5);
+}
 
-    template<typename Node,
-        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
-        typename = std::enable_if_t<std::is_scalar_v<T>>>
-        static constexpr auto squaredLength(const Node& n0, const Node& n1)
-    {
-        Node v{};
-        std::transform(n0.begin(), n0.end(), n1.begin(), v.begin(), std::minus<T>());
-        return std::inner_product(std::begin(v), std::end(v), std::begin(v), 0);
-    }
-
-    template<typename Node,
-        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
-        typename = std::enable_if_t<std::is_scalar_v<T>>>
-        static constexpr auto length(const Node& n0, const Node& n1)
-    {
-        return std::sqrt(squaredLength(n0, n1));
-    }
-};
-
-} // namespace sofa::geometry
+}// namespace sofa

--- a/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Triangle_test.cpp
+++ b/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Triangle_test.cpp
@@ -23,48 +23,73 @@
 #include <sofa/geometry/Triangle.h>
 
 #include <sofa/type/fixed_array.h>
+#include <sofa/type/Vec.h>
 #include <array>
 
 #include <gtest/gtest.h>
 
 namespace sofa
 {
-
-TEST(GeometryTriangle_test, area2f_stdarray)
+template <typename VecType>
+class Geometry2DTriangle_test : public ::testing::Test
 {
-    const std::array<float, 2> a{ -2.f, 3.f };
-    const std::array<float, 2> b{ -3.f, -1.f };
-    const std::array<float, 2> c{ 3.f, -2.f };
+};
+template <typename VecType>
+class Geometry3DTriangle_test : public ::testing::Test
+{
+};
+
+using Vec2Types = ::testing::Types <
+    std::array<float, 2>, sofa::type::fixed_array<float, 2>, sofa::type::Vec < 2, float >,
+    std::array<double, 2>, sofa::type::fixed_array<double, 2>, sofa::type::Vec < 2, double >>;
+TYPED_TEST_SUITE(Geometry2DTriangle_test, Vec2Types);
+
+using Vec3Types = ::testing::Types <
+    std::array<float, 3>, sofa::type::fixed_array<float, 3>, sofa::type::Vec < 3, float >,
+    std::array<double, 3>, sofa::type::fixed_array<double, 3>, sofa::type::Vec < 3, double >>;
+TYPED_TEST_SUITE(Geometry3DTriangle_test, Vec3Types);
+
+
+TYPED_TEST(Geometry2DTriangle_test, area)
+{
+    const TypeParam a{ -2.f, 3.f };
+    const TypeParam b{ -3.f, -1.f };
+    const TypeParam c{ 3.f, -2.f };
 
     const auto testArea = sofa::geometry::Triangle::area(a, b, c);
+
     EXPECT_FLOAT_EQ(testArea, 12.5f);
 }
-TEST(GeometryTriangle_test, area3f_stdarray)
+
+TYPED_TEST(Geometry3DTriangle_test, area)
 {
-    const std::array<float, 3> a{ -5.f, 5.f, -5.f };
-    const std::array<float, 3> b{ 1.f, -6.f, 6.f };
-    const std::array<float, 3> c{ 2.f, -3.f, 4.f };
+    const TypeParam a{ -5.f, 5.f, -5.f };
+    const TypeParam b{ 1.f, -6.f, 6.f };
+    const TypeParam c{ 2.f, -3.f, 4.f };
 
     const auto testArea = sofa::geometry::Triangle::area(a, b, c);
     EXPECT_FLOAT_EQ(testArea, 19.306734f);
 }
-TEST(GeometryTriangle_test, flat_area2f_stdarray)
+
+TYPED_TEST(Geometry2DTriangle_test, flat_area)
 {
-    const std::array<float, 2> a{ 0.f, 0.f };
-    const std::array<float, 2> b{ 0.f, 2.f };
-    const std::array<float, 2> c{ 0.f, 1.f };
+    const TypeParam a{ 0.f, 0.f };
+    const TypeParam b{ 0.f, 2.f };
+    const TypeParam c{ 0.f, 1.f };
 
     const auto testArea = sofa::geometry::Triangle::area(a, b, c);
     EXPECT_FLOAT_EQ(testArea, 0.f);
 }
-TEST(GeometryTriangle_test, flat_area3f_stdarray)
+
+TYPED_TEST(Geometry3DTriangle_test, flat_area)
 {
-    const std::array<float, 3> a{ 0.f, 0.f, 0.f };
-    const std::array<float, 3> b{ 0.f, 2.f, 0.f };
-    const std::array<float, 3> c{ 0.f, 1.f, 0.f };
+    const TypeParam a{ 0.f, 0.f, 0.f };
+    const TypeParam b{ 0.f, 2.f, 0.f };
+    const TypeParam c{ 0.f, 1.f, 0.f };
 
     const auto testArea = sofa::geometry::Triangle::area(a, b, c);
     EXPECT_FLOAT_EQ(testArea, 0.f);
 }
+
 
 }// namespace sofa

--- a/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Triangle_test.cpp
+++ b/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Triangle_test.cpp
@@ -48,5 +48,23 @@ TEST(GeometryTriangle_test, area3f_stdarray)
     const auto testArea = sofa::geometry::Triangle::area(a, b, c);
     EXPECT_FLOAT_EQ(testArea, 19.306734f);
 }
+TEST(GeometryTriangle_test, flat_area2f_stdarray)
+{
+    const std::array<float, 2> a{ 0.f, 0.f };
+    const std::array<float, 2> b{ 0.f, 2.f };
+    const std::array<float, 2> c{ 0.f, 1.f };
+
+    const auto testArea = sofa::geometry::Triangle::area(a, b, c);
+    EXPECT_FLOAT_EQ(testArea, 0.f);
+}
+TEST(GeometryTriangle_test, flat_area3f_stdarray)
+{
+    const std::array<float, 3> a{ 0.f, 0.f, 0.f };
+    const std::array<float, 3> b{ 0.f, 2.f, 0.f };
+    const std::array<float, 3> c{ 0.f, 1.f, 0.f };
+
+    const auto testArea = sofa::geometry::Triangle::area(a, b, c);
+    EXPECT_FLOAT_EQ(testArea, 0.f);
+}
 
 }// namespace sofa

--- a/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Triangle_test.cpp
+++ b/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Triangle_test.cpp
@@ -19,40 +19,34 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#pragma once
 
-#include <sofa/geometry/config.h>
-#include <cmath>
-#include <numeric>
-#include <iterator>
-#include <algorithm>
+#include <sofa/geometry/Triangle.h>
 
-namespace sofa::geometry
+#include <sofa/type/fixed_array.h>
+#include <array>
+
+#include <gtest/gtest.h>
+
+namespace sofa
 {
 
-struct Edge
+TEST(GeometryTriangle_test, area2f_stdarray)
 {
-    static constexpr sofa::Size NumberOfNodes = 2;
+    const std::array<float, 2> a{ -2.f, 3.f };
+    const std::array<float, 2> b{ -3.f, -1.f };
+    const std::array<float, 2> c{ 3.f, -2.f };
 
-    Edge() = default;
+    const auto testArea = sofa::geometry::Triangle::area(a, b, c);
+    EXPECT_FLOAT_EQ(testArea, 12.5f);
+}
+TEST(GeometryTriangle_test, area3f_stdarray)
+{
+    const std::array<float, 3> a{ -5.f, 5.f, -5.f };
+    const std::array<float, 3> b{ 1.f, -6.f, 6.f };
+    const std::array<float, 3> c{ 2.f, -3.f, 4.f };
 
-    template<typename Node,
-        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
-        typename = std::enable_if_t<std::is_scalar_v<T>>>
-        static constexpr auto squaredLength(const Node& n0, const Node& n1)
-    {
-        Node v{};
-        std::transform(n0.begin(), n0.end(), n1.begin(), v.begin(), std::minus<T>());
-        return std::inner_product(std::begin(v), std::end(v), std::begin(v), 0);
-    }
+    const auto testArea = sofa::geometry::Triangle::area(a, b, c);
+    EXPECT_FLOAT_EQ(testArea, 19.306734f);
+}
 
-    template<typename Node,
-        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
-        typename = std::enable_if_t<std::is_scalar_v<T>>>
-        static constexpr auto length(const Node& n0, const Node& n1)
-    {
-        return std::sqrt(squaredLength(n0, n1));
-    }
-};
-
-} // namespace sofa::geometry
+}// namespace sofa

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
@@ -36,7 +36,7 @@ struct Edge
 {
     static constexpr sofa::Size NumberOfNodes = 2;
 
-    Edge() = default;
+    Edge() = delete;
 
     /**
     * @brief	Compute the squared length (or norm) of an edge

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
@@ -51,6 +51,7 @@ struct Edge
              typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
              typename = std::enable_if_t<std::is_scalar_v<T>>
     >
+    [[nodiscard]]
     static constexpr auto squaredLength(const Node& n0, const Node& n1)
     {
         constexpr Node v{};

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
@@ -26,6 +26,7 @@
 #include <numeric>
 #include <iterator>
 #include <algorithm>
+#include <iostream>
 
 namespace sofa::geometry
 {
@@ -43,7 +44,7 @@ struct Edge
     {
         Node v{};
         std::transform(n0.begin(), n0.end(), n1.begin(), v.begin(), std::minus<T>());
-        return std::inner_product(std::begin(v), std::end(v), std::begin(v), 0);
+        return std::inner_product(std::cbegin(v), std::cend(v), std::cbegin(v), static_cast<T>(0));
     }
 
     template<typename Node,

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
@@ -26,7 +26,6 @@
 #include <numeric>
 #include <iterator>
 #include <algorithm>
-#include <iostream>
 
 namespace sofa::geometry
 {

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
@@ -38,13 +38,24 @@ struct Edge
 
     Edge() = default;
 
+    /**
+    * @brief	Compute the squared length (or norm) of an edge
+    * @remark   Depending of the type of Node, it will either use a optimized version or a generic one
+    * @remark   Optimizations are enabled for sofa::type::Vec
+    * @tparam   Node iterable container (or sofa::type::Vec for operator- and norm2())
+    * @tparam   T scalar
+    * @param	n0,n1 nodes of the edge
+    * @return	Squared length of the edge (a T scalar)
+    */
     template<typename Node,
-        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
-        typename = std::enable_if_t<std::is_scalar_v<T>>>
+             typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
+             typename = std::enable_if_t<std::is_scalar_v<T>>
+    >
     static constexpr auto squaredLength(const Node& n0, const Node& n1)
     {
         constexpr Node v{};
         constexpr auto size = std::distance(std::cbegin(v), std::cend(v));
+
         // specialized function is faster than the generic (using STL) one
         if constexpr (std::is_same_v< Node, sofa::type::Vec<size, T>>)
         {
@@ -58,9 +69,19 @@ struct Edge
         }
     }
 
+    /**
+    * @brief	Compute the length (or norm) of an edge
+    * @remark   Depending of the type of Node, it will either use a optimized version or a generic one
+    * @remark   Optimizations are enabled for sofa::type::Vec
+    * @tparam   Node iterable container (or sofa::type::Vec for squaredLength())
+    * @tparam   T scalar
+    * @param	n0,n1 nodes of the edge
+    * @return	Length of the edge (a T scalar)
+    */
     template<typename Node,
-        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
-        typename = std::enable_if_t<std::is_scalar_v<T>>>
+             typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
+             typename = std::enable_if_t<std::is_scalar_v<T>>
+    >
     static constexpr auto length(const Node& n0, const Node& n1)
     {
         return std::sqrt(squaredLength(n0, n1));

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <sofa/geometry/config.h>
+#include <sofa/type/Vec.h>
 #include <cmath>
 #include <numeric>
 #include <iterator>

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
@@ -61,7 +61,7 @@ struct Edge
     template<typename Node,
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>>
-        static constexpr auto length(const Node& n0, const Node& n1)
+    static constexpr auto length(const Node& n0, const Node& n1)
     {
         return std::sqrt(squaredLength(n0, n1));
     }

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
@@ -41,7 +41,7 @@ struct Edge
     template<typename Node,
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>>
-        static constexpr auto squaredLength(const Node& n0, const Node& n1)
+    static constexpr auto squaredLength(const Node& n0, const Node& n1)
     {
         constexpr Node v{};
         constexpr auto size = std::distance(std::cbegin(v), std::cend(v));

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
@@ -39,7 +39,7 @@ struct Edge
     template<typename Node,
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>>
-    static constexpr auto squaredLength(const Node & n0, const Node & n1)
+        static constexpr auto squaredLength(const Node& n0, const Node& n1)
     {
         const auto v = n1 - n0;
         return std::inner_product(std::begin(v), std::end(v), std::begin(v), 0);
@@ -48,18 +48,9 @@ struct Edge
     template<typename Node,
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>>
-    static constexpr auto length(const Node & n0, const Node & n1)
+        static constexpr auto length(const Node& n0, const Node& n1)
     {
-        return std::sqrt(computeSquaredLength(n0, n1));
-    }
-
-    template<typename Node,
-        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
-        typename = std::enable_if_t<std::is_scalar_v<T>>>
-    static constexpr auto center(const Node& n0, const Node& n1)
-    {
-        return std::transform(n0.begin(), n0.end(), n1.begin(), n0.begin(),
-            [](T c0, T c1) -> T { return (c0 + c1) / static_cast<T>(NumberOfNodes); });
+        return std::sqrt(squaredLength(n0, n1));
     }
 };
 

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Hexahedron.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Hexahedron.h
@@ -67,6 +67,7 @@ struct Hexahedron
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>
     >
+    [[nodiscard]]
     static constexpr auto center(const Node& n0, const Node& n1, const Node& n2, const Node& n3, 
                                  const Node& n4, const Node& n5, const Node& n6, const Node& n7)
     {
@@ -94,6 +95,7 @@ struct Hexahedron
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>
     >
+    [[nodiscard]]
     static constexpr auto barycentricCoefficients(const Node& n0, const Node& n1, const Node& n2, const Node& n3,
                                                   const Node& n4, const Node& n5, const Node& n6, const Node& n7, 
                                                   const Node& pos)
@@ -142,6 +144,7 @@ struct Hexahedron
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>
     >
+    [[nodiscard]]
     static constexpr auto squaredDistanceTo(const Node& n0, const Node& n1, const Node& n2, const Node& n3,
                                             const Node& n4, const Node& n5, const Node& n6, const Node& n7, 
                                             const Node& pos)
@@ -171,6 +174,7 @@ struct Hexahedron
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>
     >
+    [[nodiscard]]
     static constexpr auto getPositionFromBarycentricCoefficients(const Node& n0, const Node& n1, const Node& n2, const Node& n3,
             const Node& n4, const Node& n5, const Node& n6, const Node& n7, const sofa::type::fixed_array<SReal, 3>& baryC)
     {
@@ -200,7 +204,9 @@ struct Hexahedron
     */
     template<typename Node,
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
-        typename = std::enable_if_t<std::is_scalar_v<T>>>
+        typename = std::enable_if_t<std::is_scalar_v<T>>
+    >
+    [[nodiscard]]
     static constexpr auto volume(const Node& n0, const Node& n1, const Node& n2, const Node& n3,
                                  const Node& n4, const Node& n5, const Node& n6, const Node& n7)
     {
@@ -218,6 +224,7 @@ struct Hexahedron
         }
         else
         {
+            BOOST_STATIC_WARNING("Hexahedron::volume() is called with a non-3D context. This function will return 0.")
             //does not make sense to compute volume other than 3D
             //but some code effectively wants 2d volumes(??)
             //an exception may be a better solution

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Hexahedron.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Hexahedron.h
@@ -41,27 +41,34 @@ struct Hexahedron
     Hexahedron() = default;
 
     // CONVENTION : indices ordering for the nodes of an hexahedron :
-//
-//     Y  n3---------n2
-//     ^  /          /|
-//     | /          / |
-//     n7---------n6  |
-//     |          |   |
-//     |  n0------|--n1
-//     | /        | /
-//     |/         |/
-//     n4---------n5-->X
-//    /
-//   /
-//  Z
+    //
+    //     Y  n3---------n2
+    //     ^  /          /|
+    //     | /          / |
+    //     n7---------n6  |
+    //     |          |   |
+    //     |  n0------|--n1
+    //     | /        | /
+    //     |/         |/
+    //     n4---------n5-->X
+    //    /
+    //   /
+    //  Z
 
-    // nodes order is not necessary
+    /**
+    * @brief	Compute the center of a hexahedron
+    * @remark	The order of nodes given as parameter is not necessary.
+    * @tparam   Node iterable container, with operator[]
+    * @tparam   T scalar
+    * @param	n0,n1,n2,n3,n4,n5,n6,n7 nodes of the hexahedron
+    * @return	Center of the hexahedron (same type as the given nodes)
+    */
     template<typename Node,
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>
     >
-        static constexpr auto center(const Node& n0, const Node& n1, const Node& n2, const Node& n3, 
-                                     const Node& n4, const Node& n5, const Node& n6, const Node& n7)
+    static constexpr auto center(const Node& n0, const Node& n1, const Node& n2, const Node& n3, 
+                                 const Node& n4, const Node& n5, const Node& n6, const Node& n7)
     {
         constexpr auto dimensions = sizeof(Node) / sizeof(T);
         auto centerRes = n0;
@@ -74,13 +81,22 @@ struct Hexahedron
         return centerRes;
     }
 
-    // nodes order is necessary
+    /**
+    * @brief	Compute the barycentric coefficients of a node in a hexahedron
+    * @remark	Due to some optimizations, the order of nodes given as parameter is necessary.
+    * @tparam   Node iterable container, with operator[]
+    * @tparam   T scalar
+    * @param	n0,n1,n2,n3,n4,n5,n6,n7 nodes of the hexahedron
+    * @param    pos position of the node from which the coefficients will be computed 
+    * @return	A Vec3 container with the barycentric coefficients of the given node
+    */
     template<typename Node,
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>
     >
-        static constexpr auto barycentricCoefficients(const Node& n0, const Node& n1, const Node& n2, const Node& n3,
-            const Node& n4, const Node& n5, const Node& n6, const Node& n7, const Node& pos)
+    static constexpr auto barycentricCoefficients(const Node& n0, const Node& n1, const Node& n2, const Node& n3,
+                                                  const Node& n4, const Node& n5, const Node& n6, const Node& n7, 
+                                                  const Node& pos)
     {
         SOFA_UNUSED(n2);
         SOFA_UNUSED(n5);
@@ -113,13 +129,22 @@ struct Hexahedron
         return tmpResult;
     }
 
-    // nodes order is necessary
+    /**
+    * @brief	Compute the squared distance between a node and the center of a hexahedron
+    * @remark	Due to some optimizations, the order of nodes given as parameter is necessary.
+    * @tparam   Node iterable container, with operator[]
+    * @tparam   T scalar
+    * @param	n0,n1,n2,n3,n4,n5,n6,n7 nodes of the hexahedron
+    * @param    pos position of the node from which the distance will be computed
+    * @return	Distance from the node and the center of the hexahedron, as a T scalar
+    */
     template<typename Node,
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>
     >
     static constexpr auto squaredDistanceTo(const Node& n0, const Node& n1, const Node& n2, const Node& n3,
-        const Node& n4, const Node& n5, const Node& n6, const Node& n7, const Node& pos)
+                                            const Node& n4, const Node& n5, const Node& n6, const Node& n7, 
+                                            const Node& pos)
     {
         const auto& v = barycentricCoefficients(n0,n1,n2,n3,n4,n5,n6,n7, pos);
 
@@ -133,6 +158,15 @@ struct Hexahedron
         return d;
     }
 
+    /**
+    * @brief	Compute a position from a given set of barycentric coefficients and the associated hexahedron
+    * @remark	The order of nodes given as parameter is necessary.
+    * @tparam   Node iterable container, with operator* applicable with a scalar
+    * @tparam   T scalar
+    * @param	n0,n1,n2,n3,n4,n5,n6,n7 nodes of the hexahedron
+    * @param    baryC barycentric coefficients
+    * @return	Position computed from the coefficients, as a Node type
+    */
     template<typename Node,
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>
@@ -156,12 +190,19 @@ struct Hexahedron
         return pos;
     }
 
-    //non optimized version: just return the sum of the 6 inner-tetrahedra
+    /**
+    * @brief	Compute the volume of a hexahedron
+    * @remark	non optimized version: just return the sum of the 6 inner-tetrahedra
+    * @tparam   Node iterable container
+    * @tparam   T scalar
+    * @param	n0,n1,n2,n3,n4,n5,n6,n7 nodes of the hexahedron
+    * @return	Volume of the hexahedron, as a T scalar
+    */
     template<typename Node,
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>>
     static constexpr auto volume(const Node& n0, const Node& n1, const Node& n2, const Node& n3,
-        const Node& n4, const Node& n5, const Node& n6, const Node& n7)
+                                 const Node& n4, const Node& n5, const Node& n6, const Node& n7)
     {
         constexpr Node n{};
         //static_assert(std::distance(std::begin(n), std::end(n)) == 3, "volume can only be computed in 3 dimensions.");

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Hexahedron.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Hexahedron.h
@@ -224,7 +224,7 @@ struct Hexahedron
         }
         else
         {
-            BOOST_STATIC_WARNING("Hexahedron::volume() is called with a non-3D context. This function will return 0.")
+            BOOST_STATIC_WARNING(true)
             //does not make sense to compute volume other than 3D
             //but some code effectively wants 2d volumes(??)
             //an exception may be a better solution

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Hexahedron.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Hexahedron.h
@@ -38,7 +38,7 @@ struct Hexahedron
 {
     static constexpr sofa::Size NumberOfNodes = 8;
 
-    Hexahedron() = default;
+    Hexahedron() = delete;
 
     // CONVENTION : indices ordering for the nodes of an hexahedron :
     //

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Hexahedron.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Hexahedron.h
@@ -118,8 +118,8 @@ struct Hexahedron
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>
     >
-        static constexpr auto squaredDistanceTo(const Node& n0, const Node& n1, const Node& n2, const Node& n3,
-            const Node& n4, const Node& n5, const Node& n6, const Node& n7, const Node& pos)
+    static constexpr auto squaredDistanceTo(const Node& n0, const Node& n1, const Node& n2, const Node& n3,
+        const Node& n4, const Node& n5, const Node& n6, const Node& n7, const Node& pos)
     {
         const auto& v = barycentricCoefficients(n0,n1,n2,n3,n4,n5,n6,n7, pos);
 
@@ -160,8 +160,8 @@ struct Hexahedron
     template<typename Node,
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>>
-        static constexpr auto volume(const Node& n0, const Node& n1, const Node& n2, const Node& n3,
-            const Node& n4, const Node& n5, const Node& n6, const Node& n7)
+    static constexpr auto volume(const Node& n0, const Node& n1, const Node& n2, const Node& n3,
+        const Node& n4, const Node& n5, const Node& n6, const Node& n7)
     {
         constexpr Node n{};
         //static_assert(std::distance(std::begin(n), std::end(n)) == 3, "volume can only be computed in 3 dimensions.");

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Hexahedron.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Hexahedron.h
@@ -29,6 +29,8 @@
 #include <iterator>
 #include <array>
 
+#include <sofa/geometry/Tetrahedron.h>
+
 namespace sofa::geometry
 {
 
@@ -143,8 +145,32 @@ struct Hexahedron
         return pos;
     }
 
-    
+    //non optimized version: just return the sum of the 6 inner-tetrahedra
+    template<typename Node,
+        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
+        typename = std::enable_if_t<std::is_scalar_v<T>>>
+        static constexpr auto volume(const Node& n0, const Node& n1, const Node& n2, const Node& n3,
+            const Node& n4, const Node& n5, const Node& n6, const Node& n7)
+    {
+        constexpr Node n{};
+        //static_assert(std::distance(std::begin(n), std::end(n)) == 3, "volume can only be computed in 3 dimensions.");
 
+        if constexpr (std::distance(std::begin(n), std::end(n)) == 3)
+        {
+            return sofa::geometry::Tetrahedron::volume(n0, n5, n1, n6)
+                 + sofa::geometry::Tetrahedron::volume(n0, n1, n3, n6)
+                 + sofa::geometry::Tetrahedron::volume(n1, n3, n6, n2)
+                 + sofa::geometry::Tetrahedron::volume(n6, n3, n0, n7)
+                 + sofa::geometry::Tetrahedron::volume(n6, n7, n0, n5)
+                 + sofa::geometry::Tetrahedron::volume(n7, n5, n4, n0);
+        }
+        else
+        {
+            //does not make sense to compute volume other than 3D
+            //but some code effectively wants 2d volumes(??)
+            return static_cast<T>(0);
+        }
+    }
 };
 
 } // namespace sofa::geometry

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Pentahedron.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Pentahedron.h
@@ -30,7 +30,7 @@ struct Pentahedron
 {
     static const sofa::Size NumberOfNodes = 6;
 
-    Pentahedron() = default;
+    Pentahedron() = delete;
 };
 
 } // namespace sofa::geometry

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Point.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Point.h
@@ -30,7 +30,7 @@ struct Point
 {
     static const sofa::Size NumberOfNodes = 1;
 
-    Point() = default;
+    Point() = delete;
 };
 
 } // namespace sofa::geometry

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Pyramid.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Pyramid.h
@@ -30,7 +30,7 @@ struct Pyramid
 {
     static const sofa::Size NumberOfNodes = 5;
 
-    Pyramid() = default;
+    Pyramid() = delete;
 };
 
 } // namespace sofa::geometry

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Quad.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Quad.h
@@ -37,7 +37,7 @@ struct Quad
     template<typename Node,
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>>
-        static constexpr auto area(const Node& n0, const Node& n1, const Node& n2, const Node& n3)
+    static constexpr auto area(const Node& n0, const Node& n1, const Node& n2, const Node& n3)
     {
 
         return Triangle::area(n0, n1, n2) + Triangle::area(n0, n2, n3);

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Quad.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Quad.h
@@ -23,6 +23,8 @@
 
 #include <sofa/geometry/config.h>
 
+#include <sofa/geometry/Triangle.h>
+
 namespace sofa::geometry
 {
 
@@ -31,6 +33,15 @@ struct Quad
     static const sofa::Size NumberOfNodes = 4;
 
     Quad() = default;
+
+    template<typename Node,
+        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
+        typename = std::enable_if_t<std::is_scalar_v<T>>>
+        static constexpr auto area(const Node& n0, const Node& n1, const Node& n2, const Node& n3)
+    {
+
+        return Triangle::area(n0, n1, n2) + Triangle::area(n0, n2, n3);
+    }
 };
 
 } // namespace sofa::geometry

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Quad.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Quad.h
@@ -45,7 +45,8 @@ struct Quad
     template<typename Node,
              typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
              typename = std::enable_if_t<std::is_scalar_v<T>>
-    >
+    > 
+    [[nodiscard]]
     static constexpr auto area(const Node& n0, const Node& n1, const Node& n2, const Node& n3)
     {
 

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Quad.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Quad.h
@@ -32,7 +32,7 @@ struct Quad
 {
     static const sofa::Size NumberOfNodes = 4;
 
-    Quad() = default;
+    Quad() = delete;
 
     /**
     * @brief	Compute the area of a quadrilateral

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Quad.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Quad.h
@@ -34,9 +34,18 @@ struct Quad
 
     Quad() = default;
 
+    /**
+    * @brief	Compute the area of a quadrilateral
+    * @remark	The order of nodes needs to be consecutive
+    * @tparam   Node iterable container
+    * @tparam   T scalar
+    * @param	n0,n1,n2,n3 nodes of the quadrilateral
+    * @return	Area of the quadrilateral (a T scalar)
+    */
     template<typename Node,
-        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
-        typename = std::enable_if_t<std::is_scalar_v<T>>>
+             typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
+             typename = std::enable_if_t<std::is_scalar_v<T>>
+    >
     static constexpr auto area(const Node& n0, const Node& n1, const Node& n2, const Node& n3)
     {
 

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Tetrahedron.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Tetrahedron.h
@@ -55,7 +55,7 @@ struct Tetrahedron
         else
         {
             //does not make sense to compute volume other than 3D
-            //but some code effectively call 2d volumes(??)
+            //but some code effectively wants 2d volumes(??)
             return static_cast<T>(0);
         }
     }

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Tetrahedron.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Tetrahedron.h
@@ -37,10 +37,18 @@ struct Tetrahedron
 
     Tetrahedron() = default;
 
-    //needs dot, cross
+    /**
+    * @brief	Compute the volume of a tetrahedron
+    * @remark	This function is not generic
+    * @tparam   Node a container of the type sofa::type::Vec3 (needed for cross(), dot(), operator-)
+    * @tparam   T scalar
+    * @param	n0,n1,n2,n3,n4 nodes of the tetrahedron
+    * @return	Volume of the hexahedron (a T scalar)
+    */
     template<typename Node,
-        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
-        typename = std::enable_if_t<std::is_scalar_v<T>>>
+             typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
+             typename = std::enable_if_t<std::is_scalar_v<T>>
+    >
     static constexpr auto volume(const Node& n0, const Node& n1, const Node& n2, const Node& n3)
     {
         constexpr Node n{};

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Tetrahedron.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Tetrahedron.h
@@ -37,7 +37,7 @@ struct Tetrahedron
 
     Tetrahedron() = default;
 
-    //needs cross
+    //needs dot, cross
     template<typename Node,
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>>

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Tetrahedron.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Tetrahedron.h
@@ -66,7 +66,7 @@ struct Tetrahedron
         }
         else
         {
-            BOOST_STATIC_WARNING("Tetrahedron::volume() is called with a non-3D context. This function will return 0.")
+            BOOST_STATIC_WARNING(true)
             //does not make sense to compute volume other than 3D
             //but some code effectively wants 2d volumes(??)
             return static_cast<T>(0);

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Tetrahedron.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Tetrahedron.h
@@ -35,7 +35,7 @@ struct Tetrahedron
 {
     static const sofa::Size NumberOfNodes = 4;
 
-    Tetrahedron() = default;
+    Tetrahedron() = delete;
 
     /**
     * @brief	Compute the volume of a tetrahedron

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Tetrahedron.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Tetrahedron.h
@@ -24,6 +24,8 @@
 #include <sofa/geometry/config.h>
 
 #include <sofa/type/fixed_array_algorithms.h>
+#include <sofa/type/vector_algebra.h>
+#include <sofa/type/Vec.h>
 #include <iterator>
 
 namespace sofa::geometry
@@ -50,7 +52,7 @@ struct Tetrahedron
             const auto b = n2 - n0;
             const auto c = n3 - n0;
 
-            return sofa::type::dot(a, b.cross(c)) / static_cast<T>(6);
+            return std::abs(sofa::type::dot(sofa::type::cross(a, b), c) / static_cast<T>(6));
         }
         else
         {

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Tetrahedron.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Tetrahedron.h
@@ -41,7 +41,7 @@ struct Tetrahedron
     template<typename Node,
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>>
-        static constexpr auto volume(const Node& n0, const Node& n1, const Node& n2, const Node& n3)
+    static constexpr auto volume(const Node& n0, const Node& n1, const Node& n2, const Node& n3)
     {
         constexpr Node n{};
         //static_assert(std::distance(std::begin(n), std::end(n)) == 3, "volume can only be computed in 3 dimensions.");

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Tetrahedron.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Tetrahedron.h
@@ -27,6 +27,7 @@
 #include <sofa/type/vector_algebra.h>
 #include <sofa/type/Vec.h>
 #include <iterator>
+#include <boost/serialization/static_warning.hpp>
 
 namespace sofa::geometry
 {
@@ -49,6 +50,7 @@ struct Tetrahedron
              typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
              typename = std::enable_if_t<std::is_scalar_v<T>>
     >
+    [[nodiscard]]
     static constexpr auto volume(const Node& n0, const Node& n1, const Node& n2, const Node& n3)
     {
         constexpr Node n{};
@@ -64,6 +66,7 @@ struct Tetrahedron
         }
         else
         {
+            BOOST_STATIC_WARNING("Tetrahedron::volume() is called with a non-3D context. This function will return 0.")
             //does not make sense to compute volume other than 3D
             //but some code effectively wants 2d volumes(??)
             return static_cast<T>(0);

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Tetrahedron.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Tetrahedron.h
@@ -23,6 +23,9 @@
 
 #include <sofa/geometry/config.h>
 
+#include <sofa/type/fixed_array_algorithms.h>
+#include <iterator>
+
 namespace sofa::geometry
 {
 
@@ -31,6 +34,31 @@ struct Tetrahedron
     static const sofa::Size NumberOfNodes = 4;
 
     Tetrahedron() = default;
+
+    //needs cross
+    template<typename Node,
+        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
+        typename = std::enable_if_t<std::is_scalar_v<T>>>
+        static constexpr auto volume(const Node& n0, const Node& n1, const Node& n2, const Node& n3)
+    {
+        constexpr Node n{};
+        //static_assert(std::distance(std::begin(n), std::end(n)) == 3, "volume can only be computed in 3 dimensions.");
+
+        if constexpr (std::distance(std::begin(n), std::end(n)) == 3)
+        {
+            const auto a = n1 - n0;
+            const auto b = n2 - n0;
+            const auto c = n3 - n0;
+
+            return sofa::type::dot(a, b.cross(c)) / static_cast<T>(6);
+        }
+        else
+        {
+            //does not make sense to compute volume other than 3D
+            //but some code effectively call 2d volumes(??)
+            return static_cast<T>(0);
+        }
+    }
 };
 
 } // namespace sofa::geometry

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
@@ -32,7 +32,7 @@ struct Triangle
 {
     static const sofa::Size NumberOfNodes = 3;
 
-    Triangle() = default;
+    Triangle() = delete;
 
     /**
     * @brief	Compute the area of a triangle

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
@@ -23,6 +23,8 @@
 
 #include <sofa/geometry/config.h>
 
+#include <sofa/geometry/Edge.h>
+
 namespace sofa::geometry
 {
 
@@ -31,6 +33,21 @@ struct Triangle
     static const sofa::Size NumberOfNodes = 3;
 
     Triangle() = default;
+
+
+    template<typename Node,
+        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
+        typename = std::enable_if_t<std::is_scalar_v<T>>>
+        static constexpr auto area(const Node& n0, const Node& n1, const Node& n2)
+    {
+        const auto a = sofa::geometry::Edge::squaredLength(n0, n1);
+        const auto b = sofa::geometry::Edge::squaredLength(n0, n2);
+        const auto c = sofa::geometry::Edge::squaredLength(n1, n2);
+
+        const auto squaredArea = (2 * a * b + 2 * b * c + 2 * c * a - (a * a) - (b * b) - (c * c)) / 16;
+
+        return std::sqrt(squaredArea);
+    }
 };
 
 } // namespace sofa::geometry

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
@@ -43,7 +43,7 @@ struct Triangle
         const auto b = sofa::geometry::Edge::length(n0, n2);
         const auto c = sofa::geometry::Edge::length(n1, n2);
 
-        const auto area = 0.25 * std::sqrt((a + b + c) * (-a + b + c) * (a - b + c) * (a + b - c));
+        const auto area = static_cast<T>(0.25) * std::sqrt((a + b + c) * (-a + b + c) * (a - b + c) * (a + b - c));
         return area;
     }
 };

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
@@ -47,6 +47,7 @@ struct Triangle
              typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
              typename = std::enable_if_t<std::is_scalar_v<T>>
     >
+    [[nodiscard]]
     static constexpr auto area(const Node& n0, const Node& n1, const Node& n2)
     {
         if constexpr (std::is_same_v < Node, sofa::type::Vec<3, T> >)

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
@@ -39,12 +39,20 @@ struct Triangle
         typename = std::enable_if_t<std::is_scalar_v<T>>>
         static constexpr auto area(const Node& n0, const Node& n1, const Node& n2)
     {
-        const auto a = sofa::geometry::Edge::length(n0, n1);
-        const auto b = sofa::geometry::Edge::length(n0, n2);
-        const auto c = sofa::geometry::Edge::length(n1, n2);
+        if constexpr (std::is_same_v < Node, sofa::type::Vec<3, T> > || std::is_same_v< Node, sofa::type::Vec<2, T> >)
+        {
+            const auto a = n1 - n0;
+            const auto b = n2 - n0;
+            return static_cast<T>(0.5) * sofa::type::cross(a, b).norm();
+        }
+        else // generic without cross or diff
+        {
+            const auto a = sofa::geometry::Edge::length(n0, n1);
+            const auto b = sofa::geometry::Edge::length(n0, n2);
+            const auto c = sofa::geometry::Edge::length(n1, n2);
 
-        const auto area = static_cast<T>(0.25) * std::sqrt((a + b + c) * (-a + b + c) * (a - b + c) * (a + b - c));
-        return area;
+            return static_cast<T>(0.25) * std::sqrt((a + b + c) * (-a + b + c) * (a - b + c) * (a + b - c));
+        }
     }
 };
 

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
@@ -34,9 +34,19 @@ struct Triangle
 
     Triangle() = default;
 
+    /**
+    * @brief	Compute the area of a triangle
+    * @remark   Depending of the type of Node, it will either use a optimized version or a generic one
+    * @remark   Optimizations are enabled for sofa::type::Vec and the dimension (2D or 3D)
+    * @tparam   Node iterable container (or sofa::type::Vec with cross() and norm())
+    * @tparam   T scalar
+    * @param	n0,n1,n2 nodes of the triangle
+    * @return	Area of the triangle (a T scalar)
+    */
     template<typename Node,
-        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
-        typename = std::enable_if_t<std::is_scalar_v<T>>>
+             typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
+             typename = std::enable_if_t<std::is_scalar_v<T>>
+    >
     static constexpr auto area(const Node& n0, const Node& n1, const Node& n2)
     {
         if constexpr (std::is_same_v < Node, sofa::type::Vec<3, T> >)

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
@@ -37,7 +37,7 @@ struct Triangle
     template<typename Node,
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>>
-        static constexpr auto area(const Node& n0, const Node& n1, const Node& n2)
+    static constexpr auto area(const Node& n0, const Node& n1, const Node& n2)
     {
         if constexpr (std::is_same_v < Node, sofa::type::Vec<3, T> >)
         {

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
@@ -39,18 +39,23 @@ struct Triangle
         typename = std::enable_if_t<std::is_scalar_v<T>>>
         static constexpr auto area(const Node& n0, const Node& n1, const Node& n2)
     {
-        if constexpr (std::is_same_v < Node, sofa::type::Vec<3, T> > || std::is_same_v< Node, sofa::type::Vec<2, T> >)
+        if constexpr (std::is_same_v < Node, sofa::type::Vec<3, T> >)
         {
+            // half the area of a quadrilateral
             const auto a = n1 - n0;
             const auto b = n2 - n0;
             return static_cast<T>(0.5) * sofa::type::cross(a, b).norm();
+        }
+        else if constexpr (std::is_same_v< Node, sofa::type::Vec<2, T> >)
+        {
+            // shoelace formula
+            return static_cast<T>(0.5) * (n0[0] * n1[1] + n1[0] * n2[1] + n2[0] * n0[1] - n1[0] * n0[1] - n2[0] * n1[1] - n0[0] * n2[1]);
         }
         else // generic without cross or diff
         {
             const auto a = sofa::geometry::Edge::length(n0, n1);
             const auto b = sofa::geometry::Edge::length(n0, n2);
             const auto c = sofa::geometry::Edge::length(n1, n2);
-
             return static_cast<T>(0.25) * std::sqrt((a + b + c) * (-a + b + c) * (a - b + c) * (a + b - c));
         }
     }

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
@@ -39,13 +39,12 @@ struct Triangle
         typename = std::enable_if_t<std::is_scalar_v<T>>>
         static constexpr auto area(const Node& n0, const Node& n1, const Node& n2)
     {
-        const auto a = sofa::geometry::Edge::squaredLength(n0, n1);
-        const auto b = sofa::geometry::Edge::squaredLength(n0, n2);
-        const auto c = sofa::geometry::Edge::squaredLength(n1, n2);
+        const auto a = sofa::geometry::Edge::length(n0, n1);
+        const auto b = sofa::geometry::Edge::length(n0, n2);
+        const auto c = sofa::geometry::Edge::length(n1, n2);
 
-        const auto squaredArea = (2 * a * b + 2 * b * c + 2 * c * a - (a * a) - (b * b) - (c * c)) / 16;
-
-        return std::sqrt(squaredArea);
+        const auto area = 0.25 * std::sqrt((a + b + c) * (-a + b + c) * (a - b + c) * (a + b - c));
+        return area;
     }
 };
 

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
@@ -34,7 +34,6 @@ struct Triangle
 
     Triangle() = default;
 
-
     template<typename Node,
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>>

--- a/SofaKernel/modules/Sofa.Topology/CMakeLists.txt
+++ b/SofaKernel/modules/Sofa.Topology/CMakeLists.txt
@@ -46,3 +46,11 @@ sofa_create_package_with_targets(
     INCLUDE_SOURCE_DIR "src"
     INCLUDE_INSTALL_DIR "${PROJECT_NAME}"
 )
+
+# Tests
+# If SOFA_BUILD_TESTS exists and is OFF, then these tests will be auto-disabled
+cmake_dependent_option(SOFATOPOLOGY_BUILD_TESTS "Compile the automatic tests" ON "SOFA_BUILD_TESTS OR NOT DEFINED SOFA_BUILD_TESTS" OFF)
+if(SOFATOPOLOGY_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(${PROJECT_NAME}_test)
+endif()

--- a/SofaKernel/modules/Sofa.Topology/Sofa.Topology_test/CMakeLists.txt
+++ b/SofaKernel/modules/Sofa.Topology/Sofa.Topology_test/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(Sofa.Topology_test)
+
+set(SOURCE_FILES
+    Hexahedron_test.cpp
+)
+
+add_executable(${PROJECT_NAME} ${SOURCE_FILES})
+
+target_link_libraries(${PROJECT_NAME} Sofa.Testing Sofa.Topology)
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/SofaKernel/modules/Sofa.Topology/Sofa.Topology_test/Hexahedron_test.cpp
+++ b/SofaKernel/modules/Sofa.Topology/Sofa.Topology_test/Hexahedron_test.cpp
@@ -1,0 +1,93 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <sofa/topology/Hexahedron.h>
+
+#include <sofa/type/Vec.h>
+
+#include <gtest/gtest.h>
+
+namespace sofa
+{
+    //from nine_hexa.msh
+    static const std::array<sofa::type::Vec3d, 32> nine_hexa_vertices {{
+    { 0., 0., 0. },
+    { 1., 0., 0. },
+    { 2., 0., 0. },
+    { 3., 0., 0. },
+    { 0., 1., 0. },
+    { 1., 1., 0. },
+    { 2., 1., 0. },
+    { 3., 1., 0. },
+    { 0., 2., 0. },
+    { 1., 2., 0. },
+    { 2., 2., 0. },
+    { 3., 2., 0. },
+    { 0., 3., 0. },
+    { 1., 3., 0. },
+    { 2., 3., 0. },
+    { 3., 3., 0. },
+    { 0., 0., 1. },
+    { 1., 0., 1. },
+    { 2., 0., 1. },
+    { 3., 0., 1. },
+    { 0., 1., 1. },
+    { 1., 1., 1. },
+    { 2., 1., 1. },
+    { 3., 1., 1. },
+    { 0., 2., 1. },
+    { 1., 2., 1. },
+    { 2., 2., 1. },
+    { 3., 2., 1. },
+    { 0., 3., 1. },
+    { 1., 3., 1. },
+    { 2., 3., 1. },
+    { 3., 3., 1. }
+    } };
+    static const std::vector<sofa::topology::Hexahedron> nine_hexa_indices{ {
+        { 0, 1, 5, 4, 16, 17, 21, 20 },
+        { 1, 2, 6, 5, 17, 18, 22, 21 },
+        { 2, 3, 7, 6, 18, 19, 23, 22 },
+        { 4, 5, 9, 8, 20, 21, 25, 24 },
+        { 5, 6, 10, 9, 21, 22, 26, 25 },
+        { 6, 7, 11, 10, 23, 23 ,27 ,26 },
+        { 8, 9, 13, 12, 24, 25, 29, 28 },
+        { 9, 10, 14, 13, 25, 26, 30, 29},
+        { 10, 11, 15, 14, 26, 27, 31, 30},
+    } };
+
+TEST(TopologyHexahedron_test, getClosestHexahedronIndex)
+{   
+    sofa::type::fixed_array<SReal, 3> coeffs{};
+    SReal distance{};
+
+    const sofa::type::Vec3d pos0{0.001, 0., 0.};
+    EXPECT_EQ(0, sofa::topology::getClosestHexahedronIndex(nine_hexa_vertices, nine_hexa_indices, pos0,coeffs,distance));
+
+    const sofa::type::Vec3d pos1{ 3., 3., 1.001 };
+    EXPECT_EQ(8, sofa::topology::getClosestHexahedronIndex(nine_hexa_vertices, nine_hexa_indices, pos1, coeffs, distance));
+
+    const sofa::type::Vec3d pos2{ 1.5, 1.5, 0.5 };
+    EXPECT_EQ(4, sofa::topology::getClosestHexahedronIndex(nine_hexa_vertices, nine_hexa_indices, pos2, coeffs, distance));
+}
+
+}// namespace sofa

--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Hexahedron.h
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Hexahedron.h
@@ -40,7 +40,7 @@ namespace sofa::topology
         for (sofa::Index c = 0; c < hexahedra.size(); ++c)
         {
             const auto& h = hexahedra[c];
-            const auto d = sofa::geometry::Hexahedron::distanceTo(hexahedronPositions[h[0]], hexahedronPositions[h[1]], hexahedronPositions[h[2]], hexahedronPositions[h[3]],
+            const auto d = sofa::geometry::Hexahedron::squaredDistanceTo(hexahedronPositions[h[0]], hexahedronPositions[h[1]], hexahedronPositions[h[2]], hexahedronPositions[h[3]],
                 hexahedronPositions[h[4]], hexahedronPositions[h[5]], hexahedronPositions[h[6]], hexahedronPositions[h[7]],
                 pos);
 

--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/fixed_array.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/fixed_array.h
@@ -108,6 +108,11 @@ public:
     {
         return elems;
     }
+    constexpr const_iterator cbegin() const noexcept
+    {
+        return elems;
+    }
+
     constexpr iterator end() noexcept
     {
         return elems+N;
@@ -115,6 +120,10 @@ public:
     constexpr const_iterator end() const noexcept
     {
         return elems+N;
+    }
+    constexpr const_iterator cend() const noexcept
+    {
+        return elems + N;
     }
 
     // operator[]

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/BarycentricMappers/BarycentricMapperHexahedronSetTopology.inl
@@ -274,7 +274,7 @@ void BarycentricMapperHexahedronSetTopology<In,Out>::handleTopologyChange(core::
                     if (d_map.getValue()[j].in_index == cubeId) // invalidate mapping
                     {
                         const auto& baryMap = d_map.getValue()[j];
-                        std::array<SReal, 3> coefs;
+                        sofa::type::fixed_array<SReal, 3> coefs;
                         coefs[0] = baryMap.baryCoords[0];
                         coefs[1] = baryMap.baryCoords[1];
                         coefs[2] = baryMap.baryCoords[2];

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaBarycentricMappingRigid.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaBarycentricMappingRigid.cpp
@@ -150,7 +150,7 @@ void BarycentricMapperHexahedronSetTopology<CudaVec3Types, defaulttype::Rigid3Ty
                 {
                     if ( d_map.getValue()[j].in_index == cubeId ) // invalidate mapping
                     {
-                        std::array<SReal, 3> coefs;
+                        sofa::type::fixed_array<SReal, 3> coefs;
                         coefs[0] = d_map.getValue()[j].baryCoords[0];
                         coefs[1] = d_map.getValue()[j].baryCoords[1];
                         coefs[2] = d_map.getValue()[j].baryCoords[2];

--- a/modules/SofaMiscMapping/src/SofaMiscMapping/BarycentricMappingRigid.cpp
+++ b/modules/SofaMiscMapping/src/SofaMiscMapping/BarycentricMappingRigid.cpp
@@ -143,7 +143,7 @@ void BarycentricMapperHexahedronSetTopology<defaulttype::Vec3Types, defaulttype:
                 {
                     if ( d_map.getValue()[j].in_index == cubeId ) // invalidate mapping
                     {
-                        std::array<SReal, 3> coefs;
+                        sofa::type::fixed_array<SReal, 3> coefs;
                         coefs[0] = d_map.getValue()[j].baryCoords[0];
                         coefs[1] = d_map.getValue()[j].baryCoords[1];
                         coefs[2] = d_map.getValue()[j].baryCoords[2];


### PR DESCRIPTION
Continuing task #2402 (towards the huge task to remove *GeometryAlgoritms)

- add geometry functions (will be called for DiagonalMass to replace GeometryAlgoritms,  see #2436 )
- create the unit test module Sofa.Geometry_test and add some tests
- create the unit test module Sofa.Topology_test and add some tests for the getClosestHexahedron() function

I tried to make functions as generic as possible, so it could be used with different container (std::array, vec... could be std::list as well...) but I needed some functions from SOFA for dot/cross because I was a bit lazy 😗. Actually I dont know if we should be as generic as possible. Let discuss about that.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
