### PR TITLE
[SofaBaseVisual] Remove unused background setting in BaseCamera

### DIFF
--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/BaseCamera.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/BaseCamera.cpp
@@ -61,7 +61,6 @@ BaseCamera::BaseCamera()
     ,p_fixedLookAtPoint(initData(&p_fixedLookAtPoint, false, "fixedLookAt", "keep the lookAt point always fixed"))
     ,p_modelViewMatrix(initData(&p_modelViewMatrix,  "modelViewMatrix", "ModelView Matrix"))
     ,p_projectionMatrix(initData(&p_projectionMatrix,  "projectionMatrix", "Projection Matrix"))
-    ,l_background(initLink("backgroundSetting", "Link pointing to a BackgroundSetting object set the background parameters for this camera."))
     ,b_setDefaultParameters(false)
 {
     this->f_listening.setValue(true);

--- a/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/BaseCamera.h
+++ b/SofaKernel/modules/SofaBaseVisual/src/SofaBaseVisual/BaseCamera.h
@@ -22,7 +22,6 @@
 #pragma once
 #include <SofaBaseVisual/config.h>
 
-#include <SofaBaseVisual/BackgroundSetting.h>
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/type/Vec.h>
 #include <sofa/type/Ray.h>
@@ -88,9 +87,6 @@ public:
     
     Data<type::vector<SReal> > p_modelViewMatrix; ///< ModelView Matrix
     Data<type::vector<SReal> > p_projectionMatrix; ///< Projection Matrix
-
-    SingleLink<BaseCamera, sofa::component::configurationsetting::BackgroundSetting,
-               BaseLink::FLAG_STOREPATH> l_background ;
 
     BaseCamera();
     ~BaseCamera() override;


### PR DESCRIPTION
And remove dependency.

If you need to link a background (image/pix) to a camera (for a gui), I dont think the camera itself should be aware of it, but the GUI itself. (and it should then bear the dependency with BackgroundSetting)

(Could not find any use of it in the SOFA code base, or even in the plugins)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
