### PR TITLE
[FEM.Elastic] Minor changes in TetraXX FEM at init and to be able to access Data 

### DIFF
--- a/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.h
+++ b/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.h
@@ -108,6 +108,8 @@ protected:
         }
     };
 
+
+public:
     /// Topology Data
     typedef typename VecCoord::template rebind<TetrahedronRestInformation>::other VecTetrahedronRestInformation;
     typedef typename VecCoord::template rebind <Mat3x3>::other VecMat3x3;
@@ -116,19 +118,7 @@ protected:
     core::topology::EdgeData<VecMat3x3 > edgeInfo; ///< Internal edge data
     core::topology::TetrahedronData<VecTetrahedronRestInformation > tetrahedronInfo; ///< Internal tetrahedron data
 
-    /** Method to initialize @sa TetrahedronRestInformation when a new Tetrahedron is created.
-    * Will be set as creation callback in the TetrahedronData @sa tetrahedronInfo
-    */
-    void createTetrahedronRestInformation(Index, TetrahedronRestInformation& t,
-        const core::topology::BaseMeshTopology::Tetrahedron&,
-        const sofa::type::vector<Index>&,
-        const sofa::type::vector<SReal>&);
-
-    sofa::core::topology::BaseMeshTopology* m_topology;
     VecCoord  _initialPoints;///< the intial positions of the points
-
-    bool updateMatrix;
-
     Data<std::string> f_method; ///< the computation method of the displacements
     RotationDecompositionMethod m_decompositionMethod;
 
@@ -193,8 +183,20 @@ public:
 protected :
     static void computeQRRotation( Mat3x3 &r, const Coord *dp);
 
+    /** Method to initialize @sa TetrahedronRestInformation when a new Tetrahedron is created.
+    * Will be set as creation callback in the TetrahedronData @sa tetrahedronInfo
+    */
+    void createTetrahedronRestInformation(Index, TetrahedronRestInformation& t,
+        const core::topology::BaseMeshTopology::Tetrahedron&,
+        const sofa::type::vector<Index>&,
+        const sofa::type::vector<SReal>&);
+
     core::topology::EdgeData< VecMat3x3 > &getEdgeInfo() {return edgeInfo;}
     
+    sofa::core::topology::BaseMeshTopology* m_topology;    
+
+    bool updateMatrix;
+
     typedef FastTetrahedralCorotationalForceFieldData<DataTypes> ExtraData;
     ExtraData m_data;
 };

--- a/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.inl
+++ b/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/FastTetrahedralCorotationalForceField.inl
@@ -152,7 +152,8 @@ FastTetrahedralCorotationalForceField<DataTypes>::FastTetrahedralCorotationalFor
     , drawColor4(initData(&drawColor4, sofa::type::RGBAColor(0.5f, 1.0f, 1.0f, 1.0f), "drawColor4", " draw color for faces 4"))
     , l_topology(initLink("topology", "link to the topology container"))
 {
-
+    f_poissonRatio.setRequired(true);
+    f_youngModulus.setRequired(true);
 }
 
 template <class DataTypes> 

--- a/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedralCorotationalFEMForceField.inl
+++ b/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedralCorotationalFEMForceField.inl
@@ -103,6 +103,12 @@ void TetrahedralCorotationalFEMForceField<DataTypes>::init()
         this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         return;
     }
+
+    if (m_topology->getNbTetrahedra() == 0)
+    {
+        msg_warning() << "No tetrahedra found in linked Topology.";
+    }
+
     reinit(); // compute per-element stiffness matrices and other precomputed values
 }
 

--- a/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.h
+++ b/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.h
@@ -92,6 +92,7 @@ public:
     typedef core::topology::BaseMeshTopology::Tetra Element;
     typedef core::topology::BaseMeshTopology::SeqTetrahedra VecElement;
     typedef core::topology::BaseMeshTopology::Tetrahedron Tetrahedron;
+    using TetrahedronID = core::topology::BaseMeshTopology::TetrahedronID;
 
     enum { SMALL = 0,   ///< Symbol of small displacements tetrahedron solver
            LARGE = 1,   ///< Symbol of corotational large displacements tetrahedron solver based on a QR decomposition    -> Nesme et al 2005 "Efficient, Physically Plausible Finite Elements"
@@ -162,6 +163,11 @@ protected:
 
     Real m_restVolume;
     sofa::helper::ColorMap* m_VonMisesColorMap;
+
+    Transformation InvalidTransform;
+    type::fixed_array<Coord, 4> InvalidCoords;
+    MaterialStiffness InvalidMaterialStiffness;
+    StrainDisplacement InvalidStrainDisplacement;
 
 public:
     // get the volume of the mesh
@@ -240,8 +246,15 @@ public:
     void setComputeGlobalMatrix(bool val) { this->_assembling.setValue(val); }
 
     //for tetra mapping, should be removed in future
-    Transformation getActualTetraRotation(Index index);
-    Transformation getInitialTetraRotation(Index index);
+    const Transformation& getActualTetraRotation(Index index);
+    const Transformation& getInitialTetraRotation(Index index);
+
+    const MaterialStiffness& getMaterialStiffness(TetrahedronID tetraId);
+    const StrainDisplacement& getStrainDisplacement(TetrahedronID tetraId);
+
+    // large displacements method
+    const type::fixed_array<Coord, 4>& getRotatedInitialElements(TetrahedronID tetraId);
+
 
     void setMethod(std::string methodName);
     void setMethod(int val);

--- a/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
+++ b/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/TetrahedronFEMForceField.inl
@@ -2126,20 +2126,61 @@ void TetrahedronFEMForceField<DataTypes>::setYoungModulus(Real val)
 }
 
 template<class DataTypes>
-typename TetrahedronFEMForceField<DataTypes>::Transformation TetrahedronFEMForceField<DataTypes>::getActualTetraRotation(unsigned int index)
+const typename TetrahedronFEMForceField<DataTypes>::Transformation& TetrahedronFEMForceField<DataTypes>::getActualTetraRotation(unsigned int index)
 {
-    if (index < rotations.size() )
+    if (index < rotations.size())
         return rotations[index];
-    else { Transformation t; t.identity(); return t; }
+
+    msg_warning() << "Method getActualTetraRotation called with element index: " << index
+        << " which is out of bounds: [0, " << rotations.size() << "]. Returning default empty array of coordinates.";
+    return InvalidTransform;
 }
 
 template<class DataTypes>
-typename TetrahedronFEMForceField<DataTypes>::Transformation TetrahedronFEMForceField<DataTypes>::getInitialTetraRotation(unsigned int index)
-{
-    if (index < rotations.size() )
+const typename TetrahedronFEMForceField<DataTypes>::Transformation& TetrahedronFEMForceField<DataTypes>::getInitialTetraRotation(unsigned int index)
+{ 
+    if (index < _initialRotations.size())
         return _initialRotations[index];
-    else { Transformation t; t.identity(); return t; }
+
+    msg_warning() << "Method getInitialTetraRotation called with element index: " << index
+        << " which is out of bounds: [0, " << _initialRotations.size() << "]. Returning default empty array of coordinates.";
+    return InvalidTransform;
 }
+
+template<class DataTypes>
+const typename TetrahedronFEMForceField<DataTypes>::MaterialStiffness& TetrahedronFEMForceField<DataTypes>::getMaterialStiffness(TetrahedronID tetraId)
+{
+    if (tetraId != sofa::InvalidID && tetraId < materialsStiffnesses.size())
+        return materialsStiffnesses[tetraId];
+
+    msg_warning() << "Method getMaterialStiffness called with element index: " << tetraId
+        << " which is out of bounds: [0, " << materialsStiffnesses.size() << "]. Returning default empty array of coordinates.";
+    return InvalidMaterialStiffness;
+}
+
+template<class DataTypes>
+const typename TetrahedronFEMForceField<DataTypes>::StrainDisplacement& TetrahedronFEMForceField<DataTypes>::getStrainDisplacement(TetrahedronID tetraId)
+{
+    if (tetraId != sofa::InvalidID && tetraId < strainDisplacements.size())
+        return strainDisplacements[tetraId];
+
+    msg_warning() << "Method getStrainDisplacement called with element index: " << tetraId
+        << " which is out of bounds: [0, " << strainDisplacements.size() << "]. Returning default empty array of coordinates.";
+    return InvalidStrainDisplacement;
+}
+
+
+template<class DataTypes>
+const type::fixed_array<typename TetrahedronFEMForceField<DataTypes>::Coord, 4>& TetrahedronFEMForceField<DataTypes>::getRotatedInitialElements(TetrahedronID tetraId)
+{
+    if (tetraId != sofa::InvalidID && tetraId < _rotatedInitialElements.size())
+        return _rotatedInitialElements[tetraId];
+
+    msg_warning() << "Method getRotatedInitialElements called with element index: " << tetraId
+        << " which is out of bounds: [0, " << _rotatedInitialElements.size() << "]. Returning default empty array of coordinates.";
+    return InvalidCoords;
+}
+
 
 template<class DataTypes>
 void TetrahedronFEMForceField<DataTypes>::setMethod(std::string methodName)


### PR DESCRIPTION
- `TetrahedronFEMForceField` Add getter per tetrahedron for:
  - Rotation matrix
  - Initial rotation matrix
  - Material stiffness matrix
  - Strain Displacement
  - Local coordinates (in rotated frame)
  
- `TetrahedralCorotationalFEMForceField`
  - Add warning at init if topology is empty
  
- `FastTetrahedralCorotationalForceField`
  - Move Data scope as public
  - Set poisson and young modulus as required Data

This PR integrate changes in component needed for tests introduced in #2842

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
