### PR TITLE
[SofaDefaultType] Speedup MapMapSparseMatrix

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/MultiVecId.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/MultiVecId.h
@@ -24,6 +24,8 @@
 
 #include <sofa/core/VecId.h>
 #include <sofa/core/objectmodel/Data.h>
+#include <map>
+
 namespace sofa
 {
 

--- a/SofaKernel/modules/SofaDefaultType/SofaDefaultType_test/MapMapSparseMatrixEigenUtils_test.cpp
+++ b/SofaKernel/modules/SofaDefaultType/SofaDefaultType_test/MapMapSparseMatrixEigenUtils_test.cpp
@@ -114,10 +114,14 @@ TEST(MapMapSparseMatrixEigenUtilsTest, checkConversionEigenSparseMapMapSparseVec
     int indexEntry = 0;
     for (auto row = mat.begin(); row != mat.end(); ++row)
     {
-
         for (auto col = row.begin(); col != row.end(); ++col)
         {
-            EXPECT_EQ( matEntries[indexEntry++].value(), col.val()[0]  );
+            EXPECT_NE(std::find_if(matEntries.begin(), matEntries.end(),
+                [&col, &row](const auto& el )
+                {
+                    return col.index() == el.col() && row.index() == col.row() && col.val().front() == el.value();
+                }), matEntries.end());
+            ++indexEntry;
         }
     }
 

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/MapMapSparseMatrix.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/MapMapSparseMatrix.h
@@ -22,7 +22,7 @@
 #ifndef SOFA_DEFAULTTYPE_MAPMAPSPARSEMATRIX_H
 #define SOFA_DEFAULTTYPE_MAPMAPSPARSEMATRIX_H
 
-#include <map>
+#include <unordered_map>
 #include <sofa/linearalgebra/BaseVector.h>
 
 namespace sofa
@@ -46,7 +46,7 @@ class MapMapSparseMatrix
 public:
     typedef T Data;
     typedef unsigned int KeyType;
-    typedef typename std::map< KeyType, T > RowType;
+    typedef typename std::unordered_map< KeyType, T > RowType;
 
     /// Removes every matrix elements
     void clear()
@@ -132,7 +132,7 @@ public:
 
 protected:
 
-    typedef std::map< KeyType, RowType > SparseMatrix;
+    typedef std::unordered_map< KeyType, RowType > SparseMatrix;
 
     /// Data container
     SparseMatrix m_data;

--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/MapMapSparseMatrixEigenUtils.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/MapMapSparseMatrixEigenUtils.h
@@ -35,14 +35,15 @@ namespace defaulttype
 
 
 template< class TBloc >
-struct MapMapSparseMatrixToEigenSparse
+class MapMapSparseMatrixToEigenSparse
 {
 
 };
 
 template <typename TVec, typename Real>
-struct MapMapSparseMatrixToEigenSparseVec 
+class MapMapSparseMatrixToEigenSparseVec
 {
+public:
     typedef MapMapSparseMatrix< TVec >                 TMapMapSparseMatrix;
     typedef Eigen::SparseMatrix<Real, Eigen::RowMajor> EigenSparseMatrix;
 
@@ -93,7 +94,7 @@ class MapMapSparseMatrixToEigenSparse< sofa::defaulttype::RigidDeriv<N, Real > >
 
 
 template< class TBloc >
-struct EigenSparseToMapMapSparseMatrix
+class EigenSparseToMapMapSparseMatrix
 {
 
 };

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/DistanceGrid.h
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/DistanceGrid.h
@@ -23,19 +23,14 @@
 #define SOFA_SOFADISTANCEGRID_DISTANCEGRID_H
 #include <SofaDistanceGrid/config.h>
 
+#include <map>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/helper/rmath.h>
 
 ///// Forward declaration
-namespace sofa
+namespace sofa::helper::io
 {
-    namespace helper
-    {
-        namespace io
-        {
-            class Mesh ;
-        }
-    }
+    class Mesh ;
 }
 
 


### PR DESCRIPTION
Change `std::map` for `std::unordered_map` in `MapMapSparseMatrix`.
It means the data is no longer processed in a predictable order. In most cases, it does not change anything since the data structure is converted to another. This conversion does not depend on the order.

Benchmarks from https://github.com/alxbilger/SofaBenchmark/pull/14 before:

```
---------------------------------------------------------------------------------
Benchmark                                       Time             CPU   Iterations
---------------------------------------------------------------------------------
BM_MapMapSparseMatrix_writeLine/512          3.28 us         3.22 us       213333
BM_MapMapSparseMatrix_writeLine/1024         15.8 us         16.0 us        44800
BM_MapMapSparseMatrix_writeLine/2048         49.6 us         50.0 us        10000
BM_MapMapSparseMatrix_writeLine/4096          112 us          109 us         5600
BM_MapMapSparseMatrix_addCol/512/512         1.77 ms         1.80 ms          407
BM_MapMapSparseMatrix_addCol/1024/512        3.54 ms         3.53 ms          195
BM_MapMapSparseMatrix_addCol/2048/512        7.01 ms         7.11 ms          112
BM_MapMapSparseMatrix_addCol/4096/512        14.1 ms         14.1 ms           50
BM_MapMapSparseMatrix_addCol/512/1024        5.74 ms         5.72 ms          112
BM_MapMapSparseMatrix_addCol/1024/1024       11.8 ms         11.7 ms           56
BM_MapMapSparseMatrix_addCol/2048/1024       23.4 ms         23.4 ms           30
BM_MapMapSparseMatrix_addCol/4096/1024       46.1 ms         46.9 ms           14
BM_MapMapSparseMatrix_addCol/512/2048        23.5 ms         23.4 ms           28
BM_MapMapSparseMatrix_addCol/1024/2048       46.2 ms         45.8 ms           15
BM_MapMapSparseMatrix_addCol/2048/2048       92.6 ms         93.8 ms            9
BM_MapMapSparseMatrix_addCol/4096/2048        187 ms          188 ms            4
BM_MapMapSparseMatrix_addCol/512/4096        59.8 ms         59.7 ms           11
BM_MapMapSparseMatrix_addCol/1024/4096        119 ms          120 ms            6
BM_MapMapSparseMatrix_addCol/2048/4096        238 ms          240 ms            3
BM_MapMapSparseMatrix_addCol/4096/4096        480 ms          477 ms            2
```


After:

```
---------------------------------------------------------------------------------
Benchmark                                       Time             CPU   Iterations
---------------------------------------------------------------------------------
BM_MapMapSparseMatrix_writeLine/512          1.48 us         1.46 us       448000
BM_MapMapSparseMatrix_writeLine/1024         2.95 us         2.95 us       248889
BM_MapMapSparseMatrix_writeLine/2048         6.29 us         6.28 us       112000
BM_MapMapSparseMatrix_writeLine/4096         12.0 us         12.0 us        64000
BM_MapMapSparseMatrix_addCol/512/512         1.08 ms         1.07 ms          640
BM_MapMapSparseMatrix_addCol/1024/512        2.26 ms         2.26 ms          373
BM_MapMapSparseMatrix_addCol/2048/512        3.45 ms         3.45 ms          195
BM_MapMapSparseMatrix_addCol/4096/512        6.93 ms         6.94 ms           90
BM_MapMapSparseMatrix_addCol/512/1024        1.68 ms         1.71 ms          448
BM_MapMapSparseMatrix_addCol/1024/1024       3.43 ms         3.37 ms          213
BM_MapMapSparseMatrix_addCol/2048/1024       6.65 ms         6.70 ms          112
BM_MapMapSparseMatrix_addCol/4096/1024       13.2 ms         13.1 ms           50
BM_MapMapSparseMatrix_addCol/512/2048        3.36 ms         3.37 ms          218
BM_MapMapSparseMatrix_addCol/1024/2048       6.44 ms         6.60 ms           90
BM_MapMapSparseMatrix_addCol/2048/2048       13.5 ms         13.4 ms           50
BM_MapMapSparseMatrix_addCol/4096/2048       27.1 ms         26.9 ms           25
BM_MapMapSparseMatrix_addCol/512/4096        6.64 ms         6.70 ms          112
BM_MapMapSparseMatrix_addCol/1024/4096       12.6 ms         12.6 ms           56
BM_MapMapSparseMatrix_addCol/2048/4096       26.0 ms         26.2 ms           28
BM_MapMapSparseMatrix_addCol/4096/4096       51.2 ms         51.6 ms           10
```

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
