### PR TITLE
[SofaCore] Check link to mstate if specified

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ForceField.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ForceField.h
@@ -189,9 +189,26 @@ public:
     template<class T>
     static bool canCreate(T*& obj, objectmodel::BaseContext* context, objectmodel::BaseObjectDescription* arg)
     {
-        if (dynamic_cast<MechanicalState<DataTypes>*>(context->getMechanicalState()) == nullptr) {
-            arg->logError(std::string("No mechanical state with the datatype '") + DataTypes::Name() + "' found in the context node.");
-            return false;
+        const std::string attributeName {"mstate"};
+        std::string mstateLink = arg->getAttribute(attributeName,"");
+        if (mstateLink.empty())
+        {
+            if (dynamic_cast<MechanicalState<DataTypes>*>(context->getMechanicalState()) == nullptr)
+            {
+                arg->logError("Since the attribute '" + attributeName + "' has not been specified, a mechanical state "
+                    "with the datatype '" + DataTypes::Name() + "' has been searched in the current context, but not found.");
+                return false;
+            }
+        }
+        else
+        {
+            MechanicalState<DataTypes>* mstate = nullptr;
+            context->findLinkDest(mstate, mstateLink, nullptr);
+            if (!mstate)
+            {
+                arg->logError("Data attribute '" + attributeName + "' does not point to a valid mechanical state of datatype '" + std::string(DataTypes::Name()) + "'.");
+                return false;
+            }
         }
         return BaseObject::canCreate(obj, context, arg);
     }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ForceField.inl
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/ForceField.inl
@@ -42,7 +42,7 @@ ForceField<DataTypes>::~ForceField() = default;
 template<class DataTypes>
 void ForceField<DataTypes>::addForce(const MechanicalParams* mparams, MultiVecDerivId fId )
 {
-    if (mparams)
+    if (mparams && this->mstate)
     {
         addForce(mparams, *fId[this->mstate.get()].write() , *mparams->readX(this->mstate), *mparams->readV(this->mstate));
     }
@@ -51,7 +51,7 @@ void ForceField<DataTypes>::addForce(const MechanicalParams* mparams, MultiVecDe
 template<class DataTypes>
 void ForceField<DataTypes>::addDForce(const MechanicalParams* mparams, MultiVecDerivId dfId )
 {
-    if (mparams)
+    if (mparams && this->mstate)
     {
 
 #ifndef NDEBUG
@@ -71,7 +71,7 @@ void ForceField<DataTypes>::addDForce(const MechanicalParams* mparams, MultiVecD
 template<class DataTypes>
 void ForceField<DataTypes>::addClambda(const MechanicalParams* mparams, MultiVecDerivId resId, MultiVecDerivId lambdaId, SReal cFactor )
 {
-    if (mparams)
+    if (mparams && this->mstate)
     {
         addClambda(mparams, *resId[this->mstate.get()].write(), *lambdaId[this->mstate.get()].read(), cFactor);
     }
@@ -96,10 +96,13 @@ SReal ForceField<DataTypes>::getPotentialEnergy(const MechanicalParams* mparams)
 template<class DataTypes>
 void ForceField<DataTypes>::addKToMatrix(const MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix )
 {
-    sofa::core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate);
-    if (r)
-        addKToMatrix(r.matrix, sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams,rayleighStiffness.getValue()), r.offset);
-    else msg_error()<<"addKToMatrix found no valid matrix accessor.";
+    if (this->mstate)
+    {
+        sofa::core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate);
+        if (r)
+            addKToMatrix(r.matrix, sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams,rayleighStiffness.getValue()), r.offset);
+        else msg_error()<<"addKToMatrix found no valid matrix accessor.";
+    }
 }
 
 template<class DataTypes>
@@ -119,9 +122,12 @@ void ForceField<DataTypes>::addKToMatrix(sofa::linearalgebra::BaseMatrix * /*mat
 template<class DataTypes>
 void ForceField<DataTypes>::addBToMatrix(const MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {
-    sofa::core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate);
-    if (r)
-        addBToMatrix(r.matrix, sofa::core::mechanicalparams::bFactor(mparams) , r.offset);
+    if (this->mstate)
+    {
+        sofa::core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate);
+        if (r)
+            addBToMatrix(r.matrix, sofa::core::mechanicalparams::bFactor(mparams) , r.offset);
+    }
 }
 template<class DataTypes>
 void ForceField<DataTypes>::addBToMatrix(sofa::linearalgebra::BaseMatrix * /*mat*/, SReal /*bFact*/, unsigned int &/*offset*/)


### PR DESCRIPTION
In case the force field is not located in the same context than the MechanicalState it works on, `canCreate` denied the creation of the force field.
This PR makes sure it is possible to create the force field in the aforementioned condition. A new condition authorizes the creation of the force field: when the link to the mstate is valid (even if the mstate is not in the current context).

This PR also check if mstate is null before using it in some functions (`addForce`, `addDForce` etc).





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
