### PR TITLE
[Core] Fix ObjectFactory::getEntriesFromTarget that returns duplicated names

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/ObjectFactory.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/ObjectFactory.cpp
@@ -389,7 +389,10 @@ void ObjectFactory::getEntriesFromTarget(std::vector<ClassEntry::SPtr>& result, 
             {
                 Creator::SPtr c = itc->second;
                 if (target == c->getTarget())
+                {
                     inTarget = true;
+                    break;
+                }
             }
             if (inTarget)
                 result.push_back(entry);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/ObjectFactory.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/ObjectFactory.cpp
@@ -376,20 +376,25 @@ void ObjectFactory::getAllEntries(std::vector<ClassEntry::SPtr>& result)
 
 void ObjectFactory::getEntriesFromTarget(std::vector<ClassEntry::SPtr>& result, std::string target)
 {
+    // The map is used to select the aliases only once.
     result.clear();
     for(ClassEntryMap::iterator it = registry.begin(), itEnd = registry.end();
         it != itEnd; ++it)
     {
         ClassEntry::SPtr entry = it->second;
-        bool inTarget = false;
-        for (CreatorMap::iterator itc = entry->creatorMap.begin(), itcend = entry->creatorMap.end(); itc != itcend; ++itc)
+        if(entry->className == it->first)
         {
-            Creator::SPtr c = itc->second;
-            if (target == c->getTarget())
-                inTarget = true;
+
+            bool inTarget = false;
+            for (CreatorMap::iterator itc = entry->creatorMap.begin(), itcend = entry->creatorMap.end(); itc != itcend; ++itc)
+            {
+                Creator::SPtr c = itc->second;
+                if (target == c->getTarget())
+                    inTarget = true;
+            }
+            if (inTarget)
+                result.push_back(entry);
         }
-        if (inTarget)
-            result.push_back(entry);
     }
 }
 
@@ -441,12 +446,12 @@ static std::string xmlencode(const std::string& str)
     {
         switch(str[i])
         {
-            case '<': res += "&lt;"; break;
-            case '>': res += "&gt;"; break;
-            case '&': res += "&amp;"; break;
-            case '"': res += "&quot;"; break;
-            case '\'': res += "&apos;"; break;
-            default:  res += str[i];
+        case '<': res += "&lt;"; break;
+        case '>': res += "&gt;"; break;
+        case '&': res += "&amp;"; break;
+        case '"': res += "&quot;"; break;
+        case '\'': res += "&apos;"; break;
+        default:  res += str[i];
         }
     }
     return res;

--- a/SofaKernel/modules/SofaCore/src/sofa/core/ObjectFactory.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/ObjectFactory.cpp
@@ -376,7 +376,6 @@ void ObjectFactory::getAllEntries(std::vector<ClassEntry::SPtr>& result)
 
 void ObjectFactory::getEntriesFromTarget(std::vector<ClassEntry::SPtr>& result, std::string target)
 {
-    // The map is used to select the aliases only once.
     result.clear();
     for(ClassEntryMap::iterator it = registry.begin(), itEnd = registry.end();
         it != itEnd; ++it)


### PR DESCRIPTION
Because of aliases. 
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
