### PR TITLE
[Sofa.Defaulttype] Revert #2641 (changing unordered_map from map in MapMapSparseMatrix)

### DIFF
--- a/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/MapMapSparseMatrix.h
+++ b/SofaKernel/modules/SofaDefaultType/src/sofa/defaulttype/MapMapSparseMatrix.h
@@ -22,7 +22,7 @@
 #ifndef SOFA_DEFAULTTYPE_MAPMAPSPARSEMATRIX_H
 #define SOFA_DEFAULTTYPE_MAPMAPSPARSEMATRIX_H
 
-#include <unordered_map>
+#include <map>
 #include <sofa/linearalgebra/BaseVector.h>
 
 namespace sofa
@@ -46,7 +46,7 @@ class MapMapSparseMatrix
 public:
     typedef T Data;
     typedef unsigned int KeyType;
-    typedef typename std::unordered_map< KeyType, T > RowType;
+    typedef typename std::map< KeyType, T > RowType;
 
     /// Removes every matrix elements
     void clear()
@@ -132,7 +132,7 @@ public:
 
 protected:
 
-    typedef std::unordered_map< KeyType, RowType > SparseMatrix;
+    typedef std::map< KeyType, RowType > SparseMatrix;
 
     /// Data container
     SparseMatrix m_data;


### PR DESCRIPTION
See #2641 and especially https://github.com/sofa-framework/sofa/pull/2641#issuecomment-1036695510

@EulalieCoevoet could you try this branch to make sure it fixes the error ? Thanks !

(NOTE: I did not revert the PR itself as there are some welcoming cleanings)

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
