### PR TITLE
[HyperElastic] Introduce example scene for StandardTetrahedralFEMForceField

### DIFF
--- a/examples/Components/forcefield/StandardTetrahedralFEMForceField.scn
+++ b/examples/Components/forcefield/StandardTetrahedralFEMForceField.scn
@@ -1,0 +1,128 @@
+﻿<?xml version="1.0" ?>
+<Node name="root" dt="0.005" showBoundingTree="0" gravity="0 -9 0">
+    <RequiredPlugin pluginName='SofaBoundaryCondition'/>
+    <RequiredPlugin pluginName='SofaEngine'/>
+    <RequiredPlugin pluginName='SofaGeneralVisual'/>
+    <RequiredPlugin pluginName='SofaImplicitOdeSolver'/>
+    <RequiredPlugin pluginName='SofaMiscCollision'/>
+    <RequiredPlugin pluginName='SofaMiscFem'/>
+    <RequiredPlugin pluginName='SofaSimpleFem'/>
+    <RequiredPlugin pluginName='SofaTopologyMapping'/>
+
+    <VisualStyle displayFlags="showForceFields showBehaviorModels" />
+    <DefaultPipeline verbose="0" />
+    <BruteForceBroadPhase/>
+    <BVHNarrowPhase/>
+    <DefaultContactManager response="PenalityContactForceField" />
+    <MinProximityIntersection name="Proximity" alarmDistance="0.8" contactDistance="0.5" />
+    <DefaultCollisionGroupManager />
+
+    <Node name="Corrotational">
+        <EulerImplicitSolver name="cg_odesolver" printLog="false" />
+        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
+
+        <RegularGridTopology name="hexaGrid" min="0 0 0" max="1 1 2.7" n="3 3 8" p0="0 0 0"/>
+
+        <MechanicalObject name="mechObj"/>
+        <UniformMass/>
+        <TetrahedronFEMForceField name="FEM" youngModulus="10000" poissonRatio="0.45" method="large" />
+
+        <BoxROI drawBoxes="0" box="0 0 0 1 1 0.05" name="box"/>
+        <FixedConstraint indices="@box.indices"/>
+        <Visual3DText text="Corrotational" position="1 0 -0.5" scale="0.2" />
+    </Node>
+
+    <Node name="ArrudaBoyce">
+        <EulerImplicitSolver name="cg_odesolver" printLog="false" />
+        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
+
+        <RegularGridTopology name="hexaGrid" min="0 0 0" max="1 1 2.7" n="3 3 8" p0="2 0 0"/>
+
+        <MechanicalObject name="mechObj"/>
+        <UniformMass/>
+
+        <Node name="tetras">
+            <TetrahedronSetTopologyContainer name="Container"/>
+            <TetrahedronSetTopologyModifier name="Modifier" />
+            <TetrahedronSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
+            <Hexa2TetraTopologicalMapping name="default28" input="@../" output="@Container" printLog="0" />
+
+            <StandardTetrahedralFEMForceField name="FEM" ParameterSet="3448.2759 31034.483"/>
+        </Node>
+
+        <BoxROI drawBoxes="1" box="2 0 0 3 1 0.05" name="box"/>
+        <FixedConstraint indices="@box.indices"/>
+        <Visual3DText text="ArrudaBoyce" position="3 0 -0.5" scale="0.2" />
+    </Node>
+
+    <Node name="StVenantKirchhoff">
+        <EulerImplicitSolver name="cg_odesolver" printLog="false" />
+        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
+
+        <RegularGridTopology name="hexaGrid" min="0 0 0" max="1 1 2.7" n="3 3 8" p0="4 0 0"/>
+
+        <MechanicalObject name="mechObj"/>
+        <UniformMass/>
+
+        <Node name="tetras">
+            <TetrahedronSetTopologyContainer name="Container"/>
+            <TetrahedronSetTopologyModifier name="Modifier" />
+            <TetrahedronSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
+            <Hexa2TetraTopologicalMapping name="default28" input="@../" output="@Container" printLog="0" />
+
+            <StandardTetrahedralFEMForceField name="FEM" ParameterSet="3448.2759 31034.483" materialName="StVenantKirchhoff"/>
+        </Node>
+
+        <BoxROI drawBoxes="1" box="4 0 0 5 1 0.05" name="box"/>
+        <FixedConstraint indices="@box.indices"/>
+        <Visual3DText text="StVenantKirchhoff" position="5 0 -0.5" scale="0.2" />
+    </Node>
+
+
+    <Node name="NeoHookean">
+        <EulerImplicitSolver name="cg_odesolver" printLog="false" />
+        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
+
+        <RegularGridTopology name="hexaGrid" min="0 0 0" max="1 1 2.7" n="3 3 8" p0="6 0 0"/>
+
+        <MechanicalObject name="mechObj"/>
+        <UniformMass/>
+
+        <Node name="tetras">
+            <TetrahedronSetTopologyContainer name="Container"/>
+            <TetrahedronSetTopologyModifier name="Modifier" />
+            <TetrahedronSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
+            <Hexa2TetraTopologicalMapping name="default28" input="@../" output="@Container" printLog="0" />
+
+            <StandardTetrahedralFEMForceField name="FEM" ParameterSet="3448.2759 31034.483" materialName="NeoHookean"/>
+        </Node>
+
+        <BoxROI drawBoxes="1" box="6 0 0 7 1 0.05" name="box"/>
+        <FixedConstraint indices="@box.indices"/>
+        <Visual3DText text="NeoHookean" position="7 0 -0.5" scale="0.2" />
+    </Node>
+
+
+    <Node name="MooneyRivlin">
+        <EulerImplicitSolver name="cg_odesolver" printLog="false" />
+        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
+
+        <RegularGridTopology name="hexaGrid" min="0 0 0" max="1 1 2.7" n="3 3 8" p0="8 0 0"/>
+
+        <MechanicalObject name="mechObj"/>
+        <UniformMass/>
+
+        <Node name="tetras">
+            <TetrahedronSetTopologyContainer name="Container"/>
+            <TetrahedronSetTopologyModifier name="Modifier" />
+            <TetrahedronSetGeometryAlgorithms template="Vec3d" name="GeomAlgo" />
+            <Hexa2TetraTopologicalMapping name="default28" input="@../" output="@Container" printLog="0" />
+
+            <StandardTetrahedralFEMForceField name="FEM" ParameterSet="5000 7000 10" materialName="MooneyRivlin"/>
+        </Node>
+
+        <BoxROI drawBoxes="1" box="8 0 0 9 1 0.05" name="box"/>
+        <FixedConstraint indices="@box.indices"/>
+        <Visual3DText text="MooneyRivlin" position="9 0 -0.5" scale="0.2" />
+    </Node>
+</Node>


### PR DESCRIPTION
This is the same scene than TetrahedronHyperelasticityFEMForceField.scn but TetrahedronHyperelasticityFEMForceField has been replaced by StandardTetrahedralFEMForceField






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
