### PR TITLE
[examples] add a warning comment in the scene header

### DIFF
--- a/examples/Components/animationloop/FreeMotionAnimationLoop.scn
+++ b/examples/Components/animationloop/FreeMotionAnimationLoop.scn
@@ -1,4 +1,10 @@
 <?xml version="1.0" ?>
+<!--
+WARNING: this scene uses a PrecomputedConstraintCorrection which has a heavy initialization step. It may take some time
+to load the scene. To cache the result, set the recompute Data of PrecomputedConstraintCorrection to false.
+To speed up the collision detection, replace BVHNarrowPhase by ParallelBVHNarrowPhase located in the MultiThreading plugin.
+-->
+
 <Node name="root" dt="0.01" gravity="0 981 0">
     <RequiredPlugin pluginName="SofaOpenglVisual"/>
     <RequiredPlugin pluginName='SofaConstraint'/> 
@@ -9,7 +15,7 @@
     <RequiredPlugin pluginName='SofaSimpleFem'/> 
 
     <VisualStyle displayFlags="showBehaviorModels"/>
-    <FreeMotionAnimationLoop/>
+    <FreeMotionAnimationLoop parallelCollisionDetectionAndFreeMotion="true"/>
     <LCPConstraintSolver tolerance="1e-3" maxIt="1000"/>
     <DefaultPipeline depth="6" verbose="0" draw="0"/>
     <BruteForceBroadPhase/>
@@ -36,7 +42,7 @@
         <UniformMass totalMass="0.2"/>
         <TetrahedronFEMForceField name="FEM" youngModulus="60000" poissonRatio="0.48" computeGlobalMatrix="false" method="polar"/>
         <!--<LinearSolverConstraintCorrection />-->
-        <PrecomputedConstraintCorrection rotations="true" recompute="1"/>
+        <PrecomputedConstraintCorrection rotations="true" recompute="true"/>
         <Node name="Visu">
             <MeshObjLoader name="meshLoader_2" filename="mesh/torus.obj" scale="5.0" handleSeams="1" />
             <OglModel name="Visual" src="@meshLoader_2" color="red" dx="-12" dy="0" dz="0" rx="0" ry="0" rz="0"/>


### PR DESCRIPTION
The scene `examples/Components/animationloop/FreeMotionAnimationLoop.scn` takes a lot of time to initialize. I would like to warn the user that it is normal, that SOFA did not freeze.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
