### PR TITLE
[SofaMiscMapping] Support points removal in SubsetMultiMapping

### DIFF
--- a/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetTopologyModifier.cpp
+++ b/Component/Topology/Container/Dynamic/src/sofa/component/topology/container/dynamic/PointSetTopologyModifier.cpp
@@ -437,11 +437,11 @@ void PointSetTopologyModifier::propagateTopologicalChanges()
     sofa::core::topology::EndingEvent* e = new sofa::core::topology::EndingEvent();
     m_container->addTopologyChange(e);
     this->propagateTopologicalEngineChanges();
-    
+
     sofa::core::ExecParams* params = sofa::core::execparams::defaultInstance();
     sofa::simulation::TopologyChangeVisitor a(params, m_container);
 
-    getContext()->executeVisitor(&a);
+    this->getContext()->getRootContext()->executeVisitor(&a);
 
     // remove the changes we just propagated, so that we don't send them again next time
     m_container->resetTopologyChangeList();

--- a/Component/Topology/Mapping/src/sofa/component/topology/mapping/SubsetTopologicalMapping.h
+++ b/Component/Topology/Mapping/src/sofa/component/topology/mapping/SubsetTopologicalMapping.h
@@ -33,7 +33,7 @@ namespace sofa::component::topology::mapping
 {
 
 /**
- * This class is a specific implementation of TopologicalMapping where the destination topology should be kept identical to the source topology.
+ * This class is a specific implementation of TopologicalMapping where the destination topology is a subset of the source topology.
  * The implementation currently assumes that both topology have been initialized identically.
  */
 

--- a/SofaKernel/modules/SofaCore/CMakeLists.txt
+++ b/SofaKernel/modules/SofaCore/CMakeLists.txt
@@ -143,6 +143,7 @@ set(HEADER_FILES
     ${SRC_ROOT}/objectmodel/vectorData.h
     ${SRC_ROOT}/objectmodel/vectorLinks.h
     ${SRC_ROOT}/topology/BaseMeshTopology.h
+    ${SRC_ROOT}/topology/BaseTopologicalMapping.h
     ${SRC_ROOT}/topology/BaseTopology.h
     ${SRC_ROOT}/topology/BaseTopologyData.h
     ${SRC_ROOT}/topology/BaseTopologyObject.h

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopologicalMapping.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopologicalMapping.h
@@ -26,7 +26,7 @@
 namespace sofa::core::topology
 {
 
-class BaseTopologicalMapping : public virtual objectmodel::BaseObject
+class SOFA_CORE_API BaseTopologicalMapping : public virtual objectmodel::BaseObject
 {
 public:
     SOFA_ABSTRACT_CLASS(BaseTopologicalMapping, objectmodel::BaseObject);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopologicalMapping.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/BaseTopologicalMapping.h
@@ -19,20 +19,38 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <sofa/core/topology/TopologicalMapping.h>
+#pragma once
+
+#include <sofa/core/topology/BaseMeshTopology.h>
 
 namespace sofa::core::topology
 {
 
-bool TopologicalMapping::isTopologyAnInput(core::topology::Topology* topology)
+class BaseTopologicalMapping : public virtual objectmodel::BaseObject
 {
-    return fromModel.get() == topology;
-}
+public:
+    SOFA_ABSTRACT_CLASS(BaseTopologicalMapping, objectmodel::BaseObject);
 
-bool TopologicalMapping::isTopologyAnOutput(core::topology::Topology* topology)
-{
-    return toModel.get() == topology;
-}
+    /// Input Topology
+    using In = BaseMeshTopology;
+    /// Output Topology
+    using Out = BaseMeshTopology;
 
-} /// namespace sofa::core::topology
+    /// Method called at each topological changes propagation which comes from the INPUT topologies to adapt the OUTPUT topologies :
+    virtual void updateTopologicalMappingTopDown() = 0;
 
+    /// Method called at each topological changes propagation which comes from the OUTPUT topologies to adapt the INPUT topologies :
+    virtual void updateTopologicalMappingBottomUp() {}
+
+    /// Return true if this mapping is able to propagate topological changes from input to output topologies
+    virtual bool propagateFromInputToOutputModel() { return true; }
+
+    /// Return true if this mapping is able to propagate topological changes from output to input topologies
+    virtual bool propagateFromOutputToInputModel() { return false; }
+
+    virtual bool isTopologyAnInput(core::topology::Topology* topology) { return false; }
+    virtual bool isTopologyAnOutput(core::topology::Topology* topology) { return false; }
+
+};
+
+} // namespace sofa::core::topology

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologicalMapping.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologicalMapping.h
@@ -39,7 +39,7 @@ namespace sofa::core::topology
 * So, at each time step, the geometrical and adjacency information are consistent in both topologies.
 *
 */
-class TopologicalMapping : public virtual BaseTopologicalMapping
+class SOFA_CORE_API TopologicalMapping : public virtual BaseTopologicalMapping
 {
 public:
     SOFA_ABSTRACT_CLASS(TopologicalMapping, BaseTopologicalMapping);

--- a/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologicalMapping.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/topology/TopologicalMapping.h
@@ -19,22 +19,16 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_CORE_TOPOLOGY_TOPOLOGICALMAPPING_H
-#define SOFA_CORE_TOPOLOGY_TOPOLOGICALMAPPING_H
+#pragma once
 
+#include <sofa/core/topology/BaseTopologicalMapping.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
 
-namespace sofa
-{
-
-namespace core
-{
-
-namespace topology
+namespace sofa::core::topology
 {
 
 /**
-*  \brief This Interface is a new kind of Mapping, called TopologicalMapping, which converts an INPUT TOPOLOGY to an OUTPUT TOPOLOGY (both topologies are of type BaseTopology)
+*  \brief This Interface is a kind of Mapping, called TopologicalMapping, which converts an INPUT TOPOLOGY to an OUTPUT TOPOLOGY (both topologies are of type BaseTopology)
 *
 * It first initializes the mesh of the output topology from the mesh of the input topology,
 * and it creates the two Index Maps that maintain the correspondence between the indices of their common elements.
@@ -45,15 +39,13 @@ namespace topology
 * So, at each time step, the geometrical and adjacency information are consistent in both topologies.
 *
 */
-class TopologicalMapping : public virtual objectmodel::BaseObject
+class TopologicalMapping : public virtual BaseTopologicalMapping
 {
 public:
-    SOFA_ABSTRACT_CLASS(TopologicalMapping, objectmodel::BaseObject);
+    SOFA_ABSTRACT_CLASS(TopologicalMapping, BaseTopologicalMapping);
 
-    /// Input Topology
-    typedef BaseMeshTopology In;
-    /// Output Topology
-    typedef BaseMeshTopology Out;
+    using BaseTopologicalMapping::In;
+    using BaseTopologicalMapping::Out;
 
     using Index = sofa::Index;
 
@@ -72,6 +64,9 @@ public:
         this->toModel.set( to );
     };
 
+    bool isTopologyAnInput(core::topology::Topology* topology) override;
+    bool isTopologyAnOutput(core::topology::Topology* topology) override;
+
     /// Set the path to the objects mapped in the scene graph
     void setPathInputObject(const std::string &o) {fromModel.setPath(o);}
     void setPathOutputObject(const std::string &o) {toModel.setPath(o);}
@@ -81,18 +76,6 @@ public:
 
     /// Accessor to the OUTPUT topology of the TopologicalMapping :
     Out* getTo() {return toModel.get();}
-
-    /// Method called at each topological changes propagation which comes from the INPUT topology to adapt the OUTPUT topology :
-    virtual void updateTopologicalMappingTopDown() = 0;
-
-    /// Method called at each topological changes propagation which comes from the OUTPUT topology to adapt the INPUT topology :
-    virtual void updateTopologicalMappingBottomUp() {}
-
-    /// Return true if this mapping is able to propagate topological changes from input to output model
-    virtual bool propagateFromInputToOutputModel() { return true; }
-
-    /// Return true if this mapping is able to propagate topological changes from output to input model
-    virtual bool propagateFromOutputToInputModel() { return false; }
 
     /// return true if the output topology subdivide the input one. (the topology uses the Loc2GlobVec/Glob2LocMap/In2OutMap structs and share the same DOFs)
     virtual bool isTheOutputTopologySubdividingTheInputOne() { return true; }
@@ -235,10 +218,10 @@ public:
 protected:
     /// Input source BaseTopology
     SingleLink<TopologicalMapping, In, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> fromModel;
-    //In* fromModel;
+
     /// Output target BaseTopology
     SingleLink<TopologicalMapping, Out, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> toModel;
-    //Out* toModel;
+
 
     // Two index maps :
 
@@ -253,10 +236,5 @@ protected:
     std::map<Index, sofa::type::vector<Index> > In2OutMap;
 };
 
-} // namespace topology
+} // namespace sofa::core::topology
 
-} // namespace core
-
-} // namespace sofa
-
-#endif

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/TopologyChangeVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/TopologyChangeVisitor.cpp
@@ -73,10 +73,10 @@ Visitor::Result TopologyChangeVisitor::processNodeTopDown(simulation::Node* node
     // search for topological mapping, run the mapping first. Do not stop the propagation of parent topology
     for (simulation::Node::ObjectIterator it = node->object.begin(); it != node->object.end(); ++it)
     {
-        sofa::core::topology::TopologicalMapping* obj = dynamic_cast<sofa::core::topology::TopologicalMapping*>(it->get());
+        auto obj = dynamic_cast<sofa::core::topology::BaseTopologicalMapping*>(it->get());
         if (obj != nullptr)  // find a TopologicalMapping node among the brothers (it must be the first one written)
         {
-            if(obj->propagateFromInputToOutputModel() && obj->getFrom() == m_source)  //node != root){ // the propagation of topological changes comes (at least) from a father node, not from a brother
+            if(obj->propagateFromInputToOutputModel() && obj->isTopologyAnInput(m_source))  //node != root){ // the propagation of topological changes comes (at least) from a father node, not from a brother
             {
                 ctime_t t0=begin(node,obj);
                 obj->updateTopologicalMappingTopDown(); // update the specific TopologicalMapping
@@ -96,10 +96,10 @@ void TopologyChangeVisitor::processNodeBottomUp(simulation::Node* node)
 {
     for (simulation::Node::ObjectIterator it = node->object.begin(); it != node->object.end(); ++it)
     {
-        sofa::core::topology::TopologicalMapping* obj = dynamic_cast<sofa::core::topology::TopologicalMapping*>(it->get());
+        auto* obj = dynamic_cast<sofa::core::topology::BaseTopologicalMapping*>(it->get());
         if (obj != nullptr)  // find a TopologicalMapping node among the brothers (it must be the first one written)
         {
-            if(obj->propagateFromOutputToInputModel() && obj->getTo() == m_source)  //node == root){
+            if(obj->propagateFromOutputToInputModel() && obj->isTopologyAnOutput(m_source))  //node == root){
             {
                 obj->updateTopologicalMappingBottomUp(); // update the specific TopologicalMapping
             }

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/TopologyChangeVisitor.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/TopologyChangeVisitor.cpp
@@ -73,7 +73,7 @@ Visitor::Result TopologyChangeVisitor::processNodeTopDown(simulation::Node* node
     // search for topological mapping, run the mapping first. Do not stop the propagation of parent topology
     for (simulation::Node::ObjectIterator it = node->object.begin(); it != node->object.end(); ++it)
     {
-        auto obj = dynamic_cast<sofa::core::topology::BaseTopologicalMapping*>(it->get());
+        auto* obj = dynamic_cast<sofa::core::topology::BaseTopologicalMapping*>(it->get());
         if (obj != nullptr)  // find a TopologicalMapping node among the brothers (it must be the first one written)
         {
             if(obj->propagateFromInputToOutputModel() && obj->isTopologyAnInput(m_source))  //node != root){ // the propagation of topological changes comes (at least) from a father node, not from a brother

--- a/examples/Benchmark/TopologicalChanges/RemovingPointSubsetMultiMapping.scn
+++ b/examples/Benchmark/TopologicalChanges/RemovingPointSubsetMultiMapping.scn
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0"?>
+<Node name="root" dt="0.1" gravity="0 -10 0">
+    <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/>
+    <RequiredPlugin name="SofaBoundaryCondition"/>
+    <RequiredPlugin name="SofaDeformable"/>
+    <RequiredPlugin name="SofaMiscMapping"/>
+    <RequiredPlugin name="SofaOpenglVisual"/>
+    <RequiredPlugin name="SofaMiscTopology"/>
+
+    <VisualStyle displayFlags="hideVisualModels showBehaviorModels showForceFields showCollisionModels showInteractionForceFields" />
+
+    <OglGrid size="5" nbSubdiv="20"/>
+    <OglLineAxis size="1"/>
+    <OglSceneFrame/>
+
+    <DefaultAnimationLoop/>
+    <DefaultVisualManagerLoop/>
+
+    <EulerImplicitSolver/>
+    <CGLinearSolver iterations="3000" tolerance="1e-9" threshold="1e-9"/>
+
+    <Node name="FixedPointNode">
+        <MechanicalObject name="dof" position="0 2 0  1 2 0  2 2 0  3 2 0" showIndices="false" showIndicesScale="0.1"/>
+        <FixedConstraint indices="0 1 2 3"/>
+    </Node>
+
+    <Node name="MassNode">
+        <PointSetTopologyContainer name="container" position="2 1 0  0 1 0  1 1 0  3 1 0"/>
+        <PointSetTopologyModifier name="modifier" />
+        <MechanicalObject name="dof" showIndices="false" showIndicesScale="0.1"/>
+        <UniformMass name="mass" vertexMass="10"/>
+        <TopologicalChangeProcessor useDataInputs="true" pointsToRemove="0 1" timeToRemove="0.2"/>
+    </Node>
+
+    <Node name="merge">
+
+        <MechanicalObject template="Vec3d" name="dofs" showIndices="true" showIndicesScale="0.1" printLog="true"/>
+
+        <SubsetMultiMapping
+                input="@../FixedPointNode/dof @../MassNode/dof"
+                inputTopologies="@null @../MassNode/container"
+                output="@dofs"
+                outputTopologies="@container"
+                indexPairs="0 0  0 1  0 2  0 3     1 0  1 1  1 2  1 3"
+                printLog="true"/>
+        <PointSetTopologyContainer name="container" printLog="true"/>
+        <PointSetTopologyModifier name="modifier" printLog="true" />
+
+        <StiffSpringForceField spring="
+            2 4 100 0 1
+            1 6 100 0 1
+            3 7 100 0 1
+            0 5 100 0 1
+            1 4 100 0 1
+            0 6 100 0 1
+        " drawMode="1" printLog="1"/>
+
+    </Node>
+
+</Node>


### PR DESCRIPTION
Following the comments in https://github.com/sofa-framework/sofa/pull/2720, this PR replaces:

1. https://github.com/sofa-framework/sofa/pull/2720
2. https://github.com/sofa-framework/sofa/pull/2729

A base class for TopologicalMapping is introduced (BaseTopologicalMapping). It has no link to topologies.

SubsetMultiMapping is now a BaseTopologicalMapping and has MultiLinks for input topologies and output topologies.
The consequence is that SubsetMultiMapping gets the propagation of the topological changes through the visitor `TopologyChangeVisitor`. It does not need any callback and subscribe to any topology.

Note that `TopologyChangeVisitor` is now called on the root, rather than on the Node of the topology undergoing changes. It's a bit more expansive, but my SubsetMultiMapping is not in the same Node.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
