### PR TITLE
[SofaCore] Required data msg now depends on existing default value

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
@@ -235,6 +235,8 @@ public:
     /// This method should not be called directly, the %Data registration methods in Base should be used instead.
     void setName(const std::string& name) { m_name=name; }
 
+    /// Return whether the Data has a default value or not
+    bool hasDefaultValue() const { return m_hasDefaultValue; }
 
     /// @name Optimized edition and retrieval API (for multi-threading performances)
     /// @{
@@ -244,10 +246,6 @@ public:
     SOFA_ATTRIBUTE_DEPRECATED__ASPECT_EXECPARAMS()
     bool isSet(const core::ExecParams*) const { return isSet(); }
     bool isSet() const { return m_isSet; }
-
-    /// Return whether the Data has a default value or not
-    bool hasDefaultValue() const { return m_hasDefaultValue; }
-    /// @}
 
     /// Reset the isSet flag to false, to indicate that the current value is the default for this %Data.
     SOFA_ATTRIBUTE_DEPRECATED__ASPECT_EXECPARAMS()

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseData.h
@@ -245,6 +245,10 @@ public:
     bool isSet(const core::ExecParams*) const { return isSet(); }
     bool isSet() const { return m_isSet; }
 
+    /// Return whether the Data has a default value or not
+    bool hasDefaultValue() const { return m_hasDefaultValue; }
+    /// @}
+
     /// Reset the isSet flag to false, to indicate that the current value is the default for this %Data.
     SOFA_ATTRIBUTE_DEPRECATED__ASPECT_EXECPARAMS()
     void unset(const core::ExecParams*) { unset(); }
@@ -306,6 +310,8 @@ public:
     Base* m_owner {nullptr};
     /// Data name within the Base component
     std::string m_name;
+    /// True if this %Data has a default value
+    bool m_hasDefaultValue = false;
 
     /// Parent Data
     DataLink<BaseData> parentData;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.cpp
@@ -256,7 +256,14 @@ void BaseObject::init()
     {
         if (data->isRequired() && !data->isSet())
         {
-            msg_error() << "Required data \"" << data->getName() << "\" has not been set. (Current value is " << data->getValueString() << ")" ;
+            if(data->hasDefaultValue())
+            {
+                msg_warning() << "Required data \"" << data->getName() << "\" has not been set. (Current value is " << data->getValueString() << ")" ;
+            }
+            else
+            {
+                msg_error() << "Required data \"" << data->getName() << "\" has not been set. It must be set since it has no default value." ;
+            }
         }
     }
 }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.cpp
@@ -258,7 +258,7 @@ void BaseObject::init()
         {
             if(data->hasDefaultValue())
             {
-                msg_warning() << "Required data \"" << data->getName() << "\" has not been set. (Current value is " << data->getValueString() << ")" ;
+                msg_warning() << "Required data \"" << data->getName() << "\" has not been set. Falling back to default value: " << data->getValueString();
             }
             else
             {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Data.h
@@ -113,6 +113,7 @@ public:
     explicit Data(const InitData& init) : BaseData(init)
     {
         m_value = ValueType(init.value);
+        m_hasDefaultValue = true;
     }
 
     /** \copydoc BaseData(const char*, bool, bool) */

--- a/modules/SofaMiscFem/SofaMiscFem_test/TriangleFEMForceField_test.cpp
+++ b/modules/SofaMiscFem/SofaMiscFem_test/TriangleFEMForceField_test.cpp
@@ -267,7 +267,7 @@ public:
             createObject(m_root, "TriangularFEMForceField");
         }
 
-        EXPECT_MSG_EMIT(Error);
+        EXPECT_MSG_EMIT(Warning);
 
         /// Init simulation
         sofa::simulation::getSimulation()->init(m_root.get());


### PR DESCRIPTION
Now the messaging when required data is not set by the user:

- either a warning is sent if a default value is available in the associated class constructor
- or an error is sent no a default value exists



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
