### PR TITLE
[SofaBaseTopology] Clearer error message

### DIFF
--- a/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyContainer.cpp
+++ b/SofaKernel/modules/SofaBaseTopology/src/SofaBaseTopology/TriangleSetTopologyContainer.cpp
@@ -282,7 +282,12 @@ void TriangleSetTopologyContainer::createEdgesInTriangleArray()
                 {
                     msg_error() << "Cannot find edge " << j
                         << " [" << t[(j + 1) % 3] << ", " << t[(j + 2) % 3] << "]"
-                        << " in triangle " << i;
+                        << " in triangle " << i << " [" << t << "]" << " in the provided edge list ("
+                        << this->d_edge.getLinkPath() << "). It shows an inconsistency between the edge list ("
+                        << this->d_edge.getLinkPath() << ") and the triangle list (" << this->d_triangle.getLinkPath()
+                        << "). Either fix the topology (probably in a mesh file), or provide only the triangle list to '"
+                        << this->getPathName() << "' and not the edges. In the latter case, the edge list will be "
+                        "computed from triangles.";
                     m_edgesInTriangle.clear();
                     this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
                     return;


### PR DESCRIPTION
The new message is:
```
[ERROR]   [TriangleSetTopologyContainer(topo)] Cannot find edge 0 [161, 158] in triangle 0 [0 161 158] in the provided edge list (@/vtk file/topo.edges). It shows an inconsistency between the edge list (@/vtk file/topo.edges) and the triangle list (@/vtk file/topo.triangles). Either fix the topology (probably in a mesh file), or provide only the triangle list to '/vtk file/topo' and not the edges. In the latter case, the edge list will be computed from triangles.
```

Previously it was:
```
[ERROR]   [TriangleSetTopologyContainer(topo)] Cannot find edge 0 [161, 158] in triangle 0
```

Fixes https://github.com/sofa-framework/sofa/issues/2636


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
