### PR TITLE
[Sofa.Helper] Remove duplicated code

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/Factory.cpp
@@ -21,11 +21,7 @@
 ******************************************************************************/
 #define SOFAHELPER_FACTORY_CPP
 #include <sofa/helper/Factory.inl>
-#include <typeinfo>
-#ifdef __GNUC__
-#include <cxxabi.h>
-#endif
-#include <cstdlib>
+#include <sofa/helper/NameDecoder.h>
 
 namespace sofa::helper
 {
@@ -33,51 +29,7 @@ namespace sofa::helper
 /// Decode the type's name to a more readable form if possible
 SOFA_HELPER_API std::string gettypename(const std::type_info& t)
 {
-    std::string name;
-#ifdef __GNUC__
-    char* realname = nullptr;
-    int status;
-    realname = abi::__cxa_demangle(t.name(), 0, 0, &status);
-    if (realname!=nullptr)
-    {
-        int length = 0;
-        while(realname[length] != '\0')
-        {
-            length++;
-        }
-        name.resize(length);
-        for(int i=0; i<(int)length; i++)
-            name[i] = realname[i];
-        free(realname);
-    }
-#else
-    name = t.name();
-#endif
-    // Remove namespaces
-    for(;;)
-    {
-        std::string::size_type pos = name.find("::");
-        if (pos == std::string::npos) break;
-        std::string::size_type first = name.find_last_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_",pos-1);
-        if (first == std::string::npos) first = 0;
-        else first++;
-        name.erase(first,pos-first+2);
-    }
-    //Remove "class "
-    for(;;)
-    {
-        std::string::size_type pos = name.find("class ");
-        if (pos == std::string::npos) break;
-        name.erase(pos,6);
-    }
-	//Remove "struct "
-    for(;;)
-    {
-        std::string::size_type pos = name.find("struct ");
-        if (pos == std::string::npos) break;
-        name.erase(pos,7);
-    }
-    return name;
+    return NameDecoder::decodeTypeName(t);
 }
 
 SOFA_HELPER_API std::string& getFactoryLog()


### PR DESCRIPTION
The code in `sofa::helper::gettypename` is similar (almost identical) to `NameDecoder::decodeTypeName`.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
