### PR TITLE
[SofaGeneralSimpleFEM] Some cleaning in TriangularFEMForceFieldOptim

### DIFF
--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.h
@@ -180,8 +180,8 @@ public:
     /// Topology Data
     typedef typename VecCoord::template rebind<TriangleInfo>::other VecTriangleInfo;
     typedef typename VecCoord::template rebind<TriangleState>::other VecTriangleState;
-    topology::TriangleData<VecTriangleInfo> d_triangleInfo; ///< Internal triangle data (persistent)
-    topology::TriangleData<VecTriangleState> d_triangleState; ///< Internal triangle data (time-dependent)
+    core::topology::TriangleData<VecTriangleInfo> d_triangleInfo; ///< Internal triangle data (persistent)
+    core::topology::TriangleData<VecTriangleState> d_triangleState; ///< Internal triangle data (time-dependent)
 
     /** Method to create @sa TriangleInfo when a new triangle is created.
     * Will be set as creation callback in the TriangleData @sa d_triangleInfo

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.h
@@ -182,56 +182,12 @@ public:
             return in;
         }
     };
-    /// Class to store FEM information on each edge, for topology modification handling
-    class EdgeInfo
-    {
-    public:
-        bool fracturable;
-
-        EdgeInfo()
-            : fracturable(false) { }
-
-        /// Output stream
-        inline friend std::ostream& operator<< ( std::ostream& os, const EdgeInfo& /*ei*/ )
-        {
-            return os;
-        }
-
-        /// Input stream
-        inline friend std::istream& operator>> ( std::istream& in, EdgeInfo& /*ei*/ )
-        {
-            return in;
-        }
-    };
-
-    /// Class to store FEM information on each vertex, for topology modification handling
-    class VertexInfo
-    {
-    public:
-        VertexInfo()
-        /*:sumEigenValues(0.0)*/ {}
-
-        /// Output stream
-        inline friend std::ostream& operator<< ( std::ostream& os, const VertexInfo& /*vi*/)
-        {
-            return os;
-        }
-        /// Input stream
-        inline friend std::istream& operator>> ( std::istream& in, VertexInfo& /*vi*/)
-        {
-            return in;
-        }
-    };
 
     /// Topology Data
     typedef typename VecCoord::template rebind<TriangleInfo>::other VecTriangleInfo;
     typedef typename VecCoord::template rebind<TriangleState>::other VecTriangleState;
-    typedef typename VecCoord::template rebind<VertexInfo>::other VecVertexInfo;
-    typedef typename VecCoord::template rebind<EdgeInfo>::other VecEdgeInfo;
-    core::topology::TriangleData<VecTriangleInfo> d_triangleInfo; ///< Internal triangle data (persistent)
-    core::topology::TriangleData<VecTriangleState> d_triangleState; ///< Internal triangle data (time-dependent)
-    core::topology::PointData<VecVertexInfo> d_vertexInfo; ///< Internal point data
-    core::topology::EdgeData<VecEdgeInfo> d_edgeInfo; ///< Internal edge data
+    topology::TriangleData<VecTriangleInfo> d_triangleInfo; ///< Internal triangle data (persistent)
+    topology::TriangleData<VecTriangleState> d_triangleState; ///< Internal triangle data (time-dependent)
 
     /** Method to create @sa TriangleInfo when a new triangle is created.
     * Will be set as creation callback in the TriangleData @sa d_triangleInfo

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.h
@@ -21,17 +21,11 @@
 ******************************************************************************/
 #pragma once
 #include <SofaGeneralSimpleFem/config.h>
-
-
-
 #include <sofa/core/behavior/ForceField.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/type/Mat.h>
 #include <sofa/core/topology/TopologyData.h>
-
-#include <map>
-#include <sofa/helper/map.h>
 
 namespace sofa::component::forcefield
 {
@@ -127,7 +121,7 @@ public:
         Real bx, cx, cy, ss_factor;
         Transformation init_frame; // Mat<2,3,Real>
 
-        TriangleInfo() { }
+        TriangleInfo() :bx(0), cx(0), cy(0), ss_factor(0) { }
 
         /// Output stream
         inline friend std::ostream& operator<< ( std::ostream& os, const TriangleInfo& ti )

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.inl
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.inl
@@ -42,8 +42,6 @@ template <class DataTypes>
 TriangularFEMForceFieldOptim<DataTypes>::TriangularFEMForceFieldOptim()
     : d_triangleInfo(initData(&d_triangleInfo, "triangleInfo", "Internal triangle data (persistent)"))
     , d_triangleState(initData(&d_triangleState, "triangleState", "Internal triangle data (time-dependent)"))
-    , d_vertexInfo(initData(&d_vertexInfo, "vertexInfo", "Internal point data"))
-    , d_edgeInfo(initData(&d_edgeInfo, "edgeInfo", "Internal edge data"))
     , d_poisson(initData(&d_poisson,(Real)(0.3),"poissonRatio","Poisson ratio in Hooke's law"))
     , d_young(initData(&d_young,(Real)(1000.0),"youngModulus","Young modulus in Hooke's law"))
     , d_damping(initData(&d_damping,(Real)0.,"damping","Ratio damping/stiffness"))
@@ -108,9 +106,6 @@ void TriangularFEMForceFieldOptim<DataTypes>::init()
     {
         createTriangleState(triangleIndex, ti, t, ancestors, coefs);
     });
-
-    d_edgeInfo.createTopologyHandler(m_topology);
-    d_vertexInfo.createTopologyHandler(m_topology);
 
     if (m_topology->getNbTriangles() == 0)
     {
@@ -244,16 +239,6 @@ void TriangularFEMForceFieldOptim<DataTypes>::reinit()
     d_triangleInfo.endEdit();
     d_triangleState.endEdit();
 
-    /// prepare to store info in the edge array
-    VecEdgeInfo& edgeInf = *(d_edgeInfo.beginEdit());
-    edgeInf.resize(m_topology->getNbEdges());
-    d_edgeInfo.endEdit();
-
-    /// prepare to store info in the vertex array
-    unsigned int nbPoints = m_topology->getNbPoints();
-    VecVertexInfo& vi = *(d_vertexInfo.beginEdit());
-    vi.resize(nbPoints);
-    d_vertexInfo.endEdit();
     data.reinit(this);
 }
 

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.inl
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.inl
@@ -19,16 +19,11 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-
 #pragma once
-#include "TriangularFEMForceFieldOptim.h"
-
+#include <SofaGeneralSimpleFem/TriangularFEMForceFieldOptim.h>
 #include <SofaBaseLinearSolver/BlocMatrixWriter.h>
-
 #include <sofa/core/visual/VisualParams.h>
-
 #include <sofa/core/topology/TopologyData.inl>
-
 #include <limits>
 
 


### PR DESCRIPTION
- Remove unsued topologyData: d_vertexInfo, d_edgeInfo
- remove corresponding inner classes
- small cleanings in headers



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
