### PR TITLE
[SofaMiscCollision] Fix the BarycentricStickContact response

### DIFF
--- a/examples/Components/collision/StickContactForceField.scn
+++ b/examples/Components/collision/StickContactForceField.scn
@@ -1,0 +1,43 @@
+<Node name="root" dt="0.02">
+    <RequiredPlugin pluginName='SofaOpenglVisual SofaGeneralLoader SofaConstraint SofaImplicitOdeSolver SofaLoader SofaMiscCollision SofaSimpleFem'/>
+
+    <VisualStyle displayFlags="hideBehaviorModels showForceFields showCollision showInteractionForceFields" />
+
+    <DefaultAnimationLoop />
+    <DefaultVisualManagerLoop />
+
+    <DefaultPipeline verbose="0" />
+    <BruteForceBroadPhase/>
+    <BVHNarrowPhase/>
+    <DefaultContactManager name="Response" response="stick" />
+    <DefaultCollisionGroupManager name="Group" />
+    <LocalMinDistance contactDistance="1" alarmDistance="2" />
+    
+    <Node name="cubeFEM">
+        <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
+        <RegularGridTopology nx="5" ny="5" nz="5" xmin="-3.5" xmax="3.5" ymin="-3.5" ymax="3.5" zmin="-3.5" zmax="3.5" />
+        <MechanicalObject />
+        <UniformMass vertexMass="0.25" />
+        <TetrahedronFEMForceField name="FEM" youngModulus="25" poissonRatio="0.3" computeGlobalMatrix="false" updateStiffnessMatrix="false" method="large" />
+        <Node name="Visu">
+            <MeshObjLoader name="meshLoader_0" filename="mesh/smCube125.obj" handleSeams="1" />
+            <OglModel name="Visual" src="@meshLoader_0" color="red" />
+            <SubsetMapping input="@.." output="@Visual" />
+        </Node>
+        <Node name="Surf">
+            <VisualStyle displayFlags="hideCollision" />
+            <SphereLoader filename="mesh/smCube27b.sph" />
+            <MechanicalObject position="@[-1].position" />
+            <SphereCollisionModel listRadius="@[-2].listRadius" contactStiffness="10000"/>
+            <BarycentricMapping />
+        </Node>
+    </Node>
+    <SphereLoader filename="mesh/floor.sph" />
+    <MechanicalObject position="@[-1].position" translation="0 -12.5 0" />
+    <SphereCollisionModel name="Floor" listRadius="@[-2].listRadius" simulated="0" moving="0" contactStiffness="10000" />
+    <Node>
+        <MeshObjLoader name="meshLoader_1" filename="mesh/floor2.obj" translation="0 -12.5 0" handleSeams="1" />
+        <OglModel name="FloorV" src="@meshLoader_1" texturename="textures/floor2.bmp" />
+    </Node>
+</Node>

--- a/examples/Components/collision/StickContactForceField.scn
+++ b/examples/Components/collision/StickContactForceField.scn
@@ -27,15 +27,15 @@
         </Node>
         <Node name="Surf">
             <VisualStyle displayFlags="hideCollision" />
-            <SphereLoader filename="mesh/smCube27b.sph" />
-            <MechanicalObject position="@[-1].position" />
-            <SphereCollisionModel listRadius="@[-2].listRadius" contactStiffness="10000"/>
+            <SphereLoader name="SphereLoader-Surf" filename="mesh/smCube27b.sph" />
+            <MechanicalObject position="@SphereLoader-Surf.position" />
+            <SphereCollisionModel listRadius="@SphereLoader.listRadius" contactStiffness="10000"/>
             <BarycentricMapping />
         </Node>
     </Node>
-    <SphereLoader filename="mesh/floor.sph" />
-    <MechanicalObject position="@[-1].position" translation="0 -12.5 0" />
-    <SphereCollisionModel name="Floor" listRadius="@[-2].listRadius" simulated="0" moving="0" contactStiffness="10000" />
+    <SphereLoader name="SphereLoader-root" filename="mesh/floor.sph" />
+    <MechanicalObject position="@SphereLoader-root.position" translation="0 -12.5 0" />
+    <SphereCollisionModel name="Floor" listRadius="@SphereLoader-root.listRadius" simulated="0" moving="0" contactStiffness="10000" />
     <Node>
         <MeshObjLoader name="meshLoader_1" filename="mesh/floor2.obj" translation="0 -12.5 0" handleSeams="1" />
         <OglModel name="FloorV" src="@meshLoader_1" texturename="textures/floor2.bmp" />

--- a/modules/SofaGuiCommon/src/sofa/gui/PickHandler.cpp
+++ b/modules/SofaGuiCommon/src/sofa/gui/PickHandler.cpp
@@ -379,7 +379,7 @@ component::collision::BodyPicked PickHandler::findCollisionUsingPipeline()
 
     const type::Vector3& origin          = mouseCollision->getRay(0).origin();
     const type::Vector3& direction       = mouseCollision->getRay(0).direction();
-    const double& maxLength                     = mouseCollision->getRay(0).l();
+    const double& maxLength              = mouseCollision->getRay(0).l();
     
     const std::set< sofa::component::collision::BaseRayContact*> &contacts = mouseCollision->getContacts();
     for (std::set< sofa::component::collision::BaseRayContact*>::const_iterator it=contacts.begin(); it != contacts.end(); ++it)

--- a/modules/SofaMiscCollision/src/SofaMiscCollision/BarycentricStickContact.h
+++ b/modules/SofaMiscCollision/src/SofaMiscCollision/BarycentricStickContact.h
@@ -19,8 +19,8 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_COMPONENT_COLLISION_BARYCENTRICSTICKCONTACT_H
-#define SOFA_COMPONENT_COLLISION_BARYCENTRICSTICKCONTACT_H
+#pragma once
+
 #include <SofaMiscCollision/config.h>
 
 #include <sofa/core/collision/Contact.h>
@@ -29,15 +29,8 @@
 #include <SofaGeneralDeformable/VectorSpringForceField.h>
 
 
-namespace sofa
+namespace sofa::component::collision
 {
-
-namespace component
-{
-
-namespace collision
-{
-
 
 template < class TCollisionModel1, class TCollisionModel2, class ResponseDataTypes = sofa::defaulttype::Vec3Types >
 class BarycentricStickContact : public core::collision::Contact
@@ -100,10 +93,5 @@ public:
     void draw(const core::visual::VisualParams* vparams) override;
 };
 
-} // namespace collision
+} // namespace sofa::component::collision
 
-} // namespace component
-
-} // namespace sofa
-
-#endif

--- a/modules/SofaMiscCollision/src/SofaMiscCollision/BarycentricStickContact.inl
+++ b/modules/SofaMiscCollision/src/SofaMiscCollision/BarycentricStickContact.inl
@@ -175,11 +175,10 @@ void BarycentricStickContact<TCollisionModel1,TCollisionModel2,ResponseDataTypes
         // Create mapping for second point
         index2 = mapper2.addPointB(o->point[1], index2, r2);
 
-        double distance = d0 + r1 + r2;
-        double stiffness = (elem1.getContactStiffness() + elem2.getContactStiffness());
+        const double stiffness = (elem1.getContactStiffness() + elem2.getContactStiffness());
         ff->m_stiffness.setValue(stiffness);
 
-        double mu_v = (elem1.getContactFriction() + elem2.getContactFriction());
+        const double mu_v = (elem1.getContactFriction() + elem2.getContactFriction());
 
         ff->addSpring(index1, index2, stiffness, mu_v/* *distance */, o->point[1]-o->point[0]);
     }

--- a/modules/SofaMiscCollision/src/SofaMiscCollision/BarycentricStickContact.inl
+++ b/modules/SofaMiscCollision/src/SofaMiscCollision/BarycentricStickContact.inl
@@ -19,23 +19,13 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_COMPONENT_COLLISION_BARYCENTRICSTICKCONTACT_INL
-#define SOFA_COMPONENT_COLLISION_BARYCENTRICSTICKCONTACT_INL
+#pragma once
 
 #include <SofaMiscCollision/BarycentricStickContact.h>
 #include <sofa/core/visual/VisualParams.h>
 
-namespace sofa
+namespace sofa::component::collision
 {
-
-namespace component
-{
-
-namespace collision
-{
-
-
-
 
 template < class TCollisionModel1, class TCollisionModel2, class ResponseDataTypes >
 BarycentricStickContact<TCollisionModel1,TCollisionModel2,ResponseDataTypes>::BarycentricStickContact(CollisionModel1* model1, CollisionModel2* model2, Intersection* intersectionMethod)
@@ -80,6 +70,7 @@ void BarycentricStickContact<TCollisionModel1,TCollisionModel2,ResponseDataTypes
         ff = sofa::core::objectmodel::New<ResponseForceField>(mstate1,mstate2);
         ff->setName( getName());
         setInteractionTags(mstate1, mstate2);
+        ff->init();
     }
 
     int insize = outputs.size();
@@ -185,17 +176,17 @@ void BarycentricStickContact<TCollisionModel1,TCollisionModel2,ResponseDataTypes
         index2 = mapper2.addPointB(o->point[1], index2, r2);
 
         double distance = d0 + r1 + r2;
-        double stiffness = (elem1.getContactStiffness() * elem2.getContactStiffness())/distance;
+        double stiffness = (elem1.getContactStiffness() + elem2.getContactStiffness());
+        ff->m_stiffness.setValue(stiffness);
 
         double mu_v = (elem1.getContactFriction() + elem2.getContactFriction());
-//        ff->addContact(index1, index2, elem1.getIndex(), elem2.getIndex(), o->normal, distance, stiffness, mu_v/* *distance */, mu_v, index);
+
         ff->addSpring(index1, index2, stiffness, mu_v/* *distance */, o->point[1]-o->point[0]);
     }
     // Update mappings
     mapper1.update();
     mapper2.update();
-    mapper1.updateXfree();
-    mapper2.updateXfree();
+
     msg_info() << size << "BarycentricStickContact springs created";
 }
 
@@ -249,10 +240,4 @@ void BarycentricStickContact<TCollisionModel1,TCollisionModel2,ResponseDataTypes
         ff->addTag(*it);
 }
 
-} // namespace collision
-
-} // namespace component
-
-} // namespace sofa
-
-#endif
+} //namespace sofa::component::collision

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/RayNewProximityIntersection.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/RayNewProximityIntersection.cpp
@@ -28,8 +28,6 @@
 #include <sofa/core/collision/IntersectorFactory.h>
 #include <sofa/type/Mat.h>
 
-#include <SofaUserInteraction/RayContact.h>
-
 namespace sofa::component::collision
 {
 


### PR DESCRIPTION
On my end, never used, because never really worked this BarycentricStickContact response!
Now it is, and an example scene is provided.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
