### PR TITLE
[examples] Speed up the falling cubes

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -453,7 +453,7 @@ public:
     /// The default implementation return the class name.
     ///
     /// This method should be used as follow :
-    /// \code  std::string type = Base::shortNam<B>(); \endcode
+    /// \code  std::string type = Base::shortName<B>(); \endcode
     /// This way derived classes can redefine the shortName method
     template< class T>
     static std::string shortName(const T* ptr = nullptr, BaseObjectDescription* = nullptr )

--- a/applications/plugins/MultiThreading/examples/ParallelBruteForceBroadPhase.scn
+++ b/applications/plugins/MultiThreading/examples/ParallelBruteForceBroadPhase.scn
@@ -12,16 +12,18 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
 
 
 <Node name="root" dt="0.01" gravity="0 -9.81 0">
-    <RequiredPlugin name="SofaOpenglVisual"/>
-    <RequiredPlugin name="SofaConstraint"/>
-    <RequiredPlugin name="SofaMeshCollision"/>
-    <RequiredPlugin name="SofaRigid"/>
-    <RequiredPlugin name="SofaImplicitOdeSolver"/>
-    <RequiredPlugin name="SofaLoader"/>
-    <RequiredPlugin name="SofaGeneralEngine"/>
-    <RequiredPlugin name='MultiThreading'/>
-    <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/>
-    <RequiredPlugin name="SofaMiscCollision"/>
+    <Node name="pluginList" />
+        <RequiredPlugin name="SofaOpenglVisual"/>
+        <RequiredPlugin name="SofaConstraint"/>
+        <RequiredPlugin name="SofaMeshCollision"/>
+        <RequiredPlugin name="SofaRigid"/>
+        <RequiredPlugin name="SofaImplicitOdeSolver"/>
+        <RequiredPlugin name="SofaLoader"/>
+        <RequiredPlugin name="SofaGeneralEngine"/>
+        <RequiredPlugin name='MultiThreading'/>
+        <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/>
+        <RequiredPlugin name="SofaMiscCollision"/>
+    </Node>
 
 
     <VisualStyle displayFlags="showBehavior showCollisionModels" />

--- a/applications/plugins/MultiThreading/examples/ParallelBruteForceBroadPhase.scn
+++ b/applications/plugins/MultiThreading/examples/ParallelBruteForceBroadPhase.scn
@@ -12,14 +12,16 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
 
 
 <Node name="root" dt="0.01" gravity="0 -9.81 0">
-    <RequiredPlugin pluginName="SofaOpenglVisual"/>
-    <RequiredPlugin pluginName='SofaConstraint'/>
-    <RequiredPlugin pluginName='SofaMeshCollision'/>
-    <RequiredPlugin pluginName='SofaRigid'/>
-    <RequiredPlugin pluginName='SofaImplicitOdeSolver'/>
-    <RequiredPlugin pluginName='SofaLoader'/>
-    <RequiredPlugin pluginName='SofaGeneralEngine'/>
-    <RequiredPlugin pluginName='MultiThreading'/>
+    <RequiredPlugin name="SofaOpenglVisual"/>
+    <RequiredPlugin name="SofaConstraint"/>
+    <RequiredPlugin name="SofaMeshCollision"/>
+    <RequiredPlugin name="SofaRigid"/>
+    <RequiredPlugin name="SofaImplicitOdeSolver"/>
+    <RequiredPlugin name="SofaLoader"/>
+    <RequiredPlugin name="SofaGeneralEngine"/>
+    <RequiredPlugin name='MultiThreading'/>
+    <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/>
+    <RequiredPlugin name="SofaMiscCollision"/>
 
 
     <VisualStyle displayFlags="showBehavior showCollisionModels" />
@@ -35,7 +37,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
 <!--    <BruteForceBroadPhase/>-->
 <!--    <BVHNarrowPhase/>-->
 
-    <LocalMinDistance name="Proximity" alarmDistance="0.2" contactDistance="0.09" angleCone="0.0" />
+    <NewProximityIntersection name="Proximity" alarmDistance="0.2" contactDistance="0.09" angleCone="0.0" />
     <DefaultContactManager name="Response" response="FrictionContactConstraint" />
     <LCPConstraintSolver maxIt="1000" tolerance="0.001"/>
     <!-- Using a rigid cube using collision triangles, lines and points  -->
@@ -49,20 +51,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.74819886067333 0.13000773132313 0.93028979372712" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -72,20 +61,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.3804729733991 0.77457089385696 0.27803373722268" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -95,20 +71,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.8670557578407 0.72764094440622 0.57778551223585" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -118,20 +81,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.52166113561097 5.0046672055054 0.10088881528978" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -141,20 +91,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.9450474625663 5.2738956775395 0.89534907690033" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -164,20 +101,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.305407303062 4.5237374729587 0.39064753911954" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -187,20 +111,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.071737911119935 9.523777224833 0.58510420731507" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -210,20 +121,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.0065867209372 9.9413022501121 0.37843590061107" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -233,20 +131,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.2205059766865 9.1447510035451 0.6489813419287" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -256,20 +141,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.45521484057196 13.636816443939 0.34713000261557" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -279,20 +151,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.7994200369806 13.985573250561 0.064533073019485" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -302,20 +161,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.7237247050385 13.884293768268 0.63587171194883" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -325,20 +171,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.93478864614609 18.345891356164 0.70599745712522" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -348,20 +181,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.321946673478 18.265142549884 0.52448542440519" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -371,20 +191,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.2815712151497 18.894561551928 0.31266520419748" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -394,20 +201,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.3549315493344 23.275718517963 0.24514779459925" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -417,20 +211,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.5063231964625 23.236317592085 0.37010838993364" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -440,20 +221,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.9298104769223 23.441940895255 0.67634991681033" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -463,20 +231,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.95332908441933 0.36214441310714 3.8638965107332" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -486,20 +241,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.8713179339521 0.72825660031673 4.4170562354462" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -509,20 +251,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.3623172698367 0.42303866540223 4.2916329795456" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -532,20 +261,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.41599076540023 5.011850300949 4.0764630770201" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -555,20 +271,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.1831578415274 4.5458585773808 3.657553949001" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -578,20 +281,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.3023503712855 5.2596857597864 4.4541927831965" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -601,20 +291,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.76817353431516 9.4053872043292 3.9015833886348" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -624,20 +301,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.2292593758224 9.1146520563004 3.6763078310417" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -647,20 +311,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.0779307592092 9.5021445925823 3.5487861833762" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -670,20 +321,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.95456032825381 14.079579005753 3.9779275546213" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -693,20 +331,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.523460344888 14.072634430869 3.847393618127" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -716,20 +341,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.147231008926 14.275786010444 4.385838838241" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -739,20 +351,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.033113344587904 18.947797390142 3.5628156732129" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -762,20 +361,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.1209282542676 18.712580375705 4.1972367044991" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -785,20 +371,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.4567343417819 18.837116944528 3.9945605623045" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -808,20 +381,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.45280707555488 22.736685181612 3.6824013070121" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -831,20 +391,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.2000142329838 22.655285063272 4.4546194779475" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -854,20 +401,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.2545063110322 23.301119732578 3.7903861488637" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -877,20 +411,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.15341132886401 0.16820048083002 7.5094929363157" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -900,20 +421,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.8576176000562 0.53452356138012 7.1683901088165" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -923,20 +431,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.0715503013095 0.51248217444517 7.0173420589498" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -946,20 +441,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.25969415216692 5.333801087846 7.2361134994943" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -969,20 +451,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.0694888157628 5.1161159149446 7.6208188285217" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -992,20 +461,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.5960498701763 4.9855055615704 7.3799518441688" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1015,20 +471,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.76430473093144 9.6086890309158 7.0650074975868" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1038,20 +481,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.8057373828747 9.1482642410082 7.4258274763943" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1061,20 +491,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.5454184466719 9.4156656071617 7.6357635323125" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1084,20 +501,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.27177981393029 13.737715651392 7.6596358635741" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1107,20 +511,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.3768386486344 14.108665051688 7.9202950656974" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1130,20 +521,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.6850976271951 13.885693371941 7.6036874165776" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1153,20 +531,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.73397222474868 18.105128143497 7.5915422609968" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1176,20 +541,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.5186291742225 18.128789600045 7.3756774833313" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1199,20 +551,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.1199427680671 18.613336643955 7.5970546564074" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1222,20 +561,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.87562178442051 23.386319402552 7.7875950596238" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1245,20 +571,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.0230774183399 22.973699588549 7.3888650198415" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1268,20 +581,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.1893345374564 23.204612573006 7.9542482183102" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1291,20 +591,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.70143965198725 0.46208797370181 11.339157561231" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1314,20 +601,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.5612233099813 0.76873835118894 10.7542899946" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1337,20 +611,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.8808409226503 0.47441122283899 10.761158771935" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1360,20 +621,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.20105870682795 5.2240685013701 11.228900610343" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1383,20 +631,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.7781574303648 5.1834110597537 11.499482400249" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1406,20 +641,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.378450799444 4.6493099369804 10.858263911846" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1429,20 +651,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.5189850952099 9.8197980647999 10.900365949795" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1452,20 +661,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.4804301839231 9.4211909856746 10.967158918952" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1475,20 +671,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.7952008055501 9.8081736153961 11.096402088458" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1498,20 +681,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.79275295687502 14.464405236284 10.748098089475" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1521,20 +691,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.6885991167224 13.893336361457 10.928832660163" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1544,20 +701,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.2408640437018 14.334363525191 11.055393364539" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1567,20 +711,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.71346587348425 18.499748504488 11.371397064939" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1590,20 +721,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.5899672480719 18.040807920527 10.888626934676" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1613,20 +731,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.2406462054889 18.491647830928 10.765999238596" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1636,20 +741,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.18580314292843 22.549640740757 10.934388120861" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1659,20 +751,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.1552629799839 23.388142889779 11.26025542466" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1682,20 +761,7 @@ On a CPU with 6 cores, each core tests 3906 pairs of collision models.
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.1060958626243 22.531728374321 11.242810407068" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection />
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 

--- a/applications/plugins/MultiThreading/src/MultiThreading/ParallelBVHNarrowPhase.cpp
+++ b/applications/plugins/MultiThreading/src/MultiThreading/ParallelBVHNarrowPhase.cpp
@@ -139,6 +139,9 @@ void ParallelBVHNarrowPhase::createOutput(
 
 void ParallelBVHNarrowPhase::initializeTopology(sofa::core::topology::BaseMeshTopology* topology)
 {
+    if (!topology)
+        return;
+
     auto insertionIt = m_initializedTopology.insert(topology);
     if (insertionIt.second)
     {
@@ -146,9 +149,18 @@ void ParallelBVHNarrowPhase::initializeTopology(sofa::core::topology::BaseMeshTo
         // Those arrays cannot be created on the fly, in a concurrent environment,
         // due to possible race conditions.
         // Depending on the scene graph, it is possible that those calls are not enough.
-        topology->getTrianglesAroundVertex(0);
-        topology->getEdgesInTriangle(0);
-        topology->getTrianglesAroundEdge(0);
+        if (topology->getNbPoints())
+        {
+            topology->getTrianglesAroundVertex(0);
+        }
+        if (topology->getNbTriangles())
+        {
+            topology->getEdgesInTriangle(0);
+        }
+        if (topology->getNbEdges())
+        {
+            topology->getTrianglesAroundEdge(0);
+        }
     }
 }
 

--- a/examples/Benchmark/Performance/benchmark_cubes.pscn
+++ b/examples/Benchmark/Performance/benchmark_cubes.pscn
@@ -2,15 +2,17 @@
 <?php echo '<!-- Generated from benchmark_cubes.pscn -->';?>
 
 <Node name="root" dt="0.01" gravity="0 -9.81 0">
-    <RequiredPlugin name="SofaOpenglVisual"/>
-    <RequiredPlugin name="SofaConstraint"/>
-    <RequiredPlugin name="SofaMeshCollision"/>
-    <RequiredPlugin name="SofaRigid"/>
-    <RequiredPlugin name="SofaImplicitOdeSolver"/>
-    <RequiredPlugin name="SofaLoader"/>
-    <RequiredPlugin name="SofaGeneralEngine"/>
-    <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/>
-    <RequiredPlugin name="SofaMiscCollision"/>
+    <Node name="pluginList"/>
+        <RequiredPlugin name="SofaOpenglVisual"/>
+        <RequiredPlugin name="SofaConstraint"/>
+        <RequiredPlugin name="SofaMeshCollision"/>
+        <RequiredPlugin name="SofaRigid"/>
+        <RequiredPlugin name="SofaImplicitOdeSolver"/>
+        <RequiredPlugin name="SofaLoader"/>
+        <RequiredPlugin name="SofaGeneralEngine"/>
+        <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/>
+        <RequiredPlugin name="SofaMiscCollision"/>
+    </Node>
 
 
     <VisualStyle displayFlags="showBehavior showCollisionModels" />

--- a/examples/Benchmark/Performance/benchmark_cubes.pscn
+++ b/examples/Benchmark/Performance/benchmark_cubes.pscn
@@ -2,13 +2,15 @@
 <?php echo '<!-- Generated from benchmark_cubes.pscn -->';?>
 
 <Node name="root" dt="0.01" gravity="0 -9.81 0">
-    <RequiredPlugin pluginName="SofaOpenglVisual"/>
-    <RequiredPlugin pluginName='SofaConstraint'/>
-    <RequiredPlugin pluginName='SofaMeshCollision'/>
-    <RequiredPlugin pluginName='SofaRigid'/>
-    <RequiredPlugin pluginName='SofaImplicitOdeSolver'/>
-    <RequiredPlugin pluginName='SofaLoader'/>
-    <RequiredPlugin pluginName='SofaGeneralEngine'/>
+    <RequiredPlugin name="SofaOpenglVisual"/>
+    <RequiredPlugin name="SofaConstraint"/>
+    <RequiredPlugin name="SofaMeshCollision"/>
+    <RequiredPlugin name="SofaRigid"/>
+    <RequiredPlugin name="SofaImplicitOdeSolver"/>
+    <RequiredPlugin name="SofaLoader"/>
+    <RequiredPlugin name="SofaGeneralEngine"/>
+    <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/>
+    <RequiredPlugin name="SofaMiscCollision"/>
 
 
     <VisualStyle displayFlags="showBehavior showCollisionModels" />
@@ -54,18 +56,11 @@
 
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
             <Node name="Collision Model">
                 <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
                 <MechanicalObject name="Collision_Cube" />
                 <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
+                <OBBCollisionModel/>
                 <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
             </Node>
         </Node>

--- a/examples/Benchmark/Performance/benchmark_cubes.scn
+++ b/examples/Benchmark/Performance/benchmark_cubes.scn
@@ -1,15 +1,17 @@
 <?xml version="1.0" ?>
 <!-- Generated from benchmark_cubes.pscn -->
 <Node name="root" dt="0.01" gravity="0 -9.81 0">
-    <RequiredPlugin name="SofaOpenglVisual"/>
-    <RequiredPlugin name="SofaConstraint"/>
-    <RequiredPlugin name="SofaMeshCollision"/>
-    <RequiredPlugin name="SofaRigid"/>
-    <RequiredPlugin name="SofaImplicitOdeSolver"/>
-    <RequiredPlugin name="SofaLoader"/>
-    <RequiredPlugin name="SofaGeneralEngine"/>
-    <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/>
-    <RequiredPlugin name="SofaMiscCollision"/>
+    <Node name="pluginList"/>
+        <RequiredPlugin name="SofaOpenglVisual"/>
+        <RequiredPlugin name="SofaConstraint"/>
+        <RequiredPlugin name="SofaMeshCollision"/>
+        <RequiredPlugin name="SofaRigid"/>
+        <RequiredPlugin name="SofaImplicitOdeSolver"/>
+        <RequiredPlugin name="SofaLoader"/>
+        <RequiredPlugin name="SofaGeneralEngine"/>
+        <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/>
+        <RequiredPlugin name="SofaMiscCollision"/>
+    </Node>
 
 
     <VisualStyle displayFlags="showBehavior showCollisionModels" />

--- a/examples/Benchmark/Performance/benchmark_cubes.scn
+++ b/examples/Benchmark/Performance/benchmark_cubes.scn
@@ -1,13 +1,15 @@
 <?xml version="1.0" ?>
 <!-- Generated from benchmark_cubes.pscn -->
 <Node name="root" dt="0.01" gravity="0 -9.81 0">
-    <RequiredPlugin pluginName="SofaOpenglVisual"/>
-    <RequiredPlugin pluginName='SofaConstraint'/>
-    <RequiredPlugin pluginName='SofaMeshCollision'/>
-    <RequiredPlugin pluginName='SofaRigid'/>
-    <RequiredPlugin pluginName='SofaImplicitOdeSolver'/>
-    <RequiredPlugin pluginName='SofaLoader'/>
-    <RequiredPlugin pluginName='SofaGeneralEngine'/>
+    <RequiredPlugin name="SofaOpenglVisual"/>
+    <RequiredPlugin name="SofaConstraint"/>
+    <RequiredPlugin name="SofaMeshCollision"/>
+    <RequiredPlugin name="SofaRigid"/>
+    <RequiredPlugin name="SofaImplicitOdeSolver"/>
+    <RequiredPlugin name="SofaLoader"/>
+    <RequiredPlugin name="SofaGeneralEngine"/>
+    <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/>
+    <RequiredPlugin name="SofaMiscCollision"/>
 
 
     <VisualStyle displayFlags="showBehavior showCollisionModels" />
@@ -18,10 +20,9 @@
     <DefaultPipeline name="CollisionPipeline" />
     <BruteForceBroadPhase/>
     <BVHNarrowPhase/>
-    <LocalMinDistance name="Proximity" alarmDistance="0.2" contactDistance="0.09" angleCone="0.0" />
+    <NewProximityIntersection name="Proximity" alarmDistance="0.2" contactDistance="0.09" angleCone="0.0" />
     <DefaultContactManager name="Response" response="FrictionContactConstraint" />
     <LCPConstraintSolver maxIt="1000" tolerance="0.001"  build_lcp="false"/>
-    <!-- Using a rigid cube using collision triangles, lines and points  -->
 
     <Node name="grid0">
 
@@ -33,20 +34,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.79651767564775 0.23534488828636 0.62856632593487" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -54,20 +42,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.3298019589064 0.90313527542312 0.56314962150676" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -75,20 +50,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.040631733388 0.60021829679619 0.69654145822699" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -96,20 +58,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.22556304429917 4.6633254267105 0.90770914447853" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -117,20 +66,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.7343778201539 5.3072580456768 0.074551252217289" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -138,20 +74,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.8949448763835 5.2974116689513 0.17577114197229" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -159,20 +82,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.90099986637989 9.2176064845257 0.50775879272621" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -180,20 +90,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.062696211302 9.8810689243866 0.5277417113668" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -201,20 +98,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.4209515910693 9.007395009048 0.681342001856" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -222,20 +106,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.005192205777947 13.750173297827 0.90410906444495" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -243,20 +114,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.994098104301 14.493326258843 0.53339270434035" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -264,20 +122,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.6230569820027 14.447623942489 0.16592024041615" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -285,20 +130,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.49724685842974 18.632081866093 0.86869300523246" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -306,20 +138,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.6350066080387 18.110523692849 0.27798229841421" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -327,20 +146,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.9811339708889 18.840672375094 0.72286798698961" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -348,20 +154,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.06368661488578 23.108215603795 0.72430901123411" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -369,20 +162,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.2475454969087 22.955908922691 0.94110363951936" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -390,20 +170,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.9986849152477 22.882033123347 0.92880002405904" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -411,20 +178,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.90492991353615 0.61495581251334 3.9056746691492" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -432,20 +186,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.2540228994349 0.30426315139246 3.5036937501299" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -453,20 +194,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.4032614093289 0.80336397225194 3.7280769726392" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -474,20 +202,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.2311619963642 4.9233211662729 4.3096789935649" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -495,20 +210,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.2380010754513 4.7720463328399 4.0542798585046" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -516,20 +218,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.1234578020514 4.7954820130465 4.0037744815945" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -537,20 +226,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.79285998632799 9.8976890481532 3.8774289485893" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -558,20 +234,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.7187772464095 9.523823458014 4.041411202653" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -579,20 +242,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.624497530807 9.8511557182535 3.8668896399284" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -600,20 +250,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.85963227313926 13.901258930285 3.99533380172" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -621,20 +258,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.2528582642567 13.633806005648 4.0736756960739" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -642,20 +266,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.3388524802117 14.207905129859 4.1100969927432" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -663,20 +274,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.38095528137915 18.720826869235 3.9899627298536" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -684,20 +282,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.9060738298139 18.87181822484 3.8123395844886" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -705,20 +290,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.3954623199047 18.310147769894 3.9674514180363" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -726,20 +298,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.82624955560372 22.718795680077 3.8855834269829" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -747,20 +306,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.397846069605 23.380261078887 3.7872952959907" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -768,20 +314,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.9129211008143 23.132203160148 4.0997577312401" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -789,20 +322,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.109141636225 0.98964954353387 7.1050366531615" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -810,20 +330,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.5282848710326 0.40631115781437 7.8483444069737" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -831,20 +338,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.4896466543384 0.42746051141408 7.8614615168709" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -852,20 +346,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.09942296431373 5.3124922960123 7.8807732243467" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -873,20 +354,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.0457056050867 4.5637058848812 7.1883953009678" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -894,20 +362,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.846233538746 4.9817758945198 7.7229976387336" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -915,20 +370,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.41505177710906 9.798281302116 7.6596170252467" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -936,20 +378,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.8209109917846 9.942342658966 7.0945688980141" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -957,20 +386,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.5247284814365 9.1244888683429 7.0357517991381" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -978,20 +394,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.37610916391765 14.054407390558 7.6828577936081" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -999,20 +402,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.7039565221425 14.283010485015 7.4883950010354" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1020,20 +410,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.784837009285 14.266542820151 7.9754339498353" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1041,20 +418,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.60978462435761 18.581848868905 7.3736439893831" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1062,20 +426,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.820304349214 18.232016320448 7.2924406874424" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1083,20 +434,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.8129227039464 18.797770145255 7.1637384962122" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1104,20 +442,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.65875774745772 23.39287385712 7.0489197336365" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1125,20 +450,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.1412463079399 23.485394549084 7.2261028132523" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1146,20 +458,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.5158917924929 23.06210657701 7.459417015528" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1167,20 +466,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.28941979039899 0.30964365522826 11.401663174341" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1188,20 +474,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.4977896241461 0.62403311888875 10.763085350517" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1209,20 +482,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.6118152456413 0.45218409199835 11.133681740441" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1230,20 +490,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.59610502403048 4.5344086932179 11.081000185842" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1251,20 +498,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.5233323271495 4.6680139699802 10.984344068675" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1272,20 +506,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.5471444346696 5.4112367648218 10.814558484738" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1293,20 +514,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.80446162019133 9.1277456503025 10.661886685138" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1314,20 +522,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.0016806840439 9.3237644775416 11.030315342606" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1335,20 +530,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.5544745915357 9.0530478274697 10.535105559991" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1356,20 +538,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.33053967465206 14.488772870502 11.315183723259" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1377,20 +546,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="3.8240462314915 14.084437524706 10.651789947018" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1398,20 +554,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.6727035411972 14.338479767944 10.791967782794" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1419,20 +562,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.032720559757538 18.218189485007 11.371878318429" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1440,20 +570,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.1337697765016 18.291751564151 10.728676719698" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1461,20 +578,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.6531143680462 18.784674598269 11.108104123086" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1482,20 +586,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="0.81810166864568 23.034771791443 10.559826741954" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1503,20 +594,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="4.2385477417794 22.953586567404 11.44155728628" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
 
@@ -1524,20 +602,7 @@
             <MechanicalObject name="Cube_RigidDOF" template="Rigid3d" translation="7.773801100335 22.523104810167 11.297833491488" />
             <UniformMass name="UniformMass" totalMass="10.0" />
             <UncoupledConstraintCorrection useOdeSolverIntegrationFactors="0"/>
-            <Node name="Visual Model">
-                <MeshOBJLoader name="myLoader" filename="mesh/cube.obj"/>
-                <OglModel name="Visual_Cube" src="@myLoader" color="1 1 0 1.0" />
-                <RigidMapping name="RigidMapping Visual-RigidDOF" input="@../Cube_RigidDOF" output="@Visual_Cube" />
-            </Node>
-            <Node name="Collision Model">
-                <MeshTopology name="Cube Mesh" filename="mesh/cube.obj" />
-                <MechanicalObject name="Collision_Cube" />
-                <!-- Collision Models -->
-                <TriangleCollisionModel name="Cube Triangle For Collision" />
-                <LineCollisionModel name="Cube Edge For Collision" />
-                <PointCollisionModel name="Cube Point For Collision" />
-                <RigidMapping name="RigidMapping Collision-RigidDOF" input="@../Cube_RigidDOF" output="@Collision_Cube" />
-            </Node>
+            <OBBCollisionModel/>
         </Node>
 
         


### PR DESCRIPTION
In the example of 72 falling cubes, mesh-based collision models are replaced by `OBBCollisionModel`, which is more suited for cubes.
I had to change from LocalMinDistance to NewProximityIntersection. It was the only intersection method supporting intersection between OBB and triangle. I tried adding it to LocalMinDistance, without success.
I also removed the visual models because we can see the cubes from the collision models.
The scene is at least twice faster.

I also added security guards in ParallelBVHNarrowPhase because of a crash I experienced. I did not investigate why this crash happens.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
