### PR TITLE
[SofaGuiQt] FIX screenshot mechanism

### DIFF
--- a/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
@@ -387,6 +387,13 @@ RealGUI::RealGUI ( const char* viewername)
     connect ( exportGnuplotFilesCheckbox, SIGNAL ( toggled ( bool ) ), this, SLOT ( setExportGnuplot ( bool ) ) );
     connect ( tabs, SIGNAL ( currentChanged ( int ) ), this, SLOT ( currentTabChanged ( int ) ) );
 
+    connect ( ResetViewButton, SIGNAL ( clicked() ), this, SLOT ( resetView() ) );
+    connect ( SaveViewButton, SIGNAL ( clicked() ), this, SLOT ( saveView() ) );
+    connect ( screenshotButton, SIGNAL ( clicked() ), this, SLOT ( screenshot() ) );
+    connect ( screenshotButton, SIGNAL ( clicked() ), this, SLOT ( test() ) );
+    connect ( sizeW, SIGNAL ( valueChanged ( int ) ), this, SLOT ( setSizeW ( int ) ) );
+    connect ( sizeH, SIGNAL ( valueChanged ( int ) ), this, SLOT ( setSizeH ( int ) ) );
+
     /// We activate this timer only if the interactive mode is enabled (ie livecoding+mouse mouve event).
     if(m_enableInteraction){
         timerIdle = new QTimer(this);
@@ -500,7 +507,6 @@ RealGUI::RealGUI ( const char* viewername)
 
     // Trigger QDialog for "About" section
     connect(helpAboutAction, SIGNAL(triggered()), this, SLOT(showAbout()));
-
 
     m_filelistener = new RealGUIFileListener(this);
 }
@@ -1805,14 +1811,6 @@ void RealGUI::initViewer(BaseViewer* _viewer)
     }
 
     m_sofaMouseManager->setPickHandler(_viewer->getPickHandler());
-
-    connect ( ResetViewButton, SIGNAL ( clicked() ), this, SLOT ( resetView() ) );
-    connect ( SaveViewButton, SIGNAL ( clicked() ), this, SLOT ( saveView() ) );
-    connect ( screenshotButton, SIGNAL ( clicked() ), this, SLOT ( screenshot() ) );
-    connect ( screenshotButton, SIGNAL ( clicked() ), this, SLOT ( test() ) );
-    connect ( sizeW, SIGNAL ( valueChanged ( int ) ), this, SLOT ( setSizeW ( int ) ) );
-    connect ( sizeH, SIGNAL ( valueChanged ( int ) ), this, SLOT ( setSizeH ( int ) ) );
-
 }
 
 //------------------------------------

--- a/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
@@ -464,8 +464,8 @@ RealGUI::RealGUI ( const char* viewername)
 #ifndef SOFA_GUI_QT_NO_RECORDER
     if (recorder)
         connect( recorder, SIGNAL( RecordSimulation(bool) ), startButton, SLOT( setChecked(bool) ) );
-    if (recorder && getQtViewer())
-        connect( recorder, SIGNAL( NewTime() ), getQtViewer()->getQWidget(), SLOT( update() ) );
+    if (recorder && getSofaViewer())
+        connect( recorder, SIGNAL( NewTime() ), getSofaViewer()->getQWidget(), SLOT( update() ) );
 #endif
 
 #ifdef SOFA_GUI_INTERACTION
@@ -489,7 +489,7 @@ RealGUI::RealGUI ( const char* viewername)
     m_interactionActived = false;
 
     if(mCreateViewersOpt)
-        getQtViewer()->getQWidget()->installEventFilter(this);
+        getSofaViewer()->getQWidget()->installEventFilter(this);
 #endif
 
 #if(SOFAGUIQT_HAVE_QT5_WEBENGINE)
@@ -871,7 +871,7 @@ void RealGUI::emitIdle()
     }
 
     if(isEmbeddedViewer())
-        getQtViewer()->getQWidget()->update();
+        getSofaViewer()->getQWidget()->update();
 }
 
 /// This open popup the file selection windows.
@@ -1022,9 +1022,9 @@ void RealGUI::setSceneWithoutMonitor (Node::SPtr root, const char* filename, boo
 
         if( isEmbeddedViewer() )
         {
-            getQtViewer()->getQWidget()->setFocus();
-            getQtViewer()->getQWidget()->show();
-            getQtViewer()->getQWidget()->update();
+            getSofaViewer()->getQWidget()->setFocus();
+            getSofaViewer()->getQWidget()->show();
+            getSofaViewer()->getQWidget()->update();
         }
 
         resetScene();
@@ -1244,7 +1244,7 @@ void RealGUI::setViewerResolution ( int w, int h )
     if( isEmbeddedViewer() )
     {
         QSize winSize = size();
-        QSize viewSize = ( getViewer() ) ? getQtViewer()->getQWidget()->size() : QSize(0,0);
+        QSize viewSize = ( getViewer() ) ? getSofaViewer()->getQWidget()->size() : QSize(0,0);
 
 #if (QT_VERSION < QT_VERSION_CHECK(5, 11, 0))
         const QRect screen = QApplication::desktop()->availableGeometry(QApplication::desktop()->screenNumber(this));
@@ -1466,10 +1466,10 @@ BaseViewer* RealGUI::getViewer()
 
 //------------------------------------
 
-sofa::gui::qt::viewer::SofaViewer* RealGUI::getQtViewer()
+sofa::gui::qt::viewer::SofaViewer* RealGUI::getSofaViewer()
 {
-    sofa::gui::qt::viewer::SofaViewer* qtViewer = dynamic_cast<sofa::gui::qt::viewer::SofaViewer*>(mViewer);
-    return qtViewer ? qtViewer : nullptr;
+    sofa::gui::qt::viewer::SofaViewer* sofaViewer = dynamic_cast<sofa::gui::qt::viewer::SofaViewer*>(mViewer);
+    return sofaViewer ? sofaViewer : nullptr;
 }
 
 //------------------------------------
@@ -1487,7 +1487,7 @@ void RealGUI::removeViewer()
     {
         if(isEmbeddedViewer())
         {
-            getQtViewer()->removeViewerTab(tabs);
+            getSofaViewer()->removeViewerTab(tabs);
         }
         delete mViewer;
         mViewer = nullptr;
@@ -1643,7 +1643,7 @@ void RealGUI::eventNewTime()
 
 void RealGUI::keyPressEvent ( QKeyEvent * e )
 {
-    sofa::gui::qt::viewer::SofaViewer* qtViewer = dynamic_cast<sofa::gui::qt::viewer::SofaViewer*>(getViewer());
+    sofa::gui::qt::viewer::SofaViewer* sofaViewer = dynamic_cast<sofa::gui::qt::viewer::SofaViewer*>(getViewer());
 
 #ifdef SOFA_GUI_INTERACTION
     if(m_interactionActived)
@@ -1655,7 +1655,7 @@ void RealGUI::keyPressEvent ( QKeyEvent * e )
         else
         {
             sofa::core::objectmodel::KeypressedEvent keyEvent(e->key());
-            Node* groot = qtViewer->getScene();
+            Node* groot = sofaViewer->getScene();
             if (groot)
                 groot->propagateEvent(core::execparams::defaultInstance(), &keyEvent);
         }
@@ -1710,8 +1710,8 @@ void RealGUI::keyPressEvent ( QKeyEvent * e )
     }
     default:
     {
-        if (qtViewer)
-            qtViewer->keyPressEvent(e);
+        if (sofaViewer)
+            sofaViewer->keyPressEvent(e);
         break;
     }
     }
@@ -1760,8 +1760,8 @@ void RealGUI::initViewer(BaseViewer* _viewer)
     init(); //init data member from RealGUI for the viewer initialisation in the GUI
 
     // Is our viewer embedded or not ?
-    sofa::gui::qt::viewer::SofaViewer* qtViewer = dynamic_cast<sofa::gui::qt::viewer::SofaViewer*>(_viewer);
-    if( qtViewer == nullptr )
+    sofa::gui::qt::viewer::SofaViewer* sofaViewer = dynamic_cast<sofa::gui::qt::viewer::SofaViewer*>(_viewer);
+    if( sofaViewer == nullptr )
     {
         isEmbeddedViewer(false);
         std::cout<<"initViewer: The viewer isn't embedded in the GUI"<<std::endl;
@@ -1769,39 +1769,39 @@ void RealGUI::initViewer(BaseViewer* _viewer)
     else
     {
         isEmbeddedViewer(true);
-        this->mainWidgetLayout->addWidget(qtViewer->getQWidget());
+        this->mainWidgetLayout->addWidget(sofaViewer->getQWidget());
 
-        qtViewer->getQWidget()->setFocusPolicy ( Qt::StrongFocus );
+        sofaViewer->getQWidget()->setFocusPolicy ( Qt::StrongFocus );
 
-        qtViewer->getQWidget()->setSizePolicy ( QSizePolicy ( ( QSizePolicy::Policy ) 7,
+        sofaViewer->getQWidget()->setSizePolicy ( QSizePolicy ( ( QSizePolicy::Policy ) 7,
                                                               ( QSizePolicy::Policy ) 7
                                                               //, 100, 1,
-                                                              //qtViewer->getQWidget()->sizePolicy().hasHeightForWidth() )
+                                                              //sofaViewer->getQWidget()->sizePolicy().hasHeightForWidth() )
                                                               ));
 
-        qtViewer->getQWidget()->setMinimumSize ( QSize ( 0, 0 ) );
-        qtViewer->getQWidget()->setMouseTracking ( true );
-        qtViewer->configureViewerTab(tabs);
+        sofaViewer->getQWidget()->setMinimumSize ( QSize ( 0, 0 ) );
+        sofaViewer->getQWidget()->setMouseTracking ( true );
+        sofaViewer->configureViewerTab(tabs);
 
-        connect ( qtViewer->getQWidget(), SIGNAL ( resizeW ( int ) ), sizeW, SLOT ( setValue ( int ) ) );
-        connect ( qtViewer->getQWidget(), SIGNAL ( resizeH ( int ) ), sizeH, SLOT ( setValue ( int ) ) );
-        connect ( qtViewer->getQWidget(), SIGNAL ( quit (  ) ), this, SLOT ( fileExit (  ) ) );
+        connect ( sofaViewer->getQWidget(), SIGNAL ( resizeW ( int ) ), sizeW, SLOT ( setValue ( int ) ) );
+        connect ( sofaViewer->getQWidget(), SIGNAL ( resizeH ( int ) ), sizeH, SLOT ( setValue ( int ) ) );
+        connect ( sofaViewer->getQWidget(), SIGNAL ( quit (  ) ), this, SLOT ( fileExit (  ) ) );
         connect(simulationGraph, SIGNAL(focusChanged(sofa::core::objectmodel::BaseObject*)),
-                qtViewer->getQWidget(), SLOT(fitObjectBBox(sofa::core::objectmodel::BaseObject*))
+                sofaViewer->getQWidget(), SLOT(fitObjectBBox(sofa::core::objectmodel::BaseObject*))
                 );
         connect(simulationGraph, SIGNAL( focusChanged(sofa::core::objectmodel::BaseNode*) ),
-                qtViewer->getQWidget(), SLOT( fitNodeBBox(sofa::core::objectmodel::BaseNode*) )
+                sofaViewer->getQWidget(), SLOT( fitNodeBBox(sofa::core::objectmodel::BaseNode*) )
                 );
 
         // setGUI
-        textEdit1->setText ( qtViewer->helpString() );
-        connect ( this, SIGNAL( newStep()), qtViewer->getQWidget(), SLOT( update()));
+        textEdit1->setText ( sofaViewer->helpString() );
+        connect ( this, SIGNAL( newStep()), sofaViewer->getQWidget(), SLOT( update()));
 
-        qtViewer->getQWidget()->setFocus();
-        qtViewer->getQWidget()->show();
-        qtViewer->getQWidget()->update();
+        sofaViewer->getQWidget()->setFocus();
+        sofaViewer->getQWidget()->show();
+        sofaViewer->getQWidget()->update();
 
-        qtViewer->getPickHandler()->addCallBack(&informationOnPickCallBack );
+        sofaViewer->getPickHandler()->addCallBack(&informationOnPickCallBack );
     }
 
     m_sofaMouseManager->setPickHandler(_viewer->getPickHandler());
@@ -1809,6 +1809,7 @@ void RealGUI::initViewer(BaseViewer* _viewer)
     connect ( ResetViewButton, SIGNAL ( clicked() ), this, SLOT ( resetView() ) );
     connect ( SaveViewButton, SIGNAL ( clicked() ), this, SLOT ( saveView() ) );
     connect ( screenshotButton, SIGNAL ( clicked() ), this, SLOT ( screenshot() ) );
+    connect ( screenshotButton, SIGNAL ( clicked() ), this, SLOT ( test() ) );
     connect ( sizeW, SIGNAL ( valueChanged ( int ) ), this, SLOT ( setSizeW ( int ) ) );
     connect ( sizeH, SIGNAL ( valueChanged ( int ) ), this, SLOT ( setSizeH ( int ) ) );
 
@@ -1989,7 +1990,7 @@ void RealGUI::NewRootNode(sofa::simulation::Node* root, const char* path)
         getViewer()->load();
         getViewer()->resetView();
         if(isEmbeddedViewer())
-            getQtViewer()->getQWidget()->update();
+            getSofaViewer()->getQWidget()->update();
         statWidget->CreateStats(root);
     }
 }
@@ -2287,9 +2288,9 @@ void RealGUI::screenshot()
                                  "Choose a filename to save under"
                                  );
 
-    viewer::SofaViewer* qtViewer = getQtViewer();
-    if( qtViewer )
-        qtViewer->getQWidget()->repaint();
+    viewer::SofaViewer* sofaViewer = getSofaViewer();
+    if( sofaViewer )
+        sofaViewer->getQWidget()->repaint();
 
     if ( filename != "" )
     {
@@ -2318,7 +2319,7 @@ void RealGUI::showhideElements()
 {
     displayFlag->updateDataValue();
     if(isEmbeddedViewer())
-        getQtViewer()->getQWidget()->update();
+        getSofaViewer()->getQWidget()->update();
 }
 
 //------------------------------------
@@ -2326,7 +2327,7 @@ void RealGUI::showhideElements()
 void RealGUI::Update()
 {
     if(isEmbeddedViewer())
-        getQtViewer()->getQWidget()->update();
+        getSofaViewer()->getQWidget()->update();
     statWidget->CreateStats(currentSimulation());
 }
 
@@ -2337,7 +2338,7 @@ void RealGUI::updateBackgroundColour()
     if(getViewer())
         getViewer()->setBackgroundColour(background[0]->text().toFloat(),background[1]->text().toFloat(),background[2]->text().toFloat());
     if(isEmbeddedViewer())
-        getQtViewer()->getQWidget()->update();
+        getSofaViewer()->getQWidget()->update();
 }
 
 //------------------------------------
@@ -2347,7 +2348,7 @@ void RealGUI::updateBackgroundImage()
     if(getViewer())
         getViewer()->setBackgroundImage( backgroundImage->text().toStdString() );
     if(isEmbeddedViewer())
-        getQtViewer()->getQWidget()->update();
+        getSofaViewer()->getQWidget()->update();
 }
 
 //------------------------------------

--- a/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
@@ -1473,8 +1473,7 @@ BaseViewer* RealGUI::getViewer()
 
 sofa::gui::qt::viewer::SofaViewer* RealGUI::getSofaViewer()
 {
-    sofa::gui::qt::viewer::SofaViewer* sofaViewer = dynamic_cast<sofa::gui::qt::viewer::SofaViewer*>(mViewer);
-    return sofaViewer ? sofaViewer : nullptr;
+    return dynamic_cast<sofa::gui::qt::viewer::SofaViewer*>(mViewer);
 }
 
 //------------------------------------

--- a/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
@@ -1703,6 +1703,11 @@ void RealGUI::keyPressEvent ( QKeyEvent * e )
         emit(quit());
         break;
     }
+    case Qt::Key_S:
+    {
+        screenshot();
+        break;
+    }
     default:
     {
         if (qtViewer)

--- a/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
@@ -390,7 +390,6 @@ RealGUI::RealGUI ( const char* viewername)
     connect ( ResetViewButton, SIGNAL ( clicked() ), this, SLOT ( resetView() ) );
     connect ( SaveViewButton, SIGNAL ( clicked() ), this, SLOT ( saveView() ) );
     connect ( screenshotButton, SIGNAL ( clicked() ), this, SLOT ( screenshot() ) );
-    connect ( screenshotButton, SIGNAL ( clicked() ), this, SLOT ( test() ) );
     connect ( sizeW, SIGNAL ( valueChanged ( int ) ), this, SLOT ( setSizeW ( int ) ) );
     connect ( sizeH, SIGNAL ( valueChanged ( int ) ), this, SLOT ( setSizeH ( int ) ) );
 

--- a/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.h
@@ -354,7 +354,6 @@ public slots:
     virtual void updateDtEditState();
     virtual void resetScene();
     virtual void screenshot();
-    virtual void test() { std::cout << "test" << std::endl;}
     virtual void showhideElements();
     virtual void Update();
     virtual void updateBackgroundColour();

--- a/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.h
@@ -273,7 +273,7 @@ public:
 
     /// A way to know if our viewer is embedded or not... (see initViewer)
     /// TODO: Find a better way to do this
-    sofa::gui::qt::viewer::SofaViewer* getQtViewer();
+    sofa::gui::qt::viewer::SofaViewer* getSofaViewer();
 
     /// Our viewer is a QObject SofaViewer
     bool isEmbeddedViewer();
@@ -354,6 +354,7 @@ public slots:
     virtual void updateDtEditState();
     virtual void resetScene();
     virtual void screenshot();
+    virtual void test() { std::cout << "test" << std::endl;}
     virtual void showhideElements();
     virtual void Update();
     virtual void updateBackgroundColour();

--- a/modules/SofaGuiQt/src/sofa/gui/qt/viewer/SofaViewer.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/viewer/SofaViewer.cpp
@@ -97,11 +97,6 @@ void SofaViewer::keyPressEvent(QKeyEvent * e)
         m_bShowAxis = !m_bShowAxis;
         break;
     }
-    case Qt::Key_S:
-    {
-        m_backend->screenshot(m_backend->screenshotName());
-        break;
-    }
     case Qt::Key_V:
         // --- save video
     {

--- a/modules/SofaGuiQt/src/sofa/gui/qt/viewer/qgl/QtGLViewer.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/viewer/qgl/QtGLViewer.cpp
@@ -857,7 +857,6 @@ void QtGLViewer::keyPressEvent ( QKeyEvent * e )
         switch(e->key())
         {
         case Qt::Key_A: // axis
-        case Qt::Key_S: // sofa screenshot
         case Qt::Key_H: // help page
         case Qt::Key_G: // show grid
         {
@@ -877,6 +876,13 @@ void QtGLViewer::keyPressEvent ( QKeyEvent * e )
         }
     }
     update();
+}
+
+
+void QtGLViewer::screenshot(const std::string& filename, int compression_level)
+{
+    SOFA_UNUSED(compression_level);
+    QGLViewer::saveSnapshot(QString::fromStdString(filename), false);
 }
 
 

--- a/modules/SofaGuiQt/src/sofa/gui/qt/viewer/qgl/QtGLViewer.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/viewer/qgl/QtGLViewer.h
@@ -99,9 +99,9 @@ public:
                 ;
     }
 
-    static const char* viewerName()  { return "QGLViewer"; }
+    static const char* viewerName()  { return "QGLViewer (QtGLViewer)"; }
 
-    static const char* acceleratedName()  { return "&QGLViewer"; }
+    static const char* acceleratedName()  { return "&QGLViewer (QtGLViewer)"; }
 
     virtual void drawColourPicking (ColourPickingVisitor::ColourCode code) override;
 
@@ -140,6 +140,8 @@ public:
     void moveRayPickInteractor(int eventX, int eventY) override;
 
     void setCameraMode(core::visual::VisualParams::CameraType mode) override;
+
+    void screenshot(const std::string& filename, int compression_level = -1) override;
 
     QString helpString() const override;
 

--- a/modules/SofaGuiQt/src/sofa/gui/qt/viewer/qt/QtViewer.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/viewer/qt/QtViewer.h
@@ -141,12 +141,12 @@ public:
 
     static const char* viewerName()
     {
-        return "OpenGL";
+        return "OpenGL (QtViewer)";
     }
 
     static const char* acceleratedName()
     {
-        return "Open&GL";
+        return "Open&GL (QtViewer)";
     }
 
     /// Activate this class of viewer.


### PR DESCRIPTION
Fixes #1791 

Screenshot mechanism was broken and inconsistent between viewers.

With this PR, using the screenshot button or pressing "S" will do the same thing, regardless of the viewer.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
