### PR TITLE
[SofaPreconditioner] Cleaning

### DIFF
--- a/modules/SofaPreconditioner/src/SofaPreconditioner/PrecomputedWarpPreconditioner.inl
+++ b/modules/SofaPreconditioner/src/SofaPreconditioner/PrecomputedWarpPreconditioner.inl
@@ -476,7 +476,7 @@ void PrecomputedWarpPreconditioner<TDataTypes>::rotateConstraints()
     if (node != nullptr)
     {
         rotationFinder = node->get< sofa::core::behavior::RotationFinder<TDataTypes> > ();
-        msg_info_when(rotationFinder == nullptr) << "No rotation defined : only applicable for components implementing RotationFinder!";
+        msg_warning_when(rotationFinder == nullptr) << "No rotation defined : only applicable for components implementing RotationFinder!";
     }
 
     Transformation Rotation;

--- a/modules/SofaPreconditioner/src/SofaPreconditioner/ShewchukPCGLinearSolver.h
+++ b/modules/SofaPreconditioner/src/SofaPreconditioner/ShewchukPCGLinearSolver.h
@@ -19,8 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_COMPONENT_LINEARSOLVER_ShewchukPCGLinearSolver_H
-#define SOFA_COMPONENT_LINEARSOLVER_ShewchukPCGLinearSolver_H
+#pragma once
 #include <SofaPreconditioner/config.h>
 
 #include <sofa/core/behavior/LinearSolver.h>
@@ -29,15 +28,8 @@
 
 #include <cmath>
 
-namespace sofa
+namespace sofa::component::linearsolver
 {
-
-namespace component
-{
-
-namespace linearsolver
-{
-
 
 /// Linear system solver using the conjugate gradient iterative algorithm
 template<class TMatrix, class TVector>
@@ -106,10 +98,4 @@ inline void ShewchukPCGLinearSolver<component::linearsolver::GraphScatteredMatri
 template<>
 inline void ShewchukPCGLinearSolver<component::linearsolver::GraphScatteredMatrix,component::linearsolver::GraphScatteredVector>::cgstep_alpha(Vector& x,Vector& p,double alpha);
 
-} // namespace linearsolver
-
-} // namespace component
-
-} // namespace sofa
-
-#endif
+} // namespace sofa::component::linearsolver


### PR DESCRIPTION
- namespace concatenation
- pragma once
- ScopedAdvancedTimer instead of StepBegin/StepEnd
- Allman style
- `Inherit1::init();` called in `ShewchukPCGLinearSolver::init()`


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
