### PR TITLE
[SofaGuiQt] Fix graph update on startup

### DIFF
--- a/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
@@ -2147,6 +2147,7 @@ void RealGUI::interactionGUI ( bool )
 //called at each step of the rendering
 void RealGUI::step()
 {
+    simulationGraph->Unfreeze();
     sofa::helper::AdvancedTimer::begin("Animate");
 
     Node* root = currentSimulation();
@@ -2211,6 +2212,8 @@ void RealGUI::step()
 #endif
 
     sofa::helper::AdvancedTimer::end("Animate");
+    
+    simulationGraph->Freeze();
 }
 
 //------------------------------------


### PR DESCRIPTION
(should) Fix issue #2066

The GraphListener for the visual Graph is frozen when runSOFA is started (and never unfrozen)
The temp fix to swap tabs was unfreezing it actually.
But I think letting it unfrozen is also a not-so-good idea as the listener will update a lot (how many? I dont know) the graph for nothing.

Now this PR unfreeze/freeze the visual graph at each timestep of the simulation.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
