### PR TITLE
[Sofa.GL.Component] Fix tangents/bitangents type set for OpenGL

### DIFF
--- a/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
+++ b/Component/Visual/src/sofa/component/visual/VisualModelImpl.cpp
@@ -1157,9 +1157,10 @@ void VisualModelImpl::computeTangents()
     const VecVisualQuad& quads = m_quads.getValue();
     const VecCoord& vertices = getVertices();
     const VecTexCoord& texcoords = m_vtexcoords.getValue();
-    VecCoord& normals = *(m_vnormals.beginEdit());
-    VecCoord& tangents = *(m_vtangents.beginEdit());
-    VecCoord& bitangents = *(m_vbitangents.beginEdit());
+    const auto& normals = m_vnormals.getValue();
+
+    auto tangents = sofa::helper::getWriteOnlyAccessor(m_vtangents);
+    auto bitangents = sofa::helper::getWriteOnlyAccessor(m_vbitangents);
 
     tangents.resize(vertices.size());
     bitangents.resize(vertices.size());
@@ -1172,22 +1173,22 @@ void VisualModelImpl::computeTangents()
     const bool fixMergedUVSeams = m_fixMergedUVSeams.getValue();
     for (std::size_t i = 0; i < triangles.size() ; i++)
     {
-        const Coord v1 = vertices[triangles[i][0]];
-        const Coord v2 = vertices[triangles[i][1]];
-        const Coord v3 = vertices[triangles[i][2]];
-        TexCoord t1 = texcoords[triangles[i][0]];
+        const Coord& v1 = vertices[triangles[i][0]];
+        const Coord& v2 = vertices[triangles[i][1]];
+        const Coord& v3 = vertices[triangles[i][2]];
+        const TexCoord& t1 = texcoords[triangles[i][0]];
         TexCoord t2 = texcoords[triangles[i][1]];
         TexCoord t3 = texcoords[triangles[i][2]];
         if (fixMergedUVSeams)
         {
-            for (Size j=0; j<t1.size(); ++j)
+            for (Size j=0; j<TexCoord::size(); ++j)
             {
                 t2[j] += helper::rnear(t1[j]-t2[j]);
                 t3[j] += helper::rnear(t1[j]-t3[j]);
             }
         }
-        Coord t = computeTangent(v1, v2, v3, t1, t2, t3);
-        Coord b = computeBitangent(v1, v2, v3, t1, t2, t3);
+        const Coord t = computeTangent(v1, v2, v3, t1, t2, t3);
+        const Coord b = computeBitangent(v1, v2, v3, t1, t2, t3);
 
         tangents[triangles[i][0]] += t;
         tangents[triangles[i][1]] += t;
@@ -1199,14 +1200,14 @@ void VisualModelImpl::computeTangents()
 
     for (std::size_t i = 0; i < quads.size() ; i++)
     {
-        const Coord & v1 = vertices[quads[i][0]];
-        const Coord & v2 = vertices[quads[i][1]];
-        const Coord & v3 = vertices[quads[i][2]];
-        const Coord & v4 = vertices[quads[i][3]];
-        const TexCoord t1 = texcoords[quads[i][0]];
-        const TexCoord t2 = texcoords[quads[i][1]];
-        const TexCoord t3 = texcoords[quads[i][2]];
-        const TexCoord t4 = texcoords[quads[i][3]];
+        const Coord& v1 = vertices[quads[i][0]];
+        const Coord& v2 = vertices[quads[i][1]];
+        const Coord& v3 = vertices[quads[i][2]];
+        const Coord& v4 = vertices[quads[i][3]];
+        const TexCoord& t1 = texcoords[quads[i][0]];
+        const TexCoord& t2 = texcoords[quads[i][1]];
+        const TexCoord& t3 = texcoords[quads[i][2]];
+        const TexCoord& t4 = texcoords[quads[i][3]];
 
         // Too many options how to split a quad into two triangles...
         Coord t123 = computeTangent  (v1, v2, v3, t1, t2, t3);
@@ -1232,15 +1233,14 @@ void VisualModelImpl::computeTangents()
     }
     for (std::size_t i = 0; i < vertices.size(); i++)
     {
-        Coord n = normals[i];
+        const Coord& n = normals[i];
         Coord& t = tangents[i];
         Coord& b = bitangents[i];
 
         b = sofa::type::cross(n, t.normalized());
         t = sofa::type::cross(b, n);
     }
-    m_vtangents.endEdit();
-    m_vbitangents.endEdit();
+
 }
 
 void VisualModelImpl::computeBBox(const core::ExecParams*, bool)

--- a/SofaKernel/modules/Sofa.GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.cpp
+++ b/SofaKernel/modules/Sofa.GL/Component/Rendering3D/src/sofa/gl/component/rendering3d/OglModel.cpp
@@ -427,7 +427,7 @@ void OglModel::internalDraw(const core::visual::VisualParams* vparams, bool tran
             glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 
             glBindBuffer(GL_ARRAY_BUFFER, vbo);
-            glTexCoordPointer(3, GL_FLOAT, 0,
+            glTexCoordPointer(3, GL_DOUBLE, 0,
                               reinterpret_cast<void*>(vertexArrayByteSize + normalArrayByteSize + textureArrayByteSize));
             glBindBuffer(GL_ARRAY_BUFFER, 0);
 
@@ -435,7 +435,7 @@ void OglModel::internalDraw(const core::visual::VisualParams* vparams, bool tran
             glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 
             glBindBuffer(GL_ARRAY_BUFFER, vbo);
-            glTexCoordPointer(3, GL_FLOAT, 0,
+            glTexCoordPointer(3, GL_DOUBLE, 0,
                               reinterpret_cast<void*>(vertexArrayByteSize + normalArrayByteSize
                               + textureArrayByteSize + tangentArrayByteSize));
             glBindBuffer(GL_ARRAY_BUFFER, 0);


### PR DESCRIPTION
Found while investigating https://github.com/sofa-framework/sofa/discussions/2815

Tangents and bitangents were of type Vec3d but was set as float while setting the OpenGL buffer.
This rises the problem of data for visual things.

This PR is only for fix, but it would make sense to template the VisualModelimpl to have either everything in float (for speed) or double (for precision)

Not related, but I put references and some cleanings here and there in VisualModelimpl  (while investigating the problem)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
