### PR TITLE
[SofaBaseTopology] Create edges if not found

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyContainer.cpp
@@ -283,8 +283,11 @@ void TriangleSetTopologyContainer::createEdgesInTriangleArray()
                     msg_warning() << "Cannot find edge " << j
                         << " [" << t[(j + 1) % 3] << ", " << t[(j + 2) % 3] << "]"
                         << " from triangle " << i << " [" << t << "]" << " in edge list: edge is added to the list";
-                    sofa::helper::getWriteAccessor(d_edge)->emplace_back(std::min(t[(j + 1) % 3], t[(j + 2) % 3]), std::max(t[(j + 1) % 3], t[(j + 2) % 3]));
+                    const Edge e{std::min(t[(j + 1) % 3], t[(j + 2) % 3]), std::max(t[(j + 1) % 3], t[(j + 2) % 3])};
+                    sofa::helper::getWriteAccessor(d_edge)->emplace_back(e);
                     m_edgesInTriangle[i][j] = m_edge.size() - 1;
+                    edgesAroundVertexMap.insert(std::make_pair(e[0], (EdgeID)(m_edge.size() - 1)));
+                    edgesAroundVertexMap.insert(std::make_pair(e[1], (EdgeID)(m_edge.size() - 1)));
                     foundEdge = true;
                 }
             }

--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyContainer.cpp
@@ -280,12 +280,12 @@ void TriangleSetTopologyContainer::createEdgesInTriangleArray()
 
                 if (!foundEdge)
                 {
-                    msg_error() << "Cannot find edge " << j
+                    msg_warning() << "Cannot find edge " << j
                         << " [" << t[(j + 1) % 3] << ", " << t[(j + 2) % 3] << "]"
-                        << " in triangle " << i;
-                    m_edgesInTriangle.clear();
-                    this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
-                    return;
+                        << " from triangle " << i << " [" << t << "]" << " in edge list: edge is added to the list";
+                    sofa::helper::getWriteAccessor(d_edge)->emplace_back(std::min(t[(j + 1) % 3], t[(j + 2) % 3]), std::max(t[(j + 1) % 3], t[(j + 2) % 3]));
+                    m_edgesInTriangle[i][j] = m_edge.size() - 1;
+                    foundEdge = true;
                 }
             }
         }


### PR DESCRIPTION
Gmsh seems to export an edge list along with the tetrahedron list. This list is not the list of all the edges contained in the tetrahedrons, but only a subset (the most important?). See in the 'before' video what edges are exported.
When the topology is computed, it sees that a list of edges is already there. At some point, it loops over the edges in the triangles and cannot find an edge in the edge list. Which makes sense because the edge list is only a subset.
Instead of stopping and returning an error. I suggest to add the missing edges in the list.

Before:

https://user-images.githubusercontent.com/10572752/149795361-2bda98ea-3b3f-4ad0-bf72-eed7d3119360.mp4

After:


https://user-images.githubusercontent.com/10572752/149795490-b660cfea-ac5d-4804-b269-2eda829f6acf.mp4






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
