### PR TITLE
[SofaSimpleFem] Add regression tests for tetra FEM assembled and plasticity

### DIFF
--- a/examples/Components/forcefield/TetrahedronFEMForceField_assemble.scn
+++ b/examples/Components/forcefield/TetrahedronFEMForceField_assemble.scn
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<Node name="root" dt="0.01" gravity="0 -9 0">
+    <RequiredPlugin name="SofaBoundaryCondition"/>
+    <RequiredPlugin name="SofaEngine"/>
+    <RequiredPlugin name="SofaImplicitOdeSolver"/>
+    <RequiredPlugin name="SofaSimpleFem"/>
+    <RequiredPlugin name="SofaTopologyMapping"/>
+
+    <VisualStyle displayFlags="showBehaviorModels showForceFields" />
+    
+    <Node name="BeamFEM_SMALL">
+        <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9"/>
+        
+        <RegularGridTopology name="grid" min="-5 -5 0" max="5 5 40" n="5 5 20"/>
+        <MechanicalObject template="Vec3d" />
+        
+        <TetrahedronSetTopologyContainer name="Tetra_topo"/>
+        <TetrahedronSetTopologyModifier name="Modifier" />
+        <TetrahedronSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
+        <Hexa2TetraTopologicalMapping input="@grid" output="@Tetra_topo" />
+        
+        <DiagonalMass massDensity="0.2" />
+        <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.4" computeGlobalMatrix="true"
+        method="small" computeVonMisesStress="2" showVonMisesStressPerElement="true"/>
+        
+        <BoxROI template="Vec3d" name="box_roi" box="-6 -6 -1 50 6 0.1" drawBoxes="1" />
+        <FixedConstraint template="Vec3d" indices="@box_roi.indices" />
+    </Node>
+
+    
+    <Node name="BeamFEM_LARGE">
+        <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
+        
+        <RegularGridTopology name="grid" min="-5 -5 0" max="5 5 40" n="5 5 20"/>
+        <MechanicalObject template="Vec3d" translation="11 0 0"/>
+        
+        <TetrahedronSetTopologyContainer name="Tetra_topo"/>
+        <TetrahedronSetTopologyModifier name="Modifier" />
+        <TetrahedronSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
+        <Hexa2TetraTopologicalMapping input="@grid" output="@Tetra_topo" />
+        
+        <DiagonalMass massDensity="0.2" />
+        <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.4" computeGlobalMatrix="true"
+        method="large" computeVonMisesStress="1" showVonMisesStressPerElement="true"/>
+        
+        <BoxROI template="Vec3d" name="box_roi" box="-6 -6 -1 50 6 0.1" drawBoxes="1" />
+        <FixedConstraint template="Vec3d" indices="@box_roi.indices" />
+    </Node>
+
+</Node>

--- a/examples/RegressionStateScenes.regression-tests
+++ b/examples/RegressionStateScenes.regression-tests
@@ -23,6 +23,8 @@ Components/forcefield/MeshSpringForceField.scn 300 1e-4 0 1
 Components/forcefield/QuadBendingFEMForceField.scn 300 1e-4 0 1
 Components/forcefield/TetrahedralCorotationalFEMForceField.scn 300 1e-4 0 1
 Components/forcefield/TetrahedronFEMForceField.scn 300 1e-4 0 1
+Components/forcefield/TetrahedronFEMForceField_assemble.scn 300 1e-4 0 1
+Components/forcefield/TetrahedronFEMForceField_plasticity.scn 300 1e-4 0 1
 Components/forcefield/TetrahedronHyperelasticityFEMForceField.scn 100 1e-4 0 1
 Components/forcefield/TriangularFEMForceFieldOptim.scn 100 1e-4 0 1
 Components/interactionforcefield/InteractionEllipsoidForceField.scn 100 1e-4 0 1


### PR DESCRIPTION
[ci-depends-on https://github.com/sofa-framework/Regression/pull/22]

- One existing scene is added to the list of regression tests (`Components/forcefield/TetrahedronFEMForceField_plasticity.scn`)
- One scene is introduced (`Components/forcefield/TetrahedronFEMForceField_assemble.scn`) so it is also added to the regression tests. The scene is the same than `Components/forcefield/TetrahedronFEMForceField.scn` except that the data `computeGlobalMatrix` from `TetrahedronFEMForceField` is set to `true`. Only methods `large` and `small` are introduced. The others don't support `computeGlobalMatrix=true`





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
