### PR TITLE
[SofaBoundaryCondition] Sanitize

### DIFF
--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.inl
@@ -204,9 +204,9 @@ void AffineMovementConstraint<DataTypes>::projectMatrix( sofa::linearalgebra::Ba
     // clears the rows and columns associated with constrained particles
     const unsigned blockSize = DataTypes::deriv_total_size;
 
-    for(SetIndexArray::const_iterator it= m_indices.getValue().begin(), iend=m_indices.getValue().end(); it!=iend; it++ )
+    for (const auto id : m_indices.getValue())
     {
-        M->clearRowsCols((*it) * blockSize,(*it+1) * (blockSize) );
+        M->clearRowsCols( id * blockSize, (id+1) * blockSize );
     }
 }
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.inl
@@ -96,9 +96,7 @@ void AffineMovementConstraint<DataTypes>::init()
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
-    sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();
-
-    if (_topology)
+    if (sofa::core::topology::BaseMeshTopology* _topology = l_topology.get())
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";        
 
@@ -292,12 +290,12 @@ template <class DataTypes>
 void AffineMovementConstraint<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
     const SetIndexArray & indices = m_indices.getValue();
-    std::vector< Vector3 > points;
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
     Vector3 point;
 
     if(m_drawConstrainedPoints.getValue())
     {
+        std::vector< Vector3 > points;
         for( auto& index : indices )
         {
             point = DataTypes::getCPos(x[index]);

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.inl
@@ -202,7 +202,7 @@ template <class DataTypes>
 void AffineMovementConstraint<DataTypes>::projectMatrix( sofa::linearalgebra::BaseMatrix* M, unsigned /*offset*/ )
 {
     // clears the rows and columns associated with constrained particles
-    unsigned blockSize = DataTypes::deriv_total_size;
+    const unsigned blockSize = DataTypes::deriv_total_size;
 
     for(SetIndexArray::const_iterator it= m_indices.getValue().begin(), iend=m_indices.getValue().end(); it!=iend; it++ )
     {
@@ -248,9 +248,9 @@ void AffineMovementConstraint<defaulttype::Rigid3Types>::transform(const SetInde
 {
     // Get quaternion and translation values
     RotationMatrix rotationMat(0);
-    Quat quat =  m_quaternion.getValue();
+    const Quat quat =  m_quaternion.getValue();
     quat.toMatrix(rotationMat);
-    Vector3 translation = m_translation.getValue();
+    const Vector3 translation = m_translation.getValue();
 
     // Apply transformation
     for (size_t i=0; i < indices.size() ; ++i)

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ConicalForceField.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ConicalForceField.h
@@ -62,7 +62,8 @@ protected:
         int index;
         Coord normal;
         Coord pos;
-        Contact( int index=0, Coord normal=Coord(),Coord pos=Coord())
+
+        explicit Contact( int index=0, Coord normal=Coord(),Coord pos=Coord())
             : index(index),normal(normal),pos(pos)
         {
         }

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ConstantForceField.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ConstantForceField.h
@@ -103,7 +103,7 @@ public:
     void doUpdateInternal() override;
 
     /// Set a force to a given particle
-    void setForce( unsigned i, const Deriv& f );
+    void setForce( unsigned i, const Deriv& force );
 
     using Inherit::addAlias ;
     using Inherit::addKToMatrix;

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ConstantForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ConstantForceField.inl
@@ -369,13 +369,13 @@ void ConstantForceField<DataTypes>::computeForceFromTotalForce()
 
 
 template<class DataTypes>
-void ConstantForceField<DataTypes>::addForce(const core::MechanicalParams* params, DataVecDeriv& f1, const DataVecCoord& x1, const DataVecDeriv& v1)
+void ConstantForceField<DataTypes>::addForce(const core::MechanicalParams* params, DataVecDeriv& f, const DataVecCoord& x1, const DataVecDeriv& v1)
 {
     SOFA_UNUSED(params);
     SOFA_UNUSED(x1);
     SOFA_UNUSED(v1);
 
-    sofa::helper::WriteAccessor< core::objectmodel::Data< VecDeriv > > _f1 = f1;
+    sofa::helper::WriteAccessor< core::objectmodel::Data< VecDeriv > > _f1 = f;
     const VecIndex& indices = d_indices.getValue();
     const VecDeriv& forces = d_forces.getValue();
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ConstantForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ConstantForceField.inl
@@ -79,13 +79,13 @@ void ConstantForceField<DataTypes>::init()
     else
     {
         msg_info() << "No topology component found at path: " << l_topology.getLinkedPath() << ", nor in current context: " << this->getContext()->name;
-        core::behavior::BaseMechanicalState* state = this->getContext()->getMechanicalState();
+        const core::behavior::BaseMechanicalState* state = this->getContext()->getMechanicalState();
         m_systemSize = state->getSize();
     }
 
 
     const VecIndex & indices = d_indices.getValue();
-    auto indicesSize = indices.size();
+    const auto indicesSize = indices.size();
 
     if (d_indices.isSet() && indicesSize!=0)
     {
@@ -193,7 +193,7 @@ void ConstantForceField<DataTypes>::doUpdateInternal()
         msg_info() << "doUpdateInternal: data indices has changed";
 
         const VecIndex & indices = d_indices.getValue();
-        size_t indicesSize = indices.size();
+        const size_t indicesSize = indices.size();
 
         this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
 
@@ -280,7 +280,7 @@ void ConstantForceField<DataTypes>::doUpdateInternal()
 template<class DataTypes>
 bool ConstantForceField<DataTypes>::checkForce(const Deriv& force)
 {
-    size_t size = Deriv::spatial_dimensions;
+    const size_t size = Deriv::spatial_dimensions;
 
     for (size_t i=0; i<size; i++)
     {
@@ -380,7 +380,7 @@ void ConstantForceField<DataTypes>::addForce(const core::MechanicalParams* param
     const VecIndex& indices = d_indices.getValue();
     const VecDeriv& forces = d_forces.getValue();
 
-    size_t indicesSize = indices.size();
+    const size_t indicesSize = indices.size();
     m_systemSize = _f1.size();
 
     if (!d_indexFromEnd.getValue())
@@ -558,7 +558,7 @@ void ConstantForceField<DataTypes>::draw(const core::visual::VisualParams* vpara
             type::Vector3 p1( xx, xy, xz);
             type::Vector3 p2( aSC*fx+xx, aSC*fy+xy, aSC*fz+xz );
 
-            float norm = static_cast<float>((p2-p1).norm());
+            const float norm = static_cast<float>((p2-p1).norm());
 
             if( aSC > 0.0)
             {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ConstantForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ConstantForceField.inl
@@ -65,9 +65,8 @@ void ConstantForceField<DataTypes>::init()
     }
 
     // temprory pointer to topology
-    sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();    
 
-    if (_topology)
+    if (sofa::core::topology::BaseMeshTopology* _topology = l_topology.get())
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
         

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ConstantForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ConstantForceField.inl
@@ -46,6 +46,7 @@ ConstantForceField<DataTypes>::ConstantForceField()
     , d_showArrowSize(initData(&d_showArrowSize,SReal(0.0), "showArrowSize", "Size of the drawn arrows (0->no arrows, sign->direction of drawing. (default=0)"))
     , d_color(initData(&d_color, sofa::type::RGBAColor(0.2f,0.9f,0.3f,1.0f), "showColor", "Color for object display (default: [0.2,0.9,0.3,1.0])"))
     , l_topology(initLink("topology", "link to the topology container"))
+    , m_systemSize(0)
 {
     d_showArrowSize.setGroup("Visualization");
     d_color.setGroup("Visualization");

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/EdgePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/EdgePressureForceField.inl
@@ -171,7 +171,7 @@ void EdgePressureForceField<DataTypes>::initEdgeInformation()
     sofa::type::vector<EdgePressureInformation>& my_subset = *(edgePressureMap).beginEdit();
 
     const VecCoord& x0 = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
-    auto getEdgeLength = [x0](const sofa::topology::Edge& e, const VecCoord& pos)
+    auto getEdgeLength = [](const sofa::topology::Edge& e, const VecCoord& pos)
     {
         const auto& n0 = DataTypes::getCPos(pos[e[0]]);
         const auto& n1 = DataTypes::getCPos(pos[e[1]]);

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/EdgePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/EdgePressureForceField.inl
@@ -363,7 +363,7 @@ void EdgePressureForceField<DataTypes>::selectEdgesFromIndices(const type::vecto
 
     sofa::type::vector<EdgePressureInformation>& my_subset = *(edgePressureMap).beginEdit();
 
-    unsigned int sizeTest = m_topology->getNbEdges();
+    const unsigned int sizeTest = m_topology->getNbEdges();
 
     for (unsigned int i = 0; i < inputIndices.size(); ++i)
     {
@@ -418,7 +418,7 @@ void EdgePressureForceField<DataTypes>::draw(const core::visual::VisualParams* v
 
     vparams->drawTool()->saveLastState();
 
-    SReal aSC = arrowSizeCoef.getValue();
+    const SReal aSC = arrowSizeCoef.getValue();
 
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
     vparams->drawTool()->disableLighting();

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/EdgePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/EdgePressureForceField.inl
@@ -327,11 +327,10 @@ void EdgePressureForceField<DataTypes>::selectEdgesAlongPlane()
 {
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
     std::vector<bool> vArray;
-    unsigned int i;
 
     vArray.resize(x.size());
 
-    for( i=0; i<x.size(); ++i)
+    for( unsigned int i=0; i<x.size(); ++i)
     {
         vArray[i]=isPointInPlane(x[i]);
     }

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/EllipsoidForceField.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/EllipsoidForceField.h
@@ -62,7 +62,8 @@ protected:
     public:
         int index;
         Mat m;
-        Contact( int index=0, const Mat& m=Mat())
+
+        explicit Contact( int index=0, const Mat& m=Mat())
             : index(index), m(m)
         {
         }

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/EllipsoidForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/EllipsoidForceField.inl
@@ -175,8 +175,8 @@ void EllipsoidForceField<DataTypes>::draw(const core::visual::VisualParams* vpar
     DataTypes::get(cx, cy, cz, center.getValue());
     Real rx=1, ry=1, rz=1;
     DataTypes::get(rx, ry, rz, vradius.getValue());
-	sofa::type::Vector3 radii(rx, ry, (stiffness.getValue()>0 ? rz : -rz));
-	sofa::type::Vector3 vCenter(cx, cy, cz);
+    const sofa::type::Vector3 radii(rx, ry, (stiffness.getValue()>0 ? rz : -rz));
+    const sofa::type::Vector3 vCenter(cx, cy, cz);
 
     vparams->drawTool()->enableLighting();
     

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.cpp
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.cpp
@@ -110,7 +110,7 @@ void FixedConstraint<Rigid2Types>::draw(const core::visual::VisualParams* vparam
 
     const VecCoord& x =mstate->read(core::ConstVecCoordId::position())->getValue();
     vparams->drawTool()->setLightingEnabled(false);
-    sofa::type::RGBAColor color (1,0.5,0.5,1);
+    const sofa::type::RGBAColor color (1,0.5,0.5,1);
     std::vector<sofa::type::Vector3> vertices;
 
     if(d_fixAll.getValue())

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.h
@@ -106,7 +106,7 @@ public:
 
 
     void applyConstraint(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
-    void applyConstraint(const core::MechanicalParams* mparams, linearalgebra::BaseVector* vector, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
+    void applyConstraint(const core::MechanicalParams* mparams, linearalgebra::BaseVector* vect, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
 
     /** Project the given matrix (Experimental API).
       See doc in base parent class

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.inl
@@ -151,7 +151,7 @@ void  FixedConstraint<DataTypes>::checkIndices()
     if (!invalidIndices.empty())
     {
         std::sort( invalidIndices.begin(), invalidIndices.end(), std::greater<Index>() );
-        int max = invalidIndices.size()-1;
+        const int max = invalidIndices.size()-1;
         for (int i=max; i>= 0; i--)
         {
             removeConstraint(invalidIndices[i]);
@@ -166,7 +166,7 @@ void FixedConstraint<DataTypes>::projectMatrix( sofa::linearalgebra::BaseMatrix*
 
     if( d_fixAll.getValue() )
     {
-        unsigned size = this->mstate->getSize();
+        const unsigned size = this->mstate->getSize();
         for( unsigned i=0; i<size; i++ )
         {
             M->clearRowsCols( offset + i * blockSize, offset + (i+1) * (blockSize) );
@@ -290,7 +290,7 @@ void FixedConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* m
 
         if( d_fixAll.getValue() )
         {
-            unsigned size = this->mstate->getSize();
+            const unsigned size = this->mstate->getSize();
             for(unsigned int i=0; i<size; i++)
             {
                 // Reset Fixed Row and Col
@@ -322,10 +322,10 @@ template <class DataTypes>
 void FixedConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* mparams, linearalgebra::BaseVector* vect, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {
     SOFA_UNUSED(mparams);
-    int o = matrix->getGlobalOffset(this->mstate.get());
+    const int o = matrix->getGlobalOffset(this->mstate.get());
     if (o >= 0)
     {
-        unsigned int offset = (unsigned int)o;
+        const unsigned int offset = (unsigned int)o;
         const unsigned int N = Deriv::size();
 
         if( d_fixAll.getValue() )

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.inl
@@ -105,9 +105,7 @@ void FixedConstraint<DataTypes>::init()
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
-    sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();
-
-    if (_topology)
+    if (sofa::core::topology::BaseMeshTopology* _topology = l_topology.get())
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 
@@ -283,8 +281,7 @@ template <class DataTypes>
 void FixedConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {
     SOFA_UNUSED(mparams);
-    core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate.get());
-    if(r)
+    if(core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate.get()))
     {
         const unsigned int N = Deriv::size();
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedConstraint.inl
@@ -175,9 +175,9 @@ void FixedConstraint<DataTypes>::projectMatrix( sofa::linearalgebra::BaseMatrix*
     else
     {
         // clears the rows and columns associated with fixed particles
-        for(SetIndexArray::const_iterator it= d_indices.getValue().begin(), iend=d_indices.getValue().end(); it!=iend; it++ )
+        for (const auto id : d_indices.getValue())
         {
-            M->clearRowsCols( offset + (*it) * blockSize, offset + (*it+1) * (blockSize) );
+            M->clearRowsCols( offset + id * blockSize, offset + (id+1) * blockSize );
         }
     }
 }

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedPlaneConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedPlaneConstraint.h
@@ -93,7 +93,7 @@ public:
     void applyConstraint(const MechanicalParams* mparams,
                                  const MultiMatrixAccessor* matrix) override;
 
-    void applyConstraint(const MechanicalParams* mparams, BaseVector* vector,
+    void applyConstraint(const MechanicalParams* mparams, BaseVector* vect,
                                  const MultiMatrixAccessor* matrix) override;
 
     void setDirection (Coord dir);

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedPlaneConstraint.inl
@@ -87,10 +87,10 @@ void FixedPlaneConstraint<DataTypes>::applyConstraint(const MechanicalParams* mp
                                                       const MultiMatrixAccessor* matrix)
 {
     SOFA_UNUSED(mparams);
-    int o = matrix->getGlobalOffset(mstate.get());
+    const int o = matrix->getGlobalOffset(mstate.get());
     if (o >= 0)
     {
-        unsigned int offset = (unsigned int)o;
+        const unsigned int offset = (unsigned int)o;
         /// Implement plane constraint only when the direction is along the coordinates directions
         // TODO : generalize projection to any direction
         Coord dir=d_direction.getValue();
@@ -145,7 +145,7 @@ template <class DataTypes>
 void FixedPlaneConstraint<DataTypes>::projectMatrix( sofa::linearalgebra::BaseMatrix* M, unsigned /*offset*/ )
 {
     /// clears the rows and columns associated with constrained particles
-    unsigned blockSize = DataTypes::deriv_total_size;
+    const unsigned blockSize = DataTypes::deriv_total_size;
 
     for(auto& index : d_indices.getValue())
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedPlaneConstraint.inl
@@ -59,8 +59,7 @@ template <class DataTypes>
 void FixedPlaneConstraint<DataTypes>::applyConstraint(const MechanicalParams* mparams, const MultiMatrixAccessor* matrix)
 {
     SOFA_UNUSED(mparams);
-    MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(mstate.get());
-    if(r)
+    if(const MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(mstate.get()))
     {
         /// Implement plane constraint only when the direction is along the coordinates directions
         // TODO : generalize projection to any direction
@@ -198,9 +197,7 @@ void FixedPlaneConstraint<DataTypes>::init()
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
-    sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();
-
-    if (_topology)
+    if (sofa::core::topology::BaseMeshTopology* _topology = l_topology.get())
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
         

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedRotationConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedRotationConstraint.inl
@@ -87,9 +87,9 @@ void FixedRotationConstraint<DataTypes>::projectPosition(const core::MechanicalP
     for (unsigned int i = 0; i < x.size(); ++i)
     {
         // Current orientations
-        const sofa::type::Quat<SReal> Q = x[i].getOrientation();
+        const sofa::type::Quat<SReal>& Q = x[i].getOrientation();
         // Previous orientations
-        const sofa::type::Quat<SReal> Q_prev = previousOrientation[i];
+        const sofa::type::Quat<SReal>& Q_prev = previousOrientation[i];
 
         auto project = [](const Vec3 a, const Vec3 b) -> Vec3 {
             return (a * b) * b;

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedRotationConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedRotationConstraint.inl
@@ -87,9 +87,9 @@ void FixedRotationConstraint<DataTypes>::projectPosition(const core::MechanicalP
     for (unsigned int i = 0; i < x.size(); ++i)
     {
         // Current orientations
-        sofa::type::Quat<SReal> Q = x[i].getOrientation();
+        const sofa::type::Quat<SReal> Q = x[i].getOrientation();
         // Previous orientations
-        sofa::type::Quat<SReal> Q_prev = previousOrientation[i];
+        const sofa::type::Quat<SReal> Q_prev = previousOrientation[i];
 
         auto project = [](const Vec3 a, const Vec3 b) -> Vec3 {
             return (a * b) * b;

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedTranslationConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedTranslationConstraint.inl
@@ -183,7 +183,7 @@ void FixedTranslationConstraint<DataTypes>::draw(const core::visual::VisualParam
     vparams->drawTool()->disableLighting();
 
     std::vector<sofa::type::Vector3> vertices;
-    sofa::type::RGBAColor color(1, 0.5, 0.5, 1);
+    const sofa::type::RGBAColor color(1, 0.5, 0.5, 1);
 
     if (f_fixAll.getValue() == true)
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedTranslationConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/FixedTranslationConstraint.inl
@@ -84,9 +84,7 @@ void FixedTranslationConstraint<DataTypes>::init()
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
-    sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();
-    
-    if (_topology)
+    if (sofa::core::topology::BaseMeshTopology* _topology = l_topology.get())
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/HermiteSplineConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/HermiteSplineConstraint.h
@@ -86,7 +86,7 @@ public:
     SingleLink<HermiteSplineConstraint<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
     
 protected:
-    HermiteSplineConstraint(core::behavior::MechanicalState<DataTypes>* mstate = nullptr);
+    explicit HermiteSplineConstraint(core::behavior::MechanicalState<DataTypes>* mstate = nullptr);
 
     ~HermiteSplineConstraint();
 public:

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/HermiteSplineConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/HermiteSplineConstraint.inl
@@ -75,9 +75,7 @@ void HermiteSplineConstraint<DataTypes>::init()
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
-    sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();
-
-    if (_topology)
+    if (sofa::core::topology::BaseMeshTopology* _topology = l_topology.get())
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearForceField.inl
@@ -113,9 +113,9 @@ void LinearForceField<DataTypes>::clearKeyForces()
 }
 
 template<class DataTypes>
-void LinearForceField<DataTypes>::addForce(const core::MechanicalParams* /*mparams*/, DataVecDeriv& f1, const DataVecCoord& /*p1*/, const DataVecDeriv&)
+void LinearForceField<DataTypes>::addForce(const core::MechanicalParams* /*mparams*/, DataVecDeriv& f, const DataVecCoord& /*p1*/, const DataVecDeriv&)
 {
-    sofa::helper::WriteAccessor< core::objectmodel::Data< VecDeriv > > _f1 = f1;
+    sofa::helper::WriteAccessor< core::objectmodel::Data< VecDeriv > > _f1 = f;
 
     Real cT = (Real) this->getContext()->getTime();
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearForceField.inl
@@ -147,8 +147,8 @@ void LinearForceField<DataTypes>::addForce(const core::MechanicalParams* /*mpara
                     nextF = *it_f;
                     finished = true;
                 }
-                it_t++;
-                it_f++;
+                ++it_t;
+                ++it_f;
             }
             if (finished)
             {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearForceField.inl
@@ -54,9 +54,7 @@ void LinearForceField<DataTypes>::init()
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
-    sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();
-    
-    if (_topology)
+    if (sofa::core::topology::BaseMeshTopology* _topology = l_topology.get())
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
         

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.inl
@@ -115,9 +115,7 @@ void LinearMovementConstraint<DataTypes>::init()
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
-    sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();
-
-    if (_topology)
+    if (sofa::core::topology::BaseMeshTopology* _topology = l_topology.get())
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 
@@ -355,8 +353,7 @@ template <class DataTypes>
 void LinearMovementConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {
     SOFA_UNUSED(mparams);
-    core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate.get());
-    if(r)
+    if(const core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate.get()))
     {
         const unsigned int N = Deriv::size();
         const SetIndexArray & indices = m_indices.getValue();

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.inl
@@ -329,8 +329,8 @@ void LinearMovementConstraint<DataTypes>::findKeyTimes()
                 nextM = *it_m;
                 finished = true;
             }
-            it_t++;
-            it_m++;
+            ++it_t;
+            ++it_m;
         }
     }
 }
@@ -342,9 +342,9 @@ void LinearMovementConstraint<DataTypes>::projectMatrix( sofa::linearalgebra::Ba
     static const unsigned blockSize = DataTypes::deriv_total_size;
 
     // clears the rows and columns associated with fixed particles
-    for(SetIndexArray::const_iterator it= m_indices.getValue().begin(), iend=m_indices.getValue().end(); it!=iend; it++ )
+    for (const auto id : m_indices.getValue())
     {
-        M->clearRowsCols( offset + (*it) * blockSize, offset + (*it+1) * (blockSize) );
+        M->clearRowsCols( offset + id * blockSize, offset + (id+1) * blockSize );
     }
     
 }

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.inl
@@ -377,10 +377,10 @@ template <class DataTypes>
 void LinearMovementConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* mparams, linearalgebra::BaseVector* vector, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {
     SOFA_UNUSED(mparams);
-    int o = matrix->getGlobalOffset(this->mstate.get());
+    const int o = matrix->getGlobalOffset(this->mstate.get());
     if (o >= 0)
     {
-        unsigned int offset = (unsigned int)o;
+        const unsigned int offset = (unsigned int)o;
         const unsigned int N = Deriv::size();
 
         const SetIndexArray & indices = m_indices.getValue();
@@ -400,7 +400,7 @@ void LinearMovementConstraint<DataTypes>::draw(const core::visual::VisualParams*
         return;
 
     vparams->drawTool()->saveLastState();
-    sofa::type::RGBAColor color(1, 0.5, 0.5, 1);
+    const sofa::type::RGBAColor color(1, 0.5, 0.5, 1);
 
     if (showMovement.getValue())
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearMovementConstraint.inl
@@ -43,6 +43,7 @@ LinearMovementConstraint<DataTypes>::LinearMovementConstraint()
     , d_relativeMovements( initData(&d_relativeMovements, bool(true), "relativeMovements", "If true, movements are relative to first position, absolute otherwise") )
     , showMovement( initData(&showMovement, bool(false), "showMovement", "Visualization of the movement to be applied to constrained dofs."))
     , l_topology(initLink("topology", "link to the topology container"))
+    , finished(false)
 {
     // default to indice 0
     m_indices.beginEdit()->push_back(0);

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearVelocityConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearVelocityConstraint.inl
@@ -112,9 +112,7 @@ void LinearVelocityConstraint<TDataTypes>::init()
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
-    sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();
-
-    if (_topology)
+    if (sofa::core::topology::BaseMeshTopology* _topology = l_topology.get())
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearVelocityConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearVelocityConstraint.inl
@@ -41,6 +41,7 @@ LinearVelocityConstraint<TDataTypes>::LinearVelocityConstraint()
     , d_keyVelocities(  initData(&d_keyVelocities,"velocities","velocities corresponding to the key times") )
     , d_coordinates( initData(&d_coordinates, "coordinates", "coordinates on which to apply velocities") )
     , l_topology(initLink("topology", "link to the topology container"))
+    , finished(false)
 {
     d_indices.beginEdit()->push_back(0);
     d_indices.endEdit();

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearVelocityConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearVelocityConstraint.inl
@@ -323,7 +323,7 @@ void LinearVelocityConstraint<TDataTypes>::draw(const core::visual::VisualParams
     vparams->drawTool()->disableLighting();
 
     std::vector<sofa::type::Vector3> vertices;
-    sofa::type::RGBAColor color(1, 0.5, 0.5, 1);
+    const sofa::type::RGBAColor color(1, 0.5, 0.5, 1);
     const VecDeriv& keyVelocities = d_keyVelocities.getValue();
     const SetIndexArray & indices = d_indices.getValue();
     for (unsigned int i=0 ; i<keyVelocities.size()-1 ; i++)

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearVelocityConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearVelocityConstraint.inl
@@ -301,8 +301,8 @@ void LinearVelocityConstraint<DataTypes>::findKeyTimes()
                 nextV = *it_v;
                 finished = true;
             }
-            it_t++;
-            it_v++;
+            ++it_t;
+            ++it_v;
         }
     }
 }// LinearVelocityConstraint::findKeyTimes

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/OscillatingTorsionPressureForceField.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/OscillatingTorsionPressureForceField.h
@@ -114,7 +114,7 @@ public:
 
     // returns the rotation of the driven part of the object relative to the original state (in radians)
     // this value is updated in addForce()
-    SReal getRotationAngle() { return rotationAngle; }
+    SReal getRotationAngle() const { return rotationAngle; }
 
 protected :
     OscillatingTorsionPressureForceField();

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/OscillatingTorsionPressureForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/OscillatingTorsionPressureForceField.inl
@@ -244,11 +244,10 @@ void OscillatingTorsionPressureForceField<DataTypes>::selectTrianglesAlongPlane(
 {
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
     std::vector<bool> vArray;
-    unsigned int i;
 
     vArray.resize(x.size());
 
-    for( i=0; i<x.size(); ++i)
+    for( unsigned int i=0; i<x.size(); ++i)
     {
         vArray[i]=isPointInPlane(x[i]);
     }

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/OscillatingTorsionPressureForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/OscillatingTorsionPressureForceField.inl
@@ -104,7 +104,7 @@ template<class DataTypes>
 SReal OscillatingTorsionPressureForceField<DataTypes>::getAmplitude()
 {
     SReal t = this->getContext()->getTime();
-    SReal val = cos( 6.2831853 * frequency.getValue() * t );
+    const SReal val = cos( 6.2831853 * frequency.getValue() * t );
     return val;
 }
 
@@ -136,7 +136,7 @@ void OscillatingTorsionPressureForceField<DataTypes>::addForce(const core::Mecha
     rotationAngle = avgRotAngle;
 
     // calculate and apply penalty forces to ideal positions
-    type::Quat<SReal> quat( axis.getValue(), avgRotAngle );
+    const type::Quat<SReal> quat( axis.getValue(), avgRotAngle );
     Real avgError = 0, maxError = 0;
     int pointCnt = 0;
     Real appliedMoment = 0;
@@ -309,7 +309,7 @@ void OscillatingTorsionPressureForceField<DataTypes>::draw(const core::visual::V
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
 
     vparams->drawTool()->disableLighting();
-    sofa::type::RGBAColor color = sofa::type::RGBAColor::green();
+    const sofa::type::RGBAColor color = sofa::type::RGBAColor::green();
     std::vector<sofa::type::Vector3> vertices;
 
     const sofa::type::vector<Index>& my_map = trianglePressureMap.getMap2Elements();

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/OscillatorConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/OscillatorConstraint.h
@@ -85,7 +85,7 @@ protected:
 
 
 public:
-    OscillatorConstraint(core::behavior::MechanicalState<TDataTypes>* mstate=nullptr);
+    explicit OscillatorConstraint(core::behavior::MechanicalState<TDataTypes>* mstate=nullptr);
     ~OscillatorConstraint() override ;
 
     OscillatorConstraint<TDataTypes>* addConstraint(unsigned index,

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/OscillatorConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/OscillatorConstraint.inl
@@ -117,7 +117,7 @@ void OscillatorConstraint<TDataTypes>::projectJacobianMatrix(const core::Mechani
 }
 
 template <class TDataTypes>
-OscillatorConstraint<TDataTypes>::Oscillator::Oscillator()
+OscillatorConstraint<TDataTypes>::Oscillator::Oscillator(): index(0)
 {
 }
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ParabolicConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ParabolicConstraint.h
@@ -80,7 +80,7 @@ protected:
     /// the quaternion doing the projection
     QuatR m_projection;
 
-    ParabolicConstraint(core::behavior::MechanicalState<DataTypes>* mstate = nullptr);
+    explicit ParabolicConstraint(core::behavior::MechanicalState<DataTypes>* mstate = nullptr);
 
     ~ParabolicConstraint();
 public:

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ParabolicConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ParabolicConstraint.inl
@@ -224,7 +224,7 @@ void ParabolicConstraint<DataTypes>::draw(const core::visual::VisualParams* vpar
     Real nbStep = t/dt;
 
     vparams->drawTool()->disableLighting();
-    sofa::type::RGBAColor color(1, 0.5, 0.5, 1);
+    const sofa::type::RGBAColor color(1, 0.5, 0.5, 1);
     std::vector<sofa::type::Vector3> vertices;
 
     for (unsigned int i=0 ; i< nbStep ; i++)

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ParabolicConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ParabolicConstraint.inl
@@ -65,9 +65,7 @@ void ParabolicConstraint<DataTypes>::init()
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
-    sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();
-
-    if (_topology)
+    if (sofa::core::topology::BaseMeshTopology* _topology = l_topology.get())
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialFixedConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialFixedConstraint.inl
@@ -213,8 +213,7 @@ template <class DataTypes>
 void PartialFixedConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {
     SOFA_UNUSED(mparams);
-    core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate.get());
-    if(r)
+    if(const core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate.get()))
     {
         const unsigned int N = Deriv::size();
         const VecBool& blockedDirection = d_fixedDirections.getValue();

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialFixedConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialFixedConstraint.inl
@@ -171,10 +171,10 @@ template <class DataTypes>
 void PartialFixedConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* mparams, linearalgebra::BaseVector* vector, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {
     SOFA_UNUSED(mparams);
-    int o = matrix->getGlobalOffset(this->mstate.get());
+    const int o = matrix->getGlobalOffset(this->mstate.get());
     if (o >= 0)
     {
-        unsigned int offset = (unsigned int)o;
+        const unsigned int offset = (unsigned int)o;
         const unsigned int N = Deriv::size();
 
         const VecBool& blockedDirection = d_fixedDirections.getValue();
@@ -195,7 +195,7 @@ void PartialFixedConstraint<DataTypes>::applyConstraint(const core::MechanicalPa
         else
         {
             const SetIndexArray & indices = this->d_indices.getValue();
-            for (unsigned int index : indices)
+            for (const unsigned int index : indices)
             {
                 for (unsigned int c = 0; c < N; ++c)
                 {
@@ -222,7 +222,7 @@ void PartialFixedConstraint<DataTypes>::applyConstraint(const core::MechanicalPa
 
         if( this->d_fixAll.getValue() )
         {
-            unsigned size = this->mstate->getSize();
+            const unsigned size = this->mstate->getSize();
             for(unsigned int i=0; i<size; i++)
             {
                 // Reset Fixed Row and Col
@@ -277,7 +277,7 @@ void PartialFixedConstraint<DataTypes>::projectMatrix( sofa::linearalgebra::Base
 
     if( this->d_fixAll.getValue() )
     {
-        unsigned size = this->mstate->getSize();
+        const unsigned size = this->mstate->getSize();
         for( unsigned i=0; i<size; i++ )
         {
             for (unsigned int c = 0; c < blockSize; ++c)

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
@@ -430,7 +430,7 @@ template <class DataTypes>
 void PartialLinearMovementConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* mparams, linearalgebra::BaseVector* vector, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {
     SOFA_UNUSED(mparams);
-    int o = matrix->getGlobalOffset(this->mstate.get());
+    const int o = matrix->getGlobalOffset(this->mstate.get());
     if (o >= 0) {
         unsigned int offset = (unsigned int)o;
         VecBool movedDirection = movedDirections.getValue();
@@ -458,7 +458,7 @@ void PartialLinearMovementConstraint<DataTypes>::draw(const core::visual::Visual
         return;
 
     sofa::type::vector<type::Vector3> vertices;
-    sofa::type::RGBAColor color(1, 0.5, 0.5, 1);
+    const sofa::type::RGBAColor color(1, 0.5, 0.5, 1);
 
     if (showMovement.getValue())
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
@@ -461,7 +461,6 @@ void PartialLinearMovementConstraint<DataTypes>::draw(const core::visual::Visual
     if (showMovement.getValue())
     {
         vparams->drawTool()->disableLighting();
-        type::Vector3 v0, v1;
 
         const SetIndexArray & indices = m_indices.getValue();
         const VecDeriv& keyMovements = m_keyMovements.getValue();
@@ -469,8 +468,8 @@ void PartialLinearMovementConstraint<DataTypes>::draw(const core::visual::Visual
         {
             for (SetIndexArray::const_iterator it = indices.begin(); it != indices.end(); ++it)
             {
-                v0 = DataTypes::getCPos(x0[*it]) + DataTypes::getDPos(keyMovements[i]);
-                v1 = DataTypes::getCPos(x0[*it]) + DataTypes::getDPos(keyMovements[i + 1]);
+                const type::Vector3 v0 { DataTypes::getCPos(x0[*it]) + DataTypes::getDPos(keyMovements[i]) };
+                const type::Vector3 v1 { DataTypes::getCPos(x0[*it]) + DataTypes::getDPos(keyMovements[i + 1]) };
 
                 vertices.push_back(v0);
                 vertices.push_back(v1);

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
@@ -394,8 +394,8 @@ void PartialLinearMovementConstraint<DataTypes>::findKeyTimes()
                 nextM = *it_m;
                 finished = true;
             }
-            it_t++;
-            it_m++;
+            ++it_t;
+            ++it_m;
         }
     }
 }

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
@@ -130,9 +130,7 @@ void PartialLinearMovementConstraint<DataTypes>::init()
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
-    sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();
-
-    if (_topology)
+    if (sofa::core::topology::BaseMeshTopology* _topology = l_topology.get())
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 
@@ -406,9 +404,9 @@ void PartialLinearMovementConstraint<DataTypes>::applyConstraint(const core::Mec
 {
     SOFA_UNUSED(mparams);
     const SetIndexArray & indices = m_indices.getValue();
-    core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate.get());
 
-    if (r) {
+    if (core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate.get()))
+    {
         VecBool movedDirection = movedDirections.getValue();
         for (SetIndexArray::const_iterator it = indices.begin(); it != indices.end(); ++it)
         {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialLinearMovementConstraint.inl
@@ -53,6 +53,7 @@ PartialLinearMovementConstraint<DataTypes>::PartialLinearMovementConstraint()
     , Z0 ( initData ( &Z0, Real(0.0),"Z0","Size of specimen in Z-direction" ) )
     , movedDirections( initData(&movedDirections,"movedDirections","for each direction, 1 if moved, 0 if free") )
     , l_topology(initLink("topology", "link to the topology container"))
+    , finished(false)
 {
     // default to indice 0
     m_indices.beginEdit()->push_back(0);

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PatchTestMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PatchTestMovementConstraint.inl
@@ -96,9 +96,7 @@ void PatchTestMovementConstraint<DataTypes>::init()
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
-    sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();
-
-    if (_topology)
+    if (sofa::core::topology::BaseMeshTopology* _topology = l_topology.get())
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 
@@ -430,12 +428,12 @@ template <class DataTypes>
 void PatchTestMovementConstraint<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
     const SetIndexArray & indices = d_indices.getValue();
-    std::vector< type::Vector3 > points;
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
     type::Vector3 point;
 
     if(d_drawConstrainedPoints.getValue())
     {
+        std::vector< type::Vector3 > points;
         for (unsigned int index : indices)
         {
             point = DataTypes::getCPos(x[index]);

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PatchTestMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PatchTestMovementConstraint.inl
@@ -112,7 +112,7 @@ void PatchTestMovementConstraint<DataTypes>::init()
 
     const SetIndexArray & indices = d_indices.getValue();
 
-    Index maxIndex=this->mstate->getSize();
+    const Index maxIndex=this->mstate->getSize();
     for (unsigned int i=0; i<indices.size(); ++i)
     {
         const Index index=indices[i];
@@ -246,7 +246,7 @@ void PatchTestMovementConstraint<DataTypes>::projectVelocity(const core::Mechani
 template <class DataTypes>
 void PatchTestMovementConstraint<DataTypes>::projectPosition(const core::MechanicalParams* /*mparams*/, DataVecCoord& xData)
 {
-    sofa::simulation::Node::SPtr root = down_cast<sofa::simulation::Node>( this->getContext()->getRootContext() );
+    const sofa::simulation::Node::SPtr root = down_cast<sofa::simulation::Node>( this->getContext()->getRootContext() );
     helper::WriteAccessor<DataVecCoord> x = xData;
     const SetIndexArray & indices = d_indices.getValue();
 
@@ -293,7 +293,7 @@ template <class DataTypes>
 void PatchTestMovementConstraint<DataTypes>::projectMatrix( sofa::linearalgebra::BaseMatrix* M, unsigned offset )
 {
     // clears the rows and columns associated with constrained particles
-    unsigned blockSize = DataTypes::deriv_total_size;
+    const unsigned blockSize = DataTypes::deriv_total_size;
 
     for(SetIndexArray::const_iterator it= d_indices.getValue().begin(), iend=d_indices.getValue().end(); it!=iend; it++ )
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PatchTestMovementConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PatchTestMovementConstraint.inl
@@ -295,9 +295,9 @@ void PatchTestMovementConstraint<DataTypes>::projectMatrix( sofa::linearalgebra:
     // clears the rows and columns associated with constrained particles
     const unsigned blockSize = DataTypes::deriv_total_size;
 
-    for(SetIndexArray::const_iterator it= d_indices.getValue().begin(), iend=d_indices.getValue().end(); it!=iend; it++ )
+    for (const auto id : d_indices.getValue())
     {
-        M->clearRowsCols( offset + (*it) * blockSize, offset + (*it+1) * (blockSize) );
+        M->clearRowsCols( offset + id * blockSize, offset + (id+1) * blockSize );
     }
 
 }

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PlaneForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PlaneForceField.inl
@@ -201,7 +201,7 @@ void PlaneForceField<DataTypes>::addKToMatrix(const core::MechanicalParams* mpar
     const Real fact = (Real)(-this->d_stiffness.getValue()*sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue()));
     Deriv normal;
     DataTypes::setDPos(normal, d_planeNormal.getValue());
-    sofa::core::behavior::MultiMatrixAccessor::MatrixRef mref = matrix->getMatrix(this->mstate);
+    const sofa::core::behavior::MultiMatrixAccessor::MatrixRef mref = matrix->getMatrix(this->mstate);
     sofa::linearalgebra::BaseMatrix* mat = mref.matrix;
     unsigned int offset = mref.offset;
 
@@ -300,7 +300,7 @@ void PlaneForceField<DataTypes>::drawPlane(const core::visual::VisualParams* vpa
     v2 = v1.cross(normal);
     v2.normalize();
 
-    type::Vec3d center = normal*d_planeD.getValue();
+    const type::Vec3d center = normal*d_planeD.getValue();
     type::Vec3d corners[4];
     corners[0] = center-v1*size-v2*size;
     corners[1] = center+v1*size-v2*size;
@@ -366,8 +366,8 @@ void PlaneForceField<DataTypes>::computeBBox(const core::ExecParams * params, bo
     Real maxBBox[3] = {min_real,min_real,min_real};
     Real minBBox[3] = {max_real,max_real,max_real};
 
-    type::Vec3d normal; normal = d_planeNormal.getValue();
-    SReal size=d_drawSize.getValue();
+    type::Vec3d normal ( d_planeNormal.getValue() );
+    const SReal size = d_drawSize.getValue();
 
     // find a first vector inside the plane
     type::Vec3d v1;
@@ -376,12 +376,10 @@ void PlaneForceField<DataTypes>::computeBBox(const core::ExecParams * params, bo
     else if ( 0.0 != normal[2] ) v1 = type::Vec3d(1.0, 0.0, -normal[0]/normal[2]);
     v1.normalize();
 
-    // find a second vector inside the plane and orthogonal to the first
-    type::Vec3d v2;
-    v2 = v1.cross(normal);
+    type::Vec3d v2 = v1.cross(normal);
     v2.normalize();
 
-    type::Vec3d center = normal*d_planeD.getValue();
+    const type::Vec3d center = normal*d_planeD.getValue();
     type::Vec3d corners[4];
     corners[0] = center-v1*size-v2*size;
     corners[1] = center+v1*size-v2*size;

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PlaneForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PlaneForceField.inl
@@ -252,8 +252,8 @@ void PlaneForceField<DataTypes>::rotate( Deriv axe, Real angle )
     if(this->d_componentState.getValue() != ComponentState::Valid)
         return ;
 
-    type::Vec3d axe3d(1,1,1); axe3d = DataTypes::getDPos(axe);
-    type::Vec3d normal3d; normal3d = d_planeNormal.getValue();
+    const type::Vec3d axe3d { DataTypes::getDPos(axe) };
+    type::Vec3d normal3d { d_planeNormal.getValue() };
     type::Vec3d v = normal3d.cross(axe3d);
     if (v.norm2() < 1.0e-10) return;
     v.normalize();
@@ -286,7 +286,7 @@ void PlaneForceField<DataTypes>::drawPlane(const core::visual::VisualParams* vpa
 
     helper::ReadAccessor<VecCoord> p1 = this->mstate->read(core::ConstVecCoordId::position())->getValue();
 
-    type::Vec3d normal; normal = d_planeNormal.getValue();
+    type::Vec3d normal { d_planeNormal.getValue() };
 
     // find a first vector inside the plane
     type::Vec3d v1;

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PointConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PointConstraint.inl
@@ -132,8 +132,7 @@ template <class DataTypes>
 void PointConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {
     SOFA_UNUSED(mparams);
-    core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate.get());
-    if(r)
+    if(const core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate.get()))
     {
         const unsigned int N = Deriv::size();
         const SetIndexArray & indices = f_indices.getValue();

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PointConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PointConstraint.inl
@@ -61,8 +61,8 @@ void PointConstraint<DataTypes>::init()
 template <class DataTypes>
 const sofa::linearalgebra::BaseMatrix*  PointConstraint<DataTypes>::getJ(const core::MechanicalParams* )
 {
-    unsigned numBlocks = this->mstate->getSize();
-    unsigned blockSize = DataTypes::deriv_total_size;
+    const unsigned numBlocks = this->mstate->getSize();
+    const unsigned blockSize = DataTypes::deriv_total_size;
     jacobian.resize( numBlocks*blockSize,numBlocks*blockSize );
 
     for(unsigned i=0; i<numBlocks*blockSize; i++ )
@@ -154,10 +154,10 @@ template <class DataTypes>
 void PointConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* mparams, linearalgebra::BaseVector* vector, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {
     SOFA_UNUSED(mparams);
-    int o = matrix->getGlobalOffset(this->mstate.get());
+    const int o = matrix->getGlobalOffset(this->mstate.get());
     if (o >= 0)
     {
-        unsigned int offset = (unsigned int)o;
+        const unsigned int offset = (unsigned int)o;
         const unsigned int N = Deriv::size();
 
         const SetIndexArray & indices = f_indices.getValue();

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PositionBasedDynamicsConstraint.cpp
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PositionBasedDynamicsConstraint.cpp
@@ -63,12 +63,12 @@ void PositionBasedDynamicsConstraint<Rigid3Types>::projectPosition(const core::M
     SOFA_UNUSED(mparams);
 
     helper::WriteAccessor<DataVecCoord> res ( xData );
-    helper::ReadAccessor<DataVecCoord> tpos = position ;
+    const helper::ReadAccessor<DataVecCoord> tpos = position ;
     helper::WriteAccessor<DataVecDeriv> vel ( velocity );
     helper::WriteAccessor<DataVecCoord> old_pos ( old_position );
     if (tpos.size() != res.size()) { msg_error() << "Invalid target position vector size."; return; }
 
-    Real dt =  (Real)this->getContext()->getDt();
+    const Real dt =  (Real)this->getContext()->getDt();
     if(!dt) return;
 
     vel.resize(res.size());
@@ -80,7 +80,7 @@ void PositionBasedDynamicsConstraint<Rigid3Types>::projectPosition(const core::M
 
     Vec<3,Real> a; Real phi;
 
-    Real s = stiffness.getValue();
+    const Real s = stiffness.getValue();
     for( size_t i=0; i<res.size(); i++ )
     {
         res[i].getCenter() += ( tpos[i].getCenter() - res[i].getCenter()) * s;

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.inl
@@ -88,10 +88,8 @@ void ProjectDirectionConstraint<DataTypes>::init()
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
-    sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();
-   
 
-    if (_topology)
+    if (sofa::core::topology::BaseMeshTopology* _topology = l_topology.get())
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
         

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.inl
@@ -105,7 +105,7 @@ void ProjectDirectionConstraint<DataTypes>::init()
 
     const Indices & indices = f_indices.getValue();
 
-    Index maxIndex=this->mstate->getSize();
+    const Index maxIndex=this->mstate->getSize();
     for (unsigned int i=0; i<indices.size(); ++i)
     {
         const Index index=indices[i];
@@ -143,7 +143,7 @@ void  ProjectDirectionConstraint<DataTypes>::reinit()
 
     // resize the jacobian
     unsigned numBlocks = this->mstate->getSize();
-    unsigned blockSize = DataTypes::deriv_total_size;
+    const unsigned blockSize = DataTypes::deriv_total_size;
     jacobian.resize( numBlocks*blockSize,numBlocks*blockSize );
 
     // fill the jacobian in ascending order

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.inl
@@ -154,7 +154,7 @@ void  ProjectDirectionConstraint<DataTypes>::reinit()
         if( it != tmp.end() && i==*it )  // constrained particle: set diagonal to projection block, and  the cursor to the next constraint
         {
             jacobian.insertBackBlock(i,i,bProjection);
-            it++;
+            ++it;
         }
         else           // unconstrained particle: set diagonal to identity block
         {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.inl
@@ -200,9 +200,9 @@ void ProjectDirectionConstraint<DataTypes>::projectJacobianMatrix(const core::Me
 }
 
 template <class DataTypes>
-void ProjectDirectionConstraint<DataTypes>::projectVelocity(const core::MechanicalParams* mparams, DataVecDeriv& vdata)
+void ProjectDirectionConstraint<DataTypes>::projectVelocity(const core::MechanicalParams* mparams, DataVecDeriv& vData)
 {
-    projectResponse(mparams,vdata);
+    projectResponse(mparams,vData);
 }
 
 template <class DataTypes>

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectDirectionConstraint.inl
@@ -166,9 +166,9 @@ void  ProjectDirectionConstraint<DataTypes>::reinit()
 
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::position())->getValue();
     const Indices &indices = f_indices.getValue();
-    for( Indices::const_iterator it = indices.begin() ; it != indices.end() ; ++it )
+    for (const auto id : indices)
     {
-        m_origin.push_back( DataTypes::getCPos(x[*it]) );
+        m_origin.push_back(DataTypes::getCPos(x[id]));
     }
 
 }

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.inl
@@ -202,9 +202,9 @@ void ProjectToLineConstraint<DataTypes>::projectJacobianMatrix(const core::Mecha
 }
 
 template <class DataTypes>
-void ProjectToLineConstraint<DataTypes>::projectVelocity(const core::MechanicalParams* mparams, DataVecDeriv& vdata)
+void ProjectToLineConstraint<DataTypes>::projectVelocity(const core::MechanicalParams* mparams, DataVecDeriv& vData)
 {
-    projectResponse(mparams,vdata);
+    projectResponse(mparams,vData);
 }
 
 template <class DataTypes>

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.inl
@@ -159,7 +159,7 @@ void  ProjectToLineConstraint<DataTypes>::updateJacobian()
         if( it!=tmp.end() && i==*it )  // constrained particle: set diagonal to projection block, and  the cursor to the next constraint
         {
             jacobian.insertBackBlock(i,i,bProjection);
-            it++;
+            ++it;
         }
         else           // unconstrained particle: set diagonal to identity block
         {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.inl
@@ -88,9 +88,7 @@ void ProjectToLineConstraint<DataTypes>::init()
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
-    sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();
-
-    if (_topology)
+    if (sofa::core::topology::BaseMeshTopology* _topology = l_topology.get())
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
         

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToLineConstraint.inl
@@ -104,7 +104,7 @@ void ProjectToLineConstraint<DataTypes>::init()
 
     const Indices & indices = f_indices.getValue();
 
-    Index maxIndex=this->mstate->getSize();
+    const Index maxIndex=this->mstate->getSize();
     for (unsigned int i=0; i<indices.size(); ++i)
     {
         const Index index=indices[i];
@@ -148,7 +148,7 @@ void  ProjectToLineConstraint<DataTypes>::updateJacobian()
 
     // resize the jacobian
     unsigned numBlocks = this->mstate->getSize();
-    unsigned blockSize = DataTypes::deriv_total_size;
+    const unsigned blockSize = DataTypes::deriv_total_size;
     jacobian.resize( numBlocks*blockSize,numBlocks*blockSize );
 
     // fill the jacobian in ascending order

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
@@ -104,7 +104,7 @@ void ProjectToPlaneConstraint<DataTypes>::init()
 
     const Indices & indices = f_indices.getValue();
 
-    Index maxIndex=this->mstate->getSize();
+    const Index maxIndex=this->mstate->getSize();
     for (unsigned int i=0; i<indices.size(); ++i)
     {
         const Index index=indices[i];
@@ -151,7 +151,7 @@ void  ProjectToPlaneConstraint<DataTypes>::reinit()
 
     // resize the jacobian
     unsigned numBlocks = this->mstate->getSize();
-    unsigned blockSize = DataTypes::deriv_total_size;
+    const unsigned blockSize = DataTypes::deriv_total_size;
     jacobian.resize( numBlocks*blockSize,numBlocks*blockSize );
 
     // fill the jacobian in ascending order

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
@@ -200,9 +200,9 @@ void ProjectToPlaneConstraint<DataTypes>::projectJacobianMatrix(const core::Mech
 }
 
 template <class DataTypes>
-void ProjectToPlaneConstraint<DataTypes>::projectVelocity(const core::MechanicalParams* mparams, DataVecDeriv& vdata)
+void ProjectToPlaneConstraint<DataTypes>::projectVelocity(const core::MechanicalParams* mparams, DataVecDeriv& vData)
 {
-    projectResponse(mparams,vdata);
+    projectResponse(mparams,vData);
 }
 
 template <class DataTypes>

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
@@ -88,9 +88,7 @@ void ProjectToPlaneConstraint<DataTypes>::init()
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
-    sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();
-
-    if (_topology)
+    if (sofa::core::topology::BaseMeshTopology* _topology = l_topology.get())
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPlaneConstraint.inl
@@ -162,7 +162,7 @@ void  ProjectToPlaneConstraint<DataTypes>::reinit()
         if(  it!=tmp.end() && i==*it )  // constrained particle: set diagonal to projection block, and  the cursor to the next constraint
         {
             jacobian.insertBackBlock(i,i,bProjection); // only one block to create
-            it++;
+            ++it;
         }
         else           // unconstrained particle: set diagonal to identity block
         {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.inl
@@ -90,9 +90,7 @@ void ProjectToPointConstraint<DataTypes>::init()
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
-    sofa::core::topology::BaseMeshTopology* _topology = l_topology.get();
-
-    if (_topology)
+    if (sofa::core::topology::BaseMeshTopology* _topology = l_topology.get())
     {
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 
@@ -242,8 +240,7 @@ template <class DataTypes>
 void ProjectToPointConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {
     SOFA_UNUSED(mparams);
-    core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate.get());
-    if(r)
+    if(const core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate.get()))
     {
         const unsigned int N = Deriv::size();
         const SetIndexArray & indices = f_indices.getValue();

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.inl
@@ -137,9 +137,9 @@ void ProjectToPointConstraint<DataTypes>::projectMatrix( sofa::linearalgebra::Ba
     const unsigned blockSize = DataTypes::deriv_total_size;
 
     // clears the rows and columns associated with fixed particles
-    for(SetIndexArray::const_iterator it= f_indices.getValue().begin(), iend=f_indices.getValue().end(); it!=iend; it++ )
+    for (const auto id : f_indices.getValue())
     {
-        M->clearRowsCols( offset + (*it) * blockSize, offset + (*it+1) * (blockSize) );
+        M->clearRowsCols( offset + id * blockSize, offset + (id+1) * blockSize );
     }
 }
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/ProjectToPointConstraint.inl
@@ -107,7 +107,7 @@ void ProjectToPointConstraint<DataTypes>::init()
     const SetIndexArray & indices = f_indices.getValue();
 
     std::stringstream sstream;
-    Index maxIndex=this->mstate->getSize();
+    const Index maxIndex=this->mstate->getSize();
     for (unsigned int i=0; i<indices.size(); ++i)
     {
         const Index index=indices[i];
@@ -134,7 +134,7 @@ void  ProjectToPointConstraint<DataTypes>::reinit()
 template <class DataTypes>
 void ProjectToPointConstraint<DataTypes>::projectMatrix( sofa::linearalgebra::BaseMatrix* M, unsigned offset )
 {
-    unsigned blockSize = DataTypes::deriv_total_size;
+    const unsigned blockSize = DataTypes::deriv_total_size;
 
     // clears the rows and columns associated with fixed particles
     for(SetIndexArray::const_iterator it= f_indices.getValue().begin(), iend=f_indices.getValue().end(); it!=iend; it++ )
@@ -264,10 +264,10 @@ template <class DataTypes>
 void ProjectToPointConstraint<DataTypes>::applyConstraint(const core::MechanicalParams* mparams, linearalgebra::BaseVector* vector, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {
     SOFA_UNUSED(mparams);
-    int o = matrix->getGlobalOffset(this->mstate.get());
+    const int o = matrix->getGlobalOffset(this->mstate.get());
     if (o >= 0)
     {
-        unsigned int offset = (unsigned int)o;
+        const unsigned int offset = (unsigned int)o;
         const unsigned int N = Deriv::size();
 
         const SetIndexArray & indices = f_indices.getValue();

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/QuadPressureForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/QuadPressureForceField.inl
@@ -160,11 +160,10 @@ void QuadPressureForceField<DataTypes>::selectQuadsAlongPlane()
 {
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
     std::vector<bool> vArray;
-    unsigned int i;
 
     vArray.resize(x.size());
 
-    for( i=0; i<x.size(); ++i)
+    for( unsigned int i=0; i<x.size(); ++i)
     {
         vArray[i]=isPointInPlane(x[i]);
     }

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/QuadPressureForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/QuadPressureForceField.inl
@@ -235,7 +235,7 @@ void QuadPressureForceField<DataTypes>::draw(const core::visual::VisualParams* v
 
     vparams->drawTool()->disableLighting();
     std::vector<sofa::type::Vector3> vertices;
-    sofa::type::RGBAColor color = sofa::type::RGBAColor::green();
+    const sofa::type::RGBAColor color = sofa::type::RGBAColor::green();
 
     const sofa::type::vector<Index>& my_map = quadPressureMap.getMap2Elements();
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SkeletalMotionConstraint.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SkeletalMotionConstraint.h
@@ -91,7 +91,7 @@ public:
 
     void setSkeletalMotion(const type::vector<SkeletonJoint<DataTypes> >& skeletonJoints, const type::vector<SkeletonBone>& skeletonBones);
 
-	void addChannel(unsigned int index , Coord channel, double time);
+	void addChannel(unsigned int jointIndex , Coord channel, double time);
 
 protected:
     template <class DataDeriv>

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SkeletalMotionConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SkeletalMotionConstraint.inl
@@ -343,8 +343,8 @@ void SkeletalMotionConstraint<DataTypes>::applyConstraint(const core::Mechanical
 template <class DataTypes>
 void SkeletalMotionConstraint<DataTypes>::projectMatrix( sofa::linearalgebra::BaseMatrix* M, unsigned offset )
 {
-    unsigned blockSize = DataTypes::deriv_total_size;
-    unsigned size = this->mstate->getSize();
+    const unsigned blockSize = DataTypes::deriv_total_size;
+    const unsigned size = this->mstate->getSize();
     for( unsigned i=0; i<size; i++ )
     {
         M->clearRowsCols( offset + i * blockSize, offset + (i+1) * (blockSize) );

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SkeletalMotionConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SkeletalMotionConstraint.inl
@@ -34,11 +34,13 @@ namespace sofa::component::projectiveconstraintset
 {
 
 template <class DataTypes>
-SkeletalMotionConstraint<DataTypes>::SkeletalMotionConstraint() : sofa::core::behavior::ProjectiveConstraintSet<DataTypes>()
+SkeletalMotionConstraint<DataTypes>::SkeletalMotionConstraint() :
+    sofa::core::behavior::ProjectiveConstraintSet<DataTypes>()
     , skeletonJoints(initData(&skeletonJoints, "joints", "skeleton joints"))
     , skeletonBones(initData(&skeletonBones, "bones", "skeleton bones"))
 	, animationSpeed(initData(&animationSpeed, 1.0f, "animationSpeed", "animation speed"))
     , active(initData(&active, true, "active", "is the constraint active?"))
+    , finished(false)
 {
 }
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SkeletalMotionConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SkeletalMotionConstraint.inl
@@ -61,7 +61,7 @@ void SkeletalMotionConstraint<DataTypes>::reset()
 }
 
 template <class DataTypes>
-void SkeletalMotionConstraint<DataTypes>::findKeyTimes(Real cT)
+void SkeletalMotionConstraint<DataTypes>::findKeyTimes(Real ct)
 {
     //Note: works only if the times are sorted
     
@@ -78,7 +78,7 @@ void SkeletalMotionConstraint<DataTypes>::findKeyTimes(Real cT)
         for(unsigned int j = 0; j < skeletonJoint.mTimes.size(); ++j)
         {
             Real keyTime = (Real) skeletonJoint.mTimes[j];
-            if(keyTime <= cT)
+            if(keyTime <= ct)
             {
                 {
                     skeletonJoint.mPreviousMotionTime = keyTime;

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SphereForceField.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SphereForceField.h
@@ -62,7 +62,8 @@ protected:
         int index;
         Coord normal;
         Real fact;
-        Contact( int index=0, Coord normal=Coord(),Real fact=Real(0))
+
+        explicit Contact( int index=0, Coord normal=Coord(),Real fact=Real(0))
             : index(index),normal(normal),fact(fact)
         {
         }

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SurfacePressureForceField.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SurfacePressureForceField.h
@@ -135,7 +135,7 @@ protected:
      * @brief Returns next pressure value in pulse mode.
      * Pressure is computed according to the pressureSpeed attribute and the simulation time step.
      */
-    const Real computePulseModePressure(void);
+    Real computePulseModePressure();
 
 
     /**

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SurfacePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SurfacePressureForceField.inl
@@ -451,7 +451,7 @@ bool SurfacePressureForceField<DataTypes>::isInPressuredBox(const Coord &x) cons
 }
 
 template<class DataTypes>
-const typename SurfacePressureForceField<DataTypes>::Real SurfacePressureForceField<DataTypes>::computePulseModePressure()
+typename SurfacePressureForceField<DataTypes>::Real SurfacePressureForceField<DataTypes>::computePulseModePressure()
 {
     SReal dt = this->getContext()->getDt();
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SurfacePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SurfacePressureForceField.inl
@@ -51,6 +51,7 @@ SurfacePressureForceField<DataTypes>::SurfacePressureForceField():
     m_mainDirection(initData(&m_mainDirection, Deriv(), "mainDirection", "Main direction for pressure application")),
     m_drawForceScale(initData(&m_drawForceScale, (Real)0, "drawForceScale", "DEBUG: scale used to render force vectors"))
     , l_topology(initLink("topology", "link to the topology container"))
+    , state(INCREASE)
     , m_topology(nullptr)
 {
 
@@ -87,7 +88,7 @@ void SurfacePressureForceField<DataTypes>::init()
         return;
     }
 
-    state = ( m_pressure.getValue() > 0 ) ? INCREASE : DECREASE;
+    state = m_pressure.getValue() > 0 ? INCREASE : DECREASE;
 
     if (m_pulseMode.getValue() && (m_pressureSpeed.getValue() == 0.0))
     {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SurfacePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/SurfacePressureForceField.inl
@@ -240,9 +240,7 @@ void SurfacePressureForceField<DataTypes>::addDForce(const core::MechanicalParam
 template<class DataTypes>
 void SurfacePressureForceField<DataTypes>::addKToMatrix(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix )
 {
-
-
-    sofa::core::behavior::MultiMatrixAccessor::MatrixRef mref = matrix->getMatrix(this->mstate);
+    const sofa::core::behavior::MultiMatrixAccessor::MatrixRef mref = matrix->getMatrix(this->mstate);
     sofa::linearalgebra::BaseMatrix* mat = mref.matrix;
     unsigned int offset = mref.offset;
     Real kFact = (Real)sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue());
@@ -533,9 +531,7 @@ template<>
 void SurfacePressureForceField<defaulttype::Rigid3Types>::addDForce(const core::MechanicalParams* mparams ,
                                                                      DataVecDeriv& d_df , const DataVecDeriv& d_dx)
 {
-
-
-    Real kFactor = (Real)sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue());
+    const Real kFactor = (Real)sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue());
 	VecDeriv& df       = *(d_df.beginEdit());
 	const VecDeriv& dx =   d_dx.getValue()  ;
 
@@ -545,7 +541,7 @@ void SurfacePressureForceField<defaulttype::Rigid3Types>::addDForce(const core::
 
 		for (unsigned int j=0; j<derivTriNormalIndices[i].size(); j++)
 		{
-			unsigned int v = derivTriNormalIndices[i][j];
+            const unsigned int v = derivTriNormalIndices[i][j];
 			df[i].getVCenter() += (derivTriNormalValues[i][j] * dx[v].getVCenter())*kFactor;
 
 		}
@@ -680,7 +676,7 @@ void SurfacePressureForceField<defaulttype::Rigid3Types>::addTriangleSurfacePres
 	{
         defaulttype::Rigid3Types::CPos n = ab.cross(ac);
 		n.normalize();
-		Real scal = n * m_mainDirection.getValue().getVCenter();
+        const Real scal = n * m_mainDirection.getValue().getVCenter();
 		p *= fabs(scal);
 	}
 
@@ -694,14 +690,14 @@ void SurfacePressureForceField<defaulttype::Rigid3Types>::addQuadSurfacePressure
 {
 	Quad q = m_topology->getQuad(quadId);
 
-    defaulttype::Rigid3Types::CPos ab = x[q[1]].getCenter() - x[q[0]].getCenter();
-    defaulttype::Rigid3Types::CPos ac = x[q[2]].getCenter() - x[q[0]].getCenter();
-    defaulttype::Rigid3Types::CPos ad = x[q[3]].getCenter() - x[q[0]].getCenter();
+    const defaulttype::Rigid3Types::CPos ab = x[q[1]].getCenter() - x[q[0]].getCenter();
+    const defaulttype::Rigid3Types::CPos ac = x[q[2]].getCenter() - x[q[0]].getCenter();
+    const defaulttype::Rigid3Types::CPos ad = x[q[3]].getCenter() - x[q[0]].getCenter();
 
-    defaulttype::Rigid3Types::CPos p1 = (ab.cross(ac)) * (pressure / static_cast<Real>(6.0));
-    defaulttype::Rigid3Types::CPos p2 = (ac.cross(ad)) * (pressure / static_cast<Real>(6.0));
+    const defaulttype::Rigid3Types::CPos p1 = (ab.cross(ac)) * (pressure / static_cast<Real>(6.0));
+    const defaulttype::Rigid3Types::CPos p2 = (ac.cross(ad)) * (pressure / static_cast<Real>(6.0));
 
-    defaulttype::Rigid3Types::CPos p = p1 + p2;
+    const defaulttype::Rigid3Types::CPos p = p1 + p2;
 
 	f[q[0]].getVCenter() += p;
 	f[q[1]].getVCenter() += p1;

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TaitSurfacePressureForceField.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TaitSurfacePressureForceField.h
@@ -109,7 +109,7 @@ public:
     void addKToMatrix(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix ) override;
     SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord&  /* x */) const override;
     template<class MatrixWriter>
-    void addKToMatrixT(const core::MechanicalParams* mparams, MatrixWriter m);
+    void addKToMatrixT(const core::MechanicalParams* mparams, MatrixWriter mwriter);
 
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TaitSurfacePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TaitSurfacePressureForceField.inl
@@ -448,11 +448,11 @@ void TaitSurfacePressureForceField<DataTypes>::draw(const core::visual::VisualPa
 
     const helper::ReadAccessor< Data< SeqTriangles > > pressureTriangles = m_pressureTriangles;
 
-    std::vector< sofa::type::Vector3 > points;
     std::vector< sofa::type::Vec3i > indices;
     std::vector< type::Vector3 > normals;
     if (m_drawForceScale.getValue() != (Real)0.0)
     {
+        std::vector< sofa::type::Vector3 > points;
         points.clear();
         const Real fscale = m_currentPressure.getValue()*m_drawForceScale.getValue();
         for (unsigned int i=0; i<pressureTriangles.size(); i++)

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TaitSurfacePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TaitSurfacePressureForceField.inl
@@ -223,7 +223,7 @@ void TaitSurfacePressureForceField<DataTypes>::addForce(const core::MechanicalPa
     helper::ReadAccessor<DataVecCoord> x = d_x;
     //helper::ReadAccessor<DataVecDeriv> v = d_v;
     //helper::ReadAccessor<DataVecCoord> x0 = this->mstate->read(core::ConstVecCoordId::restPosition());
-    helper::ReadAccessor< Data< SeqTriangles > > pressureTriangles = m_pressureTriangles;
+    const helper::ReadAccessor< Data< SeqTriangles > > pressureTriangles = m_pressureTriangles;
 
     computeMeshVolumeAndArea(*m_currentVolume.beginEdit(), *m_currentSurfaceArea.beginEdit(), x);
     m_currentVolume.endEdit();
@@ -283,7 +283,7 @@ void TaitSurfacePressureForceField<DataTypes>::addDForce(const core::MechanicalP
     helper::ReadAccessor<DataVecDeriv> dx = d_dx;
     helper::ReadAccessor<DataVecCoord> x = mparams->readX(this->mstate);
     //helper::ReadAccessor<DataVecCoord> x0 = this->mstate->read(core::ConstVecCoordId::restPosition());
-    helper::ReadAccessor< Data< SeqTriangles > > pressureTriangles = m_pressureTriangles;
+    const helper::ReadAccessor< Data< SeqTriangles > > pressureTriangles = m_pressureTriangles;
     helper::ReadAccessor<VecDeriv> gradV = this->gradV;
 
     const Real kFactor = (Real)sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue());
@@ -347,7 +347,7 @@ template<class MatrixWriter>
 void TaitSurfacePressureForceField<DataTypes>::addKToMatrixT(const core::MechanicalParams* mparams, MatrixWriter mwriter)
 {
     helper::ReadAccessor<DataVecCoord> x = mparams->readX(this->mstate);
-    helper::ReadAccessor< Data< SeqTriangles > > pressureTriangles = m_pressureTriangles;
+    const helper::ReadAccessor< Data< SeqTriangles > > pressureTriangles = m_pressureTriangles;
 
     const Real kFactor = (Real)sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue());
     const Real currentPressure = m_currentPressure.getValue();
@@ -414,7 +414,7 @@ void TaitSurfacePressureForceField<DataTypes>::computeMeshVolumeAndArea(Real& vo
     Real volume6 = 0;
     Real area2 = 0;
 
-    helper::ReadAccessor< Data< SeqTriangles > > pressureTriangles = m_pressureTriangles;
+    const helper::ReadAccessor< Data< SeqTriangles > > pressureTriangles = m_pressureTriangles;
     for (unsigned int i = 0; i < pressureTriangles.size(); i++)
     {
         Triangle t = pressureTriangles[i];
@@ -446,7 +446,7 @@ void TaitSurfacePressureForceField<DataTypes>::draw(const core::visual::VisualPa
 
     helper::ReadAccessor<DataVecCoord> x = this->mstate->read(core::ConstVecCoordId::position());
 
-    helper::ReadAccessor< Data< SeqTriangles > > pressureTriangles = m_pressureTriangles;
+    const helper::ReadAccessor< Data< SeqTriangles > > pressureTriangles = m_pressureTriangles;
 
     std::vector< sofa::type::Vector3 > points;
     std::vector< sofa::type::Vec3i > indices;

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TorsionForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TorsionForceField.inl
@@ -127,7 +127,7 @@ void TorsionForceField<DataTypes>::addKToMatrix(linearalgebra::BaseMatrix* matri
 		for(Size n = 0 ; n < nNodes ; ++n)
 		{
 			PointId id = indices[n];
-			unsigned int c = offset + Deriv::total_size*id;
+			const unsigned int c = offset + Deriv::total_size*id;
 
 			matrix->add(c+0, c+0, D(0,0));
 			matrix->add(c+0, c+1, D(0,1));
@@ -165,7 +165,7 @@ void TorsionForceField<Rigid3Types>::addForce(const core::MechanicalParams *, Da
 
 	for(Size n = 0 ; n < nNodes ; ++n)
 	{
-		PointId id = indices[n];
+		const PointId id = indices[n];
 		const Pos t = tau*m_u;
 		fq[id].getVCenter() += t.cross(q[id].getCenter() - (o + (q[id].getCenter() * m_u)*m_u) );
 		fq[id].getVOrientation() += t;
@@ -193,7 +193,7 @@ void TorsionForceField<Rigid3Types>::addDForce(const core::MechanicalParams *mpa
 
 	for(Size n = 0 ; n < nNodes ; ++n)
 	{
-		PointId id = indices[n];
+		const PointId id = indices[n];
 		dfq[id].getVCenter() += D * dq[id].getVCenter();
 	}
 }

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TorsionForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TorsionForceField.inl
@@ -76,7 +76,7 @@ void TorsionForceField<DataTypes>::addForce(const MechanicalParams* /*params*/, 
 }
 
 template<typename DataTypes>
-void TorsionForceField<DataTypes>::addDForce(const MechanicalParams* params, DataVecDeriv& df, const DataVecDeriv& dx)
+void TorsionForceField<DataTypes>::addDForce(const MechanicalParams* mparams, DataVecDeriv& df, const DataVecDeriv& dx)
 {
 	const VecId& indices = m_indices.getValue();
 	const VecDeriv& dq = dx.getValue();
@@ -84,7 +84,7 @@ void TorsionForceField<DataTypes>::addDForce(const MechanicalParams* params, Dat
 	VecDeriv& dfq = *df.beginEdit();
 
 	const auto nNodes = indices.size();
-	const Real& kfact = params->kFactor();
+	const Real& kfact = mparams->kFactor();
 
 	Mat3 D;
 	D(0,0) = 1 - m_u(0)*m_u(0) ;	D(0,1) = -m_u(1)*m_u(0) ;		D(0,2) = -m_u(2)*m_u(0);

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TrianglePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TrianglePressureForceField.inl
@@ -185,11 +185,10 @@ void TrianglePressureForceField<DataTypes>::selectTrianglesAlongPlane()
 {
     const VecCoord& x = this->mstate->read(core::ConstVecCoordId::restPosition())->getValue();
     std::vector<bool> vArray;
-    unsigned int i;
 
     vArray.resize(x.size());
 
-    for( i=0; i<x.size(); ++i)
+    for( unsigned int i=0; i<x.size(); ++i)
     {
         vArray[i]=isPointInPlane(x[i]);
     }

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TrianglePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TrianglePressureForceField.inl
@@ -92,7 +92,6 @@ void TrianglePressureForceField<DataTypes>::addForce(const core::MechanicalParam
 {
 
     VecDeriv& f = *d_f.beginEdit();
-    Deriv force;
 
     const sofa::type::vector<Index>& my_map = trianglePressureMap.getMap2Elements();
 
@@ -102,7 +101,7 @@ void TrianglePressureForceField<DataTypes>::addForce(const core::MechanicalParam
 
 		for (unsigned int i=0; i<my_map.size(); ++i)
 		{
-			force=my_subset[i].force/3;
+			const auto force=my_subset[i].force/3;
 			f[m_topology->getTriangle(my_map[i])[0]]+=force;
 			f[m_topology->getTriangle(my_map[i])[1]]+=force;
 			f[m_topology->getTriangle(my_map[i])[2]]+=force;
@@ -113,13 +112,13 @@ void TrianglePressureForceField<DataTypes>::addForce(const core::MechanicalParam
 		const sofa::type::vector<Triangle> &ta = m_topology->getTriangles();
 		const  VecDeriv p = d_x.getValue();
 		MatSym3 cauchy=cauchyStress.getValue();
-		Deriv areaVector,force;
+		Deriv areaVector;
 
 		for (unsigned int i=0; i<my_map.size(); ++i)
 		{
 			const Triangle &t=ta[my_map[i]];
 			areaVector=cross(p[t[1]]-p[t[0]],p[t[2]]-p[t[0]])/6.0f;
-			force=cauchy*areaVector;
+			const auto force=cauchy*areaVector;
 			for (size_t j=0;j<3;++j) {
 				f[t[j]]+=force;
 			}


### PR DESCRIPTION
- Hiding local declaration 
- Parameter names do not match 
- Uninitialized class members 
- Lambda capture is never used 
- Local variable can be made const 
- Result of a postfix operator is discarded 
- add explicit specifier to make constructor non-converting 
- Member function can be made const 
- Variable can be moved to if-statement 
- Declaration and assignment can be joined 
- Return by const value



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
