### PR TITLE
[SofaGuiQt] Get rid of magic numbers when centering the window

### DIFF
--- a/applications/projects/runSofa/Main.cpp
+++ b/applications/projects/runSofa/Main.cpp
@@ -436,6 +436,7 @@ int main(int argc, char** argv)
 
     //To set a specific resolution for the viewer, use the component ViewerSetting in you scene graph
     GUIManager::SetDimension(width, height);
+    GUIManager::CenterWindow();
 
     // Create and register the SceneCheckerListener before scene loading
     if(!noSceneCheck)

--- a/modules/SofaGuiCommon/src/sofa/gui/BaseGUI.h
+++ b/modules/SofaGuiCommon/src/sofa/gui/BaseGUI.h
@@ -77,6 +77,7 @@ public:
     virtual void setViewerConfiguration(sofa::component::configurationsetting::ViewerSetting* /*viewerConf*/) {}
     virtual void setViewerResolution(int /* width */, int /* height */) {}
     virtual void setFullScreen() {}
+    virtual void centerWindow() {}
     virtual void setBackgroundColor(const sofa::type::RGBAColor& /*color*/) {}
     virtual void setBackgroundImage(const std::string& /*image*/) {}
 

--- a/modules/SofaGuiCommon/src/sofa/gui/GUIManager.cpp
+++ b/modules/SofaGuiCommon/src/sofa/gui/GUIManager.cpp
@@ -302,6 +302,15 @@ void GUIManager::SetFullScreen()
     if (currentGUI) currentGUI->setFullScreen();
     else{ msg_error("GUIManager") <<"no currentGUI" ; }
 }
+
+void GUIManager::CenterWindow()
+{
+    if (currentGUI)
+    {
+        currentGUI->centerWindow();
+    }
+}
+
 void GUIManager::SaveScreenshot(const char* filename)
 {
     if (currentGUI) {

--- a/modules/SofaGuiCommon/src/sofa/gui/GUIManager.h
+++ b/modules/SofaGuiCommon/src/sofa/gui/GUIManager.h
@@ -79,6 +79,7 @@ public:
     static void SetScene(sofa::simulation::NodeSPtr groot, const char* filename=nullptr, bool temporaryFile=false);
     static void SetDimension(int  width , int  height );
     static void SetFullScreen();
+    static void CenterWindow();
     static void SaveScreenshot(const char* filename);
 
     /// @}

--- a/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
@@ -457,13 +457,7 @@ RealGUI::RealGUI ( const char* viewername)
     m_sofaMouseManager->hide();
     SofaVideoRecorderManager::getInstance()->hide();
 
-    //Center the application
-#if (QT_VERSION < QT_VERSION_CHECK(5, 11, 0))
-    const QRect screen = QApplication::desktop()->availableGeometry(QApplication::desktop()->primaryScreen());
-#else
-    const QRect screen = QGuiApplication::primaryScreen()->availableGeometry();
-#endif
-    this->move(  ( screen.width()- this->width()  ) / 2 - 200,  ( screen.height() - this->height()) / 2 - 50  );
+    centerWindow();
 
     tabs->removeTab(tabs->indexOf(TabVisualGraph));
 
@@ -1328,6 +1322,17 @@ void RealGUI::setFullScreen (bool enable)
     {
         getViewer()->setFullScreen(enable);
     }
+}
+
+void RealGUI::centerWindow()
+{
+    //Center the application
+#if (QT_VERSION < QT_VERSION_CHECK(5, 11, 0))
+    const QRect screen = QApplication::desktop()->availableGeometry(QApplication::desktop()->primaryScreen());
+#else
+    const QRect screen = QGuiApplication::primaryScreen()->availableGeometry();
+#endif
+    this->move(  ( screen.width() - this->width()  ) / 2,  ( screen.height() - this->height()) / 2 );
 }
 
 //------------------------------------

--- a/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.h
@@ -247,6 +247,7 @@ public:
     void setViewerResolution(int w, int h) override;
     void setFullScreen() override { setFullScreen(true); }
     virtual void setFullScreen(bool enable);
+    void centerWindow() override;
     void setBackgroundColor(const sofa::type::RGBAColor& c) override;
     virtual void setBackgroundImage(const std::string& i) override;
     void setViewerConfiguration(sofa::component::configurationsetting::ViewerSetting* viewerConf) override;


### PR DESCRIPTION
Magic numbers (200 and 50) were introduced when centering the window. This is to anticipate the change of viewer resolution that happens later. Instead, I suggest to remove the magic numbers to keep a nice regular formula of centering, and call the center function just after the viewer has been resized.

This is compatible with #2416 without changing another value.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
