### PR TITLE
[examples] Speedup the caduceus

### DIFF
--- a/examples/Demos/caduceus.scn
+++ b/examples/Demos/caduceus.scn
@@ -14,7 +14,7 @@
     
     <VisualStyle displayFlags="showVisual  " /> <!--showBehaviorModels showCollisionModels-->
     <LCPConstraintSolver tolerance="1e-3" maxIt="1000" initial_guess="false" build_lcp="false"  printLog="0" mu="0.2"/>
-    <FreeMotionAnimationLoop />
+    <FreeMotionAnimationLoop parallelCollisionDetectionAndFreeMotion="true"/>
     <DefaultPipeline depth="15" verbose="0" draw="0" />
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>


### PR DESCRIPTION
In the caduceus scene, the collision detection and the free motion can be computed in parallel.

Here are the timings for 1000 time steps on my computer:

# Before

```
 LEVEL   START    NUM      MIN     MAX   MEAN     DEV    TOTAL  PERCENT ID
   0       0    1000       1.43    8.29    2.27    0.44 2266.53  100    TOTAL
   1       0       1       1.43    8.27    2.27    0.44    2.27   99.95 .Simulation::animate
   2       0.06    1       1.05    6.97    1.28    0.22    1.28   56.46 ..FreeMotion+CollisionDetection

```
[INFO]    [BatchGUI] 1000 iterations done in 2.57462 s ( 388.407 FPS).


# After

```
 LEVEL   START    NUM      MIN     MAX   MEAN     DEV    TOTAL  PERCENT ID
   0       0    1000       1.21    7.79    1.95    0.39 1948.88  100    TOTAL
   1       0       1       1.21    7.78    1.95    0.39    1.95   99.95 .Simulation::animate
   2       0.06    1       0.80    6.66    0.99    0.21    0.99   50.72 ..FreeMotion+CollisionDetection

```
[INFO]    [BatchGUI] 1000 iterations done in 2.24415 s ( 445.602 FPS).





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
