### PR TITLE
[SofaDeformable] Springs are able to compute their bounding box

### DIFF
--- a/SofaKernel/modules/SofaDeformable/src/SofaDeformable/SpringForceField.h
+++ b/SofaKernel/modules/SofaDeformable/src/SofaDeformable/SpringForceField.h
@@ -151,6 +151,7 @@ public:
     void setDrawMode(int m) {drawMode.setValue(m);}
 
     void draw(const core::visual::VisualParams* vparams) override;
+    void computeBBox(const core::ExecParams* params, bool onlyVisible=false) override;
 
     // -- Modifiers
 

--- a/SofaKernel/modules/SofaDeformable/src/SofaDeformable/SpringForceField.inl
+++ b/SofaKernel/modules/SofaDeformable/src/SofaDeformable/SpringForceField.inl
@@ -298,23 +298,32 @@ void SpringForceField<DataTypes>::computeBBox(const core::ExecParams* params, bo
 
     constexpr Real max_real = std::numeric_limits<Real>::max();
     constexpr Real min_real = std::numeric_limits<Real>::lowest();
-    Real maxBBox[3] = {min_real,min_real,min_real};
-    Real minBBox[3] = {max_real,max_real,max_real};
+    Real maxBBox[DataTypes::spatial_dimensions];
+    Real minBBox[DataTypes::spatial_dimensions];
+
+    for (int c = 0; c < DataTypes::spatial_dimensions; ++c)
+    {
+        maxBBox[c] = min_real;
+        minBBox[c] = max_real;
+    }
 
     for (const auto& spring : springsValue)
     {
         if (spring.enabled)
         {
-            const auto& a = p1[spring.m1];
-            const auto& b = p2[spring.m2];
-            for (const auto& p : {a, b})
+            if (spring.m1 < p1.size() && spring.m2 < p2.size())
             {
-                for (int c=0; c<3; c++)
+                const auto& a = p1[spring.m1];
+                const auto& b = p2[spring.m2];
+                for (const auto& p : {a, b})
                 {
-                    if (p[c] > maxBBox[c])
-                        maxBBox[c] = p[c];
-                    else if (p[c] < minBBox[c])
-                        minBBox[c] = p[c];
+                    for (int c = 0; c < DataTypes::spatial_dimensions; ++c)
+                    {
+                        if (p[c] > maxBBox[c])
+                            maxBBox[c] = p[c];
+                        else if (p[c] < minBBox[c])
+                            minBBox[c] = p[c];
+                    }
                 }
             }
         }

--- a/SofaKernel/modules/SofaDeformable/src/SofaDeformable/SpringForceField.inl
+++ b/SofaKernel/modules/SofaDeformable/src/SofaDeformable/SpringForceField.inl
@@ -307,12 +307,16 @@ void SpringForceField<DataTypes>::computeBBox(const core::ExecParams* params, bo
         minBBox[c] = max_real;
     }
 
+    bool foundSpring = false;
+
     for (const auto& spring : springsValue)
     {
         if (spring.enabled)
         {
             if (spring.m1 < p1.size() && spring.m2 < p2.size())
             {
+                foundSpring = true;
+
                 const auto& a = p1[spring.m1];
                 const auto& b = p2[spring.m2];
                 for (const auto& p : {a, b})
@@ -329,7 +333,10 @@ void SpringForceField<DataTypes>::computeBBox(const core::ExecParams* params, bo
         }
     }
 
-    this->f_bbox.setValue(sofa::type::TBoundingBox<Real>(minBBox,maxBBox));
+    if (foundSpring)
+    {
+        this->f_bbox.setValue(sofa::type::TBoundingBox<Real>(minBBox,maxBBox));
+    }
 }
 
 template<class DataTypes>


### PR DESCRIPTION
Add the `computeBBox` method to `SpringForceField`, so all spring force fields having `SpringForceField` as the base class can update their bounding box.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
