### PR TITLE
[Sofa.Component.Diffusion][Sofa.Component.Mass] Fix diffusion

### DIFF
--- a/Component/Diffusion/src/sofa/component/diffusion/TetrahedronDiffusionFEMForceField.h
+++ b/Component/Diffusion/src/sofa/component/diffusion/TetrahedronDiffusionFEMForceField.h
@@ -93,7 +93,7 @@ public:
 
       /// Single value for diffusion coefficient (constant coefficient)
       Data<Real> d_constantDiffusionCoefficient;
-      /// Vector of diffusivities associated to all tetras
+      /// Vector of diffusivities associated with all tetras
       Data<sofa::type::vector<Real> > d_tetraDiffusionCoefficient;
       /// bool used to specify 1D diffusion
       /// This data is now useless, as it can be deduced from the template

--- a/Component/Diffusion/src/sofa/component/diffusion/TetrahedronDiffusionFEMForceField.h
+++ b/Component/Diffusion/src/sofa/component/diffusion/TetrahedronDiffusionFEMForceField.h
@@ -96,7 +96,9 @@ public:
       /// Vector of diffusivities associated to all tetras
       Data<sofa::type::vector<Real> > d_tetraDiffusionCoefficient;
       /// bool used to specify 1D diffusion
-      Data<bool> d_1DDiffusion;
+      /// This data is now useless, as it can be deduced from the template
+      DeprecatedAndRemoved d_1DDiffusion;
+
       /// Ratio for anisotropic diffusion
       Data<Real> d_transverseAnisotropyRatio;
       /// Vector for transverse anisotropy

--- a/Component/Diffusion/src/sofa/component/diffusion/TetrahedronDiffusionFEMForceField.inl
+++ b/Component/Diffusion/src/sofa/component/diffusion/TetrahedronDiffusionFEMForceField.inl
@@ -321,21 +321,10 @@ void TetrahedronDiffusionFEMForceField<DataTypes>::addForce (const core::Mechani
         v0 = edges[i][0];
         v1 = edges[i][1];
 
-        //Case 1D Diffusion
-        if constexpr (DataTypes::spatial_dimensions == 1)
-        {
-            dp[0] = (x[v1][0] - x[v0][0]) * edgeDiffusionCoefficient[i];
+        dp = (x[v1] - x[v0]) * edgeDiffusionCoefficient[i];
 
-            f[v1][0] += dp[0];
-            f[v0][0] -= dp[0];
-        }
-        else //Case >1D Diffusion
-        {
-            dp = (x[v1] - x[v0]) * edgeDiffusionCoefficient[i];
-
-            f[v1] += dp;
-            f[v0] -= dp;
-        }
+        f[v1] += dp;
+        f[v0] -= dp;
     }
 
     sofa::helper::AdvancedTimer::stepEnd("addForceDiffusion");
@@ -359,21 +348,10 @@ void TetrahedronDiffusionFEMForceField<DataTypes>::addDForce(const sofa::core::M
         v0 = edges[i][0];
         v1 = edges[i][1];
 
-        //Case 1D Diffusion
-        if constexpr (DataTypes::spatial_dimensions == 1)
-        {
-            dp[0] = (dx[v1][0]-dx[v0][0]) * edgeDiffusionCoefficient[i] * kFactor;
+        dp = (dx[v1]-dx[v0]) * edgeDiffusionCoefficient[i] * kFactor;
 
-            df[v1][0]+=dp[0];
-            df[v0][0]-=dp[0];
-        }
-        else //Case >1D Diffusion
-        {
-            dp = (dx[v1]-dx[v0]) * edgeDiffusionCoefficient[i] * kFactor;
-
-            df[v1]+=dp;
-            df[v0]-=dp;
-        }
+        df[v1]+=dp;
+        df[v0]-=dp;
     }
     sofa::helper::AdvancedTimer::stepEnd("addDForceDiffusion");
 }

--- a/Component/Mass/src/sofa/component/mass/DiagonalMass.cpp
+++ b/Component/Mass/src/sofa/component/mass/DiagonalMass.cpp
@@ -150,7 +150,7 @@ void DiagonalMass<RigidTypes, GeometricalTypes>::initRigidImpl()
 
     if (l_topology.empty())
     {
-        msg_warning() << "Link to the Topology \"topology\" should be set to ensure right behavior. First Topology found in current context will be used.";
+        msg_warning() << "Link \"topology\" to the Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
         
@@ -167,7 +167,7 @@ void DiagonalMass<RigidTypes, GeometricalTypes>::initRigidImpl()
 
         if (l_geometryState.empty())
         {
-            msg_warning() << "Link to position container \"geometryState\" should be set to ensure right behavior. First container found from the topology context will be used.";
+            msg_warning() << "Link \"geometryState\" to the MechanicalObject associated to the geometry should be set to ensure right behavior. First container found from the topology context will be used.";
             sofa::core::behavior::BaseMechanicalState::SPtr baseState;
             l_topology->getContext()->get(baseState);
 

--- a/Component/Mass/src/sofa/component/mass/DiagonalMass.cpp
+++ b/Component/Mass/src/sofa/component/mass/DiagonalMass.cpp
@@ -167,7 +167,7 @@ void DiagonalMass<RigidTypes, GeometricalTypes>::initRigidImpl()
 
         if (l_geometryState.empty())
         {
-            msg_warning() << "Link \"geometryState\" to the MechanicalObject associated to the geometry should be set to ensure right behavior. First container found from the topology context will be used.";
+            msg_warning() << "Link \"geometryState\" to the MechanicalObject associated with the geometry should be set to ensure right behavior. First container found from the topology context will be used.";
             sofa::core::behavior::BaseMechanicalState::SPtr baseState;
             l_topology->getContext()->get(baseState);
 

--- a/Component/Mass/src/sofa/component/mass/DiagonalMass.cpp
+++ b/Component/Mass/src/sofa/component/mass/DiagonalMass.cpp
@@ -150,7 +150,7 @@ void DiagonalMass<RigidTypes, GeometricalTypes>::initRigidImpl()
 
     if (l_topology.empty())
     {
-        msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
+        msg_warning() << "Link to the Topology \"topology\" should be set to ensure right behavior. First Topology found in current context will be used.";
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
         
@@ -167,7 +167,7 @@ void DiagonalMass<RigidTypes, GeometricalTypes>::initRigidImpl()
 
         if (l_geometryState.empty())
         {
-            msg_info() << "link to position container (State) should be set to ensure right behavior. First container found from the topology context will be used.";
+            msg_warning() << "Link to position container \"geometryState\" should be set to ensure right behavior. First container found from the topology context will be used.";
             sofa::core::behavior::BaseMechanicalState::SPtr baseState;
             l_topology->getContext()->get(baseState);
 

--- a/Component/Mass/src/sofa/component/mass/DiagonalMass.cpp
+++ b/Component/Mass/src/sofa/component/mass/DiagonalMass.cpp
@@ -37,9 +37,9 @@ using sofa::core::objectmodel::ComponentState ;
 using namespace sofa::type;
 using namespace sofa::defaulttype;
 
-template <class RigidTypes>
+template <class RigidTypes, class GeometricalTypes>
 template <class T>
-SReal DiagonalMass<RigidTypes>::getPotentialEnergyRigidImpl( const MechanicalParams* mparams,
+SReal DiagonalMass<RigidTypes, GeometricalTypes>::getPotentialEnergyRigidImpl( const MechanicalParams* mparams,
                                                                         const DataVecCoord& x) const
 {
     SOFA_UNUSED(mparams) ;
@@ -59,9 +59,9 @@ SReal DiagonalMass<RigidTypes>::getPotentialEnergyRigidImpl( const MechanicalPar
 }
 
 
-template <class RigidTypes>
+template <class RigidTypes, class GeometricalTypes>
 template <class T>
-void DiagonalMass<RigidTypes>::drawRigid3dImpl(const VisualParams* vparams)
+void DiagonalMass<RigidTypes, GeometricalTypes>::drawRigid3dImpl(const VisualParams* vparams)
 {
     const MassVector &masses= d_vertexMass.getValue();
     if (!vparams->displayFlags().getShowBehaviorModels()) return;
@@ -107,9 +107,9 @@ void DiagonalMass<RigidTypes>::drawRigid3dImpl(const VisualParams* vparams)
 }
 
 
-template <class RigidTypes>
+template <class RigidTypes, class GeometricalTypes>
 template <class T>
-void DiagonalMass<RigidTypes>::drawRigid2dImpl(const VisualParams* vparams)
+void DiagonalMass<RigidTypes, GeometricalTypes>::drawRigid2dImpl(const VisualParams* vparams)
 {
     const MassVector &masses= d_vertexMass.getValue();
     if (!vparams->displayFlags().getShowBehaviorModels()) return;
@@ -127,9 +127,9 @@ void DiagonalMass<RigidTypes>::drawRigid2dImpl(const VisualParams* vparams)
     }
 }
 
-template <class RigidTypes>
+template <class RigidTypes, class GeometricalTypes>
 template <class T>
-void DiagonalMass<RigidTypes>::initRigidImpl()
+void DiagonalMass<RigidTypes, GeometricalTypes>::initRigidImpl()
 {
     if(this->getContext()==nullptr){
         dmsg_error(this) << "Calling the initRigidImpl function is only possible if the object has a valid associated context \n" ;
@@ -186,9 +186,9 @@ void DiagonalMass<RigidTypes>::initRigidImpl()
     this->d_componentState.setValue(ComponentState::Valid) ;
 }
 
-template <class RigidTypes>
+template <class RigidTypes, class GeometricalTypes>
 template <class T>
-type::Vector6 DiagonalMass<RigidTypes>::getMomentumRigid3Impl ( const MechanicalParams*,
+type::Vector6 DiagonalMass<RigidTypes, GeometricalTypes>::getMomentumRigid3Impl ( const MechanicalParams*,
                                                                     const DataVecCoord& vx,
                                                                     const DataVecDeriv& vv ) const
 {
@@ -211,9 +211,9 @@ type::Vector6 DiagonalMass<RigidTypes>::getMomentumRigid3Impl ( const Mechanical
     return momentum;
 }
 
-template <class Vec3Types>
+template <class Vec3Types, class GeometricalTypes >
 template <class T>
-type::Vector6 DiagonalMass<Vec3Types>::getMomentumVec3Impl( const MechanicalParams*,
+type::Vector6 DiagonalMass<Vec3Types, GeometricalTypes>::getMomentumVec3Impl( const MechanicalParams*,
                                                                 const DataVecCoord& vx,
                                                                 const DataVecDeriv& vv ) const
 {
@@ -307,17 +307,24 @@ type::Vector6 DiagonalMass<Rigid3Types>::getMomentum ( const MechanicalParams* m
 // Register in the Factory
 int DiagonalMassClass = core::RegisterObject("Define a specific mass for each particle")
         .add< DiagonalMass<Vec3Types> >()
-        .add< DiagonalMass<Vec2Types> >()
+        .add< DiagonalMass<Vec2Types, Vec3Types> >()
         .add< DiagonalMass<Vec1Types> >()
+        .add< DiagonalMass<Vec1Types, Vec2Types> >()
+        .add< DiagonalMass<Vec1Types, Vec3Types> >()
         .add< DiagonalMass<Rigid3Types> >()
         .add< DiagonalMass<Rigid2Types> >()
+        .add< DiagonalMass<Rigid2Types, Rigid3Types> >()
 
         ;
 
 template class SOFA_COMPONENT_MASS_API DiagonalMass<Vec3Types>;
 template class SOFA_COMPONENT_MASS_API DiagonalMass<Vec2Types>;
+template class SOFA_COMPONENT_MASS_API DiagonalMass<Vec2Types, Vec3Types>;
 template class SOFA_COMPONENT_MASS_API DiagonalMass<Vec1Types>;
+template class SOFA_COMPONENT_MASS_API DiagonalMass<Vec1Types, Vec2Types>;
+template class SOFA_COMPONENT_MASS_API DiagonalMass<Vec1Types, Vec3Types>;
 template class SOFA_COMPONENT_MASS_API DiagonalMass<Rigid3Types>;
 template class SOFA_COMPONENT_MASS_API DiagonalMass<Rigid2Types>;
+template class SOFA_COMPONENT_MASS_API DiagonalMass<Rigid2Types, Rigid3Types>;
 
 } // namespace sofa::component::mass

--- a/Component/Mass/src/sofa/component/mass/DiagonalMass.h
+++ b/Component/Mass/src/sofa/component/mass/DiagonalMass.h
@@ -39,7 +39,7 @@
 namespace sofa::component::mass
 {
 
-template<class DataTypes, class TMassType>
+template<class DataTypes, class TMassType, class GeometricalTypes>
 class DiagonalMassInternalData
 {
 public :
@@ -49,14 +49,21 @@ public :
 
     // In case of non 3D template
     typedef sofa::type::Vec<3,Real> Vec3;
-    typedef sofa::defaulttype::StdVectorTypes< Vec3, Vec3, Real > GeometricalTypes ; /// assumes the geometry object type is 3D
 };
 
-template <class DataTypes>
+/**
+* @class    DiagonalMass
+* @brief    This component computes the integral of this mass density over the volume of the object geometry but it supposes that the Mass matrix is diagonal.
+* @remark   Similar to MeshMatrixMass but it does not simplify the Mass Matrix as diagonal.
+* @remark   https://www.sofa-framework.org/community/doc/components/masses/diagonalmass/
+* @tparam   DataTypes type of the state associated to this mass
+* @tparam   GeometricalTypes type of the geometry, i.e type of the state associated with the topology (if the topology and the mass relates to the same state, this will be the same as DataTypes)
+*/
+template <class DataTypes, class GeometricalTypes = DataTypes>
 class DiagonalMass : public core::behavior::Mass<DataTypes>
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE(DiagonalMass,DataTypes), SOFA_TEMPLATE(core::behavior::Mass,DataTypes));
+    SOFA_CLASS(SOFA_TEMPLATE2(DiagonalMass,DataTypes, GeometricalTypes), SOFA_TEMPLATE(core::behavior::Mass,DataTypes));
 
     using TMassType = typename sofa::component::mass::MassType<DataTypes>::type;
 
@@ -70,9 +77,8 @@ public:
     typedef core::objectmodel::Data<VecDeriv> DataVecDeriv;
     typedef TMassType MassType;
 
-    typedef typename DiagonalMassInternalData<DataTypes,TMassType>::VecMass VecMass;
-    typedef typename DiagonalMassInternalData<DataTypes,TMassType>::MassVector MassVector;
-    typedef typename DiagonalMassInternalData<DataTypes,TMassType>::GeometricalTypes GeometricalTypes;
+    typedef typename DiagonalMassInternalData<DataTypes,TMassType,GeometricalTypes>::VecMass VecMass;
+    typedef typename DiagonalMassInternalData<DataTypes,TMassType,GeometricalTypes>::MassVector MassVector;
 
     VecMass d_vertexMass; ///< values of the particles masses
 
@@ -108,7 +114,7 @@ public:
     int m_initializationProcess;
 
     /// Link to be set to the topology container in the component graph. 
-    SingleLink<DiagonalMass<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
+    SingleLink<DiagonalMass<DataTypes, GeometricalTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 
 protected:
     ////////////////////////// Inherited attributes ////////////////////////////
@@ -127,6 +133,9 @@ protected:
 
     /// Pointer to the topology container. Will be set by link @sa l_topology
     sofa::core::topology::BaseMeshTopology* m_topology;
+
+    /// Pointer to the state owning geometrical positions, associated with the topology
+    typename sofa::core::behavior::MechanicalState<GeometricalTypes>::SPtr m_geometryState;
 
 protected:
     DiagonalMass();
@@ -393,10 +402,13 @@ type::Vector6 DiagonalMass<defaulttype::Rigid3Types>::getMomentum ( const core::
 #if  !defined(SOFA_COMPONENT_MASS_DIAGONALMASS_CPP)
 extern template class SOFA_COMPONENT_MASS_API DiagonalMass<defaulttype::Vec3Types>;
 extern template class SOFA_COMPONENT_MASS_API DiagonalMass<defaulttype::Vec2Types>;
+extern template class SOFA_COMPONENT_MASS_API DiagonalMass<defaulttype::Vec2Types, defaulttype::Vec3Types>;
 extern template class SOFA_COMPONENT_MASS_API DiagonalMass<defaulttype::Vec1Types>;
+extern template class SOFA_COMPONENT_MASS_API DiagonalMass<defaulttype::Vec1Types, defaulttype::Vec2Types>;
+extern template class SOFA_COMPONENT_MASS_API DiagonalMass<defaulttype::Vec1Types, defaulttype::Vec3Types>;
 extern template class SOFA_COMPONENT_MASS_API DiagonalMass<defaulttype::Rigid3Types>;
 extern template class SOFA_COMPONENT_MASS_API DiagonalMass<defaulttype::Rigid2Types>;
-
+extern template class SOFA_COMPONENT_MASS_API DiagonalMass<defaulttype::Rigid2Types, defaulttype::Rigid3Types>;
 #endif
 
 } // namespace sofa::component::mass

--- a/Component/Mass/src/sofa/component/mass/DiagonalMass.h
+++ b/Component/Mass/src/sofa/component/mass/DiagonalMass.h
@@ -56,7 +56,7 @@ public :
 * @brief    This component computes the integral of this mass density over the volume of the object geometry but it supposes that the Mass matrix is diagonal.
 * @remark   Similar to MeshMatrixMass but it does not simplify the Mass Matrix as diagonal.
 * @remark   https://www.sofa-framework.org/community/doc/components/masses/diagonalmass/
-* @tparam   DataTypes type of the state associated to this mass
+* @tparam   DataTypes type of the state associated with this mass
 * @tparam   GeometricalTypes type of the geometry, i.e type of the state associated with the topology (if the topology and the mass relates to the same state, this will be the same as DataTypes)
 */
 template <class DataTypes, class GeometricalTypes = DataTypes>
@@ -115,7 +115,7 @@ public:
 
     /// Link to be set to the topology container in the component graph. 
     SingleLink<DiagonalMass<DataTypes, GeometricalTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
-    /// Link to be set to the position container associated to the topology
+    /// Link to be set to the MechanicalObject associated with the geometry
     SingleLink<DiagonalMass<DataTypes, GeometricalTypes>, sofa::core::behavior::MechanicalState<GeometricalTypes>, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_geometryState;
 
 protected:

--- a/Component/Mass/src/sofa/component/mass/DiagonalMass.h
+++ b/Component/Mass/src/sofa/component/mass/DiagonalMass.h
@@ -115,6 +115,8 @@ public:
 
     /// Link to be set to the topology container in the component graph. 
     SingleLink<DiagonalMass<DataTypes, GeometricalTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
+    /// Link to be set to the position container associated to the topology
+    SingleLink<DiagonalMass<DataTypes, GeometricalTypes>, sofa::core::behavior::MechanicalState<GeometricalTypes>, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_geometryState;
 
 protected:
     ////////////////////////// Inherited attributes ////////////////////////////
@@ -130,12 +132,6 @@ protected:
     class Loader;
     /// The type of topology to build the mass from the topology
     sofa::geometry::ElementType m_massTopologyType;
-
-    /// Pointer to the topology container. Will be set by link @sa l_topology
-    sofa::core::topology::BaseMeshTopology* m_topology;
-
-    /// Pointer to the state owning geometrical positions, associated with the topology
-    typename sofa::core::behavior::MechanicalState<GeometricalTypes>::SPtr m_geometryState;
 
 protected:
     DiagonalMass();

--- a/Component/Mass/src/sofa/component/mass/DiagonalMass.h
+++ b/Component/Mass/src/sofa/component/mass/DiagonalMass.h
@@ -201,7 +201,7 @@ protected:
     /** Method to update @sa d_vertexMass when a new Triangle is created.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when TRIANGLESADDED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
     void applyTriangleCreation(const sofa::type::vector< TriangleID >& /*indices*/,
         const sofa::type::vector< Triangle >& /*elems*/,
         const sofa::type::vector< sofa::type::vector< TriangleID > >& /*ancestors*/,
@@ -210,14 +210,14 @@ protected:
     /** Method to update @sa d_vertexMass when a Triangle is removed.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when TRIANGLESREMOVED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
     void applyTriangleDestruction(const sofa::type::vector<TriangleID>& /*indices*/);
 
 
     /** Method to update @sa d_vertexMass when a new Quad is created.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when QUADSADDED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
     void applyQuadCreation(const sofa::type::vector< QuadID >& /*indices*/,
         const sofa::type::vector< Quad >& /*elems*/,
         const sofa::type::vector< sofa::type::vector< QuadID > >& /*ancestors*/,
@@ -226,14 +226,14 @@ protected:
     /** Method to update @sa d_vertexMass when a Quad is removed.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when QUADSREMOVED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
     void applyQuadDestruction(const sofa::type::vector<QuadID>& /*indices*/);
     
 
     /** Method to update @sa d_vertexMass when a new Tetrahedron is created.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when TETRAHEDRAADDED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
     void applyTetrahedronCreation(const sofa::type::vector< TetrahedronID >& /*indices*/,
         const sofa::type::vector< Tetrahedron >& /*elems*/,
         const sofa::type::vector< sofa::type::vector< TetrahedronID > >& /*ancestors*/,
@@ -242,14 +242,14 @@ protected:
     /** Method to update @sa d_vertexMass when a Tetrahedron is removed.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when TETRAHEDRAREMOVED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
     void applyTetrahedronDestruction(const sofa::type::vector<TetrahedronID>& /*indices*/);
 
 
     /** Method to update @sa d_vertexMass when a new Hexahedron is created.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when HEXAHEDRAADDED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
     void applyHexahedronCreation(const sofa::type::vector< HexahedronID >& /*indices*/,
         const sofa::type::vector< Hexahedron >& /*elems*/,
         const sofa::type::vector< sofa::type::vector< HexahedronID > >& /*ancestors*/,
@@ -258,7 +258,7 @@ protected:
     /** Method to update @sa d_vertexMass when a Hexahedron is removed.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when HEXAHEDRAREMOVED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
     void applyHexahedronDestruction(const sofa::type::vector<HexahedronID>& /*indices*/);
 
 public:
@@ -338,9 +338,13 @@ public:
             auto splitTemplates = sofa::helper::split(std::string(arg->getAttribute("template")), ',');
             if (splitTemplates.size() > 1)
             {
-                msg_warning() << "MassType is not required anymore and the template is deprecated, please delete it from your scene." << msgendl
-                    << "As your mass is templated on " << DataTypes::Name() << ", MassType has been defined as " << sofa::helper::NameDecoder::getTypeName<MassType>() << " .";
-                msg_warning() << "If you want to set the template, you must write now \"template='" << DataTypes::Name() << "'\" .";
+                // check if the given 2nd template is the deprecated MassType one
+                if (splitTemplates[1] == "float" || splitTemplates[1] == "double" || splitTemplates[1].find("RigidMass") != std::string::npos)
+                {
+                    msg_warning() << "MassType is not required anymore and the template is deprecated, please delete it from your scene." << msgendl
+                        << "As your mass is templated on " << DataTypes::Name() << ", MassType has been defined as " << sofa::helper::NameDecoder::getTypeName<MassType>() << " .";
+                    msg_warning() << "If you want to set the template, you must write now \"template='" << DataTypes::Name() << "'\" .";
+                }
             }
         }
         if (arg->getAttribute("mass"))

--- a/Component/Mass/src/sofa/component/mass/DiagonalMass.inl
+++ b/Component/Mass/src/sofa/component/mass/DiagonalMass.inl
@@ -50,7 +50,7 @@ DiagonalMass<DataTypes, GeometricalTypes>::DiagonalMass()
     , d_showAxisSize( initData(&d_showAxisSize, 1.0f, "showAxisSizeFactor", "Factor length of the axis displayed (only used for rigids)" ) )
     , d_fileMass( initData(&d_fileMass,  "filename", "Xsp3.0 file to specify the mass parameters" ) )
     , l_topology(initLink("topology", "link to the topology container"))
-    , l_geometryState(initLink("geometryState", "link to the position container associated with the topology"))
+    , l_geometryState(initLink("geometryState", "link to the MechanicalObject associated with the geometry"))
     , m_massTopologyType(sofa::geometry::ElementType::UNKNOWN)
 {
     this->addAlias(&d_fileMass,"fileMass");
@@ -763,7 +763,7 @@ bool DiagonalMass<DataTypes, GeometricalTypes>::checkTopology()
 
     if (l_geometryState.empty())
     {
-        msg_warning() << "Link to position container \"geometryState\" should be set to ensure right behavior. First container found from the topology context will be used.";
+        msg_warning() << "Link \"geometryState\" to the MechanicalObject associated with the geometry should be set to ensure right behavior. First container found from the topology context will be used.";
         sofa::core::behavior::BaseMechanicalState::SPtr baseState;
         l_topology->getContext()->get(baseState);
 

--- a/Component/Mass/src/sofa/component/mass/DiagonalMass.inl
+++ b/Component/Mass/src/sofa/component/mass/DiagonalMass.inl
@@ -751,6 +751,15 @@ bool DiagonalMass<DataTypes, GeometricalTypes>::checkTopology()
 
     }
 
+    m_topology = l_topology.get();
+    msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
+
+    if (m_topology == nullptr)
+    {
+        msg_error() << "No topology component found at path: " << l_topology.getLinkedPath() << ", nor in current context: " << this->getContext()->name;
+        return false;
+    }
+
     sofa::core::behavior::BaseMechanicalState::SPtr baseState;
     m_topology->getContext()->get(baseState);
     if (baseState == nullptr)
@@ -771,15 +780,6 @@ bool DiagonalMass<DataTypes, GeometricalTypes>::checkTopology()
             msg_info() << "Topology is associated with the state: '" << m_geometryState->getPathName() << "'";
         }
 
-    }
-
-    m_topology = l_topology.get();
-    msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
-
-    if (m_topology == nullptr)
-    {
-        msg_error() << "No topology component found at path: " << l_topology.getLinkedPath() << ", nor in current context: " << this->getContext()->name;
-        return false;
     }
 
     if (m_topology)
@@ -986,7 +986,7 @@ typename DiagonalMass<DataTypes, GeometricalTypes>::Real DiagonalMass<DataTypes,
     masses.clear();
     masses.resize(this->mstate->getSize(), Real(0));
 
-    if constexpr (DataTypes::spatial_dimensions >= 1)
+    if constexpr (GeometricalTypes::spatial_dimensions >= 1)
     {
         if (m_massTopologyType == sofa::geometry::ElementType::EDGE)
         {
@@ -1009,7 +1009,7 @@ typename DiagonalMass<DataTypes, GeometricalTypes>::Real DiagonalMass<DataTypes,
         }
     }
 
-    if constexpr (DataTypes::spatial_dimensions >= 2)
+    if constexpr (GeometricalTypes::spatial_dimensions >= 2)
     {
         if (m_massTopologyType == sofa::geometry::ElementType::TRIANGLE)
         {
@@ -1054,7 +1054,7 @@ typename DiagonalMass<DataTypes, GeometricalTypes>::Real DiagonalMass<DataTypes,
         }
     }
 
-    if constexpr (DataTypes::spatial_dimensions >= 3)
+    if constexpr (GeometricalTypes::spatial_dimensions >= 3)
     {
         if (m_massTopologyType == sofa::geometry::ElementType::TETRAHEDRON)
         {

--- a/Component/Mass/src/sofa/component/mass/DiagonalMass.inl
+++ b/Component/Mass/src/sofa/component/mass/DiagonalMass.inl
@@ -763,7 +763,7 @@ bool DiagonalMass<DataTypes, GeometricalTypes>::checkTopology()
 
     if (l_geometryState.empty())
     {
-        msg_info() << "link to position container (State) should be set to ensure right behavior. First container found from the topology context will be used.";
+        msg_warning() << "Link to position container \"geometryState\" should be set to ensure right behavior. First container found from the topology context will be used.";
         sofa::core::behavior::BaseMechanicalState::SPtr baseState;
         l_topology->getContext()->get(baseState);
 

--- a/Component/Mass/src/sofa/component/mass/DiagonalMass.inl
+++ b/Component/Mass/src/sofa/component/mass/DiagonalMass.inl
@@ -746,7 +746,7 @@ bool DiagonalMass<DataTypes, GeometricalTypes>::checkTopology()
 {
     if (l_topology.empty())
     {
-        msg_warning() << "Link to the Topology \"topology\" should be set to ensure right behavior. First Topology found in current context will be used.";
+        msg_warning() << "Link \"topology\" to the Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 

--- a/Component/Mass/src/sofa/component/mass/DiagonalMass.inl
+++ b/Component/Mass/src/sofa/component/mass/DiagonalMass.inl
@@ -746,7 +746,7 @@ bool DiagonalMass<DataTypes, GeometricalTypes>::checkTopology()
 {
     if (l_topology.empty())
     {
-        msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
+        msg_warning() << "Link to the Topology \"topology\" should be set to ensure right behavior. First Topology found in current context will be used.";
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 

--- a/Component/Mass/src/sofa/component/mass/DiagonalMass.inl
+++ b/Component/Mass/src/sofa/component/mass/DiagonalMass.inl
@@ -50,8 +50,8 @@ DiagonalMass<DataTypes, GeometricalTypes>::DiagonalMass()
     , d_showAxisSize( initData(&d_showAxisSize, 1.0f, "showAxisSizeFactor", "Factor length of the axis displayed (only used for rigids)" ) )
     , d_fileMass( initData(&d_fileMass,  "filename", "Xsp3.0 file to specify the mass parameters" ) )
     , l_topology(initLink("topology", "link to the topology container"))
+    , l_geometryState(initLink("geometryState", "link to the position container associated with the topology"))
     , m_massTopologyType(sofa::geometry::ElementType::UNKNOWN)
-    , m_topology(nullptr)
 {
     this->addAlias(&d_fileMass,"fileMass");
 }
@@ -81,7 +81,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::applyEdgeCreation(const sofa::ty
 {
     if (this->getMassTopologyType() == sofa::geometry::ElementType::EDGE)
     {
-        const auto& restPositions = m_geometryState->read(core::ConstVecCoordId::restPosition())->getValue();
+        const auto& restPositions = l_geometryState->read(core::ConstVecCoordId::restPosition())->getValue();
 
         helper::WriteAccessor<Data<MassVector> > masses(d_vertexMass);
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
@@ -93,7 +93,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::applyEdgeCreation(const sofa::ty
         for (i=0; i<edgeAdded.size(); ++i)
         {
             /// get the edge to be added
-            const Edge &e=this->m_topology->getEdge(edgeAdded[i]);
+            const Edge &e=this->l_topology->getEdge(edgeAdded[i]);
             // compute its mass based on the mass density and the edge length
             const auto& rpos0 = GeometricalTypes::getCPos(restPositions[e[0]]);
             const auto& rpos1 = GeometricalTypes::getCPos(restPositions[e[1]]);
@@ -118,7 +118,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::applyEdgeDestruction(const sofa:
 {
     if (this->getMassTopologyType() == sofa::geometry::ElementType::EDGE)
     {
-        const auto& restPositions = m_geometryState->read(core::ConstVecCoordId::restPosition())->getValue();
+        const auto& restPositions = l_geometryState->read(core::ConstVecCoordId::restPosition())->getValue();
 
         helper::WriteAccessor<Data<MassVector> > masses(d_vertexMass);
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
@@ -130,7 +130,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::applyEdgeDestruction(const sofa:
         for (i=0; i<edgeRemoved.size(); ++i)
         {
             /// get the edge to be added
-            const Edge &e= this->m_topology->getEdge(edgeRemoved[i]);
+            const Edge &e= this->l_topology->getEdge(edgeRemoved[i]);
             // compute its mass based on the mass density and the edge length
             const auto& rpos0 = GeometricalTypes::getCPos(restPositions[e[0]]);
             const auto& rpos1 = GeometricalTypes::getCPos(restPositions[e[1]]);
@@ -160,7 +160,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::applyTriangleCreation(const sofa
 {
     if (this->getMassTopologyType() == sofa::geometry::ElementType::TRIANGLE)
     {
-        const auto& restPositions = m_geometryState->read(core::ConstVecCoordId::restPosition())->getValue();
+        const auto& restPositions = l_geometryState->read(core::ConstVecCoordId::restPosition())->getValue();
 
         helper::WriteAccessor<Data<MassVector> > masses(d_vertexMass);
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
@@ -172,7 +172,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::applyTriangleCreation(const sofa
         for (i=0; i<triangleAdded.size(); ++i)
         {
             /// get the triangle to be added
-            const Triangle &t=this->m_topology->getTriangle(triangleAdded[i]);
+            const Triangle &t=this->l_topology->getTriangle(triangleAdded[i]);
             // compute its mass based on the mass density and the triangle area
             const auto& rpos0 = GeometricalTypes::getCPos(restPositions[t[0]]);
             const auto& rpos1 = GeometricalTypes::getCPos(restPositions[t[1]]);
@@ -201,7 +201,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::applyTriangleDestruction(const s
 
     if (this->getMassTopologyType() == sofa::geometry::ElementType::TRIANGLE)
     {
-        const auto& restPositions = m_geometryState->read(core::ConstVecCoordId::restPosition())->getValue();
+        const auto& restPositions = l_geometryState->read(core::ConstVecCoordId::restPosition())->getValue();
 
         helper::WriteAccessor<Data<MassVector> > masses(d_vertexMass);
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
@@ -213,7 +213,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::applyTriangleDestruction(const s
         for (i = 0; i < triangleRemoved.size(); ++i)
         {
             /// get the triangle to be added
-            const Triangle& t = this->m_topology->getTriangle(triangleRemoved[i]);
+            const Triangle& t = this->l_topology->getTriangle(triangleRemoved[i]);
 
             /// compute its mass based on the mass density and the triangle area
             const auto& rpos0 = GeometricalTypes::getCPos(restPositions[t[0]]);
@@ -246,7 +246,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::applyQuadCreation(const sofa::ty
 {
     if (this->getMassTopologyType() == sofa::geometry::ElementType::QUAD)
     {
-        const auto& restPositions = m_geometryState->read(core::ConstVecCoordId::restPosition())->getValue();
+        const auto& restPositions = l_geometryState->read(core::ConstVecCoordId::restPosition())->getValue();
 
         helper::WriteAccessor<Data<MassVector> > masses(d_vertexMass);
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
@@ -258,7 +258,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::applyQuadCreation(const sofa::ty
         for (i = 0; i < quadAdded.size(); ++i)
         {
             /// get the quad to be added
-            const Quad& q = this->m_topology->getQuad(quadAdded[i]);
+            const Quad& q = this->l_topology->getQuad(quadAdded[i]);
 
             // compute its mass based on the mass density and the quad area
             const auto& pos0 = GeometricalTypes::getCPos(restPositions[q[0]]);
@@ -289,7 +289,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::applyQuadDestruction(const sofa:
 {
     if (this->getMassTopologyType() == sofa::geometry::ElementType::QUAD)
     {
-        const auto& restPositions = m_geometryState->read(core::ConstVecCoordId::restPosition())->getValue();
+        const auto& restPositions = l_geometryState->read(core::ConstVecCoordId::restPosition())->getValue();
 
         helper::WriteAccessor<Data<MassVector> > masses(d_vertexMass);
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
@@ -301,7 +301,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::applyQuadDestruction(const sofa:
         for (i = 0; i < quadRemoved.size(); ++i)
         {
             /// get the quad to be added
-            const Quad& q = this->m_topology->getQuad(quadRemoved[i]);
+            const Quad& q = this->l_topology->getQuad(quadRemoved[i]);
 
             /// compute its mass based on the mass density and the quad area
             const auto& pos0 = GeometricalTypes::getCPos(restPositions[q[0]]);
@@ -336,7 +336,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::applyTetrahedronCreation(const s
 {
     if (this->getMassTopologyType() == sofa::geometry::ElementType::TETRAHEDRON)
     {
-        const auto& restPositions = m_geometryState->read(core::ConstVecCoordId::restPosition())->getValue();
+        const auto& restPositions = l_geometryState->read(core::ConstVecCoordId::restPosition())->getValue();
 
         helper::WriteAccessor<Data<MassVector> > masses(d_vertexMass);
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
@@ -348,7 +348,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::applyTetrahedronCreation(const s
         for (i = 0; i < tetrahedronAdded.size(); ++i)
         {
             /// get the tetrahedron to be added
-            const Tetrahedron& t = this->m_topology->getTetrahedron(tetrahedronAdded[i]);
+            const Tetrahedron& t = this->l_topology->getTetrahedron(tetrahedronAdded[i]);
 
             /// compute its mass based on the mass density and the tetrahedron volume
             const auto& rpos0 = GeometricalTypes::getCPos(restPositions[t[0]]);
@@ -379,7 +379,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::applyTetrahedronDestruction(cons
 {
     if (this->getMassTopologyType() == sofa::geometry::ElementType::TETRAHEDRON)
     {
-        const auto& restPositions = m_geometryState->read(core::ConstVecCoordId::restPosition())->getValue();
+        const auto& restPositions = l_geometryState->read(core::ConstVecCoordId::restPosition())->getValue();
 
         helper::WriteAccessor<Data<MassVector> > masses(d_vertexMass);
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
@@ -391,7 +391,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::applyTetrahedronDestruction(cons
         for (i = 0; i < tetrahedronRemoved.size(); ++i)
         {
             /// get the tetrahedron to be added
-            const Tetrahedron& t = this->m_topology->getTetrahedron(tetrahedronRemoved[i]);
+            const Tetrahedron& t = this->l_topology->getTetrahedron(tetrahedronRemoved[i]);
 
             /// compute its mass based on the mass density and the tetrahedron volume
             const auto& rpos0 = GeometricalTypes::getCPos(restPositions[t[0]]);
@@ -426,7 +426,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::applyHexahedronCreation(const so
 {
     if (this->getMassTopologyType() == sofa::geometry::ElementType::HEXAHEDRON)
     {
-        const auto& restPositions = m_geometryState->read(core::ConstVecCoordId::restPosition())->getValue();
+        const auto& restPositions = l_geometryState->read(core::ConstVecCoordId::restPosition())->getValue();
 
         helper::WriteAccessor<Data<MassVector> > masses(d_vertexMass);
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
@@ -438,7 +438,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::applyHexahedronCreation(const so
         for (i = 0; i < hexahedronAdded.size(); ++i)
         {
             /// get the tetrahedron to be added
-            const Hexahedron& h = this->m_topology->getHexahedron(hexahedronAdded[i]);
+            const Hexahedron& h = this->l_topology->getHexahedron(hexahedronAdded[i]);
             // compute its mass based on the mass density and the tetrahedron volume
             const auto& rpos0 = GeometricalTypes::getCPos(restPositions[h[0]]);
             const auto& rpos1 = GeometricalTypes::getCPos(restPositions[h[1]]);
@@ -470,7 +470,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::applyHexahedronDestruction(const
 {
     if (this->getMassTopologyType() == sofa::geometry::ElementType::HEXAHEDRON)
     {
-        const auto& restPositions = m_geometryState->read(core::ConstVecCoordId::restPosition())->getValue();
+        const auto& restPositions = l_geometryState->read(core::ConstVecCoordId::restPosition())->getValue();
 
         helper::WriteAccessor<Data<MassVector> > masses(d_vertexMass);
         helper::WriteAccessor<Data<Real> > totalMass(d_totalMass);
@@ -482,7 +482,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::applyHexahedronDestruction(const
         for (i = 0; i < hexahedronRemoved.size(); ++i)
         {
             /// get the tetrahedron to be added
-            const Hexahedron& h = this->m_topology->getHexahedron(hexahedronRemoved[i]);
+            const Hexahedron& h = this->l_topology->getHexahedron(hexahedronRemoved[i]);
 
             // compute its mass based on the mass density and the tetrahedron volume
             const auto& rpos0 = GeometricalTypes::getCPos(restPositions[h[0]]);
@@ -658,7 +658,7 @@ template <class DataTypes, class GeometricalTypes>
 void DiagonalMass<DataTypes, GeometricalTypes>::initTopologyHandlers()
 {
     // add the functions to handle topology changes.
-    d_vertexMass.createTopologyHandler(m_topology);
+    d_vertexMass.createTopologyHandler(l_topology);
     d_vertexMass.setCreationCallback([this](Index pointIndex, MassType& m,
         const core::topology::BaseMeshTopology::Point& point,
         const sofa::type::vector< Index >& ancestors,
@@ -748,67 +748,73 @@ bool DiagonalMass<DataTypes, GeometricalTypes>::checkTopology()
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
         l_topology.set(this->getContext()->getMeshTopologyLink());
-
     }
 
-    m_topology = l_topology.get();
-    msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
-
-    if (m_topology == nullptr)
+    if (l_topology.get() == nullptr)
     {
         msg_error() << "No topology component found at path: " << l_topology.getLinkedPath() << ", nor in current context: " << this->getContext()->name;
-        return false;
-    }
-
-    sofa::core::behavior::BaseMechanicalState::SPtr baseState;
-    m_topology->getContext()->get(baseState);
-    if (baseState == nullptr)
-    {
-        msg_error() << "No state associated with the topology has been found.";
+        sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         return false;
     }
     else
     {
-        m_geometryState = boost::dynamic_pointer_cast<sofa::core::behavior::MechanicalState<GeometricalTypes>>(baseState);
-        if (m_geometryState == nullptr)
+        msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
+    }
+
+    if (l_geometryState.empty())
+    {
+        msg_info() << "link to position container (State) should be set to ensure right behavior. First container found from the topology context will be used.";
+        sofa::core::behavior::BaseMechanicalState::SPtr baseState;
+        l_topology->getContext()->get(baseState);
+
+        if (baseState == nullptr)
         {
-            msg_error() << "A state associated with the topology has been found but is incompatible with the definition of the mass (templates mismatch).";
+            msg_error() << "No compatible state associated with the topology has been found.";
             return false;
         }
         else
         {
-            msg_info() << "Topology is associated with the state: '" << m_geometryState->getPathName() << "'";
+            typename sofa::core::behavior::MechanicalState<GeometricalTypes>::SPtr geometryState = boost::dynamic_pointer_cast<sofa::core::behavior::MechanicalState<GeometricalTypes>>(baseState);
+            if (geometryState == nullptr)
+            {
+                msg_error() << "A state associated with the topology has been found but is incompatible with the definition of the mass (templates mismatch).";
+                return false;
+            }
+            else
+            {
+                l_geometryState.set(geometryState);
+                msg_info() << "Topology is associated with the state: '" << l_geometryState->getPathName() << "'";
+            }
         }
-
     }
 
-    if (m_topology)
+    if (l_topology)
     {
-        if (m_topology->getNbHexahedra() > 0)
+        if (l_topology->getNbHexahedra() > 0)
         {
             msg_info() << "Hexahedral topology found.";
             m_massTopologyType = sofa::geometry::ElementType::HEXAHEDRON;
             return true;
         }
-        else if (m_topology->getNbTetrahedra() > 0)
+        else if (l_topology->getNbTetrahedra() > 0)
         {
             msg_info() << "Tetrahedral topology found.";
             m_massTopologyType = sofa::geometry::ElementType::TETRAHEDRON;
             return true;
         }
-        else if (m_topology->getNbQuads() > 0)
+        else if (l_topology->getNbQuads() > 0)
         {
             msg_info() << "Quad topology found.";
             m_massTopologyType = sofa::geometry::ElementType::QUAD;
             return true;
         }
-        else if (m_topology->getNbTriangles() > 0)
+        else if (l_topology->getNbTriangles() > 0)
         {
             msg_info() << "Triangular topology found."; 
             m_massTopologyType = sofa::geometry::ElementType::TRIANGLE;
             return true;
         }
-        else if (m_topology->getNbEdges() > 0)
+        else if (l_topology->getNbEdges() > 0)
         {
             msg_info() << "Edge topology found.";
             m_massTopologyType = sofa::geometry::ElementType::EDGE;
@@ -971,14 +977,14 @@ typename DiagonalMass<DataTypes, GeometricalTypes>::Real DiagonalMass<DataTypes,
 {
     Real total_mass = Real(0);
 
-    if (m_topology == nullptr)
+    if (l_topology == nullptr)
     {
         msg_warning() << "No topology set. DiagonalMass can't computeMass.";
         return total_mass;
     }
     
     core::ConstVecCoordId posid = d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
-    const auto& positions = m_geometryState->read(posid)->getValue();
+    const auto& positions = l_geometryState->read(posid)->getValue();
 
     Real mass = Real(0);
     helper::WriteAccessor<Data<MassVector> > masses = d_vertexMass;
@@ -990,9 +996,9 @@ typename DiagonalMass<DataTypes, GeometricalTypes>::Real DiagonalMass<DataTypes,
     {
         if (m_massTopologyType == sofa::geometry::ElementType::EDGE)
         {
-            for (Topology::EdgeID i = 0; i < m_topology->getNbEdges(); ++i)
+            for (Topology::EdgeID i = 0; i < l_topology->getNbEdges(); ++i)
             {
-                const Edge& e = m_topology->getEdge(i);
+                const Edge& e = l_topology->getEdge(i);
 
                 const auto& pos0 = GeometricalTypes::getCPos(positions[e[0]]);
                 const auto& pos1 = GeometricalTypes::getCPos(positions[e[1]]);
@@ -1013,9 +1019,9 @@ typename DiagonalMass<DataTypes, GeometricalTypes>::Real DiagonalMass<DataTypes,
     {
         if (m_massTopologyType == sofa::geometry::ElementType::TRIANGLE)
         {
-            for (Topology::TriangleID i = 0; i < m_topology->getNbTriangles(); ++i)
+            for (Topology::TriangleID i = 0; i < l_topology->getNbTriangles(); ++i)
             {
-                const Triangle& t = m_topology->getTriangle(i);
+                const Triangle& t = l_topology->getTriangle(i);
 
                 const auto& pos0 = GeometricalTypes::getCPos(positions[t[0]]);
                 const auto& pos1 = GeometricalTypes::getCPos(positions[t[1]]);
@@ -1034,9 +1040,9 @@ typename DiagonalMass<DataTypes, GeometricalTypes>::Real DiagonalMass<DataTypes,
 
         if (m_massTopologyType == sofa::geometry::ElementType::QUAD)
         {
-            for (Topology::QuadID i = 0; i < m_topology->getNbQuads(); ++i)
+            for (Topology::QuadID i = 0; i < l_topology->getNbQuads(); ++i)
             {
-                const Quad& q = m_topology->getQuad(i);
+                const Quad& q = l_topology->getQuad(i);
 
                 const auto& pos0 = GeometricalTypes::getCPos(positions[q[0]]);
                 const auto& pos1 = GeometricalTypes::getCPos(positions[q[1]]);
@@ -1058,9 +1064,9 @@ typename DiagonalMass<DataTypes, GeometricalTypes>::Real DiagonalMass<DataTypes,
     {
         if (m_massTopologyType == sofa::geometry::ElementType::TETRAHEDRON)
         {
-            for (Topology::TetrahedronID i = 0; i < m_topology->getNbTetrahedra(); ++i)
+            for (Topology::TetrahedronID i = 0; i < l_topology->getNbTetrahedra(); ++i)
             {
-                const Tetrahedron& t = m_topology->getTetrahedron(i);
+                const Tetrahedron& t = l_topology->getTetrahedron(i);
 
                 /// compute its mass based on the mass density and the tetrahedron volume
                 const auto& rpos0 = GeometricalTypes::getCPos(positions[t[0]]);
@@ -1079,9 +1085,9 @@ typename DiagonalMass<DataTypes, GeometricalTypes>::Real DiagonalMass<DataTypes,
         }
         if (m_massTopologyType == sofa::geometry::ElementType::HEXAHEDRON)
         {
-            for (Topology::HexahedronID i = 0; i < m_topology->getNbHexahedra(); ++i)
+            for (Topology::HexahedronID i = 0; i < l_topology->getNbHexahedra(); ++i)
             {
-                const Hexahedron& h = m_topology->getHexahedron(i);
+                const Hexahedron& h = l_topology->getHexahedron(i);
 
                 /// compute its mass based on the mass density and the hexahedron volume
                 const auto& rpos0 = GeometricalTypes::getCPos(positions[h[0]]);
@@ -1144,9 +1150,9 @@ bool DiagonalMass<DataTypes, GeometricalTypes>::checkVertexMass()
     const MassVector &vertexMass = d_vertexMass.getValue();
 
     //Check size of the vector
-    if (vertexMass.size() != size_t(m_topology->getNbPoints()))
+    if (vertexMass.size() != size_t(l_topology->getNbPoints()))
     {
-        msg_warning() << "Inconsistent size of vertexMass vector ("<< vertexMass.size() <<") compared to the DOFs size ("<< m_topology->getNbPoints() <<").";
+        msg_warning() << "Inconsistent size of vertexMass vector ("<< vertexMass.size() <<") compared to the DOFs size ("<< l_topology->getNbPoints() <<").";
         return false;
     }
     else
@@ -1418,7 +1424,7 @@ void DiagonalMass<DataTypes, GeometricalTypes>::draw(const core::visual::VisualP
     if (masses.empty())
         return;
 
-    const auto& x = m_geometryState->read(core::ConstVecCoordId::position())->getValue();
+    const auto& x = l_geometryState->read(core::ConstVecCoordId::position())->getValue();
     type::Vector3 gravityCenter;
     Real totalMass=0.0;
 

--- a/Component/Mass/src/sofa/component/mass/MeshMatrixMass.cpp
+++ b/Component/Mass/src/sofa/component/mass/MeshMatrixMass.cpp
@@ -75,13 +75,18 @@ Vector6 MeshMatrixMass<Vec3Types>::getMomentum ( const core::MechanicalParams*, 
 int MeshMatrixMassClass = core::RegisterObject("Define a specific mass for each particle")
         .add< MeshMatrixMass<Vec3Types> >()
         .add< MeshMatrixMass<Vec2Types> >()
+        .add< MeshMatrixMass<Vec2Types, Vec3Types> >()
         .add< MeshMatrixMass<Vec1Types> >()
+        .add< MeshMatrixMass<Vec1Types, Vec2Types> >()
+        .add< MeshMatrixMass<Vec1Types, Vec3Types> >()
+;
 
-        ;
-
-template class SOFA_COMPONENT_MASS_API MeshMatrixMass<Vec3Types>;
-template class SOFA_COMPONENT_MASS_API MeshMatrixMass<Vec2Types>;
-template class SOFA_COMPONENT_MASS_API MeshMatrixMass<Vec1Types>;
+template class SOFA_COMPONENT_MASS_API MeshMatrixMass<defaulttype::Vec3Types>;
+template class SOFA_COMPONENT_MASS_API MeshMatrixMass<defaulttype::Vec2Types>;
+template class SOFA_COMPONENT_MASS_API MeshMatrixMass<defaulttype::Vec2Types, defaulttype::Vec3Types>;
+template class SOFA_COMPONENT_MASS_API MeshMatrixMass<defaulttype::Vec1Types>;
+template class SOFA_COMPONENT_MASS_API MeshMatrixMass<defaulttype::Vec1Types, defaulttype::Vec2Types>;
+template class SOFA_COMPONENT_MASS_API MeshMatrixMass<defaulttype::Vec1Types, defaulttype::Vec3Types>;
 
 
 

--- a/Component/Mass/src/sofa/component/mass/MeshMatrixMass.cpp
+++ b/Component/Mass/src/sofa/component/mass/MeshMatrixMass.cpp
@@ -48,10 +48,10 @@ Vector6 MeshMatrixMass<Vec3Types>::getMomentum ( const core::MechanicalParams*, 
         for( int j=0 ; j<DataTypes::spatial_dimensions ; ++j ) momentum[3+j] += angularMomentum[j];
     }
 
-    for(size_t i=0 ; i<m_topology->getNbEdges() ; ++i )
+    for(size_t i=0 ; i<l_topology->getNbEdges() ; ++i )
     {
-        unsigned v0 = m_topology->getEdge(i)[0];
-        unsigned v1 = m_topology->getEdge(i)[1];
+        unsigned v0 = l_topology->getEdge(i)[0];
+        unsigned v1 = l_topology->getEdge(i)[1];
 
         // is it correct to share the edge mass between the 2 vertices?
         double m = edgeMass[i] * 0.5;

--- a/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
+++ b/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
@@ -234,10 +234,14 @@ public:
         {
             auto splitTemplates = sofa::helper::split(std::string(arg->getAttribute("template")), ',');
             if (splitTemplates.size() > 1)
-            {
-                msg_warning() << "MassType is not required anymore and the template is deprecated, please delete it from your scene." << msgendl
-                    << "As your mass is templated on " << DataTypes::Name() << ", MassType has been defined as " << sofa::helper::NameDecoder::getTypeName<MassType>() << " .";
-                msg_warning() << "If you want to set the template, you must write now \"template='" << DataTypes::Name() << "'\" .";
+            {   
+                // check if the given 2nd template is the deprecated MassType one
+                if (splitTemplates[1] == "float" || splitTemplates[1] == "double" || splitTemplates[1].find("RigidMass") != std::string::npos)
+                {
+                    msg_warning() << "MassType is not required anymore and the template is deprecated, please delete it from your scene." << msgendl
+                        << "As your mass is templated on " << DataTypes::Name() << ", MassType has been defined as " << sofa::helper::NameDecoder::getTypeName<MassType>() << " .";
+                    msg_warning() << "If you want to set the template, you must write now \"template='" << DataTypes::Name() << "'\" .";
+                }
             }
         }
     }
@@ -260,7 +264,7 @@ protected:
     /** Method to update @sa d_vertexMass using mass matrix coefficient when a new Triangle is created.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when TRIANGLESADDED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
     void applyVertexMassTriangleCreation(const sofa::type::vector< Index >& triangleAdded,
         const sofa::type::vector< core::topology::BaseMeshTopology::Triangle >& elems,
         const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
@@ -269,14 +273,14 @@ protected:
     /** Method to update @sa d_vertexMass using mass matrix coefficient when a Triangle is removed.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when TRIANGLESREMOVED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
     void applyVertexMassTriangleDestruction(const sofa::type::vector<Index>& triangleRemoved);
 
 
     /** Method to update @sa d_vertexMass using mass matrix coefficient when a new Quad is created.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when QUADSADDED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
     void applyVertexMassQuadCreation(const sofa::type::vector< Index >& quadAdded,
         const sofa::type::vector< core::topology::BaseMeshTopology::Quad >& elems,
         const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
@@ -285,14 +289,14 @@ protected:
     /** Method to update @sa d_vertexMass using mass matrix coefficient when a Quad is removed.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when QUADSREMOVED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
     void applyVertexMassQuadDestruction(const sofa::type::vector<Index>& quadRemoved);
 
 
     /** Method to update @sa d_vertexMass using mass matrix coefficient when a new Tetrahedron is created.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when TETRAHEDRAADDED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
     void applyVertexMassTetrahedronCreation(const sofa::type::vector< Index >& tetrahedronAdded,
         const sofa::type::vector< core::topology::BaseMeshTopology::Tetrahedron >& elems,
         const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
@@ -301,14 +305,14 @@ protected:
     /** Method to update @sa d_vertexMass using mass matrix coefficient when a Tetrahedron is removed.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when TETRAHEDRAREMOVED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
     void applyVertexMassTetrahedronDestruction(const sofa::type::vector<Index>& tetrahedronRemoved);
 
     
     /** Method to update @sa d_vertexMass using mass matrix coefficient when a new Hexahedron is created.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when HEXAHEDRAADDED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
     void applyVertexMassHexahedronCreation(const sofa::type::vector< Index >& hexahedronAdded,
         const sofa::type::vector< core::topology::BaseMeshTopology::Hexahedron >& elems,
         const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
@@ -317,7 +321,7 @@ protected:
     /** Method to update @sa d_vertexMass using mass matrix coefficient when a Hexahedron is removed.
     * Will be set as callback in the PointData @sa d_vertexMass to update the mass vector when HEXAHEDRAREMOVED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
     void applyVertexMassHexahedronDestruction(const sofa::type::vector<Index>& hexahedronRemoved);
    
 
@@ -339,7 +343,7 @@ protected:
     /** Method to update @sa d_edgeMass using mass matrix coefficient when a new Triangle is created.
     * Will be set as callback in the EdgeData @sa d_edgeMass to update the mass vector when TRIANGLESADDED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
     void applyEdgeMassTriangleCreation(const sofa::type::vector< Index >& triangleAdded,
         const sofa::type::vector< core::topology::BaseMeshTopology::Triangle >& elems,
         const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
@@ -348,14 +352,14 @@ protected:
     /** Method to update @sa d_edgeMass using mass matrix coefficient when a Triangle is removed.
     * Will be set as callback in the EdgeData @sa d_edgeMass to update the mass vector when TRIANGLESREMOVED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
     void applyEdgeMassTriangleDestruction(const sofa::type::vector<Index>& triangleRemoved);
 
 
     /** Method to update @sa d_edgeMass using mass matrix coefficient when a new Quad is created.
     * Will be set as callback in the EdgeData @sa d_edgeMass to update the mass vector when QUADSADDED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
     void applyEdgeMassQuadCreation(const sofa::type::vector< Index >& quadAdded,
         const sofa::type::vector< core::topology::BaseMeshTopology::Quad >& elems,
         const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
@@ -364,14 +368,14 @@ protected:
     /** Method to update @sa d_edgeMass using mass matrix coefficient when a Quad is removed.
     * Will be set as callback in the EdgeData @sa d_edgeMass to update the mass vector when QUADSREMOVED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 2, int > = 0 >
     void applyEdgeMassQuadDestruction(const sofa::type::vector<Index>& quadRemoved);
 
 
     /** Method to update @sa d_edgeMass using mass matrix coefficient when a new Tetrahedron is created.
     * Will be set as callback in the EdgeData @sa d_edgeMass to update the mass vector when TETRAHEDRAADDED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
     void applyEdgeMassTetrahedronCreation(const sofa::type::vector< Index >& tetrahedronAdded,
         const sofa::type::vector< core::topology::BaseMeshTopology::Tetrahedron >& elems,
         const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
@@ -380,14 +384,14 @@ protected:
     /** Method to update @sa d_edgeMass using mass matrix coefficient when a Tetrahedron is removed.
     * Will be set as callback in the EdgeData @sa d_edgeMass to update the mass vector when TETRAHEDRAREMOVED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
     void applyEdgeMassTetrahedronDestruction(const sofa::type::vector<Index>& tetrahedronRemoved);
 
 
     /** Method to update @sa d_edgeMass using mass matrix coefficient when a new Hexahedron is created.
     * Will be set as callback in the EdgeData @sa d_edgeMass to update the mass vector when HEXAHEDRAADDED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
     void applyEdgeMassHexahedronCreation(const sofa::type::vector< Index >& hexahedronAdded,
         const sofa::type::vector< core::topology::BaseMeshTopology::Hexahedron >& elems,
         const sofa::type::vector< sofa::type::vector< Index > >& ancestors,
@@ -396,7 +400,7 @@ protected:
     /** Method to update @sa d_vertexMass using mass matrix coefficient when a Hexahedron is removed.
     * Will be set as callback in the EdgeData @sa d_edgeMass to update the mass vector when HEXAHEDRAREMOVED event is fired.
     */
-    template <typename T = DataTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
+    template <typename T = GeometricalTypes, typename std::enable_if_t<T::spatial_dimensions >= 3, int > = 0 >
     void applyEdgeMassHexahedronDestruction(const sofa::type::vector<Index>& /*indices*/);
 
 

--- a/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
+++ b/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
@@ -111,6 +111,8 @@ public:
 
     /// Link to be set to the topology container in the component graph.
     SingleLink<MeshMatrixMass<DataTypes, GeometricalTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
+    /// Link to be set to the position container associated to the topology
+    SingleLink<MeshMatrixMass<DataTypes, GeometricalTypes>, sofa::core::behavior::MechanicalState<GeometricalTypes>, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_geometryState;
 
 protected:
 

--- a/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
+++ b/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
@@ -111,7 +111,7 @@ public:
 
     /// Link to be set to the topology container in the component graph.
     SingleLink<MeshMatrixMass<DataTypes, GeometricalTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
-    /// Link to be set to the position container associated to the topology
+    /// Link to be set to the MechanicalObject associated with the geometry
     SingleLink<MeshMatrixMass<DataTypes, GeometricalTypes>, sofa::core::behavior::MechanicalState<GeometricalTypes>, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_geometryState;
 
 protected:

--- a/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
+++ b/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
@@ -1013,7 +1013,7 @@ sofa::core::topology::TopologyElementType MeshMatrixMass<DataTypes, GeometricalT
 {
     if (l_topology.empty())
     {
-        msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
+        msg_warning() << "Link to the Topology \"topology\" should be set to ensure right behavior. First Topology found in current context will be used.";
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
@@ -1030,7 +1030,7 @@ sofa::core::topology::TopologyElementType MeshMatrixMass<DataTypes, GeometricalT
 
     if (l_geometryState.empty())
     {
-        msg_info() << "link to position container (State) should be set to ensure right behavior. First container found from the topology context will be used.";
+        msg_warning() << "Link to position container \"geometryState\" should be set to ensure right behavior. First container found from the topology context will be used.";
         sofa::core::behavior::BaseMechanicalState::SPtr baseState;
         l_topology->getContext()->get(baseState);
 

--- a/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
+++ b/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
@@ -1030,7 +1030,7 @@ sofa::core::topology::TopologyElementType MeshMatrixMass<DataTypes, GeometricalT
 
     if (l_geometryState.empty())
     {
-        msg_warning() << "Link to position container \"geometryState\" should be set to ensure right behavior. First container found from the topology context will be used.";
+        msg_warning() << "Link \"geometryState\" to the MechanicalObject associated with the geometry should be set to ensure right behavior. First container found from the topology context will be used.";
         sofa::core::behavior::BaseMechanicalState::SPtr baseState;
         l_topology->getContext()->get(baseState);
 

--- a/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
+++ b/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
@@ -1117,7 +1117,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::initTopologyHandlers(sofa::cor
     bool hasQuads = false;
 
 
-    if constexpr (DataTypes::spatial_dimensions >= 3)
+    if constexpr (GeometricalTypes::spatial_dimensions >= 3)
     {
         if (topologyType == TopologyElementType::HEXAHEDRON)
         {
@@ -1175,7 +1175,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::initTopologyHandlers(sofa::cor
         }
     }
 
-    if constexpr (DataTypes::spatial_dimensions >= 2)
+    if constexpr (GeometricalTypes::spatial_dimensions >= 2)
     {
         if (topologyType == TopologyElementType::QUAD || hasQuads)
         {
@@ -1397,7 +1397,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::computeMass()
     for (Index i = 0; i<nbEdges; ++i)
         applyEdgeMassCreation(i, my_edgeMassInfo[i], edges[i], emptyAncestor, emptyCoefficient);
 
-    if constexpr (DataTypes::spatial_dimensions >= 2)
+    if constexpr (GeometricalTypes::spatial_dimensions >= 2)
     {
         if (getMassTopologyType() == TopologyElementType::QUAD)
         {
@@ -1436,7 +1436,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::computeMass()
         }
     }
 
-    if constexpr (DataTypes::spatial_dimensions >= 3)
+    if constexpr (GeometricalTypes::spatial_dimensions >= 3)
     {
         if (getMassTopologyType() == TopologyElementType::HEXAHEDRON)
         {

--- a/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
+++ b/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
@@ -52,8 +52,8 @@ MeshMatrixMass<DataTypes, GeometricalTypes>::MeshMatrixMass()
     , d_printMass( initData(&d_printMass, false, "printMass","boolean if you want to check the mass conservation") )
     , f_graph( initData(&f_graph,"graph","Graph of the controlled potential") )
     , l_topology(initLink("topology", "link to the topology container"))
+    , l_geometryState(initLink("geometryState", "link to the position container associated with the topology"))
     , m_massTopologyType(TopologyElementType::UNKNOWN)
-    , m_topology(nullptr)
 {
     f_graph.setWidget("graph");
 
@@ -123,14 +123,14 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyVertexMassTriangleCreatio
     if (this->getMassTopologyType() == TopologyElementType::TRIANGLE)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
-        const auto& positions = m_geometryState->read(posid)->getValue();
+        const auto& positions = l_geometryState->read(posid)->getValue();
 
         helper::WriteAccessor< Data< type::vector<MassType> > > VertexMasses (d_vertexMass );
         auto totalMass = sofa::helper::getWriteOnlyAccessor(d_totalMass);        
 
         // update mass density vector
         sofa::Size nbMass = getMassDensity().size();
-        sofa::Size nbTri = this->m_topology->getNbTriangles();
+        sofa::Size nbTri = this->l_topology->getNbTriangles();
         if (nbMass < nbTri)
             addMassDensity(triangleAdded, ancestors, coefs);
 
@@ -141,7 +141,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyVertexMassTriangleCreatio
         for (unsigned int i = 0; i < triangleAdded.size(); ++i)
         {
             // Get the triangle to be added
-            const core::topology::BaseMeshTopology::Triangle& t = this->m_topology->getTriangle(triangleAdded[i]);
+            const core::topology::BaseMeshTopology::Triangle& t = this->l_topology->getTriangle(triangleAdded[i]);
 
             // Compute rest mass of conserne triangle = density * triangle surface.
             const auto& pos0 = GeometricalTypes::getCPos(positions[t[0]]);
@@ -179,14 +179,14 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyEdgeMassTriangleCreation(
     if (this->getMassTopologyType() == TopologyElementType::TRIANGLE)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
-        const auto& positions = m_geometryState->read(posid)->getValue();
+        const auto& positions = l_geometryState->read(posid)->getValue();
 
         helper::WriteAccessor< Data< type::vector<MassType> > > EdgeMasses ( d_edgeMass );
         auto totalMass = sofa::helper::getWriteOnlyAccessor(d_totalMass);
 
         // update mass density vector
         sofa::Size nbMass = getMassDensity().size();
-        sofa::Size nbTri = this->m_topology->getNbTriangles();
+        sofa::Size nbTri = this->l_topology->getNbTriangles();
         if (nbMass < nbTri)
             addMassDensity(triangleAdded, ancestors, coefs);
 
@@ -197,8 +197,8 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyEdgeMassTriangleCreation(
         for (unsigned int i = 0; i < triangleAdded.size(); ++i)
         {
             // Get the edgesInTriangle to be added
-            const core::topology::BaseMeshTopology::EdgesInTriangle& te = this->m_topology->getEdgesInTriangle(triangleAdded[i]);
-            const core::topology::BaseMeshTopology::Triangle& t = this->m_topology->getTriangle(triangleAdded[i]);
+            const core::topology::BaseMeshTopology::EdgesInTriangle& te = this->l_topology->getEdgesInTriangle(triangleAdded[i]);
+            const core::topology::BaseMeshTopology::Triangle& t = this->l_topology->getTriangle(triangleAdded[i]);
 
             // Compute rest mass of conserne triangle = density * triangle surface.
             const auto& pos0 = GeometricalTypes::getCPos(positions[t[0]]);
@@ -229,7 +229,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyVertexMassTriangleDestruc
     if (this->getMassTopologyType() == TopologyElementType::TRIANGLE)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
-        const auto& positions = m_geometryState->read(posid)->getValue();
+        const auto& positions = l_geometryState->read(posid)->getValue();
 
         helper::WriteAccessor< Data< type::vector<MassType> > > VertexMasses (d_vertexMass );
         auto totalMass = sofa::helper::getWriteOnlyAccessor(d_totalMass);
@@ -241,7 +241,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyVertexMassTriangleDestruc
         for (unsigned int i = 0; i < triangleRemoved.size(); ++i)
         {
             // Get the triangle to be removed
-            const core::topology::BaseMeshTopology::Triangle& t = this->m_topology->getTriangle(triangleRemoved[i]);
+            const core::topology::BaseMeshTopology::Triangle& t = this->l_topology->getTriangle(triangleRemoved[i]);
 
             // Compute rest mass of conserne triangle = density * triangle surface.
             const auto& pos0 = GeometricalTypes::getCPos(positions[t[0]]);
@@ -276,7 +276,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyEdgeMassTriangleDestructi
     if (this->getMassTopologyType() == TopologyElementType::TRIANGLE)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
-        const auto& positions = m_geometryState->read(posid)->getValue();
+        const auto& positions = l_geometryState->read(posid)->getValue();
 
         helper::WriteAccessor< Data< type::vector<MassType> > > EdgeMasses (d_edgeMass );
         auto totalMass = sofa::helper::getWriteOnlyAccessor(d_totalMass);
@@ -288,8 +288,8 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyEdgeMassTriangleDestructi
         for (unsigned int i = 0; i < triangleRemoved.size(); ++i)
         {
             // Get the triangle to be removed
-            const core::topology::BaseMeshTopology::EdgesInTriangle& te = this->m_topology->getEdgesInTriangle(triangleRemoved[i]);
-            const core::topology::BaseMeshTopology::Triangle& t = this->m_topology->getTriangle(triangleRemoved[i]);
+            const core::topology::BaseMeshTopology::EdgesInTriangle& te = this->l_topology->getEdgesInTriangle(triangleRemoved[i]);
+            const core::topology::BaseMeshTopology::Triangle& t = this->l_topology->getTriangle(triangleRemoved[i]);
 
             // Compute rest mass of conserne triangle = density * triangle surface.
             const auto& pos0 = GeometricalTypes::getCPos(positions[t[0]]);
@@ -330,14 +330,14 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyVertexMassQuadCreation(co
     if (this->getMassTopologyType() == TopologyElementType::QUAD)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
-        const auto& positions = m_geometryState->read(posid)->getValue();
+        const auto& positions = l_geometryState->read(posid)->getValue();
 
         helper::WriteAccessor< Data< type::vector<MassType> > > VertexMasses ( d_vertexMass );
         auto totalMass = sofa::helper::getWriteOnlyAccessor(d_totalMass);
 
         // update mass density vector
         sofa::Size nbMass = getMassDensity().size();
-        sofa::Size nbQ = this->m_topology->getNbQuads();
+        sofa::Size nbQ = this->l_topology->getNbQuads();
         if (nbMass < nbQ)
             addMassDensity(quadAdded, ancestors, coefs);
 
@@ -348,7 +348,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyVertexMassQuadCreation(co
         for (unsigned int i = 0; i < quadAdded.size(); ++i)
         {
             // Get the quad to be added
-            const core::topology::BaseMeshTopology::Quad& q = this->m_topology->getQuad(quadAdded[i]);
+            const core::topology::BaseMeshTopology::Quad& q = this->l_topology->getQuad(quadAdded[i]);
 
             // Compute rest mass of conserne quad = density * quad surface.
             const auto& pos0 = GeometricalTypes::getCPos(positions[q[0]]);
@@ -387,14 +387,14 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyEdgeMassQuadCreation(cons
     if (this->getMassTopologyType() == TopologyElementType::QUAD)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
-        const auto& positions = m_geometryState->read(posid)->getValue();
+        const auto& positions = l_geometryState->read(posid)->getValue();
 
         helper::WriteAccessor< Data< type::vector<MassType> > > EdgeMasses ( d_edgeMass );
         auto totalMass = sofa::helper::getWriteOnlyAccessor(d_totalMass);
         
         // update mass density vector
         sofa::Size nbMass = getMassDensity().size();
-        sofa::Size nbQ = this->m_topology->getNbQuads();
+        sofa::Size nbQ = this->l_topology->getNbQuads();
         if (nbMass < nbQ)
             addMassDensity(quadAdded, ancestors, coefs);
 
@@ -405,8 +405,8 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyEdgeMassQuadCreation(cons
         for (unsigned int i = 0; i < quadAdded.size(); ++i)
         {
             // Get the EdgesInQuad to be added
-            const core::topology::BaseMeshTopology::EdgesInQuad& qe = this->m_topology->getEdgesInQuad(quadAdded[i]);
-            const core::topology::BaseMeshTopology::Quad& q = this->m_topology->getQuad(quadAdded[i]);
+            const core::topology::BaseMeshTopology::EdgesInQuad& qe = this->l_topology->getEdgesInQuad(quadAdded[i]);
+            const core::topology::BaseMeshTopology::Quad& q = this->l_topology->getQuad(quadAdded[i]);
 
             // Compute rest mass of conserne quad = density * quad surface.
             const auto& pos0 = GeometricalTypes::getCPos(positions[q[0]]);
@@ -438,7 +438,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyVertexMassQuadDestruction
     if (this->getMassTopologyType() == TopologyElementType::QUAD)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
-        const auto& positions = m_geometryState->read(posid)->getValue();
+        const auto& positions = l_geometryState->read(posid)->getValue();
 
         helper::WriteAccessor< Data< type::vector<MassType> > > VertexMasses ( d_vertexMass );
         auto totalMass = sofa::helper::getWriteOnlyAccessor(d_totalMass);
@@ -450,7 +450,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyVertexMassQuadDestruction
         for (unsigned int i = 0; i < quadRemoved.size(); ++i)
         {
             // Get the quad to be removed
-            const core::topology::BaseMeshTopology::Quad& q = this->m_topology->getQuad(quadRemoved[i]);
+            const core::topology::BaseMeshTopology::Quad& q = this->l_topology->getQuad(quadRemoved[i]);
 
             // Compute rest mass of conserne quad = density * quad surface.
             const auto& pos0 = GeometricalTypes::getCPos(positions[q[0]]);
@@ -486,7 +486,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyEdgeMassQuadDestruction(c
     if (this->getMassTopologyType() == TopologyElementType::QUAD)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
-        const auto& positions = m_geometryState->read(posid)->getValue();
+        const auto& positions = l_geometryState->read(posid)->getValue();
 
         helper::WriteAccessor< Data< type::vector<MassType> > > EdgeMasses ( d_edgeMass );
         auto totalMass = sofa::helper::getWriteOnlyAccessor(d_totalMass);
@@ -498,8 +498,8 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyEdgeMassQuadDestruction(c
         for (unsigned int i = 0; i < quadRemoved.size(); ++i)
         {
             // Get the EdgesInQuad to be removed
-            const core::topology::BaseMeshTopology::EdgesInQuad& qe = this->m_topology->getEdgesInQuad(quadRemoved[i]);
-            const core::topology::BaseMeshTopology::Quad& q = this->m_topology->getQuad(quadRemoved[i]);
+            const core::topology::BaseMeshTopology::EdgesInQuad& qe = this->l_topology->getEdgesInQuad(quadRemoved[i]);
+            const core::topology::BaseMeshTopology::Quad& q = this->l_topology->getQuad(quadRemoved[i]);
 
             // Compute rest mass of conserne quad = density * quad surface.
             const auto& pos0 = GeometricalTypes::getCPos(positions[q[0]]);
@@ -544,14 +544,14 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyVertexMassTetrahedronCrea
     if (this->getMassTopologyType() == TopologyElementType::TETRAHEDRON)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
-        const auto& positions = m_geometryState->read(posid)->getValue();
+        const auto& positions = l_geometryState->read(posid)->getValue();
 
         helper::WriteAccessor< Data< type::vector<MassType> > > VertexMasses ( d_vertexMass );
         auto totalMass = sofa::helper::getWriteOnlyAccessor(d_totalMass);
 
         // update mass density vector
         sofa::Size nbMass = getMassDensity().size();
-        sofa::Size nbT = this->m_topology->getNbTetrahedra();
+        sofa::Size nbT = this->l_topology->getNbTetrahedra();
         if (nbMass < nbT)
             addMassDensity(tetrahedronAdded, ancestors, coefs);
 
@@ -562,7 +562,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyVertexMassTetrahedronCrea
         for (unsigned int i = 0; i<tetrahedronAdded.size(); ++i)
         {
             // Get the tetrahedron to be added
-            const core::topology::BaseMeshTopology::Tetrahedron &t = this->m_topology->getTetrahedron(tetrahedronAdded[i]);
+            const core::topology::BaseMeshTopology::Tetrahedron &t = this->l_topology->getTetrahedron(tetrahedronAdded[i]);
 
             // Compute rest mass of conserne tetrahedron = density * tetrahedron volume.
             const auto& rpos0 = GeometricalTypes::getCPos(positions[t[0]]);
@@ -601,14 +601,14 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyEdgeMassTetrahedronCreati
     if (this->getMassTopologyType() == TopologyElementType::TETRAHEDRON)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
-        const auto& positions = m_geometryState->read(posid)->getValue();
+        const auto& positions = l_geometryState->read(posid)->getValue();
 
         helper::WriteAccessor< Data< type::vector<MassType> > > EdgeMasses ( d_edgeMass );
         auto totalMass = sofa::helper::getWriteOnlyAccessor(d_totalMass);
 
         // update mass density vector
         sofa::Size nbMass = getMassDensity().size();
-        sofa::Size nbT = this->m_topology->getNbTetrahedra();
+        sofa::Size nbT = this->l_topology->getNbTetrahedra();
         if (nbMass < nbT)
             addMassDensity(tetrahedronAdded, ancestors, coefs);
 
@@ -619,8 +619,8 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyEdgeMassTetrahedronCreati
         for (unsigned int i = 0; i < tetrahedronAdded.size(); ++i)
         {
             // Get the edgesInTetrahedron to be added
-            const core::topology::BaseMeshTopology::EdgesInTetrahedron& te = this->m_topology->getEdgesInTetrahedron(tetrahedronAdded[i]);
-            const core::topology::BaseMeshTopology::Tetrahedron& t = this->m_topology->getTetrahedron(tetrahedronAdded[i]);
+            const core::topology::BaseMeshTopology::EdgesInTetrahedron& te = this->l_topology->getEdgesInTetrahedron(tetrahedronAdded[i]);
+            const core::topology::BaseMeshTopology::Tetrahedron& t = this->l_topology->getTetrahedron(tetrahedronAdded[i]);
 
             // Compute rest mass of conserne tetrahedron = density * tetrahedron volume.
             const auto& rpos0 = GeometricalTypes::getCPos(positions[t[0]]);
@@ -652,7 +652,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyVertexMassTetrahedronDest
     if (this->getMassTopologyType() == TopologyElementType::TETRAHEDRON)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
-        const auto& positions = m_geometryState->read(posid)->getValue();
+        const auto& positions = l_geometryState->read(posid)->getValue();
 
         helper::WriteAccessor< Data< type::vector<MassType> > > VertexMasses ( d_vertexMass );
         auto totalMass = sofa::helper::getWriteOnlyAccessor(d_totalMass);
@@ -664,7 +664,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyVertexMassTetrahedronDest
         for (unsigned int i = 0; i < tetrahedronRemoved.size(); ++i)
         {
             // Get the tetrahedron to be removed
-            const core::topology::BaseMeshTopology::Tetrahedron& t = this->m_topology->getTetrahedron(tetrahedronRemoved[i]);
+            const core::topology::BaseMeshTopology::Tetrahedron& t = this->l_topology->getTetrahedron(tetrahedronRemoved[i]);
 
             // Compute rest mass of conserne tetrahedron = density * tetrahedron volume.
             const auto& rpos0 = GeometricalTypes::getCPos(positions[t[0]]);
@@ -700,7 +700,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyEdgeMassTetrahedronDestru
     if (this->getMassTopologyType() == TopologyElementType::TETRAHEDRON)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
-        const auto& positions = m_geometryState->read(posid)->getValue();
+        const auto& positions = l_geometryState->read(posid)->getValue();
 
         helper::WriteAccessor< Data< type::vector<MassType> > > EdgeMasses ( d_edgeMass );
         auto totalMass = sofa::helper::getWriteOnlyAccessor(d_totalMass);
@@ -712,8 +712,8 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyEdgeMassTetrahedronDestru
         for (unsigned int i = 0; i < tetrahedronRemoved.size(); ++i)
         {
             // Get the edgesInTetrahedron to be removed
-            const core::topology::BaseMeshTopology::EdgesInTetrahedron& te = this->m_topology->getEdgesInTetrahedron(tetrahedronRemoved[i]);
-            const core::topology::BaseMeshTopology::Tetrahedron& t = this->m_topology->getTetrahedron(tetrahedronRemoved[i]);
+            const core::topology::BaseMeshTopology::EdgesInTetrahedron& te = this->l_topology->getEdgesInTetrahedron(tetrahedronRemoved[i]);
+            const core::topology::BaseMeshTopology::Tetrahedron& t = this->l_topology->getTetrahedron(tetrahedronRemoved[i]);
 
             // Compute rest mass of conserne tetrahedron = density * tetrahedron volume.
             const auto& rpos0 = GeometricalTypes::getCPos(positions[t[0]]);
@@ -756,14 +756,14 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyVertexMassHexahedronCreat
     if (this->getMassTopologyType() == TopologyElementType::HEXAHEDRON)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
-        const auto& positions = m_geometryState->read(posid)->getValue();
+        const auto& positions = l_geometryState->read(posid)->getValue();
 
         helper::WriteAccessor< Data< type::vector<MassType> > > VertexMasses ( d_vertexMass );
         auto totalMass = sofa::helper::getWriteOnlyAccessor(d_totalMass);
 
         // update mass density vector
         sofa::Size nbMass = getMassDensity().size();
-        sofa::Size nbT = this->m_topology->getNbHexahedra();
+        sofa::Size nbT = this->l_topology->getNbHexahedra();
         if (nbMass < nbT)
             addMassDensity(hexahedronAdded, ancestors, coefs);
 
@@ -774,7 +774,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyVertexMassHexahedronCreat
         for (unsigned int i = 0; i < hexahedronAdded.size(); ++i)
         {
             // Get the hexahedron to be added
-            const core::topology::BaseMeshTopology::Hexahedron& h = this->m_topology->getHexahedron(hexahedronAdded[i]);
+            const core::topology::BaseMeshTopology::Hexahedron& h = this->l_topology->getHexahedron(hexahedronAdded[i]);
 
             /// compute its mass based on the mass density and the hexahedron volume
             const auto& rpos0 = GeometricalTypes::getCPos(positions[h[0]]);
@@ -817,14 +817,14 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyEdgeMassHexahedronCreatio
     if (this->getMassTopologyType() == TopologyElementType::HEXAHEDRON)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
-        const auto& positions = m_geometryState->read(posid)->getValue();
+        const auto& positions = l_geometryState->read(posid)->getValue();
 
         helper::WriteAccessor< Data< type::vector<MassType> > > EdgeMasses ( d_edgeMass );
         auto totalMass = sofa::helper::getWriteOnlyAccessor(d_totalMass);
 
         // update mass density vector
         sofa::Size nbMass = getMassDensity().size();
-        sofa::Size nbT = this->m_topology->getNbHexahedra();
+        sofa::Size nbT = this->l_topology->getNbHexahedra();
         if (nbMass < nbT)
             addMassDensity(hexahedronAdded, ancestors, coefs);
 
@@ -835,8 +835,8 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyEdgeMassHexahedronCreatio
         for (unsigned int i = 0; i < hexahedronAdded.size(); ++i)
         {
             // Get the EdgesInHexahedron to be added
-            const core::topology::BaseMeshTopology::EdgesInHexahedron& he = this->m_topology->getEdgesInHexahedron(hexahedronAdded[i]);
-            const core::topology::BaseMeshTopology::Hexahedron& h = this->m_topology->getHexahedron(hexahedronAdded[i]);
+            const core::topology::BaseMeshTopology::EdgesInHexahedron& he = this->l_topology->getEdgesInHexahedron(hexahedronAdded[i]);
+            const core::topology::BaseMeshTopology::Hexahedron& h = this->l_topology->getHexahedron(hexahedronAdded[i]);
 
             /// compute its mass based on the mass density and the hexahedron volume
             const auto& rpos0 = GeometricalTypes::getCPos(positions[h[0]]);
@@ -872,7 +872,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyVertexMassHexahedronDestr
     if (this->getMassTopologyType() == TopologyElementType::HEXAHEDRON)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
-        const auto& positions = m_geometryState->read(posid)->getValue();
+        const auto& positions = l_geometryState->read(posid)->getValue();
 
         helper::WriteAccessor< Data< type::vector<MassType> > > VertexMasses ( d_vertexMass );
         auto totalMass = sofa::helper::getWriteOnlyAccessor(d_totalMass);
@@ -884,7 +884,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyVertexMassHexahedronDestr
         for (unsigned int i = 0; i < hexahedronRemoved.size(); ++i)
         {
             // Get the hexahedron to be removed
-            const core::topology::BaseMeshTopology::Hexahedron& h = this->m_topology->getHexahedron(hexahedronRemoved[i]);
+            const core::topology::BaseMeshTopology::Hexahedron& h = this->l_topology->getHexahedron(hexahedronRemoved[i]);
 
             // Compute rest mass of conserne hexahedron = density * hexahedron volume.
             const auto& rpos0 = GeometricalTypes::getCPos(positions[h[0]]);
@@ -924,7 +924,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyEdgeMassHexahedronDestruc
     if (this->getMassTopologyType() == TopologyElementType::HEXAHEDRON)
     {
         core::ConstVecCoordId posid = this->d_computeMassOnRest.getValue() ? core::ConstVecCoordId::restPosition() : core::ConstVecCoordId::position();
-        const auto& positions = m_geometryState->read(posid)->getValue();
+        const auto& positions = l_geometryState->read(posid)->getValue();
 
         helper::WriteAccessor< Data< type::vector<MassType> > > EdgeMasses ( d_edgeMass );
         auto totalMass = sofa::helper::getWriteOnlyAccessor(d_totalMass);
@@ -936,8 +936,8 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::applyEdgeMassHexahedronDestruc
         for (unsigned int i = 0; i < hexahedronRemoved.size(); ++i)
         {
             // Get the EdgesInHexahedron to be removed
-            const core::topology::BaseMeshTopology::EdgesInHexahedron& he = this->m_topology->getEdgesInHexahedron(hexahedronRemoved[i]);
-            const core::topology::BaseMeshTopology::Hexahedron& h = this->m_topology->getHexahedron(hexahedronRemoved[i]);
+            const core::topology::BaseMeshTopology::EdgesInHexahedron& he = this->l_topology->getEdgesInHexahedron(hexahedronRemoved[i]);
+            const core::topology::BaseMeshTopology::Hexahedron& h = this->l_topology->getHexahedron(hexahedronRemoved[i]);
 
             // Compute rest mass of conserne hexahedron = density * hexahedron volume.
             const auto& rpos0 = GeometricalTypes::getCPos(positions[h[0]]);
@@ -1017,58 +1017,65 @@ sofa::core::topology::TopologyElementType MeshMatrixMass<DataTypes, GeometricalT
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 
-    m_topology = l_topology.get();
-    msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
-
-    if (m_topology == nullptr)
+    if (l_topology.get() == nullptr)
     {
         msg_error() << "No topology component found at path: " << l_topology.getLinkedPath() << ", nor in current context: " << this->getContext()->name;
         sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         return sofa::core::topology::TopologyElementType::POINT;
     }
-
-    sofa::core::behavior::BaseMechanicalState::SPtr baseState;
-    m_topology->getContext()->get(baseState);
-    if (baseState == nullptr)
-    {
-        msg_error() << "No state associated with the topology has been found.";
-        return sofa::core::topology::TopologyElementType::POINT;
-    }
     else
     {
-        m_geometryState = boost::dynamic_pointer_cast<sofa::core::behavior::MechanicalState<GeometricalTypes>>(baseState);
-        if (m_geometryState == nullptr)
+        msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
+    }
+
+    if (l_geometryState.empty())
+    {
+        msg_info() << "link to position container (State) should be set to ensure right behavior. First container found from the topology context will be used.";
+        sofa::core::behavior::BaseMechanicalState::SPtr baseState;
+        l_topology->getContext()->get(baseState);
+
+        if (baseState == nullptr)
         {
-            msg_error() << "A state associated with the topology has been found but is incompatible with the definition of the mass (templates mismatch).";
+            msg_error() << "No compatible state associated with the topology has been found.";
             return sofa::core::topology::TopologyElementType::POINT;
         }
         else
         {
-            msg_info() << "Topology is associated with the state: '" << m_geometryState->getPathName() << "'";
+            typename sofa::core::behavior::MechanicalState<GeometricalTypes>::SPtr geometryState = boost::dynamic_pointer_cast<sofa::core::behavior::MechanicalState<GeometricalTypes>>(baseState);
+            if (geometryState == nullptr)
+            {
+                msg_error() << "A state associated with the topology has been found but is incompatible with the definition of the mass (templates mismatch).";
+                return sofa::core::topology::TopologyElementType::POINT;
+            }
+            else
+            {
+                l_geometryState.set(geometryState);
+                msg_info() << "Topology is associated with the state: '" << l_geometryState->getPathName() << "'";
+            }
         }
     }
-    
-    if (m_topology->getNbHexahedra() > 0)
+        
+    if (l_topology->getNbHexahedra() > 0)
     {
         msg_info() << "Hexahedral topology found.";
         return TopologyElementType::HEXAHEDRON;
     }
-    else if (m_topology->getNbTetrahedra() > 0)
+    else if (l_topology->getNbTetrahedra() > 0)
     {
         msg_info() << "Tetrahedral topology found.";
         return TopologyElementType::TETRAHEDRON;
     }
-    else if (m_topology->getNbQuads() > 0)
+    else if (l_topology->getNbQuads() > 0)
     {
         msg_info() << "Quad topology found.";
         return TopologyElementType::QUAD;
     }
-    else if (m_topology->getNbTriangles() > 0)
+    else if (l_topology->getNbTriangles() > 0)
     {
         msg_info() << "Triangular topology found.";
         return TopologyElementType::TRIANGLE;
     }
-    else if (m_topology->getNbEdges() > 0)
+    else if (l_topology->getNbEdges() > 0)
     {
         msg_info() << "Edge topology found.";
         return TopologyElementType::EDGE;
@@ -1085,7 +1092,7 @@ template <class DataTypes, class GeometricalTypes>
 void MeshMatrixMass<DataTypes, GeometricalTypes>::initTopologyHandlers(sofa::core::topology::TopologyElementType topologyType)
 {
     // add the functions to handle topology changes for Vertex informations
-    d_vertexMass.createTopologyHandler(m_topology);
+    d_vertexMass.createTopologyHandler(l_topology);
     d_vertexMass.setCreationCallback([this](Index pointIndex, MassType& m,
         const core::topology::BaseMeshTopology::Point& point,
         const sofa::type::vector< Index >& ancestors,
@@ -1099,7 +1106,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::initTopologyHandlers(sofa::cor
     });
 
     // add the functions to handle topology changes for Edge informations
-    d_edgeMass.createTopologyHandler(m_topology);
+    d_edgeMass.createTopologyHandler(l_topology);
     d_edgeMass.setCreationCallback([this](Index edgeIndex, MassType& EdgeMass,
         const core::topology::BaseMeshTopology::Edge& edge,
         const sofa::type::vector< Index >& ancestors,
@@ -1378,8 +1385,8 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::computeMass()
     auto my_edgeMassInfo = sofa::helper::getWriteOnlyAccessor(d_edgeMass);
 
     unsigned int ndof = this->mstate->getSize();
-    unsigned int nbEdges=m_topology->getNbEdges();
-    const type::vector<core::topology::BaseMeshTopology::Edge>& edges = m_topology->getEdges();
+    unsigned int nbEdges=l_topology->getNbEdges();
+    const type::vector<core::topology::BaseMeshTopology::Edge>& edges = l_topology->getEdges();
 
     my_vertexMassInfo.resize(ndof);
     my_edgeMassInfo.resize(nbEdges);
@@ -1404,17 +1411,17 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::computeMass()
             // create vector tensor by calling the quad creation function on the entire mesh
             sofa::type::vector<Index> quadsAdded;
 
-            size_t n = m_topology->getNbQuads();
+            size_t n = l_topology->getNbQuads();
             for (Index i = 0; i < n; ++i)
                 quadsAdded.push_back(i);
 
             m_massLumpingCoeff = 2.0;
             if (!isLumped())
             {
-                applyEdgeMassQuadCreation(quadsAdded, m_topology->getQuads(), emptyAncestors, emptyCoefficients);
+                applyEdgeMassQuadCreation(quadsAdded, l_topology->getQuads(), emptyAncestors, emptyCoefficients);
             }
 
-            applyVertexMassQuadCreation(quadsAdded, m_topology->getQuads(), emptyAncestors, emptyCoefficients);
+            applyVertexMassQuadCreation(quadsAdded, l_topology->getQuads(), emptyAncestors, emptyCoefficients);
         }
 
         if (getMassTopologyType() == TopologyElementType::TRIANGLE)
@@ -1422,17 +1429,17 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::computeMass()
             // create vector tensor by calling the triangle creation function on the entire mesh
             sofa::type::vector<Index> trianglesAdded;
 
-            size_t n = m_topology->getNbTriangles();
+            size_t n = l_topology->getNbTriangles();
             for (Index i = 0; i < n; ++i)
                 trianglesAdded.push_back(i);
 
             m_massLumpingCoeff = 2.0;
             if (!isLumped())
             {
-                applyEdgeMassTriangleCreation(trianglesAdded, m_topology->getTriangles(), emptyAncestors, emptyCoefficients);
+                applyEdgeMassTriangleCreation(trianglesAdded, l_topology->getTriangles(), emptyAncestors, emptyCoefficients);
             }
 
-            applyVertexMassTriangleCreation(trianglesAdded, m_topology->getTriangles(), emptyAncestors, emptyCoefficients);
+            applyVertexMassTriangleCreation(trianglesAdded, l_topology->getTriangles(), emptyAncestors, emptyCoefficients);
         }
     }
 
@@ -1442,17 +1449,17 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::computeMass()
         {
             // create vector tensor by calling the hexahedron creation function on the entire mesh
             sofa::type::vector<Index> hexahedraAdded;
-            size_t n = m_topology->getNbHexahedra();
+            size_t n = l_topology->getNbHexahedra();
             for (Index i = 0; i < n; ++i)
                 hexahedraAdded.push_back(i);
 
             m_massLumpingCoeff = 2.5;
             if (!isLumped())
             {
-                applyEdgeMassHexahedronCreation(hexahedraAdded, m_topology->getHexahedra(), emptyAncestors, emptyCoefficients);
+                applyEdgeMassHexahedronCreation(hexahedraAdded, l_topology->getHexahedra(), emptyAncestors, emptyCoefficients);
             }
 
-            applyVertexMassHexahedronCreation(hexahedraAdded, m_topology->getHexahedra(), emptyAncestors, emptyCoefficients);
+            applyVertexMassHexahedronCreation(hexahedraAdded, l_topology->getHexahedra(), emptyAncestors, emptyCoefficients);
         }
 
         if (getMassTopologyType() == TopologyElementType::TETRAHEDRON)
@@ -1460,17 +1467,17 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::computeMass()
             // create vector tensor by calling the tetrahedron creation function on the entire mesh
             sofa::type::vector<Index> tetrahedraAdded;
 
-            size_t n = m_topology->getNbTetrahedra();
+            size_t n = l_topology->getNbTetrahedra();
             for (Index i = 0; i < n; ++i)
                 tetrahedraAdded.push_back(i);
 
             m_massLumpingCoeff = 2.5;
             if (!isLumped())
             {
-                applyEdgeMassTetrahedronCreation(tetrahedraAdded, m_topology->getTetrahedra(), emptyAncestors, emptyCoefficients);
+                applyEdgeMassTetrahedronCreation(tetrahedraAdded, l_topology->getTetrahedra(), emptyAncestors, emptyCoefficients);
             }
 
-            applyVertexMassTetrahedronCreation(tetrahedraAdded, m_topology->getTetrahedra(), emptyAncestors, emptyCoefficients);
+            applyVertexMassTetrahedronCreation(tetrahedraAdded, l_topology->getTetrahedra(), emptyAncestors, emptyCoefficients);
         }
     }
 }
@@ -1554,9 +1561,9 @@ bool MeshMatrixMass<DataTypes, GeometricalTypes>::checkVertexMass()
 {
     const auto &vertexMass = d_vertexMass.getValue();
     //Check size of the vector
-    if (vertexMass.size() != size_t(m_topology->getNbPoints()))
+    if (vertexMass.size() != size_t(l_topology->getNbPoints()))
     {
-        msg_warning() << "Inconsistent size of vertexMass vector ("<< vertexMass.size() <<") compared to the DOFs size ("<< m_topology->getNbPoints() <<").";
+        msg_warning() << "Inconsistent size of vertexMass vector ("<< vertexMass.size() <<") compared to the DOFs size ("<< l_topology->getNbPoints() <<").";
         return false;
     }
     else
@@ -1611,7 +1618,7 @@ bool MeshMatrixMass<DataTypes, GeometricalTypes>::checkEdgeMass()
 {
     const auto& edgeMass = d_edgeMass.getValue();
     //Check size of the vector
-    if (edgeMass.size() != m_topology->getNbEdges())
+    if (edgeMass.size() != l_topology->getNbEdges())
     {
         msg_warning() << "Inconsistent size of vertexMass vector compared to the DOFs size.";
         return false;
@@ -1682,43 +1689,43 @@ bool MeshMatrixMass<DataTypes, GeometricalTypes>::checkMassDensity()
     //Check size of the vector
     //Size = 1, homogeneous density
     //Otherwise, heterogeneous density
-    if (m_topology->getNbHexahedra()>0)
+    if (l_topology->getNbHexahedra()>0)
     {
-        sizeElements = m_topology->getNbHexahedra();
+        sizeElements = l_topology->getNbHexahedra();
 
-        if ( massDensity.size() != m_topology->getNbHexahedra() && massDensity.size() != 1)
+        if ( massDensity.size() != l_topology->getNbHexahedra() && massDensity.size() != 1)
         {
-            msg_warning() << "Inconsistent size of massDensity = " << massDensity.size() << ", should be either 1 or " << m_topology->getNbHexahedra();
+            msg_warning() << "Inconsistent size of massDensity = " << massDensity.size() << ", should be either 1 or " << l_topology->getNbHexahedra();
             return false;
         }
     }
-    else if (m_topology->getNbTetrahedra()>0)
+    else if (l_topology->getNbTetrahedra()>0)
     {
-        sizeElements = m_topology->getNbTetrahedra();
+        sizeElements = l_topology->getNbTetrahedra();
 
-        if ( massDensity.size() != m_topology->getNbTetrahedra() && massDensity.size() != 1)
+        if ( massDensity.size() != l_topology->getNbTetrahedra() && massDensity.size() != 1)
         {
-            msg_warning() << "Inconsistent size of massDensity = " << massDensity.size() << ", should be either 1 or " << m_topology->getNbTetrahedra();
+            msg_warning() << "Inconsistent size of massDensity = " << massDensity.size() << ", should be either 1 or " << l_topology->getNbTetrahedra();
             return false;
         }
     }
-    else if (m_topology->getNbQuads()>0)
+    else if (l_topology->getNbQuads()>0)
     {
-        sizeElements = m_topology->getNbQuads();
+        sizeElements = l_topology->getNbQuads();
 
-        if ( massDensity.size() != m_topology->getNbQuads() && massDensity.size() != 1)
+        if ( massDensity.size() != l_topology->getNbQuads() && massDensity.size() != 1)
         {
-            msg_warning() << "Inconsistent size of massDensity = " << massDensity.size() << ", should be either 1 or " << m_topology->getNbQuads();
+            msg_warning() << "Inconsistent size of massDensity = " << massDensity.size() << ", should be either 1 or " << l_topology->getNbQuads();
             return false;
         }
     }
-    else if (m_topology->getNbTriangles()>0)
+    else if (l_topology->getNbTriangles()>0)
     {
-        sizeElements = m_topology->getNbTriangles();
+        sizeElements = l_topology->getNbTriangles();
 
-        if ( massDensity.size() != m_topology->getNbTriangles() && massDensity.size() != 1)
+        if ( massDensity.size() != l_topology->getNbTriangles() && massDensity.size() != 1)
         {
-            msg_warning() << "Inconsistent size of massDensity = " << massDensity.size() << ", should be either 1 or " << m_topology->getNbTriangles();
+            msg_warning() << "Inconsistent size of massDensity = " << massDensity.size() << ", should be either 1 or " << l_topology->getNbTriangles();
             return false;
         }
     }
@@ -1990,8 +1997,8 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::addMDx(const core::MechanicalP
     //using a sparse matrix---------------
     else
     {
-        size_t nbEdges=m_topology->getNbEdges();
-        const auto& edges = m_topology->getEdges();
+        size_t nbEdges=l_topology->getNbEdges();
+        const auto& edges = l_topology->getEdges();
 
         for (unsigned int i=0; i<dx.size(); i++)
         {
@@ -2083,7 +2090,7 @@ SReal MeshMatrixMass<DataTypes, GeometricalTypes>::getKineticEnergy( const core:
 
     helper::ReadAccessor< DataVecDeriv > v = vv;
 
-    unsigned int nbEdges=m_topology->getNbEdges();
+    unsigned int nbEdges=l_topology->getNbEdges();
     unsigned int v0,v1;
 
     SReal e = 0;
@@ -2095,8 +2102,8 @@ SReal MeshMatrixMass<DataTypes, GeometricalTypes>::getKineticEnergy( const core:
 
     for (unsigned int i = 0; i < nbEdges; ++i)
     {
-        v0 = m_topology->getEdge(i)[0];
-        v1 = m_topology->getEdge(i)[1];
+        v0 = l_topology->getEdge(i)[0];
+        v1 = l_topology->getEdge(i)[1];
 
         e += 2 * dot(v[v0], v[v1])*edgeMass[i];
 
@@ -2164,7 +2171,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::addMToMatrix(const core::Mecha
     const auto &vertexMass= d_vertexMass.getValue();
     const auto &edgeMass= d_edgeMass.getValue();
 
-    const size_t nbEdges=m_topology->getNbEdges();
+    const size_t nbEdges=l_topology->getNbEdges();
     sofa::Index v0,v1;
 
     static constexpr auto N = Deriv::total_size;
@@ -2173,10 +2180,10 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::addMToMatrix(const core::Mecha
     sofa::linearalgebra::BaseMatrix* mat = r.matrix;
     const Real mFactor = Real(sofa::core::mechanicalparams::mFactorIncludingRayleighDamping(mparams, this->rayleighMass.getValue()));
 
-    if((mat->colSize()) != (linearalgebra::BaseMatrix::Index)(m_topology->getNbPoints()*N) || (mat->rowSize()) != (linearalgebra::BaseMatrix::Index)(m_topology->getNbPoints()*N))
+    if((mat->colSize()) != (linearalgebra::BaseMatrix::Index)(l_topology->getNbPoints()*N) || (mat->rowSize()) != (linearalgebra::BaseMatrix::Index)(l_topology->getNbPoints()*N))
     {
         msg_error() <<"Wrong size of the input Matrix: need resize in addMToMatrix function.";
-        mat->resize(m_topology->getNbPoints()*N,m_topology->getNbPoints()*N);
+        mat->resize(l_topology->getNbPoints()*N,l_topology->getNbPoints()*N);
     }
 
     SReal massTotal=0.0;
@@ -2213,8 +2220,8 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::addMToMatrix(const core::Mecha
 
         for (size_t j = 0; j < nbEdges; ++j)
         {
-            v0 = m_topology->getEdge(j)[0];
-            v1 = m_topology->getEdge(j)[1];
+            v0 = l_topology->getEdge(j)[0];
+            v1 = l_topology->getEdge(j)[1];
 
             calc(r.matrix, edgeMass[j], r.offset + N*v0, r.offset + N*v1, mFactor);
             calc(r.matrix, edgeMass[j], r.offset + N*v1, r.offset + N*v0, mFactor);
@@ -2277,7 +2284,7 @@ void MeshMatrixMass<DataTypes, GeometricalTypes>::draw(const core::visual::Visua
 
     const auto &vertexMass= d_vertexMass.getValue();
 
-    const auto& x = m_geometryState->read(core::ConstVecCoordId::position())->getValue();
+    const auto& x = l_geometryState->read(core::ConstVecCoordId::position())->getValue();
     type::Vector3 gravityCenter;
     Real totalMass=0.0;
 

--- a/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
+++ b/Component/Mass/src/sofa/component/mass/MeshMatrixMass.inl
@@ -52,7 +52,7 @@ MeshMatrixMass<DataTypes, GeometricalTypes>::MeshMatrixMass()
     , d_printMass( initData(&d_printMass, false, "printMass","boolean if you want to check the mass conservation") )
     , f_graph( initData(&f_graph,"graph","Graph of the controlled potential") )
     , l_topology(initLink("topology", "link to the topology container"))
-    , l_geometryState(initLink("geometryState", "link to the position container associated with the topology"))
+    , l_geometryState(initLink("geometryState", "link to the MechanicalObject associated with the geometry"))
     , m_massTopologyType(TopologyElementType::UNKNOWN)
 {
     f_graph.setWidget("graph");
@@ -1013,7 +1013,7 @@ sofa::core::topology::TopologyElementType MeshMatrixMass<DataTypes, GeometricalT
 {
     if (l_topology.empty())
     {
-        msg_warning() << "Link to the Topology \"topology\" should be set to ensure right behavior. First Topology found in current context will be used.";
+        msg_warning() << "Link \"topology\" to the Topology container should be set to ensure right behavior. First Topology found in current context will be used.";
         l_topology.set(this->getContext()->getMeshTopologyLink());
     }
 

--- a/SofaKernel/modules/SofaSimpleFem/SofaSimpleFem_test/TetrahedronDiffusionFEMForceField_test.cpp
+++ b/SofaKernel/modules/SofaSimpleFem/SofaSimpleFem_test/TetrahedronDiffusionFEMForceField_test.cpp
@@ -39,17 +39,6 @@ using sofa::testing::BaseTest;
 #include <SofaEngine/initSofaEngine.h>
 #include <SofaMeshCollision/initSofaMeshCollision.h>
 #include <SofaImplicitOdeSolver/initSofaImplicitOdeSolver.h>
- 
-
-#if defined(WIN32) && _MSC_VER<=1700  // before or equal to visual studio 2012
-   #include <boost/math/special_functions/erf.hpp>
-   #define ERFC(x) boost::math::erfc(x)
-#else
-   #define ERFC(x) std::erfc(x)
-#endif
-
-
-
 
 namespace sofa {
 
@@ -185,7 +174,7 @@ struct TetrahedronDiffusionFEMForceField_test : public BaseTest
     {
         // For a Dirac heat of T=1 and a fixed BC T=0, the temperature at time = TTTT in the middle of the beam is:
         SReal temp = 1.0 / (4.0 * sqrt(timeEvaluation));
-        theorX[0] = 1.0 * ERFC( temp );
+        theorX[0] = 1.0 * std::erfc(temp);
     }
 
 

--- a/SofaKernel/modules/SofaSimpleFem/SofaSimpleFem_test/TetrahedronDiffusionFEMForceField_test.cpp
+++ b/SofaKernel/modules/SofaSimpleFem/SofaSimpleFem_test/TetrahedronDiffusionFEMForceField_test.cpp
@@ -174,7 +174,7 @@ struct TetrahedronDiffusionFEMForceField_test : public BaseTest
     {
         // For a Dirac heat of T=1 and a fixed BC T=0, the temperature at time = TTTT in the middle of the beam is:
         SReal temp = 1.0 / (4.0 * sqrt(timeEvaluation));
-        theorX[0] = 1.0 * std::erfc(temp);
+        theorX[0] = std::erfc(temp);
     }
 
 

--- a/SofaKernel/modules/SofaSimpleFem/SofaSimpleFem_test/scenes/TetrahedronDiffusionFEMForceField.scn
+++ b/SofaKernel/modules/SofaSimpleFem/SofaSimpleFem_test/scenes/TetrahedronDiffusionFEMForceField.scn
@@ -27,7 +27,6 @@
             <MechanicalObject template="Vec1d" position="@../../temperatureLoader.position"  name="gridTemperature" bbox="0 0 0 0 0 0" tags="heat" />
             <TetrahedronDiffusionFEMForceField template="Vec1d" name="DiffusionForceField" constantDiffusionCoefficient="1.0" tagMechanics="geom" tags="heat" topology="@../Container"/>
             <DiagonalMass template="Vec1d,Vec3d" name="Mass" massDensity="1.0" tags="heat"/>
-            <!-- <MeshMatrixMass name="Mass" template="Vec1d,Vec3d" lumping="0" massDensity="1.0" printLog="0" tags="heat" /> -->
             <LinearMovementConstraint template="Vec1d" keyTimes="0 998 999" movements="1 1 0" indices="@../../box-dirac.indices" />
             <FixedConstraint indices="@../../box-fixed.indices" />
         </Node>

--- a/SofaKernel/modules/SofaSimpleFem/SofaSimpleFem_test/scenes/TetrahedronDiffusionFEMForceField.scn
+++ b/SofaKernel/modules/SofaSimpleFem/SofaSimpleFem_test/scenes/TetrahedronDiffusionFEMForceField.scn
@@ -26,7 +26,7 @@
             <CGLinearSolver name="CG" iterations="1000" tolerance="1.0e-10" threshold="1.0e-30" tags="heat" />
             <MechanicalObject template="Vec1d" position="@../../temperatureLoader.position"  name="gridTemperature" bbox="0 0 0 0 0 0" tags="heat" />
             <TetrahedronDiffusionFEMForceField template="Vec1d" name="DiffusionForceField" constantDiffusionCoefficient="1.0" tagMechanics="geom" tags="heat" topology="@../Container"/>
-            <DiagonalMass template="Vec1d,Vec3d" name="Mass" massDensity="1.0" tags="heat"/>
+            <DiagonalMass template="Vec1d,Vec3d" name="Mass" massDensity="1.0" tags="heat" topology="@../Container" geometryState="@../../gridDOFs" />
             <LinearMovementConstraint template="Vec1d" keyTimes="0 998 999" movements="1 1 0" indices="@../../box-dirac.indices" />
             <FixedConstraint indices="@../../box-fixed.indices" />
         </Node>

--- a/SofaKernel/modules/SofaSimpleFem/SofaSimpleFem_test/scenes/TetrahedronDiffusionFEMForceField.scn
+++ b/SofaKernel/modules/SofaSimpleFem/SofaSimpleFem_test/scenes/TetrahedronDiffusionFEMForceField.scn
@@ -1,9 +1,13 @@
 <Node name="root" dt="0.0001" gravity="0 0 0" >
-    <VisualStyle displayFlags="showBehaviorModels"/>
     <RequiredPlugin name='SofaBoundaryCondition'/>
     <RequiredPlugin name='SofaTopologyMapping'/>
     <RequiredPlugin name='SofaLoader'/>
+    <RequiredPlugin name='SofaImplicitOdeSolver'/>
+    <RequiredPlugin name='SofaBaseLinearSolver'/>
+    <RequiredPlugin name='SofaBaseTopology'/>
 
+    <DefaultAnimationLoop />
+    <DefaultVisualManagerLoop />
     <MeshOBJLoader name="temperatureLoader" filename="beamTemperatures.obj" />
     <RegularGridTopology name="grid" n="21 11 11"  p0="0 0 0" min="0 0 0" max="1 0.5 0.5" drawHexahedra="1" tags="geom"/>
     <MechanicalObject template="Vec3d"  name="gridDOFs" tags="geom" />
@@ -21,8 +25,9 @@
             <EulerImplicitSolver name="EulerExplicitSolver" firstOrder="1" tags="heat" rayleighStiffness="0.1" rayleighMass="0.1" />
             <CGLinearSolver name="CG" iterations="1000" tolerance="1.0e-10" threshold="1.0e-30" tags="heat" />
             <MechanicalObject template="Vec1d" position="@../../temperatureLoader.position"  name="gridTemperature" bbox="0 0 0 0 0 0" tags="heat" />
-            <TetrahedronDiffusionFEMForceField template="Vec1d" name="DiffusionForceField" constantDiffusionCoefficient="1.0" tagMechanics="geom" tags="heat"/>
-            <DiagonalMass template="Vec1d" name="Mass" massDensity="1.0" tags="heat"/>
+            <TetrahedronDiffusionFEMForceField template="Vec1d" name="DiffusionForceField" constantDiffusionCoefficient="1.0" tagMechanics="geom" tags="heat" topology="@../Container"/>
+            <DiagonalMass template="Vec1d,Vec3d" name="Mass" massDensity="1.0" tags="heat"/>
+            <!-- <MeshMatrixMass name="Mass" template="Vec1d,Vec3d" lumping="0" massDensity="1.0" printLog="0" tags="heat" /> -->
             <LinearMovementConstraint template="Vec1d" keyTimes="0 998 999" movements="1 1 0" indices="@../../box-dirac.indices" />
             <FixedConstraint indices="@../../box-fixed.indices" />
         </Node>

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaDiagonalMass.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaDiagonalMass.h
@@ -35,7 +35,7 @@ namespace mass
 using namespace sofa::gpu::cuda;
 
 template<>
-class DiagonalMassInternalData<CudaVec3Types,float>
+class DiagonalMassInternalData<CudaVec3Types,float, CudaVec3Types>
 {
 public :
     typedef sofa::core::topology::PointData<CudaVector<float> > VecMass;
@@ -46,13 +46,11 @@ public :
 
 #ifdef SOFA_GPU_CUDA_DOUBLE
 template<>
-class DiagonalMassInternalData<CudaVec3dTypes,double>
+class DiagonalMassInternalData<CudaVec3dTypes,double, CudaVec3dTypes>
 {
 public :
     typedef sofa::core::topology::PointData<CudaVector<double> > VecMass;
     typedef CudaVector<double> MassVector;
-
-    typedef CudaVec3dTypes GeometricalTypes ; /// assumes the geometry object type is 3D
 };
 #endif
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMeshMatrixMass.cpp
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMeshMatrixMass.cpp
@@ -48,12 +48,18 @@ namespace mass
 
 template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec3fTypes>;
 template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2fTypes>;
+template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2fTypes, sofa::gpu::cuda::CudaVec3fTypes>;
 template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1fTypes>;
+template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1fTypes, sofa::gpu::cuda::CudaVec2fTypes>;
+template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1fTypes, sofa::gpu::cuda::CudaVec3fTypes>;
 
 #ifdef SOFA_GPU_CUDA_DOUBLE
 template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec3dTypes>;
 template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2dTypes>;
+template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2dTypes, sofa::gpu::cuda::CudaVec3dTypes>;
 template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1dTypes>;
+template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1dTypes, sofa::gpu::cuda::CudaVec2dTypes>;
+template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1dTypes, sofa::gpu::cuda::CudaVec3dTypes>;
 #endif // SOFA_GPU_CUDA_DOUBLE
 
 
@@ -70,11 +76,17 @@ namespace cuda
 int MeshMatrixMassClassCudaClass = core::RegisterObject("Supports GPU-side computations using CUDA")
         .add< component::mass::MeshMatrixMass<CudaVec3fTypes > >(true)
         .add< component::mass::MeshMatrixMass<CudaVec2fTypes > >()
+        .add< component::mass::MeshMatrixMass<CudaVec2fTypes, CudaVec3fTypes > >()
         .add< component::mass::MeshMatrixMass<CudaVec1fTypes > >()
+        .add< component::mass::MeshMatrixMass<CudaVec1fTypes, CudaVec2fTypes > >()
+        .add< component::mass::MeshMatrixMass<CudaVec1fTypes, CudaVec3fTypes > >()
 #ifdef SOFA_GPU_CUDA_DOUBLE
         .add< component::mass::MeshMatrixMass<CudaVec3dTypes > >()
         .add< component::mass::MeshMatrixMass<CudaVec2dTypes > >()
+        .add< component::mass::MeshMatrixMass<CudaVec2dTypes, CudaVec3dTypes > >()
         .add< component::mass::MeshMatrixMass<CudaVec1dTypes > >()
+        .add< component::mass::MeshMatrixMass<CudaVec1dTypes, CudaVec2dTypes > >()
+        .add< component::mass::MeshMatrixMass<CudaVec1dTypes, CudaVec3dTypes > >()
 #endif // SOFA_GPU_CUDA_DOUBLE
         ;
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMeshMatrixMass.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaMeshMatrixMass.h
@@ -35,15 +35,12 @@ namespace mass
 using namespace sofa::gpu::cuda;
 using namespace sofa::component::mass;
 
-template<>
-class MeshMatrixMassInternalData<CudaVec3fTypes,float>
+template<class GeometricalTypes>
+class MeshMatrixMassInternalData<CudaVec3fTypes,float, GeometricalTypes>
 {
 public:
     /// Cuda vector copying the vertex mass (enabling deviceRead)
     CudaVector<float> vMass;
-
-    /// assumes the geometry object type is 3D
-    typedef CudaVec3fTypes GeometricalTypes ;
 };
 
 template<>
@@ -61,15 +58,12 @@ void MeshMatrixMass<sofa::gpu::cuda::CudaVec3fTypes>::accFromF(const core::Mecha
 
 
 
-template<>
-class MeshMatrixMassInternalData<CudaVec2fTypes, float>
+template<class GeometricalTypes>
+class MeshMatrixMassInternalData<CudaVec2fTypes, float, GeometricalTypes>
 {
 public:
     /// Cuda vector copying the vertex mass (enabling deviceRead)
     CudaVector<float> vMass;
-
-    /// assumes the geometry object type is 3D
-    typedef CudaVec3fTypes GeometricalTypes ;
 };
 
 template<>
@@ -87,15 +81,12 @@ void MeshMatrixMass<sofa::gpu::cuda::CudaVec2fTypes>::accFromF(const core::Mecha
 
 
 
-template<>
-class MeshMatrixMassInternalData<CudaVec1fTypes, float>
+template<class GeometricalTypes>
+class MeshMatrixMassInternalData<CudaVec1fTypes, float, GeometricalTypes>
 {
 public:
     /// Cuda vector copying the vertex mass (enabling deviceRead)
     CudaVector<float> vMass;
-
-    /// assumes the geometry object type is 3D
-    typedef CudaVec3fTypes GeometricalTypes ;
 };
 
 template<>
@@ -112,14 +103,20 @@ void MeshMatrixMass<sofa::gpu::cuda::CudaVec1fTypes>::accFromF(const core::Mecha
 
 
 #ifndef SOFA_GPU_CUDA_CUDAMESHMATRIXMASS_CPP
-template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec3fTypes>;
-template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2fTypes>;
-template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1fTypes>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec3fTypes>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2fTypes>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2fTypes, sofa::gpu::cuda::CudaVec3fTypes>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1fTypes>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1fTypes, sofa::gpu::cuda::CudaVec2fTypes>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1fTypes, sofa::gpu::cuda::CudaVec3fTypes>;
 
 #ifdef SOFA_GPU_CUDA_DOUBLE
-template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec3dTypes>;
-template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2dTypes>;
-template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1dTypes>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec3dTypes>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2dTypes>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec2dTypes, sofa::gpu::cuda::CudaVec3dTypes>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1dTypes>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1dTypes, sofa::gpu::cuda::CudaVec2dTypes>;
+extern template class SOFA_GPU_CUDA_API MeshMatrixMass<sofa::gpu::cuda::CudaVec1dTypes, sofa::gpu::cuda::CudaVec3dTypes>;
 #endif // SOFA_GPU_CUDA_DOUBLE
 
 #endif //SOFA_GPU_CUDA_CUDAMESHMATRIXMASS_CPP

--- a/examples/Components/forcefield/TetrahedronDiffusionFEMForceField.scn
+++ b/examples/Components/forcefield/TetrahedronDiffusionFEMForceField.scn
@@ -27,7 +27,7 @@
         <CGLinearSolver name="CG" iterations="1000" tolerance="1.0e-10" threshold="1.0e-30" tags="heat"/>
         <MechanicalObject template="Vec1d" position="@../potentialLoader.position"  name="gridTemperature" bbox="0 0 0 0 0 0" tags="heat"/>
         <TetrahedronDiffusionFEMForceField template="Vec1d" name="DiffusionForceField" topology="@../topo" constantDiffusionCoefficient="1500" printLog="0" drawConduc="0" tagMechanics="mechanics" tags="heat"/>
-        <MeshMatrixMass name="Mass" template="Vec1d,Vec3d" lumping="0" massDensity="1.0" printLog="0" tags="heat"/>
+        <MeshMatrixMass name="Mass" template="Vec1d,Vec3d" lumping="0" massDensity="1.0" printLog="0" tags="heat" topology="@../topo" geometryState="@../raptorDOFs"/>
 
         <LinearMovementConstraint template="Vec1d" keyTimes="0 0.005 0.006" movements="0 0 1" indices="@../box-cold.indices" />
         <LinearMovementConstraint template="Vec1d" keyTimes="0.001 0.002 0.004 0.005 0.006" movements="0 1 0.5 1 0" indices="@../box-hot.indices" />

--- a/examples/Components/forcefield/TetrahedronDiffusionFEMForceField.scn
+++ b/examples/Components/forcefield/TetrahedronDiffusionFEMForceField.scn
@@ -26,8 +26,8 @@
         <EulerImplicitSolver name="EulerExplicitSolver" firstOrder="1" tags="heat" rayleighStiffness="0.1" rayleighMass="0.1" />
         <CGLinearSolver name="CG" iterations="1000" tolerance="1.0e-10" threshold="1.0e-30" tags="heat"/>
         <MechanicalObject template="Vec1d" position="@../potentialLoader.position"  name="gridTemperature" bbox="0 0 0 0 0 0" tags="heat"/>
-        <TetrahedronDiffusionFEMForceField template="Vec1d" name="DiffusionForceField" constantDiffusionCoefficient="1500" printLog="0" drawConduc="0" tagMechanics="mechanics" tags="heat"/>
-        <MeshMatrixMass name="Mass" lumping="0" massDensity="1.0" printLog="0" tags="heat"/>
+        <TetrahedronDiffusionFEMForceField template="Vec1d" name="DiffusionForceField" topology="@../topo" constantDiffusionCoefficient="1500" printLog="0" drawConduc="0" tagMechanics="mechanics" tags="heat"/>
+        <MeshMatrixMass name="Mass" template="Vec1d,Vec3d" lumping="0" massDensity="1.0" printLog="0" tags="heat"/>
 
         <LinearMovementConstraint template="Vec1d" keyTimes="0 0.005 0.006" movements="0 0 1" indices="@../box-cold.indices" />
         <LinearMovementConstraint template="Vec1d" keyTimes="0.001 0.002 0.004 0.005 0.006" movements="0 1 0.5 1 0" indices="@../box-hot.indices" />


### PR DESCRIPTION
By adding an optional geometrical template for mesh-based masses

Merely a refresh version of the previously closed PR 
- https://github.com/sofa-framework/sofa/pull/2476

In the end, it is just easier to add a template to manage geometrical data retrieval.
Also, some cleaning and easy optimizations in the diffusion to compute a little faster

Toward a green CI 🚀
______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
