### PR TITLE
[SofaGeneralLoader] Make GridMeshCreator work again

### DIFF
--- a/examples/Components/constraint/ProjectDirectionConstraint.scn
+++ b/examples/Components/constraint/ProjectDirectionConstraint.scn
@@ -6,9 +6,12 @@
     <RequiredPlugin pluginName='SofaMiscFem'/>
     <RequiredPlugin pluginName='SofaTopologyMapping'/> 
     <VisualStyle displayFlags="hideVisualModels showBehavior" />
+    <DefaultAnimationLoop />
+    <DefaultVisualManagerLoop />
+    
     <Node 	name="Square"  >
         <EulerImplicitSolver name="Euler Implicit"  printLog="0"  rayleighStiffness="0.5"  rayleighMass="0.5"  vdamping="0"  />
-        <CGLinearSolver template="GraphScattered" name="CG Solver"  printLog="0"  iterations="40"  tolerance="1e-06"  threshold="1e-10"  verbose="0" />
+        <CGLinearSolver template="GraphScattered" name="CG Solver"  printLog="0"  iterations="40"  tolerance="1e-06"  threshold="1e-10" />
         <GridMeshCreator name="loader" resolution="5 5" trianglePattern="1" rotation="0 0 0 " scale="1 1 0" />
         <MechanicalObject template="Vec3d" name="mObject1" position="@loader.position"    showIndices="false" showIndicesScale="0.001" />
         <TriangleSetTopologyContainer name="Container"  position="@loader.position"  edges="@loader.edges"  triangles="@loader.triangles" />

--- a/examples/Components/constraint/ProjectToLineConstraint.scn
+++ b/examples/Components/constraint/ProjectToLineConstraint.scn
@@ -6,9 +6,12 @@
     <RequiredPlugin pluginName='SofaTopologyMapping'/> 
     <RequiredPlugin pluginName='SofaBoundaryCondition'/> 
     <VisualStyle displayFlags="hideVisualModels showBehavior" />
+    <DefaultAnimationLoop />
+    <DefaultVisualManagerLoop />
+
     <Node 	name="Square"  >
         <EulerImplicitSolver name="Euler Implicit"  printLog="0"  rayleighStiffness="0.5"  rayleighMass="0.5"  vdamping="0"  />
-        <CGLinearSolver template="GraphScattered" name="CG Solver"  printLog="0"  iterations="40"  tolerance="1e-06"  threshold="1e-10"  verbose="0" />
+        <CGLinearSolver template="GraphScattered" name="CG Solver"  printLog="0"  iterations="40"  tolerance="1e-06"  threshold="1e-10" />
         <GridMeshCreator name="loader" resolution="5 5" trianglePattern="1" rotation="0 0 0 " scale="1 1 0" />
         <MechanicalObject template="Vec3d" name="mObject1" position="@loader.position"    showIndices="false" showIndicesScale="0.001" />
         <TriangleSetTopologyContainer name="Container"  position="@loader.position"  edges="@loader.edges"  triangles="@loader.triangles" />

--- a/examples/Components/constraint/ProjectToPointConstraint.scn
+++ b/examples/Components/constraint/ProjectToPointConstraint.scn
@@ -6,10 +6,12 @@
     <RequiredPlugin pluginName='SofaMiscFem'/> <!-- Needed to use components [TriangularFEMForceField, ]-->  
     <RequiredPlugin pluginName='SofaTopologyMapping'/>
     <VisualStyle displayFlags="hideVisualModels showBehavior" />
+    <DefaultAnimationLoop />
+    <DefaultVisualManagerLoop />
 
     <Node 	name="Square"  >
         <EulerImplicitSolver name="Euler Implicit"  printLog="0"  rayleighStiffness="0.5"  rayleighMass="0.5"  vdamping="0" />
-        <CGLinearSolver template="GraphScattered" name="CG Solver"  printLog="0"  iterations="40"  tolerance="1e-06"  threshold="1e-10"  verbose="0" />
+        <CGLinearSolver template="GraphScattered" name="CG Solver"  printLog="0"  iterations="40"  tolerance="1e-06"  threshold="1e-10" />
         <GridMeshCreator name="loader" resolution="5 5" trianglePattern="1" rotation="0 0 0 " scale="1 1 0" />
         <MechanicalObject template="Vec3d" name="mObject1" position="@loader.position"    showIndices="false" showIndicesScale="0.001" />
         <TriangleSetTopologyContainer name="Container"  position="@loader.position"  edges="@loader.edges"  triangles="@loader.triangles" />


### PR DESCRIPTION
3 scenes were displaying an error following the PR #2465 .

After some investigations, it appeared that those 3 scenes were not working for a while (and the PR merely showed that statement), and the culprit was that GridMeshCreator was not calling its doLoad() method.
doLoad() in MeshLoader components is triggered when d_filename is set.
But GridMeshCreator  is procedural and does not any filename at all. Therefore doLoad() was never called.
This PR forcefully set the data d_filename to dirty to force-trigger the callback.

Moreover, insertTriangle and insertQuad were using beginEdit()/endEdit() which were triggering also a doLoad() (resulting in a lot of useless edges/triangles)
This PR uses WriteOnlyAccessor to avoid this problem.

Now ProjectToLineConstraint.scn renders like this:
 ![ProjectToLineConstraint_00000001](https://user-images.githubusercontent.com/11028016/140957340-12e18507-532b-4076-bd71-6cab73fab547.png)

instead of nothing...



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
