### PR TITLE
[SofaNG] Setup AnimationLoop

### DIFF
--- a/Component/AnimationLoop/CMakeLists.txt
+++ b/Component/AnimationLoop/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.12)
+project(Sofa.Component.AnimationLoop LANGUAGES CXX)
+
+set(SOFACOMPONENTANIMATIONLOOP_SOURCE_DIR "src/sofa/component/animationloop")
+
+set(HEADER_FILES
+    ${SOFACOMPONENTANIMATIONLOOP_SOURCE_DIR}/config.h.in
+    ${SOFACOMPONENTANIMATIONLOOP_SOURCE_DIR}/FreeMotionAnimationLoop.h
+    ${SOFACOMPONENTANIMATIONLOOP_SOURCE_DIR}/FreeMotionTask.h
+    ${SOFACOMPONENTANIMATIONLOOP_SOURCE_DIR}/ConstraintAnimationLoop.h
+    ${SOFACOMPONENTANIMATIONLOOP_SOURCE_DIR}/MultiStepAnimationLoop.h
+    ${SOFACOMPONENTANIMATIONLOOP_SOURCE_DIR}/MultiTagAnimationLoop.h
+)
+
+set(SOURCE_FILES
+    ${SOFACOMPONENTANIMATIONLOOP_SOURCE_DIR}/init.cpp
+    ${SOFACOMPONENTANIMATIONLOOP_SOURCE_DIR}/FreeMotionAnimationLoop.cpp
+    ${SOFACOMPONENTANIMATIONLOOP_SOURCE_DIR}/FreeMotionTask.cpp
+    ${SOFACOMPONENTANIMATIONLOOP_SOURCE_DIR}/ConstraintAnimationLoop.cpp
+    ${SOFACOMPONENTANIMATIONLOOP_SOURCE_DIR}/MultiStepAnimationLoop.cpp
+    ${SOFACOMPONENTANIMATIONLOOP_SOURCE_DIR}/MultiTagAnimationLoop.cpp
+)
+
+sofa_find_package(Sofa.SimulationCore REQUIRED)
+sofa_find_package(Sofa.Component.Constraint.Lagrangian REQUIRED)
+
+add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
+target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.SimulationCore)
+target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Component.Constraint.Lagrangian)
+
+sofa_create_package_with_targets(
+    PACKAGE_NAME ${PROJECT_NAME}
+    PACKAGE_VERSION ${Sofa_VERSION}
+    TARGETS ${PROJECT_NAME} AUTO_SET_TARGET_PROPERTIES
+    INCLUDE_SOURCE_DIR "src"
+    INCLUDE_INSTALL_DIR "${PROJECT_NAME}"
+)

--- a/Component/AnimationLoop/Sofa.Component.AnimationLoopConfig.cmake.in
+++ b/Component/AnimationLoop/Sofa.Component.AnimationLoopConfig.cmake.in
@@ -1,0 +1,13 @@
+# CMake package configuration file for the @PROJECT_NAME@ module
+
+@PACKAGE_GUARD@
+@PACKAGE_INIT@
+
+find_package(Sofa.SimulationCore QUIET REQUIRED)
+find_package(Sofa.Component.Constraint.Lagrangian QUIET REQUIRED)
+
+if(NOT TARGET @PROJECT_NAME@)
+    include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+endif()
+
+check_required_components(@PROJECT_NAME@)

--- a/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.cpp
+++ b/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.cpp
@@ -22,7 +22,7 @@
 #include <sofa/component/animationloop/ConstraintAnimationLoop.h>
 #include <sofa/core/visual/VisualParams.h>
 
-#include <sofa/component/constraint/lagrangian/ConstraintSolverImpl.h>
+#include <sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h>
 #include <sofa/core/behavior/ConstraintResolution.h>
 
 #include <sofa/simulation/AnimateBeginEvent.h>
@@ -477,7 +477,7 @@ void ConstraintAnimationLoop::getIndividualConstraintViolations(const core::Exec
     cparams.setX(core::ConstVecCoordId::freePosition());
     cparams.setV(core::ConstVecDerivId::freeVelocity());
 
-    constraint::lagrangian::MechanicalGetConstraintViolationVisitor(&cparams, getCP()->getDfree()).execute(context);
+    constraint::lagrangian::solver::MechanicalGetConstraintViolationVisitor(&cparams, getCP()->getDfree()).execute(context);
 }
 
 void ConstraintAnimationLoop::getIndividualConstraintSolvingProcess(const core::ExecParams* params, simulation::Node *context)

--- a/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.cpp
+++ b/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.cpp
@@ -19,10 +19,10 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <SofaConstraint/ConstraintAnimationLoop.h>
+#include <sofa/component/animationloop/ConstraintAnimationLoop.h>
 #include <sofa/core/visual/VisualParams.h>
 
-#include <SofaConstraint/ConstraintSolverImpl.h>
+#include <sofa/component/constraint/lagrangian/ConstraintSolverImpl.h>
 #include <sofa/core/behavior/ConstraintResolution.h>
 
 #include <sofa/simulation/AnimateBeginEvent.h>
@@ -477,7 +477,7 @@ void ConstraintAnimationLoop::getIndividualConstraintViolations(const core::Exec
     cparams.setX(core::ConstVecCoordId::freePosition());
     cparams.setV(core::ConstVecDerivId::freeVelocity());
 
-    constraintset::MechanicalGetConstraintViolationVisitor(&cparams, getCP()->getDfree()).execute(context);
+    constraint::lagrangian::MechanicalGetConstraintViolationVisitor(&cparams, getCP()->getDfree()).execute(context);
 }
 
 void ConstraintAnimationLoop::getIndividualConstraintSolvingProcess(const core::ExecParams* params, simulation::Node *context)

--- a/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.h
+++ b/Component/AnimationLoop/src/sofa/component/animationloop/ConstraintAnimationLoop.h
@@ -20,7 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
-#include <SofaConstraint/config.h>
+#include <sofa/component/animationloop/config.h>
 
 
 #include <sofa/helper/map.h>
@@ -41,7 +41,7 @@
 namespace sofa::component::animationloop
 {
 
-class SOFA_SOFACONSTRAINT_API MechanicalGetConstraintResolutionVisitor : public simulation::BaseMechanicalVisitor
+class SOFA_COMPONENT_ANIMATIONLOOP_API MechanicalGetConstraintResolutionVisitor : public simulation::BaseMechanicalVisitor
 {
 public:
     MechanicalGetConstraintResolutionVisitor(const core::ConstraintParams* params, std::vector<core::behavior::ConstraintResolution*>& res, unsigned int offset)
@@ -59,7 +59,7 @@ private:
 };
 
 
-class SOFA_SOFACONSTRAINT_API MechanicalSetConstraint : public simulation::BaseMechanicalVisitor
+class SOFA_COMPONENT_ANIMATIONLOOP_API MechanicalSetConstraint : public simulation::BaseMechanicalVisitor
 {
 public:
     MechanicalSetConstraint(const core::ConstraintParams* _cparams, core::MultiMatrixDerivId _res, unsigned int &_contactId)
@@ -85,7 +85,7 @@ protected:
 };
 
 
-class SOFA_SOFACONSTRAINT_API MechanicalAccumulateConstraint2 : public simulation::BaseMechanicalVisitor
+class SOFA_COMPONENT_ANIMATIONLOOP_API MechanicalAccumulateConstraint2 : public simulation::BaseMechanicalVisitor
 {
 public:
     MechanicalAccumulateConstraint2(const core::ConstraintParams* _cparams, core::MultiMatrixDerivId _res)
@@ -109,7 +109,7 @@ protected:
 };
 
 
-class SOFA_SOFACONSTRAINT_API ConstraintProblem
+class SOFA_COMPONENT_ANIMATIONLOOP_API ConstraintProblem
 {
 protected:
     sofa::linearalgebra::LPtrFullMatrix<double> _W;
@@ -139,7 +139,7 @@ public:
 
 
 
-class SOFA_SOFACONSTRAINT_API ConstraintAnimationLoop : public sofa::simulation::CollisionAnimationLoop
+class SOFA_COMPONENT_ANIMATIONLOOP_API ConstraintAnimationLoop : public sofa::simulation::CollisionAnimationLoop
 {
 public:
     typedef sofa::simulation::CollisionAnimationLoop Inherit;

--- a/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
+++ b/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
@@ -19,10 +19,10 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <SofaConstraint/FreeMotionAnimationLoop.h>
+#include <sofa/component/animationloop/FreeMotionAnimationLoop.h>
 #include <sofa/core/visual/VisualParams.h>
 
-#include <SofaConstraint/LCPConstraintSolver.h>
+#include <sofa/component/constraint/lagrangian/LCPConstraintSolver.h>
 
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/VecId.h>
@@ -41,7 +41,7 @@
 #include <sofa/simulation/UpdateMappingEndEvent.h>
 #include <sofa/simulation/UpdateBoundingBoxVisitor.h>
 #include <sofa/simulation/TaskScheduler.h>
-#include <SofaConstraint/FreeMotionTask.h>
+#include <sofa/component/animationloop/FreeMotionTask.h>
 #include <sofa/simulation/CollisionVisitor.h>
 
 #include <sofa/simulation/mechanicalvisitor/MechanicalVInitVisitor.h>
@@ -89,7 +89,7 @@ void FreeMotionAnimationLoop::parse ( sofa::core::objectmodel::BaseObjectDescrip
 {
     simulation::CollisionAnimationLoop::parse(arg);
 
-    defaultSolver = sofa::core::objectmodel::New<constraintset::LCPConstraintSolver>();
+    defaultSolver = sofa::core::objectmodel::New<constraint::lagrangian::LCPConstraintSolver>();
     defaultSolver->parse(arg);
     defaultSolver->setName(defaultSolver->getContext()->getNameHelper().resolveName(defaultSolver->getClassName(), core::ComponentNameHelper::Convention::python));
 }

--- a/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
+++ b/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionAnimationLoop.cpp
@@ -22,7 +22,7 @@
 #include <sofa/component/animationloop/FreeMotionAnimationLoop.h>
 #include <sofa/core/visual/VisualParams.h>
 
-#include <sofa/component/constraint/lagrangian/LCPConstraintSolver.h>
+#include <sofa/component/constraint/lagrangian/solver/LCPConstraintSolver.h>
 
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/VecId.h>
@@ -89,7 +89,7 @@ void FreeMotionAnimationLoop::parse ( sofa::core::objectmodel::BaseObjectDescrip
 {
     simulation::CollisionAnimationLoop::parse(arg);
 
-    defaultSolver = sofa::core::objectmodel::New<constraint::lagrangian::LCPConstraintSolver>();
+    defaultSolver = sofa::core::objectmodel::New<constraint::lagrangian::solver::LCPConstraintSolver>();
     defaultSolver->parse(arg);
     defaultSolver->setName(defaultSolver->getContext()->getNameHelper().resolveName(defaultSolver->getClassName(), core::ComponentNameHelper::Convention::python));
 }

--- a/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionTask.cpp
+++ b/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionTask.cpp
@@ -20,7 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
-#include <SofaConstraint/FreeMotionTask.h>
+#include <sofa/component/animationloop/FreeMotionTask.h>
 
 #include <sofa/helper/ScopedAdvancedTimer.h>
 #include <sofa/simulation/SolveVisitor.h>
@@ -31,7 +31,8 @@
 #include <sofa/simulation/mechanicalvisitor/MechanicalVOpVisitor.h>
 using sofa::simulation::mechanicalvisitor::MechanicalVOpVisitor;
 
-namespace sofa::component::animationloop {
+namespace sofa::component::animationloop 
+{
 
 FreeMotionTask::FreeMotionTask(sofa::simulation::Node* node,
                                const sofa::core::ExecParams* params,
@@ -80,4 +81,4 @@ sofa::simulation::Task::MemoryAlloc FreeMotionTask::run()
     return simulation::Task::Stack;
 }
 
-}
+} // namespace sofa::component::animationloop

--- a/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionTask.h
+++ b/Component/AnimationLoop/src/sofa/component/animationloop/FreeMotionTask.h
@@ -66,4 +66,4 @@ private:
     bool m_parallelSolve {false };
 };
 
-}
+} // namespace sofa::component::animationloop

--- a/Component/AnimationLoop/src/sofa/component/animationloop/MultiStepAnimationLoop.cpp
+++ b/Component/AnimationLoop/src/sofa/component/animationloop/MultiStepAnimationLoop.cpp
@@ -19,7 +19,8 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <SofaGeneralAnimationLoop/MultiStepAnimationLoop.h>
+#include <sofa/component/animationloop/MultiStepAnimationLoop.h>
+
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/simulation/MechanicalVisitor.h>
@@ -33,8 +34,6 @@
 #include <sofa/simulation/UpdateContextVisitor.h>
 #include <sofa/simulation/UpdateMappingVisitor.h>
 #include <sofa/helper/ScopedAdvancedTimer.h>
-#include <cmath>
-#include <iostream>
 
 #include <sofa/simulation/mechanicalvisitor/MechanicalResetConstraintVisitor.h>
 using sofa::simulation::mechanicalvisitor::MechanicalResetConstraintVisitor;
@@ -145,4 +144,3 @@ void MultiStepAnimationLoop::step(const sofa::core::ExecParams* params, SReal dt
 }
 
 } // namespace sofa::component::animationloop
-

--- a/Component/AnimationLoop/src/sofa/component/animationloop/MultiStepAnimationLoop.h
+++ b/Component/AnimationLoop/src/sofa/component/animationloop/MultiStepAnimationLoop.h
@@ -20,31 +20,28 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
-#include <SofaConstraint/config.h>
 
+#include <sofa/component/animationloop/config.h>
+
+#include <sofa/core/behavior/BaseAnimationLoop.h>
 #include <sofa/simulation/CollisionAnimationLoop.h>
-#include <sofa/core/MultiVecId.h>
-
-namespace sofa::core::behavior
-{
-    class ConstraintSolver;
-}
 
 namespace sofa::component::animationloop
 {
 
-class SOFA_SOFACONSTRAINT_API FreeMotionAnimationLoop : public sofa::simulation::CollisionAnimationLoop
+class SOFA_COMPONENT_ANIMATIONLOOP_API MultiStepAnimationLoop : public sofa::simulation::CollisionAnimationLoop
 {
 public:
-    SOFA_CLASS(FreeMotionAnimationLoop, sofa::simulation::CollisionAnimationLoop);
+    typedef sofa::simulation::CollisionAnimationLoop Inherit;
+    SOFA_CLASS(MultiStepAnimationLoop, sofa::simulation::CollisionAnimationLoop);
+protected:
+    MultiStepAnimationLoop(simulation::Node* gnode);
 
+    ~MultiStepAnimationLoop() override;
 public:
     void step (const sofa::core::ExecParams* params, SReal dt) override;
-    void init() override;
-    void parse ( sofa::core::objectmodel::BaseObjectDescription* arg ) override;
 
-    /// Construction method called by ObjectFactory. An animation loop can only
-    /// be created if
+    /// Construction method called by ObjectFactory.
     template<class T>
     static typename T::SPtr create(T*, BaseContext* context, BaseObjectDescription* arg)
     {
@@ -55,26 +52,8 @@ public:
         return obj;
     }
 
-    Data<bool> m_solveVelocityConstraintFirst; ///< solve separately velocity constraint violations before position constraint violations
-    Data<bool> d_threadSafeVisitor; ///< If true, do not use realloc and free visitors in fwdInteractionForceField.
-    Data<bool> d_parallelCollisionDetectionAndFreeMotion; ///<If true, executes free motion and collision detection in parallel
-    Data<bool> d_parallelODESolving; ///<If true, executes all free motions in parallel
-
-protected:
-    FreeMotionAnimationLoop(simulation::Node* gnode);
-    ~FreeMotionAnimationLoop() override ;
-
-    ///< pointer towards a default ConstraintSolver (LCPConstraintSolver) used in case none was found in the scene graph
-    sofa::core::sptr<sofa::core::behavior::ConstraintSolver> defaultSolver;
-
-    ///< The ConstraintSolver used in this animation loop (required)
-    SingleLink<FreeMotionAnimationLoop, sofa::core::behavior::ConstraintSolver, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_constraintSolver;
-
-    void FreeMotionAndCollisionDetection(const sofa::core::ExecParams* params, const core::ConstraintParams& cparams, SReal dt,
-                                         sofa::core::MultiVecId pos,
-                                         sofa::core::MultiVecId freePos,
-                                         sofa::core::MultiVecDerivId freeVel,
-                                         simulation::common::MechanicalOperations* mop);
+    Data<int> collisionSteps; ///< number of collision steps between each frame rendering
+    Data<int> integrationSteps; ///< number of integration steps between each collision detection
 };
 
 } // namespace sofa::component::animationloop

--- a/Component/AnimationLoop/src/sofa/component/animationloop/MultiTagAnimationLoop.cpp
+++ b/Component/AnimationLoop/src/sofa/component/animationloop/MultiTagAnimationLoop.cpp
@@ -19,7 +19,8 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <SofaGeneralAnimationLoop/MultiTagAnimationLoop.h>
+#include <sofa/component/animationloop/MultiTagAnimationLoop.h>
+
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/simulation/MechanicalVisitor.h>
@@ -33,8 +34,6 @@
 #include <sofa/simulation/UpdateMappingEndEvent.h>
 #include <sofa/simulation/UpdateBoundingBoxVisitor.h>
 #include <sofa/helper/ScopedAdvancedTimer.h>
-#include <cmath>
-#include <iostream>
 
 #include <sofa/simulation/mechanicalvisitor/MechanicalResetConstraintVisitor.h>
 using sofa::simulation::mechanicalvisitor::MechanicalResetConstraintVisitor;
@@ -156,7 +155,5 @@ void MultiTagAnimationLoop::clear()
         tagList.clear();
     }
 }
-
-
 
 } // namespace sofa::component::animationloop

--- a/Component/AnimationLoop/src/sofa/component/animationloop/MultiTagAnimationLoop.h
+++ b/Component/AnimationLoop/src/sofa/component/animationloop/MultiTagAnimationLoop.h
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #pragma once
 
-#include <SofaGeneralAnimationLoop/config.h>
+#include <sofa/component/animationloop/config.h>
 
 #include <sofa/core/behavior/BaseAnimationLoop.h>
 #include <sofa/simulation/CollisionAnimationLoop.h>
@@ -31,7 +31,7 @@ namespace sofa::component::animationloop
 
 /** Simple animation loop that given a list of tags, animate the graph one tag after another.
 */
-class SOFA_SOFAGENERALANIMATIONLOOP_API MultiTagAnimationLoop : public sofa::simulation::CollisionAnimationLoop
+class SOFA_COMPONENT_ANIMATIONLOOP_API MultiTagAnimationLoop : public sofa::simulation::CollisionAnimationLoop
 {
 public:
     typedef sofa::simulation::CollisionAnimationLoop Inherit;

--- a/Component/AnimationLoop/src/sofa/component/animationloop/config.h.in
+++ b/Component/AnimationLoop/src/sofa/component/animationloop/config.h.in
@@ -1,0 +1,37 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/config.h>
+#include <sofa/config/sharedlibrary_defines.h>
+
+#ifdef SOFA_BUILD_SOFA_COMPONENT_ANIMATIONLOOP
+#  define SOFA_TARGET @PROJECT_NAME@
+#  define SOFA_COMPONENT_ANIMATIONLOOP_API SOFA_EXPORT_DYNAMIC_LIBRARY
+#else
+#  define SOFA_COMPONENT_ANIMATIONLOOP_API SOFA_IMPORT_DYNAMIC_LIBRARY
+#endif
+
+namespace sofa::component::animationloop
+{
+	constexpr const char* MODULE_NAME = "@PROJECT_NAME@";
+} // namespace sofa::component::animationloop

--- a/Component/AnimationLoop/src/sofa/component/animationloop/init.cpp
+++ b/Component/AnimationLoop/src/sofa/component/animationloop/init.cpp
@@ -19,69 +19,33 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include <SofaGeneralAnimationLoop/initSofaGeneralAnimationLoop.h>
+#include <sofa/component/animationloop/init.h>
 
-#include <sofa/helper/system/PluginManager.h>
-
-#include <sofa/core/ObjectFactory.h>
-using sofa::core::ObjectFactory;
-
-namespace sofa::component
+namespace sofa::component::animationloop
 {
-
-void initSofaGeneralAnimationLoop()
-{
-    static bool first = true;
-    if (first)
-    {
-        // msg_deprecated("SofaGeneralAnimationLoop") << "SofaGeneralAnimationLoop is deprecated. It will be removed at v23.06. You may use Sofa.Component.Mapping.MappedMatrix and Sofa.Component.AnimationLoop instead.";
-
-        sofa::helper::system::PluginManager::getInstance().loadPlugin("Sofa.Component.Mapping.MappedMatrix");
-        sofa::helper::system::PluginManager::getInstance().loadPlugin("Sofa.Component.AnimationLoop");
-
-        first = false;
-    }
-}
-
+    
 extern "C" {
-    SOFA_SOFAGENERALANIMATIONLOOP_API void initExternalModule();
-    SOFA_SOFAGENERALANIMATIONLOOP_API const char* getModuleName();
-    SOFA_SOFAGENERALANIMATIONLOOP_API const char* getModuleVersion();
-    SOFA_SOFAGENERALANIMATIONLOOP_API const char* getModuleLicense();
-    SOFA_SOFAGENERALANIMATIONLOOP_API const char* getModuleDescription();
-    SOFA_SOFAGENERALANIMATIONLOOP_API const char* getModuleComponentList();
+    SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
+    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
 }
 
 void initExternalModule()
 {
-    initSofaGeneralAnimationLoop();
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
 }
 
 const char* getModuleName()
 {
-    return sofa_tostring(SOFA_TARGET);
+    return MODULE_NAME;
 }
 
-const char* getModuleVersion()
+void init()
 {
-    return sofa_tostring(SOFAGENERALANIMATIONLOOP_VERSION);
+    initExternalModule();
 }
 
-const char* getModuleLicense()
-{
-    return "LGPL";
-}
-
-const char* getModuleDescription()
-{
-    return "This plugin contains contains features about General Animation Loop.";
-}
-
-const char* getModuleComponentList()
-{
-    /// string containing the names of the classes provided by the plugin
-    static std::string classes = ObjectFactory::getInstance()->listClassesFromTarget(sofa_tostring(SOFA_TARGET));
-    return classes.c_str();
-}
-
-} // namespace sofa::component
+} // namespace sofa::component::animationloop

--- a/Component/AnimationLoop/src/sofa/component/animationloop/init.h
+++ b/Component/AnimationLoop/src/sofa/component/animationloop/init.h
@@ -1,0 +1,29 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/component/animationloop/config.h>
+
+namespace sofa::component::animationloop
+{
+    SOFA_COMPONENT_ANIMATIONLOOP_API void init();
+} // namespace sofa::component::animationloop

--- a/Component/CMakeLists.txt
+++ b/Component/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 set(SOFACOMPONENT_SOURCE_DIR "src/sofa/component")
 
-set(SOFACOMPONENT_DIRS ODESolver IO Playback SceneUtility Topology Visual LinearSolver Mass Diffusion Mapping SolidMechanics StateContainer Constraint) # AnimationLoop Mapping Collision Engine UI Controller) # Device
+set(SOFACOMPONENT_DIRS ODESolver IO Playback SceneUtility Topology Visual LinearSolver Mass Diffusion Mapping SolidMechanics StateContainer Constraint AnimationLoop) # Collision Engine UI Controller) # Device
 set(SOFACOMPONENT_TARGETS)
 foreach(component_dir ${SOFACOMPONENT_DIRS})
 	sofang_add_component_subdirectory(${component_dir} ${PROJECT_NAME}.${component_dir})

--- a/Component/Compat/CMakeLists.txt
+++ b/Component/Compat/CMakeLists.txt
@@ -36,6 +36,7 @@ include(Sofa.Component.Constraint.Lagrangian.Model.cmake)
 include(Sofa.Component.Constraint.Lagrangian.Correction.cmake)
 include(Sofa.Component.Constraint.Lagrangian.Solver.cmake)
 include(Sofa.Component.Constraint.Projective.cmake)
+include(Sofa.Component.AnimationLoop.cmake)
 
 set(SOURCE_FILES
     ${SOFACOMPONENTCOMPATSRC_ROOT}/init.cpp

--- a/Component/Compat/Sofa.Component.AnimationLoop.cmake
+++ b/Component/Compat/Sofa.Component.AnimationLoop.cmake
@@ -1,0 +1,10 @@
+set(SOFACONSTRAINT_SRC src/SofaConstraint)
+set(SOFAGENERALANIMATIONLOOP_SRC src/SofaGeneralAnimationLoop)
+
+list(APPEND HEADER_FILES
+    ${SOFACONSTRAINT_SRC}/FreeMotionAnimationLoop.h
+    ${SOFACONSTRAINT_SRC}/FreeMotionTask.h
+    ${SOFACONSTRAINT_SRC}/ConstraintAnimationLoop.h
+    ${SOFAGENERALANIMATIONLOOP_SRC}/MultiStepAnimationLoop.h
+    ${SOFAGENERALANIMATIONLOOP_SRC}/MultiTagAnimationLoop.h
+)

--- a/Component/Compat/src/SofaConstraint/ConstraintAnimationLoop.h
+++ b/Component/Compat/src/SofaConstraint/ConstraintAnimationLoop.h
@@ -1,0 +1,26 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/component/animationloop/ConstraintAnimationLoop.h>
+
+// SOFA_DEPRECATED_HEADER("v22.06", "v23.06", "sofa/component/animationloop/ConstraintAnimationLoop.h")

--- a/Component/Compat/src/SofaConstraint/FreeMotionAnimationLoop.h
+++ b/Component/Compat/src/SofaConstraint/FreeMotionAnimationLoop.h
@@ -1,0 +1,26 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/component/animationloop/FreeMotionAnimationLoop.h>
+
+// SOFA_DEPRECATED_HEADER("v22.06", "v23.06", "sofa/component/animationloop/FreeMotionAnimationLoop.h")

--- a/Component/Compat/src/SofaConstraint/FreeMotionTask.h
+++ b/Component/Compat/src/SofaConstraint/FreeMotionTask.h
@@ -1,0 +1,26 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/component/animationloop/FreeMotionTask.h>
+
+// SOFA_DEPRECATED_HEADER("v22.06", "v23.06", "sofa/component/animationloop/FreeMotionTask.h")

--- a/Component/Compat/src/SofaGeneralAnimationLoop/MultiStepAnimationLoop.h
+++ b/Component/Compat/src/SofaGeneralAnimationLoop/MultiStepAnimationLoop.h
@@ -1,0 +1,26 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/component/animationloop/MultiStepAnimationLoop.h>
+
+// SOFA_DEPRECATED_HEADER("v22.06", "v23.06", "sofa/component/animationloop/MultiStepAnimationLoop.h")

--- a/Component/Compat/src/SofaGeneralAnimationLoop/MultiTagAnimationLoop.h
+++ b/Component/Compat/src/SofaGeneralAnimationLoop/MultiTagAnimationLoop.h
@@ -1,0 +1,26 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/component/animationloop/MultiTagAnimationLoop.h>
+
+// SOFA_DEPRECATED_HEADER("v22.06", "v23.06", "sofa/component/animationloop/MultiTagAnimationLoop.h")

--- a/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.cpp
+++ b/SofaKernel/modules/SofaHelper/src/sofa/helper/ComponentChange.cpp
@@ -961,7 +961,7 @@ const std::map< std::string, CreatableMoved, std::less<> > movedComponents =
     { "TubularMapping", CreatableMoved("v22.06", "SofaMiscMapping", "Sofa.Component.Mapping.Linear") },
     { "VoidMapping", CreatableMoved("v22.06", "SofaMiscMapping", "Sofa.Component.Mapping.Linear") },
 
-    // SofaConstraint was deprecated in #2635, #2790 and ...
+    // SofaConstraint was deprecated in #2635, #2790 and #2796
     { "MappingGeometricStiffnessForceField", CreatableMoved("v22.06", "SofaConstraint", "Sofa.Component.Mapping.MappedMatrix") },
     { "BilateralInteractionConstraint", CreatableMoved("v22.06", "SofaConstraint", "Sofa.Component.Constraint.Lagrangian.Model") },
     { "GenericConstraintCorrection", CreatableMoved("v22.06", "SofaConstraint", "Sofa.Component.Constraint.Lagrangian.Correction") },
@@ -974,9 +974,13 @@ const std::map< std::string, CreatableMoved, std::less<> > movedComponents =
     { "UncoupledConstraintCorrection", CreatableMoved("v22.06", "SofaConstraint", "Sofa.Component.Constraint.Lagrangian.Correction") },
     { "UniformConstraint", CreatableMoved("v22.06", "SofaConstraint", "Sofa.Component.Constraint.Lagrangian.Model") },
     { "UnilateralInteractionConstraint", CreatableMoved("v22.06", "SofaConstraint", "Sofa.Component.Constraint.Lagrangian.Model") },
+    { "ConstraintAnimationLoop", CreatableMoved("v22.06", "SofaConstraint", "Sofa.Component.AnimationLoop") },
+    { "FreeMotionAnimationLoop", CreatableMoved("v22.06", "SofaConstraint", "Sofa.Component.AnimationLoop") },
 
-    // SofaGeneralAnimationLoop was deprecated in #2635 and ...
+    // SofaGeneralAnimationLoop was deprecated in #2635 and #2796
     { "MechanicalMatrixMapper", CreatableMoved("v22.06", "SofaGeneralAnimationLoop", "Sofa.Component.Mapping.MappedMatrix") },
+    { "MultiStepAnimationLoop", CreatableMoved("v22.06", "SofaGeneralAnimationLoop", "Sofa.Component.AnimationLoop") },
+    { "MultiTagAnimationLoop", CreatableMoved("v22.06", "SofaGeneralAnimationLoop", "Sofa.Component.AnimationLoop") },
 
     // SofaSimpleFem was deprecated in #2759
     { "HexahedronFEMForceField", CreatableMoved("v22.06", "SofaSimpleFem", "Sofa.Component.SolidMechanics.FEM.Elastic") },
@@ -1035,7 +1039,7 @@ const std::map< std::string, CreatableMoved, std::less<> > movedComponents =
 
     // SofaGeneralObjectInteraction was deprecated in #2759
     { "RepulsiveSpringForceField", CreatableMoved("v22.06", "SofaGeneralObjectInteraction", "Sofa.Component.SolidMechanics.Spring") },
-    
+
     // SofaGeneralObjectInteraction was deprecated in #2790 and ...
     { "AttachConstraint", CreatableMoved("v22.06", "SofaGeneralObjectInteraction", "Sofa.Component.Constraint.Projective") },
 

--- a/modules/SofaConstraint/CMakeLists.txt
+++ b/modules/SofaConstraint/CMakeLists.txt
@@ -13,12 +13,9 @@ set(SOURCE_FILES
     )
 
 list(APPEND HEADER_FILES
-    ${SOFACONSTRAINT_SRC}/ConstraintAnimationLoop.h
     ${SOFACONSTRAINT_SRC}/ConstraintAttachBodyPerformer.h
     ${SOFACONSTRAINT_SRC}/ConstraintAttachBodyPerformer.inl
     ${SOFACONSTRAINT_SRC}/ContactIdentifier.h
-    ${SOFACONSTRAINT_SRC}/FreeMotionAnimationLoop.h
-    ${SOFACONSTRAINT_SRC}/FreeMotionTask.h
     ${SOFACONSTRAINT_SRC}/FrictionContact.h
     ${SOFACONSTRAINT_SRC}/FrictionContact.inl
     ${SOFACONSTRAINT_SRC}/LocalMinDistance.h
@@ -26,11 +23,8 @@ list(APPEND HEADER_FILES
     ${SOFACONSTRAINT_SRC}/StickContactConstraint.inl
     )
 list(APPEND SOURCE_FILES
-    ${SOFACONSTRAINT_SRC}/ConstraintAnimationLoop.cpp
     ${SOFACONSTRAINT_SRC}/ConstraintAttachBodyPerformer.cpp
     ${SOFACONSTRAINT_SRC}/ContactIdentifier.cpp
-    ${SOFACONSTRAINT_SRC}/FreeMotionAnimationLoop.cpp
-    ${SOFACONSTRAINT_SRC}/FreeMotionTask.cpp
     ${SOFACONSTRAINT_SRC}/FrictionContact.cpp
     ${SOFACONSTRAINT_SRC}/LocalMinDistance.cpp
     ${SOFACONSTRAINT_SRC}/StickContactConstraint.cpp
@@ -44,17 +38,19 @@ sofa_find_package(SofaUserInteraction REQUIRED)
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaMeshCollision SofaImplicitOdeSolver SofaUserInteraction SofaBaseLinearSolver)
 
-message(WARNING "${PROJECT_NAME} module is being deprecated. It will be removed at v23.06. You may use Sofa.Component.Mapping.MappedMatrix, Sofa.Component.Constraint.Lagrangian.Model, Sofa.Component.Constraint.Lagrangian.Correction and Sofa.Component.Constraint.Lagrangian.Solver instead.")
+message(WARNING "${PROJECT_NAME} module is being deprecated. It will be removed at v23.06. You may use Sofa.Component.Mapping.MappedMatrix, Sofa.Component.Constraint.Lagrangian.Model, Sofa.Component.Constraint.Lagrangian.Correction, Sofa.Component.Constraint.Lagrangian.Solver and Sofa.Component.AnimationLoop instead.")
 
 # forward to the new sofang module
 sofa_find_package(Sofa.Component.Mapping.MappedMatrix REQUIRED)
 sofa_find_package(Sofa.Component.Constraint.Lagrangian.Model REQUIRED)
 sofa_find_package(Sofa.Component.Constraint.Lagrangian.Correction REQUIRED)
 sofa_find_package(Sofa.Component.Constraint.Lagrangian.Solver REQUIRED)
+sofa_find_package(Sofa.Component.AnimationLoop REQUIRED)
 target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Component.Mapping.MappedMatrix)
 target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Component.Constraint.Lagrangian.Model)
 target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Component.Constraint.Lagrangian.Correction)
 target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Component.Constraint.Lagrangian.Solver)
+target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Component.AnimationLoop)
 
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}

--- a/modules/SofaConstraint/SofaConstraintConfig.cmake.in
+++ b/modules/SofaConstraint/SofaConstraintConfig.cmake.in
@@ -5,7 +5,7 @@
 
 get_property(@PROJECT_NAME@_SENT_DEPRECATION_MESSAGE GLOBAL PROPERTY PROPERTY_@PROJECT_NAME@_SENT_DEPRECATION_MESSAGE SET)
 if(NOT @PROJECT_NAME@_SENT_DEPRECATION_MESSAGE)
-    message(WARNING "@PROJECT_NAME@ module is being deprecated. It will be removed at v23.06. You may use Sofa.Component.Mapping.MappedMatrix, Sofa.Component.Constraint.Lagrangian.Model, Sofa.Component.Constraint.Lagrangian.Correction and Sofa.Component.Constraint.Lagrangian.Solver instead.")
+    message(WARNING "@PROJECT_NAME@ module is being deprecated. It will be removed at v23.06. You may use Sofa.Component.Mapping.MappedMatrix, Sofa.Component.Constraint.Lagrangian.Model, Sofa.Component.Constraint.Lagrangian.Correction, Sofa.Component.Constraint.Lagrangian.Solver and Sofa.Component.AnimationLoop instead.")
 endif()
 set_property(GLOBAL PROPERTY PROPERTY_@PROJECT_NAME@_SENT_DEPRECATION_MESSAGE TRUE)
 
@@ -17,6 +17,7 @@ find_package(Sofa.Component.Mapping.MappedMatrix QUIET REQUIRED)
 find_package(Sofa.Component.Constraint.Lagrangian.Model QUIET REQUIRED)
 find_package(Sofa.Component.Constraint.Lagrangian.Correction QUIET REQUIRED)
 find_package(Sofa.Component.Constraint.Lagrangian.Solver QUIET REQUIRED)
+find_package(Sofa.Component.AnimationLoop QUIET REQUIRED)
 
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/modules/SofaConstraint/src/SofaConstraint/initSofaConstraint.cpp
+++ b/modules/SofaConstraint/src/SofaConstraint/initSofaConstraint.cpp
@@ -34,12 +34,13 @@ void initSofaConstraint()
     static bool first = true;
     if (first)
     {
-        // msg_deprecated("SofaConstraint") << "SofaConstraint is deprecated. It will be removed at v23.06. You may use Sofa.Component.Mapping.MappedMatrix, Sofa.Component.Constraint.Lagrangian.Model, Sofa.Component.Constraint.Lagrangian.Correction and Sofa.Component.Constraint.Lagrangian.Solver instead.";
+        // msg_deprecated("SofaConstraint") << "SofaConstraint is deprecated. It will be removed at v23.06. You may use Sofa.Component.Mapping.MappedMatrix, Sofa.Component.Constraint.Lagrangian.Model, Sofa.Component.Constraint.Lagrangian.Correction, Sofa.Component.Constraint.Lagrangian.Solver and Sofa.Component.AnimationLoop instead.";
 
         sofa::helper::system::PluginManager::getInstance().loadPlugin("Sofa.Component.Mapping.MappedMatrix");
         sofa::helper::system::PluginManager::getInstance().loadPlugin("Sofa.Component.Constraint.Lagrangian.Model");
         sofa::helper::system::PluginManager::getInstance().loadPlugin("Sofa.Component.Constraint.Lagrangian.Correction");
         sofa::helper::system::PluginManager::getInstance().loadPlugin("Sofa.Component.Constraint.Lagrangian.Solver");
+        sofa::helper::system::PluginManager::getInstance().loadPlugin("Sofa.Component.AnimationLoop");
 
         first = false;
     }

--- a/modules/SofaGeneralAnimationLoop/CMakeLists.txt
+++ b/modules/SofaGeneralAnimationLoop/CMakeLists.txt
@@ -12,24 +12,15 @@ set(SOURCE_FILES
     ${SOFAGENERALANIMATIONLOOP_SRC}/initSofaGeneralAnimationLoop.cpp
     )
 
-list(APPEND HEADER_FILES
-    ${SOFAGENERALANIMATIONLOOP_SRC}/MultiStepAnimationLoop.h
-    ${SOFAGENERALANIMATIONLOOP_SRC}/MultiTagAnimationLoop.h)
-
-list(APPEND SOURCE_FILES
-    ${SOFAGENERALANIMATIONLOOP_SRC}/MultiStepAnimationLoop.cpp
-    ${SOFAGENERALANIMATIONLOOP_SRC}/MultiTagAnimationLoop.cpp)
-
-sofa_find_package(SofaBase REQUIRED) # SofaBaseLinearSolver
-
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaSimulationCommon SofaBaseLinearSolver)
 
-message(WARNING "${PROJECT_NAME} module is being deprecated. It will be removed at v23.06. You may use Sofa.Component.Mapping.MappedMatrix instead.")
+message(WARNING "${PROJECT_NAME} module is deprecated. It will be removed at v23.06. Use Sofa.Component.Mapping.MappedMatrix and Sofa.Component.AnimationLoop instead.")
 
 # forward to the new sofang module
 sofa_find_package(Sofa.Component.Mapping.MappedMatrix REQUIRED)
+sofa_find_package(Sofa.Component.AnimationLoop REQUIRED)
 target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Component.Mapping.MappedMatrix)
+target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Component.AnimationLoop)
 
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}

--- a/modules/SofaGeneralAnimationLoop/SofaGeneralAnimationLoopConfig.cmake.in
+++ b/modules/SofaGeneralAnimationLoop/SofaGeneralAnimationLoopConfig.cmake.in
@@ -5,13 +5,14 @@
 
 get_property(@PROJECT_NAME@_SENT_DEPRECATION_MESSAGE GLOBAL PROPERTY PROPERTY_@PROJECT_NAME@_SENT_DEPRECATION_MESSAGE SET)
 if(NOT @PROJECT_NAME@_SENT_DEPRECATION_MESSAGE)
-    message(WARNING "@PROJECT_NAME@ module is being deprecated. It will be removed at v23.06. You may use Sofa.Component.Mapping.MappedMatrix instead.")
+    message(WARNING "@PROJECT_NAME@ module is being deprecated. It will be removed at v23.06. Use Sofa.Component.Mapping.MappedMatrix and Sofa.Component.AnimationLoop instead.")
 endif()
 set_property(GLOBAL PROPERTY PROPERTY_@PROJECT_NAME@_SENT_DEPRECATION_MESSAGE TRUE)
 
 find_package(SofaBase QUIET REQUIRED)
 find_package(SofaSimulationCommon QUIET REQUIRED)
 find_package(Sofa.Component.Mapping.MappedMatrix QUIET REQUIRED)
+find_package(Sofa.Component.AnimationLoop QUIET REQUIRED)
 
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
#1527 

based on:
- #2790

Deprecates partially **SofaConstraint**
Deprecates **SofaGeneralAnimationLoop**

Module with all the non-default animation loop.
DefaultAL stays in Core to allow scene to run even if one did not build this module (and its deps).

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
