### PR TITLE
[SofaCore] Fix invalid include in MappingHelper

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/MappingHelper.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/MappingHelper.h
@@ -20,7 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
-#include <SofaBaseMechanics/config.h>
+#include <sofa/core/config.h>
 
 #include <sofa/type/Vec.h>
 #include <sofa/defaulttype/RigidTypes.h>


### PR DESCRIPTION
A file in SofaCore wants to include something in SofaBaseMechanics (further in the dependency graph).
This was not throwing any error as only stuff from SofaBaseMechanics (and its siblings/children) was including this file, and this file contains only templated functions.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
