### PR TITLE
[SofaCore] Restore default component naming for python

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/ComponentNameHelper.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/ComponentNameHelper.cpp
@@ -37,7 +37,7 @@ std::string ComponentNameHelper::resolveName(const std::string& type, const std:
 
 std::string ComponentNameHelper::resolveName(const std::string& type, Convention convention)
 {
-    std::string radix = helper::NameDecoder::shortName(type);
+    std::string radix = type;
     if (convention == Convention::xml)
     {
         return radix + std::to_string((m_instanceCounter[radix]++) + 1);


### PR DESCRIPTION
Following my [comment](https://github.com/sofa-framework/sofa/pull/2773#issuecomment-1075391909) on #2773.
This PR restores the default component naming for python.


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
