### PR TITLE
[SofaMiscSolver] Accumulate mapped forces in NewmarkImplicitSolver

### DIFF
--- a/modules/SofaMiscSolver/src/SofaMiscSolver/NewmarkImplicitSolver.cpp
+++ b/modules/SofaMiscSolver/src/SofaMiscSolver/NewmarkImplicitSolver.cpp
@@ -100,7 +100,7 @@ void NewmarkImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa
 
     // 2. Compute right hand term of equation on a_{t+h}
 
-    mop.computeForce(b,true,false);
+    mop.computeForce(b);
     //b = f;
     // b = M a
     if (rM != 0.0 || rK != 0.0 || beta != 0.5)

--- a/modules/SofaMiscSolver/src/SofaMiscSolver/NewmarkImplicitSolver.cpp
+++ b/modules/SofaMiscSolver/src/SofaMiscSolver/NewmarkImplicitSolver.cpp
@@ -176,7 +176,7 @@ void NewmarkImplicitSolver::solve(const core::ExecParams* params, SReal dt, sofa
     a.eq(aResult);
 }
 
-int NewmarkImplicitSolverClass = core::RegisterObject("Implicit time integratorusing Newmark scheme")
+int NewmarkImplicitSolverClass = core::RegisterObject("Implicit time integrator using Newmark scheme")
         .add< NewmarkImplicitSolver >();
 
 } // namespace sofa::component::odesolver


### PR DESCRIPTION
`NewmarkImplicitSolver` never accumulated forces in a mapped Node. This PR fixes it.

What I think happened:
Initially (before 2011), the ODE solvers did not accumulated mapped forces, because "_accumulation through mappings is disabled as it will be done by addMBKv after all factors are computed_" (quote from a [comment](https://github.com/sofa-framework/sofa/commit/0943c8fa75490d0a1d3dc50ba3b22df4ae7d7f07)). This behavior changed in https://github.com/sofa-framework/sofa/commit/0943c8fa75490d0a1d3dc50ba3b22df4ae7d7f07, but `NewmarkImplicitSolver` was never updated.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
