### PR TITLE
[Sofa.LinearAlgebra] Fix SOFA_OPENMP

### DIFF
--- a/SofaKernel/modules/Sofa.LinearAlgebra/CMakeLists.txt
+++ b/SofaKernel/modules/Sofa.LinearAlgebra/CMakeLists.txt
@@ -20,7 +20,6 @@ set(HEADER_FILES
     ${SOFALINEARALGEBRASRC_ROOT}/CompressedRowSparseMatrix.h
     ${SOFALINEARALGEBRASRC_ROOT}/DiagonalMatrix.h
     ${SOFALINEARALGEBRASRC_ROOT}/EigenBaseSparseMatrix.h
-    ${SOFALINEARALGEBRASRC_ROOT}/EigenBaseSparseMatrix_MT.h
     ${SOFALINEARALGEBRASRC_ROOT}/EigenMatrixManipulator.h
     ${SOFALINEARALGEBRASRC_ROOT}/EigenSparseMatrix.h
     ${SOFALINEARALGEBRASRC_ROOT}/EigenVector.h
@@ -54,7 +53,9 @@ set(SOURCE_FILES
     ${SOFALINEARALGEBRASRC_ROOT}/init.cpp
 )
 
-if (SOFA_OPENMP AND "${EIGEN3_VERSION}" VERSION_LESS 3.2.9)
+sofa_find_package(Eigen3 REQUIRED)
+
+if (SOFA_OPENMP AND "${EIGEN3_VERSION}" VERSION_LESS 3.2.10)
     sofa_find_package(OpenMP BOTH_SCOPES) # will set/update SOFA_LINEARALGEBRA_HAVE_OPENMP
 endif()
 
@@ -62,13 +63,8 @@ if (SOFA_LINEARALGEBRA_HAVE_OPENMP)
     list(APPEND HEADER_FILES ${SOFALINEARALGEBRASRC_ROOT}/EigenBaseSparseMatrix_MT.h)
 endif()
 
-if (SOFA_LINEARALGEBRA_HAVE_OPENMP)
-    target_link_libraries(${PROJECT_NAME} PUBLIC OpenMP::OpenMP_CXX)
-endif()
-
 sofa_find_package(Sofa.Type REQUIRED)
 sofa_find_package(Sofa.Helper REQUIRED)
-sofa_find_package(Eigen3 REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 


### PR DESCRIPTION
` EIGEN3_VERSION` needed a `find_package` on Eigen before being used.
`target_link_libraries(${PROJECT_NAME} PUBLIC OpenMP::OpenMP_CXX)` is called twice, and the first time it's too early because the target is not defined yet.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
