### PR TITLE
[SofaCore] Remove assert in case of multiple init

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGNode.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGNode.cpp
@@ -113,7 +113,6 @@ void DDGNode::addOutput(DDGNode* n)
 {
     if(std::find(outputs.begin(), outputs.end(), n) != outputs.end())
     {
-        assert(false && "trying to add a DDGNode that is already in the output set.");
         return;
     }
 

--- a/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGNode.cpp
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/DDGNode.cpp
@@ -93,7 +93,6 @@ void DDGNode::addInput(DDGNode* n)
 {
     if(std::find(inputs.begin(), inputs.end(), n) != inputs.end())
     {
-        assert(false && "trying to add a DDGNode that is already in the input set.");
         return;
     }
     doAddInput(n);


### PR DESCRIPTION
The assert triggers in the following case:
A SphereROI is defined in a Python script. In order for the outputs to be used right away, it must be initialize by the Python script, just after its definition.
But when the scene is completely defined, a visitor calls again the init method.

So the assert triggers in case the addInput method is called multiple times (like in the example I gave).



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
