### PR TITLE
[SofaGeneralEngine] Extend features of NearestPointROI

### DIFF
--- a/examples/Components/engine/NearestPointROI.scn
+++ b/examples/Components/engine/NearestPointROI.scn
@@ -95,7 +95,7 @@
         <Node name="merge1">
             <BoxROI name="box1" position="@../M1/mo.position" box="3.9 -0.1 8.9 7.1 3.1 9.1"/>
             <BoxROI name="box2" position="@../M2/mo.position" box="3.9 -0.1 8.9 7.1 3.1 9.1"/>
-            <NearestPointROI template="Vec3" name="np" object1="@../M1/mo" object2="@../M2/mo" radius="1e5" filterIndices1="@box1.indices" filterIndices2="@box2.indices"/>
+            <NearestPointROI template="Vec3" name="np" object1="@../M1/mo" object2="@../M2/mo" radius="1e5" inputIndices1="@box1.indices" inputIndices2="@box2.indices"/>
             <MechanicalObject name="dofs"/>
             <SubsetMultiMapping input="@../M1/mo @../M2/mo" output="@dofs" indexPairs="@np.indexPairs"/>
             <EdgeSetTopologyContainer edges="@np.edges"/>
@@ -105,7 +105,7 @@
         <Node name="merge2">
             <BoxROI name="box1" position="@../M2/mo.position" box="3.9 -0.1 17.9 7.1 3.1 18.1"/>
             <BoxROI name="box2" position="@../M3/mo.position" box="3.9 -0.1 17.9 7.1 3.1 18.1"/>
-            <NearestPointROI template="Vec3" name="np" object1="@../M2/mo" object2="@../M3/mo" radius="1e5" filterIndices1="@box1.indices" filterIndices2="@box2.indices"/>
+            <NearestPointROI template="Vec3" name="np" object1="@../M2/mo" object2="@../M3/mo" radius="1e5" inputIndices1="@box1.indices" inputIndices2="@box2.indices"/>
             <MechanicalObject name="dofs"/>
             <SubsetMultiMapping input="@../M2/mo @../M3/mo" output="@dofs" indexPairs="@np.indexPairs"/>
             <EdgeSetTopologyContainer edges="@np.edges"/>

--- a/examples/Components/engine/NearestPointROI.scn
+++ b/examples/Components/engine/NearestPointROI.scn
@@ -1,71 +1,106 @@
 <Node name="root" dt="0.02">
-    <RequiredPlugin pluginName='SofaBoundaryCondition'/>
-    <RequiredPlugin pluginName='SofaEngine'/>
-    <RequiredPlugin pluginName='SofaGeneralEngine'/>
-    <RequiredPlugin pluginName='SofaGeneralObjectInteraction'/>
-    <RequiredPlugin pluginName='SofaImplicitOdeSolver'/>
-    <RequiredPlugin pluginName='SofaSimpleFem'/> 
-    <VisualStyle displayFlags="showBehaviorModels showForceFields" />
-    <Node name="AttachTwoWay">
-        <EulerImplicitSolver name="cg_odesolver" printLog="false" />
-        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-        <Node name="M1">
-            <MechanicalObject />
-            <UniformMass vertexMass="1" />
-            <RegularGridTopology nx="4" ny="4" nz="10" xmin="1" xmax="4" ymin="0" ymax="3" zmin="0" zmax="9" />
-            <BoxConstraint box="0.9 -0.1 -0.1 4.1 3.1 0.1" />
-            <TetrahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" />
-        </Node>
-        <Node name="M2">
-            <EulerImplicitSolver name="cg_odesolver" printLog="false" />
-            <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-            <MechanicalObject />
-            <UniformMass vertexMass="1" />
-            <RegularGridTopology nx="4" ny="4" nz="10" xmin="1" xmax="4" ymin="0" ymax="3" zmin="9" zmax="18" />
-            <TetrahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" />
-        </Node>
-        <Node name="M3">
-            <EulerImplicitSolver name="cg_odesolver" printLog="false" />
-            <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
-            <MechanicalObject />
-            <UniformMass vertexMass="1" />
-            <RegularGridTopology nx="4" ny="4" nz="10" xmin="1" xmax="4" ymin="0" ymax="3" zmin="18" zmax="27" />
-            <!--<BoxConstraint box="0.9 -0.1 26.9 4.1 3.1 27.1" />-->
-            <TetrahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" />
-        </Node>
-        <AttachConstraint object1="@M1" object2="@M2" twoWay="true" indices1="144 145 146 147 148 149 150 151 152 153 154 155 156 157 158 159" indices2="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15" constraintFactor="1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"/>
-        <AttachConstraint object1="@M2" object2="@M3" twoWay="true" indices1="144 145 146 147 148 149 150 151 152 153 154 155 156 157 158 159" indices2="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15" constraintFactor="1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"/>
+    <Node name="requiredPlugins">
+        <RequiredPlugin name="SofaBoundaryCondition"/>
+        <RequiredPlugin name="SofaConstraint"/>
+        <RequiredPlugin name="SofaDeformable"/>
+        <RequiredPlugin name="SofaEngine"/>
+        <RequiredPlugin name="SofaGeneralEngine"/>
+        <RequiredPlugin name="SofaImplicitOdeSolver"/>
+        <RequiredPlugin name="SofaMiscMapping"/>
+        <RequiredPlugin name="SofaSimpleFem"/>
     </Node>
-    <Node name="AttachTwoWayWithRadius">
-        <EulerImplicitSolver name="cg_odesolver" printLog="false" />
+
+    <VisualStyle displayFlags="showBehaviorModels showForceFields showInteractionForceFields" />
+
+    <FreeMotionAnimationLoop parallelODESolving="true"/>
+    <GenericConstraintSolver tolerance="0.001" maxIterations="1000" unbuilt="true" multithreading="true"/>
+
+    <Node name="BilateralInteractionConstraint">
+        <EulerImplicitSolver name="cg_odesolver" rayleighStiffness="0.1" rayleighMass="0.1"/>
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
         <Node name="M1">
             <MechanicalObject name="mo"/>
             <UniformMass vertexMass="1" />
-            <RegularGridTopology nx="4" ny="4" nz="10" xmin="6" xmax="9" ymin="0" ymax="3" zmin="0" zmax="9" />
-            <BoxConstraint box="5.9 -0.1 -0.1 9.1 3.1 0.1" />
-            <TetrahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" />
+            <RegularGridTopology nx="4" ny="4" nz="10" xmin="0" xmax="3" ymin="0" ymax="3" zmin="0" zmax="9" />
+            <BoxROI box="-0.1 -0.1 -0.1 3.1 3.1 0.1" name="box"/>
+            <FixedConstraint indices="@box.indices"/>
+            <TetrahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" computeVonMisesStress="1" showVonMisesStressPerElement="true"/>
+            <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
         </Node>
         <Node name="M2">
-            <EulerImplicitSolver name="cg_odesolver" printLog="false" />
-            <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
             <MechanicalObject name="mo"/>
             <UniformMass vertexMass="1" />
-            <RegularGridTopology nx="4" ny="4" nz="10" xmin="6" xmax="9" ymin="0" ymax="3" zmin="9" zmax="18" />
-            <TetrahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" />
+            <RegularGridTopology nx="4" ny="4" nz="10" xmin="0" xmax="3" ymin="0" ymax="3" zmin="9" zmax="18" />
+            <TetrahedronFEMForceField name="FEM" youngModulus="20000" poissonRatio="0.3" computeVonMisesStress="1" showVonMisesStressPerElement="true"/>
+            <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
         </Node>
         <Node name="M3">
-            <EulerImplicitSolver name="cg_odesolver" printLog="false" />
-            <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
             <MechanicalObject name="mo"/>
             <UniformMass vertexMass="1" />
-            <RegularGridTopology nx="4" ny="4" nz="10" xmin="6" xmax="9" ymin="0" ymax="3" zmin="18" zmax="27" />
-            <!--<BoxConstraint box="-4.1 -0.1 26.9 -0.9 3.1 27.1" />-->
-            <TetrahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" />
+            <RegularGridTopology nx="4" ny="4" nz="10" xmin="0" xmax="3" ymin="0" ymax="3" zmin="18" zmax="27" />
+            <BoxROI box="-0.1 -0.1 26.99 3.1 3.1 27.1" name="box"/>
+            <FixedConstraint indices="@box.indices"/>
+            <TetrahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" computeVonMisesStress="1" showVonMisesStressPerElement="true"/>
+            <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
         </Node>
+
         <NearestPointROI template="Vec3" name="np1" object1="@./M1/mo" object2="@./M2/mo" radius="0.1"/>
         <NearestPointROI template="Vec3" name="np2" object1="@./M2/mo" object2="@./M3/mo" radius="0.1"/>
-        <AttachConstraint object1="@M1" object2="@M2" twoWay="true" indices1="@np1.indices1" indices2="@np1.indices2"/>
-        <AttachConstraint object1="@M2" object2="@M3" twoWay="true" indices1="@np2.indices1" indices2="@np2.indices2"/>
+
+        <BilateralInteractionConstraint template="Vec3d" object1="@M1" object2="@M2" first_point="@np1.indices1" second_point="@np1.indices2" />
+        <BilateralInteractionConstraint template="Vec3d" object1="@M2" object2="@M3" first_point="@np2.indices1" second_point="@np2.indices2" />
+    </Node>
+
+    <Node name="Springs">
+        <EulerImplicitSolver name="cg_odesolver" rayleighStiffness="0.1" rayleighMass="0.1"/>
+        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
+        <Node name="M1">
+            <MechanicalObject name="mo"/>
+            <UniformMass vertexMass="1" />
+            <RegularGridTopology nx="4" ny="4" nz="10" xmin="4" xmax="7" ymin="0" ymax="3" zmin="0" zmax="9" />
+            <BoxROI box="3.9 -0.1 -0.1 7.1 3.1 0.1" name="box"/>
+            <FixedConstraint indices="@box.indices"/>
+            <TetrahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" computeVonMisesStress="1" showVonMisesStressPerElement="true"/>
+            <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
+        </Node>
+        <Node name="M2">
+            <MechanicalObject name="mo"/>
+            <UniformMass vertexMass="1" />
+            <RegularGridTopology nx="4" ny="4" nz="10" xmin="4" xmax="7" ymin="0" ymax="3" zmin="9" zmax="18" />
+            <TetrahedronFEMForceField name="FEM" youngModulus="20000" poissonRatio="0.3" computeVonMisesStress="1" showVonMisesStressPerElement="true"/>
+            <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
+        </Node>
+        <Node name="M3">
+            <MechanicalObject name="mo"/>
+            <UniformMass vertexMass="1" />
+            <RegularGridTopology nx="4" ny="4" nz="10" xmin="4" xmax="7" ymin="0" ymax="3" zmin="18" zmax="27" />
+            <BoxROI box="3.9 -0.1 26.99 7.1 3.1 27.1" name="box"/>
+            <FixedConstraint indices="@box.indices"/>
+            <TetrahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" computeVonMisesStress="1" showVonMisesStressPerElement="true"/>
+            <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
+        </Node>
+
+        <!--
+            In the following Nodes, dofs from 2 mechanical objects are fused into a new mechanical object, based on the
+            minimal distance between points.
+            A mapping links the three objects. An edge topology is created.
+            Springs are created based on the topology.
+        -->
+        <Node name="merge1">
+            <NearestPointROI template="Vec3" name="np" object1="@../M1/mo" object2="@../M2/mo" radius="0.1"/>
+            <MechanicalObject name="dofs"/>
+            <SubsetMultiMapping input="@../M1/mo @../M2/mo" output="@dofs" indexPairs="@np.indexPairs"/>
+            <EdgeSetTopologyContainer edges="@np.edges"/>
+            <MeshSpringForceField stiffness="10000" damping="1" linesStiffness="10000" linesDamping="1" drawMode="1" drawSpringSize="1"/>
+        </Node>
+
+        <Node name="merge2">
+            <NearestPointROI template="Vec3" name="np" object1="@../M2/mo" object2="@../M3/mo" radius="0.1"/>
+            <MechanicalObject name="dofs"/>
+            <SubsetMultiMapping input="@../M2/mo @../M3/mo" output="@dofs" indexPairs="@np.indexPairs"/>
+            <EdgeSetTopologyContainer edges="@np.edges"/>
+            <MeshSpringForceField stiffness="10000" damping="1" linesStiffness="10000" linesDamping="1" drawMode="1" drawSpringSize="1"/>
+        </Node>
+
     </Node>
 </Node>

--- a/examples/Components/engine/NearestPointROI.scn
+++ b/examples/Components/engine/NearestPointROI.scn
@@ -18,7 +18,7 @@
     <!--
         This Node shows how NearestPointROI is used to create constraints to link close vertices
     -->
-    <Node name="BilateralInteractionConstraint">
+    <Node name="ObjectsAttachedWithConstraints">
         <EulerImplicitSolver name="cg_odesolver" rayleighStiffness="0.1" rayleighMass="0.1"/>
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
         <Node name="M1">

--- a/examples/Components/engine/NearestPointROI.scn
+++ b/examples/Components/engine/NearestPointROI.scn
@@ -15,12 +15,15 @@
     <FreeMotionAnimationLoop parallelODESolving="true"/>
     <GenericConstraintSolver tolerance="0.001" maxIterations="1000" unbuilt="true" multithreading="true"/>
 
+    <!--
+        This Node shows how NearestPointROI is used to create constraints to link close vertices
+    -->
     <Node name="BilateralInteractionConstraint">
         <EulerImplicitSolver name="cg_odesolver" rayleighStiffness="0.1" rayleighMass="0.1"/>
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
         <Node name="M1">
             <MechanicalObject name="mo"/>
-            <UniformMass vertexMass="1" />
+            <UniformMass totalMass="160" />
             <RegularGridTopology nx="4" ny="4" nz="10" xmin="0" xmax="3" ymin="0" ymax="3" zmin="0" zmax="9" />
             <BoxROI box="-0.1 -0.1 -0.1 3.1 3.1 0.1" name="box"/>
             <FixedConstraint indices="@box.indices"/>
@@ -29,14 +32,14 @@
         </Node>
         <Node name="M2">
             <MechanicalObject name="mo"/>
-            <UniformMass vertexMass="1" />
+            <UniformMass totalMass="160" />
             <RegularGridTopology nx="4" ny="4" nz="10" xmin="0" xmax="3" ymin="0" ymax="3" zmin="9" zmax="18" />
             <TetrahedronFEMForceField name="FEM" youngModulus="20000" poissonRatio="0.3" computeVonMisesStress="1" showVonMisesStressPerElement="true"/>
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
         </Node>
         <Node name="M3">
             <MechanicalObject name="mo"/>
-            <UniformMass vertexMass="1" />
+            <UniformMass totalMass="160" />
             <RegularGridTopology nx="4" ny="4" nz="10" xmin="0" xmax="3" ymin="0" ymax="3" zmin="18" zmax="27" />
             <BoxROI box="-0.1 -0.1 26.99 3.1 3.1 27.1" name="box"/>
             <FixedConstraint indices="@box.indices"/>
@@ -51,28 +54,31 @@
         <BilateralInteractionConstraint template="Vec3d" object1="@M2" object2="@M3" first_point="@np2.indices1" second_point="@np2.indices2" />
     </Node>
 
+    <!--
+        This Node shows how NearestPointROI is used to create SubsetMultiMapping and EdgeSetTopologyContainer.
+    -->
     <Node name="Springs">
         <EulerImplicitSolver name="cg_odesolver" rayleighStiffness="0.1" rayleighMass="0.1"/>
         <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
         <Node name="M1">
             <MechanicalObject name="mo"/>
-            <UniformMass vertexMass="1" />
+            <UniformMass totalMass="160" />
             <RegularGridTopology nx="4" ny="4" nz="10" xmin="4" xmax="7" ymin="0" ymax="3" zmin="0" zmax="9" />
             <BoxROI box="3.9 -0.1 -0.1 7.1 3.1 0.1" name="box"/>
             <FixedConstraint indices="@box.indices"/>
             <TetrahedronFEMForceField name="FEM" youngModulus="4000" poissonRatio="0.3" computeVonMisesStress="1" showVonMisesStressPerElement="true"/>
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
         </Node>
-        <Node name="M2">
+        <Node name="M2"> <!-- This object has a higher resolution than the others -->
             <MechanicalObject name="mo"/>
-            <UniformMass vertexMass="1" />
-            <RegularGridTopology nx="4" ny="4" nz="10" xmin="4" xmax="7" ymin="0" ymax="3" zmin="9" zmax="18" />
+            <UniformMass totalMass="160" />
+            <RegularGridTopology nx="8" ny="8" nz="20" xmin="4" xmax="7" ymin="0" ymax="3" zmin="9" zmax="18" />
             <TetrahedronFEMForceField name="FEM" youngModulus="20000" poissonRatio="0.3" computeVonMisesStress="1" showVonMisesStressPerElement="true"/>
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
         </Node>
         <Node name="M3">
             <MechanicalObject name="mo"/>
-            <UniformMass vertexMass="1" />
+            <UniformMass totalMass="160" />
             <RegularGridTopology nx="4" ny="4" nz="10" xmin="4" xmax="7" ymin="0" ymax="3" zmin="18" zmax="27" />
             <BoxROI box="3.9 -0.1 26.99 7.1 3.1 27.1" name="box"/>
             <FixedConstraint indices="@box.indices"/>
@@ -87,7 +93,9 @@
             Springs are created based on the topology.
         -->
         <Node name="merge1">
-            <NearestPointROI template="Vec3" name="np" object1="@../M1/mo" object2="@../M2/mo" radius="0.1"/>
+            <BoxROI name="box1" position="@../M1/mo.position" box="3.9 -0.1 8.9 7.1 3.1 9.1"/>
+            <BoxROI name="box2" position="@../M2/mo.position" box="3.9 -0.1 8.9 7.1 3.1 9.1"/>
+            <NearestPointROI template="Vec3" name="np" object1="@../M1/mo" object2="@../M2/mo" radius="1e5" filterIndices1="@box1.indices" filterIndices2="@box2.indices"/>
             <MechanicalObject name="dofs"/>
             <SubsetMultiMapping input="@../M1/mo @../M2/mo" output="@dofs" indexPairs="@np.indexPairs"/>
             <EdgeSetTopologyContainer edges="@np.edges"/>
@@ -95,7 +103,9 @@
         </Node>
 
         <Node name="merge2">
-            <NearestPointROI template="Vec3" name="np" object1="@../M2/mo" object2="@../M3/mo" radius="0.1"/>
+            <BoxROI name="box1" position="@../M2/mo.position" box="3.9 -0.1 17.9 7.1 3.1 18.1"/>
+            <BoxROI name="box2" position="@../M3/mo.position" box="3.9 -0.1 17.9 7.1 3.1 18.1"/>
+            <NearestPointROI template="Vec3" name="np" object1="@../M2/mo" object2="@../M3/mo" radius="1e5" filterIndices1="@box1.indices" filterIndices2="@box2.indices"/>
             <MechanicalObject name="dofs"/>
             <SubsetMultiMapping input="@../M2/mo @../M3/mo" output="@dofs" indexPairs="@np.indexPairs"/>
             <EdgeSetTopologyContainer edges="@np.edges"/>

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.cpp
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.cpp
@@ -32,8 +32,15 @@ int NearestPointROIClass = core::RegisterObject("Attach given pair of particles,
         .add< NearestPointROI<Vec3Types> >()
         .add< NearestPointROI<Vec2Types> >()
         .add< NearestPointROI<Vec1Types> >()
+        .add< NearestPointROI<Vec6Types> >()
         .add< NearestPointROI<Rigid3Types> >()
         .add< NearestPointROI<Rigid2Types> >()
         ;
 
+template class SOFA_SOFAGENERALENGINE_API NearestPointROI<sofa::defaulttype::Vec3Types>;
+template class SOFA_SOFAGENERALENGINE_API NearestPointROI<sofa::defaulttype::Vec2Types>;
+template class SOFA_SOFAGENERALENGINE_API NearestPointROI<sofa::defaulttype::Vec1Types>;
+template class SOFA_SOFAGENERALENGINE_API NearestPointROI<sofa::defaulttype::Vec6Types>;
+template class SOFA_SOFAGENERALENGINE_API NearestPointROI<sofa::defaulttype::Rigid3Types>;
+template class SOFA_SOFAGENERALENGINE_API NearestPointROI<sofa::defaulttype::Rigid2Types>;
 } //namespace sofa::component::engine

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.cpp
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.cpp
@@ -23,13 +23,10 @@
 #include <SofaGeneralEngine/NearestPointROI.inl>
 #include <sofa/core/ObjectFactory.h>
 
-#include <sofa/simulation/Node.h>
-
 namespace sofa::component::engine
 {
 
 using namespace sofa::defaulttype;
-using namespace sofa::helper;
 
 int NearestPointROIClass = core::RegisterObject("Attach given pair of particles, projecting the positions of the second particles to the first ones")
         .add< NearestPointROI<Vec3Types> >()

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.h
@@ -61,8 +61,8 @@ public:
     typedef type::vector<unsigned int> SetIndexArray;
     typedef sofa::core::topology::TopologySubsetIndices SetIndex;
 
-    SetIndex d_filterIndices1; ///< Only these indices are considered in the first model
-    SetIndex d_filterIndices2; ///< Only these indices are considered in the second model
+    SetIndex d_inputIndices1; ///< Only these indices are considered in the first model
+    SetIndex d_inputIndices2; ///< Only these indices are considered in the second model
     Data<Real> f_radius; ///< Radius to search corresponding fixed point if no indices are given
     Data<bool> d_useRestPosition; ///< If true will use rest position only at init. Otherwise will recompute the maps at each update. Default is true.
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.h
@@ -90,6 +90,7 @@ protected:
 extern template class SOFA_SOFAGENERALENGINE_API NearestPointROI<defaulttype::Vec3Types>;
 extern template class SOFA_SOFAGENERALENGINE_API NearestPointROI<defaulttype::Vec2Types>;
 extern template class SOFA_SOFAGENERALENGINE_API NearestPointROI<defaulttype::Vec1Types>;
+extern template class SOFA_SOFAGENERALENGINE_API NearestPointROI<defaulttype::Vec6Types>;
 extern template class SOFA_SOFAGENERALENGINE_API NearestPointROI<defaulttype::Rigid3Types>;
 extern template class SOFA_SOFAGENERALENGINE_API NearestPointROI<defaulttype::Rigid2Types>;
 #endif

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.h
@@ -61,10 +61,17 @@ public:
     typedef type::vector<unsigned int> SetIndexArray;
     typedef sofa::core::topology::TopologySubsetIndices SetIndex;
 
-    SetIndex f_indices1; ///< Indices of the source points on the first model
-    SetIndex f_indices2; ///< Indices of the fixed points on the second model
+
     Data<Real> f_radius; ///< Radius to search corresponding fixed point if no indices are given
     Data<bool> d_useRestPosition; ///< If true will use rest position only at init. Otherwise will recompute the maps at each update. Default is true.
+
+    /// Output Data
+    ///@{
+    SetIndex f_indices1; ///< Indices of the source points on the first model
+    SetIndex f_indices2; ///< Indices of the fixed points on the second model
+    Data< sofa::type::vector<topology::Edge> > d_edges; ///< List of edges. The indices point to a list composed as an interleaved fusion of output degrees of freedom. It could be used to fuse two mechanical objects and create a topology from the fusion.
+    Data< type::vector<unsigned> > d_indexPairs;        ///< Two indices per child: the parent, and the index within the parent. Could be used with a SubsetMultiMapping
+    ///@}
 
     NearestPointROI();
     ~NearestPointROI() override;

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.h
@@ -74,7 +74,7 @@ public:
     Data< type::vector<unsigned> > d_indexPairs;        ///< Two indices per child: the parent, and the index within the parent. Could be used with a SubsetMultiMapping
     ///@}
 
-    NearestPointROI();
+    explicit NearestPointROI(core::behavior::MechanicalState<DataTypes> * = nullptr, core::behavior::MechanicalState<DataTypes> *mm2 = nullptr);
     ~NearestPointROI() override;
 
     void init() override;

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.h
@@ -38,10 +38,10 @@ namespace sofa::component::engine
  * Attach given pair of particles, projecting the positions of the second particles to the first ones.
  */
 template <class DataTypes>
-class NearestPointROI : public sofa::core::DataEngine
+class NearestPointROI : public sofa::core::DataEngine, public core::behavior::PairStateAccessor<DataTypes, DataTypes>
 {
-public:    
-    SOFA_CLASS(SOFA_TEMPLATE(NearestPointROI, DataTypes), sofa::core::DataEngine);
+public:
+    SOFA_CLASS2(SOFA_TEMPLATE(NearestPointROI, DataTypes), sofa::core::DataEngine, SOFA_TEMPLATE2(core::behavior::PairStateAccessor, DataTypes, DataTypes));
 
     typedef typename DataTypes::VecCoord VecCoord;
     typedef typename DataTypes::VecDeriv VecDeriv;
@@ -59,9 +59,6 @@ public:
     SetIndex f_indices2; ///< Indices of the fixed points on the second model
     Data<Real> f_radius; ///< Radius to search corresponding fixed point if no indices are given
     Data<bool> d_useRestPosition; ///< If true will use rest position only at init. Otherwise will recompute the maps at each update. Default is true.
-    
-    SingleLink<NearestPointROI<DataTypes>, core::behavior::MechanicalState<DataTypes>, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> mstate1;
-    SingleLink<NearestPointROI<DataTypes>, core::behavior::MechanicalState<DataTypes>, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> mstate2;
 
     NearestPointROI();
     ~NearestPointROI() override;

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.h
@@ -61,7 +61,8 @@ public:
     typedef type::vector<unsigned int> SetIndexArray;
     typedef sofa::core::topology::TopologySubsetIndices SetIndex;
 
-
+    SetIndex d_filterIndices1; ///< Only these indices are considered in the first model
+    SetIndex d_filterIndices2; ///< Only these indices are considered in the second model
     Data<Real> f_radius; ///< Radius to search corresponding fixed point if no indices are given
     Data<bool> d_useRestPosition; ///< If true will use rest position only at init. Otherwise will recompute the maps at each update. Default is true.
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.h
@@ -25,26 +25,18 @@
 #include <sofa/core/behavior/PairInteractionProjectiveConstraintSet.h>
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
-#include <sofa/core/objectmodel/Event.h>
-#include <sofa/linearalgebra/BaseMatrix.h>
-#include <sofa/linearalgebra/BaseVector.h>
-#include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/type/vector.h>
 #include <sofa/core/topology/TopologySubsetIndices.h>
-#include <set>
 #include <sofa/core/DataEngine.h>
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/config.h>
 
-
-
 namespace sofa::component::engine
 {
-/** Attach given pair of particles, projecting the positions of the second particles to the first ones.
-*/
 
-using sofa::core::behavior::MechanicalState ;
-
+/**
+ * Attach given pair of particles, projecting the positions of the second particles to the first ones.
+ */
 template <class DataTypes>
 class NearestPointROI : public sofa::core::DataEngine
 {
@@ -63,16 +55,14 @@ public:
     typedef type::vector<unsigned int> SetIndexArray;
     typedef sofa::core::topology::TopologySubsetIndices SetIndex;
 
-public:
     SetIndex f_indices1; ///< Indices of the source points on the first model
     SetIndex f_indices2; ///< Indices of the fixed points on the second model
     Data<Real> f_radius; ///< Radius to search corresponding fixed point if no indices are given
     Data<bool> d_useRestPosition; ///< If true will use rest position only at init. Otherwise will recompute the maps at each update. Default is true.
     
-    SingleLink<NearestPointROI<DataTypes>, MechanicalState<DataTypes>, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> mstate1;
-    SingleLink<NearestPointROI<DataTypes>, MechanicalState<DataTypes>, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> mstate2;
+    SingleLink<NearestPointROI<DataTypes>, core::behavior::MechanicalState<DataTypes>, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> mstate1;
+    SingleLink<NearestPointROI<DataTypes>, core::behavior::MechanicalState<DataTypes>, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> mstate2;
 
-public:
     NearestPointROI();
     ~NearestPointROI() override;
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.h
@@ -72,6 +72,7 @@ public:
     SetIndex f_indices2; ///< Indices of the fixed points on the second model
     Data< sofa::type::vector<topology::Edge> > d_edges; ///< List of edges. The indices point to a list composed as an interleaved fusion of output degrees of freedom. It could be used to fuse two mechanical objects and create a topology from the fusion.
     Data< type::vector<unsigned> > d_indexPairs;        ///< Two indices per child: the parent, and the index within the parent. Could be used with a SubsetMultiMapping
+    Data< type::vector<Real> > d_distances; /// List of distances between pairs of points
     ///@}
 
     explicit NearestPointROI(core::behavior::MechanicalState<DataTypes> * = nullptr, core::behavior::MechanicalState<DataTypes> *mm2 = nullptr);

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.h
@@ -35,7 +35,13 @@ namespace sofa::component::engine
 {
 
 /**
- * Attach given pair of particles, projecting the positions of the second particles to the first ones.
+ * Given two mechanical states, find correspondance between degrees of freedom, based on the minimal distance.
+ *
+ * Project all the points from the second mechanical state on the first one. This done by finding the point in the
+ * first mechanical state closest to each point in the second mechanical state. If the distance is less than a provided
+ * distance (named radius), the indices of the degrees of freedom in their respective mechanical states is added to
+ * an output list.
+ *
  */
 template <class DataTypes>
 class NearestPointROI : public sofa::core::DataEngine, public core::behavior::PairStateAccessor<DataTypes, DataTypes>

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
@@ -106,13 +106,13 @@ template <class DataTypes>
 void NearestPointROI<DataTypes>::computeNearestPointMaps(const VecCoord& x1, const VecCoord& x2)
 {
     Coord pt2;
-    auto dist = [](const Coord& a, const Coord& b) { return (b - a).norm(); };
-    auto cmp = [&pt2, &dist](const Coord& a, const Coord& b) {
+    constexpr auto dist = [](const Coord& a, const Coord& b) { return (b - a).norm(); };
+    constexpr auto cmp = [&pt2, &dist](const Coord& a, const Coord& b) {
         return dist(a, pt2) < dist(b, pt2);
     };
 
-    auto indices1 = f_indices1.beginEdit();
-    auto indices2 = f_indices2.beginEdit();
+    auto indices1 = sofa::helper::getWriteOnlyAccessor(f_indices1);
+    auto indices2 = sofa::helper::getWriteOnlyAccessor(f_indices2);
     indices1->clear();
     indices2->clear();
 
@@ -128,12 +128,9 @@ void NearestPointROI<DataTypes>::computeNearestPointMaps(const VecCoord& x1, con
             indices2->push_back(i2);
         }
     }
-    
-    f_indices1.endEdit();
-    f_indices2.endEdit();
 
     // Check coherency of size between indices vectors 1 and 2
-    if (f_indices1.getValue().size() != f_indices2.getValue().size())
+    if (indices1.size() != indices2.size())
     {
         msg_error() << "Size mismatch between indices1 and indices2";
     }

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
@@ -121,10 +121,13 @@ void NearestPointROI<DataTypes>::computeNearestPointMaps(const VecCoord& x1, con
     for (unsigned int i2 = 0; i2 < x2.size(); ++i2)
     {
         pt2 = x2[i2];
-        auto el = std::min_element(std::begin(x1), std::end(x1), cmp);
-        if (dist(*el, pt2) < maxR) 
+
+        //find the nearest element from pt2 in x1
+        auto pt1 = std::min_element(std::begin(x1), std::end(x1), cmp);
+
+        if (dist(*pt1, pt2) < maxR)
         {
-            indices1->push_back(std::distance(std::begin(x1), el));
+            indices1->push_back(std::distance(std::begin(x1), pt1));
             indices2->push_back(i2);
         }
     }

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
@@ -34,7 +34,8 @@ NearestPointROI<DataTypes>::NearestPointROI()
     , f_radius( initData(&f_radius,(Real)1,"radius", "Radius to search corresponding fixed point") )
     , d_useRestPosition(initData(&d_useRestPosition, true, "useRestPosition", "If true will use restPosition only at init"))
 {
-
+    f_indices1.setGroup("Output");
+    f_indices2.setGroup("Output");
 }
 
 template <class DataTypes>

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
@@ -29,8 +29,8 @@ template <class DataTypes>
 NearestPointROI<DataTypes>::NearestPointROI(core::behavior::MechanicalState<DataTypes>* mm1, core::behavior::MechanicalState<DataTypes>* mm2)
     : Inherit1()
     , Inherit2(mm1, mm2)
-    , d_filterIndices1( initData(&d_filterIndices1,"filterIndices1","Indices of the points to consider on the first model") )
-    , d_filterIndices2( initData(&d_filterIndices2,"filterIndices2","Indices of the points to consider on the first model") )
+    , d_inputIndices1( initData(&d_inputIndices1,"inputIndices1","Indices of the points to consider on the first model") )
+    , d_inputIndices2( initData(&d_inputIndices2,"inputIndices2","Indices of the points to consider on the first model") )
     , f_radius( initData(&f_radius,(Real)1,"radius", "Radius to search corresponding fixed point") )
     , d_useRestPosition(initData(&d_useRestPosition, true, "useRestPosition", "If true will use restPosition only at init"))
     , f_indices1( initData(&f_indices1,"indices1","Indices from the first model associated to a dof from the second model") )
@@ -118,8 +118,8 @@ void NearestPointROI<DataTypes>::computeNearestPointMaps(const VecCoord& x1, con
         return dist(x1[a], pt2) < dist(x1[b], pt2);
     };
 
-    auto filterIndices1 = sofa::helper::getWriteAccessor(d_filterIndices1);
-    auto filterIndices2 = sofa::helper::getWriteAccessor(d_filterIndices2);
+    auto filterIndices1 = sofa::helper::getWriteAccessor(d_inputIndices1);
+    auto filterIndices2 = sofa::helper::getWriteAccessor(d_inputIndices2);
     if (filterIndices1.empty())
     {
         filterIndices1.resize(x1.size());

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
@@ -37,6 +37,7 @@ NearestPointROI<DataTypes>::NearestPointROI(core::behavior::MechanicalState<Data
     , f_indices2( initData(&f_indices2,"indices2","Indices from the second model associated to a dof from the first model") )
     , d_edges(initData(&d_edges, "edges", "List of edge indices"))
     , d_indexPairs(initData(&d_indexPairs, "indexPairs", "list of couples (parent index + index in the parent)"))
+    , d_distances(initData(&d_distances, "distances", "List of distances between pairs of points"))
 {
 }
 
@@ -71,6 +72,7 @@ void NearestPointROI<DataTypes>::init()
     addOutput(&f_indices2);
     addOutput(&d_edges);
     addOutput(&d_indexPairs);
+    addOutput(&d_distances);
 }
 
 template <class DataTypes>
@@ -140,6 +142,9 @@ void NearestPointROI<DataTypes>::computeNearestPointMaps(const VecCoord& x1, con
     auto indexPairs = sofa::helper::getWriteOnlyAccessor(d_indexPairs);
     indexPairs->clear();
 
+    auto distances = sofa::helper::getWriteOnlyAccessor(d_distances);
+    distances->clear();
+
     const Real maxR = f_radius.getValue();
     const auto maxRSquared = maxR * maxR;
 
@@ -151,7 +156,8 @@ void NearestPointROI<DataTypes>::computeNearestPointMaps(const VecCoord& x1, con
         auto i1 = *std::min_element(std::begin(filterIndices1), std::end(filterIndices1), cmp);
         const auto& pt1 = x1[i1];
 
-        if (dist(pt1, pt2) < maxRSquared)
+        const auto d = dist(pt1, pt2);
+        if (d < maxRSquared)
         {
             indices1->push_back(i1);
             indices2->push_back(i2);
@@ -162,6 +168,8 @@ void NearestPointROI<DataTypes>::computeNearestPointMaps(const VecCoord& x1, con
 
             indexPairs->push_back(1);
             indexPairs->push_back(indices2->back());
+
+            distances->push_back(std::sqrt(d));
         }
     }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
@@ -27,12 +27,12 @@ namespace sofa::component::engine
 
 template <class DataTypes>
 NearestPointROI<DataTypes>::NearestPointROI()
-    : f_indices1( initData(&f_indices1,"indices1","Indices of the points on the first model") )
+    : Inherit1()
+    , Inherit2(nullptr, nullptr)
+    , f_indices1( initData(&f_indices1,"indices1","Indices of the points on the first model") )
     , f_indices2( initData(&f_indices2,"indices2","Indices of the points on the second model") )
     , f_radius( initData(&f_radius,(Real)1,"radius", "Radius to search corresponding fixed point") )
     , d_useRestPosition(initData(&d_useRestPosition, true, "useRestPosition", "If true will use restPosition only at init"))
-    , mstate1(initLink("object1", "First object to constrain"))
-    , mstate2(initLink("object2", "Second object to constrain"))
 {
 
 }
@@ -45,36 +45,13 @@ NearestPointROI<DataTypes>::~NearestPointROI()
 template <class DataTypes>
 void NearestPointROI<DataTypes>::init()
 {
-    // Test inputs
-    bool success = true;
-    if (mstate1 && !mstate1.get())
-    {
-        msg_error_when(!mstate1.get()) << "Cannot Initialize, mstate1 link is pointing to invalid object!";
-        success = false;
-    }
-    else if (!mstate1)
-    {
-        msg_error_when(!mstate1) << "Cannot Initialize, mstate1 link is invalid!";
-        success = false;
-    }
+    Inherit2::init();
 
-    if (mstate2 && !mstate2.get())
-    {
-        msg_error_when(!mstate2.get()) << "Cannot Initialize, mstate2 link is pointing to invalid object!";
-        success = false;
-    }
-    else if (!mstate2)
-    {
-        msg_error_when(!mstate2) << "Cannot Initialize, mstate2 link is invalid!";
-        success = false;
-    }
-
-    if (!success)
+    if (!this->mstate1 || !this->mstate2)
     {
         this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         return;
     }
-
 
     if (d_useRestPosition.getValue())
     {
@@ -95,11 +72,14 @@ template <class DataTypes>
 void NearestPointROI<DataTypes>::reinit()
 {
     this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
-    if(f_radius.getValue() <= 0){
+    if(f_radius.getValue() <= 0)
+    {
         msg_error() << "Radius must be a positive real.";
         return;
     }
-    if(!this->mstate1 || !this->mstate2){
+
+    if(!this->mstate1 || !this->mstate2)
+    {
         msg_error() << "2 valid mechanicalobjects are required.";
         return;
     }
@@ -115,7 +95,7 @@ void NearestPointROI<DataTypes>::doUpdate()
     const VecCoord& x1 = this->mstate1->read(vecCoordId)->getValue();
     const VecCoord& x2 = this->mstate2->read(vecCoordId)->getValue();
 
-    if (x1.size() == 0 || x2.size() == 0)
+    if (x1.empty() || x2.empty())
         return;
 
     computeNearestPointMaps(x1, x2);

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
@@ -107,7 +107,7 @@ template <class DataTypes>
 void NearestPointROI<DataTypes>::computeNearestPointMaps(const VecCoord& x1, const VecCoord& x2)
 {
     Coord pt2;
-    constexpr auto dist = [](const Coord& a, const Coord& b) { return (b - a).norm(); };
+    constexpr auto dist = [](const Coord& a, const Coord& b) { return (b - a).norm2(); };
     constexpr auto cmp = [&pt2, &dist](const Coord& a, const Coord& b) {
         return dist(a, pt2) < dist(b, pt2);
     };
@@ -118,6 +118,7 @@ void NearestPointROI<DataTypes>::computeNearestPointMaps(const VecCoord& x1, con
     indices2->clear();
 
     const Real maxR = f_radius.getValue();
+    const auto maxRSquared = maxR * maxR;
 
     for (unsigned int i2 = 0; i2 < x2.size(); ++i2)
     {
@@ -126,7 +127,7 @@ void NearestPointROI<DataTypes>::computeNearestPointMaps(const VecCoord& x1, con
         //find the nearest element from pt2 in x1
         auto pt1 = std::min_element(std::begin(x1), std::end(x1), cmp);
 
-        if (dist(*pt1, pt2) < maxR)
+        if (dist(*pt1, pt2) < maxRSquared)
         {
             indices1->push_back(std::distance(std::begin(x1), pt1));
             indices2->push_back(i2);

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
@@ -26,9 +26,9 @@ namespace sofa::component::engine
 {
 
 template <class DataTypes>
-NearestPointROI<DataTypes>::NearestPointROI()
+NearestPointROI<DataTypes>::NearestPointROI(core::behavior::MechanicalState<DataTypes>* mm1, core::behavior::MechanicalState<DataTypes>* mm2)
     : Inherit1()
-    , Inherit2(nullptr, nullptr)
+    , Inherit2(mm1, mm2)
     , d_filterIndices1( initData(&d_filterIndices1,"filterIndices1","Indices of the points to consider on the first model") )
     , d_filterIndices2( initData(&d_filterIndices2,"filterIndices2","Indices of the points to consider on the first model") )
     , f_radius( initData(&f_radius,(Real)1,"radius", "Radius to search corresponding fixed point") )

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
@@ -21,16 +21,9 @@
 ******************************************************************************/
 #pragma once
 #include <SofaGeneralEngine/NearestPointROI.h>
-#include <sofa/core/visual/VisualParams.h>
-#include <sofa/type/RGBAColor.h>
-#include <sofa/defaulttype/RigidTypes.h>
-#include <iostream>
-#include <sofa/simulation/Node.h>
 
 namespace sofa::component::engine
 {
-
-using sofa::simulation::Node ;
 
 template <class DataTypes>
 NearestPointROI<DataTypes>::NearestPointROI()


### PR DESCRIPTION
1. a clean of the `NearestPointROI` class.
2. More features are added to NearestPointROI:
- Generates more output format so they can be used in other components accepting only those formats. Now, it can be used with SubsetMultiMapping and EdgeSetTopologyContainer.
- Add a filter on the input dofs.

The example scene has been reworked. It now uses constraints. And springs have been added to show how to use the new features from this PR.

This PR replaces https://github.com/sofa-framework/sofa/pull/2562

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
