### PR TITLE
[Sofa.Helper] Introduce narrow_cast

### DIFF
--- a/SofaKernel/modules/SofaHelper/CMakeLists.txt
+++ b/SofaKernel/modules/SofaHelper/CMakeLists.txt
@@ -31,6 +31,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/MatEigen.h
     ${SRC_ROOT}/MemoryManager.h
     ${SRC_ROOT}/NameDecoder.h
+    ${SRC_ROOT}/narrow_cast.h
     ${SRC_ROOT}/OptionsGroup.h
     ${SRC_ROOT}/OwnershipSPtr.h
     ${SRC_ROOT}/Polynomial_LD.h

--- a/SofaKernel/modules/SofaHelper/SofaHelper_test/CMakeLists.txt
+++ b/SofaKernel/modules/SofaHelper/SofaHelper_test/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCE_FILES
     Factory_test.cpp
     KdTree_test.cpp
     NameDecoder_test.cpp
+    narrow_cast_test.cpp
     Utils_test.cpp
     io/MeshOBJ_test.cpp
     io/XspLoader_test.cpp

--- a/SofaKernel/modules/SofaHelper/SofaHelper_test/narrow_cast_test.cpp
+++ b/SofaKernel/modules/SofaHelper/SofaHelper_test/narrow_cast_test.cpp
@@ -58,57 +58,45 @@ namespace sofa
         //size_t -> int: out of range
         {
             constexpr size_t a = static_cast<size_t>(std::numeric_limits<int>::max()) + 1;
-            if constexpr (sofa::helper::forceNarrowCastChecking)
-            {
-                EXPECT_THROW(sofa::helper::narrow_cast<int>(a), sofa::helper::narrowing_error);
-            }
-            else
-            {
-                constexpr int b = std::numeric_limits<int>::min(); // overflow
-                EXPECT_EQ(sofa::helper::narrow_cast<int>(a), b);
-            }
+#if !defined(NDEBUG)
+            EXPECT_THROW(sofa::helper::narrow_cast<int>(a), sofa::helper::narrowing_error);
+#else
+            constexpr int b = std::numeric_limits<int>::min(); // overflow
+            EXPECT_EQ(sofa::helper::narrow_cast<int>(a), b);
+#endif
         }
 
         //unsigned int -> int : out of range
         {
             constexpr unsigned int a = static_cast<unsigned int>(std::numeric_limits<int>::max()) + 1;
-            if constexpr (sofa::helper::forceNarrowCastChecking)
-            {
-                EXPECT_THROW(sofa::helper::narrow_cast<int>(a), sofa::helper::narrowing_error);
-            }
-            else
-            {
-                constexpr int b = std::numeric_limits<int>::min(); // overflow
-                EXPECT_EQ(sofa::helper::narrow_cast<int>(a), b);
-            }
+#if !defined(NDEBUG)
+            EXPECT_THROW(sofa::helper::narrow_cast<int>(a), sofa::helper::narrowing_error);
+#else
+            constexpr int b = std::numeric_limits<int>::min(); // overflow
+            EXPECT_EQ(sofa::helper::narrow_cast<int>(a), b);
+#endif
         }
 
         //int -> unsigned int : negative value
         {
             constexpr int a = -1;
-            if constexpr (sofa::helper::forceNarrowCastChecking)
-            {
-                EXPECT_THROW(sofa::helper::narrow_cast<unsigned int>(a), sofa::helper::narrowing_error);
-            }
-            else
-            {
-                constexpr int b = std::numeric_limits<unsigned int>::max();
-                EXPECT_EQ(sofa::helper::narrow_cast<unsigned int>(a), b);
-            }
+#if !defined(NDEBUG)
+            EXPECT_THROW(sofa::helper::narrow_cast<unsigned int>(a), sofa::helper::narrowing_error);
+#else
+            constexpr int b = std::numeric_limits<unsigned int>::max();
+            EXPECT_EQ(sofa::helper::narrow_cast<unsigned int>(a), b);
+#endif
         }
 
         //int -> short: out of range
         {
             constexpr int a = static_cast<size_t>(std::numeric_limits<short>::max()) + 1;
-            if constexpr (sofa::helper::forceNarrowCastChecking)
-            {
-                EXPECT_THROW(sofa::helper::narrow_cast<short>(a), sofa::helper::narrowing_error);
-            }
-            else
-            {
-                constexpr int b = std::numeric_limits<short>::min(); // overflow
-                EXPECT_EQ(sofa::helper::narrow_cast<short>(a), b);
-            }
+#if !defined(NDEBUG)
+            EXPECT_THROW(sofa::helper::narrow_cast<short>(a), sofa::helper::narrowing_error);
+#else
+            constexpr int b = std::numeric_limits<short>::min(); // overflow
+            EXPECT_EQ(sofa::helper::narrow_cast<short>(a), b);
+#endif
         }
     }
 }

--- a/SofaKernel/modules/SofaHelper/SofaHelper_test/narrow_cast_test.cpp
+++ b/SofaKernel/modules/SofaHelper/SofaHelper_test/narrow_cast_test.cpp
@@ -55,6 +55,7 @@ namespace sofa
     // Situations where narrow conversion changes the input value
     TEST(narrow_cast_test, out_of_range)
     {
+        //size_t -> int: out of range
         {
             constexpr size_t a = static_cast<size_t>(std::numeric_limits<int>::max()) + 1;
             if constexpr (sofa::helper::forceNarrowCastChecking)
@@ -63,8 +64,50 @@ namespace sofa
             }
             else
             {
-                const int b = std::numeric_limits<int>::min(); // overflow
+                constexpr int b = std::numeric_limits<int>::min(); // overflow
                 EXPECT_EQ(sofa::helper::narrow_cast<int>(a), b);
+            }
+        }
+
+        //unsigned int -> int : out of range
+        {
+            constexpr unsigned int a = static_cast<unsigned int>(std::numeric_limits<int>::max()) + 1;
+            if constexpr (sofa::helper::forceNarrowCastChecking)
+            {
+                EXPECT_THROW(sofa::helper::narrow_cast<int>(a), sofa::helper::narrowing_error);
+            }
+            else
+            {
+                constexpr int b = std::numeric_limits<int>::min(); // overflow
+                EXPECT_EQ(sofa::helper::narrow_cast<int>(a), b);
+            }
+        }
+
+        //int -> unsigned int : negative value
+        {
+            constexpr int a = -1;
+            if constexpr (sofa::helper::forceNarrowCastChecking)
+            {
+                EXPECT_THROW(sofa::helper::narrow_cast<unsigned int>(a), sofa::helper::narrowing_error);
+            }
+            else
+            {
+                constexpr int b = std::numeric_limits<unsigned int>::max();
+                EXPECT_EQ(sofa::helper::narrow_cast<unsigned int>(a), b);
+            }
+        }
+
+        //int -> short: out of range
+        {
+            constexpr int a = static_cast<size_t>(std::numeric_limits<short>::max()) + 1;
+            if constexpr (sofa::helper::forceNarrowCastChecking)
+            {
+                EXPECT_THROW(sofa::helper::narrow_cast<short>(a), sofa::helper::narrowing_error);
+            }
+            else
+            {
+                constexpr int b = std::numeric_limits<short>::min(); // overflow
+                EXPECT_EQ(sofa::helper::narrow_cast<short>(a), b);
             }
         }
     }

--- a/SofaKernel/modules/SofaHelper/SofaHelper_test/narrow_cast_test.cpp
+++ b/SofaKernel/modules/SofaHelper/SofaHelper_test/narrow_cast_test.cpp
@@ -1,0 +1,71 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <sofa/helper/narrow_cast.h>
+#include <gtest/gtest.h>
+
+namespace sofa
+{
+    TEST(narrow_cast_test, in_range)
+    {
+        {
+            size_t a = 0;
+            int b = 0;
+            EXPECT_EQ(sofa::helper::narrow_cast<int>(a), b);
+        }
+
+        {
+            const size_t a = 0;
+            int b = 0;
+            EXPECT_EQ(sofa::helper::narrow_cast<int>(a), b);
+        }
+
+        {
+            const size_t a = 0;
+            const int b = 0;
+            EXPECT_EQ(sofa::helper::narrow_cast<int>(a), b);
+        }
+
+        {
+            constexpr size_t a = std::numeric_limits<int>::max();
+            constexpr int b = std::numeric_limits<int>::max();
+            EXPECT_EQ(sofa::helper::narrow_cast<int>(a), b);
+        }
+
+    }
+
+    // Situations where narrow conversion changes the input value
+    TEST(narrow_cast_test, out_of_range)
+    {
+        {
+            constexpr size_t a = static_cast<size_t>(std::numeric_limits<int>::max()) + 1;
+            if constexpr (sofa::helper::forceNarrowCastChecking)
+            {
+                EXPECT_THROW(sofa::helper::narrow_cast<int>(a), sofa::helper::narrowing_error);
+            }
+            else
+            {
+                const int b = std::numeric_limits<int>::min(); // overflow
+                EXPECT_EQ(sofa::helper::narrow_cast<int>(a), b);
+            }
+        }
+    }
+}

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/io/MeshGmsh.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/io/MeshGmsh.cpp
@@ -28,6 +28,7 @@
 #include <istream>
 #include <fstream>
 #include <string>
+#include <sofa/helper/narrow_cast.h>
 
 namespace sofa
 {
@@ -284,7 +285,7 @@ bool MeshGmsh::readGmsh(std::ifstream &file, const unsigned int gmshFormat)
                 {
                     HighOrderEdgePosition hoep;
                     hoep[0] = nodes[2];
-                    hoep[1] = m_edges.size() - 1;
+                    hoep[1] = sofa::helper::narrow_cast<PointID>(m_edges.size() - 1);
                     hoep[2] = 1;
                     hoep[3] = 1;
                     m_highOrderEdgePositions.push_back(hoep);
@@ -306,7 +307,7 @@ bool MeshGmsh::readGmsh(std::ifstream &file, const unsigned int gmshFormat)
                             edgeSet.insert(e);
                             m_edges.push_back(Edge(v0, v1));
                             hoep[0] = nodes[j + 3];
-                            hoep[1] = m_edges.size() - 1;
+                            hoep[1] = sofa::helper::narrow_cast<PointID>(m_edges.size() - 1);
                             hoep[2] = 1;
                             hoep[3] = 1;
                             m_highOrderEdgePositions.push_back(hoep);
@@ -330,7 +331,7 @@ bool MeshGmsh::readGmsh(std::ifstream &file, const unsigned int gmshFormat)
                             edgeSet.insert(e);
                             m_edges.push_back(Edge(v0, v1));
                             hoep[0] = nodes[j + 4];
-                            hoep[1] = m_edges.size() - 1;
+                            hoep[1] = sofa::helper::narrow_cast<PointID>(m_edges.size() - 1);
                             hoep[2] = 1;
                             hoep[3] = 1;
                             m_highOrderEdgePositions.push_back(hoep);
@@ -505,7 +506,7 @@ bool MeshGmsh::readGmsh(std::ifstream &file, const unsigned int gmshFormat)
                     {
                         HighOrderEdgePosition hoep;
                         hoep[0] = nodes[2];
-                        hoep[1] = m_edges.size() - 1;
+                        hoep[1] = sofa::helper::narrow_cast<PointID>(m_edges.size() - 1);
                         hoep[2] = 1;
                         hoep[3] = 1;
                         m_highOrderEdgePositions.push_back(hoep);
@@ -529,7 +530,7 @@ bool MeshGmsh::readGmsh(std::ifstream &file, const unsigned int gmshFormat)
                                 edgeSet.insert(e);
                                 m_edges.push_back(Edge(v0, v1));
                                 hoep[0] = nodes[j + 3];
-                                hoep[1] = m_edges.size() - 1;
+                                hoep[1] = sofa::helper::narrow_cast<PointID>(m_edges.size() - 1);
                                 hoep[2] = 1;
                                 hoep[3] = 1;
                                 m_highOrderEdgePositions.push_back(hoep);
@@ -555,7 +556,7 @@ bool MeshGmsh::readGmsh(std::ifstream &file, const unsigned int gmshFormat)
                                 edgeSet.insert(e);
                                 m_edges.push_back(Edge(v0, v1));
                                 hoep[0] = nodes[j + 4];
-                                hoep[1] = m_edges.size() - 1;
+                                hoep[1] = sofa::helper::narrow_cast<PointID>(m_edges.size() - 1);
                                 hoep[2] = 1;
                                 hoep[3] = 1;
                                 m_highOrderEdgePositions.push_back(hoep);

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/narrow_cast.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/narrow_cast.h
@@ -26,7 +26,12 @@
 namespace sofa::helper
 {
     /// If true, narrow_cast will check if the value changed after the narrow conversion. Otherwise, no check is performed
-    constexpr bool forceNarrowCastChecking = NDEBUG;
+#if defined(NDEBUG)
+    constexpr bool forceNarrowCastChecking = false;
+#else
+    constexpr bool forceNarrowCastChecking = true;
+#endif
+
 
     /**
      * \brief Explicit narrow conversion
@@ -57,14 +62,16 @@ namespace sofa::helper
     {
         const T t = narrow_cast_nocheck<T>(u);
 
-        if (static_cast<U>(t) != u)
+        using U_decay = std::decay_t<U>;
+
+        if (static_cast<U_decay>(t) != u)
         {
             throw narrowing_error{};
         }
 
-        if constexpr (std::is_arithmetic_v<T> && std::is_signed_v<T> != std::is_signed_v<U>)
+        if constexpr (std::is_arithmetic_v<T> && std::is_signed_v<T> != std::is_signed_v<U_decay>)
         {
-            if ((t < T{}) != (u < U{}))
+            if ((t < T{}) != (u < U_decay{}))
             {
                 throw narrowing_error{};
             }

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/narrow_cast.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/narrow_cast.h
@@ -62,11 +62,9 @@ namespace sofa::helper
             throw narrowing_error{};
         }
 
-        if constexpr (std::is_arithmetic_v<T>)
+        if constexpr (std::is_arithmetic_v<T> && std::is_signed_v<T> != std::is_signed_v<U>)
         {
-            constexpr bool is_different_signedness = std::is_signed_v<T> != std::is_signed_v<U>;
-
-            if (is_different_signedness && (t < T{}) != (u < U{}))
+            if ((t < T{}) != (u < U{}))
             {
                 throw narrowing_error{};
             }

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/narrow_cast.h
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/narrow_cast.h
@@ -1,0 +1,100 @@
+﻿/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <exception>
+#include <utility>
+
+namespace sofa::helper
+{
+    /// If true, narrow_cast will check if the value changed after the narrow conversion. Otherwise, no check is performed
+    constexpr bool forceNarrowCastChecking = NDEBUG;
+
+    /**
+     * \brief Explicit narrow conversion
+     * Inspired by the Guidelines Support Library (https://github.com/microsoft/GSL)
+     * \tparam T Target type
+     * \tparam U Source type
+     * \param u Value to cast
+     * \return The value converted to the target type
+     */
+    template <class T, class U>
+    constexpr T narrow_cast_nocheck(U&& u) noexcept
+    {
+        return static_cast<T>(std::forward<U>(u));
+    }
+
+    struct narrowing_error : public std::exception
+    {
+        const char* what() const noexcept override { return "narrowing_error"; }
+    };
+
+    /**
+     * Explicit narrow conversion checking that the value is unchanged by the cast.
+     * If the value changed, an exception is thrown
+     * Inspired by the Guidelines Support Library (https://github.com/microsoft/GSL)
+     */
+    template <class T, class U>
+    constexpr T narrow_cast_check(U u)
+    {
+        const T t = narrow_cast_nocheck<T>(u);
+
+        if (static_cast<U>(t) != u)
+        {
+            throw narrowing_error{};
+        }
+
+        if constexpr (std::is_arithmetic_v<T>)
+        {
+            constexpr bool is_different_signedness = std::is_signed_v<T> != std::is_signed_v<U>;
+
+            if (is_different_signedness && (t < T{}) != (u < U{}))
+            {
+                throw narrowing_error{};
+            }
+        }
+
+        return t;
+    }
+
+    /**
+     * \brief Explicit narrow conversion
+     * Inspired by the Guidelines Support Library (https://github.com/microsoft/GSL)
+     * \tparam T Target type
+     * \tparam U Source type
+     * \param u Value to cast
+     * \return The value converted to the target type
+     */
+    template <class T, class U>
+    constexpr T narrow_cast(U&& u)
+    {
+        if constexpr (forceNarrowCastChecking)
+        {
+            return narrow_cast_check<T, U>(std::forward<U>(u));
+        }
+        else
+        {
+            return narrow_cast_nocheck<T, U>(std::forward<U>(u));
+        }
+    }
+
+
+}


### PR DESCRIPTION
This is a way to explicit the narrowing conversions in SOFA. Instead of using the classic `static_cast`, this function can check if the value changed after the cast. It can happen in case of narrowing conversion, when the target type is smaller than the source type.
Since the check must be performed at run-time (affects the performances), it is enabled only in DEBUG mode.

The idea is to use this cast everywhere the compiler warns about possible data loss and it's not possible to avoid a narrow conversion (e.g. by adapting both target and source types). An example is provided in this PR in `MeshGmsh`.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
