### PR TITLE
[SofaGuiCommon] Restore argv 

### DIFF
--- a/modules/SofaGuiCommon/src/sofa/gui/ArgumentParser.cpp
+++ b/modules/SofaGuiCommon/src/sofa/gui/ArgumentParser.cpp
@@ -79,6 +79,8 @@ void ArgumentParser::parse()
     for (const auto& arg : vecArg)
     {
         m_parseResult.insert({ arg.key(), arg.value() });
+        if(arg.key() == "argv")
+            extra.push_back(arg.value());
 
         //go through all possible keys (because of the short/long names)
         for (const auto& callback : m_mapCallbacks)


### PR DESCRIPTION
This PR restores the use of argv with runSofa. I'm sorry I've been keeping this fix for a long time now, so I cannot tell you which PR broke the feature. 



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
