### PR TITLE
[all] Variable can be made constexpr

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/RandomGenerator.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/RandomGenerator.cpp
@@ -43,8 +43,6 @@ namespace sofa
 namespace helper
 {
 
-constexpr unsigned long RandomGenerator::RANDOM_BASE_MAX = 4294967295U;
-
 RandomGenerator::RandomGenerator()
 {
     __rand48_seed[0] = RAND48_SEED_0;

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/RandomGenerator.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/RandomGenerator.cpp
@@ -43,7 +43,7 @@ namespace sofa
 namespace helper
 {
 
-const unsigned long RandomGenerator::RANDOM_BASE_MAX = 4294967295U;
+constexpr unsigned long RandomGenerator::RANDOM_BASE_MAX = 4294967295U;
 
 RandomGenerator::RandomGenerator()
 {

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/RandomGenerator.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/RandomGenerator.h
@@ -92,7 +92,7 @@ public:
     }
 
 private:
-	static const unsigned long RANDOM_BASE_MAX;
+	static constexpr unsigned long RANDOM_BASE_MAX = 4294967295U;
 
 };
 

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/rmath.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/rmath.h
@@ -72,7 +72,7 @@ inline int rnear(double r)
 template<class real>
 inline int rfloor(real r)
 {
-    static const double FLOATTOINTCONST=(1.5*(1LL<<(52-16)));
+    static constexpr double FLOATTOINTCONST=(1.5*(1LL<<(52-16)));
     union
     {
         double d;
@@ -85,7 +85,7 @@ inline int rfloor(real r)
 template<class real>
 inline int rnear(real r)
 {
-    static const double FLOATTOINTCONST_0_5=(1.5*(1LL<<(52-16)))+0.5;
+    static constexpr double FLOATTOINTCONST_0_5=(1.5*(1LL<<(52-16)))+0.5;
     union
     {
         double d;

--- a/modules/SofaGuiCommon/src/sofa/gui/BatchGUI.cpp
+++ b/modules/SofaGuiCommon/src/sofa/gui/BatchGUI.cpp
@@ -40,7 +40,7 @@ namespace sofa::gui
 
 using sofa::helper::AdvancedTimer;
 
-const signed int BatchGUI::DEFAULT_NUMBER_OF_ITERATIONS = 1000;
+constexpr signed int BatchGUI::DEFAULT_NUMBER_OF_ITERATIONS = 1000;
 signed int BatchGUI::nbIter = BatchGUI::DEFAULT_NUMBER_OF_ITERATIONS;
 std::string BatchGUI::nbIterInp="";
 BatchGUI::BatchGUI()

--- a/modules/SofaGuiCommon/src/sofa/gui/ColourPickingVisitor.cpp
+++ b/modules/SofaGuiCommon/src/sofa/gui/ColourPickingVisitor.cpp
@@ -43,7 +43,7 @@ using namespace sofa::core::collision;
 
 namespace
 {
-const float threshold = std::numeric_limits<float>::min();
+constexpr float threshold = std::numeric_limits<float>::min();
 }
 
 void decodeCollisionElement(const sofa::type::Vec4f colour,  sofa::component::collision::BodyPicked& body)


### PR DESCRIPTION
My IDE found that some variables could be made `constexpr`.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
