### PR TITLE
[examples] Fix ProjectToPointconstraint scene by using MeshSpringForceField

### DIFF
--- a/examples/Components/constraint/ProjectToPointConstraint.scn
+++ b/examples/Components/constraint/ProjectToPointConstraint.scn
@@ -18,7 +18,7 @@
         <TriangleSetTopologyModifier name="Modifier" />
         <TriangleSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
         <UniformMass totalMass="1"  />
-		<MeshSpringForceField name="Springs" trianglesStiffness="1000" tetrasDamping="0" />        
+        <MeshSpringForceField name="Springs" trianglesStiffness="1000" tetrasDamping="0" />        
         <BoxConstraint box="-0.05 -0.05 -0.05    0.05 0.05 0.05" drawBoxes="1"  />
         <BoxROI box="-0.05 -0.05 -0.05    0.05 1.05 0.05" drawBoxes="1" name="ProjectToPlane"/>
         <ProjectToPointConstraint point="0 0 0" indices="@[-1].indices" drawSize="0.03" />

--- a/examples/Components/constraint/ProjectToPointConstraint.scn
+++ b/examples/Components/constraint/ProjectToPointConstraint.scn
@@ -18,7 +18,7 @@
         <TriangleSetTopologyModifier name="Modifier" />
         <TriangleSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
         <UniformMass totalMass="1"  />
-        <TriangularFEMForceField template="Vec3d" name="FEM"  method="large"  poissonRatio="0.3"  youngModulus="20" />
+		<MeshSpringForceField name="Springs" trianglesStiffness="1000" tetrasDamping="0" />        
         <BoxConstraint box="-0.05 -0.05 -0.05    0.05 0.05 0.05" drawBoxes="1"  />
         <BoxROI box="-0.05 -0.05 -0.05    0.05 1.05 0.05" drawBoxes="1" name="ProjectToPlane"/>
         <ProjectToPointConstraint point="0 0 0" indices="@[-1].indices" drawSize="0.03" />

--- a/examples/Components/constraint/ProjectToPointConstraint.scn
+++ b/examples/Components/constraint/ProjectToPointConstraint.scn
@@ -18,7 +18,7 @@
         <TriangleSetTopologyModifier name="Modifier" />
         <TriangleSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
         <UniformMass totalMass="1"  />
-        <MeshSpringForceField name="Springs" trianglesStiffness="1000" tetrasDamping="0" />
+        <MeshSpringForceField name="Springs" trianglesStiffness="1000" />
         <BoxConstraint box="-0.05 -0.05 -0.05    0.05 0.05 0.05" drawBoxes="1"  />
         <BoxROI box="-0.05 -0.05 -0.05    0.05 1.05 0.05" drawBoxes="1" name="ProjectToPlane"/>
         <ProjectToPointConstraint point="0 0 0" indices="@[-1].indices" drawSize="0.03" />

--- a/examples/Components/constraint/ProjectToPointConstraint.scn
+++ b/examples/Components/constraint/ProjectToPointConstraint.scn
@@ -18,7 +18,7 @@
         <TriangleSetTopologyModifier name="Modifier" />
         <TriangleSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
         <UniformMass totalMass="1"  />
-        <MeshSpringForceField name="Springs" trianglesStiffness="1000" tetrasDamping="0" />        
+        <MeshSpringForceField name="Springs" trianglesStiffness="1000" tetrasDamping="0" />
         <BoxConstraint box="-0.05 -0.05 -0.05    0.05 0.05 0.05" drawBoxes="1"  />
         <BoxROI box="-0.05 -0.05 -0.05    0.05 1.05 0.05" drawBoxes="1" name="ProjectToPlane"/>
         <ProjectToPointConstraint point="0 0 0" indices="@[-1].indices" drawSize="0.03" />


### PR DESCRIPTION
This scene was using a TriangleFEMForceField and exploding. This is not possible as the projectToPointConstraint is constraining several points in a single position, leading to flat triangles. 
Using a MeshSpringForceField instead.


![ProjectToPointConstraint_00000001](https://user-images.githubusercontent.com/21199245/161145056-22a75286-ccf8-4346-b10f-b7059e5738e8.png)


![ProjectToPointConstraint_00000002](https://user-images.githubusercontent.com/21199245/161145064-b0fb09f8-3235-498b-b019-12170b1ad6ef.png)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
