### PR TITLE
[SofaCore] By default, state accessors get the bbox of their states

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/StateAccessor.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/StateAccessor.h
@@ -72,8 +72,8 @@ inline void StateAccessor::computeBBox(const core::ExecParams* params, bool only
 
     static constexpr SReal max_real = std::numeric_limits<SReal>::max();
     static constexpr SReal min_real = std::numeric_limits<SReal>::lowest();
-    SReal maxBBox[3] { min_real, min_real, min_real};
-    SReal minBBox[3] { max_real, max_real, max_real};
+    SReal maxBBox[3] { min_real, min_real, min_real };
+    SReal minBBox[3] { max_real, max_real, max_real };
 
     bool anyMState = false;
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/StateAccessor.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/StateAccessor.h
@@ -48,6 +48,8 @@ public:
         return l_mechanicalStates.getValue();
     }
 
+    void computeBBox(const core::ExecParams* params, bool onlyVisible=false) override;
+
 protected:
 
     StateAccessor()
@@ -62,5 +64,37 @@ protected:
     MultiLink < StateAccessor, BaseMechanicalState, BaseLink::FLAG_DUPLICATE > l_mechanicalStates;
 
 };
+
+
+inline void StateAccessor::computeBBox(const core::ExecParams* params, bool onlyVisible)
+{
+    if( !onlyVisible ) return;
+
+    static constexpr SReal max_real = std::numeric_limits<SReal>::max();
+    static constexpr SReal min_real = std::numeric_limits<SReal>::lowest();
+    SReal maxBBox[3] { min_real, min_real, min_real};
+    SReal minBBox[3] { max_real, max_real, max_real};
+
+    bool anyMState = false;
+
+    for (const auto mstate : l_mechanicalStates)
+    {
+        if (mstate)
+        {
+            const auto& bbox = mstate->f_bbox.getValue();
+            for (unsigned int i = 0; i < 3; ++i)
+            {
+                maxBBox[i] = std::max(maxBBox[i], bbox.maxBBox()[i]);
+                minBBox[i] = std::min(minBBox[i], bbox.minBBox()[i]);
+            }
+            anyMState = true;
+        }
+    }
+
+    if (anyMState)
+    {
+        this->f_bbox.setValue(sofa::type::TBoundingBox(minBBox,maxBBox));
+    }
+}
 
 } // namespace sofa::core::behavior

--- a/examples/Components/constraint/InextensiblePendulum.scn
+++ b/examples/Components/constraint/InextensiblePendulum.scn
@@ -9,6 +9,7 @@
     <RequiredPlugin pluginName='SofaGeneralEngine'/> 
     <RequiredPlugin pluginName='SofaImplicitOdeSolver'/>
     <RequiredPlugin pluginName='SofaMiscMapping'/>
+    <RequiredPlugin name="Sofa.Component.IO.Mesh"/>
 
     <VisualStyle displayFlags="hideVisualModels showBehaviorModels showMappings showForceFields" />
     <FreeMotionAnimationLoop solveVelocityConstraintFirst="true" />

--- a/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
+++ b/modules/SofaGuiQt/src/sofa/gui/qt/RealGUI.cpp
@@ -1001,7 +1001,7 @@ void RealGUI::setSceneWithoutMonitor (Node::SPtr root, const char* filename, boo
         if(nodeBBox.isNegligeable())
         {
             msg_warning("RealGUI") << "Global Bounding Box seems very small; Your viewer settings (based on the bbox) are likely invalid, switching to default value of [-1,-1,-1,1,1,1]."
-                                   << "This is caused by using component which does not implement properly the updateBBox function."
+                                   << "This is caused by using component which does not implement properly the computeBBox function."
                                    << "You can remove this warning by manually forcing a value in the parameter bbox=\"minX minY minZ maxX maxY maxZ\" in your root node \n";
             sofa::type::BoundingBox b(-1.0,-1.0,-1.0,1.0,1.0,1.0);
             root->f_bbox.setValue(b);


### PR DESCRIPTION
Since state accessors work closely with a mstate, it seems logical that they inherit the same bbox.
Note that the mstate must be visited before the accessor in `UpdateBoundingBoxVisitor`.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
