### PR TITLE
[Sofa.Core] Remove annoying 'unused' warning in StateAccessor

### DIFF
--- a/SofaKernel/modules/SofaCore/src/sofa/core/behavior/StateAccessor.h
+++ b/SofaKernel/modules/SofaCore/src/sofa/core/behavior/StateAccessor.h
@@ -68,6 +68,8 @@ protected:
 
 inline void StateAccessor::computeBBox(const core::ExecParams* params, bool onlyVisible)
 {
+    SOFA_UNUSED(params);
+
     if( !onlyVisible ) return;
 
     static constexpr SReal max_real = std::numeric_limits<SReal>::max();


### PR DESCRIPTION
StateAccessor is used quite intensively so this warning is popping up everywhere.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
