### PR TITLE
[tools] Correction of the import of the queue library

### DIFF
--- a/tools/sofa-launcher/launcher.py
+++ b/tools/sofa-launcher/launcher.py
@@ -9,7 +9,7 @@
 #       - damien.marchal@univ-lille.1
 #############################################################################
 import threading
-import Queue
+from queue import Queue
 import tempfile 
 import sys
 from Cheetah.Template import Template
@@ -59,7 +59,7 @@ class SerialLauncher(Launcher):
 class ParallelLauncher(Launcher):
         def __init__(self, numprocess):
                 self.numprocess = numprocess
-                self.pendingtask = Queue.Queue()
+                self.pendingtask = Queue()
                 self.times = {}
                                
                 # Create the threads


### PR DESCRIPTION
Correction of the import of the queue library so that it can work with python3




The import and use of the queue library has changed between python2 and python3.
I updated it to use it in python3

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
