### PR TITLE
[SofaBaseMechanics] Use directly clear() when resetting force in MechanicalObject

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/MechanicalObject.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/MechanicalObject.inl
@@ -2515,7 +2515,7 @@ void MechanicalObject<DataTypes>::resetForce(const core::ExecParams* params, cor
     {
         helper::WriteOnlyAccessor< Data<VecDeriv> > f( *this->write(fid) );
         for (unsigned i = 0; i < f.size(); ++i)
-            f[i] = Deriv();
+            f[i].clear();
     }
 }
 


### PR DESCRIPTION
...instead of assign operator + defaultconstructor (which in fine do the same clear() function)

Micro optimization but still 😗
(nice french idiom for that: "ça ne mange pas de pain")

(on examples/Components/DiagonalMass.scn)
Before:
![Capture1](https://user-images.githubusercontent.com/11028016/144096997-260f4c68-2784-4b9a-a71b-869ad5536567.PNG)
After:
![Capture2](https://user-images.githubusercontent.com/11028016/144097259-7a1640be-2697-47d3-a94a-2fa73b84a002.PNG)

_______________________________________


By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
