### PR TITLE
[SofaEngine] BoxROI support for 2d and 1d types

### DIFF
--- a/SofaKernel/modules/SofaEngine/src/SofaEngine/BoxROI.cpp
+++ b/SofaKernel/modules/SofaEngine/src/SofaEngine/BoxROI.cpp
@@ -31,6 +31,7 @@ using namespace sofa::defaulttype;
 
 int BoxROIClass = core::RegisterObject("Find the primitives (vertex/edge/triangle/quad/tetrahedron/hexahedron) inside given boxes")
         .add< BoxROI<Vec3Types> >(true) //default
+        .add< BoxROI<Vec2Types> >()
         .add< BoxROI<Rigid3Types> >()
         .add< BoxROI<Vec6Types> >()
  

--- a/SofaKernel/modules/SofaEngine/src/SofaEngine/BoxROI.cpp
+++ b/SofaKernel/modules/SofaEngine/src/SofaEngine/BoxROI.cpp
@@ -32,6 +32,7 @@ using namespace sofa::defaulttype;
 int BoxROIClass = core::RegisterObject("Find the primitives (vertex/edge/triangle/quad/tetrahedron/hexahedron) inside given boxes")
         .add< BoxROI<Vec3Types> >(true) //default
         .add< BoxROI<Vec2Types> >()
+        .add< BoxROI<Vec1Types> >()
         .add< BoxROI<Rigid3Types> >()
         .add< BoxROI<Vec6Types> >()
  

--- a/SofaKernel/modules/SofaEngine/src/SofaEngine/BoxROI.cpp
+++ b/SofaKernel/modules/SofaEngine/src/SofaEngine/BoxROI.cpp
@@ -39,6 +39,8 @@ int BoxROIClass = core::RegisterObject("Find the primitives (vertex/edge/triangl
         ;
 
 template class SOFA_SOFAENGINE_API BoxROI<Vec3Types>;
+template class SOFA_SOFAENGINE_API BoxROI<Vec2Types>;
+template class SOFA_SOFAENGINE_API BoxROI<Vec1Types>;
 template class SOFA_SOFAENGINE_API BoxROI<Rigid3Types>;
 template class SOFA_SOFAENGINE_API BoxROI<Vec6Types>;
  

--- a/SofaKernel/modules/SofaEngine/src/SofaEngine/BoxROI.h
+++ b/SofaKernel/modules/SofaEngine/src/SofaEngine/BoxROI.h
@@ -190,6 +190,8 @@ protected:
 
 #if  !defined(SOFA_COMPONENT_ENGINE_BOXROI_CPP)
 extern template class SOFA_SOFAENGINE_API BoxROI<defaulttype::Vec3Types>;
+extern template class SOFA_SOFAENGINE_API BoxROI<defaulttype::Vec2Types>;
+extern template class SOFA_SOFAENGINE_API BoxROI<defaulttype::Vec1Types>;
 extern template class SOFA_SOFAENGINE_API BoxROI<defaulttype::Rigid3Types>;
 extern template class SOFA_SOFAENGINE_API BoxROI<defaulttype::Vec6Types>;
  

--- a/SofaKernel/modules/SofaEngine/src/SofaEngine/BoxROI.h
+++ b/SofaKernel/modules/SofaEngine/src/SofaEngine/BoxROI.h
@@ -171,7 +171,7 @@ protected:
     void computeOrientedBoxes();
 
     bool isPointInOrientedBox(const CPos& p, const OrientedBox& box);
-    bool isPointInAlignedBox(const typename DataTypes::CPos& p, const Vec6& box);
+    static bool isPointInAlignedBox(const typename DataTypes::CPos& p, const Vec6& box);
     bool isPointInBoxes(const CPos& p);
     bool isPointInBoxes(const PointID& pid);
     bool isEdgeInBoxes(const Edge& e);

--- a/examples/Components/engine/BoxROI_1d.scn
+++ b/examples/Components/engine/BoxROI_1d.scn
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+<Node name="root" gravity="9.81 0 0" dt="0.02">
+    <RequiredPlugin name="SofaEngine"/>
+    <RequiredPlugin name="SofaImplicitOdeSolver"/>
+    <RequiredPlugin name="SofaBoundaryCondition"/>
+    <RequiredPlugin name="SofaDeformable"/>
+
+    <VisualStyle displayFlags="showBehaviorModels showForceFields" />
+
+    <DefaultAnimationLoop/>
+    <DefaultVisualManagerLoop/>
+
+    <Node name="M1">
+        <EulerImplicitSolver name="odesolver" rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver template="CompressedRowSparseMatrixd" iterations="1000" threshold="1e-9" tolerance="1e-9"/>
+        <MechanicalObject template="Vec1d" showObject="true" showObjectScale="10"/>
+        <UniformMass vertexMass="1" />
+        <RegularGridTopology nx="21" ny="1" nz="1" xmin="0" xmax="20" ymin="0" ymax="0" zmin="0" zmax="0"/>
+        <BoxROI name="box" box="-0.1 -1e4 -1e4  0.1 1e4 1e4"/>
+        <FixedConstraint indices="@box.indices" />
+        <MeshSpringForceField stiffness="500"/>
+    </Node>
+</Node>

--- a/examples/Components/engine/BoxROI_2d.scn
+++ b/examples/Components/engine/BoxROI_2d.scn
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<Node name="root" gravity="0 -9.81 1" dt="0.02">
+    <VisualStyle displayFlags="showBehaviorModels showForceFields" />
+
+    <Node name="M1">
+        <EulerImplicitSolver name="odesolver" rayleighStiffness="0.1" rayleighMass="0.1" />
+        <CGLinearSolver template="CompressedRowSparseMatrixd" iterations="1000" threshold="1e-9" tolerance="1e-9"/>
+        <MechanicalObject template="Vec2d"/>
+        <UniformMass vertexMass="1" />
+        <RegularGridTopology nx="21" ny="5" nz="1" xmin="0" xmax="20" ymin="0" ymax="4" zmin="0" zmax="0"/>
+        <BoxROI name="box" box="-0.1 -0.1 -1e4  0.1 4.1 1e4"/>
+        <FixedConstraint indices="@box.indices" />
+        <MeshSpringForceField stiffness="10000"/>
+    </Node>
+</Node>

--- a/examples/Components/engine/BoxROI_2d.scn
+++ b/examples/Components/engine/BoxROI_2d.scn
@@ -1,6 +1,14 @@
 <?xml version="1.0" ?>
 <Node name="root" gravity="0 -9.81 1" dt="0.02">
+    <RequiredPlugin name="SofaEngine"/>
+    <RequiredPlugin name="SofaImplicitOdeSolver"/>
+    <RequiredPlugin name="SofaBoundaryCondition"/>
+    <RequiredPlugin name="SofaDeformable"/>
+
     <VisualStyle displayFlags="showBehaviorModels showForceFields" />
+
+    <DefaultAnimationLoop/>
+    <DefaultVisualManagerLoop/>
 
     <Node name="M1">
         <EulerImplicitSolver name="odesolver" rayleighStiffness="0.1" rayleighMass="0.1" />


### PR DESCRIPTION
BoxROI couln't be used in 2d or 1d scenes.
Examples are also added.
Note that with this PR, BoxROI still require a 3d box and inclusion algorithms still work in 3d, which means the dimensions that are not used in the mechanics are still used in BoxROI. That is why I put big numbers in the `box` filed in the examples.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
