### PR TITLE
[Preconditioner] Fix missing find_package() in the cmake.in

### DIFF
--- a/Component/LinearSolver/Preconditioner/Sofa.Component.LinearSolver.PreconditionerConfig.cmake.in
+++ b/Component/LinearSolver/Preconditioner/Sofa.Component.LinearSolver.PreconditionerConfig.cmake.in
@@ -4,6 +4,9 @@
 @PACKAGE_INIT@
 
 find_package(Sofa.SimulationCore QUIET REQUIRED)
+find_package(Sofa.Component.ODESolver.Backward QUIET REQUIRED)
+find_package(Sofa.Component.LinearSolver.Iterative QUIET REQUIRED)
+find_package(Sofa.Component.LinearSolver.Direct QUIET REQUIRED)
 
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
Title says all.
Not detectable on the CI unfortunately.
Thanks to @alxbilger for the report



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
