### PR TITLE
[SofaConstraint] Divide a timer in 2

### DIFF
--- a/modules/SofaConstraint/src/SofaConstraint/LCPConstraintSolver.cpp
+++ b/modules/SofaConstraint/src/SofaConstraint/LCPConstraintSolver.cpp
@@ -26,12 +26,11 @@
 #include <sofa/simulation/BehaviorUpdatePositionVisitor.h>
 
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 
 #include <sofa/core/ObjectFactory.h>
 
 #include <sofa/simulation/mechanicalvisitor/MechanicalVOpVisitor.h>
-
-#include "sofa/helper/ScopedAdvancedTimer.h"
 using sofa::simulation::mechanicalvisitor::MechanicalVOpVisitor;
 
 #include <sofa/simulation/mechanicalvisitor/MechanicalResetConstraintVisitor.h>

--- a/modules/SofaConstraint/src/SofaConstraint/LCPConstraintSolver.cpp
+++ b/modules/SofaConstraint/src/SofaConstraint/LCPConstraintSolver.cpp
@@ -30,6 +30,8 @@
 #include <sofa/core/ObjectFactory.h>
 
 #include <sofa/simulation/mechanicalvisitor/MechanicalVOpVisitor.h>
+
+#include "sofa/helper/ScopedAdvancedTimer.h"
 using sofa::simulation::mechanicalvisitor::MechanicalVOpVisitor;
 
 #include <sofa/simulation/mechanicalvisitor/MechanicalResetConstraintVisitor.h>
@@ -313,11 +315,18 @@ void LCPConstraintSolver::build_LCP()
     cparams.setX(core::ConstVecCoordId::freePosition());
     cparams.setV(core::ConstVecDerivId::freeVelocity());
 
-    sofa::helper::AdvancedTimer::stepBegin("Accumulate Constraint");
-    // mechanical action executed from root node to propagate the constraints
-    MechanicalResetConstraintVisitor(&cparams).execute(context);
-    MechanicalAccumulateConstraint(&cparams, cparams.j(), _numConstraints).execute(context);
-    sofa::helper::AdvancedTimer::stepEnd  ("Accumulate Constraint");
+    {
+        helper::ScopedAdvancedTimer resetConstraintsTimer("Reset Constraint");
+        MechanicalResetConstraintVisitor resetCtr(&cparams);
+        resetCtr.execute(context);
+    }
+
+    {
+        helper::ScopedAdvancedTimer accumulateConstraintsTimer("Accumulate Constraint");
+        MechanicalAccumulateConstraint accCtr(&cparams, cparams.j(), _numConstraints );
+        accCtr.execute(context);
+    }
+
     _mu = mu.getValue();
     sofa::helper::AdvancedTimer::valSet("numConstraints", _numConstraints);
 
@@ -696,15 +705,18 @@ void LCPConstraintSolver::build_problem_info()
 
     _numConstraints = 0;
 
-    sofa::helper::AdvancedTimer::stepBegin("Accumulate Constraint");
+    {
+        helper::ScopedAdvancedTimer resetConstraintsTimer("Reset Constraint");
+        MechanicalResetConstraintVisitor resetCtr(&cparams);
+        resetCtr.execute(context);
+    }
 
-    // Accumulate Constraints
+    {
+        helper::ScopedAdvancedTimer accumulateConstraintsTimer("Accumulate Constraint");
+        MechanicalAccumulateConstraint accCtr(&cparams, cparams.j(), _numConstraints );
+        accCtr.execute(context);
+    }
 
-    MechanicalResetConstraintVisitor resetCtr(&cparams);
-    resetCtr.execute(context);
-    MechanicalAccumulateConstraint accCtr(&cparams, cparams.j(), _numConstraints );
-    accCtr.execute(context);
-    sofa::helper::AdvancedTimer::stepEnd  ("Accumulate Constraint");
     _mu = mu.getValue();
     sofa::helper::AdvancedTimer::valSet("numConstraints", _numConstraints);
 


### PR DESCRIPTION
The timer `Accumulate Constraint` included two steps: 1) reset the constraint, 2) accumulate the constraints.
Since resetting the constraints is not negligible, I suggest that each of the step has its own timer.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
