### PR TITLE
[Sofa.Helper] clean ComponentChange and add new category

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.cpp
@@ -22,14 +22,10 @@
 #include "ComponentChange.h"
 
 
-namespace sofa
-{
-namespace helper
-{
-namespace lifecycle
+namespace sofa::helper::lifecycle
 {
 
-std::map<std::string, Deprecated> deprecatedComponents = {
+const std::map<std::string, Deprecated, std::less<> > deprecatedComponents = {
     // SofaMiscForceField
     {"MatrixMass", Deprecated("v19.06", "v19.12")},
     {"RayTraceDetection", Deprecated("v21.06", "v21.12")},
@@ -38,7 +34,7 @@ std::map<std::string, Deprecated> deprecatedComponents = {
     {"PointConstraint", Deprecated("v21.12", "v22.06")},
 };
 
-std::map<std::string, ComponentChange> uncreatableComponents = {
+const std::map<std::string, ComponentChange, std::less<> > uncreatableComponents = {
     // SofaDistanceGrid was pluginized in #389
     {"BarycentricPenalityContact", Pluginized("v17.12", "SofaMeshCollision")},
     {"DistanceGridCollisionModel", Pluginized("v17.12", "SofaDistanceGrid")},
@@ -684,7 +680,6 @@ std::map<std::string, ComponentChange> uncreatableComponents = {
 
 };
 
-} // namespace lifecycle
-} // namespace helper
-} // namespace sofa
+const std::map< std::string, CreatableMoved, std::less<> > movedComponents = {};
 
+} // namespace sofa::helper::lifecycle

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.h
@@ -120,7 +120,7 @@ public:
         std::stringstream output;
         output << "This component has been MOVED from " << fromPlugin << " to " << toPlugin << " since SOFA " << sinceVersion << ". "
                 << "You can still use this component because " << fromPlugin << " loaded " << toPlugin <<". "
-               <<  "It is advised to use " << toPlugin << " from now on."
+               <<  "It is advised to directly load " << toPlugin << " from now on, e.g. you may add:"
                <<  "You can do it by adding <RequiredPlugin name='" << toPlugin << "'/>";
         m_message = output.str();
         m_changeVersion = sinceVersion;

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.h
@@ -121,7 +121,7 @@ public:
         output << "This component has been MOVED from " << fromPlugin << " to " << toPlugin << " since SOFA " << sinceVersion << ". "
                 << "You can still use this component because " << fromPlugin << " loaded " << toPlugin <<". "
                <<  "It is advised to directly load " << toPlugin << " from now on, e.g. you may add:"
-               <<  "You can do it by adding <RequiredPlugin name='" << toPlugin << "'/>";
+               <<  "<RequiredPlugin name='" << toPlugin << "'/>";
         m_message = output.str();
         m_changeVersion = sinceVersion;
     }

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.h
@@ -19,8 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_HELPER_COMPONENTCHANGE_H
-#define SOFA_HELPER_COMPONENTCHANGE_H
+#pragma once
 
 #include <string>
 #include <vector>
@@ -28,35 +27,33 @@
 #include <sstream>
 #include <sofa/helper/config.h>
 
-namespace sofa
-{
-namespace helper
-{
-namespace lifecycle
+namespace sofa::helper::lifecycle
 {
 
 class SOFA_HELPER_API ComponentChange
 {
 public:
-    ComponentChange() {}
-    ComponentChange(std::string sinceVersion) {
+    ComponentChange() = default;
+    explicit ComponentChange(const std::string& sinceVersion)
+    {
         std::stringstream output;
         output << "This component changed since SOFA " << sinceVersion;
         m_message = output.str();
         m_changeVersion = sinceVersion;
     }
-    virtual ~ComponentChange() {}
+    virtual ~ComponentChange() = default;
 
     std::string m_message;
     std::string m_changeVersion;
-    const std::string& getMessage() { return m_message; }
-    const std::string& getVersion() { return m_changeVersion; }
+    const std::string& getMessage() const { return m_message; }
+    const std::string& getVersion() const { return m_changeVersion; }
 };
 
 class SOFA_HELPER_API Deprecated : public ComponentChange
 {
 public:
-    Deprecated(std::string sinceVersion, std::string untilVersion) {
+    explicit Deprecated(const std::string& sinceVersion, const std::string& untilVersion)
+    {
         std::stringstream output;
         output << "This component has been DEPRECATED since SOFA " << sinceVersion << " "
                   "and will be removed in SOFA " << untilVersion << ". "
@@ -72,7 +69,8 @@ public:
 class SOFA_HELPER_API Pluginized : public ComponentChange
 {
 public:
-    Pluginized(std::string sinceVersion, std::string plugin) {
+    explicit Pluginized(const std::string& sinceVersion, const std::string& plugin)
+    {
         std::stringstream output;
         output << "This component has been PLUGINIZED since SOFA " << sinceVersion << ". "
                   "To continue using this component you need to update you scene "
@@ -85,7 +83,8 @@ public:
 class SOFA_HELPER_API Removed : public ComponentChange
 {
 public:
-    Removed(std::string  sinceVersion, std::string atVersion) {
+    explicit Removed(const std::string&  sinceVersion, const std::string& atVersion)
+    {
         std::stringstream output;
         output << "This component has been REMOVED since SOFA " << atVersion << " "
                   "(deprecated since " << sinceVersion << "). "
@@ -100,22 +99,39 @@ public:
 class SOFA_HELPER_API Moved : public ComponentChange
 {
 public:
-    Moved(std::string sinceVersion, std::string fromPlugin, std::string toPlugin)
+    Moved(const std::string& sinceVersion, const std::string& fromPlugin, const std::string& toPlugin)
     {
         std::stringstream output;
         output << "This component has been MOVED from " << fromPlugin << " to " << toPlugin << " since SOFA " << sinceVersion << ". "
-               <<  "To continue using this component you may need to update your scene "
-               <<  "by adding <RequiredPlugin name='" << toPlugin << "'/>";
+            << "To continue using this component you may need to update your scene "
+            << "by adding <RequiredPlugin name='" << toPlugin << "'/>";
         m_message = output.str();
         m_changeVersion = sinceVersion;
     }
 };
 
-extern SOFA_HELPER_API std::map< std::string, Deprecated > deprecatedComponents;
-extern SOFA_HELPER_API std::map< std::string, ComponentChange > uncreatableComponents;
+class SOFA_HELPER_API CreatableMoved : public ComponentChange
+{
+public:
+    explicit CreatableMoved(const std::string& sinceVersion, const std::string& fromPlugin, const std::string& toPlugin)
+        : fromPlugin(fromPlugin)
+        , toPlugin(toPlugin)
+    {
+        std::stringstream output;
+        output << "This component has been MOVED from " << fromPlugin << " to " << toPlugin << " since SOFA " << sinceVersion << ". "
+                << "You can still use this component because " << fromPlugin << " loaded " << toPlugin <<". "
+               <<  "It is advised to use " << toPlugin << " from now on."
+               <<  "You can do it by adding <RequiredPlugin name='" << toPlugin << "'/>";
+        m_message = output.str();
+        m_changeVersion = sinceVersion;
+    }
 
-} // namespace lifecycle
-} // namespace helper
-} // namespace sofa
+    std::string fromPlugin;
+    std::string toPlugin;
+};
 
-#endif
+extern SOFA_HELPER_API const std::map< std::string, Deprecated, std::less<> > deprecatedComponents;
+extern SOFA_HELPER_API const std::map< std::string, ComponentChange, std::less<> > uncreatableComponents;
+extern SOFA_HELPER_API const std::map< std::string, CreatableMoved, std::less<> > movedComponents;
+
+} // namespace sofa::helper::lifecycle


### PR DESCRIPTION
Preparation for sofang

ComponentChange does not handle the case where a component is still creatable/invokable from a (deprecated) plugin but the "real" component has been moved into an other plugin (typically from a current Sofa Module to a planned new SofaNG module)
This PR add this case into ComponentChange.

The current "Moved" class handles the case where a component has been *really* moved  from two plugins (i.e not creatable anymore if the original plugin is still used.

+ some cleanups coming from suggestions from SonarLint



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
