### PR TITLE
[SofaBoundaryCondition] Remove duplicated code

### DIFF
--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialFixedConstraint.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/PartialFixedConstraint.inl
@@ -37,21 +37,10 @@ PartialFixedConstraint<DataTypes>::PartialFixedConstraint()
     : d_fixedDirections( initData(&d_fixedDirections,"fixedDirections","for each direction, 1 if fixed, 0 if free") )
     , d_projectVelocity(initData(&d_projectVelocity, false, "projectVelocity", "project velocity to ensure no drift of the fixed point"))
 {
-    // default to indice 0
-    this->d_indices.beginEdit()->push_back(0);
-    this->d_indices.endEdit();
-
     VecBool blockedDirection;
     for( unsigned i=0; i<NumDimensions; i++)
         blockedDirection[i] = true;
     d_fixedDirections.setValue(blockedDirection);
-
-    this->addUpdateCallback("updateIndices", { &this->d_indices}, [this](const core::DataTracker& t)
-    {
-        SOFA_UNUSED(t);
-        this->checkIndices();
-        return sofa::core::objectmodel::ComponentState::Valid;
-    }, {});
 }
 
 


### PR DESCRIPTION
Code duplicated from the base class constructor (```FixedConstraint```), therefore called twice






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
