### PR TITLE
[SofaSparseSolver] Add cmake configuration for Threads

### DIFF
--- a/modules/SofaSparseSolver/CMakeLists.txt
+++ b/modules/SofaSparseSolver/CMakeLists.txt
@@ -15,6 +15,9 @@ if(NOT metis_FOUND)
 endif()
 sofa_set_01(SOFASPARSESOLVER_HAVE_METIS VALUE TRUE)
 
+# make sure you have threads for AsyncSparseLDLSolver
+sofa_find_package(Threads REQUIRED)
+
 set(SRC_ROOT src/SofaSparseSolver)
 
 # Sources
@@ -47,6 +50,7 @@ set(SOURCE_FILES
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaBaseLinearSolver SofaGeneralLinearSolver)
 target_link_libraries(${PROJECT_NAME} PUBLIC metis csparse)
+target_link_libraries(${PROJECT_NAME} PUBLIC Threads::Threads)
 
 sofa_create_package_with_targets(
     PACKAGE_NAME SofaSparseSolver

--- a/modules/SofaSparseSolver/SofaSparseSolverConfig.cmake.in
+++ b/modules/SofaSparseSolver/SofaSparseSolverConfig.cmake.in
@@ -10,6 +10,7 @@ find_package(SofaBase QUIET REQUIRED)
 find_package(SofaImplicitOdeSolver QUIET REQUIRED) 
 find_package(SofaSimpleFem QUIET REQUIRED)
 find_package(SofaGeneralLinearSolver QUIET REQUIRED)
+find_package(Threads QUIET REQUIRED)
 
 if(SOFASPARSESOLVER_HAVE_METIS)
     find_package(Metis QUIET REQUIRED HINTS "${CMAKE_CURRENT_LIST_DIR}/..")


### PR DESCRIPTION
In some cases (which ones?), gcc does not link against pthread which is necessary for the recently added AsyncSparseLDLSolver.
I got the case on the latest gcc on Manjaro (`gcc version 11.1.0`), and at least one other user is reported the same error #2736 

Same configuration with clang worked fine without so I suppose the added library comes from somewhere (but I dont where/what). 
This PR adds the necessary library in any case.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
