### PR TITLE
[SofaGeometry] Add geometric methods in class Triangle and Edge

### DIFF
--- a/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Edge_test.cpp
+++ b/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Edge_test.cpp
@@ -114,4 +114,119 @@ TEST(GeometryEdge_test, length3f)
     EXPECT_FLOAT_EQ(expectedResult, sofa::geometry::Edge::length((a3 * -1.f), (b3 * -1.f)));
 }
 
+
+
+TEST(GeometryEdge_test, pointBaryCoefs1f)
+{
+    const sofa::type::Vec1f a1{ 0.f };
+    const sofa::type::Vec1f b1{ 2.f };
+    
+    const sofa::type::Vec1f p1{ 1.f };
+    const auto res1 = sofa::geometry::Edge::pointBaryCoefs(p1, a1, b1);    
+    EXPECT_FLOAT_EQ(res1[0], 0.5f);
+    EXPECT_FLOAT_EQ(res1[1], 0.5f);
+
+    const sofa::type::Vec1f p2{ 0.25f };
+    const auto res2 = sofa::geometry::Edge::pointBaryCoefs(p2, a1, b1);
+    EXPECT_FLOAT_EQ(res2[0], 0.875f);
+    EXPECT_FLOAT_EQ(res2[1], 0.125f);
+
+    //special cases
+    // Edge null
+    const sofa::type::Vec1f c1{ 2.f };
+    const auto res4 = sofa::geometry::Edge::pointBaryCoefs(p2, b1, c1);
+    EXPECT_FLOAT_EQ(res4[0], 0.5f);
+    EXPECT_FLOAT_EQ(res4[1], 0.5f);
+
+    // Point on one Node
+    const auto res5 = sofa::geometry::Edge::pointBaryCoefs(b1, a1, b1);
+    EXPECT_FLOAT_EQ(res5[0], 0.0f);
+    EXPECT_FLOAT_EQ(res5[1], 1.0f);
+
+    // Point out of Edge
+    const sofa::type::Vec1f p4{ -1.0f };
+    const auto res6 = sofa::geometry::Edge::pointBaryCoefs(p4, a1, b1);
+    EXPECT_FLOAT_EQ(res6[0], 1.5f);
+    EXPECT_FLOAT_EQ(res6[1], 0.5f);
+}
+
+TEST(GeometryEdge_test, pointBaryCoefs2f)
+{
+    const sofa::type::Vec2f a1{ 0.f, 0.f };
+    const sofa::type::Vec2f b1{ 2.f, 2.f };
+
+    const sofa::type::Vec2f p1{ 1.f, 1.f };
+    const auto res1 = sofa::geometry::Edge::pointBaryCoefs(p1, a1, b1);
+    EXPECT_FLOAT_EQ(res1[0], 0.5f);
+    EXPECT_FLOAT_EQ(res1[1], 0.5f);
+
+    const sofa::type::Vec2f p2{ 0.25f, 0.25f};
+    const auto res2 = sofa::geometry::Edge::pointBaryCoefs(p2, a1, b1);
+    EXPECT_FLOAT_EQ(res2[0], 0.875f);
+    EXPECT_FLOAT_EQ(res2[1], 0.125f);
+
+    const sofa::type::Vec2f p3{ 1.0f, 0.25f };
+    const auto res3 = sofa::geometry::Edge::pointBaryCoefs(p3, a1, b1);
+    EXPECT_FLOAT_EQ(res3[0], 0.71260965);
+    EXPECT_FLOAT_EQ(res3[1], 0.36443448);
+
+    //special cases
+    // Edge null
+    const sofa::type::Vec2f c1{ 2.f, 2.f };
+    const auto res4 = sofa::geometry::Edge::pointBaryCoefs(p2, b1, c1);
+    EXPECT_FLOAT_EQ(res4[0], 0.5f);
+    EXPECT_FLOAT_EQ(res4[1], 0.5f);
+
+    // Point on one Node
+    const auto res5 = sofa::geometry::Edge::pointBaryCoefs(b1, a1, b1);
+    EXPECT_FLOAT_EQ(res5[0], 0.0f);
+    EXPECT_FLOAT_EQ(res5[1], 1.0f);
+
+    // Point out of Edge
+    const sofa::type::Vec2f p4{ -1.0f, -1.0f };
+    const auto res6 = sofa::geometry::Edge::pointBaryCoefs(p4, a1, b1);
+    EXPECT_FLOAT_EQ(res6[0], 1.5f);
+    EXPECT_FLOAT_EQ(res6[1], 0.5f);
+}
+
+
+TEST(GeometryEdge_test, pointBaryCoefs3f)
+{
+    const sofa::type::Vec3f a1{ 0.f, 0.f, 0.f };
+    const sofa::type::Vec3f b1{ 2.f, 2.f, 2.f };
+    
+    const sofa::type::Vec3f p1{ 1.f, 1.f, 1.f };
+    const auto res1 = sofa::geometry::Edge::pointBaryCoefs(p1, a1, b1);
+    EXPECT_FLOAT_EQ(res1[0], 0.5f);
+    EXPECT_FLOAT_EQ(res1[1], 0.5f);
+
+    const sofa::type::Vec3f p2{ 0.25f, 0.25f, 0.25f };
+    const auto res2 = sofa::geometry::Edge::pointBaryCoefs(p2, a1, b1);
+    EXPECT_FLOAT_EQ(res2[0], 0.875f);
+    EXPECT_FLOAT_EQ(res2[1], 0.125f);
+
+    const sofa::type::Vec3f p3{ 1.0f, 0.25f, 0.25f };
+    const auto res3 = sofa::geometry::Edge::pointBaryCoefs(p3, a1, b1);
+    EXPECT_FLOAT_EQ(res3[0], 0.77055174);
+    EXPECT_FLOAT_EQ(res3[1], 0.3061862);
+   
+    //special cases
+    // Edge null
+    const sofa::type::Vec3f c1{ 2.f, 2.f, 2.f };
+    const auto res4 = sofa::geometry::Edge::pointBaryCoefs(p2, b1, c1);
+    EXPECT_FLOAT_EQ(res4[0], 0.5f);
+    EXPECT_FLOAT_EQ(res4[1], 0.5f);
+
+    // Point on one Node
+    const auto res5 = sofa::geometry::Edge::pointBaryCoefs(b1, a1, b1);
+    EXPECT_FLOAT_EQ(res5[0], 0.0f);
+    EXPECT_FLOAT_EQ(res5[1], 1.0f);
+
+    // Point out of Edge
+    const sofa::type::Vec3f p4{ -1.0f, -1.0f, -1.0f };
+    const auto res6 = sofa::geometry::Edge::pointBaryCoefs(p4, a1, b1);
+    EXPECT_FLOAT_EQ(res6[0], 1.5f);
+    EXPECT_FLOAT_EQ(res6[1], 0.5f);
+}
+
 }// namespace sofa

--- a/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Edge_test.cpp
+++ b/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Edge_test.cpp
@@ -229,4 +229,52 @@ TEST(GeometryEdge_test, pointBaryCoefs3f)
     EXPECT_FLOAT_EQ(res6[1], 0.5f);
 }
 
+
+TEST(GeometryEdge_test, intersectionWithPlane3f)
+{
+    const sofa::type::Vec3f a1{ 0.f, 0.f, 0.f };
+    const sofa::type::Vec3f b1{ 2.f, 2.f, 2.f };
+
+    const sofa::type::Vec3f planP{ 0.f, 1.f, 0.f };
+    const sofa::type::Vec3f planN1{ 0.f, 1.f, 0.f };
+    sofa::type::Vec3f inter{ 0.f, 0.f, 0.f };
+
+    // basic cases
+    bool res = sofa::geometry::Edge::intersectionWithPlane(a1, b1, planP, planN1, inter);
+    EXPECT_EQ(res, true);
+    EXPECT_FLOAT_EQ(inter[0], 1.0f);
+    EXPECT_FLOAT_EQ(inter[1], 1.0f);
+    EXPECT_FLOAT_EQ(inter[2], 1.0f);
+
+    const sofa::type::Vec3f planN2{ 1.f, 2.f, 1.f };
+    bool res2 = sofa::geometry::Edge::intersectionWithPlane(a1, b1, planP, planN2, inter);
+    EXPECT_EQ(res2, true);
+    EXPECT_FLOAT_EQ(inter[0], 0.5f);
+    EXPECT_FLOAT_EQ(inter[1], 0.5f);
+    EXPECT_FLOAT_EQ(inter[2], 0.5f);
+
+    // border case: plan - Edge intersection on Edge node
+    const sofa::type::Vec3f planN3{ 1.f, 0.f, 0.f };
+    bool res3 = sofa::geometry::Edge::intersectionWithPlane(a1, b1, planP, planN3, inter);
+    EXPECT_EQ(res3, true);
+    EXPECT_FLOAT_EQ(inter[0], 0.0f);
+    EXPECT_FLOAT_EQ(inter[1], 0.0f);
+    EXPECT_FLOAT_EQ(inter[2], 0.0f);
+
+    // negative case: plan - Edge has no intersection
+    const sofa::type::Vec3f planN4{ -1.f, 2.f, -1.f };
+    bool res4 = sofa::geometry::Edge::intersectionWithPlane(a1, b1, planP, planN4, inter);
+    EXPECT_EQ(res4, false);
+    EXPECT_FLOAT_EQ(inter[0], 0.0f);
+    EXPECT_FLOAT_EQ(inter[1], 0.0f);
+    EXPECT_FLOAT_EQ(inter[2], 0.0f);
+
+    // failing case: Edge length == 0
+    bool res5 = sofa::geometry::Edge::intersectionWithPlane(a1, a1, planP, planN1, inter);
+    EXPECT_EQ(res5, false);
+    EXPECT_FLOAT_EQ(inter[0], 0.0f);
+    EXPECT_FLOAT_EQ(inter[1], 0.0f);
+    EXPECT_FLOAT_EQ(inter[2], 0.0f);
+}
+
 }// namespace sofa

--- a/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Edge_test.cpp
+++ b/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Edge_test.cpp
@@ -235,42 +235,42 @@ TEST(GeometryEdge_test, intersectionWithPlane3f)
     const sofa::type::Vec3f a1{ 0.f, 0.f, 0.f };
     const sofa::type::Vec3f b1{ 2.f, 2.f, 2.f };
 
-    const sofa::type::Vec3f planP{ 0.f, 1.f, 0.f };
-    const sofa::type::Vec3f planN1{ 0.f, 1.f, 0.f };
+    const sofa::type::Vec3f planeP{ 0.f, 1.f, 0.f };
+    const sofa::type::Vec3f planeN1{ 0.f, 1.f, 0.f };
     sofa::type::Vec3f inter{ 0.f, 0.f, 0.f };
 
     // basic cases
-    bool res = sofa::geometry::Edge::intersectionWithPlane(a1, b1, planP, planN1, inter);
+    bool res = sofa::geometry::Edge::intersectionWithPlane(a1, b1, planeP, planeN1, inter);
     EXPECT_EQ(res, true);
     EXPECT_FLOAT_EQ(inter[0], 1.0f);
     EXPECT_FLOAT_EQ(inter[1], 1.0f);
     EXPECT_FLOAT_EQ(inter[2], 1.0f);
 
-    const sofa::type::Vec3f planN2{ 1.f, 2.f, 1.f };
-    bool res2 = sofa::geometry::Edge::intersectionWithPlane(a1, b1, planP, planN2, inter);
+    const sofa::type::Vec3f planeN2{ 1.f, 2.f, 1.f };
+    bool res2 = sofa::geometry::Edge::intersectionWithPlane(a1, b1, planeP, planeN2, inter);
     EXPECT_EQ(res2, true);
     EXPECT_FLOAT_EQ(inter[0], 0.5f);
     EXPECT_FLOAT_EQ(inter[1], 0.5f);
     EXPECT_FLOAT_EQ(inter[2], 0.5f);
 
     // border case: plan - Edge intersection on Edge node
-    const sofa::type::Vec3f planN3{ 1.f, 0.f, 0.f };
-    bool res3 = sofa::geometry::Edge::intersectionWithPlane(a1, b1, planP, planN3, inter);
+    const sofa::type::Vec3f planeN3{ 1.f, 0.f, 0.f };
+    bool res3 = sofa::geometry::Edge::intersectionWithPlane(a1, b1, planeP, planeN3, inter);
     EXPECT_EQ(res3, true);
     EXPECT_FLOAT_EQ(inter[0], 0.0f);
     EXPECT_FLOAT_EQ(inter[1], 0.0f);
     EXPECT_FLOAT_EQ(inter[2], 0.0f);
 
     // negative case: plan - Edge has no intersection
-    const sofa::type::Vec3f planN4{ -1.f, 2.f, -1.f };
-    bool res4 = sofa::geometry::Edge::intersectionWithPlane(a1, b1, planP, planN4, inter);
+    const sofa::type::Vec3f planeN4{ -1.f, 2.f, -1.f };
+    bool res4 = sofa::geometry::Edge::intersectionWithPlane(a1, b1, planeP, planeN4, inter);
     EXPECT_EQ(res4, false);
     EXPECT_FLOAT_EQ(inter[0], 0.0f);
     EXPECT_FLOAT_EQ(inter[1], 0.0f);
     EXPECT_FLOAT_EQ(inter[2], 0.0f);
 
     // failing case: Edge length == 0
-    bool res5 = sofa::geometry::Edge::intersectionWithPlane(a1, a1, planP, planN1, inter);
+    bool res5 = sofa::geometry::Edge::intersectionWithPlane(a1, a1, planeP, planeN1, inter);
     EXPECT_EQ(res5, false);
     EXPECT_FLOAT_EQ(inter[0], 0.0f);
     EXPECT_FLOAT_EQ(inter[1], 0.0f);

--- a/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Triangle_test.cpp
+++ b/SofaKernel/modules/Sofa.Geometry/Sofa.Geometry_test/Triangle_test.cpp
@@ -92,4 +92,28 @@ TYPED_TEST(Geometry3DTriangle_test, flat_area)
 }
 
 
+TEST(GeometryTriangle_test, normal3f)
+{
+    // normal case
+    const sofa::type::Vec3f a{ 0.f, 0.f, 0.f };
+    const sofa::type::Vec3f b{ 0.f, 2.f, 0.f };
+    const sofa::type::Vec3f c{ 0.f, 0.f, 2.f };
+
+    auto normal = sofa::geometry::Triangle::normal(a, b, c);
+    EXPECT_FLOAT_EQ(normal[0], 4.f);
+    EXPECT_FLOAT_EQ(normal[1], 0.f);
+    EXPECT_FLOAT_EQ(normal[2], 0.f);
+
+    // flat triangle case
+    const sofa::type::Vec3f a2{ 0.f, 0.f, 0.f };
+    const sofa::type::Vec3f b2{ 0.f, 2.f, 0.f };
+    const sofa::type::Vec3f c2{ 0.f, 1.f, 0.f };
+    
+    normal = sofa::geometry::Triangle::normal(a2, b2, c2);
+    EXPECT_FLOAT_EQ(normal[0], 0.f);
+    EXPECT_FLOAT_EQ(normal[1], 0.f);
+    EXPECT_FLOAT_EQ(normal[2], 0.f);
+}
+
+
 }// namespace sofa

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
@@ -122,12 +122,12 @@ struct Edge
 
 
     /**
-    * @brief	Compute the intersection between a plan (defined by a point and a normal) and the Edge (n0, n1)
+    * @brief	Compute the intersection between a plane (defined by a point and a normal) and the Edge (n0, n1)
     * @tparam   Node iterable container
     * @tparam   T scalar
     * @param	n0,n1 nodes of the edge
-    * @param	planP0,normal position and normal defining the plan
-    * @param    intersection position of the intersection (if one) between the plan and the Edge
+    * @param	planeP0,normal position and normal defining the plan
+    * @param    intersection position of the intersection (if one) between the plane and the Edge
     * @return	bool true if there is an intersection, otherwise false
     */
     template<typename Node,
@@ -135,23 +135,23 @@ struct Edge
         typename = std::enable_if_t<std::is_scalar_v<T>>
     >
     [[nodiscard]]
-    static constexpr bool intersectionWithPlane(const Node& n0, const Node& n1, const sofa::type::Vec<3, T>& planP0, const sofa::type::Vec<3, T>& normal, sofa::type::Vec<3, T>& intersection)
+    static constexpr bool intersectionWithPlane(const Node& n0, const Node& n1, const sofa::type::Vec<3, T>& planeP0, const sofa::type::Vec<3, T>& normal, sofa::type::Vec<3, T>& intersection)
     {
         constexpr Node n{}; 
-        static_assert(std::distance(std::begin(n), std::end(n)) == 3, "Plan - Edge intersection can only be computed in 3 dimensions.");
+        static_assert(std::distance(std::begin(n), std::end(n)) == 3, "Plane - Edge intersection can only be computed in 3 dimensions.");
 
         //plane equation
-        const sofa::type::Vec<3, T> planNorm = normal.normalized();
-        const T d = planNorm * planP0;
+        const sofa::type::Vec<3, T> planeNorm = normal.normalized();
+        const T d = planeNorm * planeP0;
 
         //compute intersection between line and plane equation
-        const T denominator = planNorm * (n1 - n0);
+        const T denominator = planeNorm * (n1 - n0);
         if (denominator < EQUALITY_THRESHOLD)
         {
             return false;
         }
 
-        const T t = (d - planNorm * n0) / denominator;
+        const T t = (d - planeNorm * n0) / denominator;
         if ((t <= 1) && (t >= 0))
         {
             intersection = n0 + (n1 - n0) * t;

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
@@ -137,6 +137,9 @@ struct Edge
     [[nodiscard]]
     static constexpr bool intersectionWithPlane(const Node& n0, const Node& n1, const sofa::type::Vec<3, T>& planP0, const sofa::type::Vec<3, T>& normal, sofa::type::Vec<3, T>& intersection)
     {
+        constexpr Node n{}; 
+        static_assert(std::distance(std::begin(n), std::end(n)) == 3, "Plan - Edge intersection can only be computed in 3 dimensions.");
+
         //plane equation
         const sofa::type::Vec<3, T> planNorm = normal.normalized();
         const T d = planNorm * planP0;
@@ -151,7 +154,7 @@ struct Edge
         const T t = (d - planNorm * n0) / denominator;
         if ((t <= 1) && (t >= 0))
         {
-            intersection = edgeP1 + (edgeP2 - edgeP1) * t;
+            intersection = n0 + (n1 - n0) * t;
             return true;
         }
         return false;

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
@@ -87,6 +87,54 @@ struct Edge
     {
         return std::sqrt(squaredLength(n0, n1));
     }
+
+
+
+    template<typename Node,
+        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
+        typename = std::enable_if_t<std::is_scalar_v<T>>
+    >
+        static constexpr auto pointBaryCoefs(const sofa::type::Vec<3, T>& point, const Node& n0, const Node& n1)
+    {
+        sofa::type::Vec<2, T> baryCoefs;
+        T dis = (n1 - n0).norm();
+
+        if (dis < 1e-6) // TODO: change this threshold to limit
+        {
+            baryCoefs[0] = 0.5;
+            baryCoefs[1] = 0.5;
+        }
+        else
+        {
+            baryCoefs[0] = (point - n1).norm() / dis;
+            baryCoefs[1] = (point - n0).norm() / dis;
+        }
+
+        return baryCoefs;
+    }
+
+
+    template<typename Node,
+        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
+        typename = std::enable_if_t<std::is_scalar_v<T>>
+    >
+        static constexpr bool intersectionWithPlane(const Node& n0, const Node& n1, const sofa::type::Vec<3, T>& planP0, const sofa::type::Vec<3, T>& normal, sofa::type::Vec<3, T>& intersection)
+    {
+        //plane equation
+        sofa::type::Vec<3, T> planNorm = normal.normalized();
+        T d = planNorm * planP0;
+
+        //compute intersection between line and plane equation
+        T t = (d - planNorm * n0) / (planNorm * (n1 - n0));
+
+        if ((t <= 1) && (t >= 0))
+        {
+            intersection = edgeP1 + (edgeP2 - edgeP1) * t;
+            return true;
+        }
+        else
+            return false;
+    }
 };
 
 } // namespace sofa::geometry

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
@@ -97,7 +97,7 @@ struct Edge
         static constexpr auto pointBaryCoefs(const sofa::type::Vec<3, T>& point, const Node& n0, const Node& n1)
     {
         sofa::type::Vec<2, T> baryCoefs;
-        T dis = (n1 - n0).norm();
+        const T dis = (n1 - n0).norm();
 
         if (dis < 1e-6) // TODO: change this threshold to limit
         {

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Edge.h
@@ -121,8 +121,8 @@ struct Edge
         static constexpr bool intersectionWithPlane(const Node& n0, const Node& n1, const sofa::type::Vec<3, T>& planP0, const sofa::type::Vec<3, T>& normal, sofa::type::Vec<3, T>& intersection)
     {
         //plane equation
-        sofa::type::Vec<3, T> planNorm = normal.normalized();
-        T d = planNorm * planP0;
+        const sofa::type::Vec<3, T> planNorm = normal.normalized();
+        const T d = planNorm * planP0;
 
         //compute intersection between line and plane equation
         T t = (d - planNorm * n0) / (planNorm * (n1 - n0));
@@ -132,8 +132,7 @@ struct Edge
             intersection = edgeP1 + (edgeP2 - edgeP1) * t;
             return true;
         }
-        else
-            return false;
+        return false;
     }
 };
 

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
@@ -70,6 +70,26 @@ struct Triangle
             return static_cast<T>(0.25) * std::sqrt((a + b + c) * (-a + b + c) * (a - b + c) * (a + b - c));
         }
     }
+
+
+    template<typename Node,
+        typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
+        typename = std::enable_if_t<std::is_scalar_v<T>>
+    >
+        [[nodiscard]]
+    static constexpr auto normal(const Node& n0, const Node& n1, const Node& n2)
+    {
+        if constexpr (std::is_same_v < Node, sofa::type::Vec<3, T> >)
+        {
+            sofa::type::Vec<3, T> normal_t = (n1 - n0).cross(n2 - n0);
+            return normal_t;
+        }
+        else /*if constexpr (std::is_same_v< Node, sofa::type::Vec<2, T> >)*/
+        {
+            // shoelace formula
+            return sofa::type::Vec<3, T>();
+        }
+    }
 };
 
 } // namespace sofa::geometry

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
@@ -74,7 +74,7 @@ struct Triangle
     /**
     * @brief	Compute the normal of a triangle
     * @remark   triangle normal computation is only possible in 3D
-    * @remark   normal returned is not normalised
+    * @remark   normal returned is not normalized
     * @tparam   Node iterable container (or sofa::type::Vec with cross() and norm())
     * @tparam   T scalar
     * @param	n0,n1,n2 nodes of the triangle

--- a/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
+++ b/SofaKernel/modules/Sofa.Geometry/src/sofa/geometry/Triangle.h
@@ -71,24 +71,26 @@ struct Triangle
         }
     }
 
-
+    /**
+    * @brief	Compute the normal of a triangle
+    * @remark   triangle normal computation is only possible in 3D
+    * @remark   normal returned is not normalised
+    * @tparam   Node iterable container (or sofa::type::Vec with cross() and norm())
+    * @tparam   T scalar
+    * @param	n0,n1,n2 nodes of the triangle
+    * @return	Vec3 normal of this triangle
+    */
     template<typename Node,
         typename T = std::decay_t<decltype(*std::begin(std::declval<Node>()))>,
         typename = std::enable_if_t<std::is_scalar_v<T>>
     >
-        [[nodiscard]]
+    [[nodiscard]]
     static constexpr auto normal(const Node& n0, const Node& n1, const Node& n2)
     {
-        if constexpr (std::is_same_v < Node, sofa::type::Vec<3, T> >)
-        {
-            sofa::type::Vec<3, T> normal_t = (n1 - n0).cross(n2 - n0);
-            return normal_t;
-        }
-        else /*if constexpr (std::is_same_v< Node, sofa::type::Vec<2, T> >)*/
-        {
-            // shoelace formula
-            return sofa::type::Vec<3, T>();
-        }
+        constexpr Node n{};
+        static_assert(std::distance(std::begin(n), std::end(n)) == 3, "Triangle normal can only be computed in 3 dimensions.");
+
+        return (n1 - n0).cross(n2 - n0);
     }
 };
 


### PR DESCRIPTION
New methods:
- Edge: method ```pointBaryCoefs``` which, given a point, will return the 2 barycoefs of the edge describing the relative position.
- Edge: method ```intersectionWithPlane```, given and edge and a plan position + normal, return if there is an intersection and at which point.
- Triangle: method ```normal```  to compute the normal of the triangle.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
