### PR TITLE
[SofaCUDA] Fix static variable definition for double-precision

### DIFF
--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
@@ -77,6 +77,12 @@ ContactMapperCreator< ContactMapper<sofa::component::collision::SphereCollisionM
 template<> SOFA_GPU_CUDA_API
 std::unordered_map<std::type_index, typename FixParticlePerformer<CudaVec3fTypes>::GetFixationPointsOnModelFunction >
 FixParticlePerformer<CudaVec3fTypes>::s_mapSupportedModels;
+
+#ifdef SOFA_GPU_CUDA_DOUBLE
+std::unordered_map<std::type_index, typename FixParticlePerformer<CudaVec3dTypes>::GetFixationPointsOnModelFunction >
+FixParticlePerformer<CudaVec3dTypes>::s_mapSupportedModels;
+#endif
+
 #endif // WIN32
 
 helper::Creator<ComponentMouseInteraction::ComponentMouseInteractionFactory, TComponentMouseInteraction<CudaVec3fTypes> > ComponentMouseInteractionCudaVec3fClass ("MouseSpringCudaVec3f",true);


### PR DESCRIPTION
Static variable was not defined with double precision Cuda types. The CI probably does not compile SofaCUDA with double precision (off by default).



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
