### PR TITLE
[SofaSparseSolver] Disable matrix export in SparseLDLSolver

### DIFF
--- a/modules/SofaSparseSolver/src/SofaSparseSolver/AsyncSparseLDLSolver.inl
+++ b/modules/SofaSparseSolver/src/SofaSparseSolver/AsyncSparseLDLSolver.inl
@@ -95,11 +95,6 @@ void AsyncSparseLDLSolver<TMatrix, TVector, TThreadManager>::solve(Matrix& M, Ve
 template <class TMatrix, class TVector, class TThreadManager>
 void AsyncSparseLDLSolver<TMatrix, TVector, TThreadManager>::invert(TMatrix& M)
 {
-    if (this->f_saveMatrixToFile.getValue())
-    {
-        this->saveMatrix(M);
-    }
-
     Inherit1::factorize(M, m_asyncThreadInvertData);
 }
 

--- a/modules/SofaSparseSolver/src/SofaSparseSolver/SparseLDLSolver.h
+++ b/modules/SofaSparseSolver/src/SofaSparseSolver/SparseLDLSolver.h
@@ -57,15 +57,21 @@ public :
     typedef typename Inherit::JMatrixType JMatrixType;
     typedef SparseLDLImplInvertData<type::vector<int>, type::vector<Real> > InvertData;
 
+    void parse( sofa::core::objectmodel::BaseObjectDescription* arg ) override;
     void solve (Matrix& M, Vector& x, Vector& b) override;
     void invert(Matrix& M) override;
     bool doAddJMInvJtLocal(ResMatrixType* result, const JMatrixType* J, SReal fact, InvertData* data);
     bool addJMInvJtLocal(TMatrix * M, ResMatrixType * result,const JMatrixType * J, SReal fact) override;
     int numStep;
 
-    Data<bool> f_saveMatrixToFile;      ///< save matrix to a text file (can be very slow, as full matrix is stored)
-    sofa::core::objectmodel::DataFileName d_filename;   ///< file where this matrix will be saved
-    Data<int> d_precision;      ///< number of digits used to save system's matrix, default is 6
+    SOFA_ATTRIBUTE_DISABLED__SPARSELDLSOLVER_MATRIXEXPORT
+    DeprecatedAndRemoved f_saveMatrixToFile;
+
+    SOFA_ATTRIBUTE_DISABLED__SPARSELDLSOLVER_MATRIXEXPORT
+    DeprecatedAndRemoved d_filename;
+
+    SOFA_ATTRIBUTE_DISABLED__SPARSELDLSOLVER_MATRIXEXPORT
+    DeprecatedAndRemoved d_precision;
 
     MatrixInvertData * createInvertData() override {
         return new InvertData();
@@ -98,7 +104,6 @@ protected :
     sofa::linearalgebra::CompressedRowSparseMatrix<Real> Mfiltered;
 
     bool factorize(Matrix& M, InvertData * invertData);
-    void saveMatrix(Matrix& M);
 };
 
 #if  !defined(SOFA_COMPONENT_LINEARSOLVER_SPARSELDLSOLVER_CPP)

--- a/modules/SofaSparseSolver/src/SofaSparseSolver/SparseLDLSolver.inl
+++ b/modules/SofaSparseSolver/src/SofaSparseSolver/SparseLDLSolver.inl
@@ -39,32 +39,23 @@ namespace sofa::component::linearsolver {
 template<class TMatrix, class TVector, class TThreadManager>
 SparseLDLSolver<TMatrix,TVector,TThreadManager>::SparseLDLSolver()
     : numStep(0)
-    , f_saveMatrixToFile( initData(&f_saveMatrixToFile, false, "savingMatrixToFile", "save matrix to a text file (can be very slow, as full matrix is stored"))
-    , d_filename( initData(&d_filename, std::string("MatrixInLDL_%04d.txt"),"savingFilename", "Name of file where system matrix (mass, stiffness and damping) will be stored."))
-    , d_precision( initData(&d_precision, 6, "savingPrecision", "Number of digits used to store system's matrix. Default is 6."))
 {}
+
+template <class TMatrix, class TVector, class TThreadManager>
+void SparseLDLSolver<TMatrix, TVector, TThreadManager>::parse(sofa::core::objectmodel::BaseObjectDescription* arg)
+{
+    Inherit1::parse(arg);
+
+    if (arg->getAttribute("savingMatrixToFile"))
+    {
+        msg_warning() << "It is no longer possible to export the linear system matrix from within SparseLDLSolver. Instead, use the component GlobalSystemMatrixExporter.";
+    }
+}
 
 template<class TMatrix, class TVector, class TThreadManager>
 void SparseLDLSolver<TMatrix,TVector,TThreadManager>::solve (Matrix& M, Vector& z, Vector& r)
 {
     Inherit::solve_cpu(&z[0],&r[0],(InvertData *) this->getMatrixInvertData(&M));
-}
-
-
-template <class TMatrix, class TVector, class TThreadManager>
-void SparseLDLSolver<TMatrix, TVector, TThreadManager>::saveMatrix(Matrix& M)
-{
-    std::ofstream f;
-    std::string name=d_filename.getValue().c_str();
-    if (d_filename.getValue().find("%d"))
-    {
-        char bname[100];
-        snprintf(bname, 100, d_filename.getValue().c_str(), numStep);
-        name=bname;
-    }
-    f.open(name);
-    f << std::scientific << std::setprecision(d_precision.getValue()) << M;
-    f.close();
 }
 
 template <class TMatrix, class TVector, class TThreadManager>
@@ -96,11 +87,6 @@ bool SparseLDLSolver<TMatrix, TVector, TThreadManager>::factorize(
 template<class TMatrix, class TVector, class TThreadManager>
 void SparseLDLSolver<TMatrix,TVector,TThreadManager>::invert(Matrix& M)
 {
-    if (f_saveMatrixToFile.getValue())
-    {
-        saveMatrix(M);
-    }
-
     factorize(M, (InvertData *) this->getMatrixInvertData(&M));
 }
 

--- a/modules/SofaSparseSolver/src/SofaSparseSolver/SparseLDLSolver.inl
+++ b/modules/SofaSparseSolver/src/SofaSparseSolver/SparseLDLSolver.inl
@@ -48,7 +48,7 @@ void SparseLDLSolver<TMatrix, TVector, TThreadManager>::parse(sofa::core::object
 
     if (arg->getAttribute("savingMatrixToFile"))
     {
-        msg_warning() << "It is no longer possible to export the linear system matrix from within SparseLDLSolver. Instead, use the component GlobalSystemMatrixExporter.";
+        msg_warning() << "It is no longer possible to export the linear system matrix from within " << this->getClassName() <<  ". Instead, use the component GlobalSystemMatrixExporter (from the SofaMatrix plugin).";
     }
 }
 

--- a/modules/SofaSparseSolver/src/SofaSparseSolver/config.h.in
+++ b/modules/SofaSparseSolver/src/SofaSparseSolver/config.h.in
@@ -34,4 +34,12 @@
 #  define SOFA_SOFASPARSESOLVER_API SOFA_IMPORT_DYNAMIC_LIBRARY
 #endif
 
+#ifdef SOFA_BUILD_SOFASPARSESOLVER
+#define SOFA_ATTRIBUTE_DISABLED__SPARSELDLSOLVER_MATRIXEXPORT
+#else
+#define SOFA_ATTRIBUTE_DISABLED__SPARSELDLSOLVER_MATRIXEXPORT \
+    SOFA_ATTRIBUTE_DISABLED( \
+    "v22.06 (PR#2725)", "v22.12", "It is no longer possible to export the linear system matrix from within SparseLDLSolver. Instead, use the component GlobalSystemMatrixExporter.")
+#endif
+
 #endif


### PR DESCRIPTION
Since it is now possible to export a system matrix from any solver, the matrix export included in SparseLDLSolver is no longer required.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
