### PR TITLE
[SofaTopologyMapping] Fix Tetra2TriangleTopologicalMapping lost ancestor info

### DIFF
--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.cpp
@@ -435,14 +435,14 @@ void Tetra2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
 
         case core::topology::EDGESADDED:
         {
-            const auto* edgeAdded = static_cast<const sofa::component::topology::EdgesAdded*>(*itBegin);
+            const auto* edgeAdded = static_cast<const sofa::core::topology::EdgesAdded*>(*itBegin);
             m_outTopoModifier->addEdges(edgeAdded->edgeArray, edgeAdded->ancestorsList, edgeAdded->coefs);
             break;
         }
 
         case core::topology::POINTSADDED:
         {
-            const auto* pointAdded = static_cast<const sofa::component::topology::PointsAdded*>(*itBegin);
+            const auto* pointAdded = static_cast<const sofa::core::topology::PointsAdded*>(*itBegin);
             m_outTopoModifier->addPoints(sofa::Size(pointAdded->getNbAddedVertices()), pointAdded->ancestorsList, pointAdded->coefs, true);
             break;
         }

--- a/modules/SofaTopologyMapping/src/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.cpp
+++ b/modules/SofaTopologyMapping/src/SofaTopologyMapping/Tetra2TriangleTopologicalMapping.cpp
@@ -435,15 +435,15 @@ void Tetra2TriangleTopologicalMapping::updateTopologicalMappingTopDown()
 
         case core::topology::EDGESADDED:
         {
-            const auto * edgeAdded=static_cast< const EdgesAdded * >( *itBegin );
-            m_outTopoModifier->addEdges(edgeAdded->edgeArray);
+            const auto* edgeAdded = static_cast<const sofa::component::topology::EdgesAdded*>(*itBegin);
+            m_outTopoModifier->addEdges(edgeAdded->edgeArray, edgeAdded->ancestorsList, edgeAdded->coefs);
             break;
         }
 
         case core::topology::POINTSADDED:
         {
-            const auto nbAddedPoints = ( static_cast< const sofa::component::topology::PointsAdded * >( *itBegin ) )->getNbAddedVertices();
-            m_outTopoModifier->addPoints(nbAddedPoints, true);
+            const auto* pointAdded = static_cast<const sofa::component::topology::PointsAdded*>(*itBegin);
+            m_outTopoModifier->addPoints(sofa::Size(pointAdded->getNbAddedVertices()), pointAdded->ancestorsList, pointAdded->coefs, true);
             break;
         }
 


### PR DESCRIPTION
Ancestors and coefficient parameters were lost during EdgeAdded and PointAdded methods coming from Tetrahedron to Triangle mesh.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
