### PR TITLE
[SofaHelper] Speedup ReadAccessor conversion operator

### DIFF
--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/accessor.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/accessor.h
@@ -182,7 +182,7 @@ public:
     const_iterator end() const { return vref->end(); }
 
     ///////// Access the container for reading ////////////////
-    operator const T& () const { return  *vref; }
+    operator const_container_type& () const { return  *vref; }
     const_container_type* operator->() const { return vref; }
     const_container_type& operator* () const { return  *vref; }
     const_container_type& ref() const { return *vref; }          ///< this duplicate operator* (remove ?)

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/accessor.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/accessor.h
@@ -182,7 +182,7 @@ public:
     const_iterator end() const { return vref->end(); }
 
     ///////// Access the container for reading ////////////////
-    operator  const_container_type () const { return  *vref; }
+    operator const T& () const { return  *vref; }
     const_container_type* operator->() const { return vref; }
     const_container_type& operator* () const { return  *vref; }
     const_container_type& ref() const { return *vref; }          ///< this duplicate operator* (remove ?)


### PR DESCRIPTION
The implicit conversion operator returned a const value. Now, it's a const reference.

Before:
```
------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                          Time             CPU   Iterations
------------------------------------------------------------------------------------------------------------------------------------
BM_Data_GetValue<int>                                                                           2.12 ns         2.15 ns    320000000
BM_Data_GetValue<sofa::type::vector<int>>/10000                                                 2.12 ns         2.15 ns    320000000
BM_Data_GetValue<sofa::type::vector<int>>/100000                                                2.13 ns         2.10 ns    320000000
BM_Data_GetValue<sofa::type::vector<int>>/1000000                                               2.23 ns         2.20 ns    320000000
BM_Data_GetValue<sofa::type::vector<sofa::type::Vec3>>/10000                                    1.92 ns         1.90 ns    344615385
BM_Data_GetValue<sofa::type::vector<sofa::type::Vec3>>/100000                                   1.92 ns         1.88 ns    373333333
BM_Data_GetValue<sofa::type::vector<sofa::type::Vec3>>/1000000                                  1.99 ns         1.99 ns    344615385
BM_Data_ReadAccessor_ImplicitConversion<int>                                                    2.84 ns         2.85 ns    235789474
BM_Data_ReadAccessor_ImplicitConversion<sofa::type::vector<int>>/10000                           802 ns          802 ns       896000
BM_Data_ReadAccessor_ImplicitConversion<sofa::type::vector<int>>/100000                         7127 ns         7115 ns       112000
BM_Data_ReadAccessor_ImplicitConversion<sofa::type::vector<int>>/1000000                      645701 ns       641741 ns         1120
BM_Data_ReadAccessor_ImplicitConversion<sofa::type::vector<sofa::type::Vec3>>/10000            13166 ns        13137 ns        49953
BM_Data_ReadAccessor_ImplicitConversion<sofa::type::vector<sofa::type::Vec3>>/100000          572983 ns       571987 ns         1120
BM_Data_ReadAccessor_ImplicitConversion<sofa::type::vector<sofa::type::Vec3>>/1000000        6777096 ns      6835938 ns          112
BM_Data_ReadAccessor_ExplicitConversion<int>                                                    2.66 ns         2.67 ns    263529412
BM_Data_ReadAccessor_ExplicitConversion<sofa::type::vector<int>>/10000                           812 ns          802 ns       896000
BM_Data_ReadAccessor_ExplicitConversion<sofa::type::vector<int>>/100000                        19633 ns        19496 ns        34462
BM_Data_ReadAccessor_ExplicitConversion<sofa::type::vector<int>>/1000000                      674789 ns       683594 ns         1120
BM_Data_ReadAccessor_ExplicitConversion<sofa::type::vector<sofa::type::Vec3>>/10000            14338 ns        14509 ns        56000
BM_Data_ReadAccessor_ExplicitConversion<sofa::type::vector<sofa::type::Vec3>>/100000          586180 ns       575474 ns          896
BM_Data_ReadAccessor_ExplicitConversion<sofa::type::vector<sofa::type::Vec3>>/1000000        6556092 ns      6666667 ns           75
BM_Data_ReadAccessor_StarOperatorConversion<int>                                                2.61 ns         2.62 ns    280000000
BM_Data_ReadAccessor_StarOperatorConversion<sofa::type::vector<int>>/10000                      2.59 ns         2.55 ns    263529412
BM_Data_ReadAccessor_StarOperatorConversion<sofa::type::vector<int>>/100000                     2.58 ns         2.55 ns    263529412
BM_Data_ReadAccessor_StarOperatorConversion<sofa::type::vector<int>>/1000000                    2.60 ns         2.61 ns    263529412
BM_Data_ReadAccessor_StarOperatorConversion<sofa::type::vector<sofa::type::Vec3>>/10000         2.80 ns         2.83 ns    248888889
BM_Data_ReadAccessor_StarOperatorConversion<sofa::type::vector<sofa::type::Vec3>>/100000        2.76 ns         2.76 ns    248888889
BM_Data_ReadAccessor_StarOperatorConversion<sofa::type::vector<sofa::type::Vec3>>/1000000       2.80 ns         2.76 ns    248888889
```

After:

```
------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                          Time             CPU   Iterations
------------------------------------------------------------------------------------------------------------------------------------
BM_Data_GetValue<int>                                                                           2.26 ns         2.26 ns    248888889
BM_Data_GetValue<sofa::type::vector<int>>/10000                                                 2.13 ns         2.15 ns    320000000
BM_Data_GetValue<sofa::type::vector<int>>/100000                                                2.14 ns         2.14 ns    298666667
BM_Data_GetValue<sofa::type::vector<int>>/1000000                                               2.14 ns         2.15 ns    320000000
BM_Data_GetValue<sofa::type::vector<sofa::type::Vec3>>/10000                                    2.00 ns         2.01 ns    373333333
BM_Data_GetValue<sofa::type::vector<sofa::type::Vec3>>/100000                                   1.94 ns         1.90 ns    344615385
BM_Data_GetValue<sofa::type::vector<sofa::type::Vec3>>/1000000                                  2.01 ns         2.01 ns    373333333
BM_Data_ReadAccessor_ImplicitConversion<int>                                                    2.88 ns         2.85 ns    235789474
BM_Data_ReadAccessor_ImplicitConversion<sofa::type::vector<int>>/10000                          2.81 ns         2.83 ns    248888889
BM_Data_ReadAccessor_ImplicitConversion<sofa::type::vector<int>>/100000                         3.02 ns         3.01 ns    248888889
BM_Data_ReadAccessor_ImplicitConversion<sofa::type::vector<int>>/1000000                        2.88 ns         2.83 ns    248888889
BM_Data_ReadAccessor_ImplicitConversion<sofa::type::vector<sofa::type::Vec3>>/10000             2.62 ns         2.61 ns    263529412
BM_Data_ReadAccessor_ImplicitConversion<sofa::type::vector<sofa::type::Vec3>>/100000            2.61 ns         2.61 ns    263529412
BM_Data_ReadAccessor_ImplicitConversion<sofa::type::vector<sofa::type::Vec3>>/1000000           2.58 ns         2.57 ns    280000000
BM_Data_ReadAccessor_ExplicitConversion<int>                                                    2.57 ns         2.55 ns    263529412
BM_Data_ReadAccessor_ExplicitConversion<sofa::type::vector<int>>/10000                          2.59 ns         2.55 ns    263529412
BM_Data_ReadAccessor_ExplicitConversion<sofa::type::vector<int>>/100000                         2.60 ns         2.61 ns    263529412
BM_Data_ReadAccessor_ExplicitConversion<sofa::type::vector<int>>/1000000                        2.64 ns         2.68 ns    280000000
BM_Data_ReadAccessor_ExplicitConversion<sofa::type::vector<sofa::type::Vec3>>/10000             2.81 ns         2.76 ns    248888889
BM_Data_ReadAccessor_ExplicitConversion<sofa::type::vector<sofa::type::Vec3>>/100000            2.85 ns         2.83 ns    248888889
BM_Data_ReadAccessor_ExplicitConversion<sofa::type::vector<sofa::type::Vec3>>/1000000           2.86 ns         2.83 ns    248888889
BM_Data_ReadAccessor_StarOperatorConversion<int>                                                2.66 ns         2.67 ns    263529412
BM_Data_ReadAccessor_StarOperatorConversion<sofa::type::vector<int>>/10000                      2.64 ns         2.67 ns    263529412
BM_Data_ReadAccessor_StarOperatorConversion<sofa::type::vector<int>>/100000                     2.59 ns         2.55 ns    263529412
BM_Data_ReadAccessor_StarOperatorConversion<sofa::type::vector<int>>/1000000                    2.57 ns         2.57 ns    280000000
BM_Data_ReadAccessor_StarOperatorConversion<sofa::type::vector<sofa::type::Vec3>>/10000         2.80 ns         2.83 ns    248888889
BM_Data_ReadAccessor_StarOperatorConversion<sofa::type::vector<sofa::type::Vec3>>/100000        3.03 ns         2.95 ns    248888889
BM_Data_ReadAccessor_StarOperatorConversion<sofa::type::vector<sofa::type::Vec3>>/1000000       2.81 ns         2.78 ns    235789474
```



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
