### PR TITLE
[SofaSimpleFem] Check topology in draw

### DIFF
--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/HexahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/HexahedronFEMForceField.inl
@@ -127,7 +127,7 @@ void HexahedronFEMForceField<DataTypes>::init()
     }
 
 
-    if ( m_topology->getNbHexahedra() <= 0 )
+    if ( m_topology->getTopologyType() != sofa::core::topology::TopologyElementType::HEXAHEDRON )
     {
         msg_error() << "Object must have a hexahedric MeshTopology." << msgendl
                     << " name: " << m_topology->getName() << msgendl

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/HexahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/HexahedronFEMForceField.inl
@@ -102,8 +102,11 @@ HexahedronFEMForceField<DataTypes>::HexahedronFEMForceField()
 template <class DataTypes>
 void HexahedronFEMForceField<DataTypes>::init()
 {
-    if(_alreadyInit)return;
-    else _alreadyInit=true;
+    if (_alreadyInit)
+    {
+        return;
+    }
+    _alreadyInit=true;
 
     this->core::behavior::ForceField<DataTypes>::init();
 
@@ -124,14 +127,16 @@ void HexahedronFEMForceField<DataTypes>::init()
     }
 
 
-    if( m_topology->getNbHexahedra()<=0 )
+    if ( m_topology->getNbHexahedra() <= 0 )
     {
         msg_error() << "Object must have a hexahedric MeshTopology." << msgendl
                     << " name: " << m_topology->getName() << msgendl
-                    << " typename: " << m_topology->getTypeName()<< msgendl
-                    << " nbPoints:" << m_topology->getNbPoints()<< msgendl;
+                    << " typename: " << m_topology->getTypeName() << msgendl
+                    << " nbPoints:" << m_topology->getNbPoints() << msgendl;
+        this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         return;
     }
+
     _sparseGrid = dynamic_cast<topology::SparseGridTopology*>(m_topology);
     m_potentialEnergy = 0;
 
@@ -1189,10 +1194,10 @@ template<class DataTypes>
 void HexahedronFEMForceField<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
     if (!vparams->displayFlags().getShowForceFields()) return;
-    if (!this->mstate) return;
     if (!f_drawing.getValue()) return;
+    if (this->d_componentState.getValue() != sofa::core::objectmodel::ComponentState::Valid) return;
+    if (!this->mstate) return;
     if (!m_topology) return;
-
 
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
 

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/HexahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/HexahedronFEMForceField.inl
@@ -127,7 +127,7 @@ void HexahedronFEMForceField<DataTypes>::init()
     }
 
 
-    if ( m_topology->getTopologyType() != sofa::core::topology::TopologyElementType::HEXAHEDRON )
+    if ( m_topology->getNbHexahedra() <= 0 )
     {
         msg_error() << "Object must have a hexahedric MeshTopology." << msgendl
                     << " name: " << m_topology->getName() << msgendl

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/HexahedronFEMForceField.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/HexahedronFEMForceField.inl
@@ -1191,6 +1191,7 @@ void HexahedronFEMForceField<DataTypes>::draw(const core::visual::VisualParams* 
     if (!vparams->displayFlags().getShowForceFields()) return;
     if (!this->mstate) return;
     if (!f_drawing.getValue()) return;
+    if (!m_topology) return;
 
 
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();


### PR DESCRIPTION
In `HexahedronFEMForceField<DataTypes>::draw`, the topology pointer is checked first before being used. It avoids a crash if the topology cannot be found in the initialization.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
