### PR TITLE
[Sofa.Type] Change (?) default constructor for fixed_array

### DIFF
--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/fixed_array.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/fixed_array.h
@@ -78,7 +78,7 @@ public:
     typedef sofa::Size     size_type;
     typedef std::ptrdiff_t difference_type;
 
-    constexpr fixed_array() = default;
+    constexpr fixed_array() {}
 
     /// Specific constructor for 1-element vectors.
     template<size_type NN = N, typename std::enable_if<NN == 1, int>::type = 0>


### PR DESCRIPTION
### Win/MSVC
I was exploring the performance profiler in MSVC on the caduceus, and I noticed that the default constructor of sofa::type::fixed_array was taking a **whole 1% of all the running time**, which was weird to me.

![Capture](https://user-images.githubusercontent.com/11028016/157214662-809a58b4-d153-44ad-9e13-df817896b8dc.PNG)
Even taking more time than the FEM....

Moreover, in the bench:
```
BM_FixedArray_defaultconstruct<stdarray3f>/32768                 30.7 us         30.5 us 
BM_FixedArray_defaultconstruct<sofatypefixedarray3f>/32768       60.6 us         60.0 us
```
`fixed_array` should have the same perf than `std::array`

After some tries, the change to "empty statement {}" instead of `=default` for the default constructor did the trick

```
BM_FixedArray_defaultconstruct<stdarray3f>/32768                 38.0 us         38.5 us
BM_FixedArray_defaultconstruct<sofatypefixedarray3f>/32768       38.1 us         38.5 us 
```

I dont really know why (after spending lots of time on cppreference, stackoverflow, etc) as both of them should not have any initialization on the C-array inside. It seems with the `=default`, MSVC does default-initialization or something like that.
This behavior can be seen with vec3() and vec3(NOINIT)

```
BM_FixedArray_defaultconstruct<stdarray3f>/32768                 32.5 us         33.0 us 
BM_FixedArray_defaultconstruct<sofatypefixedarray3f>/32768       32.7 us         32.2 us 
BM_FixedArray_defaultconstruct<sofa::type::Vec3f>/32768          73.3 us         73.2 us     
BM_FixedArray_defaultconstruct_vec3noinit/32768                  33.0 us         33.0 us 
```
Bench on caduceus (10k steps)
- before : `10000 iterations done in 23.5033 s ( 425.471 FPS)`
- after:   : `10000 iterations done in 21.5335 s ( 464.393 FPS)`

Nice 10% speedup for a really trivial change

### Ubuntu/gcc
Actually on Ubuntu/gcc, the change does nothing as std::array/fixed_array/vec as the same timing (which is good)
```
BM_FixedArray_defaultconstruct<stdarray3f>/32768                 15.6 us         15.6 us 
BM_FixedArray_defaultconstruct<sofatypefixedarray3f>/32768       15.2 us         15.2 us 
BM_FixedArray_defaultconstruct<sofa::type::Vec3f>/32768          15.3 us         15.3 us 
BM_FixedArray_defaultconstruct_vec3noinit/32768                  15.2 us         15.2 us  
```

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
