### PR TITLE
[Sofa.Core] More information when the same Data name is used multiple times

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -171,10 +171,13 @@ void Base::addData(BaseData* f)
 /// Note that this method should only be called if the field was not initialized with the initData method
 void Base::addData(BaseData* f, const std::string& name)
 {
-    if (name.size() > 0 && (findData(name) || findLink(name)))
+    if (!name.empty())
     {
-        msg_warning() << "Data field name " << name
-                << " already used in this class or in a parent class !";
+        msg_warning_when(findData(name)) << "Data field name '" << name
+            << "' already used as a Data in this class or in a parent class";
+
+        msg_warning_when(findLink(name)) << "Data field name '" << name
+            << "' already used as a Link in this class or in a parent class";
     }
     m_vecData.push_back(f);
     m_aliasData.insert(std::make_pair(name, f));
@@ -192,10 +195,13 @@ void Base::addAlias( BaseData* field, const char* alias)
 void Base::addLink(BaseLink* l)
 {
     const std::string& name = l->getName();
-    if (name.size() > 0 && (findData(name) || findLink(name)))
+    if (!name.empty())
     {
-        msg_warning() << "Link name '" << name
-                << "' already used in this class or in a parent class !";
+        msg_warning_when(findData(name)) << "Link name '" << name
+            << "' already used as a Data in this class or in a parent class";
+
+        msg_warning_when(findLink(name)) << "Link name '" << name
+            << "' already used as a Link in this class or in a parent class";
     }
     m_vecLink.push_back(l);
     m_aliasLink.insert(std::make_pair(name, l));


### PR DESCRIPTION
The warning message now indicates if the newly added Data/Link is used as a Data or as a Link.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
