### PR TITLE
[SofaEngine] Fix BoxROI undefined behavior

### DIFF
--- a/SofaKernel/modules/SofaEngine/src/SofaEngine/BoxROI.inl
+++ b/SofaKernel/modules/SofaEngine/src/SofaEngine/BoxROI.inl
@@ -133,6 +133,13 @@ template<class DataTypes>
 void BoxROI<DataTypes>::parse( sofa::core::objectmodel::BaseObjectDescription* arg )
 {
     Inherit1::parse(arg);
+
+    if constexpr (DataTypes::spatial_dimensions != 3)
+    {
+        static const std::string message = "\nOriented bounding boxes are not supported in " + std::to_string(DataTypes::spatial_dimensions) + "D";
+        d_orientedBoxes.setHelp(d_orientedBoxes.getHelp() + message);
+        msg_warning_when(d_orientedBoxes.isSet()) << message;
+    }
 }
 
 
@@ -314,6 +321,11 @@ void BoxROI<DataTypes>::reinit()
 template <class DataTypes>
 void BoxROI<DataTypes>::computeOrientedBoxes()
 {
+    if constexpr (DataTypes::spatial_dimensions != 3)
+    {
+        return;
+    }
+
     const vector<Vec10>& orientedBoxes = d_orientedBoxes.getValue();
 
     if(orientedBoxes.empty())
@@ -323,18 +335,18 @@ void BoxROI<DataTypes>::computeOrientedBoxes()
 
     for(unsigned int i=0; i<orientedBoxes.size(); i++)
     {
-        Vec10 box = orientedBoxes[i];
+        const Vec10& box = orientedBoxes[i];
 
-        Vec3 p0 = Vec3(box[0], box[1], box[2]);
-        Vec3 p1 = Vec3(box[3], box[4], box[5]);
-        Vec3 p2 = Vec3(box[6], box[7], box[8]);
+        const Vec3 p0 = Vec3(box[0], box[1], box[2]);
+        const Vec3 p1 = Vec3(box[3], box[4], box[5]);
+        const Vec3 p2 = Vec3(box[6], box[7], box[8]);
         double depth = box[9];
 
         Vec3 normal = (p1-p0).cross(p2-p0);
         normal.normalize();
 
-        Vec3 p3 = p0 + (p2-p1);
-        Vec3 p6 = p2 + normal * depth;
+        const Vec3 p3 = p0 + (p2-p1);
+        const Vec3 p6 = p2 + normal * depth;
 
         Vec3 plane0 = (p1-p0).cross(normal);
         plane0.normalize();
@@ -366,24 +378,30 @@ void BoxROI<DataTypes>::computeOrientedBoxes()
 template <class DataTypes>
 bool BoxROI<DataTypes>::isPointInOrientedBox(const typename DataTypes::CPos& point, const OrientedBox& box)
 {
-    Vec3 pv0 = Vec3(point[0]-box.p0[0], point[1]-box.p0[1], point[2]-box.p0[2]);
-    Vec3 pv1 = Vec3(point[0]-box.p2[0], point[1]-box.p2[1], point[2]-box.p2[2]);
-
-
-    if( fabs(dot(pv0, box.plane0)) <= box.width && fabs(dot(pv1, box.plane1)) <= box.width )
+    if constexpr (DataTypes::spatial_dimensions != 3)
     {
-        if ( fabs(dot(pv0, box.plane2)) <= box.length && fabs(dot(pv1, box.plane3)) <= box.length )
+        return false;
+    }
+    else
+    {
+        const Vec3 pv0 = Vec3(point[0]-box.p0[0], point[1]-box.p0[1], point[2]-box.p0[2]);
+        const Vec3 pv1 = Vec3(point[0]-box.p2[0], point[1]-box.p2[1], point[2]-box.p2[2]);
+
+        if( fabs(dot(pv0, box.plane0)) <= box.width && fabs(dot(pv1, box.plane1)) <= box.width )
         {
-            if ( !(fabs(dot(pv0, box.normal)) <= fabs(box.depth/2)) )
+            if ( fabs(dot(pv0, box.plane2)) <= box.length && fabs(dot(pv1, box.plane3)) <= box.length )
+            {
+                if ( !(fabs(dot(pv0, box.normal)) <= fabs(box.depth/2)) )
+                    return false;
+            }
+            else
                 return false;
         }
         else
             return false;
-    }
-    else
-        return false;
 
-    return true;
+        return true;
+    }
 }
 
 template <class DataTypes>
@@ -408,9 +426,12 @@ bool BoxROI<DataTypes>::isPointInBoxes(const typename DataTypes::CPos& p)
         if (isPointInAlignedBox(p, alignedBoxes[i]))
             return true;
 
-    for (unsigned int i=0; i<m_orientedBoxes.size(); ++i)
-        if (isPointInOrientedBox(p, m_orientedBoxes[i]))
-            return true;
+    if constexpr (DataTypes::spatial_dimensions == 3)
+    {
+        for (unsigned int i=0; i<m_orientedBoxes.size(); ++i)
+            if (isPointInOrientedBox(p, m_orientedBoxes[i]))
+                return true;
+    }
 
     return false;
 }

--- a/SofaKernel/modules/SofaEngine/src/SofaEngine/BoxROI.inl
+++ b/SofaKernel/modules/SofaEngine/src/SofaEngine/BoxROI.inl
@@ -133,13 +133,6 @@ template<class DataTypes>
 void BoxROI<DataTypes>::parse( sofa::core::objectmodel::BaseObjectDescription* arg )
 {
     Inherit1::parse(arg);
-
-    if constexpr (DataTypes::spatial_dimensions != 3)
-    {
-        static const std::string message = "\nOriented bounding boxes are not supported in " + std::to_string(DataTypes::spatial_dimensions) + "D";
-        d_orientedBoxes.setHelp(d_orientedBoxes.getHelp() + message);
-        msg_warning_when(d_orientedBoxes.isSet()) << message;
-    }
 }
 
 
@@ -303,6 +296,13 @@ void BoxROI<DataTypes>::init()
             if (alignedBoxes[bi][1] > alignedBoxes[bi][4]) std::swap(alignedBoxes[bi][1], alignedBoxes[bi][4]);
             if (alignedBoxes[bi][2] > alignedBoxes[bi][5]) std::swap(alignedBoxes[bi][2], alignedBoxes[bi][5]);
         }
+    }
+
+    if constexpr (DataTypes::spatial_dimensions != 3)
+    {
+        static const std::string message = "\nOriented bounding boxes are not supported in " + std::to_string(DataTypes::spatial_dimensions) + "D";
+        d_orientedBoxes.setHelp(d_orientedBoxes.getHelp() + message);
+        msg_warning_when(d_orientedBoxes.isSet()) << message;
     }
 
     computeOrientedBoxes();

--- a/SofaKernel/modules/SofaEngine/src/SofaEngine/BoxROI.inl
+++ b/SofaKernel/modules/SofaEngine/src/SofaEngine/BoxROI.inl
@@ -389,7 +389,14 @@ bool BoxROI<DataTypes>::isPointInOrientedBox(const typename DataTypes::CPos& poi
 template <class DataTypes>
 bool BoxROI<DataTypes>::isPointInAlignedBox(const typename DataTypes::CPos& p, const Vec6& box)
 {
-    return ( p[0] >= box[0] && p[0] <= box[3] && p[1] >= box[1] && p[1] <= box[4] && p[2] >= box[2] && p[2] <= box[5] );
+    for (std::size_t i = 0; i < DataTypes::spatial_dimensions; ++i)
+    {
+        if (p[i] < box[i] || p[i] > box[i + 3])
+        {
+            return false;
+        }
+    }
+    return true;
 }
 
 template <class DataTypes>


### PR DESCRIPTION
Since BoxROI supports 2D and 1D data types, it can lead to undefined behavior, due to out-of-range access.
This PR fixes them.
Oriented bounding box are not supported in 2D and 1D. A future PR could add the support in 2D.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
