### PR TITLE
[SofaBaseLinearSolver] Remove the IsRequired flag in CGLinearSolver

### DIFF
--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/CGLinearSolver.inl
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/CGLinearSolver.inl
@@ -40,9 +40,6 @@ CGLinearSolver<TMatrix,TVector>::CGLinearSolver()
     , d_graph( initData(&d_graph,"graph","Graph of residuals at each iteration") )
 {
     d_graph.setWidget("graph");
-    d_maxIter.setRequired(true);
-    d_tolerance.setRequired(true);
-    d_smallDenominatorThreshold.setRequired(true);
 }
 
 /// Initialization function checking input Data


### PR DESCRIPTION
PR 2419 restores the correct behavior of CGLinearSolver regarding the call-super-init
https://github.com/sofa-framework/sofa/pull/2419

But as some of its data are tagged as Required, this rise an error message when the value
is not set by the user.

I'm not sure it is wise to set the required flag when data provides meaningful and usable default values.

I recommand removing it and more generally keep the isRequired only for data field that really have no possibility to have a default value (eg: the filename for a loader). 

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
