### PR TITLE
[SofaMiscForceField] Fix type conversion in tests

### DIFF
--- a/SofaKernel/modules/Sofa.Testing/src/sofa/testing/NumericTest.h
+++ b/SofaKernel/modules/Sofa.Testing/src/sofa/testing/NumericTest.h
@@ -191,6 +191,17 @@ protected:
 
 };
 
+// Generic macro for comparing floating-point numbers
+// Google Test provides EXPECT_FLOAT_EQ and EXPECT_DOUBLE_EQ, but it supposes that the type is known and constant. It
+// cannot rely on a template mechanism for example.
+#define EXPECT_FLOATINGPOINT_EQ(val1, val2) {\
+    static_assert(std::is_same_v<std::decay_t<decltype(val1)>, std::decay_t<decltype(val2)> >,\
+        "Different types for val1 and val2 are not supported");\
+    static_assert(std::is_floating_point_v<std::decay_t<decltype(val1)> >,\
+        "Non-floating-point types are not supported");\
+    EXPECT_PRED_FORMAT2(::testing::internal::CmpHelperFloatingPointEQ<std::decay_t<decltype(val1)> >, \
+        val1, val2);}
+
 
 /// Resize the Vector and copy it from the Data
 template<class Vector, class ReadData>

--- a/modules/SofaMiscForceField/SofaMiscForceField_test/MeshMatrixMass_test.cpp
+++ b/modules/SofaMiscForceField/SofaMiscForceField_test/MeshMatrixMass_test.cpp
@@ -25,6 +25,8 @@ using sofa::core::execparams::defaultInstance;
 #include <sofa/testing/BaseSimulationTest.h>
 using sofa::testing::BaseSimulationTest;
 
+#include <sofa/testing/NumericTest.h>
+
 #include <SofaBaseMechanics/MechanicalObject.h>
 #include <SofaBaseTopology/EdgeSetTopologyContainer.h>
 #include <SofaBaseTopology/EdgeSetGeometryAlgorithms.h>
@@ -134,17 +136,17 @@ public:
         }
 
         // Check the total mass.
-        EXPECT_FLOAT_EQ(expectedTotalMass, mass->d_totalMass.getValue());
+        EXPECT_FLOATINGPOINT_EQ(expectedTotalMass, mass->d_totalMass.getValue());
 
         // Check mass density
-        EXPECT_FLOAT_EQ(expectedMassDensity, mass->getMassDensity()[0]);
+        EXPECT_FLOATINGPOINT_EQ(expectedMassDensity, mass->getMassDensity()[0]);
 
         // Check the mass at each index.
         auto vertexMass = mass->d_vertexMass.getValue();
         ASSERT_EQ(expectedVMass.size(), vertexMass.size());
 
         for (size_t i = 0 ; i < vertexMass.size(); i++)
-            EXPECT_FLOAT_EQ(expectedVMass[i], vertexMass[i]);
+            EXPECT_FLOATINGPOINT_EQ(expectedVMass[i], vertexMass[i]);
 
         // Check edge mass 
         auto edgeMass = mass->d_edgeMass.getValue();
@@ -152,7 +154,7 @@ public:
 
         for (size_t i = 0; i < edgeMass.size(); i++) {
             if (edgeMass[i] != 0.0) // == 0 is possible if edge is not part of the element structure (for example in grid)
-                EXPECT_FLOAT_EQ(expectedEMass[i], edgeMass[i]);
+                EXPECT_FLOATINGPOINT_EQ(expectedEMass[i], edgeMass[i]);
         }
     }
 
@@ -239,13 +241,13 @@ public:
             EXPECT_EQ( mass->d_vertexMass.getValue().size(), 27 );
             EXPECT_EQ( mass->d_edgeMass.getValue().size(), 90);
 
-            EXPECT_FLOAT_EQ( mass->getTotalMass(), expectedTotalMass);
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], expectedDensity);
+            EXPECT_FLOATINGPOINT_EQ( mass->getTotalMass(), expectedTotalMass);
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], expectedDensity);
 
-            EXPECT_FLOAT_EQ(mass->d_vertexMass.getValue()[0], (MassType)(expectedDensity * volumeElem * 1 / 20));
-            EXPECT_FLOAT_EQ(mass->d_vertexMass.getValue()[1], (MassType)(expectedDensity * volumeElem * 1 / 20 * 2)); // vertex shared by 2 hexa
-            EXPECT_FLOAT_EQ(mass->d_edgeMass.getValue()[0], (MassType)(expectedDensity * volumeElem * 1 / 40 * 2)); // Edge shared by 2 hexa
-            EXPECT_FLOAT_EQ(mass->d_edgeMass.getValue()[2], (MassType)(expectedDensity * volumeElem * 1 / 40)); 
+            EXPECT_FLOATINGPOINT_EQ(mass->d_vertexMass.getValue()[0], (MassType)(expectedDensity * volumeElem * 1 / 20));
+            EXPECT_FLOATINGPOINT_EQ(mass->d_vertexMass.getValue()[1], (MassType)(expectedDensity * volumeElem * 1 / 20 * 2)); // vertex shared by 2 hexa
+            EXPECT_FLOATINGPOINT_EQ(mass->d_edgeMass.getValue()[0], (MassType)(expectedDensity * volumeElem * 1 / 40 * 2)); // Edge shared by 2 hexa
+            EXPECT_FLOATINGPOINT_EQ(mass->d_edgeMass.getValue()[2], (MassType)(expectedDensity * volumeElem * 1 / 40)); 
         }
 
         return ;
@@ -282,13 +284,13 @@ public:
             EXPECT_EQ( mass->getMassCount(), 27 );
             EXPECT_EQ( mass->d_edgeMass.getValue().size(), 90);
 
-            EXPECT_FLOAT_EQ(mass->getTotalMass(), expectedTotalMass);
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], expectedDensity);
+            EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), expectedTotalMass);
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], expectedDensity);
 
-            EXPECT_FLOAT_EQ(mass->d_vertexMass.getValue()[0], (MassType)(expectedDensity * volumeElem * 1 / 20));
-            EXPECT_FLOAT_EQ(mass->d_vertexMass.getValue()[1], (MassType)(expectedDensity * volumeElem * 1 / 20 * 2)); // vertex shared by 2 hexa
-            EXPECT_FLOAT_EQ(mass->d_edgeMass.getValue()[0], (MassType)(expectedDensity * volumeElem * 1 / 40 * 2)); // Edge shared by 2 hexa
-            EXPECT_FLOAT_EQ(mass->d_edgeMass.getValue()[2], (MassType)(expectedDensity * volumeElem * 1 / 40));
+            EXPECT_FLOATINGPOINT_EQ(mass->d_vertexMass.getValue()[0], (MassType)(expectedDensity * volumeElem * 1 / 20));
+            EXPECT_FLOATINGPOINT_EQ(mass->d_vertexMass.getValue()[1], (MassType)(expectedDensity * volumeElem * 1 / 20 * 2)); // vertex shared by 2 hexa
+            EXPECT_FLOATINGPOINT_EQ(mass->d_edgeMass.getValue()[0], (MassType)(expectedDensity * volumeElem * 1 / 40 * 2)); // Edge shared by 2 hexa
+            EXPECT_FLOATINGPOINT_EQ(mass->d_edgeMass.getValue()[2], (MassType)(expectedDensity * volumeElem * 1 / 40));
         }
 
         return ;
@@ -327,14 +329,14 @@ public:
             EXPECT_EQ(mass->d_edgeMass.getValue().size(), 90);
 
             EXPECT_EQ(mass->isLumped(), true);
-            EXPECT_FLOAT_EQ(mass->getTotalMass(), expectedTotalMass);
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], expectedDensity);
+            EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), expectedTotalMass);
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], expectedDensity);
             EXPECT_EQ(mass->getVertexMass()[0], 1.0);
 
-            EXPECT_FLOAT_EQ(mass->d_vertexMass.getValue()[0], 1.0);
-            EXPECT_FLOAT_EQ(mass->d_vertexMass.getValue()[1], 1.0);
-            EXPECT_FLOAT_EQ(mass->d_edgeMass.getValue()[0], 0.0);
-            EXPECT_FLOAT_EQ(mass->d_edgeMass.getValue()[2], 0.0);
+            EXPECT_FLOATINGPOINT_EQ(mass->d_vertexMass.getValue()[0], 1.0);
+            EXPECT_FLOATINGPOINT_EQ(mass->d_vertexMass.getValue()[1], 1.0);
+            EXPECT_FLOATINGPOINT_EQ(mass->d_edgeMass.getValue()[0], 0.0);
+            EXPECT_FLOATINGPOINT_EQ(mass->d_edgeMass.getValue()[2], 0.0);
         }
 
         return ;
@@ -369,9 +371,9 @@ public:
 
         if(mass!=nullptr){
             EXPECT_EQ( mass->getMassCount(), 27 );
-            EXPECT_FLOAT_EQ( mass->getTotalMass(), 2.0 ); 
-            EXPECT_FLOAT_EQ( mass->getMassDensity()[0], mass->getTotalMass() / 8.0); // 8 hexa
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], mass->getMassDensity()[0] / 20);
+            EXPECT_FLOATINGPOINT_EQ( mass->getTotalMass(), 2.0 ); 
+            EXPECT_FLOATINGPOINT_EQ( mass->getMassDensity()[0], mass->getTotalMass() / 8.0); // 8 hexa
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], mass->getMassDensity()[0] / 20);
         }
 
         return ;
@@ -403,9 +405,9 @@ public:
         if(mass!=nullptr){
             EXPECT_EQ( mass->isLumped(), true );
             EXPECT_EQ( mass->getMassCount(), 27 );
-            EXPECT_FLOAT_EQ( mass->getTotalMass(), 2.0 );
-            EXPECT_FLOAT_EQ( mass->getMassDensity()[0], mass->getTotalMass() / 8.0);
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], mass->getMassDensity()[0] / 20);
+            EXPECT_FLOATINGPOINT_EQ( mass->getTotalMass(), 2.0 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getMassDensity()[0], mass->getTotalMass() / 8.0);
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], mass->getMassDensity()[0] / 20);
         }
 
         return ;
@@ -437,9 +439,9 @@ public:
         if(mass!=nullptr){
             EXPECT_EQ( mass->isLumped(), true );
             EXPECT_EQ( mass->getMassCount(), 27 );
-            EXPECT_FLOAT_EQ( mass->getTotalMass(), 8.0 );
-            EXPECT_FLOAT_EQ( mass->getMassDensity()[0], 1.0 );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], 0.05 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getTotalMass(), 8.0 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getMassDensity()[0], 1.0 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], 0.05 );
         }
 
         return ;
@@ -472,9 +474,9 @@ public:
 
         if(mass!=nullptr){
             EXPECT_EQ( mass->getMassCount(), 27 );
-            EXPECT_FLOAT_EQ( mass->getTotalMass(), 1.0 );
-            EXPECT_FLOAT_EQ( mass->getMassDensity()[0], 0.125 );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], 0.00625 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getTotalMass(), 1.0 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getMassDensity()[0], 0.125 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], 0.00625 );
         }
 
         return ;
@@ -504,9 +506,9 @@ public:
 
         if(mass!=nullptr){
             EXPECT_EQ( mass->getMassCount(), 27 );
-            EXPECT_FLOAT_EQ(mass->getTotalMass(), 1.0 );
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], 0.125 );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], 0.00625);
+            EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), 1.0 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], 0.125 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], 0.00625);
         }
 
         return ;
@@ -536,9 +538,9 @@ public:
 
         if(mass!=nullptr){
             EXPECT_EQ( mass->getMassCount(), 27 );
-            EXPECT_FLOAT_EQ(mass->getTotalMass(), 1.0 );
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], 0.125 );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], 0.00625 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), 1.0 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], 0.125 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], 0.00625 );
         }
 
         return ;
@@ -569,9 +571,9 @@ public:
 
         if(mass!=nullptr){
             EXPECT_EQ( mass->getMassCount(), 27 );
-            EXPECT_FLOAT_EQ(mass->getTotalMass(), 1.0 );
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], 0.125 );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], 0.00625 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), 1.0 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], 0.125 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], 0.00625 );
         }
 
         return ;
@@ -601,9 +603,9 @@ public:
 
         if(mass!=nullptr){
             EXPECT_EQ( mass->getMassCount(), 27 );
-            EXPECT_FLOAT_EQ(mass->getTotalMass(), 1.0 );
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], 0.125 );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], 0.00625 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), 1.0 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], 0.125 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], 0.00625 );
         }
 
         return ;
@@ -637,9 +639,9 @@ public:
 
         if(mass!=nullptr){
             EXPECT_EQ( mass->getMassCount(), 27 );
-            EXPECT_FLOAT_EQ(mass->getTotalMass(), 1.0 );
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], 0.125 );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], 0.00625 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), 1.0 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], 0.125 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], 0.00625 );
         }
 
         return ;
@@ -671,9 +673,9 @@ public:
 
         if(mass!=nullptr){
             EXPECT_EQ( mass->getMassCount(), 27 );
-            EXPECT_FLOAT_EQ(mass->getTotalMass(), 2.0 );
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], 0.25 );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], 0.0125 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), 2.0 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], 0.25 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], 0.0125 );
         }
 
         return ;
@@ -722,10 +724,10 @@ public:
 
         if(mass!=nullptr){
             EXPECT_EQ( mass->getMassCount(), 8 );
-            EXPECT_FLOAT_EQ(mass->getTotalMass(), 1.0 );
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], 0.125 );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], (0.25/3.0) );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[7], (0.25/3.0) );
+            EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), 1.0 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], 0.125 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], (0.25/3.0) );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[7], (0.25/3.0) );
         }
         return ;
     }
@@ -760,10 +762,10 @@ public:
 
         if(mass!=nullptr){
             EXPECT_EQ( mass->getMassCount(), 8 );
-            EXPECT_FLOAT_EQ(mass->getTotalMass(), 2.0 );
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], 0.25 );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], (0.5/3.0) );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[1], 0.1 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), 2.0 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], 0.25 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], (0.5/3.0) );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[1], 0.1 );
         }
 
         return ;
@@ -799,9 +801,9 @@ public:
 
         if(mass!=nullptr){
             EXPECT_EQ( mass->getMassCount(), 8 );
-            EXPECT_FLOAT_EQ(mass->getTotalMass(), 8.0 );
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], 1.0 );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], (2.0/3.0) );
+            EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), 8.0 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], 1.0 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], (2.0/3.0) );
         }
 
         return ;
@@ -838,9 +840,9 @@ public:
         if(mass!=nullptr){
             EXPECT_EQ( mass->isLumped(), true );
             EXPECT_EQ( mass->getMassCount(), 8 );
-            EXPECT_FLOAT_EQ(mass->getTotalMass(), 8.0 );
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], 1.0 );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], 1.0 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), 8.0 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], 1.0 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], 1.0 );
         }
 
         return ;
@@ -881,9 +883,9 @@ public:
 
         if(mass!=nullptr){
             EXPECT_EQ( mass->getMassCount(), 8 );
-            EXPECT_FLOAT_EQ(mass->getTotalMass(), 2.0 );
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], 0.25 );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], (0.5/3.0) );
+            EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), 2.0 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], 0.25 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], (0.5/3.0) );
         }
 
         return ;
@@ -920,9 +922,9 @@ public:
         if(mass!=nullptr){
             EXPECT_EQ( mass->isLumped(), true );
             EXPECT_EQ( mass->getMassCount(), 8 );
-            EXPECT_FLOAT_EQ(mass->getTotalMass(), 2.0 );
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], 0.25 );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], (0.5/3.0) );
+            EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), 2.0 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], 0.25 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], (0.5/3.0) );
         }
 
         return ;
@@ -959,9 +961,9 @@ public:
         if(mass!=nullptr){
             EXPECT_EQ( mass->isLumped(), true );
             EXPECT_EQ( mass->getMassCount(), 8 );
-            EXPECT_FLOAT_EQ(mass->getTotalMass(), 8.0 );
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], 1.0 );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], (2.0/3.0) );
+            EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), 8.0 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], 1.0 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], (2.0/3.0) );
         }
 
         return ;
@@ -1000,9 +1002,9 @@ public:
 
         if(mass!=nullptr){
             EXPECT_EQ( mass->getMassCount(), 8 );
-            EXPECT_FLOAT_EQ(mass->getTotalMass(), 1.0 );
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], 0.125 );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], (0.25/3.0) );
+            EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), 1.0 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], 0.125 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], (0.25/3.0) );
         }
 
         return ;
@@ -1038,9 +1040,9 @@ public:
 
         if(mass!=nullptr){
             EXPECT_EQ( mass->getMassCount(), 8 );
-            EXPECT_FLOAT_EQ(mass->getTotalMass(), 1.0 );
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], 0.125 );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], (0.25/3.0) );
+            EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), 1.0 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], 0.125 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], (0.25/3.0) );
         }
 
         return ;
@@ -1076,9 +1078,9 @@ public:
 
         if(mass!=nullptr){
             EXPECT_EQ( mass->getMassCount(), 8 );
-            EXPECT_FLOAT_EQ(mass->getTotalMass(), 1.0 );
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], 0.125 );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], (0.25/3.0) );
+            EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), 1.0 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], 0.125 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], (0.25/3.0) );
         }
 
         return ;
@@ -1114,9 +1116,9 @@ public:
 
         if(mass!=nullptr){
             EXPECT_EQ( mass->getMassCount(), 8 );
-            EXPECT_FLOAT_EQ(mass->getTotalMass(), 1.0 );
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], 0.125 );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], (0.25/3.0) );
+            EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), 1.0 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], 0.125 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], (0.25/3.0) );
         }
 
         return ;
@@ -1151,9 +1153,9 @@ public:
 
         if(mass!=nullptr){
             EXPECT_EQ( mass->getMassCount(), 8 );
-            EXPECT_FLOAT_EQ(mass->getTotalMass(), 1.0 );
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], 0.125 );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], (0.25/3.0) );
+            EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), 1.0 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], 0.125 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], (0.25/3.0) );
         }
 
         return ;
@@ -1193,9 +1195,9 @@ public:
 
         if(mass!=nullptr){
             EXPECT_EQ( mass->getMassCount(), 8 );
-            EXPECT_FLOAT_EQ(mass->getTotalMass(), 1.0 );
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], 0.125 );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], (0.25/3.0) );
+            EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), 1.0 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], 0.125 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], (0.25/3.0) );
         }
 
         return ;
@@ -1233,9 +1235,9 @@ public:
 
         if(mass!=nullptr){
             EXPECT_EQ( mass->getMassCount(), 8 );
-            EXPECT_FLOAT_EQ(mass->getTotalMass(), 2.0 );
-            EXPECT_FLOAT_EQ(mass->getMassDensity()[0], 0.25 );
-            EXPECT_FLOAT_EQ( mass->getVertexMass()[0], (0.5/3.0) );
+            EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), 2.0 );
+            EXPECT_FLOATINGPOINT_EQ(mass->getMassDensity()[0], 0.25 );
+            EXPECT_FLOATINGPOINT_EQ( mass->getVertexMass()[0], (0.5/3.0) );
         }
 
         return ;
@@ -1302,21 +1304,21 @@ public:
         // check value at init
         EXPECT_EQ(vMasses.size(), 27);
         EXPECT_EQ(eMasses.size(), 90);
-        EXPECT_FLOAT_EQ(mass->getTotalMass(), expectedTotalMass);
+        EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), expectedTotalMass);
         
         // check vertex mass
-        EXPECT_FLOAT_EQ(vMasses[0], refValueV);
-        EXPECT_FLOAT_EQ(vMasses[1], refValueV * 2);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[0], refValueV);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[1], refValueV * 2);
         // check edge mass (only if not lumped else eMass is not computed)
         if(!lumped)
         {
-            EXPECT_FLOAT_EQ(eMasses[0], refValueE * 2);
-            EXPECT_FLOAT_EQ(eMasses[2], refValueE); // eMasses[1] == 0 because not taken into account from grid to hexahedron Topology
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], refValueE * 2);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[2], refValueE); // eMasses[1] == 0 because not taken into account from grid to hexahedron Topology
         }
         else
         {
-            EXPECT_FLOAT_EQ(eMasses[0], 0.);
-            EXPECT_FLOAT_EQ(eMasses[2], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[2], 0.);
         }
         
         // -- remove hexahedron id: 0 -- 
@@ -1324,42 +1326,42 @@ public:
         modifier->removeHexahedra(hexaIds);
         EXPECT_EQ(vMasses.size(), 26);
         EXPECT_EQ(eMasses.size(), 87);
-        EXPECT_FLOAT_EQ(mass->getTotalMass(), 7.0);
+        EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), 7.0);
 
         // check vertex mass
-        EXPECT_FLOAT_EQ(vMasses[0], refValueV); // check update of Mass when removing tetra
-        EXPECT_FLOAT_EQ(vMasses[1], refValueV);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[0], refValueV); // check update of Mass when removing tetra
+        EXPECT_FLOATINGPOINT_EQ(vMasses[1], refValueV);
         // check edge mass (only if not lumped else eMass is not computed)
         if(!lumped)
         {
-            EXPECT_FLOAT_EQ(eMasses[0], refValueE);
-            EXPECT_FLOAT_EQ(eMasses[3], refValueE);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], refValueE);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[3], refValueE);
         }
         else
         {
-            EXPECT_FLOAT_EQ(eMasses[0], 0.);
-            EXPECT_FLOAT_EQ(eMasses[3], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[3], 0.);
         }
 
         // -- remove hexahedron id: 0 --
         modifier->removeHexahedra(hexaIds);
         EXPECT_EQ(vMasses.size(), 25);
         EXPECT_EQ(eMasses.size(), 84);
-        EXPECT_FLOAT_EQ(mass->getTotalMass(), 6.0);
+        EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), 6.0);
 
         // check vertex mass
-        EXPECT_FLOAT_EQ(vMasses[0], refValueV); // check update of Mass when removing tetra
-        EXPECT_FLOAT_EQ(vMasses[1], refValueV);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[0], refValueV); // check update of Mass when removing tetra
+        EXPECT_FLOATINGPOINT_EQ(vMasses[1], refValueV);
         // check edge mass (only if not lumped else eMass is not computed)
         if(!lumped)
         {
-            EXPECT_FLOAT_EQ(eMasses[0], refValueE);
-            EXPECT_FLOAT_EQ(eMasses[3], refValueE);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], refValueE);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[3], refValueE);
         }
         else
         {
-            EXPECT_FLOAT_EQ(eMasses[0], 0.);
-            EXPECT_FLOAT_EQ(eMasses[3], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[3], 0.);
         }
         
         // -- remove hexahedron id: 0, 1 --
@@ -1367,21 +1369,21 @@ public:
         modifier->removeHexahedra(hexaIds);
         EXPECT_EQ(vMasses.size(), 21);
         EXPECT_EQ(eMasses.size(), 74);
-        EXPECT_FLOAT_EQ(mass->getTotalMass(), 4.0);
+        EXPECT_NEAR(mass->getTotalMass(), 4.0, 1e-14);
 
         // check vertex mass
-        EXPECT_FLOAT_EQ(vMasses[0], refValueV);
-        EXPECT_FLOAT_EQ(vMasses[1], refValueV * 2);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[0], refValueV);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[1], refValueV * 2);
         // check edge mass (only if not lumped else eMass is not computed)
         if(!lumped)
         {
-            EXPECT_FLOAT_EQ(eMasses[3], refValueE);
-            EXPECT_FLOAT_EQ(eMasses[20], refValueE);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[3], refValueE);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[20], refValueE);
         }
         else
         {
-            EXPECT_FLOAT_EQ(eMasses[3], 0.);
-            EXPECT_FLOAT_EQ(eMasses[20], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[3], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[20], 0.);
         }
 
         // -- remove hexahedron id: 0, 1, 2, 3 --
@@ -1460,21 +1462,21 @@ public:
         // check value at init
         EXPECT_EQ(vMasses.size(), 8);
         EXPECT_EQ(eMasses.size(), 19);
-        EXPECT_FLOAT_EQ(mass->getTotalMass(), expectedTotalMass);
+        EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), expectedTotalMass);
 
         // check vertex mass
-        EXPECT_FLOAT_EQ(vMasses[0], refValueV * 5);
-        EXPECT_FLOAT_EQ(vMasses[1], refValueV * 3);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[0], refValueV * 5);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[1], refValueV * 3);
         // check edge mass (only if not lumped else eMass is not computed)
         if(!lumped)
         {
-            EXPECT_FLOAT_EQ(eMasses[0], refValueE * 3);
-            EXPECT_FLOAT_EQ(eMasses[1], refValueE * 2);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], refValueE * 3);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[1], refValueE * 2);
         }
         else
         {
-            EXPECT_FLOAT_EQ(eMasses[0], 0.);
-            EXPECT_FLOAT_EQ(eMasses[1], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[1], 0.);
         }
 
         // -- remove tetrahedron id: 0 -- 
@@ -1482,21 +1484,21 @@ public:
         modifier->removeTetrahedra(elemIds);
         EXPECT_EQ(vMasses.size(), 8);
         EXPECT_EQ(eMasses.size(), 18);
-        EXPECT_FLOAT_EQ(mass->getTotalMass(), expectedTotalMass - massElem);
+        EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), expectedTotalMass - massElem);
 
         // check vertex mass
-        EXPECT_FLOAT_EQ(vMasses[0], refValueV * 4); // check update of Mass when removing tetra
-        EXPECT_FLOAT_EQ(vMasses[1], refValueV * 2);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[0], refValueV * 4); // check update of Mass when removing tetra
+        EXPECT_FLOATINGPOINT_EQ(vMasses[1], refValueV * 2);
         // check edge mass (only if not lumped else eMass is not computed)
         if(!lumped)
         {
-            EXPECT_FLOAT_EQ(eMasses[0], refValueE * 2);
-            EXPECT_FLOAT_EQ(eMasses[1], refValueE);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], refValueE * 2);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[1], refValueE);
         }
         else
         {
-            EXPECT_FLOAT_EQ(eMasses[0], 0.);
-            EXPECT_FLOAT_EQ(eMasses[1], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[1], 0.);
         }
 
 
@@ -1504,21 +1506,21 @@ public:
         modifier->removeTetrahedra(elemIds);
         EXPECT_EQ(vMasses.size(), 7);
         EXPECT_EQ(eMasses.size(), 15);
-        EXPECT_FLOAT_EQ(mass->getTotalMass(), expectedTotalMass - 2 * massElem);
+        EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), expectedTotalMass - 2 * massElem);
 
         // check vertex mass
-        EXPECT_FLOAT_EQ(vMasses[0], refValueV * 3); // check update of Mass when removing tetra
-        EXPECT_FLOAT_EQ(vMasses[1], refValueV * 2);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[0], refValueV * 3); // check update of Mass when removing tetra
+        EXPECT_FLOATINGPOINT_EQ(vMasses[1], refValueV * 2);
         // check edge mass (only if not lumped else eMass is not computed)
         if(!lumped)
         {
-            EXPECT_FLOAT_EQ(eMasses[0], refValueE);
-            EXPECT_FLOAT_EQ(eMasses[1], refValueE);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], refValueE);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[1], refValueE);
         }
         else
         {
-            EXPECT_FLOAT_EQ(eMasses[0], 0.);
-            EXPECT_FLOAT_EQ(eMasses[1], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[1], 0.);
         }
 
 
@@ -1527,21 +1529,21 @@ public:
         modifier->removeTetrahedra(elemIds);
         EXPECT_EQ(vMasses.size(), 6);
         EXPECT_EQ(eMasses.size(), 11);
-        EXPECT_FLOAT_EQ(mass->getTotalMass(), expectedTotalMass - 4 * massElem);
+        EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), expectedTotalMass - 4 * massElem);
 
         // check vertex mass
-        EXPECT_FLOAT_EQ(vMasses[0], refValueV);
-        EXPECT_FLOAT_EQ(vMasses[1], refValueV);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[0], refValueV);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[1], refValueV);
         // check edge mass (only if not lumped else eMass is not computed)
         if(!lumped)
         {
-            EXPECT_FLOAT_EQ(eMasses[0], refValueE);
-            EXPECT_FLOAT_EQ(eMasses[1], refValueE);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], refValueE);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[1], refValueE);
         }
         else
         {
-            EXPECT_FLOAT_EQ(eMasses[0], 0.);
-            EXPECT_FLOAT_EQ(eMasses[1], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[1], 0.);
         }
 
         // -- remove tetrahedron id: 0, 1 --
@@ -1613,21 +1615,21 @@ public:
         // check value at init
         EXPECT_EQ(vMasses.size(), 9);
         EXPECT_EQ(eMasses.size(), 16);
-        EXPECT_FLOAT_EQ(mass->getTotalMass(), expectedTotalMass);
+        EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), expectedTotalMass);
 
         // check vertex mass
-        EXPECT_FLOAT_EQ(vMasses[0], refValueV);
-        EXPECT_FLOAT_EQ(vMasses[1], refValueV * 2);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[0], refValueV);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[1], refValueV * 2);
         // check edge mass (only if not lumped else eMass is not computed)
         if(!lumped)
         {
-            EXPECT_FLOAT_EQ(eMasses[0], refValueE * 2);
-            EXPECT_FLOAT_EQ(eMasses[2], refValueE); // eMasses[1] == 0 because not taken into account from grid to quad Topology
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], refValueE * 2);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[2], refValueE); // eMasses[1] == 0 because not taken into account from grid to quad Topology
         }
         else
         {
-            EXPECT_FLOAT_EQ(eMasses[0], 0.);
-            EXPECT_FLOAT_EQ(eMasses[2], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[2], 0.);
         }
 
         // -- remove quad id: 0 -- 
@@ -1635,42 +1637,42 @@ public:
         modifier->removeQuads(elemIds, true, true);
         EXPECT_EQ(vMasses.size(), 8);
         EXPECT_EQ(eMasses.size(), 14);
-        EXPECT_FLOAT_EQ(mass->getTotalMass(), expectedTotalMass - massElem);
+        EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), expectedTotalMass - massElem);
 
         // check vertex mass
-        EXPECT_FLOAT_EQ(vMasses[0], refValueV); // check update of Mass when removing tetra
-        EXPECT_FLOAT_EQ(vMasses[1], refValueV);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[0], refValueV); // check update of Mass when removing tetra
+        EXPECT_FLOATINGPOINT_EQ(vMasses[1], refValueV);
         // check edge mass (only if not lumped else eMass is not computed)
         if(!lumped)
         {
-            EXPECT_FLOAT_EQ(eMasses[0], refValueE);
-            EXPECT_FLOAT_EQ(eMasses[3], refValueE);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], refValueE);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[3], refValueE);
         }
         else
         {
-            EXPECT_FLOAT_EQ(eMasses[0], 0.);
-            EXPECT_FLOAT_EQ(eMasses[3], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[3], 0.);
         }
 
         // -- remove quad id: 0 --
         modifier->removeQuads(elemIds, true, true);
         EXPECT_EQ(vMasses.size(), 7);
         EXPECT_EQ(eMasses.size(), 12);
-        EXPECT_FLOAT_EQ(mass->getTotalMass(), expectedTotalMass - 2 * massElem);
+        EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), expectedTotalMass - 2 * massElem);
 
         // check vertex mass
-        EXPECT_FLOAT_EQ(vMasses[0], refValueV);
-        EXPECT_FLOAT_EQ(vMasses[1], refValueV);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[0], refValueV);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[1], refValueV);
         // check edge mass (only if not lumped else eMass is not computed)
         if(!lumped)
         {
-            EXPECT_FLOAT_EQ(eMasses[0], refValueE);
-            EXPECT_FLOAT_EQ(eMasses[3], refValueE);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], refValueE);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[3], refValueE);
         }
         else
         {
-            EXPECT_FLOAT_EQ(eMasses[0], 0.);
-            EXPECT_FLOAT_EQ(eMasses[3], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[3], 0.);
         }
 
         // -- remove quad id: 0, 1 --
@@ -1744,21 +1746,21 @@ public:
         // check value at init
         EXPECT_EQ(vMasses.size(), 9);
         EXPECT_EQ(eMasses.size(), 16);
-        EXPECT_FLOAT_EQ(mass->getTotalMass(), expectedTotalMass);
+        EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), expectedTotalMass);
 
         // check vertex mass
-        EXPECT_FLOAT_EQ(vMasses[0], refValueV * 2);
-        EXPECT_FLOAT_EQ(vMasses[1], refValueV * 3);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[0], refValueV * 2);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[1], refValueV * 3);
         // check edge mass (only if not lumped else eMass is not computed)
         if(!lumped)
         {
-            EXPECT_FLOAT_EQ(eMasses[0], refValueE * 2);
-            EXPECT_FLOAT_EQ(eMasses[1], refValueE * 2);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], refValueE * 2);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[1], refValueE * 2);
         }
         else
         {
-            EXPECT_FLOAT_EQ(eMasses[0], 0.);
-            EXPECT_FLOAT_EQ(eMasses[1], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[1], 0.);
         }
 
 
@@ -1767,42 +1769,42 @@ public:
         modifier->removeTriangles(elemIds, true, true);
         EXPECT_EQ(vMasses.size(), 9);
         EXPECT_EQ(eMasses.size(), 15);
-        EXPECT_FLOAT_EQ(mass->getTotalMass(), expectedTotalMass - massElem);
+        EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), expectedTotalMass - massElem);
 
         // check vertex mass
-        EXPECT_FLOAT_EQ(vMasses[0], refValueV); // check update of Mass when removing tetra
-        EXPECT_FLOAT_EQ(vMasses[1], refValueV * 2);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[0], refValueV); // check update of Mass when removing tetra
+        EXPECT_FLOATINGPOINT_EQ(vMasses[1], refValueV * 2);
         // check edge mass (only if not lumped else eMass is not computed)
         if(!lumped)
         {
-            EXPECT_FLOAT_EQ(eMasses[0], refValueE);
-            EXPECT_FLOAT_EQ(eMasses[3], refValueE * 2);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], refValueE);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[3], refValueE * 2);
         }
         else
         {
-            EXPECT_FLOAT_EQ(eMasses[0], 0.);
-            EXPECT_FLOAT_EQ(eMasses[3], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[3], 0.);
         }
 
         // -- remove triangle id: 0 --
         modifier->removeTriangles(elemIds, true, true);
         EXPECT_EQ(vMasses.size(), 9);
         EXPECT_EQ(eMasses.size(), 14);
-        EXPECT_FLOAT_EQ(mass->getTotalMass(), expectedTotalMass - 2 * massElem);
+        EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), expectedTotalMass - 2 * massElem);
 
         // check vertex mass
-        EXPECT_FLOAT_EQ(vMasses[0], refValueV);
-        EXPECT_FLOAT_EQ(vMasses[1], refValueV * 2);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[0], refValueV);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[1], refValueV * 2);
         // check edge mass (only if not lumped else eMass is not computed)
         if(!lumped)
         {
-            EXPECT_FLOAT_EQ(eMasses[0], refValueE);
-            EXPECT_FLOAT_EQ(eMasses[3], refValueE * 2);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], refValueE);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[3], refValueE * 2);
         }
         else
         {
-            EXPECT_FLOAT_EQ(eMasses[0], 0.);
-            EXPECT_FLOAT_EQ(eMasses[3], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[3], 0.);
         }
 
         // -- remove triangle id: 0, 1 --
@@ -1810,21 +1812,21 @@ public:
         modifier->removeTriangles(elemIds, true, true);
         EXPECT_EQ(vMasses.size(), 7);
         EXPECT_EQ(eMasses.size(), 10);
-        EXPECT_FLOAT_EQ(mass->getTotalMass(), expectedTotalMass - 4 * massElem);
+        EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), expectedTotalMass - 4 * massElem);
 
         // check vertex mass
-        EXPECT_FLOAT_EQ(vMasses[0], refValueV * 2);
-        EXPECT_FLOAT_EQ(vMasses[1], refValueV * 2);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[0], refValueV * 2);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[1], refValueV * 2);
         // check edge mass (only if not lumped else eMass is not computed)
         if(!lumped)
         {
-            EXPECT_FLOAT_EQ(eMasses[0], refValueE);
-            EXPECT_FLOAT_EQ(eMasses[3], refValueE);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], refValueE);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[3], refValueE);
         }
         else
         {
-            EXPECT_FLOAT_EQ(eMasses[0], 0.);
-            EXPECT_FLOAT_EQ(eMasses[3], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[0], 0.);
+            EXPECT_FLOATINGPOINT_EQ(eMasses[3], 0.);
         }
 
         // -- remove triangle id: 0, 1, 2, 3 --
@@ -1886,7 +1888,7 @@ public:
 
         const VecMass& vMasses = mass->d_vertexMass.getValue();
         const VecMass& eMasses = mass->d_edgeMass.getValue();
-       static const MassType wrongValue = 0; 
+        static const MassType wrongValue = 0;
        // TODO epernod 2021-06-29: MeshMatrixMass based on edge topology doesn't support topological changes
        // Keeping expected values for record
        /*
@@ -1902,41 +1904,41 @@ public:
         // check value at init
         EXPECT_EQ(vMasses.size(), 4);
         EXPECT_EQ(eMasses.size(), 3);
-        EXPECT_FLOAT_EQ(mass->getTotalMass(), /*expectedTotalMass*/ wrongValue);
+        EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), /*expectedTotalMass*/ wrongValue);
 
         // check vertex mass
-        EXPECT_FLOAT_EQ(vMasses[0], wrongValue);
-        EXPECT_FLOAT_EQ(vMasses[1], wrongValue);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[0], wrongValue);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[1], wrongValue);
         // check edge mass
-        EXPECT_FLOAT_EQ(eMasses[0], wrongValue);
-        EXPECT_FLOAT_EQ(eMasses[1], wrongValue);
+        EXPECT_FLOATINGPOINT_EQ(eMasses[0], wrongValue);
+        EXPECT_FLOATINGPOINT_EQ(eMasses[1], wrongValue);
 
         // -- remove edge id: 0 -- 
         sofa::type::vector<sofa::Index> elemIds = { 0 };
         modifier->removeEdges(elemIds, true);
         EXPECT_EQ(vMasses.size(), 3);
         EXPECT_EQ(eMasses.size(), 2);
-        EXPECT_FLOAT_EQ(mass->getTotalMass(), /*expectedTotalMass - massElem*/ wrongValue);
+        EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), /*expectedTotalMass - massElem*/ wrongValue);
 
         // check vertex mass
-        EXPECT_FLOAT_EQ(vMasses[0], wrongValue); // check update of Mass when removing tetra
-        EXPECT_FLOAT_EQ(vMasses[1], wrongValue);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[0], wrongValue); // check update of Mass when removing tetra
+        EXPECT_FLOATINGPOINT_EQ(vMasses[1], wrongValue);
         // check edge mass
-        EXPECT_FLOAT_EQ(eMasses[0], wrongValue);
-        EXPECT_FLOAT_EQ(eMasses[1], wrongValue);
+        EXPECT_FLOATINGPOINT_EQ(eMasses[0], wrongValue);
+        EXPECT_FLOATINGPOINT_EQ(eMasses[1], wrongValue);
 
 
         // -- remove edge id: 0 --
         modifier->removeEdges(elemIds, true);
         EXPECT_EQ(vMasses.size(), 2);
         EXPECT_EQ(eMasses.size(), 1);
-        EXPECT_FLOAT_EQ(mass->getTotalMass(), /*expectedTotalMass - 2 * massElem*/ wrongValue);
+        EXPECT_FLOATINGPOINT_EQ(mass->getTotalMass(), /*expectedTotalMass - 2 * massElem*/ wrongValue);
 
         // check vertex mass
-        EXPECT_FLOAT_EQ(vMasses[0], wrongValue);
-        EXPECT_FLOAT_EQ(vMasses[1], wrongValue);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[0], wrongValue);
+        EXPECT_FLOATINGPOINT_EQ(vMasses[1], wrongValue);
         // check edge mass
-        EXPECT_FLOAT_EQ(eMasses[0], wrongValue);
+        EXPECT_FLOATINGPOINT_EQ(eMasses[0], wrongValue);
 
 
         // -- remove edge id: 0 --


### PR DESCRIPTION
In `modules/SofaMiscForceField/SofaMiscForceField_test/MeshMatrixMass_test.cpp`, the tests used `EXPECT_FLOAT_EQ`. It supposed that both values are of type `float`. In these tests, they are actually of type `SReal`, which is `double` by default. Hence, a type conversion from `double` to `float`.

A macro detecting the type is introduced, and replaces `EXPECT_FLOAT_EQ`.

Note that, line 1372, I had to change the test. The test with `EXPECT_FLOATINGPOINT_EQ` failed due to the higher precision.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
