### PR TITLE
[SofaGuiQt] Fix some dll export macro missing

### DIFF
--- a/modules/SofaGuiQt/src/sofa/gui/qt/DataWidget.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/DataWidget.h
@@ -216,7 +216,7 @@ protected:
 
 
 
-class QPushButtonUpdater: public QPushButton
+class SOFA_SOFAGUIQT_API QPushButtonUpdater: public QPushButton
 {
     Q_OBJECT
 public:
@@ -228,7 +228,7 @@ public Q_SLOTS:
 };
 
 //Widget used to display the name of a Data and if needed the link to another Data
-class QDisplayDataInfoWidget: public QWidget
+class SOFA_SOFAGUIQT_API QDisplayDataInfoWidget: public QWidget
 {
     Q_OBJECT
 public:

--- a/modules/SofaGuiQt/src/sofa/gui/qt/LinkWidget.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/LinkWidget.h
@@ -172,7 +172,7 @@ protected:
 
 
 /// Widget used to display the name of a Link
-class QDisplayLinkInfoWidget: public QWidget
+class SOFA_SOFAGUIQT_API QDisplayLinkInfoWidget: public QWidget
 {
     Q_OBJECT
 public:

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QDataDescriptionWidget.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QDataDescriptionWidget.h
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 #include <sofa/core/objectmodel/Base.h>
+#include <sofa/gui/qt/config.h>
 
 #include <QWidget>
 #include <QTextEdit>
@@ -33,7 +34,7 @@ namespace sofa::gui::qt
 {
 
 struct ModifyObjectFlags;
-class QDataDescriptionWidget : public QWidget
+class SOFA_SOFAGUIQT_API QDataDescriptionWidget : public QWidget
 {
     Q_OBJECT
 public:

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QDisplayDataWidget.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QDisplayDataWidget.h
@@ -36,7 +36,7 @@ class DataWidget;
 class QDisplayDataInfoWidget;
 struct ModifyObjectFlags;
 
-class QDisplayDataWidget : public QGroupBox
+class SOFA_SOFAGUIQT_API QDisplayDataWidget : public QGroupBox
 {
     Q_OBJECT
 public:
@@ -81,7 +81,7 @@ protected:
 
 
 
-class QDataSimpleEdit : public DataWidget
+class SOFA_SOFAGUIQT_API QDataSimpleEdit : public DataWidget
 {
     Q_OBJECT
     typedef enum QEditType { TEXTEDIT, LINEEDIT } QEditType;
@@ -108,7 +108,7 @@ protected:
     QSimpleEdit innerWidget_;
 };
 
-class QPoissonRatioWidget : public TDataWidget<double>
+class SOFA_SOFAGUIQT_API QPoissonRatioWidget : public TDataWidget<double>
 {
     Q_OBJECT
 public :

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QDisplayLinkWidget.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QDisplayLinkWidget.h
@@ -37,7 +37,7 @@ class LinkWidget;
 class QDisplayLinkInfoWidget;
 struct ModifyObjectFlags;
 
-class QDisplayLinkWidget : public QGroupBox
+class SOFA_SOFAGUIQT_API QDisplayLinkWidget : public QGroupBox
 {
     Q_OBJECT
 public:
@@ -79,7 +79,7 @@ protected:
 
 
 
-class QLinkSimpleEdit : public LinkWidget
+class SOFA_SOFAGUIQT_API QLinkSimpleEdit : public LinkWidget
 {
     Q_OBJECT
     typedef enum QEditType { TEXTEDIT, LINEEDIT } QEditType;

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QEnergyStatWidget.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QEnergyStatWidget.h
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 #include <sofa/gui/qt/QGraphStatWidget.h>
+#include <sofa/gui/qt/config.h>
 
 namespace sofa::simulation::mechanicalvisitor
 {
@@ -30,7 +31,7 @@ namespace sofa::simulation::mechanicalvisitor
 namespace sofa::gui::qt
 {
 
-class QEnergyStatWidget : public QGraphStatWidget
+class SOFA_SOFAGUIQT_API QEnergyStatWidget : public QGraphStatWidget
 {
 
     Q_OBJECT

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QModelViewTableUpdater.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QModelViewTableUpdater.h
@@ -32,7 +32,7 @@
 namespace sofa::gui::qt
 {
 
-class QTableViewUpdater : public QTableView
+class SOFA_SOFAGUIQT_API QTableViewUpdater : public QTableView
 {
     Q_OBJECT
 
@@ -44,7 +44,7 @@ public slots:
 
 };
 
-class QTableModelUpdater : public QStandardItemModel
+class SOFA_SOFAGUIQT_API QTableModelUpdater : public QStandardItemModel
 {
     Q_OBJECT
     bool m_isReadOnly ;

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QMomentumStatWidget.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QMomentumStatWidget.h
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 #include <sofa/gui/qt/QGraphStatWidget.h>
+#include <sofa/gui/qt/config.h>
 
 namespace sofa::simulation::mechanicalvisitor
 {
@@ -30,7 +31,7 @@ class MechanicalGetMomentumVisitor;
 namespace sofa::gui::qt
 {
 
-class QMomentumStatWidget : public QGraphStatWidget
+class SOFA_SOFAGUIQT_API QMomentumStatWidget : public QGraphStatWidget
 {
 
     Q_OBJECT

--- a/modules/SofaGuiQt/src/sofa/gui/qt/QMouseWheelAdjustementGuard.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/QMouseWheelAdjustementGuard.h
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #pragma once
 #include <QObject>
+#include <sofa/gui/qt/config.h>
 
 namespace sofa::gui::qt
 {
@@ -33,7 +34,7 @@ namespace sofa::gui::qt
 ///
 /// This code is grabbed from:
 /// https://stackoverflow.com/questions/5821802/qspinbox-inside-a-qscrollarea-how-to-prevent-spin-box-from-stealing-focus-when
-class QMouseWheelAdjustmentGuard : public QObject
+class SOFA_SOFAGUIQT_API QMouseWheelAdjustmentGuard : public QObject
 {
 public:
     explicit QMouseWheelAdjustmentGuard(QObject *parent);


### PR DESCRIPTION
Those macro are needed if you are trying to enhance the gui from your plugin linking with SofaGuiQt



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
