### PR TITLE
[SofaMiscForcefield] Small optimization in addMdx in MeshMatrixMass

### DIFF
--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -1961,7 +1961,7 @@ void MeshMatrixMass<DataTypes, MassType>::addMDx(const core::MechanicalParams*, 
             res[e[0]] += dx[e[1]] * tempMass;
             res[e[1]] += dx[e[0]] * tempMass;
 
-            massTotal += 2*edgeMass[j] * Real(factor);
+            massTotal += 2 * tempMass;
         }
     }
 

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -1942,7 +1942,7 @@ void MeshMatrixMass<DataTypes, MassType>::addMDx(const core::MechanicalParams*, 
     else
     {
         size_t nbEdges=m_topology->getNbEdges();
-        size_t v0,v1;
+        const auto& edges = m_topology->getEdges();
 
         for (unsigned int i=0; i<dx.size(); i++)
         {
@@ -1954,13 +1954,12 @@ void MeshMatrixMass<DataTypes, MassType>::addMDx(const core::MechanicalParams*, 
 
         for (unsigned int j=0; j<nbEdges; ++j)
         {
+            const auto& e = edges[j];
+
             tempMass = edgeMass[j] * Real(factor);
 
-            v0=m_topology->getEdge(j)[0];
-            v1=m_topology->getEdge(j)[1];
-
-            res[v0] += dx[v1] * tempMass;
-            res[v1] += dx[v0] * tempMass;
+            res[e[0]] += dx[e[1]] * tempMass;
+            res[e[1]] += dx[e[0]] * tempMass;
 
             massTotal += 2*edgeMass[j] * Real(factor);
         }


### PR DESCRIPTION
getEdge() from EdgeSetTopologyContainer does bound-checking and the compiler cannot really optimize that.
EDIT: and moreover, getNbEdges() (edges, etc) used in the getEdge is extremely non-optimized...

In a nutsheel, it is much faster to do
```
const auto& edges = topo.getEdges();
for(const auto& e : edges) 
{ 
    blabla(e);
}
```
than
```
for(auto i = 0; i < topo.getNbEdges() ; i++) 
{ 
    blabla(topo.getEdge(i));
}
```

Some idea to keep the getEdge() (and others) would be either to remove the bound-check (maybe enable only in debug like std::vector), or do an unsafe version.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
