### PR TITLE
[all] Move addInput/addOutput from init() to constructor

### DIFF
--- a/SofaKernel/modules/Sofa.GL/Component/Engine/src/sofa/gl/component/engine/TextureInterpolation.inl
+++ b/SofaKernel/modules/Sofa.GL/Component/Engine/src/sofa/gl/component/engine/TextureInterpolation.inl
@@ -44,14 +44,15 @@ TextureInterpolation<DataTypes>::TextureInterpolation()
     ,f_graph( initData(&f_graph,"graph","Vertex state value per iteration") )
 {
     f_graph.setWidget("graph");
+
+    addInput(&_inputField);
+    addOutput(&_outputCoord);
 }
 
 
 template <class DataTypes>
 void TextureInterpolation<DataTypes>::init()
 {
-    addInput(&_inputField);
-    addOutput(&_outputCoord);
     setDirtyValue();
 
     if (!_inputField.isSet())

--- a/SofaKernel/modules/SofaCore/SofaCore_test/DataEngine_test.cpp
+++ b/SofaKernel/modules/SofaCore/SofaCore_test/DataEngine_test.cpp
@@ -46,14 +46,15 @@ public:
         : Inherit1()
         , input(initData(&input,false,"input","input"))
         , output(initData(&output,(int)UNDEFINED,"output","output"))
-    {}
+    {
+        addInput(&input);
+        addOutput(&output);
+    }
 
     ~TestEngine() override {}
 
     void init() override
     {
-        addInput(&input);
-        addOutput(&output);
         setDirtyValue();
     }
 

--- a/applications/plugins/SofaMatrix/src/SofaMatrix/FillReducingOrdering.inl
+++ b/applications/plugins/SofaMatrix/src/SofaMatrix/FillReducingOrdering.inl
@@ -36,18 +36,17 @@ FillReducingOrdering<DataTypes>::FillReducingOrdering()
     , d_hexahedra(initData(&d_hexahedra, "hexahedra", "Reordered hexahedra"))
     , d_tetrahedra(initData(&d_tetrahedra, "tetrahedra", "Reordered tetrahedra"))
 {
+    addOutput(&d_permutation);
+    addOutput(&d_invPermutation);
+    addOutput(&d_position);
+    addOutput(&d_hexahedra);
+    addOutput(&d_tetrahedra);
 }
 
 template <class DataTypes>
 void FillReducingOrdering<DataTypes>::init()
 {
     DataEngine::init();
-
-    addOutput(&d_permutation);
-    addOutput(&d_invPermutation);
-    addOutput(&d_position);
-    addOutput(&d_hexahedra);
-    addOutput(&d_tetrahedra);
 
     if (!l_mstate)
     {

--- a/modules/SofaGeneralEngine/SofaGeneralEngine_test/TestEngine.cpp
+++ b/modules/SofaGeneralEngine/SofaGeneralEngine_test/TestEngine.cpp
@@ -47,13 +47,14 @@ TestEngine::TestEngine()
     counter = 0;
     instance++;
     this->identifier =  instance;
+
+    addInput(&f_factor);
+    addInput(&f_numberToMultiply);
+    addOutput(&f_result);
 }
 
 void TestEngine::init()
 {
-    addInput(&f_factor);
-    addInput(&f_numberToMultiply);
-    addOutput(&f_result);
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/AverageCoord.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/AverageCoord.inl
@@ -36,15 +36,16 @@ AverageCoord<DataTypes>::AverageCoord()
     , d_average( initData (&d_average, "average", "average of the values with the given indices in the given coordinate vector \n"
                                                    "(default value corresponds to the average coord of the mechanical context)") )
 {
+    addInput(&d_indices);
+    addInput(&d_vecId);
+    addOutput(&d_average);
 }
 
 template <class DataTypes>
 void AverageCoord<DataTypes>::init()
 {
     mstate = dynamic_cast< sofa::core::behavior::MechanicalState<DataTypes>* >(getContext()->getMechanicalState());
-    addInput(&d_indices);
-    addInput(&d_vecId);
-    addOutput(&d_average);
+
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/ClusteringEngine.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/ClusteringEngine.inl
@@ -55,6 +55,13 @@ ClusteringEngine<DataTypes>::ClusteringEngine()
     , output_filename(initData(&output_filename,"outFile","export clusters"))
     , topo(nullptr)
 {
+    addInput(&d_radius);
+    addInput(&d_fixedRadius);
+    addInput(&d_nbClusters);
+    addInput(&d_fixedPosition);
+    addInput(&d_position);
+    addInput(&input_filename);
+    addOutput(&d_cluster);
 }
 
 template <class DataTypes>
@@ -65,13 +72,6 @@ void ClusteringEngine<DataTypes>::init()
     if(this->mstate==nullptr)
         msg_info(this) << "This component requires a mechanical state in its context for output visualization.";
 
-    addInput(&d_radius);
-    addInput(&d_fixedRadius);
-    addInput(&d_nbClusters);
-    addInput(&d_fixedPosition);
-    addInput(&d_position);
-    addInput(&input_filename);
-    addOutput(&d_cluster);
     setDirtyValue();
 
     //- Topology Container

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/ComplementaryROI.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/ComplementaryROI.inl
@@ -47,6 +47,12 @@ ComplementaryROI<DataTypes>::ComplementaryROI()
     , d_pointsInROI(initData(&d_pointsInROI, "pointsInROI", "points in the ROI"))
 {
     vd_setIndices.resize(d_nbSet.getValue());
+
+    addInput(&d_position);
+    addInput(&d_nbSet);
+
+    addOutput(&d_indices);
+    addOutput(&d_pointsInROI);
 }
 
 template <class DataTypes>
@@ -72,14 +78,7 @@ void ComplementaryROI<DataTypes>::parseFields ( const map<string,string*>& str )
 template <class DataTypes>
 void ComplementaryROI<DataTypes>::init()
 {
-    addInput(&d_position);
-    addInput(&d_nbSet);
-
     vd_setIndices.resize(d_nbSet.getValue());
-
-    addOutput(&d_indices);
-    addOutput(&d_pointsInROI);
-
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/DifferenceEngine.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/DifferenceEngine.inl
@@ -33,15 +33,14 @@ DifferenceEngine<DataTypes>::DifferenceEngine()
     , d_substractor ( initData (&d_substractor, "substractor", "vector to substract to input") )
     , d_output( initData (&d_output, "output", "output vector = input-substractor") )
 {
-
+    addInput(&d_input);
+    addInput(&d_substractor);
+    addOutput(&d_output);
 }
 
 template <class DataType>
 void DifferenceEngine<DataType>::init()
 {
-    addInput(&d_input);
-    addInput(&d_substractor);
-    addOutput(&d_output);
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/DilateEngine.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/DilateEngine.inl
@@ -45,12 +45,7 @@ DilateEngine<DataTypes>::DilateEngine()
     , d_minThickness( initData (&d_minThickness, (Real)0, "minThickness", "minimal thickness to enforce") )
 {
     addAlias(&d_inputX,"position");
-}
 
-
-template <class DataTypes>
-void DilateEngine<DataTypes>::init()
-{
     addInput(&d_inputX);
     addInput(&d_triangles);
     addInput(&d_quads);
@@ -59,6 +54,12 @@ void DilateEngine<DataTypes>::init()
     addOutput(&d_outputX);
     addOutput(&d_normals);
     addOutput(&d_thickness);
+}
+
+
+template <class DataTypes>
+void DilateEngine<DataTypes>::init()
+{
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/ExtrudeEdgesAndGenerateQuads.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/ExtrudeEdgesAndGenerateQuads.inl
@@ -43,18 +43,17 @@ ExtrudeEdgesAndGenerateQuads<DataTypes>::ExtrudeEdgesAndGenerateQuads()
     , d_extrudedEdges( initData (&d_extrudedEdges, "extrudedEdges", "List of all edges generated during the extrusion") )
     , d_extrudedQuads( initData (&d_extrudedQuads, "extrudedQuads", "List of all quads generated during the extrusion") )
 {
-}
-
-template <class DataTypes>
-void ExtrudeEdgesAndGenerateQuads<DataTypes>::init()
-{
     addInput(&d_curveVertices);
     addInput(&d_curveEdges);
 
     addOutput(&d_extrudedVertices);
     addOutput(&d_extrudedEdges);
     addOutput(&d_extrudedQuads);
+}
 
+template <class DataTypes>
+void ExtrudeEdgesAndGenerateQuads<DataTypes>::init()
+{
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/ExtrudeQuadsAndGenerateHexas.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/ExtrudeQuadsAndGenerateHexas.inl
@@ -42,11 +42,6 @@ ExtrudeQuadsAndGenerateHexas<DataTypes>::ExtrudeQuadsAndGenerateHexas()
     , f_extrudedQuads( initData (&f_extrudedQuads, "extrudedQuads", "List of all quads generated during the extrusion") )
     , f_extrudedHexas( initData (&f_extrudedHexas, "extrudedHexas", "List of hexahedra generated during the extrusion") )
 {
-}
-
-template <class DataTypes>
-void ExtrudeQuadsAndGenerateHexas<DataTypes>::init()
-{
     addInput(&f_surfaceQuads);
     addInput(&f_surfaceVertices);
 
@@ -54,7 +49,11 @@ void ExtrudeQuadsAndGenerateHexas<DataTypes>::init()
     addOutput(&f_extrudedSurfaceQuads);
     addOutput(&f_extrudedQuads);
     addOutput(&f_extrudedHexas);
+}
 
+template <class DataTypes>
+void ExtrudeQuadsAndGenerateHexas<DataTypes>::init()
+{
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/ExtrudeSurface.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/ExtrudeSurface.inl
@@ -38,17 +38,17 @@ ExtrudeSurface<DataTypes>::ExtrudeSurface()
     , f_extrusionTriangles( initData (&f_extrusionTriangles, "extrusionTriangles", "Triangles indices of the extrusion") )
     , f_surfaceTriangles( initData (&f_surfaceTriangles, "surfaceTriangles", "Indices of the triangles of the surface to extrude") )
 {
-}
-
-template <class DataTypes>
-void ExtrudeSurface<DataTypes>::init()
-{
     addInput(&f_surfaceTriangles);
     addInput(&f_surfaceVertices);
     addInput(&f_triangles);
 
     addOutput(&f_extrusionVertices);
     addOutput(&f_extrusionTriangles);
+}
+
+template <class DataTypes>
+void ExtrudeSurface<DataTypes>::init()
+{
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/GenerateCylinder.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/GenerateCylinder.inl
@@ -52,12 +52,7 @@ GenerateCylinder<DataTypes>::GenerateCylinder()
 {
     addAlias(&f_outputTetrahedraPositions,"position");
     addAlias(&f_outputTetrahedraPositions,"output_position");
-}
 
-
-template <class DataTypes>
-void GenerateCylinder<DataTypes>::init()
-{
     addInput(&f_radius);
     addInput(&f_height);
     addInput(&f_origin);
@@ -76,6 +71,12 @@ void GenerateCylinder<DataTypes>::init()
     addOutput(&f_outputTetrahedraPositions);
     addOutput(&f_bezierTetrahedronWeight);
     addOutput(&f_isBezierTetrahedronRational);
+}
+
+
+template <class DataTypes>
+void GenerateCylinder<DataTypes>::init()
+{
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/GenerateGrid.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/GenerateGrid.inl
@@ -37,12 +37,7 @@ GenerateGrid<DataTypes>::GenerateGrid()
     , d_resolution( initData (&d_resolution,Vec3Int(3,3,3), "resolution", "the number of cubes in the x,y,z directions. If resolution in the z direction is  0 then a 2D grid is generated") )
 {
     addAlias(&d_outputX,"position");
-}
 
-
-template <class DataTypes>
-void GenerateGrid<DataTypes>::init()
-{
     addInput(&d_minCorner);
     addInput(&d_maxCorner);
     addInput(&d_resolution);
@@ -51,6 +46,12 @@ void GenerateGrid<DataTypes>::init()
     addOutput(&d_hexahedron);
     addOutput(&d_quad);
     addOutput(&d_triangle);
+}
+
+
+template <class DataTypes>
+void GenerateGrid<DataTypes>::init()
+{
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/GenerateRigidMass.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/GenerateRigidMass.inl
@@ -46,16 +46,6 @@ GenerateRigidMass<DataTypes,MassType>::GenerateRigidMass()
     , massCenter(  initData(&massCenter,"massCenter","output: the gravity center of the mesh") )
     , centerToOrigin(  initData(&centerToOrigin,"centerToOrigin","output: vector going from the mass center to the space origin") )
 {
-}
-
-template <class DataTypes, class MassType>
-GenerateRigidMass<DataTypes,MassType>::~GenerateRigidMass()
-{
-}
-
-template <class DataTypes, class MassType>
-void  GenerateRigidMass<DataTypes, MassType>::init()
-{
     addInput(&m_density);
     addInput(&m_positions);
     addInput(&m_triangles);
@@ -68,7 +58,16 @@ void  GenerateRigidMass<DataTypes, MassType>::init()
     addOutput(&inertiaMatrix);
     addOutput(&massCenter);
     addOutput(&centerToOrigin);
+}
 
+template <class DataTypes, class MassType>
+GenerateRigidMass<DataTypes,MassType>::~GenerateRigidMass()
+{
+}
+
+template <class DataTypes, class MassType>
+void  GenerateRigidMass<DataTypes, MassType>::init()
+{
     setDirtyValue();
 
     reinit();

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/GenerateSphere.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/GenerateSphere.inl
@@ -127,28 +127,28 @@ GenerateSphere<DataTypes>::GenerateSphere()
 {
     addAlias(&f_outputTetrahedraPositions,"position");
     addAlias(&f_outputTetrahedraPositions,"output_position");
+
+    addInput(&f_tessellationDegree);
+    addInput(&f_origin);
+    addInput(&f_platonicSolidName);
+
+
+    addOutput(&f_triangles);
+    addOutput(&f_outputTrianglesPositions);
+    addOutput(&f_bezierTriangleWeight);
+    addOutput(&f_isBezierTriangleRational);
+
+
+    addOutput(&f_tetrahedra);
+    addOutput(&f_outputTetrahedraPositions);
+    addOutput(&f_bezierTetrahedronWeight);
+    addOutput(&f_isBezierTetrahedronRational);
 }
 
 
 template <class DataTypes>
 void GenerateSphere<DataTypes>::init()
 {
-    addInput(&f_tessellationDegree);
-    addInput(&f_origin);
-    addInput(&f_platonicSolidName);
-
-
-	addOutput(&f_triangles);
-    addOutput(&f_outputTrianglesPositions);
-    addOutput(&f_bezierTriangleWeight);
-	addOutput(&f_isBezierTriangleRational);
-
-
-    addOutput(&f_tetrahedra);
-    addOutput(&f_outputTetrahedraPositions);
-	addOutput(&f_bezierTetrahedronWeight);
-	addOutput(&f_isBezierTetrahedronRational);
-
     setDirtyValue();
 
 	if (f_platonicSolidName.getValue() == "icosahedron"){

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/GroupFilterYoungModulus.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/GroupFilterYoungModulus.inl
@@ -38,14 +38,14 @@ GroupFilterYoungModulus<DataTypes>::GroupFilterYoungModulus()
     , p_defaultModulus( initData (&p_defaultModulus, (Real) 10000.0, "defaultYoungModulus", "Default value if the primitive is not in a group") )
     , p_groupMod( initData (&p_groupMod, "groupModulus", "list of young modulus for each group") )
 {
+    addInput(&f_groups);
+    addInput(&f_primitives);
+    addOutput(&f_youngModulus);
 }
 
 template <class DataTypes>
 void GroupFilterYoungModulus<DataTypes>::init()
 {
-    addInput(&f_groups);
-    addInput(&f_primitives);
-    addOutput(&f_youngModulus);
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/IndexValueMapper.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/IndexValueMapper.inl
@@ -34,17 +34,16 @@ IndexValueMapper<DataTypes>::IndexValueMapper()
     , f_outputValues(initData(&f_outputValues, "outputValues", "New map between indices and values"))
     , p_defaultValue(initData(&p_defaultValue, (Real) 1.0, "defaultValue", "Default value for indices without any value"))
 {
-}
-
-template <class DataTypes>
-void IndexValueMapper<DataTypes>::init()
-{
     addInput(&f_inputValues);
     addInput(&f_indices);
     addInput(&f_value);
 
     addOutput(&f_outputValues);
+}
 
+template <class DataTypes>
+void IndexValueMapper<DataTypes>::init()
+{
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/Indices2ValuesMapper.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/Indices2ValuesMapper.inl
@@ -39,17 +39,16 @@ Indices2ValuesMapper<DataTypes>::Indices2ValuesMapper()
     , f_outputValues(initData(&f_outputValues, "outputValues", "New map between indices and values"))
     , p_defaultValue(initData(&p_defaultValue, (Real) 1.0, "defaultValue", "Default value for indices without any value"))
 {
-}
-
-template <class DataTypes>
-void Indices2ValuesMapper<DataTypes>::init()
-{
     addInput(&f_inputValues);
     addInput(&f_indices);
     addInput(&f_values);
 
     addOutput(&f_outputValues);
+}
 
+template <class DataTypes>
+void Indices2ValuesMapper<DataTypes>::init()
+{
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/IndicesFromValues.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/IndicesFromValues.inl
@@ -34,6 +34,10 @@ IndicesFromValues<T>::IndicesFromValues()
     , f_otherIndices( initData(&f_otherIndices, "otherIndices","Output indices of the other values, (NOT the given ones) searched in global") )
     , f_recursiveSearch( initData(&f_recursiveSearch, false, "recursiveSearch", "if set to true, output are indices of the \"global\" data matching with one of the values"))
 {
+    addInput(&f_values);
+    addInput(&f_global);
+    addOutput(&f_indices);
+    addOutput(&f_otherIndices);
 }
 
 template <class T>
@@ -44,10 +48,6 @@ IndicesFromValues<T>::~IndicesFromValues()
 template <class T>
 void IndicesFromValues<T>::init()
 {
-    addInput(&f_values);
-    addInput(&f_global);
-    addOutput(&f_indices);
-    addOutput(&f_otherIndices);
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/JoinPoints.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/JoinPoints.inl
@@ -35,16 +35,15 @@ JoinPoints<DataTypes>::JoinPoints()
     , f_distance(initData(&f_distance, "distance", "Distance to merge points"))
     , f_mergedPoints(initData(&f_mergedPoints, "mergedPoints", "Merged Points"))
 {
+    addInput(&f_points);
+    addInput(&f_distance);
+
+    addOutput(&f_mergedPoints);
 }
 
 template <class DataTypes>
 void JoinPoints<DataTypes>::init()
 {
-    addInput(&f_points);
-    addInput(&f_distance);
-
-    addOutput(&f_mergedPoints);
-
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/MapIndices.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/MapIndices.inl
@@ -34,6 +34,11 @@ MapIndices<T>::MapIndices()
     , f_outStr( initData (&f_outStr, "outStr", "Output indices, converted as a string"))
     , f_transpose( initData (&f_transpose, false, "transpose", "Should the transposed mapping be used ?"))
 {
+    f_outStr.setParent(&f_out);
+    addInput(&f_in);
+    addInput(&f_indices);
+    addInput(&f_transpose);
+    addOutput(&f_out);
 }
 
 template <class T>
@@ -44,11 +49,6 @@ MapIndices<T>::~MapIndices()
 template <class T>
 void MapIndices<T>::init()
 {
-    f_outStr.setParent(&f_out);
-    addInput(&f_in);
-    addInput(&f_indices);
-    addInput(&f_transpose);
-    addOutput(&f_out);
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/MergePoints.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/MergePoints.inl
@@ -36,17 +36,17 @@ MergePoints<DataTypes>::MergePoints()
     , f_points( initData (&f_points, "points", "position coordinates of the merge") )
     , f_noUpdate( initData (&f_noUpdate, false, "noUpdate", "do not update the output at eacth time step (false)") )
 {
-}
-
-template <class DataTypes>
-void MergePoints<DataTypes>::init()
-{
     addInput(&f_X1);
     addInput(&f_X2);
     addInput(&f_X2_mapping);
     addOutput(&f_indices1);
     addOutput(&f_indices2);
     addOutput(&f_points);
+}
+
+template <class DataTypes>
+void MergePoints<DataTypes>::init()
+{
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/MergeSets.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/MergeSets.inl
@@ -35,6 +35,10 @@ MergeSets<T>::MergeSets()
     , f_out( initData (&f_out, "out", "merged set of indices") )
     , f_op( initData (&f_op, std::string("union"), "op", "name of operation to compute (union, intersection, difference, symmetric_difference)") )
 {
+    addInput(&f_in1);
+    addInput(&f_in2);
+    addInput(&f_op);
+    addOutput(&f_out);
 }
 
 template <class T>
@@ -45,10 +49,6 @@ MergeSets<T>::~MergeSets()
 template <class T>
 void MergeSets<T>::init()
 {
-    addInput(&f_in1);
-    addInput(&f_in2);
-    addInput(&f_op);
-    addOutput(&f_out);
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/MeshBarycentricMapperEngine.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/MeshBarycentricMapperEngine.inl
@@ -38,6 +38,11 @@ MeshBarycentricMapperEngine<DataTypes>::MeshBarycentricMapperEngine()
     , d_interpolationValues(initData(&d_interpolationValues, "linearInterpolationValues", "Values of a linear interpolation"))
     , l_topology(initLink("topology", "Name of the master topology"))
 {
+    addInput(&d_inputPositions);
+    addInput(&d_mappedPointPositions);
+
+    addOutput(&d_barycentricPositions);
+    addOutput(&d_tableElements);
 }
 
 
@@ -62,12 +67,6 @@ void MeshBarycentricMapperEngine<DataTypes>::init()
         }
     }
 
-
-    addInput(&d_inputPositions);
-    addInput(&d_mappedPointPositions);
-
-    addOutput(&d_barycentricPositions);
-    addOutput(&d_tableElements);
     setDirtyValue();
 
     d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/MeshBoundaryROI.cpp
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/MeshBoundaryROI.cpp
@@ -35,15 +35,14 @@ MeshBoundaryROI::MeshBoundaryROI(): Inherited()
                                     , d_inputROI(initData(&d_inputROI,"inputROI","optional subset of the input mesh"))
                                     , d_indices(initData(&d_indices,"indices","Index lists of the closing vertices"))
 {
-}
-
-void MeshBoundaryROI::init()
-{
     addInput(&d_triangles);
     addInput(&d_quads);
     addInput(&d_inputROI);
     addOutput(&d_indices);
+}
 
+void MeshBoundaryROI::init()
+{
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/MeshClosingEngine.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/MeshClosingEngine.h
@@ -83,13 +83,6 @@ protected:
       , closingPosition(initData(&closingPosition,"closingPosition","Vertices of the closing parts"))
       , closingTriangles(initData(&closingTriangles,"closingTriangles","Triangles of the closing parts"))
     {
-    }
-
-    ~MeshClosingEngine() override {}
-
-public:
-    void init() override
-    {
         addInput(&inputPosition);
         addInput(&inputTriangles);
         addInput(&inputQuads);
@@ -99,6 +92,13 @@ public:
         addOutput(&indices);
         addOutput(&closingPosition);
         addOutput(&closingTriangles);
+    }
+
+    ~MeshClosingEngine() override {}
+
+public:
+    void init() override
+    {
         setDirtyValue();
     }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/MeshROI.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/MeshROI.inl
@@ -81,11 +81,7 @@ MeshROI<DataTypes>::MeshROI()
 {
     d_indices.beginEdit()->push_back(0);
     d_indices.endEdit();
-}
 
-template <class DataTypes>
-void MeshROI<DataTypes>::init()
-{
     addInput(&d_X0);
     addInput(&d_edges);
     addInput(&d_triangles);
@@ -113,7 +109,11 @@ void MeshROI<DataTypes>::init()
     addOutput(&d_edgeOutIndices);
     addOutput(&d_triangleOutIndices);
     addOutput(&d_tetrahedronOutIndices);
+}
 
+template <class DataTypes>
+void MeshROI<DataTypes>::init()
+{
     setDirtyValue();
 
     checkInputData();

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/MeshSampler.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/MeshSampler.inl
@@ -42,17 +42,17 @@ MeshSampler<DataTypes>::MeshSampler()
     , outputIndices(initData(&outputIndices,"outputIndices","Computed sample indices."))
     , outputPosition(initData(&outputPosition,"outputPosition","Computed sample coordinates."))
 {
-}
-
-template <class DataTypes>
-void MeshSampler<DataTypes>::init()
-{
     addInput(&number);
     addInput(&position);
     addInput(&f_edges);
     addInput(&maxIter);
     addOutput(&outputIndices);
     addOutput(&outputPosition);
+}
+
+template <class DataTypes>
+void MeshSampler<DataTypes>::init()
+{
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/MeshSubsetEngine.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/MeshSubsetEngine.h
@@ -74,15 +74,6 @@ protected:
 public:
     void init() override
     {
-        addInput(&inputPosition);
-        addInput(&inputEdges);
-        addInput(&inputTriangles);
-        addInput(&inputQuads);
-        addInput(&indices);
-        addOutput(&position);
-        addOutput(&edges);
-        addOutput(&triangles);
-        addOutput(&quads);
         setDirtyValue();
     }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/MeshSubsetEngine.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/MeshSubsetEngine.inl
@@ -38,6 +38,15 @@ MeshSubsetEngine<DataTypes>::MeshSubsetEngine()
     , triangles(initData(&triangles,"triangles","Triangles of mesh subset"))
     , quads(initData(&quads,"quads","Quads of mesh subset"))
 {
+    addInput(&inputPosition);
+    addInput(&inputEdges);
+    addInput(&inputTriangles);
+    addInput(&inputQuads);
+    addInput(&indices);
+    addOutput(&position);
+    addOutput(&edges);
+    addOutput(&triangles);
+    addOutput(&quads);
 }
 
 template <class DataTypes>

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NearestPointROI.inl
@@ -39,6 +39,11 @@ NearestPointROI<DataTypes>::NearestPointROI(core::behavior::MechanicalState<Data
     , d_indexPairs(initData(&d_indexPairs, "indexPairs", "list of couples (parent index + index in the parent)"))
     , d_distances(initData(&d_distances, "distances", "List of distances between pairs of points"))
 {
+    addOutput(&f_indices1);
+    addOutput(&f_indices2);
+    addOutput(&d_edges);
+    addOutput(&d_indexPairs);
+    addOutput(&d_distances);
 }
 
 template <class DataTypes>
@@ -67,12 +72,6 @@ void NearestPointROI<DataTypes>::init()
         addInput(this->mstate1->findData("position"));
         addInput(this->mstate2->findData("position"));
     }
-
-    addOutput(&f_indices1);
-    addOutput(&f_indices2);
-    addOutput(&d_edges);
-    addOutput(&d_indexPairs);
-    addOutput(&d_distances);
 }
 
 template <class DataTypes>

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NormEngine.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NormEngine.inl
@@ -32,15 +32,14 @@ NormEngine<DataTypes>::NormEngine()
     , d_output( initData (&d_output, "output", "output array of scalar norms") )
     , d_normType( initData (&d_normType, 2, "normType", "The type of norm. Use a negative value for the infinite norm.") )
 {
-
+    addInput(&d_input);
+    addOutput(&d_output);
+    addInput(&d_normType);
 }
 
 template <class DataType>
 void NormEngine<DataType>::init()
 {
-    addInput(&d_input);
-    addOutput(&d_output);
-    addInput(&d_normType);
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/NormalsFromPoints.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/NormalsFromPoints.inl
@@ -37,17 +37,17 @@ NormalsFromPoints<DataTypes>::NormalsFromPoints()
     , useAngles( initData (&useAngles, false, "useAngles", "Use incident angles to weight faces normal contributions at each vertex") )
 
 {
-}
-
-template <class DataTypes>
-void NormalsFromPoints<DataTypes>::init()
-{
     addInput(&position);
     addInput(&triangles);
     addInput(&quads);
     addInput(&invertNormals);
     addInput(&useAngles);
     addOutput(&normals);
+}
+
+template <class DataTypes>
+void NormalsFromPoints<DataTypes>::init()
+{
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/PairBoxRoi.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/PairBoxRoi.inl
@@ -46,6 +46,10 @@ PairBoxROI<DataTypes>::PairBoxROI()
     addAlias(&f_pointsInROI,"pointsInBox");
     addAlias(&f_X0,"rest_position");
 
+    addInput(&f_X0);
+
+    addOutput(&f_indices);
+    addOutput(&f_pointsInROI);
 }
 
 template <class DataTypes>
@@ -91,11 +95,6 @@ void PairBoxROI<DataTypes>::init()
             }
         }
     }
-
-    addInput(&f_X0);
-
-    addOutput(&f_indices);
-    addOutput(&f_pointsInROI);
 
     setDirtyValue();
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/PlaneROI.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/PlaneROI.inl
@@ -60,6 +60,20 @@ PlaneROI<DataTypes>::PlaneROI()
 
     f_indices.beginEdit()->push_back(0);
     f_indices.endEdit();
+
+    addInput(&f_X0);
+    addInput(&f_edges);
+    addInput(&f_triangles);
+    addInput(&f_tetrahedra);
+
+    addOutput(&f_indices);
+    addOutput(&f_edgeIndices);
+    addOutput(&f_triangleIndices);
+    addOutput(&f_tetrahedronIndices);
+    addOutput(&f_pointsInROI);
+    addOutput(&f_edgesInROI);
+    addOutput(&f_trianglesInROI);
+    addOutput(&f_tetrahedraInROI);
 }
 
 template <class DataTypes>
@@ -131,19 +145,6 @@ void PlaneROI<DataTypes>::init()
         }
     }
 
-    addInput(&f_X0);
-    addInput(&f_edges);
-    addInput(&f_triangles);
-    addInput(&f_tetrahedra);
-
-    addOutput(&f_indices);
-    addOutput(&f_edgeIndices);
-    addOutput(&f_triangleIndices);
-    addOutput(&f_tetrahedronIndices);
-    addOutput(&f_pointsInROI);
-    addOutput(&f_edgesInROI);
-    addOutput(&f_trianglesInROI);
-    addOutput(&f_tetrahedraInROI);
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/PointsFromIndices.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/PointsFromIndices.inl
@@ -32,6 +32,9 @@ PointsFromIndices<DataTypes>::PointsFromIndices()
     , f_indices( initData(&f_indices,"indices","Indices of the points") )
     , f_indices_position( initData (&f_indices_position, "indices_position", "Coordinates of the points contained in indices"))
 {
+    addInput(&f_X);
+    addInput(&f_indices);
+    addOutput(&f_indices_position);
 }
 
 template <class DataTypes>
@@ -51,9 +54,7 @@ void PointsFromIndices<DataTypes>::init()
             }
         }
     }
-    addInput(&f_X);
-    addInput(&f_indices);
-    addOutput(&f_indices_position);
+
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/ProximityROI.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/ProximityROI.inl
@@ -53,6 +53,17 @@ ProximityROI<DataTypes>::ProximityROI()
 
     f_indices.beginEdit()->push_back(0);
     f_indices.endEdit();
+
+    addInput(&f_X0);
+
+    addInput(&centers);
+    addInput(&radii);
+    addInput(&f_num);
+
+    addOutput(&f_indices);
+    addOutput(&f_pointsInROI);
+    addOutput(&f_distanceInROI);
+    addOutput(&f_indicesOut);
 }
 
 template <class DataTypes>
@@ -86,17 +97,6 @@ void ProximityROI<DataTypes>::init()
             }
         }
     }
-
-    addInput(&f_X0);
-
-    addInput(&centers);
-    addInput(&radii);
-    addInput(&f_num);
-
-    addOutput(&f_indices);
-    addOutput(&f_pointsInROI);
-    addOutput(&f_distanceInROI);
-    addOutput(&f_indicesOut);
 
     setDirtyValue();
 }

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/QuatToRigidEngine.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/QuatToRigidEngine.inl
@@ -37,6 +37,12 @@ QuatToRigidEngine<DataTypes>::QuatToRigidEngine()
     addAlias(&f_orientations,"orientation");
     addAlias(&f_colinearPositions,"colinearPosition");
     addAlias(&f_rigids,"rigid");
+
+    addInput(&f_positions);
+    addInput(&f_orientations);
+    addInput(&f_colinearPositions);
+
+    addOutput(&f_rigids);
 }
 
 template <class DataTypes>
@@ -48,12 +54,6 @@ QuatToRigidEngine<DataTypes>::~QuatToRigidEngine()
 template <class DataTypes>
 void QuatToRigidEngine<DataTypes>::init()
 {
-    addInput(&f_positions);
-    addInput(&f_orientations);
-    addInput(&f_colinearPositions);
-
-    addOutput(&f_rigids);
-
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/ROIValueMapper.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/ROIValueMapper.h
@@ -58,11 +58,9 @@ public:
 
     void init() override
     {
-        addInput(&nbROIs);
         f_indices.resize(nbROIs.getValue());
         f_value.resize(nbROIs.getValue());
 
-        addOutput(&f_outputValues);
         setDirtyValue();
     }
 
@@ -99,6 +97,8 @@ protected:
         , f_outputValues(initData(&f_outputValues, "outputValues", "New vector of values"))
         , p_defaultValue(initData(&p_defaultValue, (Real) 0.0, "defaultValue", "Default value for indices out of ROIs"))
     {
+        addInput(&nbROIs);
+        addOutput(&f_outputValues);
     }
 
     ~ROIValueMapper() override {}

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/RandomPointDistributionInSurface.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/RandomPointDistributionInSurface.inl
@@ -45,6 +45,10 @@ RandomPointDistributionInSurface<DataTypes>::RandomPointDistributionInSurface()
     , f_outPoints( initData (&f_outPoints, "outPoints", "Points outside the surface") )
     , safeCounter(0), safeLimit(UINT_MAX)
 {
+    addInput(&f_triangles);
+    addInput(&f_vertices);
+
+    addOutput(&f_inPoints);
 }
 
 template <class DataTypes>
@@ -69,11 +73,6 @@ void RandomPointDistributionInSurface<DataTypes>::init()
     generateRandomDirections();
 
     safeLimit = numberOfInPoints.getValue()*numberOfInPoints.getValue()*numberOfInPoints.getValue()*numberOfInPoints.getValue();
-
-    addInput(&f_triangles);
-    addInput(&f_vertices);
-
-    addOutput(&f_inPoints);
 
     setDirtyValue();
 }

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/RigidToQuatEngine.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/RigidToQuatEngine.inl
@@ -36,6 +36,12 @@ RigidToQuatEngine<DataTypes>::RigidToQuatEngine()
     addAlias(&f_positions,"position");
     addAlias(&f_orientations,"orientation");
     addAlias(&f_rigids,"rigid");
+
+    addInput(&f_rigids);
+
+    addOutput(&f_positions);
+    addOutput(&f_orientations);
+    addOutput(&f_orientationsEuler);
 }
 
 template <class DataTypes>
@@ -47,12 +53,6 @@ RigidToQuatEngine<DataTypes>::~RigidToQuatEngine()
 template <class DataTypes>
 void RigidToQuatEngine<DataTypes>::init()
 {
-    addInput(&f_rigids);
-
-    addOutput(&f_positions);
-    addOutput(&f_orientations);
-    addOutput(&f_orientationsEuler);
-
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/SelectConnectedLabelsROI.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/SelectConnectedLabelsROI.h
@@ -64,16 +64,18 @@ public:
       , d_indices ( initData ( &d_indices,"indices","selected point/cell indices" ) )
     {
         d_labels.resize(d_nbLabels.getValue());
+
+        addInput(&d_nbLabels);
+        addInput(&d_connectLabels);
+        addOutput(&d_indices);
     }
 
     ~SelectConnectedLabelsROI() override {}
 
     void init() override
     {
-        addInput(&d_nbLabels);
         d_labels.resize(d_nbLabels.getValue());
-        addInput(&d_connectLabels);
-        addOutput(&d_indices);
+
         setDirtyValue();
     }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/SelectLabelROI.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/SelectLabelROI.h
@@ -60,9 +60,6 @@ public:
 
     void init() override
     {
-        addInput(&d_labels);
-        addInput(&d_selectLabels);
-        addOutput(&d_indices);
         setDirtyValue();
     }
 
@@ -78,6 +75,9 @@ protected:
       , d_selectLabels ( initData ( &d_selectLabels,"selectLabels","list of selected labels" ) )
       , d_indices ( initData ( &d_indices,"indices","selected point/cell indices" ) )
     {
+        addInput(&d_labels);
+        addInput(&d_selectLabels);
+        addOutput(&d_indices);
     }
 
     ~SelectLabelROI() override {}

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/ShapeMatching.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/ShapeMatching.inl
@@ -72,17 +72,18 @@ ShapeMatching<DataTypes>::ShapeMatching()
     , oldRestPositionSize(0)
     , oldfixedweight(0)
 {
+    addInput(&fixedPosition0);
+    addInput(&fixedPosition);
+    addInput(&position);
+    addInput(&cluster);
+    addOutput(&targetPosition);
 }
 
 template <class DataTypes>
 void ShapeMatching<DataTypes>::init()
 {
     mstate = dynamic_cast< sofa::core::behavior::MechanicalState<DataTypes>* >(getContext()->getMechanicalState());
-    addInput(&fixedPosition0);
-    addInput(&fixedPosition);
-    addInput(&position);
-    addInput(&cluster);
-    addOutput(&targetPosition);
+
     setDirtyValue();
 
     //- Topology Container

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/SmoothMeshEngine.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/SmoothMeshEngine.inl
@@ -39,15 +39,13 @@ SmoothMeshEngine<DataTypes>::SmoothMeshEngine()
     , l_topology(initLink("topology", "link to the topology container"))
     , m_topology(nullptr)
 {
-
+    addInput(&input_position);
+    addOutput(&output_position);
 }
 
 template <class DataTypes>
 void SmoothMeshEngine<DataTypes>::init()
 {
-    addInput(&input_position);
-    addOutput(&output_position);
-
     if (l_topology.empty())
     {
         msg_info() << "link to Topology container should be set to ensure right behavior. First Topology found in current context will be used.";

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/SphereROI.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/SphereROI.inl
@@ -71,6 +71,30 @@ SphereROI<DataTypes>::SphereROI()
 
     f_indices.beginEdit()->push_back(0);
     f_indices.endEdit();
+
+    addInput(&f_X0);
+    addInput(&f_edges);
+    addInput(&f_triangles);
+    addInput(&f_quads);
+    addInput(&f_tetrahedra);
+
+    addInput(&centers);
+    addInput(&radii);
+    addInput(&direction);
+    addInput(&normal);
+    addInput(&edgeAngle);
+    addInput(&triAngle);
+
+    addOutput(&f_indices);
+    addOutput(&f_edgeIndices);
+    addOutput(&f_triangleIndices);
+    addOutput(&f_quadIndices);
+    addOutput(&f_pointsInROI);
+    addOutput(&f_edgesInROI);
+    addOutput(&f_trianglesInROI);
+    addOutput(&f_quadsInROI);
+    addOutput(&f_tetrahedraInROI);
+    addOutput(&f_indicesOut);
 }
 
 template <class DataTypes>
@@ -151,30 +175,6 @@ void SphereROI<DataTypes>::init()
             }
         }
     }
-
-    addInput(&f_X0);
-    addInput(&f_edges);
-    addInput(&f_triangles);
-    addInput(&f_quads);
-    addInput(&f_tetrahedra);
-
-    addInput(&centers);
-    addInput(&radii);
-    addInput(&direction);
-    addInput(&normal);
-    addInput(&edgeAngle);
-    addInput(&triAngle);
-
-    addOutput(&f_indices);
-    addOutput(&f_edgeIndices);
-    addOutput(&f_triangleIndices);
-    addOutput(&f_quadIndices);
-    addOutput(&f_pointsInROI);
-    addOutput(&f_edgesInROI);
-    addOutput(&f_trianglesInROI);
-    addOutput(&f_quadsInROI);
-    addOutput(&f_tetrahedraInROI);
-    addOutput(&f_indicesOut);
 
     setDirtyValue();
 }

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/Spiral.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/Spiral.inl
@@ -35,13 +35,13 @@ Spiral<DataTypes>::Spiral()
     , f_X( initData (&f_X, "position", "Position coordinates of the degrees of freedom") )
     , curvature( initData (&curvature, Real(0.2),"curvature", "Spiral curvature factor") )
 {
+    addInput(&f_X0);
+    addOutput(&f_X);
 }
 
 template <class DataTypes>
 void Spiral<DataTypes>::init()
 {
-    addInput(&f_X0);
-    addOutput(&f_X);
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/SubsetTopology.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/SubsetTopology.inl
@@ -79,6 +79,40 @@ SubsetTopology<DataTypes>::SubsetTopology()
     f_indices.beginEdit()->push_back(0);
     f_indices.endEdit();
     typeROI = BOX;
+
+    addInput(&centers);
+    addInput(&radii);
+    addInput(&direction);
+    addInput(&normal);
+    addInput(&edgeAngle);
+    addInput(&triAngle);
+    addInput(&d_tetrahedraInput);
+
+    addInput(&f_X0);
+    addInput(&f_edges);
+    addInput(&f_triangles);
+    addInput(&f_quads);
+    addInput(&f_tetrahedra);
+    addInput(&f_hexahedra);
+
+    addOutput(&f_indices);
+    addOutput(&f_edgeIndices);
+    addOutput(&f_triangleIndices);
+    addOutput(&f_quadIndices);
+    addOutput(&f_tetrahedronIndices);
+    addOutput(&f_hexahedronIndices);
+    addOutput(&f_pointsInROI);
+    addOutput(&f_pointsOutROI);
+    addOutput(&f_edgesInROI);
+    addOutput(&f_edgesOutROI);
+    addOutput(&f_trianglesInROI);
+    addOutput(&f_trianglesOutROI);
+    addOutput(&f_quadsInROI);
+    addOutput(&f_quadsOutROI);
+    addOutput(&f_tetrahedraInROI);
+    addOutput(&f_tetrahedraOutROI);
+    addOutput(&f_hexahedraInROI);
+    addOutput(&f_hexahedraOutROI);
 }
 
 template <class DataTypes>
@@ -154,39 +188,6 @@ void SubsetTopology<DataTypes>::init()
         }
     }
 
-    addInput(&centers);
-    addInput(&radii);
-    addInput(&direction);
-    addInput(&normal);
-    addInput(&edgeAngle);
-    addInput(&triAngle);
-    addInput(&d_tetrahedraInput);
-
-    addInput(&f_X0);
-    addInput(&f_edges);
-    addInput(&f_triangles);
-    addInput(&f_quads);
-    addInput(&f_tetrahedra);
-    addInput(&f_hexahedra);
-
-    addOutput(&f_indices);
-    addOutput(&f_edgeIndices);
-    addOutput(&f_triangleIndices);
-    addOutput(&f_quadIndices);
-    addOutput(&f_tetrahedronIndices);
-    addOutput(&f_hexahedronIndices);
-    addOutput(&f_pointsInROI);
-    addOutput(&f_pointsOutROI);
-    addOutput(&f_edgesInROI);
-    addOutput(&f_edgesOutROI);
-    addOutput(&f_trianglesInROI);
-    addOutput(&f_trianglesOutROI);
-    addOutput(&f_quadsInROI);
-    addOutput(&f_quadsOutROI);
-    addOutput(&f_tetrahedraInROI);
-    addOutput(&f_tetrahedraOutROI);
-    addOutput(&f_hexahedraInROI);
-    addOutput(&f_hexahedraOutROI);
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/SubsetTopology.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/SubsetTopology.inl
@@ -79,40 +79,6 @@ SubsetTopology<DataTypes>::SubsetTopology()
     f_indices.beginEdit()->push_back(0);
     f_indices.endEdit();
     typeROI = BOX;
-
-    addInput(&centers);
-    addInput(&radii);
-    addInput(&direction);
-    addInput(&normal);
-    addInput(&edgeAngle);
-    addInput(&triAngle);
-    addInput(&d_tetrahedraInput);
-
-    addInput(&f_X0);
-    addInput(&f_edges);
-    addInput(&f_triangles);
-    addInput(&f_quads);
-    addInput(&f_tetrahedra);
-    addInput(&f_hexahedra);
-
-    addOutput(&f_indices);
-    addOutput(&f_edgeIndices);
-    addOutput(&f_triangleIndices);
-    addOutput(&f_quadIndices);
-    addOutput(&f_tetrahedronIndices);
-    addOutput(&f_hexahedronIndices);
-    addOutput(&f_pointsInROI);
-    addOutput(&f_pointsOutROI);
-    addOutput(&f_edgesInROI);
-    addOutput(&f_edgesOutROI);
-    addOutput(&f_trianglesInROI);
-    addOutput(&f_trianglesOutROI);
-    addOutput(&f_quadsInROI);
-    addOutput(&f_quadsOutROI);
-    addOutput(&f_tetrahedraInROI);
-    addOutput(&f_tetrahedraOutROI);
-    addOutput(&f_hexahedraInROI);
-    addOutput(&f_hexahedraOutROI);
 }
 
 template <class DataTypes>
@@ -188,6 +154,39 @@ void SubsetTopology<DataTypes>::init()
         }
     }
 
+    addInput(&centers);
+    addInput(&radii);
+    addInput(&direction);
+    addInput(&normal);
+    addInput(&edgeAngle);
+    addInput(&triAngle);
+    addInput(&d_tetrahedraInput);
+
+    addInput(&f_X0);
+    addInput(&f_edges);
+    addInput(&f_triangles);
+    addInput(&f_quads);
+    addInput(&f_tetrahedra);
+    addInput(&f_hexahedra);
+
+    addOutput(&f_indices);
+    addOutput(&f_edgeIndices);
+    addOutput(&f_triangleIndices);
+    addOutput(&f_quadIndices);
+    addOutput(&f_tetrahedronIndices);
+    addOutput(&f_hexahedronIndices);
+    addOutput(&f_pointsInROI);
+    addOutput(&f_pointsOutROI);
+    addOutput(&f_edgesInROI);
+    addOutput(&f_edgesOutROI);
+    addOutput(&f_trianglesInROI);
+    addOutput(&f_trianglesOutROI);
+    addOutput(&f_quadsInROI);
+    addOutput(&f_quadsOutROI);
+    addOutput(&f_tetrahedraInROI);
+    addOutput(&f_tetrahedraOutROI);
+    addOutput(&f_hexahedraInROI);
+    addOutput(&f_hexahedraOutROI);
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/SumEngine.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/SumEngine.inl
@@ -33,14 +33,13 @@ SumEngine<DataTypes>::SumEngine()
     : d_input ( initData (&d_input, "input", "input vector") )
     , d_output( initData (&d_output, "output", "output sum") )
 {
-
+    addInput(&d_input);
+    addOutput(&d_output);
 }
 
 template <class DataType>
 void SumEngine<DataType>::init()
 {
-    addInput(&d_input);
-    addOutput(&d_output);
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/TransformMatrixEngine.cpp
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/TransformMatrixEngine.cpp
@@ -52,12 +52,13 @@ int RotateTransformMatrixEngineClass = core::RegisterObject("Compose the input t
 AbstractTransformMatrixEngine::AbstractTransformMatrixEngine()
     : d_inT ( initData (&d_inT, Matrix4::s_identity, "inT", "input transformation if any") )
     , d_outT( initData (&d_outT, "outT", "output transformation") )
-{}
-
-void AbstractTransformMatrixEngine::init()
 {
     addInput(&d_inT);
     addOutput(&d_outT);
+}
+
+void AbstractTransformMatrixEngine::init()
+{
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/TransformPosition.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/TransformPosition.inl
@@ -68,6 +68,17 @@ TransformPosition<DataTypes>::TransformPosition()
         "affine",
         "fromFile");
     f_method.endEdit();
+
+    addInput(&f_inputX);
+    addInput(&f_origin);
+    addInput(&f_normal);
+    addInput(&f_translation);
+    addInput(&f_rotation);
+    addInput(&f_scale);
+    addInput(&f_affineMatrix);
+    addInput(&f_fixedIndices);
+
+    addOutput(&f_outputX);
 }
 
 template <class DataTypes>
@@ -142,17 +153,6 @@ void TransformPosition<DataTypes>::init()
         normal/=normal.norm();
 
     f_normal.endEdit();
-
-    addInput(&f_inputX);
-    addInput(&f_origin);
-    addInput(&f_normal);
-    addInput(&f_translation);
-    addInput(&f_rotation);
-    addInput(&f_scale);
-    addInput(&f_affineMatrix);
-    addInput(&f_fixedIndices);
-
-    addOutput(&f_outputX);
 
     setDirtyValue();
 }

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/ValuesFromIndices.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/ValuesFromIndices.inl
@@ -35,6 +35,10 @@ ValuesFromIndices<T>::ValuesFromIndices()
 {
     addAlias(&f_in, "input");
     addAlias(&f_out, "output");
+
+    addInput(&f_in);
+    addInput(&f_indices);
+    addOutput(&f_out);
 }
 
 template <class T>
@@ -46,9 +50,7 @@ template <class T>
 void ValuesFromIndices<T>::init()
 {
     f_outStr.setParent(&f_out);
-    addInput(&f_in);
-    addInput(&f_indices);
-    addOutput(&f_out);
+
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/ValuesFromPositions.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/ValuesFromPositions.inl
@@ -55,6 +55,23 @@ ValuesFromPositions<DataTypes>::ValuesFromPositions()
     p_fieldType.setValue(m_newoptiongroup);
 
     addAlias(&f_X0,"rest_position");
+
+    addInput(&f_inputValues);
+    addInput(&f_direction);
+    addInput(&f_X0);
+    addInput(&f_edges);
+    addInput(&f_triangles);
+    addInput(&f_tetrahedra);
+
+    addOutput(&f_values);
+    addOutput(&f_edgeValues);
+    addOutput(&f_triangleValues);
+    addOutput(&f_tetrahedronValues);
+
+    addOutput(&f_pointVectors);
+    addOutput(&f_edgeVectors);
+    addOutput(&f_triangleVectors);
+    addOutput(&f_tetrahedronVectors);
 }
 
 template <class DataTypes>
@@ -127,22 +144,6 @@ void ValuesFromPositions<DataTypes>::init()
         }
     }
 
-    addInput(&f_inputValues);
-    addInput(&f_direction);
-    addInput(&f_X0);
-    addInput(&f_edges);
-    addInput(&f_triangles);
-    addInput(&f_tetrahedra);
-
-    addOutput(&f_values);
-    addOutput(&f_edgeValues);
-    addOutput(&f_triangleValues);
-    addOutput(&f_tetrahedronValues);
-
-    addOutput(&f_pointVectors);
-    addOutput(&f_edgeVectors);
-    addOutput(&f_triangleVectors);
-    addOutput(&f_tetrahedronVectors);
     setDirtyValue();
 }
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/Vertex2Frame.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/Vertex2Frame.inl
@@ -41,11 +41,6 @@ Vertex2Frame<DataTypes>::Vertex2Frame():
     , d_rotation( initData (&d_rotation, 0, "rotation", "Apply a local rotation on the frames. If 0 a x-axis rotation is applied. If 1 a y-axis rotation is applied, If 2 a z-axis rotation is applied.") )
     , d_rotationAngle( initData (&d_rotationAngle, 0.0, "rotationAngle", "Angle rotation") )
 {
-}
-
-template <class DataTypes>
-void Vertex2Frame<DataTypes>::init()
-{
     addInput(&d_vertices);
     addInput(&d_texCoords);
     addInput(&d_normals);
@@ -53,7 +48,11 @@ void Vertex2Frame<DataTypes>::init()
     addInput(&d_rotationAngle);
 
     addOutput(&d_frames);
+}
 
+template <class DataTypes>
+void Vertex2Frame<DataTypes>::init()
+{
     setDirtyValue();
 }
 

--- a/modules/SofaMiscEngine/src/SofaMiscEngine/ProjectiveTransformEngine.inl
+++ b/modules/SofaMiscEngine/src/SofaMiscEngine/ProjectiveTransformEngine.inl
@@ -35,15 +35,15 @@ ProjectiveTransformEngine<DataTypes>::ProjectiveTransformEngine()
     , proj_mat(initData(&proj_mat, "proj_mat", "projection matrix ") )
     , focal_distance(initData(&focal_distance, (Real)1,"focal_distance", "focal distance ") )
 {
+    addInput(&f_inputX);
+    addInput(&focal_distance);
+    addOutput(&f_outputX);
 }
 
 
 template <class DataTypes>
 void ProjectiveTransformEngine<DataTypes>::init()
 {
-    addInput(&f_inputX);
-    addInput(&focal_distance);
-    addOutput(&f_outputX);
     setDirtyValue();
 }
 


### PR DESCRIPTION
Even if it's not a good practice, it is possible to call `BaseObject::init()` several times.
In most cases, `DataEngine::init()` was the place where input and output Data were defined. Therefore, input and output could be defined several times, but it is not advisable.
This PR moves the input/output definition from the `init()` method to the constructor. Therefore, `init()` could be called multiple times safely (regarding only the input/output).



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
