### PR TITLE
[SofaGeneralImplicitOdeSolver] Propagate position inside Newton loop

### DIFF
--- a/modules/SofaGeneralImplicitOdeSolver/src/SofaGeneralImplicitOdeSolver/VariationalSymplecticSolver.cpp
+++ b/modules/SofaGeneralImplicitOdeSolver/src/SofaGeneralImplicitOdeSolver/VariationalSymplecticSolver.cpp
@@ -231,6 +231,8 @@ void VariationalSymplecticSolver::solve(const core::ExecParams* params, SReal dt
 			ops[2].second.push_back(std::make_pair(x_1.id(),1.0));
 			vop.v_multiop(ops);
 
+			mop.propagateX(x_1);
+
 			err_newton = resi.norm()/positionNorm; /// this should decrease
 			i_newton++;
 


### PR DESCRIPTION
Propagation of positions through mappings is required in Newton loop, otherwise the initial position (the one before the Newton loop) is used when computing forces.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
