### PR TITLE
[SofaBoundaryCondition] Replace deprecated headers

### DIFF
--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/EdgePressureForceField.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/EdgePressureForceField.h
@@ -23,7 +23,7 @@
 #include <SofaBoundaryCondition/config.h>
 
 #include <sofa/core/behavior/ForceField.h>
-#include <SofaBaseTopology/TopologySubsetData.h>
+#include <sofa/core/topology/TopologySubsetData.h>
 
 namespace sofa::component::forcefield
 {

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TrianglePressureForceField.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TrianglePressureForceField.h
@@ -24,7 +24,7 @@
 
 
 #include <sofa/core/behavior/ForceField.h>
-#include <SofaBaseTopology/TopologySubsetData.h>
+#include <sofa/core/topology/TopologySubsetData.h>
 #include <sofa/type/MatSym.h>
 
 namespace sofa::component::forcefield

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TrianglePressureForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TrianglePressureForceField.inl
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <SofaBoundaryCondition/TrianglePressureForceField.h>
-#include <SofaBaseTopology/TopologySubsetData.inl>
+#include <sofa/core/topology/TopologySubsetData.inl>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/MechanicalParams.h>
 #include <sofa/type/RGBAColor.h>


### PR DESCRIPTION
Just happened to compile without the Compat option, and these 3 files were still using compat files.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
