### PR TITLE
[SofaMiscTopology] Introduce EdgeTopologyFrom2PointSets

### DIFF
--- a/examples/Components/mapping/EdgeTopologyFrom2PointSets.scn
+++ b/examples/Components/mapping/EdgeTopologyFrom2PointSets.scn
@@ -1,0 +1,91 @@
+<?xml version="1.0"?>
+<Node name="root" dt="0.1" gravity="0 -9.81 0">
+
+    <VisualStyle displayFlags="showBehaviorModels hideForceFields showWireFrame" />
+
+    <RequiredPlugin name="SofaEngine"/>
+    <RequiredPlugin name="SofaImplicitOdeSolver"/>
+    <RequiredPlugin name="SofaMiscMapping"/>
+    <RequiredPlugin name="SofaMiscTopology"/>
+    <RequiredPlugin name="SofaOpenglVisual"/>
+    <RequiredPlugin name="SofaSimpleFem"/>
+    <RequiredPlugin name="SofaTopologyMapping"/>
+    <RequiredPlugin name="SofaBoundaryCondition"/>
+    <RequiredPlugin name="SofaDeformable"/>
+
+
+    <EulerImplicitSolver  rayleighStiffness="0.1" rayleighMass="0.1" />
+    <CGLinearSolver iterations="10" tolerance="1e-5" threshold="1e-5"/>
+
+    <Node name="cube-a">
+
+        <RegularGridTopology name="grid"
+                             nx="10" ny="10" nz="10"
+                             xmin="-1" xmax="1"
+                             ymin="-1" ymax="1"
+                             zmin="-1" zmax="1"
+        />
+
+        <MechanicalObject template="Vec3d" name="dofs"/>
+        <UniformMass totalMass="1000"/>
+        <TetrahedronFEMForceField name="FEM" youngModulus="10000" poissonRatio="0.4" method="large" />
+        <BoxROI name="fixedBox" box="-1.01 -1 -1 -0.99 1 1"/>
+        <FixedConstraint indices="@fixedBox.indices"/>
+        <BoxROI name="box" box="0.99 -1 -1 1.01 1 1"/>
+
+        <Node name="Visual">
+            <TetrahedronSetTopologyContainer name="tetraContainer" />
+            <TetrahedronSetTopologyModifier/>
+            <Hexa2TetraTopologicalMapping input="@../grid" output="@tetraContainer" />
+
+            <TriangleSetTopologyContainer name="triangleContainer" />
+            <TriangleSetTopologyModifier/>
+            <Tetra2TriangleTopologicalMapping input="@tetraContainer" output="@triangleContainer" />
+
+            <OglModel topology="@triangleContainer" state="@../dofs" color="red"/>
+            <IdentityMapping input="@../dofs" output="@Visual" />
+        </Node>
+    </Node>
+
+    <Node name="cube-b">
+
+        <RegularGridTopology name="grid"
+                             nx="12" ny="12" nz="12"
+                             xmin="2" xmax="4"
+                             ymin="-1" ymax="1"
+                             zmin="-1" zmax="1"
+        />
+
+        <MechanicalObject template="Vec3d" name="dofs"/>
+        <UniformMass totalMass="1000"/>
+        <TetrahedronFEMForceField name="FEM" youngModulus="10000" poissonRatio="0.4" method="large" />
+        <BoxROI name="fixedBox" box="3.99 -1 -1 4.01 1 1"/>
+        <FixedConstraint indices="@fixedBox.indices"/>
+        <BoxROI name="box" box="1.99 -1 -1 2.01 1 1"/>
+
+        <Node name="Visual">
+            <TetrahedronSetTopologyContainer name="tetraContainer" />
+            <TetrahedronSetTopologyModifier/>
+            <Hexa2TetraTopologicalMapping input="@../grid" output="@tetraContainer" />
+
+            <TriangleSetTopologyContainer name="triangleContainer" />
+            <TriangleSetTopologyModifier/>
+            <Tetra2TriangleTopologicalMapping input="@tetraContainer" output="@triangleContainer" />
+
+            <OglModel topology="@triangleContainer" state="@../dofs" color="red"/>
+            <IdentityMapping input="@../dofs" output="@Visual" />
+        </Node>
+    </Node>
+
+    <Node name="merge">
+        <VisualStyle displayFlags="showForceFields" />
+
+        <EdgeTopologyFrom2PointSets name="edges" project2on1="false" project1on2="true"
+                positions1="@../cube-a/dofs.position" indices1="@../cube-a/box.indices"
+                positions2="@../cube-b/dofs.position" indices2="@../cube-b/box.indices"/>
+        <MechanicalObject name="dofs"/>
+        <MeshSpringForceField stiffness="10000" damping="1" linesStiffness="10000" linesDamping="1" drawMode="1" drawSpringSize="1"/>
+        <SubsetMultiMapping input="@../cube-a/dofs @../cube-b/dofs" output="@dofs" indexPairs="@edges.indexPairs"/>
+    </Node>
+
+</Node>

--- a/modules/SofaMiscTopology/CMakeLists.txt
+++ b/modules/SofaMiscTopology/CMakeLists.txt
@@ -4,23 +4,25 @@ project(SofaMiscTopology LANGUAGES CXX)
 set(SOFAMISCTOPOLOGY_SRC "src/${PROJECT_NAME}")
 
 set(HEADER_FILES
-	${SOFAMISCTOPOLOGY_SRC}/config.h.in
-	${SOFAMISCTOPOLOGY_SRC}/initSofaMiscTopology.h
+    ${SOFAMISCTOPOLOGY_SRC}/config.h.in
+    ${SOFAMISCTOPOLOGY_SRC}/initSofaMiscTopology.h
 )
 
 set(SOURCE_FILES
-	${SOFAMISCTOPOLOGY_SRC}/initSofaMiscTopology.cpp
+    ${SOFAMISCTOPOLOGY_SRC}/initSofaMiscTopology.cpp
 )
 
 list(APPEND HEADER_FILES
-	${SOFAMISCTOPOLOGY_SRC}/TopologicalChangeProcessor.h
-	${SOFAMISCTOPOLOGY_SRC}/TopologyChecker.h
+    ${SOFAMISCTOPOLOGY_SRC}/EdgeTopologyFrom2PointSets.h
+    ${SOFAMISCTOPOLOGY_SRC}/TopologicalChangeProcessor.h
+    ${SOFAMISCTOPOLOGY_SRC}/TopologyChecker.h
     ${SOFAMISCTOPOLOGY_SRC}/TopologyBoundingTrasher.h
     ${SOFAMISCTOPOLOGY_SRC}/TopologyBoundingTrasher.inl
 )
 list(APPEND SOURCE_FILES
-	${SOFAMISCTOPOLOGY_SRC}/TopologicalChangeProcessor.cpp
-	${SOFAMISCTOPOLOGY_SRC}/TopologyChecker.cpp
+    ${SOFAMISCTOPOLOGY_SRC}/EdgeTopologyFrom2PointSets.cpp
+    ${SOFAMISCTOPOLOGY_SRC}/TopologicalChangeProcessor.cpp
+    ${SOFAMISCTOPOLOGY_SRC}/TopologyChecker.cpp
     ${SOFAMISCTOPOLOGY_SRC}/TopologyBoundingTrasher.cpp
 )
 

--- a/modules/SofaMiscTopology/src/SofaMiscTopology/EdgeTopologyFrom2PointSets.cpp
+++ b/modules/SofaMiscTopology/src/SofaMiscTopology/EdgeTopologyFrom2PointSets.cpp
@@ -1,0 +1,137 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <SofaMiscTopology/EdgeTopologyFrom2PointSets.h>
+#include <sofa/core/ObjectFactory.h>
+
+namespace sofa::component::topology
+{
+
+int EdgeTopologyFrom2PointSetsClass = core::RegisterObject("Edge set topology container created from two point sets")
+        .add< EdgeTopologyFrom2PointSets >()
+        ;
+
+EdgeTopologyFrom2PointSets::EdgeTopologyFrom2PointSets()
+    : Inherit1()
+    , d_positions1(initData(&d_positions1, "positions1", "List of vertices corresponding to the first point set"))
+    , d_positions2(initData(&d_positions2, "positions2", "List of vertices corresponding to the second point set"))
+    , d_indices1(initData(&d_indices1, "indices1", "Only indices from this list are considered in the first point set"))
+    , d_indices2(initData(&d_indices2, "indices2", "Only indices from this list are considered in the second point set"))
+    , d_project1on2(initData(&d_project1on2, false, "project1on2", "To create edges, project the first point set on the second based on the minimum distance"))
+    , d_project2on1(initData(&d_project2on1, true, "project2on1", "To create edges, project the second point set on the first based on the minimum distance"))
+    , d_indexPairs( initData( &d_indexPairs, type::vector<unsigned>(), "indexPairs", "List of two indices: index of the object (first or second), index of a point within this object. Could be used in association with a SubsetMultiMapping"))
+{
+    d_positions1.setGroup("Input");
+    d_positions2.setGroup("Input");
+
+    d_indices1.setGroup("Input");
+    d_indices2.setGroup("Input");
+
+    d_indexPairs.setGroup("Output");
+}
+
+void EdgeTopologyFrom2PointSets::projectPointSet(
+    const sofa::type::vector<sofa::Index>& indices1, const sofa::type::vector<sofa::Index>& indices2,
+    const InitTypes::VecCoord& p1, const InitTypes::VecCoord& p2,
+    const InsertionMapping& insertionMapping1, const InsertionMapping& insertionMapping2)
+{
+    for (const auto id1 : indices1)
+    {
+        if (id1 < p1.size())
+        {
+            const auto& v1 = p1[id1];
+            unsigned int closestIn2 = -1;
+            {
+                InitTypes::Real shortestDistance = std::numeric_limits<InitTypes::Real>::max();
+                for (const auto id2 : indices2)
+                {
+                    if (id2 < p2.size())
+                    {
+                        const auto& v2 = p2[id2];
+                        const auto d = (v1-v2).norm2();
+                        if ( d < shortestDistance)
+                        {
+                            closestIn2 = id2;
+                            shortestDistance = d;
+                        }
+                    }
+                }
+            }
+
+            const auto it1 = insertionMapping1.find(id1);
+            const auto it2 = insertionMapping2.find(closestIn2);
+            if (it1 != insertionMapping1.end() && it2 != insertionMapping2.end())
+            {
+                this->addEdge(it1->second, it2->second);
+            }
+        }
+    }
+}
+
+void EdgeTopologyFrom2PointSets::addPointSet(
+    InitTypes::VecCoord& outPositions,
+    const InitTypes::VecCoord& inPositions,
+    const sofa::type::vector<sofa::Index>& indices,
+    type::vector<unsigned>& indexPairs,
+    InsertionMapping& insertionMapping,
+    unsigned int pointSetIndex)
+{
+    for (const auto id : indices)
+    {
+        if (id < inPositions.size())
+        {
+            outPositions.push_back(inPositions[id]);
+            insertionMapping[id] = outPositions.size()-1;
+            indexPairs.push_back(pointSetIndex);
+            indexPairs.push_back(id);
+        }
+    }
+}
+
+void EdgeTopologyFrom2PointSets::init()
+{
+    auto p = sofa::helper::getWriteOnlyAccessor(d_initPoints);
+    const auto p1 = sofa::helper::getReadAccessor(d_positions1);
+    const auto p2 = sofa::helper::getReadAccessor(d_positions2);
+    const auto indices1 = sofa::helper::getReadAccessor(d_indices1);
+    const auto indices2 = sofa::helper::getReadAccessor(d_indices2);
+    auto indexPairs = sofa::helper::getWriteOnlyAccessor(d_indexPairs);
+
+    InsertionMapping insertionMapping1;
+    InsertionMapping insertionMapping2;
+
+    addPointSet(*p, p1, indices1, *indexPairs, insertionMapping1, 0);
+    addPointSet(*p, p2, indices2, *indexPairs, insertionMapping2, 1);
+
+    if (d_project1on2.getValue())
+    {
+        projectPointSet(indices1, indices2, p1, p2, insertionMapping1, insertionMapping2);
+    }
+
+    if (d_project2on1.getValue())
+    {
+        projectPointSet(indices2, indices1, p2, p1, insertionMapping2, insertionMapping1);
+    }
+
+    EdgeSetTopologyContainer::init();
+}
+
+}//namespace sofa::component::topology

--- a/modules/SofaMiscTopology/src/SofaMiscTopology/EdgeTopologyFrom2PointSets.h
+++ b/modules/SofaMiscTopology/src/SofaMiscTopology/EdgeTopologyFrom2PointSets.h
@@ -1,0 +1,80 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <SofaMiscTopology/config.h>
+
+#include <SofaBaseTopology/EdgeSetTopologyContainer.h>
+
+namespace sofa::component::topology
+{
+
+/**
+ * Builds an edge topology from 2 point sets.
+ *
+ * Both point sets are merged and edges are created based on the minimum distance between one point to the other point set.
+ */
+class SOFA_SOFAMISCTOPOLOGY_API EdgeTopologyFrom2PointSets : public EdgeSetTopologyContainer
+{
+public:
+    SOFA_CLASS(EdgeTopologyFrom2PointSets, EdgeSetTopologyContainer);
+
+    using InitTypes = defaulttype::Vec3Types;
+    using InsertionMapping = std::map< unsigned int, unsigned int >;
+
+protected:
+
+    /// Input
+    ///@{
+    Data< InitTypes::VecCoord > d_positions1;
+    Data< InitTypes::VecCoord > d_positions2;
+
+    Data< sofa::type::vector<sofa::Index> > d_indices1;
+    Data< sofa::type::vector<sofa::Index> > d_indices2;
+
+    Data< bool > d_project1on2;
+    Data< bool > d_project2on1;
+
+    ///@}
+
+    /// List of two indices: index of the object (first or second), index of a point within this object. Could be used
+    /// in association with a SubsetMultiMapping
+    Data< type::vector<unsigned> > d_indexPairs;
+
+    EdgeTopologyFrom2PointSets();
+    void init() override;
+
+    static void EdgeTopologyFrom2PointSets::addPointSet(
+        InitTypes::VecCoord& outPositions,
+        const InitTypes::VecCoord& inPositions,
+        const sofa::type::vector<sofa::Index>& indices,
+        type::vector<unsigned>& indexPairs,
+        InsertionMapping& insertionMapping,
+        unsigned int pointSetIndex);
+
+    void projectPointSet(
+        const sofa::type::vector<sofa::Index>& indices1, const sofa::type::vector<sofa::Index>& indices2,
+        const InitTypes::VecCoord& p1, const InitTypes::VecCoord& p2,
+        const InsertionMapping& insertionMapping1, const InsertionMapping& insertionMapping2);
+};
+
+} //namespace sofa::component::topology

--- a/modules/SofaMiscTopology/src/SofaMiscTopology/EdgeTopologyFrom2PointSets.h
+++ b/modules/SofaMiscTopology/src/SofaMiscTopology/EdgeTopologyFrom2PointSets.h
@@ -63,7 +63,7 @@ protected:
     EdgeTopologyFrom2PointSets();
     void init() override;
 
-    static void EdgeTopologyFrom2PointSets::addPointSet(
+    static void addPointSet(
         InitTypes::VecCoord& outPositions,
         const InitTypes::VecCoord& inPositions,
         const sofa::type::vector<sofa::Index>& indices,


### PR DESCRIPTION
`EdgeTopologyFrom2PointSets` is an edge topology built from 2 point sets. It computes pairs of points based on the nearest distance from one point to the other point set. It is very useful to be used in combination with springs and SubsetMultiMapping.

This component may change depending on the work in #2554 

![image](https://user-images.githubusercontent.com/10572752/147271052-fa2f162e-72f2-4cc9-816f-6f64a0307f87.png)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
