### PR TITLE
[SofaBaseLinearSolver] Link is not overwritten

### DIFF
--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/GlobalSystemMatrixExporter.cpp
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/GlobalSystemMatrixExporter.cpp
@@ -44,11 +44,14 @@ GlobalSystemMatrixExporter::GlobalSystemMatrixExporter()
 
 void GlobalSystemMatrixExporter::doInit()
 {
-    l_linearSolver.set(this->getContext()->template get<sofa::core::behavior::LinearSolver>());
+    if (!l_linearSolver)
+    {
+        l_linearSolver.set(this->getContext()->template get<sofa::core::behavior::LinearSolver>());
+    }
 
     if (!l_linearSolver)
     {
-        msg_error() << "A linear solver has not been found in the current context, whereas it is required. This component exports the matrix from a linear solver.";
+        msg_error() << "No linear solver found in the current context, whereas it is required. This component exports the matrix from a linear solver.";
         this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
     }
 }


### PR DESCRIPTION
The link to the linear solver was always overwritten by the first linear solver in the current context. This PR adds the possibility for the user to specify which linear solver to use. This is useful when there are multiple linear solver in the current context (preconditioning methods)

EDIT: about GlobalSystemMatrixExporter

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
