### PR TITLE
[SofaCUDA] Add support for NearestPointROI

### DIFF
--- a/applications/plugins/SofaCUDA/CMakeLists.txt
+++ b/applications/plugins/SofaCUDA/CMakeLists.txt
@@ -165,6 +165,7 @@ set(SOURCE_FILES
 
     sofa/gpu/cuda/CudaBeamLinearMapping.cpp
     sofa/gpu/cuda/CudaBoxROI.cpp
+    sofa/gpu/cuda/CudaNearestPointROI.cpp
     sofa/gpu/cuda/CudaSphereROI.cpp
 
     sofa/gpu/cuda/CudaExtraMonitor.cpp

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaNearestPointROI.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaNearestPointROI.cpp
@@ -19,7 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "CudaTypes.h"
+#include <sofa/gpu/cuda/CudaTypes.h>
 #include <sofa/core/ObjectFactory.h>
 #include <SofaGeneralEngine/NearestPointROI.inl>
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaNearestPointROI.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaNearestPointROI.cpp
@@ -1,0 +1,55 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include "CudaTypes.h"
+#include <sofa/core/ObjectFactory.h>
+#include <SofaGeneralEngine/NearestPointROI.inl>
+
+namespace sofa
+{
+
+namespace component::engine
+{
+
+template class SOFA_GPU_CUDA_API NearestPointROI<gpu::cuda::CudaVec3fTypes>;
+template class SOFA_GPU_CUDA_API NearestPointROI<gpu::cuda::CudaVec3f1Types>;
+#ifdef SOFA_GPU_CUDA_DOUBLE
+template class SOFA_GPU_CUDA_API NearestPointROI<gpu::cuda::CudaVec2dTypes>;
+template class SOFA_GPU_CUDA_API NearestPointROI<gpu::cuda::CudaVec3dTypes>;
+#endif // SOFA_GPU_CUDA_DOUBLE
+
+} // namespace component::engine
+
+namespace gpu::cuda
+{
+
+int NearestPointROICudaClass = core::RegisterObject("Supports GPU-side computations using CUDA")
+        .add< component::engine::NearestPointROI<CudaVec3fTypes> >()
+        .add< component::engine::NearestPointROI<CudaVec3f1Types> >()
+#ifdef SOFA_GPU_CUDA_DOUBLE
+        .add< component::engine::NearestPointROI<CudaVec3dTypes> >()
+        .add< component::engine::NearestPointROI<CudaVec3d1Types> >()
+#endif // SOFA_GPU_CUDA_DOUBLE
+        ;
+
+} // namespace gpu::cuda
+
+} // namespace sofa

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaNearestPointROI.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaNearestPointROI.cpp
@@ -32,8 +32,8 @@ namespace component::engine
 template class SOFA_GPU_CUDA_API NearestPointROI<gpu::cuda::CudaVec3fTypes>;
 template class SOFA_GPU_CUDA_API NearestPointROI<gpu::cuda::CudaVec3f1Types>;
 #ifdef SOFA_GPU_CUDA_DOUBLE
-template class SOFA_GPU_CUDA_API NearestPointROI<gpu::cuda::CudaVec2dTypes>;
 template class SOFA_GPU_CUDA_API NearestPointROI<gpu::cuda::CudaVec3dTypes>;
+template class SOFA_GPU_CUDA_API NearestPointROI<gpu::cuda::CudaVec3d1Types>;
 #endif // SOFA_GPU_CUDA_DOUBLE
 
 } // namespace component::engine


### PR DESCRIPTION
`NearestPointROI` is now compatible with 3d Cuda types. It is still executed on the CPU though.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
