### PR TITLE
[SofaMiscMapping] Topology is resized by the mapping

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/MechanicalObject.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/MechanicalObject.h
@@ -378,6 +378,9 @@ public:
    /// if this mechanical object stores independent dofs (in opposition to mapped dofs)
    bool isIndependent() const;
 
+    /// Get the associated topology
+    [[nodiscard]] core::topology::BaseMeshTopology* getTopology() const;
+
 protected :
 
     /// @name Initial geometric transformations

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/MechanicalObject.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/MechanicalObject.inl
@@ -2883,5 +2883,9 @@ bool MechanicalObject<DataTypes>::isIndependent() const
     return static_cast<const simulation::Node*>(this->getContext())->mechanicalMapping.empty();
 }
 
-
+template <class DataTypes>
+core::topology::BaseMeshTopology* MechanicalObject<DataTypes>::getTopology() const
+{
+    return l_topology.get();
+}
 } // namespace sofa::component::container

--- a/modules/SofaMiscMapping/src/SofaMiscMapping/SubsetMultiMapping.inl
+++ b/modules/SofaMiscMapping/src/SofaMiscMapping/SubsetMultiMapping.inl
@@ -25,6 +25,7 @@
 
 #include <sofa/linearalgebra/EigenSparseMatrix.h>
 #include <sofa/core/MappingHelper.h>
+#include <SofaBaseMechanics/MechanicalObject.h>
 
 namespace sofa::component::mapping
 {
@@ -36,6 +37,13 @@ void SubsetMultiMapping<TIn, TOut>::init()
     const unsigned indexPairSize = indexPairs.getValue().size()/2;
 
     this->toModels[0]->resize( indexPairSize );
+    if (auto* mobject = dynamic_cast<sofa::component::container::MechanicalObject<Out> *>(this->toModels[0]))
+    {
+        if (auto* topology = mobject->getTopology())
+        {
+            topology->setNbPoints(indexPairSize);
+        }
+    }
 
     Inherit::init();
 


### PR DESCRIPTION
`SubsetMultiMapping` resizes the target `State` according to the provided input Data. However, it did not update the topology.
For example, a `PointSetTopologyContainer` associated to the target `State` kept a number of vertices equal to zero.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
