### PR TITLE
[Sofa.LinearAlgebra] Fix forgotten typo from #2404

### DIFF
--- a/SofaKernel/modules/Sofa.LinearAlgebra/src/sofa/linearalgebra/matrix_bloc_traits.h
+++ b/SofaKernel/modules/Sofa.LinearAlgebra/src/sofa/linearalgebra/matrix_bloc_traits.h
@@ -113,7 +113,7 @@ public:
                 if (b[i][j] != 0) return false;
         return true;
     }
-    static void invert(Bloc& result, const Bloc& b)
+    static void invert(Block& result, const Block& b)
     {
         const bool canInvert = result.invert(b);
         assert(canInvert);


### PR DESCRIPTION
In #2404 I rename types `Bloc` to `Block`. I forgot one that now triggers compilation warning.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
