### PR TITLE
[SofaBaseLinearSolver] Fix compilation when enabling CRSMultiMatrixAccessor

### DIFF
--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/CRSMultiMatrixAccessor.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/CRSMultiMatrixAccessor.h
@@ -146,7 +146,7 @@ inline bool opAddMulJTM_TBloc(defaulttype::BaseMatrix* out, defaulttype::BaseMat
         MBloc Mblocbuffer;
 
 
-        for (int JBRowIndex = 0; JBRowIndex < Jmatrix->nBlocRow; JBRowIndex++)
+        for (int JBRowIndex = 0; JBRowIndex < Jmatrix->nBlockRow; JBRowIndex++)
         {
             //through X, must take each row  (but test can be added)
             for (JBColConstIterator JBColIter = Jmatrix->bRowBegin(JBRowIndex); JBColIter < Jmatrix->bRowEnd(JBRowIndex); JBColIter++)
@@ -190,7 +190,7 @@ inline bool opAddMulJTM_TBloc(defaulttype::BaseMatrix* out, defaulttype::BaseMat
         JBloc Jblocbuffer;
         MBloc Mblocbuffer;
 
-        for (int JBRowIndex = 0; JBRowIndex < Jmatrix->nBlocRow; JBRowIndex++)
+        for (int JBRowIndex = 0; JBRowIndex < Jmatrix->nBlockRow; JBRowIndex++)
         {
             //through X, must take each row  (but test can be added)
             for (JBColConstIterator JBColIter = Jmatrix->bRowBegin(JBRowIndex); JBColIter < Jmatrix->bRowEnd(JBRowIndex); JBColIter++)
@@ -349,7 +349,7 @@ inline bool opAddMulMJ_TBloc(defaulttype::BaseMatrix* out, defaulttype::BaseMatr
         JBloc Jblocbuffer;
         MBloc Mblocbuffer;
 
-        for (int MBRowIndex = 0; MBRowIndex < Mmatrix->nBlocRow; MBRowIndex++)
+        for (int MBRowIndex = 0; MBRowIndex < Mmatrix->nBlockRow; MBRowIndex++)
         {
             //through X, must take each row  (but test can be added)
             for (MBColConstIterator MBColIter = Mmatrix->bRowBegin(MBRowIndex); MBColIter < Mmatrix->bRowEnd(MBRowIndex); MBColIter++)
@@ -393,7 +393,7 @@ inline bool opAddMulMJ_TBloc(defaulttype::BaseMatrix* out, defaulttype::BaseMatr
         JBloc Jblocbuffer;
         MBloc Mblocbuffer;
 
-        for (int MBRowIndex = 0; MBRowIndex < Mmatrix->nBlocRow; MBRowIndex++)
+        for (int MBRowIndex = 0; MBRowIndex < Mmatrix->nBlockRow; MBRowIndex++)
         {
             //through X, must take each row  (but test can be added)
             for (MBColConstIterator MBColIter = Mmatrix->bRowBegin(MBRowIndex); MBColIter < Mmatrix->bRowEnd(MBRowIndex); MBColIter++)


### PR DESCRIPTION
Unexpectedly enabled this option in one of my build...
This class did not follow the renaming bloc to block in #2404 (#2329) .

CI result is useless as the CRSMultiMatrixAccessor is not activated on it.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
