### PR TITLE
[SofaCUDA] Add support of CudaVector for qt gui dataWidget

### DIFF
--- a/applications/plugins/SofaCUDA/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/CMakeLists.txt
@@ -255,6 +255,12 @@ else()
     message(STATUS "SofaCUDA: Plugin VolumetricRendering was not enabled/found, therefore CudaTetrahedralVisualModel will not be compiled.")
 endif()
 
+sofa_find_package(SofaGuiQt QUIET)
+if(SofaGuiQt_FOUND)
+    list(APPEND HEADER_FILES sofa/gpu/gui/CudaDataWidget.h)
+    list(APPEND SOURCE_FILES sofa/gpu/gui/CudaDataWidget.cpp)
+endif()
+
 find_package(SofaDistanceGrid QUIET)
 sofa_find_package(MiniFlowVR QUIET)
 
@@ -409,6 +415,10 @@ endif()
 
 if(MiniFlowVR_FOUND)
     target_link_libraries(${PROJECT_NAME} miniFlowVR)
+endif()
+
+if(SofaGuiQt_FOUND)
+    target_link_libraries(${PROJECT_NAME} SofaGuiQt)
 endif()
 
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/gui/CudaDataWidget.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/gui/CudaDataWidget.cpp
@@ -1,0 +1,79 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/gpu/gui/CudaDataWidget.h>
+#include <sofa/gpu/cuda/CudaTypes.h>
+#include <sofa/helper/Factory.inl>
+#include <sofa/gui/qt/DataWidget.h>
+#include <sofa/gui/qt/SimpleDataWidget.h>
+#include <sofa/gui/qt/TableDataWidget.h>
+
+namespace sofa::gui::qt
+{
+using sofa::helper::Creator;
+using namespace sofa::type;
+using namespace sofa::defaulttype;
+
+Creator<DataWidgetFactory, SimpleDataWidget< Vec<1, int> > > DWClass_Vec12i("default", true);
+
+template class SOFA_GPU_CUDA_API TDataWidget<sofa::gpu::cuda::CudaVector<int> >;
+template class SOFA_GPU_CUDA_API TDataWidget<sofa::gpu::cuda::CudaVector<unsigned int> >;
+template class SOFA_GPU_CUDA_API TDataWidget<sofa::gpu::cuda::CudaVector<float> >;
+template class SOFA_GPU_CUDA_API TDataWidget<sofa::gpu::cuda::CudaVector<double> >;
+
+template class SOFA_GPU_CUDA_API TDataWidget<sofa::gpu::cuda::CudaVector<Vec1i> >;
+template class SOFA_GPU_CUDA_API TDataWidget<sofa::gpu::cuda::CudaVector<Vec2i> >;
+template class SOFA_GPU_CUDA_API TDataWidget<sofa::gpu::cuda::CudaVector<Vec3i> >;
+template class SOFA_GPU_CUDA_API TDataWidget<sofa::gpu::cuda::CudaVector<Vec4i> >;
+
+template class SOFA_GPU_CUDA_API TDataWidget<sofa::gpu::cuda::CudaVector<Vec1f> >;
+template class SOFA_GPU_CUDA_API TDataWidget<sofa::gpu::cuda::CudaVector<Vec2f> >;
+template class SOFA_GPU_CUDA_API TDataWidget<sofa::gpu::cuda::CudaVector<Vec3f> >;
+template class SOFA_GPU_CUDA_API TDataWidget<sofa::gpu::cuda::CudaVector<Vec4f> >;
+
+template class SOFA_GPU_CUDA_API TDataWidget<sofa::gpu::cuda::CudaVector<Vec1d> >;
+template class SOFA_GPU_CUDA_API TDataWidget<sofa::gpu::cuda::CudaVector<Vec2d> >;
+template class SOFA_GPU_CUDA_API TDataWidget<sofa::gpu::cuda::CudaVector<Vec3d> >;
+template class SOFA_GPU_CUDA_API TDataWidget<sofa::gpu::cuda::CudaVector<Vec4d> >;
+
+
+Creator<DataWidgetFactory, TableDataWidget< sofa::gpu::cuda::CudaVector<int>, TABLE_HORIZONTAL > > DWClass_cudaVectori("default", true);
+Creator<DataWidgetFactory, TableDataWidget< sofa::gpu::cuda::CudaVector<unsigned int>, TABLE_HORIZONTAL > > DWClass_cudaVectorui("default", true);
+Creator<DataWidgetFactory, TableDataWidget< sofa::gpu::cuda::CudaVector<float>, TABLE_HORIZONTAL > > DWClass_cudaVectorf("default", true);
+Creator<DataWidgetFactory, TableDataWidget< sofa::gpu::cuda::CudaVector<double>, TABLE_HORIZONTAL > > DWClass_cudaVectord("default", true);
+
+Creator<DataWidgetFactory, TableDataWidget< sofa::gpu::cuda::CudaVector<Vec1i> > > DWClass_cudaVectorVec1i("default", true);
+Creator<DataWidgetFactory, TableDataWidget< sofa::gpu::cuda::CudaVector<Vec2i> > > DWClass_cudaVectorVec2i("default", true);
+Creator<DataWidgetFactory, TableDataWidget< sofa::gpu::cuda::CudaVector<Vec3i> > > DWClass_cudaVectorVec3i("default", true);
+Creator<DataWidgetFactory, TableDataWidget< sofa::gpu::cuda::CudaVector<Vec4i> > > DWClass_cudaVectorVec4i("default", true);
+
+Creator<DataWidgetFactory, TableDataWidget< sofa::gpu::cuda::CudaVector<Vec1f> > > DWClass_cudaVectorVec1f("default", true);
+Creator<DataWidgetFactory, TableDataWidget< sofa::gpu::cuda::CudaVector<Vec2f> > > DWClass_cudaVectorVec2f("default", true);
+Creator<DataWidgetFactory, TableDataWidget< sofa::gpu::cuda::CudaVector<Vec3f> > > DWClass_cudaVectorVec3f("default", true);
+Creator<DataWidgetFactory, TableDataWidget< sofa::gpu::cuda::CudaVector<Vec4f> > > DWClass_cudaVectorVec4f("default", true);
+
+Creator<DataWidgetFactory, TableDataWidget< sofa::gpu::cuda::CudaVector<Vec1d> > > DWClass_cudaVectorVec1d("default", true);
+Creator<DataWidgetFactory, TableDataWidget< sofa::gpu::cuda::CudaVector<Vec2d> > > DWClass_cudaVectorVec2d("default", true);
+Creator<DataWidgetFactory, TableDataWidget< sofa::gpu::cuda::CudaVector<Vec3d> > > DWClass_cudaVectorVec3d("default", true);
+Creator<DataWidgetFactory, TableDataWidget< sofa::gpu::cuda::CudaVector<Vec4d> > > DWClass_cudaVectorVec4d("default", true);
+
+
+} // namespace sofa::gui::qt

--- a/applications/plugins/SofaCUDA/sofa/gpu/gui/CudaDataWidget.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/gui/CudaDataWidget.h
@@ -1,0 +1,62 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <sofa/gpu/cuda/CudaTypes.h>
+#include <sofa/gui/qt/QModelViewTableDataContainer.h>
+
+namespace sofa::gui::qt
+{
+////////////////////////////////////////////////////////////////
+/// variable-sized vectors support
+////////////////////////////////////////////////////////////////
+
+template<class T>
+class vector_data_trait < sofa::gpu::cuda::CudaVector<T> >
+{
+public:
+    typedef sofa::gpu::cuda::CudaVector<T> data_type;
+    typedef T value_type;
+    enum { NDIM = 1 };
+    static int size(const data_type& d) {
+        return d.size();
+    }
+    static const char* header(const data_type& /*d*/, int /*i*/ = 0)
+    {
+        return nullptr;
+    }
+    static const value_type* get(const data_type& d, int i = 0)
+    {
+        return ((unsigned)i < (unsigned)size(d)) ? &(d[i]) : nullptr;
+    }
+    static void set(const value_type& v, data_type& d, int i = 0)
+    {
+        if ((unsigned)i < (unsigned)size(d))
+            d[i] = v;
+    }
+    static void resize(int s, data_type& d)
+    {
+        d.resize(s);
+    }
+};
+
+
+} // namespace sofa::gui::qt


### PR DESCRIPTION
This is just to better display the CudaVector inside the qt gui.

Before:
![SOFA v21 12 99 - C__projects_sofa-src_applications_plugins_SofaCUDA_scenes_cpu-gpu_validation_CudaStiffSpringForceField scn 12_22_2021 4_34_15 PM](https://user-images.githubusercontent.com/21199245/147117105-858be56c-1440-4bac-bca8-020efcaa81df.png)


After:
![SOFA v21 12 99 - C__projects_sofa-src_applications_plugins_SofaCUDA_scenes_cpu-gpu_validation_CudaStiffSpringForceField scn 12_22_2021 4_33_29 PM](https://user-images.githubusercontent.com/21199245/147116953-03eda549-2825-42b0-ac81-5855e658b51b.png)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
