### PR TITLE
[SofaGuiQt] Error handling when exporting graph

### DIFF
--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/ExportDotVisitor.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/ExportDotVisitor.h
@@ -29,6 +29,10 @@
 namespace sofa::simulation::graph
 {
 
+/**
+ * Write the graph, starting from a root Node, into a std::ostream.
+ * The format is the DOT language from Graphviz (https://graphviz.org/)
+ */
 class SOFA_SIMULATION_CORE_API ExportDotVisitor : public sofa::simulation::Visitor
 {
 public:

--- a/modules/SofaGuiQt/src/sofa/gui/qt/GenGraphForm.h
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/GenGraphForm.h
@@ -47,7 +47,8 @@ public slots:
     virtual void doExport();
     virtual void doDisplay();
     virtual void doClose();
-    virtual void taskFinished();
+    virtual void taskFinished(int exitCode ,QProcess::ExitStatus exitStatus);
+    virtual void taskError(QProcess::ProcessError error);
     virtual void changeFilter();
     virtual void setFilter();
 


### PR DESCRIPTION
Catch error if task could not be started, probably because Graphviz is not found.
Before, nothing mentioned that the feature required Graphviz.

This feature allows to export a graph as an image like:

![test](https://user-images.githubusercontent.com/10572752/157454936-6efab78a-295c-4631-b193-762a1084e878.png)







______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
