### PR TITLE
[SofaCUDA] Add first version of CudaFastTetrahedralCorotationalForceField

### DIFF
--- a/applications/plugins/SofaCUDA/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/CMakeLists.txt
@@ -55,6 +55,8 @@ set(HEADER_FILES
     
 
     ### FEM
+    sofa/gpu/cuda/CudaFastTetrahedralCorotationalForceField.h
+    sofa/gpu/cuda/CudaFastTetrahedralCorotationalForceField.inl
     sofa/gpu/cuda/CudaHexahedronFEMForceField.h
     sofa/gpu/cuda/CudaHexahedronFEMForceField.inl
     sofa/gpu/cuda/CudaHexahedronTLEDForceField.h
@@ -131,6 +133,7 @@ set(SOURCE_FILES
     sofa/gpu/cuda/CudaUniformMass.cpp
 
     ### FEM
+    sofa/gpu/cuda/CudaFastTetrahedralCorotationalForceField.cpp
     sofa/gpu/cuda/CudaHexahedronFEMForceField.cpp
     sofa/gpu/cuda/CudaHexahedronTLEDForceField.cpp
     sofa/gpu/cuda/CudaStandardTetrahedralFEMForceField.cpp
@@ -193,6 +196,7 @@ set(CUDA_SOURCES
     sofa/gpu/cuda/CudaUniformMass.cu
 
     ### FEM
+    sofa/gpu/cuda/CudaFastTetrahedralCorotationalForceField.cu
     sofa/gpu/cuda/CudaHexahedronFEMForceField.cu
     sofa/gpu/cuda/CudaHexahedronTLEDForceField.cu
     sofa/gpu/cuda/CudaStandardTetrahedralFEMForceField.cu

--- a/applications/plugins/SofaCUDA/scenes/benchmarks/FastTetrahedralCorotationalForceField_beam10x10x40_cpu.scn
+++ b/applications/plugins/SofaCUDA/scenes/benchmarks/FastTetrahedralCorotationalForceField_beam10x10x40_cpu.scn
@@ -1,0 +1,56 @@
+<?xml version="1.0" ?>
+<Node name="root" gravity="0 -9 0" dt="0.01">
+    <RequiredPlugin name="SofaBoundaryCondition"/> <!-- Needed to use components [FixedConstraint] -->
+    <RequiredPlugin name="SofaEngine"/> <!-- Needed to use components [BoxROI] -->
+    <RequiredPlugin name="SofaImplicitOdeSolver"/> <!-- Needed to use components [EulerImplicitSolver] -->
+    <RequiredPlugin name="SofaOpenglVisual"/> <!-- Needed to use components [OglModel] -->
+    <RequiredPlugin name="SofaMiscFem"/> <!-- Needed to use components [FastTetrahedralCorotationalForceField] -->
+    <RequiredPlugin name="SofaTopologyMapping"/> <!-- Needed to use components [Hexa2TetraTopologicalMapping, Tetra2TriangleTopologicalMapping] -->
+  
+    <VisualStyle displayFlags="showBehaviorModels showVisual" />
+	
+    <DefaultAnimationLoop />
+    <DefaultVisualManagerLoop />
+    <DefaultPipeline name="CollisionPipeline" verbose="0" />
+    <BruteForceBroadPhase/>
+    <BVHNarrowPhase/>
+    <DefaultContactManager name="collision response" response="default" />
+    <DiscreteIntersection/>
+    
+    <Node name="Beam">
+        <RegularGridTopology name="grid" n="40 10 10" min="0 6 -2" max="16 10 2" />
+        <TetrahedronSetTopologyContainer name="BeamTopo" />
+        <TetrahedronSetTopologyModifier name="Modifier" />
+
+        <Hexa2TetraTopologicalMapping input="@grid" output="@BeamTopo" />
+    </Node>
+   
+    <Node name="FastTetrahedralCorotationalForceField-CPU-red">
+        <EulerImplicitSolver name="cg_odesolver" rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver iterations="20" name="linear solver" tolerance="1.0e-6" threshold="1.0e-6" />
+        
+        <MechanicalObject position="@../Beam/grid.position" name="Volume" template="Vec3"/>
+
+        <TetrahedronSetTopologyContainer name="Container" src="@../Beam/BeamTopo"/>
+        <TetrahedronSetTopologyModifier name="Modifier" />
+        <TetrahedronSetGeometryAlgorithms name="GeomAlgo" template="Vec3" />
+
+        <DiagonalMass totalMass="50.0" />
+        <BoxROI name="ROI1" box="-0.1 5 -3 0.1 11 3" drawBoxes="1" />
+        
+        <FixedConstraint indices="@ROI1.indices" />
+        <FastTetrahedralCorotationalForceField template="Vec3" name="FEM" method="large" poissonRatio="0.3" youngModulus="2000" />
+        
+        <Node name="surface">
+            <TriangleSetTopologyContainer name="Container" />
+            <TriangleSetTopologyModifier name="Modifier" />
+            <TriangleSetGeometryAlgorithms template="Vec3" name="GeomAlgo" />
+            
+            <Tetra2TriangleTopologicalMapping input="@../Container" output="@Container" />
+            <Node name="Visu">
+                <OglModel name="Visual" color="red" />
+                <IdentityMapping input="@../../Volume" output="@Visual" />
+            </Node>
+        </Node>
+    </Node>   
+</Node>

--- a/applications/plugins/SofaCUDA/scenes/benchmarks/FastTetrahedralCorotationalForceField_beam10x10x40_gpu.scn
+++ b/applications/plugins/SofaCUDA/scenes/benchmarks/FastTetrahedralCorotationalForceField_beam10x10x40_gpu.scn
@@ -1,0 +1,56 @@
+<?xml version="1.0" ?>
+<Node name="root" gravity="0 -9 0" dt="0.01">
+    <RequiredPlugin name="SofaBoundaryCondition"/> <!-- Needed to use components [FixedConstraint] -->
+    <RequiredPlugin name="SofaEngine"/> <!-- Needed to use components [BoxROI] -->
+    <RequiredPlugin name="SofaImplicitOdeSolver"/> <!-- Needed to use components [EulerImplicitSolver] -->
+    <RequiredPlugin name="SofaOpenglVisual"/> <!-- Needed to use components [OglModel] -->
+    <RequiredPlugin name="SofaCUDA"/>
+    <RequiredPlugin name="SofaTopologyMapping"/> <!-- Needed to use components [Hexa2TetraTopologicalMapping, Tetra2TriangleTopologicalMapping] -->
+  
+    <VisualStyle displayFlags="showBehaviorModels showVisual" />
+	
+    <DefaultAnimationLoop />
+    <DefaultVisualManagerLoop />
+    <DefaultPipeline name="CollisionPipeline" verbose="0" />
+    <BruteForceBroadPhase/>
+    <BVHNarrowPhase/>
+    <DefaultContactManager name="collision response" response="default" />
+    <DiscreteIntersection/>
+    
+    <Node name="Beam">
+        <RegularGridTopology name="grid" n="40 10 10" min="0 6 -2" max="16 10 2" />
+        <TetrahedronSetTopologyContainer name="BeamTopo" />
+        <TetrahedronSetTopologyModifier name="Modifier" />
+
+        <Hexa2TetraTopologicalMapping input="@grid" output="@BeamTopo" />
+    </Node>
+   
+    <Node name="FastTetrahedralCorotationalForceField-GPU-Green">
+        <EulerImplicitSolver name="cg_odesolver" rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver iterations="20" name="linear solver" tolerance="1.0e-6" threshold="1.0e-6" />
+        
+        <MechanicalObject position="@../Beam/grid.position" name="Volume" template="CudaVec3f"/>
+
+        <TetrahedronSetTopologyContainer name="Container" src="@../Beam/BeamTopo"/>
+        <TetrahedronSetTopologyModifier name="Modifier" />
+        <TetrahedronSetGeometryAlgorithms name="GeomAlgo" template="CudaVec3f" />
+
+        <DiagonalMass totalMass="50.0" />
+        <BoxROI name="ROI1" box="-0.1 5 -3 0.1 11 3" drawBoxes="1" />
+        
+        <FixedConstraint indices="@ROI1.indices" />
+        <FastTetrahedralCorotationalForceField template="CudaVec3f" name="FEM" method="large" poissonRatio="0.3" youngModulus="2000" />
+        
+        <Node name="surface">
+            <TriangleSetTopologyContainer name="Container" />
+            <TriangleSetTopologyModifier name="Modifier" />
+            <TriangleSetGeometryAlgorithms template="CudaVec3f" name="GeomAlgo" />
+            
+            <Tetra2TriangleTopologicalMapping input="@../Container" output="@Container" />
+            <Node name="Visu">
+                <OglModel name="Visual" color="green" />
+                <IdentityMapping input="@../../Volume" output="@Visual" />
+            </Node>
+        </Node>
+    </Node>
+</Node>

--- a/applications/plugins/SofaCUDA/scenes/benchmarks/FastTetrahedralCorotationalForceField_beam16x16x76_cpu.scn
+++ b/applications/plugins/SofaCUDA/scenes/benchmarks/FastTetrahedralCorotationalForceField_beam16x16x76_cpu.scn
@@ -1,0 +1,70 @@
+<?xml version="1.0" ?>
+<Node name="root" gravity="0 -9 0" dt="0.04">
+    <RequiredPlugin name="SofaBoundaryCondition"/> <!-- Needed to use components [FixedConstraint] -->
+    <RequiredPlugin name="SofaEngine"/> <!-- Needed to use components [BoxROI] -->
+    <RequiredPlugin name="SofaImplicitOdeSolver"/> <!-- Needed to use components [EulerImplicitSolver] -->
+    <RequiredPlugin name="SofaOpenglVisual"/> <!-- Needed to use components [OglModel] -->
+    <RequiredPlugin name="SofaMiscFem"/> <!-- Needed to use components [FastTetrahedralCorotationalForceField] -->
+    <RequiredPlugin name="SofaTopologyMapping"/> <!-- Needed to use components [Hexa2TetraTopologicalMapping, Tetra2TriangleTopologicalMapping] -->
+  
+    <VisualStyle displayFlags="showBehaviorModels showVisual" />
+	
+    <DefaultAnimationLoop />
+    <DefaultVisualManagerLoop />
+    <DefaultPipeline name="CollisionPipeline" verbose="0" />
+    <BruteForceBroadPhase/>
+    <BVHNarrowPhase/>
+    <DefaultContactManager name="collision response" response="default" />
+    <DiscreteIntersection/>
+    
+    <Node name="Beam">
+        <RegularGridTopology name="grid" n="76 16 16" min="0 6 -2" max="19 10 2" />
+        <TetrahedronSetTopologyContainer name="BeamTopo" />
+        <TetrahedronSetTopologyModifier name="Modifier" />
+
+        <Hexa2TetraTopologicalMapping input="@grid" output="@BeamTopo" />
+    </Node>
+   
+    <Node name="FastTetrahedralCorotationalForceField-CPU-red">
+        <EulerImplicitSolver name="cg_odesolver" rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver iterations="10" name="linear solver" tolerance="1.0e-6" threshold="1.0e-6" />
+        
+        <MechanicalObject position="@../Beam/grid.position" name="Volume" template="Vec3"/>
+
+        <TetrahedronSetTopologyContainer name="Container" src="@../Beam/BeamTopo"/>
+        <TetrahedronSetTopologyModifier name="Modifier" />
+        <TetrahedronSetGeometryAlgorithms name="GeomAlgo" template="Vec3" />
+
+        <DiagonalMass totalMass="50.0" />
+        <BoxROI name="ROI1" box="-0.1 5 -3 0.1 11 3" drawBoxes="1" />
+        
+        <FixedConstraint indices="@ROI1.indices" />
+        <FastTetrahedralCorotationalForceField template="Vec3" name="FEM" method="large" poissonRatio="0.3" youngModulus="1000" />
+		<PlaneForceField normal="0 1 0" d="2" stiffness="10000"  showPlane="1" />
+        
+        <Node name="surface">
+            <TriangleSetTopologyContainer name="Container" />
+            <TriangleSetTopologyModifier name="Modifier" />
+            <TriangleSetGeometryAlgorithms template="Vec3" name="GeomAlgo" />
+            
+            <Tetra2TriangleTopologicalMapping input="@../Container" output="@Container" />
+            <Node name="Visu">
+                <OglModel name="Visual" color="red" />
+                <IdentityMapping input="@../../Volume" output="@Visual" />
+            </Node>
+        </Node>
+    </Node>
+    
+    <Node name="Floor">
+		<RegularGridTopology
+			nx="4" ny="1" nz="4"
+			xmin="-10" xmax="30"
+			ymin="1.9" ymax="1.9"
+			zmin="-20" zmax="20" />
+		<MechanicalObject />
+		<Node name="Visu">
+			<OglModel name="Visual" color="white"/>
+			<IdentityMapping input="@.." output="@Visual"/>
+		</Node>
+	</Node>
+</Node>

--- a/applications/plugins/SofaCUDA/scenes/benchmarks/FastTetrahedralCorotationalForceField_beam16x16x76_gpu.scn
+++ b/applications/plugins/SofaCUDA/scenes/benchmarks/FastTetrahedralCorotationalForceField_beam16x16x76_gpu.scn
@@ -1,0 +1,69 @@
+<?xml version="1.0" ?>
+<Node name="root" gravity="0 -9 0" dt="0.04">
+    <RequiredPlugin name="SofaBoundaryCondition"/> <!-- Needed to use components [FixedConstraint] -->
+    <RequiredPlugin name="SofaEngine"/> <!-- Needed to use components [BoxROI] -->
+    <RequiredPlugin name="SofaImplicitOdeSolver"/> <!-- Needed to use components [EulerImplicitSolver] -->
+    <RequiredPlugin name="SofaOpenglVisual"/> <!-- Needed to use components [OglModel] -->
+    <RequiredPlugin name="SofaCUDA"/>
+    <RequiredPlugin name="SofaTopologyMapping"/> <!-- Needed to use components [Hexa2TetraTopologicalMapping, Tetra2TriangleTopologicalMapping] -->
+  
+    <VisualStyle displayFlags="showBehaviorModels showVisual" />
+	
+    <DefaultAnimationLoop />
+    <DefaultVisualManagerLoop />
+    <DefaultPipeline name="CollisionPipeline" verbose="0" />
+    <BruteForceBroadPhase/>
+    <BVHNarrowPhase/>
+    <DefaultContactManager name="collision response" response="default" />
+    <DiscreteIntersection/>
+    
+    <Node name="Beam">
+        <RegularGridTopology name="grid" n="76 16 16" min="0 6 -2" max="19 10 2" />
+        <TetrahedronSetTopologyContainer name="BeamTopo" />
+        <TetrahedronSetTopologyModifier name="Modifier" />
+
+        <Hexa2TetraTopologicalMapping input="@grid" output="@BeamTopo" />
+    </Node>
+   
+    <Node name="FastTetrahedralCorotationalForceField-GPU-Green">
+        <EulerImplicitSolver name="cg_odesolver" rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver iterations="20" name="linear solver" tolerance="1.0e-6" threshold="1.0e-6" />
+        
+        <MechanicalObject position="@../Beam/grid.position" name="Volume" template="CudaVec3f"/>
+
+        <TetrahedronSetTopologyContainer name="Container" src="@../Beam/BeamTopo"/>
+        <TetrahedronSetTopologyModifier name="Modifier" />
+        <TetrahedronSetGeometryAlgorithms name="GeomAlgo" template="CudaVec3f" />
+
+        <DiagonalMass totalMass="50.0" />
+        <BoxROI name="ROI1" box="-0.1 5 -3 0.1 11 3" drawBoxes="1" />
+        
+        <FixedConstraint indices="@ROI1.indices" />
+        <FastTetrahedralCorotationalForceField template="CudaVec3f" name="FEM" method="large" poissonRatio="0.3" youngModulus="2000" />
+        
+        <Node name="surface">
+            <TriangleSetTopologyContainer name="Container" />
+            <TriangleSetTopologyModifier name="Modifier" />
+            <TriangleSetGeometryAlgorithms template="CudaVec3f" name="GeomAlgo" />
+            
+            <Tetra2TriangleTopologicalMapping input="@../Container" output="@Container" />
+            <Node name="Visu">
+                <OglModel name="Visual" color="green" />
+                <IdentityMapping input="@../../Volume" output="@Visual" />
+            </Node>
+        </Node>
+    </Node>
+    
+    <Node name="Floor">
+		<RegularGridTopology name="floor_topo"
+			nx="4" ny="1" nz="4"
+			xmin="-10" xmax="30"
+			ymin="1.9" ymax="1.9"
+			zmin="-20" zmax="20" />
+		<MechanicalObject name="floor_dofs" template="CudaVec3f"/>
+		<Node name="Visu">
+			<OglModel name="Visual" color="white"/>
+			<IdentityMapping input="@.." output="@Visual"/>
+		</Node>
+	</Node>
+</Node>

--- a/applications/plugins/SofaCUDA/scenes/cpu-gpu_validation/CudaFastTetrahedralCorotationalForceField_beam10x10x40_implicit.scn
+++ b/applications/plugins/SofaCUDA/scenes/cpu-gpu_validation/CudaFastTetrahedralCorotationalForceField_beam10x10x40_implicit.scn
@@ -1,0 +1,87 @@
+<?xml version="1.0" ?>
+<Node name="root" gravity="0 -9 0" dt="0.01">
+<RequiredPlugin name="SofaBoundaryCondition"/> <!-- Needed to use components [FixedConstraint] -->
+    <RequiredPlugin name="SofaCUDA"/> <!-- Needed to use components [BoxROI, DiagonalMass, FixedConstraint, IdentityMapping, MechanicalObject, TetrahedronFEMForceField, TetrahedronSetGeometryAlgorithms, TriangleSetGeometryAlgorithms] -->
+    <RequiredPlugin name="SofaEngine"/> <!-- Needed to use components [BoxROI] -->
+    <RequiredPlugin name="SofaImplicitOdeSolver"/> <!-- Needed to use components [EulerImplicitSolver] -->
+    <RequiredPlugin name="SofaOpenglVisual"/> <!-- Needed to use components [OglModel] -->
+    <RequiredPlugin name="SofaMiscFem"/> <!-- Needed to use components [FastTetrahedralCorotationalForceField] -->
+    <RequiredPlugin name="SofaTopologyMapping"/> <!-- Needed to use components [Hexa2TetraTopologicalMapping, Tetra2TriangleTopologicalMapping] -->
+    <VisualStyle displayFlags="showBehaviorModels showVisual" />
+	
+    <DefaultAnimationLoop />
+    <DefaultVisualManagerLoop />
+    <DefaultPipeline verbose="0" />
+    <BruteForceBroadPhase/>
+    <BVHNarrowPhase/>
+    <DefaultContactManager response="default" />
+    <DiscreteIntersection/>
+    
+    <Node name="Beam">
+        <RegularGridTopology name="grid" n="40 10 10" min="0 6 -2" max="16 10 2" />
+        <TetrahedronSetTopologyContainer name="BeamTopo" />
+        <TetrahedronSetTopologyModifier name="Modifier" />
+
+        <Hexa2TetraTopologicalMapping input="@grid" output="@BeamTopo" />
+    </Node>
+    
+
+    <Node name="FastTetrahedralCorotationalForceField-GPU-Green">
+        <EulerImplicitSolver name="cg_odesolver" rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver iterations="20" name="linear solver" tolerance="1.0e-6" threshold="1.0e-6" />
+        
+        <MechanicalObject position="@../Beam/grid.position" name="Volume" template="CudaVec3f"/>
+
+        <TetrahedronSetTopologyContainer name="Container" src="@../Beam/BeamTopo"/>
+        <TetrahedronSetTopologyModifier name="Modifier" />
+        <TetrahedronSetGeometryAlgorithms name="GeomAlgo" template="CudaVec3f" />
+
+        <DiagonalMass totalMass="50.0" />
+        <BoxROI name="ROI1" box="-0.1 5 -3 0.1 11 3" drawBoxes="1" />
+        
+        <FixedConstraint indices="@ROI1.indices" />
+        <FastTetrahedralCorotationalForceField template="CudaVec3f" name="FEM" method="large" poissonRatio="0.3" youngModulus="2000" />
+        
+        <Node name="surface">
+            <TriangleSetTopologyContainer name="Container" />
+            <TriangleSetTopologyModifier name="Modifier" />
+            <TriangleSetGeometryAlgorithms template="CudaVec3f" name="GeomAlgo" />
+            
+            <Tetra2TriangleTopologicalMapping input="@../Container" output="@Container" />
+            <Node name="Visu">
+                <OglModel name="Visual" color="green" />
+                <IdentityMapping input="@../../Volume" output="@Visual" />
+            </Node>
+        </Node>
+    </Node>
+    
+   
+    <Node name="FastTetrahedralCorotationalForceField-CPU-red">
+        <EulerImplicitSolver name="cg_odesolver" rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver iterations="20" name="linear solver" tolerance="1.0e-6" threshold="1.0e-6" />
+        
+        <MechanicalObject position="@../Beam/grid.position" name="Volume" template="Vec3"/>
+
+        <TetrahedronSetTopologyContainer name="Container" src="@../Beam/BeamTopo"/>
+        <TetrahedronSetTopologyModifier name="Modifier" />
+        <TetrahedronSetGeometryAlgorithms name="GeomAlgo" template="Vec3" />
+
+        <DiagonalMass totalMass="50.0" />
+        <BoxROI name="ROI1" box="-0.1 5 -3 0.1 11 3" drawBoxes="1" />
+        
+        <FixedConstraint indices="@ROI1.indices" />
+        <FastTetrahedralCorotationalForceField template="Vec3" name="FEM" method="large" poissonRatio="0.3" youngModulus="2000" />
+        
+        <Node name="surface">
+            <TriangleSetTopologyContainer name="Container" />
+            <TriangleSetTopologyModifier name="Modifier" />
+            <TriangleSetGeometryAlgorithms template="Vec3" name="GeomAlgo" />
+            
+            <Tetra2TriangleTopologicalMapping input="@../Container" output="@Container" />
+            <Node name="Visu">
+                <OglModel name="Visual" color="red" />
+                <IdentityMapping input="@../../Volume" output="@Visual" />
+            </Node>
+        </Node>
+    </Node>   
+</Node>

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaFastTetrahedralCorotationalForceField.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaFastTetrahedralCorotationalForceField.cpp
@@ -1,0 +1,47 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/gpu/cuda/CudaTypes.h>
+#include <sofa/gpu/cuda/CudaFastTetrahedralCorotationalForceField.inl>
+#include <sofa/core/ObjectFactory.h>
+
+namespace sofa::component::forcefield
+{
+
+template class SOFA_GPU_CUDA_API FastTetrahedralCorotationalForceField<sofa::gpu::cuda::CudaVec3fTypes>;
+#ifdef SOFA_GPU_CUDA_DOUBLE
+template class SOFA_GPU_CUDA_API FastTetrahedralCorotationalForceField<sofa::gpu::cuda::CudaVec3dTypes>;
+#endif // SOFA_GPU_CUDA_DOUBLE
+
+} // sofa::component::forcefield
+
+
+namespace sofa::gpu::cuda
+{
+
+int FastTetrahedralCorotationalForceFieldCudaClass = core::RegisterObject("Supports GPU-side computations using CUDA")
+    .add< component::forcefield::FastTetrahedralCorotationalForceField<CudaVec3fTypes> >()
+#ifdef SOFA_GPU_CUDA_DOUBLE
+    .add< component::forcefield::FastTetrahedralCorotationalForceField<CudaVec3dTypes> >()
+#endif // SOFA_GPU_CUDA_DOUBLE
+    ;
+
+} // sofa::gpu::cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaFastTetrahedralCorotationalForceField.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaFastTetrahedralCorotationalForceField.cu
@@ -1,0 +1,268 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include "CudaCommon.h"
+#include "CudaMath.h"
+#include "cuda.h"
+
+
+#if defined(__cplusplus)
+namespace sofa
+{
+namespace gpu
+{
+namespace cuda
+{
+#endif
+
+struct GPUTetrahedron
+{
+    int indices[4];
+};
+
+template <typename real>
+struct GPUTetrahedronRestInformation
+{
+    CudaVec3<real> shapeVector[4];
+    real restVolume;
+    CudaVec3<real> restEdgeVector[6];
+
+    matrix3<real> linearDfDxDiag[4];  // the diagonal 3x3 block matrices that makes the 12x12 linear elastic matrix
+    matrix3<real> linearDfDx[6];  // the off-diagonal 3x3 block matrices that makes the 12x12 linear elastic matrix
+    matrix3<real> rotation; // rotation from deformed to rest configuration
+    matrix3<real> restRotation; // used for QR decomposition
+
+    real edgeOrientation[6];
+};
+
+
+//////////////////////
+// GPU-side methods //
+//////////////////////
+
+template <typename real>
+__global__ void FastTetrahedralCorotationalForceFieldCudaVec3_addForce_kernel(int size, CudaVec3<real>* f, const CudaVec3<real>* x, const CudaVec3<real>* v,
+    unsigned int nbTetrahedra, GPUTetrahedronRestInformation<real>* tetrahedronInfo, const GPUTetrahedron* gpuTetra)
+{
+    using CudaVec3 = CudaVec3<real>;
+    int index0 = (blockIdx.x*BSIZE);
+    int index = threadIdx.x;
+    int tetraId = index0+index;
+
+    GPUTetrahedron tetra = gpuTetra[tetraId];
+    GPUTetrahedronRestInformation<real>& tetraRInfo = tetrahedronInfo[tetraId];
+    
+    // compute current tetrahedron displacement
+    const unsigned int edgesInTetrahedronArray[6][2] = { {0,1}, {0,2}, {0,3}, {1,2}, {1,3}, {2,3} }; // TODO check how to store static array on device
+    CudaVec3 displ[6];
+    for (int j = 0; j < 6; ++j)
+    {
+        displ[j] = x[tetra.indices[edgesInTetrahedronArray[j][1]]] - x[tetra.indices[edgesInTetrahedronArray[j][0]]];
+    }
+
+    // Only QR_DECOMPOSITION for the moment    
+    /// perform QR decomposition
+    //computeQRRotation(rot, displ);
+    matrix3<real> frame;
+    CudaVec3 edgex = displ[0];
+    CudaVec3 edgey = displ[1];
+    CudaVec3 edgez = cross(edgex, edgey);
+    edgey = cross(edgez, edgex);
+
+    edgex *= invnorm(edgex);
+    edgey *= invnorm(edgey);
+    edgez *= invnorm(edgez);
+
+    frame = matrix3<real>::make(edgex.x, edgex.y, edgex.z, edgey.x, edgey.y, edgey.z, edgez.x, edgez.y, edgez.z);
+    matrix3<real> rot = frame.transpose(frame) * tetraRInfo.restRotation;
+
+    // store transpose of rotation
+    matrix3<real> rotT = rot.transpose(rot);
+    tetraRInfo.rotation = rotT;
+    
+    CudaVec3 force[4];
+    force[0] = CudaVec3::make(0.0, 0.0, 0.0);
+    force[1] = CudaVec3::make(0.0, 0.0, 0.0);
+    force[2] = CudaVec3::make(0.0, 0.0, 0.0);
+    force[3] = CudaVec3::make(0.0, 0.0, 0.0);
+
+    for (int j = 0; j < 6; ++j)
+    {
+        // displacement in the rest configuration
+        displ[j] = tetraRInfo.rotation * displ[j] - tetraRInfo.restEdgeVector[j];
+
+        // force on first vertex in the rest configuration
+        force[edgesInTetrahedronArray[j][1]] += tetraRInfo.linearDfDx[j] * displ[j];
+        
+        // force on second vertex in the rest configuration
+        matrix3<real> linearT = tetraRInfo.linearDfDx[j].transpose(tetraRInfo.linearDfDx[j]);
+        force[edgesInTetrahedronArray[j][0]] -= linearT * displ[j];
+    }
+
+    for (int j = 0; j < 4; ++j)
+    {
+        force[j] = rot * force[j];
+        unsigned int idV = tetra.indices[j];
+
+        atomicAdd(&(f[idV].x), force[j].x);
+        atomicAdd(&(f[idV].y), force[j].y);
+        atomicAdd(&(f[idV].z), force[j].z);
+    }
+}
+
+
+//template <typename real>
+//__global__ void FastTetrahedralCorotationalForceFieldCudaVec3_addDForce_kernel(int size, CudaVec3<real>* df, const CudaVec3<real>* dx, real kFactor,
+//    const TriangleState<real>* triState, const TriangleInfo<real>* triInfo,
+//    unsigned int nbTriangles,
+//    const GPUTriangleInfo* gpuTriangleInfo,
+//    real gamma, real mu
+//)
+//{
+//    using CudaVec3 = CudaVec3<real>;
+//    int index0 = (blockIdx.x*BSIZE);
+//    int index = threadIdx.x;
+//    int i = index0+index;
+//    
+//    GPUTriangleInfo t = gpuTriangleInfo[i];
+//    const TriangleInfo<real>& ti = triInfo[i];
+//    const TriangleState<real>& ts = triState[i];
+//
+//    CudaVec3 da  = dx[t.ia];
+//    CudaVec3 dab = dx[t.ib]-da;
+//    CudaVec3 dac = dx[t.ic]-da;
+//    real dbx = dot(ts.frame_x, dab);
+//    real dby = dot(ts.frame_y, dab);
+//    real dcx = dot(ts.frame_x, dac);
+//    real dcy = dot(ts.frame_y, dac);
+//
+//    CudaVec3 dstrain = CudaVec3::make (
+//        ti.cy  * dbx,                             // ( cy,   0,  0,  0) * (dbx, dby, dcx, dcy)
+//        ti.bx * dcy - ti.cx * dby,                // (  0, -cx,  0, bx) * (dbx, dby, dcx, dcy)
+//        ti.bx * dcx - ti.cx * dbx + ti.cy * dby); // (-cx,  cy, bx,  0) * (dbx, dby, dcx, dcy)
+//
+//    real gammaXY = (dstrain.x + dstrain.y) * gamma;
+//
+//    CudaVec3 dstress = CudaVec3::make (
+//        mu*dstrain.x + gammaXY,    // (gamma+mu, gamma   ,    0) * dstrain
+//        mu*dstrain.y + gammaXY,    // (gamma   , gamma+mu,    0) * dstrain
+//        (float)(0.5)*mu*dstrain.z); // (       0,        0, mu/2) * dstrain
+//
+//    dstress *= ti.ss_factor * kFactor;
+//    CudaVec3 dfb = ts.frame_x * (ti.cy * dstress.x - ti.cx * dstress.z)  // (cy,   0, -cx) * dstress
+//            + ts.frame_y * (ti.cy * dstress.z - ti.cx * dstress.y);   // ( 0, -cx,  cy) * dstress
+//    CudaVec3 dfc = ts.frame_x * (ti.bx * dstress.z)                      // ( 0,   0,  bx) * dstress
+//            + ts.frame_y * (ti.bx * dstress.y);                       // ( 0,  bx,   0) * dstress
+//    CudaVec3 dfa = -dfb-dfc;
+//
+//    atomicAdd(&(df[t.ia].x), -dfa.x);
+//    atomicAdd(&(df[t.ia].y), -dfa.y);
+//    atomicAdd(&(df[t.ia].z), -dfa.z);
+//
+//    atomicAdd(&(df[t.ib].x), -dfb.x);
+//    atomicAdd(&(df[t.ib].y), -dfb.y);
+//    atomicAdd(&(df[t.ib].z), -dfb.z);
+//    
+//    atomicAdd(&(df[t.ic].x), -dfc.x);
+//    atomicAdd(&(df[t.ic].y), -dfc.y);
+//    atomicAdd(&(df[t.ic].z), -dfc.z);
+//}
+
+
+//////////////////////
+// CPU-side methods //
+//////////////////////
+
+extern "C"
+{
+
+void FastTetrahedralCorotationalForceFieldCuda3f_addForce(unsigned int size, void* f, const void* x, const void* v,
+    unsigned int nbTetrahedra, void* tetrahedronInfo, const void* gpuTetra)
+{
+    dim3 threads(BSIZE, 1);
+    dim3 grid((nbTetrahedra + BSIZE - 1) / BSIZE, 1);
+    {
+    FastTetrahedralCorotationalForceFieldCudaVec3_addForce_kernel<float> <<< grid, threads >>> (size, (CudaVec3f*)f, (const CudaVec3f*)x, (const CudaVec3f*)v,
+        nbTetrahedra, (GPUTetrahedronRestInformation<float>*)tetrahedronInfo, (const GPUTetrahedron*)gpuTetra);
+    mycudaDebugError("FastTetrahedralCorotationalForceFieldCuda3f_addForce_kernel"); }
+}
+
+void FastTetrahedralCorotationalForceFieldCuda3f_addDForce(unsigned int size, void* df, const void* dx, float kFactor,
+    const void* triangleState, const void* triangleInfo,
+    unsigned int nbTriangles,
+    const void* gpuTriangleInfo,
+    float gamma, float mu) //, const void* dfdx)
+{
+    //dim3 threads(BSIZE, 1);
+    //dim3 grid((nbTriangles + BSIZE - 1) / BSIZE, 1);
+    //{FastTetrahedralCorotationalForceFieldCudaVec3_addDForce_kernel<float> <<< grid, threads >>> (size, (CudaVec3f*)df, (const CudaVec3f*)dx, kFactor,
+    //    (const TriangleState<float>*)triangleState,
+    //    (const TriangleInfo<float>*)triangleInfo,
+    //    nbTriangles,
+    //    (const GPUTriangleInfo*)gpuTriangleInfo,
+    //    gamma, mu
+    //    ); mycudaDebugError("FastTetrahedralCorotationalForceFieldCuda3f_addDForce_kernel"); }
+}
+
+
+#ifdef SOFA_GPU_CUDA_DOUBLE
+void FastTetrahedralCorotationalForceFieldCuda3d_addForce(unsigned int size, void* f, const void* x, const void* v,
+    unsigned int nbTetrahedra, void* tetrahedronInfo, const void* gpuTetra)
+{
+
+    dim3 threads(BSIZE, 1);
+    dim3 grid((nbTriangles + BSIZE - 1) / BSIZE, 1);
+    {
+
+        FastTetrahedralCorotationalForceFieldCudaVec3_addForce_kernel<double> <<< grid, threads >>> (size, (CudaVec3d*)f, (const CudaVec3d*)x, (const CudaVec3d*)v,
+            (TriangleState<double>*)triangleState,
+            (const TriangleInfo<double>*)triangleInfo,
+            nbTriangles,
+            (const GPUTriangleInfo*)gpuTriangleInfo,
+            gamma, mu
+            ); mycudaDebugError("FastTetrahedralCorotationalForceFieldCuda3f_addForce_kernel"); }
+}
+
+void FastTetrahedralCorotationalForceFieldCuda3d_addDForce(unsigned int size, void* df, const void* dx, float kFactor,
+    const void* triangleState, const void* triangleInfo,
+    unsigned int nbTriangles,
+    const void* gpuTriangleInfo,
+    double gamma, double mu) //, const void* dfdx)
+{
+    dim3 threads(BSIZE, 1);
+    dim3 grid((nbTriangles + BSIZE - 1) / BSIZE, 1);
+    {FastTetrahedralCorotationalForceFieldCudaVec3_addDForce_kernel<double> <<< grid, threads >>> (size, (CudaVec3d*)df, (const CudaVec3d*)dx, kFactor,
+        (const TriangleState<double>*)triangleState,
+        (const TriangleInfo<double>*)triangleInfo,
+        nbTriangles,
+        (const GPUTriangleInfo*)gpuTriangleInfo,
+        gamma, mu
+        ); mycudaDebugError("FastTetrahedralCorotationalForceFieldCuda3f_addDForce_kernel"); }
+}
+#endif
+
+} // extern "C"
+
+#if defined(__cplusplus)
+} // namespace cuda
+} // namespace gpu
+} // namespace sofa
+#endif

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaFastTetrahedralCorotationalForceField.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaFastTetrahedralCorotationalForceField.h
@@ -27,11 +27,12 @@
 namespace sofa::component::forcefield
 {
 
-template <>
-class FastTetrahedralCorotationalForceFieldData<gpu::cuda::CudaVec3Types>
+template <class TCoord, class TDeriv, class TReal>
+class FastTetrahedralCorotationalForceFieldData<gpu::cuda::CudaVectorTypes<TCoord, TDeriv, TReal> >
 {
 public:
-    typedef FastTetrahedralCorotationalForceField<gpu::cuda::CudaVec3Types> Main;
+    typedef gpu::cuda::CudaVectorTypes<TCoord, TDeriv, TReal> DataTypes;
+    typedef FastTetrahedralCorotationalForceField<DataTypes> Main;
     
     struct GPUTetrahedron
     {

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaFastTetrahedralCorotationalForceField.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaFastTetrahedralCorotationalForceField.h
@@ -1,0 +1,77 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/gpu/cuda/CudaTypes.h>
+#include <SofaMiscFem/FastTetrahedralCorotationalForceField.h>
+
+namespace sofa::component::forcefield
+{
+
+template <>
+class FastTetrahedralCorotationalForceFieldData<gpu::cuda::CudaVec3Types>
+{
+public:
+    typedef FastTetrahedralCorotationalForceField<gpu::cuda::CudaVec3Types> Main;
+    
+    struct GPUTetrahedron
+    {
+        int indices[4];
+    };
+
+    typedef gpu::cuda::CudaVector<GPUTetrahedron> VecGPUTetrahedron;
+
+    VecGPUTetrahedron gpuTetrahedra;
+
+    void reinit(Main* m)
+    {
+
+        const core::topology::BaseMeshTopology::SeqTetrahedra& tetrahedra = m->l_topology.get()->getTetrahedra();
+        helper::WriteAccessor< VecGPUTetrahedron > _gpuTetrahedra = this->gpuTetrahedra;
+
+        _gpuTetrahedra.resize(tetrahedra.size());
+        for (unsigned int i=0;i< tetrahedra.size();++i)
+        {
+            for (unsigned int j = 0; j < 4; ++j)
+            {
+                _gpuTetrahedra[i].indices[j] = tetrahedra[i][j];
+            }
+        }
+    }
+
+};
+
+template <>
+void FastTetrahedralCorotationalForceField<gpu::cuda::CudaVec3fTypes>::addForce(const core::MechanicalParams* mparams, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v);
+
+template <>
+void FastTetrahedralCorotationalForceField<gpu::cuda::CudaVec3fTypes>::addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx);
+
+
+#ifdef SOFA_GPU_CUDA_DOUBLE
+template <>
+void FastTetrahedralCorotationalForceField<gpu::cuda::CudaVec3dTypes>::addForce(const core::MechanicalParams* mparams, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v);
+template <>
+void FastTetrahedralCorotationalForceField<gpu::cuda::CudaVec3dTypes>::addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx);
+#endif // SOFA_GPU_CUDA_DOUBLE
+
+} // namespace sofa::component::forcefield

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaFastTetrahedralCorotationalForceField.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaFastTetrahedralCorotationalForceField.inl
@@ -1,0 +1,211 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/gpu/cuda/CudaFastTetrahedralCorotationalForceField.h>
+#include <SofaMiscFem/FastTetrahedralCorotationalForceField.inl>
+
+namespace sofa::gpu::cuda
+{
+
+
+extern "C"
+{
+void FastTetrahedralCorotationalForceFieldCuda3f_addForce(unsigned int size, void* f, const void* x, const void* v,
+    unsigned int nbTetrahedra, void* tetrahedronInfo, const void* gpuTetra);
+
+void FastTetrahedralCorotationalForceFieldCuda3f_addDForce(unsigned int size, void* f, const void* dx, float kFactor,
+    const void* triangleState, const void* triangleInfo,
+    unsigned int nbTriangles,
+    const void* gpuTriangleInfo,
+    float gamma, float mu); //, const void* dfdx);
+
+#ifdef SOFA_GPU_CUDA_DOUBLE
+void FastTetrahedralCorotationalForceFieldCuda3d_addForce(unsigned int size, void* f, const void* x, const void* v,
+    unsigned int nbTetrahedra, void* tetrahedronInfo, const void* gpuTetra);
+
+void FastTetrahedralCorotationalForceFieldCuda3d_addDForce(unsigned int size, void* f, const void* dx, double kFactor,
+    const void* triangleState, const void* triangleInfo,
+    unsigned int nbTriangles,
+    const void* gpuTriangleInfo,
+    double gamma, double mu); //, const void* dfdx);
+#endif // SOFA_GPU_CUDA_DOUBLE
+
+}
+
+} // namespace sofa::gpu::cuda
+
+namespace sofa::component::forcefield 
+{
+
+using namespace gpu::cuda;
+
+template <>
+void FastTetrahedralCorotationalForceField<gpu::cuda::CudaVec3fTypes>::addForce(const core::MechanicalParams* /*mparams*/, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v)
+{
+    VecDeriv& f = *d_f.beginEdit();
+    const VecCoord& x = d_x.getValue();
+    const VecDeriv& v = d_v.getValue();
+
+    sofa::Size nbTetrahedra = m_topology->getNbTetrahedra();
+    VecTetrahedronRestInformation& tetrahedronInf = *tetrahedronInfo.beginEdit();
+    const core::topology::BaseMeshTopology::SeqTetrahedra& tetrahedra = m_topology->getTetrahedra();
+    const ExtraData::VecGPUTetrahedron& gpuTetra = m_data.gpuTetrahedra;
+
+    f.resize(x.size());
+ 
+    FastTetrahedralCorotationalForceFieldCuda3f_addForce(x.size(), f.deviceWrite(), x.deviceRead(), v.deviceRead(),
+        nbTetrahedra, 
+        tetrahedronInf.deviceWrite(),
+        gpuTetra.deviceRead());
+
+
+    updateMatrix = true; // next time assemble the matrix
+
+    tetrahedronInfo.endEdit();
+    d_f.endEdit();
+}
+
+template <>
+void FastTetrahedralCorotationalForceField<gpu::cuda::CudaVec3fTypes>::addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx)
+{
+    VecDeriv& df = *d_df.beginEdit();
+    const VecDeriv& dx = d_dx.getValue();
+    const Real kFactor = (Real)sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue());
+
+    unsigned int j;
+    int i;
+    int nbEdges = m_topology->getNbEdges();
+
+    if (updateMatrix == true)
+    {
+        // the matrix must be stored in edges
+        helper::WriteOnlyAccessor< Data< VecTetrahedronRestInformation > > tetrahedronInf = tetrahedronInfo;
+        helper::WriteOnlyAccessor< Data< VecMat3x3 > > edgeDfDx = edgeInfo;
+
+        int nbTetrahedra = m_topology->getNbTetrahedra();
+        Mat3x3 tmp;
+
+        updateMatrix = false;
+
+        // reset all edge matrices
+        for (unsigned int j = 0; j < edgeDfDx.size(); j++)
+        {
+            edgeDfDx[j].clear();
+        }
+
+        for (i = 0; i < nbTetrahedra; i++)
+        {
+            TetrahedronRestInformation& tetinfo = tetrahedronInf[i];
+            const core::topology::BaseMeshTopology::EdgesInTetrahedron& tea = m_topology->getEdgesInTetrahedron(i);
+
+            for (j = 0; j < 6; ++j)
+            {
+                unsigned int edgeID = tea[j];
+
+                // test if the tetrahedron edge has the same orientation as the global edge
+                tmp = tetinfo.linearDfDx[j] * tetinfo.rotation;
+
+                if (tetinfo.edgeOrientation[j] == 1)
+                {
+                    // store the two edge matrices since the stiffness matrix is not symmetric
+                    edgeDfDx[edgeID] += tetinfo.rotation.transposed() * tmp;
+                }
+                else
+                {
+                    edgeDfDx[edgeID] += tmp.transposed() * tetinfo.rotation;
+                }
+            }
+        }
+    }
+
+    const VecMat3x3& edgeDfDx = edgeInfo.getValue();
+    Coord deltax;
+
+    // use the already stored matrix
+    for (i = 0; i < nbEdges; i++)
+    {
+        const core::topology::BaseMeshTopology::Edge& edge = m_topology->getEdge(i);
+
+        deltax = dx[edge[1]] - dx[edge[0]];
+        df[edge[1]] += edgeDfDx[i] * (deltax * kFactor);
+        df[edge[0]] -= edgeDfDx[i].multTranspose(deltax * kFactor);
+    }
+
+    d_df.endEdit();
+}
+
+
+#ifdef SOFA_GPU_CUDA_DOUBLE
+
+template <>
+void FastTetrahedralCorotationalForceField<gpu::cuda::CudaVec3dTypes>::addForce(const core::MechanicalParams* /*mparams*/, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v)
+{
+    VecDeriv& f = *d_f.beginEdit();
+    const VecCoord& x = d_x.getValue();
+    const VecDeriv& v = d_v.getValue();
+
+    sofa::Size nbTetrahedra = m_topology->getNbTetrahedra();
+    VecTetrahedronRestInformation& tetrahedronInf = *tetrahedronInfo.beginEdit();
+    const core::topology::BaseMeshTopology::SeqTetrahedra& tetrahedra = m_topology->getTetrahedra();
+    const ExtraData::VecGPUTetrahedron& gpuTetra = m_data.gpuTetrahedra;
+
+    f.resize(x.size());
+
+    FastTetrahedralCorotationalForceFieldCuda3d_addForce(x.size(), f.deviceWrite(), x.deviceRead(), v.deviceRead(),
+        nbTetrahedra,
+        tetrahedronInf.deviceWrite(),
+        gpuTetra.deviceRead());
+
+    tetrahedronInfo.endEdit();
+    d_f.endEdit();
+}
+
+template <>
+void FastTetrahedralCorotationalForceField<gpu::cuda::CudaVec3dTypes>::addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx)
+{
+    VecDeriv& df = *d_df.beginEdit();
+    const VecDeriv& dx = d_dx.getValue();
+    const Real kFactor = (Real)sofa::core::mechanicalparams::kFactorIncludingRayleighDamping(mparams, this->rayleighStiffness.getValue());
+
+    const VecTriangleState& triState = d_triangleState.getValue();
+    const VecTriangleInfo& triInfo = d_triangleInfo.getValue();
+    const unsigned int nbTriangles = m_topology->getNbTriangles();
+    const InternalData::VecGPUTriangleInfo& gpuTriangleInfo = data.gpuTriangleInfo;
+    const Real gamma = this->gamma;
+    const Real mu = this->mu;
+
+    df.resize(dx.size());
+
+    FastTetrahedralCorotationalForceFieldCuda3d_addDForce(dx.size(), df.deviceWrite(), dx.deviceRead(), kFactor,
+        triState.deviceRead(),
+        triInfo.deviceRead(),
+        nbTriangles,
+        gpuTriangleInfo.deviceRead(),
+        gamma, mu);
+
+    d_df.endEdit();
+}
+
+#endif // SOFA_GPU_CUDA_DOUBLE
+
+} // namespace sofa::component::forcefield

--- a/modules/SofaMiscFem/src/SofaMiscFem/FastTetrahedralCorotationalForceField.h
+++ b/modules/SofaMiscFem/src/SofaMiscFem/FastTetrahedralCorotationalForceField.h
@@ -78,7 +78,7 @@ public:
     typedef sofa::Index Index;
     
 
-protected:    
+public:
     /// data structure stored for each tetrahedron
     class TetrahedronRestInformation
     {
@@ -147,6 +147,7 @@ protected:
     /// Link to be set to the topology container in the component graph.
     SingleLink<FastTetrahedralCorotationalForceField<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
+protected:
     FastTetrahedralCorotationalForceField();
 
     virtual ~FastTetrahedralCorotationalForceField();


### PR DESCRIPTION
Add first version of the code compatible with CudaVec3f and CudaVec3d.
Performances are lower than CUDATetrahedronFEMForceField for the moment. Some profiling work will be done in future work. 

Add cpu-gpu comparison scene and benchmarks scenes on a beam.

this PR depends on changes done in FastTetrahedralCorotationalForceField suggested in PR #2569 (will need to rebase)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
