### PR TITLE
[SofaFramework] Add tests on aliases for "multiple projects" out-of-tree build

### DIFF
--- a/SofaKernel/modules/SofaCore/Sofa.CoreConfig.cmake.in
+++ b/SofaKernel/modules/SofaCore/Sofa.CoreConfig.cmake.in
@@ -12,11 +12,13 @@ if(NOT TARGET @PROJECT_NAME@)
 endif()
 
 # Create alias to support compatibility, starting from v21.06
-# This alias will be deleted in v21.12
-get_target_property(Sofa.Core_IMPORTED Sofa.Core IMPORTED)
-if(Sofa.Core_IMPORTED)
-    set_target_properties(Sofa.Core PROPERTIES IMPORTED_GLOBAL TRUE)
+# This alias will be deleted in v22.06
+if(NOT TARGET SofaCore) # test if alias was not already created
+    get_target_property(Sofa.Core_IMPORTED Sofa.Core IMPORTED)
+    if(Sofa.Core_IMPORTED)
+        set_target_properties(Sofa.Core PROPERTIES IMPORTED_GLOBAL TRUE)
+    endif()
+    add_library(SofaCore ALIAS Sofa.Core)
 endif()
-add_library(SofaCore ALIAS Sofa.Core)
 
 check_required_components(@PROJECT_NAME@)

--- a/SofaKernel/modules/SofaDefaultType/Sofa.DefaultTypeConfig.cmake.in
+++ b/SofaKernel/modules/SofaDefaultType/Sofa.DefaultTypeConfig.cmake.in
@@ -12,11 +12,13 @@ if(NOT TARGET @PROJECT_NAME@)
 endif()
 
 # Create alias to support compatibility, starting from v21.06
-# This alias will be deleted in v21.12
-get_target_property(Sofa.DefaultType_IMPORTED Sofa.DefaultType IMPORTED)
-if(Sofa.DefaultType_IMPORTED)
-    set_target_properties(Sofa.DefaultType PROPERTIES IMPORTED_GLOBAL TRUE)
+# This alias will be deleted in v22.06
+if(NOT TARGET SofaCore) # test if alias was not already created
+    get_target_property(Sofa.DefaultType_IMPORTED Sofa.DefaultType IMPORTED)
+    if(Sofa.DefaultType_IMPORTED)
+        set_target_properties(Sofa.DefaultType PROPERTIES IMPORTED_GLOBAL TRUE)
+    endif()
+    add_library(SofaDefaultType ALIAS Sofa.DefaultType)
 endif()
-add_library(SofaDefaultType ALIAS Sofa.DefaultType)
 
 check_required_components(@PROJECT_NAME@)

--- a/SofaKernel/modules/SofaDefaultType/Sofa.DefaultTypeConfig.cmake.in
+++ b/SofaKernel/modules/SofaDefaultType/Sofa.DefaultTypeConfig.cmake.in
@@ -13,7 +13,7 @@ endif()
 
 # Create alias to support compatibility, starting from v21.06
 # This alias will be deleted in v22.06
-if(NOT TARGET SofaCore) # test if alias was not already created
+if(NOT TARGET SofaDefaultType) # test if alias was not already created
     get_target_property(Sofa.DefaultType_IMPORTED Sofa.DefaultType IMPORTED)
     if(Sofa.DefaultType_IMPORTED)
         set_target_properties(Sofa.DefaultType PROPERTIES IMPORTED_GLOBAL TRUE)

--- a/SofaKernel/modules/SofaHelper/Sofa.HelperConfig.cmake.in
+++ b/SofaKernel/modules/SofaHelper/Sofa.HelperConfig.cmake.in
@@ -14,11 +14,13 @@ if(NOT TARGET @PROJECT_NAME@)
 endif()
 
 # Create alias to support compatibility, starting from v21.06
-# This alias will be deleted in v21.12
-get_target_property(Sofa.Helper_IMPORTED Sofa.Helper IMPORTED)
-if(Sofa.Helper_IMPORTED)
-    set_target_properties(Sofa.Helper PROPERTIES IMPORTED_GLOBAL TRUE)
+# This alias will be deleted in v22.06
+if(NOT TARGET SofaHelper) # test if alias was not already created
+    get_target_property(Sofa.Helper_IMPORTED Sofa.Helper IMPORTED)
+    if(Sofa.Helper_IMPORTED)
+        set_target_properties(Sofa.Helper PROPERTIES IMPORTED_GLOBAL TRUE)
+    endif()
+    add_library(SofaHelper ALIAS Sofa.Helper)
 endif()
-add_library(SofaHelper ALIAS Sofa.Helper)
 
 check_required_components(@PROJECT_NAME@)

--- a/SofaKernel/modules/SofaSimulationCore/Sofa.SimulationCoreConfig.cmake.in
+++ b/SofaKernel/modules/SofaSimulationCore/Sofa.SimulationCoreConfig.cmake.in
@@ -10,11 +10,13 @@ if(NOT TARGET @PROJECT_NAME@)
 endif()
 
 # Create alias to support compatibility, starting from v21.06
-# This alias will be deleted in v21.12
-get_target_property(Sofa.SimulationCore_IMPORTED Sofa.SimulationCore IMPORTED)
-if(Sofa.SimulationCore_IMPORTED)
-    set_target_properties(Sofa.SimulationCore PROPERTIES IMPORTED_GLOBAL TRUE)
+# This alias will be deleted in v22.06
+if(NOT TARGET SofaSimulationCore) # test if alias was not already created
+    get_target_property(Sofa.SimulationCore_IMPORTED Sofa.SimulationCore IMPORTED)
+    if(Sofa.SimulationCore_IMPORTED)
+        set_target_properties(Sofa.SimulationCore PROPERTIES IMPORTED_GLOBAL TRUE)
+    endif()
+    add_library(SofaSimulationCore ALIAS Sofa.SimulationCore)
 endif()
-add_library(SofaSimulationCore ALIAS Sofa.SimulationCore)
 
 check_required_components(@PROJECT_NAME@)


### PR DESCRIPTION
While making out-of-tree builds with SofaGLFW, which entrypoint is a a cmakelists with two add_sofa_something(), cmake is throwing this kind of error while reading the second project:
```cmake
CMake Error at C:/Work/sofa/install/master_fredroy/lib/cmake/Sofa.DefaultType/Sofa.DefaultTypeConfig.cmake:44 (set_target_properties):
  Attempt to promote imported target "Sofa.DefaultType" to global scope (by
  setting IMPORTED_GLOBAL) which is not built in this directory.
```
which appears (after some headaches) to be linked with the fact that the Sofa.DefaultTypeConfig is read twice and cmake tries to set a flag (imported global) on something which has already the flag, and more generally to do twice the job of aliasing.

So this PR adds a test on the four "legacy" SofaFramework targets to only make aliases if it was not done before.
 
And for good measure, update the date for the removal of the aliases to v22.06


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
