### PR TITLE
[SofaCore] Restore xml and python different naming conventions

### DIFF
--- a/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.h
+++ b/SofaKernel/modules/SofaBaseCollision/src/SofaBaseCollision/BruteForceDetection.h
@@ -41,11 +41,11 @@ public:
     static typename T::SPtr create(T*, sofa::core::objectmodel::BaseContext* context, sofa::core::objectmodel::BaseObjectDescription* arg)
     {
         BruteForceBroadPhase::SPtr broadPhase = sofa::core::objectmodel::New<BruteForceBroadPhase>();
-        broadPhase->setName(context->getNameHelper().resolveName(broadPhase->getClassName(), {}));
+        broadPhase->setName(context->getNameHelper().resolveName(broadPhase->getClassName(), core::ComponentNameHelper::Convention::python));
         if (context) context->addObject(broadPhase);
 
         BVHNarrowPhase::SPtr narrowPhase = sofa::core::objectmodel::New<BVHNarrowPhase>();
-        narrowPhase->setName(context->getNameHelper().resolveName(narrowPhase->getClassName(), {}));
+        narrowPhase->setName(context->getNameHelper().resolveName(narrowPhase->getClassName(), core::ComponentNameHelper::Convention::python));
         if (context) context->addObject(narrowPhase);
 
         typename T::SPtr obj = sofa::core::objectmodel::New<T>();

--- a/SofaKernel/modules/SofaCore/src/sofa/core/ComponentNameHelper.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/ComponentNameHelper.cpp
@@ -26,16 +26,24 @@
 namespace sofa::core
 {
 
-std::string ComponentNameHelper::resolveName(const std::string& type, const std::string& name)
+std::string ComponentNameHelper::resolveName(const std::string& type, const std::string& name, Convention convention)
 {
     if (name.empty())
     {
-        const std::string radix = helper::NameDecoder::shortName(type);
-        std::ostringstream oss;
-        oss << radix << m_instanceCounter[radix]++;
-        return oss.str();
+        return resolveName(type, convention);
     }
     return name;
+}
+
+std::string ComponentNameHelper::resolveName(const std::string& type, Convention convention)
+{
+    std::string radix = helper::NameDecoder::shortName(type);
+    if (convention == Convention::xml)
+    {
+        return radix + std::to_string((m_instanceCounter[radix]++) + 1);
+    }
+
+    return radix;
 }
 
 }//namespace sofa::core

--- a/SofaKernel/modules/SofaCore/src/sofa/core/ComponentNameHelper.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/ComponentNameHelper.h
@@ -29,13 +29,24 @@ namespace sofa::core
 {
 
 /**
- * Helper class to get a unique name for a component, based on a counter suffix.
+ * Helper class to name a component based on its type.
+ *
+ * Two conventions are available for legacy reasons:
+ * - XML: use a counter to add a unique suffix at the end of the name
+ * - Python: the short name of the type is returned
  */
 class SOFA_CORE_API ComponentNameHelper
 {
 public:
 
-    std::string resolveName(const std::string& type, const std::string& name);
+    enum class Convention : char
+    {
+        xml,
+        python
+    };
+
+    std::string resolveName(const std::string& type, const std::string& name, Convention convention);
+    std::string resolveName(const std::string& type, Convention convention);
 
 private:
 

--- a/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/xml/ObjectElement.cpp
+++ b/SofaKernel/modules/SofaSimulationCommon/src/SofaSimulationCommon/xml/ObjectElement.cpp
@@ -94,7 +94,7 @@ bool ObjectElement::initNode()
     auto& objName = *obj->name.beginEdit();
     if (objName.empty())
     {
-        objName = ctx->getNameHelper().resolveName(obj->getClassName(), objName);
+        objName = ctx->getNameHelper().resolveName(obj->getClassName(), objName, sofa::core::ComponentNameHelper::Convention::xml);
     }
     obj->name.endEdit();
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Simulation.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/Simulation.cpp
@@ -165,7 +165,7 @@ void Simulation::init ( Node* root )
             "Default Animation Manager Loop will be used. Add DefaultAnimationLoop to the root node of scene file to remove this warning";
         
         DefaultAnimationLoop::SPtr aloop = sofa::core::objectmodel::New<DefaultAnimationLoop>(root);
-        aloop->setName(root->getNameHelper().resolveName(aloop->getClassName(), {}));
+        aloop->setName(root->getNameHelper().resolveName(aloop->getClassName(), sofa::core::ComponentNameHelper::Convention::python));
         root->addObject(aloop,sofa::core::objectmodel::TypeOfInsertion::AtBegin);
     }
 
@@ -175,7 +175,7 @@ void Simulation::init ( Node* root )
             "Default Visual Manager Loop will be used. Add DefaultVisualManagerLoop to the root node of scene file to remove this warning";
 
         DefaultVisualManagerLoop::SPtr vloop = sofa::core::objectmodel::New<DefaultVisualManagerLoop>(root);
-        vloop->setName(root->getNameHelper().resolveName(vloop->getClassName(), {}));
+        vloop->setName(root->getNameHelper().resolveName(vloop->getClassName(), sofa::core::ComponentNameHelper::Convention::python));
         root->addObject(vloop,sofa::core::objectmodel::TypeOfInsertion::AtBegin);
     }
 

--- a/modules/SofaConstraint/src/SofaConstraint/FreeMotionAnimationLoop.cpp
+++ b/modules/SofaConstraint/src/SofaConstraint/FreeMotionAnimationLoop.cpp
@@ -91,7 +91,7 @@ void FreeMotionAnimationLoop::parse ( sofa::core::objectmodel::BaseObjectDescrip
 
     defaultSolver = sofa::core::objectmodel::New<constraintset::LCPConstraintSolver>();
     defaultSolver->parse(arg);
-    defaultSolver->setName(defaultSolver->getContext()->getNameHelper().resolveName(defaultSolver->getClassName(), {}));
+    defaultSolver->setName(defaultSolver->getContext()->getNameHelper().resolveName(defaultSolver->getClassName(), core::ComponentNameHelper::Convention::python));
 }
 
 

--- a/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/DirectSAP.h
+++ b/modules/SofaGeneralMeshCollision/src/SofaGeneralMeshCollision/DirectSAP.h
@@ -42,11 +42,11 @@ public:
     static typename T::SPtr create(T*, sofa::core::objectmodel::BaseContext* context, sofa::core::objectmodel::BaseObjectDescription* arg)
     {
         BruteForceBroadPhase::SPtr broadPhase = sofa::core::objectmodel::New<BruteForceBroadPhase>();
-        broadPhase->setName(context->getNameHelper().resolveName(broadPhase->getClassName(), {}));
+        broadPhase->setName(context->getNameHelper().resolveName(broadPhase->getClassName(), core::ComponentNameHelper::Convention::python));
         if (context) context->addObject(broadPhase);
 
         DirectSAPNarrowPhase::SPtr narrowPhase = sofa::core::objectmodel::New<DirectSAPNarrowPhase>();
-        narrowPhase->setName(context->getNameHelper().resolveName(narrowPhase->getClassName(), {}));
+        narrowPhase->setName(context->getNameHelper().resolveName(narrowPhase->getClassName(), core::ComponentNameHelper::Convention::python));
         if (context) context->addObject(narrowPhase);
 
         typename T::SPtr obj = sofa::core::objectmodel::New<T>();

--- a/modules/SofaGuiCommon/src/sofa/gui/BaseViewer.cpp
+++ b/modules/SofaGuiCommon/src/sofa/gui/BaseViewer.cpp
@@ -208,7 +208,7 @@ bool BaseViewer::load()
         if (!currentCamera)
         {
             currentCamera = sofa::core::objectmodel::New<component::visualmodel::InteractiveCamera>();
-            currentCamera->setName(groot->getNameHelper().resolveName(currentCamera->getClassName(), {}));
+            currentCamera->setName(groot->getNameHelper().resolveName(currentCamera->getClassName(), sofa::core::ComponentNameHelper::Convention::python));
             groot->addObject(currentCamera);
             //currentCamera->p_position.forceSet();
             //currentCamera->p_orientation.forceSet();
@@ -219,7 +219,7 @@ bool BaseViewer::load()
         if (!visualStyle)
         {
             visualStyle = sofa::core::objectmodel::New<component::visualmodel::VisualStyle>();
-            visualStyle->setName(groot->getNameHelper().resolveName(visualStyle->getClassName(), {}));
+            visualStyle->setName(groot->getNameHelper().resolveName(visualStyle->getClassName(), sofa::core::ComponentNameHelper::Convention::python));
 
             core::visual::DisplayFlags* displayFlags = visualStyle->displayFlags.beginEdit();
             displayFlags->setShowVisualModels(sofa::core::visual::tristate::true_value);


### PR DESCRIPTION
Based on the discussion started in https://github.com/sofa-framework/sofa/pull/2631 and finished during a dev meeting, this PR restores the old behavior:
- Two different conventions based on whether the scene is in XML or Python
- XML suffixes start at 1

Nevertheless, the class that provides the names is still common.

[ci-depends-on https://github.com/sofa-framework/SofaPython3/pull/241]

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
