### PR TITLE
[all] Expression is converted to bool and can be replaced

### DIFF
--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/vector_device.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/vector_device.h
@@ -347,7 +347,7 @@ public:
 
     void invalidateHost()
     {
-        hostIsValid = 0;
+        hostIsValid = false;
         deviceIsValid = ALL_DEVICE_VALID;
     }
 

--- a/modules/SofaGuiCommon/src/sofa/gui/MouseOperations.h
+++ b/modules/SofaGuiCommon/src/sofa/gui/MouseOperations.h
@@ -215,7 +215,7 @@ protected:
 class SOFA_SOFAGUICOMMON_API TopologyOperation : public Operation
 {
 public:
-    TopologyOperation():scale (0.0), volumicMesh (0), firstClick(1) {}
+    TopologyOperation():scale (0.0), volumicMesh (false), firstClick(true) {}
 
     ~TopologyOperation() override {}
     void start() override;

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QMouseOperations.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QMouseOperations.cpp
@@ -161,8 +161,8 @@ void QFixOperation::configure(PickHandler *picker, sofa::component::configuratio
 
 //*******************************************************************************************
 QInciseOperation::QInciseOperation()
-    : finishIncision(0)
-    , keepPoint(0)
+    : finishIncision(false)
+    , keepPoint(false)
 {
     //Building the GUI for the Injection Operation
     QVBoxLayout *layout=new QVBoxLayout(this);
@@ -364,10 +364,7 @@ int QTopologyOperation::getTopologicalOperation() const
 
 bool QTopologyOperation::getVolumicMesh() const
 {
-    if (meshType2->isChecked())
-        return 1;
-    else
-        return 0;
+    return meshType2->isChecked();
 }
 
 void QTopologyOperation::setEnableBox(int i)


### PR DESCRIPTION
0 or 1 is assigned to a `bool`. It is implicitly converted to `bool`, so it can be replaced directly with a `bool` for more clarity.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
