### PR TITLE
[SofaCUDA] Clean Cuda Collision models

### DIFF
--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLineModel.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLineModel.cpp
@@ -19,20 +19,12 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "CudaTypes.h"
-#include "CudaTriangleModel.h"
+#include <sofa/gpu/cuda/CudaLineModel.h>
 #include <SofaMeshCollision/LineModel.inl>
 #include <sofa/core/ObjectFactory.h>
 
-namespace sofa
+namespace sofa::component::collision
 {
-
-namespace component
-{
-
-namespace collision
-{
-
 template class SOFA_GPU_CUDA_API LineCollisionModel<sofa::gpu::cuda::CudaVec3fTypes>;
 template class SOFA_GPU_CUDA_API LineCollisionModel<sofa::gpu::cuda::CudaVec3f1Types>;
 
@@ -41,17 +33,13 @@ template class SOFA_GPU_CUDA_API LineCollisionModel<sofa::gpu::cuda::CudaVec3dTy
 template class SOFA_GPU_CUDA_API LineCollisionModel<sofa::gpu::cuda::CudaVec3d1Types>;
 #endif // SOFA_GPU_CUDA_DOUBLE
 
-} // namespace collision
+} // namespace sofa::component::collision
 
-} // namespace component
 
-namespace gpu
+namespace sofa::gpu::cuda
 {
 
-namespace cuda
-{
-
-int LineModelCudaClass = core::RegisterObject("Supports GPU-side computations using CUDA")
+const int LineModelCudaClass = core::RegisterObject("Supports GPU-side computations using CUDA")
         .add< component::collision::LineCollisionModel<CudaVec3fTypes> >()
         .add< component::collision::LineCollisionModel<CudaVec3f1Types> >()
 #ifdef SOFA_GPU_CUDA_DOUBLE
@@ -60,8 +48,4 @@ int LineModelCudaClass = core::RegisterObject("Supports GPU-side computations us
 #endif // SOFA_GPU_CUDA_DOUBLE
         ;
 
-} // namespace cuda
-
-} // namespace gpu
-
-} // namespace sofa
+} // namespace sofa::gpu::cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLineModel.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLineModel.h
@@ -27,7 +27,9 @@
 namespace sofa::gpu::cuda
 {
 
-typedef sofa::component::collision::LineCollisionModel<CudaVec3fTypes> CudaLineModel;
-typedef sofa::component::collision::TLine<CudaVec3fTypes> CudaLine;
+using CudaLineCollisionModel = sofa::component::collision::LineCollisionModel<CudaVec3Types>;
+using CudaLineCollisionModelf1 = sofa::component::collision::LineCollisionModel<CudaVec3f1Types>;
+
+using CudaLine = sofa::component::collision::TLine<CudaVec3fTypes>;
 
 } // namespace sofa::gpu::cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLineModel.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLineModel.h
@@ -19,28 +19,15 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_GPU_CUDA_CUDALINEMODEL_H
-#define SOFA_GPU_CUDA_CUDALINEMODEL_H
+#pragma once
 
-#include "CudaTypes.h"
+#include <sofa/gpu/cuda/CudaTypes.h>
 #include <SofaMeshCollision/LineModel.h>
 
-namespace sofa
-{
-
-namespace gpu
-{
-
-namespace cuda
+namespace sofa::gpu::cuda
 {
 
 typedef sofa::component::collision::LineCollisionModel<CudaVec3fTypes> CudaLineModel;
 typedef sofa::component::collision::TLine<CudaVec3fTypes> CudaLine;
 
-} // namespace cuda
-
-} // namespace gpu
-
-} // namespace sofa
-
-#endif
+} // namespace sofa::gpu::cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLineModel.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLineModel.h
@@ -27,6 +27,9 @@
 namespace sofa::gpu::cuda
 {
 
+SOFA_CUDA_ATTRIBUTE_DEPRECATED("v22.06 (PR #2673)", "CudaLineCollisionModel")
+CudaDeprecatedAndRemoved CudaLineModel;
+
 using CudaLineCollisionModel = sofa::component::collision::LineCollisionModel<CudaVec3Types>;
 using CudaLineCollisionModelf1 = sofa::component::collision::LineCollisionModel<CudaVec3f1Types>;
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPointModel.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPointModel.cpp
@@ -19,20 +19,12 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "CudaPointModel.h"
+#include <sofa/gpu/cuda/CudaPointModel.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <SofaBaseCollision/CubeModel.h>
-#include <fstream>
-#include <sofa/gl/gl.h>
 
-namespace sofa
-{
-
-namespace gpu
-{
-
-namespace cuda
+namespace sofa::gpu::cuda
 {
 
 int CudaPointCollisionModelClass = core::RegisterObject("GPU-based point collision model using CUDA")
@@ -156,8 +148,4 @@ void CudaPointCollisionModel::computeBoundingTree(int maxDepth)
     }
 }
 
-} // namespace cuda
-
-} // namespace gpu
-
-} // namespace sofa
+} // namespace sofa::gpu::cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPointModel.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPointModel.h
@@ -19,11 +19,9 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_GPU_CUDA_CUDAPOINTCOLLISIONMODEL_H
-#define SOFA_GPU_CUDA_CUDAPOINTCOLLISIONMODEL_H
+#pragma once
 
-#include "CudaTypes.h"
-
+#include <sofa/gpu/cuda/CudaTypes.h>
 #include <sofa/core/CollisionModel.h>
 #include <SofaBaseMechanics/MechanicalObject.h>
 #include <sofa/defaulttype/VecTypes.h>
@@ -110,5 +108,3 @@ inline std::size_t CudaPoint::getSize()
 }
 
 } // namespace sofa::gpu::cuda
-
-#endif

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSphereModel.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSphereModel.cpp
@@ -19,16 +19,11 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "CudaSphereModel.h"
+#include <sofa/gpu/cuda/CudaSphereModel.h>
 #include <SofaBaseCollision/SphereModel.inl>
 #include <sofa/core/ObjectFactory.h>
-namespace sofa
-{
 
-namespace component
-{
-
-namespace collision
+namespace sofa::component::collision
 {
 
 template class SOFA_GPU_CUDA_API SphereCollisionModel<sofa::gpu::cuda::CudaVec3fTypes>;
@@ -38,17 +33,13 @@ template class SOFA_GPU_CUDA_API SphereCollisionModel<sofa::gpu::cuda::CudaVec3d
 template class SOFA_GPU_CUDA_API SphereCollisionModel<sofa::gpu::cuda::CudaVec3d1Types>;
 #endif // SOFA_GPU_CUDA_DOUBLE
 
-} // namespace collision
+} // namespace sofa::component::collision
 
-} // namespace component
 
-namespace gpu
+namespace sofa::gpu::cuda
 {
 
-namespace cuda
-{
-
-int CudaSphereModelClass = core::RegisterObject("Supports GPU-side computations using CUDA")
+const int CudaSphereModelClass = core::RegisterObject("Supports GPU-side computations using CUDA")
         .add< component::collision::SphereCollisionModel<CudaVec3fTypes> >()
         .add< component::collision::SphereCollisionModel<CudaVec3f1Types> >()
 #ifdef SOFA_GPU_CUDA_DOUBLE
@@ -58,8 +49,5 @@ int CudaSphereModelClass = core::RegisterObject("Supports GPU-side computations 
         .addAlias("CudaSphere")
         .addAlias("CudaSphereModel");
 
-} // namespace cuda
+} // namespace sofa::gpu::cuda
 
-} // namespace gpu
-
-} // namespace sofa

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSphereModel.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSphereModel.h
@@ -19,35 +19,21 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_GPU_CUDA_CUDASPHEREMODEL_H
-#define SOFA_GPU_CUDA_CUDASPHEREMODEL_H
+#pragma once
 
-#include "CudaTypes.h"
-
+#include <sofa/gpu/cuda/CudaTypes.h>
 #include <SofaBaseCollision/SphereModel.h>
 
-namespace sofa
+namespace sofa::gpu::cuda
 {
 
-namespace gpu
+//using CudaSphere = sofa::component::collision::TSphere<gpu::cuda::CudaVec3Types>;
+
+} // namespace sofa::gpu::cuda
+
+
+namespace sofa::component::collision
 {
-
-namespace cuda
-{
-
-using CudaSphere = sofa::component::collision::TSphere<gpu::cuda::CudaVec3Types>;
-
-
-} // namespace cuda
-
-} // namespace gpu
-
-
-namespace component
-{
-namespace collision
-{
-
 
 #if  !defined(SOFA_BUILD_GPU_CUDA)
 extern template class SOFA_GPU_CUDA_API sofa::component::collision::SphereCollisionModel<sofa::gpu::cuda::CudaVec3fTypes>;
@@ -58,11 +44,4 @@ extern template class SOFA_GPU_CUDA_API sofa::component::collision::SphereCollis
 #endif // SOFA_GPU_CUDA_DOUBLE
 #endif
 
-} // namespace collision
-
-} // namespace component
-
-
-} // namespace sofa
-
-#endif
+} // namespace sofa::component::collision

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSphereModel.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSphereModel.h
@@ -27,7 +27,10 @@
 namespace sofa::gpu::cuda
 {
 
-//using CudaSphere = sofa::component::collision::TSphere<gpu::cuda::CudaVec3Types>;
+using CudaSphereCollisionModel = sofa::component::collision::SphereCollisionModel<CudaVec3Types>;
+using CudaSphereCollisionModelf1 = sofa::component::collision::SphereCollisionModel<CudaVec3f1Types>;
+
+using CudaSphere = sofa::component::collision::TSphere<CudaVec3fTypes>;
 
 } // namespace sofa::gpu::cuda
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTriangleModel.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTriangleModel.cpp
@@ -19,18 +19,11 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "CudaTypes.h"
-#include "CudaTriangleModel.h"
+#include <sofa/gpu/cuda/CudaTriangleModel.h>
 #include <SofaMeshCollision/TriangleModel.inl>
 #include <sofa/core/ObjectFactory.h>
 
-namespace sofa
-{
-
-namespace component
-{
-
-namespace collision
+namespace sofa::component::collision
 {
 
 template class SOFA_GPU_CUDA_API TriangleCollisionModel<sofa::gpu::cuda::CudaVec3fTypes>;
@@ -40,17 +33,12 @@ template class SOFA_GPU_CUDA_API TriangleCollisionModel<sofa::gpu::cuda::CudaVec
 template class SOFA_GPU_CUDA_API TriangleCollisionModel<sofa::gpu::cuda::CudaVec3d1Types>;
 #endif // SOFA_GPU_CUDA_DOUBLE
 
-} // namespace collision
+} // namespace sofa::component::collision
 
-} // namespace component
-
-namespace gpu
+namespace sofa::gpu::cuda
 {
 
-namespace cuda
-{
-
-int TriangleModelCudaClass = core::RegisterObject("Supports GPU-side computations using CUDA")
+const int TriangleModelCudaClass = core::RegisterObject("Supports GPU-side computations using CUDA")
         .add< component::collision::TriangleCollisionModel<CudaVec3fTypes> >()
         .add< component::collision::TriangleCollisionModel<CudaVec3f1Types> >()
 #ifdef SOFA_GPU_CUDA_DOUBLE
@@ -59,8 +47,5 @@ int TriangleModelCudaClass = core::RegisterObject("Supports GPU-side computation
 #endif // SOFA_GPU_CUDA_DOUBLE
         ;
 
-} // namespace cuda
+} // namespace sofa::gpu::cuda
 
-} // namespace gpu
-
-} // namespace sofa

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTriangleModel.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTriangleModel.h
@@ -19,28 +19,15 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_GPU_CUDA_CUDATRIANGLEMODEL_H
-#define SOFA_GPU_CUDA_CUDATRIANGLEMODEL_H
+#pragma once
 
-#include "CudaTypes.h"
+#include <sofa/gpu/cuda/CudaTypes.h>
 #include <SofaMeshCollision/TriangleModel.h>
 
-namespace sofa
-{
-
-namespace gpu
-{
-
-namespace cuda
+namespace sofa::gpu::cuda
 {
 
 typedef sofa::component::collision::TriangleCollisionModel<CudaVec3fTypes> CudaTriangleModel;
 typedef sofa::component::collision::TTriangle<CudaVec3fTypes> CudaTriangle;
 
-} // namespace cuda
-
-} // namespace gpu
-
-} // namespace sofa
-
-#endif
+} // namespace sofa::gpu::cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTriangleModel.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTriangleModel.h
@@ -23,11 +23,14 @@
 
 #include <sofa/gpu/cuda/CudaTypes.h>
 #include <SofaMeshCollision/TriangleModel.h>
+#include <SofaMeshCollision/TriangleModel.inl>
 
 namespace sofa::gpu::cuda
 {
 
-typedef sofa::component::collision::TriangleCollisionModel<CudaVec3fTypes> CudaTriangleModel;
-typedef sofa::component::collision::TTriangle<CudaVec3fTypes> CudaTriangle;
+using CudaTriangleCollisionModel = sofa::component::collision::TriangleCollisionModel<CudaVec3Types>;
+using CudaTriangleCollisionModelf1 = sofa::component::collision::TriangleCollisionModel<CudaVec3f1Types>;
+
+using CudaTriangle = sofa::component::collision::TTriangle<CudaVec3fTypes>;
 
 } // namespace sofa::gpu::cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTriangleModel.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTriangleModel.h
@@ -28,6 +28,9 @@
 namespace sofa::gpu::cuda
 {
 
+SOFA_CUDA_ATTRIBUTE_DEPRECATED("v22.06 (PR #2673)", "CudaTriangleCollisionModel")
+CudaDeprecatedAndRemoved CudaTriangleModel;
+
 using CudaTriangleCollisionModel = sofa::component::collision::TriangleCollisionModel<CudaVec3Types>;
 using CudaTriangleCollisionModelf1 = sofa::component::collision::TriangleCollisionModel<CudaVec3f1Types>;
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTypes.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTypes.h
@@ -45,6 +45,14 @@ namespace gpu
 namespace cuda
 {
 
+// Empty class to be used to highlight deprecated objects in SofaCUDA plugin at compilation time.
+class CudaDeprecatedAndRemoved {};
+
+#define SOFA_CUDA_ATTRIBUTE_DEPRECATED(removeDate, toFixMsg) \
+    [[deprecated( \
+        "Has been DEPRECATED and removed since " removeDate ". " \
+        " To fix your code use " toFixMsg)]]
+
 template<typename T>
 struct DataTypeInfoManager
 {


### PR DESCRIPTION
Some cleaning in `CudaPointModel`, `CudaLineModel`, `CudaTriangleModel `and `CudaSphereModel`
and fix the ambiguity between Collision element model and collision element. for example:
`using CudaLine = sofa::component::collision::TLine<CudaVec3fTypes>; // collision element`
`using CudaLineCollisionModel = sofa::component::collision::LineCollisionModel<CudaVec3Types>; // collision element model`

No support of Cuda double for now.




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
