### PR TITLE
[SofaBaseMechanics] Simplify expression

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/MechanicalObject.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/MechanicalObject.inl
@@ -2537,13 +2537,10 @@ template <class DataTypes>
 void MechanicalObject<DataTypes>::resetConstraint(const core::ConstraintParams* cParams)
 {
     Data<MatrixDeriv>& c_data = *this->write(cParams->j().getId(this));
-    MatrixDeriv *c = c_data.beginEdit();
-    c->clear();
-    c_data.endEdit();
+    sofa::helper::getWriteOnlyAccessor(c_data)->clear();
+
     Data<MatrixDeriv>& m_data = *this->write(core::MatrixDerivId::mappingJacobian());
-    MatrixDeriv *m = m_data.beginEdit();
-    m->clear();
-    m_data.endEdit();
+    sofa::helper::getWriteOnlyAccessor(m_data)->clear();
 }
 
 template <class DataTypes>


### PR DESCRIPTION
Using `getWriteOnlyAccessor` instead of `beginEdit/endEdit`.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
