### PR TITLE
[Mass] Fix point topological changes for UniformMass

### DIFF
--- a/Sofa/Component/Mass/src/sofa/component/mass/UniformMass.inl
+++ b/Sofa/Component/Mass/src/sofa/component/mass/UniformMass.inl
@@ -179,7 +179,7 @@ void UniformMass<DataTypes>::initDefaultImpl()
         msg_info() << "Topology path used: '" << l_topology.getLinkedPath() << "'";
 
         d_indices.createTopologyHandler(meshTopology);
-        d_indices.supportNewElements(true);
+        d_indices.supportNewTopologyElements(true);
 
         // Need to create a call back to assign index of new point into the topologySubsetData. Deletion is automatically handle.
         d_indices.setCreationCallback([this](Index dataIndex, Index& valueIndex,

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/tests/BeamFEMForceField_test.cpp
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/tests/BeamFEMForceField_test.cpp
@@ -92,7 +92,7 @@ public:
         createObject(m_root, "EdgeSetGeometryAlgorithms", { {"template","Rigid3d"} });
 
         createObject(m_root, "BeamFEMForceField", { {"Name","Beam"}, {"template", "Rigid3d"}, {"radius", str(radius)}, {"youngModulus", str(youngModulus)}, {"poissonRatio", str(poissonRatio)} });
-        createObject(m_root, "UniformMass", { {"name","mass"}, {"totalMass","1.0"}, {"handleTopologicalChanges", "1" } });
+        createObject(m_root, "UniformMass", { {"name","mass"}, {"totalMass","1.0"} });
         createObject(m_root, "FixedConstraint", { {"name","fix"}, {"indices","0"} });
 
         /// Init simulation

--- a/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.h
+++ b/Sofa/framework/Core/src/sofa/core/topology/TopologySubsetIndices.h
@@ -50,7 +50,7 @@ public:
     void createTopologyHandler(sofa::core::topology::BaseMeshTopology* _topology) override;
 
     SOFA_ATTRIBUTE_DISABLED("v21.12 (PR#2393)", "v21.12 (PR#2393)", "This method has been removed, TopologyHandler is now created internally. Method createTopologyHandler(BaseMeshTopology*) should be used.")
-    void createTopologyHandler(sofa::core::topology::BaseMeshTopology* _topology, sofa::core::topology::TopologyDataHandler < core::topology::BaseMeshTopology::Point, type::vector<Index> >* topoEngine) = delete;
+    void createTopologyHandler(sofa::core::topology::BaseMeshTopology* _topology, sofa::core::topology::TopologyDataHandler < core::topology::BaseMeshTopology::Point, type::vector<Index> >* topoEngine) override = delete;
 
 protected:
     void swapPostProcess(Index i1, Index i2) override;

--- a/examples/Components/topology/TopologicalModifiers/AddingPointInTriangleProcess.scn
+++ b/examples/Components/topology/TopologicalModifiers/AddingPointInTriangleProcess.scn
@@ -1,4 +1,4 @@
-<Node >
+<Node bbox="0 0 0 20 20 20">
     <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [UniformMass] -->
     <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [TriangularFEMForceField] -->
     <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->


### PR DESCRIPTION
Based on #2870 

The topological callback was actually not working for the UniformMass.
Now POINTSADDED and POINTSREMOVED are handled

in addition:
- add override to avoid massive warnings
- add box in scene to allow seeing the mesh

Thanks to @oparras for rising this in #2668
A regression could be added on this scene

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
