### PR TITLE
[SofaCUDA] Remove calls to __umul24 on device

### DIFF
--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaBarycentricMapping.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaBarycentricMapping.cu
@@ -100,7 +100,7 @@ struct __align__(8) GPULinearMap
 template<class TIn>
 __global__ void RegularGridMapperCuda3f_apply_kernel(unsigned int size, unsigned int nx, unsigned int nxny, const GPUCubeData* map, float* out, const TIn* in)
 {
-    const int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    const int index0 = blockIdx.x * BSIZE; //blockDim.x;
     const int index1 = threadIdx.x;
 
     //! Dynamically allocated shared memory to reorder global memory access
@@ -135,7 +135,7 @@ __global__ void RegularGridMapperCuda3f_apply_kernel(unsigned int size, unsigned
 
     //__syncthreads();
 
-    const int index3 = umul24(3,index1);
+    const int index3 = 3 * index1;
 
     temp[index3  ] = res.x;
     temp[index3+1] = res.y;
@@ -143,7 +143,7 @@ __global__ void RegularGridMapperCuda3f_apply_kernel(unsigned int size, unsigned
 
     __syncthreads();
 
-    out += umul24(index0,3);
+    out += index0 * 3;
     out[index1        ] = temp[index1        ];
     out[index1+  BSIZE] = temp[index1+  BSIZE];
     out[index1+2*BSIZE] = temp[index1+2*BSIZE];
@@ -153,7 +153,7 @@ __global__ void RegularGridMapperCuda3f_apply_kernel(unsigned int size, unsigned
 template<class TIn>
 __global__ void RegularGridMapperCuda3f1_apply_kernel(unsigned int size, unsigned int nx, unsigned int nxny, const GPUCubeData* map, CudaVec4<float>* out, const TIn* in)
 {
-    const int index = umul24(blockIdx.x,BSIZE) + threadIdx.x;
+    const int index = blockIdx.x * BSIZE + threadIdx.x;
 
     CudaVec3<float> res = CudaVec3<float>::make(0,0,0);
 
@@ -188,7 +188,7 @@ __global__ void RegularGridMapperCuda3f1_apply_kernel(unsigned int size, unsigne
 template<class TIn>
 __global__ void RegularGridMapperCuda3f_applyJT_kernel(unsigned int size, unsigned int maxNOut, const GPULinearMap* mapT, float* out, const TIn* in)
 {
-    const int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    const int index0 = blockIdx.x * BSIZE; //blockDim.x;
     const int index1 = threadIdx.x;
 
     //! Dynamically allocated shared memory to reorder global memory access
@@ -197,7 +197,7 @@ __global__ void RegularGridMapperCuda3f_applyJT_kernel(unsigned int size, unsign
     CudaVec3<float> res = CudaVec3<float>::make(0,0,0);
     //res += *in * mapT[index0+index1].f;
 
-    mapT+=umul24(index0,maxNOut)+index1;
+    mapT+=index0 * maxNOut + index1;
     for (int s = 0; s < maxNOut; s++)
     {
         GPULinearMap data = *mapT;
@@ -206,7 +206,7 @@ __global__ void RegularGridMapperCuda3f_applyJT_kernel(unsigned int size, unsign
             res += CudaVec3<float>::make(in[data.i]) * data.f;
     }
 
-    const int index3 = umul24(index1,3);
+    const int index3 = index1 * 3;
 
     temp[index3  ] = res.x;
     temp[index3+1] = res.y;
@@ -214,7 +214,7 @@ __global__ void RegularGridMapperCuda3f_applyJT_kernel(unsigned int size, unsign
 
     __syncthreads();
 
-    out += umul24(index0,3);
+    out += index0 * 3;
     out[index1        ] += temp[index1        ];
     out[index1+  BSIZE] += temp[index1+  BSIZE];
     out[index1+2*BSIZE] += temp[index1+2*BSIZE];
@@ -223,14 +223,14 @@ __global__ void RegularGridMapperCuda3f_applyJT_kernel(unsigned int size, unsign
 template<class TIn>
 __global__ void RegularGridMapperCuda3f1_applyJT_kernel(unsigned int size, unsigned int maxNOut, const GPULinearMap* mapT, CudaVec4<float>* out, const TIn* in)
 {
-    const int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    const int index0 = blockIdx.x * BSIZE; //blockDim.x;
     const int index1 = threadIdx.x;
     const int index = index0+index1;
 
     CudaVec3<float> res = CudaVec3<float>::make(0,0,0);
     //res += *in * mapT[index0+index1].f;
 
-    mapT+=umul24(index0,maxNOut)+index1;
+    mapT+=index0 * maxNOut + index1;
     for (int s = 0; s < maxNOut; s++)
     {
         GPULinearMap data = *mapT;
@@ -253,7 +253,7 @@ __global__ void RegularGridMapperCuda3f1_applyJT_kernel(unsigned int size, unsig
 template<class TIn>
 __global__ void MeshMapperCuda3f_apply_kernel(unsigned int size, unsigned int maxN, const GPULinearMap* map, float* out, const TIn* in)
 {
-    const int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    const int index0 = blockIdx.x * BSIZE; //blockDim.x;
     const int index1 = threadIdx.x;
 
     //! Dynamically allocated shared memory to reorder global memory access
@@ -262,7 +262,7 @@ __global__ void MeshMapperCuda3f_apply_kernel(unsigned int size, unsigned int ma
     CudaVec3<float> res = CudaVec3<float>::make(0,0,0);
     //res += *in * mapT[index0+index1].f;
 
-    map+=umul24(index0,maxN)+index1;
+    map+=index0 * maxN + index1;
     for (int s = 0; s < maxN; s++)
     {
         GPULinearMap data = *map;
@@ -271,7 +271,7 @@ __global__ void MeshMapperCuda3f_apply_kernel(unsigned int size, unsigned int ma
             res += CudaVec3<float>::make(in[data.i-1]) * data.f;
     }
 
-    const int index3 = umul24(index1,3);
+    const int index3 = index1 * 3;
 
     temp[index3  ] = res.x;
     temp[index3+1] = res.y;
@@ -279,7 +279,7 @@ __global__ void MeshMapperCuda3f_apply_kernel(unsigned int size, unsigned int ma
 
     __syncthreads();
 
-    out += umul24(index0,3);
+    out += index0 * 3;
     out[index1        ] = temp[index1        ];
     out[index1+  BSIZE] = temp[index1+  BSIZE];
     out[index1+2*BSIZE] = temp[index1+2*BSIZE];
@@ -288,14 +288,14 @@ __global__ void MeshMapperCuda3f_apply_kernel(unsigned int size, unsigned int ma
 template<class TIn>
 __global__ void MeshMapperCuda3f1_apply_kernel(unsigned int size, unsigned int maxN, const GPULinearMap* map, CudaVec4<float>* out, const TIn* in)
 {
-    const int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    const int index0 = blockIdx.x * BSIZE; //blockDim.x;
     const int index1 = threadIdx.x;
     const int index = index0+index1;
 
     CudaVec3<float> res = CudaVec3<float>::make(0,0,0);
     //res += *in * mapT[index0+index1].f;
 
-    map+=umul24(index0,maxN)+index1;
+    map+=index0 * maxN + index1;
     for (int s = 0; s < maxN; s++)
     {
         GPULinearMap data = *map;
@@ -320,7 +320,7 @@ __global__ void MeshMapperCuda3f1_apply_kernel(unsigned int size, unsigned int m
 template<class TIn>
 __global__ void MeshMapperCuda3f_applyPEq_kernel(unsigned int size, unsigned int maxN, const GPULinearMap* map, float* out, const TIn* in)
 {
-    const int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    const int index0 = blockIdx.x * BSIZE; //blockDim.x;
     const int index1 = threadIdx.x;
 
     //! Dynamically allocated shared memory to reorder global memory access
@@ -329,7 +329,7 @@ __global__ void MeshMapperCuda3f_applyPEq_kernel(unsigned int size, unsigned int
     CudaVec3<float> res = CudaVec3<float>::make(0,0,0);
     //res += *in * mapT[index0+index1].f;
 
-    map+=umul24(index0,maxN)+index1;
+    map+=index0 * maxN + index1;
     for (int s = 0; s < maxN; s++)
     {
         GPULinearMap data = *map;
@@ -338,7 +338,7 @@ __global__ void MeshMapperCuda3f_applyPEq_kernel(unsigned int size, unsigned int
             res += CudaVec3<float>::make(in[data.i-1]) * data.f;
     }
 
-    const int index3 = umul24(index1,3);
+    const int index3 = index1 * 3;
 
     temp[index3  ] = res.x;
     temp[index3+1] = res.y;
@@ -346,7 +346,7 @@ __global__ void MeshMapperCuda3f_applyPEq_kernel(unsigned int size, unsigned int
 
     __syncthreads();
 
-    out += umul24(index0,3);
+    out += index0 * 3;
     out[index1        ] += temp[index1        ];
     out[index1+  BSIZE] += temp[index1+  BSIZE];
     out[index1+2*BSIZE] += temp[index1+2*BSIZE];
@@ -355,14 +355,14 @@ __global__ void MeshMapperCuda3f_applyPEq_kernel(unsigned int size, unsigned int
 template<class TIn>
 __global__ void MeshMapperCuda3f1_applyPEq_kernel(unsigned int size, unsigned int maxN, const GPULinearMap* map, CudaVec4<float>* out, const TIn* in)
 {
-    const int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    const int index0 = blockIdx.x * BSIZE; //blockDim.x;
     const int index1 = threadIdx.x;
     const int index = index0+index1;
 
     CudaVec3<float> res = CudaVec3<float>::make(0,0,0);
     //res += *in * mapT[index0+index1].f;
 
-    map+=umul24(index0,maxN)+index1;
+    map+=index0 * maxN + index1;
     for (int s = 0; s < maxN; s++)
     {
         GPULinearMap data = *map;
@@ -381,10 +381,10 @@ __global__ void MeshMapperCuda3f1_applyPEq_kernel(unsigned int size, unsigned in
 template<class TIn>
 __global__ void SparseGridMapperCuda3f_apply_kernel(unsigned int size, const int * cudaHexa, const GPUCubeData* map, float* out, const TIn* in)
 {
-    const int index0 = umul24(blockIdx.x,SPARSE_GRID_BSIZE);
+    const int index0 = blockIdx.x * SPARSE_GRID_BSIZE;
     const int index1 = threadIdx.x;
-    const int index3 = umul24(3,index1);
-    out += umul24(index0,3);
+    const int index3 = 3 * index1;
+    out += index0 * 3;
 
     if (index0+index1 < size)
     {
@@ -408,7 +408,7 @@ __global__ void SparseGridMapperCuda3f_apply_kernel(unsigned int size, const int
 template<class TIn>
 __global__ void SparseGridMapperCuda3f1_apply_kernel(unsigned int size, const int * cudaHexa, const GPUCubeData* map, CudaVec4<float>* out, const TIn* in)
 {
-    const int index0 = umul24(blockIdx.x,SPARSE_GRID_BSIZE);
+    const int index0 = blockIdx.x * SPARSE_GRID_BSIZE;
     const int index1 = threadIdx.x;
 
     if (index0+index1 < size)
@@ -507,7 +507,7 @@ __global__ void SparseGridMapperCuda3f_applyJT_kernel(unsigned int size, const u
 
     if (tx<3)
     {
-        out += umul24(bi,3);
+        out += bi * 3;
         out[tx] += ((float*) &readValue[0])[tx];
     }
 }

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaBaseVector.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaBaseVector.cu
@@ -54,7 +54,7 @@ extern "C"
 template<class real>
 __global__ void Cuda_CopyVector_kernel(int dim, const real * a, real * b)
 {
-    int ti = umul24(blockIdx.x,BSIZE) + threadIdx.x;
+    int ti = blockIdx.x * BSIZE + threadIdx.x;
     if (ti >= dim) return;
     b[ti] = a[ti];
 }
@@ -80,7 +80,7 @@ void SOFA_GPU_CUDA_API copy_vectord(int dim,const void * a, void * b)
 template<class real>
 __global__ void Cuda_vector_vector_peq_kernel(int dim,real f, const real * a, real * b)
 {
-    int ti = umul24(blockIdx.x,BSIZE) + threadIdx.x;
+    int ti = blockIdx.x * BSIZE + threadIdx.x;
     if (ti >= dim) return;
     b[ti] += a[ti]*f;
 }
@@ -107,7 +107,7 @@ void SOFA_GPU_CUDA_API vector_vector_peqd(int dim,double f,const void * a,void *
 template<class real>
 __global__ void Cuda_sub_vector_kernel(int dim,const real * a, const real * b, real * r)
 {
-    int ti = umul24(blockIdx.x,BSIZE) + threadIdx.x;
+    int ti = blockIdx.x * BSIZE + threadIdx.x;
     if (ti >= dim) return;
     r[ti] = a[ti] - b[ti];
 }
@@ -134,7 +134,7 @@ void SOFA_GPU_CUDA_API sub_vector_vectord(int dim,const void * a, const void * b
 template<class real>
 __global__ void permute_vector_kernel(int dim,const real * a, const int * perm, real * b)
 {
-    int ti = umul24(blockIdx.x,BSIZE) + threadIdx.x;
+    int ti = blockIdx.x * BSIZE + threadIdx.x;
     if (ti >= dim) return;
     b[ti] = a[perm[ti]];
 }

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaDiagonalMass.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaDiagonalMass.cu
@@ -48,7 +48,7 @@ extern "C"
 template<class real>
 __global__ void DiagonalMassCuda_addMDx_kernel(int size,real factor, const real * mass, const real* dx, real* res)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     int index3 = index * 3;
     if (index < size)
     {
@@ -61,7 +61,7 @@ __global__ void DiagonalMassCuda_addMDx_kernel(int size,real factor, const real 
 template<class real>
 __global__ void DiagonalMassCuda_accFromF_kernel(int size, const real * inv_mass, const real* f, real* a)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     int index3 = index * 3;
     if (index < size)
     {
@@ -74,7 +74,7 @@ __global__ void DiagonalMassCuda_accFromF_kernel(int size, const real * inv_mass
 template<class real>
 __global__ void DiagonalMassCuda_addForce_kernel(int size, const real * mass, real g_x, real g_y, real g_z, real* f)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     int index3 = index * 3;
     if (index < size)
     {

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaEllipsoidForceField.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaEllipsoidForceField.cu
@@ -64,8 +64,8 @@ int EllipsoidForceFieldCuda3f_getNTmp()
 
 __global__ void EllipsoidForceFieldCuda3f_addForce_kernel(int size, GPUEllipsoid ellipsoid, float* tmp, float* f, const float* x, const float* v)
 {
-    int index0 = umul24(blockIdx.x,BSIZE);
-    int index0_3 = umul24(blockIdx.x,BSIZE*3); //index0*3;
+    int index0 = blockIdx.x * BSIZE;
+    int index0_3 = index0 * 3;
 
     tmp += index0*NTMP;
     f += index0_3;
@@ -73,7 +73,7 @@ __global__ void EllipsoidForceFieldCuda3f_addForce_kernel(int size, GPUEllipsoid
     v += index0_3;
 
     int index = threadIdx.x;
-    int index_3 = umul24(index,3); //index*3;
+    int index_3 = index * 3;
 
     //! Dynamically allocated shared memory to reorder global memory access
     extern  __shared__  float temp[];
@@ -157,8 +157,8 @@ __global__ void EllipsoidForceFieldCuda3f_addForce_kernel(int size, GPUEllipsoid
 
 __global__ void EllipsoidForceFieldCuda3f1_addForce_kernel(int size, GPUEllipsoid ellipsoid, float* tmp, CudaVec4<float>* f, const CudaVec4<float>* x, const CudaVec4<float>* v)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
-    tmp += umul24(blockIdx.x,BSIZE*NTMP);
+    int index = blockIdx.x * BSIZE+threadIdx.x;
+    tmp += blockIdx.x * BSIZE * NTMP;
 
     CudaVec4<float> temp = x[index];
     CudaVec3<float> dp = CudaVec3<float>::make(temp) - ellipsoid.center;
@@ -220,15 +220,15 @@ __global__ void EllipsoidForceFieldCuda3f1_addForce_kernel(int size, GPUEllipsoi
 
 __global__ void EllipsoidForceFieldCuda3f_addDForce_kernel(int size, const float* tmp, float* df, const float* dx, float factor)
 {
-    int index0 = umul24(blockIdx.x,BSIZE);
-    int index0_3 = umul24(blockIdx.x,BSIZE*3); //index0*3;
+    int index0 = blockIdx.x * BSIZE;
+    int index0_3 = index0 * 3;
 
     tmp += index0*NTMP;
     df += index0_3;
     dx += index0_3;
 
     int index = threadIdx.x;
-    int index_3 = umul24(index,3); //index*3;
+    int index_3 = index * 3;
 
     //! Dynamically allocated shared memory to reorder global memory access
     extern  __shared__  float temp[];
@@ -276,8 +276,8 @@ __global__ void EllipsoidForceFieldCuda3f_addDForce_kernel(int size, const float
 
 __global__ void EllipsoidForceFieldCuda3f1_addDForce_kernel(int size, const float* tmp, CudaVec4<float>* df, const CudaVec4<float>* dx, float factor)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
-    tmp += umul24(blockIdx.x,BSIZE*NTMP);
+    int index = blockIdx.x * BSIZE+threadIdx.x;
+    tmp += blockIdx.x * BSIZE * NTMP;
 
     CudaVec4<float> dxi = dx[index];
     float d = tmp[threadIdx.x+0*BSIZE];

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaFixedConstraint.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaFixedConstraint.cu
@@ -63,7 +63,7 @@ extern "C"
 template<class real>
 __global__ void FixedConstraintCuda1t_projectResponseContiguous_kernel(int size, real* dx)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     if (index < size)
         dx[index] = 0.0f;
 }
@@ -71,7 +71,7 @@ __global__ void FixedConstraintCuda1t_projectResponseContiguous_kernel(int size,
 template<class real>
 __global__ void FixedConstraintCuda3t_projectResponseContiguous_kernel(int size, CudaVec3<real>* dx)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     if (index < size)
         dx[index] = CudaVec3<real>::make(0.0f,0.0f,0.0f);
 }
@@ -79,7 +79,7 @@ __global__ void FixedConstraintCuda3t_projectResponseContiguous_kernel(int size,
 template<class real>
 __global__ void FixedConstraintCuda3t1_projectResponseContiguous_kernel(int size, CudaVec4<real>* dx)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     if (index < size)
         dx[index] = CudaVec4<real>::make(0.0f,0.0f,0.0f,0.0f);
 }
@@ -87,7 +87,7 @@ __global__ void FixedConstraintCuda3t1_projectResponseContiguous_kernel(int size
 template<class real>
 __global__ void FixedConstraintCudaRigid3t_projectResponseContiguous_kernel(int size, CudaRigidDeriv3<real>* dx)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     if (index < size)
         dx[index] = CudaRigidDeriv3<real>::make(0.0f,0.0f,0.0f,0.0f,0.0f,0.0f);
 }
@@ -95,7 +95,7 @@ __global__ void FixedConstraintCudaRigid3t_projectResponseContiguous_kernel(int 
 template<class real>
 __global__ void FixedConstraintCuda1t_projectResponseIndexed_kernel(int size, const int* indices, real* dx)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     if (index < size)
         dx[indices[index]] = 0.0f;
 }
@@ -103,7 +103,7 @@ __global__ void FixedConstraintCuda1t_projectResponseIndexed_kernel(int size, co
 template<class real>
 __global__ void FixedConstraintCuda3t_projectResponseIndexed_kernel(int size, const int* indices, CudaVec3<real>* dx)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     if (index < size)
         dx[indices[index]] = CudaVec3<real>::make(0.0f,0.0f,0.0f);
 }
@@ -111,7 +111,7 @@ __global__ void FixedConstraintCuda3t_projectResponseIndexed_kernel(int size, co
 template<class real>
 __global__ void FixedConstraintCuda3t1_projectResponseIndexed_kernel(int size, const int* indices, CudaVec4<real>* dx)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     if (index < size)
         dx[indices[index]] = CudaVec4<real>::make(0.0f,0.0f,0.0f,0.0f);
 }
@@ -119,7 +119,7 @@ __global__ void FixedConstraintCuda3t1_projectResponseIndexed_kernel(int size, c
 template<class real>
 __global__ void FixedConstraintCudaRigid3t_projectResponseIndexed_kernel(int size, const int* indices, CudaRigidDeriv3<real>* dx)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     if (index < size)
         dx[indices[index]] = CudaRigidDeriv3<real>::make(0.0f,0.0f,0.0f,0.0f,0.0f,0.0f);
 }

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaHexahedronFEMForceField.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaHexahedronFEMForceField.cu
@@ -937,18 +937,18 @@ __global__ void HexahedronFEMForceFieldCuda3t_calcDForce_kernel(int nbElem, cons
 template<typename real, int BSIZE>
 __global__ void HexahedronFEMForceFieldCuda3t_addForce1_kernel(int nbVertex, unsigned int nbElemPerVertex, const CudaVec4<real>* eforce, const int* velems, real* f)
 {
-    int index0 = fastmul(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x*BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
-    int index3 = fastmul(index1,3); //3*index1;
+    int index3 = 3 * index1;
 
     //! Shared memory buffer to reorder global memory access
     __shared__  real temp[BSIZE*3];
 
-    int iext = fastmul(blockIdx.x,BSIZE*3)+index1; //index0*3+index1;
+    int iext = blockIdx.x*BSIZE*3+index1; //index0*3+index1;
 
     CudaVec3<real> force = CudaVec3<real>::make(0.0f,0.0f,0.0f);
 
-    velems+=fastmul(index0,nbElemPerVertex)+index1;
+    velems+=index0*nbElemPerVertex+index1;
 
     if (index0+index1 < nbVertex)
         for (int s = 0; s < nbElemPerVertex; s++)
@@ -976,7 +976,7 @@ __global__ void HexahedronFEMForceFieldCuda3t_addForce1_kernel(int nbVertex, uns
 template<typename real, int BSIZE>
 __global__ void HexahedronFEMForceFieldCuda3t_addForce4_kernel(int /*nbVertex*/, unsigned int nb4ElemPerVertex, const CudaVec4<real>* eforce, const int* velems, real* f)
 {
-    int index0 = fastmul(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x*BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
 
     //! Shared memory buffer to reorder global memory access
@@ -997,7 +997,7 @@ __global__ void HexahedronFEMForceFieldCuda3t_addForce4_kernel(int /*nbVertex*/,
         }
     }
 
-    int iout = fastmul((index1>>2) + ((index1&3)*(BSIZE/4)),3);
+    int iout = ((index1>>2) + ((index1&3)*(BSIZE/4)))*3;
     temp[iout  ] = force.x;
     temp[iout+1] = force.y;
     temp[iout+2] = force.z;
@@ -1010,7 +1010,7 @@ __global__ void HexahedronFEMForceFieldCuda3t_addForce4_kernel(int /*nbVertex*/,
 
         real res = temp[index1] + temp[index1+ (BSIZE/4)*3] + temp[index1+ 2*(BSIZE/4)*3] + temp[index1+ 3*(BSIZE/4)*3];
 
-        int iext = fastmul(blockIdx.x,(BSIZE/4)*3)+index1; //index0*3+index1;
+        int iext = blockIdx.x*(BSIZE/4)*3+index1; //index0*3+index1;
 
         f[iext] += res;
     }
@@ -1019,7 +1019,7 @@ __global__ void HexahedronFEMForceFieldCuda3t_addForce4_kernel(int /*nbVertex*/,
 template<typename real, int BSIZE>
 __global__ void HexahedronFEMForceFieldCuda3t_addForce8_kernel(int /*nbVertex*/, unsigned int nb8ElemPerVertex, const CudaVec4<real>* eforce, const int* velems, real* f)
 {
-    int index0 = fastmul(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x*BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
 
     //! Shared memory buffer to reorder global memory access
@@ -1040,7 +1040,7 @@ __global__ void HexahedronFEMForceFieldCuda3t_addForce8_kernel(int /*nbVertex*/,
         }
     }
 
-    int iout = fastmul((index1>>3) + ((index1&3)*(BSIZE/8)),3);
+    int iout = ((index1>>3) + ((index1&3)*(BSIZE/8)))*3;
     if (index1&4)
     {
         temp[iout  ] = force.x;
@@ -1061,7 +1061,7 @@ __global__ void HexahedronFEMForceFieldCuda3t_addForce8_kernel(int /*nbVertex*/,
         // we need to merge 4 values together
         real res = temp[index1] + temp[index1+ (BSIZE/8)*3] + temp[index1+ 2*(BSIZE/8)*3] + temp[index1+ 3*(BSIZE/8)*3];
 
-        int iext = fastmul(blockIdx.x,(BSIZE/8)*3)+index1; //index0*3+index1;
+        int iext = blockIdx.x*(BSIZE/8)*3+index1; //index0*3+index1;
 
         f[iext] += res;
     }
@@ -1072,11 +1072,11 @@ __global__ void HexahedronFEMForceFieldCuda3t_getRotations1_kernel(int nbVertex,
 {
     int index0 = blockIdx.x * BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
-    int index9 = fastmul(index1,9); //3*index1;
+    int index9 = index1 * 9;
 
     __shared__  real temp[BSIZE*9];
 
-    int iext = fastmul(blockIdx.x,BSIZE*9)+index1; //index0*3+index1;
+    int iext = index0*9+index1;
 
     matrix3<real> R = matrix3<real>::make();
     int ne=0;
@@ -1160,7 +1160,7 @@ __global__ void HexahedronFEMForceFieldCuda3t_getRotations4_kernel(int nbVertex9
     }
 
     //int iout = (index1>>2)*3 + (index1&3)*((BSIZE/4)*3);
-    int iout = fastmul((index1>>2) + ((index1&3)*(BSIZE/4)),9);
+    int iout = ((index1>>2) + ((index1&3)*(BSIZE/4)))*9;
     temp[iout  ] = R.x.x;
     temp[iout+1] = R.x.y;
     temp[iout+2] = R.x.z;
@@ -1173,7 +1173,7 @@ __global__ void HexahedronFEMForceFieldCuda3t_getRotations4_kernel(int nbVertex9
 
     __syncthreads();
 
-    int iext = fastmul(blockIdx.x,(BSIZE/4)*9)+index1; //index0*3+index1;
+    int iext = blockIdx.x*(BSIZE/4)*9+index1; //index0*3+index1;
 
     if (iext>=nbVertex9) return;
     nrotation[iext] = (temp[index1] + temp[index1+ (BSIZE/4)*9] + temp[index1+ 2*(BSIZE/4)*9] + temp[index1+ 3*(BSIZE/4)*9])*0.25;
@@ -1222,7 +1222,7 @@ __global__ void HexahedronFEMForceFieldCuda3t_getRotations8_kernel(int nbVertex9
         R.x.x = 1.0;R.y.y = 1.0;R.z.z = 1.0;
     }
 
-    int iout = fastmul((index1>>3) + ((index1&3)*(BSIZE/8)),9);
+    int iout = ((index1>>3) + ((index1&3)*(BSIZE/8)))*9;
     if (index1&4)
     {
         temp[iout  ] = R.x.x;
@@ -1253,7 +1253,7 @@ __global__ void HexahedronFEMForceFieldCuda3t_getRotations8_kernel(int nbVertex9
 
     __syncthreads();
 
-    int iext = fastmul(blockIdx.x,(BSIZE/8)*9)+index1; //index0*3+index1;
+    int iext = blockIdx.x*(BSIZE/8)*9+index1; //index0*3+index1;
     if (iext>=nbVertex9) return;
     nrotation[iext] = (temp[index1] + temp[index1+ (BSIZE/8)*9] + temp[index1+ 2*(BSIZE/8)*9] + temp[index1+ 3*(BSIZE/8)*9])*0.25;
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaHexahedronFEMForceField.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaHexahedronFEMForceField.cu
@@ -260,7 +260,7 @@ public:
 
     static __inline__ __device__ CudaVec3<real> getX(int i, const TIn* x)
     {
-	int i3 = umul24(i,3);
+	int i3 = i * 3;
 	float x1 = tex1Dfetch(tex_3f_x, i3);
 	float x2 = tex1Dfetch(tex_3f_x, i3+1);
 	float x3 = tex1Dfetch(tex_3f_x, i3+2);
@@ -279,7 +279,7 @@ public:
 
     static __inline__ __device__ CudaVec3<real> getDX(int i, const TIn* dx)
     {
-	int i3 = umul24(i,3);
+	int i3 = i * 3;
 	float x1 = tex1Dfetch(tex_3f_dx, i3);
 	float x2 = tex1Dfetch(tex_3f_dx, i3+1);
 	float x3 = tex1Dfetch(tex_3f_dx, i3+2);
@@ -352,7 +352,7 @@ public:
 
     static __inline__ __device__ CudaVec3<real> getElementForce(int i, const TIn* x)
     {
-	int i3 = umul24(i,3);
+	int i3 = i * 3;
 	float x1 = tex1Dfetch(tex_3f_eforce, i3);
 	float x2 = tex1Dfetch(tex_3f_eforce, i3+1);
 	float x3 = tex1Dfetch(tex_3f_eforce, i3+2);
@@ -391,7 +391,7 @@ public:
 template<typename real, class TIn>
 __global__ void HexahedronFEMForceFieldCuda3t_calcForce_kernel(int nbElem, const GPUElement<real>* elems, GPURotation<real>* rotation,const GPUKMatrix<real>* kmatrix, real* eforce, const TIn* x)
 {
-  int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+  int index0 = blockIdx.x * BSIZE; //blockDim.x;
   int index1 = threadIdx.x;
   int index = index0+index1;
 
@@ -581,7 +581,7 @@ __global__ void HexahedronFEMForceFieldCuda3t_calcForce_kernel(int nbElem, const
     
   int HALFBSIZE = BSIZE<<1;
   extern __shared__ real temp[];
-  int index13 = umul24(index1,13);
+  int index13 = index1 * 13;
 
   temp[index13+0 ] = fA.x;
   temp[index13+1 ] = fA.y;
@@ -599,7 +599,7 @@ __global__ void HexahedronFEMForceFieldCuda3t_calcForce_kernel(int nbElem, const
   __syncthreads();
 
   // we write only the 4th first vertices of hexahedron
-  real* out = ((real*)eforce)+(umul24(blockIdx.x,BSIZE*32))+index1+umul24(index1>>4,16);
+  real* out = ((real*)eforce)+(blockIdx.x*BSIZE*32)+index1+(index1>>4)*16;
   real v = 0;
   index1 += (index1>>4) - (index1>>2);
 
@@ -654,7 +654,7 @@ __global__ void HexahedronFEMForceFieldCuda3t_calcForce_kernel(int nbElem, const
   __syncthreads();
 
   index1 = threadIdx.x;
-  out = ((real*)eforce)+(umul24(blockIdx.x,BSIZE*32))+index1+umul24(index1>>4,16)+16;
+  out = ((real*)eforce)+(blockIdx.x*BSIZE*32)+index1+(index1>>4)*16+16;
   index1 += (index1>>4) - (index1>>2);
 
    v = temp[index1]; index1 += (BSIZE+(BSIZE>>4)-(BSIZE>>2)); 
@@ -695,7 +695,7 @@ __global__ void HexahedronFEMForceFieldCuda3t_calcForce_kernel(int nbElem, const
 
 template<typename real, class TIn>
 __global__ void HexahedronFEMForceFieldCuda3t_calcDForce_kernel(int nbElem, const GPUElement<real>* elems, const GPURotation<real>* rotation,const GPUKMatrix<real>* kmatrix, real* eforce, const TIn* x, real fact) {
-  int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+  int index0 = blockIdx.x * BSIZE; //blockDim.x;
   int index1 = threadIdx.x;
   int index = index0+index1;
 
@@ -823,7 +823,7 @@ __global__ void HexahedronFEMForceFieldCuda3t_calcDForce_kernel(int nbElem, cons
   int HALFBSIZE = BSIZE<<1;
   real* temp = SharedMemory<real>::get();
 
-  int index13 = umul24(index1,13);
+  int index13 = index1 * 13;
   temp[index13+0 ] = fA.x;
   temp[index13+1 ] = fA.y;
   temp[index13+2 ] = fA.z;
@@ -840,7 +840,7 @@ __global__ void HexahedronFEMForceFieldCuda3t_calcDForce_kernel(int nbElem, cons
   __syncthreads();
 
   // we write only the 4th first vertices of hexahedron
-  real* out = ((real*)eforce)+(umul24(blockIdx.x,BSIZE*32))+index1+umul24(index1>>4,16);
+  real* out = ((real*)eforce)+(blockIdx.x*BSIZE*32)+index1+(index1>>4)*16;
   real v = 0;
   index1 += (index1>>4) - (index1>>2);
 
@@ -896,7 +896,7 @@ __global__ void HexahedronFEMForceFieldCuda3t_calcDForce_kernel(int nbElem, cons
 
 
   index1 = threadIdx.x;
-  out = ((real*)eforce)+(umul24(blockIdx.x,BSIZE*32))+index1+umul24(index1>>4,16)+16;
+  out = ((real*)eforce)+(blockIdx.x*BSIZE*32)+index1+(index1>>4)*16+16;
   index1 += (index1>>4) - (index1>>2);
 
   v = temp[index1]; index1 += (BSIZE+(BSIZE>>4)-(BSIZE>>2)); 
@@ -1070,7 +1070,7 @@ __global__ void HexahedronFEMForceFieldCuda3t_addForce8_kernel(int /*nbVertex*/,
 template<typename real, int BSIZE>
 __global__ void HexahedronFEMForceFieldCuda3t_getRotations1_kernel(int nbVertex, unsigned int nbElemPerVertex, const int* velems, const GPURotation<real>* erotation, const GPURotation<real>* irotation,real * nrotation)
 {
-    int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x * BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
     int index9 = fastmul(index1,9); //3*index1;
 
@@ -1081,7 +1081,7 @@ __global__ void HexahedronFEMForceFieldCuda3t_getRotations1_kernel(int nbVertex,
     matrix3<real> R = matrix3<real>::make();
     int ne=0;
 
-    velems+=umul24(index0,nbElemPerVertex)+index1;
+    velems += index0 * nbElemPerVertex + index1;
 
     if (index0+index1<nbVertex) {
         for (int s = 0;s < nbElemPerVertex; s++)
@@ -1129,7 +1129,7 @@ __global__ void HexahedronFEMForceFieldCuda3t_getRotations1_kernel(int nbVertex,
 template<typename real, int BSIZE>
 __global__ void HexahedronFEMForceFieldCuda3t_getRotations4_kernel(int nbVertex9, unsigned int nb4ElemPerVertex, const int* velems, const GPURotation<real>* erotation, const GPURotation<real>* irotation,real * nrotation)
 {
-    int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x * BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
 
     __shared__  real temp[BSIZE*9];
@@ -1192,7 +1192,7 @@ __global__ void HexahedronFEMForceFieldCuda3t_getRotations4_kernel(int nbVertex9
 template<typename real, int BSIZE>
 __global__ void HexahedronFEMForceFieldCuda3t_getRotations8_kernel(int nbVertex9, unsigned int nb8ElemPerVertex, const int* velems, const GPURotation<real>* erotation, const GPURotation<real>* irotation,real * nrotation)
 {
-    int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x * BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
 
     __shared__  real temp[BSIZE/2*9];

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaHexahedronTLEDForceField.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaHexahedronTLEDForceField.cu
@@ -164,7 +164,7 @@ static void setX(const void* x)
 // Device function returning the position of vertex i as a float3
 static __device__ CudaVec3f getX(int i)
 {
-    int i3 = umul24(i,3);
+    int i3 = i * 3;
     float x1 = tex1Dfetch(texX, i3);
     float x2 = tex1Dfetch(texX, i3+1);
     float x3 = tex1Dfetch(texX, i3+2);
@@ -183,7 +183,7 @@ static void setX0(const void* x0)
 // Device function returning the rest position of vertex i as a float3
 static __device__ CudaVec3f getX0(int i)
 {
-    int i3 = umul24(i,3);
+    int i3 = i * 3;
     float x1 = tex1Dfetch(texX0, i3);
     float x2 = tex1Dfetch(texX0, i3+1);
     float x3 = tex1Dfetch(texX0, i3+2);
@@ -210,7 +210,7 @@ static void setX0(const void* x0)
  */
 __global__ void CudaHexahedronTLEDForceField3f_calcForce_kernel0(float Lambda, float Mu, int nbElem, float4* F0_gpu, float4* F1_gpu, float4* F2_gpu, float4* F3_gpu, float4* F4_gpu, float4* F5_gpu, float4* F6_gpu, float4* F7_gpu)
 {
-    int index0 = umul24(blockIdx.x,BSIZE);
+    int index0 = blockIdx.x * BSIZE;
     int index1 = threadIdx.x;
     int index = index0+index1;
 
@@ -383,7 +383,7 @@ __global__ void CudaHexahedronTLEDForceField3f_calcForce_kernel0(float Lambda, f
  */
 __global__ void CudaHexahedronTLEDForceField3f_calcForce_kernel1(float Lambda, float Mu, int nbElem, float4* F0_gpu, float4* F1_gpu, float4* F2_gpu, float4* F3_gpu, float4* F4_gpu, float4* F5_gpu, float4* F6_gpu, float4* F7_gpu)
 {
-    int index0 = umul24(blockIdx.x,BSIZE);
+    int index0 = blockIdx.x * BSIZE;
     int index1 = threadIdx.x;
     int index = index0+index1;
 
@@ -563,7 +563,7 @@ __global__ void CudaHexahedronTLEDForceField3f_calcForce_kernel1(float Lambda, f
  */
 __global__ void CudaHexahedronTLEDForceField3f_calcForce_kernel2(float Lambda, float Mu, int nbElem, float4 * Di1, float4 * Di2, float4 * Dv1, float4 * Dv2, float4* F0_gpu, float4* F1_gpu, float4* F2_gpu, float4* F3_gpu, float4* F4_gpu, float4* F5_gpu, float4* F6_gpu, float4* F7_gpu)
 {
-    int index0 = umul24(blockIdx.x,BSIZE);
+    int index0 = blockIdx.x * BSIZE;
     int index1 = threadIdx.x;
     int index = index0+index1;
 
@@ -781,7 +781,7 @@ __global__ void CudaHexahedronTLEDForceField3f_calcForce_kernel2(float Lambda, f
  */
 __global__ void CudaHexahedronTLEDForceField3f_calcForce_kernel3(float Lambda, float Mu, int nbElem, float4 * Di1, float4 * Di2, float4 * Dv1, float4 * Dv2, float4* F0_gpu, float4* F1_gpu, float4* F2_gpu, float4* F3_gpu, float4* F4_gpu, float4* F5_gpu, float4* F6_gpu, float4* F7_gpu)
 {
-    int index0 = umul24(blockIdx.x,BSIZE);
+    int index0 = blockIdx.x * BSIZE;
     int index1 = threadIdx.x;
     int index = index0+index1;
 
@@ -1148,12 +1148,12 @@ __device__ float4 computeForce_hex(const int node, const float4 Dh0_a, const flo
  */
 __global__ void CudaHexahedronTLEDForceField3f_addForce_kernel(int nbVertex, unsigned int valence, float* f/*, float* test*/)
 {
-    int index0 = umul24(blockIdx.x,BSIZE);
+    int index0 = blockIdx.x * BSIZE;
     int index1 = threadIdx.x;
     int index = index0+index1;
 
-    int index3 = umul24(index1,3); //3*index1;
-    int iext = umul24(blockIdx.x,BSIZE*3)+index1; //index0*3+index1;
+    int index3 = index1 * 3; //3*index1;
+    int iext = index0 * 3 + index1;
 
     //! Dynamically allocated shared memory to reorder global memory access
     extern  __shared__  float temp[];

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearForceField.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearForceField.cu
@@ -49,7 +49,7 @@ extern "C"
 template<class real>
 __global__ void LinearForceFieldCudaRigid3t_addForce_kernel(unsigned size, const int* indices, real fx, real fy, real fz, real frx, real fry, real frz, CudaRigidDeriv3<real>* f)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
 
     CudaRigidDeriv3<real> force = CudaRigidDeriv3<real>::make(fx, fy, fz, frx, fry, frz);
     if (index < size)

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearMovementConstraint.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaLinearMovementConstraint.cu
@@ -61,7 +61,7 @@ extern "C"
 template<class real>
 __global__ void LinearMovementConstraintCudaVec6t_projectPositionIndexed_kernel(unsigned size, const int* indices, real dirX, real dirY, real dirZ, real dirU, real dirV, real dirW, const CudaVec6<real>* x0, CudaVec6<real>* x)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
 
     CudaVec6<real> m = CudaVec6<real>::make(dirX, dirY, dirZ, dirU, dirV, dirW);
     if (index < size)
@@ -74,7 +74,7 @@ __global__ void LinearMovementConstraintCudaVec6t_projectPositionIndexed_kernel(
 template<class real>
 __global__ void LinearMovementConstraintCudaRigid3t_projectResponseIndexed_kernel(unsigned size, const int* indices, CudaRigidDeriv3<real>* dx)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
 
     if (index < size)
     {
@@ -85,7 +85,7 @@ __global__ void LinearMovementConstraintCudaRigid3t_projectResponseIndexed_kerne
 template<class real>
 __global__ void LinearMovementConstraintCudaRigid3t_projectPositionIndexed_kernel(unsigned size, const int* indices, real dirX, real dirY, real dirZ, real dirU, real dirV, real dirW, const CudaRigidCoord3<real>* x0, CudaRigidCoord3<real>* x)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
 
     CudaRigidCoord3<real> m = CudaRigidCoord3<real>::make(dirX, dirY, dirZ, dirU, dirV, dirW, 0.0);
     if (index < size)
@@ -99,7 +99,7 @@ __global__ void LinearMovementConstraintCudaRigid3t_projectPositionIndexed_kerne
 template<class real>
 __global__ void LinearMovementConstraintCudaRigid3t_projectVelocityIndexed_kernel(unsigned size, const int* indices, real velX, real velY, real velZ, real velU, real velV, real velW, CudaRigidDeriv3<real>* dx)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
 
     CudaRigidDeriv3<real> vel = CudaRigidDeriv3<real>::make(velX, velY, velZ, velU, velV, velW);
     if (index < size)

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMath.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMath.h
@@ -34,12 +34,6 @@ namespace cuda
 {
 #endif
 
-#if (__CUDA_ARCH__ < 200)
-#define fastmul(x,y)	__mul24((x),(y))
-#else
-#define fastmul(x,y)	((x)*(y))
-#endif
-
 
 template<class real>
 class CudaVec2;

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMechanicalObject.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMechanicalObject.cu
@@ -270,7 +270,7 @@ extern "C"
 template<class real>
 __global__ void MechanicalObjectCudaVec1t_vClear_kernel(int size, real* res)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         res[index] = 0.0f;
@@ -280,7 +280,7 @@ __global__ void MechanicalObjectCudaVec1t_vClear_kernel(int size, real* res)
 template<class real>
 __global__ void MechanicalObjectCudaVec2t_vClear_kernel(int size, CudaVec2<real>* res)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         res[index] = CudaVec2<real>::make(0.0f,0.0f);
@@ -290,7 +290,7 @@ __global__ void MechanicalObjectCudaVec2t_vClear_kernel(int size, CudaVec2<real>
 template<class real>
 __global__ void MechanicalObjectCudaVec3t_vClear_kernel(int size, CudaVec3<real>* res)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         res[index] = CudaVec3<real>::make(0.0f,0.0f,0.0f);
@@ -300,7 +300,7 @@ __global__ void MechanicalObjectCudaVec3t_vClear_kernel(int size, CudaVec3<real>
 template<class real>
 __global__ void MechanicalObjectCudaVec3t1_vClear_kernel(int size, CudaVec4<real>* res)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         res[index] = CudaVec4<real>::make(0.0f,0.0f,0.0f,0.0f);
@@ -310,7 +310,7 @@ __global__ void MechanicalObjectCudaVec3t1_vClear_kernel(int size, CudaVec4<real
 template<class real>
 __global__ void MechanicalObjectCudaVec1t_vMEq_kernel(int size, real* res, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         res[index] *= f;
@@ -320,7 +320,7 @@ __global__ void MechanicalObjectCudaVec1t_vMEq_kernel(int size, real* res, real 
 template<class real>
 __global__ void MechanicalObjectCudaVec2t_vMEq_kernel(int size, real* res, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE*2)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 2 + threadIdx.x;
     //if (index < size)
     {
         res[index] *= f;
@@ -335,7 +335,7 @@ __global__ void MechanicalObjectCudaVec2t_vMEq_kernel(int size, real* res, real 
 template<class real>
 __global__ void MechanicalObjectCudaVec3t_vMEq_kernel(int size, real* res, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE*3)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 3 + threadIdx.x;
     //if (index < size)
     {
         res[index] *= f;
@@ -352,7 +352,7 @@ __global__ void MechanicalObjectCudaVec3t_vMEq_kernel(int size, real* res, real 
 template<class real>
 __global__ void MechanicalObjectCudaVec3t1_vMEq_kernel(int size, CudaVec4<real>* res, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         //res[index] = res[index]*f;
@@ -367,7 +367,7 @@ __global__ void MechanicalObjectCudaVec3t1_vMEq_kernel(int size, CudaVec4<real>*
 template<class real>
 __global__ void MechanicalObjectCudaRigid3t_vMEqCoord_kernel(int size, CudaRigidCoord3<real>* res, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
 
     if (index < size)
     {
@@ -385,7 +385,7 @@ __global__ void MechanicalObjectCudaRigid3t_vMEqCoord_kernel(int size, CudaRigid
 template<class real>
 __global__ void MechanicalObjectCudaRigid3t_vMEqDeriv_kernel(int size, real* res, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE*6)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 6 + threadIdx.x;
     //if (index < size)
     {
         res[index] *= f;
@@ -405,7 +405,7 @@ __global__ void MechanicalObjectCudaRigid3t_vMEqDeriv_kernel(int size, real* res
 template<class real>
 __global__ void MechanicalObjectCudaVec1t_vEqBF_kernel(int size, real* res, const real* b, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         res[index] = b[index] * f;
@@ -415,7 +415,7 @@ __global__ void MechanicalObjectCudaVec1t_vEqBF_kernel(int size, real* res, cons
 template<class real>
 __global__ void MechanicalObjectCudaVec2t_vEqBF_kernel(int size, real* res, const real* b, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE*2)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 2 + threadIdx.x;
     //if (index < size)
     {
         res[index] = b[index] * f;
@@ -430,7 +430,7 @@ __global__ void MechanicalObjectCudaVec2t_vEqBF_kernel(int size, real* res, cons
 template<class real>
 __global__ void MechanicalObjectCudaVec3t_vEqBF_kernel(int size, real* res, const real* b, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE*3)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 3 + threadIdx.x;
     //if (index < size)
     {
         res[index] = b[index] * f;
@@ -447,7 +447,7 @@ __global__ void MechanicalObjectCudaVec3t_vEqBF_kernel(int size, real* res, cons
 template<class real>
 __global__ void MechanicalObjectCudaVec3t1_vEqBF_kernel(int size, CudaVec4<real>* res, const CudaVec4<real>* b, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         //res[index] = b[index] * f;
@@ -462,7 +462,7 @@ __global__ void MechanicalObjectCudaVec3t1_vEqBF_kernel(int size, CudaVec4<real>
 template<class real>
 __global__ void MechanicalObjectCudaRigid3t_vEqBFCoord_kernel(int size, CudaRigidCoord3<real>* res, const CudaRigidCoord3<real>* b, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         CudaRigidCoord3<real> v = CudaRigidCoord3<real>::make(b[index]);
@@ -479,7 +479,7 @@ __global__ void MechanicalObjectCudaRigid3t_vEqBFCoord_kernel(int size, CudaRigi
 template<class real>
 __global__ void MechanicalObjectCudaRigid3t_vEqBFDeriv_kernel(int size, real* res, const real* b, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE*6)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 6 + threadIdx.x;
     //if (index < size)
     {
         res[index] = b[index] * f;
@@ -499,7 +499,7 @@ __global__ void MechanicalObjectCudaRigid3t_vEqBFDeriv_kernel(int size, real* re
 template<class real>
 __global__ void MechanicalObjectCudaVec1t_vPEq_kernel(int size, real* res, const real* a)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         res[index] += a[index];
@@ -509,7 +509,7 @@ __global__ void MechanicalObjectCudaVec1t_vPEq_kernel(int size, real* res, const
 template<class real>
 __global__ void MechanicalObjectCudaVec2t_vPEq_kernel(int size, CudaVec2<real>* res, const CudaVec2<real>* a)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     if (index < size)
     {
         //res[index] += a[index];
@@ -526,7 +526,7 @@ __global__ void MechanicalObjectCudaVec2t_vPEq_kernel(int size, CudaVec2<real>* 
 template<class real>
 __global__ void MechanicalObjectCudaVec3t_vPEq_kernel(int size, real* res, const real* a)
 {
-    int index = umul24(blockIdx.x,BSIZE*3)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 3 + threadIdx.x;
     //if (index < size)
     {
         res[index] += a[index];
@@ -544,7 +544,7 @@ __global__ void MechanicalObjectCudaVec3t_vPEq_kernel(int size, real* res, const
 template<class real>
 __global__ void MechanicalObjectCudaVec3t1_vPEq_kernel(int size, CudaVec4<real>* res, const CudaVec4<real>* a)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         //res[index] += a[index];
@@ -560,7 +560,7 @@ __global__ void MechanicalObjectCudaVec3t1_vPEq_kernel(int size, CudaVec4<real>*
 template<class real>
 __global__ void MechanicalObjectCudaRigid3t_vPEqCoord_kernel(int size, CudaRigidCoord3<real>* res, const CudaRigidCoord3<real>* a)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
 //	  CudaRigidCoord3<real> v = CudaRigidCoord3<real>::make(res[index]);
@@ -584,7 +584,7 @@ __global__ void MechanicalObjectCudaRigid3t_vPEqCoord_kernel(int size, CudaRigid
 template<class real>
 __global__ void MechanicalObjectCudaRigid3t_vPEqCoordDeriv_kernel(int size, CudaRigidCoord3<real>* res, const CudaRigidDeriv3<real>* a)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
 //	  CudaRigidCoord3<real> v = CudaRigidCoord3<real>::make(res[index]);
@@ -599,7 +599,7 @@ __global__ void MechanicalObjectCudaRigid3t_vPEqCoordDeriv_kernel(int size, Cuda
 template<class real>
 __global__ void MechanicalObjectCudaRigid3t_vPEqDeriv_kernel(int size, real* res, const real* a)
 {
-    int index = umul24(blockIdx.x,BSIZE*6)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 6 + threadIdx.x;
     //if (index < size)
     {
         res[index] += a[index];
@@ -619,7 +619,7 @@ __global__ void MechanicalObjectCudaRigid3t_vPEqDeriv_kernel(int size, real* res
 template<class real>
 __global__ void MechanicalObjectCudaVec1t_vPEqBF_kernel(int size, real* res, const real* b, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         res[index] += b[index] * f;
@@ -629,7 +629,7 @@ __global__ void MechanicalObjectCudaVec1t_vPEqBF_kernel(int size, real* res, con
 template<class real>
 __global__ void MechanicalObjectCudaVec2t_vPEqBF_kernel(int size, real* res, const real* b, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE*2)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 2 + threadIdx.x;
     //if (index < size)
     {
         res[index] += b[index] * f;
@@ -645,7 +645,7 @@ __global__ void MechanicalObjectCudaVec2t_vPEqBF_kernel(int size, real* res, con
 template<class real>
 __global__ void MechanicalObjectCudaVec3t_vPEqBF_kernel(int size, real* res, const real* b, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE*3)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 3 + threadIdx.x;
     //if (index < size)
     {
         res[index] += b[index] * f;
@@ -663,7 +663,7 @@ __global__ void MechanicalObjectCudaVec3t_vPEqBF_kernel(int size, real* res, con
 template<class real>
 __global__ void MechanicalObjectCudaVec3t1_vPEqBF_kernel(int size, CudaVec4<real>* res, const CudaVec4<real>* b, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         //res[index] += b[index] * f;
@@ -679,7 +679,7 @@ __global__ void MechanicalObjectCudaVec3t1_vPEqBF_kernel(int size, CudaVec4<real
 template<class real>
 __global__ void MechanicalObjectCudaRigid3t_vPEqBFCoord_kernel(int size, CudaRigidCoord3<real>* res, const CudaRigidCoord3<real>* b, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         CudaRigidCoord3<real> v = res[index];
@@ -694,7 +694,7 @@ __global__ void MechanicalObjectCudaRigid3t_vPEqBFCoord_kernel(int size, CudaRig
 template<class real>
 __global__ void MechanicalObjectCudaRigid3t_vPEqBFCoordDeriv_kernel(int size, CudaRigidCoord3<real>* res, const CudaRigidDeriv3<real>* b, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
 //	  CudaRigidCoord3<real> v = CudaRigidCoord3<real>::make(res[index]);
@@ -734,7 +734,7 @@ __global__ void MechanicalObjectCudaRigid3t_vPEqBFCoordDeriv_kernel(int size, Cu
 template<class real>
 __global__ void MechanicalObjectCudaRigid3t_vPEqBFDeriv_kernel(int size, real* res, const real* b, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE*6)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 6 + threadIdx.x;
     //if (index < size)
     {
         res[index] += b[index] * f;
@@ -754,7 +754,7 @@ __global__ void MechanicalObjectCudaRigid3t_vPEqBFDeriv_kernel(int size, real* r
 template<class real>
 __global__ void MechanicalObjectCudaVec1t_vPEqBF2_kernel(int size, real* res1, const real* b1, real f1, real* res2, const real* b2, real f2)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         res1[index] += b1[index] * f1;
@@ -765,7 +765,7 @@ __global__ void MechanicalObjectCudaVec1t_vPEqBF2_kernel(int size, real* res1, c
 template<class real>
 __global__ void MechanicalObjectCudaVec2t_vPEqBF2_kernel(int size, real* res1, const real* b1, real f1, real* res2, const real* b2, real f2)
 {
-    int index = umul24(blockIdx.x,BSIZE*2)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 2 + threadIdx.x;
     //if (index < size)
     {
         res1[index] += b1[index] * f1;
@@ -783,7 +783,7 @@ __global__ void MechanicalObjectCudaVec2t_vPEqBF2_kernel(int size, real* res1, c
 template<class real>
 __global__ void MechanicalObjectCudaVec3t_vPEqBF2_kernel(int size, real* res1, const real* b1, real f1, real* res2, const real* b2, real f2)
 {
-    int index = umul24(blockIdx.x,BSIZE*3)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 3 + threadIdx.x;
     //if (index < size)
     {
         res1[index] += b1[index] * f1;
@@ -804,7 +804,7 @@ __global__ void MechanicalObjectCudaVec3t_vPEqBF2_kernel(int size, real* res1, c
 template<class real>
 __global__ void MechanicalObjectCudaVec3t1_vPEqBF2_kernel(int size, CudaVec4<real>* res1, const CudaVec4<real>* b1, real f1, CudaVec4<real>* res2, const CudaVec4<real>* b2, real f2)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         //res[index] += b[index] * f;
@@ -827,7 +827,7 @@ template<class real>
 __global__ void MechanicalObjectCudaVec1t_vPEq4BF2_kernel(int size, real* res1, const real* b11, real f11, const real* b12, real f12, const real* b13, real f13, const real* b14, real f14,
         real* res2, const real* b21, real f21, const real* b22, real f22, const real* b23, real f23, const real* b24, real f24)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         real r1,r2;
@@ -850,7 +850,7 @@ template<class real>
 __global__ void MechanicalObjectCudaVec2t_vPEq4BF2_kernel(int size, real* res1, const real* b11, real f11, const real* b12, real f12, const real* b13, real f13, const real* b14, real f14,
         real* res2, const real* b21, real f21, const real* b22, real f22, const real* b23, real f23, const real* b24, real f24)
 {
-    int index = umul24(blockIdx.x,BSIZE*2)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 2 + threadIdx.x;
     //if (index < size)
     {
         real r1,r2;
@@ -886,7 +886,7 @@ template<class real>
 __global__ void MechanicalObjectCudaVec3t_vPEq4BF2_kernel(int size, real* res1, const real* b11, real f11, const real* b12, real f12, const real* b13, real f13, const real* b14, real f14,
         real* res2, const real* b21, real f21, const real* b22, real f22, const real* b23, real f23, const real* b24, real f24)
 {
-    int index = umul24(blockIdx.x,BSIZE*3)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 3 + threadIdx.x;
     //if (index < size)
     {
         real r1,r2;
@@ -935,7 +935,7 @@ template<class real>
 __global__ void MechanicalObjectCudaVec3t1_vPEq4BF2_kernel(int size, CudaVec4<real>* res1, const CudaVec4<real>* b11, real f11, const CudaVec4<real>* b12, real f12, const CudaVec4<real>* b13, real f13, const CudaVec4<real>* b14, real f14,
         CudaVec4<real>* res2, const CudaVec4<real>* b21, real f21, const CudaVec4<real>* b22, real f22, const CudaVec4<real>* b23, real f23, const CudaVec4<real>* b24, real f24)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         CudaVec4<real> v = res1[index];
@@ -980,7 +980,7 @@ __global__ void MechanicalObjectCudaVec3t1_vPEq4BF2_kernel(int size, CudaVec4<re
 template<class real>
 __global__ void MechanicalObjectCudaVec1t_vAdd_kernel(int size, real* res, const real* a, const real* b)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         res[index] = a[index] + b[index];
@@ -990,7 +990,7 @@ __global__ void MechanicalObjectCudaVec1t_vAdd_kernel(int size, real* res, const
 template<class real>
 __global__ void MechanicalObjectCudaVec2t_vAdd_kernel(int size, real* res, const real* a, const real* b)
 {
-    int index = umul24(blockIdx.x,BSIZE*2)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 2 + threadIdx.x;
     //if (index < size)
     {
         res[index] = a[index] + b[index];
@@ -1006,7 +1006,7 @@ __global__ void MechanicalObjectCudaVec2t_vAdd_kernel(int size, real* res, const
 template<class real>
 __global__ void MechanicalObjectCudaVec3t_vAdd_kernel(int size, real* res, const real* a, const real* b)
 {
-    int index = umul24(blockIdx.x,BSIZE*3)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 3 + threadIdx.x;
     //if (index < size)
     {
         res[index] = a[index] + b[index];
@@ -1024,7 +1024,7 @@ __global__ void MechanicalObjectCudaVec3t_vAdd_kernel(int size, real* res, const
 template<class real>
 __global__ void MechanicalObjectCudaVec3t1_vAdd_kernel(int size, CudaVec4<real>* res, const CudaVec4<real>* a, const CudaVec4<real>* b)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         //res[index] = a[index] + b[index];
@@ -1040,7 +1040,7 @@ __global__ void MechanicalObjectCudaVec3t1_vAdd_kernel(int size, CudaVec4<real>*
 template<class real>
 __global__ void MechanicalObjectCudaRigid3t_vAddCoord_kernel(int size, CudaRigidCoord3<real>* res, const CudaRigidCoord3<real>* a, const CudaRigidCoord3<real>* b)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         CudaRigidCoord3<real> v = a[index];
@@ -1052,7 +1052,7 @@ __global__ void MechanicalObjectCudaRigid3t_vAddCoord_kernel(int size, CudaRigid
 template<class real>
 __global__ void MechanicalObjectCudaRigid3t_vAddCoordDeriv_kernel(int size, CudaRigidCoord3<real>* res, const CudaRigidCoord3<real>* a, const CudaRigidDeriv3<real>* b)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     {
         CudaRigidCoord3<real> v = a[index];
         CudaRigidDeriv3<real> v2 = b[index];
@@ -1065,7 +1065,7 @@ __global__ void MechanicalObjectCudaRigid3t_vAddCoordDeriv_kernel(int size, Cuda
 template<class real>
 __global__ void MechanicalObjectCudaRigid3t_vAddDeriv_kernel(int size, real* res, const real* a, const real* b)
 {
-    int index = umul24(blockIdx.x,BSIZE*6)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 6 + threadIdx.x;
     //if (index < size)
     {
         res[index] = a[index] + b[index];
@@ -1085,7 +1085,7 @@ __global__ void MechanicalObjectCudaRigid3t_vAddDeriv_kernel(int size, real* res
 template<class real>
 __global__ void MechanicalObjectCudaVec1t_vOp_kernel(int size, real* res, const real* a, const real* b, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         res[index] = a[index] + b[index] * f;
@@ -1095,7 +1095,7 @@ __global__ void MechanicalObjectCudaVec1t_vOp_kernel(int size, real* res, const 
 template<class real>
 __global__ void MechanicalObjectCudaVec2t_vOp_kernel(int size, real* res, const real* a, const real* b, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE*2)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 2 + threadIdx.x;
     //if (index < size)
     {
         res[index] = a[index] + b[index] * f;
@@ -1111,7 +1111,7 @@ __global__ void MechanicalObjectCudaVec2t_vOp_kernel(int size, real* res, const 
 template<class real>
 __global__ void MechanicalObjectCudaVec3t_vOp_kernel(int size, real* res, const real* a, const real* b, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE*3)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 3 + threadIdx.x;
     //if (index < size)
     {
         res[index] = a[index] + b[index] * f;
@@ -1129,7 +1129,7 @@ __global__ void MechanicalObjectCudaVec3t_vOp_kernel(int size, real* res, const 
 template<class real>
 __global__ void MechanicalObjectCudaVec3t1_vOp_kernel(int size, CudaVec4<real>* res, const CudaVec4<real>* a, const CudaVec4<real>* b, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         //res[index] = a[index] + b[index] * f;
@@ -1145,7 +1145,7 @@ __global__ void MechanicalObjectCudaVec3t1_vOp_kernel(int size, CudaVec4<real>* 
 template<class real>
 __global__ void MechanicalObjectCudaRigid3t_vOpCoord_kernel(int size, CudaRigidCoord3<real>* res, const CudaRigidCoord3<real>* a, const CudaRigidCoord3<real>* b, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         CudaRigidCoord3<real> v = a[index];
@@ -1163,7 +1163,7 @@ __global__ void MechanicalObjectCudaRigid3t_vOpCoord_kernel(int size, CudaRigidC
 template<class real>
 __global__ void MechanicalObjectCudaRigid3t_vOpCoordDeriv_kernel(int size, CudaRigidCoord3<real>* res, const CudaRigidCoord3<real>* a, const CudaRigidDeriv3<real>* b, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     {
         CudaRigidCoord3<real> v = a[index];
         CudaRigidDeriv3<real> v2 = b[index];
@@ -1185,7 +1185,7 @@ __global__ void MechanicalObjectCudaRigid3t_vOpCoordDeriv_kernel(int size, CudaR
 template<class real>
 __global__ void MechanicalObjectCudaRigid3t_vOpDeriv_kernel(int size, real* res, const real* a, const real* b, real f)
 {
-    int index = umul24(blockIdx.x,BSIZE*6)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 6 + threadIdx.x;
     //if (index < size)
     {
         res[index] = a[index] + b[index] * f;
@@ -1205,7 +1205,7 @@ __global__ void MechanicalObjectCudaRigid3t_vOpDeriv_kernel(int size, real* res,
 template<class real>
 __global__ void MechanicalObjectCudaVec1t_vOp2_kernel(int size, real* res1, const real* a1, const real* b1, real f1, real* res2, const real* a2, const real* b2, real f2)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         res1[index] = a1[index] + b1[index] * f1;
@@ -1216,7 +1216,7 @@ __global__ void MechanicalObjectCudaVec1t_vOp2_kernel(int size, real* res1, cons
 template<class real>
 __global__ void MechanicalObjectCudaVec2t_vOp2_kernel(int size, real* res1, const real* a1, const real* b1, real f1, real* res2, const real* a2, const real* b2, real f2)
 {
-    int index = umul24(blockIdx.x,BSIZE*2)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 2 + threadIdx.x;
     //if (index < size)
     {
         res1[index] = a1[index] + b1[index] * f1;
@@ -1230,7 +1230,7 @@ __global__ void MechanicalObjectCudaVec2t_vOp2_kernel(int size, real* res1, cons
 template<class real>
 __global__ void MechanicalObjectCudaVec3t_vOp2_kernel(int size, real* res1, const real* a1, const real* b1, real f1, real* res2, const real* a2, const real* b2, real f2)
 {
-    int index = umul24(blockIdx.x,BSIZE*3)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 3 + threadIdx.x;
     //if (index < size)
     {
         res1[index] = a1[index] + b1[index] * f1;
@@ -1247,7 +1247,7 @@ __global__ void MechanicalObjectCudaVec3t_vOp2_kernel(int size, real* res1, cons
 template<class real>
 __global__ void MechanicalObjectCudaVec3t1_vOp2_kernel(int size, CudaVec4<real>* res1, const CudaVec4<real>* a1, const CudaVec4<real>* b1, real f1, CudaVec4<real>* res2, const CudaVec4<real>* a2, const CudaVec4<real>* b2, real f2)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         //res[index] = a[index] + b[index] * f;
@@ -1269,7 +1269,7 @@ __global__ void MechanicalObjectCudaVec3t1_vOp2_kernel(int size, CudaVec4<real>*
 template<class real>
 __global__ void MechanicalObjectCudaVec1t_vIntegrate_kernel(int size, const real* a, real* v, real* x, real f_v_v, real f_v_a, real f_x_x, real f_x_v)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         real vi = v[index]*f_v_v + a[index] * f_v_a;
@@ -1281,7 +1281,7 @@ __global__ void MechanicalObjectCudaVec1t_vIntegrate_kernel(int size, const real
 template<class real>
 __global__ void MechanicalObjectCudaVec2t_vIntegrate_kernel(int size, const real* a, real* v, real* x, real f_v_v, real f_v_a, real f_x_x, real f_x_v)
 {
-    int index = umul24(blockIdx.x,BSIZE*2)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 2 + threadIdx.x;
     //if (index < size)
     {
         real vi;
@@ -1298,7 +1298,7 @@ __global__ void MechanicalObjectCudaVec2t_vIntegrate_kernel(int size, const real
 template<class real>
 __global__ void MechanicalObjectCudaVec3t_vIntegrate_kernel(int size, const real* a, real* v, real* x, real f_v_v, real f_v_a, real f_x_x, real f_x_v)
 {
-    int index = umul24(blockIdx.x,BSIZE*3)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 3 + threadIdx.x;
     //if (index < size)
     {
         real vi;
@@ -1319,7 +1319,7 @@ __global__ void MechanicalObjectCudaVec3t_vIntegrate_kernel(int size, const real
 template<class real>
 __global__ void MechanicalObjectCudaVec3t1_vIntegrate_kernel(int size, const CudaVec4<real>* a, CudaVec4<real>* v, CudaVec4<real>* x, real f_v_v, real f_v_a, real f_x_x, real f_x_v)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         //res[index] = a[index] + b[index] * f;
@@ -1524,7 +1524,7 @@ __global__ void MechanicalObjectCudaVec_vSum_kernel(int n, real* res, const real
 template<class real>
 __global__ void MechanicalObjectCudaVec1t_vMultiOpA1B3_kernel(int size, real* res1, const real* a1, real* res2, const real* a21, real f21, const real* a22, real f22, const real* a23, real f23)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         res1[index] = a1[index];
@@ -1535,7 +1535,7 @@ __global__ void MechanicalObjectCudaVec1t_vMultiOpA1B3_kernel(int size, real* re
 template<class real>
 __global__ void MechanicalObjectCudaVec2t_vMultiOpA1B3_kernel(int size, real* res1, const real* a1, real* res2, const real* a21, real f21, const real* a22, real f22, const real* a23, real f23)
 {
-    int index = umul24(blockIdx.x,BSIZE*2)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 2 + threadIdx.x;
     //if (index < size)
     {
         res1[index] = a1[index];
@@ -1549,7 +1549,7 @@ __global__ void MechanicalObjectCudaVec2t_vMultiOpA1B3_kernel(int size, real* re
 template<class real>
 __global__ void MechanicalObjectCudaVec3t_vMultiOpA1B3_kernel(int size, real* res1, const real* a1, real* res2, const real* a21, real f21, const real* a22, real f22, const real* a23, real f23)
 {
-    int index = umul24(blockIdx.x,BSIZE*3)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 3 + threadIdx.x;
     //if (index < size)
     {
         res1[index] = a1[index];
@@ -1566,7 +1566,7 @@ __global__ void MechanicalObjectCudaVec3t_vMultiOpA1B3_kernel(int size, real* re
 template<class real>
 __global__ void MechanicalObjectCudaVec1t_vOp4_kernel(int size, real* res1, const real* a11, real f11, const real* a12, real f12, const real* a13, real f13, const real* a14, real f14)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         res1[index] = a11[index] * f11 + a12[index] * f12 + a13[index] * f13 + a14[index] * f14;
@@ -1576,7 +1576,7 @@ __global__ void MechanicalObjectCudaVec1t_vOp4_kernel(int size, real* res1, cons
 template<class real>
 __global__ void MechanicalObjectCudaVec2t_vOp4_kernel(int size, real* res1, const real* a11, real f11, const real* a12, real f12, const real* a13, real f13, const real* a14, real f14)
 {
-    int index = umul24(blockIdx.x,BSIZE*2)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 2 + threadIdx.x;
     //if (index < size)
     {
         res1[index] = a11[index] * f11 + a12[index] * f12 + a13[index] * f13 + a14[index] * f14;
@@ -1588,7 +1588,7 @@ __global__ void MechanicalObjectCudaVec2t_vOp4_kernel(int size, real* res1, cons
 template<class real>
 __global__ void MechanicalObjectCudaVec3t_vOp4_kernel(int size, real* res1, const real* a11, real f11, const real* a12, real f12, const real* a13, real f13, const real* a14, real f14)
 {
-    int index = umul24(blockIdx.x,BSIZE*3)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 3 + threadIdx.x;
     //if (index < size)
     {
         res1[index] = a11[index] * f11 + a12[index] * f12 + a13[index] * f13 + a14[index] * f14;
@@ -1602,7 +1602,7 @@ __global__ void MechanicalObjectCudaVec3t_vOp4_kernel(int size, real* res1, cons
 template<class real>
 __global__ void MechanicalObjectCudaVec1t_vOpMCNAB_kernel(int size, real* res1, const real* a11, const real* a12, real f12, real* res2, const real* a21, real* res3, const real* a31)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     //if (index < size)
     {
         res1[index] = a11[index] + a12[index] * f12;
@@ -1614,7 +1614,7 @@ __global__ void MechanicalObjectCudaVec1t_vOpMCNAB_kernel(int size, real* res1, 
 template<class real>
 __global__ void MechanicalObjectCudaVec2t_vOpMCNAB_kernel(int size, real* res1, const real* a11, const real* a12, real f12, real* res2, const real* a21, real* res3, const real* a31)
 {
-    int index = umul24(blockIdx.x,BSIZE*2)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 2 + threadIdx.x;
     //if (index < size)
     {
         res1[index] = a11[index] + a12[index] * f12;
@@ -1630,7 +1630,7 @@ __global__ void MechanicalObjectCudaVec2t_vOpMCNAB_kernel(int size, real* res1, 
 template<class real>
 __global__ void MechanicalObjectCudaVec3t_vOpMCNAB_kernel(int size, real* res1, const real* a11, const real* a12, real f12, real* res2, const real* a21, real* res3, const real* a31)
 {
-    int index = umul24(blockIdx.x,BSIZE*3)+threadIdx.x;
+    int index = blockIdx.x * BSIZE * 3 + threadIdx.x;
     //if (index < size)
     {
         res1[index] = a11[index] + a12[index] * f12;

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMeshMatrixMass.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMeshMatrixMass.cu
@@ -60,7 +60,7 @@ __global__ void MeshMatrixMassCuda_addMDx3f_kernel(real factor, real massLumping
 {
     int tx = threadIdx.x;
     int tx2 = tx/3;
-    int index1 = umul24(blockIdx.x,BSIZE);
+    int index1 = blockIdx.x * BSIZE;
     int index2 = index1*3;
 
     __shared__ real s_dx[BSIZE];
@@ -87,7 +87,7 @@ __global__ void MeshMatrixMassCuda_addMDx3f_kernel(real factor, real massLumping
 template<class real>
 __global__ void MeshMatrixMassCuda_addForce3f_kernel(int dim, real *  f, const real * vertexMass, real g_x, real g_y, real massLumpingCoeff)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     int index2 = index * 3;
     if (index < dim)
     {
@@ -100,7 +100,7 @@ __global__ void MeshMatrixMassCuda_addForce3f_kernel(int dim, real *  f, const r
 template<class real>
 __global__ void MeshMatrixMassCuda_accFromF3f_kernel(int dim, real * acc, const real * f, const real * vertexMass, real massLumpingCoeff)
 {
-//    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+//    int index = blockIdx.x * BSIZE+threadIdx.x;
 //    int index2 = index * 2;
 //    if (index < dim) {
 //      acc[index2+0] = f[index2+0] / (vertexMass[index2+0] * massLumpingCoeff);
@@ -108,7 +108,7 @@ __global__ void MeshMatrixMassCuda_accFromF3f_kernel(int dim, real * acc, const 
 //    }
     int tx = threadIdx.x;
     int tx2 = tx/3;
-    int index1 = umul24(blockIdx.x,BSIZE);
+    int index1 = blockIdx.x * BSIZE;
     int index2 = index1*3;
 
     __shared__ real s_f[BSIZE];
@@ -176,7 +176,7 @@ __global__ void MeshMatrixMassCuda_addMDx2f_kernel(real factor, real massLumping
 {
     int tx = threadIdx.x;
     int tx2 = tx>>1;
-    int index1 = umul24(blockIdx.x,BSIZE);
+    int index1 = blockIdx.x * BSIZE;
     int index2 = index1<<1;
 
     __shared__ real s_dx[BSIZE];
@@ -203,7 +203,7 @@ __global__ void MeshMatrixMassCuda_addMDx2f_kernel(real factor, real massLumping
 template<class real>
 __global__ void MeshMatrixMassCuda_addForce2f_kernel(int dim, real *  f, const real * vertexMass, real g_x, real g_y, real massLumpingCoeff)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     int index2 = index * 2;
     if (index < dim)
     {
@@ -215,7 +215,7 @@ __global__ void MeshMatrixMassCuda_addForce2f_kernel(int dim, real *  f, const r
 template<class real>
 __global__ void MeshMatrixMassCuda_accFromF2f_kernel(int dim, real * acc, const real * f, const real * vertexMass, real massLumpingCoeff)
 {
-//    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+//    int index = blockIdx.x * BSIZE+threadIdx.x;
 //    int index2 = index * 2;
 //    if (index < dim) {
 //      acc[index2+0] = f[index2+0] / (vertexMass[index2+0] * massLumpingCoeff);
@@ -223,7 +223,7 @@ __global__ void MeshMatrixMassCuda_accFromF2f_kernel(int dim, real * acc, const 
 //    }
     int tx = threadIdx.x;
     int tx2 = tx>>1;
-    int index1 = umul24(blockIdx.x,BSIZE);
+    int index1 = blockIdx.x * BSIZE;
     int index2 = index1<<1;
 
     __shared__ real s_f[BSIZE];
@@ -290,7 +290,7 @@ template<class real>
 __global__ void MeshMatrixMassCuda_addMDx1f_kernel(real factor, real massLumpingCoeff,const real * vertexMass, const real* dx, real* res)
 {
     int tx = threadIdx.x;
-    int index = umul24(blockIdx.x,BSIZE);
+    int index = blockIdx.x * BSIZE;
 
     __shared__ real s_dx[BSIZE];
     __shared__ real s_vertexMass[BSIZE];
@@ -314,7 +314,7 @@ __global__ void MeshMatrixMassCuda_addMDx1f_kernel(real factor, real massLumping
 template<class real>
 __global__ void MeshMatrixMassCuda_addForce1f_kernel(int dim, real *  f, const real * vertexMass, real g_x, real g_y, real massLumpingCoeff)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     if (index < dim)
     {
         f[index] += vertexMass[index] * massLumpingCoeff * g_x;
@@ -324,14 +324,14 @@ __global__ void MeshMatrixMassCuda_addForce1f_kernel(int dim, real *  f, const r
 template<class real>
 __global__ void MeshMatrixMassCuda_accFromF1f_kernel(int dim, real * acc, const real * f, const real * vertexMass, real massLumpingCoeff)
 {
-//    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+//    int index = blockIdx.x * BSIZE+threadIdx.x;
 //    int index2 = index * 2;
 //    if (index < dim) {
 //      acc[index2+0] = f[index2+0] / (vertexMass[index2+0] * massLumpingCoeff);
 //      acc[index2+1] = f[index2+1] / (vertexMass[index2+1] * massLumpingCoeff);
 //    }
     int tx = threadIdx.x;
-    int index = umul24(blockIdx.x,BSIZE);
+    int index = blockIdx.x * BSIZE;
 
     __shared__ real s_f[BSIZE];
     __shared__ real s_vertexMass[BSIZE];

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaParticleSource.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaParticleSource.cu
@@ -54,14 +54,14 @@ extern "C"
 template<class real>
 __global__ void ParticleSourceCuda3t_fillValues_kernel(unsigned int totalsize, unsigned int subsetsize, real* dest, const unsigned int* indices, real fx, real fy, real fz)
 {
-    unsigned int index0 = umul24(blockIdx.x,BSIZE);
+    unsigned int index0 = blockIdx.x * BSIZE;
     unsigned int index = index0+threadIdx.x;
     if (index < subsetsize)
     {
         unsigned int dindex = indices[index];
         if (dindex < totalsize)
         {
-            unsigned int dindex3 = umul24(dindex,3);
+            unsigned int dindex3 = dindex * 3;
             dest[dindex3+0] = fx;
             dest[dindex3+1] = fy;
             dest[dindex3+2] = fz;
@@ -72,15 +72,15 @@ __global__ void ParticleSourceCuda3t_fillValues_kernel(unsigned int totalsize, u
 template<class real>
 __global__ void ParticleSourceCuda3t_copyValuesWithOffset_kernel(unsigned int totalsize, unsigned int subsetsize, real* dest, const unsigned int* indices, const real* src, real fx, real fy, real fz)
 {
-    unsigned int index0 = umul24(blockIdx.x,BSIZE);
+    unsigned int index0 = blockIdx.x * BSIZE;
     unsigned int index = index0+threadIdx.x;
     if (index < subsetsize)
     {
         unsigned int dindex = indices[index];
         if (dindex < totalsize)
         {
-            unsigned int dindex3 = umul24(dindex,3);
-            unsigned int index3 = umul24(index,3);
+            unsigned int dindex3 = dindex * 3;
+            unsigned int index3 = index * 3;
             dest[dindex3+0] = src[index3+0]+fx;
             dest[dindex3+1] = src[index3+1]+fy;
             dest[dindex3+2] = src[index3+2]+fz;

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaParticlesRepulsionForceField.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaParticlesRepulsionForceField.cu
@@ -104,7 +104,7 @@ __global__ void ParticlesRepulsionForceFieldCuda3t_addForce_kernel(int size, con
     __shared__ int ghost;
     __shared__ real temp_x[BSIZE*3];
     __shared__ real temp_v[BSIZE*3];
-    int tx3 = __umul24(threadIdx.x,3);
+    int tx3 = threadIdx.x * 3;
     for (int cell = blockIdx.x; cell < size; cell += gridDim.x)
     {
         if (!threadIdx.x)
@@ -194,7 +194,7 @@ __global__ void ParticlesRepulsionForceFieldCuda3t_addDForce_kernel(int size, co
     __shared__ int ghost;
     __shared__ real temp_x[BSIZE*3];
     __shared__ real temp_dx[BSIZE*3];
-    int tx3 = __umul24(threadIdx.x,3);
+    int tx3 = threadIdx.x * 3;
     for (int cell = blockIdx.x; cell < size; cell += gridDim.x)
     {
         if (!threadIdx.x)

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPenalityContactForceField.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPenalityContactForceField.cu
@@ -89,8 +89,8 @@ __global__ void PenalityContactForceFieldCuda3f_setContacts_kernel(const GPUTest
 __global__ void PenalityContactForceFieldCuda3f_addForce_kernel(int size, const CudaVec4<float>* contacts, float* pen, float* f1, const float* x1, const float* v1, float* f2, const float* x2, const float* v2)
 //, GPUSphere sphere, CudaVec4<float>* penetration, float* f, const float* x, const float* v)
 {
-    int index0 = umul24(blockIdx.x,BSIZE);
-    int index0_3 = umul24(blockIdx.x,BSIZE*3); //index0*3;
+    int index0 = blockIdx.x * BSIZE;
+    int index0_3 = index0 * 3;
 
     contacts += index0;
     pen += index0;
@@ -102,7 +102,7 @@ __global__ void PenalityContactForceFieldCuda3f_addForce_kernel(int size, const 
     v2 += index0_3;
 
     int index = threadIdx.x;
-    int index_3 = umul24(index,3); //index*3;
+    int index_3 = index * 3;
 
     //! Dynamically allocated shared memory to reorder global memory access
     extern  __shared__  float temp[];
@@ -142,8 +142,8 @@ __global__ void PenalityContactForceFieldCuda3f_addForce_kernel(int size, const 
 
 __global__ void PenalityContactForceFieldCuda3f_addDForce_kernel(int size, const CudaVec4<float>* contacts, const float* pen, float* df1, const float* dx1, float* df2, const float* dx2, float factor)
 {
-    int index0 = umul24(blockIdx.x,BSIZE);
-    int index0_3 = umul24(blockIdx.x,BSIZE*3); //index0*3;
+    int index0 = blockIdx.x * BSIZE;
+    int index0_3 = index0 * 3;
 
     contacts += index0;
     pen += index0;
@@ -153,7 +153,7 @@ __global__ void PenalityContactForceFieldCuda3f_addDForce_kernel(int size, const
     dx2 += index0_3;
 
     int index = threadIdx.x;
-    int index_3 = umul24(index,3); //index*3;
+    int index_3 = index * 3;
 
     //! Dynamically allocated shared memory to reorder global memory access
     extern  __shared__  float temp[];

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPlaneForceField.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaPlaneForceField.cu
@@ -72,8 +72,8 @@ extern "C"
 template<class real>
 __global__ void PlaneForceFieldCuda3t_addForce_kernel(int size, GPUPlane<real> plane, real* penetration, real* f, const real* x, const real* v)
 {
-    int index0 = umul24(blockIdx.x,BSIZE);
-    int index0_3 = umul24(blockIdx.x,BSIZE*3); //index0*3;
+    int index0 = blockIdx.x * BSIZE;
+    int index0_3 = index0 * 3;
 
     penetration += index0;
     f += index0_3;
@@ -81,7 +81,7 @@ __global__ void PlaneForceFieldCuda3t_addForce_kernel(int size, GPUPlane<real> p
     v += index0_3;
 
     int index = threadIdx.x;
-    int index_3 = umul24(index,3); //index*3;
+    int index_3 = index * 3;
 
     //! Dynamically allocated shared memory to reorder global memory access
     __shared__  real temp[BSIZE*3];
@@ -137,7 +137,7 @@ __global__ void PlaneForceFieldCuda3t_addForce_kernel(int size, GPUPlane<real> p
 template<class real>
 __global__ void PlaneForceFieldCuda3t1_addForce_kernel(int size, GPUPlane<real> plane, real* penetration, CudaVec4<real>* f, const CudaVec4<real>* x, const CudaVec4<real>* v)
 {
-    int index = umul24(blockIdx.x,BSIZE) + threadIdx.x;
+    int index = blockIdx.x * BSIZE + threadIdx.x;
 
     CudaVec4<real> xi = x[index];
     real d = dot(CudaVec3<real>::make(xi),CudaVec3<real>::make(plane.normal_x,plane.normal_y,plane.normal_z))-plane.d;
@@ -164,15 +164,15 @@ __global__ void PlaneForceFieldCuda3t1_addForce_kernel(int size, GPUPlane<real> 
 template<class real>
 __global__ void PlaneForceFieldCuda3t_addDForce_kernel(int size, GPUPlane<real> plane, const real* penetration, real* df, const real* dx)
 {
-    int index0 = umul24(blockIdx.x,BSIZE);
-    int index0_3 = umul24(blockIdx.x,BSIZE*3); //index0*3;
+    int index0 = blockIdx.x * BSIZE;
+    int index0_3 = index0 * 3;
 
     penetration += index0;
     df += index0_3;
     dx += index0_3;
 
     int index = threadIdx.x;
-    int index_3 = umul24(index,3); //index*3;
+    int index_3 = index * 3;
 
     //! Dynamically allocated shared memory to reorder global memory access
     __shared__  real temp[BSIZE*3];
@@ -215,7 +215,7 @@ __global__ void PlaneForceFieldCuda3t_addDForce_kernel(int size, GPUPlane<real> 
 template<class real>
 __global__ void PlaneForceFieldCuda3t1_addDForce_kernel(int size, GPUPlane<real> plane, const real* penetration, CudaVec4<real>* df, const CudaVec4<real>* dx)
 {
-    int index = umul24(blockIdx.x,BSIZE) + threadIdx.x;
+    int index = blockIdx.x * BSIZE + threadIdx.x;
 
     CudaVec4<real> dxi = dx[index];
     real d = penetration[index];

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaRigidMapping.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaRigidMapping.cu
@@ -45,13 +45,13 @@ extern "C"
 
 __global__ void RigidMappingCuda3f_apply_kernel(unsigned int size, CudaVec3<float> rotation_x, CudaVec3<float> rotation_y, CudaVec3<float> rotation_z, CudaVec3<float> translation, float* out, float* rotated, const float* in)
 {
-    int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x * BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
 
     //! Dynamically allocated shared memory to reorder global memory access
     extern  __shared__  float temp[];
 
-    int base = umul24(index0,3);
+    int base = index0 * 3;
     in  += base;
     out += base;
     rotated += base;
@@ -62,7 +62,7 @@ __global__ void RigidMappingCuda3f_apply_kernel(unsigned int size, CudaVec3<floa
 
     __syncthreads();
 
-    int index3 = umul24(3,index1);
+    int index3 = index1 * 3;
     CudaVec3<float> p = CudaVec3<float>::make(temp[index3  ],temp[index3+1],temp[index3+2]);
 
     // rotated
@@ -93,13 +93,13 @@ __global__ void RigidMappingCuda3f_apply_kernel(unsigned int size, CudaVec3<floa
 
 __global__ void RigidMappingCuda3f_applyJ_kernel(unsigned int size, CudaVec3<float> v, CudaVec3<float> omega, float* out, const float* rotated)
 {
-    int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x * BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
 
     //! Dynamically allocated shared memory to reorder global memory access
     extern  __shared__  float temp[];
 
-    int base = umul24(index0,3);
+    int base = index0 * 3;
     out += base;
     rotated += base;
 
@@ -109,7 +109,7 @@ __global__ void RigidMappingCuda3f_applyJ_kernel(unsigned int size, CudaVec3<flo
 
     __syncthreads();
 
-    int index3 = umul24(3,index1);
+    int index3 = index1 * 3;
     CudaVec3<float> p = v - cross(CudaVec3<float>::make(temp[index3  ],temp[index3+1],temp[index3+2]),omega);
 
     temp[index3  ] = p.x;
@@ -125,7 +125,7 @@ __global__ void RigidMappingCuda3f_applyJ_kernel(unsigned int size, CudaVec3<flo
 
 __global__ void RigidMappingCuda3f_applyJT_kernel(unsigned int size, unsigned int nbloc, float* out, const float* rotated, const float* in)
 {
-    int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x * BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
 
     //! Dynamically allocated shared memory to reorder global memory access
@@ -134,12 +134,12 @@ __global__ void RigidMappingCuda3f_applyJT_kernel(unsigned int size, unsigned in
     CudaVec3<float> t = CudaVec3<float>::make(0.0f, 0.0f, 0.0f);
     CudaVec3<float> r = CudaVec3<float>::make(0.0f, 0.0f, 0.0f);
 
-    int index3 = umul24(3,index1);
+    int index3 = index1 * 3;
 
     while (index0 < size)
     {
 
-        int base = umul24(index0,3);
+        int base = index0 * 3;
 
         temp[index1        ] = in[base+index1        ];
         temp[index1+  BSIZE] = in[base+index1+  BSIZE];
@@ -157,7 +157,7 @@ __global__ void RigidMappingCuda3f_applyJT_kernel(unsigned int size, unsigned in
             r += cross(CudaVec3<float>::make(temp[index3  +3*BSIZE],temp[index3+1+3*BSIZE],temp[index3+2+3*BSIZE]),v);
         }
         __syncthreads();
-        index0 += umul24(nbloc, BSIZE);
+        index0 += nbloc * BSIZE;
     }
 
     temp[index3  ] = t.x;
@@ -192,7 +192,7 @@ __global__ void RigidMappingCuda3f_applyJT_kernel(unsigned int size, unsigned in
     __syncthreads();
     if (index1 < 6)
     {
-        out[umul24(blockIdx.x,6) + index1] = temp[index1];
+        out[blockIdx.x * 6 + index1] = temp[index1];
     }
 }
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSPHFluidForceField.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSPHFluidForceField.cu
@@ -493,7 +493,7 @@ __global__ void SPHFluidForceFieldCuda3t_computeDensity_kernel(int size, const i
     __shared__ int2 range;
     __shared__ int ghost;
     __shared__ real temp_x[BSIZE*3];
-    int tx3 = __umul24(threadIdx.x,3);
+    int tx3 = threadIdx.x * 3;
     for (int cell = blockIdx.x; cell < size; cell += gridDim.x)
     {
         __syncthreads();
@@ -578,7 +578,7 @@ __global__ void SPHFluidForceFieldCuda3t_addForce_kernel(int size, const int *ce
     __shared__ int ghost;
     __shared__ real temp_x[BSIZE*4];
     __shared__ real temp_v[BSIZE*3];
-    int tx3 = __umul24(threadIdx.x,3);
+    int tx3 = threadIdx.x * 3;
     int tx4 = threadIdx.x << 2;
     for (int cell = blockIdx.x; cell < size; cell += gridDim.x)
     {
@@ -672,7 +672,7 @@ __global__ void SPHFluidForceFieldCuda3t_addDForce_kernel(int size, const int *c
     __shared__ real temp_x[BSIZE*4];
     __shared__ real temp_v[BSIZE*3];
     __shared__ real temp_dx[BSIZE*3];
-    int tx3 = __umul24(threadIdx.x,3);
+    int tx3 = threadIdx.x * 3;
     int tx4 = threadIdx.x << 2;
     for (int cell = blockIdx.x; cell < size; cell += gridDim.x)
     {

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSpatialGridContainer.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSpatialGridContainer.cu
@@ -139,8 +139,8 @@ __device__ __inline__ float3 getPos3(const float3* pos, int index0, int index)
 {
     //return pos[index];
 
-    int index03 = __umul24(index0,3);
-    int index3 = __umul24(threadIdx.x,3);
+    int index03 = index0 * 3;
+    int index3 = threadIdx.x * 3;
     ftemp[threadIdx.x] = ((const float*)pos)[index03+threadIdx.x];
     ftemp[threadIdx.x+BSIZE] = ((const float*)pos)[index03+threadIdx.x+BSIZE];
     ftemp[threadIdx.x+2*BSIZE] = ((const float*)pos)[index03+threadIdx.x+2*BSIZE];
@@ -155,7 +155,7 @@ __device__ __inline__ float4 getPos4(const float4* pos, int index0, int index)
 
 __device__ __inline__ float4 getPos4(const float3* pos, int index0, int index)
 {
-    int index3 = __umul24(threadIdx.x,3);
+    int index3 = threadIdx.x * 3;
     pos += index0;
     ftemp[threadIdx.x] = ((const float*)pos)[threadIdx.x];
     ftemp[threadIdx.x+BSIZE] = ((const float*)pos)[threadIdx.x+BSIZE];

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSphereForceField.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSphereForceField.cu
@@ -55,8 +55,8 @@ extern "C"
 
 __global__ void SphereForceFieldCuda3f_addForce_kernel(int size, GPUSphere sphere, CudaVec4<float>* penetration, float* f, const float* x, const float* v)
 {
-    int index0 = umul24(blockIdx.x,BSIZE);
-    int index0_3 = umul24(blockIdx.x,BSIZE*3); //index0*3;
+    int index0 = blockIdx.x * BSIZE;
+    int index0_3 = index0 * 3;
 
     penetration += index0;
     f += index0_3;
@@ -64,7 +64,7 @@ __global__ void SphereForceFieldCuda3f_addForce_kernel(int size, GPUSphere spher
     v += index0_3;
 
     int index = threadIdx.x;
-    int index_3 = umul24(index,3); //index*3;
+    int index_3 = index * 3;
 
     //! Dynamically allocated shared memory to reorder global memory access
     extern  __shared__  float temp[];
@@ -125,7 +125,7 @@ __global__ void SphereForceFieldCuda3f_addForce_kernel(int size, GPUSphere spher
 
 __global__ void SphereForceFieldCuda3f1_addForce_kernel(int size, GPUSphere sphere, CudaVec4<float>* penetration, CudaVec4<float>* f, const CudaVec4<float>* x, const CudaVec4<float>* v)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
 
     CudaVec4<float> temp = x[index];
     CudaVec3<float> dp = CudaVec3<float>::make(temp) - sphere.center;
@@ -158,15 +158,15 @@ __global__ void SphereForceFieldCuda3f1_addForce_kernel(int size, GPUSphere sphe
 
 __global__ void SphereForceFieldCuda3f_addDForce_kernel(int size, GPUSphere sphere, const CudaVec4<float>* penetration, float* df, const float* dx)
 {
-    int index0 = umul24(blockIdx.x,BSIZE);
-    int index0_3 = umul24(blockIdx.x,BSIZE*3); //index0*3;
+    int index0 = blockIdx.x * BSIZE;
+    int index0_3 = index0 * 3;
 
     penetration += index0;
     df += index0_3;
     dx += index0_3;
 
     int index = threadIdx.x;
-    int index_3 = umul24(index,3); //index*3;
+    int index_3 = index * 3;
 
     //! Dynamically allocated shared memory to reorder global memory access
     extern  __shared__  float temp[];
@@ -209,7 +209,7 @@ __global__ void SphereForceFieldCuda3f_addDForce_kernel(int size, GPUSphere sphe
 
 __global__ void SphereForceFieldCuda3f1_addDForce_kernel(int size, GPUSphere sphere, const CudaVec4<float>* penetration, CudaVec4<float>* df, const CudaVec4<float>* dx)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
 
     CudaVec4<float> dxi = dx[index];
     CudaVec4<float> d = penetration[index];

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSpringForceField.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSpringForceField.cu
@@ -280,7 +280,7 @@ public:
 
     static __inline__ __device__ CudaVec3<real> getX(int i, const TIn* x)
     {
-        int i3 = umul24(i,3);
+        int i3 = i * 3;
         float x1 = tex1Dfetch(tex_3f_x, i3);
         float x2 = tex1Dfetch(tex_3f_x, i3+1);
         float x3 = tex1Dfetch(tex_3f_x, i3+2);
@@ -299,7 +299,7 @@ public:
 
     static __inline__ __device__ CudaVec3<real> getV(int i, const TIn* x)
     {
-        int i3 = umul24(i,3);
+        int i3 = i * 3;
         float x1 = tex1Dfetch(tex_3f_v, i3);
         float x2 = tex1Dfetch(tex_3f_v, i3+1);
         float x3 = tex1Dfetch(tex_3f_v, i3+2);
@@ -318,7 +318,7 @@ public:
 
     static __inline__ __device__ CudaVec3<real> getDX(int i, const TIn* dx)
     {
-        int i3 = umul24(i,3);
+        int i3 = i * 3;
         float x1 = tex1Dfetch(tex_3f_dx, i3);
         float x2 = tex1Dfetch(tex_3f_dx, i3+1);
         float x3 = tex1Dfetch(tex_3f_dx, i3+2);
@@ -338,7 +338,7 @@ public:
 
     static __inline__ __device__ CudaVec3<real> getX2(int i, const TIn* x)
     {
-        int i3 = umul24(i,3);
+        int i3 = i * 3;
         float x1 = tex1Dfetch(tex_3f_x2, i3);
         float x2 = tex1Dfetch(tex_3f_x2, i3+1);
         float x3 = tex1Dfetch(tex_3f_x2, i3+2);
@@ -357,7 +357,7 @@ public:
 
     static __inline__ __device__ CudaVec3<real> getV2(int i, const TIn* x)
     {
-        int i3 = umul24(i,3);
+        int i3 = i * 3;
         float x1 = tex1Dfetch(tex_3f_v2, i3);
         float x2 = tex1Dfetch(tex_3f_v2, i3+1);
         float x3 = tex1Dfetch(tex_3f_v2, i3+2);
@@ -376,7 +376,7 @@ public:
 
     static __inline__ __device__ CudaVec3<real> getDX2(int i, const TIn* dx)
     {
-        int i3 = umul24(i,3);
+        int i3 = i * 3;
         float x1 = tex1Dfetch(tex_3f_dx2, i3);
         float x2 = tex1Dfetch(tex_3f_dx2, i3+1);
         float x3 = tex1Dfetch(tex_3f_dx2, i3+2);
@@ -500,14 +500,14 @@ public:
 template<typename real>
 __global__ void SpringForceFieldCuda3t_addExternalForce_kernel(unsigned int nbSpringPerVertex, const GPUSpring* springs, real* f1, const real* x1, const real* v1, const real* x2, const real* v2)
 {
-    const int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    const int index0 = blockIdx.x * BSIZE; //blockDim.x;
     const int index1 = threadIdx.x;
 
     //! Dynamically allocated shared memory to reorder global memory access
     __shared__  real temp[BSIZE*6];
 
     // First copy x and v inside temp
-    const int iext = umul24(blockIdx.x,BSIZE*3)+index1; //index0*3+index1;
+    const int iext = index0 * 3 + index1;
     temp[index1        ] = x1[iext        ];
     temp[index1+  BSIZE] = x1[iext+  BSIZE];
     temp[index1+2*BSIZE] = x1[iext+2*BSIZE];
@@ -517,12 +517,12 @@ __global__ void SpringForceFieldCuda3t_addExternalForce_kernel(unsigned int nbSp
 
     __syncthreads();
 
-    const int index3 = umul24(index1,3); //3*index1;
+    const int index3 = index1 * 3; //3*index1;
     CudaVec3<real> pos1 = CudaVec3<real>::make(temp[index3  ],temp[index3+1],temp[index3+2]);
     CudaVec3<real> vel1 = CudaVec3<real>::make(temp[index3  +3*BSIZE],temp[index3+1+3*BSIZE],temp[index3+2+3*BSIZE]);
     CudaVec3<real> force = CudaVec3<real>::make(0.0f,0.0f,0.0f);
 
-    springs+=(umul24(index0,nbSpringPerVertex)<<1)+index1;
+    springs+=(index0*nbSpringPerVertex<<1)+index1;
 
     for (int s = 0; s < nbSpringPerVertex; s++)
     {
@@ -583,14 +583,14 @@ __global__ void SpringForceFieldCuda3t_addExternalForce_kernel(unsigned int nbSp
 template<typename real>
 __global__ void SpringForceFieldCuda3t1_addForce_kernel(unsigned int nbSpringPerVertex, const GPUSpring* springs, CudaVec4<real>* f1, const CudaVec4<real>* x1, const CudaVec4<real>* v1, const CudaVec4<real>* x2, const CudaVec4<real>* v2)
 {
-    const int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    const int index0 = blockIdx.x * BSIZE; //blockDim.x;
     const int index1 = threadIdx.x;
     const int index = index0 + index1;
     CudaVec3<real> pos1 = CudaVec3<real>::make(x1[index]);
     CudaVec3<real> vel1 = CudaVec3<real>::make(v1[index]);
     CudaVec3<real> force = CudaVec3<real>::make(0.0f,0.0f,0.0f);
 
-    springs+=(umul24(index0,nbSpringPerVertex)<<1)+index1;
+    springs+=(index0*nbSpringPerVertex<<1)+index1;
 
     for (int s = 0; s < nbSpringPerVertex; s++)
     {
@@ -645,14 +645,14 @@ __global__ void SpringForceFieldCuda3t1_addForce_kernel(unsigned int nbSpringPer
 template<typename real>
 __global__ void SpringForceFieldCuda3t_addForce_kernel(unsigned int nbSpringPerVertex, const GPUSpring* springs, real* f, const real* x, const real* v)
 {
-    const int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    const int index0 = blockIdx.x * BSIZE; //blockDim.x;
     const int index1 = threadIdx.x;
 
     //! Dynamically allocated shared memory to reorder global memory access
     __shared__  real temp[BSIZE*6];
 
     // First copy x and v inside temp
-    const int iext = umul24(blockIdx.x,BSIZE*3)+index1; //index0*3+index1;
+    const int iext = index0 * 3 + index1;
     temp[index1        ] = x[iext        ];
     temp[index1+  BSIZE] = x[iext+  BSIZE];
     temp[index1+2*BSIZE] = x[iext+2*BSIZE];
@@ -662,12 +662,12 @@ __global__ void SpringForceFieldCuda3t_addForce_kernel(unsigned int nbSpringPerV
 
     __syncthreads();
 
-    const int index3 = umul24(index1,3); //3*index1;
+    const int index3 = index1 * 3; //3*index1;
     CudaVec3<real> pos1 = CudaVec3<real>::make(temp[index3  ],temp[index3+1],temp[index3+2]);
     CudaVec3<real> vel1 = CudaVec3<real>::make(temp[index3  +3*BSIZE],temp[index3+1+3*BSIZE],temp[index3+2+3*BSIZE]);
     CudaVec3<real> force = CudaVec3<real>::make(0.0f,0.0f,0.0f);
 
-    springs+=(umul24(index0,nbSpringPerVertex)<<1)+index1;
+    springs+=(index0*nbSpringPerVertex<<1)+index1;
 
     for (int s = 0; s < nbSpringPerVertex; s++)
     {
@@ -736,14 +736,14 @@ __global__ void SpringForceFieldCuda3t_addForce_kernel(unsigned int nbSpringPerV
 template<typename real>
 __global__ void StiffSpringForceFieldCuda3t_addExternalForce_kernel(unsigned int nbSpringPerVertex, const GPUSpring* springs, real* f1, const real* x1, const real* v1, const real* x2, const real* v2, real* dfdx)
 {
-    const int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    const int index0 = blockIdx.x * BSIZE; //blockDim.x;
     const int index1 = threadIdx.x;
 
     //! Dynamically allocated shared memory to reorder global memory access
     __shared__  real temp[BSIZE*6];
 
     // First copy x and v inside temp
-    const int iext = umul24(blockIdx.x,BSIZE*3)+index1; //index0*3+index1;
+    const int iext = index0 * 3 + index1;
     temp[index1        ] = x1[iext        ];
     temp[index1+  BSIZE] = x1[iext+  BSIZE];
     temp[index1+2*BSIZE] = x1[iext+2*BSIZE];
@@ -753,13 +753,13 @@ __global__ void StiffSpringForceFieldCuda3t_addExternalForce_kernel(unsigned int
 
     __syncthreads();
 
-    const int index3 = umul24(index1,3); //3*index1;
+    const int index3 = index1 * 3; //3*index1;
     CudaVec3<real> pos1 = CudaVec3<real>::make(temp[index3  ],temp[index3+1],temp[index3+2]);
     CudaVec3<real> vel1 = CudaVec3<real>::make(temp[index3  +3*BSIZE],temp[index3+1+3*BSIZE],temp[index3+2+3*BSIZE]);
     CudaVec3<real> force = CudaVec3<real>::make(0.0f,0.0f,0.0f);
 
-    springs+=(umul24(index0,nbSpringPerVertex)<<1)+index1;
-    dfdx+=umul24(index0,nbSpringPerVertex)+index1;
+    springs+=(index0*nbSpringPerVertex<<1)+index1;
+    dfdx+=index0*nbSpringPerVertex+index1;
 
     for (int s = 0; s < nbSpringPerVertex; s++)
     {
@@ -831,15 +831,15 @@ __global__ void StiffSpringForceFieldCuda3t_addExternalForce_kernel(unsigned int
 template<typename real>
 __global__ void StiffSpringForceFieldCuda3t1_addForce_kernel(unsigned int nbSpringPerVertex, const GPUSpring* springs, CudaVec4<real>* f1, const CudaVec4<real>* x1, const CudaVec4<real>* v1, const CudaVec4<real>* x2, const CudaVec4<real>* v2, real* dfdx)
 {
-    const int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    const int index0 = blockIdx.x * BSIZE; //blockDim.x;
     const int index1 = threadIdx.x;
     const int index = index0 + index1;
     CudaVec3<real> pos1 = CudaVec3<real>::make(x1[index]);
     CudaVec3<real> vel1 = CudaVec3<real>::make(v1[index]);
     CudaVec3<real> force = CudaVec3<real>::make(0.0f,0.0f,0.0f);
 
-    springs+=(umul24(index0,nbSpringPerVertex)<<1)+index1;
-    dfdx+=umul24(index0,nbSpringPerVertex)+index1;
+    springs+=(index0*nbSpringPerVertex<<1)+index1;
+    dfdx+=index0*nbSpringPerVertex+index1;
 
     for (int s = 0; s < nbSpringPerVertex; s++)
     {
@@ -896,14 +896,14 @@ __global__ void StiffSpringForceFieldCuda3t1_addForce_kernel(unsigned int nbSpri
 template<typename real>
 __global__ void StiffSpringForceFieldCuda3t_addForce_kernel(unsigned int nbSpringPerVertex, const GPUSpring* springs, real* f, const real* x, const real* v, real* dfdx)
 {
-    const int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    const int index0 = blockIdx.x * BSIZE; //blockDim.x;
     const int index1 = threadIdx.x;
 
     //! Dynamically allocated shared memory to reorder global memory access
     __shared__  real temp[BSIZE*6];
 
     // First copy x and v inside temp
-    const int iext = umul24(blockIdx.x,BSIZE*3)+index1; //index0*3+index1;
+    const int iext = index0 * 3 + index1;
     temp[index1        ] = x[iext        ];
     temp[index1+  BSIZE] = x[iext+  BSIZE];
     temp[index1+2*BSIZE] = x[iext+2*BSIZE];
@@ -913,13 +913,13 @@ __global__ void StiffSpringForceFieldCuda3t_addForce_kernel(unsigned int nbSprin
 
     __syncthreads();
 
-    const int index3 = umul24(index1,3); //3*index1;
+    const int index3 = index1 * 3; //3*index1;
     CudaVec3<real> pos1 = CudaVec3<real>::make(temp[index3  ],temp[index3+1],temp[index3+2]);
     CudaVec3<real> vel1 = CudaVec3<real>::make(temp[index3  +3*BSIZE],temp[index3+1+3*BSIZE],temp[index3+2+3*BSIZE]);
     CudaVec3<real> force = CudaVec3<real>::make(0.0f,0.0f,0.0f);
 
-    springs+=(umul24(index0,nbSpringPerVertex)<<1)+index1;
-    dfdx+=umul24(index0,nbSpringPerVertex)+index1;
+    springs+=(index0*nbSpringPerVertex<<1)+index1;
+    dfdx+=index0*nbSpringPerVertex+index1;
 
     for (int s = 0; s < nbSpringPerVertex; s++)
     {
@@ -998,14 +998,14 @@ __global__ void StiffSpringForceFieldCuda3t_addForce_kernel(unsigned int nbSprin
 template<typename real>
 __global__ void StiffSpringForceFieldCuda3t_addExternalDForce_kernel(unsigned int nbSpringPerVertex, const GPUSpring* springs, real* f1, const real* dx1, const real* x1, const real* dx2, const real* x2, const real* dfdx, real factor)
 {
-    const int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    const int index0 = blockIdx.x * BSIZE; //blockDim.x;
     const int index1 = threadIdx.x;
 
     //! Dynamically allocated shared memory to reorder global memory access
     __shared__  real temp[BSIZE*6];
 
     // First copy dx and x inside temp
-    const int iext = umul24(blockIdx.x,BSIZE*3)+index1; //index0*3+index1;
+    const int iext = index0 * 3 + index1;
     temp[index1        ] = dx1[iext        ];
     temp[index1+  BSIZE] = dx1[iext+  BSIZE];
     temp[index1+2*BSIZE] = dx1[iext+2*BSIZE];
@@ -1015,13 +1015,13 @@ __global__ void StiffSpringForceFieldCuda3t_addExternalDForce_kernel(unsigned in
 
     __syncthreads();
 
-    const int index3 = umul24(index1,3); //3*index1;
+    const int index3 = index1 * 3; //3*index1;
     CudaVec3<real> dpos1 = CudaVec3<real>::make(temp[index3  ],temp[index3+1],temp[index3+2]);
     CudaVec3<real> pos1 = CudaVec3<real>::make(temp[index3  +3*BSIZE],temp[index3+1+3*BSIZE],temp[index3+2+3*BSIZE]);
     CudaVec3<real> dforce = CudaVec3<real>::make(0.0f,0.0f,0.0f);
 
-    springs+=(umul24(index0,nbSpringPerVertex)<<1)+index1;
-    dfdx+=umul24(index0,nbSpringPerVertex)+index1;
+    springs+=(index0*nbSpringPerVertex<<1)+index1;
+    dfdx+=index0*nbSpringPerVertex+index1;
 
     for (int s = 0; s < nbSpringPerVertex; s++)
     {
@@ -1080,15 +1080,15 @@ __global__ void StiffSpringForceFieldCuda3t_addExternalDForce_kernel(unsigned in
 template<typename real>
 __global__ void StiffSpringForceFieldCuda3t1_addDForce_kernel(unsigned int nbSpringPerVertex, const GPUSpring* springs, CudaVec4<real>* f1, const CudaVec4<real>* dx1, const CudaVec4<real>* x1, const CudaVec4<real>* dx2, const CudaVec4<real>* x2, const real* dfdx, real factor)
 {
-    const int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    const int index0 = blockIdx.x * BSIZE; //blockDim.x;
     const int index1 = threadIdx.x;
     const int index = index0 + index1;
     CudaVec3<real> dpos1 = CudaVec3<real>::make(dx1[index]);
     CudaVec3<real> pos1 = CudaVec3<real>::make(x1[index]);
     CudaVec3<real> dforce = CudaVec3<real>::make(0.0f,0.0f,0.0f);
 
-    springs+=(umul24(index0,nbSpringPerVertex)<<1)+index1;
-    dfdx+=umul24(index0,nbSpringPerVertex)+index1;
+    springs+=(index0*nbSpringPerVertex<<1)+index1;
+    dfdx+=index0*nbSpringPerVertex+index1;
 
     for (int s = 0; s < nbSpringPerVertex; s++)
     {
@@ -1135,13 +1135,13 @@ __global__ void StiffSpringForceFieldCuda3t1_addDForce_kernel(unsigned int nbSpr
 template<typename real>
 __global__ void StiffSpringForceFieldCuda3t_addDForce_kernel(unsigned int nbSpringPerVertex, const GPUSpring* springs, real* f, const real* dx, const real* x, const real* dfdx, real factor)
 {
-    int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x * BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
 
     //! Dynamically allocated shared memory to reorder global memory access
     __shared__  real temp[BSIZE*6];
-    int iext = umul24(blockIdx.x,BSIZE*3)+index1; //index0*3+index1;
-    int index3 = umul24(index1,3); //3*index1;
+    int iext = index0 * 3 + index1;
+    int index3 = index1 * 3; //3*index1;
 
 #ifdef USE_TEXTURE
     CudaVec3<real> dpos1 = CudaSpringForceFieldInputTextures<real,CudaVec3<real> >::getDX(index0+index1, (const CudaVec3<real>*)dx); //((const CudaVec3<real>*)dx)[index0+index1];
@@ -1162,8 +1162,8 @@ __global__ void StiffSpringForceFieldCuda3t_addDForce_kernel(unsigned int nbSpri
 #endif
     CudaVec3<real> dforce = CudaVec3<real>::make(0.0f,0.0f,0.0f);
 
-    springs+=(umul24(index0,nbSpringPerVertex)<<1)+index1;
-    dfdx+=umul24(index0,nbSpringPerVertex)+index1;
+    springs+=(index0*nbSpringPerVertex<<1)+index1;
+    dfdx+=index0*nbSpringPerVertex+index1;
 
     for (int s = 0; s < nbSpringPerVertex; s++)
     {
@@ -1186,7 +1186,7 @@ __global__ void StiffSpringForceFieldCuda3t_addDForce_kernel(unsigned int nbSpri
             if (spring.index >= index0 && spring.index < index0+BSIZE)
             {
                 // 'local' point
-                int i3 = umul24(spring.index - index0, 3);
+                int i3 = (spring.index - index0) * 3;
                 du = CudaVec3<real>::make(temp[i3  ], temp[i3+1], temp[i3+2]);
                 u = CudaVec3<real>::make(temp[i3  +3*BSIZE], temp[i3+1+3*BSIZE], temp[i3+2+3*BSIZE]);
             }

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSubsetMapping.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaSubsetMapping.cu
@@ -62,7 +62,7 @@ extern "C"
 template<typename TIn>
 __global__ void SubsetMappingCuda3f_apply_kernel(unsigned int size, const int* map, float* out, const TIn* in)
 {
-    const int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    const int index0 = blockIdx.x * BSIZE; //blockDim.x;
     const int index1 = threadIdx.x;
 
     //! Dynamically allocated shared memory to reorder global memory access
@@ -78,7 +78,7 @@ __global__ void SubsetMappingCuda3f_apply_kernel(unsigned int size, const int* m
 
     //__syncthreads();
 
-    const int index3 = umul24(index1,3);
+    const int index3 = index1 * 3;
 
     temp[index3  ] = res.x;
     temp[index3+1] = res.y;
@@ -86,7 +86,7 @@ __global__ void SubsetMappingCuda3f_apply_kernel(unsigned int size, const int* m
 
     __syncthreads();
 
-    out += umul24(index0,3);
+    out += index0 * 3;
     out[index1        ] = temp[index1        ];
     out[index1+  BSIZE] = temp[index1+  BSIZE];
     out[index1+2*BSIZE] = temp[index1+2*BSIZE];
@@ -95,7 +95,7 @@ __global__ void SubsetMappingCuda3f_apply_kernel(unsigned int size, const int* m
 template<typename TIn>
 __global__ void SubsetMappingCuda3f1_apply_kernel(unsigned int size, const int* map, CudaVec4<float>* out, const TIn* in)
 {
-    const int index = umul24(blockIdx.x,BSIZE) + threadIdx.x;
+    const int index = blockIdx.x * BSIZE + threadIdx.x;
 
     CudaVec4<float> res = CudaVec4<float>::make(0,0,0,0);
 
@@ -111,7 +111,7 @@ __global__ void SubsetMappingCuda3f1_apply_kernel(unsigned int size, const int* 
 template<typename TIn>
 __global__ void SubsetMappingCuda3f_applyJT_kernel(unsigned int size, unsigned int maxNOut, const int* mapT, float* out, const TIn* in)
 {
-    const int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    const int index0 = blockIdx.x * BSIZE; //blockDim.x;
     const int index1 = threadIdx.x;
 
     //! Dynamically allocated shared memory to reorder global memory access
@@ -120,7 +120,7 @@ __global__ void SubsetMappingCuda3f_applyJT_kernel(unsigned int size, unsigned i
     CudaVec3<float> res = CudaVec3<float>::make(0,0,0);
     //res += *((const CudaVec3<float>*)in) * mapT[index0+index1].f;
 
-    mapT+=umul24(index0,maxNOut)+index1;
+    mapT+=index0*maxNOut+index1;
     for (int s = 0; s < maxNOut; s++)
     {
         int data = *mapT;
@@ -129,7 +129,7 @@ __global__ void SubsetMappingCuda3f_applyJT_kernel(unsigned int size, unsigned i
             res += CudaVec3<float>::make(in[data]);
     }
 
-    const int index3 = umul24(index1,3);
+    const int index3 = index1 * 3;
 
     temp[index3  ] = res.x;
     temp[index3+1] = res.y;
@@ -137,7 +137,7 @@ __global__ void SubsetMappingCuda3f_applyJT_kernel(unsigned int size, unsigned i
 
     __syncthreads();
 
-    out += umul24(index0,3);
+    out += index0 * 3;
     out[index1        ] += temp[index1        ];
     out[index1+  BSIZE] += temp[index1+  BSIZE];
     out[index1+2*BSIZE] += temp[index1+2*BSIZE];
@@ -146,14 +146,14 @@ __global__ void SubsetMappingCuda3f_applyJT_kernel(unsigned int size, unsigned i
 template<typename TIn>
 __global__ void SubsetMappingCuda3f1_applyJT_kernel(unsigned int size, unsigned int maxNOut, const int* mapT, CudaVec4<float>* out, const TIn* in)
 {
-    const int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    const int index0 = blockIdx.x * BSIZE; //blockDim.x;
     const int index1 = threadIdx.x;
     const int index = index0 + index1;
 
     CudaVec3<float> res = CudaVec3<float>::make(0,0,0);
     //res += *((const CudaVec3<float>*)in) * mapT[index0+index1].f;
 
-    mapT+=umul24(index0,maxNOut)+index1;
+    mapT+=index0*maxNOut+index1;
     for (int s = 0; s < maxNOut; s++)
     {
         int data = *mapT;
@@ -172,20 +172,20 @@ template<typename TOut>
 __global__ void SubsetMappingCuda3f_applyJT1_kernel(unsigned int size, const int* map, TOut* out, const float* in)
 {
 
-    const int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    const int index0 = blockIdx.x * BSIZE; //blockDim.x;
     const int index1 = threadIdx.x;
 
     //! Dynamically allocated shared memory to reorder global memory access
     extern  __shared__  float temp[];
 
-    in += umul24(index0,3);
+    in += index0 * 3;
     temp[index1        ] = in[index1        ];
     temp[index1+  BSIZE] = in[index1+  BSIZE];
     temp[index1+2*BSIZE] = in[index1+2*BSIZE];
 
     __syncthreads();
 
-    const int index3 = umul24(3,index1);
+    const int index3 = 3 * index1;
     CudaVec3<float> res = CudaVec3<float>::make(temp[index3  ],temp[index3+1],temp[index3+2]);
 
     int c = map[index0+index1];
@@ -202,7 +202,7 @@ __global__ void SubsetMappingCuda3f_applyJT1_kernel(unsigned int size, const int
 template<typename TOut>
 __global__ void SubsetMappingCuda3f1_applyJT1_kernel(unsigned int size, const int* map, TOut* out, const CudaVec4<float>* in)
 {
-    const int index = umul24(blockIdx.x,BSIZE) + threadIdx.x;
+    const int index = blockIdx.x * BSIZE + threadIdx.x;
 
     CudaVec3<float> res = CudaVec3<float>::make(in[index]);
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronFEMForceField.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronFEMForceField.cu
@@ -26,8 +26,6 @@
 #include "mycuda.h"
 #include <stdio.h>
 
-//#define umul24(x,y) ((x)*(y))
-
 #if defined(__cplusplus)
 namespace sofa
 {
@@ -226,7 +224,7 @@ public:
 
     static __inline__ __device__ CudaVec3<real> getX(int i, const TIn* x)
     {
-        int i3 = umul24(i,3);
+        int i3 = i * 3;
         float x1 = tex1Dfetch(tex_3f_x, i3);
         float x2 = tex1Dfetch(tex_3f_x, i3+1);
         float x3 = tex1Dfetch(tex_3f_x, i3+2);
@@ -245,7 +243,7 @@ public:
 
     static __inline__ __device__ CudaVec3<real> getDX(int i, const TIn* dx)
     {
-        int i3 = umul24(i,3);
+        int i3 = i * 3;
         float x1 = tex1Dfetch(tex_3f_dx, i3);
         float x2 = tex1Dfetch(tex_3f_dx, i3+1);
         float x3 = tex1Dfetch(tex_3f_dx, i3+2);
@@ -318,7 +316,7 @@ public:
 
     static __inline__ __device__ CudaVec3<real> getX(int i, const TIn* x)
     {
-        int i3 = umul24(i,3);
+        int i3 = i * 3;
         double x1 = tex1Dfetch(tex_3d_x, i3);
         double x2 = tex1Dfetch(tex_3d_x, i3+1);
         double x3 = tex1Dfetch(tex_3d_x, i3+2);
@@ -337,7 +335,7 @@ public:
 
     static __inline__ __device__ CudaVec3<real> getDX(int i, const TIn* dx)
     {
-        int i3 = umul24(i,3);
+        int i3 = i * 3;
         double x1 = tex1Dfetch(tex_3d_dx, i3);
         double x2 = tex1Dfetch(tex_3d_dx, i3+1);
         double x3 = tex1Dfetch(tex_3d_dx, i3+2);
@@ -412,7 +410,7 @@ public:
 
     static __inline__ __device__ CudaVec3<real> getElementForce(int i, const TIn* x)
     {
-        int i3 = umul24(i,3);
+        int i3 = i * 3;
         float x1 = tex1Dfetch(tex_3f_eforce, i3);
         float x2 = tex1Dfetch(tex_3f_eforce, i3+1);
         float x3 = tex1Dfetch(tex_3f_eforce, i3+2);
@@ -469,7 +467,7 @@ public:
 
     static __inline__ __device__ CudaVec3<real> getElementForce(int i, const TIn* x)
     {
-        int i3 = umul24(i,3);
+        int i3 = i * 3;
         double x1 = tex1Dfetch(tex_3d_eforce, i3);
         double x2 = tex1Dfetch(tex_3d_eforce, i3+1);
         double x3 = tex1Dfetch(tex_3d_eforce, i3+2);
@@ -509,7 +507,7 @@ public:
 template<typename real, class TIn>
 __global__ void TetrahedronFEMForceFieldCuda3t_calcForce_kernel(int nbElem, const GPUElement<real>* elems, real* rotations, real* eforce, const TIn* x)
 {
-    int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x * BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
     int index = index0+index1;
 
@@ -517,7 +515,7 @@ __global__ void TetrahedronFEMForceFieldCuda3t_calcForce_kernel(int nbElem, cons
     //GPUElementState<real> s;
     const GPUElement<real>* e = elems + blockIdx.x;
     matrix3<real> Rt;
-    rotations += umul24(index0,9)+index1;
+    rotations += index0 * 9 + index1;
     //GPUElementForce<real> f;
     CudaVec3<real> fB,fC,fD;
 
@@ -655,7 +653,7 @@ __global__ void TetrahedronFEMForceFieldCuda3t_calcForce_kernel(int nbElem, cons
 
     //! Dynamically allocated shared memory to reorder global memory access
     __shared__  real temp[BSIZE*13];
-    int index13 = umul24(index1,13);
+    int index13 = index1 * 13;
     temp[index13+0 ] = -(fB.x+fC.x+fD.x);
     temp[index13+1 ] = -(fB.y+fC.y+fD.y);
     temp[index13+2 ] = -(fB.z+fC.z+fD.z);
@@ -669,7 +667,7 @@ __global__ void TetrahedronFEMForceFieldCuda3t_calcForce_kernel(int nbElem, cons
     temp[index13+10] = fD.y;
     temp[index13+11] = fD.z;
     __syncthreads();
-    real* out = ((real*)eforce)+(umul24(blockIdx.x,BSIZE*16))+index1;
+    real* out = ((real*)eforce)+(blockIdx.x * BSIZE * 16)+index1;
     real v = 0;
     bool read = true; //(index1&4)<3;
     index1 += (index1>>4) - (index1>>2); // remove one for each 4-values before this thread, but add an extra one each 16 threads (so each 12 input cells, to align to 13)
@@ -849,13 +847,13 @@ __global__ void TetrahedronFEMForceFieldCuda3t_addForce8_kernel(int nbVertex, un
 template<typename real, int BSIZE>
 __global__ void TetrahedronFEMForceFieldCuda3t1_addForce1_kernel(int nbVertex, unsigned int nbElemPerVertex, const CudaVec4<real>* eforce, const int* velems, CudaVec4<real>* f)
 {
-    const int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    const int index0 = blockIdx.x * BSIZE; //blockDim.x;
     const int index1 = threadIdx.x;
     const int index = index0 + index1;
 
     CudaVec3<real> force = CudaVec3<real>::make(0.0f,0.0f,0.0f);
 
-    velems+=umul24(index0,nbElemPerVertex)+index1;
+    velems += index0 * nbElemPerVertex + index1;
 
     if (index < nbVertex)
         for (int s = 0; s < nbElemPerVertex; s++)
@@ -877,7 +875,7 @@ __global__ void TetrahedronFEMForceFieldCuda3t1_addForce1_kernel(int nbVertex, u
 template<typename real, class TIn>
 __global__ void TetrahedronFEMForceFieldCuda3t_calcDForce_kernel(int nbElem, const GPUElement<real>* elems, const real* rotations, real* eforce, const TIn* x, real factor)
 {
-    int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x * BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
     int index = index0+index1;
 
@@ -887,7 +885,7 @@ __global__ void TetrahedronFEMForceFieldCuda3t_calcDForce_kernel(int nbElem, con
     //GPUElementForce<real> f;
     CudaVec3<real> fB,fC,fD;
     matrix3<real> Rt;
-    rotations += umul24(index0,9)+index1;
+    rotations += index0 * 9 + index1;
     Rt.readAoS(rotations);
     //Rt = ((const rmatrix3*)rotations)[index];
 
@@ -1003,7 +1001,7 @@ __global__ void TetrahedronFEMForceFieldCuda3t_calcDForce_kernel(int nbElem, con
 
     //! Dynamically allocated shared memory to reorder global memory access
     __shared__  real temp[BSIZE*13];
-    int index13 = umul24(index1,13);
+    int index13 = index1 * 13;
     temp[index13+0 ] = -(fB.x+fC.x+fD.x);
     temp[index13+1 ] = -(fB.y+fC.y+fD.y);
     temp[index13+2 ] = -(fB.z+fC.z+fD.z);
@@ -1017,7 +1015,7 @@ __global__ void TetrahedronFEMForceFieldCuda3t_calcDForce_kernel(int nbElem, con
     temp[index13+10] = fD.y;
     temp[index13+11] = fD.z;
     __syncthreads();
-    real* out = ((real*)eforce)+(umul24(blockIdx.x,BSIZE*16))+index1;
+    real* out = ((real*)eforce)+(blockIdx.x * BSIZE * 16)+index1;
     real v = 0;
     bool read = true; //(index1&4)<3;
     index1 += (index1>>4) - (index1>>2); // remove one for each 4-values before this thread, but add an extra one each 16 threads (so each 12 input cells, to align to 13)
@@ -1059,7 +1057,7 @@ __global__ void TetrahedronFEMForceFieldCuda3t_calcDForce_kernel(int nbElem, con
 template<typename real>
 __global__ void TetrahedronFEMForceFieldCuda3t_getRotations_kernel(int nbVertex, const real* initState, const real* state, const int* rotationIdx, real* rotations)
 {
-    int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x * BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
     int index = index0+index1;
 
@@ -1097,14 +1095,14 @@ __global__ void TetrahedronFEMForceFieldCuda3t_getRotations_kernel(int nbVertex,
 template<typename real>
 __global__ void TetrahedronFEMForceFieldCuda3t_getElementRotations_kernel(unsigned nbElem,const real* rotationsAos, real* rotations)
 {
-    int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x * BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
     int index = index0+index1;
 
     if (index>=nbElem) return;
 
     matrix3<real> R;
-    rotationsAos += umul24(index0,9)+index1;
+    rotationsAos += index0 * 9 + index1;
     R.readAoS(rotationsAos);
 
     rotations += 9*index;

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronFEMForceField.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronFEMForceField.cu
@@ -710,18 +710,18 @@ __global__ void TetrahedronFEMForceFieldCuda3t_calcForce_kernel(int nbElem, cons
 template<typename real,int BSIZE>
 __global__ void TetrahedronFEMForceFieldCuda3t_addForce1_kernel(int nbVertex, unsigned int nbElemPerVertex, const CudaVec4<real>* eforce, const int* velems, real* f)
 {
-    int index0 = fastmul(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x * BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
-    int index3 = fastmul(index1,3); //3*index1;
+    int index3 = 3 * index1;
 
     //! Shared memory buffer to reorder global memory access
     __shared__  real temp[BSIZE*3];
 
-    int iext = fastmul(blockIdx.x,BSIZE*3)+index1; //index0*3+index1;
+    int iext = index0 * 3 + index1;
 
     CudaVec3<real> force = CudaVec3<real>::make(0.0f,0.0f,0.0f);
 
-    velems+=fastmul(index0,nbElemPerVertex)+index1;
+    velems += index0 * nbElemPerVertex + index1;
 
     if (index0+index1 < nbVertex)
         for (int s = 0; s < nbElemPerVertex; s++)
@@ -749,7 +749,7 @@ __global__ void TetrahedronFEMForceFieldCuda3t_addForce1_kernel(int nbVertex, un
 template<typename real,int BSIZE>
 __global__ void TetrahedronFEMForceFieldCuda3t_addForce4_kernel(int nbVertex, unsigned int nb4ElemPerVertex, const CudaVec4<real>* eforce, const int* velems, real* f)
 {
-    int index0 = fastmul(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x * BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
 
     //! Shared memory buffer to reorder global memory access
@@ -772,7 +772,7 @@ __global__ void TetrahedronFEMForceFieldCuda3t_addForce4_kernel(int nbVertex, un
     }
 
     //int iout = (index1>>2)*3 + (index1&3)*((BSIZE/4)*3);
-    int iout = fastmul((index1>>2) + ((index1&3)*(BSIZE/4)),3);
+    int iout = ((index1>>2) + ((index1&3)*(BSIZE/4)))*3;
     temp[iout  ] = force.x;
     temp[iout+1] = force.y;
     temp[iout+2] = force.z;
@@ -785,7 +785,7 @@ __global__ void TetrahedronFEMForceFieldCuda3t_addForce4_kernel(int nbVertex, un
 
         real res = temp[index1] + temp[index1+ (BSIZE/4)*3] + temp[index1+ 2*(BSIZE/4)*3] + temp[index1+ 3*(BSIZE/4)*3];
 
-        int iext = fastmul(blockIdx.x,(BSIZE/4)*3)+index1; //index0*3+index1;
+        int iext = blockIdx.x*(BSIZE/4)*3+index1; //index0*3+index1;
 
         f[iext] += res;
     }
@@ -794,7 +794,7 @@ __global__ void TetrahedronFEMForceFieldCuda3t_addForce4_kernel(int nbVertex, un
 template<typename real,int BSIZE>
 __global__ void TetrahedronFEMForceFieldCuda3t_addForce8_kernel(int nbVertex, unsigned int nb8ElemPerVertex, const CudaVec4<real>* eforce, const int* velems, real* f)
 {
-    int index0 = fastmul(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x*BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
 
     //! Shared memory buffer to reorder global memory access
@@ -817,7 +817,7 @@ __global__ void TetrahedronFEMForceFieldCuda3t_addForce8_kernel(int nbVertex, un
     }
 
     //int iout = (index1>>2)*3 + (index1&7)*((BSIZE/8)*3);
-    int iout = fastmul((index1>>3) + ((index1&3)*(BSIZE/8)),3);
+    int iout = ((index1>>3) + ((index1&3)*(BSIZE/8)))*3;
     if (index1&4)
     {
         temp[iout  ] = force.x;
@@ -838,7 +838,7 @@ __global__ void TetrahedronFEMForceFieldCuda3t_addForce8_kernel(int nbVertex, un
         // we need to merge 4 values together
         real res = temp[index1] + temp[index1+ (BSIZE/8)*3] + temp[index1+ 2*(BSIZE/8)*3] + temp[index1+ 3*(BSIZE/8)*3];
 
-        int iext = fastmul(blockIdx.x,(BSIZE/8)*3)+index1; //index0*3+index1;
+        int iext = blockIdx.x*(BSIZE/8)*3+index1; //index0*3+index1;
 
         f[iext] += res;
     }

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTetrahedronTLEDForceField.cu
@@ -149,7 +149,7 @@ static void setX(const void* x)
 // Device function returning the position of vertex i as a float3
 __device__ CudaVec3f getX(int i)
 {
-    int i3 = umul24(i,3);
+    int i3 = i * 3;
     float x1 = tex1Dfetch(texX, i3);
     float x2 = tex1Dfetch(texX, i3+1);
     float x3 = tex1Dfetch(texX, i3+2);
@@ -168,7 +168,7 @@ static void setX0(const void* x0)
 // Device function returning the rest position of vertex i as a float3
 __device__ CudaVec3f getX0(int i)
 {
-    int i3 = umul24(i,3);
+    int i3 = i * 3;
     float x1 = tex1Dfetch(texX0, i3);
     float x2 = tex1Dfetch(texX0, i3+1);
     float x3 = tex1Dfetch(texX0, i3+2);
@@ -196,7 +196,7 @@ static void setX0(const void* x0)
  */
 __global__ void CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet0(float Lambda, float Mu, int nbElem, float4* F0, float4* F1, float4* F2, float4* F3)
 {
-    int index0 = umul24(blockIdx.x,BSIZE);
+    int index0 = blockIdx.x * BSIZE;
     int index1 = threadIdx.x;
     int index = index0+index1;
 
@@ -332,7 +332,7 @@ __global__ void CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet0(float Lamb
  */
 __global__ void CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet1(float Lambda, float Mu, int nbElem, float4* F0, float4* F1, float4* F2, float4* F3)
 {
-    int index0 = umul24(blockIdx.x,BSIZE);
+    int index0 = blockIdx.x * BSIZE;
     int index1 = threadIdx.x;
     int index = index0+index1;
 
@@ -476,7 +476,7 @@ __global__ void CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet1(float Lamb
  */
 __global__ void CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet2(float Lambda, float Mu, int nbElem, float4 * Di1, float4 * Di2, float4 * Dv1, float4 * Dv2, float4* F0, float4* F1, float4* F2, float4* F3)
 {
-    int index0 = umul24(blockIdx.x,BSIZE);
+    int index0 = blockIdx.x * BSIZE;
     int index1 = threadIdx.x;
     int index = index0+index1;
 
@@ -658,7 +658,7 @@ __global__ void CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet2(float Lamb
  */
 __global__ void CudaTetrahedronTLEDForceField3f_calcForce_kernel_tet3(float Lambda, float Mu, int nbElem, float4 * Di1, float4 * Di2, float4 * Dv1, float4 * Dv2, float4* F0, float4* F1, float4* F2, float4* F3)
 {
-    int index0 = umul24(blockIdx.x,BSIZE);
+    int index0 = blockIdx.x * BSIZE;
     int index1 = threadIdx.x;
     int index = index0+index1;
 
@@ -941,12 +941,12 @@ __device__ float4 computeForce_tet(const int node, const float4 DhC0, const floa
  */
 __global__ void CudaTetrahedronTLEDForceField3f_addForce_kernel(int nbVertex, unsigned int valence, float* f)
 {
-    int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x * BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
     int index = index0+index1;
 
-    int index3 = umul24(index1,3); //3*index1;
-    int iext = umul24(blockIdx.x,BSIZE*3)+index1; //index0*3+index1;
+    int index3 = index1 * 3; //3*index1;
+    int iext = index0 * 3 + index1;
 
     //! Dynamically allocated shared memory to reorder global memory access
     extern  __shared__  float temp[];

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaUniformMass.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaUniformMass.cu
@@ -70,7 +70,7 @@ extern "C"
 template<class real>
 __global__ void UniformMassCuda1t_addMDx_kernel(int size, const real mass, real* res, const real* dx)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     if (index < size)
     {
         res[index] += dx[index] * mass;
@@ -80,7 +80,7 @@ __global__ void UniformMassCuda1t_addMDx_kernel(int size, const real mass, real*
 template<class real>
 __global__ void UniformMassCuda3t_addMDx_kernel(int size, const real mass, CudaVec3<real>* res, const CudaVec3<real>* dx)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     if (index < size)
     {
         //res[index] += dx[index] * mass;
@@ -94,7 +94,7 @@ __global__ void UniformMassCuda3t_addMDx_kernel(int size, const real mass, CudaV
 template<class real>
 __global__ void UniformMassCuda3t1_addMDx_kernel(int size, const real mass, CudaVec4<real>* res, const CudaVec4<real>* dx)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     if (index < size)
     {
         //res[index] += dx[index] * mass;
@@ -148,7 +148,7 @@ __global__ void UniformMassCudaRigid3t_addMDx_kernel(const unsigned int size, co
 template<class real>
 __global__ void UniformMassCuda1t_accFromF_kernel(int size, const real inv_mass, real* a, const real* f)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     if (index < size)
     {
         a[index] = f[index] * inv_mass;
@@ -158,7 +158,7 @@ __global__ void UniformMassCuda1t_accFromF_kernel(int size, const real inv_mass,
 template<class real>
 __global__ void UniformMassCuda3t_accFromF_kernel(int size, const real inv_mass, CudaVec3<real>* a, const CudaVec3<real>* f)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     if (index < size)
     {
         //a[index] = f[index] * inv_mass;
@@ -171,7 +171,7 @@ __global__ void UniformMassCuda3t_accFromF_kernel(int size, const real inv_mass,
 template<class real>
 __global__ void UniformMassCuda3t1_accFromF_kernel(int size, const real inv_mass, CudaVec4<real>* a, const CudaVec4<real>* f)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     if (index < size)
     {
         //a[index] = f[index] * inv_mass;
@@ -230,7 +230,7 @@ __global__ void UniformMassCudaRigid3t_accFromF_kernel(const unsigned int size, 
 template<class real>
 __global__ void UniformMassCuda1t_addForce_kernel(int size, const real mg, real* f)
 {
-    int index = umul24(blockIdx.x,BSIZE);
+    int index = blockIdx.x * BSIZE;
     if (index < size)
     {
         f[index] += mg;
@@ -241,9 +241,9 @@ template<class real>
 //__global__ void UniformMassCuda3t_addForce_kernel(int size, const CudaVec3<real> mg, real* f)
 __global__ void UniformMassCuda3t_addForce_kernel(int size, real mg_x, real mg_y, real mg_z, real* f)
 {
-    //int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    //int index = blockIdx.x * BSIZE+threadIdx.x;
     //f[index] += mg;
-    f += umul24(blockIdx.x,BSIZE*3); //blockIdx.x*BSIZE*3;
+    f += blockIdx.x * BSIZE * 3;
     int index = threadIdx.x;
     __shared__  real temp[BSIZE*3];
     temp[index] = f[index];
@@ -252,9 +252,9 @@ __global__ void UniformMassCuda3t_addForce_kernel(int size, real mg_x, real mg_y
 
     __syncthreads();
 
-    if (umul24(blockIdx.x,BSIZE)+threadIdx.x < size)
+    if (blockIdx.x * BSIZE+threadIdx.x < size)
     {
-        int index3 = umul24(index,3); //3*index;
+        int index3 = index * 3;
         temp[index3+0] += mg_x;
         temp[index3+1] += mg_y;
         temp[index3+2] += mg_z;
@@ -270,7 +270,7 @@ __global__ void UniformMassCuda3t_addForce_kernel(int size, real mg_x, real mg_y
 template<class real>
 __global__ void UniformMassCuda3t1_addForce_kernel(int size, real mg_x, real mg_y, real mg_z, CudaVec4<real>* f)
 {
-    int index = umul24(blockIdx.x,BSIZE)+threadIdx.x;
+    int index = blockIdx.x * BSIZE+threadIdx.x;
     if (index < size)
     {
         //f[index] += mg;

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaVisualModel.cu
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaVisualModel.cu
@@ -24,8 +24,6 @@
 #include "CudaTexture.h"
 #include "cuda.h"
 
-//#define umul24(x,y) ((x)*(y))
-
 #if defined(__cplusplus) && CUDA_VERSION < 2000
 namespace sofa
 {
@@ -117,7 +115,7 @@ public:
 
     static __inline__ __device__ CudaVec3<real> getX(int i, const TIn* x)
     {
-        int i3 = umul24(i,3);
+        int i3 = i * 3;
         float x1 = tex1Dfetch(tex_3f_x, i3);
         float x2 = tex1Dfetch(tex_3f_x, i3+1);
         float x3 = tex1Dfetch(tex_3f_x, i3+2);
@@ -136,7 +134,7 @@ public:
 
     static __inline__ __device__ CudaVec3<real> getN(int i, const TIn* n)
     {
-        int i3 = umul24(i,3);
+        int i3 = i * 3;
         float x1 = tex1Dfetch(tex_3f_n, i3);
         float x2 = tex1Dfetch(tex_3f_n, i3+1);
         float x3 = tex1Dfetch(tex_3f_n, i3+2);
@@ -190,11 +188,11 @@ public:
 template<typename real, class TIn>
 __global__ void CudaVisualModelCuda3t_calcTNormals_kernel(int nbElem, const int* elems, real* fnormals, const TIn* x)
 {
-    int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x * BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
     int index = index0+index1;
-    int index3 = umul24(index1,3);
-    int iext = umul24(blockIdx.x,BSIZE*3)+index1; //index0*3+index1;
+    int index3 = index1 * 3;
+    int iext = index0 * 3 + index1;
 
     __shared__  union
     {
@@ -236,11 +234,11 @@ __global__ void CudaVisualModelCuda3t_calcTNormals_kernel(int nbElem, const int*
 template<typename real, class TIn>
 __global__ void CudaVisualModelCuda3t1_calcTNormals_kernel(int nbElem, const int* elems, CudaVec4<real>* fnormals, const TIn* x)
 {
-    int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x * BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
     int index = index0+index1;
-    int index3 = umul24(index1,3);
-    int iext = umul24(blockIdx.x,BSIZE*3)+index1; //index0*3+index1;
+    int index3 = index1 * 3;
+    int iext = index0 * 3 + index1;
 
     __shared__ int itemp[3*BSIZE];
 
@@ -268,11 +266,11 @@ __global__ void CudaVisualModelCuda3t1_calcTNormals_kernel(int nbElem, const int
 template<typename real, class TIn>
 __global__ void CudaVisualModelCuda3t_calcQNormals_kernel(int nbElem, const int4* elems, real* fnormals, const TIn* x)
 {
-    int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x * BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
     int index = index0+index1;
-    int index3 = umul24(index1,3);
-    int iext = umul24(blockIdx.x,BSIZE*3)+index1; //index0*3+index1;
+    int index3 = index1 * 3;
+    int iext = index0 * 3 + index1;
 
     __shared__ real rtemp[3*BSIZE];
 
@@ -304,7 +302,7 @@ __global__ void CudaVisualModelCuda3t_calcQNormals_kernel(int nbElem, const int4
 template<typename real, class TIn>
 __global__ void CudaVisualModelCuda3t1_calcQNormals_kernel(int nbElem, const int4* elems, CudaVec4<real>* fnormals, const TIn* x)
 {
-    int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x * BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
     int index = index0+index1;
 
@@ -328,17 +326,17 @@ __global__ void CudaVisualModelCuda3t1_calcQNormals_kernel(int nbElem, const int
 template<typename real, class TIn>
 __global__ void CudaVisualModelCuda3t_calcVNormals_kernel(int nbVertex, unsigned int nbElemPerVertex, const int* velems, real* vnormals, const TIn* fnormals)
 {
-    int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    int index0 = blockIdx.x * BSIZE; //blockDim.x;
     int index1 = threadIdx.x;
-    int index3 = umul24(index1,3); //3*index1;
+    int index3 = index1 * 3; //3*index1;
 
     __shared__  real temp[3*BSIZE];
 
-    int iext = umul24(blockIdx.x,BSIZE*3)+index1; //index0*3+index1;
+    int iext = index0 * 3 + index1;
 
     CudaVec3<real> n = CudaVec3<real>::make(0.0f,0.0f,0.0f);
 
-    velems+=umul24(index0,nbElemPerVertex)+index1;
+    velems += index0 * nbElemPerVertex + index1;
 
     if (index0+index1 < nbVertex)
     {
@@ -370,13 +368,13 @@ __global__ void CudaVisualModelCuda3t_calcVNormals_kernel(int nbVertex, unsigned
 template<typename real, class TIn>
 __global__ void CudaVisualModelCuda3t1_calcVNormals_kernel(int nbVertex, unsigned int nbElemPerVertex, const int* velems, CudaVec4<real>* vnormals, const TIn* fnormals)
 {
-    const int index0 = umul24(blockIdx.x,BSIZE); //blockDim.x;
+    const int index0 = blockIdx.x * BSIZE; //blockDim.x;
     const int index1 = threadIdx.x;
     const int index = index0 + index1;
 
     CudaVec3<real> n = CudaVec3<real>::make(0.0f,0.0f,0.0f);
 
-    velems+=umul24(index0,nbElemPerVertex)+index1;
+    velems += index0 * nbElemPerVertex + index1;
 
     if (index < nbVertex)
     {


### PR DESCRIPTION
According to web, this was useful only on architecture prior to fermi (cuda capabilities < 2.0)

useful link from 2011: https://stackoverflow.com/questions/5544355/cuda-umul24-function-useful-or-not


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
