### PR TITLE
[Sofa.LinearAlgebra] Deprecate unused EigenMatrixManipulator

### DIFF
--- a/SofaKernel/modules/Sofa.Config/src/sofa/config.h.in
+++ b/SofaKernel/modules/Sofa.Config/src/sofa/config.h.in
@@ -150,7 +150,7 @@ class DeprecatedAndRemoved {};
         SOFA_PRAGMA_WARNING( \
             "This header has been DEPRECATED since " deprecateDate ". " \
             "You have until " disableDate " to fix your code. " \
-            "It will not replaced by another one. " )
+            "It will not be replaced by another one. " )
 
     #define SOFA_DISABLED_HEADER_NOT_REPLACED(deprecateDate, disableDate) \
         SOFA_PRAGMA_ERROR( \
@@ -175,7 +175,7 @@ class DeprecatedAndRemoved {};
         SOFA_PRAGMA_WARNING( \
             This header has been DEPRECATED since deprecateDate. \
             You have until disableDate to fix your code. \
-            It will not replaced by another one. )
+            It will not be replaced by another one. )
 
     #define SOFA_DISABLED_HEADER_NOT_REPLACED(deprecateDate, disableDate) \
         SOFA_PRAGMA_ERROR( \

--- a/SofaKernel/modules/Sofa.LinearAlgebra/src/sofa/linearalgebra/EigenMatrixManipulator.h
+++ b/SofaKernel/modules/Sofa.LinearAlgebra/src/sofa/linearalgebra/EigenMatrixManipulator.h
@@ -39,7 +39,8 @@ typedef Eigen::SparseMatrix<SReal>    SparseMatrixEigen;
 typedef Eigen::SparseVector<SReal>    SparseVectorEigen;
 typedef Eigen::Matrix<SReal, Eigen::Dynamic, 1>       VectorEigen;
 
-struct SOFA_MATRIXMANIPULATOR_DEPRECATED() SOFA_LINEARALGEBRA_API LLineManipulator
+SOFA_MATRIXMANIPULATOR_DEPRECATED()
+struct SOFA_LINEARALGEBRA_API LLineManipulator
 {
     typedef std::pair<unsigned int, SReal> LineCombination;
     typedef type::vector< LineCombination > InternalData;
@@ -73,7 +74,8 @@ protected:
     InternalData _data;
 };
 
-struct SOFA_MATRIXMANIPULATOR_DEPRECATED() SOFA_LINEARALGEBRA_API LMatrixManipulator
+SOFA_MATRIXMANIPULATOR_DEPRECATED()
+struct SOFA_LINEARALGEBRA_API LMatrixManipulator
 {
     void init(const SparseMatrixEigen& L);
 

--- a/SofaKernel/modules/Sofa.LinearAlgebra/src/sofa/linearalgebra/EigenMatrixManipulator.h
+++ b/SofaKernel/modules/Sofa.LinearAlgebra/src/sofa/linearalgebra/EigenMatrixManipulator.h
@@ -39,8 +39,8 @@ typedef Eigen::SparseMatrix<SReal>    SparseMatrixEigen;
 typedef Eigen::SparseVector<SReal>    SparseVectorEigen;
 typedef Eigen::Matrix<SReal, Eigen::Dynamic, 1>       VectorEigen;
 
-SOFA_MATRIXMANIPULATOR_DEPRECATED()
-struct SOFA_LINEARALGEBRA_API LLineManipulator
+SOFA_LINEARALGEBRA_API
+struct SOFA_MATRIXMANIPULATOR_DEPRECATED() LLineManipulator
 {
     typedef std::pair<unsigned int, SReal> LineCombination;
     typedef type::vector< LineCombination > InternalData;
@@ -74,8 +74,8 @@ protected:
     InternalData _data;
 };
 
-SOFA_MATRIXMANIPULATOR_DEPRECATED()
-struct SOFA_LINEARALGEBRA_API LMatrixManipulator
+SOFA_LINEARALGEBRA_API
+struct SOFA_MATRIXMANIPULATOR_DEPRECATED() LMatrixManipulator
 {
     void init(const SparseMatrixEigen& L);
 

--- a/SofaKernel/modules/Sofa.LinearAlgebra/src/sofa/linearalgebra/EigenMatrixManipulator.h
+++ b/SofaKernel/modules/Sofa.LinearAlgebra/src/sofa/linearalgebra/EigenMatrixManipulator.h
@@ -22,6 +22,8 @@
 #pragma once
 #include <sofa/linearalgebra/config.h>
 
+SOFA_DEPRECATED_HEADER_NOT_REPLACED("v22.06", "v23.06")
+
 #include <sofa/type/vector.h>
 
 #include <Eigen/Core>
@@ -37,9 +39,7 @@ typedef Eigen::SparseMatrix<SReal>    SparseMatrixEigen;
 typedef Eigen::SparseVector<SReal>    SparseVectorEigen;
 typedef Eigen::Matrix<SReal, Eigen::Dynamic, 1>       VectorEigen;
 
-struct LMatrixManipulator;
-
-struct SOFA_LINEARALGEBRA_API LLineManipulator
+struct SOFA_MATRIXMANIPULATOR_DEPRECATED() SOFA_LINEARALGEBRA_API LLineManipulator
 {
     typedef std::pair<unsigned int, SReal> LineCombination;
     typedef type::vector< LineCombination > InternalData;
@@ -73,7 +73,7 @@ protected:
     InternalData _data;
 };
 
-struct SOFA_LINEARALGEBRA_API LMatrixManipulator
+struct SOFA_MATRIXMANIPULATOR_DEPRECATED() SOFA_LINEARALGEBRA_API LMatrixManipulator
 {
     void init(const SparseMatrixEigen& L);
 

--- a/SofaKernel/modules/Sofa.LinearAlgebra/src/sofa/linearalgebra/config.h.in
+++ b/SofaKernel/modules/Sofa.LinearAlgebra/src/sofa/linearalgebra/config.h.in
@@ -51,3 +51,9 @@
     SOFA_ATTRIBUTE_DISABLED( \
         "v21.12", "v22.06", \
         "The type 'Bloc' has been renamed in 'Block'. ")
+#define SOFA_MATRIXMANIPULATOR_DEPRECATED() \
+    SOFA_ATTRIBUTE_DEPRECATED( \
+        "v22.06", "v22.12", "")
+#define SOFA_MATRIXMANIPULATOR_DISABLED() \
+    SOFA_ATTRIBUTE_DISABLED( \
+        "v22.12", "v23.06", "")


### PR DESCRIPTION




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
