### PR TITLE
[SofaBaseCollision] Fixed invalid vector bug in ContactListener

### DIFF
--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/ContactListener.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/ContactListener.cpp
@@ -89,7 +89,7 @@ void ContactListener::handleEvent( core::objectmodel::Event* _event )
                 {
                     if ( const type::vector<DetectionOutput>* contacts = dynamic_cast<type::vector<DetectionOutput>*>(it.second) )
                     {
-                        m_ContactsVector.push_back( contacts );
+                        m_ContactsVector.push_back( *contacts );
                     }
                 }
             }
@@ -106,7 +106,7 @@ void ContactListener::handleEvent( core::objectmodel::Event* _event )
                 {
                     if ( const type::vector<DetectionOutput>* contacts = dynamic_cast<type::vector<DetectionOutput>*>(it.second) )
                     {
-                        m_ContactsVector.push_back( contacts );
+                        m_ContactsVector.push_back( *contacts );
                     }
                 }
             }
@@ -119,7 +119,7 @@ sofa::Size ContactListener::getNumberOfContacts() const
 {
     if (!m_ContactsVectorBuffer.empty())
     {
-        const sofa::Size numberOfContacts = m_ContactsVectorBuffer[0][0].size();
+        const sofa::Size numberOfContacts = m_ContactsVectorBuffer[0].size();
         if (0 < numberOfContacts && ((numberOfContacts <= m_CollisionModel1->getSize()) || (numberOfContacts <= m_CollisionModel2->getSize()))){
             return numberOfContacts;
         }
@@ -138,7 +138,7 @@ type::vector<double> ContactListener::getDistances() const
     const sofa::Size numberOfContacts = getNumberOfContacts();
     if (0 < numberOfContacts){ // can be 0
         distances.reserve(numberOfContacts);
-        for (const auto& c: m_ContactsVectorBuffer[0][0]){
+        for (const auto& c: m_ContactsVectorBuffer[0]){
             distances.emplace_back(c.value);
         }
     }
@@ -151,7 +151,7 @@ std::vector<std::tuple<unsigned int, sofa::type::Vector3, unsigned int, sofa::ty
     const sofa::Size numberOfContacts = getNumberOfContacts();
     if (0 < numberOfContacts){ // can be 0
         contactPoints.reserve(numberOfContacts);
-        for (const auto& c: m_ContactsVectorBuffer[0][0]){
+        for (const auto& c: m_ContactsVectorBuffer[0]){
             unsigned int firstID = m_CollisionModel1 != c.elem.first.getCollisionModel();
             unsigned int secondID = !firstID;
             contactPoints.emplace_back(firstID, c.point[0], secondID, c.point[1]);
@@ -166,7 +166,7 @@ std::vector<std::tuple<unsigned int, unsigned int, unsigned int, unsigned int>> 
     const sofa::Size numberOfContacts = getNumberOfContacts();
     if (0 < numberOfContacts){ // can be 0
         contactElements.reserve(numberOfContacts);
-        for (const auto& c: m_ContactsVectorBuffer[0][0]){
+        for (const auto& c: m_ContactsVectorBuffer[0]){
             unsigned int firstID = m_CollisionModel1 != c.elem.first.getCollisionModel();
             unsigned int secondID = !firstID;
             contactElements.emplace_back(firstID, c.elem.first.getIndex(), secondID, c.elem.second.getIndex());
@@ -175,7 +175,7 @@ std::vector<std::tuple<unsigned int, unsigned int, unsigned int, unsigned int>> 
     return contactElements;
 }
 
-type::vector<const type::vector<DetectionOutput>* > ContactListener::getContactsVector() const
+type::vector<type::vector<DetectionOutput>> ContactListener::getContactsVector() const
 {
     return m_ContactsVector;
 }

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/ContactListener.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/ContactListener.cpp
@@ -62,7 +62,7 @@ void ContactListener::handleEvent( core::objectmodel::Event* _event )
 {
     if (simulation::CollisionBeginEvent::checkEventType(_event))
     {
-        m_ContactsVectorBuffer = m_ContactsVector;
+        m_ContactsVector.swap(m_ContactsVectorBuffer);
         m_ContactsVector.clear();
     }
 
@@ -138,12 +138,7 @@ type::vector<double> ContactListener::getDistances() const
     const sofa::Size numberOfContacts = getNumberOfContacts();
     if (0 < numberOfContacts){ // can be 0
         distances.reserve(numberOfContacts);
-        unsigned int counter = 0; // loop over m_ContactsVectorBuffer seems to be invalid sometimes (values way bigger that numberOfContacts)
         for (const auto& c: m_ContactsVectorBuffer[0][0]){
-            if (++counter > numberOfContacts) {
-                printf("Encountered invalid ContactsVector in ContactListener!\n");
-                break;
-            }
             distances.emplace_back(c.value);
         }
     }
@@ -156,12 +151,7 @@ std::vector<std::tuple<unsigned int, sofa::type::Vector3, unsigned int, sofa::ty
     const sofa::Size numberOfContacts = getNumberOfContacts();
     if (0 < numberOfContacts){ // can be 0
         contactPoints.reserve(numberOfContacts);
-        unsigned int counter = 0; // loop over m_ContactsVectorBuffer seems to be invalid sometimes (values way bigger that numberOfContacts)
         for (const auto& c: m_ContactsVectorBuffer[0][0]){
-            if (++counter > numberOfContacts) {
-                printf("Encountered invalid ContactsVector in ContactListener!\n");
-                break;
-            }
             unsigned int firstID = m_CollisionModel1 != c.elem.first.getCollisionModel();
             unsigned int secondID = !firstID;
             contactPoints.emplace_back(firstID, c.point[0], secondID, c.point[1]);
@@ -176,12 +166,7 @@ std::vector<std::tuple<unsigned int, unsigned int, unsigned int, unsigned int>> 
     const sofa::Size numberOfContacts = getNumberOfContacts();
     if (0 < numberOfContacts){ // can be 0
         contactElements.reserve(numberOfContacts);
-        unsigned int counter = 0; // loop over m_ContactsVectorBuffer seems to be invalid sometimes (values way bigger that numberOfContacts)
         for (const auto& c: m_ContactsVectorBuffer[0][0]){
-            if (++counter > numberOfContacts) {
-                printf("Encountered invalid ContactsVector in ContactListener!\n");
-                break;
-            }
             unsigned int firstID = m_CollisionModel1 != c.elem.first.getCollisionModel();
             unsigned int secondID = !firstID;
             contactElements.emplace_back(firstID, c.elem.first.getIndex(), secondID, c.elem.second.getIndex());

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/ContactListener.cpp
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/ContactListener.cpp
@@ -138,7 +138,12 @@ type::vector<double> ContactListener::getDistances() const
     const sofa::Size numberOfContacts = getNumberOfContacts();
     if (0 < numberOfContacts){ // can be 0
         distances.reserve(numberOfContacts);
+        unsigned int counter = 0; // loop over m_ContactsVectorBuffer seems to be invalid sometimes (values way bigger that numberOfContacts)
         for (const auto& c: m_ContactsVectorBuffer[0][0]){
+            if (++counter > numberOfContacts) {
+                printf("Encountered invalid ContactsVector in ContactListener!\n");
+                break;
+            }
             distances.emplace_back(c.value);
         }
     }
@@ -151,7 +156,12 @@ std::vector<std::tuple<unsigned int, sofa::type::Vector3, unsigned int, sofa::ty
     const sofa::Size numberOfContacts = getNumberOfContacts();
     if (0 < numberOfContacts){ // can be 0
         contactPoints.reserve(numberOfContacts);
+        unsigned int counter = 0; // loop over m_ContactsVectorBuffer seems to be invalid sometimes (values way bigger that numberOfContacts)
         for (const auto& c: m_ContactsVectorBuffer[0][0]){
+            if (++counter > numberOfContacts) {
+                printf("Encountered invalid ContactsVector in ContactListener!\n");
+                break;
+            }
             unsigned int firstID = m_CollisionModel1 != c.elem.first.getCollisionModel();
             unsigned int secondID = !firstID;
             contactPoints.emplace_back(firstID, c.point[0], secondID, c.point[1]);
@@ -166,7 +176,12 @@ std::vector<std::tuple<unsigned int, unsigned int, unsigned int, unsigned int>> 
     const sofa::Size numberOfContacts = getNumberOfContacts();
     if (0 < numberOfContacts){ // can be 0
         contactElements.reserve(numberOfContacts);
+        unsigned int counter = 0; // loop over m_ContactsVectorBuffer seems to be invalid sometimes (values way bigger that numberOfContacts)
         for (const auto& c: m_ContactsVectorBuffer[0][0]){
+            if (++counter > numberOfContacts) {
+                printf("Encountered invalid ContactsVector in ContactListener!\n");
+                break;
+            }
             unsigned int firstID = m_CollisionModel1 != c.elem.first.getCollisionModel();
             unsigned int secondID = !firstID;
             contactElements.emplace_back(firstID, c.elem.first.getIndex(), secondID, c.elem.second.getIndex());

--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/ContactListener.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/ContactListener.h
@@ -50,8 +50,6 @@ public:
 
     void init(void) override;
 
-    virtual void beginContact(const type::vector<const type::vector<DetectionOutput>* >& ) {}
-    virtual void endContact(void*) {}
 
     void handleEvent( core::objectmodel::Event* event ) override;
 
@@ -62,7 +60,7 @@ public:
     type::vector<double> getDistances() const;
 
     // Returns the full ContactsVector
-    type::vector<const type::vector<DetectionOutput>* > getContactsVector() const;
+    type::vector<type::vector<DetectionOutput>> getContactsVector() const;
 
     // Returns the contact points in the form of a vector of tuples containing two positive integers and two Vector3.
     // The Vector3 store the X, Y, Z coordinates of the points in contact
@@ -157,9 +155,12 @@ protected:
     const CollisionModel* m_CollisionModel2;
 
 private:
-    type::vector<const type::vector<DetectionOutput>* > m_ContactsVector;
-    type::vector<const type::vector<DetectionOutput>* > m_ContactsVectorBuffer;
+    type::vector<type::vector<DetectionOutput>> m_ContactsVector;
+    type::vector<type::vector<DetectionOutput>> m_ContactsVectorBuffer;
     core::collision::NarrowPhaseDetection* m_NarrowPhase;
+
+    virtual void beginContact(const type::vector<type::vector<DetectionOutput>>& ) {}
+    virtual void endContact(void*) {}
 };
 
 } // namespace sofa::core::collision


### PR DESCRIPTION
Sometimes (every few thousand occurrences) the vector becomes invalid between getting its length and iterating over it. 

This error was first described in https://www.sofa-framework.org/community/forum/topic/m_contactsvectorbuffer-not-valid-sometimes/.

Now swapping the contents and the error does not occur anymore.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
