### PR TITLE
[examples] Add another way to link two independent objects

### DIFF
--- a/examples/Components/forcefield/StiffSpringForceField_simple.scn
+++ b/examples/Components/forcefield/StiffSpringForceField_simple.scn
@@ -4,6 +4,7 @@
     <RequiredPlugin name="SofaDeformable"/>
     <RequiredPlugin name="SofaImplicitOdeSolver"/>
     <RequiredPlugin name="SofaSparseSolver"/>
+    <RequiredPlugin name="SofaMiscMapping"/>
 
     <VisualStyle displayFlags="showCollision showInteractionForceFields showForceFields" />
 
@@ -48,4 +49,42 @@
     <StiffSpringForceField template="Vec3d" name="spring3" object1="@sphere2/dofs"   object2="@sphere3-4/dofs" spring="0 0 50 1 1  0 1 50 1 1" showArrowSize="0.05" drawMode="2"/>
     <StiffSpringForceField template="Vec3d" name="spring5" object1="@sphere3-4/dofs" object2="@sphere3-4/dofs" spring="0 1 50 1 1"             showArrowSize="0.05" drawMode="2"/>
     <StiffSpringForceField template="Vec3d" name="spring6" object1="@sphere3-4/dofs" object2="@sphere5-6/dofs" spring="0 0 50 1 1  1 1 50 1 1" showArrowSize="0.05" drawMode="2"/>
+
+    <!-- Example of springs linking two different objects using a mapping -->
+    <Node name="springUsingMapping">
+        <Node name="sphere-a">
+            <MechanicalObject template="Vec3d" name="dofs" position="-3 0 0 -2 0 0 -1 0 0" showObject="true"/>
+            <UniformMass/>
+            <SphereCollisionModel listRadius="0.25 0.25 0.25"/>
+            <FixedConstraint indices="0 1 2"/>
+        </Node>
+
+        <Node name="sphere-b">
+            <MechanicalObject template="Vec3d" name="dofs" position="-3 -0.25 0 -2 -0.25 0 -1 -0.25 0 -2 -0.5 0" showObject="true"/>
+            <UniformMass/>
+            <SphereCollisionModel listRadius="0.25 0.25 0.25 0.25"/>
+            <StiffSpringForceField template="Vec3d" spring="3 0 50 1 1 3 1 50 1 1 3 2 50 1 1" showArrowSize="0.05" drawMode="2"/>
+        </Node>
+
+        <!--
+        Points from both objects are merged into a single object using a mapping.
+        Then, the mapping transfers the forces to the initial two objects.
+        -->
+        <Node name="merge">
+            <MechanicalObject template="Vec3d" name="dofs"/>
+            <SubsetMultiMapping input="@../sphere-a/dofs @../sphere-b/dofs" output="@dofs" indexPairs="0 0  0 1  0 2  1 0  1 1  1 2"/>
+            <StiffSpringForceField template="Vec3d" spring="
+                3 0 50 1 1
+                3 1 50 1 1
+                4 0 50 1 1
+                4 1 50 1 1
+                4 2 50 1 1
+                4 3 50 1 1
+                4 5 50 1 1
+                5 1 50 1 1
+                5 2 50 1 1
+            " showArrowSize="0.05" drawMode="2"/>
+        </Node>
+    </Node>
+
 </Node>


### PR DESCRIPTION
A mapping-based scene design is introduced in `examples/Components/forcefield/StiffSpringForceField_simple.scn`.

The force field is defined on a mechanical state which is the fusion of two independent sets of points.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
