### PR TITLE
[SceneUtility] MakeDataAliasComponent: Remove alias in destructor

### DIFF
--- a/Component/SceneUtility/src/sofa/component/sceneutility/MakeDataAliasComponent.cpp
+++ b/Component/SceneUtility/src/sofa/component/sceneutility/MakeDataAliasComponent.cpp
@@ -37,14 +37,13 @@ MakeDataAliasComponent::MakeDataAliasComponent()
     : d_componentname(initData(&d_componentname, "componentname", "The component class for which to create an alias."))
     , d_dataname(initData(&d_dataname, "dataname", "The data field for which to create an alias."))
     , d_alias(initData(&d_alias, "alias", "The alias of the data field."))
-    , d_keepAliasAfterDestruction(initData(&d_keepAliasAfterDestruction, false, "keepAliasAfterDestruction", "If true, the alias continues to be active after the destruction of this component. Otherwise, it is removed."))
 {
     d_componentState.setValue(ComponentState::Invalid) ;
 }
 
 MakeDataAliasComponent::~MakeDataAliasComponent()
 {
-    if (m_hasAddedAlias && !d_keepAliasAfterDestruction.getValue())
+    if (m_hasAddedAlias)
     {
         ObjectFactory::ClassEntry& creatorentry = ObjectFactory::getInstance()->getEntry(d_componentname.getValue());
         auto& aliases = creatorentry.m_dataAlias[d_dataname.getValue()];

--- a/Component/SceneUtility/src/sofa/component/sceneutility/MakeDataAliasComponent.cpp
+++ b/Component/SceneUtility/src/sofa/component/sceneutility/MakeDataAliasComponent.cpp
@@ -79,8 +79,6 @@ void MakeDataAliasComponent::parse ( core::objectmodel::BaseObjectDescription* a
                            "To remove this error message you need to add a targetcomponent attribute pointing to a valid component's ClassName.";
         return ;
     }
-    string sdataname(dataname) ;
-
 
     const char* alias=arg->getAttribute("alias") ;
     if(alias==nullptr)

--- a/Component/SceneUtility/src/sofa/component/sceneutility/MakeDataAliasComponent.cpp
+++ b/Component/SceneUtility/src/sofa/component/sceneutility/MakeDataAliasComponent.cpp
@@ -33,12 +33,27 @@ using std::string;
 namespace sofa::component::sceneutility::makedataaliascomponent
 {
 
-MakeDataAliasComponent::MakeDataAliasComponent() :
-   d_componentname(initData(&d_componentname, "componentname", "The component class for which to create an alias."))
-  ,d_dataname(initData(&d_dataname, "dataname", "The data field for which to create an alias."))
-  ,d_alias(initData(&d_alias, "alias", "The alias of the data field."))
+MakeDataAliasComponent::MakeDataAliasComponent()
+    : d_componentname(initData(&d_componentname, "componentname", "The component class for which to create an alias."))
+    , d_dataname(initData(&d_dataname, "dataname", "The data field for which to create an alias."))
+    , d_alias(initData(&d_alias, "alias", "The alias of the data field."))
+    , d_keepAliasAfterDestruction(initData(&d_keepAliasAfterDestruction, false, "keepAliasAfterDestruction", "If true, the alias continues to be active after the destruction of this component. Otherwise, it is removed."))
 {
     d_componentState.setValue(ComponentState::Invalid) ;
+}
+
+MakeDataAliasComponent::~MakeDataAliasComponent()
+{
+    if (m_hasAddedAlias && !d_keepAliasAfterDestruction.getValue())
+    {
+        ObjectFactory::ClassEntry& creatorentry = ObjectFactory::getInstance()->getEntry(d_componentname.getValue());
+        auto& aliases = creatorentry.m_dataAlias[d_dataname.getValue()];
+        const auto it = std::find(aliases.begin(), aliases.end(), d_alias.getValue());
+        if (it != aliases.end())
+        {
+            aliases.erase(std::remove(aliases.begin(), aliases.end(), d_alias.getValue()), aliases.end());
+        }
+    }
 }
 
 void MakeDataAliasComponent::parse ( core::objectmodel::BaseObjectDescription* arg )
@@ -85,12 +100,15 @@ void MakeDataAliasComponent::parse ( core::objectmodel::BaseObjectDescription* a
     }
 
     ObjectFactory::ClassEntry& creatorentry = ObjectFactory::getInstance()->getEntry(scomponent);
-    if(creatorentry.m_dataAlias.find(dataname) != creatorentry.m_dataAlias.end()){
-        creatorentry.m_dataAlias[dataname] = std::vector<std::string>();
+    auto& aliases = creatorentry.m_dataAlias[dataname];
+    const auto it = std::find(aliases.begin(), aliases.end(), salias);
+    if (it != aliases.end())
+    {
+        aliases.push_back(salias);
+        m_hasAddedAlias = true;
     }
-    creatorentry.m_dataAlias[dataname].push_back(salias) ;
 
-    d_componentState.setValue(ComponentState::Valid) ;
+    d_componentState.setValue(ComponentState::Valid);
 }
 
 int MakeDataAliasComponentClass = RegisterObject("This object create an alias to a data field. ")

--- a/Component/SceneUtility/src/sofa/component/sceneutility/MakeDataAliasComponent.h
+++ b/Component/SceneUtility/src/sofa/component/sceneutility/MakeDataAliasComponent.h
@@ -61,7 +61,7 @@ public:
     {
         return "MakeDataAlias" ;
     }
-protected:
+private:
 
     bool m_hasAddedAlias { false };
 };

--- a/Component/SceneUtility/src/sofa/component/sceneutility/MakeDataAliasComponent.h
+++ b/Component/SceneUtility/src/sofa/component/sceneutility/MakeDataAliasComponent.h
@@ -43,7 +43,7 @@ public:
     SOFA_CLASS(MakeDataAliasComponent, core::objectmodel::BaseObject);
 
     MakeDataAliasComponent() ;
-    ~MakeDataAliasComponent() override{}
+    ~MakeDataAliasComponent() override;
 
     /// Inherited from BaseObject.
     /// Parse the given description to assign values to this object's fields and
@@ -53,6 +53,7 @@ public:
     Data<std::string>   d_componentname       ; ///< The component class for which to create an alias.
     Data<std::string>   d_dataname            ; ///< The data field for which to create an alias.
     Data<std::string>   d_alias               ; ///< The alias of the data field.
+    Data<bool>          d_keepAliasAfterDestruction;
 
     /// Returns the sofa class name. By default the name of the c++ class is exposed... but
     /// Here we want it to be MakeAlias so we need to customize it.
@@ -61,7 +62,9 @@ public:
     {
         return "MakeDataAlias" ;
     }
+protected:
 
+    bool m_hasAddedAlias { false };
 };
 
 } // namespace sofa::component::sceneutility::makedataaliascomponent

--- a/Component/SceneUtility/src/sofa/component/sceneutility/MakeDataAliasComponent.h
+++ b/Component/SceneUtility/src/sofa/component/sceneutility/MakeDataAliasComponent.h
@@ -53,7 +53,6 @@ public:
     Data<std::string>   d_componentname       ; ///< The component class for which to create an alias.
     Data<std::string>   d_dataname            ; ///< The data field for which to create an alias.
     Data<std::string>   d_alias               ; ///< The alias of the data field.
-    Data<bool>          d_keepAliasAfterDestruction;
 
     /// Returns the sofa class name. By default the name of the c++ class is exposed... but
     /// Here we want it to be MakeAlias so we need to customize it.


### PR DESCRIPTION
Due to the static nature of the ObjectFactory, the alias survived the destruction of a MakeDataAliasComponent. It is a problem if the program continues and still uses the ObjectFactory.






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
