### PR TITLE
[All] Few fixes to allow compilation with MSVC/Clang-cl

### DIFF
--- a/SofaKernel/modules/Sofa.Config/CMakeLists.txt
+++ b/SofaKernel/modules/Sofa.Config/CMakeLists.txt
@@ -194,6 +194,18 @@ if(WIN32)
         list(APPEND SOFACONFIG_COMPILE_OPTIONS_RELEASE "/GL")
         list(APPEND SOFACONFIG_LINK_OPTIONS_RELEASE "/LTCG")
     endif()
+
+
+    # Experimental: compilation with MSVC/Clang-cl
+    if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+        if( ${CMAKE_CXX_COMPILER_FRONTEND_VARIANT} STREQUAL MSVC) #something weird happen if we put the two test in one if ??
+            message(WARNING "Experimental: you are trying to compile with MSVC and the clang-cl toolchain; this is not officially supported.")
+            # remove lots of warnings
+            list(APPEND SOFACONFIG_COMPILE_OPTIONS "-Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-double-promotion -Wno-old-style-cast -Wno-reserved-id-macro -Wno-language-extension-token -Wno-dllexport-explicit-instantiation-decl -Wno-nonportable-system-include-path")
+            # optimization flags (not sure if necessary..)
+            list(APPEND SOFACONFIG_COMPILE_OPTIONS_RELEASE "/fp:fast -march=native")
+        endif()
+    endif()
 endif()
 
 # Mac specific

--- a/SofaKernel/modules/Sofa.Config/CMakeLists.txt
+++ b/SofaKernel/modules/Sofa.Config/CMakeLists.txt
@@ -198,12 +198,12 @@ if(WIN32)
 
     # Experimental: compilation with MSVC/Clang-cl
     if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-        if( ${CMAKE_CXX_COMPILER_FRONTEND_VARIANT} STREQUAL MSVC) #something weird happen if we put the two test in one if ??
+        if( ${CMAKE_CXX_COMPILER_FRONTEND_VARIANT} STREQUAL MSVC) # something weird happens if we put the two test in one if ??
             message(WARNING "Experimental: you are trying to compile with MSVC and the clang-cl toolchain; this is not officially supported.")
-            # remove lots of warnings
-            list(APPEND SOFACONFIG_COMPILE_OPTIONS "-Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-double-promotion -Wno-old-style-cast -Wno-reserved-id-macro -Wno-language-extension-token -Wno-dllexport-explicit-instantiation-decl -Wno-nonportable-system-include-path")
+            # remove lots of warnings (the Wall of "normal" clang seems different of Wall of clang-cl)
+            list(APPEND SOFACONFIG_COMPILE_OPTIONS -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-double-promotion -Wno-old-style-cast -Wno-reserved-id-macro -Wno-language-extension-token -Wno-dllexport-explicit-instantiation-decl -Wno-nonportable-system-include-path -Wno-zero-as-null-pointer-constant -Wno-documentation)
             # optimization flags (not sure if necessary..)
-            list(APPEND SOFACONFIG_COMPILE_OPTIONS_RELEASE "/fp:fast -march=native")
+            list(APPEND SOFACONFIG_COMPILE_OPTIONS_RELEASE /fp:fast -march=native)
         endif()
     endif()
 endif()

--- a/SofaKernel/modules/Sofa.Testing/extlibs/gtest/CMakeLists.txt
+++ b/SofaKernel/modules/Sofa.Testing/extlibs/gtest/CMakeLists.txt
@@ -16,8 +16,10 @@ include(cmake/internal_utils.cmake)
 config_compiler_and_linker()  # Defined in internal_utils.cmake.
 
 # The code must be relocatable if we want to link a shared library against it.
-if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xGNU" OR "x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xClang")
-    add_compile_options(-fPIC)
+if(NOT WIN32)
+    if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xGNU" OR "x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xClang")
+        add_compile_options(-fPIC)
+    endif()
 endif()
 
 set(HEADER_FILES

--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Triangle.h
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Triangle.h
@@ -46,7 +46,7 @@ namespace sofa::topology
     * @return	index of the triangle in the given direction, if parameters allow it; sofa::InvalidID
     */
     template<typename Coordinates, typename VectorCoordinates, typename Real = SReal>
-    static const sofa::Index getTriangleIDInDirection(const VectorCoordinates& trianglePositions, const sofa::type::vector<Triangle>& allTriangles,
+    static sofa::Index getTriangleIDInDirection(const VectorCoordinates& trianglePositions, const sofa::type::vector<Triangle>& allTriangles,
                                                           const sofa::type::vector<sofa::Index>& shellTriangles, const sofa::Index pointID, 
                                                           const Coordinates& direction)
     {

--- a/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Triangle.h
+++ b/SofaKernel/modules/Sofa.Topology/src/sofa/topology/Triangle.h
@@ -46,7 +46,7 @@ namespace sofa::topology
     * @return	index of the triangle in the given direction, if parameters allow it; sofa::InvalidID
     */
     template<typename Coordinates, typename VectorCoordinates, typename Real = SReal>
-    static constexpr sofa::Index getTriangleIDInDirection(const VectorCoordinates& trianglePositions, const sofa::type::vector<Triangle>& allTriangles,
+    static const sofa::Index getTriangleIDInDirection(const VectorCoordinates& trianglePositions, const sofa::type::vector<Triangle>& allTriangles,
                                                           const sofa::type::vector<sofa::Index>& shellTriangles, const sofa::Index pointID, 
                                                           const Coordinates& direction)
     {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyChange.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyChange.cpp
@@ -25,12 +25,12 @@
 
 namespace std
 {
-    template class list<const sofa::core::topology::TopologyChange*>;
+    template class SOFA_CORE_API list<const sofa::core::topology::TopologyChange*>;
 }
 
 namespace sofa::core::objectmodel
 {
-    template class Data<std::list<const sofa::core::topology::TopologyChange*>>;
+    template class SOFA_CORE_API Data<std::list<const sofa::core::topology::TopologyChange*>>;
 }
 
 namespace sofa

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyChange.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyChange.h
@@ -1460,11 +1460,11 @@ public:
 #ifndef SOFA_CORE_TOPOLOGY_TOPOLOGYCHANGE_DEFINITION
 namespace std
 {
-    extern template class std::list<const sofa::core::topology::TopologyChange*>;
+    extern template class SOFA_CORE_API std::list<const sofa::core::topology::TopologyChange*>;
 }
 namespace sofa::core::objectmodel
 {
-    extern template class Data<std::list<const sofa::core::topology::TopologyChange*>>;
+    extern template class SOFA_CORE_API Data<std::list<const sofa::core::topology::TopologyChange*>>;
 }
 
 #endif /// SOFA_CORE_TOPOLOGY_BASETOPOLOGYENGINE_DEFINITION

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
@@ -73,18 +73,6 @@ template class SOFA_GPU_CUDA_API FixParticlePerformer< CudaVec3dTypes >;
 
 ContactMapperCreator< ContactMapper<sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>> > CudaSphereContactMapperClass("PenalityContactForceField",true);
 
-#ifdef WIN32
-template<> SOFA_GPU_CUDA_API
-std::unordered_map<std::type_index, typename FixParticlePerformer<CudaVec3fTypes>::GetFixationPointsOnModelFunction >
-FixParticlePerformer<CudaVec3fTypes>::s_mapSupportedModels;
-
-#ifdef SOFA_GPU_CUDA_DOUBLE
-std::unordered_map<std::type_index, typename FixParticlePerformer<CudaVec3dTypes>::GetFixationPointsOnModelFunction >
-FixParticlePerformer<CudaVec3dTypes>::s_mapSupportedModels;
-#endif
-
-#endif // WIN32
-
 helper::Creator<ComponentMouseInteraction::ComponentMouseInteractionFactory, TComponentMouseInteraction<CudaVec3fTypes> > ComponentMouseInteractionCudaVec3fClass ("MouseSpringCudaVec3f",true);
 helper::Creator<InteractionPerformer::InteractionPerformerFactory, AttachBodyPerformer <CudaVec3fTypes> >  AttachBodyPerformerCudaVec3fClass("AttachBody",true);
 helper::Creator<InteractionPerformer::InteractionPerformerFactory, FixParticlePerformer<CudaVec3fTypes> >  FixParticlePerformerCudaVec3fClass("FixParticle",true);

--- a/modules/SofaSparseSolver/extlibs/metis-5.1.0/GKlib/gk_getopt.h
+++ b/modules/SofaSparseSolver/extlibs/metis-5.1.0/GKlib/gk_getopt.h
@@ -52,11 +52,10 @@ struct gk_option {
 
 
 /* Function prototypes */
-extern int gk_getopt(int __argc, char **__argv, char *__shortopts);
-extern int gk_getopt_long(int __argc, char **__argv, char *__shortopts,
+extern int gk_getopt(int argc, char** argv, char* options);
+extern int gk_getopt_long(int argc, char** argv, char* options,
               struct gk_option *__longopts, int *__longind);
-extern int gk_getopt_long_only (int __argc, char **__argv,
-              char *__shortopts, struct gk_option *__longopts, int *__longind);
+extern int gk_getopt_long_only (int argc, char** argv, char* options, struct gk_option *__longopts, int *__longind);
 
 
 

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
@@ -26,11 +26,11 @@
 namespace sofa::component::collision
 {
 
-#ifdef WIN32
-template<> SOFA_SOFAUSERINTERACTION_API
-    std::unordered_map<std::type_index, typename FixParticlePerformer<defaulttype::Vec3Types>::GetFixationPointsOnModelFunction >
-    FixParticlePerformer<defaulttype::Vec3Types>::s_mapSupportedModels;
-#endif // WIN32
+//#ifdef WIN32
+//template<> SOFA_SOFAUSERINTERACTION_API
+//    std::unordered_map<std::type_index, typename FixParticlePerformer<defaulttype::Vec3Types>::GetFixationPointsOnModelFunction >
+//    FixParticlePerformer<defaulttype::Vec3Types>::s_mapSupportedModels;
+//#endif // WIN32
 using FixParticlePerformer3d = FixParticlePerformer<defaulttype::Vec3Types>;
 
 template class SOFA_SOFAUSERINTERACTION_API FixParticlePerformer<defaulttype::Vec3Types>;

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.cpp
@@ -26,11 +26,6 @@
 namespace sofa::component::collision
 {
 
-//#ifdef WIN32
-//template<> SOFA_SOFAUSERINTERACTION_API
-//    std::unordered_map<std::type_index, typename FixParticlePerformer<defaulttype::Vec3Types>::GetFixationPointsOnModelFunction >
-//    FixParticlePerformer<defaulttype::Vec3Types>::s_mapSupportedModels;
-//#endif // WIN32
 using FixParticlePerformer3d = FixParticlePerformer<defaulttype::Vec3Types>;
 
 template class SOFA_SOFAUSERINTERACTION_API FixParticlePerformer<defaulttype::Vec3Types>;

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.h
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.h
@@ -67,11 +67,11 @@ public:
     using GetFixationPointsOnModelFunction = std::function<void(sofa::core::sptr<sofa::core::CollisionModel>, const Index, type::vector<Index>&, Coord&)>;
     using MapTypeFunction = std::unordered_map<std::type_index, GetFixationPointsOnModelFunction >;
 
-    static MapTypeFunction* getMapInstance()
+    static std::shared_ptr<MapTypeFunction> getMapInstance()
     {
         if (!s_mapSupportedModels)
         {
-            s_mapSupportedModels = new MapTypeFunction();
+            s_mapSupportedModels = std::make_shared<MapTypeFunction>();
         }
         return s_mapSupportedModels;
     }
@@ -111,14 +111,7 @@ protected:
 
     std::vector< simulation::Node * > fixations;
 
-    // inline initialization of templated static members works on VS2019/gcc/clang (>5?)
-    // but not on VS2017 and crash the compilation itself using clang5.
-    // TODO: once VS2017 and clang5 support is dropped, just uncomment the inline static initialization 
-    // and remove the initialization in the inl file (linux/mac) and cpp (windows)
-    inline static MapTypeFunction* s_mapSupportedModels = nullptr;
-    //inline static MapTypeFunction s_mapSupportedModels;
-    //static std::unordered_map<std::type_index, GetFixationPointsOnModelFunction > s_mapSupportedModels;
-
+    inline static std::shared_ptr<MapTypeFunction> s_mapSupportedModels;
 };
 
 #if  !defined(SOFA_COMPONENT_COLLISION_FIXPARTICLEPERFORMER_CPP)

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.h
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.h
@@ -67,11 +67,13 @@ public:
     using GetFixationPointsOnModelFunction = std::function<void(sofa::core::sptr<sofa::core::CollisionModel>, const Index, type::vector<Index>&, Coord&)>;
     using MapTypeFunction = std::unordered_map<std::type_index, GetFixationPointsOnModelFunction >;
 
-    static std::shared_ptr<MapTypeFunction> getMapInstance()
+    //static std::shared_ptr<MapTypeFunction> getMapInstance()
+    static MapTypeFunction* getMapInstance()
     {
         if (!s_mapSupportedModels)
         {
-            s_mapSupportedModels = std::make_shared<MapTypeFunction>();
+            //s_mapSupportedModels = std::make_shared<MapTypeFunction>();
+            s_mapSupportedModels = new MapTypeFunction();
         }
         return s_mapSupportedModels;
     }
@@ -111,7 +113,10 @@ protected:
 
     std::vector< simulation::Node * > fixations;
 
-    inline static std::shared_ptr<MapTypeFunction> s_mapSupportedModels;
+    // VS2017 does not like inline static with classes apparently, shared_ptr provokes a linkage error
+    // (works fine with VS2019 and VS2022)
+    //inline static std::shared_ptr<MapTypeFunction> s_mapSupportedModels;
+    inline static MapTypeFunction* s_mapSupportedModels = nullptr;
 };
 
 #if  !defined(SOFA_COMPONENT_COLLISION_FIXPARTICLEPERFORMER_CPP)

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.h
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.h
@@ -65,11 +65,21 @@ public:
     void draw(const core::visual::VisualParams* vparams);
 
     using GetFixationPointsOnModelFunction = std::function<void(sofa::core::sptr<sofa::core::CollisionModel>, const Index, type::vector<Index>&, Coord&)>;
+    using MapTypeFunction = std::unordered_map<std::type_index, GetFixationPointsOnModelFunction >;
+
+    static MapTypeFunction* getMapInstance()
+    {
+        if (!s_mapSupportedModels)
+        {
+            s_mapSupportedModels = new MapTypeFunction();
+        }
+        return s_mapSupportedModels;
+    }
 
     template<typename TCollisionModel>
     static int RegisterSupportedModel(GetFixationPointsOnModelFunction func)
     {
-        s_mapSupportedModels[std::type_index(typeid(TCollisionModel))] = func;
+        (*getMapInstance())[std::type_index(typeid(TCollisionModel))] = func;
 
         return 1;
     }
@@ -105,8 +115,9 @@ protected:
     // but not on VS2017 and crash the compilation itself using clang5.
     // TODO: once VS2017 and clang5 support is dropped, just uncomment the inline static initialization 
     // and remove the initialization in the inl file (linux/mac) and cpp (windows)
-    //inline static std::unordered_map<std::type_index, GetFixationPointsOnModelFunction > s_mapSupportedModels;
-    static std::unordered_map<std::type_index, GetFixationPointsOnModelFunction > s_mapSupportedModels;
+    inline static MapTypeFunction* s_mapSupportedModels = nullptr;
+    //inline static MapTypeFunction s_mapSupportedModels;
+    //static std::unordered_map<std::type_index, GetFixationPointsOnModelFunction > s_mapSupportedModels;
 
 };
 

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.inl
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.inl
@@ -138,10 +138,4 @@ sofa::component::container::MechanicalObject< DataTypes >* FixParticlePerformer<
     return collisionState;
 }
 
-//#ifndef WIN32
-//template<typename DataTypes>
-//    std::unordered_map<std::type_index, typename FixParticlePerformer<DataTypes>::GetFixationPointsOnModelFunction >
-//    FixParticlePerformer<DataTypes>::s_mapSupportedModels;
-//#endif // WIN32
-
 } // namespace sofa::component::collision

--- a/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.inl
+++ b/modules/SofaUserInteraction/src/SofaUserInteraction/FixParticlePerformer.inl
@@ -116,8 +116,8 @@ sofa::component::container::MechanicalObject< DataTypes >* FixParticlePerformer<
     {
         collisionState = dynamic_cast<MouseContainer*>(b.body->getContext()->getMechanicalState());
 
-        auto funcGetFixationPoints = s_mapSupportedModels.find(std::type_index(typeid(*b.body)));
-        if (funcGetFixationPoints != s_mapSupportedModels.end())
+        auto funcGetFixationPoints = (*getMapInstance()).find(std::type_index(typeid(*b.body)));
+        if (funcGetFixationPoints != (*getMapInstance()).end())
         {
             funcGetFixationPoints->second(b.body, idx, points, fixPoint);
         }
@@ -138,10 +138,10 @@ sofa::component::container::MechanicalObject< DataTypes >* FixParticlePerformer<
     return collisionState;
 }
 
-#ifndef WIN32
-template<typename DataTypes>
-    std::unordered_map<std::type_index, typename FixParticlePerformer<DataTypes>::GetFixationPointsOnModelFunction >
-    FixParticlePerformer<DataTypes>::s_mapSupportedModels;
-#endif // WIN32
+//#ifndef WIN32
+//template<typename DataTypes>
+//    std::unordered_map<std::type_index, typename FixParticlePerformer<DataTypes>::GetFixationPointsOnModelFunction >
+//    FixParticlePerformer<DataTypes>::s_mapSupportedModels;
+//#endif // WIN32
 
 } // namespace sofa::component::collision


### PR DESCRIPTION
... with the current standard set of modules/plugins.
## About
Since MSVC2019, VS proposes the choice to use the clang-cl toolchain (clang with msvc tools). Not possible to enable it with the latest(?) cmake-gui but possible to generate a solution with the commandline version: `cmake -G"Visual Studio 2019" -T ClangCL ..`
## This PR
 - add necessary cmake config to allow compilation (and avoid 1e999 warnings)
 - fix few problems detected with clang (rightly so)
 - change the FixParticlePerformerFactory shenanigan to be cleaner

## Results
It appears that clang is somewhat more clever than cl.exe and seems to produces more optimized binaries.
Results are not always good, and really depends on the situation/scene. Few cases where cl is slightly faster than clang-cl
Some bench:
 - `caduceus.scn -g batch -n 10000`
   - cl: `21.2541 s ( 470.498 FPS)`
   - clang-cl:  `19.6914 s ( 507.836 FPS)`
 - MeshMatrixMass.scn with 4096 steps (from SofaBenchmark)
    - cl: `25504 ms`
    - clang-cl: `18161 ms`
 -  `examples/Benchmark/Performance/benchmark_cubes.scn -g batch -n 1000`
    - cl: `36.7404 s ( 27.218 FPS`
    - clang-cl:  ` 37.8146 s ( 26.4448 FPS)`
  -  `examples/Benchmark/Performance/TorusFall.scn -g batch -n 1000`
    - cl: `8.63699 s ( 115.781 FPS)`
    - clang-cl:  ` 7.72771 s ( 129.404 FPS)`
  -  `applications/plugins/SofaCUDA/examples/beam16x16x76-fem-implicit-CPU.scn -g batch -n 1000`
    - cl: ` 113.022 s ( 8.8478 FPS))`
    - clang-cl:  ` 100.645 s ( 9.93587 FPS)`
 - SofaBenchmark, a lot shows only improvement around 10-15% but some are interesting:
   - `BM_FixedArray_construct<sofa::type::Vec3f>/8192`
     - cl: ` 10.5 us`
     - clang-cl: ` 6.42 us`
   - `BM_Matrix_typemat3x3f_assign/512` this one is weird (the same bench with eigenmat is much closer)
     - cl: `  3.44 us`
     - clang-cl: `  1.18 us`

## Warning
 pybind is not compatible with clang-cl (and I am sure a lot of other libraries), even gtest as it is was not compatible

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
