### PR TITLE
[SofaGuiQt] Remove sec unit from GUI

### DIFF
--- a/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
@@ -1639,7 +1639,7 @@ void RealGUI::eventNewTime()
     {
         double time = root->getTime();
         char buf[100];
-        sprintf ( buf, "Time: %.3g", time );
+        sprintf ( buf, "Time: %.3g,   Steps:  %o", time, frameCounter );
         timeLabel->setText ( buf );
     }
 #endif
@@ -2132,7 +2132,6 @@ void RealGUI::playpauseGUI ( bool startSimulation )
         SimulationStopEvent startEvt;
         root->propagateEvent(core::execparams::defaultInstance(), &startEvt);
         m_clockBeforeLastStep = 0;
-        frameCounter=0;
         timerStep->start(0);
         return;
     }

--- a/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
@@ -429,7 +429,7 @@ RealGUI::RealGUI ( const char* viewername)
     fpsLabel->setMinimumSize ( fpsLabel->sizeHint() );
     fpsLabel->clear();
 
-    timeLabel = new QLabel ( "Time: 999.9999 s", statusBar() );
+    timeLabel = new QLabel ( "Time: 999.9999", statusBar() );
     timeLabel->setMinimumSize ( timeLabel->sizeHint() );
     timeLabel->clear();
     statusBar()->addWidget ( fpsLabel );

--- a/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
@@ -1639,7 +1639,7 @@ void RealGUI::eventNewTime()
     {
         double time = root->getTime();
         char buf[100];
-        sprintf ( buf, "Time: %.3g,   Steps:  %o", time, frameCounter );
+        sprintf ( buf, "Time: %.3g,   Steps:  %i", time, frameCounter );
         timeLabel->setText ( buf );
     }
 #endif

--- a/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
@@ -1639,7 +1639,7 @@ void RealGUI::eventNewTime()
     {
         double time = root->getTime();
         char buf[100];
-        sprintf ( buf, "Time: %.3g s", time );
+        sprintf ( buf, "Time: %.3g", time );
         timeLabel->setText ( buf );
     }
 #endif


### PR DESCRIPTION
Unit should not be specified in the GUI, nothing tell us that seconds are used.
This PR just remove the secs from the GUI.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
