### PR TITLE
[SofaMiscFem] FIX missing Strain Displacement matrix update in TriangularFEMForceField

### DIFF
--- a/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
+++ b/modules/SofaMiscFem/src/SofaMiscFem/TriangularFEMForceField.inl
@@ -1008,10 +1008,7 @@ void TriangularFEMForceField<DataTypes>::computeForce(Displacement &F, Index ele
         Coord B = R_0_2 * (p[b]-p[a]);
         Coord C = R_0_2 * (p[c]-p[a]);
 
-        if (_anisotropicMaterial)
-            computeStrainDisplacement(J, elementIndex, A, B, C);
-        else
-            J = triangleInf[elementIndex].strainDisplacementMatrix;
+        computeStrainDisplacement(J, elementIndex, A, B, C);
         computeStrain(strain, J, D);
         computeStress(stress, triangleInf[elementIndex].materialMatrix, strain);
         computeStiffness(J,K,triangleInf[elementIndex].materialMatrix);


### PR DESCRIPTION
In TriangularFEMForceField, the strainDisplacementMatrix was not re-computed for a new simulation step in the computeForce-method. Because of that, the strain computation used an old version of the strainDisplacementMatrix


EDIT: this will fix issue: 
fix #2704


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
