### PR TITLE
[Sofa.Type] Optimize constructor with params for sofa::type::vec

### DIFF
--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/Vec.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/Vec.h
@@ -90,8 +90,8 @@ public:
         typename = std::enable_if_t< (sizeof...(ArgsT) == N && sizeof...(ArgsT) > 1) >
     >
     constexpr Vec(const ArgsT... r) noexcept
+        : sofa::type::fixed_array<ValueType, size_t(N)>(r...)
     {
-        this->set(r...);
     }
 
     /// Specific constructor for 6-elements vectors, taking two 3-elements vectors


### PR DESCRIPTION
Playing with [SofaBenchmarks](https://github.com/alxbilger/SofaBenchmark), stumbled on the constructor of sofa::type::vec:

```
BM_FixedArray_construct<stdarray3f>/8192                 14.6 us         13.2 us        74667
BM_FixedArray_construct<sofatypefixedarray3f>/8192       13.0 us         14.2 us       112000
BM_FixedArray_construct<sofa::type::Vec3f>/8192          26.7 us         24.2 us        21333
```
(trying to construct 8192 std::array<float, 3> vs sofa::fixed_array<float,3> vs sofa::type::vec3f)
Unexpectedly, the vec3f is almost twice slower that the other, which is weird as type::vec3f inherits fixed_array<float,3>
By using the constructor of fixed_array (instead of calling set()), we can achieve closer results:

```
BM_FixedArray_construct<stdarray3f>/8192                 14.9 us         12.2 us        64000
BM_FixedArray_construct<sofatypefixedarray3f>/8192       12.7 us         10.6 us        89600
BM_FixedArray_construct<sofa::type::Vec3f>/8192          15.0 us         17.4 us        42165
```

I did my tests on Windows/MSVC2019 so maybe results are different with different compilers/systems though...



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
