### PR TITLE
[Sofa.Type] Speed up fixed_array constructors with perfect forwarding

### DIFF
--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/Mat.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/Mat.h
@@ -81,11 +81,9 @@ public:
         typename = std::enable_if_t< (std::is_convertible_v<ArgsT, Line> && ...) >,
         typename = std::enable_if_t< (sizeof...(ArgsT) == L && sizeof...(ArgsT) > 1) >
     >
-    constexpr Mat(const ArgsT... r) noexcept
-    {
-        std::size_t i = 0;
-        ((this->elems[i++] = r), ...);
-    }
+    constexpr Mat(ArgsT&&... r) noexcept
+        : sofa::type::fixed_array<LineNoInit, L>(std::forward<ArgsT>(r)...)
+    {}
 
     /// Constructor from an element
     explicit constexpr Mat(const real& v) noexcept

--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/Vec.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/Vec.h
@@ -89,10 +89,9 @@ public:
         typename = std::enable_if_t< (std::is_convertible_v<ArgsT, ValueType> && ...) >,
         typename = std::enable_if_t< (sizeof...(ArgsT) == N && sizeof...(ArgsT) > 1) >
     >
-    constexpr Vec(const ArgsT... r) noexcept
-        : sofa::type::fixed_array<ValueType, size_t(N)>(r...)
-    {
-    }
+    constexpr Vec(ArgsT&&... r) noexcept
+        : sofa::type::fixed_array<ValueType, size_t(N)>(std::forward<ArgsT>(r)...)
+    {}
 
     /// Specific constructor for 6-elements vectors, taking two 3-elements vectors
     template<typename R, typename T, Size NN = N, typename std::enable_if<NN == 6, int>::type = 0 >
@@ -580,8 +579,8 @@ class VecNoInit : public Vec<N,real>
 public:
     constexpr VecNoInit() noexcept
         : Vec<N,real>(NOINIT)
-    {
-    }
+    {}
+    using Vec<N,real>::Vec;
 
     using Vec<N,real>::operator=; // make every = from Vec available
 

--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/fixed_array.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/fixed_array.h
@@ -69,7 +69,6 @@ public:
 
     typedef T Array[N]; ///< name the array type
 
-public:
     // type definitions
     typedef T              value_type;
     typedef T*             iterator;
@@ -92,12 +91,9 @@ public:
         typename = std::enable_if_t< (std::is_convertible_v<ArgsT, value_type> && ...) >,
         typename = std::enable_if_t< (sizeof...(ArgsT) == N && sizeof...(ArgsT) > 1) >
     >
-    constexpr fixed_array(const ArgsT... r) noexcept
-    {
-        // elems = { r... }; // doable if elems was assignable
-        std::size_t i = 0;
-        ( (elems[i++] = r), ...);
-    }
+    constexpr fixed_array(ArgsT&&... r) noexcept
+        : elems{static_cast<value_type>(std::forward< ArgsT >(r))...}
+    {}
 
     // iterator support
     constexpr iterator begin() noexcept


### PR DESCRIPTION
I think constructors in fixed_array, Vec and Mat passed their arguments by value. Perfect forwarding avoids this copy. Also, constructors of base classes are called instead of re-defining a similar constructor.

# Before

```
------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations
------------------------------------------------------------------------------
BM_Matrix_typemat3x3f_construct/128       1.09 us         1.10 us       640000
BM_Matrix_typemat3x3f_construct/256       2.20 us         2.20 us       320000
BM_Matrix_typemat3x3f_construct/512       4.40 us         4.39 us       160000
BM_Matrix_eigenmat33_construct/128       0.270 us        0.270 us      2488889
BM_Matrix_eigenmat33_construct/256       0.509 us        0.500 us      1000000
BM_Matrix_eigenmat33_construct/512       0.996 us        0.977 us       640000
```

# After

```
-------------------------------------------------------------------------------------
Benchmark                                           Time             CPU   Iterations
-------------------------------------------------------------------------------------
BM_Matrix_typemat3x3f_construct/128             0.324 us        0.328 us      2240000
BM_Matrix_typemat3x3f_construct/256             0.627 us        0.628 us      1120000
BM_Matrix_typemat3x3f_construct/512              1.26 us         1.26 us       560000
BM_Matrix_typemat3x3f_construct_noinit/128      0.323 us        0.321 us      2240000
BM_Matrix_typemat3x3f_construct_noinit/256      0.638 us        0.628 us      1120000
BM_Matrix_typemat3x3f_construct_noinit/512       1.28 us         1.28 us       560000
BM_Matrix_eigenmat33_construct/128              0.255 us        0.256 us      2986667
BM_Matrix_eigenmat33_construct/256              0.502 us        0.500 us      1000000
BM_Matrix_eigenmat33_construct/512              0.993 us         1.00 us       746667
```

Now the construction of a 3x3 matrix is 3x faster and close to the construction of a 3x3 matrix with Eigen.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
