### PR TITLE
[SofaCUDA] Add matrix3 transpose method on device

### DIFF
--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMath.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMath.h
@@ -626,6 +626,15 @@ public:
                      x.z * v.x.z + y.z * v.y.z + z.z * v.z.z );
     }
 
+    __device__ matrix3<real> transpose(matrix3<real> v)
+    {
+        matrix3<real> M;
+        M.x = CudaVec3<real>::make(v.x.x, v.y.x, v.z.x);
+        M.y = CudaVec3<real>::make(v.x.y, v.y.y, v.z.y);
+        M.z = CudaVec3<real>::make(v.x.z, v.y.z, v.z.z);
+        return M;
+    }
+
     __device__ real determinant(matrix3<real> v)
     {
         real det;

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMath.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMath.h
@@ -626,13 +626,11 @@ public:
                      x.z * v.x.z + y.z * v.y.z + z.z * v.z.z );
     }
 
-    __device__ matrix3<real> transpose(matrix3<real> v)
+    __device__ matrix3<real> transpose(const matrix3<real>& v) const
     {
-        matrix3<real> M;
-        M.x = CudaVec3<real>::make(v.x.x, v.y.x, v.z.x);
-        M.y = CudaVec3<real>::make(v.x.y, v.y.y, v.z.y);
-        M.z = CudaVec3<real>::make(v.x.z, v.y.z, v.z.z);
-        return M;
+        return make(v.x.x, v.y.x, v.z.x,
+                    v.x.y, v.y.y, v.z.y,
+                    v.x.z, v.y.z, v.z.z);
     }
 
     __device__ real determinant(matrix3<real> v)


### PR DESCRIPTION
transpose method was missing for matrix3 on device.
Not sure it is the best implementation but it does the job.

Will fix PR #2585 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
