### PR TITLE
[All] Remove some trivial dependencies on SofaBaseTopology

### DIFF
--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.cpp
@@ -21,13 +21,8 @@
 ******************************************************************************/
 #include <SofaBaseVisual/VisualModelImpl.h>
 
-#include <SofaBaseTopology/TriangleSetTopologyModifier.h>
-#include <SofaBaseTopology/QuadSetTopologyModifier.h>
-#include <SofaBaseTopology/TetrahedronSetTopologyModifier.h>
-#include <SofaBaseTopology/HexahedronSetTopologyModifier.h>
 #include <SofaBaseTopology/TopologyData.inl>
 #include <SofaBaseTopology/SparseGridTopology.h>
-#include <SofaBaseTopology/CommonAlgorithms.h>
 
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/behavior/BaseMechanicalState.h>

--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.h
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.h
@@ -30,7 +30,7 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/helper/io/Mesh.h>
-#include <SofaBaseTopology/TopologyData.h>
+#include <SofaBaseTopology/TopologyData.inl>
 #include <string>
 
 namespace sofa::component::visualmodel

--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.h
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/VisualModelImpl.h
@@ -30,7 +30,7 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/helper/io/Mesh.h>
-#include <SofaBaseTopology/TopologyData.inl>
+#include <SofaBaseTopology/TopologyData.h>
 #include <string>
 
 namespace sofa::component::visualmodel

--- a/modules/SofaConstraint/src/SofaConstraint/UncoupledConstraintCorrection.inl
+++ b/modules/SofaConstraint/src/SofaConstraint/UncoupledConstraintCorrection.inl
@@ -26,7 +26,6 @@
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/core/topology/TopologyChange.h>
 #include <sofa/defaulttype/BaseMatrix.h>
-#include <SofaBaseTopology/PointSetTopologyContainer.h>
 #include <SofaBaseTopology/TopologyData.inl>
 
 namespace sofa::component::constraintset

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.inl
@@ -122,8 +122,8 @@ void TriangularBiquadraticSpringsForceField<DataTypes>::applyEdgeCreation(Index 
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
 
     const auto& e = this->m_topology->getEdge(edgeIndex);
-    const auto& n0 = DataTypes::CPos(x[e[0]]);
-    const auto& n1 = DataTypes::CPos(x[e[1]]);
+    const auto& n0 = DataTypes::getCPos(x[e[0]]);
+    const auto& n1 = DataTypes::getCPos(x[e[1]]);
 
     ei.restSquareLength = sofa::geometry::Edge::squaredLength(n0, n1);
     ei.stiffness=0;

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.inl
@@ -23,11 +23,8 @@
 
 #include <SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.h>
 #include <sofa/core/visual/VisualParams.h>
-#include <fstream> // for reading the file
-#include <iostream> //for debugging
 #include <sofa/type/RGBAColor.h>
 #include <SofaBaseTopology/TopologyData.inl>
-#include <SofaBaseTopology/TriangleSetGeometryAlgorithms.h>
 
 namespace sofa::component::forcefield
 {

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularBiquadraticSpringsForceField.inl
@@ -118,15 +118,16 @@ void TriangularBiquadraticSpringsForceField<DataTypes>::applyEdgeCreation(Index 
         const sofa::type::vector<double> &)
 
 {
-    sofa::component::topology::TriangleSetGeometryAlgorithms<DataTypes>* triangleGeo;
-    this->getContext()->get(triangleGeo);
-
     // store the rest length of the edge created
-    ei.restSquareLength=triangleGeo->computeRestSquareEdgeLength(edgeIndex);
+    const VecCoord& x = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
+
+    const auto& e = this->m_topology->getEdge(edgeIndex);
+    const auto& n0 = DataTypes::CPos(x[e[0]]);
+    const auto& n1 = DataTypes::CPos(x[e[1]]);
+
+    ei.restSquareLength = sofa::geometry::Edge::squaredLength(n0, n1);
     ei.stiffness=0;
 }
-
-
 
 template <class DataTypes> TriangularBiquadraticSpringsForceField<DataTypes>::TriangularBiquadraticSpringsForceField()
     : triangleInfo(initData(&triangleInfo, "triangleInfo", "Internal triangle data"))

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.inl
@@ -39,8 +39,8 @@ void TriangularQuadraticSpringsForceField<DataTypes>::applyEdgeCreation(Index ed
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
 
     const auto& e = this->m_topology->getEdge(edgeIndex);
-    const auto& n0 = DataTypes::CPos(x[e[0]]);
-    const auto& n1 = DataTypes::CPos(x[e[1]]);
+    const auto& n0 = DataTypes::getCPos(x[e[0]]);
+    const auto& n1 = DataTypes::getCPos(x[e[1]]);
 
     ei.restLength = sofa::geometry::Edge::length(n0, n1);
     ei.stiffness=0;

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.inl
@@ -35,11 +35,14 @@ namespace sofa::component::forcefield
 template< class DataTypes>
 void TriangularQuadraticSpringsForceField<DataTypes>::applyEdgeCreation(Index edgeIndex, EdgeRestInformation &ei, const core::topology::Edge &, const sofa::type::vector<Index> &, const sofa::type::vector<double> &)
 {
-    sofa::component::topology::TriangleSetGeometryAlgorithms<DataTypes>* triangleGeo=nullptr;
-    this->getContext()->get(triangleGeo);
-
     // store the rest length of the edge created
-    ei.restLength=triangleGeo->computeRestEdgeLength(edgeIndex);
+    const VecCoord& x = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
+
+    const auto& e = this->m_topology->getEdge(edgeIndex);
+    const auto& n0 = DataTypes::CPos(x[e[0]]);
+    const auto& n1 = DataTypes::CPos(x[e[1]]);
+
+    ei.restLength = sofa::geometry::Edge::length(n0, n1);
     ei.stiffness=0;
 }
 

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/TriangularQuadraticSpringsForceField.inl
@@ -23,10 +23,7 @@
 
 #include <SofaGeneralDeformable/TriangularQuadraticSpringsForceField.h>
 #include <sofa/core/visual/VisualParams.h>
-#include <fstream> // for reading the file
-#include <iostream> //for debugging
 #include <sofa/type/RGBAColor.h>
-#include <SofaBaseTopology/TriangleSetGeometryAlgorithms.h>
 #include <SofaBaseTopology/TopologyData.inl>
 
 namespace sofa::component::forcefield

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/VectorSpringForceField.h
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/VectorSpringForceField.h
@@ -31,9 +31,6 @@
 #include <SofaBaseTopology/TopologyData.h>
 #include <sofa/core/objectmodel/DataFileName.h>
 
-#include <SofaBaseTopology/EdgeSetGeometryAlgorithms.h>
-#include <SofaBaseTopology/EdgeSetTopologyModifier.h>
-
 
 namespace sofa::component::interactionforcefield
 {
@@ -112,10 +109,6 @@ public:
     /// Link to be set to the topology container in the component graph.
     SingleLink<VectorSpringForceField<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
     
-    sofa::component::topology::EdgeSetTopologyContainer* edgeCont;
-    sofa::component::topology::EdgeSetGeometryAlgorithms<DataTypes>* edgeGeo;
-    sofa::component::topology::EdgeSetTopologyModifier* edgeMod;
-
     /// Pointer to the current topology
     sofa::core::topology::BaseMeshTopology* m_topology;
 

--- a/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/VectorSpringForceField.inl
+++ b/modules/SofaGeneralDeformable/src/SofaGeneralDeformable/VectorSpringForceField.inl
@@ -173,8 +173,6 @@ void VectorSpringForceField<DataTypes>::init()
             createEdgeInformation(edgeIndex, t, e, ancestors, coefs);
         });
     }
-    this->getContext()->get(edgeGeo);
-    this->getContext()->get(edgeMod);
 
     this->Inherit::init();
 }

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/ClusteringEngine.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/ClusteringEngine.h
@@ -28,9 +28,8 @@
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/core/VecId.h>
 #include <sofa/core/behavior/MechanicalState.h>
+#include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/defaulttype/VecTypes.h>
-#include <SofaBaseTopology/TriangleSetTopologyContainer.h>
-#include <SofaBaseTopology/TriangleSetGeometryAlgorithms.h>
 #include <sofa/type/Vec.h>
 #include <sofa/type/SVector.h>
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/ShapeMatching.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/ShapeMatching.h
@@ -28,9 +28,8 @@
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/core/VecId.h>
 #include <sofa/core/behavior/MechanicalState.h>
+#include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/defaulttype/RigidTypes.h>
-#include <SofaBaseTopology/TriangleSetTopologyContainer.h>
-#include <SofaBaseTopology/TriangleSetGeometryAlgorithms.h>
 #include <sofa/type/Vec.h>
 #include <sofa/type/SVector.h>
 

--- a/modules/SofaGeneralRigid/src/SofaGeneralRigid/SkinningMapping.inl
+++ b/modules/SofaGeneralRigid/src/SofaGeneralRigid/SkinningMapping.inl
@@ -23,7 +23,6 @@
 #include <SofaGeneralRigid/SkinningMapping.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/type/RGBAColor.h>
-#include <SofaBaseTopology/TriangleSetTopologyContainer.h>
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/helper/io/Mesh.h>
 #include <limits>

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/HexahedralFEMForceField.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/HexahedralFEMForceField.h
@@ -28,7 +28,6 @@
 #include <sofa/type/Vec.h>
 #include <sofa/type/Mat.h>
 
-#include <SofaBaseTopology/HexahedronSetTopologyContainer.h>
 #include <SofaBaseTopology/TopologyData.h>
 
 namespace sofa::component::forcefield
@@ -196,7 +195,7 @@ public:
         const sofa::type::vector<Index>&, const sofa::type::vector<double>&);
 
 protected:
-    topology::HexahedronSetTopologyContainer* _topology;
+    core::topology::BaseMeshTopology* _topology;
 
     type::Mat<8,3,int> _coef; ///< coef of each vertices to compute the strain stress matrix
 };

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/HexahedralFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/HexahedralFEMForceField.inl
@@ -92,7 +92,7 @@ void HexahedralFEMForceField<DataTypes>::init()
         return;
     }
 
-    if (_topology->getTopologyType() != sofa::core::topology::TopologyElementType::TETRAHEDRON)
+    if (_topology->getHexahedra().empty())
     {
         msg_error() << "Object must have a Topology with hexahedra.";
         sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/HexahedralFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/HexahedralFEMForceField.inl
@@ -94,7 +94,7 @@ void HexahedralFEMForceField<DataTypes>::init()
 
     if (_topology->getHexahedra().empty())
     {
-        msg_error() << "Object must have a Topology wit hexahedra.";
+        msg_error() << "Object must have a Topology with hexahedra.";
         sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         return;
     }

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/HexahedralFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/HexahedralFEMForceField.inl
@@ -87,7 +87,14 @@ void HexahedralFEMForceField<DataTypes>::init()
 
     if (_topology==nullptr)
     {
-        msg_error() << "Object must have a HexahedronSetTopology.";
+        msg_error() << "Object must have a Topology.";
+        sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+        return;
+    }
+
+    if (_topology->getHexahedra().empty())
+    {
+        msg_error() << "Object must have a Topology wit hexahedra.";
         sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         return;
     }

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/HexahedralFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/HexahedralFEMForceField.inl
@@ -92,7 +92,7 @@ void HexahedralFEMForceField<DataTypes>::init()
         return;
     }
 
-    if (_topology->getHexahedra().empty())
+    if (_topology->getTopologyType() != sofa::core::topology::TopologyElementType::TETRAHEDRON)
     {
         msg_error() << "Object must have a Topology with hexahedra.";
         sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglShaderVisualModel.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglShaderVisualModel.cpp
@@ -24,7 +24,6 @@
 #include <sofa/core/ObjectFactory.h>
 
 #include <sofa/core/topology/TopologyChange.h>
-#include <SofaBaseTopology/PointSetGeometryAlgorithms.h>
 #include <sofa/simulation/Node.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <SofaOpenglVisual/OglAttribute.inl>

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/InciseAlongPathPerformer.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/InciseAlongPathPerformer.cpp
@@ -22,7 +22,6 @@
 #include <SofaUserInteraction/InciseAlongPathPerformer.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <SofaBaseTopology/TriangleSetGeometryAlgorithms.h>
-#include <SofaBaseTopology/TriangleSetTopologyContainer.h>
 
 #include <sofa/helper/Factory.inl>
 
@@ -221,10 +220,10 @@ void InciseAlongPathPerformer::draw(const core::visual::VisualParams* vparams)
     if (!topoGeo)
         return;
 
-    sofa::component::topology::TriangleSetTopologyContainer* topoCon;
+    sofa::core::topology::BaseMeshTopology* topoCon;
     firstBody.body->getContext()->get(topoCon);
 
-    if (!topoCon)
+    if (!topoCon || topoCon->getTriangles().empty())
         return;
 
     // Output declarations

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/InciseAlongPathPerformer.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/InciseAlongPathPerformer.cpp
@@ -223,7 +223,7 @@ void InciseAlongPathPerformer::draw(const core::visual::VisualParams* vparams)
     sofa::core::topology::BaseMeshTopology* topoCon;
     firstBody.body->getContext()->get(topoCon);
 
-    if (!topoCon || topoCon->getTopologyType() != sofa::core::topology::TopologyElementType::TRIANGLE)
+    if (!topoCon || topoCon->getTriangles().empty())
         return;
 
     // Output declarations

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/InciseAlongPathPerformer.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/InciseAlongPathPerformer.cpp
@@ -223,7 +223,7 @@ void InciseAlongPathPerformer::draw(const core::visual::VisualParams* vparams)
     sofa::core::topology::BaseMeshTopology* topoCon;
     firstBody.body->getContext()->get(topoCon);
 
-    if (!topoCon || topoCon->getTriangles().empty())
+    if (!topoCon || topoCon->getTopologyType() != sofa::core::topology::TopologyElementType::TRIANGLE)
         return;
 
     // Output declarations

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/SuturePointPerformer.inl
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/SuturePointPerformer.inl
@@ -86,7 +86,7 @@ void SuturePointPerformer<DataTypes>::start()
             msg_error(this->interactor) << "Can't find a topology.";
             return;
         }
-        else if (triangleContainer->getTriangles().empty())
+        else if (triangleContainer->getTopologyType() != sofa::core::topology::TopologyElementType::TRIANGLE)
         {
             msg_error(this->interactor) << "Can't find a topology with triangles.";
             return;

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/SuturePointPerformer.inl
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/SuturePointPerformer.inl
@@ -86,7 +86,7 @@ void SuturePointPerformer<DataTypes>::start()
             msg_error(this->interactor) << "Can't find a topology.";
             return;
         }
-        else if (triangleContainer->getTopologyType() != sofa::core::topology::TopologyElementType::TRIANGLE)
+        else if (triangleContainer->getTriangles().empty())
         {
             msg_error(this->interactor) << "Can't find a topology with triangles.";
             return;

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/SuturePointPerformer.inl
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/SuturePointPerformer.inl
@@ -22,7 +22,6 @@
 #include <SofaUserInteraction/SuturePointPerformer.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <SofaBaseMechanics/MechanicalObject.h>
-#include <SofaBaseTopology/TriangleSetTopologyContainer.h>
 #include <SofaMeshCollision/TriangleModel.h>
 #include <sofa/defaulttype/VecTypes.h>
 
@@ -69,7 +68,7 @@ void SuturePointPerformer<DataTypes>::start()
 
         CollisionModel->getContext()->get (SpringObject, sofa::core::objectmodel::BaseContext::SearchRoot);
 
-        sofa::component::topology::TriangleSetTopologyContainer* triangleContainer;
+        sofa::core::topology::BaseMeshTopology* triangleContainer;
         CollisionModel->getContext()->get (triangleContainer);
 
         sofa::component::container::MechanicalObject <defaulttype::Vec3Types>* MechanicalObject;
@@ -85,6 +84,11 @@ void SuturePointPerformer<DataTypes>::start()
         else if (!triangleContainer)
         {
             msg_error(this->interactor) << "Can't find triangleContainer.";
+            return;
+        }
+        else if (triangleContainer->getTriangles().empty())
+        {
+            msg_error(this->interactor) << "Can't find a topology with triangles.";
             return;
         }
         else if (!MechanicalObject)

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/SuturePointPerformer.inl
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/SuturePointPerformer.inl
@@ -83,7 +83,7 @@ void SuturePointPerformer<DataTypes>::start()
         }
         else if (!triangleContainer)
         {
-            msg_error(this->interactor) << "Can't find triangleContainer.";
+            msg_error(this->interactor) << "Can't find a topology.";
             return;
         }
         else if (triangleContainer->getTriangles().empty())


### PR DESCRIPTION
Continuing task #2402 

Some components were including SofaBaseTopology components for nothing.
Some other were using Container which could be easily changes for the abstract `BaseMeshTopology` ; this change has the nice side-effect to make components supporting other topologies other than *TopologyContainer.

(needs #2434 for a function in edge)

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
