### PR TITLE
[examples] Fix falling cubes scene

### DIFF
--- a/examples/Benchmark/Performance/benchmark_cubes.pscn
+++ b/examples/Benchmark/Performance/benchmark_cubes.pscn
@@ -2,7 +2,7 @@
 <?php echo '<!-- Generated from benchmark_cubes.pscn -->';?>
 
 <Node name="root" dt="0.01" gravity="0 -9.81 0">
-    <Node name="pluginList"/>
+    <Node name="pluginList" >
         <RequiredPlugin name="SofaOpenglVisual"/>
         <RequiredPlugin name="SofaConstraint"/>
         <RequiredPlugin name="SofaMeshCollision"/>

--- a/examples/Benchmark/Performance/benchmark_cubes.scn
+++ b/examples/Benchmark/Performance/benchmark_cubes.scn
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <!-- Generated from benchmark_cubes.pscn -->
 <Node name="root" dt="0.01" gravity="0 -9.81 0">
-    <Node name="pluginList"/>
+    <Node name="pluginList" >
         <RequiredPlugin name="SofaOpenglVisual"/>
         <RequiredPlugin name="SofaConstraint"/>
         <RequiredPlugin name="SofaMeshCollision"/>


### PR DESCRIPTION
The line defining node gathering all the plugins was immediately closed (slash at the end)
consequently, the second `</Node>` was closing the root node itself. (so the loaded scene was containing nothing)



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
