### PR TITLE
[CMake] Remove option SOFA_ENABLE_SOFT_DEPS_TO_SOFAPYTHON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,10 +175,6 @@ endif()
 ### Ninja build pools
 option(SOFA_NINJA_BUILD_POOLS "Activate the Ninja build pools feature, to limit the cores used by specific targets" OFF)
 
-# This option is useful to compile SOFA + internal plugins without SofaPython soft dependencies (Compliant, image, ...)
-# it simplifies binaries generation and cohabitation between SofaPython and SofaPython3
-option(SOFA_ENABLE_SOFT_DEPS_TO_SOFAPYTHON "Enable all soft dependencies to SofaPython" ON)
-
 ### Extlibs
 add_subdirectory(extlibs)
 

--- a/applications/plugins/CMakeLists.txt
+++ b/applications/plugins/CMakeLists.txt
@@ -17,22 +17,10 @@ sofa_add_plugin(SofaDistanceGrid SofaDistanceGrid) # Depends on SofaMiscCollisio
 sofa_add_plugin(SofaImplicitField SofaImplicitField)
 sofa_add_plugin(MultiThreading MultiThreading)
 sofa_add_plugin(DiffusionSolver DiffusionSolver) # Depends on CImgPlugin
-
-if(SOFA_ENABLE_SOFT_DEPS_TO_SOFAPYTHON)
-    # Add SofaPython BEFORE image and Compliant to enable their soft dependency
-    sofa_add_plugin_external(SofaPython SofaPython)
-endif()
-
-sofa_add_plugin(image image)           # Depends on CImgPlugin, DiffusionSolver, MultiThreading (soft)
+sofa_add_plugin_external(SofaPython SofaPython)
+sofa_add_plugin(image image) # Depends on CImgPlugin, DiffusionSolver, MultiThreading (soft)
 sofa_add_plugin_external(Compliant Compliant)
-
-if(NOT SOFA_ENABLE_SOFT_DEPS_TO_SOFAPYTHON)
-    # Add SofaPython AFTER image and Compliant to disable their soft dependency
-    sofa_add_plugin(SofaPython SofaPython)
-endif()
-
 sofa_add_subdirectory_external(SofaPython3 SofaPython3)
-
 sofa_add_plugin_external(CGALPlugin CGALPlugin) # Depends on image
 sofa_add_plugin_external(Flexible Flexible)     # Depends on image, CImgPlugin, SofaHighOrderTopology (soft)
 sofa_add_plugin(Registration Registration) # Depends on image, SofaPython, SofaSimpleGUI and #SOFADISTANCEGRID


### PR DESCRIPTION
Not needed anymore as SofaPython has been discontinued.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
