### PR TITLE
[SofaBaseTopology][SofaMiscForcefield] Remove GeometryAlgorithms from DiagonalMass & MeshMatrixMass

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
@@ -131,7 +131,7 @@ protected:
 
 public:
     bool m_bManageEdgeChange{false};
-    sofa::component::topology::TriangleSetGeometryAlgorithms<GeometricalTypes>* triangleGeo;
+    bool m_bManageTriangleChange{ false };
     sofa::component::topology::QuadSetGeometryAlgorithms<GeometricalTypes>* quadGeo;
     sofa::component::topology::TetrahedronSetGeometryAlgorithms<GeometricalTypes>* tetraGeo;
     sofa::component::topology::HexahedronSetGeometryAlgorithms<GeometricalTypes>* hexaGeo;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
@@ -132,7 +132,7 @@ protected:
 public:
     bool m_bManageEdgeChange{false};
     bool m_bManageTriangleChange{ false };
-    sofa::component::topology::QuadSetGeometryAlgorithms<GeometricalTypes>* quadGeo;
+    bool m_bManageQuadChange{ false };
     sofa::component::topology::TetrahedronSetGeometryAlgorithms<GeometricalTypes>* tetraGeo;
     sofa::component::topology::HexahedronSetGeometryAlgorithms<GeometricalTypes>* hexaGeo;
 protected:

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
@@ -118,21 +118,17 @@ protected:
 
     class Loader;
     /// The type of topology to build the mass from the topology
-    sofa::core::topology::TopologyElementType m_massTopologyType;
+    sofa::geometry::ElementType m_massTopologyType;
 
     /// Pointer to the topology container. Will be set by link @sa l_topology
     sofa::core::topology::BaseMeshTopology* m_topology;
+private:
+    sofa::geometry::ElementType m_manageElementTypeChange{ sofa::geometry::ElementType::POINT };
 
-public:
-    bool m_bManageEdgeChange{ false };
-    bool m_bManageTriangleChange{ false };
-    bool m_bManageQuadChange{ false };
-    bool m_bManageTetraChange{ false };
-    bool m_bManageHexaChange{ false };
 protected:
     DiagonalMass();
 
-    ~DiagonalMass() override;
+    ~DiagonalMass() override = default;
 public:
 
     bool load(const char *filename);
@@ -145,7 +141,7 @@ public:
 
     void doUpdateInternal() override;
 
-    sofa::core::topology::TopologyElementType getMassTopologyType() const
+    sofa::geometry::ElementType getMassTopologyType() const
     {
         return m_massTopologyType;
     }

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
@@ -31,12 +31,6 @@
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/type/Vec.h>
 
-#include <SofaBaseTopology/EdgeSetGeometryAlgorithms.h>
-#include <SofaBaseTopology/TriangleSetGeometryAlgorithms.h>
-#include <SofaBaseTopology/TetrahedronSetGeometryAlgorithms.h>
-#include <SofaBaseTopology/QuadSetGeometryAlgorithms.h>
-#include <SofaBaseTopology/HexahedronSetGeometryAlgorithms.h>
-
 #include <sofa/core/objectmodel/DataFileName.h>
 
 namespace sofa::component::mass

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
@@ -133,7 +133,7 @@ public:
     bool m_bManageEdgeChange{false};
     bool m_bManageTriangleChange{ false };
     bool m_bManageQuadChange{ false };
-    sofa::component::topology::TetrahedronSetGeometryAlgorithms<GeometricalTypes>* tetraGeo;
+    bool m_bManageTetraChange{ false };
     sofa::component::topology::HexahedronSetGeometryAlgorithms<GeometricalTypes>* hexaGeo;
 protected:
     DiagonalMass();

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
@@ -130,11 +130,11 @@ protected:
     sofa::core::topology::BaseMeshTopology* m_topology;
 
 public:
-    bool m_bManageEdgeChange{false};
+    bool m_bManageEdgeChange{ false };
     bool m_bManageTriangleChange{ false };
     bool m_bManageQuadChange{ false };
     bool m_bManageTetraChange{ false };
-    sofa::component::topology::HexahedronSetGeometryAlgorithms<GeometricalTypes>* hexaGeo;
+    bool m_bManageHexaChange{ false };
 protected:
     DiagonalMass();
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
@@ -130,7 +130,7 @@ protected:
     sofa::core::topology::BaseMeshTopology* m_topology;
 
 public:
-    sofa::component::topology::EdgeSetGeometryAlgorithms<GeometricalTypes>* edgeGeo;
+    bool m_bManageEdgeChange{false};
     sofa::component::topology::TriangleSetGeometryAlgorithms<GeometricalTypes>* triangleGeo;
     sofa::component::topology::QuadSetGeometryAlgorithms<GeometricalTypes>* quadGeo;
     sofa::component::topology::TetrahedronSetGeometryAlgorithms<GeometricalTypes>* tetraGeo;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
@@ -746,31 +746,31 @@ bool DiagonalMass<DataTypes, MassType>::checkTopology()
         if (m_topology->getNbHexahedra() > 0)
         {
             msg_info() << "Hexahedral topology found.";
-            m_manageElementTypeChange == sofa::geometry::ElementType::HEXAHEDRON;
+            m_manageElementTypeChange = sofa::geometry::ElementType::HEXAHEDRON;
             return true;
         }
         else if (m_topology->getNbTetrahedra() > 0)
         {
             msg_info() << "Tetrahedral topology found.";
-            m_manageElementTypeChange == sofa::geometry::ElementType::TETRAHEDRON;
+            m_manageElementTypeChange = sofa::geometry::ElementType::TETRAHEDRON;
             return true;
         }
         else if (m_topology->getNbQuads() > 0)
         {
             msg_info() << "Quad topology found.";
-            m_manageElementTypeChange == sofa::geometry::ElementType::QUAD;
+            m_manageElementTypeChange = sofa::geometry::ElementType::QUAD;
             return true;
         }
         else if (m_topology->getNbTriangles() > 0)
         {
             msg_info() << "Triangular topology found."; 
-            m_manageElementTypeChange == sofa::geometry::ElementType::TRIANGLE;
+            m_manageElementTypeChange = sofa::geometry::ElementType::TRIANGLE;
             return true;
         }
         else if (m_topology->getNbEdges() > 0)
         {
             msg_info() << "Edge topology found.";
-            m_manageElementTypeChange == sofa::geometry::ElementType::EDGE;
+            m_manageElementTypeChange = sofa::geometry::ElementType::EDGE;
             return true;
         }
         else

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
@@ -50,18 +50,11 @@ DiagonalMass<DataTypes, MassType>::DiagonalMass()
     , d_showAxisSize( initData(&d_showAxisSize, 1.0f, "showAxisSizeFactor", "Factor length of the axis displayed (only used for rigids)" ) )
     , d_fileMass( initData(&d_fileMass,  "filename", "Xsp3.0 file to specify the mass parameters" ) )
     , l_topology(initLink("topology", "link to the topology container"))
-    , m_massTopologyType(TopologyElementType::UNKNOWN)
+    , m_massTopologyType(sofa::geometry::ElementType::UNKNOWN)
     , m_topology(nullptr)
 {
     this->addAlias(&d_fileMass,"fileMass");
 }
-
-template <class DataTypes, class MassType>
-DiagonalMass<DataTypes, MassType>::~DiagonalMass()
-{
-
-}
-
 
 template <class DataTypes, class MassType>
 void DiagonalMass<DataTypes,MassType>::applyPointCreation(PointID, MassType &m, const Point &, const sofa::type::vector<PointID> &, const sofa::type::vector<double> &)
@@ -86,7 +79,7 @@ void DiagonalMass<DataTypes,MassType>::applyEdgeCreation(const sofa::type::vecto
         const sofa::type::vector< sofa::type::vector< EdgeID > >& /*ancestors*/,
         const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/)
 {
-    if (this->getMassTopologyType() == TopologyElementType::EDGE)
+    if (this->getMassTopologyType() == sofa::geometry::ElementType::EDGE)
     {
         const auto& restPositions = this->getMState()->read(core::ConstVecCoordId::restPosition())->getValue();
 
@@ -123,7 +116,7 @@ void DiagonalMass<DataTypes,MassType>::applyEdgeCreation(const sofa::type::vecto
 template <class DataTypes, class MassType>
 void DiagonalMass<DataTypes,MassType>::applyEdgeDestruction(const sofa::type::vector<EdgeID> & edgeRemoved)
 {
-    if (this->getMassTopologyType() == TopologyElementType::EDGE)
+    if (this->getMassTopologyType() == sofa::geometry::ElementType::EDGE)
     {
         const auto& restPositions = this->getMState()->read(core::ConstVecCoordId::restPosition())->getValue();
 
@@ -164,7 +157,7 @@ void DiagonalMass<DataTypes,MassType>::applyTriangleCreation(const sofa::type::v
         const sofa::type::vector< sofa::type::vector< TriangleID > >& /*ancestors*/,
         const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/)
 {
-    if (this->getMassTopologyType() == TopologyElementType::TRIANGLE)
+    if (this->getMassTopologyType() == sofa::geometry::ElementType::TRIANGLE)
     {
         const auto& restPositions = this->getMState()->read(core::ConstVecCoordId::restPosition())->getValue();
 
@@ -203,7 +196,7 @@ void DiagonalMass<DataTypes,MassType>::applyTriangleCreation(const sofa::type::v
 template <class DataTypes, class MassType>
 void DiagonalMass<DataTypes,MassType>::applyTriangleDestruction(const sofa::type::vector<TriangleID > & triangleRemoved)
 {
-    if (this->getMassTopologyType() == TopologyElementType::TRIANGLE)
+    if (this->getMassTopologyType() == sofa::geometry::ElementType::TRIANGLE)
     {
         const auto& restPositions = this->getMState()->read(core::ConstVecCoordId::restPosition())->getValue();
 
@@ -247,7 +240,7 @@ void DiagonalMass<DataTypes, MassType>::applyQuadCreation(const sofa::type::vect
     const sofa::type::vector< sofa::type::vector< QuadID > >& /*ancestors*/,
     const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/)
 {
-    if (this->getMassTopologyType() == TopologyElementType::QUAD)
+    if (this->getMassTopologyType() == sofa::geometry::ElementType::QUAD)
     {
         const auto& restPositions = this->getMState()->read(core::ConstVecCoordId::restPosition())->getValue();
 
@@ -289,7 +282,7 @@ void DiagonalMass<DataTypes, MassType>::applyQuadCreation(const sofa::type::vect
 template <class DataTypes, class MassType>
 void DiagonalMass<DataTypes, MassType>::applyQuadDestruction(const sofa::type::vector<QuadID >& quadRemoved)
 {
-    if (this->getMassTopologyType() == TopologyElementType::QUAD)
+    if (this->getMassTopologyType() == sofa::geometry::ElementType::QUAD)
     {
         const auto& restPositions = this->getMState()->read(core::ConstVecCoordId::restPosition())->getValue();
 
@@ -335,7 +328,7 @@ void DiagonalMass<DataTypes,MassType>::applyTetrahedronCreation(const sofa::type
         const sofa::type::vector< sofa::type::vector< TetrahedronID > >& /*ancestors*/,
         const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/)
 {
-    if (this->getMassTopologyType() == TopologyElementType::TETRAHEDRON)
+    if (this->getMassTopologyType() == sofa::geometry::ElementType::TETRAHEDRON)
     {
         const auto& restPositions = this->getMState()->read(core::ConstVecCoordId::restPosition())->getValue();
 
@@ -377,7 +370,7 @@ void DiagonalMass<DataTypes,MassType>::applyTetrahedronCreation(const sofa::type
 template <class DataTypes, class MassType>
 void DiagonalMass<DataTypes,MassType>::applyTetrahedronDestruction(const sofa::type::vector<TetrahedronID> & tetrahedronRemoved)
 {
-    if (this->getMassTopologyType() == TopologyElementType::TETRAHEDRON)
+    if (this->getMassTopologyType() == sofa::geometry::ElementType::TETRAHEDRON)
     {
         const auto& restPositions = this->getMState()->read(core::ConstVecCoordId::restPosition())->getValue();
 
@@ -423,7 +416,7 @@ void DiagonalMass<DataTypes,MassType>::applyHexahedronCreation(const sofa::type:
         const sofa::type::vector< sofa::type::vector< HexahedronID > >& /*ancestors*/,
         const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/)
 {
-    if (this->getMassTopologyType() == TopologyElementType::HEXAHEDRON)
+    if (this->getMassTopologyType() == sofa::geometry::ElementType::HEXAHEDRON)
     {
         const auto& restPositions = this->getMState()->read(core::ConstVecCoordId::restPosition())->getValue();
 
@@ -466,7 +459,7 @@ void DiagonalMass<DataTypes,MassType>::applyHexahedronCreation(const sofa::type:
 template <class DataTypes, class MassType>
 void DiagonalMass<DataTypes,MassType>::applyHexahedronDestruction(const sofa::type::vector<HexahedronID> & hexahedronRemoved)
 {
-    if (this->getMassTopologyType() == TopologyElementType::HEXAHEDRON)
+    if (this->getMassTopologyType() == sofa::geometry::ElementType::HEXAHEDRON)
     {
         const auto& restPositions = this->getMState()->read(core::ConstVecCoordId::restPosition())->getValue();
 
@@ -667,7 +660,7 @@ void DiagonalMass<DataTypes, MassType>::initTopologyHandlers()
         applyPointDestruction(pointIndex, m);
     });
 
-    if (m_bManageEdgeChange) 
+    if (m_manageElementTypeChange == sofa::geometry::ElementType::EDGE)
     {
         d_vertexMass.linkToEdgeDataArray();
         d_vertexMass.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::EDGESADDED, [this](const core::topology::TopologyChange* eventTopo) {
@@ -679,7 +672,7 @@ void DiagonalMass<DataTypes, MassType>::initTopologyHandlers()
             applyEdgeDestruction(edgeRemove->getArray());
         });
     }
-    if (m_bManageTriangleChange)
+    if (m_manageElementTypeChange == sofa::geometry::ElementType::TRIANGLE)
     {
         d_vertexMass.linkToTriangleDataArray();
         d_vertexMass.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::TRIANGLESADDED, [this](const core::topology::TopologyChange* eventTopo) {
@@ -691,7 +684,7 @@ void DiagonalMass<DataTypes, MassType>::initTopologyHandlers()
             applyTriangleDestruction(tRemove->getArray());
         });
     }
-    if (m_bManageQuadChange)
+    if (m_manageElementTypeChange == sofa::geometry::ElementType::QUAD)
     {
         d_vertexMass.linkToQuadDataArray();
         d_vertexMass.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::QUADSADDED, [this](const core::topology::TopologyChange* eventTopo) {
@@ -703,7 +696,7 @@ void DiagonalMass<DataTypes, MassType>::initTopologyHandlers()
             applyQuadDestruction(qRemove->getArray());
         });
     }
-    if (m_bManageTetraChange)
+    if (m_manageElementTypeChange == sofa::geometry::ElementType::TETRAHEDRON)
     {
         d_vertexMass.linkToTetrahedronDataArray();
         d_vertexMass.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::TETRAHEDRAADDED, [this](const core::topology::TopologyChange* eventTopo) {
@@ -715,7 +708,7 @@ void DiagonalMass<DataTypes, MassType>::initTopologyHandlers()
             applyTetrahedronDestruction(tRemove->getArray());
         });
     }
-    if (m_bManageHexaChange)
+    if (m_manageElementTypeChange == sofa::geometry::ElementType::HEXAHEDRON)
     {
         d_vertexMass.linkToHexahedronDataArray();
         d_vertexMass.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::HEXAHEDRAADDED, [this](const core::topology::TopologyChange* eventTopo) {
@@ -753,51 +746,31 @@ bool DiagonalMass<DataTypes, MassType>::checkTopology()
         if (m_topology->getNbHexahedra() > 0)
         {
             msg_info() << "Hexahedral topology found.";
-            m_bManageEdgeChange = false;
-            m_bManageTriangleChange = false;
-            m_bManageQuadChange = false;
-            m_bManageTetraChange = false;
-            m_bManageHexaChange = true;
+            m_manageElementTypeChange == sofa::geometry::ElementType::HEXAHEDRON;
             return true;
         }
         else if (m_topology->getNbTetrahedra() > 0)
         {
             msg_info() << "Tetrahedral topology found.";
-            m_bManageEdgeChange = false;
-            m_bManageTriangleChange = false;
-            m_bManageQuadChange = false;
-            m_bManageTetraChange = true;
-            m_bManageHexaChange = false;
+            m_manageElementTypeChange == sofa::geometry::ElementType::TETRAHEDRON;
             return true;
         }
         else if (m_topology->getNbQuads() > 0)
         {
             msg_info() << "Quad topology found.";
-            m_bManageEdgeChange = false;
-            m_bManageTriangleChange = false;
-            m_bManageQuadChange = true;
-            m_bManageTetraChange = false;
-            m_bManageHexaChange = false;
+            m_manageElementTypeChange == sofa::geometry::ElementType::QUAD;
             return true;
         }
         else if (m_topology->getNbTriangles() > 0)
         {
-            msg_info() << "Triangular topology found.";
-            m_bManageEdgeChange = false;
-            m_bManageTriangleChange = true;
-            m_bManageQuadChange = false;
-            m_bManageTetraChange = false;
-            m_bManageHexaChange = false;
+            msg_info() << "Triangular topology found."; 
+            m_manageElementTypeChange == sofa::geometry::ElementType::TRIANGLE;
             return true;
         }
         else if (m_topology->getNbEdges() > 0)
         {
             msg_info() << "Edge topology found.";
-            m_bManageEdgeChange = true;
-            m_bManageTriangleChange = false;
-            m_bManageQuadChange = false;
-            m_bManageTetraChange = false;
-            m_bManageHexaChange = false;
+            m_manageElementTypeChange == sofa::geometry::ElementType::EDGE;
             return true;
         }
         else
@@ -963,10 +936,10 @@ void DiagonalMass<DataTypes, MassType>::computeMass()
         core::ConstVecCoordId posid = d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
         const auto& positions = this->getMState()->read(posid)->getValue();
 
-        if (m_topology->getNbHexahedra()>0 && m_bManageHexaChange)
+        if (m_topology->getNbHexahedra()>0 && m_manageElementTypeChange == sofa::geometry::ElementType::HEXAHEDRON)
         {
             helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
-            m_massTopologyType = TopologyElementType::HEXAHEDRON;
+            m_massTopologyType = sofa::geometry::ElementType::HEXAHEDRON;
 
             masses.resize(this->mstate->getSize());
             for(unsigned int i=0; i<masses.size(); ++i)
@@ -1002,10 +975,10 @@ void DiagonalMass<DataTypes, MassType>::computeMass()
 
             d_totalMass.setValue(total_mass);
         }
-        else if (m_topology->getNbTetrahedra()>0 && m_bManageTetraChange)
+        else if (m_topology->getNbTetrahedra()>0 && m_manageElementTypeChange == sofa::geometry::ElementType::TETRAHEDRON)
         {
             helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
-            m_massTopologyType = TopologyElementType::TETRAHEDRON;
+            m_massTopologyType = sofa::geometry::ElementType::TETRAHEDRON;
 
             // resize array
             clear();
@@ -1039,9 +1012,9 @@ void DiagonalMass<DataTypes, MassType>::computeMass()
             }
             d_totalMass.setValue(total_mass);
         }
-        else if (m_topology->getNbQuads()>0 && m_bManageQuadChange) {
+        else if (m_topology->getNbQuads()>0 && m_manageElementTypeChange == sofa::geometry::ElementType::QUAD) {
             helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
-            m_massTopologyType = TopologyElementType::QUAD;
+            m_massTopologyType = sofa::geometry::ElementType::QUAD;
 
             // resize array
             clear();
@@ -1074,10 +1047,10 @@ void DiagonalMass<DataTypes, MassType>::computeMass()
             }
             d_totalMass.setValue(total_mass);
         }
-        else if (m_topology->getNbTriangles()>0 && m_bManageTriangleChange)
+        else if (m_topology->getNbTriangles()>0 && m_manageElementTypeChange == sofa::geometry::ElementType::TRIANGLE)
         {
             helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
-            m_massTopologyType = TopologyElementType::TRIANGLE;
+            m_massTopologyType = sofa::geometry::ElementType::TRIANGLE;
 
             // resize array
             clear();
@@ -1109,10 +1082,10 @@ void DiagonalMass<DataTypes, MassType>::computeMass()
             }
             d_totalMass.setValue(total_mass);
         }
-        else if (m_topology->getNbEdges()>0 && m_bManageEdgeChange)
+        else if (m_topology->getNbEdges()>0 && m_manageElementTypeChange == sofa::geometry::ElementType::EDGE)
         {
             helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
-            m_massTopologyType = TopologyElementType::EDGE;
+            m_massTopologyType = sofa::geometry::ElementType::EDGE;
 
             // resize array
             clear();
@@ -1167,9 +1140,9 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
     masses.clear();
     masses.resize(this->mstate->getSize(), Real(0));
 
-    if (m_topology->getNbHexahedra() > 0 && m_bManageHexaChange)
+    if (m_topology->getNbHexahedra() > 0 && m_manageElementTypeChange == sofa::geometry::ElementType::HEXAHEDRON)
     {
-        m_massTopologyType = TopologyElementType::HEXAHEDRON;
+        m_massTopologyType = sofa::geometry::ElementType::HEXAHEDRON;
 
         for (Topology::HexahedronID i = 0; i < m_topology->getNbHexahedra(); ++i)
         {
@@ -1195,9 +1168,9 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
             }
         }
     }
-    else if (m_topology->getNbTetrahedra() > 0 && m_bManageTetraChange)
+    else if (m_topology->getNbTetrahedra() > 0 && m_manageElementTypeChange == sofa::geometry::ElementType::TETRAHEDRON)
     {
-        m_massTopologyType = TopologyElementType::TETRAHEDRON;
+        m_massTopologyType = sofa::geometry::ElementType::TETRAHEDRON;
 
         for (Topology::TetrahedronID i = 0; i < m_topology->getNbTetrahedra(); ++i)
         {
@@ -1218,9 +1191,9 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
             }
         }
     }
-    else if (m_topology->getNbQuads() > 0 && m_bManageQuadChange) 
+    else if (m_topology->getNbQuads() > 0 && m_manageElementTypeChange == sofa::geometry::ElementType::QUAD)
     {
-        m_massTopologyType = TopologyElementType::QUAD;
+        m_massTopologyType = sofa::geometry::ElementType::QUAD;
 
         for (Topology::QuadID i = 0; i < m_topology->getNbQuads(); ++i)
         {
@@ -1240,9 +1213,9 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
             }
         }
     }
-    else if (m_topology->getNbTriangles() > 0 && m_bManageTriangleChange)
+    else if (m_topology->getNbTriangles() > 0 && m_manageElementTypeChange == sofa::geometry::ElementType::TRIANGLE)
     {
-        m_massTopologyType = TopologyElementType::TRIANGLE;
+        m_massTopologyType = sofa::geometry::ElementType::TRIANGLE;
 
         for (Topology::TriangleID i = 0; i < m_topology->getNbTriangles(); ++i)
         {
@@ -1262,9 +1235,9 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
             }
         }
     }
-    else if (m_topology->getNbEdges() > 0 && m_bManageEdgeChange)
+    else if (m_topology->getNbEdges() > 0 && m_manageElementTypeChange == sofa::geometry::ElementType::EDGE)
     {
-        m_massTopologyType = TopologyElementType::EDGE;
+        m_massTopologyType = sofa::geometry::ElementType::EDGE;
 
         for (Topology::EdgeID i = 0; i < m_topology->getNbEdges(); ++i)
         {

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
@@ -88,6 +88,8 @@ void DiagonalMass<DataTypes,MassType>::applyEdgeCreation(const sofa::type::vecto
 {
     if (this->getMassTopologyType() == TopologyElementType::EDGE)
     {
+        const auto& restPositions = this->getMState()->read(core::ConstVecCoordId::restPosition())->getValue();
+
         helper::WriteAccessor<Data<MassVector> > masses(d_vertexMass);
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
 
@@ -100,10 +102,12 @@ void DiagonalMass<DataTypes,MassType>::applyEdgeCreation(const sofa::type::vecto
             /// get the edge to be added
             const Edge &e=this->m_topology->getEdge(edgeAdded[i]);
             // compute its mass based on the mass density and the edge length
-            if(this->edgeGeo)
-            {
-                mass=(md*this->edgeGeo->computeRestEdgeLength(edgeAdded[i]))/(typename DataTypes::Real(2.0));
-            }
+            const auto& rpos0 = DataTypes::getCPos(restPositions[e[0]]);
+            const auto& rpos1 = DataTypes::getCPos(restPositions[e[1]]);
+
+            const auto restEdgeLength = sofa::geometry::Edge::length(rpos0, rpos1);
+            mass= (md* restEdgeLength) / (typename DataTypes::Real(2.0));
+
             // added mass on its two vertices
             masses[e[0]]+=mass;
             masses[e[1]]+=mass;
@@ -121,6 +125,8 @@ void DiagonalMass<DataTypes,MassType>::applyEdgeDestruction(const sofa::type::ve
 {
     if (this->getMassTopologyType() == TopologyElementType::EDGE)
     {
+        const auto& restPositions = this->getMState()->read(core::ConstVecCoordId::restPosition())->getValue();
+
         helper::WriteAccessor<Data<MassVector> > masses(d_vertexMass);
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
 
@@ -133,10 +139,12 @@ void DiagonalMass<DataTypes,MassType>::applyEdgeDestruction(const sofa::type::ve
             /// get the edge to be added
             const Edge &e= this->m_topology->getEdge(edgeRemoved[i]);
             // compute its mass based on the mass density and the edge length
-            if(this->edgeGeo)
-            {
-                mass=(md*this->edgeGeo->computeRestEdgeLength(edgeRemoved[i]))/(typename DataTypes::Real (2.0));
-            }
+            const auto& rpos0 = DataTypes::getCPos(restPositions[e[0]]);
+            const auto& rpos1 = DataTypes::getCPos(restPositions[e[1]]);
+
+            const auto restEdgeLength = sofa::geometry::Edge::length(rpos0, rpos1);
+            mass = (md * restEdgeLength) / (typename DataTypes::Real(2.0));
+
             // removed mass on its two vertices
             masses[e[0]]-=mass;
             masses[e[1]]-=mass;
@@ -158,6 +166,8 @@ void DiagonalMass<DataTypes,MassType>::applyTriangleCreation(const sofa::type::v
 {
     if (this->getMassTopologyType() == TopologyElementType::TRIANGLE)
     {
+        const auto& restPositions = this->getMState()->read(core::ConstVecCoordId::restPosition())->getValue();
+
         helper::WriteAccessor<Data<MassVector> > masses(d_vertexMass);
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
 
@@ -168,12 +178,15 @@ void DiagonalMass<DataTypes,MassType>::applyTriangleCreation(const sofa::type::v
         for (i=0; i<triangleAdded.size(); ++i)
         {
             /// get the triangle to be added
-            const Triangle &t= this->m_topology->getTriangle(triangleAdded[i]);
+            const Triangle &t=this->m_topology->getTriangle(triangleAdded[i]);
             // compute its mass based on the mass density and the triangle area
-            if(this->triangleGeo)
-            {
-                mass=(md*this->triangleGeo->computeRestTriangleArea(triangleAdded[i]))/(typename DataTypes::Real(3.0));
-            }
+            const auto& rpos0 = DataTypes::getCPos(restPositions[t[0]]);
+            const auto& rpos1 = DataTypes::getCPos(restPositions[t[1]]);
+            const auto& rpos2 = DataTypes::getCPos(restPositions[t[2]]);
+
+            const auto restTriangleArea = sofa::geometry::Triangle::area(rpos0, rpos1, rpos2);
+            mass = (md * restTriangleArea) / (typename DataTypes::Real(3.0));
+
             // added mass on its three vertices
             masses[t[0]]+=mass;
             masses[t[1]]+=mass;
@@ -192,6 +205,8 @@ void DiagonalMass<DataTypes,MassType>::applyTriangleDestruction(const sofa::type
 {
     if (this->getMassTopologyType() == TopologyElementType::TRIANGLE)
     {
+        const auto& restPositions = this->getMState()->read(core::ConstVecCoordId::restPosition())->getValue();
+
         helper::WriteAccessor<Data<MassVector> > masses(d_vertexMass);
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
 
@@ -205,10 +220,12 @@ void DiagonalMass<DataTypes,MassType>::applyTriangleDestruction(const sofa::type
             const Triangle &t= this->m_topology->getTriangle(triangleRemoved[i]);
 
             /// compute its mass based on the mass density and the triangle area
-            if(this->triangleGeo)
-            {
-                mass=(md*this->triangleGeo->computeRestTriangleArea(triangleRemoved[i]))/(typename DataTypes::Real(3.0));
-            }
+            const auto& rpos0 = DataTypes::getCPos(restPositions[t[0]]);
+            const auto& rpos1 = DataTypes::getCPos(restPositions[t[1]]);
+            const auto& rpos2 = DataTypes::getCPos(restPositions[t[2]]);
+
+            const auto restTriangleArea = sofa::geometry::Triangle::area(rpos0, rpos1, rpos2);
+            mass = (md * restTriangleArea) / (typename DataTypes::Real(3.0));
 
             /// removed  mass on its three vertices
             masses[t[0]]-=mass;
@@ -232,6 +249,8 @@ void DiagonalMass<DataTypes, MassType>::applyQuadCreation(const sofa::type::vect
 {
     if (this->getMassTopologyType() == TopologyElementType::QUAD)
     {
+        const auto& restPositions = this->getMState()->read(core::ConstVecCoordId::restPosition())->getValue();
+
         helper::WriteAccessor<Data<MassVector> > masses(d_vertexMass);
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
 
@@ -244,10 +263,12 @@ void DiagonalMass<DataTypes, MassType>::applyQuadCreation(const sofa::type::vect
             /// get the quad to be added
             const Quad& q = this->m_topology->getQuad(quadAdded[i]);
             // compute its mass based on the mass density and the quad area
-            if (this->quadGeo)
-            {
-                mass = (md * this->quadGeo->computeRestQuadArea(quadAdded[i])) / (typename DataTypes::Real(4.0));
-            }
+            const auto& pos0 = DataTypes::getCPos(positions[q[0]]);
+            const auto& pos1 = DataTypes::getCPos(positions[q[1]]);
+            const auto& pos2 = DataTypes::getCPos(positions[q[2]]);
+            const auto& pos3 = DataTypes::getCPos(positions[q[3]]);
+
+            const auto quadArea = sofa::geometry::Quad::area(pos0, pos1, pos2, pos3);
             // added mass on its three vertices
             masses[q[0]] += mass;
             masses[q[1]] += mass;
@@ -267,6 +288,8 @@ void DiagonalMass<DataTypes, MassType>::applyQuadDestruction(const sofa::type::v
 {
     if (this->getMassTopologyType() == TopologyElementType::QUAD)
     {
+        const auto& restPositions = this->getMState()->read(core::ConstVecCoordId::restPosition())->getValue();
+
         helper::WriteAccessor<Data<MassVector> > masses(d_vertexMass);
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
 
@@ -280,10 +303,12 @@ void DiagonalMass<DataTypes, MassType>::applyQuadDestruction(const sofa::type::v
             const Quad& q = this->m_topology->getQuad(quadRemoved[i]);
 
             /// compute its mass based on the mass density and the quad area
-            if (this->quadGeo)
-            {
-                mass = (md * this->quadGeo->computeRestQuadArea(quadRemoved[i])) / (typename DataTypes::Real(4.0));
-            }
+            const auto& pos0 = DataTypes::getCPos(positions[q[0]]);
+            const auto& pos1 = DataTypes::getCPos(positions[q[1]]);
+            const auto& pos2 = DataTypes::getCPos(positions[q[2]]);
+            const auto& pos3 = DataTypes::getCPos(positions[q[3]]);
+
+            const auto quadArea = sofa::geometry::Quad::area(pos0, pos1, pos2, pos3);
 
             /// removed  mass on its three vertices
             masses[q[0]] -= mass;
@@ -308,6 +333,8 @@ void DiagonalMass<DataTypes,MassType>::applyTetrahedronCreation(const sofa::type
 {
     if (this->getMassTopologyType() == TopologyElementType::TETRAHEDRON)
     {
+        const auto& restPositions = this->getMState()->read(core::ConstVecCoordId::restPosition())->getValue();
+
         helper::WriteAccessor<Data<MassVector> > masses(d_vertexMass);
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
 
@@ -321,10 +348,13 @@ void DiagonalMass<DataTypes,MassType>::applyTetrahedronCreation(const sofa::type
             const Tetrahedron &t= this->m_topology->getTetrahedron(tetrahedronAdded[i]);
 
             /// compute its mass based on the mass density and the tetrahedron volume
-            if(this->tetraGeo)
-            {
-                mass=(md*this->tetraGeo->computeRestTetrahedronVolume(tetrahedronAdded[i]))/(typename DataTypes::Real(4.0));
-            }
+            const auto& rpos0 = DataTypes::getCPos(restPositions[t[0]]);
+            const auto& rpos1 = DataTypes::getCPos(restPositions[t[1]]);
+            const auto& rpos2 = DataTypes::getCPos(restPositions[t[2]]);
+            const auto& rpos3 = DataTypes::getCPos(restPositions[t[3]]);
+
+            const auto restTetraVolume = sofa::geometry::Tetrahedron::volume(rpos0, rpos1, rpos2, rpos3);
+            mass = (md * restTetraVolume) / (typename DataTypes::Real(4.0));
 
             /// added  mass on its four vertices
             masses[t[0]]+=mass;
@@ -345,6 +375,8 @@ void DiagonalMass<DataTypes,MassType>::applyTetrahedronDestruction(const sofa::t
 {
     if (this->getMassTopologyType() == TopologyElementType::TETRAHEDRON)
     {
+        const auto& restPositions = this->getMState()->read(core::ConstVecCoordId::restPosition())->getValue();
+
         helper::WriteAccessor<Data<MassVector> > masses(d_vertexMass);
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
 
@@ -356,11 +388,16 @@ void DiagonalMass<DataTypes,MassType>::applyTetrahedronDestruction(const sofa::t
         {
             /// get the tetrahedron to be added
             const Tetrahedron &t= this->m_topology->getTetrahedron(tetrahedronRemoved[i]);
-            if(this->tetraGeo)
-            {
-                // compute its mass based on the mass density and the tetrahedron volume
-                mass=(md*this->tetraGeo->computeRestTetrahedronVolume(tetrahedronRemoved[i]))/(typename DataTypes::Real(4.0));
-            }
+
+            /// compute its mass based on the mass density and the tetrahedron volume
+            const auto& rpos0 = DataTypes::getCPos(restPositions[t[0]]);
+            const auto& rpos1 = DataTypes::getCPos(restPositions[t[1]]);
+            const auto& rpos2 = DataTypes::getCPos(restPositions[t[2]]);
+            const auto& rpos3 = DataTypes::getCPos(restPositions[t[3]]);
+
+            const auto restTetraVolume = sofa::geometry::Tetrahedron::volume(rpos0, rpos1, rpos2, rpos3);
+            mass = (md * restTetraVolume) / (typename DataTypes::Real(4.0));
+
             // removed  mass on its four vertices
             masses[t[0]]-=mass;
             masses[t[1]]-=mass;
@@ -396,11 +433,19 @@ void DiagonalMass<DataTypes,MassType>::applyHexahedronCreation(const sofa::type:
             /// get the tetrahedron to be added
             const Hexahedron &t=this->m_topology->getHexahedron(hexahedronAdded[i]);
             // compute its mass based on the mass density and the tetrahedron volume
-            if(this->hexaGeo)
-            {
-                mass=(md*this->hexaGeo->computeRestHexahedronVolume(hexahedronAdded[i]))/(typename DataTypes::Real(8.0));
-            }
-            // added  mass on its four vertices
+            const auto& rpos0 = DataTypes::getCPos(restPositions[h[0]]);
+            const auto& rpos1 = DataTypes::getCPos(restPositions[h[1]]);
+            const auto& rpos2 = DataTypes::getCPos(restPositions[h[2]]);
+            const auto& rpos3 = DataTypes::getCPos(restPositions[h[3]]);
+            const auto& rpos4 = DataTypes::getCPos(restPositions[h[4]]);
+            const auto& rpos5 = DataTypes::getCPos(restPositions[h[5]]);
+            const auto& rpos6 = DataTypes::getCPos(restPositions[h[6]]);
+            const auto& rpos7 = DataTypes::getCPos(restPositions[h[7]]);
+
+            const auto hexaVolume = sofa::geometry::Hexahedron::volume(rpos0, rpos1, rpos2, rpos3, rpos4, rpos5, rpos6, rpos7);
+            mass = (md * hexaVolume) / (typename DataTypes::Real(8.0));
+
+            // added  mass on its eight vertices
             for (unsigned int j=0; j<8; ++j)
                 masses[t[j]]+=mass;
 
@@ -428,12 +473,21 @@ void DiagonalMass<DataTypes,MassType>::applyHexahedronDestruction(const sofa::ty
         {
             /// get the tetrahedron to be added
             const Hexahedron &t=this->m_topology->getHexahedron(hexahedronRemoved[i]);
-            if(this->hexaGeo)
-            {
-                // compute its mass based on the mass density and the tetrahedron volume
-                mass=(md*this->hexaGeo->computeRestHexahedronVolume(hexahedronRemoved[i]))/(typename DataTypes::Real(8.0));
-            }
-            // removed  mass on its four vertices
+
+            // compute its mass based on the mass density and the tetrahedron volume
+            const auto& rpos0 = DataTypes::getCPos(restPositions[h[0]]);
+            const auto& rpos1 = DataTypes::getCPos(restPositions[h[1]]);
+            const auto& rpos2 = DataTypes::getCPos(restPositions[h[2]]);
+            const auto& rpos3 = DataTypes::getCPos(restPositions[h[3]]);
+            const auto& rpos4 = DataTypes::getCPos(restPositions[h[4]]);
+            const auto& rpos5 = DataTypes::getCPos(restPositions[h[5]]);
+            const auto& rpos6 = DataTypes::getCPos(restPositions[h[6]]);
+            const auto& rpos7 = DataTypes::getCPos(restPositions[h[7]]);
+
+            const auto hexaVolume = sofa::geometry::Hexahedron::volume(rpos0, rpos1, rpos2, rpos3, rpos4, rpos5, rpos6, rpos7);
+            mass = (md * hexaVolume) / (typename DataTypes::Real(8.0));
+
+            // removed  mass on its eight vertices
             for (unsigned int j=0; j<8; ++j)
                 masses[t[j]]-=mass;
 
@@ -605,7 +659,7 @@ void DiagonalMass<DataTypes, MassType>::initTopologyHandlers()
         applyPointDestruction(pointIndex, m);
     });
 
-    if (edgeGeo) 
+    if (m_bManageEdgeChange) 
     {
         d_vertexMass.linkToEdgeDataArray();
         d_vertexMass.addTopologyEventCallBack(sofa::core::topology::TopologyChangeType::EDGESADDED, [this](const core::topology::TopologyChange* eventTopo) {
@@ -686,99 +740,57 @@ bool DiagonalMass<DataTypes, MassType>::checkTopology()
         return false;
     }
 
-    this->getContext()->get(edgeGeo);
-    this->getContext()->get(triangleGeo);
-    this->getContext()->get(quadGeo);
-    this->getContext()->get(tetraGeo);
-    this->getContext()->get(hexaGeo);
-
     if (m_topology)
     {
         if (m_topology->getNbHexahedra() > 0)
         {
-            if(!hexaGeo)
-            {
-                msg_error() << "Hexahedron topology found but geometry algorithms are missing. Add the component HexahedronSetGeometryAlgorithms.";
-                return false;
-            }
-            else
-            {
-                msg_info() << "Hexahedral topology found.";
-                edgeGeo = nullptr;
-                triangleGeo = nullptr;
-                quadGeo = nullptr;
-                tetraGeo = nullptr;
-                return true;
-            }
+            msg_info() << "Hexahedral topology found.";
+            m_bManageEdgeChange = false;
+            m_bManageTriangleChange = false;
+            m_bManageQuadChange = false;
+            m_bManageTetraChange = false;
+            m_bManageHexaChange = true;
+            return true;
         }
         else if (m_topology->getNbTetrahedra() > 0)
         {
-            if(!tetraGeo)
-            {
-                msg_error() << "Tetrahedron topology found but geometry algorithms are missing. Add the component TetrahedronSetGeometryAlgorithms.";
-                return false;
-            }
-            else
-            {
-                msg_info() << "Tetrahedral topology found.";
-                edgeGeo = nullptr;
-                triangleGeo = nullptr;
-                quadGeo = nullptr;
-                hexaGeo = nullptr;
-
-                return true;
-            }
+            msg_info() << "Tetrahedral topology found.";
+            m_bManageEdgeChange = false;
+            m_bManageTriangleChange = false;
+            m_bManageQuadChange = false;
+            m_bManageTetraChange = true;
+            m_bManageHexaChange = false;
+            return true;
         }
         else if (m_topology->getNbQuads() > 0)
         {
-            if(!quadGeo)
-            {
-                msg_error() << "Quad topology found but geometry algorithms are missing. Add the component QuadSetGeometryAlgorithms.";
-                return false;
-            }
-            else
-            {
-                msg_info() << "Quad topology found.";
-                edgeGeo = nullptr;
-                triangleGeo = nullptr;
-                tetraGeo  = nullptr;
-                hexaGeo = nullptr;
-                return true;
-            }
+            msg_info() << "Quad topology found.";
+            m_bManageEdgeChange = false;
+            m_bManageTriangleChange = false;
+            m_bManageQuadChange = true;
+            m_bManageTetraChange = false;
+            m_bManageHexaChange = false;
+            return true;
         }
         else if (m_topology->getNbTriangles() > 0)
         {
-            if(!triangleGeo)
-            {
-                msg_error() << "Triangle topology found but geometry algorithms are missing. Add the component TriangleSetGeometryAlgorithms.";
-                return false;
-            }
-            else
-            {
-                msg_info() << "Triangular topology found.";
-                edgeGeo = nullptr;
-                quadGeo = nullptr;
-                tetraGeo  = nullptr;
-                hexaGeo = nullptr;
-                return true;
-            }
+            msg_info() << "Triangular topology found.";
+            m_bManageEdgeChange = false;
+            m_bManageTriangleChange = true;
+            m_bManageQuadChange = false;
+            m_bManageTetraChange = false;
+            m_bManageHexaChange = false;
+            return true;
         }
         else if (m_topology->getNbEdges() > 0)
         {
-            if(!edgeGeo)
-            {
-                msg_error() << "Edge topology found but geometry algorithms are missing. Add the component EdgeSetGeometryAlgorithms.";
-                return false;
-            }
-            else
-            {
-                msg_info() << "Edge topology found.";
-                triangleGeo = nullptr;
-                quadGeo = nullptr;
-                tetraGeo  = nullptr;
-                hexaGeo = nullptr;
-                return true;
-            }
+            msg_info() << "Edge topology found.";
+            m_bManageEdgeChange = true;
+            m_bManageTriangleChange = false;
+            m_bManageQuadChange = false;
+            m_bManageTetraChange = false;
+            m_bManageHexaChange = false;
+            return true;
         }
         else
         {
@@ -940,7 +952,10 @@ void DiagonalMass<DataTypes, MassType>::computeMass()
 {
     if (m_topology && (d_massDensity.getValue() > 0 || d_vertexMass.getValue().size() == 0))
     {
-        if (m_topology->getNbHexahedra()>0 && hexaGeo)
+        core::ConstVecCoordId posid = d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
+        const auto& positions = this->getMState()->read(posid)->getValue();
+
+        if (m_topology->getNbHexahedra()>0 && m_bManageHexaChange)
         {
             helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
             m_massTopologyType = TopologyElementType::HEXAHEDRON;
@@ -956,24 +971,30 @@ void DiagonalMass<DataTypes, MassType>::computeMass()
             for (Topology::HexahedronID i=0; i<m_topology->getNbHexahedra(); ++i)
             {
                 const Hexahedron &h=m_topology->getHexahedron(i);
-                if (hexaGeo)
-                {
-                    if (d_computeMassOnRest.getValue())
-                        mass=(md*hexaGeo->computeRestHexahedronVolume(i))/(Real(8.0));
-                    else
-                        mass=(md*hexaGeo->computeHexahedronVolume(i))/(Real(8.0));
 
-                    for (unsigned int j = 0 ; j < h.size(); j++)
-                    {
-                        masses[h[j]] += mass;
-                        total_mass += mass;
-                    }
+                /// compute its mass based on the mass density and the hexahedron volume
+                const auto& rpos0 = DataTypes::getCPos(positions[h[0]]);
+                const auto& rpos1 = DataTypes::getCPos(positions[h[1]]);
+                const auto& rpos2 = DataTypes::getCPos(positions[h[2]]);
+                const auto& rpos3 = DataTypes::getCPos(positions[h[3]]);
+                const auto& rpos4 = DataTypes::getCPos(positions[h[4]]);
+                const auto& rpos5 = DataTypes::getCPos(positions[h[5]]);
+                const auto& rpos6 = DataTypes::getCPos(positions[h[6]]);
+                const auto& rpos7 = DataTypes::getCPos(positions[h[7]]);
+
+                const auto hexaVolume = sofa::geometry::Hexahedron::volume(rpos0, rpos1, rpos2, rpos3, rpos4, rpos5, rpos6, rpos7);
+                mass = (md * hexaVolume) / (typename DataTypes::Real(8.0));
+
+                for (unsigned int j = 0 ; j < h.size(); j++)
+                {
+                    masses[h[j]] += mass;
+                    total_mass += mass;
                 }
             }
 
             d_totalMass.setValue(total_mass);
         }
-        else if (m_topology->getNbTetrahedra()>0 && tetraGeo)
+        else if (m_topology->getNbTetrahedra()>0 && m_bManageTetraChange)
         {
             helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
             m_massTopologyType = TopologyElementType::TETRAHEDRON;
@@ -992,13 +1013,16 @@ void DiagonalMass<DataTypes, MassType>::computeMass()
             for (Topology::TetrahedronID i=0; i<m_topology->getNbTetrahedra(); ++i)
             {
                 const Tetrahedron &t=m_topology->getTetrahedron(i);
-                if(tetraGeo)
-                {
-                    if (d_computeMassOnRest.getValue())
-                        mass=(md*tetraGeo->computeRestTetrahedronVolume(i))/(Real(4.0));
-                    else
-                        mass=(md*tetraGeo->computeTetrahedronVolume(i))/(Real(4.0));
-                }
+
+                /// compute its mass based on the mass density and the tetrahedron volume
+                const auto& rpos0 = DataTypes::getCPos(positions[t[0]]);
+                const auto& rpos1 = DataTypes::getCPos(positions[t[1]]);
+                const auto& rpos2 = DataTypes::getCPos(positions[t[2]]);
+                const auto& rpos3 = DataTypes::getCPos(positions[t[3]]);
+
+                const auto tetraVolume = sofa::geometry::Tetrahedron::volume(rpos0, rpos1, rpos2, rpos3);
+                mass = (md * tetraVolume) / (typename DataTypes::Real(4.0));
+
                 for (unsigned int j = 0 ; j < t.size(); j++)
                 {
                     masses[t[j]] += mass;
@@ -1007,7 +1031,7 @@ void DiagonalMass<DataTypes, MassType>::computeMass()
             }
             d_totalMass.setValue(total_mass);
         }
-        else if (m_topology->getNbQuads()>0 && quadGeo) {
+        else if (m_topology->getNbQuads()>0 && m_bManageQuadChange) {
             helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
             m_massTopologyType = TopologyElementType::QUAD;
 
@@ -1024,23 +1048,25 @@ void DiagonalMass<DataTypes, MassType>::computeMass()
 
             for (Topology::QuadID i=0; i<m_topology->getNbQuads(); ++i)
             {
-                const Quad &t=m_topology->getQuad(i);
-                if(quadGeo)
+                const Quad &q=m_topology->getQuad(i);
+
+                const auto& pos0 = DataTypes::getCPos(positions[q[0]]);
+                const auto& pos1 = DataTypes::getCPos(positions[q[1]]);
+                const auto& pos2 = DataTypes::getCPos(positions[q[2]]);
+                const auto& pos3 = DataTypes::getCPos(positions[q[3]]);
+
+                const auto quadArea = sofa::geometry::Quad::area(pos0, pos1, pos2, pos3);
+                mass = (md * quadArea) / (Real(4.0));
+
+                for (unsigned int j = 0 ; j < q.size(); j++)
                 {
-                    if (d_computeMassOnRest.getValue())
-                        mass=(md*quadGeo->computeRestQuadArea(i))/(Real(4.0));
-                    else
-                        mass=(md*quadGeo->computeQuadArea(i))/(Real(4.0));
-                }
-                for (unsigned int j = 0 ; j < t.size(); j++)
-                {
-                    masses[t[j]] += mass;
+                    masses[q[j]] += mass;
                     total_mass += mass;
                 }
             }
             d_totalMass.setValue(total_mass);
         }
-        else if (m_topology->getNbTriangles()>0 && triangleGeo)
+        else if (m_topology->getNbTriangles()>0 && m_bManageTriangleChange)
         {
             helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
             m_massTopologyType = TopologyElementType::TRIANGLE;
@@ -1059,13 +1085,14 @@ void DiagonalMass<DataTypes, MassType>::computeMass()
             for (Topology::TriangleID i=0; i<m_topology->getNbTriangles(); ++i)
             {
                 const Triangle &t=m_topology->getTriangle(i);
-                if(triangleGeo)
-                {
-                    if (d_computeMassOnRest.getValue())
-                        mass=(md*triangleGeo->computeRestTriangleArea(i))/(Real(3.0));
-                    else
-                        mass=(md*triangleGeo->computeTriangleArea(i))/(Real(3.0));
-                }
+
+                const auto& pos0 = DataTypes::getCPos(positions[t[0]]);
+                const auto& pos1 = DataTypes::getCPos(positions[t[1]]);
+                const auto& pos2 = DataTypes::getCPos(positions[t[2]]);
+
+                const auto triangleArea = sofa::geometry::Triangle::area(pos0, pos1, pos2);
+                mass = (md * triangleArea) / (Real(3.0));
+
                 for (unsigned int j = 0 ; j < t.size(); j++)
                 {
                     masses[t[j]] += mass;
@@ -1074,7 +1101,7 @@ void DiagonalMass<DataTypes, MassType>::computeMass()
             }
             d_totalMass.setValue(total_mass);
         }
-        else if (m_topology->getNbEdges()>0 && edgeGeo)
+        else if (m_topology->getNbEdges()>0 && m_bManageEdgeChange)
         {
             helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
             m_massTopologyType = TopologyElementType::EDGE;
@@ -1093,13 +1120,13 @@ void DiagonalMass<DataTypes, MassType>::computeMass()
             for (Topology::EdgeID i=0; i<m_topology->getNbEdges(); ++i)
             {
                 const Edge &e=m_topology->getEdge(i);
-                if(edgeGeo)
-                {
-                    if (d_computeMassOnRest.getValue())
-                        mass=(md*edgeGeo->computeRestEdgeLength(i))/(Real(2.0));
-                    else
-                        mass=(md*edgeGeo->computeEdgeLength(i))/(Real(2.0));
-                }
+
+                const auto& pos0 = DataTypes::getCPos(positions[e[0]]);
+                const auto& pos1 = DataTypes::getCPos(positions[e[1]]);
+
+                const auto edgeLength = sofa::geometry::Edge::length(pos0, pos1);
+                mass = (md * edgeLength) / (Real(2.0));
+
                 for (unsigned int j = 0 ; j < e.size(); j++)
                 {
                     masses[e[j]] += mass;
@@ -1123,13 +1150,16 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
         return total_mass;
     }
     
+    core::ConstVecCoordId posid = d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
+    const auto& positions = this->getMState()->read(posid)->getValue();
+
     Real mass = Real(0);
     helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
     // resize array
     masses.clear();
     masses.resize(this->mstate->getSize(), Real(0));
 
-    if (m_topology->getNbHexahedra() > 0 && hexaGeo)
+    if (m_topology->getNbHexahedra() > 0 && m_bManageHexaChange)
     {
         m_massTopologyType = TopologyElementType::HEXAHEDRON;
 
@@ -1137,10 +1167,18 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
         {
             const Hexahedron& h = m_topology->getHexahedron(i);
 
-            if (d_computeMassOnRest.getValue())
-                mass = (density * hexaGeo->computeRestHexahedronVolume(i)) / (Real(8.0));
-            else
-                mass = (density * hexaGeo->computeHexahedronVolume(i)) / (Real(8.0));
+            /// compute its mass based on the mass density and the hexahedron volume
+            const auto& rpos0 = DataTypes::getCPos(positions[h[0]]);
+            const auto& rpos1 = DataTypes::getCPos(positions[h[1]]);
+            const auto& rpos2 = DataTypes::getCPos(positions[h[2]]);
+            const auto& rpos3 = DataTypes::getCPos(positions[h[3]]);
+            const auto& rpos4 = DataTypes::getCPos(positions[h[4]]);
+            const auto& rpos5 = DataTypes::getCPos(positions[h[5]]);
+            const auto& rpos6 = DataTypes::getCPos(positions[h[6]]);
+            const auto& rpos7 = DataTypes::getCPos(positions[h[7]]);
+
+            const auto hexaVolume = sofa::geometry::Hexahedron::volume(rpos0, rpos1, rpos2, rpos3, rpos4, rpos5, rpos6, rpos7);
+            mass = (density * hexaVolume) / (typename DataTypes::Real(8.0));
 
             for (unsigned int j = 0; j < h.size(); j++)
             {
@@ -1149,7 +1187,7 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
             }
         }
     }
-    else if (m_topology->getNbTetrahedra() > 0 && tetraGeo)
+    else if (m_topology->getNbTetrahedra() > 0 && m_bManageTetraChange)
     {
         m_massTopologyType = TopologyElementType::TETRAHEDRON;
 
@@ -1157,11 +1195,14 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
         {
             const Tetrahedron& t = m_topology->getTetrahedron(i);
 
-            if (d_computeMassOnRest.getValue())
-                mass = (density * tetraGeo->computeRestTetrahedronVolume(i)) / (Real(4.0));
-            else
-                mass = (density * tetraGeo->computeTetrahedronVolume(i)) / (Real(4.0));
+            /// compute its mass based on the mass density and the tetrahedron volume
+            const auto& rpos0 = DataTypes::getCPos(positions[t[0]]);
+            const auto& rpos1 = DataTypes::getCPos(positions[t[1]]);
+            const auto& rpos2 = DataTypes::getCPos(positions[t[2]]);
+            const auto& rpos3 = DataTypes::getCPos(positions[t[3]]);
 
+            const auto tetraVolume = sofa::geometry::Tetrahedron::volume(rpos0, rpos1, rpos2, rpos3);
+            mass = (density * tetraVolume) / (typename DataTypes::Real(4.0));
             for (unsigned int j = 0; j < t.size(); j++)
             {
                 masses[t[j]] += mass;
@@ -1169,7 +1210,7 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
             }
         }
     }
-    else if (m_topology->getNbQuads() > 0 && quadGeo) 
+    else if (m_topology->getNbQuads() > 0 && m_bManageQuadChange) 
     {
         m_massTopologyType = TopologyElementType::QUAD;
 
@@ -1177,11 +1218,13 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
         {
             const Quad& t = m_topology->getQuad(i);
 
-            if (d_computeMassOnRest.getValue())
-                mass = (density * quadGeo->computeRestQuadArea(i)) / (Real(4.0));
-            else
-                mass = (density * quadGeo->computeQuadArea(i)) / (Real(4.0));
+            const auto& pos0 = DataTypes::getCPos(positions[q[0]]);
+            const auto& pos1 = DataTypes::getCPos(positions[q[1]]);
+            const auto& pos2 = DataTypes::getCPos(positions[q[2]]);
+            const auto& pos3 = DataTypes::getCPos(positions[q[3]]);
 
+            const auto quadArea = sofa::geometry::Quad::area(pos0, pos1, pos2, pos3);
+            mass = (density * quadArea) / (Real(4.0));
             for (unsigned int j = 0; j < t.size(); j++)
             {
                 masses[t[j]] += mass;
@@ -1189,7 +1232,7 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
             }
         }
     }
-    else if (m_topology->getNbTriangles() > 0 && triangleGeo)
+    else if (m_topology->getNbTriangles() > 0 && m_bManageTriangleChange)
     {
         m_massTopologyType = TopologyElementType::TRIANGLE;
 
@@ -1197,11 +1240,13 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
         {
             const Triangle& t = m_topology->getTriangle(i);
 
-            if (d_computeMassOnRest.getValue())
-                mass = (density * triangleGeo->computeRestTriangleArea(i)) / (Real(3.0));
-            else
-                mass = (density * triangleGeo->computeTriangleArea(i)) / (Real(3.0));
+            const auto& pos0 = DataTypes::getCPos(positions[t[0]]);
+            const auto& pos1 = DataTypes::getCPos(positions[t[1]]);
+            const auto& pos2 = DataTypes::getCPos(positions[t[2]]);
 
+            const auto triangleArea = sofa::geometry::Triangle::area(pos0, pos1, pos2);
+            mass = (density * triangleArea) / (Real(3.0));
+            
             for (unsigned int j = 0; j < t.size(); j++)
             {
                 masses[t[j]] += mass;
@@ -1209,7 +1254,7 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
             }
         }
     }
-    else if (m_topology->getNbEdges() > 0 && edgeGeo)
+    else if (m_topology->getNbEdges() > 0 && m_bManageEdgeChange)
     {
         m_massTopologyType = TopologyElementType::EDGE;
 
@@ -1217,10 +1262,11 @@ typename DiagonalMass<DataTypes, MassType>::Real DiagonalMass<DataTypes, MassTyp
         {
             const Edge& e = m_topology->getEdge(i);
 
-            if (d_computeMassOnRest.getValue())
-                mass = (density * edgeGeo->computeRestEdgeLength(i)) / (Real(2.0));
-            else
-                mass = (density * edgeGeo->computeEdgeLength(i)) / (Real(2.0));
+            const auto& pos0 = DataTypes::getCPos(positions[e[0]]);
+            const auto& pos1 = DataTypes::getCPos(positions[e[1]]);
+
+            const auto edgeLength = sofa::geometry::Edge::length(pos0, pos1);
+            mass = (density * edgeLength) / (Real(2.0));
 
             for (unsigned int j = 0; j < e.size(); j++)
             {

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.h
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.h
@@ -34,18 +34,6 @@
 #include <sofa/helper/map.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 
-
-namespace sofa::component::topology
-{
-	/// forward declaration to avoid adding includes in .h
-	template< class DataTypes> class EdgeSetGeometryAlgorithms;
-	template< class DataTypes> class TriangleSetGeometryAlgorithms;
-	template< class DataTypes> class TetrahedronSetGeometryAlgorithms;
-	template< class DataTypes> class QuadSetGeometryAlgorithms;
-	template< class DataTypes> class HexahedronSetGeometryAlgorithms;
-}
-
-
 namespace sofa::component::mass
 {
 
@@ -132,13 +120,6 @@ protected:
 
 
 public:
-    sofa::component::topology::EdgeSetGeometryAlgorithms<GeometricalTypes>* edgeGeo;
-    sofa::component::topology::TriangleSetGeometryAlgorithms<GeometricalTypes>* triangleGeo;
-    sofa::component::topology::QuadSetGeometryAlgorithms<GeometricalTypes>* quadGeo;
-    sofa::component::topology::TetrahedronSetGeometryAlgorithms<GeometricalTypes>* tetraGeo;
-    sofa::component::topology::HexahedronSetGeometryAlgorithms<GeometricalTypes>* hexaGeo;
-
-
     virtual void clear();
 
     void reinit() override;

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -30,12 +30,6 @@
 #include <SofaBaseMechanics/AddMToMatrixFunctor.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/type/vector.h>
-#include <SofaBaseTopology/CommonAlgorithms.h>
-#include <SofaBaseTopology/EdgeSetGeometryAlgorithms.h>
-#include <SofaBaseTopology/TriangleSetGeometryAlgorithms.h>
-#include <SofaBaseTopology/TetrahedronSetGeometryAlgorithms.h>
-#include <SofaBaseTopology/QuadSetGeometryAlgorithms.h>
-#include <SofaBaseTopology/HexahedronSetGeometryAlgorithms.h>
 #include <sofa/simulation/AnimateEndEvent.h>
 #include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <numeric>
@@ -897,7 +891,7 @@ void MeshMatrixMass<DataTypes, MassType>::applyVertexMassHexahedronDestruction(c
             const auto& rpos7 = DataTypes::getCPos(positions[h[7]]);
 
             const auto hexaVolume = sofa::geometry::Hexahedron::volume(rpos0, rpos1, rpos2, rpos3, rpos4, rpos5, rpos6, rpos7);
-            mass = (densityM[hexahedronRemoved[i]] * hexaVolume) / (typename DataTypes::Real(40.0));
+            mass = (densityM[hexahedronRemoved[i]] * hexaVolume) / (typename DataTypes::Real(20.0));
 
             // Removing mass
             for (unsigned int j=0; j<8; ++j)

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -129,6 +129,9 @@ void MeshMatrixMass<DataTypes, MassType>::applyVertexMassTriangleCreation(const 
     SOFA_UNUSED(elems);
     if (this->getMassTopologyType() == TopologyElementType::TRIANGLE)
     {
+        core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
+        const auto& positions = this->getMState()->read(posid)->getValue();
+
         helper::WriteAccessor< Data< type::vector<MassType> > > VertexMasses (d_vertexMass );
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);        
 
@@ -148,17 +151,12 @@ void MeshMatrixMass<DataTypes, MassType>::applyVertexMassTriangleCreation(const 
             const core::topology::BaseMeshTopology::Triangle &t = this->m_topology->getTriangle(triangleAdded[i]);
 
             // Compute rest mass of conserne triangle = density * triangle surface.
-            if(this->triangleGeo)
-            {
-                if(d_computeMassOnRest.getValue())
-                {
-                    mass=(densityM[triangleAdded[i]] * this->triangleGeo->computeRestTriangleArea(triangleAdded[i]))/(typename DataTypes::Real(6.0));
-                }
-                else
-                {
-                    mass=(densityM[triangleAdded[i]] * this->triangleGeo->computeTriangleArea(triangleAdded[i]))/(typename DataTypes::Real(6.0));
-                }
-            }
+            const auto& pos0 = DataTypes::getCPos(positions[t[0]]);
+            const auto& pos1 = DataTypes::getCPos(positions[t[1]]);
+            const auto& pos2 = DataTypes::getCPos(positions[t[2]]);
+
+            const auto triangleArea = sofa::geometry::Triangle::area(pos0, pos1, pos2);
+            mass = (densityM[triangleAdded[i]] * triangleArea) / (typename DataTypes::Real(6.0));
 
             // Adding mass
             for (unsigned int j=0; j<3; ++j)
@@ -187,6 +185,9 @@ void MeshMatrixMass<DataTypes, MassType>::applyEdgeMassTriangleCreation(const so
     SOFA_UNUSED(elems);
     if (this->getMassTopologyType() == TopologyElementType::TRIANGLE)
     {
+        core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
+        const auto& positions = this->getMState()->read(posid)->getValue();
+
         helper::WriteAccessor< Data< type::vector<MassType> > > EdgeMasses ( d_edgeMass );
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
 
@@ -204,19 +205,15 @@ void MeshMatrixMass<DataTypes, MassType>::applyEdgeMassTriangleCreation(const so
         {
             // Get the edgesInTriangle to be added
             const core::topology::BaseMeshTopology::EdgesInTriangle &te = this->m_topology->getEdgesInTriangle(triangleAdded[i]);
+            const core::topology::BaseMeshTopology::Triangle& t = this->m_topology->getTriangle(triangleAdded[i]);
 
             // Compute rest mass of conserne triangle = density * triangle surface.
-            if(this->triangleGeo)
-            {
-                if(d_computeMassOnRest.getValue())
-                {
-                    mass=(densityM[triangleAdded[i]] * this->triangleGeo->computeRestTriangleArea(triangleAdded[i]))/(typename DataTypes::Real(12.0));
-                }
-                else
-                {
-                    mass=(densityM[triangleAdded[i]] * this->triangleGeo->computeTriangleArea(triangleAdded[i]))/(typename DataTypes::Real(12.0));
-                }
-            }
+            const auto& pos0 = DataTypes::getCPos(positions[t[0]]);
+            const auto& pos1 = DataTypes::getCPos(positions[t[1]]);
+            const auto& pos2 = DataTypes::getCPos(positions[t[2]]);
+
+            const auto triangleArea = sofa::geometry::Triangle::area(pos0, pos1, pos2);
+            mass = (densityM[triangleAdded[i]] * triangleArea) / (typename DataTypes::Real(12.0));
 
             // Adding mass edges of concerne triangle
             for (unsigned int j=0; j<3; ++j)
@@ -237,6 +234,9 @@ void MeshMatrixMass<DataTypes, MassType>::applyVertexMassTriangleDestruction(con
 {
     if (this->getMassTopologyType() == TopologyElementType::TRIANGLE)
     {
+        core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
+        const auto& positions = this->getMState()->read(posid)->getValue();
+
         helper::WriteAccessor< Data< type::vector<MassType> > > VertexMasses (d_vertexMass );
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
 
@@ -250,17 +250,12 @@ void MeshMatrixMass<DataTypes, MassType>::applyVertexMassTriangleDestruction(con
             const core::topology::BaseMeshTopology::Triangle &t = this->m_topology->getTriangle(triangleRemoved[i]);
 
             // Compute rest mass of conserne triangle = density * triangle surface.
-            if(this->triangleGeo)
-            {
-                if(d_computeMassOnRest.getValue())
-                {
-                    mass=(densityM[triangleRemoved[i]] * this->triangleGeo->computeRestTriangleArea(triangleRemoved[i]))/(typename DataTypes::Real(6.0));
-                }
-                else
-                {
-                    mass=(densityM[triangleRemoved[i]] * this->triangleGeo->computeTriangleArea(triangleRemoved[i]))/(typename DataTypes::Real(6.0));
-                }
-            }
+            const auto& pos0 = DataTypes::getCPos(positions[t[0]]);
+            const auto& pos1 = DataTypes::getCPos(positions[t[1]]);
+            const auto& pos2 = DataTypes::getCPos(positions[t[2]]);
+
+            const auto triangleArea = sofa::geometry::Triangle::area(pos0, pos1, pos2);
+            mass = (densityM[triangleRemoved[i]] * triangleArea) / (typename DataTypes::Real(6.0));
 
             // Removing mass
             for (unsigned int j=0; j<3; ++j)
@@ -285,6 +280,9 @@ void MeshMatrixMass<DataTypes, MassType>::applyEdgeMassTriangleDestruction(const
 {
     if (this->getMassTopologyType() == TopologyElementType::TRIANGLE)
     {
+        core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
+        const auto& positions = this->getMState()->read(posid)->getValue();
+
         helper::WriteAccessor< Data< type::vector<MassType> > > EdgeMasses (d_edgeMass );
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
 
@@ -296,19 +294,15 @@ void MeshMatrixMass<DataTypes, MassType>::applyEdgeMassTriangleDestruction(const
         {
             // Get the triangle to be removed
             const core::topology::BaseMeshTopology::EdgesInTriangle &te = this->m_topology->getEdgesInTriangle(triangleRemoved[i]);
+            const core::topology::BaseMeshTopology::Triangle& t = this->m_topology->getTriangle(triangleRemoved[i]);
 
             // Compute rest mass of conserne triangle = density * triangle surface.
-            if(this->triangleGeo)
-            {
-                if(d_computeMassOnRest.getValue())
-                {
-                    mass=(densityM[triangleRemoved[i]] * this->triangleGeo->computeRestTriangleArea(triangleRemoved[i]))/(typename DataTypes::Real(12.0));
-                }
-                else
-                {
-                    mass=(densityM[triangleRemoved[i]] * this->triangleGeo->computeTriangleArea(triangleRemoved[i]))/(typename DataTypes::Real(12.0));
-                }
-            }
+            const auto& pos0 = DataTypes::getCPos(positions[t[0]]);
+            const auto& pos1 = DataTypes::getCPos(positions[t[1]]);
+            const auto& pos2 = DataTypes::getCPos(positions[t[2]]);
+
+            const auto triangleArea = sofa::geometry::Triangle::area(pos0, pos1, pos2);
+            mass = (densityM[triangleRemoved[i]] * triangleArea) / (typename DataTypes::Real(12.0));
 
             // Removing mass edges of concerne triangle
             for (unsigned int j=0; j<3; ++j)
@@ -340,6 +334,9 @@ void MeshMatrixMass<DataTypes, MassType>::applyVertexMassQuadCreation(const sofa
     SOFA_UNUSED(elems);
     if (this->getMassTopologyType() == TopologyElementType::QUAD)
     {
+        core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
+        const auto& positions = this->getMState()->read(posid)->getValue();
+
         helper::WriteAccessor< Data< type::vector<MassType> > > VertexMasses ( d_vertexMass );
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
 
@@ -359,17 +356,13 @@ void MeshMatrixMass<DataTypes, MassType>::applyVertexMassQuadCreation(const sofa
             const core::topology::BaseMeshTopology::Quad &q = this->m_topology->getQuad(quadAdded[i]);
 
             // Compute rest mass of conserne quad = density * quad surface.
-            if(this->quadGeo)
-            {
-                if(d_computeMassOnRest.getValue())
-                {
-                    mass=(densityM[quadAdded[i]] * this->quadGeo->computeRestQuadArea(quadAdded[i]))/(typename DataTypes::Real(8.0));
-                }
-                else
-                {
-                    mass=(densityM[quadAdded[i]] * this->quadGeo->computeQuadArea(quadAdded[i]))/(typename DataTypes::Real(8.0));
-                }
-            }
+            const auto& pos0 = DataTypes::getCPos(positions[q[0]]);
+            const auto& pos1 = DataTypes::getCPos(positions[q[1]]);
+            const auto& pos2 = DataTypes::getCPos(positions[q[2]]);
+            const auto& pos3 = DataTypes::getCPos(positions[q[3]]);
+
+            const auto quadArea = sofa::geometry::Quad::area(pos0, pos1, pos2, pos3);
+            mass = (densityM[quadAdded[i]] * quadArea) / (typename DataTypes::Real(8.0));
 
             // Adding mass
             for (unsigned int j=0; j<4; ++j)
@@ -399,6 +392,9 @@ void MeshMatrixMass<DataTypes, MassType>::applyEdgeMassQuadCreation(const sofa::
 
     if (this->getMassTopologyType() == TopologyElementType::QUAD)
     {
+        core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
+        const auto& positions = this->getMState()->read(posid)->getValue();
+
         helper::WriteAccessor< Data< type::vector<MassType> > > EdgeMasses ( d_edgeMass );
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
         
@@ -416,19 +412,16 @@ void MeshMatrixMass<DataTypes, MassType>::applyEdgeMassQuadCreation(const sofa::
         {
             // Get the EdgesInQuad to be added
             const core::topology::BaseMeshTopology::EdgesInQuad &qe = this->m_topology->getEdgesInQuad(quadAdded[i]);
+            const core::topology::BaseMeshTopology::Quad& q = this->m_topology->getQuad(quadAdded[i]);
 
             // Compute rest mass of conserne quad = density * quad surface.
-            if(this->quadGeo)
-            {
-                if(d_computeMassOnRest.getValue())
-                {
-                    mass=(densityM[quadAdded[i]] * this->quadGeo->computeRestQuadArea(quadAdded[i]))/(typename DataTypes::Real(16.0));
-                }
-                else
-                {
-                    mass=(densityM[quadAdded[i]] * this->quadGeo->computeQuadArea(quadAdded[i]))/(typename DataTypes::Real(16.0));
-                }
-            }
+            const auto& pos0 = DataTypes::getCPos(positions[q[0]]);
+            const auto& pos1 = DataTypes::getCPos(positions[q[1]]);
+            const auto& pos2 = DataTypes::getCPos(positions[q[2]]);
+            const auto& pos3 = DataTypes::getCPos(positions[q[3]]);
+
+            const auto quadArea = sofa::geometry::Quad::area(pos0, pos1, pos2, pos3);
+            mass = (densityM[quadAdded[i]] * quadArea) / (typename DataTypes::Real(16.0));
 
             // Adding mass edges of concerne quad
             for (unsigned int j=0; j<4; ++j)
@@ -449,6 +442,9 @@ void MeshMatrixMass<DataTypes, MassType>::applyVertexMassQuadDestruction(const s
 {
     if (this->getMassTopologyType() == TopologyElementType::QUAD)
     {
+        core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
+        const auto& positions = this->getMState()->read(posid)->getValue();
+
         helper::WriteAccessor< Data< type::vector<MassType> > > VertexMasses ( d_vertexMass );
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
 
@@ -462,17 +458,13 @@ void MeshMatrixMass<DataTypes, MassType>::applyVertexMassQuadDestruction(const s
             const core::topology::BaseMeshTopology::Quad &q = this->m_topology->getQuad(quadRemoved[i]);
 
             // Compute rest mass of conserne quad = density * quad surface.
-            if(this->quadGeo)
-            {
-                if(d_computeMassOnRest.getValue())
-                {
-                    mass=(densityM[quadRemoved[i]] * this->quadGeo->computeRestQuadArea(quadRemoved[i]))/(typename DataTypes::Real(8.0));
-                }
-                else
-                {
-                    mass=(densityM[quadRemoved[i]] * this->quadGeo->computeQuadArea(quadRemoved[i]))/(typename DataTypes::Real(8.0));
-                }
-            }
+            const auto& pos0 = DataTypes::getCPos(positions[q[0]]);
+            const auto& pos1 = DataTypes::getCPos(positions[q[1]]);
+            const auto& pos2 = DataTypes::getCPos(positions[q[2]]);
+            const auto& pos3 = DataTypes::getCPos(positions[q[3]]);
+
+            const auto quadArea = sofa::geometry::Quad::area(pos0, pos1, pos2, pos3);
+            mass = (densityM[quadRemoved[i]] * quadArea) / (typename DataTypes::Real(8.0));
 
             // Removing mass
             for (unsigned int j=0; j<4; ++j)
@@ -497,6 +489,9 @@ void MeshMatrixMass<DataTypes, MassType>::applyEdgeMassQuadDestruction(const sof
 {
     if (this->getMassTopologyType() == TopologyElementType::QUAD)
     {
+        core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
+        const auto& positions = this->getMState()->read(posid)->getValue();
+
         helper::WriteAccessor< Data< type::vector<MassType> > > EdgeMasses ( d_edgeMass );
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
 
@@ -508,19 +503,16 @@ void MeshMatrixMass<DataTypes, MassType>::applyEdgeMassQuadDestruction(const sof
         {
             // Get the EdgesInQuad to be removed
             const core::topology::BaseMeshTopology::EdgesInQuad &qe = this->m_topology->getEdgesInQuad(quadRemoved[i]);
+            const core::topology::BaseMeshTopology::Quad& q = this->m_topology->getQuad(quadRemoved[i]);
 
             // Compute rest mass of conserne quad = density * quad surface.
-            if(this->quadGeo)
-            {
-                if(d_computeMassOnRest.getValue())
-                {
-                    mass=(densityM[quadRemoved[i]] * this->quadGeo->computeRestQuadArea(quadRemoved[i]))/(typename DataTypes::Real(16.0));
-                }
-                else
-                {
-                    mass=(densityM[quadRemoved[i]] * this->quadGeo->computeQuadArea(quadRemoved[i]))/(typename DataTypes::Real(16.0));
-                }
-            }
+            const auto& pos0 = DataTypes::getCPos(positions[q[0]]);
+            const auto& pos1 = DataTypes::getCPos(positions[q[1]]);
+            const auto& pos2 = DataTypes::getCPos(positions[q[2]]);
+            const auto& pos3 = DataTypes::getCPos(positions[q[3]]);
+
+            const auto quadArea = sofa::geometry::Quad::area(pos0, pos1, pos2, pos3);
+            mass = (densityM[quadRemoved[i]] * quadArea) / (typename DataTypes::Real(16.0));
 
             // Removing mass edges of concerne quad
             for (unsigned int j=0; j<4; ++j)
@@ -554,6 +546,9 @@ void MeshMatrixMass<DataTypes, MassType>::applyVertexMassTetrahedronCreation(con
     SOFA_UNUSED(elems);
     if (this->getMassTopologyType() == TopologyElementType::TETRAHEDRON)
     {
+        core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
+        const auto& positions = this->getMState()->read(posid)->getValue();
+
         helper::WriteAccessor< Data< type::vector<MassType> > > VertexMasses ( d_vertexMass );
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
 
@@ -573,16 +568,13 @@ void MeshMatrixMass<DataTypes, MassType>::applyVertexMassTetrahedronCreation(con
             const core::topology::BaseMeshTopology::Tetrahedron &t = this->m_topology->getTetrahedron(tetrahedronAdded[i]);
 
             // Compute rest mass of conserne tetrahedron = density * tetrahedron volume.
-            if(this->tetraGeo)
-            {
-                if(d_computeMassOnRest.getValue())
-                {
-                    mass=(densityM[tetrahedronAdded[i]] * this->tetraGeo->computeRestTetrahedronVolume(tetrahedronAdded[i]))/(typename DataTypes::Real(10.0));
-                }
-                else
-                {
-                    mass=(densityM[tetrahedronAdded[i]] * this->tetraGeo->computeTetrahedronVolume(tetrahedronAdded[i]))/(typename DataTypes::Real(10.0));
-                }
+            const auto& rpos0 = DataTypes::getCPos(positions[t[0]]);
+            const auto& rpos1 = DataTypes::getCPos(positions[t[1]]);
+            const auto& rpos2 = DataTypes::getCPos(positions[t[2]]);
+            const auto& rpos3 = DataTypes::getCPos(positions[t[3]]);
+
+            const auto tetraVolume = sofa::geometry::Tetrahedron::volume(rpos0, rpos1, rpos2, rpos3);
+            mass = (densityM[tetrahedronAdded[i]] * tetraVolume) / (typename DataTypes::Real(10.0));
             }
 
             // Adding mass
@@ -612,6 +604,9 @@ void MeshMatrixMass<DataTypes, MassType>::applyEdgeMassTetrahedronCreation(const
     SOFA_UNUSED(elems);
     if (this->getMassTopologyType() == TopologyElementType::TETRAHEDRON)
     {
+        core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
+        const auto& positions = this->getMState()->read(posid)->getValue();
+
         helper::WriteAccessor< Data< type::vector<MassType> > > EdgeMasses ( d_edgeMass );
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
         
@@ -630,18 +625,14 @@ void MeshMatrixMass<DataTypes, MassType>::applyEdgeMassTetrahedronCreation(const
             // Get the edgesInTetrahedron to be added
             const core::topology::BaseMeshTopology::EdgesInTetrahedron &te = this->m_topology->getEdgesInTetrahedron(tetrahedronAdded[i]);
 
-            // Compute rest mass of conserne triangle = density * tetrahedron volume.
-            if(this->tetraGeo)
-            {
-                if(d_computeMassOnRest.getValue())
-                {
-                    mass=(densityM[tetrahedronAdded[i]] * this->tetraGeo->computeRestTetrahedronVolume(tetrahedronAdded[i]))/(typename DataTypes::Real(20.0));
-                }
-                else
-                {
-                    mass=(densityM[tetrahedronAdded[i]] * this->tetraGeo->computeTetrahedronVolume(tetrahedronAdded[i]))/(typename DataTypes::Real(20.0));
-                }
-            }
+            // Compute rest mass of conserne tetrahedron = density * tetrahedron volume.
+            const auto& rpos0 = DataTypes::getCPos(positions[t[0]]);
+            const auto& rpos1 = DataTypes::getCPos(positions[t[1]]);
+            const auto& rpos2 = DataTypes::getCPos(positions[t[2]]);
+            const auto& rpos3 = DataTypes::getCPos(positions[t[3]]);
+
+            const auto tetraVolume = sofa::geometry::Tetrahedron::volume(rpos0, rpos1, rpos2, rpos3);
+            mass = (densityM[tetrahedronAdded[i]] * tetraVolume) / (typename DataTypes::Real(20.0));
 
             // Adding mass edges of concerne triangle
             for (unsigned int j=0; j<6; ++j)
@@ -662,6 +653,9 @@ void MeshMatrixMass<DataTypes, MassType>::applyVertexMassTetrahedronDestruction(
 {
     if (this->getMassTopologyType() == TopologyElementType::TETRAHEDRON)
     {
+        core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
+        const auto& positions = this->getMState()->read(posid)->getValue();
+
         helper::WriteAccessor< Data< type::vector<MassType> > > VertexMasses ( d_vertexMass );
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
 
@@ -675,17 +669,13 @@ void MeshMatrixMass<DataTypes, MassType>::applyVertexMassTetrahedronDestruction(
             const core::topology::BaseMeshTopology::Tetrahedron &t = this->m_topology->getTetrahedron(tetrahedronRemoved[i]);
 
             // Compute rest mass of conserne tetrahedron = density * tetrahedron volume.
-            if(this->tetraGeo)
-            {
-                if(d_computeMassOnRest.getValue())
-                {
-                    mass=(densityM[tetrahedronRemoved[i]] * this->tetraGeo->computeRestTetrahedronVolume(tetrahedronRemoved[i]))/(typename DataTypes::Real(10.0));
-                }
-                else
-                {
-                    mass=(densityM[tetrahedronRemoved[i]] * this->tetraGeo->computeTetrahedronVolume(tetrahedronRemoved[i]))/(typename DataTypes::Real(10.0));
-                }
-            }
+            const auto& rpos0 = DataTypes::getCPos(positions[t[0]]);
+            const auto& rpos1 = DataTypes::getCPos(positions[t[1]]);
+            const auto& rpos2 = DataTypes::getCPos(positions[t[2]]);
+            const auto& rpos3 = DataTypes::getCPos(positions[t[3]]);
+
+            const auto tetraVolume = sofa::geometry::Tetrahedron::volume(rpos0, rpos1, rpos2, rpos3);
+            mass = (densityM[tetrahedronRemoved[i]] * tetraVolume) / (typename DataTypes::Real(10.0));
 
             // Removing mass
             for (unsigned int j=0; j<4; ++j)
@@ -710,6 +700,9 @@ void MeshMatrixMass<DataTypes, MassType>::applyEdgeMassTetrahedronDestruction(co
 {
     if (this->getMassTopologyType() == TopologyElementType::TETRAHEDRON)
     {
+        core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
+        const auto& positions = this->getMState()->read(posid)->getValue();
+
         helper::WriteAccessor< Data< type::vector<MassType> > > EdgeMasses ( d_edgeMass );
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
 
@@ -721,19 +714,16 @@ void MeshMatrixMass<DataTypes, MassType>::applyEdgeMassTetrahedronDestruction(co
         {
             // Get the edgesInTetrahedron to be removed
             const core::topology::BaseMeshTopology::EdgesInTetrahedron &te = this->m_topology->getEdgesInTetrahedron(tetrahedronRemoved[i]);
+            const core::topology::BaseMeshTopology::Tetrahedron& t = this->m_topology->getTetrahedron(tetrahedronRemoved[i]);
 
-            // Compute rest mass of conserne triangle = density * tetrahedron volume.
-            if(this->tetraGeo)
-            {
-                if(d_computeMassOnRest.getValue())
-                {
-                    mass=(densityM[tetrahedronRemoved[i]] * this->tetraGeo->computeRestTetrahedronVolume(tetrahedronRemoved[i]))/(typename DataTypes::Real(20.0));
-                }
-                else
-                {
-                    mass=(densityM[tetrahedronRemoved[i]] * this->tetraGeo->computeTetrahedronVolume(tetrahedronRemoved[i]))/(typename DataTypes::Real(20.0));
-                }
-            }
+            // Compute rest mass of conserne tetrahedron = density * tetrahedron volume.
+            const auto& rpos0 = DataTypes::getCPos(positions[t[0]]);
+            const auto& rpos1 = DataTypes::getCPos(positions[t[1]]);
+            const auto& rpos2 = DataTypes::getCPos(positions[t[2]]);
+            const auto& rpos3 = DataTypes::getCPos(positions[t[3]]);
+
+            const auto tetraVolume = sofa::geometry::Tetrahedron::volume(rpos0, rpos1, rpos2, rpos3);
+            mass = (densityM[tetrahedronRemoved[i]] * tetraVolume) / (typename DataTypes::Real(20.0));
 
             // Removing mass edges of concerne triangle
             for (unsigned int j=0; j<6; ++j)
@@ -766,6 +756,9 @@ void MeshMatrixMass<DataTypes, MassType>::applyVertexMassHexahedronCreation(cons
     SOFA_UNUSED(elems);
     if (this->getMassTopologyType() == TopologyElementType::HEXAHEDRON)
     {
+        core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
+        const auto& positions = this->getMState()->read(posid)->getValue();
+
         helper::WriteAccessor< Data< type::vector<MassType> > > VertexMasses ( d_vertexMass );
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
         
@@ -784,18 +777,18 @@ void MeshMatrixMass<DataTypes, MassType>::applyVertexMassHexahedronCreation(cons
             // Get the hexahedron to be added
             const core::topology::BaseMeshTopology::Hexahedron &h = this->m_topology->getHexahedron(hexahedronAdded[i]);
 
-            // Compute rest mass of conserne hexahedron = density * hexahedron volume.
-            if(this->hexaGeo)
-            {
-                if(d_computeMassOnRest.getValue())
-                {
-                    mass=(densityM[hexahedronAdded[i]] * this->hexaGeo->computeRestHexahedronVolume(hexahedronAdded[i]))/(typename DataTypes::Real(20.0));
-                }
-                else
-                {
-                    mass=(densityM[hexahedronAdded[i]] * this->hexaGeo->computeHexahedronVolume(hexahedronAdded[i]))/(typename DataTypes::Real(20.0));
-                }
-            }
+            /// compute its mass based on the mass density and the hexahedron volume
+            const auto& rpos0 = DataTypes::getCPos(positions[h[0]]);
+            const auto& rpos1 = DataTypes::getCPos(positions[h[1]]);
+            const auto& rpos2 = DataTypes::getCPos(positions[h[2]]);
+            const auto& rpos3 = DataTypes::getCPos(positions[h[3]]);
+            const auto& rpos4 = DataTypes::getCPos(positions[h[4]]);
+            const auto& rpos5 = DataTypes::getCPos(positions[h[5]]);
+            const auto& rpos6 = DataTypes::getCPos(positions[h[6]]);
+            const auto& rpos7 = DataTypes::getCPos(positions[h[7]]);
+
+            const auto hexaVolume = sofa::geometry::Hexahedron::volume(rpos0, rpos1, rpos2, rpos3, rpos4, rpos5, rpos6, rpos7);
+            mass = (densityM[hexahedronAdded[i]] * hexaVolume) / (typename DataTypes::Real(20.0));
 
             // Adding mass
             for (unsigned int j=0; j<8; ++j)
@@ -824,6 +817,9 @@ void MeshMatrixMass<DataTypes, MassType>::applyEdgeMassHexahedronCreation(const 
     SOFA_UNUSED(elems);
     if (this->getMassTopologyType() == TopologyElementType::HEXAHEDRON)
     {
+        core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
+        const auto& positions = this->getMState()->read(posid)->getValue();
+
         helper::WriteAccessor< Data< type::vector<MassType> > > EdgeMasses ( d_edgeMass );
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
 
@@ -841,19 +837,20 @@ void MeshMatrixMass<DataTypes, MassType>::applyEdgeMassHexahedronCreation(const 
         {
             // Get the EdgesInHexahedron to be added
             const core::topology::BaseMeshTopology::EdgesInHexahedron &he = this->m_topology->getEdgesInHexahedron(hexahedronAdded[i]);
+            const core::topology::BaseMeshTopology::Hexahedron& h = this->m_topology->getHexahedron(hexahedronAdded[i]);
 
-            // Compute rest mass of conserne hexahedron = density * hexahedron volume.
-            if(this->hexaGeo)
-            {
-                if(d_computeMassOnRest.getValue())
-                {
-                    mass=(densityM[hexahedronAdded[i]] * this->hexaGeo->computeRestHexahedronVolume(hexahedronAdded[i]))/(typename DataTypes::Real(40.0));
-                }
-                else
-                {
-                    mass=(densityM[hexahedronAdded[i]] * this->hexaGeo->computeHexahedronVolume(hexahedronAdded[i]))/(typename DataTypes::Real(40.0));
-                }
-            }
+            /// compute its mass based on the mass density and the hexahedron volume
+            const auto& rpos0 = DataTypes::getCPos(positions[h[0]]);
+            const auto& rpos1 = DataTypes::getCPos(positions[h[1]]);
+            const auto& rpos2 = DataTypes::getCPos(positions[h[2]]);
+            const auto& rpos3 = DataTypes::getCPos(positions[h[3]]);
+            const auto& rpos4 = DataTypes::getCPos(positions[h[4]]);
+            const auto& rpos5 = DataTypes::getCPos(positions[h[5]]);
+            const auto& rpos6 = DataTypes::getCPos(positions[h[6]]);
+            const auto& rpos7 = DataTypes::getCPos(positions[h[7]]);
+
+            const auto hexaVolume = sofa::geometry::Hexahedron::volume(rpos0, rpos1, rpos2, rpos3, rpos4, rpos5, rpos6, rpos7);
+            mass = (densityM[hexahedronAdded[i]] * hexaVolume) / (typename DataTypes::Real(40.0));
 
             // Adding mass edges of concerne triangle
             for (unsigned int j=0; j<12; ++j)
@@ -874,6 +871,9 @@ void MeshMatrixMass<DataTypes, MassType>::applyVertexMassHexahedronDestruction(c
 {
     if (this->getMassTopologyType() == TopologyElementType::HEXAHEDRON)
     {
+        core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
+        const auto& positions = this->getMState()->read(posid)->getValue();
+
         helper::WriteAccessor< Data< type::vector<MassType> > > VertexMasses ( d_vertexMass );
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
 
@@ -887,17 +887,17 @@ void MeshMatrixMass<DataTypes, MassType>::applyVertexMassHexahedronDestruction(c
             const core::topology::BaseMeshTopology::Hexahedron &h = this->m_topology->getHexahedron(hexahedronRemoved[i]);
 
             // Compute rest mass of conserne hexahedron = density * hexahedron volume.
-            if(this->hexaGeo)
-            {
-                if(d_computeMassOnRest.getValue())
-                {
-                    mass=(densityM[hexahedronRemoved[i]] * this->hexaGeo->computeRestHexahedronVolume(hexahedronRemoved[i]))/(typename DataTypes::Real(20.0));
-                }
-                else
-                {
-                    mass=(densityM[hexahedronRemoved[i]] * this->hexaGeo->computeHexahedronVolume(hexahedronRemoved[i]))/(typename DataTypes::Real(20.0));
-                }
-            }
+            const auto& rpos0 = DataTypes::getCPos(positions[h[0]]);
+            const auto& rpos1 = DataTypes::getCPos(positions[h[1]]);
+            const auto& rpos2 = DataTypes::getCPos(positions[h[2]]);
+            const auto& rpos3 = DataTypes::getCPos(positions[h[3]]);
+            const auto& rpos4 = DataTypes::getCPos(positions[h[4]]);
+            const auto& rpos5 = DataTypes::getCPos(positions[h[5]]);
+            const auto& rpos6 = DataTypes::getCPos(positions[h[6]]);
+            const auto& rpos7 = DataTypes::getCPos(positions[h[7]]);
+
+            const auto hexaVolume = sofa::geometry::Hexahedron::volume(rpos0, rpos1, rpos2, rpos3, rpos4, rpos5, rpos6, rpos7);
+            mass = (densityM[hexahedronRemoved[i]] * hexaVolume) / (typename DataTypes::Real(40.0));
 
             // Removing mass
             for (unsigned int j=0; j<8; ++j)
@@ -934,18 +934,20 @@ void MeshMatrixMass<DataTypes, MassType>::applyEdgeMassHexahedronDestruction(con
             // Get the EdgesInHexahedron to be removed
             const core::topology::BaseMeshTopology::EdgesInHexahedron &he = this->m_topology->getEdgesInHexahedron(hexahedronRemoved[i]);
 
+            const core::topology::BaseMeshTopology::Hexahedron& h = this->m_topology->getHexahedron(hexahedronRemoved[i]);
+
             // Compute rest mass of conserne hexahedron = density * hexahedron volume.
-            if(this->hexaGeo)
-            {
-                if(d_computeMassOnRest.getValue())
-                {
-                    mass=(densityM[hexahedronRemoved[i]] * this->hexaGeo->computeRestHexahedronVolume(hexahedronRemoved[i]))/(typename DataTypes::Real(40.0));
-                }
-                else
-                {
-                    mass=(densityM[hexahedronRemoved[i]] * this->hexaGeo->computeHexahedronVolume(hexahedronRemoved[i]))/(typename DataTypes::Real(40.0));
-                }
-            }
+            const auto& rpos0 = DataTypes::getCPos(positions[h[0]]);
+            const auto& rpos1 = DataTypes::getCPos(positions[h[1]]);
+            const auto& rpos2 = DataTypes::getCPos(positions[h[2]]);
+            const auto& rpos3 = DataTypes::getCPos(positions[h[3]]);
+            const auto& rpos4 = DataTypes::getCPos(positions[h[4]]);
+            const auto& rpos5 = DataTypes::getCPos(positions[h[5]]);
+            const auto& rpos6 = DataTypes::getCPos(positions[h[6]]);
+            const auto& rpos7 = DataTypes::getCPos(positions[h[7]]);
+
+            const auto hexaVolume = sofa::geometry::Hexahedron::volume(rpos0, rpos1, rpos2, rpos3, rpos4, rpos5, rpos6, rpos7);
+            mass = (densityM[hexahedronRemoved[i]] * hexaVolume) / (typename DataTypes::Real(40.0));
 
             // Removing mass edges of concerne triangle
             for (unsigned int j=0; j<12; ++j)
@@ -1014,77 +1016,31 @@ sofa::core::topology::TopologyElementType MeshMatrixMass<DataTypes, MassType>::c
         sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         return sofa::core::topology::TopologyElementType::POINT;
     }
-
-    this->getContext()->get(edgeGeo);
-    this->getContext()->get(triangleGeo);
-    this->getContext()->get(quadGeo);
-    this->getContext()->get(tetraGeo);
-    this->getContext()->get(hexaGeo);
     
     if (m_topology->getNbHexahedra() > 0)
     {
-        if(!hexaGeo)
-        {
-            msg_error() << "Hexahedron topology but no geometry algorithms found. Add the component HexahedronSetGeometryAlgorithms.";
-            return TopologyElementType::POINT;
-        }
-        else
-        {
-            msg_info() << "Hexahedral topology found.";
-            return TopologyElementType::HEXAHEDRON;
-        }
+        msg_info() << "Hexahedral topology found.";
+        return TopologyElementType::HEXAHEDRON;
     }
     else if (m_topology->getNbTetrahedra() > 0)
     {
-        if(!tetraGeo)
-        {
-            msg_error() << "Tetrahedron topology but no geometry algorithms found. Add the component TetrahedronSetGeometryAlgorithms.";
-            return TopologyElementType::POINT;
-        }
-        else
-        {
-            msg_info() << "Tetrahedral topology found.";
-            return TopologyElementType::TETRAHEDRON;
-        }
+        msg_info() << "Tetrahedral topology found.";
+        return TopologyElementType::TETRAHEDRON;
     }
     else if (m_topology->getNbQuads() > 0)
     {
-        if(!quadGeo)
-        {
-            msg_error() << "Quad topology but no geometry algorithms found. Add the component QuadSetGeometryAlgorithms.";
-            return TopologyElementType::POINT;
-        }
-        else
-        {
-            msg_info() << "Quad topology found.";
-            return TopologyElementType::QUAD;
-        }
+        msg_info() << "Quad topology found.";
+        return TopologyElementType::QUAD;
     }
     else if (m_topology->getNbTriangles() > 0)
     {
-        if(!triangleGeo)
-        {
-            msg_error() << "Triangle topology but no geometry algorithms found. Add the component TriangleSetGeometryAlgorithms.";
-            return TopologyElementType::POINT;
-        }
-        else
-        {
-            msg_info() << "Triangular topology found.";
-            return TopologyElementType::TRIANGLE;
-        }
+        msg_info() << "Triangular topology found.";
+        return TopologyElementType::TRIANGLE;
     }
     else if (m_topology->getNbEdges() > 0)
     {
-        if(!edgeGeo)
-        {
-            msg_error() << "Edge topology but no geometry algorithms found. Add the component EdgeSetGeometryAlgorithms.";
-            return TopologyElementType::POINT;
-        }
-        else
-        {
-            msg_info() << "Edge topology found.";
-            return TopologyElementType::EDGE;
-        }
+        msg_info() << "Edge topology found.";
+        return TopologyElementType::EDGE;
     }
     else
     {
@@ -1403,7 +1359,7 @@ void MeshMatrixMass<DataTypes, MassType>::computeMass()
         applyEdgeMassCreation(i, my_edgeMassInfo[i], edges[i], emptyAncestor, emptyCoefficient);
 
     // Create mass matrix depending on current Topology:
-    if (m_topology->getNbHexahedra()>0 && hexaGeo)  // Hexahedron topology
+    if (m_topology->getNbHexahedra()>0)  // Hexahedron topology
     {
         // create vector tensor by calling the hexahedron creation function on the entire mesh
         sofa::type::vector<Index> hexahedraAdded;
@@ -1420,7 +1376,7 @@ void MeshMatrixMass<DataTypes, MassType>::computeMass()
         
         applyVertexMassHexahedronCreation(hexahedraAdded, m_topology->getHexahedra(), emptyAncestors, emptyCoefficients);
     }
-    else if (m_topology->getNbTetrahedra()>0 && tetraGeo)  // Tetrahedron topology
+    else if (m_topology->getNbTetrahedra()>0)  // Tetrahedron topology
     {
         // create vector tensor by calling the tetrahedron creation function on the entire mesh
         sofa::type::vector<Index> tetrahedraAdded;
@@ -1438,7 +1394,7 @@ void MeshMatrixMass<DataTypes, MassType>::computeMass()
 
         applyVertexMassTetrahedronCreation(tetrahedraAdded, m_topology->getTetrahedra(), emptyAncestors, emptyCoefficients);
     }
-    else if (m_topology->getNbQuads()>0 && quadGeo)  // Quad topology
+    else if (m_topology->getNbQuads()>0)  // Quad topology
     {
         // create vector tensor by calling the quad creation function on the entire mesh
         sofa::type::vector<Index> quadsAdded;
@@ -1456,7 +1412,7 @@ void MeshMatrixMass<DataTypes, MassType>::computeMass()
 
         applyVertexMassQuadCreation(quadsAdded, m_topology->getQuads(), emptyAncestors, emptyCoefficients);
     }
-    else if (m_topology->getNbTriangles()>0 && triangleGeo) // Triangle topology
+    else if (m_topology->getNbTriangles()>0) // Triangle topology
     {
         // create vector tensor by calling the triangle creation function on the entire mesh
         sofa::type::vector<Index> trianglesAdded;
@@ -1684,7 +1640,7 @@ bool MeshMatrixMass<DataTypes, MassType>::checkMassDensity()
     //Check size of the vector
     //Size = 1, homogeneous density
     //Otherwise, heterogeneous density
-    if (m_topology->getNbHexahedra()>0 && hexaGeo)
+    if (m_topology->getNbHexahedra()>0)
     {
         sizeElements = m_topology->getNbHexahedra();
 
@@ -1694,7 +1650,7 @@ bool MeshMatrixMass<DataTypes, MassType>::checkMassDensity()
             return false;
         }
     }
-    else if (m_topology->getNbTetrahedra()>0 && tetraGeo)
+    else if (m_topology->getNbTetrahedra()>0)
     {
         sizeElements = m_topology->getNbTetrahedra();
 
@@ -1704,7 +1660,7 @@ bool MeshMatrixMass<DataTypes, MassType>::checkMassDensity()
             return false;
         }
     }
-    else if (m_topology->getNbQuads()>0 && quadGeo)
+    else if (m_topology->getNbQuads()>0)
     {
         sizeElements = m_topology->getNbQuads();
 
@@ -1714,7 +1670,7 @@ bool MeshMatrixMass<DataTypes, MassType>::checkMassDensity()
             return false;
         }
     }
-    else if (m_topology->getNbTriangles()>0 && triangleGeo)
+    else if (m_topology->getNbTriangles()>0)
     {
         sizeElements = m_topology->getNbTriangles();
 

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -575,7 +575,6 @@ void MeshMatrixMass<DataTypes, MassType>::applyVertexMassTetrahedronCreation(con
 
             const auto tetraVolume = sofa::geometry::Tetrahedron::volume(rpos0, rpos1, rpos2, rpos3);
             mass = (densityM[tetrahedronAdded[i]] * tetraVolume) / (typename DataTypes::Real(10.0));
-            }
 
             // Adding mass
             for (unsigned int j=0; j<4; ++j)
@@ -624,6 +623,7 @@ void MeshMatrixMass<DataTypes, MassType>::applyEdgeMassTetrahedronCreation(const
         {
             // Get the edgesInTetrahedron to be added
             const core::topology::BaseMeshTopology::EdgesInTetrahedron &te = this->m_topology->getEdgesInTetrahedron(tetrahedronAdded[i]);
+            const core::topology::BaseMeshTopology::Tetrahedron& t = this->m_topology->getTetrahedron(tetrahedronAdded[i]);
 
             // Compute rest mass of conserne tetrahedron = density * tetrahedron volume.
             const auto& rpos0 = DataTypes::getCPos(positions[t[0]]);
@@ -922,6 +922,9 @@ void MeshMatrixMass<DataTypes, MassType>::applyEdgeMassHexahedronDestruction(con
 {
     if (this->getMassTopologyType() == TopologyElementType::HEXAHEDRON)
     {
+        core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
+        const auto& positions = this->getMState()->read(posid)->getValue();
+
         helper::WriteAccessor< Data< type::vector<MassType> > > EdgeMasses ( d_edgeMass );
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
 
@@ -933,7 +936,6 @@ void MeshMatrixMass<DataTypes, MassType>::applyEdgeMassHexahedronDestruction(con
         {
             // Get the EdgesInHexahedron to be removed
             const core::topology::BaseMeshTopology::EdgesInHexahedron &he = this->m_topology->getEdgesInHexahedron(hexahedronRemoved[i]);
-
             const core::topology::BaseMeshTopology::Hexahedron& h = this->m_topology->getHexahedron(hexahedronRemoved[i]);
 
             // Compute rest mass of conserne hexahedron = density * hexahedron volume.

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -26,16 +26,9 @@
 #include <sofa/core/MechanicalParams.h>
 #include <sofa/defaulttype/DataTypeInfo.h>
 #include <SofaBaseTopology/TopologyData.inl>
-#include <SofaBaseTopology/RegularGridTopology.h>
 #include <SofaBaseMechanics/AddMToMatrixFunctor.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/type/vector.h>
-#include <SofaBaseTopology/CommonAlgorithms.h>
-#include <SofaBaseTopology/EdgeSetGeometryAlgorithms.h>
-#include <SofaBaseTopology/TriangleSetGeometryAlgorithms.h>
-#include <SofaBaseTopology/TetrahedronSetGeometryAlgorithms.h>
-#include <SofaBaseTopology/QuadSetGeometryAlgorithms.h>
-#include <SofaBaseTopology/HexahedronSetGeometryAlgorithms.h>
 #include <sofa/simulation/AnimateEndEvent.h>
 #include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <numeric>

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -26,9 +26,16 @@
 #include <sofa/core/MechanicalParams.h>
 #include <sofa/defaulttype/DataTypeInfo.h>
 #include <SofaBaseTopology/TopologyData.inl>
+#include <SofaBaseTopology/RegularGridTopology.h>
 #include <SofaBaseMechanics/AddMToMatrixFunctor.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/type/vector.h>
+#include <SofaBaseTopology/CommonAlgorithms.h>
+#include <SofaBaseTopology/EdgeSetGeometryAlgorithms.h>
+#include <SofaBaseTopology/TriangleSetGeometryAlgorithms.h>
+#include <SofaBaseTopology/TetrahedronSetGeometryAlgorithms.h>
+#include <SofaBaseTopology/QuadSetGeometryAlgorithms.h>
+#include <SofaBaseTopology/HexahedronSetGeometryAlgorithms.h>
 #include <sofa/simulation/AnimateEndEvent.h>
 #include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <numeric>


### PR DESCRIPTION
Continuing task #2402

Contains #2434 

As the title says, this PR removes the dependency (useless IMO) to *GeometryAlgorithms,
If a user was not adding a geometryAlgorithms, it was not computing mass, which is weird to me.
In the end, we use the newly introduced functions from #2434 instead
This allow to reveal some inconsistencies:
 - these 2 masses compute volume for 2d and area for 1d.....
 - diffusion (from TetraFEMDiffusion) is really weird and is using a side-effect to compute effectively the diffusion (template on 1d but manages space in 3D thanks to the instanciation of the geometryalgo)

This PR will break (almost intentionally) the Diffusion, thus forcing us to redesign this code to be more "consistent".

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
