### PR TITLE
[SofaBaseMechanics] Clean AddMToMatrixFunctor

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/DiagonalMass.inl
@@ -618,12 +618,14 @@ template <class DataTypes>
 void DiagonalMass<DataTypes>::addMToMatrix(const core::MechanicalParams *mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix)
 {
     const MassVector &masses= d_vertexMass.getValue();
-    const auto N = defaulttype::DataTypeInfo<Deriv>::size();
+    static constexpr auto N = Deriv::total_size;
     AddMToMatrixFunctor<Deriv,MassType> calc;
     sofa::core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate);
-    Real mFactor = Real(sofa::core::mechanicalparams::mFactorIncludingRayleighDamping(mparams, this->rayleighMass.getValue()));
-    for (unsigned int i=0; i<masses.size(); i++)
-        calc(r.matrix, masses[i], r.offset + N*i, mFactor);
+    const Real mFactor = Real(sofa::core::mechanicalparams::mFactorIncludingRayleighDamping(mparams, this->rayleighMass.getValue()));
+    for (unsigned int i = 0; i < masses.size(); i++)
+    {
+        calc(r.matrix, masses[i], r.offset + N * i, mFactor);
+    }
 }
 
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/UniformMass.inl
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/UniformMass.inl
@@ -548,16 +548,18 @@ void UniformMass<DataTypes>::addMToMatrix (const MechanicalParams *mparams,
 {
     const MassType& m = d_vertexMass.getValue();
 
-    const size_t N = DataTypeInfo<Deriv>::size();
+    static constexpr auto N = Deriv::total_size;
 
     AddMToMatrixFunctor<Deriv,MassType> calc;
     MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(mstate);
 
-    Real mFactor = Real(sofa::core::mechanicalparams::mFactorIncludingRayleighDamping(mparams, this->rayleighMass.getValue()));
+    const Real mFactor = Real(sofa::core::mechanicalparams::mFactorIncludingRayleighDamping(mparams, this->rayleighMass.getValue()));
 
     ReadAccessor<Data<SetIndexArray > > indices = d_indices;
-    for ( unsigned int i=0; i<indices.size(); i++ )
-        calc ( r.matrix, m, int(r.offset + N*indices[i]), mFactor);
+    for (auto id : *indices)
+    {
+        calc ( r.matrix, m, int(r.offset + N * id), mFactor);
+    }
 }
 
 

--- a/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
+++ b/modules/SofaMiscForceField/src/SofaMiscForceField/MeshMatrixMass.inl
@@ -2138,14 +2138,14 @@ void MeshMatrixMass<DataTypes>::addMToMatrix(const core::MechanicalParams *mpara
     const auto &vertexMass= d_vertexMass.getValue();
     const auto &edgeMass= d_edgeMass.getValue();
 
-    size_t nbEdges=m_topology->getNbEdges();
+    const size_t nbEdges=m_topology->getNbEdges();
     sofa::Index v0,v1;
 
-    const int N = defaulttype::DataTypeInfo<Deriv>::size();
+    static constexpr auto N = Deriv::total_size;
     AddMToMatrixFunctor<Deriv,MassType> calc;
     sofa::core::behavior::MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate);
     sofa::linearalgebra::BaseMatrix* mat = r.matrix;
-    Real mFactor = Real(sofa::core::mechanicalparams::mFactorIncludingRayleighDamping(mparams, this->rayleighMass.getValue()));
+    const Real mFactor = Real(sofa::core::mechanicalparams::mFactorIncludingRayleighDamping(mparams, this->rayleighMass.getValue()));
 
     if((mat->colSize()) != (linearalgebra::BaseMatrix::Index)(m_topology->getNbPoints()*N) || (mat->rowSize()) != (linearalgebra::BaseMatrix::Index)(m_topology->getNbPoints()*N))
     {


### PR DESCRIPTION
- A specialization for Mat was not used. 
- Hard-coded doubles are replaced by the right type, which depends on the template
- Floating points are passed by value. 
- A description is added
- Rigid types specialization are factorized






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
