### PR TITLE
[all] Fix missing #include config.h or invalid ordering that disturb the factory's getTarget() to operate properly.

### DIFF
--- a/Component/IO/Mesh/src/sofa/component/io/mesh/GIDMeshLoader.cpp
+++ b/Component/IO/Mesh/src/sofa/component/io/mesh/GIDMeshLoader.cpp
@@ -23,8 +23,8 @@
 #include <string>
 #include <fstream>
 
-#include <sofa/core/ObjectFactory.h>
 #include <sofa/component/io/mesh/GIDMeshLoader.h>
+#include <sofa/core/ObjectFactory.h>
 
 using namespace sofa::helper;
 

--- a/Component/IO/Mesh/src/sofa/component/io/mesh/GridMeshCreator.cpp
+++ b/Component/IO/Mesh/src/sofa/component/io/mesh/GridMeshCreator.cpp
@@ -19,9 +19,9 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <sofa/core/ObjectFactory.h>
 #include <sofa/component/io/mesh/GridMeshCreator.h>
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/core/ObjectFactory.h>
 
 namespace sofa::component::io::mesh
 {

--- a/Component/IO/Mesh/src/sofa/component/io/mesh/MeshGmshLoader.cpp
+++ b/Component/IO/Mesh/src/sofa/component/io/mesh/MeshGmshLoader.cpp
@@ -19,6 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <sofa/component/io/mesh/config.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/component/io/mesh/MeshGmshLoader.h>
 #include <sofa/core/visual/VisualParams.h>

--- a/Component/IO/Mesh/src/sofa/component/io/mesh/MeshOffLoader.cpp
+++ b/Component/IO/Mesh/src/sofa/component/io/mesh/MeshOffLoader.cpp
@@ -19,9 +19,9 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <sofa/core/ObjectFactory.h>
 #include <sofa/component/io/mesh/MeshOffLoader.h>
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/core/ObjectFactory.h>
 #include <fstream>
 
 namespace sofa::component::io::mesh

--- a/Component/IO/Mesh/src/sofa/component/io/mesh/MeshSTLLoader.cpp
+++ b/Component/IO/Mesh/src/sofa/component/io/mesh/MeshSTLLoader.cpp
@@ -19,10 +19,10 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <sofa/core/ObjectFactory.h>
-#include <sofa/helper/system/FileRepository.h>
 #include <sofa/component/io/mesh/MeshSTLLoader.h>
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/core/ObjectFactory.h>
+#include <sofa/helper/system/FileRepository.h>
 
 #include <iostream>
 #include <fstream>

--- a/Component/IO/Mesh/src/sofa/component/io/mesh/MeshTrianLoader.cpp
+++ b/Component/IO/Mesh/src/sofa/component/io/mesh/MeshTrianLoader.cpp
@@ -19,9 +19,9 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <sofa/core/ObjectFactory.h>
 #include <sofa/component/io/mesh/MeshTrianLoader.h>
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/core/ObjectFactory.h>
 
 #include <iostream>
 #include <fstream>

--- a/Component/IO/Mesh/src/sofa/component/io/mesh/StringMeshCreator.cpp
+++ b/Component/IO/Mesh/src/sofa/component/io/mesh/StringMeshCreator.cpp
@@ -19,9 +19,9 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <sofa/core/ObjectFactory.h>
 #include <sofa/component/io/mesh/StringMeshCreator.h>
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/core/ObjectFactory.h>
 
 namespace sofa::component::io::mesh
 {

--- a/Component/SceneUtility/src/sofa/component/sceneutility/APIVersion.cpp
+++ b/Component/SceneUtility/src/sofa/component/sceneutility/APIVersion.cpp
@@ -19,6 +19,8 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+
+#include <sofa/component/sceneutility/config.h>
 #include <sofa/core/objectmodel/BaseNode.h>
 using sofa::core::objectmodel::BaseNode ;
 

--- a/Component/SceneUtility/src/sofa/component/sceneutility/InfoComponent.cpp
+++ b/Component/SceneUtility/src/sofa/component/sceneutility/InfoComponent.cpp
@@ -19,6 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <sofa/component/sceneutility/config.h>
 #include <sofa/core/ObjectFactory.h>
 using sofa::core::RegisterObject ;
 

--- a/Component/SceneUtility/src/sofa/component/sceneutility/MakeAliasComponent.cpp
+++ b/Component/SceneUtility/src/sofa/component/sceneutility/MakeAliasComponent.cpp
@@ -19,6 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <sofa/component/sceneutility/config.h>
 #include <sofa/core/ObjectFactory.h>
 using sofa::core::RegisterObject ;
 using sofa::core::ObjectFactory ;

--- a/Component/SceneUtility/src/sofa/component/sceneutility/MakeDataAliasComponent.cpp
+++ b/Component/SceneUtility/src/sofa/component/sceneutility/MakeDataAliasComponent.cpp
@@ -19,6 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <sofa/component/sceneutility/config.h>
 #include <sofa/core/ObjectFactory.h>
 using sofa::core::RegisterObject ;
 using sofa::core::ObjectFactory ;

--- a/Component/SceneUtility/src/sofa/component/sceneutility/MessageHandlerComponent.cpp
+++ b/Component/SceneUtility/src/sofa/component/sceneutility/MessageHandlerComponent.cpp
@@ -23,6 +23,7 @@
 * User of this library should read the documentation
 * in the logging.h file.
 ******************************************************************************/
+#include <sofa/component/sceneutility/config.h>
 #include <sofa/core/ObjectFactory.h>
 using sofa::core::RegisterObject ;
 

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.cpp
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/DistanceGridCollisionModel.cpp
@@ -22,7 +22,7 @@
 #define SOFA_COMPONENT_COLLISION_DISTANCEGRIDCOLLISIONMODEL_CPP
 #include <fstream>
 #include <sstream>
-
+#include <SofaDistanceGrid/config.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/ObjectFactory.h>

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/FFDDistanceGridDiscreteIntersection.cpp
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/FFDDistanceGridDiscreteIntersection.cpp
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #include <iostream>
 #include <algorithm>
-
+#include <SofaDistanceGrid/config.h>
 #include <sofa/helper/proximity.h>
 #include <sofa/core/collision/Intersection.inl>
 #include <sofa/core/collision/IntersectorFactory.h>

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/RigidDistanceGridDiscreteIntersection.cpp
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/collision/RigidDistanceGridDiscreteIntersection.cpp
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <algorithm>
 
+#include <SofaDistanceGrid/config.h>
 #include <sofa/core/collision/Intersection.inl>
 #include <sofa/core/collision/IntersectorFactory.h>
 #include <sofa/helper/proximity.h>

--- a/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/forcefield/DistanceGridForceField.cpp
+++ b/applications/plugins/SofaDistanceGrid/src/SofaDistanceGrid/components/forcefield/DistanceGridForceField.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #define SOFA_COMPONENT_INTERACTIONFORCEFIELD_DISTANCEGRIDFORCEFIELD_CPP
+#include <SofaDistanceGrid/config.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/core/ObjectFactory.h>
 #include "DistanceGridForceField.inl"

--- a/applications/plugins/SofaImplicitField/components/geometry/BottleField.cpp
+++ b/applications/plugins/SofaImplicitField/components/geometry/BottleField.cpp
@@ -19,6 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <SofaImplicitField/config.h>
 #include <sofa/core/ObjectFactory.h>
 using sofa::core::RegisterObject ;
 

--- a/applications/plugins/SofaImplicitField/components/geometry/DiscreteGridField.cpp
+++ b/applications/plugins/SofaImplicitField/components/geometry/DiscreteGridField.cpp
@@ -20,7 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <fstream>
-
+#include <SofaImplicitField/config.h>
 #include <sofa/core/ObjectFactory.h>
 using sofa::core::RegisterObject ;
 

--- a/applications/plugins/SofaImplicitField/components/geometry/SphericalField.cpp
+++ b/applications/plugins/SofaImplicitField/components/geometry/SphericalField.cpp
@@ -19,6 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <SofaImplicitField/config.h>
 #include <sofa/core/ObjectFactory.h>
 using sofa::core::RegisterObject ;
 

--- a/applications/plugins/SofaImplicitField/components/geometry/StarShapedField.cpp
+++ b/applications/plugins/SofaImplicitField/components/geometry/StarShapedField.cpp
@@ -19,6 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <SofaImplicitField/config.h>
 #include <sofa/core/ObjectFactory.h>
 using sofa::core::RegisterObject ;
 

--- a/applications/plugins/SofaImplicitField/components/mapping/ImplicitSurfaceMapping.cpp
+++ b/applications/plugins/SofaImplicitField/components/mapping/ImplicitSurfaceMapping.cpp
@@ -20,8 +20,8 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #define SOFA_COMPONENT_MAPPING_IMPLICITSURFACEMAPPING_CPP
+#include <SofaImplicitField/config.h>
 #include <sofa/core/ObjectFactory.h>
-
 #include "ImplicitSurfaceMapping.inl"
 
 namespace sofa

--- a/applications/plugins/SofaImplicitField/deprecated/InterpolatedImplicitSurface.cpp
+++ b/applications/plugins/SofaImplicitField/deprecated/InterpolatedImplicitSurface.cpp
@@ -1,3 +1,4 @@
+#include <SofaImplicitField/config.h>
 #include <sofa/core/ObjectFactory.h>
 using sofa::core::RegisterObject ;
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.cpp
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/AffineMovementConstraint.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #define SOFABOUNDARYCONDITION_AFFINEMOVEMENT_CONSTRAINT_CPP
 
+#include <SofaBoundaryCondition/config.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/defaulttype/RigidTypes.h>

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearForceField.cpp
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/LinearForceField.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #define SOFA_COMPONENT_FORCEFIELD_LINEARFORCEFIELD_CPP
 
+#include <SofaBoundaryCondition/config.h>
 #include <sofa/core/ObjectFactory.h>
 #include "LinearForceField.inl"
 

--- a/modules/SofaConstraint/src/SofaConstraint/MappingGeometricStiffnessForceField.cpp
+++ b/modules/SofaConstraint/src/SofaConstraint/MappingGeometricStiffnessForceField.cpp
@@ -19,8 +19,8 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <SofaConstraint/config.h>
 #include <SofaConstraint/MappingGeometricStiffnessForceField.inl>
-
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/defaulttype/VecTypes.h>

--- a/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/IncrSAP.cpp
+++ b/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/IncrSAP.cpp
@@ -19,6 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <SofaGeneralMeshCollision/config.h>
 #include <sofa/core/ObjectFactory.h>
 #include <SofaGeneralMeshCollision/IncrSAP.h>
 

--- a/modules/SofaNonUniformFem/src/SofaNonUniformFem/SparseGridRamificationTopology.cpp
+++ b/modules/SofaNonUniformFem/src/SofaNonUniformFem/SparseGridRamificationTopology.cpp
@@ -20,9 +20,9 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
-#include <sofa/core/ObjectFactory.h>
 #include <sstream>
 #include "SparseGridRamificationTopology.h"
+#include <sofa/core/ObjectFactory.h>
 
 namespace sofa::component::topology
 {

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/DataDisplay.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/DataDisplay.cpp
@@ -28,11 +28,11 @@
 # define isnan(x) (std::isnan(x))
 #endif
 
-#include <sofa/core/ObjectFactory.h>
 #include <sofa/defaulttype/VecTypes.h>
 
 #include <SofaOpenglVisual/DataDisplay.h>
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/core/ObjectFactory.h>
 
 
 namespace sofa

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglCylinderModel.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglCylinderModel.cpp
@@ -19,9 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-
-#include <sofa/core/ObjectFactory.h>
-
+#include <SofaOpenglVisual/config.h>
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/core/behavior/BaseMechanicalState.h>
 
@@ -31,6 +29,7 @@
 #include <sofa/core/visual/VisualParams.h>
 
 #include <sofa/core/topology/TopologyData.inl>
+#include <sofa/core/ObjectFactory.h>
 
 namespace sofa
 {

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglSceneFrame.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/OglSceneFrame.cpp
@@ -19,7 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-
+#include <SofaOpenglVisual/config.h>
 #include <sofa/core/ObjectFactory.h>
 
 #include "OglSceneFrame.h"

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/PointSplatModel.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/PointSplatModel.cpp
@@ -22,7 +22,6 @@
 
 #include <map>
 #include <sofa/gl/template.h>
-#include <sofa/core/ObjectFactory.h>
 
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/core/behavior/BaseMechanicalState.h>
@@ -37,6 +36,7 @@
 #include <sofa/core/topology/TopologyData.inl>
 
 #include <sofa/type/RGBAColor.h>
+#include <sofa/core/ObjectFactory.h>
 
 namespace sofa
 {

--- a/modules/SofaOpenglVisual/src/SofaOpenglVisual/SlicedVolumetricModel.cpp
+++ b/modules/SofaOpenglVisual/src/SofaOpenglVisual/SlicedVolumetricModel.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 
 #include <map>
+#include <SofaOpenglVisual/config.h>
 #include <sofa/gl/template.h>
 #include <sofa/core/ObjectFactory.h>
 

--- a/modules/SofaSparseSolver/src/SofaSparseSolver/SparseLDLSolver.cpp
+++ b/modules/SofaSparseSolver/src/SofaSparseSolver/SparseLDLSolver.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #define SOFA_COMPONENT_LINEARSOLVER_SPARSELDLSOLVER_CPP
+#include <SofaSparseSolver/config.h>
 #include <SofaSparseSolver/SparseLDLSolver.inl>
 #include <sofa/core/ObjectFactory.h>
 

--- a/modules/SofaSparseSolver/src/SofaSparseSolver/SparseLUSolver.cpp
+++ b/modules/SofaSparseSolver/src/SofaSparseSolver/SparseLUSolver.cpp
@@ -20,8 +20,9 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #define SOFA_COMPONENT_LINEARSOLVER_SPARSELUSOLVER_CPP
-#include <sofa/core/ObjectFactory.h>
+#include <SofaSparseSolver/config.h>
 #include <SofaSparseSolver/SparseLUSolver.inl>
+#include <sofa/core/ObjectFactory.h>
 
 namespace sofa::component::linearsolver
 {

--- a/modules/SofaValidation/src/SofaValidation/ExtraMonitor.cpp
+++ b/modules/SofaValidation/src/SofaValidation/ExtraMonitor.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #define SOFA_COMPONENT_MISC_EXTRAMONITOR_CPP
+#include <SofaValidation/config.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/defaulttype/VecTypes.h>


### PR DESCRIPTION
Because of the tricky mecanisme to inject SOFA_TARGET in the ObjectFactory, the config.h file must always be included before the ObjectFactory.h 

Not doing that results in broken target. 
The PR fix the faulty components.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
