### PR TITLE
[SofaCore] Make inheritance virtual

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseInteractionProjectiveConstraintSet.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/BaseInteractionProjectiveConstraintSet.h
@@ -35,7 +35,7 @@ namespace sofa::core::behavior
  *  bodies given their current positions and velocities.
  *
  */
-class SOFA_CORE_API BaseInteractionProjectiveConstraintSet : public BaseProjectiveConstraintSet, public StateAccessor
+class SOFA_CORE_API BaseInteractionProjectiveConstraintSet : public BaseProjectiveConstraintSet, public virtual StateAccessor
 {
 public:
     SOFA_ABSTRACT_CLASS2(BaseInteractionProjectiveConstraintSet, BaseProjectiveConstraintSet, StateAccessor);


### PR DESCRIPTION
If not virtual, it leads to multiple construction of `StateAccessor` in `PairInteractionProjectiveConstraintSet`.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
