### PR TITLE
[SofaUserInteraction] Fix InteractionPerformerFactory symbol export

### DIFF
--- a/modules/SofaConstraint/SofaConstraint_test/CMakeLists.txt
+++ b/modules/SofaConstraint/SofaConstraint_test/CMakeLists.txt
@@ -7,10 +7,11 @@ sofa_find_package(SofaConstraint REQUIRED)
 set(SOURCE_FILES ../../empty.cpp)
 
 list(APPEND SOURCE_FILES
-    #LocalMinDistance_test.cpp
-    GenericConstraintSolver_test.cpp
     BilateralInteractionConstraint_test.cpp
-    UncoupledConstraintCorrection_test.cpp)
+    ConstraintAttachBodyPerformer_test.cpp
+    GenericConstraintSolver_test.cpp
+    UncoupledConstraintCorrection_test.cpp
+)
 
 add_definitions("-DSOFATEST_SCENES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/scenes_test\"")
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})

--- a/modules/SofaConstraint/SofaConstraint_test/ConstraintAttachBodyPerformer_test.cpp
+++ b/modules/SofaConstraint/SofaConstraint_test/ConstraintAttachBodyPerformer_test.cpp
@@ -1,0 +1,35 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <SofaConstraint/initSofaConstraint.h>
+#include <gtest/gtest.h>
+#include <SofaUserInteraction/InteractionPerformer.h>
+
+namespace sofa
+{
+
+TEST(ConstraintAttachBodyPerformer, Factory)
+{
+    component::initSofaConstraint();
+    EXPECT_TRUE(component::collision::InteractionPerformer::InteractionPerformerFactory::HasKey("ConstraintAttachBody"));
+}
+
+}

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/InteractionPerformer.h
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/InteractionPerformer.h
@@ -78,3 +78,8 @@ public:
 };
 
 } //namespace sofa::component::collision
+
+namespace sofa::helper
+{
+extern template class SOFA_SOFAUSERINTERACTION_API Factory<std::string, component::collision::InteractionPerformer, component::collision::BaseMouseInteractor*>;
+} //namespace sofa::helper


### PR DESCRIPTION
Should fix #2486 (at least it was working for me :p )

The InteractionPerformerFactory was instantiated in SofaUserInteraction but not exported so I suppose other dlls using this factory was created their own InteractionPerformerFactory (creating discrepancies between the various registations) 
This is valid only for Windows (Mac/Linux is not using this import/export mechanism)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
