### PR TITLE
[examples] Add handleDynamicTopology in OglModel with dynamic texcoords

### DIFF
--- a/examples/Components/engine/TextureInterpolation.scn
+++ b/examples/Components/engine/TextureInterpolation.scn
@@ -25,7 +25,7 @@
         </Node>
         <Node name="visu" gravity="0 0 0">
             <TextureInterpolation template="Vec1d" name="EngineInterpolation" input_states="@../ElecNode/ElecObj.position" input_coordinates="@../mecaObj.position" min_value="0.0" max_value="10.0" manual_scale="1" drawPotentiels="1" />
-            <OglModel template="Vec3d" name="oglPotentiel" texcoords="@EngineInterpolation.output_coordinates" texturename="textures/heatColor.bmp" />
+            <OglModel template="Vec3d" name="oglPotentiel" texcoords="@EngineInterpolation.output_coordinates" texturename="textures/heatColor.bmp" handleDynamicTopology="0" />
         </Node>
     </Node>
 </Node>

--- a/examples/Components/forcefield/TetrahedronDiffusionFEMForceField.scn
+++ b/examples/Components/forcefield/TetrahedronDiffusionFEMForceField.scn
@@ -34,7 +34,7 @@
 
         <Node name="Visu">
             <TextureInterpolation template="Vec1d" name="EngineInterpolation"  input_states="@../gridTemperature.position"  input_coordinates="@../../raptorDOFs.position"  min_value="0.0"  max_value="1.0"  manual_scale="1"  drawPotentiels="0"  showIndicesScale="5e-05" />
-            <OglModel template="Vec3d" name="oglPotentiel" handleDynamicTopology="0" texcoords="@EngineInterpolation.output_coordinates" texturename="textures/heatColor.bmp" scale3d="1 1 1"  material="Default Diffuse 1 1 1 1 0.5 Ambient 1 1 1 1 0.3 Specular 0 0.5 0.5 0.5 1 Emissive 0 0.5 0.5 0.5 1 Shininess 0 45 No texture linked to the material No bump texture linked to the material "/>
+            <OglModel template="Vec3d" name="oglPotentiel" texcoords="@EngineInterpolation.output_coordinates" handleDynamicTopology="0" texturename="textures/heatColor.bmp" scale3d="1 1 1"  material="Default Diffuse 1 1 1 1 0.5 Ambient 1 1 1 1 0.3 Specular 0 0.5 0.5 0.5 1 Emissive 0 0.5 0.5 0.5 1 Shininess 0 45 No texture linked to the material No bump texture linked to the material "/>
             <IdentityMapping input="@../../raptorDOFs" output="@oglPotentiel" />
         </Node>
     </Node>


### PR DESCRIPTION
Further to #2300 and issue was noticed in #2392 : texture coordinates of the OglModel were not updating anymore from parent (InterpolationEngine recomputing the tex coord) since the link was broken.

It has been decided that if dynamic tex coordinates are managed by the parent component the option `handleDynamicTopology="0"` could be used.

The two corresponding scene are changed here






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
