### PR TITLE
[SofaGeneralObjectInteraction] Fix dependencies in cmake

### DIFF
--- a/modules/SofaGeneralObjectInteraction/SofaGeneralObjectInteractionConfig.cmake.in
+++ b/modules/SofaGeneralObjectInteraction/SofaGeneralObjectInteractionConfig.cmake.in
@@ -3,7 +3,9 @@
 @PACKAGE_GUARD@
 @PACKAGE_INIT@
 
-find_package(SofaDeformable QUIET REQUIRED) # SofaDeformable
+find_package(SofaDeformable QUIET REQUIRED)
+find_package(SofaEngine QUIET REQUIRED)
+find_package(SofaGeneralEngine QUIET REQUIRED)
 
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
The cmake.in file for SofaGeneralObjectInteraction was missing the two news deps on SofaEngine and SofaGeneralEngine, following the PR on #2621 

Fix #2658
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
