### PR TITLE
[SofaMiscForceField] Fix error while trying to compile a plugin depending on SofaGuiQt

### DIFF
--- a/modules/SofaGuiQt/SofaGuiQtConfig.cmake.in
+++ b/modules/SofaGuiQt/SofaGuiQtConfig.cmake.in
@@ -19,7 +19,6 @@ list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}/..")
 
 find_package(SofaBaseVisual QUIET REQUIRED)
 find_package(SofaLoader QUIET REQUIRED)
-find_package(SofaBaseMechanics QUIET REQUIRED)
 find_package(SofaMiscForceField QUIET REQUIRED)
 find_package(SofaGuiCommon QUIET REQUIRED)
 

--- a/modules/SofaGuiQt/SofaGuiQtConfig.cmake.in
+++ b/modules/SofaGuiQt/SofaGuiQtConfig.cmake.in
@@ -19,6 +19,7 @@ list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}/..")
 
 find_package(SofaBaseVisual QUIET REQUIRED)
 find_package(SofaLoader QUIET REQUIRED)
+find_package(SofaBaseMechanics QUIET REQUIRED)
 find_package(SofaMiscForceField QUIET REQUIRED)
 find_package(SofaGuiCommon QUIET REQUIRED)
 

--- a/modules/SofaMiscForceField/SofaMiscForceFieldConfig.cmake.in
+++ b/modules/SofaMiscForceField/SofaMiscForceFieldConfig.cmake.in
@@ -3,6 +3,7 @@
 @PACKAGE_INIT@
 
 find_package(SofaFramework QUIET REQUIRED) # SofaHelper
+find_package(SofaBaseMechanics QUIET REQUIRED)
 find_package(SofaDeformable QUIET REQUIRED)
 find_package(SofaBoundaryCondition QUIET REQUIRED)
 find_package(SofaGeneralTopology QUIET REQUIRED) 


### PR DESCRIPTION
Fixed this error while trying to configure a out-of-tree compilation of a plugin depending on SofaGuiQt

`CMake Error at sofa/install/lib/cmake/SofaGuiQt/SofaGuiQtConfig.cmake:49 (find_package):
  Found package configuration file:

    sofa/install/plugins/SofaMiscForceField/lib/cmake/SofaMiscForceField/SofaMiscForceFieldConfig.cmake

  but it set SofaMiscForceField_FOUND to FALSE so package
  "SofaMiscForceField" is considered to be NOT FOUND.  Reason given by
  package:

  The following imported targets are referenced, but are missing:
  SofaBaseMechanics`






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
