### PR TITLE
[SofaGuiQt][WindowProfiler] Add root tree + show overhead

### DIFF
--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Simulation.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Simulation.cpp
@@ -60,6 +60,7 @@
 #include <cstring>
 
 #include <sofa/helper/logging/Messaging.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 
 #include <sofa/simulation/mechanicalvisitor/MechanicalProjectPositionAndVelocityVisitor.h>
 using sofa::simulation::mechanicalvisitor::MechanicalProjectPositionAndVelocityVisitor;
@@ -427,6 +428,8 @@ void Simulation::exportOBJ ( Node* root, const char* filename, bool exportMTL )
 
 void Simulation::dumpState ( Node* root, std::ofstream& out )
 {
+    sofa::helper::ScopedAdvancedTimer dumpStateTimer("dumpState");
+
     sofa::core::ExecParams* params = sofa::core::execparams::defaultInstance();
     out<<root->getTime() <<" ";
     WriteStateVisitor ( params, out ).execute ( root );

--- a/modules/SofaGuiCommon/src/sofa/gui/BaseGUI.cpp
+++ b/modules/SofaGuiCommon/src/sofa/gui/BaseGUI.cpp
@@ -37,6 +37,7 @@
 #include <cstring>
 
 #include <sofa/simulation/ExportGnuplotVisitor.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 
 using namespace sofa::simulation;
 using sofa::helper::system::FileSystem;
@@ -120,6 +121,8 @@ void BaseGUI::configureGUI(sofa::simulation::Node::SPtr groot)
 
 void BaseGUI::exportGnuplot(sofa::simulation::Node* node, std::string /*gnuplot_directory*/ )
 {
+    sofa::helper::ScopedAdvancedTimer exportGnuplotTimer("exportGnuplot");
+
     sofa::core::ExecParams* params = sofa::core::execparams::defaultInstance();
     ExportGnuplotVisitor expg ( params, node->getTime());
     node->execute ( expg );

--- a/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
@@ -66,6 +66,8 @@
 #include <sofa/simulation/DeactivatedNodeVisitor.h>
 #include <SofaBaseVisual/VisualStyle.h>
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
+
 #include <sofa/helper/system/SetDirectory.h>
 using sofa::helper::system::SetDirectory;
 
@@ -2371,6 +2373,8 @@ void RealGUI::redraw()
 void RealGUI::exportOBJ (simulation::Node* root,  bool exportMTL )
 {
     if ( !root ) return;
+
+    sofa::helper::ScopedAdvancedTimer exportOBJTimer("exportOBJ");
 
     std::string sceneFileName(this->windowFilePath ().toStdString());
     std::ostringstream ofilename;

--- a/modules/SofaGuiQt/src/sofa/gui/qt/SofaWindowProfiler.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/SofaWindowProfiler.cpp
@@ -198,6 +198,8 @@ bool SofaWindowProfiler::AnimationStepData::processData(const std::string& idStr
 {
     type::vector<Record> _records = sofa::helper::AdvancedTimer::getRecords(idString);
 
+    m_totalTimers = 0;
+
     //AnimationSubStepData* currentSubStep = nullptr;
     std::stack<AnimationSubStepData*> processStack;
     int level = 0;
@@ -254,6 +256,7 @@ bool SofaWindowProfiler::AnimationStepData::processData(const std::string& idStr
 
         if (rec.type == Record::REND || rec.type == Record::RSTEP_END)
         {
+            ++m_totalTimers;
             --level;
 //            for (int i=0; i<level; ++i)
 //                std::cout << ".";
@@ -603,6 +606,7 @@ void SofaWindowProfiler::updateSummaryLabels(int step)
     label_stepValue->setText(QString::number(stepData->m_stepIteration));
     label_timeValue->setText(QString::number(stepData->m_totalMs));
     label_overheadValue->setText(QString::number(stepData->m_overheadMs));
+    label_timersCounterValue->setText(QString::number(stepData->m_totalTimers));
 }
 
 void SofaWindowProfiler::updateTree(int step)

--- a/modules/SofaGuiQt/src/sofa/gui/qt/SofaWindowProfiler.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/SofaWindowProfiler.cpp
@@ -93,12 +93,6 @@ SReal convertInMs(ctime_t t, int nbIter=1)
     return 1000.0 * SReal(t) / SReal (timer_freqd * nbIter);
 }
 
-ctime_t convertInCTime(SReal timeInMs)
-{
-    static SReal timer_freqd = static_cast<SReal>(CTime::getTicksPerSec());
-    return timer_freqd * timeInMs / 1000.;
-}
-
 ///////////////////////////////////////// AnimationSubStepData ///////////////////////////////////
 
 SofaWindowProfiler::AnimationSubStepData::AnimationSubStepData(int level, std::string name, ctime_t start)

--- a/modules/SofaGuiQt/src/sofa/gui/qt/SofaWindowProfiler.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/SofaWindowProfiler.cpp
@@ -93,6 +93,12 @@ SReal convertInMs(ctime_t t, int nbIter=1)
     return 1000.0 * SReal(t) / SReal (timer_freqd * nbIter);
 }
 
+ctime_t convertInCTime(SReal timeInMs)
+{
+    static SReal timer_freqd = static_cast<SReal>(CTime::getTicksPerSec());
+    return timer_freqd * timeInMs / 1000.;
+}
+
 ///////////////////////////////////////// AnimationSubStepData ///////////////////////////////////
 
 SofaWindowProfiler::AnimationSubStepData::AnimationSubStepData(int level, std::string name, ctime_t start)
@@ -176,6 +182,8 @@ SReal SofaWindowProfiler::AnimationSubStepData::getStepMs(const std::string& ste
 SofaWindowProfiler::AnimationStepData::AnimationStepData(int step, const std::string& idString)
     : m_stepIteration(step)
     , m_totalMs(0.0)
+    , m_idString(idString)
+    , m_overheadMs(0.)
 {
     m_subSteps.clear();
     
@@ -278,11 +286,16 @@ bool SofaWindowProfiler::AnimationStepData::processData(const std::string& idStr
     m_totalMs = convertInMs(tEnd - t0);
 
     // update percentage
-    SReal invTotalMs = 100 / m_totalMs;
+    const SReal invTotalMs = 100. / m_totalMs;
+    SReal totalChildrenMs = 0.0;
     for (unsigned int i=0; i<m_subSteps.size(); i++)
     {
         m_subSteps[i]->computeTimeAndPercentage(invTotalMs);
+        totalChildrenMs += m_subSteps[i]->m_totalMs;
     }
+
+    m_selfMs = m_totalMs - totalChildrenMs;
+    m_selfPercent = 100. * m_selfMs / m_totalMs;
 
     return true;
 }
@@ -381,12 +394,16 @@ void SofaWindowProfiler::activateATimer(bool activate)
 
 void SofaWindowProfiler::pushStepData()
 {
+    const ctime_t start = CTime::getRefTime();
+
     m_profilingData.pop_front();
     const static std::string idString = "Animate";
     m_profilingData.push_back(new AnimationStepData(m_step, idString));
     m_step++;
 
     updateChart();
+
+    m_profilingData.back()->m_overheadMs = convertInMs(CTime::getRefTime() - start);
 }
 
 
@@ -591,6 +608,7 @@ void SofaWindowProfiler::updateSummaryLabels(int step)
     const AnimationStepData* stepData = m_profilingData.at(step);
     label_stepValue->setText(QString::number(stepData->m_stepIteration));
     label_timeValue->setText(QString::number(stepData->m_totalMs));
+    label_overheadValue->setText(QString::number(stepData->m_overheadMs));
 }
 
 void SofaWindowProfiler::updateTree(int step)
@@ -602,13 +620,9 @@ void SofaWindowProfiler::updateTree(int step)
     //clear old values
     tree_steps->clear();
 
-    // add new step items
-    QList<QTreeWidgetItem*> children;
-    for (auto* substep : stepData->m_subSteps)
-    {
-        children << addTreeItem(substep);
-    }
-    tree_steps->addTopLevelItems(children);
+    QList<QTreeWidgetItem*> root;
+    root << addTreeItem(stepData);
+    tree_steps->addTopLevelItems(root);
 
     //Expand the first two levels
     for (int i = 0; i < tree_steps->topLevelItemCount(); ++i)
@@ -665,6 +679,35 @@ QTreeWidgetItem* SofaWindowProfiler::addTreeItem(AnimationSubStepData* subStep)
     return treeItem;
 }
 
+QTreeWidgetItem* SofaWindowProfiler::addTreeItem(const AnimationStepData* step)
+{
+    QStringList columns;
+    columns << QString::fromStdString(step->m_idString);
+    columns << "100";
+    columns << QString::number(step->m_selfPercent, 'g', 2);
+    columns << QString::number(step->m_totalMs);
+    columns << QString::number(step->m_selfMs);
+
+    QTreeWidgetItem* treeItem = new QTreeWidgetItem(columns);
+
+    QFont font = QApplication::font();
+    font.setBold(true);
+
+    for (int i = 0; i<treeItem->columnCount(); i++)
+        treeItem->setFont(i, font);
+
+    // add new step items
+    QList<QTreeWidgetItem*> children;
+    for (auto* substep : step->m_subSteps)
+    {
+        children << addTreeItem(substep);
+    }
+
+    treeItem->addChildren(children);
+
+    return treeItem;
+}
+
 void SofaWindowProfiler::onStepSelected(QTreeWidgetItem *item, int /*column*/)
 {
     if (item->parent())
@@ -700,15 +743,19 @@ void SofaWindowProfiler::onStepSelected(QTreeWidgetItem *item, int /*column*/)
             m_checkedSeries.erase(it);
         }
 
-        int cpt = 0;
-        QVector<QPointF> seriesPoints;
-        for (auto* stepData : m_profilingData)
+        if (item->parent())
         {
-            const SReal value = stepData->getStepMs(m_selectedStep, m_selectedParentStep);
-            seriesPoints << QPointF(cpt++, value);
+            m_chart->addSeries(m_selectionSeries);
+            int cpt = 0;
+            QVector<QPointF> seriesPoints;
+            for (auto* stepData : m_profilingData)
+            {
+                const SReal value = stepData->getStepMs(m_selectedStep, m_selectedParentStep);
+                seriesPoints << QPointF(cpt++, value);
+            }
+            m_selectionSeries->replace(seriesPoints);
+            m_selectionSeries->setName(QString(m_selectedStep.c_str()));
         }
-        m_selectionSeries->replace(seriesPoints);
-        m_selectionSeries->setName(QString(m_selectedStep.c_str()));
     }
 }
 

--- a/modules/SofaGuiQt/src/sofa/gui/qt/SofaWindowProfiler.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/SofaWindowProfiler.h
@@ -158,6 +158,7 @@ public:
         AnimationStepData()
             : m_stepIteration(-1)
             , m_totalMs(0.0)
+            , m_overheadMs(0.)
         {}
 
         AnimationStepData(int step, const std::string& idString);
@@ -168,8 +169,14 @@ public:
         virtual ~AnimationStepData();
         int m_stepIteration;
         SReal m_totalMs;
+        SReal m_selfMs {}; ///< Difference between the total time and the time of all children
+        SReal m_selfPercent {}; ///< Difference between the total time and the time of all children as a percentage
+        std::string m_idString; ///< Name of the timer
 
         sofa::type::vector<AnimationSubStepData*> m_subSteps;
+
+        /// The overhead due to timers processing. In milliseconds
+        SReal m_overheadMs;
     protected:
         bool processData(const std::string& idString);
     };
@@ -184,6 +191,8 @@ protected:
     void updateChart();
     /// Method to add new QTreeWidgetItem item inside the QTreeWidget using the data from \sa AnimationSubStepData
     QTreeWidgetItem* addTreeItem(AnimationSubStepData* subStep);
+
+    QTreeWidgetItem* addTreeItem(const AnimationStepData* step);
 
 public slots:
     void closeEvent( QCloseEvent* ) override

--- a/modules/SofaGuiQt/src/sofa/gui/qt/SofaWindowProfiler.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/SofaWindowProfiler.h
@@ -177,6 +177,9 @@ public:
 
         /// The overhead due to timers processing. In milliseconds
         SReal m_overheadMs;
+
+        /// Total number of timers in this step
+        unsigned int m_totalTimers {};
     protected:
         bool processData(const std::string& idString);
     };

--- a/modules/SofaGuiQt/src/sofa/gui/qt/WindowProfiler.ui
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/WindowProfiler.ui
@@ -62,17 +62,27 @@
          </item>
          <item>
           <layout class="QGridLayout" name="Layout_summaryInfo">
-           <item row="0" column="1">
-            <widget class="QLabel" name="label_stepValue">
-             <property name="text">
-              <string>0</string>
-             </property>
-            </widget>
-           </item>
            <item row="0" column="0">
             <widget class="QLabel" name="label_stepN">
              <property name="text">
               <string>Step Number:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_overhead">
+             <property name="toolTip">
+              <string>Overhead due to the process of the timers. Close this window to avoid the overhead.</string>
+             </property>
+             <property name="text">
+              <string>Overhead (ms)</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLabel" name="label_stepValue">
+             <property name="text">
+              <string>0</string>
              </property>
             </widget>
            </item>
@@ -90,18 +100,25 @@
              </property>
             </widget>
            </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="label_overhead">
-             <property name="toolTip">
-              <string>Overhead due to the process of the timers. Close this window to avoid the overhead.</string>
-             </property>
+           <item row="2" column="1">
+            <widget class="QLabel" name="label_overheadValue">
              <property name="text">
-              <string>Overhead (ms)</string>
+              <string>0</string>
              </property>
             </widget>
            </item>
-           <item row="2" column="1">
-            <widget class="QLabel" name="label_overheadValue">
+           <item row="3" column="0">
+            <widget class="QLabel" name="label_timersCounter">
+             <property name="toolTip">
+              <string>Number of timers in the current step</string>
+             </property>
+             <property name="text">
+              <string>Timers Counter:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QLabel" name="label_timersCounterValue">
              <property name="text">
               <string>0</string>
              </property>

--- a/modules/SofaGuiQt/src/sofa/gui/qt/WindowProfiler.ui
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/WindowProfiler.ui
@@ -90,6 +90,23 @@
              </property>
             </widget>
            </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_overhead">
+             <property name="toolTip">
+              <string>Overhead due to the process of the timers. Close this window to avoid the overhead.</string>
+             </property>
+             <property name="text">
+              <string>Overhead (ms)</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QLabel" name="label_overheadValue">
+             <property name="text">
+              <string>0</string>
+             </property>
+            </widget>
+           </item>
           </layout>
          </item>
          <item>


### PR DESCRIPTION
The root tree is now displayed in the tree. Previously, only the root children were displayed. This root item provides more information about the time step: the time that has not been measured by timers (children). It's in the columns 'Self'. In the example, 3% of the step is not measured, corresponding to 1 ms.

The second addition is the overhead due to timers processing. It is displayed in the left panel. Here, it takes 10 ms to process the incoming timers and update the chart.

![image](https://user-images.githubusercontent.com/10572752/151393063-10d272a0-38d9-4c64-9a76-b326fb010e15.png)




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
