### PR TITLE
[Sofa.Type] Mat: Correct tensorProduct

### DIFF
--- a/SofaKernel/modules/Sofa.Type/Sofa.Type_test/MatTypes_test.cpp
+++ b/SofaKernel/modules/Sofa.Type/Sofa.Type_test/MatTypes_test.cpp
@@ -203,3 +203,13 @@ TEST(MatTypesTest, invert55)
         EXPECT_EQ(M, Mtest);
     }
 }
+
+TEST(MatTypesTest, tensorProduct)
+{
+    Vec<2,SReal> v1(0.,1.), v2(1.,2.);
+    Mat<2, 2, SReal> Mtest = tensorProduct(v1,v2);
+
+    Mat<2, 2, SReal> M(Mat<2, 2, SReal>::Line(0.,  0.),
+                       Mat<2, 2, SReal>::Line( 1., 2.));
+    EXPECT_EQ(M, Mtest);
+}

--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/Mat.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/Mat.h
@@ -1105,9 +1105,8 @@ constexpr Mat<L,L,Real> tensorProduct(const Vec<L,Real> a, const Vec<L,Real> b )
 
     for( typename Mat::Size i=0 ; i<L ; ++i )
     {
-        m[i][i] = a[i]*b[i];
-        for( typename Mat::Size j=i+1 ; j<L ; ++j )
-            m[i][j] = m[j][i] = a[i]*b[j];
+        for( typename Mat::Size j=0 ; j<L ; ++j )
+            m[i][j] = a[i]*b[j];
     }
 
     return m;

--- a/SofaKernel/modules/Sofa.Type/src/sofa/type/Mat.h
+++ b/SofaKernel/modules/Sofa.Type/src/sofa/type/Mat.h
@@ -1098,16 +1098,14 @@ constexpr Mat<3, 3, Real> crossProductMatrix(const Vec<3, Real>& v) noexcept
 
 /// return a * b^T
 template<sofa::Size L,class Real>
-constexpr Mat<L,L,Real> tensorProduct(const Vec<L,Real> a, const Vec<L,Real> b ) noexcept
+constexpr Mat<L,L,Real> tensorProduct(const Vec<L,Real>& a, const Vec<L,Real>& b ) noexcept
 {
-    typedef Mat<L,L,Real> Mat;
+    typedef MatNoInit<L,L,Real> Mat;
     Mat m;
 
     for( typename Mat::Size i=0 ; i<L ; ++i )
-    {
         for( typename Mat::Size j=0 ; j<L ; ++j )
             m[i][j] = a[i]*b[j];
-    }
 
     return m;
 }


### PR DESCRIPTION
The current implementation of the tensor product of two vectors seems incorrect since it assumes the resulting square matrix is always symmetric.
This is not true in general, for example: 
```
tensorProduct([0 1],[1 2]) = [0 1]'*[1 2] 
= [[0,0]
   [1 2]]
```





______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
