### PR TITLE
[SofaMatrix] Move CI setting to the plugin folder

### DIFF
--- a/applications/plugins/SofaMatrix/examples/.scene-tests
+++ b/applications/plugins/SofaMatrix/examples/.scene-tests
@@ -1,0 +1,2 @@
+# No need for more than 1 iteration to test an export
+iterations "Components/linearsolver/GlobalSystemMatrixExporter.scn" "1"

--- a/applications/plugins/SofaMatrix/examples/.scene-tests
+++ b/applications/plugins/SofaMatrix/examples/.scene-tests
@@ -1,2 +1,2 @@
 # No need for more than 1 iteration to test an export
-iterations "Components/linearsolver/GlobalSystemMatrixExporter.scn" "1"
+iterations "GlobalSystemMatrixExporter.scn" "1"

--- a/examples/.scene-tests
+++ b/examples/.scene-tests
@@ -45,6 +45,3 @@ ignore "Components/controller/MechanicalStateController.scn"
 # To be removed when scenes are fixed.
 ignore "Benchmark/TopologicalChanges/ProjectToPlaneConstraint_RemovingMeshTest.scn"
 ignore "Benchmark/TopologicalChanges/FixedPlaneConstraint_RemovingMeshTest.scn"
-
-# No need for more than 1 iteration to test an export
-iterations "Components/linearsolver/GlobalSystemMatrixExporter.scn" "1"


### PR DESCRIPTION
When the scene `GlobalSystemMatrixExporter.scn` was moved, the CI settings were not moved. Because of that, it causes a timeout on Windows on the CI.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
