### PR TITLE
[Sofa.Core] Fix diamond inheritance in PairInteractionConstraint

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseInteractionConstraint.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseInteractionConstraint.h
@@ -34,7 +34,7 @@ namespace sofa::core::behavior
  *  bodies given their current positions and velocities.
  *
  */
-class SOFA_CORE_API BaseInteractionConstraint : public BaseConstraint, StateAccessor
+class SOFA_CORE_API BaseInteractionConstraint : public BaseConstraint, public virtual StateAccessor
 {
 public:
     SOFA_ABSTRACT_CLASS2(BaseInteractionConstraint, BaseConstraint, StateAccessor);


### PR DESCRIPTION
`PairInteractionConstraint` inherits multiple times from `StateAccessor`. `StateAccessor` constructor can be called multiple times. Therefore it initializes the Data multiple times. To prevent that the solution is virtual inheritance.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
