### PR TITLE
[SofaCUDA] Fix symbol definition at run time and compilation error

### DIFF
--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaConstantForceField.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaConstantForceField.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #include <SofaBoundaryCondition/ConstantForceField.inl>
 #include <sofa/core/ObjectFactory.h>
+#include <sofa/core/behavior/ForceField.inl>
 #include <sofa/gpu/cuda/CudaTypes.h>
 
 namespace sofa::gpu::cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTriangularFEMForceFieldOptim.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTriangularFEMForceFieldOptim.h
@@ -46,7 +46,7 @@ public:
     void reinit(Main* m)
     {
 
-        const Main::VecElement& triangles = m->l_topology.get()->getTriangles();
+        const typename Main::VecElement& triangles = m->l_topology.get()->getTriangles();
         helper::WriteAccessor< VecGPUTriangleInfo > gpuTriangleInfo = this->gpuTriangleInfo;
 
         gpuTriangleInfo.resize(triangles.size());


### PR DESCRIPTION
Fixed two things : 
- Compilation error in CudaTriangular[..]
- Undefined symbol while loading the plugin in CudaConstant[..] 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
