### PR TITLE
[all] Declaration hides previous local declaration

### DIFF
--- a/SofaKernel/modules/Sofa.LinearAlgebra/src/sofa/linearalgebra/RotationMatrix.cpp
+++ b/SofaKernel/modules/Sofa.LinearAlgebra/src/sofa/linearalgebra/RotationMatrix.cpp
@@ -211,8 +211,9 @@ void RotationMatrix<Real>::rotateMatrix(linearalgebra::BaseMatrix * mat,const li
         mat->resize(Jmat->rowSize(),Jmat->colSize());
     }
 
-    if (const SparseMatrix<float> * J = dynamic_cast<const SparseMatrix<float> * >(Jmat)) {
-        for (typename sofa::linearalgebra::SparseMatrix<float>::LineConstIterator jit1 = J->begin(), jend = J->end() ; jit1 != jend; jit1++)
+    if (const auto* Jf = dynamic_cast<const SparseMatrix<float> * >(Jmat))
+    {
+        for (typename sofa::linearalgebra::SparseMatrix<float>::LineConstIterator jit1 = Jf->begin(), jend = Jf->end() ; jit1 != jend; jit1++)
         {
             sofa::SignedIndex l = jit1->first;
             for (typename sofa::linearalgebra::SparseMatrix<float>::LElementConstIterator i1 = jit1->second.begin(), jitend = jit1->second.end(); i1 != jitend;)
@@ -226,8 +227,10 @@ void RotationMatrix<Real>::rotateMatrix(linearalgebra::BaseMatrix * mat,const li
                 mat->set(l,c+2,v0 * data[(c+0)*3+2] + v1 * data[(c+1)*3+2] + v2 * data[(c+2)*3+2] );
             }
         }
-    } else if (const SparseMatrix<double> * J = dynamic_cast<const SparseMatrix<double> * >(Jmat)) {
-        for (typename sofa::linearalgebra::SparseMatrix<double>::LineConstIterator jit1 = J->begin(), jend = J->end() ; jit1 != jend; jit1++)
+    }
+    else if (const auto* Jd = dynamic_cast<const SparseMatrix<double> * >(Jmat))
+    {
+        for (typename sofa::linearalgebra::SparseMatrix<double>::LineConstIterator jit1 = Jd->begin(), jend = Jd->end() ; jit1 != jend; jit1++)
         {
             sofa::SignedIndex l = jit1->first;
             for (typename sofa::linearalgebra::SparseMatrix<double>::LElementConstIterator i1 = jit1->second.begin(), jitend = jit1->second.end(); i1 != jitend;)
@@ -241,7 +244,9 @@ void RotationMatrix<Real>::rotateMatrix(linearalgebra::BaseMatrix * mat,const li
                 mat->set(l,c+2,v0 * data[(c+0)*3+2] + v1 * data[(c+1)*3+2] + v2 * data[(c+2)*3+2] );
             }
         }
-    } else {
+    }
+    else
+    {
         dmsg_warning("RotationMatrix") << "rotateMatrix for this kind of matrix is not implemented" ;
     }
 }

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DefaultAnimationLoop.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/DefaultAnimationLoop.cpp
@@ -126,8 +126,8 @@ void DefaultAnimationLoop::step(const core::ExecParams* params, SReal dt)
 
     {
         AnimateEndEvent ev ( dt );
-        PropagateEventVisitor act ( params, &ev );
-        gnode->execute ( act );
+        PropagateEventVisitor propagateEventVisitor ( params, &ev );
+        gnode->execute ( propagateEventVisitor );
     }
 
     sofa::helper::AdvancedTimer::stepBegin("UpdateMapping");
@@ -135,8 +135,8 @@ void DefaultAnimationLoop::step(const core::ExecParams* params, SReal dt)
     gnode->execute< UpdateMappingVisitor >(params);
     {
         UpdateMappingEndEvent ev ( dt );
-        PropagateEventVisitor act ( params , &ev );
-        gnode->execute ( act );
+        PropagateEventVisitor propagateEventVisitor ( params , &ev );
+        gnode->execute ( propagateEventVisitor );
     }
     sofa::helper::AdvancedTimer::stepEnd("UpdateMapping");
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/ExportDotVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/ExportDotVisitor.cpp
@@ -253,18 +253,18 @@ void ExportDotVisitor::processObject(Node* /*node*/, core::objectmodel::BaseObje
     const char* color=nullptr;
     if (display(obj,&color))
     {
-        std::string name = getName(obj);
+        const std::string name = getName(obj);
         *out << name << " [shape=box,";
         if (color!=nullptr)
             *out << "style=\"filled\",fillcolor=\"" << color << "\",";
         *out << "label=\"";
         if (labelObjectClass)
         {
-            std::string name = helper::gettypename(typeid(*obj));
-            std::string::size_type pos = name.find('<');
+            std::string objTypename = helper::gettypename(typeid(*obj));
+            const std::string::size_type pos = objTypename.find('<');
             if (pos != std::string::npos)
-                name.erase(pos);
-            *out << name;
+                objTypename.erase(pos);
+            *out << objTypename;
             if (labelObjectName)
                 *out << "\\n";
         }
@@ -274,7 +274,7 @@ void ExportDotVisitor::processObject(Node* /*node*/, core::objectmodel::BaseObje
                 *out << obj->getName();
         }
         *out << "\"];" << std::endl;
-        std::string pname = getParentName(obj);
+        const std::string pname = getParentName(obj);
         if (!pname.empty())
         {
             *out << pname << " -> " << name;


### PR DESCRIPTION
Two variables with the same name in the same scope: declaration hides previous local declaration



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
