### PR TITLE
[SofaBaseMechanics][SofaMiscForceField][SofaSimpleFem] Add an optional template for geometrical informations for two Masses

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.cpp
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.cpp
@@ -36,9 +36,9 @@ using sofa::core::objectmodel::ComponentState ;
 using namespace sofa::type;
 using namespace sofa::defaulttype;
 
-template <class RigidTypes, class RigidMass>
+template <class RigidTypes, class RigidMass, class GeometricalTypes>
 template <class T>
-SReal DiagonalMass<RigidTypes, RigidMass>::getPotentialEnergyRigidImpl( const MechanicalParams* mparams,
+SReal DiagonalMass<RigidTypes, RigidMass, GeometricalTypes>::getPotentialEnergyRigidImpl( const MechanicalParams* mparams,
                                                                         const DataVecCoord& x) const
 {
     SOFA_UNUSED(mparams) ;
@@ -58,9 +58,9 @@ SReal DiagonalMass<RigidTypes, RigidMass>::getPotentialEnergyRigidImpl( const Me
 }
 
 
-template <class RigidTypes, class RigidMass>
+template <class RigidTypes, class RigidMass, class GeometricalTypes>
 template <class T>
-void DiagonalMass<RigidTypes, RigidMass>::drawRigid3dImpl(const VisualParams* vparams)
+void DiagonalMass<RigidTypes, RigidMass, GeometricalTypes>::drawRigid3dImpl(const VisualParams* vparams)
 {
     const MassVector &masses= d_vertexMass.getValue();
     if (!vparams->displayFlags().getShowBehaviorModels()) return;
@@ -106,9 +106,9 @@ void DiagonalMass<RigidTypes, RigidMass>::drawRigid3dImpl(const VisualParams* vp
 }
 
 
-template <class RigidTypes, class RigidMass>
+template <class RigidTypes, class RigidMass, class GeometricalTypes>
 template <class T>
-void DiagonalMass<RigidTypes, RigidMass>::drawRigid2dImpl(const VisualParams* vparams)
+void DiagonalMass<RigidTypes, RigidMass, GeometricalTypes>::drawRigid2dImpl(const VisualParams* vparams)
 {
     const MassVector &masses= d_vertexMass.getValue();
     if (!vparams->displayFlags().getShowBehaviorModels()) return;
@@ -126,9 +126,9 @@ void DiagonalMass<RigidTypes, RigidMass>::drawRigid2dImpl(const VisualParams* vp
     }
 }
 
-template <class RigidTypes, class RigidMass>
+template <class RigidTypes, class RigidMass, class GeometricalTypes >
 template <class T>
-void DiagonalMass<RigidTypes, RigidMass>::initRigidImpl()
+void DiagonalMass<RigidTypes, RigidMass, GeometricalTypes>::initRigidImpl()
 {
     if(this->getContext()==nullptr){
         dmsg_error(this) << "Calling the initRigidImpl function is only possible if the object has a valid associated context \n" ;
@@ -185,9 +185,9 @@ void DiagonalMass<RigidTypes, RigidMass>::initRigidImpl()
     this->d_componentState.setValue(ComponentState::Valid) ;
 }
 
-template <class RigidTypes, class RigidMass>
+template <class RigidTypes, class RigidMass, class GeometricalTypes>
 template <class T>
-type::Vector6 DiagonalMass<RigidTypes,RigidMass>::getMomentumRigid3Impl ( const MechanicalParams*,
+type::Vector6 DiagonalMass<RigidTypes,RigidMass, GeometricalTypes>::getMomentumRigid3Impl ( const MechanicalParams*,
                                                                     const DataVecCoord& vx,
                                                                     const DataVecDeriv& vv ) const
 {
@@ -210,9 +210,9 @@ type::Vector6 DiagonalMass<RigidTypes,RigidMass>::getMomentumRigid3Impl ( const 
     return momentum;
 }
 
-template <class Vec3Types, class Vec3Mass>
+template <class Vec3Types, class Vec3Mass, class GeometricalTypes>
 template <class T>
-type::Vector6 DiagonalMass<Vec3Types, Vec3Mass>::getMomentumVec3Impl( const MechanicalParams*,
+type::Vector6 DiagonalMass<Vec3Types, Vec3Mass, GeometricalTypes>::getMomentumVec3Impl( const MechanicalParams*,
                                                                 const DataVecCoord& vx,
                                                                 const DataVecDeriv& vv ) const
 {
@@ -305,18 +305,25 @@ type::Vector6 DiagonalMass<Rigid3Types,Rigid3Mass>::getMomentum ( const Mechanic
 
 // Register in the Factory
 int DiagonalMassClass = core::RegisterObject("Define a specific mass for each particle")
-        .add< DiagonalMass<Vec3Types,double> >()
-        .add< DiagonalMass<Vec2Types,double> >()
-        .add< DiagonalMass<Vec1Types,double> >()
-        .add< DiagonalMass<Rigid3Types,Rigid3Mass> >()
-        .add< DiagonalMass<Rigid2Types,Rigid2Mass> >()
-
+        .add< DiagonalMass<Vec3Types, double> >()
+        .add< DiagonalMass<Vec2Types, double> >()
+        .add< DiagonalMass<Vec2Types, double, Vec3Types> >()
+        .add< DiagonalMass<Vec1Types, double> >()
+        .add< DiagonalMass<Vec1Types, double, Vec3Types> >()
+        .add< DiagonalMass<Vec1Types, double, Vec2Types> >()
+        .add< DiagonalMass<Rigid3Types, Rigid3Mass> >()
+        .add< DiagonalMass<Rigid2Types, Rigid2Mass> >()
+        .add< DiagonalMass<Rigid2Types, Rigid2Mass, Vec3Types> >()
         ;
 
-template class SOFA_SOFABASEMECHANICS_API DiagonalMass<Vec3Types,double>;
-template class SOFA_SOFABASEMECHANICS_API DiagonalMass<Vec2Types,double>;
-template class SOFA_SOFABASEMECHANICS_API DiagonalMass<Vec1Types,double>;
+template class SOFA_SOFABASEMECHANICS_API DiagonalMass<Vec3Types, double>;
+template class SOFA_SOFABASEMECHANICS_API DiagonalMass<Vec2Types, double>;
+template class SOFA_SOFABASEMECHANICS_API DiagonalMass<Vec2Types, double, Vec3Types>;
+template class SOFA_SOFABASEMECHANICS_API DiagonalMass<Vec1Types, double>;
+template class SOFA_SOFABASEMECHANICS_API DiagonalMass<Vec1Types, double, Vec3Types>;
+template class SOFA_SOFABASEMECHANICS_API DiagonalMass<Vec1Types, double, Vec2Types>;
 template class SOFA_SOFABASEMECHANICS_API DiagonalMass<Rigid3Types,Rigid3Mass>;
 template class SOFA_SOFABASEMECHANICS_API DiagonalMass<Rigid2Types,Rigid2Mass>;
+template class SOFA_SOFABASEMECHANICS_API DiagonalMass<Rigid2Types, Rigid2Mass, Vec3Types>;
 
 } // namespace sofa::component::mass

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
@@ -48,6 +48,15 @@ public :
     typedef sofa::type::Vec<3,Real> Vec3;
 };
 
+/**
+* @class    DiagonalMass
+* @brief    This component computes the integral of this mass density over the volume of the object geometry but it supposes that the Mass matrix is diagonal.
+* @remark   Similar to MeshMatrixMass but it does not simplify the Mass Matrix as diagonal.
+* @remark   https://www.sofa-framework.org/community/doc/components/masses/diagonalmass/
+* @tparam   DataTypes type of the state associated to this mass
+* @tparam   TMassType type of the mass value
+* @tparam   GeometricalTypes type of the geometry, i.e type of the state associated with the topology (if the topology and the mass relates to the same state, this will be the same as DataTypes)
+*/
 template <class DataTypes, class TMassType, class GeometricalTypes = DataTypes>
 class DiagonalMass : public core::behavior::Mass<DataTypes>
 {

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
@@ -36,7 +36,7 @@
 namespace sofa::component::mass
 {
 
-template<class DataTypes, class TMassType>
+template<class DataTypes, class TMassType, class GeometricalTypes>
 class DiagonalMassInternalData
 {
 public :
@@ -46,14 +46,13 @@ public :
 
     // In case of non 3D template
     typedef sofa::type::Vec<3,Real> Vec3;
-    typedef sofa::defaulttype::StdVectorTypes< Vec3, Vec3, Real > GeometricalTypes ; /// assumes the geometry object type is 3D
 };
 
-template <class DataTypes, class TMassType>
+template <class DataTypes, class TMassType, class GeometricalTypes = DataTypes>
 class DiagonalMass : public core::behavior::Mass<DataTypes>
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE2(DiagonalMass,DataTypes,TMassType), SOFA_TEMPLATE(core::behavior::Mass,DataTypes));
+    SOFA_CLASS(SOFA_TEMPLATE3(DiagonalMass,DataTypes,TMassType,GeometricalTypes), SOFA_TEMPLATE(core::behavior::Mass,DataTypes));
 
     typedef core::behavior::Mass<DataTypes> Inherited;
     typedef typename DataTypes::VecCoord VecCoord;
@@ -65,9 +64,8 @@ public:
     typedef core::objectmodel::Data<VecDeriv> DataVecDeriv;
     typedef TMassType MassType;
 
-    typedef typename DiagonalMassInternalData<DataTypes,TMassType>::VecMass VecMass;
-    typedef typename DiagonalMassInternalData<DataTypes,TMassType>::MassVector MassVector;
-    typedef typename DiagonalMassInternalData<DataTypes,TMassType>::GeometricalTypes GeometricalTypes;
+    typedef typename DiagonalMassInternalData<DataTypes,TMassType, GeometricalTypes>::VecMass VecMass;
+    typedef typename DiagonalMassInternalData<DataTypes,TMassType, GeometricalTypes>::MassVector MassVector;
 
     VecMass d_vertexMass; ///< values of the particles masses
 
@@ -102,8 +100,8 @@ public:
     /// value defining the initialization process of the mass (0 : totalMass, 1 : massDensity, 2 : vertexMass)
     int m_initializationProcess;
 
-    /// Link to be set to the topology container in the component graph.
-    SingleLink<DiagonalMass<DataTypes, TMassType>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
+    /// Link to be set to the topology container in the component graph. 
+    SingleLink<DiagonalMass<DataTypes, TMassType, GeometricalTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
 protected:
     ////////////////////////// Inherited attributes ////////////////////////////
@@ -122,6 +120,9 @@ protected:
 
     /// Pointer to the topology container. Will be set by link @sa l_topology
     sofa::core::topology::BaseMeshTopology* m_topology;
+
+    /// Pointer to the state owning geometrical positions, associated with the topology
+    typename sofa::core::behavior::MechanicalState<GeometricalTypes>::SPtr m_geometryState;
 private:
     sofa::geometry::ElementType m_manageElementTypeChange{ sofa::geometry::ElementType::POINT };
 
@@ -370,11 +371,15 @@ type::Vector6 DiagonalMass<defaulttype::Rigid3Types,defaulttype::Rigid3Mass>::ge
 
 
 #if  !defined(SOFA_COMPONENT_MASS_DIAGONALMASS_CPP)
-extern template class SOFA_SOFABASEMECHANICS_API DiagonalMass<defaulttype::Vec3Types,double>;
-extern template class SOFA_SOFABASEMECHANICS_API DiagonalMass<defaulttype::Vec2Types,double>;
-extern template class SOFA_SOFABASEMECHANICS_API DiagonalMass<defaulttype::Vec1Types,double>;
-extern template class SOFA_SOFABASEMECHANICS_API DiagonalMass<defaulttype::Rigid3Types,defaulttype::Rigid3Mass>;
-extern template class SOFA_SOFABASEMECHANICS_API DiagonalMass<defaulttype::Rigid2Types,defaulttype::Rigid2Mass>;
+extern template class SOFA_SOFABASEMECHANICS_API DiagonalMass<defaulttype::Vec3Types, double>;
+extern template class SOFA_SOFABASEMECHANICS_API DiagonalMass<defaulttype::Vec2Types, double>;
+extern template class SOFA_SOFABASEMECHANICS_API DiagonalMass<defaulttype::Vec2Types, double, defaulttype::Vec3Types>;
+extern template class SOFA_SOFABASEMECHANICS_API DiagonalMass<defaulttype::Vec1Types, double>;
+extern template class SOFA_SOFABASEMECHANICS_API DiagonalMass<defaulttype::Vec1Types, double, defaulttype::Vec3Types>;
+extern template class SOFA_SOFABASEMECHANICS_API DiagonalMass<defaulttype::Vec1Types, double, defaulttype::Vec2Types>;
+extern template class SOFA_SOFABASEMECHANICS_API DiagonalMass<defaulttype::Rigid3Types, defaulttype::Rigid3Mass>;
+extern template class SOFA_SOFABASEMECHANICS_API DiagonalMass<defaulttype::Rigid2Types, defaulttype::Rigid2Mass>;
+extern template class SOFA_SOFABASEMECHANICS_API DiagonalMass<defaulttype::Rigid2Types, defaulttype::Rigid2Mass, defaulttype::Vec2Types>;
 
 #endif
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.h
@@ -102,7 +102,7 @@ public:
     /// value defining the initialization process of the mass (0 : totalMass, 1 : massDensity, 2 : vertexMass)
     int m_initializationProcess;
 
-    /// Link to be set to the topology container in the component graph. 
+    /// Link to be set to the topology container in the component graph.
     SingleLink<DiagonalMass<DataTypes, TMassType>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
 protected:
@@ -173,7 +173,7 @@ protected:
 
 
     /** Method to update @sa d_vertexMass when a new Edge is created.
-    * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when EDGESADDED event is fired.    
+    * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when EDGESADDED event is fired.
     */
     void applyEdgeCreation(const sofa::type::vector< EdgeID >& /*indices*/,
         const sofa::type::vector< Edge >& /*elems*/,
@@ -212,7 +212,7 @@ protected:
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when QUADSREMOVED event is fired.
     */
     void applyQuadDestruction(const sofa::type::vector<QuadID>& /*indices*/);
-    
+
 
     /** Method to update @sa d_vertexMass when a new Tetrahedron is created.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when TETRAHEDRAADDED event is fired.
@@ -235,7 +235,7 @@ protected:
         const sofa::type::vector< Hexahedron >& /*elems*/,
         const sofa::type::vector< sofa::type::vector< HexahedronID > >& /*ancestors*/,
         const sofa::type::vector< sofa::type::vector< double > >& /*coefs*/);
-    
+
     /** Method to update @sa d_vertexMass when a Hexahedron is removed.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when HEXAHEDRAREMOVED event is fired.
     */

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
@@ -812,12 +812,11 @@ bool DiagonalMass<DataTypes, MassType, GeometricalTypes>::checkTopology()
 template <class DataTypes, class MassType, class GeometricalTypes>
 void DiagonalMass<DataTypes, MassType, GeometricalTypes>::init()
 {
-    this->d_componentState.setValue(ComponentState::Valid);
+    this->d_componentState.setValue(ComponentState::Invalid);
 
     if (!d_fileMass.getValue().empty())
     {
         if(!load(d_fileMass.getFullPath().c_str())){
-            this->d_componentState.setValue(ComponentState::Invalid);
             return;
         }
         msg_warning() << "File given as input for DiagonalMass, in this a case:" << msgendl
@@ -827,12 +826,12 @@ void DiagonalMass<DataTypes, MassType, GeometricalTypes>::init()
     }
     else
     {
+        Inherited::init();
+
         if(!checkTopology())
         {
-            this->d_componentState.setValue(ComponentState::Invalid);
             return;
         }
-        Inherited::init();
         initTopologyHandlers();
 
         // TODO(dmarchal 2018-11-10): this code is duplicated with the one in RigidImpl we should factor it (remove in 1 year if not done or update the dates)
@@ -852,6 +851,7 @@ void DiagonalMass<DataTypes, MassType, GeometricalTypes>::init()
         this->trackInternalData(d_massDensity);
         this->trackInternalData(d_totalMass);
     }
+
     this->d_componentState.setValue(ComponentState::Valid);
 }
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
@@ -593,7 +593,7 @@ SReal DiagonalMass<DataTypes, MassType, GeometricalTypes>::getPotentialEnergy( c
     DataTypes::set ( theGravity, g[0], g[1], g[2]);
     for (unsigned int i=0; i<masses.size(); i++)
     {
-        e -= dot(theGravity, _x[i]) * masses[i];
+        e -= type::dot(theGravity, _x[i]) * masses[i];
     }
     return e;
 }
@@ -1595,7 +1595,7 @@ void DiagonalMass<DataTypes, MassType, GeometricalTypes>::draw(const core::visua
         return;
 
     const auto& x = m_geometryState->read(core::ConstVecCoordId::position())->getValue();
-    Vector3 gravityCenter;
+    type::Vector3 gravityCenter;
     Real totalMass=0.0;
 
     std::vector<  type::Vector3 > points;

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
@@ -1012,7 +1012,8 @@ void DiagonalMass<DataTypes, MassType>::computeMass()
             }
             d_totalMass.setValue(total_mass);
         }
-        else if (m_topology->getNbQuads()>0 && m_manageElementTypeChange == sofa::geometry::ElementType::QUAD) {
+        else if (m_topology->getNbQuads()>0 && m_manageElementTypeChange == sofa::geometry::ElementType::QUAD)
+        {
             helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
             m_massTopologyType = sofa::geometry::ElementType::QUAD;
 

--- a/SofaKernel/modules/SofaSimpleFem/SofaSimpleFem_test/TetrahedronDiffusionFEMForceField_test.cpp
+++ b/SofaKernel/modules/SofaSimpleFem/SofaSimpleFem_test/TetrahedronDiffusionFEMForceField_test.cpp
@@ -40,17 +40,6 @@ using sofa::testing::BaseTest;
 #include <SofaMeshCollision/initSofaMeshCollision.h>
 #include <SofaImplicitOdeSolver/initSofaImplicitOdeSolver.h>
  
-
-#if defined(WIN32) && _MSC_VER<=1700  // before or equal to visual studio 2012
-   #include <boost/math/special_functions/erf.hpp>
-   #define ERFC(x) boost::math::erfc(x)
-#else
-   #define ERFC(x) std::erfc(x)
-#endif
-
-
-
-
 namespace sofa {
 
 /** @brief Comparison of the result of simulation with theoretical values in Diffusion case
@@ -185,7 +174,7 @@ struct TetrahedronDiffusionFEMForceField_test : public BaseTest
     {
         // For a Dirac heat of T=1 and a fixed BC T=0, the temperature at time = TTTT in the middle of the beam is:
         SReal temp = 1.0 / (4.0 * sqrt(timeEvaluation));
-        theorX[0] = 1.0 * ERFC( temp );
+        theorX[0] = 1.0 * std::erfc(temp);
     }
 
 

--- a/SofaKernel/modules/SofaSimpleFem/SofaSimpleFem_test/scenes/TetrahedronDiffusionFEMForceField.scn
+++ b/SofaKernel/modules/SofaSimpleFem/SofaSimpleFem_test/scenes/TetrahedronDiffusionFEMForceField.scn
@@ -20,9 +20,9 @@
         <Node name="Temperature" gravity="0 0 0"  >
             <EulerImplicitSolver name="EulerExplicitSolver" firstOrder="1" tags="heat" rayleighStiffness="0.1" rayleighMass="0.1" />
             <CGLinearSolver name="CG" iterations="1000" tolerance="1.0e-10" threshold="1.0e-30" tags="heat" />
-            <MechanicalObject template="Vec1d" position="@../../temperatureLoader.position"  name="gridTemperature" bbox="0 0 0 0 0 0" tags="heat" />
-            <TetrahedronDiffusionFEMForceField template="Vec1d" name="DiffusionForceField" constantDiffusionCoefficient="1.0" tagMechanics="geom" tags="heat"/>
-            <DiagonalMass template="Vec1d" name="Mass" massDensity="1.0" tags="heat"/>
+            <MechanicalObject template="Vec1d" position="@../../temperatureLoader.position"  name="gridTemperature" bbox="0 0 0 0 0 0" tags="heat"  />
+            <TetrahedronDiffusionFEMForceField template="Vec1d" name="DiffusionForceField" constantDiffusionCoefficient="1.0" tagMechanics="geom" tags="heat" topology="@../Container"/>
+            <DiagonalMass template="Vec1d,double,Vec3d" name="Mass" massDensity="1.0" tags="heat"/>
             <LinearMovementConstraint template="Vec1d" keyTimes="0 998 999" movements="1 1 0" indices="@../../box-dirac.indices" />
             <FixedConstraint indices="@../../box-fixed.indices" />
         </Node>

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronDiffusionFEMForceField.h
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronDiffusionFEMForceField.h
@@ -96,7 +96,9 @@ public:
       /// Vector of diffusivities associated to all tetras
       Data<sofa::type::vector<Real> > d_tetraDiffusionCoefficient;
       /// bool used to specify 1D diffusion
-      Data<bool> d_1DDiffusion;
+      /// This data is now useless, as it can be deduced from the template
+      DeprecatedAndRemoved d_1DDiffusion;
+
       /// Ratio for anisotropic diffusion
       Data<Real> d_transverseAnisotropyRatio;
       /// Vector for transverse anisotropy

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronDiffusionFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronDiffusionFEMForceField.inl
@@ -180,7 +180,7 @@ void TetrahedronDiffusionFEMForceField<DataTypes>::init()
     }
 
     /// Initialize all the diffusion coefficients (for tetras) to the value given by the user.
-    sofa::type::vector<Real>& tetraDiff = *(d_tetraDiffusionCoefficient.beginEdit());
+    auto tetraDiff = sofa::helper::getWriteOnlyAccessor(d_tetraDiffusionCoefficient);
     loadedDiffusivity = false;
 
     /// case no potential vector input
@@ -202,7 +202,6 @@ void TetrahedronDiffusionFEMForceField<DataTypes>::init()
 
         msg_info() << "diffusion coefficient is loaded per tetra";
     }
-    d_tetraDiffusionCoefficient.endEdit();
 
     /// Get the mechanical object containing the mesh position in 3D
     Tag mechanicalTag(d_tagMeshMechanics.getValue());

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaDiagonalMass.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaDiagonalMass.h
@@ -35,24 +35,20 @@ namespace mass
 using namespace sofa::gpu::cuda;
 
 template<>
-class DiagonalMassInternalData<CudaVec3Types,float>
+class DiagonalMassInternalData<CudaVec3Types,float, CudaVec3Types>
 {
 public :
     typedef sofa::component::topology::PointData<CudaVector<float> > VecMass;
     typedef CudaVector<float> MassVector;
-
-    typedef CudaVec3fTypes GeometricalTypes ; /// assumes the geometry object type is 3D
 };
 
 #ifdef SOFA_GPU_CUDA_DOUBLE
 template<>
-class DiagonalMassInternalData<CudaVec3dTypes,double>
+class DiagonalMassInternalData<CudaVec3dTypes,double, CudaVec3dTypes>
 {
 public :
     typedef sofa::component::topology::PointData<CudaVector<double> > VecMass;
     typedef CudaVector<double> MassVector;
-
-    typedef CudaVec3dTypes GeometricalTypes ; /// assumes the geometry object type is 3D
 };
 #endif
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMeshMatrixMass.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMeshMatrixMass.cpp
@@ -19,7 +19,6 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_GPU_CUDA_CUDAMESHMATRIXMASS_CPP
 #define SOFA_GPU_CUDA_CUDAMESHMATRIXMASS_CPP
 
 #include <sofa/gpu/cuda/CudaMeshMatrixMass.inl>
@@ -48,12 +47,18 @@ namespace mass
 
 template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec3fTypes, float>;
 template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2fTypes, float>;
+template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2fTypes, float, sofa::gpu::cuda::CudaVec3fTypes>;
 template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1fTypes, float>;
+template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1fTypes, float, sofa::gpu::cuda::CudaVec3fTypes>;
+template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1fTypes, float, sofa::gpu::cuda::CudaVec2fTypes>;
 
 #ifdef SOFA_GPU_CUDA_DOUBLE
 template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec3dTypes, double>;
 template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2dTypes, double>;
+template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2dTypes, double, sofa::gpu::cuda::CudaVec3dTypes>;
 template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1dTypes, double>;
+template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1dTypes, double, sofa::gpu::cuda::CudaVec3dTypes>;
+template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1dTypes, double, sofa::gpu::cuda::CudaVec2dTypes>;
 #endif // SOFA_GPU_CUDA_DOUBLE
 
 
@@ -70,11 +75,17 @@ namespace cuda
 int MeshMatrixMassClassCudaClass = core::RegisterObject("Supports GPU-side computations using CUDA")
         .add< component::mass::MeshMatrixMass<CudaVec3fTypes, float > >(true)
         .add< component::mass::MeshMatrixMass<CudaVec2fTypes, float > >()
+        .add< component::mass::MeshMatrixMass<CudaVec2fTypes, float, CudaVec3fTypes > >()
         .add< component::mass::MeshMatrixMass<CudaVec1fTypes, float > >()
+        .add< component::mass::MeshMatrixMass<CudaVec1fTypes, float, CudaVec3fTypes > >()
+        .add< component::mass::MeshMatrixMass<CudaVec1fTypes, float, CudaVec2fTypes > >()
 #ifdef SOFA_GPU_CUDA_DOUBLE
         .add< component::mass::MeshMatrixMass<CudaVec3dTypes, double > >()
         .add< component::mass::MeshMatrixMass<CudaVec2dTypes, double > >()
+        .add< component::mass::MeshMatrixMass<CudaVec2dTypes, double, CudaVec3dTypes > >()
         .add< component::mass::MeshMatrixMass<CudaVec1dTypes, double > >()
+        .add< component::mass::MeshMatrixMass<CudaVec1dTypes, double, CudaVec3dTypes > >()
+        .add< component::mass::MeshMatrixMass<CudaVec1dTypes, double, CudaVec2dTypes > >()
 #endif // SOFA_GPU_CUDA_DOUBLE
         ;
 
@@ -83,6 +94,3 @@ int MeshMatrixMassClassCudaClass = core::RegisterObject("Supports GPU-side compu
 } // namespace gpu
 
 } // namespace sofa
-
-#endif //SOFA_GPU_CUDA_CUDAMESHMATRIXMASS_CPP
-

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMeshMatrixMass.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMeshMatrixMass.h
@@ -35,15 +35,12 @@ namespace mass
 using namespace sofa::gpu::cuda;
 using namespace sofa::component::mass;
 
-template<>
-class MeshMatrixMassInternalData<CudaVec3fTypes,float>
+template<class GeometricalTypes>
+class MeshMatrixMassInternalData<CudaVec3fTypes,float, GeometricalTypes>
 {
 public:
     /// Cuda vector copying the vertex mass (enabling deviceRead)
     CudaVector<float> vMass;
-
-    /// assumes the geometry object type is 3D
-    typedef CudaVec3fTypes GeometricalTypes ;
 };
 
 template<>
@@ -61,15 +58,12 @@ void MeshMatrixMass<sofa::gpu::cuda::CudaVec3fTypes, float>::accFromF(const core
 
 
 
-template<>
-class MeshMatrixMassInternalData<CudaVec2fTypes,float>
+template<class GeometricalTypes>
+class MeshMatrixMassInternalData<CudaVec2fTypes,float, GeometricalTypes>
 {
 public:
     /// Cuda vector copying the vertex mass (enabling deviceRead)
     CudaVector<float> vMass;
-
-    /// assumes the geometry object type is 3D
-    typedef CudaVec3fTypes GeometricalTypes ;
 };
 
 template<>
@@ -87,15 +81,13 @@ void MeshMatrixMass<sofa::gpu::cuda::CudaVec2fTypes, float>::accFromF(const core
 
 
 
-template<>
-class MeshMatrixMassInternalData<CudaVec1fTypes,float>
+template<class GeometricalTypes>
+class MeshMatrixMassInternalData<CudaVec1fTypes,float, GeometricalTypes>
 {
 public:
     /// Cuda vector copying the vertex mass (enabling deviceRead)
     CudaVector<float> vMass;
 
-    /// assumes the geometry object type is 3D
-    typedef CudaVec3fTypes GeometricalTypes ;
 };
 
 template<>
@@ -112,14 +104,20 @@ void MeshMatrixMass<sofa::gpu::cuda::CudaVec1fTypes, float>::accFromF(const core
 
 
 #ifndef SOFA_GPU_CUDA_CUDAMESHMATRIXMASS_CPP
-template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec3fTypes, float>;
-template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2fTypes, float>;
-template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1fTypes, float>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec3fTypes, float>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2fTypes, float>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2fTypes, float, sofa::gpu::cuda::CudaVec3fTypes>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1fTypes, float>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1fTypes, float sofa::gpu::cuda::CudaVec3fTypes>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1fTypes, float sofa::gpu::cuda::CudaVec2fTypes>;
 
 #ifdef SOFA_GPU_CUDA_DOUBLE
-template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec3dTypes, double>;
-template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2dTypes, double>;
-template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1dTypes, double>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec3dTypes, double>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2dTypes, double>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2dTypes, double, sofa::gpu::cuda::CudaVec3dTypes>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1dTypes, double>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1dTypes, double, sofa::gpu::cuda::CudaVec3dTypes>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1dTypes, double, sofa::gpu::cuda::CudaVec2dTypes>;
 #endif // SOFA_GPU_CUDA_DOUBLE
 
 #endif //SOFA_GPU_CUDA_CUDAMESHMATRIXMASS_CPP

--- a/examples/Components/forcefield/TetrahedronDiffusionFEMForceField.scn
+++ b/examples/Components/forcefield/TetrahedronDiffusionFEMForceField.scn
@@ -25,9 +25,9 @@
 
         <EulerImplicitSolver name="EulerExplicitSolver" firstOrder="1" tags="heat" rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver name="CG" iterations="1000" tolerance="1.0e-10" threshold="1.0e-30" tags="heat"/>
-        <MechanicalObject template="Vec1d" position="@../potentialLoader.position"  name="gridTemperature" bbox="0 0 0 0 0 0" tags="heat"/>
-        <TetrahedronDiffusionFEMForceField template="Vec1d" name="DiffusionForceField" constantDiffusionCoefficient="1500" printLog="0" drawConduc="0" tagMechanics="mechanics" tags="heat"/>
-        <MeshMatrixMass name="Mass" lumping="0" massDensity="1.0" printLog="0" tags="heat"/>
+        <MechanicalObject template="Vec1d" position="@../potentialLoader.position"  name="gridTemperature" bbox="0 0 0 0 0 0" topology="@../topo" tags="heat"/>
+        <TetrahedronDiffusionFEMForceField template="Vec1d" name="DiffusionForceField" constantDiffusionCoefficient="1500" printLog="0" drawConduc="0" scalarDiffusion="true" tagMechanics="mechanics" tags="heat"/>
+        <MeshMatrixMass template="Vec1d,double,Vec3d" name="Mass" lumping="0" massDensity="1.0" printLog="0" tags="heat"/>
 
         <LinearMovementConstraint template="Vec1d" keyTimes="0 0.005 0.006" movements="0 0 1" indices="@../box-cold.indices" />
         <LinearMovementConstraint template="Vec1d" keyTimes="0.001 0.002 0.004 0.005 0.006" movements="0 1 0.5 1 0" indices="@../box-hot.indices" />

--- a/examples/Components/forcefield/TetrahedronDiffusionFEMForceField.scn
+++ b/examples/Components/forcefield/TetrahedronDiffusionFEMForceField.scn
@@ -26,7 +26,7 @@
         <EulerImplicitSolver name="EulerExplicitSolver" firstOrder="1" tags="heat" rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver name="CG" iterations="1000" tolerance="1.0e-10" threshold="1.0e-30" tags="heat"/>
         <MechanicalObject template="Vec1d" position="@../potentialLoader.position"  name="gridTemperature" bbox="0 0 0 0 0 0" topology="@../topo" tags="heat"/>
-        <TetrahedronDiffusionFEMForceField template="Vec1d" name="DiffusionForceField" constantDiffusionCoefficient="1500" printLog="0" drawConduc="0" scalarDiffusion="true" tagMechanics="mechanics" tags="heat"/>
+        <TetrahedronDiffusionFEMForceField template="Vec1d" name="DiffusionForceField" constantDiffusionCoefficient="1500" printLog="0" drawConduc="0" tagMechanics="mechanics" tags="heat"/>
         <MeshMatrixMass template="Vec1d,double,Vec3d" name="Mass" lumping="0" massDensity="1.0" printLog="0" tags="heat"/>
 
         <LinearMovementConstraint template="Vec1d" keyTimes="0 0.005 0.006" movements="0 0 1" indices="@../box-cold.indices" />

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.cpp
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.cpp
@@ -73,15 +73,20 @@ Vector6 MeshMatrixMass<Vec3Types, double>::getMomentum ( const core::MechanicalP
 
 // Register in the Factory
 int MeshMatrixMassClass = core::RegisterObject("Define a specific mass for each particle")
-        .add< MeshMatrixMass<Vec3Types,Vec3Types::Real> >()
-        .add< MeshMatrixMass<Vec2Types,Vec2Types::Real> >()
-        .add< MeshMatrixMass<Vec1Types,Vec1Types::Real> >()
-
+        .add< MeshMatrixMass<Vec3Types, Vec3Types::Real> >()
+        .add< MeshMatrixMass<Vec2Types, Vec2Types::Real> >()
+        .add< MeshMatrixMass<Vec2Types, Vec2Types::Real, Vec3Types> >()
+        .add< MeshMatrixMass<Vec1Types, Vec1Types::Real> >()
+        .add< MeshMatrixMass<Vec1Types, Vec1Types::Real, Vec3Types> >()
+        .add< MeshMatrixMass<Vec1Types, Vec1Types::Real, Vec2Types> >()
         ;
 
-template class SOFA_SOFAMISCFORCEFIELD_API MeshMatrixMass<Vec3Types,Vec3Types::Real>;
-template class SOFA_SOFAMISCFORCEFIELD_API MeshMatrixMass<Vec2Types,Vec2Types::Real>;
-template class SOFA_SOFAMISCFORCEFIELD_API MeshMatrixMass<Vec1Types,Vec1Types::Real>;
+template class SOFA_SOFAMISCFORCEFIELD_API MeshMatrixMass<Vec3Types, Vec3Types::Real>;
+template class SOFA_SOFAMISCFORCEFIELD_API MeshMatrixMass<Vec2Types, Vec2Types::Real>;
+template class SOFA_SOFAMISCFORCEFIELD_API MeshMatrixMass<Vec2Types, Vec2Types::Real, Vec3Types>;
+template class SOFA_SOFAMISCFORCEFIELD_API MeshMatrixMass<Vec1Types, Vec1Types::Real>;
+template class SOFA_SOFAMISCFORCEFIELD_API MeshMatrixMass<Vec1Types, Vec1Types::Real, Vec3Types>;
+template class SOFA_SOFAMISCFORCEFIELD_API MeshMatrixMass<Vec1Types, Vec1Types::Real, Vec2Types>;
 
 
 

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.h
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.h
@@ -47,7 +47,15 @@ public:
     typedef type::Vec<3,Real> Vec3;
 };
 
-
+/**
+* @class    MeshMatrixMass
+* @brief    This component computes the integral of this mass density over the volume of the object geometry.
+* @remark   Similar to DiagonalMass which simplifies the Mass Matrix as diagonal.
+* @remark   https://www.sofa-framework.org/community/doc/components/masses/meshmatrixmass/
+* @tparam   DataTypes type of the state associated to this mass
+* @tparam   TMassType type of the mass value
+* @tparam   GeometricalTypes type of the geometry, i.e type of the state associated with the topology (if the topology and the mass relates to the same state, this will be the same as DataTypes)
+*/
 template <class DataTypes, class TMassType, class GeometricalTypes = DataTypes>
 class MeshMatrixMass : public core::behavior::Mass<DataTypes>
 {

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.h
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.h
@@ -37,7 +37,7 @@
 namespace sofa::component::mass
 {
 
-template<class DataTypes, class TMassType>
+template<class DataTypes, class TMassType, class GeometricalTypes>
 class MeshMatrixMassInternalData
 {
 public:
@@ -45,16 +45,14 @@ public:
 
     /// In case of non 3D template
     typedef type::Vec<3,Real> Vec3;
-    /// assumes the geometry object type is 3D
-    typedef defaulttype::StdVectorTypes< Vec3, Vec3, Real > GeometricalTypes;
 };
 
 
-template <class DataTypes, class TMassType>
+template <class DataTypes, class TMassType, class GeometricalTypes = DataTypes>
 class MeshMatrixMass : public core::behavior::Mass<DataTypes>
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE2(MeshMatrixMass,DataTypes,TMassType), SOFA_TEMPLATE(core::behavior::Mass,DataTypes));
+    SOFA_CLASS(SOFA_TEMPLATE3(MeshMatrixMass,DataTypes,TMassType,GeometricalTypes), SOFA_TEMPLATE(core::behavior::Mass,DataTypes));
 
     typedef core::behavior::Mass<DataTypes> Inherited;
     typedef typename DataTypes::VecCoord                    VecCoord;
@@ -69,8 +67,6 @@ public:
     typedef type::vector<MassVector>                      MassVectorVector;
 
     using Index = sofa::Index;
-
-    typedef typename MeshMatrixMassInternalData<DataTypes,TMassType>::GeometricalTypes GeometricalTypes;
 
     /// @name Data of mass information
     /// @{
@@ -99,8 +95,8 @@ public:
     Data< std::map < std::string, sofa::type::vector<double> > > f_graph; ///< Graph of the controlled potential
 
     /// Link to be set to the topology container in the component graph.
-    SingleLink<MeshMatrixMass<DataTypes, TMassType>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
-
+    SingleLink<MeshMatrixMass<DataTypes, TMassType, GeometricalTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
+    
 protected:
 
     /// The type of topology to build the mass from the topology
@@ -115,8 +111,8 @@ protected:
     void massInitialization();
 
     /// Internal data required for Cuda computation (copy of vertex mass for deviceRead)
-    MeshMatrixMassInternalData<DataTypes, MassType> data;
-    friend class MeshMatrixMassInternalData<DataTypes, MassType>;
+    MeshMatrixMassInternalData<DataTypes, MassType, GeometricalTypes> data;
+    friend class MeshMatrixMassInternalData<DataTypes, MassType, GeometricalTypes>;
 
 
 public:
@@ -359,14 +355,19 @@ protected:
     void applyEdgeMassHexahedronDestruction(const sofa::type::vector<Index>& /*indices*/);
 
 
+    /// Pointer to the topology container. Will be set by link @sa l_topology
     sofa::core::topology::BaseMeshTopology* m_topology;
+    /// Pointer to the state owning geometrical positions, associated with the topology
+    typename sofa::core::behavior::MechanicalState<GeometricalTypes>::SPtr m_geometryState;
 };
 
 #if  !defined(SOFA_COMPONENT_MASS_MESHMATRIXMASS_CPP)
-extern template class SOFA_SOFAMISCFORCEFIELD_API MeshMatrixMass<defaulttype::Vec3Types,defaulttype::Vec3Types::Real>;
-extern template class SOFA_SOFAMISCFORCEFIELD_API MeshMatrixMass<defaulttype::Vec2Types,defaulttype::Vec2Types::Real>;
-extern template class SOFA_SOFAMISCFORCEFIELD_API MeshMatrixMass<defaulttype::Vec1Types,defaulttype::Vec1Types::Real>;
-
+extern template class SOFA_SOFAMISCFORCEFIELD_API MeshMatrixMass<defaulttype::Vec3Types, defaulttype::Vec3Types::Real>;
+extern template class SOFA_SOFAMISCFORCEFIELD_API MeshMatrixMass<defaulttype::Vec2Types, defaulttype::Vec2Types::Real>;
+extern template class SOFA_SOFAMISCFORCEFIELD_API MeshMatrixMass<defaulttype::Vec2Types, defaulttype::Vec2Types::Real, defaulttype::Vec3Types>;
+extern template class SOFA_SOFAMISCFORCEFIELD_API MeshMatrixMass<defaulttype::Vec1Types, defaulttype::Vec1Types::Real>;
+extern template class SOFA_SOFAMISCFORCEFIELD_API MeshMatrixMass<defaulttype::Vec1Types, defaulttype::Vec1Types::Real, defaulttype::Vec3Types>;
+extern template class SOFA_SOFAMISCFORCEFIELD_API MeshMatrixMass<defaulttype::Vec1Types, defaulttype::Vec1Types::Real, defaulttype::Vec2Types>;
 #endif
 
 } // namespace sofa::component::mass

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -30,12 +30,6 @@
 #include <SofaBaseMechanics/AddMToMatrixFunctor.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/type/vector.h>
-#include <SofaBaseTopology/CommonAlgorithms.h>
-#include <SofaBaseTopology/EdgeSetGeometryAlgorithms.h>
-#include <SofaBaseTopology/TriangleSetGeometryAlgorithms.h>
-#include <SofaBaseTopology/TetrahedronSetGeometryAlgorithms.h>
-#include <SofaBaseTopology/QuadSetGeometryAlgorithms.h>
-#include <SofaBaseTopology/HexahedronSetGeometryAlgorithms.h>
 #include <sofa/simulation/AnimateEndEvent.h>
 #include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <numeric>

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -966,6 +966,8 @@ using sofa::core::topology::TopologyElementType;
 template <class DataTypes, class MassType, class GeometricalTypes>
 void MeshMatrixMass<DataTypes, MassType, GeometricalTypes>::init()
 {
+    this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+
     m_massLumpingCoeff = 0.0;
 
     Inherited::init();
@@ -973,7 +975,6 @@ void MeshMatrixMass<DataTypes, MassType, GeometricalTypes>::init()
     TopologyElementType topoType = checkTopology();
     if(topoType == TopologyElementType::POINT)
     {
-        this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         return;
     }
     initTopologyHandlers(topoType);
@@ -992,6 +993,9 @@ void MeshMatrixMass<DataTypes, MassType, GeometricalTypes>::init()
 
     //Function for GPU-CUDA version only
     this->copyVertexMass();
+
+    //everything has been initialized so mark the component in a valid state
+    this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
 }
 
 

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -938,8 +938,6 @@ void MeshMatrixMass<DataTypes, MassType>::applyEdgeMassHexahedronDestruction(con
             const core::topology::BaseMeshTopology::EdgesInHexahedron &he = this->m_topology->getEdgesInHexahedron(hexahedronRemoved[i]);
             const core::topology::BaseMeshTopology::Hexahedron& h = this->m_topology->getHexahedron(hexahedronRemoved[i]);
 
-            const core::topology::BaseMeshTopology::Hexahedron& h = this->m_topology->getHexahedron(hexahedronRemoved[i]);
-
             // Compute rest mass of conserne hexahedron = density * hexahedron volume.
             const auto& rpos0 = DataTypes::getCPos(positions[h[0]]);
             const auto& rpos1 = DataTypes::getCPos(positions[h[1]]);

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -2274,7 +2274,7 @@ void MeshMatrixMass<DataTypes, MassType, GeometricalTypes>::draw(const core::vis
     const MassVector &vertexMass= d_vertexMass.getValue();
 
     const auto& x = m_geometryState->read(core::ConstVecCoordId::position())->getValue();
-    Vector3 gravityCenter;
+    type::Vector3 gravityCenter;
     Real totalMass=0.0;
 
     std::vector<  type::Vector3 > points;
@@ -2307,7 +2307,7 @@ void MeshMatrixMass<DataTypes, MassType, GeometricalTypes>::draw(const core::vis
         gravityCenter /= totalMass;
         for(unsigned int i=0 ; i<3 ; i++)
         {
-            Vector3 v, diff;
+            type::Vector3 v{};
             v[i] = d_showAxisSize.getValue();
             vertices.push_back(gravityCenter - v);
             vertices.push_back(gravityCenter + v);

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -932,6 +932,8 @@ void MeshMatrixMass<DataTypes, MassType>::applyEdgeMassHexahedronDestruction(con
             const core::topology::BaseMeshTopology::EdgesInHexahedron &he = this->m_topology->getEdgesInHexahedron(hexahedronRemoved[i]);
             const core::topology::BaseMeshTopology::Hexahedron& h = this->m_topology->getHexahedron(hexahedronRemoved[i]);
 
+            const core::topology::BaseMeshTopology::Hexahedron& h = this->m_topology->getHexahedron(hexahedronRemoved[i]);
+
             // Compute rest mass of conserne hexahedron = density * hexahedron volume.
             const auto& rpos0 = DataTypes::getCPos(positions[h[0]]);
             const auto& rpos1 = DataTypes::getCPos(positions[h[1]]);

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -26,9 +26,16 @@
 #include <sofa/core/MechanicalParams.h>
 #include <sofa/defaulttype/DataTypeInfo.h>
 #include <SofaBaseTopology/TopologyData.inl>
+#include <SofaBaseTopology/RegularGridTopology.h>
 #include <SofaBaseMechanics/AddMToMatrixFunctor.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/type/vector.h>
+#include <SofaBaseTopology/CommonAlgorithms.h>
+#include <SofaBaseTopology/EdgeSetGeometryAlgorithms.h>
+#include <SofaBaseTopology/TriangleSetGeometryAlgorithms.h>
+#include <SofaBaseTopology/TetrahedronSetGeometryAlgorithms.h>
+#include <SofaBaseTopology/QuadSetGeometryAlgorithms.h>
+#include <SofaBaseTopology/HexahedronSetGeometryAlgorithms.h>
 #include <sofa/simulation/AnimateEndEvent.h>
 #include <sofa/core/behavior/MultiMatrixAccessor.h>
 #include <numeric>

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -26,7 +26,6 @@
 #include <sofa/core/MechanicalParams.h>
 #include <sofa/defaulttype/DataTypeInfo.h>
 #include <SofaBaseTopology/TopologyData.inl>
-#include <SofaBaseTopology/RegularGridTopology.h>
 #include <SofaBaseMechanics/AddMToMatrixFunctor.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/type/vector.h>


### PR DESCRIPTION
Follow-up of #2436 

The replacement of the usage of the GeometryAlgorithms had the unattended consequence that there was not information anymore about the geometry itself (it was hidden before by the geometryAlgorithms having a pointer on the topology before).
Now if one wants to define a geometry type different of the type of the associated state, it can be done by giving a third template (called GeometricalTypes). This template is equal to DataTypes by default if omitted (as it was before)

It should fix the scene failing since #2436 (about the diffusion, which is having a geometrical type (Vec3d) different of its associated state (Vec1d)

This PR cleans the DiffusionFEM as well (trivial optimizations, removal of one useless data which can be infered from the DataTypes)

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
