### PR TITLE
[SofaCUDA] harmless cleaning of namespace declaration and header inclusion

### DIFF
--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaCollision.cpp
@@ -47,17 +47,10 @@
 #include <sofa/core/Mapping.inl>
 #include <fstream>
 
-namespace sofa
-{
-
-namespace component
-{
-
-namespace collision
+namespace sofa::component::collision
 {
 
 using namespace sofa::gpu::cuda;
-
 
 template class SOFA_GPU_CUDA_API MouseInteractor<CudaVec3fTypes>;
 template class SOFA_GPU_CUDA_API TComponentMouseInteraction< CudaVec3fTypes >;
@@ -88,16 +81,10 @@ using FixParticlePerformerCuda3d = FixParticlePerformer<gpu::cuda::CudaVec3Types
 int triangleFixParticle = FixParticlePerformerCuda3d::RegisterSupportedModel<TriangleCollisionModel<gpu::cuda::Vec3Types>>(&FixParticlePerformerCuda3d::getFixationPointsTriangle<TriangleCollisionModel<gpu::cuda::Vec3Types>>);
 
 
-} //namespace collision
+} //namespace sofa::component::collision
 
 
-} //namespace component
-
-
-namespace gpu
-{
-
-namespace cuda
+namespace sofa::gpu::cuda
 {
 
 
@@ -137,8 +124,4 @@ int CudaProximityIntersectionClass = core::RegisterObject("GPGPU Proximity Inter
 
 sofa::helper::Creator<core::collision::Contact::Factory, component::collision::RayContact<sofa::component::collision::SphereCollisionModel<gpu::cuda::CudaVec3Types>> > RayCudaSphereContactClass("RayContact",true);
 
-} // namespace cuda
-
-} // namespace gpu
-
-} // namespace sofa
+} // namespace sofa::gpu::cuda

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaContactMapper.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaContactMapper.h
@@ -19,8 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_GPU_CUDA_CUDACONTACTMAPPER_H
-#define SOFA_GPU_CUDA_CUDACONTACTMAPPER_H
+#pragma once
 
 #include <SofaMeshCollision/BarycentricContactMapper.h>
 #include <SofaMeshCollision/RigidContactMapper.inl>
@@ -33,13 +32,8 @@
 #include <sofa/gpu/cuda/CudaSubsetMapping.h>
 
 
-namespace sofa
-{
 
-namespace gpu
-{
-
-namespace cuda
+namespace sofa::gpu::cuda
 {
 
 extern "C"
@@ -48,17 +42,14 @@ extern "C"
     void SubsetContactMapperCuda3f_setPoints1(unsigned int size, unsigned int nbTests, unsigned int maxPoints, unsigned int nbPointsPerElem, const void* tests, const void* contacts, void* map);
 }
 
-} // namespace cuda
+} // namespace sofa::gpu::cuda
 
-} // namespace gpu
 
-namespace component
-{
-
-namespace collision
+namespace sofa::component::collision
 {
 
 using namespace sofa::defaulttype;
+using namespace sofa::gpu::cuda;
 using sofa::core::collision::GPUDetectionOutputVector;
 
 
@@ -199,8 +190,6 @@ public:
 
 } // namespace collision
 
-} // namespace component
 
-} // namespace sofa
 
-#endif
+} // namespace sofa::component::collision

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaContactMapper.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaContactMapper.h
@@ -186,10 +186,4 @@ public:
     }
 };
 
-
-
-} // namespace collision
-
-
-
 } // namespace sofa::component::collision

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaIdentityMapping.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaIdentityMapping.cpp
@@ -22,27 +22,16 @@
 #ifndef SOFA_GPU_CUDA_CUDAIDENTITYMAPPING_CPP
 #define SOFA_GPU_CUDA_CUDAIDENTITYMAPPING_CPP
 
-#include "CudaTypes.h"
-#include "CudaIdentityMapping.inl"
-#include <sofa/core/ObjectFactory.h>
+#include <sofa/gpu/cuda/CudaTypes.h>
 #include <sofa/defaulttype/VecTypes.h>
-#include <sofa/core/behavior/MechanicalState.h>
-#include <sofa/core/Mapping.inl>
+#include <sofa/gpu/cuda/CudaIdentityMapping.inl>
+#include <sofa/core/ObjectFactory.h>
 
-namespace sofa
-{
-
-namespace component
-{
-
-namespace mapping
+namespace sofa::component::mapping
 {
 
 using namespace sofa::defaulttype;
-using namespace sofa::core;
-using namespace sofa::core::behavior;
 using namespace sofa::gpu::cuda;
-
 
 // CudaVec3fTypes
 template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3fTypes, CudaVec3fTypes>;
@@ -65,27 +54,18 @@ template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3dTypes, Vec3Types>;
 
 template class SOFA_GPU_CUDA_API  IdentityMapping< CudaVec3fTypes, CudaVec3dTypes>;
 template class SOFA_GPU_CUDA_API  IdentityMapping< Vec3Types, CudaVec3dTypes>;
-
-
 #endif
 
+} // namespace sofa::component::mapping
 
-} // namespace mapping
 
-} // namespace component
-
-namespace gpu
+namespace sofa::gpu::cuda
 {
 
-namespace cuda
-{
 using namespace sofa::defaulttype;
-using namespace sofa::core;
-using namespace sofa::core::behavior;
 using namespace sofa::component::mapping;
 
 int IdentityMappingCudaClass = core::RegisterObject("Supports GPU-side computations using CUDA")
-
     // CudaVec3fTypes
     .add< IdentityMapping< CudaVec3fTypes, CudaVec3fTypes> >()
     .add< IdentityMapping< CudaVec3fTypes, CudaVec3f1Types> >()
@@ -108,14 +88,8 @@ int IdentityMappingCudaClass = core::RegisterObject("Supports GPU-side computati
     .add< IdentityMapping< Vec3Types, CudaVec3dTypes> >()
 
 #endif
-        
-        ;
+    ;
 
-} // namespace cuda
-
-} // namespace gpu
-
-} // namespace sofa
-
+} // namespace sofa::gpu::cuda
 
 #endif // SOFA_GPU_CUDA_CUDAIDENTITYMAPPING_CPP

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaIdentityMapping.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaIdentityMapping.h
@@ -19,26 +19,13 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_GPU_CUDA_CUDAIDENTITYMAPPING_H
-#define SOFA_GPU_CUDA_CUDAIDENTITYMAPPING_H
+#pragma once
 
-#include "CudaTypes.h"
+#include <sofa/gpu/cuda/CudaTypes.h>
 #include <SofaBaseMechanics/IdentityMapping.h>
-#include <sofa/core/behavior/MechanicalState.h>
 
-namespace sofa
+namespace sofa::component::mapping
 {
-
-namespace component
-{
-
-namespace mapping
-{
-
-using namespace sofa::defaulttype;
-using namespace sofa::core;
-using namespace sofa::core::behavior;
-using namespace sofa::gpu::cuda;
 
 template <>
 inline void IdentityMapping<gpu::cuda::CudaVec3fTypes, gpu::cuda::CudaVec3fTypes>::apply( const core::MechanicalParams* mparams, OutDataVecCoord& dOut, const InDataVecCoord& dIn );
@@ -101,10 +88,4 @@ extern template class SOFA_GPU_CUDA_API  IdentityMapping< Vec3Types, CudaVec3dTy
 #endif
 
 
-} // namespace mapping
-
-} // namespace component
-
-} // namespace sofa
-
-#endif
+} // sofa::component::mapping

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaIdentityMapping.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaIdentityMapping.inl
@@ -19,19 +19,12 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_GPU_CUDA_CUDAIDENTITYMAPPING_INL
-#define SOFA_GPU_CUDA_CUDAIDENTITYMAPPING_INL
+#pragma once
 
-#include "CudaIdentityMapping.h"
+#include <sofa/gpu/cuda/CudaIdentityMapping.h>
 #include <SofaBaseMechanics/IdentityMapping.inl>
 
-namespace sofa
-{
-
-namespace gpu
-{
-
-namespace cuda
+namespace sofa::gpu::cuda
 {
 
 extern "C"
@@ -42,14 +35,9 @@ extern "C"
     void MechanicalObjectCudaVec3f1_vPEq(unsigned int size, void* res, const void* a);
 }
 
-} // namespace cuda
+} // namespace sofa::gpu::cuda
 
-} // namespace gpu
-
-namespace component
-{
-
-namespace mapping
+namespace sofa::component::mapping
 {
 
 using namespace sofa::defaulttype;
@@ -148,10 +136,4 @@ void IdentityMapping<gpu::cuda::CudaVec3f1Types, gpu::cuda::CudaVec3f1Types>::ap
 
 
 
-} // namespace mapping
-
-} // namespace component
-
-} // namespace sofa
-
-#endif
+} // namespace sofa::component::mapping

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSubsetMapping.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSubsetMapping.cpp
@@ -19,24 +19,15 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "CudaTypes.h"
-#include "CudaSubsetMapping.inl"
+#ifndef SOFA_GPU_CUDA_CUDASUBSETMAPPING_CPP
+#define SOFA_GPU_CUDA_CUDASUBSETMAPPING_CPP
+
+#include <sofa/gpu/cuda/CudaTypes.h>
+#include <sofa/gpu/cuda/CudaSubsetMapping.inl>
 #include <sofa/core/ObjectFactory.h>
-#include <sofa/defaulttype/VecTypes.h>
-#include <sofa/core/behavior/MechanicalState.h>
-#include <sofa/core/Mapping.inl>
 
-namespace sofa
+namespace sofa::component::mapping
 {
-
-namespace component
-{
-
-namespace mapping
-{
-using namespace sofa::defaulttype;
-using namespace sofa::core;
-using namespace sofa::core::behavior;
 using namespace sofa::gpu::cuda;
 
 template class SOFA_GPU_CUDA_API SubsetMapping< CudaVec3fTypes, CudaVec3fTypes >;
@@ -44,20 +35,10 @@ template class SOFA_GPU_CUDA_API SubsetMapping< CudaVec3f1Types, CudaVec3f1Types
 template class SOFA_GPU_CUDA_API SubsetMapping< CudaVec3f1Types, CudaVec3fTypes >;
 template class SOFA_GPU_CUDA_API SubsetMapping< CudaVec3fTypes, CudaVec3f1Types >;
 
+} // namespace sofa::component::mapping
 
-
-} // namespace mapping
-
-} // namespace component
-
-namespace gpu
+namespace sofa::gpu::cuda
 {
-
-namespace cuda
-{
-using namespace sofa::defaulttype;
-using namespace sofa::core;
-using namespace sofa::core::behavior;
 using namespace sofa::component::mapping;
 
 int SubsetMappingCudaClass = core::RegisterObject("Supports GPU-side computations using CUDA")
@@ -65,12 +46,8 @@ int SubsetMappingCudaClass = core::RegisterObject("Supports GPU-side computation
         .add< SubsetMapping< CudaVec3f1Types, CudaVec3f1Types > >()
         .add< SubsetMapping< CudaVec3f1Types, CudaVec3fTypes > >()
         .add< SubsetMapping< CudaVec3fTypes, CudaVec3f1Types > >()
-
-
         ;
 
-} // namespace cuda
+} // namespace sofa::gpu::cuda
 
-} // namespace gpu
-
-} // namespace sofa
+#endif // SOFA_GPU_CUDA_CUDASUBSETMAPPING_CPP

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSubsetMapping.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSubsetMapping.h
@@ -19,20 +19,12 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_GPU_CUDA_CUDASUBSETMAPPING_H
-#define SOFA_GPU_CUDA_CUDASUBSETMAPPING_H
+#pragma once
 
-#include "CudaTypes.h"
+#include <sofa/gpu/cuda/CudaTypes.h>
 #include <SofaBaseMechanics/SubsetMapping.h>
-#include <sofa/core/behavior/MechanicalState.h>
 
-namespace sofa
-{
-
-namespace component
-{
-
-namespace mapping
+namespace sofa::component::mapping
 {
 
 template <>
@@ -152,10 +144,12 @@ void SubsetMapping<gpu::cuda::CudaVec3fTypes, gpu::cuda::CudaVec3f1Types>::apply
 template <>
 void SubsetMapping<gpu::cuda::CudaVec3fTypes, gpu::cuda::CudaVec3f1Types>::applyJT( const core::MechanicalParams* mparams, InDataVecDeriv& dOut, const OutDataVecDeriv& dIn );
 
-} // namespace mapping
 
-} // namespace component
-
-} // namespace sofa
-
+#ifndef SOFA_GPU_CUDA_CUDASUBSETMAPPING_CPP
+extern template class SOFA_GPU_CUDA_API SubsetMapping< CudaVec3fTypes, CudaVec3fTypes >;
+extern template class SOFA_GPU_CUDA_API SubsetMapping< CudaVec3f1Types, CudaVec3f1Types >;
+extern template class SOFA_GPU_CUDA_API SubsetMapping< CudaVec3f1Types, CudaVec3fTypes >;
+extern template class SOFA_GPU_CUDA_API SubsetMapping< CudaVec3fTypes, CudaVec3f1Types >;
 #endif
+
+} // namespace sofa::component::mapping

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSubsetMapping.inl
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSubsetMapping.inl
@@ -19,21 +19,13 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_GPU_CUDA_CUDASUBSETMAPPING_INL
-#define SOFA_GPU_CUDA_CUDASUBSETMAPPING_INL
+#pragma once
 
-#include "CudaSubsetMapping.h"
+#include <sofa/gpu/cuda/CudaSubsetMapping.h>
 #include <SofaBaseMechanics/SubsetMapping.inl>
 #include <sofa/core/topology/TopologySubsetData.inl>
-#include <sofa/core/MechanicalParams.h>
 
-namespace sofa
-{
-
-namespace gpu
-{
-
-namespace cuda
+namespace sofa::gpu::cuda
 {
 
 extern "C"
@@ -59,16 +51,12 @@ extern "C"
     void SubsetMappingCuda3f_3f1_applyJT1(unsigned int size, const void* map, void* out, const void* in);
 }
 
-} // namespace cuda
+} // namespace sofa::gpu::cuda
 
-} // namespace gpu
 
-namespace component
+namespace sofa::component::mapping
 {
-
-namespace mapping
-{
-
+    
 using namespace gpu::cuda;
 
 template <>
@@ -265,10 +253,4 @@ void SubsetMapping<gpu::cuda::CudaVec3fTypes, gpu::cuda::CudaVec3f1Types>::apply
     dOut.endEdit();
 }
 
-} // namespace mapping
-
-} // namespace component
-
-} // namespace sofa
-
-#endif
+} // namespace sofa::component::mapping


### PR DESCRIPTION
Replace some \#ifndef by pragma, update some namespace and remove some relatives header inclusions in:
- CudaCollision
- CudaContactMapper
- CudaIdentityMapping
- CudaSubsetMapping



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
