### PR TITLE
[SofaMiscMapping] Support points removal in SubsetMultiMapping

### DIFF
--- a/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetTopologyContainer.cpp
+++ b/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetTopologyContainer.cpp
@@ -165,9 +165,13 @@ void PointSetTopologyContainer::addPoints(const Size nPoints)
 
 void PointSetTopologyContainer::removePoints(const Size nPoints)
 {
-    if (nPoints < nbPoints.getValue())
+    if (nPoints <= nbPoints.getValue())
     {
         setNbPoints( nbPoints.getValue() - nPoints );
+    }
+    else
+    {
+        msg_error() << "Trying to set a negative number of points";
     }
 }
 

--- a/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetTopologyContainer.cpp
+++ b/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetTopologyContainer.cpp
@@ -165,7 +165,10 @@ void PointSetTopologyContainer::addPoints(const Size nPoints)
 
 void PointSetTopologyContainer::removePoints(const Size nPoints)
 {
-    setNbPoints( nbPoints.getValue() - nPoints );
+    if (nPoints < nbPoints.getValue())
+    {
+        setNbPoints( nbPoints.getValue() - nPoints );
+    }
 }
 
 void PointSetTopologyContainer::addPoint()

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/MechanicalObject.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/MechanicalObject.h
@@ -378,6 +378,9 @@ public:
    /// if this mechanical object stores independent dofs (in opposition to mapped dofs)
    bool isIndependent() const;
 
+    /// Get the associated topology
+    [[nodiscard]] core::topology::BaseMeshTopology* getTopology() const;
+
 protected :
 
     /// @name Initial geometric transformations

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/MechanicalObject.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/MechanicalObject.inl
@@ -2883,5 +2883,9 @@ bool MechanicalObject<DataTypes>::isIndependent() const
     return static_cast<const simulation::Node*>(this->getContext())->mechanicalMapping.empty();
 }
 
-
+template <class DataTypes>
+core::topology::BaseMeshTopology* MechanicalObject<DataTypes>::getTopology() const
+{
+    return l_topology.get();
+}
 } // namespace sofa::component::container

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopologyData.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopologyData.h
@@ -44,11 +44,7 @@ class BaseTopologyData : public sofa::core::objectmodel::Data <T>
 {
 public:
 
-    /** \copydoc Data(const BaseData::BaseInitData&) */
-    explicit BaseTopologyData(const sofa::core::objectmodel::BaseData::BaseInitData& init)
-        : Data<T>(init)
-    {
-    }
+    using sofa::core::objectmodel::Data<T>::Data;
 
     /// Add some values. Values are added at the end of the vector.
     virtual void add(const sofa::type::vector< Topology::PointID >& ,

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyData.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyData.h
@@ -62,8 +62,7 @@ public:
     typedef typename sofa::core::topology::TopologyDataHandler< TopologyElementType, VecT>  TopologyDataElementHandler;
     typedef typename TopologyDataElementHandler::TopologyChangeCallback TopologyChangeCallback;
 
-    /// Constructor
-    TopologyData(const typename sofa::core::topology::BaseTopologyData< VecT >::InitData& data);
+    using sofa::core::topology::BaseTopologyData<VecT>::BaseTopologyData;
 
 
     /// Function to create topology handler to manage this Data. @param Pointer to dynamic topology is needed.
@@ -145,9 +144,9 @@ public:
     virtual void createTopologyHandler(sofa::core::topology::BaseMeshTopology* _topology, sofa::core::topology::TopologyDataHandler< TopologyElementType, VecT>* topoHandler) = delete;
     
 protected:
-    std::unique_ptr<TopologyDataElementHandler> m_topologyHandler;
+    std::unique_ptr<TopologyDataElementHandler> m_topologyHandler { nullptr };
 
-    bool m_isTopologyDynamic;
+    bool m_isTopologyDynamic { false };
 
     void linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Point*);
     void linkToElementDataArray(sofa::core::topology::BaseMeshTopology::Edge*);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyData.inl
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologyData.inl
@@ -35,14 +35,6 @@ static const sofa::type::vector< SReal > s_empty_coefficients;
 /////////////////////////////   Generic Topology Data Implementation   /////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-template <typename TopologyElementType, typename VecT>
-TopologyData <TopologyElementType, VecT>::TopologyData(const typename sofa::core::topology::BaseTopologyData< VecT >::InitData& data)
-    : sofa::core::topology::BaseTopologyData< VecT >(data)
-    , m_topologyHandler(nullptr)
-    , m_isTopologyDynamic(false)
-{
-}
-
 
 template <typename TopologyElementType, typename VecT>
 void TopologyData <TopologyElementType, VecT>::createTopologyHandler(sofa::core::topology::BaseMeshTopology* _topology)

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologySubsetData.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologySubsetData.h
@@ -47,8 +47,7 @@ public:
     typedef core::topology::TopologyChangeElementInfo<TopologyElementType> ChangeElementInfo;
     typedef typename ChangeElementInfo::AncestorElem    AncestorElem;
 
-    /// Default Constructor to init Data
-    TopologySubsetData(const typename sofa::core::topology::BaseTopologyData< VecT >::InitData& data);
+    using sofa::core::topology::TopologyData<TopologyElementType, VecT>::TopologyData;
 
     /// Method to set a vector map to rull this subsetData. Will set @sa m_usingMap to true Otherwise will use the Data as the map
     void setMap2Elements(const sofa::type::vector<Index> _map2Elements);
@@ -141,7 +140,7 @@ protected:
     sofa::type::vector<Index> m_map2Elements;
 
     /// boolen to set subdata as concerne, will allow to add element
-    bool m_isConcerned;
+    bool m_isConcerned { false };
 };
 
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologySubsetData.inl
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologySubsetData.inl
@@ -31,13 +31,6 @@ namespace sofa::core::topology
 /////////////////////////////   Generic Topology Data Implementation   /////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-template <typename TopologyElementType, typename VecT>
-TopologySubsetData <TopologyElementType, VecT>::TopologySubsetData(const typename sofa::core::topology::BaseTopologyData< VecT >::InitData& data)
-    : sofa::core::topology::TopologyData< TopologyElementType, VecT >(data)
-    , m_isConcerned(false)
-{
-
-}
 
 ///////////////////// Private functions on TopologySubsetData changes /////////////////////////////
 template <typename TopologyElementType, typename VecT>

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologySubsetIndices.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologySubsetIndices.cpp
@@ -28,11 +28,6 @@
 namespace sofa::core::topology
 {
 
-TopologySubsetIndices::TopologySubsetIndices(const typename sofa::core::topology::BaseTopologyData< type::vector<Index> >::InitData& data)
-    : sofa::core::topology::TopologySubsetData< core::topology::BaseMeshTopology::Point, type::vector<Index> >(data)
-{
-
-}
 
 Index TopologySubsetIndices::indexOfElement(Index index)
 {

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologySubsetIndices.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologySubsetIndices.h
@@ -42,8 +42,7 @@ public:
     typedef Index value_type;
     typedef sofa::core::topology::TopologySubsetData < core::topology::BaseMeshTopology::Point, container_type> Inherit;
 
-    /// Default Constructor to init Data
-    explicit TopologySubsetIndices(const typename sofa::core::topology::BaseTopologyData< type::vector<Index> >::InitData& data);
+    using sofa::core::topology::TopologySubsetData<core::topology::BaseMeshTopology::Point, type::vector<Index> >::TopologySubsetData;
     
     Index indexOfElement(Index index) override;
 

--- a/examples/Components/topology/TopologicalModifiers/RemovingPointSubsetMultiMapping.scn
+++ b/examples/Components/topology/TopologicalModifiers/RemovingPointSubsetMultiMapping.scn
@@ -35,7 +35,7 @@
 
         <SubsetMultiMapping input="@../FixedPointNode/dof @../MassNode/dof" output="@dofs" indexPairs="0 0  0 1  0 2  0 3     1 0  1 1  1 2  1 3" printLog="true"/>
         <PointSetTopologyContainer name="container" printLog="true"/>
-<!--        <PointSetTopologyModifier name="modifier" printLog="true" />-->
+        <PointSetTopologyModifier name="modifier" printLog="true" />
         <StiffSpringForceField spring="
             2 4 100 0 1
             1 6 100 0 1

--- a/examples/Components/topology/TopologicalModifiers/RemovingPointSubsetMultiMapping.scn
+++ b/examples/Components/topology/TopologicalModifiers/RemovingPointSubsetMultiMapping.scn
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0"?>
+<Node name="root" dt="0.1" gravity="0 -10 0">
+    <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/>
+    <RequiredPlugin name="SofaBoundaryCondition"/>
+    <RequiredPlugin name="SofaDeformable"/>
+    <RequiredPlugin name="SofaMiscMapping"/>
+    <RequiredPlugin name="SofaOpenglVisual"/>
+    <RequiredPlugin name="SofaMiscTopology"/>
+
+    <VisualStyle displayFlags="hideVisualModels showBehaviorModels showForceFields showCollisionModels showInteractionForceFields" />
+
+    <OglGrid size="5" nbSubdiv="20"/>
+    <OglLineAxis size="1"/>
+    <OglSceneFrame/>
+
+    <EulerImplicitSolver/>
+    <CGLinearSolver iterations="3000" tolerance="1e-9" threshold="1e-9"/>
+
+    <Node name="FixedPointNode">
+        <MechanicalObject name="dof" position="0 2 0  1 2 0  2 2 0  3 2 0" showIndices="false" showIndicesScale="0.1"/>
+        <FixedConstraint indices="0 1 2 3"/>
+    </Node>
+
+    <Node name="MassNode">
+        <PointSetTopologyContainer name="container" position="2 1 0  0 1 0  1 1 0  3 1 0"/>
+        <PointSetTopologyModifier name="modifier" />
+        <MechanicalObject name="dof" showIndices="false" showIndicesScale="0.1"/>
+        <UniformMass name="mass" vertexMass="10"/>
+        <TopologicalChangeProcessor useDataInputs="true" pointsToRemove="0 1" timeToRemove="0.2"/>
+    </Node>
+
+    <Node name="merge">
+
+        <MechanicalObject template="Vec3d" name="dofs" showIndices="true" showIndicesScale="0.1" printLog="true"/>
+
+        <SubsetMultiMapping input="@../FixedPointNode/dof @../MassNode/dof" output="@dofs" indexPairs="0 0  0 1  0 2  0 3     1 0  1 1  1 2  1 3" printLog="true"/>
+        <PointSetTopologyContainer name="container" printLog="true"/>
+<!--        <PointSetTopologyModifier name="modifier" printLog="true" />-->
+        <StiffSpringForceField spring="
+            2 4 100 0 1
+            1 6 100 0 1
+            3 7 100 0 1
+            0 5 100 0 1
+            1 4 100 0 1
+            0 6 100 0 1
+        " drawMode="1" printLog="1"/>
+    </Node>
+
+</Node>

--- a/modules/SofaMiscMapping/src/SofaMiscMapping/SubsetMultiMapping.h
+++ b/modules/SofaMiscMapping/src/SofaMiscMapping/SubsetMultiMapping.h
@@ -27,6 +27,7 @@
 #include <sofa/core/behavior/BaseMechanicalState.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 #include <sofa/defaulttype/VecTypes.h>
+#include <sofa/core/topology/TopologySubsetIndices.h>
 
 namespace sofa::component::mapping
 {
@@ -94,9 +95,16 @@ public:
 protected :
 
     SubsetMultiMapping();
-    virtual ~SubsetMultiMapping();
+    ~SubsetMultiMapping() override;
 
     type::vector<linearalgebra::BaseMatrix*> baseMatrices;      ///< Jacobian of the mapping, in a vector
+
+    void initializeTopologyIndices();
+    void initializeMappingMatrices();
+
+    std::map<unsigned, sofa::core::topology::TopologySubsetIndices*> m_topologyIndices; ///< Map a parent id to a list of indices in this parent
+
+    void applyRemovedPoints(const core::topology::PointsRemoved* pointsRemoved, unsigned int parentId, core::topology::BaseMeshTopology* parentTopology);
 
 };
 

--- a/modules/SofaMiscMapping/src/SofaMiscMapping/SubsetMultiMapping.inl
+++ b/modules/SofaMiscMapping/src/SofaMiscMapping/SubsetMultiMapping.inl
@@ -25,6 +25,7 @@
 
 #include <sofa/linearalgebra/EigenSparseMatrix.h>
 #include <sofa/core/MappingHelper.h>
+#include <SofaBaseMechanics/MechanicalObject.h>
 
 namespace sofa::component::mapping
 {
@@ -36,6 +37,13 @@ void SubsetMultiMapping<TIn, TOut>::init()
     const unsigned indexPairSize = indexPairs.getValue().size()/2;
 
     this->toModels[0]->resize( indexPairSize );
+    if (auto* mobject = dynamic_cast<sofa::component::container::MechanicalObject<Out> *>(this->toModels[0]))
+    {
+        if (auto* topology = mobject->getTopology())
+        {
+            topology->setNbPoints(indexPairSize);
+        }
+    }
 
     Inherit::init();
 

--- a/modules/SofaMiscMapping/src/SofaMiscMapping/SubsetMultiMapping.inl
+++ b/modules/SofaMiscMapping/src/SofaMiscMapping/SubsetMultiMapping.inl
@@ -53,8 +53,10 @@ void SubsetMultiMapping<TIn, TOut>::initializeTopologyIndices()
         parents[indexPairsAccessor[i * 2]].push_back(indexPairsAccessor[i * 2 + 1]);
     }
 
-    for (const auto& [parentId, indices] : parents)
+    for (const auto& p : parents)
     {
+        const auto parentId = p.first;
+        const auto& indices = p.second;
         auto* d = new sofa::core::topology::TopologySubsetIndices("Parent #" + std::to_string(parentId) + " indices", true, true);
         d->setName("parent"+std::to_string(parentId));
         this->addData(d);


### PR DESCRIPTION
Based on https://github.com/sofa-framework/sofa/pull/2720

To support points removal in SubsetMultiMapping, `TopologySubsetIndices` have been added. To create them, I had to make available a constructor that does not take a `initData`, therefore I made available all the constructors of `Data`.
A `TopologySubsetIndices` is created for each input of the mapping. They subscribe to the corresponding topology changes.
When a topology change (point removal only) occurs, the mapping propagates the changes to the output Node of the mapping (and also renumbers internal indices).

The application of the topology changes require a `BaseMeshTopology` and a topology modifier in both input and output of the mapping.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
