### PR TITLE
[Sofa.Core] Use forward declaration for BoundingBox in Base

### DIFF
--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/fwd.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/fwd.h
@@ -100,4 +100,8 @@ typedef Mat<4,4,SReal> Matrix4;
 template <typename RealType> class Quat;
 using Quatd = type::Quat<double>;
 using Quatf = type::Quat<float>;
+
+class BoundingBox;
+class BoundingBox1D;
+class BoundingBox2D;
 }

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.cpp
@@ -21,6 +21,8 @@
 ******************************************************************************/
 #define SOFA_CORE_OBJECTMODEL_BASE_CPP
 #include <sofa/core/objectmodel/Base.h>
+
+#include <sofa/type/BoundingBox.h>
 #include <sofa/helper/Factory.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/PathResolver.h>

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -22,7 +22,6 @@
 #ifndef SOFA_CORE_OBJECTMODEL_BASE_H
 #define SOFA_CORE_OBJECTMODEL_BASE_H
 
-#include <sofa/type/BoundingBox.h>
 #include <sofa/core/objectmodel/Data.h>
 #include <sofa/core/objectmodel/Link.h>
 #include <sofa/core/objectmodel/BaseClass.h>
@@ -39,6 +38,11 @@
 #include <sofa/core/DataTrackerCallback.h>
 
 #include <sofa/helper/system/SofaOStream.h>
+
+namespace sofa::type
+{
+    class BoundingBox;
+}
 
 // forward declaration of castable classes
 // @author Matthieu Nesme, 2015

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h
@@ -36,13 +36,9 @@
 #include <sofa/core/objectmodel/ComponentState.h>
 #include <sofa/core/DataTracker.h>
 #include <sofa/core/DataTrackerCallback.h>
+#include <sofa/type/fwd.h>
 
 #include <sofa/helper/system/SofaOStream.h>
-
-namespace sofa::type
-{
-    class BoundingBox;
-}
 
 // forward declaration of castable classes
 // @author Matthieu Nesme, 2015


### PR DESCRIPTION
Playing with ClangBuildAnalyzer, I noticed that BoundingBox was in the top ten of the most expensive include.
Indeed BBox was included in Base.h so everybody is including it. (and consequently Vec.h too)

```
423823 ms: SofaKernel/modules/Sofa.Type/src/sofa/type/Vec.h (included 828 times, avg 511 ms), 
362330 ms: SofaKernel/modules/Sofa.Type/src/sofa/type/BoundingBox.h (included 778 times, avg 465 ms),:
```

Fortunately, It was painless to do a forward declaration with it.
After this update, BBox.h (and Vec.h) is much less expensive in the whole compilation process.

```
84215 ms: SofaKernel/modules/Sofa.Type/src/sofa/type/Vec.h (included 828 times, avg 101 ms),
22233 ms: SofaKernel/modules/Sofa.Type/src/sofa/type/BoundingBox.h (included 779 times, avg 28 ms)`
```

Weirdly, it is still included a lot (because of DataTypeInfo_BoundingBox.h) but it is nevertheless much less expensive.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
