### PR TITLE
[SofaSimpleFem] Refactor TetrahedronFEMForceField for better readability

### DIFF
--- a/SofaKernel/modules/SofaSimpleFem/CMakeLists.txt
+++ b/SofaKernel/modules/SofaSimpleFem/CMakeLists.txt
@@ -13,6 +13,23 @@ set(HEADER_FILES
     ${SOFASIMPLEFEM_SRC}/TetrahedronFEMForceField.inl
     ${SOFASIMPLEFEM_SRC}/TetrahedronDiffusionFEMForceField.h
     ${SOFASIMPLEFEM_SRC}/TetrahedronDiffusionFEMForceField.inl
+
+    ${SOFASIMPLEFEM_SRC}/TetrahedronFEMForceFieldImpl.h
+
+    ${SOFASIMPLEFEM_SRC}/TetrahedronFEMForceFieldImplSmall.h
+    ${SOFASIMPLEFEM_SRC}/TetrahedronFEMForceFieldImplSmall.inl
+
+    ${SOFASIMPLEFEM_SRC}/TetrahedronFEMForceFieldImplCorotational.h
+    ${SOFASIMPLEFEM_SRC}/TetrahedronFEMForceFieldImplCorotational.inl
+
+    ${SOFASIMPLEFEM_SRC}/TetrahedronFEMForceFieldImplLarge.h
+    ${SOFASIMPLEFEM_SRC}/TetrahedronFEMForceFieldImplLarge.inl
+
+    ${SOFASIMPLEFEM_SRC}/TetrahedronFEMForceFieldImplPolar.h
+    ${SOFASIMPLEFEM_SRC}/TetrahedronFEMForceFieldImplPolar.inl
+
+    ${SOFASIMPLEFEM_SRC}/TetrahedronFEMForceFieldImplSVD.h
+    ${SOFASIMPLEFEM_SRC}/TetrahedronFEMForceFieldImplSVD.inl
 )
 
 set(SOURCE_FILES

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.h
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceField.h
@@ -23,6 +23,7 @@
 #include <SofaSimpleFem/fwd.h>
 
 #include <sofa/core/behavior/ForceField.h>
+#include <SofaSimpleFem/TetrahedronFEMForceFieldImpl.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/type/vector.h>
 #include <sofa/defaulttype/VecTypes.h>
@@ -100,6 +101,9 @@ public:
          };
 
 protected:
+
+    std::unique_ptr<TetrahedronFEMForceFieldImpl<DataTypes> > m_impl { nullptr };
+    void createImplementor();
 
     /// @name Per element (tetrahedron) data
     /// @{
@@ -274,41 +278,12 @@ public:
     virtual void computeMaterialStiffness(MaterialStiffness& materialMatrix, Index&a, Index&b, Index&c, Index&d);
 
 protected:
-    void computeStrainDisplacement( StrainDisplacement &J, Coord a, Coord b, Coord c, Coord d );
-    Real peudo_determinant_for_coef ( const type::Mat<2, 3, Real>&  M );
+    type::vector<Transformation> _initialRotations;
+    type::vector<unsigned int> _rotationIdx;
 
     void computeStiffnessMatrix( StiffnessMatrix& S,StiffnessMatrix& SR,const MaterialStiffness &K, const StrainDisplacement &J, const Transformation& Rot );
 
-    virtual void computeMaterialStiffness(Index i, Index&a, Index&b, Index&c, Index&d);
-
-
-    void computeForce( Displacement &F, const Displacement &Depl, VoigtTensor &plasticStrain, const MaterialStiffness &K, const StrainDisplacement &J );
-    void computeForce( Displacement &F, const Displacement &Depl, const MaterialStiffness &K, const StrainDisplacement &J, SReal fact );
-
-
-    ////////////// small displacements method
-    void initSmall(Index i, Index&a, Index&b, Index&c, Index&d);
-    void accumulateForceSmall( Vector& f, const Vector & p, typename VecElement::const_iterator elementIt, Index elementIndex );
-    void applyStiffnessSmall( Vector& f, const Vector& x, Index i=0, Index a=0,Index b=1,Index c=2,Index d=3, SReal fact=1.0  );
-
-    ////////////// large displacements method
-    type::vector<type::fixed_array<Coord,4> > _rotatedInitialElements;   ///< The initials positions in its frame
-    type::vector<Transformation> _initialRotations;
-    void initLarge(Index i, Index&a, Index&b, Index&c, Index&d);
-    void computeRotationLarge( Transformation &r, const Vector &p, const Index &a, const Index &b, const Index &c);
-    void accumulateForceLarge( Vector& f, const Vector & p, typename VecElement::const_iterator elementIt, Index elementIndex );
-
-    ////////////// polar decomposition method
-    type::vector<unsigned int> _rotationIdx;
-    void initPolar(Index i, Index&a, Index&b, Index&c, Index&d);
-    void accumulateForcePolar( Vector& f, const Vector & p, typename VecElement::const_iterator elementIt, Index elementIndex );
-
-    ////////////// svd decomposition method
-    type::vector<Transformation>  _initialTransformation;
-    void initSVD(Index i, Index&a, Index&b, Index&c, Index&d);
-    void accumulateForceSVD( Vector& f, const Vector & p, typename VecElement::const_iterator elementIt, Index elementIndex );
-
-    void applyStiffnessCorotational( Vector& f, const Vector& x, Index i=0, Index a=0,Index b=1,Index c=2,Index d=3, SReal fact=1.0  );
+    virtual void computeMaterialStiffness(Index i, Index a, Index b, Index c, Index d);
 
     void handleTopologyChange() override { needUpdateTopology = true; }
 

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImpl.h
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImpl.h
@@ -1,0 +1,414 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <sofa/core/topology/BaseMeshTopology.h>
+#include <SofaSimpleFem/config.h>
+
+namespace sofa::component::forcefield
+{
+
+template<class DataTypes>
+class TetrahedronFEMForceFieldImpl
+{
+public:
+    using Coord    = typename DataTypes::Coord;
+    using Deriv    = typename DataTypes::Deriv;
+    using Real     = typename Coord::value_type;
+    using VecCoord = typename DataTypes::VecCoord;
+    using VecDeriv = typename DataTypes::VecDeriv;
+
+    using Element    = sofa::core::topology::BaseMeshTopology::Tetra;
+    using VecElement = sofa::core::topology::BaseMeshTopology::SeqTetrahedra;
+
+    using Force              = sofa::type::VecNoInit<12, Real>;
+    using Displacement       = sofa::type::VecNoInit<12, Real>;
+    using VoigtTensor        = sofa::type::VecNoInit< 6, Real>;
+    using MaterialStiffness  = sofa::type::Mat      < 6,  6, Real>;
+    using StrainDisplacement = sofa::type::Mat      <12,  6, Real>;
+    using StiffnessMatrix    = sofa::type::Mat      <12, 12, Real>;
+    using Transformation     = sofa::type::MatNoInit< 3,  3, Real>;
+
+    using VecStrainDisplacement = sofa::type::vector<StrainDisplacement>;
+    using VecMaterialStiffness  = sofa::type::vector<MaterialStiffness>;
+
+    typedef std::pair<Index,Real> Col_Value;
+    typedef type::vector< Col_Value > CompressedValue;
+    typedef type::vector< CompressedValue > CompressedMatrix;
+
+    struct PlasticityParameters
+    {
+        Real maxThreshold;
+        Real yieldThreshold;
+        Real creep;
+
+        bool hasPlasticity() const
+        {
+            return maxThreshold > static_cast<Real>(0);
+        }
+    } m_plasticity;
+
+    bool m_assemble { false };
+
+    struct FiniteElementArrays
+    {
+        /// Input
+        ///@{
+        const VecElement* elements      { nullptr };
+        const VecCoord*   initialPoints { nullptr };
+        const VecCoord*   positions     { nullptr };
+        const VecDeriv*   dx            { nullptr };
+        ///@}
+
+        /// Output
+        ///@{
+        VecDeriv*                        force                { nullptr };
+        VecDeriv*                        dForce               { nullptr };
+        VecStrainDisplacement*           strainDisplacements  { nullptr };
+        sofa::type::vector<VoigtTensor>* plasticStrains       { nullptr };
+        VecMaterialStiffness*            materialsStiffnesses { nullptr };
+        CompressedMatrix*                stiffnesses          { nullptr };
+        ///@}
+    };
+
+    virtual ~TetrahedronFEMForceFieldImpl() = default;
+
+    virtual void init(const FiniteElementArrays& finiteElementArrays) = 0;
+    virtual void addForce(const FiniteElementArrays& finiteElementArrays) = 0;
+    virtual void addDForce(const FiniteElementArrays& finiteElementArrays, Real kFactor) = 0;
+
+    virtual Displacement getDisplacement(const VecCoord& positions, const Element& element, const unsigned elementIndex) const
+    {
+        return {};
+    }
+
+    virtual Transformation getRotation(const unsigned int elementIndex) const
+    {
+        Transformation identity;
+        identity.identity();
+        return identity;
+    }
+
+    void initStiffnesses(const FiniteElementArrays& finiteElementArrays)
+    {
+        if (finiteElementArrays.stiffnesses)
+        {
+            if (finiteElementArrays.initialPoints)
+            {
+                finiteElementArrays.stiffnesses->resize( finiteElementArrays.initialPoints->size() * 3);
+            }
+            for (auto& s : *finiteElementArrays.stiffnesses)
+            {
+                s.clear();
+            }
+        }
+    }
+
+    static void copyForceFromElementToGlobal(VecCoord& globalForceVector, const Force& elementForce, const Element& element)
+    {
+        globalForceVector[element[0]] += Deriv( elementForce[0], elementForce[ 1], elementForce[ 2] );
+        globalForceVector[element[1]] += Deriv( elementForce[3], elementForce[ 4], elementForce[ 5] );
+        globalForceVector[element[2]] += Deriv( elementForce[6], elementForce[ 7], elementForce[ 8] );
+        globalForceVector[element[3]] += Deriv( elementForce[9], elementForce[10], elementForce[11] );
+    }
+
+    static void copyForceFromElementToGlobal(VecCoord& globalForceVector, const Force& elementForce, const Element& element, const Transformation& rotation)
+    {
+        // globalForceVector[element[0]] += rotation * Deriv( elementForce[0], elementForce[ 1], elementForce[ 2] );
+        // globalForceVector[element[1]] += rotation * Deriv( elementForce[3], elementForce[ 4], elementForce[ 5] );
+        // globalForceVector[element[2]] += rotation * Deriv( elementForce[6], elementForce[ 7], elementForce[ 8] );
+        // globalForceVector[element[3]] += rotation * Deriv( elementForce[9], elementForce[10], elementForce[11] );
+
+        auto& fa = globalForceVector[element[0]];
+        auto& fb = globalForceVector[element[1]];
+        auto& fc = globalForceVector[element[2]];
+        auto& fd = globalForceVector[element[3]];
+
+        fa[0] += rotation[0][0] *  elementForce[0] +  rotation[0][1] * elementForce[1]  + rotation[0][2] * elementForce[2];
+        fa[1] += rotation[1][0] *  elementForce[0] +  rotation[1][1] * elementForce[1]  + rotation[1][2] * elementForce[2];
+        fa[2] += rotation[2][0] *  elementForce[0] +  rotation[2][1] * elementForce[1]  + rotation[2][2] * elementForce[2];
+
+        fb[0] += rotation[0][0] *  elementForce[3] +  rotation[0][1] * elementForce[4]  + rotation[0][2] * elementForce[5];
+        fb[1] += rotation[1][0] *  elementForce[3] +  rotation[1][1] * elementForce[4]  + rotation[1][2] * elementForce[5];
+        fb[2] += rotation[2][0] *  elementForce[3] +  rotation[2][1] * elementForce[4]  + rotation[2][2] * elementForce[5];
+
+        fc[0] += rotation[0][0] *  elementForce[6] +  rotation[0][1] * elementForce[7]  + rotation[0][2] * elementForce[8];
+        fc[1] += rotation[1][0] *  elementForce[6] +  rotation[1][1] * elementForce[7]  + rotation[1][2] * elementForce[8];
+        fc[2] += rotation[2][0] *  elementForce[6] +  rotation[2][1] * elementForce[7]  + rotation[2][2] * elementForce[8];
+
+        fd[0] += rotation[0][0] *  elementForce[9] +  rotation[0][1] * elementForce[10] + rotation[0][2] * elementForce[11];
+        fd[1] += rotation[1][0] *  elementForce[9] +  rotation[1][1] * elementForce[10] + rotation[1][2] * elementForce[11];
+        fd[2] += rotation[2][0] *  elementForce[9] +  rotation[2][1] * elementForce[10] + rotation[2][2] * elementForce[11];
+
+    }
+
+    static StrainDisplacement computeStrainDisplacement(const Coord& a, const Coord& b, const Coord& c, const Coord& d)
+    {
+        StrainDisplacement J;
+
+        // shape functions matrix
+        type::Mat<2, 3, Real> M;
+
+        const auto peudo_determinant_for_coef = [](const type::Mat<2, 3, Real>& M)
+        {
+            return  M[0][1]*M[1][2] - M[1][1]*M[0][2] -  M[0][0]*M[1][2] + M[1][0]*M[0][2] + M[0][0]*M[1][1] - M[1][0]*M[0][1];
+        };
+
+        M[0][0] = b[1];
+        M[0][1] = c[1];
+        M[0][2] = d[1];
+        M[1][0] = b[2];
+        M[1][1] = c[2];
+        M[1][2] = d[2];
+        J[0][0] = J[1][3] = J[2][5]   = - peudo_determinant_for_coef( M );
+        M[0][0] = b[0];
+        M[0][1] = c[0];
+        M[0][2] = d[0];
+        J[0][3] = J[1][1] = J[2][4]   = peudo_determinant_for_coef( M );
+        M[1][0] = b[1];
+        M[1][1] = c[1];
+        M[1][2] = d[1];
+        J[0][5] = J[1][4] = J[2][2]   = - peudo_determinant_for_coef( M );
+
+        M[0][0] = c[1];
+        M[0][1] = d[1];
+        M[0][2] = a[1];
+        M[1][0] = c[2];
+        M[1][1] = d[2];
+        M[1][2] = a[2];
+        J[3][0] = J[4][3] = J[5][5]   = peudo_determinant_for_coef( M );
+        M[0][0] = c[0];
+        M[0][1] = d[0];
+        M[0][2] = a[0];
+        J[3][3] = J[4][1] = J[5][4]   = - peudo_determinant_for_coef( M );
+        M[1][0] = c[1];
+        M[1][1] = d[1];
+        M[1][2] = a[1];
+        J[3][5] = J[4][4] = J[5][2]   = peudo_determinant_for_coef( M );
+
+        M[0][0] = d[1];
+        M[0][1] = a[1];
+        M[0][2] = b[1];
+        M[1][0] = d[2];
+        M[1][1] = a[2];
+        M[1][2] = b[2];
+        J[6][0] = J[7][3] = J[8][5]   = - peudo_determinant_for_coef( M );
+        M[0][0] = d[0];
+        M[0][1] = a[0];
+        M[0][2] = b[0];
+        J[6][3] = J[7][1] = J[8][4]   = peudo_determinant_for_coef( M );
+        M[1][0] = d[1];
+        M[1][1] = a[1];
+        M[1][2] = b[1];
+        J[6][5] = J[7][4] = J[8][2]   = - peudo_determinant_for_coef( M );
+
+        M[0][0] = a[1];
+        M[0][1] = b[1];
+        M[0][2] = c[1];
+        M[1][0] = a[2];
+        M[1][1] = b[2];
+        M[1][2] = c[2];
+        J[9][0] = J[10][3] = J[11][5]   = peudo_determinant_for_coef( M );
+        M[0][0] = a[0];
+        M[0][1] = b[0];
+        M[0][2] = c[0];
+        J[9][3] = J[10][1] = J[11][4]   = - peudo_determinant_for_coef( M );
+        M[1][0] = a[1];
+        M[1][1] = b[1];
+        M[1][2] = c[1];
+        J[9][5] = J[10][4] = J[11][2]   = peudo_determinant_for_coef( M );
+
+        return J;
+    }
+
+    static void computeElasticJtD(VoigtTensor& JtD, const StrainDisplacement &J, const Displacement &Depl)
+    {
+        JtD[0] =   J[ 0][0]*Depl[ 0]+/*J[ 1][0]*Depl[ 1]+  J[ 2][0]*Depl[ 2]+*/
+                   J[ 3][0]*Depl[ 3]+/*J[ 4][0]*Depl[ 4]+  J[ 5][0]*Depl[ 5]+*/
+                   J[ 6][0]*Depl[ 6]+/*J[ 7][0]*Depl[ 7]+  J[ 8][0]*Depl[ 8]+*/
+                   J[ 9][0]*Depl[ 9] /*J[10][0]*Depl[10]+  J[11][0]*Depl[11]*/;
+        JtD[1] = /*J[ 0][1]*Depl[ 0]+*/J[ 1][1]*Depl[ 1]+/*J[ 2][1]*Depl[ 2]+*/
+                 /*J[ 3][1]*Depl[ 3]+*/J[ 4][1]*Depl[ 4]+/*J[ 5][1]*Depl[ 5]+*/
+                 /*J[ 6][1]*Depl[ 6]+*/J[ 7][1]*Depl[ 7]+/*J[ 8][1]*Depl[ 8]+*/
+                 /*J[ 9][1]*Depl[ 9]+*/J[10][1]*Depl[10] /*J[11][1]*Depl[11]*/;
+        JtD[2] = /*J[ 0][2]*Depl[ 0]+  J[ 1][2]*Depl[ 1]+*/J[ 2][2]*Depl[ 2]+
+                 /*J[ 3][2]*Depl[ 3]+  J[ 4][2]*Depl[ 4]+*/J[ 5][2]*Depl[ 5]+
+                 /*J[ 6][2]*Depl[ 6]+  J[ 7][2]*Depl[ 7]+*/J[ 8][2]*Depl[ 8]+
+                 /*J[ 9][2]*Depl[ 9]+  J[10][2]*Depl[10]+*/J[11][2]*Depl[11]  ;
+        JtD[3] =   J[ 0][3]*Depl[ 0]+  J[ 1][3]*Depl[ 1]+/*J[ 2][3]*Depl[ 2]+*/
+                   J[ 3][3]*Depl[ 3]+  J[ 4][3]*Depl[ 4]+/*J[ 5][3]*Depl[ 5]+*/
+                   J[ 6][3]*Depl[ 6]+  J[ 7][3]*Depl[ 7]+/*J[ 8][3]*Depl[ 8]+*/
+                   J[ 9][3]*Depl[ 9]+  J[10][3]*Depl[10] /*J[11][3]*Depl[11]*/;
+        JtD[4] = /*J[ 0][4]*Depl[ 0]+*/J[ 1][4]*Depl[ 1]+  J[ 2][4]*Depl[ 2]+
+                 /*J[ 3][4]*Depl[ 3]+*/J[ 4][4]*Depl[ 4]+  J[ 5][4]*Depl[ 5]+
+                 /*J[ 6][4]*Depl[ 6]+*/J[ 7][4]*Depl[ 7]+  J[ 8][4]*Depl[ 8]+
+                 /*J[ 9][4]*Depl[ 9]+*/J[10][4]*Depl[10]+  J[11][4]*Depl[11]  ;
+        JtD[5] =   J[ 0][5]*Depl[ 0]+/*J[ 1][5]*Depl[ 1]*/ J[ 2][5]*Depl[ 2]+
+                   J[ 3][5]*Depl[ 3]+/*J[ 4][5]*Depl[ 4]*/ J[ 5][5]*Depl[ 5]+
+                   J[ 6][5]*Depl[ 6]+/*J[ 7][5]*Depl[ 7]*/ J[ 8][5]*Depl[ 8]+
+                   J[ 9][5]*Depl[ 9]+/*J[10][5]*Depl[10]*/ J[11][5]*Depl[11];
+    }
+
+    static void computePlasticJtD(VoigtTensor& JtD, VoigtTensor& plasticStrain, const PlasticityParameters& plasticity)
+    {
+        VoigtTensor elasticStrain = JtD; // JtD is the total strain
+        elasticStrain -= plasticStrain; // totalStrain = elasticStrain + plasticStrain
+
+        if( elasticStrain.norm2() > plasticity.yieldThreshold * plasticity.yieldThreshold )
+        {
+            plasticStrain += plasticity.creep * elasticStrain;
+        }
+
+        const Real plasticStrainNorm2 = plasticStrain.norm2();
+        if( plasticStrainNorm2 > plasticity.maxThreshold * plasticity.maxThreshold )
+        {
+            plasticStrain *= plasticity.maxThreshold / helper::rsqrt( plasticStrainNorm2 );
+        }
+
+        // remaining elasticStrain = totatStrain - plasticStrain
+        JtD -= plasticStrain;
+    }
+
+    static void computeKJtD(VoigtTensor& KJtD, const MaterialStiffness& K, const VoigtTensor& JtD)
+    {
+        KJtD[0] =   K[0][0]*JtD[0]+  K[0][1]*JtD[1]+  K[0][2]*JtD[2]
+                  /*K[0][3]*JtD[3]+  K[0][4]*JtD[4]+  K[0][5]*JtD[5]*/;
+        KJtD[1] =   K[1][0]*JtD[0]+  K[1][1]*JtD[1]+  K[1][2]*JtD[2]
+                  /*K[1][3]*JtD[3]+  K[1][4]*JtD[4]+  K[1][5]*JtD[5]*/;
+        KJtD[2] =   K[2][0]*JtD[0]+  K[2][1]*JtD[1]+  K[2][2]*JtD[2]
+                  /*K[2][3]*JtD[3]+  K[2][4]*JtD[4]+  K[2][5]*JtD[5]*/;
+        KJtD[3] = /*K[3][0]*JtD[0]+  K[3][1]*JtD[1]+  K[3][2]*JtD[2]+*/
+                    K[3][3]*JtD[3] /*K[3][4]*JtD[4]+  K[3][5]*JtD[5]*/;
+        KJtD[4] = /*K[4][0]*JtD[0]+  K[4][1]*JtD[1]+  K[4][2]*JtD[2]+*/
+                  /*K[4][3]*JtD[3]+*/K[4][4]*JtD[4] /*K[4][5]*JtD[5]*/;
+        KJtD[5] = /*K[5][0]*JtD[0]+  K[5][1]*JtD[1]+  K[5][2]*JtD[2]+*/
+                  /*K[5][3]*JtD[3]+  K[5][4]*JtD[4]+*/K[5][5]*JtD[5]  ;
+    }
+
+    static void computeJKJtD(Force& F, const StrainDisplacement &J, const VoigtTensor& KJtD)
+    {
+        F[ 0] =   J[ 0][0]*KJtD[0]+/*J[ 0][1]*KJtD[1]+  J[ 0][2]*KJtD[2]+*/
+                  J[ 0][3]*KJtD[3]+/*J[ 0][4]*KJtD[4]+*/J[ 0][5]*KJtD[5]  ;
+        F[ 1] = /*J[ 1][0]*KJtD[0]+*/J[ 1][1]*KJtD[1]+/*J[ 1][2]*KJtD[2]+*/
+                  J[ 1][3]*KJtD[3]+  J[ 1][4]*KJtD[4] /*J[ 1][5]*KJtD[5]*/;
+        F[ 2] = /*J[ 2][0]*KJtD[0]+  J[ 2][1]*KJtD[1]+*/J[ 2][2]*KJtD[2]+
+                /*J[ 2][3]*KJtD[3]+*/J[ 2][4]*KJtD[4]+  J[ 2][5]*KJtD[5]  ;
+        F[ 3] =   J[ 3][0]*KJtD[0]+/*J[ 3][1]*KJtD[1]+  J[ 3][2]*KJtD[2]+*/
+                  J[ 3][3]*KJtD[3]+/*J[ 3][4]*KJtD[4]+*/J[ 3][5]*KJtD[5]  ;
+        F[ 4] = /*J[ 4][0]*KJtD[0]+*/J[ 4][1]*KJtD[1]+/*J[ 4][2]*KJtD[2]+*/
+                  J[ 4][3]*KJtD[3]+  J[ 4][4]*KJtD[4] /*J[ 4][5]*KJtD[5]*/;
+        F[ 5] = /*J[ 5][0]*KJtD[0]+  J[ 5][1]*KJtD[1]+*/J[ 5][2]*KJtD[2]+
+                /*J[ 5][3]*KJtD[3]+*/J[ 5][4]*KJtD[4]+  J[ 5][5]*KJtD[5]  ;
+        F[ 6] =   J[ 6][0]*KJtD[0]+/*J[ 6][1]*KJtD[1]+  J[ 6][2]*KJtD[2]+*/
+                  J[ 6][3]*KJtD[3]+/*J[ 6][4]*KJtD[4]+*/J[ 6][5]*KJtD[5]  ;
+        F[ 7] = /*J[ 7][0]*KJtD[0]+*/J[ 7][1]*KJtD[1]+/*J[ 7][2]*KJtD[2]+*/
+                  J[ 7][3]*KJtD[3]+  J[ 7][4]*KJtD[4] /*J[ 7][5]*KJtD[5]*/;
+        F[ 8] = /*J[ 8][0]*KJtD[0]+  J[ 8][1]*KJtD[1]+*/J[ 8][2]*KJtD[2]+
+                /*J[ 8][3]*KJtD[3]+*/J[ 8][4]*KJtD[4]+  J[ 8][5]*KJtD[5]  ;
+        F[ 9] =   J[ 9][0]*KJtD[0]+/*J[ 9][1]*KJtD[1]+  J[ 9][2]*KJtD[2]+*/
+                  J[ 9][3]*KJtD[3]+/*J[ 9][4]*KJtD[4]+*/J[ 9][5]*KJtD[5]  ;
+        F[10] = /*J[10][0]*KJtD[0]+*/J[10][1]*KJtD[1]+/*J[10][2]*KJtD[2]+*/
+                  J[10][3]*KJtD[3]+  J[10][4]*KJtD[4] /*J[10][5]*KJtD[5]*/;
+        F[11] = /*J[11][0]*KJtD[0]+  J[11][1]*KJtD[1]+*/J[11][2]*KJtD[2]+
+                /*J[11][3]*KJtD[3]+*/J[11][4]*KJtD[4]+  J[11][5]*KJtD[5]  ;
+    }
+
+    /// Compute the force as the following product : (J * (K * (J^T * Depl)))
+    /// Note:Although (JKJ^T) is constant, it is faster to compute (J * (K * (J^T * Depl)))
+    /// than (A * Depl) where A = (JKJ^T) and has been pre-computed
+    static void computeForce(
+        Force& F,
+        const Displacement &Depl,
+        VoigtTensor &plasticStrain,
+        const MaterialStiffness &K,
+        const StrainDisplacement &J,
+        const PlasticityParameters& plasticity)
+    {
+        VoigtTensor JtD;
+        computeElasticJtD(JtD, J, Depl);
+
+        // eventually remove a part of the strain to simulate plasticity
+        if( plasticity.hasPlasticity() )
+        {
+            computePlasticJtD(JtD, plasticStrain, plasticity);
+        }
+
+        VoigtTensor KJtD;
+        computeKJtD(KJtD, K, JtD);
+        computeJKJtD(F, J, KJtD);
+    }
+
+    static void computeForce(
+        Force& F,
+        const Displacement &Depl,
+        const MaterialStiffness &K,
+        const StrainDisplacement &J)
+    {
+        VoigtTensor JtD;
+        computeElasticJtD(JtD, J, Depl);
+
+        VoigtTensor KJtD;
+        computeKJtD(KJtD, K, JtD);
+        computeJKJtD(F, J, KJtD);
+    }
+
+    virtual StiffnessMatrix computeStiffnessMatrix(const MaterialStiffness &K, const StrainDisplacement &J, const unsigned elementIndex) const
+    {
+        SOFA_UNUSED(elementIndex);
+        const auto Jt = J.transposed();
+        return J * K * Jt;
+    }
+
+    StiffnessMatrix assembleStiffnessMatrix(const FiniteElementArrays& finiteElementArrays, const Element& element,
+        const unsigned elementIndex)
+    {
+        const auto JKJt = computeStiffnessMatrix(
+            (*finiteElementArrays.materialsStiffnesses)[elementIndex],
+            (*finiteElementArrays.strainDisplacements)[elementIndex],
+            elementIndex);
+
+        for(int i = 0; i < 12; ++i)
+        {
+            const Index row = element[i/3] * 3 + i % 3;
+
+            for(int j = 0; j < 12; ++j)
+            {
+                if(JKJt[i][j] != 0)
+                {
+                    const Index col = element[j/3] * 3 + j % 3;
+                    // search if the vertex is already taken into account by another element
+                    auto& stiffnessRow = (*finiteElementArrays.stiffnesses)[row];
+                    auto result = std::find_if(stiffnessRow.begin(), stiffnessRow.end(),
+                                               [col](const auto& e){ return e.first == col;});
+
+                    if( result == stiffnessRow.end() )
+                        stiffnessRow.emplace_back( col, JKJt[i][j] );
+                    else
+                        result->second += JKJt[i][j];
+                }
+            }
+        }
+
+        return JKJt;
+    }
+};
+
+}

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplCorotational.h
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplCorotational.h
@@ -31,29 +31,29 @@ class TetrahedronFEMForceFieldImplCorotational : public TetrahedronFEMForceField
 public:
 
     using Inherit = TetrahedronFEMForceFieldImpl<DataTypes>;
-    using Inherit::Real;
-    using Inherit::Coord;
-    using Inherit::Deriv;
-    using Inherit::VecCoord;
-    using Inherit::VecDeriv;
-    using Inherit::Element;
-    using Inherit::VecElement;
-    using Inherit::Displacement;
-    using Inherit::MaterialStiffness;
-    using Inherit::StrainDisplacement;
-    using Inherit::VecStrainDisplacement;
-    using Inherit::Force;
-    using Inherit::FiniteElementArrays;
-    using Inherit::Transformation;
-    using Inherit::StiffnessMatrix;
+    using typename Inherit::Real;
+    using typename Inherit::Coord;
+    using typename Inherit::Deriv;
+    using typename Inherit::VecCoord;
+    using typename Inherit::VecDeriv;
+    using typename Inherit::Element;
+    using typename Inherit::VecElement;
+    using typename Inherit::Displacement;
+    using typename Inherit::MaterialStiffness;
+    using typename Inherit::StrainDisplacement;
+    using typename Inherit::VecStrainDisplacement;
+    using typename Inherit::Force;
+    using typename Inherit::FiniteElementArrays;
+    using typename Inherit::Transformation;
+    using typename Inherit::StiffnessMatrix;
 
     void init(const FiniteElementArrays& finiteElementArrays) override;
     void addForce(const FiniteElementArrays& finiteElementArrays) override;
     void addDForce(const FiniteElementArrays& finiteElementArrays, Real kFactor) override;
 
-    Displacement getDisplacement(const VecCoord& positions, const Element& element, unsigned elementIndex) const override;
+    typename Inherit::Displacement getDisplacement(const VecCoord& positions, const Element& element, unsigned elementIndex) const override;
 
-    Transformation getRotation(const unsigned int elementIndex) const override
+    typename Inherit::Transformation getRotation(const unsigned int elementIndex) const override
     {
         return m_rotations[elementIndex];
     }
@@ -89,7 +89,7 @@ protected:
     virtual type::fixed_array<Coord,4>
     computeRotatedInitialElement(const Transformation& rotation, const Element& element, const VecCoord& initialPoints) const;
 
-    StiffnessMatrix computeStiffnessMatrix(const MaterialStiffness &K, const StrainDisplacement &J, unsigned elementIndex) const override;
+    typename Inherit::StiffnessMatrix computeStiffnessMatrix(const MaterialStiffness &K, const StrainDisplacement &J, unsigned elementIndex) const override;
 };
 
 }

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplCorotational.h
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplCorotational.h
@@ -1,0 +1,97 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <SofaSimpleFem/TetrahedronFEMForceFieldImpl.h>
+namespace sofa::component::forcefield
+{
+
+template<class DataTypes>
+class TetrahedronFEMForceFieldImplCorotational : public TetrahedronFEMForceFieldImpl<DataTypes>
+{
+public:
+
+    using Inherit = TetrahedronFEMForceFieldImpl<DataTypes>;
+    using Inherit::Real;
+    using Inherit::Coord;
+    using Inherit::Deriv;
+    using Inherit::VecCoord;
+    using Inherit::VecDeriv;
+    using Inherit::Element;
+    using Inherit::VecElement;
+    using Inherit::Displacement;
+    using Inherit::MaterialStiffness;
+    using Inherit::StrainDisplacement;
+    using Inherit::VecStrainDisplacement;
+    using Inherit::Force;
+    using Inherit::FiniteElementArrays;
+    using Inherit::Transformation;
+    using Inherit::StiffnessMatrix;
+
+    void init(const FiniteElementArrays& finiteElementArrays) override;
+    void addForce(const FiniteElementArrays& finiteElementArrays) override;
+    void addDForce(const FiniteElementArrays& finiteElementArrays, Real kFactor) override;
+
+    Displacement getDisplacement(const VecCoord& positions, const Element& element, unsigned elementIndex) const override;
+
+    Transformation getRotation(const unsigned int elementIndex) const override
+    {
+        return m_rotations[elementIndex];
+    }
+
+protected:
+
+    type::vector<Transformation> m_initialRotations;
+    type::vector<Transformation> m_rotations;
+    std::vector<type::fixed_array<Coord,4> > m_rotatedInitialElements;   ///< The initials positions in its frame
+
+    void initElement(const VecCoord& initialPoints, StrainDisplacement& strainDisplacement, const Element& element, unsigned int elementIndex);
+
+    virtual void computeRotation(Transformation& rotation, const VecCoord& positions, Index a, Index b, Index c, Index d, unsigned elementIndex) const = 0;
+    virtual void computeInitialRotation(Transformation& rotation, const VecCoord& positions, Index a, Index b, Index c, Index d, unsigned elementIndex) const;
+
+    void addForceElementElastic(const FiniteElementArrays& finiteElementArrays, const Element& element, const unsigned int elementIndex);
+
+    virtual void addForceAssembled(const FiniteElementArrays& finiteElementArrays);
+    void addForceElementAssembled(const FiniteElementArrays& finiteElementArrays, const Element& element, const unsigned int elementIndex);
+
+    static void computeDisplacement(Displacement& displacement, const VecDeriv& dx, Index a, Index b, Index c, Index d,
+                                    const Transformation& rotation);
+
+    void addDForceElement(const FiniteElementArrays& finiteElementArrays, Real kFactor, const VecDeriv& dx, unsigned elementIndex,
+                          const Element& element);
+
+    virtual void
+    computeDeformedElement(type::fixed_array<type::VecNoInit<3, Real>,4>& deforme, const Transformation& rotation, const Coord& xa, const Coord& xb, const Coord& xc, const Coord& xd) const;
+
+    virtual void computeDisplacement(Displacement& displacement, const type::fixed_array<type::VecNoInit<3, Real>,4>& deformedElement,
+        const type::fixed_array<Coord,4>& rotatedInitialElement) const;
+
+    virtual type::fixed_array<Coord,4>
+    computeRotatedInitialElement(const Transformation& rotation, const Element& element, const VecCoord& initialPoints) const;
+
+    StiffnessMatrix computeStiffnessMatrix(const MaterialStiffness &K, const StrainDisplacement &J, unsigned elementIndex) const override;
+};
+
+}
+
+#include <SofaSimpleFem/TetrahedronFEMForceFieldImplCorotational.inl>

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplCorotational.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplCorotational.inl
@@ -199,7 +199,8 @@ void TetrahedronFEMForceFieldImplCorotational<DataTypes>::addForceAssembled(
     }
     else
     {
-        if (static bool first = true)
+        static bool first = true;
+        if (first)
         {
             msg_error("TetrahedronFEMForceFieldImpl") << "Assembled matrix with plasticity is not supported";
             first = false;
@@ -236,7 +237,7 @@ void TetrahedronFEMForceFieldImplCorotational<DataTypes>::addForceElementAssembl
     (*finiteElementArrays.strainDisplacements)[elementIndex][9][0] = 0;
     (*finiteElementArrays.strainDisplacements)[elementIndex][10][1] = 0;
 
-    assembleStiffnessMatrix(finiteElementArrays, element, elementIndex);
+    this->assembleStiffnessMatrix(finiteElementArrays, element, elementIndex);
 
     Force F;
     Inherit::computeForce(F,

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplCorotational.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplCorotational.inl
@@ -1,0 +1,377 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <SofaSimpleFem/TetrahedronFEMForceFieldImplCorotational.h>
+
+namespace sofa::component::forcefield
+{
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplCorotational<DataTypes>::init(const FiniteElementArrays& finiteElementArrays)
+{
+    const auto& initialPoints = *finiteElementArrays.initialPoints;
+
+    m_initialRotations.clear();
+    m_initialRotations.reserve(finiteElementArrays.elements->size());
+
+    m_rotations.clear();
+    m_rotations.reserve(finiteElementArrays.elements->size());
+
+    m_rotatedInitialElements.clear();
+    m_rotatedInitialElements.reserve(finiteElementArrays.elements->size());
+
+    auto& strainDisplacements = *finiteElementArrays.strainDisplacements;
+    strainDisplacements.resize(finiteElementArrays.elements->size());
+
+    unsigned int elementIndex {};
+    for (const auto element : *finiteElementArrays.elements)
+    {
+        initElement(initialPoints, strainDisplacements[elementIndex], element, elementIndex);
+        ++elementIndex;
+    }
+}
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplCorotational<DataTypes>::initElement(const VecCoord& initialPoints, StrainDisplacement& strainDisplacement, const Element& element, unsigned int elementIndex)
+{
+    const Index a = element[0];
+    const Index b = element[1];
+    const Index c = element[2];
+    const Index d = element[3];
+
+    Transformation R_0_1;
+    computeInitialRotation(R_0_1, initialPoints, a, b, c, d, elementIndex);
+
+    Transformation R_0_1_T;
+    R_0_1_T.transpose(R_0_1);
+
+    m_initialRotations.push_back(R_0_1_T);
+    m_rotations.push_back(R_0_1_T);
+
+    const auto rotatedElement = computeRotatedInitialElement(R_0_1, element, initialPoints);
+    // msg_info("tetra") << "rotated initial element " << elementIndex << ": " << rotatedElement;
+
+    m_rotatedInitialElements.push_back(rotatedElement);
+
+    strainDisplacement = Inherit::computeStrainDisplacement(
+        rotatedElement[0], rotatedElement[1], rotatedElement[2], rotatedElement[3] );
+
+    // msg_info("tetra") << "strain displacement " << elementIndex << ": " << strainDisplacement;
+}
+
+template <class DataTypes>
+auto TetrahedronFEMForceFieldImplCorotational<DataTypes>::computeRotatedInitialElement(
+    const Transformation& rotation,
+    const Element& element,
+    const VecCoord& initialPoints) const
+-> type::fixed_array<Coord,4>
+{
+    const Index a = element[0];
+    const Index b = element[1];
+    const Index c = element[2];
+    const Index d = element[3];
+
+    const auto firstNodeRotated = rotation * initialPoints[a];
+    return
+    {
+        Coord(0,0,0),
+          rotation * initialPoints[b] - firstNodeRotated,
+          rotation * initialPoints[c] - firstNodeRotated,
+          rotation * initialPoints[d] - firstNodeRotated
+    };
+}
+
+template <class DataTypes>
+typename TetrahedronFEMForceFieldImpl<DataTypes>::StiffnessMatrix TetrahedronFEMForceFieldImplCorotational<DataTypes>::
+computeStiffnessMatrix(const MaterialStiffness& K, const StrainDisplacement& J, const unsigned elementIndex) const
+{
+    const auto JKJt = Inherit::computeStiffnessMatrix(K, J, elementIndex);
+
+    const auto& Rot = m_rotations[elementIndex];
+
+    type::MatNoInit<12, 12, Real> RR, RRt;
+    RR.clear();
+    RRt.clear();
+
+    for(int i=0; i<3; ++i)
+    {
+        for(int j=0; j<3; ++j)
+        {
+            RR[i][j] = RR[i+3][j+3] = RR[i+6][j+6] = RR[i+9][j+9] = Rot[i][j];
+            RRt[i][j]= RRt[i+3][j+3]= RRt[i+6][j+6]= RRt[i+9][j+9]= Rot[j][i];
+        }
+    }
+
+    return RR * JKJt * RRt;
+}
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplCorotational<DataTypes>::addForce(const FiniteElementArrays& finiteElementArrays)
+{
+    if (!this->m_assemble)
+    {
+        unsigned int elementIndex {};
+        for (const auto& element : *finiteElementArrays.elements)
+        {
+            addForceElementElastic(finiteElementArrays, element, elementIndex++);
+        }
+    }
+    else
+    {
+        addForceAssembled(finiteElementArrays);
+    }
+}
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplCorotational<DataTypes>::computeInitialRotation(Transformation& rotation,
+    const VecCoord& positions, Index a, Index b, Index c, Index d, unsigned elementIndex) const
+{
+    return computeRotation(rotation, positions, a, b, c, d, elementIndex);
+}
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplCorotational<DataTypes>::addForceElementElastic(
+    const FiniteElementArrays& finiteElementArrays, const Element& element, const unsigned elementIndex)
+{
+    const Index a = element[0];
+    const Index b = element[1];
+    const Index c = element[2];
+    const Index d = element[3];
+
+    const auto& p = *finiteElementArrays.positions;
+
+    Transformation R_0_2;
+    computeRotation(R_0_2, p, a, b, c, d, elementIndex);
+
+    auto& rotation = m_rotations[elementIndex];
+
+    rotation.transpose(R_0_2);
+
+    type::fixed_array<type::VecNoInit<3, Real>,4> deforme;
+    computeDeformedElement(deforme, R_0_2, p[a], p[b], p[c], p[d]);
+
+    Displacement displacement;
+    computeDisplacement(displacement,
+        deforme, m_rotatedInitialElements[elementIndex]);
+
+    Force F;
+    Inherit::computeForce(F,
+        displacement,
+        (*finiteElementArrays.materialsStiffnesses)[elementIndex],
+        (*finiteElementArrays.strainDisplacements)[elementIndex]);
+
+    Inherit::copyForceFromElementToGlobal(*finiteElementArrays.force, F, element, rotation);
+}
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplCorotational<DataTypes>::addForceAssembled(
+    const FiniteElementArrays& finiteElementArrays)
+{
+    unsigned int elementIndex {};
+    if (!this->m_plasticity.hasPlasticity())
+    {
+        Inherit::initStiffnesses(finiteElementArrays);
+
+        for (const auto element : *finiteElementArrays.elements)
+        {
+            addForceElementAssembled(finiteElementArrays, element, elementIndex++);
+        }
+    }
+    else
+    {
+        if (static bool first = true)
+        {
+            msg_error("TetrahedronFEMForceFieldImpl") << "Assembled matrix with plasticity is not supported";
+            first = false;
+        }
+    }
+}
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplCorotational<DataTypes>::addForceElementAssembled(
+    const FiniteElementArrays& finiteElementArrays, const Element& element, const unsigned elementIndex)
+{
+    const Index a = element[0];
+    const Index b = element[1];
+    const Index c = element[2];
+    const Index d = element[3];
+
+    const auto& p = *finiteElementArrays.positions;
+
+    Transformation R_0_2;
+    computeRotation(R_0_2, p, a, b, c, d, elementIndex);
+
+    auto& rotation = m_rotations[elementIndex];
+
+    rotation.transpose(R_0_2);
+
+    type::fixed_array<type::VecNoInit<3, Real>,4> deforme;
+    computeDeformedElement(deforme, R_0_2, p[a], p[b], p[c], p[d]);
+
+    Displacement displacement;
+    computeDisplacement(displacement,
+        deforme, m_rotatedInitialElements[elementIndex]);
+
+    (*finiteElementArrays.strainDisplacements)[elementIndex][6][0] = 0;
+    (*finiteElementArrays.strainDisplacements)[elementIndex][9][0] = 0;
+    (*finiteElementArrays.strainDisplacements)[elementIndex][10][1] = 0;
+
+    assembleStiffnessMatrix(finiteElementArrays, element, elementIndex);
+
+    Force F;
+    Inherit::computeForce(F,
+        displacement,
+        (*finiteElementArrays.materialsStiffnesses)[elementIndex],
+        (*finiteElementArrays.strainDisplacements)[elementIndex]);
+
+    Inherit::copyForceFromElementToGlobal(*finiteElementArrays.force, F, element, rotation);
+}
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplCorotational<DataTypes>::computeDisplacement(Displacement& displacement, const VecDeriv& dx, const Index a, const Index b, const Index c, const Index d, const Transformation& rotation)
+{
+    displacement[0]  = rotation[0][0] * dx[a][0] + rotation[1][0] * dx[a][1] + rotation[2][0] * dx[a][2];
+    displacement[1]  = rotation[0][1] * dx[a][0] + rotation[1][1] * dx[a][1] + rotation[2][1] * dx[a][2];
+    displacement[2]  = rotation[0][2] * dx[a][0] + rotation[1][2] * dx[a][1] + rotation[2][2] * dx[a][2];
+
+    displacement[3]  = rotation[0][0] * dx[b][0] + rotation[1][0] * dx[b][1] + rotation[2][0] * dx[b][2];
+    displacement[4]  = rotation[0][1] * dx[b][0] + rotation[1][1] * dx[b][1] + rotation[2][1] * dx[b][2];
+    displacement[5]  = rotation[0][2] * dx[b][0] + rotation[1][2] * dx[b][1] + rotation[2][2] * dx[b][2];
+
+    displacement[6]  = rotation[0][0] * dx[c][0] + rotation[1][0] * dx[c][1] + rotation[2][0] * dx[c][2];
+    displacement[7]  = rotation[0][1] * dx[c][0] + rotation[1][1] * dx[c][1] + rotation[2][1] * dx[c][2];
+    displacement[8]  = rotation[0][2] * dx[c][0] + rotation[1][2] * dx[c][1] + rotation[2][2] * dx[c][2];
+
+    displacement[9]  = rotation[0][0] * dx[d][0] + rotation[1][0] * dx[d][1] + rotation[2][0] * dx[d][2];
+    displacement[10] = rotation[0][1] * dx[d][0] + rotation[1][1] * dx[d][1] + rotation[2][1] * dx[d][2];
+    displacement[11] = rotation[0][2] * dx[d][0] + rotation[1][2] * dx[d][1] + rotation[2][2] * dx[d][2];
+}
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplCorotational<DataTypes>::addDForceElement(
+    const FiniteElementArrays& finiteElementArrays,
+    const Real kFactor,
+    const VecDeriv& dx,
+    const unsigned elementIndex,
+    const Element& element)
+{
+    const Index a = element[0];
+    const Index b = element[1];
+    const Index c = element[2];
+    const Index d = element[3];
+
+    Displacement displacement;
+
+    const auto& rotation = m_rotations[elementIndex];
+
+    // rotate by rotation transposed (compute R^T * D)
+    computeDisplacement(displacement, dx, a, b, c, d, rotation);
+
+    Force F;
+
+    // compute J * K * J_T * (R^T * D)
+    // Another application of R is required on the left
+    Inherit::computeForce(F,
+        displacement, // = R^T * D
+        (*finiteElementArrays.plasticStrains)[elementIndex],
+        (*finiteElementArrays.materialsStiffnesses)[elementIndex],
+        (*finiteElementArrays.strainDisplacements)[elementIndex],
+        this->m_plasticity);
+
+    F *= - kFactor;
+
+    // copy R*F, therefore the final computation is F = -kFactor * R * J * K * J^T * R^T * D
+    Inherit::copyForceFromElementToGlobal(*finiteElementArrays.dForce, F, element, rotation);
+}
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplCorotational<DataTypes>::addDForce(const FiniteElementArrays& finiteElementArrays,
+    Real kFactor)
+{
+    const auto& dx = *finiteElementArrays.dx;
+
+    unsigned int elementIndex {};
+    for (const auto& element : *finiteElementArrays.elements)
+    {
+        addDForceElement(finiteElementArrays, kFactor, dx, elementIndex++, element);
+    }
+
+}
+
+template <class DataTypes>
+typename TetrahedronFEMForceFieldImpl<DataTypes>::Displacement TetrahedronFEMForceFieldImplCorotational<DataTypes>::
+getDisplacement(const VecCoord& positions, const Element& element, const unsigned elementIndex) const
+{
+    const Index a = element[0];
+    const Index b = element[1];
+    const Index c = element[2];
+    const Index d = element[3];
+
+    const auto& p = positions;
+    Transformation R_0_2;
+    computeRotation(R_0_2, p, a, b, c, d, elementIndex);
+
+    type::fixed_array<type::VecNoInit<3, Real>,4> deforme;
+    computeDeformedElement(deforme, R_0_2, p[a], p[b], p[c], p[d]);
+
+    Displacement displacement;
+    computeDisplacement(displacement,
+        deforme, m_rotatedInitialElements[elementIndex]);
+
+    return displacement;
+}
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplCorotational<DataTypes>
+::computeDeformedElement(type::fixed_array<type::VecNoInit<3, Real>,4>& deforme, const Transformation& rotation, const Coord& xa, const Coord& xb, const Coord& xc, const Coord& xd) const
+{
+    deforme[0] = rotation * xa;
+    deforme[1] = rotation * xb;
+    deforme[2] = rotation * xc;
+    deforme[3] = rotation * xd;
+
+    deforme[1][0] -= deforme[0][0];
+    deforme[2][0] -= deforme[0][0];
+    deforme[2][1] -= deforme[0][1];
+    deforme[3] -= deforme[0];
+}
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplCorotational<DataTypes>::
+computeDisplacement(Displacement& displacement, const type::fixed_array<type::VecNoInit<3, Real>, 4>& deformedElement, const type::fixed_array<Coord,4>& rotatedInitialElement) const
+{
+    displacement[ 0] = 0;
+    displacement[ 1] = 0;
+    displacement[ 2] = 0;
+    displacement[ 3] = rotatedInitialElement[1][0] - deformedElement[1][0];
+    displacement[ 4] = 0;
+    displacement[ 5] = 0;
+    displacement[ 6] = rotatedInitialElement[2][0] - deformedElement[2][0];
+    displacement[ 7] = rotatedInitialElement[2][1] - deformedElement[2][1];
+    displacement[ 8] = 0;
+    displacement[ 9] = rotatedInitialElement[3][0] - deformedElement[3][0];
+    displacement[10] = rotatedInitialElement[3][1] - deformedElement[3][1];
+    displacement[11] = rotatedInitialElement[3][2] - deformedElement[3][2];
+}
+
+}

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplLarge.h
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplLarge.h
@@ -31,9 +31,9 @@ class TetrahedronFEMForceFieldImplLarge : public TetrahedronFEMForceFieldImplCor
 {
 public:
     using Inherit = TetrahedronFEMForceFieldImplCorotational<DataTypes>;
-    using Inherit::Transformation;
-    using Inherit::Coord;
-    using Inherit::VecCoord;
+    using typename Inherit::Transformation;
+    using typename Inherit::Coord;
+    using typename Inherit::VecCoord;
 
 protected:
 

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplLarge.h
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplLarge.h
@@ -1,0 +1,45 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <SofaSimpleFem/TetrahedronFEMForceFieldImplCorotational.h>
+
+namespace sofa::component::forcefield
+{
+
+template<class DataTypes>
+class TetrahedronFEMForceFieldImplLarge : public TetrahedronFEMForceFieldImplCorotational<DataTypes>
+{
+public:
+    using Inherit = TetrahedronFEMForceFieldImplCorotational<DataTypes>;
+    using Inherit::Transformation;
+    using Inherit::Coord;
+    using Inherit::VecCoord;
+
+protected:
+
+    void computeRotation(Transformation& rotation, const VecCoord& positions, Index a, Index b, Index c, Index d, unsigned elementIndex) const override;
+};
+
+}
+
+#include <SofaSimpleFem/TetrahedronFEMForceFieldImplLarge.inl>

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplLarge.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplLarge.inl
@@ -1,0 +1,58 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <SofaSimpleFem/TetrahedronFEMForceFieldImplLarge.h>
+
+namespace sofa::component::forcefield
+{
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplLarge<DataTypes>::
+computeRotation(Transformation& rotation, const VecCoord& positions, const Index a, const Index b, const Index c, const Index d, unsigned elementIndex) const
+{
+    SOFA_UNUSED(d);
+    SOFA_UNUSED(elementIndex);
+
+    // first vector on first edge
+    // second vector in the plane of the two first edges
+    // third vector orthogonal to first and second
+
+    const Coord edgex = (positions[b]-positions[a]).normalized();
+          Coord edgey = positions[c]-positions[a];
+    const Coord edgez = cross( edgex, edgey ).normalized();
+                edgey = cross( edgez, edgex );
+
+    rotation[0][0] = edgex[0];
+    rotation[0][1] = edgex[1];
+    rotation[0][2] = edgex[2];
+    rotation[1][0] = edgey[0];
+    rotation[1][1] = edgey[1];
+    rotation[1][2] = edgey[2];
+    rotation[2][0] = edgez[0];
+    rotation[2][1] = edgez[1];
+    rotation[2][2] = edgez[2];
+
+    // TODO handle degenerated cases like in the SVD method
+}
+
+}

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplPolar.h
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplPolar.h
@@ -1,0 +1,62 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <SofaSimpleFem/TetrahedronFEMForceFieldImplCorotational.h>
+
+namespace sofa::component::forcefield
+{
+
+template<class DataTypes>
+class TetrahedronFEMForceFieldImplPolar : public TetrahedronFEMForceFieldImplCorotational<DataTypes>
+{
+protected:
+
+    using Inherit = TetrahedronFEMForceFieldImplCorotational<DataTypes>;
+    using Inherit::Transformation;
+    using Inherit::Coord;
+    using Inherit::VecCoord;
+    using Inherit::Real;
+    using Inherit::Displacement;
+    using Inherit::Element;
+    using Inherit::FiniteElementArrays;
+
+    void computeRotation(Transformation& rotation, const VecCoord& positions, Index a, Index b, Index c, Index d, unsigned elementIndex) const override;
+
+    void computeDisplacement(Displacement& displacement, const type::fixed_array<type::VecNoInit<3, Real>,4>& deformedElement,
+            const type::fixed_array<Coord,4>& rotatedInitialElement) const override;
+
+    type::fixed_array<Coord,4>
+    computeRotatedInitialElement(const Transformation& rotation, const Element& element, const VecCoord& initialPoints) const override;
+
+    void computeDeformedElement(type::fixed_array<type::VecNoInit<3, Real>,4>& deforme,
+        const Transformation& rotation, const Coord& xa, const Coord& xb, const Coord& xc, const Coord& xd) const override;
+
+    void addForceAssembled(const FiniteElementArrays& finiteElementArrays) override;
+
+};
+
+
+
+}
+
+#include <SofaSimpleFem/TetrahedronFEMForceFieldImplPolar.inl>

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplPolar.h
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplPolar.h
@@ -32,13 +32,13 @@ class TetrahedronFEMForceFieldImplPolar : public TetrahedronFEMForceFieldImplCor
 protected:
 
     using Inherit = TetrahedronFEMForceFieldImplCorotational<DataTypes>;
-    using Inherit::Transformation;
-    using Inherit::Coord;
-    using Inherit::VecCoord;
-    using Inherit::Real;
-    using Inherit::Displacement;
-    using Inherit::Element;
-    using Inherit::FiniteElementArrays;
+    using typename Inherit::Transformation;
+    using typename Inherit::Coord;
+    using typename Inherit::VecCoord;
+    using typename Inherit::Real;
+    using typename Inherit::Displacement;
+    using typename Inherit::Element;
+    using typename Inherit::FiniteElementArrays;
 
     void computeRotation(Transformation& rotation, const VecCoord& positions, Index a, Index b, Index c, Index d, unsigned elementIndex) const override;
 

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplPolar.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplPolar.inl
@@ -1,0 +1,101 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <SofaSimpleFem/TetrahedronFEMForceFieldImplPolar.h>
+
+namespace sofa::component::forcefield
+{
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplPolar<DataTypes>::computeRotation(Transformation& rotation, const VecCoord& positions, const Index a, const Index b, const Index c, const Index d, unsigned elementIndex) const
+{
+    Transformation A;
+    A[0] = positions[b]-positions[a];
+    A[1] = positions[c]-positions[a];
+    A[2] = positions[d]-positions[a];
+
+    helper::Decompose<Real>::polarDecomposition( A, rotation );
+}
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplPolar<DataTypes>
+::computeDisplacement(Displacement& displacement, const type::fixed_array<type::VecNoInit<3, Real>, 4>& deformed_element,
+    const type::fixed_array<Coord, 4>& rotated_initial_element) const
+{
+    displacement[ 0] = rotated_initial_element[0][0] - deformed_element[0][0];
+    displacement[ 1] = rotated_initial_element[0][1] - deformed_element[0][1];
+    displacement[ 2] = rotated_initial_element[0][2] - deformed_element[0][2];
+    displacement[ 3] = rotated_initial_element[1][0] - deformed_element[1][0];
+    displacement[ 4] = rotated_initial_element[1][1] - deformed_element[1][1];
+    displacement[ 5] = rotated_initial_element[1][2] - deformed_element[1][2];
+    displacement[ 6] = rotated_initial_element[2][0] - deformed_element[2][0];
+    displacement[ 7] = rotated_initial_element[2][1] - deformed_element[2][1];
+    displacement[ 8] = rotated_initial_element[2][2] - deformed_element[2][2];
+    displacement[ 9] = rotated_initial_element[3][0] - deformed_element[3][0];
+    displacement[10] = rotated_initial_element[3][1] - deformed_element[3][1];
+    displacement[11] = rotated_initial_element[3][2] - deformed_element[3][2];
+}
+
+template <class DataTypes>
+auto TetrahedronFEMForceFieldImplPolar<DataTypes>::computeRotatedInitialElement(
+    const Transformation& rotation,
+    const Element& element,
+    const VecCoord& initialPoints) const
+-> type::fixed_array<Coord,4>
+{
+    const Index a = element[0];
+    const Index b = element[1];
+    const Index c = element[2];
+    const Index d = element[3];
+
+    return
+    {
+        rotation * initialPoints[a],
+        rotation * initialPoints[b],
+        rotation * initialPoints[c],
+        rotation * initialPoints[d]
+    };
+}
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplPolar<
+DataTypes>::computeDeformedElement(type::fixed_array<type::VecNoInit<3, Real>,4>& deforme, const Transformation& rotation, const Coord& xa, const Coord& xb, const Coord& xc,
+    const Coord& xd) const
+{
+    deforme[0] = rotation * xa;
+    deforme[1] = rotation * xb;
+    deforme[2] = rotation * xc;
+    deforme[3] = rotation * xd;
+}
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplPolar<DataTypes>::addForceAssembled(const FiniteElementArrays& finite_element_arrays)
+{
+    static bool first = true;
+    if (first)
+    {
+        msg_error("TetrahedronFEMForceFieldImplPolar") << "Computing the assembled matrix is not supported with the polar method";
+        first = false;
+    }
+}
+}

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplSVD.h
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplSVD.h
@@ -31,12 +31,12 @@ class TetrahedronFEMForceFieldImplSVD : public TetrahedronFEMForceFieldImplPolar
 {
 public:
     using Inherit = TetrahedronFEMForceFieldImplCorotational<DataTypes>;
-    using Inherit::FiniteElementArrays;
-    using Inherit::Transformation;
-    using Inherit::Coord;
-    using Inherit::VecCoord;
-    using Inherit::Real;
-    using Inherit::Displacement;
+    using typename Inherit::FiniteElementArrays;
+    using typename Inherit::Transformation;
+    using typename Inherit::Coord;
+    using typename Inherit::VecCoord;
+    using typename Inherit::Real;
+    using typename Inherit::Displacement;
 
     void init(const FiniteElementArrays& finiteElementArrays) override;
 

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplSVD.h
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplSVD.h
@@ -1,0 +1,55 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <SofaSimpleFem/TetrahedronFEMForceFieldImplPolar.h>
+
+namespace sofa::component::forcefield
+{
+
+template<class DataTypes>
+class TetrahedronFEMForceFieldImplSVD : public TetrahedronFEMForceFieldImplPolar<DataTypes>
+{
+public:
+    using Inherit = TetrahedronFEMForceFieldImplCorotational<DataTypes>;
+    using Inherit::FiniteElementArrays;
+    using Inherit::Transformation;
+    using Inherit::Coord;
+    using Inherit::VecCoord;
+    using Inherit::Real;
+    using Inherit::Displacement;
+
+    void init(const FiniteElementArrays& finiteElementArrays) override;
+
+protected:
+
+    void computeRotation(Transformation& rotation, const VecCoord& positions, Index a, Index b, Index c, Index d, unsigned elementIndex) const override;
+    void computeInitialRotation(Transformation& rotation, const VecCoord& positions, Index a, Index b, Index c, Index d, unsigned elementIndex) const override;
+
+    type::vector<Transformation> m_initialTransformation;
+
+    void addForceAssembled(const FiniteElementArrays& finiteElementArrays) override;
+};
+
+}
+
+#include <SofaSimpleFem/TetrahedronFEMForceFieldImplSVD.inl>

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplSVD.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplSVD.inl
@@ -1,0 +1,107 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <SofaSimpleFem/TetrahedronFEMForceFieldImplSVD.h>
+
+namespace sofa::component::forcefield
+{
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplSVD<DataTypes>::init(const FiniteElementArrays& finiteElementArrays)
+{
+    m_initialTransformation.clear();
+    m_initialTransformation.reserve(finiteElementArrays.elements->size());
+
+    Inherit::init(finiteElementArrays);
+
+    const auto& positions = *finiteElementArrays.initialPoints;
+    for (const auto& element : *finiteElementArrays.elements)
+    {
+        const Index a = element[0];
+        const Index b = element[1];
+        const Index c = element[2];
+        const Index d = element[3];
+
+        Transformation A;
+        A[0] = positions[b]-positions[a];
+        A[1] = positions[c]-positions[a];
+        A[2] = positions[d]-positions[a];
+
+        Transformation A_inverted;
+        const bool canInvert = A_inverted.invert(A);
+        assert(canInvert);
+        SOFA_UNUSED(canInvert);
+
+        m_initialTransformation.emplace_back(std::move(A_inverted));
+    }
+}
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplSVD<DataTypes>
+::computeRotation(Transformation& rotation, const VecCoord& positions, const Index a, const Index b, const Index c, const Index d, unsigned elementIndex) const
+{
+    Transformation A;
+    A[0] = positions[b]-positions[a];
+    A[1] = positions[c]-positions[a];
+    A[2] = positions[d]-positions[a];
+
+    const auto F = A * this->m_initialTransformation[elementIndex];
+
+    rotation.clear();
+
+    if(type::determinant(F) < 1e-6 ) // inverted or too flat element -> SVD decomposition + handle degenerated cases
+    {
+        helper::Decompose<Real>::polarDecomposition_stable( F, rotation );
+        rotation = rotation.multTransposed( this->m_initialRotations[elementIndex] );
+    }
+    else // not inverted & not degenerated -> classical polar
+    {
+        helper::Decompose<Real>::polarDecomposition( A, rotation );
+    }
+}
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplSVD<DataTypes>::computeInitialRotation(Transformation& rotation,
+    const VecCoord& positions, Index a, Index b, Index c, Index d, unsigned elementIndex) const
+{
+    SOFA_UNUSED(elementIndex);
+
+    Transformation A;
+    A[0] = positions[b]-positions[a];
+    A[1] = positions[c]-positions[a];
+    A[2] = positions[d]-positions[a];
+
+    helper::Decompose<Real>::polarDecomposition_stable( A, rotation );
+}
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplSVD<DataTypes>::addForceAssembled(const FiniteElementArrays& finite_element_arrays)
+{
+    static bool first = true;
+    if (first)
+    {
+        msg_error("TetrahedronFEMForceFieldImplSVD") << "Computing the assembled matrix is not supported with the SVD method";
+        first = false;
+    }
+}
+}

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplSmall.h
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplSmall.h
@@ -1,0 +1,70 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <SofaSimpleFem/TetrahedronFEMForceFieldImpl.h>
+namespace sofa::component::forcefield
+{
+
+template<class DataTypes>
+class TetrahedronFEMForceFieldImplSmall : public TetrahedronFEMForceFieldImpl<DataTypes>
+{
+public:
+
+    using Inherit = TetrahedronFEMForceFieldImpl<DataTypes>;
+    using Inherit::Real;
+    using Inherit::Coord;
+    using Inherit::Deriv;
+    using Inherit::VecCoord;
+    using Inherit::Element;
+    using Inherit::VecElement;
+    using Inherit::Displacement;
+    using Inherit::MaterialStiffness;
+    using Inherit::VecStrainDisplacement;
+    using Inherit::Force;
+    using Inherit::FiniteElementArrays;
+    using Inherit::Transformation;
+    using Inherit::StiffnessMatrix;
+
+    void init(const FiniteElementArrays& finiteElementArrays) override;
+    void addForce(const FiniteElementArrays& finiteElementArrays) override;
+    void addDForce(const FiniteElementArrays& finiteElementArrays, Real kFactor) override;
+
+protected:
+
+    void addForceAssembled(const FiniteElementArrays& finiteElementArrays);
+
+    void addForceElementElastic(const FiniteElementArrays& finiteElementArrays, const Element& element, const unsigned int elementIndex);
+
+    void addForceElementAssembled(const FiniteElementArrays& finiteElementArrays, const Element& element, const unsigned int elementIndex);
+
+    static Displacement computeDisplacement(const VecCoord& initialPoints, const VecCoord& positions, const Element& element);
+
+    static Displacement computeDisplacement(
+        const Coord& a_0, const Coord& b_0, const Coord& c_0, const Coord& d_0,
+        const Coord& a  , const Coord& b  , const Coord& c  , const Coord& d
+    );
+};
+
+}
+
+#include <SofaSimpleFem/TetrahedronFEMForceFieldImplSmall.inl>

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplSmall.h
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplSmall.h
@@ -31,19 +31,19 @@ class TetrahedronFEMForceFieldImplSmall : public TetrahedronFEMForceFieldImpl<Da
 public:
 
     using Inherit = TetrahedronFEMForceFieldImpl<DataTypes>;
-    using Inherit::Real;
-    using Inherit::Coord;
-    using Inherit::Deriv;
-    using Inherit::VecCoord;
-    using Inherit::Element;
-    using Inherit::VecElement;
-    using Inherit::Displacement;
-    using Inherit::MaterialStiffness;
-    using Inherit::VecStrainDisplacement;
-    using Inherit::Force;
-    using Inherit::FiniteElementArrays;
-    using Inherit::Transformation;
-    using Inherit::StiffnessMatrix;
+    using typename Inherit::Real;
+    using typename Inherit::Coord;
+    using typename Inherit::Deriv;
+    using typename Inherit::VecCoord;
+    using typename Inherit::Element;
+    using typename Inherit::VecElement;
+    using typename Inherit::Displacement;
+    using typename Inherit::MaterialStiffness;
+    using typename Inherit::VecStrainDisplacement;
+    using typename Inherit::Force;
+    using typename Inherit::FiniteElementArrays;
+    using typename Inherit::Transformation;
+    using typename Inherit::StiffnessMatrix;
 
     void init(const FiniteElementArrays& finiteElementArrays) override;
     void addForce(const FiniteElementArrays& finiteElementArrays) override;
@@ -57,9 +57,9 @@ protected:
 
     void addForceElementAssembled(const FiniteElementArrays& finiteElementArrays, const Element& element, const unsigned int elementIndex);
 
-    static Displacement computeDisplacement(const VecCoord& initialPoints, const VecCoord& positions, const Element& element);
+    static typename Inherit::Displacement computeDisplacement(const VecCoord& initialPoints, const VecCoord& positions, const Element& element);
 
-    static Displacement computeDisplacement(
+    static typename Inherit::Displacement computeDisplacement(
         const Coord& a_0, const Coord& b_0, const Coord& c_0, const Coord& d_0,
         const Coord& a  , const Coord& b  , const Coord& c  , const Coord& d
     );

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplSmall.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplSmall.inl
@@ -1,0 +1,194 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <SofaSimpleFem/TetrahedronFEMForceFieldImplSmall.h>
+
+namespace sofa::component::forcefield
+{
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplSmall<DataTypes>::init(const FiniteElementArrays& finiteElementArrays)
+{
+    unsigned int elementIndex {};
+    const auto& initialPoints = *finiteElementArrays.initialPoints;
+    auto& strainDisplacements = *finiteElementArrays.strainDisplacements;
+
+    for (const auto element : *finiteElementArrays.elements)
+    {
+        const Index a = element[0];
+        const Index b = element[1];
+        const Index c = element[2];
+        const Index d = element[3];
+
+        strainDisplacements[elementIndex++] = Inherit::computeStrainDisplacement(
+            initialPoints[a], initialPoints[b], initialPoints[c], initialPoints[d] );
+        // msg_info("tetra") << "strain displacement " << elementIndex-1 << ": " << strainDisplacements[elementIndex-1];
+    }
+}
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplSmall<DataTypes>::addForce(const FiniteElementArrays& finiteElementArrays)
+{
+    if (!this->m_assemble)
+    {
+        unsigned int elementIndex {};
+        for (const auto& element : *finiteElementArrays.elements)
+        {
+            addForceElementElastic(finiteElementArrays, element, elementIndex++);
+        }
+    }
+    else
+    {
+        addForceAssembled(finiteElementArrays);
+    }
+}
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplSmall<DataTypes>::addDForce(const FiniteElementArrays& finiteElementArrays,
+    Real kFactor)
+{
+    const auto& dx = *finiteElementArrays.dx;
+
+    unsigned int elementIndex {};
+    for (const auto& element : *finiteElementArrays.elements)
+    {
+        Displacement displacement;
+        for (unsigned int node = 0; node < element.static_size; ++node)
+        {
+            const Index nodeId = element[node];
+            const auto& dxNode = dx[nodeId];
+            for (unsigned int i = 0; i < Deriv::total_size; ++i)
+            {
+                displacement[node * Deriv::total_size + i] = dxNode[i];
+            }
+        }
+
+        Force F;
+        Inherit::computeForce(F,
+            displacement,
+            (*finiteElementArrays.plasticStrains)[elementIndex],
+            (*finiteElementArrays.materialsStiffnesses)[elementIndex],
+            (*finiteElementArrays.strainDisplacements)[elementIndex],
+            this->m_plasticity);
+        F *= - kFactor;
+
+        Inherit::copyForceFromElementToGlobal(*finiteElementArrays.dForce, F, element);
+
+        ++elementIndex;
+    }
+}
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplSmall<DataTypes>::addForceAssembled(const FiniteElementArrays& finiteElementArrays)
+{
+    unsigned int elementIndex {};
+    if (!this->m_plasticity.hasPlasticity())
+    {
+        Inherit::initStiffnesses(finiteElementArrays);
+
+        for (const auto element : *finiteElementArrays.elements)
+        {
+            addForceElementAssembled(finiteElementArrays, element, elementIndex++);
+        }
+    }
+    else
+    {
+        if (static bool first = true)
+        {
+            msg_error("TetrahedronFEMForceFieldImpl") << "Assembled matrix with plasticity is not supported";
+            first = false;
+        }
+    }
+}
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplSmall<DataTypes>::addForceElementElastic(
+    const FiniteElementArrays& finiteElementArrays, const Element& element, const unsigned elementIndex)
+{
+    const auto displacement = computeDisplacement(
+        *finiteElementArrays.initialPoints,
+        *finiteElementArrays.positions,
+        element);
+
+    Force F;
+    Inherit::computeForce(F,
+        displacement,
+        (*finiteElementArrays.plasticStrains)[elementIndex],
+        (*finiteElementArrays.materialsStiffnesses)[elementIndex],
+        (*finiteElementArrays.strainDisplacements)[elementIndex],
+        this->m_plasticity);
+
+    Inherit::copyForceFromElementToGlobal(*finiteElementArrays.force, F, element);
+}
+
+template <class DataTypes>
+void TetrahedronFEMForceFieldImplSmall<DataTypes>::addForceElementAssembled(
+    const FiniteElementArrays& finiteElementArrays, const Element& element, const unsigned elementIndex)
+{
+    const auto displacement = computeDisplacement(
+        *finiteElementArrays.initialPoints,
+        *finiteElementArrays.positions,
+        element);
+
+    const auto JKJt = assembleStiffnessMatrix(finiteElementArrays, element, elementIndex);
+
+    const auto F = JKJt * displacement;
+
+    Inherit::copyForceFromElementToGlobal(*finiteElementArrays.force, F, element);
+}
+
+template <class DataTypes>
+typename TetrahedronFEMForceFieldImpl<DataTypes>::Displacement TetrahedronFEMForceFieldImplSmall<DataTypes>::
+computeDisplacement(const VecCoord& initialPoints, const VecCoord& positions, const Element& element)
+{
+    const Index a = element[0];
+    const Index b = element[1];
+    const Index c = element[2];
+    const Index d = element[3];
+
+    return computeDisplacement(
+        initialPoints[a], initialPoints[b], initialPoints[c], initialPoints[d],
+        positions[a], positions[b], positions[c], positions[d]);
+}
+
+template <class DataTypes>
+typename TetrahedronFEMForceFieldImpl<DataTypes>::Displacement TetrahedronFEMForceFieldImplSmall<DataTypes>::
+computeDisplacement(const Coord& a_0, const Coord& b_0, const Coord& c_0, const Coord& d_0, const Coord& a,
+    const Coord& b, const Coord& c, const Coord& d)
+{
+    Displacement D;
+    D[0] = 0;
+    D[1] = 0;
+    D[2] = 0;
+    D[3] =  b_0[0] - a_0[0] - b[0] + a[0];
+    D[4] =  b_0[1] - a_0[1] - b[1] + a[1];
+    D[5] =  b_0[2] - a_0[2] - b[2] + a[2];
+    D[6] =  c_0[0] - a_0[0] - c[0] + a[0];
+    D[7] =  c_0[1] - a_0[1] - c[1] + a[1];
+    D[8] =  c_0[2] - a_0[2] - c[2] + a[2];
+    D[9] =  d_0[0] - a_0[0] - d[0] + a[0];
+    D[10] = d_0[1] - a_0[1] - d[1] + a[1];
+    D[11] = d_0[2] - a_0[2] - d[2] + a[2];
+    return D;
+}
+
+}

--- a/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplSmall.inl
+++ b/SofaKernel/modules/SofaSimpleFem/src/SofaSimpleFem/TetrahedronFEMForceFieldImplSmall.inl
@@ -112,7 +112,8 @@ void TetrahedronFEMForceFieldImplSmall<DataTypes>::addForceAssembled(const Finit
     }
     else
     {
-        if (static bool first = true)
+        static bool first = true;
+        if (first)
         {
             msg_error("TetrahedronFEMForceFieldImpl") << "Assembled matrix with plasticity is not supported";
             first = false;
@@ -149,7 +150,7 @@ void TetrahedronFEMForceFieldImplSmall<DataTypes>::addForceElementAssembled(
         *finiteElementArrays.positions,
         element);
 
-    const auto JKJt = assembleStiffnessMatrix(finiteElementArrays, element, elementIndex);
+    const auto JKJt = this->assembleStiffnessMatrix(finiteElementArrays, element, elementIndex);
 
     const auto F = JKJt * displacement;
 

--- a/examples/Components/forcefield/TetrahedronFEMForceField.scn
+++ b/examples/Components/forcefield/TetrahedronFEMForceField.scn
@@ -7,86 +7,96 @@
     <RequiredPlugin name="SofaTopologyMapping"/>
 
     <VisualStyle displayFlags="showBehaviorModels showForceFields" />
-    
+    <DefaultPipeline verbose="0" />
+    <BruteForceBroadPhase/>
+    <BVHNarrowPhase/>
+    <MinProximityIntersection name="Proximity" alarmDistance="0.8" contactDistance="0.5" />
+
     <Node name="BeamFEM_SMALL">
         <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9"/>
-        
+
         <RegularGridTopology name="grid" min="-5 -5 0" max="5 5 40" n="5 5 20"/>
         <MechanicalObject template="Vec3d" />
-        
+
         <TetrahedronSetTopologyContainer name="Tetra_topo"/>
         <TetrahedronSetTopologyModifier name="Modifier" />
         <TetrahedronSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
         <Hexa2TetraTopologicalMapping input="@grid" output="@Tetra_topo" />
-        
+
         <DiagonalMass massDensity="0.2" />
-        <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.4" computeGlobalMatrix="false" 
+        <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.4" computeGlobalMatrix="false"
+                                  method="small" computeVonMisesStress="2" />
         method="small" computeVonMisesStress="2" showVonMisesStressPerElement="true"/>
-        
+
         <BoxROI template="Vec3d" name="box_roi" box="-6 -6 -1 50 6 0.1" drawBoxes="1" />
         <FixedConstraint template="Vec3d" indices="@box_roi.indices" />
     </Node>
 
-    
+
     <Node name="BeamFEM_LARGE">
         <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-        
+
         <RegularGridTopology name="grid" min="-5 -5 0" max="5 5 40" n="5 5 20"/>
         <MechanicalObject template="Vec3d" translation="11 0 0"/>
-        
+
         <TetrahedronSetTopologyContainer name="Tetra_topo"/>
         <TetrahedronSetTopologyModifier name="Modifier" />
         <TetrahedronSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
         <Hexa2TetraTopologicalMapping input="@grid" output="@Tetra_topo" />
-        
+
         <DiagonalMass massDensity="0.2" />
-        <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.4" computeGlobalMatrix="false" 
+        <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.4" computeGlobalMatrix="false"
+                                  method="large" computeVonMisesStress="1" />
         method="large" computeVonMisesStress="1" showVonMisesStressPerElement="true"/>
-        
+
         <BoxROI template="Vec3d" name="box_roi" box="-6 -6 -1 50 6 0.1" drawBoxes="1" />
         <FixedConstraint template="Vec3d" indices="@box_roi.indices" />
     </Node>
-    
+
     <Node name="BeamFEM_POLAR">
         <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-        
+
         <RegularGridTopology name="grid" min="-5 -5 0" max="5 5 40" n="5 5 20"/>
         <MechanicalObject template="Vec3d" translation="22 0 0"/>
-        
+
         <TetrahedronSetTopologyContainer name="Tetra_topo" />
         <TetrahedronSetTopologyModifier name="Modifier" />
         <TetrahedronSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
         <Hexa2TetraTopologicalMapping input="@grid" output="@Tetra_topo" />
-        
+
         <DiagonalMass massDensity="0.2" />
-        <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.4" computeGlobalMatrix="false" 
+        <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.4" computeGlobalMatrix="false"
+                                  method="polar" computeVonMisesStress="1"/>
         method="polar" computeVonMisesStress="1" showVonMisesStressPerElement="true"/>
-        
+
         <BoxROI template="Vec3d" name="box_roi" box="-6 -6 -1 50 6 0.1" drawBoxes="1" />
         <FixedConstraint template="Vec3d" indices="@box_roi.indices" />
     </Node>
-    
+
     <Node name="BeamFEM_SVD">
         <EulerImplicitSolver name="cg_odesolver" printLog="false"  rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-        
+
         <RegularGridTopology name="grid" min="-5 -5 0" max="5 5 40" n="5 5 20"/>
         <MechanicalObject template="Vec3d" translation="33 0 0"/>
-        
+
         <TetrahedronSetTopologyContainer name="Tetra_topo"/>
         <TetrahedronSetTopologyModifier name="Modifier" />
         <TetrahedronSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
         <Hexa2TetraTopologicalMapping input="@grid" output="@Tetra_topo" />
-        
+
         <DiagonalMass massDensity="0.2" />
-        <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.4" computeGlobalMatrix="false" 
+        <TetrahedronFEMForceField name="FEM" youngModulus="1000" poissonRatio="0.4" computeGlobalMatrix="false"
+                                  method="svd" computeVonMisesStress="1"/>
         method="svd" computeVonMisesStress="1" showVonMisesStressPerElement="true"/>
-        
+
         <BoxROI template="Vec3d" name="box_roi" box="-6 -6 -1 50 6 0.1" drawBoxes="1" />
         <FixedConstraint template="Vec3d" indices="@box_roi.indices" />
     </Node>
-    
+
 </Node>
+


### PR DESCRIPTION
This is a tentative to refactor `TetrahedronFEMForceField` for better readability.

All the FEM methods have been dispatched into dedicated files.

The methods are now classes sharing the same interface (polymorphism), called by the component.

Advantages:
- `TetrahedronFEMForceField` is smaller
- `TetrahedronFEMForceField` had many similar codes (often identical). This is now avoided as all common code are in the base classes.
- It is easier to read the differences between the different FEM methods.
- We could imagine having a factory of FEM methods for `TetrahedronFEMForceField`. Then, the component could be extended in plugins by adding more methods into the factory.

To do:

- [ ] Clean
- [ ] Move some class members from `TetrahedronFEMForceField` to `TetrahedronFEMForceFieldImpl`
- [ ] Restore initial performances
- [ ] Fix broken features such as drawing rotations
- [ ] If everyone agrees, remove the assembled methods. It adds complexity while the resulted matrix is not used.
- [ ] Adapt (if necessary) the derived classes (multithreading, CUDA etc)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
