### PR TITLE
[Sofa.Component.ODESolver] Rewrite tests without SceneCreator

### DIFF
--- a/Component/ODESolver/Backward/tests/CMakeLists.txt
+++ b/Component/ODESolver/Backward/tests/CMakeLists.txt
@@ -16,4 +16,4 @@ add_definitions("-DSOFACOMPONENTODESOLVERBACKWARD_TEST_SCENES_DIR=\"${CMAKE_CURR
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 # dependencies are managed directly in the target_link_libraries pass
-target_link_libraries(${PROJECT_NAME} Sofa.Testing Sofa.Component.ODESolver.Testing Sofa.Component.ODESolver.Backward SofaBaseUtils SofaBaseMechanics SofaDeformable SofaBoundaryCondition SceneCreator)
+target_link_libraries(${PROJECT_NAME} Sofa.Testing Sofa.Component.ODESolver.Testing Sofa.Component.ODESolver.Backward SofaBaseUtils SofaBaseMechanics SofaDeformable SofaBoundaryCondition)

--- a/Component/ODESolver/Backward/tests/EulerImplicitSolverDynamic_test.cpp
+++ b/Component/ODESolver/Backward/tests/EulerImplicitSolverDynamic_test.cpp
@@ -22,7 +22,6 @@
 #include <sofa/testing/BaseSimulationTest.h>
 using sofa::testing::BaseSimulationTest;
 
-#include <sofa/component/odesolver/testing/MassSpringSystemCreation.h>
 #include <sofa/component/odesolver/testing/ODESolverSpringTest.h>
 
 #include <sofa/simulation/Node.h>
@@ -31,10 +30,6 @@ using sofa::testing::BaseSimulationTest;
 
 #include <SofaBaseMechanics/MechanicalObject.h>
 typedef sofa::component::container::MechanicalObject<sofa::defaulttype::Vec3Types> MechanicalObject3;
-
-// Solvers
-#include <SofaImplicitOdeSolver/EulerImplicitSolver.h>
-#include <SofaBaseLinearSolver/CGLinearSolver.h>
 
 #include <sofa/defaulttype/VecTypes.h>
 

--- a/Component/ODESolver/Backward/tests/EulerImplicitSolverDynamic_test.cpp
+++ b/Component/ODESolver/Backward/tests/EulerImplicitSolverDynamic_test.cpp
@@ -22,9 +22,8 @@
 #include <sofa/testing/BaseSimulationTest.h>
 using sofa::testing::BaseSimulationTest;
 
-#include <SceneCreator/SceneCreator.h>
-
 #include <sofa/component/odesolver/testing/MassSpringSystemCreation.h>
+#include <sofa/component/odesolver/testing/ODESolverSpringTest.h>
 
 #include <sofa/simulation/Node.h>
 #include <sofa/simulation/Simulation.h>
@@ -45,7 +44,6 @@ namespace sofa {
 using namespace component;
 using namespace defaulttype;
 using namespace simulation;
-using namespace modeling;
 using type::vector;
 
 /**  Dynamic solver test.
@@ -58,65 +56,24 @@ Then it compares the effective mass position to the computed mass position every
 */
 
 template <typename _DataTypes>
-struct EulerImplicitDynamic_test : public BaseSimulationTest
+struct EulerImplicitDynamic_test : public component::odesolver::testing::ODESolverSpringTest
 {
     typedef _DataTypes DataTypes;
     typedef typename DataTypes::Coord Coord;
 
-    typedef container::MechanicalObject<DataTypes> MechanicalObject;
-    typedef component::odesolver::EulerImplicitSolver EulerImplicitSolver;
-    typedef component::linearsolver::CGLinearSolver<component::linearsolver::GraphScatteredMatrix, component::linearsolver::GraphScatteredVector> CGLinearSolver;
-
-
-    /// Root of the scene graph
-    simulation::Node::SPtr root;      
-    /// Tested simulation
-    simulation::Simulation* simulation;  
     /// Position and velocity array
     vector<double> positionsArray;
     vector<double> velocitiesArray;
 
-    
     /// Create the context for the scene
     void createScene(double K, double m, double l0, double rm = 0, double rk=0)
-    { 
-        // Init simulation
-        sofa::simulation::setSimulation(simulation = new sofa::simulation::graph::DAGSimulation());
-        root = simulation::getSimulation()->createNewGraph("root");
-
-        // Create the scene
-        root->setGravity(Coord(0,-10,0));
-
-        // Solver
-        EulerImplicitSolver::SPtr eulerSolver = addNew<EulerImplicitSolver> (root);
-        eulerSolver->f_rayleighStiffness.setValue(rk);
-        eulerSolver->f_rayleighMass.setValue(rm);
-
-        CGLinearSolver::SPtr cgLinearSolver = addNew<CGLinearSolver>   (root);
-        cgLinearSolver->d_maxIter.setValue(3000);
-        cgLinearSolver->d_tolerance.setValue(1e-9);
-        cgLinearSolver->d_smallDenominatorThreshold.setValue(1e-9);
-
-        // Set initial positions and velocities of fixed point and mass
-        MechanicalObject3::VecCoord xFixed(1);
-        MechanicalObject3::DataTypes::set( xFixed[0], 0., 2.,0.);
-        MechanicalObject3::VecDeriv vFixed(1);
-        MechanicalObject3::DataTypes::set( vFixed[0], 0.,0.,0.);
-        MechanicalObject3::VecCoord xMass(1);
-        MechanicalObject3::DataTypes::set( xMass[0], 0., 1.,0.);
-        MechanicalObject3::VecDeriv vMass(1);
-        MechanicalObject3::DataTypes::set( vFixed[0], 0.,0.,0.);
-
-        // Add mass spring system
-        root =  sofa::createMassSpringSystem<DataTypes>(
-                root,   // add mass spring system to the node containing solver
-                K,      // stiffness
-                m,      // mass
-                l0,     // spring rest length
-                xFixed, // Initial position of fixed point
-                vFixed, // Initial velocity of fixed point
-                xMass,  // Initial position of mass
-                vMass); // Initial velocity of mass
+    {
+        this->prepareScene(K, m, l0);
+        // add ODE Solver to test
+        simpleapi::createObject(m_si.root, "EulerImplicitSolver", {
+            { "rayleighStiffness", simpleapi::str(rk)},
+            { "rayleighMass", simpleapi::str(rm)}
+        });
 
     }
 
@@ -156,12 +113,12 @@ struct EulerImplicitDynamic_test : public BaseSimulationTest
     {
         int i = 0;
         // Init simulation
-        sofa::simulation::getSimulation()->init(root.get());
-        double time = root->getTime();
+        m_si.initScene();
+        double time = m_si.root->getTime();
 
         // Get mechanical object
-        simulation::Node::SPtr massNode = root->getChild("MassNode");
-        typename MechanicalObject::SPtr dofs = massNode->get<MechanicalObject>(root->SearchDown);
+        simulation::Node::SPtr massNode = m_si.root->getChild("MassNode");
+        typename container::MechanicalObject<_DataTypes>::SPtr dofs = massNode->get<container::MechanicalObject<_DataTypes>>(m_si.root->SearchDown);
 
         // Animate
         do
@@ -182,8 +139,8 @@ struct EulerImplicitDynamic_test : public BaseSimulationTest
             }
 
             //Animate
-            sofa::simulation::getSimulation()->animate(root.get(),h);
-            time = root->getTime();
+            m_si.simulate(h);
+            time = m_si.root->getTime();
             // Iterate
             i++;
         }

--- a/Component/ODESolver/Backward/tests/EulerImplicitSolverStatic_test.cpp
+++ b/Component/ODESolver/Backward/tests/EulerImplicitSolverStatic_test.cpp
@@ -26,12 +26,6 @@ using sofa::testing::BaseSimulationTest;
 using sofa::testing::NumericTest;
 
 #include <SofaSimulationGraph/SimpleApi.h>
-#include <SofaImplicitOdeSolver/EulerImplicitSolver.h>
-#include <SofaBaseLinearSolver/CGLinearSolver.h>
-#include <SofaBaseMechanics/UniformMass.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
-#include <SofaBoundaryCondition/FixedConstraint.h>
-#include <SofaDeformable/StiffSpringForceField.h>
 
 #include <sofa/simulation/Simulation.h>
 #include <sofa/component/odesolver/testing/EigenTestUtilities.h>
@@ -44,12 +38,6 @@ using namespace testing;
 using namespace defaulttype;
 using core::objectmodel::New;
 
-using sofa::component::mass::UniformMass;
-using sofa::component::container::MechanicalObject;
-using sofa::component::interactionforcefield::StiffSpringForceField;
-using sofa::component::projectiveconstraintset::FixedConstraint;
-using sofa::component::odesolver::EulerImplicitSolver;
-typedef component::linearsolver::CGLinearSolver<component::linearsolver::GraphScatteredMatrix, component::linearsolver::GraphScatteredVector> CGLinearSolver;
 
 /// Create a stiff string
 Node::SPtr massSpringString(Node::SPtr parent,

--- a/Component/ODESolver/Backward/tests/EulerImplicitSolverStatic_test.cpp
+++ b/Component/ODESolver/Backward/tests/EulerImplicitSolverStatic_test.cpp
@@ -115,11 +115,21 @@ struct EulerImplicit_test_2_particles_to_equilibrium : public BaseSimulationTest
         simulation::Node::SPtr root = simpleapi::createRootNode(simu, "root");
         //*******
         // begin create scene under the root node
+        sofa::simpleapi::importPlugin("Sofa.Component.ODESolver");
+        sofa::simpleapi::importPlugin("SofaBaseLinearSolver");
+        sofa::simpleapi::importPlugin("SofaBaseMechanics");
+        sofa::simpleapi::importPlugin("SofaDeformable");
+        sofa::simpleapi::importPlugin("SofaBoundaryCondition");
+
+        // remove warnings
+        simpleapi::createObject(root, "DefaultAnimationLoop", {});
+        simpleapi::createObject(root, "DefaultVisualManagerLoop", {});
+
         simpleapi::createObject(root, "EulerImplicitSolver", {});
         simpleapi::createObject(root, "CGLinearSolver", {
-            { "maxIter", simpleapi::str(25)},
+            { "iterations", simpleapi::str(25)},
             { "tolerance", simpleapi::str(1e-5)},
-            { "smallDenominatorThreshold", simpleapi::str(1e-5)},
+            { "threshold", simpleapi::str(1e-5)},
         });
 
         simulation::Node::SPtr string = massSpringString (
@@ -131,8 +141,9 @@ struct EulerImplicit_test_2_particles_to_equilibrium : public BaseSimulationTest
                     1000.0, // stiffness
                     0.1     // damping ratio
                     );
-        simpleapi::createObject(root, "FixedConstraint", {
-            { "indices", simpleapi::str(0)}
+
+        simpleapi::createObject(string, "FixedConstraint", {
+            { "indices", "0"}
         });
 
         Vec3d expected(0,-0.00981,0); // expected position of second particle after relaxation
@@ -201,44 +212,53 @@ struct EulerImplicit_test_2_particles_in_different_nodes_to_equilibrium  : publi
         // create scene
         root->setGravity(Vec3(0,0,0));
 
+        sofa::simpleapi::importPlugin("Sofa.Component.ODESolver");
+        sofa::simpleapi::importPlugin("SofaBaseLinearSolver");
+        sofa::simpleapi::importPlugin("SofaBaseMechanics");
+        sofa::simpleapi::importPlugin("SofaDeformable");
+        sofa::simpleapi::importPlugin("SofaBoundaryCondition");
+        // remove warnings
+        simpleapi::createObject(root, "DefaultAnimationLoop", {});
+        simpleapi::createObject(root, "DefaultVisualManagerLoop", {});
+
         simpleapi::createObject(root, "EulerImplicitSolver", {});
         simpleapi::createObject(root, "CGLinearSolver", {
-            { "maxIter", simpleapi::str(25)},
+            { "iterations", simpleapi::str(25)},
             { "tolerance", simpleapi::str(1e-5)},
-            { "smallDenominatorThreshold", simpleapi::str(1e-5)},
+            { "threshold", simpleapi::str(1e-5)},
             });
 
         simpleapi::createObject(root, "MechanicalObject", {
             {"name", "DOF"},
-            {"size", simpleapi::str(1)},
             {"position", simpleapi::str("0.0 2.0 0.0")},
             {"velocity", simpleapi::str("0.0 0.0 0.0")}
         });
 
         simpleapi::createObject(root, "UniformMass", {
             { "name","mass"},
-            { "vertexMass", simpleapi::str("1.0")}
+            { "vertexMass", "1.0"}
         });
 
         // create a child node with its own DOF
         simulation::Node::SPtr child = root->createChild("childNode");
-        simpleapi::createObject(root, "MechanicalObject", {
+        simpleapi::createObject(child, "MechanicalObject", {
             {"name", "childDof"},
-            {"size", simpleapi::str(1)},
             {"position", simpleapi::str("0.0 -1.0 0.0")},
             {"velocity", simpleapi::str("0.0 0.0 0.0")}
         });
 
-        simpleapi::createObject(root, "UniformMass", {
+        simpleapi::createObject(child, "UniformMass", {
             { "name","childMass"},
             { "vertexMass", simpleapi::str("1.0")}
         });
 
         // attach a spring
         std::ostringstream oss;
-        oss << 0 << 0 << 1000.0 << 0.1 << 1.0f;
+        oss << 0 << " " << 0 << " " << 1000.0 << " " << 0.1 << " " << 1.0f;
         simpleapi::createObject(root, "StiffSpringForceField", {
-            {"spring", oss.str()}
+            {"spring", oss.str()},
+            { "object1", "@/DOF"},
+            { "object2", "@childNode/childDof"},
         });
 
         Vec3d expected(0,0,0); // expected position of second particle after relaxation

--- a/Component/ODESolver/Backward/tests/NewmarkImplicitSolverDynamic_test.cpp
+++ b/Component/ODESolver/Backward/tests/NewmarkImplicitSolverDynamic_test.cpp
@@ -25,8 +25,7 @@ using sofa::testing::BaseSimulationTest;
 using sofa::testing::NumericTest;
 
 #include <sofa/component/odesolver/testing/MassSpringSystemCreation.h>
-
-#include <SceneCreator/SceneCreator.h>
+#include <sofa/component/odesolver/testing/ODESolverSpringTest.h>
 
 //Including Simulation
 #include <sofa/simulation/Simulation.h>
@@ -48,7 +47,6 @@ namespace sofa {
 using namespace component;
 using namespace defaulttype;
 using namespace simulation;
-using namespace modeling;
 using type::vector;
 
 /**  Dynamic solver test.
@@ -61,20 +59,13 @@ Then it compares the effective mass position to the computed mass position every
 */
 
 template <typename _DataTypes>
-struct NewmarkImplicitDynamic_test : public BaseSimulationTest
+struct NewmarkImplicitDynamic_test : public component::odesolver::testing::ODESolverSpringTest
 {
     typedef _DataTypes DataTypes;
     typedef typename DataTypes::Coord Coord;
 
     typedef container::MechanicalObject<DataTypes> MechanicalObject;
-    typedef component::odesolver::NewmarkImplicitSolver NewmarkImplicitSolver;
-    typedef component::linearsolver::CGLinearSolver<component::linearsolver::GraphScatteredMatrix, component::linearsolver::GraphScatteredVector> CGLinearSolver;
 
-
-    /// Root of the scene graph
-    simulation::Node::SPtr root;      
-    /// Tested simulation
-    simulation::Simulation* simulation;  
     /// Position and velocity array
     vector<double> positionsArray;
     vector<double> velocitiesArray;
@@ -83,43 +74,12 @@ struct NewmarkImplicitDynamic_test : public BaseSimulationTest
     /// Create the context for the scene
     void createScene(double K, double m, double l0, double rm=0, double rk=0)
     {
-        // Init simulation
-        sofa::simulation::setSimulation(simulation = new sofa::simulation::graph::DAGSimulation());
-        root = simulation::getSimulation()->createNewGraph("root");
-
-        // Create the scene
-        root->setGravity(Coord(0,-10,0));
-
-        // Solver
-        NewmarkImplicitSolver::SPtr newmarkSolver = addNew<NewmarkImplicitSolver> (root);
-        newmarkSolver->d_rayleighStiffness.setValue(rk);
-        newmarkSolver->d_rayleighMass.setValue(rm);
-
-        CGLinearSolver::SPtr cgLinearSolver = addNew<CGLinearSolver> (root);
-        cgLinearSolver->d_maxIter.setValue(3000);
-        cgLinearSolver->d_tolerance.setValue(1e-9);
-        cgLinearSolver->d_smallDenominatorThreshold.setValue(1e-9);
-
-        // Set initial positions and velocities of fixed point and mass
-        MechanicalObject3::VecCoord xFixed(1);
-        MechanicalObject3::DataTypes::set( xFixed[0], 0., 2.,0.);
-        MechanicalObject3::VecDeriv vFixed(1);
-        MechanicalObject3::DataTypes::set( vFixed[0], 0.,0.,0.);
-        MechanicalObject3::VecCoord xMass(1);
-        MechanicalObject3::DataTypes::set( xMass[0], 0., 1.,0.);
-        MechanicalObject3::VecDeriv vMass(1);
-        MechanicalObject3::DataTypes::set( vFixed[0], 0.,0.,0.);
-
-        // Mass spring system
-        root = sofa::createMassSpringSystem<DataTypes>(
-                root,   // add mass spring system to the node containing solver
-                K,      // stiffness
-                m,      // mass
-                l0,     // spring rest length
-                xFixed, // Initial position of fixed point
-                vFixed, // Initial velocity of fixed point
-                xMass,  // Initial position of mass
-                vMass); // Initial velocity of mass
+        this->prepareScene(K, m, l0);
+        // add ODE Solver to test
+        simpleapi::createObject(m_si.root, "NewmarkImplicitSolver", {
+            { "rayleighStiffness", simpleapi::str(rk)},
+            { "rayleighMass", simpleapi::str(rm)}
+            });
     }
 
 
@@ -167,12 +127,12 @@ struct NewmarkImplicitDynamic_test : public BaseSimulationTest
     {
         int i = 0;
         // Init simulation
-        sofa::simulation::getSimulation()->init(root.get());
-        double time = root->getTime();
+        m_si.initScene();
+        double time = m_si.root->getTime();
 
         // Get mechanical object
-        simulation::Node::SPtr massNode = root->getChild("MassNode");
-        typename MechanicalObject::SPtr dofs = massNode->get<MechanicalObject>(root->SearchDown);
+        simulation::Node::SPtr massNode = m_si.root->getChild("MassNode");
+        typename MechanicalObject::SPtr dofs = massNode->get<MechanicalObject>(m_si.root->SearchDown);
 
         // Animate
         do
@@ -193,8 +153,8 @@ struct NewmarkImplicitDynamic_test : public BaseSimulationTest
             }
 
             //Animate
-            sofa::simulation::getSimulation()->animate(root.get(),h);
-            time = root->getTime();
+            m_si.simulate(h);
+            time = m_si.root->getTime();
             // Iterate
             i++;
         }

--- a/Component/ODESolver/Backward/tests/NewmarkImplicitSolverDynamic_test.cpp
+++ b/Component/ODESolver/Backward/tests/NewmarkImplicitSolverDynamic_test.cpp
@@ -24,7 +24,6 @@ using sofa::testing::BaseSimulationTest;
 #include <sofa/testing/NumericTest.h>
 using sofa::testing::NumericTest;
 
-#include <sofa/component/odesolver/testing/MassSpringSystemCreation.h>
 #include <sofa/component/odesolver/testing/ODESolverSpringTest.h>
 
 //Including Simulation
@@ -35,10 +34,6 @@ using sofa::testing::NumericTest;
 // Including mechanical object
 #include <SofaBaseMechanics/MechanicalObject.h>
 using MechanicalObject3 = sofa::component::container::MechanicalObject<sofa::defaulttype::Vec3Types> ;
-
-// Solvers
-#include <SofaMiscSolver/NewmarkImplicitSolver.h>
-#include <SofaBaseLinearSolver/CGLinearSolver.h>
 
 #include <sofa/defaulttype/VecTypes.h>
 

--- a/Component/ODESolver/Backward/tests/VariationalSymplecticExplicitSolverDynamic_test.cpp
+++ b/Component/ODESolver/Backward/tests/VariationalSymplecticExplicitSolverDynamic_test.cpp
@@ -21,10 +21,7 @@
 ******************************************************************************/
 #include <sofa/testing/BaseSimulationTest.h>
 using sofa::testing::BaseSimulationTest;
-#include <sofa/testing/NumericTest.h>
-using sofa::testing::NumericTest;
 
-#include <sofa/component/odesolver/testing/MassSpringSystemCreation.h>
 #include <sofa/component/odesolver/testing/ODESolverSpringTest.h>
 
 //Including Simulation
@@ -35,10 +32,6 @@ using sofa::testing::NumericTest;
 // Including mechanical object
 #include <SofaBaseMechanics/MechanicalObject.h>
 using MechanicalObject3 = sofa::component::container::MechanicalObject<sofa::defaulttype::Vec3Types> ;
-
-// Solvers
-#include <SofaGeneralImplicitOdeSolver/VariationalSymplecticSolver.h>
-#include <SofaBaseLinearSolver/CGLinearSolver.h>
 
 #include <sofa/defaulttype/VecTypes.h>
 

--- a/Component/ODESolver/Backward/tests/VariationalSymplecticExplicitSolverDynamic_test.cpp
+++ b/Component/ODESolver/Backward/tests/VariationalSymplecticExplicitSolverDynamic_test.cpp
@@ -25,8 +25,7 @@ using sofa::testing::BaseSimulationTest;
 using sofa::testing::NumericTest;
 
 #include <sofa/component/odesolver/testing/MassSpringSystemCreation.h>
-
-#include <SceneCreator/SceneCreator.h>
+#include <sofa/component/odesolver/testing/ODESolverSpringTest.h>
 
 //Including Simulation
 #include <sofa/simulation/Simulation.h>
@@ -48,7 +47,6 @@ namespace sofa {
 using namespace component;
 using namespace defaulttype;
 using namespace simulation;
-using namespace modeling;
 
 /**  Dynamic solver test.
 Test the dynamic behavior of solver: study a mass-spring system under gravity initialize with spring rest length it will oscillate around its equilibrium position if there is no damping.
@@ -60,21 +58,14 @@ Then it compares the effective mass position to the computed mass position every
 */
 
 template <typename _DataTypes>
-struct VariationalSymplecticExplicitSolverDynamic_test : public BaseSimulationTest
+struct VariationalSymplecticExplicitSolverDynamic_test : public component::odesolver::testing::ODESolverSpringTest
 {
     typedef _DataTypes DataTypes;
     typedef typename DataTypes::Coord Coord;
     typedef typename DataTypes::Real Real;
 
     typedef container::MechanicalObject<DataTypes> MechanicalObject;
-    typedef component::odesolver::VariationalSymplecticSolver VariationalSymplecticSolver;
-    typedef component::linearsolver::CGLinearSolver<component::linearsolver::GraphScatteredMatrix, component::linearsolver::GraphScatteredVector> CGLinearSolver;
 
-
-    /// Root of the scene graph
-    simulation::Node::SPtr root;      
-    /// Tested simulation
-    simulation::Simulation* simulation;  
     /// Position and velocity array
     type::vector<Real> positionsArray;
     type::vector<Real> velocitiesArray;
@@ -83,44 +74,12 @@ struct VariationalSymplecticExplicitSolverDynamic_test : public BaseSimulationTe
     /// Create the context for the scene
     void createScene(double K, double m, double l0, double rm=0)
     {
-        // Init simulation
-        sofa::simulation::setSimulation(simulation = new sofa::simulation::graph::DAGSimulation());
-        root = simulation::getSimulation()->createNewGraph("root");
-
-        // Create the scene
-        root->setGravity(Coord(0,-10,0));
-
-        // Solver
-        VariationalSymplecticSolver::SPtr variationalSolver = addNew<VariationalSymplecticSolver> (root);
-        // Explicit solver
-        variationalSolver->f_explicit.setValue("true");
-        variationalSolver->f_rayleighMass.setValue(rm);
-
-        CGLinearSolver::SPtr cgLinearSolver = addNew<CGLinearSolver> (root);
-        cgLinearSolver->d_maxIter.setValue(3000);
-        cgLinearSolver->d_tolerance.setValue(1e-9);
-        cgLinearSolver->d_smallDenominatorThreshold.setValue(1e-9);
-
-        // Set initial positions and velocities of fixed point and mass
-        MechanicalObject3::VecCoord xFixed(1);
-        MechanicalObject3::DataTypes::set( xFixed[0], 0., 2.,0.);
-        MechanicalObject3::VecDeriv vFixed(1);
-        MechanicalObject3::DataTypes::set( vFixed[0], 0.,0.,0.);
-        MechanicalObject3::VecCoord xMass(1);
-        MechanicalObject3::DataTypes::set( xMass[0], 0., 1.,0.);
-        MechanicalObject3::VecDeriv vMass(1);
-        MechanicalObject3::DataTypes::set( vFixed[0], 0.,0.,0.);
-
-        // Mass spring system
-        root = sofa::createMassSpringSystem<DataTypes>(
-                root,   // add mass spring system to the node containing solver
-                K,      // stiffness
-                m,      // mass
-                l0,     // spring rest length
-                xFixed, // Initial position of fixed point
-                vFixed, // Initial velocity of fixed point
-                xMass,  // Initial position of mass
-                vMass); // Initial velocity of mass
+        this->prepareScene(K, m, l0);
+        // add ODE Solver to test
+        simpleapi::createObject(m_si.root, "VariationalSymplecticSolver", {
+            { "explicit", simpleapi::str(true)},
+            { "rayleighMass", simpleapi::str(rm)}
+            });
 
     }
 
@@ -162,12 +121,12 @@ struct VariationalSymplecticExplicitSolverDynamic_test : public BaseSimulationTe
     {
         int i = 0;
         // Init simulation
-        sofa::simulation::getSimulation()->init(root.get());
-        double time = root->getTime();
+        m_si.initScene();
+        double time = m_si.root->getTime();
 
         // Get mechanical object
-        simulation::Node::SPtr massNode = root->getChild("MassNode");
-        typename MechanicalObject::SPtr dofs = massNode->get<MechanicalObject>(root->SearchDown);
+        simulation::Node::SPtr massNode = m_si.root->getChild("MassNode");
+        typename MechanicalObject::SPtr dofs = massNode->get<MechanicalObject>(m_si.root->SearchDown);
 
         // Animate
         do
@@ -188,8 +147,8 @@ struct VariationalSymplecticExplicitSolverDynamic_test : public BaseSimulationTe
             }
 
             //Animate
-            sofa::simulation::getSimulation()->animate(root.get(),h);
-            time = root->getTime();
+            m_si.simulate(h);
+            time = m_si.root->getTime();
             // Iterate
             i++;
         }

--- a/Component/ODESolver/Backward/tests/VariationalSymplecticExplicitSolverDynamic_test.cpp
+++ b/Component/ODESolver/Backward/tests/VariationalSymplecticExplicitSolverDynamic_test.cpp
@@ -77,9 +77,9 @@ struct VariationalSymplecticExplicitSolverDynamic_test : public component::odeso
         this->prepareScene(K, m, l0);
         // add ODE Solver to test
         simpleapi::createObject(m_si.root, "VariationalSymplecticSolver", {
-            { "explicit", simpleapi::str(true)},
+            { "explicitIntegration", simpleapi::str(true)},
             { "rayleighMass", simpleapi::str(rm)}
-            });
+        });
 
     }
 
@@ -126,7 +126,7 @@ struct VariationalSymplecticExplicitSolverDynamic_test : public component::odeso
 
         // Get mechanical object
         simulation::Node::SPtr massNode = m_si.root->getChild("MassNode");
-        typename MechanicalObject::SPtr dofs = massNode->get<MechanicalObject>(m_si.root->SearchDown);
+        typename container::MechanicalObject<_DataTypes>::SPtr dofs = massNode->get<container::MechanicalObject<_DataTypes>>(m_si.root->SearchDown);
 
         // Animate
         do

--- a/Component/ODESolver/Backward/tests/VariationalSymplecticImplicitSolverDynamic_test.cpp
+++ b/Component/ODESolver/Backward/tests/VariationalSymplecticImplicitSolverDynamic_test.cpp
@@ -26,8 +26,7 @@ using sofa::testing::BaseSimulationTest;
 using sofa::testing::NumericTest;
 
 #include <sofa/component/odesolver/testing/MassSpringSystemCreation.h>
-
-#include <SceneCreator/SceneCreator.h>
+#include <sofa/component/odesolver/testing/ODESolverSpringTest.h>
 
 //Including Simulation
 #include <sofa/simulation/Simulation.h>
@@ -49,7 +48,6 @@ namespace sofa {
 using namespace component;
 using namespace defaulttype;
 using namespace simulation;
-using namespace modeling;
 
 /**  Dynamic solver test.
 Test the dynamic behavior of solver: study a mass-spring system under gravity initialize with spring rest length it will oscillate around its equilibrium position if there is no damping.
@@ -61,25 +59,18 @@ Then it compares the effective mass position to the computed mass position every
 */
 
 template <typename _DataTypes>
-struct VariationalSymplecticImplicitSolverDynamic_test : public BaseSimulationTest
+struct VariationalSymplecticImplicitSolverDynamic_test : public component::odesolver::testing::ODESolverSpringTest
 {
     typedef _DataTypes DataTypes;
     typedef typename DataTypes::Coord Coord;
 
     typedef container::MechanicalObject<DataTypes> MechanicalObject;
     typedef component::odesolver::VariationalSymplecticSolver VariationalSymplecticSolver;
-    typedef component::linearsolver::CGLinearSolver<component::linearsolver::GraphScatteredMatrix, component::linearsolver::GraphScatteredVector> CGLinearSolver;
 
-    /// Root of the scene graph
-    simulation::Node::SPtr root;      
-    /// Tested simulation
-    simulation::Simulation* simulation;  
     /// Position and velocity array
     type::vector<double> positionsArray;
     type::vector<double> velocitiesArray;
     type::vector<double> energiesArray;
-    // solver
-    VariationalSymplecticSolver::SPtr variationalSolver;
 
     // totalEnergy
     double totalEnergy;
@@ -87,46 +78,16 @@ struct VariationalSymplecticImplicitSolverDynamic_test : public BaseSimulationTe
     /// Create the context for the scene
     void createScene(double K, double m, double l0, double rm=0, double rk=0)
     {
-        // Init simulation
-        sofa::simulation::setSimulation(simulation = new sofa::simulation::graph::DAGSimulation());
-        root = simulation::getSimulation()->createNewGraph("root");
+        this->prepareScene(K, m, l0);
 
-        // Create the scene
-        root->setGravity(Coord(0,-10,0));
-
-        // Solver
-        variationalSolver = addNew<VariationalSymplecticSolver> (root);
-        variationalSolver->f_rayleighStiffness.setValue(rk);
-        variationalSolver->f_rayleighMass.setValue(rm);
-        variationalSolver->f_computeHamiltonian.setValue(1);
-        variationalSolver->f_newtonError.setValue(1e-12);//1e-18
-        variationalSolver->f_newtonSteps.setValue(4);//7
-
-        CGLinearSolver::SPtr cgLinearSolver = addNew<CGLinearSolver> (root);
-        cgLinearSolver->d_maxIter.setValue(3000);
-        cgLinearSolver->d_tolerance.setValue(1e-12);
-        cgLinearSolver->d_smallDenominatorThreshold.setValue(1e-12);
-
-        // Set initial positions and velocities of fixed point and mass
-        MechanicalObject3::VecCoord xFixed(1);
-        MechanicalObject3::DataTypes::set( xFixed[0], 0., 2.,0.);
-        MechanicalObject3::VecDeriv vFixed(1);
-        MechanicalObject3::DataTypes::set( vFixed[0], 0.,0.,0.);
-        MechanicalObject3::VecCoord xMass(1);
-        MechanicalObject3::DataTypes::set( xMass[0], 0., 1.,0.);
-        MechanicalObject3::VecDeriv vMass(1);
-        MechanicalObject3::DataTypes::set( vMass[0], 0., 0., 0.);
-
-        // Mass spring system
-        root = sofa::createMassSpringSystem<DataTypes>(
-                root,   // add mass spring system to the node containing solver
-                K,      // stiffness
-                m,      // mass
-                l0,     // spring rest length
-                xFixed, // Initial position of fixed point
-                vFixed, // Initial velocity of fixed point
-                xMass,  // Initial position of mass
-                vMass); // Initial velocity of mass
+        // add ODE Solver to test
+        simpleapi::createObject(m_si.root, "VariationalSymplecticSolver", {
+            { "rayleighStiffness", simpleapi::str(rk)},
+            { "rayleighMass", simpleapi::str(rm)},
+            { "computeHamiltonian", simpleapi::str(true)},
+            { "newtonError", simpleapi::str(1e-12)},
+            { "newtonSteps", simpleapi::str(4)}
+            });
     }
 
 
@@ -171,16 +132,18 @@ struct VariationalSymplecticImplicitSolverDynamic_test : public BaseSimulationTe
     }
 
     /// After simulation compare the positions of points to the theoretical positions.
-    bool compareSimulatedToTheoreticalPositions( double h, double tolerancePosition, double toleranceEnergy = 1e-13, double checkEnergyConservation=false)
+    bool compareSimulatedToTheoreticalPositions( double h, double tolerancePosition, double toleranceEnergy = 1e-13, bool checkEnergyConservation=false)
     {
         int i = 0;
         // Init simulation
-        sofa::simulation::getSimulation()->init(root.get());
-        double time = root->getTime();
+        m_si.initScene();
+        double time = m_si.root->getTime();
 
         // Get mechanical object
-        simulation::Node::SPtr massNode = root->getChild("MassNode");
-        typename MechanicalObject::SPtr dofs = massNode->get<MechanicalObject>(root->SearchDown);
+        simulation::Node::SPtr massNode = m_si.root->getChild("MassNode");
+        typename MechanicalObject::SPtr dofs = massNode->get<MechanicalObject>(m_si.root->SearchDown);
+        typename VariationalSymplecticSolver::SPtr variationalSolver = massNode->get<VariationalSymplecticSolver>(m_si.root->SearchDown);
+        
 
         // Animate
         do
@@ -201,8 +164,8 @@ struct VariationalSymplecticImplicitSolverDynamic_test : public BaseSimulationTe
             }
 
             //Animate
-            sofa::simulation::getSimulation()->animate(root.get(),h);
-            time = root->getTime();
+            m_si.simulate(h);
+            time = m_si.root->getTime();
 
 
             // Check if hamiltonian energy is constant when there is no damping

--- a/Component/ODESolver/Backward/tests/VariationalSymplecticImplicitSolverDynamic_test.cpp
+++ b/Component/ODESolver/Backward/tests/VariationalSymplecticImplicitSolverDynamic_test.cpp
@@ -25,7 +25,6 @@ using sofa::testing::BaseSimulationTest;
 #include <sofa/testing/NumericTest.h>
 using sofa::testing::NumericTest;
 
-#include <sofa/component/odesolver/testing/MassSpringSystemCreation.h>
 #include <sofa/component/odesolver/testing/ODESolverSpringTest.h>
 
 //Including Simulation
@@ -39,7 +38,6 @@ using MechanicalObject3 = sofa::component::container::MechanicalObject<sofa::def
 
 // Solvers
 #include <SofaGeneralImplicitOdeSolver/VariationalSymplecticSolver.h>
-#include <SofaBaseLinearSolver/CGLinearSolver.h>
 
 #include <sofa/defaulttype/VecTypes.h>
 

--- a/Component/ODESolver/Backward/tests/VariationalSymplecticImplicitSolverDynamic_test.cpp
+++ b/Component/ODESolver/Backward/tests/VariationalSymplecticImplicitSolverDynamic_test.cpp
@@ -84,7 +84,7 @@ struct VariationalSymplecticImplicitSolverDynamic_test : public component::odeso
         simpleapi::createObject(m_si.root, "VariationalSymplecticSolver", {
             { "rayleighStiffness", simpleapi::str(rk)},
             { "rayleighMass", simpleapi::str(rm)},
-            { "computeHamiltonian", simpleapi::str(true)},
+            { "computeHamiltonian", "1"},
             { "newtonError", simpleapi::str(1e-12)},
             { "newtonSteps", simpleapi::str(4)}
             });
@@ -141,8 +141,8 @@ struct VariationalSymplecticImplicitSolverDynamic_test : public component::odeso
 
         // Get mechanical object
         simulation::Node::SPtr massNode = m_si.root->getChild("MassNode");
-        typename MechanicalObject::SPtr dofs = massNode->get<MechanicalObject>(m_si.root->SearchDown);
-        typename VariationalSymplecticSolver::SPtr variationalSolver = massNode->get<VariationalSymplecticSolver>(m_si.root->SearchDown);
+        typename container::MechanicalObject<_DataTypes>::SPtr dofs = massNode->get<container::MechanicalObject<_DataTypes>>(m_si.root->SearchDown);
+        typename VariationalSymplecticSolver::SPtr variationalSolver = m_si.root->get<VariationalSymplecticSolver>(m_si.root->SearchDown);
         
 
         // Animate

--- a/Component/ODESolver/Forward/tests/CMakeLists.txt
+++ b/Component/ODESolver/Forward/tests/CMakeLists.txt
@@ -11,4 +11,4 @@ set(SOURCE_FILES
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 # dependencies are managed directly in the target_link_libraries pass
-target_link_libraries(${PROJECT_NAME} Sofa.Testing Sofa.Component.ODESolver.Testing Sofa.Component.ODESolver.Forward SofaBaseUtils SofaBaseMechanics SofaDeformable SofaBoundaryCondition SceneCreator)
+target_link_libraries(${PROJECT_NAME} Sofa.Testing Sofa.Component.ODESolver.Testing Sofa.Component.ODESolver.Forward SofaBaseUtils SofaBaseMechanics SofaDeformable SofaBoundaryCondition)

--- a/Component/ODESolver/Forward/tests/CentralDifferenceExplicitSolverDynamic_test.cpp
+++ b/Component/ODESolver/Forward/tests/CentralDifferenceExplicitSolverDynamic_test.cpp
@@ -21,8 +21,6 @@
 ******************************************************************************/
 #include <sofa/testing/BaseSimulationTest.h>
 using sofa::testing::BaseSimulationTest;
-#include <sofa/testing/NumericTest.h>
-using sofa::testing::NumericTest;
 
 #include <sofa/component/odesolver/testing/ODESolverSpringTest.h>
 
@@ -31,12 +29,8 @@ using sofa::testing::NumericTest;
 #include <SofaSimulationGraph/DAGSimulation.h>
 #include <sofa/simulation/Node.h>
 
-// Including mechanical object
 #include <SofaBaseMechanics/MechanicalObject.h>
-using MechanicalObject3 = sofa::component::container::MechanicalObject<sofa::defaulttype::Vec3Types> ;
-
-// Solvers
-#include <SofaGeneralExplicitOdeSolver/CentralDifferenceSolver.h>
+using MechanicalObject3 = sofa::component::container::MechanicalObject<sofa::defaulttype::Vec3Types>;
 
 namespace sofa {
 
@@ -61,7 +55,6 @@ struct CentralDifferenceExplicitSolverDynamic_test : public component::odesolver
     typedef typename DataTypes::Coord Coord;
 
     typedef container::MechanicalObject<DataTypes> MechanicalObject;
-    typedef component::odesolver::CentralDifferenceSolver CentralDifferenceSolver;
 
     /// Position, velocity and acceleration array
     vector<double> positionsArray;

--- a/Component/ODESolver/Forward/tests/CentralDifferenceExplicitSolverDynamic_test.cpp
+++ b/Component/ODESolver/Forward/tests/CentralDifferenceExplicitSolverDynamic_test.cpp
@@ -24,11 +24,7 @@ using sofa::testing::BaseSimulationTest;
 #include <sofa/testing/NumericTest.h>
 using sofa::testing::NumericTest;
 
-#include <sofa/component/odesolver/testing/MassSpringSystemCreation.h>
-
-#include <SceneCreator/SceneCreator.h>
-
-
+#include <sofa/component/odesolver/testing/ODESolverSpringTest.h>
 
 //Including Simulation
 #include <sofa/simulation/Simulation.h>
@@ -47,7 +43,6 @@ namespace sofa {
 using namespace component;
 using namespace defaulttype;
 using namespace simulation;
-using namespace modeling;
 using type::vector;
 
 /**  Dynamic solver test.
@@ -60,7 +55,7 @@ Then it compares the effective mass position to the computed mass position every
 */
 
 template <typename _DataTypes>
-struct CentralDifferenceExplicitSolverDynamic_test : public BaseSimulationTest
+struct CentralDifferenceExplicitSolverDynamic_test : public component::odesolver::testing::ODESolverSpringTest
 {
     typedef _DataTypes DataTypes;
     typedef typename DataTypes::Coord Coord;
@@ -68,10 +63,6 @@ struct CentralDifferenceExplicitSolverDynamic_test : public BaseSimulationTest
     typedef container::MechanicalObject<DataTypes> MechanicalObject;
     typedef component::odesolver::CentralDifferenceSolver CentralDifferenceSolver;
 
-    /// Root of the scene graph
-    simulation::Node::SPtr root;      
-    /// Tested simulation
-    simulation::Simulation* simulation;  
     /// Position, velocity and acceleration array
     vector<double> positionsArray;
     vector<double> velocitiesArray;
@@ -80,37 +71,11 @@ struct CentralDifferenceExplicitSolverDynamic_test : public BaseSimulationTest
     /// Create the context for the scene
     void createScene(double K, double m, double l0,double rm)
     {
-        // Init simulation
-        sofa::simulation::setSimulation(simulation = new sofa::simulation::graph::DAGSimulation());
-        root = simulation::getSimulation()->createNewGraph("root");
-
-        // Create the scene
-        root->setGravity(Coord(0,-10,0));
-
-        // Solver
-        CentralDifferenceSolver::SPtr centralDifferenceSolver = addNew<CentralDifferenceSolver> (root);
-        centralDifferenceSolver->f_rayleighMass.setValue(double(rm));
-
-        // Set initial positions and velocities of fixed point and mass
-        MechanicalObject3::VecCoord xFixed(1);
-        MechanicalObject3::DataTypes::set( xFixed[0], 0., 2.,0.);
-        MechanicalObject3::VecDeriv vFixed(1);
-        MechanicalObject3::DataTypes::set( vFixed[0], 0.,0.,0.);
-        MechanicalObject3::VecCoord xMass(1);
-        MechanicalObject3::DataTypes::set( xMass[0], 0., 1.,0.);
-        MechanicalObject3::VecDeriv vMass(1);
-        MechanicalObject3::DataTypes::set( vMass[0], 0., 0., 0.);
-
-        // Mass spring system
-        root = sofa::createMassSpringSystem<DataTypes>(
-                root,   // add mass spring system to the node containing solver
-                K,      // stiffness
-                m,      // mass
-                l0,     // spring rest length
-                xFixed, // Initial position of fixed point
-                vFixed, // Initial velocity of fixed point
-                xMass,  // Initial position of mass
-                vMass); // Initial velocity of mass
+        this->prepareScene(K, m, l0);
+        // add ODE Solver to test
+        simpleapi::createObject(m_si.root, "CentralDifferenceSolver", {
+            { "rayleighMass", simpleapi::str(rm)}
+            });
     }
 
 
@@ -183,12 +148,12 @@ struct CentralDifferenceExplicitSolverDynamic_test : public BaseSimulationTest
     {
         int i = 0;
         // Init simulation
-        sofa::simulation::getSimulation()->init(root.get());
-        double time = root->getTime();
+        m_si.initScene();
+        double time = m_si.root->getTime();
 
         // Get mechanical object
-        simulation::Node::SPtr massNode = root->getChild("MassNode");
-        typename MechanicalObject::SPtr dofs = massNode->get<MechanicalObject>(root->SearchDown);
+        simulation::Node::SPtr massNode = m_si.root->getChild("MassNode");
+        typename MechanicalObject::SPtr dofs = massNode->get<MechanicalObject>(m_si.root->SearchDown);
 
         // Animate
         do
@@ -209,8 +174,8 @@ struct CentralDifferenceExplicitSolverDynamic_test : public BaseSimulationTest
             }
 
             //Animate
-            sofa::simulation::getSimulation()->animate(root.get(),h);
-            time = root->getTime();
+            m_si.simulate(h);
+            time = m_si.root->getTime();
             // Iterate
             i++;
         }

--- a/Component/ODESolver/Forward/tests/EulerExplicitSolverDynamic_test.cpp
+++ b/Component/ODESolver/Forward/tests/EulerExplicitSolverDynamic_test.cpp
@@ -22,7 +22,7 @@
 #include <sofa/testing/BaseSimulationTest.h>
 using sofa::testing::BaseSimulationTest;
 
-#include <SceneCreator/SceneCreator.h>
+#include <sofa/component/odesolver/testing/ODESolverSpringTest.h>
 
 //Including Simulation
 #include <sofa/simulation/Simulation.h>
@@ -38,14 +38,11 @@ typedef sofa::component::container::MechanicalObject<sofa::defaulttype::Vec3Type
 
 #include <sofa/defaulttype/VecTypes.h>
 
-#include <sofa/component/odesolver/testing/MassSpringSystemCreation.h>
-
 namespace sofa {
 
 using namespace component;
 using namespace defaulttype;
 using namespace simulation;
-using namespace modeling;
 using type::vector;
 
 /**  Dynamic solver test.
@@ -58,7 +55,7 @@ Then it compares the effective mass position to the computed mass position every
 */
 
 template <typename _DataTypes>
-struct EulerExplicitDynamic_test : public BaseSimulationTest
+struct EulerExplicitDynamic_test : public component::odesolver::testing::ODESolverSpringTest
 {
     typedef _DataTypes DataTypes;
     typedef typename DataTypes::Coord Coord;
@@ -66,10 +63,6 @@ struct EulerExplicitDynamic_test : public BaseSimulationTest
     typedef container::MechanicalObject<DataTypes> MechanicalObject;
     typedef component::odesolver::EulerExplicitSolver EulerExplicitSolver;
 
-    /// Root of the scene graph
-    simulation::Node::SPtr root;      
-    /// Tested simulation
-    simulation::Simulation* simulation;  
     /// Position and velocity array
     vector<double> positionsArray;
     vector<double> velocitiesArray;
@@ -78,37 +71,11 @@ struct EulerExplicitDynamic_test : public BaseSimulationTest
     /// Create the context for the scene
     void createScene(double K, double m, double l0)
     { 
-        // Init simulation
-        sofa::simulation::setSimulation(simulation = new sofa::simulation::graph::DAGSimulation());
-        root = simulation::getSimulation()->createNewGraph("root");
-
-        // Create the scene
-        root->setGravity(Coord(0,-10,0));
-
-        // Solver
-        EulerExplicitSolver::SPtr eulerExplicitSolver = addNew<EulerExplicitSolver> (root);
-
-        // Set initial positions and velocities of fixed point and mass
-        MechanicalObject3::VecCoord xFixed(1);
-        MechanicalObject3::DataTypes::set( xFixed[0], 0., 2.,0.);
-        MechanicalObject3::VecDeriv vFixed(1);
-        MechanicalObject3::DataTypes::set( vFixed[0], 0.,0.,0.);
-        MechanicalObject3::VecCoord xMass(1);
-        MechanicalObject3::DataTypes::set( xMass[0], 0., 1.,0.);
-        MechanicalObject3::VecDeriv vMass(1);
-        MechanicalObject3::DataTypes::set( vFixed[0], 0.,0.,0.);
-
-        // Mass spring system
-        root = sofa::createMassSpringSystem<DataTypes>(
-                root,   // add mass spring system to the node containing solver
-                K,      // stiffness
-                m,      // mass
-                l0,     // spring rest length
-                xFixed, // Initial position of fixed point
-                vFixed, // Initial velocity of fixed point
-                xMass,  // Initial position of mass
-                vMass); // Initial velocity of mass
-
+        this->prepareScene(K, m, l0);
+        // add ODE Solver to test
+        simpleapi::createObject(m_si.root, "EulerExplicitSolver", {
+            { }
+        });
     }
 
     /// Generate discrete mass position values with euler explicit solver
@@ -144,12 +111,12 @@ struct EulerExplicitDynamic_test : public BaseSimulationTest
     {
         int i = 0;
         // Init simulation
-        sofa::simulation::getSimulation()->init(root.get());
-        double time = root->getTime();
+        m_si.initScene();
+        double time = m_si.root->getTime();
 
         // Get mechanical object
-        simulation::Node::SPtr massNode = root->getChild("MassNode");
-        typename MechanicalObject::SPtr dofs = massNode->get<MechanicalObject>(root->SearchDown);
+        simulation::Node::SPtr massNode = m_si.root->getChild("MassNode");
+        typename MechanicalObject::SPtr dofs = massNode->get<MechanicalObject>(m_si.root->SearchDown);
 
         // Animate
         do
@@ -170,8 +137,8 @@ struct EulerExplicitDynamic_test : public BaseSimulationTest
             }
 
             //Animate
-            sofa::simulation::getSimulation()->animate(root.get(),h);
-            time = root->getTime();
+            m_si.simulate(h);
+            time = m_si.root->getTime();
 
             // Iterate
             i++;

--- a/Component/ODESolver/Forward/tests/EulerExplicitSolverDynamic_test.cpp
+++ b/Component/ODESolver/Forward/tests/EulerExplicitSolverDynamic_test.cpp
@@ -33,9 +33,6 @@ using sofa::testing::BaseSimulationTest;
 #include <SofaBaseMechanics/MechanicalObject.h>
 typedef sofa::component::container::MechanicalObject<sofa::defaulttype::Vec3Types> MechanicalObject3;
 
-// Solvers
-#include <SofaExplicitOdeSolver/EulerSolver.h>
-
 #include <sofa/defaulttype/VecTypes.h>
 
 namespace sofa {
@@ -61,7 +58,6 @@ struct EulerExplicitDynamic_test : public component::odesolver::testing::ODESolv
     typedef typename DataTypes::Coord Coord;
 
     typedef container::MechanicalObject<DataTypes> MechanicalObject;
-    typedef component::odesolver::EulerExplicitSolver EulerExplicitSolver;
 
     /// Position and velocity array
     vector<double> positionsArray;

--- a/Component/ODESolver/Forward/tests/RungeKutta2ExplicitSolverDynamic_test.cpp
+++ b/Component/ODESolver/Forward/tests/RungeKutta2ExplicitSolverDynamic_test.cpp
@@ -37,10 +37,6 @@ using sofa::testing::NumericTest;
 #include <SofaBaseMechanics/MechanicalObject.h>
 using MechanicalObject3 = sofa::component::container::MechanicalObject<sofa::defaulttype::Vec3Types> ;
 
-// Solvers
-#include <SofaGeneralExplicitOdeSolver/RungeKutta2Solver.h>
-#include <SofaBaseLinearSolver/CGLinearSolver.h>
-
 #include <sofa/defaulttype/VecTypes.h>
 
 namespace sofa {
@@ -67,8 +63,6 @@ struct RungeKutta2ExplicitSolverDynamic_test : public component::odesolver::test
     typedef typename DataTypes::Coord Coord;
 
     typedef container::MechanicalObject<DataTypes> MechanicalObject;
-    typedef component::odesolver::RungeKutta2Solver RungeKutta2Solver;
-    typedef component::linearsolver::CGLinearSolver<component::linearsolver::GraphScatteredMatrix, component::linearsolver::GraphScatteredVector> CGLinearSolver;
 
     /// Position, velocity and acceleration array
     vector<double> positionsArray;

--- a/Component/ODESolver/Forward/tests/RungeKutta2ExplicitSolverDynamic_test.cpp
+++ b/Component/ODESolver/Forward/tests/RungeKutta2ExplicitSolverDynamic_test.cpp
@@ -26,8 +26,6 @@ using sofa::testing::NumericTest;
 
 #include <sofa/component/odesolver/testing/ODESolverSpringTest.h>
 
-#include <SceneCreator/SceneCreator.h>
-
 //Including Simulation
 #include <sofa/simulation/Simulation.h>
 #include <SofaSimulationGraph/DAGSimulation.h>
@@ -44,7 +42,6 @@ namespace sofa {
 using namespace component;
 using namespace defaulttype;
 using namespace simulation;
-using namespace modeling;
 using type::vector;
 
 /**  Dynamic solver test.

--- a/Component/ODESolver/Forward/tests/RungeKutta2ExplicitSolverDynamic_test.cpp
+++ b/Component/ODESolver/Forward/tests/RungeKutta2ExplicitSolverDynamic_test.cpp
@@ -24,7 +24,7 @@ using sofa::testing::BaseSimulationTest;
 #include <sofa/testing/NumericTest.h>
 using sofa::testing::NumericTest;
 
-#include <sofa/component/odesolver/testing/MassSpringSystemCreation.h>
+#include <sofa/component/odesolver/testing/ODESolverSpringTest.h>
 
 #include <SceneCreator/SceneCreator.h>
 
@@ -61,7 +61,7 @@ Then it compares the effective mass position to the computed mass position every
 */
 
 template <typename _DataTypes>
-struct RungeKutta2ExplicitSolverDynamic_test : public BaseSimulationTest
+struct RungeKutta2ExplicitSolverDynamic_test : public component::odesolver::testing::ODESolverSpringTest
 {
     typedef _DataTypes DataTypes;
     typedef typename DataTypes::Coord Coord;
@@ -70,11 +70,6 @@ struct RungeKutta2ExplicitSolverDynamic_test : public BaseSimulationTest
     typedef component::odesolver::RungeKutta2Solver RungeKutta2Solver;
     typedef component::linearsolver::CGLinearSolver<component::linearsolver::GraphScatteredMatrix, component::linearsolver::GraphScatteredVector> CGLinearSolver;
 
-
-    /// Root of the scene graph
-    simulation::Node::SPtr root;      
-    /// Tested simulation
-    simulation::Simulation* simulation;  
     /// Position, velocity and acceleration array
     vector<double> positionsArray;
     vector<double> velocitiesArray;
@@ -83,41 +78,12 @@ struct RungeKutta2ExplicitSolverDynamic_test : public BaseSimulationTest
     /// Create the context for the scene
     void createScene(double K, double m, double l0)
     {
-        // Init simulation
-        sofa::simulation::setSimulation(simulation = new sofa::simulation::graph::DAGSimulation());
-        root = simulation::getSimulation()->createNewGraph("root");
+        this->prepareScene(K, m, l0);
+        // add ODE Solver to test
+        simpleapi::createObject(m_si.root, "RungeKutta2Solver", {
+            { }
+        });
 
-        // Create the scene
-        root->setGravity(Coord(0,-10,0));
-
-        // Solver
-        RungeKutta2Solver::SPtr rungeKutta2Solver = addNew<RungeKutta2Solver> (root);
-
-        CGLinearSolver::SPtr cgLinearSolver = addNew<CGLinearSolver> (root);
-        cgLinearSolver->d_maxIter.setValue(3000);
-        cgLinearSolver->d_tolerance.setValue(1e-9);
-        cgLinearSolver->d_smallDenominatorThreshold.setValue(1e-9);
-
-        // Set initial positions and velocities of fixed point and mass
-        MechanicalObject3::VecCoord xFixed(1);
-        MechanicalObject3::DataTypes::set( xFixed[0], 0., 2.,0.);
-        MechanicalObject3::VecDeriv vFixed(1);
-        MechanicalObject3::DataTypes::set( vFixed[0], 0.,0.,0.);
-        MechanicalObject3::VecCoord xMass(1);
-        MechanicalObject3::DataTypes::set( xMass[0], 0., 1.,0.);
-        MechanicalObject3::VecDeriv vMass(1);
-        MechanicalObject3::DataTypes::set( vMass[0], 0., 0., 0.);
-
-        // Mass spring system
-        root = sofa::createMassSpringSystem<DataTypes>(
-                root,   // add mass spring system to the node containing solver
-                K,      // stiffness
-                m,      // mass
-                l0,     // spring rest length
-                xFixed, // Initial position of fixed point
-                vFixed, // Initial velocity of fixed point
-                xMass,  // Initial position of mass
-                vMass); // Initial velocity of mass
     }
 
 
@@ -165,12 +131,12 @@ struct RungeKutta2ExplicitSolverDynamic_test : public BaseSimulationTest
     {
         int i = 0;
         // Init simulation
-        sofa::simulation::getSimulation()->init(root.get());
-        double time = root->getTime();
+        m_si.initScene();
+        double time = m_si.root->getTime();
 
         // Get mechanical object
-        simulation::Node::SPtr massNode = root->getChild("MassNode");
-        typename MechanicalObject::SPtr dofs = massNode->get<MechanicalObject>(root->SearchDown);
+        simulation::Node::SPtr massNode = m_si.root->getChild("MassNode");
+        typename MechanicalObject::SPtr dofs = massNode->get<MechanicalObject>(m_si.root->SearchDown);
 
         // Animate
         do
@@ -191,8 +157,8 @@ struct RungeKutta2ExplicitSolverDynamic_test : public BaseSimulationTest
             }
 
             //Animate
-            sofa::simulation::getSimulation()->animate(root.get(),h);
-            time = root->getTime();
+            m_si.simulate(h);
+            time = m_si.root->getTime();
             // Iterate
             i++;
         }

--- a/Component/ODESolver/Forward/tests/RungeKutta4ExplicitSolverDynamic_test.cpp
+++ b/Component/ODESolver/Forward/tests/RungeKutta4ExplicitSolverDynamic_test.cpp
@@ -21,12 +21,8 @@
 ******************************************************************************/
 #include <sofa/testing/BaseSimulationTest.h>
 using sofa::testing::BaseSimulationTest;
-#include <sofa/testing/NumericTest.h>
-using sofa::testing::NumericTest;
 
 #include <sofa/component/odesolver/testing/ODESolverSpringTest.h>
-
-#include <SceneCreator/SceneCreator.h>
 
 //Including Simulation
 #include <sofa/simulation/Simulation.h>
@@ -37,10 +33,6 @@ using sofa::testing::NumericTest;
 #include <SofaBaseMechanics/MechanicalObject.h>
 using MechanicalObject3 = sofa::component::container::MechanicalObject<sofa::defaulttype::Vec3Types> ;
 
-// Solvers
-#include <SofaGeneralExplicitOdeSolver/RungeKutta4Solver.h>
-#include <SofaBaseLinearSolver/CGLinearSolver.h>
-
 #include <sofa/defaulttype/VecTypes.h>
 
 namespace sofa {
@@ -48,7 +40,6 @@ namespace sofa {
 using namespace component;
 using namespace defaulttype;
 using namespace simulation;
-using namespace modeling;
 using type::vector;
 
 /**  Dynamic solver test.
@@ -74,8 +65,6 @@ struct RungeKutta4ExplicitSolverDynamic_test : public component::odesolver::test
     typedef typename DataTypes::Real Real;
 
     typedef container::MechanicalObject<DataTypes> MechanicalObject;
-    typedef component::odesolver::RungeKutta4Solver RungeKutta4Solver;
-    typedef component::linearsolver::CGLinearSolver<component::linearsolver::GraphScatteredMatrix, component::linearsolver::GraphScatteredVector> CGLinearSolver;
 
     /// Position, velocity and acceleration array
     vector<double> positionsArray;

--- a/Component/ODESolver/Testing/CMakeLists.txt
+++ b/Component/ODESolver/Testing/CMakeLists.txt
@@ -4,15 +4,16 @@ project(Sofa.Component.ODESolver.Testing)
 
 set(SOFACOMPONENTODESOLVERTESTING_SRC "src/sofa/component/odesolver/testing")
 
-# only header files
 set(HEADER_FILES
+    ${SOFACOMPONENTODESOLVERTESTING_SRC}/EigenTestUtilities.h
     ${SOFACOMPONENTODESOLVERTESTING_SRC}/MassSpringSystemCreation.h
+    ${SOFACOMPONENTODESOLVERTESTING_SRC}/ODESolverSpringTest.h
     ${SOFACOMPONENTODESOLVERTESTING_SRC}/SunPlanetSystemCreation.h
 )
 
 set(SOURCE_FILES
-    ${SOFACOMPONENTODESOLVERTESTING_SRC}/empty.cpp # because of not interface type
+    ${SOFACOMPONENTODESOLVERTESTING_SRC}/empty.cpp 
 )
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_include_directories(${PROJECT_NAME} PUBLIC src/)
-target_link_libraries(${PROJECT_NAME} Sofa.Config)
+target_link_libraries(${PROJECT_NAME} Sofa.Config Sofa.SimulationCore)

--- a/Component/ODESolver/Testing/src/sofa/component/odesolver/testing/EigenTestUtilities.h
+++ b/Component/ODESolver/Testing/src/sofa/component/odesolver/testing/EigenTestUtilities.h
@@ -1,0 +1,112 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU General Public License as published by the Free  *
+* Software Foundation; either version 2 of the License, or (at your option)   *
+* any later version.                                                          *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for    *
+* more details.                                                               *
+*                                                                             *
+* You should have received a copy of the GNU General Public License along     *
+* with this program. If not, see <http://www.gnu.org/licenses/>.              *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <sofa/linearalgebra/FullVector.h>
+#include <sofa/simulation/Visitor.h>
+#include <sofa/core/VecId.h>
+#include <sofa/simulation/Node.h>
+#include <sofa/core/behavior/BaseMechanicalState.h>
+#include <Eigen/Dense>
+
+namespace sofa::component::odesolver::testing
+{
+
+class GetVectorVisitor : public sofa::simulation::Visitor
+{
+public:
+    GetVectorVisitor(const sofa::core::ExecParams* params, linearalgebra::BaseVector* vec, core::ConstVecId src)
+        : sofa::simulation::Visitor(params), vec(vec), src(src) {}
+
+    ~GetVectorVisitor() override = default;
+
+    Result processNodeTopDown(simulation::Node* gnode) override
+    {
+        if (gnode->mechanicalState != nullptr && (gnode->mechanicalMapping == nullptr || independentOnly == false))
+        {
+            gnode->mechanicalState->copyToBaseVector(vec, src, offset);
+        }
+        return Visitor::RESULT_CONTINUE;
+    }
+    const char* getClassName() const override { return "GetVectorVisitor"; }
+
+    /// If true, process the independent nodes only
+    void setIndependentOnly(bool b) { independentOnly = b; }
+
+protected:
+    linearalgebra::BaseVector* vec;
+    core::ConstVecId src;
+    unsigned offset{0};
+    bool independentOnly{false};
+
+};
+
+class GetAssembledSizeVisitor : public sofa::simulation::Visitor
+{
+public:
+    GetAssembledSizeVisitor(const sofa::core::ExecParams* params = sofa::core::mechanicalparams::castToExecParams(core::mechanicalparams::defaultInstance())) 
+        : sofa::simulation::Visitor(params)
+    {};
+    ~GetAssembledSizeVisitor() override {}
+
+    Result processNodeTopDown(simulation::Node* gnode) override
+    {
+        if (gnode->mechanicalState != nullptr && (gnode->mechanicalMapping == nullptr || independentOnly == false))
+        {
+            xsize += gnode->mechanicalState->getSize() * gnode->mechanicalState->getCoordDimension();
+            vsize += gnode->mechanicalState->getMatrixSize();
+        }
+        return Visitor::RESULT_CONTINUE;
+    }
+    const char* getClassName() const override { return "GetAssembledSizeVisitor"; }
+
+    unsigned positionSize() const { return xsize; }
+    unsigned velocitySize() const { return vsize; }
+    void setIndependentOnly(bool b) { independentOnly = b; }
+
+protected:
+    std::size_t xsize{ 0 };
+    std::size_t vsize{ 0 };
+    bool independentOnly{ false };
+};
+
+inline Eigen::VectorXd getVector(simulation::Node::SPtr root, core::ConstVecId id, bool indep = true )
+{
+    GetAssembledSizeVisitor getSizeVisitor;
+    getSizeVisitor.setIndependentOnly(indep);
+    root->execute(getSizeVisitor);
+    unsigned size;
+    if (id.type == sofa::core::V_COORD)
+        size =  getSizeVisitor.positionSize();
+    else
+        size = getSizeVisitor.velocitySize();
+    linearalgebra::FullVector<SReal> v(size);
+    GetVectorVisitor getVec( sofa::core::mechanicalparams::castToExecParams(core::mechanicalparams::defaultInstance()), &v, id);
+    getVec.setIndependentOnly(indep);
+    root->execute(getVec);
+
+    Eigen::VectorXd ve(size);
+    for(size_t i=0; i<size; i++)
+        ve(i)=v[i];
+    return ve;
+}
+
+} /// sofa

--- a/Component/ODESolver/Testing/src/sofa/component/odesolver/testing/MassSpringSystemCreation.h
+++ b/Component/ODESolver/Testing/src/sofa/component/odesolver/testing/MassSpringSystemCreation.h
@@ -41,10 +41,11 @@ inline simulation::Node::SPtr createMassSpringSystem(
     const std::string& vMass)
 {
     // Fixed point
-    simulation::Node::SPtr fixedPointNode = root->createChild("FixedPointNode");
+    auto fixedPointNode = simpleapi::createChild(root, "FixedPointNode" );
 
     simpleapi::createObject(fixedPointNode, "MechanicalObject", {
         { "name","fixedPoint"},
+        { "template","Vec3"},
         { "position", xFixedPoint},
         { "velocity", vFixedPoint},
     });
@@ -52,14 +53,14 @@ inline simulation::Node::SPtr createMassSpringSystem(
     simpleapi::createObject(fixedPointNode, "FixedConstraint", {
         { "name","fixed"},
         { "indices", "0"},
-        { "velocity", vFixedPoint},
     });
 
     // Mass
-    simulation::Node::SPtr massNode = root->createChild("MassNode");
+    auto massNode = simpleapi::createChild(root, "MassNode");
 
     simpleapi::createObject(massNode, "MechanicalObject", {
         { "name","massDof"},
+        { "template","Vec3"},
         { "position", xMass},
         { "velocity", vMass}
     });
@@ -70,12 +71,12 @@ inline simulation::Node::SPtr createMassSpringSystem(
     });
 
     std::ostringstream oss;
-    oss << 0 << 0 << stiffness << 0 << restLength;
+    oss << 0 << " " << 0 << " " << stiffness << " " << 0 << " " << restLength;
 
     // attach a spring
     simpleapi::createObject(root, "StiffSpringForceField", {
         { "name","ff"},
-        { "springs", oss.str()},
+        { "spring", oss.str()},
         { "object1", "@FixedPointNode/fixedPoint"},
         { "object2", "@MassNode/massDof"},
     });

--- a/Component/ODESolver/Testing/src/sofa/component/odesolver/testing/MassSpringSystemCreation.h
+++ b/Component/ODESolver/Testing/src/sofa/component/odesolver/testing/MassSpringSystemCreation.h
@@ -21,21 +21,70 @@
 ******************************************************************************/
 #pragma once
 
-#include <SceneCreator/SceneCreator.h>
+#include <SofaSimulationGraph/SimpleApi.h>
 
 #include <sofa/testing/NumericTest.h>
 #include <sofa/simulation/Node.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
-#include <SofaBaseMechanics/UniformMass.h>
-#include <SofaBoundaryCondition/FixedConstraint.h>
-#include <SofaDeformable/StiffSpringForceField.h>
 
-namespace sofa
+namespace sofa::component::odesolver::testing
 {
 
-/// Create a mass srping system
+/// Create a mass spring system
+inline simulation::Node::SPtr createMassSpringSystem(
+    simulation::Node::SPtr root,
+    const std::string& stiffness,
+    const std::string& mass,
+    const std::string& restLength,
+    const std::string& xFixedPoint,
+    const std::string& vFixedPoint,
+    const std::string& xMass,
+    const std::string& vMass)
+{
+    // Fixed point
+    simulation::Node::SPtr fixedPointNode = root->createChild("FixedPointNode");
+
+    simpleapi::createObject(fixedPointNode, "MechanicalObject", {
+        { "name","fixedPoint"},
+        { "position", xFixedPoint},
+        { "velocity", vFixedPoint},
+    });
+
+    simpleapi::createObject(fixedPointNode, "FixedConstraint", {
+        { "name","fixed"},
+        { "indices", "0"},
+        { "velocity", vFixedPoint},
+    });
+
+    // Mass
+    simulation::Node::SPtr massNode = root->createChild("MassNode");
+
+    simpleapi::createObject(massNode, "MechanicalObject", {
+        { "name","massDof"},
+        { "position", xMass},
+        { "velocity", vMass}
+    });
+
+    simpleapi::createObject(massNode, "UniformMass", {
+        { "name","mass"},
+        { "totalMass", mass}
+    });
+
+    std::ostringstream oss;
+    oss << 0 << 0 << stiffness << 0 << restLength;
+
+    // attach a spring
+    simpleapi::createObject(root, "StiffSpringForceField", {
+        { "name","ff"},
+        { "springs", oss.str()},
+        { "object1", "@FixedPointNode/fixedPoint"},
+        { "object2", "@MassNode/massDof"},
+    });
+
+    return root;
+}
+
 template<typename DataTypes>
-simulation::Node::SPtr createMassSpringSystem(
+inline simulation::Node::SPtr createMassSpringSystem(
     simulation::Node::SPtr root,
     double stiffness,
     double mass,
@@ -45,47 +94,11 @@ simulation::Node::SPtr createMassSpringSystem(
     typename DataTypes::VecCoord xMass,
     typename DataTypes::VecDeriv vMass)
 {
-
-    typedef component::container::MechanicalObject<defaulttype::Vec3Types> MechanicalObject3;
-    typedef component::projectiveconstraintset::FixedConstraint<defaulttype::Vec3Types> FixedConstraint3;
-    typedef component::mass::UniformMass<defaulttype::Vec3Types> UniformMass3;
-    typedef component::interactionforcefield::StiffSpringForceField<defaulttype::Vec3Types > StiffSpringForceField3;
-
-    // Fixed point
-    simulation::Node::SPtr fixedPointNode = root->createChild("FixedPointNode");
-    MechanicalObject3::SPtr FixedPoint = modeling::addNew<MechanicalObject3>(fixedPointNode, "fixedPoint");
-
-    // Set position and velocity
-    FixedPoint->resize(1);
-    MechanicalObject3::WriteVecCoord xdof = FixedPoint->writePositions();
-    sofa::testing::copyToData(xdof, xFixedPoint);
-    MechanicalObject3::WriteVecDeriv vdof = FixedPoint->writeVelocities();
-    sofa::testing::copyToData(vdof, vFixedPoint);
-
-    FixedConstraint3::SPtr fixed = modeling::addNew<FixedConstraint3>(fixedPointNode, "FixedPointNode");
-    fixed->addConstraint(0);      // attach particle
-
-
-    // Mass
-    simulation::Node::SPtr massNode = root->createChild("MassNode");
-    MechanicalObject3::SPtr massDof = modeling::addNew<MechanicalObject3>(massNode, "massNode");
-
-    // Set position and velocity
-    FixedPoint->resize(1);
-    MechanicalObject3::WriteVecCoord xMassDof = massDof->writePositions();
-    sofa::testing::copyToData(xMassDof, xMass);
-    MechanicalObject3::WriteVecDeriv vMassDof = massDof->writeVelocities();
-    sofa::testing::copyToData(vMassDof, vMass);
-
-    UniformMass3::SPtr massPtr = modeling::addNew<UniformMass3>(massNode, "mass");
-    massPtr->d_totalMass.setValue(mass);
-
-    // attach a spring
-    StiffSpringForceField3::SPtr spring = core::objectmodel::New<StiffSpringForceField3>(FixedPoint.get(), massDof.get());
-    root->addObject(spring);
-    spring->addSpring(0, 0, stiffness, 0, restLength);
-
-    return root;
+    return createMassSpringSystem(root,
+        simpleapi::str(stiffness), simpleapi::str(mass), simpleapi::str(restLength),
+        simpleapi::str(xFixedPoint), simpleapi::str(vFixedPoint),
+        simpleapi::str(xMass), simpleapi::str(vMass)
+    );
 }
 
-} // namespace sofa
+} // namespace sofa::component::odesolver::testing

--- a/Component/ODESolver/Testing/src/sofa/component/odesolver/testing/ODESolverSpringTest.h
+++ b/Component/ODESolver/Testing/src/sofa/component/odesolver/testing/ODESolverSpringTest.h
@@ -46,7 +46,8 @@ struct ODESolverSpringTest : public BaseSimulationTest
         sofa::simpleapi::importPlugin("Sofa.Component.ODESolver");
         sofa::simpleapi::importPlugin("SofaBaseLinearSolver");
         sofa::simpleapi::importPlugin("SofaBaseMechanics");
-        sofa::simpleapi::importPlugin("SofaDeformable");
+        sofa::simpleapi::importPlugin("SofaDeformable"); 
+        sofa::simpleapi::importPlugin("SofaBoundaryCondition");
 
         // remove warnings
         simpleapi::createObject(m_si.root, "DefaultAnimationLoop", {});
@@ -54,8 +55,8 @@ struct ODESolverSpringTest : public BaseSimulationTest
         
         simpleapi::createObject(m_si.root, "CGLinearSolver", {
             { "iterations", simpleapi::str(3000)},
-            { "tolerance", simpleapi::str(1e-9)},
-            { "threshold", simpleapi::str(1e-9)},
+            { "tolerance", simpleapi::str(1e-12)},
+            { "threshold", simpleapi::str(1e-12)},
             });
 
         // Add mass spring system
@@ -64,10 +65,10 @@ struct ODESolverSpringTest : public BaseSimulationTest
             simpleapi::str(K),      // stiffness
             simpleapi::str(m),      // mass
             simpleapi::str(l0),     // spring rest length
-            "0.0 2.0 0.0", // Initial position of fixed point
-            "0.0 0.0 0.0", // Initial velocity of fixed point
-            "0.0 1.0 0.0",  // Initial position of mass
-            "0.0 0.0 0.0"); // Initial velocity of mass
+            std::string("0.0 2.0 0.0"), // Initial position of fixed point
+            std::string("0.0 0.0 0.0"), // Initial velocity of fixed point
+            std::string("0.0 1.0 0.0"),  // Initial position of mass
+            std::string("0.0 0.0 0.0")); // Initial velocity of mass
     }
 };
 

--- a/Component/ODESolver/Testing/src/sofa/component/odesolver/testing/ODESolverSpringTest.h
+++ b/Component/ODESolver/Testing/src/sofa/component/odesolver/testing/ODESolverSpringTest.h
@@ -1,0 +1,74 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU General Public License as published by the Free  *
+* Software Foundation; either version 2 of the License, or (at your option)   *
+* any later version.                                                          *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for    *
+* more details.                                                               *
+*                                                                             *
+* You should have received a copy of the GNU General Public License along     *
+* with this program. If not, see <http://www.gnu.org/licenses/>.              *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/testing/BaseSimulationTest.h>
+using sofa::testing::BaseSimulationTest;
+
+#include <SofaSimulationGraph/SimpleApi.h>
+
+#include <sofa/testing/NumericTest.h>
+#include <sofa/simulation/Node.h>
+
+#include <sofa/component/odesolver/testing/MassSpringSystemCreation.h>
+
+namespace sofa::component::odesolver::testing
+{
+
+struct ODESolverSpringTest : public BaseSimulationTest
+{
+    SceneInstance m_si{};
+
+    inline void prepareScene(double K, double m, double l0)
+    {
+        // Create the scene
+        m_si.root->setGravity({ 0, -10, 0 });
+
+        sofa::simpleapi::importPlugin("Sofa.Component.ODESolver");
+        sofa::simpleapi::importPlugin("SofaBaseLinearSolver");
+        sofa::simpleapi::importPlugin("SofaBaseMechanics");
+        sofa::simpleapi::importPlugin("SofaDeformable");
+
+        // remove warnings
+        simpleapi::createObject(m_si.root, "DefaultAnimationLoop", {});
+        simpleapi::createObject(m_si.root, "DefaultVisualManagerLoop", {});
+        
+        simpleapi::createObject(m_si.root, "CGLinearSolver", {
+            { "iterations", simpleapi::str(3000)},
+            { "tolerance", simpleapi::str(1e-9)},
+            { "threshold", simpleapi::str(1e-9)},
+            });
+
+        // Add mass spring system
+        createMassSpringSystem(
+            m_si.root,   // add mass spring system to the node containing solver
+            simpleapi::str(K),      // stiffness
+            simpleapi::str(m),      // mass
+            simpleapi::str(l0),     // spring rest length
+            "0.0 2.0 0.0", // Initial position of fixed point
+            "0.0 0.0 0.0", // Initial velocity of fixed point
+            "0.0 1.0 0.0",  // Initial position of mass
+            "0.0 0.0 0.0"); // Initial velocity of mass
+    }
+};
+
+} // namespace sofa::component::odesolver::testing

--- a/Component/ODESolver/Testing/src/sofa/component/odesolver/testing/SunPlanetSystemCreation.h
+++ b/Component/ODESolver/Testing/src/sofa/component/odesolver/testing/SunPlanetSystemCreation.h
@@ -31,7 +31,7 @@
 #include <SofaMiscForceField/LennardJonesForceField.h>
 
 
-namespace sofa
+namespace sofa::component::odesolver::testing
 {
 
 typedef component::container::MechanicalObject<defaulttype::Vec3Types> MechanicalObject3;
@@ -89,4 +89,4 @@ simulation::Node::SPtr createSunPlanetSystem(
 
 }
 
-} // namespace sofa
+} // namespace sofa::component::odesolver::testing

--- a/Component/ODESolver/Testing/src/sofa/component/odesolver/testing/empty.cpp
+++ b/Component/ODESolver/Testing/src/sofa/component/odesolver/testing/empty.cpp
@@ -1,0 +1,3 @@
+#include <sofa/config.h>
+
+SOFA_EXPORT_DYNAMIC_LIBRARY void init(){}

--- a/Component/ODESolver/Testing/src/sofa/component/odesolver/testing/empty.cpp
+++ b/Component/ODESolver/Testing/src/sofa/component/odesolver/testing/empty.cpp
@@ -1,3 +1,0 @@
-#include <sofa/config.h>
-
-SOFA_EXPORT_DYNAMIC_LIBRARY void init(){}


### PR DESCRIPTION
As the title says.

and Refactor as a majority of tests had the same scene structure.

More dependencies could be removed (MechanicalObject in particular) but rewriting was very time-consuming and I was lazy 🤥


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
