### PR TITLE
[SofaBaseLinearSolver] PoC: in-class Data initializers

### DIFF
--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/CGLinearSolver.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/CGLinearSolver.h
@@ -38,12 +38,22 @@ public:
     typedef TMatrix Matrix;
     typedef TVector Vector;
     typedef sofa::component::linearsolver::MatrixLinearSolver<TMatrix,TVector> Inherit;
+    typedef std::map<std::string,sofa::type::vector<SReal> > GraphType;
 
-    Data<unsigned> d_maxIter; ///< maximum number of iterations of the Conjugate Gradient solution
-    Data<SReal> d_tolerance; ///< desired precision of the Conjugate Gradient Solution (ratio of current residual norm over initial residual norm)
-    Data<SReal> d_smallDenominatorThreshold; ///< minimum value of the denominator in the conjugate Gradient solution
-    Data<bool> d_warmStart; ///< Use previous solution as initial solution
-    Data<std::map < std::string, sofa::type::vector<SReal> > > d_graph; ///< Graph of residuals at each iteration
+    Data<unsigned> d_maxIter
+    { initData(&d_maxIter, 25u, "iterations", "Maximum number of iterations of the Conjugate Gradient solution") };
+
+    Data<SReal> d_tolerance
+    { initData(&d_tolerance, SReal(1e-5), "tolerance", "Desired accuracy of the Conjugate Gradient solution evaluating: |r|²/|b|² (ratio of current residual norm over initial residual norm)") };
+
+    Data<SReal> d_smallDenominatorThreshold
+    { initData(&d_smallDenominatorThreshold, SReal(1e-5), "threshold", "Minimum value of the denominator (pT A p)^ in the conjugate Gradient solution") };
+
+    Data<bool> d_warmStart
+    { initData(&d_warmStart, bool(false), "warmStart", "Use previous solution as initial solution") };
+
+    Data<GraphType> d_graph
+    { initData(&d_graph, GraphType({}), "graph", "Graph of residuals at each iteration") };
 
 protected:
 

--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/CGLinearSolver.h
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/CGLinearSolver.h
@@ -40,18 +40,23 @@ public:
     typedef sofa::component::linearsolver::MatrixLinearSolver<TMatrix,TVector> Inherit;
     typedef std::map<std::string,sofa::type::vector<SReal> > GraphType;
 
+    /// maximum number of iterations of the Conjugate Gradient solution
     Data<unsigned> d_maxIter
     { initData(&d_maxIter, 25u, "iterations", "Maximum number of iterations of the Conjugate Gradient solution") };
 
+    /// desired precision of the Conjugate Gradient Solution (ratio of current residual norm over initial residual norm)
     Data<SReal> d_tolerance
     { initData(&d_tolerance, SReal(1e-5), "tolerance", "Desired accuracy of the Conjugate Gradient solution evaluating: |r|²/|b|² (ratio of current residual norm over initial residual norm)") };
 
+    /// minimum value of the denominator in the conjugate Gradient solution
     Data<SReal> d_smallDenominatorThreshold
     { initData(&d_smallDenominatorThreshold, SReal(1e-5), "threshold", "Minimum value of the denominator (pT A p)^ in the conjugate Gradient solution") };
 
+    /// Use previous solution as initial solution
     Data<bool> d_warmStart
     { initData(&d_warmStart, bool(false), "warmStart", "Use previous solution as initial solution") };
 
+    /// Graph of residuals at each iteration
     Data<GraphType> d_graph
     { initData(&d_graph, GraphType({}), "graph", "Graph of residuals at each iteration") };
 

--- a/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/CGLinearSolver.inl
+++ b/SofaKernel/modules/SofaBaseLinearSolver/src/SofaBaseLinearSolver/CGLinearSolver.inl
@@ -33,11 +33,6 @@ namespace sofa::component::linearsolver
 /// Linear system solver using the conjugate gradient iterative algorithm
 template<class TMatrix, class TVector>
 CGLinearSolver<TMatrix,TVector>::CGLinearSolver()
-    : d_maxIter( initData(&d_maxIter, 25u,"iterations","Maximum number of iterations of the Conjugate Gradient solution") )
-    , d_tolerance( initData(&d_tolerance,(SReal)1e-5,"tolerance","Desired accuracy of the Conjugate Gradient solution evaluating: |r|²/|b|² (ratio of current residual norm over initial residual norm)") )
-    , d_smallDenominatorThreshold( initData(&d_smallDenominatorThreshold,(SReal)1e-5,"threshold","Minimum value of the denominator (pT A p)^ in the conjugate Gradient solution") )
-    , d_warmStart( initData(&d_warmStart,false,"warmStart","Use previous solution as initial solution") )
-    , d_graph( initData(&d_graph,"graph","Graph of residuals at each iteration") )
 {
     d_graph.setWidget("graph");
     d_maxIter.setRequired(true);


### PR DESCRIPTION
The idea is to define component Data's where they are declared, usually in the header file. See https://isocpp.org/wiki/faq/cpp11-language-classes#member-init.

Pros:
- All pros described in https://isocpp.org/wiki/faq/cpp11-language-classes#member-init
- Data name, variable name and description are declared and defined at the same place. No more back and forth between the declaration and the constructor definition.
- No duplicates between Doxygen and Data description

Cons:
- A change in the definition leads to a re-compilation of the files including the header
- Does not solve https://github.com/sofa-framework/sofa/issues/274 or https://github.com/sofa-framework/sofa/issues/44

An evolution of this proof of concept will be proposed in another PR

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
