### PR TITLE
[All] Removing the simplest bwdInit functions

### DIFF
--- a/Component/IO/Mesh/src/sofa/component/io/mesh/VTKExporter.cpp
+++ b/Component/IO/Mesh/src/sofa/component/io/mesh/VTKExporter.cpp
@@ -92,6 +92,9 @@ void VTKExporter::init()
         fetchDataFields(cellsData, cellsDataObject, cellsDataField, cellsDataName);
     }
 
+    /// Activate the listening to the event in order to be able to export file at first step or the nth-step
+    if(exportEveryNbSteps.getValue() != 0 || exportAtBegin.getValue())
+        this->f_listening.setValue(true);
 }
 
 void VTKExporter::fetchDataFields(const type::vector<std::string>& strData, type::vector<std::string>& objects, type::vector<std::string>& fields, type::vector<std::string>& names)

--- a/Component/IO/Mesh/src/sofa/component/io/mesh/VTKExporter.cpp
+++ b/Component/IO/Mesh/src/sofa/component/io/mesh/VTKExporter.cpp
@@ -23,6 +23,7 @@
 
 #include <sofa/core/ObjectFactory.h>
 
+#include <sofa/simulation/AnimateBeginEvent.h>
 #include <sofa/simulation/AnimateEndEvent.h>
 #include <sofa/core/objectmodel/KeypressedEvent.h>
 
@@ -973,19 +974,22 @@ void VTKExporter::handleEvent(sofa::core::objectmodel::Event *event)
                 writeVTKSimple();
         }
     }
+    else if ( /*simulation::AnimateBeginEvent* ev =*/ simulation::AnimateBeginEvent::checkEventType(event))
+    {
+        if (isFirstStep && exportAtBegin.getValue())
+        {
+            (fileFormat.getValue()) ? writeVTKXML() : writeVTKSimple();
+            isFirstStep = false;
+        }
+    }
 }
 
 void VTKExporter::cleanup()
 {
     if (exportAtEnd.getValue())
+    {
         (fileFormat.getValue()) ? writeVTKXML() : writeVTKSimple();
-
-}
-
-void VTKExporter::bwdInit()
-{
-    if (exportAtBegin.getValue())
-        (fileFormat.getValue()) ? writeVTKXML() : writeVTKSimple();
+    }
 }
 
 } // namespace sofa::component::_vtkexporter_

--- a/Component/IO/Mesh/src/sofa/component/io/mesh/VTKExporter.h
+++ b/Component/IO/Mesh/src/sofa/component/io/mesh/VTKExporter.h
@@ -42,6 +42,7 @@ protected:
     sofa::core::topology::BaseMeshTopology* topology;
     sofa::core::behavior::BaseMechanicalState* mstate;
     unsigned int stepCounter;
+    bool isFirstStep = true;
 
     std::ofstream* outfile;
 
@@ -84,8 +85,6 @@ protected:
 public:
     void init() override;
     void cleanup() override;
-    void bwdInit() override;
-
     void handleEvent(sofa::core::objectmodel::Event *) override;
 };
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/BaseSimulationExporter.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/BaseSimulationExporter.cpp
@@ -128,8 +128,8 @@ void BaseSimulationExporter::updateFromDataField()
         d_filename.setValue(getName());
     }
 
-    /// Activate the listening to the event in order to be able to export file at the nth-step
-    if(d_exportEveryNbSteps.getValue() != 0)
+    /// Activate the listening to the event in order to be able to export file at first step or the nth-step
+    if(d_exportEveryNbSteps.getValue() != 0 || d_exportAtBegin.getValue())
         this->f_listening.setValue(true);
 }
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/BaseSimulationExporter.cpp
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/BaseSimulationExporter.cpp
@@ -94,6 +94,14 @@ void BaseSimulationExporter::handleEvent(Event *event){
             }
         }
     }
+    else if (AnimateBeginEvent::checkEventType(event))
+    {
+        if (firstStep && d_isEnabled.getValue() && d_exportAtBegin.getValue())
+        {
+            write();
+            firstStep = false;
+        }
+    }
 
     BaseObject::handleEvent(event) ;
 }
@@ -128,13 +136,6 @@ void BaseSimulationExporter::updateFromDataField()
 void BaseSimulationExporter::cleanup()
 {
     if (d_isEnabled.getValue() && d_exportAtEnd.getValue())
-        write();
-}
-
-
-void BaseSimulationExporter::bwdInit()
-{
-    if (d_isEnabled.getValue() && d_exportAtBegin.getValue())
         write();
 }
 

--- a/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/BaseSimulationExporter.h
+++ b/SofaKernel/modules/SofaSimulationCore/src/sofa/simulation/BaseSimulationExporter.h
@@ -62,7 +62,6 @@ public:
     void reinit() final ;
 
     void cleanup() override ;
-    void bwdInit() override ;
     void handleEvent(Event *event) override ;
 
     virtual void doInit() {}
@@ -77,6 +76,7 @@ protected:
     const std::string getOrCreateTargetPath(const std::string& filename, bool autonumbering) ;
     void updateFromDataField() ;
     unsigned int       m_stepCounter {0} ;
+    bool firstStep = true;
 };
 
 } /// namespace _baseexporter_

--- a/applications/plugins/LeapMotion/src/LeapMotionDriver.cpp
+++ b/applications/plugins/LeapMotion/src/LeapMotionDriver.cpp
@@ -135,12 +135,6 @@ void LeapMotionDriver::init()
 }
 
 
-void LeapMotionDriver::bwdInit()
-{
-    msg_info() <<"LeapMotionDriver::bwdInit()";
-}
-
-
 void LeapMotionDriver::reset()
 {
     msg_info() <<"LeapMotionDriver::reset()";

--- a/applications/plugins/LeapMotion/src/LeapMotionDriver.h
+++ b/applications/plugins/LeapMotion/src/LeapMotionDriver.h
@@ -97,7 +97,6 @@ public:
     virtual ~LeapMotionDriver();
 
     void init();
-    void bwdInit();
     void reset();
     void reinit();
 

--- a/applications/plugins/image/ImageExporter.h
+++ b/applications/plugins/image/ImageExporter.h
@@ -240,6 +240,8 @@ public:
     Data<bool> exportAtBegin; ///< export file at the initialization
     Data<bool> exportAtEnd; ///< export file when the simulation is finished
 
+    bool firstStep = true;
+
     ImageExporter()	: Inherited()
         , image(initData(&image,ImageTypes(),"image","image"))
         , transform(initData(&transform, TransformType(), "transform" , ""))
@@ -261,9 +263,7 @@ public:
 
     ~ImageExporter() override {}
 
-    	void cleanup() override { if (exportAtEnd.getValue()) write();	}
-
-    void bwdInit() override { if (exportAtBegin.getValue())	write(); }
+    void cleanup() override { if (exportAtEnd.getValue()) write();	}
 
 protected:
 
@@ -320,6 +320,14 @@ protected:
 
             if (guiEvent->getValueName().compare("ImageExport") == 0)
                 write();
+        }
+        else if ( /*simulation::AnimateBeginEvent* ev =*/ simulation::AnimateBeginEvent::checkEventType(event))
+        {
+            if (firstStep && exportAtBegin.getValue())
+            {
+                write();
+                firstStep = false;
+            }
         }
     }
 

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TorsionForceField.h
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TorsionForceField.h
@@ -88,7 +88,6 @@ public:
 	TorsionForceField();
 	virtual ~TorsionForceField();
 
-	void bwdInit() override;
 	void addForce(const MechanicalParams *, DataVecDeriv &f, const DataVecCoord &x, const DataVecDeriv &v) override;
 	void addDForce(const MechanicalParams *mparams, DataVecDeriv &df, const DataVecDeriv &dx) override;
 	void addKToMatrix(linearalgebra::BaseMatrix *matrix, SReal kFact, unsigned int &offset) override;

--- a/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TorsionForceField.inl
+++ b/modules/SofaBoundaryCondition/src/SofaBoundaryCondition/TorsionForceField.inl
@@ -39,19 +39,19 @@ TorsionForceField<DataTypes>::TorsionForceField() :
 	m_axis(initData(&m_axis, "axis", "direction of the axis (will be normalized)")),
 	m_origin(initData(&m_origin, "origin", "origin of the axis"))
 {
+    /// Update the normalized axis from m_axis
+    this->addUpdateCallback("updateNormalAxis", {&m_axis}, [this](const core::DataTracker& )
+    {
+        m_u = m_axis.getValue();
+        m_u.normalize();
+        return sofa::core::objectmodel::ComponentState::Valid;
+    }, {&m_indices});
 }
 
 template<typename DataTypes>
 TorsionForceField<DataTypes>::~TorsionForceField()
 {
 
-}
-
-template<typename DataTypes>
-void TorsionForceField<DataTypes>::bwdInit()
-{
-	m_u = m_axis.getValue();
-	m_u.normalize();
 }
 
 template<typename DataTypes>

--- a/modules/SofaGeneralEngine/SofaGeneralEngine_test/DilateEngine_test.cpp
+++ b/modules/SofaGeneralEngine/SofaGeneralEngine_test/DilateEngine_test.cpp
@@ -76,7 +76,6 @@ struct DilateEngine_test : public BaseSimulationTest,
         EXPECT_TRUE( m_thisObject->findData("minThickness") != nullptr ) ;
 
         EXPECT_NO_THROW( m_thisObject->init() ) ;
-        EXPECT_NO_THROW( m_thisObject->bwdInit() ) ;
         EXPECT_NO_THROW( m_thisObject->reinit() ) ;
         EXPECT_NO_THROW( m_thisObject->reset() ) ;
         EXPECT_NO_THROW(this->update()) ;

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/DilateEngine.h
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/DilateEngine.h
@@ -58,7 +58,6 @@ public:
     ~DilateEngine() override {}
 
     void init() override;
-    void bwdInit() override;
     void reinit() override;
     void doUpdate() override;
 

--- a/modules/SofaGeneralEngine/src/SofaGeneralEngine/DilateEngine.inl
+++ b/modules/SofaGeneralEngine/src/SofaGeneralEngine/DilateEngine.inl
@@ -65,17 +65,6 @@ void DilateEngine<DataTypes>::init()
 
 
 template <class DataTypes>
-void DilateEngine<DataTypes>::bwdInit()
-{
-    if((d_triangles.getValue().size()==0) && (d_quads.getValue().size()==0))
-        msg_warning(this) << "No input mesh";
-
-    if(d_inputX.getValue().size()==0)
-        msg_warning(this) << "No input position";
-}
-
-
-template <class DataTypes>
 void DilateEngine<DataTypes>::reinit()
 {
     update();
@@ -91,12 +80,21 @@ void DilateEngine<DataTypes>::doUpdate()
     const Real minThickness = d_minThickness.getValue();
 
     WriteOnlyAccessor<Data<VecCoord> > out = d_outputX;
+    WriteOnlyAccessor<Data<VecCoord> > normals = d_normals;
 
     const int nbp = in.size();
     const int nbt = triangles.size();
     const int nbq = quads.size();
 
-    WriteOnlyAccessor<Data<VecCoord> > normals = d_normals;
+    if((nbt==0) && (nbq==0))
+    {
+        msg_warning() << "No input mesh";
+    }
+    if(nbp==0)
+    {
+        msg_warning() << "No input mesh";
+    }
+
     normals.resize(nbp);
     for (int i=0; i<nbp; ++i)
         normals[i].clear();

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/BeamFEMForceField.h
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/BeamFEMForceField.h
@@ -158,7 +158,6 @@ public:
     bool m_partialListSegment;
     bool m_updateStiffnessMatrix;
     bool m_assembling;
-    SReal m_lastUpdatedStep;
 
     Quat<SReal>& beamQuat(int i);
 
@@ -171,7 +170,6 @@ public:
 public:
 
     void init() override;
-    void bwdInit() override;
     void reinit() override;
     virtual void reinitBeam(Index i);
     void addForce(const MechanicalParams* mparams, DataVecDeriv &  dataF, const DataVecCoord &  dataX , const DataVecDeriv & dataV ) override;

--- a/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/BeamFEMForceField.inl
+++ b/modules/SofaGeneralSimpleFem/src/SofaGeneralSimpleFem/BeamFEMForceField.inl
@@ -86,16 +86,6 @@ BeamFEMForceField<DataTypes>::~BeamFEMForceField()
 
 }
 
-template <class DataTypes>
-void BeamFEMForceField<DataTypes>::bwdInit()
-{
-    core::behavior::BaseMechanicalState* state = this->getContext()->getMechanicalState();
-    if(!state)
-        msg_warning() << "Missing mechanical state";
-    m_lastUpdatedStep=-1.0;
-}
-
-
 
 template <class DataTypes>
 void BeamFEMForceField<DataTypes>::init()


### PR DESCRIPTION
Among the remaining `bwdInit()` functions, this PR removes the one which were useless or rather related to the AnimateBeginEvent


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
